### PR TITLE
Add API tests for LifecycleEnvironment and GPGKey

### DIFF
--- a/robottelo/entities.py
+++ b/robottelo/entities.py
@@ -15,7 +15,6 @@ useful to :class:`robottelo.factory.EntityFactoryMixin`.
 from robottelo.common.constants import VALID_GPG_KEY_FILE
 from robottelo.common.helpers import get_data_file
 from robottelo import factory, orm
-import urlparse
 # (too-few-public-methods) pylint:disable=R0903
 
 
@@ -531,14 +530,18 @@ class Interface(orm.Entity):
         api_path = 'api/v2/hosts/:host_id/interfaces'
 
 
-class LifecycleEnvironment(orm.Entity):
+class LifecycleEnvironment(orm.Entity, factory.EntityFactoryMixin):
     """A representation of a Lifecycle Environment entity."""
     organization = orm.OneToOneField('Organization', required=True)
     name = orm.StringField(required=True)
     description = orm.StringField()
     # Name of an environment that is prior to the new environment in the chain.
     # It has to be either 'Library' or an environment at the end of a chain.
-    prior = orm.StringField(default='Library', required=True)
+    prior = orm.OneToOneField(
+        'LifecycleEnvironment',
+        default=None,
+        required=True,
+    )
 
     class Meta(object):
         """Non-field information about this entity."""

--- a/tests/foreman/api/test_gpgkey_v2.py
+++ b/tests/foreman/api/test_gpgkey_v2.py
@@ -1,0 +1,34 @@
+"""Unit tests for the ``gpgkeys`` paths.
+
+Each ``TestCase`` subclass tests a single URL. A full list of URLs to be tested
+can be found here: http://theforeman.org/api/apidoc/v2/gpgkeys.html
+
+"""
+from robottelo.api import client
+from robottelo.common.helpers import get_server_credentials
+from robottelo import entities
+from unittest import TestCase
+import httplib
+# (too many public methods) pylint: disable=R0904
+
+
+class GPGKeyTestCase(TestCase):
+    """Tests for ``katello/api/v2/gpg_keys``."""
+    def test_get_all(self):
+        """@Test: Get ``katello/api/v2/gpg_keys`` and specify just an
+        organization ID.
+
+        @Feature: GPGKey
+
+        @Assert: HTTP 200 is returned with an ``application/json`` content-type
+
+        """
+        org_attrs = entities.Organization().create()
+        response = client.get(
+            entities.GPGKey().path(),
+            auth=get_server_credentials(),
+            params={'organization_id': org_attrs['id']},
+            verify=False,
+        )
+        self.assertEqual(response.status_code, httplib.OK)
+        self.assertIn('application/json', response.headers['content-type'])

--- a/tests/foreman/api/test_lifecycleenvironment_v2.py
+++ b/tests/foreman/api/test_lifecycleenvironment_v2.py
@@ -1,0 +1,34 @@
+"""Unit tests for the ``environments`` paths.
+
+Each ``TestCase`` subclass tests a single URL. A full list of URLs to be tested
+can be found here: http://theforeman.org/api/apidoc/v2/environments.html
+
+"""
+from robottelo.api import client
+from robottelo.common.helpers import get_server_credentials
+from robottelo import entities
+from unittest import TestCase
+import httplib
+# (too many public methods) pylint: disable=R0904
+
+
+class LifecycleEnvironmentTestCase(TestCase):
+    """Tests for ``katello/api/v2/environments``."""
+    def test_get_all(self):
+        """@Test: Get ``katello/api/v2/environments`` and specify just an
+        organization ID.
+
+        @Feature: LifecycleEnvironment
+
+        @Assert: HTTP 200 is returned with an ``application/json`` content-type
+
+        """
+        org_attrs = entities.Organization().create()
+        response = client.get(
+            entities.LifecycleEnvironment().path(),
+            auth=get_server_credentials(),
+            params={'organization_id': org_attrs['id']},
+            verify=False,
+        )
+        self.assertEqual(response.status_code, httplib.OK)
+        self.assertIn('application/json', response.headers['content-type'])

--- a/tests/foreman/api/test_multiple_paths.py
+++ b/tests/foreman/api/test_multiple_paths.py
@@ -24,6 +24,7 @@ class EntityTestCase(TestCase):
         entities.Domain,
         # entities.GPGKey,  # must specify an organization id
         entities.Host,
+        # entities.LifecycleEnvironment,  # must specify an organization id
         entities.Model,
         entities.OperatingSystem,
         entities.Organization,
@@ -53,6 +54,7 @@ class EntityTestCase(TestCase):
         entities.Domain,
         entities.GPGKey,
         entities.Host,
+        entities.LifecycleEnvironment,
         entities.Model,
         entities.OperatingSystem,
         entities.Organization,
@@ -77,6 +79,7 @@ class EntityTestCase(TestCase):
         entities.ContentView,
         entities.Domain,
         entities.GPGKey,
+        entities.LifecycleEnvironment,
         entities.Model,
         entities.OperatingSystem,
         entities.Organization,
@@ -90,6 +93,8 @@ class EntityTestCase(TestCase):
         """
         if entity in BZ_1118015_ENTITIES and bz_bug_is_open(1118015):
             self.skipTest("Bugzilla bug 1118015 is open.""")
+        if entity is entities.LifecycleEnvironment and bz_bug_is_open(1129441):
+            self.skipTest("Bugzilla bug 1129441 is open.""")
         path = entity().path()
         response = client.post(
             path,
@@ -112,6 +117,7 @@ class EntityTestCase(TestCase):
         entities.Domain,
         entities.GPGKey,
         entities.Host,
+        entities.LifecycleEnvironment,
         entities.Model,
         entities.OperatingSystem,
         entities.Organization,


### PR DESCRIPTION
Add several API tests which target the following URLs:
- `katello/api/v2/gpg_keys`
- `katello/api/v2/environments`

Many tests were already in place for GPG keys. However, there was no test for
issuing a GET to `katello/api/v2/gpg_keys`. This commit fixes that. In contrast,
there were no tests for lifecycle environments, and this commit adds a basic set
of HTTP POST and GET requests for lifecycle environments.
