### PR TITLE
Fixed activation_key tests and user tests

### DIFF
--- a/tests/foreman/ui/test_user.py
+++ b/tests/foreman/ui/test_user.py
@@ -23,7 +23,7 @@ from robottelo.ui.locators import common_locators, tab_locators, locators
 from robottelo.ui.session import Session
 
 
-def valid_strings(len1=100):
+def valid_strings(len1=10):
     """Generates a list of all the input strings, (excluding html)"""
     return [
         gen_string("alpha", 5),
@@ -55,6 +55,7 @@ class User(UITestCase):
 
     """
 
+    @skip_if_bug_open('bugzilla', 1177097)
     @attr('ui', 'user', 'implemented')
     @data(*valid_strings())
     def test_delete_user(self, user_name):
@@ -63,6 +64,8 @@ class User(UITestCase):
         @Feature: User - Delete
 
         @Assert: User is deleted
+
+        @BZ: 1177097
 
         """
         with Session(self.browser) as session:
@@ -143,7 +146,7 @@ class User(UITestCase):
             self.assertIsNotNone(self.user.search(user_name, search_key))
 
     @attr('ui', 'user', 'implemented')
-    @data(*valid_strings(50))
+    @data(*valid_strings())
     def test_positive_create_user_2(self, first_name):
         """@Test: Create User for all variations of First Name
 


### PR DESCRIPTION
- Blocked delete_user tests with bzid as UI doesn't raise success notification on deletion
- Updated the length of first_name to 10 instead of 50
- Blocked two negative test where we update description with more than 1000 char
- Search for updated entity doesn't work so blocked `test_positive_update_activation_key_1` with bzid
- Converted `create_cv` function in three diff functions as  create_cv fn doesn't create new manifest when a test calls it. I think it uses the same object again and again and tried to import same manifest,  so test were failing with error:
: [u'Import is the same as existing data\nOwner has already imported from another subscription management application.']

So I'm calling manifest clone and upload explicitly in the appropriate test itself rather than from a common function.