### PR TITLE
Make robottelo more PEP8 compatible

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -94,8 +94,8 @@ epub_copyright = u'2012, Og Maciel <omaciel@redhat.com>'
 #
 # As a result, the API documentation is much more concise.
 
-import ddt
-import robottelo.common.decorators  # pylint:disable=import-error
+import ddt  # noqa
+import robottelo.common.decorators  # noqa pylint:disable=import-error
 # robttelo.common.decorators can only be imported if the `sys.path.insert` at
 # the top of this document is executed. pylint tries to be a static code
 # analyzer, so that does not happen, and it therefore cannot find this module.

--- a/robottelo/cli/metatest/__init__.py
+++ b/robottelo/cli/metatest/__init__.py
@@ -1,14 +1,10 @@
-"""
-Meta class for all CLI tests
-"""
+"""Meta class for all CLI tests"""
 
-import default_data
 import itertools
-import template_methods
 import types
 
 from ddt import ddt
-
+from robottelo.cli.metatest import default_data, template_methods
 from robottelo.common.decorators import data
 
 
@@ -26,7 +22,7 @@ class MetaCLITest(type):
     factory = None
     test_class = None
 
-    def __new__(mcs, name, bases, attributes):
+    def __new__(cls, name, bases, attributes):
         """
         Adds a create method for the specific class.
 
@@ -38,7 +34,7 @@ class MetaCLITest(type):
         """
 
         _klass = super(
-            MetaCLITest, mcs).__new__(mcs, name, bases, attributes)
+            MetaCLITest, cls).__new__(cls, name, bases, attributes)
 
         # When loading test classes for a test run, the Nose class
         # loader "transplants" any class that inherits from unittest.TestCase

--- a/robottelo/common/decorators.py
+++ b/robottelo/common/decorators.py
@@ -1,26 +1,19 @@
 # -*- encoding: utf-8 -*-
-# vim: ts=4 sw=4 expandtab ai
-
-"""
-Implements various decorators
-"""
+"""Implements various decorators"""
 
 import bugzilla
 import logging
 import random
 import requests
-from functools import wraps
-
-import sys
-if sys.hexversion >= 0x2070000:
+try:
     import unittest
-else:
+except ImportError:
     import unittest2 as unittest
 
-
 from ddt import data as ddt_data
-from robottelo.common.constants import NOT_IMPLEMENTED
+from functools import wraps
 from robottelo.common import conf
+from robottelo.common.constants import NOT_IMPLEMENTED
 from xml.parsers.expat import ExpatError, errors
 from xmlrpclib import Fault
 
@@ -166,7 +159,7 @@ def run_only_on(project):
         'only on "{1}" mode.'.format(robottelo_mode, project))
 
 
-def skipRemote(func):
+def skipRemote(func):  # noqa
     """Decorator to skip tests based on whether server is remote,
     Remote in the sense whether it is Sauce Labs"""
 
@@ -324,7 +317,7 @@ class BugTypeError(Exception):
     """Indicates that an incorrect bug type was specified."""
 
 
-class skip_if_bug_open(object):  # pylint:disable=C0103,R0903
+class skip_if_bug_open(object):  # noqa pylint:disable=C0103,R0903
     """A decorator that can be used to skip a unit test."""
 
     def __init__(self, bug_type, bug_id):

--- a/robottelo/common/ssh.py
+++ b/robottelo/common/ssh.py
@@ -168,7 +168,7 @@ def command(cmd, hostname=None, expect_csv=False, timeout=None):
         stdout = u"".join(stdout).split("\n")
         output = [
             regex.sub('', line) for line in stdout if not line.startswith("[")
-            ]
+        ]
     else:
         output = []
 

--- a/robottelo/test.py
+++ b/robottelo/test.py
@@ -8,9 +8,9 @@ import logging
 import os
 import signal
 import sys
-if sys.hexversion >= 0x2070000:
+try:
     import unittest
-else:
+except ImportError:
     import unittest2 as unittest
 
 from automation_tools import product_install
@@ -63,7 +63,7 @@ class TestCase(unittest.TestCase):
     """Robottelo test case"""
 
     @classmethod
-    def setUpClass(cls):
+    def setUpClass(cls):  # noqa
         super(TestCase, cls).setUpClass()
         cls.logger = logging.getLogger('robottelo')
         # NOTE: longMessage defaults to True in Python 3.1 and above
@@ -80,7 +80,7 @@ class CLITestCase(TestCase):
     _multiprocess_can_split_ = True
 
     @classmethod
-    def setUpClass(cls):
+    def setUpClass(cls):  # noqa
         """Make sure that we only read configuration values once."""
         super(CLITestCase, cls).setUpClass()
         cls.hostname = conf.properties['main.server.hostname']
@@ -91,7 +91,7 @@ class CLITestCase(TestCase):
         cls.locale = conf.properties['main.locale']
         cls.verbosity = int(conf.properties['main.verbosity'])
 
-    def setUp(self):
+    def setUp(self):  # noqa
         """Log test class and method name before each test."""
         self.logger.debug(
             "Running test %s/%s", type(self).__name__, self._testMethodName)
@@ -109,7 +109,7 @@ class UITestCase(TestCase):
     """Test case for UI tests."""
 
     @classmethod
-    def setUpClass(cls):
+    def setUpClass(cls):  # noqa
         """Make sure that we only read configuration values once."""
         super(UITestCase, cls).setUpClass()
         cls.katello_user = conf.properties['foreman.admin.username']
@@ -155,7 +155,7 @@ class UITestCase(TestCase):
         else:
             cls.display = None
 
-    def setUp(self):
+    def setUp(self):  # noqa
         """We do want a new browser instance for every test."""
         if not self.remote:
             if self.driver_name.lower() == 'firefox':
@@ -168,7 +168,7 @@ class UITestCase(TestCase):
                 service_args = ['--ignore-ssl-errors=true']
                 self.browser = webdriver.PhantomJS(
                     service_args=service_args
-                    )
+                )
             else:
                 self.browser = webdriver.Remote()
         else:
@@ -250,7 +250,7 @@ class UITestCase(TestCase):
         )
         self.browser.save_screenshot(os.path.join(dir_structure, filename))
 
-    def tearDown(self):
+    def tearDown(self):  # noqa
         """Make sure to close the browser after each test."""
         if sys.exc_info()[0] is not None:
             self.take_screenshot(self._testMethodName)
@@ -258,7 +258,7 @@ class UITestCase(TestCase):
         self.browser = None
 
     @classmethod
-    def tearDownClass(cls):
+    def tearDownClass(cls):  # noqa
         if cls.display is not None:
             if (cls.window_manager is not None and
                     cls.window_manager.is_started):
@@ -294,7 +294,7 @@ class InstallerTestCase(TestCase):
     vm_os = 'rhel7'
 
     @classmethod
-    def setUpClass(cls):
+    def setUpClass(cls):  # noqa
         super(InstallerTestCase, cls).setUpClass()
         cls.vm = VirtualMachine(cls.vm_cpu, cls.vm_ram, cls.vm_os)
         cls.vm.create()
@@ -307,6 +307,6 @@ class InstallerTestCase(TestCase):
             )
 
     @classmethod
-    def tearDownClass(cls):
+    def tearDownClass(cls):  # noqa
         super(InstallerTestCase, cls).tearDownClass()
         cls.vm.destroy()

--- a/robottelo/ui/base.py
+++ b/robottelo/ui/base.py
@@ -1,17 +1,15 @@
 # -*- encoding: utf-8 -*-
-# vim: ts=4 sw=4 expandtab ai
+"""Base class for all UI operations"""
 
-"""
-Base class for all UI operations
-"""
 import logging
+
+from robottelo.common.helpers import escape_search
 from robottelo.ui.locators import locators, common_locators
 from selenium.common.exceptions import NoSuchElementException
 from selenium.common.exceptions import TimeoutException
 from selenium.common.exceptions import WebDriverException
-from robottelo.common.helpers import escape_search
+from selenium.webdriver.support import expected_conditions
 from selenium.webdriver.support.ui import WebDriverWait
-from selenium.webdriver.support import expected_conditions as EC
 
 
 class UINoSuchElementError(Exception):
@@ -196,7 +194,7 @@ class Base(object):
         try:
             element = WebDriverWait(
                 self.browser, timeout, poll_frequency
-            ).until(EC.visibility_of_element_located(locator))
+            ).until(expected_conditions.visibility_of_element_located(locator))
             self.wait_for_ajax(poll_frequency=poll_frequency)
             return element
         except TimeoutException as e:

--- a/robottelo/ui/location.py
+++ b/robottelo/ui/location.py
@@ -7,7 +7,7 @@ Implements Locations UI
 
 from robottelo.ui.base import Base, UINoSuchElementError
 from robottelo.ui.locators import common_locators, locators, tab_locators
-from robottelo.ui.navigator import Navigator as nav
+from robottelo.ui.navigator import Navigator
 from robottelo.common.constants import FILTER
 from selenium.webdriver.support.select import Select
 
@@ -110,7 +110,7 @@ class Location(Base):
 
     def search(self, name):
         """Searches existing location from UI."""
-        nav(self.browser).go_to_loc()
+        Navigator(self.browser).go_to_loc()
         self.wait_for_ajax()
         element = self.search_entity(name, locators["location.select_name"])
         return element

--- a/robottelo/ui/org.py
+++ b/robottelo/ui/org.py
@@ -1,14 +1,10 @@
 # -*- encoding: utf-8 -*-
-# vim: ts=4 sw=4 expandtab ai
+"""Implements Org UI"""
 
-"""
-Implements Org UI
-"""
-
+from robottelo.common.constants import FILTER
 from robottelo.ui.base import Base, UINoSuchElementError
 from robottelo.ui.locators import locators, common_locators, tab_locators
-from robottelo.ui.navigator import Navigator as nav
-from robottelo.common.constants import FILTER
+from robottelo.ui.navigator import Navigator
 from selenium.webdriver.support.select import Select
 
 
@@ -113,7 +109,7 @@ class Org(Base):
 
     def search(self, name):
         """Searches existing Organization from UI."""
-        nav(self.browser).go_to_org()
+        Navigator(self.browser).go_to_org()
         self.wait_for_ajax()
         element = self.search_entity(name, locators["org.org_name"])
         return element

--- a/scripts/generate_entities.py
+++ b/scripts/generate_entities.py
@@ -14,8 +14,8 @@ ROBOTTELO_PATH = os.path.realpath(
 if ROBOTTELO_PATH not in sys.path:
     sys.path.append(ROBOTTELO_PATH)
 
-from robottelo.api import inspect
-from StringIO import StringIO
+from robottelo.api import inspect  # noqa
+from StringIO import StringIO  # noqa
 
 
 TAG_RE = re.compile(r'<[^>]+>')

--- a/scripts/graph_entities.py
+++ b/scripts/graph_entities.py
@@ -18,8 +18,8 @@ if ROBOTTELO_PATH not in sys.path:
     sys.path.append(ROBOTTELO_PATH)
 
 # Proceed with normal imports.
-from robottelo import entities, orm
-import inspect
+import inspect  # noqa
+from robottelo import entities, orm  # noqa
 
 
 def graph():

--- a/tests/foreman/api/test_contentview.py
+++ b/tests/foreman/api/test_contentview.py
@@ -194,7 +194,7 @@ class CVPublishPromoteTestCase(APITestCase):
     """Tests for publishing and promoting content views."""
 
     @classmethod
-    def setUpClass(cls):
+    def setUpClass(cls):  # noqa
         """Set up organization, product and repositories for tests."""
         super(CVPublishPromoteTestCase, cls).setUpClass()
 
@@ -432,7 +432,7 @@ class ContentViewUpdateTestCase(APITestCase):
     """Tests for updating content views."""
 
     @classmethod
-    def setUpClass(cls):
+    def setUpClass(cls):  # noqa
         """Create a content view."""
         cls.content_view = entities.ContentView(
             id=entities.ContentView().create()['id']

--- a/tests/foreman/api/test_organization.py
+++ b/tests/foreman/api/test_organization.py
@@ -203,7 +203,7 @@ class OrganizationUpdateTestCase(APITestCase):
     """Tests for the ``organizations`` path."""
 
     @classmethod
-    def setUpClass(cls):
+    def setUpClass(cls):  # noqa
         """Create an organization."""
         cls.organization = entities.Organization(
             id=entities.Organization().create_json()['id']

--- a/tests/foreman/api/test_permission.py
+++ b/tests/foreman/api/test_permission.py
@@ -132,7 +132,7 @@ def _permission_name(entity, which_perm):
 class UserRoleTestCase(APITestCase):
     """Give a user various permissions and see if they are enforced."""
 
-    def setUp(self):
+    def setUp(self):  # noqa
         """Create a set of credentials and a user."""
         self.auth = (gen_alphanumeric(), gen_alphanumeric())  # login, password
         self.user = entities.User(

--- a/tests/foreman/api/test_product.py
+++ b/tests/foreman/api/test_product.py
@@ -85,7 +85,7 @@ class ProductUpdateTestCase(APITestCase):
     """Tests for updating a product."""
 
     @classmethod
-    def setUpClass(cls):
+    def setUpClass(cls):  # noqa
         """Create a product."""
         cls.product_n = entities.Product(
             id=entities.Product().create()['id']

--- a/tests/foreman/api/test_repository.py
+++ b/tests/foreman/api/test_repository.py
@@ -46,7 +46,7 @@ class RepositoryTestCase(APITestCase):
     """Tests for ``katello/api/v2/repositories``."""
 
     @classmethod
-    def setUpClass(cls):
+    def setUpClass(cls):  # noqa
         """Create an organization and product which can be re-used in tests."""
         cls.org_id = entities.Organization().create()['id']
         cls.prod_id = entities.Product(organization=cls.org_id).create()['id']
@@ -217,7 +217,7 @@ class RepositoryUpdateTestCase(APITestCase):
     """Tests for updating repositories."""
 
     @classmethod
-    def setUpClass(cls):
+    def setUpClass(cls):  # noqa
         """Create a repository which can be repeatedly updated."""
         cls.repository = entities.Repository(
             id=entities.Repository().create()['id']
@@ -292,7 +292,7 @@ class DockerRepositoryTestCase(APITestCase):
     """Tests specific to using ``Docker`` repositories."""
 
     @classmethod
-    def setUpClass(cls):
+    def setUpClass(cls):  # noqa
         """Create an organization and product which can be re-used in tests."""
         cls.org_id = entities.Organization().create()['id']
 

--- a/tests/foreman/cli/test_activationkey.py
+++ b/tests/foreman/cli/test_activationkey.py
@@ -31,7 +31,7 @@ class TestActivationKey(CLITestCase):
     env1 = None
     env2 = None
 
-    def setUp(self):
+    def setUp(self):  # noqa
         """Tests for activation keys via Hammer CLI"""
         super(TestActivationKey, self).setUp()
 

--- a/tests/foreman/cli/test_computeresource.py
+++ b/tests/foreman/cli/test_computeresource.py
@@ -35,7 +35,7 @@ class TestComputeResource(CLITestCase):
     """ComputeResource CLI tests."""
 
     @classmethod
-    def setUpClass(cls):
+    def setUpClass(cls):  # noqa
         CLITestCase.setUpClass()
         cls.compute_res_updates = make_compute_resource({
             'provider': FOREMAN_PROVIDERS['libvirt'],

--- a/tests/foreman/cli/test_contenthost.py
+++ b/tests/foreman/cli/test_contenthost.py
@@ -28,7 +28,7 @@ class TestContentHost(CLITestCase):
     LIBRARY = None
     DEFAULT_CV = None
 
-    def setUp(self):
+    def setUp(self):  # noqa
         """Tests for Content Host via Hammer CLI"""
 
         super(TestContentHost, self).setUp()

--- a/tests/foreman/cli/test_contentviews.py
+++ b/tests/foreman/cli/test_contentviews.py
@@ -129,7 +129,7 @@ class TestContentView(CLITestCase):
             TestContentView.rhel_content_org = None
             self.fail("Couldn't synchronize repo")
 
-    def setUp(self):
+    def setUp(self):  # noqa
         """Tests for content-view via Hammer CLI"""
 
         super(TestContentView, self).setUp()

--- a/tests/foreman/cli/test_fact.py
+++ b/tests/foreman/cli/test_fact.py
@@ -2,18 +2,11 @@
 # vim: ts=4 sw=4 expandtab ai
 """Test class for Fact  CLI"""
 
-import sys
-
 from ddt import ddt
 from fauxfactory import gen_string
 from robottelo.cli.fact import Fact
-from robottelo.common.decorators import data, run_only_on
+from robottelo.common.decorators import data, run_only_on, stubbed
 from robottelo.test import CLITestCase
-
-if sys.hexversion >= 0x2070000:
-    import unittest
-else:
-    import unittest2 as unittest
 
 
 @run_only_on('sat')
@@ -21,7 +14,7 @@ else:
 class TestFact(CLITestCase):
     """Fact related tests."""
 
-    @unittest.skip("Need to create facts before we can check them.")
+    @stubbed('Need to create facts before we can check them.')
     @data(
         'uptime', 'uptime_days', 'uptime_seconds', 'memoryfree', 'ipaddress',
     )

--- a/tests/foreman/cli/test_gpgkey.py
+++ b/tests/foreman/cli/test_gpgkey.py
@@ -56,7 +56,7 @@ class TestGPGKey(CLITestCase):
     search_key = 'name'
 
     @classmethod
-    def setUpClass(cls):
+    def setUpClass(cls):  # noqa
         """Create a shared organization for all tests to avoid generating
         hundreds of organizations
 

--- a/tests/foreman/cli/test_host_collection.py
+++ b/tests/foreman/cli/test_host_collection.py
@@ -26,7 +26,7 @@ class TestHostCollection(CLITestCase):
     library = None
     default_cv = None
 
-    def setUp(self):
+    def setUp(self):  # noqa
         """Tests for Host Collections via Hammer CLI"""
 
         super(TestHostCollection, self).setUp()

--- a/tests/foreman/cli/test_host_system_unification.py
+++ b/tests/foreman/cli/test_host_system_unification.py
@@ -1,20 +1,8 @@
 # -*- encoding: utf-8 -*-
-# vim: ts=4 sw=4 expandtab ai
+"""Test class for Host/System Unification"""
 
-"""
-Test class for Host/System Unification
-"""
-
-import sys
-
-from robottelo.common.constants import NOT_IMPLEMENTED
-from robottelo.common.decorators import run_only_on
+from robottelo.common.decorators import run_only_on, stubbed
 from robottelo.test import CLITestCase
-
-if sys.hexversion >= 0x2070000:
-    import unittest
-else:
-    import unittest2 as unittest
 
 
 @run_only_on('sat')
@@ -30,7 +18,7 @@ class TestHostSystemUnificationCLI(CLITestCase):
     # (the link/join will) "Most likely an internal UUID, not something
     # fuzzy like hostname"
 
-    @unittest.skip(NOT_IMPLEMENTED)
+    @stubbed
     def test_all_hosts_appear_in_foreman(self):
         """@test: Hosts registered to Katello via rhsm appear in foreman
 
@@ -48,7 +36,7 @@ class TestHostSystemUnificationCLI(CLITestCase):
         """
         pass
 
-    @unittest.skip(NOT_IMPLEMENTED)
+    @stubbed
     def all_hosts_appear_in_katello(self):
         """@test: Hosts provisioned in foreman via appear in katello
 

--- a/tests/foreman/cli/test_installer.py
+++ b/tests/foreman/cli/test_installer.py
@@ -1,16 +1,6 @@
 # -*- encoding: utf-8 -*-
-# vim: ts=4 sw=4 expandtab ai
-
-import sys
-
-from robottelo.common.constants import NOT_IMPLEMENTED
-from robottelo.common.decorators import run_only_on
+from robottelo.common.decorators import run_only_on, stubbed
 from robottelo.test import CLITestCase
-
-if sys.hexversion >= 0x2070000:
-    import unittest
-else:
-    import unittest2 as unittest
 
 
 @run_only_on('sat')
@@ -21,7 +11,7 @@ class TestSSOCLI(CLITestCase):
     # that can parse logs? It would be better (and possibly less
     # error-prone) than simply grepping for ERROR/FATAL
 
-    @unittest.skip(NOT_IMPLEMENTED)
+    @stubbed
     def test_installer_check_services(self):
         # devnote:
         # maybe `hammer ping` command might be useful here to check
@@ -39,7 +29,7 @@ class TestSSOCLI(CLITestCase):
         """
         pass
 
-    @unittest.skip(NOT_IMPLEMENTED)
+    @stubbed
     def test_installer_logfile_check(self):
         """@test: Look for ERROR or FATAL references in logfiles
 
@@ -57,7 +47,7 @@ class TestSSOCLI(CLITestCase):
         """
         pass
 
-    @unittest.skip(NOT_IMPLEMENTED)
+    @stubbed
     def test_installer_check_progress_meter(self):
         """@test:  Assure progress indicator/meter "works"
 
@@ -71,7 +61,7 @@ class TestSSOCLI(CLITestCase):
         """
         pass
 
-    @unittest.skip(NOT_IMPLEMENTED)
+    @stubbed
     def test_installer_from_iso(self):
         """@test:  Can install product from ISO
 
@@ -84,7 +74,7 @@ class TestSSOCLI(CLITestCase):
         """
         pass
 
-    @unittest.skip(NOT_IMPLEMENTED)
+    @stubbed
     def test_installer_server_install(self):
         """@test:  Can install main satellite instance successfully via RPM
 
@@ -97,7 +87,7 @@ class TestSSOCLI(CLITestCase):
         """
         pass
 
-    @unittest.skip(NOT_IMPLEMENTED)
+    @stubbed
     def test_installer_node_install(self):
         """@test:  Can install node successfully via RPM
 
@@ -110,7 +100,7 @@ class TestSSOCLI(CLITestCase):
         """
         pass
 
-    @unittest.skip(NOT_IMPLEMENTED)
+    @stubbed
     def test_installer_smartproxy_install(self):
         """@test:  Can install smart-proxy successfully via RPM
 
@@ -123,7 +113,7 @@ class TestSSOCLI(CLITestCase):
         """
         pass
 
-    @unittest.skip(NOT_IMPLEMENTED)
+    @stubbed
     def test_installer_disconnected_util_install(self):
         """@test:  Can install  satellite disconnected utility successfully
         via RPM
@@ -137,7 +127,7 @@ class TestSSOCLI(CLITestCase):
         """
         pass
 
-    @unittest.skip(NOT_IMPLEMENTED)
+    @stubbed
     def test_installer_smartproxy_registers(self):
         """@test: Upon installation, smart-proxy instance self-registers
         itself to parent instance
@@ -152,7 +142,7 @@ class TestSSOCLI(CLITestCase):
         """
         pass
 
-    @unittest.skip(NOT_IMPLEMENTED)
+    @stubbed
     def test_installer_clear_data(self):
         """@test:  User can run installer to clear existing data
 

--- a/tests/foreman/cli/test_lifecycleenvironment.py
+++ b/tests/foreman/cli/test_lifecycleenvironment.py
@@ -18,7 +18,7 @@ class TestLifeCycleEnvironment(CLITestCase):
 
     org = None
 
-    def setUp(self):
+    def setUp(self):  # noqa
         """Tests for Lifecycle Environment via Hammer CLI"""
 
         super(TestLifeCycleEnvironment, self).setUp()

--- a/tests/foreman/cli/test_myaccount.py
+++ b/tests/foreman/cli/test_myaccount.py
@@ -2,15 +2,8 @@
 # vim: ts=4 sw=4 expandtab ai
 """Test class for Users CLI"""
 
-import sys
-
-from robottelo.common.constants import NOT_IMPLEMENTED
+from robottelo.common.decorators import stubbed
 from robottelo.test import CLITestCase
-
-if sys.hexversion >= 0x2070000:
-    import unittest
-else:
-    import unittest2 as unittest
 
 
 class MyAccount(CLITestCase):
@@ -25,6 +18,7 @@ class MyAccount(CLITestCase):
 
     """
 
+    @stubbed
     def test_positive_update_my_account_1(self):
         """@Test: Update Firstname in My Account
 
@@ -38,8 +32,8 @@ class MyAccount(CLITestCase):
         @Status: Manual
 
         """
-        unittest.skip(NOT_IMPLEMENTED)
 
+    @stubbed
     def test_positive_update_my_account_2(self):
         """@Test: Update Surname in My Account
 
@@ -53,8 +47,8 @@ class MyAccount(CLITestCase):
         @Status: Manual
 
         """
-        unittest.skip(NOT_IMPLEMENTED)
 
+    @stubbed
     def test_positive_update_my_account_3(self):
         """@Test: Update Email Address in My Account
 
@@ -68,8 +62,8 @@ class MyAccount(CLITestCase):
         @Status: Manual
 
         """
-        unittest.skip(NOT_IMPLEMENTED)
 
+    @stubbed
     def test_positive_update_my_account_4(self):
         """@Test: Update Language in My Account
 
@@ -83,8 +77,8 @@ class MyAccount(CLITestCase):
         @Status: Manual
 
         """
-        unittest.skip(NOT_IMPLEMENTED)
 
+    @stubbed
     def test_positive_update_my_account_5(self):
         """@Test: Update Password/Verify fields in My Account
 
@@ -98,8 +92,8 @@ class MyAccount(CLITestCase):
         @Status: Manual
 
         """
-        unittest.skip(NOT_IMPLEMENTED)
 
+    @stubbed
     def test_negative_update_my_account_1(self):
         """@Test: Update My Account with invalid FirstName
 
@@ -113,8 +107,8 @@ class MyAccount(CLITestCase):
         @Status: Manual
 
         """
-        unittest.skip(NOT_IMPLEMENTED)
 
+    @stubbed
     def test_negative_update_my_account_2(self):
         """@Test: Update My Account with invalid Surname
 
@@ -128,8 +122,8 @@ class MyAccount(CLITestCase):
         @Status: Manual
 
         """
-        unittest.skip(NOT_IMPLEMENTED)
 
+    @stubbed
     def test_negative_update_my_account_3(self):
         """@Test: Update My Account with invalid Email Address
 
@@ -143,8 +137,8 @@ class MyAccount(CLITestCase):
         @Status: Manual
 
         """
-        unittest.skip(NOT_IMPLEMENTED)
 
+    @stubbed
     def test_negative_update_my_account_4(self):
         """@Test: Update My Account with invalid Password/Verify fields
 
@@ -159,8 +153,8 @@ class MyAccount(CLITestCase):
         @Status: Manual
 
         """
-        unittest.skip(NOT_IMPLEMENTED)
 
+    @stubbed
     def test_negative_update_my_account_5(self):
         """@Test: Update My Account with non-matching values in Password and
 
@@ -176,8 +170,8 @@ class MyAccount(CLITestCase):
         @Status: Manual
 
         """
-        unittest.skip(NOT_IMPLEMENTED)
 
+    @stubbed
     def test_negative_update_my_account_6(self):
         """@Test: [UI ONLY] Attempt to update all info in My Accounts page and
 
@@ -193,4 +187,3 @@ class MyAccount(CLITestCase):
         @Status: Manual
 
         """
-        unittest.skip(NOT_IMPLEMENTED)

--- a/tests/foreman/cli/test_partitiontable.py
+++ b/tests/foreman/cli/test_partitiontable.py
@@ -14,16 +14,13 @@ from robottelo.common.decorators import run_only_on
 class TestPartitionTableUpdateCreate(CLITestCase):
     """Test case for CLI tests."""
 
-    def setUp(self):
+    def setUp(self):  # noqa
         """Set up file"""
         super(TestPartitionTableUpdateCreate, self).setUp()
         self.content = "Fake ptable"
         self.name = gen_alphanumeric(6)
         self.args = {'name': self.name,
                      'content': self.content}
-
-    def tearDown(self):
-        """Remove the file"""
 
     def test_create_ptable(self):
         """@Test: Check if Partition Table can be created

--- a/tests/foreman/cli/test_ping.py
+++ b/tests/foreman/cli/test_ping.py
@@ -30,7 +30,7 @@ class PingTestCase(CLITestCase):
         # iterate over the lines grouping every 3 lines
         # example [1, 2, 3, 4, 5, 6] will return [(1, 2, 3), (4, 5, 6)]
         # only the status line is relevant for this test
-        for _, status, _ in izip(*[iter(result.stdout)]*3):
+        for _, status, _ in izip(*[iter(result.stdout)] * 3):
             status_count += 1
 
             if status.split(':')[1].strip().lower() == 'ok':

--- a/tests/foreman/cli/test_product.py
+++ b/tests/foreman/cli/test_product.py
@@ -17,7 +17,7 @@ class TestProduct(CLITestCase):
 
     org = None
 
-    def setUp(self):
+    def setUp(self):  # noqa
         """Tests for Lifecycle Environment via Hammer CLI"""
 
         super(TestProduct, self).setUp()

--- a/tests/foreman/cli/test_proxy.py
+++ b/tests/foreman/cli/test_proxy.py
@@ -15,7 +15,7 @@ import random
 @ddt
 class TestProxy(CLITestCase):
 
-    def setUp(self):
+    def setUp(self):  # noqa
         """Skipping tests until we can create ssh tunnels"""
         self.skipTest('Skipping tests until we can create ssh tunnels')
 

--- a/tests/foreman/cli/test_report.py
+++ b/tests/foreman/cli/test_report.py
@@ -14,7 +14,7 @@ from robottelo.test import CLITestCase
 class TestReport(CLITestCase):
     """Test class for Reports CLI. """
 
-    def setUp(self):
+    def setUp(self):  # noqa
         super(TestReport, self).setUp()
         self.run_puppet_agent()
 

--- a/tests/foreman/cli/test_repository.py
+++ b/tests/foreman/cli/test_repository.py
@@ -44,7 +44,7 @@ class TestRepository(CLITestCase):
     org = None
     product = None
 
-    def setUp(self):
+    def setUp(self):  # noqa
         """Tests for Repositiry via Hammer CLI"""
 
         super(TestRepository, self).setUp()

--- a/tests/foreman/cli/test_sso.py
+++ b/tests/foreman/cli/test_sso.py
@@ -2,15 +2,8 @@
 # vim: ts=4 sw=4 expandtab ai
 """Test class for SSO (CLI)"""
 
-import sys
-
-from robottelo.common.constants import NOT_IMPLEMENTED
+from robottelo.common.decorators import stubbed
 from robottelo.test import CLITestCase
-
-if sys.hexversion >= 0x2070000:
-    import unittest
-else:
-    import unittest2 as unittest
 
 
 class TestSSOCLI(CLITestCase):
@@ -25,7 +18,7 @@ class TestSSOCLI(CLITestCase):
     # possibly other LDAP types. These (in particular, the LDAP variations)
     # can be easily added later.
 
-    @unittest.skip(NOT_IMPLEMENTED)
+    @stubbed
     def test_sso_kerberos_cli(self):
         """@test: kerberos user can login to CLI
 
@@ -40,7 +33,7 @@ class TestSSOCLI(CLITestCase):
         """
         pass
 
-    @unittest.skip(NOT_IMPLEMENTED)
+    @stubbed
     def test_sso_ipa_cli(self):
         """@test: IPA user can login to CLI
 
@@ -55,7 +48,7 @@ class TestSSOCLI(CLITestCase):
         """
         pass
 
-    @unittest.skip(NOT_IMPLEMENTED)
+    @stubbed
     def test_sso_openldap_cli(self):
         """@test: OpenLDAP user can login to CLI
 

--- a/tests/foreman/cli/test_subscription.py
+++ b/tests/foreman/cli/test_subscription.py
@@ -17,7 +17,7 @@ class TestSubscription(CLITestCase):
     signing_key = None
     fake_manifest = None
 
-    def setUp(self):
+    def setUp(self):  # noqa
         """Tests for content-view via Hammer CLI"""
 
         super(TestSubscription, self).setUp()

--- a/tests/foreman/cli/test_syncplan.py
+++ b/tests/foreman/cli/test_syncplan.py
@@ -17,7 +17,7 @@ class TestSyncPlan(CLITestCase):
 
     org = None
 
-    def setUp(self):
+    def setUp(self):  # noqa
         """Tests for Sync Plans via Hammer CLI"""
 
         super(TestSyncPlan, self).setUp()

--- a/tests/foreman/installer/test_installer.py
+++ b/tests/foreman/installer/test_installer.py
@@ -51,7 +51,8 @@ class InstallerTestCase(unittest.TestCase):
 
         # iterate over the lines grouping every 3 lines
         # example [1, 2, 3, 4, 5, 6] will return [(1, 2, 3), (4, 5, 6)]
-        for service, status, server_response in izip(*[iter(result.stdout)]*3):
+        for service, status, server_response in izip(
+                *[iter(result.stdout)] * 3):
             service = service.replace(':', '').strip()
             status = status.split(':')[1].strip().lower()
             server_response = server_response.split(':', 1)[1].strip()

--- a/tests/foreman/ui/test_activationkey.py
+++ b/tests/foreman/ui/test_activationkey.py
@@ -1,12 +1,6 @@
 # -*- encoding: utf-8 -*-
 # vim: ts=4 sw=4 expandtab ai
 """Test class for Activation key UI"""
-import sys
-
-if sys.hexversion >= 0x2070000:
-    import unittest
-else:
-    import unittest2 as unittest
 
 from ddt import ddt
 from fauxfactory import gen_string
@@ -15,9 +9,9 @@ from robottelo import entities
 from robottelo.api import utils
 from robottelo.common import manifests
 from robottelo.common.constants import (
-    ENVIRONMENT, FAKE_1_YUM_REPO, FAKE_2_YUM_REPO, DEFAULT_CV, NOT_IMPLEMENTED,
-    REPO_TYPE)
-from robottelo.common.decorators import data, run_only_on, skip_if_bug_open
+    ENVIRONMENT, FAKE_1_YUM_REPO, FAKE_2_YUM_REPO, DEFAULT_CV, REPO_TYPE)
+from robottelo.common.decorators import (
+    data, run_only_on, skip_if_bug_open, stubbed)
 from robottelo.common.helpers import (
     valid_names_list, invalid_names_list,
     valid_data_list, get_server_credentials)
@@ -43,7 +37,7 @@ class ActivationKey(UITestCase):
     """
 
     @classmethod
-    def setUpClass(cls):
+    def setUpClass(cls):  # noqa
         org_attrs = entities.Organization().create()
         # org label is required for subcription-manager cmd.
         cls.org_label = org_attrs['label']
@@ -1042,7 +1036,7 @@ class ActivationKey(UITestCase):
             vm1.destroy()
             vm2.destroy()
 
-    @unittest.skip(NOT_IMPLEMENTED)
+    @stubbed
     def test_associate_host(self):
         """@Test: Test that hosts can be associated to Activation Keys
 
@@ -1225,7 +1219,7 @@ class ActivationKey(UITestCase):
                                  (common_locators["alert.success"]))
 
     @skip_if_bug_open('bugzilla', 1078676)
-    @unittest.skip(NOT_IMPLEMENTED)
+    @stubbed
     def test_delete_manifest(self):
         """@Test: Check if deleting a manifest removes it from Activation key
 
@@ -1243,7 +1237,6 @@ class ActivationKey(UITestCase):
         @BZ: 1078676
 
         """
-        pass
 
     @run_only_on('sat')
     def test_multiple_activation_keys_to_system(self):
@@ -1336,7 +1329,7 @@ class ActivationKey(UITestCase):
 
     @run_only_on('sat')
     @skip_if_bug_open('bugzilla', 1078676)
-    @unittest.skip(NOT_IMPLEMENTED)
+    @stubbed
     def test_end_to_end_activation_key(self):
         """@Test: Create Activation key and provision content-host with it
 

--- a/tests/foreman/ui/test_contentenv.py
+++ b/tests/foreman/ui/test_contentenv.py
@@ -16,9 +16,8 @@ class ContentEnvironment(UITestCase):
     """Implements Life cycle content environment tests in UI"""
 
     @classmethod
-    def setUpClass(cls):
+    def setUpClass(cls):  # noqa
         cls.org_name = entities.Organization().create()['name']
-
         super(ContentEnvironment, cls).setUpClass()
 
     def test_positive_create_content_environment_1(self):

--- a/tests/foreman/ui/test_contentviews.py
+++ b/tests/foreman/ui/test_contentviews.py
@@ -6,13 +6,6 @@ Feature details: https://fedorahosted.org/katello/wiki/ContentViews
 
 """
 
-import sys
-
-if sys.hexversion >= 0x2070000:
-    import unittest
-else:
-    import unittest2 as unittest
-
 from ddt import ddt
 from fauxfactory import gen_string
 from robottelo import entities
@@ -20,8 +13,9 @@ from robottelo.api import utils
 from robottelo.common import manifests
 from robottelo.common.constants import (
     FILTER_CONTENT_TYPE, FILTER_TYPE, REPO_TYPE, FAKE_1_YUM_REPO,
-    FAKE_0_PUPPET_REPO, NOT_IMPLEMENTED)
-from robottelo.common.decorators import data, run_only_on, skip_if_bug_open
+    FAKE_0_PUPPET_REPO)
+from robottelo.common.decorators import (
+    data, run_only_on, skip_if_bug_open, stubbed)
 from robottelo.common.helpers import invalid_names_list, valid_names_list
 from robottelo.ui.factory import make_contentview, make_lifecycle_environment
 from robottelo.ui.locators import common_locators, locators
@@ -35,7 +29,7 @@ class TestContentViewsUI(UITestCase):
     """Implement tests for content view via UI"""
 
     @classmethod
-    def setUpClass(cls):
+    def setUpClass(cls):  # noqa
         org_attrs = entities.Organization().create()
         cls.org_name = org_attrs['name']
         cls.org_id = org_attrs['id']
@@ -416,7 +410,7 @@ class TestContentViewsUI(UITestCase):
             self.assertIsNotNone(self.content_views.wait_until_element
                                  (common_locators["alert.error"]))
 
-    @unittest.skip(NOT_IMPLEMENTED)
+    @stubbed
     def test_cv_edit_rh_custom_spin(self):
         # Variations might be:
         #   * A filter on errata date (only content that matches date
@@ -565,7 +559,7 @@ class TestContentViewsUI(UITestCase):
             self.assertIsNotNone(self.content_views.wait_until_element
                                  (common_locators["alert.success"]))
 
-    @unittest.skip(NOT_IMPLEMENTED)
+    @stubbed
     def test_associate_view_rh_custom_spin(self):
         # Variations might be:
         #   * A filter on errata date (only content that matches date
@@ -685,7 +679,7 @@ class TestContentViewsUI(UITestCase):
                              "Couldn't find repo '%s'"
                              "to add into CV" % repo_name)
 
-    @unittest.skip(NOT_IMPLEMENTED)
+    @stubbed
     def test_cv_associate_composite_dupe_modules_negative(self):
         """@test: attempt to associate duplicate puppet module(s) within a
         content view
@@ -744,7 +738,7 @@ class TestContentViewsUI(UITestCase):
             self.assertIsNotNone(self.content_views.wait_until_element
                                  (common_locators["alert.success"]))
 
-    @unittest.skip(NOT_IMPLEMENTED)
+    @stubbed
     def test_cv_promote_rh_custom_spin(self):
         """@test: attempt to promote a content view containing a custom RH
         spin - i.e., contains filters.
@@ -793,7 +787,7 @@ class TestContentViewsUI(UITestCase):
             self.assertIsNotNone(self.content_views.wait_until_element
                                  (common_locators["alert.success"]))
 
-    @unittest.skip(NOT_IMPLEMENTED)
+    @stubbed
     def test_cv_promote_composite(self):
         # Variations:
         # RHEL, custom content (i.e., google repos), puppet modules
@@ -813,7 +807,7 @@ class TestContentViewsUI(UITestCase):
 
         """
 
-    @unittest.skip(NOT_IMPLEMENTED)
+    @stubbed
     def test_cv_promote_default_negative(self):
         """@test: attempt to promote a the default content views
 
@@ -860,7 +854,7 @@ class TestContentViewsUI(UITestCase):
             self.assertIsNotNone(self.content_views.wait_until_element
                                  (common_locators["alert.success"]))
 
-    @unittest.skip(NOT_IMPLEMENTED)
+    @stubbed
     def test_cv_publish_rh_custom_spin(self):
         """@test: attempt to publish  a content view containing a custom RH
         spin - i.e., contains filters.
@@ -906,7 +900,7 @@ class TestContentViewsUI(UITestCase):
             self.assertIsNotNone(self.content_views.wait_until_element
                                  (common_locators["alert.success"]))
 
-    @unittest.skip(NOT_IMPLEMENTED)
+    @stubbed
     def test_cv_publish_composite(self):
         # Variations:
         # RHEL, custom content (i.e., google repos), puppet modules
@@ -924,7 +918,7 @@ class TestContentViewsUI(UITestCase):
 
         """
 
-    @unittest.skip(NOT_IMPLEMENTED)
+    @stubbed
     def test_cv_publish_version_changes_in_target_env(self):
         # Dev notes:
         # If Dev has version x, then when I promote version y into
@@ -948,7 +942,7 @@ class TestContentViewsUI(UITestCase):
 
         """
 
-    @unittest.skip(NOT_IMPLEMENTED)
+    @stubbed
     def test_cv_publish_version_changes_in_source_env(self):
         # Dev notes:
         # Similarly when I publish version y, version x goes away from
@@ -971,7 +965,7 @@ class TestContentViewsUI(UITestCase):
 
         """
 
-    @unittest.skip(NOT_IMPLEMENTED)
+    @stubbed
     def test_cv_clone_within_same_env(self):
         # Dev note: "not implemented yet"
         """@test: attempt to create new content view based on existing
@@ -985,7 +979,7 @@ class TestContentViewsUI(UITestCase):
 
         """
 
-    @unittest.skip(NOT_IMPLEMENTED)
+    @stubbed
     def test_cv_clone_within_diff_env(self):
         # Dev note: "not implemented yet"
         """@test: attempt to create new content view based on existing
@@ -999,7 +993,7 @@ class TestContentViewsUI(UITestCase):
 
         """
 
-    @unittest.skip(NOT_IMPLEMENTED)
+    @stubbed
     def test_cv_refresh_errata_to_new_view_in_same_env(self):
         """@test: attempt to refresh errata in a new view, based on
         an existing view, from within the same  environment
@@ -1012,7 +1006,7 @@ class TestContentViewsUI(UITestCase):
 
         """
 
-    @unittest.skip(NOT_IMPLEMENTED)
+    @stubbed
     def test_cv_subscribe_system(self):
         # Notes:
         # this should be limited to only those content views
@@ -1034,7 +1028,7 @@ class TestContentViewsUI(UITestCase):
 
         """
 
-    @unittest.skip(NOT_IMPLEMENTED)
+    @stubbed
     def test_cv_dynflow_restart_promote(self):
         """@test: attempt to restart a promotion
 
@@ -1050,7 +1044,7 @@ class TestContentViewsUI(UITestCase):
 
         """
 
-    @unittest.skip(NOT_IMPLEMENTED)
+    @stubbed
     def test_cv_dynflow_restart_publish(self):
         """@test: attempt to restart a publish
 
@@ -1069,7 +1063,7 @@ class TestContentViewsUI(UITestCase):
     # ROLES TESTING
     # All this stuff is speculative at best.
 
-    @unittest.skip(NOT_IMPLEMENTED)
+    @stubbed
     def test_cv_roles_admin_user(self):
         # Note:
         # Obviously all of this stuff should work with 'admin' user
@@ -1092,7 +1086,7 @@ class TestContentViewsUI(UITestCase):
 
         """
 
-    @unittest.skip(NOT_IMPLEMENTED)
+    @stubbed
     def test_cv_roles_readonly_user(self):
         # Note:
         # Obviously all of this stuff should work with 'admin' user
@@ -1116,7 +1110,7 @@ class TestContentViewsUI(UITestCase):
 
         """
 
-    @unittest.skip(NOT_IMPLEMENTED)
+    @stubbed
     def test_cv_roles_admin_user_negative(self):
         # Note:
         # Obviously all of this stuff should work with 'admin' user
@@ -1139,7 +1133,7 @@ class TestContentViewsUI(UITestCase):
 
         """
 
-    @unittest.skip(NOT_IMPLEMENTED)
+    @stubbed
     def test_cv_roles_readonly_user_negative(self):
         # Note:
         # Obviously all of this stuff should work with 'admin' user

--- a/tests/foreman/ui/test_gpgkey.py
+++ b/tests/foreman/ui/test_gpgkey.py
@@ -2,25 +2,18 @@
 # vim: ts=4 sw=4 expandtab ai
 """Test class for GPG Key UI"""
 
-import sys
-
-if sys.hexversion >= 0x2070000:
-    import unittest
-else:
-    import unittest2 as unittest
-
 from ddt import ddt
 from fauxfactory import gen_string
 from robottelo import entities
 from robottelo.common.constants import (
     FAKE_1_YUM_REPO,
     FAKE_2_YUM_REPO,
-    NOT_IMPLEMENTED,
     REPO_DISCOVERY_URL,
     VALID_GPG_KEY_BETA_FILE,
     VALID_GPG_KEY_FILE,
 )
-from robottelo.common.decorators import data, run_only_on, skip_if_bug_open
+from robottelo.common.decorators import (
+    data, run_only_on, skip_if_bug_open, stubbed)
 from robottelo.common.helpers import (
     get_data_file, read_data_file, valid_names_list, invalid_names_list,
     generate_strings_list)
@@ -36,7 +29,7 @@ class GPGKey(UITestCase):
     """Implements tests for GPG Keys via UI"""
 
     @classmethod
-    def setUpClass(cls):
+    def setUpClass(cls):  # noqa
         org_attrs = entities.Organization().create()
         cls.org_name = org_attrs['name']
         cls.org_id = org_attrs['id']
@@ -364,7 +357,7 @@ class GPGKey(UITestCase):
                             (common_locators["alert.error"]))
             self.assertIsNone(self.gpgkey.search(new_name))
 
-    @unittest.skip(NOT_IMPLEMENTED)
+    @stubbed
     @data("""DATADRIVENGOESHERE
         name is alpha
         name is numeric
@@ -388,7 +381,7 @@ class GPGKey(UITestCase):
 
         pass
 
-    @unittest.skip(NOT_IMPLEMENTED)
+    @stubbed
     @data("""DATADRIVENGOESHERE
         name is alpha
         name is numeric
@@ -412,7 +405,7 @@ class GPGKey(UITestCase):
 
         pass
 
-    @unittest.skip(NOT_IMPLEMENTED)
+    @stubbed
     @data("""DATADRIVENGOESHERE
         name is alpha
         name is numeric
@@ -436,7 +429,7 @@ class GPGKey(UITestCase):
 
         pass
 
-    @unittest.skip(NOT_IMPLEMENTED)
+    @stubbed
     @data("""DATADRIVENGOESHERE
         name is alpha
         name is numeric
@@ -459,7 +452,7 @@ class GPGKey(UITestCase):
 
         pass
 
-    @unittest.skip(NOT_IMPLEMENTED)
+    @stubbed
     @data("""DATADRIVENGOESHERE
         name is alpha
         name is numeric
@@ -482,7 +475,7 @@ class GPGKey(UITestCase):
 
         pass
 
-    @unittest.skip(NOT_IMPLEMENTED)
+    @stubbed
     @data("""DATADRIVENGOESHERE
         name is alpha
         name is numeric
@@ -512,7 +505,7 @@ class GPGKeyProductAssociate(UITestCase):
     """Implements Product Association tests for GPG Keys via UI"""
 
     @classmethod
-    def setUpClass(cls):
+    def setUpClass(cls):  # noqa
         org_attrs = entities.Organization().create()
         cls.org_name = org_attrs['name']
         cls.org_id = org_attrs['id']
@@ -766,7 +759,7 @@ class GPGKeyProductAssociate(UITestCase):
                                  (name, product=False))
 
     @skip_if_bug_open('bugzilla', 1085924)
-    @unittest.skip(NOT_IMPLEMENTED)
+    @stubbed
     @data("""DATADRIVENGOESHERE
         name is alpha
         name is numeric
@@ -1090,7 +1083,7 @@ class GPGKeyProductAssociate(UITestCase):
                                  (new_name, product=False))
 
     @skip_if_bug_open('bugzilla', 1085924)
-    @unittest.skip(NOT_IMPLEMENTED)
+    @stubbed
     @data("""DATADRIVENGOESHERE
         name is alpha
         name is numeric
@@ -1406,7 +1399,7 @@ class GPGKeyProductAssociate(UITestCase):
                               (name, product_name, repository_1_name))
 
     @skip_if_bug_open('bugzilla', 1085924)
-    @unittest.skip(NOT_IMPLEMENTED)
+    @stubbed
     @data("""DATADRIVENGOESHERE
         name is alpha
         name is numeric

--- a/tests/foreman/ui/test_host.py
+++ b/tests/foreman/ui/test_host.py
@@ -1,14 +1,8 @@
 # -*- encoding: utf-8 -*-
 # vim: ts=4 sw=4 expandtab ai
 
-import sys
-
-if sys.hexversion >= 0x2070000:
-    import unittest
-else:
-    import unittest2 as unittest
 from fauxfactory import gen_string
-from robottelo.common.decorators import run_only_on
+from robottelo.common.decorators import run_only_on, stubbed
 from robottelo.test import UITestCase
 from robottelo.ui.locators import common_locators
 
@@ -16,7 +10,7 @@ from robottelo.ui.locators import common_locators
 @run_only_on('sat')
 class Host(UITestCase):
 
-    @unittest.skip("Test needs to create other required stuff")
+    @stubbed('Test needs to create other required stuff')
     def test_create_host(self):
         """@Test: Create a new Host
 
@@ -41,7 +35,7 @@ class Host(UITestCase):
         search = self.hosts.search(name)
         self.assertIsNotNone(search)
 
-    @unittest.skip("Test needs to create other required stuff")
+    @stubbed('Test needs to create other required stuff')
     def test_create_delete(self):
         """@Test: Delete a Host
 

--- a/tests/foreman/ui/test_host_system_unification.py
+++ b/tests/foreman/ui/test_host_system_unification.py
@@ -1,16 +1,9 @@
 # -*- encoding: utf-8 -*-
 # vim: ts=4 sw=4 expandtab ai
 """Test class for Host/System Unification"""
-import sys
 
-from robottelo.common.constants import NOT_IMPLEMENTED
-from robottelo.common.decorators import run_only_on
+from robottelo.common.decorators import run_only_on, stubbed
 from robottelo.test import UITestCase
-
-if sys.hexversion >= 0x2070000:
-    import unittest
-else:
-    import unittest2 as unittest
 
 
 @run_only_on('sat')
@@ -23,7 +16,7 @@ class TestHostSystemUnificationUI(UITestCase):
     # (the link/join will) "Most likely an internal UUID, not something
     # fuzzy like hostname"
 
-    @unittest.skip(NOT_IMPLEMENTED)
+    @stubbed
     def test_katello_host_in_foreman(self):
         """@test: Hosts registered to Katello via rhsm appear in foreman
 
@@ -41,7 +34,7 @@ class TestHostSystemUnificationUI(UITestCase):
         """
         pass
 
-    @unittest.skip(NOT_IMPLEMENTED)
+    @stubbed
     def test_foreman_host_in_katello(self):
         """@test: Hosts provisioned in foreman via appear in katello
 
@@ -59,7 +52,7 @@ class TestHostSystemUnificationUI(UITestCase):
         """
         pass
 
-    @unittest.skip(NOT_IMPLEMENTED)
+    @stubbed
     def test_renamed_host_foreman(self):
         """@test: Hosts renamed in foreman appear in katello
 
@@ -77,7 +70,7 @@ class TestHostSystemUnificationUI(UITestCase):
         """
         pass
 
-    @unittest.skip(NOT_IMPLEMENTED)
+    @stubbed
     def test_renamed_host_katello(self):
         """@test: Hosts renamed in katello via appear in foreman
 
@@ -95,7 +88,7 @@ class TestHostSystemUnificationUI(UITestCase):
         """
         pass
 
-    @unittest.skip(NOT_IMPLEMENTED)
+    @stubbed
     def test_deleted_host_foreman(self):
         """@test: Hosts delete in foreman disappear from both sides of UI
 
@@ -113,7 +106,7 @@ class TestHostSystemUnificationUI(UITestCase):
         """
         pass
 
-    @unittest.skip(NOT_IMPLEMENTED)
+    @stubbed
     def test_deleted_host_katello(self):
         """@test: Hosts delete in katello disappear from both sides of UI
 

--- a/tests/foreman/ui/test_myaccount.py
+++ b/tests/foreman/ui/test_myaccount.py
@@ -2,14 +2,7 @@
 # vim: ts=4 sw=4 expandtab ai
 """Test class for Users UI"""
 
-import sys
-
-if sys.hexversion >= 0x2070000:
-    import unittest
-else:
-    import unittest2 as unittest
-
-from robottelo.common.constants import NOT_IMPLEMENTED
+from robottelo.common.decorators import stubbed
 from robottelo.test import UITestCase
 
 
@@ -25,7 +18,7 @@ class MyAccount(UITestCase):
 
     """
 
-    @unittest.skip(NOT_IMPLEMENTED)
+    @stubbed
     def test_positive_update_my_account_1(self):
         """@Test: Update Firstname in My Account
 
@@ -41,7 +34,7 @@ class MyAccount(UITestCase):
         """
         pass
 
-    @unittest.skip(NOT_IMPLEMENTED)
+    @stubbed
     def test_positive_update_my_account_2(self):
         """@Test: Update Surname in My Account
 
@@ -57,7 +50,7 @@ class MyAccount(UITestCase):
         """
         pass
 
-    @unittest.skip(NOT_IMPLEMENTED)
+    @stubbed
     def test_positive_update_my_account_3(self):
         """@Test: Update Email Address in My Account
 
@@ -73,7 +66,7 @@ class MyAccount(UITestCase):
         """
         pass
 
-    @unittest.skip(NOT_IMPLEMENTED)
+    @stubbed
     def test_positive_update_my_account_4(self):
         """@Test: Update Language in My Account
 
@@ -89,7 +82,7 @@ class MyAccount(UITestCase):
         """
         pass
 
-    @unittest.skip(NOT_IMPLEMENTED)
+    @stubbed
     def test_positive_update_my_account_5(self):
         """@Test: Update Password/Verify fields in My Account
 
@@ -105,7 +98,7 @@ class MyAccount(UITestCase):
         """
         pass
 
-    @unittest.skip(NOT_IMPLEMENTED)
+    @stubbed
     def test_negative_update_my_account_1(self):
         """@Test: Update My Account with invalid FirstName
 
@@ -121,7 +114,7 @@ class MyAccount(UITestCase):
         """
         pass
 
-    @unittest.skip(NOT_IMPLEMENTED)
+    @stubbed
     def test_negative_update_my_account_2(self):
         """@Test: Update My Account with invalid Surname
 
@@ -137,7 +130,7 @@ class MyAccount(UITestCase):
         """
         pass
 
-    @unittest.skip(NOT_IMPLEMENTED)
+    @stubbed
     def test_negative_update_my_account_3(self):
         """@Test: Update My Account with invalid Email Address
 
@@ -153,7 +146,7 @@ class MyAccount(UITestCase):
         """
         pass
 
-    @unittest.skip(NOT_IMPLEMENTED)
+    @stubbed
     def test_negative_update_my_account_4(self):
         """@Test: Update My Account with invalid Password/Verify fields
 
@@ -170,7 +163,7 @@ class MyAccount(UITestCase):
         """
         pass
 
-    @unittest.skip(NOT_IMPLEMENTED)
+    @stubbed
     def test_negative_update_my_account_5(self):
         """@Test: Update My Account with non-matching values in Password and
         verify fields
@@ -188,7 +181,7 @@ class MyAccount(UITestCase):
         """
         pass
 
-    @unittest.skip(NOT_IMPLEMENTED)
+    @stubbed
     def test_negative_update_my_account_6(self):
         """@Test: [UI ONLY] Attempt to update all info in My Accounts page and
         Cancel

--- a/tests/foreman/ui/test_openscap.py
+++ b/tests/foreman/ui/test_openscap.py
@@ -181,7 +181,7 @@ class OpenScap(UITestCase):
 
         """
 
-    def test_deashboard_Views(self):
+    def test_dashboard_views(self):
         """@Test: Dashboard views that can tell Audited/Un-Audited,
         Compliant/Non-Compliant and trends.
 

--- a/tests/foreman/ui/test_org.py
+++ b/tests/foreman/ui/test_org.py
@@ -4,16 +4,10 @@
 # pylint: disable=R0904
 """Test class for Organization UI"""
 
-import sys
 from ddt import ddt
-if sys.hexversion >= 0x2070000:
-    import unittest
-else:
-    import unittest2 as unittest
 from fauxfactory import gen_string, gen_ipaddr
 from robottelo import entities
 from robottelo.common import conf
-
 from robottelo.common.helpers import generate_strings_list
 from robottelo.common.decorators import (data, run_only_on, stubbed,
                                          skip_if_bug_open, bz_bug_is_open)
@@ -69,7 +63,7 @@ class Org(UITestCase):
             make_org(session, org_name=org_name)
             self.assertIsNotNone(self.org.search(org_name))
 
-    @unittest.skip("parent_org feature is disabled currently")
+    @stubbed('parent_org feature is disabled currently')
     @data({'label': gen_string('alpha'),
            'name': gen_string('alpha'),
            'desc': gen_string('alpha')},

--- a/tests/foreman/ui/test_products.py
+++ b/tests/foreman/ui/test_products.py
@@ -16,7 +16,7 @@ class Products(UITestCase):
     """Implements Product tests in UI"""
 
     @classmethod
-    def setUpClass(cls):
+    def setUpClass(cls):  # noqa
         cls.org_name = entities.Organization().create()['name']
         cls.loc_name = entities.Location().create()['name']
 

--- a/tests/foreman/ui/test_puppet_classes.py
+++ b/tests/foreman/ui/test_puppet_classes.py
@@ -1,13 +1,9 @@
 """Test class for Puppet Classes UI"""
 
-import sys
-if sys.hexversion >= 0x2070000:
-    import unittest
-else:
-    import unittest2 as unittest
 from ddt import ddt
 from fauxfactory import gen_string
-from robottelo.common.decorators import data, run_only_on, skip_if_bug_open
+from robottelo.common.decorators import (
+    data, run_only_on, skip_if_bug_open, stubbed)
 from robottelo.common.helpers import generate_strings_list
 from robottelo.test import UITestCase
 from robottelo.ui.factory import make_puppetclasses
@@ -15,7 +11,7 @@ from robottelo.ui.locators import common_locators
 from robottelo.ui.session import Session
 
 
-@unittest.skip("Now Puppet Classes can only be created via API's")
+@stubbed("Now Puppet Classes can only be created via API's")
 @run_only_on('sat')
 @ddt
 class PuppetClasses(UITestCase):

--- a/tests/foreman/ui/test_repository.py
+++ b/tests/foreman/ui/test_repository.py
@@ -28,7 +28,7 @@ class Repos(UITestCase):
     """Implements Repos tests in UI"""
 
     @classmethod
-    def setUpClass(cls):
+    def setUpClass(cls):  # noqa
         org_attrs = entities.Organization().create()
         loc_attrs = entities.Location().create()
         cls.org_name = org_attrs['name']

--- a/tests/foreman/ui/test_sso.py
+++ b/tests/foreman/ui/test_sso.py
@@ -2,14 +2,7 @@
 # vim: ts=4 sw=4 expandtab ai
 """Test class for installer (UI)"""
 
-import sys
-
-if sys.hexversion >= 0x2070000:
-    import unittest
-else:
-    import unittest2 as unittest
-
-from robottelo.common.constants import NOT_IMPLEMENTED
+from robottelo.common.decorators import stubbed
 from robottelo.test import UITestCase
 
 
@@ -24,7 +17,7 @@ class TestSSOUI(UITestCase):
     # possibly other LDAP types. These (in particular, the LDAP variations)
     # can be easily added later.
 
-    @unittest.skip(NOT_IMPLEMENTED)
+    @stubbed
     def test_sso_kerberos_basic_no_roles(self):
         """@test: SSO - kerberos login (basic) that has no rights
 
@@ -42,7 +35,7 @@ class TestSSOUI(UITestCase):
 
         """
 
-    @unittest.skip(NOT_IMPLEMENTED)
+    @stubbed
     def test_sso_kerberos_basic_roles(self):
         """@test: SSO - kerberos login (basic) that has rights assigned
 
@@ -60,7 +53,7 @@ class TestSSOUI(UITestCase):
 
         """
 
-    @unittest.skip(NOT_IMPLEMENTED)
+    @stubbed
     def test_sso_kerberos_user_disabled(self):
         """@test: Kerberos user activity when kerb account has been deleted or
         deactivated
@@ -78,7 +71,7 @@ class TestSSOUI(UITestCase):
 
         """
 
-    @unittest.skip(NOT_IMPLEMENTED)
+    @stubbed
     def test_sso_ipa_basic_no_roles(self):
         """@test: Login with LDAP - IPA for user with no roles/rights
 
@@ -96,7 +89,7 @@ class TestSSOUI(UITestCase):
 
         """
 
-    @unittest.skip(NOT_IMPLEMENTED)
+    @stubbed
     def test_sso_ipa_basic_roles(self):
         """@test: Login with LDAP - IPA for user with roles/rights
 
@@ -114,7 +107,7 @@ class TestSSOUI(UITestCase):
 
         """
 
-    @unittest.skip(NOT_IMPLEMENTED)
+    @stubbed
     def test_sso_ipa_user_disabled(self):
         """@test: LDAP - IPA user activity when IPA account has been deleted
         or deactivated
@@ -132,7 +125,7 @@ class TestSSOUI(UITestCase):
 
         """
 
-    @unittest.skip(NOT_IMPLEMENTED)
+    @stubbed
     def test_sso_openldap_basic_no_roles(self):
         """@test: Login with LDAP - OpenLDAP that has no roles / rights
 
@@ -150,7 +143,7 @@ class TestSSOUI(UITestCase):
 
         """
 
-    @unittest.skip(NOT_IMPLEMENTED)
+    @stubbed
     def test_sso_openldap_basic_roles(self):
         """@test: Login with LDAP - OpenLDAP for user with roles/rights assigned
 
@@ -168,7 +161,7 @@ class TestSSOUI(UITestCase):
 
         """
 
-    @unittest.skip(NOT_IMPLEMENTED)
+    @stubbed
     def test_sso_openldap_user_disabled(self):
         """@test: LDAP - OpenLDAP user activity when OpenLDAP account has been
         deleted or deactivated
@@ -186,7 +179,7 @@ class TestSSOUI(UITestCase):
 
         """
 
-    @unittest.skip(NOT_IMPLEMENTED)
+    @stubbed
     def test_sso_multiple_ldap_backends(self):
         """@test: SSO - multiple LDAP servers kafo instance
 
@@ -206,7 +199,7 @@ class TestSSOUI(UITestCase):
 
         """
 
-    @unittest.skip(NOT_IMPLEMENTED)
+    @stubbed
     def test_sso_multiple_ldap_namespace_collision(self):
         # devnote:
         # users have auth_source which could distinguish them, but validation
@@ -229,7 +222,7 @@ class TestSSOUI(UITestCase):
 
         """
 
-    @unittest.skip(NOT_IMPLEMENTED)
+    @stubbed
     def test_sso_ldap_user_named_admin(self):
         # devnote:
         # shouldn't be a problem since admin from internal DB will be used at
@@ -250,7 +243,7 @@ class TestSSOUI(UITestCase):
 
         """
 
-    @unittest.skip(NOT_IMPLEMENTED)
+    @stubbed
     def test_sso_ldap_server_down_before_session(self):
         """@test: SSO - what happens when we have an ldap server that goes down
         before logging in?
@@ -267,7 +260,7 @@ class TestSSOUI(UITestCase):
 
         """
 
-    @unittest.skip(NOT_IMPLEMENTED)
+    @stubbed
     def test_sso_ldap_server_down_during_session(self):
         """@test: SSO - what happens when we have an ldap server that goes down
         after login?
@@ -285,7 +278,7 @@ class TestSSOUI(UITestCase):
 
         """
 
-    @unittest.skip(NOT_IMPLEMENTED)
+    @stubbed
     def test_sso_usergroup_roles_read(self):
         """@test: Usergroups: group roles get pushed down to user
 
@@ -304,7 +297,7 @@ class TestSSOUI(UITestCase):
 
         """
 
-    @unittest.skip(NOT_IMPLEMENTED)
+    @stubbed
     def test_sso_usergroup_roles_update(self):
         """@test: Usergroups: added usergroup roles get pushed down to user
 
@@ -323,7 +316,7 @@ class TestSSOUI(UITestCase):
 
         """
 
-    @unittest.skip(NOT_IMPLEMENTED)
+    @stubbed
     def test_sso_usergroup_roles_delete(self):
         """@test: Usergroups: deleted usergroup roles get pushed down to user
 
@@ -342,7 +335,7 @@ class TestSSOUI(UITestCase):
 
         """
 
-    @unittest.skip(NOT_IMPLEMENTED)
+    @stubbed
     def test_sso_usergroup_additional_user_roles(self):
         """@test: Assure that user has roles/can access feature areas for
         additional roles assigned outside any roles assigned by his group
@@ -365,7 +358,7 @@ class TestSSOUI(UITestCase):
 
         """
 
-    @unittest.skip(NOT_IMPLEMENTED)
+    @stubbed
     def test_sso_usergroup_user_add(self):
         """@test: Usergroups: new user added to usegroup inherits roles
 

--- a/tests/foreman/ui/test_subscription.py
+++ b/tests/foreman/ui/test_subscription.py
@@ -15,7 +15,7 @@ class SubscriptionTestCase(UITestCase):
     """Implements subscriptions/manifests tests in UI"""
 
     @classmethod
-    def setUpClass(cls):
+    def setUpClass(cls):  # noqa
         cls.org_name = entities.Organization().create()['name']
 
         super(SubscriptionTestCase, cls).setUpClass()

--- a/tests/foreman/ui/test_sync.py
+++ b/tests/foreman/ui/test_sync.py
@@ -26,7 +26,7 @@ class Sync(UITestCase):
     """Implements Custom Sync tests in UI"""
 
     @classmethod
-    def setUpClass(cls):
+    def setUpClass(cls):  # noqa
         org_attrs = entities.Organization().create()
         cls.org_name = org_attrs['name']
         cls.org_id = org_attrs['id']

--- a/tests/foreman/ui/test_syncplan.py
+++ b/tests/foreman/ui/test_syncplan.py
@@ -18,7 +18,7 @@ class Syncplan(UITestCase):
     """Implements Sync Plan tests in UI"""
 
     @classmethod
-    def setUpClass(cls):
+    def setUpClass(cls):  # noqa
         org_attrs = entities.Organization().create()
         cls.org_name = org_attrs['name']
         cls.org_id = org_attrs['id']

--- a/tests/foreman/ui/test_user.py
+++ b/tests/foreman/ui/test_user.py
@@ -2,19 +2,13 @@
 # vim: ts=4 sw=4 expandtab ai
 """Test class for Users UI"""
 
-import sys
-
-if sys.hexversion >= 0x2070000:
-    import unittest
-else:
-    import unittest2 as unittest
-
 from ddt import ddt
 from fauxfactory import gen_string
 from selenium.webdriver.support.select import Select
 from robottelo import entities
-from robottelo.common.constants import LANGUAGES, NOT_IMPLEMENTED
-from robottelo.common.decorators import data, run_only_on, skip_if_bug_open
+from robottelo.common.constants import LANGUAGES
+from robottelo.common.decorators import (
+    data, run_only_on, skip_if_bug_open, stubbed)
 from robottelo.common.helpers import invalid_names_list
 from robottelo.test import UITestCase
 from robottelo.ui.factory import make_user
@@ -193,7 +187,7 @@ class User(UITestCase):
                 ).get_attribute('value')
             )
 
-    @unittest.skip(NOT_IMPLEMENTED)
+    @stubbed
     def test_positive_create_user_4(self):
         """@Test: Create User for all variations of Email Address
 
@@ -208,7 +202,6 @@ class User(UITestCase):
         @Status: Manual
 
         """
-        pass
 
     @data(*LANGUAGES)
     def test_positive_create_user_5(self, language):
@@ -236,7 +229,7 @@ class User(UITestCase):
                 ).get_attribute('value')
             )
 
-    @unittest.skip(NOT_IMPLEMENTED)
+    @stubbed
     def test_positive_create_user_6(self):
         """@Test: Create User by choosing Authorized by - INTERNAL
 
@@ -251,7 +244,6 @@ class User(UITestCase):
         @Status: Manual
 
         """
-        pass
 
     @data(
         u'foo@!#$^&*( ) {0}'.format(gen_string("alpha", 2)),
@@ -276,7 +268,7 @@ class User(UITestCase):
                       password2=password)
             self.assertIsNotNone(self.user.search(name, search_key))
 
-    @unittest.skip(NOT_IMPLEMENTED)
+    @stubbed
     def test_positive_create_user_8(self):
         """@Test: Create an Admin user
 
@@ -287,7 +279,6 @@ class User(UITestCase):
         @Status: Manual
 
         """
-        pass
 
     def test_positive_create_user_9(self):
         """@Test: Create User with one role
@@ -341,7 +332,7 @@ class User(UITestCase):
                                                         value % role))
                 self.assertIsNotNone(element)
 
-    @unittest.skip(NOT_IMPLEMENTED)
+    @stubbed
     def test_positive_create_user_11(self):
         """@Test: Create User and assign all available roles to it
 
@@ -355,9 +346,8 @@ class User(UITestCase):
         @Status: Manual
 
         """
-        pass
 
-    @unittest.skip(NOT_IMPLEMENTED)
+    @stubbed
     def test_positive_create_user_12(self):
         """@Test: Create User with one owned host
 
@@ -371,9 +361,8 @@ class User(UITestCase):
         @Status: Manual
 
         """
-        pass
 
-    @unittest.skip(NOT_IMPLEMENTED)
+    @stubbed
     def test_positive_create_user_13(self):
         """@Test: Create User with mutiple owned hosts
 
@@ -387,9 +376,8 @@ class User(UITestCase):
         @Status: Manual
 
         """
-        pass
 
-    @unittest.skip(NOT_IMPLEMENTED)
+    @stubbed
     def test_positive_create_user_14(self):
         """@Test: Create User with all owned hosts
 
@@ -403,10 +391,9 @@ class User(UITestCase):
         @Status: Manual
 
         """
-        pass
 
     @run_only_on('sat')
-    @unittest.skip(NOT_IMPLEMENTED)
+    @stubbed
     def test_positive_create_user_15(self):
         """@Test: Create User with one Domain host
 
@@ -420,10 +407,9 @@ class User(UITestCase):
         @Status: Manual
 
         """
-        pass
 
     @run_only_on('sat')
-    @unittest.skip(NOT_IMPLEMENTED)
+    @stubbed
     def test_positive_create_user_16(self):
         """@Test: Create User with mutiple Domain hosts
 
@@ -437,10 +423,9 @@ class User(UITestCase):
         @Status: Manual
 
         """
-        pass
 
     @run_only_on('sat')
-    @unittest.skip(NOT_IMPLEMENTED)
+    @stubbed
     def test_positive_create_user_17(self):
         """@Test: Create User with all Domain hosts
 
@@ -454,10 +439,9 @@ class User(UITestCase):
         @Status: Manual
 
         """
-        pass
 
     @run_only_on('sat')
-    @unittest.skip(NOT_IMPLEMENTED)
+    @stubbed
     def test_positive_create_user_18(self):
         """@Test: Create User with one Compute Resource
 
@@ -471,10 +455,9 @@ class User(UITestCase):
         @Status: Manual
 
         """
-        pass
 
     @run_only_on('sat')
-    @unittest.skip(NOT_IMPLEMENTED)
+    @stubbed
     def test_positive_create_user_19(self):
         """@Test: Create User with mutiple Compute Resources
 
@@ -488,10 +471,9 @@ class User(UITestCase):
         @Status: Manual
 
         """
-        pass
 
     @run_only_on('sat')
-    @unittest.skip(NOT_IMPLEMENTED)
+    @stubbed
     def test_positive_create_user_20(self):
         """@Test: Create User with all Compute Resources
 
@@ -505,10 +487,9 @@ class User(UITestCase):
         @Status: Manual
 
         """
-        pass
 
     @run_only_on('sat')
-    @unittest.skip(NOT_IMPLEMENTED)
+    @stubbed
     def test_positive_create_user_21(self):
         """@Test: Create User with one Host group
 
@@ -522,10 +503,9 @@ class User(UITestCase):
         @Status: Manual
 
         """
-        pass
 
     @run_only_on('sat')
-    @unittest.skip(NOT_IMPLEMENTED)
+    @stubbed
     def test_positive_create_user_22(self):
         """@Test: Create User with multiple Host groups
 
@@ -539,10 +519,9 @@ class User(UITestCase):
         @Status: Manual
 
         """
-        pass
 
     @run_only_on('sat')
-    @unittest.skip(NOT_IMPLEMENTED)
+    @stubbed
     def test_positive_create_user_23(self):
         """@Test: Create User with all Host groups
 
@@ -556,7 +535,6 @@ class User(UITestCase):
         @Status: Manual
 
         """
-        pass
 
     def test_positive_create_user_24(self):
         """@Test: Create User associated to one Org
@@ -606,7 +584,7 @@ class User(UITestCase):
                                                         value % org_name))
                 self.assertIsNotNone(element)
 
-    @unittest.skip(NOT_IMPLEMENTED)
+    @stubbed
     def test_positive_create_user_26(self):
         """@Test: Create User associated to all available Orgs
 
@@ -617,10 +595,9 @@ class User(UITestCase):
         @Status: Manual
 
         """
-        pass
 
     @run_only_on('sat')
-    @unittest.skip(NOT_IMPLEMENTED)
+    @stubbed
     def test_positive_create_user_27(self):
         """@Test: Create User with a new Fact filter
 
@@ -634,9 +611,8 @@ class User(UITestCase):
         @Status: Manual
 
         """
-        pass
 
-    @unittest.skip(NOT_IMPLEMENTED)
+    @stubbed
     def test_positive_create_user_28(self):
         """@Test: Create User in supported ldap modes
 
@@ -651,7 +627,6 @@ class User(UITestCase):
         @Status: Manual
 
         """
-        pass
 
     def test_positive_create_user_29(self):
         """@Test: Create User and associate a default Org
@@ -707,7 +682,7 @@ class User(UITestCase):
             option = Select(loc_element).first_selected_option
             self.assertEqual(loc_name, option.text)
 
-    @unittest.skip(NOT_IMPLEMENTED)
+    @stubbed
     def test_negative_create_user_1(self):
         """@Test:[UI ONLY] Enter all User creation details and Cancel
 
@@ -723,7 +698,6 @@ class User(UITestCase):
         @Status: Manual
 
         """
-        pass
 
     @data(*invalid_names_list())
     def test_negative_create_user_2(self, user_name):
@@ -781,7 +755,7 @@ class User(UITestCase):
             error = self.user.wait_until_element(common_locators["haserror"])
             self.assertIsNotNone(error)
 
-    @unittest.skip(NOT_IMPLEMENTED)
+    @stubbed
     def test_negative_create_user_5(self):
         """@Test: Create User with invalid Email Address
 
@@ -796,7 +770,6 @@ class User(UITestCase):
         @Status: Manual
 
         """
-        pass
 
     def test_negative_create_user_6(self):
         """@Test: Create User with blank Authorized by
@@ -866,7 +839,7 @@ class User(UITestCase):
             self.login.login(new_username, password)
             self.assertTrue(self.login.is_logged())
 
-    @unittest.skip(NOT_IMPLEMENTED)
+    @stubbed
     def test_positive_update_user_2(self):
         """@Test: Update Firstname in User
 
@@ -881,9 +854,8 @@ class User(UITestCase):
         @Status: Manual
 
         """
-        pass
 
-    @unittest.skip(NOT_IMPLEMENTED)
+    @stubbed
     def test_positive_update_user_3(self):
         """@Test: Update Surname in User
 
@@ -898,9 +870,8 @@ class User(UITestCase):
         @Status: Manual
 
         """
-        pass
 
-    @unittest.skip(NOT_IMPLEMENTED)
+    @stubbed
     def test_positive_update_user_4(self):
         """@Test: Update Email Address in User
 
@@ -915,9 +886,8 @@ class User(UITestCase):
         @Status: Manual
 
         """
-        pass
 
-    @unittest.skip(NOT_IMPLEMENTED)
+    @stubbed
     def test_positive_update_user_5(self):
         """@Test: Update Language in User
 
@@ -932,9 +902,8 @@ class User(UITestCase):
         @Status: Manual
 
         """
-        pass
 
-    @unittest.skip(NOT_IMPLEMENTED)
+    @stubbed
     def test_positive_update_user_6(self):
         """@Test: Update Password/Verify fields in User
 
@@ -949,9 +918,8 @@ class User(UITestCase):
         @Status: Manual
 
         """
-        pass
 
-    @unittest.skip(NOT_IMPLEMENTED)
+    @stubbed
     def test_positive_update_user_7(self):
         """@Test: Convert an user from an admin user to non-admin user
 
@@ -966,9 +934,8 @@ class User(UITestCase):
         @Status: Manual
 
         """
-        pass
 
-    @unittest.skip(NOT_IMPLEMENTED)
+    @stubbed
     def test_positive_update_user_8(self):
         """@Test: Convert a user to an admin user
 
@@ -983,9 +950,8 @@ class User(UITestCase):
         @Status: Manual
 
         """
-        pass
 
-    @unittest.skip(NOT_IMPLEMENTED)
+    @stubbed
     def test_positive_update_user_9(self):
         """@Test: Update User with one role
 
@@ -1000,9 +966,8 @@ class User(UITestCase):
         @Status: Manual
 
         """
-        pass
 
-    @unittest.skip(NOT_IMPLEMENTED)
+    @stubbed
     def test_positive_update_user_10(self):
         """@Test: Update User with multiple roles
 
@@ -1017,9 +982,8 @@ class User(UITestCase):
         @Status: Manual
 
         """
-        pass
 
-    @unittest.skip(NOT_IMPLEMENTED)
+    @stubbed
     def test_positive_update_user_11(self):
         """@Test: Update User with all roles
 
@@ -1034,9 +998,8 @@ class User(UITestCase):
         @Status: Manual
 
         """
-        pass
 
-    @unittest.skip(NOT_IMPLEMENTED)
+    @stubbed
     def test_positive_update_user_12(self):
         """@Test: Update User with one owned host
 
@@ -1051,9 +1014,8 @@ class User(UITestCase):
         @Status: Manual
 
         """
-        pass
 
-    @unittest.skip(NOT_IMPLEMENTED)
+    @stubbed
     def test_positive_update_user_13(self):
         """@Test: Update User with multiple owned hosts
 
@@ -1068,9 +1030,8 @@ class User(UITestCase):
         @Status: Manual
 
         """
-        pass
 
-    @unittest.skip(NOT_IMPLEMENTED)
+    @stubbed
     def test_positive_update_user_14(self):
         """@Test: Update User with all owned hosts
 
@@ -1085,10 +1046,9 @@ class User(UITestCase):
         @Status: Manual
 
         """
-        pass
 
     @run_only_on('sat')
-    @unittest.skip(NOT_IMPLEMENTED)
+    @stubbed
     def test_positive_update_user_15(self):
         """@Test: Update User with one Domain host
 
@@ -1103,10 +1063,9 @@ class User(UITestCase):
         @Status: Manual
 
         """
-        pass
 
     @run_only_on('sat')
-    @unittest.skip(NOT_IMPLEMENTED)
+    @stubbed
     def test_positive_update_user_16(self):
         """@Test: Update User with multiple Domain hosts
 
@@ -1121,10 +1080,9 @@ class User(UITestCase):
         @Status: Manual
 
         """
-        pass
 
     @run_only_on('sat')
-    @unittest.skip(NOT_IMPLEMENTED)
+    @stubbed
     def test_positive_update_user_17(self):
         """@Test: Update User with all Domain hosts
 
@@ -1139,10 +1097,9 @@ class User(UITestCase):
         @Status: Manual
 
         """
-        pass
 
     @run_only_on('sat')
-    @unittest.skip(NOT_IMPLEMENTED)
+    @stubbed
     def test_positive_update_user_18(self):
         """@Test: Update User with one Compute Resource
 
@@ -1157,10 +1114,9 @@ class User(UITestCase):
         @Status: Manual
 
         """
-        pass
 
     @run_only_on('sat')
-    @unittest.skip(NOT_IMPLEMENTED)
+    @stubbed
     def test_positive_update_user_19(self):
         """@Test: Update User with multiple Compute Resources
 
@@ -1175,10 +1131,9 @@ class User(UITestCase):
         @Status: Manual
 
         """
-        pass
 
     @run_only_on('sat')
-    @unittest.skip(NOT_IMPLEMENTED)
+    @stubbed
     def test_positive_update_user_20(self):
         """@Test: Update User with all Compute Resources
 
@@ -1193,10 +1148,9 @@ class User(UITestCase):
         @Status: Manual
 
         """
-        pass
 
     @run_only_on('sat')
-    @unittest.skip(NOT_IMPLEMENTED)
+    @stubbed
     def test_positive_update_user_21(self):
         """@Test: Update User with one Host group
 
@@ -1211,10 +1165,9 @@ class User(UITestCase):
         @Status: Manual
 
         """
-        pass
 
     @run_only_on('sat')
-    @unittest.skip(NOT_IMPLEMENTED)
+    @stubbed
     def test_positive_update_user_22(self):
         """@Test: Update User with multiple Host groups
 
@@ -1229,10 +1182,9 @@ class User(UITestCase):
         @Status: Manual
 
         """
-        pass
 
     @run_only_on('sat')
-    @unittest.skip(NOT_IMPLEMENTED)
+    @stubbed
     def test_positive_update_user_23(self):
         """@Test: Update User with all Host groups
 
@@ -1247,9 +1199,8 @@ class User(UITestCase):
         @Status: Manual
 
         """
-        pass
 
-    @unittest.skip(NOT_IMPLEMENTED)
+    @stubbed
     def test_positive_update_user_24(self):
         """@Test: Assign a User to an Org
 
@@ -1264,9 +1215,8 @@ class User(UITestCase):
         @Status: Manual
 
         """
-        pass
 
-    @unittest.skip(NOT_IMPLEMENTED)
+    @stubbed
     def test_positive_update_user_25(self):
         """@Test: Assign a User to multiple Orgs
 
@@ -1281,9 +1231,8 @@ class User(UITestCase):
         @Status: Manual
 
         """
-        pass
 
-    @unittest.skip(NOT_IMPLEMENTED)
+    @stubbed
     def test_positive_update_user_26(self):
         """@Test: Assign a User to all available Orgs
 
@@ -1298,10 +1247,9 @@ class User(UITestCase):
         @Status: Manual
 
         """
-        pass
 
     @run_only_on('sat')
-    @unittest.skip(NOT_IMPLEMENTED)
+    @stubbed
     def test_positive_update_user_28(self):
         """@Test: Update User with a new Fact filter
 
@@ -1316,9 +1264,8 @@ class User(UITestCase):
         @Status: Manual
 
         """
-        pass
 
-    @unittest.skip(NOT_IMPLEMENTED)
+    @stubbed
     def test_negative_update_user_1(self):
         """@Test: Update invalid Username in an User
 
@@ -1333,9 +1280,8 @@ class User(UITestCase):
         @Status: Manual
 
         """
-        pass
 
-    @unittest.skip(NOT_IMPLEMENTED)
+    @stubbed
     def test_negative_update_user_2(self):
         """@Test: Update invalid Firstname in an User
 
@@ -1350,9 +1296,8 @@ class User(UITestCase):
         @Status: Manual
 
         """
-        pass
 
-    @unittest.skip(NOT_IMPLEMENTED)
+    @stubbed
     def test_negative_update_user_3(self):
         """@Test: Update invalid Surname in an User
 
@@ -1367,9 +1312,8 @@ class User(UITestCase):
         @Status: Manual
 
         """
-        pass
 
-    @unittest.skip(NOT_IMPLEMENTED)
+    @stubbed
     def test_negative_update_user_4(self):
         """@Test: Update invalid Email Address in an User
 
@@ -1384,9 +1328,8 @@ class User(UITestCase):
         @Status: Manual
 
         """
-        pass
 
-    @unittest.skip(NOT_IMPLEMENTED)
+    @stubbed
     def test_negative_update_user_5(self):
         """@Test: Update different values in Password and verify fields
 
@@ -1402,9 +1345,8 @@ class User(UITestCase):
         @Status: Manual
 
         """
-        pass
 
-    @unittest.skip(NOT_IMPLEMENTED)
+    @stubbed
     def test_negative_update_user_6(self):
         """@Test: [UI ONLY] Attempt to update User info and Cancel
 
@@ -1420,9 +1362,8 @@ class User(UITestCase):
         @Status: Manual
 
         """
-        pass
 
-    @unittest.skip(NOT_IMPLEMENTED)
+    @stubbed
     def test_positive_delete_user_1(self):
         """@Test: Delete a user
 
@@ -1437,9 +1378,8 @@ class User(UITestCase):
         @Status: Manual
 
         """
-        pass
 
-    @unittest.skip(NOT_IMPLEMENTED)
+    @stubbed
     def test_positive_delete_user_2(self):
         """@Test: Delete an admin user
 
@@ -1454,9 +1394,8 @@ class User(UITestCase):
         @Status: Manual
 
         """
-        pass
 
-    @unittest.skip(NOT_IMPLEMENTED)
+    @stubbed
     def test_negative_delete_user_1(self):
         """@Test: [UI ONLY] Attempt to delete an User and cancel
 
@@ -1471,9 +1410,8 @@ class User(UITestCase):
         @Status: Manual
 
         """
-        pass
 
-    @unittest.skip(NOT_IMPLEMENTED)
+    @stubbed
     def test_negative_delete_user_2(self):
         """@Test: Attempt to delete the last remaining admin user
 
@@ -1489,9 +1427,8 @@ class User(UITestCase):
         @Status: Manual
 
         """
-        pass
 
-    @unittest.skip(NOT_IMPLEMENTED)
+    @stubbed
     def test_list_user_1(self):
         """@Test: List User for all variations of Username
 
@@ -1507,9 +1444,8 @@ class User(UITestCase):
         @Status: Manual
 
         """
-        pass
 
-    @unittest.skip(NOT_IMPLEMENTED)
+    @stubbed
     def test_list_user_2(self):
         """@Test: List User for all variations of Firstname
 
@@ -1525,9 +1461,8 @@ class User(UITestCase):
         @Status: Manual
 
         """
-        pass
 
-    @unittest.skip(NOT_IMPLEMENTED)
+    @stubbed
     def test_list_user_3(self):
         """@Test: List User for all variations of Surname
 
@@ -1543,9 +1478,8 @@ class User(UITestCase):
         @Status: Manual
 
         """
-        pass
 
-    @unittest.skip(NOT_IMPLEMENTED)
+    @stubbed
     def test_list_user_4(self):
         """@Test: List User for all variations of Email Address
 
@@ -1561,9 +1495,8 @@ class User(UITestCase):
         @Status: Manual
 
         """
-        pass
 
-    @unittest.skip(NOT_IMPLEMENTED)
+    @stubbed
     def test_list_user_5(self):
         """@Test: List User for all variations of Language
 
@@ -1579,9 +1512,8 @@ class User(UITestCase):
         @Status: Manual
 
         """
-        pass
 
-    @unittest.skip(NOT_IMPLEMENTED)
+    @stubbed
     def test_search_user_1(self):
         """@Test: Search User for all variations of Username
 
@@ -1597,9 +1529,8 @@ class User(UITestCase):
         @Status: Manual
 
         """
-        pass
 
-    @unittest.skip(NOT_IMPLEMENTED)
+    @stubbed
     def test_search_user_2(self):
         """@Test: Search User for all variations of Firstname
 
@@ -1615,9 +1546,8 @@ class User(UITestCase):
         @Status: Manual
 
         """
-        pass
 
-    @unittest.skip(NOT_IMPLEMENTED)
+    @stubbed
     def test_search_user_3(self):
         """@Test: Search User for all variations of Surname
 
@@ -1633,9 +1563,8 @@ class User(UITestCase):
         @Status: Manual
 
         """
-        pass
 
-    @unittest.skip(NOT_IMPLEMENTED)
+    @stubbed
     def test_search_user_4(self):
         """@Test: Search User for all variations of Email Address
 
@@ -1651,9 +1580,8 @@ class User(UITestCase):
         @Status: Manual
 
         """
-        pass
 
-    @unittest.skip(NOT_IMPLEMENTED)
+    @stubbed
     def test_search_user_5(self):
         """@Test: Search User for all variations of Language
 
@@ -1669,9 +1597,8 @@ class User(UITestCase):
         @Status: Manual
 
         """
-        pass
 
-    @unittest.skip(NOT_IMPLEMENTED)
+    @stubbed
     def test_info_user_1(self):
         """@Test: Get User info for all variations of Username
 
@@ -1687,9 +1614,8 @@ class User(UITestCase):
         @Status: Manual
 
         """
-        pass
 
-    @unittest.skip(NOT_IMPLEMENTED)
+    @stubbed
     def test_info_user_2(self):
         """@Test: Search User for all variations of Firstname
 
@@ -1705,9 +1631,8 @@ class User(UITestCase):
         @Status: Manual
 
         """
-        pass
 
-    @unittest.skip(NOT_IMPLEMENTED)
+    @stubbed
     def test_info_user_3(self):
         """@Test: Search User for all variations of Surname
 
@@ -1723,9 +1648,8 @@ class User(UITestCase):
         @Status: Manual
 
         """
-        pass
 
-    @unittest.skip(NOT_IMPLEMENTED)
+    @stubbed
     def test_info_user_4(self):
         """@Test: Search User for all variations of Email Address
 
@@ -1741,9 +1665,8 @@ class User(UITestCase):
         @Status: Manual
 
         """
-        pass
 
-    @unittest.skip(NOT_IMPLEMENTED)
+    @stubbed
     def test_info_user_5(self):
         """@Test: Search User for all variations of Language
 
@@ -1759,9 +1682,8 @@ class User(UITestCase):
         @Status: Manual
 
         """
-        pass
 
-    @unittest.skip(NOT_IMPLEMENTED)
+    @stubbed
     def test_end_to_end_user_1(self):
         """@Test: Create User and perform different operations
 
@@ -1781,9 +1703,8 @@ class User(UITestCase):
         @Status: Manual
 
         """
-        pass
 
-    @unittest.skip(NOT_IMPLEMENTED)
+    @stubbed
     def test_end_to_end_user_2(self):
         """@Test: Create User with no Org assigned and attempt different
         operations
@@ -1803,9 +1724,8 @@ class User(UITestCase):
         @Status: Manual
 
         """
-        pass
 
-    @unittest.skip(NOT_IMPLEMENTED)
+    @stubbed
     def test_positive_create_bookmark_1(self):
         """@Test: Create a bookmark with default values
 
@@ -1820,9 +1740,8 @@ class User(UITestCase):
         @Status: Manual
 
         """
-        pass
 
-    @unittest.skip(NOT_IMPLEMENTED)
+    @stubbed
     def test_positive_create_bookmark_2(self):
         """@Test: Create a bookmark by altering the default values
 
@@ -1837,9 +1756,8 @@ class User(UITestCase):
         @Status: Manual
 
         """
-        pass
 
-    @unittest.skip(NOT_IMPLEMENTED)
+    @stubbed
     def test_positive_create_bookmark_3(self):
         """@Test: Create a bookmark in public mode
 
@@ -1855,9 +1773,8 @@ class User(UITestCase):
         @Status: Manual
 
         """
-        pass
 
-    @unittest.skip(NOT_IMPLEMENTED)
+    @stubbed
     def test_positive_create_bookmark_4(self):
         """@Test: Create a bookmark in private mode
 
@@ -1873,9 +1790,8 @@ class User(UITestCase):
         @Status: Manual
 
         """
-        pass
 
-    @unittest.skip(NOT_IMPLEMENTED)
+    @stubbed
     def test_negative_create_bookmark_1(self):
         """@Test: Create a bookmark with a blank bookmark name
 
@@ -1890,9 +1806,8 @@ class User(UITestCase):
         @Status: Manual
 
         """
-        pass
 
-    @unittest.skip(NOT_IMPLEMENTED)
+    @stubbed
     def test_negative_create_bookmark_2(self):
         """@Test: Create a bookmark with a blank bookmark query
 
@@ -1907,4 +1822,3 @@ class User(UITestCase):
         @Status: Manual
 
         """
-        pass

--- a/tests/foreman/ui/test_usergroup.py
+++ b/tests/foreman/ui/test_usergroup.py
@@ -18,7 +18,7 @@ class UserGroup(UITestCase):
     """Implements UserGroup tests from UI"""
 
     @classmethod
-    def setUpClass(cls):
+    def setUpClass(cls):  # noqa
         cls.org_name = entities.Organization().create()
 
         super(UserGroup, cls).setUpClass()

--- a/tests/robottelo/test_cli.py
+++ b/tests/robottelo/test_cli.py
@@ -12,13 +12,13 @@ class CLIClass(Base):
 
 class BaseCliTestCase(unittest.TestCase):
     """Tests for the Base cli class"""
-    def setUp(self):
+    def setUp(self):  # noqa
         super(BaseCliTestCase, self).setUp()
         self.old_properties = conf.properties.copy()
         conf.properties['foreman.admin.username'] = 'configusername'
         conf.properties['foreman.admin.password'] = 'configpassword'
 
-    def tearDown(self):
+    def tearDown(self):  # noqa
         super(BaseCliTestCase, self).tearDown()
         conf.properties = self.old_properties
 

--- a/tests/robottelo/test_decorators.py
+++ b/tests/robottelo/test_decorators.py
@@ -8,7 +8,7 @@ from unittest import TestCase
 
 class DataTestCase(TestCase):
     """Tests for :func:`robottelo.common.decorators.data`."""
-    def setUp(self):  # pylint:disable=C0103
+    def setUp(self):  # noqa pylint:disable=C0103
         self.test_data = ('one', 'two', 'three')
 
         def function():
@@ -35,12 +35,12 @@ class DataTestCase(TestCase):
 class BzBugIsOpenTestCase(TestCase):
     """Tests for :func:`robottelo.common.decorators.bz_bug_is_open`."""
     # (protected-access) pylint:disable=W0212
-    def setUp(self):  # pylint:disable=C0103
+    def setUp(self):  # noqa pylint:disable=C0103
         """Back up objects and generate common values."""
         self.backup = decorators._get_bugzilla_bug
         self.bug_id = gen_integer()
 
-    def tearDown(self):  # pylint:disable=C0103
+    def tearDown(self):  # noqa pylint:disable=C0103
         """Restore backed-up objects."""
         decorators._get_bugzilla_bug = self.backup
 
@@ -78,14 +78,14 @@ class BzBugIsOpenTestCase(TestCase):
 class RmBugIsOpenTestCase(TestCase):
     """Tests for :func:`robottelo.common.decorators.rm_bug_is_open`."""
     # (protected-access) pylint:disable=W0212
-    def setUp(self):  # pylint:disable=C0103
+    def setUp(self):  # noqa pylint:disable=C0103
         """Back up objects and generate common values."""
         self.rm_backup = decorators._get_redmine_bug_status_id
         self.stat_backup = decorators._redmine_closed_issue_statuses
         decorators._redmine_closed_issue_statuses = lambda: [1, 2]
         self.bug_id = gen_integer()
 
-    def tearDown(self):  # pylint:disable=C0103
+    def tearDown(self):  # noqa pylint:disable=C0103
         """Restore backed-up objects."""
         decorators._get_redmine_bug_status_id = self.rm_backup
         decorators._redmine_closed_issue_statuses = self.stat_backup
@@ -115,11 +115,11 @@ class RmBugIsOpenTestCase(TestCase):
 
 class RunOnlyOnTestCase(TestCase):
     """Tests for :func:`robottelo.common.decorators.run_only_on`."""
-    def setUp(self):
+    def setUp(self):  # noqa
         """Backup object."""
         self.project_backup = conf.properties.get('main.project')
 
-    def tearDown(self):
+    def tearDown(self):  # noqa
         """Restore backed-up object."""
         conf.properties['main.project'] = self.project_backup
 

--- a/tests/robottelo/test_helpers.py
+++ b/tests/robottelo/test_helpers.py
@@ -19,7 +19,7 @@ class GetServerURLTestCase(unittest.TestCase):
     that particular test.
 
     """
-    def setUp(self):  # pylint:disable=C0103
+    def setUp(self):  # noqa pylint:disable=C0103
         """Back up and customize ``conf.properties``."""
         self.conf_properties = conf.properties.copy()
         conf.properties['main.server.hostname'] = 'example.com'
@@ -28,7 +28,7 @@ class GetServerURLTestCase(unittest.TestCase):
         if 'main.server.port' in conf.properties:
             del conf.properties['main.server.port']
 
-    def tearDown(self):  # pylint:disable=C0103
+    def tearDown(self):  # noqa pylint:disable=C0103
         """Restore ``conf.properties``."""
         conf.properties = self.conf_properties
 
@@ -83,13 +83,13 @@ class GetServerURLTestCase(unittest.TestCase):
 
 class GetServerCredentialsTestCase(unittest.TestCase):
     """Tests for method ``get_server_credentials``."""
-    def setUp(self):  # pylint:disable=C0103
+    def setUp(self):  # noqa pylint:disable=C0103
         """Back up and customize ``conf.properties``."""
         self.conf_properties = conf.properties.copy()
         conf.properties['foreman.admin.username'] = 'alice'
         conf.properties['foreman.admin.password'] = 'hackme'
 
-    def tearDown(self):  # pylint:disable=C0103
+    def tearDown(self):  # noqa pylint:disable=C0103
         """Restore ``conf.properties``."""
         conf.properties = self.conf_properties
 

--- a/tests/robottelo/test_orm.py
+++ b/tests/robottelo/test_orm.py
@@ -61,7 +61,7 @@ class EntityWithRead(orm.Entity, orm.EntityReadMixin):
 
 class EntityTestCase(unittest.TestCase):
     """Tests for :class:`robottelo.orm.Entity`."""
-    def setUp(self):  # pylint:disable=C0103
+    def setUp(self):  # noqa pylint:disable=C0103
         """
         Back up and configure ``conf.properties``, and set ``self.base_path``.
         """
@@ -72,7 +72,7 @@ class EntityTestCase(unittest.TestCase):
             SampleEntity.Meta.api_path
         )
 
-    def tearDown(self):  # pylint:disable=C0103
+    def tearDown(self):  # noqa pylint:disable=C0103
         """Restore ``conf.properties``."""
         conf.properties = self.conf_properties
 
@@ -97,7 +97,7 @@ class EntityTestCase(unittest.TestCase):
 
 class EntityDeleteMixinTestCase(unittest.TestCase):
     """Tests for entity mixin classes."""
-    def setUp(self):  # pylint:disable=C0103
+    def setUp(self):  # noqa pylint:disable=C0103
         """Back up several objects so they can be safely modified.
 
         Also generate a number suitable for use as an entity ID.
@@ -113,7 +113,7 @@ class EntityDeleteMixinTestCase(unittest.TestCase):
         # e.g. SomeEntity(id=self.entity_id)
         self.entity_id = gen_integer(min_value=1)
 
-    def tearDown(self):  # pylint:disable=C0103
+    def tearDown(self):  # noqa pylint:disable=C0103
         """Restore backed-up objects."""
         client.delete = self.client_delete
         client.get = self.client_get

--- a/tests/robottelo/test_robottelo_api_utils.py
+++ b/tests/robottelo/test_robottelo_api_utils.py
@@ -13,7 +13,7 @@ class MockResponse(object):
 
 class StatusCodeErrorTestCase(TestCase):
     """Tests fore :func:`robottelo.api.utils.status_code_error`."""
-    def setUp(self):
+    def setUp(self):  # noqa
         self.path = gen_string(
             'utf8',
             gen_integer(min_value=1, max_value=100)


### PR DESCRIPTION
New version of flake8 started complaining about some methods names. Add
noqa to avoid that on classes which override unittest methods.

Also avoid checking for python version when importing unittest in favor
of using try/except for that. In addition, avoid this kind of logic as
much as possible by using stubbed decorator on test skips.

Finally, fix other minor issues like: first attr of a class method
should be named cls, changing cases during import, indentation of
closing `)]}`