### PR TITLE
Unblocking CLI tests for content-host command.

### DIFF
--- a/tests/foreman/cli/test_contenthost.py
+++ b/tests/foreman/cli/test_contenthost.py
@@ -13,13 +13,11 @@ from robottelo.cli.factory import (
 from robottelo.cli.contenthost import ContentHost
 from robottelo.cli.contentview import ContentView
 from robottelo.cli.lifecycleenvironment import LifecycleEnvironment
-from robottelo.common.decorators import data, bzbug
+from robottelo.common.decorators import data
 from robottelo.common.helpers import generate_string
 from tests.foreman.cli.basecli import BaseCLI
 
 
-@bzbug('1084722')
-@bzbug('1099655')
 @ddt
 class TestContentHost(BaseCLI):
     """


### PR DESCRIPTION
The two Bugzilla issues that were blocking all of our CLI tests for the
content-host command, namely BZs #1099655 and #1084722, have been
verified, so I have removed the `bzbug` decorators and ran the
tests (smoke=1).

``` bash
$ nosetests -c robottelo.properties tests/foreman/cli/test_contenthost.py

Ran 6 tests in 244.344s

OK
```
