### PR TITLE
Rewrite prose in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,57 +1,47 @@
 Robottelo
 =========
 
-This is an automation test suite for [The Foreman](http://theforeman.org/)
-project.
+Robottelo is a test suite which exercises [The Foreman](http://theforeman.org/).
+All tests are automated, suited for use in a continuous integration environment,
+and [data driven](http://en.wikipedia.org/wiki/Data-driven_testing). There are
+three types of tests:
 
-The goal is to design a [data
-driven](http://en.wikipedia.org/wiki/Data-driven_testing) test suite that can be
-used in a continuous integration environment.
-
-**Robottelo** uses Selenium's
-[WebDriver](http://docs.seleniumhq.org/projects/webdriver/) for all user
-interface (UI) tests, [Paramiko](http://www.paramiko.org/) for all command line
-interface (CLI) tests and [Requests](http://docs.python-requests.org/en/latest/)
-for API tests.
+* UI tests, which rely on Selenium's
+  [WebDriver](http://docs.seleniumhq.org/projects/webdriver/)
+* CLI tests, which rely on [Paramiko](http://www.paramiko.org/)
+* API tests, which rely on
+  [Requests](http://docs.python-requests.org/en/latest/)
 
 Quickstart
 ==========
 
-This page gives you a brief introduction in how to get started with
-**Robottelo**. For more information, please read the
-[documentation](http://robottelo.readthedocs.org/en/latest/).
+The following is only a brief setup guide for **Robottelo**. More thorough
+documentation is available at [Read the
+Docs](http://robottelo.readthedocs.org/en/latest/).
 
 Requirements:
 -------------
 
-* If you haven't cloned the source code yet, then make sure to do it now:
+Get the source code (if you haven't done so already) and install dependencies:
 
 ```bash
 $ git clone git://github.com/omaciel/robottelo.git
-```
-
-* Install locally all of **Robottelo**'s dependency modules using ``pip
-  install``:
-
-```bash
 $ pip install -r requirements.txt
 ```
 
-**NOTE 1**: You may want to consider running ``yum groupinstall "Development
-Tools"`` for **Fedora/RHEL** or **Development** packages if installing python
-modules via pip for your OS.
+That's it! You can now go ahead and start testing The Foreman. However, there
+are a few other things you may wish to do before continuing:
 
-**NOTE 2**: You may also want to consider running ``yum install openssl-devel
-python-devel`` packages for ``python-stageportal`` installation.
+1. You may want to install development tools (such as gcc) for your OS. If
+   running **Fedora/RHEL**, execute `yum groupinstall "Development Tools"`.
+2. If using `python-stageportal`, you should install `openssl-devel`,
+   `python-devel` and `python-rhsm`. They are required for working with
+   certificates.
 
-**NOTE 3**: Some of the modules that will be installed via the pip  command
-above are ``python-rhsm`` and ``python-stageportal`` which are only required for
-certificates.
-
-Running the tests
+Running the Tests
 =================
 
-All tests are written so that it is possible to run them using Python
+All tests are written so that it is possible to run them using either Python
 [Nosetests](https://nose.readthedocs.org/en/latest/man.html) or Python's
 [Unittest](http://docs.python.org/2/library/unittest.html) module. For more
 instructions about how to run the tests take a look at the following sections.
@@ -60,8 +50,8 @@ Initial Configuration
 ---------------------
 
 The first thing you need to do is copy the existing
-**robottelo.properties.sample** files and save it as **robottelo.properties**
-inside of the checkout directory. Then, edit it so that at least the following
+`robottelo.properties.sample` files and save it as `robottelo.properties` inside
+of the checkout directory. Then, edit it so that at least the following
 attributes are set:
 
 ```INI
@@ -84,7 +74,7 @@ tests and even configuration to run the automation using
 browsers you can use, check Selenium's WebDriver
 [documentation](http://docs.seleniumhq.org/projects/webdriver/).
 
-Testing with Python Nose
+Testing With Python Nose
 ------------------------
 
 Tests can be run using the Python Nose module. Assuming that you have Nose
@@ -95,7 +85,7 @@ you can run all tests:
 $ nosetests -c robottelo.properties
 ```
 
-The test arguments can be either the path to the ``tests`` directory or Python
+The test arguments can be either the path to the `tests` directory or Python
 import-like style:
 
 ```bash
@@ -129,16 +119,16 @@ $ nosetests -c robottelo.properties tests.foreman.cli.test_user:TestUser.test_cr
 
 Many of the existing tests use the [DDT](http://ddt.readthedocs.org/en/latest/)
 module to allow for a more data-driven methodology and in order to run a
-specific test you need override the way ``nosetests`` discovers test names. For
-instance, if you wanted to run only the ``test_positive_create_1`` data-driven
-tests for the ``foreman/cli/test_org.py`` module:
+specific test you need override the way `nosetests` discovers test names. For
+instance, if you wanted to run only the `test_positive_create_1` data-driven
+tests for the `foreman/cli/test_org.py` module:
 
 ```bash
 $ nosetests -c robottelo.properties -m test_positive_create_1 tests/foreman/cli/test_org.py
 ```
 
-Testing with unittest module
-----------------------------
+Testing With Unittest
+---------------------
 
 Tests can also be run using Python's **unittest** module:
 
@@ -191,8 +181,14 @@ For more information about Python's unittest module take a look on the Python's
 Known Issues
 ============
 
-Author
-------
+Bugs are listed [on GitHub](https://github.com/omaciel/robottelo/issues). If you
+think you've found a new issue, please do one of the following:
 
-The design and development for this software is led by: [Og
+* Open a new bug report on Github.
+* Join the #robottelo IRC channel on Freenode.
+
+Author
+======
+
+The design and development for this software is led by [Og
 Maciel](http://www.ogmaciel.com)


### PR DESCRIPTION
Make the prose in the readme flow more nicely.

Also: replace double backticks (``) with single backticks (`) as appropriate.
