### PR TITLE
The system command is now content-host.

### DIFF
--- a/robottelo/cli/system.py
+++ b/robottelo/cli/system.py
@@ -26,7 +26,7 @@ class System(Base):
     Manipulates Katello engine's system command.
     """
 
-    command_base = "system"
+    command_base = "content-host"
     command_requires_org = True
 
     @classmethod


### PR DESCRIPTION
Due to the changes introduced by
https://github.com/Katello/hammer-cli-katello/pull/145, the CLI command
`system` has been renamed to `content-host`. This only affects the
CLI.
