### PR TITLE
Remove code for unpacking server responses

### DIFF
--- a/robottelo/entities.py
+++ b/robottelo/entities.py
@@ -296,10 +296,6 @@ class Domain(orm.Entity, factory.EntityFactoryMixin):
         """Non-field information about this entity."""
         api_path = 'api/v2/domains'
 
-    def _unpack_response(self, response):
-        """Unpack the server's response after creating an entity."""
-        return response['domain']
-
 
 class Environment(orm.Entity):
     """A representation of a Environment entity."""
@@ -572,10 +568,6 @@ class Model(orm.Entity, factory.EntityFactoryMixin):
         """Non-field information about this entity."""
         api_path = 'api/v2/models'
 
-    def _unpack_response(self, response):
-        """Unpack the server's response after creating an entity."""
-        return response['model']
-
 
 class OperatingSystem(orm.Entity, factory.EntityFactoryMixin):
     """A representation of a Operating System entity.
@@ -615,10 +607,6 @@ class OrganizationDefaultInfo(orm.Entity):
         api_path = ('katello/api/v2/organizations/:organization_id/'
                     'default_info/:informable_type')
 
-    def _unpack_response(self, response):  # (no-self-use) pylint:disable=R0201
-        """Unpack the server's response after creating an entity."""
-        return response['model']
-
 
 class Organization(orm.Entity, factory.EntityFactoryMixin):
     """A representation of an Organization entity."""
@@ -629,10 +617,6 @@ class Organization(orm.Entity, factory.EntityFactoryMixin):
     class Meta(object):
         """Non-field information about this entity."""
         api_path = 'katello/api/v2/organizations'
-
-    def _unpack_response(self, response):  # (no-self-use) pylint:disable=R0201
-        """Unpack the server's response after creating an entity."""
-        return response['organization']
 
 
 class OSDefaultTemplate(orm.Entity):

--- a/robottelo/factory.py
+++ b/robottelo/factory.py
@@ -77,13 +77,11 @@ class Factory(object):
 
     * :meth:`Factory._factory_data`
     * :meth:`Factory._factory_path`
-    * :meth:`Factory._unpack_response`
 
     A subclass may use :meth:`Factory.attributes` if it overrides
     :meth:`Factory._factory_data`. A subclass may also use
     :meth:`Factory.build` and :meth:`Factory.create` if it overrides
-    :meth:`Factory._factory_path` (and sometimes
-    :meth:`Factory._unpack_response` too).
+    :meth:`Factory._factory_path`.
 
     """
     def _factory_data(self):
@@ -114,32 +112,6 @@ class Factory(object):
 
         """
         raise NotImplementedError
-
-    # Pylint warns that `self` is unused. This is OK, as subclasses may use it.
-    def _unpack_response(self, response):  # pylint:disable=R0201
-        """Unpack the server's response after creating an entity.
-
-        After sucessfully creating an entity on a server, a response is sent
-        back. For example, after creating a "Model" entity::
-
-            {u'model': {
-                u'info': None, u'hosts_count': 0, u'name': u'foo',
-                u'created_at': u'2014-07-07T16:06:23Z', u'updated_at':
-                u'2014-07-07T16:06:23Z', u'hardware_model': None,
-                u'vendor_class': None, u'id': 11
-            }}
-
-        The job of this method is to return information about the entity which
-        was just created. In the example above, the inner dict should be
-        returned.
-
-        :param dict response: The data sent back from the server after creating
-            an entity.
-        :return: Information about the just-created entity.
-        :rtype: dict
-
-        """
-        return response
 
     def attributes(self, fields=None):
         """Return values for populating a new entity.
@@ -264,7 +236,7 @@ class Factory(object):
             )
 
         # Tell caller about created entity.
-        return self._unpack_response(response)
+        return response
 
 
 class EntityFactoryMixin(Factory):

--- a/tests/robottelo/test_factory.py
+++ b/tests/robottelo/test_factory.py
@@ -21,10 +21,6 @@ class SampleFactory(factory.Factory):
         """Return a "Sample" entity's field names and types."""
         return {'name': SAMPLE_FACTORY_NAME, 'cost': SAMPLE_FACTORY_COST}
 
-    def _unpack_response(self, response):
-        """Unpack the server's response after creating an entity."""
-        return response['sample']
-
 
 class MockResponse(object):  # (too-few-public-methods) pylint:disable=R0903
     """A mock ``requests.response`` object."""
@@ -35,7 +31,7 @@ class MockResponse(object):  # (too-few-public-methods) pylint:disable=R0903
 
         """
         # (protected-access) pylint:disable=W0212
-        return {'sample': SampleFactory()._factory_data()}
+        return SampleFactory()._factory_data()
 
 
 class MockErrorResponse(object):  # too-few-public-methods pylint:disable=R0903
@@ -146,18 +142,6 @@ class FactoryTestCase(TestCase):
         """
         with self.assertRaises(NotImplementedError):
             factory.Factory()._factory_path()
-
-    def test__unpack_response(self):
-        """Call :meth:`robottelo.factory.Factory._unpack_response`.
-
-        Ensure the method returns the response untouched.
-
-        """
-        response = {'entity name': {'field name': 'field value'}}
-        self.assertEqual(
-            response,
-            factory.Factory()._unpack_response(response)
-        )
 
 
 class SampleFactoryTestCase(TestCase):


### PR DESCRIPTION
Formerly, some server responses were in this format:

```
{'entity_name': {...}}
```

And some server responses were in this format:

```
{...}
```

Bugzilla bug 1087372 deals with this issue. Remove the code that allowed the
test client to deal with either type of response, as only the latter type of
response is now expected.
