### PR TITLE
Make ActivationKey.read_json poll upon getting 404

### DIFF
--- a/tests/foreman/api/test_activationkey.py
+++ b/tests/foreman/api/test_activationkey.py
@@ -4,7 +4,6 @@ from fauxfactory import gen_integer, gen_string
 from requests.exceptions import HTTPError
 from robottelo.api import client
 from robottelo.api.utils import status_code_error
-from robottelo.common.decorators import skip_if_bug_open
 from robottelo.common.helpers import get_server_credentials
 from robottelo import entities
 from unittest import TestCase
@@ -70,7 +69,6 @@ class ActivationKeysTestCase(TestCase):
         gen_string(str_type='cjk'),
         gen_string(str_type='latin1'),
     )
-    @skip_if_bug_open('bugzilla', 1127335)
     def test_positive_create_3(self, name):
         """@Test: Create an activation key providing the initial name.
 
@@ -99,7 +97,6 @@ class ActivationKeysTestCase(TestCase):
         gen_string(str_type='cjk'),
         gen_string(str_type='latin1'),
     )
-    @skip_if_bug_open('bugzilla', 1127335)
     def test_positive_create_4(self, description):
         """@Test: Create an activation key and provide a description.
 
@@ -175,7 +172,6 @@ class ActivationKeysTestCase(TestCase):
         gen_integer(min_value=1, max_value=30),
         gen_integer(min_value=10000, max_value=20000),
     )
-    @skip_if_bug_open('bugzilla', 1127335)
     def test_positive_update_1(self, max_content_hosts):
         """@Test: Create activation key then update it to limited content
         hosts.
@@ -219,7 +215,6 @@ class ActivationKeysTestCase(TestCase):
         -1,
         0
     )
-    @skip_if_bug_open('bugzilla', 1127335)
     def test_negative_update_1(self, max_content_hosts):
         """@Test: Create activation key then update its limit to invalid value.
 
@@ -263,7 +258,6 @@ class ActivationKeysTestCase(TestCase):
             self.assertEqual(attrs[attr], new_attrs[attr])
         self.assertTrue(new_attrs['unlimited_content_hosts'])
 
-    @skip_if_bug_open('bugzilla', 1127335)
     def test_update_max_content_hosts(self):
         """@Test: Create an activation key with ``max_content_hosts == 1``,
         then update that field with a string value.
@@ -339,7 +333,6 @@ class ActivationKeysTestCase(TestCase):
         self.assertIn('results', response.keys())
         self.assertEqual(type(response['results']), list)
 
-    @skip_if_bug_open('bugzilla', 1127335)
     def test_set_host_collection(self):
         """@Test: Associate an activation key with several host collections.
 

--- a/tests/foreman/api/test_multiple_paths.py
+++ b/tests/foreman/api/test_multiple_paths.py
@@ -296,8 +296,6 @@ class EntityIdTestCase(TestCase):
 
         """
         skip_if_sam(self, entity)
-        if entity is entities.ActivationKey and bz_bug_is_open(1127335):
-            self.skipTest("Bugzilla bug 1127335 is open.")
         try:
             entity_n = entity(id=entity().create()['id'])
         except HTTPError as err:


### PR DESCRIPTION
Make method `ActivationKey.read_json` poll the server up to five additional
times upon receiving an HTTP 404 response. As per an IRC conversation with
@thomasmckay, bugzilla bug 1127335 will not be fixed, and clients **must**
resort to polling the server to determine whether a 404 is valid or not.

Several tests in module `test_activationkey` fail, but due to unrelated reasons
(that should be investigated!).

```
$ nosetests tests/foreman/api/test_activationkey.py
InsecureRequestWarning)
......FFF...................
======================================================================
…
----------------------------------------------------------------------
Ran 28 tests in 86.375s

FAILED (failures=3)
```

Fix the one remaining failure in module `test_multiple_paths`:

```
$ nosetests tests/foreman/api/test_multiple_paths.py -m ActivationKey
InsecureRequestWarning)
.S....SS
----------------------------------------------------------------------
Ran 8 tests in 38.545s

OK (SKIP=3)
```

Fix several Jenkins failures. Target #1578.
