### PR TITLE
Updated repository tests to use api's for dependent entities

### DIFF
--- a/robottelo/common/constants.py
+++ b/robottelo/common/constants.py
@@ -151,3 +151,4 @@ GOOGLE_CHROME_REPO = u'http://dl.google.com/linux/chrome/rpm/stable/x86_64'
 FAKE_PUPPET_REPO = u'http://davidd.fedorapeople.org/repos/random_puppet/'
 FAKE_1_YUM_REPO = "http://inecas.fedorapeople.org/fakerepos/zoo3/"
 FAKE_2_YUM_REPO = "http://inecas.fedorapeople.org/fakerepos/zoo2/"
+REPO_DISCOVERY_URL = "http://omaciel.fedorapeople.org/"

--- a/robottelo/entities.py
+++ b/robottelo/entities.py
@@ -553,6 +553,7 @@ class GPGKey(
         factory.EntityFactoryMixin):
     """A representation of a GPG Key entity."""
     organization = orm.OneToOneField('Organization', required=True)
+    location = orm.OneToOneField('Location', null=True)
     # identifier of the gpg key
     # validator: string from 2 to 128 characters containting only alphanumeric
     # characters, space, '_', '-' with no leading or trailing space.
@@ -798,7 +799,7 @@ class LifecycleEnvironment(
         api_path = 'katello/api/v2/environments'
 
 
-class Location(orm.Entity):
+class Location(orm.Entity, factory.EntityFactoryMixin):
     """A representation of a Location entity."""
     name = orm.StringField(required=True)
 
@@ -1126,6 +1127,7 @@ class Product(
         factory.EntityFactoryMixin):
     """A representation of a Product entity."""
     organization = orm.OneToOneField('Organization', required=True)
+    location = orm.OneToOneField('Location', null=True)
     description = orm.StringField()
     gpg_key = orm.OneToOneField('GPGKey')
     sync_plan = orm.OneToOneField('SyncPlan', null=True)


### PR DESCRIPTION
- Tests are updated to use api's for dependent entities(GPGkeys and Products). Now tests using webUI only for repository feature
- All tests are using location along with organization.
- Updated location param for GPGKey, Product api entities
- Defined  the repo discovery URL under `CONSTANTS`
