### PR TITLE
Make `AuthSourceLDAP.read` work

### DIFF
--- a/robottelo/entities.py
+++ b/robottelo/entities.py
@@ -132,7 +132,7 @@ class Architecture(
         return super(Architecture, self).create(auth, data)
 
     # NOTE: See BZ 1151240
-    def read(self, auth=None, entity=None, attrs=None):
+    def read(self, auth=None, entity=None, attrs=None, ignore=()):
         """Override the default implementation of
         :meth:`robottelo.orm.EntityReadMixin.read`.
 
@@ -201,6 +201,15 @@ class AuthSourceLDAP(
             values['attr_login'] = cls.attr_login.get_value()
             values['attr_mail'] = cls.attr_mail.get_value()
         return values
+
+    def read(
+            self,
+            auth=None,
+            entity=None,
+            attrs=None,
+            ignore=('account_password',)):
+        """Do not read the ``account_password`` attribute from the server."""
+        return super(AuthSourceLDAP, self).read(auth, entity, attrs, ignore)
 
     class Meta(object):
         """Non-field information about this entity."""
@@ -1134,7 +1143,7 @@ class Media(
         return super(Media, self).create(auth, data)
 
     # NOTE: See BZ 1151240
-    def read(self, auth=None, entity=None, attrs=None):
+    def read(self, auth=None, entity=None, attrs=None, ignore=()):
         """Override the default implementation of
         :meth:`robottelo.orm.EntityReadMixin.read`.
 
@@ -1261,7 +1270,7 @@ class OperatingSystemParameter(
         )
         super(OperatingSystemParameter, self).__init__(**kwargs)
 
-    def read(self, auth=None, entity=None, attrs=None):
+    def read(self, auth=None, entity=None, attrs=None, ignore=()):
         """Override the default implementation of
         :meth:`robottelo.orm.EntityReadMixin.read`.
 
@@ -1273,7 +1282,8 @@ class OperatingSystemParameter(
         return super(OperatingSystemParameter, self).read(
             auth=auth,
             entity=OperatingSystemParameter(self.os_id),
-            attrs=attrs
+            attrs=attrs,
+            ignore=(),
         )
 
 
@@ -1878,7 +1888,7 @@ class Repository(
         return super(Repository, self).path(which)
 
     # NOTE: See BZ 1151240
-    def read(self, auth=None, entity=None, attrs=None):
+    def read(self, auth=None, entity=None, attrs=None, ignore=()):
         """Override the default implementation of
         :meth:`robottelo.orm.EntityReadMixin.read`.
 

--- a/robottelo/orm.py
+++ b/robottelo/orm.py
@@ -505,7 +505,7 @@ class EntityReadMixin(object):
         response.raise_for_status()
         return response.json()
 
-    def read(self, auth=None, entity=None, attrs=None):
+    def read(self, auth=None, entity=None, attrs=None, ignore=()):
         """Get information about the current entity.
 
         Call :meth:`read_json`. Use this information to populate an object of
@@ -535,6 +535,9 @@ class EntityReadMixin(object):
             returned. An object of type ``type(self)`` by default.
         :param dict attrs: Data used to populate the object's attributes. The
             response from ``read_json`` by default.
+        :param tuple ignore: Attributes which should not be read from the
+            server. This is mainly useful for attributes like a password which
+            are not returned.
         :return: An instance of type ``type(self)``.
         :rtype: robottelo.orm.Entity
 
@@ -558,6 +561,8 @@ class EntityReadMixin(object):
         # Well, that's the ideal. Unfortunately, the server often serves up
         # weirdly structured or incomplete data. (See BZ #1122267)
         for field_name, field_type in entity.get_fields().items():
+            if field_name in ignore:
+                continue
             if isinstance(field_type, OneToOneField):
                 # `OneToOneField.entity` may be either a class or a string. For
                 # examples of this, look at a couple class definitions in


### PR DESCRIPTION
Expand the signature of method `EntityReadMixin.read` with a new parameter:
`ignore`. This new argument allows a user to specify that certain attributes
should not be read from the server. Update all overrides of the `read` method to
accomodate this change.

Define `AuthSourceLDAP.read`. This allows the method to succeed, and it fixes a
failing Jenkins test.

```
$ nosetests tests/foreman/api/test_multiple_paths.py -m test_entity_read_1_AuthSourceLDAP
.
----------------------------------------------------------------------
Ran 1 test in 1.534s

OK
```
