### PR TITLE
Skip a test that fails due to BZ 1198731

### DIFF
--- a/tests/foreman/api/test_permission.py
+++ b/tests/foreman/api/test_permission.py
@@ -13,7 +13,7 @@ from nailgun import client
 from requests.exceptions import HTTPError
 from robottelo import entities
 from robottelo.common.constants import PERMISSIONS
-from robottelo.common.decorators import data, run_only_on
+from robottelo.common.decorators import bz_bug_is_open, data, run_only_on
 from robottelo.common.helpers import get_server_credentials
 from robottelo.test import APITestCase
 # (too-many-public-methods) pylint:disable=R0904
@@ -42,6 +42,10 @@ class PermissionsTestCase(APITestCase):
         is the one searched for.
 
         """
+        if (
+                permission_name == 'power_compute_resources_vms' and
+                bz_bug_is_open(1198731)):
+            self.skipTest('BZ 1198731 is open.')
         result = entities.Permission(name=permission_name).search()
         self.assertEqual(len(result), 1, permission_name)
         self.assertEqual(permission_name, result[0]['name'])


### PR DESCRIPTION
From the bug desciption:

> To the best of my knowledge, each permission should be uniquely named.
> Unfortunately, there are two permissions named "power_compute_resources_vms".
> For example:
>
>     >>> from robottelo import entities
>     >>> entities.Permission(name='power_compute_resources_vms').search()
>     [
>         {
>             u'name': u'power_compute_resources_vms',
>             u'resource_type': u'ComputeResource',
>             u'id': 26,
>         },
>         {
>             u'name': u'power_compute_resources_vms',
>             u'resource_type': None,
>             u'id': 166,
>         },
>     ]

Tested against Satellite 6.1.0 and Foreman 1.9.0-develop:

    nosetests tests/foreman/api/test_permission.py -m test_search_by_name
    ...........................................................................................................................................S...............................................................................
    ----------------------------------------------------------------------
    Ran 219 tests in 24.544s

    OK (SKIP=1)