### PR TITLE
Remove arg from Factory.{attributes,build,create}

### DIFF
--- a/tests/robottelo/test_factory.py
+++ b/tests/robottelo/test_factory.py
@@ -182,36 +182,6 @@ class SampleFactoryTestCase(TestCase):
             SampleFactory().attributes()
         )
 
-    def test_attributes_fields(self):
-        """Call ``attributes`` and specify the ``fields`` argument.
-
-        Assert that the values provided via the ``fields`` argument override
-        the default values generated.
-
-        """
-        name = FauxFactory.generate_string(
-            'utf8',
-            FauxFactory.generate_integer(1, 100)
-        )
-        self.assertEqual(
-            {'name': name, 'cost': SAMPLE_FACTORY_COST},
-            SampleFactory().attributes(fields={'name': name}),
-        )
-
-        cost = FauxFactory.generate_integer()
-        self.assertEqual(
-            {'name': name, 'cost': cost},
-            SampleFactory().attributes(fields={'name': name, 'cost': cost}),
-        )
-
-        extra = FauxFactory.generate_boolean()
-        self.assertEqual(
-            {'name': name, 'cost': cost, 'extra': extra},
-            SampleFactory().attributes(
-                fields={'name': name, 'cost': cost, 'extra': extra}
-            ),
-        )
-
     def test_create(self):
         """Call ``create`` with no arguments. Receive a normal response.
 


### PR DESCRIPTION
Remove the `fields` argument from methods `Factory.attributes`, `Factory.build`
and `Factory.create`. These three methods largely duplicated the functionality
provided by entities. This is bad in an of itself, because it meant that the
API-related code was not orthogonal:

``` python
SomeEntity(field=value).create()
SomeEntity().create(fields={'field': value})
```

However, the arg is also worth dropping because it makes the user vulnerable to
trivial errors. For example, consider these two statements:

``` python
Organization(not_a_field=value).create()
Organization().create(fields={'not_a_field': value})
```

Only one of them will raise an error, though both are clearly wrong.
