### PR TITLE
Fix go_to_life_cycle_environments navigator method

### DIFF
--- a/robottelo/ui/locators.py
+++ b/robottelo/ui/locators.py
@@ -47,8 +47,7 @@ menu_locators = {
     "menu.life_cycle_environments": (
         By.XPATH,
         ("//div[contains(@style,'static') or contains(@style, 'fixed')]"
-         "//li[contains(@class,'menu_tab_katello')]"
-         "/a[@id='menu_item_environments']")),
+         "//a[@id='menu_item_environments']")),
     "menu.red_hat_subscriptions": (
         By.XPATH,
         ("//div[contains(@style,'static')]"


### PR DESCRIPTION
The UI code have changed, so this PR update the Lifecycle Enviroments locator.
