### PR TITLE
Adjust and fix content view code

### DIFF
--- a/robottelo/entities.py
+++ b/robottelo/entities.py
@@ -447,8 +447,10 @@ class ContentViewVersion(orm.Entity, orm.EntityReadMixin):
         :param bool synchronous: What should happen if the server returns an
             HTTP 202 (accepted) status code? Wait for the task to complete if
             ``True``. Immediately return a task ID otherwise.
-        :return: A foreman task ID if an HTTP 202 (accepted) response is
-            received, or None if any other response is received.
+        :return: Return information about the completed foreman task if an HTTP
+            202 response is received and ``synchronous`` is true. Return the
+            JSON response otherwise.
+        :rtype: dict
 
         """
         response = client.post(
@@ -459,13 +461,10 @@ class ContentViewVersion(orm.Entity, orm.EntityReadMixin):
         )
         response.raise_for_status()
 
-        # Return either a ForemanTask ID or None.
-        if response.status_code is httplib.ACCEPTED:
-            task_id = response.json()['id']
-            if synchronous is True:
-                ForemanTask(id=task_id).poll()
-            return task_id
-        return None
+        # Poll a task if necessary, then return the JSON response.
+        if synchronous is True and response.status_code is httplib.ACCEPTED:
+            return ForemanTask(id=response.json()['id']).poll()
+        return response.json()
 
 
 class ContentViewFilterRule(orm.Entity):
@@ -587,8 +586,10 @@ class ContentView(
         :param bool synchronous: What should happen if the server returns an
             HTTP 202 (accepted) status code? Wait for the task to complete if
             ``True``. Immediately return a task ID otherwise.
-        :return: A foreman task ID if an HTTP 202 (accepted) response is
-            received, or None if any other response is received.
+        :return: Return information about the completed foreman task if an HTTP
+            202 response is received and ``synchronous`` is true. Return the
+            JSON response otherwise.
+        :rtype: dict
 
         """
         response = client.post(
@@ -599,18 +600,15 @@ class ContentView(
         )
         response.raise_for_status()
 
-        # Return either a ForemanTask ID or None.
-        if response.status_code is httplib.ACCEPTED:
-            task_id = response.json()['id']
-            if synchronous is True:
-                ForemanTask(id=task_id).poll()
-            return task_id
-        return None
+        # Poll a task if necessary, then return the JSON response.
+        if synchronous is True and response.status_code is httplib.ACCEPTED:
+            return ForemanTask(id=response.json()['id']).poll()
+        return response.json()
 
     def set_repository_ids(self, repo_ids):
-        """Set content of view.
+        """Give this content view some repositories.
 
-        :param repo_ids list of repository ids
+        :param list repo_ids: A list of repository IDs.
 
         """
         response = client.put(

--- a/tests/foreman/smoke/test_api_smoke.py
+++ b/tests/foreman/smoke/test_api_smoke.py
@@ -865,8 +865,7 @@ class TestSmoke(TestCase):
         )
 
         # step 2.9: Publish content view
-        task_id = entities.ContentView(id=content_view['id']).publish()
-        task_status = entities.ForemanTask(id=task_id).poll()
+        task_status = entities.ContentView(id=content_view['id']).publish()
         self.assertEqual(
             task_status['result'],
             u'success',
@@ -882,10 +881,9 @@ class TestSmoke(TestCase):
             len(content_view['versions'][0]['environment_ids']),
             1,
             u"Content view should be present on 1 lifecycle only")
-        task_id = entities.ContentViewVersion(
+        task_status = entities.ContentViewVersion(
             id=content_view['versions'][0]['id']
         ).promote(le1['id'])
-        task_status = entities.ForemanTask(id=task_id).poll()
         self.assertEqual(
             task_status['result'],
             u'success',
@@ -901,10 +899,9 @@ class TestSmoke(TestCase):
             len(content_view['versions'][0]['environment_ids']),
             2,
             u"Content view should be present on 2 lifecycles only")
-        task_id = entities.ContentViewVersion(
+        task_status = entities.ContentViewVersion(
             id=content_view['versions'][0]['id']
         ).promote(le2['id'])
-        task_status = entities.ForemanTask(id=task_id).poll()
         self.assertEqual(
             task_status['result'],
             u'success',
@@ -1050,8 +1047,7 @@ class TestSmoke(TestCase):
         response.raise_for_status()
 
         # step 6.1: Publish content view
-        task_id = entities.ContentView(id=content_view['id']).publish()
-        task_status = entities.ForemanTask(id=task_id).poll()
+        task_status = entities.ContentView(id=content_view['id']).publish()
         self.assertEqual(
             task_status['result'],
             u'success',
@@ -1061,9 +1057,9 @@ class TestSmoke(TestCase):
         # step 6.2: Promote content view to lifecycle_env
         content_view = entities.ContentView(id=content_view['id']).read_json()
         self.assertEqual(len(content_view['versions']), 1)
-        task_id = entities.ContentViewVersion(
-            id=content_view['versions'][0]['id']).promote(lifecycle_env['id'])
-        task_status = entities.ForemanTask(id=task_id).poll()
+        task_status = entities.ContentViewVersion(
+            id=content_view['versions'][0]['id']
+        ).promote(lifecycle_env['id'])
         self.assertEqual(
             task_status['result'],
             u'success',


### PR DESCRIPTION
Make `ContentView.publish` and `ContentViewVersion.promote` return the full JSON
response from the server. Fix existing usages of those methods.

Many usages of those methods are in module `tests.foreman.api.test_contentview`.
Walk through this module and severely update some tests in this module in
addition to fixing existing usages of the aforementioned methods. In particular:
1. Collapse `ContentViewPublishTestCase` and `ContentViewPromoteTestCase` into
   `CVPublishPromoteTestCase`. Fix the `setUpClass` method by changing the
   `self` parameter to `cls`, and make the method generate just specialized
   objects instead of a mix of dicts and specialized objects.
2. Drop the `_publish` and `_promote` private helper functions.
3. Halve the number of test methods, but make each test method more compact and
   thorough.

```
$ nosetests tests/foreman/api/test_contentview.py:CVPublishPromoteTestCase
......
----------------------------------------------------------------------
Ran 6 tests in 786.747s

OK
```
