### PR TITLE
Fix a syntax error in the test suite

### DIFF
--- a/tests/foreman/api/test_syncplan.py
+++ b/tests/foreman/api/test_syncplan.py
@@ -258,7 +258,7 @@ class SyncPlanProductTestCase(APITestCase):
         cls.prod2_id = entities.Product(
             organization=cls.org_id
         ).create_json()['id']
-        super(SyncPlanSynchronizeTestCase, cls).setUpClass()
+        super(SyncPlanProductTestCase, cls).setUpClass()
 
     @stubbed()
     @run_only_on('sat')


### PR DESCRIPTION
New test results:

    $ nosetests tests/foreman/api/test_syncplan.py:SyncPlanProductTestCase
    SSSS
    ----------------------------------------------------------------------
    Ran 4 tests in 2.494s

    OK (SKIP=4)