### PR TITLE
Drop references to BZ 1166365

### DIFF
--- a/robottelo/entities.py
+++ b/robottelo/entities.py
@@ -2308,21 +2308,6 @@ class Repository(
             )
         return response_json
 
-    def delete(self, auth=None, synchronous=True):
-        """Wait for elasticsearch to catch up to repository deletion.
-
-        Repository.delete launches a ForemanTask, but the ID of the task is not
-        returned. See BZ 1166365.
-
-        """
-        response = super(Repository, self).delete(auth, synchronous)
-        if bz_bug_is_open(1166365):
-            for _ in range(5):
-                if self.read_raw().status_code == 404:
-                    break
-                sleep(5)
-        return response
-
     class Meta(object):
         """Non-field information about this entity."""
         api_path = 'katello/api/v2/repositories'

--- a/tests/foreman/api/test_multiple_paths.py
+++ b/tests/foreman/api/test_multiple_paths.py
@@ -631,8 +631,6 @@ class DoubleCheckTestCase(APITestCase):
             self.skipTest('BZ 1096333: Cannot delete config templates.')
         if entity_cls in BZ_1187366_ENTITIES and bz_bug_is_open(1187366):
             self.skipTest('BZ 1187366: Cannot delete orgs or environments.')
-        if entity_cls is entities.Repository and bz_bug_is_open(1166365):
-            self.skipTest('BZ 1166365: Cannot monitor repository deletion.')
         if entity_cls == entities.System and bz_bug_is_open(1133071):
             self.skipTest('BZ 1133071: Receive HTTP 400s instead of 404s.')
 

--- a/tests/foreman/api/test_repository.py
+++ b/tests/foreman/api/test_repository.py
@@ -15,12 +15,7 @@ from robottelo.common.constants import (
     VALID_GPG_KEY_BETA_FILE,
     VALID_GPG_KEY_FILE,
 )
-from robottelo.common.decorators import (
-    bz_bug_is_open,
-    data,
-    run_only_on,
-    skip_if_bug_open,
-)
+from robottelo.common.decorators import bz_bug_is_open, data, run_only_on
 from robottelo.common.helpers import (
     get_server_credentials, get_data_file, read_data_file)
 from robottelo.test import APITestCase
@@ -125,7 +120,6 @@ class RepositoryTestCase(APITestCase):
                 entities.Repository(id=repo2_attrs['id']).read_json()):
             self.assertEqual(attrs['name'], name)
 
-    @skip_if_bug_open('bugzilla', 1166365)
     @run_only_on('sat')
     @data(*_test_data())  # (star-args) pylint:disable=W0142
     def test_delete(self, attrs):


### PR DESCRIPTION
BZ 1166365 is verified. Drop all references to the bug. Example test results:

    $ nosetests tests/foreman/api/test_repository.py -m test_delete
    ...........
    ----------------------------------------------------------------------
    Ran 11 tests in 43.024s

    OK