### PR TITLE
Fix a broken link in the blog feed

### DIFF
--- a/feed.xml
+++ b/feed.xml
@@ -6,7 +6,7 @@ layout: null
     <id>{{ site.url | xml_escape }}</id>
     <title>{{ site.title | xml_escape }}</title>
     <subtitle>{{ site.description | strip_newlines | xml_escape }}</subtitle>
-    <link href='{{ site.url | xml_escape }}feed.xml' rel='self' />
+    <link href='{{ site.url | xml_escape }}/feed.xml' rel='self' />
     <updated>{{ site.posts[0].date | date_to_xmlschema }}</updated>
     <!-- NOTE: The author tag has been omitted, so each entry MUST have an author. -->
     {% comment %}


### PR DESCRIPTION
The `link` tag (in the root `feed` tag) contains a reference to the feed
itself. It currently contains an incorrect URL, with this value:

    https://satelliteqe.github.io/robottelofeed.xml

It should contain this value:

    https://satelliteqe.github.io/robottelo/feed.xml

Fix this.