### PR TITLE
Max Content Hosts data passed as string.

### DIFF
--- a/tests/foreman/cli/test_host_collection.py
+++ b/tests/foreman/cli/test_host_collection.py
@@ -111,7 +111,7 @@ class TestHostCollection(BaseCLI):
             "Descriptions don't match"
         )
 
-    @data(1, 3, 5, 10, 20)
+    @data('1', '3', '5', '10', '20')
     @attr('cli', 'hostcollection')
     def test_positive_create_3(self, test_data):
         """
@@ -290,7 +290,7 @@ class TestHostCollection(BaseCLI):
         )
 
     @bzbug('1084240')
-    @data(3, 6, 9, 12, 15, 17, 19)
+    @data('3', '6', '9', '12', '15', '17', '19')
     @attr('cli', 'hostcollection')
     def test_positive_update_3(self, test_data):
         """


### PR DESCRIPTION
Host Collection tests for max content hosts via the CLI were failing
during the assertion because it was comparing an integer to a string.
