### PR TITLE
Improve logging configuration

### DIFF
--- a/robottelo/common/__init__.py
+++ b/robottelo/common/__init__.py
@@ -116,6 +116,9 @@ def _configure_logging(verbosity=2):
     for name in ('root', 'robottelo'):
         logging.getLogger(name).setLevel(log_level)
 
+    # All output should be made by the logging module, including warnings
+    logging.captureWarnings(True)
+
 
 def _configure_third_party_logging():
     """Increase the level of third party packages logging
@@ -124,9 +127,11 @@ def _configure_third_party_logging():
 
     """
     loggers = (
+        'bugzilla',
         'easyprocess',
         'paramiko',
         'pyvirtualdisplay',
+        'requests.packages.urllib3.connectionpool',
         'selenium.webdriver.remote.remote_connection',
     )
 

--- a/robottelo/common/decorators.py
+++ b/robottelo/common/decorators.py
@@ -43,11 +43,6 @@ _redmine = {
     'issues': {},
 }
 
-# Increase the level of third party packages logging
-logging.getLogger('bugzilla').setLevel(logging.WARNING)
-logging.getLogger(
-    'requests.packages.urllib3.connectionpool').setLevel(logging.WARNING)
-
 
 def data(*values):
     """

--- a/robottelo/common/ssh.py
+++ b/robottelo/common/ssh.py
@@ -75,9 +75,6 @@ def _get_connection(
     :rtype: paramiko.SSHClient
 
     """
-    # Hide base logger from paramiko
-    logging.getLogger('paramiko').setLevel(logging.ERROR)
-
     if hostname is None:
         hostname = conf.properties['main.server.hostname']
     if username is None:


### PR DESCRIPTION
Centralize all logging related configuration for third party packages.
Also make logging module capture warnings from the warnings module in
order to have all Robottelo output running through logging.