### PR TITLE
Fix CLI and API smoke tests for sat6.1 compose

### DIFF
--- a/robottelo/orm.py
+++ b/robottelo/orm.py
@@ -20,7 +20,7 @@ import urlparse
 #: Default for ``poll_rate`` argument to :func:`robottelo.orm._poll_task`.
 TASK_POLL_RATE = 5
 #: Default for ``timeout`` argument to :func:`robottelo.orm._poll_task`.
-TASK_TIMEOUT = 180
+TASK_TIMEOUT = 300
 
 
 class TaskTimeout(Exception):

--- a/tests/foreman/smoke/test_api_smoke.py
+++ b/tests/foreman/smoke/test_api_smoke.py
@@ -1131,7 +1131,7 @@ class TestSmoke(TestCase):
 
         # Create VM
         package_name = "python-kitchen"
-        with VirtualMachine(distro='rhel65') as vm:
+        with VirtualMachine(distro='rhel66') as vm:
             # Download and Install rpm
             result = vm.run(
                 "wget -nd -r -l1 --no-parent -A '*.noarch.rpm' http://{0}/pub/"
@@ -1159,6 +1159,17 @@ class TestSmoke(TestCase):
             self.assertEqual(
                 result.return_code, 0,
                 "failed to register client:: {0} and return code: {1}"
+                .format(result.stderr, result.return_code)
+            )
+            # Enable Red Hat Enterprise Virtualization Agents repo via cli
+            # As the below repo is disabled by default under ak's prd-content
+            result = vm.run(
+                'subscription-manager repos --enable '
+                'rhel-6-server-rhev-agent-rpms'
+            )
+            self.assertEqual(
+                result.return_code, 0,
+                "Enabling repo failed: {0} and return code: {1}"
                 .format(result.stderr, result.return_code)
             )
             # Install contents from sat6 server

--- a/tests/foreman/smoke/test_cli_smoke.py
+++ b/tests/foreman/smoke/test_cli_smoke.py
@@ -663,7 +663,7 @@ class TestSmoke(CLITestCase):
         # Create VM
         package_name = "python-kitchen"
         server_name = conf.properties['main.server.hostname']
-        with VirtualMachine(distro='rhel65') as vm:
+        with VirtualMachine(distro='rhel66') as vm:
             # Download and Install rpm
             result = vm.run(
                 "wget -nd -r -l1 --no-parent -A '*.noarch.rpm' http://{0}/pub/"
@@ -691,6 +691,17 @@ class TestSmoke(CLITestCase):
             self.assertEqual(
                 result.return_code, 0,
                 "failed to register client:: {0} and return code: {1}"
+                .format(result.stderr, result.return_code)
+            )
+            # Enable Red Hat Enterprise Virtualization Agents repo via cli
+            # As the below repo is disabled by default under ak's prd-content
+            result = vm.run(
+                'subscription-manager repos --enable '
+                'rhel-6-server-rhev-agent-rpms'
+            )
+            self.assertEqual(
+                result.return_code, 0,
+                "Enabling repo failed: {0} and return code: {1}"
                 .format(result.stderr, result.return_code)
             )
             # Install contents from sat6 server


### PR DESCRIPTION
* CLI and API smoke tests now use rhel66 client
* Will be enabling the rhev-agent repo on the client directly.
* increased the timeout for POLL tasks to 5 mins as many automation
  failures are related to it.