### PR TITLE
Polish permissions-related API tests and docs

### DIFF
--- a/robottelo/common/constants.py
+++ b/robottelo/common/constants.py
@@ -203,8 +203,8 @@ REPO_DISCOVERY_URL = "http://omaciel.fedorapeople.org/"
 
 PUPPET_MODULE_NTP_PUPPETLABS = "puppetlabs-ntp-3.2.1.tar.gz"
 
-# All satellite permissions
-# API test_permission_v2 ensures that this will not get obsolete
+#: All permissions exposed by the server.
+#: :mod:`tests.foreman.api.test_permission` makes use of this.
 PERMISSIONS = {
     None: (
         'access_dashboard',

--- a/robottelo/entities.py
+++ b/robottelo/entities.py
@@ -1556,16 +1556,23 @@ class Permission(orm.Entity, orm.EntityReadMixin):
         """Searches for permissions using the values for instance name and
         resource_type
 
-        Usage::
+        Example usage::
 
-            result = Permission(resource_type='Architecture').search()
-            result = Permission(name='create_architectures').search()
+            >>> entities.Permission(resource_type='Domain').search()
+            [
+                {u'name': u'view_domains', u'resource_type': u'Domain', u'id': 39},
+                {u'name': u'create_domains', u'resource_type': u'Domain', u'id': 40},
+                {u'name': u'edit_domains', u'resource_type': u'Domain', u'id': 41},
+                {u'name': u'destroy_domains', u'resource_type': u'Domain', u'id': 42}
+            ]
+            >>> entities.Permission(name='view_domains').search()
+            [{u'name': u'view_domains', u'resource_type': u'Domain', u'id': 39}]
 
-        If you search by using both name and resource_type then the default
-        server behavior is to search by resource_type.
+        If both ``name`` and ``resource_type`` are provided, ``name`` is
+        ignored.
 
         :param int per_page: number of results per page to return
-        :returns: A list with the found results
+        :returns: A list of matching permissions.
         :rtype: list
 
         """


### PR DESCRIPTION
* Document `robottelo.common.constants.PERMISSIONS`,
  `tests.foreman.api.test_permission.PERMISSION_RESOURCE_TYPES` and
  `tests.foreman.api.test_permission.PERMISSION_NAMES`.
* Rewrite the docstrings for `robottelo.entities.Permission` and several methods
  in `tests.foreman.api.test_permission`.
* Rewrite the contents of several tests in
  `tests.foreman.api.test_permission.PermissionsTestCase`. Do this with the
  intent of making the tests more readable and agressive.
  `test_search_permissions` has received the most agressive makeover. It now
  checks that searching for all permissions returns a correct set of permissions
  in a more agressive manner.