### PR TITLE
Revert changes to smoke test suite.

### DIFF
--- a/tests/foreman/smoke/test_api_smoke.py
+++ b/tests/foreman/smoke/test_api_smoke.py
@@ -19,7 +19,7 @@ class TestSmoke(TestCase):
         @Feature: Smoke Test
         @Assert: 'Default Organization' is found
         """
-        query = u'Default Organization'
+        query = u'Default_Organization'
         self._search(entities.Organization, query)
 
     @attr('smoke')
@@ -29,7 +29,7 @@ class TestSmoke(TestCase):
         @Feature: Smoke Test
         @Assert: 'Default Location' is found
         """
-        query = u'Default Location'
+        query = u'Default_Location'
         self._search(entities.Location, query)
 
     @attr('smoke')

--- a/tests/foreman/smoke/test_cli_smoke.py
+++ b/tests/foreman/smoke/test_cli_smoke.py
@@ -34,11 +34,11 @@ class TestSmoke(CLITestCase):
         @Assert: 'Default Organization' is found
         """
 
-        query = {u'name': u'Default Organization'}
+        query = {u'name': u'Default_Organization'}
         result = self._search(Org, query)
         self.assertEqual(
             result.stdout['name'],
-            'Default Organization',
+            'Default_Organization',
             u"Could not find the Default Organization"
         )
 
@@ -50,11 +50,11 @@ class TestSmoke(CLITestCase):
         @Assert: 'Default Location' is found
         """
 
-        query = {u'name': u'Default Location'}
+        query = {u'name': u'Default_Location'}
         result = self._search(Location, query)
         self.assertEqual(
             result.stdout['name'],
-            'Default Location',
+            'Default_Location',
             u"Could not find the 'Default Location'"
         )
 


### PR DESCRIPTION
Just recently I updated the smoke test suite to go from
'Default_Organization' and 'Default_Location' to 'Default Organization'
and 'Default Location' respectively (note the absence of the
underscore). Well, turns out that only upstream `Katello` code applies
to this change but not downstream code. So sadly, this PR reverts these
changes and we will handle the upstream tests differently.
