### PR TITLE
Update EntityDeleteMixin, change _poll_task args

### DIFF
--- a/robottelo/entities.py
+++ b/robottelo/entities.py
@@ -763,7 +763,7 @@ class ForemanTask(orm.Entity, orm.EntityReadMixin):
             )
         return super(ForemanTask, self).path(which='self')
 
-    def poll(self, poll_rate=5, timeout=120, auth=None):
+    def poll(self, poll_rate=None, timeout=None, auth=None):
         """Return the status of a task or timeout.
 
         There are several API calls that trigger asynchronous tasks, such as
@@ -773,8 +773,10 @@ class ForemanTask(orm.Entity, orm.EntityReadMixin):
         task completion, returns information about that task.
 
         :param int poll_rate: Delay between the end of one task check-up and
-            the start of the next check-up.
+            the start of the next check-up. Defaults to
+            :data:`robottelo.orm.TASK_POLL_RATE`.
         :param int timeout: Maximum number of seconds to wait until timing out.
+            Defaults to :data:`robottelo.orm.TASK_TIMEOUT`.
         :param tuple auth: A ``(username, password)`` tuple used when accessing
             the API. If ``None``, the credentials provided by
             :func:`robottelo.common.helpers.get_server_credentials` are used.
@@ -787,7 +789,8 @@ class ForemanTask(orm.Entity, orm.EntityReadMixin):
 
         """
         # (protected-access) pylint:disable=W0212
-        # See docstring for orm._poll_task for an explanation.
+        # See docstring for orm._poll_task for an explanation of why a private
+        # method is called.
         return orm._poll_task(self.id, poll_rate, timeout, auth)
 
 

--- a/tests/foreman/api/test_multiple_paths.py
+++ b/tests/foreman/api/test_multiple_paths.py
@@ -384,11 +384,7 @@ class EntityIdTestCase(APITestCase):
             entity = entity_cls(id=entity_cls().create_json()['id'])
         except HTTPError as err:
             self.fail(err)
-        response = client.delete(
-            entity.path(),
-            auth=get_server_credentials(),
-            verify=False,
-        )
+        response = entity.delete_raw()
         self.assertIn(
             response.status_code,
             (httplib.NO_CONTENT, httplib.OK, httplib.ACCEPTED)


### PR DESCRIPTION
Create method `EntityDeleteMixin.delete_raw`. This method is useful when a
client wishes to delete something and get the response object, which contains
information such as a status code and the raw byte response.

Make method `EntityDeleteMixin.delete` act more like other methods that deal
with foreman tasks. It now always returns a dict of data, rather than evaluating
some mildly complex logic and returning either a foreman task ID or None.

Change the arguments to the `robottelo.orm._poll_task` method. Make that method
use `None` as a default argument to several methods instead of concrete values.
This change makes it easier to override that method.

Update the unit tests for `robottelo.orm.EntityDeleteMixin.delete`.

```
$ nosetests tests/robottelo/
......................................................................................................................................................
----------------------------------------------------------------------
Ran 150 tests in 0.107s

OK
```

Use method `delete_raw` instead of `client.delete`. Using `delete_raw` allows
for more compact code.

```
$ nosetests tests/foreman/api/test_multiple_paths.py  -m test_delete_status_code
......................
----------------------------------------------------------------------
Ran 22 tests in 31.614s

OK
```
