### PR TITLE
Make ActivationKey.read_json poll upon getting 404

### DIFF
--- a/tests/foreman/api/test_multiple_paths.py
+++ b/tests/foreman/api/test_multiple_paths.py
@@ -218,8 +218,6 @@ class EntityIdTestCase(TestCase):
         @Assert: HTTP 200 is returned with an ``application/json`` content-type
 
         """
-        if entity is entities.ActivationKey and bz_bug_is_open(1127335):
-            self.skipTest("Bugzilla bug 1127335 is open.""")
         try:
             entity_n = entity(id=entity().create()['id'])
         except factory.FactoryError as err:


### PR DESCRIPTION
Make method `ActivationKey.read_json` poll the server up to five additional
times upon receiving an HTTP 404 response. As per an IRC conversation with
@thomasmckay, bugzilla bug 1127335 will not be fixed, and clients **must**
resort to polling the server to determine whether a 404 is valid or not.

Several tests in module `test_activationkey` fail, but due to unrelated reasons
(that should be investigated!).

```
$ nosetests tests/foreman/api/test_activationkey.py
InsecureRequestWarning)
......FFF...................
======================================================================
…
----------------------------------------------------------------------
Ran 28 tests in 86.375s

FAILED (failures=3)
```

Fix the one remaining failure in module `test_multiple_paths`:

```
$ nosetests tests/foreman/api/test_multiple_paths.py -m ActivationKey
InsecureRequestWarning)
.S....SS
----------------------------------------------------------------------
Ran 8 tests in 38.545s

OK (SKIP=3)
```

Fix several Jenkins failures. Target #1578.

(cherry picked from commit 3b88291b49e2a6ca17a899bd8e0710a9c56721f6)

Conflicts:
    robottelo/entities.py
    tests/foreman/api/test_activationkey.py
    tests/foreman/api/test_multiple_paths.py
