### PR TITLE
Improve the API layer for the Media class

### DIFF
--- a/robottelo/orm.py
+++ b/robottelo/orm.py
@@ -522,6 +522,11 @@ class EntityReadMixin(object):
         if attrs is None:
             attrs = self.read_json(auth=auth)
 
+        # Rename fields using entity.Meta.api_names, if present.
+        if hasattr(entity.Meta, 'api_names'):
+            for local_name, remote_name in entity.Meta.api_names:
+                attrs[local_name] = attrs.pop(remote_name)
+
         # We must populate `entity`'s attributes from `attrs`.
         #
         # * OneToOneField names end with "_id"

--- a/tests/foreman/api/test_multiple_paths.py
+++ b/tests/foreman/api/test_multiple_paths.py
@@ -635,7 +635,7 @@ class EntityReadTestCase(TestCase):
         # entities.Host,  # Host().create() does not work
         entities.HostCollection,
         # entities.LifecycleEnvironment,
-        # entities.Media,
+        entities.Media,
         entities.Model,
         entities.OperatingSystem,
         # entities.OperatingSystemParameter,  # see test_osparameter_read
@@ -707,3 +707,15 @@ class EntityReadTestCase(TestCase):
         self.assertIsInstance(read_entity, entities.Permission)
         self.assertGreater(len(read_entity.name), 0)
         self.assertGreater(len(read_entity.resource_type), 0)
+
+    def test_media_read(self):
+        """@Test: Create a media pointing at an OS and read the media.
+
+        @Assert: The media points at the correct operating system.
+
+        """
+        os_id = entities.OperatingSystem().create()['id']
+        media_id = entities.Media(operatingsystem=[os_id]).create()['id']
+        media = entities.Media(id=media_id).read()
+        self.assertEqual(len(media.operatingsystem), 1)
+        self.assertEqual(media.operatingsystem[0].id, os_id)


### PR DESCRIPTION
Make the following code work correctly:

```
Media(operatingsystem=[1, 2, 3]).create()
```

Formerly, operating system IDs would be completely ignored.

Make `Media.read` capable of correctly unpacking operating system IDs.

Make `EntityReadMixin.read` capable of correctly dealing with
`SomeEntity.Meta.api_names`. In other words, make `EntityReadMixin.read` capable
of dealing with mappings between local attribute names and remote attribute
names.

Test these changes.
