### PR TITLE
Updated setUpClass method with decorator and using alpha string for org name

### DIFF
--- a/tests/foreman/ui/test_activationkey.py
+++ b/tests/foreman/ui/test_activationkey.py
@@ -41,7 +41,7 @@ class ActivationKey(UITestCase):
     Lesser than Min Length, Greater than Max DB size
 
     """
-
+    @classmethod
     def setUpClass(cls):
         org_attrs = entities.Organization().create()
         cls.org_name = org_attrs['name']


### PR DESCRIPTION
Fix following two issues:
1. @classmethod decorator was missing so tests were failing with error:
   TypeError: unbound method setUpClass() must be called with ActivationKey instance as first argument
2. org name should be alpha string otherwise tests were failed with this error,
   UnicodeEncodeError: 'ascii' codec can't encode characters in position 0-24: ordinal not in range(128)
