### PR TITLE
Refactor cli to better handle organization-id

### DIFF
--- a/robottelo/cli/factory.py
+++ b/robottelo/cli/factory.py
@@ -43,7 +43,7 @@ from tempfile import mkstemp
 logger = logging.getLogger("robottelo")
 
 
-def create_object(cli_object, args, organization_id=None):
+def create_object(cli_object, args):
     """
     Creates <object> with dictionary of arguments.
 
@@ -58,7 +58,7 @@ def create_object(cli_object, args, organization_id=None):
     @return: A dictionary representing the newly created resource.
     """
 
-    result = cli_object.create(args, organization_id)
+    result = cli_object.create(args)
     # Some methods require a bit of waiting
     sleep_for_seconds(5)
 
@@ -432,7 +432,7 @@ def make_system(options=None):
     }
 
     args = update_dictionary(args, options)
-    args.update(create_object(System, args, args['organization-id']))
+    args.update(create_object(System, args))
 
     return args
 

--- a/robottelo/cli/gpgkey.py
+++ b/robottelo/cli/gpgkey.py
@@ -26,27 +26,7 @@ class GPGKey(Base):
     """
 
     command_base = "gpg"
-
-    @classmethod
-    def exists(cls, organization_id, tuple_search=None):
-        """
-        Search for a GPG Key.
-        """
-
-        # Katello subcommands require the organization-id
-        options = {}
-
-        if tuple_search:
-            search_criteria = "%s:\"%s\"" % (tuple_search[0], tuple_search[1])
-            options["search"] = search_criteria
-        # Katello subcommands require extra arguments such as organization-id
-
-        result = cls.list(organization_id, options)
-
-        if result.stdout:
-            result.stdout = result.stdout[0]
-
-        return result
+    command_requires_org = True
 
     @classmethod
     def info(cls, options=None):
@@ -78,24 +58,5 @@ class GPGKey(Base):
                     key_record['content'] += val
             # Update stdout with dictionary
             result.stdout = key_record
-
-        return result
-
-    @classmethod
-    def list(cls, organization_id, options=None):
-        """
-        Lists available GPG Keys.
-        """
-
-        cls.command_sub = "list"
-
-        if options is None:
-            options = {}
-            options['per-page'] = 10000
-
-        # Katello subcommands require the organization-id
-        options['organization-id'] = organization_id
-
-        result = cls.execute(cls._construct_command(options), expect_csv=True)
 
         return result

--- a/robottelo/cli/lifecycleenvironment.py
+++ b/robottelo/cli/lifecycleenvironment.py
@@ -26,42 +26,4 @@ class LifecycleEnvironment(Base):
     """
 
     command_base = "lifecycle-environment"
-
-    @classmethod
-    def exists(cls, organization_id, tuple_search=None):
-        """
-        Search for a lifecycle environment.
-        """
-
-        # Katello subcommands require the organization-id
-        options = {}
-
-        if tuple_search:
-            search_criteria = "%s:\"%s\"" % (tuple_search[0], tuple_search[1])
-            options["search"] = search_criteria
-        # Katello subcommands require extra arguments such as organization-id
-
-        result = cls.list(organization_id, options)
-
-        if result.stdout:
-            result.stdout = result.stdout[0]
-
-        return result
-
-    @classmethod
-    def list(cls, organization_id, options=None):
-        """
-        Lists available Lifecycle Environments for organization.
-        """
-
-        cls.command_sub = "list"
-
-        if options is None:
-            options = {}
-
-        # Katello subcommands require the organization-id
-        options['organization-id'] = organization_id
-
-        result = cls.execute(cls._construct_command(options), expect_csv=True)
-
-        return result
+    command_requires_org = True

--- a/robottelo/cli/metatest/template_methods.py
+++ b/robottelo/cli/metatest/template_methods.py
@@ -26,7 +26,7 @@ def test_positive_create(self, data):
 
     # Can we find the new object?
     result = self.factory_obj().exists(
-        (self.search_key, new_obj[self.search_key])
+        tuple_search=(self.search_key, new_obj[self.search_key])
     )
 
     self.assertTrue(result.return_code == 0, "Failed to create object")
@@ -83,7 +83,7 @@ def test_positive_update(self, data):
     new_obj = self.factory(orig_dict)
 
     result = self.factory_obj().exists(
-        (self.search_key, new_obj[self.search_key])
+        tuple_search=(self.search_key, new_obj[self.search_key])
     )
     self.assertTrue(result.return_code == 0, "Failed to create object")
     self.assertTrue(
@@ -139,7 +139,7 @@ def test_negative_update(self, data):
     new_obj = self.factory(orig_dict)
 
     result = self.factory_obj().exists(
-        (self.search_key, new_obj[self.search_key])
+        tuple_search=(self.search_key, new_obj[self.search_key])
     )
     self.assertTrue(result.return_code == 0, "Failed to create object")
     self.assertTrue(
@@ -160,7 +160,7 @@ def test_negative_update(self, data):
     self.assertTrue(len(result.stderr) > 0, "There should be errors")
 
     result = self.factory_obj().exists(
-        (self.search_key, new_obj[self.search_key])
+        tuple_search=(self.search_key, new_obj[self.search_key])
     )
     # Verify that new values were not updated
     self.assertEqual(new_obj, result.stdout, "Object should not be updated")
@@ -187,7 +187,7 @@ def test_positive_delete(self, data):
     new_obj = self.factory(data)
 
     result = self.factory_obj().exists(
-        (self.search_key, new_obj[self.search_key])
+        tuple_search=(self.search_key, new_obj[self.search_key])
     )
     self.assertTrue(result.return_code == 0, "Failed to create object")
 
@@ -228,7 +228,7 @@ def test_negative_delete(self, data):
     new_obj = self.factory()
 
     result = self.factory_obj().exists(
-        (self.search_key, new_obj[self.search_key])
+        tuple_search=(self.search_key, new_obj[self.search_key])
     )
     self.assertTrue(result.return_code == 0, "Failed to create object")
     # Store the new object for further assertions
@@ -241,7 +241,7 @@ def test_negative_delete(self, data):
     # Now make sure that it still exists
 
     result = self.factory_obj().exists(
-        (self.search_key, new_obj[self.search_key])
+        tuple_search=(self.search_key, new_obj[self.search_key])
     )
     self.assertTrue(result.return_code == 0, "Failed to find object")
     self.assertEqual(new_obj, result.stdout)

--- a/robottelo/cli/product.py
+++ b/robottelo/cli/product.py
@@ -28,6 +28,7 @@ class Product(Base):
     """
 
     command_base = "product"
+    command_requires_org = True
 
     @classmethod
     def info(cls, options=None):
@@ -58,25 +59,6 @@ class Product(Base):
 
         # Update result.stdout
         result.stdout = gpg_key
-
-        return result
-
-    @classmethod
-    def list(cls, organization_id, options=None):
-        """
-        Lists available products.
-        """
-
-        cls.command_sub = "list"
-
-        if options is None:
-            options = {}
-            options['per-page'] = 10000
-
-        # Katello subcommands require the organization-id
-        options['organization-id'] = organization_id
-
-        result = cls.execute(cls._construct_command(options), expect_csv=True)
 
         return result
 

--- a/robottelo/cli/repository.py
+++ b/robottelo/cli/repository.py
@@ -27,23 +27,27 @@ class Repository(Base):
     """
 
     command_base = "repository"
+    command_requires_org = True
 
     @classmethod
-    def list(cls, organization_id, options=None):
-        """
-        Lists available repositories.
-        """
+    def create(cls, options=None):
+        cls.command_requires_org = False
 
-        cls.command_sub = "list"
+        try:
+            result = super(Repository, cls).create(options)
+        finally:
+            cls.command_requires_org = True
 
-        if options is None:
-            options = {}
-            options['per-page'] = 10000
+        return result
 
-        # Katello subcommands require the organization-id
-        options['organization-id'] = organization_id
+    @classmethod
+    def info(cls, options=None):
+        cls.command_requires_org = False
 
-        result = cls.execute(cls._construct_command(options), expect_csv=True)
+        try:
+            result = super(Repository, cls).info(options)
+        finally:
+            cls.command_requires_org = True
 
         return result
 

--- a/robottelo/cli/syncplan.py
+++ b/robottelo/cli/syncplan.py
@@ -26,22 +26,26 @@ class SyncPlan(Base):
     """
 
     command_base = "sync-plan"
+    command_requires_org = True
 
     @classmethod
-    def list(cls, organization_id, options=None):
-        """
-        Lists available sync plans.
-        """
+    def create(cls, options=None):
+        cls.command_requires_org = False
 
-        cls.command_sub = "list"
+        try:
+            result = super(SyncPlan, cls).create(options)
+        finally:
+            cls.command_requires_org = True
 
-        if options is None:
-            options = {}
-            options['per-page'] = 10000
+        return result
 
-        # Katello subcommands require the organization-id
-        options['organization-id'] = organization_id
+    @classmethod
+    def info(cls, options=None):
+        cls.command_requires_org = False
 
-        result = cls.execute(cls._construct_command(options), expect_csv=True)
+        try:
+            result = super(SyncPlan, cls).info(options)
+        finally:
+            cls.command_requires_org = True
 
         return result

--- a/robottelo/cli/system.py
+++ b/robottelo/cli/system.py
@@ -27,28 +27,10 @@ class System(Base):
     """
 
     command_base = "system"
+    command_requires_org = True
 
     @classmethod
-    def list(cls, organization_id, options=None):
-        """
-        Lists available systems
-        """
-
-        cls.command_sub = "list"
-
-        if options is None:
-            options = {}
-            options['per-page'] = 10000
-
-        # Katello subcommands require the organization-id
-        options['organization-id'] = organization_id
-
-        result = cls.execute(cls._construct_command(options), expect_csv=True)
-
-        return result
-
-    @classmethod
-    def tasks(cls, organization_id, options=None):
+    def tasks(cls, options=None):
         """
         Lists async tasks for a system
         """
@@ -57,17 +39,21 @@ class System(Base):
 
         if options is None:
             options = {}
+
+        if 'per-page' not in options:
             options['per-page'] = 10000
 
-        # Katello subcommands require the organization-id
-        options['organization-id'] = organization_id
+        if cls.command_requires_org and 'organization-id' not in options:
+            raise Exception(
+                'organization-id option is required for %s.tasks' %
+                cls.__name__)
 
         result = cls.execute(cls._construct_command(options), expect_csv=True)
 
         return result
 
     @classmethod
-    def update(cls, organization_id, options=None):
+    def update(cls, options=None):
         """
         Update system information
         """
@@ -76,10 +62,14 @@ class System(Base):
 
         if options is None:
             options = {}
+
+        if 'per-page' not in options:
             options['per-page'] = 10000
 
-        # Katello subcommands require the organization-id
-        options['organization-id'] = organization_id
+        if cls.command_requires_org and 'organization-id' not in options:
+            raise Exception(
+                'organization-id option is required for %s.update' %
+                cls.__name__)
 
         result = cls.execute(cls._construct_command(options), expect_csv=True)
 

--- a/robottelo/cli/systemgroup.py
+++ b/robottelo/cli/systemgroup.py
@@ -25,22 +25,4 @@ class SystemGroup(Base):
     """
 
     command_base = "system-group"
-
-    @classmethod
-    def list(cls, organization_id, options=None):
-        """
-        Lists available system groups
-        """
-
-        cls.command_sub = "list"
-
-        if options is None:
-            options = {}
-            options['per-page'] = 10000
-
-        # Katello subcommands require the organization-id
-        options['organization-id'] = organization_id
-
-        result = cls.execute(cls._construct_command(options), expect_csv=True)
-
-        return result
+    command_requires_org = True

--- a/tests/foreman/cli/test_computeresource.py
+++ b/tests/foreman/cli/test_computeresource.py
@@ -93,7 +93,7 @@ class TestComputeResource(BaseCLI):
         self.assertTrue(len(result_list.stdout) > 0,
                         "ComputeResource list - stdout has results")
         stdout = ComputeResource.exists(
-            ('name', result_create['name'])).stdout
+            tuple_search=('name', result_create['name'])).stdout
         self.assertTrue(
             stdout,
             "ComputeResource list - exists name")
@@ -141,7 +141,7 @@ class TestComputeResource(BaseCLI):
             result_delete.return_code, 0,
             "ComputeResource delete - exit code")
         stdout = ComputeResource.exists(
-            ('name', result_create['name'])).stdout
+            tuple_search=('name', result_create['name'])).stdout
         self.assertFalse(
             stdout,
             "ComputeResource list - does not exist name")

--- a/tests/foreman/cli/test_gpgkey.py
+++ b/tests/foreman/cli/test_gpgkey.py
@@ -73,7 +73,7 @@ class TestGPGKey(BaseCLI):
         """Creates and returns an organization"""
         label = generate_name(6)
         org = make_org({'label': label})
-        result = Org.exists(('id', org['id']))
+        result = Org.exists(tuple_search=('id', org['id']))
 
         org.update(result.stdout)
 
@@ -221,7 +221,7 @@ class TestGPGKey(BaseCLI):
 
         # Can we find the new object?
         result = GPGKey().exists(
-            org['label'],
+            {'organization-id': org['label']},
             (self.search_key, new_obj[self.search_key])
         )
 
@@ -251,7 +251,7 @@ class TestGPGKey(BaseCLI):
 
         # Can we find the new object?
         result = GPGKey().exists(
-            self.org['label'],
+            {'organization-id': self.org['label']},
             (self.search_key, new_obj[self.search_key])
         )
 
@@ -282,7 +282,7 @@ class TestGPGKey(BaseCLI):
 
         # Can we find the new object?
         result = GPGKey().exists(
-            self.org['label'],
+            {'organization-id': self.org['label']},
             (self.search_key, new_obj[self.search_key])
         )
 

--- a/tests/foreman/cli/test_org.py
+++ b/tests/foreman/cli/test_org.py
@@ -130,7 +130,7 @@ class TestOrg(BaseCLI):
 
         new_obj = make_org(test_data)
         # Can we find the new object?
-        result = Org.exists(('name', new_obj['name']))
+        result = Org.exists(tuple_search=('name', new_obj['name']))
 
         self.assertEqual(result.return_code, 0, "Failed to create object")
         self.assertEqual(len(result.stderr), 0,
@@ -168,7 +168,7 @@ class TestOrg(BaseCLI):
 
         new_obj = make_org(test_data)
         # Can we find the new object?
-        result = Org.exists(('label', new_obj['label']))
+        result = Org.exists(tuple_search=('label', new_obj['label']))
 
         self.assertEqual(result.return_code, 0, "Failed to find the object")
         self.assertEqual(len(result.stderr), 0,
@@ -702,11 +702,10 @@ class TestOrg(BaseCLI):
         })
 
         # Can we list the new environment?
-        environment = LifecycleEnvironment.list(
-            new_obj['label'],
-            {
-                'name': env_result['name']
-            })
+        environment = LifecycleEnvironment.list({
+            'name': env_result['name'],
+            'oraganization-id': new_obj['label'],
+        })
         # Result is a list of one item
         new_env = environment.stdout[0]
 
@@ -727,11 +726,10 @@ class TestOrg(BaseCLI):
         })
 
         # Can we list the new environment?
-        environment = LifecycleEnvironment.list(
-            new_obj['label'],
-            {
-                'name': env_result['name']
-            })
+        environment = LifecycleEnvironment.list({
+            'name': env_result['name'],
+            'organization-id': new_obj['label'],
+        })
         # Result is a list of one item
         new_env = environment.stdout[0]
 

--- a/tests/foreman/cli/test_partitiontable.py
+++ b/tests/foreman/cli/test_partitiontable.py
@@ -27,7 +27,7 @@ class TestPartitionTable(MetaCLI):
         name = generate_name(6)
         make_partition_table({'name': name, 'content': content})
 
-        ptable = PartitionTable().exists(('name', name)).stdout
+        ptable = PartitionTable().exists(tuple_search=('name', name)).stdout
 
         args = {
             'id': ptable['id'],
@@ -48,11 +48,12 @@ class TestPartitionTable(MetaCLI):
         name = generate_name(6)
         make_partition_table({'name': name, 'content': content})
 
-        ptable = PartitionTable().exists(('name', name)).stdout
+        ptable = PartitionTable().exists(tuple_search=('name', name)).stdout
 
         args = {
             'id': ptable['id'],
         }
 
         PartitionTable().delete(args)
-        self.assertFalse(PartitionTable().exists(('name', name)).stdout)
+        self.assertFalse(
+            PartitionTable().exists(tuple_search=('name', name)).stdout)

--- a/tests/foreman/cli/test_system_group.py
+++ b/tests/foreman/cli/test_system_group.py
@@ -16,7 +16,6 @@ from tests.foreman.cli.basecli import BaseCLI
 
 
 @bzbug('1084240')
-@bzbug('1080475')
 @ddt
 class TestSystemGroup(BaseCLI):
     """

--- a/tests/foreman/cli/test_user.py
+++ b/tests/foreman/cli/test_user.py
@@ -1030,7 +1030,8 @@ class User(BaseCLI):
         self.assertTrue(result.stderr)
         self.assertNotEqual(result.return_code, 0)
         # check name have not changed
-        updated_user = UserObj().exists(('login', new_user['login']))
+        updated_user = UserObj().exists(
+            tuple_search=('login', new_user['login']))
         self.assertEqual(updated_user.stdout['name'], "%s %s" %
                                                       (new_user['firstname'],
                                                        new_user['lastname']))
@@ -1052,7 +1053,8 @@ class User(BaseCLI):
         self.assertTrue(result.stderr)
         self.assertNotEqual(result.return_code, 0)
         # check name have not changed
-        updated_user = UserObj().exists(('login', new_user['login']))
+        updated_user = UserObj().exists(
+            tuple_search=('login', new_user['login']))
         self.assertEqual(updated_user.stdout['name'], "%s %s" %
                                                       (new_user['firstname'],
                                                        new_user['lastname']))
@@ -1083,7 +1085,8 @@ class User(BaseCLI):
         self.assertTrue(result.stderr)
         self.assertNotEqual(result.return_code, 0)
         # check name have not changed
-        updated_user = UserObj().exists(('login', new_user['login']))
+        updated_user = UserObj().exists(
+            tuple_search=('login', new_user['login']))
         self.assertEqual(updated_user.stdout['email'], new_user['mail'])
 
     @bzbug('1079649')
@@ -1155,7 +1158,7 @@ class User(BaseCLI):
         result = user.delete({'login': 'admin'})
         self.assertTrue(result.stderr)
         self.assertNotEqual(result.return_code, 0)
-        result = UserObj().exists(('login', 'admin'))
+        result = UserObj().exists(tuple_search=('login', 'admin'))
         self.assertTrue(result.stdout)
 
     @data({'login': generate_string("alpha", 10)},


### PR DESCRIPTION
- Unify the expected parameters for cli methods
- Give more flexibility to exists method

Now we have a concise way of dealing with organization-id hammer parameter, it is passed on a dict as other parameters. Also will raise an exception if organization-id is required.

The changes was based on the factory implementation.

Related to #608
