### PR TITLE
Skip known-failing test (see BZ 1154803)

### DIFF
--- a/tests/foreman/api/test_multiple_paths.py
+++ b/tests/foreman/api/test_multiple_paths.py
@@ -345,6 +345,8 @@ class EntityIdTestCase(TestCase):
         skip_if_sam(self, entity)
         if entity is entities.Host and bz_bug_is_open(1154156):
             self.skipTest("Bugzilla bug 1154156 is open.")
+        if entity is entities.User and bz_bug_is_open(1154803):
+            self.skipTest("Bugzilla bug 1154803 is open.")
 
         path = entity(id=entity().create()['id']).path()
         response = client.put(


### PR DESCRIPTION
Issuing a PUT request to the /users/:id API path will fail if the request
includes the `auth_source_id` parameter. The API doc states that this
parameter is acceptable, but the application returns an HTTP 500 error with this
message:

```
auth_source_id is not allowed as nested parameter for users. Allowed
parameters are auth_source_ldap_id, role_id, location_id, organization_id,
usergroup_id
```

Test results:

```
$ nosetests tests/foreman/api/test_multiple_paths.py -m 'test_put_status_code_.*_User'
S
----------------------------------------------------------------------
Ran 1 test in 0.636s

OK (SKIP=1)
```
