### PR TITLE
Skipping z-stream invalid email address tests

### DIFF
--- a/tests/foreman/cli/test_user.py
+++ b/tests/foreman/cli/test_user.py
@@ -505,7 +505,7 @@ class User(CLITestCase):
         self.assertNotEqual(result.return_code, 0)
         self.assertTrue(result.stderr)
 
-    @skip_if_bug_open('bugzilla', 1070730)
+    @unittest.skip('Note: BZ 1070730 is fixed in upstream but not downstream')
     @data('foreman@',
           '@foreman',
           '@',
@@ -1099,7 +1099,7 @@ class User(CLITestCase):
                                                       (new_user['firstname'],
                                                        new_user['lastname']))
 
-    @skip_if_bug_open('bugzilla', 1070730)
+    @unittest.skip('Note: BZ 1070730 is fixed in upstream but not downstream')
     @data('foreman@',
           '@foreman',
           '@',


### PR DESCRIPTION
test_negative_create_user_4 and test_negative_update_user_4 are skipped using BZ 1070730.  This bug was fixed in upstream and VERIFIED.  Since the fix did not land z-stream yet, the skipping of these test is necessary.
