### PR TITLE
Rewrite `Entity.__init__`, add sync plan tests

### DIFF
--- a/tests/foreman/api/test_multiple_paths.py
+++ b/tests/foreman/api/test_multiple_paths.py
@@ -706,6 +706,24 @@ class EntityReadTestCase(APITestCase):
         self.assertEqual(len(architecture.operatingsystem), 1)
         self.assertEqual(architecture.operatingsystem[0].id, os_id)
 
+    def test_syncplan_read(self):
+        """@Test: Create a SyncPlan and read it back using
+        :meth:`robottelo.orm.EntityReadMixin.read`.
+
+        @Feature: Test multiple API paths.
+
+        @Assert: The just-read entity is an instance of the correct class.
+
+        """
+        org_id = entities.Organization().create_json()['id']
+        syncplan_id = entities.SyncPlan(
+            organization=org_id
+        ).create_json()['id']
+        self.assertIsInstance(
+            entities.SyncPlan(organization=org_id, id=syncplan_id).read(),
+            entities.SyncPlan
+        )
+
     @run_only_on('sat')
     def test_osparameter_read(self):
         """@Test: Create an OperatingSystemParameter and get it using
@@ -716,14 +734,14 @@ class EntityReadTestCase(APITestCase):
         @Assert: The just-read entity is an instance of the correct class.
 
         """
-        os_attrs = entities.OperatingSystem().create_json()
-        osp_attrs = entities.OperatingSystemParameter(
-            os_attrs['id']
-        ).create_json()
+        os_id = entities.OperatingSystem().create_json()['id']
+        osp_id = entities.OperatingSystemParameter(
+            operatingsystem=os_id
+        ).create_json()['id']
         self.assertIsInstance(
             entities.OperatingSystemParameter(
-                os_attrs['id'],
-                id=osp_attrs['id'],
+                id=osp_id,
+                operatingsystem=os_id,
             ).read(),
             entities.OperatingSystemParameter
         )

--- a/tests/foreman/api/test_operatingsystem.py
+++ b/tests/foreman/api/test_operatingsystem.py
@@ -35,11 +35,14 @@ class OSParameterTestCase(APITestCase):
         name = gen_utf8(20)
         value = gen_utf8(20)
         osp_id = entities.OperatingSystemParameter(
-            1,
             name=name,
+            operatingsystem=1,
             value=value,
         ).create()['id']
-        attrs = entities.OperatingSystemParameter(1, id=osp_id).read_json()
+        attrs = entities.OperatingSystemParameter(
+            id=osp_id,
+            operatingsystem=1,
+        ).read_json()
         self.assertEqual(attrs['name'], name)
         self.assertEqual(attrs['value'], value)
 

--- a/tests/robottelo/test_entities.py
+++ b/tests/robottelo/test_entities.py
@@ -140,6 +140,24 @@ class PathTestCase(TestCase):
                 entities.ForemanTask(id=self.id_).path(which='bulk_search')):
             self.assertIn('/foreman_tasks/api/tasks/bulk_search', gen_path)
 
+    def test_syncplan_path(self):
+        """Test :meth:`robottelo.entities.SyncPlan.path`.
+
+        Assert that the correct paths are returned when the following paths are
+        provided to ``SyncPlan.path``:
+
+        * ``add_products``
+        * ``remove_products``
+
+        """
+        for which in ('add_products', 'remove_products'):
+            path = entities.SyncPlan(organization=1, id=2).path(which)
+            self.assertIn(
+                'organizations/1/sync_plans/2/{0}'.format(which),
+                path
+            )
+            self.assertRegexpMatches(path, '{0}$'.format(which))
+
     def test_system_path(self):
         """Test :meth:`robottelo.entities.System.path`.
 


### PR DESCRIPTION
See individual commit messages for details.

The changes made in this PR are extensive, so I decided that it was appropriate to run the entire test suite. Here's the results:

    Ran 971 tests in 1556.222s

    FAILED (SKIP=196, errors=14, failures=9)

Twelve of the failures were due to my `robottelo.properties` file not containing docker configuration options. After updating my `robottelo.properties` files, I am convinced that they are fine. Several more failures are due to abrt-related permissions not being returned from the server. The remaining failures are due to the server rejecting the bogus manifest submitted during the `test_subscription` tests. All in all, the test results are completely sane.