### PR TITLE
Converted arch tests to data-driven

### DIFF
--- a/tests/foreman/ui/test_architecture.py
+++ b/tests/foreman/ui/test_architecture.py
@@ -6,7 +6,8 @@ Test class for Architecture UI
 """
 from ddt import ddt
 from robottelo.common.decorators import data
-from robottelo.common.helpers import generate_string, valid_names_list
+from robottelo.common.helpers import (generate_string, valid_names_list,
+                                      generate_strings_list)
 from robottelo.test import UITestCase
 from robottelo.ui.factory import (make_org, make_loc,
                                   make_os, make_arch)
@@ -33,21 +34,33 @@ class Architecture(UITestCase):
                 make_org(session, org_name=Architecture.org_name)
                 make_loc(session, name=Architecture.loc_name)
 
-    def test_positive_create_arch_1(self):
+    @data({u'name': generate_string('alpha', 10),
+           u'os_name': generate_string('alpha', 10),
+           u'major_version': generate_string('numeric', 1)},
+          {u'name': generate_string('html', 10),
+           u'os_name': generate_string('html', 10),
+           u'major_version': generate_string('numeric', 4)},
+          {u'name': generate_string('utf8', 10),
+           u'os_name': generate_string('utf8', 10),
+           u'major_version': generate_string('numeric', 5)},
+          {u'name': generate_string('alphanumeric', 255),
+           u'os_name': generate_string('alphanumeric', 255),
+           u'major_version': generate_string('numeric', 5)})
+    def test_positive_create_arch_1(self, test_data):
         """
         @Test: Create a new Architecture with OS
         @Feature: Architecture - Positive Create
         @Assert: Architecture is created
         """
-        name = generate_string("alpha", 4)
-        os_name = generate_string("alpha", 6)
-        major_version = generate_string('numeric', 1)
+
         with Session(self.browser) as session:
-            make_os(session, name=os_name,
-                    major_version=major_version)
-            self.assertIsNotNone(self.operatingsys.search(os_name))
-            make_arch(session, name=name, os_names=[os_name])
-            self.assertIsNotNone(self.architecture.search(name))
+            make_os(session, name=test_data['os_name'],
+                    major_version=test_data['major_version'])
+            self.assertIsNotNone(self.operatingsys.search
+                                 (test_data['os_name']))
+            make_arch(session, name=test_data['name'],
+                      os_names=test_data['os_name'])
+            self.assertIsNotNone(self.architecture.search(test_data['name']))
 
     @data(*valid_names_list())
     def test_positive_create_arch_2(self, name):
@@ -60,13 +73,14 @@ class Architecture(UITestCase):
             make_arch(session, name=name)
             self.assertIsNotNone(self.architecture.search(name))
 
-    def test_negative_create_arch_1(self):
+    @data(*generate_strings_list(len1=256))
+    def test_negative_create_arch_1(self, name):
         """
         @Test: Create a new Architecture with 256 characters in name
         @Feature: Architecture - Negative Create
         @Assert: Architecture is not created
         """
-        name = generate_string("alpha", 256)
+
         with Session(self.browser) as session:
             make_arch(session, name=name)
             self.assertIsNotNone(self.architecture.wait_until_element
@@ -97,13 +111,14 @@ class Architecture(UITestCase):
             self.assertIsNotNone(self.architecture.wait_until_element
                                  (common_locators["name_haserror"]))
 
-    def test_negative_create_arch_4(self):
+    @data(*generate_strings_list(len1=6))
+    def test_negative_create_arch_4(self, name):
         """
         @Test: Create a new Architecture with same name
         @Feature: Architecture - Negative Create
         @Assert: Architecture is not created
         """
-        name = generate_string("alpha", 4)
+
         with Session(self.browser) as session:
             make_arch(session, name=name)
             self.assertIsNotNone(self.architecture.search(name))
@@ -111,42 +126,69 @@ class Architecture(UITestCase):
             self.assertIsNotNone(self.architecture.wait_until_element
                                  (common_locators["name_haserror"]))
 
-    def test_remove_arch(self):
+    @data({u'name': generate_string('alpha', 10),
+           u'os_name': generate_string('alpha', 10),
+           u'major_version': generate_string('numeric', 1)},
+          {u'name': generate_string('html', 10),
+           u'os_name': generate_string('html', 10),
+           u'major_version': generate_string('numeric', 4)},
+          {u'name': generate_string('utf8', 10),
+           u'os_name': generate_string('utf8', 10),
+           u'major_version': generate_string('numeric', 5)},
+          {u'name': generate_string('alphanumeric', 255),
+           u'os_name': generate_string('alphanumeric', 255),
+           u'major_version': generate_string('numeric', 5)})
+    def test_remove_arch(self, test_data):
         """
         @Test: Delete an existing Architecture
         @Feature: Architecture - Delete
         @Assert: Architecture is deleted
         """
 
-        name = generate_string("alpha", 4)
-        os_name = generate_string("alpha", 6)
-        major_version = generate_string('numeric', 1)
         with Session(self.browser) as session:
-            make_os(session, name=os_name,
-                    major_version=major_version)
-            self.assertIsNotNone(self.operatingsys.search(os_name))
-            make_arch(session, name=name, os_names=[os_name])
-            self.assertIsNotNone(self.architecture.search(name))
-            self.architecture.delete(name, True)
-            self.assertIsNone(self.architecture.search(name))
+            make_os(session, name=test_data['os_name'],
+                    major_version=test_data['major_version'])
+            self.assertIsNotNone(self.operatingsys.search
+                                 (test_data['os_name']))
+            make_arch(session, name=test_data['name'],
+                      os_names=test_data['os_name'])
+            self.assertIsNotNone(self.architecture.search(test_data['name']))
+            self.architecture.delete(test_data['name'], True)
+            self.assertIsNone(self.architecture.search(test_data['name']))
 
-    def test_update_arch(self):
+    @data({u'old_name': generate_string('alpha', 10),
+           u'new_name': generate_string('alpha', 10),
+           u'os_name': generate_string('alpha', 10),
+           u'major_version': generate_string('numeric', 1)},
+          {u'old_name': generate_string('html', 10),
+           u'new_name': generate_string('html', 10),
+           u'os_name': generate_string('html', 10),
+           u'major_version': generate_string('numeric', 4)},
+          {u'old_name': generate_string('utf8', 10),
+           u'new_name': generate_string('utf8', 10),
+           u'os_name': generate_string('utf8', 10),
+           u'major_version': generate_string('numeric', 5)},
+          {u'old_name': generate_string('alphanumeric', 255),
+           u'new_name': generate_string('alphanumeric', 255),
+           u'os_name': generate_string('alphanumeric', 255),
+           u'major_version': generate_string('numeric', 5)})
+    def test_update_arch(self, test_data):
         """
         @Test: Update Architecture with new name and OS
         @Feature: Architecture - Update
         @Assert: Architecture is updated
         """
 
-        old_name = generate_string("alpha", 6)
-        new_name = generate_string("alpha", 4)
-        os_name = generate_string("alpha", 6)
-        major_version = generate_string('numeric', 1)
         with Session(self.browser) as session:
-            make_os(session, name=os_name,
-                    major_version=major_version)
-            self.assertIsNotNone(self.operatingsys.search(os_name))
-            make_arch(session, name=old_name)
-            self.assertIsNotNone(self.architecture.search(old_name))
-            self.architecture.update(old_name, new_name,
-                                     new_os_names=[os_name])
-            self.assertIsNotNone(self.architecture.search(new_name))
+            make_os(session, name=test_data['os_name'],
+                    major_version=test_data['major_version'])
+            self.assertIsNotNone(self.operatingsys.search
+                                 (test_data['os_name']))
+            make_arch(session, name=test_data['old_name'])
+            self.assertIsNotNone(self.architecture.search
+                                 (test_data['old_name']))
+            self.architecture.update(test_data['old_name'],
+                                     test_data['new_name'],
+                                     new_os_names=test_data['os_name'])
+            self.assertIsNotNone(self.architecture.search
+                                 (test_data['new_name']))


### PR DESCRIPTION
Y'day PR #1076 was merged where tests were not implemented as data-driven. So updated all arch tests to data-driven in this PR.
