### PR TITLE
Improve test for updating repository content type

### DIFF
--- a/tests/foreman/api/test_repository.py
+++ b/tests/foreman/api/test_repository.py
@@ -233,8 +233,6 @@ class RepositoryUpdateTestCase(APITestCase):
         @Feature: Repository
 
         """
-        if 'content_type' in attrs:
-            self.skipTest('Cannot update the content_type of a repository.')
         client.put(
             self.repository.path(),
             attrs,
@@ -244,7 +242,14 @@ class RepositoryUpdateTestCase(APITestCase):
         real_attrs = self.repository.read_json()
         for name, value in attrs.items():
             self.assertIn(name, real_attrs.keys())
-            self.assertEqual(value, real_attrs[name])
+            if name == 'content_type':
+                # Cannot update a repository's content type.
+                self.assertEqual(
+                    entities.Repository.content_type.default,
+                    real_attrs[name]
+                )
+            else:
+                self.assertEqual(value, real_attrs[name])
 
 
 class RepositorySyncTestCase(APITestCase):


### PR DESCRIPTION
A repository's content type cannot be updated. Make a test which updates a
repository's content type explicitly check to make sure that its content type is
not updated.

```
$ nosetests tests/foreman/api/test_repository.py -m test_update
.............
----------------------------------------------------------------------
Ran 13 tests in 25.713s

OK
```

This should have been implemented in fb5f58094d7b64f7bd355ce5bd1c844f5766ab0b.
