### PR TITLE
Fixed few more UI test failures

### DIFF
--- a/robottelo/entities.py
+++ b/robottelo/entities.py
@@ -376,6 +376,7 @@ class ConfigTemplate(
     template_combinations = entity_fields.ListField(null=True)  # flake8:noqa pylint:disable=C0103
     template_kind = entity_fields.OneToOneField('TemplateKind', null=True)
     template = entity_fields.StringField(required=True)
+    organization = entity_fields.OneToManyField('Organization', null=True)
 
     class Meta(object):
         """Non-field information about this entity."""
@@ -1472,6 +1473,7 @@ class Media(
     media_path = entity_fields.URLField(required=True)
     name = entity_fields.StringField(required=True)
     operatingsystem = entity_fields.OneToManyField('OperatingSystem', null=True)
+    organization = entity_fields.OneToManyField('Organization', null=True)
     os_family = entity_fields.StringField(choices=(
         'AIX', 'Archlinux', 'Debian', 'Freebsd', 'Gentoo', 'Junos', 'Redhat',
         'Solaris', 'Suse', 'Windows',

--- a/tests/foreman/ui/test_operatingsys.py
+++ b/tests/foreman/ui/test_operatingsys.py
@@ -20,6 +20,13 @@ from robottelo.ui.session import Session
 class OperatingSys(UITestCase):
     """Implements Operating system tests from UI"""
 
+    @classmethod
+    def setUpClass(cls):  # noqa
+        org_attrs = entities.Organization().create_json()
+        cls.org_name = org_attrs['name']
+        cls.org_id = org_attrs['id']
+        super(OperatingSys, cls).setUpClass()
+
     def test_create_os(self):
         """@Test: Create a new OS
 
@@ -344,9 +351,11 @@ class OperatingSys(UITestCase):
         entities.Media(
             name=medium_name,
             media_path=path,
-        ).create()
-        os_name = entities.OperatingSystem().create()['name']
-        with Session(self.browser):
+            organization=[self.org_id],
+        ).create_json()
+        os_name = entities.OperatingSystem().create_json()['name']
+        with Session(self.browser) as session:
+            session.nav.go_to_select_org(self.org_name)
             self.operatingsys.update(os_name, new_mediums=[medium_name])
             result_obj = self.operatingsys.get_os_entities(os_name, "medium")
             self.assertEqual(medium_name, result_obj['medium'])

--- a/tests/foreman/ui/test_subnet.py
+++ b/tests/foreman/ui/test_subnet.py
@@ -18,6 +18,13 @@ from robottelo.ui.session import Session
 class Subnet(UITestCase):
     """Implements Subnet tests in UI"""
 
+    @classmethod
+    def setUpClass(cls):  # noqa
+        org_attrs = entities.Organization().create_json()
+        cls.org_name = org_attrs['name']
+        cls.org_id = org_attrs['id']
+        super(Subnet, cls).setUpClass()
+
     @data(*generate_strings_list(len1=8))
     def test_create_subnet_1(self, name):
         """@Test: Create new subnet
@@ -76,10 +83,13 @@ class Subnet(UITestCase):
         name = gen_string("alpha", 4)
         network = gen_ipaddr(ip3=True)
         mask = gen_netmask()
-        domain_name = entities.Domain().create()['name']
+        domain_name = entities.Domain(
+            organization=[self.org_id]
+        ).create_json()['name']
         with Session(self.browser) as session:
-            make_subnet(session, subnet_name=name, subnet_network=network,
-                        subnet_mask=mask, domains=[domain_name])
+            make_subnet(session, org=self.org_name, subnet_name=name,
+                        subnet_network=network, subnet_mask=mask,
+                        domains=[domain_name])
             self.assertIsNotNone(self.subnet.search_subnet(subnet_name=name))
             session.nav.search_entity(
                 name, locators['subnet.display_name']).click()

--- a/tests/foreman/ui/test_template.py
+++ b/tests/foreman/ui/test_template.py
@@ -17,6 +17,13 @@ from robottelo.ui.session import Session
 class Template(UITestCase):
     """Implements Provisioning Template tests from UI"""
 
+    @classmethod
+    def setUpClass(cls):  # noqa
+        org_attrs = entities.Organization().create_json()
+        cls.org_name = org_attrs['name']
+        cls.org_id = org_attrs['id']
+        super(Template, cls).setUpClass()
+
     @data(*generate_strings_list(len1=8))
     def test_positive_create_template(self, name):
         """@Test: Create new template
@@ -172,11 +179,13 @@ class Template(UITestCase):
         @BZ: 1177756
 
         """
-        entities.ConfigTemplate(name=template_name).create_json()
-        with Session(self.browser):
+        entities.ConfigTemplate(
+            name=template_name, organization=[self.org_id]
+        ).create_json()
+        with Session(self.browser) as session:
+            session.nav.go_to_select_org(self.org_name)
             self.template.delete(template_name, True)
-            self.assertIsNotNone(self.template.wait_until_element
-                                 (common_locators["notif.success"]))
+            self.assertIsNone(self.template.search(template_name))
 
     def test_update_template(self):
         """@Test: Update template name and template type


### PR DESCRIPTION
- fixed `test_remove_template` by associating org with template
- fixed `test_create_subnet_3` by assciating org with domain

Issue is that when we create any entity without associating an org then it won't be visible globally if any org is selected. For ex: If you create a template in 'Any context' then that template won't be visible under any selected org. 

So I fixed the tests by associating the orgs with all entities.