### PR TITLE
Fix the `clone()` function call for better readability.

### DIFF
--- a/tests/foreman/cli/test_contentviews.py
+++ b/tests/foreman/cli/test_contentviews.py
@@ -16,7 +16,7 @@ from robottelo.cli.factory import (
     make_repository,
     make_user,
 )
-from robottelo.common.manifests import clone
+from robottelo.common import manifests
 from robottelo.cli.repository import Repository
 from robottelo.cli.repository_set import RepositorySet
 from robottelo.entities import Organization
@@ -88,7 +88,7 @@ class TestContentView(CLITestCase):
             return
 
         TestContentView.rhel_content_org = make_org()
-        manifest = clone()
+        manifest = manifests.clone()
         finished_task = Organization(
             id=TestContentView.rhel_content_org['id']
         ).upload_manifest(manifest)

--- a/tests/foreman/cli/test_subscription.py
+++ b/tests/foreman/cli/test_subscription.py
@@ -6,7 +6,7 @@ from robottelo.cli.subscription import Subscription
 from robottelo.cli.repository import Repository
 from robottelo.cli.repository_set import RepositorySet
 from robottelo.cli.factory import make_org
-from robottelo.common.manifests import clone
+from robottelo.common import manifests
 from robottelo.common.ssh import upload_file
 from robottelo.test import CLITestCase
 
@@ -22,7 +22,7 @@ class TestSubscription(CLITestCase):
 
         super(TestSubscription, self).setUp()
         self.org = make_org()
-        self.manifest = clone()
+        self.manifest = manifests.clone()
 
     def test_manifest_upload(self):
         """@Test: upload manifest (positive)

--- a/tests/foreman/ui/test_subscription.py
+++ b/tests/foreman/ui/test_subscription.py
@@ -3,8 +3,8 @@
 from ddt import ddt
 from fauxfactory import gen_string
 from nose.plugins.attrib import attr
+from robottelo.common import manifests
 from robottelo.common.decorators import skipRemote
-from robottelo.common.manifests import clone
 from robottelo.common.ssh import upload_file
 from robottelo.test import UITestCase
 from robottelo.ui.factory import make_org
@@ -39,13 +39,13 @@ class SubscriptionTestCase(UITestCase):
         """
 
         alert_loc = common_locators['alert.success']
-        path = clone()
+        manifest_path = manifests.clone()
         # upload_file function should take care of uploading to sauce labs.
-        upload_file(path, remote_file=path)
+        upload_file(manifest_path, remote_file=manifest_path)
         with Session(self.browser) as session:
             session.nav.go_to_select_org(self.org_name)
             session.nav.go_to_red_hat_subscriptions()
-            self.subscriptions.upload(path)
+            self.subscriptions.upload(manifest_path)
             success_ele = self.subscriptions.wait_until_element(alert_loc)
             self.assertTrue(success_ele)
 
@@ -61,13 +61,13 @@ class SubscriptionTestCase(UITestCase):
         """
 
         alert_loc = common_locators['alert.success']
-        path = clone()
+        manifest_path = manifests.clone()
         # upload_file function should take care of uploading to sauce labs.
-        upload_file(path, remote_file=path)
+        upload_file(manifest_path, remote_file=manifest_path)
         with Session(self.browser) as session:
             session.nav.go_to_select_org(self.org_name)
             session.nav.go_to_red_hat_subscriptions()
-            self.subscriptions.upload(path)
+            self.subscriptions.upload(manifest_path)
             self.subscriptions.delete()
             success_ele = self.subscriptions.wait_until_element(alert_loc)
             self.assertTrue(success_ele)

--- a/tests/foreman/ui/test_sync.py
+++ b/tests/foreman/ui/test_sync.py
@@ -7,7 +7,7 @@ from fauxfactory import gen_string, gen_integer
 from robottelo.common.constants import FAKE_1_YUM_REPO
 from robottelo.common.decorators import data, run_only_on
 from robottelo.common.helpers import generate_strings_list
-from robottelo.common.manifests import clone
+from robottelo.common import manifests
 from robottelo.common.ssh import upload_file
 from robottelo.test import UITestCase
 from robottelo.ui.locators import common_locators
@@ -82,13 +82,13 @@ class Sync(UITestCase):
 
         repos = self.sync.create_repos_tree(RHCT)
         alert_loc = common_locators['alert.success']
-        path = clone()
+        manifest_path = manifests.clone()
         # upload_file function should take care of uploading to sauce labs.
-        upload_file(path, remote_file=path)
+        upload_file(manifest_path, remote_file=manifest_path)
         with Session(self.browser) as session:
             session.nav.go_to_select_org(self.org_name)
             session.nav.go_to_red_hat_subscriptions()
-            self.subscriptions.upload(path)
+            self.subscriptions.upload(manifest_path)
             success_ele = session.nav.wait_until_element(alert_loc)
             self.assertTrue(success_ele)
             session.nav.go_to_red_hat_repositories()


### PR DESCRIPTION
Let's use the below way for better readability.

``` python
from robottelo.common import manifests
manifest = manifests.clone()
```
