### PR TITLE
Make test assertions more verbose

### DIFF
--- a/tests/foreman/api/test_contentview.py
+++ b/tests/foreman/api/test_contentview.py
@@ -217,7 +217,12 @@ class CVPublishPromoteTestCase(APITestCase):
         # Publish the content view several times and check that each version
         # has some software packages.
         for _ in range(REPEAT):
-            self.assertEqual('success', content_view.publish()['result'])
+            response = content_view.publish()
+            self.assertEqual(
+                response['result'],
+                'success',
+                response['humanized']['errors']
+            )
         for cvv_id in (  # content view version ID
                 version['id']
                 for version
@@ -278,7 +283,12 @@ class CVPublishPromoteTestCase(APITestCase):
             lc_env_id = entities.LifecycleEnvironment(
                 organization=self.org.id
             ).create_json()['id']
-            self.assertEqual(cvv.promote(lc_env_id)['result'], 'success')
+            response = cvv.promote(lc_env_id)
+            self.assertEqual(
+                response['result'],
+                'success',
+                response['humanized']['errors']
+            )
 
         # Does it show up in the correct number of lifecycle environments?
         self.assertEqual(
@@ -310,7 +320,12 @@ class CVPublishPromoteTestCase(APITestCase):
             lc_env_id = entities.LifecycleEnvironment(
                 organization=self.org.id
             ).create_json()['id']
-            self.assertEqual(cvv.promote(lc_env_id)['result'], 'success')
+            response = cvv.promote(lc_env_id)
+            self.assertEqual(
+                response['result'],
+                'success',
+                response['humanized']['errors']
+            )
 
         # Everything's done - check some content view attributes...
         cv_attrs = content_view.read_json()


### PR DESCRIPTION
Several API tests in module  `tests.foreman.api.test_contentview` are currently
failing when executed by Jenkins:

* `test_positive_publish_2`
* `test_positive_promote_1`
* `test_positive_promote_2`

Unfortunately, the error messages produced by those tests are not especially
helpful. For example:

> AssertionError: u'error' != 'success'

Also, the failures cannot be reproduced manually, and they therefore cannot be
diagnosed. Make the test assertions more verbose so that more information is
emitted by Jenkins.