### PR TITLE
Do not check content-type of HTTP 204 messages

### DIFF
--- a/tests/foreman/api/test_multiple_paths.py
+++ b/tests/foreman/api/test_multiple_paths.py
@@ -297,7 +297,12 @@ class EntityIdTestCase(TestCase):
             status_code,
             status_code_error(path, status_code, response),
         )
-        self.assertIn('application/json', response.headers['content-type'])
+
+        # According to RFC 2616, HTTP 204 responses "MUST NOT include a
+        # message-body". If a message does not have a body, there is no need to
+        # set the content-type of the message.
+        if status_code is not httplib.NO_CONTENT:
+            self.assertIn('application/json', response.headers['content-type'])
 
 
 @ddt

--- a/tests/foreman/api/test_system_v2.py
+++ b/tests/foreman/api/test_system_v2.py
@@ -94,7 +94,12 @@ class EntityIdTestCaseClone(TestCase):
             status_code,
             status_code_error(path, status_code, response),
         )
-        self.assertIn('application/json', response.headers['content-type'])
+
+        # According to RFC 2616, HTTP 204 responses "MUST NOT include a
+        # message-body". If a message does not have a body, there is no need to
+        # set the content-type of the message.
+        if status_code is not httplib.NO_CONTENT:
+            self.assertIn('application/json', response.headers['content-type'])
 
 
 class LongMessageTestCaseClone(TestCase):


### PR DESCRIPTION
Checking the content-type of an HTTP 204 message does not make sense, as HTTP
204 messages "MUST NOT include a message-body". Make the test suite reflect this
fact.
