### PR TITLE
Remove unimplemented __init__ for CLI classes

### DIFF
--- a/robottelo/cli/architecture.py
+++ b/robottelo/cli/architecture.py
@@ -28,9 +28,3 @@ class Architecture(Base):
     """
 
     command_base = "architecture"
-
-    def __init__(self):
-        """
-        Sets the base command for class.
-        """
-        Base.__init__(self)

--- a/robottelo/cli/base.py
+++ b/robottelo/cli/base.py
@@ -46,9 +46,6 @@ class Base(object):
     katello_user = conf.properties['foreman.admin.username']
     katello_passwd = conf.properties['foreman.admin.password']
 
-    def __init__(self):
-        pass
-
     @classmethod
     def add_operating_system(cls, options=None):
         """

--- a/robottelo/cli/computeresource.py
+++ b/robottelo/cli/computeresource.py
@@ -26,9 +26,3 @@ class ComputeResource(Base):
     """
 
     command_base = "compute-resource"
-
-    def __init__(self):
-        """
-        Sets the base command for class.
-        """
-        Base.__init__(self)

--- a/robottelo/cli/domain.py
+++ b/robottelo/cli/domain.py
@@ -28,9 +28,3 @@ class Domain(Base):
     """
 
     command_base = "domain"
-
-    def __init__(self):
-        """
-        Sets the base command for class.
-        """
-        Base.__init__(self)

--- a/robottelo/cli/environment.py
+++ b/robottelo/cli/environment.py
@@ -27,9 +27,3 @@ class Environment(Base):
     """
 
     command_base = "environment"
-
-    def __init__(self):
-        """
-        Sets the base command for class.
-        """
-        Base.__init__(self)

--- a/robottelo/cli/fact.py
+++ b/robottelo/cli/fact.py
@@ -22,9 +22,3 @@ class Fact(Base):
     """
 
     command_base = "fact"
-
-    def __init__(self):
-        """
-        Sets the base command for class.
-        """
-        Base.__init__(self)

--- a/robottelo/cli/globalparam.py
+++ b/robottelo/cli/globalparam.py
@@ -25,12 +25,6 @@ class GlobalParameter(Base):
 
     command_base = "global-parameter"
 
-    def __init__(self):
-        """
-        Sets the base command for class.
-        """
-        Base.__init__(self)
-
     @classmethod
     def set(cls, options=None):
         """ Set global parameter """

--- a/robottelo/cli/gpgkey.py
+++ b/robottelo/cli/gpgkey.py
@@ -27,12 +27,6 @@ class GPGKey(Base):
 
     command_base = "gpg"
 
-    def __init__(self):
-        """
-        Sets the base command for class.
-        """
-        Base.__init__(self)
-
     @classmethod
     def exists(cls, organization_id, tuple_search=None):
         """

--- a/robottelo/cli/host.py
+++ b/robottelo/cli/host.py
@@ -38,12 +38,6 @@ class Host(Base):
 
     command_base = "host"
 
-    def __init__(self):
-        """
-        Sets the base command for class.
-        """
-        Base.__init__(self)
-
     @classmethod
     def facts(cls, options=None):
         """

--- a/robottelo/cli/hostgroup.py
+++ b/robottelo/cli/hostgroup.py
@@ -30,9 +30,3 @@ class HostGroup(Base):
     """
 
     command_base = "hostgroup"
-
-    def __init__(self):
-        """
-        Sets the base command for class
-        """
-        Base.__init__(self)

--- a/robottelo/cli/lifecycleenvironment.py
+++ b/robottelo/cli/lifecycleenvironment.py
@@ -27,12 +27,6 @@ class LifecycleEnvironment(Base):
 
     command_base = "lifecycle-environment"
 
-    def __init__(self):
-        """
-        Sets the base command for class.
-        """
-        Base.__init__(self)
-
     @classmethod
     def exists(cls, organization_id, tuple_search=None):
         """

--- a/robottelo/cli/medium.py
+++ b/robottelo/cli/medium.py
@@ -28,9 +28,3 @@ class Medium(Base):
     """
 
     command_base = "medium"
-
-    def __init__(self):
-        """
-        Sets the base command for class.
-        """
-        Base.__init__(self)

--- a/robottelo/cli/model.py
+++ b/robottelo/cli/model.py
@@ -26,9 +26,3 @@ class Model(Base):
     """
 
     command_base = "model"
-
-    def __init__(self):
-        """
-        Sets the base command for class.
-        """
-        Base.__init__(self)

--- a/robottelo/cli/operatingsys.py
+++ b/robottelo/cli/operatingsys.py
@@ -36,12 +36,6 @@ class OperatingSys(Base):
 
     command_base = "os"
 
-    def __init__(self):
-        """
-        Sets the base command for class.
-        """
-        Base.__init__(self)
-
     @classmethod
     def add_architecture(cls, options=None):
         """

--- a/robottelo/cli/org.py
+++ b/robottelo/cli/org.py
@@ -45,12 +45,6 @@ class Org(Base):
 
     command_base = "organization"
 
-    def __init__(self):
-        """
-        Sets the base command for class
-        """
-        Base.__init__(self)
-
     @classmethod
     def add_subnet(cls, options=None):
         """

--- a/robottelo/cli/partitiontable.py
+++ b/robottelo/cli/partitiontable.py
@@ -29,9 +29,3 @@ class PartitionTable(Base):
     """
 
     command_base = "partition-table"
-
-    def __init__(self):
-        """
-        Sets the base command for class.
-        """
-        Base.__init__(self)

--- a/robottelo/cli/product.py
+++ b/robottelo/cli/product.py
@@ -29,12 +29,6 @@ class Product(Base):
 
     command_base = "product"
 
-    def __init__(self):
-        """
-        Sets the base command for class.
-        """
-        Base.__init__(self)
-
     @classmethod
     def list(cls, organization_id, options=None):
         """

--- a/robottelo/cli/proxy.py
+++ b/robottelo/cli/proxy.py
@@ -28,12 +28,6 @@ class Proxy(Base):
 
     command_base = "proxy"
 
-    def __init__(self):
-        """
-        Sets the base command for class.
-        """
-        Base.__init__(self)
-
     @classmethod
     def importclasses(cls, options=None):
         """

--- a/robottelo/cli/puppet.py
+++ b/robottelo/cli/puppet.py
@@ -23,9 +23,4 @@ class Puppet(Base):
     Search Foreman's puppet modules.
     """
 
-    def __init__(self):
-        """
-        Sets the base command for class.
-        """
-        Base.__init__(self)
-        self.command_base = "puppet-class"
+    command_base = "puppet-class"

--- a/robottelo/cli/report.py
+++ b/robottelo/cli/report.py
@@ -25,9 +25,3 @@ class Report(Base):
     """
 
     command_base = "report"
-
-    def __init__(self):
-        """
-        Sets the base command for class.
-        """
-        Base.__init__(self)

--- a/robottelo/cli/smartclass.py
+++ b/robottelo/cli/smartclass.py
@@ -24,9 +24,3 @@ class SmartClassParameter(Base):
     """
 
     command_base = "sc-param"
-
-    def __init__(self):
-        """
-        Sets the base command for class.
-        """
-        Base.__init__(self)

--- a/robottelo/cli/subnet.py
+++ b/robottelo/cli/subnet.py
@@ -27,9 +27,3 @@ class Subnet(Base):
     """
 
     command_base = "subnet"
-
-    def __init__(self):
-        """
-        Sets the base command for class.
-        """
-        Base.__init__(self)

--- a/robottelo/cli/subscription.py
+++ b/robottelo/cli/subscription.py
@@ -15,12 +15,6 @@ class Subscription(Base):
 
     command_base = "subscription"
 
-    def __init__(self):
-        """
-        Sets the base command for class.
-        """
-        Base.__init__(self)
-
     @classmethod
     def upload(cls, options=None):
         """

--- a/robottelo/cli/syncplan.py
+++ b/robottelo/cli/syncplan.py
@@ -27,12 +27,6 @@ class SyncPlan(Base):
 
     command_base = "sync-plan"
 
-    def __init__(self):
-        """
-        Sets the base command for class.
-        """
-        Base.__init__(self)
-
     @classmethod
     def info(cls, organization_id, options=None):
         """

--- a/robottelo/cli/template.py
+++ b/robottelo/cli/template.py
@@ -31,12 +31,6 @@ class Template(Base):
 
     command_base = "template"
 
-    def __init__(self):
-        """
-        Sets the base command for class.
-        """
-        Base.__init__(self)
-
     @classmethod
     def kinds(cls, options=None):
         """

--- a/robottelo/cli/user.py
+++ b/robottelo/cli/user.py
@@ -26,9 +26,3 @@ class User(Base):
     """
 
     command_base = "user"
-
-    def __init__(self):
-        """
-        Sets the base command for class.
-        """
-        Base.__init__(self)


### PR DESCRIPTION
CLI classes are using classmethods now and the `__init__` was not implemented.
