### PR TITLE
Update CLI organization environments tests.

### DIFF
--- a/robottelo/cli/factory.py
+++ b/robottelo/cli/factory.py
@@ -16,6 +16,7 @@ from robottelo.cli.domain import Domain
 from robottelo.cli.environment import Environment
 from robottelo.cli.gpgkey import GPGKey
 from robottelo.cli.hostgroup import HostGroup
+from robottelo.cli.lifecycleenvironment import LifecycleEnvironment
 from robottelo.cli.medium import Medium
 from robottelo.cli.model import Model
 from robottelo.cli.org import Org
@@ -532,6 +533,48 @@ def make_environment(options=None):
 
     args = update_dictionary(args, options)
     args.update(create_object(Environment, args))
+
+    return args
+
+
+def make_lifecycle_environment(options=None):
+    """
+    Usage:
+    hammer lifecycle-environment create [OPTIONS]
+
+    Options:
+        --organization-id ORGANIZATION_ID name of organization
+        --name NAME                   name of the environment
+        --description DESCRIPTION     description of the environment
+        --prior PRIOR                 Name of an environment that is prior to
+    the new environment in the chain. It has to be either ‘Library’ or an
+    environment at the end of a chain.
+
+
+    """
+
+    # Organization ID is required
+    if not options or not options.get('organization-id', None):
+        raise Exception("Please provide a valid ORG ID.")
+    if not options.get('prior', None):
+        result = LifecycleEnvironment.list(
+            {
+                'organization-id': options['organization-id'],
+                'library': 1,
+            }
+        )
+        options['prior'] = result.stdout[0]['id']
+
+    #Assigning default values for attributes
+    args = {
+        'organization-id': None,
+        'name': generate_name(6),
+        'description': None,
+        'prior': None,
+    }
+
+    args = update_dictionary(args, options)
+    args.update(create_object(LifecycleEnvironment, args))
 
     return args
 


### PR DESCRIPTION
Organizations use "Lifecycle-Environments" and not what Foreman calls
"environments", so our two existing Organization tests that add/remove
environments needed to be updated. I have updated the code to add a new
"make_lifecycle_environment" method and in the process I filed Bugzilla
1075282. The tests should work once the issue is handled by the
developers.

``` python
In [1]: from robottelo.cli.lifecycleenvironment import LifecycleEnvironment
INFO ssh:63: Paramiko instance prepared (and would be reused): 0x10326fd90

In [2]: foo = LifecycleEnvironment.list({'organization-id': 'ACME_Corporation'})

In [3]: foo.stdout
Out[3]: [{'id': '1', 'name': 'Library'}, {'id': '86', 'name': 'DEV'}]

In [4]: foo = LifecycleEnvironment.list({'organization-id': 'ACME_Corporation', 'library': 1})

In [5]: foo.stdout
Out[5]: [{'id': '1', 'name': 'Library'}]

In [6]: foo = LifecycleEnvironment.list({'organization-id': 'ACME_Corporation', 'name': 'DEV'})

In [7]: foo.stdout
Out[7]: [{'id': '86', 'name': 'DEV'}]

In [8]: from robottelo.cli.factory import make_lifecycle_environment

In [9]: make_lifecycle_environment({'organization-id': 'ACME_Corporation'})
Out[9]:
{'description': '""',
 'id': '124',
 'label': '2nwbudt',
 'library': '""',
 'name': '2nwbudt',
 'organization': 'ACME_Corporation',
 'organization-id': 'ACME_Corporation',
 'prior': '1',
 'prior-lifecycle-environment': 'Library'}

In [10]: make_lifecycle_environment({'organization-id': 'ACME_Corporation', 'prior': 124})
Out[10]:
{'description': '""',
 'id': '125',
 'label': 'xaz6uq',
 'library': '""',
 'name': 'xaz6uq',
 'organization': 'ACME_Corporation',
 'organization-id': 'ACME_Corporation',
 'prior': 124,
 'prior-lifecycle-environment': '2nwbudt'}
```
