### PR TITLE
Resolve #690 issue

### DIFF
--- a/robottelo/entities.py
+++ b/robottelo/entities.py
@@ -799,6 +799,7 @@ class ContentView(
                 'available_puppet_modules',
                 'content_view_puppet_modules',
                 'content_view_versions',
+                'copy',
                 'publish'):
             return '{0}/{1}'.format(
                 super(ContentView, self).path(which='self'),
@@ -885,6 +886,23 @@ class ContentView(
         response = client.post(
             self.path('content_view_puppet_modules'),
             {u'author': author, u'name': name},
+            auth=self._server_config.auth,
+            verify=self._server_config.verify,
+        )
+        response.raise_for_status()
+        return response.json()
+
+    def copy(self, name):
+        """Clone provided content view.
+
+        :param str name: The name for new cloned content view.
+        :rtype: dict
+        :returns: The server's response, with all JSON decoded.
+
+        """
+        response = client.post(
+            self.path('copy'),
+            {u'id': self.id, u'name': name},
             auth=self._server_config.auth,
             verify=self._server_config.verify,
         )

--- a/tests/robottelo/test_entities.py
+++ b/tests/robottelo/test_entities.py
@@ -57,6 +57,7 @@ class PathTestCase(TestCase):
         (entities.ContentView, '/content_views', 'available_puppet_module_names'),  # flake8:noqa pylint:disable=C0301
         (entities.ContentView, '/content_views', 'content_view_puppet_modules'),  # flake8:noqa pylint:disable=C0301
         (entities.ContentView, '/content_views', 'content_view_versions'),
+        (entities.ContentView, '/content_views', 'copy'),
         (entities.ContentView, '/content_views', 'publish'),
         (entities.ContentViewVersion, '/content_view_versions', 'promote'),
         (entities.Organization, '/organizations', 'subscriptions'),


### PR DESCRIPTION
Added coverage for API tests:
test_cv_clone_within_same_env
test_cv_clone_within_diff_env

We have a little bit code duplication here, but it is due
test case logic.