### PR TITLE
Fixed 2 CLI failures related to lifecycle env.

### DIFF
--- a/tests/cli/test_org.py
+++ b/tests/cli/test_org.py
@@ -634,8 +634,8 @@ class TestOrg(BaseCLI):
 
         # Can we list the new environment?
         environment = LifecycleEnvironment.list(
+            new_obj['label'],
             {
-                'organization-id': new_obj['label'],
                 'name': env_result['name']
             })
         # Result is a list of one item
@@ -659,8 +659,8 @@ class TestOrg(BaseCLI):
 
         # Can we list the new environment?
         environment = LifecycleEnvironment.list(
+            new_obj['label'],
             {
-                'organization-id': new_obj['label'],
                 'name': env_result['name']
             })
         # Result is a list of one item
@@ -681,8 +681,8 @@ class TestOrg(BaseCLI):
 
         # Can we list the new environment?
         environment = LifecycleEnvironment.list(
+            new_obj['label'],
             {
-                'organization-id': new_obj['label'],
                 'name': env_result['name']
             })
         self.assertEqual(


### PR DESCRIPTION
The CLI `list` method for `lifecycle-environment` takes 2 arguments
and not a single dictionary.

``` bash
======================================================================
ERROR: @Test: Check if an environment can be added to an Org
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/jenkins/workspace/foreman-compose-cli/tests/cli/test_org.py", line 642, in test_add_environment
    new_env = environment.stdout[0]
IndexError: list index out of range

======================================================================
ERROR: @Test: Check if an Environment can be removed from an Org
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/jenkins/workspace/foreman-compose-cli/tests/cli/test_org.py", line 667, in test_remove_environment
    new_env = environment.stdout[0]
IndexError: list index out of range
```

With the proposed fix:

``` bash
$ nosetests -c robottelo.properties
tests/cli/test_org.py:TestOrg.test_add_environment tests/cli/test_org.py:TestOrg.test_remove_environment

@Test: Check if an environment can be added to an Org ... ok
@Test: Check if an Environment can be removed from an Org ... ok

----------------------------------------------------------------------
XML: foreman-results.xml
----------------------------------------------------------------------
Ran 2 tests in 48.855s

OK
```
