### PR TITLE
Add "entity" class DockerHubContainer

### DIFF
--- a/tests/robottelo/test_entities.py
+++ b/tests/robottelo/test_entities.py
@@ -47,6 +47,8 @@ class PathTestCase(TestCase):
         )
 
     @data(
+        (entities.AbstractDockerContainer, 'containers', 'logs'),
+        (entities.AbstractDockerContainer, 'containers', 'power'),
         (entities.ActivationKey, '/activation_keys', 'releases'),
         (entities.ActivationKey, '/activation_keys', 'add_subscriptions'),
         (entities.ActivationKey, '/activation_keys', 'remove_subscriptions'),


### PR DESCRIPTION
Class `DockerHubContainer` represents a container whose image comes from the
docker hub. This class is manually tested. It is possible to create, read and
delete containers. It is also possible to start, stop, get the status of, and
get logs from a container.

Be warned that the `read` method will not work until #1941 is merged.