### PR TITLE
blocked all implemented activation key tests with bz-id

### DIFF
--- a/tests/ui/test_activationkey.py
+++ b/tests/ui/test_activationkey.py
@@ -60,7 +60,7 @@ class ActivationKey(BaseUI):
         1. Create Activation key for all valid Activation Key name variation
         in [1] using valid Description, Environment, Content View, Usage limit
         @Assert: Activation key is created
-        @Status: Manual
+        @BZ: 1078676
         """
         self.login.login(self.katello_user, self.katello_passwd)
         self.navigator.go_to_select_org(ActivationKey.org_name)
@@ -80,7 +80,7 @@ class ActivationKey(BaseUI):
         1. Create Activation key for all valid Description variation in [1]
         using valid Name, Environment, Content View and Usage limit
         @Assert: Activation key is created
-        @Status: Manual
+        @BZ: 1078676
         """
 
         name = generate_name(6)
@@ -102,6 +102,7 @@ class ActivationKey(BaseUI):
         using valid Name, Description, Content View and Usage limit
         @Assert: Activation key is created
         @Status: Manual
+        @BZ: 1078676
         """
         pass
 
@@ -116,6 +117,7 @@ class ActivationKey(BaseUI):
         using valid Name, Description, Environment and Usage limit
         @Assert: Activation key is created
         @Status: Manual
+        @BZ: 1078676
         """
         pass
 
@@ -130,6 +132,7 @@ class ActivationKey(BaseUI):
         using valid Name, Description, Environment, Content View, Usage limit
         @Assert: Activation key is created
         @Status: Manual
+        @BZ: 1078676
         """
         pass
 
@@ -143,7 +146,7 @@ class ActivationKey(BaseUI):
         1. Create Activation key with default Usage Limit (Unlimited)
         using valid Name, Description, Environment and Content View
         @Assert: Activation key is created
-        @Status: Manual
+        @BZ: 1078676
         """
         name = generate_name(6)
         description = generate_name(6)
@@ -163,7 +166,7 @@ class ActivationKey(BaseUI):
         1. Create Activation key with finite Usage Limit (Not Unlimited)
         using valid Name, Description, Environment and Content View
         @Assert: Activation key is created
-        @Status: Manual
+        @BZ: 1078676
         """
         name = generate_name(6)
         description = generate_name(6)
@@ -184,7 +187,7 @@ class ActivationKey(BaseUI):
         1. Create Activation key by entering Activation Key Name alone
         leaving Description, Content View and Usage Limit as default values
         @Assert: Activation key is created
-        @Status: Manual
+        @BZ: 1078676
         """
         name = generate_name(6)
         self.login.login(self.katello_user, self.katello_passwd)
@@ -326,6 +329,7 @@ class ActivationKey(BaseUI):
         2. Delete the Content View
         @Assert: Activation key is deleted or updated accordingly
         @Status: Manual
+        @BZ: 1078676
         """
         pass
 
@@ -341,6 +345,7 @@ class ActivationKey(BaseUI):
         3. Click Cancel in the confirmation dialog box
         @Assert: Activation key is not deleted
         @Status: Manual
+        @BZ: 1078676
         """
         pass
 
@@ -355,7 +360,7 @@ class ActivationKey(BaseUI):
         1. Create Activation key
         2. Update Activation key name for all variations in [1]
         @Assert: Activation key is updated
-        @Status: Manual
+        @BZ: 1078676
         """
 
         name = generate_name(6)
@@ -378,7 +383,7 @@ class ActivationKey(BaseUI):
         1. Create Activation key
         2. Update Description for all variations in [1]
         @Assert: Activation key is updated
-        @Status: Manual
+        @BZ: 1078676
         """
 
         name = generate_name(6)
@@ -403,6 +408,7 @@ class ActivationKey(BaseUI):
         2. Update Environment for all variations in [1]
         @Assert: Activation key is updated
         @Status: Manual
+        @BZ: 1078676
         """
         pass
 
@@ -418,6 +424,7 @@ class ActivationKey(BaseUI):
         RH and custom products
         @Assert: Activation key is updated
         @Status: Manual
+        @BZ: 1078676
         """
         pass
 
@@ -431,7 +438,7 @@ class ActivationKey(BaseUI):
         1. Create Activation key
         2. Update Usage limit from Unlimited to a definite number
         @Assert: Activation key is updated
-        @Status: Manual
+        @BZ: 1078676
         """
 
         name = generate_name(6)
@@ -455,7 +462,7 @@ class ActivationKey(BaseUI):
         1. Create Activation key
         2. Update Usage limit from definite number to Unlimited
         @Assert: Activation key is updated
-        @Status: Manual
+        @BZ: 1078676
         """
 
         name = generate_name(6)
@@ -481,6 +488,7 @@ class ActivationKey(BaseUI):
         2. Update Activation key name for all variations in [2]
         @Assert: Activation key is not updated.  Appropriate error shown.
         @Status: Manual
+        @BZ: 1078676
         """
         pass
 
@@ -495,6 +503,7 @@ class ActivationKey(BaseUI):
         2. Update Description for all variations in [2]
         @Assert: Activation key is not updated.  Appropriate error shown.
         @Status: Manual
+        @BZ: 1078676
         """
         pass
 
@@ -509,6 +518,7 @@ class ActivationKey(BaseUI):
         2. Update Usage Limit for all variations in [2]
         @Assert: Activation key is not updated.  Appropriate error shown.
         @Status: Manual
+        @BZ: 1078676
         """
         pass
 
@@ -525,6 +535,7 @@ class ActivationKey(BaseUI):
         4. Attempt to register an other system after reaching the Usage Limit
         @Assert: System Registration fails. Appropriate error shown
         @Status: Manual
+        @BZ: 1078676
         """
         pass
 
@@ -540,6 +551,7 @@ class ActivationKey(BaseUI):
         3. Associate the hosts to Activation key
         @Assert: Hosts are successfully associated to Activation key
         @Status: Manual
+        @BZ: 1078676
         """
         pass
 
@@ -554,6 +566,7 @@ class ActivationKey(BaseUI):
         2. Associate RH product(s) to Activation Key
         @Assert: RH products are successfully associated to Activation key
         @Status: Manual
+        @BZ: 1078676
         """
         pass
 
@@ -568,6 +581,7 @@ class ActivationKey(BaseUI):
         2. Associate custom product(s) to Activation Key
         @Assert: Custom products are successfully associated to Activation key
         @Status: Manual
+        @BZ: 1078676
         """
         pass
 
@@ -583,6 +597,7 @@ class ActivationKey(BaseUI):
         3. Associate custom product(s) to Activation Key
         @Assert: RH/Custom product is successfully associated to Activation key
         @Status: Manual
+        @BZ: 1078676
         """
         pass
 
@@ -598,6 +613,7 @@ class ActivationKey(BaseUI):
         3. Delete the manifest
         @Assert: Deleting a manifest removes it from the Activation key
         @Status: Manual
+        @BZ: 1078676
         """
         pass
 
@@ -612,6 +628,7 @@ class ActivationKey(BaseUI):
         2. Attach all the created Activation keys to a System
         @Assert: Multiple Activation keys are attached to a system
         @Status: Manual
+        @BZ: 1078676
         """
         pass
 
@@ -627,6 +644,7 @@ class ActivationKey(BaseUI):
         2. List Activation key
         @Assert: Activation key is listed
         @Status: Manual
+        @BZ: 1078676
         """
         pass
 
@@ -641,6 +659,7 @@ class ActivationKey(BaseUI):
         2. List Activation key
         @Assert: Activation key is listed
         @Status: Manual
+        @BZ: 1078676
         """
         pass
 
@@ -670,6 +689,7 @@ class ActivationKey(BaseUI):
         2. Search/find Activation key
         @Assert: Activation key is found
         @Status: Manual
+        @BZ: 1078676
         """
         pass
 
@@ -686,6 +706,7 @@ class ActivationKey(BaseUI):
         2. Get info of the Activation key
         @Assert: Activation key info is displayed
         @Status: Manual
+        @BZ: 1078676
         """
         pass
 
@@ -700,6 +721,7 @@ class ActivationKey(BaseUI):
         2. Get info of the Activation key
         @Assert: Activation key info is displayed
         @Status: Manual
+        @BZ: 1078676
         """
         pass
 
@@ -714,5 +736,6 @@ class ActivationKey(BaseUI):
         2. Provision systems with Activation key
         @Assert: Systems are successfully provisioned with Activation key
         @Status: Manual
+        @BZ: 1078676
         """
         pass


### PR DESCRIPTION
I saw many failures in latest UI jenkin run, and all are failing due to a blocking bz (1078676).
