### PR TITLE
Change main configuration file.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,4 @@
 NOSETESTS=$(shell which nosetests)
-PYTHON=$(shell which python)
 
 # Paths
 ROBOTTELO_TESTS_PATH=tests/robottelo/
@@ -15,11 +14,8 @@ docs:
 docs-clean:
 	@cd docs; $(MAKE) clean
 
-# Nose doesn't play nicely with doctests.
 test-robottelo:
-	$(PYTHON) -m unittest discover \
-	    --start-directory $(ROBOTTELO_TESTS_PATH) \
-	    --top-level-directory .
+	$(NOSETESTS) -c robottelo.properties $(ROBOTTELO_TESTS_PATH)
 
 test-foreman-api:
 	$(NOSETESTS) -c robottelo.properties $(FOREMAN_API_TESTS_PATH)

--- a/robottelo.properties.sample
+++ b/robottelo.properties.sample
@@ -1,8 +1,13 @@
-# Copy this file and rename it to robottelo.properties
+# Make a copy of this file named robottelo.properties
 
 [main]
+
+# A hostname is required. scheme (default: https) and port are optional.
+# Suggested values for "scheme" are "http" and "https".
 server.hostname=
-server.port=443
+#server.scheme=https
+#server.port=
+
 server.ssh.key_private=/home/whoami/.ssh/id_hudson_dsa
 server.ssh.username=root
 project=foreman

--- a/robottelo/records/smartproxy.py
+++ b/robottelo/records/smartproxy.py
@@ -5,8 +5,9 @@ Module for Smart proxy api an record implementation
 """
 
 
-from robottelo.common import conf, records
 from robottelo.api.apicrud import ApiCrud
+from robottelo.common.helpers import get_server_url
+from robottelo.common import records
 
 
 class SmartProxyApi(ApiCrud):
@@ -24,8 +25,7 @@ class SmartProxy(records.Record):
     We asume, that main server has smart proxy configured.
     """
     name = records.StringField()
-    url = records.StringField(
-        default="https://" + conf.properties['main.server.hostname'])
+    url = records.StringField(default=get_server_url())
 
     class Meta:
         """Linking record definition with api implementation.

--- a/robottelo/test.py
+++ b/robottelo/test.py
@@ -11,6 +11,7 @@ if sys.hexversion >= 0x2070000:
 else:
     import unittest2 as unittest
 from robottelo.cli.metatest import MetaCLITest
+from robottelo.common.helpers import get_server_url
 from robottelo.common import conf
 from robottelo.ui.activationkey import ActivationKey
 from robottelo.ui.architecture import Architecture
@@ -38,8 +39,8 @@ from robottelo.ui.sync import Sync
 from robottelo.ui.syncplan import Syncplan
 from robottelo.ui.systemgroup import SystemGroup
 from robottelo.ui.template import Template
-from robottelo.ui.user import User
 from robottelo.ui.usergroup import UserGroup
+from robottelo.ui.user import User
 from selenium_factory.SeleniumFactory import SeleniumFactory
 from selenium import webdriver
 
@@ -105,8 +106,6 @@ class UITestCase(TestCase):
         Make sure that we only read configuration values once.
         """
         super(UITestCase, cls).setUpClass()
-        cls.host = conf.properties['main.server.hostname']
-        cls.port = conf.properties['main.server.port']
         cls.katello_user = conf.properties['foreman.admin.username']
         cls.katello_passwd = conf.properties['foreman.admin.password']
         cls.driver_name = conf.properties['saucelabs.driver']
@@ -138,7 +137,7 @@ class UITestCase(TestCase):
                 job_name=self.id(), show_session_id=True)
 
         self.browser.maximize_window()
-        self.browser.get("https://%s:%s" % (self.host, self.port))
+        self.browser.get(get_server_url())
 
         # Library methods
         self.activationkey = ActivationKey(self.browser)

--- a/tests/robottelo/test_helpers.py
+++ b/tests/robottelo/test_helpers.py
@@ -1,9 +1,79 @@
+"""Tests for module ``robottelo.common.helpers``."""
+# (Too many public methods) pylint: disable=R0904
 import unittest
-
+from robottelo.common import conf
 from robottelo.common.helpers import (
-    generate_name, generate_email_address, valid_names_list, valid_data_list,
-    invalid_names_list, generate_ipaddr, generate_mac, generate_string,
-    generate_strings_list, escape_search, info_dictionary)
+    escape_search, generate_email_address, generate_ipaddr, generate_mac,
+    generate_name, generate_string, generate_strings_list, get_server_url,
+    info_dictionary, invalid_names_list, valid_data_list, valid_names_list,
+)
+
+
+class GetServerURLTestCase(unittest.TestCase):
+    """Tests for method ``get_server_url``.
+
+    The methods in this class test ``get_server_url`` by setting different
+    values in the ``conf`` object and checking that output is as expected.
+    There are many permutations of values that can be placed in the test cases,
+    so method descriptions only briefly state of the ``conf`` object during
+    that particular test.
+
+    """
+    def setUp(self):
+        """Set some default values in the config file."""
+        conf.properties['main.server.hostname'] = 'example.com'
+        if 'main.server.scheme' in conf.properties:
+            del(conf.properties['main.server.scheme'])
+        if 'main.server.port' in conf.properties:
+            del(conf.properties['main.server.port'])
+
+    def test_default_v1(self):
+        """Hostname set."""
+        self.assertEqual(get_server_url(), 'https://example.com')
+
+    def test_default_v2(self):
+        """Hostname set, port blank."""
+        conf.properties['main.server.port'] = ''
+        self.assertEqual(get_server_url(), 'https://example.com')
+
+    def test_default_v3(self):
+        """Hostname set, scheme blank."""
+        conf.properties['main.server.scheme'] = ''
+        self.assertEqual(get_server_url(), 'https://example.com')
+
+    def test_default_v4(self):
+        """Hostname set, scheme and port blank."""
+        conf.properties['main.server.port'] = ''
+        conf.properties['main.server.scheme'] = ''
+        self.assertEqual(get_server_url(), 'https://example.com')
+
+    def test_port(self):
+        """Hostname and port set."""
+        conf.properties['main.server.port'] = '1234'
+        self.assertEqual(get_server_url(), 'https://example.com:1234')
+
+    def test_port_v2(self):
+        """Hostname and port set, scheme blank."""
+        conf.properties['main.server.port'] = '1234'
+        conf.properties['main.server.scheme'] = ''
+        self.assertEqual(get_server_url(), 'https://example.com:1234')
+
+    def test_scheme(self):
+        """Hostname and scheme set."""
+        conf.properties['main.server.scheme'] = 'telnet'
+        self.assertEqual(get_server_url(), 'telnet://example.com')
+
+    def test_scheme_v2(self):
+        """Hostname and scheme set, port blank."""
+        conf.properties['main.server.port'] = ''
+        conf.properties['main.server.scheme'] = 'telnet'
+        self.assertEqual(get_server_url(), 'telnet://example.com')
+
+    def test_all(self):
+        """Hostname, scheme and port set."""
+        conf.properties['main.server.port'] = '1234'
+        conf.properties['main.server.scheme'] = 'telnet'
+        self.assertEqual(get_server_url(), 'telnet://example.com:1234')
 
 
 class FakeSSHResult(object):


### PR DESCRIPTION
Add a new setting to the main config file: `main.server.scheme`. Valid values
for this config option are, for example, http and https.

By default, comment out two settings in the config file: `main.server.scheme`
and `main.server.port`. This is in line with what many venerable daemons such as
sshd and vsftpd do. This change has the potential to break code, but the
introduction of method `get_server_url` should mitigate any negative effects.

Create method `get_server_url` in module `robottelo.common.helpers`. This method
constructs the URL of the server being tested by reading `main.server.scheme`,
`main.server.hostname` and `main.server.port`. Refactor some code which,
formerly, constructed the server URL directly from the config file. If possible,
make that code use `get_server_url` instead.

Create a unit test for `get_server_url`.
