### PR TITLE
Fixed the remove-computeresource testcase.

### DIFF
--- a/tests/foreman/ui/test_computeresource.py
+++ b/tests/foreman/ui/test_computeresource.py
@@ -210,6 +210,4 @@ class ComputeResource(UITestCase):
             search = self.compute_resource.search(name)
             self.assertIsNotNone(search)
             self.compute_resource.delete(name, really=True)
-            notif = session.nav.wait_until_element(
-                common_locators["notif.success"])
-            self.assertIsNotNone(notif)
+            self.assertIsNone(self.compute_resource.search(name))


### PR DESCRIPTION
* Will be using an alternate way to assert the deletion of CR.
* Instead of asserting notification, asserting whether the
  search yields no results and is None.
* Similar approach is being used for almost all of the delete
  test-cases for the UI part.