### PR TITLE
Drop nose dependency

### DIFF
--- a/robottelo.properties.sample
+++ b/robottelo.properties.sample
@@ -25,6 +25,8 @@ manifest.fake_url=http://example.org/valid-redhat-manifest.zip
 manifest.key_url=http://example.org/fake_manifest.key
 manifest.cert_url=http://example.org/fake_manifest.crt
 
+verbosity=2
+
 # Virtual display controls if PyVirtualDisplay should be used to run UI tests
 # when setting it to 1 then make sure to install required dependencies
 virtual_display=0
@@ -48,14 +50,5 @@ admin.password=changeme
 
 [saucelabs]
 driver=firefox
-
-[nosetests]
-verbosity=2
-with-xunit=1
-xunit-file=foreman-results.xml
-# NOTE: nosetests --with-xunit does not work with
-# 'processes' property enabled.
-# processes=1
-# process-timeout=120
 
 # NOTE: Candlepin url accepts just the hostname.

--- a/robottelo/common/__init__.py
+++ b/robottelo/common/__init__.py
@@ -32,7 +32,7 @@ class Configs(object):
 
         # Configure logging using a value from the config file, if available.
         try:
-            _configure_logging(int(self.properties['nosetests.verbosity']))
+            _configure_logging(int(self.properties['main.verbosity']))
         except KeyError:
             _configure_logging()
 
@@ -87,9 +87,8 @@ def _configure_logging(verbosity=2):
     custom logging output format is set, and default values are used for all
     other logging options.
 
-    :param int verbosity: A nosetests-style verbosity value. Useful values are
-        in the range 1-5 inclusive, and higher numbers produce more verbose
-        logging.
+    :param int verbosity: Useful values are in the range 1-5 inclusive, and
+        higher numbers produce more verbose logging.
     :rtype: None
 
     """
@@ -100,7 +99,7 @@ def _configure_logging(verbosity=2):
             format='%(levelname)s %(module)s:%(lineno)d: %(message)s'
         )
 
-    # Translate from nosetests verbosity values to logging verbosity values.
+    # Translate from robottelo verbosity values to logging verbosity values.
     # This code is inspired by method `Config.configureLogging` in module
     # `nose.config` in the nose source code.
     if verbosity >= 5:

--- a/robottelo/test.py
+++ b/robottelo/test.py
@@ -89,7 +89,7 @@ class CLITestCase(TestCase):
         cls.key_filename = conf.properties['main.server.ssh.key_private']
         cls.root = conf.properties['main.server.ssh.username']
         cls.locale = conf.properties['main.locale']
-        cls.verbosity = int(conf.properties['nosetests.verbosity'])
+        cls.verbosity = int(conf.properties['main.verbosity'])
 
     def setUp(self):
         """Log test class and method name before each test."""
@@ -116,7 +116,7 @@ class UITestCase(TestCase):
         cls.katello_passwd = conf.properties['foreman.admin.password']
         cls.driver_name = conf.properties['saucelabs.driver']
         cls.locale = conf.properties['main.locale']
-        cls.verbosity = int(conf.properties['nosetests.verbosity'])
+        cls.verbosity = int(conf.properties['main.verbosity'])
         cls.remote = int(conf.properties['main.remote'])
         cls.server_name = conf.properties.get('main.server.hostname')
         cls.screenshots_dir = conf.properties.get('main.screenshots.base_path')

--- a/tests/foreman/cli/test_activationkey.py
+++ b/tests/foreman/cli/test_activationkey.py
@@ -4,7 +4,6 @@
 
 from ddt import ddt
 from fauxfactory import gen_string
-from nose.plugins.attrib import attr
 from robottelo.cli.activationkey import ActivationKey
 from robottelo.cli.lifecycleenvironment import LifecycleEnvironment
 from robottelo.cli.factory import (
@@ -100,7 +99,6 @@ class TestActivationKey(CLITestCase):
         {'name': gen_string('utf8', 15)},
         {'name': gen_string('html', 15)},
     )
-    @attr('cli', 'activation-key')
     def test_positive_create_activation_key_1(self, test_data):
         """@Test: Create Activation key for all variations of
             Activation key name
@@ -131,7 +129,6 @@ class TestActivationKey(CLITestCase):
         {'description': gen_string('utf8', 15)},
         {'description': gen_string('html', 15)},
     )
-    @attr('cli', 'activation-key')
     def test_positive_create_activation_key_2(self, test_data):
         """@Test: Create Activation key for all variations of Description
 
@@ -163,7 +160,6 @@ class TestActivationKey(CLITestCase):
         {'name': gen_string('utf8', 15)},
         {'name': gen_string('html', 15)},
     )
-    @attr('cli', 'activation-key')
     def test_positive_create_associate_environ_1(self, test_data):
         """@Test: Create Activation key and associate with Library environment
 
@@ -196,7 +192,6 @@ class TestActivationKey(CLITestCase):
         {'name': gen_string('utf8', 15)},
         {'name': gen_string('html', 15)},
     )
-    @attr('cli', 'activation-key')
     def test_positive_create_associate_environ_2(self, test_data):
         """@Test: Create Activation key and associate with environment
 
@@ -231,7 +226,6 @@ class TestActivationKey(CLITestCase):
         {'name': gen_string("html", 10),
          'content-view': gen_string("alpha", 10)},
     )
-    @attr('cli', 'activation-key')
     def test_positive_create_activation_key_4(self, test_data):
         """@Test: Create Activation key for all variations of Content Views
 

--- a/tests/foreman/cli/test_contenthost.py
+++ b/tests/foreman/cli/test_contenthost.py
@@ -7,7 +7,6 @@
 
 from ddt import ddt
 from fauxfactory import gen_string
-from nose.plugins.attrib import attr
 from robottelo.cli.factory import (
     CLIFactoryError, make_org, make_content_view,
     make_lifecycle_environment, make_content_host)
@@ -79,7 +78,6 @@ class TestContentHost(CLITestCase):
         {u'name': gen_string('utf8', 15)},
         {u'name': gen_string('html', 15)},
     )
-    @attr('cli', 'content-host')
     def test_positive_create_1(self, test_data):
         """@Test: Check if content host can be created with random names
 
@@ -110,7 +108,6 @@ class TestContentHost(CLITestCase):
         {u'description': gen_string('utf8', 15)},
         {u'description': gen_string('html', 15)},
     )
-    @attr('cli', 'content-host')
     def test_positive_create_2(self, test_data):
         """@Test: Check if content host can be created with random description
 
@@ -133,7 +130,6 @@ class TestContentHost(CLITestCase):
             "Descriptions don't match"
         )
 
-    @attr('cli', 'content-host')
     def test_positive_create_3(self):
         """@Test: Check if content host can be created with organization name
 
@@ -160,7 +156,6 @@ class TestContentHost(CLITestCase):
             self.LIBRARY['name'],
             "Environments don't match")
 
-    @attr('cli', 'content-host')
     def test_positive_create_4(self):
         """@Test: Check if content host can be created with organization label
 
@@ -188,7 +183,6 @@ class TestContentHost(CLITestCase):
             "Environments don't match")
 
     @run_only_on('sat')
-    @attr('cli', 'content-host')
     def test_positive_create_5(self):
         """@Test: Check if content host can be created with content view name
 
@@ -213,7 +207,6 @@ class TestContentHost(CLITestCase):
 
     @run_only_on('sat')
     @skip_if_bug_open('bugzilla', 1107319)
-    @attr('cli', 'content-host')
     def test_positive_create_6(self):
         """@Test: Check if content host can be created with lifecycle name
 
@@ -237,7 +230,6 @@ class TestContentHost(CLITestCase):
 
     @run_only_on('sat')
     @skip_if_bug_open('bugzilla', 1114046)
-    @attr('cli', 'content-host')
     def test_positive_create_7(self):
         """@Test: Check if content host can be created with new lifecycle
 
@@ -263,7 +255,6 @@ class TestContentHost(CLITestCase):
         )
 
     @run_only_on('sat')
-    @attr('cli', 'content-host')
     def test_positive_create_8(self):
         """@Test: Check if content host can be created with new content view
 
@@ -297,7 +288,6 @@ class TestContentHost(CLITestCase):
         {u'name': gen_string('utf8', 300)},
         {u'name': gen_string('html', 300)},
     )
-    @attr('cli', 'content-host')
     def test_negative_create_1(self, test_data):
         """@Test: Check if content host can be created with random long names
 
@@ -316,7 +306,6 @@ class TestContentHost(CLITestCase):
             })
 
     @run_only_on('sat')
-    @attr('cli', 'content-host')
     def test_negative_create_2(self):
         """@Test: Check if content host can be created with new content view
 
@@ -345,7 +334,6 @@ class TestContentHost(CLITestCase):
         {u'name': gen_string('utf8', 15)},
         {u'name': gen_string('html', 15)},
     )
-    @attr('cli', 'content-host')
     def test_positive_update_1(self, test_data):
         """@Test: Check if content host name can be updated
 
@@ -414,7 +402,6 @@ class TestContentHost(CLITestCase):
         {u'description': gen_string('utf8', 15)},
         {u'description': gen_string('html', 15)},
     )
-    @attr('cli', 'content-host')
     def test_positive_update_2(self, test_data):
         """@Test: Check if content host description can be updated
 
@@ -482,7 +469,6 @@ class TestContentHost(CLITestCase):
         {u'name': gen_string('utf8', 15)},
         {u'name': gen_string('html', 15)},
     )
-    @attr('cli', 'content-host')
     def test_positive_delete_1(self, test_data):
         """@Test: Check if content host can be created and deleted
 

--- a/tests/foreman/cli/test_fact.py
+++ b/tests/foreman/cli/test_fact.py
@@ -6,7 +6,6 @@ import sys
 
 from ddt import ddt
 from fauxfactory import gen_string
-from nose.plugins.attrib import attr
 from robottelo.cli.fact import Fact
 from robottelo.common.decorators import data, run_only_on
 from robottelo.test import CLITestCase
@@ -26,7 +25,6 @@ class TestFact(CLITestCase):
     @data(
         'uptime', 'uptime_days', 'uptime_seconds', 'memoryfree', 'ipaddress',
     )
-    @attr('cli', 'fact')
     def test_list_success(self, fact):
         """@Test: Test Fact List
 
@@ -51,7 +49,6 @@ class TestFact(CLITestCase):
         gen_string("alpha", 10),
         gen_string("alpha", 10),
     )
-    @attr('cli', 'fact')
     def test_list_fail(self, fact):
         """@Test: Test Fact List failure
 

--- a/tests/foreman/cli/test_host_collection.py
+++ b/tests/foreman/cli/test_host_collection.py
@@ -5,7 +5,6 @@
 
 from ddt import ddt
 from fauxfactory import gen_string
-from nose.plugins.attrib import attr
 from robottelo.cli.contentview import ContentView
 from robottelo.cli.lifecycleenvironment import LifecycleEnvironment
 from robottelo.cli.factory import (
@@ -104,7 +103,6 @@ class TestHostCollection(CLITestCase):
         {'name': gen_string('utf8', 15)},
         {'name': gen_string('html', 15)},
     )
-    @attr('cli', 'hostcollection')
     def test_positive_create_1(self, test_data):
         """@Test: Check if host collection can be created with random names
 
@@ -130,7 +128,6 @@ class TestHostCollection(CLITestCase):
         {'description': gen_string('utf8', 15)},
         {'description': gen_string('html', 15)},
     )
-    @attr('cli', 'hostcollection')
     def test_positive_create_2(self, test_data):
         """@Test: Check if host collection can be created with random description
 
@@ -150,7 +147,6 @@ class TestHostCollection(CLITestCase):
         )
 
     @data('1', '3', '5', '10', '20')
-    @attr('cli', 'hostcollection')
     def test_positive_create_3(self, test_data):
         """@Test: Check if host collection can be created with random limits
 
@@ -178,7 +174,6 @@ class TestHostCollection(CLITestCase):
         {'name': gen_string('utf8', 300)},
         {'name': gen_string('html', 300)},
     )
-    @attr('cli', 'hostcollection')
     def test_negative_create_1(self, test_data):
         """@Test: Check if host collection can be created with random names
 
@@ -200,7 +195,6 @@ class TestHostCollection(CLITestCase):
         {'name': gen_string('utf8', 15)},
         {'name': gen_string('html', 15)},
     )
-    @attr('cli', 'hostcollection')
     def test_positive_update_1(self, test_data):
         """@Test: Check if host collection name can be updated
 
@@ -274,7 +268,6 @@ class TestHostCollection(CLITestCase):
         {'description': gen_string('utf8', 15)},
         {'description': gen_string('html', 15)},
     )
-    @attr('cli', 'hostcollection')
     def test_positive_update_2(self, test_data):
         """@Test: Check if host collection description can be updated
 
@@ -341,7 +334,6 @@ class TestHostCollection(CLITestCase):
     @skip_if_bug_open('bugzilla', 1084240)
     @skip_if_bug_open('bugzilla', 1171669)
     @data('3', '6', '9', '12', '15', '17', '19')
-    @attr('cli', 'hostcollection')
     def test_positive_update_3(self, test_data):
         """@Test: Check if host collection limits be updated
 
@@ -402,7 +394,6 @@ class TestHostCollection(CLITestCase):
         {'name': gen_string('utf8', 15)},
         {'name': gen_string('html', 15)},
     )
-    @attr('cli', 'hostcollection')
     def test_positive_delete_1(self, test_data):
         """@Test: Check if host collection can be created and deleted
 

--- a/tests/foreman/cli/test_product.py
+++ b/tests/foreman/cli/test_product.py
@@ -7,7 +7,6 @@ from fauxfactory import gen_string
 from robottelo.cli.factory import (
     CLIFactoryError, make_gpg_key, make_org, make_product, make_sync_plan)
 from robottelo.cli.product import Product
-from nose.plugins.attrib import attr
 from robottelo.common.decorators import data, run_only_on, skip_if_bug_open
 from robottelo.test import CLITestCase
 
@@ -36,7 +35,6 @@ class TestProduct(CLITestCase):
         {u'name': gen_string('utf8', 15)},
         {u'name': gen_string('html', 15)},
     )
-    @attr('cli', 'product')
     def test_positive_create_1(self, test_name):
         """@Test: Check if product can be created with random names
 
@@ -86,7 +84,6 @@ class TestProduct(CLITestCase):
         {u'name': gen_string('html', 15),
          u'label': gen_string('numeric', 15)},
     )
-    @attr('cli', 'product')
     def test_positive_create_2(self, test_name):
         """@Test: Check if product can be created with random labels
 
@@ -137,7 +134,6 @@ class TestProduct(CLITestCase):
         {u'name': gen_string('html', 15),
          u'description': gen_string('html', 15)},
     )
-    @attr('cli', 'product')
     def test_positive_create_3(self, test_name):
         """@Test: Check if product can be created with random description
 
@@ -184,7 +180,6 @@ class TestProduct(CLITestCase):
         {u'name': gen_string('utf8', 15)},
         {u'name': gen_string('html', 15)},
     )
-    @attr('cli', 'product')
     def test_positive_create_4(self, test_name):
         """@Test: Check if product can be created with gpg key
 
@@ -233,7 +228,6 @@ class TestProduct(CLITestCase):
         {u'name': gen_string('utf8', 15)},
         {u'name': gen_string('html', 15)},
     )
-    @attr('cli', 'product')
     def test_positive_create_5(self, test_name):
         """@Test: Check if product can be created with sync plan
 
@@ -279,7 +273,6 @@ class TestProduct(CLITestCase):
         {u'name': gen_string('utf8', 300)},
         {u'name': gen_string('html', 300)},
     )
-    @attr('cli', 'product')
     def test_negative_create_1(self, test_name):
         """@Test: Check that only valid names can be used
 
@@ -306,7 +299,6 @@ class TestProduct(CLITestCase):
         {u'name': gen_string('html', 15),
          u'label': gen_string('html', 15)},
     )
-    @attr('cli', 'product')
     def test_negative_create_2(self, test_name):
         """@Test: Check that only valid labels can be used
 
@@ -335,7 +327,6 @@ class TestProduct(CLITestCase):
         {u'description': gen_string('utf8', 15)},
         {u'description': gen_string('html', 15)},
     )
-    @attr('cli', 'product')
     def test_positive_update_1(self, test_data):
         """@Test: Update the description of a product
 
@@ -399,7 +390,6 @@ class TestProduct(CLITestCase):
         {u'name': gen_string('utf8', 15)},
         {u'name': gen_string('html', 15)},
     )
-    @attr('cli', 'product')
     def test_positive_update_2(self, test_name):
         """@Test: Update product's gpg keys
 
@@ -497,7 +487,6 @@ class TestProduct(CLITestCase):
         {u'name': gen_string('utf8', 15)},
         {u'name': gen_string('html', 15)},
     )
-    @attr('cli', 'product')
     def test_positive_update_3(self, test_name):
         """@Test: Update product's sync plan
 
@@ -596,7 +585,6 @@ class TestProduct(CLITestCase):
         {u'name': gen_string('utf8', 15)},
         {u'name': gen_string('html', 15)},
     )
-    @attr('cli', 'product')
     def test_positive_delete_1(self, test_name):
         """@Test: Check if product can be deleted
 
@@ -649,7 +637,6 @@ class TestProduct(CLITestCase):
         self.assertGreater(
             len(result.stderr), 0, "Error was expected")
 
-    @attr('cli', 'product')
     def test_add_syncplan_1(self):
         """@Test: Check if product can be assigned a syncplan
 
@@ -690,7 +677,6 @@ class TestProduct(CLITestCase):
             result.stdout['sync-plan-id'], sync_plan['id'],
             "Info should have consistent sync ids.")
 
-    @attr('cli', 'product')
     def test_remove_syncplan_1(self):
         """@Test: Check if product can be assigned a syncplan
 

--- a/tests/foreman/cli/test_repository.py
+++ b/tests/foreman/cli/test_repository.py
@@ -4,7 +4,6 @@
 
 from ddt import ddt
 from fauxfactory import gen_string
-from nose.plugins.attrib import attr
 from robottelo.cli.factory import (
     make_gpg_key,
     make_org,
@@ -76,7 +75,6 @@ class TestRepository(CLITestCase):
         gen_string('utf8', 15),
         gen_string('html', 15),
     )
-    @attr('cli', 'repository')
     def test_positive_create_1(self, name):
         """@Test: Check if repository can be created with random names
 
@@ -99,7 +97,6 @@ class TestRepository(CLITestCase):
         gen_string('utf8', 15),
         gen_string('html', 15),
     )
-    @attr('cli', 'repository')
     def test_positive_create_2(self, name):
         """@Test: Check if repository can be created with random names and labels
 
@@ -132,7 +129,6 @@ class TestRepository(CLITestCase):
         {u'url': FAKE_2_YUM_REPO, u'content-type': u'yum'},
         {u'url': FAKE_1_YUM_REPO, u'content-type': u'yum'},
     )
-    @attr('cli', 'repository')
     def test_positive_create_3(self, test_data):
         """@Test: Create YUM repository
 
@@ -163,7 +159,6 @@ class TestRepository(CLITestCase):
         {u'url': FAKE_4_PUPPET_REPO, u'content-type': u'puppet'},
         {u'url': FAKE_5_PUPPET_REPO, u'content-type': u'puppet'},
     )
-    @attr('cli', 'repository')
     def test_positive_create_4(self, test_data):
         """@Test: Create Puppet repository
 
@@ -195,7 +190,6 @@ class TestRepository(CLITestCase):
         gen_string('utf8', 15),
         gen_string('html', 15),
     )
-    @attr('cli', 'repository')
     def test_positive_create_5(self, name):
         """@Test: Check if repository can be created with gpg key ID
 
@@ -242,7 +236,6 @@ class TestRepository(CLITestCase):
         gen_string('utf8', 15),
         gen_string('html', 15),
     )
-    @attr('cli', 'repository')
     def test_positive_create_6(self, name):
         """@Test: Check if repository can be created with gpg key name
 
@@ -284,7 +277,6 @@ class TestRepository(CLITestCase):
 
     @run_only_on('sat')
     @data(u'true', u'yes', u'1')
-    @attr('cli', 'repository')
     def test_positive_create_7(self, test_data):
         """@Test: Create repository published via http
 
@@ -313,7 +305,6 @@ class TestRepository(CLITestCase):
 
     @run_only_on('sat')
     @data(u'false', u'no', u'0')
-    @attr('cli', 'repository')
     def test_positive_create_8(self, use_http):
         """@Test: Create repository not published via http
 
@@ -341,7 +332,6 @@ class TestRepository(CLITestCase):
         )
 
     @run_only_on('sat')
-    @attr('cli', 'repository', 'docker')
     def test_positive_create_9(self):
         """@Test: Create a Docker repository
 
@@ -404,7 +394,6 @@ class TestRepository(CLITestCase):
         gen_string('utf8', 300),
         gen_string('html', 300),
     )
-    @attr('cli', 'repository')
     def test_negative_create_1(self, name):
         """@Test: Repository name cannot be 300-characters long
 
@@ -424,7 +413,6 @@ class TestRepository(CLITestCase):
         {u'url': FAKE_1_YUM_REPO, u'content-type': u'yum'},
     )
     @skip_if_bug_open('bugzilla', 1152237)
-    @attr('cli', 'repository')
     def test_positive_synchronize_1(self, test_data):
         """@Test: Check if repository can be created and synced
 
@@ -462,7 +450,6 @@ class TestRepository(CLITestCase):
 
     @run_only_on('sat')
     @skip_if_bug_open('bugzilla', 1152237)
-    @attr('cli', 'repository', 'docker')
     def test_positive_synchronize_2(self):
         """@Test: Check if Docker repository can be created and synced
 
@@ -497,7 +484,6 @@ class TestRepository(CLITestCase):
         FAKE_3_PUPPET_REPO,
         FAKE_2_YUM_REPO,
     )
-    @attr('cli', 'repository')
     def test_positive_update_1(self, url):
         """@Test: Update the original url for a repository
 
@@ -542,7 +528,6 @@ class TestRepository(CLITestCase):
 
     @run_only_on('sat')
     @stubbed
-    @attr('cli', 'repository')
     def test_positive_update_2(self, test_data):
         """@Test: Update the original gpg key
 
@@ -556,7 +541,6 @@ class TestRepository(CLITestCase):
 
     @run_only_on('sat')
     @stubbed
-    @attr('cli', 'repository')
     def test_positive_update_3(self, test_data):
         """@Test: Update the original publishing method
 
@@ -623,7 +607,6 @@ class TestRepository(CLITestCase):
         gen_string('utf8', 15),
         gen_string('html', 15),
     )
-    @attr('cli', 'repository')
     def test_positive_delete_1(self, name):
         """@Test: Check if repository can be created and deleted
 

--- a/tests/foreman/cli/test_subnet.py
+++ b/tests/foreman/cli/test_subnet.py
@@ -3,7 +3,6 @@
 """Test class for Subnet CLI"""
 
 from ddt import ddt
-from nose.plugins.attrib import attr
 from fauxfactory import gen_string, gen_integer, gen_ipaddr
 from robottelo.cli.factory import make_subnet, CLIFactoryError
 from robottelo.cli.subnet import Subnet
@@ -24,7 +23,6 @@ class TestSubnet(CLITestCase):
         gen_string(str_type='latin1'),
         gen_string(str_type='utf8'),
     )
-    @attr('cli', 'subnet')
     def test_positive_create_1(self, test_name):
         """@Test: Check if Subnet can be created with random names
 
@@ -128,7 +126,6 @@ class TestSubnet(CLITestCase):
         with self.assertRaises(CLIFactoryError):
             make_subnet(opts)
 
-    @attr('cli', 'subnet')
     def test_list(self):
         """@Test: Check if Subnet can be listed
 
@@ -162,7 +159,6 @@ class TestSubnet(CLITestCase):
         gen_string(str_type='latin1'),
         gen_string(str_type='utf8'),
     )
-    @attr('cli', 'subnet')
     def test_positive_update_1(self, test_name):
         """@Test: Check if Subnet name can be updated
 
@@ -352,7 +348,6 @@ class TestSubnet(CLITestCase):
         gen_string(str_type='latin1'),
         gen_string(str_type='utf8'),
     )
-    @attr('cli', 'subnet')
     def test_positive_delete_1(self, test_name):
         """@Test: Check if Subnet can be deleted
 

--- a/tests/foreman/cli/test_syncplan.py
+++ b/tests/foreman/cli/test_syncplan.py
@@ -5,7 +5,6 @@
 from datetime import datetime, timedelta
 from ddt import ddt
 from fauxfactory import gen_string
-from nose.plugins.attrib import attr
 from robottelo.cli.factory import make_org, make_sync_plan
 from robottelo.cli.syncplan import SyncPlan
 from robottelo.common.decorators import data
@@ -62,7 +61,6 @@ class TestSyncPlan(CLITestCase):
         {u'name': gen_string('utf8', 15)},
         {u'name': gen_string('html', 15)},
     )
-    @attr('cli', 'syncplan')
     def test_positive_create_1(self, test_data):
         """@Test: Check if syncplan can be created with random names
 
@@ -88,7 +86,6 @@ class TestSyncPlan(CLITestCase):
         {u'description': gen_string('utf8', 15)},
         {u'description': gen_string('html', 15)},
     )
-    @attr('cli', 'syncplan')
     def test_positive_create_2(self, test_data):
         """@Test: Check if syncplan can be created with random description
 
@@ -181,7 +178,6 @@ class TestSyncPlan(CLITestCase):
             u'interval': u'weekly'
         },
     )
-    @attr('cli', 'syncplan')
     def test_positive_create_3(self, test_data):
         """@Test: Check if syncplan can be created with varied intervals
 
@@ -214,7 +210,6 @@ class TestSyncPlan(CLITestCase):
         {u'name': gen_string('utf8', 300)},
         {u'name': gen_string('html', 300)},
     )
-    @attr('cli', 'syncplan')
     def test_negative_create_1(self, test_data):
         """@Test: Check if syncplan can be created with random names
 
@@ -235,7 +230,6 @@ class TestSyncPlan(CLITestCase):
         {u'description': gen_string('utf8', 15)},
         {u'description': gen_string('html', 15)},
     )
-    @attr('cli', 'syncplan')
     def test_positive_update_1(self, test_data):
         """@Test: Check if syncplan description can be updated
 
@@ -334,7 +328,6 @@ class TestSyncPlan(CLITestCase):
         {u'name': gen_string('html', 15),
          u'interval': u'hourly', u'new-interval': u'weekly'},
     )
-    @attr('cli', 'syncplan')
     def test_positive_update_2(self, test_data):
         """@Test: Check if syncplan interval be updated
 
@@ -407,7 +400,6 @@ class TestSyncPlan(CLITestCase):
         {u'name': gen_string('utf8', 15)},
         {u'name': gen_string('html', 15)},
     )
-    @attr('cli', 'syncplan')
     def test_positive_update_3(self, test_data):
         """@Test: Check if syncplan sync date can be updated
 
@@ -476,7 +468,6 @@ class TestSyncPlan(CLITestCase):
         {u'name': gen_string('utf8', 15)},
         {u'name': gen_string('html', 15)},
     )
-    @attr('cli', 'syncplan')
     def test_positive_delete_1(self, test_data):
         """@Test: Check if syncplan can be created and deleted
 

--- a/tests/foreman/smoke/test_api_smoke.py
+++ b/tests/foreman/smoke/test_api_smoke.py
@@ -2,7 +2,6 @@
 """Smoke tests for the ``API`` end-to-end scenario."""
 from fauxfactory import gen_string
 from nailgun import client
-from nose.plugins.attrib import attr
 from robottelo.api import utils
 from robottelo.api.utils import status_code_error
 from robottelo.common.constants import FAKE_0_PUPPET_REPO, GOOGLE_CHROME_REPO
@@ -710,7 +709,6 @@ class TestAvailableURLs(TestCase):
 class TestSmoke(TestCase):
     """End-to-end tests using the ``API`` path."""
 
-    @attr('smoke')
     def test_find_default_org(self):
         """
         @Test: Check if 'Default Organization' is present
@@ -720,7 +718,6 @@ class TestSmoke(TestCase):
         query = u'Default_Organization'
         self._search(entities.Organization, query)
 
-    @attr('smoke')
     def test_find_default_location(self):
         """
         @Test: Check if 'Default Location' is present
@@ -730,7 +727,6 @@ class TestSmoke(TestCase):
         query = u'Default_Location'
         self._search(entities.Location, query)
 
-    @attr('smoke')
     def test_find_admin_user(self):
         """
         @Test: Check if Admin User is present
@@ -740,7 +736,6 @@ class TestSmoke(TestCase):
         query = u'admin'
         self._search(entities.User, query)
 
-    @attr('smoke')
     def test_ping(self):
         """
         @Test: Check if all services are running
@@ -769,7 +764,6 @@ class TestSmoke(TestCase):
         )
 
     # FIXME: This test is still being developed and is not complete yet.
-    @attr('smoke')
     def test_smoke(self):
         """
         @Test: Check that basic content can be created
@@ -1007,7 +1001,6 @@ class TestSmoke(TestCase):
 
         return response.json()
 
-    @attr('smoke')
     def test_end_to_end(self):
         """@Test: Perform end to end smoke tests using RH repos.
 

--- a/tests/foreman/smoke/test_cli_smoke.py
+++ b/tests/foreman/smoke/test_cli_smoke.py
@@ -1,7 +1,6 @@
 """Smoke tests for the ``CLI`` end-to-end scenario."""
 from ddt import ddt
 from fauxfactory import gen_alphanumeric, gen_ipaddr
-from nose.plugins.attrib import attr
 from robottelo.cli.activationkey import ActivationKey
 from robottelo.cli.computeresource import ComputeResource
 from robottelo.cli.contentview import ContentView
@@ -36,7 +35,6 @@ import random
 class TestSmoke(CLITestCase):
     """End-to-end tests using the ``CLI`` path."""
 
-    @attr('smoke')
     def test_find_default_org(self):
         """
         @Test: Check if 'Default Organization' is present
@@ -52,7 +50,6 @@ class TestSmoke(CLITestCase):
             u"Could not find the Default Organization"
         )
 
-    @attr('smoke')
     def test_find_default_location(self):
         """
         @Test: Check if 'Default Location' is present
@@ -68,7 +65,6 @@ class TestSmoke(CLITestCase):
             u"Could not find the 'Default Location'"
         )
 
-    @attr('smoke')
     def test_find_admin_user(self):
         """
         @Test: Check if Admin User is present
@@ -91,7 +87,6 @@ class TestSmoke(CLITestCase):
                 result.stdout['admin'])
         )
 
-    @attr('smoke')
     def test_smoke(self):
         """
         @Test: Check that basic content can be created

--- a/tests/foreman/smoke/test_ui_smoke.py
+++ b/tests/foreman/smoke/test_ui_smoke.py
@@ -2,7 +2,6 @@
 
 from ddt import ddt
 from fauxfactory import gen_string, gen_ipaddr
-from nose.plugins.attrib import attr
 from robottelo.common import conf
 from robottelo.common import manifests
 from robottelo.common.constants import (
@@ -24,7 +23,6 @@ from robottelo.vm import VirtualMachine
 class TestSmoke(UITestCase):
     """End-to-end tests using the ``WebUI``."""
 
-    @attr('smoke')
     def test_find_default_org(self):
         """@Test: Check if :data:`robottelo.common.constants.DEFAULT_ORG`
         is present
@@ -39,7 +37,6 @@ class TestSmoke(UITestCase):
             selected_org = session.nav.go_to_select_org(DEFAULT_ORG)
             self.assertEqual(selected_org, DEFAULT_ORG)
 
-    @attr('smoke')
     def test_find_default_location(self):
         """@Test: Check if :data:`robottelo.common.constants.DEFAULT_LOC`
         is present
@@ -54,7 +51,6 @@ class TestSmoke(UITestCase):
             selected_loc = session.nav.go_to_select_loc(DEFAULT_LOC)
             self.assertEqual(selected_loc, DEFAULT_LOC)
 
-    @attr('smoke')
     def test_find_admin_user(self):
         """@Test: Check if Admin User is present
 
@@ -71,7 +67,6 @@ class TestSmoke(UITestCase):
             is_admin_role_selected = self.user.admin_role_to_user("admin")
             self.assertTrue(is_admin_role_selected)
 
-    @attr('smoke')
     def test_smoke(self):
         """@Test: Check that basic content can be created
 

--- a/tests/foreman/ui/test_activationkey.py
+++ b/tests/foreman/ui/test_activationkey.py
@@ -11,7 +11,6 @@ else:
 from ddt import ddt
 from fauxfactory import gen_string
 from nailgun import client
-from nose.plugins.attrib import attr
 from robottelo import entities
 from robottelo.api import utils
 from robottelo.common import manifests
@@ -142,7 +141,6 @@ class ActivationKey(UITestCase):
             cv_version.promote(environment_id=env_attrs['id'])['result']
         )
 
-    @attr('ui', 'ak', 'implemented')
     @data(*valid_data_list())
     def test_positive_create_activation_key_1(self, name):
         """@Test: Create Activation key for all variations of Activation
@@ -166,7 +164,6 @@ class ActivationKey(UITestCase):
             )
             self.assertIsNotNone(self.activationkey.search_key(name))
 
-    @attr('ui', 'ak', 'implemented')
     @data(*valid_data_list())
     def test_positive_create_activation_key_2(self, description):
         """@Test: Create Activation key for all variations of Description
@@ -190,7 +187,6 @@ class ActivationKey(UITestCase):
             self.assertIsNotNone(self.activationkey.search_key(name))
 
     @run_only_on('sat')
-    @attr('ui', 'ak', 'implemented')
     @data(*valid_data_list())
     def test_positive_create_activation_key_3(self, env_name):
         """@Test: Create Activation key for all variations of Environments
@@ -222,7 +218,6 @@ class ActivationKey(UITestCase):
             self.assertIsNotNone(self.activationkey.search_key(name))
 
     @run_only_on('sat')
-    @attr('ui', 'ak', 'implemented')
     @data(*valid_data_list())
     def test_positive_create_activation_key_4(self, cv_name):
         """@Test: Create Activation key for all variations of Content Views
@@ -252,7 +247,6 @@ class ActivationKey(UITestCase):
             )
             self.assertIsNotNone(self.activationkey.search_key(name))
 
-    @attr('ui', 'ak', 'implemented')
     @data(*valid_data_list())
     def test_positive_create_activation_key_5(self, hc_name):
         """@Test: Create Activation key for all variations of Host Collections
@@ -293,7 +287,6 @@ class ActivationKey(UITestCase):
                 strategy, value % host_col['name']))
             self.assertIsNotNone(host_collection)
 
-    @attr('ui', 'ak', 'implemented')
     def test_positive_create_activation_key_6(self):
         """@Test: Create Activation key with default Usage limit (Unlimited)
 
@@ -317,7 +310,6 @@ class ActivationKey(UITestCase):
             )
             self.assertIsNotNone(self.activationkey.search_key(name))
 
-    @attr('ui', 'ak', 'implemented')
     def test_positive_create_activation_key_7(self):
         """@Test: Create Activation key with finite Usage limit
 
@@ -343,7 +335,6 @@ class ActivationKey(UITestCase):
                                description=description)
             self.assertIsNotNone(self.activationkey.search_key(name))
 
-    @attr('ui', 'ak', 'implemented')
     def test_positive_create_activation_key_8(self):
         """@Test: Create Activation key with minimal input parameters
 
@@ -441,7 +432,6 @@ class ActivationKey(UITestCase):
             self.assertIsNotNone(invalid)
             self.assertIsNone(self.activationkey.search_key(name))
 
-    @attr('ui', 'ak', 'implemented')
     @data(*valid_data_list())
     def test_positive_delete_activation_key_1(self, name):
         """@Test: Create Activation key and delete it for all variations of
@@ -467,7 +457,6 @@ class ActivationKey(UITestCase):
             self.activationkey.delete(name, True)
             self.assertIsNone(self.activationkey.search_key(name))
 
-    @attr('ui', 'ak', 'implemented')
     @data(*valid_data_list())
     def test_positive_delete_activation_key_2(self, description):
         """@Test: Create Activation key and delete it for all variations of
@@ -494,7 +483,6 @@ class ActivationKey(UITestCase):
             self.assertIsNone(self.activationkey.search_key(name))
 
     @run_only_on('sat')
-    @attr('ui', 'ak', 'implemented')
     @data(*valid_data_list())
     def test_positive_delete_activation_key_3(self, env_name):
         """@Test: Create Activation key and delete it for all variations of
@@ -526,7 +514,6 @@ class ActivationKey(UITestCase):
             self.assertIsNone(self.activationkey.search_key(name))
 
     @run_only_on('sat')
-    @attr('ui', 'ak', 'implemented')
     @data(*valid_data_list())
     def test_positive_delete_activation_key_4(self, cv_name):
         """@Test: Create Activation key and delete it for all variations of
@@ -690,7 +677,6 @@ class ActivationKey(UITestCase):
             self.assertIsNotNone(self.activationkey.search_key(name))
 
     @skip_if_bug_open('bugzilla', 1177330)
-    @attr('ui', 'ak', 'implemented')
     @data(*valid_data_list())
     def test_positive_update_activation_key_1(self, new_name):
         """@Test: Update Activation Key Name in an Activation key
@@ -715,7 +701,6 @@ class ActivationKey(UITestCase):
             self.activationkey.update(name, new_name)
             self.assertIsNotNone(self.activationkey.search_key(new_name))
 
-    @attr('ui', 'ak', 'implemented')
     @data(*valid_data_list())
     def test_positive_update_activation_key_2(self, new_description):
         """@Test: Update Description in an Activation key
@@ -744,7 +729,6 @@ class ActivationKey(UITestCase):
                                  (common_locators["alert.success"]))
 
     @run_only_on('sat')
-    @attr('ui', 'ak', 'implemented')
     @data(*valid_data_list())
     def test_positive_update_activation_key_3(self, env_name):
         """@Test: Update Environment in an Activation key
@@ -782,7 +766,6 @@ class ActivationKey(UITestCase):
             self.assertEqual(env_name, selected_env)
 
     @run_only_on('sat')
-    @attr('ui', 'ak', 'implemented')
     @data(*valid_data_list())
     def test_positive_update_activation_key_4(self, cv2_name):
         """@Test: Update Content View in an Activation key
@@ -827,7 +810,6 @@ class ActivationKey(UITestCase):
             self.assertEqual(cv2_name, selected_cv)
             # TODO: Need to check for RH Product too
 
-    @attr('ui', 'ak', 'implemented')
     def test_positive_update_activation_key_5(self):
         """@Test: Update Usage limit from Unlimited to a finite number
 
@@ -854,7 +836,6 @@ class ActivationKey(UITestCase):
                                  (common_locators["alert.success"]))
 
     @skip_if_bug_open('bugzilla', 1127090)
-    @attr('ui', 'ak', 'implemented')
     def test_positive_update_activation_key_6(self):
         """@Test: Update Usage limit from definite number to Unlimited
 
@@ -967,7 +948,6 @@ class ActivationKey(UITestCase):
                              "Please update content host limit "
                              "with valid integer value")
 
-    @attr('ui', 'ak', 'implemented')
     @run_only_on('sat')
     def test_usage_limit(self):
         """@Test: Test that Usage limit actually limits usage
@@ -1375,7 +1355,6 @@ class ActivationKey(UITestCase):
         pass
 
     @run_only_on('sat')
-    @attr('ui', 'ak', 'implemented')
     @data(*valid_names_list())
     def test_positive_copy_activation_key(self, new_name):
         """@Test: Create Activation key and copy it
@@ -1398,7 +1377,6 @@ class ActivationKey(UITestCase):
             self.assertIsNotNone(self.activationkey.search_key(new_name))
 
     @run_only_on('sat')
-    @attr('ui', 'ak', 'implemented')
     @data(*invalid_names_list())
     def test_negative_copy_activation_key(self, new_name):
         """@Test: Create Activation key and fail copying it

--- a/tests/foreman/ui/test_computeresource.py
+++ b/tests/foreman/ui/test_computeresource.py
@@ -3,7 +3,6 @@
 
 from ddt import ddt
 from fauxfactory import gen_string
-from nose.plugins.attrib import attr
 from robottelo.common import conf
 from robottelo.common.constants import FOREMAN_PROVIDERS
 from robottelo.common.decorators import run_only_on
@@ -21,7 +20,6 @@ from robottelo import entities
 class ComputeResource(UITestCase):
     """Implements Compute Resource tests in UI"""
 
-    @attr('ui', 'resource', 'implemented')
     @data(*generate_strings_list(len1=8))
     def test_create_resource_1(self, name):
         """@Test: Create a new libvirt Compute Resource
@@ -40,7 +38,6 @@ class ComputeResource(UITestCase):
             search = self.compute_resource.search(name)
             self.assertIsNotNone(search)
 
-    @attr('ui', 'resource', 'implemented')
     @data(
         gen_string('alphanumeric', 255),
         gen_string('alpha', 255),
@@ -65,7 +62,6 @@ class ComputeResource(UITestCase):
             search = self.compute_resource.search(name)
             self.assertIsNotNone(search)
 
-    @attr('ui', 'resource', 'implemented')
     @data(
         gen_string('alphanumeric', 255),
         gen_string('alpha', 255),
@@ -93,7 +89,6 @@ class ComputeResource(UITestCase):
             search = self.compute_resource.search(name)
             self.assertIsNotNone(search)
 
-    @attr('ui', 'resource', 'implemented')
     @data(*generate_strings_list(len1=256))
     def test_create_resource_negative_1(self, name):
         """@Test: Create a new libvirt Compute Resource with 256 char name
@@ -113,7 +108,6 @@ class ComputeResource(UITestCase):
                 common_locators["name_haserror"]
             ))
 
-    @attr('ui', 'resource', 'implemented')
     @data(*generate_strings_list(len1=256))
     def test_create_resource_negative_2(self, description):
         """@Test: Create libvirt Compute Resource with 256 char description.
@@ -155,7 +149,6 @@ class ComputeResource(UITestCase):
                 common_locators["name_haserror"])
             self.assertIsNotNone(error_element)
 
-    @attr('ui', 'resource', 'implemented')
     @data({'name': gen_string('alpha'),
            'newname': gen_string('alpha')},
           {'name': gen_string('numeric'),
@@ -199,7 +192,6 @@ class ComputeResource(UITestCase):
             search = self.compute_resource.search(newname)
             self.assertIsNotNone(search)
 
-    @attr('ui', 'location', 'implemented')
     @data(*generate_strings_list(len1=8))
     def test_remove_resource(self, name):
         """@Test: Delete a Compute Resource

--- a/tests/foreman/ui/test_config_groups.py
+++ b/tests/foreman/ui/test_config_groups.py
@@ -2,7 +2,6 @@
 
 from ddt import ddt
 from fauxfactory import gen_string
-from nose.plugins.attrib import attr
 from robottelo.common.decorators import data, run_only_on
 from robottelo.common.helpers import generate_strings_list
 from robottelo.test import UITestCase
@@ -16,7 +15,6 @@ from robottelo.ui.session import Session
 class ConfigGroups(UITestCase):
     """Implements Config Groups tests in UI."""
 
-    @attr('ui', 'config-groups', 'implemented')
     @data(*generate_strings_list(len1=8))
     def test_create_positive_1(self, name):
         """@Test: Create new Config-Group
@@ -31,7 +29,6 @@ class ConfigGroups(UITestCase):
             search = self.configgroups.search(name)
             self.assertIsNotNone(search)
 
-    @attr('ui', 'config-groups', 'implemented')
     @data(
         gen_string('alphanumeric', 255),
         gen_string('alpha', 255),
@@ -52,7 +49,6 @@ class ConfigGroups(UITestCase):
             search = self.configgroups.search(name)
             self.assertIsNotNone(search)
 
-    @attr('ui', 'config-groups', 'implemented')
     @data(*generate_strings_list(len1=256))
     def test_create_negative_1(self, name):
         """@Test: Create new config-groups with 256 chars
@@ -86,7 +82,6 @@ class ConfigGroups(UITestCase):
                 common_locators["name_haserror"])
             self.assertIsNotNone(error)
 
-    @attr('ui', 'config-group', 'implemented')
     @data({'name': gen_string('alpha', 10),
            'new_name': gen_string('alpha', 10)},
           {'name': gen_string('numeric', 10),
@@ -115,7 +110,6 @@ class ConfigGroups(UITestCase):
             search = self.configgroups.search(new_name)
             self.assertIsNotNone(search)
 
-    @attr('ui', 'config-groups', 'implemented')
     @data(*generate_strings_list(len1=8))
     def test_delete_positive_1(self, name):
         """@Test: Create new config-groups

--- a/tests/foreman/ui/test_contentenv.py
+++ b/tests/foreman/ui/test_contentenv.py
@@ -3,7 +3,6 @@
 """Test class for Life cycle environments UI"""
 
 from fauxfactory import gen_string
-from nose.plugins.attrib import attr
 from robottelo import entities
 from robottelo.common.decorators import run_only_on
 from robottelo.test import UITestCase
@@ -22,7 +21,6 @@ class ContentEnvironment(UITestCase):
 
         super(ContentEnvironment, cls).setUpClass()
 
-    @attr('ui', 'contentenv', 'implemented')
     def test_positive_create_content_environment_1(self):
         """@Test: Create content environment with minimal input parameters
 
@@ -40,7 +38,6 @@ class ContentEnvironment(UITestCase):
             self.assertIsNotNone(self.contentenv.wait_until_element
                                  ((strategy, value % name)))
 
-    @attr('ui', 'contentenv', 'implemented')
     def test_positive_create_content_environment_2(self):
         """@Test: Create Content Environment in a chain
 
@@ -63,7 +60,6 @@ class ContentEnvironment(UITestCase):
             self.assertIsNotNone(self.contentenv.wait_until_element
                                  ((strategy, value % env2_name)))
 
-    @attr('ui', 'contentenv', 'implemented')
     def test_positive_delete_content_environment_1(self):
         """@Test: Create Content Environment and delete it
 
@@ -85,7 +81,6 @@ class ContentEnvironment(UITestCase):
             self.assertIsNone(self.contentenv.wait_until_element
                               ((strategy, value % name), 3))
 
-    @attr('ui', 'contentenv', 'implemented')
     def test_positive_update_content_environment_1(self):
         """@Test: Create Content Environment and update it
 

--- a/tests/foreman/ui/test_domain.py
+++ b/tests/foreman/ui/test_domain.py
@@ -3,7 +3,6 @@
 """Test class for Domain UI"""
 from ddt import ddt
 from fauxfactory import gen_string
-from nose.plugins.attrib import attr
 from robottelo.common.decorators import data, run_only_on, skip_if_bug_open
 from robottelo.common.helpers import generate_strings_list
 from robottelo.test import UITestCase
@@ -19,7 +18,6 @@ DOMAIN = "lab.dom.%s.com"
 class Domain(UITestCase):
     """Implements Domain tests in UI"""
 
-    @attr('ui', 'domain', 'implemented')
     @data(*generate_strings_list(len1=4))
     def test_create_domain_1(self, name):
         """@Test: Create a new domain
@@ -35,7 +33,6 @@ class Domain(UITestCase):
             element = self.domain.search(description)
             self.assertIsNotNone(element)
 
-    @attr('ui', 'domain', 'implemented')
     # The length of chars is in accordance with DOMAIN global variable.
     @data(
         gen_string('alphanumeric', 243),
@@ -58,7 +55,6 @@ class Domain(UITestCase):
             element = self.domain.search(description)
             self.assertIsNotNone(element)
 
-    @attr('ui', 'domain', 'implemented')
     @data(*generate_strings_list(len1=4))
     def test_remove_domain(self, name):
         """@Test: Delete a domain
@@ -79,7 +75,6 @@ class Domain(UITestCase):
                 common_locators["notif.success"]))
             self.assertIsNone(self.domain.search(description, timeout=5))
 
-    @attr('ui', 'domain', 'implemented')
     @data({'name': gen_string('alpha', 10),
            'newname': gen_string('alpha', 10)},
           {'name': gen_string('numeric', 10),
@@ -109,7 +104,6 @@ class Domain(UITestCase):
             self.domain.update(domain_name, new_name, new_description)
             self.assertIsNotNone(self.domain.search(new_description))
 
-    @attr('ui', 'domain', 'implemented')
     # The length of chars is in accordance with DOMAIN global variable.
     @data(*generate_strings_list(len1=244))
     def test_negative_create_domain_1(self, name):
@@ -142,7 +136,6 @@ class Domain(UITestCase):
                 common_locators["name_haserror"])
             self.assertIsNotNone(error)
 
-    @attr('ui', 'domain', 'implemented')
     @data(*generate_strings_list(len1=4))
     def test_positive_set_domain_parameter_1(self, name):
         """@Test: Set parameter name and value for domain
@@ -262,7 +255,6 @@ class Domain(UITestCase):
             self.assertIsNotNone(session.nav.wait_until_element(
                 common_locators["common_param_error"]))
 
-    @attr('ui', 'domain', 'implemented')
     @data(*generate_strings_list(len1=4))
     def test_remove_domain_parameter(self, name):
         """@Test: Remove a selected domain paramter

--- a/tests/foreman/ui/test_environment.py
+++ b/tests/foreman/ui/test_environment.py
@@ -4,7 +4,6 @@
 
 from ddt import ddt
 from fauxfactory import gen_string
-from nose.plugins.attrib import attr
 from robottelo.common.decorators import data, run_only_on, skip_if_bug_open
 from robottelo.test import UITestCase
 from robottelo.ui.factory import make_env
@@ -21,7 +20,6 @@ class Environment(UITestCase):
 
     """
 
-    @attr('ui', 'environment', 'implemented')
     @data(
         gen_string('alpha', 8),
         gen_string('numeric', 8),
@@ -40,7 +38,6 @@ class Environment(UITestCase):
             search = self.environment.search(name)
             self.assertIsNotNone(search)
 
-    @attr('ui', 'environment', 'implemented')
     @data(
         gen_string('alpha', 255),
         gen_string('numeric', 255),
@@ -59,7 +56,6 @@ class Environment(UITestCase):
             search = self.environment.search(name)
             self.assertIsNotNone(search)
 
-    @attr('ui', 'environment', 'implemented')
     @data(
         gen_string('alpha', 256),
         gen_string('numeric', 256),
@@ -94,7 +90,6 @@ class Environment(UITestCase):
             self.assertIsNotNone(error)
 
     @skip_if_bug_open('bugzilla', 1126033)
-    @attr('ui', 'environment', 'implemented')
     @data({'name': gen_string('alpha', 8),
            'new_name': gen_string('alpha', 8)},
           {'name': gen_string('numeric', 8),
@@ -120,7 +115,6 @@ class Environment(UITestCase):
             self.assertIsNotNone(search)
 
     @skip_if_bug_open('bugzilla', 1126033)
-    @attr('ui', 'environment', 'implemented')
     @data(
         gen_string('alpha', 8),
         gen_string('numeric', 8),

--- a/tests/foreman/ui/test_gpgkey.py
+++ b/tests/foreman/ui/test_gpgkey.py
@@ -11,7 +11,6 @@ else:
 
 from ddt import ddt
 from fauxfactory import gen_string
-from nose.plugins.attrib import attr
 from robottelo import entities
 from robottelo.common.constants import (
     FAKE_1_YUM_REPO,
@@ -46,7 +45,6 @@ class GPGKey(UITestCase):
 
     # Positive Create
 
-    @attr('ui', 'gpgkey', 'implemented')
     @data(*generate_strings_list())
     def test_positive_create_1(self, name):
         """@test: Create gpg key with valid name and valid gpg key
@@ -65,7 +63,6 @@ class GPGKey(UITestCase):
                         key_path=key_path)
             self.assertIsNotNone(self.gpgkey.search(name))
 
-    @attr('ui', 'gpgkey', 'implemented')
     @data(*generate_strings_list())
     def test_positive_create_2(self, name):
         """@test: Create gpg key with valid name and valid gpg key text via
@@ -85,7 +82,6 @@ class GPGKey(UITestCase):
 
     # Negative Create
 
-    @attr('ui', 'gpgkey', 'implemented')
     @data(*generate_strings_list())
     def test_negative_create_1(self, name):
         """@test: Create gpg key with valid name and valid gpg key via
@@ -109,7 +105,6 @@ class GPGKey(UITestCase):
             self.assertIsNotNone(self.gpgkey.wait_until_element
                                  (common_locators["alert.error"]))
 
-    @attr('ui', 'gpgkey', 'implemented')
     @data(*generate_strings_list())
     def test_negative_create_2(self, name):
         """@test: Create gpg key with valid name and valid gpg key text via
@@ -131,7 +126,6 @@ class GPGKey(UITestCase):
             self.assertTrue(self.gpgkey.wait_until_element
                             (common_locators["alert.error"]))
 
-    @attr('ui', 'gpgkey', 'implemented')
     @data(*generate_strings_list())
     def test_negative_create_3(self, name):
         """@test: Create gpg key with valid name and no gpg key
@@ -148,7 +142,6 @@ class GPGKey(UITestCase):
                             name=name)
             self.assertIsNone(self.gpgkey.search(name))
 
-    @attr('ui', 'gpgkey', 'implemented')
     @data(*invalid_names_list())
     def test_negative_create_4(self, name):
         """@test: Create gpg key with invalid name and valid gpg key via
@@ -169,7 +162,6 @@ class GPGKey(UITestCase):
                             (common_locators["alert.error"]))
             self.assertIsNone(self.gpgkey.search(name))
 
-    @attr('ui', 'gpgkey', 'implemented')
     def test_negative_create_5(self):
         """@test: Create gpg key with blank name and valid gpg key via
         file import
@@ -189,7 +181,6 @@ class GPGKey(UITestCase):
                             (common_locators["haserror"]))
             self.assertIsNone(self.gpgkey.search(name))
 
-    @attr('ui', 'gpgkey', 'implemented')
     @data(*invalid_names_list())
     def test_negative_create_6(self, name):
         """@test: Create gpg key with invalid name and valid gpg key text via
@@ -211,7 +202,6 @@ class GPGKey(UITestCase):
 
     # Positive Delete
 
-    @attr('ui', 'gpgkey', 'implemented')
     @data(*valid_names_list())
     def test_positive_delete_1(self, name):
         """@test: Create gpg key with valid name and valid gpg key via file
@@ -232,7 +222,6 @@ class GPGKey(UITestCase):
             self.gpgkey.delete(name, True)
             self.assertIsNone(self.gpgkey.search(name))
 
-    @attr('ui', 'gpgkey', 'implemented')
     @data(*valid_names_list())
     def test_positive_delete_2(self, name):
         """@test: Create gpg key with valid name and valid gpg key text via
@@ -254,7 +243,6 @@ class GPGKey(UITestCase):
 
     # Positive Update
 
-    @attr('ui', 'gpgkey', 'implemented')
     def test_positive_update_1(self):
         """@test: Create gpg key with valid name and valid gpg key via file
         import then update its name
@@ -277,7 +265,6 @@ class GPGKey(UITestCase):
             self.assertTrue(self.gpgkey.wait_until_element
                             (common_locators["alert.success"]))
 
-    @attr('ui', 'gpgkey', 'implemented')
     def test_positive_update_2(self):
         """@test: Create gpg key with valid name and valid gpg key via file
         import then update its gpg key file
@@ -300,7 +287,6 @@ class GPGKey(UITestCase):
             self.assertTrue(self.gpgkey.wait_until_element
                             (common_locators["alert.success"]))
 
-    @attr('ui', 'gpgkey', 'implemented')
     def test_positive_update_3(self):
         """@test: Create gpg key with valid name and valid gpg key text via
         cut and paste/string then update its name
@@ -322,7 +308,6 @@ class GPGKey(UITestCase):
             self.assertTrue(self.gpgkey.wait_until_element
                             (common_locators["alert.success"]))
 
-    @attr('ui', 'gpgkey', 'implemented')
     def test_positive_update_4(self):
         """@test: Create gpg key with valid name and valid gpg key text via
         cut and paste/string then update its gpg key text
@@ -346,7 +331,6 @@ class GPGKey(UITestCase):
 
     # Negative Update
 
-    @attr('ui', 'gpgkey', 'implemented')
     @data(*invalid_names_list())
     def test_negative_update_1(self, new_name):
         """@test: Create gpg key with valid name and valid gpg key via file
@@ -370,7 +354,6 @@ class GPGKey(UITestCase):
                             (common_locators["alert.error"]))
             self.assertIsNone(self.gpgkey.search(new_name))
 
-    @attr('ui', 'gpgkey', 'implemented')
     @data(*invalid_names_list())
     def test_negative_update_2(self, new_name):
         """@test: Create gpg key with valid name and valid gpg key text via
@@ -395,7 +378,6 @@ class GPGKey(UITestCase):
 
     # Product association
 
-    @attr('ui', 'gpgkey', 'implemented')
     @data(*generate_strings_list())
     def test_key_associate_1(self, name):
         """@test: Create gpg key with valid name and valid gpg key
@@ -427,7 +409,6 @@ class GPGKey(UITestCase):
             self.assertIsNotNone(self.gpgkey.assert_product_repo
                                  (name, product=True))
 
-    @attr('ui', 'gpgkey', 'implemented')
     @data(*generate_strings_list())
     def test_key_associate_2(self, name):
         """@test: Create gpg key with valid name and valid gpg key
@@ -470,7 +451,6 @@ class GPGKey(UITestCase):
             self.assertIsNotNone(self.gpgkey.assert_product_repo
                                  (name, product=False))
 
-    @attr('ui', 'gpgkey', 'implemented')
     @data(*generate_strings_list())
     def test_key_associate_3(self, name):
         """@test: Create gpg key with valid name and valid gpg key
@@ -521,7 +501,6 @@ class GPGKey(UITestCase):
                                  (name, product=False))
 
     @skip_if_bug_open('bugzilla', 1085035)
-    @attr('ui', 'gpgkey', 'implemented')
     @data(*generate_strings_list())
     def test_key_associate_4(self, name):
         """@test: Create gpg key with valid name and valid gpg key
@@ -554,7 +533,6 @@ class GPGKey(UITestCase):
             self.assertIsNotNone(self.gpgkey.assert_product_repo
                                  (name, product=False))
 
-    @attr('ui', 'gpgkey', 'implemented')
     @data(*generate_strings_list())
     def test_key_associate_5(self, name):
         """@test: Create gpg key with valid name and valid gpg key then
@@ -597,7 +575,6 @@ class GPGKey(UITestCase):
             self.assertIsNotNone(self.gpgkey.assert_product_repo
                                  (name, product=False))
 
-    @attr('ui', 'gpgkey', 'implemented')
     @data(*generate_strings_list())
     def test_key_associate_6(self, name):
         """@test: Create gpg key with valid name and valid gpg key then
@@ -675,7 +652,6 @@ class GPGKey(UITestCase):
 
         pass
 
-    @attr('ui', 'gpgkey', 'implemented')
     @data(*generate_strings_list())
     def test_key_associate_8(self, name):
         """@test: Create gpg key with valid name and valid gpg key then
@@ -713,7 +689,6 @@ class GPGKey(UITestCase):
             self.assertEqual(product_name, self.gpgkey.assert_product_repo
                              (new_name, product=True))
 
-    @attr('ui', 'gpgkey', 'implemented')
     @data(*generate_strings_list())
     def test_key_associate_9(self, name):
         """@test: Create gpg key with valid name and valid gpg key
@@ -765,7 +740,6 @@ class GPGKey(UITestCase):
             self.assertIsNotNone(self.gpgkey.assert_product_repo
                                  (new_name, product=False))
 
-    @attr('ui', 'gpgkey', 'implemented')
     @data(*generate_strings_list())
     def test_key_associate_10(self, name):
         """@test: Create gpg key with valid name and valid gpg key
@@ -825,7 +799,6 @@ class GPGKey(UITestCase):
                                  (new_name, product=False))
 
     @skip_if_bug_open('bugzilla', 1085035)
-    @attr('ui', 'gpgkey', 'implemented')
     @data(*generate_strings_list())
     def test_key_associate_11(self, name):
         """@test: Create gpg key with valid name and valid gpg key
@@ -868,7 +841,6 @@ class GPGKey(UITestCase):
             self.assertIsNotNone(self.gpgkey.assert_product_repo
                                  (new_name, product=False))
 
-    @attr('ui', 'gpgkey', 'implemented')
     @data(*generate_strings_list())
     def test_key_associate_12(self, name):
         """@test: Create gpg key with valid name and valid gpg key then
@@ -921,7 +893,6 @@ class GPGKey(UITestCase):
             self.assertIsNotNone(self.gpgkey.assert_product_repo
                                  (new_name, product=False))
 
-    @attr('ui', 'gpgkey', 'implemented')
     @data(*generate_strings_list())
     def test_key_associate_13(self, name):
         """@test: Create gpg key with valid name and valid gpg key then
@@ -1009,7 +980,6 @@ class GPGKey(UITestCase):
 
         pass
 
-    @attr('ui', 'gpgkey', 'implemented')
     @data(*generate_strings_list())
     def test_key_associate_15(self, name):
         """@test: Create gpg key with valid name and valid gpg key
@@ -1048,7 +1018,6 @@ class GPGKey(UITestCase):
             self.assertIsNone(self.gpgkey.assert_key_from_product
                               (name, product_name))
 
-    @attr('ui', 'gpgkey', 'implemented')
     @data(*generate_strings_list())
     def test_key_associate_16(self, name):
         """@test: Create gpg key with valid name and valid gpg key then
@@ -1096,7 +1065,6 @@ class GPGKey(UITestCase):
             self.assertIsNone(self.gpgkey.assert_key_from_product
                               (name, product_name))
 
-    @attr('ui', 'gpgkey', 'implemented')
     @data(*generate_strings_list())
     def test_key_associate_17(self, name):
         """@test: Create gpg key with valid name and valid gpg key
@@ -1153,7 +1121,6 @@ class GPGKey(UITestCase):
                               (name, product_name))
 
     @skip_if_bug_open('bugzilla', 1085035)
-    @attr('ui', 'gpgkey', 'implemented')
     @data(*generate_strings_list())
     def test_key_associate_18(self, name):
         """@test: Create gpg key with valid name and valid gpg then associate
@@ -1194,7 +1161,6 @@ class GPGKey(UITestCase):
             self.assertIsNone(self.gpgkey.assert_key_from_product
                               (name, prd_name))
 
-    @attr('ui', 'gpgkey', 'implemented')
     @data(*generate_strings_list())
     def test_key_associate_19(self, name):
         """@test: Create gpg key with valid name and valid gpg key then
@@ -1243,7 +1209,6 @@ class GPGKey(UITestCase):
             self.assertIsNone(self.gpgkey.assert_key_from_product
                               (name, product_name, repository_name))
 
-    @attr('ui', 'gpgkey', 'implemented')
     @data(*generate_strings_list())
     def test_key_associate_20(self, name):
         """@test: Create gpg key with valid name and valid gpg key then

--- a/tests/foreman/ui/test_hw_model.py
+++ b/tests/foreman/ui/test_hw_model.py
@@ -2,7 +2,6 @@
 
 from ddt import ddt
 from fauxfactory import gen_string
-from nose.plugins.attrib import attr
 from robottelo.common.decorators import data, run_only_on
 from robottelo.common.helpers import generate_strings_list
 from robottelo.test import UITestCase
@@ -16,7 +15,6 @@ from robottelo.ui.session import Session
 class HardwareModelTestCase(UITestCase):
     """Implements Hardware Model tests in UI."""
 
-    @attr('ui', 'hardware-model', 'implemented')
     @data(*generate_strings_list(len1=8))
     def test_create_positive_1(self, name):
         """@test: Create new Hardware-Model
@@ -31,7 +29,6 @@ class HardwareModelTestCase(UITestCase):
             search = self.hardwaremodel.search(name)
             self.assertIsNotNone(search)
 
-    @attr('ui', 'hardware-model', 'implemented')
     @data(
         gen_string('alphanumeric', 255),
         gen_string('alpha', 255),
@@ -52,7 +49,6 @@ class HardwareModelTestCase(UITestCase):
             search = self.hardwaremodel.search(name)
             self.assertIsNotNone(search)
 
-    @attr('ui', 'hardware-model', 'implemented')
     @data(*generate_strings_list(len1=256))
     def test_create_negative_1(self, name):
         """@test: Create new Hardware-Model with 256 chars
@@ -98,7 +94,6 @@ class HardwareModelTestCase(UITestCase):
                 common_locators["name_haserror"])
             self.assertIsNotNone(error)
 
-    @attr('ui', 'hardware-model', 'implemented')
     @data({'name': gen_string('alpha'),
            'new_name': gen_string('alpha')},
           {'name': gen_string('numeric'),
@@ -127,7 +122,6 @@ class HardwareModelTestCase(UITestCase):
             search = self.hardwaremodel.search(new_name)
             self.assertIsNotNone(search)
 
-    @attr('ui', 'hardware-model', 'implemented')
     @data(*generate_strings_list(len1=8))
     def test_delete_positive_1(self, name):
         """@test: Deletes the Hardware-Model

--- a/tests/foreman/ui/test_location.py
+++ b/tests/foreman/ui/test_location.py
@@ -6,7 +6,6 @@
 
 from ddt import ddt
 from fauxfactory import gen_string, gen_ipaddr
-from nose.plugins.attrib import attr
 from robottelo import entities
 from robottelo.common import conf
 from robottelo.common.decorators import (data, run_only_on, skip_if_bug_open,
@@ -50,7 +49,6 @@ class Location(UITestCase):
 
     # Positive Create
 
-    @attr('ui', 'location', 'implemented')
     @data(*generate_strings_list())
     def test_positive_create_1(self, loc_name):
         """@test: Create Location with valid name only
@@ -66,7 +64,6 @@ class Location(UITestCase):
             self.assertIsNotNone(self.location.search(loc_name))
 
     @skip_if_bug_open('bugzilla', 1123818)
-    @attr('ui', 'location', 'implemented')
     @data(*generate_strings_list(len1=247))
     def test_negative_create_1(self, loc_name):
         """@test: Create location with name as too long
@@ -116,7 +113,6 @@ class Location(UITestCase):
                 common_locators["name_haserror"])
             self.assertIsNotNone(error)
 
-    @attr('ui', 'location', 'implemented')
     @data(*generate_strings_list())
     def test_negative_create_4(self, loc_name):
         """@test: Create location with valid values, then create a new one
@@ -136,7 +132,6 @@ class Location(UITestCase):
                 common_locators["name_haserror"])
             self.assertIsNotNone(error)
 
-    @attr('ui', 'location', 'implemented')
     @data({'org_name': gen_string('alpha', 10),
            'loc_name': gen_string('alpha', 10)},
           {'org_name': gen_string('numeric', 10),
@@ -171,7 +166,6 @@ class Location(UITestCase):
 
     # Positive Update
 
-    @attr('ui', 'location', 'implemented')
     @data(*generate_strings_list())
     def test_positive_update_1(self, new_name):
         """@test: Create Location with valid values then update its name
@@ -192,7 +186,6 @@ class Location(UITestCase):
     # Negative Update
 
     @skip_if_bug_open('bugzilla', 1123818)
-    @attr('ui', 'location', 'implemented')
     @data(*generate_strings_list())
     def test_negative_update_1(self, loc_name):
         """@test: Create Location with valid values then fail to update
@@ -217,7 +210,6 @@ class Location(UITestCase):
 
     # Miscellaneous
 
-    @attr('ui', 'location', 'implemented')
     @data(*generate_strings_list())
     def test_search_key_1(self, loc_name):
         """@test: Create location and search/find it
@@ -231,7 +223,6 @@ class Location(UITestCase):
             make_loc(session, name=loc_name)
             self.assertIsNotNone(self.location.search(loc_name))
 
-    @attr('ui', 'location', 'implemented')
     @data(*generate_strings_list())
     def test_add_subnet_1(self, subnet_name):
         """@test: Add a subnet by using location name and subnet name
@@ -262,7 +253,6 @@ class Location(UITestCase):
                                                       value % subnet_name))
             self.assertIsNotNone(element)
 
-    @attr('ui', 'location', 'implemented')
     @data(*generate_strings_list())
     def test_add_domain_1(self, domain_name):
         """@test: Add a domain to a Location
@@ -287,7 +277,6 @@ class Location(UITestCase):
                                                       value % domain_name))
             self.assertIsNotNone(element)
 
-    @attr('ui', 'location', 'implemented')
     @data(gen_string('alpha', 8),
           gen_string('numeric', 8),
           gen_string('alphanumeric', 8),
@@ -340,7 +329,6 @@ class Location(UITestCase):
                 tab_locators["context.tab_hostgrps"], context="location")
             self.assertIsNotNone(selected)
 
-    @attr('ui', 'location', 'implemented')
     @data(*generate_strings_list())
     def test_add_hostgroup_1(self, host_grp_name):
         """@test: Add a hostgroup by using the location
@@ -365,7 +353,6 @@ class Location(UITestCase):
                                                       value % host_grp_name))
             self.assertIsNotNone(element)
 
-    @attr('ui', 'location', 'implemented')
     @data(*generate_strings_list())
     def test_add_org_1(self, org_name):
         """@test: Add a organization by using the location
@@ -391,7 +378,6 @@ class Location(UITestCase):
                                                       value % org_name))
             self.assertIsNotNone(element)
 
-    @attr('ui', 'location', 'implemented')
     @data(gen_string('alpha', 8),
           gen_string('numeric', 8),
           gen_string('alphanumeric', 8))
@@ -418,7 +404,6 @@ class Location(UITestCase):
                                                       value % env_name))
             self.assertIsNotNone(element)
 
-    @attr('ui', 'location', 'implemented')
     @data(*generate_strings_list())
     def test_add_computeresource_1(self, resource_name):
         """@test: Add compute resource using the location
@@ -450,7 +435,6 @@ class Location(UITestCase):
                                                       value % resource_name))
             self.assertIsNotNone(element)
 
-    @attr('ui', 'location', 'implemented')
     @data(*generate_strings_list())
     def test_add_medium_1(self, medium_name):
         """@test: Add medium by using the location name and medium name
@@ -498,7 +482,6 @@ class Location(UITestCase):
                 tab_locators["context.tab_template"], context="location")
             self.assertIsNotNone(selected)
 
-    @attr('ui', 'location', 'implemented')
     @data(*generate_strings_list())
     def test_add_configtemplate_1(self, template):
         """@test: Add config template by using location name and
@@ -526,7 +509,6 @@ class Location(UITestCase):
                                                       value % template))
             self.assertIsNotNone(element)
 
-    @attr('ui', 'location', 'implemented')
     @data(gen_string('alpha', 8),
           gen_string('numeric', 8),
           gen_string('alphanumeric', 8))
@@ -561,7 +543,6 @@ class Location(UITestCase):
             # Item is listed in 'All Items' list and not 'Selected Items' list.
             self.assertIsNotNone(element)
 
-    @attr('ui', 'location', 'implemented')
     @data(*generate_strings_list())
     def test_remove_subnet_1(self, subnet_name):
         """@test: Remove subnet by using location name and subnet name
@@ -600,7 +581,6 @@ class Location(UITestCase):
             # Item is listed in 'All Items' list and not 'Selected Items' list.
             self.assertIsNotNone(element)
 
-    @attr('ui', 'location', 'implemented')
     @data(*generate_strings_list())
     def test_remove_domain_1(self, domain_name):
         """@test: Add a domain to an location and remove it by location
@@ -635,7 +615,6 @@ class Location(UITestCase):
             # Item is listed in 'All Items' list and not 'Selected Items' list.
             self.assertIsNotNone(element)
 
-    @attr('ui', 'location', 'implemented')
     @data(gen_string('alpha', 8),
           gen_string('numeric', 8),
           gen_string('alphanumeric', 8),
@@ -678,7 +657,6 @@ class Location(UITestCase):
             # Item is listed in 'All Items' list and not 'Selected Items' list.
             self.assertIsNotNone(element)
 
-    @attr('ui', 'location', 'implemented')
     @data(*generate_strings_list())
     def test_remove_hostgroup_1(self, host_grp_name):
         """@test: Add a hostgroup and remove it by using the location
@@ -711,7 +689,6 @@ class Location(UITestCase):
             # Item is listed in 'All Items' list and not 'Selected Items' list.
             self.assertIsNone(element)
 
-    @attr('ui', 'location', 'implemented')
     @data(*generate_strings_list())
     def test_remove_computeresource_1(self, resource_name):
         """@test: Remove computeresource by using the location
@@ -751,7 +728,6 @@ class Location(UITestCase):
             # Item is listed in 'All Items' list and not 'Selected Items' list.
             self.assertIsNotNone(element)
 
-    @attr('ui', 'location', 'implemented')
     @data(*generate_strings_list())
     def test_remove_medium_1(self, medium_name):
         """@test: Remove medium by using location name and medium name
@@ -789,7 +765,6 @@ class Location(UITestCase):
             # Item is listed in 'All Items' list and not 'Selected Items' list.
             self.assertIsNotNone(element)
 
-    @attr('ui', 'location', 'implemented')
     @data(
         {u'user_name': gen_string('alpha', 8)},
         {u'user_name': gen_string('numeric', 8)},

--- a/tests/foreman/ui/test_org.py
+++ b/tests/foreman/ui/test_org.py
@@ -11,7 +11,6 @@ if sys.hexversion >= 0x2070000:
 else:
     import unittest2 as unittest
 from fauxfactory import gen_string, gen_ipaddr
-from nose.plugins.attrib import attr
 from robottelo import entities
 from robottelo.common import conf
 
@@ -55,7 +54,6 @@ class Org(UITestCase):
 
     # Positive Create
 
-    @attr('ui', 'org', 'implemented')
     @data(*generate_strings_list())
     def test_positive_create_1(self, org_name):
         """@test: Create organization with valid name only.
@@ -72,7 +70,6 @@ class Org(UITestCase):
             self.assertIsNotNone(self.org.search(org_name))
 
     @unittest.skip("parent_org feature is disabled currently")
-    @attr('ui', 'org', 'implemented')
     @data({'label': gen_string('alpha'),
            'name': gen_string('alpha'),
            'desc': gen_string('alpha')},
@@ -109,7 +106,6 @@ class Org(UITestCase):
                      desc=desc, parent_org=parent)
             self.assertIsNotNone(self.org.search(org_name))
 
-    @attr('ui', 'org', 'implemented')
     @data({'name': gen_string('alpha', 10),
            'label': gen_string('alpha', 10)},
           {'name': gen_string('numeric', 10),
@@ -139,7 +135,6 @@ class Org(UITestCase):
                 label_loc).get_attribute("value")
             self.assertNotEqual(name, label)
 
-    @attr('ui', 'org', 'implemented')
     @data(gen_string('alpha', 10),
           gen_string('numeric', 10),
           gen_string('alphanumeric', 10))
@@ -166,7 +161,6 @@ class Org(UITestCase):
 
     @skip_if_bug_open('bugzilla', 1079482)
     @skip_if_bug_open('bugzilla', 1131469)
-    @attr('ui', 'org', 'implemented')
     @data({'name': gen_string('alpha', 10),
            'desc': gen_string('alpha', 10)},
           {'name': gen_string('numeric', 10),
@@ -203,7 +197,6 @@ class Org(UITestCase):
             label_value = label_ele.get_attribute("value")
             self.assertIsNotNone(label_value)
 
-    @attr('ui', 'org', 'implemented')
     @data({'org_name': gen_string('alpha', 10),
            'loc_name': gen_string('alpha', 10)},
           {'org_name': gen_string('numeric', 10),
@@ -236,7 +229,6 @@ class Org(UITestCase):
             self.assertEqual(organization, org_name)
             self.assertEqual(location, loc_name)
 
-    @attr('ui', 'org', 'implemented')
     @data(*generate_strings_list(len1=256))
     def test_negative_create_0(self, org_name):
         """@test: Create organization with valid label and description, name is
@@ -286,7 +278,6 @@ class Org(UITestCase):
             self.assertIsNotNone(error)
 
     @skip_if_bug_open('bugzilla', 1131469)
-    @attr('ui', 'org', 'implemented')
     @data(*generate_strings_list())
     def test_negative_create_3(self, org_name):
         """@test: Create organization with valid values, then create a new one
@@ -310,7 +301,6 @@ class Org(UITestCase):
     # Positive Delete
 
     @stubbed('Organization deletion is disabled')
-    @attr('ui', 'org', 'implemented')
     @data(*generate_strings_list())
     def test_positive_delete_1(self, org_name):
         """@test: Create organization with valid values then delete it.
@@ -331,7 +321,6 @@ class Org(UITestCase):
     # Positive Update
 
     @skip_if_bug_open('bugzilla', 1131469)
-    @attr('ui', 'org', 'implemented')
     @data(*generate_strings_list())
     def test_positive_update_1(self, new_name):
         """@test: Create organization with valid values then update its name.
@@ -354,7 +343,6 @@ class Org(UITestCase):
     # Negative Update
 
     @skip_if_bug_open('bugzilla', 1131469)
-    @attr('ui', 'org', 'implemented')
     @data(*generate_strings_list())
     def test_negative_update_1(self, org_name):
         """@test: Create organization with valid values then fail to update
@@ -379,7 +367,6 @@ class Org(UITestCase):
     # Miscellaneous
 
     @skip_if_bug_open('bugzilla', 1131469)
-    @attr('ui', 'org', 'implemented')
     @data(*generate_strings_list())
     def test_search_key_1(self, org_name):
         """@test: Create organization and search/find it.
@@ -398,7 +385,6 @@ class Org(UITestCase):
     # Associations
 
     @run_only_on('sat')
-    @attr('ui', 'org', 'implemented')
     @data(*generate_strings_list())
     def test_remove_domain_1(self, domain_name):
         """@test: Add a domain to an organization and remove it by organization
@@ -433,7 +419,6 @@ class Org(UITestCase):
             self.assertIsNotNone(element)
 
     #  Note: HTML username is invalid as per the UI msg.
-    @attr('ui', 'org', 'implemented')
     @data(
         {u'user_name': gen_string('alpha', 8)},
         {u'user_name': gen_string('numeric', 8)},
@@ -483,7 +468,6 @@ class Org(UITestCase):
             self.assertIsNotNone(element)
 
     @run_only_on('sat')
-    @attr('ui', 'org', 'implemented')
     @data(*generate_strings_list())
     def test_remove_hostgroup_1(self, host_grp_name):
         """@test: Add a hostgroup and remove it by using the organization
@@ -542,7 +526,6 @@ class Org(UITestCase):
         pass
 
     @run_only_on('sat')
-    @attr('ui', 'org', 'implemented')
     @data(*generate_strings_list())
     def test_add_subnet_1(self, subnet_name):
         """@test: Add a subnet by using organization name and subnet name.
@@ -574,7 +557,6 @@ class Org(UITestCase):
             self.assertIsNotNone(element)
 
     @run_only_on('sat')
-    @attr('ui', 'org', 'implemented')
     @data(*generate_strings_list())
     def test_add_domain_1(self, domain_name):
         """@test: Add a domain to an organization.
@@ -599,7 +581,6 @@ class Org(UITestCase):
                                                       value % domain_name))
             self.assertIsNotNone(element)
 
-    @attr('ui', 'org', 'implemented')
     @data(
         {u'user_name': gen_string('alpha', 8)},
         {u'user_name': gen_string('numeric', 8)},
@@ -642,7 +623,6 @@ class Org(UITestCase):
             self.assertIsNotNone(element)
 
     @run_only_on('sat')
-    @attr('ui', 'org', 'implemented')
     @data(*generate_strings_list())
     def test_add_hostgroup_1(self, host_grp_name):
         """@test: Add a hostgroup by using the organization
@@ -669,7 +649,6 @@ class Org(UITestCase):
             self.assertIsNotNone(element)
 
     @run_only_on('sat')
-    @attr('ui', 'org', 'implemented')
     @data(*generate_strings_list())
     def test_add_location_1(self, location_name):
         """@test: Add a location by using the organization
@@ -696,7 +675,6 @@ class Org(UITestCase):
             self.assertIsNotNone(element)
 
     @run_only_on('sat')
-    @attr('ui', 'org', 'implemented')
     @data(*generate_strings_list())
     def test_remove_computeresource_1(self, resource_name):
         """@test: Remove computeresource by using the organization
@@ -738,7 +716,6 @@ class Org(UITestCase):
             self.assertIsNotNone(element)
 
     @run_only_on('sat')
-    @attr('ui', 'org', 'implemented')
     @data(*generate_strings_list())
     def test_remove_medium_1(self, medium_name):
         """@test: Remove medium by using organization name and medium name.
@@ -780,7 +757,6 @@ class Org(UITestCase):
             self.assertIsNotNone(element)
 
     @run_only_on('sat')
-    @attr('ui', 'org', 'implemented')
     @data(*generate_strings_list())
     def test_remove_configtemplate_1(self, template_name):
         """@test: Remove config template.
@@ -815,7 +791,6 @@ class Org(UITestCase):
             self.assertIsNotNone(element)
 
     @run_only_on('sat')
-    @attr('ui', 'org', 'implemented')
     @data(gen_string('alpha', 8),
           gen_string('numeric', 8),
           gen_string('alphanumeric', 8))
@@ -867,7 +842,6 @@ class Org(UITestCase):
         pass
 
     @run_only_on('sat')
-    @attr('ui', 'org', 'implemented')
     @data(*generate_strings_list())
     def test_add_computeresource_1(self, resource_name):
         """@test: Add compute resource using the organization
@@ -900,7 +874,6 @@ class Org(UITestCase):
             self.assertIsNotNone(element)
 
     @run_only_on('sat')
-    @attr('ui', 'org', 'implemented')
     @data(*generate_strings_list())
     def test_add_medium_1(self, medium_name):
         """@test: Add medium by using the organization name and medium name.
@@ -931,7 +904,6 @@ class Org(UITestCase):
             self.assertIsNotNone(element)
 
     @run_only_on('sat')
-    @attr('ui', 'org', 'implemented')
     @data(*generate_strings_list())
     def test_add_configtemplate_1(self, template_name):
         """@test: Add config template by using organization name and
@@ -960,7 +932,6 @@ class Org(UITestCase):
             self.assertIsNotNone(element)
 
     @run_only_on('sat')
-    @attr('ui', 'org', 'implemented')
     @data(gen_string('alpha', 8),
           gen_string('numeric', 8),
           gen_string('alphanumeric', 8))
@@ -996,7 +967,6 @@ class Org(UITestCase):
             self.assertIsNotNone(element)
 
     @run_only_on('sat')
-    @attr('ui', 'org', 'implemented')
     @data(*generate_strings_list())
     def test_remove_subnet_1(self, subnet_name):
         """@test: Remove subnet by using organization name and subnet name.

--- a/tests/foreman/ui/test_products.py
+++ b/tests/foreman/ui/test_products.py
@@ -2,7 +2,6 @@
 
 from ddt import ddt
 from fauxfactory import gen_string
-from nose.plugins.attrib import attr
 from robottelo import entities
 from robottelo.common.decorators import data, run_only_on, skip_if_bug_open
 from robottelo.common.helpers import generate_strings_list
@@ -24,7 +23,6 @@ class Products(UITestCase):
         super(Products, cls).setUpClass()
 
     @run_only_on('sat')
-    @attr('ui', 'prd', 'implemented')
     @data(*generate_strings_list())
     def test_positive_create_1(self, prd_name):
         """@Test: Create Content Product minimal input parameters
@@ -41,7 +39,6 @@ class Products(UITestCase):
             self.assertIsNotNone(self.products.search(prd_name))
 
     @run_only_on('sat')
-    @attr('ui', 'prd', 'implemented')
     @data(*generate_strings_list())
     def test_positive_create_2(self, prd_name):
         """@Test: Create Content Product with same name but in another org
@@ -65,7 +62,6 @@ class Products(UITestCase):
             self.assertIsNotNone(self.products.search(prd_name))
 
     @run_only_on('sat')
-    @attr('ui', 'prd', 'implemented')
     @data(*generate_strings_list(len1=256))
     def test_negative_create_1(self, prd_name):
         """@Test: Create Content Product with too long input parameters
@@ -120,7 +116,6 @@ class Products(UITestCase):
             self.assertIsNotNone(invalid)
 
     @run_only_on('sat')
-    @attr('ui', 'prd', 'implemented')
     @data(*generate_strings_list())
     def test_negative_create_4(self, prd_name):
         """@Test: Create Content Product with same name input parameter
@@ -141,7 +136,6 @@ class Products(UITestCase):
             self.assertIsNotNone(error)
 
     @run_only_on('sat')
-    @attr('ui', 'prd', 'implemented')
     @data(*generate_strings_list())
     def test_positive_update_1(self, prd_name):
         """@Test: Update Content Product with minimal input parameters
@@ -161,7 +155,6 @@ class Products(UITestCase):
             self.assertIsNotNone(self.products.search(new_prd_name))
 
     @run_only_on('sat')
-    @attr('ui', 'prd', 'implemented')
     @data(*generate_strings_list())
     def test_negative_update_1(self, prd_name):
         """@Test: Update Content Product with too long input parameters
@@ -184,7 +177,6 @@ class Products(UITestCase):
 
     @skip_if_bug_open('redmine', 7845)
     @run_only_on('sat')
-    @attr('ui', 'prd', 'implemented')
     @data(*generate_strings_list())
     def test_remove_prd(self, prd_name):
         """@Test: Delete Content Product

--- a/tests/foreman/ui/test_puppet_classes.py
+++ b/tests/foreman/ui/test_puppet_classes.py
@@ -7,7 +7,6 @@ else:
     import unittest2 as unittest
 from ddt import ddt
 from fauxfactory import gen_string
-from nose.plugins.attrib import attr
 from robottelo.common.decorators import data, run_only_on, skip_if_bug_open
 from robottelo.common.helpers import generate_strings_list
 from robottelo.test import UITestCase
@@ -22,7 +21,6 @@ from robottelo.ui.session import Session
 class PuppetClasses(UITestCase):
     """Implements puppet classes tests in UI."""
 
-    @attr('ui', 'puppet-classes', 'implemented')
     @data({'name': gen_string('alpha', 10),
            'new_name': gen_string('alpha', 10)},
           {'name': gen_string('numeric', 10),
@@ -50,7 +48,6 @@ class PuppetClasses(UITestCase):
             self.puppetclasses.update(name, new_name)
 
     @skip_if_bug_open('bugzilla', 1126473)
-    @attr('ui', 'puppet-classes', 'implemented')
     @data(*generate_strings_list(len1=8))
     def test_delete_positive_1(self, name):
         """@Test: Create new puppet-class

--- a/tests/foreman/ui/test_repository.py
+++ b/tests/foreman/ui/test_repository.py
@@ -3,7 +3,6 @@
 import time
 from ddt import ddt
 from fauxfactory import gen_string
-from nose.plugins.attrib import attr
 from robottelo import entities
 from robottelo.common.constants import (
     CHECKSUM_TYPE,
@@ -77,7 +76,6 @@ class Repos(UITestCase):
         return result == 'success'
 
     @run_only_on('sat')
-    @attr('ui', 'repo', 'implemented')
     @data(*generate_strings_list())
     def test_create_repo_1(self, repo_name):
         """@Test: Create repository with minimal input parameters
@@ -99,7 +97,6 @@ class Repos(UITestCase):
             self.assertIsNotNone(self.repository.search(repo_name))
 
     @run_only_on('sat')
-    @attr('ui', 'repo', 'implemented')
     @data(*generate_strings_list())
     def test_create_repo_2(self, repo_name):
         """@Test: Create repository in two different orgs with same name
@@ -134,7 +131,6 @@ class Repos(UITestCase):
             self.assertIsNotNone(self.repository.search(repo_name))
 
     @run_only_on('sat')
-    @attr('ui', 'repo', 'implemented', 'docker')
     def test_create_repo_3(self):
         """@Test: Create a Docker-based repository
 
@@ -158,7 +154,6 @@ class Repos(UITestCase):
 
     @run_only_on('sat')
     @skip_if_bug_open('bugzilla', 1167837)
-    @attr('ui', 'repo', 'implemented', 'docker')
     def test_create_repo_4(self):
         """@Test: Create and sync a Docker-based repository
 
@@ -185,7 +180,6 @@ class Repos(UITestCase):
             self.assertTrue(synced)
 
     @run_only_on('sat')
-    @attr('ui', 'repo', 'implemented')
     @data(*generate_strings_list())
     def test_create_repo_5(self, repo_name):
         """@Test: Create repository with checksum type as sha256.
@@ -236,7 +230,6 @@ class Repos(UITestCase):
             self.assertIsNotNone(invalid)
 
     @run_only_on('sat')
-    @attr('ui', 'repo', 'implemented')
     @data(*generate_strings_list())
     def test_negative_create_2(self, repo_name):
         """@Test: Create repository with same name
@@ -265,7 +258,6 @@ class Repos(UITestCase):
             self.assertTrue(invalid)
 
     @run_only_on('sat')
-    @attr('ui', 'repo', 'implemented')
     @data(*generate_strings_list(len1=256))
     def test_negative_create_3(self, repo_name):
         """@Test: Create content repository with 256 characters in name
@@ -290,7 +282,6 @@ class Repos(UITestCase):
             self.assertTrue(error)
 
     @run_only_on('sat')
-    @attr('ui', 'repo', 'implemented')
     @data(*generate_strings_list())
     def test_positive_update_1(self, repo_name):
         """@Test: Update content repository with new URL
@@ -323,7 +314,6 @@ class Repos(UITestCase):
             self.assertEqual(url_text, FAKE_2_YUM_REPO)
 
     @run_only_on('sat')
-    @attr('ui', 'repo', 'implemented')
     @data(*generate_strings_list())
     def test_positive_update_2(self, repo_name):
         """@Test: Update content repository with new gpg-key
@@ -370,7 +360,6 @@ class Repos(UITestCase):
             self.assertEqual(gpgkey_2_text, gpgkey_2_name)
 
     @run_only_on('sat')
-    @attr('ui', 'repo', 'implemented')
     @data(*generate_strings_list())
     def test_positive_update_3(self, repo_name):
         """@Test: Update content repository with new checksum type
@@ -406,7 +395,6 @@ class Repos(UITestCase):
             self.assertEqual(checksum_text, checksum_update)
 
     @run_only_on('sat')
-    @attr('ui', 'repo', 'implemented')
     @data(*generate_strings_list())
     def test_remove_repo(self, repo_name):
         """@Test: Create content repository and remove it
@@ -475,7 +463,6 @@ class Repos(UITestCase):
             self.assertIsNotNone(self.products.search(product_name))
 
     @run_only_on('sat')
-    @attr('ui', 'repo', 'implemented')
     @data(*generate_strings_list())
     def test_syncnow_custom_repos_1(self, repository_name):
         """@Test: Create Custom yum repos and sync it via the repos page.
@@ -503,7 +490,6 @@ class Repos(UITestCase):
             self.assertTrue(self.prd_sync_is_ok(repository_name))
 
     @run_only_on('sat')
-    @attr('ui', 'repo', 'implemented')
     @data(*generate_strings_list())
     def test_syncnow_custom_repos_2(self, repository_name):
         """@Test: Create Custom puppet repos and sync it via the repos page.
@@ -533,7 +519,6 @@ class Repos(UITestCase):
 
     @run_only_on('sat')
     @skip_if_bug_open('bugzilla', 1167837)
-    @attr('ui', 'repo', 'implemented')
     @data(gen_string('alpha', 8).lower(),
           gen_string('numeric', 8),
           gen_string('alphanumeric', 8).lower(),

--- a/tests/foreman/ui/test_subnet.py
+++ b/tests/foreman/ui/test_subnet.py
@@ -5,7 +5,6 @@
 from ddt import ddt
 from fauxfactory import gen_ipaddr, gen_netmask, gen_string
 from robottelo import entities
-from nose.plugins.attrib import attr
 from robottelo.common.decorators import (
     data, run_only_on, skip_if_bug_open, bz_bug_is_open)
 from robottelo.common.helpers import generate_strings_list
@@ -20,7 +19,6 @@ from robottelo.ui.session import Session
 class Subnet(UITestCase):
     """Implements Subnet tests in UI"""
 
-    @attr('ui', 'subnet', 'implemented')
     @data(*generate_strings_list(len1=8))
     def test_create_subnet_1(self, name):
         """@Test: Create new subnet
@@ -38,7 +36,6 @@ class Subnet(UITestCase):
             self.assertIsNotNone(self.subnet.search_subnet(subnet_name=name))
 
     @skip_if_bug_open('bugzilla', 1123815)
-    @attr('ui', 'subnet', 'implemented')
     @data(
         {'name': gen_string('alphanumeric', 255)},
         {'name': gen_string('alpha', 255)},
@@ -103,7 +100,6 @@ class Subnet(UITestCase):
                 self.assertIsNotNone()
 
     @skip_if_bug_open('bugzilla', 1123815)
-    @attr('ui', 'subnet', 'implemented')
     @data(*generate_strings_list(len1=256))
     def test_create_subnet_negative_1(self, name):
         """@Test: Create new subnet with 256 characters in name
@@ -175,7 +171,6 @@ class Subnet(UITestCase):
             self.assertIsNotNone(primarydns_element)
             self.assertIsNotNone(secondarydns_element)
 
-    @attr('ui', 'subnet', 'implemented')
     @data(*generate_strings_list(len1=8))
     def test_remove_subnet_1(self, name):
         """@Test: Delete a subnet
@@ -194,7 +189,6 @@ class Subnet(UITestCase):
             self.assertIsNone(self.subnet.search_subnet(
                 subnet_name=name, timeout=5))
 
-    @attr('ui', 'subnet', 'implemented')
     @data(*generate_strings_list(len1=8))
     def test_remove_subnet_2(self, name):
         """@Test: Delete subnet.
@@ -215,7 +209,6 @@ class Subnet(UITestCase):
             self.assertIsNotNone(self.subnet.search_subnet(subnet_name=name,
                                                            timeout=5))
 
-    @attr('ui', 'subnet', 'implemented')
     @data(*generate_strings_list(len1=8))
     def test_update_subnet_1(self, name):
         """@Test: Update Subnet name
@@ -235,7 +228,6 @@ class Subnet(UITestCase):
             result_object = self.subnet.search_subnet(new_name)
             self.assertEqual(new_name, result_object['name'])
 
-    @attr('ui', 'subnet', 'implemented')
     @data(*generate_strings_list(len1=8))
     def test_update_subnet_2(self, name):
         """@Test: Update Subnet network
@@ -255,7 +247,6 @@ class Subnet(UITestCase):
             result_object = self.subnet.search_subnet(name)
             self.assertEqual(new_network, result_object['network'])
 
-    @attr('ui', 'subnet', 'implemented')
     @data(*generate_strings_list(len1=8))
     def test_update_subnet_3(self, name):
         """@Test: Update Subnet mask
@@ -275,7 +266,6 @@ class Subnet(UITestCase):
             result_object = self.subnet.search_subnet(name)
             self.assertEqual(new_mask, result_object['mask'])
 
-    @attr('ui', 'subnet', 'implemented')
     @data(*generate_strings_list(len1=8))
     def test_search_subnet_1(self, name):
         """@Test: Search Subnet with Subnet name

--- a/tests/foreman/ui/test_subscription.py
+++ b/tests/foreman/ui/test_subscription.py
@@ -1,7 +1,6 @@
 """Test class for Subscriptions/Manifests UI"""
 
 from ddt import ddt
-from nose.plugins.attrib import attr
 from robottelo import entities
 from robottelo.common import manifests
 from robottelo.common.decorators import skipRemote
@@ -22,7 +21,6 @@ class SubscriptionTestCase(UITestCase):
         super(SubscriptionTestCase, cls).setUpClass()
 
     @skipRemote
-    @attr('ui', 'subs', 'implemented')
     def test_positive_upload_1(self):
         """@Test: Upload a manifest with minimal input parameters
 
@@ -44,7 +42,6 @@ class SubscriptionTestCase(UITestCase):
             self.assertTrue(success_ele)
 
     @skipRemote
-    @attr('ui', 'subs', 'implemented')
     def test_positive_delete_1(self):
         """@Test: Upload a manifest and delete the manifest.
 
@@ -67,7 +64,6 @@ class SubscriptionTestCase(UITestCase):
             self.assertTrue(success_ele)
 
     @skipRemote
-    @attr('ui', 'subs', 'implemented')
     def test_assert_delete_button(self):
         """@Test: Upload and delete a manifest
 

--- a/tests/foreman/ui/test_sync.py
+++ b/tests/foreman/ui/test_sync.py
@@ -1,7 +1,6 @@
 """Test class for Custom Sync UI"""
 
 from ddt import ddt
-from nose.plugins.attrib import attr
 from robottelo import entities
 from robottelo.common.constants import FAKE_1_YUM_REPO
 from robottelo.common.decorators import data, run_only_on
@@ -35,7 +34,6 @@ class Sync(UITestCase):
         super(Sync, cls).setUpClass()
 
     @run_only_on('sat')
-    @attr('ui', 'sync', 'implemented')
     @data(*generate_strings_list())
     def test_sync_custom_repos(self, repository_name):
         """@Test: Create Content Custom Sync with minimal input parameters

--- a/tests/foreman/ui/test_syncplan.py
+++ b/tests/foreman/ui/test_syncplan.py
@@ -3,7 +3,6 @@
 from ddt import ddt
 from datetime import datetime, timedelta
 from fauxfactory import gen_string
-from nose.plugins.attrib import attr
 from robottelo import entities
 from robottelo.common.constants import SYNC_INTERVAL
 from robottelo.common.decorators import data, skip_if_bug_open
@@ -26,7 +25,6 @@ class Syncplan(UITestCase):
 
         super(Syncplan, cls).setUpClass()
 
-    @attr('ui', 'syncplan', 'implemented')
     @data({u'name': gen_string('alpha', 10),
            u'desc': gen_string('alpha', 10),
            u'interval': SYNC_INTERVAL['hour']},
@@ -88,7 +86,6 @@ class Syncplan(UITestCase):
             self.assertIsNotNone(self.syncplan.search(test_data['name']))
 
     @skip_if_bug_open('bugzilla', 1131661)
-    @attr('ui', 'syncplan', 'implemented')
     def test_positive_create_2(self):
         """@Test: Create Sync plan with specified start time
 
@@ -126,7 +123,6 @@ class Syncplan(UITestCase):
             self.assertEqual(saved_starttime, starttime)
 
     @skip_if_bug_open('bugzilla', 1131661)
-    @attr('ui', 'syncplan', 'implemented')
     def test_positive_create_3(self):
         """@Test: Create Sync plan with specified start date
 
@@ -172,7 +168,6 @@ class Syncplan(UITestCase):
             self.assertIsNotNone(invalid)
 
     @skip_if_bug_open('bugzilla', 1087425)
-    @attr('ui', 'syncplan', 'implemented')
     @data(*generate_strings_list(len1=256))
     def test_negative_create_2(self, name):
         """@Test: Create Sync Plan with 256 characters in name
@@ -192,7 +187,6 @@ class Syncplan(UITestCase):
             error = self.syncplan.wait_until_element(locator)
             self.assertIsNotNone(error)
 
-    @attr('ui', 'syncplan', 'implemented')
     @data(*generate_strings_list())
     def test_negative_create_3(self, name):
         """@Test: Create Sync Plan with an existing name
@@ -215,7 +209,6 @@ class Syncplan(UITestCase):
             error = self.syncplan.wait_until_element(locator)
             self.assertIsNotNone(error)
 
-    @attr('ui', 'syncplan', 'implemented')
     @data(*generate_strings_list())
     def test_positive_update_1(self, plan_name):
         """@Test: Update Sync plan's name
@@ -236,7 +229,6 @@ class Syncplan(UITestCase):
             self.syncplan.update(plan_name, new_name=new_plan_name)
             self.assertIsNotNone(self.syncplan.search(new_plan_name))
 
-    @attr('ui', 'syncplan', 'implemented')
     @data({u'name': gen_string('alpha', 10),
            u'interval': SYNC_INTERVAL['hour']},
           {u'name': gen_string('numeric', 10),
@@ -292,7 +284,6 @@ class Syncplan(UITestCase):
             interval_text = self.syncplan.wait_until_element(locator).text
             self.assertEqual(interval_text, test_data['interval'])
 
-    @attr('ui', 'syncplan', 'implemented')
     @data(*generate_strings_list())
     def test_positive_update_3(self, plan_name):
         """@Test: Update Sync plan and associate products
@@ -324,7 +315,6 @@ class Syncplan(UITestCase):
                 (strategy, value % product_name))
             self.assertIsNotNone(element)
 
-    @attr('ui', 'syncplan', 'implemented')
     @data(*generate_strings_list())
     def test_positive_update_4(self, plan_name):
         """@Test: Update Sync plan and disassociate products
@@ -369,7 +359,6 @@ class Syncplan(UITestCase):
                 (strategy, value % product_name))
             self.assertIsNotNone(element)
 
-    @attr('ui', 'syncplan', 'implemented')
     @data(*generate_strings_list())
     def test_positive_delete_1(self, plan_name):
         """@Test: Delete a Sync plan

--- a/tests/foreman/ui/test_user.py
+++ b/tests/foreman/ui/test_user.py
@@ -11,7 +11,6 @@ else:
 
 from ddt import ddt
 from fauxfactory import gen_string
-from nose.plugins.attrib import attr
 from selenium.webdriver.support.select import Select
 from robottelo import entities
 from robottelo.common.constants import LANGUAGES, NOT_IMPLEMENTED
@@ -56,7 +55,6 @@ class User(UITestCase):
     """
 
     @skip_if_bug_open('bugzilla', 1177097)
-    @attr('ui', 'user', 'implemented')
     @data(*valid_strings())
     def test_delete_user(self, user_name):
         """@Test: Delete a User
@@ -77,7 +75,6 @@ class User(UITestCase):
             self.assertIsNone(self.user.search(user_name, search_key))
 
     @skip_if_bug_open('bugzilla', 1139616)
-    @attr('ui', 'user', 'implemented')
     def test_update_password(self):
         """@Test: Update password for a user
 
@@ -98,7 +95,6 @@ class User(UITestCase):
             self.login.login(user_name, new_password)
             self.assertTrue(self.login.is_logged())
 
-    @attr('ui', 'user', 'implemented')
     def test_update_role(self):
         """@Test: Update role for a user
 
@@ -127,7 +123,6 @@ class User(UITestCase):
                                                      value % role_name))
             self.assertIsNotNone(element2)
 
-    @attr('ui', 'user', 'implemented')
     @data(*valid_strings())
     def test_positive_create_user_1(self, user_name):
         """@Test: Create User for all variations of Username
@@ -145,7 +140,6 @@ class User(UITestCase):
             make_user(session, username=user_name)
             self.assertIsNotNone(self.user.search(user_name, search_key))
 
-    @attr('ui', 'user', 'implemented')
     @data(*valid_strings())
     def test_positive_create_user_2(self, first_name):
         """@Test: Create User for all variations of First Name
@@ -172,7 +166,6 @@ class User(UITestCase):
                 ).get_attribute('value')
             )
 
-    @attr('ui', 'user', 'implemented')
     @data(*valid_strings(50))
     def test_positive_create_user_3(self, last_name):
         """@Test: Create User for all variations of Surname
@@ -217,7 +210,6 @@ class User(UITestCase):
         """
         pass
 
-    @attr('ui', 'user', 'implemented')
     @data(*LANGUAGES)
     def test_positive_create_user_5(self, language):
         """@Test: Create User for all variations of Language
@@ -261,7 +253,6 @@ class User(UITestCase):
         """
         pass
 
-    @attr('ui', 'user', 'implemented')
     @data(
         u'foo@!#$^&*( ) {0}'.format(gen_string("alpha", 2)),
         u'bar+{{}}|\"?hi {0}'.format(gen_string("alpha", 2)),
@@ -298,7 +289,6 @@ class User(UITestCase):
         """
         pass
 
-    @attr('ui', 'user', 'implemented')
     def test_positive_create_user_9(self):
         """@Test: Create User with one role
 
@@ -322,7 +312,6 @@ class User(UITestCase):
                                                     value % role_name))
             self.assertIsNotNone(element)
 
-    @attr('ui', 'user', 'implemented')
     def test_positive_create_user_10(self):
         """@Test: Create User with multiple roles
 
@@ -569,7 +558,6 @@ class User(UITestCase):
         """
         pass
 
-    @attr('ui', 'user', 'implemented')
     def test_positive_create_user_24(self):
         """@Test: Create User associated to one Org
 
@@ -592,7 +580,6 @@ class User(UITestCase):
                                                     value % org_name))
             self.assertIsNotNone(element)
 
-    @attr('ui', 'user', 'implemented')
     def test_positive_create_user_25(self):
         """@Test: Create User associated to multiple Orgs
 
@@ -666,7 +653,6 @@ class User(UITestCase):
         """
         pass
 
-    @attr('ui', 'user', 'implemented')
     def test_positive_create_user_29(self):
         """@Test: Create User and associate a default Org
 
@@ -694,7 +680,6 @@ class User(UITestCase):
             option = Select(org_element).first_selected_option
             self.assertEqual(org_name, option.text)
 
-    @attr('ui', 'user', 'implemented')
     def test_positive_create_user_30(self):
         """@Test: Create User and associate a default Location.
 
@@ -740,7 +725,6 @@ class User(UITestCase):
         """
         pass
 
-    @attr('ui', 'user', 'implemented')
     @data(*invalid_names_list())
     def test_negative_create_user_2(self, user_name):
         """@Test: Create User with invalid User Name
@@ -759,7 +743,6 @@ class User(UITestCase):
             error = self.user.wait_until_element(common_locators["haserror"])
             self.assertIsNotNone(error)
 
-    @attr('ui', 'user', 'implemented')
     @data(*invalid_names_list())
     def test_negative_create_user_3(self, first_name):
         """@Test: Create User with invalid FirstName
@@ -779,7 +762,6 @@ class User(UITestCase):
             error = self.user.wait_until_element(common_locators["haserror"])
             self.assertIsNotNone(error)
 
-    @attr('ui', 'user', 'implemented')
     @data(*invalid_names_list())
     def test_negative_create_user_4(self, last_name):
         """@Test: Create User with invalid Surname
@@ -816,7 +798,6 @@ class User(UITestCase):
         """
         pass
 
-    @attr('ui', 'user', 'implemented')
     def test_negative_create_user_6(self):
         """@Test: Create User with blank Authorized by
 
@@ -835,7 +816,6 @@ class User(UITestCase):
             error = self.user.wait_until_element(common_locators["haserror"])
             self.assertIsNotNone(error)
 
-    @attr('ui', 'user', 'implemented')
     def test_negative_create_user_8(self):
         """@Test: Create User with non-matching values in Password and verify
 
@@ -859,7 +839,6 @@ class User(UITestCase):
             self.assertIsNotNone(error)
 
     @skip_if_bug_open('bugzilla', 1139616)
-    @attr('ui', 'user', 'implemented')
     @data(*valid_strings())
     def test_positive_update_user_1(self, new_username):
         """@Test: Update Username in User


### PR DESCRIPTION
Even though nose was listed as a optional requirement it was a real
dependency as its @attr decorator was being used in may places. The attr
was added in order to be able to run tests by feature. But using a test
runner like nose or py.test or even unittest is possible to specify
which feature to run by just running an specific test module, thanks
robottelo test organization. With that said the attr decorator is not
needed and also not wide used over the test automation.

Also move verbosity config to main section. Robottelo should have its
own verbosity configuration and should not be the same from a nose
config.