### PR TITLE
Fix smoke test `test_get_links`

### DIFF
--- a/tests/foreman/smoke/test_api_smoke.py
+++ b/tests/foreman/smoke/test_api_smoke.py
@@ -172,6 +172,7 @@ API_PATHS = {
         u'/katello/api/content_view_versions/:id',
         u'/katello/api/content_view_versions/:id',
         u'/katello/api/content_view_versions/:id/promote',
+        u'/katello/api/content_view_versions/incremental_update',
     ),
     u'dashboard': (
         u'/api/dashboard',
@@ -224,7 +225,6 @@ API_PATHS = {
     u'external_usergroups': (
         u'/api/usergroups/:usergroup_id/external_usergroups',
         u'/api/usergroups/:usergroup_id/external_usergroups',
-        u'/api/usergroups/:usergroup_id/external_usergroups/:id',
         u'/api/usergroups/:usergroup_id/external_usergroups/:id',
         u'/api/usergroups/:usergroup_id/external_usergroups/:id',
         u'/api/usergroups/:usergroup_id/external_usergroups/:id/refresh',
@@ -553,6 +553,7 @@ API_PATHS = {
     u'systems_bulk_actions': (
         u'/katello/api/systems/bulk/add_host_collections',
         u'/katello/api/systems/bulk/applicable_errata',
+        u'/katello/api/systems/bulk/available_incremental_updates',
         u'/katello/api/systems/bulk/destroy',
         u'/katello/api/systems/bulk/environment_content_view',
         u'/katello/api/systems/bulk/install_content',
@@ -609,6 +610,8 @@ API_PATHS = {
 
 class TestAvailableURLs(TestCase):
     """Tests for ``api/v2``."""
+    longMessage = True
+
     def setUp(self):
         """Define commonly-used variables."""
         self.path = '{0}/api/v2'.format(helpers.get_server_url())
@@ -667,9 +670,14 @@ class TestAvailableURLs(TestCase):
         for group in api_paths.keys():
             self.assertEqual(
                 frozenset(api_paths[group]),
-                frozenset(API_PATHS[group])
+                frozenset(API_PATHS[group]),
+                group
             )
-            self.assertEqual(len(api_paths[group]), len(API_PATHS[group]))
+            self.assertEqual(
+                len(api_paths[group]),
+                len(API_PATHS[group]),
+                group
+            )
 
         # (line-too-long) pylint:disable=C0301
         # response.json()['links'] is a dict like this:


### PR DESCRIPTION
Apparently this smoke test has been failing for quite some time. Mea culpa.
Update the test as per the current state of Foreman and Katello:

* `/katello/api/content_view_versions/incremental_update` was added in
  Katello/katello@981dac777fd1d9ee7c15c2ed220bef7e16f64605
* `/api/usergroups/:usergroup_id/external_usergroups/:id` was dropped in
  theforeman/foreman@4b2dffaede08779b374a671e4a7fa64aa5060887
* `/katello/api/systems/bulk/available_incremental_updates` was added in
  Katello/katello@a55f62fa5c1dc1b9786ed6f65527411f0cc376fc

Tweak the contents of the test itself so that future test failures are easier to
understand.