### PR TITLE
Fix script for graphing entities

### DIFF
--- a/scripts/graph_entities.py
+++ b/scripts/graph_entities.py
@@ -35,13 +35,9 @@ for entity_name, entity in entities_.items():
     for field_name, field in entity.get_fields().items():
         if (isinstance(field, orm.OneToOneField)
                 or isinstance(field, orm.OneToManyField)):
-            if isinstance(field, orm.OneToOneField):
-                dependency = field.model  # *sigh* This is not so great.
-            else:
-                dependency = field.entity
             print('{0} -> {1} [label="{2}"{3}]'.format(
                 entity_name,
-                dependency,
+                field.entity,
                 field_name,
                 ' color=red' if field.options.get('required', False) else ''
             ))


### PR DESCRIPTION
PR #1220 simplified the implementation of the `OneToOneField` and
`OneToManyField` classes. Both classes now record which kind of entity they
point to in the instance variable "entity". Formerly, only the `OneToManyField`
did this, and the `OneToOneField` used a variable named "model".

Fix `scripts/graph_entities.py` to deal with this change.
