### PR TITLE
Added tests stubs for errata mgmt

### DIFF
--- a/tests/foreman/api/test_email.py
+++ b/tests/foreman/api/test_email.py
@@ -1,0 +1,25 @@
+"""API Tests for the email notification feature"""
+
+from robottelo.common.decorators import stubbed
+from robottelo.test import APITestCase
+
+
+class EmailTestCase(APITestCase):
+    """API Tests for the email notification feature"""
+
+    @stubbed
+    def test_email_1(self):
+        """@Test: Manage user email notification preferences.
+
+        @Feature: Email Notification
+
+        @Steps:
+
+        1. Enable and disable email notifications using /api/mail_notifications
+
+        @Assert: Enabling and disabling email notification preferences saved
+        accordingly.
+
+        @Status: Manual
+
+        """

--- a/tests/foreman/api/test_errata.py
+++ b/tests/foreman/api/test_errata.py
@@ -1,0 +1,271 @@
+"""API Tests for the errata management feature"""
+
+# For ease of use hc refers to host-collection throughout this document
+
+from robottelo.common.decorators import stubbed
+from robottelo.test import APITestCase
+
+
+class ErrataTestCase(APITestCase):
+    """API Tests for the errata management feature"""
+
+    @stubbed
+    def test_hc_errata_install_1(self):
+        """@Test: Install errata in a host-collection
+
+        @Feature: Errata
+
+        @Setup: Errata synced on satellite server.
+
+        @Steps:
+
+        1. PUT /katello/api/systems/bulk/update_content
+
+        @Assert: errata is installed in the host-collection.
+
+        @Status: Manual
+
+        """
+
+    @stubbed
+    def test_errata_list_1(self):
+        """@Test: View all errata specific to an Org
+
+        @Feature: Errata
+
+        @Setup: Errata synced on satellite server.
+
+        @Steps: Create two Orgs each having a product synced and contains
+        errata.
+
+        @Assert: Check that the errata belonging to one Org is not showing in
+        the other.
+
+        @Status: Manual
+
+        """
+
+    @stubbed
+    def test_errata_list_2(self):
+        """@Test: View all errata in an Org sorted by Updated
+
+        @Feature: Errata
+
+        @Setup: Errata synced on satellite server.
+
+        @Steps:
+
+        1. GET /katello/api/errata
+
+        @Assert: Errata is filtered by Org and sorted by Updated date.
+
+        @Status: Manual
+
+        """
+
+    @stubbed
+    def test_errata_list_3(self):
+        """@Test: Filter errata by CVE
+
+        @Feature: Errata
+
+        @Setup: Errata synced on satellite server.
+
+        @Steps:
+
+        1. GET /katello/api/errata
+
+        @Assert: Errata is filtered by CVE.
+
+        @Status: Manual
+
+        """
+
+    @stubbed
+    def test_errata_systems_list_1(self):
+        """@Test: View a list of affected content hosts for an erratum
+
+        @Feature: Errata
+
+        @Setup: Errata synced on satellite server.
+
+        @Steps:
+
+        1. GET /katello/api/systems
+
+        @Assert: List of affected content hosts for the given erratum is
+        retrieved.
+
+        @Status: Manual
+
+        """
+
+    @stubbed
+    def test_errata_systems_list_2(self):
+        """@Test: Filter errata list based on affected content hosts
+
+        @Feature: Errata
+
+        @Setup: Errata synced on satellite server.
+
+        @Steps:
+
+        1. GET /katello/api/errata
+
+        @Assert: Errata is filtered based on affected content hosts.
+
+        @Status: Manual
+
+        """
+
+    @stubbed
+    def test_errata_sort_1(self):
+        """@Test: Filter errata by issued date
+
+        @Feature: Errata
+
+        @Setup: Errata synced on satellite server.
+
+        @Steps:
+
+        1. GET /katello/api/errata
+
+        @Assert: Errata is sorted by issued date.
+
+        @Status: Manual
+
+        """
+
+    @stubbed
+    def test_errata_content_host_1(self):
+        """@Test: Filter applicable errata for a content host by current and
+        Library environments
+
+        @Feature: Errata
+
+        @Setup:
+
+        1. Make sure multiple environments are present.
+        2. One of Content host's previous environment has additional errata.
+
+        @Steps:
+
+        1. GET /katello/api/errata
+
+        @Assert: The errata for the content host is filtered by current and
+        Library environments.
+
+        @Status: Manual
+
+        """
+
+    @stubbed
+    def test_errata_content_host_2(self):
+        """@Test: Available errata count when retrieving Content host
+
+        @Feature: Errata
+
+        @Setup:
+
+        1. Errata synced on satellite server.
+        2. Some Content hosts present.
+
+        @Steps:
+
+        1. GET /katello/api/systems
+
+        @Assert: The available errata count is retrieved.
+
+        @Status: Manual
+
+        """
+
+    @stubbed
+    def test_errata_content_view_1(self):
+        """@Test: Generate a difference in errata between a set of enviroments
+        for a content view
+
+        @Feature: Errata
+
+        @Setup:
+
+        1. Errata synced on satellite server.
+        2. Multiple environments present.
+
+        @Steps:
+
+        1. GET /katello/api/compare
+
+        @Assert: Difference in errata between a set of environments for a
+        content view is retrieved.
+
+        @Status: Manual
+
+        """
+
+    @stubbed
+    def test_incremental_update_1(self):
+        """@Test: Select multiple errata and apply them to multiple content
+        views in multiple environments
+
+        @Feature: Errata
+
+        @Setup:
+
+        1. Errata synced on satellite server.
+        2. Multiple environments/content views present.
+
+        @Steps:
+
+        1. POST /katello/api/systems/bulk/available_incremental_updates
+
+        @Assert: Selected errata are applied to multiple content views in
+        multiple environments.
+
+        @Status: Manual
+
+        """
+
+    @stubbed
+    def test_incremental_update_2(self):
+        """@Test: Query a subset of environments or content views to push new
+        errata
+
+        @Feature: Errata
+
+        @Setup:
+
+        1. Errata synced on satellite server.
+        2. Multiple environments/content views present.
+
+        @Steps:
+
+        1. POST /katello/api/content_view_versions/incremental_update
+
+        @Assert: Subset of environments/content views retrieved.
+
+        @Status: Manual
+
+        """
+
+    @stubbed
+    def test_incremental_update_3(self):
+        """@Test: Select multiple packages and apply them to multiple content
+        views in multiple environments
+
+        @Feature: Errata
+
+        @Setup:
+
+        1. Errata synced on satellite server.
+        2. Multiple environments/content views present.
+
+        @Steps:
+
+        1. POST /katello/api/content_view_versions/incremental_update
+
+        @Assert: Packages are applied to multiple environments/content views.
+
+        @Status: Manual
+
+        """

--- a/tests/foreman/cli/test_errata.py
+++ b/tests/foreman/cli/test_errata.py
@@ -1,0 +1,684 @@
+"""CLI Tests for the errata management feature"""
+
+# For ease of use hc refers to host-collection throughout this document
+
+from robottelo.common.decorators import stubbed
+from robottelo.test import CLITestCase
+
+
+class ErrataTestCase(CLITestCase):
+    """CLI Tests for the errata management feature"""
+
+    @stubbed
+    def test_hc_errata_install_1(self):
+        """@Test: Using hc-id and org id to install an erratum in a hc
+
+        @Feature: Errata
+
+        @Setup: Errata synced on satellite server.
+
+        @Steps:
+
+        1. host-collection erratum install --errata <errata> --id <id>
+        --organization-id <orgid>
+
+        @Assert: Erratum is installed.
+
+        @Status: Manual
+
+        """
+
+    @stubbed
+    def test_hc_errata_install_2(self):
+        """@Test: Using hc-id and org name to install an erratum in a hc
+
+        @Feature: Errata
+
+        @Setup: Errata synced on satellite server.
+
+        @Steps:
+
+        1. host-collection erratum install --errata <errata> --id <id>
+        --organization <org name>
+
+        @Assert: Erratum is installed.
+
+        @Status: Manual
+
+        """
+
+    @stubbed
+    def test_hc_errata_install_3(self):
+        """@Test: Use hc-id and org label to install an erratum in a hc
+
+        @Feature: Errata
+
+        @Setup: errata synced on satellite server.
+
+        @Steps:
+
+        1. host-collection erratum install --errata <errata> --id <id>
+        --organization-label <org label>
+
+        @Assert: Errata is installed.
+
+        @Status: Manual
+
+        """
+
+    @stubbed
+    def test_hc_errata_install_4(self):
+        """@Test: Use hc-name and org id to install an erratum in a hc
+
+        @Feature: Errata
+
+        @Setup: Errata synced on satellite server.
+
+        @Steps:
+
+        1. host-collection erratum install --errata <errata> --name <name>
+        --organization-id <orgid>
+
+        @Assert: Erratum is installed.
+
+        @Status: Manual
+
+        """
+
+    @stubbed
+    def test_hc_errata_install_5(self):
+        """@Test: Use hc name and org name to install an erratum in a hc
+
+        @Feature: Errata
+
+        @Setup: Errata synced on satellite server.
+
+        @Steps:
+
+        1. host-collection erratum install --errata <errata> --name <name>
+        --organization <org name>
+
+        @Assert: Erratum is installed.
+
+        @Status: Manual
+
+        """
+
+    @stubbed
+    def test_hc_errata_install_6(self):
+        """@Test: Use hc-name and org label to install an erratum in a hc
+
+        @Feature: Errata
+
+        @Setup: Errata synced on satellite server.
+
+        @Steps:
+
+        1. host-collection erratum install --errata <errata> --name <name>
+        --organization-label <org label>
+
+        @Assert: Erratum is installed.
+
+        @Status: Manual
+
+        """
+
+    @stubbed
+    def test_hc_errata_install_7(self):
+        """@Test: Attempt to install an erratum in a hc using hc-id and not
+        specifying the erratum info
+
+        @Feature: Errata
+
+        @Setup: Errata synced on satellite server.
+
+        @Steps:
+
+        1. host-collection erratum install --id <id> --organization-id <orgid>
+
+        @Assert: Error message thrown.
+
+        @Status: Manual
+
+        """
+
+    @stubbed
+    def test_hc_errata_install_8(self):
+        """@Test: Attempt to install an erratum in a hc using hc-name and not
+        specifying the erratum info
+
+        @Feature: Errata
+
+        @Setup: Errata synced on satellite server.
+
+        @Steps:
+
+        1. host-collection erratum install --name <name> --organization-id
+        <orgid>
+
+        @Assert: Error message thrown.
+
+        @Status: Manual
+
+        """
+
+    @stubbed
+    def test_hc_errata_install_9(self):
+        """@Test: Attempt to install an erratum in a hc by not specifying hc
+        info
+
+        @Feature: Errata
+
+        @Setup: Errata synced on satellite server.
+
+        @Steps:
+
+        1. host-collection erratum install --errata <errata> --organization-id
+        <orgid>
+
+        @Assert: Error message thrown.
+
+        @Status: Manual
+
+        """
+
+    @stubbed
+    def test_hc_errata_install_10(self):
+        """@Test: Attempt to install an erratum in a hc using hc-id and not
+        specifying org info
+
+        @Feature: Errata
+
+        @Setup: Errata synced on satellite server.
+
+        @Steps:
+
+        1. host-collection erratum install --errata <errata> --id <id>
+
+        @Assert: Error message thrown.
+
+        @Status: Manual
+
+        """
+
+    @stubbed
+    def test_hc_errata_install_11(self):
+        """@Test: Attempt to install an erratum in a hc without specifying hc
+        info
+
+        @Feature: Errata
+
+        @Setup: Errata synced on satellite server.
+
+        @Steps:
+
+        1. host-collection erratum install --errata <errata> --name <name>
+
+        @Assert: Error message thrown.
+
+        @Status: Manual
+
+        """
+
+    @stubbed
+    def test_errata_list_sort_1(self):
+        """@Test: Sort errata by Issued date
+
+        @Feature: Errata
+
+        @Setup: Errata synced on satellite server.
+
+        @Steps:
+
+        1. erratum list --order 'issued ASC'
+        2. erratum list --order 'issued DESC'
+
+        @Assert: Errata is sorted by Issued date.
+
+        @Status: Manual
+
+        """
+
+    @stubbed
+    def test_errata_list_sort_2(self):
+        """@Test: Filter errata by org id and sort by updated date
+
+        @Feature: Errata
+
+        @Setup: Errata synced on satellite server.
+
+        @Steps:
+
+        1. erratum list --organization-id=<orgid> --order 'updated ASC'
+        2. erratum list --organization-id=<orgid> --order 'updated DESC'
+
+        @Assert: Errata is filtered by org id and sorted by updated date.
+
+        @Status: Manual
+
+        """
+
+    @stubbed
+    def test_errata_list_sort_3(self):
+        """@Test: Filter errata by org name and sort by updated date
+
+        @Feature: Errata
+
+        @Setup: Errata synced on satellite server.
+
+        @Steps:
+
+        1. erratum list --organization=<org name> --order 'updated ASC'
+        2. erratum list --organization=<org name> --order 'updated DESC'
+
+        @Assert: Errata is filtered by org name and sorted by updated date.
+
+        @Status: Manual
+
+        """
+
+    @stubbed
+    def test_errata_list_sort_4(self):
+        """@Test: Filter errata by org label and sort by updated date
+
+        @Feature: Errata
+
+        @Setup: Errata synced on satellite server.
+
+        @Steps:
+
+        1. erratum list --organization-label=<org_label> --order 'updated ASC'
+        2. erratum list --organization-label=<org_label> --order 'updated DESC'
+
+        @Assert: Errata is filtered by org label and sorted by updated date.
+
+        @Status: Manual
+
+        """
+
+    @stubbed
+    def test_errata_list_sort_5(self):
+        """@Test: Filter errata by org id and sort by issued date
+
+        @Feature: Errata
+
+        @Setup: Errata synced on satellite server.
+
+        @Steps:
+
+        1. erratum list --organization-id=<org_id> --order 'issued ASC'
+        2. erratum list --organization-id=<org_id> --order 'issued DESC'
+
+        @Assert: Errata is filtered by org id and sorted by issued date.
+
+        @Status: Manual
+
+        """
+
+    @stubbed
+    def test_errata_list_sort_6(self):
+        """@Test: Filter errata by org name and sort by issued date
+
+        @Feature: Errata
+
+        @Setup: Errata synced on satellite server.
+
+        @Steps:
+
+        1. erratum list --organization=<org_name> --order 'issued ASC'
+        2. erratum list --organization=<org_name> --order 'issued DESC'
+
+        @Assert: Errata is filtered by org name and sorted by issued date.
+
+        @Status: Manual
+
+        """
+
+    @stubbed
+    def test_errata_list_sort_7(self):
+        """@Test: Filter errata by org label and sort by issued date
+
+        @Feature: Errata
+
+        @Setup: Errata synced on satellite server.
+
+        @Steps:
+
+        1. erratum list --organization-label=<org_label> --order 'issued ASC'
+        2. erratum list --organization-label=<org_label> --order 'issued DESC'
+
+        @Assert: Errata is filtered by org label and sorted by issued date.
+
+        @Status: Manual
+
+        """
+
+    @stubbed
+    def test_errata_list_1(self):
+        """@Test: Filter errata by product id
+
+        @Feature: Errata
+
+        @Setup: Errata synced on satellite server.
+
+        @Steps:
+
+        1. erratum list --product-id=<productid>
+
+        @Assert: Errata is filtered by product id.
+
+        @Status: Manual
+
+        """
+
+    @stubbed
+    def test_errata_list_2(self):
+        """@Test: Filter errata by product name
+
+        @Feature: Errata
+
+        @Setup: Errata synced on satellite server.
+
+        @Steps:
+
+        1. erratum list --product=<productname>
+
+        @Assert: Errata is filtered by product name.
+
+        @Status: Manual
+
+        """
+
+    @stubbed
+    def test_errata_list_3(self):
+        """@Test: Filter errata by product id and Org id
+
+        @Feature: Errata
+
+        @Setup: Errata synced on satellite server.
+
+        @Steps:
+
+        1. erratum list --product-id=<product_id> --organization-id=<org_id>
+
+        @Assert: Errata is filtered by product id and Org id.
+
+        @Status: Manual
+
+        """
+
+    @stubbed
+    def test_errata_list_4(self):
+        """@Test: Filter errata by product id and Org name
+
+        @Feature: Errata
+
+        @Setup: errata synced on satellite server.
+
+        @Steps:
+
+        1. erratum list --product-id=<product_id> --organization=<org_name>
+
+        @Assert: Errata is filtered by product id and Org name.
+
+        @Status: Manual
+
+        """
+
+    @stubbed
+    def test_errata_list_5(self):
+        """@Test: Filter errata by product id
+
+        @Feature: Errata
+
+        @Setup: errata synced on satellite server.
+
+        @Steps:
+
+        1. erratum list --product-id=<productid>
+        2. erratum list --product-id=<product_id> --organization-id=<org_id>
+        3. erratum list --product-id=<product_id> --organization=<org_name>
+        4. erratum list --product-id=<product_id>
+        --organization-label=<org_label>
+
+        @Assert: Errata is filtered by product id.
+
+        @Status: Manual
+
+        """
+
+    @stubbed
+    def test_errata_list_6(self):
+        """@Test: Filter errata by product name
+
+        @Feature: Errata
+
+        @Setup: Errata synced on satellite server.
+
+        @Steps:
+
+        1. erratum list --product=<productname>
+
+        @Assert: Errata is filtered by product name.
+
+        @Status: Manual
+
+        """
+
+    @stubbed
+    def test_errata_list_7(self):
+        """@Test: Filter errata by product name and Org id
+
+        @Feature: Errata
+
+        @Setup: Errata synced on satellite server.
+
+        @Steps:
+
+        1. erratum list --product=<product_name> --organization-id=<org_id>
+
+        @Assert: Errata is filtered by product name and Org id.
+
+        @Status: Manual
+
+        """
+
+    @stubbed
+    def test_errata_list_8(self):
+        """@Test: Filter errata by product name and Org name
+
+        @Feature: Errata
+
+        @Setup: Errata synced on satellite server.
+
+        @Steps:
+
+        1. erratum list --product=<product_name> --organization=<org_name>
+
+        @Assert: Errata is filtered by product name and Org name.
+
+        @Status: Manual
+
+        """
+
+    @stubbed
+    def test_errata_list_9(self):
+        """@Test: Filter errata by product name and Org label
+
+        @Feature: Errata
+
+        @Setup: Errata synced on satellite server.
+
+        @Steps:
+
+        1. erratum list --product=<product_name>
+        --organization-label=<org_label>
+
+        @Assert: Errata is filtered by product name and Org label.
+
+        @Status: Manual
+
+        """
+
+    @stubbed
+    def test_errata_list_10(self):
+        """@Test: Filter errata by Org id
+
+        @Feature: Errata
+
+        @Setup: Errata synced on satellite server.
+
+        @Steps:
+
+        1. erratum list --organization-id=<orgid>
+
+        @Assert: Errata is filtered by Org id.
+
+        @Status: Manual
+
+        """
+
+    @stubbed
+    def test_errata_list_11(self):
+        """@Test: Filter errata by Org name
+
+        @Feature: Errata
+
+        @Setup: Errata synced on satellite server.
+
+        @Steps:
+
+        1. erratum list --organization=<org name>
+
+        @Assert: Errata is filtered by Org name.
+
+        @Status: Manual
+
+        """
+
+    @stubbed
+    def test_errata_list_12(self):
+        """@Test: Filter errata by Org label
+
+        @Feature: Errata
+
+        @Setup: Errata synced on satellite server.
+
+        @Steps:
+
+        1. erratum list --organization-label=<org_label>
+
+        @Assert: Errata is filtered by Org label.
+
+        @Status: Manual
+
+        """
+
+    @stubbed
+    def test_errata_list_13(self):
+        """@Test: Filter errata by CVE
+
+        @Feature: Errata
+
+        @Setup: Errata synced on satellite server.
+
+        @Steps:
+
+        1. erratum list --cve <cve_id>
+
+        @Assert: Errata is filtered by CVE.
+
+        @Status: Manual
+
+        """
+
+    @stubbed
+    def test_errata_list_permission_1(self):
+        """@Test: Show errata only if the User has permissions to view them
+
+        @Feature: Errata
+
+        @Setup:
+
+        1. Create two products with one repo each. Sync them.
+        2. Make sure that they both have errata.
+        3. Create a user with view access on one product and not on the other.
+
+        @Steps:
+
+        1. erratum list --organization-id=<orgid>
+
+        @Assert: Check that the new user is able to see errata for one
+        product only.
+
+        @Status: Manual
+
+        """
+
+    @stubbed
+    def test_errata_systems_list_1(self):
+        """@Test: View a list of affected content hosts for an erratum
+
+        @Feature: Errata
+
+        @Setup: Errata synced on satellite server.
+
+        @Steps:
+
+        1. content-host list --erratum-id=<erratum_id>
+        --organization-id=<org_id>
+
+        @Assert: List of affected content hosts for an erratum is displayed.
+
+        @Status: Manual
+
+        """
+
+    @stubbed
+    def test_errata_systems_list_2(self):
+        """@Test: View a list of affected content hosts for an erratum filtered
+        with restrict flags
+
+        @Feature: Errata
+
+        @Setup: Errata synced on satellite server.
+
+        @Steps:
+
+        1. content-host list --erratum-id=<erratum_id>
+        --organization-id=<org_id> --erratum-restrict-available=1
+        2. content-host list --erratum-id=<erratum_id>
+        --organization-id=<org_id> --erratum-restrict-unavailable=1
+        3. content-host list --erratum-id=<erratum_id>
+        --organization-id=<org_id> --erratum-restrict-available=0
+        4. content-host list --erratum-id=<erratum_id>
+        --organization-id=<org_id> --erratum-restrict-unavailable=0
+
+        @Assert: List of affected content hosts for an erratum is displayed
+        filtered with corresponding restrict flags.
+
+        @Status: Manual
+
+        """
+
+    @stubbed
+    def test_errata_content_host_1(self):
+        """@Test: Available errata count displayed while viewing a list of
+        Content hosts
+
+        @Feature: Errata
+
+        @Setup:
+
+        1. Errata synced on satellite server.
+        2. Some content hosts present.
+
+        @Steps:
+
+        1. hammer content-host list --organization-id=<orgid>
+
+        @Assert: The available errata count is retrieved.
+
+        @Status: Manual
+
+        """

--- a/tests/foreman/ui/test_email.py
+++ b/tests/foreman/ui/test_email.py
@@ -1,0 +1,310 @@
+"""UI Tests for the email notification feature"""
+
+from robottelo.common.decorators import stubbed
+from robottelo.test import UITestCase
+
+
+class EmailTestCase(UITestCase):
+    """UI Tests for the email notification feature"""
+
+    @stubbed
+    def test_email_preference(self):
+        """@Test: Manage user email notification preferences
+
+        @Feature: Email Notification
+
+        @Steps:
+
+        1. Navigate to User -> My Account -> Mail Preferences.
+        2. Attempt to enable and disable the following email notification
+        preferences: Mail Enabled, Katello Sync Errata, Katello Host Advisory,
+        Katello Promote Errata, Puppet Error state, Puppet Summary.
+
+        @Assert: Enabling and disabling email notification preferences saved.
+        accordingly.
+
+        @Status: Manual
+
+        """
+
+    @stubbed
+    def test_email_sync_1(self):
+        """@Test: Receive email after every sync operation
+
+        @Feature: Email Notification
+
+        @Steps:
+
+        1. Navigate to User -> My Account -> Mail Preferences.
+        2. Enable notification for 'Katello Sync Errata'.
+        3. Perform a sync operation on a product.
+
+        @Assert: Email notification received after sync operation.
+
+        @Status: Manual
+
+        """
+
+    @stubbed
+    def test_email_sync_2(self):
+        """@Test: Do not receive email after every sync operation
+
+        @Feature: Email Notification
+
+        @Steps:
+
+        1. Navigate to User -> My Account -> Mail Preferences.
+        2. Disable notification by 'Katello Sync Errata' -> 'No Emails'.
+        3. Perform a sync operation on a product.
+
+        @Assert: No email notification received after sync operation.
+
+        @Status: Manual
+
+        """
+
+    @stubbed
+    def test_email_promote_1(self):
+        """@Test: Receive email after every promote operation
+
+        @Feature: Email Notification
+
+        @Steps:
+
+        1. Navigate to User -> My Account -> Mail Preferences.
+        2. Enable notification for 'Katello Promote Errata'.
+        3. Perform a promote operation in a content view.
+
+        @Assert: Email notification received after Promote operation.
+
+        @Status: Manual
+
+        """
+
+    @stubbed
+    def test_email_promote_2(self):
+        """@Test: Do not receive email after every promote operation
+
+        @Feature: Email Notification
+
+        @Steps:
+
+        1. Navigate to User -> My Account -> Mail Preferences.
+        2. Disable notification by 'Katello Promote Errata' -> 'No Emails'.
+        3. Perform a promote operation in a content view.
+
+        @Assert: No email notification received after Promote operation.
+
+        @Status: Manual
+
+        """
+
+    @stubbed
+    def test_email_host_1(self):
+        """@Test: Receive daily email with host advisory information
+
+        @Feature: Email Notification
+
+        @Steps:
+
+        1. Navigate to User -> My Account -> Mail Preferences.
+        2. Enable notification for 'Katello Host Advisory' -> Daily.
+
+        @Assert: Email notification received daily with Katello Host Advisory
+        information.
+
+        @Status: Manual
+
+        """
+
+    @stubbed
+    def test_email_host_2(self):
+        """@Test: Receive weekly email with host advisory information
+
+        @Feature: Email Notification
+
+        @Steps:
+
+        1. Navigate to User -> My Account -> Mail Preferences.
+        2. Enable notification for 'Katello Host Advisory' -> Weekly.
+
+        @Assert: Email notification received Weekly with Katello Host Advisory
+        information.
+
+        @Status: Manual
+
+        """
+
+    @stubbed
+    def test_email_host_3(self):
+        """@Test: Receive monthly email with host advisory information
+
+        @Feature: Email Notification
+
+        @Steps:
+
+        1. Navigate to User -> My Account -> Mail Preferences.
+        2. Enable notification for 'Katello Host Advisory' -> Monthly.
+
+        @Assert: Email notification received monthly with Katello Host Advisory
+        information.
+
+        @Status: Manual
+
+        """
+
+    @stubbed
+    def test_email_host_4(self):
+        """@Test: Receive no email with host advisory information
+
+        @Feature: Email Notification
+
+        @Steps:
+
+        1. Navigate to User -> My Account -> Mail Preferences.
+        2. Disable notification by 'Katello Host Advisory' -> 'No emails'.
+
+        @Assert: No email notification received with Katello Host Advisory
+        information.
+
+        @Status: Manual
+
+        """
+
+    @stubbed
+    def test_email_puppet_error_1(self):
+        """@Test: Receive email after puppet error
+
+        @Feature: Email Notification
+
+        @Steps:
+
+        1. Navigate to User -> My Account -> Mail Preferences.
+        2. Enable notification for 'Puppet Error State'.
+        3. Simulate a Puppet error.
+
+        @Assert: Email notification received with Puppet error.
+
+        @Status: Manual
+
+        """
+
+    @stubbed
+    def test_email_puppet_error_2(self):
+        """@Test: Do not receive email after puppet error
+
+        @Feature: Email Notification
+
+        @Steps:
+
+        1. Navigate to User -> My Account -> Mail Preferences.
+        2. Disable notification by 'Puppet Error State' -> 'No Emails'.
+        3. Simulate a Puppet error.
+
+        @Assert: No email notification received after Puppet error.
+
+        @Status: Manual
+
+        """
+
+    @stubbed
+    def test_email_permission_1(self):
+        """@Test: Receive 'Katello Sync Errata' notifications - only for
+        repositories and content views that the user has view access to
+
+        @Feature: Email Notification
+
+        @setup:
+
+        1. Create multiple products with synced errata.
+        2. The test user does not have view access to atleast some of the
+        products.
+
+        @Steps:
+
+        1. Navigate to User -> My Account -> Mail Preferences.
+        2. Enable notification for test user for 'Katello Sync Errata'.
+        3. Login as admin and perform sync on a product for which the test user
+        does not have view access.
+
+        @Assert: Test user does not receive email notification.
+
+        @Status: Manual
+
+        """
+
+    @stubbed
+    def test_email_permission_2(self):
+        """@Test: Receive 'Katello Promote Errata' notifications - only for
+        repositories and content views that the user has view access to
+
+        @Feature: Email Notification
+
+        @setup:
+
+        1. Create multiple products with synced errata.
+        2. The test user does not have view access to atleast some of the
+        products.
+
+        @Steps:
+
+        1. Navigate to User -> My Account -> Mail Preferences.
+        2. Enable notification for the test user for 'Katello Promote Errata'.
+        3. Login as admin and perform sync on a product for which the test user
+        does not have view access.
+
+        @Assert: Test user does not receive email notification.
+
+        @Status: Manual
+
+        """
+
+    @stubbed
+    def test_email_permission_3(self):
+        """@Test: Receive 'Katello Host Advisory' notifications - only for
+        repositories and content views that the user has view access to
+
+        @Feature: Email Notification
+
+        @setup:
+
+        1. Create multiple products with synced errata.
+        2. The test user does not have view access to atleast some of the
+        products.
+
+        @Steps:
+
+        1. Navigate to User -> My Account -> Mail Preferences.
+        2. Enable notification for the test user for 'Katello Host Advisory'.
+
+        @Assert: Test user receives email notification with the host info for
+        the repositories and content views that the user has access to.
+
+        @Status: Manual
+
+        """
+
+    @stubbed
+    def test_email_permission_4(self):
+        """@Test: Receive 'Katello Host Advisory' notifications - only for
+        content hosts that the user has view access to
+
+        @Feature: Email Notification
+
+        @setup:
+
+        1. Make sure to have multiple content hosts
+        2. The test user does not have view access to atleast some of the
+        products
+
+        @Steps:
+
+        1. Navigate to User -> My Account -> Mail Preferences.
+        2. Enable notification for test user for 'Katello Host Advisory'.
+
+        @Assert: Test user receives email notification which does not list the
+        content hosts for which the user does not have view access.
+
+        @Status: Manual
+
+        """

--- a/tests/foreman/ui/test_errata.py
+++ b/tests/foreman/ui/test_errata.py
@@ -1,0 +1,379 @@
+"""UI Tests for the errata management feature"""
+
+from robottelo.common.decorators import stubbed
+from robottelo.test import UITestCase
+
+
+class ErrataTestCase(UITestCase):
+    """UI Tests for the errata management feature"""
+
+    @stubbed
+    def test_errata_sort(self):
+        """@Test: Sort the columns of Errata page
+
+        @Feature: Errata
+
+        @Setup: Errata synced on satellite server.
+
+        @Steps:
+
+        1. Go to Content -> Errata.
+        2. Sort by Errata Id, Title, Type, Affected Content Hosts, Updated.
+
+        @Assert: Errata is sorted by selected column.
+
+        @Status: Manual
+
+        """
+
+    @stubbed
+    def test_errata_list(self):
+        """@Test: View all errata in an Org
+
+        @Feature: Errata
+
+        @Setup: Errata synced on satellite server.
+
+        @Steps:
+
+        1. Create two Orgs each having a product synced which contains errata.
+
+        @Assert: Check that the errata belonging to one Org is not showing in
+        the other.
+
+        @Status: Manual
+
+        """
+
+    @stubbed
+    def test_errata_list_permission(self):
+        """@Test: Show errata only if the User has permissions to view them
+
+        @Feature: Errata
+
+        @Setup:
+
+        1. Create two products with one repo each. Sync them.
+        2. Make sure that they both have errata.
+        3. Create a user with view access on one product and not on the other.
+
+        @Steps:
+
+        1. Go to Content -> Errata.
+
+        @Assert: Check that the new user is able to see errata for one product
+        only.
+
+        @Status: Manual
+
+        """
+
+    @stubbed
+    def test_apply_errata_1(self):
+        """@Test: Apply an erratum for selected content hosts
+
+        @Feature: Errata
+
+        @Setup: Errata synced on satellite server.
+
+        @Steps:
+
+        1. Go to Content -> Errata. Select an erratum -> Content Hosts tab.
+        2. Select few Content Hosts and apply the erratum.
+
+        @Assert: Check that the erratum is applied in the selected content
+        hosts.
+
+        @Status: Manual
+
+        """
+
+    @stubbed
+    def test_apply_errata_2(self):
+        """@Test: Apply an erratum for all content hosts
+
+        @Feature: Errata
+
+        @Setup: Errata synced on satellite server.
+
+        @Steps:
+
+        1. Go to Content -> Errata. Select an erratum -> Content Hosts tab.
+        2. Select all Content Hosts and apply the erratum.
+
+        @Assert: Check that the erratum is applied in all the content hosts.
+
+        @Status: Manual
+
+        """
+
+    @stubbed
+    def test_view_errata_1(self):
+        """@Test: View erratum similar to RH Customer portal
+
+        @Feature: Errata
+
+        @Setup: Errata synced on satellite server.
+
+        @Steps:
+
+        1. Go to Content -> Errata. Review the Errata page.
+
+        @Assert: The following fields are displayed: Errata Id, Title, Type,
+        Affected Content Hosts, Updated.
+
+        @Status: Manual
+
+        """
+
+    @stubbed
+    def test_view_errata_2(self):
+        """@Test: View erratum details similar to RH Customer portal
+
+        @Feature: Errata
+
+        @Setup: Errata synced on satellite server.
+
+        @Steps:
+
+        1. Go to Content -> Errata.  Select an Errata -> Details tab.
+
+        @Assert: The following fields are displayed: : Advisory, CVEs, Type,
+        Severity, Issued, Last Update on, Reboot Suggested, Topic, Description,
+        Solution, Affected Packages.
+
+        @Status: Manual
+
+        """
+
+    @stubbed
+    def test_view_errata_3(self):
+        """@Test: View a list of products/repositories for an erratum
+
+        @Feature: Errata
+
+        @Setup: Errata synced on satellite server.
+
+        @Steps:
+
+        1. Go to Content -> Errata.  Select an Errata -> Repositories tab.
+
+        @Assert: The Repositories tab lists affected Products and Repositories.
+
+        @Status: Manual
+
+        """
+
+    @stubbed
+    def test_view_errata_4(self):
+        """@Test: View CVE number(s) in Errata Details page
+
+        @Feature: Errata
+
+        @Setup: Errata synced on satellite server.
+
+        @Steps:
+
+        1. Go to Content -> Errata.  Select an Errata.
+
+        @Assert:
+
+        1: Check if the CVE information is shown in Errata Details page.
+
+        2. Check if 'N/A' is displayed if CVE information is not present.
+
+        @Status: Manual
+
+        """
+
+    @stubbed
+    def test_view_errata_5(self):
+        """@Test: Filter Content hosts by environment
+
+        @Feature: Errata
+
+        @Setup: Errata synced on satellite server.
+
+        @Steps:
+
+        1. Go to Content -> Errata.  Select an Errata -> Content Hosts tab ->
+        Filter content hosts by Environment.
+
+        @Assert: Content hosts can be filtered by Environment.
+
+        @Status: Manual
+
+        """
+
+    @stubbed
+    def test_search_errata_1(self):
+        """@Test: Check if autocomplete works in search field of Errata page
+
+        @Feature: Errata
+
+        @Setup: Errata synced on satellite server.
+
+        @Steps:
+
+        1. Go to Content -> Errata.
+
+        @Assert: Check if autocomplete works in search field of Errata page.
+
+        @Status: Manual
+
+        """
+
+    @stubbed
+    def test_search_errata_2(self):
+        """@Test: Check if all the errata searches are redirected to the new
+        errata page
+
+        @Feature: Errata
+
+        @Setup: Errata synced on satellite server.
+
+        @Steps:
+
+        1. Go to Content -> Products -> Repositories ->
+        Click on any of the errata hyperlink.
+        2. Go to Content -> Products -> Repositories -> Click on a repository->
+        Click on any of the errata hyperlink.
+        3. Go to Content -> Content Views -> Select a Content View -> Yum
+        Content -> Click on any of the errata hyperlink.
+        4. Go to Content -> Content Views -> Select a Content View -> Yum
+        Content -> Filters -> Select a Filter -> Click on any of the errata
+        hyperlink.
+
+        @Assert: Check if all the above mentioned scenarios redirect to the new
+        errata page.
+
+        @Status: Manual
+
+        """
+
+    @stubbed
+    def test_errata_content_host_1(self):
+        """@Test: Check if the applicable errata are available from the content
+        host's previous environment
+
+        @Feature: Errata
+
+        @Setup:
+
+        1. Make sure multiple environments are present.
+        2. Content host's previous environments have additional errata.
+
+        @Steps:
+
+        1. Go to Content Hosts -> Select content host -> Errata Tab -> Select
+        Previous environments.
+
+        @Assert: The errata from previous enviornments are displayed.
+
+        @Status: Manual
+
+        """
+
+    @stubbed
+    def test_errata_content_host_2(self):
+        """@Test: Check if the applicable errata are available from the content
+        host's Library
+
+        @Feature: Errata
+
+        @Setup:
+
+        1. Make sure multiple environments are present.
+        2. Content host's Library environment has additional errata.
+
+        @Steps:
+
+        1. Go to Content Hosts -> Select content host -> Errata Tab -> Select
+        'Library'.
+
+        @Assert: The errata from Library are displayed.
+
+        @Status: Manual
+
+        """
+
+    @stubbed
+    def test_errata_content_host_3(self):
+        """@Test: Available errata count displayed in Content hosts page
+
+        @Feature: Errata
+
+        @Setup:
+
+        1. Errata synced on satellite server.
+        2. Some content hosts are present.
+
+        @Steps:
+
+        1. Go to Hosts -> Content Hosts.
+
+        @Assert:
+
+        1. The available errata count is displayed.
+        2. Errata count is displayed with color icons.
+
+           - An errata count of 0 = green
+           - If security errata, >0 = red
+           - If any other errata, >0 = yellow
+
+        @Status: Manual
+
+        """
+
+    @stubbed
+    def test_errata_content_host_4(self):
+        """@Test: Errata count on Content host Details page
+
+        @Feature: Errata
+
+        @Setup:
+
+        1. Errata synced on satellite server.
+        2. Some content hosts are present.
+
+        @Steps:
+
+        1. Go to Hosts -> Content Hosts -> Select Content Host -> Details page.
+
+        @Assert:
+
+        1. The errata section should be displayed with Security, Bugfix,
+        Enhancement types.
+        2. The number should link to the errata details page, filtered  by
+        type.
+
+        @Status: Manual
+
+        """
+
+    @stubbed
+    def test_incremental_update_1(self):
+        """@Test: Update composite content views and environments with new
+        point releases
+
+        @Feature: Errata
+
+        @Setup:
+
+        1. Errata synced on satellite server.
+        2. Composite content views present.
+
+        @Steps:
+
+        1. As a user, I would expect updated point releases to update
+        composites with a new point release as well in the respective
+        environments (i.e. if ComponentA gets updated from 1.0 to 1.1, any
+        composite that is using 1.0 will have a new point release bumped and
+        published with the new 1.1 ComponentA and pushed to the environment
+        it was in.
+
+        @Assert: Composite content views updated with point releases.
+
+        @Status: Manual
+
+        """


### PR DESCRIPTION
77 test stubs ready :

```py
# nosetests -c robottelo.properties tests.foreman.api.test_errata
@Test: Filter applicable errata for a content host by current and ... SKIP: Test not implemented
@Test: Available errata count when retrieving Content host ... SKIP: Test not implemented
@Test: Generate a difference in errata between a set of enviroments ... SKIP: Test not implemented
@Test: View all errata specific to an Org ... SKIP: Test not implemented
@Test: View all errata in an Org sorted by Updated ... SKIP: Test not implemented
@Test: Filter errata by CVE ... SKIP: Test not implemented
@Test: Filter errata by issued date ... SKIP: Test not implemented
@Test: View a list of affected content hosts for an erratum ... SKIP: Test not implemented
@Test: Filter errata list based on affected content hosts ... SKIP: Test not implemented
@Test: Install errata in a host-collection ... SKIP: Test not implemented
@Test: Select multiple errata and apply them to multiple content ... SKIP: Test not implemented
@Test: Query a subset of environments or content views to push new ... SKIP: Test not implemented
@Test: Select multiple packages and apply them to multiple content ... SKIP: Test not implemented

Ran 13 tests in 0.004s
OK (SKIP=13)

# nosetests -c robottelo.properties tests.foreman.cli.test_errata
@Test: Available errata count displayed while viewing a list of ... SKIP: Test not implemented
@Test: Filter errata by product id ... SKIP: Test not implemented
@Test: Filter errata by Org id ... SKIP: Test not implemented
@Test: Filter errata by Org name ... SKIP: Test not implemented
@Test: Filter errata by Org label ... SKIP: Test not implemented
@Test: Filter errata by CVE ... SKIP: Test not implemented
@Test: Filter errata by product name ... SKIP: Test not implemented
@Test: Filter errata by product id and Org id ... SKIP: Test not implemented
@Test: Filter errata by product id and Org name ... SKIP: Test not implemented
@Test: Filter errata by product id ... SKIP: Test not implemented
@Test: Filter errata by product name ... SKIP: Test not implemented
@Test: Filter errata by product name and Org id ... SKIP: Test not implemented
@Test: Filter errata by product name and Org name ... SKIP: Test not implemented
@Test: Filter errata by product name and Org label ... SKIP: Test not implemented
@Test: Show errata only if the User has permissions to view them ... SKIP: Test not implemented
@Test: Sort errata by Issued date ... SKIP: Test not implemented
@Test: Filter errata by org id and sort by updated date ... SKIP: Test not implemented
@Test: Filter errata by org name and sort by updated date ... SKIP: Test not implemented
@Test: Filter errata by org label and sort by updated date ... SKIP: Test not implemented
@Test: Filter errata by org id and sort by issued date ... SKIP: Test not implemented
@Test: Filter errata by org name and sort by issued date ... SKIP: Test not implemented
@Test: Filter errata by org label and sort by issued date ... SKIP: Test not implemented
@Test: View a list of affected content hosts for an erratum ... SKIP: Test not implemented
@Test: View a list of affected content hosts for an erratum filtered ... SKIP: Test not implemented
@Test: Using hc-id and org id to install an erratum in a hc ... SKIP: Test not implemented
@Test: Attempt to install an erratum in a hc using hc-id and not ... SKIP: Test not implemented
@Test: Attempt to install an erratum in a hc without specifying hc ... SKIP: Test not implemented
@Test: Using hc-id and org name to install an erratum in a hc ... SKIP: Test not implemented
@Test: Use hc-id and org label to install an erratum in a hc ... SKIP: Test not implemented
@Test: Use hc-name and org id to install an erratum in a hc ... SKIP: Test not implemented
@Test: Use hc name and org name to install an erratum in a hc ... SKIP: Test not implemented
@Test: Use hc-name and org label to install an erratum in a hc ... SKIP: Test not implemented
@Test: Attempt to install an erratum in a hc using hc-id and not ... SKIP: Test not implemented
@Test: Attempt to install an erratum in a hc using hc-name and not ... SKIP: Test not implemented
@Test: Attempt to install an erratum in a hc by not specifying hc ... SKIP: Test not implemented

Ran 35 tests in 0.007s
OK (SKIP=35)


# nosetests -c robottelo.properties tests.foreman.api.test_errata
@Test: Filter applicable errata for a content host by current and ... SKIP: Test not implemented
@Test: Available errata count when retrieving Content host ... SKIP: Test not implemented
@Test: Generate a difference in errata between a set of enviroments ... SKIP: Test not implemented
@Test: View all errata specific to an Org ... SKIP: Test not implemented
@Test: View all errata in an Org sorted by Updated ... SKIP: Test not implemented
@Test: Filter errata by CVE ... SKIP: Test not implemented
@Test: Filter errata by issued date ... SKIP: Test not implemented
@Test: View a list of affected content hosts for an erratum ... SKIP: Test not implemented
@Test: Filter errata list based on affected content hosts ... SKIP: Test not implemented
@Test: Install errata in a host-collection ... SKIP: Test not implemented
@Test: Select multiple errata and apply them to multiple content ... SKIP: Test not implemented
@Test: Query a subset of environments or content views to push new ... SKIP: Test not implemented
@Test: Select multiple packages and apply them to multiple content ... SKIP: Test not implemented

Ran 13 tests in 0.004s
OK (SKIP=13)

# nosetests -c robottelo.properties tests.foreman.ui.test_email
@Test: Receive daily email with host advisory information ... SKIP: Test not implemented
@Test: Receive weekly email with host advisory information ... SKIP: Test not implemented
@Test: Receive monthly email with host advisory information ... SKIP: Test not implemented
@Test: Receive no email with host advisory information ... SKIP: Test not implemented
@Test: Receive 'Katello Sync Errata' notifications - only for ... SKIP: Test not implemented
@Test: Receive 'Katello Promote Errata' notifications - only for ... SKIP: Test not implemented
@Test: Receive 'Katello Host Advisory' notifications - only for ... SKIP: Test not implemented
@Test: Receive 'Katello Host Advisory' notifications - only for ... SKIP: Test not implemented
@Test: Manage user email notification preferences ... SKIP: Test not implemented
@Test: Receive email after every promote operation ... SKIP: Test not implemented
@Test: Do not receive email after every promote operation ... SKIP: Test not implemented
@Test: Receive email after puppet error ... SKIP: Test not implemented
@Test: Do not receive email after puppet error ... SKIP: Test not implemented
@Test: Receive email after every sync operation ... SKIP: Test not implemented
@Test: Do not receive email after every sync operation ... SKIP: Test not implemented

Ran 15 tests in 0.005s
OK (SKIP=15)

# nosetests -c robottelo.properties tests.foreman.api.test_email
@Test: Manage user email notification preferences. ... SKIP: Test not implemented

Ran 1 test in 0.002s
OK (SKIP=1)

```