### PR TITLE
Refactor all UI tests setUp method

### DIFF
--- a/tests/foreman/ui/test_activationkey.py
+++ b/tests/foreman/ui/test_activationkey.py
@@ -9,7 +9,7 @@ else:
     import unittest2 as unittest
 
 from ddt import ddt
-from fauxfactory import gen_string, gen_integer
+from fauxfactory import gen_string
 from nose.plugins.attrib import attr
 from robottelo import entities
 from robottelo.api import client
@@ -39,18 +39,12 @@ class ActivationKey(UITestCase):
 
     """
 
-    org_name = None
-    org_id = None
+    def setUpClass(cls):
+        org_attrs = entities.Organization().create()
+        cls.org_name = org_attrs['name']
+        cls.org_id = org_attrs['id']
 
-    def setUp(self):
-        super(ActivationKey, self).setUp()
-        # Make sure to use the Class' org_name instance
-        if ActivationKey.org_name is None:
-            org_name = gen_string(str_type='alphanumeric',
-                                  length=gen_integer(5, 80))
-            org_attrs = entities.Organization(name=org_name).create()
-            ActivationKey.org_name = org_attrs['name']
-            ActivationKey.org_id = org_attrs['id']
+        super(ActivationKey, cls).setUpClass()
 
     def create_cv(self, name, env_name, repo_url=None):
         """Create product/repo and sync it and promote to given env"""

--- a/tests/foreman/ui/test_architecture.py
+++ b/tests/foreman/ui/test_architecture.py
@@ -17,24 +17,6 @@ from robottelo.ui.session import Session
 class Architecture(UITestCase):
     """Implements Architecture tests from UI"""
 
-    org_name = None
-    loc_name = None
-    org_id = None
-    loc_id = None
-
-    def setUp(self):
-        super(Architecture, self).setUp()
-        #  Make sure to use the Class' org_name instance
-        if Architecture.org_name is None and Architecture.loc_name is None:
-            org_name = gen_string("alpha", 8)
-            loc_name = gen_string("alpha", 8)
-            org_attrs = entities.Organization(name=org_name).create()
-            loc_attrs = entities.Location(name=loc_name).create()
-            Architecture.org_name = org_attrs['name']
-            Architecture.org_id = org_attrs['id']
-            Architecture.loc_name = loc_attrs['name']
-            Architecture.loc_id = loc_attrs['id']
-
     @data({u'name': gen_string('alpha', 10),
            u'os_name': gen_string('alpha', 10)},
           {u'name': gen_string('html', 10),

--- a/tests/foreman/ui/test_computeresource.py
+++ b/tests/foreman/ui/test_computeresource.py
@@ -10,8 +10,7 @@ from robottelo.common.decorators import run_only_on, skip_if_bug_open
 from robottelo.common.decorators import data
 from robottelo.common.helpers import generate_strings_list
 from robottelo.test import UITestCase
-from robottelo.ui.factory import (make_org, make_loc,
-                                  make_resource)
+from robottelo.ui.factory import make_org, make_resource
 from robottelo.ui.locators import common_locators
 from robottelo.ui.session import Session
 
@@ -20,19 +19,6 @@ from robottelo.ui.session import Session
 @ddt
 class ComputeResource(UITestCase):
     """Implements Compute Resource tests in UI"""
-    org_name = None
-    loc_name = None
-
-    def setUp(self):
-        super(ComputeResource, self).setUp()
-        # Make sure to use the Class' org_name instance
-        if (ComputeResource.org_name is None and
-           ComputeResource.loc_name is None):
-            ComputeResource.org_name = gen_string("alpha", 8)
-            ComputeResource.loc_name = gen_string("alpha", 8)
-            with Session(self.browser) as session:
-                make_org(session, org_name=ComputeResource.org_name)
-                make_loc(session, name=ComputeResource.loc_name)
 
     @attr('ui', 'resource', 'implemented')
     @data(*generate_strings_list(len1=8))

--- a/tests/foreman/ui/test_config_groups.py
+++ b/tests/foreman/ui/test_config_groups.py
@@ -6,7 +6,7 @@ from nose.plugins.attrib import attr
 from robottelo.common.decorators import data, run_only_on
 from robottelo.common.helpers import generate_strings_list
 from robottelo.test import UITestCase
-from robottelo.ui.factory import make_org, make_loc, make_config_groups
+from robottelo.ui.factory import make_config_groups
 from robottelo.ui.locators import common_locators, locators
 from robottelo.ui.session import Session
 
@@ -15,19 +15,6 @@ from robottelo.ui.session import Session
 @ddt
 class ConfigGroups(UITestCase):
     """Implements Config Groups tests in UI."""
-    org_name = None
-    loc_name = None
-
-    def setUp(self):
-        super(ConfigGroups, self).setUp()
-        # Make sure to use the Class' org_name instance
-        if (ConfigGroups.org_name is None and
-           ConfigGroups.loc_name is None):
-            ConfigGroups.org_name = gen_string("alpha", 8)
-            ConfigGroups.loc_name = gen_string("alpha", 8)
-            with Session(self.browser) as session:
-                make_org(session, org_name=ConfigGroups.org_name)
-                make_loc(session, name=ConfigGroups.loc_name)
 
     @attr('ui', 'config-groups', 'implemented')
     @data(*generate_strings_list(len1=8))

--- a/tests/foreman/ui/test_contentenv.py
+++ b/tests/foreman/ui/test_contentenv.py
@@ -4,9 +4,10 @@
 
 from fauxfactory import gen_string
 from nose.plugins.attrib import attr
+from robottelo import entities
 from robottelo.common.decorators import run_only_on
 from robottelo.test import UITestCase
-from robottelo.ui.factory import make_org, make_lifecycle_environment
+from robottelo.ui.factory import make_lifecycle_environment
 from robottelo.ui.locators import common_locators
 from robottelo.ui.session import Session
 
@@ -15,16 +16,10 @@ from robottelo.ui.session import Session
 class ContentEnvironment(UITestCase):
     """Implements Life cycle content environment tests in UI"""
 
-    org_name = None
+    def setUpClass(cls):
+        cls.org_name = entities.Organization().create()['name']
 
-    def setUp(self):
-        super(ContentEnvironment, self).setUp()
-        # Make sure to use the Class' org_name instance
-        if ContentEnvironment.org_name is None:
-            ContentEnvironment.org_name = gen_string(
-                "alpha", 8)
-            with Session(self.browser) as session:
-                make_org(session, org_name=ContentEnvironment.org_name)
+        super(ContentEnvironment, cls).setUpClass()
 
     @attr('ui', 'contentenv', 'implemented')
     def test_positive_create_content_environment_1(self):

--- a/tests/foreman/ui/test_contentviews.py
+++ b/tests/foreman/ui/test_contentviews.py
@@ -14,7 +14,7 @@ else:
     import unittest2 as unittest
 
 from ddt import ddt
-from fauxfactory import gen_string, gen_integer
+from fauxfactory import gen_string
 from robottelo import entities
 from robottelo.api import utils
 from robottelo.common import manifests
@@ -35,19 +35,12 @@ from robottelo.test import UITestCase
 class TestContentViewsUI(UITestCase):
     """Implement tests for content view via UI"""
 
-    org_name = None
-    org_id = None
+    def setUpClass(cls):
+        org_attrs = entities.Organization().create()
+        cls.org_name = org_attrs['name']
+        cls.org_id = org_attrs['id']
 
-    def setUp(self):
-        super(TestContentViewsUI, self).setUp()
-
-        # Make sure to use the Class' org_name instance
-        if TestContentViewsUI.org_name is None:
-            org_name = gen_string(str_type='alphanumeric',
-                                  length=gen_integer(5, 80))
-            org_attrs = entities.Organization(name=org_name).create()
-            TestContentViewsUI.org_name = org_attrs['name']
-            TestContentViewsUI.org_id = org_attrs['id']
+        super(TestContentViewsUI, cls).setUpClass()
 
     def setup_to_create_cv(self, session, cv_name, repo_name=None,
                            repo_url=None, repo_type=None, rh_repo=None):

--- a/tests/foreman/ui/test_domain.py
+++ b/tests/foreman/ui/test_domain.py
@@ -7,8 +7,7 @@ from nose.plugins.attrib import attr
 from robottelo.common.decorators import data, run_only_on, skip_if_bug_open
 from robottelo.common.helpers import generate_strings_list
 from robottelo.test import UITestCase
-from robottelo.ui.factory import (make_org, make_loc,
-                                  make_domain)
+from robottelo.ui.factory import make_domain
 from robottelo.ui.locators import common_locators
 from robottelo.ui.session import Session
 
@@ -19,18 +18,6 @@ DOMAIN = "lab.dom.%s.com"
 @ddt
 class Domain(UITestCase):
     """Implements Domain tests in UI"""
-    org_name = None
-    loc_name = None
-
-    def setUp(self):
-        super(Domain, self).setUp()
-        # Make sure to use the Class' org_name instance
-        if Domain.org_name is None and Domain.loc_name is None:
-            Domain.org_name = gen_string("alpha", 8)
-            Domain.loc_name = gen_string("alpha", 8)
-            with Session(self.browser) as session:
-                make_org(session, org_name=Domain.org_name)
-                make_loc(session, name=Domain.loc_name)
 
     @attr('ui', 'domain', 'implemented')
     @data(*generate_strings_list(len1=4))

--- a/tests/foreman/ui/test_environment.py
+++ b/tests/foreman/ui/test_environment.py
@@ -7,7 +7,7 @@ from fauxfactory import gen_string
 from nose.plugins.attrib import attr
 from robottelo.common.decorators import data, run_only_on, skip_if_bug_open
 from robottelo.test import UITestCase
-from robottelo.ui.factory import make_org, make_loc, make_env
+from robottelo.ui.factory import make_env
 from robottelo.ui.locators import common_locators
 from robottelo.ui.session import Session
 
@@ -20,19 +20,6 @@ class Environment(UITestCase):
     Please note that, Environment will accept only alphanumeric chars as name.
 
     """
-    org_name = None
-    loc_name = None
-
-    def setUp(self):
-        super(Environment, self).setUp()
-        # Make sure to use the Class' org_name instance
-        if (Environment.org_name is None and
-           Environment.loc_name is None):
-            Environment.org_name = gen_string("alpha", 8)
-            Environment.loc_name = gen_string("alpha", 8)
-            with Session(self.browser) as session:
-                make_org(session, org_name=Environment.org_name)
-                make_loc(session, name=Environment.loc_name)
 
     @attr('ui', 'environment', 'implemented')
     @data(

--- a/tests/foreman/ui/test_gpgkey.py
+++ b/tests/foreman/ui/test_gpgkey.py
@@ -10,7 +10,7 @@ else:
     import unittest2 as unittest
 
 from ddt import ddt
-from fauxfactory import gen_string, gen_integer
+from fauxfactory import gen_string
 from nose.plugins.attrib import attr
 from robottelo import entities
 from robottelo.common.constants import (
@@ -36,19 +36,12 @@ from robottelo.ui.session import Session
 class GPGKey(UITestCase):
     """Implements tests for GPG Keys via UI"""
 
-    org_name = None
-    org_id = None
+    def setUpClass(cls):
+        org_attrs = entities.Organization().create()
+        cls.org_name = org_attrs['name']
+        cls.org_id = org_attrs['id']
 
-    def setUp(self):
-        super(GPGKey, self).setUp()
-
-        # Make sure to use the Class' org_name instance
-        if GPGKey.org_name is None:
-            org_name = gen_string(str_type='alphanumeric',
-                                  length=gen_integer(5, 80))
-            org_attrs = entities.Organization(name=org_name).create()
-            GPGKey.org_name = org_attrs['name']
-            GPGKey.org_id = org_attrs['id']
+        super(GPGKey, cls).setUpClass()
 
     # Positive Create
 
@@ -66,7 +59,7 @@ class GPGKey(UITestCase):
 
         key_path = get_data_file(VALID_GPG_KEY_FILE)
         with Session(self.browser) as session:
-            make_gpgkey(session, org=GPGKey.org_name,
+            make_gpgkey(session, org=self.org_name,
                         name=name, upload_key=True,
                         key_path=key_path)
             self.assertIsNotNone(self.gpgkey.search(name))
@@ -85,7 +78,7 @@ class GPGKey(UITestCase):
 
         key_content = read_data_file(VALID_GPG_KEY_FILE)
         with Session(self.browser) as session:
-            make_gpgkey(session, org=GPGKey.org_name,
+            make_gpgkey(session, org=self.org_name,
                         name=name, key_content=key_content)
             self.assertIsNotNone(self.gpgkey.search(name))
 
@@ -105,11 +98,11 @@ class GPGKey(UITestCase):
 
         key_path = get_data_file(VALID_GPG_KEY_FILE)
         with Session(self.browser) as session:
-            make_gpgkey(session, org=GPGKey.org_name,
+            make_gpgkey(session, org=self.org_name,
                         name=name, upload_key=True,
                         key_path=key_path)
             self.assertIsNotNone(self.gpgkey.search(name))
-            make_gpgkey(session, org=GPGKey.org_name,
+            make_gpgkey(session, org=self.org_name,
                         name=name, upload_key=True,
                         key_path=key_path)
             self.assertIsNotNone(self.gpgkey.wait_until_element
@@ -129,10 +122,10 @@ class GPGKey(UITestCase):
 
         key_content = read_data_file(VALID_GPG_KEY_FILE)
         with Session(self.browser) as session:
-            make_gpgkey(session, org=GPGKey.org_name,
+            make_gpgkey(session, org=self.org_name,
                         name=name, key_content=key_content)
             self.assertIsNotNone(self.gpgkey.search(name))
-            make_gpgkey(session, org=GPGKey.org_name,
+            make_gpgkey(session, org=self.org_name,
                         name=name, key_content=key_content)
             self.assertTrue(self.gpgkey.wait_until_element
                             (common_locators["alert.error"]))
@@ -150,7 +143,7 @@ class GPGKey(UITestCase):
 
         with Session(self.browser) as session:
             with self.assertRaises(Exception):
-                make_gpgkey(session, org=GPGKey.org_name,
+                make_gpgkey(session, org=self.org_name,
                             name=name)
             self.assertIsNone(self.gpgkey.search(name))
 
@@ -168,7 +161,7 @@ class GPGKey(UITestCase):
 
         key_path = get_data_file(VALID_GPG_KEY_FILE)
         with Session(self.browser) as session:
-            make_gpgkey(session, org=GPGKey.org_name,
+            make_gpgkey(session, org=self.org_name,
                         name=name, upload_key=True,
                         key_path=key_path)
             self.assertTrue(self.gpgkey.wait_until_element
@@ -188,7 +181,7 @@ class GPGKey(UITestCase):
         name = " "
         key_path = get_data_file(VALID_GPG_KEY_FILE)
         with Session(self.browser) as session:
-            make_gpgkey(session, org=GPGKey.org_name,
+            make_gpgkey(session, org=self.org_name,
                         name=name, upload_key=True,
                         key_path=key_path)
             self.assertTrue(self.gpgkey.wait_until_element
@@ -209,7 +202,7 @@ class GPGKey(UITestCase):
 
         key_content = read_data_file(VALID_GPG_KEY_FILE)
         with Session(self.browser) as session:
-            make_gpgkey(session, org=GPGKey.org_name,
+            make_gpgkey(session, org=self.org_name,
                         name=name, key_content=key_content)
             self.assertTrue(self.gpgkey.wait_until_element
                             (common_locators["alert.error"]))
@@ -231,7 +224,7 @@ class GPGKey(UITestCase):
 
         key_path = get_data_file(VALID_GPG_KEY_FILE)
         with Session(self.browser) as session:
-            make_gpgkey(session, org=GPGKey.org_name,
+            make_gpgkey(session, org=self.org_name,
                         name=name, upload_key=True,
                         key_path=key_path)
             self.assertIsNotNone(self.gpgkey.search(name))
@@ -252,7 +245,7 @@ class GPGKey(UITestCase):
 
         key_content = read_data_file(VALID_GPG_KEY_FILE)
         with Session(self.browser) as session:
-            make_gpgkey(session, org=GPGKey.org_name,
+            make_gpgkey(session, org=self.org_name,
                         name=name, key_content=key_content)
             self.assertIsNotNone(self.gpgkey.search(name))
             self.gpgkey.delete(name, True)
@@ -275,7 +268,7 @@ class GPGKey(UITestCase):
         new_name = gen_string("alpha", 6)
         key_path = get_data_file(VALID_GPG_KEY_FILE)
         with Session(self.browser) as session:
-            make_gpgkey(session, org=GPGKey.org_name,
+            make_gpgkey(session, org=self.org_name,
                         name=name, upload_key=True,
                         key_path=key_path)
             self.assertIsNotNone(self.gpgkey.search(name))
@@ -298,7 +291,7 @@ class GPGKey(UITestCase):
         key_path = get_data_file(VALID_GPG_KEY_FILE)
         new_key_path = get_data_file(VALID_GPG_KEY_BETA_FILE)
         with Session(self.browser) as session:
-            make_gpgkey(session, org=GPGKey.org_name,
+            make_gpgkey(session, org=self.org_name,
                         name=name, upload_key=True,
                         key_path=key_path)
             self.assertIsNotNone(self.gpgkey.search(name))
@@ -321,7 +314,7 @@ class GPGKey(UITestCase):
         new_name = gen_string("alpha", 6)
         key_content = read_data_file(VALID_GPG_KEY_FILE)
         with Session(self.browser) as session:
-            make_gpgkey(session, org=GPGKey.org_name,
+            make_gpgkey(session, org=self.org_name,
                         name=name, key_content=key_content)
             self.assertIsNotNone(self.gpgkey.search(name))
             self.gpgkey.update(name, new_name)
@@ -343,7 +336,7 @@ class GPGKey(UITestCase):
         key_content = read_data_file(VALID_GPG_KEY_FILE)
         new_key_path = get_data_file(VALID_GPG_KEY_BETA_FILE)
         with Session(self.browser) as session:
-            make_gpgkey(session, org=GPGKey.org_name,
+            make_gpgkey(session, org=self.org_name,
                         name=name, key_content=key_content)
             self.assertIsNotNone(self.gpgkey.search(name))
             self.gpgkey.update(name, new_key=new_key_path)
@@ -367,7 +360,7 @@ class GPGKey(UITestCase):
         name = gen_string("alpha", 6)
         key_path = get_data_file(VALID_GPG_KEY_FILE)
         with Session(self.browser) as session:
-            make_gpgkey(session, org=GPGKey.org_name,
+            make_gpgkey(session, org=self.org_name,
                         name=name, upload_key=True,
                         key_path=key_path)
             self.assertIsNotNone(self.gpgkey.search(name))
@@ -391,7 +384,7 @@ class GPGKey(UITestCase):
         name = gen_string("alpha", 6)
         key_content = read_data_file(VALID_GPG_KEY_FILE)
         with Session(self.browser) as session:
-            make_gpgkey(session, org=GPGKey.org_name,
+            make_gpgkey(session, org=self.org_name,
                         name=name, key_content=key_content)
             self.assertIsNotNone(self.gpgkey.search(name))
             self.gpgkey.update(name, new_name)
@@ -427,7 +420,7 @@ class GPGKey(UITestCase):
             organization=self.org_id
         ).create()
         with Session(self.browser) as session:
-            session.nav.go_to_select_org(GPGKey.org_name)
+            session.nav.go_to_select_org(self.org_name)
             session.nav.go_to_gpg_keys()
             # Assert that GPGKey is associated with product
             self.assertIsNotNone(self.gpgkey.assert_product_repo
@@ -467,7 +460,7 @@ class GPGKey(UITestCase):
             product=product_attrs['id'],
         ).create()
         with Session(self.browser) as session:
-            session.nav.go_to_select_org(GPGKey.org_name)
+            session.nav.go_to_select_org(self.org_name)
             session.nav.go_to_gpg_keys()
             # Assert that GPGKey is associated with product
             self.assertIsNotNone(self.gpgkey.assert_product_repo
@@ -517,7 +510,7 @@ class GPGKey(UITestCase):
             product=product_attrs['id']
         ).create()
         with Session(self.browser) as session:
-            session.nav.go_to_select_org(GPGKey.org_name)
+            session.nav.go_to_select_org(self.org_name)
             session.nav.go_to_gpg_keys()
             # Assert that GPGKey is associated with product
             self.assertIsNotNone(self.gpgkey.assert_product_repo
@@ -547,7 +540,7 @@ class GPGKey(UITestCase):
         discovered_urls = ["fakerepo01/"]
         key_content = read_data_file(VALID_GPG_KEY_FILE)
         with Session(self.browser) as session:
-            make_gpgkey(session, org=GPGKey.org_name,
+            make_gpgkey(session, org=self.org_name,
                         name=name, key_content=key_content)
             self.assertIsNotNone(self.gpgkey.search(name))
             session.nav.go_to_products()
@@ -594,7 +587,7 @@ class GPGKey(UITestCase):
             gpg_key=gpgkey_attrs['id'],
         ).create()
         with Session(self.browser) as session:
-            session.nav.go_to_select_org(GPGKey.org_name)
+            session.nav.go_to_select_org(self.org_name)
             session.nav.go_to_gpg_keys()
             # Assert that GPGKey is not associated with product
             self.assertIsNone(self.gpgkey.assert_product_repo
@@ -645,7 +638,7 @@ class GPGKey(UITestCase):
             product=product_attrs['id'],
         ).create()
         with Session(self.browser) as session:
-            session.nav.go_to_select_org(GPGKey.org_name)
+            session.nav.go_to_select_org(self.org_name)
             session.nav.go_to_gpg_keys()
             # Assert that GPGKey is not associated with product
             self.assertIsNone(self.gpgkey.assert_product_repo
@@ -708,7 +701,7 @@ class GPGKey(UITestCase):
             organization=self.org_id
         ).create()
         with Session(self.browser) as session:
-            session.nav.go_to_select_org(GPGKey.org_name)
+            session.nav.go_to_select_org(self.org_name)
             session.nav.go_to_gpg_keys()
             # Assert that GPGKey is associated with product
             self.assertIsNotNone(self.gpgkey.assert_product_repo
@@ -755,7 +748,7 @@ class GPGKey(UITestCase):
             product=product_attrs['id'],
         ).create()
         with Session(self.browser) as session:
-            session.nav.go_to_select_org(GPGKey.org_name)
+            session.nav.go_to_select_org(self.org_name)
             session.nav.go_to_gpg_keys()
             # Assert that before update GPGKey is associated with product
             self.assertIsNotNone(self.gpgkey.assert_product_repo
@@ -814,7 +807,7 @@ class GPGKey(UITestCase):
             product=product_attrs['id'],
         ).create()
         with Session(self.browser) as session:
-            session.nav.go_to_select_org(GPGKey.org_name)
+            session.nav.go_to_select_org(self.org_name)
             session.nav.go_to_gpg_keys()
             # Assert that before update GPGKey is associated with product
             self.assertIsNotNone(self.gpgkey.assert_product_repo
@@ -858,7 +851,7 @@ class GPGKey(UITestCase):
             organization=self.org_id
         ).create()
         with Session(self.browser) as session:
-            session.nav.go_to_select_org(GPGKey.org_name)
+            session.nav.go_to_select_org(self.org_name)
             session.nav.go_to_products()
             # Perform repo discovery
             self.repository.discover_repo(url, discovered_urls,
@@ -910,7 +903,7 @@ class GPGKey(UITestCase):
             gpg_key=gpgkey_attrs['id'],
         ).create()
         with Session(self.browser) as session:
-            session.nav.go_to_select_org(GPGKey.org_name)
+            session.nav.go_to_select_org(self.org_name)
             session.nav.go_to_gpg_keys()
             # Assert that GPGKey is not associated with product
             self.assertIsNone(self.gpgkey.assert_product_repo
@@ -970,7 +963,7 @@ class GPGKey(UITestCase):
             product=product_attrs['id'],
         ).create()
         with Session(self.browser) as session:
-            session.nav.go_to_select_org(GPGKey.org_name)
+            session.nav.go_to_select_org(self.org_name)
             session.nav.go_to_gpg_keys()
             # Assert that GPGKey is not associated with product
             self.assertIsNone(self.gpgkey.assert_product_repo
@@ -1043,7 +1036,7 @@ class GPGKey(UITestCase):
             organization=self.org_id
         ).create()
         with Session(self.browser) as session:
-            session.nav.go_to_select_org(GPGKey.org_name)
+            session.nav.go_to_select_org(self.org_name)
             session.nav.go_to_gpg_keys()
             # Assert that GPGKey is associated with product
             self.assertIsNotNone(self.gpgkey.assert_product_repo
@@ -1088,7 +1081,7 @@ class GPGKey(UITestCase):
             product=product_attrs['id'],
         ).create()
         with Session(self.browser) as session:
-            session.nav.go_to_select_org(GPGKey.org_name)
+            session.nav.go_to_select_org(self.org_name)
             session.nav.go_to_gpg_keys()
             # Assert that GPGKey is associated with product
             self.assertIsNotNone(self.gpgkey.assert_product_repo
@@ -1144,7 +1137,7 @@ class GPGKey(UITestCase):
             product=product_attrs['id'],
         ).create()
         with Session(self.browser) as session:
-            session.nav.go_to_select_org(GPGKey.org_name)
+            session.nav.go_to_select_org(self.org_name)
             session.nav.go_to_gpg_keys()
             # Assert that GPGKey is associated with product
             self.assertIsNotNone(self.gpgkey.assert_product_repo
@@ -1185,7 +1178,7 @@ class GPGKey(UITestCase):
             organization=self.org_id
         ).create()
         with Session(self.browser) as session:
-            session.nav.go_to_select_org(GPGKey.org_name)
+            session.nav.go_to_select_org(self.org_name)
             session.nav.go_to_products()
             # Perform repo discovery
             self.repository.discover_repo(url, discovered_urls,
@@ -1235,7 +1228,7 @@ class GPGKey(UITestCase):
             gpg_key=gpgkey_attrs['id'],
         ).create()
         with Session(self.browser) as session:
-            session.nav.go_to_select_org(GPGKey.org_name)
+            session.nav.go_to_select_org(self.org_name)
             session.nav.go_to_gpg_keys()
             # Assert that GPGKey is not associated with product
             self.assertIsNone(self.gpgkey.assert_product_repo
@@ -1293,7 +1286,7 @@ class GPGKey(UITestCase):
             # notice that we're not making this repo point to the GPG key
         ).create()
         with Session(self.browser) as session:
-            session.nav.go_to_select_org(GPGKey.org_name)
+            session.nav.go_to_select_org(self.org_name)
             session.nav.go_to_gpg_keys()
             # Assert that GPGKey is not associated with product
             self.assertIsNone(self.gpgkey.assert_product_repo

--- a/tests/foreman/ui/test_hostgroup.py
+++ b/tests/foreman/ui/test_hostgroup.py
@@ -8,7 +8,7 @@ from fauxfactory import gen_string
 from robottelo.common.decorators import data, run_only_on, skip_if_bug_open
 from robottelo.common.helpers import generate_strings_list
 from robottelo.test import UITestCase
-from robottelo.ui.factory import make_org, make_loc, make_hostgroup
+from robottelo.ui.factory import make_hostgroup
 from robottelo.ui.locators import common_locators
 from robottelo.ui.session import Session
 
@@ -17,19 +17,6 @@ from robottelo.ui.session import Session
 @ddt
 class Hostgroup(UITestCase):
     """Implements HostGroup tests from UI"""
-
-    org_name = None
-    loc_name = None
-
-    def setUp(self):
-        super(Hostgroup, self).setUp()
-        #  Make sure to use the Class' org_name instance
-        if Hostgroup.org_name is None and Hostgroup.loc_name is None:
-            Hostgroup.org_name = gen_string("alpha", 8)
-            Hostgroup.loc_name = gen_string("alpha", 8)
-            with Session(self.browser) as session:
-                make_org(session, org_name=Hostgroup.org_name)
-                make_loc(session, name=Hostgroup.loc_name)
 
     @data(*generate_strings_list(len1=4))
     def test_create_hostgroup(self, name):

--- a/tests/foreman/ui/test_hw_model.py
+++ b/tests/foreman/ui/test_hw_model.py
@@ -6,7 +6,7 @@ from nose.plugins.attrib import attr
 from robottelo.common.decorators import data, run_only_on
 from robottelo.common.helpers import generate_strings_list
 from robottelo.test import UITestCase
-from robottelo.ui.factory import make_org, make_loc, make_hw_model
+from robottelo.ui.factory import make_hw_model
 from robottelo.ui.locators import common_locators
 from robottelo.ui.session import Session
 
@@ -15,21 +15,6 @@ from robottelo.ui.session import Session
 @ddt
 class HardwareModelTestCase(UITestCase):
     """Implements Hardware Model tests in UI."""
-    org_name = None
-    loc_name = None
-
-    def setUp(self):
-        super(HardwareModelTestCase, self).setUp()
-        # Make sure to use the Class' org_name instance
-        if (HardwareModelTestCase.org_name is None and
-                HardwareModelTestCase.loc_name is None):
-            HardwareModelTestCase.org_name = gen_string(
-                "alpha", 8)
-            HardwareModelTestCase.loc_name = gen_string(
-                "alpha", 8)
-            with Session(self.browser) as session:
-                make_org(session, org_name=HardwareModelTestCase.org_name)
-                make_loc(session, name=HardwareModelTestCase.loc_name)
 
     @attr('ui', 'hardware-model', 'implemented')
     @data(*generate_strings_list(len1=8))

--- a/tests/foreman/ui/test_medium.py
+++ b/tests/foreman/ui/test_medium.py
@@ -4,7 +4,6 @@
 
 from ddt import ddt
 from fauxfactory import gen_string
-from robottelo import entities
 from robottelo.common.constants import INSTALL_MEDIUM_URL
 from robottelo.common.decorators import data, run_only_on
 from robottelo.common.helpers import generate_strings_list
@@ -18,24 +17,6 @@ from robottelo.ui.session import Session
 @ddt
 class Medium(UITestCase):
     """Implements all Installation Media tests"""
-
-    org_name = None
-    loc_name = None
-    org_id = None
-    loc_id = None
-
-    def setUp(self):
-        super(Medium, self).setUp()
-        #  Make sure to use the Class' org_name instance
-        if (Medium.org_name is None and Medium.loc_name is None):
-            org_name = gen_string("alpha", 8)
-            loc_name = gen_string("alpha", 8)
-            org_attrs = entities.Organization(name=org_name).create()
-            loc_attrs = entities.Location(name=loc_name).create()
-            Medium.org_name = org_attrs['name']
-            Medium.org_id = org_attrs['id']
-            Medium.loc_name = loc_attrs['name']
-            Medium.loc_id = loc_attrs['id']
 
     @data(*generate_strings_list(len1=4))
     def test_positive_create_medium_1(self, name):

--- a/tests/foreman/ui/test_operatingsys.py
+++ b/tests/foreman/ui/test_operatingsys.py
@@ -21,24 +21,6 @@ from robottelo.ui.session import Session
 class OperatingSys(UITestCase):
     """Implements Operating system tests from UI"""
 
-    org_name = None
-    loc_name = None
-    org_id = None
-    loc_id = None
-
-    def setUp(self):
-        super(OperatingSys, self).setUp()
-        #  Make sure to use the Class' org_name instance
-        if OperatingSys.org_name is None and OperatingSys.loc_name is None:
-            org_name = gen_string("alpha", 8)
-            loc_name = gen_string("alpha", 8)
-            org_attrs = entities.Organization(name=org_name).create()
-            loc_attrs = entities.Location(name=loc_name).create()
-            OperatingSys.org_name = org_attrs['name']
-            OperatingSys.org_id = org_attrs['id']
-            OperatingSys.loc_name = loc_attrs['name']
-            OperatingSys.loc_id = loc_attrs['id']
-
     def test_create_os(self):
         """@Test: Create a new OS
 

--- a/tests/foreman/ui/test_partitiontable.py
+++ b/tests/foreman/ui/test_partitiontable.py
@@ -8,8 +8,7 @@ from robottelo.common.decorators import data, run_only_on
 from robottelo.common.constants import PARTITION_SCRIPT_DATA_FILE
 from robottelo.common.helpers import read_data_file, generate_strings_list
 from robottelo.test import UITestCase
-from robottelo.ui.factory import (make_org, make_loc,
-                                  make_partitiontable)
+from robottelo.ui.factory import make_partitiontable
 from robottelo.ui.locators import common_locators
 from robottelo.ui.session import Session
 
@@ -18,20 +17,6 @@ from robottelo.ui.session import Session
 @ddt
 class PartitionTable(UITestCase):
     """Implements the partition table tests from UI"""
-
-    org_name = None
-    loc_name = None
-
-    def setUp(self):
-        super(PartitionTable, self).setUp()
-        #  Make sure to use the Class' org_name instance
-        if (PartitionTable.org_name is None
-                and PartitionTable.loc_name is None):
-            PartitionTable.org_name = gen_string("alpha", 8)
-            PartitionTable.loc_name = gen_string("alpha", 8)
-            with Session(self.browser) as session:
-                make_org(session, org_name=PartitionTable.org_name)
-                make_loc(session, name=PartitionTable.loc_name)
 
     @data(*generate_strings_list())
     def test_positive_create_partition_table(self, name):

--- a/tests/foreman/ui/test_products.py
+++ b/tests/foreman/ui/test_products.py
@@ -7,7 +7,7 @@ from robottelo import entities
 from robottelo.common.decorators import data, run_only_on, skip_if_bug_open
 from robottelo.common.helpers import generate_strings_list
 from robottelo.test import UITestCase
-from robottelo.ui.factory import make_org, make_loc, make_product
+from robottelo.ui.factory import make_product
 from robottelo.ui.locators import common_locators
 from robottelo.ui.session import Session
 
@@ -16,18 +16,11 @@ from robottelo.ui.session import Session
 class Products(UITestCase):
     """Implements Product tests in UI"""
 
-    org_name = None
-    loc_name = None
+    def setUpClass(cls):
+        cls.org_name = entities.Organization().create()['name']
+        cls.loc_name = entities.Location().create()['name']
 
-    def setUp(self):
-        super(Products, self).setUp()
-        # Make sure to use the Class' org_name instance
-        if Products.org_name is None and Products.loc_name is None:
-            Products.org_name = gen_string("alpha", 8)
-            Products.loc_name = gen_string("alpha", 8)
-            with Session(self.browser) as session:
-                make_org(session, org_name=Products.org_name)
-                make_loc(session, name=Products.loc_name)
+        super(Products, cls).setUpClass()
 
     @run_only_on('sat')
     @attr('ui', 'prd', 'implemented')

--- a/tests/foreman/ui/test_puppet_classes.py
+++ b/tests/foreman/ui/test_puppet_classes.py
@@ -6,7 +6,7 @@ from nose.plugins.attrib import attr
 from robottelo.common.decorators import data, run_only_on, skip_if_bug_open
 from robottelo.common.helpers import generate_strings_list
 from robottelo.test import UITestCase
-from robottelo.ui.factory import make_org, make_loc, make_puppetclasses
+from robottelo.ui.factory import make_puppetclasses
 from robottelo.ui.locators import common_locators
 from robottelo.ui.session import Session
 
@@ -15,19 +15,6 @@ from robottelo.ui.session import Session
 @ddt
 class PuppetClasses(UITestCase):
     """Implements puppet classes tests in UI."""
-    org_name = None
-    loc_name = None
-
-    def setUp(self):
-        super(PuppetClasses, self).setUp()
-        # Make sure to use the Class' org_name instance
-        if (PuppetClasses.org_name is None and
-           PuppetClasses.loc_name is None):
-            PuppetClasses.org_name = gen_string("alpha", 8)
-            PuppetClasses.loc_name = gen_string("alpha", 8)
-            with Session(self.browser) as session:
-                make_org(session, org_name=PuppetClasses.org_name)
-                make_loc(session, name=PuppetClasses.loc_name)
 
     @attr('ui', 'puppet-classes', 'implemented')
     @data(*generate_strings_list(len1=8))

--- a/tests/foreman/ui/test_repository.py
+++ b/tests/foreman/ui/test_repository.py
@@ -27,23 +27,15 @@ from robottelo.ui.session import Session
 class Repos(UITestCase):
     """Implements Repos tests in UI"""
 
-    org_name = None
-    org_id = None
-    loc_name = None
-    loc_id = None
+    def setUpClass(cls):
+        org_attrs = entities.Organization().create()
+        loc_attrs = entities.Location().create()
+        cls.org_name = org_attrs['name']
+        cls.org_id = org_attrs['id']
+        cls.loc_name = loc_attrs['name']
+        cls.loc_id = loc_attrs['id']
 
-    def setUp(self):
-        super(Repos, self).setUp()
-        # Make sure to use the Class' org_name instance
-        if Repos.org_name is None and Repos.loc_name is None:
-            org_name = gen_string("alpha", 10)
-            loc_name = gen_string("alpha", 10)
-            org_attrs = entities.Organization(name=org_name).create()
-            loc_attrs = entities.Location(name=loc_name).create()
-            Repos.org_name = org_attrs['name']
-            Repos.org_id = org_attrs['id']
-            Repos.loc_name = loc_attrs['name']
-            Repos.loc_id = loc_attrs['id']
+        super(Repos, cls).setUpClass()
 
     def setup_navigate_syncnow(self, session, prd_name, repo_name):
         """Helps with Navigation for syncing via the repos page."""

--- a/tests/foreman/ui/test_settings.py
+++ b/tests/foreman/ui/test_settings.py
@@ -6,7 +6,7 @@ from ddt import ddt
 from fauxfactory import gen_string
 from robottelo.common.decorators import data, run_only_on, skip_if_bug_open
 from robottelo.test import UITestCase
-from robottelo.ui.factory import make_org, make_loc, edit_param
+from robottelo.ui.factory import edit_param
 from robottelo.ui.locators import tab_locators, common_locators
 from robottelo.ui.session import Session
 
@@ -14,19 +14,6 @@ from robottelo.ui.session import Session
 @ddt
 class Settings(UITestCase):
     """Implements Boundary tests for Settings menu"""
-
-    org_name = None
-    loc_name = None
-
-    def setUp(self):
-        super(Settings, self).setUp()
-        #  Make sure to use the Class' org_name instance
-        if (Settings.org_name is None and Settings.loc_name is None):
-            Settings.org_name = gen_string("alpha", 8)
-            Settings.loc_name = gen_string("alpha", 8)
-            with Session(self.browser) as session:
-                make_org(session, org_name=Settings.org_name)
-                make_loc(session, name=Settings.loc_name)
 
     @data({u'param_value': "true"},
           {u'param_value': "false"})

--- a/tests/foreman/ui/test_subnet.py
+++ b/tests/foreman/ui/test_subnet.py
@@ -18,23 +18,6 @@ from robottelo.ui.session import Session
 @ddt
 class Subnet(UITestCase):
     """Implements Subnet tests in UI"""
-    org_name = None
-    loc_name = None
-    org_id = None
-    loc_id = None
-
-    def setUp(self):
-        super(Subnet, self).setUp()
-        # Make sure to use the Class' org_name instance
-        if Subnet.org_name is None and Subnet.loc_name is None:
-            org_name = gen_string("alpha", 8)
-            loc_name = gen_string("alpha", 8)
-            org_attrs = entities.Organization(name=org_name).create()
-            loc_attrs = entities.Location(name=loc_name).create()
-            Subnet.org_name = org_attrs['name']
-            Subnet.org_id = org_attrs['id']
-            Subnet.loc_name = loc_attrs['name']
-            Subnet.loc_id = loc_attrs['id']
 
     @attr('ui', 'subnet', 'implemented')
     @data(*generate_strings_list(len1=8))

--- a/tests/foreman/ui/test_subscription.py
+++ b/tests/foreman/ui/test_subscription.py
@@ -1,13 +1,12 @@
 """Test class for Subscriptions/Manifests UI"""
 
 from ddt import ddt
-from fauxfactory import gen_string
 from nose.plugins.attrib import attr
+from robottelo import entities
 from robottelo.common import manifests
 from robottelo.common.decorators import skipRemote
 from robottelo.common.ssh import upload_file
 from robottelo.test import UITestCase
-from robottelo.ui.factory import make_org
 from robottelo.ui.locators import common_locators
 from robottelo.ui.session import Session
 
@@ -16,16 +15,10 @@ from robottelo.ui.session import Session
 class SubscriptionTestCase(UITestCase):
     """Implements subscriptions/manifests tests in UI"""
 
-    org_name = None
+    def setUpClass(cls):
+        cls.org_name = entities.Organization().create()['name']
 
-    def setUp(self):
-        super(SubscriptionTestCase, self).setUp()
-        # Make sure to use the Class' org_name instance
-        if SubscriptionTestCase.org_name is None:
-            SubscriptionTestCase.org_name = gen_string(
-                "alpha", 8)
-            with Session(self.browser) as session:
-                make_org(session, org_name=SubscriptionTestCase.org_name)
+        super(SubscriptionTestCase, cls).setUpClass()
 
     @skipRemote
     @attr('ui', 'subs', 'implemented')

--- a/tests/foreman/ui/test_sync.py
+++ b/tests/foreman/ui/test_sync.py
@@ -3,7 +3,6 @@
 from ddt import ddt
 from nose.plugins.attrib import attr
 from robottelo import entities
-from fauxfactory import gen_string, gen_integer
 from robottelo.common.constants import FAKE_1_YUM_REPO
 from robottelo.common.decorators import data, run_only_on
 from robottelo.common.helpers import generate_strings_list
@@ -28,18 +27,12 @@ RHCT = [('rhel', 'rhct6', 'rhct65', 'repo_name',
 class Sync(UITestCase):
     """Implements Custom Sync tests in UI"""
 
-    org_name = None
-    org_id = None
+    def setUpClass(cls):
+        org_attrs = entities.Organization().create()
+        cls.org_name = org_attrs['name']
+        cls.org_id = org_attrs['id']
 
-    def setUp(self):
-        super(Sync, self).setUp()
-        # Make sure to use the Class' org_name instance
-        if Sync.org_name is None:
-            org_name = gen_string(str_type='alphanumeric',
-                                  length=gen_integer(5, 80))
-            org_attrs = entities.Organization(name=org_name).create()
-            Sync.org_name = org_attrs['name']
-            Sync.org_id = org_attrs['id']
+        super(Sync, cls).setUpClass()
 
     @run_only_on('sat')
     @attr('ui', 'sync', 'implemented')

--- a/tests/foreman/ui/test_syncplan.py
+++ b/tests/foreman/ui/test_syncplan.py
@@ -18,17 +18,12 @@ from robottelo.ui.session import Session
 class Syncplan(UITestCase):
     """Implements Sync Plan tests in UI"""
 
-    org_name = None
-    org_id = None
+    def setUpClass(cls):
+        org_attrs = entities.Organization().create()
+        cls.org_name = org_attrs['name']
+        cls.org_id = org_attrs['id']
 
-    def setUp(self):
-        super(Syncplan, self).setUp()
-        # Make sure to use the Class' org_name instance
-        if Syncplan.org_name is None:
-            org_name = gen_string("alpha", 10)
-            org_attrs = entities.Organization(name=org_name).create()
-            Syncplan.org_name = org_attrs['name']
-            Syncplan.org_id = org_attrs['id']
+        super(Syncplan, cls).setUpClass()
 
     @attr('ui', 'syncplan', 'implemented')
     @data({u'name': gen_string('alpha', 10),

--- a/tests/foreman/ui/test_template.py
+++ b/tests/foreman/ui/test_template.py
@@ -19,24 +19,6 @@ from robottelo.ui.session import Session
 class Template(UITestCase):
     """Implements Provisioning Template tests from UI"""
 
-    org_name = None
-    loc_name = None
-    org_id = None
-    loc_id = None
-
-    def setUp(self):
-        super(Template, self).setUp()
-        #  Make sure to use the Class' org_name instance
-        if Template.org_name is None and Template.loc_name is None:
-            org_name = gen_string("alpha", 8)
-            loc_name = gen_string("alpha", 8)
-            org_attrs = entities.Organization(name=org_name).create()
-            loc_attrs = entities.Location(name=loc_name).create()
-            Template.org_name = org_attrs['name']
-            Template.org_id = org_attrs['id']
-            Template.loc_name = loc_attrs['name']
-            Template.loc_id = loc_attrs['id']
-
     @data(*generate_strings_list())
     def test_positive_create_template(self, name):
         """@Test: Create new template

--- a/tests/foreman/ui/test_user.py
+++ b/tests/foreman/ui/test_user.py
@@ -54,17 +54,6 @@ class User(UITestCase):
     Lesser than Min Length, Greater than Max DB size
 
     """
-    org_name = None
-    org_id = None
-
-    def setUp(self):
-        super(User, self).setUp()
-        # Make sure to use the Class' org_name instance
-        if User.org_name is None:
-            org_name = gen_string("alpha", 10)
-            org_attrs = entities.Organization(name=org_name).create()
-            User.org_name = org_attrs['name']
-            User.org_id = org_attrs['id']
 
     @attr('ui', 'user', 'implemented')
     @data(*valid_strings())

--- a/tests/foreman/ui/test_usergroup.py
+++ b/tests/foreman/ui/test_usergroup.py
@@ -17,18 +17,10 @@ from robottelo.ui.session import Session
 class UserGroup(UITestCase):
     """Implements UserGroup tests from UI"""
 
-    org_name = None
-    org_id = None
+    def setUpClass(cls):
+        cls.org_name = entities.Organization().create()
 
-    def setUp(self):
-        super(UserGroup, self).setUp()
-
-        # Make sure to use the Class' org_name instance
-        if UserGroup.org_name is None:
-            org_name = gen_string("alpha", 6)
-            org_attrs = entities.Organization(name=org_name).create()
-            UserGroup.org_name = org_attrs['name']
-            UserGroup.org_id = org_attrs['id']
+        super(UserGroup, cls).setUpClass()
 
     @skip_if_bug_open('bugzilla', 1142588)
     @data(*generate_strings_list())


### PR DESCRIPTION
Remove unused setUp override.
Convert calls to UI factory to API factory.
Move super setUp call to the bottom to avoid leaving the browser open.
Because tearDown method will not run if setUp raises an exception and
the API factory could raise if server does not behave as expected.
