### PR TITLE
Fix CLI test_environment_paths

### DIFF
--- a/tests/foreman/cli/test_lifecycleenvironment.py
+++ b/tests/foreman/cli/test_lifecycleenvironment.py
@@ -411,21 +411,20 @@ class TestLifeCycleEnvironment(CLITestCase):
         """
         try:
             org = make_org(cached=True)
-            payload = {
+            test_env = make_lifecycle_environment({
                 'organization-id': org['id'],
-            }
-            test_env = make_lifecycle_environment(payload)
+            })
         except CLIFactoryError as err:
             self.fail(err)
 
         # Add paths to lifecycle environments
-        result = LifecycleEnvironment.paths({'organization-id': org['id'],
-                                            'permission-type': 'readable'})
-        self.assertEqual(result.return_code, 0,
-                         "return code must be 0, instead got {0}".
-                         format(result.return_code))
-        self.assertEqual(
-            len(result.stderr), 0,
-            "There should not be an error here.")
-        self.assertIn(u'Library >> {0}'.format(test_env['name']),
-                      result.stdout)
+        result = LifecycleEnvironment.paths({
+            'organization-id': org['id'],
+            'permission-type': 'readable',
+        })
+        self.assertEqual(result.return_code, 0)
+        self.assertEqual(len(result.stderr), 0)
+        self.assertIn(
+            u'Library >> {0}'.format(test_env['name']),
+            u''.join(result.stdout)
+        )


### PR DESCRIPTION
Lifecycle environment paths are returned containing a new line character
for each line. Fix the test to join the lines and assert for a string in
a unique result string.

Test results:

```
$ py.test tests/foreman/cli/test_lifecycleenvironment.py -k test_environment_paths
================================ test session starts ================================
platform darwin -- Python 2.7.6 -- py-1.4.26 -- pytest-2.6.4
collected 33 items

tests/foreman/cli/test_lifecycleenvironment.py .

================= 32 tests deselected by '-ktest_environment_paths' =================
===================== 1 passed, 32 deselected in 27.57 seconds ======================
```