### PR TITLE
Give content view API tests better error messages

### DIFF
--- a/tests/foreman/api/test_contentview.py
+++ b/tests/foreman/api/test_contentview.py
@@ -194,7 +194,12 @@ class CVPublishPromoteTestCase(APITestCase):
         content_view = entities.ContentView()
         content_view.id = content_view.create_json()['id']
         for _ in range(REPEAT):
-            self.assertEqual(content_view.publish()['result'], 'success')
+            response = content_view.publish()
+            self.assertEqual(
+                response['result'],
+                'success',
+                response['humanized']['errors']
+            )
         self.assertEqual(len(content_view.read_json()['versions']), REPEAT)
 
     def test_positive_publish_2(self):
@@ -254,7 +259,12 @@ class CVPublishPromoteTestCase(APITestCase):
         # Publish the content view several times and check that each version
         # has the puppet module added above.
         for _ in range(REPEAT):
-            self.assertEqual('success', content_view.publish()['result'])
+            response = content_view.publish()
+            self.assertEqual(
+                response['result'],
+                'success',
+                response['humanized']['errors']
+            )
         for cvv_id in (  # content view version ID
                 version['id']
                 for version
@@ -273,7 +283,12 @@ class CVPublishPromoteTestCase(APITestCase):
         """
         content_view = entities.ContentView(organization=self.org.id)
         content_view.id = content_view.create_json()['id']
-        self.assertEqual(content_view.publish()['result'], 'success')
+        response = content_view.publish()
+        self.assertEqual(
+            response['result'],
+            'success',
+            response['humanized']['errors']
+        )
 
         # Promote the content view version several times.
         cvv = entities.ContentViewVersion(
@@ -310,7 +325,12 @@ class CVPublishPromoteTestCase(APITestCase):
         content_view = entities.ContentView(organization=self.org.id)
         content_view.id = content_view.create_json()['id']
         content_view.set_repository_ids([self.yum_repo.id])
-        self.assertEqual(content_view.publish()['result'], 'success')
+        response = content_view.publish()
+        self.assertEqual(
+            response['result'],
+            'success',
+            response['humanized']['errors']
+        )
 
         # Promote the content view version.
         cvv = entities.ContentViewVersion(
@@ -357,7 +377,12 @@ class CVPublishPromoteTestCase(APITestCase):
             puppet_module['author'],
             puppet_module['name']
         )
-        self.assertEqual(content_view.publish()['result'], u'success')
+        response = content_view.publish()
+        self.assertEqual(
+            response['result'],
+            'success',
+            response['humanized']['errors']
+        )
 
         # Promote the content view version.
         cvv = entities.ContentViewVersion(
@@ -367,7 +392,12 @@ class CVPublishPromoteTestCase(APITestCase):
             lc_env_id = entities.LifecycleEnvironment(
                 organization=self.org.id
             ).create_json()['id']
-            self.assertEqual(cvv.promote(lc_env_id)['result'], 'success')
+            response = cvv.promote(lc_env_id)
+            self.assertEqual(
+                response['result'],
+                'success',
+                response['humanized']['errors']
+            )
 
         # Everything's done. Check some content view attributes...
         cv_attrs = content_view.read_json()


### PR DESCRIPTION
Several tests in class
`tests.foreman.api.test_contentview.CVPublishPromoteTestCase` produce the
following error message:

    AssertionError: u'error' != 'success'

This is not very useful. Make the assertions in that class produce more useful
output upon failure. This will make it easier to understand why those tests are
failing and diagnose the failures.

Several tests in this class already have more verbose error messages, but not
all of them. This commit brings quality error messages to all publish and
promote-related assertions in the class.