### PR TITLE
Fix the broken blog feed

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -4,7 +4,7 @@ email: your-email@domain.com
 description: >
   Robottelo is a test suite which exercises The Foreman.
 baseurl: "/robottelo/" # the subpath of your site, e.g. /blog/
-url: "https://satelliteqe.github.io/robottelo/"
+url: "https://satelliteqe.github.io/robottelo"
 twitter_username: OgMaciel
 github_username:  SatelliteQE
 

--- a/_posts/2014-10-09-what-is-new.markdown
+++ b/_posts/2014-10-09-what-is-new.markdown
@@ -1,8 +1,9 @@
 ---
 layout: post
-title:  "What's New"
-date:   2014-10-09 16:13:58
+title: "What's New"
+date: 2014-10-09 16:13:58
 categories: update
+author: Og Maciel
 ---
 
 First off, we're starting a brand, spanking new blog to keep anyone

--- a/_posts/2014-11-05-recent-api-changes.md
+++ b/_posts/2014-11-05-recent-api-changes.md
@@ -3,6 +3,7 @@ layout: post
 title: "Recent API Changes"
 date: 2014-11-05 15:12:15
 categories: update
+author: Jeremy Audet
 ---
 
 Robottelo's API abstraction layer received a major update in [pull request

--- a/_posts/2014-12-12-automatic-code-profiling.md
+++ b/_posts/2014-12-12-automatic-code-profiling.md
@@ -3,6 +3,7 @@ layout: post
 title: "Automatic Code Profiling"
 date: 2014-12-12 17:08:00
 categories: update
+author: Jeremy Audet
 ---
 
 [Pull request #1766](https://github.com/SatelliteQE/robottelo/pull/1766) added

--- a/_posts/2014-12-12-better-test-result-output.md
+++ b/_posts/2014-12-12-better-test-result-output.md
@@ -3,6 +3,7 @@ layout: post
 title: "Better test result output"
 date: 2014-12-12 14:50:00
 categories: update
+author: Elyézer Rezende
 ---
 
 [Pull request 1773](https://github.com/SatelliteQE/robottelo/pull/1773) removed the `nocapture` and `nologcapture` nose options from the `robottelo.properties.sample` file. This change was made to provide better test result output.

--- a/feed.xml
+++ b/feed.xml
@@ -1,30 +1,27 @@
 ---
 layout: null
 ---
-<?xml version="1.0" encoding="UTF-8"?>
-<rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom">
-  <channel>
+<?xml version='1.0' encoding='utf-8'?>
+<feed xmlns='http://www.w3.org/2005/Atom'>
+    <id>{{ site.url | xml_escape }}</id>
     <title>{{ site.title | xml_escape }}</title>
-    <description>{{ site.description | xml_escape }}</description>
-    <link>{{ site.url }}{{ site.baseurl }}/</link>
-    <atom:link href="{{ "/feed.xml" | prepend: site.baseurl | prepend: site.url }}" rel="self" type="application/rss+xml" />
-    <pubDate>{{ site.time | date_to_rfc822 }}</pubDate>
-    <lastBuildDate>{{ site.time | date_to_rfc822 }}</lastBuildDate>
-    <generator>Jekyll v{{ jekyll.version }}</generator>
+    <subtitle>{{ site.description | strip_newlines | xml_escape }}</subtitle>
+    <link href='{{ site.url | xml_escape }}feed.xml' rel='self' />
+    <updated>{{ site.posts[0].date | date_to_xmlschema }}</updated>
+    <!-- NOTE: The author tag has been omitted, so each entry MUST have an author. -->
+    {% comment %}
+    `date_to_rfc3339` does not produce RFC 3339 dates. `date_to_xmlschema` does.
+    {% endcomment %}
+
     {% for post in site.posts limit:10 %}
-      <item>
+    {% assign post_url = site.url | append:post.url | xml_escape %}
+    <entry>
+        <id>{{ post_url }}</id>
         <title>{{ post.title | xml_escape }}</title>
-        <description>{{ post.content | xml_escape }}</description>
-        <pubDate>{{ post.date | date_to_rfc822 }}</pubDate>
-        <link>{{ post.url | prepend: site.baseurl | prepend: site.url }}</link>
-        <guid isPermaLink="true">{{ post.url | prepend: site.baseurl | prepend: site.url }}</guid>
-        {% for tag in post.tags %}
-        <category>{{ tag | xml_escape }}</category>
-        {% endfor %}
-        {% for cat in post.categories %}
-        <category>{{ cat | xml_escape }}</category>
-        {% endfor %}
-      </item>
+        <link href='{{ post_url }}' />
+        <author><name>{{ post.author | xml_escape }}</name></author>
+        <summary>{{ post.content | strip_html | truncate:140, '…' | xml_escape }}</summary>
+        <updated>{{ post.date | date_to_xmlschema }}</updated>
+    </entry>
     {% endfor %}
-  </channel>
-</rss>
+</feed>


### PR DESCRIPTION
The links in the blog feed do not correctly link to blog posts, and the feed
itself is a weird mish-mash of RSS and Atom. Do the following:

* Rewrite `feed.xml` in Atom format. Use correct tags and format all dates as
  per RFC 3339.
* Add `author` tags to the YAML front matter at the beginning of each blog post.
* Tweak the site URL in `_config.yml`.

The resultant blog feed validates against http://validator.w3.org/feed/.

Fix #1777.