### PR TITLE
Fix or skip tests for /config_templates API path

### DIFF
--- a/robottelo/entities.py
+++ b/robottelo/entities.py
@@ -400,6 +400,13 @@ class ConfigTemplate(
             )
         return values
 
+    # NOTE: See BZ 1151220
+    def create(self, auth=None, data=None):
+        """Wrap submitted data within an extra dict."""
+        if data is None:
+            data = {u'config_template': self.build(auth=auth)}
+        return super(ConfigTemplate, self).create(auth, data)
+
 
 class ContentUpload(orm.Entity):
     """A representation of a Content Upload entity."""

--- a/tests/foreman/api/test_multiple_paths.py
+++ b/tests/foreman/api/test_multiple_paths.py
@@ -30,7 +30,7 @@ BZ_1151240_ENTITIES = (
     entities.ActivationKey, entities.ContentView, entities.GPGKey,
     entities.LifecycleEnvironment, entities.Product, entities.Repository
 )
-BZ_1154156_ENTITIES = (entities.Host, entities.User)
+BZ_1154156_ENTITIES = (entities.ConfigTemplate, entities.Host, entities.User)
 
 
 def skip_if_sam(self, entity):


### PR DESCRIPTION
The `/config_templates` API path incorrectly rejects some parameters. Skip some
tests that fail due to this issue. For more information, see:
- https://bugzilla.redhat.com/show_bug.cgi?id=1154156
- http://projects.theforeman.org/issues/7989

The API documentation also states that all POST requests to the
`/config_templates` path should be wrapped in an extra hash. Do so.

These two changes fix a number of failing tests. Updated test results:

```
$ nosetests tests/foreman/api/test_multiple_paths.py -m ConfigTemplate
InsecureRequestWarning)
.SS..S..SS
----------------------------------------------------------------------
Ran 10 tests in 7.735s

OK (SKIP=5)
```
