### PR TITLE
Rename methods

### DIFF
--- a/tests/foreman/api/test_multiple_paths.py
+++ b/tests/foreman/api/test_multiple_paths.py
@@ -20,7 +20,7 @@ class EntityTestCase(TestCase):
         entities.OperatingSystem,
         entities.Organization,
     )
-    def test_get(self, entity):
+    def test_get_status_code(self, entity):
         """@Test GET an entity-dependent path.
 
         @Assert: HTTP 200 is returned with an ``application/json`` content-type
@@ -133,7 +133,7 @@ class EntityIdTestCase(TestCase):
         entities.Organization,
         entities.Repository,
     )
-    def test_get(self, entity):
+    def test_get_status_code(self, entity):
         """@Test: Create an entity and GET it.
 
         @Assert: HTTP 200 is returned with an ``application/json`` content-type


### PR DESCRIPTION
Rename method `test_get` to `test_get_status_code`, both in classes
`EntityTestCase` and `EntityIdTestCase`. This rename is performed for two
reasons:
- The new names are more descriptive.
- The new names allow one to more precisely select which test should be run when
  using nosetest's `-m` regex option. Formerly, issuing `nosetests -m test_get`
  would cause methods `test_get` and `test_get_unauthorized` to run. Now, one
  can issue `nosetests -m test_get_status_code` and run a more precise set of
  tests.
