### PR TITLE
Fix docstrings

### DIFF
--- a/tests/foreman/api/test_activationkey_v2.py
+++ b/tests/foreman/api/test_activationkey_v2.py
@@ -1,7 +1,7 @@
 """Unit tests for the ``activationkeys`` paths.
 
 Each ``TestCase`` subclass tests a single URL. A full list of URLs to be tested
-can be found here: http://theforeman.org/api/apidoc/v2/activation_keys
+can be found here: http://theforeman.org/api/apidoc/v2/activation_keys.html
 
 """
 from ddt import data, ddt

--- a/tests/foreman/api/test_host_v2.py
+++ b/tests/foreman/api/test_host_v2.py
@@ -1,7 +1,7 @@
 """Unit tests for the ``hosts`` paths.
 
 Each ``TestCase`` subclass tests a single URL. A full list of URLs to be tested
-can be found here: http://theforeman.org/api/apidoc/v2/hosts
+can be found here: http://theforeman.org/api/apidoc/v2/hosts.html
 
 """
 from fauxfactory import FauxFactory

--- a/tests/foreman/api/test_organization_v2.py
+++ b/tests/foreman/api/test_organization_v2.py
@@ -1,7 +1,7 @@
 """Unit tests for the ``organizations`` paths.
 
 Each ``TestCase`` subclass tests a single URL. A full list of URLs to be tested
-can be found here: http://theforeman.org/api/apidoc/v2/organizations
+can be found here: http://theforeman.org/api/apidoc/v2/organizations.html
 
 """
 from robottelo.api import client

--- a/tests/foreman/api/test_user_v2.py
+++ b/tests/foreman/api/test_user_v2.py
@@ -1,7 +1,7 @@
 """Unit tests for the ``users`` paths.
 
 Each ``TestCase`` subclass tests a single URL. A full list of URLs to be tested
-can be found here: http://theforeman.org/api/apidoc/v2/users
+can be found here: http://theforeman.org/api/apidoc/v2/users.html
 
 """
 from ddt import data, ddt


### PR DESCRIPTION
If the ".html" extension is omitted, then the linked-to-page will only show a
single path/method combination. If the ".html" extension is added, the
linked-to-page will show all available path/method combinations for an entity.
