### PR TITLE
Fix stubbed decorator call

### DIFF
--- a/tests/foreman/api/test_contentview.py
+++ b/tests/foreman/api/test_contentview.py
@@ -496,7 +496,7 @@ class ContentViewTestCaseStub(APITestCase):
     # implemented. In the meantime, let's not worry about bad names.
     # (invalid-name) pylint:disable=C0103
 
-    @stubbed
+    @stubbed()
     def test_cv_edit_rh_custom_spin(self):
         """
         @test: edit content views for a custom rh spin.  For example,
@@ -520,7 +520,7 @@ class ContentViewTestCaseStub(APITestCase):
     # katello content definition add_repo --label=MyView
     #   --repo=repo1 --org=ACME
 
-    @stubbed
+    @stubbed()
     def test_associate_view_rh(self):
         """
         @test: associate Red Hat content in a view
@@ -530,7 +530,7 @@ class ContentViewTestCaseStub(APITestCase):
         @status: Manual
         """
 
-    @stubbed
+    @stubbed()
     def test_associate_view_rh_custom_spin(self):
         """
         @test: associate Red Hat content in a view
@@ -546,7 +546,7 @@ class ContentViewTestCaseStub(APITestCase):
         #   * A filter on severity (only content of specific errata
         # severity.
 
-    @stubbed
+    @stubbed()
     def test_associate_view_custom_content(self):
         """
         @test: associate Red Hat content in a view
@@ -556,7 +556,7 @@ class ContentViewTestCaseStub(APITestCase):
         @status: Manual
         """
 
-    @stubbed
+    @stubbed()
     def test_cv_associate_puppet_repo_negative(self):
         """
         @test: attempt to associate puppet repos within a custom
@@ -567,7 +567,7 @@ class ContentViewTestCaseStub(APITestCase):
         @status: Manual
         """
 
-    @stubbed
+    @stubbed()
     def test_cv_associate_components_composite_negative(self):
         """
         @test: attempt to associate components n a non-composite
@@ -577,7 +577,7 @@ class ContentViewTestCaseStub(APITestCase):
         @status: Manual
         """
 
-    @stubbed
+    @stubbed()
     def test_cv_associate_composite_dupe_repos_negative(self):
         """
         @test: attempt to associate the same repo multiple times within a
@@ -587,7 +587,7 @@ class ContentViewTestCaseStub(APITestCase):
         @status: Manual
         """
 
-    @stubbed
+    @stubbed()
     def test_cv_associate_composite_dupe_modules_negative(self):
         """
         @test: attempt to associate duplicate puppet module(s) within a
@@ -601,7 +601,7 @@ class ContentViewTestCaseStub(APITestCase):
     # katello content view promote --label=MyView --env=Dev --org=ACME
     # katello content view promote --view=MyView --env=Staging --org=ACME
 
-    @stubbed
+    @stubbed()
     def test_cv_promote_rh(self):
         """
         @test: attempt to promote a content view containing RH content
@@ -611,7 +611,7 @@ class ContentViewTestCaseStub(APITestCase):
         @status: Manual
         """
 
-    @stubbed
+    @stubbed()
     def test_cv_promote_rh_custom_spin(self):
         """
         @test: attempt to promote a content view containing a custom RH
@@ -622,7 +622,7 @@ class ContentViewTestCaseStub(APITestCase):
         @status: Manual
         """
 
-    @stubbed
+    @stubbed()
     def test_cv_promote_custom_content(self):
         """
         @test: attempt to promote a content view containing custom content
@@ -631,7 +631,7 @@ class ContentViewTestCaseStub(APITestCase):
         @assert: Content view can be promoted
         """
 
-    @stubbed
+    @stubbed()
     def test_cv_promote_composite(self):
         """
         @test: attempt to promote a content view containing custom content
@@ -646,7 +646,7 @@ class ContentViewTestCaseStub(APITestCase):
         # Custom content (i.e., fedora), puppet modules
         # ...etc.
 
-    @stubbed
+    @stubbed()
     def test_cv_promote_badid_negative(self):
         """
         @test: attempt to promote a content view using an invalid id
@@ -666,7 +666,7 @@ class ContentViewTestCaseStub(APITestCase):
     # Content Views: publish
     # katello content definition publish --label=MyView
 
-    @stubbed
+    @stubbed()
     def test_cv_publish_rh(self):
         """
         @test: attempt to publish a content view containing RH content
@@ -676,7 +676,7 @@ class ContentViewTestCaseStub(APITestCase):
         """
         # See method test_subscribe_system_to_cv in module test_contentview_v2
 
-    @stubbed
+    @stubbed()
     def test_cv_publish_rh_custom_spin(self):
         """
         @test: attempt to publish  a content view containing a custom RH
@@ -687,7 +687,7 @@ class ContentViewTestCaseStub(APITestCase):
         @status: Manual
         """
 
-    @stubbed
+    @stubbed()
     def test_cv_publish_custom_content(self):
         """
         @test: attempt to publish a content view containing custom content
@@ -697,7 +697,7 @@ class ContentViewTestCaseStub(APITestCase):
         @status: Manual
         """
 
-    @stubbed
+    @stubbed()
     def test_cv_publish_composite(self):
         """
         @test: attempt to publish  a content view containing custom content
@@ -711,7 +711,7 @@ class ContentViewTestCaseStub(APITestCase):
         # Custom content (i.e., fedora), puppet modules
         # ...etc.
 
-    @stubbed
+    @stubbed()
     def test_cv_publish_badlabel_negative(self):
         """
         @test: attempt to publish a content view containing invalid strings
@@ -725,7 +725,7 @@ class ContentViewTestCaseStub(APITestCase):
         # Variations might be:
         # zero length, too long, symbols, etc.
 
-    @stubbed
+    @stubbed()
     def test_cv_publish_version_changes_in_target_env(self):
         """
         @test: when publishing new version to environment, version
@@ -744,7 +744,7 @@ class ContentViewTestCaseStub(APITestCase):
         # Dev, version x goes away (ie when I promote version 1 to Dev,
         # version 3 goes away)
 
-    @stubbed
+    @stubbed()
     def test_cv_publish_version_changes_in_source_env(self):
         """
         @test: when publishing new version to environment, version
@@ -762,7 +762,7 @@ class ContentViewTestCaseStub(APITestCase):
         # Similarly when I publish version y, version x goes away from
         # Library (ie when I publish version 2, version 1 disappears)
 
-    @stubbed
+    @stubbed()
     def test_cv_clone_within_same_env(self):
         """
         @test: attempt to create new content view based on existing
@@ -773,7 +773,7 @@ class ContentViewTestCaseStub(APITestCase):
         """
         # Dev note: "not implemented yet"
 
-    @stubbed
+    @stubbed()
     def test_cv_clone_within_diff_env(self):
         """
         @test: attempt to create new content view based on existing
@@ -784,7 +784,7 @@ class ContentViewTestCaseStub(APITestCase):
         """
         # Dev note: "not implemented yet"
 
-    @stubbed
+    @stubbed()
     def test_cv_refresh_errata_to_new_view_in_same_env(self):
         """
         @test: attempt to refresh errata in a new view, based on
@@ -794,7 +794,7 @@ class ContentViewTestCaseStub(APITestCase):
         @status: Manual
         """
 
-    @stubbed
+    @stubbed()
     def test_cv_subscribe_system(self):
         """
         @test: attempt to  subscribe systems to content view(s)
@@ -813,7 +813,7 @@ class ContentViewTestCaseStub(APITestCase):
         # * composite
         # * CVs with puppet modules
 
-    @stubbed
+    @stubbed()
     def test_custom_cv_subscribe_system(self):
         """
         @test: attempt to  subscribe systems to content view(s)
@@ -823,7 +823,7 @@ class ContentViewTestCaseStub(APITestCase):
         # This test is implemented in tests/foreman/smoke/test_api_smoke.py.
         # See the end of method TestSmoke.test_smoke.
 
-    @stubbed
+    @stubbed()
     def test_cv_dynflow_restart_promote(self):
         """
         @test: attempt to restart a promotion
@@ -835,7 +835,7 @@ class ContentViewTestCaseStub(APITestCase):
         @status: Manual
         """
 
-    @stubbed
+    @stubbed()
     def test_cv_dynflow_restart_publish(self):
         """
         @test: attempt to restart a publish
@@ -850,7 +850,7 @@ class ContentViewTestCaseStub(APITestCase):
     # ROLES TESTING
     # All this stuff is speculative at best.
 
-    @stubbed
+    @stubbed()
     def test_cv_roles_admin_user(self):
         """
         @test: attempt to view content views
@@ -869,7 +869,7 @@ class ContentViewTestCaseStub(APITestCase):
         # Variations:
         #  * Read, Modify, Delete, Promote Publish, Subscribe
 
-    @stubbed
+    @stubbed()
     def test_cv_roles_readonly_user(self):
         """
         @test: attempt to view content views
@@ -889,7 +889,7 @@ class ContentViewTestCaseStub(APITestCase):
         # Variations:
         #  * Read, Modify,  Promote?, Publish?, Subscribe??
 
-    @stubbed
+    @stubbed()
     def test_cv_roles_admin_user_negative(self):
         """
         @test: attempt to view content views
@@ -908,7 +908,7 @@ class ContentViewTestCaseStub(APITestCase):
         # Variations:
         #  * Read, Modify, Delete, Promote Publish, Subscribe
 
-    @stubbed
+    @stubbed()
     def test_cv_roles_readonly_user_negative(self):
         """
         @test: attempt to view content views

--- a/tests/foreman/api/test_email.py
+++ b/tests/foreman/api/test_email.py
@@ -7,7 +7,7 @@ from robottelo.test import APITestCase
 class EmailTestCase(APITestCase):
     """API Tests for the email notification feature"""
 
-    @stubbed
+    @stubbed()
     def test_email_1(self):
         """@Test: Manage user email notification preferences.
 

--- a/tests/foreman/api/test_errata.py
+++ b/tests/foreman/api/test_errata.py
@@ -9,7 +9,7 @@ from robottelo.test import APITestCase
 class ErrataTestCase(APITestCase):
     """API Tests for the errata management feature"""
 
-    @stubbed
+    @stubbed()
     def test_hc_errata_install_1(self):
         """@Test: Install errata in a host-collection
 
@@ -27,7 +27,7 @@ class ErrataTestCase(APITestCase):
 
         """
 
-    @stubbed
+    @stubbed()
     def test_errata_list_1(self):
         """@Test: View all errata specific to an Org
 
@@ -45,7 +45,7 @@ class ErrataTestCase(APITestCase):
 
         """
 
-    @stubbed
+    @stubbed()
     def test_errata_list_2(self):
         """@Test: View all errata in an Org sorted by Updated
 
@@ -63,7 +63,7 @@ class ErrataTestCase(APITestCase):
 
         """
 
-    @stubbed
+    @stubbed()
     def test_errata_list_3(self):
         """@Test: Filter errata by CVE
 
@@ -81,7 +81,7 @@ class ErrataTestCase(APITestCase):
 
         """
 
-    @stubbed
+    @stubbed()
     def test_errata_systems_list_1(self):
         """@Test: View a list of affected content hosts for an erratum
 
@@ -100,7 +100,7 @@ class ErrataTestCase(APITestCase):
 
         """
 
-    @stubbed
+    @stubbed()
     def test_errata_systems_list_2(self):
         """@Test: Filter errata list based on affected content hosts
 
@@ -118,7 +118,7 @@ class ErrataTestCase(APITestCase):
 
         """
 
-    @stubbed
+    @stubbed()
     def test_errata_sort_1(self):
         """@Test: Filter errata by issued date
 
@@ -136,7 +136,7 @@ class ErrataTestCase(APITestCase):
 
         """
 
-    @stubbed
+    @stubbed()
     def test_errata_content_host_1(self):
         """@Test: Filter applicable errata for a content host by current and
         Library environments
@@ -159,7 +159,7 @@ class ErrataTestCase(APITestCase):
 
         """
 
-    @stubbed
+    @stubbed()
     def test_errata_content_host_2(self):
         """@Test: Available errata count when retrieving Content host
 
@@ -180,7 +180,7 @@ class ErrataTestCase(APITestCase):
 
         """
 
-    @stubbed
+    @stubbed()
     def test_errata_content_view_1(self):
         """@Test: Generate a difference in errata between a set of enviroments
         for a content view
@@ -203,7 +203,7 @@ class ErrataTestCase(APITestCase):
 
         """
 
-    @stubbed
+    @stubbed()
     def test_incremental_update_1(self):
         """@Test: Select multiple errata and apply them to multiple content
         views in multiple environments
@@ -226,7 +226,7 @@ class ErrataTestCase(APITestCase):
 
         """
 
-    @stubbed
+    @stubbed()
     def test_incremental_update_2(self):
         """@Test: Query a subset of environments or content views to push new
         errata
@@ -248,7 +248,7 @@ class ErrataTestCase(APITestCase):
 
         """
 
-    @stubbed
+    @stubbed()
     def test_incremental_update_3(self):
         """@Test: Select multiple packages and apply them to multiple content
         views in multiple environments

--- a/tests/foreman/api/test_hostgroup.py
+++ b/tests/foreman/api/test_hostgroup.py
@@ -21,7 +21,7 @@ class HostGroupTestCaseStub(APITestCase):
 
     """
 
-    @stubbed
+    @stubbed()
     def test_remove_hostgroup_1(self, test_data):
         """
         @feature: Organizations
@@ -31,7 +31,7 @@ class HostGroupTestCaseStub(APITestCase):
         @status: manual
         """
 
-    @stubbed
+    @stubbed()
     def test_remove_hostgroup_2(self, test_data):
         """
         @feature: Organizations
@@ -41,7 +41,7 @@ class HostGroupTestCaseStub(APITestCase):
         @status: manual
         """
 
-    @stubbed
+    @stubbed()
     def test_remove_hostgroup_3(self, test_data):
         """
         @feature: Organizations
@@ -51,7 +51,7 @@ class HostGroupTestCaseStub(APITestCase):
         @status: manual
         """
 
-    @stubbed
+    @stubbed()
     def test_remove_hostgroup_4(self, test_data):
         """
         @feature: Organizations
@@ -61,7 +61,7 @@ class HostGroupTestCaseStub(APITestCase):
         @status: manual
         """
 
-    @stubbed
+    @stubbed()
     def test_add_hostgroup_1(self, test_data):
         """
         @feature: Organizations
@@ -71,7 +71,7 @@ class HostGroupTestCaseStub(APITestCase):
         @status: manual
         """
 
-    @stubbed
+    @stubbed()
     def test_add_hostgroup_2(self, test_data):
         """
         @feature: Organizations
@@ -81,7 +81,7 @@ class HostGroupTestCaseStub(APITestCase):
         @status: manual
         """
 
-    @stubbed
+    @stubbed()
     def test_add_hostgroup_3(self, test_data):
         """
         @feature: Organizations
@@ -91,7 +91,7 @@ class HostGroupTestCaseStub(APITestCase):
         @status: manual
         """
 
-    @stubbed
+    @stubbed()
     def test_add_hostgroup_4(self, test_data):
         """
         @feature: Organizations

--- a/tests/foreman/api/test_media.py
+++ b/tests/foreman/api/test_media.py
@@ -22,7 +22,7 @@ class MediaTestCase(APITestCase):
 
     """
 
-    @stubbed
+    @stubbed()
     def test_remove_medium_1(self, test_data):
         """
         @feature: Organizations
@@ -31,7 +31,7 @@ class MediaTestCase(APITestCase):
         @status: manual
         """
 
-    @stubbed
+    @stubbed()
     def test_remove_medium_2(self, test_data):
         """
         @feature: Organizations
@@ -40,7 +40,7 @@ class MediaTestCase(APITestCase):
         @status: manual
         """
 
-    @stubbed
+    @stubbed()
     def test_remove_medium_3(self, test_data):
         """
         @feature: Organizations
@@ -49,7 +49,7 @@ class MediaTestCase(APITestCase):
         @status: manual
         """
 
-    @stubbed
+    @stubbed()
     def test_remove_medium_4(self, test_data):
         """
         @feature: Organizations
@@ -58,7 +58,7 @@ class MediaTestCase(APITestCase):
         @status: manual
         """
 
-    @stubbed
+    @stubbed()
     def test_add_medium_1(self, test_data):
         """
         @feature: Organizations
@@ -67,7 +67,7 @@ class MediaTestCase(APITestCase):
         @status: manual
         """
 
-    @stubbed
+    @stubbed()
     def test_add_medium_2(self, test_data):
         """
         @feature: Organizations
@@ -76,7 +76,7 @@ class MediaTestCase(APITestCase):
         @status: manual
         """
 
-    @stubbed
+    @stubbed()
     def test_add_medium_3(self, test_data):
         """
         @feature: Organizations
@@ -85,7 +85,7 @@ class MediaTestCase(APITestCase):
         @status: manual
         """
 
-    @stubbed
+    @stubbed()
     def test_add_medium_4(self, test_data):
         """
         @feature: Organizations

--- a/tests/foreman/api/test_smartproxy.py
+++ b/tests/foreman/api/test_smartproxy.py
@@ -22,7 +22,7 @@ class SmartProxyTestCaseStub(APITestCase):
 
     """
 
-    @stubbed
+    @stubbed()
     def test_add_smartproxy_1(self, test_data):
         """
         @feature: Organizations
@@ -31,7 +31,7 @@ class SmartProxyTestCaseStub(APITestCase):
         @status: manual
         """
 
-    @stubbed
+    @stubbed()
     def test_add_smartproxy_2(self, test_data):
         """
         @feature: Organizations
@@ -40,7 +40,7 @@ class SmartProxyTestCaseStub(APITestCase):
         @status: manual
         """
 
-    @stubbed
+    @stubbed()
     def test_add_smartproxy_3(self, test_data):
         """
         @feature: Organizations
@@ -49,7 +49,7 @@ class SmartProxyTestCaseStub(APITestCase):
         @status: manual
         """
 
-    @stubbed
+    @stubbed()
     def test_add_smartproxy_4(self, test_data):
         """
         @feature: Organizations
@@ -58,7 +58,7 @@ class SmartProxyTestCaseStub(APITestCase):
         @status: manual
         """
 
-    @stubbed
+    @stubbed()
     def test_remove_smartproxy_1(self, test_data):
         """
         @feature: Organizations
@@ -67,7 +67,7 @@ class SmartProxyTestCaseStub(APITestCase):
         @status: manual
         """
 
-    @stubbed
+    @stubbed()
     def test_remove_smartproxy_2(self, test_data):
         """
         @feature: Organizations
@@ -76,7 +76,7 @@ class SmartProxyTestCaseStub(APITestCase):
         @status: manual
         """
 
-    @stubbed
+    @stubbed()
     def test_remove_smartproxy_3(self, test_data):
         """
         @feature: Organizations
@@ -85,7 +85,7 @@ class SmartProxyTestCaseStub(APITestCase):
         @status: manual
         """
 
-    @stubbed
+    @stubbed()
     def test_remove_smartproxy_4(self, test_data):
         """
         @feature: Organizations

--- a/tests/foreman/cli/test_activationkey.py
+++ b/tests/foreman/cli/test_activationkey.py
@@ -261,7 +261,7 @@ class TestActivationKey(CLITestCase):
                 new_ackey['content-view'], test_data['content-view'])
         )
 
-    @stubbed
+    @stubbed()
     def test_positive_create_activation_key_5(self):
         """@Test: Create Activation key for all variations of System Groups
 
@@ -279,7 +279,7 @@ class TestActivationKey(CLITestCase):
         """
         pass
 
-    @stubbed
+    @stubbed()
     def test_positive_create_activation_key_6(self):
         """@Test: Create Activation key with default Usage limit (Unlimited)
 
@@ -297,7 +297,7 @@ class TestActivationKey(CLITestCase):
         """
         pass
 
-    @stubbed
+    @stubbed()
     def test_positive_create_activation_key_7(self):
         """@Test: Create Activation key with finite Usage limit
 
@@ -315,7 +315,7 @@ class TestActivationKey(CLITestCase):
         """
         pass
 
-    @stubbed
+    @stubbed()
     def test_positive_create_activation_key_8(self):
         """@Test: Create Activation key with minimal input parameters
 
@@ -360,7 +360,7 @@ class TestActivationKey(CLITestCase):
         except CLIFactoryError as err:
             self.fail(err)
 
-    @stubbed
+    @stubbed()
     def test_negative_create_activation_key_1(self):
         """@Test: Create Activation key with invalid Name
 
@@ -378,7 +378,7 @@ class TestActivationKey(CLITestCase):
         """
         pass
 
-    @stubbed
+    @stubbed()
     def test_negative_create_activation_key_2(self):
         """@Test: Create Activation key with invalid Description
 
@@ -396,7 +396,7 @@ class TestActivationKey(CLITestCase):
         """
         pass
 
-    @stubbed
+    @stubbed()
     def test_negative_create_activation_key_3(self):
         """@Test: Create Activation key with invalid Usage Limit
 
@@ -506,7 +506,7 @@ class TestActivationKey(CLITestCase):
         self.assertEqual(
             len(result.stdout), 0, 'Output should be blank')
 
-    @stubbed
+    @stubbed()
     def test_positive_delete_activation_key_3(self):
         """@Test: Create Activation key and delete it for all variations of
         Environment
@@ -526,7 +526,7 @@ class TestActivationKey(CLITestCase):
         """
         pass
 
-    @stubbed
+    @stubbed()
     def test_positive_delete_activation_key_4(self):
         """@Test: Create Activation key and delete it for all variations of
         Content Views
@@ -546,7 +546,7 @@ class TestActivationKey(CLITestCase):
         """
         pass
 
-    @stubbed
+    @stubbed()
     def test_positive_delete_activation_key_5(self):
         """@Test: Delete an Activation key which has registered systems
 
@@ -565,7 +565,7 @@ class TestActivationKey(CLITestCase):
         """
         pass
 
-    @stubbed
+    @stubbed()
     def test_positive_delete_activation_key_6(self):
         """@Test: Delete a Content View associated to an Activation Key deletes
         the Activation Key
@@ -584,7 +584,7 @@ class TestActivationKey(CLITestCase):
         """
         pass
 
-    @stubbed
+    @stubbed()
     def test_negative_delete_activation_key_1(self):
         """@Test: [UI ONLY] Attempt to delete an Activation Key and cancel it
 
@@ -750,7 +750,7 @@ class TestActivationKey(CLITestCase):
             'Activation key description was not updated')
 
     @run_only_on('sat')
-    @stubbed
+    @stubbed()
     def test_positive_update_activation_key_4(self):
         """@Test: Update Environment in an Activation key
 
@@ -824,7 +824,7 @@ class TestActivationKey(CLITestCase):
             result.stdout['content-view'], content_view,
             'Activation key content-view was not updated')
 
-    @stubbed
+    @stubbed()
     def test_positive_update_activation_key_6(self):
         """@Test: Update Usage limit from Unlimited to a finite number
 
@@ -842,7 +842,7 @@ class TestActivationKey(CLITestCase):
         """
         pass
 
-    @stubbed
+    @stubbed()
     def test_positive_update_activation_key_7(self):
         """@Test: Update Usage limit from definite number to Unlimited
 
@@ -860,7 +860,7 @@ class TestActivationKey(CLITestCase):
         """
         pass
 
-    @stubbed
+    @stubbed()
     def test_negative_update_activation_key_1(self):
         """@Test: Update invalid name in an activation key
 
@@ -878,7 +878,7 @@ class TestActivationKey(CLITestCase):
         """
         pass
 
-    @stubbed
+    @stubbed()
     def test_negative_update_activation_key_2(self):
         """@Test: Update invalid Description in an activation key
 
@@ -896,7 +896,7 @@ class TestActivationKey(CLITestCase):
         """
         pass
 
-    @stubbed
+    @stubbed()
     def test_negative_update_activation_key_3(self):
         """@Test: Update invalid Usage Limit in an activation key
 
@@ -914,7 +914,7 @@ class TestActivationKey(CLITestCase):
         """
         pass
 
-    @stubbed
+    @stubbed()
     def test_usage_limit(self):
         """@Test: Test that Usage limit actually limits usage
 
@@ -995,7 +995,7 @@ class TestActivationKey(CLITestCase):
             result.stdout['host-collection'], host_col,
             'Activation key host-collection added')
 
-    @stubbed
+    @stubbed()
     def test_associate_product_1(self):
         """@Test: Test that RH product can be associated to Activation Keys
 
@@ -1014,7 +1014,7 @@ class TestActivationKey(CLITestCase):
         pass
 
     @run_only_on('sat')
-    @stubbed
+    @stubbed()
     def test_associate_product_2(self):
         """@Test: Test that custom product can be associated to Activation Keys
 
@@ -1033,7 +1033,7 @@ class TestActivationKey(CLITestCase):
         pass
 
     @run_only_on('sat')
-    @stubbed
+    @stubbed()
     def test_associate_product_3(self):
         """@Test: Test if RH/Custom product can be associated to Activation key
 
@@ -1052,7 +1052,7 @@ class TestActivationKey(CLITestCase):
         """
         pass
 
-    @stubbed
+    @stubbed()
     def test_delete_manifest(self):
         """@Test: Check if deleting a manifest removes it from Activation key
 
@@ -1071,7 +1071,7 @@ class TestActivationKey(CLITestCase):
         """
         pass
 
-    @stubbed
+    @stubbed()
     def test_multiple_activation_keys_to_system(self):
         """@Test: Check if multiple Activation keys can be attached to a system
 
@@ -1089,7 +1089,7 @@ class TestActivationKey(CLITestCase):
         """
         pass
 
-    @stubbed
+    @stubbed()
     def test_list_activation_keys_1(self):
         """@Test: List Activation key for all variations of Activation key name
 
@@ -1108,7 +1108,7 @@ class TestActivationKey(CLITestCase):
         """
         pass
 
-    @stubbed
+    @stubbed()
     def test_list_activation_keys_2(self):
         """@Test: List Activation key for all variations of Description
 
@@ -1126,7 +1126,7 @@ class TestActivationKey(CLITestCase):
         """
         pass
 
-    @stubbed
+    @stubbed()
     def test_search_activation_keys_1(self):
         """@Test: Search Activation key for all variations of
             Activation key name
@@ -1146,7 +1146,7 @@ class TestActivationKey(CLITestCase):
         """
         pass
 
-    @stubbed
+    @stubbed()
     def test_search_activation_keys_2(self):
         """@Test: Search Activation key for all variations of Description
 
@@ -1164,7 +1164,7 @@ class TestActivationKey(CLITestCase):
         """
         pass
 
-    @stubbed
+    @stubbed()
     def test_info_activation_keys_1(self):
         """@Test: Get Activation key info for all variations of Activation key
         name
@@ -1184,7 +1184,7 @@ class TestActivationKey(CLITestCase):
         """
         pass
 
-    @stubbed
+    @stubbed()
     def test_info_activation_keys_2(self):
         """@Test: Get Activation key info for all variations of Description
 
@@ -1203,7 +1203,7 @@ class TestActivationKey(CLITestCase):
         pass
 
     @run_only_on('sat')
-    @stubbed
+    @stubbed()
     def test_end_to_end(self):
         """@Test: Create Activation key and provision systems with it
 

--- a/tests/foreman/cli/test_contentviews.py
+++ b/tests/foreman/cli/test_contentviews.py
@@ -1882,7 +1882,7 @@ class TestContentView(CLITestCase):
             len(result.stderr), 0,
             "There should have been an exception here")
 
-    @stubbed
+    @stubbed()
     def test_cv_roles_readonly_user(self):
         # Note:
         # Obviously all of this stuff should work with 'admin' user
@@ -1906,7 +1906,7 @@ class TestContentView(CLITestCase):
 
         """
 
-    @stubbed
+    @stubbed()
     def test_cv_roles_readonly_user_negative(self):
         # Note:
         # Obviously all of this stuff should work with 'admin' user

--- a/tests/foreman/cli/test_errata.py
+++ b/tests/foreman/cli/test_errata.py
@@ -9,7 +9,7 @@ from robottelo.test import CLITestCase
 class ErrataTestCase(CLITestCase):
     """CLI Tests for the errata management feature"""
 
-    @stubbed
+    @stubbed()
     def test_hc_errata_install_1(self):
         """@Test: Using hc-id and org id to install an erratum in a hc
 
@@ -28,7 +28,7 @@ class ErrataTestCase(CLITestCase):
 
         """
 
-    @stubbed
+    @stubbed()
     def test_hc_errata_install_2(self):
         """@Test: Using hc-id and org name to install an erratum in a hc
 
@@ -47,7 +47,7 @@ class ErrataTestCase(CLITestCase):
 
         """
 
-    @stubbed
+    @stubbed()
     def test_hc_errata_install_3(self):
         """@Test: Use hc-id and org label to install an erratum in a hc
 
@@ -66,7 +66,7 @@ class ErrataTestCase(CLITestCase):
 
         """
 
-    @stubbed
+    @stubbed()
     def test_hc_errata_install_4(self):
         """@Test: Use hc-name and org id to install an erratum in a hc
 
@@ -85,7 +85,7 @@ class ErrataTestCase(CLITestCase):
 
         """
 
-    @stubbed
+    @stubbed()
     def test_hc_errata_install_5(self):
         """@Test: Use hc name and org name to install an erratum in a hc
 
@@ -104,7 +104,7 @@ class ErrataTestCase(CLITestCase):
 
         """
 
-    @stubbed
+    @stubbed()
     def test_hc_errata_install_6(self):
         """@Test: Use hc-name and org label to install an erratum in a hc
 
@@ -123,7 +123,7 @@ class ErrataTestCase(CLITestCase):
 
         """
 
-    @stubbed
+    @stubbed()
     def test_hc_errata_install_7(self):
         """@Test: Attempt to install an erratum in a hc using hc-id and not
         specifying the erratum info
@@ -142,7 +142,7 @@ class ErrataTestCase(CLITestCase):
 
         """
 
-    @stubbed
+    @stubbed()
     def test_hc_errata_install_8(self):
         """@Test: Attempt to install an erratum in a hc using hc-name and not
         specifying the erratum info
@@ -162,7 +162,7 @@ class ErrataTestCase(CLITestCase):
 
         """
 
-    @stubbed
+    @stubbed()
     def test_hc_errata_install_9(self):
         """@Test: Attempt to install an erratum in a hc by not specifying hc
         info
@@ -182,7 +182,7 @@ class ErrataTestCase(CLITestCase):
 
         """
 
-    @stubbed
+    @stubbed()
     def test_hc_errata_install_10(self):
         """@Test: Attempt to install an erratum in a hc using hc-id and not
         specifying org info
@@ -201,7 +201,7 @@ class ErrataTestCase(CLITestCase):
 
         """
 
-    @stubbed
+    @stubbed()
     def test_hc_errata_install_11(self):
         """@Test: Attempt to install an erratum in a hc without specifying hc
         info
@@ -220,7 +220,7 @@ class ErrataTestCase(CLITestCase):
 
         """
 
-    @stubbed
+    @stubbed()
     def test_errata_list_sort_1(self):
         """@Test: Sort errata by Issued date
 
@@ -239,7 +239,7 @@ class ErrataTestCase(CLITestCase):
 
         """
 
-    @stubbed
+    @stubbed()
     def test_errata_list_sort_2(self):
         """@Test: Filter errata by org id and sort by updated date
 
@@ -258,7 +258,7 @@ class ErrataTestCase(CLITestCase):
 
         """
 
-    @stubbed
+    @stubbed()
     def test_errata_list_sort_3(self):
         """@Test: Filter errata by org name and sort by updated date
 
@@ -277,7 +277,7 @@ class ErrataTestCase(CLITestCase):
 
         """
 
-    @stubbed
+    @stubbed()
     def test_errata_list_sort_4(self):
         """@Test: Filter errata by org label and sort by updated date
 
@@ -296,7 +296,7 @@ class ErrataTestCase(CLITestCase):
 
         """
 
-    @stubbed
+    @stubbed()
     def test_errata_list_sort_5(self):
         """@Test: Filter errata by org id and sort by issued date
 
@@ -315,7 +315,7 @@ class ErrataTestCase(CLITestCase):
 
         """
 
-    @stubbed
+    @stubbed()
     def test_errata_list_sort_6(self):
         """@Test: Filter errata by org name and sort by issued date
 
@@ -334,7 +334,7 @@ class ErrataTestCase(CLITestCase):
 
         """
 
-    @stubbed
+    @stubbed()
     def test_errata_list_sort_7(self):
         """@Test: Filter errata by org label and sort by issued date
 
@@ -353,7 +353,7 @@ class ErrataTestCase(CLITestCase):
 
         """
 
-    @stubbed
+    @stubbed()
     def test_errata_list_1(self):
         """@Test: Filter errata by product id
 
@@ -371,7 +371,7 @@ class ErrataTestCase(CLITestCase):
 
         """
 
-    @stubbed
+    @stubbed()
     def test_errata_list_2(self):
         """@Test: Filter errata by product name
 
@@ -389,7 +389,7 @@ class ErrataTestCase(CLITestCase):
 
         """
 
-    @stubbed
+    @stubbed()
     def test_errata_list_3(self):
         """@Test: Filter errata by product id and Org id
 
@@ -407,7 +407,7 @@ class ErrataTestCase(CLITestCase):
 
         """
 
-    @stubbed
+    @stubbed()
     def test_errata_list_4(self):
         """@Test: Filter errata by product id and Org name
 
@@ -425,7 +425,7 @@ class ErrataTestCase(CLITestCase):
 
         """
 
-    @stubbed
+    @stubbed()
     def test_errata_list_5(self):
         """@Test: Filter errata by product id
 
@@ -447,7 +447,7 @@ class ErrataTestCase(CLITestCase):
 
         """
 
-    @stubbed
+    @stubbed()
     def test_errata_list_6(self):
         """@Test: Filter errata by product name
 
@@ -465,7 +465,7 @@ class ErrataTestCase(CLITestCase):
 
         """
 
-    @stubbed
+    @stubbed()
     def test_errata_list_7(self):
         """@Test: Filter errata by product name and Org id
 
@@ -483,7 +483,7 @@ class ErrataTestCase(CLITestCase):
 
         """
 
-    @stubbed
+    @stubbed()
     def test_errata_list_8(self):
         """@Test: Filter errata by product name and Org name
 
@@ -501,7 +501,7 @@ class ErrataTestCase(CLITestCase):
 
         """
 
-    @stubbed
+    @stubbed()
     def test_errata_list_9(self):
         """@Test: Filter errata by product name and Org label
 
@@ -520,7 +520,7 @@ class ErrataTestCase(CLITestCase):
 
         """
 
-    @stubbed
+    @stubbed()
     def test_errata_list_10(self):
         """@Test: Filter errata by Org id
 
@@ -538,7 +538,7 @@ class ErrataTestCase(CLITestCase):
 
         """
 
-    @stubbed
+    @stubbed()
     def test_errata_list_11(self):
         """@Test: Filter errata by Org name
 
@@ -556,7 +556,7 @@ class ErrataTestCase(CLITestCase):
 
         """
 
-    @stubbed
+    @stubbed()
     def test_errata_list_12(self):
         """@Test: Filter errata by Org label
 
@@ -574,7 +574,7 @@ class ErrataTestCase(CLITestCase):
 
         """
 
-    @stubbed
+    @stubbed()
     def test_errata_list_13(self):
         """@Test: Filter errata by CVE
 
@@ -592,7 +592,7 @@ class ErrataTestCase(CLITestCase):
 
         """
 
-    @stubbed
+    @stubbed()
     def test_errata_list_permission_1(self):
         """@Test: Show errata only if the User has permissions to view them
 
@@ -615,7 +615,7 @@ class ErrataTestCase(CLITestCase):
 
         """
 
-    @stubbed
+    @stubbed()
     def test_errata_systems_list_1(self):
         """@Test: View a list of affected content hosts for an erratum
 
@@ -634,7 +634,7 @@ class ErrataTestCase(CLITestCase):
 
         """
 
-    @stubbed
+    @stubbed()
     def test_errata_systems_list_2(self):
         """@Test: View a list of affected content hosts for an erratum filtered
         with restrict flags
@@ -661,7 +661,7 @@ class ErrataTestCase(CLITestCase):
 
         """
 
-    @stubbed
+    @stubbed()
     def test_errata_content_host_1(self):
         """@Test: Available errata count displayed while viewing a list of
         Content hosts

--- a/tests/foreman/cli/test_gpgkey.py
+++ b/tests/foreman/cli/test_gpgkey.py
@@ -373,7 +373,7 @@ class TestGPGKey(CLITestCase):
         name is html
         gpg key file is valid always
     """
-    @stubbed
+    @stubbed()
     def test_positive_delete_1(self):
         """@test: Create gpg key with valid name and valid gpg key via file
         import then delete it
@@ -397,7 +397,7 @@ class TestGPGKey(CLITestCase):
         name is html
         gpg key text is valid text from a valid gpg key file
     """
-    @stubbed
+    @stubbed()
     def test_positive_delete_2(self):
         """@test: Create gpg key with valid name and valid gpg key text via
         cut and paste/string then delete it
@@ -425,7 +425,7 @@ class TestGPGKey(CLITestCase):
         delete using a negative gpg key ID
         delete using a random string as the gpg key ID
     """
-    @stubbed
+    @stubbed()
     def test_negative_delete_1(self):
         """@test: Create gpg key with valid name and valid gpg key via file
         import then fail to delete it
@@ -451,7 +451,7 @@ class TestGPGKey(CLITestCase):
         delete using a negative gpg key ID
         delete using a random string as the gpg key ID
     """
-    @stubbed
+    @stubbed()
     def test_negative_delete_2(self):
         """@test: Create gpg key with valid name and valid gpg key text via
         cut and paste/string then fail to delete it
@@ -477,7 +477,7 @@ class TestGPGKey(CLITestCase):
         name is html
         gpg key file is valid always
     """
-    @stubbed
+    @stubbed()
     def test_positive_update_1(self):
         """@test: Create gpg key with valid name and valid gpg key via file
         import then update its name
@@ -501,7 +501,7 @@ class TestGPGKey(CLITestCase):
         name is html
         gpg key file is valid always
     """
-    @stubbed
+    @stubbed()
     def test_positive_update_2(self):
         """@test: Create gpg key with valid name and valid gpg key via file
         import then update its gpg key file
@@ -525,7 +525,7 @@ class TestGPGKey(CLITestCase):
         name is html
         gpg key text is valid text from a valid gpg key file
     """
-    @stubbed
+    @stubbed()
     def test_positive_update_3(self):
         """@test: Create gpg key with valid name and valid gpg key text via
         cut and paste/string then update its name
@@ -549,7 +549,7 @@ class TestGPGKey(CLITestCase):
         name is html
         gpg key text is valid text from a valid gpg key file
     """
-    @stubbed
+    @stubbed()
     def test_positive_update_4(self):
         """@test: Create gpg key with valid name and valid gpg key text via
         cut and paste/string then update its gpg key text
@@ -576,7 +576,7 @@ class TestGPGKey(CLITestCase):
         update name is html 300 characters long
         gpg key file is valid always
     """
-    @stubbed
+    @stubbed()
     def test_negative_update_1(self):
         """@test: Create gpg key with valid name and valid gpg key via file
         import then fail to update its name
@@ -601,7 +601,7 @@ class TestGPGKey(CLITestCase):
         update name is html 300 characters long
         gpg key text is valid text from a valid gpg key file
     """
-    @stubbed
+    @stubbed()
     def test_negative_update_2(self):
         """@test: Create gpg key with valid name and valid gpg key text via
         cut and paste/string then fail to update its name
@@ -627,7 +627,7 @@ class TestGPGKey(CLITestCase):
         name is html
         gpg key file is valid always
     """
-    @stubbed
+    @stubbed()
     def test_key_associate_1(self):
         """@test: Create gpg key with valid name and valid gpg key via file
         import then associate it with empty (no repos) custom product
@@ -651,7 +651,7 @@ class TestGPGKey(CLITestCase):
         name is html
         gpg key file is valid always
     """
-    @stubbed
+    @stubbed()
     def test_key_associate_2(self):
         """@test: Create gpg key with valid name and valid gpg key via file
         import then associate it with custom product that has one repository
@@ -675,7 +675,7 @@ class TestGPGKey(CLITestCase):
         name is html
         gpg key file is valid always
     """
-    @stubbed
+    @stubbed()
     def test_key_associate_3(self):
         """@test: Create gpg key with valid name and valid gpg key via file
         import then associate it with custom product that has more than one
@@ -700,7 +700,7 @@ class TestGPGKey(CLITestCase):
         name is html
         gpg key file is valid always
     """
-    @stubbed
+    @stubbed()
     def test_key_associate_4(self):
         """@test: Create gpg key with valid name and valid gpg key via file
         import then associate it with custom product using Repo discovery
@@ -725,7 +725,7 @@ class TestGPGKey(CLITestCase):
         name is html
         gpg key file is valid always
     """
-    @stubbed
+    @stubbed()
     def test_key_associate_5(self):
         """@test: Create gpg key with valid name and valid gpg key via file
         import then associate it to repository from custom product that has
@@ -750,7 +750,7 @@ class TestGPGKey(CLITestCase):
         name is html
         gpg key file is valid always
     """
-    @stubbed
+    @stubbed()
     def test_key_associate_6(self):
         """@test: Create gpg key via file import and associate with custom repo
 
@@ -777,7 +777,7 @@ class TestGPGKey(CLITestCase):
         name is html
         gpg key file is valid always
     """
-    @stubbed
+    @stubbed()
     def test_key_associate_7(self):
         """@test: Create gpg key with valid name and valid gpg key via file
         import then associate it to repos from custom product using Repo
@@ -802,7 +802,7 @@ class TestGPGKey(CLITestCase):
         name is html
         gpg key file is valid always
     """
-    @stubbed
+    @stubbed()
     def test_key_associate_8(self):
         """@test: Create gpg key with valid name and valid gpg key via file
         import then associate it with empty (no repos) custom product then
@@ -827,7 +827,7 @@ class TestGPGKey(CLITestCase):
         name is html
         gpg key file is valid always
     """
-    @stubbed
+    @stubbed()
     def test_key_associate_9(self):
         """@test: Create gpg key with valid name and valid gpg key via file
         import then associate it with custom product that has one repository
@@ -853,7 +853,7 @@ class TestGPGKey(CLITestCase):
         name is html
         gpg key file is valid always
     """
-    @stubbed
+    @stubbed()
     def test_key_associate_10(self):
         """@test: Create gpg key with valid name and valid gpg key via file
         import then associate it with custom product that has more than one
@@ -879,7 +879,7 @@ class TestGPGKey(CLITestCase):
         name is html
         gpg key file is valid always
     """
-    @stubbed
+    @stubbed()
     def test_key_associate_11(self):
         """@test: Create gpg key with valid name and valid gpg key via file
         import then associate it with custom product using Repo discovery
@@ -905,7 +905,7 @@ class TestGPGKey(CLITestCase):
         name is html
         gpg key file is valid always
     """
-    @stubbed
+    @stubbed()
     def test_key_associate_12(self):
         """@test: Create gpg key with valid name and valid gpg key via file
         import then associate it to repository from custom product that has
@@ -931,7 +931,7 @@ class TestGPGKey(CLITestCase):
         name is html
         gpg key file is valid always
     """
-    @stubbed
+    @stubbed()
     def test_key_associate_13(self):
         """@test: Create gpg key with valid name and valid gpg key via file
         import then associate it to repository from custom product that has
@@ -957,7 +957,7 @@ class TestGPGKey(CLITestCase):
         name is html
         gpg key file is valid always
     """
-    @stubbed
+    @stubbed()
     def test_key_associate_14(self):
         """@test: Create gpg key with valid name and valid gpg key via file
         import then associate it to repos from custom product using Repo
@@ -983,7 +983,7 @@ class TestGPGKey(CLITestCase):
         name is html
         gpg key file is valid always
     """
-    @stubbed
+    @stubbed()
     def test_key_associate_15(self):
         """@test: Create gpg key with valid name and valid gpg key via file
         import then associate it with empty (no repos) custom product
@@ -1009,7 +1009,7 @@ class TestGPGKey(CLITestCase):
         name is html
         gpg key file is valid always
     """
-    @stubbed
+    @stubbed()
     def test_key_associate_16(self):
         """@test: Create gpg key with valid name and valid gpg key via file
         import then associate it with custom product that has one repository
@@ -1035,7 +1035,7 @@ class TestGPGKey(CLITestCase):
         name is html
         gpg key file is valid always
     """
-    @stubbed
+    @stubbed()
     def test_key_associate_17(self):
         """@test: Create gpg key with valid name and valid gpg key via file
         import then associate it with custom product that has more than one
@@ -1061,7 +1061,7 @@ class TestGPGKey(CLITestCase):
         name is html
         gpg key file is valid always
     """
-    @stubbed
+    @stubbed()
     def test_key_associate_18(self):
         """@test: Create gpg key with valid name and valid gpg key via file
         import then associate it with custom product using Repo discovery
@@ -1087,7 +1087,7 @@ class TestGPGKey(CLITestCase):
         name is html
         gpg key file is valid always
     """
-    @stubbed
+    @stubbed()
     def test_key_associate_19(self):
         """@test: Create gpg key with valid name and valid gpg key via file
         import then associate it to repository from custom product that has
@@ -1113,7 +1113,7 @@ class TestGPGKey(CLITestCase):
         name is html
         gpg key file is valid always
     """
-    @stubbed
+    @stubbed()
     def test_key_associate_20(self):
         """@test: Create gpg key with valid name and valid gpg key via file
         import then associate it to repository from custom product that has
@@ -1139,7 +1139,7 @@ class TestGPGKey(CLITestCase):
         name is html
         gpg key file is valid always
     """
-    @stubbed
+    @stubbed()
     def test_key_associate_21(self):
         """@test: Create gpg key with valid name and valid gpg key via file
         import then associate it to repos from custom product using Repo
@@ -1166,7 +1166,7 @@ class TestGPGKey(CLITestCase):
         name is html
         gpg key file is valid always
     """
-    @stubbed
+    @stubbed()
     def test_key_associate_22(self):
         """@test: Create gpg key with valid name and valid gpg key text via
         cut and paste/string then associate it with empty (no repos)
@@ -1191,7 +1191,7 @@ class TestGPGKey(CLITestCase):
         name is html
         gpg key file is valid always
     """
-    @stubbed
+    @stubbed()
     def test_key_associate_23(self):
         """@test: Create gpg key with valid name and valid gpg key text via
         cut and paste/string then associate it with custom product that has
@@ -1216,7 +1216,7 @@ class TestGPGKey(CLITestCase):
         name is html
         gpg key file is valid always
     """
-    @stubbed
+    @stubbed()
     def test_key_associate_24(self):
         """@test: Create gpg key with valid name and valid gpg key text via
         cut and paste/string then associate it with custom product that has
@@ -1241,7 +1241,7 @@ class TestGPGKey(CLITestCase):
         name is html
         gpg key file is valid always
     """
-    @stubbed
+    @stubbed()
     def test_key_associate_25(self):
         """@test: Create gpg key with valid name and valid gpg key via text via
         cut and paste/string then associate it with custom product using
@@ -1266,7 +1266,7 @@ class TestGPGKey(CLITestCase):
         name is html
         gpg key file is valid always
     """
-    @stubbed
+    @stubbed()
     def test_key_associate_26(self):
         """@test: Create gpg key with valid name and valid gpg key text via
         cut and paste/string then associate it to repository from custom
@@ -1291,7 +1291,7 @@ class TestGPGKey(CLITestCase):
         name is html
         gpg key file is valid always
     """
-    @stubbed
+    @stubbed()
     def test_key_associate_27(self):
         """@test: Create gpg key with valid name and valid gpg key text via
         cut and paste/string then associate it to repository from custom
@@ -1316,7 +1316,7 @@ class TestGPGKey(CLITestCase):
         name is html
         gpg key file is valid always
     """
-    @stubbed
+    @stubbed()
     def test_key_associate_28(self):
         """@test: Create gpg key with valid name and valid gpg key text via
         cut and paste/string then associate it to repos from custom product
@@ -1341,7 +1341,7 @@ class TestGPGKey(CLITestCase):
         name is html
         gpg key file is valid always
     """
-    @stubbed
+    @stubbed()
     def test_key_associate_29(self):
         """@test: Create gpg key with valid name and valid gpg key text via
         cut and paste/string then associate it with empty (no repos)
@@ -1366,7 +1366,7 @@ class TestGPGKey(CLITestCase):
         name is html
         gpg key file is valid always
     """
-    @stubbed
+    @stubbed()
     def test_key_associate_30(self):
         """@test: Create gpg key with valid name and valid gpg key text via
         cut and paste/string then associate it with custom product that has
@@ -1392,7 +1392,7 @@ class TestGPGKey(CLITestCase):
         name is html
         gpg key file is valid always
     """
-    @stubbed
+    @stubbed()
     def test_key_associate_31(self):
         """@test: Create gpg key with valid name and valid gpg key text via
         cut and paste/string then associate it with custom product that has
@@ -1418,7 +1418,7 @@ class TestGPGKey(CLITestCase):
         name is html
         gpg key file is valid always
     """
-    @stubbed
+    @stubbed()
     def test_key_associate_32(self):
         """@test: Create gpg key with valid name and valid gpg key text via
         cut and paste/string then associate it with custom product using
@@ -1444,7 +1444,7 @@ class TestGPGKey(CLITestCase):
         name is html
         gpg key file is valid always
     """
-    @stubbed
+    @stubbed()
     def test_key_associate_33(self):
         """@test: Create gpg key with valid name and valid gpg key text via
         cut and paste/string then associate it to repository from custom
@@ -1470,7 +1470,7 @@ class TestGPGKey(CLITestCase):
         name is html
         gpg key file is valid always
     """
-    @stubbed
+    @stubbed()
     def test_key_associate_34(self):
         """@test: Create gpg key with valid name and valid gpg key text via
         cut and paste/string then associate it to repository from custom
@@ -1496,7 +1496,7 @@ class TestGPGKey(CLITestCase):
         name is html
         gpg key file is valid always
     """
-    @stubbed
+    @stubbed()
     def test_key_associate_35(self):
         """@test: Create gpg key with valid name and valid gpg key text via
         cut and paste/string then associate it to repos from custom product
@@ -1522,7 +1522,7 @@ class TestGPGKey(CLITestCase):
         name is html
         gpg key file is valid always
     """
-    @stubbed
+    @stubbed()
     def test_key_associate_36(self):
         """@test: Create gpg key with valid name and valid gpg key text via
         cut and paste/string then associate it with empty (no repos) custom
@@ -1548,7 +1548,7 @@ class TestGPGKey(CLITestCase):
         name is html
         gpg key file is valid always
     """
-    @stubbed
+    @stubbed()
     def test_key_associate_37(self):
         """@test: Create gpg key with valid name and valid gpg key text via
         cut and paste/string then associate it with custom product that has
@@ -1574,7 +1574,7 @@ class TestGPGKey(CLITestCase):
         name is html
         gpg key file is valid always
     """
-    @stubbed
+    @stubbed()
     def test_key_associate_38(self):
         """@test: Create gpg key with valid name and valid gpg key text via
         cut and paste/string then associate it with custom product that has
@@ -1600,7 +1600,7 @@ class TestGPGKey(CLITestCase):
         name is html
         gpg key file is valid always
     """
-    @stubbed
+    @stubbed()
     def test_key_associate_39(self):
         """@test: Create gpg key with valid name and valid gpg key text via
         cut and paste/string then associate it with custom product using
@@ -1626,7 +1626,7 @@ class TestGPGKey(CLITestCase):
         name is html
         gpg key file is valid always
     """
-    @stubbed
+    @stubbed()
     def test_key_associate_40(self):
         """@test: Create gpg key with valid name and valid gpg key text via
         cut and paste/string then associate it to repository from custom
@@ -1652,7 +1652,7 @@ class TestGPGKey(CLITestCase):
         name is html
         gpg key file is valid always
     """
-    @stubbed
+    @stubbed()
     def test_key_associate_41(self):
         """@test: Create gpg key with valid name and valid gpg key text via
         cut and paste/string then associate it to repository from custom
@@ -1678,7 +1678,7 @@ class TestGPGKey(CLITestCase):
         name is html
         gpg key file is valid always
     """
-    @stubbed
+    @stubbed()
     def test_key_associate_42(self):
         """@test: Create gpg key with valid name and valid gpg key text via
         cut and paste/string then associate it to repos from custom product
@@ -1707,7 +1707,7 @@ class TestGPGKey(CLITestCase):
         name is html
         gpg key file is valid always
     """
-    @stubbed
+    @stubbed()
     def test_consume_content_1(self):
         """@test: Hosts can install packages using gpg key associated with
         single custom repository
@@ -1731,7 +1731,7 @@ class TestGPGKey(CLITestCase):
         name is html
         gpg key file is valid always
     """
-    @stubbed
+    @stubbed()
     def test_consume_content_2(self):
         """@test: Hosts can install packages using gpg key associated with
         multiple custom repositories
@@ -1755,7 +1755,7 @@ class TestGPGKey(CLITestCase):
         name is html
         gpg key file is valid always
     """
-    @stubbed
+    @stubbed()
     def test_consume_content_3(self):
         """@test:Hosts can install packages using different gpg keys associated
         with multiple custom repositories
@@ -1781,7 +1781,7 @@ class TestGPGKey(CLITestCase):
         name is html
         gpg key file is valid always
     """
-    @stubbed
+    @stubbed()
     def test_list_key_1(self):
         """@test: Create gpg key and list it
 
@@ -1804,7 +1804,7 @@ class TestGPGKey(CLITestCase):
         name is html
         gpg key file is valid always
     """
-    @stubbed
+    @stubbed()
     def test_search_key_1(self):
         """@test: Create gpg key and search/find it
 
@@ -1827,7 +1827,7 @@ class TestGPGKey(CLITestCase):
         name is html
         gpg key file is valid always
     """
-    @stubbed
+    @stubbed()
     def test_info_key_1(self):
         """@test: Create single gpg key and get its info
 

--- a/tests/foreman/cli/test_host_system_unification.py
+++ b/tests/foreman/cli/test_host_system_unification.py
@@ -18,7 +18,7 @@ class TestHostSystemUnificationCLI(CLITestCase):
     # (the link/join will) "Most likely an internal UUID, not something
     # fuzzy like hostname"
 
-    @stubbed
+    @stubbed()
     def test_all_hosts_appear_in_foreman(self):
         """@test: Hosts registered to Katello via rhsm appear in foreman
 
@@ -36,7 +36,7 @@ class TestHostSystemUnificationCLI(CLITestCase):
         """
         pass
 
-    @stubbed
+    @stubbed()
     def all_hosts_appear_in_katello(self):
         """@test: Hosts provisioned in foreman via appear in katello
 

--- a/tests/foreman/cli/test_installer.py
+++ b/tests/foreman/cli/test_installer.py
@@ -11,7 +11,7 @@ class TestSSOCLI(CLITestCase):
     # that can parse logs? It would be better (and possibly less
     # error-prone) than simply grepping for ERROR/FATAL
 
-    @stubbed
+    @stubbed()
     def test_installer_check_services(self):
         # devnote:
         # maybe `hammer ping` command might be useful here to check
@@ -29,7 +29,7 @@ class TestSSOCLI(CLITestCase):
         """
         pass
 
-    @stubbed
+    @stubbed()
     def test_installer_logfile_check(self):
         """@test: Look for ERROR or FATAL references in logfiles
 
@@ -47,7 +47,7 @@ class TestSSOCLI(CLITestCase):
         """
         pass
 
-    @stubbed
+    @stubbed()
     def test_installer_check_progress_meter(self):
         """@test:  Assure progress indicator/meter "works"
 
@@ -61,7 +61,7 @@ class TestSSOCLI(CLITestCase):
         """
         pass
 
-    @stubbed
+    @stubbed()
     def test_installer_from_iso(self):
         """@test:  Can install product from ISO
 
@@ -74,7 +74,7 @@ class TestSSOCLI(CLITestCase):
         """
         pass
 
-    @stubbed
+    @stubbed()
     def test_installer_server_install(self):
         """@test:  Can install main satellite instance successfully via RPM
 
@@ -87,7 +87,7 @@ class TestSSOCLI(CLITestCase):
         """
         pass
 
-    @stubbed
+    @stubbed()
     def test_installer_node_install(self):
         """@test:  Can install node successfully via RPM
 
@@ -100,7 +100,7 @@ class TestSSOCLI(CLITestCase):
         """
         pass
 
-    @stubbed
+    @stubbed()
     def test_installer_smartproxy_install(self):
         """@test:  Can install smart-proxy successfully via RPM
 
@@ -113,7 +113,7 @@ class TestSSOCLI(CLITestCase):
         """
         pass
 
-    @stubbed
+    @stubbed()
     def test_installer_disconnected_util_install(self):
         """@test:  Can install  satellite disconnected utility successfully
         via RPM
@@ -127,7 +127,7 @@ class TestSSOCLI(CLITestCase):
         """
         pass
 
-    @stubbed
+    @stubbed()
     def test_installer_smartproxy_registers(self):
         """@test: Upon installation, smart-proxy instance self-registers
         itself to parent instance
@@ -142,7 +142,7 @@ class TestSSOCLI(CLITestCase):
         """
         pass
 
-    @stubbed
+    @stubbed()
     def test_installer_clear_data(self):
         """@test:  User can run installer to clear existing data
 

--- a/tests/foreman/cli/test_myaccount.py
+++ b/tests/foreman/cli/test_myaccount.py
@@ -18,7 +18,7 @@ class MyAccount(CLITestCase):
 
     """
 
-    @stubbed
+    @stubbed()
     def test_positive_update_my_account_1(self):
         """@Test: Update Firstname in My Account
 
@@ -33,7 +33,7 @@ class MyAccount(CLITestCase):
 
         """
 
-    @stubbed
+    @stubbed()
     def test_positive_update_my_account_2(self):
         """@Test: Update Surname in My Account
 
@@ -48,7 +48,7 @@ class MyAccount(CLITestCase):
 
         """
 
-    @stubbed
+    @stubbed()
     def test_positive_update_my_account_3(self):
         """@Test: Update Email Address in My Account
 
@@ -63,7 +63,7 @@ class MyAccount(CLITestCase):
 
         """
 
-    @stubbed
+    @stubbed()
     def test_positive_update_my_account_4(self):
         """@Test: Update Language in My Account
 
@@ -78,7 +78,7 @@ class MyAccount(CLITestCase):
 
         """
 
-    @stubbed
+    @stubbed()
     def test_positive_update_my_account_5(self):
         """@Test: Update Password/Verify fields in My Account
 
@@ -93,7 +93,7 @@ class MyAccount(CLITestCase):
 
         """
 
-    @stubbed
+    @stubbed()
     def test_negative_update_my_account_1(self):
         """@Test: Update My Account with invalid FirstName
 
@@ -108,7 +108,7 @@ class MyAccount(CLITestCase):
 
         """
 
-    @stubbed
+    @stubbed()
     def test_negative_update_my_account_2(self):
         """@Test: Update My Account with invalid Surname
 
@@ -123,7 +123,7 @@ class MyAccount(CLITestCase):
 
         """
 
-    @stubbed
+    @stubbed()
     def test_negative_update_my_account_3(self):
         """@Test: Update My Account with invalid Email Address
 
@@ -138,7 +138,7 @@ class MyAccount(CLITestCase):
 
         """
 
-    @stubbed
+    @stubbed()
     def test_negative_update_my_account_4(self):
         """@Test: Update My Account with invalid Password/Verify fields
 
@@ -154,7 +154,7 @@ class MyAccount(CLITestCase):
 
         """
 
-    @stubbed
+    @stubbed()
     def test_negative_update_my_account_5(self):
         """@Test: Update My Account with non-matching values in Password and
 
@@ -171,7 +171,7 @@ class MyAccount(CLITestCase):
 
         """
 
-    @stubbed
+    @stubbed()
     def test_negative_update_my_account_6(self):
         """@Test: [UI ONLY] Attempt to update all info in My Accounts page and
 

--- a/tests/foreman/cli/test_org.py
+++ b/tests/foreman/cli/test_org.py
@@ -760,7 +760,7 @@ class TestOrg(CLITestCase):
                          compute_res['name'])
 
     @run_only_on('sat')
-    @stubbed
+    @stubbed()
     def test_remove_computeresource(self):
         """@Test: Check if a ComputeResource can be removed from an Org
 
@@ -1409,7 +1409,7 @@ class TestOrg(CLITestCase):
 
     # Miscelaneous
 
-    @stubbed
+    @stubbed()
     @data("""DATADRIVENGOESHERE
         name, label and description are is alpha
         name, label and description are is numeric
@@ -1431,7 +1431,7 @@ class TestOrg(CLITestCase):
 
         pass
 
-    @stubbed
+    @stubbed()
     @data("""DATADRIVENGOESHERE
         name, label and description are is alpha
         name, label and description are is numeric
@@ -1453,7 +1453,7 @@ class TestOrg(CLITestCase):
 
         pass
 
-    @stubbed
+    @stubbed()
     @data("""DATADRIVENGOESHERE
         name, label and description are is alpha
         name, label and description are is numeric
@@ -1478,7 +1478,7 @@ class TestOrg(CLITestCase):
 
     # Associations
 
-    @stubbed
+    @stubbed()
     @data("""DATADRIVENGOESHERE
         domain name is alpha
         domain name is numeric
@@ -1501,7 +1501,7 @@ class TestOrg(CLITestCase):
 
         pass
 
-    @stubbed
+    @stubbed()
     @data("""DATADRIVENGOESHERE
         domain name is alpha
         domain name is numeric
@@ -1524,7 +1524,7 @@ class TestOrg(CLITestCase):
 
         pass
 
-    @stubbed
+    @stubbed()
     @data("""DATADRIVENGOESHERE
         domain name is alpha
         domain name is numeric
@@ -1547,7 +1547,7 @@ class TestOrg(CLITestCase):
 
         pass
 
-    @stubbed
+    @stubbed()
     @data("""DATADRIVENGOESHERE
         domain name is alpha
         domain name is numeric
@@ -1570,7 +1570,7 @@ class TestOrg(CLITestCase):
 
         pass
 
-    @stubbed
+    @stubbed()
     @data("""DATADRIVENGOESHERE
         user name is alpha
         user name is numeric
@@ -1593,7 +1593,7 @@ class TestOrg(CLITestCase):
 
         pass
 
-    @stubbed
+    @stubbed()
     @data("""DATADRIVENGOESHERE
         user name is alpha
         user name is numeric
@@ -1616,7 +1616,7 @@ class TestOrg(CLITestCase):
 
         pass
 
-    @stubbed
+    @stubbed()
     @data("""DATADRIVENGOESHERE
         user name is alpha and admin
         user name is numeric and admin
@@ -1640,7 +1640,7 @@ class TestOrg(CLITestCase):
         pass
 
     @run_only_on('sat')
-    @stubbed
+    @stubbed()
     @data("""DATADRIVENGOESHERE
         hostgroup name is alpha
         hostgroup name is numeric
@@ -1664,7 +1664,7 @@ class TestOrg(CLITestCase):
         pass
 
     @run_only_on('sat')
-    @stubbed
+    @stubbed()
     @data("""DATADRIVENGOESHERE
         hostgroup name is alpha
         hostgroup name is numeric
@@ -1688,7 +1688,7 @@ class TestOrg(CLITestCase):
         pass
 
     @run_only_on('sat')
-    @stubbed
+    @stubbed()
     @data("""DATADRIVENGOESHERE
         hostgroup name is alpha
         hostgroup name is numeric
@@ -1712,7 +1712,7 @@ class TestOrg(CLITestCase):
         pass
 
     @run_only_on('sat')
-    @stubbed
+    @stubbed()
     @data("""DATADRIVENGOESHERE
         hostgroup name is alpha
         hostgroup name is numeric
@@ -1736,7 +1736,7 @@ class TestOrg(CLITestCase):
         pass
 
     @run_only_on('sat')
-    @stubbed
+    @stubbed()
     @data("""DATADRIVENGOESHERE
         smartproxy name is alpha
         smartproxy name is numeric
@@ -1759,7 +1759,7 @@ class TestOrg(CLITestCase):
         pass
 
     @run_only_on('sat')
-    @stubbed
+    @stubbed()
     @data("""DATADRIVENGOESHERE
         smartproxy name is alpha
         smartproxy name is numeric
@@ -1782,7 +1782,7 @@ class TestOrg(CLITestCase):
         pass
 
     @run_only_on('sat')
-    @stubbed
+    @stubbed()
     @data("""DATADRIVENGOESHERE
         smartproxy name is alpha
         smartproxy name is numeric
@@ -1805,7 +1805,7 @@ class TestOrg(CLITestCase):
         pass
 
     @run_only_on('sat')
-    @stubbed
+    @stubbed()
     @data("""DATADRIVENGOESHERE
         smartproxy name is alpha
         smartproxy name is numeric
@@ -1860,7 +1860,7 @@ class TestOrg(CLITestCase):
         self.assertIn(name, result.stdout['subnets'][0])
 
     @run_only_on('sat')
-    @stubbed
+    @stubbed()
     @data("""DATADRIVENGOESHERE
         subnet name is alpha
         subnet name is numeric
@@ -1883,7 +1883,7 @@ class TestOrg(CLITestCase):
         pass
 
     @run_only_on('sat')
-    @stubbed
+    @stubbed()
     @data("""DATADRIVENGOESHERE
         subnet name is alpha
         subnet name is numeric
@@ -1906,7 +1906,7 @@ class TestOrg(CLITestCase):
         pass
 
     @run_only_on('sat')
-    @stubbed
+    @stubbed()
     @data("""DATADRIVENGOESHERE
         subnet name is alpha
         subnet name is numeric
@@ -1929,7 +1929,7 @@ class TestOrg(CLITestCase):
         pass
 
     @run_only_on('sat')
-    @stubbed
+    @stubbed()
     @data("""DATADRIVENGOESHERE
         domain name is alpha
         domain name is numeric
@@ -1951,7 +1951,7 @@ class TestOrg(CLITestCase):
 
         pass
 
-    @stubbed
+    @stubbed()
     @data("""DATADRIVENGOESHERE
         user name is alpha
         user name is numeric
@@ -1974,7 +1974,7 @@ class TestOrg(CLITestCase):
 
         pass
 
-    @stubbed
+    @stubbed()
     @data("""DATADRIVENGOESHERE
         user name is alpha
         user name is numeric
@@ -1997,7 +1997,7 @@ class TestOrg(CLITestCase):
 
         pass
 
-    @stubbed
+    @stubbed()
     @data("""DATADRIVENGOESHERE
         user name is alpha and an admin
         user name is numeric and an admin
@@ -2020,7 +2020,7 @@ class TestOrg(CLITestCase):
         pass
 
     @run_only_on('sat')
-    @stubbed
+    @stubbed()
     @data("""DATADRIVENGOESHERE
         hostgroup name is alpha
         hostgroup name is numeric
@@ -2044,7 +2044,7 @@ class TestOrg(CLITestCase):
         pass
 
     @run_only_on('sat')
-    @stubbed
+    @stubbed()
     @data("""DATADRIVENGOESHERE
         hostgroup name is alpha
         hostgroup name is numeric
@@ -2068,7 +2068,7 @@ class TestOrg(CLITestCase):
         pass
 
     @run_only_on('sat')
-    @stubbed
+    @stubbed()
     @data("""DATADRIVENGOESHERE
         hostgroup name is alpha
         hostgroup name is numeric
@@ -2092,7 +2092,7 @@ class TestOrg(CLITestCase):
         pass
 
     @run_only_on('sat')
-    @stubbed
+    @stubbed()
     @data("""DATADRIVENGOESHERE
         hostgroup name is alpha
         hostgroup name is numeric
@@ -2116,7 +2116,7 @@ class TestOrg(CLITestCase):
         pass
 
     @run_only_on('sat')
-    @stubbed
+    @stubbed()
     @data("""DATADRIVENGOESHERE
         computeresource is alpha
         computeresource is numeric
@@ -2140,7 +2140,7 @@ class TestOrg(CLITestCase):
         pass
 
     @run_only_on('sat')
-    @stubbed
+    @stubbed()
     @data("""DATADRIVENGOESHERE
         computeresource is alpha
         computeresource is numeric
@@ -2164,7 +2164,7 @@ class TestOrg(CLITestCase):
         pass
 
     @run_only_on('sat')
-    @stubbed
+    @stubbed()
     @data("""DATADRIVENGOESHERE
         computeresource is alpha
         computeresource is numeric
@@ -2188,7 +2188,7 @@ class TestOrg(CLITestCase):
         pass
 
     @run_only_on('sat')
-    @stubbed
+    @stubbed()
     @data("""DATADRIVENGOESHERE
         computeresource is alpha
         computeresource is numeric
@@ -2212,7 +2212,7 @@ class TestOrg(CLITestCase):
         pass
 
     @run_only_on('sat')
-    @stubbed
+    @stubbed()
     @data("""DATADRIVENGOESHERE
         medium name is alpha
         medium name is numeric
@@ -2235,7 +2235,7 @@ class TestOrg(CLITestCase):
         pass
 
     @run_only_on('sat')
-    @stubbed
+    @stubbed()
     @data("""DATADRIVENGOESHERE
         medium name is alpha
         medium name is numeric
@@ -2258,7 +2258,7 @@ class TestOrg(CLITestCase):
         pass
 
     @run_only_on('sat')
-    @stubbed
+    @stubbed()
     @data("""DATADRIVENGOESHERE
         medium name is alpha
         medium name is numeric
@@ -2281,7 +2281,7 @@ class TestOrg(CLITestCase):
         pass
 
     @run_only_on('sat')
-    @stubbed
+    @stubbed()
     @data("""DATADRIVENGOESHERE
         medium name is alpha
         medium name is numeric
@@ -2304,7 +2304,7 @@ class TestOrg(CLITestCase):
         pass
 
     @run_only_on('sat')
-    @stubbed
+    @stubbed()
     @data("""DATADRIVENGOESHERE
         configtemplate name is alpha
         configtemplate name is numeric
@@ -2327,7 +2327,7 @@ class TestOrg(CLITestCase):
         pass
 
     @run_only_on('sat')
-    @stubbed
+    @stubbed()
     @data("""DATADRIVENGOESHERE
         environment name is alpha
         environment name is numeric
@@ -2351,7 +2351,7 @@ class TestOrg(CLITestCase):
         pass
 
     @run_only_on('sat')
-    @stubbed
+    @stubbed()
     @data("""DATADRIVENGOESHERE
         environment name is alpha
         environment name is numeric
@@ -2375,7 +2375,7 @@ class TestOrg(CLITestCase):
         pass
 
     @run_only_on('sat')
-    @stubbed
+    @stubbed()
     @data("""DATADRIVENGOESHERE
         environment name is alpha
         environment name is numeric
@@ -2399,7 +2399,7 @@ class TestOrg(CLITestCase):
         pass
 
     @run_only_on('sat')
-    @stubbed
+    @stubbed()
     @data("""DATADRIVENGOESHERE
         environment name is alpha
         environment name is numeric
@@ -2423,7 +2423,7 @@ class TestOrg(CLITestCase):
         pass
 
     @run_only_on('sat')
-    @stubbed
+    @stubbed()
     @data("""DATADRIVENGOESHERE
         smartproxy name is alpha
         smartproxy name is numeric
@@ -2446,7 +2446,7 @@ class TestOrg(CLITestCase):
         pass
 
     @run_only_on('sat')
-    @stubbed
+    @stubbed()
     @data("""DATADRIVENGOESHERE
         smartproxy name is alpha
         smartproxy name is numeric
@@ -2469,7 +2469,7 @@ class TestOrg(CLITestCase):
         pass
 
     @run_only_on('sat')
-    @stubbed
+    @stubbed()
     @data("""DATADRIVENGOESHERE
         smartproxy name is alpha
         smartproxy name is numeric
@@ -2492,7 +2492,7 @@ class TestOrg(CLITestCase):
         pass
 
     @run_only_on('sat')
-    @stubbed
+    @stubbed()
     @data("""DATADRIVENGOESHERE
         smartproxy name is alpha
         smartproxy name is numeric
@@ -2515,7 +2515,7 @@ class TestOrg(CLITestCase):
         pass
 
     @run_only_on('sat')
-    @stubbed
+    @stubbed()
     @data("""DATADRIVENGOESHERE
         computeresource is alpha
         computeresource is numeric
@@ -2539,7 +2539,7 @@ class TestOrg(CLITestCase):
         pass
 
     @run_only_on('sat')
-    @stubbed
+    @stubbed()
     @data("""DATADRIVENGOESHERE
         computeresource is alpha
         computeresource is numeric
@@ -2563,7 +2563,7 @@ class TestOrg(CLITestCase):
         pass
 
     @run_only_on('sat')
-    @stubbed
+    @stubbed()
     @data("""DATADRIVENGOESHERE
         computeresource is alpha
         computeresource is numeric
@@ -2587,7 +2587,7 @@ class TestOrg(CLITestCase):
         pass
 
     @run_only_on('sat')
-    @stubbed
+    @stubbed()
     @data("""DATADRIVENGOESHERE
         computeresource is alpha
         computeresource is numeric
@@ -2611,7 +2611,7 @@ class TestOrg(CLITestCase):
         pass
 
     @run_only_on('sat')
-    @stubbed
+    @stubbed()
     @data("""DATADRIVENGOESHERE
         medium name is alpha
         medium name is numeric
@@ -2634,7 +2634,7 @@ class TestOrg(CLITestCase):
         pass
 
     @run_only_on('sat')
-    @stubbed
+    @stubbed()
     @data("""DATADRIVENGOESHERE
         medium name is alpha
         medium name is numeric
@@ -2657,7 +2657,7 @@ class TestOrg(CLITestCase):
         pass
 
     @run_only_on('sat')
-    @stubbed
+    @stubbed()
     @data("""DATADRIVENGOESHERE
         medium name is alpha
         medium name is numeric
@@ -2680,7 +2680,7 @@ class TestOrg(CLITestCase):
         pass
 
     @run_only_on('sat')
-    @stubbed
+    @stubbed()
     @data("""DATADRIVENGOESHERE
         medium name is alpha
         medium name is numeric
@@ -2703,7 +2703,7 @@ class TestOrg(CLITestCase):
         pass
 
     @run_only_on('sat')
-    @stubbed
+    @stubbed()
     @data("""DATADRIVENGOESHERE
         configtemplate name is alpha
         configtemplate name is numeric
@@ -2727,7 +2727,7 @@ class TestOrg(CLITestCase):
         pass
 
     @run_only_on('sat')
-    @stubbed
+    @stubbed()
     @data("""DATADRIVENGOESHERE
         configtemplate name is alpha
         configtemplate name is numeric
@@ -2751,7 +2751,7 @@ class TestOrg(CLITestCase):
         pass
 
     @run_only_on('sat')
-    @stubbed
+    @stubbed()
     @data("""DATADRIVENGOESHERE
         configtemplate name is alpha
         configtemplate name is numeric
@@ -2775,7 +2775,7 @@ class TestOrg(CLITestCase):
         pass
 
     @run_only_on('sat')
-    @stubbed
+    @stubbed()
     @data("""DATADRIVENGOESHERE
         configtemplate name is alpha
         configtemplate name is numeric
@@ -2799,7 +2799,7 @@ class TestOrg(CLITestCase):
         pass
 
     @run_only_on('sat')
-    @stubbed
+    @stubbed()
     @data("""DATADRIVENGOESHERE
         environment name is alpha
         environment name is numeric
@@ -2822,7 +2822,7 @@ class TestOrg(CLITestCase):
         pass
 
     @run_only_on('sat')
-    @stubbed
+    @stubbed()
     @data("""DATADRIVENGOESHERE
         environment name is alpha
         environment name is numeric
@@ -2845,7 +2845,7 @@ class TestOrg(CLITestCase):
         pass
 
     @run_only_on('sat')
-    @stubbed
+    @stubbed()
     @data("""DATADRIVENGOESHERE
         environment name is alpha
         environment name is numeric
@@ -2868,7 +2868,7 @@ class TestOrg(CLITestCase):
         pass
 
     @run_only_on('sat')
-    @stubbed
+    @stubbed()
     @data("""DATADRIVENGOESHERE
         environment name is alpha
         environment name is numeric
@@ -2891,7 +2891,7 @@ class TestOrg(CLITestCase):
         pass
 
     @run_only_on('sat')
-    @stubbed
+    @stubbed()
     @data("""DATADRIVENGOESHERE
         subnet name is alpha
         subnet name is numeric
@@ -2914,7 +2914,7 @@ class TestOrg(CLITestCase):
         pass
 
     @run_only_on('sat')
-    @stubbed
+    @stubbed()
     @data("""DATADRIVENGOESHERE
         subnet name is alpha
         subnet name is numeric
@@ -2937,7 +2937,7 @@ class TestOrg(CLITestCase):
         pass
 
     @run_only_on('sat')
-    @stubbed
+    @stubbed()
     @data("""DATADRIVENGOESHERE
         subnet name is alpha
         subnet name is numeric
@@ -2960,7 +2960,7 @@ class TestOrg(CLITestCase):
         pass
 
     @run_only_on('sat')
-    @stubbed
+    @stubbed()
     @data("""DATADRIVENGOESHERE
         subnet name is alpha
         subnet name is numeric

--- a/tests/foreman/cli/test_repository.py
+++ b/tests/foreman/cli/test_repository.py
@@ -548,7 +548,7 @@ class TestRepository(CLITestCase):
         )
 
     @run_only_on('sat')
-    @stubbed
+    @stubbed()
     def test_positive_update_2(self, test_data):
         """@Test: Update the original gpg key
 
@@ -561,7 +561,7 @@ class TestRepository(CLITestCase):
         """
 
     @run_only_on('sat')
-    @stubbed
+    @stubbed()
     def test_positive_update_3(self, test_data):
         """@Test: Update the original publishing method
 

--- a/tests/foreman/cli/test_sso.py
+++ b/tests/foreman/cli/test_sso.py
@@ -18,7 +18,7 @@ class TestSSOCLI(CLITestCase):
     # possibly other LDAP types. These (in particular, the LDAP variations)
     # can be easily added later.
 
-    @stubbed
+    @stubbed()
     def test_sso_kerberos_cli(self):
         """@test: kerberos user can login to CLI
 
@@ -33,7 +33,7 @@ class TestSSOCLI(CLITestCase):
         """
         pass
 
-    @stubbed
+    @stubbed()
     def test_sso_ipa_cli(self):
         """@test: IPA user can login to CLI
 
@@ -48,7 +48,7 @@ class TestSSOCLI(CLITestCase):
         """
         pass
 
-    @stubbed
+    @stubbed()
     def test_sso_openldap_cli(self):
         """@test: OpenLDAP user can login to CLI
 

--- a/tests/foreman/cli/test_system_registration.py
+++ b/tests/foreman/cli/test_system_registration.py
@@ -6,7 +6,7 @@ from robottelo.common.decorators import stubbed
 class SystemRegistrationTestCase(CLITestCase):
     """Tests for System Registration CLI"""
 
-    @stubbed
+    @stubbed()
     def test_rpm_install(self):
         """@test: rpm can be retrieved
 
@@ -21,7 +21,7 @@ class SystemRegistrationTestCase(CLITestCase):
 
         """
 
-    @stubbed
+    @stubbed()
     def test_register_no_activation_key(self):
         """@test: register system to sat without activation key
 
@@ -33,7 +33,7 @@ class SystemRegistrationTestCase(CLITestCase):
 
         """
 
-    @stubbed
+    @stubbed()
     def test_register_with_activation_key(self):
         """@test: register system with activation key
 
@@ -46,7 +46,7 @@ class SystemRegistrationTestCase(CLITestCase):
 
         """
 
-    @stubbed
+    @stubbed()
     def test_cannot_register_twice_negative(self):
         """@test: Attempt to register a system twice to an instance
 
@@ -58,7 +58,7 @@ class SystemRegistrationTestCase(CLITestCase):
 
         """
 
-    @stubbed
+    @stubbed()
     def test_registered_systems_pull_content(self):
         # variations:  RH rpms/errata; custom content repos
         """@test: assure RH RPM content can be installed
@@ -71,7 +71,7 @@ class SystemRegistrationTestCase(CLITestCase):
 
         """
 
-    @stubbed
+    @stubbed()
     def test_registered_system_can_be_listed_cli(self):
         """@test: perform a system list for a given org
 
@@ -83,7 +83,7 @@ class SystemRegistrationTestCase(CLITestCase):
 
         """
 
-    @stubbed
+    @stubbed()
     def test_system_deregister_cli(self):
         """@test: deregister/delete system via RHSM
 
@@ -96,7 +96,7 @@ class SystemRegistrationTestCase(CLITestCase):
 
         """
 
-    @stubbed
+    @stubbed()
     def test_deregistered_system_cannot_pull_content(self):
         """@test: try and retrieve content (via yum, etc.) after system has
         been removed from sat

--- a/tests/foreman/installer/test_installer.py
+++ b/tests/foreman/installer/test_installer.py
@@ -91,7 +91,7 @@ class InstallerTestCase(unittest.TestCase):
                                                          logfile['path'],
                                                          ''.join(result)))
 
-    @stubbed
+    @stubbed()
     def test_installer_check_progress_meter(self):
         """
         @test:  Assure progress indicator/meter "works"
@@ -101,7 +101,7 @@ class InstallerTestCase(unittest.TestCase):
         @status: Manual
         """
 
-    @stubbed
+    @stubbed()
     def test_installer_from_iso(self):
         """
         @test:  Can install product from ISO
@@ -110,7 +110,7 @@ class InstallerTestCase(unittest.TestCase):
         @status: Manual
         """
 
-    @stubbed
+    @stubbed()
     def test_installer_server_install(self):
         """
         @test:  Can install main satellite instance successfully via RPM
@@ -119,7 +119,7 @@ class InstallerTestCase(unittest.TestCase):
         @status: Manual
         """
 
-    @stubbed
+    @stubbed()
     def test_installer_node_install(self):
         """
         @test:  Can install node successfully via RPM
@@ -128,7 +128,7 @@ class InstallerTestCase(unittest.TestCase):
         @status: Manual
         """
 
-    @stubbed
+    @stubbed()
     def test_installer_capsule_install(self):
         """
         @test:  Can install capsule successfully via RPM
@@ -137,7 +137,7 @@ class InstallerTestCase(unittest.TestCase):
         @status: Manual
         """
 
-    @stubbed
+    @stubbed()
     def test_installer_disconnected_util_install(self):
         """
         @test: Can install  satellite disconnected utility successfully via
@@ -147,7 +147,7 @@ class InstallerTestCase(unittest.TestCase):
         @status: Manual
         """
 
-    @stubbed
+    @stubbed()
     def test_installer_capsule_registers(self):
         """
         @test: Upon installation, capsule instance self-registers itself to
@@ -158,7 +158,7 @@ class InstallerTestCase(unittest.TestCase):
         @status: Manual
         """
 
-    @stubbed
+    @stubbed()
     def test_installer_clear_data(self):
         """
         @test:  User can run installer to clear existing data

--- a/tests/foreman/ui/test_activationkey.py
+++ b/tests/foreman/ui/test_activationkey.py
@@ -1036,7 +1036,7 @@ class ActivationKey(UITestCase):
             vm1.destroy()
             vm2.destroy()
 
-    @stubbed
+    @stubbed()
     def test_associate_host(self):
         """@Test: Test that hosts can be associated to Activation Keys
 
@@ -1219,7 +1219,7 @@ class ActivationKey(UITestCase):
                                  (common_locators["alert.success"]))
 
     @skip_if_bug_open('bugzilla', 1078676)
-    @stubbed
+    @stubbed()
     def test_delete_manifest(self):
         """@Test: Check if deleting a manifest removes it from Activation key
 
@@ -1329,7 +1329,7 @@ class ActivationKey(UITestCase):
 
     @run_only_on('sat')
     @skip_if_bug_open('bugzilla', 1078676)
-    @stubbed
+    @stubbed()
     def test_end_to_end_activation_key(self):
         """@Test: Create Activation key and provision content-host with it
 

--- a/tests/foreman/ui/test_contentviews.py
+++ b/tests/foreman/ui/test_contentviews.py
@@ -410,7 +410,7 @@ class TestContentViewsUI(UITestCase):
             self.assertIsNotNone(self.content_views.wait_until_element
                                  (common_locators["alert.error"]))
 
-    @stubbed
+    @stubbed()
     def test_cv_edit_rh_custom_spin(self):
         # Variations might be:
         #   * A filter on errata date (only content that matches date
@@ -559,7 +559,7 @@ class TestContentViewsUI(UITestCase):
             self.assertIsNotNone(self.content_views.wait_until_element
                                  (common_locators["alert.success"]))
 
-    @stubbed
+    @stubbed()
     def test_associate_view_rh_custom_spin(self):
         # Variations might be:
         #   * A filter on errata date (only content that matches date
@@ -679,7 +679,7 @@ class TestContentViewsUI(UITestCase):
                              "Couldn't find repo '%s'"
                              "to add into CV" % repo_name)
 
-    @stubbed
+    @stubbed()
     def test_cv_associate_composite_dupe_modules_negative(self):
         """@test: attempt to associate duplicate puppet module(s) within a
         content view
@@ -738,7 +738,7 @@ class TestContentViewsUI(UITestCase):
             self.assertIsNotNone(self.content_views.wait_until_element
                                  (common_locators["alert.success"]))
 
-    @stubbed
+    @stubbed()
     def test_cv_promote_rh_custom_spin(self):
         """@test: attempt to promote a content view containing a custom RH
         spin - i.e., contains filters.
@@ -787,7 +787,7 @@ class TestContentViewsUI(UITestCase):
             self.assertIsNotNone(self.content_views.wait_until_element
                                  (common_locators["alert.success"]))
 
-    @stubbed
+    @stubbed()
     def test_cv_promote_composite(self):
         # Variations:
         # RHEL, custom content (i.e., google repos), puppet modules
@@ -807,7 +807,7 @@ class TestContentViewsUI(UITestCase):
 
         """
 
-    @stubbed
+    @stubbed()
     def test_cv_promote_default_negative(self):
         """@test: attempt to promote a the default content views
 
@@ -854,7 +854,7 @@ class TestContentViewsUI(UITestCase):
             self.assertIsNotNone(self.content_views.wait_until_element
                                  (common_locators["alert.success"]))
 
-    @stubbed
+    @stubbed()
     def test_cv_publish_rh_custom_spin(self):
         """@test: attempt to publish  a content view containing a custom RH
         spin - i.e., contains filters.
@@ -900,7 +900,7 @@ class TestContentViewsUI(UITestCase):
             self.assertIsNotNone(self.content_views.wait_until_element
                                  (common_locators["alert.success"]))
 
-    @stubbed
+    @stubbed()
     def test_cv_publish_composite(self):
         # Variations:
         # RHEL, custom content (i.e., google repos), puppet modules
@@ -918,7 +918,7 @@ class TestContentViewsUI(UITestCase):
 
         """
 
-    @stubbed
+    @stubbed()
     def test_cv_publish_version_changes_in_target_env(self):
         # Dev notes:
         # If Dev has version x, then when I promote version y into
@@ -942,7 +942,7 @@ class TestContentViewsUI(UITestCase):
 
         """
 
-    @stubbed
+    @stubbed()
     def test_cv_publish_version_changes_in_source_env(self):
         # Dev notes:
         # Similarly when I publish version y, version x goes away from
@@ -965,7 +965,7 @@ class TestContentViewsUI(UITestCase):
 
         """
 
-    @stubbed
+    @stubbed()
     def test_cv_clone_within_same_env(self):
         # Dev note: "not implemented yet"
         """@test: attempt to create new content view based on existing
@@ -979,7 +979,7 @@ class TestContentViewsUI(UITestCase):
 
         """
 
-    @stubbed
+    @stubbed()
     def test_cv_clone_within_diff_env(self):
         # Dev note: "not implemented yet"
         """@test: attempt to create new content view based on existing
@@ -993,7 +993,7 @@ class TestContentViewsUI(UITestCase):
 
         """
 
-    @stubbed
+    @stubbed()
     def test_cv_refresh_errata_to_new_view_in_same_env(self):
         """@test: attempt to refresh errata in a new view, based on
         an existing view, from within the same  environment
@@ -1006,7 +1006,7 @@ class TestContentViewsUI(UITestCase):
 
         """
 
-    @stubbed
+    @stubbed()
     def test_cv_subscribe_system(self):
         # Notes:
         # this should be limited to only those content views
@@ -1028,7 +1028,7 @@ class TestContentViewsUI(UITestCase):
 
         """
 
-    @stubbed
+    @stubbed()
     def test_cv_dynflow_restart_promote(self):
         """@test: attempt to restart a promotion
 
@@ -1044,7 +1044,7 @@ class TestContentViewsUI(UITestCase):
 
         """
 
-    @stubbed
+    @stubbed()
     def test_cv_dynflow_restart_publish(self):
         """@test: attempt to restart a publish
 
@@ -1063,7 +1063,7 @@ class TestContentViewsUI(UITestCase):
     # ROLES TESTING
     # All this stuff is speculative at best.
 
-    @stubbed
+    @stubbed()
     def test_cv_roles_admin_user(self):
         # Note:
         # Obviously all of this stuff should work with 'admin' user
@@ -1086,7 +1086,7 @@ class TestContentViewsUI(UITestCase):
 
         """
 
-    @stubbed
+    @stubbed()
     def test_cv_roles_readonly_user(self):
         # Note:
         # Obviously all of this stuff should work with 'admin' user
@@ -1110,7 +1110,7 @@ class TestContentViewsUI(UITestCase):
 
         """
 
-    @stubbed
+    @stubbed()
     def test_cv_roles_admin_user_negative(self):
         # Note:
         # Obviously all of this stuff should work with 'admin' user
@@ -1133,7 +1133,7 @@ class TestContentViewsUI(UITestCase):
 
         """
 
-    @stubbed
+    @stubbed()
     def test_cv_roles_readonly_user_negative(self):
         # Note:
         # Obviously all of this stuff should work with 'admin' user

--- a/tests/foreman/ui/test_email.py
+++ b/tests/foreman/ui/test_email.py
@@ -7,7 +7,7 @@ from robottelo.test import UITestCase
 class EmailTestCase(UITestCase):
     """UI Tests for the email notification feature"""
 
-    @stubbed
+    @stubbed()
     def test_email_preference(self):
         """@Test: Manage user email notification preferences
 
@@ -27,7 +27,7 @@ class EmailTestCase(UITestCase):
 
         """
 
-    @stubbed
+    @stubbed()
     def test_email_sync_1(self):
         """@Test: Receive email after every sync operation
 
@@ -45,7 +45,7 @@ class EmailTestCase(UITestCase):
 
         """
 
-    @stubbed
+    @stubbed()
     def test_email_sync_2(self):
         """@Test: Do not receive email after every sync operation
 
@@ -63,7 +63,7 @@ class EmailTestCase(UITestCase):
 
         """
 
-    @stubbed
+    @stubbed()
     def test_email_promote_1(self):
         """@Test: Receive email after every promote operation
 
@@ -81,7 +81,7 @@ class EmailTestCase(UITestCase):
 
         """
 
-    @stubbed
+    @stubbed()
     def test_email_promote_2(self):
         """@Test: Do not receive email after every promote operation
 
@@ -99,7 +99,7 @@ class EmailTestCase(UITestCase):
 
         """
 
-    @stubbed
+    @stubbed()
     def test_email_host_1(self):
         """@Test: Receive daily email with host advisory information
 
@@ -117,7 +117,7 @@ class EmailTestCase(UITestCase):
 
         """
 
-    @stubbed
+    @stubbed()
     def test_email_host_2(self):
         """@Test: Receive weekly email with host advisory information
 
@@ -135,7 +135,7 @@ class EmailTestCase(UITestCase):
 
         """
 
-    @stubbed
+    @stubbed()
     def test_email_host_3(self):
         """@Test: Receive monthly email with host advisory information
 
@@ -153,7 +153,7 @@ class EmailTestCase(UITestCase):
 
         """
 
-    @stubbed
+    @stubbed()
     def test_email_host_4(self):
         """@Test: Receive no email with host advisory information
 
@@ -171,7 +171,7 @@ class EmailTestCase(UITestCase):
 
         """
 
-    @stubbed
+    @stubbed()
     def test_email_puppet_error_1(self):
         """@Test: Receive email after puppet error
 
@@ -189,7 +189,7 @@ class EmailTestCase(UITestCase):
 
         """
 
-    @stubbed
+    @stubbed()
     def test_email_puppet_error_2(self):
         """@Test: Do not receive email after puppet error
 
@@ -207,7 +207,7 @@ class EmailTestCase(UITestCase):
 
         """
 
-    @stubbed
+    @stubbed()
     def test_email_permission_1(self):
         """@Test: Receive 'Katello Sync Errata' notifications - only for
         repositories and content views that the user has view access to
@@ -233,7 +233,7 @@ class EmailTestCase(UITestCase):
 
         """
 
-    @stubbed
+    @stubbed()
     def test_email_permission_2(self):
         """@Test: Receive 'Katello Promote Errata' notifications - only for
         repositories and content views that the user has view access to
@@ -259,7 +259,7 @@ class EmailTestCase(UITestCase):
 
         """
 
-    @stubbed
+    @stubbed()
     def test_email_permission_3(self):
         """@Test: Receive 'Katello Host Advisory' notifications - only for
         repositories and content views that the user has view access to
@@ -284,7 +284,7 @@ class EmailTestCase(UITestCase):
 
         """
 
-    @stubbed
+    @stubbed()
     def test_email_permission_4(self):
         """@Test: Receive 'Katello Host Advisory' notifications - only for
         content hosts that the user has view access to

--- a/tests/foreman/ui/test_errata.py
+++ b/tests/foreman/ui/test_errata.py
@@ -7,7 +7,7 @@ from robottelo.test import UITestCase
 class ErrataTestCase(UITestCase):
     """UI Tests for the errata management feature"""
 
-    @stubbed
+    @stubbed()
     def test_errata_sort(self):
         """@Test: Sort the columns of Errata page
 
@@ -26,7 +26,7 @@ class ErrataTestCase(UITestCase):
 
         """
 
-    @stubbed
+    @stubbed()
     def test_errata_list(self):
         """@Test: View all errata in an Org
 
@@ -45,7 +45,7 @@ class ErrataTestCase(UITestCase):
 
         """
 
-    @stubbed
+    @stubbed()
     def test_errata_list_permission(self):
         """@Test: Show errata only if the User has permissions to view them
 
@@ -68,7 +68,7 @@ class ErrataTestCase(UITestCase):
 
         """
 
-    @stubbed
+    @stubbed()
     def test_apply_errata_1(self):
         """@Test: Apply an erratum for selected content hosts
 
@@ -88,7 +88,7 @@ class ErrataTestCase(UITestCase):
 
         """
 
-    @stubbed
+    @stubbed()
     def test_apply_errata_2(self):
         """@Test: Apply an erratum for all content hosts
 
@@ -107,7 +107,7 @@ class ErrataTestCase(UITestCase):
 
         """
 
-    @stubbed
+    @stubbed()
     def test_view_errata_1(self):
         """@Test: View erratum similar to RH Customer portal
 
@@ -126,7 +126,7 @@ class ErrataTestCase(UITestCase):
 
         """
 
-    @stubbed
+    @stubbed()
     def test_view_errata_2(self):
         """@Test: View erratum details similar to RH Customer portal
 
@@ -146,7 +146,7 @@ class ErrataTestCase(UITestCase):
 
         """
 
-    @stubbed
+    @stubbed()
     def test_view_errata_3(self):
         """@Test: View a list of products/repositories for an erratum
 
@@ -164,7 +164,7 @@ class ErrataTestCase(UITestCase):
 
         """
 
-    @stubbed
+    @stubbed()
     def test_view_errata_4(self):
         """@Test: View CVE number(s) in Errata Details page
 
@@ -186,7 +186,7 @@ class ErrataTestCase(UITestCase):
 
         """
 
-    @stubbed
+    @stubbed()
     def test_view_errata_5(self):
         """@Test: Filter Content hosts by environment
 
@@ -205,7 +205,7 @@ class ErrataTestCase(UITestCase):
 
         """
 
-    @stubbed
+    @stubbed()
     def test_search_errata_1(self):
         """@Test: Check if autocomplete works in search field of Errata page
 
@@ -223,7 +223,7 @@ class ErrataTestCase(UITestCase):
 
         """
 
-    @stubbed
+    @stubbed()
     def test_search_errata_2(self):
         """@Test: Check if all the errata searches are redirected to the new
         errata page
@@ -251,7 +251,7 @@ class ErrataTestCase(UITestCase):
 
         """
 
-    @stubbed
+    @stubbed()
     def test_errata_content_host_1(self):
         """@Test: Check if the applicable errata are available from the content
         host's previous environment
@@ -274,7 +274,7 @@ class ErrataTestCase(UITestCase):
 
         """
 
-    @stubbed
+    @stubbed()
     def test_errata_content_host_2(self):
         """@Test: Check if the applicable errata are available from the content
         host's Library
@@ -297,7 +297,7 @@ class ErrataTestCase(UITestCase):
 
         """
 
-    @stubbed
+    @stubbed()
     def test_errata_content_host_3(self):
         """@Test: Available errata count displayed in Content hosts page
 
@@ -325,7 +325,7 @@ class ErrataTestCase(UITestCase):
 
         """
 
-    @stubbed
+    @stubbed()
     def test_errata_content_host_4(self):
         """@Test: Errata count on Content host Details page
 
@@ -351,7 +351,7 @@ class ErrataTestCase(UITestCase):
 
         """
 
-    @stubbed
+    @stubbed()
     def test_incremental_update_1(self):
         """@Test: Update composite content views and environments with new
         point releases

--- a/tests/foreman/ui/test_gpgkey.py
+++ b/tests/foreman/ui/test_gpgkey.py
@@ -357,7 +357,7 @@ class GPGKey(UITestCase):
                             (common_locators["alert.error"]))
             self.assertIsNone(self.gpgkey.search(new_name))
 
-    @stubbed
+    @stubbed()
     @data("""DATADRIVENGOESHERE
         name is alpha
         name is numeric
@@ -381,7 +381,7 @@ class GPGKey(UITestCase):
 
         pass
 
-    @stubbed
+    @stubbed()
     @data("""DATADRIVENGOESHERE
         name is alpha
         name is numeric
@@ -405,7 +405,7 @@ class GPGKey(UITestCase):
 
         pass
 
-    @stubbed
+    @stubbed()
     @data("""DATADRIVENGOESHERE
         name is alpha
         name is numeric
@@ -429,7 +429,7 @@ class GPGKey(UITestCase):
 
         pass
 
-    @stubbed
+    @stubbed()
     @data("""DATADRIVENGOESHERE
         name is alpha
         name is numeric
@@ -452,7 +452,7 @@ class GPGKey(UITestCase):
 
         pass
 
-    @stubbed
+    @stubbed()
     @data("""DATADRIVENGOESHERE
         name is alpha
         name is numeric
@@ -475,7 +475,7 @@ class GPGKey(UITestCase):
 
         pass
 
-    @stubbed
+    @stubbed()
     @data("""DATADRIVENGOESHERE
         name is alpha
         name is numeric
@@ -759,7 +759,7 @@ class GPGKeyProductAssociate(UITestCase):
                                  (name, product=False))
 
     @skip_if_bug_open('bugzilla', 1085924)
-    @stubbed
+    @stubbed()
     @data("""DATADRIVENGOESHERE
         name is alpha
         name is numeric
@@ -1083,7 +1083,7 @@ class GPGKeyProductAssociate(UITestCase):
                                  (new_name, product=False))
 
     @skip_if_bug_open('bugzilla', 1085924)
-    @stubbed
+    @stubbed()
     @data("""DATADRIVENGOESHERE
         name is alpha
         name is numeric
@@ -1399,7 +1399,7 @@ class GPGKeyProductAssociate(UITestCase):
                               (name, product_name, repository_1_name))
 
     @skip_if_bug_open('bugzilla', 1085924)
-    @stubbed
+    @stubbed()
     @data("""DATADRIVENGOESHERE
         name is alpha
         name is numeric

--- a/tests/foreman/ui/test_host_system_unification.py
+++ b/tests/foreman/ui/test_host_system_unification.py
@@ -16,7 +16,7 @@ class TestHostSystemUnificationUI(UITestCase):
     # (the link/join will) "Most likely an internal UUID, not something
     # fuzzy like hostname"
 
-    @stubbed
+    @stubbed()
     def test_katello_host_in_foreman(self):
         """@test: Hosts registered to Katello via rhsm appear in foreman
 
@@ -34,7 +34,7 @@ class TestHostSystemUnificationUI(UITestCase):
         """
         pass
 
-    @stubbed
+    @stubbed()
     def test_foreman_host_in_katello(self):
         """@test: Hosts provisioned in foreman via appear in katello
 
@@ -52,7 +52,7 @@ class TestHostSystemUnificationUI(UITestCase):
         """
         pass
 
-    @stubbed
+    @stubbed()
     def test_renamed_host_foreman(self):
         """@test: Hosts renamed in foreman appear in katello
 
@@ -70,7 +70,7 @@ class TestHostSystemUnificationUI(UITestCase):
         """
         pass
 
-    @stubbed
+    @stubbed()
     def test_renamed_host_katello(self):
         """@test: Hosts renamed in katello via appear in foreman
 
@@ -88,7 +88,7 @@ class TestHostSystemUnificationUI(UITestCase):
         """
         pass
 
-    @stubbed
+    @stubbed()
     def test_deleted_host_foreman(self):
         """@test: Hosts delete in foreman disappear from both sides of UI
 
@@ -106,7 +106,7 @@ class TestHostSystemUnificationUI(UITestCase):
         """
         pass
 
-    @stubbed
+    @stubbed()
     def test_deleted_host_katello(self):
         """@test: Hosts delete in katello disappear from both sides of UI
 

--- a/tests/foreman/ui/test_myaccount.py
+++ b/tests/foreman/ui/test_myaccount.py
@@ -18,7 +18,7 @@ class MyAccount(UITestCase):
 
     """
 
-    @stubbed
+    @stubbed()
     def test_positive_update_my_account_1(self):
         """@Test: Update Firstname in My Account
 
@@ -34,7 +34,7 @@ class MyAccount(UITestCase):
         """
         pass
 
-    @stubbed
+    @stubbed()
     def test_positive_update_my_account_2(self):
         """@Test: Update Surname in My Account
 
@@ -50,7 +50,7 @@ class MyAccount(UITestCase):
         """
         pass
 
-    @stubbed
+    @stubbed()
     def test_positive_update_my_account_3(self):
         """@Test: Update Email Address in My Account
 
@@ -66,7 +66,7 @@ class MyAccount(UITestCase):
         """
         pass
 
-    @stubbed
+    @stubbed()
     def test_positive_update_my_account_4(self):
         """@Test: Update Language in My Account
 
@@ -82,7 +82,7 @@ class MyAccount(UITestCase):
         """
         pass
 
-    @stubbed
+    @stubbed()
     def test_positive_update_my_account_5(self):
         """@Test: Update Password/Verify fields in My Account
 
@@ -98,7 +98,7 @@ class MyAccount(UITestCase):
         """
         pass
 
-    @stubbed
+    @stubbed()
     def test_negative_update_my_account_1(self):
         """@Test: Update My Account with invalid FirstName
 
@@ -114,7 +114,7 @@ class MyAccount(UITestCase):
         """
         pass
 
-    @stubbed
+    @stubbed()
     def test_negative_update_my_account_2(self):
         """@Test: Update My Account with invalid Surname
 
@@ -130,7 +130,7 @@ class MyAccount(UITestCase):
         """
         pass
 
-    @stubbed
+    @stubbed()
     def test_negative_update_my_account_3(self):
         """@Test: Update My Account with invalid Email Address
 
@@ -146,7 +146,7 @@ class MyAccount(UITestCase):
         """
         pass
 
-    @stubbed
+    @stubbed()
     def test_negative_update_my_account_4(self):
         """@Test: Update My Account with invalid Password/Verify fields
 
@@ -163,7 +163,7 @@ class MyAccount(UITestCase):
         """
         pass
 
-    @stubbed
+    @stubbed()
     def test_negative_update_my_account_5(self):
         """@Test: Update My Account with non-matching values in Password and
         verify fields
@@ -181,7 +181,7 @@ class MyAccount(UITestCase):
         """
         pass
 
-    @stubbed
+    @stubbed()
     def test_negative_update_my_account_6(self):
         """@Test: [UI ONLY] Attempt to update all info in My Accounts page and
         Cancel

--- a/tests/foreman/ui/test_org.py
+++ b/tests/foreman/ui/test_org.py
@@ -497,7 +497,7 @@ class Org(UITestCase):
             self.assertIsNotNone(element)
 
     @run_only_on('sat')
-    @stubbed
+    @stubbed()
     @data("""DATADRIVENGOESHERE
         smartproxy name is alpha
         smartproxy name is numeric
@@ -812,7 +812,7 @@ class Org(UITestCase):
             self.assertIsNotNone(element)
 
     @run_only_on('sat')
-    @stubbed
+    @stubbed()
     @data("""DATADRIVENGOESHERE
         smartproxy name is alpha
         smartproxy name is numeric

--- a/tests/foreman/ui/test_sso.py
+++ b/tests/foreman/ui/test_sso.py
@@ -17,7 +17,7 @@ class TestSSOUI(UITestCase):
     # possibly other LDAP types. These (in particular, the LDAP variations)
     # can be easily added later.
 
-    @stubbed
+    @stubbed()
     def test_sso_kerberos_basic_no_roles(self):
         """@test: SSO - kerberos login (basic) that has no rights
 
@@ -35,7 +35,7 @@ class TestSSOUI(UITestCase):
 
         """
 
-    @stubbed
+    @stubbed()
     def test_sso_kerberos_basic_roles(self):
         """@test: SSO - kerberos login (basic) that has rights assigned
 
@@ -53,7 +53,7 @@ class TestSSOUI(UITestCase):
 
         """
 
-    @stubbed
+    @stubbed()
     def test_sso_kerberos_user_disabled(self):
         """@test: Kerberos user activity when kerb account has been deleted or
         deactivated
@@ -71,7 +71,7 @@ class TestSSOUI(UITestCase):
 
         """
 
-    @stubbed
+    @stubbed()
     def test_sso_ipa_basic_no_roles(self):
         """@test: Login with LDAP - IPA for user with no roles/rights
 
@@ -89,7 +89,7 @@ class TestSSOUI(UITestCase):
 
         """
 
-    @stubbed
+    @stubbed()
     def test_sso_ipa_basic_roles(self):
         """@test: Login with LDAP - IPA for user with roles/rights
 
@@ -107,7 +107,7 @@ class TestSSOUI(UITestCase):
 
         """
 
-    @stubbed
+    @stubbed()
     def test_sso_ipa_user_disabled(self):
         """@test: LDAP - IPA user activity when IPA account has been deleted
         or deactivated
@@ -125,7 +125,7 @@ class TestSSOUI(UITestCase):
 
         """
 
-    @stubbed
+    @stubbed()
     def test_sso_openldap_basic_no_roles(self):
         """@test: Login with LDAP - OpenLDAP that has no roles / rights
 
@@ -143,7 +143,7 @@ class TestSSOUI(UITestCase):
 
         """
 
-    @stubbed
+    @stubbed()
     def test_sso_openldap_basic_roles(self):
         """@test: Login with LDAP - OpenLDAP for user with roles/rights assigned
 
@@ -161,7 +161,7 @@ class TestSSOUI(UITestCase):
 
         """
 
-    @stubbed
+    @stubbed()
     def test_sso_openldap_user_disabled(self):
         """@test: LDAP - OpenLDAP user activity when OpenLDAP account has been
         deleted or deactivated
@@ -179,7 +179,7 @@ class TestSSOUI(UITestCase):
 
         """
 
-    @stubbed
+    @stubbed()
     def test_sso_multiple_ldap_backends(self):
         """@test: SSO - multiple LDAP servers kafo instance
 
@@ -199,7 +199,7 @@ class TestSSOUI(UITestCase):
 
         """
 
-    @stubbed
+    @stubbed()
     def test_sso_multiple_ldap_namespace_collision(self):
         # devnote:
         # users have auth_source which could distinguish them, but validation
@@ -222,7 +222,7 @@ class TestSSOUI(UITestCase):
 
         """
 
-    @stubbed
+    @stubbed()
     def test_sso_ldap_user_named_admin(self):
         # devnote:
         # shouldn't be a problem since admin from internal DB will be used at
@@ -243,7 +243,7 @@ class TestSSOUI(UITestCase):
 
         """
 
-    @stubbed
+    @stubbed()
     def test_sso_ldap_server_down_before_session(self):
         """@test: SSO - what happens when we have an ldap server that goes down
         before logging in?
@@ -260,7 +260,7 @@ class TestSSOUI(UITestCase):
 
         """
 
-    @stubbed
+    @stubbed()
     def test_sso_ldap_server_down_during_session(self):
         """@test: SSO - what happens when we have an ldap server that goes down
         after login?
@@ -278,7 +278,7 @@ class TestSSOUI(UITestCase):
 
         """
 
-    @stubbed
+    @stubbed()
     def test_sso_usergroup_roles_read(self):
         """@test: Usergroups: group roles get pushed down to user
 
@@ -297,7 +297,7 @@ class TestSSOUI(UITestCase):
 
         """
 
-    @stubbed
+    @stubbed()
     def test_sso_usergroup_roles_update(self):
         """@test: Usergroups: added usergroup roles get pushed down to user
 
@@ -316,7 +316,7 @@ class TestSSOUI(UITestCase):
 
         """
 
-    @stubbed
+    @stubbed()
     def test_sso_usergroup_roles_delete(self):
         """@test: Usergroups: deleted usergroup roles get pushed down to user
 
@@ -335,7 +335,7 @@ class TestSSOUI(UITestCase):
 
         """
 
-    @stubbed
+    @stubbed()
     def test_sso_usergroup_additional_user_roles(self):
         """@test: Assure that user has roles/can access feature areas for
         additional roles assigned outside any roles assigned by his group
@@ -358,7 +358,7 @@ class TestSSOUI(UITestCase):
 
         """
 
-    @stubbed
+    @stubbed()
     def test_sso_usergroup_user_add(self):
         """@test: Usergroups: new user added to usegroup inherits roles
 

--- a/tests/foreman/ui/test_system_registration.py
+++ b/tests/foreman/ui/test_system_registration.py
@@ -6,7 +6,7 @@ from robottelo.common.decorators import stubbed
 class SystemRegistrationTestCase(UITestCase):
     """Tests for System Registration UI"""
 
-    @stubbed
+    @stubbed()
     def test_registered_system_get_pushed_content(self):
         # variations: content types - RH rpms/errata; custom content rpms;
         # puppet modules
@@ -20,7 +20,7 @@ class SystemRegistrationTestCase(UITestCase):
 
         """
 
-    @stubbed
+    @stubbed()
     def test_registered_system_can_be_listed_ui(self):
         """@test: perform a system list for a given org
 
@@ -32,7 +32,7 @@ class SystemRegistrationTestCase(UITestCase):
 
         """
 
-    @stubbed
+    @stubbed()
     def test_system_deregister_ui(self):
         """@test: delete system via Systems UI
 
@@ -44,7 +44,7 @@ class SystemRegistrationTestCase(UITestCase):
 
         """
 
-    @stubbed
+    @stubbed()
     def test_compliance_green(self):
         """@test: system with appropriate entitlements for subscriptions
 
@@ -56,7 +56,7 @@ class SystemRegistrationTestCase(UITestCase):
 
         """
 
-    @stubbed
+    @stubbed()
     def test_compliance_red(self):
         """@test: system without appropriate entitlements for subscriptions
 
@@ -68,7 +68,7 @@ class SystemRegistrationTestCase(UITestCase):
 
         """
 
-    @stubbed
+    @stubbed()
     def test_compliance_yellow(self):
         """@test: system with some, but not all, appropriate entitlements for
         subscriptions

--- a/tests/foreman/ui/test_user.py
+++ b/tests/foreman/ui/test_user.py
@@ -187,7 +187,7 @@ class User(UITestCase):
                 ).get_attribute('value')
             )
 
-    @stubbed
+    @stubbed()
     def test_positive_create_user_4(self):
         """@Test: Create User for all variations of Email Address
 
@@ -229,7 +229,7 @@ class User(UITestCase):
                 ).get_attribute('value')
             )
 
-    @stubbed
+    @stubbed()
     def test_positive_create_user_6(self):
         """@Test: Create User by choosing Authorized by - INTERNAL
 
@@ -268,7 +268,7 @@ class User(UITestCase):
                       password2=password)
             self.assertIsNotNone(self.user.search(name, search_key))
 
-    @stubbed
+    @stubbed()
     def test_positive_create_user_8(self):
         """@Test: Create an Admin user
 
@@ -332,7 +332,7 @@ class User(UITestCase):
                                                         value % role))
                 self.assertIsNotNone(element)
 
-    @stubbed
+    @stubbed()
     def test_positive_create_user_11(self):
         """@Test: Create User and assign all available roles to it
 
@@ -347,7 +347,7 @@ class User(UITestCase):
 
         """
 
-    @stubbed
+    @stubbed()
     def test_positive_create_user_12(self):
         """@Test: Create User with one owned host
 
@@ -362,7 +362,7 @@ class User(UITestCase):
 
         """
 
-    @stubbed
+    @stubbed()
     def test_positive_create_user_13(self):
         """@Test: Create User with mutiple owned hosts
 
@@ -377,7 +377,7 @@ class User(UITestCase):
 
         """
 
-    @stubbed
+    @stubbed()
     def test_positive_create_user_14(self):
         """@Test: Create User with all owned hosts
 
@@ -393,7 +393,7 @@ class User(UITestCase):
         """
 
     @run_only_on('sat')
-    @stubbed
+    @stubbed()
     def test_positive_create_user_15(self):
         """@Test: Create User with one Domain host
 
@@ -409,7 +409,7 @@ class User(UITestCase):
         """
 
     @run_only_on('sat')
-    @stubbed
+    @stubbed()
     def test_positive_create_user_16(self):
         """@Test: Create User with mutiple Domain hosts
 
@@ -425,7 +425,7 @@ class User(UITestCase):
         """
 
     @run_only_on('sat')
-    @stubbed
+    @stubbed()
     def test_positive_create_user_17(self):
         """@Test: Create User with all Domain hosts
 
@@ -441,7 +441,7 @@ class User(UITestCase):
         """
 
     @run_only_on('sat')
-    @stubbed
+    @stubbed()
     def test_positive_create_user_18(self):
         """@Test: Create User with one Compute Resource
 
@@ -457,7 +457,7 @@ class User(UITestCase):
         """
 
     @run_only_on('sat')
-    @stubbed
+    @stubbed()
     def test_positive_create_user_19(self):
         """@Test: Create User with mutiple Compute Resources
 
@@ -473,7 +473,7 @@ class User(UITestCase):
         """
 
     @run_only_on('sat')
-    @stubbed
+    @stubbed()
     def test_positive_create_user_20(self):
         """@Test: Create User with all Compute Resources
 
@@ -489,7 +489,7 @@ class User(UITestCase):
         """
 
     @run_only_on('sat')
-    @stubbed
+    @stubbed()
     def test_positive_create_user_21(self):
         """@Test: Create User with one Host group
 
@@ -505,7 +505,7 @@ class User(UITestCase):
         """
 
     @run_only_on('sat')
-    @stubbed
+    @stubbed()
     def test_positive_create_user_22(self):
         """@Test: Create User with multiple Host groups
 
@@ -521,7 +521,7 @@ class User(UITestCase):
         """
 
     @run_only_on('sat')
-    @stubbed
+    @stubbed()
     def test_positive_create_user_23(self):
         """@Test: Create User with all Host groups
 
@@ -584,7 +584,7 @@ class User(UITestCase):
                                                         value % org_name))
                 self.assertIsNotNone(element)
 
-    @stubbed
+    @stubbed()
     def test_positive_create_user_26(self):
         """@Test: Create User associated to all available Orgs
 
@@ -597,7 +597,7 @@ class User(UITestCase):
         """
 
     @run_only_on('sat')
-    @stubbed
+    @stubbed()
     def test_positive_create_user_27(self):
         """@Test: Create User with a new Fact filter
 
@@ -612,7 +612,7 @@ class User(UITestCase):
 
         """
 
-    @stubbed
+    @stubbed()
     def test_positive_create_user_28(self):
         """@Test: Create User in supported ldap modes
 
@@ -682,7 +682,7 @@ class User(UITestCase):
             option = Select(loc_element).first_selected_option
             self.assertEqual(loc_name, option.text)
 
-    @stubbed
+    @stubbed()
     def test_negative_create_user_1(self):
         """@Test:[UI ONLY] Enter all User creation details and Cancel
 
@@ -755,7 +755,7 @@ class User(UITestCase):
             error = self.user.wait_until_element(common_locators["haserror"])
             self.assertIsNotNone(error)
 
-    @stubbed
+    @stubbed()
     def test_negative_create_user_5(self):
         """@Test: Create User with invalid Email Address
 
@@ -839,7 +839,7 @@ class User(UITestCase):
             self.login.login(new_username, password)
             self.assertTrue(self.login.is_logged())
 
-    @stubbed
+    @stubbed()
     def test_positive_update_user_2(self):
         """@Test: Update Firstname in User
 
@@ -855,7 +855,7 @@ class User(UITestCase):
 
         """
 
-    @stubbed
+    @stubbed()
     def test_positive_update_user_3(self):
         """@Test: Update Surname in User
 
@@ -871,7 +871,7 @@ class User(UITestCase):
 
         """
 
-    @stubbed
+    @stubbed()
     def test_positive_update_user_4(self):
         """@Test: Update Email Address in User
 
@@ -887,7 +887,7 @@ class User(UITestCase):
 
         """
 
-    @stubbed
+    @stubbed()
     def test_positive_update_user_5(self):
         """@Test: Update Language in User
 
@@ -903,7 +903,7 @@ class User(UITestCase):
 
         """
 
-    @stubbed
+    @stubbed()
     def test_positive_update_user_6(self):
         """@Test: Update Password/Verify fields in User
 
@@ -919,7 +919,7 @@ class User(UITestCase):
 
         """
 
-    @stubbed
+    @stubbed()
     def test_positive_update_user_7(self):
         """@Test: Convert an user from an admin user to non-admin user
 
@@ -935,7 +935,7 @@ class User(UITestCase):
 
         """
 
-    @stubbed
+    @stubbed()
     def test_positive_update_user_8(self):
         """@Test: Convert a user to an admin user
 
@@ -951,7 +951,7 @@ class User(UITestCase):
 
         """
 
-    @stubbed
+    @stubbed()
     def test_positive_update_user_9(self):
         """@Test: Update User with one role
 
@@ -967,7 +967,7 @@ class User(UITestCase):
 
         """
 
-    @stubbed
+    @stubbed()
     def test_positive_update_user_10(self):
         """@Test: Update User with multiple roles
 
@@ -983,7 +983,7 @@ class User(UITestCase):
 
         """
 
-    @stubbed
+    @stubbed()
     def test_positive_update_user_11(self):
         """@Test: Update User with all roles
 
@@ -999,7 +999,7 @@ class User(UITestCase):
 
         """
 
-    @stubbed
+    @stubbed()
     def test_positive_update_user_12(self):
         """@Test: Update User with one owned host
 
@@ -1015,7 +1015,7 @@ class User(UITestCase):
 
         """
 
-    @stubbed
+    @stubbed()
     def test_positive_update_user_13(self):
         """@Test: Update User with multiple owned hosts
 
@@ -1031,7 +1031,7 @@ class User(UITestCase):
 
         """
 
-    @stubbed
+    @stubbed()
     def test_positive_update_user_14(self):
         """@Test: Update User with all owned hosts
 
@@ -1048,7 +1048,7 @@ class User(UITestCase):
         """
 
     @run_only_on('sat')
-    @stubbed
+    @stubbed()
     def test_positive_update_user_15(self):
         """@Test: Update User with one Domain host
 
@@ -1065,7 +1065,7 @@ class User(UITestCase):
         """
 
     @run_only_on('sat')
-    @stubbed
+    @stubbed()
     def test_positive_update_user_16(self):
         """@Test: Update User with multiple Domain hosts
 
@@ -1082,7 +1082,7 @@ class User(UITestCase):
         """
 
     @run_only_on('sat')
-    @stubbed
+    @stubbed()
     def test_positive_update_user_17(self):
         """@Test: Update User with all Domain hosts
 
@@ -1099,7 +1099,7 @@ class User(UITestCase):
         """
 
     @run_only_on('sat')
-    @stubbed
+    @stubbed()
     def test_positive_update_user_18(self):
         """@Test: Update User with one Compute Resource
 
@@ -1116,7 +1116,7 @@ class User(UITestCase):
         """
 
     @run_only_on('sat')
-    @stubbed
+    @stubbed()
     def test_positive_update_user_19(self):
         """@Test: Update User with multiple Compute Resources
 
@@ -1133,7 +1133,7 @@ class User(UITestCase):
         """
 
     @run_only_on('sat')
-    @stubbed
+    @stubbed()
     def test_positive_update_user_20(self):
         """@Test: Update User with all Compute Resources
 
@@ -1150,7 +1150,7 @@ class User(UITestCase):
         """
 
     @run_only_on('sat')
-    @stubbed
+    @stubbed()
     def test_positive_update_user_21(self):
         """@Test: Update User with one Host group
 
@@ -1167,7 +1167,7 @@ class User(UITestCase):
         """
 
     @run_only_on('sat')
-    @stubbed
+    @stubbed()
     def test_positive_update_user_22(self):
         """@Test: Update User with multiple Host groups
 
@@ -1184,7 +1184,7 @@ class User(UITestCase):
         """
 
     @run_only_on('sat')
-    @stubbed
+    @stubbed()
     def test_positive_update_user_23(self):
         """@Test: Update User with all Host groups
 
@@ -1200,7 +1200,7 @@ class User(UITestCase):
 
         """
 
-    @stubbed
+    @stubbed()
     def test_positive_update_user_24(self):
         """@Test: Assign a User to an Org
 
@@ -1216,7 +1216,7 @@ class User(UITestCase):
 
         """
 
-    @stubbed
+    @stubbed()
     def test_positive_update_user_25(self):
         """@Test: Assign a User to multiple Orgs
 
@@ -1232,7 +1232,7 @@ class User(UITestCase):
 
         """
 
-    @stubbed
+    @stubbed()
     def test_positive_update_user_26(self):
         """@Test: Assign a User to all available Orgs
 
@@ -1249,7 +1249,7 @@ class User(UITestCase):
         """
 
     @run_only_on('sat')
-    @stubbed
+    @stubbed()
     def test_positive_update_user_28(self):
         """@Test: Update User with a new Fact filter
 
@@ -1265,7 +1265,7 @@ class User(UITestCase):
 
         """
 
-    @stubbed
+    @stubbed()
     def test_negative_update_user_1(self):
         """@Test: Update invalid Username in an User
 
@@ -1281,7 +1281,7 @@ class User(UITestCase):
 
         """
 
-    @stubbed
+    @stubbed()
     def test_negative_update_user_2(self):
         """@Test: Update invalid Firstname in an User
 
@@ -1297,7 +1297,7 @@ class User(UITestCase):
 
         """
 
-    @stubbed
+    @stubbed()
     def test_negative_update_user_3(self):
         """@Test: Update invalid Surname in an User
 
@@ -1313,7 +1313,7 @@ class User(UITestCase):
 
         """
 
-    @stubbed
+    @stubbed()
     def test_negative_update_user_4(self):
         """@Test: Update invalid Email Address in an User
 
@@ -1329,7 +1329,7 @@ class User(UITestCase):
 
         """
 
-    @stubbed
+    @stubbed()
     def test_negative_update_user_5(self):
         """@Test: Update different values in Password and verify fields
 
@@ -1346,7 +1346,7 @@ class User(UITestCase):
 
         """
 
-    @stubbed
+    @stubbed()
     def test_negative_update_user_6(self):
         """@Test: [UI ONLY] Attempt to update User info and Cancel
 
@@ -1363,7 +1363,7 @@ class User(UITestCase):
 
         """
 
-    @stubbed
+    @stubbed()
     def test_positive_delete_user_1(self):
         """@Test: Delete a user
 
@@ -1379,7 +1379,7 @@ class User(UITestCase):
 
         """
 
-    @stubbed
+    @stubbed()
     def test_positive_delete_user_2(self):
         """@Test: Delete an admin user
 
@@ -1395,7 +1395,7 @@ class User(UITestCase):
 
         """
 
-    @stubbed
+    @stubbed()
     def test_negative_delete_user_1(self):
         """@Test: [UI ONLY] Attempt to delete an User and cancel
 
@@ -1411,7 +1411,7 @@ class User(UITestCase):
 
         """
 
-    @stubbed
+    @stubbed()
     def test_negative_delete_user_2(self):
         """@Test: Attempt to delete the last remaining admin user
 
@@ -1428,7 +1428,7 @@ class User(UITestCase):
 
         """
 
-    @stubbed
+    @stubbed()
     def test_list_user_1(self):
         """@Test: List User for all variations of Username
 
@@ -1445,7 +1445,7 @@ class User(UITestCase):
 
         """
 
-    @stubbed
+    @stubbed()
     def test_list_user_2(self):
         """@Test: List User for all variations of Firstname
 
@@ -1462,7 +1462,7 @@ class User(UITestCase):
 
         """
 
-    @stubbed
+    @stubbed()
     def test_list_user_3(self):
         """@Test: List User for all variations of Surname
 
@@ -1479,7 +1479,7 @@ class User(UITestCase):
 
         """
 
-    @stubbed
+    @stubbed()
     def test_list_user_4(self):
         """@Test: List User for all variations of Email Address
 
@@ -1496,7 +1496,7 @@ class User(UITestCase):
 
         """
 
-    @stubbed
+    @stubbed()
     def test_list_user_5(self):
         """@Test: List User for all variations of Language
 
@@ -1513,7 +1513,7 @@ class User(UITestCase):
 
         """
 
-    @stubbed
+    @stubbed()
     def test_search_user_1(self):
         """@Test: Search User for all variations of Username
 
@@ -1530,7 +1530,7 @@ class User(UITestCase):
 
         """
 
-    @stubbed
+    @stubbed()
     def test_search_user_2(self):
         """@Test: Search User for all variations of Firstname
 
@@ -1547,7 +1547,7 @@ class User(UITestCase):
 
         """
 
-    @stubbed
+    @stubbed()
     def test_search_user_3(self):
         """@Test: Search User for all variations of Surname
 
@@ -1564,7 +1564,7 @@ class User(UITestCase):
 
         """
 
-    @stubbed
+    @stubbed()
     def test_search_user_4(self):
         """@Test: Search User for all variations of Email Address
 
@@ -1581,7 +1581,7 @@ class User(UITestCase):
 
         """
 
-    @stubbed
+    @stubbed()
     def test_search_user_5(self):
         """@Test: Search User for all variations of Language
 
@@ -1598,7 +1598,7 @@ class User(UITestCase):
 
         """
 
-    @stubbed
+    @stubbed()
     def test_info_user_1(self):
         """@Test: Get User info for all variations of Username
 
@@ -1615,7 +1615,7 @@ class User(UITestCase):
 
         """
 
-    @stubbed
+    @stubbed()
     def test_info_user_2(self):
         """@Test: Search User for all variations of Firstname
 
@@ -1632,7 +1632,7 @@ class User(UITestCase):
 
         """
 
-    @stubbed
+    @stubbed()
     def test_info_user_3(self):
         """@Test: Search User for all variations of Surname
 
@@ -1649,7 +1649,7 @@ class User(UITestCase):
 
         """
 
-    @stubbed
+    @stubbed()
     def test_info_user_4(self):
         """@Test: Search User for all variations of Email Address
 
@@ -1666,7 +1666,7 @@ class User(UITestCase):
 
         """
 
-    @stubbed
+    @stubbed()
     def test_info_user_5(self):
         """@Test: Search User for all variations of Language
 
@@ -1683,7 +1683,7 @@ class User(UITestCase):
 
         """
 
-    @stubbed
+    @stubbed()
     def test_end_to_end_user_1(self):
         """@Test: Create User and perform different operations
 
@@ -1704,7 +1704,7 @@ class User(UITestCase):
 
         """
 
-    @stubbed
+    @stubbed()
     def test_end_to_end_user_2(self):
         """@Test: Create User with no Org assigned and attempt different
         operations
@@ -1725,7 +1725,7 @@ class User(UITestCase):
 
         """
 
-    @stubbed
+    @stubbed()
     def test_positive_create_bookmark_1(self):
         """@Test: Create a bookmark with default values
 
@@ -1741,7 +1741,7 @@ class User(UITestCase):
 
         """
 
-    @stubbed
+    @stubbed()
     def test_positive_create_bookmark_2(self):
         """@Test: Create a bookmark by altering the default values
 
@@ -1757,7 +1757,7 @@ class User(UITestCase):
 
         """
 
-    @stubbed
+    @stubbed()
     def test_positive_create_bookmark_3(self):
         """@Test: Create a bookmark in public mode
 
@@ -1774,7 +1774,7 @@ class User(UITestCase):
 
         """
 
-    @stubbed
+    @stubbed()
     def test_positive_create_bookmark_4(self):
         """@Test: Create a bookmark in private mode
 
@@ -1791,7 +1791,7 @@ class User(UITestCase):
 
         """
 
-    @stubbed
+    @stubbed()
     def test_negative_create_bookmark_1(self):
         """@Test: Create a bookmark with a blank bookmark name
 
@@ -1807,7 +1807,7 @@ class User(UITestCase):
 
         """
 
-    @stubbed
+    @stubbed()
     def test_negative_create_bookmark_2(self):
         """@Test: Create a bookmark with a blank bookmark query
 


### PR DESCRIPTION
Stubbed expect a string parameter or None. By just calling `@stubbed`
the argument will be the decorated method and not a string. Because this
nosetests will not count those skips and py.test will fail all of them.