### PR TITLE
Fix add_version command parameter

### DIFF
--- a/tests/foreman/cli/test_contentviews.py
+++ b/tests/foreman/cli/test_contentviews.py
@@ -303,8 +303,10 @@ class TestContentView(BaseCLI):
         self.assertEqual(len(result.stderr), 0, "No error was expected")
 
         # Associate version to composite CV
-        result = ContentView.add_version({u'id': con_view['id'],
-                                          u'version-id': version1_id})
+        result = ContentView.add_version({
+            u'id': con_view['id'],
+            u'content-view-version-id': version1_id,
+        })
         self.assertEqual(result.return_code, 0,
                          "Repo was not associated to selected CV")
         self.assertEqual(len(result.stderr), 0, "No error was expected")
@@ -868,8 +870,10 @@ class TestContentView(BaseCLI):
         self.assertEqual(len(result.stderr), 0, "No error was expected")
 
         # Associate version to composite CV
-        result = ContentView.add_version({u'id': con_view['id'],
-                                          u'version-id': version1_id})
+        result = ContentView.add_version({
+            u'id': con_view['id'],
+            u'content-view-version-id': version1_id,
+        })
         self.assertEqual(result.return_code, 0,
                          "Repo was not associated to selected CV")
         self.assertEqual(len(result.stderr), 0, "No error was expected")
@@ -1118,8 +1122,10 @@ class TestContentView(BaseCLI):
         self.assertEqual(len(result.stderr), 0, "No error was expected")
 
         # Associate version to composite CV
-        result = ContentView.add_version({u'id': con_view['id'],
-                                          u'version-id': version1_id})
+        result = ContentView.add_version({
+            u'id': con_view['id'],
+            u'content-view-version-id': version1_id,
+        })
         self.assertEqual(result.return_code, 0,
                          "Repo was not associated to selected CV")
         self.assertEqual(len(result.stderr), 0, "No error was expected")


### PR DESCRIPTION
Now hammer content-view add-version is accepting
--content-view-version-id instead of --version-id

This fixes the failures for content views tests from last compose cli job run
