### PR TITLE
After updating signo_sso param reverting it to its default value

### DIFF
--- a/tests/foreman/ui/test_settings.py
+++ b/tests/foreman/ui/test_settings.py
@@ -547,6 +547,12 @@ class Settings(UITestCase):
             saved_element = self.settings.get_saved_value(tab_locator,
                                                           param_name)
             self.assertEqual(test_data['param_value'], saved_element)
+            # This is to revert the signo_sso to default value 'false'
+            if saved_element == 'true':
+                edit_param(session, tab_locator=tab_locator,
+                           param_name=param_name,
+                           value_type=value_type,
+                           param_value='false')
 
     @data({u'param_value': "http://" + generate_string("alpha", 10) +
            ".dom.com"},


### PR DESCRIPTION
Sometime back we wrote boundary tests for parameters under settings menu. There is a param `signo_sso` whose default value is 'false' but if we set it to 'true' all api's calls start to fail as its not pointing to correct URL.  From last few days we are just switching servers, if hammer cli or api calls starts failing. 

So if my test sets the value to 'true' then this PR will revert it to 'false'(default value). Hope this solve the original issue. Thanks to @AdamSaleh  for catching it.
