### PR TITLE
Add back the __init__ for UI base class

### DIFF
--- a/robottelo/ui/base.py
+++ b/robottelo/ui/base.py
@@ -21,6 +21,12 @@ class Base(object):
 
     logger = logging.getLogger("robottelo")
 
+    def __init__(self, browser):
+        """
+        Sets up the browser object.
+        """
+        self.browser = browser
+
     def find_element(self, locator):
         """
         Wrapper around Selenium's WebDriver that allows you to search for an


### PR DESCRIPTION
#638 was for taking advantage of inheritance for UI tests, but the `__init__` method was removed by mistake from base class. Adding it back again to really take advantage of inheritance for UI.
