### PR TITLE
Make Sphinx happy

### DIFF
--- a/docs/api/robottelo.api.rst
+++ b/docs/api/robottelo.api.rst
@@ -5,13 +5,6 @@
     :members:
     :undoc-members:
 
-:mod:`robottelo.api.apicrud`
-----------------------------
-
-.. automodule:: robottelo.api.apicrud
-    :members:
-    :undoc-members:
-
 :mod:`robottelo.api.base`
 -------------------------
 

--- a/tests/foreman/api/test_multiple_paths.py
+++ b/tests/foreman/api/test_multiple_paths.py
@@ -41,11 +41,11 @@ def skip_if_sam(self, entity):
             skip_if_sam(self, entity)
             # test code continues here
 
-    The above code snippet skips the test when
-       - ``robottelo.properties`` is defined with ``main.project=sam``
-       - the corresponding entity's definition in :class:`robottelo.entities`
-         does not specify sam in server_modes. Example:
-         ``server_modes = ('sat')``
+    The above code snippet skips the test when:
+
+    * ``robottelo.properties`` is defined with ``main.project=sam``, and
+    * the corresponding entity's definition in :mod:`robottelo.entities` does
+      not specify sam in server_modes. For example: ``server_modes = ('sat')``.
 
     :param entity: One of the entities defined in :meth:`robottelo.entities`.
     :returns: Either ``self.skipTest`` or ``None``.


### PR DESCRIPTION
Do not attempt to auto-generate API docs for the non-existent
`robottelo.api.apicrud` module. Fix a module reference.
