### PR TITLE
Fixed few more UI failures

### DIFF
--- a/robottelo/ui/computeresource.py
+++ b/robottelo/ui/computeresource.py
@@ -82,6 +82,7 @@ class ComputeResource(Base):
         Searches existing compute resource from UI
         """
         Navigator(self.browser).go_to_compute_resources()
+        self.wait_for_ajax()
         element = self.search_entity(name, locators["resource.select_name"])
         return element
 

--- a/robottelo/ui/configgroups.py
+++ b/robottelo/ui/configgroups.py
@@ -45,6 +45,7 @@ class ConfigGroups(Base):
         Searches existing config-groups from UI
         """
         Navigator(self.browser).go_to_config_groups()
+        self.wait_for_ajax()
         element = self.search_entity(name,
                                      locators["config_groups.select_name"])
         return element

--- a/robottelo/ui/domain.py
+++ b/robottelo/ui/domain.py
@@ -46,6 +46,7 @@ class Domain(Base):
         Searches existing domain from UI
         """
         Navigator(self.browser).go_to_domains()
+        self.wait_for_ajax()
         element = self.search_entity(description,
                                      locators["domain.domain_description"],
                                      timeout=timeout)

--- a/robottelo/ui/location.py
+++ b/robottelo/ui/location.py
@@ -120,6 +120,7 @@ class Location(Base):
         Searches existing location from UI
         """
         nav(self.browser).go_to_loc()
+        self.wait_for_ajax()
         element = self.search_entity(name, locators["location.select_name"])
         return element
 

--- a/robottelo/ui/medium.py
+++ b/robottelo/ui/medium.py
@@ -51,6 +51,7 @@ class Medium(Base):
         Searches existing medium from UI
         """
         Navigator(self.browser).go_to_installation_media()
+        self.wait_for_ajax()
         element = self.search_entity(name, locators["medium.medium_name"])
         return element
 

--- a/robottelo/ui/org.py
+++ b/robottelo/ui/org.py
@@ -122,6 +122,7 @@ class Org(Base):
         Searches existing Organization from UI
         """
         nav(self.browser).go_to_org()
+        self.wait_for_ajax()
         element = self.search_entity(name, locators["org.org_name"])
         return element
 

--- a/tests/foreman/ui/test_location.py
+++ b/tests/foreman/ui/test_location.py
@@ -77,7 +77,7 @@ class Location(UITestCase):
         @BZ: 1123818
         """
         with Session(self.browser) as session:
-            make_loc(session, name=loc_name)
+            make_loc(session, name=loc_name, edit=False)
             error = session.nav.wait_until_element(
                 common_locators["name_haserror"])
             self.assertIsNotNone(error)
@@ -91,7 +91,7 @@ class Location(UITestCase):
 
         loc_name = ""
         with Session(self.browser) as session:
-            make_loc(session, name=loc_name)
+            make_loc(session, name=loc_name, edit=False)
             error = session.nav.wait_until_element(
                 common_locators["name_haserror"])
             self.assertIsNotNone(error)
@@ -105,7 +105,7 @@ class Location(UITestCase):
 
         loc_name = "    "
         with Session(self.browser) as session:
-            make_loc(session, name=loc_name)
+            make_loc(session, name=loc_name, edit=False)
             error = session.nav.wait_until_element(
                 common_locators["name_haserror"])
             self.assertIsNotNone(error)
@@ -123,7 +123,7 @@ class Location(UITestCase):
         with Session(self.browser) as session:
             make_loc(session, name=loc_name)
             self.assertIsNotNone(self.location.search(loc_name))
-            make_loc(session, name=loc_name)
+            make_loc(session, name=loc_name, edit=False)
             error = session.nav.wait_until_element(
                 common_locators["name_haserror"])
             self.assertIsNotNone(error)

--- a/tests/foreman/ui/test_org.py
+++ b/tests/foreman/ui/test_org.py
@@ -204,7 +204,7 @@ class Org(UITestCase):
         @assert: organization is not created
         """
         with Session(self.browser) as session:
-            make_org(session, org_name=org_name)
+            make_org(session, org_name=org_name, edit=False)
             error = session.nav.wait_until_element(
                 common_locators["name_haserror"])
             self.assertIsNotNone(error)
@@ -218,7 +218,7 @@ class Org(UITestCase):
         """
         org_name = ""
         with Session(self.browser) as session:
-            make_org(session, org_name=org_name)
+            make_org(session, org_name=org_name, edit=False)
             error = session.nav.wait_until_element(
                 common_locators["name_haserror"])
             self.assertIsNotNone(error)
@@ -232,7 +232,7 @@ class Org(UITestCase):
         """
         org_name = "    "
         with Session(self.browser) as session:
-            make_org(session, org_name=org_name)
+            make_org(session, org_name=org_name, edit=False)
             error = session.nav.wait_until_element(
                 common_locators["name_haserror"])
             self.assertIsNotNone(error)


### PR DESCRIPTION
Fixed: `test_negative_create_{0-2}` org test by setting the edit variable value to False
Fixed: `org`, `location`, `domain`, `config_group`, `medium` tests by placing wait_for_ajax before calling search fn
Fixed: `test_negative_create{1-4}` location tests

This PR will fix almost all org and location tests. Also, some tests were failing while asserting final result via search. I think its because now navigation is part of search function. So after each `go_to` statement we need to add wait_for_ajax. I hope this PR should fix bunch of more tests.

Also, this PR needs to be cherry-picked to master. I'll do that once it will be merged. thanks
