### PR TITLE
Removed Bugzilla decorators from SyncPlan via CLI.

### DIFF
--- a/tests/foreman/cli/test_syncplan.py
+++ b/tests/foreman/cli/test_syncplan.py
@@ -10,7 +10,7 @@ from ddt import ddt
 from nose.plugins.attrib import attr
 from robottelo.cli.factory import make_org, make_sync_plan
 from robottelo.cli.syncplan import SyncPlan
-from robottelo.common.decorators import data, bzbug
+from robottelo.common.decorators import data
 from robottelo.common.helpers import generate_string
 from tests.foreman.cli.basecli import BaseCLI
 


### PR DESCRIPTION
These 2 automated tests are now passing.

``` bash
$ nosetests -c robottelo.properties -m test_positive_update_1 tests/foreman/cli/test_syncplan.py
2014-05-07 15:23:44 - robottelo - INFO - Paramiko instance prepared (and would be reused): 0x10b6cf810
@Test: Check if syncplan description can be updated ... ok
@Test: Check if syncplan description can be updated ... ok
@Test: Check if syncplan description can be updated ... ok
@Test: Check if syncplan description can be updated ... ok
@Test: Check if syncplan description can be updated ... ok
@Test: Check if syncplan description can be updated ... ok

----------------------------------------------------------------------
XML: foreman-results.xml
----------------------------------------------------------------------
Ran 6 tests in 107.009s

OK

$ nosetests -c robottelo.properties -m test_positive_delete_1 tests/foreman/cli/test_syncplan.py
2014-05-07 15:21:15 - robottelo - INFO - Paramiko instance prepared (and would be reused): 0x10fa7c810
@Test: Check if syncplan can be created and deleted ... ok
@Test: Check if syncplan can be created and deleted ... ok
@Test: Check if syncplan can be created and deleted ... ok
@Test: Check if syncplan can be created and deleted ... ok
@Test: Check if syncplan can be created and deleted ... ok
@Test: Check if syncplan can be created and deleted ... ok

----------------------------------------------------------------------
XML: foreman-results.xml
----------------------------------------------------------------------
Ran 6 tests in 104.557s

OK
```
