### PR TITLE
Added support to sync repos via the repository page.

### DIFF
--- a/robottelo/ui/locators.py
+++ b/robottelo/ui/locators.py
@@ -1008,6 +1008,8 @@ locators = {
         By.XPATH,
         ("//script[contains(@alch-modal,'removeRepository(repository)')]"
          "/../button[contains(@ng-show, 'repository')]")),
+    "repo.sync_now": (
+        By.XPATH, "//button[contains(@ng-click, 'syncSelectedRepositories')]"),
     "repo.select_checkbox": (
         By.XPATH, ("//a[@class='ng-binding' and contains(.,'%s')]"
                    "/../../td/input[contains(@ng-model,'repository')]")),

--- a/robottelo/ui/sync.py
+++ b/robottelo/ui/sync.py
@@ -11,17 +11,17 @@ from robottelo.ui.locators import locators
 
 
 class Sync(Base):
-    """
-    Synchronizes products and repos from UI.
-    """
+    """Synchronizes products and repos from UI."""
 
-    def assert_sync(self, repos):
+    def assert_sync(self, repos, product=None):
         """Asserts sync status of the Repositories.
 
         Asserts the sync of Repositories, loops over while cancel is visible,
         during the syncing process.
 
         :param list repos: List of repositories names to assert sync status.
+        :param str product: product is required only when syncing via
+            repository page.
         :return: Returns True if sync is successful.
         :rtype: boolean
 
@@ -29,6 +29,14 @@ class Sync(Base):
         repos_result = []
         strategy1, value1 = locators["sync.fetch_result"]
         strategy2, value2 = locators["sync.cancel"]
+        strategy3, value3 = locators["sync.prd_expander"]
+        if product:
+            prd_exp = self.wait_until_element((strategy3, value3 % product))
+            if not prd_exp:
+                raise UINoSuchElementError(
+                    "Could not find the product expander: '{0}'"
+                    .format(product))
+            prd_exp.click()
         for repo in repos:
             timeout = time.time() + 60 * 10
             sync_cancel = self.wait_until_element((strategy2,

--- a/tests/foreman/ui/test_sync.py
+++ b/tests/foreman/ui/test_sync.py
@@ -68,7 +68,7 @@ class Sync(UITestCase):
             session.nav.go_to_sync_status()
             sync = self.sync.sync_custom_repos(product_attrs['name'],
                                                [repository_name])
-            # syn.sync_rh_repos returns boolean values and not objects
+            # syn.sync_custom_repos returns boolean values and not objects
             self.assertTrue(sync)
 
     def test_sync_rh_repos(self):


### PR DESCRIPTION
This required tweaking the existing `assert_sync` function at,
ui/sync.py to sync repos via the repository pages.

Added tests to test all the repo types 'yum', 'puppet', 'docker'.
