### PR TITLE
Fix OneToManyField, simplify OneToOneField

### DIFF
--- a/tests/robottelo/test_orm.py
+++ b/tests/robottelo/test_orm.py
@@ -92,30 +92,16 @@ class EntityTestCase(unittest.TestCase):
 
 class OneToManyFieldTestCase(unittest.TestCase):
     """Tests for the OneToManyField"""
+    def test_get_value(self):
+        """Test :meth:`robottelo.orm.OneToManyField.get_value`.
 
-    def test_value_is_single_model_instance(self):
-        """Test a single entity value"""
-        entity = SampleEntity(name='aname')
-        other = ManyRelatedEntity(entities=entity)
+        Assert that ``get_value()`` returns a list of entity instances.
 
-        self.assertIsInstance(other.entities, list)
-        self.assertEqual(other.entities[0].name, 'aname')
-
-    def test_value_is_dictionary(self):
-        """Test a single dictionary value"""
-        entity = {'name': 'aname'}
-        other = ManyRelatedEntity(entities=entity)
-
-        self.assertIsInstance(other.entities, list)
-        self.assertEqual(other.entities[0].name, 'aname')
-
-    def test_value_is_list_of_dictionary(self):
-        """Test a list of dictionaries value"""
-        entity = [{'name': 'aname'}]
-        other = ManyRelatedEntity(entities=entity)
-
-        self.assertIsInstance(other.entities, list)
-        self.assertEqual(other.entities[0].name, 'aname')
+        """
+        values = orm.OneToManyField(SampleEntity).get_value()
+        self.assertIsInstance(values, list)
+        for value in values:
+            self.assertIsInstance(value, SampleEntity)
 
 
 class BooleanFieldTestCase(unittest.TestCase):
@@ -247,14 +233,14 @@ class MACAddressFieldTestCase(unittest.TestCase):
 class OneToOneFieldTestCase(unittest.TestCase):
     """Tests for :class:`robottelo.orm.OneToOneField`."""
     def test_get_value(self):
-        """Test method ``get_value``.
+        """Test :meth:`robottelo.orm.OneToOneField.get_value`.
 
-        Assert a :class:`robottelo.orm.Entity` instance is returned.
+        Assert that ``get_value()`` returns an entity instance.
 
         """
         self.assertIsInstance(
             orm.OneToOneField(SampleEntity).get_value(),
-            orm.Entity
+            SampleEntity
         )
 
 


### PR DESCRIPTION
The methods `Factory.build` and `Factory.create` misbehave when a
`OneToManyField` is involved. For example, the following both raise exceptions:

```
entities.Filter(role=N, permission=[X, Y, Z]).build()
entities.Filter(role=N, permission=[X, Y, Z]).create()
```

(For the above example, you'll need to fix up `Filter` and the letters above all
represent numbers. Just follow the example.)

Attempting to fix the above exceptions as-is is challenging, because the
implementation of `OneToManyField` is highly complicated. Thus, do the
following:
- Greatly simplify the implementation of `OneToManyField` so as to be much more
  comprehensible to mere mortals.
- Simplify the implementation of `OneToOneField` so that it is highly similar to
  the implementation of `OneToManyField` - and therefore easy to understand.
- Update the set of unit tests for methods `OneToOneField.get_value` and
  `OneToManyField.get_value`.

With this done, also fix up the implementation `Factory.build` to properly deal
with `OneToManyField`s.
