### PR TITLE
Test ActivationKey/HostCollection associations

### DIFF
--- a/robottelo/entities.py
+++ b/robottelo/entities.py
@@ -36,6 +36,7 @@ class ActivationKey(
     content_view = orm.OneToOneField('ContentView')
     unlimited_content_hosts = orm.BooleanField()
     max_content_hosts = orm.IntegerField()
+    host_collection = orm.OneToManyField('HostCollection')
 
     class Meta(object):
         """Non-field information about this entity."""

--- a/tests/foreman/api/test_activationkey.py
+++ b/tests/foreman/api/test_activationkey.py
@@ -3,9 +3,8 @@
 
 from ddt import ddt
 from robottelo.api.apicrud import ApiCrud
-from robottelo.common.decorators import data, skip_if_bug_open
+from robottelo.common.decorators import data, skip_if_bug_open, stubbed
 from robottelo.records.activation_key import ActivationKey
-from robottelo.records.host_collection import HostCollectionDefOrg
 from robottelo.test import APITestCase
 
 
@@ -42,7 +41,7 @@ class ActivationKeys(APITestCase):
         ak_u = ApiCrud.record_update(ak_cr)
         self.assertEquals(ak_u.description, ak_cr.description)
 
-    @skip_if_bug_open('bugzilla', 1099533)
+    @stubbed
     @data(*ActivationKey.enumerate())
     def test_host_collections(self, test_data):
         """
@@ -50,11 +49,4 @@ class ActivationKeys(APITestCase):
         @feature: ActivationKey
         @assert: there was no system group and you have added one
         """
-        acc = ApiCrud.record_create(test_data)
-        self.assertEqual(len(acc.host_collections), 0)
-        sg = HostCollectionDefOrg()
-        sgc = ApiCrud.record_create(sg)
-        r = acc._meta.api_class.add_host_collection(acc, [sgc.id])
-        self.assertTrue(r.ok)
-        acr = ApiCrud.record_resolve(acc)
-        self.assertEqual(len(acr.host_collections), 1)
+        # See method test_set_host_collection in file test_activationkey_v2.py


### PR DESCRIPTION
Add a test that associates an activation key with zero, one, two and then zero
host collections. Remove a test which currently attempts to test the same thing
but is failing for some unknown reason.
