### PR TITLE
Improve logging for UI

### DIFF
--- a/robottelo/ui/locators.py
+++ b/robottelo/ui/locators.py
@@ -1,14 +1,45 @@
 # -*- encoding: utf-8 -*-
-# vim: ts=4 sw=4 expandtab ai
+"""Implements different locators for UI"""
 
-"""
-Implements different locators for UI
-"""
+import collections
+import logging
 
 from selenium.webdriver.common.by import By
 
 
-menu_locators = {
+LOGGER = logging.getLogger(__name__)
+
+
+class LocatorDict(collections.Mapping):
+    """This class will log every time an item is selected
+
+    The constructor accepts a dictionary or keyword arguments like the
+    built-in ``dict``::
+
+        >>> dict({'a': 'b'})
+        {'a': 'b'}
+        >>> dict(a='b')
+        {'a': 'b'}
+
+    """
+    def __init__(self, *args, **kwargs):
+        self.store = dict(*args, **kwargs)
+
+    def __getitem__(self, key):
+        item = self.store[key]
+        LOGGER.debug(
+            'Accessing locator "%s" by %s: "%s"', key, item[0], item[1]
+        )
+        return item
+
+    def __len__(self):
+        return len(self.store)
+
+    def __iter__(self):
+        return iter(self.store)
+
+
+menu_locators = LocatorDict({
     # Menus
 
     # Monitor Menu
@@ -289,9 +320,9 @@ menu_locators = {
         By.XPATH,
         ("//div[contains(@style,'static') or contains(@style,'fixed')]"
          "//a[@href='/locations/clear']/../../li/a[contains(.,'%s')]"))
-}
+})
 
-tab_locators = {
+tab_locators = LocatorDict({
 
     # common
     "tab_primary": (By.XPATH, "//a[@href='#primary']"),
@@ -500,9 +531,10 @@ tab_locators = {
         "//a[@data-toggle='tab' and contains(@href, 'ForemanTasks')]"),
     "settings.tab_provisioning": (
         By.XPATH,
-        "//a[@data-toggle='tab' and contains(@href, 'Provisioning')]")}
+        "//a[@data-toggle='tab' and contains(@href, 'Provisioning')]")
+})
 
-common_locators = {
+common_locators = LocatorDict({
 
     # common locators
 
@@ -595,9 +627,10 @@ common_locators = {
     "all_values_selection": (
         By.XPATH,
         ("//div[@class='ms-selection']//ul[@class='ms-list']/li"
-         "/span[contains(.,'%s')]/.."))}
+         "/span[contains(.,'%s')]/.."))
+})
 
-locators = {
+locators = LocatorDict({
 
     # Locations
     "location.new": (By.XPATH, "//a[@data-id='aid_locations_new']"),
@@ -1657,4 +1690,5 @@ locators = {
         By.XPATH, "//a[contains(@href,'models') and contains(.,'%s')]"),
     "hwmodels.delete": (
         By.XPATH, ("//a[contains(@data-confirm,'%s')"
-                   " and @class='delete']"))}
+                   " and @class='delete']"))
+})


### PR DESCRIPTION
Now every time a locator is selected a debug entry mentioning the
locator key and value will be created.

After the changes:

```
2015-03-24 16:55:07 - robottelo.ui.locators - DEBUG - Accessing locator "login.username" by id: "login_login"
2015-03-24 16:55:07 - robottelo.ui.locators - DEBUG - Accessing locator "login.username" by id: "login_login"
2015-03-24 16:55:08 - robottelo.ui.locators - DEBUG - Accessing locator "login.password" by id: "login_password"
2015-03-24 16:55:08 - robottelo.ui.locators - DEBUG - Accessing locator "submit" by name: "commit"
2015-03-24 16:55:13 - robottelo.ui.locators - DEBUG - Accessing locator "notif.error" by xpath: "//div[contains(@class, 'jnotify-notification-error')]"
2015-03-24 16:55:13 - robottelo.ui.locators - DEBUG - Accessing locator "menu.administer" by xpath: "//div[contains(@style,'static') or contains(@style, 'fixed')]//a[@id='administer_menu']"
2015-03-24 16:55:13 - robottelo.ui.locators - DEBUG - Accessing locator "menu.users" by xpath: "//div[contains(@style,'static') or contains(@style, 'fixed')]//a[@id='menu_item_users']"
2015-03-24 16:55:15 - robottelo.ui.locators - DEBUG - Accessing locator "users.new" by xpath: "//a[contains(@href, '/users/new')]"
2015-03-24 16:55:18 - robottelo.ui.locators - DEBUG - Accessing locator "users.new" by xpath: "//a[contains(@href, '/users/new')]"
2015-03-24 16:55:19 - robottelo.ui.locators - DEBUG - Accessing locator "users.username" by id: "user_login"
2015-03-24 16:55:21 - robottelo.ui.locators - DEBUG - Accessing locator "users.username" by id: "user_login"
2015-03-24 16:55:22 - robottelo.ui.locators - DEBUG - Accessing locator "users.firstname" by id: "user_firstname"
2015-03-24 16:55:23 - robottelo.ui.locators - DEBUG - Accessing locator "users.lastname" by id: "user_lastname"
2015-03-24 16:55:23 - robottelo.ui.locators - DEBUG - Accessing locator "users.authorized_by" by id: "user_auth_source_id"
2015-03-24 16:55:23 - robottelo.ui.locators - DEBUG - Accessing locator "users.authorized_by" by id: "user_auth_source_id"
2015-03-24 16:55:24 - robottelo.ui.locators - DEBUG - Accessing locator "users.email" by id: "user_mail"
2015-03-24 16:55:25 - robottelo.ui.locators - DEBUG - Accessing locator "users.email" by id: "user_mail"
2015-03-24 16:55:26 - robottelo.ui.locators - DEBUG - Accessing locator "users.password" by id: "user_password"
2015-03-24 16:55:26 - robottelo.ui.locators - DEBUG - Accessing locator "users.password" by id: "user_password"
2015-03-24 16:55:27 - robottelo.ui.locators - DEBUG - Accessing locator "users.password_confirmation" by id: "user_password_confirmation"
2015-03-24 16:55:27 - robottelo.ui.locators - DEBUG - Accessing locator "users.password_confirmation" by id: "user_password_confirmation"
2015-03-24 16:55:28 - robottelo.ui.locators - DEBUG - Accessing locator "submit" by name: "commit"
2015-03-24 16:55:33 - robottelo.ui.locators - DEBUG - Accessing locator "menu.administer" by xpath: "//div[contains(@style,'static') or contains(@style, 'fixed')]//a[@id='administer_menu']"
2015-03-24 16:55:33 - robottelo.ui.locators - DEBUG - Accessing locator "menu.users" by xpath: "//div[contains(@style,'static') or contains(@style, 'fixed')]//a[@id='menu_item_users']"
2015-03-24 16:55:38 - robottelo.ui.locators - DEBUG - Accessing locator "users.user" by xpath: "//a[contains(., '%s')]"
2015-03-24 16:55:38 - robottelo.ui.locators - DEBUG - Accessing locator "search" by id: "search"
2015-03-24 16:55:38 - robottelo.ui.locators - DEBUG - Accessing locator "search_button" by xpath: "//button[contains(@type,'submit')]"
2015-03-24 16:55:44 - robottelo.ui.locators - DEBUG - Accessing locator "login.gravatar" by xpath: "//img[contains(@class, 'avatar')]"
2015-03-24 16:55:44 - robottelo.ui.locators - DEBUG - Accessing locator "menu.account" by xpath: "//a[@id='account_menu']"
2015-03-24 16:55:44 - robottelo.ui.locators - DEBUG - Accessing locator "menu.sign_out" by xpath: "//a[@id='menu_item_logout']"
```