### PR TITLE
Add str_type argument to StringField

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -97,6 +97,7 @@ nitpick_ignore = [
     ('py:obj', 'bool'),
     ('py:obj', 'dict'),
     ('py:obj', 'int'),
+    ('py:obj', 'sequence'),
     ('py:obj', 'str'),
     ('py:obj', 'tuple'),
 ]

--- a/robottelo/orm.py
+++ b/robottelo/orm.py
@@ -81,7 +81,7 @@ class IntegerField(booby.fields.Integer):
 
 class StringField(booby.fields.String):
     """Field that represents a string."""
-    def __init__(self, max_len=80, *args, **kwargs):
+    def __init__(self, max_len=80, str_type=('utf8',), *args, **kwargs):
         """Constructor for a ``StringField``.
 
         ``max_len`` is set to 80 for convenience. Many fields have a maximum
@@ -90,9 +90,13 @@ class StringField(booby.fields.String):
 
         :param int max_len: The maximum length of the string generated when
             :meth:`get_value` is called.
+        :param sequence str_type: The types of characters to generate when
+            :meth:`get-value` is called. Any argument which can be passed to
+            ``FauxFactory.generate_string`` can be provided in the sequence.
 
         """
         self.max_len = max_len
+        self.str_type = str_type
         super(StringField, self).__init__(*args, **kwargs)
 
     def get_value(self):
@@ -100,7 +104,7 @@ class StringField(booby.fields.String):
         return _get_value(
             self,
             lambda: FauxFactory.generate_string(
-                'utf8',
+                FauxFactory.generate_choice(self.str_type),
                 FauxFactory.generate_integer(1, self.max_len)
             )
         )
@@ -284,7 +288,7 @@ class Entity(booby.Model):
     # The id() builtin is still available within instance methods, class
     # methods, static methods, inner classes, and so on. However, id() is *not*
     # available at the current level of lexical scoping after this point.
-    id = IntegerField()
+    id = IntegerField()  # pylint:disable=C0103
 
     class Meta(object):
         """Non-field information about this entity.

--- a/tests/robottelo/test_orm.py
+++ b/tests/robottelo/test_orm.py
@@ -258,6 +258,31 @@ class StringFieldTestCase(unittest.TestCase):
         self.assertGreater(len(string), 0)
         self.assertLessEqual(len(string), 20)
 
+    def test_str_type(self):
+        """Set a ``str_type`` can call ``get_value``.
+
+        Assert the string generated is comprised of characters within the
+        specified character set.
+
+        """
+        # This can be shrunk down to about 5 lines of idiomatic code, but doing
+        # so totally destroys readability.
+        self.assertTrue(
+            orm.StringField(str_type=('alpha',)).get_value().isalpha()
+        )
+        self.assertTrue(
+            orm.StringField(str_type=['alpha']).get_value().isalpha()
+        )
+        self.assertTrue(
+            orm.StringField(str_type=('numeric',)).get_value().isnumeric()
+        )
+        self.assertTrue(
+            orm.StringField(str_type=['numeric']).get_value().isnumeric()
+        )
+
+        string = orm.StringField(str_type=('alpha', 'numeric')).get_value()
+        self.assertTrue(string.isalpha() or string.isnumeric())
+
 
 class GetClassTestCase(unittest.TestCase):
     """Tests for :func:`robottelo.orm._get_class`."""


### PR DESCRIPTION
Allow the following code to be written:

```
StringField(str_type=['alpha'])
```

Or:

```
StringField(str_type=('alpha',))
```
