### PR TITLE
Improve cli org deletion tests

### DIFF
--- a/tests/foreman/cli/test_org.py
+++ b/tests/foreman/cli/test_org.py
@@ -281,13 +281,14 @@ class TestOrg(BaseCLI):
 
         self.assertEqual(new_obj['name'], result.stdout['name'])
 
+    @bzbug('1096241')
     @bzbug('1061658')
     def test_bugzilla_1061658(self):
         """
         @Test: Organization delete fails with 500 Server / Candlepin 404 error
         @Feature: Org
         @Assert: Organization is created and deleted
-        @bz: 1061658
+        @bz: 1096241, 1061658
         """
         new_obj = make_org()
         return_value = Org.delete({'id': new_obj['id']})
@@ -881,6 +882,7 @@ class TestOrg(BaseCLI):
     def test_positive_delete_1(self, test_data):
         """
         @test: Create organization with valid values then delete it
+        by ID
         @feature: Organizations
         @assert: organization is deleted
         @bz: 1076568
@@ -896,6 +898,70 @@ class TestOrg(BaseCLI):
         self.assertEqual(new_obj['name'], result.stdout['name'])
 
         return_value = Org.delete({'id': new_obj['name']})
+        self.assertEqual(return_value.return_code, 0, "Deletion failed")
+        self.assertEqual(
+            len(return_value.stderr), 0, "There should not be an error here")
+
+        # Can we find the object?
+        result = Org.info({'id': new_obj['id']})
+        self.assertNotEqual(
+            result.return_code, 0, "Organization should be deleted")
+        self.assertGreater(len(result.stderr), 0,
+                           "There should not be an exception here")
+        self.assertEqual(
+            len(result.stdout), 0, "Output should be blank.")
+
+    @data(*positive_name_desc_label_data())
+    def test_positive_delete_2(self, test_data):
+        """
+        @test: Create organization with valid values then delete it
+        by label
+        @feature: Organizations
+        @assert: organization is deleted
+        """
+
+        new_obj = make_org(test_data)
+
+        # Can we find the new object?
+        result = Org.info({'id': new_obj['id']})
+
+        self.assertEqual(result.return_code, 0)
+        self.assertEqual(len(result.stderr), 0)
+        self.assertEqual(new_obj['name'], result.stdout['name'])
+
+        return_value = Org.delete({'label': new_obj['label']})
+        self.assertEqual(return_value.return_code, 0, "Deletion failed")
+        self.assertEqual(
+            len(return_value.stderr), 0, "There should not be an error here")
+
+        # Can we find the object?
+        result = Org.info({'id': new_obj['id']})
+        self.assertNotEqual(
+            result.return_code, 0, "Organization should be deleted")
+        self.assertGreater(len(result.stderr), 0,
+                           "There should not be an exception here")
+        self.assertEqual(
+            len(result.stdout), 0, "Output should be blank.")
+
+    @data(*positive_name_desc_label_data())
+    def test_positive_delete_3(self, test_data):
+        """
+        @test: Create organization with valid values then delete it
+        by name
+        @feature: Organizations
+        @assert: organization is deleted
+        """
+
+        new_obj = make_org(test_data)
+
+        # Can we find the new object?
+        result = Org.info({'id': new_obj['id']})
+
+        self.assertEqual(result.return_code, 0)
+        self.assertEqual(len(result.stderr), 0)
+        self.assertEqual(new_obj['name'], result.stdout['name'])
+
+        return_value = Org.delete({'name': new_obj['name']})
         self.assertEqual(return_value.return_code, 0, "Deletion failed")
         self.assertEqual(
             len(return_value.stderr), 0, "There should not be an error here")


### PR DESCRIPTION
- Add tests to test if an organization could be deleted by name
  and by label
- Add bzbug decorator due to a regression on organization delete command
