### PR TITLE
Fix typos in UITestCase and valid_strings

### DIFF
--- a/robottelo/test.py
+++ b/robottelo/test.py
@@ -119,8 +119,8 @@ class UITestCase(TestCase):
             cls.display.start()
             cls.logger.debug(
                 'Virtual display started (pid=%d, display="%s")',
-                cls.window_manager.pid,
-                cls.window_manager.display
+                cls.display.pid,
+                cls.display.display
             )
 
             window_manager_cmd = conf.properties.get(

--- a/tests/foreman/ui/test_user.py
+++ b/tests/foreman/ui/test_user.py
@@ -34,7 +34,7 @@ def valid_strings(len1=100):
         u'նորօգտվող-{0}'.format(FauxFactory.generate_string("alpha", 2)),
         u'新用戶-{0}'.format(FauxFactory.generate_string("alpha", 2)),
         u'новогопользоват-{0}'.format(FauxFactory.generate_string("alpha", 2)),
-        u'uusikäyttäjä-{0}'.fromat(FauxFactory.generate_string("alpha", 2)),
+        u'uusikäyttäjä-{0}'.format(FauxFactory.generate_string("alpha", 2)),
         u'νέοςχρήστης-{0}'.format(FauxFactory.generate_string("alpha", 2)),
     ]
 


### PR DESCRIPTION
Have passed a typo in the previous PR.

I have also fixed a typo in ui.test_user module.
