### PR TITLE
Initial proposal to differentiate sam only and sat only tests

### DIFF
--- a/robottelo.properties.sample
+++ b/robottelo.properties.sample
@@ -10,7 +10,8 @@ server.hostname=
 
 server.ssh.key_private=/home/whoami/.ssh/id_hudson_dsa
 server.ssh.username=root
-project=foreman
+# Enter only 'sat' for Satellite and 'sam' for SAM 
+project=sat
 locale=en_US.UTF-8
 remote=0
 smoke=0


### PR DESCRIPTION
Now tests can use decorators to run/skip tests basead on server modes:
- runIf('sam') - runs only on sam server
- runIf('sat') - runs only on sat server
- no decoractor - runs on all server modes
