### PR TITLE
Polish smoke test `test_ping`

### DIFF
--- a/tests/foreman/smoke/test_api_smoke.py
+++ b/tests/foreman/smoke/test_api_smoke.py
@@ -740,39 +740,24 @@ class TestSmoke(TestCase):
         @Feature: Smoke Test
         @Assert: Overall and individual services status should be 'ok'.
         """
-        path = entities.Ping().path()
         response = client.get(
-            path,
+            entities.Ping().path(),
             auth=get_server_credentials(),
-            verify=False)
-        self.assertEqual(
-            response.status_code,
-            httplib.OK,
-            status_code_error(path, httplib.OK, response)
+            verify=False,
         )
-        # Check overal status
-        self.assertEqual(
-            response.json()['status'],
-            u'ok',
-            U"The server does not seem to be configured properly!"
-        )
+        response.raise_for_status()
+        self.assertEqual(response.json()['status'], u'ok')  # overall status
 
-        # Extract all services status information returned with the format:
+        # Check that all services are OK. ['services'] is in this format:
+        #
         # {u'services': {
         #    u'candlepin': {u'duration_ms': u'40', u'status': u'ok'},
         #    u'candlepin_auth': {u'duration_ms': u'41', u'status': u'ok'},
-        #    u'elasticsearch': {u'duration_ms': u'22', u'status': u'ok'},
-        #    u'katello_jobs': {u'duration_ms': u'43', u'status': u'ok'},
-        #    u'pulp': {u'duration_ms': u'18', u'status': u'ok'},
-        #    u'pulp_auth': {u'duration_ms': u'30', u'status': u'ok'}},
-        #    u'status': u'ok'}
+        #    …
+        # }, u'status': u'ok'}
         services = response.json()['services']
-        # Check if all services are 'OK'
-        ok_status = all(
-            [service['status'] == u'ok' for service in services.values()]
-        )
         self.assertTrue(
-            ok_status,
+            all([service['status'] == u'ok' for service in services.values()]),
             u"Not all services seem to be up and running!"
         )
 


### PR DESCRIPTION
Make the `test_ping` test much more compact. This does not change the
functionality of the test in any appreciable way, but it does make the test much
easier to understand.

Test result:

    $ nosetests tests/foreman/smoke/test_api_smoke.py -m test_ping
    .
    ----------------------------------------------------------------------
    Ran 1 test in 1.486s

    OK