### PR TITLE
Improve logging

### DIFF
--- a/logging.conf
+++ b/logging.conf
@@ -9,16 +9,15 @@ keys=simpleFormatter
 
 [logger_nailgun]
 level=DEBUG
-handlers=consoleHandler,fileHandler
+handlers=fileHandler
 qualname=nailgun
 
 [logger_root]
-level=DEBUG
-handlers=consoleHandler,fileHandler
+handlers=consoleHandler
 
 [logger_robottelo]
 level=DEBUG
-handlers=consoleHandler,fileHandler
+handlers=fileHandler
 qualname=robottelo
 
 [handler_consoleHandler]

--- a/robottelo/common/__init__.py
+++ b/robottelo/common/__init__.py
@@ -113,7 +113,7 @@ def _configure_logging(verbosity=2):
     else:
         log_level = logging.CRITICAL
 
-    for name in ('nailgun', 'root', 'robottelo'):
+    for name in ('nailgun', 'robottelo'):
         logging.getLogger(name).setLevel(log_level)
 
     # All output should be made by the logging module, including warnings


### PR DESCRIPTION
Robottelo logging was being duplicated on console and robottelo.log file
due to miss configuration. Improve the logging configuration in order to
have just one entry on both console and the log file.

With this new configuration root logger will send all output to console,
including entries from its children loggers. Robottelo and nailgun
loggers will send its output to the robotello.log file.