### PR TITLE
Fix assertion

### DIFF
--- a/tests/robottelo/test_orm.py
+++ b/tests/robottelo/test_orm.py
@@ -227,4 +227,4 @@ class StringFieldTestCase(unittest.TestCase):
         """
         string = orm.StringField(max_len=20).get_value()
         self.assertGreater(len(string), 0)
-        self.assertLess(len(string), 20)
+        self.assertLessEqual(len(string), 20)


### PR DESCRIPTION
As per the docstring in the relevant test:

> Assert the string generated is between 1 and `max_len` chars long, inclusive.
