### PR TITLE
Add a test subscribing a system to a content view

### DIFF
--- a/robottelo/entities.py
+++ b/robottelo/entities.py
@@ -233,13 +233,20 @@ class ContentViewVersion(orm.Entity):
     def promote(self, environment_id):
         """Helper for promoting an existing published content view.
 
+        :returns: The server's response, with all JSON decoded.
+        :rtype: dict
+        :raises: ``requests.exceptions.HTTPError`` If the server responds with
+            an HTTP 4XX or 5XX message.
+
         """
-        return client.post(
+        response = client.post(
             self.path('promote'),
             auth=get_server_credentials(),
             verify=False,
             data={u'environment_id': environment_id}
         )
+        response.raise_for_status()
+        return response.json()
 
 
 class ContentViewFilterRule(orm.Entity):
@@ -359,13 +366,20 @@ class ContentView(orm.Entity, factory.EntityFactoryMixin):
     def publish(self):
         """Helper for publishing an existing content view.
 
+        :returns: The server's response, with all JSON decoded.
+        :rtype: dict
+        :raises: ``requests.exceptions.HTTPError`` If the server responds with
+            an HTTP 4XX or 5XX message.
+
         """
-        return client.post(
+        response = client.post(
             self.path('publish'),
             auth=get_server_credentials(),
             verify=False,
             data={u'id': self.id}
         )
+        response.raise_for_status()
+        return response.json()
 
 
 class CustomInfo(orm.Entity):

--- a/tests/foreman/api/test_contentview_v2.py
+++ b/tests/foreman/api/test_contentview_v2.py
@@ -1,0 +1,79 @@
+"""Unit tests for the ``content_views`` paths.
+
+A full API reference for content views can be found here:
+http://theforeman.org/api/apidoc/v2/content_views.html
+
+"""
+from robottelo.api import client
+from robottelo.common.helpers import get_server_credentials
+from robottelo import entities
+from unittest import TestCase
+# (too many public methods) pylint: disable=R0904
+
+
+class ContentViewTestCase(TestCase):
+    """Tests for content views."""
+    def test_subscribe_system_to_cv(self):
+        """@Test: Subscribe a system to a content view.
+
+        @Feature: ContentView
+
+        @Assert: It is possible to create a system and set its
+        'content_view_id' attribute.
+
+        """
+        # Create an organization, lifecycle environment and content view.
+        organization = entities.Organization().create()
+        lifecycle_environment = entities.LifecycleEnvironment(
+            organization=organization['id']
+        ).create()
+        content_view = entities.ContentView(
+            organization=organization['id']
+        ).create()
+
+        # Publish the newly created content view.
+        response = entities.ContentView(id=content_view['id']).publish()
+        self.assertEqual(
+            u'success',
+            entities.ForemanTask(id=response['id']).poll()['result']
+        )
+
+        # Fetch and promote the newly published content view version.
+        content_view_version = client.get(
+            entities.ContentViewVersion().path(),
+            auth=get_server_credentials(),
+            data={u'content_view_id': content_view['id']},
+            verify=False,
+        ).json()['results'][0]
+        response = entities.ContentViewVersion(
+            id=content_view_version['id']
+        ).promote(environment_id=lifecycle_environment['id'])
+        self.assertEqual(
+            u'success',
+            entities.ForemanTask(id=response['id']).poll()['result']
+        )
+
+        # Create a system that is subscribed to the published and promoted
+        # content view. Associating this system with the organization and
+        # environment created above is not particularly important, but doing so
+        # means a shorter test where fewer entities are created, as
+        # System.organization and System.environment are required attributes.
+        system = entities.System(
+            content_view=content_view['id'],
+            environment=lifecycle_environment['id'],
+            organization=organization['id'],
+        ).create()
+
+        # See bugzilla bug #1122267.
+        self.assertEqual(
+            system['content_view_id'],  # This is good.
+            content_view['id']
+        )
+        self.assertEqual(
+            system['environment']['id'],  # This is bad.
+            lifecycle_environment['id']
+        )
+        # self.assertEqual(
+        #     system['organization_id'],  # And this is unavailable.
+        #     organization['id']
+        # )

--- a/tests/foreman/smoke/test_api_smoke.py
+++ b/tests/foreman/smoke/test_api_smoke.py
@@ -351,7 +351,7 @@ class TestSmoke(TestCase):
         )
 
         # step 2.9: Publish content view
-        task = entities.ContentView(id=content_view['id']).publish().json()
+        task = entities.ContentView(id=content_view['id']).publish()
         task_status = entities.ForemanTask(id=task['id']).poll()
         self.assertEqual(
             task_status['result'],
@@ -372,7 +372,7 @@ class TestSmoke(TestCase):
             1,
             u"Content view should be present on 1 lifecycle only")
         task = entities.ContentViewVersion(
-            id=content_view['versions'][0]['id']).promote(le1['id']).json()
+            id=content_view['versions'][0]['id']).promote(le1['id'])
         task_status = entities.ForemanTask(id=task['id']).poll()
         self.assertEqual(
             task_status['result'],
@@ -393,7 +393,7 @@ class TestSmoke(TestCase):
             2,
             u"Content view should be present on 2 lifecycles only")
         task = entities.ContentViewVersion(
-            id=content_view['versions'][0]['id']).promote(le2['id']).json()
+            id=content_view['versions'][0]['id']).promote(le2['id'])
         task_status = entities.ForemanTask(id=task['id']).poll()
         self.assertEqual(
             task_status['result'],


### PR DESCRIPTION
Add a new test module: `tests.foreman.api.test_contentview_v2`. Add a test to
this module which does the following:
1. Create an organization, lifecycle environment and content view.
2. Publish the newly created content view.
3. Promote the newly published content view.
4. Create a system which references the organization, lifecycle environment and
   content view.

Make `ContentView.publish` raise an exception if an HTTP 4XX or 5XX response is
received. Otherwise, return a response with the JSON already decoded. Update
`tests/foreman/smoke/test_api_smoke.py` to deal with the change.

Addresses #691. Inspired by #1225, #1205, #1203 and #1197.
