### PR TITLE
Add API tests for compute profiles

### DIFF
--- a/robottelo/entities.py
+++ b/robottelo/entities.py
@@ -135,7 +135,9 @@ class ComputeAttribute(orm.Entity):
         # '/api/v2/compute_profiles/:compute_profile_id/compute_attributes',
 
 
-class ComputeProfile(orm.Entity):
+class ComputeProfile(
+        orm.Entity, orm.EntityReadMixin, orm.EntityDeleteMixin,
+        factory.EntityFactoryMixin):
     """A representation of a Compute Profile entity."""
     name = orm.StringField(required=True)
 

--- a/tests/foreman/api/test_multiple_paths.py
+++ b/tests/foreman/api/test_multiple_paths.py
@@ -28,6 +28,7 @@ class EntityTestCase(TestCase):
     @data(
         # entities.ActivationKey,  # need organization_id or environment_id
         entities.Architecture,
+        entities.ComputeProfile,
         # entities.ContentView,  # need organization_id
         entities.Domain,
         entities.Environment,
@@ -65,6 +66,7 @@ class EntityTestCase(TestCase):
     @data(
         # entities.ActivationKey,  # need organization id or environment id
         entities.Architecture,
+        entities.ComputeProfile,
         entities.ContentView,
         entities.Domain,
         entities.Environment,
@@ -97,6 +99,7 @@ class EntityTestCase(TestCase):
     @data(
         entities.ActivationKey,
         entities.Architecture,
+        entities.ComputeProfile,
         entities.ContentView,
         entities.Domain,
         entities.Environment,
@@ -137,6 +140,7 @@ class EntityTestCase(TestCase):
     @data(
         entities.ActivationKey,
         entities.Architecture,
+        entities.ComputeProfile,
         entities.ContentView,
         entities.Domain,
         entities.Environment,
@@ -174,6 +178,7 @@ class EntityIdTestCase(TestCase):
     @data(
         entities.ActivationKey,
         entities.Architecture,
+        entities.ComputeProfile,
         entities.ContentView,
         entities.Domain,
         entities.Environment,
@@ -214,6 +219,7 @@ class EntityIdTestCase(TestCase):
     @data(
         entities.ActivationKey,
         entities.Architecture,
+        entities.ComputeProfile,
         entities.ContentView,
         entities.Domain,
         entities.Environment,
@@ -252,6 +258,7 @@ class EntityIdTestCase(TestCase):
     @data(
         entities.ActivationKey,
         entities.Architecture,
+        entities.ComputeProfile,
         entities.ContentView,
         entities.Domain,
         entities.Environment,
@@ -307,6 +314,7 @@ class DoubleCheckTestCase(TestCase):
     @data(
         entities.ActivationKey,
         entities.Architecture,
+        entities.ComputeProfile,
         entities.ContentView,
         entities.Domain,
         entities.Environment,
@@ -354,6 +362,7 @@ class DoubleCheckTestCase(TestCase):
     @data(
         entities.ActivationKey,
         entities.Architecture,
+        entities.ComputeProfile,
         entities.ContentView,
         entities.Domain,
         entities.Environment,
@@ -404,6 +413,7 @@ class DoubleCheckTestCase(TestCase):
     @data(
         entities.ActivationKey,
         entities.Architecture,
+        entities.ComputeProfile,
         entities.ContentView,
         entities.Domain,
         entities.Environment,
@@ -456,6 +466,7 @@ class EntityReadTestCase(TestCase):
     @data(
         # entities.ActivationKey,
         # entities.Architecture,
+        entities.ComputeProfile,
         # entities.ContentView,
         # entities.Domain,
         entities.Environment,


### PR DESCRIPTION
Update the `ComputeProfile` class definition: add mixins for creation, reading
and deletion. Thoroughly test the relevant API endpoint.
