### PR TITLE
Expose the TimeOut argument for CLI commands.

### DIFF
--- a/robottelo/cli/base.py
+++ b/robottelo/cli/base.py
@@ -133,7 +133,8 @@ class Base(object):
         return result
 
     @classmethod
-    def execute(cls, command, user=None, password=None, expect_csv=False):
+    def execute(cls, command, user=None, password=None,
+                expect_csv=False, timeout=None):
         """
         Executes the command
         """
@@ -150,7 +151,8 @@ class Base(object):
 
         cmd = shell_cmd % (cls.locale, user, password, output_csv, command)
 
-        return ssh.command(cmd.encode('utf-8'), expect_csv=expect_csv)
+        return ssh.command(
+            cmd.encode('utf-8'), expect_csv=expect_csv, timeout=timeout)
 
     @classmethod
     def exists(cls, options=None, tuple_search=None):

--- a/robottelo/cli/contentview.py
+++ b/robottelo/cli/contentview.py
@@ -64,14 +64,18 @@ class ContentView(Base):
         return result
 
     @classmethod
-    def publish(cls, options):
+    def publish(cls, options, timeout=None):
         """
         Publishes a new version of content-view.
         """
 
         cls.command_sub = "publish"
 
-        result = cls.execute(cls._construct_command(options))
+        # Publishing can take a while so try to wait a bit longer
+        if timeout is None:
+            timeout = 120
+
+        result = cls.execute(cls._construct_command(options), timeout=timeout)
 
         return result
 

--- a/robottelo/common/ssh.py
+++ b/robottelo/common/ssh.py
@@ -87,11 +87,15 @@ def upload_file(local_file, remote_file=None):
     # TODO: Upload file to sauce labs via VPN tunnel in the else part.
 
 
-def command(cmd, hostname=None, expect_csv=False, timeout=50):
+def command(cmd, hostname=None, expect_csv=False, timeout=None):
     """
     Executes SSH command(s) on remote hostname.
     Defaults to main.server.hostname.
     """
+
+    # Set a default timeout of 60 seconds
+    if timeout is None:
+        timeout = 60
 
     # Start the timer
     start = time.time()


### PR DESCRIPTION
There are some CLI actions, such as content view promotions, can take a
bit longer to return and the default timeout of 50 seconds, which was
not exposed, was not long enough for some of our tests.

I have exposed the (optional) timeout argument via CLI's base class.
Also, I have set a default timeout of 120 seconds for content view
publishing for this PR.
