### PR TITLE
Manifests-UI: Enabling the subscriptions and sync related tests.

### DIFF
--- a/robottelo/ui/subscription.py
+++ b/robottelo/ui/subscription.py
@@ -12,8 +12,11 @@ class Subscriptions(Base):
     """
 
     def upload(self, path, repo_url=None):
-        """
-        Uploads Manifest/subscriptions via UI
+        """Uploads Manifest/subscriptions via UI.
+
+        :param str path: The manifest path to upload.
+        :param str repo_url: The RedHat URL to sync content from.
+
         """
 
         self.wait_until_element(locators["subs.manage_manifest"]).click()
@@ -26,12 +29,11 @@ class Subscriptions(Base):
         browse_element = self.wait_until_element(locators["subs.file_path"])
         browse_element.send_keys(path)
         self.wait_until_element(locators["subs.upload"]).click()
-        self.wait_until_element(locators["subs.manifest_exists"], 10)
+        # Waits till the below locator is visible or until 60 seconds.
+        self.wait_until_element(locators["subs.manifest_exists"], 60)
 
     def delete(self):
-        """
-        Uploads Manifest/subscriptions via UI
-        """
+        """Uploads Manifest/subscriptions via UI."""
 
         self.wait_until_element(locators["subs.manage_manifest"]).click()
         self.wait_for_ajax()
@@ -39,9 +41,7 @@ class Subscriptions(Base):
         self.wait_for_ajax()
 
     def refresh(self):
-        """
-        Refreshes Manifest/subscriptions via UI
-        """
+        """Refreshes Manifest/subscriptions via UI."""
 
         self.wait_until_element(locators["subs.manage_manifest"]).click()
         self.wait_for_ajax()

--- a/robottelo/ui/sync.py
+++ b/robottelo/ui/sync.py
@@ -6,7 +6,7 @@ import time
 from collections import defaultdict
 from functools import partial
 from robottelo.common.constants import PRDS, REPOSET
-from robottelo.ui.base import Base
+from robottelo.ui.base import Base, UINoSuchElementError
 from robottelo.ui.locators import locators
 
 
@@ -16,65 +16,75 @@ class Sync(Base):
     """
 
     def assert_sync(self, repos):
-        """
-        Asserts the sync of Repos, loops over until cancel is visible,
-        while syncing.
+        """Asserts sync status of the Repositories.
+
+        Asserts the sync of Repositories, loops over while cancel is visible,
+        during the syncing process.
+
+        :param list repos: List of repositories names to assert sync status.
+        :return: Returns True if sync is successful.
+        :rtype: boolean
+
         """
         repos_result = []
-        strategy1 = locators["sync.fetch_result"][0]
-        value1 = locators["sync.fetch_result"][1]
-        strategy2 = locators["sync.cancel"][0]
-        value2 = locators["sync.cancel"][1]
+        strategy1, value1 = locators["sync.fetch_result"]
+        strategy2, value2 = locators["sync.cancel"]
         for repo in repos:
             timeout = time.time() + 60 * 10
             sync_cancel = self.wait_until_element((strategy2,
-                                                   value2 % repo))
+                                                   value2 % repo), 3)
             # Waits until sync "cancel" is visible on the UI or times out
             # after 10mins
             while sync_cancel:
                 if time.time() > timeout:
                     break
                 sync_cancel = self.wait_until_element((strategy2,
-                                                       value2 % repo))
-            result = self.wait_until_element((strategy1, value1 % repo)).text
+                                                       value2 % repo), 3)
+            result = self.wait_until_element((strategy1,
+                                              value1 % repo), 5).text
             # Updates the result of every sync repo to the repos_result list.
             repos_result.append(result)
-        # Checks whether every item(sync result) in the list is "Sync complete"
-        # This function returns None if it encounters any of the below:
-        # "Error Syncing", "Queued", "None" or "Cancel".
-        if all([str(r) == "Sync complete." for r in repos_result]):
+        # Checks whether every item(sync result) in the list is
+        # "Syncing Complete."
+        # This function returns False if it encounters any of the below:
+        # "Error Syncing", "Queued", "None", "Never Synced" or "Cancel".
+        if all([str(r) == "Syncing Complete." for r in repos_result]):
             return True
         else:
             return False
 
     def sync_custom_repos(self, product, repos):
-        """
+        """Syncs Repositories from Custom Product.
+
         Selects multiple custom repos to Synchronize from UI,
         by first expanding the product.
+
+        :param str product: The product which repositories belongs to.
+        :param list repos: The list of repositories to sync.
+
         """
-        strategy = locators["sync.prd_expander"][0]
-        value = locators["sync.prd_expander"][1]
-        strategy1 = locators["sync.repo_checkbox"][0]
-        value1 = locators["sync.repo_checkbox"][1]
+        strategy, value = locators["sync.prd_expander"]
+        strategy1, value1 = locators["sync.repo_checkbox"]
         prd_exp = self.wait_until_element((strategy, value % product))
         if prd_exp:
             prd_exp.click()
         else:
-            raise Exception("Could not find the \
-                             product expander: '%s'" % product)
+            raise UINoSuchElementError(
+                "Could not find the product expander: '%s'" % product)
         for repo in repos:
             repo_select = self.wait_until_element((strategy1, value1 % repo))
             if repo_select:
                 repo_select.click()
             else:
-                raise Exception("Could not find the \
-                                 repo: '%s'" % repo)
+                raise UINoSuchElementError(
+                    "Could not find the repo: '%s'" % repo)
         self.wait_until_element(locators["sync.sync_now"]).click()
         self.wait_for_ajax()
         return self.assert_sync(repos)
 
     def create_repos_tree(self, repos):
-        """
+        """Creates list of dictionary.
+
         Creates a list of dynamic hierarchial dictonary of repositories.  A
         sample data which needs to be passed can be fetched from constants::
 
@@ -95,6 +105,9 @@ class Sync(Base):
                 })
             })})})
 
+        :param list repos: repos is a list of tuples.
+        :return: Returns list of dictionary.
+
         """
         repos_tree = defaultdict(partial(defaultdict,
                                          partial(defaultdict,
@@ -108,30 +121,29 @@ class Sync(Base):
         return repos_tree
 
     def enable_rh_repos(self, repos_tree):
+        """Enables Red Hat Repos, after importing a RedHat Manifest.
+
+        We need to first select the PRD to enable, then the reposet
+        and then the repos. A Product could have multiple reposets and
+        each reposet could have multiple repos.
+
+        :param repos_tree: Repositories to enable which is a List of dictionary
+        :return: None.
+
         """
-        Enables Red Hat Repos, after importing a RedHat Manifest.
-        """
-        strategy = locators["rh.prd_expander"][0]
-        value = locators["rh.prd_expander"][1]
-        strategy1 = locators["rh.reposet_expander"][0]
-        value1 = locators["rh.reposet_expander"][1]
-        strategy2 = locators["rh.reposet_checkbox"][0]
-        value2 = locators["rh.reposet_checkbox"][1]
-        strategy3 = locators["rh.repo_checkbox"][0]
-        value3 = locators["rh.repo_checkbox"][1]
-        strategy4 = locators["rh.reposet_spinner"][0]
-        value4 = locators["rh.reposet_spinner"][1]
-        strategy5 = locators["rh.repo_spinner"][0]
-        value5 = locators["rh.repo_spinner"][1]
-        # I believe the variables names makes it very intuitive as what to
-        # expect while looping over repos_tree.
+        strategy, value = locators["rh.prd_expander"]
+        strategy1, value1 = locators["rh.reposet_expander"]
+        strategy2, value2 = locators["rh.reposet_checkbox"]
+        strategy3, value3 = locators["rh.repo_checkbox"]
+        strategy4, value4 = locators["rh.reposet_spinner"]
+        strategy5, value5 = locators["rh.repo_spinner"]
         for prd in repos_tree:
-            self.wait_until_element((strategy, value % PRDS[prd])).click()
+            self.wait_until_element((strategy, value % PRDS[prd]), 60).click()
             for reposet in repos_tree[prd]:
-                rs_exp = self.wait_until_element((strategy1,
-                                                  value1 % REPOSET[reposet]))
-                rs_cb = self.wait_until_element((strategy2,
-                                                 value2 % REPOSET[reposet]))
+                rs_exp = self.wait_until_element(
+                    (strategy1, value1 % REPOSET[reposet]), 5)
+                rs_cb = self.wait_until_element(
+                    (strategy2, value2 % REPOSET[reposet]), 5)
                 # Below loop helps when reposet checkbox is already expanded
                 # and when selecting multiple repos.
                 if rs_exp:
@@ -141,47 +153,47 @@ class Sync(Base):
                     # Selecting a rs checkbox takes time and spinner is visible
                     # the below code loops for over 2 mins till the spinner is
                     # visible.
-                    rs_spinner = self.\
-                        wait_until_element((strategy4,
-                                            value4 % REPOSET[reposet]))
+                    rs_spinner = self.wait_until_element(
+                        (strategy4, value4 % REPOSET[reposet]), 3)
                     timeout = time.time() + 60 * 2
                     while rs_spinner:
                         if time.time() > timeout:
                             break
-                        rs_spinner = self.\
-                            wait_until_element((strategy4,
-                                                value4 % REPOSET[reposet]))
+                        rs_spinner = self.wait_until_element(
+                            (strategy4, value4 % REPOSET[reposet]), 3)
                 for repo in repos_tree[prd][reposet]:
                     repo_values = repos_tree[prd][reposet][repo]
                     repo_name = repo_values['repo_name']
-                    self.wait_until_element((strategy3,
-                                             value3 % repo_name)).click()
+                    self.wait_until_element(
+                        (strategy3, value3 % repo_name), 60).click()
                     # Similar to above reposet checkbox spinner
-                    repo_spinner = self.\
-                        wait_until_element((strategy5,
-                                            value5 % repo_name))
+                    repo_spinner = self.wait_until_element(
+                        (strategy5, value5 % repo_name), 3)
                     timeout = time.time() + 30
                     while repo_spinner:
                         if time.time() > timeout:
                             break
-                        repo_spinner = self.\
-                            wait_until_element((strategy5,
-                                                value5 % repo_name))
+                        repo_spinner = self.wait_until_element(
+                            (strategy5, value5 % repo_name), 3)
 
     def sync_rh_repos(self, repos_tree):
-        """
+        """Syncs RedHat repositories.
+
         Selects Red Hat Repos to Synchronize from UI.
+
+        :param repos_tree: Repositories to choose which is a List of dictionary
+        :return: Returns True if the sync was successful.
+        :rtype: boolean
+
         """
-        strategy = locators["sync.prd_expander"][0]
-        value = locators["sync.prd_expander"][1]
-        strategy1 = locators["sync.verarch_expander"][0]
-        value1 = locators["sync.verarch_expander"][1]
-        strategy2 = locators["sync.repo_checkbox"][0]
-        value2 = locators["sync.repo_checkbox"][1]
+        strategy, value = locators["sync.prd_expander"]
+        strategy1, value1 = locators["sync.verarch_expander"]
+        strategy2, value2 = locators["sync.repo_checkbox"]
         repos = []
         # create_repos_tree returns data needed to be passed to this function.
         for prd in repos_tree:
-            prd_exp = self.wait_until_element((strategy, value % PRDS[prd]))
+            prd_exp = self.wait_until_element(
+                (strategy, value % PRDS[prd]))
             if prd_exp:
                 prd_exp.click()
             for reposet in repos_tree[prd]:
@@ -191,30 +203,33 @@ class Sync(Base):
                     repo_arch = repo_values['repo_arch']
                     repo_ver = repo_values['repo_ver']
                     repos.append(repo_name)
-                    ver_exp = self.wait_until_element((strategy1,
-                                                       value1 % repo_ver))
+                    ver_exp = self.wait_until_element(
+                        (strategy1, value1 % repo_ver))
                     if ver_exp:
                         ver_exp.click()
                         self.wait_for_ajax()
                     else:
-                        raise Exception("Could not find the \
-                                        version expander: '%s'" % repo_ver)
-                    arch_exp = self.wait_until_element((strategy1,
-                                                        value1 % repo_arch))
+                        raise UINoSuchElementError(
+                            "Could not find the version expander: '%s'" %
+                            repo_ver)
+                    arch_exp = self.wait_until_element(
+                        (strategy1, value1 % repo_arch))
                     if arch_exp:
                         arch_exp.click()
                         self.wait_for_ajax()
                     else:
-                        raise Exception("Could not find the \
-                                        arch expander: '%s'" % repo_arch)
-                    repo_select = self.wait_until_element((strategy2,
-                                                           value2 % repo_name))
+                        raise UINoSuchElementError(
+                            "Could not find the arch expander: '%s'" %
+                            repo_arch)
+                    repo_select = self.wait_until_element(
+                        (strategy2, value2 % repo_name))
                     if repo_select:
                         repo_select.click()
                         self.wait_for_ajax()
                     else:
-                        raise Exception("Could not find the \
-                                        repository name: '%s'" % repo_name)
+                        raise UINoSuchElementError(
+                            "Could not find the repository name: '%s'" %
+                            repo_name)
                 self.wait_until_element(locators["sync.sync_now"]).click()
                 self.wait_for_ajax()
         # Let's assert without navigating away from sync status page to avoid

--- a/tests/foreman/ui/test_subscription.py
+++ b/tests/foreman/ui/test_subscription.py
@@ -2,9 +2,9 @@
 
 from ddt import ddt
 from nose.plugins.attrib import attr
-from robottelo.common.decorators import skipRemote, stubbed
+from robottelo.common.decorators import skipRemote
 from robottelo.common.helpers import generate_string
-# from robottelo.common.manifests import manifest  # FIXME: does not exist
+from robottelo.common.manifests import clone
 from robottelo.common.ssh import upload_file
 from robottelo.test import UITestCase
 from robottelo.ui.factory import make_org
@@ -13,20 +13,19 @@ from robottelo.ui.session import Session
 
 
 @ddt
-class Subscription(UITestCase):
+class SubscriptionTestCase(UITestCase):
     """Implements subscriptions/manifests tests in UI"""
 
     org_name = None
 
     def setUp(self):
-        super(Subscription, self).setUp()
+        super(SubscriptionTestCase, self).setUp()
         # Make sure to use the Class' org_name instance
-        if Subscription.org_name is None:
-            Subscription.org_name = generate_string("alpha", 8)
+        if SubscriptionTestCase.org_name is None:
+            SubscriptionTestCase.org_name = generate_string("alpha", 8)
             with Session(self.browser) as session:
-                make_org(session, org_name=Subscription.org_name)
+                make_org(session, org_name=SubscriptionTestCase.org_name)
 
-    @stubbed('Need to implement a new manifest api')
     @skipRemote
     @attr('ui', 'subs', 'implemented')
     def test_positive_upload_1(self):
@@ -39,23 +38,16 @@ class Subscription(UITestCase):
         """
 
         alert_loc = common_locators['alert.success']
-        # FIXME: remove directives after manifest implemented
-        mdetails = manifest.fetch_manifest()  # flake8:noqa pylint:disable=E0602
-        path = mdetails['path']
-        try:
-            # upload_file function should take care of uploading to sauce labs.
-            upload_file(mdetails['path'], remote_file=mdetails['path'])
-            with Session(self.browser) as session:
-                session.nav.go_to_select_org(self.org_name)
-                session.nav.go_to_red_hat_subscriptions()
-                self.subscriptions.upload(path)
-                success_ele = self.subscriptions.wait_until_element(alert_loc)
-                self.assertTrue(success_ele)
-        finally:
-            # FIXME: remove directives after manifest implemented
-            manifest.delete_distributor(ds_uuid=mdetails['uuid']) # flake8:noqa pylint:disable=E0602
+        path = clone()
+        # upload_file function should take care of uploading to sauce labs.
+        upload_file(path, remote_file=path)
+        with Session(self.browser) as session:
+            session.nav.go_to_select_org(self.org_name)
+            session.nav.go_to_red_hat_subscriptions()
+            self.subscriptions.upload(path)
+            success_ele = self.subscriptions.wait_until_element(alert_loc)
+            self.assertTrue(success_ele)
 
-    @stubbed('Need to implement a new manifest api')
     @skipRemote
     @attr('ui', 'subs', 'implemented')
     def test_positive_delete_1(self):
@@ -68,19 +60,13 @@ class Subscription(UITestCase):
         """
 
         alert_loc = common_locators['alert.success']
-        # FIXME: remove directives after manifest implemented
-        mdetails = manifest.fetch_manifest()  # flake8:noqa pylint:disable=E0602
-        path = mdetails['path']
-        try:
-            # upload_file function should take care of uploading to sauce labs.
-            upload_file(mdetails['path'], remote_file=mdetails['path'])
-            with Session(self.browser) as session:
-                session.nav.go_to_select_org(self.org_name)
-                session.nav.go_to_red_hat_subscriptions()
-                self.subscriptions.upload(path)
-                self.subscriptions.delete()
-                success_ele = self.subscriptions.wait_until_element(alert_loc)
-                self.assertTrue(success_ele)
-        finally:
-            # FIXME: remove directives after manifest implemented
-            manifest.delete_distributor(ds_uuid=mdetails['uuid']) # flake8:noqa pylint:disable=E0602
+        path = clone()
+        # upload_file function should take care of uploading to sauce labs.
+        upload_file(path, remote_file=path)
+        with Session(self.browser) as session:
+            session.nav.go_to_select_org(self.org_name)
+            session.nav.go_to_red_hat_subscriptions()
+            self.subscriptions.upload(path)
+            self.subscriptions.delete()
+            success_ele = self.subscriptions.wait_until_element(alert_loc)
+            self.assertTrue(success_ele)


### PR DESCRIPTION
Manifests can now be uploaded via the UI using the `clone` function
from `robottelo.common.manifests` module.

The `clone` function now uses by default, the `key_file` path  and
the `manifest_template` path which is specified in the,
robottelo.properties file.

Also tests related to enabling of RedHat Repos and Syncing these
Repos have also been fixed..

We are using RedHat Manifests, cloning them and just changing the
UUID in consumer.json file, so as to enable it to import in
different Organizations.
