### PR TITLE
(API) Fix up the "OperatingSystem" entity.

### DIFF
--- a/docs/api/tests.foreman.api.rst
+++ b/docs/api/tests.foreman.api.rst
@@ -75,6 +75,13 @@
     :members:
     :undoc-members:
 
+:mod:`tests.foreman.api.test_operatingsystem_v2`
+------------------------------------------------
+
+.. automodule:: tests.foreman.api.test_operatingsystem_v2
+    :members:
+    :undoc-members:
+
 :mod:`tests.foreman.api.test_organization_v2`
 ---------------------------------------------
 

--- a/tests/foreman/api/test_operatingsystem_v2.py
+++ b/tests/foreman/api/test_operatingsystem_v2.py
@@ -1,34 +1,77 @@
-"""Unit tests for the ``api/v2/operatingsystems/:id/parameters`` paths.
+"""Unit tests for the ``operatingsystems`` paths.
 
-A reference for the relevant paths can be found here:
-http://theforeman.org/api/apidoc/v2/parameters.html
+References for the relevant paths can be found here:
+
+* http://theforeman.org/api/apidoc/v2/operatingsystems.html
+* http://theforeman.org/api/apidoc/v2/parameters.html
 
 """
-from robottelo import entities
+from fauxfactory import gen_utf8
 from robottelo.common.decorators import run_only_on
+from robottelo import entities
 from unittest import TestCase
 # (too many public methods) pylint: disable=R0904
 
 
 @run_only_on('sat')
 class OSParameterTestCase(TestCase):
-    """Tests for the ``api/v2/operatingsystems/:id/parameters`` paths."""
+    """Tests for operating system parameters."""
     def test_bz_1114640(self):
         """@Test: Create a parameter for operating system 1.
 
         @Assert: A parameter is created and can be read afterwards.
 
+        @Feature: OperatingSystemParameter
+
         """
-        # Check whether OS 1 exists. Do not catch
-        # requests.exceptions.HTTPError, as doing so destroys useful stack
-        # trace information.
-        entities.OperatingSystem(id=1).read()
+        # Check whether OS 1 exists.
+        entities.OperatingSystem(id=1).read_json()
 
-        # Create a param for OS 1 and read the param back.
-        osp_attrs = entities.OperatingSystemParameter(1).create()
-        osp = entities.OperatingSystemParameter(1, id=osp_attrs['id']).read()
+        # Create and read a parameter for operating system 1. The purpose of
+        # this test is to make sure an HTTP 422 is not returned, but we're also
+        # going to verify the name and value of the parameter, just for good
+        # measure.
+        name = gen_utf8(20)
+        value = gen_utf8(20)
+        osp_id = entities.OperatingSystemParameter(
+            1,
+            name=name,
+            value=value,
+        ).create()['id']
+        attrs = entities.OperatingSystemParameter(1, id=osp_id).read_json()
+        self.assertEqual(attrs['name'], name)
+        self.assertEqual(attrs['value'], value)
 
-        # The main point of this test is "does create() return an HTTP 422?"
-        # These are here just for good measure.
-        self.assertEqual(osp_attrs['name'], osp.name)
-        self.assertEqual(osp_attrs['value'], osp.value)
+
+@run_only_on('sat')
+class OSTestCase(TestCase):
+    """Tests for operating systems."""
+    def test_point_to_arch(self):
+        """@Test: Create an operating system that points at an architecture.
+
+        @Assert: The operating system is created and points at the given
+        architecture.
+
+        @Feature: OperatingSystem
+
+        """
+        arch_id = entities.Architecture().create()['id']
+        os_id = entities.OperatingSystem(architecture=[arch_id]).create()['id']
+        attrs = entities.OperatingSystem(id=os_id).read_json()
+        self.assertEqual(len(attrs['architectures']), 1)
+        self.assertEqual(attrs['architectures'][0]['id'], arch_id)
+
+    def test_point_to_ptable(self):
+        """@Test: Create an operating system that points at a partition table.
+
+        @Assert: The operating system is created and points at the given
+        partition table.
+
+        @Feature: OperatingSystem
+
+        """
+        ptable_id = entities.PartitionTable().create()['id']
+        os_id = entities.OperatingSystem(ptable=[ptable_id]).create()['id']
+        attrs = entities.OperatingSystem(id=os_id).read_json()
+        self.assertEqual(len(attrs['ptables']), 1)
+        self.assertEqual(attrs['ptables'][0]['id'], ptable_id)


### PR DESCRIPTION
Give the `OperatingSystem` entity three new attributes:
- architecture
- medium
- ptable

Override `OperatingSystem.create` so that these attributes can be correctly
specified. Write new API tests for the "architecture" and "ptable" attributes.
Do not create a test for the "medium" attribute, as it is not currently possible
to create a medium using the API tools.
