### PR TITLE
Fixed the syncplan tests for zstream

### DIFF
--- a/robottelo/ui/syncplan.py
+++ b/robottelo/ui/syncplan.py
@@ -30,7 +30,7 @@ class Syncplan(Base):
         self.wait_for_ajax()
 
     def create(self, name, description=None, startdate=None,
-               sync_interval=None, start_hour=None,
+               sync_interval='hourly', start_hour=None,
                start_minute=None):
         """
         Creates new Sync Plans from UI

--- a/tests/foreman/ui/test_syncplan.py
+++ b/tests/foreman/ui/test_syncplan.py
@@ -241,7 +241,7 @@ class Syncplan(UITestCase):
         description = "update sync plan"
         self.configure_syncplan()
         self.syncplan.create(plan_name, description)
-        self.assertIsNotNone(self.synplan.search(plan_name))
+        self.assertIsNotNone(self.syncplan.search(plan_name))
         self.syncplan.update(plan_name, new_name=new_plan_name)
         self.assertIsNotNone(self.syncplan.search(new_plan_name))
 


### PR DESCRIPTION
Why these tests where skipped?

Bcoz interval was not set and the tests fail, we had a bug for it
which was in open state for a long time now. This bug was fixed
for sat6.1 recently but not for zstream releases. Our UI automation
now uses the 'hourly' interval by default for all the test-cases to
make it run from now on.