### PR TITLE
Update `Host` entity. Test BZ 1120800 and 1135651.

### DIFF
--- a/tests/foreman/api/test_host.py
+++ b/tests/foreman/api/test_host.py
@@ -7,7 +7,7 @@ http://theforeman.org/api/apidoc/v2/hosts.html
 import httplib
 from fauxfactory import gen_integer, gen_string
 from nailgun import client
-from robottelo.common.decorators import run_only_on
+from robottelo.common.decorators import skip_if_bug_open, run_only_on
 from robottelo.common.helpers import get_server_credentials
 from robottelo import entities
 from robottelo.test import APITestCase
@@ -53,3 +53,25 @@ class HostsTestCase(APITestCase):
         )
         self.assertEqual(response.status_code, httplib.OK)
         self.assertEqual(response.json()['per_page'], per_page)
+
+    @skip_if_bug_open('bugzilla', 1120800)
+    def test_bz_1120800(self):
+        """@Test: Create a host with the ``name`` parameter in the outer hash.
+
+        @Feature: Host
+
+        @Assert: A host is created.
+
+        """
+        host = entities.Host()
+        host.create_missing()
+        payload = host.create_payload()
+        payload['name'] = payload['host'].pop('name')
+        response = client.post(
+            host.path(),
+            payload,
+            auth=get_server_credentials(),
+            verify=False,
+        )
+        response.raise_for_status()
+        self.assertTrue('id' in response.json())

--- a/tests/foreman/api/test_multiple_paths.py
+++ b/tests/foreman/api/test_multiple_paths.py
@@ -391,12 +391,13 @@ class EntityIdTestCase(APITestCase):
             self.skipTest("Bugzilla bug 1154156 is open.")
 
         # Create an entity
-        entity = entity_cls(id=entity_cls().create_json()['id'])
+        entity_id = entity_cls().create_json()['id']
 
         # Update that entity.
+        entity = entity_cls()
         entity.create_missing()
         response = client.put(
-            entity.path(),
+            entity_cls(id=entity_id).path(),
             entity.create_payload(),  # FIXME: use entity.update_payload()
             auth=get_server_credentials(),
             verify=False,


### PR DESCRIPTION
Mark fewer fields on the `Host` class as required. By itself, this change makes
it impossible to automagically create hosts, so also update method
`Host.create_missing`:

> The exact set of attributes that are required varies depending on e.g.
> whether the host is managed or inherits values from a host group.
> Unfortunately, the rules for determining which attributes should be
> filled in are mildly complex, and it is hard to know which scenario
> a user is aiming for.
>
> Populate the values necessary to create a bogus managed host. However,
> _only_ do so if no instance attributes are present. Raise an exception
> if any instance attributes are present.

In other words, `Host.create_missing` fills in all the values necessary to make
a bogus managed host, but it is very timid about doing so. Existing tests pass:

    $ nosetests tests/foreman/api/test_multiple_paths.py -m Host
    .................SSSS
    ----------------------------------------------------------------------
    Ran 21 tests in 40.248s

    OK (SKIP=4)

Add one new test for BZ 1120800:

    $ nosetests tests/foreman/api/test_host.py
    S..
    ----------------------------------------------------------------------
    Ran 3 tests in 1.592s

    OK (SKIP=1)