### PR TITLE
Org & Loc tests UI: Dependent Entities use now APIs

### DIFF
--- a/robottelo/common/helpers.py
+++ b/robottelo/common/helpers.py
@@ -195,12 +195,13 @@ def generate_strings_list(len1=8):
     """
     Generates a list of all the input strings
     """
-    str_types = [STR.alpha,
-                 STR.numeric,
-                 STR.alphanumeric,
-                 STR.html,
-                 STR.latin1,
-                 STR.utf8]
+    str_types = ["alpha",
+                 "numeric",
+                 "alphanumeric",
+                 "latin1",
+                 "utf8",
+                 "cjk",
+                 "html"]
     str_list = []
     for str_type in str_types:
         string1 = FauxFactory.generate_string(str_type, len1)

--- a/robottelo/entities.py
+++ b/robottelo/entities.py
@@ -679,7 +679,7 @@ class HostGroupClasses(orm.Entity):
         api_path = 'api/v2/hostgroups/:hostgroup_id/puppetclass_ids'
 
 
-class HostGroup(orm.Entity):
+class HostGroup(orm.Entity, factory.EntityFactoryMixin):
     """A representation of a Host Group entity."""
     name = orm.StringField(required=True)
     parent = orm.OneToOneField('HostGroup', null=True)
@@ -862,7 +862,7 @@ class Location(orm.Entity, factory.EntityFactoryMixin):
         api_path = 'api/v2/locations'
 
 
-class Media(orm.Entity):
+class Media(orm.Entity, factory.EntityFactoryMixin):
     """A representation of a Media entity."""
     # Name of media
     # validator: String


### PR DESCRIPTION
The dependent entities now use APIs to create them.

Now `ui/test_location` and `ui/test_org` now uses `FauxFactory`
module for generate_string, generate_ipaddr, generate_email.
