### PR TITLE
Remove latin1 related stuff

### DIFF
--- a/docs/records.rst
+++ b/docs/records.rst
@@ -71,8 +71,6 @@ Field that generates a random string with a max length of ``max`` option, defaul
 
 * numeric: generates a random numeric string
 
-* latin1: generates a random latin1 encoded string
-
 * utf8: generates a random utf8 encoded string
 
 * html: generates a random piece of html code

--- a/robottelo/cli/metatest/default_data.py
+++ b/robottelo/cli/metatest/default_data.py
@@ -1,7 +1,6 @@
 from robottelo.common.helpers import generate_string
 
 POSITIVE_CREATE_DATA = (
-    {'name': generate_string("latin1", 10)},
     {'name': generate_string("utf8", 10)},
     {'name': generate_string("alpha", 10)},
     {'name': generate_string("alphanumeric", 10)},
@@ -10,15 +9,12 @@ POSITIVE_CREATE_DATA = (
 )
 
 NEGATIVE_CREATE_DATA = (
-    {'name': generate_string("latin1", 300)},
     {'name': " "},
     {'': generate_string("alpha", 10)},
     {generate_string("alphanumeric", 10): " "},
 )
 
 POSITIVE_UPDATE_DATA = (
-    ({'name': generate_string("latin1", 10)},
-     {'new-name': generate_string("latin1", 10)}),
     ({'name': generate_string("utf8", 10)},
      {'new-name': generate_string("utf8", 10)}),
     ({'name': generate_string("alpha", 10)},
@@ -39,7 +35,6 @@ NEGATIVE_UPDATE_DATA = (
 )
 
 POSITIVE_DELETE_DATA = (
-    {'name': generate_string("latin1", 10)},
     {'name': generate_string("utf8", 10)},
     {'name': generate_string("alpha", 10)},
     {'name': generate_string("alphanumeric", 10)},

--- a/robottelo/common/helpers.py
+++ b/robottelo/common/helpers.py
@@ -75,7 +75,6 @@ def valid_data_list():
         generate_string("numeric", 8),
         generate_string("alphanumeric", 300),
         generate_string("utf8", 8),
-        generate_string("latin1", 8),
         generate_string("html", 8)
     ]
 
@@ -92,7 +91,6 @@ def invalid_names_list():
         generate_string("numeric", 300),
         generate_string("alphanumeric", 300),
         generate_string("utf8", 300),
-        generate_string("latin1", 300),
         generate_string("html", 300),
         generate_name(256),
         u' %s' % generate_name(),
@@ -139,7 +137,6 @@ class STR:
     alpha = "alpha"
     numeric = "numeric"
     html = "html"
-    latin1 = "latin1"
     utf8 = "utf8"
 
 
@@ -175,20 +172,6 @@ def generate_string(str_type, length):
         output_string = u''.join(
             random.choice(string.digits) for i in range(length)
         )
-    elif str_type == "latin1":
-        range0 = range1 = range2 = []
-        range0 = ['00C0', '00D6']
-        range1 = ['00D8', '00F6']
-        range2 = ['00F8', '00FF']
-        output_array = []
-        for i in range(int(range0[0], 16), int(range0[1], 16)):
-            output_array.append(i)
-        for i in range(int(range1[0], 16), int(range1[1], 16)):
-            output_array.append(i)
-        for i in range(int(range2[0], 16), int(range2[1], 16)):
-            output_array.append(i)
-        output_string = u''.join(
-            unichr(random.choice(output_array)) for x in xrange(length))
     elif str_type == "utf8":
         cjk_range = []
         cjk_range = ['4E00', '9FCC']
@@ -202,9 +185,8 @@ def generate_string(str_type, length):
         output_string = u'<%s>%s</%s>' % (
             html_tag, generate_string("alpha", length), html_tag)
     else:
-        raise Exception(
-            'Unexpected output type, valid types are \"alpha\", \
-            \"alphanumeric\", \"html\", \"latin1\", \"numeric\" or \"utf8\".')
+        raise Exception('Unexpected output type, valid types are "alpha", '
+                        '"alphanumeric", "html", "numeric" or "utf8".')
     return unicode(output_string)
 
 
@@ -216,7 +198,6 @@ def generate_strings_list(len1=8):
                  STR.numeric,
                  STR.alphanumeric,
                  STR.html,
-                 STR.latin1,
                  STR.utf8]
     str_list = []
     for str_type in str_types:

--- a/robottelo/common/records/fields.py
+++ b/robottelo/common/records/fields.py
@@ -135,7 +135,6 @@ class StringField(Field):
         * alphanumeric: randomly generates alphanumeric strings
         * alpha: randomly generates alpha strings
         * numeric: randomly generates numeric strings
-        * latin1: randomly generates latin1 encoded strings
         * utf8: randomly generates utf8 encoded strings
         * html: randomly generates a piece of HTML which have the format
           <tag>random string</tag>. In this case the maxlen controls the len of
@@ -303,7 +302,7 @@ class BasicPositiveField(ChoiceField):
         super(ChoiceField, self).__init__(**kwargs)
         lst = [
             STR.alpha, STR.alphanumeric, STR.html,
-            STR.latin1, STR.numeric, STR.utf8]
+            STR.numeric, STR.utf8]
 
         if include:
             lst = include

--- a/robottelo/ui/locators.py
+++ b/robottelo/ui/locators.py
@@ -455,7 +455,7 @@ locators = {
     "org.proceed_to_edit": (
         By.XPATH,
         "//a[@class='btn btn-default' and contains(@href, '/edit')]"),
-    # By.XPATH works also with latin1 and html chars, so removed By.LINK_TEXT
+    # By.XPATH works also with html chars, so removed By.LINK_TEXT
     "org.org_name": (
         By.XPATH,
         "//a[contains(@href,'organizations')]/span[contains(.,'%s')]"),

--- a/robottelo/ui/org.py
+++ b/robottelo/ui/org.py
@@ -121,7 +121,7 @@ class Org(Base):
         Searches existing Organization from UI
         """
 
-        # latin1 and html requires double quotes for search, Bug: 1071253
+        # html requires double quotes for search, Bug: 1071253
         qname = "\"" + name + "\""
         strategy = locators["org.org_name"][0]
         value = locators["org.org_name"][1]

--- a/tests/foreman/api/test_computeresource.py
+++ b/tests/foreman/api/test_computeresource.py
@@ -22,7 +22,6 @@ class TestComputeresource(BaseAPI):
         computeresource is numeric
         computeresource is alpha_numeric
         computeresource is utf-8
-        computeresource is latin1
         computeresource is html
     """)
     @unittest.skip(NOT_IMPLEMENTED)
@@ -43,7 +42,6 @@ class TestComputeresource(BaseAPI):
         computeresource is numeric
         computeresource is alpha_numeric
         computeresource is utf-8
-        computeresource is latin1
         computeresource is html
     """)
     @unittest.skip(NOT_IMPLEMENTED)
@@ -64,7 +62,6 @@ class TestComputeresource(BaseAPI):
         computeresource is numeric
         computeresource is alpha_numeric
         computeresource is utf-8
-        computeresource is latin1
         computeresource is html
     """)
     @unittest.skip(NOT_IMPLEMENTED)
@@ -85,7 +82,6 @@ class TestComputeresource(BaseAPI):
         computeresource is numeric
         computeresource is alpha_numeric
         computeresource is utf-8
-        computeresource is latin1
         computeresource is html
     """)
     @unittest.skip(NOT_IMPLEMENTED)
@@ -106,7 +102,6 @@ class TestComputeresource(BaseAPI):
         computeresource is numeric
         computeresource is alpha_numeric
         computeresource is utf-8
-        computeresource is latin1
         computeresource is html
     """)
     @unittest.skip(NOT_IMPLEMENTED)
@@ -127,7 +122,6 @@ class TestComputeresource(BaseAPI):
         computeresource is numeric
         computeresource is alpha_numeric
         computeresource is utf-8
-        computeresource is latin1
         computeresource is html
     """)
     @unittest.skip(NOT_IMPLEMENTED)
@@ -148,7 +142,6 @@ class TestComputeresource(BaseAPI):
         computeresource is numeric
         computeresource is alpha_numeric
         computeresource is utf-8
-        computeresource is latin1
         computeresource is html
     """)
     @unittest.skip(NOT_IMPLEMENTED)
@@ -169,7 +162,6 @@ class TestComputeresource(BaseAPI):
         computeresource is numeric
         computeresource is alpha_numeric
         computeresource is utf-8
-        computeresource is latin1
         computeresource is html
     """)
     @unittest.skip(NOT_IMPLEMENTED)

--- a/tests/foreman/api/test_configtemplate.py
+++ b/tests/foreman/api/test_configtemplate.py
@@ -22,7 +22,6 @@ class TestConfigtemplate(BaseAPI):
         configtemplate name is numeric
         configtemplate name is alpha_numeric
         configtemplate name is utf-8
-        configtemplate name is latin1
         configtemplate name  is html
     """)
     @unittest.skip(NOT_IMPLEMENTED)
@@ -42,7 +41,6 @@ class TestConfigtemplate(BaseAPI):
         configtemplate name is numeric
         configtemplate name is alpha_numeric
         configtemplate name is utf-8
-        configtemplate name is latin1
         configtemplate name  is html
     """)
     @unittest.skip(NOT_IMPLEMENTED)
@@ -63,7 +61,6 @@ class TestConfigtemplate(BaseAPI):
         configtemplate name is numeric
         configtemplate name is alpha_numeric
         configtemplate name is utf-8
-        configtemplate name is latin1
         configtemplate name  is html
     """)
     @unittest.skip(NOT_IMPLEMENTED)
@@ -84,7 +81,6 @@ class TestConfigtemplate(BaseAPI):
         configtemplate name is numeric
         configtemplate name is alpha_numeric
         configtemplate name is utf-8
-        configtemplate name is latin1
         configtemplate name  is html
     """)
     @unittest.skip(NOT_IMPLEMENTED)
@@ -105,7 +101,6 @@ class TestConfigtemplate(BaseAPI):
         configtemplate name is numeric
         configtemplate name is alpha_numeric
         configtemplate name is utf-8
-        configtemplate name is latin1
         configtemplate name  is html
     """)
     @unittest.skip(NOT_IMPLEMENTED)

--- a/tests/foreman/api/test_domain.py
+++ b/tests/foreman/api/test_domain.py
@@ -26,7 +26,6 @@ class TestDomain(BaseAPI):
         domain name is numeric
         domain name is alph_numeric
         domain name is utf-8
-        domain name is latin1
         domain name is html
     """)
     @unittest.skip(NOT_IMPLEMENTED)
@@ -51,7 +50,6 @@ class TestDomain(BaseAPI):
         domain name is numeric
         domain name is alph_numeric
         domain name is utf-8
-        domain name is latin1
         domain name is html
     """)
     @unittest.skip(NOT_IMPLEMENTED)
@@ -75,7 +73,6 @@ class TestDomain(BaseAPI):
         domain name is numeric
         domain name is alph_numeric
         domain name is utf-8
-        domain name is latin1
         domain name is html
     """)
     @unittest.skip(NOT_IMPLEMENTED)
@@ -99,7 +96,6 @@ class TestDomain(BaseAPI):
         domain name is numeric
         domain name is alph_numeric
         domain name is utf-8
-        domain name is latin1
         domain name is html
     """)
     @unittest.skip(NOT_IMPLEMENTED)
@@ -123,7 +119,6 @@ class TestDomain(BaseAPI):
         domain name is numeric
         domain name is alph_numeric
         domain name is utf-8
-        domain name is latin1
         domain name is html
     """)
     @unittest.skip(NOT_IMPLEMENTED)

--- a/tests/foreman/api/test_environments.py
+++ b/tests/foreman/api/test_environments.py
@@ -41,7 +41,6 @@ class TestEnvironment(BaseAPI):
         generate_string('numeric', 256),
         generate_string('alphanumeric', 256),
         generate_string('utf8', 8),
-        generate_string('latin1', 8),
         generate_string('html', 8),
     )
     def test_negative_create(self, name):
@@ -63,7 +62,6 @@ class TestEnvironment(BaseAPI):
         environment name is numeric
         environment name is alpha_numeric
         environment name is utf-8
-        environment name is latin1
         environment name  is html
     """)
     @unittest.skip(NOT_IMPLEMENTED)
@@ -84,7 +82,6 @@ class TestEnvironment(BaseAPI):
         environment name is numeric
         environment name is alpha_numeric
         environment name is utf-8
-        environment name is latin1
         environment name  is html
     """)
     @unittest.skip(NOT_IMPLEMENTED)
@@ -105,7 +102,6 @@ class TestEnvironment(BaseAPI):
         environment name is numeric
         environment name is alpha_numeric
         environment name is utf-8
-        environment name is latin1
         environment name  is html
     """)
     @unittest.skip(NOT_IMPLEMENTED)
@@ -126,7 +122,6 @@ class TestEnvironment(BaseAPI):
         environment name is numeric
         environment name is alpha_numeric
         environment name is utf-8
-        environment name is latin1
         environment name  is html
     """)
     @unittest.skip(NOT_IMPLEMENTED)
@@ -147,7 +142,6 @@ class TestEnvironment(BaseAPI):
         environment name is numeric
         environment name is alpha_numeric
         environment name is utf-8
-        environment name is latin1
         environment name  is html
     """)
     @unittest.skip(NOT_IMPLEMENTED)
@@ -167,7 +161,6 @@ class TestEnvironment(BaseAPI):
         environment name is numeric
         environment name is alpha_numeric
         environment name is utf-8
-        environment name is latin1
         environment name  is html
     """)
     @unittest.skip(NOT_IMPLEMENTED)
@@ -187,7 +180,6 @@ class TestEnvironment(BaseAPI):
         environment name is numeric
         environment name is alpha_numeric
         environment name is utf-8
-        environment name is latin1
         environment name  is html
     """)
     @unittest.skip(NOT_IMPLEMENTED)
@@ -207,7 +199,6 @@ class TestEnvironment(BaseAPI):
         environment name is numeric
         environment name is alpha_numeric
         environment name is utf-8
-        environment name is latin1
         environment name  is html
     """)
     @unittest.skip(NOT_IMPLEMENTED)

--- a/tests/foreman/api/test_hostgroup.py
+++ b/tests/foreman/api/test_hostgroup.py
@@ -23,7 +23,6 @@ class TestHostgroup(BaseAPI):
         hostgroup name is numeric
         hostgroup name is alpha_numeric
         hostgroup name is utf-8
-        hostgroup name is latin1
         hostgroup name is html
     """)
     @unittest.skip(NOT_IMPLEMENTED)
@@ -44,7 +43,6 @@ class TestHostgroup(BaseAPI):
         hostgroup name is numeric
         hostgroup name is alpha_numeric
         hostgroup name is utf-8
-        hostgroup name is latin1
         hostgroup name is html
     """)
     @unittest.skip(NOT_IMPLEMENTED)
@@ -65,7 +63,6 @@ class TestHostgroup(BaseAPI):
         hostgroup name is numeric
         hostgroup name is alpha_numeric
         hostgroup name is utf-8
-        hostgroup name is latin1
         hostgroup name is html
     """)
     @unittest.skip(NOT_IMPLEMENTED)
@@ -86,7 +83,6 @@ class TestHostgroup(BaseAPI):
         hostgroup name is numeric
         hostgroup name is alpha_numeric
         hostgroup name is utf-8
-        hostgroup name is latin1
         hostgroup name is html
     """)
     @unittest.skip(NOT_IMPLEMENTED)
@@ -107,7 +103,6 @@ class TestHostgroup(BaseAPI):
         hostgroup name is numeric
         hostgroup name is alpha_numeric
         hostgroup name is utf-8
-        hostgroup name is latin1
         hostgroup name is html
     """)
     @unittest.skip(NOT_IMPLEMENTED)
@@ -128,7 +123,6 @@ class TestHostgroup(BaseAPI):
         hostgroup name is numeric
         hostgroup name is alpha_numeric
         hostgroup name is utf-8
-        hostgroup name is latin1
         hostgroup name is html
     """)
     @unittest.skip(NOT_IMPLEMENTED)
@@ -149,7 +143,6 @@ class TestHostgroup(BaseAPI):
         hostgroup name is numeric
         hostgroup name is alpha_numeric
         hostgroup name is utf-8
-        hostgroup name is latin1
         hostgroup name is html
     """)
     @unittest.skip(NOT_IMPLEMENTED)
@@ -170,7 +163,6 @@ class TestHostgroup(BaseAPI):
         hostgroup name is numeric
         hostgroup name is alpha_numeric
         hostgroup name is utf-8
-        hostgroup name is latin1
         hostgroup name is html
     """)
     @unittest.skip(NOT_IMPLEMENTED)

--- a/tests/foreman/api/test_medium.py
+++ b/tests/foreman/api/test_medium.py
@@ -22,7 +22,6 @@ class TestMedium(BaseAPI):
         medium name is numeric
         medium name is alpha_numeric
         medium name is utf-8
-        medium name is latin1
         medium name is html
         """)
     @unittest.skip(NOT_IMPLEMENTED)
@@ -42,7 +41,6 @@ class TestMedium(BaseAPI):
         medium name is numeric
         medium name is alpha_numeric
         medium name is utf-8
-        medium name is latin1
         medium name is html
         """)
     @unittest.skip(NOT_IMPLEMENTED)
@@ -62,7 +60,6 @@ class TestMedium(BaseAPI):
         medium name is numeric
         medium name is alpha_numeric
         medium name is utf-8
-        medium name is latin1
         medium name is html
         """)
     @unittest.skip(NOT_IMPLEMENTED)
@@ -82,7 +79,6 @@ class TestMedium(BaseAPI):
         medium name is numeric
         medium name is alpha_numeric
         medium name is utf-8
-        medium name is latin1
         medium name is html
         """)
     @unittest.skip(NOT_IMPLEMENTED)
@@ -102,7 +98,6 @@ class TestMedium(BaseAPI):
         medium name is numeric
         medium name is alpha_numeric
         medium name is utf-8
-        medium name is latin1
         medium name is html
     """)
     @unittest.skip(NOT_IMPLEMENTED)
@@ -122,7 +117,6 @@ class TestMedium(BaseAPI):
         medium name is numeric
         medium name is alpha_numeric
         medium name is utf-8
-        medium name is latin1
         medium name is html
     """)
     @unittest.skip(NOT_IMPLEMENTED)
@@ -142,7 +136,6 @@ class TestMedium(BaseAPI):
         medium name is numeric
         medium name is alpha_numeric
         medium name is utf-8
-        medium name is latin1
         medium name is html
     """)
     @unittest.skip(NOT_IMPLEMENTED)
@@ -162,7 +155,6 @@ class TestMedium(BaseAPI):
         medium name is numeric
         medium name is alpha_numeric
         medium name is utf-8
-        medium name is latin1
         medium name is html
     """)
     @unittest.skip(NOT_IMPLEMENTED)

--- a/tests/foreman/api/test_org.py
+++ b/tests/foreman/api/test_org.py
@@ -327,7 +327,6 @@ class TestOrganization(BaseAPI):
         configtemplate name is numeric
         configtemplate name is alpha_numeric
         configtemplate name is utf-8
-        configtemplate name is latin1
         configtemplate name  is html
     """)
     @unittest.skip(NOT_IMPLEMENTED)
@@ -347,7 +346,6 @@ class TestOrganization(BaseAPI):
         configtemplate name is numeric
         configtemplate name is alpha_numeric
         configtemplate name is utf-8
-        configtemplate name is latin1
         configtemplate name  is html
     """)
     @unittest.skip(NOT_IMPLEMENTED)
@@ -368,7 +366,6 @@ class TestOrganization(BaseAPI):
         configtemplate name is numeric
         configtemplate name is alpha_numeric
         configtemplate name is utf-8
-        configtemplate name is latin1
         configtemplate name  is html
     """)
     @unittest.skip(NOT_IMPLEMENTED)
@@ -389,7 +386,6 @@ class TestOrganization(BaseAPI):
         configtemplate name is numeric
         configtemplate name is alpha_numeric
         configtemplate name is utf-8
-        configtemplate name is latin1
         configtemplate name  is html
     """)
     @unittest.skip(NOT_IMPLEMENTED)
@@ -410,7 +406,6 @@ class TestOrganization(BaseAPI):
         configtemplate name is numeric
         configtemplate name is alpha_numeric
         configtemplate name is utf-8
-        configtemplate name is latin1
         configtemplate name  is html
     """)
     @unittest.skip(NOT_IMPLEMENTED)

--- a/tests/foreman/api/test_smartproxy.py
+++ b/tests/foreman/api/test_smartproxy.py
@@ -22,7 +22,6 @@ class TestSmartproxy(BaseAPI):
         smartproxy name is numeric
         smartproxy name is alpha_numeric
         smartproxy name  is utf-8
-        smartproxy name is latin1
         smartproxy name is html
     """)
     @unittest.skip(NOT_IMPLEMENTED)
@@ -42,7 +41,6 @@ class TestSmartproxy(BaseAPI):
         smartproxy name is numeric
         smartproxy name is alpha_numeric
         smartproxy name  is utf-8
-        smartproxy name is latin1
         smartproxy name is html
     """)
     @unittest.skip(NOT_IMPLEMENTED)
@@ -62,7 +60,6 @@ class TestSmartproxy(BaseAPI):
         smartproxy name is numeric
         smartproxy name is alpha_numeric
         smartproxy name  is utf-8
-        smartproxy name is latin1
         smartproxy name is html
     """)
     @unittest.skip(NOT_IMPLEMENTED)
@@ -82,7 +79,6 @@ class TestSmartproxy(BaseAPI):
         smartproxy name is numeric
         smartproxy name is alpha_numeric
         smartproxy name  is utf-8
-        smartproxy name is latin1
         smartproxy name is html
     """)
     @unittest.skip(NOT_IMPLEMENTED)
@@ -100,7 +96,6 @@ class TestSmartproxy(BaseAPI):
         smartproxy name is numeric
         smartproxy name is alpha_numeric
         smartproxy name  is utf-8
-        smartproxy name is latin1
         smartproxy name is html
     """)
     @unittest.skip(NOT_IMPLEMENTED)
@@ -120,7 +115,6 @@ class TestSmartproxy(BaseAPI):
         smartproxy name is numeric
         smartproxy name is alpha_numeric
         smartproxy name  is utf-8
-        smartproxy name is latin1
         smartproxy name is html
     """)
     @unittest.skip(NOT_IMPLEMENTED)
@@ -140,7 +134,6 @@ class TestSmartproxy(BaseAPI):
         smartproxy name is numeric
         smartproxy name is alpha_numeric
         smartproxy name  is utf-8
-        smartproxy name is latin1
         smartproxy name is html
     """)
     @unittest.skip(NOT_IMPLEMENTED)
@@ -160,7 +153,6 @@ class TestSmartproxy(BaseAPI):
         smartproxy name is numeric
         smartproxy name is alpha_numeric
         smartproxy name  is utf-8
-        smartproxy name is latin1
         smartproxy name is html
     """)
     @unittest.skip(NOT_IMPLEMENTED)

--- a/tests/foreman/api/test_subnet.py
+++ b/tests/foreman/api/test_subnet.py
@@ -23,7 +23,6 @@ class TestSubnet(BaseAPI):
         subnet name is numeric
         subnet name is alpha_numeric
         subnet name is utf-8
-        subnet name is latin1
         subnet name  is html
     """)
     @unittest.skip(NOT_IMPLEMENTED)
@@ -43,7 +42,6 @@ class TestSubnet(BaseAPI):
         subnet name is numeric
         subnet name is alpha_numeric
         subnet name is utf-8
-        subnet name is latin1
         subnet name  is html
     """)
     @unittest.skip(NOT_IMPLEMENTED)
@@ -63,7 +61,6 @@ class TestSubnet(BaseAPI):
         subnet name is numeric
         subnet name is alpha_numeric
         subnet name is utf-8
-        subnet name is latin1
         subnet name  is html
     """)
     @unittest.skip(NOT_IMPLEMENTED)
@@ -83,7 +80,6 @@ class TestSubnet(BaseAPI):
         subnet name is numeric
         subnet name is alpha_numeric
         subnet name is utf-8
-        subnet name is latin1
         subnet name  is html
     """)
     @unittest.skip(NOT_IMPLEMENTED)
@@ -103,7 +99,6 @@ class TestSubnet(BaseAPI):
         subnet name is numeric
         subnet name is alpha_numeric
         subnet name is utf-8
-        subnet name is latin1
         subnet name  is html
     """)
     @unittest.skip(NOT_IMPLEMENTED)
@@ -123,7 +118,6 @@ class TestSubnet(BaseAPI):
         subnet name is numeric
         subnet name is alpha_numeric
         subnet name is utf-8
-        subnet name is latin1
         subnet name  is html
     """)
     @unittest.skip(NOT_IMPLEMENTED)
@@ -143,7 +137,6 @@ class TestSubnet(BaseAPI):
         subnet name is numeric
         subnet name is alpha_numeric
         subnet name is utf-8
-        subnet name is latin1
         subnet name  is html
     """)
     @unittest.skip(NOT_IMPLEMENTED)
@@ -163,7 +156,6 @@ class TestSubnet(BaseAPI):
         subnet name is numeric
         subnet name is alpha_numeric
         subnet name is utf-8
-        subnet name is latin1
         subnet name  is html
     """)
     @unittest.skip(NOT_IMPLEMENTED)

--- a/tests/foreman/cli/test_environment.py
+++ b/tests/foreman/cli/test_environment.py
@@ -35,8 +35,6 @@ class TestEnvironment(MetaCLI):
         ({'name': generate_string("alphanumeric", 10)},
          {'new-name': generate_string("alphanumeric", 300)}),
         ({'name': generate_string("alphanumeric", 10)},
-         {'new-name': generate_string("latin1", 10)}),
-        ({'name': generate_string("alphanumeric", 10)},
          {'new-name': generate_string("utf8", 10)}),
         ({'name': generate_string("alphanumeric", 10)},
          {'new-name': generate_string("html", 6)}),

--- a/tests/foreman/cli/test_gpgkey.py
+++ b/tests/foreman/cli/test_gpgkey.py
@@ -30,7 +30,6 @@ def positive_create_data():
     """Random data for positive creation"""
 
     return (
-        {'name': generate_string("latin1", 10)},
         {'name': generate_string("utf8", 10)},
         {'name': generate_string("alpha", 10)},
         {'name': generate_string("alphanumeric", 10)},
@@ -48,7 +47,6 @@ def negative_create_data():
         {'name': generate_string('numeric', 300)},
         {'name': generate_string('alphanumeric', 300)},
         {'name': generate_string('utf8', 300)},
-        {'name': generate_string('latin1', 300)},
         {'name': generate_string('html', 300)},
     )
 
@@ -355,7 +353,6 @@ class TestGPGKey(BaseCLI):
         name is numeric
         name is alphanumeric
         name is utf-8
-        name is latin1
         name is html
         gpg key file is valid always
     """
@@ -376,7 +373,6 @@ class TestGPGKey(BaseCLI):
         name is numeric
         name is alphanumeric
         name is utf-8
-        name is latin1
         name is html
         gpg key text is valid text from a valid gpg key file
     """
@@ -399,7 +395,6 @@ class TestGPGKey(BaseCLI):
         name is numeric
         name is alphanumeric
         name is utf-8
-        name is latin1
         name is html
         gpg key file is valid always
         delete using a negative gpg key ID
@@ -422,7 +417,6 @@ class TestGPGKey(BaseCLI):
         name is numeric
         name is alphanumeric
         name is utf-8
-        name is latin1
         name is html
         gpg key text is valid text from a valid gpg key file
         delete using a negative gpg key ID
@@ -447,7 +441,6 @@ class TestGPGKey(BaseCLI):
         name is numeric
         name is alphanumeric
         name is utf-8
-        name is latin1
         name is html
         gpg key file is valid always
     """
@@ -468,7 +461,6 @@ class TestGPGKey(BaseCLI):
         name is numeric
         name is alphanumeric
         name is utf-8
-        name is latin1
         name is html
         gpg key file is valid always
 """
@@ -489,7 +481,6 @@ class TestGPGKey(BaseCLI):
         name is numeric
         name is alphanumeric
         name is utf-8
-        name is latin1
         name is html
         gpg key text is valid text from a valid gpg key file
 """
@@ -510,7 +501,6 @@ class TestGPGKey(BaseCLI):
         name is numeric
         name is alphanumeric
         name is utf-8
-        name is latin1
         name is html
         gpg key text is valid text from a valid gpg key file
 """
@@ -534,7 +524,6 @@ class TestGPGKey(BaseCLI):
         update name is numeric 300 characters long
         update name is alphanumeric 300 characters long
         update name is utf-8 300 characters long
-        update name is latin1 300 characters long
         update name is html 300 characters long
         gpg key file is valid always
 """
@@ -556,7 +545,6 @@ class TestGPGKey(BaseCLI):
         update name is numeric 300 characters long
         update name is alphanumeric 300 characters long
         update name is utf-8 300 characters long
-        update name is latin1 300 characters long
         update name is html 300 characters long
         gpg key text is valid text from a valid gpg key file
 """
@@ -579,7 +567,6 @@ class TestGPGKey(BaseCLI):
         name is numeric
         name is alphanumeric
         name is utf-8
-        name is latin1
         name is html
         gpg key file is valid always
         """
@@ -600,7 +587,6 @@ class TestGPGKey(BaseCLI):
         name is numeric
         name is alphanumeric
         name is utf-8
-        name is latin1
         name is html
         gpg key file is valid always
         """
@@ -621,7 +607,6 @@ class TestGPGKey(BaseCLI):
         name is numeric
         name is alphanumeric
         name is utf-8
-        name is latin1
         name is html
         gpg key file is valid always
         """
@@ -643,7 +628,6 @@ class TestGPGKey(BaseCLI):
         name is numeric
         name is alphanumeric
         name is utf-8
-        name is latin1
         name is html
         gpg key file is valid always
         """
@@ -665,7 +649,6 @@ class TestGPGKey(BaseCLI):
         name is numeric
         name is alphanumeric
         name is utf-8
-        name is latin1
         name is html
         gpg key file is valid always
         """
@@ -687,7 +670,6 @@ class TestGPGKey(BaseCLI):
         name is numeric
         name is alphanumeric
         name is utf-8
-        name is latin1
         name is html
         gpg key file is valid always
         """
@@ -710,7 +692,6 @@ class TestGPGKey(BaseCLI):
         name is numeric
         name is alphanumeric
         name is utf-8
-        name is latin1
         name is html
         gpg key file is valid always
 """
@@ -732,7 +713,6 @@ class TestGPGKey(BaseCLI):
         name is numeric
         name is alphanumeric
         name is utf-8
-        name is latin1
         name is html
         gpg key file is valid always
 """
@@ -754,7 +734,6 @@ class TestGPGKey(BaseCLI):
         name is numeric
         name is alphanumeric
         name is utf-8
-        name is latin1
         name is html
         gpg key file is valid always
 """
@@ -777,7 +756,6 @@ class TestGPGKey(BaseCLI):
         name is numeric
         name is alphanumeric
         name is utf-8
-        name is latin1
         name is html
         gpg key file is valid always
 """
@@ -800,7 +778,6 @@ class TestGPGKey(BaseCLI):
         name is numeric
         name is alphanumeric
         name is utf-8
-        name is latin1
         name is html
         gpg key file is valid always
 """
@@ -823,7 +800,6 @@ class TestGPGKey(BaseCLI):
         name is numeric
         name is alphanumeric
         name is utf-8
-        name is latin1
         name is html
         gpg key file is valid always
 """
@@ -846,7 +822,6 @@ class TestGPGKey(BaseCLI):
         name is numeric
         name is alphanumeric
         name is utf-8
-        name is latin1
         name is html
         gpg key file is valid always
 """
@@ -869,7 +844,6 @@ class TestGPGKey(BaseCLI):
         name is numeric
         name is alphanumeric
         name is utf-8
-        name is latin1
         name is html
         gpg key file is valid always
 """
@@ -892,7 +866,6 @@ class TestGPGKey(BaseCLI):
         name is numeric
         name is alphanumeric
         name is utf-8
-        name is latin1
         name is html
         gpg key file is valid always
 """
@@ -915,7 +888,6 @@ class TestGPGKey(BaseCLI):
         name is numeric
         name is alphanumeric
         name is utf-8
-        name is latin1
         name is html
         gpg key file is valid always
 """
@@ -938,7 +910,6 @@ class TestGPGKey(BaseCLI):
         name is numeric
         name is alphanumeric
         name is utf-8
-        name is latin1
         name is html
         gpg key file is valid always
 """
@@ -961,7 +932,6 @@ class TestGPGKey(BaseCLI):
         name is numeric
         name is alphanumeric
         name is utf-8
-        name is latin1
         name is html
         gpg key file is valid always
 """
@@ -984,7 +954,6 @@ class TestGPGKey(BaseCLI):
         name is numeric
         name is alphanumeric
         name is utf-8
-        name is latin1
         name is html
         gpg key file is valid always
 """
@@ -1007,7 +976,6 @@ class TestGPGKey(BaseCLI):
         name is numeric
         name is alphanumeric
         name is utf-8
-        name is latin1
         name is html
         gpg key file is valid always
 """
@@ -1030,7 +998,6 @@ class TestGPGKey(BaseCLI):
         name is numeric
         name is alphanumeric
         name is utf-8
-        name is latin1
         name is html
         gpg key file is valid always
 """
@@ -1054,7 +1021,6 @@ class TestGPGKey(BaseCLI):
         name is numeric
         name is alphanumeric
         name is utf-8
-        name is latin1
         name is html
         gpg key file is valid always
 """
@@ -1076,7 +1042,6 @@ class TestGPGKey(BaseCLI):
         name is numeric
         name is alphanumeric
         name is utf-8
-        name is latin1
         name is html
         gpg key file is valid always
 """
@@ -1098,7 +1063,6 @@ class TestGPGKey(BaseCLI):
         name is numeric
         name is alphanumeric
         name is utf-8
-        name is latin1
         name is html
         gpg key file is valid always
 """
@@ -1120,7 +1084,6 @@ class TestGPGKey(BaseCLI):
         name is numeric
         name is alphanumeric
         name is utf-8
-        name is latin1
         name is html
         gpg key file is valid always
 """
@@ -1142,7 +1105,6 @@ class TestGPGKey(BaseCLI):
         name is numeric
         name is alphanumeric
         name is utf-8
-        name is latin1
         name is html
         gpg key file is valid always
 """
@@ -1164,7 +1126,6 @@ class TestGPGKey(BaseCLI):
         name is numeric
         name is alphanumeric
         name is utf-8
-        name is latin1
         name is html
         gpg key file is valid always
 """
@@ -1186,7 +1147,6 @@ class TestGPGKey(BaseCLI):
         name is numeric
         name is alphanumeric
         name is utf-8
-        name is latin1
         name is html
         gpg key file is valid always
 """
@@ -1208,7 +1168,6 @@ class TestGPGKey(BaseCLI):
         name is numeric
         name is alphanumeric
         name is utf-8
-        name is latin1
         name is html
         gpg key file is valid always
 """
@@ -1230,7 +1189,6 @@ class TestGPGKey(BaseCLI):
         name is numeric
         name is alphanumeric
         name is utf-8
-        name is latin1
         name is html
         gpg key file is valid always
 """
@@ -1253,7 +1211,6 @@ class TestGPGKey(BaseCLI):
         name is numeric
         name is alphanumeric
         name is utf-8
-        name is latin1
         name is html
         gpg key file is valid always
 """
@@ -1276,7 +1233,6 @@ class TestGPGKey(BaseCLI):
         name is numeric
         name is alphanumeric
         name is utf-8
-        name is latin1
         name is html
         gpg key file is valid always
 """
@@ -1299,7 +1255,6 @@ class TestGPGKey(BaseCLI):
         name is numeric
         name is alphanumeric
         name is utf-8
-        name is latin1
         name is html
         gpg key file is valid always
 """
@@ -1322,7 +1277,6 @@ class TestGPGKey(BaseCLI):
         name is numeric
         name is alphanumeric
         name is utf-8
-        name is latin1
         name is html
         gpg key file is valid always
 """
@@ -1345,7 +1299,6 @@ class TestGPGKey(BaseCLI):
         name is numeric
         name is alphanumeric
         name is utf-8
-        name is latin1
         name is html
         gpg key file is valid always
 """
@@ -1368,7 +1321,6 @@ class TestGPGKey(BaseCLI):
         name is numeric
         name is alphanumeric
         name is utf-8
-        name is latin1
         name is html
         gpg key file is valid always
 """
@@ -1391,7 +1343,6 @@ class TestGPGKey(BaseCLI):
         name is numeric
         name is alphanumeric
         name is utf-8
-        name is latin1
         name is html
         gpg key file is valid always
 """
@@ -1414,7 +1365,6 @@ class TestGPGKey(BaseCLI):
         name is numeric
         name is alphanumeric
         name is utf-8
-        name is latin1
         name is html
         gpg key file is valid always
 """
@@ -1437,7 +1387,6 @@ class TestGPGKey(BaseCLI):
         name is numeric
         name is alphanumeric
         name is utf-8
-        name is latin1
         name is html
         gpg key file is valid always
 """
@@ -1460,7 +1409,6 @@ class TestGPGKey(BaseCLI):
         name is numeric
         name is alphanumeric
         name is utf-8
-        name is latin1
         name is html
         gpg key file is valid always
 """
@@ -1483,7 +1431,6 @@ class TestGPGKey(BaseCLI):
         name is numeric
         name is alphanumeric
         name is utf-8
-        name is latin1
         name is html
         gpg key file is valid always
 """
@@ -1506,7 +1453,6 @@ class TestGPGKey(BaseCLI):
         name is numeric
         name is alphanumeric
         name is utf-8
-        name is latin1
         name is html
         gpg key file is valid always
 """
@@ -1532,7 +1478,6 @@ class TestGPGKey(BaseCLI):
         name is numeric
         name is alphanumeric
         name is utf-8
-        name is latin1
         name is html
         gpg key file is valid always
 """
@@ -1553,7 +1498,6 @@ class TestGPGKey(BaseCLI):
         name is numeric
         name is alphanumeric
         name is utf-8
-        name is latin1
         name is html
         gpg key file is valid always
 """
@@ -1574,7 +1518,6 @@ class TestGPGKey(BaseCLI):
         name is numeric
         name is alphanumeric
         name is utf-8
-        name is latin1
         name is html
         gpg key file is valid always
 """
@@ -1597,7 +1540,6 @@ class TestGPGKey(BaseCLI):
         name is numeric
         name is alphanumeric
         name is utf-8
-        name is latin1
         name is html
         gpg key file is valid always
 """
@@ -1617,7 +1559,6 @@ class TestGPGKey(BaseCLI):
         name is numeric
         name is alphanumeric
         name is utf-8
-        name is latin1
         name is html
         gpg key file is valid always
 """
@@ -1637,7 +1578,6 @@ class TestGPGKey(BaseCLI):
         name is numeric
         name is alphanumeric
         name is utf-8
-        name is latin1
         name is html
         gpg key file is valid always
 """

--- a/tests/foreman/cli/test_hostgroup.py
+++ b/tests/foreman/cli/test_hostgroup.py
@@ -17,8 +17,6 @@ class TestHostGroup(MetaCLI):
     factory_obj = HostGroup
 
     POSITIVE_UPDATE_DATA = (
-        ({'id': generate_string("latin1", 10)},
-         {'name': generate_string("latin1", 10)}),
         ({'id': generate_string("utf8", 10)},
          {'name': generate_string("utf8", 10)}),
         ({'id': generate_string("alpha", 10)},

--- a/tests/foreman/cli/test_lifecycleenvironment.py
+++ b/tests/foreman/cli/test_lifecycleenvironment.py
@@ -106,7 +106,6 @@ class TestLifeCycleEnvironment(BaseCLI):
         {'name': generate_string("alpha", 15)},
         {'name': generate_string("alphanumeric", 15)},
         {'name': generate_string("numeric", 15)},
-        {'name': generate_string("latin1", 15)},
         {'name': generate_string("utf8", 15)},
         {'name': generate_string("html", 15)},
     )
@@ -152,7 +151,6 @@ class TestLifeCycleEnvironment(BaseCLI):
         {'name': generate_string("alpha", 15)},
         {'name': generate_string("alphanumeric", 15)},
         {'name': generate_string("numeric", 15)},
-        {'name': generate_string("latin1", 15)},
         {'name': generate_string("utf8", 15)},
         {'name': generate_string("html", 15)},
     )
@@ -205,7 +203,6 @@ class TestLifeCycleEnvironment(BaseCLI):
         {'name': generate_string("alpha", 15)},
         {'name': generate_string("alphanumeric", 15)},
         {'name': generate_string("numeric", 15)},
-        {'name': generate_string("latin1", 15)},
         {'name': generate_string("utf8", 15)},
         {'name': generate_string("html", 15)},
     )
@@ -275,7 +272,6 @@ class TestLifeCycleEnvironment(BaseCLI):
         {'name': generate_string("alpha", 15)},
         {'name': generate_string("alphanumeric", 15)},
         {'name': generate_string("numeric", 15)},
-        {'name': generate_string("latin1", 15)},
         {'name': generate_string("utf8", 15)},
         {'name': generate_string("html", 15)},
     )
@@ -338,7 +334,6 @@ class TestLifeCycleEnvironment(BaseCLI):
         {'description': generate_string("alpha", 15)},
         {'description': generate_string("alphanumeric", 15)},
         {'description': generate_string("numeric", 15)},
-        {'description': generate_string("latin1", 15)},
         {'description': generate_string("utf8", 15)},
         {'description': generate_string("html", 15)},
     )

--- a/tests/foreman/cli/test_medium.py
+++ b/tests/foreman/cli/test_medium.py
@@ -30,8 +30,7 @@ class TestMedium(BaseCLI):
     factory = make_medium
     factory_obj = Medium
 
-    @data({'name': generate_string("latin1", 10)},
-          {'name': generate_string("utf8", 10)},
+    @data({'name': generate_string("utf8", 10)},
           {'name': generate_string("alpha", 10)},
           {'name': generate_string("alphanumeric", 10)},
           {'name': generate_string("numeric", 10)},
@@ -56,8 +55,7 @@ class TestMedium(BaseCLI):
         self.assertEqual(new_obj['name'],
                          result.stdout['name'])
 
-    @data({'name': generate_string("latin1", 10)},
-          {'name': generate_string("utf8", 10)},
+    @data({'name': generate_string("utf8", 10)},
           {'name': generate_string("alpha", 10)},
           {'name': generate_string("alphanumeric", 10)},
           {'name': generate_string("numeric", 10)},

--- a/tests/foreman/cli/test_org.py
+++ b/tests/foreman/cli/test_org.py
@@ -26,7 +26,6 @@ def positive_create_data_1():
     """Random data for positive creation"""
 
     return (
-        {'name': generate_string("latin1", 10)},
         {'name': generate_string("utf8", 10)},
         {'name': generate_string("alpha", 10)},
         {'name': generate_string("alphanumeric", 10)},
@@ -58,8 +57,6 @@ def positive_name_label_data():
     """Random data for Label tests"""
 
     return (
-        {'name': generate_string("latin1", 10),
-         'label': generate_string("alpha", 10)},
         {'name': generate_string("utf8", 10),
          'label': generate_string("alpha", 10)},
         {'name': generate_string("alpha", 10),
@@ -77,8 +74,6 @@ def positive_name_desc_data():
     """Random data for Descriptions tests"""
 
     return (
-        {'name': generate_string("latin1", 10),
-         'description': generate_string("latin1", 10)},
         {'name': generate_string("utf8", 10),
          'description': generate_string("utf8", 10)},
         {'name': generate_string("alpha", 10),
@@ -807,8 +802,6 @@ class TestOrg(BaseCLI):
           {'label': generate_string('alpha', 10),
            'name': generate_string('utf8', 300)},
           {'label': generate_string('alpha', 10),
-           'name': generate_string('latin1', 300)},
-          {'label': generate_string('alpha', 10),
            'name': generate_string('html', 300)})
     def test_negative_create_0(self, test_data):
         """
@@ -913,8 +906,7 @@ class TestOrg(BaseCLI):
     # Positive Update
 
     @bzbug('1076541')
-    @data({'name': generate_string("latin1", 10)},
-          {'name': generate_string("utf8", 10)},
+    @data({'name': generate_string("utf8", 10)},
           {'name': generate_string("alpha", 10)},
           {'name': generate_string("alphanumeric", 10)},
           {'name': generate_string("numeric", 10)},
@@ -951,8 +943,7 @@ class TestOrg(BaseCLI):
             "Org name was not updated"
         )
 
-    @data({'description': generate_string("latin1", 10)},
-          {'description': generate_string("utf8", 10)},
+    @data({'description': generate_string("utf8", 10)},
           {'description': generate_string("alpha", 10)},
           {'description': generate_string("alphanumeric", 10)},
           {'description': generate_string("numeric", 10)},
@@ -990,9 +981,7 @@ class TestOrg(BaseCLI):
         )
 
     @bzbug('1076541')
-    @data({'description': generate_string("latin1", 10),
-           'name': generate_string("latin1", 10)},
-          {'description': generate_string("utf8", 10),
+    @data({'description': generate_string("utf8", 10),
            'name': generate_string("utf8", 10)},
           {'description': generate_string("alpha", 10),
            'name': generate_string("alpha", 10)},
@@ -1049,7 +1038,6 @@ class TestOrg(BaseCLI):
           {'name': generate_string('numeric', 300)},
           {'name': generate_string('alphanumeric', 300)},
           {'name': generate_string('utf8', 300)},
-          {'name': generate_string('latin1', 300)},
           {'name': generate_string('html', 300)})
     def test_negative_update_1(self, test_data):
         """
@@ -1078,7 +1066,6 @@ class TestOrg(BaseCLI):
           {'description': generate_string('numeric', 3000)},
           {'description': generate_string('alphanumeric', 3000)},
           {'description': generate_string('utf8', 3000)},
-          {'description': generate_string('latin1', 3000)},
           {'description': generate_string('html', 3000)})
     def test_negative_update_3(self, test_data):
         """
@@ -1110,7 +1097,6 @@ class TestOrg(BaseCLI):
         name, label and description are is numeric
         name, label and description are is alphanumeric
         name, label and description are is utf-8
-        name, label and description are is latin1
         name, label and description are is html
     """)
     def test_list_key_1(self, test_data):
@@ -1129,7 +1115,6 @@ class TestOrg(BaseCLI):
         name, label and description are is numeric
         name, label and description are is alphanumeric
         name, label and description are is utf-8
-        name, label and description are is latin1
         name, label and description are is html
     """)
     def test_search_key_1(self, test_data):
@@ -1148,7 +1133,6 @@ class TestOrg(BaseCLI):
         name, label and description are is numeric
         name, label and description are is alphanumeric
         name, label and description are is utf-8
-        name, label and description are is latin1
         name, label and description are is html
     """)
     def test_info_key_1(self, test_data):
@@ -1170,7 +1154,6 @@ class TestOrg(BaseCLI):
         domain name is numeric
         domain name is alph_numeric
         domain name is utf-8
-        domain name is latin1
         domain name is html
     """)
     def test_remove_domain_1(self, test_data):
@@ -1190,7 +1173,6 @@ class TestOrg(BaseCLI):
         domain name is numeric
         domain name is alph_numeric
         domain name is utf-8
-        domain name is latin1
         domain name is html
     """)
     def test_remove_domain_2(self, test_data):
@@ -1210,7 +1192,6 @@ class TestOrg(BaseCLI):
         domain name is numeric
         domain name is alph_numeric
         domain name is utf-8
-        domain name is latin1
         domain name is html
     """)
     def test_remove_domain_3(self, test_data):
@@ -1230,7 +1211,6 @@ class TestOrg(BaseCLI):
         domain name is numeric
         domain name is alph_numeric
         domain name is utf-8
-        domain name is latin1
         domain name is html
     """)
     def test_remove_domain_4(self, test_data):
@@ -1250,7 +1230,6 @@ class TestOrg(BaseCLI):
         user name is numeric
         user name is alpha_numeric
         user name is utf-8
-        user name is latin1
         user name is html
     """)
     def test_remove_user_1(self, test_data):
@@ -1270,7 +1249,6 @@ class TestOrg(BaseCLI):
         user name is numeric
         user name is alpha_numeric
         user name is utf-8
-        user name is latin1
         user name is html
     """)
     def test_remove_user_2(self, test_data):
@@ -1290,7 +1268,6 @@ class TestOrg(BaseCLI):
         user name is numeric and admin
         user name is alpha_numeric and admin
         user name is utf-8 and admin
-        user name is latin1 and admin
         user name is html and admin
     """)
     def test_remove_user_3(self, test_data):
@@ -1310,7 +1287,6 @@ class TestOrg(BaseCLI):
         hostgroup name is numeric
         hostgroup name is alpha_numeric
         hostgroup name is utf-8
-        hostgroup name is latin1
         hostgroup name is html
     """)
     def test_remove_hostgroup_1(self, test_data):
@@ -1330,7 +1306,6 @@ class TestOrg(BaseCLI):
         hostgroup name is numeric
         hostgroup name is alpha_numeric
         hostgroup name is utf-8
-        hostgroup name is latin1
         hostgroup name is html
     """)
     def test_remove_hostgroup_2(self, test_data):
@@ -1350,7 +1325,6 @@ class TestOrg(BaseCLI):
         hostgroup name is numeric
         hostgroup name is alpha_numeric
         hostgroup name is utf-8
-        hostgroup name is latin1
         hostgroup name is html
     """)
     def test_remove_hostgroup_3(self, test_data):
@@ -1370,7 +1344,6 @@ class TestOrg(BaseCLI):
         hostgroup name is numeric
         hostgroup name is alpha_numeric
         hostgroup name is utf-8
-        hostgroup name is latin1
         hostgroup name is html
     """)
     def test_remove_hostgroup_4(self, test_data):
@@ -1390,7 +1363,6 @@ class TestOrg(BaseCLI):
         smartproxy name is numeric
         smartproxy name is alpha_numeric
         smartproxy name  is utf-8
-        smartproxy name is latin1
         smartproxy name is html
     """)
     def test_add_smartproxy_1(self, test_data):
@@ -1409,7 +1381,6 @@ class TestOrg(BaseCLI):
         smartproxy name is numeric
         smartproxy name is alpha_numeric
         smartproxy name  is utf-8
-        smartproxy name is latin1
         smartproxy name is html
     """)
     def test_add_smartproxy_2(self, test_data):
@@ -1428,7 +1399,6 @@ class TestOrg(BaseCLI):
         smartproxy name is numeric
         smartproxy name is alpha_numeric
         smartproxy name  is utf-8
-        smartproxy name is latin1
         smartproxy name is html
     """)
     def test_add_smartproxy_3(self, test_data):
@@ -1447,7 +1417,6 @@ class TestOrg(BaseCLI):
         smartproxy name is numeric
         smartproxy name is alpha_numeric
         smartproxy name  is utf-8
-        smartproxy name is latin1
         smartproxy name is html
     """)
     def test_add_smartproxy_4(self, test_data):
@@ -1466,7 +1435,6 @@ class TestOrg(BaseCLI):
         subnet name is numeric
         subnet name is alpha_numeric
         subnet name is utf-8
-        subnet name is latin1
         subnet name  is html
     """)
     def test_add_subnet_1(self, test_data):
@@ -1485,7 +1453,6 @@ class TestOrg(BaseCLI):
         subnet name is numeric
         subnet name is alpha_numeric
         subnet name is utf-8
-        subnet name is latin1
         subnet name  is html
     """)
     def test_add_subnet_2(self, test_data):
@@ -1504,7 +1471,6 @@ class TestOrg(BaseCLI):
         subnet name is numeric
         subnet name is alpha_numeric
         subnet name is utf-8
-        subnet name is latin1
         subnet name  is html
     """)
     def test_add_subnet_3(self, test_data):
@@ -1523,7 +1489,6 @@ class TestOrg(BaseCLI):
         subnet name is numeric
         subnet name is alpha_numeric
         subnet name is utf-8
-        subnet name is latin1
         subnet name  is html
     """)
     def test_add_subnet_4(self, test_data):
@@ -1542,7 +1507,6 @@ class TestOrg(BaseCLI):
         domain name is numeric
         domain name is alph_numeric
         domain name is utf-8
-        domain name is latin1
         domain name is html
     """)
     def test_add_domain_1(self, test_data):
@@ -1561,7 +1525,6 @@ class TestOrg(BaseCLI):
         user name is numeric
         user name is alpha_numeric
         user name is utf-8
-        user name is latin1
         user name is html
     """)
     def test_add_user_1(self, test_data):
@@ -1581,7 +1544,6 @@ class TestOrg(BaseCLI):
         user name is numeric
         user name is alpha_numeric
         user name is utf-8
-        user name is latin1
         user name is html
     """)
     def test_add_user_2(self, test_data):
@@ -1601,7 +1563,6 @@ class TestOrg(BaseCLI):
         user name is numeric and an admin
         user name is alpha_numeric and an admin
         user name is utf-8 and an admin
-        user name is latin1 and an admin
         user name is html and an admin
     """)
     def test_add_user_3(self, test_data):
@@ -1620,7 +1581,6 @@ class TestOrg(BaseCLI):
         hostgroup name is numeric
         hostgroup name is alpha_numeric
         hostgroup name is utf-8
-        hostgroup name is latin1
         hostgroup name is html
     """)
     def test_add_hostgroup_1(self, test_data):
@@ -1640,7 +1600,6 @@ class TestOrg(BaseCLI):
         hostgroup name is numeric
         hostgroup name is alpha_numeric
         hostgroup name is utf-8
-        hostgroup name is latin1
         hostgroup name is html
     """)
     def test_add_hostgroup_2(self, test_data):
@@ -1660,7 +1619,6 @@ class TestOrg(BaseCLI):
         hostgroup name is numeric
         hostgroup name is alpha_numeric
         hostgroup name is utf-8
-        hostgroup name is latin1
         hostgroup name is html
     """)
     def test_add_hostgroup_3(self, test_data):
@@ -1680,7 +1638,6 @@ class TestOrg(BaseCLI):
         hostgroup name is numeric
         hostgroup name is alpha_numeric
         hostgroup name is utf-8
-        hostgroup name is latin1
         hostgroup name is html
     """)
     def test_add_hostgroup_4(self, test_data):
@@ -1700,7 +1657,6 @@ class TestOrg(BaseCLI):
         computeresource is numeric
         computeresource is alpha_numeric
         computeresource is utf-8
-        computeresource is latin1
         computeresource is html
     """)
     def test_remove_computeresource_1(self, test_data):
@@ -1720,7 +1676,6 @@ class TestOrg(BaseCLI):
         computeresource is numeric
         computeresource is alpha_numeric
         computeresource is utf-8
-        computeresource is latin1
         computeresource is html
     """)
     def test_remove_computeresource_2(self, test_data):
@@ -1740,7 +1695,6 @@ class TestOrg(BaseCLI):
         computeresource is numeric
         computeresource is alpha_numeric
         computeresource is utf-8
-        computeresource is latin1
         computeresource is html
     """)
     def test_remove_computeresource_3(self, test_data):
@@ -1760,7 +1714,6 @@ class TestOrg(BaseCLI):
         computeresource is numeric
         computeresource is alpha_numeric
         computeresource is utf-8
-        computeresource is latin1
         computeresource is html
     """)
     def test_remove_computeresource_4(self, test_data):
@@ -1780,7 +1733,6 @@ class TestOrg(BaseCLI):
         medium name is numeric
         medium name is alpha_numeric
         medium name is utf-8
-        medium name is latin1
         medium name is html
         """)
     def test_remove_medium_1(self, test_data):
@@ -1799,7 +1751,6 @@ class TestOrg(BaseCLI):
         medium name is numeric
         medium name is alpha_numeric
         medium name is utf-8
-        medium name is latin1
         medium name is html
         """)
     def test_remove_medium_2(self, test_data):
@@ -1818,7 +1769,6 @@ class TestOrg(BaseCLI):
         medium name is numeric
         medium name is alpha_numeric
         medium name is utf-8
-        medium name is latin1
         medium name is html
         """)
     def test_remove_medium_3(self, test_data):
@@ -1837,7 +1787,6 @@ class TestOrg(BaseCLI):
         medium name is numeric
         medium name is alpha_numeric
         medium name is utf-8
-        medium name is latin1
         medium name is html
         """)
     def test_remove_medium_4(self, test_data):
@@ -1856,7 +1805,6 @@ class TestOrg(BaseCLI):
         configtemplate name is numeric
         configtemplate name is alpha_numeric
         configtemplate name is utf-8
-        configtemplate name is latin1
         configtemplate name  is html
     """)
     def test_remove_configtemplate_1(self, test_data):
@@ -1875,7 +1823,6 @@ class TestOrg(BaseCLI):
         environment name is numeric
         environment name is alpha_numeric
         environment name is utf-8
-        environment name is latin1
         environment name  is html
     """)
     def test_remove_environment_1(self, test_data):
@@ -1895,7 +1842,6 @@ class TestOrg(BaseCLI):
         environment name is numeric
         environment name is alpha_numeric
         environment name is utf-8
-        environment name is latin1
         environment name  is html
     """)
     def test_remove_environment_2(self, test_data):
@@ -1915,7 +1861,6 @@ class TestOrg(BaseCLI):
         environment name is numeric
         environment name is alpha_numeric
         environment name is utf-8
-        environment name is latin1
         environment name  is html
     """)
     def test_remove_environment_3(self, test_data):
@@ -1935,7 +1880,6 @@ class TestOrg(BaseCLI):
         environment name is numeric
         environment name is alpha_numeric
         environment name is utf-8
-        environment name is latin1
         environment name  is html
     """)
     def test_remove_environment_4(self, test_data):
@@ -1955,7 +1899,6 @@ class TestOrg(BaseCLI):
         smartproxy name is numeric
         smartproxy name is alpha_numeric
         smartproxy name  is utf-8
-        smartproxy name is latin1
         smartproxy name is html
     """)
     def test_remove_smartproxy_1(self, test_data):
@@ -1974,7 +1917,6 @@ class TestOrg(BaseCLI):
         smartproxy name is numeric
         smartproxy name is alpha_numeric
         smartproxy name  is utf-8
-        smartproxy name is latin1
         smartproxy name is html
     """)
     def test_remove_smartproxy_2(self, test_data):
@@ -1993,7 +1935,6 @@ class TestOrg(BaseCLI):
         smartproxy name is numeric
         smartproxy name is alpha_numeric
         smartproxy name  is utf-8
-        smartproxy name is latin1
         smartproxy name is html
     """)
     def test_remove_smartproxy_3(self, test_data):
@@ -2012,7 +1953,6 @@ class TestOrg(BaseCLI):
         smartproxy name is numeric
         smartproxy name is alpha_numeric
         smartproxy name  is utf-8
-        smartproxy name is latin1
         smartproxy name is html
     """)
     def test_remove_smartproxy_4(self, test_data):
@@ -2031,7 +1971,6 @@ class TestOrg(BaseCLI):
         computeresource is numeric
         computeresource is alpha_numeric
         computeresource is utf-8
-        computeresource is latin1
         computeresource is html
     """)
     def test_add_computeresource_1(self, test_data):
@@ -2051,7 +1990,6 @@ class TestOrg(BaseCLI):
         computeresource is numeric
         computeresource is alpha_numeric
         computeresource is utf-8
-        computeresource is latin1
         computeresource is html
     """)
     def test_add_computeresource_2(self, test_data):
@@ -2071,7 +2009,6 @@ class TestOrg(BaseCLI):
         computeresource is numeric
         computeresource is alpha_numeric
         computeresource is utf-8
-        computeresource is latin1
         computeresource is html
     """)
     def test_add_computeresource_3(self, test_data):
@@ -2091,7 +2028,6 @@ class TestOrg(BaseCLI):
         computeresource is numeric
         computeresource is alpha_numeric
         computeresource is utf-8
-        computeresource is latin1
         computeresource is html
     """)
     def test_add_computeresource_4(self, test_data):
@@ -2111,7 +2047,6 @@ class TestOrg(BaseCLI):
         medium name is numeric
         medium name is alpha_numeric
         medium name is utf-8
-        medium name is latin1
         medium name is html
     """)
     def test_add_medium_1(self, test_data):
@@ -2130,7 +2065,6 @@ class TestOrg(BaseCLI):
         medium name is numeric
         medium name is alpha_numeric
         medium name is utf-8
-        medium name is latin1
         medium name is html
     """)
     def test_add_medium_2(self, test_data):
@@ -2149,7 +2083,6 @@ class TestOrg(BaseCLI):
         medium name is numeric
         medium name is alpha_numeric
         medium name is utf-8
-        medium name is latin1
         medium name is html
     """)
     def test_add_medium_3(self, test_data):
@@ -2168,7 +2101,6 @@ class TestOrg(BaseCLI):
         medium name is numeric
         medium name is alpha_numeric
         medium name is utf-8
-        medium name is latin1
         medium name is html
     """)
     def test_add_medium_4(self, test_data):
@@ -2187,7 +2119,6 @@ class TestOrg(BaseCLI):
         configtemplate name is numeric
         configtemplate name is alpha_numeric
         configtemplate name is utf-8
-        configtemplate name is latin1
         configtemplate name  is html
     """)
     def test_add_configtemplate_1(self, test_data):
@@ -2207,7 +2138,6 @@ class TestOrg(BaseCLI):
         configtemplate name is numeric
         configtemplate name is alpha_numeric
         configtemplate name is utf-8
-        configtemplate name is latin1
         configtemplate name  is html
     """)
     def test_add_configtemplate_2(self, test_data):
@@ -2227,7 +2157,6 @@ class TestOrg(BaseCLI):
         configtemplate name is numeric
         configtemplate name is alpha_numeric
         configtemplate name is utf-8
-        configtemplate name is latin1
         configtemplate name  is html
     """)
     def test_add_configtemplate_3(self, test_data):
@@ -2247,7 +2176,6 @@ class TestOrg(BaseCLI):
         configtemplate name is numeric
         configtemplate name is alpha_numeric
         configtemplate name is utf-8
-        configtemplate name is latin1
         configtemplate name  is html
     """)
     def test_add_configtemplate_4(self, test_data):
@@ -2267,7 +2195,6 @@ class TestOrg(BaseCLI):
         environment name is numeric
         environment name is alpha_numeric
         environment name is utf-8
-        environment name is latin1
         environment name  is html
     """)
     def test_add_environment_1(self, test_data):
@@ -2286,7 +2213,6 @@ class TestOrg(BaseCLI):
         environment name is numeric
         environment name is alpha_numeric
         environment name is utf-8
-        environment name is latin1
         environment name  is html
     """)
     def test_add_environment_2(self, test_data):
@@ -2305,7 +2231,6 @@ class TestOrg(BaseCLI):
         environment name is numeric
         environment name is alpha_numeric
         environment name is utf-8
-        environment name is latin1
         environment name  is html
     """)
     def test_add_environment_3(self, test_data):
@@ -2324,7 +2249,6 @@ class TestOrg(BaseCLI):
         environment name is numeric
         environment name is alpha_numeric
         environment name is utf-8
-        environment name is latin1
         environment name  is html
     """)
     def test_add_environment_4(self, test_data):
@@ -2343,7 +2267,6 @@ class TestOrg(BaseCLI):
         subnet name is numeric
         subnet name is alpha_numeric
         subnet name is utf-8
-        subnet name is latin1
         subnet name  is html
     """)
     def test_remove_subnet_1(self, test_data):
@@ -2362,7 +2285,6 @@ class TestOrg(BaseCLI):
         subnet name is numeric
         subnet name is alpha_numeric
         subnet name is utf-8
-        subnet name is latin1
         subnet name  is html
     """)
     def test_remove_subnet_2(self, test_data):
@@ -2381,7 +2303,6 @@ class TestOrg(BaseCLI):
         subnet name is numeric
         subnet name is alpha_numeric
         subnet name is utf-8
-        subnet name is latin1
         subnet name  is html
     """)
     def test_remove_subnet_3(self, test_data):
@@ -2400,7 +2321,6 @@ class TestOrg(BaseCLI):
         subnet name is numeric
         subnet name is alpha_numeric
         subnet name is utf-8
-        subnet name is latin1
         subnet name  is html
     """)
     def test_remove_subnet_4(self, test_data):

--- a/tests/foreman/cli/test_os.py
+++ b/tests/foreman/cli/test_os.py
@@ -13,7 +13,6 @@ from tests.foreman.cli.basecli import BaseCLI
 
 
 POSITIVE_CREATE_DATA = (
-    {'name': generate_string("latin1", 10)},
     {'name': generate_string("utf8", 10)},
     {'name': generate_string("alpha", 10)},
     {'name': generate_string("alphanumeric", 10)},
@@ -22,7 +21,6 @@ POSITIVE_CREATE_DATA = (
 )
 
 NEGATIVE_CREATE_DATA = (
-    {'name': generate_string("latin1", 300)},
     {'name': generate_string("utf8", 300)},
     {'name': generate_string("alpha", 300)},
     {'name': generate_string("alphanumeric", 300)},
@@ -32,8 +30,6 @@ NEGATIVE_CREATE_DATA = (
 )
 
 POSITIVE_UPDATE_DATA = (
-    ({'name': generate_string("latin1", 10)},
-     {'name': generate_string("latin1", 10)}),
     ({'name': generate_string("utf8", 10)},
      {'name': generate_string("utf8", 10)}),
     ({'name': generate_string("alpha", 10)},
@@ -47,8 +43,6 @@ POSITIVE_UPDATE_DATA = (
 )
 
 NEGATIVE_UPDATE_DATA = (
-    ({'name': generate_string("latin1", 10)},
-     {'name': generate_string("latin1", 300)}),
     ({'name': generate_string("utf8", 10)},
      {'name': generate_string("utf8", 300)}),
     ({'name': generate_string("alpha", 10)},
@@ -64,7 +58,6 @@ NEGATIVE_UPDATE_DATA = (
 )
 
 POSITIVE_DELETE_DATA = (
-    {'name': generate_string("latin1", 10)},
     {'name': generate_string("utf8", 10)},
     {'name': generate_string("alpha", 10)},
     {'name': generate_string("alphanumeric", 10)},

--- a/tests/foreman/cli/test_product.py
+++ b/tests/foreman/cli/test_product.py
@@ -39,7 +39,6 @@ class TestProduct(BaseCLI):
         {'name': generate_string('alpha', 15)},
         {'name': generate_string('alphanumeric', 15)},
         {'name': generate_string('numeric', 15)},
-        {'name': generate_string('latin1', 15)},
         {'name': generate_string('utf8', 15)},
         {'name': generate_string('html', 15)},
     )
@@ -79,8 +78,6 @@ class TestProduct(BaseCLI):
          'label': generate_string('alphanumeric', 15)},
         {'name': generate_string('numeric', 15),
          'label': generate_string('numeric', 15)},
-        {'name': generate_string('latin1', 15),
-         'label': generate_string('alpha', 15)},
         {'name': generate_string('utf8', 15),
          'label': generate_string('alphanumeric', 15)},
         {'name': generate_string('html', 15),
@@ -123,8 +120,6 @@ class TestProduct(BaseCLI):
          'description': generate_string('alphanumeric', 15)},
         {'name': generate_string('numeric', 15),
          'description': generate_string('numeric', 15)},
-        {'name': generate_string('latin1', 15),
-         'description': generate_string('latin1', 15)},
         {'name': generate_string('utf8', 15),
          'description': generate_string('utf8', 15)},
         {'name': generate_string('html', 15),
@@ -166,7 +161,6 @@ class TestProduct(BaseCLI):
         {'name': generate_string('alpha', 15)},
         {'name': generate_string('alphanumeric', 15)},
         {'name': generate_string('numeric', 15)},
-        {'name': generate_string('latin1', 15)},
         {'name': generate_string('utf8', 15)},
         {'name': generate_string('html', 15)},
     )
@@ -209,7 +203,6 @@ class TestProduct(BaseCLI):
         {'name': generate_string('alpha', 15)},
         {'name': generate_string('alphanumeric', 15)},
         {'name': generate_string('numeric', 15)},
-        {'name': generate_string('latin1', 15)},
         {'name': generate_string('utf8', 15)},
         {'name': generate_string('html', 15)},
     )
@@ -227,7 +220,6 @@ class TestProduct(BaseCLI):
         {'name': generate_string('alpha', 300)},
         {'name': generate_string('alphanumeric', 300)},
         {'name': generate_string('numeric', 300)},
-        {'name': generate_string('latin1', 300)},
         {'name': generate_string('utf8', 300)},
         {'name': generate_string('html', 300)},
     )
@@ -248,8 +240,6 @@ class TestProduct(BaseCLI):
             )
 
     @data(
-        {'name': generate_string('latin1', 15),
-         'label': generate_string('latin1', 15)},
         {'name': generate_string('utf8', 15),
          'label': generate_string('utf8', 15)},
         {'name': generate_string('html', 15),
@@ -276,7 +266,6 @@ class TestProduct(BaseCLI):
         {'description': generate_string('alpha', 15)},
         {'description': generate_string('alphanumeric', 15)},
         {'description': generate_string('numeric', 15)},
-        {'description': generate_string('latin1', 15)},
         {'description': generate_string('utf8', 15)},
         {'description': generate_string('html', 15)},
     )
@@ -333,7 +322,6 @@ class TestProduct(BaseCLI):
         {'name': generate_string('alpha', 15)},
         {'name': generate_string('alphanumeric', 15)},
         {'name': generate_string('numeric', 15)},
-        {'name': generate_string('latin1', 15)},
         {'name': generate_string('utf8', 15)},
         {'name': generate_string('html', 15)},
     )
@@ -393,7 +381,6 @@ class TestProduct(BaseCLI):
         {'name': generate_string('alpha', 15)},
         {'name': generate_string('alphanumeric', 15)},
         {'name': generate_string('numeric', 15)},
-        {'name': generate_string('latin1', 15)},
         {'name': generate_string('utf8', 15)},
         {'name': generate_string('html', 15)},
     )
@@ -485,7 +472,6 @@ class TestProduct(BaseCLI):
         {'name': generate_string('alpha', 15)},
         {'name': generate_string('alphanumeric', 15)},
         {'name': generate_string('numeric', 15)},
-        {'name': generate_string('latin1', 15)},
         {'name': generate_string('utf8', 15)},
         {'name': generate_string('html', 15)},
     )
@@ -503,7 +489,6 @@ class TestProduct(BaseCLI):
         {'name': generate_string('alpha', 15)},
         {'name': generate_string('alphanumeric', 15)},
         {'name': generate_string('numeric', 15)},
-        {'name': generate_string('latin1', 15)},
         {'name': generate_string('utf8', 15)},
         {'name': generate_string('html', 15)},
     )

--- a/tests/foreman/cli/test_repository.py
+++ b/tests/foreman/cli/test_repository.py
@@ -72,7 +72,6 @@ class TestRepository(BaseCLI):
         {u'name': generate_string('alpha', 15)},
         {u'name': generate_string('alphanumeric', 15)},
         {u'name': generate_string('numeric', 15)},
-        {u'name': generate_string('latin1', 15)},
         {u'name': generate_string('utf8', 15)},
         {u'name': generate_string('html', 15)},
     )
@@ -96,7 +95,6 @@ class TestRepository(BaseCLI):
         {u'name': generate_string('alpha', 15)},
         {u'name': generate_string('alphanumeric', 15)},
         {u'name': generate_string('numeric', 15)},
-        {u'name': generate_string('latin1', 15)},
         {u'name': generate_string('utf8', 15)},
         {u'name': generate_string('html', 15)},
     )
@@ -200,7 +198,6 @@ class TestRepository(BaseCLI):
         {u'name': generate_string('alpha', 15)},
         {u'name': generate_string('alphanumeric', 15)},
         {u'name': generate_string('numeric', 15)},
-        {u'name': generate_string('latin1', 15)},
         {u'name': generate_string('utf8', 15)},
         {u'name': generate_string('html', 15)},
     )
@@ -267,7 +264,6 @@ class TestRepository(BaseCLI):
         {u'name': generate_string('alpha', 300)},
         {u'name': generate_string('alphanumeric', 300)},
         {u'name': generate_string('numeric', 300)},
-        {u'name': generate_string('latin1', 300)},
         {u'name': generate_string('utf8', 300)},
         {u'name': generate_string('html', 300)},
     )
@@ -388,7 +384,6 @@ class TestRepository(BaseCLI):
         {u'name': generate_string('alpha', 15)},
         {u'name': generate_string('alphanumeric', 15)},
         {u'name': generate_string('numeric', 15)},
-        {u'name': generate_string('latin1', 15)},
         {u'name': generate_string('utf8', 15)},
         {u'name': generate_string('html', 15)},
     )

--- a/tests/foreman/cli/test_subnet.py
+++ b/tests/foreman/cli/test_subnet.py
@@ -24,7 +24,6 @@ class TestSubnet(BaseCLI):
         {'name': generate_string('alpha', 15)},
         {'name': generate_string('alphanumeric', 15)},
         {'name': generate_string('numeric', 15)},
-        {'name': generate_string('latin1', 15)},
         {'name': generate_string('utf8', 15)},
         {'name': generate_string('html', 15)},
     )
@@ -75,7 +74,6 @@ class TestSubnet(BaseCLI):
         {'name': generate_string('alpha', 15)},
         {'name': generate_string('alphanumeric', 15)},
         {'name': generate_string('numeric', 15)},
-        {'name': generate_string('latin1', 15)},
         {'name': generate_string('utf8', 15)},
         {'name': generate_string('html', 15)},
     )
@@ -126,7 +124,6 @@ class TestSubnet(BaseCLI):
         {'name': generate_string('alpha', 15)},
         {'name': generate_string('alphanumeric', 15)},
         {'name': generate_string('numeric', 15)},
-        {'name': generate_string('latin1', 15)},
         {'name': generate_string('utf8', 15)},
         {'name': generate_string('html', 15)},
     )

--- a/tests/foreman/cli/test_system.py
+++ b/tests/foreman/cli/test_system.py
@@ -68,7 +68,6 @@ class TestSystem(BaseCLI):
         {'name': generate_string('alpha', 15)},
         {'name': generate_string('alphanumeric', 15)},
         {'name': generate_string('numeric', 15)},
-        {'name': generate_string('latin1', 15)},
         {'name': generate_string('utf8', 15)},
         {'name': generate_string('html', 15)},
     )
@@ -92,7 +91,6 @@ class TestSystem(BaseCLI):
         {'description': generate_string('alpha', 15)},
         {'description': generate_string('alphanumeric', 15)},
         {'description': generate_string('numeric', 15)},
-        {'description': generate_string('latin1', 15)},
         {'description': generate_string('utf8', 15)},
         {'description': generate_string('html', 15)},
     )
@@ -117,7 +115,6 @@ class TestSystem(BaseCLI):
         {'name': generate_string('alpha', 300)},
         {'name': generate_string('alphanumeric', 300)},
         {'name': generate_string('numeric', 300)},
-        {'name': generate_string('latin1', 300)},
         {'name': generate_string('utf8', 300)},
         {'name': generate_string('html', 300)},
     )
@@ -136,7 +133,6 @@ class TestSystem(BaseCLI):
         {'name': generate_string('alpha', 15)},
         {'name': generate_string('alphanumeric', 15)},
         {'name': generate_string('numeric', 15)},
-        {'name': generate_string('latin1', 15)},
         {'name': generate_string('utf8', 15)},
         {'name': generate_string('html', 15)},
     )
@@ -205,7 +201,6 @@ class TestSystem(BaseCLI):
         {'description': generate_string('alpha', 15)},
         {'description': generate_string('alphanumeric', 15)},
         {'description': generate_string('numeric', 15)},
-        {'description': generate_string('latin1', 15)},
         {'description': generate_string('utf8', 15)},
         {'description': generate_string('html', 15)},
     )
@@ -274,7 +269,6 @@ class TestSystem(BaseCLI):
         {'name': generate_string('alpha', 15)},
         {'name': generate_string('alphanumeric', 15)},
         {'name': generate_string('numeric', 15)},
-        {'name': generate_string('latin1', 15)},
         {'name': generate_string('utf8', 15)},
         {'name': generate_string('html', 15)},
     )

--- a/tests/foreman/cli/test_system_group.py
+++ b/tests/foreman/cli/test_system_group.py
@@ -69,7 +69,6 @@ class TestSystemGroup(BaseCLI):
         {'name': generate_string('alpha', 15)},
         {'name': generate_string('alphanumeric', 15)},
         {'name': generate_string('numeric', 15)},
-        {'name': generate_string('latin1', 15)},
         {'name': generate_string('utf8', 15)},
         {'name': generate_string('html', 15)},
     )
@@ -93,7 +92,6 @@ class TestSystemGroup(BaseCLI):
         {'description': generate_string('alpha', 15)},
         {'description': generate_string('alphanumeric', 15)},
         {'description': generate_string('numeric', 15)},
-        {'description': generate_string('latin1', 15)},
         {'description': generate_string('utf8', 15)},
         {'description': generate_string('html', 15)},
     )
@@ -136,7 +134,6 @@ class TestSystemGroup(BaseCLI):
         {'name': generate_string('alpha', 300)},
         {'name': generate_string('alphanumeric', 300)},
         {'name': generate_string('numeric', 300)},
-        {'name': generate_string('latin1', 300)},
         {'name': generate_string('utf8', 300)},
         {'name': generate_string('html', 300)},
     )
@@ -155,7 +152,6 @@ class TestSystemGroup(BaseCLI):
         {'name': generate_string('alpha', 15)},
         {'name': generate_string('alphanumeric', 15)},
         {'name': generate_string('numeric', 15)},
-        {'name': generate_string('latin1', 15)},
         {'name': generate_string('utf8', 15)},
         {'name': generate_string('html', 15)},
     )
@@ -224,7 +220,6 @@ class TestSystemGroup(BaseCLI):
         {'description': generate_string('alpha', 15)},
         {'description': generate_string('alphanumeric', 15)},
         {'description': generate_string('numeric', 15)},
-        {'description': generate_string('latin1', 15)},
         {'description': generate_string('utf8', 15)},
         {'description': generate_string('html', 15)},
     )
@@ -343,7 +338,6 @@ class TestSystemGroup(BaseCLI):
         {'name': generate_string('alpha', 15)},
         {'name': generate_string('alphanumeric', 15)},
         {'name': generate_string('numeric', 15)},
-        {'name': generate_string('latin1', 15)},
         {'name': generate_string('utf8', 15)},
         {'name': generate_string('html', 15)},
     )

--- a/tests/foreman/cli/test_user.py
+++ b/tests/foreman/cli/test_user.py
@@ -96,8 +96,7 @@ class User(BaseCLI):
 
     # CRUD
 
-    @data({'login': generate_string("latin1", 10)},
-          {'login': generate_string("utf8", 10)},
+    @data({'login': generate_string("utf8", 10)},
           {'login': generate_string("alpha", 10)},
           {'login': generate_string("alphanumeric", 10)},
           {'login': generate_string("numeric", 10)},
@@ -114,8 +113,7 @@ class User(BaseCLI):
         args = make_user(data)
         self.__assert_exists(args)
 
-    @data({'firstname': generate_string("latin1", 10)},
-          {'firstname': generate_string("utf8", 10)},
+    @data({'firstname': generate_string("utf8", 10)},
           {'firstname': generate_string("alpha", 10)},
           {'firstname': generate_string("alphanumeric", 10)},
           {'firstname': generate_string("numeric", 10)},
@@ -132,8 +130,7 @@ class User(BaseCLI):
         args = make_user(data)
         self.__assert_exists(args)
 
-    @data({'lastname': generate_string("latin1", 10)},
-          {'lastname': generate_string("utf8", 10)},
+    @data({'lastname': generate_string("utf8", 10)},
           {'lastname': generate_string("alpha", 10)},
           {'lastname': generate_string("alphanumeric", 10)},
           {'lastname': generate_string("numeric", 10)},
@@ -150,9 +147,7 @@ class User(BaseCLI):
         args = make_user(data)
         self.__assert_exists(args)
 
-    @data({'mail': generate_string("latin1", 10) +
-           "@somemail.com"},
-          {'mail': generate_string("utf8", 10) +
+    @data({'mail': generate_string("utf8", 10) +
            "@somemail.com"},
           {'mail': generate_string("alpha", 10) + "@somemail.com"},
           {'mail': generate_string("alphanumeric", 10) + "@somemail.com"},
@@ -171,8 +166,7 @@ class User(BaseCLI):
         args = make_user(data)
         self.__assert_exists(args)
 
-    @data({'password': generate_string("latin1", 10)},
-          {'password': generate_string("utf8", 10)},
+    @data({'password': generate_string("utf8", 10)},
           {'password': generate_string("alpha", 10)},
           {'password': generate_string("alphanumeric", 10)},
           {'password': generate_string("numeric", 10)},
@@ -576,8 +570,7 @@ class User(BaseCLI):
         self.assertNotEqual(result.return_code, 0)
         self.assertTrue(result.stderr)
 
-    @data({'firstname': generate_string("latin1", 10)},
-          {'firstname': generate_string("utf8", 10)},
+    @data({'firstname': generate_string("utf8", 10)},
           {'firstname': generate_string("alpha", 10)},
           {'firstname': generate_string("alphanumeric", 10)},
           {'firstname': generate_string("numeric", 10)},)
@@ -616,8 +609,7 @@ class User(BaseCLI):
             "User first name was not updated"
         )
 
-    @data({'lastname': generate_string("latin1", 10)},
-          {'lastname': generate_string("utf8", 10)},
+    @data({'lastname': generate_string("utf8", 10)},
           {'lastname': generate_string("alpha", 10)},
           {'lastname': generate_string("alphanumeric", 10)},
           {'lastname': generate_string("numeric", 10)},)
@@ -658,8 +650,7 @@ class User(BaseCLI):
             "User last name was not updated"
         )
 
-    @data({'mail': generate_string("latin1", 10)},
-          {'mail': generate_string("utf8", 10)},
+    @data({'mail': generate_string("utf8", 10)},
           {'mail': generate_string("alpha", 10)},
           {'mail': generate_string("alphanumeric", 10)},
           {'mail': generate_string("numeric", 10)},)
@@ -1087,8 +1078,7 @@ class User(BaseCLI):
         self.assertEqual(updated_user.stdout['email'], new_user['mail'])
 
     @bzbug('1079649')
-    @data({'login': generate_string("latin1", 10)},
-          {'login': generate_string("utf8", 10)},
+    @data({'login': generate_string("utf8", 10)},
           {'login': generate_string("alpha", 10)},
           {'login': generate_string("alphanumeric", 10)},
           {'login': generate_string("numeric", 10)},
@@ -1114,8 +1104,7 @@ class User(BaseCLI):
         self.assertGreater(len(result.stderr), 0)
 
     @bzbug('1079649')
-    @data({'login': generate_string("latin1", 10)},
-          {'login': generate_string("utf8", 10)},
+    @data({'login': generate_string("utf8", 10)},
           {'login': generate_string("alpha", 10)},
           {'login': generate_string("alphanumeric", 10)},
           {'login': generate_string("numeric", 10)},
@@ -1161,7 +1150,6 @@ class User(BaseCLI):
     @data({'login': generate_string("alpha", 10)},
           {'login': generate_string("alphanumeric", 10)},
           {'login': generate_string("numeric", 10)},
-          {'login': generate_string("latin1", 10)},
           {'login': generate_string("utf8", 10)},
           {'login': generate_string("alphanumeric", 100)})
     def test_list_user_1(self, test_data):
@@ -1186,8 +1174,7 @@ class User(BaseCLI):
             'id': user['id'],
             'email': user['mail']}, result.stdout[0])
 
-    @data({'firstname': generate_string("latin1", 10)},
-          {'firstname': generate_string("utf8", 10)},
+    @data({'firstname': generate_string("utf8", 10)},
           {'firstname': generate_string("alpha", 10)},
           {'firstname': generate_string("alphanumeric", 10)},
           {'firstname': generate_string("numeric", 10)},
@@ -1214,8 +1201,7 @@ class User(BaseCLI):
             'id': user['id'],
             'email': user['mail']} in result.stdout)
 
-    @data({'lastname': generate_string("latin1", 10)},
-          {'lastname': generate_string("utf8", 10)},
+    @data({'lastname': generate_string("utf8", 10)},
           {'lastname': generate_string("alpha", 10)},
           {'lastname': generate_string("alphanumeric", 10)},
           {'lastname': generate_string("numeric", 10)},
@@ -1242,8 +1228,7 @@ class User(BaseCLI):
             'id': user['id'],
             'email': user['mail']} in result.stdout)
 
-    @data({'mail': generate_string("latin1", 10) + "@somemail.com"},
-          {'mail': generate_string("utf8", 10) + "@somemail.com"},
+    @data({'mail': generate_string("utf8", 10) + "@somemail.com"},
           {'mail': generate_string("alpha", 10) + "@somemail.com"},
           {'mail': generate_string("alphanumeric", 10) + "@somemail.com"},
           {'mail': generate_string("numeric", 10) + "@somemail.com"},

--- a/tests/foreman/ui/test_gpgkey.py
+++ b/tests/foreman/ui/test_gpgkey.py
@@ -444,7 +444,6 @@ class GPGKey(BaseUI):
         name is numeric
         name is alphanumeric
         name is utf-8
-        name is latin1
         name is html
         gpg key file is valid always
         """)
@@ -533,7 +532,6 @@ class GPGKey(BaseUI):
         name is numeric
         name is alphanumeric
         name is utf-8
-        name is latin1
         name is html
         gpg key file is valid always
 """)
@@ -663,7 +661,6 @@ class GPGKey(BaseUI):
         name is numeric
         name is alphanumeric
         name is utf-8
-        name is latin1
         name is html
         gpg key file is valid always
 """)
@@ -766,7 +763,6 @@ class GPGKey(BaseUI):
         name is numeric
         name is alphanumeric
         name is utf-8
-        name is latin1
         name is html
         gpg key file is valid always
 """)
@@ -894,7 +890,6 @@ class GPGKey(BaseUI):
         name is numeric
         name is alphanumeric
         name is utf-8
-        name is latin1
         name is html
         gpg key file is valid always
 """)
@@ -995,7 +990,6 @@ class GPGKey(BaseUI):
         name is numeric
         name is alphanumeric
         name is utf-8
-        name is latin1
         name is html
         gpg key file is valid always
 """)
@@ -1113,7 +1107,6 @@ class GPGKey(BaseUI):
         name is numeric
         name is alphanumeric
         name is utf-8
-        name is latin1
         name is html
         gpg key file is valid always
 """)
@@ -1204,7 +1197,6 @@ class GPGKey(BaseUI):
         name is numeric
         name is alphanumeric
         name is utf-8
-        name is latin1
         name is html
         gpg key file is valid always
 """)
@@ -1336,7 +1328,6 @@ class GPGKey(BaseUI):
         name is numeric
         name is alphanumeric
         name is utf-8
-        name is latin1
         name is html
         gpg key file is valid always
 """)
@@ -1440,7 +1431,6 @@ class GPGKey(BaseUI):
         name is numeric
         name is alphanumeric
         name is utf-8
-        name is latin1
         name is html
         gpg key file is valid always
 """)
@@ -1567,7 +1557,6 @@ class GPGKey(BaseUI):
         name is numeric
         name is alphanumeric
         name is utf-8
-        name is latin1
         name is html
         gpg key file is valid always
 """)
@@ -1667,7 +1656,6 @@ class GPGKey(BaseUI):
         name is numeric
         name is alphanumeric
         name is utf-8
-        name is latin1
         name is html
         gpg key file is valid always
 """)
@@ -1693,7 +1681,6 @@ class GPGKey(BaseUI):
         name is numeric
         name is alphanumeric
         name is utf-8
-        name is latin1
         name is html
         gpg key file is valid always
 """)
@@ -1714,7 +1701,6 @@ class GPGKey(BaseUI):
         name is numeric
         name is alphanumeric
         name is utf-8
-        name is latin1
         name is html
         gpg key file is valid always
 """)
@@ -1735,7 +1721,6 @@ class GPGKey(BaseUI):
         name is numeric
         name is alphanumeric
         name is utf-8
-        name is latin1
         name is html
         gpg key file is valid always
 """)
@@ -1758,7 +1743,6 @@ class GPGKey(BaseUI):
         name is numeric
         name is alphanumeric
         name is utf-8
-        name is latin1
         name is html
         gpg key file is valid always
 """)
@@ -1778,7 +1762,6 @@ class GPGKey(BaseUI):
         name is numeric
         name is alphanumeric
         name is utf-8
-        name is latin1
         name is html
         gpg key file is valid always
 """)
@@ -1798,7 +1781,6 @@ class GPGKey(BaseUI):
         name is numeric
         name is alphanumeric
         name is utf-8
-        name is latin1
         name is html
         gpg key file is valid always
 """)

--- a/tests/foreman/ui/test_org.py
+++ b/tests/foreman/ui/test_org.py
@@ -81,9 +81,6 @@ class Org(BaseUI):
            'name': generate_string('utf8', 10),
            'desc': generate_string('utf8', 10)},
           {'label': generate_string('alpha', 10),
-           'name': generate_string('latin1', 20),
-           'desc': generate_string('latin1', 10)},
-          {'label': generate_string('alpha', 10),
            'name': generate_string('html', 20),
            'desc': generate_string('html', 10)})
     def test_positive_create_2(self, test_data):
@@ -168,8 +165,6 @@ class Org(BaseUI):
            'desc': generate_string('alphanumeric', 10)},
           {'name': generate_string('utf8', 10),
            'desc': generate_string('utf8', 10)},
-          {'name': generate_string('latin1', 20),
-           'desc': generate_string('latin1', 10)},
           {'name': generate_string('html', 20),
            'desc': generate_string('html', 10)})
     def test_positive_create_5(self, test_data):
@@ -461,7 +456,6 @@ class Org(BaseUI):
         smartproxy name is numeric
         smartproxy name is alpha_numeric
         smartproxy name  is utf-8
-        smartproxy name is latin1
         smartproxy name is html
     """)
     def test_add_smartproxy_1(self, test_data):
@@ -789,7 +783,6 @@ class Org(BaseUI):
         smartproxy name is numeric
         smartproxy name is alpha_numeric
         smartproxy name  is utf-8
-        smartproxy name is latin1
         smartproxy name is html
     """)
     def test_remove_smartproxy_1(self, test_data):

--- a/tests/robottelo/test_helpers.py
+++ b/tests/robottelo/test_helpers.py
@@ -65,10 +65,6 @@ class GenerateStringTestCase(unittest.TestCase):
         """Tests if generate numeric string returns a unicode string"""
         self.assertIsInstance(generate_string('numeric', 8), unicode)
 
-    def test_latin1_return_type(self):
-        """Tests if generate latin1 string returns a unicode string"""
-        self.assertIsInstance(generate_string('latin1', 8), unicode)
-
     def test_utf8_return_type(self):
         """Tests if generate utf-8 string returns a unicode string"""
         self.assertIsInstance(generate_string('utf8', 8), unicode)


### PR DESCRIPTION
Testing using utf-8 suffice the multibyte string testing. Also to really test latin1 encoded strings will be needed a machine configured with latin1 and not utf-8. As utf-8 already test multibyte string we are fine to test using utf-8 encoded strings.

Related to #554
