### PR TITLE
set_context function in ui/factory no longer depends on "@" char.

### DIFF
--- a/tests/foreman/ui/test_repository.py
+++ b/tests/foreman/ui/test_repository.py
@@ -96,10 +96,9 @@ class Repos(UITestCase):
                             name=repo_name, product=product_1_name,
                             url=FAKE_1_YUM_REPO)
             self.assertIsNotNone(self.repository.search(repo_name))
-            session.nav.go_to_select_org(org_2_name)
             make_repository(session, org=org_2_name, loc=self.loc_name,
                             name=repo_name, product=product_2_name,
-                            url=FAKE_1_YUM_REPO)
+                            url=FAKE_1_YUM_REPO, force_context=True)
             self.assertIsNotNone(self.repository.search(repo_name))
 
     @run_only_on('sat')


### PR DESCRIPTION
We now fetch both organization and location separately, hence no
longer we need to deal with "@" char. This is undesired as org and
location both could contains "@" char and complicate things.

Also no need to explicitly set the navigation again when creating
second organization, ui/factory should take care of it when the
force_context=True.
