### PR TITLE
Fixed various failing tests

### DIFF
--- a/robottelo/ui/activationkey.py
+++ b/robottelo/ui/activationkey.py
@@ -110,7 +110,13 @@ class ActivationKey(Base):
             if limit:
                 self.find_element(locators["ak.edit_limit"]).click()
                 self.set_limit(limit)
-                self.find_element(locators["ak.save_limit"]).click()
+                if self.wait_until_element(locators["ak.save_limit"]
+                                           ).is_enabled():
+                    self.find_element(locators["ak.save_limit"]).click()
+                else:
+                    raise ValueError(
+                        "Please update content host "
+                        "limit with valid integer value")
             if content_view:
                 if env:
                     strategy = locators["ak.env"][0]

--- a/robottelo/ui/locators.py
+++ b/robottelo/ui/locators.py
@@ -1045,7 +1045,8 @@ locators = {
         "//input[@ng-model='item.selected']/parent::label[contains(., '%s')]"),
     "ak.selected_env": (
         By.XPATH,
-        "//input[@class='ng-pristine ng-valid']/parent::label"),
+        ("//input[@ng-model='item.selected']"
+         "/parent::label[contains(@class, 'active')]")),
     "ak.content_view": (By.ID, "content_view_id"),
     "ak.usage_limit_checkbox": (
         By.XPATH,
@@ -1463,6 +1464,8 @@ locators = {
          "//input[@ng-model='detailsTable.searchTerm']")),
     "contentviews.search_button": (
         By.XPATH, "//button[contains(@ng-click, 'detailsTable.search')]"),
+    "contentviews.filter_name": (
+        By.XPATH, "//tr[@row-select='filter']/td[2]/a[contains(., '%s')]"),
 
     # System Groups
     "system-groups.new": (

--- a/robottelo/ui/operatingsys.py
+++ b/robottelo/ui/operatingsys.py
@@ -91,13 +91,14 @@ class OperatingSys(Base):
             raise Exception(
                 "Could not create new operating system '%s'" % name)
 
-    def search(self, name):
+    def search(self, name, search_key=None):
         """
         Searches existing operating system from UI
         """
         Navigator(self.browser).go_to_operating_systems()
         element = self.search_entity(
-            name, locators['operatingsys.operatingsys_name'])
+            name, locators['operatingsys.operatingsys_name'],
+            search_key)
         return element
 
     def delete(self, os_name, really):

--- a/tests/foreman/ui/test_activationkey.py
+++ b/tests/foreman/ui/test_activationkey.py
@@ -725,8 +725,11 @@ class ActivationKey(UITestCase):
                         (common_locators["alert.error"]))
 
     @skip_if_bug_open('bugzilla', 1083027)
-    @data(*invalid_names_list())
-    def test_negative_update_activation_key_3(self, limit):
+    @data({u'limit': " "},
+          {u'limit': "-1"},
+          {u'limit': "text"},
+          {u'limit': "0"})
+    def test_negative_update_activation_key_3(self, test_data):
         """
         @Feature: Activation key - Negative Update
         @Test: Update invalid Usage Limit in an activation key
@@ -743,10 +746,11 @@ class ActivationKey(UITestCase):
         self.navigator.go_to_activation_keys()
         self.activationkey.create(name, ENVIRONMENT)
         self.assertIsNotNone(self.activationkey.search_key(name))
-        self.activationkey.update(name, limit=limit)
-        invalid = self.activationkey.wait_until_element(locators
-                                                        ["ak.invalid_limit"])
-        self.assertTrue(invalid)
+        with self.assertRaises(ValueError) as context:
+            self.activationkey.update(name, limit=test_data['limit'])
+        self.assertEqual(context.exception.message,
+                         "Please update content host limit "
+                         "with valid integer value")
 
     @skip_if_bug_open('bugzilla', 1078676)
     @unittest.skip(NOT_IMPLEMENTED)

--- a/tests/foreman/ui/test_architecture.py
+++ b/tests/foreman/ui/test_architecture.py
@@ -6,7 +6,7 @@ Test class for Architecture UI
 """
 from ddt import ddt
 from robottelo.common.decorators import data
-from robottelo.common.helpers import (generate_string, valid_names_list,
+from robottelo.common.helpers import (generate_string,
                                       generate_strings_list)
 from robottelo.test import UITestCase
 from robottelo.ui.factory import (make_org, make_loc,
@@ -59,10 +59,10 @@ class Architecture(UITestCase):
             self.assertIsNotNone(self.operatingsys.search
                                  (test_data['os_name']))
             make_arch(session, name=test_data['name'],
-                      os_names=test_data['os_name'])
+                      os_names=[test_data['os_name']])
             self.assertIsNotNone(self.architecture.search(test_data['name']))
 
-    @data(*valid_names_list())
+    @data(*generate_strings_list(len1=8))
     def test_positive_create_arch_2(self, name):
         """
         @Test: Create a new Architecture with different data
@@ -151,7 +151,7 @@ class Architecture(UITestCase):
             self.assertIsNotNone(self.operatingsys.search
                                  (test_data['os_name']))
             make_arch(session, name=test_data['name'],
-                      os_names=test_data['os_name'])
+                      os_names=[test_data['os_name']])
             self.assertIsNotNone(self.architecture.search(test_data['name']))
             self.architecture.delete(test_data['name'], True)
             self.assertIsNone(self.architecture.search(test_data['name']))
@@ -189,6 +189,6 @@ class Architecture(UITestCase):
                                  (test_data['old_name']))
             self.architecture.update(test_data['old_name'],
                                      test_data['new_name'],
-                                     new_os_names=test_data['os_name'])
+                                     new_os_names=[test_data['os_name']])
             self.assertIsNotNone(self.architecture.search
                                  (test_data['new_name']))

--- a/tests/foreman/ui/test_contentviews.py
+++ b/tests/foreman/ui/test_contentviews.py
@@ -182,8 +182,8 @@ class TestContentViewsUI(UITestCase):
         self.content_views.add_filter(cv_name, filter_name,
                                       content_type, filter_type)
         self.content_views.remove_filter(cv_name, [filter_name])
-        self.assertIsNotNone(self.content_views.wait_until_element
-                             (common_locators["alert.success"]))
+        self.assertIsNone(self.content_views.search_filter
+                          (cv_name, filter_name))
 
     def test_create_package_filter(self):
         """

--- a/tests/foreman/ui/test_environment.py
+++ b/tests/foreman/ui/test_environment.py
@@ -132,6 +132,7 @@ class Environment(UITestCase):
             search = self.environment.search(new_name)
             self.assertIsNotNone(search)
 
+    @skip_if_bug_open('bugzilla', 1126033)
     @attr('ui', 'environment', 'implemented')
     @data({'name': generate_string('alpha', 8)},
           {'name': generate_string('numeric', 8)},

--- a/tests/foreman/ui/test_operatingsys.py
+++ b/tests/foreman/ui/test_operatingsys.py
@@ -94,7 +94,8 @@ class OperatingSys(UITestCase):
                     minor_version=test_data['minor_version'],
                     description=test_data['desc'],
                     os_family=test_data['os_family'], archs=[arch])
-            self.assertIsNotNone(self.operatingsys.search(test_data['name']))
+            self.assertIsNotNone(self.operatingsys.search
+                                 (test_data['desc'], search_key="description"))
 
     @skip_if_bug_open('bugzilla', 1120181)
     def test_negative_create_os_1(self):

--- a/tests/foreman/ui/test_role.py
+++ b/tests/foreman/ui/test_role.py
@@ -82,9 +82,14 @@ class Role(UITestCase):
         """
         name = generate_name(6)
         org_name = generate_name(6)
+        resource_type = 'Activation Keys'
+        permission_list = ['view_activation_keys']
         self.login.login(self.katello_user, self.katello_passwd)  # login
         self.navigator.go_to_org()
         self.org.create(org_name)
         self.navigator.go_to_roles()
         self.role.create(name)
-        self.role.update(name, add_permission=True, organization=[org_name])
+        self.role.update(name, add_permission=True,
+                         resource_type=resource_type,
+                         permission_list=permission_list,
+                         organization=[org_name])

--- a/tests/foreman/ui/test_settings.py
+++ b/tests/foreman/ui/test_settings.py
@@ -147,7 +147,7 @@ class Settings(UITestCase):
         param_value = generate_string("numeric", 5)
         tab_locator = tab_locators["settings.tab_general"]
         param_name = "entries_per_page"
-        value_type = "input1"
+        value_type = "input"
         with Session(self.browser) as session:
             edit_param(session, tab_locator=tab_locator,
                        param_name=param_name,


### PR DESCRIPTION
This PR includes various test fixes and in different modules.
- Fixed: `test_negative_update_activation_key_3`: Now save button remains disabled when we update content-host limit with invalid value. So updated the `update` fn and test accordingly
- Fixed: `test_positive_update_activation_key_3`: updated locator to locate the updated env
- Fixed: `4 architecture tests`
- Fixed: `test_remove_filter`: when we remove filter, UI doesn't raise success notification, so added a `search_filter` function to assert whether the filter was removed or not.
- Fixed `test_positive_create_os` test: this test was failing due to bz 1120568, but as per dev, its working as per design. so made changes in test to fix it, ( when we create OS with description, name column dislays description)
- Fixed: `test_positive_update_general_param_5` ( Found a typo for valid_type)
