### PR TITLE
Add two fields to the "User" entity class

### DIFF
--- a/robottelo/entities.py
+++ b/robottelo/entities.py
@@ -2752,7 +2752,9 @@ class User(
     default_organization = entity_fields.OneToOneField('Organization', null=True)
     firstname = entity_fields.StringField(null=True, length=(1, 50))
     lastname = entity_fields.StringField(null=True, length=(1, 50))
+    location = entity_fields.OneToManyField('Location', null=True)
     mail = entity_fields.EmailField(required=True)
+    organization = entity_fields.OneToManyField('Organization', null=True)
     password = entity_fields.StringField(required=True)
 
     def __init__(self, server_config=None, **kwargs):


### PR DESCRIPTION
According to the most recent downstream builds, "organization_ids" and
"location_ids" fields may be specified when creating or updating a user. NailGun
makes use of this fact in its example documentation. As you can see, the
`organizations` field is listed in the response from the server each time a user
is created:

    $ ./create_user_nailgun.py
    {u'admin': False,
    u'auth_source_id': 1,
    u'auth_source_internal': {u'id': 1,
                            u'name': u'Internal',
                            u'type': u'AuthSourceInternal'},
    u'auth_source_name': u'Internal',
    u'created_at': u'2015-04-07T15:43:41Z',
    u'default_location': None,
    u'default_organization': None,
    u'firstname': None,
    u'id': 124,
    u'last_login_on': None,
    u'lastname': None,
    u'locations': [],
    u'login': u'Charlie',
    u'mail': u'alice@example.com',
    u'mail_notifications': [],
    u'organizations': [{u'id': 1,
                        u'name': u'Default Organization',
                        u'title': u'Default Organization'}],
    u'roles': [{u'id': 14, u'name': u'Anonymous'}],
    u'updated_at': u'2015-04-07T15:43:41Z',
    u'usergroups': []}
    {u'admin': False,
    u'auth_source_id': 1,
    u'auth_source_internal': {u'id': 1,
                            u'name': u'Internal',
                            u'type': u'AuthSourceInternal'},
    u'auth_source_name': u'Internal',
    u'created_at': u'2015-04-07T15:43:43Z',
    u'default_location': None,
    u'default_organization': None,
    u'firstname': None,
    u'id': 125,
    u'last_login_on': None,
    u'lastname': None,
    u'locations': [],
    u'login': u'Charlie',
    u'mail': u'alice@example.com',
    u'mail_notifications': [],
    u'organizations': [{u'id': 1,
                        u'name': u'Default Organization',
                        u'title': u'Default Organization'}],
    u'roles': [{u'id': 14, u'name': u'Anonymous'}],
    u'updated_at': u'2015-04-07T15:43:43Z',
    u'usergroups': []}