### PR TITLE
Fixing CLI User tests.

### DIFF
--- a/robottelo/cli/base.py
+++ b/robottelo/cli/base.py
@@ -130,12 +130,10 @@ class Base(object):
             options = {"search": "%s=\"%s\"" %
                        (tuple_search[0], tuple_search[1])}
 
-        result_list = self.list(options)
+        result = self.list(options)
 
-        if result_list.stdout:
-            result = result_list.stdout[0]
-        else:
-            result = []
+        if result.stdout:
+            result.stdout = result.stdout[0]
 
         return result
 

--- a/robottelo/cli/factory.py
+++ b/robottelo/cli/factory.py
@@ -54,7 +54,7 @@ def update_dictionary(default, updates):
     return default
 
 
-def create_object(cli_object, args):
+def create_object(cli_object, args, search_field='name'):
     """
     Creates <object> with dictionary of arguments.
 
@@ -71,7 +71,7 @@ def create_object(cli_object, args):
 
     # If the object is not created, raise exception, stop the show.
     if result.return_code != 0 or not cli_object().exists(
-            ('name', args['name'])):
+            (search_field, args[search_field])).stdout:
 
         logger.debug(result.stderr)  # Show why creation failed.
         raise Exception("Failed to create object.")
@@ -266,7 +266,7 @@ def make_user(options=None):
     }
 
     args = update_dictionary(args, options)
-    create_object(User, args)
+    create_object(User, args, 'login')
 
     return args
 

--- a/robottelo/cli/metatest/__init__.py
+++ b/robottelo/cli/metatest/__init__.py
@@ -72,9 +72,9 @@ class MetaCLITest(type):
 
                 # The data provided is a tuple so we need to unpack to pass to
                 # the  data decorator e.g. @data(*((a, b), (a, c)))
-                if data_name in attributes.keys():
+                if data_name.upper() in attributes.keys():
                     # Use data provided by test class
-                    params = attributes[data_name]
+                    params = attributes[data_name.upper()]
                 else:
                     # Use data provided by default_data module
                     params = getattr(default_data, data_name.upper())

--- a/robottelo/cli/metatest/template_methods.py
+++ b/robottelo/cli/metatest/template_methods.py
@@ -25,8 +25,9 @@ def test_positive_create(self, data):
     new_obj = self.factory(data)
 
     # Can we find the new object?
-    result = self.factory_obj().info(
-        {self.search_key: new_obj[self.search_key]})
+    result = self.factory_obj().exists(
+        (self.search_key, new_obj[self.search_key])
+    )
 
     self.assertTrue(result.return_code == 0, "Failed to create object")
     self.assertTrue(
@@ -81,8 +82,9 @@ def test_positive_update(self, data):
     # Create a new object passing @data to factory method
     new_obj = self.factory(orig_dict)
 
-    result = self.factory_obj().info(
-        {self.search_key: new_obj[self.search_key]})
+    result = self.factory_obj().exists(
+        (self.search_key, new_obj[self.search_key])
+    )
     self.assertTrue(result.return_code == 0, "Failed to create object")
     self.assertTrue(
         len(result.stderr) == 0, "There should not be an exception here")
@@ -135,8 +137,10 @@ def test_negative_update(self, data):
 
     # Create a new object passing @data to factory method
     new_obj = self.factory(orig_dict)
-    result = self.factory_obj().info(
-        {self.search_key: new_obj[self.search_key]})
+
+    result = self.factory_obj().exists(
+        (self.search_key, new_obj[self.search_key])
+    )
     self.assertTrue(result.return_code == 0, "Failed to create object")
     self.assertTrue(
         len(result.stderr) == 0, "There should not be an exception here")
@@ -154,8 +158,10 @@ def test_negative_update(self, data):
     #updated")
     self.assertFalse(result.return_code == 0, "%s, %s" % (data, result.stdout))
     self.assertTrue(len(result.stderr) > 0, "There should be errors")
-    result = self.factory_obj().info(
-        {self.search_key: new_obj[self.search_key]})
+
+    result = self.factory_obj().exists(
+        (self.search_key, new_obj[self.search_key])
+    )
     # Verify that new values were not updated
     self.assertEqual(new_obj, result.stdout, "Object should not be updated")
 
@@ -179,8 +185,10 @@ def test_positive_delete(self, data):
 
     # Create a new object passing @data to factory method
     new_obj = self.factory(data)
-    result = self.factory_obj().info(
-        {self.search_key: new_obj[self.search_key]})
+
+    result = self.factory_obj().exists(
+        (self.search_key, new_obj[self.search_key])
+    )
     self.assertTrue(result.return_code == 0, "Failed to create object")
 
     # Store the new object for future assertionss and to use its ID
@@ -218,8 +226,10 @@ def test_negative_delete(self, data):
 
     # Create a new object using default values
     new_obj = self.factory()
-    result = self.factory_obj().info(
-        {self.search_key: new_obj[self.search_key]})
+
+    result = self.factory_obj().exists(
+        (self.search_key, new_obj[self.search_key])
+    )
     self.assertTrue(result.return_code == 0, "Failed to create object")
     # Store the new object for further assertions
     new_obj = result.stdout
@@ -229,7 +239,9 @@ def test_negative_delete(self, data):
     self.assertFalse(result.return_code == 0, "Should not delete object")
     self.assertTrue(len(result.stderr) > 0, "Should have gotten an error")
     # Now make sure that it still exists
-    result = self.factory_obj().info(
-        {self.search_key: new_obj[self.search_key]})
+
+    result = self.factory_obj().exists(
+        (self.search_key, new_obj[self.search_key])
+    )
     self.assertTrue(result.return_code == 0, "Failed to find object")
     self.assertEqual(new_obj, result.stdout)

--- a/tests/cli/test_computeresource.py
+++ b/tests/cli/test_computeresource.py
@@ -80,10 +80,10 @@ class TestComputeResource(BaseCLI):
                           "ComputeResource list - exit code")
         self.assertTrue(len(result_list.stdout) > 0,
                         "ComputeResource list - stdout has results")
+        stdout = ComputeResource().exists(
+            ('name', result_create['name'])).stdout
         self.assertTrue(
-            ComputeResource().exists(
-                ('name', result_create['name'])
-            ),
+            stdout,
             "ComputeResource list - exists name")
 
     @data(
@@ -122,7 +122,8 @@ class TestComputeResource(BaseCLI):
             result_delete.return_code, 0,
             "ComputeResource delete - exit code")
         sleep_for_seconds(5)
+        stdout = ComputeResource().exists(
+            ('name', result_create['name'])).stdout
         self.assertFalse(
-            ComputeResource().exists(
-                ('name', result_create['name'])),
+            stdout,
             "ComputeResource list - does not exist name")

--- a/tests/cli/test_medium.py
+++ b/tests/cli/test_medium.py
@@ -43,7 +43,7 @@ class TestMedium(MetaCLI):
 
         Medium().create(args)
 
-        self.assertTrue(Medium().exists(('name', args['name'])))
+        self.assertTrue(Medium().exists(('name', args['name'])).stdout)
 
     def test_create_medium_1(self):
         "Successfully creates a new medium"
@@ -57,11 +57,11 @@ class TestMedium(MetaCLI):
         name = generate_name(6)
         self._create_medium(name)
 
-        medium = Medium().exists(('name', name))
+        medium = Medium().exists(('name', name)).stdout
 
         args = {
             'id': medium['id'],
         }
 
         Medium().delete(args)
-        self.assertFalse(Medium().exists(('name', name)))
+        self.assertFalse(Medium().exists(('name', name)).stdout)

--- a/tests/cli/test_partitiontable.py
+++ b/tests/cli/test_partitiontable.py
@@ -23,7 +23,7 @@ class TestPartitionTable(MetaCLI):
         name = generate_name(6)
         make_partition_table({'name': name, 'content': content})
 
-        ptable = PartitionTable().exists(('name', name))
+        ptable = PartitionTable().exists(('name', name)).stdout
 
         args = {
             'id': ptable['id'],
@@ -40,11 +40,11 @@ class TestPartitionTable(MetaCLI):
         name = generate_name(6)
         make_partition_table({'name': name, 'content': content})
 
-        ptable = PartitionTable().exists(('name', name))
+        ptable = PartitionTable().exists(('name', name)).stdout
 
         args = {
             'id': ptable['id'],
         }
 
         PartitionTable().delete(args)
-        self.assertFalse(PartitionTable().exists(('name', name)))
+        self.assertFalse(PartitionTable().exists(('name', name)).stdout)

--- a/tests/cli/test_template.py
+++ b/tests/cli/test_template.py
@@ -41,7 +41,7 @@ class TestTemplate(BaseCLI):
 
         Template().create(args)
 
-        self.assertTrue(Template().exists(('name', args['name'])))
+        self.assertTrue(Template().exists(('name', args['name'])).stdout)
 
     def test_create_template_1(self):
         "Successfully creates a new template"
@@ -57,7 +57,7 @@ class TestTemplate(BaseCLI):
         name = generate_name(6)
         self._create_template(name=name, content=content)
 
-        template = Template().exists(('name', name))
+        template = Template().exists(('name', name)).stdout
 
         args = {
             'id': template['id'],
@@ -73,11 +73,11 @@ class TestTemplate(BaseCLI):
         name = generate_name(6)
         self._create_template(name=name, content=content)
 
-        template = Template().exists(('name', name))
+        template = Template().exists(('name', name)).stdout
 
         args = {
             'id': template['id'],
         }
 
         Template().delete(args)
-        self.assertFalse(Template().exists(('name', name)))
+        self.assertFalse(Template().exists(('name', name)).stdout)

--- a/tests/cli/test_user.py
+++ b/tests/cli/test_user.py
@@ -7,7 +7,6 @@ Test class for User CLI
 
 from robottelo.cli.user import User
 from robottelo.cli.factory import make_user
-from robottelo.common.helpers import generate_name
 from robottelo.common.helpers import generate_string
 from tests.cli.basecli import MetaCLI
 
@@ -16,7 +15,7 @@ class TestUser(MetaCLI):
 
     factory = make_user
     factory_obj = User
-    search_key = 'id'
+    search_key = 'login'
 
     POSITIVE_CREATE_DATA = (
         {'login': generate_string("latin1", 10).encode("utf-8")},
@@ -36,24 +35,24 @@ class TestUser(MetaCLI):
 
     POSITIVE_UPDATE_DATA = (
         ({'login': generate_string("latin1", 10).encode("utf-8")},
-         {'lastname': generate_string("latin1", 10).encode("utf-8")}),
+         {'login': generate_string("latin1", 10).encode("utf-8")}),
         ({'login': generate_string("utf8", 10).encode("utf-8")},
-         {'lastname': generate_string("utf8", 10).encode("utf-8")}),
+         {'login': generate_string("utf8", 10).encode("utf-8")}),
         ({'login': generate_string("alpha", 10)},
-         {'lastname': generate_string("alpha", 10)}),
+         {'login': generate_string("alpha", 10)}),
         ({'login': generate_string("alphanumeric", 10)},
-         {'lastname': generate_string("alphanumeric", 10)}),
+         {'login': generate_string("alphanumeric", 10)}),
         ({'login': generate_string("numeric", 10)},
-         {'lastname': generate_string("numeric", 10)}),
+         {'login': generate_string("numeric", 10)}),
         ({'login': generate_string("utf8", 10).encode("utf-8")},
-         {'lastname': generate_string("html", 6)}),
+         {'login': generate_string("html", 6)}),
     )
 
     NEGATIVE_UPDATE_DATA = (
         ({'login': generate_string("utf8", 10).encode("utf-8")},
-         {'lastname': generate_string("utf8", 300).encode("utf-8")}),
+         {'login': generate_string("utf8", 300).encode("utf-8")}),
         ({'login': generate_string("utf8", 10).encode("utf-8")},
-         {'lastname': ""}),
+         {'login': " "}),
     )
 
     POSITIVE_DELETE_DATA = (
@@ -67,51 +66,7 @@ class TestUser(MetaCLI):
     NEGATIVE_DELETE_DATA = (
         {'id': generate_string("alpha", 10)},
         {'id': None},
-        {'id': ""},
+        {'id': " "},
         {},
         {'id': -1},
     )
-
-    def test_create_user_1(self):
-        "Successfully creates a new user"
-
-        password = generate_name(6)
-        return_code = self.make_user({'password': password})
-        self.assertEqual(return_code, 0)
-
-    def test_delete_user_1(self):
-        "Creates and immediately deletes user."
-
-        password = generate_name(6)
-        login = generate_name(6)
-        self.make_user({'login': login, 'password': password})
-
-        user = User().exists(('login', login))
-
-        args = {
-            'id': user['id'],
-        }
-
-        ret = User().delete(args)
-        self.assertFalse(User().exists(('login', login)))
-        self.assertEqual(ret.return_code, 0)
-
-    def test_create_user_utf8(self):
-        "Create utf8 user"
-
-        password = generate_string('alpha', 6)
-        email_name = generate_string('alpha', 6)
-        email = "%s@example.com" % email_name
-        login = generate_string('utf8', 6).encode('utf-8')
-        self.make_user({'login': login, 'email': email, 'password': password})
-        self.assertFalse(User().exists(('login', login)))
-
-    def test_create_user_latin1(self):
-        "Create latin1 user"
-
-        password = generate_string('alpha', 6)
-        email_name = generate_string('alpha', 6)
-        email = "%s@example.com" % email_name
-        login = generate_string('latin1', 6).encode('utf-8')
-        self.make_user({'login': login, 'email': email, 'password': password})
-        self.assertFalse(User().exists(('login', login)))


### PR DESCRIPTION
- The User command in foreman does not allow for getting a record's
  information (using the `info` argument) using `--login`, only
  `---id`. So I have fixed user tests so that `login` is used
  for assertions and updates.
- I noticed that data from test modules were getting overriden by the
  default data sets included in
  `robottelo/cli/metatest/template_methods.py`, so I fixed it as
  well.
- Updated CLI base `exists` method to return a
  `SSHCommandResult` object instead a single record from Foreman.
- Updated all CLI tests that use `exists`.
