### PR TITLE
Fix Sphinx warnings

### DIFF
--- a/docs/api/robottelo.rst
+++ b/docs/api/robottelo.rst
@@ -20,14 +20,6 @@ Submodules:
     :members:
     :undoc-members:
 
-:mod:`robottelo.factory`
-------------------------
-
-.. automodule:: robottelo.factory
-    :members:
-    :undoc-members:
-    :private-members:
-
 :mod:`robottelo.log`
 --------------------
 

--- a/docs/api/tests.robottelo.rst
+++ b/docs/api/tests.robottelo.rst
@@ -7,13 +7,6 @@ Submodules:
     :members:
     :undoc-members:
 
-:mod:`tests.robottelo.test_factory`
------------------------------------
-
-.. automodule:: tests.robottelo.test_factory
-    :members:
-    :undoc-members:
-
 :mod:`tests.robottelo.test_cli`
 -------------------------------
 

--- a/robottelo/entities.py
+++ b/robottelo/entities.py
@@ -1068,13 +1068,13 @@ class LifecycleEnvironment(
         return data
 
     def create_missing(self, auth=None):
-        """Extend the implementation of :meth:`robottelo.factory.Factory.build`.
+        """Automatically populate additional instance attributes.
 
         When a new lifecycle environment is created, it must either:
 
         * Reference a parent lifecycle environment in the tree of lifecycle
-          environments via the ``prior`` field.
-        * Have a name of "Library".
+          environments via the ``prior`` field, or
+        * have a name of "Library".
 
         Within a given organization, there can only be a single lifecycle
         environment with a name of 'Library'. This lifecycle environment is at

--- a/robottelo/orm.py
+++ b/robottelo/orm.py
@@ -570,7 +570,7 @@ class EntityCreateMixin(object):
     """A mixin that provides the ability to create an entity.
 
     The methods provided by this mixin work together to create an entity. A
-    typical tree of method calls looks like this:
+    typical tree of method calls looks like this::
 
         create
         └── create_json
@@ -641,9 +641,9 @@ class EntityCreateMixin(object):
         """Create an entity.
 
         Generate values for required, unset fields by calling
-        :meth:`gen_missing`. Only do this if ``create_missing`` is true. Then
-        make an HTTP POST call to ``self.path('base')``. Return the response
-        received from the server.
+        :meth:`create_missing`. Only do this if ``create_missing`` is true.
+        Then make an HTTP POST call to ``self.path('base')``. Return the
+        response received from the server.
 
         :param tuple auth: A ``(username, password)`` pair to use when
             communicating with the API. If ``None``, the credentials returned


### PR DESCRIPTION
- Do not reference the non-existent modules `robottelo.factory` and
  `tests.robottelo.test_factory`.
- Do not reference the non-existent method `robottelo.factory.Factory.build`.
- Correctly demarcate a code block with `::`.
- Change a mistaken reference from `gen_missing` to `create_missing`.
