### PR TITLE
Fix tests that fail due to BZ 1151240 being closed

### DIFF
--- a/tests/foreman/api/test_architecture.py
+++ b/tests/foreman/api/test_architecture.py
@@ -39,17 +39,25 @@ class ArchitectureTestCase(APITestCase):
         self.assertIn('operatingsystems', attrs)
         self.assertEqual([os_id], attrs['operatingsystems'])
 
-    @skip_if_bug_open('bugzilla', 1151240)
-    def test_get_hash(self):
-        """@Test: Read the API and look for a list of IDs.
+    def test_associate_with_os(self):
+        """@Test: Create an architecture and associate it with an OS.
 
-        @Assert: The architecture-OS foreign key relationship is described with
-        a list of IDs.
+        @Assert: The architecture can be created, and the association can be
+        read back from the server.
 
         @Feature: Architecture
 
         """
+        # Create an architecture and an OS.
         os_id = entities.OperatingSystem().create()['id']
-        attrs = entities.Architecture(operatingsystem=[os_id]).create()
-        self.assertIn('operatingsystem_ids', attrs)
-        self.assertEqual(attrs['operatingsystem_ids'], [os_id])
+        arch_id = entities.Architecture(
+            operatingsystem=[os_id]
+        ).create_json()['id']
+
+        # Read back the architecture and verify its attributes.
+        arch_attrs = entities.Architecture(id=arch_id).read_json()
+        self.assertIn('operatingsystems', arch_attrs)
+        self.assertEqual(
+            [os_id],
+            [os['id'] for os in arch_attrs['operatingsystems']],
+        )


### PR DESCRIPTION
BZ 1151240 contained two complaints:

* When one asks the server for information about an entity, the server will
  respond with incomplete information. Some foreign key relationships are not
  described.
* The format used to describe foreign key relationships is unwieldy. It's much
  easier to deal with a list of IDs than a list of hashes that (hopefully)
  contain entity IDs.

The BZ has been closed. The first complaint is allegedly addressed. The second
complaint may be addressed in APIv3, but not now. Fix tests that fail due to
this BZ being closed. It is important to note that foreign key relationships are
ignored in the fixed tests. It is very hard to validate this information given
the variable naming and unwieldy structure of foreign key relationships returned
by the server. A more productive approach for tackling this problem is to simply
flesh out all of the `read` methods.

    $ nosetests tests/foreman/api/test_multiple_paths.py -m test_put_and_get
    ......................
    ----------------------------------------------------------------------
    Ran 22 tests in 50.022s

    OK
    $ nosetests tests/foreman/api/test_multiple_paths.py -m test_post_and_get
    ......................
    ----------------------------------------------------------------------
    Ran 22 tests in 24.693s

    OK
    $ nosetests tests/foreman/api/test_architecture.py
    .S
    ----------------------------------------------------------------------
    Ran 2 tests in 0.931s

    OK (SKIP=1)