### PR TITLE
Add API tests for usergroups

### DIFF
--- a/robottelo/entities.py
+++ b/robottelo/entities.py
@@ -2427,14 +2427,24 @@ class TemplateKind(orm.Entity, orm.EntityReadMixin):
         NUM_CREATED_BY_DEFAULT = 8
 
 
-class UserGroup(orm.Entity):
+class UserGroup(
+        orm.Entity, orm.EntityReadMixin, orm.EntityDeleteMixin,
+        orm.EntityCreateMixin):
     """A representation of a User Group entity."""
     name = entity_fields.StringField(required=True)
+    role = entity_fields.OneToManyField('Role')
+    user = entity_fields.OneToManyField('User', required=True)
+    usergroup = entity_fields.OneToManyField('UserGroup')
 
     class Meta(object):
         """Non-field information about this entity."""
         api_path = 'api/v2/usergroups'
         server_modes = ('sat')
+
+    # NOTE: See BZ 1151220
+    def create_payload(self):
+        """Wrap submitted data within an extra dict."""
+        return {u'usergroup': super(UserGroup, self).create_payload()}
 
 
 class User(

--- a/tests/foreman/api/test_multiple_paths.py
+++ b/tests/foreman/api/test_multiple_paths.py
@@ -142,6 +142,7 @@ class EntityTestCase(APITestCase):
         # entities.System,  # need organization_id
         entities.TemplateKind,
         entities.User,
+        entities.UserGroup,
     )
     def test_get_status_code(self, entity_cls):
         """@Test: GET an entity-dependent path.
@@ -182,6 +183,7 @@ class EntityTestCase(APITestCase):
         entities.System,
         entities.TemplateKind,
         entities.User,
+        entities.UserGroup,
     )
     def test_get_unauthorized(self, entity_cls):
         """@Test: GET an entity-dependent path without credentials.
@@ -227,6 +229,7 @@ class EntityTestCase(APITestCase):
         entities.System,
         # entities.TemplateKind,  # see comments in class definition
         entities.User,
+        entities.UserGroup,
     )
     def test_post_status_code(self, entity_cls):
         """@Test: Issue a POST request and check the returned status code.
@@ -274,6 +277,7 @@ class EntityTestCase(APITestCase):
         entities.System,
         entities.TemplateKind,
         entities.User,
+        entities.UserGroup,
     )
     @skip_if_bug_open('bugzilla', 1122257)
     def test_post_unauthorized(self, entity_cls):
@@ -321,6 +325,7 @@ class EntityIdTestCase(APITestCase):
         # entities.System,  # See test_activationkey_v2.py
         # entities.TemplateKind,  # see comments in class definition
         entities.User,
+        entities.UserGroup,
     )
     def test_get_status_code(self, entity_cls):
         """@Test: Create an entity and GET it.
@@ -365,6 +370,7 @@ class EntityIdTestCase(APITestCase):
         # entities.System,  # See test_activationkey_v2.py
         # entities.TemplateKind,  # see comments in class definition
         entities.User,
+        entities.UserGroup,
     )
     def test_put_status_code(self, entity_cls):
         """@Test Issue a PUT request and check the returned status code.
@@ -418,6 +424,7 @@ class EntityIdTestCase(APITestCase):
         # entities.System,  # See test_activationkey_v2.py
         # entities.TemplateKind,  # see comments in class definition
         entities.User,
+        entities.UserGroup,
     )
     def test_delete_status_code(self, entity_cls):
         """@Test Issue an HTTP DELETE request and check the returned status
@@ -488,6 +495,7 @@ class DoubleCheckTestCase(APITestCase):
         # entities.System,  # See test_activationkey_v2.py
         # entities.TemplateKind,  # see comments in class definition
         entities.User,
+        entities.UserGroup,
     )
     def test_put_and_get(self, entity_cls):
         """@Test: Update an entity, then read it back.
@@ -548,6 +556,7 @@ class DoubleCheckTestCase(APITestCase):
         # entities.System,  # See test_activationkey_v2.py
         # entities.TemplateKind,  # see comments in class definition
         entities.User,
+        entities.UserGroup,
     )
     def test_post_and_get(self, entity_cls):
         """@Test: Create an entity, then read it back.
@@ -597,6 +606,7 @@ class DoubleCheckTestCase(APITestCase):
         # entities.System,  # See test_activationkey_v2.py
         # entities.TemplateKind,  # see comments in class definition
         entities.User,
+        entities.UserGroup,
     )
     def test_delete_and_get(self, entity_cls):
         """@Test: Issue an HTTP DELETE request and GET the deleted entity.
@@ -663,6 +673,7 @@ class EntityReadTestCase(APITestCase):
         entities.System,
         # entities.TemplateKind,  # see comments in class definition
         entities.User,
+        entities.UserGroup,
     )
     def test_entity_read(self, entity_cls):
         """@Test: Create an entity and get it using


### PR DESCRIPTION
Tested against nightly:

    $ nosetests tests/foreman/api/test_multiple_paths.py -m UserGroup
    ..........S
    ----------------------------------------------------------------------
    Ran 11 tests in 13.311s

    OK (SKIP=1)