### PR TITLE
Fix typo in CLI proxy module

### DIFF
--- a/robottelo/cli/proxy.py
+++ b/robottelo/cli/proxy.py
@@ -27,7 +27,7 @@ import contextlib
 import logging
 
 
-def SSHTunnelError(Exception):
+class SSHTunnelError(Exception):
     """Raised when ssh tunnel creation fails."""
 
 
@@ -42,44 +42,36 @@ def default_url_on_new_port(oldport, newport):
     :rtype: str
 
     """
-    logger = logging.getLogger("robottelo")
+    logger = logging.getLogger('robottelo')
     domain = conf.properties['main.server.hostname']
     user = conf.properties['main.server.ssh.username']
     key = conf.properties['main.server.ssh.key_private']
-    ssh.upload_file(key, "/tmp/dsa_%s" % newport)
-    ssh.command("chmod 700 /tmp/dsa_%s" % newport)
+    ssh.upload_file(key, '/tmp/dsa_{0}'.format(newport))
+    ssh.command('chmod 700 /tmp/dsa_{0}'.format(newport))
 
     with ssh._get_connection() as connection:
-        command = u"ssh -i {0} -L {1}:{2}:{3} {4}@{5}".format(
-            "/tmp/dsa_{0}".format(newport),
+        command = u'ssh -i {0} -L {1}:{2}:{3} {4}@{5}'.format(
+            '/tmp/dsa_{0}'.format(newport),
             newport, domain, oldport, user, domain)
-        logger.debug("Creating tunell %s", command)
+        logger.debug('Creating tunnel %s', command)
         # Run command and timeout in 30 seconds.
         _, _, stderr = connection.exec_command(command, 30)
 
         stderr = stderr.read()
         if len(stderr) > 0:
-            logger.debug("Tunell failed: %s", stderr)
+            logger.debug('Tunnel failed: %s', stderr)
             # Something failed, so raise an exception.
             raise SSHTunnelError(stderr)
-        yield "https://{0}:{1}".format(domain, newport)
+        yield 'https://{0}:{1}'.format(domain, newport)
 
 
 class Proxy(Base):
-    """
-    Manipulates Foreman's smart proxies.
-    """
+    """Manipulates Foreman's smart proxies. """
 
-    command_base = "proxy"
+    command_base = 'proxy'
 
     @classmethod
     def importclasses(cls, options=None):
-        """
-        Import puppet classes from puppet proxy.
-        """
-
-        cls.command_sub = "import-classes"
-
-        result = cls.execute(cls._construct_command(options))
-
-        return result
+        """Import puppet classes from puppet proxy."""
+        cls.command_sub = 'import-classes'
+        return cls.execute(cls._construct_command(options))


### PR DESCRIPTION
An exception was defined using def instead of class statement, fixing
this.

Also do some formatting adjustments like using single quote for string
in the entire module and some spell fixes.
