### PR TITLE
updated activation-key tests to use factory and api's for dependent entities

### DIFF
--- a/robottelo/common/constants.py
+++ b/robottelo/common/constants.py
@@ -133,6 +133,7 @@ REPOSET = {'rhct6': "Red Hat CloudForms Tools for RHEL 6 (RPMs)",
 
 DEFAULT_ORG = "Default_Organization"
 DEFAULT_LOC = "Default_Location"
+DEFAULT_CV = "Default Organization View"
 
 LANGUAGES = ["en", "en_GB",
              "fr", "gl",

--- a/robottelo/entities.py
+++ b/robottelo/entities.py
@@ -1237,6 +1237,19 @@ class Repository(
         attrs['product_id'] = attrs.pop('product')['id']
         return super(Repository, self).read(auth, entity, attrs)
 
+    def sync(self):
+        """Helper for syncing an existing repository."""
+
+        response = client.post(
+            self.path('sync'),
+            auth=get_server_credentials(),
+            verify=False,
+            data={u'id': self.id} # Fixme: "Sync" path already includes an ID,
+                                  # This is a redundant ID, need to remove
+        )
+        response.raise_for_status()
+        return response.json()
+
     class Meta(object):
         """Non-field information about this entity."""
         api_path = 'katello/api/v2/repositories'

--- a/robottelo/ui/contentviews.py
+++ b/robottelo/ui/contentviews.py
@@ -95,11 +95,11 @@ class ContentViews(Base):
                 raise Exception(
                     'Could not delete the %s content view.' % name)
 
-    def move_affected_components(self, env="Library",
-                                 cv='Default Organization View'):
-        """
-        Moves the affected components (e.g. activation-key or content-hosts)
-        to other env or CV
+    def move_affected_components(self, env, cv):
+        """Move affected components to another environment or content view.
+
+        Activation keys and content hosts are examples of affected components.
+
         """
         strategy, value = locators['contentviews.change_env']
         env_element = self.wait_until_element((strategy, value % env))
@@ -115,11 +115,11 @@ class ContentViews(Base):
         self.wait_until_element(locators['contentviews.next_button']).click()
         self.wait_for_ajax()
 
-    def delete_version(self, name, is_affected_comps=False,
-                       env=None, cv=None, really=True):
-        """
-        Deletes published content view's version and handles the associated
+    def delete_version(self, name, env, cv, is_affected_comps=False,
+                       really=True):
+        """Deletes published content view's version and handles the associated
         entities before deleting the selected CV.
+
         """
         element = self.search(name)
 

--- a/robottelo/ui/factory.py
+++ b/robottelo/ui/factory.py
@@ -3,6 +3,7 @@
 from robottelo.common.helpers import (update_dictionary, generate_string,
                                       generate_email_address)
 from robottelo.common.constants import REPO_TYPE
+from robottelo.ui.activationkey import ActivationKey
 from robottelo.ui.architecture import Architecture
 from robottelo.ui.computeresource import ComputeResource
 from robottelo.ui.configgroups import ConfigGroups
@@ -145,6 +146,23 @@ def make_lifecycle_environment(session, org=None, loc=None,
     core_factory(create_args, kwargs, session, page,
                  org=org, loc=loc, force_context=force_context)
     ContentEnvironment(session.browser).create(**create_args)
+
+
+def make_activationkey(session, org=None, loc=None,
+                       force_context=False, **kwargs):
+    """Creates Activation Key"""
+
+    create_args = {
+        'name': None,
+        'env': None,
+        'limit': None,
+        'description': None,
+        'content_view': None,
+    }
+    page = session.nav.go_to_activation_keys
+    core_factory(create_args, kwargs, session, page,
+                 org=org, loc=loc, force_context=force_context)
+    ActivationKey(session.browser).create(**create_args)
 
 
 def make_product(session, org=None, loc=None, force_context=False, **kwargs):


### PR DESCRIPTION
- All tests are now updated with factory implementation
- Doc-strings are now in new format
- Tests using UI only for activation-key feature, dependent entities(repo/product and CV) handled by api's.
