### PR TITLE
Update CLI tests

### DIFF
--- a/tests/foreman/cli/test_activationkey.py
+++ b/tests/foreman/cli/test_activationkey.py
@@ -1741,7 +1741,7 @@ class TestActivationKey(CLITestCase):
             result = ActivationKey.content_override({
                 u'id': self.pub_key['key_id'],
                 u'organization-id': self.pub_key['org_id'],
-                u'label': product_label,
+                u'content-label': product_label,
                 u'value': override_value,
             })
         except CLIFactoryError as err:

--- a/tests/foreman/cli/test_docker.py
+++ b/tests/foreman/cli/test_docker.py
@@ -11,7 +11,12 @@ from robottelo.cli.factory import (
 )
 from robottelo.cli.repository import Repository
 from robottelo.common.constants import DOCKER_REGISTRY_HUB
-from robottelo.common.decorators import data, run_only_on, stubbed
+from robottelo.common.decorators import (
+    data,
+    run_only_on,
+    skip_if_bug_open,
+    stubbed,
+)
 from robottelo.common.helpers import (
     get_external_docker_url,
     get_internal_docker_url,
@@ -27,12 +32,15 @@ INTERNAL_DOCKER_URL = get_internal_docker_url()
 class DockerImageTestCase(CLITestCase):
     """Tests related to docker image command"""
 
+    @skip_if_bug_open('bugzilla', 1205826)
     def test_bugzilla_1190122(self):
         """@Test: docker image displays tags information for a docker image
 
         @Feature: Docker
 
         @Assert: docker image displays tags information for a docker image
+
+        @BZ: 1205826
 
         """
         try:

--- a/tests/foreman/cli/test_os.py
+++ b/tests/foreman/cli/test_os.py
@@ -152,12 +152,15 @@ class TestOperatingSystem(CLITestCase):
                          'OS major version was not updated')
 
     @skip_if_bug_open('bugzilla', 1203457)
+    @skip_if_bug_open('bugzilla', 1200116)
     def test_bugzilla_1203457(self):
         """@test: Create an OS pointing to an arch, medium and partition table.
 
         @feature: Operating System - Create
 
         @assert: An operating system is created.
+
+        @bz: 1203457, 1200116
 
         """
         architecture = make_architecture()


### PR DESCRIPTION
Based on Jenkins failures:

* Update Activation Key add content override command option.
* Skip test_bugzilla_1190122 Docker test because the required ruby gem
  is not being installed. Linked it to related BZ.
* Skip test_bugzilla_1203457 Operating System test because missing
  previous accepted options. Linked it to related BZ.

This should decrease the number of failures on Jenkins. It also can make the CLI automation green because other failures seems to be related to the server being a little slow to delete/update some data.