### PR TITLE
publish and promote function related to cv now return tas_id.

### DIFF
--- a/tests/foreman/api/test_contentview.py
+++ b/tests/foreman/api/test_contentview.py
@@ -18,10 +18,8 @@ def _publish(content_view):
     :rtype: str
 
     """
-    response = entities.ContentView(id=content_view['id']).publish()
-    # FIXME: Update ``entities.ContentView.publish`` to automatically wait
-    # for task to complete.
-    return entities.ForemanTask(id=response['id']).poll()['result']
+    task_id = entities.ContentView(id=content_view['id']).publish()
+    return entities.ForemanTask(id=task_id).poll()['result']
 
 
 def _promote(content_view, lifecycle, version):
@@ -38,11 +36,10 @@ def _promote(content_view, lifecycle, version):
     # Re-fetch cotent view
     content_view = entities.ContentView(id=content_view['id']).read_json()
     # Promote it
-    response = entities.ContentViewVersion(
-        id=content_view['versions'][version]['id']).promote(lifecycle['id'])
-    # FIXME: Update ``entities.ContentViewVersion.promote`` to automatically
-    # wait for task to complete.
-    return entities.ForemanTask(id=response['id']).poll()['result']
+    task_id = entities.ContentViewVersion(
+        id=content_view['versions'][version]['id']
+    ).promote(lifecycle['id'])
+    return entities.ForemanTask(id=task_id).poll()['result']
 
 
 @decorators.run_only_on('sat')
@@ -81,12 +78,12 @@ class ContentViewTestCase(TestCase):
             data={u'content_view_id': content_view['id']},
             verify=False,
         ).json()['results'][0]
-        response = entities.ContentViewVersion(
+        task_id = entities.ContentViewVersion(
             id=content_view_version['id']
         ).promote(environment_id=lifecycle_environment['id'])
         self.assertEqual(
             u'success',
-            entities.ForemanTask(id=response['id']).poll()['result']
+            entities.ForemanTask(id=task_id).poll()['result']
         )
 
         # Create a system that is subscribed to the published and promoted

--- a/tests/foreman/smoke/test_api_smoke.py
+++ b/tests/foreman/smoke/test_api_smoke.py
@@ -352,8 +352,8 @@ class TestSmoke(TestCase):
         )
 
         # step 2.9: Publish content view
-        task = entities.ContentView(id=content_view['id']).publish()
-        task_status = entities.ForemanTask(id=task['id']).poll()
+        task_id = entities.ContentView(id=content_view['id']).publish()
+        task_status = entities.ForemanTask(id=task_id).poll()
         self.assertEqual(
             task_status['result'],
             u'success',
@@ -369,9 +369,10 @@ class TestSmoke(TestCase):
             len(content_view['versions'][0]['environment_ids']),
             1,
             u"Content view should be present on 1 lifecycle only")
-        task = entities.ContentViewVersion(
-            id=content_view['versions'][0]['id']).promote(le1['id'])
-        task_status = entities.ForemanTask(id=task['id']).poll()
+        task_id = entities.ContentViewVersion(
+            id=content_view['versions'][0]['id']
+        ).promote(le1['id'])
+        task_status = entities.ForemanTask(id=task_id).poll()
         self.assertEqual(
             task_status['result'],
             u'success',
@@ -387,9 +388,10 @@ class TestSmoke(TestCase):
             len(content_view['versions'][0]['environment_ids']),
             2,
             u"Content view should be present on 2 lifecycles only")
-        task = entities.ContentViewVersion(
-            id=content_view['versions'][0]['id']).promote(le2['id'])
-        task_status = entities.ForemanTask(id=task['id']).poll()
+        task_id = entities.ContentViewVersion(
+            id=content_view['versions'][0]['id']
+        ).promote(le2['id'])
+        task_status = entities.ForemanTask(id=task_id).poll()
         self.assertEqual(
             task_status['result'],
             u'success',
@@ -424,7 +426,6 @@ class TestSmoke(TestCase):
             le2['id'],
             u"Environments do not match."
         )
-
 
     def _search(self, entity, query, auth=None):
         """

--- a/tests/foreman/ui/test_activationkey.py
+++ b/tests/foreman/ui/test_activationkey.py
@@ -94,17 +94,18 @@ class ActivationKey(UITestCase):
         response.raise_for_status()
 
         # Publish content view
-        task = entities.ContentView(id=content_view['id']).publish()
-        task_status = entities.ForemanTask(id=task['id']).poll()
+        task_id = entities.ContentView(id=content_view['id']).publish()
+        task_status = entities.ForemanTask(id=task_id).poll()
         self.assertEqual(
             task_status['result'],
             u'success',
             u"Publishing {0} failed.".format(content_view['name']))
         # Promote the Version 1 to selected environment
         content_view = entities.ContentView(id=content_view['id']).read_json()
-        task = entities.ContentViewVersion(
-            id=content_view['versions'][0]['id']).promote(env_attrs['id'])
-        task_status = entities.ForemanTask(id=task['id']).poll()
+        task_id = entities.ContentViewVersion(
+            id=content_view['versions'][0]['id']
+        ).promote(env_attrs['id'])
+        task_status = entities.ForemanTask(id=task_id).poll()
         self.assertEqual(
             task_status['result'],
             u'success',


### PR DESCRIPTION
So now it waits for task to complete only if synchronous=True and
returns a task_id.

Also the relevent testcases have now been updated accordingly.
