### PR TITLE
Added extra API paths to content views.

### DIFF
--- a/tests/robottelo/test_entities.py
+++ b/tests/robottelo/test_entities.py
@@ -24,6 +24,8 @@ class PathTestCase(TestCase):
 
     @data(
         (entities.ActivationKey, '/activation_keys'),
+        (entities.ContentView, '/content_views'),
+        (entities.ContentViewVersion, '/content_view_versions'),
         (entities.Repository, '/repositories'),
     )
     @unpack
@@ -43,6 +45,11 @@ class PathTestCase(TestCase):
 
     @data(
         (entities.ActivationKey, '/activation_keys', 'releases'),
+        (entities.ContentView, '/content_views', 'content_view_versions'),
+        (entities.ContentView, '/content_views', 'publish'),
+        (entities.ContentView, '/content_views',
+         'available_puppet_module_names'),
+        (entities.ContentViewVersion, '/content_view_versions', 'promote'),
         (entities.Repository, '/repositories', 'sync'),
     )
     @unpack
@@ -69,6 +76,10 @@ class PathTestCase(TestCase):
 
     @data(
         (entities.ActivationKey, 'releases'),
+        (entities.ContentView, 'content_view_versions'),
+        (entities.ContentView, 'publish'),
+        (entities.ContentView, 'available_puppet_module_names'),
+        (entities.ContentViewVersion, 'promote'),
         (entities.Repository, 'sync'),
         (entities.ForemanTask, 'this')
     )


### PR DESCRIPTION
Added the following new API paths to entities related to content views:
- `entities.ContentView`
  - `content_view_versions` - List content view versions
  - `publish` - Publish a content view
  - `available_puppet_module_names` - Get puppet modules names that are available to be added to the content view
- `entities.ContentViewVersion`
  - `promote` - Promote a content view version

I have also added two new helper methods, namely
`entities.ContentView.publish` and
`entities.ContentViewVersion.promote` to handle publishing and
promotion of content views with (hopefully) an easier syntax, as shown
below. Assuming you had a `content-view` with `id=3`:

``` pycon
In [1]: from robottelo.api import client

In [2]: from robottelo import entities

In [3]: from robottelo.common.helpers import get_server_credentials

In [4]: cv = client.get(entities.ContentView(id=3).path(), auth=get_server_credentials(), verify=False).json()

In [5]: cv['versions']
Out[5]:
[]

In [6]: task = entities.ContentView(id=99).publish().json()

In [7]: entities.ForemanTask(id=task['id']).poll()
Out[7]:
{u'cli_example': None,
 u'ended_at': u'2014-08-20T19:04:39Z',
 u'humanized': {u'action': u'Publish',
  u'errors': [],
  u'input': [[u'content_view',
    {u'link': u'#/content_views/3/versions', u'text': u"content view 'Foo'"}],
   [u'organization',
    {u'link': u'/organizations/3/edit', u'text': u"organization 'Oregon'"}]],
  u'output': u''},
 u'id': u'2af5f92e-1143-488f-9ba4-61fafc8f6e20',
 u'input': {u'content_view': {u'id': 3, u'label': u'Foo', u'name': u'Foo'},
  u'content_view_id': 3,
  u'environment_id': 4,
  u'history_id': 14,
  u'locale': u'en',
  u'organization': {u'id': 3, u'label': u'Oregon', u'name': u'Oregon'},
  u'user_id': 3},
 u'label': u'Actions::Katello::ContentView::Publish',
 u'output': {},
 u'pending': False,
 u'progress': 1.0,
 u'result': u'success',
 u'started_at': u'2014-08-20T19:04:29Z',
 u'state': u'stopped',
 u'username': u'admin'}

In [8]: cv = client.get(entities.ContentView(id=3).path(), auth=get_server_credentials(), verify=False).json()

In [9]: cv['versions']
Out[9]:
[ {u'environment_ids': [4],
  u'id': 10,
  u'published': u'2014-08-20T19:04:29Z',
  u'version': 1}]

In [10]: task = entities.ContentViewVersion(id=10).promote(5).json()

In [11]: entities.ForemanTask(id=task['id']).poll()
Out[11]:
{u'cli_example': None,
 u'ended_at': u'2014-08-20T19:13:53Z',
 u'humanized': {u'action': u'Promotion',
  u'errors': [],
  u'input': [[u'content_view',
    {u'link': u'#/content_views/3/versions', u'text': u"content view 'Foo'"}],
   [u'organization',
    {u'link': u'/organizations/3/edit', u'text': u"organization 'Oregon'"}]],
  u'output': u''},
 u'id': u'd61a26e6-dca6-4014-be29-86779ca2308f',
 u'input': {u'content_view': {u'id': 3, u'label': u'Foo', u'name': u'Foo'},
  u'content_view_id': 3,
  u'environment_id': 5,
  u'environment_name': u'DEV',
  u'history_id': 15,
  u'locale': u'en',
  u'organization': {u'id': 3, u'label': u'Oregon', u'name': u'Oregon'},
  u'user_id': 3},
 u'label': u'Actions::Katello::ContentView::Promote',
 u'output': {},
 u'pending': False,
 u'progress': 1.0,
 u'result': u'success',
 u'started_at': u'2014-08-20T19:13:45Z',
 u'state': u'stopped',
 u'username': u'admin'}

In [12]: cv = client.get(entities.ContentView(id=3).path(), auth=get_server_credentials(), verify=False).json()

In [13]: cv['versions']
Out[14]:
[{u'environment_ids': [4, 5],
  u'id': 10,
  u'published': u'2014-08-20T19:04:29Z',
  u'version': 2}]
```

Finally, also added tests for the new paths:

``` bash
Test :meth:`robottelo.entities.ForemanTask.path`. ... ok
Test what happens when no entity ID is provided and ``which=path``. ... ok
Test what happens when no entity ID is provided and ``which=path``. ... ok
Test what happens when no entity ID is provided and ``which=path``. ... ok
Test what happens when no entity ID is provided and ``which=path``. ... ok
Test what happens when no entity ID is provided and ``which=path``. ... ok
Test what happens when no entity ID is provided and ``which=path``. ... ok
Test what happens when no entity ID is provided and ``which=path``. ... ok
Test what happens when an entity ID is given and ``which=which``. ... ok
Test what happens when an entity ID is given and ``which=which``. ... ok
Test what happens when an entity ID is given and ``which=which``. ... ok
Test what happens when an entity ID is given and ``which=which``. ... ok
Test what happens when an entity ID is given and ``which=which``. ... ok
Test what happens when an entity ID is given and ``which=which``. ... ok
Test what happens when the ``which`` argument is omitted. ... ok
Test what happens when the ``which`` argument is omitted. ... ok
Test what happens when the ``which`` argument is omitted. ... ok
Test what happens when the ``which`` argument is omitted. ... ok

----------------------------------------------------------------------
Ran 18 tests in 0.006s

OK
```
