### PR TITLE
Skip yet more tests that fail due to BZ 1184644

### DIFF
--- a/tests/foreman/api/test_contentview.py
+++ b/tests/foreman/api/test_contentview.py
@@ -91,10 +91,10 @@ class ContentViewTestCase(APITestCase):
         cv_version = entities.ContentViewVersion(id=results[0]['id'])
 
         # Promote the content view version.
-        self.assertEqual(
-            'success',
-            cv_version.promote(environment_id=lifecycle_env.id)['result']
-        )
+        response = cv_version.promote(environment_id=lifecycle_env.id)
+        humanized_errors = response['humanized']['errors']
+        _check_bz_1186432(humanized_errors)
+        self.assertEqual('success', response['result'], humanized_errors)
 
         # Create a system that is subscribed to the published and promoted
         # content view. Associating this system with the organization and
@@ -324,11 +324,9 @@ class CVPublishPromoteTestCase(APITestCase):
                 organization=self.org.id
             ).create_json()['id']
             response = cvv.promote(lc_env_id)
-            self.assertEqual(
-                response['result'],
-                'success',
-                response['humanized']['errors']
-            )
+            humanized_errors = response['humanized']['errors']
+            _check_bz_1186432(humanized_errors)
+            self.assertEqual(response['result'], 'success', humanized_errors)
 
         # Does it show up in the correct number of lifecycle environments?
         self.assertEqual(
@@ -364,11 +362,9 @@ class CVPublishPromoteTestCase(APITestCase):
                 organization=self.org.id
             ).create_json()['id']
             response = cvv.promote(lc_env_id)
-            self.assertEqual(
-                response['result'],
-                'success',
-                response['humanized']['errors']
-            )
+            humanized_errors = response['humanized']['errors']
+            _check_bz_1186432(humanized_errors)
+            self.assertEqual(response['result'], 'success', humanized_errors)
 
         # Everything's done - check some content view attributes...
         cv_attrs = content_view.read_json()
@@ -414,11 +410,9 @@ class CVPublishPromoteTestCase(APITestCase):
                 organization=self.org.id
             ).create_json()['id']
             response = cvv.promote(lc_env_id)
-            self.assertEqual(
-                response['result'],
-                'success',
-                response['humanized']['errors']
-            )
+            humanized_errors = response['humanized']['errors']
+            _check_bz_1186432(humanized_errors)
+            self.assertEqual(response['result'], 'success', humanized_errors)
 
         # Everything's done. Check some content view attributes...
         cv_attrs = content_view.read_json()


### PR DESCRIPTION
BZ 1184644 describes how content view publication sometimes fails due to errors
in foreman-proxy. Further test results show that this issue also affects content
view version promotion, and with identical error messages. Here is an example of
one error message returned when attempting to promote a content view version:

> ERF12-4115 [ProxyAPI::ProxyException]: Unable to get classes from Puppet for
> KT_FLroGDT3UX_ilMwJQdmVG_xRCEOKGtxC_10 ([RestClient::NotAcceptable]: 406 Not
> Acceptable) for proxy https://<snip>:9090/puppet

At least one of the updated tests can still execute correctly:

    $ nosetests tests/foreman/api/test_contentview.py -m test_positive_promote_1
    .
    ----------------------------------------------------------------------
    Ran 1 test in 253.897s

    OK