### PR TITLE
Add a test targeting bugzilla bug 1102120

### DIFF
--- a/tests/foreman/api/test_contentviewfilter_v2.py
+++ b/tests/foreman/api/test_contentviewfilter_v2.py
@@ -1,0 +1,58 @@
+"""Unit tests for the ``content_view_filters`` paths.
+
+A full API reference for content views can be found here:
+http://theforeman.org/api/apidoc/v2/content_view_filters.html
+
+"""
+from robottelo.api import client
+from robottelo.common.helpers import get_server_credentials
+from robottelo import entities
+from unittest import TestCase
+import httplib
+# (too many public methods) pylint: disable=R0904
+
+
+class ContentViewFilterTestCase(TestCase):
+    """Tests for content view filters."""
+    def test_get_with_no_args(self):
+        """@Test: Issue an HTTP GET to the base content view filters path.
+
+        @Feature: ContentViewFilter
+
+        @Assert: An HTTP 400 or 422 response is received if a GET request is
+        issued with no arguments specified.
+
+        This test targets bugzilla bug #1102120.
+
+        """
+        response = client.get(
+            entities.ContentViewFilter().path(),
+            auth=get_server_credentials(),
+            verify=False,
+        )
+        self.assertIn(
+            response.status_code,
+            (httplib.BAD_REQUEST, httplib.UNPROCESSABLE_ENTITY)
+        )
+
+    def test_get_with_bad_args(self):
+        """@Test: Issue an HTTP GET to the base content view filters path.
+
+        @Feature: ContentViewFilter
+
+        @Assert: An HTTP 400 or 422 response is received if a GET request is
+        issued with bad arguments specified.
+
+        This test targets bugzilla bug #1102120.
+
+        """
+        response = client.get(
+            entities.ContentViewFilter().path(),
+            auth=get_server_credentials(),
+            verify=False,
+            data={'foo': 'bar'},
+        )
+        self.assertIn(
+            response.status_code,
+            (httplib.BAD_REQUEST, httplib.UNPROCESSABLE_ENTITY)
+        )


### PR DESCRIPTION
Add a test which issues an HTTP GET request to the base content view filters
path. Assert that the response is an HTTP 400 (bad request) or 422
(unprocessable entity) message.
