### PR TITLE
Generate a random HTML string for data input.

### DIFF
--- a/robottelo/common/constants.py
+++ b/robottelo/common/constants.py
@@ -25,3 +25,18 @@ TEMPLATE_TYPES = [
     'PXEGrub',
     'snippet',
 ]
+
+HTML_TAGS = [
+    'A', 'ABBR', 'ACRONYM', 'ADDRESS', 'APPLET', 'AREA', 'B',
+    'BASE', 'BASEFONT', 'BDO', 'BIG', 'BLINK', 'BLOCKQUOTE', 'BODY', 'BR',
+    'BUTTON', 'CAPTION', 'CENTER', 'CITE', 'CODE', 'COL', 'COLGROUP',
+    'DD', 'DEL', 'DFN', 'DIR', 'DIV', 'DL', 'DT',
+    'EM', 'FIELDSET', 'FONT', 'FORM', 'FRAME', 'FRAMESET', 'H1',
+    'H2', 'H3', 'H4', 'H5', 'H6', 'HEAD', 'HR',
+    'HTML', 'I', 'IFRAME', 'IMG', 'INPUT', 'INS', 'ISINDEX',
+    'KBD', 'LABEL', 'LEGEND', 'LI', 'LINK', 'MAP', 'MENU',
+    'META', 'NOFRAMES', 'NOSCRIPT', 'OBJECT', 'OL', 'OPTGROUP', 'OPTION',
+    'P', 'PARAM', 'PRE', 'Q', 'S', 'SAMP', 'SCRIPT',
+    'SELECT', 'SMALL', 'SPAN', 'STRIKE', 'STRONG', 'STYLE', 'SUB',
+    'SUP', 'TABLE', 'TBODY', 'TD', 'TEXTAREA', 'TFOOT', 'TH',
+    'THEAD', 'TITLE', 'TR', 'TT', 'U', 'UL', 'VAR']

--- a/robottelo/common/helpers.py
+++ b/robottelo/common/helpers.py
@@ -10,6 +10,7 @@ import string
 import time
 
 from itertools import izip
+from robottelo.common.constants import HTML_TAGS
 
 
 def generate_name(minimum=4, maximum=8):
@@ -118,6 +119,10 @@ def generate_string(str_type, length):
     # (note: includes some mathematical symbol, which sort of wreaks
     # havoc with using full range.  See range broken outto avoid these,
     # below)
+
+    # First lowercase the selected str type
+    str_type = str_type.lower()
+
     if str_type == "alphanumeric":
         output_string = ''.join(
             random.choice(
@@ -155,6 +160,10 @@ def generate_string(str_type, length):
         output_string = ''.join(
             unichr(random.choice(output_array)) for x in xrange(length))
         output_string.encode('utf-8')
+    elif str_type == "html":
+        html_tag = random.choice(HTML_TAGS)
+        output_string = "<%s>%s</%s>" % (
+            html_tag, generate_string("alpha", length), html_tag)
     else:
         raise Exception(
             'Unexpected output type, valid types are "alphanumeric", \


### PR DESCRIPTION
Modified generate_string function to include an option that returns a
very simple HTML string. Right now the string generated is made up of
a single HTML tag surrounding a random alpha string. It would be nice
to eventually have a better generator to give us more 'advanced'
strings such as `'<img src="http://example.com" alt="foo" />'`, but I
guess this is good for now.
