### PR TITLE
Add and refactor API tests for products

### DIFF
--- a/robottelo/entities.py
+++ b/robottelo/entities.py
@@ -1128,7 +1128,9 @@ class Ping(orm.Entity):
         api_path = 'katello/api/v2/ping'
 
 
-class Product(orm.Entity, factory.EntityFactoryMixin, orm.EntityDeleteMixin):
+class Product(
+        orm.Entity, orm.EntityReadMixin, orm.EntityDeleteMixin,
+        factory.EntityFactoryMixin):
     """A representation of a Product entity."""
     organization = orm.OneToOneField('Organization', required=True)
     description = orm.StringField()

--- a/tests/foreman/api/test_multiple_paths.py
+++ b/tests/foreman/api/test_multiple_paths.py
@@ -13,12 +13,12 @@ import httplib
 BZ_1118015_ENTITIES = (
     entities.ActivationKey, entities.Architecture, entities.ContentView,
     entities.Environment, entities.GPGKey, entities.HostCollection,
-    entities.LifecycleEnvironment, entities.OperatingSystem,
+    entities.LifecycleEnvironment, entities.OperatingSystem, entities.Product,
     entities.Repository, entities.Role, entities.System, entities.User,
 )
 BZ_1122267_ENTITIES = (
     entities.ActivationKey, entities.ContentView, entities.GPGKey,
-    entities.LifecycleEnvironment, entities.Repository
+    entities.LifecycleEnvironment, entities.Product, entities.Repository
 )
 
 
@@ -39,6 +39,7 @@ class EntityTestCase(TestCase):
         entities.Model,
         entities.OperatingSystem,
         entities.Organization,
+        # entities.Product,  # need organization_id
         # entities.Repository,  # need organization_id
         entities.Role,
         # entities.System,  # need organization_id
@@ -78,6 +79,7 @@ class EntityTestCase(TestCase):
         entities.Model,
         entities.OperatingSystem,
         entities.Organization,
+        entities.Product,
         entities.Repository,
         entities.Role,
         entities.System,
@@ -112,6 +114,7 @@ class EntityTestCase(TestCase):
         entities.Model,
         entities.OperatingSystem,
         entities.Organization,
+        entities.Product,
         entities.Repository,
         entities.Role,
         entities.System,
@@ -154,6 +157,7 @@ class EntityTestCase(TestCase):
         entities.Model,
         entities.OperatingSystem,
         entities.Organization,
+        entities.Product,
         entities.Repository,
         entities.Role,
         entities.System,
@@ -193,6 +197,7 @@ class EntityIdTestCase(TestCase):
         entities.Model,
         entities.OperatingSystem,
         entities.Organization,
+        entities.Product,
         entities.Repository,
         entities.Role,
         # entities.System,  # See test_activationkey_v2.py
@@ -235,6 +240,7 @@ class EntityIdTestCase(TestCase):
         entities.Model,
         entities.OperatingSystem,
         entities.Organization,
+        entities.Product,
         entities.Repository,
         entities.Role,
         # entities.System,  # See test_activationkey_v2.py
@@ -275,6 +281,7 @@ class EntityIdTestCase(TestCase):
         entities.Model,
         entities.OperatingSystem,
         entities.Organization,
+        entities.Product,
         entities.Repository,
         entities.Role,
         # entities.System,  # See test_activationkey_v2.py
@@ -337,6 +344,7 @@ class DoubleCheckTestCase(TestCase):
         entities.Model,
         entities.OperatingSystem,
         entities.Organization,
+        entities.Product,
         entities.Repository,
         entities.Role,
         # entities.System,  # See test_activationkey_v2.py
@@ -386,6 +394,7 @@ class DoubleCheckTestCase(TestCase):
         entities.Model,
         entities.OperatingSystem,
         entities.Organization,
+        entities.Product,
         entities.Repository,
         entities.Role,
         # entities.System,  # See test_activationkey_v2.py
@@ -438,6 +447,7 @@ class DoubleCheckTestCase(TestCase):
         entities.Model,
         entities.OperatingSystem,
         entities.Organization,
+        entities.Product,
         entities.Repository,
         entities.Role,
         # entities.System,  # See test_activationkey_v2.py
@@ -493,6 +503,7 @@ class EntityReadTestCase(TestCase):
         entities.OperatingSystem,
         # entities.OperatingSystemParameter,  # see test_osparameter_read
         entities.Organization,
+        # entities.Product,
         entities.Repository,
         entities.Role,
         # entities.System,

--- a/tests/foreman/api/test_product_v2.py
+++ b/tests/foreman/api/test_product_v2.py
@@ -5,13 +5,11 @@ can be found here: http://theforeman.org/api/apidoc/v2/products.html
 
 """
 from robottelo.api import client
-from robottelo.api.utils import status_code_error
 from robottelo.common.constants import VALID_GPG_KEY_FILE
 from robottelo.common.helpers import get_server_credentials, read_data_file
 from robottelo import entities, orm
 from unittest import TestCase
 import ddt
-import httplib
 
 
 @ddt.ddt
@@ -31,22 +29,9 @@ class ProductsTestCase(TestCase):
         @Assert: Product is created with specified name
 
         """
-        # Create an organization and product
-        org_attrs = entities.Organization().create()
-        product_attrs = entities.Product(
-            name=name,
-            organization=org_attrs['id']
-        ).create()
-
-        path = entities.Product(id=product_attrs['id']).path()
-
-        # GET the product and verify it's name.
-        response = client.get(
-            path,
-            auth=get_server_credentials(),
-            verify=False,
-        ).json()
-        self.assertEqual(response['name'], name)
+        prod_id = entities.Product(name=name).create()['id']
+        prod_attrs = entities.Product(id=prod_id).read_json()
+        self.assertEqual(prod_attrs['name'], name)
 
     @ddt.data(
         orm.StringField(str_type=('alphanumeric',)).get_value(),
@@ -63,124 +48,51 @@ class ProductsTestCase(TestCase):
         """
         key_content = read_data_file(VALID_GPG_KEY_FILE)
         key_name = orm.StringField(str_type=('alphanumeric',)).get_value()
-        # Create an organization gpg_key
+
+        # Create an organization, GPG key and product.
+        #
+        # * GPG key points to organization
+        # * Product points to organization and GPG key
+        #
         org_attrs = entities.Organization().create()
         gpgkey_attrs = entities.GPGKey(
             name=key_name,
             content=key_content,
             organization=org_attrs['id']
         ).create()
-
-        # Creates new product and associate GPGKey with it
         product_attrs = entities.Product(
             name=name,
             gpg_key=gpgkey_attrs['id'],
             organization=org_attrs['id']
         ).create()
 
-        path = entities.Product(id=product_attrs['id']).path()
-
         # GET the product and verify it's name and gpg_key id.
-        response = client.get(
-            path,
-            auth=get_server_credentials(),
-            verify=False,
-        ).json()
+        response = entities.Product(id=product_attrs['id']).read_json()
         self.assertEqual(response['name'], name)
         self.assertEqual(response['gpg_key_id'], gpgkey_attrs['id'])
 
     @ddt.data(
-        orm.StringField(str_type=('alphanumeric',)).get_value(),
         orm.StringField(str_type=('alpha',)).get_value(),
+        orm.StringField(str_type=('alphanumeric',)).get_value(),
         orm.StringField(str_type=('numeric',)).get_value(),
     )
-    def test_positive_delete_1(self, name):
-        """@Test: Create a Product and delete it
-
-        @Feature: Products
-
-        @Assert: Product is deleted and HTTP 404 is returned
-
-        """
-        # Create an organization and product
-        org_attrs = entities.Organization().create()
-        product_attrs = entities.Product(
-            name=name,
-            organization=org_attrs['id']
-        ).create()
-
-        path = entities.Product(id=product_attrs['id']).path()
-
-        # GET the product and verify it's name.
-        response = client.get(
-            path,
-            auth=get_server_credentials(),
-            verify=False,
-        ).json()
-        self.assertEqual(response['name'], name)
-
-        # Delete the product, GET it, and assert that an HTTP 404 is returned.
-        entities.Product(id=product_attrs['id']).delete()
-        response = client.get(
-            path,
-            auth=get_server_credentials(),
-            verify=False,
-        )
-        status_code = httplib.NOT_FOUND
-        self.assertEqual(
-            status_code,
-            response.status_code,
-            status_code_error(path, status_code, response),
-        )
-
-    @ddt.data(
-        {u'name': orm.StringField(str_type=('alphanumeric',)).get_value(),
-         u'new_name': orm.StringField(str_type=('alphanumeric',)).get_value()},
-        {u'name': orm.StringField(str_type=('numeric',)).get_value(),
-         u'new_name': orm.StringField(str_type=('numeric',)).get_value()},
-        {u'name': orm.StringField(str_type=('alpha',)).get_value(),
-         u'new_name': orm.StringField(str_type=('alpha',)).get_value()}
-    )
-    def test_positive_update_1(self, test_data):
+    def test_positive_update_1(self, name):
         """@Test: Create a product and update its name
 
         @Feature: Products
 
-        @Assert: Product name should be updated
+        @Assert: Product name has been updated
 
         """
-        # Create an organization and product
-        org_attrs = entities.Organization().create()
-        product_attrs = entities.Product(
-            name=test_data['name'],
-            organization=org_attrs['id']
-        ).create()
-
-        path = entities.Product(id=product_attrs['id']).path()
-
-        product_copy = product_attrs.copy()
-        product_copy['name'] = test_data['new_name']
-
-        response = client.put(
-            path,
-            product_copy,
+        # Create a product and update its name.
+        prod_id = entities.Product().create()['id']
+        client.put(
+            entities.Product(id=prod_id).path(),
+            {u'name': name},
             auth=get_server_credentials(),
             verify=False,
-        )
-        status_code = httplib.OK
-        self.assertEqual(
-            response.status_code,
-            status_code,
-            status_code_error(path, status_code, response),
-        )
-        # Fetch the updated product
-        updated_attrs = client.get(
-            path,
-            auth=get_server_credentials(),
-            verify=False,
-        ).json()
-        # Assert that name is updated
-        self.assertNotEqual(
-            updated_attrs['name'],
-            product_attrs['name'],
-        )
+        ).raise_for_status()
+
+        # Fetch the updated product and assert that name has been updated.
+        prod_attrs = entities.Product(id=prod_id).read_json()
+        self.assertEqual(prod_attrs['name'], name)


### PR DESCRIPTION
Make `Product` inherit from `EntityReadMixin`. use this mixin to trim down
module `tests.foreman.api.test_product_v2`.

Test the ability to CRUD products by adding `Product` to module
`test_multiple_paths.py`. Remove a deletion-related test from module
`test_product_v2` because `test_multiple_paths` covers the same ground.
