### PR TITLE
Add test for BZ 1203323

### DIFF
--- a/tests/foreman/api/test_hostcollection.py
+++ b/tests/foreman/api/test_hostcollection.py
@@ -1,4 +1,5 @@
 """Unit tests for host collections."""
+from robottelo.common.decorators import skip_if_bug_open
 from robottelo import entities
 from robottelo.test import APITestCase
 # (too-many-public-methods) pylint:disable=R0904
@@ -51,4 +52,24 @@ class HostCollectionTestCase(APITestCase):
         self.assertEqual(
             len(entities.HostCollection(id=hc_id).read().system),
             len(self.system_uuids),
+        )
+
+    @skip_if_bug_open('bugzilla', 1203323)
+    def test_read_system_ids(self):
+        """@Test: Read a host collection and look at the ``system_ids`` field.
+
+        @Feature: HostCollection
+
+        @Assert: The ``system_ids`` field matches the system IDs passed in when
+        creating the host collection.
+
+        """
+        hc_id = entities.HostCollection(
+            organization=self.org_id,
+            system=self.system_uuids,
+        ).create_json()['id']
+        hc_attrs = entities.HostCollection(id=hc_id).read_json()
+        self.assertEqual(
+            frozenset(hc_attrs['system_ids']),
+            frozenset(self.system_uuids),
         )


### PR DESCRIPTION
From the bug report:

> GET /katello/api/v2/host_collections/:id returns the attributes of a
> particular host collection. Here is an example of one response:
>
>     {
>         u'created_at': u'2015-03-18T14:27:45Z',
>         u'description': None,
>         u'id': 13,
>         u'max_content_hosts': None,
>         u'name': u'…',
>         u'organization_id': 180,
>         u'permissions': {u'editable': True, u'deletable': True},
>         u'system_ids': [5, 6],
>         u'total_content_hosts': 2,
>         u'unlimited_content_hosts': True,
>         u'updated_at': u'2015-03-18T14:27:45Z',
>     }
>
> Notice that "system_ids" is a list of IDs, not UUIDs. This is problematic
> because systems are identified by their UUIDs throughout the API. For example:
>
> * When executing GET /katello/api/v2/systems/:id, ":id" should be a UUID.
> * When executing POST /katello/api/v2/host_collections, you can specify either
>   (both?) "system_ids" or "system_uuids" parameters, and they should be UUIDs.
>
> As a result, it is impossible to fetch information about the referenced
> systems given this information. In other words, given a host collection, you
> cannot determine which systems are in it.

Test result against a downstream system:

    $ nosetests tests/foreman/api/test_hostcollection.py
    ..S
    ----------------------------------------------------------------------
    Ran 3 tests in 12.420s

    OK (SKIP=1)