### PR TITLE
Added a function `enable_rhrepo_and_fetch_repoid` and few fixes.

### DIFF
--- a/tests/foreman/api/test_subscriptions_v2.py
+++ b/tests/foreman/api/test_subscriptions_v2.py
@@ -6,7 +6,7 @@ https://<sat6.com>/apidoc/v2/subscriptions.html
 """
 from robottelo import entities
 from unittest import TestCase
-from robottelo.common.manifests import clone
+from robottelo.common import manifests
 
 
 class SubscriptionsTestCase(TestCase):
@@ -20,7 +20,7 @@ class SubscriptionsTestCase(TestCase):
         @Feature: Subscriptions
 
         """
-        cloned_manifest_path = clone()
+        cloned_manifest_path = manifests.clone()
         org_id = entities.Organization().create()['id']
         task_id = entities.Organization(id=org_id).upload_manifest(
             path=cloned_manifest_path
@@ -36,7 +36,7 @@ class SubscriptionsTestCase(TestCase):
         @Feature: Subscriptions
 
         """
-        cloned_manifest_path = clone()
+        cloned_manifest_path = manifests.clone()
         org_id = entities.Organization().create()['id']
         task_id = entities.Organization(id=org_id).upload_manifest(
             path=cloned_manifest_path
@@ -55,7 +55,7 @@ class SubscriptionsTestCase(TestCase):
         @Feature: Subscriptions
 
         """
-        cloned_manifest_path = clone()
+        cloned_manifest_path = manifests.clone()
         orgid_one = entities.Organization().create()['id']
         orgid_two = entities.Organization().create()['id']
         taskid_one = entities.Organization(id=orgid_one).upload_manifest(

--- a/tests/foreman/ui/test_activationkey.py
+++ b/tests/foreman/ui/test_activationkey.py
@@ -67,10 +67,10 @@ class ActivationKey(UITestCase):
         ).create()
 
         # Sync repository
-        response = entities.Repository(id=repo_attrs['id']).sync()
-        task_status = entities.ForemanTask(id=response['id']).poll()
+        task_id = entities.Repository(id=repo_attrs['id']).sync()
+        task_result = entities.ForemanTask(id=task_id).poll()['results']
         self.assertEqual(
-            task_status['result'],
+            task_result,
             u'success',
             u"Sync for repository {0} failed.".format(repo_attrs['name']))
 
@@ -91,6 +91,7 @@ class ActivationKey(UITestCase):
             auth=get_server_credentials(),
             verify=False,
             data={u'repository_ids': [repo_attrs['id']]})
+        response.raise_for_status()
 
         # Publish content view
         task = entities.ContentView(id=content_view['id']).publish()


### PR DESCRIPTION
Added `enable_rhrepo_and_fetch_repoid` function, to group many
steps required for syncing RedHat Repos.

The `sync` function under `Repository` Class now returns a task_id.

Added and Fixed many docstrings.

Updated the import related to cloning manifests.

Added test related to syncing RedHat Repository

Few fixes after Repository.sync returns task_id
