### PR TITLE
Make the `read` method work for most entities

### DIFF
--- a/tests/foreman/api/test_multiple_paths.py
+++ b/tests/foreman/api/test_multiple_paths.py
@@ -632,40 +632,37 @@ class EntityReadTestCase(APITestCase):
     function correctly.
     """
 
-    # Most entities are commented-out because they do not inherit from
-    # EntityReadMixin, due to issues with data returned from the API.
-    #
     # ComputeResource entities cannot be reliably read because, depending upon
     # the provider, different sets of attributes are returned. For example, the
     # "uuid" attribute is only returned for certain providers. Perhaps multiple
     # types of compute resources should be created? For example:
     # LibvirtComputeResource.
     @data(
-        # entities.ActivationKey,
+        entities.ActivationKey,
         # entities.Architecture,  # see test_architecture_read
         entities.AuthSourceLDAP,
         entities.ComputeProfile,
         # partial(entities.ComputeResource, provider='Libvirt'),
-        # entities.ConfigTemplate,
-        # entities.ContentView,
-        # entities.Domain,
+        entities.ConfigTemplate,
+        entities.ContentView,
+        entities.Domain,
         entities.Environment,
-        # entities.GPGKey,
-        # entities.Host,  # FIXME: investigate this
+        entities.GPGKey,
+        entities.Host,
         entities.HostCollection,
-        # entities.LifecycleEnvironment,
+        entities.LifecycleEnvironment,
         entities.Media,
         entities.Model,
         entities.OperatingSystem,
         # entities.OperatingSystemParameter,  # see test_osparameter_read
         entities.Organization,
-        # entities.Product,
+        entities.Product,
         entities.Repository,
         entities.Role,
-        # entities.Subnet,  # "domains" attribute is useless when reading.
-        # entities.System,
+        entities.Subnet,
+        entities.System,
         # entities.TemplateKind,  # see comments in class definition
-        # entities.User,
+        entities.User,
     )
     def test_entity_read(self, entity_cls):
         """@Test: Create an entity and get it using
@@ -686,8 +683,8 @@ class EntityReadTestCase(APITestCase):
 
         @Feature: Test multiple API paths
 
-        @Assert: The call to :meth:`robottelo.entities.Architecture.read`
-        succeeds, and the response contains the correct operating system ID.
+        @Assert: The call to ``Architecture.read`` succeeds, and the response
+        contains the correct operating system ID.
 
         """
         os_id = entities.OperatingSystem().create_json()['id']


### PR DESCRIPTION
Uncomment nearly all of the tests that call `EntityReadMixin.read`. The only
entity whose `read` method is not being tested is `ComputeResource`, due to
design issues with the class. Make all relevant tests pass:

    $ nosetests tests/foreman/api/test_multiple_paths.py:EntityReadTestCase
    .........................
    ----------------------------------------------------------------------
    Ran 25 tests in 25.024s

    OK

As a result of this change, it is now possible to execute chains of method
calls. For example, to discover the name of the organization that a repository
belongs to:

    entities.Repository(id=1).read().product.read().organization.read().name

Or, to get a list of all attributes for that organization:

    vars(entities.Repository(id=1).read().product.read().organization.read())

You can also discover some interesting aspects of the database design:

    >>> entities.System(id=some_uuid).read().organization.id == \
    ... entities.System(id=some_uuid).read().content_view.read().organization.id
    True