### PR TITLE
Add Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,29 @@
+NOSETESTS=$(shell which nosetests)
+
+# Paths
+ROBOTTELO_TESTS_PATH=tests/robottelo/
+FOREMAN_TESTS_PATH=tests/foreman/
+FOREMAN_API_TESTS_PATH=$(join $(FOREMAN_TESTS_PATH), api)
+FOREMAN_CLI_TESTS_PATH=$(join $(FOREMAN_TESTS_PATH), cli)
+FOREMAN_UI_TESTS_PATH=$(join $(FOREMAN_TESTS_PATH), ui)
+
+
+docs:
+	@cd docs; $(MAKE) html
+
+docs-clean:
+	@cd docs; $(MAKE) clean
+
+test:
+	$(NOSETESTS) $(ROBOTTELO_TESTS_PATH)
+
+test-foreman-api:
+	$(NOSETESTS) -c robottelo.properties $(FOREMAN_API_TESTS_PATH)
+
+test-foreman-cli:
+	$(NOSETESTS) -c robottelo.properties $(FOREMAN_CLI_TESTS_PATH)
+
+test-foreman-ui:
+	$(NOSETESTS) -c robottelo.properties $(FOREMAN_UI_TESTS_PATH)
+
+.PHONY: docs docs-clean test test-foreman-api test-foreman-cli test-foreman-ui


### PR DESCRIPTION
Add rules to build and clean the docs
Add rule to test robottelo itself
Add rules for testing foreman api, cli and ui

This PR is intended to add a standardized way to evoke the tests. So in the future if we change the tool used (for example from nose to py.test) or if we improve the project's directory structure we will continue evoking the same command `make test-foreman-(api | cli | ui)`.

`make test` is intended to run the robottelo's tests.

Also with `make docs` and `make docs-clean` is possible to build and clean the docs without leaving the project root.
