### PR TITLE
Do not use the `fields` build() and create() arg

### DIFF
--- a/robottelo/entities.py
+++ b/robottelo/entities.py
@@ -25,7 +25,7 @@ class ActivationKey(orm.Entity, factory.EntityFactoryMixin):
     description = orm.StringField()
     environment = orm.OneToOneField('Environment')
     content_view = orm.OneToOneField('ContentView')
-    # maximum number of registered content hosts, or 'unlimited'
+    unlimited_content_hosts = orm.BooleanField()
     max_content_hosts = orm.IntegerField()
 
     class Meta(object):
@@ -549,8 +549,8 @@ class LifecycleEnvironment(orm.Entity, factory.EntityFactoryMixin):
 
         Since a ``LifecycleEnvironment`` can be associated to another instance
         of a ``LifecycleEnvironment`` via the ``prior`` field, the expected
-        foreignkey is not ``prior_id`` as expected, but ``prior``. Therefore,
-        we must update the entity's fields and make sure that we have a ``prior``
+        foreignkey is not ``prior_id`` as expected, but ``prior``. Therefore, we
+        must update the entity's fields and make sure that we have a ``prior``
         attribute before any further actions can be performed.
 
         """

--- a/tests/foreman/api/test_activationkey_v2.py
+++ b/tests/foreman/api/test_activationkey_v2.py
@@ -49,10 +49,10 @@ class ActivationKeysTestCase(TestCase):
         @Feature: ActivationKey
         """
         try:
-            attrs = entities.ActivationKey().create(fields={
-                u'unlimited_content_hosts': False,
-                u'max_content_hosts': max_content_hosts
-            })
+            attrs = entities.ActivationKey(
+                unlimited_content_hosts=False,
+                max_content_hosts=max_content_hosts,
+            ).create()
         except FactoryError as err:
             self.fail(err)
         # Assert that it defaults to limited content host...
@@ -83,7 +83,7 @@ class ActivationKeysTestCase(TestCase):
         @Feature: ActivationKey
         """
         try:
-            attrs = entities.ActivationKey().create(fields={u'name': name})
+            attrs = entities.ActivationKey(name=name).create()
         except FactoryError as err:
             self.fail(err)
 
@@ -108,9 +108,7 @@ class ActivationKeysTestCase(TestCase):
         @Feature: ActivationKey
         """
         with self.assertRaises(FactoryError):
-            entities.ActivationKey().create(
-                fields={u'unlimited_content_hosts': False}
-            )
+            entities.ActivationKey(unlimited_content_hosts=False).create()
 
     @data(
         StringField(str_type=('alpha',)).get_value(),
@@ -125,12 +123,10 @@ class ActivationKeysTestCase(TestCase):
         @Feature: ActivationKey
         """
         with self.assertRaises(FactoryError):
-            entities.ActivationKey().create(
-                fields={
-                    u'unlimited_content_hosts': False,
-                    u'max_content_hosts': max_content_hosts
-                }
-            )
+            entities.ActivationKey(
+                unlimited_content_hosts=False,
+                max_content_hosts=max_content_hosts
+            ).create()
 
     @data(
         IntegerField(min_val=-10, max_val=-1).get_value(),
@@ -146,10 +142,10 @@ class ActivationKeysTestCase(TestCase):
         @Feature: ActivationKey
         """
         with self.assertRaises(FactoryError):
-            entities.ActivationKey().create(fields={
-                u'unlimited_content_hosts': True,
-                u'max_content_hosts': max_content_hosts
-            })
+            entities.ActivationKey(
+                unlimited_content_hosts=True,
+                max_content_hosts=max_content_hosts
+            ).create()
 
     @data(
         IntegerField(min_val=1, max_val=30).get_value(),

--- a/tests/foreman/api/test_user_v2.py
+++ b/tests/foreman/api/test_user_v2.py
@@ -31,7 +31,7 @@ class UsersTestCase(TestCase):
         @Feature: User
         """
         path = entities.User().path()
-        attrs = entities.User().build(fields={u'login': login})
+        attrs = entities.User(login=login).build()
         response = client.post(
             path,
             attrs,


### PR DESCRIPTION
Remove all usages of the `field` argument. For example, this:

```
SomeEntity().create(fields={'field': value})
```

Is now written as this:

```
SomeEntity(field=value).create()
```

The `fields` argument to `build()` and `create()` should not be used, as it is
highly error-prone.
