### PR TITLE
Add feature to run UI in headless mode

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -160,6 +160,23 @@ module::
     $ nosetests -c robottelo.properties -m test_positive_create_1 \
         tests.foreman.cli.test_org
 
+Running UI tests in a headless server
+-------------------------------------
+
+If you want to run UI test suite in a headless server, like a continuous
+integration server you will need to set ``virtual_display=1`` on properties
+file and also install ``PyVirtualDisplay`` package (this package will be
+already installed if you have installed the ``requirements-optional``).
+``PyVirtualDisplay`` uses Xvfb to create a virtual display, so you will need to
+install Xvfb, you can install on a yum based distro by running::
+
+    # yum install xorg-x11-server-Xvfb
+
+With the initial configuration in place, now every time that an UI test runs it
+will not pop any browser window if run in a desktop or will be able to run in a
+headless server. Also this setup allows you to just run ``make
+test-foreman-ui`` in order to run the entire UI test suite.
+
 API Reference
 =============
 

--- a/requirements-optional.txt
+++ b/requirements-optional.txt
@@ -12,3 +12,7 @@ sphinx
 
 # ???
 nose_xunitmp
+
+# For running UI tests in a headless mode
+# PyVirtualDisplay requires xvfb
+PyVirtualDisplay

--- a/robottelo.properties.sample
+++ b/robottelo.properties.sample
@@ -15,6 +15,10 @@ locale=en_US
 remote=0
 smoke=0
 
+# Virtual display controls if PyVirtualDisplay should be used to run UI tests
+# when setting it to 1 then make sure to install required dependencies
+virtual_display=0
+
 [foreman]
 admin.username=admin
 admin.password=changeme

--- a/robottelo/test.py
+++ b/robottelo/test.py
@@ -10,6 +10,7 @@ if sys.hexversion >= 0x2070000:
     import unittest
 else:
     import unittest2 as unittest
+
 from robottelo.cli.metatest import MetaCLITest
 from robottelo.common.helpers import get_server_url
 from robottelo.common import conf
@@ -115,6 +116,14 @@ class UITestCase(TestCase):
         cls.verbosity = int(conf.properties['nosetests.verbosity'])
         cls.remote = int(conf.properties['main.remote'])
 
+        if int(conf.properties.get('main.virtual_display', '0')):
+            # Importing here because PyVirtualDisplay is optional
+            from pyvirtualdisplay import Display
+            cls.display = Display(size=(1024, 768))
+            cls.display.start()
+        else:
+            cls.display = None
+
     def setUp(self):
         """
         We do want a new browser instance for every test.
@@ -182,6 +191,11 @@ class UITestCase(TestCase):
 
         self.browser.quit()
         self.browser = None
+
+    @classmethod
+    def tearDownClass(cls):
+        if cls.display is not None:
+            cls.display.stop()
 
 
 def assert_instance_intersects(first, other):


### PR DESCRIPTION
By configuring virtual_display=1 in properties file, robottelo will use
a virtual display to run UI tests using PyVirtualDisplay package and
Xvfb.
