### PR TITLE
Make robottelo code testimony compliant

### DIFF
--- a/tests/foreman/api/test_multiple_paths.py
+++ b/tests/foreman/api/test_multiple_paths.py
@@ -105,7 +105,9 @@ class EntityTestCase(APITestCase):
         entities.User,
     )
     def test_get_status_code(self, entity_cls):
-        """@Test GET an entity-dependent path.
+        """@Test: GET an entity-dependent path.
+
+        @Feature: Test multiple API paths
 
         @Assert: HTTP 200 is returned with an ``application/json`` content-type
 
@@ -144,6 +146,8 @@ class EntityTestCase(APITestCase):
     )
     def test_get_unauthorized(self, entity_cls):
         """@Test: GET an entity-dependent path without credentials.
+
+        @Feature: Test multiple API paths
 
         @Assert: HTTP 401 is returned
 
@@ -187,6 +191,8 @@ class EntityTestCase(APITestCase):
     )
     def test_post_status_code(self, entity_cls):
         """@Test: Issue a POST request and check the returned status code.
+
+        @Feature: Test multiple API paths
 
         @Assert: HTTP 201 is returned with an ``application/json`` content-type
 
@@ -234,6 +240,8 @@ class EntityTestCase(APITestCase):
     def test_post_unauthorized(self, entity_cls):
         """@Test: POST to an entity-dependent path without credentials.
 
+        @Feature: Test multiple API paths
+
         @Assert: HTTP 401 is returned
 
         """
@@ -278,6 +286,8 @@ class EntityIdTestCase(APITestCase):
     def test_get_status_code(self, entity_cls):
         """@Test: Create an entity and GET it.
 
+        @Feature: Test multiple API paths
+
         @Assert: HTTP 200 is returned with an ``application/json`` content-type
 
         """
@@ -319,6 +329,8 @@ class EntityIdTestCase(APITestCase):
     )
     def test_put_status_code(self, entity_cls):
         """@Test Issue a PUT request and check the returned status code.
+
+        @Feature: Test multiple API paths
 
         @Assert: HTTP 200 is returned with an ``application/json`` content-type
 
@@ -371,6 +383,8 @@ class EntityIdTestCase(APITestCase):
     def test_delete_status_code(self, entity_cls):
         """@Test Issue an HTTP DELETE request and check the returned status
         code.
+
+        @Feature: Test multiple API paths
 
         @Assert: HTTP 200, 202 or 204 is returned with an ``application/json``
         content-type.
@@ -436,6 +450,8 @@ class DoubleCheckTestCase(APITestCase):
     )
     def test_put_and_get(self, entity_cls):
         """@Test: Issue a PUT request and GET the updated entity.
+
+        @Feature: Test multiple API paths
 
         @Assert: The updated entity has the correct attributes.
 
@@ -513,6 +529,8 @@ class DoubleCheckTestCase(APITestCase):
     def test_post_and_get(self, entity_cls):
         """@Test Issue a POST request and GET the created entity.
 
+        @Feature: Test multiple API paths
+
         @Assert: The created entity has the correct attributes.
 
         """
@@ -577,6 +595,8 @@ class DoubleCheckTestCase(APITestCase):
     )
     def test_delete_and_get(self, entity_cls):
         """@Test: Issue an HTTP DELETE request and GET the deleted entity.
+
+        @Feature: Test multiple API paths
 
         @Assert: An HTTP 404 is returned when fetching the missing entity.
 
@@ -644,6 +664,8 @@ class EntityReadTestCase(APITestCase):
         """@Test: Create an entity and get it using
         :meth:`robottelo.orm.EntityReadMixin.read`.
 
+        @Feature: Test multiple API paths
+
         @Assert: The just-read entity is an instance of the correct class.
 
         """
@@ -654,6 +676,8 @@ class EntityReadTestCase(APITestCase):
 
     def test_architecture_read(self):
         """@Test: Create an arch that points to an OS, and read the arch.
+
+        @Feature: Test multiple API paths
 
         @Assert: The call to :meth:`robottelo.entities.Architecture.read`
         succeeds, and the response contains the correct operating system ID.
@@ -671,6 +695,8 @@ class EntityReadTestCase(APITestCase):
     def test_osparameter_read(self):
         """@Test: Create an OperatingSystemParameter and get it using
         :meth:`robottelo.orm.EntityReadMixin.read`.
+
+        @Feature: Test multiple API paths
 
         @Assert: The just-read entity is an instance of the correct class.
 
@@ -692,6 +718,8 @@ class EntityReadTestCase(APITestCase):
         """@Test: Create an Permission entity and get it using
         :meth:`robottelo.orm.EntityReadMixin.read`.
 
+        @Feature: Test multiple API paths
+
         @Assert: The just-read entity is an instance of the correct class and
         name and resource_type fields are populated
 
@@ -704,6 +732,8 @@ class EntityReadTestCase(APITestCase):
 
     def test_media_read(self):
         """@Test: Create a media pointing at an OS and read the media.
+
+        @Feature: Test multiple API paths
 
         @Assert: The media points at the correct operating system.
 

--- a/tests/foreman/api/test_system.py
+++ b/tests/foreman/api/test_system.py
@@ -35,6 +35,8 @@ class EntityIdTestCaseClone(APITestCase):
     def test_get_status_code(self):
         """@Test: Create a system and GET it.
 
+        @Feature: System APIs
+
         @Assert: HTTP 200 is returned with an ``application/json`` content-type
 
         """
@@ -49,7 +51,9 @@ class EntityIdTestCaseClone(APITestCase):
         self.assertIn('application/json', response.headers['content-type'])
 
     def test_put_status_code(self):
-        """@Test Issue a PUT request and check the returned status code.
+        """@Test: Issue a PUT request and check the returned status code.
+
+        @Feature: System APIs
 
         @Assert: HTTP 200 is returned with an ``application/json`` content-type
 
@@ -67,8 +71,10 @@ class EntityIdTestCaseClone(APITestCase):
         self.assertIn('application/json', response.headers['content-type'])
 
     def test_delete_status_code(self):
-        """@Test Issue an HTTP DELETE request and check the returned status
+        """@Test: Issue an HTTP DELETE request and check the returned status
         code.
+
+        @Feature: System APIs
 
         @Assert: HTTP 200, 202 or 204 is returned with an ``application/json``
         content-type.
@@ -109,6 +115,8 @@ class DoubleCheckTestCase(APITestCase):
     def test_put_and_get(self):
         """@Test: Issue a PUT request and GET the updated system.
 
+        @Feature: System APIs
+
         @Assert: The updated system has the correct attributes.
 
         """
@@ -135,6 +143,8 @@ class DoubleCheckTestCase(APITestCase):
     def test_post_and_get(self):
         """@Test Issue a POST request and GET the created system.
 
+        @Feature: System APIs
+
         @Assert: The created system has the correct attributes.
 
         """
@@ -151,6 +161,8 @@ class DoubleCheckTestCase(APITestCase):
     @skip_if_bug_open('bugzilla', 1133071)
     def test_delete_and_get(self):
         """@Test: Issue an HTTP DELETE request and GET the deleted system.
+
+        @Feature: System APIs
 
         @Assert: An HTTP 404 is returned when fetching the missing system.
 

--- a/tests/foreman/installer/test_basic_installer.py
+++ b/tests/foreman/installer/test_basic_installer.py
@@ -6,6 +6,12 @@ class BasicInstallTestCase(InstallerTestCase):
     """Test the basic product installation"""
 
     def test_hammer_ping(self):
-        """Test hammer ping output"""
+        """@Test: Test hammer ping command.
+
+        @Feature: Installer Test
+
+        @Assert: Return code is zero
+
+        """
         result = self.vm.run('hammer -u admin -p changeme ping')
         self.assertEqual(result.return_code, 0)


### PR DESCRIPTION
Now robottelo is 100% testimony compliant.  These issues werent caught before because of a testimony bug https://github.com/SatelliteQE/testimony/issues/67 which is now fixed.

```py
# python testimony/__main__.py validate_docstring /robottelo/tests/foreman/

Fetching Test Path /robottelo/tests/foreman/

Fetching Test Path /robottelo/tests/foreman/api
Scanning test_contentview.py...
Scanning test_host.py...
Scanning test_smartproxy.py...
Scanning test_operatingsystem.py...
Scanning test_permission.py...
Scanning test_subscription.py...
Scanning test_rhsm.py...
Scanning test_email.py...
Scanning test_multiple_paths.py...
Scanning test_media.py...
Scanning test_repository.py...
Scanning test_activationkey.py...
Scanning test_gpgkey.py...
Scanning test_foremantask.py...
Scanning test_errata.py...
Scanning test_environment.py...
Scanning test_product.py...
Scanning test_filter.py...
Scanning test_contentviewversion.py...
Scanning test_hostgroup.py...
Scanning test_lifecycleenvironment.py...
Scanning test_role.py...
Scanning test_organization.py...
Scanning test_architecture.py...
Scanning test_contentviewfilter.py...
Scanning test_user.py...
Scanning test_system.py...

Fetching Test Path /robottelo/tests/foreman/cli
Scanning test_os.py...
Scanning test_host_collection.py...
Scanning test_domain.py...
Scanning test_org.py...
Scanning test_host.py...
Scanning test_puppetmodule.py...
Scanning test_subscription.py...
Scanning test_medium.py...
Scanning test_system_registration.py...
Scanning test_partitiontable.py...
Scanning test_host_system_unification.py...
Scanning test_globalparam.py...
Scanning test_model.py...
Scanning test_repository.py...
Scanning test_activationkey.py...
Scanning test_gpgkey.py...
Scanning test_proxy.py...
Scanning test_repository_set.py...
Scanning test_abrt.py...
Scanning test_capsule_installer.py...
Scanning test_scparam.py...
Scanning test_ping.py...
Scanning test_computeresource.py...
Scanning test_capsule.py...
Scanning test_fact.py...
Scanning test_errata.py...
Scanning test_environment.py...
Scanning test_sso.py...
Scanning test_report.py...
Scanning test_roles.py...
Scanning test_product.py...
Scanning test_hostgroup.py...
Scanning test_syncplan.py...
Scanning test_installer.py...
Scanning test_subnet.py...
Scanning test_lifecycleenvironment.py...
Scanning test_contenthost.py...
Scanning test_architecture.py...
Scanning test_myaccount.py...
Scanning test_contentviews.py...
Scanning test_user.py...
Scanning test_template.py...

Fetching Test Path /robottelo/tests/foreman/installer
Scanning test_installer.py...
Scanning test_basic_installer.py...

Fetching Test Path /robottelo/tests/foreman/ui
Scanning test_domain.py...
Scanning test_org.py...
Scanning test_discovery.py...
Scanning test_settings.py...
Scanning test_login.py...
Scanning test_host.py...
Scanning test_sync.py...
Scanning test_subscription.py...
Scanning test_medium.py...
Scanning test_system_registration.py...
Scanning test_partitiontable.py...
Scanning test_host_system_unification.py...
Scanning test_email.py...
Scanning test_hw_model.py...
Scanning test_puppet_classes.py...
Scanning test_repository.py...
Scanning test_activationkey.py...
Scanning test_gpgkey.py...
Scanning test_operatingsys.py...
Scanning test_location.py...
Scanning test_config_groups.py...
Scanning test_products.py...
Scanning test_computeresource.py...
Scanning test_capsule.py...
Scanning test_errata.py...
Scanning test_environment.py...
Scanning test_sso.py...
Scanning test_usergroup.py...
Scanning test_contentenv.py...
Scanning test_hostgroup.py...
Scanning test_syncplan.py...
Scanning test_subnet.py...
Scanning test_role.py...
Scanning test_architecture.py...
Scanning test_myaccount.py...
Scanning test_contentviews.py...
Scanning test_user.py...
Scanning test_template.py...

Fetching Test Path /robottelo/tests/foreman/smoke
Scanning test_cli_smoke.py...
Scanning test_ui_smoke.py...
Scanning test_api_smoke.py...


Total Number of invalid docstrings:  0
Test cases with no docstrings:   0
Test cases missing minimal docstrings:  0

```