### PR TITLE
Change which BZ bug states cause a test to skip

### DIFF
--- a/robottelo/common/decorators.py
+++ b/robottelo/common/decorators.py
@@ -26,7 +26,7 @@ from xmlrpclib import Fault
 
 
 BUGZILLA_URL = "https://bugzilla.redhat.com/xmlrpc.cgi"
-BUGZILLA_OPEN_BUG_STATUSES = ('NEW', 'ASSIGNED')
+BUGZILLA_OPEN_BUG_STATUSES = ('NEW', 'ASSIGNED', 'POST', 'MODIFIED')
 REDMINE_URL = 'http://projects.theforeman.org'
 
 # A dict mapping bug IDs to python-bugzilla bug objects.


### PR DESCRIPTION
Make the `skip_if_bug_open` decorator skip a test if it points to a bugzilla bug
in any of the following states:
- NEW
- ASSIGNED
- POST
- MODIFIED

Formerly, only the 'NEW' and 'ASSIGNED' bugzilla bug states caused
`skip_if_bug_open` to skip a test.
