### PR TITLE
Skip known-failing tests

### DIFF
--- a/robottelo/entities.py
+++ b/robottelo/entities.py
@@ -944,6 +944,13 @@ class Host(
             self.puppet_proxy = response.json()['results'][0]['id']
         return super(Host, self)._factory_data()
 
+    # NOTE: See BZ 1151220
+    def create(self, auth=None, data=None):
+        """Wrap submitted data within an extra dict."""
+        if data is None:
+            data = {u'host': self.build(auth=auth)}
+        return super(Host, self).create(auth, data)
+
 
 class Image(orm.Entity):
     """A representation of a Image entity."""

--- a/tests/foreman/api/test_multiple_paths.py
+++ b/tests/foreman/api/test_multiple_paths.py
@@ -296,7 +296,7 @@ class EntityIdTestCase(TestCase):
         """
         skip_if_sam(self, entity)
         if entity is entities.ActivationKey and bz_bug_is_open(1127335):
-            self.skipTest("Bugzilla bug 1127335 is open.""")
+            self.skipTest("Bugzilla bug 1127335 is open.")
         try:
             entity_n = entity(id=entity().create()['id'])
         except HTTPError as err:
@@ -343,6 +343,9 @@ class EntityIdTestCase(TestCase):
 
         """
         skip_if_sam(self, entity)
+        if entity is entities.Host and bz_bug_is_open(1154156):
+            self.skipTest("Bugzilla bug 1154156 is open.")
+
         path = entity(id=entity().create()['id']).path()
         response = client.put(
             path,
@@ -463,6 +466,8 @@ class DoubleCheckTestCase(TestCase):
 
         """
         skip_if_sam(self, entity)
+        if entity is entities.Host and bz_bug_is_open(1154156):
+            self.skipTest("Bugzilla bug 1154156 is open.")
 
         # Create an entity.
         entity_n = entity(id=entity().create()['id'])
@@ -525,6 +530,8 @@ class DoubleCheckTestCase(TestCase):
         skip_if_sam(self, entity)
         if entity in BZ_1151240_ENTITIES and bz_bug_is_open(1151240):
             self.skipTest("Bugzilla bug 1151240 is open.""")
+        if entity is entities.Host and bz_bug_is_open(1154156):
+            self.skipTest("Bugzilla bug 1154156 is open.")
 
         # Generate some attributes and use them to create an entity.
         gen_attrs = entity().build()


### PR DESCRIPTION
Skip tests that are known to fail due to BZ 1154156.

```
$ nosetests tests/foreman/api/test_multiple_paths.py -m _Host
..S.S.....S.....SSSS
----------------------------------------------------------------------
Ran 20 tests in 48.694s

OK (SKIP=7)
```

Make method `Host.create` submit a nested hash of parameters, e.g. `{'host':
{...}}`.
