### PR TITLE
Rename smoke tests to follow test naming

### DIFF
--- a/tests/foreman/smoke/test_api_smoke.py
+++ b/tests/foreman/smoke/test_api_smoke.py
@@ -976,7 +976,7 @@ class TestSmoke(TestCase):
         return response.json()
 
     @attr('smoke')
-    def end_to_end_api_test(self):
+    def test_end_to_end(self):
         """@Test: Perform end to end smoke tests using RH repos.
 
         1. Create new organization and environment

--- a/tests/foreman/smoke/test_cli_smoke.py
+++ b/tests/foreman/smoke/test_cli_smoke.py
@@ -495,7 +495,7 @@ class TestSmoke(CLITestCase):
 
         return result
 
-    def end_to_end_cli_test(self):
+    def test_end_to_end(self):
         """@Test: Perform end to end smoke tests using RH repos.
 
         1. Create new organization and environment

--- a/tests/foreman/smoke/test_ui_smoke.py
+++ b/tests/foreman/smoke/test_ui_smoke.py
@@ -218,7 +218,7 @@ class TestSmoke(UITestCase):
             make_hostgroup(session, name=hostgroup_name)
             self.assertIsNotNone(self.hostgroup.search(hostgroup_name))
 
-    def end_to_end_ui_test(self):
+    def test_end_to_end(self):
         """@Test: Perform end to end smoke tests using RH repos.
 
         @Feature: Smoke test


### PR DESCRIPTION
Tests should start with test_ and we don't need to specify api, cli and
ui as the tests is already in a module that have that differentiation.
