### PR TITLE
BZ 1158620 is fixed, so un-skip test code

### DIFF
--- a/tests/foreman/api/test_contentview.py
+++ b/tests/foreman/api/test_contentview.py
@@ -104,8 +104,7 @@ class ContentViewTestCase(TestCase):
         # See BZ #1151240
         self.assertEqual(system_attrs['content_view_id'], content_view.id)
         self.assertEqual(system_attrs['environment']['id'], lifecycle_env.id)
-        if not bz_bug_is_open(1158620):
-            self.assertEqual(system_attrs['organization_id'], org.id)
+        self.assertEqual(system_attrs['organization_id'], org.id)
 
 
 @ddt


### PR DESCRIPTION
[BZ 1158620](https://bugzilla.redhat.com/show_bug.cgi?id=1158620) is fixed, which means that HTTP GET calls to `/katello/api/v2/systems` returns an `organization_id`. Un-skip some test code which relies on this attribute.

```
$ nosetests tests/foreman/api/test_contentview.py -m test_subscribe_system_to_cv
.
----------------------------------------------------------------------
Ran 1 test in 73.045s

OK
```
