### PR TITLE
Re-enabling Organization deletion tests via CLI.

### DIFF
--- a/tests/foreman/cli/test_org.py
+++ b/tests/foreman/cli/test_org.py
@@ -173,7 +173,6 @@ class TestOrg(CLITestCase):
         self.assertEqual(new_obj['name'],
                          result.stdout['name'])
 
-    @stubbed('Organization deletion is disabled')
     def test_bugzilla_1076568_1(self):
         """
         @test: Delete organization by name
@@ -211,7 +210,6 @@ class TestOrg(CLITestCase):
         self.assertEqual(
             len(result.stdout), 0, "Output should be blank.")
 
-    @stubbed('Organization deletion is disabled')
     def test_bugzilla_1076568_2(self):
         """
         @test: Delete organization by ID
@@ -249,7 +247,6 @@ class TestOrg(CLITestCase):
         self.assertEqual(
             len(result.stdout), 0, "Output should be blank.")
 
-    @stubbed('Organization deletion is disabled')
     def test_bugzilla_1076568_3(self):
         """
         @test: Delete organization by label
@@ -358,15 +355,11 @@ class TestOrg(CLITestCase):
 
         self.assertEqual(new_obj['name'], result.stdout['name'])
 
-    @stubbed('Organization deletion is disabled')
-    @skip_if_bz_bug_open('1096241')
-    @skip_if_bz_bug_open('1061658')
     def test_bugzilla_1061658(self):
         """
         @Test: Organization delete fails with 500 Server / Candlepin 404 error
         @Feature: Org
         @Assert: Organization is created and deleted
-        @bz: 1096241, 1061658
         """
         new_obj = make_org()
         return_value = Org.delete({'id': new_obj['id']})
@@ -956,7 +949,6 @@ class TestOrg(CLITestCase):
 
     # Positive Delete
 
-    @stubbed('Organization deletion is disabled')
     @data(*positive_name_desc_label_data())
     def test_positive_delete_1(self, test_data):
         """
@@ -989,7 +981,6 @@ class TestOrg(CLITestCase):
         self.assertEqual(
             len(result.stdout), 0, "Output should be blank.")
 
-    @stubbed('Organization deletion is disabled')
     @data(*positive_name_desc_label_data())
     def test_positive_delete_2(self, test_data):
         """
@@ -1022,7 +1013,6 @@ class TestOrg(CLITestCase):
         self.assertEqual(
             len(result.stdout), 0, "Output should be blank.")
 
-    @stubbed('Organization deletion is disabled')
     @data(*positive_name_desc_label_data())
     def test_positive_delete_3(self, test_data):
         """


### PR DESCRIPTION
Since most (if not all) Bugzilla issues related to org deletion are now
closed or ready for testing, it is safe to re-enable the CLI tests that
we had disabled before.

The Bugzilla issues are:
- https://bugzilla.redhat.com/show_bug.cgi?id=1061658
- https://bugzilla.redhat.com/show_bug.cgi?id=1076568
- https://bugzilla.redhat.com/show_bug.cgi?id=1096241
- https://bugzilla.redhat.com/show_bug.cgi?id=1100311
- https://bugzilla.redhat.com/show_bug.cgi?id=1120336

The modified tests were run against build:
- Satellite-6.0.4-RHEL-6-20140730.0

``` bash
$ nosetests -c robottelo.properties tests/foreman/cli/test_org.py:TestOrg.test_bugzilla_1076568_1 tests/foreman/cli/test_org.py:TestOrg.test_bugzilla_1076568_2 tests/foreman/cli/test_org.py:TestOrg.test_bugzilla_1076568_3 tests/foreman/cli/test_org.py:TestOrg.test_bugzilla_1061658
nose.config: INFO: Ignoring files matching ['^\\.', '^_', '^setup\\.py$']
@test: Delete organization by name ... ok
@test: Delete organization by ID ... ok
@test: Delete organization by label ... ok
@Test: Organization delete fails with 500 Server / Candlepin 404 error ... ok

Ran 4 tests in 106.166s

OK
$ nosetests -c robottelo.properties -m test_positive_delete_1 tests/foreman/cli/test_org.py
nose.config: INFO: Ignoring files matching ['^\\.', '^_', '^setup\\.py$']
@test: Create organization with valid values then delete it ... ok
@test: Create organization with valid values then delete it ... ok
@test: Create organization with valid values then delete it ... ok
@test: Create organization with valid values then delete it ... ok

Ran 4 tests in 106.037s

OK
$ nosetests -c robottelo.properties -m test_positive_delete_2 tests/foreman/cli/test_org.py
nose.config: INFO: Ignoring files matching ['^\\.', '^_', '^setup\\.py$']
@test: Create organization with valid values then delete it ... ok
@test: Create organization with valid values then delete it ... ok
@test: Create organization with valid values then delete it ... ok
@test: Create organization with valid values then delete it ... ok

Ran 4 tests in 111.509s

OK
$ nosetests -c robottelo.properties -m test_positive_delete_3 tests/foreman/cli/test_org.py
nose.config: INFO: Ignoring files matching ['^\\.', '^_', '^setup\\.py$']
@test: Create organization with valid values then delete it ... ok
@test: Create organization with valid values then delete it ... ok
@test: Create organization with valid values then delete it ... ok
@test: Create organization with valid values then delete it ... ok

Ran 4 tests in 111.231s

OK
```
