### PR TITLE
Test "auth_source_ldaps" API paths

### DIFF
--- a/robottelo/entities.py
+++ b/robottelo/entities.py
@@ -63,27 +63,43 @@ class Architecture(
         api_path = 'api/v2/architectures'
 
 
-class AuthSourceLDAP(orm.Entity, factory.EntityFactoryMixin):
+class AuthSourceLDAP(
+        orm.Entity, orm.EntityReadMixin, orm.EntityDeleteMixin,
+        factory.EntityFactoryMixin):
     """A representation of a AuthSourceLDAP entity."""
-    name = orm.StringField(required=True, len=(1, 60))
-    host = orm.StringField(required=True, len=(1, 60))
-    # defaults to 389
-    port = orm.IntegerField(null=True)
     account = orm.StringField(null=True)
+    attr_photo = orm.StringField(null=True)
     base_dn = orm.StringField(null=True)
+    host = orm.StringField(required=True, len=(1, 60))
+    name = orm.StringField(required=True, len=(1, 60))
+    onthefly_register = orm.BooleanField(null=True)
+    port = orm.IntegerField(null=True)  # default: 389
+    tls = orm.BooleanField(null=True)
+
     # required if onthefly_register is true
     account_password = orm.StringField(null=True)
-    # required if onthefly_register is true
-    attr_login = orm.StringField(null=True)
-    # required if onthefly_register is true
     attr_firstname = orm.StringField(null=True)
-    # required if onthefly_register is true
     attr_lastname = orm.StringField(null=True)
-    # required if onthefly_register is true
+    attr_login = orm.StringField(null=True)
     attr_mail = orm.EmailField(null=True)
-    attr_photo = orm.StringField(null=True)
-    onthefly_register = orm.BooleanField(null=True)
-    tls = orm.BooleanField(null=True)
+
+    def _factory_data(self):
+        """Customize the data provided to :class:`robottelo.factory.Factory`.
+
+        If ``onthefly_register is True``, several other fields must also be
+        filled in.
+
+        """
+        values = super(AuthSourceLDAP, self)._factory_data()
+        cls = type(self)
+        if ('onthefly_register' in values.keys() and
+                values['ontheflyregister'] is True):
+            values['account_password'] = cls.account_password.get_value()
+            values['attr_firstname'] = cls.attr_firstname.get_value()
+            values['attr_lastname'] = cls.attr_lastname.get_value()
+            values['attr_login'] = cls.attr_login.get_value()
+            values['attr_mail'] = cls.attr_mail.get_value()
+        return values
 
     class Meta(object):
         """Non-field information about this entity."""

--- a/tests/foreman/api/test_multiple_paths.py
+++ b/tests/foreman/api/test_multiple_paths.py
@@ -33,6 +33,7 @@ class EntityTestCase(TestCase):
     @data(
         # entities.ActivationKey,  # need organization_id or environment_id
         entities.Architecture,
+        entities.AuthSourceLDAP,
         entities.ComputeProfile,
         entities.ConfigTemplate,
         # entities.ContentView,  # need organization_id
@@ -75,6 +76,7 @@ class EntityTestCase(TestCase):
     @data(
         # entities.ActivationKey,  # need organization id or environment id
         entities.Architecture,
+        entities.AuthSourceLDAP,
         entities.ComputeProfile,
         entities.ConfigTemplate,
         entities.ContentView,
@@ -112,6 +114,7 @@ class EntityTestCase(TestCase):
     @data(
         entities.ActivationKey,
         entities.Architecture,
+        entities.AuthSourceLDAP,
         entities.ComputeProfile,
         entities.ConfigTemplate,
         entities.ContentView,
@@ -157,6 +160,7 @@ class EntityTestCase(TestCase):
     @data(
         entities.ActivationKey,
         entities.Architecture,
+        entities.AuthSourceLDAP,
         entities.ComputeProfile,
         entities.ConfigTemplate,
         entities.ContentView,
@@ -199,6 +203,7 @@ class EntityIdTestCase(TestCase):
     @data(
         entities.ActivationKey,
         entities.Architecture,
+        entities.AuthSourceLDAP,
         entities.ComputeProfile,
         entities.ConfigTemplate,
         entities.ContentView,
@@ -244,6 +249,7 @@ class EntityIdTestCase(TestCase):
     @data(
         entities.ActivationKey,
         entities.Architecture,
+        entities.AuthSourceLDAP,
         entities.ComputeProfile,
         entities.ConfigTemplate,
         entities.ContentView,
@@ -287,6 +293,7 @@ class EntityIdTestCase(TestCase):
     @data(
         entities.ActivationKey,
         entities.Architecture,
+        entities.AuthSourceLDAP,
         entities.ComputeProfile,
         entities.ConfigTemplate,
         entities.ContentView,
@@ -354,6 +361,7 @@ class DoubleCheckTestCase(TestCase):
     @data(
         entities.ActivationKey,
         entities.Architecture,
+        entities.AuthSourceLDAP,
         entities.ComputeProfile,
         entities.ConfigTemplate,
         entities.ContentView,
@@ -379,6 +387,10 @@ class DoubleCheckTestCase(TestCase):
         @Assert: The updated entity has the correct attributes.
 
         """
+        if entity is entities.AuthSourceLDAP and bz_bug_is_open(1140313):
+            self.skipTest("Bugzilla bug 1140313 is open.""")
+
+        # Create an entity.
         entity_n = entity(id=entity().create()['id'])
         logger.info('test_put_and_get path: {0}'.format(entity_n.path()))
 
@@ -401,6 +413,7 @@ class DoubleCheckTestCase(TestCase):
     @data(
         entities.ActivationKey,
         entities.Architecture,
+        entities.AuthSourceLDAP,
         entities.ComputeProfile,
         entities.ConfigTemplate,
         entities.ContentView,
@@ -428,6 +441,8 @@ class DoubleCheckTestCase(TestCase):
         """
         if entity in BZ_1122267_ENTITIES and bz_bug_is_open(1122267):
             self.skipTest("Bugzilla bug 1122267 is open.""")
+        if entity is entities.AuthSourceLDAP and bz_bug_is_open(1140313):
+            self.skipTest("Bugzilla bug 1140313 is open.""")
 
         # Generate some attributes and use them to create an entity.
         gen_attrs = entity().build()
@@ -450,6 +465,7 @@ class DoubleCheckTestCase(TestCase):
     @data(
         entities.ActivationKey,
         entities.Architecture,
+        entities.AuthSourceLDAP,
         entities.ComputeProfile,
         entities.ConfigTemplate,
         entities.ContentView,
@@ -511,6 +527,7 @@ class EntityReadTestCase(TestCase):
     @data(
         # entities.ActivationKey,
         # entities.Architecture,
+        entities.AuthSourceLDAP,
         entities.ComputeProfile,
         # entities.ConfigTemplate,
         # entities.ContentView,
@@ -538,6 +555,8 @@ class EntityReadTestCase(TestCase):
         @Assert: The just-read entity is an instance of the correct class.
 
         """
+        if entity is entities.AuthSourceLDAP and bz_bug_is_open(1140313):
+            self.skipTest("Bugzilla bug 1140313 is open.""")
         attrs = entity().create()
         read_entity = entity(id=attrs['id']).read()
         self.assertIsInstance(read_entity, entity)


### PR DESCRIPTION
Flesh out the `AuthSourceLDAP` class and add this class to module
`test_multiple_paths`. Reference bugzilla bug 1140313 ("Cannot read an auth
source ldap's host via the API") in the updated test suite.
