### PR TITLE
[DONOTMERGE] Skip a test which is failing due to BZ 1173742

### DIFF
--- a/tests/foreman/smoke/test_api_smoke.py
+++ b/tests/foreman/smoke/test_api_smoke.py
@@ -6,7 +6,7 @@ from robottelo.api import client, utils
 from robottelo.api.utils import status_code_error
 from robottelo.common.constants import FAKE_0_PUPPET_REPO, GOOGLE_CHROME_REPO
 from robottelo.common.decorators import bz_bug_is_open, skip_if_bug_open
-from robottelo.common.helpers import get_server_credentials
+from robottelo.common.helpers import get_server_credentials, get_server_url
 from robottelo.common import conf
 from robottelo.common import helpers
 from robottelo.common import manifests
@@ -637,6 +637,9 @@ class TestAvailableURLs(TestCase):
         @Assert: The paths returned are equal to ``API_PATHS``.
 
         """
+        if bz_bug_is_open(1173742) and 'qe-sat6-rhel' in get_server_url():
+            self.skipTest('BZ bug 1173742 is open.')
+
         # Did the server give us any paths at all?
         response = client.get(
             self.path,


### PR DESCRIPTION
Issuing an HTTP GET request to `/api/v2` should return a set of paths in this
format:

```
{
    u'content_views': {
        u'…': u'/katello/api/content_views/:id',
        u'…': u'/katello/api/content_views/:id/available_puppet_modules',
        u'…': u'/katello/api/organizations/:organization_id/content_views',
        u'…': u'/katello/api/organizations/:organization_id/content_views',
    },
    u'…': {…}
}
```

A response in this format is actually returned:

```
u'List filters': u'/katello/api/content_views/:content_view_id/filters',
u'List gpg keys': u'/katello/api/gpg_keys',
u'List host collections': u'/katello/api/host_collections',
```

The above issue occurs only on recent composes. It does not occur in older
composes or upstream (Foreman).

Test result when run against upstream:

```
$ nosetests tests/foreman/smoke/test_api_smoke.py -m test_get_links
.
----------------------------------------------------------------------
Ran 1 test in 1.863s

OK
```

Test result when run against a recent compose:

```
$ nosetests tests/foreman/smoke/test_api_smoke.py -m test_get_links
S
----------------------------------------------------------------------
Ran 1 test in 0.915s

OK (SKIP=1)
```
