### PR TITLE
Better representation for a Product via CLI.

### DIFF
--- a/robottelo/cli/product.py
+++ b/robottelo/cli/product.py
@@ -30,6 +30,40 @@ class Product(Base):
     command_base = "product"
 
     @classmethod
+    def info(cls, options=None):
+        """
+        Gets information by provided: options dictionary.
+        @param options: ID (sometimes name or id).
+        """
+        cls.command_sub = "info"
+
+        # Use the 'base' output adapter
+        result = cls.execute(cls._construct_command(options), expect_csv=False)
+
+        # This will hold our GPG key dictionary
+        gpg_key = {}
+
+        for items in result.stdout:
+            # Break each item splitting at the ':'
+            # Example:  Organization: dTVfLkUhHIDiwPIQHqRn
+            item = items.split(':')
+            # Get rid of empty items
+            if len(item) == 2:
+                # Strip leading whitespace, use dashes and lower keys
+                key = item[0].lstrip().replace(' ', '-').lower()
+                # Strip leading whitespaces from values
+                value = item[1].lstrip()
+                # Build the dictionary
+                gpg_key[key] = value
+        if len(result.stdout) == 0:
+            raise Exception("Info subcommand returned more than 1 result.")
+
+        # Update result.stdout
+        result.stdout = gpg_key
+
+        return result
+
+    @classmethod
     def list(cls, organization_id, options=None):
         """
         Lists available products.


### PR DESCRIPTION
Noticed that using the 'csv' output adapter to obtain information for a
given product via Hammer was returning extra information that was
unusable. It also broke several of the automated tests for Products and
Repositories. I have filed a Bugzilla issue but in the meantime I have
decided to add an 'Info' method for Products and tweak the data so that
it returns a proper python dictionary (which should fix the failing
tests).

Here's what the CSV adapter was returning:

``` bash
ID,Name,Label,Description,Sync Plan ID,Sync State,Sync Plan ID,GPG,Organization,Readonly,Deletable,Content
27,阄軍萫兏瑆泳厾馃槠硾拻灦孤筂雸諶應榦糱甶,c6bbbe8f-4d9d-42d4-8e87-ddc34764c0b4,<pre>diwTISpSdfYulZdHHiRC</pre>,"",not_synced,"",productContentprovidernamed143b68a-bddb-4463-afcb-70b8132d236elibrary_repositoriesrepository_count0sync_statusuuidparametersfinish_timeuser_id0updated_attask_typeprogresssize_left0total_size0total_count0items_left0organization_ididtask_owner_typetask_owner_idstatenot_syncedcreated_atpending?falseresultstart_timepermissionsdeletabletruesync_plan_idlabelc6bbbe8f-4d9d-42d4-8e87-ddc34764c0b4name阄軍萫兏瑆泳厾馃槠硾拻灦孤筂雸諶應榦糱甶id27updated_at2014-04-06T21:47:53ZorganizationlabelBsEVvO0bxipI0ivJI64vnamedTVfLkUhHIDiwPIQHqRnreadonlyfalsecreated_at2014-04-06T05:39:48Zcp_id1396762787854gpg_keynamefoobarid39gpg_key_id39provider_id169description<pre>diwTISpSdfYulZdHHiRC</pre>,dTVfLkUhHIDiwPIQHqRn,"",true,""
```

and the BASE (default) adapter is what I used:

``` bash
ID:           27
Name:         阄軍萫兏瑆泳厾馃槠硾拻灦孤筂雸諶應榦糱甶
Label:        c6bbbe8f-4d9d-42d4-8e87-ddc34764c0b4
Description:  <pre>diwTISpSdfYulZdHHiRC</pre>
Sync Plan ID:
Sync State:   not_synced
Sync Plan ID:
GPG:
    GPG Key ID: 39
    GPG Key:    foobar
Organization: dTVfLkUhHIDiwPIQHqRn
Readonly:     false
Deletable:    true
Content:
```

Here's what the proposed fix does:

``` python
In [1]: from robottelo.cli.product import Product

In [2]: Product.info({'id': 27}).stdout

Out[2]:
{u'content': u'',
 u'deletable': u'true',
 u'description': u'<pre>diwTISpSdfYulZdHHiRC</pre>',
 u'gpg': u'',
 u'gpg-key': u'foobar',
 u'gpg-key-id': u'39',
 u'id': u'27',
 u'label': u'c6bbbe8f-4d9d-42d4-8e87-ddc34764c0b4',
 u'name': u'\u9604\u8ecd\u842b\u514f\u7446\u6cf3\u53be\u9983\u69e0\u787e\u62fb\u7066\u5b64\u7b42\u96f8\u8af6\u61c9\u69a6\u7cf1\u7536',
 u'organization': u'dTVfLkUhHIDiwPIQHqRn',
 u'readonly': u'false',
 u'sync-plan-id': u'',
 u'sync-state': u'not_synced'}
```
