### PR TITLE
Update CLI tests because factories update

### DIFF
--- a/robottelo/cli/factory.py
+++ b/robottelo/cli/factory.py
@@ -52,7 +52,7 @@ from robottelo.common.constants import (
 from robottelo.common.helpers import update_dictionary
 from tempfile import mkstemp
 
-logger = logging.getLogger("robottelo")
+logger = logging.getLogger(__name__)
 
 ORG_KEYS = ['organization', 'organization-id', 'organization-label']
 CONTENT_VIEW_KEYS = ['content-view', 'content-view-id']
@@ -846,6 +846,10 @@ def make_user(options=None):
         u'password': gen_alphanumeric(),
         u'auth-source-id': 1,
     }
+    logger.debug(
+        'User "{0}" password not provided {1} was generated'
+        .format(args['login'], args['password'])
+    )
 
     return create_object(User, args, options)
 

--- a/tests/foreman/cli/test_os.py
+++ b/tests/foreman/cli/test_os.py
@@ -130,7 +130,7 @@ class TestOperatingSystem(CLITestCase):
             self.fail(err)
 
         # New value for major
-        major = int(os['major']) + 1
+        major = int(os['major-version']) + 1
 
         result = OperatingSys.update(
             {'id': os['id'], 'major': major})
@@ -188,8 +188,14 @@ class TestOperatingSystem(CLITestCase):
         # major and minor
         self.assertEqual(result['id'], os_info.stdout['id'])
         self.assertEqual(result['name'], os_info.stdout['name'])
-        self.assertEqual(str(result['major']), os_info.stdout['major-version'])
-        self.assertEqual(str(result['minor']), os_info.stdout['minor-version'])
+        self.assertEqual(
+            str(result['major-version']),
+            os_info.stdout['major-version']
+        )
+        self.assertEqual(
+            str(result['minor-version']),
+            os_info.stdout['minor-version']
+        )
 
     @data(*POSITIVE_CREATE_DATA)
     def test_positive_create_1(self, test_data):

--- a/tests/foreman/cli/test_partitiontable.py
+++ b/tests/foreman/cli/test_partitiontable.py
@@ -183,7 +183,7 @@ class TestPartitionTableDelete(CLITestCase):
                          "There should not be an exception here")
 
         result = PartitionTable.info({'id': ptable['id']})
-        self.assertIn(os['full-name'],
+        self.assertIn(os['name'],
                       result.stdout['operating-systems'])
 
         result = PartitionTable.remove_operating_system(args)

--- a/tests/foreman/cli/test_syncplan.py
+++ b/tests/foreman/cli/test_syncplan.py
@@ -419,27 +419,23 @@ class TestSyncPlan(CLITestCase):
 
         # Set the sync date to today/right now
         today = datetime.now()
-        new_sync_plan = self._make_sync_plan(
-            {
-                u'name': test_data['name'],
-                u'sync-date': today.strftime("%Y-%m-%d %H:%M:%S")
-            })
+        new_sync_plan = self._make_sync_plan({
+            u'name': test_data['name'],
+            u'sync-date': today.strftime("%Y-%m-%d %H:%M:%S"),
+        })
         # Assert that sync date matches data passed
         self.assertEqual(
-            new_sync_plan['sync-date'],
-            today.strftime("%Y-%m-%d %H:%M:%S"),
-            "Sync dates don't match"
+            new_sync_plan['start-date'],
+            today.strftime("%Y/%m/%d %H:%M:%S"),
         )
 
         # Set sync date 5 days in the future
         future_date = today + timedelta(days=5)
         # Update sync interval
-        result = SyncPlan.update(
-            {
-                u'id': new_sync_plan['id'],
-                u'sync-date': future_date.strftime("%Y-%m-%d %H:%M:%S")
-            }
-        )
+        result = SyncPlan.update({
+            u'id': new_sync_plan['id'],
+            u'sync-date': future_date.strftime("%Y-%m-%d %H:%M:%S"),
+        })
         self.assertEqual(
             result.return_code,
             0,
@@ -448,11 +444,9 @@ class TestSyncPlan(CLITestCase):
             len(result.stderr), 0, "No error was expected")
 
         # Fetch it
-        result = SyncPlan.info(
-            {
-                u'id': new_sync_plan['id'],
-            }
-        )
+        result = SyncPlan.info({
+            u'id': new_sync_plan['id'],
+        })
         self.assertEqual(
             result.return_code,
             0,
@@ -461,7 +455,7 @@ class TestSyncPlan(CLITestCase):
             len(result.stderr), 0, "No error was expected")
         self.assertNotEqual(
             result.stdout['start-date'],
-            new_sync_plan['sync-date'],
+            new_sync_plan['start-date'],
             "Sync date was not updated"
         )
         self.assertGreater(

--- a/tests/foreman/cli/test_template.py
+++ b/tests/foreman/cli/test_template.py
@@ -87,30 +87,26 @@ class TestTemplate(CLITestCase):
         name = gen_string("alpha", 10)
 
         try:
-            new_obj = make_template(
-                {
-                    'name': name,
-                    'content': content,
-                }
-            )
+            new_template = make_template({
+                'name': name,
+                'content': content,
+            })
             new_os = make_os()
-        except CLIFactoryError as e:
-            self.fail(e)
+        except CLIFactoryError as err:
+            self.fail(err)
 
-        result = Template.add_operatingsystem(
-            {
-                "id": new_obj["id"],
-                "operatingsystem-id": new_os["id"]
-            }
-        )
+        result = Template.add_operatingsystem({
+            "id": new_template["id"],
+            "operatingsystem-id": new_os["id"],
+        })
         self.assertEqual(result.return_code, 0)
         self.assertEqual(len(result.stderr), 0)
 
-        result = Template.info({'id': new_obj['id']})
+        result = Template.info({'id': new_template['id']})
         self.assertEqual(result.return_code, 0)
         self.assertEqual(len(result.stderr), 0)
-        os_string = "%s %s.%s" % (
-            new_os['name'], new_os['major'], new_os['minor']
+        os_string = '{0} {1}.{2}'.format(
+            new_os['name'], new_os['major-version'], new_os['minor-version']
         )
         self.assertIn(os_string, result.stdout['operating-systems'])
 
@@ -149,25 +145,23 @@ class TestTemplate(CLITestCase):
         result = Template.info({'id': new_obj['id']})
         self.assertEqual(result.return_code, 0)
         self.assertEqual(len(result.stderr), 0)
-        os_string = "%s %s.%s" % (
-            new_os['name'], new_os['major'], new_os['minor']
+        os_string = '{0} {1}.{2}'.format(
+            new_os['name'], new_os['major-version'], new_os['minor-version']
         )
         self.assertIn(os_string, result.stdout['operating-systems'])
 
-        result = Template.remove_operatingsystem(
-            {
-                "id": new_obj["id"],
-                "operatingsystem-id": new_os["id"]
-            }
-        )
+        result = Template.remove_operatingsystem({
+            "id": new_obj["id"],
+            "operatingsystem-id": new_os["id"]
+        })
         self.assertEqual(result.return_code, 0)
         self.assertEqual(len(result.stderr), 0)
 
         result = Template.info({'id': new_obj['id']})
         self.assertEqual(result.return_code, 0)
         self.assertEqual(len(result.stderr), 0)
-        os_string = "%s %s.%s" % (
-            new_os['name'], new_os['major'], new_os['minor']
+        os_string = '{0} {1}.{2}'.format(
+            new_os['name'], new_os['major-version'], new_os['minor-version']
         )
         self.assertNotIn(os_string, result.stdout['operating-systems'])
 

--- a/tests/foreman/cli/test_user.py
+++ b/tests/foreman/cli/test_user.py
@@ -31,21 +31,21 @@ class User(CLITestCase):
 
     """
 
-    def __assert_exists(self, args):
-        """Checks if the object that passed as args parameter really exists
-        in `hammer user list --search args['login']` and has values of:
+    def __assert_exists(self, user):
+        """Checks if the object that passed as user parameter really exists
+        in `hammer user list --search user['login']` and has values of:
         Login,Name,Email
 
         """
-        result = UserObj().list({'search': 'login=\"%s\"' % args['login']})
-        self.assertTrue(result.return_code == 0,
-                        "User search - exit code %d" %
-                        result.return_code)
-        self.assertTrue(result.stdout[0]['name'] ==
-                        args['firstname'] + " " + args['lastname'],
-                        "User search - check our value 'Name'")
-        self.assertTrue(result.stdout[0]['email'] == args['mail'],
-                        "User search - check our value 'Email'")
+        result = UserObj().list({
+            'search': 'login="{0}"'.format(user['login']),
+        })
+        self.assertEqual(
+            result.return_code, 0,
+            'User search - exit code {0}'.format(result.return_code)
+        )
+        self.assertEqual(result.stdout[0]['name'], user['name'])
+        self.assertEqual(result.stdout[0]['email'], user['email'])
 
     # Issues
 
@@ -572,9 +572,9 @@ class User(CLITestCase):
         pass
 
     @data({'login': ''},
-          {'login': "space %s" % gen_string("alpha", 10)},
-          {'login': gen_string("alpha", 101)},
-          {'login': gen_string("html", 10)})
+          {'login': 'space {0}'.format(gen_string('alpha', 10))},
+          {'login': gen_string('alpha', 101)},
+          {'login': gen_string('html', 10)})
     def test_negative_create_user_1(self, opts):
         """@Test: Create User with invalid Username
 
@@ -1366,9 +1366,7 @@ class User(CLITestCase):
         # check name have not changed
         updated_user = UserObj().exists(
             tuple_search=('login', new_user['login']))
-        self.assertEqual(updated_user.stdout['name'], "%s %s" %
-                                                      (new_user['firstname'],
-                                                       new_user['lastname']))
+        self.assertEqual(updated_user.stdout['name'], new_user['name'])
 
     @data({'lastname': gen_string("alpha", 51)},
           {'lastname': gen_string("html", 10)})
@@ -1392,9 +1390,7 @@ class User(CLITestCase):
         # check name have not changed
         updated_user = UserObj().exists(
             tuple_search=('login', new_user['login']))
-        self.assertEqual(updated_user.stdout['name'], "%s %s" %
-                                                      (new_user['firstname'],
-                                                       new_user['lastname']))
+        self.assertEqual(updated_user.stdout['name'], new_user['name'])
 
     @skip_if_bug_open('bugzilla', 1070730)
     @data(
@@ -1430,7 +1426,7 @@ class User(CLITestCase):
         # check name have not changed
         updated_user = UserObj().exists(
             tuple_search=('login', new_user['login']))
-        self.assertEqual(updated_user.stdout['email'], new_user['mail'])
+        self.assertEqual(updated_user.stdout['email'], new_user['email'])
 
     @skip_if_bug_open('bugzilla', 1079649)
     @data(
@@ -1569,7 +1565,9 @@ class User(CLITestCase):
 
         user = make_user(test_data)
         self.__assert_exists(user)
-        result = UserObj.list({'search': 'login = %s' % test_data['login']})
+        result = UserObj.list({
+            'search': 'login = {0}'.format(test_data['login']),
+        })
         self.assertEqual(len(result.stdout), 1)
         self.assertEqual(len(result.stderr), 0)
         # make sure user is in list result
@@ -1577,7 +1575,7 @@ class User(CLITestCase):
             'name': user['name'],
             'login': user['login'],
             'id': user['id'],
-            'email': user['mail']}, result.stdout[0])
+            'email': user['email']}, result.stdout[0])
 
     @data(
         {'firstname': gen_string("latin1", 10)},
@@ -1611,15 +1609,16 @@ class User(CLITestCase):
 
         user = make_user(test_data)
         self.__assert_exists(user)
-        result = UserObj.list(
-            {'search': 'firstname = %s' % test_data['firstname']})
+        result = UserObj.list({
+            'search': 'firstname = {0}'.format(test_data['firstname']),
+        })
         self.assertEqual(len(result.stderr), 0)
         # make sure user is in list result
         self.assertTrue({
             'name': user['name'],
             'login': user['login'],
             'id': user['id'],
-            'email': user['mail']} in result.stdout)
+            'email': user['email']} in result.stdout)
 
     @data(
         {'lastname': gen_string("latin1", 10)},
@@ -1653,15 +1652,16 @@ class User(CLITestCase):
 
         user = make_user(test_data)
         self.__assert_exists(user)
-        result = UserObj.list(
-            {'search': 'lastname = %s' % test_data['lastname']})
+        result = UserObj.list({
+            'search': 'lastname = {0}'.format(test_data['lastname']),
+        })
         self.assertEqual(len(result.stderr), 0)
         # make sure user is in list result
         self.assertTrue({
             'name': user['name'],
             'login': user['login'],
             'id': user['id'],
-            'email': user['mail']} in result.stdout)
+            'email': user['email']} in result.stdout)
 
     @data(
         {'mail': gen_string("latin1", 10) + "@somemail.com"},
@@ -1688,14 +1688,16 @@ class User(CLITestCase):
         """
         user = make_user(test_data)
         self.__assert_exists(user)
-        result = UserObj.list({'search': 'mail = %s' % test_data['mail']})
+        result = UserObj.list({
+            'search': 'mail = {0}'.format(test_data['mail']),
+        })
         self.assertEqual(len(result.stderr), 0)
         # make sure user is in list result
         self.assertTrue({
             'name': user['name'],
             'login': user['login'],
             'id': user['id'],
-            'email': user['mail']} in result.stdout)
+            'email': user['email']} in result.stdout)
 
     @unittest.skip(NOT_IMPLEMENTED)
     def test_search_user_1(self):

--- a/tests/foreman/smoke/test_cli_smoke.py
+++ b/tests/foreman/smoke/test_cli_smoke.py
@@ -116,7 +116,11 @@ class TestSmoke(CLITestCase):
         """
 
         # Create new user
-        new_user = make_user({u'admin': 'true'})
+        password = gen_alphanumeric()
+        new_user = make_user({u'admin': u'true', u'password': password})
+
+        # Append the password as the info command does not return it
+        new_user[u'password'] = password
 
         # Create new org as new user
         new_org = self._create(


### PR DESCRIPTION
Update keys for the values returned by the factories. This because
factories are only returning values returned by the hammer info command.

All touched tests are either passing or failing due to a hammer bug.
