### PR TITLE
Change expected HTTP status codes to 201

### DIFF
--- a/tests/foreman/api/test_host_v2.py
+++ b/tests/foreman/api/test_host_v2.py
@@ -111,7 +111,7 @@ class ApiHostsTestCase(TestCase):
             verify=False,
         )
 
-        status_code = 200
+        status_code = 201
         self.assertEqual(
             status_code,
             response.status_code,

--- a/tests/foreman/api/test_model_v2.py
+++ b/tests/foreman/api/test_model_v2.py
@@ -72,7 +72,7 @@ class ApiModelsTestCase(TestCase):
             verify=False,
         )
 
-        status_code = 200
+        status_code = 201
         self.assertEqual(
             status_code,
             response.status_code,


### PR DESCRIPTION
The HTTP 201 status code means that a resource was created. The tests which
attempt to create a resource should expect an HTTP 201, not an HTTP 200.
