### PR TITLE
Add test targeting bugzilla bug 1116043

### DIFF
--- a/tests/foreman/api/test_organization_v2.py
+++ b/tests/foreman/api/test_organization_v2.py
@@ -1,0 +1,41 @@
+"""Unit tests for the ``organizations`` paths.
+
+Each ``TestCase`` subclass tests a single URL. A full list of URLs to be tested
+can be found here: http://theforeman.org/api/apidoc/v2/organizations
+
+"""
+from robottelo.api import client
+from robottelo.api.utils import status_code_error
+from robottelo.common.decorators import skip_if_bz_bug_open
+from robottelo.common.helpers import get_server_credentials
+from robottelo import entities
+from unittest import TestCase
+import httplib
+# (too many public methods) pylint: disable=R0904
+
+
+class OrganizationsTestCase(TestCase):
+    """Tests for the ``organizations`` path."""
+    @skip_if_bz_bug_open(1116043)
+    def test_create(self):
+        """@Test Create an organization.
+
+        @Assert: HTTP 201 is returned.
+        @Feature: Organization
+
+        """
+        path = entities.Organization().path()
+        attrs = entities.Organization().build()
+        response = client.post(
+            path,
+            attrs,
+            auth=get_server_credentials(),
+            headers={'content-type': 'text/plain'},
+            verify=False,
+        )
+        status_code = httplib.CREATED
+        self.assertEqual(
+            status_code,
+            response.status_code,
+            status_code_error(path, status_code, response),
+        )


### PR DESCRIPTION
By default, the API client makes calls to the Foreman API with a content-type of
application/json. BZ bug 1116043 describes an issue that occurs if the
content-type is text/plain. Add a test which directly targets this bug.
