### PR TITLE
Work around a known issue with repository deletion

### DIFF
--- a/tests/foreman/api/test_multiple_paths.py
+++ b/tests/foreman/api/test_multiple_paths.py
@@ -5,6 +5,7 @@ from robottelo.api.utils import status_code_error
 from robottelo.common.decorators import bz_bug_is_open, skip_if_bug_open
 from robottelo.common.helpers import get_server_credentials
 from robottelo import entities, factory
+from time import sleep
 from unittest import TestCase
 import httplib
 import logging
@@ -474,6 +475,10 @@ class DoubleCheckTestCase(TestCase):
             self.fail(err)
         logger.info('test_delete_and_get path: {0}'.format(entity_n.path()))
         entity_n.delete()
+        if entity == entities.Repository and bz_bug_is_open(1166365):
+            # Repository.delete launches a ForemanTask, but the ID of the task
+            # is not returned. See BZ 1166365.
+            sleep(20)
 
         # An HTTP 404 response code should always be returned, but this bug is
         # unlikely to be fixed in a z-stream release due to how minor it is.


### PR DESCRIPTION
A ForemanTask is launched when a repository is deleted. Unfortunately, the
task's ID is not returned, so there is no way to monitor the status of that
task. See: https://bugzilla.redhat.com/show_bug.cgi?id=1166365

This issue is unlikely to be fixed in the 6.0 branch. Insert a delay into the
repository deletion test so that the task has time to complete.

    $ nosetests tests/foreman/api/test_multiple_paths.py -m test_delete_and_get_15_Repository
    .
    ----------------------------------------------------------------------
    Ran 1 test in 26.303s

    OK