### PR TITLE
Allow flags to be passed to hammer commands

### DIFF
--- a/robottelo/cli/base.py
+++ b/robottelo/cli/base.py
@@ -296,7 +296,10 @@ class Base(object):
 
         for key, val in options.items():
             if val is not None:
-                tail += u" --%s='%s'" % (key, val)
+                if val is True:
+                    tail += u" --%s" % key
+                elif val is not False:
+                    tail += u" --%s='%s'" % (key, val)
         cmd = u"%s %s %s" % (cls.command_base, cls.command_sub, tail.strip())
 
         return cmd

--- a/tests/robottelo/test_cli.py
+++ b/tests/robottelo/test_cli.py
@@ -1,0 +1,23 @@
+import unittest
+
+from robottelo.cli.base import Base
+
+
+class BaseCliTestCase(unittest.TestCase):
+    def test_construct_command(self):
+        """_construct_command builds a command using flags and arguments"""
+        Base.command_base = 'basecommand'
+        Base.command_sub = 'subcommand'
+        command_parts = Base._construct_command({
+            u'flag-one': True,
+            u'flag-two': False,
+            u'argument': u'value',
+            u'ommited-arg': None,
+        }).split()
+
+        self.assertIn(u'basecommand', command_parts)
+        self.assertIn(u'subcommand', command_parts)
+        self.assertIn(u'--flag-one', command_parts)
+        self.assertIn(u'--argument=\'value\'', command_parts)
+        self.assertNotIn(u'--flag-two', command_parts)
+        self.assertEqual(len(command_parts), 4)


### PR DESCRIPTION
Add a way to pass flags to hammer commands.

The implementation was defined as if an argument is `True` or `False` then it is a flag and will be added to the command output only if the value is `True`.

Also was added a test for `_construct_command` function.

Related to #703
