### PR TITLE
Make autogenerated role names 2–30 chars long

### DIFF
--- a/robottelo/entities.py
+++ b/robottelo/entities.py
@@ -1286,7 +1286,11 @@ class Role(
         orm.EntityReadMixin):
     """A representation of a Role entity."""
     # FIXME: UTF-8 characters should be acceptable for `name`. See BZ 1129785
-    name = orm.StringField(required=True, str_type=('alphanumeric',))
+    name = orm.StringField(
+        required=True,
+        str_type=('alphanumeric',),
+        len=(2, 30),  # min length is 2 and max length is arbitrary
+    )
 
     class Meta(object):
         """Non-field information about this entity."""


### PR DESCRIPTION
By default, `StringField` generates strings 1–30 chars long. However, role names
must be at least two characters long. Increase the minimum length of
auto-generated role names.
