### PR TITLE
api/test_contentviews.py test fixed; organization_id X organization.id in record definition; workaround in apicrud recursive create;  minor test fix/workaround

### DIFF
--- a/robottelo/api/apicrud.py
+++ b/robottelo/api/apicrud.py
@@ -547,7 +547,10 @@ class ApiCrud(object):
             api = instance_orig._meta.api_class
             return api.record_create_recursive(instance_orig, user=user)
         res_instance = cls.record_create_dependencies(instance_orig, user=user)
-        return cls.record_create(res_instance, user=user)
+        ret = cls.record_create(res_instance, user=user)
+        if instance_orig.__class__.__name__ is "ContentViewDefinition":
+            ret['organization_id'] = res_instance['organization_id']
+        return ret
 
 
 class Task(object):

--- a/robottelo/records/content_view_definition.py
+++ b/robottelo/records/content_view_definition.py
@@ -16,7 +16,7 @@ class ContentViewDefinitionApi(ApiCrud):
     """Content view api implementation utilizes :organization.id,
     what means, that create requires initialize organization object.
     """
-    api_path = "/katello/api/v2/organizations/:organization.id/content_views/"
+    api_path = "/katello/api/v2/organizations/:organization_id/content_views/"
     api_path_get = "/katello/api/v2/content_views/"
     api_path_put = "/katello/api/v2/content_views/"
     api_path_delete = "/katello/api/v2/content_views/"

--- a/tests/foreman/api/test_contentviews.py
+++ b/tests/foreman/api/test_contentviews.py
@@ -101,6 +101,7 @@ class TestContentView(APITestCase):
         con_view = ContentViewDefinition()
         depends = ApiCrud.record_create_dependencies(con_view)
         t = ApiCrud.record_create(depends)
+        t['organization_id'] = depends['organization_id']
         con_view.name = data.name
         ApiCrud.record_update(t)
 
@@ -133,6 +134,7 @@ class TestContentView(APITestCase):
         data.label = "conview_del"
         depends = ApiCrud.record_create_dependencies(data)
         t = ApiCrud.record_create(depends)
+        t['organization_id'] = depends['organization_id']
         self.assertTrue(ApiCrud.record_exists(t))
         ApiCrud.record_remove(t)
         self.assertFalse(ApiCrud.record_exists(t))


### PR DESCRIPTION
Fix of api/test_contentviews.py test. Organization_id is required to find content view, but it is not returned by record_create. This is more of a workaround than a solution.
