### PR TITLE
Increasing the timeout for CLI commands.

### DIFF
--- a/robottelo/common/ssh.py
+++ b/robottelo/common/ssh.py
@@ -93,9 +93,9 @@ def command(cmd, hostname=None, expect_csv=False, timeout=None):
     Defaults to main.server.hostname.
     """
 
-    # Set a default timeout of 60 seconds
+    # Set a default timeout of 120 seconds
     if timeout is None:
-        timeout = 60
+        timeout = 120
 
     # Start the timer
     start = time.time()


### PR DESCRIPTION
Increased the timeout for a CLI command from 60 to 120 seconds to see if
we can get rid of some false negative tests.
