### PR TITLE
Added new 'stubbed' decorator for stubbed tests.

### DIFF
--- a/robottelo/common/decorators.py
+++ b/robottelo/common/decorators.py
@@ -17,6 +17,7 @@ else:
 
 
 from robottelo.common import conf
+from robottelo.common.constants import NOT_IMPLEMENTED
 from xml.parsers.expat import ExpatError
 
 
@@ -25,6 +26,11 @@ bugzilla_log.setLevel(logging.WARNING)
 
 BUGZILLA_URL = "https://bugzilla.redhat.com/xmlrpc.cgi"
 REDMINE_URL = 'http://projects.theforeman.org'
+
+
+def stubbed(func):
+    """Skips test since they're not yet implemented"""
+    return unittest.skip(NOT_IMPLEMENTED)(func)
 
 
 def runIf(project):


### PR DESCRIPTION
Right now, in order to skip tests that have been 'stubbed' and don't
have any code implementing it, we have to import unittest, the
NOT_IMPLEMENTED constant and deal with unittest x unittest2 imports,
which is messy and duplicated in many places.

Instead I propose the creation of this 'stubbed' decorator to simplify
the process described above. If merged I'll create a separate PR (or
amend this one is desired) so that all existing tests are refactored.
