### PR TITLE
Fixed assertion: can fetch added puppet module name

### DIFF
--- a/robottelo/ui/contentviews.py
+++ b/robottelo/ui/contentviews.py
@@ -387,12 +387,6 @@ class ContentViews(Base):
                     raise Exception(
                         "Couldn't find the selected version '%s'\
                          of puppet module '%s'" % (filter_term, module_name))
-                self.text_field_update(common_locators
-                                       ["cv_filter"], module_name)
-                strategy, value = locators["contentviews.get_module_name"]
-                element = self.wait_until_element((strategy,
-                                                   value % module_name))
-                return element
             else:
                 raise Exception(
                     "Couldn't find the given puppet module '%s'" % module_name)
@@ -428,6 +422,7 @@ class ContentViews(Base):
             else:
                 self.find_element(tab_locators
                                   ["contentviews.tab_cv_remove"]).click()
+            self.wait_for_ajax()
             strategy, value = locators["contentviews.select_cv"]
             for cv_name in cv_names:
                 element = self.wait_until_element((strategy,
@@ -443,6 +438,7 @@ class ContentViews(Base):
                         self.wait_until_element(locators
                                                 ["contentviews.remove_cv"]
                                                 ).click()
+                    self.wait_for_ajax()
                 else:
                     raise Exception(
                         "Couldn't find content-view '%s'"
@@ -671,3 +667,30 @@ class ContentViews(Base):
             self.find_element(locators
                               ["contentviews.remove_errata"]).click()
         self.wait_for_ajax()
+
+    def fetch_puppet_module(self, cv_name, module_name):
+        """Get added puppet module name from selected content-view"""
+
+        element = self.search(cv_name)
+
+        if element is None:
+            raise UINoSuchElementError(
+                'Could not find the %s content view.' % cv_name)
+        else:
+            element.click()
+            self.wait_for_ajax()
+            if self.wait_until_element(tab_locators
+                                       ["contentviews.tab_puppet_modules"]):
+                self.find_element(tab_locators
+                                  ["contentviews.tab_puppet_modules"]
+                                  ).click()
+                self.wait_for_ajax()
+                self.text_field_update(common_locators
+                                       ["cv_filter"], module_name)
+                strategy, value = locators["contentviews.get_module_name"]
+                element = self.wait_until_element((strategy,
+                                                   value % module_name))
+                return element
+            else:
+                raise UINoSuchElementError(
+                    "Couldn't find puppet-modules tab")

--- a/robottelo/ui/locators.py
+++ b/robottelo/ui/locators.py
@@ -1400,7 +1400,7 @@ locators = {
         By.XPATH, "//div[@data-block='table']//td[contains(., '%s')]"),
     "contentviews.select_cv": (
         By.XPATH,
-        ("//tr[@row-select='contentView']"
+        ("//div[@alch-table='detailsTable']//tr[@row-select='contentView']"
          "//td[contains(normalize-space(.), '%s')]"
          "/preceding-sibling::td[@class='row-select']"
          "/input[@type='checkbox']")),

--- a/tests/foreman/ui/test_contentviews.py
+++ b/tests/foreman/ui/test_contentviews.py
@@ -199,11 +199,19 @@ class TestContentViewsUI(UITestCase):
         with Session(self.browser) as session:
             self.setup_to_create_cv(session, name, repo_url=repo_url,
                                     repo_type=REPO_TYPE['puppet'])
-            module = self.content_views.add_puppet_module(
+            self.content_views.add_puppet_module(
                 name,
                 puppet_module,
                 filter_term=module_ver
             )
+        # Workaround to fetch added puppet module name:
+        # UI doesn't refresh and populate the added module name
+        # until we logout and navigate again to puppet-module tab
+        with Session(self.browser) as session:
+            session.nav.go_to_select_org(self.org_name)
+            session.nav.go_to_content_views()
+            module = self.content_views.fetch_puppet_module(name,
+                                                            puppet_module)
             self.assertIsNotNone(module)
 
     def test_remove_filter(self):
@@ -458,14 +466,28 @@ class TestContentViewsUI(UITestCase):
             self.setup_to_create_cv(session, cv_name,
                                     repo_url=FAKE_PUPPET_REPO,
                                     repo_type=REPO_TYPE['puppet'])
-            module = self.content_views.add_puppet_module(
+            self.content_views.add_puppet_module(
                 cv_name,
                 puppet_module,
                 filter_term=module_ver
             )
+        # Workaround to fetch added puppet module name:
+        # UI doesn't refresh and populate the added module name
+        # until we logout and navigate again to puppet-module tab
+        with Session(self.browser) as session:
+            session.nav.go_to_select_org(self.org_name)
+            session.nav.go_to_content_views()
+            module = self.content_views.fetch_puppet_module(cv_name,
+                                                            puppet_module)
             self.assertIsNotNone(module)
             self.content_views.publish(cv_name)
             self.content_views.create(composite_name, is_composite=True)
+        # UI doesn't populate the created content-view name to add it into
+        # existing composite-view until we logout and navigate again to
+        # puppet-module tab
+        with Session(self.browser) as session:
+            session.nav.go_to_select_org(self.org_name)
+            session.nav.go_to_content_views()
             self.content_views.add_remove_cv(composite_name, [cv_name])
             self.assertIsNotNone(self.content_views.wait_until_element
                                  (common_locators["alert.success"]))


### PR DESCRIPTION
I cherry-picked this commit[https://github.com/SatelliteQE/robottelo/commit/a8e700ede70be7071d727aefb903d4bbc9f37ca2] from master branch. This will fix following two CV tests:
- test_associate_puppet_module
- test_cv_composite_create
