### PR TITLE
Skip failing activation-key tests

### DIFF
--- a/tests/foreman/api/test_activationkey.py
+++ b/tests/foreman/api/test_activationkey.py
@@ -4,6 +4,7 @@ from fauxfactory import gen_integer, gen_string
 from requests.exceptions import HTTPError
 from robottelo.api import client
 from robottelo.api.utils import status_code_error
+from robottelo.common.decorators import skip_if_bug_open
 from robottelo.common.helpers import get_server_credentials
 from robottelo import entities
 from unittest import TestCase
@@ -148,6 +149,7 @@ class ActivationKeysTestCase(TestCase):
                 max_content_hosts=max_content_hosts
             ).create()
 
+    @skip_if_bug_open('bugzilla', 1156555)
     @data(
         gen_integer(min_value=-10, max_value=-1),
         gen_integer(min_value=1, max_value=20),


### PR DESCRIPTION
Creating an activation key with these options fails, as it should:
- max_content_hosts=-5
- max_content_hosts='ABcd37'

However, creating an activation key with these options succeed:
- unlimited_content_hosts=True, max_content_hosts=-5
- unlimited_content_hosts=True, max_content_hosts='ABcd37'
- unlimited_content_hosts=True, max_content_hosts=5

As demonstrated above, the API allows an invalid value for the
`max_content_hosts` argument when `unlimited_content_hosts` is true. When this
occurs, the `max_content_hosts` option is entirely ignored. Here's a concrete
example:

```
>>> attrs = entities.ActivationKey(
...     max_content_hosts='ABcd37',
...     unlimited_content_hosts=True
... ).create()
>>> for attr in ('max_content_hosts', 'unlimited_content_hosts'):
...     print(attrs[attr])
...
None
True
```

See bugzilla bug 1156555 for more information. Skip tests due to this bug:

```
$ nosetests tests/foreman/api/test_activationkey.py  -m test_negative_create_3
SSS
----------------------------------------------------------------------
Ran 3 tests in 0.518s

OK (SKIP=3)
```
