### PR TITLE
Base class for CLI returns a dictionary.

### DIFF
--- a/lib/cli/base.py
+++ b/lib/cli/base.py
@@ -3,14 +3,16 @@
 # vim: ts=4 sw=4 expandtab ai
 
 import logging.config
+import sys
+
 from lib.common import conf
 from lib.common.helpers import csv_to_dictionary
 from threading import Lock
+
 try:
     import paramiko
-except Exception, e:
+except ImportError:
     print "Please install paramiko."
-    import sys
     sys.exit(-1)
 
 
@@ -59,6 +61,9 @@ class Base():
 
     __connection = None
 
+    def __init__(self):
+        pass
+
     @classmethod
     def get_connection(cls):
         if not cls.__connection:
@@ -73,8 +78,10 @@ class Base():
             key_filename = conf.properties['main.server.ssh.key_private']
             conn.connect(host, username=root, key_filename=key_filename)
             cls.__connection = conn
-            cls.logger.info("Paramiko instance prepared" + \
-                "(and would be reused): %s" % hex(id(cls.__connection)))
+            cls.logger.info(
+                "Paramiko instance prepared (and would be reused): %s"
+                % hex(id(cls.__connection))
+            )
         return cls.__connection
 
     @classmethod
@@ -99,9 +106,9 @@ class Base():
 
         options = options or {}
 
-        (stdout, stderr, errorcode) = self.execute(self._construct_command(options))
+        result = self.execute(self._construct_command(options))
 
-        return False if stderr else True
+        return result
 
     def create(self, options=None):
         """
@@ -112,9 +119,9 @@ class Base():
 
         options = options or {}
 
-        (stdout, stderr, errorcode) = self.execute(self._construct_command(options))
+        result = self.execute(self._construct_command(options))
 
-        return False if stderr else True, errorcode
+        return result
 
     def delete(self, options=None):
         """
@@ -125,9 +132,9 @@ class Base():
 
         options = options or {}
 
-        (stdout, stderr, errorcode) = self.execute(self._construct_command(options))
+        result = self.execute(self._construct_command(options))
 
-        return False if stderr else True, errorcode
+        return result
 
     def dump(self, options=None):
         """
@@ -138,24 +145,18 @@ class Base():
 
         options = options or {}
 
-        (stdout, stderr, errorcode) = self.execute(self._construct_command(options))
+        result = self.execute(self._construct_command(options))
 
-        return '' if stderr else stdout[0]
-
-    def error_code_zero(self, code):
-        """
-        Checks status of error code returned from command execution
-        * Run an AssertTrue against this if you expect a zero.
-        * Run an AssertFalse against this if you expect a non-zero
-          (i.e., a negative test).
-        """
-        if code == 0:
-            return True
-        else:
-            return False
-
+        return '' if result['stderr'] else result['stdout'][0]
 
     def execute(self, command, user=None, password=None):
+
+        # Dictionary object to hold all artifacts from Paramiko.
+        result = {
+            'stdout': None,
+            'stderr': None,
+            'retcode': None,
+        }
 
         if user is None:
             user = self.katello_user
@@ -172,6 +173,11 @@ class Base():
             output = stdout.readlines()
             errors = stderr.readlines()
 
+            # Update results
+            result['stdout'] = output
+            result['stderr'] = errors
+            result['retcode'] = errorcode
+
         # helps for each command to be grouped with a new line.
         print ""
 
@@ -182,7 +188,7 @@ class Base():
         if errors:
             self.logger.error("".join(errors))
 
-        return output, errors, errorcode
+        return result
 
     def exists(self, name):
         """
@@ -209,21 +215,22 @@ class Base():
         if options is None:
             options = {}
 
-        stdout = self.execute(self._construct_command(options))[0]
+        result = self.execute(self._construct_command(options))
+        stdout = result['stdout']
 
         return csv_to_dictionary(stdout) if stdout else {}
 
     def list(self, options=None):
         """
         List information.
-        @param cmdID: ID (sometimes name works as well) to retrieve info.
+        @param options: ID (sometimes name works as well) to retrieve info.
         """
         self.command_sub = "list"
         if options is None:
             options = {}
             options['per-page'] = 10000
 
-        stdout = self.execute(self._construct_command(options))[0]
+        stdout = self.execute(self._construct_command(options))['stdout']
         return csv_to_dictionary(stdout) if stdout else {}
 
     def remove_operating_system(self, options=None):
@@ -235,9 +242,9 @@ class Base():
 
         options = options or {}
 
-        (stdout, stderr, errorcode) = self.execute(self._construct_command(options))
+        result = self.execute(self._construct_command(options))
 
-        return False if stderr else True
+        return result
 
     def update(self, options=None):
         """
@@ -248,18 +255,18 @@ class Base():
 
         options = options or {}
 
-        (stdout, stderr, errorcode) = self.execute(self._construct_command(options))
+        result = self.execute(self._construct_command(options))
 
-        return False if stderr else True
+        return result
 
     def _construct_command(self, options={}):
         tail = ""
 
         for key, val in options.items():
             if val:
-                tail = tail + " --%s='%s'" % (key, val)
+                tail += " --%s='%s'" % (key, val)
             else:
-                tail = tail + " --%s" % key
+                tail += " --%s" % key
         cmd = self.command_base + " " + self.command_sub + " " + tail.strip()
 
         return cmd

--- a/robottelo_runner.py
+++ b/robottelo_runner.py
@@ -45,5 +45,5 @@ if __name__ == "__main__":
         suite.addTests(loader.loadTestsFromName(test_name))
 
     runner = unittest.TextTestRunner(
-                verbosity=int(conf.properties.get("nosetests.verbosity")))
+        verbosity=int(conf.properties.get("nosetests.verbosity")))
     result = runner.run(suite)

--- a/tests/cli/test_Architecture.py
+++ b/tests/cli/test_Architecture.py
@@ -22,13 +22,13 @@ class Architecture(BaseCLI):
         self.assertTrue(self.arch.exists(name))
 
     def test_create_architecture_1(self):
-        "Successfully creates a new architecture"
+        """Successfully creates a new architecture"""
 
         name = generate_name(6)
         self._create_arch(name)
 
     def test_delete_architecture_1(self):
-        "Creates and immediately deletes architecture."
+        """Creates and immediately deletes architecture."""
 
         name = generate_name(6)
         self._create_arch(name)

--- a/tests/cli/test_Domain.py
+++ b/tests/cli/test_Domain.py
@@ -9,9 +9,10 @@ from lib.common.helpers import generate_name
 class Domain(BaseCLI):
 
     def test_create_domain(self):
-        "Create a new domain"
+        """Create a new domain"""
         args = {
             "name": generate_name(6)
         }
-        res = self.domain.create(args)
-        self.assertTrue(res)
+
+        self.domain.create(args)
+        self.assertTrue(self.domain.exists(args['name']))

--- a/tests/cli/test_Fact.py
+++ b/tests/cli/test_Fact.py
@@ -30,6 +30,7 @@ class TestFact(BaseCLI):
         }
 
         _ret = Fact().list(args)
+
         self.assertEqual(_ret[0]['Fact'], fact)
 
     @data(
@@ -44,4 +45,4 @@ class TestFact(BaseCLI):
         args = {
             'search': "fact='%s'" % fact,
         }
-        self.assertFalse(Fact().list(args))
+        self.assertEqual(Fact().list(args), [], "No records should be returned")

--- a/tests/cli/test_Host.py
+++ b/tests/cli/test_Host.py
@@ -22,4 +22,5 @@ class Host(BaseCLI):
             "partition-table-id": 1,
             "mac": generate_mac()
         }
-        self.assertTrue(self.host.create(args))
+
+        self.host.create(args)['stdout']

--- a/tests/cli/test_Hostgroup.py
+++ b/tests/cli/test_Hostgroup.py
@@ -15,5 +15,5 @@ class Hostgroup(BaseCLI):
             'name': generate_name(),
         }
 
-        res = self.hostgroup.create(args)
-        self.assertTrue(res)
+        self.hostgroup.create(args)
+        self.assertTrue(self.hostgroup.exists(args['name']))

--- a/tests/cli/test_OperatingSys.py
+++ b/tests/cli/test_OperatingSys.py
@@ -12,10 +12,14 @@ class OperatingSys(BaseCLI):
 
     def _create_os(self, name=None, major=None, minor=None):
 
+        name = name or generate_name()
+        major = major or random.randint(0, 10)
+        minor = minor or random.randint(0, 10)
+
         args = {
-            'name': name or generate_name(),
-            'major': major or random.randint(0, 10),
-            'minor': minor or random.randint(0, 10),
+            'name': name,
+            'major': major,
+            'minor': minor,
         }
 
         self.os.create(args)

--- a/tests/cli/test_PartitionTable.py
+++ b/tests/cli/test_PartitionTable.py
@@ -67,6 +67,7 @@ class PartitionTable(BaseCLI):
         }
 
         ptable_content = self.ptable.dump(args)
+
         self.assertTrue(content in ptable_content)
 
     def test_delete_medium_1(self):

--- a/tests/cli/test_User.py
+++ b/tests/cli/test_User.py
@@ -21,16 +21,18 @@ class User(BaseCLI):
             'password': passwd1 or generate_name(),
             'auth-source-id': auth_id,
         }
-        status, errorcode = self.user.create(args)
+
+        ret = self.user.create(args)
         self.assertTrue(self.user.exists(args['login']))
-        return errorcode
+
+        return ret['retcode']
 
     def test_create_user_1(self):
         "Successfully creates a new user"
 
         password = generate_name(6)
-        errorcode = self._create_user(None, None, password)
-        self.assertTrue(self.user.error_code_zero(errorcode))
+        return_code = self._create_user(None, None, password)
+        self.assertEqual(return_code, 0)
 
     def test_delete_user_1(self):
         "Creates and immediately deletes user."
@@ -45,9 +47,9 @@ class User(BaseCLI):
             'id': user['Id'],
         }
 
-        status, errorcode = self.user.delete(args)
+        ret = self.user.delete(args)
         self.assertFalse(self.user.exists(login))
-        self.assertTrue(self.user.error_code_zero(errorcode))
+        self.assertEqual(ret['retcode'], 0)
 
     def test_create_user_utf8(self):
         "Create utf8 user"
@@ -56,8 +58,9 @@ class User(BaseCLI):
         email_name = generate_string('alpha', 6)
         email = "%s@example.com" % email_name
         login = generate_string('utf8', 6).encode('utf-8')
-        errorcode = self._create_user(login=login, email=email, passwd1=password)
-        self.assertTrue(self.user.error_code_zero(errorcode))
+        return_code = self._create_user(
+            login=login, email=email, passwd1=password)
+        self.assertEqual(return_code, 0)
 
     def test_create_user_latin1(self):
         "Create latin1 user"
@@ -66,5 +69,6 @@ class User(BaseCLI):
         email_name = generate_string('alpha', 6)
         email = "%s@example.com" % email_name
         login = generate_string('latin1', 6).encode('utf-8')
-        errorcode = self._create_user(login=login, email=email, passwd1=password)
-        self.assertTrue(self.user.error_code_zero(errorcode))
+        return_code = self._create_user(
+            login=login, email=email, passwd1=password)
+        self.assertEqual(return_code, 0)


### PR DESCRIPTION
The 'execute' method now returns a python dictionary containing the
results for stdout, stderr and return code of the command executed. It
is up to the test implementer how to properly handle the results
returned.

I have also applied some PEP8 love and fixed some tests that were
broken.

TODO: test_Host.py needs to be updated so that all required values are
generated from existing methods.
