### PR TITLE
Always run hammer commands in verbose mode.

### DIFF
--- a/robottelo/cli/base.py
+++ b/robottelo/cli/base.py
@@ -116,7 +116,7 @@ class Base(object):
         output_csv = ""
         if expect_csv:
             output_csv = " --output csv"
-        shell_cmd = "LANG=%s hammer -u %s -p %s" + output_csv + " %s"
+        shell_cmd = "LANG=%s hammer -v -u %s -p %s" + output_csv + " %s"
         cmd = shell_cmd % (self.locale, user, password, command)
 
         return ssh.command(cmd, expect_csv=expect_csv)


### PR DESCRIPTION
Most of the time when a hammer cli command fails, we only capture the
error message returned in the CLI. However, getting the specific
stacktrace associated with the error is something useful, specially
when filing an issue. This pull request changes the default behavior
for all of our CLI commands to use the `-v` flag. Note that both
stdout and stderr will have some Rails data but we only really want to
see that in the cases where there was an error while running the
command.

``` python
In [1]: from robottelo.cli.org import Org
2014-01-14 14:37:32 - robottelo - INFO - Paramiko instance prepared (and would be reused): 0x1108bc310

In [2]: result = Org().create({'name': 'b1234567'})

In [3]: result.stdout
Out[3]: []

In [4]: result.stderr
Out[4]:
['[\x1b[32m INFO\x1b[0m \x1b[34m2014-01-14 14:35:41\x1b[0m \x1b[36mInit\x1b[0m] Initialization of Hammer CLI (0.0.14) has started...\n',
 '[\x1b[32m INFO\x1b[0m \x1b[34m2014-01-14 14:35:41\x1b[0m \x1b[36mInit\x1b[0m] Configuration from the file /etc/foreman/cli_config.yml has been loaded\n',
 '[\x1b[32m INFO\x1b[0m \x1b[34m2014-01-14 14:35:41\x1b[0m \x1b[36mModules\x1b[0m] Extension module hammer_cli_foreman (0.0.15) loaded\n',
 '[\x1b[32m INFO\x1b[0m \x1b[34m2014-01-14 14:35:41\x1b[0m \x1b[36mHammerCLI::MainCommand\x1b[0m] Called with options: {"verbose"=>true, "username"=>"admin", "password"=>"***"}\n',
 '[\x1b[32m INFO\x1b[0m \x1b[34m2014-01-14 14:35:41\x1b[0m \x1b[36mHammerCLIForeman::Organization\x1b[0m] Called with options: {}\n',
 '[\x1b[32m INFO\x1b[0m \x1b[34m2014-01-14 14:35:41\x1b[0m \x1b[36mHammerCLIForeman::Organization::CreateCommand\x1b[0m] Called with options: {"name"=>"b1234567"}\n',
 '[\x1b[31mERROR\x1b[0m \x1b[34m2014-01-14 14:35:42\x1b[0m \x1b[36mException\x1b[0m] Error: 500 Internal Server Error\n',
 'Could not create the organization:\n',
 '  Error: 500 Internal Server Error\n',
 '[\x1b[31mERROR\x1b[0m \x1b[34m2014-01-14 14:35:42\x1b[0m \x1b[36mException\x1b[0m] \n',
 '\n',
 'RestClient::InternalServerError (500 Internal Server Error):\n',
 "    /usr/lib/ruby/gems/1.8/gems/rest-client-1.6.1/lib/restclient/abstract_response.rb:48:in `return!'\n",
 "    /usr/lib/ruby/gems/1.8/gems/rest-client-1.6.1/lib/restclient/request.rb:220:in `process_result'\n",
 "    /usr/lib/ruby/gems/1.8/gems/rest-client-1.6.1/lib/restclient/request.rb:169:in `transmit'\n",
 "    /usr/lib/ruby/1.8/net/http.rb:543:in `start'\n",
 "    /usr/lib/ruby/gems/1.8/gems/rest-client-1.6.1/lib/restclient/request.rb:166:in `transmit'\n",
 "    /usr/lib/ruby/gems/1.8/gems/rest-client-1.6.1/lib/restclient/request.rb:60:in `execute'\n",
 "    /usr/lib/ruby/gems/1.8/gems/rest-client-1.6.1/lib/restclient/request.rb:31:in `execute'\n",
 "    /usr/lib/ruby/gems/1.8/gems/rest-client-1.6.1/lib/restclient/resource.rb:63:in `post'\n",
 "    /usr/lib/ruby/gems/1.8/gems/foreman_api-0.1.9/lib/foreman_api/base.rb:78:in `send'\n",
 "    /usr/lib/ruby/gems/1.8/gems/foreman_api-0.1.9/lib/foreman_api/base.rb:78:in `http_call'\n",
 "    /usr/lib/ruby/gems/1.8/gems/foreman_api-0.1.9/lib/foreman_api/base.rb:61:in `perform_call'\n",
 "    /usr/lib/ruby/gems/1.8/gems/foreman_api-0.1.9/lib/foreman_api/resources/organization.rb:37:in `create'\n",
 "    /usr/lib/ruby/gems/1.8/gems/hammer_cli-0.0.14/lib/hammer_cli/./apipie/resource.rb:38:in `send'\n",
 "    /usr/lib/ruby/gems/1.8/gems/hammer_cli-0.0.14/lib/hammer_cli/./apipie/resource.rb:38:in `call'\n",
 "    /usr/lib/ruby/gems/1.8/gems/hammer_cli_foreman-0.0.15/lib/hammer_cli_foreman/commands.rb:34:in `send_request'\n",
 "    /usr/lib/ruby/gems/1.8/gems/hammer_cli-0.0.14/lib/hammer_cli/./apipie/write_command.rb:10:in `execute'\n",
 "    /usr/lib/ruby/gems/1.8/gems/hammer_cli_foreman-0.0.15/lib/hammer_cli_foreman/resource_supported_test.rb:9:in `execute'\n",
 "    /usr/lib/ruby/gems/1.8/gems/clamp-0.6.2/lib/clamp/command.rb:67:in `run'\n",
 "    /usr/lib/ruby/gems/1.8/gems/hammer_cli-0.0.14/lib/hammer_cli/abstract.rb:22:in `run'\n",
 "    /usr/lib/ruby/gems/1.8/gems/clamp-0.6.2/lib/clamp/subcommand/execution.rb:11:in `execute'\n",
 "    /usr/lib/ruby/gems/1.8/gems/clamp-0.6.2/lib/clamp/command.rb:67:in `run'\n",
 "    /usr/lib/ruby/gems/1.8/gems/hammer_cli-0.0.14/lib/hammer_cli/abstract.rb:22:in `run'\n",
 "    /usr/lib/ruby/gems/1.8/gems/clamp-0.6.2/lib/clamp/subcommand/execution.rb:11:in `execute'\n",
 "    /usr/lib/ruby/gems/1.8/gems/clamp-0.6.2/lib/clamp/command.rb:67:in `run'\n",
 "    /usr/lib/ruby/gems/1.8/gems/hammer_cli-0.0.14/lib/hammer_cli/abstract.rb:22:in `run'\n",
 "    /usr/lib/ruby/gems/1.8/gems/clamp-0.6.2/lib/clamp/command.rb:125:in `run'\n",
 '    /usr/lib/ruby/gems/1.8/gems/hammer_cli-0.0.14/bin/hammer:61\n',
 "    /usr/bin/hammer:19:in `load'\n",
 '    /usr/bin/hammer:19\n']

In [5]: result.return_code
Out[5]: 70

In [6]: result = Org().create({'name': 'b12345678'})

In [7]: result.stdout
Out[7]: ['Organization created\n']

In [8]: result.stderr
Out[8]: []

In [9]: result.return_code
Out[9]: 0
```
