### PR TITLE
Fixed failed UI tests

### DIFF
--- a/robottelo/ui/locators.py
+++ b/robottelo/ui/locators.py
@@ -598,8 +598,7 @@ locators = {
     # Organizations
     "org.new": (
         By.XPATH,
-        ("//a[@class='btn btn-success'"
-            "and contains(@href, '/organizations/new')]")),
+        ("//a[contains(@href, '/organizations/new')]")),
     "org.name": (By.ID, "organization_name"),
     "org.parent": (By.ID, "organization_parent_id"),
     "org.label": (By.ID, "organization_label"),
@@ -990,7 +989,7 @@ locators = {
     "repo.discover_button": (By.XPATH, "//button[@type='submit']"),
     "repo.discovered_url_checkbox": (
         By.XPATH, ("//table[@alch-table='discoveryTable']"
-                   "//td[normalize-space(.)='%s']"
+                   "//td[contains(., '%s')]"
                    "/../td/input[@type='checkbox']")),
     "repo.cancel_discover": (
         By.XPATH, "//button[@ng-show='discovery.pending']"),

--- a/tests/foreman/ui/test_computeresource.py
+++ b/tests/foreman/ui/test_computeresource.py
@@ -53,8 +53,12 @@ class ComputeResource(UITestCase):
 
     @skip_if_bug_open('bugzilla', 1120271)
     @attr('ui', 'resource', 'implemented')
-    @data(*generate_strings_list(len1=255))
-    def test_create_resource_2(self, name):
+    @data({u'name': generate_string('alphanumeric', 255)},
+          {u'name': generate_string('alpha', 255)},
+          {u'name': generate_string('numeric', 255)},
+          {u'name': generate_string('latin1', 255)},
+          {u'name': generate_string('utf8', 255)})
+    def test_create_resource_2(self, test_data):
         """
         @Test: Create a new libvirt Compute Resource with 255 char name
         @Feature: Compute Resource - Create
@@ -65,9 +69,9 @@ class ComputeResource(UITestCase):
         provider_type = FOREMAN_PROVIDERS['libvirt']
         url = (libvirt_url % conf.properties['main.server.hostname'])
         with Session(self.browser) as session:
-            make_resource(session, name=name,
+            make_resource(session, name=test_data['name'],
                           provider_type=provider_type, url=url)
-            search = self.compute_resource.search(name)
+            search = self.compute_resource.search(test_data['name'])
             self.assertIsNotNone(search)
 
     @attr('ui', 'resource', 'implemented')
@@ -107,7 +111,7 @@ class ComputeResource(UITestCase):
             make_resource(session, name=name,
                           provider_type=provider_type, url=url)
             search = self.compute_resource.search(name)
-            self.assertIsNotNone(search)
+            self.assertIsNone(search)
 
     @skip_if_bug_open('bugzilla', 1120271)
     @attr('ui', 'resource', 'implemented')
@@ -129,7 +133,7 @@ class ComputeResource(UITestCase):
                           description=description,
                           provider_type=provider_type, url=url)
             error = session.nav.wait_until_element(
-                common_locators["name_haserror"])
+                common_locators["haserror"])
             self.assertIsNotNone(error)
 
     def test_create_resource_negative_3(self):

--- a/tests/foreman/ui/test_gpgkey.py
+++ b/tests/foreman/ui/test_gpgkey.py
@@ -20,7 +20,7 @@ from robottelo.common.constants import (NOT_IMPLEMENTED, VALID_GPG_KEY_FILE,
 from robottelo.common.decorators import data, skip_if_bug_open
 from robottelo.common.helpers import (generate_string, get_data_file,
                                       read_data_file, valid_names_list,
-                                      invalid_names_list, valid_data_list,
+                                      invalid_names_list,
                                       generate_strings_list)
 from robottelo.test import UITestCase
 from robottelo.ui.factory import make_gpgkey
@@ -51,7 +51,7 @@ class GPGKey(UITestCase):
     # Positive Create
 
     @attr('ui', 'gpgkey', 'implemented')
-    @data(*valid_names_list())
+    @data(*generate_strings_list())
     def test_positive_create_1(self, name):
         """
         @feature: GPG Keys
@@ -67,7 +67,7 @@ class GPGKey(UITestCase):
             self.assertIsNotNone(self.gpgkey.search(name))
 
     @attr('ui', 'gpgkey', 'implemented')
-    @data(*valid_names_list())
+    @data(*generate_strings_list())
     def test_positive_create_2(self, name):
         """
         @feature: GPG Keys
@@ -85,7 +85,7 @@ class GPGKey(UITestCase):
     # Negative Create
 
     @attr('ui', 'gpgkey', 'implemented')
-    @data(*valid_data_list())
+    @data(*generate_strings_list())
     def test_negative_create_1(self, name):
         """
         @feature: GPG Keys
@@ -107,7 +107,7 @@ class GPGKey(UITestCase):
                                  (common_locators["alert.error"]))
 
     @attr('ui', 'gpgkey', 'implemented')
-    @data(*valid_data_list())
+    @data(*generate_strings_list())
     def test_negative_create_2(self, name):
         """
         @feature: GPG Keys
@@ -127,7 +127,7 @@ class GPGKey(UITestCase):
                             (common_locators["alert.error"]))
 
     @attr('ui', 'gpgkey', 'implemented')
-    @data(*valid_data_list())
+    @data(*generate_strings_list())
     def test_negative_create_3(self, name):
         """
         @feature: GPG Keys

--- a/tests/foreman/ui/test_hostgroup.py
+++ b/tests/foreman/ui/test_hostgroup.py
@@ -47,6 +47,8 @@ class Hostgroup(UITestCase):
             make_hostgroup(session, name=name)
             self.assertIsNotNone(self.hostgroup.search(name))
 
+    @skip_if_bug_open('bugzilla', 1121755)
+    @skip_if_bug_open('bugzilla', 1131416)
     @data(*generate_strings_list(len1=4))
     def test_delete_hostgroup(self, name):
         """

--- a/tests/foreman/ui/test_operatingsys.py
+++ b/tests/foreman/ui/test_operatingsys.py
@@ -419,7 +419,7 @@ class OperatingSys(UITestCase):
             except Exception as e:
                 self.fail(e)
 
-    def test_positive_set_os_parameter_2(self, name):
+    def test_positive_set_os_parameter_2(self):
         """
         @Test: Set OS parameter with blank value
         @Feature: OS - Positive update

--- a/tests/foreman/ui/test_org.py
+++ b/tests/foreman/ui/test_org.py
@@ -58,6 +58,7 @@ class Org(UITestCase):
 
     # Positive Create
 
+    @skip_if_bug_open('bugzilla', 1131469)
     @attr('ui', 'org', 'implemented')
     @data(*generate_strings_list())
     def test_positive_create_1(self, org_name):
@@ -65,6 +66,7 @@ class Org(UITestCase):
         @test: Create organization with valid name only.
         @feature: Organizations
         @assert: organization is created, label is auto-generated
+        @BZ: 1131469
         """
         with Session(self.browser) as session:
             make_org(session, org_name=org_name)
@@ -150,6 +152,7 @@ class Org(UITestCase):
         org_name = org_label = test_data['data']
         with Session(self.browser) as session:
             make_org(session, org_name=org_name, label=org_label)
+            self.org.search(org_name).click()
             name = self.org.wait_until_element(
                 name_loc).get_attribute("value")
             label = self.org.wait_until_element(
@@ -157,6 +160,7 @@ class Org(UITestCase):
             self.assertEqual(name, label)
 
     @skip_if_bug_open('bugzilla', 1079482)
+    @skip_if_bug_open('bugzilla', 1131469)
     @attr('ui', 'org', 'implemented')
     @data({'name': generate_string('alpha', 10),
            'desc': generate_string('alpha', 10)},
@@ -176,6 +180,7 @@ class Org(UITestCase):
         @feature: Organizations
         @assert: organization is created, label is auto-generated
         @BZ: 1079482
+        @BZ: 1131469
         """
 
         desc = test_data['desc']
@@ -232,6 +237,7 @@ class Org(UITestCase):
                 common_locators["name_haserror"])
             self.assertIsNotNone(error)
 
+    @skip_if_bug_open('bugzilla', 1131469)
     @attr('ui', 'org', 'implemented')
     @data(*generate_strings_list())
     def test_negative_create_3(self, org_name):
@@ -240,6 +246,7 @@ class Org(UITestCase):
         with same values.
         @feature: Organizations Negative Test.
         @assert: organization is not created
+        @BZ: 1131469
         """
         with Session(self.browser) as session:
             make_org(session, org_name=org_name)
@@ -270,6 +277,7 @@ class Org(UITestCase):
 
     # Positive Update
 
+    @skip_if_bug_open('bugzilla', 1131469)
     @attr('ui', 'org', 'implemented')
     @data(*generate_strings_list())
     def test_positive_update_1(self, new_name):
@@ -277,6 +285,7 @@ class Org(UITestCase):
         @test: Create organization with valid values then update its name.
         @feature: Organizations Positive Update test.
         @assert: organization name is updated
+        @BZ: 1131469
         """
 
         org_name = generate_string("alpha", 8)
@@ -288,6 +297,7 @@ class Org(UITestCase):
 
     # Negative Update
 
+    @skip_if_bug_open('bugzilla', 1131469)
     @attr('ui', 'org', 'implemented')
     @data(*generate_strings_list())
     def test_negative_update_1(self, org_name):
@@ -296,6 +306,7 @@ class Org(UITestCase):
         its name.
         @feature: Organizations Negative Update test.
         @assert: organization name is not updated
+        @BZ: 1131469
         """
         with Session(self.browser) as session:
             make_org(session, org_name=org_name)
@@ -308,6 +319,7 @@ class Org(UITestCase):
 
     # Miscellaneous
 
+    @skip_if_bug_open('bugzilla', 1131469)
     @attr('ui', 'org', 'implemented')
     @data(*generate_strings_list())
     def test_search_key_1(self, org_name):
@@ -315,6 +327,7 @@ class Org(UITestCase):
         @test: Create organization and search/find it.
         @feature: Organizations search.
         @assert: organization can be found
+        @BZ: 1131469
         """
         with Session(self.browser) as session:
             make_org(session, org_name=org_name)
@@ -652,6 +665,7 @@ class Org(UITestCase):
             # Item is listed in 'All Items' list and not 'Selected Items' list.
             self.assertIsNotNone(element)
 
+    @skip_if_bug_open('bugzilla', 1129612)
     @attr('ui', 'org', 'implemented')
     @data(*generate_strings_list())
     def test_remove_configtemplate_1(self, template):
@@ -659,6 +673,7 @@ class Org(UITestCase):
         @test: Remove config template.
         @feature: Organizations dissociate config templates.
         @assert: configtemplate is added then removed.
+        @BZ: 1129612
         """
         strategy, value = common_locators["entity_select"]
         strategy1, value1 = common_locators["entity_deselect"]
@@ -786,6 +801,7 @@ class Org(UITestCase):
                                                       value % medium))
             self.assertIsNotNone(element)
 
+    @skip_if_bug_open('bugzilla', 1129612)
     @attr('ui', 'org', 'implemented')
     @data(*generate_strings_list())
     def test_add_configtemplate_1(self, template):
@@ -794,6 +810,7 @@ class Org(UITestCase):
         configtemplate name.
         @feature: Organizations associate config template.
         @assert: configtemplate is added
+        @BZ: 1129612
         """
         strategy, value = common_locators["entity_deselect"]
         org_name = generate_string("alpha", 8)

--- a/tests/foreman/ui/test_partitiontable.py
+++ b/tests/foreman/ui/test_partitiontable.py
@@ -8,7 +8,7 @@ from ddt import ddt
 from robottelo.common.decorators import data
 from robottelo.common.constants import PARTITION_SCRIPT_DATA_FILE
 from robottelo.common.helpers import (generate_string, read_data_file,
-                                      valid_names_list, generate_strings_list)
+                                      generate_strings_list)
 from robottelo.test import UITestCase
 from robottelo.ui.factory import (make_org, make_loc,
                                   make_partitiontable)
@@ -36,7 +36,7 @@ class PartitionTable(UITestCase):
                 make_org(session, org_name=PartitionTable.org_name)
                 make_loc(session, name=PartitionTable.loc_name)
 
-    @data(*valid_names_list())
+    @data(*generate_strings_list())
     def test_positive_create_partition_table(self, name):
         """
         @Test: Create a new partition table
@@ -121,7 +121,7 @@ class PartitionTable(UITestCase):
                                  (common_locators["haserror"]))
             self.assertIsNone(self.partitiontable.search(name))
 
-    @data(*valid_names_list())
+    @data(*generate_strings_list())
     def test_remove_partition_table(self, name):
         """
         @Test: Delete a partition table

--- a/tests/foreman/ui/test_role.py
+++ b/tests/foreman/ui/test_role.py
@@ -65,7 +65,7 @@ class Role(UITestCase):
         """
         name = generate_name(6)
         resource_type = 'Architecture'
-        permission_list = ['access_dashboard', 'access_settings']
+        permission_list = ['view_architectures', 'create_architectures']
         self.login.login(self.katello_user, self.katello_passwd)  # login
         self.navigator.go_to_roles()
         self.role.create(name)

--- a/tests/foreman/ui/test_settings.py
+++ b/tests/foreman/ui/test_settings.py
@@ -259,7 +259,7 @@ class Settings(UITestCase):
                                                           param_name)
             self.assertNotEqual(test_data['param_value'], saved_element)
 
-    @data({'param_value': generate_string("numeric", 1)},
+    @data({'param_value': generate_string("numeric", 2)},
           {'param_value': generate_string("numeric", 5)})
     def test_positive_update_general_param_10(self, test_data):
         """

--- a/tests/foreman/ui/test_syncplan.py
+++ b/tests/foreman/ui/test_syncplan.py
@@ -118,14 +118,14 @@ class Syncplan(UITestCase):
         error = self.products.wait_until_element(locator)
         self.assertTrue(error)
 
-    @skip_if_bug_open('bugzilla', 1082632)
+    @skip_if_bug_open('bugzilla', 1096407)
     @attr('ui', 'syncplan', 'implemented')
     def test_positive_create_3(self):
         """
         @Feature: Content Sync Plan - Positive Create
         @Test: Create Sync plan with specified start time
         @Assert: Sync Plan is created with the specified time.
-        @BZ: 1082632
+        @BZ: 1096407
         """
 
         locator = locators["sp.fetch_startdate"]


### PR DESCRIPTION
Fixed two repo_discovery tests: upated locator to select discovered URL
- `test_discover_repo_1`
- `test_discover_repo_2`

Fixed all org tests and blocked some tests with bz `1131469`
- `test_positive_create_4`
- `test_negative_create_3`

Fixed compute_resource tests
- `test_create_resource_2`
- `test_create_resource_negative_2`
- `test_create_resource_negative_1`

Blocked `test_delete_hostgroup` with bz ID

Fixed role test:
- `test_update_role_permission`

Fixed OS test:
- `test_positive_set_os_parameter_1`

Fixed settings param test:
- `test_positive_update_general_param_10`
