### PR TITLE
Drop markdown code fences

### DIFF
--- a/_posts/2014-12-12-better-test-result-output.md
+++ b/_posts/2014-12-12-better-test-result-output.md
@@ -11,7 +11,7 @@ If you want have the same output as is presented in this post, remove the `nocap
 
 Consider the following Python module:
 
-```python
+{% highlight python %}
 import logging
 import unittest
 
@@ -31,46 +31,44 @@ class TestCase(unittest.TestCase):
         print('something on stdout')
         logging.getLogger(__name__).warning('WARNING')
         self.fail('failed')
-```
+{% endhighlight %}
 
 Running the module with those options enable gives the following result:
 
-```
-$ nosetests --nocapture --nologcapture test_output.py
-something on stdout
-WARNING:test_output:WARNING
-FWARNING:test_output:WARNING
-Fsomething on stdout
-F
-======================================================================
-FAIL: test_logging_stdout (test_output.TestCase)
-----------------------------------------------------------------------
-Traceback (most recent call last):
-  File "/Users/elyezer/code/robottelo/test_output.py", line 19, in test_logging_stdout
-    self.fail('failed')
-AssertionError: failed
+    $ nosetests --nocapture --nologcapture test_output.py
+    something on stdout
+    WARNING:test_output:WARNING
+    FWARNING:test_output:WARNING
+    Fsomething on stdout
+    F
+    ======================================================================
+    FAIL: test_logging_stdout (test_output.TestCase)
+    ----------------------------------------------------------------------
+    Traceback (most recent call last):
+    File "/Users/elyezer/code/robottelo/test_output.py", line 19, in test_logging_stdout
+        self.fail('failed')
+    AssertionError: failed
 
-======================================================================
-FAIL: test_logging (test_output.TestCase)
-----------------------------------------------------------------------
-Traceback (most recent call last):
-  File "/Users/elyezer/code/robottelo/test_output.py", line 14, in test_logging
-    self.fail('failed')
-AssertionError: failed
+    ======================================================================
+    FAIL: test_logging (test_output.TestCase)
+    ----------------------------------------------------------------------
+    Traceback (most recent call last):
+    File "/Users/elyezer/code/robottelo/test_output.py", line 14, in test_logging
+        self.fail('failed')
+    AssertionError: failed
 
-======================================================================
-FAIL: test_stdout (test_output.TestCase)
-----------------------------------------------------------------------
-Traceback (most recent call last):
-  File "/Users/elyezer/code/robottelo/test_output.py", line 10, in test_stdout
-    self.fail('failed')
-AssertionError: failed
+    ======================================================================
+    FAIL: test_stdout (test_output.TestCase)
+    ----------------------------------------------------------------------
+    Traceback (most recent call last):
+    File "/Users/elyezer/code/robottelo/test_output.py", line 10, in test_stdout
+        self.fail('failed')
+    AssertionError: failed
 
-----------------------------------------------------------------------
-Ran 3 tests in 0.002s
+    ----------------------------------------------------------------------
+    Ran 3 tests in 0.002s
 
-FAILED (failures=3)
-```
+    FAILED (failures=3)
 
 As you can see, messages from tests are mixed in with messages from nose, and this results in lines like "Fsomething on stdout". This is not default nose behaviour, but it was done when Robottelo was first created, as the extra output helped find issues.
 
@@ -78,53 +76,51 @@ Robottelo is now much larger and better written, and it is run daily on a Jenkin
 
 Running the example module without those options gives the following result:
 
-```
-$ nosetests test_output.py
-FFF
-======================================================================
-FAIL: test_logging_stdout (test_output.TestCase)
-----------------------------------------------------------------------
-Traceback (most recent call last):
-  File "/Users/elyezer/code/robottelo/test_output.py", line 19, in test_logging_stdout
-    self.fail('failed')
-AssertionError: failed
--------------------- >> begin captured stdout << ---------------------
-something on stdout
+    $ nosetests test_output.py
+    FFF
+    ======================================================================
+    FAIL: test_logging_stdout (test_output.TestCase)
+    ----------------------------------------------------------------------
+    Traceback (most recent call last):
+    File "/Users/elyezer/code/robottelo/test_output.py", line 19, in test_logging_stdout
+        self.fail('failed')
+    AssertionError: failed
+    -------------------- >> begin captured stdout << ---------------------
+    something on stdout
 
---------------------- >> end captured stdout << ----------------------
--------------------- >> begin captured logging << --------------------
-test_output: WARNING: WARNING
---------------------- >> end captured logging << ---------------------
+    --------------------- >> end captured stdout << ----------------------
+    -------------------- >> begin captured logging << --------------------
+    test_output: WARNING: WARNING
+    --------------------- >> end captured logging << ---------------------
 
-======================================================================
-FAIL: test_logging (test_output.TestCase)
-----------------------------------------------------------------------
-Traceback (most recent call last):
-  File "/Users/elyezer/code/robottelo/test_output.py", line 14, in test_logging
-    self.fail('failed')
-AssertionError: failed
--------------------- >> begin captured logging << --------------------
-test_output: WARNING: WARNING
---------------------- >> end captured logging << ---------------------
+    ======================================================================
+    FAIL: test_logging (test_output.TestCase)
+    ----------------------------------------------------------------------
+    Traceback (most recent call last):
+    File "/Users/elyezer/code/robottelo/test_output.py", line 14, in test_logging
+        self.fail('failed')
+    AssertionError: failed
+    -------------------- >> begin captured logging << --------------------
+    test_output: WARNING: WARNING
+    --------------------- >> end captured logging << ---------------------
 
-======================================================================
-FAIL: test_stdout (test_output.TestCase)
-----------------------------------------------------------------------
-Traceback (most recent call last):
-  File "/Users/elyezer/code/robottelo/test_output.py", line 10, in test_stdout
-    self.fail('failed')
-AssertionError: failed
--------------------- >> begin captured stdout << ---------------------
-something on stdout
+    ======================================================================
+    FAIL: test_stdout (test_output.TestCase)
+    ----------------------------------------------------------------------
+    Traceback (most recent call last):
+    File "/Users/elyezer/code/robottelo/test_output.py", line 10, in test_stdout
+        self.fail('failed')
+    AssertionError: failed
+    -------------------- >> begin captured stdout << ---------------------
+    something on stdout
 
---------------------- >> end captured stdout << ----------------------
+    --------------------- >> end captured stdout << ----------------------
 
-----------------------------------------------------------------------
-Ran 3 tests in 0.002s
+    ----------------------------------------------------------------------
+    Ran 3 tests in 0.002s
 
-FAILED (failures=3)
-```
+    FAILED (failures=3)
 
-At the beginning of the output we can see clearly that all three tests have failed (FFF output). And reading the test failures now shows what output corresponds to stdout and what corresponds to logging for that specific test.
+At the beginning of the output we can see clearly that all three tests have failed (`FFF` output). And reading the test failures now shows what output corresponds to stdout and what corresponds to logging for that specific test.
 
 Finally, with this update only relevant output will be shown, because just failures and errors output will be shown.


### PR DESCRIPTION
The markdown parser used by GitHub does not support code fences (triple
backticks). Drop them. In their stead, use either standard markdown code
intentation or tags provided by Liquid. (Jekyll uses Liquid for interpreting
templates.) In cases where syntax highlighting is desirable, use Liquid tags;
otherwise, use standard indentation, as indentation is easier to read.
