### PR TITLE
Do not raise exception for Product info.

### DIFF
--- a/robottelo/cli/product.py
+++ b/robottelo/cli/product.py
@@ -55,8 +55,6 @@ class Product(Base):
                 value = item[1].lstrip()
                 # Build the dictionary
                 gpg_key[key] = value
-        if len(result.stdout) == 0:
-            raise Exception("Info subcommand returned more than 1 result.")
 
         # Update result.stdout
         result.stdout = gpg_key


### PR DESCRIPTION
If a product information cannot be found, do not raise an exception.
This will fix the 7 current CLI failures seen on Jenkins.
