### PR TITLE
Avoid 404 on faster machines and connections

### DIFF
--- a/robottelo/orm.py
+++ b/robottelo/orm.py
@@ -485,6 +485,15 @@ class EntityReadMixin(object):
             auth=auth,
             verify=False,
         )
+        if response.status_code is 404:
+            # Avoid 404 on faster machines with faster connections. Give some
+            # time to server finish creating the entity
+            time.sleep(1)
+            response = client.get(
+                self.path(which='self'),
+                auth=auth,
+                verify=False,
+            )
         response.raise_for_status()
         return response.json()
 


### PR DESCRIPTION
Add a retry with 1 second sleep before it when get a 404 on reading an
entity. Some API tests are failing due to 404, but when accessing the
URL the entity is returned without any problems. This was not possible
to reproduce locally, had to run on the Jenkins slave which is faster
and have a faster connection to the Satellite server.

This should fix all 404 API automation failures.
