### PR TITLE
Skipping two api tests based on open BZs

### DIFF
--- a/tests/foreman/api/test_contentviews.py
+++ b/tests/foreman/api/test_contentviews.py
@@ -4,6 +4,7 @@
 """
 Test class for Host/System Unification
 Feature details:http://people.redhat.com/~dcleal/apiv2/apidoc.html"""
+import unittest
 from ddt import ddt
 from robottelo.api.apicrud import ApiCrud, ApiException
 from robottelo.common.decorators import data
@@ -338,11 +339,13 @@ class TestContentView(APITestCase):
             'errors', task.json,
             "Invalid id shouldn't be promoted")
 
+    @unittest.skip('Note: BZ 1091494 is fixed in upstream but not downstream')
     def test_cv_promote_badenvironment_negative(self):
         """
         @test: attempt to promote a content view using an invalid environment
         @feature: Content Views
         @assert: Content views cannot be promoted; handled gracefully
+        @bz: #1091494
         """
         con_view = ApiCrud.record_create_recursive(ContentViewDefinition())
         self.assertIntersects(data, con_view)

--- a/tests/foreman/api/test_multiple_paths.py
+++ b/tests/foreman/api/test_multiple_paths.py
@@ -21,7 +21,7 @@ BZ_1118015_ENTITIES = (
     entities.OperatingSystem, entities.Product, entities.Repository,
     entities.Role, entities.System, entities.User,
 )
-BZ_1122267_ENTITIES = (
+BZ_1151240_ENTITIES = (
     entities.ActivationKey, entities.ContentView, entities.GPGKey,
     entities.LifecycleEnvironment, entities.Product, entities.Repository
 )
@@ -418,9 +418,8 @@ class DoubleCheckTestCase(TestCase):
         @Assert: The created entity has the correct attributes.
 
         """
-        if entity in BZ_1122267_ENTITIES and bz_bug_is_open(1122267):
-            self.skipTest("Bugzilla bug 1122267 is open.""")
-
+        if entity in BZ_1151240_ENTITIES and bz_bug_is_open(1151240):
+            self.skipTest("Bugzilla bug 1151240 is open.""")
         # Generate some attributes and use them to create an entity.
         gen_attrs = entity().build()
         response = client.post(


### PR DESCRIPTION
- Skipping test_cv_promote_badenvironment_negative using bug 1091494 (this is closed in upstream)
- Skipping test_post_and_get using 1151240.  Earlier this was skipped using 1122267.  But 1122267 is closed in favor of 1151240
