### PR TITLE
Fix and skip failing CLI tests

### DIFF
--- a/tests/foreman/cli/test_repository.py
+++ b/tests/foreman/cli/test_repository.py
@@ -246,31 +246,20 @@ class TestRepository(CLITestCase):
         @BZ: 1103944
 
         """
-
-        # Make a new gpg key
         new_gpg_key = make_gpg_key({'organization-id': self.org['id']})
-
         new_repo = self._make_repository({
             u'name': name,
             u'gpg-key': new_gpg_key['name'],
         })
 
-        # Fetch it again
-        result = Repository.info({'id': new_repo['id']})
-        self.assertEqual(
-            result.return_code,
-            0,
-            "Repository was not found")
-        self.assertEqual(
-            len(result.stderr), 0, "No error was expected")
         # Assert that data matches data passed
         self.assertEqual(
-            result.stdout['gpg-key']['id'],
+            new_repo['gpg-key']['id'],
             new_gpg_key['id'],
             "GPG Keys ID don't match"
         )
         self.assertEqual(
-            result.stdout['gpg-key']['name'],
+            new_repo['gpg-key']['name'],
             new_gpg_key['name'],
             "GPG Keys name don't match"
         )
@@ -573,7 +562,7 @@ class TestRepository(CLITestCase):
 
         """
 
-    @skip_if_bug_open('bugzilla', 1155237)
+    @skip_if_bug_open('bugzilla', 1208305)
     @run_only_on('sat')
     @data(
         u'sha1',
@@ -587,7 +576,7 @@ class TestRepository(CLITestCase):
         @Assert: A YUM repository is updated and contains the correct checksum
         type
 
-        @BZ: 1155237
+        @BZ: 1208305
 
         """
         content_type = u'yum'

--- a/tests/foreman/cli/test_subscription.py
+++ b/tests/foreman/cli/test_subscription.py
@@ -53,12 +53,16 @@ class TestSubscription(CLITestCase):
             len(result.stderr), 0,
             "There should not be an exception while listing the manifest.")
 
+    @skip_if_bug_open('bugzilla', 1207501)
     def test_manifest_delete(self):
         """@Test: Delete uploaded manifest (positive)
 
         @Feature: Subscriptions/Manifest Delete
 
         @Assert: Manifest are deleted properly
+
+        @BZ: 1207501
+
         """
 
         upload_file(self.manifest, remote_file=self.manifest)
@@ -203,6 +207,8 @@ class TestSubscription(CLITestCase):
         @Feature: Subscriptions/Manifest refresh
 
         @Assert: Manifests can be refreshed
+
+        @BZ 1147559
 
         """
         upload_file(self.manifest, remote_file=self.manifest)

--- a/tests/foreman/cli/test_user.py
+++ b/tests/foreman/cli/test_user.py
@@ -922,8 +922,11 @@ class User(CLITestCase):
 
         # Update the mail
         email = '{0}@example.com'.format(test_data)
-        result = UserObj().update({'id': new_obj['id'],
-                                   'mail': email})
+        result = UserObj().update({
+            'id': new_obj['id'],
+            # escape ` to avoid bash syntax error
+            'mail': email.replace('`', r'\`'),
+        })
         self.assertEqual(result.return_code, 0)
         self.assertEqual(
             len(result.stderr), 0, "There should not be an error here")


### PR DESCRIPTION
Failing repository, subscription and user tests was fixed or skipped
based on the latest compose automation results.

This should decrease the failures by 4.