### PR TITLE
Add test targeting bugzilla bug #1112802

### DIFF
--- a/tests/foreman/api/test_rhsm.py
+++ b/tests/foreman/api/test_rhsm.py
@@ -1,0 +1,35 @@
+"""Unit tests for the ``rhsm`` paths.
+
+No API doc exists for the subscription manager path(s). However, bugzilla bug
+1112802 provides some relevant information.
+
+"""
+from robottelo.api import client
+from robottelo.common.helpers import get_server_credentials, get_server_url
+from unittest import TestCase
+import httplib
+# (too many public methods) pylint: disable=R0904
+
+
+class RHSMTestCase(TestCase):
+    """Tests for the ``/rhsm`` path."""
+    def test_path_exists(self):
+        """@Test: Check whether the path exists.
+
+        @Feature: Red Hat Subscription Manager
+
+        @Assert: Issuing an HTTP GET produces an HTTP 200 response with an
+        ``application/json`` content-type, and the response is a list.
+
+        This test targets bugzilla bug 1112802.
+
+        """
+        path = '{0}/rhsm'.format(get_server_url())
+        response = client.get(
+            path,
+            auth=get_server_credentials(),
+            verify=False,
+        )
+        self.assertEqual(response.status_code, httplib.OK)
+        self.assertIn('application/json', response.headers['content-type'])
+        self.assertIsInstance(response.json(), list)


### PR DESCRIPTION
Add a test which checks that issuing an HTTP GET to the "/rhsm" path results in
a response with the following properties:
- It has an HTTP 200 status code.
- It has an application/json content-type
- When the JSON is decoded, the response is a list.
