### PR TITLE
Make sure that max-content-host data is unpacked.

### DIFF
--- a/tests/foreman/cli/test_host_collection.py
+++ b/tests/foreman/cli/test_host_collection.py
@@ -111,7 +111,7 @@ class TestHostCollection(BaseCLI):
             "Descriptions don't match"
         )
 
-    @data(*[-1, 1, 5, 10, 20])
+    @data(1, 3, 5, 10, 20)
     @attr('cli', 'hostcollection')
     def test_positive_create_3(self, test_data):
         """
@@ -290,7 +290,7 @@ class TestHostCollection(BaseCLI):
         )
 
     @bzbug('1084240')
-    @data([3, 6, 9, 12, 15, 17, 19])
+    @data(3, 6, 9, 12, 15, 17, 19)
     @attr('cli', 'hostcollection')
     def test_positive_update_3(self, test_data):
         """


### PR DESCRIPTION
CLI test for host collection had been failing for a while because the
value passed from @data to represent max-content-host was not being
'unpacked' correctly, and therefore the entire list was being used. As
per @elyezer advice, I also switched from using a List to a Tuple. This
should fix the following error with latest code build:

``` bash
2014-05-29 14:29:19 - robottelo - DEBUG - Running test TestHostCollection/test_positive_update_3_1__3__6__9__12__15__17__19_
2014-05-29 14:29:19 - robottelo - DEBUG - >>> LANG=en_US hammer -v -u admin -p changeme  --output csv host-collection create --organization-id='48' --name='ieiCYVtUtrFSJrl'
2014-05-29 14:29:24 - robottelo - DEBUG - <<< [u'Message,Id,Name', u'Host collection created,7,ieiCYVtUtrFSJrl', u'']
2014-05-29 14:29:24 - robottelo - DEBUG - >>> LANG=en_US hammer -v -u admin -p changeme  host-collection info --id='7'
2014-05-29 14:29:28 - robottelo - DEBUG - <<< [u'ID:                  7', u'Name:                ieiCYVtUtrFSJrl', u'Limit:               -1', u'Description:         ', u'Total Content Hosts: 0', u'Max Content Hosts:   -1', u'', u'']
2014-05-29 14:29:33 - robottelo - DEBUG - >>> LANG=en_US hammer -v -u admin -p changeme  host-collection info --id='7'
2014-05-29 14:29:37 - robottelo - DEBUG - <<< [u'ID:                  7', u'Name:                ieiCYVtUtrFSJrl', u'Limit:               -1', u'Description:         ', u'Total Content Hosts: 0', u'Max Content Hosts:   -1', u'', u'']
2014-05-29 14:29:37 - robottelo - DEBUG - >>> LANG=en_US hammer -v -u admin -p changeme  --output csv host-collection update --max-content-hosts='[3, 6, 9, 12, 15, 17, 19]' --id='7' --organization-id='48'
2014-05-29 14:29:42 - robottelo - DEBUG - <<< [ERROR 2014-05-29 14:29:40 API] 422 Unprocessable Entity
{
            "errors" => {
        "content_host_limit" => [
            [0] "must be a positive integer value.",
            [1] "may not be set to 0."
        ]
    },
    "displayMessage" => "Validation failed: Content host limit must be a positive integer value., Content host limit may not be set to 0."
}
[ERROR 2014-05-29 14:29:40 Exception] Validation failed: Content host limit must be a positive integer value., Content host limit may not be set to 0.
Could not update the the host collection:
  Validation failed: Content host limit must be a positive integer value., Content host limit may not be set to 0.
[ERROR 2014-05-29 14:29:40 Exception]

RestClient::UnprocessableEntity (422 Unprocessable Entity):
    /usr/lib/ruby/gems/1.8/gems/rest-client-1.6.7/lib/restclient/abstract_response.rb:48:in `return!'
    /usr/lib/ruby/gems/1.8/gems/rest-client-1.6.7/lib/restclient/request.rb:230:in `process_result'
    /usr/lib/ruby/gems/1.8/gems/rest-client-1.6.7/lib/restclient/request.rb:178:in `transmit'
    /usr/lib/ruby/1.8/net/http.rb:543:in `start'
    /usr/lib/ruby/gems/1.8/gems/rest-client-1.6.7/lib/restclient/request.rb:172:in `transmit'
    /usr/lib/ruby/gems/1.8/gems/rest-client-1.6.7/lib/restclient/request.rb:64:in `execute'
    /usr/lib/ruby/gems/1.8/gems/rest-client-1.6.7/lib/restclient/request.rb:33:in `execute'
    /usr/lib/ruby/gems/1.8/gems/rest-client-1.6.7/lib/restclient/resource.rb:80:in `put'
    /usr/lib/ruby/gems/1.8/gems/apipie-bindings-0.0.8/lib/apipie_bindings/api.rb:195:in `send'
    /usr/lib/ruby/gems/1.8/gems/apipie-bindings-0.0.8/lib/apipie_bindings/api.rb:195:in `http_call'
    /usr/lib/ruby/gems/1.8/gems/apipie-bindings-0.0.8/lib/apipie_bindings/api.rb:151:in `call'
    /usr/lib/ruby/gems/1.8/gems/apipie-bindings-0.0.8/lib/apipie_bindings/resource.rb:14:in `call'
    /usr/lib/ruby/gems/1.8/gems/hammer_cli-0.1.1/lib/hammer_cli/./apipie/command.rb:42:in `send_request'
    /usr/lib/ruby/gems/1.8/gems/hammer_cli_foreman-0.1.1/lib/hammer_cli_foreman/commands.rb:113:in `send_request'
    /usr/lib/ruby/gems/1.8/gems/hammer_cli-0.1.1/lib/hammer_cli/./apipie/command.rb:33:in `execute'
    /usr/lib/ruby/gems/1.8/gems/clamp-0.6.2/lib/clamp/command.rb:67:in `run'
    /usr/lib/ruby/gems/1.8/gems/hammer_cli-0.1.1/lib/hammer_cli/./apipie/../abstract.rb:22:in `run'
    /usr/lib/ruby/gems/1.8/gems/clamp-0.6.2/lib/clamp/subcommand/execution.rb:11:in `execute'
    /usr/lib/ruby/gems/1.8/gems/clamp-0.6.2/lib/clamp/command.rb:67:in `run'
    /usr/lib/ruby/gems/1.8/gems/hammer_cli-0.1.1/lib/hammer_cli/./apipie/../abstract.rb:22:in `run'
    /usr/lib/ruby/gems/1.8/gems/clamp-0.6.2/lib/clamp/subcommand/execution.rb:11:in `execute'
    /usr/lib/ruby/gems/1.8/gems/clamp-0.6.2/lib/clamp/command.rb:67:in `run'
    /usr/lib/ruby/gems/1.8/gems/hammer_cli-0.1.1/lib/hammer_cli/./apipie/../abstract.rb:22:in `run'
    /usr/lib/ruby/gems/1.8/gems/clamp-0.6.2/lib/clamp/command.rb:125:in `run'
    /usr/lib/ruby/gems/1.8/gems/hammer_cli-0.1.1/bin/hammer:100
    /usr/bin/hammer:19:in `load'
    /usr/bin/hammer:19
```
