### PR TITLE
Renamed properties file and added validation.

### DIFF
--- a/lib/common/__init__.py
+++ b/lib/common/__init__.py
@@ -1,6 +1,8 @@
 import ConfigParser
 import logging.config
-from constants import *
+import sys
+
+from constants import ROBOTTELO_PROPERTIES
 
 
 class Configs():
@@ -9,21 +11,26 @@ class Configs():
         logging.config.fileConfig("logging.conf")
         self.log_root = logging.getLogger("root")
         prop = ConfigParser.RawConfigParser()
-        prop.read(ROBOTTELO_PROPERTIES)
-        self.properties = {}
-        for section in prop.sections():
-            for option in prop.options(section):
-                self.properties["%s.%s" % (section, option)] = \
-                prop.get(section, option)
+        if prop.read(ROBOTTELO_PROPERTIES):
+            self.properties = {}
+            for section in prop.sections():
+                for option in prop.options(section):
+                    self.properties[
+                        "%s.%s" % (section, option)
+                    ] = prop.get(section, option)
+            self.log_root.setLevel(int(self.properties.get("main.verbosity")))
+        else:
+            print "Please make sure that you have a robottelo.properties file."
+            sys.exit(-1)
 
     def dumpProperties(self):
         keylist = self.properties.keys()
         keylist.sort()
         for key in keylist:
-            self.log_root.info("property %s=%s" % (key, self.properties[key]))
+            self.log_root.debug("property %s=%s" % (key, self.properties[key]))
 
 conf = Configs()
-conf.log_root.info("")
-conf.log_root.info("# ** ** ** list properties ** ** **")
-conf.dumpProperties()
-conf.log_root.info("")
+conf.log_root.debug("")
+conf.log_root.debug("# ** ** ** list properties ** ** **")
+conf.log_root.debug(conf.dumpProperties())
+conf.log_root.debug("")

--- a/robottelo.properties.sample
+++ b/robottelo.properties.sample
@@ -1,3 +1,5 @@
+# Copy this file and rename it to robottelo.properties
+
 [main]
 server.hostname=awesome.server.com
 server.port=443


### PR DESCRIPTION
I have renamed the properties file to robottelo.properties.sample. If
you try to run the tests without creating your own
robottelo.properties file you'll get a warning and the code will exit out.
