### PR TITLE
Add API tests for api/v2/roles

### DIFF
--- a/docs/api/tests.foreman.api.rst
+++ b/docs/api/tests.foreman.api.rst
@@ -131,6 +131,13 @@
     :members:
     :undoc-members:
 
+:mod:`tests.foreman.api.test_role_v2`
+-------------------------------------
+
+.. automodule:: tests.foreman.api.test_role_v2
+    :members:
+    :undoc-members:
+
 :mod:`tests.foreman.api.test_smartproxy`
 ----------------------------------------
 

--- a/robottelo/entities.py
+++ b/robottelo/entities.py
@@ -825,13 +825,14 @@ class RoleLDAPGroups(orm.Entity):
         api_path = 'katello/api/v2/roles/:role_id/ldap_groups'
 
 
-class Role(orm.Entity):
+class Role(orm.Entity, factory.EntityFactoryMixin):
     """A representation of a Role entity."""
-    name = orm.StringField(required=True)
+    # FIXME: UTF-8 characters should be acceptable for `name`. See BZ 1129785
+    name = orm.StringField(required=True, str_type=('alphanumeric',))
 
     class Meta(object):
         """Non-field information about this entity."""
-        api_path = 'katello/api/v2/roles'
+        api_path = 'api/v2/roles'
 
 
 class SmartProxy(orm.Entity):

--- a/tests/foreman/api/test_multiple_paths.py
+++ b/tests/foreman/api/test_multiple_paths.py
@@ -12,7 +12,7 @@ import httplib
 
 BZ_1118015_ENTITIES = (
     entities.Architecture, entities.ContentView, entities.GPGKey,
-    entities.OperatingSystem, entities.Repository
+    entities.OperatingSystem, entities.Repository, entities.Role,
 )
 
 
@@ -28,6 +28,7 @@ class EntityTestCase(TestCase):
         entities.Model,
         entities.OperatingSystem,
         entities.Organization,
+        entities.Role,
     )
     def test_get_status_code(self, entity):
         """@Test GET an entity-dependent path.
@@ -58,6 +59,7 @@ class EntityTestCase(TestCase):
         entities.Model,
         entities.OperatingSystem,
         entities.Organization,
+        entities.Role,
     )
     def test_get_unauthorized(self, entity):
         """@Test: GET an entity-dependent path without credentials.
@@ -84,6 +86,7 @@ class EntityTestCase(TestCase):
         entities.OperatingSystem,
         entities.Organization,
         entities.Repository,
+        entities.Role,
     )
     def test_post_status_code(self, entity):
         """@Test: Issue a POST request and check the returned status code.
@@ -122,6 +125,7 @@ class EntityTestCase(TestCase):
         entities.OperatingSystem,
         entities.Organization,
         entities.Repository,
+        entities.Role,
     )
     @skip_if_bug_open('bugzilla', 1122257)
     def test_post_unauthorized(self, entity):
@@ -153,6 +157,7 @@ class EntityIdTestCase(TestCase):
         entities.OperatingSystem,
         entities.Organization,
         entities.Repository,
+        entities.Role,
     )
     def test_get_status_code(self, entity):
         """@Test: Create an entity and GET it.
@@ -185,6 +190,7 @@ class EntityIdTestCase(TestCase):
         entities.OperatingSystem,
         entities.Organization,
         entities.Repository,
+        entities.Role,
     )
     def test_put_status_code(self, entity):
         """@Test Issue a PUT request and check the returned status code.
@@ -217,6 +223,7 @@ class EntityIdTestCase(TestCase):
         entities.OperatingSystem,
         entities.Organization,
         entities.Repository,
+        entities.Role,
         entities.User,
     )
     def test_delete(self, entity):
@@ -267,6 +274,7 @@ class LongMessageTestCase(TestCase):
         entities.OperatingSystem,
         entities.Organization,
         entities.Repository,
+        entities.Role,
     )
     def test_put_and_get(self, entity):
         """@Test: Issue a PUT request and GET the updated entity.
@@ -307,6 +315,7 @@ class LongMessageTestCase(TestCase):
         entities.OperatingSystem,
         entities.Organization,
         entities.Repository,
+        entities.Role,
     )
     def test_post_and_get(self, entity):
         """@Test Issue a POST request and GET the created entity.

--- a/tests/foreman/api/test_role_v2.py
+++ b/tests/foreman/api/test_role_v2.py
@@ -1,0 +1,65 @@
+"""Unit tests for the ``roles`` paths.
+
+Each ``TestCase`` subclass tests a single URL. A full list of URLs to be tested
+can be found here: http://theforeman.org/api/apidoc/v2/roles.html
+
+"""
+from robottelo.api import client
+from robottelo.common.decorators import skip_if_bug_open
+from robottelo.common.helpers import get_server_credentials
+from robottelo import entities, factory, orm
+from unittest import TestCase
+import ddt
+# (too many public methods) pylint: disable=R0904
+
+
+@ddt.ddt
+class RoleTestCase(TestCase):
+    """Tests for ``api/v2/roles``."""
+    def _test_role_name(self, name):
+        """Create a role with name ``name``."""
+        try:
+            role_attrs = entities.Role(name=name).create()
+        except factory.FactoryError as err:
+            self.fail(err)  # fail instead of error
+
+        # Creation apparently succeeded. GET the role and verify it's name.
+        response = client.get(
+            entities.Role(id=role_attrs['id']).path(),
+            auth=get_server_credentials(),
+            verify=False,
+        ).json()
+        self.assertEqual(response['name'], name)
+
+    @ddt.data(
+        orm.StringField(str_type=('alphanumeric',)).get_value(),
+        orm.StringField(str_type=('alpha',)).get_value(),
+        orm.StringField(str_type=('numeric',)).get_value(),
+    )
+    def test_positive_create_1(self, name):
+        """@Test: Create a role with a name containing alphanumeric chars.
+
+        @Feature: Role
+
+        @Assert: An entity can be created without receiving any errors, the
+        entity can be fetched, and the fetched entity has the specified name.
+
+        """
+        self._test_role_name(name)
+
+    @skip_if_bug_open('bugzilla', 1129785)
+    @ddt.data(
+        orm.StringField(str_type=('cjk',)).get_value(),
+        orm.StringField(str_type=('latin1',)).get_value(),
+        orm.StringField(str_type=('utf8',)).get_value(),
+    )
+    def test_positive_create_2(self, name):
+        """@Test: Create a role with a name containing non-alphanumeric chars.
+
+        @Feature: Role
+
+        @Assert: An entity can be created without receiving any errors, the
+        entity can be fetched, and the fetched entity has the specified name.
+
+        """
+        self._test_role_name(name)


### PR DESCRIPTION
- Add a full suite of tests targeting the "Role" entity.
- `EntityTestCase.test_get_status_code` targets [bugzilla bug 1102732](https://bugzilla.redhat.com/show_bug.cgi?id=1102732). The test
  passes, which indicates that the bug has been fixed.
- `api/v2/roles` suffers from [bugzilla bug 1118015](https://bugzilla.redhat.com/show_bug.cgi?id=1118015), and this is addressed in the
  updated test suite.
- The existing entity had an incorrect API path, and this has been fixed.
  (perhaps it has changed?)
- Creating tests for this URL has revealed another error, which is documented in
  [bugzilla bug 1129785](https://bugzilla.redhat.com/show_bug.cgi?id=1129785). Also, this PR contains tests targeting that specific
  bug.
