### PR TITLE
Added `enable_repos` function to ui/activationkey module.

### DIFF
--- a/robottelo/ui/activationkey.py
+++ b/robottelo/ui/activationkey.py
@@ -191,6 +191,33 @@ class ActivationKey(Base):
             raise Exception(
                 "Couldn't find the selected activation key '%s'" % name)
 
+    def enable_repos(self, name, repos, enable=True):
+        """Enables repository via product_content tab of the activation_key."""
+
+        element = self.search_key(name)
+        strategy, value = locators["ak.prd_content.edit_repo"]
+        strategy1, value1 = locators["ak.prd_content.select_repo"]
+        if element is None:
+            raise UINoSuchElementError(
+                "Couldn't find the selected activation key {0}".format(name))
+        element.click()
+        self.wait_for_ajax()
+        self.wait_until_element(tab_locators["ak.tab_prd_content"]).click()
+        self.wait_for_ajax()
+        for repo in repos:
+            repo_edit = self.wait_until_element((strategy, value % repo))
+            if repo_edit is None:
+                raise Exception("Couldn't find the repo: {0}".format(repo))
+            repo_edit.click()
+            self.wait_for_ajax()
+            repo_select = self.wait_until_element((strategy1, value1 % repo))
+            if enable:
+                Select(repo_select).select_by_visible_text("Override to Yes")
+            else:
+                Select(repo_select).select_by_visible_text("Override to No")
+            self.wait_until_element(common_locators['save']).click()
+            self.wait_for_ajax()
+
     def get_attribute(self, name, locator):
         """
         Get the attribute of selected locator

--- a/robottelo/ui/locators.py
+++ b/robottelo/ui/locators.py
@@ -469,6 +469,8 @@ tab_locators = {
         By.XPATH, "//a[contains(@ui-sref, 'host-collections.list')]"),
     "ak.associations": (
         By.XPATH, "//ul/li[@class='dropdown']/a"),
+    "ak.tab_prd_content": (
+        By.XPATH, "//a[contains(@ui-sref, 'details.products')]/span/span"),
 
     # Manifest / subscriptions
     "subs.tab_details": (
@@ -1176,6 +1178,13 @@ locators = {
     "ak.content_host_name": (
         By.XPATH,
         "//tr[@ng-repeat='contentHost in contentHosts']/td/a"),
+    "ak.prd_content.edit_repo": (
+        By.XPATH,
+        ("//u[contains(.,'%s')]/../../div/form/div/div/span/"
+         "i[contains(@class,'icon-edit')]")),
+    "ak.prd_content.select_repo": (
+        By.XPATH,
+        "//u[contains(.,'%s')]/../../div/form/div/select"),
 
     # Sync Status
     "sync.prd_expander": (

--- a/tests/foreman/smoke/test_ui_smoke.py
+++ b/tests/foreman/smoke/test_ui_smoke.py
@@ -7,7 +7,7 @@ from robottelo.common import conf
 from robottelo.common import manifests
 from robottelo.common.constants import (
     FAKE_0_PUPPET_REPO, GOOGLE_CHROME_REPO, REPO_TYPE, FOREMAN_PROVIDERS,
-    DOMAIN, DEFAULT_ORG, DEFAULT_LOC, RHVA_REPO_TREE)
+    DOMAIN, DEFAULT_ORG, DEFAULT_LOC, RHVA_REPO_TREE, REPOSET)
 from robottelo.common.ssh import upload_file
 from robottelo.test import UITestCase
 from robottelo.ui.factory import (make_user, make_org,
@@ -233,7 +233,6 @@ class TestSmoke(UITestCase):
         activation_key_name = gen_string("alpha", 6)
         env_name = gen_string("alpha", 6)
         product_name = "Red Hat Employee Subscription"
-        repo_name = "rhel-6-server-rhev-agent-rpms"
         repo_names = [
             "Red Hat Enterprise Virtualization Agents for RHEL 6 Server "
             "RPMs x86_64 6.5",
@@ -298,6 +297,8 @@ class TestSmoke(UITestCase):
             self.activationkey.associate_product(
                 activation_key_name, [product_name]
             )
+            self.activationkey.enable_repos(activation_key_name,
+                                            [REPOSET['rhva6']])
             self.assertIsNotNone(
                 self.activationkey.wait_until_element(
                     common_locators["alert.success"]))
@@ -332,11 +333,12 @@ class TestSmoke(UITestCase):
                     "failed to register client:: {0} and return code: {1}"
                     .format(result.stderr, result.return_code)
                 )
-                # FIXME:- The below step needs to be automated via UI.
+                # FIXME:- Required for rhel65 clients as sub-man < 1.10
+                # The below block needs to be removed when rhel65 testing stops
                 # Enable Red Hat Enterprise Virtualization Agents repo via cli
                 result = vm.run(
-                    'yum-config-manager --enable {0}'
-                    .format(repo_name)
+                    'subscription-manager repos --enable '
+                    'rhel-6-server-rhev-agent-rpms'
                 )
                 self.assertEqual(
                     result.return_code, 0,


### PR DESCRIPTION
This function helps us to enable particular repos,
which by default are disabled.

Changing default settings for content hosts that register with
this activation key requires subscription-manager version 1.10
or newer to be installed on that host.

For rhel65 the installed version is 1.9 on the clients, hence
Enabling the repo via the UI doesn't enabled the repo.

Also enabling repos uses the sub-man instead of yum-config-manager.
