### PR TITLE
Fix incorrectly written API tests

### DIFF
--- a/tests/foreman/api/test_multiple_paths.py
+++ b/tests/foreman/api/test_multiple_paths.py
@@ -154,7 +154,12 @@ class EntityTestCase(APITestCase):
         """
         logger.debug('test_get_status_code arg: %s', entity_cls)
         skip_if_sam(self, entity_cls)
-        response = entity_cls().read_raw()
+        response = client.get(
+            entity_cls().path(),
+            auth=get_server_credentials(),
+            verify=False,
+        )
+        response.raise_for_status()
         self.assertEqual(httplib.OK, response.status_code)
         self.assertIn('application/json', response.headers['content-type'])
 
@@ -195,7 +200,7 @@ class EntityTestCase(APITestCase):
         """
         logger.debug('test_get_unauthorized arg: %s', entity_cls)
         skip_if_sam(self, entity_cls)
-        response = entity_cls().read_raw(auth=())
+        response = client.get(entity_cls().path(), auth=(), verify=False)
         self.assertEqual(httplib.UNAUTHORIZED, response.status_code)
 
     @data(


### PR DESCRIPTION
Commit 053b47f5a28ec140355c2cf7eefadb2b65419561 made method
`EntityReadMixin.read_raw` more strict. Class `EntityReadMixin` is only intended
to be used for reading individual entities, and that commit helped to guard
against unintended usages of the mixin by making method `read_raw` call
`self.path('self')`. Unfortunately, this broke several API tests which were
abusing the method. Fix those tests. Updated test results:

    $ nosetests tests/foreman/api/test_multiple_paths.py:EntityTestCase -m test_get_unauthorized
    ........................
    ----------------------------------------------------------------------
    Ran 24 tests in 8.928s

    OK
    $ nosetests tests/foreman/api/test_multiple_paths.py:EntityTestCase -m test_get_status_code
    .................
    ----------------------------------------------------------------------
    Ran 17 tests in 9.966s

    OK