### PR TITLE
Fix for the missing proceed_edit locator.

### DIFF
--- a/robottelo/ui/factory.py
+++ b/robottelo/ui/factory.py
@@ -121,7 +121,6 @@ def make_org(session, force_context=False, **kwargs):
         u'envs': None,
         u'hostgroups': None,
         u'locations': None,
-        u'edit': True,
         u'select': True,
     }
     page = session.nav.go_to_org
@@ -145,7 +144,6 @@ def make_loc(session, force_context=False, **kwargs):
         u'envs': None,
         u'hostgroups': None,
         u'organizations': None,
-        u'edit': True,
         u'select': True,
     }
     page = session.nav.go_to_loc

--- a/robottelo/ui/location.py
+++ b/robottelo/ui/location.py
@@ -13,9 +13,7 @@ from selenium.webdriver.support.select import Select
 
 
 class Location(Base):
-    """
-    Implements CRUD functions for UI
-    """
+    """Implements CRUD functions for UI"""
 
     def _configure_location(self, users=None, proxies=None, subnets=None,
                             resources=None, medias=None, templates=None,
@@ -26,9 +24,7 @@ class Location(Base):
                             new_templates=None, new_domains=None,
                             new_envs=None, new_hostgroups=None,
                             new_organizations=None, select=None):
-        """
-        Configures different entities of selected location
-        """
+        """Configures different entities of selected location."""
 
         loc = tab_locators
 
@@ -86,10 +82,8 @@ class Location(Base):
     def create(self, name, parent=None, users=None, proxies=None,
                subnets=None, resources=None, medias=None, templates=None,
                domains=None, envs=None, hostgroups=None, organizations=None,
-               edit=False, select=True):
-        """
-        Creates new Location from UI
-        """
+               select=True):
+        """Creates new Location from UI."""
 
         self.wait_until_element(locators["location.new"]).click()
 
@@ -100,7 +94,7 @@ class Location(Base):
                     locators["location.parent"])
                     ).select_by_visible_text(parent)
             self.wait_until_element(common_locators["submit"]).click()
-            if edit:
+            if self.wait_until_element(locators["location.proceed_to_edit"]):
                 self.wait_until_element(
                     locators["location.proceed_to_edit"]).click()
             self._configure_location(users=users, proxies=proxies,
@@ -116,9 +110,7 @@ class Location(Base):
             raise Exception("Could not create new location.")
 
     def search(self, name):
-        """
-        Searches existing location from UI
-        """
+        """Searches existing location from UI."""
         nav(self.browser).go_to_loc()
         self.wait_for_ajax()
         element = self.search_entity(name, locators["location.select_name"])
@@ -132,9 +124,7 @@ class Location(Base):
                new_resources=None, new_medias=None, new_templates=None,
                new_domains=None, new_envs=None, new_hostgroups=None,
                select=False):
-        """
-        Update Location in UI
-        """
+        """Update Location in UI. """
         org_object = self.search(loc_name)
         self.wait_for_ajax()
         if org_object:
@@ -166,9 +156,7 @@ class Location(Base):
                 "Unable to find the location '%s' for update." % loc_name)
 
     def delete(self, name, really):
-        """
-        Deletes a location.
-        """
+        """Deletes a location."""
 
         self.delete_entity(name, really, locators["location.select_name"],
                            locators['location.delete'],

--- a/robottelo/ui/org.py
+++ b/robottelo/ui/org.py
@@ -13,9 +13,7 @@ from selenium.webdriver.support.select import Select
 
 
 class Org(Base):
-    """
-    Provides the CRUD functionality for Organization
-    """
+    """Provides the CRUD functionality for Organization."""
 
     def _configure_org(self, users=None, proxies=None, subnets=None,
                        resources=None, medias=None, templates=None,
@@ -25,9 +23,7 @@ class Org(Base):
                        new_templates=None, new_domains=None,
                        new_envs=None, new_hostgroups=None, new_locations=None,
                        select=None):
-        """
-        Configures different entities of selected organization
-        """
+        """Configures different entities of selected organization."""
 
         loc = tab_locators
 
@@ -85,10 +81,8 @@ class Org(Base):
     def create(self, org_name=None, parent_org=None, label=None, desc=None,
                users=None, proxies=None, subnets=None, resources=None,
                medias=None, templates=None, domains=None, envs=None,
-               hostgroups=None, locations=None, edit=False, select=True):
-        """
-        Create Organization in UI
-        """
+               hostgroups=None, locations=None, select=True):
+        """Create Organization in UI."""
         if self.wait_until_element(locators["org.new"]):
             self.wait_until_element(locators["org.new"]).click()
             if parent_org:
@@ -102,9 +96,9 @@ class Org(Base):
                 self.field_update("org.desc", desc)
             self.wait_until_element(common_locators["submit"]).click()
             self.wait_for_ajax()
-            if edit:
-                self.wait_until_element(locators
-                                        ["org.proceed_to_edit"]).click()
+            if self.wait_until_element(locators["org.proceed_to_edit"]):
+                self.wait_until_element(
+                    locators["org.proceed_to_edit"]).click()
             self._configure_org(users=users, proxies=proxies,
                                 subnets=subnets, resources=resources,
                                 medias=medias, templates=templates,
@@ -118,9 +112,7 @@ class Org(Base):
                 "Unable to create the Organization '%s'" % org_name)
 
     def search(self, name):
-        """
-        Searches existing Organization from UI
-        """
+        """Searches existing Organization from UI."""
         nav(self.browser).go_to_org()
         self.wait_for_ajax()
         element = self.search_entity(name, locators["org.org_name"])
@@ -134,9 +126,7 @@ class Org(Base):
                new_resources=None, new_medias=None, new_templates=None,
                new_domains=None, new_envs=None, new_hostgroups=None,
                select=False, new_desc=None):
-        """
-        Update Organization in UI
-        """
+        """Update Organization in UI."""
         org_object = self.search(org_name)
         self.wait_for_ajax()
         if org_object:
@@ -174,9 +164,7 @@ class Org(Base):
                 "Unable to find the organization '%s' for update." % org_name)
 
     def remove(self, org_name, really):
-        """
-        Remove Organization in UI
-        """
+        """Remove Organization in UI."""
 
         searched = self.search(org_name)
         if searched:

--- a/tests/foreman/ui/test_location.py
+++ b/tests/foreman/ui/test_location.py
@@ -76,7 +76,7 @@ class Location(UITestCase):
 
         """
         with Session(self.browser) as session:
-            make_loc(session, name=loc_name, edit=False)
+            make_loc(session, name=loc_name)
             error = session.nav.wait_until_element(
                 common_locators["name_haserror"])
             self.assertIsNotNone(error)
@@ -92,7 +92,7 @@ class Location(UITestCase):
 
         loc_name = ""
         with Session(self.browser) as session:
-            make_loc(session, name=loc_name, edit=False)
+            make_loc(session, name=loc_name)
             error = session.nav.wait_until_element(
                 common_locators["name_haserror"])
             self.assertIsNotNone(error)
@@ -108,7 +108,7 @@ class Location(UITestCase):
 
         loc_name = "    "
         with Session(self.browser) as session:
-            make_loc(session, name=loc_name, edit=False)
+            make_loc(session, name=loc_name)
             error = session.nav.wait_until_element(
                 common_locators["name_haserror"])
             self.assertIsNotNone(error)
@@ -128,7 +128,7 @@ class Location(UITestCase):
         with Session(self.browser) as session:
             make_loc(session, name=loc_name)
             self.assertIsNotNone(self.location.search(loc_name))
-            make_loc(session, name=loc_name, edit=False)
+            make_loc(session, name=loc_name)
             error = session.nav.wait_until_element(
                 common_locators["name_haserror"])
             self.assertIsNotNone(error)
@@ -541,7 +541,7 @@ class Location(UITestCase):
         env = entities.Environment(name=env_name).create()
         self.assertEqual(env['name'], env_name)
         with Session(self.browser) as session:
-            make_loc(session, name=loc_name, envs=[env_name], edit=True)
+            make_loc(session, name=loc_name, envs=[env_name])
             self.location.search(loc_name).click()
             session.nav.wait_until_element(
                 tab_locators["context.tab_env"]).click()
@@ -580,7 +580,7 @@ class Location(UITestCase):
         ).create()
         self.assertEqual(subnet['name'], subnet_name)
         with Session(self.browser) as session:
-            make_loc(session, name=loc_name, subnets=[subnet_name], edit=True)
+            make_loc(session, name=loc_name, subnets=[subnet_name])
             self.location.search(loc_name).click()
             session.nav.wait_until_element(
                 tab_locators["context.tab_subnets"]).click()
@@ -615,7 +615,7 @@ class Location(UITestCase):
         domain = entities.Domain(name=domain_name).create()
         self.assertEqual(domain['name'], domain_name)
         with Session(self.browser) as session:
-            make_loc(session, name=loc_name, domains=[domain_name], edit=True)
+            make_loc(session, name=loc_name, domains=[domain_name])
             self.location.search(loc_name).click()
             session.nav.wait_until_element(
                 tab_locators["context.tab_domains"]).click()
@@ -658,7 +658,7 @@ class Location(UITestCase):
             password=password).create()
         self.assertEqual(user['login'], user_name)
         with Session(self.browser) as session:
-            make_loc(session, name=loc_name, users=[user_name], edit=True)
+            make_loc(session, name=loc_name, users=[user_name])
             self.location.search(loc_name).click()
             session.nav.wait_until_element(
                 tab_locators["context.tab_users"]).click()
@@ -691,7 +691,7 @@ class Location(UITestCase):
         host_grp = entities.HostGroup(name=host_grp_name).create()
         self.assertEqual(host_grp['name'], host_grp_name)
         with Session(self.browser) as session:
-            make_loc(session, name=loc_name, edit=True)
+            make_loc(session, name=loc_name)
             self.location.search(loc_name).click()
             session.nav.wait_until_element(
                 tab_locators["context.tab_hostgrps"]).click()
@@ -731,8 +731,7 @@ class Location(UITestCase):
         ).create()
         self.assertEqual(resource['name'], resource_name)
         with Session(self.browser) as session:
-            make_loc(session, name=loc_name, resources=[resource_name],
-                     edit=True)
+            make_loc(session, name=loc_name, resources=[resource_name])
             self.location.search(loc_name).click()
             session.nav.wait_until_element(
                 tab_locators["context.tab_resources"]).click()
@@ -770,7 +769,7 @@ class Location(UITestCase):
         ).create()
         self.assertEqual(medium['name'], medium_name)
         with Session(self.browser) as session:
-            make_loc(session, name=loc_name, medias=[medium_name], edit=True)
+            make_loc(session, name=loc_name, medias=[medium_name])
             self.location.search(loc_name).click()
             session.nav.wait_until_element(
                 tab_locators["context.tab_media"]).click()
@@ -818,7 +817,7 @@ class Location(UITestCase):
             make_templates(session, name=template, template_path=template_path,
                            template_type=temp_type, custom_really=True)
             self.assertIsNotNone(self.template.search(template))
-            make_loc(session, name=loc_name, edit=True)
+            make_loc(session, name=loc_name)
             self.location.search(loc_name).click()
             session.nav.wait_until_element(
                 tab_locators["context.tab_template"]).click()

--- a/tests/foreman/ui/test_org.py
+++ b/tests/foreman/ui/test_org.py
@@ -246,7 +246,7 @@ class Org(UITestCase):
 
         """
         with Session(self.browser) as session:
-            make_org(session, org_name=org_name, edit=False)
+            make_org(session, org_name=org_name)
             error = session.nav.wait_until_element(
                 common_locators["name_haserror"])
             self.assertIsNotNone(error)
@@ -262,7 +262,7 @@ class Org(UITestCase):
         """
         org_name = ""
         with Session(self.browser) as session:
-            make_org(session, org_name=org_name, edit=False)
+            make_org(session, org_name=org_name)
             error = session.nav.wait_until_element(
                 common_locators["name_haserror"])
             self.assertIsNotNone(error)
@@ -278,7 +278,7 @@ class Org(UITestCase):
         """
         org_name = "    "
         with Session(self.browser) as session:
-            make_org(session, org_name=org_name, edit=False)
+            make_org(session, org_name=org_name)
             error = session.nav.wait_until_element(
                 common_locators["name_haserror"])
             self.assertIsNotNone(error)
@@ -413,8 +413,7 @@ class Org(UITestCase):
         domain = entities.Domain(name=domain_name).create()
         self.assertEqual(domain['name'], domain_name)
         with Session(self.browser) as session:
-            make_org(session, org_name=org_name, domains=[domain_name],
-                     edit=True)
+            make_org(session, org_name=org_name, domains=[domain_name])
             self.org.search(org_name).click()
             session.nav.wait_until_element(
                 tab_locators["context.tab_domains"]).click()
@@ -464,7 +463,7 @@ class Org(UITestCase):
             password=password).create()
         self.assertEqual(user['login'], user_name)
         with Session(self.browser) as session:
-            make_org(session, org_name=org_name, users=[user_name], edit=True)
+            make_org(session, org_name=org_name, users=[user_name])
             self.org.search(org_name).click()
             session.nav.wait_until_element(
                 tab_locators["context.tab_users"]).click()
@@ -499,8 +498,7 @@ class Org(UITestCase):
         host_grp = entities.HostGroup(name=host_grp_name).create()
         self.assertEqual(host_grp['name'], host_grp_name)
         with Session(self.browser) as session:
-            make_org(session, org_name=org_name, hostgroups=[host_grp_name],
-                     edit=True)
+            make_org(session, org_name=org_name, hostgroups=[host_grp_name])
             self.org.search(org_name).click()
             session.nav.wait_until_element(
                 tab_locators["context.tab_hostgrps"]).click()
@@ -719,8 +717,7 @@ class Org(UITestCase):
         ).create()
         self.assertEqual(resource['name'], resource_name)
         with Session(self.browser) as session:
-            make_org(session, org_name=org_name, resources=[resource_name],
-                     edit=True)
+            make_org(session, org_name=org_name, resources=[resource_name])
             self.org.search(org_name).click()
             session.nav.wait_until_element(
                 tab_locators["context.tab_resources"]).click()
@@ -761,7 +758,7 @@ class Org(UITestCase):
         self.assertEqual(medium['name'], medium_name)
         with Session(self.browser) as session:
             make_org(session, org_name=org_name,
-                     medias=[medium_name], edit=True)
+                     medias=[medium_name])
             self.org.search(org_name).click()
             session.nav.wait_until_element(
                 tab_locators["context.tab_media"]).click()
@@ -798,8 +795,7 @@ class Org(UITestCase):
         org_name = gen_string("alpha", 8)
         entities.ConfigTemplate(name=template_name).create()
         with Session(self.browser) as session:
-            make_org(session, org_name=org_name, templates=[template_name],
-                     edit=True)
+            make_org(session, org_name=org_name, templates=[template_name])
             self.org.search(org_name).click()
             session.nav.wait_until_element(
                 tab_locators["context.tab_template"]).click()
@@ -980,8 +976,7 @@ class Org(UITestCase):
         env = entities.Environment(name=env_name).create()
         self.assertEqual(env['name'], env_name)
         with Session(self.browser) as session:
-            make_org(session, org_name=org_name, envs=[env_name],
-                     edit=True)
+            make_org(session, org_name=org_name, envs=[env_name])
             self.org.search(org_name).click()
             session.nav.wait_until_element(
                 tab_locators["context.tab_env"]).click()
@@ -1021,8 +1016,7 @@ class Org(UITestCase):
         ).create()
         self.assertEqual(subnet['name'], subnet_name)
         with Session(self.browser) as session:
-            make_org(session, org_name=org_name, subnets=[subnet_name],
-                     edit=True)
+            make_org(session, org_name=org_name, subnets=[subnet_name])
             self.org.search(org_name).click()
             session.nav.wait_until_element(
                 tab_locators["context.tab_subnets"]).click()


### PR DESCRIPTION
Depending upon whether the org and locator being selected,
the host selection page appears. Now instead of `edit` flag,
depending upon the locator's availability the proceed_edit
button is selected.
