### PR TITLE
Revert "Remove 'skip' decorator from working test"

### DIFF
--- a/tests/foreman/api/test_role_v2.py
+++ b/tests/foreman/api/test_role_v2.py
@@ -6,6 +6,7 @@ can be found here: http://theforeman.org/api/apidoc/v2/roles.html
 """
 from robottelo.api import client
 from robottelo.api.utils import status_code_error
+from robottelo.common.decorators import skip_if_bug_open
 from robottelo.common.helpers import get_server_credentials
 from robottelo import entities, factory, orm
 from unittest import TestCase
@@ -48,6 +49,7 @@ class RoleTestCase(TestCase):
         """
         self._test_role_name(name)
 
+    @skip_if_bug_open('bugzilla', 1129785)
     @ddt.data(
         orm.StringField(str_type=('cjk',)).get_value(),
         orm.StringField(str_type=('latin1',)).get_value(),


### PR DESCRIPTION
This reverts commit ae415de566d06b4e055187ea94e790db88589494.

As per [bugzilla bug 1112657](https://bugzilla.redhat.com/show_bug.cgi?id=1112657), it should be possible to use a wide variety of
characters in a role's name. For example, the following should be valid role
names:
- foo@bar.com
- チーズ

This issue was fixed, but it appears that a regression has occurred. [Bugzilla
bug 1112657](https://bugzilla.redhat.com/show_bug.cgi?id=1112657) should be re-opened.
