### PR TITLE
Automatically generate even more API docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,5 @@ screenshots*
 .settings/
 robottelo.properties
 .metadata/
+docs/tests.*
+docs/robottelo.*

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -39,10 +39,11 @@ help:
 	@echo "  doctest    to run all doctests embedded in the documentation (if enabled)"
 
 clean:
-	-rm -rf $(BUILDDIR)/* robottelo.*
+	-rm -rf $(BUILDDIR)/* robottelo.* tests.*
 
 genapidocs:
 	sphinx-apidoc --no-toc --force -o . ../robottelo/
+	sphinx-apidoc --no-toc --force -o . ../tests/
 
 html: genapidocs
 	$(SPHINXBUILD) -b html $(ALLSPHINXOPTS) $(BUILDDIR)/html

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -159,6 +159,7 @@ covered by the API. For more granular information, follow one of the links.
 .. toctree::
     :maxdepth: 3
 
+    tests
     robottelo
 
 Miscellany


### PR DESCRIPTION
Auto-generate API docs for the `tests` module, in addition to the `robottelo`
module. Make git ignore the files which sphinx-apidoc generates.
