### PR TITLE
Run tests that were skipped due to BZ 1162860

### DIFF
--- a/tests/foreman/api/test_permission.py
+++ b/tests/foreman/api/test_permission.py
@@ -10,7 +10,7 @@ from itertools import chain
 from requests.exceptions import HTTPError
 from robottelo.api import client
 from robottelo.common.constants import PERMISSIONS
-from robottelo.common.decorators import data, run_only_on, skip_if_bug_open
+from robottelo.common.decorators import data, run_only_on
 from robottelo.common.helpers import get_server_credentials
 from robottelo import entities
 from unittest import TestCase
@@ -161,7 +161,6 @@ class UserRoleTestCase(TestCase):
             verify=False,
         ).raise_for_status()
 
-    @skip_if_bug_open('bugzilla', 1162860)
     @data(
         entities.Architecture,
         entities.Domain,
@@ -181,7 +180,6 @@ class UserRoleTestCase(TestCase):
         entity_id = entity().create(auth=self.auth)['id']
         entity(id=entity_id).read_json()  # read as an admin user
 
-    @skip_if_bug_open('bugzilla', 1162860)
     @data(
         entities.Architecture,
         entities.Domain,
@@ -201,7 +199,6 @@ class UserRoleTestCase(TestCase):
         self.give_user_permission(_permission_name(entity, 'read'))
         entity_obj.read_json(auth=self.auth)
 
-    @skip_if_bug_open('bugzilla', 1162860)
     @data(
         entities.Architecture,
         entities.Domain,
@@ -223,7 +220,6 @@ class UserRoleTestCase(TestCase):
         with self.assertRaises(HTTPError):
             entity_obj.read_json()  # As admin user
 
-    @skip_if_bug_open('bugzilla', 1162860)
     @data(
         entities.Architecture,
         entities.Domain,

--- a/tests/robottelo/test_orm.py
+++ b/tests/robottelo/test_orm.py
@@ -97,13 +97,13 @@ class OneToManyFieldTestCase(unittest.TestCase):
     def test_get_value(self):
         """Test :meth:`robottelo.orm.OneToManyField.get_value`.
 
-        Assert that ``get_value()`` returns a list of entity instances.
+        Assert that an object of the correct type is returned.
 
         """
-        values = orm.OneToManyField(SampleEntity).get_value()
-        self.assertIsInstance(values, list)
-        for value in values:
-            self.assertIsInstance(value, SampleEntity)
+        self.assertIsInstance(
+            orm.OneToManyField(SampleEntity).get_value(),
+            SampleEntity
+        )
 
 
 class BooleanFieldTestCase(unittest.TestCase):
@@ -237,7 +237,7 @@ class OneToOneFieldTestCase(unittest.TestCase):
     def test_get_value(self):
         """Test :meth:`robottelo.orm.OneToOneField.get_value`.
 
-        Assert that ``get_value()`` returns an entity instance.
+        Assert that an object of the correct type is returned.
 
         """
         self.assertIsInstance(
@@ -332,50 +332,6 @@ class GetClassTestCase(unittest.TestCase):
             SampleEntity,
             orm._get_class('SampleEntity', 'tests.robottelo.test_orm'),
         )
-
-
-@ddt.ddt
-class GetValueTestCase(unittest.TestCase):
-    """Tests for ``robottelo.orm._get_value``."""
-    # (protected-access) pylint:disable=W0212
-    def test_field_choices(self):
-        """Pass in a field that has a set of choices.
-
-        Assert a value from the choices is returned.
-
-        """
-        field = orm.StringField(choices=('a', 'b', 'c'))
-        self.assertIn(orm._get_value(field, None), ('a', 'b', 'c'))
-
-    @ddt.data('foo', None, True, False, 150)
-    def test_field_default(self, value):
-        """Pass in a field that has a default value of ``value``.
-
-        Assert ``value`` is returned.
-
-        """
-        field = orm.StringField(default=value)
-        self.assertEqual(orm._get_value(field, None), value)
-
-    @ddt.data('foo', None, True, False, 150)
-    def test_default(self, value):
-        """Pass in a field that has no default value or choices.
-
-        Assert the default argument to ``_get_value`` is returned.
-
-        """
-        field = orm.StringField()
-        self.assertEqual(orm._get_value(field, lambda: value), value)
-        self.assertEqual(orm._get_value(field, value), value)
-
-    def test_field_default_and_choices(self):
-        """Pass in a field that has a default and choices.
-
-        Assert the default value is returned.
-
-        """
-        field = orm.StringField(choices=('a', 'b', 'c'), default='d')
-        self.assertEqual(orm._get_value(field, None), 'd')
 
 
 class EntityDeleteMixinTestCase(unittest.TestCase):


### PR DESCRIPTION
BZ 1162860 states that it is impossible to interact with a server using any user
other than the admin user. This is a false alarm, and the test errors occurred
due to an issue in robottelo itself. Drop references to BZ 1162860 and fix the
issue.

The `Field` class can store the "default" and "choices" instance attributes.
Unfortunately, `OneToOneField.get_value` and `OneToManyField.get_value` ignore
these attributes. Fix this issue by simplifying all `*Field.get_value` methods,
dropping `robottelo.orm._get_value`, and moving some extra value generation
logic in to `robottelo.orm.EntityCreateMixin.create_missing`. Drop some tests
to compensate for this change.

The test suite still behaves nicely. The four errors occurred because
manifest-related settings were not set, and the four failures are existing
issues.

```
$ make test-foreman-api
nosetests -c robottelo.properties tests/foreman/api
Ran 773 tests in 3204.702s

FAILED (SKIP=102, errors=4, failures=4)
Makefile:41: recipe for target 'test-foreman-api' failed
make: *** [test-foreman-api] Error 1
```
