### PR TITLE
Fix a buggy dict update

### DIFF
--- a/robottelo/ui/factory.py
+++ b/robottelo/ui/factory.py
@@ -51,8 +51,7 @@ def core_factory(create_args, kwargs, session, page, org=None, loc=None,
     :return: None.
 
     """
-    create_args = update_dictionary(create_args, kwargs)
-    create_args.update(kwargs)
+    update_dictionary(create_args, kwargs)
     if org or loc:
         set_context(session, org=org, loc=loc, force_context=force_context)
     page()


### PR DESCRIPTION
Method `update_dictionary` behaves almost exactly like the `update` method from
the standard library. Consider these two lines of code:

```
d1.update(d2)
update_dictionary(d1, d2)
```

In the first case, `d1` will receive all keys from `d2`:

```
>>> d1 = {1: 10, 2: 20}
>>> d2 = {2: 25, 3: 30}
>>> d1.update(d2)
>>> d1
{1: 10, 2: 25, 3: 30}
```

In the second case, `d1` will receive only intersecting keys from `d2`:

```
>>> d1 = {1: 10, 2: 20}
>>> d2 = {2: 25, 3: 30}
>>> update_dictionary(d1, d2)
>>> helpers.update_dictionary(d1, d2)
{1: 10, 2: 25}
```

Fix a bug in `robottelo.ui.factory` where the two dict update methods are used,
one after the other.
