### PR TITLE
Add clients provisioning feature

### DIFF
--- a/docs/api/robottelo.rst
+++ b/docs/api/robottelo.rst
@@ -49,3 +49,10 @@ Submodules:
 .. automodule:: robottelo.test
     :members:
     :undoc-members:
+
+:mod:`robottelo.vm`
+---------------------
+
+.. automodule:: robottelo.vm
+    :members:
+    :undoc-members:

--- a/docs/api/tests.robottelo.rst
+++ b/docs/api/tests.robottelo.rst
@@ -73,3 +73,10 @@ Submodules:
 .. automodule:: tests.robottelo.test_robottelo_api_inspect
     :members:
     :undoc-members:
+
+:mod:`tests.robottelo.test_vm`
+-----------------------------------
+
+.. automodule:: tests.robottelo.test_vm
+    :members:
+    :undoc-members:

--- a/robottelo.properties.sample
+++ b/robottelo.properties.sample
@@ -29,6 +29,15 @@ virtual_display=0
 # command will be run before opening any browser window
 window_manager_command=
 
+[clients]
+# Provisioning server hostname where the clients will be created
+provisioning_server=
+# Path on the provisioning server where the virtual images will be stored. If
+# not specified in the configuration, the default libvirt path will be used
+# "/var/lib/libvirt/images/". Make sure that the path exists on the
+# provisioning server.
+image_dir=/opt/robottelo/images
+
 [foreman]
 admin.username=admin
 admin.password=changeme

--- a/robottelo/vm.py
+++ b/robottelo/vm.py
@@ -1,0 +1,179 @@
+"""Utilities to create clients
+
+Clients are virtual machines provisioned on a ``provisioning_server``. All
+virtual machine images are stored on the ``image_dir`` path on the provisioning
+server.
+
+Make sure to configure the ``clients`` section on the configuration file. Also
+make sure that the server have in place: the base images for rhel65 and rhel7,
+snap-guest and its dependencies and the ``image_dir`` path created.
+
+"""
+import logging
+import os
+import time
+
+from robottelo.common import conf, ssh
+
+
+BASE_IMAGES = ('rhel7', 'rhel65')
+
+logger = logging.getLogger(__name__)
+
+
+class VirtualMachineError(Exception):
+    """Exception raised for failed virtual machine management operations"""
+
+
+class VirtualMachine(object):
+    """Manages a virtual machine to allow client provisioning for robottelo
+
+    It expects that base images listed on ``BASE_IMAGES`` are created and
+    snap-guest is setup on the provisioning server.
+
+    This also can be used as a context manager::
+
+        with VirtualMachine() as vm:
+            result = vm.run('ls')
+            out = result.stdout
+
+    Make sure to call :meth:`destroy` to stop and clean the image on the
+    provisioning server, otherwise the virtual machine and its image will stay
+    on the server consuming hardware resources.
+
+    It is possible to customize the ``provisioning_server`` and ``image_dir``
+    as per virtual machine basis. Just set the wanted values when
+    instantiating.
+
+    """
+
+    def __init__(
+            self, cpu=1, ram=512, distro=None, provisioning_server=None,
+            image_dir=None):
+        self.cpu = cpu
+        self.ram = ram
+        if distro is None or distro not in BASE_IMAGES:
+            self.distro = BASE_IMAGES[0]
+        else:
+            self.distro = distro
+        if provisioning_server is None:
+            self.provisioning_server = conf.properties.get(
+                'clients.provisioning_server')
+        else:
+            self.provisioning_server = provisioning_server
+        if image_dir is None:
+            self.image_dir = conf.properties.get(
+                'clients.image_dir', '/var/lib/libvirt/images/')
+        else:
+            self.image_dir = image_dir
+
+        self.target_image = str(id(self))
+        self.ip_addr = None
+        self.hostname = None
+        self._created = False
+
+    def create(self):
+        """Creates a virtual machine on the provisioning server using
+        snap-guest
+
+        :raises robottelo.vm.VirtualMachineError: Whenever a virtual machine
+            could not be executed.
+
+        """
+        if self._created:
+            return
+
+        if self.provisioning_server is None:
+            raise VirtualMachineError('Provisioning server is not configured')
+
+        command_args = [
+            'snap-guest',
+            '-b {source_image}',
+            '-t {target_image}',
+            '-m {vm_ram}',
+            '-c {vm_cpu}',
+            '-n bridge=br0 -f',
+        ]
+
+        if self.image_dir is not None:
+            command_args.append('-p {image_dir}')
+
+        command = ' '.join(command_args).format(
+            source_image='{0}-base'.format(self.distro),
+            target_image=self.target_image,
+            vm_ram=self.ram,
+            vm_cpu=self.cpu,
+            image_dir=self.image_dir,
+        )
+
+        result = ssh.command(command, self.provisioning_server)
+
+        if result.return_code != 0:
+            raise VirtualMachineError(
+                'Failed to run snap-guest: {0}'.format(result.stderr))
+
+        # Give some time to machine boot
+        time.sleep(60)
+
+        result = ssh.command(
+            'ping -c 1 {}.local'.format(self.target_image),
+            self.provisioning_server
+        )
+        if result.return_code != 0:
+            raise VirtualMachineError(
+                'Failed to fetch virtual machine IP address information')
+        output = ''.join(result.stdout)
+        self.ip_addr = output.split('(')[1].split(')')[0]
+        self._created = True
+
+    def destroy(self):
+        """Destroys the virtual machine on the provisioning server"""
+        if not self._created:
+            return
+
+        result = ssh.command(
+            'virsh destroy {0}'.format(self.target_image),
+            hostname=self.provisioning_server
+        )
+        if result.return_code > 0:
+            logger.warning(result.stderr)
+        result = ssh.command(
+            'virsh undefine {0}'.format(self.target_image),
+            hostname=self.provisioning_server
+        )
+        if result.return_code > 0:
+            logger.warning(result.stderr)
+
+        image_name = '{0}.img'.format(self.target_image)
+        result = ssh.command(
+            'rm {0}'.format(os.path.join(self.image_dir, image_name)),
+            hostname=self.provisioning_server
+        )
+        if result.return_code > 0:
+            logger.warning(result.stderr)
+
+    def run(self, cmd):
+        """Runs a ssh command on the virtual machine
+
+        :param str cmd: Command to run on the virtual machine
+        :return: A :class:`robottelo.common.ssh.SSHCommandResult` instance with
+            the commands results
+        :rtype: robottelo.common.ssh.SSHCommandResult
+        :raises robottelo.vm.VirtualMachineError: If the virtual machine is not
+            created.
+
+        """
+        if not self._created:
+            raise VirtualMachineError(
+                'The virtual machine should be created before running any ssh '
+                'command'
+            )
+
+        return ssh.command(cmd, hostname=self.ip_addr)
+
+    def __enter__(self):
+        self.create()
+        return self
+
+    def __exit__(self, *exc):
+        self.destroy()

--- a/tests/robottelo/test_vm.py
+++ b/tests/robottelo/test_vm.py
@@ -1,0 +1,89 @@
+"""Tests for :mod:`robottelo.vm`."""
+import unittest
+
+from mock import call, patch
+from robottelo.common import ssh
+from robottelo.vm import VirtualMachine, VirtualMachineError
+
+
+class VirtualMachineTestCase(unittest.TestCase):
+    """Tests for :class:`robottelo.vm.VirtualMachine`."""
+
+    @patch('time.sleep')
+    @patch('robottelo.common.ssh.command', side_effect=[
+        ssh.SSHCommandResult(),
+        ssh.SSHCommandResult(stdout=['(192.168.0.1)'])
+    ])
+    def test_dont_create_if_already_created(
+            self, ssh_command, sleep):
+        """Check if the creation steps does run more than one"""
+        vm = VirtualMachine()
+
+        with patch.multiple(
+            vm,
+            image_dir='/opt/robottelo/images',
+            provisioning_server='provisioning.example.com'
+        ):
+            vm.create()
+            vm.create()
+
+        self.assertEqual(vm.ip_addr, '192.168.0.1')
+        self.assertEqual(ssh_command.call_count, 2)
+        self.assertEqual(sleep.call_count, 1)
+
+    def test_provisioning_server_not_configured(self):
+        """Check if an exception is raised if missing provisioning_server"""
+        vm = VirtualMachine()
+        with patch.object(vm, 'provisioning_server', None):
+            with self.assertRaises(VirtualMachineError):
+                vm.create()
+
+    @patch('robottelo.common.ssh.command')
+    def test_run(self, ssh_command):
+        """Check if run calls ssh.command"""
+        vm = VirtualMachine()
+
+        def create_mock():
+            """A mock for create method to set instance vars to run work"""
+            vm._created = True
+            vm.ip_addr = '192.168.0.1'
+
+        with patch.object(vm, 'create', side_effect=create_mock):
+            vm.create()
+
+        vm.run('ls')
+        ssh_command.assert_called_once_with('ls', hostname='192.168.0.1')
+
+    def test_run_raises_exception(self):
+        """Check if run raises an exception if the vm is not created"""
+        vm = VirtualMachine()
+        with self.assertRaises(VirtualMachineError):
+            vm.run('ls')
+
+    @patch('robottelo.common.ssh.command')
+    def test_destroy(self, ssh_command):
+        """Check if destroy runs the required ssh commands"""
+        image_dir = '/opt/robottelo/images'
+        provisioning_server = 'provisioning.server.com'
+        vm = VirtualMachine()
+
+        with patch.multiple(
+            vm,
+            image_dir=image_dir,
+            provisioning_server=provisioning_server,
+            _created=True
+        ):
+            vm.destroy()
+
+        self.assertEqual(ssh_command.call_count, 3)
+
+        ssh_command_args_list = [
+            call('virsh destroy {0}'.format(vm.target_image),
+                 hostname=provisioning_server),
+            call('virsh undefine {0}'.format(vm.target_image),
+                 hostname=provisioning_server),
+            call('rm {0}/{1}.img'.format(image_dir, vm.target_image),
+                 hostname=provisioning_server),
+        ]
+
+        self.assertListEqual(ssh_command.call_args_list, ssh_command_args_list)


### PR DESCRIPTION
The clients provisioning feature will allow create clients to be used on
tests that needs another machine to consume some content.

Also this improve the ssh module to allow specify the machine where to
run a command. Improved logging to show what machine the command was
executed (inspired by Fabric).

Finally was added tests for the new robotello.vm module and properly
added entries for added modules in the docs.

Bonus: refactored logging on the ssh module.
