### PR TITLE
Add JSON output support for CLI commands

### DIFF
--- a/robottelo/cli/base.py
+++ b/robottelo/cli/base.py
@@ -97,8 +97,7 @@ class Base(object):
             options = {}
 
         result = cls.execute(
-            cls._construct_command(options),
-            expect_csv=True)
+            cls._construct_command(options), output_format='csv')
 
         # Extract new object ID if it was successfully created
         if len(result.stdout) > 0 and 'id' in result.stdout[0]:
@@ -185,25 +184,21 @@ class Base(object):
         return (username, password)
 
     @classmethod
-    def execute(cls, command, user=None, password=None,
-                expect_csv=False, timeout=None):
+    def execute(cls, command, user=None, password=None, output_format=None,
+                timeout=None):
         """Executes the cli ``command`` on the server via ssh"""
         user, password = cls._get_username_password(user, password)
 
-        output_csv = u''
-
-        if expect_csv:
-            output_csv = u' --output csv'
         cmd = u'LANG={0} hammer -v -u {1} -p {2} {3} {4}'.format(
             conf.properties['main.locale'],
             user,
             password,
-            output_csv,
+            u'--output={0}'.format(output_format) if output_format else u'',
             command
         )
 
         return ssh.command(
-            cmd.encode('utf-8'), expect_csv=expect_csv, timeout=timeout)
+            cmd.encode('utf-8'), output_format=output_format, timeout=timeout)
 
     @classmethod
     def exists(cls, options=None, search=None):
@@ -249,7 +244,7 @@ class Base(object):
                 .format(cls.__name__)
             )
 
-        result = cls.execute(cls._construct_command(options), expect_csv=False)
+        result = cls.execute(cls._construct_command(options))
 
         # info_dictionary required to convert result.stdout to dic format
         updated_result = info_dictionary(result)
@@ -277,7 +272,8 @@ class Base(object):
                 .format(cls.__name__)
             )
 
-        result = cls.execute(cls._construct_command(options), expect_csv=True)
+        result = cls.execute(
+            cls._construct_command(options), output_format='csv')
 
         return result
 
@@ -289,7 +285,8 @@ class Base(object):
 
         cls.command_sub = 'puppet-classes'
 
-        result = cls.execute(cls._construct_command(options), expect_csv=True)
+        result = cls.execute(
+            cls._construct_command(options), output_format='csv')
 
         return result
 
@@ -313,7 +310,8 @@ class Base(object):
 
         cls.command_sub = 'sc-params'
 
-        result = cls.execute(cls._construct_command(options), expect_csv=True)
+        result = cls.execute(
+            cls._construct_command(options), output_format='csv')
 
         return result
 
@@ -337,7 +335,8 @@ class Base(object):
 
         cls.command_sub = 'update'
 
-        result = cls.execute(cls._construct_command(options), expect_csv=True)
+        result = cls.execute(
+            cls._construct_command(options), output_format='csv')
 
         return result
 

--- a/robottelo/cli/contenthost.py
+++ b/robottelo/cli/contenthost.py
@@ -42,6 +42,7 @@ class ContentHost(Base):
 
         cls.command_sub = 'tasks'
 
-        result = cls.execute(cls._construct_command(options), expect_csv=True)
+        result = cls.execute(
+            cls._construct_command(options), output_format='csv')
 
         return result

--- a/robottelo/cli/contentview.py
+++ b/robottelo/cli/contentview.py
@@ -46,13 +46,15 @@ class ContentView(Base):
     def add_repository(cls, options):
         """Associate repository to a selected CV."""
         cls.command_sub = 'add-repository'
-        return cls.execute(cls._construct_command(options), expect_csv=True)
+        return cls.execute(
+            cls._construct_command(options), output_format='csv')
 
     @classmethod
     def add_version(cls, options):
         """Associate version to a selected CV."""
         cls.command_sub = 'add-version'
-        return cls.execute(cls._construct_command(options), expect_csv=True)
+        return cls.execute(
+            cls._construct_command(options), output_format='csv')
 
     @classmethod
     def publish(cls, options, timeout=None):
@@ -73,7 +75,7 @@ class ContentView(Base):
         if options is None:
             options = {}
 
-        result = cls.execute(cls._construct_command(options), expect_csv=False)
+        result = cls.execute(cls._construct_command(options))
 
         # info_dictionary required to convert result.stdout
         # to dictionary format
@@ -83,7 +85,8 @@ class ContentView(Base):
     def puppet_module_add(cls, options):
         """Associate puppet_module to selected CV"""
         cls.command_sub = 'puppet-module add'
-        return cls.execute(cls._construct_command(options), expect_csv=True)
+        return cls.execute(
+            cls._construct_command(options), output_format='csv')
 
     @classmethod
     def puppet_module_info(cls, options):
@@ -93,7 +96,7 @@ class ContentView(Base):
         if options is None:
             options = {}
 
-        result = cls.execute(cls._construct_command(options), expect_csv=False)
+        result = cls.execute(cls._construct_command(options))
 
         # info_dictionary required to convert result.stdout
         # to dictionary format
@@ -108,7 +111,7 @@ class ContentView(Base):
         if options is None:
             options = {}
 
-        result = cls.execute(cls._construct_command(options), expect_csv=False)
+        result = cls.execute(cls._construct_command(options))
 
         # info_dictionary required to convert result.stdout
         # to dictionary format
@@ -122,7 +125,7 @@ class ContentView(Base):
         if options is None:
             options = {}
 
-        return cls.execute(cls._construct_command(options), expect_csv=False)
+        return cls.execute(cls._construct_command(options))
 
     @classmethod
     def filter_rule_create(cls, options):
@@ -132,7 +135,7 @@ class ContentView(Base):
         if options is None:
             options = {}
 
-        return cls.execute(cls._construct_command(options), expect_csv=False)
+        return cls.execute(cls._construct_command(options))
 
     @classmethod
     def version_list(cls, options):
@@ -142,7 +145,8 @@ class ContentView(Base):
         if options is None:
             options = {}
 
-        return cls.execute(cls._construct_command(options), expect_csv=True)
+        return cls.execute(
+            cls._construct_command(options), output_format='csv')
 
     @classmethod
     def version_promote(cls, options):

--- a/robottelo/cli/docker.py
+++ b/robottelo/cli/docker.py
@@ -5,6 +5,219 @@
 from robottelo.cli.base import Base
 
 
+class DockerContainer(Base):
+    """Manipulates Docker containers
+
+    Usage::
+
+        hammer docker container [OPTIONS] SUBCOMMAND [ARG] ...
+
+    Parameters::
+
+        SUBCOMMAND                    subcommand
+        [ARG] ...                     subcommand arguments
+
+    Subcommands::
+
+        create                        Create a container
+        delete                        Delete a container
+        info                          Show a container
+        list                          List all containers
+        logs                          Show container logs
+        start                         Power a container on
+        status                        Run power operation on a container
+        stop                          Power a container off
+
+    """
+    command_base = 'docker image'
+
+    @classmethod
+    def create(cls, options=None):
+        """Creates a docker container
+
+        Usage::
+
+            hammer docker container create [OPTIONS]
+
+        Options::
+
+            --attach-stderr ATTACH_STDERR             One of true/false,
+                                                      yes/no, 1/0.
+            --attach-stdin ATTACH_STDIN               One of true/false,
+                                                      yes/no, 1/0.
+            --attach-stdout ATTACH_STDOUT             One of true/false,
+                                                      yes/no, 1/0.
+            --cmd CMD
+            --compute-resource COMPUTE_RESOURCE_NAME  Compute resource name
+            --compute-resource-id COMPUTE_RESOURCE_ID
+            --cpu-sets CPU_SETS
+            --cpu-shares CPU_SHARES
+            --entrypoint ENTRYPOINT
+            --image IMAGE                             Image to use to create
+                                                      the container. Format
+                                                      should be repository:tag,
+                                                      e.g: centos:7
+            --katello KATELLO                         One of true/false,
+                                                      yes/no, 1/0.
+            --location-ids LOCATION_IDS               REPLACE locations with
+                                                      given ids. Comma
+                                                      separated list of values.
+            --locations LOCATION_NAMES                Comma separated list of
+                                                      values.
+            --memory MEMORY
+            --name NAME
+            --organization-ids ORGANIZATION_IDS       REPLACE organizations
+                                                      with given ids. Comma
+                                                      separated list of values.
+            --organizations ORGANIZATION_NAMES        Comma separated list of
+                                                      values.
+            --registry-id REGISTRY_ID                 Registry this container
+                                                      will have to use to get
+                                                      the image
+            --tty TTY                                 One of true/false,
+                                                      yes/no, 1/0.
+
+        """
+        return super(DockerContainer, cls).create(options)
+
+    @classmethod
+    def delete(cls, options=None):
+        """Deletes a docker container
+
+        Usage::
+
+            hammer docker container delete [OPTIONS]
+
+        Options::
+
+            --compute-resource COMPUTE_RESOURCE_NAME  Compute resource name
+            --compute-resource-id COMPUTE_RESOURCE_ID
+            --id ID
+            --name NAME                               Name to search by
+
+        """
+        return super(DockerContainer, cls).delete(options)
+
+    @classmethod
+    def info(cls, options=None):
+        """Gets information about a docker container
+
+        Usage::
+
+            hammer docker container info [OPTIONS]
+
+        Options::
+
+            --compute-resource COMPUTE_RESOURCE_NAME  Compute resource name
+            --compute-resource-id COMPUTE_RESOURCE_ID
+            --id ID
+            --name NAME                               Name to search by
+
+        """
+        return super(DockerContainer, cls).info(options)
+
+    @classmethod
+    def list(cls, options=None):
+        """Lists docker containers
+
+        Usage::
+
+            hammer docker container list [OPTIONS]
+
+        Options::
+
+            --compute-resource COMPUTE_RESOURCE_NAME  Compute resource name
+            --compute-resource-id COMPUTE_RESOURCE_ID
+            --page PAGE                               paginate results
+            --per-page PER_PAGE                       number of entries per
+                                                      request
+
+        """
+        return super(DockerContainer, cls).list(options)
+
+    @classmethod
+    def logs(cls, options=None):
+        """Reads container logs
+
+        Usage::
+
+            hammer docker container logs [OPTIONS]
+
+        Options::
+
+            --compute-resource COMPUTE_RESOURCE_NAME  Compute resource name
+            --compute-resource-id COMPUTE_RESOURCE_ID
+            --id ID
+            --name NAME                               Name to search by
+            --stderr STDERR                           One of true/false,
+                                                      yes/no, 1/0.
+            --stdout STDOUT                           One of true/false,
+                                                      yes/no, 1/0.
+            --tail TAIL                               Number of lines to tail.
+                                                      Default: 100
+
+        """
+        cls.command_sub = 'logs'
+        return cls.execute(cls._construct_command(options))
+
+    @classmethod
+    def start(cls, options=None):
+        """Starts a docker container
+
+        Usage::
+
+            hammer docker container start [OPTIONS]
+
+        Options::
+
+            --compute-resource COMPUTE_RESOURCE_NAME  Compute resource name
+            --compute-resource-id COMPUTE_RESOURCE_ID
+            --id ID
+            --name NAME                               Name to search by
+
+        """
+        cls.command_sub = 'start'
+        return cls.execute(cls._construct_command(options))
+
+    @classmethod
+    def status(cls, options=None):
+        """Gets the running status of a docker container
+
+        Usage::
+
+            hammer docker container status [OPTIONS]
+
+        Options::
+
+            --compute-resource COMPUTE_RESOURCE_NAME  Compute resource name
+            --compute-resource-id COMPUTE_RESOURCE_ID
+            --id ID
+            --name NAME                               Name to search by
+
+        """
+        cls.command_sub = 'status'
+        return cls.execute(cls._construct_command(options))
+
+    @classmethod
+    def stop(cls, options=None):
+        """Stops a docker container
+
+        Usage::
+
+            hammer docker container stop [OPTIONS]
+
+        Options::
+
+            --compute-resource COMPUTE_RESOURCE_NAME  Compute resource name
+            --compute-resource-id COMPUTE_RESOURCE_ID
+            --id ID
+            --name NAME                               Name to search by
+
+        """
+        cls.command_sub = 'stop'
+        return cls.execute(cls._construct_command(options))
+
+
 class DockerImage(Base):
     """Manipulates Docker images
 
@@ -187,6 +400,7 @@ class Docker(Base):
 
     Subcommands::
 
+        container                     Manage docker containers
         image                         Manage docker images
         tag                           Manage docker tags
 
@@ -195,5 +409,6 @@ class Docker(Base):
 
     # Shortcuts to docker subcommands. Instead of importing each subcommand
     # class, import the Docker class and use it like this: Docker.image.list()
+    container = DockerContainer
     image = DockerImage
     tag = DockerTag

--- a/robottelo/cli/gpgkey.py
+++ b/robottelo/cli/gpgkey.py
@@ -39,7 +39,8 @@ class GPGKey(Base):
 
         cls.command_sub = 'info'
 
-        result = cls.execute(cls._construct_command(options), expect_csv=True)
+        result = cls.execute(
+            cls._construct_command(options), output_format='csv')
 
         # Need to rebuild the returned object
         # First check for content key

--- a/robottelo/cli/host.py
+++ b/robottelo/cli/host.py
@@ -61,7 +61,8 @@ class Host(Base):
         """
         cls.command_sub = 'facts'
 
-        result = cls.execute(cls._construct_command(options), expect_csv=True)
+        result = cls.execute(
+            cls._construct_command(options), output_format='csv')
 
         facts = []
 
@@ -130,7 +131,8 @@ class Host(Base):
 
         cls.command_sub = 'reports'
 
-        result = cls.execute(cls._construct_command(options), expect_csv=True)
+        result = cls.execute(
+            cls._construct_command(options), output_format='csv')
 
         reports = []
 

--- a/robottelo/cli/hostcollection.py
+++ b/robottelo/cli/hostcollection.py
@@ -69,4 +69,5 @@ class HostCollection(Base):
             --organization-label Organization label to search by
         """
         cls.command_sub = 'content-hosts'
-        return cls.execute(cls._construct_command(options), expect_csv=True)
+        return cls.execute(
+            cls._construct_command(options), output_format='csv')

--- a/robottelo/cli/repository.py
+++ b/robottelo/cli/repository.py
@@ -63,7 +63,8 @@ class Repository(Base):
 
         cls.command_sub = 'synchronize'
 
-        result = cls.execute(cls._construct_command(options), expect_csv=True)
+        result = cls.execute(
+            cls._construct_command(options), output_format='csv')
 
         return result
 
@@ -71,5 +72,6 @@ class Repository(Base):
     def upload_content(cls, options):
         """Upload content to repository."""
         cls.command_sub = 'upload-content'
-        result = cls.execute(cls._construct_command(options), expect_csv=True)
+        result = cls.execute(
+            cls._construct_command(options), output_format='csv')
         return result

--- a/robottelo/cli/repository_set.py
+++ b/robottelo/cli/repository_set.py
@@ -37,13 +37,15 @@ class RepositorySet(Base):
     def enable(cls, options):
         """Enables a repository."""
         cls.command_sub = 'enable'
-        return cls.execute(cls._construct_command(options), expect_csv=True)
+        return cls.execute(
+            cls._construct_command(options), output_format='csv')
 
     @classmethod
     def disable(cls, options):
         """Disables a repository."""
         cls.command_sub = 'disable'
-        return cls.execute(cls._construct_command(options), expect_csv=True)
+        return cls.execute(
+            cls._construct_command(options), output_format='csv')
 
     @classmethod
     def available_repositories(cls, options):
@@ -72,4 +74,5 @@ class RepositorySet(Base):
 
         """
         cls.command_sub = 'available-repositories'
-        return cls.execute(cls._construct_command(options), expect_csv=True)
+        return cls.execute(
+            cls._construct_command(options), output_format='csv')

--- a/robottelo/cli/subscription.py
+++ b/robottelo/cli/subscription.py
@@ -69,7 +69,7 @@ class Subscription(Base):
         return result
 
     @classmethod
-    def manifest_history(cls, options=None, expect_csv=True):
+    def manifest_history(cls, options=None):
         """Provided history for subscription manifest"""
         cls.command_sub = 'manifest-history'
         return cls.execute(cls._construct_command(options))

--- a/robottelo/cli/template.py
+++ b/robottelo/cli/template.py
@@ -42,7 +42,8 @@ class Template(Base):
 
         cls.command_sub = 'kinds'
 
-        result = cls.execute(cls._construct_command(options), expect_csv=True)
+        result = cls.execute(
+            cls._construct_command(options), output_format='csv')
 
         kinds = []
 
@@ -59,7 +60,8 @@ class Template(Base):
 
         cls.command_sub = 'add-operatingsystem'
 
-        result = cls.execute(cls._construct_command(options), expect_csv=True)
+        result = cls.execute(
+            cls._construct_command(options), output_format='csv')
 
         return result
 
@@ -71,6 +73,7 @@ class Template(Base):
 
         cls.command_sub = 'remove-operatingsystem'
 
-        result = cls.execute(cls._construct_command(options), expect_csv=True)
+        result = cls.execute(
+            cls._construct_command(options), output_format='csv')
 
         return result

--- a/robottelo/cli/user.py
+++ b/robottelo/cli/user.py
@@ -36,10 +36,12 @@ class User(Base):
     def add_role(cls, options=None):
         """Add a role to a user."""
         cls.command_sub = 'add-role'
-        return cls.execute(cls._construct_command(options), expect_csv=True)
+        return cls.execute(
+            cls._construct_command(options), output_format='csv')
 
     @classmethod
     def remove_role(cls, options=None):
         """Remove a role from user."""
         cls.command_sub = 'remove-role'
-        return cls.execute(cls._construct_command(options), expect_csv=True)
+        return cls.execute(
+            cls._construct_command(options), output_format='csv')


### PR DESCRIPTION
Since the beginning of Robottelo it supported just the CVS and base
output adapters. Recently was added the JSON adapter, parsing JSON
output is easier than CSV and much more than the base output.

This will also allow future CLI improvements like adding more output
parsers and better control of output parsing.