### PR TITLE
Fixing api test role creation failure BZ 1112657

### DIFF
--- a/tests/foreman/api/test_role_v2.py
+++ b/tests/foreman/api/test_role_v2.py
@@ -6,12 +6,12 @@ can be found here: http://theforeman.org/api/apidoc/v2/roles.html
 """
 from robottelo.api import client
 from robottelo.api.utils import status_code_error
-from robottelo.common.decorators import skip_if_bug_open
 from robottelo.common.helpers import get_server_credentials
 from robottelo import entities, factory, orm
 from unittest import TestCase
 import ddt
 import httplib
+import unittest
 # (too many public methods) pylint: disable=R0904
 
 
@@ -49,7 +49,7 @@ class RoleTestCase(TestCase):
         """
         self._test_role_name(name)
 
-    @skip_if_bug_open('bugzilla', 1112657)
+    @unittest.skip('Note: BZ 1112657 is fixed in upstream but not downstream')
     @ddt.data(
         orm.StringField(str_type=('cjk',)).get_value(),
         orm.StringField(str_type=('latin1',)).get_value(),


### PR DESCRIPTION
Test results:

``` sh
@Test: Create a role with a name containing non-alphanumeric chars. ... SKIP: BZ 1112657 is fixed in upstream but not downstream
@Test: Create a role with a name containing non-alphanumeric chars. ... SKIP: BZ 1112657 is fixed in upstream but not downstream
@Test: Create a role with a name containing non-alphanumeric chars. ... SKIP: BZ 1112657 is fixed in upstream but not downstream
```
