### PR TITLE
Add basic API tests for host collections

### DIFF
--- a/robottelo/entities.py
+++ b/robottelo/entities.py
@@ -1044,9 +1044,6 @@ class HostCollection(
     class Meta(object):
         """Non-field information about this entity."""
         api_path = 'katello/api/v2/host_collections'
-        # Alternative paths.
-        #
-        # '/katello/api/v2/organizations/:organization_id/host_collections'
         server_modes = ('sat', 'sam')
 
     def read(self, auth=None, entity=None, attrs=None, ignore=()):
@@ -1070,6 +1067,11 @@ class HostCollection(
         ]
         return super(HostCollection, self).read(auth, entity, attrs, ignore)
 
+    def create_payload(self):
+        """Rename ``system_ids`` to ``system_uuids``."""
+        payload = super(HostCollection, self).create_payload()
+        payload['system_uuids'] = payload.pop('system_ids')
+        return payload
 
 class HostGroupClasses(orm.Entity):
     """A representation of a Host Group Classes entity."""

--- a/tests/foreman/api/test_hostcollection.py
+++ b/tests/foreman/api/test_hostcollection.py
@@ -1,0 +1,54 @@
+"""Unit tests for host collections."""
+from robottelo import entities
+from robottelo.test import APITestCase
+# (too-many-public-methods) pylint:disable=R0904
+
+
+class HostCollectionTestCase(APITestCase):
+    """Tests for :class:`robottelo.entities.HostCollection`."""
+
+    @classmethod
+    def setUpClass(cls):
+        """Create systems that can be shared by tests."""
+        cls.org_id = entities.Organization().create_json()['id']
+        cls.system_uuids = [
+            entities.System(organization=cls.org_id).create_json()['id']
+            for _
+            in range(2)
+        ]
+
+    def test_create_with_system(self):
+        """@Test: Create a host collection that contains a content host.
+
+        @Feature: HostCollection
+
+        @Assert: The host collection can be read back, and it includes one
+        content host.
+
+        """
+        hc_id = entities.HostCollection(
+            organization=self.org_id,
+            system=[self.system_uuids[0]],
+        ).create_json()['id']
+        self.assertEqual(
+            len(entities.HostCollection(id=hc_id).read().system),
+            1
+        )
+
+    def test_create_with_systems(self):
+        """@Test: Create a host collection that contains content hosts.
+
+        @Feature: HostCollection
+
+        @Assert: The host collection can be read back, and it references two
+        content hosts.
+
+        """
+        hc_id = entities.HostCollection(
+            organization=self.org_id,
+            system=self.system_uuids,
+        ).create_json()['id']
+        self.assertEqual(
+            len(entities.HostCollection(id=hc_id).read().system),
+            len(self.system_uuids),
+        )


### PR DESCRIPTION
Test whether it is possible to a create host collection that references one or
two systems. Test results:

    $ nosetests tests/foreman/api/test_hostcollection.py
    ..
    ----------------------------------------------------------------------
    Ran 2 tests in 5.679s

    OK

Interestingly, when a host collection is read back, the IDs of the systems in
that host collection are listed, but the UUIDs of the systems in that host
collection are not listed:

    {
        u'created_at': u'2015-03-06T21:40:26Z',
        u'description': None,
        u'id': 22,
        u'max_content_hosts': None,
        u'name': u'foo',
        u'organization_id': 1,
        u'permissions': {u'editable': True, u'deletable': True},
        u'system_ids': [18, 19],
        u'total_content_hosts': 2,
        u'unlimited_content_hosts': True,
        u'updated_at': u'2015-03-06T21:40:26Z',
    }

This means that it is impossible to discover which systems belong to a host
collection, as systems can only be read from the API if their UUIDs are
provided. As a result, the tests added here are not as thorough as they should
be.