### PR TITLE
Add test for BZ 1203457

### DIFF
--- a/tests/foreman/cli/test_host.py
+++ b/tests/foreman/cli/test_host.py
@@ -1,14 +1,25 @@
-from fauxfactory import gen_string, gen_integer
-from robottelo.test import CLITestCase
-from robottelo.cli.factory import (
-    CLIFactoryError, make_architecture, make_domain, make_environment,
-    make_host, make_location, make_medium, make_org, make_os,
-    make_partition_table)
+"""CLI tests for ``hammer host``."""
+from robottelo.cli.host import Host
 from robottelo.cli.proxy import Proxy
+from robottelo import entities
+from robottelo.test import CLITestCase
 
 
 class HostTestCase(CLITestCase):
     """Host CLI tests."""
+
+    def setUp(self):
+        """Find an existing puppet proxy.
+
+        Record information about this puppet proxy as ``self.puppet_proxy``.
+
+        """
+        # Use the default installation smart proxy
+        result = Proxy.list()
+        self.assertEqual(result.return_code, 0)
+        self.assertEqual(len(result.stderr), 0)
+        self.assertGreater(len(result.stdout), 0)
+        self.puppet_proxy = result.stdout[0]
 
     def test_positive_create_1(self):
         """@test: A host can be created with a random name
@@ -18,44 +29,25 @@ class HostTestCase(CLITestCase):
         @assert: A host is created and the name matches
 
         """
-        # Use the default installation smart proxy
-        result = Proxy.list()
+        host = entities.Host()
+        host.create_missing()
+        result = Host.create({
+            u'architecture-id': host.architecture.id,
+            u'domain-id': host.domain.id,
+            u'environment-id': host.environment.id,
+            u'location-id': host.location.id,  # pylint:disable=no-member
+            u'mac': host.mac,
+            u'medium-id': host.medium.id,
+            u'name': host.name,
+            u'operatingsystem-id': host.operatingsystem.id,
+            u'organization-id': host.organization.id,  # pylint:disable=E1101
+            u'partition-table-id': host.ptable.id,
+            u'puppet-proxy-id': self.puppet_proxy['id'],
+            u'root-pass': host.root_pass,
+        })
         self.assertEqual(result.return_code, 0)
         self.assertEqual(len(result.stderr), 0)
-        self.assertGreater(len(result.stdout), 0)
-        puppet_proxy = result.stdout[0]
-
-        host_name = gen_string(str_type='alpha', length=gen_integer(1, 10))
-
-        try:
-            # Creating dependent objects
-            architecture = make_architecture()
-            domain = make_domain()
-            environment = make_environment()
-            location = make_location()
-            medium = make_medium()
-            ptable = make_partition_table()
-            organization = make_org(cached=True)
-            os = make_os({
-                u'architecture-ids': architecture['id'],
-                u'medium-ids': medium['id'],
-                u'partition-table-ids': ptable['id'],
-            })
-
-            host = make_host({
-                u'architecture-id': architecture['id'],
-                u'domain-id': domain['id'],
-                u'environment-id': environment['id'],
-                u'location-id': location['id'],
-                u'medium-id': medium['id'],
-                u'name': host_name,
-                u'operatingsystem-id': os['id'],
-                u'organization-id': organization['id'],
-                u'partition-table-id': ptable['id'],
-                u'puppet-proxy-id': puppet_proxy['id'],
-            })
-        except CLIFactoryError as err:
-            self.fail(err)
-
-        name = '{0}.{1}'.format(host_name, domain['name']).lower()
-        self.assertEqual(host['name'], name)
+        self.assertEqual(
+            '{0}.{1}'.format(host.name, host.domain.read().name).lower(),
+            result.stdout['name'],
+        )


### PR DESCRIPTION
From the [bug report](https://bugzilla.redhat.com/show_bug.cgi?id=1203457):

> An operating system can have zero or more architectures, media and partition
> tables. It should be possible to associate an operating system with each of
> these things when creating an operating system using hammer. For example:
>
>     $ hammer -u … -p … os create \
>     >     --name foo \
>     >     --major 1 \
>     >     --architecture-ids 1 \
>     >     --medium-ids 1 \
>     >     --partition-table-ids 1
>     Operating system created
>
> This is especially useful when creating a host: both a host and its operating
> system must reference the same architecture, media and partition tables.
> Unfortunately, these flags are not recognized by hammer:
>
>     $ hammer -u admin -p changeme os create --name bar --major 2 --architecture-ids 1
>     Could not create the operating system:
>     Error: Unrecognised option '--architecture-ids'
>
>     See: 'hammer os create --help'
>     $ hammer -u admin -p changeme os create --name bar --major 2 --medium-ids 1
>     Could not create the operating system:
>     Error: Unrecognised option '--medium-ids'
>
>     See: 'hammer os create --help'
>     $ hammer -u admin -p changeme os create --name bar --major 2 --partition-table-ids 1
>     Could not create the operating system:
>     Error: Unrecognised option '--partition-table-ids'
>
>     See: 'hammer os create --help'
>
> The relevant flags are not displayed by `--help` either:
>
>     $ hammer -u admin -p changeme os create --help
>     Usage:
>         hammer os create [OPTIONS]
>
>     Options:
>     --description DESCRIPTION
>     --family FAMILY
>     --major MAJOR
>     --minor MINOR
>     --name NAME
>     --password-hash PASSWORD_HASH Root password hash function to use, one of MD5, SHA256, SHA512
>     --release-name RELEASE_NAME
>     -h, --help                    print help

Test results:

    $ nosetests tests/foreman/cli/test_host.py
    .
    ----------------------------------------------------------------------
    Ran 1 test in 10.335s

    OK
    $ nosetests tests/foreman/cli/test_os.py -m 1203457
    S
    ----------------------------------------------------------------------
    Ran 1 test in 0.545s

    OK (SKIP=1)