### PR TITLE
Do not try to update a repository's content_type

### DIFF
--- a/tests/foreman/api/test_repository.py
+++ b/tests/foreman/api/test_repository.py
@@ -233,6 +233,8 @@ class RepositoryUpdateTestCase(APITestCase):
         @Feature: Repository
 
         """
+        if 'content_type' in attrs:
+            self.skipTest('Cannot update the content_type of a repository.')
         client.put(
             self.repository.path(),
             attrs,


### PR DESCRIPTION
From IRC:

```
<ichimonji10> Hey all. Is it possible to update the content_type of a
repository?
<jsherrill> ichimonji10: its not
<jsherrill> you have to delete and re-create
```

This fixes a failing Jenkins test. Updated test output:

```
$ nosetests tests/foreman/api/test_repository.py -m test_update
....S........
----------------------------------------------------------------------
Ran 13 tests in 29.033s

OK (SKIP=1)
```
