### PR TITLE
Drop method update_dictionary

### DIFF
--- a/robottelo/cli/factory.py
+++ b/robottelo/cli/factory.py
@@ -49,7 +49,6 @@ from robottelo.common.constants import (
     SYNC_INTERVAL,
     TEMPLATE_TYPES,
 )
-from robottelo.common.helpers import update_dictionary
 from tempfile import mkstemp
 
 logger = logging.getLogger("robottelo")
@@ -85,7 +84,7 @@ def create_object(cli_object, options, values):
     :return: A dictionary representing the newly created resource.
 
     """
-    update_dictionary(options, values)
+    options.update(values)
     result = cli_object.create(options)
     # Some methods require a bit of waiting
     time.sleep(5)

--- a/robottelo/common/helpers.py
+++ b/robottelo/common/helpers.py
@@ -176,26 +176,6 @@ def escape_search(term):
     return u'"%s"' % strip_term.replace('\\', '\\\\').replace('"', '\\"')
 
 
-def update_dictionary(default, updates):
-    """
-    Updates default dictionary with elements from
-    optional dictionary.
-
-    @param default: A python dictionary containing the minimal
-    required arguments to create a CLI object.
-    @param updates: A python dictionary containing attributes
-    to overwrite on default dictionary.
-
-    @return default: The modified default python dictionary.
-    """
-
-    if updates:
-        for key in set(default.keys()).intersection(set(updates.keys())):
-            default[key] = updates[key]
-
-    return default
-
-
 def info_dictionary(result):
     """
     Function for converting result to dictionary, from info function in base..

--- a/robottelo/ui/factory.py
+++ b/robottelo/ui/factory.py
@@ -2,7 +2,6 @@
 
 from fauxfactory import gen_string, gen_email
 from selenium.webdriver.common.action_chains import ActionChains
-from robottelo.common.helpers import update_dictionary
 from robottelo.common.constants import REPO_TYPE, CHECKSUM_TYPE
 from robottelo.ui.activationkey import ActivationKey
 from robottelo.ui.architecture import Architecture
@@ -51,7 +50,6 @@ def core_factory(create_args, kwargs, session, page, org=None, loc=None,
     :return: None.
 
     """
-    create_args = update_dictionary(create_args, kwargs)
     create_args.update(kwargs)
     if org or loc:
         set_context(session, org=org, loc=loc, force_context=force_context)


### PR DESCRIPTION
Method `update_dictionary` behaves almost exactly like the `update` method from
the standard library. Consider these two lines of code:

```
d1.update(d2)
update_dictionary(d1, d2)
```

In the first case, `d1` will receive all keys from `d2`:

```
>>> d1 = {1: 10, 2: 20}
>>> d2 = {2: 25, 3: 30}
>>> d1.update(d2)
>>> d1
{1: 10, 2: 25, 3: 30}
```

In the second case, `d1` will receive only intersecting keys from `d2`:

```
>>> d1 = {1: 10, 2: 20}
>>> d2 = {2: 25, 3: 30}
>>> update_dictionary(d1, d2)
>>> helpers.update_dictionary(d1, d2)
{1: 10, 2: 25}
```

`update_dictionary` is used in two modules:
- robottelo.cli.factory
- robottelo.ui.factory

In the UI factory, the usage of `update_dictionary` is a no-op, as `update` is
called immediately afterwards. In the CLI factory, the usage of
`update_dictionary` appears to be useless, though this is not a logical
certainty.
