### PR TITLE
Added multi-threading support for API

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -40,6 +40,10 @@ test-robottelo:
 test-foreman-api:
 	nosetests -c robottelo.properties $(FOREMAN_API_TESTS_PATH)
 
+test-foreman-api-threaded:
+	nosetests -c robottelo.properties $(FOREMAN_API_TESTS_PATH)\
+	    --processes=-1 --process-timeout=300
+
 test-foreman-cli:
 	nosetests -c robottelo.properties $(FOREMAN_CLI_TESTS_PATH)
 

--- a/tests/foreman/api/test_activationkey.py
+++ b/tests/foreman/api/test_activationkey.py
@@ -15,6 +15,7 @@ import httplib
 @ddt
 class ActivationKeysTestCase(TestCase):
     """Tests for the ``activation_keys`` path."""
+    _multiprocess_can_split_ = True
 
     def test_positive_create_1(self):
         """@Test: Create a plain vanilla activation key.

--- a/tests/foreman/api/test_architecture.py
+++ b/tests/foreman/api/test_architecture.py
@@ -10,6 +10,7 @@ from unittest import TestCase
 
 class ArchitectureTestCase(TestCase):
     """Tests for architectures."""
+    _multiprocess_can_split_ = True
 
     @skip_if_bug_open('bugzilla', 1151220)
     def test_post_hash(self):

--- a/tests/foreman/api/test_contentview.py
+++ b/tests/foreman/api/test_contentview.py
@@ -22,6 +22,7 @@ REPEAT = 3
 @run_only_on('sat')
 class ContentViewTestCase(TestCase):
     """Tests for content views."""
+    _multiprocess_can_split_ = True
 
     def test_subscribe_system_to_cv(self):
         """@Test: Subscribe a system to a content view.
@@ -83,6 +84,7 @@ class ContentViewTestCase(TestCase):
 @ddt
 class ContentViewCreateTestCase(TestCase):
     """Tests for creating content views."""
+    _multiprocess_can_split_ = True
 
     def test_positive_create_1(self):
         """@Test: Create an empty non-composite content view.
@@ -159,6 +161,7 @@ class ContentViewCreateTestCase(TestCase):
 
 class CVPublishPromoteTestCase(TestCase):
     """Tests for publishing and promoting content views."""
+    _multiprocess_can_split_ = True
 
     @classmethod
     def setUpClass(cls):
@@ -370,6 +373,8 @@ class CVPublishPromoteTestCase(TestCase):
 @ddt
 class ContentViewUpdateTestCase(TestCase):
     """Tests for updating content views."""
+    _multiprocess_can_split_ = True
+
     @classmethod
     def setUpClass(cls):
         """Create a content view."""
@@ -434,6 +439,7 @@ class ContentViewTestCaseStub(TestCase):
     # Each of these tests should be given a better name when they're
     # implemented. In the meantime, let's not worry about bad names.
     # (invalid-name) pylint:disable=C0103
+    _multiprocess_can_split_ = True
 
     @stubbed
     def test_cv_edit_rh_custom_spin(self):

--- a/tests/foreman/api/test_contentviewfilter.py
+++ b/tests/foreman/api/test_contentviewfilter.py
@@ -16,6 +16,8 @@ import httplib
 @run_only_on('sat')
 class ContentViewFilterTestCase(TestCase):
     """Tests for content view filters."""
+    _multiprocess_can_split_ = True
+
     def test_get_with_no_args(self):
         """@Test: Issue an HTTP GET to the base content view filters path.
 

--- a/tests/foreman/api/test_contentviewversion.py
+++ b/tests/foreman/api/test_contentviewversion.py
@@ -7,6 +7,7 @@ from unittest import TestCase
 
 class CVVersionTestCase(TestCase):
     """Tests for content view versions."""
+    _multiprocess_can_split_ = True
 
     def test_negative_promote_1(self):
         """@Test: Promote the default content view version.

--- a/tests/foreman/api/test_environment.py
+++ b/tests/foreman/api/test_environment.py
@@ -18,6 +18,8 @@ import random
 @ddt
 class EnvironmentTestCase(TestCase):
     """Tests for environments."""
+    _multiprocess_can_split_ = True
+
     @data(
         gen_string('alpha', random.randint(1, 255)),
         gen_string('numeric', random.randint(1, 255)),

--- a/tests/foreman/api/test_filter.py
+++ b/tests/foreman/api/test_filter.py
@@ -12,6 +12,7 @@ from unittest import TestCase
 
 class FilterTestCase(TestCase):
     """Tests for ``api/v2/filters``."""
+    _multiprocess_can_split_ = True
 
     def test_create_filter_with_perms(self):
         """@Test: Create a filter and assign it some permissions.

--- a/tests/foreman/api/test_foremantask.py
+++ b/tests/foreman/api/test_foremantask.py
@@ -9,6 +9,8 @@ from unittest import TestCase
 @run_only_on('sat')
 class ForemanTasksIdTestCase(TestCase):
     """Tests for the ``foreman_tasks/api/v2/tasks/:id`` path."""
+    _multiprocess_can_split_ = True
+
     @skip_if_bug_open('bugzilla', 1131702)
     def test_no_such_task(self):
         """@Test: Fetch a non-existent task.

--- a/tests/foreman/api/test_gpgkey.py
+++ b/tests/foreman/api/test_gpgkey.py
@@ -11,6 +11,8 @@ import httplib
 @run_only_on('sat')
 class GPGKeyTestCase(TestCase):
     """Tests for ``katello/api/v2/gpg_keys``."""
+    _multiprocess_can_split_ = True
+
     def test_get_all(self):
         """@Test: Get ``katello/api/v2/gpg_keys`` and specify just an
         organization ID.

--- a/tests/foreman/api/test_host.py
+++ b/tests/foreman/api/test_host.py
@@ -17,6 +17,7 @@ import httplib
 @run_only_on('sat')
 class HostsTestCase(TestCase):
     """Tests for ``entities.Host().path()``."""
+    _multiprocess_can_split_ = True
 
     def test_get_search(self):
         """@Test: GET ``api/v2/hosts`` and specify the ``search`` parameter.

--- a/tests/foreman/api/test_hostgroup.py
+++ b/tests/foreman/api/test_hostgroup.py
@@ -20,6 +20,7 @@ class HostGroupTestCaseStub(unittest.TestCase):
         )
 
     """
+    _multiprocess_can_split_ = True
 
     @unittest.skip(NOT_IMPLEMENTED)
     def test_remove_hostgroup_1(self, test_data):

--- a/tests/foreman/api/test_lifecycleenvironment.py
+++ b/tests/foreman/api/test_lifecycleenvironment.py
@@ -16,6 +16,8 @@ import httplib
 @run_only_on('sat')
 class LifecycleEnvironmentTestCase(TestCase):
     """Tests for ``katello/api/v2/environments``."""
+    _multiprocess_can_split_ = True
+
     def test_get_all(self):
         """@Test: Get ``katello/api/v2/environments`` and specify just an
         organization ID.

--- a/tests/foreman/api/test_media.py
+++ b/tests/foreman/api/test_media.py
@@ -22,6 +22,7 @@ class MediaTestCase(unittest.TestCase):
         )
 
     """
+    _multiprocess_can_split_ = True
 
     @unittest.skip(NOT_IMPLEMENTED)
     def test_remove_medium_1(self, test_data):

--- a/tests/foreman/api/test_multiple_paths.py
+++ b/tests/foreman/api/test_multiple_paths.py
@@ -77,6 +77,8 @@ def skip_if_sam(self, entity):
 @ddt
 class EntityTestCase(TestCase):
     """Issue HTTP requests to various ``entity/`` paths."""
+    _multiprocess_can_split_ = True
+
     @data(
         # entities.ActivationKey,  # need organization_id or environment_id
         entities.Architecture,
@@ -247,6 +249,8 @@ class EntityTestCase(TestCase):
 @ddt
 class EntityIdTestCase(TestCase):
     """Issue HTTP requests to various ``entity/:id`` paths."""
+    _multiprocess_can_split_ = True
+
     @data(
         entities.ActivationKey,
         entities.Architecture,
@@ -408,6 +412,7 @@ class DoubleCheckTestCase(TestCase):
     action to ensure that the intended action was accomplished.
 
     """
+    _multiprocess_can_split_ = True
     longMessage = True
 
     @data(
@@ -603,6 +608,8 @@ class EntityReadTestCase(TestCase):
     Check that classes inheriting from :class:`robottelo.orm.EntityReadMixin`
     function correctly.
     """
+    _multiprocess_can_split_ = True
+
     # Most entities are commented-out because they do not inherit from
     # EntityReadMixin, due to issues with data returned from the API.
     #

--- a/tests/foreman/api/test_operatingsystem.py
+++ b/tests/foreman/api/test_operatingsystem.py
@@ -16,6 +16,8 @@ from unittest import TestCase
 @run_only_on('sat')
 class OSParameterTestCase(TestCase):
     """Tests for operating system parameters."""
+    _multiprocess_can_split_ = True
+
     def test_bz_1114640(self):
         """@Test: Create a parameter for operating system 1.
 
@@ -46,6 +48,8 @@ class OSParameterTestCase(TestCase):
 @run_only_on('sat')
 class OSTestCase(TestCase):
     """Tests for operating systems."""
+    _multiprocess_can_split_ = True
+
     def test_point_to_arch(self):
         """@Test: Create an operating system that points at an architecture.
 

--- a/tests/foreman/api/test_organization.py
+++ b/tests/foreman/api/test_organization.py
@@ -20,6 +20,8 @@ import sys
 @ddt.ddt
 class OrganizationTestCase(TestCase):
     """Tests for the ``organizations`` path."""
+    _multiprocess_can_split_ = True
+
     @skip_if_bug_open('bugzilla', 1116043)
     def test_create_text_plain(self):
         """@Test Create an organization using a 'text/plain' content-type.
@@ -199,6 +201,8 @@ class OrganizationTestCase(TestCase):
 @ddt.ddt
 class OrganizationUpdateTestCase(TestCase):
     """Tests for the ``organizations`` path."""
+    _multiprocess_can_split_ = True
+
     @classmethod
     def setUpClass(cls):
         """Create an organization."""

--- a/tests/foreman/api/test_permission.py
+++ b/tests/foreman/api/test_permission.py
@@ -29,6 +29,8 @@ PERMISSIONS_NAME = [
 @ddt
 class PermissionsTestCase(TestCase):
     """Tests for the ``permissions`` path."""
+    _multiprocess_can_split_ = True
+
     @run_only_on('sat')
     @ddt_data(*PERMISSIONS_NAME)  # pylint:disable=W0142
     def test_search_by_name(self, permission_name):
@@ -114,6 +116,7 @@ def _permission_name(entity, which_perm):
 @ddt
 class UserRoleTestCase(TestCase):
     """Give a user various permissions and see if they are enforced."""
+    _multiprocess_can_split_ = True
 
     def setUp(self):
         """Create a set of credentials and a user."""

--- a/tests/foreman/api/test_product.py
+++ b/tests/foreman/api/test_product.py
@@ -19,6 +19,7 @@ from unittest import TestCase
 @ddt
 class ProductsTestCase(TestCase):
     """Tests for ``katello/api/v2/products``."""
+    _multiprocess_can_split_ = True
 
     @run_only_on('sat')
     @data(
@@ -83,6 +84,8 @@ class ProductsTestCase(TestCase):
 @ddt
 class ProductUpdateTestCase(TestCase):
     """Tests for updating a product."""
+    _multiprocess_can_split_ = True
+
     @classmethod
     def setUpClass(cls):
         """Create a product."""

--- a/tests/foreman/api/test_repository.py
+++ b/tests/foreman/api/test_repository.py
@@ -24,6 +24,8 @@ from unittest import TestCase
 @ddt
 class RepositoryTestCase(TestCase):
     """Tests for ``katello/api/v2/repositories``."""
+    _multiprocess_can_split_ = True
+
     @classmethod
     def setUpClass(cls):
         """Create an organization and product which can be re-used in tests."""
@@ -217,6 +219,8 @@ class RepositoryTestCase(TestCase):
 @ddt
 class RepositoryUpdateTestCase(TestCase):
     """Tests for updating repositories."""
+    _multiprocess_can_split_ = True
+
     @classmethod
     def setUpClass(cls):
         """Create a repository which can be repeatedly updated."""
@@ -259,6 +263,7 @@ class RepositoryUpdateTestCase(TestCase):
 
 class RepositorySyncTestCase(TestCase):
     """Tests for ``/katello/api/repositories/:id/sync``."""
+    _multiprocess_can_split_ = True
 
     @run_only_on('sat')
     def test_redhat_sync_1(self):
@@ -293,6 +298,8 @@ class RepositorySyncTestCase(TestCase):
 @ddt
 class DockerRepositoryTestCase(TestCase):
     """Tests specific to using ``Docker`` repositories."""
+    _multiprocess_can_split_ = True
+
     @classmethod
     def setUpClass(cls):
         """Create an organization and product which can be re-used in tests."""

--- a/tests/foreman/api/test_rhsm.py
+++ b/tests/foreman/api/test_rhsm.py
@@ -13,6 +13,8 @@ import httplib
 
 class RHSMTestCase(TestCase):
     """Tests for the ``/rhsm`` path."""
+    _multiprocess_can_split_ = True
+
     def test_path_exists(self):
         """@Test: Check whether the path exists.
 

--- a/tests/foreman/api/test_role.py
+++ b/tests/foreman/api/test_role.py
@@ -25,6 +25,7 @@ import ddt
 @ddt.ddt
 class RoleTestCase(TestCase):
     """Tests for ``api/v2/roles``."""
+    _multiprocess_can_split_ = True
 
     @decorators.data(
         gen_alpha,

--- a/tests/foreman/api/test_smartproxy.py
+++ b/tests/foreman/api/test_smartproxy.py
@@ -21,8 +21,8 @@ class SmartProxyTestCaseStub(unittest.TestCase):
             medium name is utf-8,
         )
 
-
     """
+    _multiprocess_can_split_ = True
 
     @unittest.skip(NOT_IMPLEMENTED)
     def test_add_smartproxy_1(self, test_data):

--- a/tests/foreman/api/test_subscription.py
+++ b/tests/foreman/api/test_subscription.py
@@ -12,6 +12,7 @@ from robottelo.common import manifests
 
 class SubscriptionsTestCase(TestCase):
     """Tests for the ``subscriptions`` path."""
+    _multiprocess_can_split_ = True
 
     def test_positive_create_1(self):
         """@Test: Upload a manifest.

--- a/tests/foreman/api/test_system.py
+++ b/tests/foreman/api/test_system.py
@@ -31,6 +31,8 @@ logger = logging.getLogger(__name__)  # pylint:disable=C0103
 
 class EntityIdTestCaseClone(TestCase):
     """Issue HTTP requests to various ``systems/:uuid`` paths."""
+    _multiprocess_can_split_ = True
+
     def test_get_status_code(self):
         """@Test: Create a system and GET it.
 
@@ -103,6 +105,7 @@ class DoubleCheckTestCase(TestCase):
     action to ensure that the intended action was accomplished.
 
     """
+    _multiprocess_can_split_ = True
 
     @skip_if_bug_open('bugzilla', 1133097)
     def test_put_and_get(self):

--- a/tests/foreman/api/test_user.py
+++ b/tests/foreman/api/test_user.py
@@ -17,6 +17,8 @@ import ddt
 @ddt.ddt
 class UsersTestCase(TestCase):
     """Tests for the ``users`` path."""
+    _multiprocess_can_split_ = True
+
     @decorators.data(
         {u'admin': False},
         {u'admin': True},


### PR DESCRIPTION
## Usage

make test-foreman-api-threaded
## Before

Ran 759 tests in 1608.000s

FAILED (SKIP=99, errors=25, failures=10)
make: **\* [test-foreman-api] Error 1
## After

Ran 742 tests in 287.268s

FAILED (SKIP=99, errors=12, failures=8)
make: **\* [test-foreman-api] Error 1

Most additional errors are 500 Server Errors.
Because IDs are issued using sequences, we should not encounter
erroneous results, due to ID collisions.
