### PR TITLE
Fix an error in `HostCollection.create_payload`

### DIFF
--- a/robottelo/entities.py
+++ b/robottelo/entities.py
@@ -1069,7 +1069,8 @@ class HostCollection(
     def create_payload(self):
         """Rename ``system_ids`` to ``system_uuids``."""
         payload = super(HostCollection, self).create_payload()
-        payload['system_uuids'] = payload.pop('system_ids')
+        if 'system_ids' in payload:
+            payload['system_uuids'] = payload.pop('system_ids')
         return payload
 
 class HostGroupClasses(orm.Entity):


### PR DESCRIPTION
When creating a host collection, you can specify the hosts/systems that belong
in that host collection by passing in UUIDs, not IDs. However, it is also
possible to create an empty host collection. Make sure to deal with this latter
case. Test results:

    $ nosetests tests/foreman/api/test_multiple_paths.py -m HostCollection
    ........SS
    ----------------------------------------------------------------------
    Ran 10 tests in 11.053s

    OK (SKIP=2)