### PR TITLE
Add docker compute resource API creation tests

### DIFF
--- a/robottelo.properties.sample
+++ b/robottelo.properties.sample
@@ -44,6 +44,14 @@ provisioning_server=
 # provisioning server.
 image_dir=/opt/robottelo/images
 
+[docker]
+# Internal docker URL in the format http[s]://<server>:<port>. The
+# {server_hostname} variable can be used and will be replaced by
+# main.server.hostname value.
+internal_url=http://localhost:2375
+# External docker URL in the format http[s]://<server>:<port>.
+external_url=
+
 [foreman]
 admin.username=admin
 admin.password=changeme

--- a/robottelo/common/helpers.py
+++ b/robottelo/common/helpers.py
@@ -70,6 +70,25 @@ def get_server_url():
         ))
 
 
+def get_internal_docker_url():
+    """Returns the docker internal server url config
+
+    If the variable ``{server_hostname}`` is found in the string, it will be
+    replaced by ``main.server.hostname`` from the config file.
+
+    """
+    internal_url = conf.properties.get('docker.internal_url')
+    if internal_url is not None:
+        internal_url = internal_url.format(
+            server_hostname=conf.properties['main.server.hostname'])
+    return internal_url
+
+
+def get_external_docker_url():
+    """Returns the docker external server url config"""
+    return conf.properties.get('docker.external_url')
+
+
 def get_distro_info():
     """Get a tuple of information about the RHEL distribution on the server.
 

--- a/robottelo/entities.py
+++ b/robottelo/entities.py
@@ -24,6 +24,8 @@ from robottelo.common.decorators import bz_bug_is_open, rm_bug_is_open
 from robottelo.common.helpers import (
     escape_search,
     get_data_file,
+    get_external_docker_url,
+    get_internal_docker_url,
     get_server_credentials,
 )
 from robottelo import orm
@@ -296,13 +298,22 @@ class ComputeResource(
     """A representation of a Compute Resource entity."""
     description = entity_fields.StringField(null=True)
     # `name` cannot contain whitespace. Thus, the chosen string types.
-    name = entity_fields.StringField(null=True, str_type=('alphanumeric', 'cjk'))
+    name = entity_fields.StringField(
+        required=True, str_type=('alphanumeric', 'cjk'))
     password = entity_fields.StringField(null=True)
     provider = entity_fields.StringField(
         null=True,
         required=True,
-        choices=('EC2', 'GCE', 'Libvirt', 'Openstack', 'Ovirt', 'Rackspace',
-                 'Vmware')
+        choices=(
+            'Docker',
+            'EC2',
+            'GCE',
+            'Libvirt',
+            'Openstack',
+            'Ovirt',
+            'Rackspace',
+            'Vmware',
+        )
     )
     region = entity_fields.StringField(null=True)
     server = entity_fields.StringField(null=True)
@@ -323,19 +334,29 @@ class ComputeResource(
         filled in with values too.
 
         """
-        super(ComputeResource, self).create_missing(auth)
         cls = type(self)
+        provider = vars(self).get('provider')
+        if provider is None:
+            self.provider = provider = cls.provider.gen_value()
+
+        # Deal with docker provider before calling super create_missing in
+        # order to check if an URL is provided by the user and, if not,
+        # generate an URL pointing to a docker server
+        if provider.lower() == 'docker':
+            if 'url' not in vars(self):
+                self.url = random.choice((
+                    get_internal_docker_url(), get_external_docker_url()))
+
+        # Now is good to call super create_missing
+        super(ComputeResource, self).create_missing(auth)
 
         # Generate required fields according to the provider. First check if
         # the field is already set by the user, if not generate a random value
-        provider = vars(self)['provider']
         if provider == 'EC2' or provider == 'Ovirt' or provider == 'Openstack':
-            for field in ('name', 'password', 'user'):
+            for field in ('password', 'user'):
                 if field not in vars(self):
                     setattr(self, field, getattr(cls, field).gen_value())
         elif provider == 'GCE':
-            if 'name' not in vars(self):
-                self.name = cls.name.gen_value()
             # self.email = cls.email.gen_value()
             # self.key_path = cls.key_path.gen_value()
             # self.project = cls.project.gen_value()
@@ -346,9 +367,7 @@ class ComputeResource(
             # 1. Figure out valid values for these three fields.
             # 2. Uncomment the above.
             # 3. File an issue on bugzilla asking for the docs to be expanded.
-        elif provider == 'Libvirt':
-            if 'name' not in vars(self):
-                self.name = cls.name.gen_value()
+            pass
         elif provider == 'Rackspace':
             # FIXME: Foreman always returns this error:
             #
@@ -358,7 +377,7 @@ class ComputeResource(
             # 2. Figure out what data is necessary and add it here.
             pass
         elif provider == 'Vmware':
-            for field in ('name', 'password', 'user', 'uuid'):
+            for field in ('password', 'user', 'uuid'):
                 if field not in vars(self):
                     setattr(self, field, getattr(cls, field).gen_value())
 

--- a/tests/foreman/api/test_docker.py
+++ b/tests/foreman/api/test_docker.py
@@ -8,11 +8,18 @@ from robottelo import entities
 from robottelo.common.constants import DOCKER_REGISTRY_HUB
 from robottelo.common.decorators import (
     data, run_only_on, skip_if_bug_open, stubbed)
-from robottelo.common.helpers import get_server_credentials
+from robottelo.common.helpers import (
+    get_external_docker_url,
+    get_internal_docker_url,
+    get_server_credentials,
+)
 from robottelo.test import APITestCase
 # (too-many-public-methods) pylint:disable=R0904
 
 
+DOCKER_PROVIDER = 'Docker'
+EXTERNAL_DOCKER_URL = get_external_docker_url()
+INTERNAL_DOCKER_URL = get_internal_docker_url()
 STRING_TYPES = ['alpha', 'alphanumeric', 'cjk', 'utf8', 'latin1']
 
 
@@ -891,6 +898,7 @@ class DockerClientTestCase(APITestCase):
         """
 
 
+@ddt
 class DockerComputeResourceTestCase(APITestCase):
     """Tests specific to managing Docker-based Compute Resources."""
 
@@ -900,19 +908,36 @@ class DockerComputeResourceTestCase(APITestCase):
         super(DockerComputeResourceTestCase, cls).setUpClass()
         cls.org_id = entities.Organization().create_json()['id']
 
-    @stubbed()
     @run_only_on('sat')
-    def test_create_internal_docker_compute_resource(self):
-        """@Test: Create a Docker-based Compute Resource in the
-        Satellite 6 instance.
+    @data(
+        gen_string('alpha'),
+        gen_string('alphanumeric'),
+        gen_string('numeric'),
+        gen_string('latin1'),
+        gen_string('utf8'),
+        gen_string('html'),
+    )
+    def test_create_internal_docker_compute_resource(self, name):
+        """@Test: Create a Docker-based Compute Resource in the Satellite 6
+        instance.
 
         @Assert: Compute Resource can be created and listed.
 
         @Feature: Docker
 
-        @Status: Manual
-
         """
+        compute_resource_id = entities.ComputeResource(
+            name=name,
+            provider=DOCKER_PROVIDER,
+            url=INTERNAL_DOCKER_URL
+        ).create_json()['id']
+
+        compute_resource = entities.ComputeResource(
+            id=compute_resource_id).read_json()
+
+        self.assertEqual(compute_resource['name'], name)
+        self.assertEqual(compute_resource['url'], INTERNAL_DOCKER_URL)
+        self.assertEqual(compute_resource['provider'], DOCKER_PROVIDER)
 
     @stubbed()
     @run_only_on('sat')
@@ -958,19 +983,36 @@ class DockerComputeResourceTestCase(APITestCase):
 
         """
 
-    @stubbed()
     @run_only_on('sat')
-    def test_create_external_docker_compute_resource(self):
-        """@Test: Create a Docker-based Compute Resource using
-        an external Docker-enabled system.
+    @data(
+        gen_string('alpha'),
+        gen_string('alphanumeric'),
+        gen_string('numeric'),
+        gen_string('latin1'),
+        gen_string('utf8'),
+        gen_string('html'),
+    )
+    def test_create_external_docker_compute_resource(self, name):
+        """@Test: Create a Docker-based Compute Resource using an external
+        Docker-enabled system.
 
         @Assert: Compute Resource can be created and listed.
 
         @Feature: Docker
 
-        @Status: Manual
-
         """
+        compute_resource_id = entities.ComputeResource(
+            name=name,
+            provider=DOCKER_PROVIDER,
+            url=EXTERNAL_DOCKER_URL
+        ).create_json()['id']
+
+        compute_resource = entities.ComputeResource(
+            id=compute_resource_id).read_json()
+
+        self.assertEqual(compute_resource['name'], name)
+        self.assertEqual(compute_resource['url'], EXTERNAL_DOCKER_URL)
+        self.assertEqual(compute_resource['provider'], DOCKER_PROVIDER)
 
     @stubbed()
     @run_only_on('sat')


### PR DESCRIPTION
Before writing the tests was needed to:

* Update ComputeResource to deal with the Docker provider.
* Add configuration in the robottelo.properties file to configure the
  docker internal and external server URLs.
* Add helpers to get the internal and external docker server URLs. This
  will make easier to get the config without having to deal with the
  config object every time.

The above allowed write tests for creating internal and external
Docker-based compute resources, also added on this commit.