### PR TITLE
Fixes the cli tests after the updates to manifests module.

### DIFF
--- a/tests/foreman/cli/test_contentviews.py
+++ b/tests/foreman/cli/test_contentviews.py
@@ -13,9 +13,7 @@ from robottelo.cli.contentview import ContentView
 from robottelo.cli.factory import (
     make_content_view, make_org, make_repository, make_product,
     make_lifecycle_environment, make_user, CLIFactoryError)
-from robottelo.common.manifests import (
-    clone, download_signing_key,
-    download_manifest_template, install_cert_on_server)
+from robottelo.common.manifests import clone
 from robottelo.cli.repository import Repository
 from robottelo.cli.repository_set import RepositorySet
 from robottelo.entities import Organization
@@ -84,10 +82,7 @@ class TestContentView(CLITestCase):
             return
 
         TestContentView.rhel_content_org = make_org()
-        signing_key = download_signing_key()
-        fake_manifest = download_manifest_template()
-        install_cert_on_server()
-        manifest = clone(signing_key, fake_manifest)
+        manifest = clone()
         finished_task = Organization(
             id=TestContentView.rhel_content_org['id']
         ).upload_manifest(manifest)

--- a/tests/foreman/cli/test_subscription.py
+++ b/tests/foreman/cli/test_subscription.py
@@ -5,9 +5,7 @@ from robottelo.cli.subscription import Subscription
 from robottelo.cli.repository import Repository
 from robottelo.cli.repository_set import RepositorySet
 from robottelo.cli.factory import make_org
-from robottelo.common.manifests import (
-    clone, download_signing_key,
-    download_manifest_template, install_cert_on_server)
+from robottelo.common.manifests import clone
 from robottelo.common.ssh import upload_file
 from robottelo.test import CLITestCase
 
@@ -22,16 +20,8 @@ class TestSubscription(CLITestCase):
         """Tests for content-view via Hammer CLI"""
 
         super(TestSubscription, self).setUp()
-
-        if TestSubscription.signing_key is None:
-            TestSubscription.signing_key = download_signing_key()
-            TestSubscription.fake_manifest = download_manifest_template()
-            install_cert_on_server()
-
         self.org = make_org()
-        self.manifest = clone(
-            TestSubscription.signing_key,
-            TestSubscription.fake_manifest)
+        self.manifest = clone()
 
     def test_manifest_upload(self):
         """@Test: upload manifest (positive)


### PR DESCRIPTION
`install_cert_on_server` functionality is now moved to,
automation-tools github repo.

Also we can now call `clone` function without any arguments,
which picks the default values from the robottelo.properties
file.
