### PR TITLE
Port some old API tests for content views

### DIFF
--- a/tests/foreman/api/test_contentview_v2.py
+++ b/tests/foreman/api/test_contentview_v2.py
@@ -1,16 +1,12 @@
-"""Unit tests for the ``content_views`` paths.
-
-A full API reference for content views can be found here:
-http://theforeman.org/api/apidoc/v2/content_views.html
-
-"""
+"""Unit tests for the ``content_views`` paths."""
 from requests.exceptions import HTTPError
 from robottelo.api import client
 from robottelo.common.helpers import get_server_credentials
 from robottelo.common import decorators
 from robottelo.factory import FactoryError
-from robottelo import entities, orm
+from robottelo import entities
 from unittest import TestCase
+from fauxfactory import gen_utf8
 import ddt
 # (too many public methods) pylint: disable=R0904
 
@@ -147,7 +143,7 @@ class ContentViewUpdateTestCase(TestCase):
 
     @decorators.data(
         {'label': entities.ContentView.label.get_value()},  # Immutable.
-        {'name': orm.StringField(len=256).get_value()},
+        {'name': gen_utf8(256)},
     )
     def test_negative_update(self, attrs):
         """@Test: Update a content view and provide an invalid attribute.

--- a/tests/foreman/api/test_contentviews.py
+++ b/tests/foreman/api/test_contentviews.py
@@ -180,22 +180,6 @@ class TestContentView(APITestCase):
         @status: Manual
         """
 
-    def test_cv_promote_default_negative(self):
-        """
-        @test: attempt to promote a the default content views
-        @feature: Content Views
-        @assert: Default content views cannot be promoted
-        """
-        env = EnvironmentKatello()
-        created_env = ApiCrud.record_create_recursive(env)
-        task = ContentViewDefinition._meta.api_class.promote(
-            1,
-            created_env.id
-            )
-        self.assertIn(
-            'errors', task.json,
-            "Default cv shouldn't be promoted")
-
     @stubbed
     def test_cv_promote_badid_negative(self):
         """
@@ -212,27 +196,6 @@ class TestContentView(APITestCase):
         self.assertIn(
             'errors', task.json,
             "Invalid id shouldn't be promoted")
-
-    def test_cv_promote_badenvironment_negative(self):
-        """
-        @test: attempt to promote a content view using an invalid environment
-        @feature: Content Views
-        @assert: Content views cannot be promoted; handled gracefully
-        """
-        con_view = ApiCrud.record_create_recursive(ContentViewDefinition())
-        self.assertIntersects(data, con_view)
-        task = con_view._meta.api_class.publish(con_view)
-        task.poll(5, 100)  # poll every 5th second, max of 100 seconds
-        self.assertEqual('success', task.result())
-        published = ApiCrud.record_resolve(con_view)
-        task = published._meta.api_class.promote(
-            published.versions[0]['id'],
-            -1
-            )
-
-        self.assertIn(
-            'errors', task.json,
-            "Shouldn't be promoted to invalid env")
 
     # Content Views: publish
     # katello content definition publish --label=MyView

--- a/tests/foreman/api/test_contentviewversion_v2.py
+++ b/tests/foreman/api/test_contentviewversion_v2.py
@@ -1,0 +1,32 @@
+"""Unit tests for the ``content_view_versions`` paths."""
+from requests.exceptions import HTTPError
+from robottelo import entities
+from unittest import TestCase
+# (too many public methods) pylint: disable=R0904
+
+
+class CVVersionTestCase(TestCase):
+    """Tests for content view versions."""
+
+    def test_negative_promote_1(self):
+        """@Test: Promote the default content view version.
+
+        @Assert: The promotion fails.
+
+        @Feature: ContentViewVersion
+
+        """
+        env_id = entities.Environment().create()['id']
+        with self.assertRaises(HTTPError):
+            entities.ContentViewVersion(id=1).promote(env_id)
+
+    def test_negative_promote_2(self):
+        """@Test: Promote a content view version using an invalid environment.
+
+        @Assert: The promotion fails.
+
+        @Feature: ContentViewVersion
+
+        """
+        with self.assertRaises(HTTPError):
+            entities.ContentViewVersion(id=1).promote(-1)


### PR DESCRIPTION
Port all non-stubbed API tests for content views. Move those tests into either
`test_contentview_v2` or `test_contentviewversion_v2`.

Use FauxFactory to generate some random data instead of the orm fields.
