### PR TITLE
[DO NOT MERGE] Make decorator `skip_if_bug_open` more flexible

### DIFF
--- a/tests/foreman/cli/test_contenthost.py
+++ b/tests/foreman/cli/test_contenthost.py
@@ -20,6 +20,7 @@ from robottelo.common.helpers import generate_string
 from robottelo.test import CLITestCase
 
 
+@skip_if_bug_open('bugzilla', 1127629)
 @ddt
 class TestContentHost(CLITestCase):
 
@@ -34,7 +35,6 @@ class TestContentHost(CLITestCase):
     LIBRARY = None
     DEFAULT_CV = None
 
-    @skip_if_bug_open('bugzilla', 1127629)  # skip entire class
     def setUp(self):
         """
         Tests for Content Host via Hammer CLI


### PR DESCRIPTION
Make it possible to use decorator `skip_if_bug_open` on either test methods or
test cases. As part of this effort, move some business logic from
`skip_if_bug_open` to a helper function, and expand the set of tests in
`test_decorators.py` to exercise this new helper function.
