### PR TITLE
Partially skip test due to BZ 1163494

### DIFF
--- a/tests/foreman/api/test_multiple_paths.py
+++ b/tests/foreman/api/test_multiple_paths.py
@@ -599,6 +599,9 @@ class DoubleCheckTestCase(TestCase):
         except HTTPError as err:
             self.fail(err)
         entity.delete()
+
+        if entity_cls is entities.Repository and bz_bug_is_open(1163494):
+            return
         self.assertEqual(httplib.NOT_FOUND, entity.read_raw().status_code)
 
 


### PR DESCRIPTION
Issuing an HTTP GET request for a non-existent repository triggers an HTTP 500
error with this error message:

```
NoMethodError: undefined method `[]' for nil:NilClass
```

This only occurs if a repository with the given ID once existed. Fetching a
repository that has never existed will trigger an HTTP 404 as usual with a
message like this:

```
Couldn't find Katello::Repository with id=600
```

Updated test results:

```
$ nosetests tests/foreman/api/test_multiple_paths.py:DoubleCheckTestCase -m 'test_delete_and_get.*Repository'
.
----------------------------------------------------------------------
Ran 1 test in 11.153s

OK
```
