### PR TITLE
Add more modules to the API documentation

### DIFF
--- a/docs/api/tests.foreman.api.rst
+++ b/docs/api/tests.foreman.api.rst
@@ -8,6 +8,11 @@
 
 .. automodule:: tests.foreman.api.test_activationkey
 
+:mod:`tests.foreman.api.test_architecture`
+------------------------------------------
+
+.. automodule:: tests.foreman.api.test_architecture
+
 :mod:`tests.foreman.api.test_contentview`
 -----------------------------------------
 
@@ -23,10 +28,20 @@
 
 .. automodule:: tests.foreman.api.test_contentviewversion
 
+:mod:`tests.foreman.api.test_email`
+-----------------------------------
+
+.. automodule:: tests.foreman.api.test_email
+
 :mod:`tests.foreman.api.test_environment`
 -----------------------------------------
 
 .. automodule:: tests.foreman.api.test_environment
+
+:mod:`tests.foreman.api.test_errata`
+------------------------------------
+
+.. automodule:: tests.foreman.api.test_errata
 
 :mod:`tests.foreman.api.test_filter`
 ------------------------------------
@@ -43,15 +58,15 @@
 
 .. automodule:: tests.foreman.api.test_gpgkey
 
-:mod:`tests.foreman.api.test_hostgroup`
----------------------------------------
-
-.. automodule:: tests.foreman.api.test_hostgroup
-
 :mod:`tests.foreman.api.test_host`
 ----------------------------------
 
 .. automodule:: tests.foreman.api.test_host
+
+:mod:`tests.foreman.api.test_hostgroup`
+---------------------------------------
+
+.. automodule:: tests.foreman.api.test_hostgroup
 
 :mod:`tests.foreman.api.test_lifecycleenvironment`
 --------------------------------------------------

--- a/docs/api/tests.foreman.cli.rst
+++ b/docs/api/tests.foreman.cli.rst
@@ -3,6 +3,11 @@
 
 .. automodule:: tests.foreman.cli
 
+:mod:`tests.foreman.cli.test_abrt`
+----------------------------------
+
+.. automodule:: tests.foreman.cli.test_abrt
+
 :mod:`tests.foreman.cli.test_activationkey`
 -------------------------------------------
 
@@ -48,6 +53,11 @@
 
 .. automodule:: tests.foreman.cli.test_environment
 
+:mod:`tests.foreman.cli.test_errata`
+------------------------------------
+
+.. automodule:: tests.foreman.cli.test_errata
+
 :mod:`tests.foreman.cli.test_fact`
 ----------------------------------
 
@@ -63,20 +73,25 @@
 
 .. automodule:: tests.foreman.cli.test_gpgkey
 
+:mod:`tests.foreman.cli.test_host`
+----------------------------------
+
+.. automodule:: tests.foreman.cli.test_host
+
 :mod:`tests.foreman.cli.test_host_collection`
 ---------------------------------------------
 
 .. automodule:: tests.foreman.cli.test_host_collection
 
-:mod:`tests.foreman.cli.test_hostgroup`
----------------------------------------
-
-.. automodule:: tests.foreman.cli.test_hostgroup
-
 :mod:`tests.foreman.cli.test_host_system_unification`
 -----------------------------------------------------
 
 .. automodule:: tests.foreman.cli.test_host_system_unification
+
+:mod:`tests.foreman.cli.test_hostgroup`
+---------------------------------------
+
+.. automodule:: tests.foreman.cli.test_hostgroup
 
 :mod:`tests.foreman.cli.test_installer`
 ---------------------------------------
@@ -118,6 +133,11 @@
 
 .. automodule:: tests.foreman.cli.test_partitiontable
 
+:mod:`tests.foreman.cli.test_ping`
+----------------------------------
+
+.. automodule:: tests.foreman.cli.test_ping
+
 :mod:`tests.foreman.cli.test_product`
 -------------------------------------
 
@@ -128,6 +148,11 @@
 
 .. automodule:: tests.foreman.cli.test_proxy
 
+:mod:`tests.foreman.cli.test_puppetmodule`
+------------------------------------------
+
+.. automodule:: tests.foreman.cli.test_puppetmodule
+
 :mod:`tests.foreman.cli.test_report`
 ------------------------------------
 
@@ -137,6 +162,11 @@
 ----------------------------------------
 
 .. automodule:: tests.foreman.cli.test_repository
+
+:mod:`tests.foreman.cli.test_repository_set`
+--------------------------------------------
+
+.. automodule:: tests.foreman.cli.test_repository_set
 
 :mod:`tests.foreman.cli.test_roles`
 -----------------------------------
@@ -167,6 +197,11 @@
 --------------------------------------
 
 .. automodule:: tests.foreman.cli.test_syncplan
+
+:mod:`tests.foreman.cli.test_system_registration`
+-------------------------------------------------
+
+.. automodule:: tests.foreman.cli.test_system_registration
 
 :mod:`tests.foreman.cli.test_template`
 --------------------------------------

--- a/docs/api/tests.foreman.ui.rst
+++ b/docs/api/tests.foreman.ui.rst
@@ -23,6 +23,11 @@
 
 .. automodule:: tests.foreman.ui.test_computeresource
 
+:mod:`tests.foreman.ui.test_config_groups`
+------------------------------------------
+
+.. automodule:: tests.foreman.ui.test_config_groups
+
 :mod:`tests.foreman.ui.test_contentenv`
 ---------------------------------------
 
@@ -33,25 +38,35 @@
 
 .. automodule:: tests.foreman.ui.test_contentviews
 
+:mod:`tests.foreman.ui.test_discovery`
+--------------------------------------
+
+.. automodule:: tests.foreman.ui.test_discovery
+
 :mod:`tests.foreman.ui.test_domain`
 -----------------------------------
 
 .. automodule:: tests.foreman.ui.test_domain
+
+:mod:`tests.foreman.ui.test_email`
+----------------------------------
+
+.. automodule:: tests.foreman.ui.test_email
 
 :mod:`tests.foreman.ui.test_environment`
 ----------------------------------------
 
 .. automodule:: tests.foreman.ui.test_environment
 
+:mod:`tests.foreman.ui.test_errata`
+-----------------------------------
+
+.. automodule:: tests.foreman.ui.test_errata
+
 :mod:`tests.foreman.ui.test_gpgkey`
 -----------------------------------
 
 .. automodule:: tests.foreman.ui.test_gpgkey
-
-:mod:`tests.foreman.ui.test_hostgroup`
---------------------------------------
-
-.. automodule:: tests.foreman.ui.test_hostgroup
 
 :mod:`tests.foreman.ui.test_host`
 ---------------------------------
@@ -62,6 +77,21 @@
 ----------------------------------------------------
 
 .. automodule:: tests.foreman.ui.test_host_system_unification
+
+:mod:`tests.foreman.ui.test_hostgroup`
+--------------------------------------
+
+.. automodule:: tests.foreman.ui.test_hostgroup
+
+:mod:`tests.foreman.ui.test_hw_model`
+-------------------------------------
+
+.. automodule:: tests.foreman.ui.test_hw_model
+
+:mod:`tests.foreman.ui.test_location`
+-------------------------------------
+
+.. automodule:: tests.foreman.ui.test_location
 
 :mod:`tests.foreman.ui.test_login`
 ----------------------------------
@@ -98,6 +128,11 @@
 
 .. automodule:: tests.foreman.ui.test_products
 
+:mod:`tests.foreman.ui.test_puppet_classes`
+-------------------------------------------
+
+.. automodule:: tests.foreman.ui.test_puppet_classes
+
 :mod:`tests.foreman.ui.test_repository`
 ---------------------------------------
 
@@ -107,6 +142,11 @@
 ---------------------------------
 
 .. automodule:: tests.foreman.ui.test_role
+
+:mod:`tests.foreman.ui.test_settings`
+-------------------------------------
+
+.. automodule:: tests.foreman.ui.test_settings
 
 :mod:`tests.foreman.ui.test_sso`
 --------------------------------
@@ -123,27 +163,32 @@
 
 .. automodule:: tests.foreman.ui.test_subscription
 
+:mod:`tests.foreman.ui.test_sync`
+---------------------------------
+
+.. automodule:: tests.foreman.ui.test_sync
+
 :mod:`tests.foreman.ui.test_syncplan`
 -------------------------------------
 
 .. automodule:: tests.foreman.ui.test_syncplan
 
-:mod:`tests.foreman.ui.test_sync`
----------------------------------
+:mod:`tests.foreman.ui.test_system_registration`
+------------------------------------------------
 
-.. automodule:: tests.foreman.ui.test_sync
+.. automodule:: tests.foreman.ui.test_system_registration
 
 :mod:`tests.foreman.ui.test_template`
 -------------------------------------
 
 .. automodule:: tests.foreman.ui.test_template
 
-:mod:`tests.foreman.ui.test_usergroup`
---------------------------------------
-
-.. automodule:: tests.foreman.ui.test_usergroup
-
 :mod:`tests.foreman.ui.test_user`
 ---------------------------------
 
 .. automodule:: tests.foreman.ui.test_user
+
+:mod:`tests.foreman.ui.test_usergroup`
+--------------------------------------
+
+.. automodule:: tests.foreman.ui.test_usergroup


### PR DESCRIPTION
Quite a number of new modules have been added to the code base recently. Most,
if not all of these modules contain new test stubs. Add these modules to the API
documentation. Also, alphabetically sort existing documentation. `make docs`
produces only the usual errors.