### PR TITLE
Make API tests inherit from APITestCase

### DIFF
--- a/robottelo/test.py
+++ b/robottelo/test.py
@@ -68,8 +68,7 @@ class TestCase(unittest.TestCase):
 
 class APITestCase(TestCase):
     """Test case for API tests."""
-    def assertIntersects(self, first, other, msg=None):
-        assert_intersects(first, other, msg)
+    _multiprocess_can_split_ = True
 
 
 class CLITestCase(TestCase):

--- a/tests/foreman/api/test_activationkey.py
+++ b/tests/foreman/api/test_activationkey.py
@@ -1,21 +1,20 @@
 """Unit tests for the ``activation_keys`` paths."""
+import httplib
 from ddt import data, ddt
 from fauxfactory import gen_integer, gen_string
 from requests.exceptions import HTTPError
+from robottelo import entities
 from robottelo.api import client
 from robottelo.api.utils import status_code_error
 from robottelo.common.decorators import skip_if_bug_open
 from robottelo.common.helpers import get_server_credentials
-from robottelo import entities
-from unittest import TestCase
-import httplib
+from robottelo.test import APITestCase
 # (too-many-public-methods) pylint:disable=R0904
 
 
 @ddt
-class ActivationKeysTestCase(TestCase):
+class ActivationKeysTestCase(APITestCase):
     """Tests for the ``activation_keys`` path."""
-    _multiprocess_can_split_ = True
 
     def test_positive_create_1(self):
         """@Test: Create a plain vanilla activation key.

--- a/tests/foreman/api/test_architecture.py
+++ b/tests/foreman/api/test_architecture.py
@@ -1,16 +1,15 @@
 """Unit tests for the ``architectures`` paths."""
 from fauxfactory import gen_utf8
+from robottelo import entities
 from robottelo.api import client
 from robottelo.common.decorators import skip_if_bug_open
 from robottelo.common.helpers import get_server_credentials
-from robottelo import entities
-from unittest import TestCase
+from robottelo.test import APITestCase
 # (too-many-public-methods) pylint:disable=R0904
 
 
-class ArchitectureTestCase(TestCase):
+class ArchitectureTestCase(APITestCase):
     """Tests for architectures."""
-    _multiprocess_can_split_ = True
 
     @skip_if_bug_open('bugzilla', 1151220)
     def test_post_hash(self):

--- a/tests/foreman/api/test_contentview.py
+++ b/tests/foreman/api/test_contentview.py
@@ -3,13 +3,13 @@
 from ddt import ddt
 from fauxfactory import gen_integer, gen_string, gen_utf8
 from requests.exceptions import HTTPError
+from robottelo import entities
 from robottelo.api import client
+from robottelo.common.constants import PUPPET_MODULE_NTP_PUPPETLABS
 from robottelo.common.decorators import (
     bz_bug_is_open, data, run_only_on, stubbed)
 from robottelo.common.helpers import get_server_credentials
-from robottelo.common.constants import PUPPET_MODULE_NTP_PUPPETLABS
-from robottelo import entities
-from unittest import TestCase
+from robottelo.test import APITestCase
 # (too-many-public-methods) pylint:disable=R0904
 
 
@@ -20,9 +20,8 @@ REPEAT = 3
 
 
 @run_only_on('sat')
-class ContentViewTestCase(TestCase):
+class ContentViewTestCase(APITestCase):
     """Tests for content views."""
-    _multiprocess_can_split_ = True
 
     def test_subscribe_system_to_cv(self):
         """@Test: Subscribe a system to a content view.
@@ -82,9 +81,8 @@ class ContentViewTestCase(TestCase):
 
 
 @ddt
-class ContentViewCreateTestCase(TestCase):
+class ContentViewCreateTestCase(APITestCase):
     """Tests for creating content views."""
-    _multiprocess_can_split_ = True
 
     def test_positive_create_1(self):
         """@Test: Create an empty non-composite content view.
@@ -159,9 +157,8 @@ class ContentViewCreateTestCase(TestCase):
         self.assertEqual(attrs['description'], description)
 
 
-class CVPublishPromoteTestCase(TestCase):
+class CVPublishPromoteTestCase(APITestCase):
     """Tests for publishing and promoting content views."""
-    _multiprocess_can_split_ = True
 
     @classmethod
     def setUpClass(cls):
@@ -371,9 +368,8 @@ class CVPublishPromoteTestCase(TestCase):
 
 
 @ddt
-class ContentViewUpdateTestCase(TestCase):
+class ContentViewUpdateTestCase(APITestCase):
     """Tests for updating content views."""
-    _multiprocess_can_split_ = True
 
     @classmethod
     def setUpClass(cls):
@@ -434,12 +430,11 @@ class ContentViewUpdateTestCase(TestCase):
 
 
 @run_only_on('sat')
-class ContentViewTestCaseStub(TestCase):
+class ContentViewTestCaseStub(APITestCase):
     """Incomplete tests for content views."""
     # Each of these tests should be given a better name when they're
     # implemented. In the meantime, let's not worry about bad names.
     # (invalid-name) pylint:disable=C0103
-    _multiprocess_can_split_ = True
 
     @stubbed
     def test_cv_edit_rh_custom_spin(self):

--- a/tests/foreman/api/test_contentviewfilter.py
+++ b/tests/foreman/api/test_contentviewfilter.py
@@ -4,19 +4,18 @@ A full API reference for content views can be found here:
 http://theforeman.org/api/apidoc/v2/content_view_filters.html
 
 """
+import httplib
+from robottelo import entities
 from robottelo.api import client
 from robottelo.common.decorators import run_only_on
 from robottelo.common.helpers import get_server_credentials
-from robottelo import entities
-from unittest import TestCase
-import httplib
+from robottelo.test import APITestCase
 # (too-many-public-methods) pylint:disable=R0904
 
 
 @run_only_on('sat')
-class ContentViewFilterTestCase(TestCase):
+class ContentViewFilterTestCase(APITestCase):
     """Tests for content view filters."""
-    _multiprocess_can_split_ = True
 
     def test_get_with_no_args(self):
         """@Test: Issue an HTTP GET to the base content view filters path.

--- a/tests/foreman/api/test_contentviewversion.py
+++ b/tests/foreman/api/test_contentviewversion.py
@@ -1,13 +1,12 @@
 """Unit tests for the ``content_view_versions`` paths."""
 from requests.exceptions import HTTPError
 from robottelo import entities
-from unittest import TestCase
+from robottelo.test import APITestCase
 # (too-many-public-methods) pylint:disable=R0904
 
 
-class CVVersionTestCase(TestCase):
+class CVVersionTestCase(APITestCase):
     """Tests for content view versions."""
-    _multiprocess_can_split_ = True
 
     def test_negative_promote_1(self):
         """@Test: Promote the default content view version.

--- a/tests/foreman/api/test_environment.py
+++ b/tests/foreman/api/test_environment.py
@@ -4,21 +4,20 @@ A full API reference for environments can be found here:
 http://theforeman.org/api/apidoc/v2/environments.html
 
 """
+import random
 from ddt import ddt
 from fauxfactory import gen_string
 from requests.exceptions import HTTPError
-from robottelo.common.decorators import data, run_only_on
 from robottelo import entities
-from unittest import TestCase
-import random
+from robottelo.common.decorators import data, run_only_on
+from robottelo.test import APITestCase
 # (too-many-public-methods) pylint:disable=R0904
 
 
 @run_only_on('sat')
 @ddt
-class EnvironmentTestCase(TestCase):
+class EnvironmentTestCase(APITestCase):
     """Tests for environments."""
-    _multiprocess_can_split_ = True
 
     @data(
         gen_string('alpha', random.randint(1, 255)),

--- a/tests/foreman/api/test_filter.py
+++ b/tests/foreman/api/test_filter.py
@@ -6,13 +6,12 @@ http://theforeman.org/api/apidoc/v2/filters.html
 """
 from requests.exceptions import HTTPError
 from robottelo import entities
-from unittest import TestCase
+from robottelo.test import APITestCase
 # (too-many-public-methods) pylint:disable=R0904
 
 
-class FilterTestCase(TestCase):
+class FilterTestCase(APITestCase):
     """Tests for ``api/v2/filters``."""
-    _multiprocess_can_split_ = True
 
     def test_create_filter_with_perms(self):
         """@Test: Create a filter and assign it some permissions.

--- a/tests/foreman/api/test_foremantask.py
+++ b/tests/foreman/api/test_foremantask.py
@@ -1,15 +1,14 @@
 """Unit tests for the ``foreman_tasks/api/v2/tasks`` paths."""
 from requests.exceptions import HTTPError
-from robottelo.common.decorators import run_only_on, skip_if_bug_open
 from robottelo import entities
-from unittest import TestCase
+from robottelo.common.decorators import run_only_on, skip_if_bug_open
+from robottelo.test import APITestCase
 # (too-many-public-methods) pylint:disable=R0904
 
 
 @run_only_on('sat')
-class ForemanTasksIdTestCase(TestCase):
+class ForemanTasksIdTestCase(APITestCase):
     """Tests for the ``foreman_tasks/api/v2/tasks/:id`` path."""
-    _multiprocess_can_split_ = True
 
     @skip_if_bug_open('bugzilla', 1131702)
     def test_no_such_task(self):

--- a/tests/foreman/api/test_gpgkey.py
+++ b/tests/foreman/api/test_gpgkey.py
@@ -1,17 +1,16 @@
 """Unit tests for the ``gpgkeys`` paths."""
+import httplib
+from robottelo import entities
 from robottelo.api import client
 from robottelo.common.decorators import run_only_on
 from robottelo.common.helpers import get_server_credentials
-from robottelo import entities
-from unittest import TestCase
-import httplib
+from robottelo.test import APITestCase
 # (too-many-public-methods) pylint:disable=R0904
 
 
 @run_only_on('sat')
-class GPGKeyTestCase(TestCase):
+class GPGKeyTestCase(APITestCase):
     """Tests for ``katello/api/v2/gpg_keys``."""
-    _multiprocess_can_split_ = True
 
     def test_get_all(self):
         """@Test: Get ``katello/api/v2/gpg_keys`` and specify just an

--- a/tests/foreman/api/test_host.py
+++ b/tests/foreman/api/test_host.py
@@ -4,20 +4,19 @@ An API reference can be found here:
 http://theforeman.org/api/apidoc/v2/hosts.html
 
 """
+import httplib
 from fauxfactory import gen_integer, gen_string
+from robottelo import entities
 from robottelo.api import client
 from robottelo.common.decorators import run_only_on
 from robottelo.common.helpers import get_server_credentials
-from robottelo import entities
-from unittest import TestCase
-import httplib
+from robottelo.test import APITestCase
 # (too-many-public-methods) pylint:disable=R0904
 
 
 @run_only_on('sat')
-class HostsTestCase(TestCase):
+class HostsTestCase(APITestCase):
     """Tests for ``entities.Host().path()``."""
-    _multiprocess_can_split_ = True
 
     def test_get_search(self):
         """@Test: GET ``api/v2/hosts`` and specify the ``search`` parameter.

--- a/tests/foreman/api/test_hostgroup.py
+++ b/tests/foreman/api/test_hostgroup.py
@@ -1,10 +1,10 @@
 """Tests for the ``hostgroups`` paths."""
-from robottelo.common.constants import NOT_IMPLEMENTED
-import unittest
+from robottelo.common.decorators import stubbed
+from robottelo.test import APITestCase
 # (too-many-public-methods) pylint:disable=R0904
 
 
-class HostGroupTestCaseStub(unittest.TestCase):
+class HostGroupTestCaseStub(APITestCase):
     """Incomplete tests for host groups.
 
     When implemented, each of these tests should probably be data-driven. A
@@ -20,9 +20,8 @@ class HostGroupTestCaseStub(unittest.TestCase):
         )
 
     """
-    _multiprocess_can_split_ = True
 
-    @unittest.skip(NOT_IMPLEMENTED)
+    @stubbed
     def test_remove_hostgroup_1(self, test_data):
         """
         @feature: Organizations
@@ -32,7 +31,7 @@ class HostGroupTestCaseStub(unittest.TestCase):
         @status: manual
         """
 
-    @unittest.skip(NOT_IMPLEMENTED)
+    @stubbed
     def test_remove_hostgroup_2(self, test_data):
         """
         @feature: Organizations
@@ -42,7 +41,7 @@ class HostGroupTestCaseStub(unittest.TestCase):
         @status: manual
         """
 
-    @unittest.skip(NOT_IMPLEMENTED)
+    @stubbed
     def test_remove_hostgroup_3(self, test_data):
         """
         @feature: Organizations
@@ -52,7 +51,7 @@ class HostGroupTestCaseStub(unittest.TestCase):
         @status: manual
         """
 
-    @unittest.skip(NOT_IMPLEMENTED)
+    @stubbed
     def test_remove_hostgroup_4(self, test_data):
         """
         @feature: Organizations
@@ -62,7 +61,7 @@ class HostGroupTestCaseStub(unittest.TestCase):
         @status: manual
         """
 
-    @unittest.skip(NOT_IMPLEMENTED)
+    @stubbed
     def test_add_hostgroup_1(self, test_data):
         """
         @feature: Organizations
@@ -72,7 +71,7 @@ class HostGroupTestCaseStub(unittest.TestCase):
         @status: manual
         """
 
-    @unittest.skip(NOT_IMPLEMENTED)
+    @stubbed
     def test_add_hostgroup_2(self, test_data):
         """
         @feature: Organizations
@@ -82,7 +81,7 @@ class HostGroupTestCaseStub(unittest.TestCase):
         @status: manual
         """
 
-    @unittest.skip(NOT_IMPLEMENTED)
+    @stubbed
     def test_add_hostgroup_3(self, test_data):
         """
         @feature: Organizations
@@ -92,7 +91,7 @@ class HostGroupTestCaseStub(unittest.TestCase):
         @status: manual
         """
 
-    @unittest.skip(NOT_IMPLEMENTED)
+    @stubbed
     def test_add_hostgroup_4(self, test_data):
         """
         @feature: Organizations

--- a/tests/foreman/api/test_lifecycleenvironment.py
+++ b/tests/foreman/api/test_lifecycleenvironment.py
@@ -4,19 +4,18 @@ Each ``TestCase`` subclass tests a single URL. A full list of URLs to be tested
 can be found here: http://theforeman.org/api/apidoc/v2/environments.html
 
 """
+import httplib
+from robottelo import entities
 from robottelo.api import client
 from robottelo.common.decorators import run_only_on
 from robottelo.common.helpers import get_server_credentials
-from robottelo import entities
-from unittest import TestCase
-import httplib
+from robottelo.test import APITestCase
 # (too-many-public-methods) pylint:disable=R0904
 
 
 @run_only_on('sat')
-class LifecycleEnvironmentTestCase(TestCase):
+class LifecycleEnvironmentTestCase(APITestCase):
     """Tests for ``katello/api/v2/environments``."""
-    _multiprocess_can_split_ = True
 
     def test_get_all(self):
         """@Test: Get ``katello/api/v2/environments`` and specify just an

--- a/tests/foreman/api/test_media.py
+++ b/tests/foreman/api/test_media.py
@@ -1,12 +1,11 @@
 """Tests for the ``media`` paths."""
-from robottelo.common.constants import NOT_IMPLEMENTED
-from robottelo.common.decorators import run_only_on
-import unittest
+from robottelo.common.decorators import run_only_on, stubbed
+from robottelo.test import APITestCase
 # (too-many-public-methods) pylint:disable=R0904
 
 
 @run_only_on('sat')
-class MediaTestCase(unittest.TestCase):
+class MediaTestCase(APITestCase):
     """Incomplete tests for media.
 
     When implemented, each of these tests should probably be data-driven. A
@@ -22,9 +21,8 @@ class MediaTestCase(unittest.TestCase):
         )
 
     """
-    _multiprocess_can_split_ = True
 
-    @unittest.skip(NOT_IMPLEMENTED)
+    @stubbed
     def test_remove_medium_1(self, test_data):
         """
         @feature: Organizations
@@ -33,7 +31,7 @@ class MediaTestCase(unittest.TestCase):
         @status: manual
         """
 
-    @unittest.skip(NOT_IMPLEMENTED)
+    @stubbed
     def test_remove_medium_2(self, test_data):
         """
         @feature: Organizations
@@ -42,7 +40,7 @@ class MediaTestCase(unittest.TestCase):
         @status: manual
         """
 
-    @unittest.skip(NOT_IMPLEMENTED)
+    @stubbed
     def test_remove_medium_3(self, test_data):
         """
         @feature: Organizations
@@ -51,7 +49,7 @@ class MediaTestCase(unittest.TestCase):
         @status: manual
         """
 
-    @unittest.skip(NOT_IMPLEMENTED)
+    @stubbed
     def test_remove_medium_4(self, test_data):
         """
         @feature: Organizations
@@ -60,7 +58,7 @@ class MediaTestCase(unittest.TestCase):
         @status: manual
         """
 
-    @unittest.skip(NOT_IMPLEMENTED)
+    @stubbed
     def test_add_medium_1(self, test_data):
         """
         @feature: Organizations
@@ -69,7 +67,7 @@ class MediaTestCase(unittest.TestCase):
         @status: manual
         """
 
-    @unittest.skip(NOT_IMPLEMENTED)
+    @stubbed
     def test_add_medium_2(self, test_data):
         """
         @feature: Organizations
@@ -78,7 +76,7 @@ class MediaTestCase(unittest.TestCase):
         @status: manual
         """
 
-    @unittest.skip(NOT_IMPLEMENTED)
+    @stubbed
     def test_add_medium_3(self, test_data):
         """
         @feature: Organizations
@@ -87,7 +85,7 @@ class MediaTestCase(unittest.TestCase):
         @status: manual
         """
 
-    @unittest.skip(NOT_IMPLEMENTED)
+    @stubbed
     def test_add_medium_4(self, test_data):
         """
         @feature: Organizations

--- a/tests/foreman/api/test_multiple_paths.py
+++ b/tests/foreman/api/test_multiple_paths.py
@@ -1,16 +1,16 @@
 """Data-driven unit tests for multiple paths."""
+import httplib
+import logging
 from ddt import data, ddt
 from functools import partial
 from requests.exceptions import HTTPError
+from robottelo import entities
 from robottelo.api import client
 from robottelo.common import conf
 from robottelo.common.decorators import (
     bz_bug_is_open, run_only_on, skip_if_bug_open)
 from robottelo.common.helpers import get_server_credentials
-from robottelo import entities
-from unittest import TestCase
-import httplib
-import logging
+from robottelo.test import APITestCase
 # (too-many-public-methods) pylint:disable=R0904
 
 
@@ -75,9 +75,8 @@ def skip_if_sam(self, entity):
 
 
 @ddt
-class EntityTestCase(TestCase):
+class EntityTestCase(APITestCase):
     """Issue HTTP requests to various ``entity/`` paths."""
-    _multiprocess_can_split_ = True
 
     @data(
         # entities.ActivationKey,  # need organization_id or environment_id
@@ -247,9 +246,8 @@ class EntityTestCase(TestCase):
 
 
 @ddt
-class EntityIdTestCase(TestCase):
+class EntityIdTestCase(APITestCase):
     """Issue HTTP requests to various ``entity/:id`` paths."""
-    _multiprocess_can_split_ = True
 
     @data(
         entities.ActivationKey,
@@ -404,7 +402,7 @@ class EntityIdTestCase(TestCase):
 
 
 @ddt
-class DoubleCheckTestCase(TestCase):
+class DoubleCheckTestCase(APITestCase):
     """Perform in-depth tests on URLs.
 
     Do not just assume that an HTTP response with a good status code indicates
@@ -412,7 +410,6 @@ class DoubleCheckTestCase(TestCase):
     action to ensure that the intended action was accomplished.
 
     """
-    _multiprocess_can_split_ = True
     longMessage = True
 
     @data(
@@ -606,12 +603,11 @@ class DoubleCheckTestCase(TestCase):
 
 
 @ddt
-class EntityReadTestCase(TestCase):
+class EntityReadTestCase(APITestCase):
     """
     Check that classes inheriting from :class:`robottelo.orm.EntityReadMixin`
     function correctly.
     """
-    _multiprocess_can_split_ = True
 
     # Most entities are commented-out because they do not inherit from
     # EntityReadMixin, due to issues with data returned from the API.

--- a/tests/foreman/api/test_operatingsystem.py
+++ b/tests/foreman/api/test_operatingsystem.py
@@ -7,16 +7,15 @@ References for the relevant paths can be found here:
 
 """
 from fauxfactory import gen_utf8
-from robottelo.common.decorators import run_only_on
 from robottelo import entities
-from unittest import TestCase
+from robottelo.common.decorators import run_only_on
+from robottelo.test import APITestCase
 # (too-many-public-methods) pylint:disable=R0904
 
 
 @run_only_on('sat')
-class OSParameterTestCase(TestCase):
+class OSParameterTestCase(APITestCase):
     """Tests for operating system parameters."""
-    _multiprocess_can_split_ = True
 
     def test_bz_1114640(self):
         """@Test: Create a parameter for operating system 1.
@@ -46,9 +45,8 @@ class OSParameterTestCase(TestCase):
 
 
 @run_only_on('sat')
-class OSTestCase(TestCase):
+class OSTestCase(APITestCase):
     """Tests for operating systems."""
-    _multiprocess_can_split_ = True
 
     def test_point_to_arch(self):
         """@Test: Create an operating system that points at an architecture.

--- a/tests/foreman/api/test_organization.py
+++ b/tests/foreman/api/test_organization.py
@@ -1,26 +1,26 @@
 """Unit tests for the ``organizations`` paths.
 
-Each ``TestCase`` subclass tests a single URL. A full list of URLs to be tested
-can be found here: http://theforeman.org/api/apidoc/v2/organizations.html
+Each ``APITestCase`` subclass tests a single URL. A full list of URLs to be
+tested can be found here:
+http://theforeman.org/api/apidoc/v2/organizations.html
 
 """
-from fauxfactory import gen_string
-from requests.exceptions import HTTPError
-from robottelo.api import client
-from robottelo.common.decorators import skip_if_bug_open
-from robottelo.common.helpers import get_server_credentials
-from robottelo import entities
-from unittest import TestCase
 import ddt
 import httplib
 import sys
+from fauxfactory import gen_string
+from requests.exceptions import HTTPError
+from robottelo import entities
+from robottelo.api import client
+from robottelo.common.decorators import skip_if_bug_open
+from robottelo.common.helpers import get_server_credentials
+from robottelo.test import APITestCase
 # (too-many-public-methods) pylint:disable=R0904
 
 
 @ddt.ddt
-class OrganizationTestCase(TestCase):
+class OrganizationTestCase(APITestCase):
     """Tests for the ``organizations`` path."""
-    _multiprocess_can_split_ = True
 
     @skip_if_bug_open('bugzilla', 1116043)
     def test_create_text_plain(self):
@@ -199,9 +199,8 @@ class OrganizationTestCase(TestCase):
 
 
 @ddt.ddt
-class OrganizationUpdateTestCase(TestCase):
+class OrganizationUpdateTestCase(APITestCase):
     """Tests for the ``organizations`` path."""
-    _multiprocess_can_split_ = True
 
     @classmethod
     def setUpClass(cls):

--- a/tests/foreman/api/test_permission.py
+++ b/tests/foreman/api/test_permission.py
@@ -1,20 +1,20 @@
 """Unit tests for the ``permissions`` paths.
 
-Each ``TestCase`` subclass tests a single URL. A full list of URLs to be tested
-can be found here: http://theforeman.org/api/apidoc/v2/permissions.html
+Each ``APITestCase`` subclass tests a single URL. A full list of URLs to be
+tested can be found here: http://theforeman.org/api/apidoc/v2/permissions.html
 
 """
+import re
 from ddt import data as ddt_data, ddt
 from fauxfactory import gen_alphanumeric
 from itertools import chain
 from requests.exceptions import HTTPError
+from robottelo import entities
 from robottelo.api import client
 from robottelo.common.constants import PERMISSIONS
 from robottelo.common.decorators import data, run_only_on
 from robottelo.common.helpers import get_server_credentials
-from robottelo import entities
-from unittest import TestCase
-import re
+from robottelo.test import APITestCase
 # (too-many-public-methods) pylint:disable=R0904
 
 
@@ -27,9 +27,8 @@ PERMISSIONS_NAME = [
 
 
 @ddt
-class PermissionsTestCase(TestCase):
+class PermissionsTestCase(APITestCase):
     """Tests for the ``permissions`` path."""
-    _multiprocess_can_split_ = True
 
     @run_only_on('sat')
     @ddt_data(*PERMISSIONS_NAME)  # pylint:disable=W0142
@@ -114,9 +113,8 @@ def _permission_name(entity, which_perm):
 
 # This class might better belong in module test_multiple_paths.
 @ddt
-class UserRoleTestCase(TestCase):
+class UserRoleTestCase(APITestCase):
     """Give a user various permissions and see if they are enforced."""
-    _multiprocess_can_split_ = True
 
     def setUp(self):
         """Create a set of credentials and a user."""

--- a/tests/foreman/api/test_product.py
+++ b/tests/foreman/api/test_product.py
@@ -7,19 +7,18 @@ http://theforeman.org/api/apidoc/v2/products.html
 from ddt import ddt
 from fauxfactory import gen_string
 from random import randint
+from robottelo import entities
 from robottelo.api import client
 from robottelo.common.constants import VALID_GPG_KEY_FILE
-from robottelo.common.helpers import get_server_credentials, read_data_file
 from robottelo.common.decorators import data, run_only_on
-from robottelo import entities
-from unittest import TestCase
+from robottelo.common.helpers import get_server_credentials, read_data_file
+from robottelo.test import APITestCase
 # (too-many-public-methods) pylint:disable=R0904
 
 
 @ddt
-class ProductsTestCase(TestCase):
+class ProductsTestCase(APITestCase):
     """Tests for ``katello/api/v2/products``."""
-    _multiprocess_can_split_ = True
 
     @run_only_on('sat')
     @data(
@@ -82,9 +81,8 @@ class ProductsTestCase(TestCase):
 
 @run_only_on('sat')
 @ddt
-class ProductUpdateTestCase(TestCase):
+class ProductUpdateTestCase(APITestCase):
     """Tests for updating a product."""
-    _multiprocess_can_split_ = True
 
     @classmethod
     def setUpClass(cls):

--- a/tests/foreman/api/test_repository.py
+++ b/tests/foreman/api/test_repository.py
@@ -3,7 +3,9 @@ from ddt import ddt
 from fauxfactory import gen_string
 from random import randint
 from requests.exceptions import HTTPError
+from robottelo import entities
 from robottelo.api import client, utils
+from robottelo.common import manifests
 from robottelo.common.constants import (
     DOCKER_REGISTRY_HUB,
     FAKE_0_PUPPET_REPO,
@@ -13,18 +15,15 @@ from robottelo.common.constants import (
     VALID_GPG_KEY_FILE,
 )
 from robottelo.common.decorators import data, run_only_on
-from robottelo.common import manifests
 from robottelo.common.helpers import (
     get_server_credentials, get_data_file, read_data_file)
-from robottelo import entities
-from unittest import TestCase
+from robottelo.test import APITestCase
 # (too-many-public-methods) pylint:disable=R0904
 
 
 @ddt
-class RepositoryTestCase(TestCase):
+class RepositoryTestCase(APITestCase):
     """Tests for ``katello/api/v2/repositories``."""
-    _multiprocess_can_split_ = True
 
     @classmethod
     def setUpClass(cls):
@@ -217,9 +216,8 @@ class RepositoryTestCase(TestCase):
 
 
 @ddt
-class RepositoryUpdateTestCase(TestCase):
+class RepositoryUpdateTestCase(APITestCase):
     """Tests for updating repositories."""
-    _multiprocess_can_split_ = True
 
     @classmethod
     def setUpClass(cls):
@@ -261,9 +259,8 @@ class RepositoryUpdateTestCase(TestCase):
             self.assertEqual(value, real_attrs[name])
 
 
-class RepositorySyncTestCase(TestCase):
+class RepositorySyncTestCase(APITestCase):
     """Tests for ``/katello/api/repositories/:id/sync``."""
-    _multiprocess_can_split_ = True
 
     @run_only_on('sat')
     def test_redhat_sync_1(self):
@@ -296,9 +293,8 @@ class RepositorySyncTestCase(TestCase):
 
 
 @ddt
-class DockerRepositoryTestCase(TestCase):
+class DockerRepositoryTestCase(APITestCase):
     """Tests specific to using ``Docker`` repositories."""
-    _multiprocess_can_split_ = True
 
     @classmethod
     def setUpClass(cls):

--- a/tests/foreman/api/test_rhsm.py
+++ b/tests/foreman/api/test_rhsm.py
@@ -4,16 +4,15 @@ No API doc exists for the subscription manager path(s). However, bugzilla bug
 1112802 provides some relevant information.
 
 """
+import httplib
 from robottelo.api import client
 from robottelo.common.helpers import get_server_credentials, get_server_url
-from unittest import TestCase
-import httplib
+from robottelo.test import APITestCase
 # (too-many-public-methods) pylint:disable=R0904
 
 
-class RHSMTestCase(TestCase):
+class RHSMTestCase(APITestCase):
     """Tests for the ``/rhsm`` path."""
-    _multiprocess_can_split_ = True
 
     def test_path_exists(self):
         """@Test: Check whether the path exists.

--- a/tests/foreman/api/test_role.py
+++ b/tests/foreman/api/test_role.py
@@ -4,6 +4,7 @@ An API reference is available here:
 http://theforeman.org/api/apidoc/v2/roles.html
 
 """
+import ddt
 from fauxfactory import (
     gen_alpha,
     gen_alphanumeric,
@@ -13,19 +14,17 @@ from fauxfactory import (
     gen_utf8,
 )
 from requests.exceptions import HTTPError
-from robottelo.api import client
-from robottelo.common.helpers import get_server_credentials
-from robottelo.common import decorators
 from robottelo import entities
-from unittest import TestCase
-import ddt
+from robottelo.api import client
+from robottelo.common import decorators
+from robottelo.common.helpers import get_server_credentials
+from robottelo.test import APITestCase
 # (too-many-public-methods) pylint:disable=R0904
 
 
 @ddt.ddt
-class RoleTestCase(TestCase):
+class RoleTestCase(APITestCase):
     """Tests for ``api/v2/roles``."""
-    _multiprocess_can_split_ = True
 
     @decorators.data(
         gen_alpha,

--- a/tests/foreman/api/test_smartproxy.py
+++ b/tests/foreman/api/test_smartproxy.py
@@ -1,12 +1,11 @@
 """Tests for the ``smart_proxies`` paths."""
-from robottelo.common.constants import NOT_IMPLEMENTED
-from robottelo.common.decorators import run_only_on
-import unittest
+from robottelo.common.decorators import run_only_on, stubbed
+from robottelo.test import APITestCase
 # (too-many-public-methods) pylint:disable=R0904
 
 
 @run_only_on('sat')
-class SmartProxyTestCaseStub(unittest.TestCase):
+class SmartProxyTestCaseStub(APITestCase):
     """Incomplete tests for smart proxies.
 
     When implemented, each of these tests should probably be data-driven. A
@@ -22,9 +21,8 @@ class SmartProxyTestCaseStub(unittest.TestCase):
         )
 
     """
-    _multiprocess_can_split_ = True
 
-    @unittest.skip(NOT_IMPLEMENTED)
+    @stubbed
     def test_add_smartproxy_1(self, test_data):
         """
         @feature: Organizations
@@ -33,7 +31,7 @@ class SmartProxyTestCaseStub(unittest.TestCase):
         @status: manual
         """
 
-    @unittest.skip(NOT_IMPLEMENTED)
+    @stubbed
     def test_add_smartproxy_2(self, test_data):
         """
         @feature: Organizations
@@ -42,7 +40,7 @@ class SmartProxyTestCaseStub(unittest.TestCase):
         @status: manual
         """
 
-    @unittest.skip(NOT_IMPLEMENTED)
+    @stubbed
     def test_add_smartproxy_3(self, test_data):
         """
         @feature: Organizations
@@ -51,7 +49,7 @@ class SmartProxyTestCaseStub(unittest.TestCase):
         @status: manual
         """
 
-    @unittest.skip(NOT_IMPLEMENTED)
+    @stubbed
     def test_add_smartproxy_4(self, test_data):
         """
         @feature: Organizations
@@ -60,7 +58,7 @@ class SmartProxyTestCaseStub(unittest.TestCase):
         @status: manual
         """
 
-    @unittest.skip(NOT_IMPLEMENTED)
+    @stubbed
     def test_remove_smartproxy_1(self, test_data):
         """
         @feature: Organizations
@@ -69,7 +67,7 @@ class SmartProxyTestCaseStub(unittest.TestCase):
         @status: manual
         """
 
-    @unittest.skip(NOT_IMPLEMENTED)
+    @stubbed
     def test_remove_smartproxy_2(self, test_data):
         """
         @feature: Organizations
@@ -78,7 +76,7 @@ class SmartProxyTestCaseStub(unittest.TestCase):
         @status: manual
         """
 
-    @unittest.skip(NOT_IMPLEMENTED)
+    @stubbed
     def test_remove_smartproxy_3(self, test_data):
         """
         @feature: Organizations
@@ -87,7 +85,7 @@ class SmartProxyTestCaseStub(unittest.TestCase):
         @status: manual
         """
 
-    @unittest.skip(NOT_IMPLEMENTED)
+    @stubbed
     def test_remove_smartproxy_4(self, test_data):
         """
         @feature: Organizations

--- a/tests/foreman/api/test_subscription.py
+++ b/tests/foreman/api/test_subscription.py
@@ -5,14 +5,13 @@ https://<sat6.com>/apidoc/v2/subscriptions.html
 
 """
 from robottelo import entities
-from unittest import TestCase
 from robottelo.common import manifests
+from robottelo.test import APITestCase
 # (too-many-public-methods) pylint:disable=R0904
 
 
-class SubscriptionsTestCase(TestCase):
+class SubscriptionsTestCase(APITestCase):
     """Tests for the ``subscriptions`` path."""
-    _multiprocess_can_split_ = True
 
     def test_positive_create_1(self):
         """@Test: Upload a manifest.

--- a/tests/foreman/api/test_system.py
+++ b/tests/foreman/api/test_system.py
@@ -15,23 +15,22 @@ A full list of system-related URLs can be found here:
 http://theforeman.org/api/apidoc/v2/systems.html
 
 """
+import httplib
+import logging
 from requests.exceptions import HTTPError
 from robottelo.api import client
 from robottelo.common.decorators import skip_if_bug_open
 from robottelo.common.helpers import get_server_credentials
 from robottelo.entities import System
-from unittest import TestCase
-import httplib
-import logging
+from robottelo.test import APITestCase
 # (too-many-public-methods) pylint:disable=R0904
 
 
 logger = logging.getLogger(__name__)  # pylint:disable=C0103
 
 
-class EntityIdTestCaseClone(TestCase):
+class EntityIdTestCaseClone(APITestCase):
     """Issue HTTP requests to various ``systems/:uuid`` paths."""
-    _multiprocess_can_split_ = True
 
     def test_get_status_code(self):
         """@Test: Create a system and GET it.
@@ -97,7 +96,7 @@ class EntityIdTestCaseClone(TestCase):
             self.assertIn('application/json', response.headers['content-type'])
 
 
-class DoubleCheckTestCase(TestCase):
+class DoubleCheckTestCase(APITestCase):
     """Perform in-depth tests on URLs.
 
     Do not just assume that an HTTP response with a good status code indicates
@@ -105,7 +104,6 @@ class DoubleCheckTestCase(TestCase):
     action to ensure that the intended action was accomplished.
 
     """
-    _multiprocess_can_split_ = True
 
     @skip_if_bug_open('bugzilla', 1133097)
     def test_put_and_get(self):

--- a/tests/foreman/api/test_user.py
+++ b/tests/foreman/api/test_user.py
@@ -1,23 +1,22 @@
 """Unit tests for the ``users`` paths.
 
-Each ``TestCase`` subclass tests a single URL. A full list of URLs to be tested
-can be found here: http://theforeman.org/api/apidoc/v2/users.html
+Each ``APITestCase`` subclass tests a single URL. A full list of URLs to be
+tested can be found here: http://theforeman.org/api/apidoc/v2/users.html
 
 """
+import ddt
 from fauxfactory import gen_string
 from random import randint
 from requests.exceptions import HTTPError
-from robottelo.common import decorators
 from robottelo import entities
-from unittest import TestCase
-import ddt
+from robottelo.common import decorators
+from robottelo.test import APITestCase
 # (too-many-public-methods) pylint:disable=R0904
 
 
 @ddt.ddt
-class UsersTestCase(TestCase):
+class UsersTestCase(APITestCase):
     """Tests for the ``users`` path."""
-    _multiprocess_can_split_ = True
 
     @decorators.data(
         {u'admin': False},


### PR DESCRIPTION
Group similar behaviour under a common class.

Other endpoints' tests already take advantage of class inheritance to define common behaviour and attributes. As a test framework robottelo could provide more feature in the future for test classes that inherit from its provided test classes.
