### PR TITLE
Removing broken link from CLI documentation

### DIFF
--- a/tests/foreman/cli/test_contentviews.py
+++ b/tests/foreman/cli/test_contentviews.py
@@ -1,7 +1,7 @@
 # -*- encoding: utf-8 -*-
 # vim: ts=4 sw=4 expandtab ai
 
-"""Test class for Host/System Unification"""
+"""Test class for Content Views"""
 import unittest
 
 from ddt import ddt


### PR DESCRIPTION
This should be the final broken link in documentation. 
