### PR TITLE
Drop method sleep_for_seconds

### DIFF
--- a/robottelo/cli/factory.py
+++ b/robottelo/cli/factory.py
@@ -9,6 +9,7 @@ import datetime
 import logging
 import os
 import random
+import time
 
 from fauxfactory import (
     gen_alphanumeric, gen_integer,
@@ -48,7 +49,7 @@ from robottelo.common.constants import (
     SYNC_INTERVAL,
     TEMPLATE_TYPES,
 )
-from robottelo.common.helpers import sleep_for_seconds, update_dictionary
+from robottelo.common.helpers import update_dictionary
 from tempfile import mkstemp
 
 logger = logging.getLogger("robottelo")
@@ -87,7 +88,7 @@ def create_object(cli_object, options, values):
     update_dictionary(options, values)
     result = cli_object.create(options)
     # Some methods require a bit of waiting
-    sleep_for_seconds(5)
+    time.sleep(5)
 
     # If the object is not created, raise exception, stop the show.
     if result.return_code != 0:

--- a/robottelo/common/helpers.py
+++ b/robottelo/common/helpers.py
@@ -6,9 +6,7 @@ Several helper methods and functions.
 """
 
 import os
-import random
 import re
-import time
 
 from fauxfactory import gen_string, gen_integer
 from itertools import izip
@@ -176,14 +174,6 @@ def escape_search(term):
     """Wraps a search term in " and escape term's " and \\ characters"""
     strip_term = term.strip()
     return u'"%s"' % strip_term.replace('\\', '\\\\').replace('"', '\\"')
-
-
-def sleep_for_seconds(guaranteed_sleep=1):
-    """
-    Sleeps for provided seconds + random(0,1). Defaults to 1 sec.
-    @param guaranteed_sleep: Guaranteed sleep in seconds.
-    """
-    time.sleep(random.uniform(guaranteed_sleep, guaranteed_sleep + 1))
 
 
 def update_dictionary(default, updates):


### PR DESCRIPTION
Method `sleep_for_seconds` is used in only one place. It causes the current
thread to sleep for somewhere between N to N + 1 seconds, inclusive, and this
behaviour seems to serve no purpose where it is used. Drop the method and just
call `time.sleep` as needed instead.
