### PR TITLE
Skip a test that fails due to BZ 1210001

### DIFF
--- a/tests/foreman/api/test_host.py
+++ b/tests/foreman/api/test_host.py
@@ -115,6 +115,8 @@ class HostsTestCase(APITestCase):
         correct.
 
         """
+        if owner_type == 'Usergroup' and bz_bug_is_open(1210001):
+            self.skipTest('BZ 1210001: host update should block or yield task')
         host_id = entities.Host().create_json()['id']
         response = client.put(
             entities.Host(id=host_id).path(),


### PR DESCRIPTION
From the [bug report](https://bugzilla.redhat.com/show_bug.cgi?id=1210001):

> It's possible to update a host's owner type to "Usergroup", read back
> information about that host and receive a response stating that the host has
> an owner type of "User".
>
> …
>
> This issue is known to affect updating a host's owner_type, but there may be
> other host attributes that are affected by this bug.

Tested against Satellite-6.1.0-RHEL-{6,7}-20150407.1:

    $ nosetests tests/foreman/api/test_host.py -m test_update_owner_type
    .S
    ----------------------------------------------------------------------
    Ran 2 tests in 6.103s

    OK (SKIP=1)