### PR TITLE
Automatically profile with cProfile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,11 +1,12 @@
 # Variables -------------------------------------------------------------------
 
-ROBOTTELO_TESTS_PATH=tests/robottelo/
-FOREMAN_TESTS_PATH=tests/foreman/
 FOREMAN_API_TESTS_PATH=$(join $(FOREMAN_TESTS_PATH), api)
 FOREMAN_CLI_TESTS_PATH=$(join $(FOREMAN_TESTS_PATH), cli)
-FOREMAN_UI_TESTS_PATH=$(join $(FOREMAN_TESTS_PATH), ui)
 FOREMAN_SMOKE_TESTS_PATH=$(join $(FOREMAN_TESTS_PATH), smoke)
+FOREMAN_TESTS_PATH=tests/foreman/
+FOREMAN_UI_TESTS_PATH=$(join $(FOREMAN_TESTS_PATH), ui)
+NOSETESTS=python -m cProfile -o $@.pstats $$(which nosetests)
+ROBOTTELO_TESTS_PATH=tests/robottelo/
 
 # Commands --------------------------------------------------------------------
 
@@ -35,30 +36,30 @@ test-docstrings:
 	testimony validate_docstring tests/foreman/ui
 
 test-robottelo:
-	nosetests -c robottelo.properties $(ROBOTTELO_TESTS_PATH)
+	$(NOSETESTS) -c robottelo.properties $(ROBOTTELO_TESTS_PATH)
 
 test-foreman-api:
-	nosetests -c robottelo.properties $(FOREMAN_API_TESTS_PATH)
+	$(NOSETESTS) -c robottelo.properties $(FOREMAN_API_TESTS_PATH)
 
 test-foreman-api-threaded:
-	nosetests -c robottelo.properties $(FOREMAN_API_TESTS_PATH)\
+	$(NOSETESTS) -c robottelo.properties $(FOREMAN_API_TESTS_PATH)\
 	    --processes=-1 --process-timeout=300
 
 test-foreman-cli:
-	nosetests -c robottelo.properties $(FOREMAN_CLI_TESTS_PATH)
+	$(NOSETESTS) -c robottelo.properties $(FOREMAN_CLI_TESTS_PATH)
 
 test-foreman-cli-threaded:
-	nosetests -c robottelo.properties $(FOREMAN_CLI_TESTS_PATH)\
+	$(NOSETESTS) -c robottelo.properties $(FOREMAN_CLI_TESTS_PATH)\
 	    --processes=-1 --process-timeout=300
 
 test-foreman-ui:
-	nosetests -c robottelo.properties $(FOREMAN_UI_TESTS_PATH)
+	$(NOSETESTS) -c robottelo.properties $(FOREMAN_UI_TESTS_PATH)
 
 test-foreman-ui-xvfb:
 	xvfb-run nosetests -c robottelo.properties $(FOREMAN_UI_TESTS_PATH)
 
 test-foreman-smoke:
-	nosetests -c robottelo.properties $(FOREMAN_SMOKE_TESTS_PATH)
+	$(NOSETESTS) -c robottelo.properties $(FOREMAN_SMOKE_TESTS_PATH)
 
 graph-entities:
 	scripts/graph_entities.py | dot -Tsvg -o entities.svg


### PR DESCRIPTION
Make most test tasks in the main makefile collect profiling information. For
example, executing `make test-foreman-cli` will cause a
`test-foreman-cli.pstats` file to be generated. This file can then be
manipulated using any tool that understands the cProfile data format. For
example, Run Snake Run can open the file directly, gprof2dot can generate a call
tree in DOT format, and pyprof2calltree can convert the data into a format that
kcachegrind can understand.

Sort make file variable names alphabetically.
