### PR TITLE
Finish changing org label to numeric ID for API

### DIFF
--- a/robottelo/records/content_view_definition.py
+++ b/robottelo/records/content_view_definition.py
@@ -13,13 +13,13 @@ from robottelo.api.apicrud import Task
 
 
 class ContentViewDefinitionApi(ApiCrud):
-    """Content view api implementation utilizes :organization.label,
+    """Content view api implementation utilizes :organization.id,
     what means, that create requires initialize organization object.
     """
-    api_path = "/katello/api/v2/organizations/:organization.label/content_views/"  # noqa
-    api_path_get = "/katello/api/v2/content_views/"  # noqa
-    api_path_put = "/katello/api/v2/content_views/"  # noqa
-    api_path_delete = "/katello/api/v2/content_views/"  # noqa
+    api_path = "/katello/api/v2/organizations/:organization.id/content_views/"
+    api_path_get = "/katello/api/v2/content_views/"
+    api_path_put = "/katello/api/v2/content_views/"
+    api_path_delete = "/katello/api/v2/content_views/"
     api_json_key = u"content_view"
     create_fields = ["name", "description", "organization_id", "composite"]
 

--- a/robottelo/records/environment.py
+++ b/robottelo/records/environment.py
@@ -13,8 +13,7 @@ from robottelo.common import records
 class EnvironmentKatelloApi(ApiCrud):
     """ Implementation of api for  foreman environments
     """
-    api_path = ("/katello/api/v2/organizations/:organization.label/"
-                "environments/")
+    api_path = "/katello/api/v2/organizations/:organization.id/environments/"
     api_json_key = u"environment"
     create_fields = ["name", "organization_id", "label", "prior"]
 


### PR DESCRIPTION
Still having 3 errors when running API content views tests due to a bug that is overriding related organization object.
