### PR TITLE
Make `make` more resilient to errors

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,3 @@
-NOSETESTS=$(shell which nosetests)
-
 # Paths
 ROBOTTELO_TESTS_PATH=tests/robottelo/
 FOREMAN_TESTS_PATH=tests/foreman/
@@ -15,15 +13,15 @@ docs-clean:
 	@cd docs; $(MAKE) clean
 
 test-robottelo:
-	$(NOSETESTS) -c robottelo.properties $(ROBOTTELO_TESTS_PATH)
+	nosetests -c robottelo.properties $(ROBOTTELO_TESTS_PATH)
 
 test-foreman-api:
-	$(NOSETESTS) -c robottelo.properties $(FOREMAN_API_TESTS_PATH)
+	nosetests -c robottelo.properties $(FOREMAN_API_TESTS_PATH)
 
 test-foreman-cli:
-	$(NOSETESTS) -c robottelo.properties $(FOREMAN_CLI_TESTS_PATH)
+	nosetests -c robottelo.properties $(FOREMAN_CLI_TESTS_PATH)
 
 test-foreman-ui:
-	$(NOSETESTS) -c robottelo.properties $(FOREMAN_UI_TESTS_PATH)
+	nosetests -c robottelo.properties $(FOREMAN_UI_TESTS_PATH)
 
 .PHONY: docs docs-clean test test-foreman-api test-foreman-cli test-foreman-ui


### PR DESCRIPTION
Remove the `NOSETESTS=$(shell which nosetests)` line and all lines which
reference that variable. Instead, use the executable directly. This change makes
`make` more resilient to errors. If nose is not installed and the command `make
test-robottelo` is executed, an error such as the following is generated:

```
c robottelo.properties tests/robottelo/
make: c: Command not found
make: [test-robottelo] Error 127 (ignored)
```

If the executable is used directly, a much more helpful error is generated:

```
nosetests -c robottelo.properties tests/robottelo/
make: nosetests: Command not found
make: *** [test-robottelo] Error 127
```

An examination of the make files used by Vim, OpenSSH and the Django docs shows
that none of them use `$(shell which ...)`, either.
