### PR TITLE
Fixed validation error locators for foreman entities

### DIFF
--- a/robottelo/ui/locators.py
+++ b/robottelo/ui/locators.py
@@ -522,6 +522,9 @@ common_locators = {
     "common_invalid": (
         By.XPATH,
         "//input[@id='name' and contains(@class,'ng-invalid')]"),
+    "common_param_error": (
+        By.XPATH,
+        "//div[@class='fields']/span[@class='help-block']"),
 
     "cv_filter": (
         By.XPATH, "//input[@ng-model='filterTerm' and @placeholder='Filter']"),

--- a/tests/foreman/ui/test_architecture.py
+++ b/tests/foreman/ui/test_architecture.py
@@ -84,7 +84,7 @@ class Architecture(UITestCase):
         with Session(self.browser) as session:
             make_arch(session, name=name)
             self.assertIsNotNone(self.architecture.wait_until_element
-                                 (common_locators["alert.error"]))
+                                 (common_locators["name_haserror"]))
             self.assertIsNone(self.architecture.search(name))
 
     def test_negative_create_arch_2(self):

--- a/tests/foreman/ui/test_domain.py
+++ b/tests/foreman/ui/test_domain.py
@@ -141,7 +141,7 @@ class Domain(UITestCase):
 
     def test_negative_create_domain_3(self):
         """
-        @Test: Negative create a domain with whitespce name
+        @Test: Negative create a domain with whitespace name
         @Feature: Domain - Negative Create
         @Assert: Domain is not created
         """
@@ -156,7 +156,7 @@ class Domain(UITestCase):
     @data(*generate_strings_list(len1=4))
     def test_set_parameter_1(self, name):
         """
-        @Test: Set paramter name and value for domain
+        @Test: Set parameter name and value for domain
         @Feature: Domain - Misc
         @Assert: Domain is updated
         """
@@ -196,7 +196,7 @@ class Domain(UITestCase):
     @skip_if_bug_open('bugzilla', 1120685)
     def test_set_parameter_negative_1(self):
         """
-        @Test: Set a paramter in a domain with blank value.
+        @Test: Set a parameter in a domain with blank value.
         @Feature: Domain - Misc.
         @Assert: Domain parameter is not updated.
         """
@@ -214,11 +214,11 @@ class Domain(UITestCase):
             except Exception as e:
                 self.fail(e)
             self.assertIsNotNone(session.nav.wait_until_element(
-                common_locators["alert.error"]))
+                common_locators["common_param_error"]))
 
     def test_set_parameter_negative_2(self):
         """
-        @Test: Set a paramter in a domain with 256 chars in name and value.
+        @Test: Set a parameter in a domain with 256 chars in name and value.
         @Feature: Domain - Misc.
         @Assert: Domain parameter is not updated.
         """
@@ -236,12 +236,12 @@ class Domain(UITestCase):
             except Exception as e:
                 self.fail(e)
             self.assertIsNotNone(session.nav.wait_until_element(
-                common_locators["alert.error"]))
+                common_locators["common_param_error"]))
 
     @skip_if_bug_open('bugzilla', 1123360)
     def test_set_parameter_negative_3(self):
         """
-        @Test: Again set the same paramter for domain with name and value.
+        @Test: Again set the same parameter for domain with name and value.
         @Feature: Domain - Misc.
         @Assert: Domain parameter is not updated.
         @BZ: 1123360
@@ -262,7 +262,7 @@ class Domain(UITestCase):
             except Exception as e:
                 self.fail(e)
             self.assertIsNotNone(session.nav.wait_until_element(
-                common_locators["alert.error"]))
+                common_locators["common_param_error"]))
 
     @attr('ui', 'domain', 'implemented')
     @data(*generate_strings_list(len1=4))

--- a/tests/foreman/ui/test_medium.py
+++ b/tests/foreman/ui/test_medium.py
@@ -77,7 +77,7 @@ class Medium(UITestCase):
         with Session(self.browser) as session:
             make_media(session, name=name, path=path, os_family=os_family)
             self.assertIsNotNone(self.medium.wait_until_element
-                                 (common_locators["alert.error"]))
+                                 (common_locators["name_haserror"]))
             self.assertIsNone(self.medium.search(name))
 
     def test_negative_create_medium_2(self):

--- a/tests/foreman/ui/test_operatingsys.py
+++ b/tests/foreman/ui/test_operatingsys.py
@@ -116,7 +116,7 @@ class OperatingSys(UITestCase):
                     minor_version=minor_version,
                     os_family=os_family, archs=[arch])
             self.assertIsNotNone(self.operatingsys.wait_until_element
-                                 (common_locators["alert.error"]))
+                                 (common_locators["name_haserror"]))
             self.assertIsNone(self.operatingsys.search(name))
 
     def test_negative_create_os_2(self):
@@ -158,7 +158,7 @@ class OperatingSys(UITestCase):
                     description=description,
                     os_family=os_family, archs=[arch])
             self.assertIsNotNone(self.operatingsys.wait_until_element
-                                 (common_locators["alert.error"]))
+                                 (common_locators["haserror"]))
             self.assertIsNone(self.operatingsys.search(name))
 
     def test_negative_create_os_4(self):
@@ -179,7 +179,7 @@ class OperatingSys(UITestCase):
                     minor_version=minor_version,
                     os_family=os_family, archs=[arch])
             self.assertIsNotNone(self.operatingsys.wait_until_element
-                                 (common_locators["alert.error"]))
+                                 (common_locators["haserror"]))
             self.assertIsNone(self.operatingsys.search(name))
 
     def test_negative_create_os_5(self):
@@ -200,7 +200,7 @@ class OperatingSys(UITestCase):
                     minor_version=minor_version,
                     os_family=os_family, archs=[arch])
             self.assertIsNotNone(self.operatingsys.wait_until_element
-                                 (common_locators["alert.error"]))
+                                 (common_locators["haserror"]))
             self.assertIsNone(self.operatingsys.search(name))
 
     def test_negative_create_os_6(self):
@@ -242,7 +242,7 @@ class OperatingSys(UITestCase):
                     minor_version=minor_version,
                     os_family=os_family, archs=[arch])
             self.assertIsNotNone(self.operatingsys.wait_until_element
-                                 (common_locators["alert.error"]))
+                                 (common_locators["haserror"]))
             self.assertIsNone(self.operatingsys.search(name))
 
     @skip_if_bug_open('bugzilla', 1120985)
@@ -460,7 +460,7 @@ class OperatingSys(UITestCase):
             except Exception as e:
                 self.fail(e)
             self.assertIsNotNone(self.operatingsys.wait_until_element
-                                 (common_locators["alert.error"]))
+                                 (common_locators["common_param_error"]))
 
     @skip_if_bug_open('bugzilla', 1120663)
     def test_negative_set_parameter_2(self):
@@ -484,12 +484,12 @@ class OperatingSys(UITestCase):
             except Exception as e:
                 self.fail(e)
             self.assertIsNotNone(self.operatingsys.wait_until_element
-                                 (common_locators["alert.error"]))
+                                 (common_locators["common_param_error"]))
 
     @skip_if_bug_open('bugzilla', 1120685)
     def test_negative_set_parameter_3(self):
         """
-        @Test: Set OS parameter with name and  blank value
+        @Test: Set OS parameter with name and blank value
         @Feature: OS - Negative Update
         @Assert: Proper error should be raised, Name should contain a value
         @BZ: 1120685
@@ -508,7 +508,7 @@ class OperatingSys(UITestCase):
             except Exception as e:
                 self.fail(e)
             self.assertIsNotNone(self.operatingsys.wait_until_element
-                                 (common_locators["alert.error"]))
+                                 (common_locators["common_param_error"]))
 
     def test_negative_set_parameter_4(self):
         """
@@ -530,4 +530,4 @@ class OperatingSys(UITestCase):
             except Exception as e:
                 self.fail(e)
             self.assertIsNotNone(self.operatingsys.wait_until_element
-                                 (common_locators["alert.error"]))
+                                 (common_locators["common_param_error"]))

--- a/tests/foreman/ui/test_partitiontable.py
+++ b/tests/foreman/ui/test_partitiontable.py
@@ -65,7 +65,7 @@ class PartitionTable(UITestCase):
             make_partitiontable(session, name=name, layout=layout,
                                 os_family=os_family)
             self.assertIsNotNone(self.partitiontable.wait_until_element
-                                 (common_locators["alert.error"]))
+                                 (common_locators["name_haserror"]))
             self.assertIsNone(self.partitiontable.search(name))
 
     @data({u'name': ""},

--- a/tests/foreman/ui/test_template.py
+++ b/tests/foreman/ui/test_template.py
@@ -68,7 +68,7 @@ class Template(UITestCase):
             make_templates(session, name=name, template_path=template_path,
                            custom_really=True, template_type=temp_type)
             self.assertIsNotNone(self.template.wait_until_element
-                                 (common_locators["alert.error"]))
+                                 (common_locators["name_haserror"]))
             self.assertIsNone(self.template.search(name))
 
     def test_negative_create_template_2(self):


### PR DESCRIPTION
Since many bz's related to boundary validation have been fixed. Many tests were failing because of incorrect locator for validation errors. So I updated all foreman entities(OS, Medium, PartitionTable, arch, Domain) with appropriate locators.
