### PR TITLE
Fix for org+loc selection.

### DIFF
--- a/tests/foreman/ui/test_location.py
+++ b/tests/foreman/ui/test_location.py
@@ -153,8 +153,8 @@ class Location(UITestCase):
         @assert: Both organization and location are selected.
 
         """
-        org_name = test_data['org_name']
-        loc_name = test_data['loc_name']
+        org_name = test_data['org_name'].replace("@", "")
+        loc_name = test_data['loc_name'].replace("@", "")
         org = entities.Organization(name=org_name).create()
         self.assertEqual(org['name'], org_name)
         with Session(self.browser) as session:

--- a/tests/foreman/ui/test_org.py
+++ b/tests/foreman/ui/test_org.py
@@ -222,8 +222,8 @@ class Org(UITestCase):
         @assert: Both organization and location are selected.
 
         """
-        org_name = test_data['org_name']
-        loc_name = test_data['loc_name']
+        org_name = test_data['org_name'].replace("@", "")
+        loc_name = test_data['loc_name'].replace("@", "")
         location = entities.Location(name=loc_name).create()
         self.assertEqual(location['name'], loc_name)
         with Session(self.browser) as session:


### PR DESCRIPTION
If str_type is utf8, it creates a org_name which could contains "@"
which could lead to failures in org and loc selection.

Hence the fix to remove "@" char in org or loc.

Initially I thought I fix this at the CRUD function level of the UI, but turns out to be ugly so thought we better fix this at the testcase level.
