### PR TITLE
Add NetmaskField and update Subnet entity

### DIFF
--- a/robottelo/entities.py
+++ b/robottelo/entities.py
@@ -13,7 +13,7 @@ useful to :class:`robottelo.factory.EntityFactoryMixin`.
 
 """
 from datetime import datetime
-from fauxfactory import gen_alpha, gen_alphanumeric, gen_url
+from fauxfactory import gen_alpha, gen_alphanumeric, gen_netmask, gen_url
 from robottelo.api import client
 from robottelo.common.constants import (
     FAKE_1_YUM_REPO, OPERATING_SYSTEMS, VALID_GPG_KEY_FILE)
@@ -1926,7 +1926,7 @@ class Subnet(
     domain = orm.OneToManyField('Domain', null=True)
     from_ = orm.IPAddressField(null=True)
     gateway = orm.StringField(null=True)
-    mask = orm.IPAddressField(required=True)
+    mask = orm.NetmaskField(required=True)
     name = orm.StringField(required=True)
     network = orm.IPAddressField(required=True)
     to = orm.IPAddressField(null=True)  # (invalid-name) pylint:disable=C0103

--- a/robottelo/orm.py
+++ b/robottelo/orm.py
@@ -1,7 +1,7 @@
 """Module that define the model layer used to define entities"""
 from fauxfactory import (
     gen_boolean, gen_choice, gen_email,
-    gen_integer, gen_ipaddr, gen_mac,
+    gen_integer, gen_ipaddr, gen_mac, gen_netmask,
     gen_string, gen_url
 )
 from robottelo.api import client
@@ -210,6 +210,13 @@ class IPAddressField(StringField):
     def get_value(self):
         """Return a value suitable for a :class:`IPAddressField`."""
         return _get_value(self, gen_ipaddr)
+
+
+class NetmaskField(StringField):
+    """Field that represents an netmask"""
+    def get_value(self):
+        """Return a value suitable for a :class:`NetmaskField`."""
+        return _get_value(self, gen_netmask)
 
 
 # FIXME: implement get_value()


### PR DESCRIPTION
Due to recent upstream builds the mask Subnet's fields are being
validated for a valid netmask value. This adds a NetmaskField that
generates valid netmasks using FauxFactory gen_netmask generator. Also
updates the Subnet's mask field to NetmaskField.

Related to #1514
