### PR TITLE
Use ``busybox`` for Docker-based tests.

### DIFF
--- a/tests/foreman/api/test_repository.py
+++ b/tests/foreman/api/test_repository.py
@@ -303,7 +303,7 @@ class DockerRepositoryTestCase(TestCase):
         @Feature: Repository
 
         """
-        name = u'wordpress'
+        name = u'busybox'
         content_type = u'docker'
         prod_id = entities.Product(organization=self.org_id).create()['id']
 
@@ -331,7 +331,7 @@ class DockerRepositoryTestCase(TestCase):
         repo_id = entities.Repository(
             product=prod_id,
             content_type=u'docker',
-            name=u'wordpress',
+            name=u'busybox',
             url=DOCKER_REGISTRY_HUB
         ).create()['id']
 

--- a/tests/foreman/cli/test_repository.py
+++ b/tests/foreman/cli/test_repository.py
@@ -352,7 +352,7 @@ class TestRepository(CLITestCase):
         """
         content_type = u'docker'
         new_repo = self._make_repository({
-            u'name': u'wordpress',
+            u'name': u'busybox',
             u'url': DOCKER_REGISTRY_HUB,
             u'content-type': content_type,
         })
@@ -473,7 +473,7 @@ class TestRepository(CLITestCase):
         """
 
         new_repo = self._make_repository({
-            u'name': u'wordpress',
+            u'name': u'busybox',
             u'url': DOCKER_REGISTRY_HUB,
             u'content-type': u'docker',
         })

--- a/tests/foreman/ui/test_repository.py
+++ b/tests/foreman/ui/test_repository.py
@@ -112,7 +112,7 @@ class Repos(UITestCase):
 
         """
         # Creates new product
-        repo_name = u'wordpress'
+        repo_name = u'busybox'
         product_name = entities.Product(
             organization=self.org_id,
             location=self.loc_id,
@@ -135,7 +135,7 @@ class Repos(UITestCase):
 
         """
         # Creates new product
-        repo_name = u'wordpress'
+        repo_name = u'busybox'
         product_name = entities.Product(
             organization=self.org_id,
             location=self.loc_id,


### PR DESCRIPTION
Instead of using the `wordpress` Docker image for our existing tests,
I am proposing that we switch to using the `busybox` image since it is
much smaller and should speed up our tests.

I have not run our tests but I did manually try it using latest build
with success.
