### PR TITLE
Fix path on Permission's entity search method

### DIFF
--- a/robottelo/entities.py
+++ b/robottelo/entities.py
@@ -1433,7 +1433,7 @@ class Permission(orm.Entity, orm.EntityReadMixin):
             search_terms[u'resource_type'] = self.resource_type
 
         response = client.get(
-            self.path('all'),
+            self.path('base'),
             auth=get_server_credentials(),
             verify=False,
             data=search_terms


### PR DESCRIPTION
Entities path was updated to base/self instead of all/this and this was
missed for Permission entity because the relevant PR was open.
