### PR TITLE
Remove stageportal requirement and dependency

### DIFF
--- a/requirements-optional.txt
+++ b/requirements-optional.txt
@@ -1,4 +1,3 @@
-git+https://github.com/RedHatQE/python-stageportal.git#egg=stageportal
 nose
 nose_xunitmp
 pylint

--- a/robottelo.properties.sample
+++ b/robottelo.properties.sample
@@ -29,13 +29,3 @@ xunit-file=foreman-results.xml
 # process-timeout=120
 
 # NOTE: Candlepin url accepts just the hostname.
-
-[stageportal]
-api=http://api.server.com:port/svcrest
-candlepin=candlepin.server.com
-customer.portal=https://access.server.com
-customer.username=username
-customer.password=password
-distributor.name=ds_name
-subs.quantity=5
-sku.id=XXXXXXX

--- a/robottelo/common/manifests.py
+++ b/robottelo/common/manifests.py
@@ -5,11 +5,7 @@
 Implements Manifest functions
 """
 
-import stageportal
 import logging
-
-from robottelo.common import conf
-from robottelo.common.helpers import generate_string
 
 
 class Manifests():
@@ -22,72 +18,28 @@ class Manifests():
         Sets up initial configuration values
         """
 
-        self.api_url = conf.properties['stageportal.api']
-        self.candlepin_url = conf.properties['stageportal.candlepin']
-        self.portal_url = conf.properties['stageportal.customer.portal']
-        if login is not None:
-            self.login = login
-        else:
-            self.login = conf.properties['stageportal.customer.username']
-        if password is not None:
-            self.password = password
-        else:
-            self.password = conf.properties['stageportal.customer.password']
-        self.distributor_name = conf.properties['stageportal.distributor.name']
-        self.quantity = int(conf.properties['stageportal.subs.quantity'])
-        self.verbosity = int(conf.properties['nosetests.verbosity'])
-        self.prd_id = conf.properties['stageportal.sku.id']
-        self.sp = stageportal.SMPortal(
-            api_url=self.api_url,
-            candlepin_url=self.candlepin_url,
-            portal_url=self.portal_url,
-            login=self.login,
-            password=self.password
-        )
-        logging.getLogger("python-stageportal").setLevel(logging.ERROR)
+        # TODO grab configuration
+        # TODO setup manifest infrastructure
         self.logger = logging.getLogger("robottelo")
 
     def create_distributor(self, ds_name=None):
         """
         Creates the distributor with the specified name.
         """
-        if ds_name is not None:
-            self.distributor_name = ds_name
-        ds_uuid = self.sp.create_distributor(self.distributor_name)
-        return ds_uuid
+        raise NotImplementedError()
 
     def attach_subscriptions(self, ds_uuid=None, quantity=None, basic=True):
         """
         Attaches all the available subscriptions with the specified quantity
         to the specified distributor uuid.
         """
-
-        if quantity is not None:
-            self.quantity = int(quantity)
-        available_subs = self.sp.distributor_available_subscriptions(ds_uuid)
-        subs = []
-        for sub in available_subs:
-            if sub['quantity'] >= self.quantity:
-                if basic:
-                    if sub['productId'] == self.prd_id:
-                        subs = [{'id': sub['id'],
-                                 'quantity': self.quantity}]
-                        break
-                else:
-                    subs_dict = {'id': sub['id'],
-                                 'quantity': self.quantity}
-                    subs.append(subs_dict)
-            else:
-                self.logger.debug("Specified quantity : %s, is more than the \
-                available quantity: %s" % (self.quantity, sub['quantity']))
-        self.sp.distributor_attach_subscriptions(ds_uuid, subs)
+        raise NotImplementedError()
 
     def download_manifest(self, ds_uuid=None):
         """
-        Simply calls the stageportal download manifests funtion.
+        Downloads a manifest.
         """
-        ds_path = self.sp.distributor_download_manifest(ds_uuid)
-        return ds_path
+        raise NotImplementedError()
 
     def detach_subscriptions(self, ds_uuid=None):
         """
@@ -95,25 +47,14 @@ class Manifests():
         distributor with the specified uuid.
         This uuid can be obtained from the fetch_manifest.
         """
-
-        detach_subs = self.sp.distributor_attached_subscriptions(ds_uuid)
-        detach_sub_ids = []
-        for detach_sub in detach_subs:
-            detach_sub_ids.append(detach_sub['id'])
-        detach_subs = self.sp.distributor_detach_subscriptions(
-            ds_uuid,
-            detach_sub_ids)
-        if detach_subs is not None:
-            detached_subs = self.sp.distributor_attached_subscriptions(ds_uuid)
-            return detached_subs
+        raise NotImplementedError()
 
     def delete_distributor(self, ds_uuid=None):
         """
         Deletes the distributor with the specified uuid.
         This uuid can be obtained from the fetch_manifest.
         """
-
-        return self.sp.delete_distributor(ds_uuid)
+        raise NotImplementedError()
 
     def fetch_manifest(self, ds_name=None, basic=True):
         """
@@ -123,20 +64,7 @@ class Manifests():
         It returns the distributor/manifest path, distributor uuid and
         also the distributor name.
         """
-
-        distributor = {}
-        if ds_name is not None:
-            self.distributor_name = ds_name
-        else:
-            self.distributor_name = generate_string("alpha", 8)
-        ds_uuid = self.create_distributor(self.distributor_name)
-        self.attach_subscriptions(ds_uuid=ds_uuid, quantity=self.quantity,
-                                  basic=basic)
-        ds_path = self.download_manifest(ds_uuid)
-        distributor['path'] = ds_path
-        distributor['uuid'] = ds_uuid
-        distributor['name'] = self.distributor_name
-        return distributor
+        raise NotImplementedError()
 
 
 manifest = Manifests()

--- a/tests/foreman/cli/test_subscription.py
+++ b/tests/foreman/cli/test_subscription.py
@@ -6,7 +6,7 @@ from ddt import ddt
 from robottelo.cli.subscription import Subscription
 from robottelo.cli.factory import (
     make_org, make_lifecycle_environment)
-from robottelo.common.decorators import bzbug
+from robottelo.common.decorators import bzbug, stubbed
 from robottelo.common.manifests import manifest
 from robottelo.common.ssh import upload_file
 from tests.foreman.cli.basecli import BaseCLI
@@ -40,6 +40,7 @@ class TestSubscription(BaseCLI):
                 {u'organization-id': TestSubscription.org['id'],
                  u'prior': TestSubscription.env1['label']})
 
+    @stubbed('Need to implement a new manifest api')
     def test_manifest_upload(self):
         """
         @test: upload manifest (positive)
@@ -69,6 +70,7 @@ class TestSubscription(BaseCLI):
         finally:
             manifest.delete_distributor(ds_uuid=mdetails['uuid'])
 
+    @stubbed('Need to implement a new manifest api')
     def test_manifest_delete(self):
         """
         @test: Delete uploaded manifest (positive)

--- a/tests/foreman/ui/test_subscription.py
+++ b/tests/foreman/ui/test_subscription.py
@@ -4,7 +4,7 @@ Test class for Subscriptions/Manifests UI
 
 from ddt import ddt
 from nose.plugins.attrib import attr
-from robottelo.common.decorators import skipRemote
+from robottelo.common.decorators import skipRemote, stubbed
 from robottelo.common.helpers import generate_string
 from robottelo.common.manifests import manifest
 from robottelo.common.ssh import upload_file
@@ -30,6 +30,7 @@ class Subscription(BaseUI):
             with Session(self.browser) as session:
                 make_org(session, org_name=Subscription.org_name)
 
+    @stubbed('Need to implement a new manifest api')
     @skipRemote
     @attr('ui', 'subs', 'implemented')
     def test_positive_upload_1(self):
@@ -54,6 +55,7 @@ class Subscription(BaseUI):
         finally:
             manifest.delete_distributor(ds_uuid=mdetails['uuid'])
 
+    @stubbed('Need to implement a new manifest api')
     @skipRemote
     @attr('ui', 'subs', 'implemented')
     def test_positive_delete_1(self):


### PR DESCRIPTION
Stageportal and its dependencies is not easy installable via pip, so will be better to find a new way to deal with manifests instead to depend on stageportal.
