### PR TITLE
Add option to run a window manager

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -170,6 +170,9 @@ It is possible to run UI tests on a headless server. To do this:
 * Install the ``PyVirtualDisplay`` Python package. (It is listed in
   ``requirements-optional.txt``.)
 * Set ``virtual_display=1`` in the configuration file ``robottelo.properties``.
+* [Optional] If you want to run a window manager set ``window_manager_command``
+  in the configuration file. The window manager command will be run before
+  opening any browser window to allow it be maximized.
 
 This done, UI tests no longer launch a visible web browser. Instead, UI tests
 launch a web browser within a virtual display.

--- a/robottelo.properties.sample
+++ b/robottelo.properties.sample
@@ -19,6 +19,10 @@ smoke=0
 # when setting it to 1 then make sure to install required dependencies
 virtual_display=0
 
+# If virtual_display=1 and window_manager_command is not blank, the window
+# manager command will be run before opening any browser window
+window_manager_command=
+
 [foreman]
 admin.username=admin
 admin.password=changeme


### PR DESCRIPTION
Allow run a window manager for UI tests running using virtual display
feature. If the window manager command specified in the properties file
is found then it will be run before open any browser window. This will
allow the browser window be maximized.
