### PR TITLE
Rough draft of the Committing guidelines

### DIFF
--- a/docs/code_standards.rst
+++ b/docs/code_standards.rst
@@ -1,0 +1,10 @@
+
+
+Code Standards
+==============
+
+Todo
+----
+Compile a list of standards used by the **Robottelo** team
+
+Categorize each standard into how strictly they are enforced

--- a/docs/committing.rst
+++ b/docs/committing.rst
@@ -1,0 +1,121 @@
+
+Committing
+==========
+
+Every open source project lives from the generous help by contributors that
+sacrifice their time and **Robottelo** is no different.
+
+To make participation as pleasant as possible, this project adheres to
+the `Code of Conduct`_ by the Python Software Foundation.
+
+If you have something great but aren’t sure whether it adheres, or even can
+adhere, to the rules below: please submit a pull request anyway! In the best
+case, we can mold it into something; in the worst case, the pull request gets
+politely closed. There’s absolutely nothing to fear.
+
+Thank you for considering contributing to Robottelo! If you have any question
+or concerns, feel free to reach out to the team. We can be found on the
+#robottelo channel on `freenode`_.
+
+
+Before you commit
+-----------------
+
+Ensure your code follows the guidelines in the `Robottelo Standards`_.
+
+All modules, classes, and functions should have well written docstrings.
+
+See also:
+
+* `testimony`_
+* `sphinx`_
+
+Don’t *ever* break backward compatibility. If it ever has to happen for higher
+reasons, Robottelo will follow the proven `procedures`_ of the Twisted project.
+
+**Always** add tests and docs for your code. This is a hard rule; patches with
+missing tests or documentation won’t be merged. If a feature is not tested or
+documented, it doesn’t exist.
+
+In order to ensure you are able to pass the Travis CI build, it is recommended
+that you run the following commands in the base of your Robottelo directory.::
+
+    $ flake8 .
+    $ make test-docstrings
+    $ make test-robottelo
+
+:code:`flake8` will ensure that the changes you made are not in violation of
+PEP8 standards. If the command gives no output, then you have passed. If not,
+then address any corrections recommended.
+
+:code:`test-docstrings` will check if there are parts of the code base that are
+missing docstrings.
+
+:code:`test-robottelo` will run all the tests created to ensure Robottelo is
+working as expected. If you added a test, it will be run now.
+
+Peforming the commit
+--------------------
+
+Proper commit messages
+
+* The title should be a brief summary of the changes.
+
+* The body of the message should effectively explain the changes.
+
+* `This link`_ has much more information on proper commit messages.
+
+* `Close an issue`_ by stating "Fixes #XXXX" where XXXX is the issue number.
+
+Fetch and rebase from upstream/master
+
+Push the commit to your forked repository
+
+
+Initiating a Pull Request
+-------------------------
+
+Navigate to your forked repository on GitHub and click the Pull Request button.
+
+The title and message should auto-populate from your commit. If not, then
+recreate them now.
+
+Submit the request!
+
+Did you add or change a test? Include the results in a comment.
+
+Closely monitor the discussion on GitHub to address any questions or
+suggestions.
+
+**Never** merge your own pull request. Other members of the team are
+responsible for that action.
+
+
+Making Changes
+--------------
+
+If the code review process identifies something that needs to be changed,
+perform the change locally.
+
+Use :code:`commit --amend` or squash the change commit down into the previous.
+
+Finally, push again [#note]_ and continue monitoring the discussion.
+
+.. [#note] git may kick back that your GitHub repo is ahead of your current
+           commit. Just use the :code:`--force` to push it anyway.
+
+
+Cleaning up
+-----------
+
+If you created a branch, in your forked repository, you may merge it now.
+
+
+.. _Code of Conduct: http://www.python.org/psf/codeofconduct/
+.. _freenode: http://freenode.net/
+.. _Robottelo Standards: code_standards.rst
+.. _testimony: https://github.com/SatelliteQE/testimony
+.. _sphinx: http://sphinx-doc.org/markup/para.html
+.. _procedures: http://twistedmatrix.com/trac/wiki/CompatibilityPolicy
+.. _This link: http://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html
+.. _Close an issue: https://help.github.com/articles/closing-issues-via-commit-messages/

--- a/docs/reviewing_PRs.rst
+++ b/docs/reviewing_PRs.rst
@@ -1,0 +1,31 @@
+
+
+Reviewing PRs
+=============
+
+Ensure commits are squashed.
+
+Thoroughly review each change for errors or departures from the `Robottelo
+Standards`_.
+
+If you note something that should be changed, or want clarification, add a
+comment to the line of code or the PR as a whole.
+
+If tests were added, ensure the PR includes the results or simple a message
+stating *"All tests passed."* or *"Unable to run tests at this time due to
+_____."*
+
+**Don't merge** unless there have been two ACKs.
+
+**Don't merge** unless the PR passes the Travis CI build.
+
+Once all the above criteria have been met, and the author has completed all
+changes, then you may merge.
+
+
+ToDo
+----
+Elaborate on the process.
+
+
+.. _Robottelo Standards: code_standards.rst


### PR DESCRIPTION
This is the rough draft and will have many more changes as we flesh out exactly what we want our committing standards to be.
Note: the Robottelo Standards link will be broken until we create that document.
