### PR TITLE
Make Repository.read work correctly

### DIFF
--- a/robottelo/entities.py
+++ b/robottelo/entities.py
@@ -1191,7 +1191,8 @@ class Report(orm.Entity):
 
 
 class Repository(
-        orm.Entity, factory.EntityFactoryMixin, orm.EntityDeleteMixin):
+        orm.Entity, factory.EntityFactoryMixin, orm.EntityDeleteMixin,
+        orm.EntityReadMixin):
     """A representation of a Repository entity."""
     name = orm.StringField(required=True)
     label = orm.StringField()
@@ -1221,6 +1222,16 @@ class Repository(
         if which == 'sync':
             return super(Repository, self).path(which='this') + '/sync'
         return super(Repository, self).path()
+
+    def read(self, auth=None, entity=None, attrs=None):
+        """Override the default implementation of
+        `robottelo.orm.EntityReadMixin.read`.
+
+        """
+        if attrs is None:
+            attrs = self.read_json(auth)
+        attrs['product_id'] = attrs.pop('product')['id']
+        return super(Repository, self).read(auth, entity, attrs)
 
     class Meta(object):
         """Non-field information about this entity."""

--- a/robottelo/orm.py
+++ b/robottelo/orm.py
@@ -520,22 +520,19 @@ class EntityReadMixin(object):
         # weirdly structured or incomplete data. (See BZ #1122267)
         for field_name, field_type in entity.get_fields().items():
             if isinstance(field_type, OneToOneField):
+                # `OneToOneField.entity` may be either a class or a string. For
+                # examples of this, look at a couple class definitions in
+                # module `robottelo.entities`. `_get_class` returns a class.
+                other_cls = _get_class(field_type.entity)
                 entity_id = attrs[field_name + '_id']
-                setattr(
-                    entity,
-                    field_name,
-                    field_type.entity(id=entity_id),
-                )
+                setattr(entity, field_name, other_cls(id=entity_id))
             elif isinstance(field_type, OneToManyField):
+                other_cls = _get_class(field_type.entity)  # see above
                 entity_ids = attrs[field_name + '_ids']
                 setattr(
                     entity,
                     field_name,
-                    [
-                        field_type.entity(id=entity_id)
-                        for entity_id
-                        in entity_ids
-                    ]
+                    [other_cls(id=entity_id) for entity_id in entity_ids]
                 )
             else:
                 setattr(entity, field_name, attrs[field_name])

--- a/tests/foreman/api/test_multiple_paths.py
+++ b/tests/foreman/api/test_multiple_paths.py
@@ -477,7 +477,7 @@ class EntityReadTestCase(TestCase):
         entities.OperatingSystem,
         # entities.OperatingSystemParameter,  # see test_osparameter_read
         entities.Organization,
-        # entities.Repository,
+        entities.Repository,
         entities.Role,
         # entities.System,
         # entities.User,


### PR DESCRIPTION
Add `EntityReadMixin` to the `Repository` class. Override the `read` method,
allowing it to deal with the fact that issuing an HTTP GET to the API returns a
"product" hash containing an ID, but not a "product_id" integer as expected.

Test this change.

Update `EntityReadMixin` to deal with the fact that `OneToOneField`s and
`OneToManyField`s may contain either classes or strings naming classes.
