### PR TITLE
Fix errors with API smoke failures

### DIFF
--- a/robottelo/entities.py
+++ b/robottelo/entities.py
@@ -77,34 +77,38 @@ class ActivationKey(
 
         releases
             /activation_keys/<id>/releases
-        subscriptions
-            /activation_keys/<id>/subscriptions
+        add_subscriptions
+            /activation_keys/<id>/add_subscriptions
+        remove_subscriptions
+            /activation_keys/<id>/remove_subscriptions
 
         ``super`` is called otherwise.
 
         """
-        if which in ('releases', 'subscriptions',):
+        if which in ('releases', 'add_subscriptions', 'remove_subscriptions'):
             return '{0}/{1}'.format(
                 super(ActivationKey, self).path(which='self'),
                 which
             )
         return super(ActivationKey, self).path(which)
 
-    def add_subsciptions(self, subscription_id, quantity):
+    def add_subscriptions(self, params):
         """Helper for adding subscriptions to activation key.
 
+        :param dict params: Parameters that are encoded to JSON and passed in
+            with the request. See the API documentation page for a list of
+            parameters and their descriptions.
         :returns: The server's response, with all JSON decoded.
         :rtype: dict
         :raises: ``requests.exceptions.HTTPError`` If the server responds with
             an HTTP 4XX or 5XX message.
 
         """
-        response = client.post(
-            self.path('subscriptions'),
+        response = client.put(
+            self.path('add_subscriptions'),
+            params,
             auth=get_server_credentials(),
             verify=False,
-            data={u'id': subscription_id,
-                  u'quantity': quantity,}
         )
         response.raise_for_status()
         return response.json()

--- a/tests/robottelo/test_entities.py
+++ b/tests/robottelo/test_entities.py
@@ -48,6 +48,8 @@ class PathTestCase(TestCase):
 
     @data(
         (entities.ActivationKey, '/activation_keys', 'releases'),
+        (entities.ActivationKey, '/activation_keys', 'add_subscriptions'),
+        (entities.ActivationKey, '/activation_keys', 'remove_subscriptions'),
         (entities.ContentView, '/content_views', 'available_puppet_module_names'),  # flake8:noqa pylint:disable=C0301
         (entities.ContentView, '/content_views', 'content_view_puppet_modules'),  # flake8:noqa pylint:disable=C0301
         (entities.ContentView, '/content_views', 'content_view_versions'),


### PR DESCRIPTION
Fix a variety of issues with the API smoke test `test_end_to_end`:

* Class `ActivationKey` is outdated. It makes an incorrect set of paths available via method `path`, and method `add_subscriptions` is affected by that change and has design issues in general.
* API smoke test `test_end_to_end` is currently broken in part due to the outdated `ActivationKey` class and in part because it is passing incorrect parameters to path `/katello/api/v2/activation_keys/:id/add_subscriptions`.

Fix both of the above issues. `test_end_to_end` still fails, but this is due to the fact that my test machine is not configured to use the virtualization features that the test requires:

```
E
======================================================================
ERROR: @Test: Perform end to end smoke tests using RH repos.
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/ichimonji10/code/robottelo/tests/foreman/smoke/test_api_smoke.py", line 1123, in test_end_to_end
    with VirtualMachine(distro='rhel65') as vm:
  File "/home/ichimonji10/code/robottelo/robottelo/vm.py", line 175, in __enter__
    self.create()
  File "/home/ichimonji10/code/robottelo/robottelo/vm.py", line 113, in create
    'Failed to run snap-guest: {0}'.format(result.stderr))
VirtualMachineError: Failed to run snap-guest: bash: snap-guest: command not found

-------------------- >> begin captured logging << --------------------
root: INFO: Bugzilla bug 1176708 not in cache. Fetching.
--------------------- >> end captured logging << ---------------------

----------------------------------------------------------------------
Ran 1 test in 367.992s

FAILED (errors=1)
```

I've run the above test against both RHEL 66 and RHEL 7 upstream systems.

See the individual commit messages for more information.