### PR TITLE
Update CLI activation key factory

### DIFF
--- a/robottelo/cli/factory.py
+++ b/robottelo/cli/factory.py
@@ -152,7 +152,7 @@ def make_activation_key(options=None):
         u'organization': None,
         u'organization-id': None,
         u'organization-label': None,
-        u'unlimited-content-hosts': True,
+        u'unlimited-content-hosts': 'true',
     }
 
     # Override default dictionary with updated one


### PR DESCRIPTION
The unlimited-content-hosts option was updated upstream. Updating the
factory to match it.

Related to #1502
