### PR TITLE
Add test targeting BZ 1151240

### DIFF
--- a/robottelo/entities.py
+++ b/robottelo/entities.py
@@ -108,7 +108,7 @@ class Architecture(
             data = {u'architecture': self.build(auth=auth)}
         return super(Architecture, self).create(auth, data)
 
-    # FIXME: This method should not need to exist. The API has a bug.
+    # NOTE: See BZ 1151240
     def read(self, auth=None, entity=None, attrs=None):
         """Override the default implementation of
         :meth:`robottelo.orm.EntityReadMixin.read`.
@@ -1088,7 +1088,7 @@ class Media(
             data = {u'medium': self.build(auth=auth)}
         return super(Media, self).create(auth, data)
 
-    # FIXME: This method should not need to exist. The API has a bug.
+    # NOTE: See BZ 1151240
     def read(self, auth=None, entity=None, attrs=None):
         """Override the default implementation of
         :meth:`robottelo.orm.EntityReadMixin.read`.
@@ -1829,12 +1829,12 @@ class Repository(
             )
         return super(Repository, self).path(which)
 
+    # NOTE: See BZ 1151240
     def read(self, auth=None, entity=None, attrs=None):
         """Override the default implementation of
         :meth:`robottelo.orm.EntityReadMixin.read`.
 
         """
-        # FIXME: This method is a hack. It should not need to exist.
         if attrs is None:
             attrs = self.read_json(auth)
         attrs['product_id'] = attrs.pop('product')['id']

--- a/tests/foreman/api/test_architecture.py
+++ b/tests/foreman/api/test_architecture.py
@@ -12,13 +12,13 @@ class ArchitectureTestCase(TestCase):
     """Tests for architectures."""
 
     @skip_if_bug_open('bugzilla', 1151220)
-    def test_extra_hash(self):
+    def test_post_hash(self):
         """@Test: Do not wrap API calls in an extra hash.
 
         @Assert: It is possible to associate an activation key with an
         organization.
 
-        @Feature: ActivationKey
+        @Feature: Architecture
 
         """
         name = gen_utf8()
@@ -38,3 +38,18 @@ class ArchitectureTestCase(TestCase):
         self.assertEqual(name, attrs['name'])
         self.assertIn('operatingsystems', attrs)
         self.assertEqual([os_id], attrs['operatingsystems'])
+
+    @skip_if_bug_open('bugzilla', 1151240)
+    def test_get_hash(self):
+        """@Test: Read the API and look for a list of IDs.
+
+        @Assert: The architecture-OS foreign key relationship is described with
+        a list of IDs.
+
+        @Feature: Architecture
+
+        """
+        os_id = entities.OperatingSystem().create()['id']
+        attrs = entities.Architecture(operatingsystem=[os_id]).create()
+        self.assertIn('operatingsystem_ids', attrs)
+        self.assertEqual(attrs['operatingsystem_ids'], [os_id])


### PR DESCRIPTION
Some API responses contain a list of IDs, and others contain a list of hashes.

For example, a GET request to `/gpgkeys/:id` returns data in this format:

```
{u'name': u'foo', u'organization': {u'name': u'ACME', u'label': '...'}}
```

No organization ID is listed. This means that it is impossible to discover what
organization this GPG key belongs to except by issuing a follow-up search to the
`/organizations` URL (and hopefully coming up with only one result).

As a second example, a GET request to `/architectures/:id` returns data in this
format:

```
{
    u'name': u'i386',
    u'operatingsystems': [
        {u'id': 1, u'name': u'rhel65'},
        {u'id': 2, u'name': u'rhel7'},
    ]
}
```

This is awkward. In this case, the client can compile a list of associated
operating systems by iterating through the returned hashes and fetching through
their IDs. It is much easier to deal with a straight list of IDs:

```
{u'name': u'i386', u'operatingsystem_ids': [1, 2]}
```

The API should return either an ID or a list of IDs for all foreign key
relationships. Client code can be simple and straightforward if a list of IDs is
returned.
