### PR TITLE
Drop custom error checking code

### DIFF
--- a/robottelo/entities.py
+++ b/robottelo/entities.py
@@ -878,7 +878,7 @@ class LifecycleEnvironment(
                 }
             ).json()['results']
             if len(query_results) != 1:
-                raise factory.FactoryError(
+                raise APIResponseError(
                     'Could not find the "Library" lifecycle environment for '
                     'organization {0}. Search returned {1} results.'
                     ''.format(self.organization, len(query_results))
@@ -1426,7 +1426,8 @@ class Product(
         return None
 
 
-class PartitionTable(orm.Entity, orm.EntityReadMixin, orm.EntityDeleteMixin,
+class PartitionTable(
+        orm.Entity, orm.EntityReadMixin, orm.EntityDeleteMixin,
         factory.EntityFactoryMixin):
     """A representation of a Partition Table entity."""
     name = orm.StringField(required=True)

--- a/tests/foreman/api/test_activationkey_v2.py
+++ b/tests/foreman/api/test_activationkey_v2.py
@@ -5,11 +5,11 @@ http://theforeman.org/api/apidoc/v2/activation_keys.html
 
 """
 from ddt import data, ddt
+from requests.exceptions import HTTPError
 from robottelo.api import client
 from robottelo.api.utils import status_code_error
 from robottelo.common.decorators import skip_if_bug_open
 from robottelo.common.helpers import get_server_credentials
-from robottelo.factory import FactoryError
 from robottelo import entities
 from robottelo.orm import IntegerField, StringField
 from unittest import TestCase
@@ -31,7 +31,7 @@ class ActivationKeysTestCase(TestCase):
         """
         try:
             attrs = entities.ActivationKey().create()
-        except FactoryError as err:
+        except HTTPError as err:
             self.fail(err)
         # Assert that it defaults to unlimited content host
         self.assertTrue(
@@ -57,7 +57,7 @@ class ActivationKeysTestCase(TestCase):
                 unlimited_content_hosts=False,
                 max_content_hosts=max_content_hosts,
             ).create()
-        except FactoryError as err:
+        except HTTPError as err:
             self.fail(err)
         # Assert that it defaults to limited content host...
         self.assertFalse(
@@ -90,7 +90,7 @@ class ActivationKeysTestCase(TestCase):
         """
         try:
             attrs = entities.ActivationKey(name=name).create()
-        except FactoryError as err:
+        except HTTPError as err:
             self.fail(err)
 
         # Fetch the activation key. Assert that initial values match.
@@ -120,7 +120,7 @@ class ActivationKeysTestCase(TestCase):
             entity_id = entities.ActivationKey(
                 description=description
             ).create()['id']
-        except FactoryError as err:
+        except HTTPError as err:
             self.fail(err)
 
         # Fetch the activation key. Assert that initial values match.
@@ -136,7 +136,7 @@ class ActivationKeysTestCase(TestCase):
         @Feature: ActivationKey
 
         """
-        with self.assertRaises(FactoryError):
+        with self.assertRaises(HTTPError):
             entities.ActivationKey(unlimited_content_hosts=False).create()
 
     @data(
@@ -153,7 +153,7 @@ class ActivationKeysTestCase(TestCase):
         @Feature: ActivationKey
 
         """
-        with self.assertRaises(FactoryError):
+        with self.assertRaises(HTTPError):
             entities.ActivationKey(
                 unlimited_content_hosts=False,
                 max_content_hosts=max_content_hosts
@@ -173,7 +173,7 @@ class ActivationKeysTestCase(TestCase):
         @Feature: ActivationKey
 
         """
-        with self.assertRaises(FactoryError):
+        with self.assertRaises(HTTPError):
             entities.ActivationKey(
                 unlimited_content_hosts=True,
                 max_content_hosts=max_content_hosts
@@ -197,7 +197,7 @@ class ActivationKeysTestCase(TestCase):
             activation_key = entities.ActivationKey(
                 id=entities.ActivationKey().create()['id']
             )
-        except FactoryError as err:
+        except HTTPError as err:
             self.fail(err)
 
         # Update the activation key.
@@ -239,7 +239,7 @@ class ActivationKeysTestCase(TestCase):
         """
         try:
             attrs = entities.ActivationKey().create()
-        except FactoryError as err:
+        except HTTPError as err:
             self.fail(err)
         path = entities.ActivationKey(id=attrs['id']).path()
 
@@ -323,7 +323,7 @@ class ActivationKeysTestCase(TestCase):
         """
         try:
             attrs = entities.ActivationKey().create()
-        except FactoryError as err:
+        except HTTPError as err:
             self.fail(err)
         path = entities.ActivationKey(id=attrs['id']).path(which='releases')
         response = client.get(
@@ -349,7 +349,7 @@ class ActivationKeysTestCase(TestCase):
         """
         try:
             attrs = entities.ActivationKey().create()
-        except FactoryError as err:
+        except HTTPError as err:
             self.fail(err)
         response = client.get(
             entities.ActivationKey(id=attrs['id']).path(which='releases'),

--- a/tests/foreman/api/test_contentview_v2.py
+++ b/tests/foreman/api/test_contentview_v2.py
@@ -3,7 +3,6 @@ from requests.exceptions import HTTPError
 from robottelo.api import client
 from robottelo.common.helpers import get_server_credentials
 from robottelo.common import decorators
-from robottelo.factory import FactoryError
 from robottelo import entities
 from unittest import TestCase
 from fauxfactory import gen_utf8
@@ -102,7 +101,7 @@ class ContentViewTestCase(TestCase):
         @Feature: ContentView
 
         """
-        with self.assertRaises(FactoryError):
+        with self.assertRaises(HTTPError):
             entities.ContentView(name=name).create()
 
 

--- a/tests/foreman/api/test_environment_v2.py
+++ b/tests/foreman/api/test_environment_v2.py
@@ -5,8 +5,8 @@ http://theforeman.org/api/apidoc/v2/environments.html
 
 """
 from fauxfactory import FauxFactory
+from requests.exceptions import HTTPError
 from robottelo.common import decorators
-from robottelo.factory import FactoryError
 from robottelo import entities
 from unittest import TestCase
 import ddt
@@ -61,5 +61,5 @@ class EnvironmentTestCase(TestCase):
             Name is alphanumeric and cannot contain spaces
 
         """
-        with self.assertRaises(FactoryError):
+        with self.assertRaises(HTTPError):
             entities.Environment(name=name).create()

--- a/tests/foreman/api/test_multiple_paths.py
+++ b/tests/foreman/api/test_multiple_paths.py
@@ -1,13 +1,14 @@
 """Data-driven unit tests for multiple paths."""
 from ddt import data, ddt
 from functools import partial
+from requests.exceptions import HTTPError
 from robottelo.api import client
 from robottelo.api.utils import status_code_error
 from robottelo.common import conf
 from robottelo.common.decorators import (
     bz_bug_is_open, run_only_on, skip_if_bug_open)
 from robottelo.common.helpers import get_server_credentials
-from robottelo import entities, factory
+from robottelo import entities
 from unittest import TestCase
 import httplib
 import logging
@@ -278,7 +279,7 @@ class EntityIdTestCase(TestCase):
             self.skipTest("Bugzilla bug 1127335 is open.""")
         try:
             attrs = entity().create()
-        except factory.FactoryError as err:
+        except HTTPError as err:
             self.fail(err)
         path = entity(id=attrs['id']).path()
         response = client.get(
@@ -379,7 +380,7 @@ class EntityIdTestCase(TestCase):
             self.skipTest('Cannot delete config templates.')
         try:
             attrs = entity().create()
-        except factory.FactoryError as err:
+        except HTTPError as err:
             self.fail(err)
         path = entity(id=attrs['id']).path()
         response = client.delete(
@@ -560,7 +561,7 @@ class DoubleCheckTestCase(TestCase):
         # Create an entity, then delete it.
         try:
             entity_n = entity(id=entity().create()['id'])
-        except factory.FactoryError as err:
+        except HTTPError as err:
             self.fail(err)
         logger.info('test_delete_and_get path: {0}'.format(entity_n.path()))
         entity_n.delete()

--- a/tests/foreman/api/test_organization_v2.py
+++ b/tests/foreman/api/test_organization_v2.py
@@ -9,7 +9,7 @@ from robottelo.api import client
 from robottelo.api.utils import status_code_error
 from robottelo.common.decorators import skip_if_bug_open
 from robottelo.common.helpers import get_server_credentials
-from robottelo import entities, factory, orm
+from robottelo import entities, orm
 from unittest import TestCase
 import ddt
 import httplib
@@ -165,7 +165,7 @@ class OrganizationTestCase(TestCase):
         @Feature: Organization
 
         """
-        with self.assertRaises(factory.FactoryError):
+        with self.assertRaises(HTTPError):
             entities.Organization(name=name).create()
 
     def test_negative_create_duplicate(self):
@@ -178,7 +178,7 @@ class OrganizationTestCase(TestCase):
         """
         name = entities.Organization.name.get_value()
         entities.Organization(name=name).create()
-        with self.assertRaises(factory.FactoryError):
+        with self.assertRaises(HTTPError):
             entities.Organization(name=name).create()
 
     def test_positive_search(self):

--- a/tests/foreman/api/test_role_v2.py
+++ b/tests/foreman/api/test_role_v2.py
@@ -4,11 +4,12 @@ Each ``TestCase`` subclass tests a single URL. A full list of URLs to be tested
 can be found here: http://theforeman.org/api/apidoc/v2/roles.html
 
 """
+from requests.exceptions import HTTPError
 from robottelo.api import client
 from robottelo.api.utils import status_code_error
 from robottelo.common.decorators import skip_if_bug_open
 from robottelo.common.helpers import get_server_credentials
-from robottelo import entities, factory, orm
+from robottelo import entities, orm
 from unittest import TestCase
 import ddt
 import httplib
@@ -22,7 +23,7 @@ class RoleTestCase(TestCase):
         """Create a role with name ``name``."""
         try:
             role_attrs = entities.Role(name=name).create()
-        except factory.FactoryError as err:
+        except HTTPError as err:
             self.fail(err)  # fail instead of error
 
         # Creation apparently succeeded. GET the role and verify it's name.
@@ -81,7 +82,7 @@ class RoleTestCase(TestCase):
         """
         try:
             role_attrs = entities.Role(name=name).create()
-        except factory.FactoryError as err:
+        except HTTPError as err:
             self.fail(err)  # fail instead of error
 
         path = entities.Role(id=role_attrs['id']).path()
@@ -126,7 +127,7 @@ class RoleTestCase(TestCase):
         """
         try:
             role_attrs = entities.Role(name=test_data['name']).create()
-        except factory.FactoryError as err:
+        except HTTPError as err:
             self.fail(err)  # fail instead of error
 
         path = entities.Role(id=role_attrs['id']).path()
@@ -171,7 +172,7 @@ class RoleTestCase(TestCase):
 
         try:
             role_attrs = entities.Role(name=role_name).create()
-        except factory.FactoryError as err:
+        except HTTPError as err:
             self.fail(err)  # fail instead of error
 
         path = entities.Role(id=role_attrs['id']).path()
@@ -220,7 +221,7 @@ class RoleTestCase(TestCase):
 
         try:
             role_attrs = entities.Role(name=role_name).create()
-        except factory.FactoryError as err:
+        except HTTPError as err:
             self.fail(err)  # fail instead of error
 
         path = entities.Role(id=role_attrs['id']).path()
@@ -279,7 +280,7 @@ class RoleTestCase(TestCase):
 
         try:
             role_attrs = entities.Role(name=role_name).create()
-        except factory.FactoryError as err:
+        except HTTPError as err:
             self.fail(err)  # fail instead of error
 
         path = entities.Role(id=role_attrs['id']).path()

--- a/tests/foreman/api/test_system_v2.py
+++ b/tests/foreman/api/test_system_v2.py
@@ -15,12 +15,12 @@ A full list of system-related URLs can be found here:
 http://theforeman.org/api/apidoc/v2/systems.html
 
 """
+from requests.exceptions import HTTPError
 from robottelo.api import client
 from robottelo.api.utils import status_code_error
 from robottelo.common.decorators import skip_if_bug_open
 from robottelo.common.helpers import get_server_credentials
 from robottelo.entities import System
-from robottelo import factory
 from unittest import TestCase
 import httplib
 # (too many public methods) pylint: disable=R0904
@@ -80,7 +80,7 @@ class EntityIdTestCaseClone(TestCase):
         """
         try:
             attrs = System().create()
-        except factory.FactoryError as err:
+        except HTTPError as err:
             self.fail(err)
         path = System(uuid=attrs['uuid']).path()
         response = client.delete(
@@ -178,7 +178,7 @@ class LongMessageTestCaseClone(TestCase):
         """
         try:
             attrs = System().create()
-        except factory.FactoryError as err:
+        except HTTPError as err:
             self.fail(err)
         System(uuid=attrs['uuid']).delete()
 


### PR DESCRIPTION
Drop custom error checking code from `EntityFactoryMixin.create`. Drop class
`factory.FactoryError` and reference `requests.exceptions.HTTPError` instead as
necessary. Update and simplify unit tests for the `factory` module.
