### PR TITLE
Refactor test code

### DIFF
--- a/robottelo/factory.py
+++ b/robottelo/factory.py
@@ -60,17 +60,6 @@ def field_is_required(field_type):
     return False
 
 
-def _call_client_post(url, data, auth, verify):
-    """Call ``client.post`` with the provided arguments.
-
-    This method is extremely simple and does nothing with the data passed in or
-    the data returned by ``client.post``. It exists for convenience when
-    performing unit testing.
-
-    """
-    return client.post(url, data, auth=auth, verify=verify)
-
-
 class FactoryError(Exception):
     """Indicates an error occurred while creating an entity."""
 
@@ -295,7 +284,7 @@ class Factory(object):
         # field names returned by _get_values(), so we use _get_field_names()
         # to perform a field name translation.
         path = urljoin(get_server_url(), self._get_path())
-        response = _call_client_post(
+        response = client.post(
             path,
             _copy_and_update_keys(values, self._get_field_names('api')),
             auth=get_server_credentials(),

--- a/tests/robottelo/test_robottelo_api_client.py
+++ b/tests/robottelo/test_robottelo_api_client.py
@@ -134,8 +134,13 @@ class CurlArgDataTestCase(TestCase):
 class RequestTestCase(TestCase):
     """Tests for function ``request``."""
     def setUp(self):  # pylint: disable=C0103
-        """Override function ``_call_requests_request``."""
+        """Backup and override ``client._call_requests_request``."""
+        self._call_requests_request = client._call_requests_request
         client._call_requests_request = MockRequest
+
+    def tearDown(self):  # pylint: disable=C0103
+        """Restore ``client._call_requests_request``."""
+        client._call_requests_request = self._call_requests_request
 
     def test_null(self):
         """Do not provide any optional args."""
@@ -157,10 +162,19 @@ class RequestTestCase(TestCase):
 class HeadGetDeleteTestCase(TestCase):
     """Tests for functions ``head``, ``get`` and ``delete``."""
     def setUp(self):  # pylint: disable=C0103
-        """Override calls to real ``requests`` functions."""
+        """Backup and override several objects."""
+        self._call_requests_head = client._call_requests_head
+        self._call_requests_get = client._call_requests_get
+        self._call_requests_delete = client._call_requests_delete
         client._call_requests_head = MockHeadGetDelete
         client._call_requests_get = MockHeadGetDelete
         client._call_requests_delete = MockHeadGetDelete
+
+    def tearDown(self):  # pylint: disable=C0103
+        """Restore backed-up objects."""
+        client._call_requests_head = self._call_requests_head
+        client._call_requests_get = self._call_requests_get
+        client._call_requests_delete = self._call_requests_delete
 
     def test_null(self):
         """Do not provide any optional args."""
@@ -183,10 +197,19 @@ class HeadGetDeleteTestCase(TestCase):
 class PostPutPatchTestCase(TestCase):
     """Tests for functions ``post``, ``put`` and ``patch``."""
     def setUp(self):  # pylint: disable=C0103
-        """Override calls to real ``requests`` functions."""
+        """Backup and override several objects."""
+        self._call_requests_post = client._call_requests_post
+        self._call_requests_put = client._call_requests_put
+        self._call_requests_patch = client._call_requests_patch
         client._call_requests_post = MockPostPutPatch
         client._call_requests_put = MockPostPutPatch
         client._call_requests_patch = MockPostPutPatch
+
+    def tearDown(self):  # pylint: disable=C0103
+        """Restore backed-up objects."""
+        client._call_requests_post = self._call_requests_post
+        client._call_requests_put = self._call_requests_put
+        client._call_requests_patch = self._call_requests_patch
 
     def test_null(self):
         """Do not provide any optional args."""


### PR DESCRIPTION
Several unit tests override or modify a variety of objects, typically for
mocking purposes. Back up several of those objects before they are overridden or
modified, then restore those objects to their existing state after the relevant
test has finished. This prevents the test code in one location from affecting
the state of test code in other locations.

Remove function `robottelo.factory._call_client_post`. This wrapper is
unnecessary, as it wraps `robottelo.api.client.post`, which is also in the
codebase. Test code can just as easily override one as the the other, and having
less code lying around means less of a maintenance burdern.

Add several pylint directives.
