### PR TITLE
Improve logging round 2

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ FOREMAN_SMOKE_TESTS_PATH=$(join $(FOREMAN_TESTS_PATH), smoke)
 FOREMAN_TESTS_PATH=tests/foreman/
 FOREMAN_UI_TESTS_PATH=$(join $(FOREMAN_TESTS_PATH), ui)
 NOSETESTS=python -m cProfile -o $@.pstats $$(which nosetests)
-NOSETESTS_OPTS=--logging-filter=robottelo --with-xunit\
+NOSETESTS_OPTS=--logging-filter=nailgun,robottelo --with-xunit\
 			   --xunit-file=foreman-results.xml
 ROBOTTELO_TESTS_PATH=tests/robottelo/
 

--- a/logging.conf
+++ b/logging.conf
@@ -1,11 +1,16 @@
 [loggers]
-keys=root,robottelo
+keys=nailgun,root,robottelo
 
 [handlers]
 keys=consoleHandler,fileHandler
 
 [formatters]
 keys=simpleFormatter
+
+[logger_nailgun]
+level=DEBUG
+handlers=consoleHandler,fileHandler
+qualname=nailgun
 
 [logger_root]
 level=DEBUG

--- a/logging.conf
+++ b/logging.conf
@@ -15,7 +15,6 @@ handlers=consoleHandler,fileHandler
 level=DEBUG
 handlers=consoleHandler,fileHandler
 qualname=robottelo
-propagate=0
 
 [handler_consoleHandler]
 class=StreamHandler

--- a/robottelo/common/__init__.py
+++ b/robottelo/common/__init__.py
@@ -113,7 +113,7 @@ def _configure_logging(verbosity=2):
     else:
         log_level = logging.CRITICAL
 
-    for name in ('root', 'robottelo'):
+    for name in ('nailgun', 'root', 'robottelo'):
         logging.getLogger(name).setLevel(log_level)
 
     # All output should be made by the logging module, including warnings


### PR DESCRIPTION
This PR addresses two points in order to provide better tests and failures reports:

1. Make nose capture robottelo output.
2. Add nailgun logging config to get back the output that was present when it was a robottelo module.

I have split in two commits to separate the nailgun config from the robottelo logging config.

Hopefully nosetests will output something like this:

```python
nosetests --logging-filter=robottelo tests/foreman/cli/test_computeresource.py -m test_update
..F..........^C
======================================================================
FAIL: @Test: Test Compute Resource Update
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/elyezer/.virtualenvs/robottelo/lib/python2.7/site-packages/ddt.py", line 163, in wrapper
    return func(self, *args, **kwargs)
  File "/home/elyezer/code/robottelo/tests/foreman/cli/test_computeresource.py", line 134, in test_update
    "ComputeResource update - exit code")
AssertionError: 65 != 0 : ComputeResource update - exit code
-------------------- >> begin captured logging << --------------------
robottelo: DEBUG: Running test TestComputeResource/test_update_3___url____https___localhost_443_api____user____admin_internal____password____secret____description____updated_to_Ovirt____provider____Ovirt__
robottelo.common.ssh: DEBUG: >>> [host.com] LANG=en_US.UTF-8 hammer -v -u admin -p changeme  --output csv compute-resource update --description="updated to Ovirt" --url="https://localhost:443/api" --user="admin@internal" --provider="Ovirt" --password="secret" --name="K0Be4MPP"
robottelo.common.ssh: INFO: Instantiated Paramiko client 0x1109ec150
robottelo.common.ssh: INFO: Destroying Paramiko client 0x1109ec150
robottelo.common.ssh: INFO: Destroyed Paramiko client 0x1109ec150
robottelo.common.ssh: DEBUG: <<< /usr/lib/ruby/gems/1.8/gems/hammer_cli-0.1.4/lib/hammer_cli/./apipie/../abstract.rb:68: warning: already initialized constant DEFAULT_LABEL_INDENT
[ERROR 2015-01-26 13:21:43 Exception] Provider cannot be changed
Could not update the compute resource:
  Provider cannot be changed

--------------------- >> end captured logging << ---------------------

----------------------------------------------------------------------
Ran 14 tests in 292.038s

FAILED (failures=1)
```