### PR TITLE
Add bzbug decorator to test_delete_template_1 test

### DIFF
--- a/tests/foreman/cli/test_template.py
+++ b/tests/foreman/cli/test_template.py
@@ -7,7 +7,7 @@ Test class for Template CLI
 
 from robottelo.cli.factory import make_template
 from robottelo.cli.template import Template
-from robottelo.common.decorators import redminebug
+from robottelo.common.decorators import bzbug, redminebug
 from robottelo.common.helpers import generate_string
 from tests.foreman.cli.basecli import BaseCLI
 
@@ -65,11 +65,13 @@ class TestTemplate(BaseCLI):
         template_content = Template.dump({'id': new_obj['id']})
         self.assertIn(content, template_content.stdout[0])
 
+    @bzbug('1096333')
     def test_delete_template_1(self):
         """
         @Test: Check if Template can be deleted
         @Feature: Template - Delete
         @Assert: Template is deleted
+        @BZ: 1096333
         """
 
         content = generate_string("alpha", 10)


### PR DESCRIPTION
The hammer template delete command is raising an internal server error, added bzbug to track the related bug.
