### PR TITLE
The default org is called 'Default_Organization'

### DIFF
--- a/robottelo/common/constants.py
+++ b/robottelo/common/constants.py
@@ -126,7 +126,7 @@ PRDS = {'rhcf': "Red Hat CloudForms",
 REPOSET = {'rhct6': "Red Hat CloudForms Tools for RHEL 6 (RPMs)",
            'rhel6': "Red Hat Enterprise Linux 6 Server (RPMs)"}
 
-DEFAULT_ORG = "acme"
+DEFAULT_ORG = "Default_Organization"
 
 LANGUAGES = ["de", "en", "en_GB",
              "es", "fr", "gl",


### PR DESCRIPTION
The default organization for a fresh installation of Satellite 6 is now
called 'Default_Organization' and not 'ACME_Corporation'. This should
handle issue #1010.
