### PR TITLE
Fix some sphinx warnings

### DIFF
--- a/docs/api/tests.foreman.api.rst
+++ b/docs/api/tests.foreman.api.rst
@@ -5,13 +5,6 @@
     :members:
     :undoc-members:
 
-:mod:`tests.foreman.api.test_activationkey`
--------------------------------------------
-
-.. automodule:: tests.foreman.api.test_activationkey
-    :members:
-    :undoc-members:
-
 :mod:`tests.foreman.api.test_activationkey_v2`
 ----------------------------------------------
 
@@ -100,13 +93,6 @@
 --------------------------------------------
 
 .. automodule:: tests.foreman.api.test_multiple_paths
-    :members:
-    :undoc-members:
-
-:mod:`tests.foreman.api.test_org`
----------------------------------
-
-.. automodule:: tests.foreman.api.test_org
     :members:
     :undoc-members:
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -97,6 +97,7 @@ nitpick_ignore = [
     ('py:obj', 'bool'),
     ('py:obj', 'dict'),
     ('py:obj', 'int'),
+    ('py:obj', 'list'),
     ('py:obj', 'sequence'),
     ('py:obj', 'str'),
     ('py:obj', 'tuple'),


### PR DESCRIPTION
Do not include non-existent modules in the API documentation. Allow the word
"list" to be used as a data type.
