### PR TITLE
Fixed import for CLI ContentView

### DIFF
--- a/robottelo/cli/factory.py
+++ b/robottelo/cli/factory.py
@@ -12,7 +12,7 @@ import random
 
 from os import chmod
 from robottelo.cli.architecture import Architecture
-from robottelo.cli.content_view import Content_View
+from robottelo.cli.contentview import ContentView
 from robottelo.cli.computeresource import ComputeResource
 from robottelo.cli.domain import Domain
 from robottelo.cli.environment import Environment
@@ -134,7 +134,7 @@ def make_content_view(options=None):
 
     # Override default dictionary with updated one
     args = update_dictionary(args, options)
-    args.update(create_object(Content_View, args))
+    args.update(create_object(ContentView, args))
 
     return args
 

--- a/tests/foreman/cli/test_contentviews.py
+++ b/tests/foreman/cli/test_contentviews.py
@@ -7,7 +7,7 @@ Feature details: https://fedorahosted.org/katello/wiki/ContentViewCLI
 """
 from robottelo.common.constants import NOT_IMPLEMENTED
 from robottelo.common.helpers import generate_string
-from robottelo.cli.content_view import ContentView
+from robottelo.cli.contentview import ContentView
 from robottelo.cli.org import Org
 from robottelo.cli.factory import make_org
 from robottelo.cli.factory import make_content_view


### PR DESCRIPTION
When content view support for CLI underwent some refactorying, tests and
imports were not properly refactored resulting in import errors.
