### PR TITLE
Fixing test_add_configtemplate for CLI OS.

### DIFF
--- a/robottelo/cli/operatingsys.py
+++ b/robottelo/cli/operatingsys.py
@@ -10,20 +10,22 @@ Parameters:
     [ARG] ...                     subcommand arguments
 
 Subcommands:
-    set_parameter                 Create or update parameter for an
-                                  operating system.
-    remove_configtemplate         Disassociate a resource
+    add-architecture              Associate a resource
+    add-config-template           Associate a resource
+    add-ptable                    Associate a resource
     create                        Create an OS.
-    info                          Show an OS.
-    add_configtemplate            Associate a resource
-    remove_architecture           Disassociate a resource
-    list                          List all operating systems.
-    remove_ptable                 Disassociate a resource
-    update                        Update an OS.
-    add_architecture              Associate a resource
-    add_ptable                    Associate a resource
     delete                        Delete an OS.
-    delete_parameter              Delete parameter for an operating system.
+    delete-default-template
+    delete-parameter              Delete parameter for an operating system.
+    info                          Show an OS.
+    list                          List all operating systems.
+    remove-architecture           Disassociate a resource
+    remove-config-template        Disassociate a resource
+    remove-ptable                 Disassociate a resource
+    set-default-template
+    set-parameter                 Create or update parameter for an
+                                  operating system.
+    update                        Update an OS.
 """
 
 from robottelo.cli.base import Base
@@ -49,12 +51,12 @@ class OperatingSys(Base):
         return result
 
     @classmethod
-    def add_configtemplate(cls, options=None):
+    def add_config_template(cls, options=None):
         """
         Adds existing template to OS.
         """
 
-        cls.command_sub = "add-configtemplate "
+        cls.command_sub = "add-config-template "
 
         result = cls.execute(cls._construct_command(options))
 
@@ -85,12 +87,12 @@ class OperatingSys(Base):
         return result
 
     @classmethod
-    def remove_configtemplate(cls, options=None):
+    def remove_config_template(cls, options=None):
         """
         Removes template from OS.
         """
 
-        cls.command_sub = "remove-configtemplate"
+        cls.command_sub = "remove-config-template"
 
         result = cls.execute(cls._construct_command(options))
 

--- a/tests/foreman/cli/test_os.py
+++ b/tests/foreman/cli/test_os.py
@@ -383,7 +383,7 @@ class TestOperatingSystem(BaseCLI):
 
         new_obj = make_os()
         os_name = new_obj['name'].split(' ')
-        result = OperatingSys.add_configtemplate(
+        result = OperatingSys.add_config_template(
             {'id': new_obj['id'],
              'name': os_name[0],
              'config-template': conf_obj['name']})


### PR DESCRIPTION
Had to change the subcommands for adding and removing a configuration
template to an operating system:
- add-configtemplate => add-config-template
- remove-configtemplate => remove-config-template

Also renamed the action methods and places where these were being called
accordingly:
- def add_configtemplate => add_config_template
- def remove_configtemplate => remove_config_template

Failed test now passes:

``` bash
$ nosetests -c robottelo.properties
tests/foreman/cli/test_os.py:TestOperatingSystem.test_add_configtemplate
@test: Add configtemplate to os ... ok

----------------------------------------------------------------------
XML: foreman-results.xml
----------------------------------------------------------------------
Ran 1 test in 84.473s

OK
```
