### PR TITLE
Fix the `graph-entities` make rule

### DIFF
--- a/scripts/graph_entities.py
+++ b/scripts/graph_entities.py
@@ -18,7 +18,7 @@ if ROBOTTELO_PATH not in sys.path:
     sys.path.append(ROBOTTELO_PATH)
 
 # Proceed with normal imports.
-from robottelo import entities, factory, orm
+from robottelo import entities, orm
 import inspect
 
 
@@ -45,8 +45,8 @@ def graph():
                     field_name,
                     ' color=red' if field.required else ''
                 ))
-        # Make entities that are not factories more... ethereal.
-        if not issubclass(entity, factory.Factory):
+        # Make entities that cannot be created less visible.
+        if not issubclass(entity, orm.EntityCreateMixin):
             print('{0} [style=dotted]'.format(entity_name))
     print('}')
 


### PR DESCRIPTION
The `robottelo.factories` module no longer exists. Roughly equivalent
functionality has been moved into the `robottelo.orm` module.

```
$ make graph-entities
scripts/graph_entities.py | dot -Tsvg -o entities.svg
$ echo $?
0
```
