### PR TITLE
Added API tests for Docker images.

### DIFF
--- a/robottelo/common/constants.py
+++ b/robottelo/common/constants.py
@@ -177,6 +177,7 @@ FILTER_CONTENT_TYPE = {
 FILTER_TYPE = {'include': "Include",
                'exclude': "Exclude"}
 
+DOCKER_REGISTRY_HUB = u'https://registry.hub.docker.com/'
 GOOGLE_CHROME_REPO = u'http://dl.google.com/linux/chrome/rpm/stable/x86_64'
 FAKE_0_YUM_REPO = "http://inecas.fedorapeople.org/fakerepos/zoo/"
 FAKE_1_YUM_REPO = "http://inecas.fedorapeople.org/fakerepos/zoo3/"


### PR DESCRIPTION
Added two new API tests for creating repositories that use Docker
content.

**NOTE**: To synchronize a `Docker` image, the `name` of your custom
  repository **must** match (case matters) the name of the Docker image.
  For example, the
  [WordPress](https://registry.hub.docker.com/_/wordpress/) image would
  require that your repository name be `wordpress` as it is displayed
  in its URL.
