### PR TITLE
Drop unnecessary sleep on CLI factories

### DIFF
--- a/robottelo/cli/factory.py
+++ b/robottelo/cli/factory.py
@@ -9,7 +9,6 @@ import datetime
 import logging
 import os
 import random
-import time
 
 from fauxfactory import (
     gen_alphanumeric, gen_integer, gen_ipaddr,
@@ -90,8 +89,6 @@ def create_object(cli_object, options, values):
     """
     update_dictionary(options, values)
     result = cli_object.create(options)
-    # Some methods require a bit of waiting
-    time.sleep(5)
 
     # If the object is not created, raise exception, stop the show.
     if result.return_code != 0:


### PR DESCRIPTION
Due to historical reasons a sleep was left in the create_object function on
CLI factory module. It is not necessary anymore because
cli.base.Base.create already create and retrieve the entity before
running that sleep.