### PR TITLE
When making API calls, provide "data" not "params"

### DIFF
--- a/robottelo/entities.py
+++ b/robottelo/entities.py
@@ -772,9 +772,9 @@ class LifecycleEnvironment(orm.Entity, factory.EntityFactoryMixin):
                 self.path(),
                 auth=get_server_credentials(),
                 verify=False,
-                params={
-                    'name': 'Library',
-                    'organization_id': self.organization,
+                data={
+                    u'name': 'Library',
+                    u'organization_id': self.organization,
                 }
             ).json()['results']
             if len(query_results) != 1:

--- a/tests/foreman/api/test_gpgkey_v2.py
+++ b/tests/foreman/api/test_gpgkey_v2.py
@@ -27,7 +27,7 @@ class GPGKeyTestCase(TestCase):
         response = client.get(
             entities.GPGKey().path(),
             auth=get_server_credentials(),
-            params={'organization_id': org_attrs['id']},
+            data={u'organization_id': org_attrs['id']},
             verify=False,
         )
         self.assertEqual(response.status_code, httplib.OK)

--- a/tests/foreman/api/test_host_v2.py
+++ b/tests/foreman/api/test_host_v2.py
@@ -29,7 +29,7 @@ class HostsTestCase(TestCase):
         response = client.get(
             entities.Host().path(),
             auth=get_server_credentials(),
-            params={'search': query},
+            data={u'search': query},
             verify=False,
         )
         self.assertEqual(response.status_code, httplib.OK)
@@ -46,7 +46,7 @@ class HostsTestCase(TestCase):
         response = client.get(
             entities.Host().path(),
             auth=get_server_credentials(),
-            params={'per_page': per_page},
+            data={u'per_page': per_page},
             verify=False,
         )
         self.assertEqual(response.status_code, httplib.OK)

--- a/tests/foreman/api/test_lifecycleenvironment_v2.py
+++ b/tests/foreman/api/test_lifecycleenvironment_v2.py
@@ -27,7 +27,7 @@ class LifecycleEnvironmentTestCase(TestCase):
         response = client.get(
             entities.LifecycleEnvironment().path(),
             auth=get_server_credentials(),
-            params={'organization_id': org_attrs['id']},
+            data={u'organization_id': org_attrs['id']},
             verify=False,
         )
         self.assertEqual(response.status_code, httplib.OK)

--- a/tests/foreman/smoke/test_api_smoke.py
+++ b/tests/foreman/smoke/test_api_smoke.py
@@ -291,11 +291,15 @@ class TestSmoke(TestCase):
         # step 2.6: Synchronize both repositories
         response = client.post(
             entities.Repository(id=repo1['id']).path('sync'),
-            {u'ids': [repo1['id']]},
+            {
+                u'ids': [repo1['id']],
+                u'organization_id': org['id']
+            },
             auth=get_server_credentials(),
             verify=False,
-            params={u'organization_id': org['id']}).json()
+        ).json()
         # TODO: Fetch status of sync task from response task 'id'
+        # Can use ForemanTask entity to monitor tasks.
 
         # step 2.7: Create content view
         content_view = entities.ContentView(organization=org['id']).create()
@@ -323,7 +327,7 @@ class TestSmoke(TestCase):
         response = client.get(
             path,
             auth=auth,
-            params={'search': query},
+            data={u'search': query},
             verify=False,
         )
         self.assertEqual(


### PR DESCRIPTION
When using the requests library (or our wrapper), one can provide the "data" and
"params" arguments. The "data" arguments can be encoded as e.g. JSON, but the
"params" arguments are always encoded directly in a URL.

When communicating with the API, it is sensible to provide all arguments through
a single channel. This change ensures that, whenever possible, all arguments are
passed to the API as JSON-encoded data.
