### PR TITLE
Skip tests that fail due to BZ 1166365

### DIFF
--- a/tests/foreman/api/test_repository.py
+++ b/tests/foreman/api/test_repository.py
@@ -14,7 +14,7 @@ from robottelo.common.constants import (
     VALID_GPG_KEY_BETA_FILE,
     VALID_GPG_KEY_FILE,
 )
-from robottelo.common.decorators import data, run_only_on
+from robottelo.common.decorators import data, run_only_on, skip_if_bug_open
 from robottelo.common.helpers import (
     get_server_credentials, get_data_file, read_data_file)
 from robottelo.test import APITestCase
@@ -119,6 +119,7 @@ class RepositoryTestCase(APITestCase):
                 entities.Repository(id=repo2_attrs['id']).read_json()):
             self.assertEqual(attrs['name'], name)
 
+    @skip_if_bug_open('bugzilla', 1166365)
     @run_only_on('sat')
     @data(*_test_data())  # (star-args) pylint:disable=W0142
     def test_delete(self, attrs):


### PR DESCRIPTION
Deleting a repository is an asynchronous task, and there's no way to monitor the
progress of the deletion except by polling to see if that repository still
exists. This is problematic, and it's exacerbated by the fact that the task can
take a significant (10+ seconds) amount of time. When a client deletes a
repository, the server should either block until the deletion is done, or it
should return a task that can be monitored.

Here's a simple script that I've used to test this issue (it depends on some robottelo code):

```
#!/usr/bin/env python2
from robottelo.entities import Repository
from time import sleep
repo_id = Repository().create_json()['id']
repo = Repository(id=repo_id)
print('Target: 200, actual: {0}'.format(repo.read_raw().status_code))
repo.delete()
print('Target: 404, actual: {0}'.format(repo.read_raw().status_code))
sleep(10)
print('Target: 404, actual: {0}'.format(repo.read_raw().status_code))
```

And here's some output I've received:

```
Target: 200, actual: 200
Target: 404, actual: 200
Target: 404, actual: 500
```
