### PR TITLE
DO NOT MERGE:Manifest mock

### DIFF
--- a/robottelo/common/manifests.py
+++ b/robottelo/common/manifests.py
@@ -24,11 +24,11 @@ def sign(key_file, file_to_sign):
 
     Returns binary signature data.
     """
-    with open(key_file).read() as k:
-        key = RSA.importKey(k)
+    with open(key_file) as k:
+        key = RSA.importKey(k.read())
         signature = PKCS1_v1_5.new(key)
-        with open(file_to_sign, "rb").read() as data:
-            digest = SHA256.new(data)
+        with open(file_to_sign, "rb") as data:
+            digest = SHA256.new(data.read())
             return signature.sign(digest)
 
 


### PR DESCRIPTION
Usage:

1) grab `fake_manifest.key` on your machine

``` bash
cd /tmp
wget http://cosmos.lab.eng.pnq.redhat.com/rhel64/fake_manifest.key
```

2) install  `fake_manifest.cert` on candlepin server

``` bash
ssh root@qetello02.usersys.redhat.com
cd /etc/candlepin/certs/upstream/
wget cosmos.lab.eng.pnq.redhat.com/rhel64/fake_manifest.crt
service tomcat6 restart
```

3) download a valid manifest (for example to `/tmp/manifest.zip`)

4) in python:

``` python
from robottelo.common.manifests import clone
clone("/tmp/fake_manifest.key", "/tmp/manifest.zip", "/tmp/manifest2.zip")
```

5) `/tmp/manifest2.zip` should be an uploadable new manifest :)

Unfortunately, for now, candlepin complains:

> The archive does not contain the required meta.json file

I can't figure out why. If you'd figure that out, we have infinite manifest supply at our disposal :)
