### PR TITLE
Update API host tests

### DIFF
--- a/robottelo/records/host.py
+++ b/robottelo/records/host.py
@@ -7,24 +7,26 @@ Module for Host api an record implementation
 
 from robottelo.common import records
 from robottelo.api.apicrud import ApiCrud
-from robottelo.records.environment import Environment
 from robottelo.records.architecture import Architecture
 from robottelo.records.domain import Domain
-from robottelo.records.smartproxy import SmartProxy
-from robottelo.records.partitiontable import PartitionTable
+from robottelo.records.environment import Environment
+from robottelo.records.media import Media
 from robottelo.records.operatingsystem import OperatingSystem
+from robottelo.records.partitiontable import PartitionTable
+from robottelo.records.smartproxy import SmartProxy
 
 
 class HostApi(ApiCrud):
     """ Implementation of api for  foreman hosts
     """
-    api_path = "/api/hosts/"
+    api_path = "/api/v2/hosts/"
     api_json_key = u"host"
     create_fields = ["name",
                      "environment_id",
                      "architecture_id",
                      "root_pass",
                      "mac",
+                     "medium_id",
                      "domain_id",
                      "puppet_proxy_id",
                      "ptable_id",
@@ -39,6 +41,7 @@ class Host(records.Record):
     name = records.StringField(fmt=r"host\d\d\d\d\d")
     root_pass = records.StringField(default="changeme")
     mac = records.MACField()
+    medium = records.RelatedField(Media)
     environment = records.RelatedField(Environment)
     architecture = records.RelatedField(Architecture)
     domain = records.RelatedField(Domain)
@@ -54,6 +57,7 @@ class Host(records.Record):
         self.architecture.operatingsystem = [self.operatingsystem]
         self.ptable.operatingsystem = [self.operatingsystem]
         self.operatingsystem.ptables = [self.ptable]
+        self.medium.operatingsystem = [self.operatingsystem]
 
     class Meta:
         """Linking record definition with api implementation.

--- a/robottelo/records/media.py
+++ b/robottelo/records/media.py
@@ -1,0 +1,30 @@
+# -*- encoding: utf-8 -*-
+
+"""
+Module for Media api record implementation
+"""
+
+
+from robottelo.common import records
+from robottelo.api.apicrud import ApiCrud
+from robottelo.records.operatingsystem import OperatingSystem
+
+
+class MediaApi(ApiCrud):
+    """ Implementation of api for  foreman media
+    """
+    api_path = "/api/v2/media/"
+    api_json_key = u"medium"
+    create_fields = ['name', 'path', 'operatingsystem_ids']
+
+
+class Media(records.Record):
+    """Implementation of foreman media record """
+    name = records.StringField(fmt=r"media\d\d\d\d\d")
+    path = records.StringField(fmt=r"https?://\w\w\w\w\w\w.com")
+    operatingsystem = records.ManyRelatedField(OperatingSystem, 1, 3)
+
+    class Meta:
+        """Linking record definition with api implementation.
+        """
+        api_class = MediaApi

--- a/tests/foreman/api/test_host.py
+++ b/tests/foreman/api/test_host.py
@@ -31,7 +31,7 @@ class TestHost(APITestCase):
         """
         h = Host()
         self.assertTrue(ApiCrud.record_exists(h) is False)
-        ApiCrud.record_create_recursive(h)
+        h = ApiCrud.record_create_recursive(h)
         self.assertTrue(ApiCrud.record_exists(h) is True)
         ApiCrud.record_remove(h)
         self.assertTrue(ApiCrud.record_exists(h) is False)


### PR DESCRIPTION
Update API hosts tests according the latest API changes.

Now to create a host medium_id is required. The tests was updated to create a host with the extra required field.
