### PR TITLE
Fix make_domain CLI factory

### DIFF
--- a/robottelo/cli/factory.py
+++ b/robottelo/cli/factory.py
@@ -1004,7 +1004,7 @@ def make_domain(options=None):
     """
     # Assigning default values for attributes
     args = {
-        u'name': gen_alphanumeric(6),
+        u'name': gen_alphanumeric().lower(),
         u'dns-id': None,
         u'description': None,
     }


### PR DESCRIPTION
Domain names need to be lowercase otherwise it will fails the host
creation.

Thanks @Ichimonji10 for the precious tip that the domain names should be lowercase to not fail host creation
