### PR TITLE
Make this work on RHEL6

### DIFF
--- a/tests/foreman/cli/test_activationkey.py
+++ b/tests/foreman/cli/test_activationkey.py
@@ -1272,7 +1272,7 @@ class TestActivationKey(CLITestCase):
         )
         self.assertEqual(
             result.stdout['name'], name,
-            u"Activation key names don't not match {} != {}".format(
+            u"Activation key names don't not match {0} != {1}".format(
                 result.stdout['name'], name
             )
         )


### PR DESCRIPTION
```
>>> print u"Activation key names don't not match {} != {}".format('a', 'b')
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
ValueError: zero length field name in format
>>> print u"Activation key names don't not match {0} != {1}".format('a', 'b')
Activation key names don't not match a != b
```
