### PR TITLE
Fix CLI tests

### DIFF
--- a/robottelo/common/constants.py
+++ b/robottelo/common/constants.py
@@ -44,15 +44,14 @@ OPERATING_SYSTEMS = [
 ]
 
 TEMPLATE_TYPES = [
-    'PXEGrub',
-    'PXELinux',
-    'ZTP',
     'finish',
     'iPXE',
     'provision',
+    'PXEGrub',
+    'PXELinux',
     'script',
-    'snippet',
     'user_data',
+    'ZTP'
 ]
 
 #       NOTE:- Below unique filter key's are used for select-item box

--- a/tests/foreman/cli/test_contentviews.py
+++ b/tests/foreman/cli/test_contentviews.py
@@ -898,9 +898,12 @@ class TestContentView(CLITestCase):
         result = ContentView.info({u'id': new_cv['id']})
         self.assertEqual(result.return_code, 0, "ContentView was not found")
         self.assertEqual(len(result.stderr), 0, "No error was expected")
-        self.assertEqual(result.stdout['environments'][0]['id'],
-                         env1['id'],
-                         "Promotion of version not successful to the env")
+
+        environment = {
+            'id': env1['id'],
+            'name': env1['name'],
+        }
+        self.assertIn(environment, result.stdout['environments'])
 
     @unittest.skip(NOT_IMPLEMENTED)
     def test_cv_promote_rh_custom_spin(self):

--- a/tests/foreman/cli/test_domain.py
+++ b/tests/foreman/cli/test_domain.py
@@ -2,14 +2,15 @@
 # vim: ts=4 sw=4 expandtab ai
 """Test class for Domain  CLI"""
 
-from ddt import data
 from robottelo import orm
 from robottelo.cli.domain import Domain
 from robottelo.cli.factory import make_domain, CLIFactoryError
+from robottelo.common.decorators import data
 from robottelo.test import MetaCLITestCase
 
 
 class TestDomain(MetaCLITestCase):
+    """Domain CLI tests"""
 
     factory = make_domain
     factory_obj = Domain
@@ -151,8 +152,12 @@ class TestDomain(MetaCLITestCase):
         # check - parameter set
         result = Domain.info({'id': domain['id']})
         self.assertEqual(result.return_code, 0)
-        self.assertEqual(result.stdout['parameters'][options['name']],
-                         options['value'])
+
+        parameter = {
+            # Sattelite applies lower to parameter's name
+            options['name'].lower(): options['value'],
+        }
+        self.assertDictEqual(parameter, result.stdout['parameters'])
 
     @data(
         {'name': 'white spaces %s' % orm.StringField().get_value(),


### PR DESCRIPTION
Update TEMPLATE_TYPES constant with the values returned by
api/v2/template_kinds.
Better check promotion of a content view version on test_cv_promote_rh
Apply lower before checking for a domain's parameter name on
test_positive_set_parameter to match what satellite saves on db
Use robottelo's data decorator on cli test_domain module.
