### PR TITLE
Remove mistake-prone code

### DIFF
--- a/robottelo/entities.py
+++ b/robottelo/entities.py
@@ -547,26 +547,6 @@ class LifecycleEnvironment(orm.Entity, factory.EntityFactoryMixin):
         """Non-field information about this entity."""
         api_path = 'katello/api/v2/environments'
 
-    def path(self, which=None):
-        """Extend the default implementation of
-        :meth:`robottelo.orm.Entity.path`.
-
-        If a user specifies a ``which`` of ``'organization'``, return a path in
-        the format ``/organizations/<id>/environments``. Otherwise, call
-        ``super``.
-
-        :raises robottelo.orm.NoSuchPathError: If no organization ID is
-            provided.
-
-        """
-        if which == 'organization':
-            if self.organization is None:
-                raise orm.NoSuchPathError(
-                    'An organization ID must be provided.'
-                )
-            return Organization(id=self.organization).path() + '/environments'
-        return super(LifecycleEnvironment, self).path()
-
 
 class Location(orm.Entity):
     """A representation of a Location entity."""

--- a/tests/robottelo/test_entities.py
+++ b/tests/robottelo/test_entities.py
@@ -45,32 +45,3 @@ class PathTestCase(TestCase):
         # 3
         with self.assertRaises(orm.NoSuchPathError):
             entities.ActivationKey().path(which='releases')
-
-    def test_lifecycleenvironment_path(self):
-        """Tests for :meth:`robottelo.entities.LifecycleEnvironment.path`.
-
-        1. The method returns the correct string when ``which`` is not
-           specified.
-        2. Assert the method returns the correct string when ``which ==
-           'organization'``.
-        3. The method raises :class:`robottelo.orm.NoSuchPathError` when
-           ``which == 'organization'`` and no organization ID is provided.
-
-        """
-        # 1
-        self.assertIn('/environments', entities.LifecycleEnvironment().path())
-        self.assertIn(
-            '/environments/{0}'.format(self.id_),
-            entities.LifecycleEnvironment(id=self.id_).path()
-        )
-        # 2
-        self.assertIn(
-            '/organizations/{0}/environments'.format(self.id_),
-            entities.LifecycleEnvironment(
-                organization=self.id_
-            ).path(which='organization')
-        )
-        # 3
-        # pylint:disable=E1103
-        with self.assertRaises(orm.NoSuchPathError):
-            entities.LifecycleEnvironment().path(which='organization').path()


### PR DESCRIPTION
Consider how weird it is that these two calls are equivalent:

``` python
response = client.get(
    'https://example.com/katello/api/v2/environments',
    auth=get_server_credentials(),
    verify=False,
    params={'organization_id': 5},
)
response = client.get(
    'https://example.com/katello/api/v2/organizations/5/environments',
    auth=get_server_credentials(),
    verify=False,
)
```

The above demonstrates that the API lacks orthogonality, which is bad. However,
things then get ugly. Consider this code:

``` python
response = client.get(
    'https://example.com/katello/api/v2/organizations/5/environments',
    auth=get_server_credentials(),
    verify=False,
    params={'organization_id': 6},
)
```

What will happen? **We have undefined behaviour.** Rather than allowing
ourselves to make this mistake, it is best if:
- We do not provide arguments via a URL, when possible.
- We do provide arguments as JSON data, when possible.
