### PR TITLE
Multiple updates to api tests

### DIFF
--- a/tests/foreman/api/test_contentview.py
+++ b/tests/foreman/api/test_contentview.py
@@ -1,12 +1,13 @@
 """Unit tests for the ``content_views`` paths."""
+from ddt import ddt
 from fauxfactory import gen_integer, gen_string, gen_utf8
 from requests.exceptions import HTTPError
 from robottelo.api import client
+from robottelo.common.decorators import (
+    bz_bug_is_open, data, run_only_on, stubbed)
 from robottelo.common.helpers import get_server_credentials
-from robottelo.common import decorators
 from robottelo import entities
 from unittest import TestCase
-import ddt
 # (too-many-public-methods) pylint:disable=R0904
 
 
@@ -42,8 +43,8 @@ def _promote(content_view, lifecycle, version):
     return entities.ForemanTask(id=task_id).poll()['result']
 
 
-@decorators.run_only_on('sat')
-@ddt.ddt
+@run_only_on('sat')
+@ddt
 class ContentViewTestCase(TestCase):
     """Tests for content views."""
     def test_subscribe_system_to_cv(self):
@@ -112,7 +113,7 @@ class ContentViewTestCase(TestCase):
         # )
 
 
-@ddt.ddt
+@ddt
 class ContentViewCreateTestCase(TestCase):
     """Tests for creating content views."""
 
@@ -142,7 +143,7 @@ class ContentViewCreateTestCase(TestCase):
         )
         self.assertTrue(content_view.read_json()['composite'])
 
-    @decorators.data(
+    @data(
         gen_string('alpha', gen_integer(3, 30)),
         gen_string('alphanumeric', gen_integer(3, 30)),
         gen_string('cjk', gen_integer(3, 30)),
@@ -165,7 +166,7 @@ class ContentViewCreateTestCase(TestCase):
         attrs = entities.ContentView(id=content_view).read_json()
         self.assertEqual(attrs['name'], name)
 
-    @decorators.data(
+    @data(
         gen_string('alpha', gen_integer(3, 30)),
         gen_string('alphanumeric', gen_integer(3, 30)),
         gen_string('cjk', gen_integer(3, 30)),
@@ -189,7 +190,7 @@ class ContentViewCreateTestCase(TestCase):
         self.assertEqual(attrs['description'], description)
 
 
-@ddt.ddt
+@ddt
 class ContentViewPublishTestCase(TestCase):
     """Tests for publishing content views."""
 
@@ -247,7 +248,7 @@ class ContentViewPublishTestCase(TestCase):
             u"Content view should be present in 1 lifecycle only")
 
 
-@ddt.ddt
+@ddt
 class ContentViewPromoteTestCase(TestCase):
     """Tests for promoting content views."""
 
@@ -334,7 +335,7 @@ class ContentViewPromoteTestCase(TestCase):
             u"Content view should be present on 2 lifecycles only")
 
 
-@ddt.ddt
+@ddt
 class ContentViewUpdateTestCase(TestCase):
     """Tests for updating content views."""
     @classmethod
@@ -344,7 +345,7 @@ class ContentViewUpdateTestCase(TestCase):
             id=entities.ContentView().create()['id']
         )
 
-    @decorators.data(
+    @data(
         {u'name': entities.ContentView.name.get_value()},
         {u'description': entities.ContentView.description.get_value()},
     )
@@ -369,7 +370,7 @@ class ContentViewUpdateTestCase(TestCase):
             self.assertIn(name, new_attrs.keys())
             self.assertEqual(new_attrs[name], value)
 
-    @decorators.data(
+    @data(
         {u'label': gen_utf8(30), u'bz-bug': 1147100},  # Immutable.
         {u'name': gen_utf8(256)},
     )
@@ -382,7 +383,7 @@ class ContentViewUpdateTestCase(TestCase):
 
         """
         bug_id = attrs.pop('bz-bug', None)
-        if bug_id is not None and decorators.bz_bug_is_open(bug_id):
+        if bug_id is not None and bz_bug_is_open(bug_id):
             self.skipTest('Bugzilla bug {0} is open.'.format(bug_id))
 
         response = client.put(
@@ -395,14 +396,14 @@ class ContentViewUpdateTestCase(TestCase):
             response.raise_for_status()
 
 
-@decorators.run_only_on('sat')
+@run_only_on('sat')
 class ContentViewTestCaseStub(TestCase):
     """Incomplete tests for content views."""
     # Each of these tests should be given a better name when they're
     # implemented. In the meantime, let's not worry about bad names.
     # (invalid-name) pylint:disable=C0103
 
-    @decorators.stubbed
+    @stubbed
     def test_cv_edit_rh_custom_spin(self):
         """
         @test: edit content views for a custom rh spin.  For example,
@@ -426,7 +427,7 @@ class ContentViewTestCaseStub(TestCase):
     # katello content definition add_repo --label=MyView
     #   --repo=repo1 --org=ACME
 
-    @decorators.stubbed
+    @stubbed
     def test_associate_view_rh(self):
         """
         @test: associate Red Hat content in a view
@@ -436,7 +437,7 @@ class ContentViewTestCaseStub(TestCase):
         @status: Manual
         """
 
-    @decorators.stubbed
+    @stubbed
     def test_associate_view_rh_custom_spin(self):
         """
         @test: associate Red Hat content in a view
@@ -452,7 +453,7 @@ class ContentViewTestCaseStub(TestCase):
         #   * A filter on severity (only content of specific errata
         # severity.
 
-    @decorators.stubbed
+    @stubbed
     def test_associate_view_custom_content(self):
         """
         @test: associate Red Hat content in a view
@@ -462,7 +463,7 @@ class ContentViewTestCaseStub(TestCase):
         @status: Manual
         """
 
-    @decorators.stubbed
+    @stubbed
     def test_cv_associate_puppet_repo_negative(self):
         """
         @test: attempt to associate puppet repos within a custom
@@ -473,7 +474,7 @@ class ContentViewTestCaseStub(TestCase):
         @status: Manual
         """
 
-    @decorators.stubbed
+    @stubbed
     def test_cv_associate_components_composite_negative(self):
         """
         @test: attempt to associate components n a non-composite
@@ -483,7 +484,7 @@ class ContentViewTestCaseStub(TestCase):
         @status: Manual
         """
 
-    @decorators.stubbed
+    @stubbed
     def test_cv_associate_composite_dupe_repos_negative(self):
         """
         @test: attempt to associate the same repo multiple times within a
@@ -493,7 +494,7 @@ class ContentViewTestCaseStub(TestCase):
         @status: Manual
         """
 
-    @decorators.stubbed
+    @stubbed
     def test_cv_associate_composite_dupe_modules_negative(self):
         """
         @test: attempt to associate duplicate puppet module(s) within a
@@ -507,7 +508,7 @@ class ContentViewTestCaseStub(TestCase):
     # katello content view promote --label=MyView --env=Dev --org=ACME
     # katello content view promote --view=MyView --env=Staging --org=ACME
 
-    @decorators.stubbed
+    @stubbed
     def test_cv_promote_rh(self):
         """
         @test: attempt to promote a content view containing RH content
@@ -517,7 +518,7 @@ class ContentViewTestCaseStub(TestCase):
         @status: Manual
         """
 
-    @decorators.stubbed
+    @stubbed
     def test_cv_promote_rh_custom_spin(self):
         """
         @test: attempt to promote a content view containing a custom RH
@@ -528,7 +529,7 @@ class ContentViewTestCaseStub(TestCase):
         @status: Manual
         """
 
-    @decorators.stubbed
+    @stubbed
     def test_cv_promote_custom_content(self):
         """
         @test: attempt to promote a content view containing custom content
@@ -537,7 +538,7 @@ class ContentViewTestCaseStub(TestCase):
         @assert: Content view can be promoted
         """
 
-    @decorators.stubbed
+    @stubbed
     def test_cv_promote_composite(self):
         """
         @test: attempt to promote a content view containing custom content
@@ -552,7 +553,7 @@ class ContentViewTestCaseStub(TestCase):
         # Custom content (i.e., fedora), puppet modules
         # ...etc.
 
-    @decorators.stubbed
+    @stubbed
     def test_cv_promote_badid_negative(self):
         """
         @test: attempt to promote a content view using an invalid id
@@ -572,8 +573,8 @@ class ContentViewTestCaseStub(TestCase):
     # Content Views: publish
     # katello content definition publish --label=MyView
 
-    @decorators.stubbed
-    def test_cv_publish_rh(self, data):
+    @stubbed
+    def test_cv_publish_rh(self):
         """
         @test: attempt to publish a content view containing RH content
         @feature: Content Views
@@ -582,7 +583,7 @@ class ContentViewTestCaseStub(TestCase):
         """
         # See method test_subscribe_system_to_cv in module test_contentview_v2
 
-    @decorators.stubbed
+    @stubbed
     def test_cv_publish_rh_custom_spin(self):
         """
         @test: attempt to publish  a content view containing a custom RH
@@ -593,7 +594,7 @@ class ContentViewTestCaseStub(TestCase):
         @status: Manual
         """
 
-    @decorators.stubbed
+    @stubbed
     def test_cv_publish_custom_content(self):
         """
         @test: attempt to publish a content view containing custom content
@@ -603,7 +604,7 @@ class ContentViewTestCaseStub(TestCase):
         @status: Manual
         """
 
-    @decorators.stubbed
+    @stubbed
     def test_cv_publish_composite(self):
         """
         @test: attempt to publish  a content view containing custom content
@@ -617,7 +618,7 @@ class ContentViewTestCaseStub(TestCase):
         # Custom content (i.e., fedora), puppet modules
         # ...etc.
 
-    @decorators.stubbed
+    @stubbed
     def test_cv_publish_badlabel_negative(self):
         """
         @test: attempt to publish a content view containing invalid strings
@@ -631,7 +632,7 @@ class ContentViewTestCaseStub(TestCase):
         # Variations might be:
         # zero length, too long, symbols, etc.
 
-    @decorators.stubbed
+    @stubbed
     def test_cv_publish_version_changes_in_target_env(self):
         """
         @test: when publishing new version to environment, version
@@ -650,7 +651,7 @@ class ContentViewTestCaseStub(TestCase):
         # Dev, version x goes away (ie when I promote version 1 to Dev,
         # version 3 goes away)
 
-    @decorators.stubbed
+    @stubbed
     def test_cv_publish_version_changes_in_source_env(self):
         """
         @test: when publishing new version to environment, version
@@ -668,7 +669,7 @@ class ContentViewTestCaseStub(TestCase):
         # Similarly when I publish version y, version x goes away from
         # Library (ie when I publish version 2, version 1 disappears)
 
-    @decorators.stubbed
+    @stubbed
     def test_cv_clone_within_same_env(self):
         """
         @test: attempt to create new content view based on existing
@@ -679,7 +680,7 @@ class ContentViewTestCaseStub(TestCase):
         """
         # Dev note: "not implemented yet"
 
-    @decorators.stubbed
+    @stubbed
     def test_cv_clone_within_diff_env(self):
         """
         @test: attempt to create new content view based on existing
@@ -690,7 +691,7 @@ class ContentViewTestCaseStub(TestCase):
         """
         # Dev note: "not implemented yet"
 
-    @decorators.stubbed
+    @stubbed
     def test_cv_refresh_errata_to_new_view_in_same_env(self):
         """
         @test: attempt to refresh errata in a new view, based on
@@ -700,7 +701,7 @@ class ContentViewTestCaseStub(TestCase):
         @status: Manual
         """
 
-    @decorators.stubbed
+    @stubbed
     def test_cv_subscribe_system(self):
         """
         @test: attempt to  subscribe systems to content view(s)
@@ -719,7 +720,7 @@ class ContentViewTestCaseStub(TestCase):
         # * composite
         # * CVs with puppet modules
 
-    @decorators.stubbed
+    @stubbed
     def test_custom_cv_subscribe_system(self):
         """
         @test: attempt to  subscribe systems to content view(s)
@@ -729,7 +730,7 @@ class ContentViewTestCaseStub(TestCase):
         # This test is implemented in tests/foreman/smoke/test_api_smoke.py.
         # See the end of method TestSmoke.test_smoke.
 
-    @decorators.stubbed
+    @stubbed
     def test_cv_dynflow_restart_promote(self):
         """
         @test: attempt to restart a promotion
@@ -741,7 +742,7 @@ class ContentViewTestCaseStub(TestCase):
         @status: Manual
         """
 
-    @decorators.stubbed
+    @stubbed
     def test_cv_dynflow_restart_publish(self):
         """
         @test: attempt to restart a publish
@@ -756,7 +757,7 @@ class ContentViewTestCaseStub(TestCase):
     # ROLES TESTING
     # All this stuff is speculative at best.
 
-    @decorators.stubbed
+    @stubbed
     def test_cv_roles_admin_user(self):
         """
         @test: attempt to view content views
@@ -775,7 +776,7 @@ class ContentViewTestCaseStub(TestCase):
         # Variations:
         #  * Read, Modify, Delete, Promote Publish, Subscribe
 
-    @decorators.stubbed
+    @stubbed
     def test_cv_roles_readonly_user(self):
         """
         @test: attempt to view content views
@@ -795,7 +796,7 @@ class ContentViewTestCaseStub(TestCase):
         # Variations:
         #  * Read, Modify,  Promote?, Publish?, Subscribe??
 
-    @decorators.stubbed
+    @stubbed
     def test_cv_roles_admin_user_negative(self):
         """
         @test: attempt to view content views
@@ -814,7 +815,7 @@ class ContentViewTestCaseStub(TestCase):
         # Variations:
         #  * Read, Modify, Delete, Promote Publish, Subscribe
 
-    @decorators.stubbed
+    @stubbed
     def test_cv_roles_readonly_user_negative(self):
         """
         @test: attempt to view content views

--- a/tests/foreman/api/test_environment.py
+++ b/tests/foreman/api/test_environment.py
@@ -4,21 +4,21 @@ A full API reference for environments can be found here:
 http://theforeman.org/api/apidoc/v2/environments.html
 
 """
+from ddt import ddt
 from fauxfactory import gen_string
 from requests.exceptions import HTTPError
-from robottelo.common import decorators
+from robottelo.common.decorators import data, run_only_on
 from robottelo import entities
 from unittest import TestCase
-import ddt
 import random
 # (too-many-public-methods) pylint:disable=R0904
 
 
-@decorators.run_only_on('sat')
-@ddt.ddt
+@run_only_on('sat')
+@ddt
 class EnvironmentTestCase(TestCase):
     """Tests for environments."""
-    @decorators.data(
+    @data(
         gen_string('alpha', random.randint(1, 255)),
         gen_string('numeric', random.randint(1, 255)),
         gen_string('alphanumeric', random.randint(1, 255)),
@@ -39,7 +39,7 @@ class EnvironmentTestCase(TestCase):
         attrs = entities.Environment(id=attrs['id']).read_json()
         self.assertEqual(attrs['name'], name)
 
-    @decorators.data(
+    @data(
         gen_string('alpha', 256),
         gen_string('numeric', 256),
         gen_string('alphanumeric', 256),

--- a/tests/foreman/api/test_permission.py
+++ b/tests/foreman/api/test_permission.py
@@ -4,15 +4,15 @@ Each ``TestCase`` subclass tests a single URL. A full list of URLs to be tested
 can be found here: http://theforeman.org/api/apidoc/v2/permissions.html
 
 """
+from ddt import data as ddt_data, ddt
 from fauxfactory import gen_alphanumeric
 from requests.exceptions import HTTPError
 from robottelo.api import client
 from robottelo.common.constants import PERMISSIONS
+from robottelo.common.decorators import data, run_only_on
 from robottelo.common.helpers import get_server_credentials
-from robottelo.common import decorators
 from robottelo import entities
 from unittest import TestCase
-import ddt
 import itertools
 import re
 # (too-many-public-methods) pylint:disable=R0904
@@ -23,11 +23,11 @@ PERMISSIONS_RESOURCE_TYPE = [key for key in PERMISSIONS.keys()
 PERMISSIONS_NAME = [value for value in itertools.chain(*PERMISSIONS.values())]
 
 
-@ddt.ddt
+@ddt
 class PermissionsTestCase(TestCase):
     """Tests for the ``permissions`` path."""
-    @decorators.run_only_on('sat')
-    @ddt.data(*PERMISSIONS_NAME)
+    @run_only_on('sat')
+    @ddt_data(*PERMISSIONS_NAME)  # pylint:disable=W0142
     def test_search_by_name(self, permission_name):
         """@test: permissions can be searched by name
 
@@ -40,8 +40,8 @@ class PermissionsTestCase(TestCase):
         self.assertEqual(len(result), 1)
         self.assertEqual(permission_name, result[0]['name'])
 
-    @decorators.run_only_on('sat')
-    @ddt.data(*PERMISSIONS_RESOURCE_TYPE)
+    @run_only_on('sat')
+    @ddt_data(*PERMISSIONS_RESOURCE_TYPE)  # pylint:disable=W0142
     def test_search_by_resource_type(self, resource_type):
         """@test: permissions can be searched by resource type
 
@@ -57,7 +57,7 @@ class PermissionsTestCase(TestCase):
         self.assertEqual(len(result), len(permissions))
         self.assertItemsEqual(permissions, result_permissions)
 
-    @decorators.run_only_on('sat')
+    @run_only_on('sat')
     def test_search_permissions(self):
         """@test: search with no parameters return all permissions
 
@@ -108,7 +108,7 @@ def _permission_name(entity, which_perm):
 
 
 # This class might better belong in module test_multiple_paths.
-@ddt.ddt
+@ddt
 class UserRoleTestCase(TestCase):
     """Give a user various permissions and see if they are enforced."""
 
@@ -155,7 +155,7 @@ class UserRoleTestCase(TestCase):
             verify=False,
         ).raise_for_status()
 
-    @decorators.data(
+    @data(
         entities.Architecture,
         entities.Domain,
     )
@@ -174,7 +174,7 @@ class UserRoleTestCase(TestCase):
         entity_id = entity().create(auth=self.auth)['id']
         entity(id=entity_id).read_json()  # read as an admin user
 
-    @decorators.data(
+    @data(
         entities.Architecture,
         entities.Domain,
     )
@@ -193,7 +193,7 @@ class UserRoleTestCase(TestCase):
         self.give_user_permission(_permission_name(entity, 'read'))
         entity_obj.read_json(auth=self.auth)
 
-    @decorators.data(
+    @data(
         entities.Architecture,
         entities.Domain,
     )
@@ -214,7 +214,7 @@ class UserRoleTestCase(TestCase):
         with self.assertRaises(HTTPError):
             entity_obj.read_json()  # As admin user
 
-    @decorators.data(
+    @data(
         entities.Architecture,
         entities.Domain,
     )

--- a/tests/foreman/api/test_product.py
+++ b/tests/foreman/api/test_product.py
@@ -4,24 +4,24 @@ A full API reference for products can be found here:
 http://theforeman.org/api/apidoc/v2/products.html
 
 """
+from ddt import ddt
 from fauxfactory import gen_string
 from random import randint
 from robottelo.api import client
 from robottelo.common.constants import VALID_GPG_KEY_FILE
 from robottelo.common.helpers import get_server_credentials, read_data_file
-from robottelo.common import decorators
+from robottelo.common.decorators import data, run_only_on
 from robottelo import entities
 from unittest import TestCase
-import ddt
 # (too-many-public-methods) pylint:disable=R0904
 
 
-@ddt.ddt
+@ddt
 class ProductsTestCase(TestCase):
     """Tests for ``katello/api/v2/products``."""
 
-    @decorators.run_only_on('sat')
-    @decorators.data(
+    @run_only_on('sat')
+    @data(
         {u'name': gen_string('alphanumeric', randint(1, 255))},
         {u'name': gen_string('alpha', randint(1, 255))},
         {u'name': gen_string('cjk', randint(1, 85))},
@@ -49,7 +49,7 @@ class ProductsTestCase(TestCase):
             self.assertIn(name, prod_attrs.keys())
             self.assertEqual(value, prod_attrs[name])
 
-    @decorators.run_only_on('sat')
+    @run_only_on('sat')
     def test_positive_create_2(self):
         """@Test: Create a product and provide a GPG key.
 
@@ -79,8 +79,8 @@ class ProductsTestCase(TestCase):
         self.assertEqual(attrs['gpg_key_id'], gpgkey_attrs['id'])
 
 
-@decorators.run_only_on('sat')
-@ddt.ddt
+@run_only_on('sat')
+@ddt
 class ProductUpdateTestCase(TestCase):
     """Tests for updating a product."""
     @classmethod
@@ -90,7 +90,7 @@ class ProductUpdateTestCase(TestCase):
             id=entities.Product().create()['id']
         )
 
-    @decorators.data(
+    @data(
         {u'name': gen_string('alphanumeric', randint(1, 255))},
         {u'name': gen_string('alpha', randint(1, 255))},
         {u'name': gen_string('cjk', randint(1, 85))},

--- a/tests/foreman/api/test_repository.py
+++ b/tests/foreman/api/test_repository.py
@@ -1,4 +1,5 @@
 """Unit tests for the ``repositories`` paths."""
+from ddt import ddt
 from fauxfactory import gen_string
 from random import randint
 from requests.exceptions import HTTPError
@@ -11,17 +12,16 @@ from robottelo.common.constants import (
     VALID_GPG_KEY_BETA_FILE,
     VALID_GPG_KEY_FILE,
 )
-from robottelo.common import decorators
+from robottelo.common.decorators import data, run_only_on
 from robottelo.common import manifests
 from robottelo.common.helpers import (
     get_server_credentials, get_data_file, read_data_file)
 from robottelo import entities
 from unittest import TestCase
-import ddt
 # (too-many-public-methods) pylint:disable=R0904
 
 
-@ddt.ddt
+@ddt
 class RepositoryTestCase(TestCase):
     """Tests for ``katello/api/v2/repositories``."""
     @classmethod
@@ -30,8 +30,8 @@ class RepositoryTestCase(TestCase):
         cls.org_id = entities.Organization().create()['id']
         cls.prod_id = entities.Product(organization=cls.org_id).create()['id']
 
-    @decorators.run_only_on('sat')
-    @decorators.data(
+    @run_only_on('sat')
+    @data(
         {'content_type': 'puppet', 'url': FAKE_0_PUPPET_REPO},
         {'name': gen_string('alphanumeric', randint(10, 50))},
         {'name': gen_string('alpha', randint(10, 50))},
@@ -59,7 +59,7 @@ class RepositoryTestCase(TestCase):
             self.assertIn(name, real_attrs.keys())
             self.assertEqual(value, real_attrs[name])
 
-    @decorators.run_only_on('sat')
+    @run_only_on('sat')
     def test_create_gpgkey(self):
         """@Test: Create a repository and provide a GPG key ID.
 
@@ -86,7 +86,7 @@ class RepositoryTestCase(TestCase):
         repo_attrs = entities.Repository(id=repo_id).read_json()
         self.assertEqual(repo_attrs['gpg_key_id'], gpgkey_id)
 
-    @decorators.run_only_on('sat')
+    @run_only_on('sat')
     def test_create_same_name(self):
         """@Test: Create two repos with the same name in two organizations.
 
@@ -109,8 +109,8 @@ class RepositoryTestCase(TestCase):
                 entities.Repository(id=repo2_attrs['id']).read_json()):
             self.assertEqual(attrs['name'], name)
 
-    @decorators.run_only_on('sat')
-    @decorators.data(
+    @run_only_on('sat')
+    @data(
         {'content_type': 'puppet', 'url': FAKE_0_PUPPET_REPO},
         {'name': gen_string('alphanumeric', randint(10, 50))},
         {'name': gen_string('alpha', randint(10, 50))},
@@ -137,7 +137,7 @@ class RepositoryTestCase(TestCase):
         with self.assertRaises(HTTPError):
             entities.Repository(id=repo_id).read_json()
 
-    @decorators.run_only_on('sat')
+    @run_only_on('sat')
     def test_update_gpgkey(self):
         """@Test: Create a repository and update its GPGKey
 
@@ -172,7 +172,7 @@ class RepositoryTestCase(TestCase):
         attrs = entities.Repository(id=repo_id).read_json()
         self.assertEqual(attrs['gpg_key_id'], key_2_id)
 
-    @decorators.run_only_on('sat')
+    @run_only_on('sat')
     def test_update_contents(self):
         """@Test: Create a repository and upload RPM contents.
 
@@ -210,7 +210,7 @@ class RepositoryTestCase(TestCase):
         self.assertGreaterEqual(attrs[u'content_counts'][u'rpm'], 1)
 
 
-@ddt.ddt
+@ddt
 class RepositoryUpdateTestCase(TestCase):
     """Tests for updating repositories."""
     @classmethod
@@ -220,8 +220,8 @@ class RepositoryUpdateTestCase(TestCase):
             id=entities.Repository().create()['id']
         )
 
-    @decorators.run_only_on('sat')
-    @decorators.data(
+    @run_only_on('sat')
+    @data(
         {'name': gen_string('alphanumeric', randint(10, 50))},
         {'name': gen_string('alpha', randint(10, 50))},
         {'name': gen_string('cjk', randint(10, 50))},
@@ -254,7 +254,7 @@ class RepositoryUpdateTestCase(TestCase):
 class RepositorySyncTestCase(TestCase):
     """Tests for ``/katello/api/repositories/:id/sync``."""
 
-    @decorators.run_only_on('sat')
+    @run_only_on('sat')
     def test_redhat_sync_1(self):
         """@Test: Sync RedHat Repository.
 
@@ -286,7 +286,7 @@ class RepositorySyncTestCase(TestCase):
             u"Sync for repository '{0}' failed.".format(repo))
 
 
-@ddt.ddt
+@ddt
 class DockerRepositoryTestCase(TestCase):
     """Tests specific to using ``Docker`` repositories."""
     @classmethod
@@ -295,7 +295,7 @@ class DockerRepositoryTestCase(TestCase):
         cls.org_id = entities.Organization().create()['id']
         cls.prod_id = entities.Product(organization=cls.org_id).create()['id']
 
-    @decorators.run_only_on('sat')
+    @run_only_on('sat')
     def test_create_docker_repo(self):
         """@Test: Create a Docker-type repository
 
@@ -317,7 +317,7 @@ class DockerRepositoryTestCase(TestCase):
         self.assertEqual(real_attrs['name'], name)
         self.assertEqual(real_attrs['content_type'], content_type)
 
-    @decorators.run_only_on('sat')
+    @run_only_on('sat')
     def test_sync_docker_repo(self):
         """@Test: Create and sync a Docker-type repository
 


### PR DESCRIPTION
1. Removed references to decorators.($func) by importing them directly
2. Imported ddt.data as ddt_data to differentiate it from decorators.data - This change is done inorder to make the api tests **consistent** with ui/cli tests
3. Added pylint disables to make pylint happy for all the files in this commit
