### PR TITLE
Skip API tests that fail due to BZ 1187366

### DIFF
--- a/tests/foreman/api/test_multiple_paths.py
+++ b/tests/foreman/api/test_multiple_paths.py
@@ -30,6 +30,7 @@ BZ_1151240_ENTITIES = (
     entities.LifecycleEnvironment, entities.Product, entities.Repository
 )
 BZ_1154156_ENTITIES = (entities.ConfigTemplate, entities.Host, entities.User)
+BZ_1187366_ENTITIES = (entities.LifecycleEnvironment, entities.Organization)
 
 
 def _get_partial_func(obj):
@@ -399,6 +400,8 @@ class EntityIdTestCase(APITestCase):
         except HTTPError as err:
             self.fail(err)
         response = entity.delete_raw()
+        if entity_cls in BZ_1187366_ENTITIES and bz_bug_is_open(1187366):
+            self.skipTest('BZ 1187366 is open.')
         self.assertIn(
             response.status_code,
             (httplib.NO_CONTENT, httplib.OK, httplib.ACCEPTED)
@@ -611,6 +614,8 @@ class DoubleCheckTestCase(APITestCase):
             entity = entity_cls(id=entity_cls().create_json()['id'])
         except HTTPError as err:
             self.fail(err)
+        if entity_cls in BZ_1187366_ENTITIES and bz_bug_is_open(1187366):
+            self.skipTest('BZ 1187366 is open.')
         entity.delete()
 
         if entity_cls is entities.Repository and bz_bug_is_open(1166365):


### PR DESCRIPTION
From the bug report:

    It is impossible to delete an organization or environment. Doing so results
    an HTTP 500 error and the following error message:

        "undefined method `disable_auto_reindex!' for #<Katello::KTEnvironment:0x007feabd86dc10>"

    To be even more exact, issuing an HTTP DELETE request to the following URLs
    triggers the above error:

    * my-satellite6.example.com/katello/api/v2/organizations/:organization_id
    * my-satellite6.example.com/katello/api/v2/environments/:environment_id

The test suite passes a sanity check:

    $ nosetests tests/foreman/api/test_multiple_paths.py -m Organization
    S..S......S
    ----------------------------------------------------------------------
    Ran 11 tests in 11.772s

    OK (SKIP=3)