### PR TITLE
Update API tools, esp. cls ContentViewPuppetModule

### DIFF
--- a/robottelo/orm.py
+++ b/robottelo/orm.py
@@ -362,7 +362,7 @@ class EntityReadMixin(object):
         """
         if auth is None:
             auth = helpers.get_server_credentials()
-        return client.get(self.path(), auth=auth, verify=False)
+        return client.get(self.path('self'), auth=auth, verify=False)
 
     def read_json(self, auth=None):
         """Get information about the current entity.

--- a/tests/foreman/api/test_contentview.py
+++ b/tests/foreman/api/test_contentview.py
@@ -8,7 +8,7 @@ from robottelo import entities
 from robottelo.common.constants import PUPPET_MODULE_NTP_PUPPETLABS
 from robottelo.common.decorators import (
     bz_bug_is_open, data, run_only_on, stubbed)
-from robottelo.common.helpers import get_server_credentials
+from robottelo.common.helpers import get_data_file, get_server_credentials
 from robottelo.test import APITestCase
 from unittest import SkipTest
 import re
@@ -213,7 +213,8 @@ class CVPublishPromoteTestCase(APITestCase):
             product=cls.product.id,
         )
         cls.puppet_repo.id = cls.puppet_repo.create_json()['id']
-        cls.puppet_repo.upload(PUPPET_MODULE_NTP_PUPPETLABS)
+        with open(get_data_file(PUPPET_MODULE_NTP_PUPPETLABS), 'rb') as handle:
+            cls.puppet_repo.upload_content(handle)
 
     def test_positive_publish_1(self):
         """@Test: Publish a content view several times.


### PR DESCRIPTION
* Flesh out class `ContentViewPuppetModule`.
* Rename method `Repository.upload` to `Repository.upload_content`. This makes
  the method name match the server path. Make the method throw an exception if
  the server returns any status other than "success". This makes accidental
  client bugs less likely. Make the method accept a file handle instead of a
  file path, and fix the existing usage of this method to accomodate. This makes
  the method more flexible.
* Make `OperatingSystemParameter.__init__` more strict about an operating system
  ID being passed in. This prevents client code from making accidental mistakes.
* Make `EntityReadMixin.read_raw` explicitly use the "self" path. This is
  because the `EntityReadMixin` should only be used for reading individual
  entities, not for performing searches.

The changes to `ContentViewPuppetModule` have manually been tested.

The change to `Repository.upload` does not break existing code:

    $ nosetests tests/foreman/api/test_contentview.py:CVPublishPromoteTestCase
    ......
    ----------------------------------------------------------------------
    Ran 6 tests in 340.515s

    OK

The change to `OperatingSystemParameter.__init__` does not break existing code:

    $ nosetests tests/foreman/api/test_operatingsystem.py:OSParameterTestCase
    .
    ----------------------------------------------------------------------
    Ran 1 test in 0.578s

    OK

The changes to `EntityReadMixin.read_raw` are extensively manually tested. For
the record:

    >>> from robottelo import entities
    >>> os = entities.Organization(id=1).read()
    >>>