### PR TITLE
Add API test for Organization → User association - issue #1406

### DIFF
--- a/tests/foreman/api/test_organization.py
+++ b/tests/foreman/api/test_organization.py
@@ -246,6 +246,25 @@ class OrganizationUpdateTestCase(APITestCase):
             self.assertIn(name, new_attrs.keys())
             self.assertEqual(new_attrs[name], value)
 
+    def test_associate_user_with_organization(self):
+        """@Test: Update an organization, associate user with it.
+
+        @Assert: User is associated with organization.
+
+        @Feature: Organization
+
+        """
+        user_id = entities.User().create()['id']
+        client.put(
+            self.organization.path(),
+            {'organization': {'user_ids': [user_id]}},
+            verify=False,
+            auth=get_server_credentials(),
+        ).raise_for_status()
+        new_attrs = self.organization.read_json()
+        self.assertEqual(1, len(new_attrs['users']))
+        self.assertEqual(user_id, new_attrs['users'][0]['id'])
+
     @ddt.data(
         {'name': gen_string(str_type='utf8', length=256)},
         {'label': gen_string(str_type='utf8')},  # Immutable. See BZ 1089996.


### PR DESCRIPTION
Added API test to check if it's possible to associate user
with organization