### PR TITLE
Trim down ForemanTask, test ForemanTask API

### DIFF
--- a/docs/api/tests.foreman.api.rst
+++ b/docs/api/tests.foreman.api.rst
@@ -54,6 +54,13 @@
     :members:
     :undoc-members:
 
+:mod:`tests.foreman.api.test_foremantask_v2`
+--------------------------------------------
+
+.. automodule:: tests.foreman.api.test_foremantask_v2
+    :members:
+    :undoc-members:
+
 :mod:`tests.foreman.api.test_gpgkey_v2`
 ---------------------------------------
 

--- a/tests/foreman/api/test_foremantask_v2.py
+++ b/tests/foreman/api/test_foremantask_v2.py
@@ -1,0 +1,23 @@
+"""Unit tests for the ``foreman_tasks/api/v2/tasks`` paths."""
+from requests.exceptions import HTTPError
+from robottelo.common.decorators import skip_if_bug_open
+from robottelo import entities
+from unittest import TestCase
+# (too many public methods) pylint: disable=R0904
+
+
+class ForemanTasksIdTestCase(TestCase):
+    """Tests for the ``foreman_tasks/api/v2/tasks/:id`` path."""
+    @skip_if_bug_open('bugzilla', 1131702)
+    def test_no_such_task(self):
+        """@Test: Fetch a non-existent task.
+
+        @Assert: An HTTP 4XX or 5XX message is returned.
+
+        @Feature: ForemanTask
+
+        @bz: 1131702
+
+        """
+        with self.assertRaises(HTTPError):
+            entities.ForemanTask(id='abc123').read_json()


### PR DESCRIPTION
Remove the custom method `ForemanTask.read`. Make `ForemanTask` inherit from
`EntityReadMixin`. `ForemanTask.read_json` performs the same task that the old
`ForemanTask.read` method did, and no code was using the old method.

Add a test targeting bugzilla bug 1131702. The test asserts that when a
non-existent foreman task is read, an HTTP 4XX or 5XX error is received. The
test fails, so it is skipped appropriately.

Add this new test module to the API docs.
