### PR TITLE
Make DDT and skip_if_bug_open play nicely together

### DIFF
--- a/robottelo/common/decorators.py
+++ b/robottelo/common/decorators.py
@@ -6,6 +6,7 @@ Implements various decorators
 """
 
 import bugzilla
+import functools
 import logging
 import random
 import requests
@@ -257,6 +258,7 @@ class skip_if_bug_open(object):  # pylint:disable=C0103,R0903
         :param func: The function being decorated.
 
         """
+        @functools.wraps(func)
         def wrapper_func(*args, **kwargs):
             """Run ``func`` or skip it by raising an exception.
 


### PR DESCRIPTION
When the `@ddt` decorator is applied to a `unittest.TestCase` subclass, the
decorator modifies the all of that test case's methods. This is by design, and it is
correct behaviour. Unfortunately, the `skip_if_bug_open` decorator is a class,
so applying the decorator to a test method makes it... not a method. This
inadverdently causes the test to be skipped completely.

Fix issue #1158. Prevent test methods from disappearing.
