### PR TITLE
Updated some UI modules to use api's for dependent entities

### DIFF
--- a/robottelo/entities.py
+++ b/robottelo/entities.py
@@ -1213,7 +1213,8 @@ class Product(
         api_path = 'katello/api/v2/products'
 
 
-class PartitionTable(orm.Entity):
+class PartitionTable(orm.Entity, orm.EntityReadMixin, orm.EntityDeleteMixin,
+        factory.EntityFactoryMixin):
     """A representation of a Partition Table entity."""
     name = orm.StringField(required=True)
     layout = orm.StringField(required=True)

--- a/tests/foreman/ui/test_computeresource.py
+++ b/tests/foreman/ui/test_computeresource.py
@@ -89,7 +89,7 @@ class ComputeResource(UITestCase):
         FauxFactory.generate_string('utf8', 255)
     )
     def test_create_resource_3(self, description):
-        """@Test: Create a new libvirt Compute Resource with 255 char description.
+        """@Test: Create libvirt Compute Resource with 255 char description.
 
         @Feature: Compute Resource - Create with long description.
 
@@ -134,7 +134,7 @@ class ComputeResource(UITestCase):
     @attr('ui', 'resource', 'implemented')
     @data(*generate_strings_list(len1=256))
     def test_create_resource_negative_2(self, description):
-        """@Test: Create a new libvirt Compute Resource with 256 char description.
+        """@Test: Create libvirt Compute Resource with 256 char description.
 
         @Feature: Compute Resource - Create with long description.
 
@@ -156,7 +156,8 @@ class ComputeResource(UITestCase):
                 common_locators["haserror"])
             self.assertIsNotNone(error)
 
-    def test_create_resource_negative_3(self):
+    @data("", "  ")
+    def test_create_resource_negative_3(self, name):
         """@Test: Create a new libvirt Compute Resource with whitespace
 
         @Feature: Compute Resource - Create
@@ -164,26 +165,7 @@ class ComputeResource(UITestCase):
         @Assert: A libvirt Compute Resource is not created
 
         """
-        name = "   "
-        libvirt_url = "qemu+tcp://%s:16509/system"
-        provider_type = FOREMAN_PROVIDERS['libvirt']
-        url = (libvirt_url % conf.properties['main.server.hostname'])
-        with Session(self.browser) as session:
-            make_resource(session, name=name,
-                          provider_type=provider_type, url=url)
-            error = session.nav.wait_until_element(
-                common_locators["name_haserror"])
-            self.assertIsNotNone(error)
 
-    def test_create_resource_negative_4(self):
-        """@Test: Create a new libvirt Compute Resource with name blank
-
-        @Feature: Compute Resource - Create
-
-        @Assert: A libvirt Compute Resource is not created
-
-        """
-        name = ""
         libvirt_url = "qemu+tcp://%s:16509/system"
         provider_type = FOREMAN_PROVIDERS['libvirt']
         url = (libvirt_url % conf.properties['main.server.hostname'])

--- a/tests/foreman/ui/test_config_groups.py
+++ b/tests/foreman/ui/test_config_groups.py
@@ -82,7 +82,8 @@ class ConfigGroups(UITestCase):
             search = self.configgroups.search(name)
             self.assertIsNone(search)
 
-    def test_create_negative_2(self):
+    @data("", "  ")
+    def test_create_negative_2(self, name):
         """@Test: Create new config-groups with blank name
 
         @Feature: Config-Groups - Negative Create
@@ -90,22 +91,7 @@ class ConfigGroups(UITestCase):
         @Assert: Config-Groups is not created
 
         """
-        name = ""
-        with Session(self.browser) as session:
-            make_config_groups(session, name=name)
-            error = session.nav.wait_until_element(
-                common_locators["name_haserror"])
-            self.assertIsNotNone(error)
 
-    def test_create_negative_3(self):
-        """@Test: Create new config-groups with blank name
-
-        @Feature: Config-Groups - Negative Create
-
-        @Assert: Config-Groups is not created
-
-        """
-        name = "    "
         with Session(self.browser) as session:
             make_config_groups(session, name=name)
             error = session.nav.wait_until_element(

--- a/tests/foreman/ui/test_domain.py
+++ b/tests/foreman/ui/test_domain.py
@@ -132,30 +132,16 @@ class Domain(UITestCase):
             element = self.domain.search(description, timeout=5)
             self.assertIsNone(element)
 
-    def test_negative_create_domain_2(self):
-        """@Test: Negative create a domain with blank name
+    @data("", "  ")
+    def test_negative_create_domain_2(self, name):
+        """@Test: Create domain with whitespace and blank in name
 
         @Feature: Domain - Negative Create
 
         @Assert: Domain is not created
 
         """
-        domain_name = description = ""
-        with Session(self.browser) as session:
-            make_domain(session, name=domain_name, description=description)
-            error = session.nav.wait_until_element(
-                common_locators["name_haserror"])
-            self.assertIsNotNone(error)
-
-    def test_negative_create_domain_3(self):
-        """@Test: Negative create a domain with whitespace name
-
-        @Feature: Domain - Negative Create
-
-        @Assert: Domain is not created
-
-        """
-        domain_name = description = "   "
+        domain_name = description = name
         with Session(self.browser) as session:
             make_domain(session, name=domain_name, description=description)
             error = session.nav.wait_until_element(

--- a/tests/foreman/ui/test_environment.py
+++ b/tests/foreman/ui/test_environment.py
@@ -34,10 +34,12 @@ class Environment(UITestCase):
                 make_loc(session, name=Environment.loc_name)
 
     @attr('ui', 'environment', 'implemented')
-    @data({'name': FauxFactory.generate_string('alpha', 8)},
-          {'name': FauxFactory.generate_string('numeric', 8)},
-          {'name': FauxFactory.generate_string('alphanumeric', 8)})
-    def test_create_env_positive_1(self, testdata):
+    @data(
+        FauxFactory.generate_string('alpha', 8),
+        FauxFactory.generate_string('numeric', 8),
+        FauxFactory.generate_string('alphanumeric', 8)
+    )
+    def test_create_env_positive_1(self, name):
         """@Test: Create new environment
 
         @Feature: Environment - Positive Create
@@ -45,17 +47,18 @@ class Environment(UITestCase):
         @Assert: Environment is created
 
         """
-        name = testdata['name']
         with Session(self.browser) as session:
             make_env(session, name=name)
             search = self.environment.search(name)
             self.assertIsNotNone(search)
 
     @attr('ui', 'environment', 'implemented')
-    @data({'name': FauxFactory.generate_string('alpha', 255)},
-          {'name': FauxFactory.generate_string('numeric', 255)},
-          {'name': FauxFactory.generate_string('alphanumeric', 255)})
-    def test_create_env_positive_2(self, testdata):
+    @data(
+        FauxFactory.generate_string('alpha', 255),
+        FauxFactory.generate_string('numeric', 255),
+        FauxFactory.generate_string('alphanumeric', 255)
+    )
+    def test_create_env_positive_2(self, name):
         """@Test: Create new environment with 255 chars
 
         @Feature: Environment - Positive Create
@@ -63,17 +66,18 @@ class Environment(UITestCase):
         @Assert: Environment is created
 
         """
-        name = testdata['name']
         with Session(self.browser) as session:
             make_env(session, name=name)
             search = self.environment.search(name)
             self.assertIsNotNone(search)
 
     @attr('ui', 'environment', 'implemented')
-    @data({'name': FauxFactory.generate_string('alpha', 256)},
-          {'name': FauxFactory.generate_string('numeric', 256)},
-          {'name': FauxFactory.generate_string('alphanumeric', 256)})
-    def test_create_env_negative_1(self, testdata):
+    @data(
+        FauxFactory.generate_string('alpha', 256),
+        FauxFactory.generate_string('numeric', 256),
+        FauxFactory.generate_string('alphanumeric', 256)
+    )
+    def test_create_env_negative_1(self, name):
         """@Test: Create new environment with 256 chars
 
         @Feature: Environment - Negative Create
@@ -81,36 +85,20 @@ class Environment(UITestCase):
         @Assert: Environment is not created
 
         """
-        name = testdata['name']
         with Session(self.browser) as session:
             make_env(session, name=name)
             search = self.environment.search(name)
             self.assertIsNone(search)
 
-    def test_create_env_negative_2(self):
-        """@Test: Create new environment with blank name
+    @data("", "  ")
+    def test_create_env_negative_2(self, name):
+        """@Test: Create new environment with blank and whitespace in name
 
         @Feature: Environment - Negative Create
 
         @Assert: Environment is not created
 
         """
-        name = ""
-        with Session(self.browser) as session:
-            make_env(session, name=name)
-            error = session.nav.wait_until_element(
-                common_locators["name_haserror"])
-            self.assertIsNotNone(error)
-
-    def test_create_env_negative_3(self):
-        """@Test: Create new environment with whitespace name
-
-        @Feature: Environment - Negative Create
-
-        @Assert: Environment is not created
-
-        """
-        name = "   "
         with Session(self.browser) as session:
             make_env(session, name=name)
             error = session.nav.wait_until_element(
@@ -145,10 +133,12 @@ class Environment(UITestCase):
 
     @skip_if_bug_open('bugzilla', 1126033)
     @attr('ui', 'environment', 'implemented')
-    @data({'name': FauxFactory.generate_string('alpha', 8)},
-          {'name': FauxFactory.generate_string('numeric', 8)},
-          {'name': FauxFactory.generate_string('alphanumeric', 8)})
-    def test_remove_env(self, testdata):
+    @data(
+        FauxFactory.generate_string('alpha', 8),
+        FauxFactory.generate_string('numeric', 8),
+        FauxFactory.generate_string('alphanumeric', 8)
+    )
+    def test_remove_env(self, name):
         """@Test: Delete an environment
 
         @Feature: Environment - Positive Delete
@@ -156,7 +146,6 @@ class Environment(UITestCase):
         @Assert: Environment is deleted
 
         """
-        name = testdata['name']
         with Session(self.browser) as session:
             make_env(session, name=name)
             self.environment.delete(name, really=True)

--- a/tests/foreman/ui/test_location.py
+++ b/tests/foreman/ui/test_location.py
@@ -11,14 +11,12 @@ from robottelo import entities
 from robottelo.common import conf
 from robottelo.common.decorators import data, skip_if_bug_open
 from robottelo.common.helpers import generate_strings_list, get_data_file
-from robottelo.common.constants import OS_TEMPLATE_DATA_FILE
+from robottelo.common.constants import (
+    OS_TEMPLATE_DATA_FILE, INSTALL_MEDIUM_URL)
 from robottelo.test import UITestCase
 from robottelo.ui.factory import make_loc, make_templates
 from robottelo.ui.locators import common_locators, tab_locators, locators
 from robottelo.ui.session import Session
-
-
-URL = "http://mirror.fakeos.org/%s/$major.$minor/os/$arch"
 
 
 @ddt
@@ -426,7 +424,7 @@ class Location(UITestCase):
         """
         strategy, value = common_locators["entity_deselect"]
         loc_name = FauxFactory.generate_string("alpha", 8)
-        path = URL % FauxFactory.generate_string("alpha", 6)
+        path = INSTALL_MEDIUM_URL % FauxFactory.generate_string("alpha", 6)
         medium = entities.Media(
             name=medium_name,
             path=path,
@@ -729,7 +727,7 @@ class Location(UITestCase):
         strategy, value = common_locators["entity_select"]
         strategy1, value1 = common_locators["entity_deselect"]
         loc_name = FauxFactory.generate_string("alpha", 8)
-        path = URL % FauxFactory.generate_string("alpha", 6)
+        path = INSTALL_MEDIUM_URL % FauxFactory.generate_string("alpha", 6)
         medium = entities.Media(
             name=medium_name,
             path=path,

--- a/tests/foreman/ui/test_medium.py
+++ b/tests/foreman/ui/test_medium.py
@@ -4,15 +4,14 @@
 
 from ddt import ddt
 from fauxfactory import FauxFactory
+from robottelo import entities
+from robottelo.common.constants import INSTALL_MEDIUM_URL
 from robottelo.common.decorators import data
 from robottelo.common.helpers import generate_strings_list
 from robottelo.test import UITestCase
-from robottelo.ui.factory import (make_org, make_loc,
-                                  make_media)
+from robottelo.ui.factory import make_media
 from robottelo.ui.locators import common_locators
 from robottelo.ui.session import Session
-
-URL = "http://mirror.fakeos.org/%s/$major.$minor/os/$arch"
 
 
 @ddt
@@ -21,16 +20,21 @@ class Medium(UITestCase):
 
     org_name = None
     loc_name = None
+    org_id = None
+    loc_id = None
 
     def setUp(self):
         super(Medium, self).setUp()
         #  Make sure to use the Class' org_name instance
         if (Medium.org_name is None and Medium.loc_name is None):
-            Medium.org_name = FauxFactory.generate_string("alpha", 8)
-            Medium.loc_name = FauxFactory.generate_string("alpha", 8)
-            with Session(self.browser) as session:
-                make_org(session, org_name=Medium.org_name)
-                make_loc(session, name=Medium.loc_name)
+            org_name = FauxFactory.generate_string("alpha", 8)
+            loc_name = FauxFactory.generate_string("alpha", 8)
+            org_attrs = entities.Organization(name=org_name).create()
+            loc_attrs = entities.Location(name=loc_name).create()
+            Medium.org_name = org_attrs['name']
+            Medium.org_id = org_attrs['id']
+            Medium.loc_name = loc_attrs['name']
+            Medium.loc_id = loc_attrs['id']
 
     @data(*generate_strings_list(len1=4))
     def test_positive_create_medium_1(self, name):
@@ -42,7 +46,7 @@ class Medium(UITestCase):
 
         """
 
-        path = URL % FauxFactory.generate_string("alpha", 6)
+        path = INSTALL_MEDIUM_URL % FauxFactory.generate_string("alpha", 6)
         os_family = "Red Hat"
         with Session(self.browser) as session:
             make_media(session, name=name, path=path, os_family=os_family)
@@ -64,7 +68,7 @@ class Medium(UITestCase):
 
         """
 
-        path = URL % FauxFactory.generate_string("alpha", 6)
+        path = INSTALL_MEDIUM_URL % FauxFactory.generate_string("alpha", 6)
         os_family = "Red Hat"
         with Session(self.browser) as session:
             make_media(session, name=name,
@@ -81,7 +85,7 @@ class Medium(UITestCase):
         """
 
         name = FauxFactory.generate_string("alpha", 256)
-        path = URL % FauxFactory.generate_string("alpha", 6)
+        path = INSTALL_MEDIUM_URL % name
         os_family = "Red Hat"
         with Session(self.browser) as session:
             make_media(session, name=name, path=path, os_family=os_family)
@@ -89,8 +93,9 @@ class Medium(UITestCase):
                                  (common_locators["name_haserror"]))
             self.assertIsNone(self.medium.search(name))
 
-    def test_negative_create_medium_2(self):
-        """@Test: Create a new install media with whitespace in name
+    @data("", "  ")
+    def test_negative_create_medium_2(self, name):
+        """@Test: Create a new install media with blank and whitespace in name
 
         @Feature:  Media - Negative Create
 
@@ -98,25 +103,7 @@ class Medium(UITestCase):
 
         """
 
-        name = " "
-        path = URL % FauxFactory.generate_string("alpha", 6)
-        os_family = "Red Hat"
-        with Session(self.browser) as session:
-            make_media(session, name=name, path=path, os_family=os_family)
-            self.assertIsNotNone(self.medium.wait_until_element
-                                 (common_locators["name_haserror"]))
-
-    def test_negative_create_medium_3(self):
-        """@Test: Create a new install media with blank name
-
-        @Feature:  Media - Negative Create
-
-        @Assert: Media is not created
-
-        """
-
-        name = ""
-        path = URL % FauxFactory.generate_string("alpha", 6)
+        path = INSTALL_MEDIUM_URL % FauxFactory.generate_string("alpha", 6)
         os_family = "Red Hat"
         with Session(self.browser) as session:
             make_media(session, name=name, path=path, os_family=os_family)
@@ -133,7 +120,7 @@ class Medium(UITestCase):
         """
 
         name = FauxFactory.generate_string("alpha", 6)
-        path = URL % FauxFactory.generate_string("alpha", 6)
+        path = INSTALL_MEDIUM_URL % name
         os_family = "Red Hat"
         with Session(self.browser) as session:
             make_media(session, name=name, path=path, os_family=os_family)
@@ -171,7 +158,7 @@ class Medium(UITestCase):
 
         name = FauxFactory.generate_string("alpha", 6)
         new_name = FauxFactory.generate_string("alpha", 6)
-        path = URL % FauxFactory.generate_string("alpha", 6)
+        path = INSTALL_MEDIUM_URL % FauxFactory.generate_string("alpha", 6)
         os_family = "Red Hat"
         with Session(self.browser) as session:
             make_media(session, name=name, path=path, os_family=os_family)
@@ -190,7 +177,7 @@ class Medium(UITestCase):
 
         """
         name = FauxFactory.generate_string("alpha", 6)
-        path = URL % FauxFactory.generate_string("alpha", 6)
+        path = INSTALL_MEDIUM_URL % name
         os_family = "Red Hat"
         with Session(self.browser) as session:
             make_media(session, name=name, path=path, os_family=os_family)
@@ -210,8 +197,8 @@ class Medium(UITestCase):
         """
         name = FauxFactory.generate_string("alpha", 6)
         newname = FauxFactory.generate_string("alpha", 4)
-        path = URL % FauxFactory.generate_string("alpha", 6)
-        newpath = URL % FauxFactory.generate_string("alpha", 6)
+        path = INSTALL_MEDIUM_URL % name
+        newpath = INSTALL_MEDIUM_URL % newname
         os_family = "Red Hat"
         new_os_family = "Debian"
         with Session(self.browser) as session:

--- a/tests/foreman/ui/test_org.py
+++ b/tests/foreman/ui/test_org.py
@@ -858,7 +858,7 @@ class Org(UITestCase):
         path = URL % FauxFactory.generate_string("alpha", 6)
         medium = entities.Media(
             name=medium_name,
-            path=path,
+            media_path=path,
             os_family='Redhat',
         ).create()
         self.assertEqual(medium['name'], medium_name)


### PR DESCRIPTION
- Updated arch tests to use api to create OS
- Corrected indentation for few template tests
- Updated all usergroup tests to use fauxfactory and blocked tests with bz-id
- Updated subnet tests to create domain using api
- Updated OS tests to use apis to create partition_table, config_templates, arch, OS and media
- Updated all media tests to use media URL from Constants
- Using media URL from Constants for location tests
- Removed single value dict from test data
- Clubbed two negative create domain tests in one
- Clubbed two negative create config_group tests in one
- Clubbed two negative compute resource tests in one
