### PR TITLE
Make EntityDeleteMixin.delete deal with HTTP 204s

### DIFF
--- a/robottelo/orm.py
+++ b/robottelo/orm.py
@@ -457,6 +457,11 @@ class EntityDeleteMixin(object):
         response.raise_for_status()
         if synchronous is True and response.status_code is httplib.ACCEPTED:
             return _poll_task(response.json()['id'], auth=auth)
+        if response.status_code == httplib.NO_CONTENT:
+            # "The server successfully processed the request, but is not
+            # returning any content. Usually used as a response to a successful
+            # delete request."
+            return
         return response.json()
 
 


### PR DESCRIPTION
An HTTP 204 response indicates that a request has been processed but no content
is being returned. When this happens, any attempt to decode the JSON in a
response will fail, because no content is available to decode that content. Make
`EntityDeleteMixin.delete` deal with this case. This fixes a test failure.
Updated test results:

```
$ nosetests tests/foreman/api/test_multiple_paths.py:DoubleCheckTestCase -m 1_ActivationKey
.S.
----------------------------------------------------------------------
Ran 3 tests in 31.344s

OK (SKIP=1)
```
