### PR TITLE
This _should_ fix the issue with certain characters in the latin-1 range breaking strings.

### DIFF
--- a/lib/common/helpers.py
+++ b/lib/common/helpers.py
@@ -62,14 +62,11 @@ def generate_string(str_type, length):
     should suffice for the purposes of most multibyte testing.
     '''
     # approximate range of CJK Unified Ideographs
-    # It does not include extensions.
-    # utf8_begin = '4E00'
-    # utf8_end = '9FFF'
-    # Latin 1 (note: includes some mathematical symbols
-    # which sort of wreaks havoc with using full range.  See
-    # range broken outto avoid these, below)
-    # latin1_begin = '00C0'
-    # latin1_end = '00F0'
+    # It does not include extensions: '4E00- 9FFF'
+    # Latin 1 range: '00C0-00F0'
+    # (note: includes some mathematical symbol, which sort of wreaks 
+    # havoc with using full range.  See range broken outto avoid these, 
+    # below)
     if str_type == "alphanumeric":
         output_string = ''.join(
             random.choice(
@@ -88,7 +85,7 @@ def generate_string(str_type, length):
         range0 = ['00C0', '00D6']
         range1 = ['00D8', '00F6']
         range2 = ['00F8', '00FF']
-        output_array =[]
+        output_array = []
         for i in range(int(range0[0], 16), int(range0[1], 16)):
             output_array.append(i)
         for i in range(int(range1[0], 16), int(range1[1], 16)):
@@ -97,16 +94,14 @@ def generate_string(str_type, length):
             output_array.append(i)
         output_string = ''.join(unichr(random.choice(output_array)) for x in xrange(length))
         output_string.encode('utf-8')
-        # print output_string
     elif str_type == "utf8":
         cjk_range = []
-        cjk_range =['4E00', '9FFF']
+        cjk_range = ['4E00', '9FFF']
         output_array = []
         for i in range(int(cjk_range[0], 16), int(cjk_range[1], 16)):
             output_array.append(i)
         output_string = ''.join(unichr(random.choice(output_array)) for x in xrange(length))   
         output_string.encode('utf-8')
-        # print output_string
     else:
         raise Exception(
             'Unexpected output type, valid types are "alphanumeric", \


### PR DESCRIPTION
Also casts various string types to utf-8 to try and alleviate some issues -though  I'm not sure it will help 100%.  May still need to cast the string at actual execution time.
