### PR TITLE
Add assert testimony tag to hammer ping cli test

### DIFF
--- a/tests/foreman/cli/test_ping.py
+++ b/tests/foreman/cli/test_ping.py
@@ -15,6 +15,7 @@ class PingTestCase(CLITestCase):
         @steps:
         1. Execute hammer ping
         2. Check its return code, should be 0 if all services are ok else != 0
+        @assert: hammer ping returns a right return code
         @bz: 1094826
         """
         result = ssh.command('hammer ping')


### PR DESCRIPTION
Add missing `@assert` testimony tag to test hammer ping command
