### PR TITLE
Added negative test for creating system-host \w content view

### DIFF
--- a/tests/foreman/cli/test_contenthost.py
+++ b/tests/foreman/cli/test_contenthost.py
@@ -293,7 +293,7 @@ class TestContentHost(CLITestCase):
         """
         @Test: Check if content host can be created with new content view
         @Feature: Content Hosts
-        @Assert: Content host is created using new published, promoted cv
+        @Assert: Content host is not created using new unpublished cv
         """
 
         con_view = make_content_view(


### PR DESCRIPTION
If contentview is unpublished and not promoted, create should fail.
