### PR TITLE
Make the Create method for CLI return new object.

### DIFF
--- a/robottelo/cli/base.py
+++ b/robottelo/cli/base.py
@@ -67,7 +67,19 @@ class Base(object):
 
         self.command_sub = "create"
 
-        result = self.execute(self._construct_command(options))
+        result = self.execute(
+            self._construct_command(options),
+            expect_csv=True)
+
+        # Extract new object ID if it was successfully created
+        if len(result.stdout) > 0 and 'id' in result.stdout[0]:
+            obj_id = result.stdout[0]['id']
+
+            # Fetch new object
+            new_obj = self.info({'id': obj_id})
+            # stdout should be a dictionary containing the object
+            if len(new_obj.stdout) > 0:
+                result.stdout = new_obj.stdout
 
         return result
 

--- a/robottelo/cli/factory.py
+++ b/robottelo/cli/factory.py
@@ -64,6 +64,9 @@ def create_object(cli_object, args, search_field='name'):
     attributes for creating a new object.
     @raise Exception: Raise an exception if object cannot be
     created.
+
+    @rtype: dict
+    @return: A dictionary representing the newly created resource.
     """
 
     result = cli_object().create(args)
@@ -74,6 +77,8 @@ def create_object(cli_object, args, search_field='name'):
     if result.return_code != 0:
         logger.debug(result.stderr)  # Show why creation failed.
         raise Exception("Failed to create object.")
+
+    return result.stdout
 
 
 def make_architecture(options=None):
@@ -94,7 +99,7 @@ def make_architecture(options=None):
 
     # Override default dictionary with updated one
     args = update_dictionary(args, options)
-    create_object(Architecture, args)
+    args.update(create_object(Architecture, args))
 
     return args
 
@@ -137,7 +142,7 @@ def make_gpg_key(options=None):
 
     args = update_dictionary(args, options)
 
-    create_object(GPGKey, args, search_field='organization-id')
+    args.update(create_object(GPGKey, args, search_field='organization-id'))
 
     return args
 
@@ -163,7 +168,7 @@ def make_model(options=None):
 
     # Override default dictionary with updated one
     args = update_dictionary(args, options)
-    create_object(Model, args)
+    args.update(create_object(Model, args))
 
     return args
 
@@ -185,7 +190,7 @@ def make_proxy(options=None):
     }
 
     args = update_dictionary(args, options)
-    create_object(Proxy, args)
+    args.update(create_object(Proxy, args))
 
     return args
 
@@ -230,7 +235,7 @@ def make_partition_table(options=None):
     ssh.upload_file(local_file=layout, remote_file=args['file'])
 
     args = update_dictionary(args, options)
-    create_object(PartitionTable, args)
+    args.update(create_object(PartitionTable, args))
 
     return args
 
@@ -275,7 +280,7 @@ def make_subnet(options=None):
     }
 
     args = update_dictionary(args, options)
-    create_object(Subnet, args)
+    args.update(create_object(Subnet, args))
 
     return args
 
@@ -309,7 +314,7 @@ def make_user(options=None):
     }
 
     args = update_dictionary(args, options)
-    create_object(User, args, 'login')
+    args.update(create_object(User, args, 'login'))
 
     return args
 
@@ -353,7 +358,8 @@ def make_compute_resource(options=None):
         options['provider'] = FOREMAN_PROVIDERS['libvirt']
         if args['url'] is None:
             options['url'] = "qemu+tcp://localhost:16509/system"
-    create_object(ComputeResource, args)
+    args.update(create_object(ComputeResource, args))
+
     return args
 
 
@@ -376,7 +382,7 @@ def make_org(options=None):
     }
 
     args = update_dictionary(args, options)
-    create_object(Org, args)
+    args.update(create_object(Org, args))
 
     return args
 
@@ -393,7 +399,7 @@ def make_os(options=None):
     }
 
     args = update_dictionary(args, options)
-    create_object(OperatingSys, args)
+    args.update(create_object(OperatingSys, args))
 
     return args
 
@@ -416,7 +422,7 @@ def make_domain(options=None):
     }
 
     args = update_dictionary(args, options)
-    create_object(Domain, args)
+    args.update(create_object(Domain, args))
 
     return args
 
@@ -455,7 +461,7 @@ def make_hostgroup(options=None):
         'puppet-proxy-id': None,
     }
     args = update_dictionary(args, options)
-    create_object(HostGroup, args)
+    args.update(create_object(HostGroup, args))
 
     return args
 
@@ -499,7 +505,7 @@ def make_medium(options=None):
     }
 
     args = update_dictionary(args, options)
-    create_object(Medium, args)
+    args.update(create_object(Medium, args))
 
     return args
 
@@ -518,7 +524,7 @@ def make_environment(options=None):
     }
 
     args = update_dictionary(args, options)
-    create_object(Environment, args)
+    args.update(create_object(Environment, args))
 
     return args
 
@@ -558,6 +564,6 @@ def make_template(options=None):
     #End - Special handling for template factory
 
     args = update_dictionary(args, options)
-    create_object(Template, args)
+    args.update(create_object(Template, args))
 
     return args


### PR DESCRIPTION
The Create method for CLI will now return the newly created object, with
all its attributes, including the resource ID. Also updated all factory
methods to return the new object.

``` python
In [9]: from robottelo.cli.factory import *

In [10]: make_org()
Out[10]:
{'created-at': '2014/03/03 15:05:03',
 'description': '""',
 'id': '7',
 'label': '36wmj49',
 'name': '36wmj49',
 'updated-at': '2014/03/03 15:05:03'}

In [11]: make_user()
Out[11]:
{'admin': None,
 'auth-source-id': 1,
 'created-at': '2014/03/03 15:05:21',
 'email': 'q1gfbn@example.com',
 'firstname': 'x0nbj',
 'id': '6',
 'last-login': '""',
 'lastname': 'rbdaa34q',
 'login': 'q1gfbn',
 'mail': 'q1gfbn@example.com',
 'name': 'x0nbj rbdaa34q',
 'password': 'ygfg',
 'updated-at': '2014/03/03 15:05:21'}
```
