### PR TITLE
Fetches the error message when manifest upload fails.

### DIFF
--- a/tests/foreman/api/test_repository.py
+++ b/tests/foreman/api/test_repository.py
@@ -259,9 +259,11 @@ class RepositorySyncTestCase(APITestCase):
         cloned_manifest_path = manifests.clone()
         org_id = entities.Organization().create()['id']
         repo = "Red Hat Enterprise Linux 6 Server - RH Common RPMs x86_64 6.3"
-        task_result = entities.Organization(
-            id=org_id).upload_manifest(path=cloned_manifest_path)['result']
-        self.assertEqual(u'success', task_result)
+        task = entities.Organization(
+            id=org_id).upload_manifest(path=cloned_manifest_path)
+        self.assertEqual(
+            u'success', task['result'], task['humanized']['errors']
+        )
         repo_id = utils.enable_rhrepo_and_fetchid(
             "x86_64",
             org_id,

--- a/tests/foreman/api/test_subscription.py
+++ b/tests/foreman/api/test_subscription.py
@@ -23,10 +23,12 @@ class SubscriptionsTestCase(APITestCase):
         """
         cloned_manifest_path = manifests.clone()
         org_id = entities.Organization().create()['id']
-        task_result = entities.Organization(id=org_id).upload_manifest(
+        task = entities.Organization(id=org_id).upload_manifest(
             path=cloned_manifest_path
-        )['result']
-        self.assertEqual(u'success', task_result)
+        )
+        self.assertEqual(
+            u'success', task['result'], task['humanized']['errors']
+        )
 
     def test_positive_delete_1(self):
         """@Test: Delete an Uploaded manifest.
@@ -38,14 +40,18 @@ class SubscriptionsTestCase(APITestCase):
         """
         cloned_manifest_path = manifests.clone()
         org_id = entities.Organization().create()['id']
-        task_result = entities.Organization(
+        task = entities.Organization(
             id=org_id
-        ).upload_manifest(path=cloned_manifest_path)['result']
-        self.assertEqual(u'success', task_result)
-        task_result = entities.Organization(
+        ).upload_manifest(path=cloned_manifest_path)
+        self.assertEqual(
+            u'success', task['result'], task['humanized']['errors']
+        )
+        task = entities.Organization(
             id=org_id
-        ).delete_manifest()['result']
-        self.assertEqual(u'success', task_result)
+        ).delete_manifest()
+        self.assertEqual(
+            u'success', task['result'], task['humanized']['errors']
+        )
 
     def test_negative_create_1(self):
         """@Test: Upload same manifest to 2 different Organizations.
@@ -58,11 +64,15 @@ class SubscriptionsTestCase(APITestCase):
         cloned_manifest_path = manifests.clone()
         orgid_one = entities.Organization().create()['id']
         orgid_two = entities.Organization().create()['id']
-        task_result1 = entities.Organization(
+        task1 = entities.Organization(
             id=orgid_one
-        ).upload_manifest(path=cloned_manifest_path)['result']
-        self.assertEqual(u'success', task_result1)
-        task_result2 = entities.Organization(
+        ).upload_manifest(path=cloned_manifest_path)
+        self.assertEqual(
+            u'success', task1['result'], task1['humanized']['errors']
+        )
+        task2 = entities.Organization(
             id=orgid_two
-        ).upload_manifest(path=cloned_manifest_path)['result']
-        self.assertNotEqual(u'success', task_result2)
+        ).upload_manifest(path=cloned_manifest_path)
+        self.assertEqual(
+            u'success', task2['result'], task2['humanized']['errors']
+        )

--- a/tests/foreman/smoke/test_api_smoke.py
+++ b/tests/foreman/smoke/test_api_smoke.py
@@ -1047,11 +1047,12 @@ class TestSmoke(TestCase):
 
         # step 2: Upload manifest
         manifest_path = manifests.clone()
-        task_result = entities.Organization(
+        task = entities.Organization(
             id=org['id']
-        ).upload_manifest(path=manifest_path)['result']
-        self.assertEqual(u'success', task_result)
-
+        ).upload_manifest(path=manifest_path)
+        self.assertEqual(
+            u'success', task['result'], task['humanized']['errors']
+        )
         # step 3.1: Enable RH repo and fetch repository_id
         repo_id = utils.enable_rhrepo_and_fetchid(
             basearch="x86_64",

--- a/tests/foreman/ui/test_activationkey.py
+++ b/tests/foreman/ui/test_activationkey.py
@@ -73,10 +73,12 @@ class ActivationKey(UITestCase):
         else:
             # Upload manifest
             manifest_path = manifests.clone()
-            task_result = entities.Organization(
+            task = entities.Organization(
                 id=self.org_id
-            ).upload_manifest(path=manifest_path)['result']
-            self.assertEqual(u'success', task_result)
+            ).upload_manifest(path=manifest_path)
+            self.assertEqual(
+                u'success', task['result'], task['humanized']['errors']
+            )
             # Enable RH repo and fetch repository_id
             repo_id = utils.enable_rhrepo_and_fetchid(
                 rh_repo['basearch'],
@@ -1173,10 +1175,12 @@ class ActivationKey(UITestCase):
         custom_repo_id = repo_attrs['id']
         # Upload manifest
         manifest_path = manifests.clone()
-        task_result = entities.Organization(
+        task = entities.Organization(
             id=self.org_id
-        ).upload_manifest(path=manifest_path)['result']
-        self.assertEqual(u'success', task_result)
+        ).upload_manifest(path=manifest_path)
+        self.assertEqual(
+            u'success', task['result'], task['humanized']['errors']
+        )
         # Enable RH repo and fetch repository_id
         rhel_repo_id = utils.enable_rhrepo_and_fetchid(
             rh_repo['basearch'],

--- a/tests/foreman/ui/test_contentviews.py
+++ b/tests/foreman/ui/test_contentviews.py
@@ -67,11 +67,12 @@ class TestContentViewsUI(UITestCase):
             # Clone the manifest and fetch it's path.
             manifest_path = manifests.clone()
             # Uploads the manifest and returns the result.
-            task_result = entities.Organization(
+            task = entities.Organization(
                 id=self.org_id
-            ).upload_manifest(path=manifest_path)['result']
-            self.assertEqual(u'success', task_result)
-
+            ).upload_manifest(path=manifest_path)
+            self.assertEqual(
+                u'success', task['result'], task['humanized']['errors']
+            )
             # Enables the RedHat repo and fetches it's Id.
             repo_id = utils.enable_rhrepo_and_fetchid(
                 rh_repo['basearch'],


### PR DESCRIPTION
Uploading manifest seems to fail frequently when uploading at the
jenkins end. This will help us know the exact error.
