### PR TITLE
Fix `make graph-entities` command

### DIFF
--- a/robottelo/entities.py
+++ b/robottelo/entities.py
@@ -349,6 +349,15 @@ class Environment(orm.Entity):
         )
 
 
+class Errata(orm.Entity):
+    """A representation of an Errata entity."""
+    # You cannot create an errata. Instead, errata are a read-only entity.
+
+    class Meta(object):
+        """Non-field information about this entity."""
+        api_path = ('/api/v2/errata')
+
+
 class Filter(orm.Entity):
     """A representation of a Filter entity."""
     role = orm.OneToOneField('Role', required=True)


### PR DESCRIPTION
A recent PR more fully implemented `OneToManyField`s. This is good. However,
that PR also broke the graph-entities script. This commit inserts some
type-checking into `scripts.graph-entities`, thus fixing the breakage which
occurred when `OneToManyField`s were improved.

Also:
- Create an `Errata` entity. The entity is read-only.
- Visually distinguish between entities which are factories and entities which
  are not. This makes it easier to determine how much progress has been made in
  creating factories (and, therefore, tests).
