### PR TITLE
Added object caching to CLI tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -47,6 +47,10 @@ test-foreman-api-threaded:
 test-foreman-cli:
 	nosetests -c robottelo.properties $(FOREMAN_CLI_TESTS_PATH)
 
+test-foreman-cli-threaded:
+	nosetests -c robottelo.properties $(FOREMAN_CLI_TESTS_PATH)\
+	    --processes=-1 --process-timeout=300
+
 test-foreman-ui:
 	nosetests -c robottelo.properties $(FOREMAN_UI_TESTS_PATH)
 

--- a/robottelo/cli/factory.py
+++ b/robottelo/cli/factory.py
@@ -50,6 +50,7 @@ from robottelo.common.constants import (
     SYNC_INTERVAL,
     TEMPLATE_TYPES,
 )
+from robottelo.common.decorators import cacheable
 from robottelo.common.helpers import update_dictionary
 from tempfile import mkstemp
 
@@ -110,6 +111,7 @@ def create_object(cli_object, options, values):
     return result.stdout
 
 
+@cacheable
 def make_activation_key(options=None):
     """
     Usage::
@@ -133,7 +135,6 @@ def make_activation_key(options=None):
                                                           key have unlimited
                                                           content hosts
     """
-
     # Organization Name, Label or ID is a required field.
     if (
             not options
@@ -159,6 +160,7 @@ def make_activation_key(options=None):
     return create_object(ActivationKey, args, options)
 
 
+@cacheable
 def make_architecture(options=None):
     """
     Usage::
@@ -171,7 +173,6 @@ def make_architecture(options=None):
         --operatingsystem-ids OPERATINGSYSTEM_IDS Operatingsystem ID’s
                                       Comma separated list of values.
     """
-
     args = {
         u'name': gen_alphanumeric(),
         u'operatingsystem-ids': None,
@@ -180,6 +181,7 @@ def make_architecture(options=None):
     return create_object(Architecture, args, options)
 
 
+@cacheable
 def make_content_view(options=None):
     """
     Usage::
@@ -203,7 +205,6 @@ def make_content_view(options=None):
         -h, --help                    print help
 
     """
-
     # Organization ID is a required field.
     if not options or not options.get('organization-id', None):
         raise CLIFactoryError('Please provide a valid ORG ID.')
@@ -223,6 +224,7 @@ def make_content_view(options=None):
     return create_object(ContentView, args, options)
 
 
+@cacheable
 def make_gpg_key(options=None):
     """
     Usage::
@@ -238,7 +240,6 @@ def make_gpg_key(options=None):
         --organization-label ORGANIZATION_LABEL Organization label to search by
         -h, --help                    print help
     """
-
     # Organization ID is a required field.
     if not options or not options.get('organization-id', None):
         raise CLIFactoryError('Please provide a valid ORG ID.')
@@ -268,6 +269,7 @@ def make_gpg_key(options=None):
     return create_object(GPGKey, args, options)
 
 
+@cacheable
 def make_location(options=None):
     """Location CLI factory
 
@@ -326,6 +328,7 @@ def make_location(options=None):
     return create_object(Location, args, options)
 
 
+@cacheable
 def make_model(options=None):
     """
     Usage::
@@ -339,7 +342,6 @@ def make_model(options=None):
         --name NAME
         --vendor-class VENDOR_CLASS
     """
-
     args = {
         u'hardware-model': None,
         u'info': None,
@@ -350,6 +352,7 @@ def make_model(options=None):
     return create_object(Model, args, options)
 
 
+@cacheable
 def make_partition_table(options=None):
     """
     Usage::
@@ -394,6 +397,7 @@ def make_partition_table(options=None):
     return create_object(PartitionTable, args, options)
 
 
+@cacheable
 def make_product(options=None):
     """
     Usage::
@@ -414,7 +418,6 @@ def make_product(options=None):
         --sync-plan-id SYNC_PLAN_ID             Plan numeric identifier
         -h, --help                              print help
     """
-
     # Organization ID is a required field.
     if not options or not options.get('organization-id', None):
         raise CLIFactoryError('Please provide a valid ORG ID.')
@@ -435,6 +438,7 @@ def make_product(options=None):
     return create_object(Product, args, options)
 
 
+@cacheable
 def make_proxy(options=None):
     """
     Usage::
@@ -452,7 +456,6 @@ def make_proxy(options=None):
         -h, --help                      print help
 
     """
-
     args = {
         u'name': gen_alphanumeric(),
     }
@@ -470,6 +473,7 @@ def make_proxy(options=None):
     return create_object(Proxy, args, options)
 
 
+@cacheable
 def make_repository(options=None):
     """
     Usage::
@@ -499,7 +503,6 @@ def make_repository(options=None):
         -h, --help                              print help
 
     """
-
     # Product ID is a required field.
     if not options or not options.get('product-id', None):
         raise CLIFactoryError('Please provide a valid Product ID.')
@@ -523,6 +526,7 @@ def make_repository(options=None):
     return create_object(Repository, args, options)
 
 
+@cacheable
 def make_role(options=None):
     """Usage::
 
@@ -532,13 +536,13 @@ def make_role(options=None):
 
         --name NAME
     """
-
     # Assigning default values for attributes
     args = {u'name': gen_alphanumeric(6)}
 
     return create_object(Role, args, options)
 
 
+@cacheable
 def make_subnet(options=None):
     """
     Usage::
@@ -573,7 +577,6 @@ def make_subnet(options=None):
         -h, --help                    print help
 
     """
-
     args = {
         u'dhcp-id': None,
         u'dns-id': None,
@@ -596,6 +599,7 @@ def make_subnet(options=None):
     return create_object(Subnet, args, options)
 
 
+@cacheable
 def make_sync_plan(options=None):
     """
     Usage::
@@ -624,7 +628,6 @@ def make_sync_plan(options=None):
         -h, --help                              print help
 
     """
-
     # Organization ID is a required field.
     if not options or not options.get('organization-id', None):
         raise CLIFactoryError('Please provide a valid ORG ID.')
@@ -643,6 +646,7 @@ def make_sync_plan(options=None):
     return create_object(SyncPlan, args, options)
 
 
+@cacheable
 def make_content_host(options=None):
     """
     Usage::
@@ -728,6 +732,7 @@ def make_content_host(options=None):
     return create_object(ContentHost, args, options)
 
 
+@cacheable
 def make_host(options=None):
     """
     Usage::
@@ -878,6 +883,7 @@ def make_host(options=None):
     return create_object(Host, args, options)
 
 
+@cacheable
 def make_host_collection(options=None):
     """
     Usage::
@@ -909,7 +915,6 @@ def make_host_collection(options=None):
          -h, --help                                       print help
 
     """
-
     # Organization ID is required
     if not options or not options.get('organization-id', None):
         raise CLIFactoryError('Please provide a valid ORGANIZATION_ID.')
@@ -930,6 +935,7 @@ def make_host_collection(options=None):
     return create_object(HostCollection, args, options)
 
 
+@cacheable
 def make_user(options=None):
     """
     Usage::
@@ -955,7 +961,6 @@ def make_user(options=None):
         -h, --help                          print help
 
     """
-
     login = gen_alphanumeric(6)
 
     # Assigning default values for attributes
@@ -980,6 +985,7 @@ def make_user(options=None):
     return create_object(User, args, options)
 
 
+@cacheable
 def make_compute_resource(options=None):
     """
     Usage::
@@ -1038,6 +1044,7 @@ def make_compute_resource(options=None):
     return create_object(ComputeResource, args, options)
 
 
+@cacheable
 def make_org(options=None):
     """
     Usage::
@@ -1082,7 +1089,6 @@ def make_org(options=None):
         -h, --help                                  print help
 
     """
-
     # Assigning default values for attributes
     args = {
         u'compute-resource-ids': None,
@@ -1103,6 +1109,7 @@ def make_org(options=None):
     return create_object(Org, args, options)
 
 
+@cacheable
 def make_os(options=None):
     """
     Usage::
@@ -1148,6 +1155,7 @@ def make_os(options=None):
     return create_object(OperatingSys, args, options)
 
 
+@cacheable
 def make_domain(options=None):
     """
     Usage::
@@ -1179,6 +1187,7 @@ def make_domain(options=None):
     return create_object(Domain, args, options)
 
 
+@cacheable
 def make_hostgroup(options=None):
     """
     Usage::
@@ -1250,6 +1259,7 @@ def make_hostgroup(options=None):
     return create_object(HostGroup, args, options)
 
 
+@cacheable
 def make_medium(options=None):
     """
     Usage::
@@ -1301,6 +1311,7 @@ def make_medium(options=None):
     return create_object(Medium, args, options)
 
 
+@cacheable
 def make_environment(options=None):
     """
     Usage::
@@ -1328,6 +1339,7 @@ def make_environment(options=None):
     return create_object(Environment, args, options)
 
 
+@cacheable
 def make_lifecycle_environment(options=None):
     """
     Usage::
@@ -1349,7 +1361,6 @@ def make_lifecycle_environment(options=None):
         -h, --help                  print help
 
     """
-
     # Organization ID is required
     if not options or not options.get('organization-id', None):
         raise CLIFactoryError('Please provide a valid ORG ID.')
@@ -1370,6 +1381,7 @@ def make_lifecycle_environment(options=None):
     return create_object(LifecycleEnvironment, args, options)
 
 
+@cacheable
 def make_template(options=None):
     """
     Usage::

--- a/robottelo/test.py
+++ b/robottelo/test.py
@@ -73,6 +73,7 @@ class APITestCase(TestCase):
 
 class CLITestCase(TestCase):
     """Test case for CLI tests."""
+    _multiprocess_can_split_ = True
 
     @classmethod
     def setUpClass(cls):

--- a/tests/foreman/cli/test_activationkey.py
+++ b/tests/foreman/cli/test_activationkey.py
@@ -39,18 +39,19 @@ class TestActivationKey(CLITestCase):
         super(TestActivationKey, self).setUp()
 
         if TestActivationKey.org is None:
-            TestActivationKey.org = make_org()
+            TestActivationKey.org = make_org(cached=True)
         if TestActivationKey.env1 is None:
             TestActivationKey.env1 = make_lifecycle_environment(
-                {u'organization-id': TestActivationKey.org['id']})
+                {u'organization-id': TestActivationKey.org['id']},
+                cached=True)
         if TestActivationKey.env2 is None:
             TestActivationKey.env2 = make_lifecycle_environment(
                 {u'organization-id': TestActivationKey.org['id'],
                  u'prior': TestActivationKey.env1['label']})
         if TestActivationKey.product is None:
             TestActivationKey.product = make_product(
-                {u'organization-id': TestActivationKey.org['id']})
-
+                {u'organization-id': TestActivationKey.org['id']},
+                cached=True)
         if TestActivationKey.library is None:
             TestActivationKey.library = LifecycleEnvironment.info(
                 {'organization-id': TestActivationKey.org['id'],
@@ -244,7 +245,7 @@ class TestActivationKey(CLITestCase):
         """
 
         try:
-            org_obj = make_org()
+            org_obj = make_org(cached=True)
             con_view = make_content_view({
                 u'organization-id': org_obj['id'],
                 u'name': test_data['content-view']
@@ -1313,7 +1314,7 @@ class TestActivationKey(CLITestCase):
 
         """
         try:
-            org = make_org()
+            org = make_org(cached=True)
             activation_key = self._make_activation_key({
                 u'organization-id': org['id'],
             })
@@ -1388,7 +1389,7 @@ class TestActivationKey(CLITestCase):
         manifest = manifests.clone()
         upload_file(manifest, remote_file=manifest)
         try:
-            org = make_org()
+            org = make_org(cached=True)
             activation_key = self._make_activation_key({
                 u'organization-id': org['id'],
             })

--- a/tests/foreman/cli/test_contenthost.py
+++ b/tests/foreman/cli/test_contenthost.py
@@ -36,11 +36,11 @@ class TestContentHost(CLITestCase):
         super(TestContentHost, self).setUp()
 
         if TestContentHost.NEW_ORG is None:
-            TestContentHost.NEW_ORG = make_org()
+            TestContentHost.NEW_ORG = make_org(cached=True)
         if TestContentHost.NEW_LIFECYCLE is None:
             TestContentHost.NEW_LIFECYCLE = make_lifecycle_environment(
-                {u'organization-id': TestContentHost.NEW_ORG['id']}
-            )
+                {u'organization-id': TestContentHost.NEW_ORG['id']},
+                cached=True)
         if TestContentHost.LIBRARY is None:
             library_result = LifecycleEnvironment.info(
                 {u'organization-id': TestContentHost.NEW_ORG['id'],

--- a/tests/foreman/cli/test_contentviews.py
+++ b/tests/foreman/cli/test_contentviews.py
@@ -88,7 +88,7 @@ class TestContentView(CLITestCase):
         if TestContentView.rhel_content_org is not None:
             return
 
-        TestContentView.rhel_content_org = make_org()
+        TestContentView.rhel_content_org = make_org(cached=True)
         manifest = manifests.clone()
         finished_task = Organization(
             id=TestContentView.rhel_content_org['id']
@@ -135,17 +135,19 @@ class TestContentView(CLITestCase):
         super(TestContentView, self).setUp()
 
         if TestContentView.org is None:
-            TestContentView.org = make_org()
+            TestContentView.org = make_org(cached=True)
         if TestContentView.env1 is None:
             TestContentView.env1 = make_lifecycle_environment(
-                {u'organization-id': TestContentView.org['id']})
+                {u'organization-id': TestContentView.org['id']},
+                cached=True)
         if TestContentView.env2 is None:
             TestContentView.env2 = make_lifecycle_environment(
                 {u'organization-id': TestContentView.org['id'],
                  u'prior': TestContentView.env1['label']})
         if TestContentView.product is None:
             TestContentView.product = make_product(
-                {u'organization-id': TestContentView.org['id']})
+                {u'organization-id': TestContentView.org['id']},
+                cached=True)
 
     @data(*positive_create_data())
     def test_cv_create_cli(self, test_data):
@@ -158,7 +160,7 @@ class TestContentView(CLITestCase):
         @assert: content views are created
 
         """
-        org_obj = make_org()
+        org_obj = make_org(cached=True)
 
         result = Org.info({'id': org_obj['id']})
         self.assertEqual(result.return_code, 0, "Failed to create object")
@@ -189,7 +191,7 @@ class TestContentView(CLITestCase):
 
         """
 
-        org_obj = make_org()
+        org_obj = make_org(cached=True)
 
         result = Org.info({'id': org_obj['id']})
         self.assertEqual(result.return_code, 0, "Failed to create object")
@@ -231,7 +233,7 @@ class TestContentView(CLITestCase):
 
         """
 
-        org_obj = make_org()
+        org_obj = make_org(cached=True)
 
         result = Org.info({'id': org_obj['id']})
         self.assertEqual(result.return_code, 0, "Failed to create object")
@@ -286,7 +288,7 @@ class TestContentView(CLITestCase):
 
         """
 
-        org_obj = make_org()
+        org_obj = make_org(cached=True)
 
         result = Org.info({'id': org_obj['id']})
         self.assertEqual(result.return_code, 0, "Failed to create object")
@@ -1842,7 +1844,7 @@ class TestContentView(CLITestCase):
         no_rights_user = make_user({'password': password})
         no_rights_user['password'] = password
 
-        org_obj = make_org()
+        org_obj = make_org(cached=True)
 
         result = Org.info({'id': org_obj['id']})
         self.assertEqual(result.return_code, 0, "Failed to create object")

--- a/tests/foreman/cli/test_gpgkey.py
+++ b/tests/foreman/cli/test_gpgkey.py
@@ -62,18 +62,7 @@ class TestGPGKey(CLITestCase):
 
         """
         CLITestCase.setUpClass()
-        cls.org = cls.create_org()
-
-    @classmethod
-    def create_org(cls):
-        """Creates and returns an organization"""
-        label = gen_alphanumeric(6)
-        org = make_org({'label': label})
-        result = Org.exists(tuple_search=('id', org['id']))
-
-        org.update(result.stdout)
-
-        return org
+        cls.org = make_org(cached=True)
 
     def create_gpg_key_file(self, content=None):
         """Creates a fake GPG Key file and returns its path or None if an error

--- a/tests/foreman/cli/test_host.py
+++ b/tests/foreman/cli/test_host.py
@@ -35,7 +35,7 @@ class HostTestCase(CLITestCase):
             location = make_location()
             medium = make_medium()
             ptable = make_partition_table()
-            organization = make_org()
+            organization = make_org(cached=True)
             os = make_os({
                 u'architecture-ids': architecture['id'],
                 u'medium-ids': medium['id'],

--- a/tests/foreman/cli/test_host_collection.py
+++ b/tests/foreman/cli/test_host_collection.py
@@ -33,11 +33,11 @@ class TestHostCollection(CLITestCase):
         super(TestHostCollection, self).setUp()
 
         if TestHostCollection.org is None:
-            TestHostCollection.org = make_org()
+            TestHostCollection.org = make_org(cached=True)
         if TestHostCollection.new_lifecycle is None:
             TestHostCollection.new_lifecycle = make_lifecycle_environment(
-                {u'organization-id': TestHostCollection.org['id']}
-            )
+                {u'organization-id': TestHostCollection.org['id']},
+                cached=True)
         if TestHostCollection.library is None:
             library_result = LifecycleEnvironment.info(
                 {u'organization-id': TestHostCollection.org['id'],

--- a/tests/foreman/cli/test_lifecycleenvironment.py
+++ b/tests/foreman/cli/test_lifecycleenvironment.py
@@ -24,7 +24,7 @@ class TestLifeCycleEnvironment(CLITestCase):
         super(TestLifeCycleEnvironment, self).setUp()
 
         if TestLifeCycleEnvironment.org is None:
-            TestLifeCycleEnvironment.org = make_org()
+            TestLifeCycleEnvironment.org = make_org(cached=True)
 
     # Issues validation
 
@@ -434,7 +434,7 @@ class TestLifeCycleEnvironment(CLITestCase):
 
         """
         try:
-            org = make_org()
+            org = make_org(cached=True)
             payload = {
                 'organization-id': org['id'],
             }

--- a/tests/foreman/cli/test_org.py
+++ b/tests/foreman/cli/test_org.py
@@ -937,9 +937,10 @@ class TestOrg(CLITestCase):
         """
 
         new_obj = make_org()
-        env_result = make_lifecycle_environment({
-            'organization-id': new_obj['id'],
-        })
+        env_result = make_lifecycle_environment(
+            {'organization-id': new_obj['id']},
+            cached=True
+        )
 
         # Can we list the new environment?
         environment = LifecycleEnvironment.list({
@@ -967,9 +968,10 @@ class TestOrg(CLITestCase):
         """
 
         new_obj = make_org()
-        env_result = make_lifecycle_environment({
-            'organization-id': new_obj['id'],
-        })
+        env_result = make_lifecycle_environment(
+            {'organization-id': new_obj['id']},
+            cached=True
+        )
 
         # Can we list the new environment?
         environment = LifecycleEnvironment.list({

--- a/tests/foreman/cli/test_product.py
+++ b/tests/foreman/cli/test_product.py
@@ -24,7 +24,7 @@ class TestProduct(CLITestCase):
         super(TestProduct, self).setUp()
 
         if TestProduct.org is None:
-            TestProduct.org = make_org()
+            TestProduct.org = make_org(cached=True)
 
     @run_only_on('sat')
     @skip_if_bug_open('bugzilla', 1096320)

--- a/tests/foreman/cli/test_repository.py
+++ b/tests/foreman/cli/test_repository.py
@@ -51,11 +51,11 @@ class TestRepository(CLITestCase):
         super(TestRepository, self).setUp()
 
         if TestRepository.org is None:
-            TestRepository.org = make_org()
+            TestRepository.org = make_org(cached=True)
         if TestRepository.product is None:
-            TestRepository.product = make_product({
-                u'organization-id': TestRepository.org['id'],
-            })
+            TestRepository.product = make_product(
+                {u'organization-id': TestRepository.org['id']},
+                cached=True)
 
     def _make_repository(self, options=None):
         """Makes a new repository and asserts its success"""

--- a/tests/foreman/cli/test_subscription.py
+++ b/tests/foreman/cli/test_subscription.py
@@ -21,7 +21,7 @@ class TestSubscription(CLITestCase):
         """Tests for content-view via Hammer CLI"""
 
         super(TestSubscription, self).setUp()
-        self.org = make_org()
+        self.org = make_org(cached=True)
         self.manifest = manifests.clone()
 
     def test_manifest_upload(self):

--- a/tests/foreman/cli/test_syncplan.py
+++ b/tests/foreman/cli/test_syncplan.py
@@ -24,7 +24,7 @@ class TestSyncPlan(CLITestCase):
         super(TestSyncPlan, self).setUp()
 
         if TestSyncPlan.org is None:
-            TestSyncPlan.org = make_org()
+            TestSyncPlan.org = make_org(cached=True)
 
     def _make_sync_plan(self, options=None):
         """Make a sync plan and asserts its success"""


### PR DESCRIPTION
I chose to have the caching off by default.
Initial tests show time savings between 4-8 minutes for all CLI
tests.
