### PR TITLE
Make API docs include more modules

### DIFF
--- a/docs/api/tests.foreman.api.rst
+++ b/docs/api/tests.foreman.api.rst
@@ -61,10 +61,24 @@
     :members:
     :undoc-members:
 
+:mod:`tests.foreman.api.test_host_v2`
+-------------------------------------
+
+.. automodule:: tests.foreman.api.test_host_v2
+    :members:
+    :undoc-members:
+
 :mod:`tests.foreman.api.test_medium`
 ------------------------------------
 
 .. automodule:: tests.foreman.api.test_medium
+    :members:
+    :undoc-members:
+
+:mod:`tests.foreman.api.test_model_v2`
+--------------------------------------
+
+.. automodule:: tests.foreman.api.test_model_v2
     :members:
     :undoc-members:
 


### PR DESCRIPTION
Make the API docs cover the following modules:
- `tests.foreman.api.test_host_v2`
- `tests.foreman.api.test_model_v2`

Incidentally, this fixes a broken link in the API docs for module
`robottelo.factories`.
