### PR TITLE
Skip known-failing tests

### DIFF
--- a/tests/foreman/api/test_role_v2.py
+++ b/tests/foreman/api/test_role_v2.py
@@ -49,7 +49,7 @@ class RoleTestCase(TestCase):
         """
         self._test_role_name(name)
 
-    @skip_if_bug_open('bugzilla', 1129785)
+    @skip_if_bug_open('bugzilla', 1112657)
     @ddt.data(
         orm.StringField(str_type=('cjk',)).get_value(),
         orm.StringField(str_type=('latin1',)).get_value(),


### PR DESCRIPTION
Creating a role with a name containing non-ascii characters is known to fail.
Update a `skip_if_bug_open` decorator to make tests which target this issue
skip.
