### PR TITLE
Update version_promote option

### DIFF
--- a/tests/foreman/cli/test_contenthost.py
+++ b/tests/foreman/cli/test_contenthost.py
@@ -64,7 +64,7 @@ class TestContentHost(CLITestCase):
             version_id = result.stdout[0]['id']
             promotion = ContentView.version_promote({
                 u'id': version_id,
-                u'lifecycle-environment-id': TestContentHost.NEW_LIFECYCLE[
+                u'to-lifecycle-environment-id': TestContentHost.NEW_LIFECYCLE[
                     'id'],
                 u'organization-id': TestContentHost.NEW_ORG['id']
             })
@@ -93,7 +93,8 @@ class TestContentHost(CLITestCase):
             u'name': test_data['name'],
             u'organization-id': self.NEW_ORG['id'],
             u'content-view-id': self.DEFAULT_CV['id'],
-            u'lifecycle-environment-id': self.LIBRARY['id']})
+            u'lifecycle-environment-id': self.LIBRARY['id'],
+        })
         # Assert that name matches data passed
         self.assertEqual(
             new_system['name'],
@@ -123,7 +124,8 @@ class TestContentHost(CLITestCase):
             u'description': test_data['description'],
             u'organization-id': self.NEW_ORG['id'],
             u'content-view-id': self.DEFAULT_CV['id'],
-            u'lifecycle-environment-id': self.LIBRARY['id']})
+            u'lifecycle-environment-id': self.LIBRARY['id'],
+        })
         # Assert that description matches data passed
         self.assertEqual(
             new_system['description'],
@@ -145,7 +147,8 @@ class TestContentHost(CLITestCase):
             u'name': gen_string('alpha', 15),
             u'organization': self.NEW_ORG['name'],
             u'content-view-id': self.DEFAULT_CV['id'],
-            u'lifecycle-environment-id': self.LIBRARY['id']})
+            u'lifecycle-environment-id': self.LIBRARY['id'],
+        })
         # Info does not tell us information about the organization so
         # let's assert that content view and environments match instead
         self.assertEqual(
@@ -171,7 +174,8 @@ class TestContentHost(CLITestCase):
             u'name': gen_string('alpha', 15),
             u'organization-label': self.NEW_ORG['label'],
             u'content-view-id': self.DEFAULT_CV['id'],
-            u'lifecycle-environment-id': self.LIBRARY['id']})
+            u'lifecycle-environment-id': self.LIBRARY['id'],
+        })
         # Info does not tell us information about the organization so
         # let's assert that content view and environments match instead
         self.assertEqual(
@@ -198,7 +202,8 @@ class TestContentHost(CLITestCase):
             u'name': gen_string('alpha', 15),
             u'organization-id': self.NEW_ORG['id'],
             u'content-view': self.DEFAULT_CV['name'],
-            u'lifecycle-environment-id': self.LIBRARY['id']})
+            u'lifecycle-environment-id': self.LIBRARY['id'],
+        })
         # Assert that name matches data passed
         self.assertEqual(
             new_system['content-view'],
@@ -248,7 +253,8 @@ class TestContentHost(CLITestCase):
             u'name': gen_string('alpha', 15),
             u'organization-id': self.NEW_ORG['id'],
             u'content-view-id': self.PROMOTED_CV['id'],
-            u'lifecycle-environment-id': self.NEW_LIFECYCLE['id']})
+            u'lifecycle-environment-id': self.NEW_LIFECYCLE['id'],
+        })
         # Assert that content views matches data passed
         self.assertEqual(
             new_system['lifecycle-environment'],
@@ -274,7 +280,8 @@ class TestContentHost(CLITestCase):
             u'name': gen_string('alpha', 15),
             u'organization-id': TestContentHost.NEW_ORG['id'],
             u'content-view-id': TestContentHost.PROMOTED_CV['id'],
-            u'lifecycle-environment-id': TestContentHost.NEW_LIFECYCLE['id']})
+            u'lifecycle-environment-id': TestContentHost.NEW_LIFECYCLE['id'],
+        })
         # Assert that content views matches data passed
         self.assertEqual(
             new_system['content-view'],
@@ -305,7 +312,8 @@ class TestContentHost(CLITestCase):
                 u'name': test_data['name'],
                 u'organization-id': self.NEW_ORG['id'],
                 u'content-view-id': self.DEFAULT_CV['id'],
-                u'lifecycle-environment-id': self.LIBRARY['id']})
+                u'lifecycle-environment-id': self.LIBRARY['id'],
+            })
 
     @run_only_on('sat')
     @attr('cli', 'content-host')

--- a/tests/foreman/cli/test_contentviews.py
+++ b/tests/foreman/cli/test_contentviews.py
@@ -934,7 +934,7 @@ class TestContentView(CLITestCase):
         # Promote the Published version of CV to the next env
         result = ContentView.version_promote({
             u'id': result.stdout['versions'][0]['id'],
-            u'lifecycle-environment-id': env1['id']
+            u'to-lifecycle-environment-id': env1['id'],
         })
         self.assertEqual(result.return_code, 0,
                          "Promoting a version of CV was not successful")
@@ -1013,9 +1013,10 @@ class TestContentView(CLITestCase):
         self.assertEqual(len(result.stderr), 0, "No error was expected")
 
         # Promote the Published version of CV to the next env
-        result = ContentView.version_promote(
-            {u'id': result.stdout['versions'][0]['id'],
-             u'lifecycle-environment-id': self.env1['id']})
+        result = ContentView.version_promote({
+            u'id': result.stdout['versions'][0]['id'],
+            u'to-lifecycle-environment-id': self.env1['id'],
+        })
         self.assertEqual(result.return_code, 0,
                          "Promoting a version of CV was not successful")
         self.assertEqual(len(result.stderr), 0, "No error was expected")
@@ -1114,9 +1115,10 @@ class TestContentView(CLITestCase):
 
         # Promote the Published version of CV to the next env
 
-        result = ContentView.version_promote(
-            {u'id': result.stdout['versions'][0]['id'],
-             u'lifecycle-environment-id': self.env1['id']})
+        result = ContentView.version_promote({
+            u'id': result.stdout['versions'][0]['id'],
+            u'to-lifecycle-environment-id': self.env1['id'],
+        })
         self.assertEqual(result.return_code, 0,
                          "Promoting a version of CV was not successful")
         self.assertEqual(len(result.stderr), 0, "No error was expected")
@@ -1153,9 +1155,10 @@ class TestContentView(CLITestCase):
 
         # Promote the Default CV to the next env
 
-        result = ContentView.version_promote(
-            {u'id': cv_id,
-             u'lifecycle-environment-id': self.env1['id']})
+        result = ContentView.version_promote({
+            u'id': cv_id,
+            u'to-lifecycle-environment-id': self.env1['id'],
+        })
         self.assertNotEqual(result.return_code, 0)
         self.assertGreater(len(result.stderr), 0,
                            "There should be an exception here.")
@@ -1209,10 +1212,11 @@ class TestContentView(CLITestCase):
 
         # Promote the Published version of CV,
         # to the previous env which is Library
-        result = ContentView.version_promote(
-            {u'id': result.stdout['versions'][0]['id'],
-             u'lifecycle-environment-id': result.stdout[
-                 'environments'][0]['id']})
+        result = ContentView.version_promote({
+            u'id': result.stdout['versions'][0]['id'],
+            u'to-lifecycle-environment-id': result.stdout[
+                'environments'][0]['id'],
+        })
         self.assertNotEqual(result.return_code, 0)
         self.assertGreater(len(result.stderr), 0,
                            "There should be an exception here.")
@@ -1496,9 +1500,10 @@ class TestContentView(CLITestCase):
                          u'Library', "This version not in Library")
 
         # Promotion of version1 to Dev env
-        result = ContentView.version_promote(
-            {u'id': version1_id,
-             u'lifecycle-environment-id': self.env1['id']})
+        result = ContentView.version_promote({
+            u'id': version1_id,
+            u'to-lifecycle-environment-id': self.env1['id'],
+        })
         self.assertEqual(result.return_code, 0,
                          "Promoting version1 of CV was not successful")
         self.assertEqual(len(result.stderr), 0, "No error was expected")
@@ -1538,9 +1543,10 @@ class TestContentView(CLITestCase):
                          u'Library', "This version not in Library")
 
         # Promotion of version2 to Dev env
-        result = ContentView.version_promote(
-            {u'id': version2_id,
-             u'lifecycle-environment-id': self.env1['id']})
+        result = ContentView.version_promote({
+            u'id': version2_id,
+            u'to-lifecycle-environment-id': self.env1['id'],
+        })
         self.assertEqual(result.return_code, 0,
                          "Promoting version2 of CV was not successful")
         self.assertEqual(len(result.stderr), 0, "No error was expected")
@@ -1623,9 +1629,10 @@ class TestContentView(CLITestCase):
                          u'Library', "This version not in Library")
 
         # Promotion of version1 to Dev env
-        result = ContentView.version_promote(
-            {u'id': version1_id,
-             u'lifecycle-environment-id': self.env1['id']})
+        result = ContentView.version_promote({
+            u'id': version1_id,
+            u'lifecycle-environment-id': self.env1['id'],
+        })
         self.assertEqual(result.return_code, 0,
                          "Promoting version1 of CV was not successful")
         self.assertEqual(len(result.stderr), 0, "No error was expected")
@@ -1668,9 +1675,10 @@ class TestContentView(CLITestCase):
         version2_id = result.stdout['versions'][1]['id']
 
         # Promotion of version2 to next env
-        result = ContentView.version_promote(
-            {u'id': version2_id,
-             u'lifecycle-environment-id': self.env1['id']})
+        result = ContentView.version_promote({
+            u'id': version2_id,
+            u'lifecycle-environment-id': self.env1['id'],
+        })
         self.assertEqual(result.return_code, 0,
                          "Promoting version2 of CV was not successful")
         self.assertEqual(len(result.stderr), 0, "No error was expected")

--- a/tests/foreman/cli/test_host_collection.py
+++ b/tests/foreman/cli/test_host_collection.py
@@ -61,8 +61,8 @@ class TestHostCollection(CLITestCase):
             version_id = result.stdout[0]['id']
             promotion = ContentView.version_promote({
                 u'id': version_id,
-                u'lifecycle-environment-id': TestHostCollection.new_lifecycle[
-                    'id'],
+                u'to-lifecycle-environment-id': (
+                    TestHostCollection.new_lifecycle['id']),
                 u'organization-id': TestHostCollection.org['id']
             })
             if promotion.stderr == []:
@@ -464,7 +464,8 @@ class TestHostCollection(CLITestCase):
                 u'name': content_host_name,
                 u'organization-id': self.org['id'],
                 u'content-view-id': self.default_cv['id'],
-                u'lifecycle-environment-id': self.library['id']})
+                u'lifecycle-environment-id': self.library['id'],
+            })
         except CLIFactoryError as err:
             self.fail(err)
 
@@ -516,7 +517,8 @@ class TestHostCollection(CLITestCase):
                 u'name': content_host_name,
                 u'organization-id': self.org['id'],
                 u'content-view-id': self.default_cv['id'],
-                u'lifecycle-environment-id': self.library['id']})
+                u'lifecycle-environment-id': self.library['id'],
+            })
         except CLIFactoryError as err:
             self.fail(err)
 
@@ -577,7 +579,8 @@ class TestHostCollection(CLITestCase):
                 u'name': content_host_name,
                 u'organization-id': self.org['id'],
                 u'content-view-id': self.default_cv['id'],
-                u'lifecycle-environment-id': self.library['id']})
+                u'lifecycle-environment-id': self.library['id'],
+            })
         except CLIFactoryError as err:
             self.fail(err)
         no_of_content_host = new_host_col['total-content-hosts']


### PR DESCRIPTION
Update version_promote lifecycle-environment-id option to
to-lifecycle-environment-id.

Bonus: some formatting on lines containing lifecycle-environment-id for
other commands.

Thanks @tkolhar for finding these failures.
