### PR TITLE
Activation Key 404s

### DIFF
--- a/robottelo/api/client.py
+++ b/robottelo/api/client.py
@@ -79,9 +79,16 @@ def _curl_arg_user(kwargs):
     :rtype: str
 
     """
-    # True if user provided creds in this form: auth=('username', 'password')
-    # False if no creds or in e.g. this form: auth=HTTPBasicAuth('usr', 'pass')
-    if 'auth' in kwargs and isinstance(kwargs['auth'], tuple):
+    # By default, auth is `None`. The user may provide credentials in a variety
+    # for forms, such as:
+    #
+    # * ('Alice', 'hackme')
+    # * ()
+    # * HTTPBasicAuth('Bob', 'gandalf')
+    #
+    if ('auth' in kwargs and
+            isinstance(kwargs['auth'], tuple) and
+            len(kwargs['auth']) is 2):
         return u'--user {0}:{1} '.format(kwargs['auth'][0], kwargs['auth'][1])
     return ''
 

--- a/robottelo/entities.py
+++ b/robottelo/entities.py
@@ -16,6 +16,7 @@ from robottelo.api import client
 from robottelo.common.constants import VALID_GPG_KEY_FILE
 from robottelo.common.helpers import get_data_file, get_server_credentials
 from robottelo import factory, orm
+from time import sleep
 import httplib
 import random
 # (too-few-public-methods) pylint:disable=R0903
@@ -37,6 +38,16 @@ class ActivationKey(
     class Meta(object):
         """Non-field information about this entity."""
         api_path = 'katello/api/v2/activation_keys'
+
+    def read_raw(self, auth=None):
+        super_read_raw = super(ActivationKey, self).read_raw
+        response = super_read_raw(auth)
+        if response.status_code is 404:
+            # Avoid 404 on faster machines with faster connections. Give some
+            # time to server finish creating the entity
+            sleep(5)
+            response = super_read_raw(auth)
+        return response
 
     def path(self, which=None):
         """Extend the default implementation of
@@ -1450,7 +1461,7 @@ class TemplateCombination(orm.Entity):
                     'template_combinations')
 
 
-class TemplateKind(orm.Entity):
+class TemplateKind(orm.Entity, orm.EntityReadMixin):
     """A representation of a Template Kind entity."""
     # FIXME figure out fields
     # The API does not support the "api/v2/template_kinds/:id" path at all.

--- a/robottelo/orm.py
+++ b/robottelo/orm.py
@@ -398,9 +398,12 @@ class Entity(booby.Model):
 
 class EntityDeleteMixin(object):
     """A mixin that adds the ability to delete an entity."""
+    # FIXME: Define `delete_raw`. Call from `delete`. Drop pylint directive.
+    #
     # (too-few-public-methods) pylint:disable=R0903
     # It's OK that this class has only one public method. It's a targeted
     # mixin, not a standalone class.
+
     def delete(self, auth=None, synchronous=True):
         """Delete the current entity.
 
@@ -443,18 +446,31 @@ class EntityDeleteMixin(object):
 
 class EntityReadMixin(object):
     """A mixin that provides the ability to read an entity."""
-    # (too-few-public-methods) pylint:disable=R0903
-    # It's OK that this class has only one public method. It's a targeted
-    # mixin, not a standalone class.
-    def read_json(self, auth=None):
+
+    def read_raw(self, auth=None):
         """Get information about the current entity.
 
-        Send an HTTP GET request to ``self.path(which='this')``. Return the
-        decoded JSON response.
+        Send an HTTP GET request to :meth:`path`. Return the response. Do not
+        check the response for any errors, such as an HTTP 4XX or 5XX status
+        code.
 
         :param tuple auth: A ``(username, password)`` tuple used when accessing
             the API. If ``None``, the credentials provided by
             :func:`robottelo.common.helpers.get_server_credentials` are used.
+        :return: A ``requests.response`` object.
+
+        """
+        if auth is None:
+            auth = helpers.get_server_credentials()
+        return client.get(self.path(), auth=auth, verify=False)
+
+    def read_json(self, auth=None):
+        """Get information about the current entity.
+
+        Call :meth:`read_raw`. Check the response status code, decode JSON and
+        return the decoded JSON as a dict.
+
+        :param tuple auth: Same as :meth:`read_raw`.
         :return: The server's response, with all JSON decoded.
         :rtype: dict
         :raises: ``requests.exceptions.HTTPError`` if the response has an HTTP
@@ -462,28 +478,27 @@ class EntityReadMixin(object):
         :raises: ``ValueError`` If the response JSON can not be decoded.
 
         """
-        if auth is None:
-            auth = helpers.get_server_credentials()
-        response = client.get(
-            self.path(which='this'),
-            auth=auth,
-            verify=False,
-        )
+        response = self.read_raw(auth)
         response.raise_for_status()
         return response.json()
 
     def read(self, auth=None, entity=None, attrs=None):
-        """Instantiate and initialize an object of type ``type(self)``.
+        """Get information about the current entity.
 
-        Instantiate an object of type ``type(self)``. Populate the object's
-        attributes using either ``attrs`` or
-        :meth:`robottelo.orm.EntityReadMixin.read_json`. The ``attrs`` argument
-        takes precedence.
+        Call :meth:`read_json`. Use this information to populate an object of
+        type ``type(self)`` and return that object.
 
         All of an entity's one-to-one and one-to-many relationships are
         populated with objects of the correct type. For example, if
-        ``SomeEntity.other_entity`` is a one-to-one relationship, both of these
-        commands should succeed:
+        ``SomeEntity.other_entity`` is a one-to-one relationship, this should
+        return ``True``::'
+
+            isinstance(
+                SomeEntity(id=N).read().other_entity,
+                robottelo.orm.Entity
+            )
+
+        Additionally, both of these commands should succeed::
 
             SomeEntity(id=N).read().other_entity.id
             SomeEntity(id=N).read().other_entity.read().other_attr
@@ -492,17 +507,13 @@ class EntityReadMixin(object):
         with a meaningful value. Calling ``other_entity.read`` populates the
         remaining entity attributes.
 
-        :param tuple auth: Same as for
-            :meth:`robottelo.orm.EntityReadMixin.read_json`.
-        :param robottelo.orm.Entity entity: The entity to be populated and
-            returned.
-        :param dict attrs: Data used to populate the new entity's attributes.
-        :return: An instance of type ``type(self)``. In other words, an
-            instance of ``SomeEntity`` is returned if
-            ``SomeEntity(id=N).read()`` is called.
+        :param tuple auth: Same as :meth:`read_raw`.
+        :param robottelo.orm.Entity entity: The object to be populated and
+            returned. An object of type ``type(self)`` by default.
+        :param dict attrs: Data used to populate the object's attributes. The
+            response from ``read_json`` by default.
+        :return: An instance of type ``type(self)``.
         :rtype: robottelo.orm.Entity
-        :raises: ``requests.exceptions.HTTPError`` if the response has an HTTP
-            4XX or 5XX status code.
 
         """
         if entity is None:


### PR DESCRIPTION
Cherry-pick a pair of commits on to the satellite-6.0.z.1 branch. These commits prevent many 404s related to activation keys. `ActivationKey.read_raw` method will only wait 5 seconds and attempt one more read if a 404 is received, so some 404s will still be received, but this should help.
