### PR TITLE
Make travis use Makefile when running tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,14 +4,12 @@ install:
     - pip install "git+https://github.com/sthirugn/testimony.git"
     - pip install -r requirements.txt
 script:
+    - flake8 .
+    - make test-robottelo
     # The tests in `tests/foreman/` interact with a Satellite deployment, and
     # they are lengthy. Don't run them on Travis.
-    - flake8 .
     - testimony validate_docstring tests/foreman/api
     - testimony validate_docstring tests/foreman/cli
     - testimony validate_docstring tests/foreman/ui
-    - python -m unittest discover
-        --start-directory tests/robottelo/
-        --top-level-directory .
 notifications:
     irc: "chat.freenode.net#robottelo"

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,5 @@
 NOSETESTS=$(shell which nosetests)
+PYTHON=$(shell which python)
 
 # Paths
 ROBOTTELO_TESTS_PATH=tests/robottelo/
@@ -14,8 +15,11 @@ docs:
 docs-clean:
 	@cd docs; $(MAKE) clean
 
-test:
-	$(NOSETESTS) $(ROBOTTELO_TESTS_PATH)
+# Nose doesn't play nicely with doctests.
+test-robottelo:
+	$(PYTHON) -m unittest discover \
+	    --start-directory $(ROBOTTELO_TESTS_PATH) \
+	    --top-level-directory .
 
 test-foreman-api:
 	$(NOSETESTS) -c robottelo.properties $(FOREMAN_API_TESTS_PATH)


### PR DESCRIPTION
Do not hard-code `python -m unittest` or `nosetests` statements into the travis
config file. Instead, place those statements in the primary Makefile and make
Travis call the recipes in the Makefile.

Rename recipe "test" to "test-robottelo", which more accurately reflects its
purpose.
