### PR TITLE
Refactor module robottelo.common.__init__

### DIFF
--- a/robottelo/common/__init__.py
+++ b/robottelo/common/__init__.py
@@ -1,6 +1,4 @@
-"""
-Configuration class for the Framework
-"""
+"""Define and instantiate the configuration class for Robottelo."""
 
 import ConfigParser
 import logging
@@ -13,66 +11,76 @@ from robottelo.common.constants import ROBOTTELO_PROPERTIES
 
 
 class Configs(object):
-    """
-    Reads configuration attributes and sets up logging
-    """
-
+    """Read Robottelo's config file and set up logging."""
     def __init__(self):
-        """
-        Reads and initializes configuration attributes
-        """
-
-        prop = ConfigParser.RawConfigParser()
-        prop_file = os.path.join(self.get_root_path(), ROBOTTELO_PROPERTIES)
+        """Read Robottelo's config file and initialize the logger."""
+        conf_parser = ConfigParser.RawConfigParser()
+        conf_file = _config_file()
         self._properties = None
 
-        if prop.read(prop_file):
+        if conf_parser.read(conf_file):
+            # populate self._properties from the config file
             self._properties = {}
-            for section in prop.sections():
-                for option in prop.options(section):
+            for section in conf_parser.sections():
+                for option in conf_parser.options(section):
                     self._properties[
-                        "%s.%s" % (section, option)
-                    ] = prop.get(section, option)
+                        "{}.{}".format(section, option)
+                    ] = conf_parser.get(section, option)
 
         self._configure_logging()
         self.logger = logging.getLogger('robottelo')
 
     @property
     def properties(self):
+        """Return settings read from the config file.
+
+        If Robottelo's config file could not be read when this object was
+        instantiated, return ``None``. This will happen if the config file does
+        not exist.
+
+        :return: Application settings, if available.
+        :rtype: dict
+        :rtype: None
+
+        """
         if self._properties is None:
             self.logger.error(
-                'Please make sure that you have a robottelo.properties file.')
+                'No config file found at "{}".'.format(_config_file())
+            )
             sys.exit(-1)
         return self._properties
 
     def log_properties(self):
-        """
-        Displays available configuration attributes
-        """
+        """Print config options to the logging file.
 
+        :rtype: None
+
+        """
         keylist = self.properties.keys()
         keylist.sort()
         self.logger.debug("")
         self.logger.debug("# ** ** ** list properties ** ** **")
         for key in keylist:
-            self.logger.debug("property %s=%s" % (key, self.properties[key]))
+            self.logger.debug(
+                "property {}={}".format(key, self.properties[key])
+            )
         self.logger.debug("")
 
-    def get_root_path(self):
-        """
-        Returns correct path to logging config file
-        """
-
-        return os.path.realpath(os.path.join(os.path.dirname(__file__),
-                                             os.pardir, os.pardir))
-
     def _configure_logging(self):
-        """
-        Configures logging for the entire framework
-        """
+        """Configure logging for the entire framework.
 
+        If a config named ``logging.conf`` exists in Robottelo's root
+        directory, the logger is configured using the options in that file.
+        Otherwise, a custom logging output format is set, and default values
+        are used for all other logging options.
+
+        :rtype: None
+
+        """
         try:
-            logging.config.fileConfig("%s/logging.conf" % self.get_root_path())
+            logging.config.fileConfig(
+                "{}/logging.conf".format(_get_app_root())
+            )
         except NoSectionError:
             log_format = '%(levelname)s %(module)s:%(lineno)d: %(message)s'
             logging.basicConfig(format=log_format)
@@ -86,6 +94,30 @@ class Configs(object):
         for name in ['root', 'robottelo']:
             logger = logging.getLogger(name)
             logger.setLevel(log_level)
+
+
+def _get_app_root():
+    """Return the path to the application root directory.
+
+    :return: A directory path.
+    :rtype: str
+
+    """
+    return os.path.realpath(os.path.join(
+        os.path.dirname(__file__),
+        os.pardir,
+        os.pardir,
+    ))
+
+
+def _config_file():
+    """Return the path to the application-wide config file.
+
+    :return: A file path.
+    :rtype: str
+
+    """
+    return os.path.join(_get_app_root(), ROBOTTELO_PROPERTIES)
 
 
 conf = Configs()


### PR DESCRIPTION
Move method `Config.get_root_path` to function `_get_app_root`. The method
never referenced `self` and had no logical connection to the class, so there
was no reason to keep it in the class.

Trim down method `Config.__init__` and move some of its functionality into
function `_config_file`. Use this method in place of some formerly hard-coded
debugging strings.

Thoroughly improve docstrings, use the `format` string method, and generally
clean up the module.
