### PR TITLE
delete activation-key function and tests

### DIFF
--- a/robottelo/ui/activationkey.py
+++ b/robottelo/ui/activationkey.py
@@ -5,7 +5,7 @@
 Implements Activation keys UI
 """
 
-from robottelo.common.helpers import escape_search
+from robottelo.common.helpers import escape_search, sleep_for_seconds
 from robottelo.ui.base import Base
 from robottelo.ui.locators import locators, common_locators
 from selenium.webdriver.support.select import Select
@@ -52,7 +52,7 @@ class ActivationKey(Base):
                 element = self.wait_until_element((strategy, value % env))
                 if element:
                     element.click()
-                    self.wait_for_ajax()
+                    sleep_for_seconds(2)
             else:
                 raise Exception(
                     "Could not create new activation key '%s', \
@@ -83,7 +83,7 @@ class ActivationKey(Base):
         if searchbox:
             searchbox.clear()
             searchbox.send_keys(escape_search(element_name))
-            self.wait_for_ajax()
+            sleep_for_seconds(2)
             self.find_element(common_locators["kt_search_button"]).click()
             strategy = locators["ak.ak_name"][0]
             value = locators["ak.ak_name"][1]
@@ -119,3 +119,22 @@ class ActivationKey(Base):
                         )).select_by_visible_text(content_view)
         else:
             raise Exception("Could not update the activation key '%s'" % name)
+
+    def delete(self, name, really):
+        """
+        Deletes an existing activation key
+        """
+
+        element = self.search_key(name)
+
+        if element:
+            element.click()
+            self.wait_for_ajax()
+            sleep_for_seconds(2)
+            self.wait_until_element(locators["ak.remove"]).click()
+            self.wait_for_ajax()
+            if really:
+                self.wait_until_element(common_locators["confirm_remove"]
+                                        ).click()
+            else:
+                self.wait_until_element(locators["ak.cancel"]).click()

--- a/robottelo/ui/locators.py
+++ b/robottelo/ui/locators.py
@@ -337,6 +337,15 @@ tab_locators = {
     # Third level UI
     "contentviews.tab_details": (
         By.XPATH, "//a[@class='ng-scope' and contains(@href,'info')]"),
+
+    # Activation Keys
+    # Third level UI
+    "ak.details": (
+        By.XPATH, "//a[conatins(@href, 'info')]"),
+    "ak.subscriptions": (
+        By.XPATH, "//a[conatins(@href, 'subscriptions')]"),
+    "ak.system_groups": (
+        By.XPATH, "//a[conatins(@href, 'system-groups')]"),
 }
 
 common_locators = {
@@ -883,6 +892,11 @@ locators = {
     "ak.edit_content_view_select": (
         By.XPATH, "//form[@alch-edit-select='activationKey.content_view.name']\
         /select"),
+    "ak.remove": (
+        By.XPATH, "//button[@ng-click='openModal()']"),
+    "ak.cancel": (
+        By.XPATH, ("//div[@class='modal-dialog']"
+                   "//button[@ng-click='cancel()']")),
 
     # Sync Plans
     "sync.prd_expander": (

--- a/tests/foreman/ui/test_activationkey.py
+++ b/tests/foreman/ui/test_activationkey.py
@@ -254,9 +254,9 @@ class ActivationKey(BaseUI):
         self.assertTrue(invalid)
         self.assertIsNone(self.activationkey.search_key(name))
 
-    @bzbug('1063273')
-    @unittest.skip(NOT_IMPLEMENTED)
-    def test_positive_delete_activation_key_1(self):
+    @attr('ui', 'ak', 'implemented')
+    @data(*valid_names_list())
+    def test_positive_delete_activation_key_1(self, name):
         """
         @Feature: Activation key - Positive Delete
         @Test: Create Activation key and delete it for all variations of
@@ -266,13 +266,20 @@ class ActivationKey(BaseUI):
         using valid Description, Environment, Content View, Usage limit
         2. Delete the Activation key
         @Assert: Activation key is deleted
-        @Status: Manual
         """
-        pass
 
-    @bzbug('1063273')
-    @unittest.skip(NOT_IMPLEMENTED)
-    def test_positive_delete_activation_key_2(self):
+        self.login.login(self.katello_user, self.katello_passwd)
+        self.navigator.go_to_select_org(ActivationKey.org_name)
+        self.navigator.go_to_activation_keys()
+        self.activationkey.create(name, ENVIRONMENT,
+                                  description=generate_name(16))
+        self.assertIsNotNone(self.activationkey.search_key(name))
+        self.activationkey.delete(name, True)
+        self.assertIsNone(self.activationkey.search_key(name))
+
+    @attr('ui', 'ak', 'implemented')
+    @data(*valid_names_list())
+    def test_positive_delete_activation_key_2(self, description):
         """
         @Feature: Activation key - Positive Delete
         @Test: Create Activation key and delete it for all variations of
@@ -282,9 +289,17 @@ class ActivationKey(BaseUI):
         using valid Name, Environment, Content View, Usage limit
         2. Delete the Activation key
         @Assert: Activation key is deleted
-        @Status: Manual
         """
-        pass
+
+        name = generate_name(6)
+        self.login.login(self.katello_user, self.katello_passwd)
+        self.navigator.go_to_select_org(ActivationKey.org_name)
+        self.navigator.go_to_activation_keys()
+        self.activationkey.create(name, ENVIRONMENT,
+                                  description=description)
+        self.assertIsNotNone(self.activationkey.search_key(name))
+        self.activationkey.delete(name, True)
+        self.assertIsNone(self.activationkey.search_key(name))
 
     def test_positive_delete_activation_key_3(self):
         """
@@ -347,8 +362,6 @@ class ActivationKey(BaseUI):
         """
         pass
 
-    @bzbug('1063273')
-    @unittest.skip(NOT_IMPLEMENTED)
     def test_negative_delete_activation_key_1(self):
         """
         @Feature: Activation key - Positive Delete
@@ -358,10 +371,18 @@ class ActivationKey(BaseUI):
         2. Attempt to remove an Activation Key
         3. Click Cancel in the confirmation dialog box
         @Assert: Activation key is not deleted
-        @Status: Manual
         @BZ: 1078676
         """
-        pass
+
+        name = generate_name(16)
+        self.login.login(self.katello_user, self.katello_passwd)
+        self.navigator.go_to_select_org(ActivationKey.org_name)
+        self.navigator.go_to_activation_keys()
+        self.activationkey.create(name, ENVIRONMENT,
+                                  description=generate_name(16))
+        self.assertIsNotNone(self.activationkey.search_key(name))
+        self.activationkey.delete(name, really=False)
+        self.assertIsNotNone(self.activationkey.search_key(name))
 
     @bzbug('1078676')
     @attr('ui', 'ak', 'implemented')


### PR DESCRIPTION
# Changes Made are:
- Function to delete selected key
- three tests:
  `test_negative_delete_activation_key_1`
  `test_positive_delete_activation_key_1`
  `test_positive_delete_activation_key_2`
- `wait_for_ajax` is not working with activation-key, I tried to set the timeout to '120' as well. Finally, I replaced it again with `sleep_for_seconds`.
