### PR TITLE
Fixed failing CLI Organization tests.

### DIFF
--- a/robottelo/cli/base.py
+++ b/robottelo/cli/base.py
@@ -249,7 +249,7 @@ class Base(object):
         return result
 
     @classmethod
-    def list(cls, options=None):
+    def list(cls, options=None, per_page=True):
         """
         List information.
         @param options: ID (sometimes name works as well) to retrieve info.
@@ -260,8 +260,8 @@ class Base(object):
         if options is None:
             options = {}
 
-        if 'per-page' not in options:
-            options['per-page'] = 10000
+        if 'per-page' not in options and per_page:
+            options[u'per-page'] = 10000
 
         if cls.command_requires_org and 'organization-id' not in options:
             raise Exception(

--- a/robottelo/cli/lifecycleenvironment.py
+++ b/robottelo/cli/lifecycleenvironment.py
@@ -27,3 +27,10 @@ class LifecycleEnvironment(Base):
 
     command_base = "lifecycle-environment"
     command_requires_org = True
+
+    @classmethod
+    def list(cls, options=None, per_page=False):
+        result = super(LifecycleEnvironment, cls).list(
+            options, per_page=per_page)
+
+        return result

--- a/tests/foreman/cli/test_org.py
+++ b/tests/foreman/cli/test_org.py
@@ -704,7 +704,7 @@ class TestOrg(BaseCLI):
         # Can we list the new environment?
         environment = LifecycleEnvironment.list({
             'name': env_result['name'],
-            'oraganization-id': new_obj['label'],
+            'organization-id': new_obj['label'],
         })
         # Result is a list of one item
         new_env = environment.stdout[0]
@@ -748,9 +748,9 @@ class TestOrg(BaseCLI):
 
         # Can we list the new environment?
         environment = LifecycleEnvironment.list(
-            new_obj['label'],
             {
-                'name': env_result['name']
+                'name': env_result['name'],
+                'organization-id': new_obj['label'],
             })
         self.assertEqual(
             environment.return_code, 0, "Could not fetch list of environments")


### PR DESCRIPTION
There were two CLI Organization tests that were failing for a couple of
reasons.

The tests were adding or removing a lifecycle environment to an
organization. Some of the assertions were calling Lifecycle.list to make
sure that the right number of environments were present, but contrary to
most resources, Lifecycle does not take a per-page argument.

Therefore, the List method in Base.py for CLI now takes an optional
per_page argument with a default of True.

LifecycleEnvironment overrides this list method, passing per_page=False
by default.

There was also a typo in one of the tests where 'organization' was
spelled 'oraganization'.

Finally, one of the LifecycleEnvironment.list calls was passing the
organization-id outside the expected options dictionary.

The two failing tests are now passing.

``` bash
$ nosetests -c robottelo.properties tests/foreman/cli/test_org.py:TestOrg.test_add_environment tests/foreman/cli/test_org.py:TestOrg.test_remove_environment

@Test: Check if an environment can be added to an Org ... ok
@Test: Check if an Environment can be removed from an Org ... ok

----------------------------------------------------------------------
XML: foreman-results.xml
----------------------------------------------------------------------
Ran 2 tests in 53.412s

OK
```
