### PR TITLE
len option in orm.StringField

### DIFF
--- a/robottelo/entities.py
+++ b/robottelo/entities.py
@@ -66,8 +66,8 @@ class Architecture(
 
 class AuthSourceLDAP(orm.Entity, factory.EntityFactoryMixin):
     """A representation of a AuthSourceLDAP entity."""
-    name = orm.StringField(required=True, max_len=60)
-    host = orm.StringField(required=True, max_len=60)
+    name = orm.StringField(required=True, len=(1, 60))
+    host = orm.StringField(required=True, len=(1, 60))
     # defaults to 389
     port = orm.IntegerField(null=True)
     account = orm.StringField(null=True)
@@ -859,7 +859,7 @@ class OperatingSystem(
     """
     # validator: Must match regular expression /\A(\S+)\Z/.
     name = orm.StringField(required=True)
-    major = orm.StringField(required=True, str_type=('numeric',), max_len=5)
+    major = orm.StringField(required=True, str_type=('numeric',), len=(1, 5))
     minor = orm.StringField(null=True)
     description = orm.StringField(null=True)
     family = orm.StringField(null=True)
@@ -1446,8 +1446,8 @@ class User(orm.Entity, factory.EntityFactoryMixin, orm.EntityDeleteMixin):
         required=True,
         # Passing UTF8 characters to ``login`` yields 500s.
         str_type=('alpha', 'alphanumeric', 'cjk', 'latin1'))
-    firstname = orm.StringField(null=True, max_len=60)
-    lastname = orm.StringField(null=True, max_len=60)
+    firstname = orm.StringField(null=True, len=(1, 60))
+    lastname = orm.StringField(null=True, len=(1, 60))
     mail = orm.EmailField(required=True)
     # Is an admin account?
     admin = orm.BooleanField(null=True)

--- a/robottelo/orm.py
+++ b/robottelo/orm.py
@@ -131,28 +131,31 @@ class IntegerField(booby.fields.Integer):
 
 class StringField(booby.fields.String):
     """Field that represents a string."""
-    def __init__(self, max_len=30, str_type=('utf8',), *args, **kwargs):
+    def __init__(self, len=(1, 30), str_type=('utf8',), *args, **kwargs):
         """Constructor for a ``StringField``.
 
-        The default ``max_len`` of string fields is short for two reasons:
+        The default ``len`` of string fields is short for two reasons:
 
         1. Foreman's database backend limits many fields to 255 bytes in
-           length. As a result, ``max_len`` should be no longer than 85
+           length. As a result, ``len`` should be no longer than 85
            characters long, as 85 unicode characters may be up to 255 bytes
            long.
         2. Humans have to read through the error messages produced by
            Robottelo. Long error messages are hard to read through, and that
-           hurts productivity. Thus, a ``max_len`` even shorter than 85 chars
+           hurts productivity. Thus, a ``len`` even shorter than 85 chars
            is desirable.
 
-        :param int max_len: The maximum length of the string generated when
-            :meth:`get_value` is called.
+        :param len: Either a ``(min_len, max_len)`` tuple or an ``exact_len``
+            integer.
         :param sequence str_type: The types of characters to generate when
             :meth:`get-value` is called. Any argument which can be passed to
             ``FauxFactory.generate_string`` can be provided in the sequence.
 
         """
-        self.max_len = max_len
+        if isinstance(len, tuple):
+            self.min_len, self.max_len = len
+        else:
+            self.min_len = self.max_len = len
         self.str_type = str_type
         super(StringField, self).__init__(*args, **kwargs)
 
@@ -162,7 +165,7 @@ class StringField(booby.fields.String):
             self,
             lambda: FauxFactory.generate_string(
                 FauxFactory.generate_choice(self.str_type),
-                FauxFactory.generate_integer(1, self.max_len)
+                FauxFactory.generate_integer(self.min_len, self.max_len)
             )
         )
 

--- a/tests/foreman/api/test_activationkey_v2.py
+++ b/tests/foreman/api/test_activationkey_v2.py
@@ -235,7 +235,7 @@ class ActivationKeysTestCase(TestCase):
         )
 
     @data(
-        StringField(max_len=30, str_type=('alpha',)).get_value(),
+        StringField(len=(1, 30), str_type=('alpha',)).get_value(),
         IntegerField(min_val=-200, max_val=-1).get_value(),
         -1,
         0

--- a/tests/foreman/api/test_user_v2.py
+++ b/tests/foreman/api/test_user_v2.py
@@ -19,10 +19,10 @@ import httplib
 class UsersTestCase(TestCase):
     """Tests for the ``users`` path."""
     @data(
-        StringField(max_len=60, str_type=('alpha',)).get_value(),
-        StringField(max_len=60, str_type=('alphanumeric',)).get_value(),
-        StringField(max_len=60, str_type=('cjk',)).get_value(),
-        StringField(max_len=60, str_type=('latin1',)).get_value(),
+        StringField(len=(1, 60), str_type=('alpha',)).get_value(),
+        StringField(len=(1, 60), str_type=('alphanumeric',)).get_value(),
+        StringField(len=(1, 60), str_type=('cjk',)).get_value(),
+        StringField(len=(1, 60), str_type=('latin1',)).get_value(),
     )
     def test_positive_create_1(self, login):
         """

--- a/tests/foreman/cli/test_host.py
+++ b/tests/foreman/cli/test_host.py
@@ -25,7 +25,7 @@ class HostTestCase(CLITestCase):
         puppet_proxy = result.stdout[0]
 
         host_name = orm.StringField(
-            str_type=('alpha',), max_len=10).get_value()
+            str_type=('alpha',), len=(1, 10)).get_value()
 
         try:
             # Creating dependent objects

--- a/tests/robottelo/test_orm.py
+++ b/tests/robottelo/test_orm.py
@@ -286,16 +286,18 @@ class StringFieldTestCase(unittest.TestCase):
             self.assertIsInstance(string, str)
         self.assertGreater(len(string), 0)
 
-    def test_max_len(self):
-        """Set a ``max_len`` and call ``get_value``.
+    def test_len(self):
+        """Set a ``len`` and call ``get_value``.
 
-        Assert the string generated is between 1 and ``max_len`` chars long,
-        inclusive.
+        Assert the length of generated string specified by ``len``.
 
         """
-        string = orm.StringField(max_len=20).get_value()
+        string = orm.StringField(len=(1,20)).get_value()
         self.assertGreater(len(string), 0)
         self.assertLessEqual(len(string), 20)
+
+        string = orm.StringField(len=5).get_value()
+        self.assertEqual(len(string), 5)
 
     def test_str_type(self):
         """Set a ``str_type`` can call ``get_value``.


### PR DESCRIPTION
adding more options to orm.StringField()
this will be useful for boundary tests
