### PR TITLE
Add EntityReadMixin to some entities

### DIFF
--- a/robottelo/entities.py
+++ b/robottelo/entities.py
@@ -833,7 +833,9 @@ class Media(orm.Entity):
         api_path = 'api/v2/media'
 
 
-class Model(orm.Entity, factory.EntityFactoryMixin, orm.EntityDeleteMixin):
+class Model(
+        orm.Entity, factory.EntityFactoryMixin, orm.EntityDeleteMixin,
+        orm.EntityReadMixin):
     """A representation of a Model entity."""
     name = orm.StringField(required=True)
     info = orm.StringField(null=True)
@@ -846,7 +848,8 @@ class Model(orm.Entity, factory.EntityFactoryMixin, orm.EntityDeleteMixin):
 
 
 class OperatingSystem(
-        orm.Entity, factory.EntityFactoryMixin, orm.EntityDeleteMixin):
+        orm.Entity, factory.EntityFactoryMixin, orm.EntityDeleteMixin,
+        orm.EntityReadMixin):
     """A representation of a Operating System entity.
 
     ``major`` is listed as a string field in the API docs, but only numeric
@@ -887,7 +890,8 @@ class OrganizationDefaultInfo(orm.Entity):
 
 
 class Organization(
-        orm.Entity, factory.EntityFactoryMixin, orm.EntityDeleteMixin):
+        orm.Entity, factory.EntityFactoryMixin, orm.EntityDeleteMixin,
+        orm.EntityReadMixin):
     """A representation of an Organization entity."""
     name = orm.StringField(required=True)
     label = orm.StringField()
@@ -1218,7 +1222,9 @@ class RoleLDAPGroups(orm.Entity):
         api_path = 'katello/api/v2/roles/:role_id/ldap_groups'
 
 
-class Role(orm.Entity, factory.EntityFactoryMixin, orm.EntityDeleteMixin):
+class Role(
+        orm.Entity, factory.EntityFactoryMixin, orm.EntityDeleteMixin,
+        orm.EntityReadMixin):
     """A representation of a Role entity."""
     # FIXME: UTF-8 characters should be acceptable for `name`. See BZ 1129785
     name = orm.StringField(required=True, str_type=('alphanumeric',))

--- a/tests/foreman/api/test_multiple_paths.py
+++ b/tests/foreman/api/test_multiple_paths.py
@@ -286,8 +286,14 @@ class EntityIdTestCase(TestCase):
 
 
 @ddt
-class LongMessageTestCase(TestCase):
-    """Issue a variety of HTTP requests to a variety of URLs."""
+class DoubleCheckTestCase(TestCase):
+    """Perform in-depth tests on URLs.
+
+    Do not just assume that an HTTP response with a good status code indicates
+    that an action succeeded. Instead, issue a follow-up request after each
+    action to ensure that the intended action was accomplished.
+
+    """
     longMessage = True
 
     @data(
@@ -426,3 +432,39 @@ class LongMessageTestCase(TestCase):
             response.status_code,
             status_code_error(path, status_code, response),
         )
+
+
+@ddt
+class EntityReadTestCase(TestCase):
+    """
+    Check that classes inheriting from :class:`robottelo.orm.EntityReadMixin`
+    function correctly.
+    """
+    # Most entities are commented-out because they do not inherit from
+    # EntityReadMixin, due to issues with data returned from the API.
+    @data(
+        # entities.ActivationKey,
+        # entities.Architecture,
+        # entities.ContentView,
+        # entities.Domain,
+        # entities.GPGKey,
+        # entities.Host,  # Host().create() does not work
+        # entities.LifecycleEnvironment,
+        entities.Model,
+        entities.OperatingSystem,
+        entities.Organization,
+        # entities.Repository,
+        entities.Role,
+        # entities.System,
+        # entities.User,
+    )
+    def test_entity_read(self, entity):
+        """@Test: Create an entity and get it using
+        :meth:`robottelo.orm.EntityReadMixin.read`.
+
+        @Assert: The just-read entity is an instance of the correct class.
+
+        """
+        attrs = entity().create()
+        read_entity = entity(id=attrs['id']).read()
+        self.assertIsInstance(read_entity, entity)


### PR DESCRIPTION
When asked for information about an entity, the API often returns data that is
inconsistently named, inconsistently structured, or incomplete. Thus, the
EntityReadMixin can only be added to a few entities. Do so, and add a test
verifying that the mixin works.
