### PR TITLE
Add a test for BZ 1203865

### DIFF
--- a/robottelo/entities.py
+++ b/robottelo/entities.py
@@ -1210,6 +1210,10 @@ class Host(
     operatingsystem = entity_fields.OneToOneField('OperatingSystem', null=True)
     organization = entity_fields.OneToOneField('Organization', required=True)
     owner = entity_fields.OneToOneField('User', null=True)
+    owner_type = entity_fields.StringField(
+        choices=('User', 'Usergroup'),
+        null=True,
+    )
     provision_method = entity_fields.StringField(null=True)
     ptable = entity_fields.OneToOneField('PartitionTable', null=True)
     puppet_classes = entity_fields.OneToManyField('PuppetClass', null=True)


### PR DESCRIPTION
From the [bug report](https://bugzilla.redhat.com/show_bug.cgi?id=1203865):

> When creating or updating a host, it is possible to specify an owner_type. From
> the API docs:
>
> > host[owner_type]
> > optional , nil allowed
> > Host's owner type
> > Value: Must be one of: User, Usergroup.
>
> The "owner_type" attribute is set to "User" when creating a host, even if one
> provides a value of "Usergroup".

Test result:

    $ nosetests tests/foreman/api/test_host.py -m owner_type
    .S..
    ----------------------------------------------------------------------
    Ran 4 tests in 15.075s

    OK (SKIP=1)