### PR TITLE
Activation key tests

### DIFF
--- a/robottelo/ui/activationkey.py
+++ b/robottelo/ui/activationkey.py
@@ -185,3 +185,23 @@ class ActivationKey(Base):
         else:
             raise Exception(
                 "Couldn't find the selected activation key '%s'" % name)
+
+    def get_attribute(self, name, locator):
+        """
+        Get the attribute of selected locator
+        """
+
+        element = self.search_key(name)
+
+        if element:
+            element.click()
+            self.wait_for_ajax()
+            if self.wait_until_element(locator):
+                result = self.find_element(locator).text
+                return result
+            else:
+                raise Exception(
+                    "Couldn't get text attribute of a given locator")
+        else:
+            raise Exception(
+                "Couldn't find the selected activation key '%s'" % name)

--- a/robottelo/ui/locators.py
+++ b/robottelo/ui/locators.py
@@ -893,6 +893,9 @@ locators = {
     "ak.env": (
         By.XPATH,
         "//input[@ng-model='item.selected']/parent::label[contains(., '%s')]"),
+    "ak.selected_env": (
+        By.XPATH,
+        "//input[@class='ng-pristine ng-valid']/parent::label"),
     "ak.content_view": (By.ID, "content_view_id"),
     "ak.usage_limit_checkbox": (
         By.XPATH,
@@ -960,6 +963,10 @@ locators = {
          "/td/input[@ng-model='subscription.selected']")),
     "ak.add_selected_subscription": (
         By.XPATH, "//button[@ng-click='addSelected()']"),
+    "ak.selected_cv": (
+        By.XPATH,
+        ("//form[@alch-edit-select='activationKey.content_view.name']"
+         "/div[@class='alch-edit']/div/span")),
 
     # Sync Status
     "sync.prd_expander": (

--- a/tests/foreman/ui/test_activationkey.py
+++ b/tests/foreman/ui/test_activationkey.py
@@ -526,6 +526,7 @@ class ActivationKey(BaseUI):
         self.assertTrue(self.activationkey.wait_until_element
                         (common_locators["alert.success"]))
 
+    @bzbug('1089637')
     @attr('ui', 'ak', 'implemented')
     @data(*valid_names_list())
     def test_positive_update_activation_key_3(self, env_name):
@@ -536,7 +537,7 @@ class ActivationKey(BaseUI):
         1. Create Activation key
         2. Update Environment for all variations in [1]
         @Assert: Activation key is updated
-        @BZ: 1078676
+        @BZ: 1089637
         """
 
         name = generate_string("alpha", 8)
@@ -553,9 +554,14 @@ class ActivationKey(BaseUI):
         self.activationkey.create(name, ENVIRONMENT,
                                   description=generate_string("alpha", 16))
         self.assertIsNotNone(self.activationkey.search_key(name))
+        env_locator = locators["ak.selected_env"]
+        selected_env = self.activationkey.get_attribute(name, env_locator)
+        self.assertEqual(ENVIRONMENT, selected_env)
         self.activationkey.update(name, content_view=cv_name, env=env_name)
         self.assertTrue(self.activationkey.wait_until_element
                         (common_locators["alert.success"]))
+        selected_env = self.activationkey.get_attribute(name, env_locator)
+        self.assertEqual(env_name, selected_env)
 
     @attr('ui', 'ak', 'implemented')
     @data(*valid_names_list())
@@ -588,9 +594,14 @@ class ActivationKey(BaseUI):
                                   description=generate_string("alpha", 16),
                                   content_view=cv1_name)
         self.assertIsNotNone(self.activationkey.search_key(name))
+        cv_locator = locators["ak.selected_cv"]
+        selected_cv = self.activationkey.get_attribute(name, cv_locator)
+        self.assertEqual(cv1_name, selected_cv)
         self.activationkey.update(name, content_view=cv2_name)
         self.assertTrue(self.activationkey.wait_until_element
                         (common_locators["alert.success"]))
+        selected_cv = self.activationkey.get_attribute(name, cv_locator)
+        self.assertEqual(cv2_name, selected_cv)
         # TODO: Need to check for RH Product too
 
     @bzbug('1078676')


### PR DESCRIPTION
- Removed sleep statements, as wait_for_ajax is working fine.
- updated `update` fn to support environment updation, when we update env, we need to select the CV in that env.
- added a fn `associate_product` to associate custom product to selected activation key
- 7 Tests added  
  `test_positive_create_activation_key_3`
  `test_positive_create_activation_key_4`
  `test_positive_delete_activation_key_3`
  `test_positive_delete_activation_key_4`
  `test_positive_update_activation_key_3`
  `test_positive_update_activation_key_4`
  `test_associate_product_2`
