### PR TITLE
RepositorySet-API: Added the functionality to enable RedHat Repos.

### DIFF
--- a/tests/robottelo/test_entities.py
+++ b/tests/robottelo/test_entities.py
@@ -57,6 +57,10 @@ class PathTestCase(TestCase):
         (entities.Organization, '/organizations', 'subscriptions/refresh_manifest'),  # flake8:noqa pylint:disable=C0301
         (entities.Organization, '/organizations', 'subscriptions/upload'),
         (entities.Organization, '/organizations', 'sync_plans'),
+        (entities.Organization, '/organizations', 'products'),
+        (entities.Product, '/products', 'repository_sets'),
+        (entities.Product, '/products', 'repository_sets/2396/enable'),
+        (entities.Product, '/products', 'repository_sets/2396/disable'),
         (entities.Repository, '/repositories', 'sync'),
         (entities.Repository, '/repositories', 'upload_content'),
     )
@@ -94,6 +98,8 @@ class PathTestCase(TestCase):
         (entities.Organization, 'subscriptions/refresh_manifest'),
         (entities.Organization, 'subscriptions/upload'),
         (entities.Organization, 'sync_plans'),
+        (entities.Organization, 'products'),
+        (entities.Product, 'repository_sets'),
         (entities.Organization, 'this'),
         (entities.Repository, 'sync'),
         (entities.Repository, 'upload_content'),


### PR DESCRIPTION
Added `list_rhproducts` function to list all the RedHat Products
in a given Organization.

RH Products have varying Id's depending upon various other custom
products, hence we use the product-label which is a static value
to fetch the RH Product's ID in `fetch_rhproduct_id` function.

RH Reposets too have varying ID's hence we use reposet-label which
is a static value to fetch the RH Reposet's ID in `fetch_reposet_id`
functio.

Also RH Repositories first need to be enabled , so that they can be
synced.
`enable_repo` and `disable_repo` functions requires the
`reposet_id`, `basearch` and `releasever` to enable, disable the
repositories.
