### PR TITLE
Add bzbug to lifecycle environment related tests

### DIFF
--- a/tests/foreman/cli/test_contenthost.py
+++ b/tests/foreman/cli/test_contenthost.py
@@ -19,6 +19,7 @@ from tests.foreman.cli.basecli import BaseCLI
 
 
 @bzbug('1084722')
+@bzbug('1099655')
 @ddt
 class TestContentHost(BaseCLI):
     """

--- a/tests/foreman/cli/test_contentviews.py
+++ b/tests/foreman/cli/test_contentviews.py
@@ -55,6 +55,7 @@ def negative_create_data():
     )
 
 
+@bzbug('1099655')
 @ddt
 class TestContentView(BaseCLI):
     """

--- a/tests/foreman/cli/test_lifecycleenvironment.py
+++ b/tests/foreman/cli/test_lifecycleenvironment.py
@@ -61,12 +61,13 @@ class TestLifeCycleEnvironment(BaseCLI):
         )
 
     @bzbug('1077333')
+    @bzbug('1099655')
     def test_bugzilla_1077333(self):
         """
         @Test: Search lifecycle environment via its name containing UTF-8 chars
         @Feature: Lifecycle Environment
         @Assert: Can get info for lifecycle by its name
-        @BZ: 1077333
+        @BZ: 1077333, 1099655
         """
 
         payload = {
@@ -102,6 +103,7 @@ class TestLifeCycleEnvironment(BaseCLI):
 
     # CRUD
 
+    @bzbug('1099655')
     @data(
         {'name': generate_string("alpha", 15)},
         {'name': generate_string("alphanumeric", 15)},
@@ -115,6 +117,7 @@ class TestLifeCycleEnvironment(BaseCLI):
         @Test: Create lifecycle environment with valid name, prior to Library
         @Feature: Lifecycle Environment
         @Assert: Lifecycle environment is created with Library as prior
+        @BZ: 1099655
         """
 
         payload = {
@@ -148,6 +151,7 @@ class TestLifeCycleEnvironment(BaseCLI):
             "Could not find lifecycle environment \'%s\'" % new_obj['name']
         )
 
+    @bzbug('1099655')
     @data(
         {'name': generate_string("alpha", 15)},
         {'name': generate_string("alphanumeric", 15)},
@@ -162,6 +166,7 @@ class TestLifeCycleEnvironment(BaseCLI):
         prior to Library
         @Feature: Lifecycle Environment
         @Assert: Lifecycle environment is created with Library as prior
+        @BZ: 1099655
         """
 
         payload = {
@@ -201,6 +206,7 @@ class TestLifeCycleEnvironment(BaseCLI):
             "Descriptions don't match"
         )
 
+    @bzbug('1099655')
     @data(
         {'name': generate_string("alpha", 15)},
         {'name': generate_string("alphanumeric", 15)},
@@ -214,6 +220,7 @@ class TestLifeCycleEnvironment(BaseCLI):
         @Test: Create lifecycle environment with valid name, prior to Library
         @Feature: Lifecycle Environment
         @Assert: Lifecycle environment is deleted
+        @BZ: 1099655
         """
 
         payload = {
@@ -272,6 +279,7 @@ class TestLifeCycleEnvironment(BaseCLI):
         )
 
     @bzbug('1095937')
+    @bzbug('1099655')
     @data(
         {'name': generate_string("alpha", 15)},
         {'name': generate_string("alphanumeric", 15)},
@@ -285,7 +293,7 @@ class TestLifeCycleEnvironment(BaseCLI):
         @Test: Create lifecycle environment then update its name
         @Feature: Lifecycle Environment
         @Assert: Lifecycle environment name is updated
-        @BZ: 1095937
+        @BZ: 1095937, 1099655
         """
 
         payload = {
@@ -337,6 +345,7 @@ class TestLifeCycleEnvironment(BaseCLI):
         )
 
     @bzbug('1095937')
+    @bzbug('1099655')
     @data(
         {'description': generate_string("alpha", 15)},
         {'description': generate_string("alphanumeric", 15)},
@@ -350,7 +359,7 @@ class TestLifeCycleEnvironment(BaseCLI):
         @Test: Create lifecycle environment then update its description
         @Feature: Lifecycle Environment
         @Assert: Lifecycle environment description is updated
-        @BZ: 1095937
+        @BZ: 1095937, 1099655
         """
 
         payload = {

--- a/tests/foreman/cli/test_org.py
+++ b/tests/foreman/cli/test_org.py
@@ -689,11 +689,13 @@ class TestOrg(BaseCLI):
         """
         pass
 
+    @bzbug('1099655')
     def test_add_environment(self):
         """
         @Test: Check if an environment can be added to an Org
         @Feature: Org - Environment
         @Assert: Environment is added to the org
+        @BZ: 1099655
         """
 
         new_obj = make_org()
@@ -713,11 +715,13 @@ class TestOrg(BaseCLI):
             environment.return_code, 0, "Could not fetch list of environments")
         self.assertEqual(new_env['name'], env_result['name'])
 
+    @bzbug('1099655')
     def test_remove_environment(self):
         """
         @Test: Check if an Environment can be removed from an Org
         @Feature: Org - Environment
         @Assert: Environment is removed from the org
+        @BZ: 1099655
         """
 
         new_obj = make_org()

--- a/tests/foreman/cli/test_subscription.py
+++ b/tests/foreman/cli/test_subscription.py
@@ -6,11 +6,13 @@ from ddt import ddt
 from robottelo.cli.subscription import Subscription
 from robottelo.cli.factory import (
     make_org, make_lifecycle_environment)
+from robottelo.common.decorators import bzbug
 from robottelo.common.manifests import manifest
 from robottelo.common.ssh import upload_file
 from tests.foreman.cli.basecli import BaseCLI
 
 
+@bzbug('1099655')
 @ddt
 class TestSubscription(BaseCLI):
     """


### PR DESCRIPTION
This is due not being able to create a lifecycle environment via CLI
