### PR TITLE
Skip test which checks HTTP status code

### DIFF
--- a/tests/foreman/api/test_multiple_paths.py
+++ b/tests/foreman/api/test_multiple_paths.py
@@ -14,8 +14,8 @@ BZ_1118015_ENTITIES = (
     entities.ActivationKey, entities.Architecture, entities.ConfigTemplate,
     entities.ContentView, entities.Environment, entities.GPGKey,
     entities.HostCollection, entities.LifecycleEnvironment,
-    entities.OperatingSystem, entities.Repository, entities.Role,
-    entities.System, entities.User,
+    entities.OperatingSystem, entities.Product, entities.Repository,
+    entities.Role, entities.System, entities.User,
 )
 BZ_1122267_ENTITIES = (
     entities.ActivationKey, entities.ContentView, entities.GPGKey,


### PR DESCRIPTION
After creating a product, an HTTP 200 status code is received. This is OK, but
an HTTP 201 status code is preferable. List `Product` as one of the entities
that is affected by bugzilla bug 1118015, thus skipping the relevant test.
