### PR TITLE
Skip unsupported API tests.

### DIFF
--- a/tests/foreman/api/test_permission.py
+++ b/tests/foreman/api/test_permission.py
@@ -10,8 +10,10 @@ from robottelo.records.domain import Domain
 from robottelo.records.role import add_permission_to_user
 from robottelo.records.user import User
 from robottelo.test import APITestCase
+import unittest
 
 
+@unittest.skip('These API tests are not supported.')
 @ddt
 class TestPermission(APITestCase):
     """Testing basic positive permissions"""


### PR DESCRIPTION
The API tests for permissions uses code which is not well understood or
supported. Skip those tests.

```
$ nosetests tests/foreman/api/test_permission.py
SSSSSSSS
----------------------------------------------------------------------
Ran 8 tests in 0.002s

OK (SKIP=8)
```
