### PR TITLE
Updated ActivationKey API v2 Tests.

### DIFF
--- a/tests/foreman/api/test_activationkey_v2.py
+++ b/tests/foreman/api/test_activationkey_v2.py
@@ -69,47 +69,12 @@ class ActivationKeysTestCase(TestCase):
         )
 
     @data(
-        IntegerField(min_val=-10, max_val=-1).get_value(),
-        IntegerField(min_val=1, max_val=20).get_value(),
-        StringField(str_type=('alpha',)).get_value(),
-    )
-    def test_positive_create_3(self, max_content_hosts):
-        """
-        @Test Create activationkey with unlimited content hosts and set
-          max content hosts of varied values
-        @Assert:
-          1. Activationkey is created
-          2. Unlimited content host is True
-          3. max content hosts is None
-        @Feature: ActivationKey
-        """
-        try:
-            attrs = entities.ActivationKey().create(fields={
-                u'unlimited_content_hosts': True,
-                u'max_content_hosts': max_content_hosts
-            })
-        except FactoryError as err:
-            self.fail(err)
-        # Assert that it defaults to limited content host...
-        self.assertTrue(
-            attrs['unlimited_content_hosts'],
-            u"Unlimited content hosts is {0}".format(
-                attrs['unlimited_content_hosts'])
-        )
-        # ...and max_content_host is None
-        self.assertIsNone(
-            attrs['max_content_hosts'],
-            u"Max content hosts value is not None: {0}".format(
-                attrs['max_content_hosts'])
-        )
-
-    @data(
         StringField(str_type=('alpha',)).get_value(),
         StringField(str_type=('alphanumeric',)).get_value(),
         StringField(str_type=('cjk',)).get_value(),
         StringField(str_type=('latin1',)).get_value(),
     )
-    def test_positive_create_4(self, name):
+    def test_positive_create_3(self, name):
         """
         @Test Create an activationkey providing the initial name.
         @Assert: Activationkey is created and contains provided name.
@@ -164,6 +129,25 @@ class ActivationKeysTestCase(TestCase):
                     u'max_content_hosts': max_content_hosts
                 }
             )
+
+    @data(
+        IntegerField(min_val=-10, max_val=-1).get_value(),
+        IntegerField(min_val=1, max_val=20).get_value(),
+        StringField(str_type=('alpha',)).get_value(),
+    )
+    def test_negative_create_3(self, max_content_hosts):
+        """
+        @Test Create activationkey with unlimited content hosts and set
+          max content hosts of varied values
+        @Assert:
+          1. Activationkey is not created
+        @Feature: ActivationKey
+        """
+        with self.assertRaises(FactoryError):
+            entities.ActivationKey().create(fields={
+                u'unlimited_content_hosts': True,
+                u'max_content_hosts': max_content_hosts
+            })
 
     @data(
         IntegerField(min_val=1, max_val=30).get_value(),


### PR DESCRIPTION
Noticed that `test_positive_create_3` was failing because of some
apparent changes done to the POST method. Before, if I tried to create
an activationkey setting `unlimited_content_hosts` to `True` and
`max_content_hosts` to a random value, valid or invalid, the
activationkey was created and `max_content_hosts` was ignored and set
to `None` (the test checked that the key was created and that
`max_content_hosts` was `None`).

Now it looks that if you try to do the same thing, you get a `422`
error due to `max_content_hosts` being automatically set to `Nil`.

``` pycon
In[1] attrs =
entities.ActivationKey().create(
    fields={u'unlimited_content_hosts': True, u'max_content_hosts': -3})

FactoryError: Error encountered while POSTing to
https://qetello02.usersys.redhat.com/katello/api/v2/activation_keys.
Error received: {u'max_content_hosts': [u'cannot be nil']}
```

I have changed this test to be a negative test and updated the
assertions appropriately.
