### PR TITLE
Drop booby, let nil values be submitted to API

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,4 @@
 # For all tests.
-booby
 fauxfactory
 ddt
 python-bugzilla

--- a/robottelo/factory.py
+++ b/robottelo/factory.py
@@ -46,21 +46,6 @@ def _copy_and_update_keys(somedict, mapping):
     return copy
 
 
-def field_is_required(field_type):
-    """Tell whether ``field_type`` is required or not.
-
-    :param robottelo.orm.Field field_type: A ``Field``, or one of its more
-        specialized brethren.
-    :return: ``True`` if ``field_type.options.required`` is set and ``True``.
-        ``False`` otherwise.
-    :rtype: bool
-
-    """
-    if field_type.options.get('required', False):
-        return True
-    return False
-
-
 class Factory(object):
     """A mechanism for populating or creating Foreman entities.
 
@@ -261,13 +246,13 @@ class EntityFactoryMixin(Factory):
         The actual method implementation differs from the above description.
 
         """
-        values = self.get_values()  # explicit values provided by user
+        values = vars(self)         # explicit values provided by user
         fields = self.get_fields()  # fields from entity definition
 
         # When this loop is complete, `values` is complete. We just need to
         # adjust field names for Foreman.
         for name, field in fields.items():
-            if name not in values.keys() and field_is_required(field):
+            if name not in values.keys() and field.required:
                 values[name] = field.get_value()
 
         # If self.Meta.api_names is present, then we must use it to transform

--- a/scripts/graph_entities.py
+++ b/scripts/graph_entities.py
@@ -39,12 +39,11 @@ def graph():
         for field_name, field in entity.get_fields().items():
             if (isinstance(field, orm.OneToOneField)
                     or isinstance(field, orm.OneToManyField)):
-                field_is_required = field.options.get('required', False)
                 print('{0} -> {1} [label="{2}"{3}]'.format(
                     entity_name,
                     field.entity,
                     field_name,
-                    ' color=red' if field_is_required else ''
+                    ' color=red' if field.required else ''
                 ))
         # Make entities that are not factories more... ethereal.
         if not issubclass(entity, factory.Factory):

--- a/tests/robottelo/test_factory.py
+++ b/tests/robottelo/test_factory.py
@@ -29,37 +29,6 @@ class SampleEntityFactory(orm.Entity, factory.EntityFactoryMixin):
     label = orm.StringField()
 
 
-class IsRequiredTestCase(TestCase):
-    """Tests for :func:`robottelo.factory.field_is_required`."""
-    # (protected-access) pylint:disable=W0212
-    def test_field_is_required_v1(self):
-        """Do not set the ``required`` attribute at all.
-
-        Assert that :func:`robottelo.factory.field_is_required` returns
-        ``False``.
-
-        """
-        self.assertFalse(factory.field_is_required(orm.Field()))
-
-    def test_field_is_required_v2(self):
-        """Set the ``required`` attribute to ``False``.
-
-        Assert that :func:`robottelo.factory.field_is_required` returns
-        ``False``.
-
-        """
-        self.assertFalse(factory.field_is_required(orm.Field(required=False)))
-
-    def test_field_is_required_v3(self):
-        """Set the ``required`` attribute to ``True``.
-
-        Assert that :func:`robottelo.factory.field_is_required` returns
-        ``True``.
-
-        """
-        self.assertTrue(factory.field_is_required(orm.Field(required=True)))
-
-
 class CopyAndUpdateKeysTestCase(TestCase):
     """Tests for :func:`robottelo.factory._copy_and_update_keys`."""
     # (protected-access) pylint:disable=W0212

--- a/tests/robottelo/test_orm.py
+++ b/tests/robottelo/test_orm.py
@@ -73,30 +73,6 @@ class EntityTestCase(unittest.TestCase):
         """Restore ``conf.properties``."""
         conf.properties = self.conf_properties
 
-    def test_entity_get_values(self):
-        """Test :meth:`robottelo.orm.Entity.get_values`."""
-        name = orm.StringField().get_value()
-        value = orm.IntegerField().get_value()
-
-        # First, provide a name.
-        values = SampleEntity(name=name).get_values()
-        self.assertIn('name', values.keys())
-        self.assertNotIn('value', values.keys())
-        self.assertEqual(values['name'], name)
-
-        # Second, provide a value.
-        values = SampleEntity(value=value).get_values()
-        self.assertNotIn('name', values.keys())
-        self.assertIn('value', values.keys())
-        self.assertEqual(values['value'], value)
-
-        # Third, provide a name and value.
-        values = SampleEntity(name=name, value=value).get_values()
-        self.assertIn('name', values.keys())
-        self.assertIn('value', values.keys())
-        self.assertEqual(values['name'], name)
-        self.assertEqual(values['value'], value)
-
     def test_entity_get_fields(self):
         """Test :meth:`robottelo.orm.Entity.get_fields`."""
         fields = SampleEntity().get_fields()


### PR DESCRIPTION
Drop dependency on booby.
- Make class `Entity` inherit directly from `object`. Define method
  `Entity.__init__`, and make that method handle whatever instantiation logic
  booby formerly did. (but better!)
- Make class `Field` inherit directly from `object`. Define method
  `Field.__init__`, and make that method capable of recording the instance
  attributes `required`, `choices`, `default` and `null`.

This has several positive effects. First, fewer methods are necessary.
- Drop method `robottelo.factory.field_is_required`. The `required` attribute is
  guaranteed to exist on all `Field` classes, so it is possible to just call
  `SomeField.required` instead.
- Drop method `robottelo.orm.Entity.get_values`. It is now possible to just call
  `vars(SomeEntity)` instead.

Second, all classes inheriting from `Entity` and `Field` have a more
comprehensible inheritance tree and sane instantiation process. An `update`
method is no longer inherited from booby, which means that an
`EntityUpdateMixin` may finally be created without MRO issues, and no metaclass
magic is used. Incidentally, a pylint error stating that many `Entity`
subclasses have too many ancestors is now gone.

Third, it is now possible to pass `None` values into classes. This fixes #1082.
Formerly, this behaviour was exhibited:

```
>>> from robottelo.entities import Organization
>>> for org in (
...         Organization(name='ACME'),
...         Organization(name='ACME', description=None),
...         Organization(name='ACME', description='Better than ACNE!')
... ):
...     org.get_values()
...
{'name': 'ACME'}
{'name': 'ACME'}
{'description': 'Better than ACNE!', 'name': 'ACME'}
```

This is the new behaviour:

```
>>> from robottelo.entities import Organization
>>> for org in (
...         Organization(name='ACME'),
...         Organization(name='ACME', description=None),
...         Organization(name='ACME', description='Better than ACNE!')
... ):
...     vars(org)
...
{'name': 'ACME'}
{'description': None, 'name': 'ACME'}
{'description': 'Better than ACNE!', 'name': 'ACME'}
```

Drop a `pylint:disable` directive from module `robottelo.entities`. All classes
inheriting from `Entity` now have an `__init__` method.

These changes do not appear to break anything. Module `test_multiple_paths` is
in good shape:

```
$ python -m unittest tests.foreman.api.test_multiple_paths
…
----------------------------------------------------------------------
Ran 238 tests in 154.352s

FAILED (failures=1, skipped=62)
```

The one failed test relates to activation keys, which is a known issue. `make
test-robottelo` also succeeds.
