### PR TITLE
Fixes host-collection CLI test.

### DIFF
--- a/tests/foreman/cli/test_host_collection.py
+++ b/tests/foreman/cli/test_host_collection.py
@@ -111,7 +111,7 @@ class TestHostCollection(BaseCLI):
             "Descriptions don't match"
         )
 
-    @data([-1, 0, 1, 5, 10, 20])
+    @data(*[-1, 1, 5, 10, 20])
     @attr('cli', 'hostcollection')
     def test_positive_create_3(self, test_data):
         """
@@ -125,8 +125,9 @@ class TestHostCollection(BaseCLI):
         # Assert that limit matches data passed
         self.assertEqual(
             new_host_col['max-content-hosts'],
-            test_data['max-content-hosts'],
-            "Limits don't match"
+            str(test_data),
+            ("Limits don't match '%s' != '%s'" %
+             (new_host_col['max-content-hosts'], str(test_data)))
         )
 
     @data(


### PR DESCRIPTION
Latest Jenkins run showed that the `test_create_positive_3` test was
failing because instead of passing the values from a list one by one,
the entire list was being passed instead.

Before:

``` bash
2014-05-22 11:05:33 - robottelo - DEBUG - Running test TestHostCollection/test_positive_create_3_1___1__0__1__5__10__20_
2014-05-22 11:05:33 - robottelo - DEBUG - >>> LANG=en_US hammer -v -u admin -p changeme  --output csv host-collection create --max-content-hosts='[-1, 0, 1, 5, 10, 20]' --organization-id='41' --name='AuGNbVgnooldVoP'
2014-05-22 11:05:37 - robottelo - DEBUG - <<< [ERROR 2014-05-22 11:05:35 API] 422 Unprocessable Entity
{
    "displayMessage" => "Validation failed: Content host limit must be a positive integer value., Content host limit may not be set to 0.",
            "errors" => {
        "content_host_limit" => [
            [0] "must be a positive integer value.",
            [1] "may not be set to 0."
        ]
    }
}
```

Now

``` bash
nosetests -c robottelo.properties -m test_positive_create_3 tests/foreman/cli/test_host_collection.py
2014-05-22 13:50:04 - robottelo - INFO - Paramiko instance prepared (and would be reused): 0x10647a690
2014-05-22 13:50:07 - root - DEBUG - #1084240 NEW        - Katello Bug Bin - hammer system-group is missing a delete and update subcommand
2014-05-22 13:50:07 - root - DEBUG - #1084240 NEW        - Katello Bug Bin - hammer system-group is missing a delete and update subcommand
2014-05-22 13:50:07 - root - DEBUG - #1084240 NEW        - Katello Bug Bin - hammer system-group is missing a delete and update subcommand
2014-05-22 13:50:07 - robottelo - DEBUG - Running test TestHostCollection/test_positive_create_3_1_5
2014-05-22 13:50:07 - robottelo - DEBUG - >>> LANG=en_US hammer -v -u admin -p changeme  --output csv organization create --name='zcvxwjk2'
2014-05-22 13:50:13 - robottelo - DEBUG - <<< [u'Message,Id,Name', u'Organization created,88,zcvxwjk2', u'']
2014-05-22 13:50:13 - robottelo - DEBUG - >>> LANG=en_US hammer -v -u admin -p changeme  organization info --id='88'
2014-05-22 13:50:18 - robottelo - DEBUG - <<< [u'Id:                     88', u'Name:                   zcvxwjk2', u'Created at:             2014/05/22 17:50:10', u'Updated at:             2014/05/22 17:50:11', u'Label:                  zcvxwjk2', u'Description:            ', u'Red Hat Repository URL: https://cdn.redhat.com', u'', u'']
2014-05-22 13:50:24 - robottelo - DEBUG - >>> LANG=en_US hammer -v -u admin -p changeme  --output csv host-collection create --max-content-hosts='5' --organization-id='88' --name='xohQZnEATzhlUQv'
2014-05-22 13:50:28 - robottelo - DEBUG - <<< [u'Message,Id,Name', u'Host collection created,8,xohQZnEATzhlUQv', u'']
2014-05-22 13:50:28 - robottelo - DEBUG - >>> LANG=en_US hammer -v -u admin -p changeme  host-collection info --id='8'
2014-05-22 13:50:32 - robottelo - DEBUG - <<< [u'ID:                  8', u'Name:                xohQZnEATzhlUQv', u'Limit:               5', u'Description:         ', u'Total Content Hosts: 0', u'Max Content Hosts:   5', u'', u'']
2014-05-22 13:50:38 - robottelo - DEBUG - >>> LANG=en_US hammer -v -u admin -p changeme  host-collection info --id='8'
2014-05-22 13:50:42 - robottelo - DEBUG - <<< [u'ID:                  8', u'Name:                xohQZnEATzhlUQv', u'Limit:               5', u'Description:         ', u'Total Content Hosts: 0', u'Max Content Hosts:   5', u'', u'']
.
----------------------------------------------------------------------
Ran 1 test in 35.506s

OK
```
