### PR TITLE
Minor tweak to Bugzilla test.

### DIFF
--- a/tests/foreman/cli/test_org.py
+++ b/tests/foreman/cli/test_org.py
@@ -290,10 +290,10 @@ class TestOrg(BaseCLI):
         @bz: 1061658
         """
         new_obj = make_org()
-        return_value = Org.delete({'name': new_obj['name']})
+        return_value = Org.delete({'id': new_obj['id']})
         self.assertEqual(return_value.return_code, 0,
                          "Not able to delete organization")
-        self.assertNotEqual(
+        self.assertEqual(
             len(return_value.stderr),
             0,
             "There should not be an exception here"
@@ -302,8 +302,7 @@ class TestOrg(BaseCLI):
         result = Org.info({'id': new_obj['id']})
         self.assertNotEqual(result.return_code, 0, "Org was not deleted")
         self.assertGreater(len(result.stderr), 0,
-                           "There should not be an exception here")
-        self.assertEqual(new_obj['name'], result.stdout['name'])
+                           "There should be an exception here")
 
     @bzbug('1062295')
     def test_bugzilla_1062295_1(self):


### PR DESCRIPTION
We can now close the Bugzilla #1061658:

``` bash
$  nosetests -c robottelo.properties tests/foreman/cli/test_org.py:TestOrg.test_bugzilla_1061658
2014-04-24 12:56:23 - robottelo - INFO - Paramiko instance prepared (and would be reused): 0x109c331d0
2014-04-24 12:56:27 - root - DEBUG - #1076568 NEW        - Katello Bug Bin - Hammer Cli : Org delete  fails
2014-04-24 12:56:28 - root - DEBUG - #1076541 ASSIGNED   - Adam Price - Cannot update organization name via CLI
2014-04-24 12:56:29 - root - DEBUG - #1075163 NEW        - Katello Bug Bin - [RFE] Add --label as a valid argument to hammer organization info command
2014-04-24 12:56:31 - root - DEBUG - #1075156 NEW        - Katello Bug Bin - Cannot use CLI info for organizations by name
2014-04-24 12:56:34 - root - DEBUG - #1076568 NEW        - Katello Bug Bin - Hammer Cli : Org delete  fails
2014-04-24 12:56:34 - root - DEBUG - #1076541 ASSIGNED   - Adam Price - Cannot update organization name via CLI
2014-04-24 12:56:34 - root - DEBUG - #1076541 ASSIGNED   - Adam Price - Cannot update organization name via CLI
2014-04-24 12:56:34 - root - DEBUG - #1076541 ASSIGNED   - Adam Price - Cannot update organization name via CLI
2014-04-24 12:56:34 - robottelo - DEBUG - Running test TestOrg/test_bugzilla_1061658
2014-04-24 12:56:34 - robottelo - DEBUG - >>> LANG=en_US hammer -v -u admin -p changeme  --output csv organization create --name='j7e5oa'
2014-04-24 12:56:39 - robottelo - DEBUG - <<< [u'Message,Id,Name', u'Organization created,403,j7e5oa', u'']
2014-04-24 12:56:39 - robottelo - DEBUG - >>> LANG=en_US hammer -v -u admin -p changeme  organization info --id='403'
2014-04-24 12:56:42 - robottelo - DEBUG - <<< [u'Id:          403', u'Name:        j7e5oa', u'Created at:  2014/04/24 16:56:35', u'Updated at:  2014/04/24 16:56:37', u'Label:       j7e5oa', u'Description:', u'', u'']
2014-04-24 12:56:48 - robottelo - DEBUG - >>> LANG=en_US hammer -v -u admin -p changeme  organization delete --id='403'
2014-04-24 12:56:51 - robottelo - DEBUG - <<< [u'Organization deleted', u'']
2014-04-24 12:56:51 - robottelo - DEBUG - >>> LANG=en_US hammer -v -u admin -p changeme  organization info --id='403'
2014-04-24 12:56:53 - robottelo - DEBUG - <<< [ERROR 2014-04-24 12:56:52 Exception] <NilClass> nil

.
----------------------------------------------------------------------
Ran 1 test in 19.471s

OK
```
