### PR TITLE
Ignore ssl errors when using PhantomJS.

### DIFF
--- a/tests/ui/baseui.py
+++ b/tests/ui/baseui.py
@@ -71,11 +71,10 @@ class BaseUI(unittest.TestCase):
             elif self.driver_name.lower() == 'ie':
                 self.browser = webdriver.Ie()
             elif self.driver_name.lower() == 'phantomjs':
+                service_args = ['--ignore-ssl-errors=true']
                 self.browser = webdriver.PhantomJS(
-                    desired_capabilities={
-                        'acceptSslCerts': True,
-                        'javascriptEnabled': True
-                    })
+                    service_args=service_args
+                    )
             else:
                 self.browser = webdriver.Remote()
         else:


### PR DESCRIPTION
PhantomJS allows you to run all your UI tests in headless mode. I
finally figured out how to fix the issue where PhantomJS was not raising
an issue when connecting to a server via https. Ran a quick test to make
sure things worked.

``` bash
$ nosetests -c robottelo.properties tests/ui/test_login.py
@Feature: Login - Negative ... ok
@Feature: Login - Negative ... ok
@Feature: Login - Positive ... ok

----------------------------------------------------------------------
XML: foreman-results.xml
----------------------------------------------------------------------
Ran 3 tests in 11.706s

OK
```

To use it, make sure to update your `robottelo.properties` as follows:

``` INI
driver=phantomjs
```
