### PR TITLE
fixed the locators to select long name entities

### DIFF
--- a/robottelo/ui/configgroups.py
+++ b/robottelo/ui/configgroups.py
@@ -44,8 +44,12 @@ class ConfigGroups(Base):
         """
         Navigator(self.browser).go_to_config_groups()
         self.wait_for_ajax()
-        element = self.search_entity(name,
-                                     locators["config_groups.select_name"])
+        if len(name) <= 30:
+            element = self.search_entity(
+                name, locators["config_groups.select_name"])
+        else:
+            element = self.search_entity(
+                name, common_locators["select_filtered_entity"])
         return element
 
     def delete(self, name, really, drop_locator=None):

--- a/robottelo/ui/domain.py
+++ b/robottelo/ui/domain.py
@@ -47,9 +47,14 @@ class Domain(Base):
         """
         Navigator(self.browser).go_to_domains()
         self.wait_for_ajax()
-        element = self.search_entity(description,
-                                     locators["domain.domain_description"],
-                                     timeout=timeout)
+        if len(description) <= 30:
+            element = self.search_entity(
+                description, locators["domain.domain_description"],
+                timeout=timeout)
+        else:
+            element = self.search_entity(
+                description, common_locators["select_filtered_entity"],
+                timeout=timeout)
         return element
 
     def delete(self, description, really):

--- a/robottelo/ui/environment.py
+++ b/robottelo/ui/environment.py
@@ -52,8 +52,11 @@ class Environment(Base):
         Searches existing env from UI
         """
         Navigator(self.browser).go_to_environments()
-        element = self.search_entity(name,
-                                     locators["env.env_name"])
+        if len(name) <= 30:
+            element = self.search_entity(name, locators["env.env_name"])
+        else:
+            element = self.search_entity(
+                name, common_locators["select_filtered_entity"])
         return element
 
     def delete(self, name, really):

--- a/robottelo/ui/hardwaremodel.py
+++ b/robottelo/ui/hardwaremodel.py
@@ -60,9 +60,13 @@ class HardwareModel(Base):
 
         """
         Navigator(self.browser).go_to_hardware_models()
-        element = self.search_entity(name,
-                                     locators["hwmodels.select_name"],
-                                     timeout=timeout)
+        if len(name) <= 30:
+            element = self.search_entity(
+                name, locators["hwmodels.select_name"], timeout=timeout)
+        else:
+            element = self.search_entity(
+                name, common_locators["select_filtered_entity"],
+                timeout=timeout)
         return element
 
     def delete(self, name, really):

--- a/robottelo/ui/locators.py
+++ b/robottelo/ui/locators.py
@@ -523,6 +523,8 @@ common_locators = {
         By.XPATH,
         ("//div[@class='ms-selection']/ul[@class='ms-list']"
          "/li[@class='ms-elem-selection ms-selected']")),
+    "select_filtered_entity": (
+        By.XPATH, "//a/span[contains(@data-original-title, '%s')]"),
     "checked_entity": (
         By.XPATH, "//input[@checked='checked']/parent::label"),
     "entity_select": (

--- a/robottelo/ui/medium.py
+++ b/robottelo/ui/medium.py
@@ -52,7 +52,11 @@ class Medium(Base):
         """
         Navigator(self.browser).go_to_installation_media()
         self.wait_for_ajax()
-        element = self.search_entity(name, locators["medium.medium_name"])
+        if len(name) <= 30:
+            element = self.search_entity(name, locators["medium.medium_name"])
+        else:
+            element = self.search_entity(
+                name, common_locators["select_filtered_entity"])
         return element
 
     def delete(self, name, really):

--- a/robottelo/ui/operatingsys.py
+++ b/robottelo/ui/operatingsys.py
@@ -96,9 +96,14 @@ class OperatingSys(Base):
         Searches existing operating system from UI
         """
         Navigator(self.browser).go_to_operating_systems()
-        element = self.search_entity(
-            name, locators['operatingsys.operatingsys_name'],
-            search_key)
+        if len(name) <= 30:
+            element = self.search_entity(
+                name, locators['operatingsys.operatingsys_name'],
+                search_key)
+        else:
+            element = self.search_entity(
+                name, common_locators['select_filtered_entity'],
+                search_key)
         return element
 
     def delete(self, os_name, really):

--- a/robottelo/ui/subnet.py
+++ b/robottelo/ui/subnet.py
@@ -67,9 +67,14 @@ class Subnet(Base):
     def search_subnet(self, subnet_name, timeout=None):
         """Search Subnet name, network and mask to validate results."""
         result = None
-        subnet_object = self.search_entity(subnet_name,
-                                           locators['subnet.display_name'],
-                                           timeout=timeout)
+        if len(subnet_name) <= 30:
+            subnet_object = self.search_entity(
+                subnet_name, locators['subnet.display_name'],
+                timeout=timeout)
+        else:
+            subnet_object = self.search_entity(
+                subnet_name, common_locators['select_filtered_entity'],
+                timeout=timeout)
         if subnet_object:
             subnet_object.click()
             if self.wait_until_element(locators["subnet.name"]):


### PR DESCRIPTION
Here is one case to show the issue with long names.. When we use long names, UI truncates them.
for ex:
domain_name set as "longnaaaaaaaaaaaaaaaaaaaaaaaaaaame"
UI truncates it and list it as "longnaaaaa...."

Now when we assert the entity after creation, selenium doesn't find it, as name is already truncated. I've updated the locator and this should fix the test case.

```
[sghai@dhcp1xx-xx robottelo]$ nosetests  -c robottelo.properties  -m test_create_domain_2 /home/sghai/QE/robottelo/tests/foreman/ui/test_domain.py
/usr/lib/python2.7/site-packages/fauxfactory/__init__.py:737: Warning: The FauxFactory class is deprecated. Please use functions from the fauxfactory module instead.
  category=Warning)
@Test: Create a new domain ... 2015-01-07 18:37:28 - root - DEBUG - NoSuchElementException: Could not locate element //div[contains(@class, 'jnotify-notification-error')].
ok

----------------------------------------------------------------------
XML: foreman-results.xml
----------------------------------------------------------------------
Ran 1 test in 36.476s

```