### PR TITLE
Ability to retrieve errorcodes from commands sent via paramiko

### DIFF
--- a/lib/cli/base.py
+++ b/lib/cli/base.py
@@ -114,7 +114,7 @@ class Base():
 
         (stdout, stderr, errorcode) = self.execute(self._construct_command(options))
 
-        return False if stderr else True
+        return False if stderr else True, errorcode
 
     def delete(self, options=None):
         """
@@ -127,7 +127,7 @@ class Base():
 
         (stdout, stderr, errorcode) = self.execute(self._construct_command(options))
 
-        return False if stderr else True
+        return False if stderr else True, errorcode
 
     def dump(self, options=None):
         """
@@ -141,6 +141,19 @@ class Base():
         (stdout, stderr, errorcode) = self.execute(self._construct_command(options))
 
         return '' if stderr else stdout[0]
+
+    def error_code_zero(self, code):
+        """
+        Checks status of error code returned from command execution
+        * Run an AssertTrue against this if you expect a zero.
+        * Run an AssertFalse against this if you expect a non-zero
+          (i.e., a negative test).
+        """
+        if code == 0:
+            return True
+        else:
+            return False
+
 
     def execute(self, command, user=None, password=None):
 

--- a/tests/cli/test_User.py
+++ b/tests/cli/test_User.py
@@ -21,16 +21,16 @@ class User(BaseCLI):
             'password': passwd1 or generate_name(),
             'auth-source-id': auth_id,
         }
-
-        self.user.create(args)
-
+        status, errorcode = self.user.create(args)
         self.assertTrue(self.user.exists(args['login']))
+        return errorcode
 
     def test_create_user_1(self):
         "Successfully creates a new user"
 
         password = generate_name(6)
-        self._create_user(None, None, password)
+        errorcode = self._create_user(None, None, password)
+        self.assertTrue(self.user.error_code_zero(errorcode))
 
     def test_delete_user_1(self):
         "Creates and immediately deletes user."
@@ -45,8 +45,9 @@ class User(BaseCLI):
             'id': user['Id'],
         }
 
-        self.user.delete(args)
+        status, errorcode = self.user.delete(args)
         self.assertFalse(self.user.exists(login))
+        self.assertTrue(self.user.error_code_zero(errorcode))
 
     def test_create_user_utf8(self):
         "Create utf8 user"
@@ -55,7 +56,8 @@ class User(BaseCLI):
         email_name = generate_string('alpha', 6)
         email = "%s@example.com" % email_name
         login = generate_string('utf8', 6).encode('utf-8')
-        self._create_user(login=login, email=email, passwd1=password)
+        errorcode = self._create_user(login=login, email=email, passwd1=password)
+        self.assertTrue(self.user.error_code_zero(errorcode))
 
     def test_create_user_latin1(self):
         "Create latin1 user"
@@ -64,4 +66,5 @@ class User(BaseCLI):
         email_name = generate_string('alpha', 6)
         email = "%s@example.com" % email_name
         login = generate_string('latin1', 6).encode('utf-8')
-        self._create_user(login=login, email=email, passwd1=password)
+        errorcode = self._create_user(login=login, email=email, passwd1=password)
+        self.assertTrue(self.user.error_code_zero(errorcode))


### PR DESCRIPTION
Note that this means the output of execute() now has three values, not two. I have tried to fix all instances that might call execute().

I suppose it _might_ be possible to try and retrieve error code from the stdin passed to the function that is calling execute() itself, but it seems to me that we might as well get it straight from the source, rather than try to discern it after it's been passed along and possibly manipulated.

Also note that in order for this to show up in tests, the base calls will need to be modified, if desired, to pass the error code to the tests themselves.

In other words, existing def returns like

"return False if stderr else True"

...will not be enough to provide the error code. They'll need to be modified to return the error code value to the test.
