### PR TITLE
Fix CLI errors

### DIFF
--- a/robottelo/cli/factory.py
+++ b/robottelo/cli/factory.py
@@ -516,7 +516,7 @@ def make_subnet(options=None):
     """
 
     args = {
-        u'name': gen_alphanumeric(8, 8),
+        u'name': gen_alphanumeric(8),
         u'network': gen_ipaddr(ip3=True),
         u'mask': u'255.255.255.0',
         u'gateway': None,

--- a/tests/foreman/cli/test_domain.py
+++ b/tests/foreman/cli/test_domain.py
@@ -17,7 +17,7 @@ class TestDomain(MetaCLITestCase):
     factory_obj = Domain
 
     @data(
-        {u'name': 'white spaces {0}'.format(gen_string(str_type='utf8')),
+        {u'name': u'white spaces {0}'.format(gen_string(str_type='utf8')),
          u'description': gen_string(str_type='alpha')},
         {u'name': gen_string(str_type='utf8'),
          u'description': gen_string(str_type='utf8')},
@@ -56,7 +56,7 @@ class TestDomain(MetaCLITestCase):
             make_domain(options)
 
     @data(
-        {u'name': 'white spaces {0}'.format(gen_string(str_type='utf8')),
+        {u'name': u'white spaces {0}'.format(gen_string(str_type='utf8')),
          u'description': gen_string(str_type='alpha')},
         {u'name': gen_string(str_type='utf8'),
          u'description': gen_string(str_type='utf8')},
@@ -161,7 +161,7 @@ class TestDomain(MetaCLITestCase):
         self.assertDictEqual(parameter, result.stdout['parameters'])
 
     @data(
-        {'name': 'white spaces {0}'.format(gen_string(str_type='utf8')),
+        {'name': u'white spaces {0}'.format(gen_string(str_type='utf8')),
          'value': gen_string(str_type='utf8')},
         {'name': '',
          'value': gen_string(str_type='utf8')},


### PR DESCRIPTION
Fix gen_alphanumeric call on cli.facory module
Make strings unicode when formatting with unicode arguments
