### PR TITLE
Improve Makefile to list nose options

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,8 @@ FOREMAN_SMOKE_TESTS_PATH=$(join $(FOREMAN_TESTS_PATH), smoke)
 FOREMAN_TESTS_PATH=tests/foreman/
 FOREMAN_UI_TESTS_PATH=$(join $(FOREMAN_TESTS_PATH), ui)
 NOSETESTS=python -m cProfile -o $@.pstats $$(which nosetests)
+NOSETESTS_OPTS=--logging-filter=robottelo --with-xunit\
+			   --xunit-file=foreman-results.xml
 ROBOTTELO_TESTS_PATH=tests/robottelo/
 
 # Commands --------------------------------------------------------------------
@@ -38,30 +40,30 @@ test-docstrings:
 	testimony validate_docstring tests/foreman/ui
 
 test-robottelo:
-	$(NOSETESTS) -c robottelo.properties $(ROBOTTELO_TESTS_PATH)
+	$(NOSETESTS) $(ROBOTTELO_TESTS_PATH)
 
 test-foreman-api:
-	$(NOSETESTS) -c robottelo.properties $(FOREMAN_API_TESTS_PATH)
+	$(NOSETESTS) $(NOSETESTS_OPTS) $(FOREMAN_API_TESTS_PATH)
 
 test-foreman-api-threaded:
-	$(NOSETESTS) -c robottelo.properties $(FOREMAN_API_TESTS_PATH)\
+	$(NOSETESTS) $(NOSETESTS_OPTS) $(FOREMAN_API_TESTS_PATH)\
 	    --processes=-1 --process-timeout=300
 
 test-foreman-cli:
-	$(NOSETESTS) -c robottelo.properties $(FOREMAN_CLI_TESTS_PATH)
+	$(NOSETESTS) $(NOSETESTS_OPTS) $(FOREMAN_CLI_TESTS_PATH)
 
 test-foreman-cli-threaded:
-	$(NOSETESTS) -c robottelo.properties $(FOREMAN_CLI_TESTS_PATH)\
+	$(NOSETESTS) $(NOSETESTS_OPTS) $(FOREMAN_CLI_TESTS_PATH)\
 	    --processes=-1 --process-timeout=300
 
 test-foreman-ui:
-	$(NOSETESTS) -c robottelo.properties $(FOREMAN_UI_TESTS_PATH)
+	$(NOSETESTS) $(NOSETESTS_OPTS) $(FOREMAN_UI_TESTS_PATH)
 
 test-foreman-ui-xvfb:
-	xvfb-run nosetests -c robottelo.properties $(FOREMAN_UI_TESTS_PATH)
+	xvfb-run nosetests $(NOSETESTS_OPTS) $(FOREMAN_UI_TESTS_PATH)
 
 test-foreman-smoke:
-	$(NOSETESTS) -c robottelo.properties $(FOREMAN_SMOKE_TESTS_PATH)
+	$(NOSETESTS) $(NOSETESTS_OPTS) $(FOREMAN_SMOKE_TESTS_PATH)
 
 graph-entities:
 	scripts/graph_entities.py | dot -Tsvg -o entities.svg


### PR DESCRIPTION
Create a variable with nose options to be used when running foreman
tests targets. The options are the ones provided by the properties file
and also logging filter for robottelo specific messages.

This improvement will help on jenkins where those targets are used.