### PR TITLE
Implement GPG Keys cli positive create stubs

### DIFF
--- a/robottelo/cli/factory.py
+++ b/robottelo/cli/factory.py
@@ -121,6 +121,10 @@ def make_gpg_key(options=None):
         os.chmod(key_filename, 0700)
         with open(key_filename, "w") as gpg_key_file:
             gpg_key_file.write(generate_name(minimum=20, maximum=50))
+    else:
+        # If the key is provided get its local path and remove it from options
+        # to not override the remote path
+        key_filename = options.pop('key')
 
     args = {
         'name': generate_name(),
@@ -359,11 +363,16 @@ def make_org(options=None):
         hammer organization create [OPTIONS]
 
     Options:
-        --name NAME
+        --name NAME                   name
+        --label LABEL                 unique label
+        --description DESCRIPTION     description
     """
+
     #Assigning default values for attributes
     args = {
-        'name': generate_name(6)
+        'name': generate_name(6),
+        'label': None,
+        'description': None,
     }
 
     args = update_dictionary(args, options)

--- a/robottelo/cli/gpgkey.py
+++ b/robottelo/cli/gpgkey.py
@@ -52,10 +52,11 @@ class GPGKey(Base):
 
         return result
 
-    def list(self, organization_id,  options=None):
+    def list(self, organization_id, options=None):
         """
         Lists available GPG Keys.
         """
+
         self.command_sub = "list"
 
         if options is None:
@@ -63,7 +64,7 @@ class GPGKey(Base):
             options['per-page'] = 10000
 
         # Katello subcommands require the organization-id
-        options = {"organization-id": organization_id}
+        options['organization-id'] = organization_id
 
         result = self.execute(self._construct_command(options),
                               expect_csv=True)


### PR DESCRIPTION
Also:
- fix a bug in cli.GPGKey list method
- improve make_gpg_key factory to accept a local file path and upload it
- update make_org factory expected options

The tests as passing when the `redminebug` decorator is commented. Leaved there to track those opened bugs. Follow the output from the running tests without the decorator:

```
$ nosetests -c robottelo.properties tests/cli/test_gpgkey.py -m test_positive_create
INFO ssh:61: Paramiko instance prepared (and would be reused): 0x10ed80210
@feature: GPG Keys ... ok
@feature: GPG Keys ... ok
@feature: GPG Keys ... ok
@feature: GPG Keys ... ok
@feature: GPG Keys ... ok
@feature: GPG Keys ... ok
@feature: GPG Keys ... ok
@feature: GPG Keys ... ok
@feature: GPG Keys ... ok
@feature: GPG Keys ... ok
@feature: GPG Keys ... ok
@feature: GPG Keys ... ok

----------------------------------------------------------------------
XML: foreman-results.xml
----------------------------------------------------------------------
Ran 12 tests in 183.587s

OK
```

This PR is related to #422
