### PR TITLE
Simplify ssh command

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -10,7 +10,7 @@ requests
 rstr
 
 # For CLI tests.
-paramiko==1.12.3
+paramiko
 
 # For UI tests.
 selenium

--- a/robottelo/common/constants.py
+++ b/robottelo/common/constants.py
@@ -116,8 +116,6 @@ REPOSET = {'rhct6': "Red Hat CloudForms Tools for RHEL 6 (RPMs)",
 
 DEFAULT_ORG = "acme"
 
-SSH_CHANNEL_READY_TIMEOUT = 10  # 10 sec to get content
-
 LANGUAGES = ["de", "en", "en_GB",
              "es", "fr", "gl",
              "ja", "sv_SE", "zh_CN"]

--- a/tests/foreman/cli/test_user.py
+++ b/tests/foreman/cli/test_user.py
@@ -1184,7 +1184,7 @@ class User(BaseCLI):
         self.assertNotEqual(result.return_code, 0)
         self.assertGreater(len(result.stderr), 0)
 
-    @data(make_user({'admin': 'true'}),
+    @data({'admin': 'true'},
           {'login': 'admin', 'password': 'changeme'})
     def test_negative_delete_user_1(self, opts):
         """
@@ -1194,6 +1194,8 @@ class User(BaseCLI):
         1. Attempt to delete the last admin user
         @Assert: User is not deleted
         """
+        if 'login' not in opts and 'password' not in opts:
+            opts.update(make_user(opts))
         user = UserObj()
         user.katello_user = opts['login']
         user.katello_passwd = opts['password']


### PR DESCRIPTION
Leave paramiko handle the execution of the command.
Update a CLI user test to not do any ssh connection during the import time.
Update requirements, now we can run with the latest paramiko.
