### PR TITLE
Trim down test_multiple_paths.py

### DIFF
--- a/robottelo/entities.py
+++ b/robottelo/entities.py
@@ -52,7 +52,8 @@ class ActivationKey(
 
 
 class Architecture(
-        orm.Entity, factory.EntityFactoryMixin, orm.EntityDeleteMixin):
+        orm.Entity, orm.EntityReadMixin, orm.EntityDeleteMixin,
+        factory.EntityFactoryMixin):
     """A representation of a Architecture entity."""
     name = orm.StringField(required=True)
     operatingsystems = orm.OneToManyField('OperatingSystem', null=True)
@@ -421,7 +422,9 @@ class CustomInfo(orm.Entity):
                     ':informable_id')
 
 
-class Domain(orm.Entity, factory.EntityFactoryMixin, orm.EntityDeleteMixin):
+class Domain(
+        orm.Entity, orm.EntityReadMixin, orm.EntityDeleteMixin,
+        factory.EntityFactoryMixin):
     """A representation of a Domain entity."""
     # The full DNS Domain name
     name = orm.StringField(required=True)
@@ -545,7 +548,9 @@ def _gpgkey_content():
         return handle.read()
 
 
-class GPGKey(orm.Entity, factory.EntityFactoryMixin, orm.EntityDeleteMixin):
+class GPGKey(
+        orm.Entity, orm.EntityReadMixin, orm.EntityDeleteMixin,
+        factory.EntityFactoryMixin):
     """A representation of a GPG Key entity."""
     organization = orm.OneToOneField('Organization', required=True)
     # identifier of the gpg key
@@ -641,7 +646,7 @@ class HostGroup(orm.Entity):
         api_path = 'api/v2/hostgroups'
 
 
-class Host(orm.Entity, factory.EntityFactoryMixin):
+class Host(orm.Entity, orm.EntityReadMixin, factory.EntityFactoryMixin):
     """A representation of a Host entity."""
     name = orm.StringField(required=True)
     environment = orm.OneToOneField('Environment', null=True)
@@ -721,7 +726,8 @@ class Interface(orm.Entity):
 
 
 class LifecycleEnvironment(
-        orm.Entity, factory.EntityFactoryMixin, orm.EntityDeleteMixin):
+        orm.Entity, orm.EntityReadMixin, orm.EntityDeleteMixin,
+        factory.EntityFactoryMixin):
     """A representation of a Lifecycle Environment entity."""
     organization = orm.OneToOneField('Organization', required=True)
     name = orm.StringField(required=True)
@@ -828,8 +834,8 @@ class Media(orm.Entity):
 
 
 class Model(
-        orm.Entity, factory.EntityFactoryMixin, orm.EntityDeleteMixin,
-        orm.EntityReadMixin):
+        orm.Entity, orm.EntityReadMixin, orm.EntityDeleteMixin,
+        factory.EntityFactoryMixin):
     """A representation of a Model entity."""
     name = orm.StringField(required=True)
     info = orm.StringField(null=True)
@@ -842,8 +848,8 @@ class Model(
 
 
 class OperatingSystem(
-        orm.Entity, factory.EntityFactoryMixin, orm.EntityDeleteMixin,
-        orm.EntityReadMixin):
+        orm.Entity, orm.EntityReadMixin, orm.EntityDeleteMixin,
+        factory.EntityFactoryMixin):
     """A representation of a Operating System entity.
 
     ``major`` is listed as a string field in the API docs, but only numeric
@@ -865,7 +871,8 @@ class OperatingSystem(
 
 
 class OperatingSystemParameter(
-        orm.Entity, factory.EntityFactoryMixin, orm.EntityReadMixin):
+        orm.Entity, orm.EntityReadMixin, orm.EntityDeleteMixin,
+        factory.EntityFactoryMixin):
     """A representation of a parameter for an operating system."""
     name = orm.StringField(required=True)
     value = orm.StringField(required=True)
@@ -914,8 +921,8 @@ class OrganizationDefaultInfo(orm.Entity):
 
 
 class Organization(
-        orm.Entity, factory.EntityFactoryMixin, orm.EntityDeleteMixin,
-        orm.EntityReadMixin):
+        orm.Entity, orm.EntityReadMixin, orm.EntityDeleteMixin,
+        factory.EntityFactoryMixin):
     """A representation of an Organization entity."""
     name = orm.StringField(required=True)
     label = orm.StringField()
@@ -1180,8 +1187,8 @@ class Report(orm.Entity):
 
 
 class Repository(
-        orm.Entity, factory.EntityFactoryMixin, orm.EntityDeleteMixin,
-        orm.EntityReadMixin):
+        orm.Entity, orm.EntityReadMixin, orm.EntityDeleteMixin,
+        factory.EntityFactoryMixin):
     """A representation of a Repository entity."""
     name = orm.StringField(required=True)
     label = orm.StringField()
@@ -1245,8 +1252,8 @@ class RoleLDAPGroups(orm.Entity):
 
 
 class Role(
-        orm.Entity, factory.EntityFactoryMixin, orm.EntityDeleteMixin,
-        orm.EntityReadMixin):
+        orm.Entity, orm.EntityReadMixin, orm.EntityDeleteMixin,
+        factory.EntityFactoryMixin):
     """A representation of a Role entity."""
     # FIXME: UTF-8 characters should be acceptable for `name`. See BZ 1129785
     name = orm.StringField(
@@ -1378,7 +1385,9 @@ class SystemPackage(orm.Entity):
         api_path = 'katello/api/v2/systems/:system_id/packages'
 
 
-class System(orm.Entity, factory.EntityFactoryMixin, orm.EntityDeleteMixin):
+class System(
+        orm.Entity, orm.EntityReadMixin, orm.EntityDeleteMixin,
+        factory.EntityFactoryMixin):
     """A representation of a System entity."""
     content_view = orm.OneToOneField('ContentView')
     description = orm.StringField()
@@ -1465,7 +1474,9 @@ class UserGroup(orm.Entity):
         api_path = 'api/v2/usergroups'
 
 
-class User(orm.Entity, factory.EntityFactoryMixin, orm.EntityDeleteMixin):
+class User(
+        orm.Entity, orm.EntityReadMixin, orm.EntityDeleteMixin,
+        factory.EntityFactoryMixin):
     """A representation of a User entity.
 
     The LDAP authentication source with an ID of 1 is internal. It is nearly

--- a/tests/foreman/api/test_multiple_paths.py
+++ b/tests/foreman/api/test_multiple_paths.py
@@ -7,7 +7,11 @@ from robottelo.common.helpers import get_server_credentials
 from robottelo import entities, factory
 from unittest import TestCase
 import httplib
+import logging
 # (too many public methods) pylint: disable=R0904
+
+
+logger = logging.getLogger(__name__)  # pylint:disable=C0103
 
 
 BZ_1118015_ENTITIES = (
@@ -375,29 +379,24 @@ class DoubleCheckTestCase(TestCase):
         @Assert: The updated entity has the correct attributes.
 
         """
-        path = entity(id=entity().create()['id']).path()
+        entity_n = entity(id=entity().create()['id'])
+        logger.info('test_put_and_get path: {0}'.format(entity_n.path()))
 
         # Generate some attributes and use them to update an entity.
         gen_attrs = entity().attributes()
         response = client.put(
-            path,
+            entity_n.path(),
             gen_attrs,
             auth=get_server_credentials(),
             verify=False,
         )
-        self.assertEqual(response.status_code, httplib.OK, path)
+        response.raise_for_status()
 
         # Get the just-updated entity and examine its attributes.
-        real_attrs = client.get(
-            path,
-            auth=get_server_credentials(),
-            verify=False,
-        ).json()
+        real_attrs = entity_n.read_json()
         for key, value in gen_attrs.items():
-            self.assertIn(key, real_attrs.keys(), path)
-            self.assertEqual(
-                value, real_attrs[key], '{0} {1}'.format(key, path)
-            )
+            self.assertIn(key, real_attrs.keys())
+            self.assertEqual(value, real_attrs[key], key)
 
     @data(
         entities.ActivationKey,
@@ -429,6 +428,7 @@ class DoubleCheckTestCase(TestCase):
         """
         if entity in BZ_1122267_ENTITIES and bz_bug_is_open(1122267):
             self.skipTest("Bugzilla bug 1122267 is open.""")
+
         # Generate some attributes and use them to create an entity.
         gen_attrs = entity().build()
         response = client.post(
@@ -437,22 +437,15 @@ class DoubleCheckTestCase(TestCase):
             auth=get_server_credentials(),
             verify=False,
         )
-        path = entity(id=response.json()['id']).path()
-        self.assertIn(
-            response.status_code, (httplib.OK, httplib.CREATED), path
-        )
+        response.raise_for_status()
 
         # Get the just-created entity and examine its attributes.
-        real_attrs = client.get(
-            path,
-            auth=get_server_credentials(),
-            verify=False,
-        ).json()
+        entity_n = entity(id=response.json()['id'])
+        logger.info('test_post_and_get path: {0}'.format(entity_n.path()))
+        real_attrs = entity_n.read_json()
         for key, value in gen_attrs.items():
-            self.assertIn(key, real_attrs.keys(), path)
-            self.assertEqual(
-                value, real_attrs[key], '{0} {1}'.format(key, path)
-            )
+            self.assertIn(key, real_attrs.keys())
+            self.assertEqual(value, real_attrs[key], key)
 
     @data(
         entities.ActivationKey,
@@ -484,16 +477,18 @@ class DoubleCheckTestCase(TestCase):
         """
         if entity is entities.ConfigTemplate and bz_bug_is_open(1096333):
             self.skipTest('Cannot delete config templates.')
+
+        # Create an entity, then delete it.
         try:
-            attrs = entity().create()
+            entity_n = entity(id=entity().create()['id'])
         except factory.FactoryError as err:
             self.fail(err)
-        entity(id=attrs['id']).delete()
+        logger.info('test_delete_and_get path: {0}'.format(entity_n.path()))
+        entity_n.delete()
 
         # Get the now non-existent entity.
-        path = entity(id=attrs['id']).path()
         response = client.get(
-            path,
+            entity_n.path(),
             auth=get_server_credentials(),
             verify=False,
         )
@@ -501,7 +496,7 @@ class DoubleCheckTestCase(TestCase):
         self.assertEqual(
             status_code,
             response.status_code,
-            status_code_error(path, status_code, response),
+            status_code_error(entity_n.path(), status_code, response),
         )
 
 


### PR DESCRIPTION
Make all all tested entities (i.e. classes in entities.py) inherit from
`EntityReadMixin`. Take advantage of this fact to trim down module
`test_multiple_paths`.

Add a logger to module `test_multiple_paths`. Log out information in several
tests, thus allowing the assertions to be trimmed down.
