### PR TITLE
Now puppet classes can only be created by API's.

### DIFF
--- a/tests/foreman/ui/test_puppet_classes.py
+++ b/tests/foreman/ui/test_puppet_classes.py
@@ -1,5 +1,10 @@
 """Test class for Puppet Classes UI"""
 
+import sys
+if sys.hexversion >= 0x2070000:
+    import unittest
+else:
+    import unittest2 as unittest
 from ddt import ddt
 from fauxfactory import gen_string
 from nose.plugins.attrib import attr
@@ -11,94 +16,11 @@ from robottelo.ui.locators import common_locators
 from robottelo.ui.session import Session
 
 
+@unittest.skip("Now Puppet Classes can only be created via API's")
 @run_only_on('sat')
 @ddt
 class PuppetClasses(UITestCase):
     """Implements puppet classes tests in UI."""
-
-    @attr('ui', 'puppet-classes', 'implemented')
-    @data(*generate_strings_list(len1=8))
-    def test_create_positive_1(self, name):
-        """@Test: Create new puppet-class
-
-        @Feature: Puppet-Classes - Positive Create
-
-        @Assert: Puppet-Classes is created
-
-        """
-        with Session(self.browser) as session:
-            make_puppetclasses(session, name=name)
-            search = self.puppetclasses.search(name)
-            self.assertIsNotNone(search)
-
-    @attr('ui', 'puppet-classes', 'implemented')
-    @data(
-        gen_string('alphanumeric', 255),
-        gen_string('alpha', 255),
-        gen_string('numeric', 255),
-        gen_string('latin1', 255),
-        gen_string('utf8', 255)
-    )
-    def test_create_positive_2(self, name):
-        """@Test: Create new puppet-class with 255 chars
-
-        @Feature: Puppet-Classes - Positive Create
-
-        @Assert: Puppet-Classes is created with 255 chars
-
-        """
-        with Session(self.browser) as session:
-            make_puppetclasses(session, name=name)
-            search = self.puppetclasses.search(name)
-            self.assertIsNotNone(search)
-
-    @skip_if_bug_open('bugzilla', 1126496)
-    @attr('ui', 'puppet-classes', 'implemented')
-    @data(*generate_strings_list(len1=256))
-    def test_create_negative_1(self, name):
-        """@Test: Create new puppet-class with 256 chars
-
-        @Feature: Puppet-Classes - Negative Create
-
-        @Assert: Puppet-Classes is not created with 256 chars
-
-        @BZ: 1126496
-
-        """
-        with Session(self.browser) as session:
-            make_puppetclasses(session, name=name)
-            search = self.puppetclasses.search(name)
-            self.assertIsNone(search)
-
-    def test_create_negative_2(self):
-        """@Test: Create new puppet-class with blank name
-
-        @Feature: Puppet-Classes - Negative Create
-
-        @Assert: Puppet-Classes is not created with 256 chars
-
-        """
-        name = ""
-        with Session(self.browser) as session:
-            make_puppetclasses(session, name=name)
-            error = session.nav.wait_until_element(
-                common_locators["name_haserror"])
-            self.assertIsNotNone(error)
-
-    def test_create_negative_3(self):
-        """@Test: Create new puppet-class with blank name
-
-        @Feature: Puppet-Classes - Negative Create
-
-        @Assert: Puppet-Classes is not created with 256 chars
-
-        """
-        name = "    "
-        with Session(self.browser) as session:
-            make_puppetclasses(session, name=name)
-            error = session.nav.wait_until_element(
-                common_locators["name_haserror"])
-            self.assertIsNotNone(error)
 
     @attr('ui', 'puppet-classes', 'implemented')
     @data({'name': gen_string('alpha', 10),


### PR DESCRIPTION
* Confirmed from sat6 and foreman-dev channel
* Removed the Puppet Class creation tests.
* Update and deletion may be possible but need to be tested via
  API's.

Doing it via the API's needs to be looked into. Will raise a separate issue for this task.