### PR TITLE
Make Sphinx happy

### DIFF
--- a/docs/api/robottelo.rst
+++ b/docs/api/robottelo.rst
@@ -4,7 +4,6 @@
 Submodules:
 
 .. toctree::
-
     robottelo.api
     robottelo.cli
     robottelo.common

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -96,6 +96,7 @@ nitpicky = True
 nitpick_ignore = [
     ('py:obj', 'bool'),
     ('py:obj', 'dict'),
+    ('py:obj', 'int'),
     ('py:obj', 'str'),
     ('py:obj', 'tuple'),
 ]

--- a/robottelo/api/utils.py
+++ b/robottelo/api/utils.py
@@ -18,8 +18,8 @@ def get_errata(repository_id):
     :param int repository_id: A repository ID.
     :return: That repository's errata.
     :rtype: list
-    :raises RepositoryErrataException: If an error occurs while fetching
-        the requested repository's errata.
+    :raises robottelo.api.utils.RepositoryErrataException: If an error occurs
+        while fetching the requested repository's errata.
 
     """
     path = urljoin(
@@ -45,8 +45,8 @@ def get_packages(repository_id):
     :param int repository_id: A repository ID.
     :return: That repository's packages.
     :rtype: list
-    :raises RepositoryPackagesException: If an error occurs while fetching
-        the requested repository's packages.
+    :raises robottelo.api.utils.RepositoryPackagesException: If an error occurs
+        while fetching the requested repository's packages.
 
     """
     path = urljoin(

--- a/robottelo/factory.py
+++ b/robottelo/factory.py
@@ -288,12 +288,12 @@ class EntityFactoryMixin(Factory):
 
         This method does the following:
 
-        1. Ask ``self.get_fields`` for a dict of field names and types.
-           (see :meth:`orm.Entity.get_fields`)
+        1. Ask ``self.get_fields`` for a dict of field names and types. (see
+           :meth:`robottelo.orm.Entity.get_fields`)
         2. Filter out all non-required fields.
         3. Change field names using ``self.Meta.api_names``, if present.
-        4. Append the suffix '_id' and '_ids' to the name of ``OneToOneField``s
-           and ``OneTomanyField``s, respectively.
+        4. Append the suffix '_id' and '_ids' to the name of each
+           ``OneToOneField`` and ``OneTomanyField``, respectively.
         5. Generate values for each field.
 
         """


### PR DESCRIPTION
Fix two broken class references. Add 'int' to the set of ignored references.
Remove a spurious line of whitespace. Finally, the following code makes Sphinx
unhappy:

```
``MyClass``s
```

Stripping the trailing 's' fixes the issue.
