### PR TITLE
Refactor ContentView.path and related code

### DIFF
--- a/robottelo/entities.py
+++ b/robottelo/entities.py
@@ -417,33 +417,27 @@ class ContentView(
 
         The returned path will depend on the value of ``which`` being passed.
 
-        If ``which = 'content_view_puppet_modules'``, then return a path
+        If ``which is 'content_view_puppet_modules'``, return a path
         in the format ``/content_views/<id>/content_view_puppet_modules``.
 
-        If ``which == 'content_view_versions'``, then return a path in the
+        If ``which is 'content_view_versions'``, return a path in the
         format ``/content_views/<id>/content_view_versions``.
 
-        If ``which == 'publish'``, then return a path in the
+        If ``which is 'publish'``, return a path in the
         format ``/content_views/<id>/publish``.
 
-        If ``which == 'available_puppet_module_names'``, then return a path in
+        If ``which is 'available_puppet_module_names'``, return a path in
         the format ``/content_views/<id>/available_puppet_module_names``.
 
         Otherwise, call ``super``.
 
         """
-        if which == 'content_view_puppet_modules':
-            return super(ContentView, self).path(
-                which='this') + '/content_view_puppet_modules'
-        if which == 'content_view_versions':
-            return super(ContentView, self).path(
-                which='this') + '/content_view_versions'
-        if which == 'publish':
-            return super(ContentView, self).path(
-                which='this') + '/publish'
-        if which == 'available_puppet_module_names':
-            return super(ContentView, self).path(
-                which='this') + '/available_puppet_module_names'
+        if which in ('content_view_puppet_modules', 'content_view_versions',
+                'publish', 'available_puppet_module_names'):
+            return '{0}/{1}'.format(
+                super(ContentView, self).path(which='this'),
+                which
+            )
         return super(ContentView, self).path()
 
     def publish(self):

--- a/tests/robottelo/test_entities.py
+++ b/tests/robottelo/test_entities.py
@@ -48,18 +48,14 @@ class PathTestCase(TestCase):
 
     @data(
         (entities.ActivationKey, '/activation_keys', 'releases'),
+        (entities.ContentView, '/content_views', 'available_puppet_module_names'),  # flake8:noqa pylint:disable=C0301
+        (entities.ContentView, '/content_views', 'content_view_puppet_modules'),  # flake8:noqa pylint:disable=C0301
         (entities.ContentView, '/content_views', 'content_view_versions'),
         (entities.ContentView, '/content_views', 'publish'),
-        (entities.ContentView, '/content_views',
-         'available_puppet_module_names'),
-        (entities.ContentView, '/content_views',
-         'content_view_puppet_modules'),
         (entities.ContentViewVersion, '/content_view_versions', 'promote'),
+        (entities.Organization, '/organizations', 'subscriptions/delete_manifest'),  # flake8:noqa pylint:disable=C0301
+        (entities.Organization, '/organizations', 'subscriptions/refresh_manifest'),  # flake8:noqa pylint:disable=C0301
         (entities.Organization, '/organizations', 'subscriptions/upload'),
-        (entities.Organization, '/organizations',
-         'subscriptions/delete_manifest'),
-        (entities.Organization, '/organizations',
-         'subscriptions/refresh_manifest'),
         (entities.Repository, '/repositories', 'sync'),
         (entities.Repository, '/repositories', 'upload_content'),
     )
@@ -87,18 +83,18 @@ class PathTestCase(TestCase):
 
     @data(
         (entities.ActivationKey, 'releases'),
-        (entities.ContentView, 'content_view_versions'),
-        (entities.ContentView, 'publish'),
         (entities.ContentView, 'available_puppet_module_names'),
         (entities.ContentView, 'content_view_puppet_modules'),
+        (entities.ContentView, 'content_view_versions'),
+        (entities.ContentView, 'publish'),
         (entities.ContentViewVersion, 'promote'),
-        (entities.Organization, 'this'),
-        (entities.Organization, 'subscriptions/upload'),
+        (entities.ForemanTask, 'this'),
         (entities.Organization, 'subscriptions/delete_manifest'),
         (entities.Organization, 'subscriptions/refresh_manifest'),
+        (entities.Organization, 'subscriptions/upload'),
+        (entities.Organization, 'this'),
         (entities.Repository, 'sync'),
         (entities.Repository, 'upload_content'),
-        (entities.ForemanTask, 'this'),
         (entities.System, 'this'),
     )
     @unpack


### PR DESCRIPTION
Reduce the amount of duplicate code used to implement method `ContentView.path`.
Make the relevant tests easier to read, and alphabetically sort the relevant
test's data.
