### PR TITLE
`Entity.path` now uses the keywords `base` and `self`.

### DIFF
--- a/robottelo/entities.py
+++ b/robottelo/entities.py
@@ -55,7 +55,7 @@ class ActivationKey(
 
         """
         if which == 'releases':
-            return super(ActivationKey, self).path(which='this') + '/releases'
+            return super(ActivationKey, self).path(which='self') + '/releases'
         return super(ActivationKey, self).path()
 
 
@@ -381,7 +381,7 @@ class ContentViewVersion(orm.Entity):
         """
         if which == 'promote':
             return super(ContentViewVersion, self).path(
-                which='this') + '/promote'
+                which='self') + '/promote'
         return super(ContentViewVersion, self).path(which)
 
     def promote(self, environment_id):
@@ -513,7 +513,7 @@ class ContentView(
                 'content_view_puppet_modules', 'content_view_versions',
                 'publish', 'available_puppet_module_names'):
             return '{0}/{1}'.format(
-                super(ContentView, self).path(which='this'),
+                super(ContentView, self).path(which='self'),
                 which
             )
         return super(ContentView, self).path()
@@ -642,9 +642,9 @@ class ForemanTask(orm.Entity, orm.EntityReadMixin):
         """
         if which == 'bulk_search':
             return '{0}/bulk_search'.format(
-                super(ForemanTask, self).path(which='all')
+                super(ForemanTask, self).path(which='base')
             )
-        return super(ForemanTask, self).path(which='this')
+        return super(ForemanTask, self).path(which='self')
 
     def poll(self, poll_rate=5, timeout=120, auth=None):
         """Return the status of a task or timeout.
@@ -1131,7 +1131,7 @@ class Organization(
                      'subscriptions/refresh_manifest', 'sync_plans',
                      'products'):
             return '{0}/{1}'.format(
-                super(Organization, self).path(which='this'),
+                super(Organization, self).path(which='self'),
                 which
             )
         return super(Organization, self).path(which=which)
@@ -1398,7 +1398,7 @@ class Product(
         """
         if which is not None and which.startswith("repository_sets"):
             return '{0}/{1}'.format(
-                super(Product, self).path(which='this'),
+                super(Product, self).path(which='self'),
                 which,
             )
         return super(Product, self).path(which=which)
@@ -1431,7 +1431,7 @@ class Product(
 
         """
         response = client.get(
-            self.path(which="all"),
+            self.path(which='base'),
             auth=get_server_credentials(),
             verify=False,
             data={u'search': 'name={}'.format(escape_search(name)),
@@ -1620,7 +1620,7 @@ class Repository(
         """
         if which in ('sync', 'upload_content'):
             return '{0}/{1}'.format(
-                super(Repository, self).path(which='this'),
+                super(Repository, self).path(which='self'),
                 which
             )
         return super(Repository, self).path()
@@ -1889,9 +1889,9 @@ class System(
         * ``which == 'this'``.
 
         """
-        if self.uuid is not None and (which is None or which == 'this'):
+        if self.uuid is not None and (which is None or which == 'self'):
             return '{0}/{1}'.format(
-                super(System, self).path(which='all'),
+                super(System, self).path(which='base'),
                 self.uuid
             )
         return super(System, self).path(which=which)

--- a/robottelo/orm.py
+++ b/robottelo/orm.py
@@ -319,15 +319,15 @@ class Entity(booby.Model):
     def path(self, which=None):
         """Return the path to the current entity.
 
-        Return the path to all entities of this entity's type if:
+        Return the path to base entities of this entity's type if:
 
-        * ``which`` is ``'all'``, or
+        * ``which`` is ``'base'``, or
         * ``which`` is ``None`` and instance attribute ``id`` is unset.
 
         Return the path to this exact entity if instance attribute ``id`` is
         set and:
 
-        * ``which`` is ``'this'``, or
+        * ``which`` is ``'self'``, or
         * ``which`` is ``None``.
 
         Raise :class:`NoSuchPathError` otherwise.
@@ -345,7 +345,7 @@ class Entity(booby.Model):
         This will allow the extending method to accept a custom parameter
         without accidentally raising a :class:`NoSuchPathError`.
 
-        :param str which: Optional. Valid arguments are 'this' and 'all'.
+        :param str which: Optional. Valid arguments are 'self' and 'base'.
         :return: A fully qualified URL.
         :rtype: str
         :raises robottelo.orm.NoSuchPathError: If no path can be built.
@@ -365,9 +365,9 @@ class Entity(booby.Model):
             helpers.get_server_url() + '/',
             self.Meta.api_path
         )
-        if which == 'all' or which is None and self.id is None:
+        if which == 'base' or which is None and self.id is None:
             return base
-        elif self.id is not None and (which is None or which == 'this'):
+        elif self.id is not None and (which is None or which == 'self'):
             return urlparse.urljoin(base + '/', str(self.id))
         raise NoSuchPathError
 
@@ -416,7 +416,7 @@ class EntityDeleteMixin(object):
     def delete(self, auth=None, synchronous=True):
         """Delete the current entity.
 
-        Send an HTTP DELETE request to ``self.path(which='this')``.
+        Send an HTTP DELETE request to ``self.path(which='self')``.
 
         :param tuple auth: A ``(username, password)`` tuple used when accessing
             the API. If ``None``, the credentials provided by
@@ -438,7 +438,7 @@ class EntityDeleteMixin(object):
         if auth is None:
             auth = helpers.get_server_credentials()
         response = client.delete(
-            self.path(which='this'),
+            self.path(which='self'),
             auth=auth,
             verify=False,
         )
@@ -461,7 +461,7 @@ class EntityReadMixin(object):
     def read_json(self, auth=None):
         """Get information about the current entity.
 
-        Send an HTTP GET request to ``self.path(which='this')``. Return the
+        Send an HTTP GET request to ``self.path(which='self')``. Return the
         decoded JSON response.
 
         :param tuple auth: A ``(username, password)`` tuple used when accessing
@@ -477,7 +477,7 @@ class EntityReadMixin(object):
         if auth is None:
             auth = helpers.get_server_credentials()
         response = client.get(
-            self.path(which='this'),
+            self.path(which='self'),
             auth=auth,
             verify=False,
         )

--- a/tests/robottelo/test_entities.py
+++ b/tests/robottelo/test_entities.py
@@ -93,17 +93,17 @@ class PathTestCase(TestCase):
         (entities.ContentView, 'content_view_versions'),
         (entities.ContentView, 'publish'),
         (entities.ContentViewVersion, 'promote'),
-        (entities.ForemanTask, 'this'),
+        (entities.ForemanTask, 'self'),
         (entities.Organization, 'subscriptions/delete_manifest'),
         (entities.Organization, 'subscriptions/refresh_manifest'),
         (entities.Organization, 'subscriptions/upload'),
         (entities.Organization, 'sync_plans'),
         (entities.Organization, 'products'),
         (entities.Product, 'repository_sets'),
-        (entities.Organization, 'this'),
+        (entities.Organization, 'self'),
         (entities.Repository, 'sync'),
         (entities.Repository, 'upload_content'),
-        (entities.System, 'this'),
+        (entities.System, 'self'),
     )
     @unpack
     def test_no_such_path(self, entity, path):
@@ -140,19 +140,19 @@ class PathTestCase(TestCase):
         Assert that correct paths are returned when:
 
         * A UUID is provided and ``which`` is omitted.
-        * A UUID is provided and ``which='this'``.
+        * A UUID is provided and ``which='self'``.
         * A UUID is omitted and ``which`` is omitted.
-        * A UUID is omitted and ``which='all'``.
+        * A UUID is omitted and ``which='base'``.
 
         """
         for gen_path in (
                 entities.System(uuid=self.id_).path(),
-                entities.System(uuid=self.id_).path(which='this')):
+                entities.System(uuid=self.id_).path(which='self')):
             self.assertIn('/systems/{0}'.format(self.id_), gen_path)
             self.assertRegexpMatches(gen_path, '{0}$'.format(self.id_))
         for gen_path in (
                 entities.System().path(),
-                entities.System().path(which='all')):
+                entities.System().path(which='base')):
             self.assertIn('/systems', gen_path)
             self.assertRegexpMatches(gen_path, 'systems$')
 

--- a/tests/robottelo/test_orm.py
+++ b/tests/robottelo/test_orm.py
@@ -97,7 +97,6 @@ class EntityTestCase(unittest.TestCase):
         self.assertEqual(values['name'], name)
         self.assertEqual(values['value'], value)
 
-
     def test_entity_get_fields(self):
         """Test :meth:`robottelo.orm.Entity.get_fields`."""
         fields = SampleEntity().get_fields()
@@ -112,9 +111,9 @@ class EntityTestCase(unittest.TestCase):
         """Test :meth:`robottelo.orm.Entity.path`."""
         self.assertEqual(SampleEntity().path(), self.base_path)
         self.assertEqual(SampleEntity(id=5).path(), self.base_path + '/5')
-        self.assertEqual(SampleEntity(id=5).path('all'), self.base_path)
+        self.assertEqual(SampleEntity(id=5).path('base'), self.base_path)
         with self.assertRaises(orm.NoSuchPathError):
-            SampleEntity().path('this')
+            SampleEntity().path('self')
 
 
 class OneToManyFieldTestCase(unittest.TestCase):


### PR DESCRIPTION
By default, the keywords `this` and `all` were used, now
it's modified and now uses `self` and `base` respectively.

The idea being `which='base'` returns the base path and
`which='self'` returns the path with the `id` of the entity,
while generating paths.
