### PR TITLE
Run tests previous skipped by BZ #1144162

### DIFF
--- a/robottelo/entities.py
+++ b/robottelo/entities.py
@@ -2217,12 +2217,10 @@ class User(
     authentication than to spawn LDAP authentication servers for each new user.
 
     """
-    # Passing UTF8 characters for {first,last}name or login yields errors. See
-    # bugzilla bug 1144162.
     login = entity_fields.StringField(
         length=(1, 100),
         required=True,
-        str_type=('alpha', 'alphanumeric', 'cjk', 'latin1'),
+        str_type=('alpha', 'alphanumeric', 'cjk', 'latin1', 'utf8'),
     )
     admin = entity_fields.BooleanField(null=True)
     auth_source = entity_fields.OneToOneField(

--- a/tests/foreman/api/test_user.py
+++ b/tests/foreman/api/test_user.py
@@ -21,36 +21,24 @@ class UsersTestCase(APITestCase):
     @decorators.data(
         {u'admin': False},
         {u'admin': True},
-        {u'firstname': gen_string(
-            'alphanumeric', randint(1, 50))},
+        {u'firstname': gen_string('alphanumeric', randint(1, 50))},
         {u'firstname': gen_string('alpha', randint(1, 50))},
         {u'firstname': gen_string('cjk', randint(1, 50))},
         {u'firstname': gen_string('latin1', randint(1, 50))},
         {u'firstname': gen_string('numeric', randint(1, 50))},
-        {
-            u'firstname': gen_string('utf8', randint(1, 16)),
-            'bugzilla': 1144162,
-        },
-        {u'lastname': gen_string(
-            'alphanumeric', randint(1, 50))},
+        {u'firstname': gen_string('utf8', randint(1, 16))},
+        {u'lastname': gen_string('alphanumeric', randint(1, 50))},
         {u'lastname': gen_string('alpha', randint(1, 50))},
         {u'lastname': gen_string('cjk', randint(1, 50))},
         {u'lastname': gen_string('latin1', randint(1, 50))},
         {u'lastname': gen_string('numeric', randint(1, 50))},
-        {
-            u'lastname': gen_string('utf8', randint(1, 16)),
-            'bugzilla': 1144162,
-        },
-        {u'login': gen_string(
-            'alphanumeric', randint(1, 100))},
+        {u'lastname': gen_string('utf8', randint(1, 16))},
+        {u'login': gen_string('alphanumeric', randint(1, 100))},
         {u'login': gen_string('alpha', randint(1, 100))},
         {u'login': gen_string('cjk', randint(1, 100))},
         {u'login': gen_string('latin1', randint(1, 100))},
         {u'login': gen_string('numeric', randint(1, 100))},
-        {
-            u'login': gen_string('utf8', randint(1, 33)),
-            'bugzilla': 1144162,
-        },
+        {u'login': gen_string('utf8', randint(1, 33))},
     )
     def test_create(self, attrs):
         """@Test: Create a user with attributes ``attrs`` and delete it.
@@ -60,10 +48,6 @@ class UsersTestCase(APITestCase):
         @Feature: User
 
         """
-        bug_id = attrs.pop('bugzilla', None)
-        if bug_id is not None and decorators.bz_bug_is_open(bug_id):
-            self.skipTest('Bugzilla bug {0} is open.'.format(bug_id))
-
         # Create a user and validate its attributes.
         user_id = entities.User(**attrs).create()['id']
         real_attrs = entities.User(id=user_id).read_json()
@@ -74,36 +58,24 @@ class UsersTestCase(APITestCase):
     @decorators.data(
         {u'admin': False},
         {u'admin': True},
-        {u'firstname': gen_string(
-            'alphanumeric', randint(1, 50))},
+        {u'firstname': gen_string('alphanumeric', randint(1, 50))},
         {u'firstname': gen_string('alpha', randint(1, 50))},
         {u'firstname': gen_string('cjk', randint(1, 50))},
         {u'firstname': gen_string('latin1', randint(1, 50))},
         {u'firstname': gen_string('numeric', randint(1, 50))},
-        {
-            u'firstname': gen_string('utf8', randint(1, 16)),
-            'bugzilla': 1144162,
-        },
-        {u'lastname': gen_string(
-            'alphanumeric', randint(1, 50))},
+        {u'firstname': gen_string('utf8', randint(1, 16))},
+        {u'lastname': gen_string('alphanumeric', randint(1, 50))},
         {u'lastname': gen_string('alpha', randint(1, 50))},
         {u'lastname': gen_string('cjk', randint(1, 50))},
         {u'lastname': gen_string('latin1', randint(1, 50))},
         {u'lastname': gen_string('numeric', randint(1, 50))},
-        {
-            u'lastname': gen_string('utf8', randint(1, 16)),
-            'bugzilla': 1144162,
-        },
-        {u'login': gen_string(
-            'alphanumeric', randint(1, 100))},
+        {u'lastname': gen_string('utf8', randint(1, 16))},
+        {u'login': gen_string('alphanumeric', randint(1, 100))},
         {u'login': gen_string('alpha', randint(1, 100))},
         {u'login': gen_string('cjk', randint(1, 100))},
         {u'login': gen_string('latin1', randint(1, 100))},
         {u'login': gen_string('numeric', randint(1, 100))},
-        {
-            u'login': gen_string('utf8', randint(1, 33)),
-            'bugzilla': 1144162,
-        },
+        {u'login': gen_string('utf8', randint(1, 33))},
     )
     def test_delete(self, attrs):
         """@Test: Create a user with attributes ``attrs`` and delete it.
@@ -113,10 +85,6 @@ class UsersTestCase(APITestCase):
         @Feature: User
 
         """
-        bug_id = attrs.pop('bugzilla', None)
-        if bug_id is not None and decorators.bz_bug_is_open(bug_id):
-            self.skipTest('Bugzilla bug {0} is open.'.format(bug_id))
-
         # Create a user and delete it immediately afterward.
         user_id = entities.User(**attrs).create()['id']
         entities.User(id=user_id).delete()

--- a/tests/foreman/cli/test_user.py
+++ b/tests/foreman/cli/test_user.py
@@ -13,8 +13,7 @@ from ddt import ddt
 from fauxfactory import gen_alphanumeric, gen_string
 from robottelo.cli.factory import CLIFactoryError, make_user, make_role
 from robottelo.cli.user import User as UserObj
-from robottelo.common.decorators import (
-    bz_bug_is_open, data, stubbed)
+from robottelo.common.decorators import data, stubbed
 from robottelo.test import CLITestCase
 
 
@@ -106,10 +105,7 @@ class User(CLITestCase):
 
     @data(
         {'login': gen_string("latin1", 10)},
-        {
-            'login': gen_string("utf8", 10),
-            'bugzilla': 1144162,
-        },
+        {'login': gen_string("utf8", 10)},
         {'login': gen_string("alpha", 10)},
         {'login': gen_string("alphanumeric", 10)},
         {'login': gen_string("numeric", 10)},
@@ -126,13 +122,7 @@ class User(CLITestCase):
 
         @Assert: User is created
 
-        @BZ: 1144162
-
         """
-        bug_id = data.pop('bugzilla', None)
-        if bug_id is not None and bz_bug_is_open(bug_id):
-            self.skipTest('Bugzilla bug {0} is open.'.format(bug_id))
-
         try:
             args = make_user(data)
         except CLIFactoryError as err:
@@ -141,10 +131,7 @@ class User(CLITestCase):
 
     @data(
         {'firstname': gen_string("latin1", 10)},
-        {
-            'firstname': gen_string("utf8", 10),
-            'bugzilla': 1144162,
-        },
+        {'firstname': gen_string("utf8", 10)},
         {'firstname': gen_string("alpha", 10)},
         {'firstname': gen_string("alphanumeric", 10)},
         {'firstname': gen_string("numeric", 10)},
@@ -161,13 +148,7 @@ class User(CLITestCase):
 
         @Assert: User is created
 
-        @BZ: 1144162
-
         """
-        bug_id = data.pop('bugzilla', None)
-        if bug_id is not None and bz_bug_is_open(bug_id):
-            self.skipTest('Bugzilla bug {0} is open.'.format(bug_id))
-
         try:
             args = make_user(data)
         except CLIFactoryError as err:
@@ -176,10 +157,7 @@ class User(CLITestCase):
 
     @data(
         {'lastname': gen_string("latin1", 10)},
-        {
-            'lastname': gen_string("utf8", 10),
-            'bugzilla': 1144162,
-        },
+        {'lastname': gen_string("utf8", 10)},
         {'lastname': gen_string("alpha", 10)},
         {'lastname': gen_string("alphanumeric", 10)},
         {'lastname': gen_string("numeric", 10)},
@@ -196,13 +174,7 @@ class User(CLITestCase):
 
         @Assert: User is created
 
-        @BZ: 1144162
-
         """
-        bug_id = data.pop('bugzilla', None)
-        if bug_id is not None and bz_bug_is_open(bug_id):
-            self.skipTest('Bugzilla bug {0} is open.'.format(bug_id))
-
         try:
             args = make_user(data)
         except CLIFactoryError as err:
@@ -749,10 +721,7 @@ class User(CLITestCase):
 
     @data(
         {'firstname': gen_string("latin1", 10)},
-        {
-            'firstname': gen_string("utf8", 10),
-            'bugzilla': 1144162,
-        },
+        {'firstname': gen_string("utf8", 10)},
         {'firstname': gen_string("alpha", 10)},
         {'firstname': gen_string("alphanumeric", 10)},
         {'firstname': gen_string("numeric", 10)},
@@ -768,13 +737,7 @@ class User(CLITestCase):
 
         @Assert: User is updated
 
-        @BZ: 1144162
-
         """
-        bug_id = test_data.pop('bugzilla', None)
-        if bug_id is not None and bz_bug_is_open(bug_id):
-            self.skipTest('Bugzilla bug {0} is open.'.format(bug_id))
-
         try:
             new_obj = make_user()
         except CLIFactoryError as err:
@@ -805,10 +768,7 @@ class User(CLITestCase):
 
     @data(
         {'login': gen_string("latin1", 10)},
-        {
-            'login': gen_string("utf8", 10),
-            'bugzilla': 1144162,
-        },
+        {'login': gen_string("utf8", 10)},
         {'login': gen_string("alpha", 10)},
         {'login': gen_string("alphanumeric", 10)},
         {'login': gen_string("numeric", 10)},
@@ -825,13 +785,7 @@ class User(CLITestCase):
 
         @Assert: User login is updated
 
-        @BZ: 1144162
-
         """
-        bug_id = test_data.pop('bugzilla', None)
-        if bug_id is not None and bz_bug_is_open(bug_id):
-            self.skipTest('Bugzilla bug {0} is open.'.format(bug_id))
-
         try:
             new_obj = make_user()
         except CLIFactoryError as err:
@@ -861,10 +815,7 @@ class User(CLITestCase):
 
     @data(
         {'lastname': gen_string("latin1", 10)},
-        {
-            'lastname': gen_string("utf8", 10),
-            'bugzilla': 1144162,
-        },
+        {'lastname': gen_string("utf8", 10)},
         {'lastname': gen_string("alpha", 10)},
         {'lastname': gen_string("alphanumeric", 10)},
         {'lastname': gen_string("numeric", 10)},
@@ -880,13 +831,7 @@ class User(CLITestCase):
 
         @Assert: User is updated
 
-        @BZ: 1144162
-
         """
-        bug_id = test_data.pop('bugzilla', None)
-        if bug_id is not None and bz_bug_is_open(bug_id):
-            self.skipTest('Bugzilla bug {0} is open.'.format(bug_id))
-
         try:
             new_obj = make_user()
         except CLIFactoryError as err:
@@ -1467,10 +1412,7 @@ class User(CLITestCase):
 
     @data(
         {'login': gen_string("latin1", 10)},
-        {
-            'login': gen_string("utf8", 10),
-            'bugzilla': 1144162,
-        },
+        {'login': gen_string("utf8", 10)},
         {'login': gen_string("alpha", 10)},
         {'login': gen_string("alphanumeric", 10)},
         {'login': gen_string("numeric", 10)},
@@ -1488,10 +1430,6 @@ class User(CLITestCase):
         @Assert: User is deleted
 
         """
-        bug_id = test_data.pop('bugzilla', None)
-        if bug_id is not None and bz_bug_is_open(bug_id):
-            self.skipTest('Bugzilla bug {0} is open.'.format(bug_id))
-
         try:
             user = make_user(test_data)
         except CLIFactoryError as err:
@@ -1507,10 +1445,7 @@ class User(CLITestCase):
 
     @data(
         {'login': gen_string("latin1", 10)},
-        {
-            'login': gen_string("utf8", 10),
-            'bugzilla': 1144162,
-        },
+        {'login': gen_string("utf8", 10)},
         {'login': gen_string("alpha", 10)},
         {'login': gen_string("alphanumeric", 10)},
         {'login': gen_string("numeric", 10)},
@@ -1528,10 +1463,6 @@ class User(CLITestCase):
         @Assert: User is deleted
 
         """
-        bug_id = test_data.pop('bugzilla', None)
-        if bug_id is not None and bz_bug_is_open(bug_id):
-            self.skipTest('Bugzilla bug {0} is open.'.format(bug_id))
-
         test_data.update({'admin': 'true'})
         try:
             user = make_user(test_data)
@@ -1580,10 +1511,7 @@ class User(CLITestCase):
         {'login': gen_string("alphanumeric", 10)},
         {'login': gen_string("numeric", 10)},
         {'login': gen_string("latin1", 10)},
-        {
-            'login': gen_string("utf8", 10),
-            'bugzilla': 1144162,
-        },
+        {'login': gen_string("utf8", 10)},
         {'login': gen_string("alphanumeric", 100)}
     )
     def test_list_user_1(self, test_data):
@@ -1598,13 +1526,7 @@ class User(CLITestCase):
 
         @Assert: User is listed
 
-        @BZ: 1144162
-
         """
-        bug_id = test_data.pop('bugzilla', None)
-        if bug_id is not None and bz_bug_is_open(bug_id):
-            self.skipTest('Bugzilla bug {0} is open.'.format(bug_id))
-
         try:
             user = make_user(test_data)
         except CLIFactoryError as err:
@@ -1624,10 +1546,7 @@ class User(CLITestCase):
 
     @data(
         {'firstname': gen_string("latin1", 10)},
-        {
-            'firstname': gen_string("utf8", 10),
-            'bugzilla': 1144162,
-        },
+        {'firstname': gen_string("utf8", 10)},
         {'firstname': gen_string("alpha", 10)},
         {'firstname': gen_string("alphanumeric", 10)},
         {'firstname': gen_string("numeric", 10)},
@@ -1645,13 +1564,7 @@ class User(CLITestCase):
 
         @Assert: User is listed
 
-        @BZ: 1144162
-
         """
-        bug_id = test_data.pop('bugzilla', None)
-        if bug_id is not None and bz_bug_is_open(bug_id):
-            self.skipTest('Bugzilla bug {0} is open.'.format(bug_id))
-
         try:
             user = make_user(test_data)
         except CLIFactoryError as err:
@@ -1670,10 +1583,7 @@ class User(CLITestCase):
 
     @data(
         {'lastname': gen_string("latin1", 10)},
-        {
-            'lastname': gen_string("utf8", 10),
-            'bugzilla': 1144162,
-        },
+        {'lastname': gen_string("utf8", 10)},
         {'lastname': gen_string("alpha", 10)},
         {'lastname': gen_string("alphanumeric", 10)},
         {'lastname': gen_string("numeric", 10)},
@@ -1691,13 +1601,7 @@ class User(CLITestCase):
 
         @Assert: User is listed
 
-        @BZ: 1144162
-
         """
-        bug_id = test_data.pop('bugzilla', None)
-        if bug_id is not None and bz_bug_is_open(bug_id):
-            self.skipTest('Bugzilla bug {0} is open.'.format(bug_id))
-
         try:
             user = make_user(test_data)
         except CLIFactoryError as err:

--- a/tests/foreman/ui/test_org.py
+++ b/tests/foreman/ui/test_org.py
@@ -9,8 +9,8 @@ from fauxfactory import gen_string, gen_ipaddr
 from robottelo import entities
 from robottelo.common import conf
 from robottelo.common.helpers import generate_strings_list
-from robottelo.common.decorators import (data, run_only_on, stubbed,
-                                         skip_if_bug_open, bz_bug_is_open)
+from robottelo.common.decorators import (
+    data, run_only_on, stubbed, skip_if_bug_open)
 from robottelo.test import UITestCase
 from robottelo.ui.factory import make_org
 from robottelo.ui.locators import common_locators, tab_locators, locators
@@ -417,8 +417,9 @@ class Org(UITestCase):
         {u'user_name': gen_string('alpha', 8)},
         {u'user_name': gen_string('numeric', 8)},
         {u'user_name': gen_string('alphanumeric', 8)},
-        {u'user_name': gen_string('utf8', 8), 'bugzilla': 1144162},
-        {u'user_name': gen_string('latin1', 8)},)
+        {u'user_name': gen_string('utf8', 8)},
+        {u'user_name': gen_string('latin1', 8)},
+    )
     def test_remove_user_1(self, test_data):
         """@test: Create admin users then add user and remove it
         by using the organization name.
@@ -428,10 +429,6 @@ class Org(UITestCase):
         @assert: The user is added then removed from the organization
 
         """
-        bug_id = test_data.pop('bugzilla', None)
-        if bug_id is not None and bz_bug_is_open(bug_id):
-            self.skipTest('Bugzilla bug {0} is open.'.format(bug_id))
-
         strategy, value = common_locators["entity_select"]
         strategy1, value1 = common_locators["entity_deselect"]
         org_name = gen_string("alpha", 8)
@@ -579,8 +576,9 @@ class Org(UITestCase):
         {u'user_name': gen_string('alpha', 8)},
         {u'user_name': gen_string('numeric', 8)},
         {u'user_name': gen_string('alphanumeric', 8)},
-        {u'user_name': gen_string('utf8', 8), 'bugzilla': 1144162},
-        {u'user_name': gen_string('latin1', 8)},)
+        {u'user_name': gen_string('utf8', 8)},
+        {u'user_name': gen_string('latin1', 8)},
+    )
     def test_add_user_2(self, test_data):
         """@test: Create different types of users then add user
         by using the organization name.
@@ -590,11 +588,6 @@ class Org(UITestCase):
         @assert: User is added to organization.
 
         """
-
-        bug_id = test_data.pop('bugzilla', None)
-        if bug_id is not None and bz_bug_is_open(bug_id):
-            self.skipTest('Bugzilla bug {0} is open.'.format(bug_id))
-
         user_name = test_data['user_name']
         strategy, value = common_locators["entity_deselect"]
         org_name = gen_string("alpha", 8)


### PR DESCRIPTION
Fauxfactory was update and now creates UTF-8 string containing only
letters characters. These are accepted by Satellite as valid unicode
characters because the string does not contain any control characters.

Test results
=========

API
---

```
$ py.test tests/foreman/api/test_user.py
================================ test session starts ================================
platform darwin -- Python 2.7.6 -- py-1.4.26 -- pytest-2.6.4
collected 40 items

tests/foreman/api/test_user.py ........................................

============================ 40 passed in 149.55 seconds ============================
```

CLI
---

```
$ py.test tests/foreman/cli/test_user.py -k "test_positive_create_user_1 or test_positive_create_user_2 or test_positive_create_user_3 or test_positive_update_user_1 or test_positive_update_user_2 or test_positive_update_user_3 or test_positive_delete_user_1 or test_positive_delete_user_2 or test_list_user_1 or test_list_user_2 or test_list_user_3"
================================ test session starts ================================
platform darwin -- Python 2.7.6 -- py-1.4.26 -- pytest-2.6.4
collected 200 items

tests/foreman/cli/test_user.py ..................ssssssssss......sssssssss........................ssssssssss.....ssssssss...........

 99 tests deselected by '-ktest_positive_create_user_1 or test_positive_create_user_2 or test_positive_create_user_3 or test_positive_update_user_1 or test_positive_update_user_2 or test_positive_update_user_3 or test_positive_delete_user_1 or test_positive_delete_user_2 or test_list_user_1 or test_list_user_2 or test_list_user_3'
============== 64 passed, 37 skipped, 99 deselected in 1140.09 seconds ==============
```

UI
--

```
$ py.test tests/foreman/ui/test_org.py -k "test_remove_user_1 or test_add_user_2"
================================ test session starts ================================
platform darwin -- Python 2.7.6 -- py-1.4.26 -- pytest-2.6.4
collected 185 items

tests/foreman/ui/test_org.py ..........

========= 175 tests deselected by '-ktest_remove_user_1 or test_add_user_2' =========
=================== 10 passed, 175 deselected in 2319.15 seconds ====================
```

With these changes, we should have 19 more success and 19 less failures.