### PR TITLE
ConfigTemplate paths and tests

### DIFF
--- a/robottelo/entities.py
+++ b/robottelo/entities.py
@@ -413,6 +413,26 @@ class ConfigTemplate(
             attrs['template_kind'] = {'id': template_kind_id}
         return super(ConfigTemplate, self).read(auth, entity, attrs, ignore)
 
+    def path(self, which=None):
+        """Extend :meth:`robottelo.orm.Entity.path`.
+
+        The format of the returned path depends on the value of ``which``:
+
+        revision
+            /content_view_versions/revision
+        build_pxe_default
+            /content_view_versions/build_pxe_default
+
+        ``super`` is called otherwise.
+
+        """
+        if which in ('revision', 'build_pxe_default'):
+            return '{0}/{1}'.format(
+                super(ConfigTemplate, self).path(which='base'),
+                which
+            )
+        return super(ConfigTemplate, self).path(which)
+
 
 class AbstractDockerContainer(
         orm.Entity, orm.EntityReadMixin, orm.EntityDeleteMixin,

--- a/tests/foreman/api/test_config_template.py
+++ b/tests/foreman/api/test_config_template.py
@@ -1,0 +1,32 @@
+"""Unit tests for the ``config_templates`` paths.
+
+A full API reference is available here:
+http://theforeman.org/api/apidoc/v2/config_templates.html
+
+"""
+from nailgun import client
+from robottelo.common.decorators import skip_if_bug_open
+from robottelo.common.helpers import get_server_credentials
+from robottelo import entities
+from robottelo.test import APITestCase
+
+
+class ConfigTemplateTestCase(APITestCase):
+    """Tests for config templates."""
+
+    @skip_if_bug_open('bugzilla', 1202564)
+    def test_build_pxe_default(self):
+        """@Test: Call the "build_pxe_default" path.
+
+        @Assert: The response is a JSON payload.
+
+        @Feature: ConfigTemplate
+
+        """
+        response = client.get(
+            entities.ConfigTemplate().path('build_pxe_default'),
+            auth=get_server_credentials(),
+            verify=False,
+        )
+        response.raise_for_status()
+        self.assertIsInstance(response.json(), dict)

--- a/tests/robottelo/test_entities.py
+++ b/tests/robottelo/test_entities.py
@@ -70,11 +70,11 @@ class PathTestCase(TestCase):
         (entities.Repository, '/repositories', 'upload_content'),
     )
     @unpack
-    def test_path_with_which(self, entity, path, which):
+    def test_self_path_with_which(self, entity, path, which):
         """Test what happens when an entity ID is given and ``which=which``.
 
         Assert that when ``entity(id=<id>).path(which=which)`` is called, the
-        resultant path contains the following string:
+        resultant path contains the following string::
 
             'path/<id>/which'
 
@@ -92,6 +92,23 @@ class PathTestCase(TestCase):
         )
 
     @data(
+        (entities.ConfigTemplate, '/config_templates', 'build_pxe_default'),
+        (entities.ConfigTemplate, '/config_templates', 'revision'),
+    )
+    @unpack
+    def test_base_path_with_which(self, entity, path, which):
+        """Test what happens when no entity ID is given and ``which=which``.
+
+        Assert that a path in the fllowing format is returned::
+
+            {path}/{which}
+
+        """
+        gen_path = entity().path(which=which)
+        self.assertIn('{0}/{1}'.format(path, which), gen_path, entity.__name__)
+        self.assertRegexpMatches(gen_path, which + '$', entity.__name__)
+
+    @data(
         (entities.ActivationKey, 'releases'),
         (entities.ContentView, 'available_puppet_module_names'),
         (entities.ContentView, 'content_view_puppet_modules'),
@@ -99,14 +116,14 @@ class PathTestCase(TestCase):
         (entities.ContentView, 'publish'),
         (entities.ContentViewVersion, 'promote'),
         (entities.ForemanTask, 'self'),
+        (entities.Organization, 'products'),
+        (entities.Organization, 'self'),
         (entities.Organization, 'subscriptions'),
         (entities.Organization, 'subscriptions/delete_manifest'),
         (entities.Organization, 'subscriptions/refresh_manifest'),
         (entities.Organization, 'subscriptions/upload'),
         (entities.Organization, 'sync_plans'),
-        (entities.Organization, 'products'),
         (entities.Product, 'repository_sets'),
-        (entities.Organization, 'self'),
         (entities.Repository, 'sync'),
         (entities.Repository, 'upload_content'),
         (entities.System, 'self'),


### PR DESCRIPTION
Add the ability to easily generate the following paths:

* $hostname/api/v2/config_templates/revision
* $hostname/api/v2/config_templates/build_pxe_default

Add unit tests for [BZ 1202564](https://bugzilla.redhat.com/show_bug.cgi?id=1202564).

See individual commit messages for more information.