### PR TITLE
Fixing CLI failures from Hudson automation job.

### DIFF
--- a/tests/cli/test_environment.py
+++ b/tests/cli/test_environment.py
@@ -22,10 +22,10 @@ class TestEnvironment(BaseCLI):
         Environment().create({'name': name})
         sleep_for_seconds(5)  # give time to appear in the list
         result = Environment().info({'name': name})
-        self.assertEquals(
-            len(result.stdout), 1, "Environment info - return count"
-        )
-        self.assertEquals(result.stdout[0]['Name'], name,
+
+        self.assertTrue(result.return_code == 0,
+                        "Environment info - retcode")
+        self.assertEquals(result.stdout['Name'], name,
                           "Environment info - stdout contains 'Name'")
 
     def test_list(self):
@@ -52,7 +52,7 @@ class TestEnvironment(BaseCLI):
         result = Environment().delete({'name': name})
         self.assertTrue(result.return_code == 0,
                         "Environment delete - retcode")
-        sleep_for_seconds(5)  # sleep for about 5 sec.
+        sleep_for_seconds(10)  # sleep for about 10 sec.
         result = Environment().list({'search': name})
         self.assertTrue(len(result.stdout) == 0,
                         "Environment list - does not have deleted name")

--- a/tests/cli/test_globalparam.py
+++ b/tests/cli/test_globalparam.py
@@ -5,6 +5,7 @@ Test class for Global parameters CLI
 """
 
 from robottelo.cli.globalparam import GlobalParameter
+from robottelo.common.decorators import redminebug
 from robottelo.common.helpers import generate_name, sleep_for_seconds
 from tests.cli.basecli import BaseCLI
 
@@ -12,6 +13,7 @@ from tests.cli.basecli import BaseCLI
 class TestGlobalParameter(BaseCLI):
     """ GlobalParameter related CLI tests. """
 
+    @redminebug('3964')
     def test_set(self):
         """ `global_parameter set` basic test """
         name = "opt-%s" % generate_name(8, 8)
@@ -23,6 +25,7 @@ class TestGlobalParameter(BaseCLI):
                           "GlobalParameter set - exit code %d" %
                           result.return_code)
 
+    @redminebug('3964')
     def test_list(self):
         """ `global_parameter list` basic test """
         name = "opt-%s" % generate_name(8, 8)
@@ -42,6 +45,7 @@ class TestGlobalParameter(BaseCLI):
         self.assertEquals(result.stdout[0]['Value'], value,
                           "GlobalParameter list - value matches")
 
+    @redminebug('3964')
     def test_delete(self):
         """ `global_parameter delete` basic test """
         name = "opt-%s" % generate_name(8, 8)


### PR DESCRIPTION
- Info() method returns a python dictionary (not a list) or None
- Added decorator to TestGlobalParams due to Redmine #3964
