### PR TITLE
Fixed UI test failures - cherry-picked commit from zstream branch

### DIFF
--- a/robottelo/ui/computeresource.py
+++ b/robottelo/ui/computeresource.py
@@ -82,6 +82,7 @@ class ComputeResource(Base):
         Searches existing compute resource from UI
         """
         Navigator(self.browser).go_to_compute_resources()
+        self.wait_for_ajax()
         element = self.search_entity(name, locators["resource.select_name"])
         return element
 

--- a/robottelo/ui/domain.py
+++ b/robottelo/ui/domain.py
@@ -46,6 +46,7 @@ class Domain(Base):
         Searches existing domain from UI
         """
         Navigator(self.browser).go_to_domains()
+        self.wait_for_ajax()
         element = self.search_entity(description,
                                      locators["domain.domain_description"],
                                      timeout=timeout)

--- a/robottelo/ui/location.py
+++ b/robottelo/ui/location.py
@@ -120,6 +120,7 @@ class Location(Base):
         Searches existing location from UI
         """
         nav(self.browser).go_to_loc()
+        self.wait_for_ajax()
         element = self.search_entity(name, locators["location.select_name"])
         return element
 

--- a/robottelo/ui/medium.py
+++ b/robottelo/ui/medium.py
@@ -51,6 +51,7 @@ class Medium(Base):
         Searches existing medium from UI
         """
         Navigator(self.browser).go_to_installation_media()
+        self.wait_for_ajax()
         element = self.search_entity(name, locators["medium.medium_name"])
         return element
 

--- a/robottelo/ui/org.py
+++ b/robottelo/ui/org.py
@@ -122,6 +122,7 @@ class Org(Base):
         Searches existing Organization from UI
         """
         nav(self.browser).go_to_org()
+        self.wait_for_ajax()
         element = self.search_entity(name, locators["org.org_name"])
         return element
 

--- a/tests/foreman/ui/test_location.py
+++ b/tests/foreman/ui/test_location.py
@@ -76,7 +76,7 @@ class Location(UITestCase):
 
         """
         with Session(self.browser) as session:
-            make_loc(session, name=loc_name)
+            make_loc(session, name=loc_name, edit=False)
             error = session.nav.wait_until_element(
                 common_locators["name_haserror"])
             self.assertIsNotNone(error)
@@ -92,7 +92,7 @@ class Location(UITestCase):
 
         loc_name = ""
         with Session(self.browser) as session:
-            make_loc(session, name=loc_name)
+            make_loc(session, name=loc_name, edit=False)
             error = session.nav.wait_until_element(
                 common_locators["name_haserror"])
             self.assertIsNotNone(error)
@@ -108,7 +108,7 @@ class Location(UITestCase):
 
         loc_name = "    "
         with Session(self.browser) as session:
-            make_loc(session, name=loc_name)
+            make_loc(session, name=loc_name, edit=False)
             error = session.nav.wait_until_element(
                 common_locators["name_haserror"])
             self.assertIsNotNone(error)
@@ -128,7 +128,7 @@ class Location(UITestCase):
         with Session(self.browser) as session:
             make_loc(session, name=loc_name)
             self.assertIsNotNone(self.location.search(loc_name))
-            make_loc(session, name=loc_name)
+            make_loc(session, name=loc_name, edit=False)
             error = session.nav.wait_until_element(
                 common_locators["name_haserror"])
             self.assertIsNotNone(error)

--- a/tests/foreman/ui/test_org.py
+++ b/tests/foreman/ui/test_org.py
@@ -246,7 +246,7 @@ class Org(UITestCase):
 
         """
         with Session(self.browser) as session:
-            make_org(session, org_name=org_name)
+            make_org(session, org_name=org_name, edit=False)
             error = session.nav.wait_until_element(
                 common_locators["name_haserror"])
             self.assertIsNotNone(error)
@@ -262,7 +262,7 @@ class Org(UITestCase):
         """
         org_name = ""
         with Session(self.browser) as session:
-            make_org(session, org_name=org_name)
+            make_org(session, org_name=org_name, edit=False)
             error = session.nav.wait_until_element(
                 common_locators["name_haserror"])
             self.assertIsNotNone(error)
@@ -278,7 +278,7 @@ class Org(UITestCase):
         """
         org_name = "    "
         with Session(self.browser) as session:
-            make_org(session, org_name=org_name)
+            make_org(session, org_name=org_name, edit=False)
             error = session.nav.wait_until_element(
                 common_locators["name_haserror"])
             self.assertIsNotNone(error)


### PR DESCRIPTION
Fixed: test_negative_create_{0-2} org test by setting the edit variable value to False
Fixed: org, location, domain, config_group, medium tests by placing wait_for_ajax before calling search fn
Fixed: test_negative_create{1-4} location tests

(cherry picked from commit aa0b29c9ea8f791b5214ad83ab37183a2cbf4336)
