### PR TITLE
Improve run-tests.py not need define PYTHONPATH

### DIFF
--- a/run-tests.py
+++ b/run-tests.py
@@ -4,16 +4,14 @@
 
 import argparse
 import glob
+import os
 import subprocess
-import sys
 
 from lib.common import conf
 
 # Borrowed from https://github.com/pulp/pulp/blob/master/run-tests.py
 # Find and eradicate any existing .pyc files, so they do not eradicate us!
 PROJECT_DIR = conf.get_root_path()
-if PROJECT_DIR not in sys.path:
-    sys.path.append(PROJECT_DIR)
 
 subprocess.call(['find', PROJECT_DIR, '-name', '*.pyc', '-delete'])
 
@@ -46,6 +44,8 @@ params = [
     "--tests",
     ",".join("tests.%s" % test_name[:-3] for test_name in TESTS),
 ]
+
+os.environ['PYTHONPATH'] = PROJECT_DIR
 
 # for run through: run-tests.py
 # This runner caused to not make a single call point in lib/common/__init__.py


### PR DESCRIPTION
Related to issue #167
