### PR TITLE
Make it possible to create a user via API

### DIFF
--- a/robottelo/entities.py
+++ b/robottelo/entities.py
@@ -2196,3 +2196,10 @@ class User(
         """Non-field information about this entity."""
         api_path = 'api/v2/users'
         server_modes = ('sat', 'sam')
+
+    # NOTE: See BZ 1151220
+    def create(self, auth=None, data=None):
+        """Wrap submitted data within an extra dict."""
+        if data is None:
+            data = {u'user': self.build(auth=auth)}
+        return super(User, self).create(auth, data)


### PR DESCRIPTION
When POSTing to the /users URL, wrap data within an extra hash. This is per the
API document.

```
$ python -m unittest tests.foreman.api.test_user
....s......s......s.....s......s......s.
----------------------------------------------------------------------
Ran 40 tests in 79.635s

OK (skipped=6)
```

Targets #1578.
