### PR TITLE
Clean up method `skip_if_sam`

### DIFF
--- a/tests/foreman/api/test_multiple_paths.py
+++ b/tests/foreman/api/test_multiple_paths.py
@@ -32,18 +32,23 @@ BZ_1122267_ENTITIES = (
 
 
 def skip_if_sam(self, entity):
-    """Skip test if server is in "sam" mode and entity is unavailable in "sam".
+    """Skip test if testing sam features and entity is unavailable in sam.
 
     :param entity: One of the entities defined in :meth:`robottelo.entities`.
+    :returns: Either ``self.skipTest`` or ``None``.
 
     """
     robottelo_mode = conf.properties.get('main.project', '').lower()
-    server_mode = map(lambda item: item.lower(), entity().Meta.server_mode)
+    server_modes = [
+        server_mode.lower()
+        for server_mode
+        in entity.Meta.server_mode
+    ]
 
-    if (robottelo_mode == 'sam' and 'sam' not in server_mode):
+    if robottelo_mode == 'sam' and 'sam' not in server_modes:
         return self.skipTest(
             'Server runs in "{0}" mode and this entity is associated only to '
-            '"{1}" mode(s).'.format(robottelo_mode, "".join(server_mode))
+            '"{1}" mode(s).'.format(robottelo_mode, "".join(server_modes))
         )
 
     # else just return - do nothing!


### PR DESCRIPTION
- Reword the docstring with nicer prose.
- Change variable names for the sake of clarity.
- Use a list comprehension instead of a map-and-lambda combo.

A list comprehension is used instead of a map-and-lambda combo because:
- List comprehensions are more common, and in my opinion more readable. When in
  Rome...
- There is anecdotal evidence that list comprehensions are preferred by the
  community at large. See the comments to PEP 279.
- Pylint complains about the usage of a map-and-lambda combo when a list
  comprehension suffices.
- Last and least, list comprehensions are more efficent.
