### PR TITLE
Improve logging config

### DIFF
--- a/robottelo/common/decorators.py
+++ b/robottelo/common/decorators.py
@@ -22,11 +22,14 @@ from xml.parsers.expat import ExpatError
 from xmlrpclib import Fault
 
 
-bugzilla_log = logging.getLogger("bugzilla")
-bugzilla_log.setLevel(logging.WARNING)
-
 BUGZILLA_URL = "https://bugzilla.redhat.com/xmlrpc.cgi"
 REDMINE_URL = 'http://projects.theforeman.org'
+
+
+# Increase the level of third party packages logging
+logging.getLogger('bugzilla').setLevel(logging.WARNING)
+logging.getLogger(
+    'requests.packages.urllib3.connectionpool').setLevel(logging.WARNING)
 
 
 def stubbed(func):

--- a/tests/foreman/ui/baseui.py
+++ b/tests/foreman/ui/baseui.py
@@ -44,6 +44,11 @@ from selenium_factory.SeleniumFactory import SeleniumFactory
 SAUCE_URL = "http://%s:%s@ondemand.saucelabs.com:80/wd/hub"
 
 
+# Increase the level of third party packages logging
+logging.getLogger(
+    'selenium.webdriver.remote.remote_connection').setLevel(logging.WARNING)
+
+
 class BaseUI(unittest.TestCase):
     """
     Base class for all UI tests.


### PR DESCRIPTION
Increase log level for third party modules to give a cleaner debug output for the tests' logs.

Related to #651
