### PR TITLE
Removed invalid puppet repo test data

### DIFF
--- a/tests/foreman/cli/test_repository.py
+++ b/tests/foreman/cli/test_repository.py
@@ -286,10 +286,6 @@ class TestRepository(BaseCLI):
          u'content-type': u'yum'},
         {u'url': u'http://omaciel.fedorapeople.org/fakerepo02/',
          u'content-type': u'yum'},
-        {u'url': u'http://omaciel.fedorapeople.org/fakepuppet01/',
-         u'content-type': u'puppet'},
-        {u'url': u'http://omaciel.fedorapeople.org/fakepuppet02/',
-         u'content-type': u'puppet'},
         {u'url': u'http://inecas.fedorapeople.org/fakerepos/zoo3/',
          u'content-type': u'yum'},
     )


### PR DESCRIPTION
To synchronize a puppet repo is necessary a repo with an interface like
Puppet Forge

Have created #822 to track the creation of a private puppet forge
