### PR TITLE
Replace underscore with a hyphen for Foreman CLI.

### DIFF
--- a/robottelo/cli/base.py
+++ b/robottelo/cli/base.py
@@ -55,7 +55,7 @@ class Base(object):
         Adds OS to record.
         """
 
-        cls.command_sub = "add_operatingsystem"
+        cls.command_sub = "add-operatingsystem"
 
         result = cls.execute(cls._construct_command(options))
 
@@ -103,7 +103,7 @@ class Base(object):
         Deletes parameter from record.
         """
 
-        cls.command_sub = "delete_parameter"
+        cls.command_sub = "delete-parameter"
 
         result = cls.execute(cls._construct_command(options))
 
@@ -195,7 +195,7 @@ class Base(object):
         Lists all puppet classes.
         """
 
-        cls.command_sub = "puppet_classes"
+        cls.command_sub = "puppet-classes"
 
         result = cls.execute(cls._construct_command(options), expect_csv=True)
 
@@ -207,7 +207,7 @@ class Base(object):
         Removes OS from record.
         """
 
-        cls.command_sub = "remove_operatingsystem"
+        cls.command_sub = "remove-operatingsystem"
 
         result = cls.execute(cls._construct_command(options))
 
@@ -219,7 +219,7 @@ class Base(object):
         Lists all smart class parameters.
         """
 
-        cls.command_sub = "sc_params"
+        cls.command_sub = "sc-params"
 
         result = cls.execute(cls._construct_command(options), expect_csv=True)
 
@@ -231,7 +231,7 @@ class Base(object):
         Creates or updates parameter for a record.
         """
 
-        cls.command_sub = "set_parameter"
+        cls.command_sub = "set-parameter"
 
         result = cls.execute(cls._construct_command(options))
 

--- a/robottelo/cli/computeresource.py
+++ b/robottelo/cli/computeresource.py
@@ -25,7 +25,7 @@ class ComputeResource(Base):
     Manipulates Foreman's compute resources.
     """
 
-    command_base = "compute_resource"
+    command_base = "compute-resource"
 
     def __init__(self):
         """

--- a/robottelo/cli/globalparam.py
+++ b/robottelo/cli/globalparam.py
@@ -23,7 +23,7 @@ class GlobalParameter(Base):
     Manipulates Foreman's global parameters.
     """
 
-    command_base = "global_parameter"
+    command_base = "global-parameter"
 
     def __init__(self):
         """

--- a/robottelo/cli/operatingsys.py
+++ b/robottelo/cli/operatingsys.py
@@ -48,7 +48,7 @@ class OperatingSys(Base):
         Adds existing architecture to OS.
         """
 
-        cls.command_sub = "add_architecture"
+        cls.command_sub = "add-architecture"
 
         result = cls.execute(cls._construct_command(options))
 
@@ -60,7 +60,7 @@ class OperatingSys(Base):
         Adds existing template to OS.
         """
 
-        cls.command_sub = "add_configtemplate "
+        cls.command_sub = "add-configtemplate "
 
         result = cls.execute(cls._construct_command(options))
 
@@ -72,7 +72,7 @@ class OperatingSys(Base):
         Adds existing partitioning table to OS.
         """
 
-        cls.command_sub = "add_ptable"
+        cls.command_sub = "add-ptable"
 
         result = cls.execute(cls._construct_command(options))
 
@@ -84,7 +84,7 @@ class OperatingSys(Base):
         Removes architecture from OS.
         """
 
-        cls.command_sub = "remove_architecture"
+        cls.command_sub = "remove-architecture"
 
         result = cls.execute(cls._construct_command(options))
 
@@ -96,7 +96,7 @@ class OperatingSys(Base):
         Removes template from OS.
         """
 
-        cls.command_sub = "remove_configtemplate"
+        cls.command_sub = "remove-configtemplate"
 
         result = cls.execute(cls._construct_command(options))
 
@@ -108,7 +108,7 @@ class OperatingSys(Base):
         Removes partitioning table from OS.
         """
 
-        cls.command_sub = "os remove_ptable "
+        cls.command_sub = "remove-ptable "
 
         result = cls.execute(cls._construct_command(options))
 

--- a/robottelo/cli/org.py
+++ b/robottelo/cli/org.py
@@ -10,28 +10,28 @@ Parameters:
     [ARG] ...                     subcommand arguments
 
 Subcommands:
-    add_subnet                    Associate a resource
+    add-subnet                    Associate a resource
     update                        Update an organization
-    add_domain                    Associate a resource
-    add_user                      Associate a resource
-    add_hostgroup                 Associate a resource
+    add-domain                    Associate a resource
+    add-user                      Associate a resource
+    add-hostgroup                 Associate a resource
     remove_computeresource        Disassociate a resource
     remove_medium                 Disassociate a resource
     remove_configtemplate         Disassociate a resource
     delete                        Delete an organization
     remove_environment            Disassociate a resource
     remove_smartproxy             Disassociate a resource
-    add_computeresource           Associate a resource
-    add_medium                    Associate a resource
-    add_configtemplate            Associate a resource
+    add-computeresource           Associate a resource
+    add-medium                    Associate a resource
+    add-configtemplate            Associate a resource
     create                        Create an organization
-    add_environment               Associate a resource
+    add-environment               Associate a resource
     info                          Show an organization
     remove_subnet                 Disassociate a resource
     remove_domain                 Disassociate a resource
     remove_user                   Disassociate a resource
     remove_hostgroup              Disassociate a resource
-    add_smartproxy                Associate a resource
+    add-smartproxy                Associate a resource
     list                          List all organizations
 """
 
@@ -57,7 +57,7 @@ class Org(Base):
         Adds existing subnet to an org
         """
 
-        cls.command_sub = "add_subnet"
+        cls.command_sub = "add-subnet"
 
         return cls.execute(cls._construct_command(options))
 
@@ -67,7 +67,7 @@ class Org(Base):
         Removes a subnet from an org
         """
 
-        cls.command_sub = "remove_subnet"
+        cls.command_sub = "remove-subnet"
 
         return cls.execute(cls._construct_command(options))
 
@@ -77,7 +77,7 @@ class Org(Base):
         Adds a domain to an org
         """
 
-        cls.command_sub = "add_domain"
+        cls.command_sub = "add-domain"
 
         return cls.execute(cls._construct_command(options))
 
@@ -87,7 +87,7 @@ class Org(Base):
         Removes a domain from an org
         """
 
-        cls.command_sub = "remove_domain"
+        cls.command_sub = "remove-domain"
 
         return cls.execute(cls._construct_command(options))
 
@@ -97,7 +97,7 @@ class Org(Base):
         Adds an user to an org
         """
 
-        cls.command_sub = "add_user"
+        cls.command_sub = "add-user"
 
         return cls.execute(cls._construct_command(options))
 
@@ -107,7 +107,7 @@ class Org(Base):
         Removes an user from an org
         """
 
-        cls.command_sub = "remove_user"
+        cls.command_sub = "remove-user"
 
         return cls.execute(cls._construct_command(options))
 
@@ -117,7 +117,7 @@ class Org(Base):
         Adds a hostgroup to an org
         """
 
-        cls.command_sub = "add_hostgroup"
+        cls.command_sub = "add-hostgroup"
 
         return cls.execute(cls._construct_command(options))
 
@@ -127,7 +127,7 @@ class Org(Base):
         Removes a hostgroup from an org
         """
 
-        cls.command_sub = "remove_hostgroup"
+        cls.command_sub = "remove-hostgroup"
 
         return cls.execute(cls._construct_command(options))
 
@@ -137,7 +137,7 @@ class Org(Base):
         Adds a computeresource to an org
         """
 
-        cls.command_sub = "add_computeresource"
+        cls.command_sub = "add-computeresource"
 
         return cls.execute(cls._construct_command(options))
 
@@ -147,7 +147,7 @@ class Org(Base):
         Removes a computeresource from an org
         """
 
-        cls.command_sub = "remove_computeresource"
+        cls.command_sub = "remove-computeresource"
 
         return cls.execute(cls._construct_command(options))
 
@@ -157,7 +157,7 @@ class Org(Base):
         Adds a medium to an org
         """
 
-        cls.command_sub = "add_medium"
+        cls.command_sub = "add-medium"
 
         return cls.execute(cls._construct_command(options))
 
@@ -167,7 +167,7 @@ class Org(Base):
         Removes a medium from an org
         """
 
-        cls.command_sub = "remove_medium"
+        cls.command_sub = "remove-medium"
 
         return cls.execute(cls._construct_command(options))
 
@@ -177,7 +177,7 @@ class Org(Base):
         Adds a configtemplate to an org
         """
 
-        cls.command_sub = "add_configtemplate"
+        cls.command_sub = "add-configtemplate"
 
         return cls.execute(cls._construct_command(options))
 
@@ -187,7 +187,7 @@ class Org(Base):
         Removes a configtemplate from an org
         """
 
-        cls.command_sub = "remove_configtemplate"
+        cls.command_sub = "remove-configtemplate"
 
         return cls.execute(cls._construct_command(options))
 
@@ -197,7 +197,7 @@ class Org(Base):
         Adds an environment to an org
         """
 
-        cls.command_sub = "add_environment"
+        cls.command_sub = "add-environment"
 
         return cls.execute(cls._construct_command(options))
 
@@ -207,7 +207,7 @@ class Org(Base):
         Removes an environment from an org
         """
 
-        cls.command_sub = "remove_environment"
+        cls.command_sub = "remove-environment"
 
         return cls.execute(cls._construct_command(options))
 
@@ -217,7 +217,7 @@ class Org(Base):
         Adds a smartproxy to an org
         """
 
-        cls.command_sub = "add_smartproxy"
+        cls.command_sub = "add-smartproxy"
 
         return cls.execute(cls._construct_command(options))
 
@@ -227,6 +227,6 @@ class Org(Base):
         Removes a smartproxy from an org
         """
 
-        cls.command_sub = "remove_smartproxy"
+        cls.command_sub = "remove-smartproxy"
 
         return cls.execute(cls._construct_command(options))

--- a/robottelo/cli/partitiontable.py
+++ b/robottelo/cli/partitiontable.py
@@ -28,7 +28,7 @@ class PartitionTable(Base):
     Manipulates Foreman's partition tables.
     """
 
-    command_base = "partition_table"
+    command_base = "partition-table"
 
     def __init__(self):
         """

--- a/robottelo/cli/proxy.py
+++ b/robottelo/cli/proxy.py
@@ -35,12 +35,12 @@ class Proxy(Base):
         Base.__init__(self)
 
     @classmethod
-    def import_classes(cls, options=None):
+    def importclasses(cls, options=None):
         """
         Import puppet classes from puppet proxy.
         """
 
-        cls.command_sub = "import_classes"
+        cls.command_sub = "import-classes"
 
         result = cls.execute(cls._construct_command(options))
 

--- a/robottelo/cli/puppet.py
+++ b/robottelo/cli/puppet.py
@@ -28,4 +28,4 @@ class Puppet(Base):
         Sets the base command for class.
         """
         Base.__init__(self)
-        self.command_base = "puppet_class"
+        self.command_base = "puppet-class"

--- a/robottelo/cli/smartclass.py
+++ b/robottelo/cli/smartclass.py
@@ -23,7 +23,7 @@ class SmartClassParameter(Base):
     Manipulates smart class parameters in Foreman
     """
 
-    command_base = "sc_param"
+    command_base = "sc-param"
 
     def __init__(self):
         """


### PR DESCRIPTION
As per https://github.com/theforeman/hammer-cli-foreman/pull/108,
Foreman hammer CLI commands will replace underscores for hyphens.

A separate PR will be filed once Katello CLI goes through the same
changes (see http://projects.theforeman.org/issues/4709).
