### PR TITLE
Fix 22 Sphinx warnings.

### DIFF
--- a/docs/api/tests.foreman.smoke.rst
+++ b/docs/api/tests.foreman.smoke.rst
@@ -5,16 +5,16 @@
     :members:
     :undoc-members:
 
-:mod:`tests.foreman.installer.test_api_smoke`
----------------------------------------------
+:mod:`tests.foreman.smoke.test_api_smoke`
+-----------------------------------------
 
-.. automodule:: tests.foreman.installer.test_api_smoke
+.. automodule:: tests.foreman.smoke.test_api_smoke
     :members:
     :undoc-members:
 
-:mod:`tests.foreman.installer.test_cli_smoke`
----------------------------------------------
+:mod:`tests.foreman.smoke.test_cli_smoke`
+-----------------------------------------
 
-.. automodule:: tests.foreman.installer.test_cli_smoke
+.. automodule:: tests.foreman.smoke.test_cli_smoke
     :members:
     :undoc-members:

--- a/robottelo/cli/factory.py
+++ b/robottelo/cli/factory.py
@@ -103,9 +103,11 @@ def create_object(cli_object, args):
 def make_activation_key(options=None):
     """
     Usage::
+
         hammer activation-key create [OPTIONS]
 
     Options::
+
         --content-view CONTENT_VIEW_NAME Content view name to search by
         --content-view-id CONTENT_VIEW_ID content view numeric identifier
         --description DESCRIPTION     description

--- a/tests/foreman/api/test_activationkey_v2.py
+++ b/tests/foreman/api/test_activationkey_v2.py
@@ -118,7 +118,7 @@ class ActivationKeysTestCase(TestCase):
     def test_negative_create_2(self, max_content_hosts):
         """
         @Test Create activationkey with limited content hosts but
-          with invalid limit values
+        with invalid limit values
         @Assert: Activationkey is not created
         @Feature: ActivationKey
         """
@@ -138,9 +138,9 @@ class ActivationKeysTestCase(TestCase):
     def test_negative_create_3(self, max_content_hosts):
         """
         @Test Create activationkey with unlimited content hosts and set
-          max content hosts of varied values
+        max content hosts of varied values
         @Assert:
-          1. Activationkey is not created
+        1. Activationkey is not created
         @Feature: ActivationKey
         """
         with self.assertRaises(FactoryError):
@@ -231,9 +231,9 @@ class ActivationKeysTestCase(TestCase):
         """
         @Test Create activationkey then update its limit to invalid value
         @Assert:
-          1. ActivationKey is created
-          2. Update fails
-          3. Record is not changed
+        1. ActivationKey is created
+        2. Update fails
+        3. Record is not changed
         @Feature: ActivationKey
         """
         try:

--- a/tests/foreman/smoke/test_api_smoke.py
+++ b/tests/foreman/smoke/test_api_smoke.py
@@ -90,23 +90,25 @@ class TestSmoke(TestCase):
     def test_smoke(self):
         """
         @Test: Check that basic content can be created
-            * Create a new user with admin permissions
-            * Using the new user from above:
-              * Create a new organization
-              * Create two new lifecycle environments
-              * Create a custom product
-              * Create a custom YUM repository
-              * Create a custom PUPPET repository
-              * Synchronize both custom repositories
-              * Create a new content view
-              * Associate both repositories to new content view
-              * Publish content view
-              * Promote content view to both lifecycles
-              * Create a new libvirt compute resource
-              * Create a new subnet
-              * Create a new domain
-              * Create a new capsule
-              * Create a new hostgroup and associate previous entities to it
+        * Create a new user with admin permissions
+        * Using the new user from above:
+
+            * Create a new organization
+            * Create two new lifecycle environments
+            * Create a custom product
+            * Create a custom YUM repository
+            * Create a custom PUPPET repository
+            * Synchronize both custom repositories
+            * Create a new content view
+            * Associate both repositories to new content view
+            * Publish content view
+            * Promote content view to both lifecycles
+            * Create a new libvirt compute resource
+            * Create a new subnet
+            * Create a new domain
+            * Create a new capsule
+            * Create a new hostgroup and associate previous entities to it
+
         @Feature: Smoke Test
         @Assert: All entities are created and associated.
         """

--- a/tests/foreman/smoke/test_cli_smoke.py
+++ b/tests/foreman/smoke/test_cli_smoke.py
@@ -85,23 +85,25 @@ class TestSmoke(CLITestCase):
     def test_smoke(self):
         """
         @Test: Check that basic content can be created
-            * Create a new user with admin permissions
-            * Using the new user from above:
-              * Create a new organization
-              * Create two new lifecycle environments
-              * Create a custom product
-              * Create a custom YUM repository
-              * Create a custom PUPPET repository
-              * Synchronize both custom repositories
-              * Create a new content view
-              * Associate both repositories to new content view
-              * Publish content view
-              * Promote content view to both lifecycles
-              * Create a new libvirt compute resource
-              * Create a new subnet
-              * Create a new domain
-              * Create a new capsule
-              * Create a new hostgroup and associate previous entities to it
+        * Create a new user with admin permissions
+        * Using the new user from above:
+
+            * Create a new organization
+            * Create two new lifecycle environments
+            * Create a custom product
+            * Create a custom YUM repository
+            * Create a custom PUPPET repository
+            * Synchronize both custom repositories
+            * Create a new content view
+            * Associate both repositories to new content view
+            * Publish content view
+            * Promote content view to both lifecycles
+            * Create a new libvirt compute resource
+            * Create a new subnet
+            * Create a new domain
+            * Create a new capsule
+            * Create a new hostgroup and associate previous entities to it
+
         @Feature: Smoke Test
         @Assert: All entities are created and associated.
         """


### PR DESCRIPTION
Only the usual 6 warnings are still emitted. Among the warnings fixed were:
- References to modules that did not exist.
- Missing blank lines before code blocks.
- Missing blank lines before and after nested lists.
- Spuriously indented text.
