### PR TITLE
Add a test targeting BZ 1151220

### DIFF
--- a/robottelo/entities.py
+++ b/robottelo/entities.py
@@ -89,7 +89,7 @@ class Architecture(
         api_path = 'api/v2/architectures'
         server_modes = ('sat')
 
-    # FIXME: This method should not need to exist. The API has a bug.
+    # NOTE: See BZ 1151220
     def create(self, auth=None, data=None):
         """Extend the implementation of
         :meth:`robottelo.factory.Factory.create`.
@@ -1069,7 +1069,7 @@ class Media(
             )
         return super(Media, self)._factory_data()
 
-    # FIXME: This method should not need to exist. The API has a bug.
+    # NOTE: See BZ 1151220
     def create(self, auth=None, data=None):
         """Extend the implementation of
         :meth:`robottelo.factory.Factory.create`.
@@ -1178,7 +1178,7 @@ class OperatingSystem(
         )
         server_modes = ('sat')
 
-    # FIXME: This method should not need to exist. The API has a bug.
+    # NOTE: See BZ 1151220
     def create(self, auth=None, data=None):
         """Extend the implementation of
         :meth:`robottelo.factory.Factory.create`.

--- a/tests/foreman/api/test_architecture.py
+++ b/tests/foreman/api/test_architecture.py
@@ -1,0 +1,40 @@
+"""Unit tests for the ``architectures`` paths."""
+from fauxfactory import gen_utf8
+from robottelo.api import client
+from robottelo.common.decorators import skip_if_bug_open
+from robottelo.common.helpers import get_server_credentials
+from robottelo import entities
+from unittest import TestCase
+# (too-many-public-methods) pylint:disable=R0904
+
+
+class ArchitectureTestCase(TestCase):
+    """Tests for architectures."""
+
+    @skip_if_bug_open('bugzilla', 1151220)
+    def test_extra_hash(self):
+        """@Test: Do not wrap API calls in an extra hash.
+
+        @Assert: It is possible to associate an activation key with an
+        organization.
+
+        @Feature: ActivationKey
+
+        """
+        name = gen_utf8()
+        os_id = entities.OperatingSystem().create()['id']
+        response = client.post(
+            entities.Architecture().path(),
+            {u'name': name, u'operatingsystem_ids': [os_id]},
+            auth=get_server_credentials(),
+            verify=False,
+        )
+        response.raise_for_status()
+        attrs = response.json()
+
+        # The server will accept some POSTed attributes (name) and silently
+        # ignore others (operatingsystem_ids).
+        self.assertIn('name', attrs)
+        self.assertEqual(name, attrs['name'])
+        self.assertIn('operatingsystems', attrs)
+        self.assertEqual([os_id], attrs['operatingsystems'])


### PR DESCRIPTION
Clients must submit a nested hash of attributes to certain API URLs.

For example, POSTing this data to the `/architectures` URL will succeed:

```
{'name': 'foo'}
```

However, these operating system IDs will be silently ignored:

```
{'name': 'foo', 'operatingsystem_ids': [1, 2, 3]}
```

A client can hack around this oddity by wrapping submitted data inside an extra
hash:

```
{'architecture': {'name': 'foo', 'operatingsystem_ids': [1, 2, 3]}}
```

This extra hash should not be necessary. It makes the API harder to use, and
the extra hash is only required for some API calls.
