### PR TITLE
Update optional requirements

### DIFF
--- a/requirements-optional.txt
+++ b/requirements-optional.txt
@@ -1,4 +1,4 @@
-git+https://github.com/blrm/nose_xunitmp.git#egg=nose_xunitmp
 git+https://github.com/RedHatQE/python-stageportal.git#egg=stageportal
 nose
+nose_xunitmp
 pylint


### PR DESCRIPTION
Robottelo has been depending on a fork of nose_xunitmp (maintained by @blrm)
instead of the upstream version (maintained by @Ignas). However, the changes in
the fork have been merged back into upstream.

Make Robottelo depend on upstream again.
