### PR TITLE
Reference a different bugzilla bug

### DIFF
--- a/tests/foreman/api/test_multiple_paths.py
+++ b/tests/foreman/api/test_multiple_paths.py
@@ -593,7 +593,7 @@ class DoubleCheckTestCase(APITestCase):
             self.fail(err)
         entity.delete()
 
-        if entity_cls is entities.Repository and bz_bug_is_open(1163494):
+        if entity_cls is entities.Repository and bz_bug_is_open(1166365):
             return
         self.assertEqual(httplib.NOT_FOUND, entity.read_raw().status_code)
 


### PR DESCRIPTION
BZ 1163494 has been closed as a duplicate of BZ 1166365. Change a reference to
the former into a reference to the latter.
