### PR TITLE
Drop the * operator from a function call

### DIFF
--- a/tests/foreman/api/test_permission.py
+++ b/tests/foreman/api/test_permission.py
@@ -6,6 +6,7 @@ can be found here: http://theforeman.org/api/apidoc/v2/permissions.html
 """
 from ddt import data as ddt_data, ddt
 from fauxfactory import gen_alphanumeric
+from itertools import chain
 from requests.exceptions import HTTPError
 from robottelo.api import client
 from robottelo.common.constants import PERMISSIONS
@@ -13,14 +14,16 @@ from robottelo.common.decorators import data, run_only_on
 from robottelo.common.helpers import get_server_credentials
 from robottelo import entities
 from unittest import TestCase
-import itertools
 import re
 # (too-many-public-methods) pylint:disable=R0904
 
 
-PERMISSIONS_RESOURCE_TYPE = [key for key in PERMISSIONS.keys()
-                             if key is not None]
-PERMISSIONS_NAME = [value for value in itertools.chain(*PERMISSIONS.values())]
+PERMISSIONS_RESOURCE_TYPE = [
+    key for key in PERMISSIONS.keys() if key is not None
+]
+PERMISSIONS_NAME = [
+    value for value in chain.from_iterable(PERMISSIONS.values())
+]
 
 
 @ddt


### PR DESCRIPTION
The `*` operator is a useful tool, but it's also fairly mysterious. Use
`chain.from_iterable` instead.

The methods which use the affected constant should not be affected:

```
$ nosetests tests/foreman/api/test_permission.py -m test_search_permissions
.
----------------------------------------------------------------------
Ran 1 test in 1.096s

OK
$ nosetests tests/foreman/api/test_permission.py -m test_search_by_name
................................................................................................................................................................................................................
----------------------------------------------------------------------
Ran 208 tests in 89.741s

OK
```

A quick test shows that the transformation should be valid:

``` python
>>> t1 = tuple(chain(*PERMISSIONS.values()))
>>> t2 = tuple(chain.from_iterable(PERMISSIONS.values()))
>>> t1 == t2
True
```
