### PR TITLE
Remove unused iniparse requirement

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,3 @@
-# For parsing config file.
-iniparse
-
 # For all tests.
 booby
 fauxfactory


### PR DESCRIPTION
Git grep show that the iniparse is not used anywhere in the framework, better to remove it from requirements.txt

``` sh
git grep iniparse | cat -
requirements.txt:iniparse
```
