### PR TITLE
Workaround for broken nose_xunitmp

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 ddt
 git+https://github.com/RedHatQE/python-stageportal.git#egg=stageportal
 git+https://github.com/smartkiwi/SeleniumFactory-for-Python.git#egg=SeleniumFactory
-git+git://github.com/blrm/nose_xunitmp.git#egg=nose_xunitmp
+git+https://github.com/blrm/nose_xunitmp.git#egg=nose_xunitmp
 iniparse
 nose
 paramiko


### PR DESCRIPTION
When nose 1.3.1 was released a few weeks ago, it removed a _forceUnicode() method that the nose_xunitmp plugin depended on. This causes our reporting to fail at the end of a series of tests. I forked the package and made a minor change to fix this missing method, so this PR is just to point to the new plugin location in requirements.txt.
