### PR TITLE
Test BZ 1177570, update ComputeResource entity

### DIFF
--- a/robottelo/entities.py
+++ b/robottelo/entities.py
@@ -267,13 +267,14 @@ class ComputeResource(
         orm.EntityCreateMixin):
     """A representation of a Compute Resource entity."""
     description = entity_fields.StringField(null=True)
-    # `name` cannot contain whitespace. Thus, the chosen string types.
+    location = entity_fields.OneToManyField('Location')
     name = entity_fields.StringField(
-        required=True, str_type=('alphanumeric', 'cjk'))
+        required=True,
+        str_type=('alphanumeric', 'cjk'),  # name cannot contain whitespace
+    )
+    organization = entity_fields.OneToManyField('Organization')
     password = entity_fields.StringField(null=True)
     provider = entity_fields.StringField(
-        null=True,
-        required=True,
         choices=(
             'Docker',
             'EC2',
@@ -283,10 +284,13 @@ class ComputeResource(
             'Ovirt',
             'Rackspace',
             'Vmware',
-        )
+        ),
+        null=True,
+        required=True,
     )
     region = entity_fields.StringField(null=True)
     server = entity_fields.StringField(null=True)
+    set_console_password = entity_fields.BooleanField(null=True)
     tenant = entity_fields.StringField(null=True)
     url = entity_fields.URLField(required=True)
     user = entity_fields.StringField(null=True)

--- a/tests/foreman/cli/test_host.py
+++ b/tests/foreman/cli/test_host.py
@@ -1,6 +1,8 @@
 """CLI tests for ``hammer host``."""
 from robottelo.cli.host import Host
 from robottelo.cli.proxy import Proxy
+from robottelo.common.decorators import skip_if_bug_open
+from robottelo.common import conf
 from robottelo import entities
 from robottelo.test import CLITestCase
 
@@ -50,4 +52,44 @@ class HostTestCase(CLITestCase):
         self.assertEqual(
             '{0}.{1}'.format(host.name, host.domain.read().name).lower(),
             result.stdout['name'],
+        )
+
+    @skip_if_bug_open('bugzilla', 1177570)
+    def test_bz_1177570(self):
+        """@Test: Create a libvirt host and specify just a MAC address.
+
+        @Feature: Hosts
+
+        @Assert: No host is created, and an appropriately descriptive error
+        message is returned.
+
+        """
+        compute_resource_id = entities.ComputeResource(
+            provider='Libvirt',
+            url='qemu+tcp://{0}:16509/system'.format(
+                conf.properties['main.server.hostname']
+            ),
+        ).create_json()['id']
+        host = entities.Host()
+        host.create_missing()
+        result = Host.create({
+            u'architecture-id': host.architecture.id,
+            u'compute-resource-id': compute_resource_id,
+            u'domain-id': host.domain.id,
+            u'environment-id': host.environment.id,
+            u'location-id': host.location.id,  # pylint:disable=no-member
+            u'mac': host.mac,
+            u'medium-id': host.medium.id,
+            u'name': host.name,
+            u'operatingsystem-id': host.operatingsystem.id,
+            u'organization-id': host.organization.id,  # pylint:disable=E1101
+            u'partition-table-id': host.ptable.id,
+            u'puppet-proxy-id': self.puppet_proxy['id'],
+            u'root-pass': host.root_pass,
+        })
+        self.assertNotEqual(result.return_code, 0)
+        self.assertNotIn('mac value is blank', result.stderr)
+        self.assertIn(
+            'you must specify either compute attributes or a compute profile',
+            result.stderr
         )


### PR DESCRIPTION
Summary:

1. Add an automated CLI test for [BZ 1177570](https://bugzilla.redhat.com/show_bug.cgi?id=1177570).
2. Add missing fields to the `ComputeResource` entity class.

See individual commit messages for more details.