### PR TITLE
Make `ContentView` readable, trim down smoke test

### DIFF
--- a/robottelo/entities.py
+++ b/robottelo/entities.py
@@ -312,16 +312,17 @@ class ContentViewPuppetModule(orm.Entity):
 
 
 class ContentView(
-        orm.Entity, factory.EntityFactoryMixin, orm.EntityDeleteMixin):
+        orm.Entity, orm.EntityReadMixin, orm.EntityDeleteMixin,
+        factory.EntityFactoryMixin):
     """A representation of a Content View entity."""
     organization = orm.OneToOneField('Organization', required=True)
     name = orm.StringField(required=True)
     label = orm.StringField()
     composite = orm.BooleanField()
     description = orm.StringField()
-    repositories = orm.OneToManyField('Repository')
+    repository = orm.OneToManyField('Repository')
     # List of component content view version ids for composite views
-    components = orm.OneToManyField('ContentView')
+    component = orm.OneToManyField('ContentView')
 
     class Meta(object):
         """Non-field information about this entity."""

--- a/tests/foreman/smoke/test_api_smoke.py
+++ b/tests/foreman/smoke/test_api_smoke.py
@@ -359,10 +359,7 @@ class TestSmoke(TestCase):
             u"Publishing {0} failed.".format(content_view['name']))
 
         # step 2.10: Promote content view to both lifecycles
-        content_view = client.get(
-            entities.ContentView(id=content_view['id']).path(),
-            auth=get_server_credentials(),
-            verify=False).json()
+        content_view = entities.ContentView(id=content_view['id']).read_json()
         self.assertEqual(
             len(content_view['versions']),
             1,
@@ -380,10 +377,7 @@ class TestSmoke(TestCase):
             u"Promoting {0} to {1} failed.".format(
                 content_view['name'], le1['name']))
         # Check that content view exists in 2 lifecycles
-        content_view = client.get(
-            entities.ContentView(id=content_view['id']).path(),
-            auth=get_server_credentials(),
-            verify=False).json()
+        content_view = entities.ContentView(id=content_view['id']).read_json()
         self.assertEqual(
             len(content_view['versions']),
             1,
@@ -401,10 +395,7 @@ class TestSmoke(TestCase):
             u"Promoting {0} to {1} failed.".format(
                 content_view['name'], le2['name']))
         # Check that content view exists in 2 lifecycles
-        content_view = client.get(
-            entities.ContentView(id=content_view['id']).path(),
-            auth=get_server_credentials(),
-            verify=False).json()
+        content_view = entities.ContentView(id=content_view['id']).read_json()
         self.assertEqual(
             len(content_view['versions']),
             1,
@@ -460,11 +451,7 @@ class TestSmoke(TestCase):
             data={u'search': query},
             verify=False,
         )
-        self.assertEqual(
-            response.status_code,
-            httplib.OK,
-            status_code_error(path, httplib.OK, response)
-        )
+        response.raise_for_status()
         self.assertEqual(
             response.json()['search'],
             query,


### PR DESCRIPTION
Make `ContentView` inherit from `EntityReadMixin`. use this mixin to trim down
module `tests.foreman.smoke.test_api_smoke`: replace many usages of `client.get`
with `ContentView.read_json`.
