### PR TITLE
Fix go_to_domains navigator method

### DIFF
--- a/robottelo/ui/locators.py
+++ b/robottelo/ui/locators.py
@@ -177,7 +177,8 @@ menu_locators = {
         "//div[contains(@style,'static')]//a[@id='menu_item_subnets']"),
     "menu.domains": (
         By.XPATH,
-        "//div[contains(@style,'static')]//a[@id='menu_item_domains']"),
+        ("//div[contains(@style,'static') or contains(@style, 'fixed')]"
+         "//a[@id='menu_item_domains']")),
 
     # Administer Menu
     "menu.administer": (


### PR DESCRIPTION
Go to domains method was not working for some tests, added an extra selector to make sure that it works.
