### PR TITLE
Positive update activation keys tests and fn

### DIFF
--- a/robottelo/common/constants.py
+++ b/robottelo/common/constants.py
@@ -85,4 +85,6 @@ SNIPPET_URL = 'https://gist.github.com/sghai/8434467/raw'
 
 INSTALL_MEDIUM_URL = "http://mirror.fakeos.org/%s/$major.$minor/os/$arch"
 
+ENVIRONMENT = "Library"
+
 NOT_IMPLEMENTED = 'Test not implemented'

--- a/robottelo/ui/activationkey.py
+++ b/robottelo/ui/activationkey.py
@@ -8,7 +8,6 @@ Implements Activation keys UI
 from robottelo.ui.base import Base
 from robottelo.ui.locators import locators
 from selenium.webdriver.support.select import Select
-from time import sleep
 
 
 class ActivationKey(Base):
@@ -22,6 +21,19 @@ class ActivationKey(Base):
         """
         self.browser = browser
 
+    def set_limit(self, limit):
+        """
+        Sets the finite limit of activation key
+        """
+        limit_checkbox_locator = locators["ak.usage_limit_checkbox"]
+        unlimited_set = self.find_element(limit_checkbox_locator
+                                          ).get_attribute("checked")
+        if unlimited_set is None and limit == "Unlimited":
+            self.find_element(limit_checkbox_locator).click()
+        elif unlimited_set:
+            self.find_element(limit_checkbox_locator).click()
+            self.field_update("ak.usage_limit", limit)
+
     def create(self, name, env, limit=None, description=None,
                content_view=None):
         """
@@ -34,14 +46,7 @@ class ActivationKey(Base):
         if self.wait_until_element(locators["ak.name"]):
             self.field_update("ak.name", name)
             if limit:
-                unlimited_set = self.find_element(locators
-                                                  ["ak.usage_limit_checkbox"]
-                                                  ).get_attribute("checked")
-                if unlimited_set:
-                    self.find_element(locators
-                                      ["ak.usage_limit_checkbox"]
-                                      ).click()
-                self.field_update("ak.usage_limit", limit)
+                self.set_limit(limit)
             if description:
                 if self.wait_until_element(locators
                                            ["ak.description"]):
@@ -52,7 +57,7 @@ class ActivationKey(Base):
                 element = self.wait_until_element((strategy, value % env))
                 if element:
                     element.click()
-                    sleep(10)
+                    self.wait_for_ajax()
             else:
                 raise Exception(
                     "Could not create new activation key '%s', \
@@ -83,9 +88,39 @@ class ActivationKey(Base):
         if searchbox:
             searchbox.clear()
             searchbox.send_keys(element_name)
-            sleep(10)
+            self.wait_for_ajax()
             self.find_element(locators["ak.search_button"]).click()
             strategy = locators["ak.ak_name"][0]
             value = locators["ak.ak_name"][1]
             element = self.wait_until_element((strategy, value % element_name))
         return element
+
+    def update(self, name, new_name=None, description=None,
+               limit=None, content_view=None):
+        """
+        Updates an existing activation key
+        """
+
+        element = self.search_key(name)
+
+        if element:
+            element.click()
+            self.wait_for_ajax()
+            if new_name:
+                self.edit_entity("ak.edit_name", "ak.edit_name_text",
+                                 new_name, "ak.save_name")
+            if description:
+                self.edit_entity("ak.edit_description",
+                                 "ak.edit_description_text",
+                                 description, "ak.save_description")
+            if limit:
+                self.find_element(locators["ak.edit_limit"]).click()
+                self.set_limit(limit)
+                self.find_element(locators["ak.save_limit"]).click()
+            if content_view:
+                self.find_element(locators["ak.edit_content_view"]).click()
+                Select(self.find_element
+                       (locators["ak.edit_content_view_select"]
+                        )).select_by_visible_text(content_view)
+        else:
+            raise Exception("Could not update the activation key '%s'" % name)

--- a/robottelo/ui/base.py
+++ b/robottelo/ui/base.py
@@ -235,3 +235,12 @@ class Base(object):
         if remove_element:
             remove_element.click()
         self.find_element(common_locators["submit"]).click()
+
+    def edit_entity(self, edit_loc, edit_text_loc, entity_value, save_loc):
+        """
+        Function to edit the selected entity's  text and save it
+        """
+
+        self.find_element(locators[edit_loc]).click()
+        self.field_update(edit_text_loc, entity_value)
+        self.find_element(locators[save_loc]).click()

--- a/robottelo/ui/locators.py
+++ b/robottelo/ui/locators.py
@@ -281,6 +281,9 @@ common_locators = {
     "notif.close": (
         By.XPATH, "//a[@class='jnotify-close']"),
 
+    "alert.success": (
+        By.XPATH, "//div[contains(@class, 'alert-success')]"),
+
     "entity_select": (
         By.XPATH,
         "//div[@class='ms-selectable']//span[contains(.,'%s')]"),
@@ -576,7 +579,8 @@ locators = {
     "ak.usage_limit_checkbox": (
         By.XPATH,
         "//input[@ng-checked='isUnlimited(activationKey)']"),
-    "ak.usage_limit": (By.ID, "usage_limit"),
+    "ak.usage_limit": (
+        By.XPATH, "//input[@ng-model='activationKey.usage_limit']"),
     "ak.create": (
         By.XPATH,
         "//button[@ng-click='handleSave(); working = true']"),
@@ -589,4 +593,40 @@ locators = {
         "//button[@ng-click='table.search(table.searchTerm)']"),
     "ak.ak_name": (
         By.XPATH,
-        "//tr[@row-select='activationKey']/td[2]/a[contains(., '%s')]")}
+        "//tr[@row-select='activationKey']/td[2]/a[contains(., '%s')]"),
+    "ak.select_ak_name": (
+        By.XPATH,
+        "//input[@ng-model='activationKey.selected']"),
+    "ak.edit_name": (
+        By.XPATH, "//form[@alch-edit-text='activationKey.name']//div/span/i"),
+    "ak.edit_name_text": (
+        By.XPATH,
+        "//form[@alch-edit-text='activationKey.name']/div/input"),
+    "ak.save_name": (
+        By.XPATH,
+        "//form[@alch-edit-text='activationKey.name']\
+        //button[@ng-click='save()']"),
+    "ak.edit_description": (
+        By.XPATH,
+        "//form[@alch-edit-textarea='activationKey.description']//div/span/i"),
+    "ak.edit_description_text": (
+        By.XPATH,
+        "//form[@alch-edit-textarea='activationKey.description']\
+        /div/textarea"),
+    "ak.save_description": (
+        By.XPATH,
+        "//form[@alch-edit-textarea='activationKey.description']\
+        //button[@ng-click='save()']"),
+    "ak.edit_limit": (
+        By.XPATH, "//div[@alch-edit-custom='activationKey.usage_limit']\
+        //div/span/i"),
+    "ak.save_limit": (
+        By.XPATH,
+        "//div[@alch-edit-custom='activationKey.usage_limit']\
+        //button[@ng-click='save()']"),
+    "ak.edit_content_view": (
+        By.XPATH, "//form[@alch-edit-select='activationKey.content_view.name']\
+        //div/span/i"),
+    "ak.edit_content_view_select": (
+        By.XPATH, "//form[@alch-edit-select='activationKey.content_view.name']\
+        /select")}

--- a/tests/ui/test_activationkey.py
+++ b/tests/ui/test_activationkey.py
@@ -6,8 +6,11 @@ Test class for Activation key UI
 """
 
 from ddt import data, ddt
-from robottelo.common.constants import NOT_IMPLEMENTED
+from nose.plugins.attrib import attr
+from robottelo.common.constants import NOT_IMPLEMENTED, ENVIRONMENT
+from robottelo.common.decorators import bzbug
 from robottelo.common.helpers import generate_name, valid_names_list
+from robottelo.ui.locators import common_locators
 from tests.ui.baseui import BaseUI
 
 
@@ -23,6 +26,7 @@ class ActivationKey(BaseUI):
     Lesser than Min Length, Greater than Max DB size
     """
 
+    @attr('ui', 'ak', 'implemented')
     @data(*valid_names_list())
     def test_positive_create_activation_key_1(self, name):
         """
@@ -35,12 +39,13 @@ class ActivationKey(BaseUI):
         @Status: Manual
         """
 
-        env = "Library"
         self.login.login(self.katello_user, self.katello_passwd)
         self.navigator.go_to_activation_keys()
-        self.activationkey.create(name, env, description=generate_name(16))
+        self.activationkey.create(name, ENVIRONMENT,
+                                  description=generate_name(16))
         self.assertIsNotNone(self.activationkey.search_key(name))
 
+    @attr('ui', 'ak', 'implemented')
     @data(*valid_names_list())
     def test_positive_create_activation_key_2(self, description):
         """
@@ -54,10 +59,9 @@ class ActivationKey(BaseUI):
         """
 
         name = generate_name(6)
-        env = "Library"
         self.login.login(self.katello_user, self.katello_passwd)
         self.navigator.go_to_activation_keys()
-        self.activationkey.create(name, env,
+        self.activationkey.create(name, ENVIRONMENT,
                                   description=description)
         self.assertIsNotNone(self.activationkey.search_key(name))
 
@@ -97,6 +101,7 @@ class ActivationKey(BaseUI):
         """
         self.fail(NOT_IMPLEMENTED)
 
+    @attr('ui', 'ak', 'implemented')
     def test_positive_create_activation_key_6(self):
         """
         @Feature: Activation key - Positive Create
@@ -109,12 +114,12 @@ class ActivationKey(BaseUI):
         """
         name = generate_name(6)
         description = generate_name(6)
-        env = "Library"
         self.login.login(self.katello_user, self.katello_passwd)
         self.navigator.go_to_activation_keys()
-        self.activationkey.create(name, env, description=description)
+        self.activationkey.create(name, ENVIRONMENT, description=description)
         self.assertIsNotNone(self.activationkey.search_key(name))
 
+    @attr('ui', 'ak', 'implemented')
     def test_positive_create_activation_key_7(self):
         """
         @Feature: Activation key - Positive Create
@@ -127,13 +132,13 @@ class ActivationKey(BaseUI):
         """
         name = generate_name(6)
         description = generate_name(6)
-        env = "Library"
         limit = "6"
         self.login.login(self.katello_user, self.katello_passwd)
         self.navigator.go_to_activation_keys()
-        self.activationkey.create(name, env, limit, description)
+        self.activationkey.create(name, ENVIRONMENT, limit, description)
         self.assertIsNotNone(self.activationkey.search_key(name))
 
+    @attr('ui', 'ak', 'implemented')
     def test_positive_create_activation_key_8(self):
         """
         @Feature: Activation key - Positive Create
@@ -145,10 +150,9 @@ class ActivationKey(BaseUI):
         @Status: Manual
         """
         name = generate_name(6)
-        env = "Library"
         self.login.login(self.katello_user, self.katello_passwd)
         self.navigator.go_to_activation_keys()
-        self.activationkey.create(name, env)
+        self.activationkey.create(name, ENVIRONMENT)
         self.assertIsNotNone(self.activationkey.search_key(name))
 
     def test_negative_create_activation_key_1(self):
@@ -187,6 +191,7 @@ class ActivationKey(BaseUI):
         """
         self.fail(NOT_IMPLEMENTED)
 
+    @bzbug('1063273')
     def test_positive_delete_activation_key_1(self):
         """
         @Feature: Activation key - Positive Delete
@@ -201,6 +206,7 @@ class ActivationKey(BaseUI):
         """
         self.fail(NOT_IMPLEMENTED)
 
+    @bzbug('1063273')
     def test_positive_delete_activation_key_2(self):
         """
         @Feature: Activation key - Positive Delete
@@ -215,6 +221,7 @@ class ActivationKey(BaseUI):
         """
         self.fail(NOT_IMPLEMENTED)
 
+    @bzbug('1063273')
     def test_positive_delete_activation_key_3(self):
         """
         @Feature: Activation key - Positive Delete
@@ -229,6 +236,7 @@ class ActivationKey(BaseUI):
         """
         self.fail(NOT_IMPLEMENTED)
 
+    @bzbug('1063273')
     def test_positive_delete_activation_key_4(self):
         """
         @Feature: Activation key - Positive Delete
@@ -243,6 +251,7 @@ class ActivationKey(BaseUI):
         """
         self.fail(NOT_IMPLEMENTED)
 
+    @bzbug('1063273')
     def test_positive_delete_activation_key_5(self):
         """
         @Feature: Activation key - Positive Delete
@@ -256,6 +265,7 @@ class ActivationKey(BaseUI):
         """
         self.fail(NOT_IMPLEMENTED)
 
+    @bzbug('1063273')
     def test_positive_delete_activation_key_6(self):
         """
         @Feature: Activation key - Positive Delete
@@ -269,6 +279,7 @@ class ActivationKey(BaseUI):
         """
         self.fail(NOT_IMPLEMENTED)
 
+    @bzbug('1063273')
     def test_negative_delete_activation_key_1(self):
         """
         @Feature: Activation key - Positive Delete
@@ -282,7 +293,9 @@ class ActivationKey(BaseUI):
         """
         self.fail(NOT_IMPLEMENTED)
 
-    def test_positive_update_activation_key_1(self):
+    @attr('ui', 'ak', 'implemented')
+    @data(*valid_names_list())
+    def test_positive_update_activation_key_1(self, new_name):
         """
         @Feature: Activation key - Positive Update
         @Test: Update Activation Key Name in an Activation key
@@ -292,9 +305,18 @@ class ActivationKey(BaseUI):
         @Assert: Activation key is updated
         @Status: Manual
         """
-        self.fail(NOT_IMPLEMENTED)
 
-    def test_positive_update_activation_key_2(self):
+        name = generate_name(6)
+        self.login.login(self.katello_user, self.katello_passwd)
+        self.navigator.go_to_activation_keys()
+        self.activationkey.create(name, ENVIRONMENT)
+        self.assertIsNotNone(self.activationkey.search_key(name))
+        self.activationkey.update(name, new_name)
+        self.assertIsNotNone(self.activationkey.search_key(new_name))
+
+    @attr('ui', 'ak', 'implemented')
+    @data(*valid_names_list())
+    def test_positive_update_activation_key_2(self, new_description):
         """
         @Feature: Activation key - Positive Update
         @Test: Update Description in an Activation key
@@ -304,7 +326,16 @@ class ActivationKey(BaseUI):
         @Assert: Activation key is updated
         @Status: Manual
         """
-        self.fail(NOT_IMPLEMENTED)
+
+        name = generate_name(6)
+        description = generate_name(6)
+        self.login.login(self.katello_user, self.katello_passwd)
+        self.navigator.go_to_activation_keys()
+        self.activationkey.create(name, ENVIRONMENT, description=description)
+        self.assertIsNotNone(self.activationkey.search_key(name))
+        self.activationkey.update(name, description=new_description)
+        self.assertTrue(self.activationkey.wait_until_element
+                        (common_locators["alert.success"]))
 
     def test_positive_update_activation_key_3(self):
         """
@@ -331,6 +362,7 @@ class ActivationKey(BaseUI):
         """
         self.fail(NOT_IMPLEMENTED)
 
+    @attr('ui', 'ak', 'implemented')
     def test_positive_update_activation_key_5(self):
         """
         @Feature: Activation key - Positive Update
@@ -341,8 +373,18 @@ class ActivationKey(BaseUI):
         @Assert: Activation key is updated
         @Status: Manual
         """
-        self.fail(NOT_IMPLEMENTED)
 
+        name = generate_name(6)
+        limit = "8"
+        self.login.login(self.katello_user, self.katello_passwd)
+        self.navigator.go_to_activation_keys()
+        self.activationkey.create(name, ENVIRONMENT)
+        self.assertIsNotNone(self.activationkey.search_key(name))
+        self.activationkey.update(name, limit=limit)
+        self.assertTrue(self.activationkey.wait_until_element
+                        (common_locators["alert.success"]))
+
+    @attr('ui', 'ak', 'implemented')
     def test_positive_update_activation_key_6(self):
         """
         @Feature: Activation key - Positive Update
@@ -353,7 +395,17 @@ class ActivationKey(BaseUI):
         @Assert: Activation key is updated
         @Status: Manual
         """
-        self.fail(NOT_IMPLEMENTED)
+
+        name = generate_name(6)
+        limit = "6"
+        new_limit = "Unlimited"
+        self.login.login(self.katello_user, self.katello_passwd)
+        self.navigator.go_to_activation_keys()
+        self.activationkey.create(name, ENVIRONMENT, limit=limit)
+        self.assertIsNotNone(self.activationkey.search_key(name))
+        self.activationkey.update(name, limit=new_limit)
+        self.assertTrue(self.activationkey.wait_until_element
+                        (common_locators["alert.success"]))
 
     def test_negative_update_activation_key_1(self):
         """


### PR DESCRIPTION
- Using env name as constant
- Added `update` function to implement update activation-keys(ak) tests
- 4 tests are automated for updating ak's
- Replaced sleep statements with wait_for_ajax
- Updated delete ak tests with bz id
- Used `attrib` decorator to separate the implemented tests from non-implemented tests
