### PR TITLE
Updated CLI tests for Docker repositories.

### DIFF
--- a/robottelo/cli/factory.py
+++ b/robottelo/cli/factory.py
@@ -489,6 +489,8 @@ def make_repository(options=None):
         --content-type CONTENT_TYPE             type of repo (either 'yum',
                                                 'puppet' or 'docker', defaults
                                                 to 'yum')
+        --docker-upstream-name DOCKER_UPSTREAM_NAME name of the upstream docker
+                                                repository
         --gpg-key GPG_KEY_NAME                  Name to search by
         --gpg-key-id GPG_KEY_ID                 gpg key numeric identifier
         --label LABEL
@@ -511,6 +513,7 @@ def make_repository(options=None):
     args = {
         u'checksum-type': None,
         u'content-type': u'yum',
+        u'docker-upstream-name': None,
         u'gpg-key': None,
         u'gpg-key-id': None,
         u'label': None,

--- a/tests/foreman/cli/test_repository.py
+++ b/tests/foreman/cli/test_repository.py
@@ -331,42 +331,13 @@ class TestRepository(CLITestCase):
             "Publishing methods don't match"
         )
 
-    @run_only_on('sat')
-    def test_positive_create_9(self):
-        """@Test: Create a Docker repository
-
-        @Feature: Repository
-
-        @Assert: Docker repository is created and contains correct values.
-
-        """
-        content_type = u'docker'
-        new_repo = self._make_repository({
-            u'name': u'busybox',
-            u'url': DOCKER_REGISTRY_HUB,
-            u'content-type': content_type,
-        })
-        # Assert that urls and content types matches data passed
-        self.assertEqual(
-            new_repo['url'],
-            DOCKER_REGISTRY_HUB,
-            "Expected URL {0} but received {1}".format(
-                DOCKER_REGISTRY_HUB, new_repo['url'])
-        )
-        self.assertEqual(
-            new_repo['content-type'],
-            content_type,
-            "Expected content type {0} but received {1}".format(
-                content_type, new_repo['content-type'])
-        )
-
     @skip_if_bug_open('bugzilla', 1155237)
     @run_only_on('sat')
     @data(
         u'sha1',
         u'sha256',
     )
-    def test_positive_create_10(self, checksum_type):
+    def test_positive_create_9(self, checksum_type):
         """@Test: Create a YUM repository with a checksum type
 
         @Feature: Repository
@@ -384,6 +355,56 @@ class TestRepository(CLITestCase):
         })
         self.assertEqual(repository['content-type'], content_type)
         self.assertEqual(repository['checksum-type'], checksum_type)
+
+    @run_only_on('sat')
+    def test_positive_create_docker_repo_1(self):
+        """@Test: Create a Docker repository with upstream name.
+
+        @Feature: Repository
+
+        @Assert: Docker repository is created and contains correct values.
+
+        """
+        content_type = u'docker'
+        new_repo = self._make_repository({
+            u'name': u'busybox',
+            u'docker-upstream-name': u'busybox',
+            u'url': DOCKER_REGISTRY_HUB,
+            u'content-type': content_type,
+        })
+        # Assert that urls and content types matches data passed
+        self.assertEqual(new_repo['url'], DOCKER_REGISTRY_HUB)
+        self.assertEqual(new_repo['content-type'], content_type)
+        self.assertEqual(new_repo['name'], u'busybox')
+
+    @run_only_on('sat')
+    @data(
+        gen_string('alpha', 15),
+        gen_string('alphanumeric', 15),
+        gen_string('numeric', 15),
+        gen_string('latin1', 15),
+        gen_string('utf8', 15),
+        gen_string('html', 15),
+    )
+    def test_positive_create_docker_repo_2(self, name):
+        """@Test: Create a Docker repository with a randon name.
+
+        @Feature: Repository
+
+        @Assert: Docker repository is created and contains correct values.
+
+        """
+        content_type = u'docker'
+        new_repo = self._make_repository({
+            u'name': name,
+            u'docker-upstream-name': u'busybox',
+            u'url': DOCKER_REGISTRY_HUB,
+            u'content-type': content_type,
+        })
+        # Assert that urls, content types and name matches data passed
+        self.assertEqual(new_repo['url'], DOCKER_REGISTRY_HUB)
+        self.assertEqual(new_repo['content-type'], content_type)
+        self.assertEqual(new_repo['name'], name)
 
     @run_only_on('sat')
     @data(


### PR DESCRIPTION
Docker repositories now allow you to have a random name and a brand new
field to hold the actual name for the container. I have updated the
existing test to adjust to the new arguments, as well as added a new
data-driven test to make sure that we can create repositories with
random names but pointing to the same container.

Tests look good:

```bash

nosetests -c robottelo.properties -m test_positive_create_docker_repo_1 tests.foreman.cli.test_repository

.
----------------------------------------------------------------------
Ran 1 test in 30.890s

OK

nosetests -c robottelo.properties -m test_positive_create_docker_repo_2 tests.foreman.cli.test_repository

......
----------------------------------------------------------------------
Ran 6 tests in 86.228s

OK
```