### PR TITLE
fixed UI test failures

### DIFF
--- a/robottelo/common/constants.py
+++ b/robottelo/common/constants.py
@@ -132,9 +132,9 @@ REPOSET = {'rhct6': "Red Hat CloudForms Tools for RHEL 6 (RPMs)",
 DEFAULT_ORG = "Default_Organization"
 DEFAULT_LOC = "Default_Location"
 
-LANGUAGES = ["de", "en", "en_GB",
-             "es", "fr", "gl",
-             "ja", "sv_SE", "zh_CN"]
+LANGUAGES = ["en", "en_GB",
+             "fr", "gl",
+             "ja", "sv_SE"]
 
 FILTER_CONTENT_TYPE = {
     'package': "Package",

--- a/robottelo/common/helpers.py
+++ b/robottelo/common/helpers.py
@@ -128,7 +128,7 @@ def valid_data_list():
     return [
         generate_string("alpha", 8),
         generate_string("numeric", 8),
-        generate_string("alphanumeric", 300),
+        generate_string("alphanumeric", 8),
         generate_string("utf8", 8),
         generate_string("latin1", 8),
         generate_string("html", 8)
@@ -140,7 +140,6 @@ def invalid_names_list():
     List of invalid names for input testing.
     """
     return [
-        u" ",
         generate_string("alpha", 300),
         generate_string("numeric", 300),
         generate_string("alphanumeric", 300),

--- a/robottelo/ui/configgroups.py
+++ b/robottelo/ui/configgroups.py
@@ -2,7 +2,7 @@
 Implements Config Groups UI
 """
 
-from robottelo.ui.base import Base
+from robottelo.ui.base import Base, UINoSuchElementError
 from robottelo.ui.locators import locators, common_locators
 from robottelo.ui.navigator import Navigator
 
@@ -19,8 +19,13 @@ class ConfigGroups(Base):
         self.wait_until_element(locators["config_groups.new"]).click()
         if self.wait_until_element(locators["config_groups.name"]):
             self.find_element(locators["config_groups.name"]).send_keys(name)
-        self.find_element(common_locators["submit"]).click()
-        self.wait_for_ajax()
+            timeout = 60 if len(name) > 50 else 30
+            self.wait_for_ajax(timeout)
+            self.find_element(common_locators["submit"]).click()
+            self.wait_for_ajax()
+        else:
+            raise UINoSuchElementError(
+                "Could not text box to add config_group name")
 
     def update(self, old_name, new_name=None):
         """

--- a/robottelo/ui/org.py
+++ b/robottelo/ui/org.py
@@ -140,6 +140,7 @@ class Org(Base):
         self.wait_for_ajax()
         if org_object:
             org_object.click()
+            self.wait_for_ajax()
             if new_name:
                 if self.wait_until_element(locators["org.name"]):
                     self.field_update("org.name", new_name)

--- a/robottelo/ui/puppetclasses.py
+++ b/robottelo/ui/puppetclasses.py
@@ -19,6 +19,8 @@ class PuppetClasses(Base):
         self.wait_until_element(locators["puppetclass.new"]).click()
         if self.wait_until_element(locators["puppetclass.name"]):
             self.find_element(locators["puppetclass.name"]).send_keys(name)
+            timeout = 60 if len(name) > 50 else 30
+            self.wait_for_ajax(timeout)
         if environment:
             self.find_element(
                 locators['puppetclass.environments']).send_keys(environment)

--- a/tests/foreman/ui/test_activationkey.py
+++ b/tests/foreman/ui/test_activationkey.py
@@ -17,7 +17,7 @@ from robottelo import entities, orm
 from robottelo.common.constants import ENVIRONMENT, NOT_IMPLEMENTED
 from robottelo.common.decorators import data, skip_if_bug_open
 from robottelo.common.helpers import (generate_string, invalid_names_list,
-                                      valid_names_list)
+                                      valid_data_list)
 from robottelo.ui.locators import locators, common_locators, tab_locators
 from robottelo.ui.session import Session
 from robottelo.test import UITestCase
@@ -82,7 +82,7 @@ class ActivationKey(UITestCase):
 
     @skip_if_bug_open('bugzilla', 1078676)
     @attr('ui', 'ak', 'implemented')
-    @data(*valid_names_list())
+    @data(*valid_data_list())
     def test_positive_create_activation_key_1(self, name):
         """
         @Feature: Activation key - Positive Create
@@ -102,7 +102,7 @@ class ActivationKey(UITestCase):
 
     @skip_if_bug_open('bugzilla', 1078676)
     @attr('ui', 'ak', 'implemented')
-    @data(*valid_names_list())
+    @data(*valid_data_list())
     def test_positive_create_activation_key_2(self, description):
         """
         @Feature: Activation key - Positive Create
@@ -123,7 +123,7 @@ class ActivationKey(UITestCase):
         self.assertIsNotNone(self.activationkey.search_key(name))
 
     @attr('ui', 'ak', 'implemented')
-    @data(*valid_names_list())
+    @data(*valid_data_list())
     def test_positive_create_activation_key_3(self, env):
         """
         @Feature: Activation key - Positive Create
@@ -152,7 +152,7 @@ class ActivationKey(UITestCase):
         self.assertIsNotNone(self.activationkey.search_key(name))
 
     @attr('ui', 'ak', 'implemented')
-    @data(*valid_names_list())
+    @data(*valid_data_list())
     def test_positive_create_activation_key_4(self, cv_name):
         """
         @Feature: Activation key - Positive Create
@@ -182,7 +182,7 @@ class ActivationKey(UITestCase):
 
     @skip_if_bug_open('bugzilla', 1078676)
     @attr('ui', 'ak', 'implemented')
-    @data(*valid_names_list())
+    @data(*valid_data_list())
     def test_positive_create_activation_key_5(self, hc_name):
         """
         @Test: Create Activation key for all variations of Host Collections
@@ -345,7 +345,7 @@ class ActivationKey(UITestCase):
         self.assertIsNone(self.activationkey.search_key(name))
 
     @attr('ui', 'ak', 'implemented')
-    @data(*valid_names_list())
+    @data(*valid_data_list())
     def test_positive_delete_activation_key_1(self, name):
         """
         @Feature: Activation key - Positive Delete
@@ -368,7 +368,7 @@ class ActivationKey(UITestCase):
         self.assertIsNone(self.activationkey.search_key(name))
 
     @attr('ui', 'ak', 'implemented')
-    @data(*valid_names_list())
+    @data(*valid_data_list())
     def test_positive_delete_activation_key_2(self, description):
         """
         @Feature: Activation key - Positive Delete
@@ -392,7 +392,7 @@ class ActivationKey(UITestCase):
         self.assertIsNone(self.activationkey.search_key(name))
 
     @attr('ui', 'ak', 'implemented')
-    @data(*valid_names_list())
+    @data(*valid_data_list())
     def test_positive_delete_activation_key_3(self, env):
         """
         @Feature: Activation key - Positive Delete
@@ -424,7 +424,7 @@ class ActivationKey(UITestCase):
         self.assertIsNone(self.activationkey.search_key(name))
 
     @attr('ui', 'ak', 'implemented')
-    @data(*valid_names_list())
+    @data(*valid_data_list())
     def test_positive_delete_activation_key_4(self, cv_name):
         """
         @Feature: Activation key - Positive Delete
@@ -528,7 +528,7 @@ class ActivationKey(UITestCase):
 
     @skip_if_bug_open('bugzilla', 1078676)
     @attr('ui', 'ak', 'implemented')
-    @data(*valid_names_list())
+    @data(*valid_data_list())
     def test_positive_update_activation_key_1(self, new_name):
         """
         @Feature: Activation key - Positive Update
@@ -551,7 +551,7 @@ class ActivationKey(UITestCase):
 
     @skip_if_bug_open('bugzilla', 1078676)
     @attr('ui', 'ak', 'implemented')
-    @data(*valid_names_list())
+    @data(*valid_data_list())
     def test_positive_update_activation_key_2(self, new_description):
         """
         @Feature: Activation key - Positive Update
@@ -576,7 +576,7 @@ class ActivationKey(UITestCase):
 
     @skip_if_bug_open('bugzilla', 1089637)
     @attr('ui', 'ak', 'implemented')
-    @data(*valid_names_list())
+    @data(*valid_data_list())
     def test_positive_update_activation_key_3(self, env_name):
         """
         @Feature: Activation key - Positive Update
@@ -612,7 +612,7 @@ class ActivationKey(UITestCase):
         self.assertEqual(env_name, selected_env)
 
     @attr('ui', 'ak', 'implemented')
-    @data(*valid_names_list())
+    @data(*valid_data_list())
     def test_positive_update_activation_key_4(self, cv2_name):
         """
         @Feature: Activation key - Positive Update

--- a/tests/foreman/ui/test_architecture.py
+++ b/tests/foreman/ui/test_architecture.py
@@ -158,6 +158,7 @@ class Architecture(UITestCase):
             self.architecture.delete(test_data['name'], True)
             self.assertIsNone(self.architecture.search(test_data['name']))
 
+    @skip_if_bug_open('bugzilla', 1123388)
     @data({u'old_name': generate_string('alpha', 10),
            u'new_name': generate_string('alpha', 10),
            u'os_name': generate_string('alpha', 10),

--- a/tests/foreman/ui/test_gpgkey.py
+++ b/tests/foreman/ui/test_gpgkey.py
@@ -162,8 +162,26 @@ class GPGKey(UITestCase):
             self.assertIsNone(self.gpgkey.search(name))
 
     @attr('ui', 'gpgkey', 'implemented')
+    def test_negative_create_5(self):
+        """
+        @feature: GPG Keys
+        @test: Create gpg key with blank name and valid gpg key via
+        file import
+        @assert: gpg key is not created
+        """
+        name = " "
+        key_path = get_data_file(VALID_GPG_KEY_FILE)
+        with Session(self.browser) as session:
+            make_gpgkey(session, org=GPGKey.org_name,
+                        name=name, upload_key=True,
+                        key_path=key_path)
+            self.assertTrue(self.gpgkey.wait_until_element
+                            (common_locators["haserror"]))
+            self.assertIsNone(self.gpgkey.search(name))
+
+    @attr('ui', 'gpgkey', 'implemented')
     @data(*invalid_names_list())
-    def test_negative_create_5(self, name):
+    def test_negative_create_6(self, name):
         """
         @feature: GPG Keys
         @test: Create gpg key with invalid name and valid gpg key text via

--- a/tests/foreman/ui/test_location.py
+++ b/tests/foreman/ui/test_location.py
@@ -253,7 +253,8 @@ class Location(UITestCase):
         with Session(self.browser) as session:
             make_loc(session, name=loc_name)
             self.assertIsNotNone(self.location.search(loc_name))
-            make_user(session, username=user, email=email,
+            make_user(session, username=user, first_name=user,
+                      last_name=user, email=email,
                       password1=password, password2=password)
             self.assertIsNotNone(self.user.search(user, search_key))
             self.location.update(loc_name, new_users=[user])
@@ -569,7 +570,8 @@ class Location(UITestCase):
         email = generate_email_address()
         search_key = "login"
         with Session(self.browser) as session:
-            make_user(session, username=user_name, email=email,
+            make_user(session, username=user_name, first_name=user_name,
+                      last_name=user_name, email=email,
                       password1=password, password2=password)
             self.assertIsNotNone(self.user.search(user_name, search_key))
             make_loc(session, name=loc_name, users=[user_name], edit=True)

--- a/tests/foreman/ui/test_org.py
+++ b/tests/foreman/ui/test_org.py
@@ -375,7 +375,7 @@ class Org(UITestCase):
           {'name': generate_string('alphanumeric', 8)},
           {'name': generate_string('utf8', 8)},
           {'name': generate_string('latin1', 8)})
-    def test_remove_user_3(self, testdata):
+    def test_remove_user_1(self, testdata):
         """
         @test: Create admin users then add user and remove it
         by using the organization name.
@@ -390,7 +390,8 @@ class Org(UITestCase):
         email = generate_email_address()
         search_key = "login"
         with Session(self.browser) as session:
-            make_user(session, username=user_name, email=email,
+            make_user(session, username=user_name, first_name=user_name,
+                      last_name=user_name, email=email,
                       password1=password, password2=password)
             self.assertIsNotNone(self.user.search(user_name, search_key))
             make_org(session, org_name=org_name, users=[user_name], edit=True)
@@ -513,19 +514,19 @@ class Org(UITestCase):
             self.assertIsNotNone(element)
 
     @attr('ui', 'org', 'implemented')
-    @data({'name': generate_string('alpha', 8)},
-          {'name': generate_string('numeric', 8)},
-          {'name': generate_string('alphanumeric', 8)},
-          {'name': generate_string('utf8', 8)},
-          {'name': generate_string('latin1', 8)})
-    def test_add_user_2(self, testdata):
+    @data(generate_string('alpha', 8),
+          generate_string('numeric', 8),
+          generate_string('alphanumeric', 8),
+          generate_string('utf8', 8),
+          generate_string('latin1', 8))
+    def test_add_user_2(self, name):
         """
         @test: Create different types of users then add user
         by using the organization name.
         @feature: Organizations associate user.
         @assert: User is added to organization.
         """
-        user = testdata['name']
+
         strategy, value = common_locators["entity_deselect"]
         org_name = generate_string("alpha", 8)
         password = generate_string("alpha", 8)
@@ -534,15 +535,17 @@ class Org(UITestCase):
         with Session(self.browser) as session:
             make_org(session, org_name=org_name)
             self.assertIsNotNone(self.org.search(org_name))
-            make_user(session, username=user, email=email,
+            make_user(session, username=name, first_name=name,
+                      last_name=name, email=email,
                       password1=password, password2=password)
-            self.assertIsNotNone(self.user.search(user, search_key))
-            self.org.update(org_name, new_users=[user])
+            self.assertIsNotNone(self.user.search(name, search_key))
+            self.org.wait_for_ajax()
+            self.org.update(org_name, new_users=[name])
             self.org.search(org_name).click()
             session.nav.wait_until_element(
                 tab_locators["context.tab_users"]).click()
             element = session.nav.wait_until_element((strategy,
-                                                      value % user))
+                                                      value % name))
             self.assertIsNotNone(element)
 
     @attr('ui', 'org', 'implemented')

--- a/tests/foreman/ui/test_settings.py
+++ b/tests/foreman/ui/test_settings.py
@@ -154,7 +154,7 @@ class Settings(UITestCase):
                        value_type=value_type, param_value=param_value)
             saved_element = self.settings.get_saved_value(tab_locator,
                                                           param_name)
-            self.assertEqual(param_value, saved_element)
+            self.assertEqual(param_value.lstrip("0"), saved_element)
 
     @skip_if_bug_open('bugzilla', 1125181)
     @data({u'param_value': generate_string("latin1", 10) +
@@ -279,7 +279,10 @@ class Settings(UITestCase):
                        param_value=test_data['param_value'])
             saved_element = self.settings.get_saved_value(tab_locator,
                                                           param_name)
-            self.assertEqual(test_data['param_value'], saved_element)
+            self.assertEqual(
+                test_data['param_value'].lstrip("0"),
+                saved_element
+            )
 
     @skip_if_bug_open('bugzilla', 1125156)
     @data({u'param_value': " "},
@@ -329,7 +332,10 @@ class Settings(UITestCase):
                        param_value=test_data['param_value'])
             saved_element = self.settings.get_saved_value(tab_locator,
                                                           param_name)
-            self.assertEqual(test_data['param_value'], saved_element)
+            self.assertEqual(
+                test_data['param_value'].lstrip("0"),
+                saved_element
+            )
 
     @data({u'param_value': "http://" + generate_string("alpha", 10) +
            ".dom.com"},
@@ -818,4 +824,7 @@ class Settings(UITestCase):
                        param_value=test_data['param_value'])
             saved_element = self.settings.get_saved_value(tab_locator,
                                                           param_name)
-            self.assertEqual(test_data['param_value'], saved_element)
+            self.assertEqual(
+                test_data['param_value'].lstrip("0"),
+                saved_element
+            )

--- a/tests/foreman/ui/test_template.py
+++ b/tests/foreman/ui/test_template.py
@@ -205,12 +205,14 @@ class Template(UITestCase):
             self.assertIsNotNone(self.template.search(name))
 
     @skip_if_bug_open('bugzilla', 1129612)
+    @skip_if_bug_open('bugzilla', 1138543)
     def test_remove_template(self):
         """
         @Test: Remove a template
         @Feature: Template - Positive Delete
         @Assert: Template removed successfully
         @BZ: 1129612
+        @BZ: 1138543
         """
 
         name = generate_string("alpha", 6)


### PR DESCRIPTION
This PR contains fixes based on rhel7 and 6.5 runs:
- Updated languages data as user tests were failing for `de`, `es` and `zh_CN` locales..So updated 'LANGUAGE' constant
- Filed a bz 1138543 as sat6 server installed on rhel7 doesn't raises success notification on deleting a template and blocked the test with  bz id
- When you update parameter with numeric value say 001400 then UI auto truncate leading zeros on save..so tests were failing while asserting the saved string. fixed with `lstring("0")`
- Updated data in invalid_names_list, reason: this includes `u" "` as data. So when test is executed to create entity with blank name, UI doesn't raise any error, just highlights the text box with red Border. And locator for this Red Border is different than other error notifications.
- Added a separate test to cover blank name too
- Blocked test test_update_arch with bz id.
- Fixed org and location user tests: `test_add_user_1` and `test_remove_user_1`
- Fixed some timing issues related to `puppetclasses` and `config_group` tests.
