### PR TITLE
Add helper function `get_distro_info`, add workaround for BZ 1184644

### DIFF
--- a/robottelo/common/helpers.py
+++ b/robottelo/common/helpers.py
@@ -8,6 +8,8 @@ Several helper methods and functions.
 import os
 import re
 
+from automation_tools import distro_info
+from fabric.api import execute, settings
 from fauxfactory import gen_string, gen_integer
 from itertools import izip
 from robottelo.common import conf
@@ -65,6 +67,21 @@ def get_server_url():
         return urlunsplit((
             scheme, '{0}:{1}'.format(hostname, port), '', '', ''
         ))
+
+
+def get_distro_info():
+    """Get a tuple of information about the RHEL distribution on the server.
+
+    :return: A tuple of information in this format: ``('rhel', 6, 6)``.
+    :rtype: tuple
+
+    """
+    with settings(
+        key_filename=conf.properties['main.server.ssh.key_private'],
+        user=conf.properties['main.server.ssh.username'],
+    ):
+        hostname = conf.properties['main.server.hostname']
+        return execute(distro_info, host=hostname)[hostname]
 
 
 def valid_names_list():


### PR DESCRIPTION
These two commits can be submitted as separate pull requests, but I'm bundling them together for the sake of expediency. The first commit adds a helper function named `get_distro_info` and refactors some code originally added in e56085441c8504974fdf47f4c992da45320b88c6. The second commit works around a bug that only manifests itself on RHEL 6.6 hosts.

I've tested the updated code against both RHEL 6.6 and RHEL 7 hosts with this command:

    nosetests tests/foreman/api/test_permission.py:PermissionsTestCase

That command still shows one failing test on both RHEL 6.6 and RHEL 7, but that failing test is due to a separate issue which is addressed in my `perms-new` branch ([diff](https://github.com/Ichimonji10/robottelo/compare/perms-new)). I am currently unable to submit a PR that fixes that remaining issue, as I am waiting on feedback from the devs. (Ughhh. This is why we need requirements docs.)