### PR TITLE
Fix syntax errors in CLI test code

### DIFF
--- a/robottelo/cli/metatest/template_methods.py
+++ b/robottelo/cli/metatest/template_methods.py
@@ -26,7 +26,7 @@ def test_positive_create(self, data):
 
     # Can we find the new object?
     result = self.factory_obj().exists(
-        tuple_search=(self.search_key, new_obj[self.search_key])
+        search=(self.search_key, new_obj[self.search_key])
     )
 
     self.assertTrue(result.return_code == 0, 'Failed to create object')
@@ -83,7 +83,7 @@ def test_positive_update(self, data):
     new_obj = self.factory(orig_dict)
 
     result = self.factory_obj().exists(
-        tuple_search=(self.search_key, new_obj[self.search_key])
+        search=(self.search_key, new_obj[self.search_key])
     )
     self.assertTrue(result.return_code == 0, 'Failed to create object')
     self.assertTrue(
@@ -139,7 +139,7 @@ def test_negative_update(self, data):
     new_obj = self.factory(orig_dict)
 
     result = self.factory_obj().exists(
-        tuple_search=(self.search_key, new_obj[self.search_key])
+        search=(self.search_key, new_obj[self.search_key])
     )
     self.assertTrue(result.return_code == 0, 'Failed to create object')
     self.assertTrue(
@@ -160,7 +160,7 @@ def test_negative_update(self, data):
     self.assertTrue(len(result.stderr) > 0, 'There should be errors')
 
     result = self.factory_obj().exists(
-        tuple_search=(self.search_key, new_obj[self.search_key])
+        search=(self.search_key, new_obj[self.search_key])
     )
     # Verify that new values were not updated
     self.assertEqual(new_obj, result.stdout, 'Object should not be updated')
@@ -187,7 +187,7 @@ def test_positive_delete(self, data):
     new_obj = self.factory(data)
 
     result = self.factory_obj().exists(
-        tuple_search=(self.search_key, new_obj[self.search_key])
+        search=(self.search_key, new_obj[self.search_key])
     )
     self.assertTrue(result.return_code == 0, 'Failed to create object')
 
@@ -227,7 +227,7 @@ def test_negative_delete(self, data):
     new_obj = self.factory()
 
     result = self.factory_obj().exists(
-        tuple_search=(self.search_key, new_obj[self.search_key])
+        search=(self.search_key, new_obj[self.search_key])
     )
     self.assertTrue(result.return_code == 0, 'Failed to create object')
     # Store the new object for further assertions
@@ -240,7 +240,7 @@ def test_negative_delete(self, data):
     # Now make sure that it still exists
 
     result = self.factory_obj().exists(
-        tuple_search=(self.search_key, new_obj[self.search_key])
+        search=(self.search_key, new_obj[self.search_key])
     )
     self.assertTrue(result.return_code == 0, 'Failed to find object')
     self.assertEqual(new_obj, result.stdout)

--- a/tests/foreman/cli/test_computeresource.py
+++ b/tests/foreman/cli/test_computeresource.py
@@ -101,7 +101,7 @@ class TestComputeResource(CLITestCase):
         self.assertTrue(len(result_list.stdout) > 0,
                         "ComputeResource list - stdout has results")
         stdout = ComputeResource.exists(
-            tuple_search=('name', result_create['name'])).stdout
+            search=('name', result_create['name'])).stdout
         self.assertTrue(
             stdout,
             "ComputeResource list - exists name")
@@ -153,7 +153,7 @@ class TestComputeResource(CLITestCase):
             result_delete.return_code, 0,
             "ComputeResource delete - exit code")
         stdout = ComputeResource.exists(
-            tuple_search=('name', result_create['name'])).stdout
+            search=('name', result_create['name'])).stdout
         self.assertFalse(
             stdout,
             "ComputeResource list - does not exist name")

--- a/tests/foreman/cli/test_org.py
+++ b/tests/foreman/cli/test_org.py
@@ -127,7 +127,7 @@ class TestOrg(CLITestCase):
 
         new_obj = make_org(test_data)
         # Can we find the new object?
-        result = Org.exists(tuple_search=('name', new_obj['name']))
+        result = Org.exists(search=('name', new_obj['name']))
 
         self.assertEqual(result.return_code, 0, "Failed to create object")
         self.assertEqual(len(result.stderr), 0,
@@ -171,7 +171,7 @@ class TestOrg(CLITestCase):
 
         new_obj = make_org(test_data)
         # Can we find the new object?
-        result = Org.exists(tuple_search=('label', new_obj['label']))
+        result = Org.exists(search=('label', new_obj['label']))
 
         self.assertEqual(result.return_code, 0, "Failed to find the object")
         self.assertEqual(len(result.stderr), 0,

--- a/tests/foreman/cli/test_partitiontable.py
+++ b/tests/foreman/cli/test_partitiontable.py
@@ -38,7 +38,7 @@ class TestPartitionTableUpdateCreate(CLITestCase):
             make_partition_table(self.args)
         except CLIFactoryError as err:
             self.fail(err)
-        result = PartitionTable().exists(tuple_search=('name', self.name))
+        result = PartitionTable().exists(search=('name', self.name))
         self.assertEqual(result.return_code, 0, "Failed to create object")
         self.assertEqual(len(result.stderr), 0,
                          "There should not be an exception here")
@@ -56,7 +56,7 @@ class TestPartitionTableUpdateCreate(CLITestCase):
             make_partition_table(self.args)
         except CLIFactoryError as err:
             self.fail(err)
-        result = PartitionTable().exists(tuple_search=('name', self.name))
+        result = PartitionTable().exists(search=('name', self.name))
         self.assertEqual(result.return_code, 0, "Failed to create object")
         self.assertEqual(len(result.stderr), 0,
                          "There should not be an exception here")
@@ -69,7 +69,7 @@ class TestPartitionTableUpdateCreate(CLITestCase):
         self.assertEqual(len(result.stderr), 0,
                          "There should not be an exception here")
         self.assertFalse(
-            PartitionTable().exists(tuple_search=('new-name', nw_nm)).stdout)
+            PartitionTable().exists(search=('new-name', nw_nm)).stdout)
 
 
 class TestPartitionTableDelete(CLITestCase):
@@ -88,7 +88,7 @@ class TestPartitionTableDelete(CLITestCase):
         name = gen_alphanumeric(6)
         make_partition_table({'name': name, 'content': content})
 
-        ptable = PartitionTable().exists(tuple_search=('name', name)).stdout
+        ptable = PartitionTable().exists(search=('name', name)).stdout
 
         args = {'id': ptable['id']}
 
@@ -109,7 +109,7 @@ class TestPartitionTableDelete(CLITestCase):
         name = gen_alphanumeric(6)
         make_partition_table({'name': name, 'content': content})
 
-        ptable = PartitionTable().exists(tuple_search=('name', name)).stdout
+        ptable = PartitionTable().exists(search=('name', name)).stdout
 
         args = {'id': ptable['id']}
 
@@ -118,7 +118,7 @@ class TestPartitionTableDelete(CLITestCase):
         self.assertEqual(len(result.stderr), 0,
                          "There should not be an exception here")
         self.assertFalse(
-            PartitionTable().exists(tuple_search=('name', name)).stdout)
+            PartitionTable().exists(search=('name', name)).stdout)
 
     def test_addoperatingsystem_ptable(self):
         """@Test: Check if Partition Table can be associated
@@ -136,7 +136,7 @@ class TestPartitionTableDelete(CLITestCase):
             make_partition_table({'name': name, 'content': content})
         except CLIFactoryError as err:
             self.fail(err)
-        result = PartitionTable().exists(tuple_search=('name', name))
+        result = PartitionTable().exists(search=('name', name))
         self.assertEqual(result.return_code, 0, "Failed to create object")
         self.assertEqual(len(result.stderr), 0,
                          "There should not be an exception here")

--- a/tests/foreman/cli/test_user.py
+++ b/tests/foreman/cli/test_user.py
@@ -1407,7 +1407,7 @@ class User(CLITestCase):
         self.assertNotEqual(result.return_code, 0)
         # check name have not changed
         updated_user = UserObj().exists(
-            tuple_search=('login', new_user['login']))
+            search=('login', new_user['login']))
         self.assertEqual(updated_user.stdout['name'], new_user['name'])
 
     @data({'lastname': gen_string("alpha", 51)},
@@ -1434,7 +1434,7 @@ class User(CLITestCase):
         self.assertNotEqual(result.return_code, 0)
         # check name have not changed
         updated_user = UserObj().exists(
-            tuple_search=('login', new_user['login']))
+            search=('login', new_user['login']))
         self.assertEqual(updated_user.stdout['name'], new_user['name'])
 
     @skip_if_bug_open('bugzilla', 1070730)
@@ -1472,7 +1472,7 @@ class User(CLITestCase):
         self.assertNotEqual(result.return_code, 0)
         # check name have not changed
         updated_user = UserObj().exists(
-            tuple_search=('login', new_user['login']))
+            search=('login', new_user['login']))
         self.assertEqual(updated_user.stdout['email'], new_user['email'])
 
     @skip_if_bug_open('bugzilla', 1079649)
@@ -1588,7 +1588,7 @@ class User(CLITestCase):
         result = user.delete({'login': 'admin'})
         self.assertTrue(result.stderr)
         self.assertNotEqual(result.return_code, 0)
-        result = UserObj().exists(tuple_search=('login', 'admin'))
+        result = UserObj().exists(search=('login', 'admin'))
         self.assertTrue(result.stdout)
 
     @data(


### PR DESCRIPTION
Several test methods provide a `tuple_search` parameter to the `exists` method.
However, the `exists` method does not have a `tuple_search` argument. Its
signature looks like this:

    @classmethod
    def exists(cls, options=None, search=None):

The `search` parameter is an iterable that may contain two elements, and most
(if not all?) of the `tuple_search` arguments are two-tuples, so this is
probably what is intended. Some tests that currently fail now pass as a result
of this change. For example:

    $ nosetests tests/foreman/cli/test_org.py -m test_redmine_4486
    ......
    ----------------------------------------------------------------------
    Ran 6 tests in 67.645s

    OK