### PR TITLE
Fix import to make api tests green again

### DIFF
--- a/tests/api/test_org.py
+++ b/tests/api/test_org.py
@@ -9,7 +9,7 @@ from robottelo.common.constants import NOT_IMPLEMENTED
 from robottelo.common.decorators import bzbug
 from robottelo.records.organization import Organization
 from robottelo.common.records.base import NoEnum
-from robottelo.common.records.fields import basic_positive
+from robottelo.common.records.fields import BasicPositiveField
 from tests.api.baseapi import BaseAPI
 
 
@@ -79,7 +79,7 @@ class TestOrganization(BaseAPI):
 
     @data(
         *Organization.enumerate(
-            name=basic_positive(maxlen=300),
+            name=BasicPositiveField(maxlen=300),
             label=NoEnum,
             description=NoEnum)
     )
@@ -230,7 +230,7 @@ class TestOrganization(BaseAPI):
     # Negative Update
 
     @data(*Organization.enumerate(
-        name=basic_positive(maxlen=300),
+        name=BasicPositiveField(maxlen=300),
         label=NoEnum,
         description=NoEnum
         ))
@@ -255,7 +255,7 @@ class TestOrganization(BaseAPI):
 
     @data(*Organization.enumerate(
         name=NoEnum,
-        label=basic_positive(maxlen=300),
+        label=BasicPositiveField(maxlen=300),
         description=NoEnum
         ))
     def test_negative_update_2(self, test_data):


### PR DESCRIPTION
Fix for the latest nightly-api results, specifically:

```
Traceback (most recent call last):
  File "/usr/lib/python2.7/site-packages/nose/loader.py", line 411, in loadTestsFromName
    addr.filename, addr.module)
  File "/usr/lib/python2.7/site-packages/nose/importer.py", line 47, in importFromPath
    return self.importFromDir(dir_path, fqname)
  File "/usr/lib/python2.7/site-packages/nose/importer.py", line 94, in importFromDir
    mod = load_module(part_fqname, fh, filename, desc)
  File "/home/jenkins/workspace/foreman-nightly-api/tests/api/test_org.py", line 12, in <module>
    from robottelo.common.records.fields import basic_positive
ImportError: cannot import name basic_positive
```
