### PR TITLE
Added poll_frequency to wait_until_element and wait_for_ajax

### DIFF
--- a/robottelo/ui/base.py
+++ b/robottelo/ui/base.py
@@ -90,7 +90,8 @@ class Base(object):
             if timeout:
                 element = self.wait_until_element(
                     (element_locator[0], element_locator[1] % element_name),
-                    delay=timeout)
+                    timeout=timeout,
+                )
             else:
                 element = self.wait_until_element(
                     (element_locator[0], element_locator[1] % element_name))
@@ -185,16 +186,16 @@ class Base(object):
         else:
             raise Exception("Could not search the entity '%s'" % name)
 
-    def wait_until_element(self, locator, delay=12):
+    def wait_until_element(self, locator, timeout=12, poll_frequency=0.5):
         """
         Wrapper around Selenium's WebDriver that allows you to pause your test
         until an element in the web page is present.
         """
         try:
-            element = WebDriverWait(self.browser, delay).until(
-                EC.visibility_of_element_located(locator)
-            )
-            self.wait_for_ajax()
+            element = WebDriverWait(
+                self.browser, timeout, poll_frequency
+            ).until(EC.visibility_of_element_located(locator))
+            self.wait_for_ajax(poll_frequency=poll_frequency)
             return element
         except TimeoutException as e:
             logging.debug("%s: Timed out waiting for element '%s' to display.",
@@ -227,13 +228,10 @@ class Base(object):
 
         return not (jquery_active or angular_active)
 
-    def wait_for_ajax(self, timeout=30):
-        """
-        Waits for an ajax call to complete until timeout.
-        """
-
+    def wait_for_ajax(self, timeout=30, poll_frequency=0.5):
+        """Waits for an ajax call to complete until timeout."""
         WebDriverWait(
-            self.browser, timeout
+            self.browser, timeout, poll_frequency
         ).until(
             self.ajax_complete, "Timeout waiting for page to load"
         )

--- a/robottelo/ui/contentviews.py
+++ b/robottelo/ui/contentviews.py
@@ -271,13 +271,18 @@ class ContentViews(Base):
         Checks the status of progress bar while publishing and
         promoting the CV to next environment
         """
-
         strategy, value = locators["contentviews.publish_progress"]
-        check_progress = self.wait_until_element((strategy,
-                                                  value % version))
+        check_progress = self.wait_until_element(
+            (strategy, value % version),
+            timeout=6,
+            poll_frequency=2,
+        )
         while check_progress:
-            check_progress = self.wait_until_element((strategy,
-                                                      value % version))
+            check_progress = self.wait_until_element(
+                (strategy, value % version),
+                timeout=6,
+                poll_frequency=2,
+            )
 
     def publish(self, cv_name, comment=None):
         """

--- a/robottelo/ui/navigator.py
+++ b/robottelo/ui/navigator.py
@@ -5,50 +5,49 @@
 Implements Navigator UI
 """
 
-from robottelo.ui.base import Base
+from robottelo.ui.base import Base, UINoSuchElementError
 from robottelo.ui.locators import menu_locators
 from selenium.webdriver.common.action_chains import ActionChains
 
 
 class Navigator(Base):
-    """
-    Quickly navigate through menus and tabs.
-    """
+    """Quickly navigate through menus and tabs."""
 
     def menu_click(self, top_menu_locator, sub_menu_locator,
                    tertiary_menu_locator=None, entity=None):
         menu_element = self.wait_until_element(top_menu_locator)
 
-        if menu_element:
-            ActionChains(self.browser).move_to_element(menu_element).perform()
-            submenu_element = self.wait_until_element(sub_menu_locator)
-            if submenu_element and not tertiary_menu_locator:
-                submenu_element.click()
-            elif submenu_element and tertiary_menu_locator:
-                ActionChains(self.browser).move_to_element(submenu_element).\
-                    perform()
-                if entity:
-                    strategy = tertiary_menu_locator[0]
-                    value = tertiary_menu_locator[1]
-                    tertiary_element = self.\
-                        wait_until_element((strategy,
-                                            value % entity))
-                else:
-                    tertiary_element = self.\
-                        wait_until_element(tertiary_menu_locator)
-                if tertiary_element:
-                    self.browser.execute_script("arguments[0].click();",
-                                                tertiary_element)
-                else:
-                    raise Exception(
-                        "tertiary_menu_locator not found: '%s'" % str(
-                            tertiary_menu_locator))
-            elif submenu_element is None:
-                raise Exception(
-                    "sub_menu_locator not found: '%s'" % str(sub_menu_locator))
-        else:
-            raise Exception(
-                "top_menu_locator not found: '%s'" % str(top_menu_locator))
+        if menu_element is None:
+            raise UINoSuchElementError(
+                u'top_menu_locator not found: {0}'.format(top_menu_locator))
+        ActionChains(
+            self.browser
+        ).move_to_element(menu_element).perform()
+        submenu_element = self.wait_until_element(sub_menu_locator)
+        if submenu_element is None:
+            raise UINoSuchElementError(
+                u'sub_menu_locator not found: {0}'.format(sub_menu_locator))
+        elif submenu_element and not tertiary_menu_locator:
+            submenu_element.click()
+        elif submenu_element and tertiary_menu_locator:
+            ActionChains(
+                self.browser
+            ).move_to_element(submenu_element).perform()
+            if entity:
+                strategy, value = tertiary_menu_locator
+                tertiary_element = self.wait_until_element(
+                    (strategy, value % entity))
+            else:
+                tertiary_element = self.wait_until_element(
+                    tertiary_menu_locator)
+            if tertiary_element is None:
+                raise UINoSuchElementError(
+                    u'Tertiary_menu_locator not found: {0}'
+                    .format(tertiary_menu_locator))
+            self.browser.execute_script(
+                "arguments[0].click();",
+                tertiary_element,
+            )
 
     def go_to_dashboard(self):
         self.menu_click(
@@ -359,7 +358,7 @@ class Navigator(Base):
             return org
         else:
             raise Exception(
-                "Could not select the organization: '{0}'".format(org))
+                u'Could not select the organization: {0}'.format(org))
 
     def go_to_select_loc(self, loc):
         """Selects the specified location.
@@ -383,4 +382,4 @@ class Navigator(Base):
             return loc
         else:
             raise Exception(
-                "Could not select the location: '{0}'".format(loc))
+                u'Could not select the location: {0}'.format(loc))

--- a/robottelo/ui/sync.py
+++ b/robottelo/ui/sync.py
@@ -39,15 +39,21 @@ class Sync(Base):
             prd_exp.click()
         for repo in repos:
             timeout = time.time() + 60 * 10
-            sync_cancel = self.wait_until_element((strategy2,
-                                                   value2 % repo), 3)
+            sync_cancel = self.wait_until_element(
+                (strategy2, value2 % repo),
+                timeout=6,
+                poll_frequency=2,
+            )
             # Waits until sync "cancel" is visible on the UI or times out
             # after 10mins
             while sync_cancel:
                 if time.time() > timeout:
                     break
-                sync_cancel = self.wait_until_element((strategy2,
-                                                       value2 % repo), 3)
+                sync_cancel = self.wait_until_element(
+                    (strategy2, value2 % repo),
+                    timeout=6,
+                    poll_frequency=2,
+                )
             result = self.wait_until_element((strategy1,
                                               value1 % repo), 5).text
             # Updates the result of every sync repo to the repos_result list.
@@ -169,13 +175,19 @@ class Sync(Base):
                     # the below code loops for over 2 mins till the spinner is
                     # visible.
                     rs_spinner = self.wait_until_element(
-                        (strategy4, value4 % REPOSET[reposet]), 3)
+                        (strategy4, value4 % REPOSET[reposet]),
+                        timeout=6,
+                        poll_frequency=2,
+                    )
                     timeout = time.time() + 60 * 2
                     while rs_spinner:
                         if time.time() > timeout:
                             break
                         rs_spinner = self.wait_until_element(
-                            (strategy4, value4 % REPOSET[reposet]), 3)
+                            (strategy4, value4 % REPOSET[reposet]),
+                            timeout=6,
+                            poll_frequency=2,
+                        )
                 for repo in repos_tree[prd][reposet]:
                     repo_values = repos_tree[prd][reposet][repo]
                     repo_name = repo_values['repo_name']
@@ -190,13 +202,19 @@ class Sync(Base):
                             "".format(repo_name))
                     # Similar to above reposet checkbox spinner
                     repo_spinner = self.wait_until_element(
-                        (strategy5, value5 % repo_name), 3)
-                    timeout = time.time() + 30
+                        (strategy5, value5 % repo_name),
+                        timeout=6,
+                        poll_frequency=2,
+                    )
+                    timeout = time.time() + 60
                     while repo_spinner:
                         if time.time() > timeout:
                             break
                         repo_spinner = self.wait_until_element(
-                            (strategy5, value5 % repo_name), 3)
+                            (strategy5, value5 % repo_name),
+                            timeout=6,
+                            poll_frequency=2,
+                        )
 
     def sync_rh_repos(self, repos_tree):
         """Syncs RedHat repositories.

--- a/tests/foreman/ui/test_contentviews.py
+++ b/tests/foreman/ui/test_contentviews.py
@@ -160,12 +160,13 @@ class TestContentViewsUI(UITestCase):
         env_name = gen_string("alpha", 8)
         name = gen_string("alpha", 8)
         publish_version = "Version 1"
+        strategy, value = locators["content_env.select_name"]
         with Session(self.browser) as session:
             # Create Life-cycle environment
             make_lifecycle_environment(session, org=self.org_name,
                                        name=env_name)
-            self.assertIsNotNone(self.contentenv.wait_until_element
-                                 (common_locators["alert.success"]))
+            self.assertIsNotNone(session.nav.wait_until_element
+                                 ((strategy, value % env_name)))
             # Creates a CV along with product and sync'ed repository
             self.setup_to_create_cv(session, name, repo_name=repo_name)
             # Add repository to selected CV
@@ -685,11 +686,12 @@ class TestContentViewsUI(UITestCase):
         }
         env_name = gen_string("alpha", 8)
         publish_version = "Version 1"
+        strategy, value = locators["content_env.select_name"]
         with Session(self.browser) as session:
             make_lifecycle_environment(session, org=self.org_name,
                                        name=env_name)
-            self.assertIsNotNone(self.contentenv.wait_until_element
-                                 (common_locators["alert.success"]))
+            self.assertIsNotNone(session.nav.wait_until_element
+                                 ((strategy, value % env_name)))
             self.setup_to_create_cv(session, cv_name, rh_repo=rh_repo)
             self.content_views.add_remove_repos(cv_name, [rh_repo['name']])
             self.assertIsNotNone(self.content_views.wait_until_element
@@ -726,16 +728,16 @@ class TestContentViewsUI(UITestCase):
         @assert: Content view can be promoted
 
         """
-
         repo_name = gen_string("alpha", 8)
         env_name = gen_string("alpha", 8)
         publish_version = "Version 1"
         name = gen_string("alpha", 8)
+        strategy, value = locators["content_env.select_name"]
         with Session(self.browser) as session:
             make_lifecycle_environment(session, org=self.org_name,
                                        name=env_name)
-            self.assertIsNotNone(self.contentenv.wait_until_element
-                                 (common_locators["alert.success"]))
+            self.assertIsNotNone(session.nav.wait_until_element
+                                 ((strategy, value % env_name)))
             self.setup_to_create_cv(session, name, repo_name=repo_name)
             self.content_views.add_remove_repos(name, [repo_name])
             self.assertIsNotNone(self.content_views.wait_until_element
@@ -837,11 +839,12 @@ class TestContentViewsUI(UITestCase):
         repo_name = gen_string("alpha", 8)
         env_name = gen_string("alpha", 8)
         name = gen_string("alpha", 8)
+        strategy, value = locators["content_env.select_name"]
         with Session(self.browser) as session:
             make_lifecycle_environment(session, org=self.org_name,
                                        name=env_name)
-            self.assertIsNotNone(self.contentenv.wait_until_element
-                                 (common_locators["alert.success"]))
+            self.assertIsNotNone(session.nav.wait_until_element
+                                 ((strategy, value % env_name)))
             self.setup_to_create_cv(session, name, repo_name=repo_name)
             self.content_views.add_remove_repos(name, [repo_name])
             self.assertIsNotNone(self.content_views.wait_until_element


### PR DESCRIPTION
When waiting for spinner or progress bar it's desired to have
increased poll_frequency rather than a default of 0.5 secs.

This may avoid high CPU usage seen while spinner or progress bar.

Also fixed few content view test-cases.
