### PR TITLE
Improve logging

### DIFF
--- a/lib/cli/base.py
+++ b/lib/cli/base.py
@@ -2,7 +2,7 @@
 # -*- encoding: utf-8 -*-
 # vim: ts=4 sw=4 expandtab ai
 
-import logging.config
+import logging
 import sys
 
 from lib.common import conf
@@ -74,14 +74,7 @@ class Base():
     command_base = None  # each inherited instance should define this
     command_sub = None  # specific to instance, like: create, update, etc
 
-    try:
-        logging.config.fileConfig("%s/logging.conf" % conf.get_root_path())
-    except Exception:
-        log_format = '%(levelname)s %(module)s:%(lineno)d: %(message)s'
-        logging.basicConfig(format=log_format)
-
     logger = logging.getLogger("robottelo")
-    logger.setLevel(int(conf.properties['nosetests.verbosity']))
 
     locale = conf.properties['main.locale']
     katello_user = conf.properties['foreman.admin.username']
@@ -95,7 +88,6 @@ class Base():
     @classmethod
     def get_connection(cls):
         if not cls.__connection:
-            logging.config.fileConfig("%s/logging.conf" % conf.get_root_path())
             # Hide base logger from paramiko
             logging.getLogger("paramiko").setLevel(logging.ERROR)
 

--- a/lib/common/__init__.py
+++ b/lib/common/__init__.py
@@ -1,15 +1,14 @@
 import ConfigParser
-import logging.config
+import logging
 import sys
 import os
+
 from constants import ROBOTTELO_PROPERTIES
 
 
 class Configs():
 
     def __init__(self):
-        logging.config.fileConfig("%s/logging.conf" % self.get_root_path())
-        self.log_root = logging.getLogger("root")
         prop = ConfigParser.RawConfigParser()
         propFile = "%s/%s" % (self.get_root_path(), ROBOTTELO_PROPERTIES)
         if prop.read(propFile):
@@ -19,13 +18,14 @@ class Configs():
                     self.properties[
                         "%s.%s" % (section, option)
                     ] = prop.get(section, option)
-            self.log_root.setLevel(
-                int(self.properties.get("nosetests.verbosity")))
-
 #             self.log_properties()
         else:
             print "Please make sure that you have a robottelo.properties file."
             sys.exit(-1)
+
+        self._configure_logging()
+        self.log_root = logging.getLogger("root")
+
 
     def log_properties(self):
         keylist = self.properties.keys()
@@ -39,5 +39,17 @@ class Configs():
     def get_root_path(self):
         return os.path.realpath(os.path.join(os.path.dirname(__file__), \
             os.pardir, os.pardir))
+
+    def _configure_logging(self):
+        try:
+            logging.config.fileConfig("%s/logging.conf" % self.get_root_path())
+        except Exception:
+            log_format = '%(levelname)s %(module)s:%(lineno)d: %(message)s'
+            logging.basicConfig(format=log_format)
+
+        for name in ['root', 'robottelo']:
+            logger = logging.getLogger(name)
+            logger.setLevel(int(self.properties['nosetests.verbosity']))
+
 
 conf = Configs()

--- a/lib/common/manifests.py
+++ b/lib/common/manifests.py
@@ -24,10 +24,8 @@ class Manifests():
                                  portal_url=self.portal_url,
                                  login=self.login,
                                  password=self.password)
-        logging.config.fileConfig("%s/logging.conf" % conf.get_root_path())
         logging.getLogger("python-stageportal").setLevel(logging.ERROR)
         self.logger = logging.getLogger("robottelo")
-        self.logger.setLevel(self.verbosity * 10)
 
     def create_distributor(self, ds_name=None):
         """

--- a/lib/ui/base.py
+++ b/lib/ui/base.py
@@ -15,9 +15,7 @@ from lib.ui.locators import locators
 
 class Base():
 
-    logging.config.fileConfig("%s/logging.conf" % conf.get_root_path())
     logger = logging.getLogger("robottelo")
-    logger.setLevel(int(conf.properties['nosetests.verbosity']))
 
     def find_element(self, locator):
         """

--- a/tests/cli/basecli.py
+++ b/tests/cli/basecli.py
@@ -1,7 +1,7 @@
 # -*- encoding: utf-8 -*-
 # vim: ts=4 sw=4 expandtab ai
 
-import logging.config
+import logging
 import unittest
 
 from lib.common import conf
@@ -33,7 +33,6 @@ class BaseCLI(unittest.TestCase):
         self.__class__.locale = conf.properties['main.locale']
         self.__class__.verbosity = int(conf.properties['nosetests.verbosity'])
 
-        logging.config.fileConfig("%s/logging.conf" % conf.get_root_path())
         # Hide base logger from paramiko
         logging.getLogger("paramiko").setLevel(logging.ERROR)
 

--- a/tests/ui/baseui.py
+++ b/tests/ui/baseui.py
@@ -3,7 +3,7 @@
 # vim: ts=4 sw=4 expandtab ai
 
 import datetime
-import logging.config
+import logging
 import os
 import unittest
 import sauceclient
@@ -45,10 +45,7 @@ class BaseUI(unittest.TestCase):
         self.verbosity = int(conf.properties['nosetests.verbosity'])
         self.remote = int(conf.properties['main.remote'])
 
-        logging.config.fileConfig("%s/logging.conf" % conf.get_root_path())
-
         self.logger = logging.getLogger("robottelo")
-        self.logger.setLevel(self.verbosity * 10)
 
         if not self.remote:
             if self.driver_name.lower() == 'firefox':


### PR DESCRIPTION
Related to issue #179.

Some details, the logging module needs to be configured only one time. It is not necessary to have a separate module to deal with the loggers, just need to:

``` python
import logging
logger = logging.getLoger('robottelo')
```

Added automatic configuration of robottelo and root loggers level. Only get the logger and it will be ready to use.
