### PR TITLE
Increase task polling timeout

### DIFF
--- a/robottelo/orm.py
+++ b/robottelo/orm.py
@@ -20,7 +20,7 @@ class TaskTimeout(Exception):
     """Indicates that a task did not finish before the timout limit."""
 
 
-def _poll_task(task_id, poll_rate=5, timeout=120, auth=None):
+def _poll_task(task_id, poll_rate=5, timeout=180, auth=None):
     """Implement :meth:`robottelo.entities.ForemanTask.poll`.
 
     :meth:`robottelo.entities.ForemanTask.poll` calls this function, as does


### PR DESCRIPTION
Now the timeout of foreman tasks are being handled correctly. Because
this is better to increase the task timeout to avoid failing when the
task still running.
