### PR TITLE
Updates metatests docstrings dynamically.

### DIFF
--- a/robottelo/cli/metatest/__init__.py
+++ b/robottelo/cli/metatest/__init__.py
@@ -80,6 +80,9 @@ class MetaCLITest(type):
                     params = getattr(default_data, data_name.upper())
                 # Pass data to @data decorator
                 func = data(*params)(getattr(template_methods, test_name))
+                # Update method's docstring to include name of object
+                func.__doc__ = func.__doc__.replace(
+                    'FOREMAN_OBJECT', _klass.factory_obj.__name__)
                 # Add method to test class
                 setattr(_klass, test_name, func)
 

--- a/robottelo/cli/metatest/template_methods.py
+++ b/robottelo/cli/metatest/template_methods.py
@@ -8,7 +8,7 @@ Templates for generic positive/negative CRUD tests.
 
 def test_positive_create(self, data):
     """
-    Successfully creates an object.
+    Successfully creates object FOREMAN_OBJECT.
 
     1. Create a new Foreman object using the a base factory using
        B{@data} as argument;
@@ -37,7 +37,7 @@ def test_positive_create(self, data):
 
 def test_negative_create(self, data):
     """
-    Fails to creates object.
+    Fails to creates object FOREMAN_OBJECT.
 
     1. Create a new Foreman object using the a base factory using
        B{@data} as argument;
@@ -59,7 +59,7 @@ def test_negative_create(self, data):
 
 def test_positive_update(self, data):
     """
-    Successfully updates an object.
+    Successfully updates object FOREMAN_OBJECT.
 
     1. Create a new Foreman object using the test base factory using
        B{@data}[1] as argument;
@@ -114,7 +114,7 @@ def test_positive_update(self, data):
 
 def test_negative_update(self, data):
     """
-    Fails to update an object after its creation.
+    Fails to update object FOREMAN_OBJECT after its creation.
 
     1. Create a new Foreman object using the test base factory using
        B{@data} as argument;
@@ -168,7 +168,7 @@ def test_negative_update(self, data):
 
 def test_positive_delete(self, data):
     """
-    Successfully deletes an object
+    Successfully deletes object FOREMAN_OBJECT.
 
     1. Create a new Foreman object using the test base factory using
        B{@data} as argument;
@@ -208,7 +208,7 @@ def test_positive_delete(self, data):
 
 def test_negative_delete(self, data):
     """
-    Fails to update object shortly after its creation.
+    Fails to update object FOREMAN_OBJECT shortly after its creation.
 
     1. Create a new Foreman object using the test base factory without
        arguments;


### PR DESCRIPTION
When a test module uses the new metatests, the docstring displayed via
nose are too generic and don't really tells us which Foreman objects are
being tested. The proposed change will dynamically update the generic
docstrings so that the name of the Foreman object is displayed in the
output.

From:

``` bash
Fails to creates object. ... ok
Fails to update object shortly after its creation. ... ok
Fails to update object after its creation. ... ok
Successfully creates object. ... ok
Successfully deletes object. ... ok
Successfully updates object. ... ok
```

To:

``` bash
Fails to creates object Model. ... ok
Fails to update object Model shortly after its creation. ... ok
Fails to update object Model after its creation. ... ok
Successfully creates object Model. ... ok
Successfully deletes object Model. ... ok
Successfully updates object Model. ... ok
```
