### PR TITLE
Refactor and better test Repository.path

### DIFF
--- a/robottelo/entities.py
+++ b/robottelo/entities.py
@@ -1218,17 +1218,18 @@ class Repository(
 
         If a user specifies a ``which`` of ``'sync'``, return a path in the
         format ``/repositories/<id>/sync``.
-        
+
         If a user specifies a ``which`` of ``'upload_content'``, return a path
         in the format ``/repositories/<id>/upload_content``.
-        
+
         Otherwise, call ``super``.
 
         """
-        if which == 'sync':
-            return super(Repository, self).path(which='this') + '/sync'
-        if which == 'upload_content':
-            return super(Repository, self).path(which='this') + '/upload_content'
+        if which in ('sync', 'upload_content'):
+            return '{0}/{1}'.format(
+                super(Repository, self).path(which='this'),
+                which
+            )
         return super(Repository, self).path()
 
     def read(self, auth=None, entity=None, attrs=None):

--- a/tests/robottelo/test_entities.py
+++ b/tests/robottelo/test_entities.py
@@ -61,6 +61,7 @@ class PathTestCase(TestCase):
         (entities.Organization, '/organizations',
          'subscriptions/refresh_manifest'),
         (entities.Repository, '/repositories', 'sync'),
+        (entities.Repository, '/repositories', 'upload_content'),
     )
     @unpack
     def test_path_with_which(self, entity, path, which):
@@ -96,6 +97,7 @@ class PathTestCase(TestCase):
         (entities.Organization, 'subscriptions/delete_manifest'),
         (entities.Organization, 'subscriptions/refresh_manifest'),
         (entities.Repository, 'sync'),
+        (entities.Repository, 'upload_content'),
         (entities.ForemanTask, 'this'),
         (entities.System, 'this'),
     )


### PR DESCRIPTION
Refactor method `Repository.path` by trimming down the amount of underlying
code. Better test the method: only one of the two paths was being tested.
