### PR TITLE
Fix cli Base.search docstring typo

### DIFF
--- a/robottelo/cli/base.py
+++ b/robottelo/cli/base.py
@@ -207,7 +207,7 @@ class Base(object):
 
     @classmethod
     def exists(cls, options=None, search=None):
-        """Search for an entity using the query ``seach[0]="seach[1]"``
+        """Search for an entity using the query ``search[0]="search[1]"``
 
         Will be used the ``list`` command with the ``--search`` option to do
         the search.


### PR DESCRIPTION
The Base.search method docstring was updated but a typo passed in the PR
review. Fix that.
