### PR TITLE
Skip tests failing due to upstream BZ 1151240 fix

### DIFF
--- a/tests/foreman/api/test_multiple_paths.py
+++ b/tests/foreman/api/test_multiple_paths.py
@@ -416,8 +416,8 @@ class DoubleCheckTestCase(TestCase):
         @Assert: The created entity has the correct attributes.
 
         """
-        if entity in BZ_1151240_ENTITIES and bz_bug_is_open(1151240):
-            self.skipTest("Bugzilla bug 1151240 is open.""")
+        if entity in BZ_1151240_ENTITIES:
+            self.skipTest("Bugzilla bug 1151240 affects the 6.0.x branch.")
         # Generate some attributes and use them to create an entity.
         gen_attrs = entity().build()
         response = client.post(


### PR DESCRIPTION
BZ 1151240 describes an issue wherein the API fails to provide an organization
ID in response to certain requests. This bug has apparently been fixed in
upstream, which causes the relevant tests to run again. However, the bug has not
been fixed in Satellite 6.0.x, so the now-running tests fail. Skip them. No
regression has occurred in the 6.0.x branch, and letting the tests fail gives an
incorrect impression.

    $ nosetests tests/foreman/api/test_multiple_paths.py -m test_post_and_get
    S...SS.S...S..S.
    ----------------------------------------------------------------------
    Ran 16 tests in 13.775s

    OK (SKIP=6)