### PR TITLE
Make factories respect entity kwargs.

### DIFF
--- a/robottelo/orm.py
+++ b/robottelo/orm.py
@@ -364,3 +364,28 @@ class Entity(booby.Model):
 
         """
         return booby.inspection.get_fields(cls)
+
+    # FIXME: See GitHub issue #1082.
+    def get_values(self):
+        """Return all field values as a dictionary.
+
+        All fields with a value of ``None`` are omitted from the returned dict.
+        For example, if this entity is created::
+
+            SomeEntity(name='foo', description=None)
+
+        This dict is returned::
+
+            {'name': 'foo'}
+
+        This is a bug. See GitHub issue #1082.
+
+        :return: A dictionary mapping field names to field values.
+        :rtype: dict
+
+        """
+        fields = dict(self)
+        for key, value in fields.items():
+            if value is None:
+                fields.pop(key)
+        return fields

--- a/tests/robottelo/test_factory.py
+++ b/tests/robottelo/test_factory.py
@@ -45,6 +45,15 @@ class MockErrorResponse(object):  # too-few-public-methods pylint:disable=R0903
         return {'error': {'error name': 'error message'}}
 
 
+class SampleEntityFactory(orm.Entity, factory.EntityFactoryMixin):
+    """
+    A class which inherits from :class:`robottelo.factory.Factory` and
+    :class:`robottelo.factory.EntityFactoryMixin`.
+    """
+    name = orm.StringField(required=True)
+    label = orm.StringField()
+
+
 class IsRequiredTestCase(TestCase):
     """Tests for :func:`robottelo.factory.field_is_required`."""
     # (protected-access) pylint:disable=W0212
@@ -231,3 +240,29 @@ class SampleFactoryTestCase(TestCase):
         client.post = lambda url, data=None, **kwargs: MockErrorResponse()
         with self.assertRaises(factory.FactoryError):
             SampleFactory().create()
+
+
+class SampleEntityFactoryTestCase(TestCase):
+    """Tests for :class:`SampleEntityFactory`."""
+    # (protected-access) pylint:disable=W0212
+    def test_implicit_fields(self):
+        """
+        Assert :meth:`robottelo.factory.EntityFactoryMixin._factory_data`
+        returns only required fields.
+        """
+        attrs = SampleEntityFactory()._factory_data()
+        self.assertIn('name', attrs.keys())
+        self.assertNotIn('label', attrs.keys())
+
+    def test_explicit_fields(self):
+        """
+        Assert :meth:`robottelo.factory.EntityFactoryMixin._factory_data`
+        returns explicitly-specified values.
+        """
+        name = orm.StringField().get_value()
+        label = orm.StringField().get_value()
+        attrs = SampleEntityFactory(name=name, label=label)._factory_data()
+        self.assertIn('name', attrs.keys())
+        self.assertIn('label', attrs.keys())
+        self.assertEqual(attrs['name'], name)
+        self.assertEqual(attrs['label'], label)

--- a/tests/robottelo/test_orm.py
+++ b/tests/robottelo/test_orm.py
@@ -20,6 +20,7 @@ class SampleEntity(orm.Entity):
     value = orm.IntegerField()
 
     class Meta(object):
+        """Non-field attributes for this entity."""
         api_path = 'foo'
 
 
@@ -44,6 +45,31 @@ class EntityTestCase(unittest.TestCase):
     def tearDown(self):  # pylint:disable=C0103
         """Restore ``conf.properties``."""
         conf.properties = self.conf_properties
+
+    def test_entity_get_values(self):
+        """Test :meth:`robottelo.orm.Entity.get_values`."""
+        name = orm.StringField().get_value()
+        value = orm.IntegerField().get_value()
+
+        # First, provide a name.
+        values = SampleEntity(name=name).get_values()
+        self.assertIn('name', values.keys())
+        self.assertNotIn('value', values.keys())
+        self.assertEqual(values['name'], name)
+
+        # Second, provide a value.
+        values = SampleEntity(value=value).get_values()
+        self.assertNotIn('name', values.keys())
+        self.assertIn('value', values.keys())
+        self.assertEqual(values['value'], value)
+
+        # Third, provide a name and value.
+        values = SampleEntity(name=name, value=value).get_values()
+        self.assertIn('name', values.keys())
+        self.assertIn('value', values.keys())
+        self.assertEqual(values['name'], name)
+        self.assertEqual(values['value'], value)
+
 
     def test_entity_get_fields(self):
         """Test :meth:`robottelo.orm.Entity.get_fields`."""


### PR DESCRIPTION
Allow the following lines of code to act as expected:

```
SomeEntity(name='foo').attributes()
SomeEntity(name='foo').build()
SomeEntity(name='foo').create()
```

Unfortunately, the value of `None` is not supported:

```
SomeEntity(name=None).attributes()
SomeEntity(name=None).build()
SomeEntity(name=None).create()
```

See GitHub issue #1082 for more information.

Add tests for the following methods:
- `EntityFactoryMixin._factory_data`
- `Entity.get_values`
