### PR TITLE
Override DDT data decorator

### DIFF
--- a/robottelo.properties.sample
+++ b/robottelo.properties.sample
@@ -8,6 +8,7 @@ server.ssh.username=root
 project=foreman
 locale=en_US
 remote=0
+smoke=0
 
 [foreman]
 admin.username=admin

--- a/robottelo/cli/metatest/__init__.py
+++ b/robottelo/cli/metatest/__init__.py
@@ -7,7 +7,9 @@ import itertools
 import template_methods
 import types
 
-from ddt import data, ddt
+from ddt import ddt
+
+from robottelo.common.decorators import data
 
 
 # Possible permutations of CRUD tests:

--- a/robottelo/common/decorators.py
+++ b/robottelo/common/decorators.py
@@ -7,6 +7,7 @@ Implements various decorators
 
 import bugzilla
 import logging
+import random
 import requests
 
 import sys
@@ -16,6 +17,7 @@ else:
     import unittest2 as unittest
 
 
+from ddt import data as ddt_data
 from robottelo.common import conf
 from robottelo.common.constants import NOT_IMPLEMENTED
 from xml.parsers.expat import ExpatError
@@ -30,6 +32,20 @@ REDMINE_URL = 'http://projects.theforeman.org'
 logging.getLogger('bugzilla').setLevel(logging.WARNING)
 logging.getLogger(
     'requests.packages.urllib3.connectionpool').setLevel(logging.WARNING)
+
+
+def data(*values):
+    """
+    Overrides ddt.data decorator to return only one value when doing smoke
+    tests
+    """
+    def wrapper(func):
+        smoke = conf.properties.get('main.smoke', '0') == '1'
+        if smoke:
+            return ddt_data(random.choice(values))(func)
+        else:
+            return ddt_data(*values)(func)
+    return wrapper
 
 
 def stubbed(func):

--- a/tests/foreman/api/test_activationkey.py
+++ b/tests/foreman/api/test_activationkey.py
@@ -1,9 +1,9 @@
 # -*- encoding: utf-8 -*-
 # vim: ts=4 sw=4 expandtab ai
 
-from ddt import data, ddt
+from ddt import ddt
 from robottelo.api.apicrud import ApiCrud
-from robottelo.common.decorators import redminebug
+from robottelo.common.decorators import data, redminebug
 from robottelo.records.activation_key import ActivationKey
 from robottelo.records.system_group import SystemGroupDefOrg
 from tests.foreman.api.baseapi import BaseAPI

--- a/tests/foreman/api/test_computeresource.py
+++ b/tests/foreman/api/test_computeresource.py
@@ -7,8 +7,9 @@ if sys.hexversion >= 0x2070000:
 else:
     import unittest2 as unittest
 
-from ddt import data, ddt
+from ddt import ddt
 from robottelo.common.constants import NOT_IMPLEMENTED
+from robottelo.common.decorators import data
 from tests.foreman.api.baseapi import BaseAPI
 
 

--- a/tests/foreman/api/test_configtemplate.py
+++ b/tests/foreman/api/test_configtemplate.py
@@ -7,8 +7,9 @@ if sys.hexversion >= 0x2070000:
 else:
     import unittest2 as unittest
 
-from ddt import data, ddt
+from ddt import ddt
 from robottelo.common.constants import NOT_IMPLEMENTED
+from robottelo.common.decorators import data
 from tests.foreman.api.baseapi import BaseAPI
 
 

--- a/tests/foreman/api/test_domain.py
+++ b/tests/foreman/api/test_domain.py
@@ -7,9 +7,9 @@ if sys.hexversion >= 0x2070000:
 else:
     import unittest2 as unittest
 
-from ddt import data, ddt
+from ddt import ddt
 from robottelo.common.constants import NOT_IMPLEMENTED
-from robottelo.common.decorators import redminebug
+from robottelo.common.decorators import data, redminebug
 from tests.foreman.api.baseapi import BaseAPI
 
 

--- a/tests/foreman/api/test_environments.py
+++ b/tests/foreman/api/test_environments.py
@@ -7,9 +7,10 @@ if sys.hexversion >= 0x2070000:
 else:
     import unittest2 as unittest
 
-from ddt import data, ddt
+from ddt import ddt
 from robottelo.api.apicrud import ApiCrud, ApiException
 from robottelo.common.constants import NOT_IMPLEMENTED
+from robottelo.common.decorators import data
 from robottelo.common.helpers import generate_string
 from robottelo.records.environment import Environment
 from tests.foreman.api.baseapi import BaseAPI

--- a/tests/foreman/api/test_hostgroup.py
+++ b/tests/foreman/api/test_hostgroup.py
@@ -8,8 +8,9 @@ else:
     import unittest2 as unittest
 
 
-from ddt import data, ddt
+from ddt import ddt
 from robottelo.common.constants import NOT_IMPLEMENTED
+from robottelo.common.decorators import data
 from tests.foreman.api.baseapi import BaseAPI
 
 

--- a/tests/foreman/api/test_medium.py
+++ b/tests/foreman/api/test_medium.py
@@ -7,8 +7,9 @@ if sys.hexversion >= 0x2070000:
 else:
     import unittest2 as unittest
 
-from ddt import data, ddt
+from ddt import ddt
 from robottelo.common.constants import NOT_IMPLEMENTED
+from robottelo.common.decorators import data
 from tests.foreman.api.baseapi import BaseAPI
 
 

--- a/tests/foreman/api/test_org.py
+++ b/tests/foreman/api/test_org.py
@@ -7,10 +7,10 @@ if sys.hexversion >= 0x2070000:
 else:
     import unittest2 as unittest
 
-from ddt import data, ddt
+from ddt import ddt
 from robottelo.api.apicrud import ApiCrud, ApiException
 from robottelo.common.constants import NOT_IMPLEMENTED
-from robottelo.common.decorators import bzbug
+from robottelo.common.decorators import data, bzbug
 from robottelo.records.organization import Organization
 from robottelo.common.records.base import NoEnum
 from robottelo.common.records.fields import BasicPositiveField

--- a/tests/foreman/api/test_product.py
+++ b/tests/foreman/api/test_product.py
@@ -1,8 +1,9 @@
 # -*- encoding: utf-8 -*-
 # vim: ts=4 sw=4 expandtab ai
 
-from ddt import data, ddt
+from ddt import ddt
 from robottelo.api.apicrud import ApiCrud
+from robottelo.common.decorators import data
 from robottelo.records.product import CustomProduct
 from tests.foreman.api.baseapi import BaseAPI
 

--- a/tests/foreman/api/test_repository.py
+++ b/tests/foreman/api/test_repository.py
@@ -1,8 +1,9 @@
 # -*- encoding: utf-8 -*-
 # vim: ts=4 sw=4 expandtab ai
 
-from ddt import data, ddt
+from ddt import ddt
 from robottelo.api.apicrud import ApiCrud
+from robottelo.common.decorators import data
 from robottelo.records.repository import CustomRepository
 from tests.foreman.api.baseapi import BaseAPI
 

--- a/tests/foreman/api/test_smartproxy.py
+++ b/tests/foreman/api/test_smartproxy.py
@@ -7,8 +7,9 @@ if sys.hexversion >= 0x2070000:
 else:
     import unittest2 as unittest
 
-from ddt import data, ddt
+from ddt import ddt
 from robottelo.common.constants import NOT_IMPLEMENTED
+from robottelo.common.decorators import data
 from tests.foreman.api.baseapi import BaseAPI
 
 

--- a/tests/foreman/api/test_subnet.py
+++ b/tests/foreman/api/test_subnet.py
@@ -8,8 +8,9 @@ else:
     import unittest2 as unittest
 
 
-from ddt import data, ddt
+from ddt import ddt
 from robottelo.common.constants import NOT_IMPLEMENTED
+from robottelo.common.decorators import data
 from tests.foreman.api.baseapi import BaseAPI
 
 

--- a/tests/foreman/api/test_user.py
+++ b/tests/foreman/api/test_user.py
@@ -1,9 +1,9 @@
 # -*- encoding: utf-8 -*-
 # vim: ts=4 sw=4 expandtab ai
 
-from ddt import data, ddt
+from ddt import ddt
 from robottelo.api.apicrud import ApiCrud
-from robottelo.common.decorators import redminebug
+from robottelo.common.decorators import data, redminebug
 from robottelo.records.user import User
 from tests.foreman.api.baseapi import BaseAPI
 

--- a/tests/foreman/cli/test_computeresource.py
+++ b/tests/foreman/cli/test_computeresource.py
@@ -16,10 +16,10 @@ Subcommands:
     delete                        Delete a compute resource.
     image                         View and manage compute resource's images
 """
-from ddt import data
 from ddt import ddt
 from robottelo.cli.computeresource import ComputeResource
 from robottelo.common import conf
+from robottelo.common.decorators import data
 from robottelo.common.helpers import generate_string
 from robottelo.cli.factory import make_compute_resource
 from robottelo.common.constants import FOREMAN_PROVIDERS

--- a/tests/foreman/cli/test_contentviews.py
+++ b/tests/foreman/cli/test_contentviews.py
@@ -5,16 +5,17 @@
 Test class for Host/System Unification
 Feature details: https://fedorahosted.org/katello/wiki/ContentViewCLI
 """
-from robottelo.common.constants import NOT_IMPLEMENTED
-from robottelo.common.helpers import generate_string
-from robottelo.cli.contentview import ContentView
-from robottelo.cli.org import Org
-from robottelo.cli.factory import make_org, make_repository, make_product
-from robottelo.cli.factory import make_content_view
-from robottelo.cli.repository import Repository
-from ddt import data, ddt
 import unittest
 
+from ddt import ddt
+from robottelo.cli.contentview import ContentView
+from robottelo.cli.factory import (
+    make_content_view, make_org, make_repository, make_product)
+from robottelo.cli.org import Org
+from robottelo.cli.repository import Repository
+from robottelo.common.constants import NOT_IMPLEMENTED
+from robottelo.common.decorators import data
+from robottelo.common.helpers import generate_string
 from tests.foreman.cli.basecli import BaseCLI
 
 

--- a/tests/foreman/cli/test_fact.py
+++ b/tests/foreman/cli/test_fact.py
@@ -5,11 +5,11 @@
 Test class for Fact  CLI
 """
 
-from ddt import data
 from ddt import ddt
-from robottelo.cli.fact import Fact
-from robottelo.common.helpers import generate_string
 from nose.plugins.attrib import attr
+from robottelo.cli.fact import Fact
+from robottelo.common.decorators import data
+from robottelo.common.helpers import generate_string
 from tests.foreman.cli.basecli import BaseCLI
 
 import sys

--- a/tests/foreman/cli/test_gpgkey.py
+++ b/tests/foreman/cli/test_gpgkey.py
@@ -5,13 +5,13 @@
 Test class for GPG Key CLI
 """
 
-from ddt import data, ddt
+from ddt import ddt
 from robottelo.cli.factory import make_gpg_key, make_org
 from robottelo.cli.gpgkey import GPGKey
 from robottelo.cli.org import Org
 from robottelo.common import ssh
 from robottelo.common.constants import NOT_IMPLEMENTED, VALID_GPG_KEY_FILE
-from robottelo.common.decorators import redminebug
+from robottelo.common.decorators import data, redminebug
 from robottelo.common.helpers import (generate_name, generate_string,
                                       get_data_file)
 from tempfile import mkstemp

--- a/tests/foreman/cli/test_lifecycleenvironment.py
+++ b/tests/foreman/cli/test_lifecycleenvironment.py
@@ -5,10 +5,10 @@
 Test class for Host CLI
 """
 
-from ddt import data, ddt
+from ddt import ddt
 from robottelo.cli.factory import make_lifecycle_environment, make_org
 from robottelo.cli.lifecycleenvironment import LifecycleEnvironment
-from robottelo.common.decorators import bzbug
+from robottelo.common.decorators import data, bzbug
 from robottelo.common.helpers import generate_string
 from tests.foreman.cli.basecli import BaseCLI
 

--- a/tests/foreman/cli/test_medium.py
+++ b/tests/foreman/cli/test_medium.py
@@ -5,11 +5,12 @@
 Test class for Medium  CLI
 """
 
-from ddt import ddt, data
-from tests.foreman.cli.basecli import BaseCLI
-from robottelo.common.helpers import generate_string
-from robottelo.cli.medium import Medium
+from ddt import ddt
 from robottelo.cli.factory import make_medium
+from robottelo.cli.medium import Medium
+from robottelo.common.decorators import data
+from robottelo.common.helpers import generate_string
+from tests.foreman.cli.basecli import BaseCLI
 
 
 URL = "http://mirror.fakeos.org/%s/$major.$minor/os/$arch"

--- a/tests/foreman/cli/test_org.py
+++ b/tests/foreman/cli/test_org.py
@@ -5,21 +5,23 @@
 Test class for Organization CLI
 """
 
-from ddt import data, ddt
+import sys
+
+if sys.hexversion >= 0x2070000:
+    import unittest
+else:
+    import unittest2 as unittest
+
+from ddt import ddt
 from robottelo.cli.factory import (
     make_domain, make_hostgroup, make_lifecycle_environment,
     make_medium, make_org, make_proxy, make_subnet, make_template, make_user)
 from robottelo.cli.lifecycleenvironment import LifecycleEnvironment
 from robottelo.cli.org import Org
-from tests.foreman.cli.basecli import BaseCLI
-from robottelo.common.helpers import generate_string
 from robottelo.common.constants import NOT_IMPLEMENTED
-from robottelo.common.decorators import (bzbug, redminebug)
-import sys
-if sys.hexversion >= 0x2070000:
-    import unittest
-else:
-    import unittest2 as unittest
+from robottelo.common.decorators import data, bzbug, redminebug
+from robottelo.common.helpers import generate_string
+from tests.foreman.cli.basecli import BaseCLI
 
 
 def positive_create_data_1():

--- a/tests/foreman/cli/test_os.py
+++ b/tests/foreman/cli/test_os.py
@@ -4,7 +4,7 @@
 """
 Test class for Operating System CLI
 """
-from ddt import data, ddt
+from ddt import ddt
 from robottelo.cli.architecture import Architecture
 from robottelo.cli.operatingsys import OperatingSys
 from robottelo.cli.partitiontable import PartitionTable
@@ -13,7 +13,7 @@ from robottelo.cli.factory import make_architecture
 from robottelo.cli.factory import make_os
 from robottelo.cli.factory import make_partition_table
 from robottelo.cli.factory import make_template
-from robottelo.common.decorators import bzbug, redminebug
+from robottelo.common.decorators import data, bzbug, redminebug
 from robottelo.common.helpers import generate_string
 from tests.foreman.cli.basecli import BaseCLI
 

--- a/tests/foreman/cli/test_product.py
+++ b/tests/foreman/cli/test_product.py
@@ -5,13 +5,13 @@
 Test class for Product CLI
 """
 
-from ddt import data
 from ddt import ddt
 from robottelo.cli.factory import (make_gpg_key, make_org, make_product,
                                    make_sync_plan)
 from robottelo.cli.product import Product
-from robottelo.common.helpers import generate_string
 from nose.plugins.attrib import attr
+from robottelo.common.decorators import data
+from robottelo.common.helpers import generate_string
 from tests.foreman.cli.basecli import BaseCLI
 
 

--- a/tests/foreman/cli/test_repository.py
+++ b/tests/foreman/cli/test_repository.py
@@ -5,12 +5,11 @@
 Test class for Repository CLI
 """
 
-from ddt import data
 from ddt import ddt
 from robottelo.cli.factory import (make_gpg_key, make_org, make_product,
                                    make_repository)
 from robottelo.cli.repository import Repository
-from robottelo.common.decorators import bzbug
+from robottelo.common.decorators import data, bzbug
 from robottelo.common.helpers import generate_string
 from nose.plugins.attrib import attr
 from tests.foreman.cli.basecli import BaseCLI

--- a/tests/foreman/cli/test_subnet.py
+++ b/tests/foreman/cli/test_subnet.py
@@ -5,12 +5,12 @@
 Test class for Subnet CLI
 """
 
-from ddt import data
 from ddt import ddt
+from nose.plugins.attrib import attr
 from robottelo.cli.factory import make_subnet
 from robottelo.cli.subnet import Subnet
+from robottelo.common.decorators import data
 from robottelo.common.helpers import generate_string
-from nose.plugins.attrib import attr
 from tests.foreman.cli.basecli import BaseCLI
 
 

--- a/tests/foreman/cli/test_syncplan.py
+++ b/tests/foreman/cli/test_syncplan.py
@@ -6,13 +6,12 @@ Test class for Product CLI
 """
 
 from datetime import datetime, timedelta
-from ddt import data
 from ddt import ddt
+from nose.plugins.attrib import attr
 from robottelo.cli.factory import make_org, make_sync_plan
 from robottelo.cli.syncplan import SyncPlan
-from robottelo.common.decorators import bzbug
+from robottelo.common.decorators import data, bzbug
 from robottelo.common.helpers import generate_string
-from nose.plugins.attrib import attr
 from tests.foreman.cli.basecli import BaseCLI
 
 

--- a/tests/foreman/cli/test_system.py
+++ b/tests/foreman/cli/test_system.py
@@ -5,13 +5,12 @@
 Test class for System CLI
 """
 
-from ddt import data
 from ddt import ddt
+from nose.plugins.attrib import attr
 from robottelo.cli.factory import make_org, make_system
 from robottelo.cli.system import System
-from robottelo.common.decorators import bzbug
+from robottelo.common.decorators import data, bzbug
 from robottelo.common.helpers import generate_string
-from nose.plugins.attrib import attr
 from tests.foreman.cli.basecli import BaseCLI
 
 

--- a/tests/foreman/cli/test_system_group.py
+++ b/tests/foreman/cli/test_system_group.py
@@ -5,13 +5,12 @@
 Test class for Product CLI
 """
 
-from ddt import data
 from ddt import ddt
+from nose.plugins.attrib import attr
 from robottelo.cli.factory import make_org, make_system_group
 from robottelo.cli.systemgroup import SystemGroup
-from robottelo.common.decorators import bzbug
+from robottelo.common.decorators import data, bzbug
 from robottelo.common.helpers import generate_string
-from nose.plugins.attrib import attr
 from tests.foreman.cli.basecli import BaseCLI
 
 

--- a/tests/foreman/cli/test_user.py
+++ b/tests/foreman/cli/test_user.py
@@ -5,19 +5,20 @@
 Test class for Users CLI
 """
 
-from ddt import data
-from ddt import ddt
-from tests.foreman.cli.basecli import BaseCLI
-from robottelo.common.constants import NOT_IMPLEMENTED
-from robottelo.cli.factory import make_user
-from robottelo.common.helpers import generate_string
-from robottelo.common.decorators import bzbug, redminebug
-from robottelo.cli.user import User as UserObj
 import sys
+
 if sys.hexversion >= 0x2070000:
     import unittest
 else:
     import unittest2 as unittest
+
+from ddt import ddt
+from robottelo.cli.factory import make_user
+from robottelo.cli.user import User as UserObj
+from robottelo.common.constants import NOT_IMPLEMENTED
+from robottelo.common.decorators import data, bzbug, redminebug
+from robottelo.common.helpers import generate_string
+from tests.foreman.cli.basecli import BaseCLI
 
 
 @ddt

--- a/tests/foreman/ui/test_activationkey.py
+++ b/tests/foreman/ui/test_activationkey.py
@@ -10,15 +10,15 @@ if sys.hexversion >= 0x2070000:
 else:
     import unittest2 as unittest
 
-from ddt import data, ddt
+from ddt import ddt
 from nose.plugins.attrib import attr
 from robottelo.common.constants import NOT_IMPLEMENTED, ENVIRONMENT
-from robottelo.common.decorators import bzbug
+from robottelo.common.decorators import data, bzbug
 from robottelo.common.helpers import (generate_string,
                                       valid_names_list, invalid_names_list)
 from robottelo.ui.factory import make_org
-from robottelo.ui.session import Session
 from robottelo.ui.locators import locators, common_locators
+from robottelo.ui.session import Session
 from tests.foreman.ui.baseui import BaseUI
 
 

--- a/tests/foreman/ui/test_contentviews.py
+++ b/tests/foreman/ui/test_contentviews.py
@@ -12,11 +12,11 @@ if sys.hexversion >= 0x2070000:
 else:
     import unittest2 as unittest
 
-from ddt import ddt, data
+from ddt import ddt
 from robottelo.common.constants import NOT_IMPLEMENTED, REPO_TYPE
+from robottelo.common.decorators import data, bzbug
 from robottelo.common.helpers import (generate_string, valid_names_list,
                                       invalid_names_list)
-from robottelo.common.decorators import bzbug
 from robottelo.ui.factory import make_org
 from robottelo.ui.locators import (locators, common_locators)
 from robottelo.ui.session import Session

--- a/tests/foreman/ui/test_gpgkey.py
+++ b/tests/foreman/ui/test_gpgkey.py
@@ -11,11 +11,11 @@ if sys.hexversion >= 0x2070000:
 else:
     import unittest2 as unittest
 
-from ddt import data, ddt
+from ddt import ddt
 from nose.plugins.attrib import attr
 from robottelo.common.constants import (NOT_IMPLEMENTED, VALID_GPG_KEY_FILE,
                                         VALID_GPG_KEY_BETA_FILE)
-from robottelo.common.decorators import bzbug
+from robottelo.common.decorators import data, bzbug
 from robottelo.common.helpers import (generate_string, get_data_file,
                                       read_data_file, valid_names_list,
                                       invalid_names_list, valid_data_list,

--- a/tests/foreman/ui/test_org.py
+++ b/tests/foreman/ui/test_org.py
@@ -10,9 +10,11 @@ if sys.hexversion >= 0x2070000:
     import unittest
 else:
     import unittest2 as unittest
-from ddt import data, ddt
+
+from ddt import ddt
 from nose.plugins.attrib import attr
 from robottelo.common import conf
+from robottelo.common.decorators import data
 from robottelo.common.helpers import (generate_strings_list,
                                       generate_string, generate_ipaddr,
                                       generate_email_address, get_data_file)

--- a/tests/foreman/ui/test_products.py
+++ b/tests/foreman/ui/test_products.py
@@ -2,8 +2,9 @@
 Test class for Products UI
 """
 
-from ddt import data, ddt
+from ddt import ddt
 from nose.plugins.attrib import attr
+from robottelo.common.decorators import data
 from robottelo.common.helpers import generate_string, generate_strings_list
 from robottelo.ui.factory import make_org
 from robottelo.ui.locators import common_locators

--- a/tests/foreman/ui/test_repository.py
+++ b/tests/foreman/ui/test_repository.py
@@ -2,11 +2,11 @@
 Test class for Repository UI
 """
 
-from ddt import data, ddt
+from ddt import ddt
 from nose.plugins.attrib import attr
 from robottelo.common.constants import (VALID_GPG_KEY_FILE,
                                         VALID_GPG_KEY_BETA_FILE)
-from robottelo.common.decorators import bzbug
+from robottelo.common.decorators import data, bzbug
 from robottelo.common.helpers import (generate_string,
                                       generate_strings_list, get_data_file)
 from robottelo.ui.factory import make_org

--- a/tests/foreman/ui/test_sync.py
+++ b/tests/foreman/ui/test_sync.py
@@ -8,8 +8,9 @@ if sys.hexversion >= 0x2070000:
 else:
     import unittest2 as unittest
 
-from ddt import data, ddt
+from ddt import ddt
 from nose.plugins.attrib import attr
+from robottelo.common.decorators import data
 from robottelo.common.helpers import generate_string, generate_strings_list
 from robottelo.ui.factory import make_org
 from robottelo.ui.session import Session

--- a/tests/foreman/ui/test_syncplan.py
+++ b/tests/foreman/ui/test_syncplan.py
@@ -3,10 +3,10 @@ Test class for Sync Plan UI
 """
 
 from datetime import datetime, timedelta
-from ddt import data, ddt
+from ddt import ddt
 from nose.plugins.attrib import attr
 from robottelo.common.constants import SYNC_INTERVAL
-from robottelo.common.decorators import bzbug
+from robottelo.common.decorators import data, bzbug
 from robottelo.common.helpers import generate_string, generate_strings_list
 from robottelo.ui.factory import make_org
 from robottelo.ui.locators import locators, common_locators, tab_locators

--- a/tests/foreman/ui/test_user.py
+++ b/tests/foreman/ui/test_user.py
@@ -11,14 +11,15 @@ if sys.hexversion >= 0x2070000:
 else:
     import unittest2 as unittest
 
-from ddt import data, ddt
+from ddt import ddt
 from nose.plugins.attrib import attr
 from robottelo.common.constants import NOT_IMPLEMENTED, LANGUAGES
+from robottelo.common.decorators import data
 from robottelo.common.helpers import (generate_email_address,
                                       generate_string)
 from robottelo.ui.factory import make_org
-from robottelo.ui.session import Session
 from robottelo.ui.locators import common_locators, tab_locators, locators
+from robottelo.ui.session import Session
 from tests.foreman.ui.baseui import BaseUI
 
 

--- a/tests/robottelo/test_decorators.py
+++ b/tests/robottelo/test_decorators.py
@@ -1,0 +1,31 @@
+import unittest
+
+from ddt import DATA_ATTR
+
+from robottelo.common import conf
+from robottelo.common.decorators import data
+
+
+def function():
+    """Function to test data decorator against"""
+
+
+class DataDecoratorTestCase(unittest.TestCase):
+    def setUp(self):
+        self.test_data = ('one', 'two', 'three')
+
+    def test_data_decorator_smoke(self):
+        conf.properties['main.smoke'] = '1'
+        decorated = data(*self.test_data)(function)
+        data_attr = getattr(decorated, DATA_ATTR)
+
+        self.assertEqual(len(data_attr), 1)
+        self.assertIn(data_attr[0], self.test_data)
+
+    def test_data_decorator_not_smoke(self):
+        conf.properties['main.smoke'] = '0'
+        decorated = data(*self.test_data)(function)
+        data_attr = getattr(decorated, DATA_ATTR)
+
+        self.assertEqual(len(data_attr), len(self.test_data))
+        self.assertEqual(getattr(decorated, DATA_ATTR), self.test_data)


### PR DESCRIPTION
Add main.smoke to sample properties file
Add tests for robottelo.data decorator
Refactor all ddt.data decorator imports to robottelo.data
Organize alphabetically imports for some modules

To run smoke tests just change the main.smoke config to 1 in robottelo.properties file.

When not running smoke tests (main.smoke config is 0) then:

``` shell
$ nosetests --collect-only -q tests/foreman
----------------------------------------------------------------------
Ran 2417 tests in 0.086s

OK
```

When running smoke tests (main.smoke config is 1) then:

``` shell
$ nosetests --collect-only -q tests/foreman
----------------------------------------------------------------------
Ran 921 tests in 0.033s

OK
```

Related to #731
