### PR TITLE
Improve requests wrapper

### DIFF
--- a/robottelo/api/client.py
+++ b/robottelo/api/client.py
@@ -42,17 +42,26 @@ def _content_type_is_json(kwargs):
     :rtype: bool
 
     """
-    return kwargs['headers']['content-type'].lower() == 'application/json'
+    if 'headers' in kwargs and 'content-type' in kwargs['headers']:
+        return kwargs['headers']['content-type'].lower() == 'application/json'
+    else:
+        return False
 
 
 def _set_content_type(kwargs):
     """If the 'content-type' header is unset, set it to 'applcation/json'.
+
+    The 'content-type' will not be set if doing a file upload as requests will
+    automatically set it.
 
     :param dict kwargs: The keyword args supplied to :func:`request` or one of
         the convenience functions like it.
     :return: Nothing. ``kwargs`` is modified in-place.
 
     """
+    if 'files' in kwargs:
+        return  # requests will automatically set content-type
+
     headers = kwargs.pop('headers', {})
     headers.setdefault('content-type', 'application/json')
     kwargs['headers'] = headers
@@ -195,8 +204,8 @@ def _call_requests_delete(url, **kwargs):
 def request(method, url, **kwargs):
     """A wrapper for ``requests.request``."""
     _set_content_type(kwargs)
-    if _content_type_is_json(kwargs):
-        kwargs['data'] = json.dumps(kwargs.pop('data', {}))
+    if _content_type_is_json(kwargs) and kwargs.get('data') is not None:
+        kwargs['data'] = json.dumps(kwargs['data'])
     _log_request(method, url, kwargs)
     response = _call_requests_request(method, url, **kwargs)
     _log_response(response)
@@ -206,8 +215,8 @@ def request(method, url, **kwargs):
 def head(url, **kwargs):
     """A wrapper for ``requests.head``."""
     _set_content_type(kwargs)
-    if _content_type_is_json(kwargs):
-        kwargs['data'] = json.dumps(kwargs.pop('data', {}))
+    if _content_type_is_json(kwargs) and kwargs.get('data') is not None:
+        kwargs['data'] = json.dumps(kwargs['data'])
     _log_request('HEAD', url, kwargs)
     response = _call_requests_head(url, **kwargs)
     _log_response(response)
@@ -217,8 +226,8 @@ def head(url, **kwargs):
 def get(url, **kwargs):
     """A wrapper for ``requests.get``."""
     _set_content_type(kwargs)
-    if _content_type_is_json(kwargs):
-        kwargs['data'] = json.dumps(kwargs.pop('data', {}))
+    if _content_type_is_json(kwargs) and kwargs.get('data') is not None:
+        kwargs['data'] = json.dumps(kwargs['data'])
     _log_request('GET', url, kwargs)
     response = _call_requests_get(url, **kwargs)
     _log_response(response)
@@ -228,7 +237,7 @@ def get(url, **kwargs):
 def post(url, data=None, **kwargs):
     """A wrapper for ``requests.post``."""
     _set_content_type(kwargs)
-    if _content_type_is_json(kwargs):
+    if _content_type_is_json(kwargs) and data is not None:
         data = json.dumps(data)
     _log_request('POST', url, kwargs, data)
     response = _call_requests_post(url, data, **kwargs)
@@ -239,7 +248,7 @@ def post(url, data=None, **kwargs):
 def put(url, data=None, **kwargs):
     """A wrapper for ``requests.put``. Sends a PUT request."""
     _set_content_type(kwargs)
-    if _content_type_is_json(kwargs):
+    if _content_type_is_json(kwargs) and data is not None:
         data = json.dumps(data)
     _log_request('PUT', url, kwargs, data)
     response = _call_requests_put(url, data, **kwargs)
@@ -250,7 +259,7 @@ def put(url, data=None, **kwargs):
 def patch(url, data=None, **kwargs):
     """A wrapper for ``requests.patch``. Sends a PATCH request."""
     _set_content_type(kwargs)
-    if _content_type_is_json(kwargs):
+    if _content_type_is_json(kwargs) and data is not None:
         data = json.dumps(data)
     _log_request('PATCH', url, kwargs, data)
     response = _call_requests_patch(url, data, **kwargs)
@@ -261,8 +270,8 @@ def patch(url, data=None, **kwargs):
 def delete(url, **kwargs):
     """A wrapper for ``requests.delete``. Sends a DELETE request."""
     _set_content_type(kwargs)
-    if _content_type_is_json(kwargs):
-        kwargs['data'] = json.dumps(kwargs.pop('data', {}))
+    if _content_type_is_json(kwargs) and kwargs.get('data') is not None:
+        kwargs['data'] = json.dumps(kwargs['data'])
     _log_request('DELETE', url, kwargs)
     response = _call_requests_delete(url, **kwargs)
     _log_response(response)

--- a/robottelo/entities.py
+++ b/robottelo/entities.py
@@ -1033,14 +1033,12 @@ class Organization(
             data = {u'repository_url': repository_url}
 
         with open(path, 'rb') as manifest:
-            # FIXME used _call_requests_post because client.post makes
-            # requests.post fail. Also add tests for this helper function.
-            response = client._call_requests_post(
+            response = client.post(
                 self.path('subscriptions/upload'),
                 auth=get_server_credentials(),
                 verify=False,
                 data=data,
-                files={'content': manifest}
+                files={'content': manifest},
             )
         response.raise_for_status()
 
@@ -1097,9 +1095,7 @@ class Organization(
             received, ``synchronous is True`` and polling times out.
 
         """
-        # FIXME used _call_requests_put because client.put makes
-        # requests.put fail. Also add tests for this helper function.
-        response = client._call_requests_put(
+        response = client.put(
             self.path('subscriptions/refresh_manifest'),
             auth=get_server_credentials(),
             verify=False,

--- a/tests/foreman/api/test_repository_v2.py
+++ b/tests/foreman/api/test_repository_v2.py
@@ -347,7 +347,7 @@ class RepositoriesTestCase(TestCase):
         """
         # Create a repository and upload an RPM file.
         attrs = entities.Repository(url=FAKE_1_YUM_REPO).create()
-        response = client._call_requests_post(  # FIXME: use `client.post`
+        response = client.post(
             entities.Repository(id=attrs['id']).path(which='upload_content'),
             {},
             auth=get_server_credentials(),


### PR DESCRIPTION
Make the client does not set the content-type header when doing file
uploads.
Does not call json.dumps if data is None. None means that does not want
to send any data, but if the dumps is called it will be converted to
equivalent null on JavaScript and this make Satellite server break.

This also makes the test_positive_delete_1 added by #1367 pass.
