### PR TITLE
(API) Fix up the "Architecture" entity

### DIFF
--- a/robottelo/factory.py
+++ b/robottelo/factory.py
@@ -192,7 +192,7 @@ class Factory(object):
         # to the caller.
         return values
 
-    def create(self, auth=None):
+    def create(self, auth=None, data=None):
         """Create a new entity, plus all of its dependent entities.
 
         Create an entity at the path returned by :meth:`Factory._factory_path`.
@@ -203,6 +203,8 @@ class Factory(object):
             communicating with the API. If ``None``, the credentials returned
             by :func:`robottelo.common.helpers.get_server_credentials` are
             used.
+        :param dict data: A JSON version of this data is POSTed to the server.
+            ``self.build``'s return value is used if ``None``.
         :return: Information about the newly created entity.
         :rtype: dict
         :raises: ``requests.exceptions.HTTPError`` if the server returns an
@@ -211,7 +213,8 @@ class Factory(object):
         """
         if auth is None:
             auth = get_server_credentials()
-        data = self.build(auth)
+        if data is None:
+            data = self.build(auth)
 
         # Create the current entity.
         response = client.post(

--- a/tests/foreman/api/test_multiple_paths.py
+++ b/tests/foreman/api/test_multiple_paths.py
@@ -596,7 +596,7 @@ class EntityReadTestCase(TestCase):
     # LibvirtComputeResource.
     @data(
         # entities.ActivationKey,
-        # entities.Architecture,
+        # entities.Architecture,  # see test_architecture_read
         entities.AuthSourceLDAP,
         entities.ComputeProfile,
         # partial(entities.ComputeResource, provider='Libvirt'),
@@ -633,6 +633,19 @@ class EntityReadTestCase(TestCase):
         attrs = entity().create()
         read_entity = entity(id=attrs['id']).read()
         self.assertIsInstance(read_entity, entity)
+
+    def test_architecture_read(self):
+        """@Test: Create an arch that points to an OS, and read the arch.
+
+        @Assert: The call to :meth:`robottelo.entities.Architecture.read`
+        succeeds, and the response contains the correct operating system ID.
+
+        """
+        os_id = entities.OperatingSystem().create()['id']
+        arch_id = entities.Architecture(operatingsystem=[os_id]).create()['id']
+        architecture = entities.Architecture(id=arch_id).read()
+        self.assertEqual(len(architecture.operatingsystem), 1)
+        self.assertEqual(architecture.operatingsystem[0].id, os_id)
 
     @run_only_on('sat')
     def test_osparameter_read(self):


### PR DESCRIPTION
Override `Architecture.create` and `Architecture.read`. This makes it possible
to:
- Create an architecture that points to some number of operating systems.
- Read which operating systems an architecture points to.

Update the test suite to exercise these changes.
