### PR TITLE
Moved `enable_rhrepo_and_fetchid` function to api.utils module.

### DIFF
--- a/tests/foreman/api/test_repository.py
+++ b/tests/foreman/api/test_repository.py
@@ -2,7 +2,7 @@
 from fauxfactory import gen_string
 from random import randint
 from requests.exceptions import HTTPError
-from robottelo.api import client
+from robottelo.api import client, utils
 from robottelo.common.constants import (
     VALID_GPG_KEY_FILE, VALID_GPG_KEY_BETA_FILE, FAKE_0_PUPPET_REPO,
     FAKE_2_YUM_REPO, RPM_TO_UPLOAD)
@@ -246,34 +246,6 @@ class RepositoryUpdateTestCase(TestCase):
             self.assertEqual(value, real_attrs[name])
 
 
-def enable_rhrepo_and_fetchid(basearch, org_id, product, repo,
-                              reposet, releasever):
-    """Enable a RedHat Repository and fetches it's Id.
-
-    :param str org_id: The organization Id.
-    :param str product: The product name in which repository exists.
-    :param str reposet: The reposet name in which repository exists.
-    :param str repo: The repository name who's Id is to be fetched.
-    :param str basearch: The architecture of the repository.
-    :param str releasever: The releasever of the repository.
-    :return: Returns the repository Id.
-    :rtype: str
-
-    """
-    prd_id = entities.Product().fetch_rhproduct_id(name=product, org_id=org_id)
-    reposet_id = entities.Product(id=prd_id).fetch_reposet_id(name=reposet)
-    task_id = entities.Product(id=prd_id).enable_rhrepo(
-        base_arch=basearch,
-        release_ver=releasever,
-        reposet_id=reposet_id,
-    )
-    task_result = entities.ForemanTask(id=task_id).poll()['result']
-    if task_result != "success":
-        raise entities.APIResponseError(
-            "Enabling the RedHat Repository '{}' failed".format(repo))
-    return entities.Repository().fetch_repoid(name=repo, org_id=org_id)
-
-
 class RepositorySyncTestCase(TestCase):
     """Tests for ``/katello/api/repositories/:id/sync``."""
 
@@ -293,7 +265,7 @@ class RepositorySyncTestCase(TestCase):
             id=org_id).upload_manifest(path=cloned_manifest_path)
         task_result = entities.ForemanTask(id=task_id).poll()['result']
         self.assertEqual(u'success', task_result)
-        repo_id = enable_rhrepo_and_fetchid(
+        repo_id = utils.enable_rhrepo_and_fetchid(
             "x86_64",
             org_id,
             "Red Hat Enterprise Linux Server",


### PR DESCRIPTION
This helps both test_repository module and test_smoke module
to use it.
