### PR TITLE
Add method `EntityReadMixin.read_raw`

### DIFF
--- a/robottelo/api/client.py
+++ b/robottelo/api/client.py
@@ -79,9 +79,16 @@ def _curl_arg_user(kwargs):
     :rtype: str
 
     """
-    # True if user provided creds in this form: auth=('username', 'password')
-    # False if no creds or in e.g. this form: auth=HTTPBasicAuth('usr', 'pass')
-    if 'auth' in kwargs and isinstance(kwargs['auth'], tuple):
+    # By default, auth is `None`. The user may provide credentials in a variety
+    # for forms, such as:
+    #
+    # * ('Alice', 'hackme')
+    # * ()
+    # * HTTPBasicAuth('Bob', 'gandalf')
+    #
+    if ('auth' in kwargs and
+            isinstance(kwargs['auth'], tuple) and
+            len(kwargs['auth']) is 2):
         return u'--user {0}:{1} '.format(kwargs['auth'][0], kwargs['auth'][1])
     return ''
 

--- a/tests/foreman/api/test_multiple_paths.py
+++ b/tests/foreman/api/test_multiple_paths.py
@@ -106,17 +106,12 @@ class EntityTestCase(TestCase):
 
         """
         skip_if_sam(self, entity)
-        path = entity().path()
-        response = client.get(
-            path,
-            auth=get_server_credentials(),
-            verify=False,
-        )
+        response = entity().read_raw()
         status_code = httplib.OK
         self.assertEqual(
             status_code,
             response.status_code,
-            status_code_error(path, status_code, response),
+            status_code_error(entity().path(), status_code, response),
         )
         self.assertIn('application/json', response.headers['content-type'])
 
@@ -153,13 +148,12 @@ class EntityTestCase(TestCase):
 
         """
         skip_if_sam(self, entity)
-        path = entity().path()
-        response = client.get(path, verify=False)
+        response = entity().read_raw(auth=())
         status_code = httplib.UNAUTHORIZED
         self.assertEqual(
             status_code,
             response.status_code,
-            status_code_error(path, status_code, response),
+            status_code_error(entity().path(), status_code, response),
         )
 
     @data(
@@ -304,20 +298,15 @@ class EntityIdTestCase(TestCase):
         if entity is entities.ActivationKey and bz_bug_is_open(1127335):
             self.skipTest("Bugzilla bug 1127335 is open.""")
         try:
-            attrs = entity().create()
+            entity_n = entity(id=entity().create()['id'])
         except HTTPError as err:
             self.fail(err)
-        path = entity(id=attrs['id']).path()
-        response = client.get(
-            path,
-            auth=get_server_credentials(),
-            verify=False,
-        )
+        response = entity_n.read_raw()
         status_code = httplib.OK
         self.assertEqual(
             status_code,
             response.status_code,
-            status_code_error(path, status_code, response),
+            status_code_error(entity_n.path(), status_code, response),
         )
         self.assertIn('application/json', response.headers['content-type'])
 
@@ -610,11 +599,7 @@ class DoubleCheckTestCase(TestCase):
         entity_n.delete()
 
         # Get the now non-existent entity.
-        response = client.get(
-            entity_n.path(),
-            auth=get_server_credentials(),
-            verify=False,
-        )
+        response = entity_n.read_raw()
         status_code = httplib.NOT_FOUND
         self.assertEqual(
             status_code,


### PR DESCRIPTION
`read_raw` makes a call to the server being tested and returns a
`requests.models.Response` object. It does not perform any validation, such as
checking the HTTP response code or decoding JSON.

Make `EntityReadMixin.read_json` call `EntityReadMixin.read_json`.
Remove 404 handling logic from `EntityReadMixin.read_json` and add this logic to
class `ActivationKey`. The 404 handling logic is only relevant to activation
keys.

Make module `test_multiple_paths` call `read_raw` instead of directly calling
`robottelo.api.client`.
