### PR TITLE
Skip known-failing test

### DIFF
--- a/tests/foreman/api/test_multiple_paths.py
+++ b/tests/foreman/api/test_multiple_paths.py
@@ -16,7 +16,7 @@ BZ_1118015_ENTITIES = (
     entities.Repository, entities.Role, entities.User,
 )
 BZ_1122267_ENTITIES = (
-    entities.ActivationKey, entities.ContentView,
+    entities.ActivationKey, entities.ContentView, entities.GPGKey,
     entities.LifecycleEnvironment, entities.Repository
 )
 


### PR DESCRIPTION
When one fetches information about a GPG key, the following fields are returned:
- content
- created_at
- id
- name
- organization
- permissions
- products
- repositories
- updated_at

Note that 'organization' is returned, not 'organization_id'. This is bad
behaviour, and GPG keys therefore also suffer from the problem described in
bugzilla bug 1122267.
