### PR TITLE
Drop all repeated CLI info commands

### DIFF
--- a/tests/foreman/cli/test_activationkey.py
+++ b/tests/foreman/cli/test_activationkey.py
@@ -1294,18 +1294,7 @@ class TestActivationKey(CLITestCase):
                 'another activation key: {0}'.format(err)
             )
 
-        result = ActivationKey.info({
-            u'id': new_activation_key['id'],
-        })
-        self.assertEqual(
-            result.return_code, 0,
-            'Failed to get info for activation key'
-        )
-        self.assertEqual(
-            len(result.stderr), 0,
-            'There should not be an error here'
-        )
-        self.assertEqual(result.stdout['name'], name)
+        self.assertEqual(new_activation_key['name'], name)
 
     @data(
         gen_string('alpha'),
@@ -1610,26 +1599,20 @@ class TestActivationKey(CLITestCase):
 
         """
         org_id = make_org(cached=True)['id']
-        key_id = make_activation_key(
-            {u'organization-id': org_id}, cached=True)['id']
-        try:
-            attach_value = ActivationKey.info({
-                u'id': key_id,
-                u'organization-id': org_id,
-            }).stdout['auto-attach']
-        except CLIFactoryError as err:
-            self.fail(err)
+        key = make_activation_key({u'organization-id': org_id}, cached=True)
+        attach_value = key['auto-attach']
+
         # invert value
         new_value = u'false' if attach_value == u'true' else u'true'
         try:
             result = ActivationKey.update({
                 u'auto-attach': new_value,
-                u'id': key_id,
+                u'id': key['id'],
                 u'organization-id': org_id,
             })
             self.assertEqual(result.return_code, 0)
             attach_value = ActivationKey.info({
-                u'id': key_id,
+                u'id': key['id'],
                 u'organization-id': org_id,
             }).stdout['auto-attach']
         except CLIFactoryError as err:

--- a/tests/foreman/cli/test_computeresource.py
+++ b/tests/foreman/cli/test_computeresource.py
@@ -59,17 +59,16 @@ class TestComputeResource(CLITestCase):
         @Assert: Compute resource Info is displayed
 
         """
-        result_create = make_compute_resource({
+        name = gen_string('utf8')
+        compute_resource = make_compute_resource({
+            'name': name,
             'provider': FOREMAN_PROVIDERS['libvirt'],
-            'url': "qemu+tcp://%s:16509/system" %
-            conf.properties['main.server.hostname']})
-        self.assertTrue(result_create['name'],
-                        "ComputeResource create - has name")
-        result_info = ComputeResource.info({'name': result_create['name']})
-        self.assertEquals(result_info.return_code, 0,
-                          "ComputeResource info - exit code")
-        self.assertEquals(result_info.stdout['name'], result_create['name'],
-                          "ComputeResource info - check name")
+            'url': "qemu+tcp://{0}:16509/system".format(
+                conf.properties['main.server.hostname']
+            ),
+        })
+        # factory already runs info, just check the data
+        self.assertEquals(compute_resource['name'], name)
 
     def test_list(self):
         """@Test: Test Compute Resource List

--- a/tests/foreman/cli/test_gpgkey.py
+++ b/tests/foreman/cli/test_gpgkey.py
@@ -23,12 +23,12 @@ def positive_create_data():
     """Random data for positive creation"""
 
     return (
-        {'name': gen_string("latin1", 10)},
-        {'name': gen_string("utf8", 10)},
-        {'name': gen_string("alpha", 10)},
-        {'name': gen_string("alphanumeric", 10)},
+        {'name': gen_string("latin1")},
+        {'name': gen_string("utf8")},
+        {'name': gen_string("alpha")},
+        {'name': gen_string("alphanumeric")},
         {'name': gen_string("numeric", 20)},
-        {'name': gen_string("html", 10)},
+        {'name': gen_string("html")},
     )
 
 
@@ -79,41 +79,6 @@ class TestGPGKey(CLITestCase):
 
     # Bug verification
 
-    @skip_if_bug_open('redmine', 4271)
-    def test_redmine_4271(self):
-        """@Test: cvs output for gpg subcommand doesn\'t work
-
-        @Feature: GPG Keys
-
-        @Assert: cvs output for gpg info works
-
-        @BZ: Redmine#4271
-
-        """
-
-        # GPG Key data
-        data = {'name': gen_string("alpha", 10)}
-        data['organization-id'] = self.org['id']
-
-        # Setup a new key file
-        data['key'] = VALID_GPG_KEY_FILE_PATH
-        try:
-            new_obj = make_gpg_key(data)
-        except CLIFactoryError as err:
-            self.fail(err)
-
-        # Can we find the new object?
-        result = GPGKey().info(
-            {'id': new_obj['id']}
-        )
-
-        self.assertEqual(result.return_code, 0,
-                         "Failed to get object information")
-        self.assertEqual(
-            len(result.stderr), 0, "There should not be an exception here")
-        self.assertEqual(
-            new_obj[self.search_key], result.stdout[self.search_key])
-
     @skip_if_bug_open('redmine', 4272)
     def test_redmine_4272(self):
         """@Test: gpg info should display key content
@@ -125,10 +90,11 @@ class TestGPGKey(CLITestCase):
         @BZ: Redmine#4272
 
         """
-
         # GPG Key data
-        data = {'name': gen_string("alpha", 10)}
-        data['organization-id'] = self.org['id']
+        data = {
+            'name': gen_string("alpha"),
+            'organization-id': self.org['id'],
+        }
 
         # Setup a new key file
         content = gen_alphanumeric()
@@ -136,21 +102,11 @@ class TestGPGKey(CLITestCase):
         self.assertIsNotNone(gpg_key, 'GPG Key file must be created')
         data['key'] = gpg_key
         try:
-            new_obj = make_gpg_key(data)
+            gpg_key = make_gpg_key(data)
         except CLIFactoryError as err:
             self.fail(err)
 
-        # Can we find the new object?
-        result = GPGKey().info(
-            {'id': new_obj['id']}
-        )
-
-        self.assertEqual(result.return_code, 0,
-                         "Failed to get object information")
-        self.assertEqual(
-            len(result.stderr), 0, "There should not be an exception here")
-        self.assertEqual(
-            result.stdout['content'], content)
+        self.assertEqual(gpg_key['content'], content)
 
     @skip_if_bug_open('bugzilla', 1108227)
     def test_bugzilla_1108227(self):
@@ -163,13 +119,15 @@ class TestGPGKey(CLITestCase):
         @BZ: 1108227
 
         """
+        name = gen_string('utf8')
+        result = GPGKey.create({
+            'name': name,
+            'organization-id': self.org['id'],
+            'key': VALID_GPG_KEY_FILE_PATH,
+        })
+        self.assertEqual(result.return_code, 0)
+        self.assertEqual(len(result.stderr), 0)
 
-        # GPG Key data
-        data = {'name': gen_string("alpha", 10)}
-        data['organization-id'] = self.org['id']
-
-        # Setup a new key file
-        data['key'] = VALID_GPG_KEY_FILE_PATH
         try:
             new_obj = make_gpg_key(data)
         except CLIFactoryError as err:
@@ -181,11 +139,9 @@ class TestGPGKey(CLITestCase):
             'organization-id': self.org['id'],
         })
 
-        self.assertEqual(result.return_code, 0, "Failed to create object")
-        self.assertEqual(
-            len(result.stderr), 0, "There should not be an exception here")
-        self.assertEqual(
-            new_obj[self.search_key], result.stdout[self.search_key])
+        self.assertEqual(result.return_code, 0)
+        self.assertEqual(len(result.stderr), 0)
+        self.assertEqual(result.stdout['name'], name)
 
     # Positive Create
 

--- a/tests/foreman/cli/test_host_collection.py
+++ b/tests/foreman/cli/test_host_collection.py
@@ -67,31 +67,12 @@ class TestHostCollection(CLITestCase):
 
     def _new_host_collection(self, options=None):
         """Make a host collection and asserts its success"""
-
         if options is None:
             options = {}
-
         if not options.get('organization-id', None):
             options['organization-id'] = self.org['id']
 
-        group = make_host_collection(options)
-
-        # Fetch it
-        result = HostCollection.info(
-            {
-                'id': group['id']
-            }
-        )
-
-        self.assertEqual(
-            result.return_code,
-            0,
-            "Host collection was not found")
-        self.assertEqual(
-            len(result.stderr), 0, "No error was expected")
-
-        # Return the host collection dictionary
-        return group
+        return make_host_collection(options)
 
     @data(
         {'name': gen_string('alpha', 15)},
@@ -112,11 +93,7 @@ class TestHostCollection(CLITestCase):
 
         new_host_col = self._new_host_collection({'name': test_data['name']})
         # Assert that name matches data passed
-        self.assertEqual(
-            new_host_col['name'],
-            test_data['name'],
-            "Names don't match"
-        )
+        self.assertEqual(new_host_col['name'], test_data['name'])
 
     @data(
         {'description': gen_string('alpha', 15)},
@@ -135,14 +112,11 @@ class TestHostCollection(CLITestCase):
 
         """
 
-        new_host_col = self._new_host_collection(
-            {'description': test_data['description']})
+        new_host_col = self._new_host_collection({
+            'description': test_data['description'],
+        })
         # Assert that description matches data passed
-        self.assertEqual(
-            new_host_col['description'],
-            test_data['description'],
-            "Descriptions don't match"
-        )
+        self.assertEqual(new_host_col['description'], test_data['description'])
 
     @data('1', '3', '5', '10', '20')
     def test_positive_create_3(self, test_data):
@@ -154,15 +128,11 @@ class TestHostCollection(CLITestCase):
 
         """
 
-        new_host_col = self._new_host_collection(
-            {'max-content-hosts': test_data})
+        new_host_col = self._new_host_collection({
+            'max-content-hosts': test_data,
+        })
         # Assert that limit matches data passed
-        self.assertEqual(
-            new_host_col['max-content-hosts'],
-            str(test_data),
-            ("Limits don't match '%s' != '%s'" %
-             (new_host_col['max-content-hosts'], str(test_data)))
-        )
+        self.assertEqual(new_host_col['max-content-hosts'], str(test_data))
 
     @data(
         {'name': gen_string('alpha', 300)},
@@ -203,55 +173,28 @@ class TestHostCollection(CLITestCase):
 
         new_host_col = self._new_host_collection()
         # Assert that name does not matches data passed
-        self.assertNotEqual(
-            new_host_col['name'],
-            test_data['name'],
-            "Names should not match"
-        )
+        self.assertNotEqual(new_host_col['name'], test_data['name'])
 
         # Update host collection
-        result = HostCollection.update(
-            {
-                'id': new_host_col['id'],
-                'organization-id': self.org['id'],
-                'name': test_data['name']
-            }
-        )
-        self.assertEqual(
-            result.return_code,
-            0,
-            "Host collection was not updated")
-        self.assertEqual(
-            len(result.stderr), 0, "No error was expected")
+        result = HostCollection.update({
+            'id': new_host_col['id'],
+            'organization-id': self.org['id'],
+            'name': test_data['name']
+        })
+        self.assertEqual(result.return_code, 0)
+        self.assertEqual(len(result.stderr), 0)
 
         # Fetch it
-        result = HostCollection.info(
-            {
-                'id': new_host_col['id'],
-            }
-        )
-        self.assertEqual(
-            result.return_code,
-            0,
-            "Host collection was not updated")
-        self.assertEqual(
-            len(result.stderr), 0, "No error was expected")
+        result = HostCollection.info({
+            'id': new_host_col['id'],
+        })
+        self.assertEqual(result.return_code, 0)
+        self.assertEqual(len(result.stderr), 0)
         # Assert that name matches new value
-        self.assertIsNotNone(
-            result.stdout.get('name', None),
-            "The name field was not returned"
-        )
-        self.assertEqual(
-            result.stdout['name'],
-            test_data['name'],
-            "Names should match"
-        )
+        self.assertIsNotNone(result.stdout.get('name', None))
+        self.assertEqual(result.stdout['name'], test_data['name'])
         # Assert that name does not match original value
-        self.assertNotEqual(
-            new_host_col['name'],
-            result.stdout['name'],
-            "Names should not match"
-        )
+        self.assertNotEqual(new_host_col['name'], result.stdout['name'])
 
     @skip_if_bug_open('bugzilla', 1171669)
     @data(
@@ -276,54 +219,30 @@ class TestHostCollection(CLITestCase):
         new_host_col = self._new_host_collection()
         # Assert that description does not match data passed
         self.assertNotEqual(
-            new_host_col['description'],
-            test_data['description'],
-            "Descriptions should not match"
-        )
+            new_host_col['description'], test_data['description'])
 
         # Update sync plan
-        result = HostCollection.update(
-            {
-                'id': new_host_col['id'],
-                'organization-id': self.org['id'],
-                'description': test_data['description']
-            }
-        )
-        self.assertEqual(
-            result.return_code,
-            0,
-            "Host collection was not updated")
-        self.assertEqual(
-            len(result.stderr), 0, "No error was expected")
+        result = HostCollection.update({
+            'id': new_host_col['id'],
+            'organization-id': self.org['id'],
+            'description': test_data['description']
+        })
+        self.assertEqual(result.return_code, 0)
+        self.assertEqual(len(result.stderr), 0)
 
         # Fetch it
-        result = HostCollection.info(
-            {
-                'id': new_host_col['id'],
-            }
-        )
-        self.assertEqual(
-            result.return_code,
-            0,
-            "Host collection was not updated")
-        self.assertEqual(
-            len(result.stderr), 0, "No error was expected")
+        result = HostCollection.info({
+            'id': new_host_col['id'],
+        })
+        self.assertEqual(result.return_code, 0)
+        self.assertEqual(len(result.stderr), 0)
         # Assert that description matches new value
-        self.assertIsNotNone(
-            result.stdout.get('description', None),
-            "The description field was not returned"
-        )
+        self.assertIsNotNone(result.stdout.get('description', None))
         self.assertEqual(
-            result.stdout['description'],
-            test_data['description'],
-            "Descriptions should match"
-        )
+            result.stdout['description'], test_data['description'])
         # Assert that description does not matches original value
         self.assertNotEqual(
-            new_host_col['description'],
-            result.stdout['description'],
-            "Descriptions should not match"
-        )
+            new_host_col['description'], result.stdout['description'])
 
     @skip_if_bug_open('bugzilla', 1171669)
     @data('3', '6', '9', '12', '15', '17', '19')
@@ -341,42 +260,25 @@ class TestHostCollection(CLITestCase):
         new_host_col = self._new_host_collection()
 
         # Update sync interval
-        result = HostCollection.update(
-            {
-                'id': new_host_col['id'],
-                'organization-id': self.org['id'],
-                'max-content-hosts': test_data
-            }
-        )
-        self.assertEqual(
-            result.return_code,
-            0,
-            "Host collection was not updated")
-        self.assertEqual(
-            len(result.stderr), 0, "No error was expected")
+        result = HostCollection.update({
+            'id': new_host_col['id'],
+            'organization-id': self.org['id'],
+            'max-content-hosts': test_data
+        })
+        self.assertEqual(result.return_code, 0)
+        self.assertEqual(len(result.stderr), 0)
 
         # Fetch it
-        result = HostCollection.info(
-            {
-                'id': new_host_col['id'],
-            }
-        )
-        self.assertEqual(
-            result.return_code,
-            0,
-            "Host collection was not updated")
-        self.assertEqual(
-            len(result.stderr), 0, "No error was expected")
+        result = HostCollection.info({
+            'id': new_host_col['id'],
+        })
+        self.assertEqual(result.return_code, 0)
+        self.assertEqual(len(result.stderr), 0)
         # Assert that limit was updated
-        self.assertEqual(
-            result.stdout['max-content-hosts'],
-            test_data,
-            "Limits don't match"
-        )
+        self.assertEqual(result.stdout['max-content-hosts'], test_data)
         self.assertNotEqual(
             new_host_col['max-content-hosts'],
-            result.stdout['max-content-hosts'],
-            "Limits don't match"
+            result.stdout['max-content-hosts']
         )
 
     @data(
@@ -398,22 +300,14 @@ class TestHostCollection(CLITestCase):
 
         new_host_col = self._new_host_collection({'name': test_data['name']})
         # Assert that name matches data passed
-        self.assertEqual(
-            new_host_col['name'],
-            test_data['name'],
-            "Names don't match"
-        )
+        self.assertEqual(new_host_col['name'], test_data['name'])
 
         # Delete it
         result = HostCollection.delete(
             {'id': new_host_col['id'],
              'organization-id': self.org['id']})
-        self.assertEqual(
-            result.return_code,
-            0,
-            "Host collection was not deleted")
-        self.assertEqual(
-            len(result.stderr), 0, "No error was expected")
+        self.assertEqual(result.return_code, 0)
+        self.assertEqual(len(result.stderr), 0)
 
         # Fetch it
         result = HostCollection.info(
@@ -421,16 +315,8 @@ class TestHostCollection(CLITestCase):
                 'id': new_host_col['id'],
             }
         )
-        self.assertNotEqual(
-            result.return_code,
-            0,
-            "Host collection should not be found"
-        )
-        self.assertGreater(
-            len(result.stderr),
-            0,
-            "Expected an error here"
-        )
+        self.assertNotEqual(result.return_code, 0)
+        self.assertGreater(len(result.stderr), 0)
 
     def test_add_content_host(self):
         """@Test: Check if content host can be added to host collection
@@ -455,35 +341,24 @@ class TestHostCollection(CLITestCase):
         except CLIFactoryError as err:
             self.fail(err)
 
-        result = HostCollection.info({
-            u'id': new_host_col['id'],
-            u'organization-id': self.org['id']
-        })
-
-        no_of_content_host = result.stdout['total-content-hosts']
+        no_of_content_host = new_host_col['total-content-hosts']
 
         result = HostCollection.add_content_host({
-
             u'id': new_host_col['id'],
             u'organization-id': self.org['id'],
             u'content-host-ids': new_system['id']
         })
-        self.assertEqual(result.return_code, 0,
-                         "Content Host not added to host collection")
-        self.assertEqual(len(result.stderr), 0,
-                         "No error was expected")
+        self.assertEqual(result.return_code, 0)
+        self.assertEqual(len(result.stderr), 0)
 
         result = HostCollection.info({
             u'id': new_host_col['id'],
             u'organization-id': self.org['id']
         })
-        self.assertEqual(
-            result.return_code, 0, 'Failed to get info for host collection')
-        self.assertEqual(
-            len(result.stderr), 0, 'There should not be an error here')
-        self.assertGreater(result.stdout['total-content-hosts'],
-                           no_of_content_host,
-                           "There should not be an exception here")
+        self.assertEqual(result.return_code, 0)
+        self.assertEqual(len(result.stderr), 0)
+        self.assertGreater(
+            result.stdout['total-content-hosts'], no_of_content_host)
 
     def test_remove_content_host(self):
         """@Test: Check if content host can be removed from host collection
@@ -513,10 +388,8 @@ class TestHostCollection(CLITestCase):
             u'organization-id': self.org['id'],
             u'content-host-ids': new_system['id']
         })
-        self.assertEqual(result.return_code, 0,
-                         "Content Host not added to host collection")
-        self.assertEqual(len(result.stderr), 0,
-                         "No error was expected")
+        self.assertEqual(result.return_code, 0)
+        self.assertEqual(len(result.stderr), 0)
 
         result = HostCollection.info({
             u'id': new_host_col['id'],
@@ -530,22 +403,17 @@ class TestHostCollection(CLITestCase):
             u'organization-id': self.org['id'],
             u'content-host-ids': new_system['id']
         })
-        self.assertEqual(result.return_code, 0,
-                         "Content Host not removed host collection")
-        self.assertEqual(len(result.stderr), 0,
-                         "No error was expected")
+        self.assertEqual(result.return_code, 0)
+        self.assertEqual(len(result.stderr), 0)
 
         result = HostCollection.info({
             u'id': new_host_col['id'],
             u'organization-id': self.org['id']
         })
-        self.assertEqual(
-            result.return_code, 0, 'Failed to get info for host collection')
-        self.assertEqual(
-            len(result.stderr), 0, 'There should not be an error here')
-        self.assertGreater(no_of_content_host,
-                           result.stdout['total-content-hosts'],
-                           "There should not be an exception here")
+        self.assertEqual(result.return_code, 0)
+        self.assertEqual(len(result.stderr), 0)
+        self.assertGreater(
+            no_of_content_host, result.stdout['total-content-hosts'])
 
     def test_content_hosts(self):
         """@Test: Check if content hosts added to host collection is listed
@@ -575,31 +443,22 @@ class TestHostCollection(CLITestCase):
             u'organization-id': self.org['id'],
             u'content-host-ids': new_system['id']
         })
-        self.assertEqual(result.return_code, 0,
-                         "Content Host not added to host collection")
-        self.assertEqual(len(result.stderr), 0,
-                         "No error was expected")
+        self.assertEqual(result.return_code, 0)
+        self.assertEqual(len(result.stderr), 0)
 
         result = HostCollection.info({
             u'id': new_host_col['id'],
             u'organization-id': self.org['id']
         })
-        self.assertEqual(
-            result.return_code, 0, 'Failed to get info for host collection')
-        self.assertEqual(
-            len(result.stderr), 0, 'There should not be an error here')
-        self.assertGreater(result.stdout['total-content-hosts'],
-                           no_of_content_host,
-                           "There should not be an exception here")
+        self.assertEqual(result.return_code, 0)
+        self.assertEqual(len(result.stderr), 0)
+        self.assertGreater(
+            result.stdout['total-content-hosts'], no_of_content_host)
 
         result = HostCollection.content_hosts({
             u'name': host_col_name,
             u'organization-id': self.org['id']
         })
-        self.assertEqual(
-            result.return_code, 0, 'Failed to get list of content-host')
-        self.assertEqual(
-            len(result.stderr), 0, 'There should not be an error here')
-        self.assertEqual(
-            new_system['id'], result.stdout[0]['id'],
-            'There should not be an error here')
+        self.assertEqual(result.return_code, 0)
+        self.assertEqual(len(result.stderr), 0)
+        self.assertEqual(new_system['id'], result.stdout[0]['id'])

--- a/tests/foreman/cli/test_lifecycleenvironment.py
+++ b/tests/foreman/cli/test_lifecycleenvironment.py
@@ -45,14 +45,9 @@ class TestLifeCycleEnvironment(CLITestCase):
             False
         )
 
-        self.assertEqual(
-            result.return_code, 0, "Could not find the lifecycle environment"
-        )
-        self.assertEqual(
-            len(result.stderr), 0, "There should not be an error here.")
-        self.assertGreater(
-            len(result.stdout), 0, "No output was returned"
-        )
+        self.assertEqual(result.return_code, 0)
+        self.assertEqual(len(result.stderr), 0)
+        self.assertGreater(len(result.stdout), 0)
 
     def test_bugzilla_1077333(self):
         """@Test: Search lifecycle environment via its name containing UTF-8 chars
@@ -62,37 +57,19 @@ class TestLifeCycleEnvironment(CLITestCase):
         @Assert: Can get info for lifecycle by its name
 
         """
-
-        payload = {
+        data = {
             'organization-id': self.org['id'],
             'name': gen_string('utf8', 15),
         }
 
-        new_obj = make_lifecycle_environment(payload)
-        self.assertIsNotNone(
-            new_obj, "Could not create lifecycle environment.")
-
         # Can we find the new object
-        result = LifecycleEnvironment.info(
-            {
-                'organization-id': self.org['id'],
-                'name': new_obj['name'],
-            }
-        )
-
-        self.assertEqual(
-            result.return_code, 0, "Could find the lifecycle environment"
-        )
-        self.assertEqual(
-            len(result.stderr), 0, "There should not be an error here.")
-        self.assertGreater(
-            len(result.stdout), 0, "No output was returned"
-        )
-        self.assertEqual(
-            new_obj['name'],
-            result.stdout['name'],
-            "Could not find lifecycle environment \'%s\'" % new_obj['name']
-        )
+        result = LifecycleEnvironment.info({
+            'organization-id': self.org['id'],
+            'name': make_lifecycle_environment(data)['name'],
+        })
+        self.assertEqual(result.return_code, 0)
+        self.assertEqual(len(result.stderr), 0)
+        self.assertEqual(result.stdout['name'], data['name'])
 
     # CRUD
     @data(
@@ -111,37 +88,13 @@ class TestLifeCycleEnvironment(CLITestCase):
         @Assert: Lifecycle environment is created with Library as prior
 
         """
-
-        payload = {
+        lifecycle_environment = make_lifecycle_environment({
             'organization-id': self.org['id'],
             'name': test_data['name'],
-        }
-
-        new_obj = make_lifecycle_environment(payload)
-        self.assertIsNotNone(
-            new_obj, "Could not create lifecycle environment.")
-
-        # Can we find the new object
-        result = LifecycleEnvironment.info(
-            {
-                'organization-id': self.org['id'],
-                'id': new_obj['id'],
-            }
-        )
+        })
 
         self.assertEqual(
-            result.return_code, 0, "Could find the lifecycle environment"
-        )
-        self.assertEqual(
-            len(result.stderr), 0, "There should not be an error here.")
-        self.assertGreater(
-            len(result.stdout), 0, "No output was returned"
-        )
-        self.assertEqual(
-            new_obj['name'],
-            result.stdout['name'],
-            "Could not find lifecycle environment \'%s\'" % new_obj['name']
-        )
+            lifecycle_environment['prior-lifecycle-environment'], u'Library')
 
     @data(
         {'name': gen_string("alpha", 15)},
@@ -160,43 +113,19 @@ class TestLifeCycleEnvironment(CLITestCase):
         @Assert: Lifecycle environment is created with Library as prior
 
         """
+        description = test_data['name']
 
-        payload = {
+        lifecycle_environment = make_lifecycle_environment({
             'organization-id': self.org['id'],
             'name': test_data['name'],
-            'description': test_data['name'],
-        }
+            'description': description,
+        })
 
-        new_obj = make_lifecycle_environment(payload)
-        self.assertIsNotNone(
-            new_obj, "Could not create lifecycle environment.")
-
-        # Can we find the new object
-        result = LifecycleEnvironment.info(
-            {
-                'organization-id': self.org['id'],
-                'id': new_obj['id'],
-            }
-        )
-
+        self.assertEqual(lifecycle_environment['name'], test_data['name'])
         self.assertEqual(
-            result.return_code, 0, "Could find the lifecycle environment"
-        )
+            lifecycle_environment['description'], description)
         self.assertEqual(
-            len(result.stderr), 0, "There should not be an error here.")
-        self.assertGreater(
-            len(result.stdout), 0, "No output was returned"
-        )
-        self.assertEqual(
-            new_obj['name'],
-            result.stdout['name'],
-            "Could not find lifecycle environment \'%s\'" % new_obj['name']
-        )
-        self.assertEqual(
-            new_obj['description'],
-            result.stdout['description'],
-            "Descriptions don't match"
-        )
+            lifecycle_environment['prior-lifecycle-environment'], u'Library')
 
     @data(
         {'label': gen_string("alpha", 15)},
@@ -220,11 +149,7 @@ class TestLifeCycleEnvironment(CLITestCase):
         except CLIFactoryError as err:
             self.fail(err)
 
-        self.assertEqual(
-            new_le['label'],
-            test_data['label'],
-            "Incorrect label was set"
-        )
+        self.assertEqual(new_le['label'], test_data['label'])
 
     def test_create_lifecycle_environment_by_organization_name(self):
         """@Test: Create lifecycle environment, specifying organization name
@@ -237,16 +162,12 @@ class TestLifeCycleEnvironment(CLITestCase):
         try:
             new_le = make_lifecycle_environment({
                 'organization': self.org['name'],
-                'name': gen_string('alpha', 10),
+                'name': gen_string('alpha'),
             })
         except CLIFactoryError as err:
             self.fail(err)
 
-        self.assertEqual(
-            new_le['organization'],
-            self.org['name'],
-            "Wrong organization was assigned by name"
-        )
+        self.assertEqual(new_le['organization'], self.org['name'])
 
     def test_create_lifecycle_environment_by_organization_label(self):
         """@Test: Create lifecycle environment, specifying organization name
@@ -259,16 +180,12 @@ class TestLifeCycleEnvironment(CLITestCase):
         try:
             new_le = make_lifecycle_environment({
                 'organization-label': self.org['label'],
-                'name': gen_string('alpha', 10),
+                'name': gen_string('alpha'),
             })
         except CLIFactoryError as err:
             self.fail(err)
 
-        self.assertEqual(
-            new_le['organization'],
-            self.org['name'],
-            "Wrong organization was assigned by label"
-        )
+        self.assertEqual(new_le['organization'], self.org['name'])
 
     @data(
         {'name': gen_string("alpha", 15)},
@@ -286,61 +203,23 @@ class TestLifeCycleEnvironment(CLITestCase):
         @Assert: Lifecycle environment is deleted
 
         """
-
-        payload = {
+        new_obj = make_lifecycle_environment({
             'organization-id': self.org['id'],
             'name': test_data['name'],
-        }
-
-        new_obj = make_lifecycle_environment(payload)
-        self.assertIsNotNone(
-            new_obj, "Could not create lifecycle environment.")
-
-        # Can we find the new object
-        result = LifecycleEnvironment.info(
-            {
-                'organization-id': self.org['id'],
-                'id': new_obj['id'],
-            }
-        )
-
-        self.assertEqual(
-            result.return_code, 0, "Could find the lifecycle environment"
-        )
-        self.assertEqual(
-            len(result.stderr), 0, "There should not be an error here.")
-        self.assertGreater(
-            len(result.stdout), 0, "No output was returned"
-        )
-        self.assertEqual(
-            new_obj['name'],
-            result.stdout['name'],
-            "Could not find lifecycle environment \'%s\'" % new_obj['name']
-        )
+        })
 
         # Delete the lifecycle environment
         result = LifecycleEnvironment.delete({'id': new_obj['id']})
-
-        self.assertEqual(
-            result.return_code, 0, "Could find the lifecycle environment"
-        )
-        self.assertEqual(
-            len(result.stderr), 0, "There should not be an error here.")
+        self.assertEqual(result.return_code, 0)
+        self.assertEqual(len(result.stderr), 0)
 
         # Can we find the object
-        result = LifecycleEnvironment.info(
-            {
-                'organization-id': self.org['id'],
-                'id': new_obj['id'],
-            }
-        )
-
-        self.assertGreater(
-            result.return_code, 0, "Should not find the lifecycle environment"
-        )
-        self.assertGreater(
-            len(result.stderr), 0, "There should be an error here"
-        )
+        result = LifecycleEnvironment.info({
+            'organization-id': self.org['id'],
+            'id': new_obj['id'],
+        })
+        self.assertGreater(result.return_code, 0)
+        self.assertGreater(len(result.stderr), 0)
 
     @data(
         {'name': gen_string("alpha", 15)},
@@ -364,48 +243,26 @@ class TestLifeCycleEnvironment(CLITestCase):
         }
 
         new_obj = make_lifecycle_environment(payload)
-        self.assertIsNotNone(
-            new_obj, "Could not create lifecycle environment.")
 
         # Update its name
-        result = LifecycleEnvironment.update(
-            {
-                'organization-id': self.org['id'],
-                'id': new_obj['id'],
-                'new-name': test_data['name'],
-            }
-        )
-        self.assertEqual(
-            result.return_code, 0, "Could find the lifecycle environment"
-        )
-        self.assertEqual(
-            len(result.stderr), 0, "There should not be an error here.")
+        result = LifecycleEnvironment.update({
+            'organization-id': self.org['id'],
+            'id': new_obj['id'],
+            'new-name': test_data['name'],
+        })
+        self.assertEqual(result.return_code, 0)
+        self.assertEqual(len(result.stderr), 0)
 
         # Fetch the object
-        result = LifecycleEnvironment.info(
-            {
-                'organization-id': self.org['id'],
-                'id': new_obj['id'],
-            }
-        )
-        self.assertEqual(
-            result.return_code, 0, "Could find the lifecycle environment"
-        )
-        self.assertEqual(
-            len(result.stderr), 0, "There should not be an error here.")
-        self.assertGreater(
-            len(result.stdout), 0, "No output was returned"
-        )
-        self.assertEqual(
-            test_data['name'],
-            result.stdout['name'],
-            "Name was not updated"
-        )
-        self.assertNotEqual(
-            new_obj['name'],
-            result.stdout['name'],
-            "Name should have been updated"
-        )
+        result = LifecycleEnvironment.info({
+            'organization-id': self.org['id'],
+            'id': new_obj['id'],
+        })
+        self.assertEqual(result.return_code, 0)
+        self.assertEqual(len(result.stderr), 0)
+        self.assertGreater(len(result.stdout), 0)
+        self.assertEqual(test_data['name'], result.stdout['name'])
+        self.assertNotEqual(new_obj['name'], result.stdout['name'])
 
     @data(
         {'description': gen_string("alpha", 15)},
@@ -429,8 +286,6 @@ class TestLifeCycleEnvironment(CLITestCase):
         }
 
         new_obj = make_lifecycle_environment(payload)
-        self.assertIsNotNone(
-            new_obj, "Could not create lifecycle environment.")
 
         # Update its description
         result = LifecycleEnvironment.update(
@@ -440,11 +295,8 @@ class TestLifeCycleEnvironment(CLITestCase):
                 'description': test_data['description'],
             }
         )
-        self.assertEqual(
-            result.return_code, 0, "Could find the lifecycle environment"
-        )
-        self.assertEqual(
-            len(result.stderr), 0, "There should not be an error here.")
+        self.assertEqual(result.return_code, 0)
+        self.assertEqual(len(result.stderr), 0)
 
         # Fetch the object
         result = LifecycleEnvironment.info(
@@ -453,24 +305,13 @@ class TestLifeCycleEnvironment(CLITestCase):
                 'id': new_obj['id'],
             }
         )
+        self.assertEqual(result.return_code, 0)
+        self.assertEqual(len(result.stderr), 0)
+        self.assertGreater(len(result.stdout), 0)
         self.assertEqual(
-            result.return_code, 0, "Could find the lifecycle environment"
-        )
-        self.assertEqual(
-            len(result.stderr), 0, "There should not be an error here.")
-        self.assertGreater(
-            len(result.stdout), 0, "No output was returned"
-        )
-        self.assertEqual(
-            test_data['description'],
-            result.stdout['description'],
-            "Description was not updated"
-        )
+            test_data['description'], result.stdout['description'])
         self.assertNotEqual(
-            new_obj['description'],
-            result.stdout['description'],
-            "Description should have been updated"
-        )
+            new_obj['description'], result.stdout['description'])
 
     def test_environment_paths(self):
         """@Test: List the environment paths under a given organization

--- a/tests/foreman/cli/test_medium.py
+++ b/tests/foreman/cli/test_medium.py
@@ -26,12 +26,12 @@ OSES = [
 @ddt
 class TestMedium(CLITestCase):
 
-    @data({'name': gen_string("latin1", 10)},
-          {'name': gen_string("utf8", 10)},
-          {'name': gen_string("alpha", 10)},
-          {'name': gen_string("alphanumeric", 10)},
-          {'name': gen_string("numeric", 10)},
-          {'name': gen_string("html", 10)})
+    @data({'name': gen_string("latin1")},
+          {'name': gen_string("utf8")},
+          {'name': gen_string("alpha")},
+          {'name': gen_string("alphanumeric")},
+          {'name': gen_string("numeric")},
+          {'name': gen_string("html")})
     def test_positive_create_1(self, test_data):
         """@Test: Check if Medium can be created
 
@@ -41,17 +41,7 @@ class TestMedium(CLITestCase):
 
         """
         new_obj = make_medium(test_data)
-
-        # Can we find the new object?
-        result = Medium.info({'id': new_obj['id']})
-
-        self.assertEqual(result.return_code, 0, "Failed to create object")
-        self.assertEqual(len(result.stderr), 0,
-                         "There should not be an exception here")
-        self.assertGreater(
-            len(result.stdout), 0, "Failed to fetch medium")
-        self.assertEqual(new_obj['name'],
-                         result.stdout['name'])
+        self.assertEqual(new_obj['name'], test_data['name'])
 
     def test_create_medium_with_location(self):
         """@Test: Check if medium with location can be created
@@ -64,7 +54,7 @@ class TestMedium(CLITestCase):
         try:
             location = make_location()
             medium = make_medium({
-                'name': gen_string("alpha", 10),
+                'name': gen_string("alpha"),
                 'location-ids': location['id']
             })
         except CLIFactoryError as err:
@@ -87,7 +77,7 @@ class TestMedium(CLITestCase):
         try:
             org = make_org()
             medium = make_medium({
-                'name': gen_string("alpha", 10),
+                'name': gen_string("alpha"),
                 'organization-ids': org['id']
             })
         except CLIFactoryError as err:
@@ -99,12 +89,12 @@ class TestMedium(CLITestCase):
             "Organization wasn't assigned to medium"
         )
 
-    @data({'name': gen_string("latin1", 10)},
-          {'name': gen_string("utf8", 10)},
-          {'name': gen_string("alpha", 10)},
-          {'name': gen_string("alphanumeric", 10)},
-          {'name': gen_string("numeric", 10)},
-          {'name': gen_string("html", 10)})
+    @data({'name': gen_string("latin1")},
+          {'name': gen_string("utf8")},
+          {'name': gen_string("alpha")},
+          {'name': gen_string("alphanumeric")},
+          {'name': gen_string("numeric")},
+          {'name': gen_string("html")})
     def test_positive_delete_1(self, test_data):
         """@Test: Check if Medium can be deleted
 
@@ -114,13 +104,6 @@ class TestMedium(CLITestCase):
 
         """
         new_obj = make_medium(test_data)
-
-        # Can we find the new object?
-        result = Medium.info({'id': new_obj['id']})
-
-        self.assertEqual(result.return_code, 0)
-        self.assertEqual(len(result.stderr), 0)
-        self.assertEqual(new_obj['name'], result.stdout['name'])
 
         return_value = Medium.delete({'id': new_obj['id']})
         self.assertEqual(return_value.return_code, 0, "Deletion failed")

--- a/tests/foreman/cli/test_model.py
+++ b/tests/foreman/cli/test_model.py
@@ -23,9 +23,10 @@ class TestModel(MetaCLITestCase):
         @Assert: Model is created
 
         """
-        result = self.factory()
-        model = Model().info({'name': result['name']})
-        self.assertEqual(result['name'], model.stdout['name'])
+        try:
+            make_model()
+        except CLIFactoryError as err:
+            self.fail(err)
 
     def test_create_model_2(self):
         """@Test: Check if Model can be created with specific vendor class
@@ -35,12 +36,9 @@ class TestModel(MetaCLITestCase):
         @Assert: Model is created with specific vendor class
 
         """
-        result = self.factory({
-            'vendor-class': gen_string("alpha", 10),
-        })
-        # Check that Model was created with proper values
-        model = Model().info({'name': result['name']})
-        self.assertEqual(result['vendor-class'], model.stdout['vendor-class'])
+        vendor_class = gen_string('utf8'),
+        model = make_model({'vendor-class': vendor_class})
+        self.assertEqual(model['vendor-class'], vendor_class)
 
     def test_update_model(self):
         """@Test: Check if Model can be updated
@@ -51,7 +49,7 @@ class TestModel(MetaCLITestCase):
 
         """
 
-        name = gen_string("alpha", 10)
+        name = gen_string("alpha")
         try:
             model = self.factory({'name': name})
         except CLIFactoryError as err:
@@ -59,7 +57,7 @@ class TestModel(MetaCLITestCase):
 
         self.assertEqual(name, model['name'])
 
-        new_name = gen_string("alpha", 10)
+        new_name = gen_string("alpha")
         result = Model().update({'name': model['name'], 'new-name': new_name})
         self.assertEqual(result.return_code, 0)
         self.assertEqual(

--- a/tests/foreman/cli/test_org.py
+++ b/tests/foreman/cli/test_org.py
@@ -21,12 +21,12 @@ def positive_create_data_1():
     """Random data for positive creation"""
 
     return (
-        {'name': gen_string("latin1", 10)},
-        {'name': gen_string("utf8", 10)},
-        {'name': gen_string("alpha", 10)},
-        {'name': gen_string("alphanumeric", 10)},
-        {'name': gen_string("numeric", 10)},
-        {'name': gen_string("html", 10)},
+        {'name': gen_string("latin1")},
+        {'name': gen_string("utf8")},
+        {'name': gen_string("alpha")},
+        {'name': gen_string("alphanumeric")},
+        {'name': gen_string("numeric")},
+        {'name': gen_string("html")},
     )
 
 
@@ -38,9 +38,9 @@ def positive_create_data_2():
     """Random simpler data for positive creation"""
 
     return (
-        {'name': gen_string("alpha", 10)},
-        {'name': gen_string("alphanumeric", 10)},
-        {'name': gen_string("numeric", 10)},
+        {'name': gen_string("alpha")},
+        {'name': gen_string("alphanumeric")},
+        {'name': gen_string("numeric")},
         {'name': '{0}-{1}'.format(gen_string("alpha", 5),
                                   gen_string("alpha", 5))},
         {'name': '{0}_{1}'.format(gen_string("alpha", 5),
@@ -53,18 +53,18 @@ def positive_name_label_data():
     """Random data for Label tests"""
 
     return (
-        {'name': gen_string("latin1", 10),
-         'label': gen_string("alpha", 10)},
-        {'name': gen_string("utf8", 10),
-         'label': gen_string("alpha", 10)},
-        {'name': gen_string("alpha", 10),
-         'label': gen_string("alpha", 10)},
-        {'name': gen_string("alphanumeric", 10),
-         'label': gen_string("alpha", 10)},
-        {'name': gen_string("numeric", 10),
-         'label': gen_string("alpha", 10)},
-        {'name': gen_string("html", 10),
-         'label': gen_string("alpha", 10)},
+        {'name': gen_string("latin1"),
+         'label': gen_string("alpha")},
+        {'name': gen_string("utf8"),
+         'label': gen_string("alpha")},
+        {'name': gen_string("alpha"),
+         'label': gen_string("alpha")},
+        {'name': gen_string("alphanumeric"),
+         'label': gen_string("alpha")},
+        {'name': gen_string("numeric"),
+         'label': gen_string("alpha")},
+        {'name': gen_string("html"),
+         'label': gen_string("alpha")},
     )
 
 
@@ -72,18 +72,18 @@ def positive_name_desc_data():
     """Random data for Descriptions tests"""
 
     return (
-        {'name': gen_string("latin1", 10),
-         'description': gen_string("latin1", 10)},
-        {'name': gen_string("utf8", 10),
-         'description': gen_string("utf8", 10)},
-        {'name': gen_string("alpha", 10),
-         'description': gen_string("alpha", 10)},
-        {'name': gen_string("alphanumeric", 10),
-         'description': gen_string("alphanumeric", 10)},
-        {'name': gen_string("numeric", 10),
-         'description': gen_string("numeric", 10)},
-        {'name': gen_string("html", 10),
-         'description': gen_string("numeric", 10)},
+        {'name': gen_string("latin1"),
+         'description': gen_string("latin1")},
+        {'name': gen_string("utf8"),
+         'description': gen_string("utf8")},
+        {'name': gen_string("alpha"),
+         'description': gen_string("alpha")},
+        {'name': gen_string("alphanumeric"),
+         'description': gen_string("alphanumeric")},
+        {'name': gen_string("numeric"),
+         'description': gen_string("numeric")},
+        {'name': gen_string("html"),
+         'description': gen_string("numeric")},
     )
 
 
@@ -91,18 +91,18 @@ def positive_name_desc_label_data():
     """Random data for Labels and Description"""
 
     return (
-        {'name': gen_string("alpha", 10),
-         'description': gen_string("alpha", 10),
-         'label': gen_string("alpha", 10)},
-        {'name': gen_string("alphanumeric", 10),
-         'description': gen_string("alphanumeric", 10),
-         'label': gen_string("alpha", 10)},
-        {'name': gen_string("numeric", 10),
-         'description': gen_string("numeric", 10),
-         'label': gen_string("alpha", 10)},
-        {'name': gen_string("html", 10),
-         'description': gen_string("numeric", 10),
-         'label': gen_string("alpha", 10)},
+        {'name': gen_string("alpha"),
+         'description': gen_string("alpha"),
+         'label': gen_string("alpha")},
+        {'name': gen_string("alphanumeric"),
+         'description': gen_string("alphanumeric"),
+         'label': gen_string("alpha")},
+        {'name': gen_string("numeric"),
+         'description': gen_string("numeric"),
+         'label': gen_string("alpha")},
+        {'name': gen_string("html"),
+         'description': gen_string("numeric"),
+         'label': gen_string("alpha")},
     )
 
 
@@ -127,11 +127,9 @@ class TestOrg(CLITestCase):
         # Can we find the new object?
         result = Org.exists(search=('name', new_obj['name']))
 
-        self.assertEqual(result.return_code, 0, "Failed to create object")
-        self.assertEqual(len(result.stderr), 0,
-                         "There should not be an exception here")
-        self.assertEqual(new_obj['name'],
-                         result.stdout['name'])
+        self.assertEqual(result.return_code, 0)
+        self.assertEqual(len(result.stderr), 0)
+        self.assertEqual(new_obj['name'], result.stdout['name'])
 
     @run_only_on('sat')
     def test_remove_domain(self):
@@ -148,10 +146,8 @@ class TestOrg(CLITestCase):
             {'name': org_result['name'], 'domain': domain_result['name']})
         return_value = Org.remove_domain(
             {'name': org_result['name'], 'domain': domain_result['name']})
-        self.assertEqual(
-            return_value.return_code, 0, "Remove Domain - retcode")
-        self.assertEqual(
-            len(return_value.stderr), 0, "There should not be an error here")
+        self.assertEqual(return_value.return_code, 0)
+        self.assertEqual(len(return_value.stderr), 0)
 
     @data(*positive_create_data_1())
     def test_bugzilla_1079587(self, test_data):
@@ -167,11 +163,9 @@ class TestOrg(CLITestCase):
         # Can we find the new object?
         result = Org.exists(search=('label', new_obj['label']))
 
-        self.assertEqual(result.return_code, 0, "Failed to find the object")
-        self.assertEqual(len(result.stderr), 0,
-                         "There should not be an exception here")
-        self.assertEqual(new_obj['name'],
-                         result.stdout['name'])
+        self.assertEqual(result.return_code, 0)
+        self.assertEqual(len(result.stderr), 0)
+        self.assertEqual(new_obj['name'], result.stdout['name'])
 
     @skip_if_bug_open('bugzilla', 1076568)
     def test_bugzilla_1076568_1(self):
@@ -184,36 +178,17 @@ class TestOrg(CLITestCase):
         @BZ: 1076568
 
         """
+        org = make_org()
 
-        new_obj = make_org()
-
-        # Can we find the new object?
-        result = Org.info({'id': new_obj['id']})
-
+        result = Org.delete({'name': org['name']})
         self.assertEqual(result.return_code, 0)
         self.assertEqual(len(result.stderr), 0)
-        self.assertEqual(new_obj['name'], result.stdout['name'])
-
-        return_value = Org.delete({'name': new_obj['name']})
-        self.assertEqual(
-            return_value.return_code,
-            0,
-            "Deletion failed: %s" % result.stderr)
-        self.assertEqual(
-            len(return_value.stderr),
-            0,
-            "Unexpected error found: %s" % result.stderr)
 
         # Can we find the object?
-        result = Org.info({'id': new_obj['id']})
-        self.assertNotEqual(
-            result.return_code,
-            0,
-            "Organization should be deleted but was found")
-        self.assertGreater(len(result.stderr), 0,
-                           "There should not be an exception here")
-        self.assertEqual(
-            len(result.stdout), 0, "Output should be blank.")
+        result = Org.info({'id': org['id']})
+        self.assertNotEqual(result.return_code, 0)
+        self.assertGreater(len(result.stderr), 0)
+        self.assertEqual(len(result.stdout), 0)
 
     @skip_if_bug_open('bugzilla', 1076568)
     def test_bugzilla_1076568_2(self):
@@ -226,36 +201,17 @@ class TestOrg(CLITestCase):
         @BZ: 1076568
 
         """
+        org = make_org()
 
-        new_obj = make_org()
-
-        # Can we find the new object?
-        result = Org.info({'id': new_obj['id']})
-
+        result = Org.delete({'id': org['id']})
         self.assertEqual(result.return_code, 0)
         self.assertEqual(len(result.stderr), 0)
-        self.assertEqual(new_obj['name'], result.stdout['name'])
-
-        return_value = Org.delete({'id': new_obj['id']})
-        self.assertEqual(
-            return_value.return_code,
-            0,
-            "Deletion failed: %s" % result.stderr)
-        self.assertEqual(
-            len(return_value.stderr),
-            0,
-            "Unexpected error found: %s" % result.stderr)
 
         # Can we find the object?
-        result = Org.info({'id': new_obj['id']})
-        self.assertNotEqual(
-            result.return_code,
-            0,
-            "Organization should be deleted but was found")
-        self.assertGreater(len(result.stderr), 0,
-                           "There should not be an exception here")
-        self.assertEqual(
-            len(result.stdout), 0, "Output should be blank.")
+        result = Org.info({'id': org['id']})
+        self.assertNotEqual(result.return_code, 0)
+        self.assertGreater(len(result.stderr), 0)
+        self.assertEqual(len(result.stdout), 0)
 
     @skip_if_bug_open('bugzilla', 1076568)
     def test_bugzilla_1076568_3(self):
@@ -268,36 +224,17 @@ class TestOrg(CLITestCase):
         @BZ: 1076568
 
         """
+        org = make_org()
 
-        new_obj = make_org()
-
-        # Can we find the new object?
-        result = Org.info({'id': new_obj['id']})
-
+        result = Org.delete({'label': org['label']})
         self.assertEqual(result.return_code, 0)
         self.assertEqual(len(result.stderr), 0)
-        self.assertEqual(new_obj['name'], result.stdout['name'])
-
-        return_value = Org.delete({'label': new_obj['label']})
-        self.assertEqual(
-            return_value.return_code,
-            0,
-            "Deletion failed: %s" % result.stderr)
-        self.assertEqual(
-            len(return_value.stderr),
-            0,
-            "Unexpected error found: %s" % result.stderr)
 
         # Can we find the object?
-        result = Org.info({'id': new_obj['id']})
-        self.assertNotEqual(
-            result.return_code,
-            0,
-            "Organization should be deleted but was found")
-        self.assertGreater(len(result.stderr), 0,
-                           "There should not be an exception here")
-        self.assertEqual(
-            len(result.stdout), 0, "Output should be blank.")
+        result = Org.info({'id': org['id']})
+        self.assertNotEqual(result.return_code, 0)
+        self.assertGreater(len(result.stderr), 0)
+        self.assertEqual(len(result.stdout), 0)
 
     def test_bugzilla_1076541(self):
         """@test: Cannot update organization name via CLI
@@ -307,50 +244,35 @@ class TestOrg(CLITestCase):
         @assert: Organization name is updated
 
         """
-
         new_obj = make_org()
-        # Can we find the new object?
-        result = Org.info({'id': new_obj['id']})
-        self.assertEqual(result.return_code, 0)
-        self.assertEqual(len(result.stderr), 0)
-        self.assertEqual(new_obj['name'], result.stdout['name'])
 
         # Update the org name
-        new_name = gen_string("alpha", 15)
-        result = Org.update({'id': new_obj['id'],
-                             'new-name': new_name})
+        new_name = gen_string('utf8', 15)
+        result = Org.update({'id': new_obj['id'], 'new-name': new_name})
 
         self.assertEqual(result.return_code, 0)
-        self.assertEqual(
-            len(result.stderr), 0, "There should not be an error here")
+        self.assertEqual(len(result.stderr), 0)
 
         # Fetch the org again
         result = Org.info({'id': new_obj['id']})
         self.assertEqual(result.return_code, 0)
         self.assertEqual(len(result.stderr), 0)
-        self.assertEqual(
-            result.stdout['name'],
-            new_name,
-            "Org name was not updated"
-        )
+        self.assertEqual(result.stdout['name'], new_name)
 
     def test_bugzilla_1075163(self):
         """@Test: Add --label as a valid argument to organization info command
 
-        @Feature: Org - Positive Create
+        @Feature: Organization
 
         @Assert: Organization is created and info can be obtained by its label
         graciously
 
         """
-
-        new_obj = make_org()
-        result = Org.info({'id': new_obj['id']})
-        self.assertEqual(result.return_code, 0, "Failed to create object")
-        self.assertEqual(len(result.stderr), 0,
-                         "There should not be an exception here")
-
-        self.assertEqual(new_obj['name'], result.stdout['name'])
+        org = make_org()
+        result = Org.info({'label': org['label']})
+        self.assertEqual(result.return_code, 0)
+        self.assertEqual(len(result.stderr), 0)
+        self.assertEqual(org['id'], result.stdout['id'])
 
     def test_bugzilla_1075156(self):
         """@Test: Cannot use CLI info for organizations by name
@@ -361,14 +283,11 @@ class TestOrg(CLITestCase):
         graciously
 
         """
-
-        new_obj = make_org()
-        result = Org.info({'name': new_obj['name']})
-        self.assertEqual(result.return_code, 0, "Failed to create object")
-        self.assertEqual(len(result.stderr), 0,
-                         "There should not be an exception here")
-
-        self.assertEqual(new_obj['name'], result.stdout['name'])
+        org = make_org()
+        result = Org.info({'name': org['name']})
+        self.assertEqual(result.return_code, 0)
+        self.assertEqual(len(result.stderr), 0)
+        self.assertEqual(org['id'], result.stdout['id'])
 
     @run_only_on('sat')
     def test_bugzilla_1062295_1(self):
@@ -384,10 +303,8 @@ class TestOrg(CLITestCase):
         return_value = Org.add_config_template({
             'name': org_result['name'],
             'config-template': template_result['name']})
-        self.assertEqual(return_value.return_code, 0,
-                         "Add ConfigTemplate- retcode")
-        self.assertEqual(
-            len(return_value.stderr), 0, "There should not be an error here")
+        self.assertEqual(return_value.return_code, 0)
+        self.assertEqual(len(return_value.stderr), 0)
 
     @run_only_on('sat')
     def test_bugzilla_1062295_2(self):
@@ -406,13 +323,12 @@ class TestOrg(CLITestCase):
         return_value = Org.remove_config_template({
             'name': org_result['name'],
             'config-template': template_result['name']})
-        self.assertEqual(return_value.return_code, 0,
-                         "Remove ConfigTemplate- retcode")
-        self.assertEqual(
-            len(return_value.stderr), 0, "There should not be an error here")
+        self.assertEqual(return_value.return_code, 0)
+        self.assertEqual(len(return_value.stderr), 0)
 
     def test_bugzilla_1023125(self):
-        """@Test: hammer-cli: trying to create duplicate org throws unhandled ISE
+        """@Test: hammer-cli: trying to create duplicate org throws unhandled
+        ISE
 
         @Feature: Org - Positive Create
 
@@ -420,23 +336,17 @@ class TestOrg(CLITestCase):
         graciously
 
         """
-
-        new_obj = make_org()
-
-        result = Org.info({'id': new_obj['id']})
-        self.assertEqual(result.return_code, 0, "Failed to create object")
-        self.assertEqual(len(result.stderr), 0,
-                         "There should not be an exception here")
-        self.assertEqual(new_obj['name'], result.stdout['name'])
+        org = make_org()
 
         # Create new org with the same name as before
         # should yield an exception
         with self.assertRaises(Exception):
-            make_org({'name': new_obj['name']})
+            make_org({'name': org['name']})
 
     # This Bugzilla bug is private. It is impossible to fetch info about it.
     def test_bugzilla_1078866(self):
-        """@Test: hammer organization <info,list> --help types information doubled
+        """@Test: hammer organization <info,list> --help types information
+        doubled
 
         @Feature: org info/list
 
@@ -467,17 +377,8 @@ class TestOrg(CLITestCase):
         @assert: organization is created, label is auto-generated
 
         """
-
-        new_obj = make_org(test_data)
-        # Can we find the new object?
-        result = Org.info({'id': new_obj['id']})
-
-        self.assertEqual(result.return_code, 0, "Failed to create object")
-        self.assertEqual(len(result.stderr), 0,
-                         "There should not be an exception here")
-        self.assertGreater(
-            len(result.stdout), 0, "Failed to fetch organization")
-        self.assertEqual(new_obj['name'], result.stdout['name'])
+        org = make_org(test_data)
+        self.assertEqual(org['name'], test_data['name'])
 
     @data(*positive_create_data_2())
     def test_positive_create_2(self, test_data):
@@ -488,20 +389,9 @@ class TestOrg(CLITestCase):
         @assert: organization is created, label matches name
 
         """
-
         test_data['label'] = test_data['name']
-        new_obj = make_org(test_data)
-
-        # Can we find the new object?
-        result = Org.info({'id': new_obj['id']})
-
-        self.assertEqual(result.return_code, 0, "Failed to create object")
-        self.assertEqual(len(result.stderr), 0,
-                         "There should not be an exception here")
-        self.assertGreater(
-            len(result.stdout), 0, "Failed to fetch organization")
-        self.assertEqual(result.stdout['name'], result.stdout['label'])
-        self.assertEqual(new_obj['name'], result.stdout['name'])
+        org = make_org(test_data)
+        self.assertEqual(org['name'], org['label'])
 
     @skip_if_bug_open('bugzilla', 1142821)
     @data(*positive_name_label_data())
@@ -512,24 +402,13 @@ class TestOrg(CLITestCase):
 
         @assert: organization is created, label does not match name
 
+        @bz: 1142821
+
         """
-
-        new_obj = make_org(test_data)
-
-        # Can we find the new object?
-        result = Org.info({'id': new_obj['id']})
-
-        self.assertEqual(result.return_code, 0, "Failed to create object")
-        self.assertEqual(len(result.stderr), 0,
-                         "There should not be an exception here")
-        self.assertGreater(
-            len(result.stdout), 0, "Failed to fetch organization")
-        self.assertNotEqual(result.stdout['name'],
-                            result.stdout['label'])
-        self.assertEqual(new_obj['name'],
-                         result.stdout['name'])
-        self.assertEqual(new_obj['label'],
-                         result.stdout['label'])
+        org = make_org(test_data)
+        self.assertNotEqual(org['name'], org['label'])
+        self.assertEqual(org['name'], test_data['name'])
+        self.assertEqual(org['label'], test_data['label'])
 
     @data(*positive_name_desc_data())
     def test_positive_create_4(self, test_data):
@@ -540,23 +419,12 @@ class TestOrg(CLITestCase):
         @assert: organization is created, label is auto-generated
 
         """
+        org = make_org(test_data)
+        self.assertNotEqual(org['name'], org['description'])
+        self.assertEqual(org['name'], test_data['name'])
+        self.assertEqual(org['description'], test_data['description'])
 
-        test_data['label'] = ""
-        new_obj = make_org(test_data)
-
-        # Can we find the new object?
-        result = Org.info({'id': new_obj['id']})
-
-        self.assertEqual(result.return_code, 0, "Failed to create object")
-        self.assertEqual(len(result.stderr), 0,
-                         "There should not be an exception here")
-        self.assertGreater(
-            len(result.stdout), 0, "Failed to fetch organization")
-        self.assertNotEqual(result.stdout['name'],
-                            result.stdout['description'])
-        self.assertEqual(new_obj['name'],
-                         result.stdout['name'])
-
+    @skip_if_bug_open('bugzilla', 1142821)
     @data(*positive_name_desc_data())
     def test_positive_create_5(self, test_data):
         """@test: Create organization with valid name, label and description
@@ -565,20 +433,14 @@ class TestOrg(CLITestCase):
 
         @assert: organization is created
 
+        @bz: 1142821
+
         """
-
-        test_data['label'] = gen_string('alpha', 10)
-        new_obj = make_org(test_data)
-
-        # Can we find the new object?
-        result = Org.info({'id': new_obj['id']})
-
-        self.assertEqual(result.return_code, 0, "Failed to create object")
-        self.assertEqual(len(result.stderr), 0,
-                         "There should not be an exception here")
-        self.assertGreater(
-            len(result.stdout), 0, "Failed to fetch organization")
-        self.assertEqual(new_obj['name'], result.stdout['name'])
+        test_data['label'] = gen_string('alpha')
+        org = make_org(test_data)
+        self.assertEqual(org['name'], test_data['name'])
+        self.assertEqual(org['description'], test_data['description'])
+        self.assertEqual(org['label'], test_data['label'])
 
     def test_list_org(self):
         """@Test: Check if Org can be listed
@@ -589,15 +451,8 @@ class TestOrg(CLITestCase):
 
         """
         return_value = Org.list()
-        self.assertEqual(
-            return_value.return_code,
-            0,
-            "List Org - retcode")
-        self.assertEqual(
-            len(return_value.stderr),
-            0,
-            "There should not be an exception here"
-        )
+        self.assertEqual(return_value.return_code, 0)
+        self.assertEqual(len(return_value.stderr), 0)
 
     @run_only_on('sat')
     def test_add_subnet(self):
@@ -612,10 +467,8 @@ class TestOrg(CLITestCase):
         subnet_result = make_subnet()
         return_value = Org.add_subnet(
             {'name': org_result['name'], 'subnet': subnet_result['name']})
-        self.assertEqual(return_value.return_code, 0,
-                         "Add subnet - retcode")
-        self.assertEqual(
-            len(return_value.stderr), 0, "There should not be an error here")
+        self.assertEqual(return_value.return_code, 0)
+        self.assertEqual(len(return_value.stderr), 0)
 
     @run_only_on('sat')
     def test_remove_subnet(self):
@@ -632,10 +485,8 @@ class TestOrg(CLITestCase):
             {'name': org_result['name'], 'subnet': subnet_result['name']})
         return_value = Org.remove_subnet(
             {'name': org_result['name'], 'subnet': subnet_result['name']})
-        self.assertEqual(return_value.return_code, 0,
-                         "Remove Subnet - retcode")
-        self.assertEqual(
-            len(return_value.stderr), 0, "There should not be an error here")
+        self.assertEqual(return_value.return_code, 0)
+        self.assertEqual(len(return_value.stderr), 0)
 
     def test_add_user(self):
         """@Test: Check if a User can be added to an Org
@@ -649,10 +500,8 @@ class TestOrg(CLITestCase):
         user_result = make_user()
         return_value = Org.add_user(
             {'name': org_result['name'], 'user-id': user_result['id']})
-        self.assertEqual(return_value.return_code, 0,
-                         "Add User - retcode")
-        self.assertEqual(
-            len(return_value.stderr), 0, "There should not be an error here")
+        self.assertEqual(return_value.return_code, 0)
+        self.assertEqual(len(return_value.stderr), 0)
 
     def test_remove_user(self):
         """@Test: Check if a User can be removed from an Org
@@ -668,10 +517,8 @@ class TestOrg(CLITestCase):
             {'name': org_result['name'], 'user-id': user_result['login']})
         return_value = Org.remove_user(
             {'name': org_result['name'], 'user-id': user_result['login']})
-        self.assertEqual(return_value.return_code, 0,
-                         "Remove User - retcode")
-        self.assertEqual(
-            len(return_value.stderr), 0, "There should not be an error here")
+        self.assertEqual(return_value.return_code, 0)
+        self.assertEqual(len(return_value.stderr), 0)
 
     @run_only_on('sat')
     def test_add_hostgroup(self):
@@ -687,10 +534,8 @@ class TestOrg(CLITestCase):
         return_value = Org.add_hostgroup({
             'name': org_result['name'],
             'hostgroup': hostgroup_result['name']})
-        self.assertEqual(return_value.return_code, 0,
-                         "Add Hostgroup - retcode")
-        self.assertEqual(
-            len(return_value.stderr), 0, "There should not be an error here")
+        self.assertEqual(return_value.return_code, 0)
+        self.assertEqual(len(return_value.stderr), 0)
 
     @run_only_on('sat')
     def test_remove_hostgroup(self):
@@ -709,10 +554,8 @@ class TestOrg(CLITestCase):
         return_value = Org.remove_hostgroup({
             'name': org_result['name'],
             'hostgroup': hostgroup_result['name']})
-        self.assertEqual(return_value.return_code, 0,
-                         "Remove Hostgroup - retcode")
-        self.assertEqual(
-            len(return_value.stderr), 0, "There should not be an error here")
+        self.assertEqual(return_value.return_code, 0)
+        self.assertEqual(len(return_value.stderr), 0)
 
     @run_only_on('sat')
     def test_add_computeresource(self):
@@ -735,13 +578,11 @@ class TestOrg(CLITestCase):
         return_value = Org.add_compute_resource({
             'name': org['name'],
             'compute-resource': compute_res['name']})
-        self.assertEqual(return_value.return_code, 0,
-                         "Add ComputeResource - retcode")
-        self.assertEqual(
-            len(return_value.stderr), 0, "There should not be an error here")
+        self.assertEqual(return_value.return_code, 0)
+        self.assertEqual(len(return_value.stderr), 0)
         result = Org.info({'id': org['id']})
-        self.assertEqual(result.stdout['compute-resources'][0],
-                         compute_res['name'])
+        self.assertEqual(
+            result.stdout['compute-resources'][0], compute_res['name'])
 
     @run_only_on('sat')
     @stubbed()
@@ -771,10 +612,8 @@ class TestOrg(CLITestCase):
         return_value = Org.add_medium({
             'name': org_result['name'],
             'medium': medium_result['name']})
-        self.assertEqual(return_value.return_code, 0,
-                         "Add Medium - retcode")
-        self.assertEqual(
-            len(return_value.stderr), 0, "There should not be an error here")
+        self.assertEqual(return_value.return_code, 0)
+        self.assertEqual(len(return_value.stderr), 0)
 
     @run_only_on('sat')
     def test_remove_medium(self):
@@ -793,10 +632,8 @@ class TestOrg(CLITestCase):
         return_value = Org.remove_medium({
             'name': org_result['name'],
             'medium': medium_result['name']})
-        self.assertEqual(return_value.return_code, 0,
-                         "Remove Medium - retcode")
-        self.assertEqual(
-            len(return_value.stderr), 0, "There should not be an error here")
+        self.assertEqual(return_value.return_code, 0)
+        self.assertEqual(len(return_value.stderr), 0)
 
     @run_only_on('sat')
     @data(
@@ -818,7 +655,7 @@ class TestOrg(CLITestCase):
             org = make_org()
             template = make_template({
                 'name': data,
-                'content': gen_string('alpha', 10),
+                'content': gen_string('alpha'),
             })
         except CLIFactoryError as err:
             self.fail(err)
@@ -826,11 +663,8 @@ class TestOrg(CLITestCase):
             'name': org['name'],
             'config-template': template['name']
         })
-        self.assertEqual(result.return_code, 0,
-                         "return code must be 0, instead got {0}".
-                         format(result.return_code))
-        self.assertEqual(
-            len(result.stderr), 0, "There should not be an error here")
+        self.assertEqual(result.return_code, 0)
+        self.assertEqual(len(result.stderr), 0)
         result = Org.info({'id': org['id']})
         self.assertIn(
             u'{0} ({1})'. format(template['name'], template['type']),
@@ -857,7 +691,7 @@ class TestOrg(CLITestCase):
             org = make_org()
             tmplt = make_template({
                 'name': data,
-                'content': gen_string('alpha', 10)
+                'content': gen_string('alpha')
             })
         except CLIFactoryError as err:
             self.fail(err)
@@ -867,11 +701,8 @@ class TestOrg(CLITestCase):
             'name': org['name'],
             'config-template': tmplt['name']
         })
-        self.assertEqual(result.return_code, 0,
-                         "return code must be 0, instead got {0}".
-                         format(result.return_code))
-        self.assertEqual(
-            len(result.stderr), 0, "There should not be an error here")
+        self.assertEqual(result.return_code, 0)
+        self.assertEqual(len(result.stderr), 0)
         result = Org.info({'id': org['id']})
         self.assertIn(
             u'{0} ({1})'. format(tmplt['name'], tmplt['type']),
@@ -883,11 +714,8 @@ class TestOrg(CLITestCase):
             'name': org['name'],
             'config-template': tmplt['name']
         })
-        self.assertEqual(result.return_code, 0,
-                         "return code must be 0, instead got {0}".
-                         format(result.return_code))
-        self.assertEqual(
-            len(result.stderr), 0, "There should not be an error here")
+        self.assertEqual(result.return_code, 0)
+        self.assertEqual(len(result.stderr), 0)
         result = Org.info({'id': org['id']})
         self.assertNotIn(
             u'{0} ({1})'. format(tmplt['name'], tmplt['type']),
@@ -914,7 +742,7 @@ class TestOrg(CLITestCase):
             'name': lc_env_name,
             'organization-id': org_id,
         })
-        self.assertEqual(response.return_code, 0, response.stderr)
+        self.assertEqual(response.return_code, 0)
         self.assertEqual(response.stdout[0]['name'], lc_env_name)
 
     @run_only_on('sat')
@@ -938,17 +766,17 @@ class TestOrg(CLITestCase):
         # Read back information about the lifecycle environment. Verify the
         # sanity of that information.
         response = LifecycleEnvironment.list(lc_env_attrs)
-        self.assertEqual(response.return_code, 0, response.stderr)
+        self.assertEqual(response.return_code, 0)
         self.assertEqual(response.stdout[0]['name'], lc_env_name)
 
         # Delete it.
         response = LifecycleEnvironment.delete(lc_env_attrs)
-        self.assertEqual(response.return_code, 0, response.stderr)
+        self.assertEqual(response.return_code, 0)
 
         # We should get a zero-length response when searcing for the LC env.
         response = LifecycleEnvironment.list(lc_env_attrs)
-        self.assertEqual(response.return_code, 0, response.stderr)
-        self.assertEqual(len(response.stdout), 0, response.stdout)
+        self.assertEqual(response.return_code, 0)
+        self.assertEqual(len(response.stdout), 0)
 
     @run_only_on('sat')
     @stubbed("Needs to be re-worked!")
@@ -965,10 +793,8 @@ class TestOrg(CLITestCase):
         return_value = Org.add_smart_proxy({
             'name': org_result['name'],
             'smart-proxy': proxy_result['name']})
-        self.assertEqual(return_value.return_code, 0,
-                         "Add smartproxy - retcode")
-        self.assertEqual(
-            len(return_value.stderr), 0, "There should not be an error here")
+        self.assertEqual(return_value.return_code, 0)
+        self.assertEqual(len(return_value.stderr), 0)
 
     @run_only_on('sat')
     @stubbed("Needs to be re-worked!")
@@ -988,24 +814,22 @@ class TestOrg(CLITestCase):
         return_value = Org.remove_smart_proxy({
             'name': org_result['name'],
             'smart-proxy': proxy_result['name']})
-        self.assertEqual(return_value.return_code, 0,
-                         "Remove smartproxy - retcode")
-        self.assertEqual(
-            len(return_value.stderr), 0, "There should not be an error here")
+        self.assertEqual(return_value.return_code, 0)
+        self.assertEqual(len(return_value.stderr), 0)
 
     # Negative Create
 
-    @data({'label': gen_string('alpha', 10),
+    @data({'label': gen_string('alpha'),
            'name': gen_string('alpha', 300)},
-          {'label': gen_string('alpha', 10),
+          {'label': gen_string('alpha'),
            'name': gen_string('numeric', 300)},
-          {'label': gen_string('alpha', 10),
+          {'label': gen_string('alpha'),
            'name': gen_string('alphanumeric', 300)},
-          {'label': gen_string('alpha', 10),
+          {'label': gen_string('alpha'),
            'name': gen_string('utf8', 300)},
-          {'label': gen_string('alpha', 10),
+          {'label': gen_string('alpha'),
            'name': gen_string('latin1', 300)},
-          {'label': gen_string('alpha', 10),
+          {'label': gen_string('alpha'),
            'name': gen_string('html', 300)})
     def test_negative_create_0(self, test_data):
         """@test: Create organization with valid label and description, name is
@@ -1016,14 +840,17 @@ class TestOrg(CLITestCase):
         @assert: organization is not created
 
         """
-        result = Org.create({'label': test_data['label'], 'description':
-                             test_data['label'], 'name': test_data['name']})
-        self.assertTrue(result.stderr)
+        result = Org.create({
+            'description': test_data['label'],
+            'label': test_data['label'],
+            'name': test_data['name'],
+        })
+        self.assertGreater(len(result.stderr), 0)
         self.assertNotEqual(result.return_code, 0)
 
-    @data(gen_string('alpha', 10),
-          gen_string('numeric', 10),
-          gen_string('alphanumeric', 10))
+    @data(gen_string('alpha'),
+          gen_string('numeric'),
+          gen_string('alphanumeric'))
     def test_negative_create_1(self, test_data):
         """@test: Create organization with valid label and description, name is
         blank
@@ -1033,14 +860,17 @@ class TestOrg(CLITestCase):
         @assert: organization is not created
 
         """
-        result = Org.create({'label': test_data, 'description': test_data,
-                            'name': ''})
+        result = Org.create({
+            'description': test_data,
+            'label': test_data,
+            'name': '',
+        })
         self.assertTrue(result.stderr)
         self.assertNotEqual(result.return_code, 0)
 
-    @data(gen_string('alpha', 10),
-          gen_string('numeric', 10),
-          gen_string('alphanumeric', 10))
+    @data(gen_string('alpha'),
+          gen_string('numeric'),
+          gen_string('alphanumeric'))
     def test_negative_create_2(self, test_data):
         """@test: Create organization with valid label and description, name is
         whitespace
@@ -1050,15 +880,17 @@ class TestOrg(CLITestCase):
         @assert: organization is not created
 
         """
-        result = Org.create({'label': test_data, 'description': test_data,
-                             'name': ' \t'})
-        self.assertGreater(
-            len(result.stderr), 0, "There should be an exception here.")
+        result = Org.create({
+            'label': test_data,
+            'description': test_data,
+            'name': ' \t',
+        })
+        self.assertGreater(len(result.stderr), 0)
         self.assertNotEqual(result.return_code, 0)
 
-    @data(gen_string('alpha', 10),
-          gen_string('numeric', 10),
-          gen_string('alphanumeric', 10))
+    @data(gen_string('alpha'),
+          gen_string('numeric'),
+          gen_string('alphanumeric'))
     def test_negative_create_3(self, test_data):
         """@test: Create organization with valid values, then create a new one
         with same values.
@@ -1068,14 +900,19 @@ class TestOrg(CLITestCase):
         @assert: organization is not created
 
         """
-        result = Org.create({'label': test_data, 'description': test_data,
-                             'name': test_data})
+        result = Org.create({
+            'description': test_data,
+            'label': test_data,
+            'name': test_data,
+        })
         self.assertFalse(result.stderr)
         self.assertEqual(result.return_code, 0)
-        result = Org.create({'label': test_data, 'description': test_data,
-                             'name': test_data})
-        self.assertGreater(
-            len(result.stderr), 0, "There should be an exception here.")
+        result = Org.create({
+            'description': test_data,
+            'label': test_data,
+            'name': test_data,
+        })
+        self.assertGreater(len(result.stderr), 0)
         self.assertNotEqual(result.return_code, 0)
 
     # Positive Delete
@@ -1093,29 +930,17 @@ class TestOrg(CLITestCase):
         @BZ: 1076568
 
         """
+        org = make_org(test_data)
 
-        new_obj = make_org(test_data)
-
-        # Can we find the new object?
-        result = Org.info({'id': new_obj['id']})
-
+        result = Org.delete({'id': org['id']})
         self.assertEqual(result.return_code, 0)
         self.assertEqual(len(result.stderr), 0)
-        self.assertEqual(new_obj['name'], result.stdout['name'])
-
-        return_value = Org.delete({'id': new_obj['id']})
-        self.assertEqual(return_value.return_code, 0, "Deletion failed")
-        self.assertEqual(
-            len(return_value.stderr), 0, "There should not be an error here")
 
         # Can we find the object?
-        result = Org.info({'id': new_obj['id']})
-        self.assertNotEqual(
-            result.return_code, 0, "Organization should be deleted")
-        self.assertGreater(len(result.stderr), 0,
-                           "There should not be an exception here")
-        self.assertEqual(
-            len(result.stdout), 0, "Output should be blank.")
+        result = Org.info({'id': org['id']})
+        self.assertNotEqual(result.return_code, 0)
+        self.assertGreater(len(result.stderr), 0)
+        self.assertEqual(len(result.stdout), 0)
 
     @skip_if_bug_open('bugzilla', 1076568)
     @data(*positive_name_desc_label_data())
@@ -1130,29 +955,17 @@ class TestOrg(CLITestCase):
         @BZ: 1076568
 
         """
+        org = make_org(test_data)
 
-        new_obj = make_org(test_data)
-
-        # Can we find the new object?
-        result = Org.info({'id': new_obj['id']})
-
-        self.assertEqual(result.return_code, 0)
-        self.assertEqual(len(result.stderr), 0)
-        self.assertEqual(new_obj['name'], result.stdout['name'])
-
-        return_value = Org.delete({'label': new_obj['label']})
-        self.assertEqual(return_value.return_code, 0, "Deletion failed")
-        self.assertEqual(
-            len(return_value.stderr), 0, "There should not be an error here")
+        return_value = Org.delete({'label': org['label']})
+        self.assertEqual(return_value.return_code, 0)
+        self.assertEqual(len(return_value.stderr), 0)
 
         # Can we find the object?
-        result = Org.info({'id': new_obj['id']})
-        self.assertNotEqual(
-            result.return_code, 0, "Organization should be deleted")
-        self.assertGreater(len(result.stderr), 0,
-                           "There should not be an exception here")
-        self.assertEqual(
-            len(result.stdout), 0, "Output should be blank.")
+        result = Org.info({'id': org['id']})
+        self.assertNotEqual(result.return_code, 0)
+        self.assertGreater(len(result.stderr), 0)
+        self.assertEqual(len(result.stdout), 0)
 
     @skip_if_bug_open('bugzilla', 1076568)
     @data(*positive_name_desc_label_data())
@@ -1167,36 +980,24 @@ class TestOrg(CLITestCase):
         @BZ: 1076568
 
         """
+        org = make_org(test_data)
 
-        new_obj = make_org(test_data)
-
-        # Can we find the new object?
-        result = Org.info({'id': new_obj['id']})
-
-        self.assertEqual(result.return_code, 0)
-        self.assertEqual(len(result.stderr), 0)
-        self.assertEqual(new_obj['name'], result.stdout['name'])
-
-        return_value = Org.delete({'name': new_obj['name']})
-        self.assertEqual(return_value.return_code, 0, "Deletion failed")
-        self.assertEqual(
-            len(return_value.stderr), 0, "There should not be an error here")
+        return_value = Org.delete({'name': org['name']})
+        self.assertEqual(return_value.return_code, 0)
+        self.assertEqual(len(return_value.stderr), 0)
 
         # Can we find the object?
-        result = Org.info({'id': new_obj['id']})
-        self.assertNotEqual(
-            result.return_code, 0, "Organization should be deleted")
-        self.assertGreater(len(result.stderr), 0,
-                           "There should not be an exception here")
-        self.assertEqual(
-            len(result.stdout), 0, "Output should be blank.")
+        result = Org.info({'id': org['id']})
+        self.assertNotEqual(result.return_code, 0)
+        self.assertGreater(len(result.stderr), 0)
+        self.assertEqual(len(result.stdout), 0)
 
-    @data({'name': gen_string("latin1", 10)},
-          {'name': gen_string("utf8", 10)},
-          {'name': gen_string("alpha", 10)},
-          {'name': gen_string("alphanumeric", 10)},
-          {'name': gen_string("numeric", 10)},
-          {'name': gen_string("html", 10)})
+    @data({'name': gen_string("latin1")},
+          {'name': gen_string("utf8")},
+          {'name': gen_string("alpha")},
+          {'name': gen_string("alphanumeric")},
+          {'name': gen_string("numeric")},
+          {'name': gen_string("html")})
     def test_positive_update_1(self, test_data):
         """@test: Create organization with valid values then update its name
 
@@ -1205,38 +1006,29 @@ class TestOrg(CLITestCase):
         @assert: organization name is updated
 
         """
-
-        new_obj = make_org()
-        # Can we find the new object?
-        result = Org.info({'id': new_obj['id']})
-        self.assertEqual(result.return_code, 0)
-        self.assertEqual(len(result.stderr), 0)
-        self.assertEqual(new_obj['name'], result.stdout['name'])
+        org = make_org()
 
         # Update the org name
-        result = Org.update({'id': new_obj['id'],
-                             'new-name': test_data['name']})
-        self.assertEqual(result.return_code, 0)
-        self.assertEqual(
-            len(result.stderr), 0, "There should not be an error here")
-
-        # Fetch the org again
-        result = Org.info({'id': new_obj['id']})
+        result = Org.update({
+            'id': org['id'],
+            'new-name': test_data['name'],
+        })
         self.assertEqual(result.return_code, 0)
         self.assertEqual(len(result.stderr), 0)
-        self.assertEqual(
-            result.stdout['name'],
-            test_data['name'],
-            "Org name was not updated"
-        )
+
+        # Fetch the org again
+        result = Org.info({'id': org['id']})
+        self.assertEqual(result.return_code, 0)
+        self.assertEqual(len(result.stderr), 0)
+        self.assertEqual(result.stdout['name'], test_data['name'])
 
     @skip_if_bug_open('bugzilla', 1114136)
-    @data({'description': gen_string("latin1", 10)},
-          {'description': gen_string("utf8", 10)},
-          {'description': gen_string("alpha", 10)},
-          {'description': gen_string("alphanumeric", 10)},
-          {'description': gen_string("numeric", 10)},
-          {'description': gen_string("html", 10)})
+    @data({'description': gen_string("latin1")},
+          {'description': gen_string("utf8")},
+          {'description': gen_string("alpha")},
+          {'description': gen_string("alphanumeric")},
+          {'description': gen_string("numeric")},
+          {'description': gen_string("html")})
     def test_positive_update_3(self, test_data):
         """@test: Create organization with valid values then update its
         description
@@ -1248,44 +1040,36 @@ class TestOrg(CLITestCase):
         @bz: 1114136
 
         """
-
-        new_obj = make_org()
-        # Can we find the new object?
-        result = Org.info({'id': new_obj['id']})
-        self.assertEqual(result.return_code, 0)
-        self.assertEqual(len(result.stderr), 0)
-        self.assertEqual(new_obj['name'], result.stdout['name'])
+        org = make_org()
 
         # Update the org name
-        result = Org.update({'id': new_obj['id'],
-                             'description': test_data['description']})
+        result = Org.update({
+            'id': org['id'],
+            'description': test_data['description'],
+        })
         self.assertEqual(result.return_code, 0)
-        self.assertEqual(
-            len(result.stderr), 0, "There should not be an error here")
+        self.assertEqual(len(result.stderr), 0)
 
         # Fetch the org again
-        result = Org.info({'id': new_obj['id']})
+        result = Org.info({'id': org['id']})
         self.assertEqual(result.return_code, 0)
         self.assertEqual(len(result.stderr), 0)
         self.assertEqual(
-            result.stdout['description'],
-            test_data['description'],
-            "Org desc was not updated"
-        )
+            result.stdout['description'], test_data['description'])
 
     @skip_if_bug_open('bugzilla', 1114136)
-    @data({'description': gen_string("latin1", 10),
-           'name': gen_string("latin1", 10)},
-          {'description': gen_string("utf8", 10),
-           'name': gen_string("utf8", 10)},
-          {'description': gen_string("alpha", 10),
-           'name': gen_string("alpha", 10)},
-          {'description': gen_string("alphanumeric", 10),
-           'name': gen_string("alphanumeric", 10)},
-          {'description': gen_string("numeric", 10),
-           'name': gen_string("numeric", 10)},
-          {'description': gen_string("html", 10),
-           'name': gen_string("html", 10)})
+    @data({'description': gen_string("latin1"),
+           'name': gen_string("latin1")},
+          {'description': gen_string("utf8"),
+           'name': gen_string("utf8")},
+          {'description': gen_string("alpha"),
+           'name': gen_string("alpha")},
+          {'description': gen_string("alphanumeric"),
+           'name': gen_string("alphanumeric")},
+          {'description': gen_string("numeric"),
+           'name': gen_string("numeric")},
+          {'description': gen_string("html"),
+           'name': gen_string("html")})
     def test_positive_update_4(self, test_data):
         """@test: Create organization with valid values then update all values
 
@@ -1296,37 +1080,24 @@ class TestOrg(CLITestCase):
         @bz: 1114136
 
         """
-
-        new_obj = make_org()
-        # Can we find the new object?
-        result = Org.info({'id': new_obj['id']})
-        self.assertEqual(result.return_code, 0)
-        self.assertEqual(len(result.stderr), 0)
-        self.assertEqual(new_obj['name'], result.stdout['name'])
-        self.assertEqual(new_obj['description'], result.stdout['description'])
+        org = make_org()
 
         # Update the org name
-        result = Org.update({'id': new_obj['id'],
-                             'new-name': test_data['name'],
-                             'description': test_data['description']})
+        result = Org.update({
+            'id': org['id'],
+            'new-name': test_data['name'],
+            'description': test_data['description'],
+        })
         self.assertEqual(result.return_code, 0)
-        self.assertEqual(
-            len(result.stderr), 0, "There should not be an error here")
+        self.assertEqual(len(result.stderr), 0)
 
         # Fetch the org again
-        result = Org.info({'id': new_obj['id']})
+        result = Org.info({'id': org['id']})
         self.assertEqual(result.return_code, 0)
         self.assertEqual(len(result.stderr), 0)
         self.assertEqual(
-            result.stdout['description'],
-            test_data['description'],
-            "Org desc was not updated"
-        )
-        self.assertEqual(
-            result.stdout['name'],
-            test_data['name'],
-            "Org name was not updated"
-        )
+            result.stdout['description'], test_data['description'])
+        self.assertEqual(result.stdout['name'], test_data['name'])
 
     # Negative Update
 
@@ -1348,20 +1119,15 @@ class TestOrg(CLITestCase):
         @bz: 1076541
 
         """
-
-        new_obj = make_org()
-        # Can we find the new object?
-        result = Org.info({'id': new_obj['id']})
-        self.assertEqual(result.return_code, 0)
-        self.assertEqual(len(result.stderr), 0)
-        self.assertEqual(new_obj['name'], result.stdout['name'])
+        org = make_org()
 
         # Update the org name
-        result = Org.update({'id': new_obj['id'],
-                             'new-name': test_data['name']})
+        result = Org.update({
+            'id': org['id'],
+            'new-name': test_data['name'],
+        })
         self.assertNotEqual(result.return_code, 0)
-        self.assertGreater(len(result.stderr), 0,
-                           "There should be error - hammer expects error")
+        self.assertGreater(len(result.stderr), 0)
 
     # Miscelaneous
 
@@ -1784,11 +1550,11 @@ class TestOrg(CLITestCase):
         pass
 
     @run_only_on('sat')
-    @data(gen_string('alpha', 10),
-          gen_string('numeric', 10),
-          gen_string('alphanumeric', 10),
-          gen_string('utf8', 10),
-          gen_string('latin1', 10))
+    @data(gen_string('alpha'),
+          gen_string('numeric'),
+          gen_string('alphanumeric'),
+          gen_string('utf8'),
+          gen_string('latin1'))
     def test_add_subnet_1(self, name):
         """@test: Add a subnet by using organization name and subnet name
 
@@ -1808,9 +1574,7 @@ class TestOrg(CLITestCase):
             'name': org['name'],
             'subnet': new_subnet['name'],
         })
-        self.assertEqual(result.return_code, 0,
-                         "return code must be 0, instead got {0}".
-                         format(result.return_code))
+        self.assertEqual(result.return_code, 0)
 
         result = Org.info({'id': org['id']})
         self.assertIn(name, result.stdout['subnets'][0])

--- a/tests/foreman/cli/test_product.py
+++ b/tests/foreman/cli/test_product.py
@@ -41,28 +41,13 @@ class TestProduct(CLITestCase):
         @Assert: Product is created and has random name
 
         """
+        product = make_product({
+            u'name': test_name['name'],
+            u'organization-id': self.org['id']
+        })
 
-        new_product = make_product(
-            {
-                u'name': test_name['name'],
-                u'organization-id': self.org['id']
-            }
-        )
-
-        # Fetch it
-        result = Product.info(
-            {u'id': new_product['id'], u'organization-id': self.org['id']})
-        self.assertEqual(
-            result.return_code,
-            0,
-            "Product was not found")
-        self.assertEqual(
-            len(result.stderr), 0, "No error was expected")
-        self.assertEqual(
-            result.stdout['name'], new_product['name'], "Names don't match")
-        self.assertGreater(
-            len(result.stdout['label']), 0, "Label not automatically created"
-        )
+        self.assertEqual(product['name'], test_name['name'])
+        self.assertGreater(len(product['label']), 0)
 
     @run_only_on('sat')
     @data(
@@ -79,7 +64,7 @@ class TestProduct(CLITestCase):
         {u'name': gen_string('html', 15),
          u'label': gen_string('numeric', 15)},
     )
-    def test_positive_create_2(self, test_name):
+    def test_positive_create_2(self, test_data):
         """@Test: Check if product can be created with random labels
 
         @Feature: Product
@@ -87,29 +72,14 @@ class TestProduct(CLITestCase):
         @Assert: Product is created and has random label
 
         """
+        product = make_product({
+            u'name': test_data['name'],
+            u'label': test_data['label'],
+            u'organization-id': self.org['id']
+        })
 
-        new_product = make_product(
-            {
-                u'name': test_name['name'],
-                u'label': test_name['label'],
-                u'organization-id': self.org['id']
-            }
-        )
-
-        # Fetch it
-        result = Product.info(
-            {u'id': new_product['id'], u'organization-id': self.org['id']})
-        self.assertEqual(
-            result.return_code,
-            0,
-            "Product was not found")
-        self.assertEqual(
-            len(result.stderr), 0, "No error was expected")
-        self.assertEqual(
-            result.stdout['name'], new_product['name'], "Names don't match")
-        self.assertEqual(
-            result.stdout['label'], new_product['label'], "Labels don't match"
-        )
+        self.assertEqual(product['name'], test_data['name'])
+        self.assertEqual(product['label'], test_data['label'])
 
     @run_only_on('sat')
     @data(
@@ -126,7 +96,7 @@ class TestProduct(CLITestCase):
         {u'name': gen_string('html', 15),
          u'description': gen_string('html', 15)},
     )
-    def test_positive_create_3(self, test_name):
+    def test_positive_create_3(self, test_data):
         """@Test: Check if product can be created with random description
 
         @Feature: Product
@@ -134,31 +104,14 @@ class TestProduct(CLITestCase):
         @Assert: Product is created and has random description
 
         """
+        product = make_product({
+            u'name': test_data['name'],
+            u'description': test_data['description'],
+            u'organization-id': self.org['id']
+        })
 
-        new_product = make_product(
-            {
-                u'name': test_name['name'],
-                u'description': test_name['description'],
-                u'organization-id': self.org['id']
-            }
-        )
-
-        # Fetch it
-        result = Product.info(
-            {u'id': new_product['id'], u'organization-id': self.org['id']})
-        self.assertEqual(
-            result.return_code,
-            0,
-            "Product was not found")
-        self.assertEqual(
-            len(result.stderr), 0, "No error was expected")
-        self.assertEqual(
-            result.stdout['name'], new_product['name'], "Names don't match")
-        self.assertEqual(
-            result.stdout['description'],
-            new_product['description'],
-            "Descriptions don't match"
-        )
+        self.assertEqual(product['name'], test_data['name'])
+        self.assertEqual(product['description'], test_data['description'])
 
     @run_only_on('sat')
     @data(
@@ -169,7 +122,7 @@ class TestProduct(CLITestCase):
         {u'name': gen_string('utf8', 15)},
         {u'name': gen_string('html', 15)},
     )
-    def test_positive_create_4(self, test_name):
+    def test_positive_create_4(self, test_data):
         """@Test: Check if product can be created with gpg key
 
         @Feature: Product
@@ -177,33 +130,17 @@ class TestProduct(CLITestCase):
         @Assert: Product is created and has gpg key
 
         """
-
-        new_gpg_key = make_gpg_key(
+        gpg_key = make_gpg_key(
             {u'organization-id': self.org['id']}
         )
-        new_product = make_product(
-            {
-                u'name': test_name['name'],
-                u'organization-id': self.org['id'],
-                u'gpg-key-id': new_gpg_key['id'],
-            }
-        )
+        product = make_product({
+            u'name': test_data['name'],
+            u'gpg-key-id': gpg_key['id'],
+            u'organization-id': self.org['id']
+        })
 
-        # Fetch it
-        result = Product.info(
-            {u'id': new_product['id'], u'organization-id': self.org['id']})
-        self.assertEqual(
-            result.return_code,
-            0,
-            "Product was not found")
-        self.assertEqual(
-            len(result.stderr), 0, "No error was expected")
-        self.assertEqual(
-            result.stdout['name'], new_product['name'], "Names don't match")
-        self.assertEqual(
-            result.stdout['gpg']['gpg-key-id'],
-            new_gpg_key['id'],
-            "GPG Keys don't match")
+        self.assertEqual(product['name'], test_data['name'])
+        self.assertEqual(product['gpg']['gpg-key-id'], gpg_key['id'])
 
     @run_only_on('sat')
     @data(
@@ -214,7 +151,7 @@ class TestProduct(CLITestCase):
         {u'name': gen_string('utf8', 15)},
         {u'name': gen_string('html', 15)},
     )
-    def test_positive_create_5(self, test_name):
+    def test_positive_create_5(self, test_data):
         """@Test: Check if product can be created with sync plan
 
         @Feature: Product
@@ -222,31 +159,15 @@ class TestProduct(CLITestCase):
         @Assert: Product is created and has random sync plan
 
         """
+        sync_plan = make_sync_plan({u'organization-id': self.org['id']})
+        product = make_product({
+            u'name': test_data['name'],
+            u'organization-id': self.org['id'],
+            u'sync-plan-id': sync_plan['id'],
+        })
 
-        new_sync_plan = make_sync_plan({u'organization-id': self.org['id']})
-        new_product = make_product(
-            {
-                u'name': test_name['name'],
-                u'organization-id': self.org['id'],
-                u'sync-plan-id': new_sync_plan['id'],
-            }
-        )
-
-        # Fetch it
-        result = Product.info(
-            {u'id': new_product['id'], u'organization-id': self.org['id']})
-        self.assertEqual(
-            result.return_code,
-            0,
-            "Product was not found")
-        self.assertEqual(
-            len(result.stderr), 0, "No error was expected")
-        self.assertEqual(
-            result.stdout['name'], new_product['name'], "Names don't match")
-        self.assertEqual(
-            result.stdout['sync-plan-id'],
-            new_sync_plan['id'],
-            "Sync plans don't match")
+        self.assertEqual(product['name'], test_data['name'])
+        self.assertEqual(product['sync-plan-id'], sync_plan['id'])
 
     @run_only_on('sat')
     @data(
@@ -318,59 +239,30 @@ class TestProduct(CLITestCase):
         @Assert: Product description is updated
 
         """
-
-        new_product = make_product(
-            {
-                u'organization-id': self.org['id']
-            }
-        )
-
-        # Fetch it
-        result = Product.info(
-            {u'id': new_product['id'], u'organization-id': self.org['id']})
-        self.assertEqual(
-            result.return_code,
-            0,
-            "Product was not found")
-        self.assertEqual(
-            len(result.stderr), 0, "No error was expected")
+        product = make_product({
+            u'organization-id': self.org['id'],
+        })
 
         # Update the Descriptions
-        result = Product.update(
-            {u'id': new_product['id'],
-             u'description': test_data['description']}
-        )
+        result = Product.update({
+            u'id': product['id'],
+            u'description': test_data['description'],
+        })
 
         # Fetch it
-        result = Product.info(
-            {u'id': new_product['id'], u'organization-id': self.org['id']})
+        result = Product.info({
+            u'id': product['id'],
+            u'organization-id': self.org['id'],
+        })
+        self.assertEqual(result.return_code, 0)
+        self.assertEqual(len(result.stderr), 0)
         self.assertEqual(
-            result.return_code,
-            0,
-            "Product was not found")
-        self.assertEqual(
-            len(result.stderr), 0, "No error was expected")
-        self.assertEqual(
-            result.stdout['description'],
-            test_data['description'],
-            "Description was not updated"
-        )
+            result.stdout['description'], test_data['description'])
         self.assertNotEqual(
-            result.stdout['description'],
-            new_product['description'],
-            "Descriptions should not match"
-        )
+            product['description'], result.stdout['description'])
 
     @run_only_on('sat')
-    @data(
-        {u'name': gen_string('alpha', 15)},
-        {u'name': gen_string('alphanumeric', 15)},
-        {u'name': gen_string('numeric', 15)},
-        {u'name': gen_string('latin1', 15)},
-        {u'name': gen_string('utf8', 15)},
-        {u'name': gen_string('html', 15)},
-    )
-    def test_positive_update_2(self, test_name):
+    def test_positive_update_2(self):
         """@Test: Update product's gpg keys
 
         @Feature: Product
@@ -378,93 +270,41 @@ class TestProduct(CLITestCase):
         @Assert: Product gpg key is updated
 
         """
-
         first_gpg_key = make_gpg_key(
             {u'organization-id': self.org['id']}
         )
         second_gpg_key = make_gpg_key(
             {u'organization-id': self.org['id']}
         )
-        new_product = make_product(
-            {
-                u'name': test_name['name'],
-                u'organization-id': self.org['id'],
-            }
-        )
+        product = make_product({
+            u'organization-id': self.org['id'],
+            u'gpg-key-id': first_gpg_key['id'],
+        })
+
+        # Update the Descriptions
+        result = Product.update({
+            u'id': product['id'],
+            u'gpg-key-id': second_gpg_key['id'],
+        })
 
         # Fetch it
-        result = Product.info(
-            {u'id': new_product['id'], u'organization-id': self.org['id']})
-        self.assertEqual(
-            result.return_code,
-            0,
-            "Product was not found")
-        self.assertEqual(
-            len(result.stderr), 0, "No error was expected")
-        # No gpg key yet
-        self.assertEqual(
-            len(result.stdout['gpg']['gpg-key-id']), 0, "No gpg key expected"
-        )
-
-        # Add first gpg key to product
-        result = Product.update(
-            {u'id': new_product['id'],
-             u'gpg-key-id': first_gpg_key['id']}
-        )
-
-        # Fetch it
-        result = Product.info(
-            {u'id': new_product['id'], u'organization-id': self.org['id']})
-        self.assertEqual(
-            result.return_code,
-            0,
-            "Product was not found")
-        self.assertEqual(
-            len(result.stderr), 0, "No error was expected")
-        self.assertEqual(
-            result.stdout['gpg']['gpg-key-id'],
-            first_gpg_key['id'],
-            "GPG Keys don't match")
-        self.assertNotEqual(
-            result.stdout['gpg']['gpg-key-id'],
-            second_gpg_key['id'],
-            "GPG Keys should not match")
-
-        # Remove first key by updating product to use second key
-        result = Product.update(
-            {u'id': new_product['id'],
-             u'gpg-key-id': second_gpg_key['id']}
-        )
-
-        # Fetch it
-        result = Product.info(
-            {u'id': new_product['id'], u'organization-id': self.org['id']})
-        self.assertEqual(
-            result.return_code,
-            0,
-            "Product was not found")
-        self.assertEqual(
-            len(result.stderr), 0, "No error was expected")
+        result = Product.info({
+            u'id': product['id'],
+            u'organization-id': self.org['id'],
+        })
+        self.assertEqual(result.return_code, 0)
+        self.assertEqual(len(result.stderr), 0)
         self.assertEqual(
             result.stdout['gpg']['gpg-key-id'],
             second_gpg_key['id'],
-            "GPG Keys don't match"
         )
         self.assertNotEqual(
             result.stdout['gpg']['gpg-key-id'],
             first_gpg_key['id'],
-            "GPG Keys should not match")
+        )
 
     @run_only_on('sat')
-    @data(
-        {u'name': gen_string('alpha', 15)},
-        {u'name': gen_string('alphanumeric', 15)},
-        {u'name': gen_string('numeric', 15)},
-        {u'name': gen_string('latin1', 15)},
-        {u'name': gen_string('utf8', 15)},
-        {u'name': gen_string('html', 15)},
-    )
-    def test_positive_update_3(self, test_name):
+    def test_positive_update_3(self):
         """@Test: Update product's sync plan
 
         @Feature: Product
@@ -472,94 +312,41 @@ class TestProduct(CLITestCase):
         @Assert: Product sync plan is updated
 
         """
+        first_sync_plan = make_sync_plan({
+            u'organization-id': self.org['id'],
+        })
+        second_sync_plan = make_sync_plan({
+            u'organization-id': self.org['id'],
+        })
+        product = make_product({
+            u'organization-id': self.org['id'],
+            u'sync-plan-id': first_sync_plan['id'],
+        })
 
-        first_sync_plan = make_sync_plan(
-            {u'organization-id': self.org['id']}
-        )
-        second_sync_plan = make_sync_plan(
-            {u'organization-id': self.org['id']}
-        )
-        new_product = make_product(
-            {
-                u'name': test_name['name'],
-                u'organization-id': self.org['id'],
-            }
-        )
-
-        # Fetch it
-        result = Product.info(
-            {u'id': new_product['id'], u'organization-id': self.org['id']})
-        self.assertEqual(
-            result.return_code,
-            0,
-            "Product was not found")
-        self.assertEqual(
-            len(result.stderr), 0, "No error was expected")
-        # No sync plan yet
-        self.assertEqual(
-            len(result.stdout['sync-plan-id']), 0, "No sync plan expected"
-        )
-
-        # Add first sync plan to product
-        result = Product.update(
-            {u'id': new_product['id'],
-             u'sync-plan-id': first_sync_plan['id']}
-        )
+        # Update the Descriptions
+        result = Product.update({
+            u'id': product['id'],
+            u'sync-plan-id': second_sync_plan['id'],
+        })
 
         # Fetch it
-        result = Product.info(
-            {u'id': new_product['id'], u'organization-id': self.org['id']})
-        self.assertEqual(
-            result.return_code,
-            0,
-            "Product was not found")
-        self.assertEqual(
-            len(result.stderr), 0, "No error was expected")
-        self.assertEqual(
-            result.stdout['sync-plan-id'],
-            first_sync_plan['id'],
-            "Sync plans don't match")
-        self.assertNotEqual(
-            result.stdout['sync-plan-id'],
-            second_sync_plan['id'],
-            "Sync plans should not match")
-
-        # Remove first sync plan by updating product to use second plan
-        result = Product.update(
-            {u'id': new_product['id'],
-             u'name': new_product['name'],
-             u'sync-plan-id': second_sync_plan['id']}
-        )
-
-        # Fetch it
-        result = Product.info(
-            {u'id': new_product['id'], u'organization-id': self.org['id']})
-        self.assertEqual(
-            result.return_code,
-            0,
-            "Product was not found")
-        self.assertEqual(
-            len(result.stderr), 0, "No error was expected")
+        result = Product.info({
+            u'id': product['id'],
+            u'organization-id': self.org['id'],
+        })
+        self.assertEqual(result.return_code, 0)
+        self.assertEqual(len(result.stderr), 0)
         self.assertEqual(
             result.stdout['sync-plan-id'],
             second_sync_plan['id'],
-            "Sync plans don't match"
         )
         self.assertNotEqual(
             result.stdout['sync-plan-id'],
             first_sync_plan['id'],
-            "Sync plans should not match")
+        )
 
     @run_only_on('sat')
-    @data(
-        {u'name': gen_string('alpha', 15)},
-        {u'name': gen_string('alphanumeric', 15)},
-        {u'name': gen_string('numeric', 15)},
-        {u'name': gen_string('latin1', 15)},
-        {u'name': gen_string('utf8', 15)},
-        {u'name': gen_string('html', 15)},
-    )
-    def test_positive_delete_1(self, test_name):
+    def test_positive_delete_1(self):
         """@Test: Check if product can be deleted
 
         @Feature: Product
@@ -567,47 +354,22 @@ class TestProduct(CLITestCase):
         @Assert: Product is deleted
 
         """
-
-        new_product = make_product(
-            {
-                u'name': test_name['name'],
-                u'organization-id': self.org['id']
-            }
-        )
-
-        # Fetch it
-        result = Product.info(
-            {u'id': new_product['id'], u'organization-id': self.org['id']})
-        self.assertEqual(
-            result.return_code,
-            0,
-            "Product was not found")
-        self.assertEqual(
-            len(result.stderr), 0, "No error was expected")
-        self.assertEqual(
-            result.stdout['name'], new_product['name'], "Names don't match")
-        self.assertGreater(
-            len(result.stdout['label']), 0, "Label not automatically created"
-        )
+        new_product = make_product({
+            u'organization-id': self.org['id']
+        })
 
         # Delete it
         result = Product.delete({u'id': new_product['id']})
-        self.assertEqual(
-            result.return_code,
-            0,
-            "Product was not deleted")
-        self.assertEqual(
-            len(result.stderr), 0, "No error was expected")
+        self.assertEqual(result.return_code, 0)
+        self.assertEqual(len(result.stderr), 0)
 
         # Fetch it
-        result = Product.info(
-            {u'id': new_product['id'], u'organization-id': self.org['id']})
-        self.assertNotEqual(
-            result.return_code,
-            0,
-            "Product should not be found")
-        self.assertGreater(
-            len(result.stderr), 0, "Error was expected")
+        result = Product.info({
+            u'id': new_product['id'],
+            u'organization-id': self.org['id'],
+        })
+        self.assertNotEqual(result.return_code, 0)
+        self.assertGreater(len(result.stderr), 0)
 
     def test_add_syncplan_1(self):
         """@Test: Check if product can be assigned a syncplan

--- a/tests/foreman/cli/test_proxy.py
+++ b/tests/foreman/cli/test_proxy.py
@@ -83,17 +83,6 @@ class TestProxy(CLITestCase):
             proxy['name'],
             data['name'], "Input and output name should be consistent")
 
-        result = Proxy.info({u'id': proxy['id']})
-        self.assertEqual(
-            result.return_code,
-            0,
-            "Proxy should be found"
-        )
-        self.assertEqual(
-            len(result.stderr),
-            0,
-            "No error excepted"
-        )
         result = Proxy.delete({u'id': proxy['id']})
         self.assertEqual(
             result.return_code,

--- a/tests/foreman/cli/test_repository.py
+++ b/tests/foreman/cli/test_repository.py
@@ -75,23 +75,15 @@ class TestRepository(CLITestCase):
         value
 
         """
-        new_repo = self._make_repository({
-            u'name': gen_string('alpha', 10),
+        repository = self._make_repository({
+            u'name': gen_string('alpha'),
             u'content-type': u'docker',
             u'docker-upstream-name': u'fedora/rabbitmq',
         })
-        result = Repository.info({'id': new_repo['id']})
 
-        self.assertIn(
-            u'upstream-repository-name',
-            result.stdout,
-            'upstream-repository-name parameter was not found in output'
-        )
+        self.assertIn(u'upstream-repository-name', repository)
         self.assertEqual(
-            result.stdout['upstream-repository-name'],
-            u'fedora/rabbitmq',
-            'Wrong value of upstream-repository-name parameter'
-        )
+            repository['upstream-repository-name'], u'fedora/rabbitmq')
 
     @run_only_on('sat')
     @data(
@@ -113,7 +105,7 @@ class TestRepository(CLITestCase):
 
         new_repo = self._make_repository({u'name': name})
         # Assert that name matches data passed
-        self.assertEqual(new_repo['name'], name, "Names don't match")
+        self.assertEqual(new_repo['name'], name)
 
     @run_only_on('sat')
     @data(
@@ -141,12 +133,8 @@ class TestRepository(CLITestCase):
             u'label': label,
         })
         # Assert that name matches data passed
-        self.assertEqual(new_repo['name'], name, "Names don't match")
-        self.assertNotEqual(
-            new_repo['name'],
-            new_repo['label'],
-            "Label should not match the repository name"
-        )
+        self.assertEqual(new_repo['name'], name)
+        self.assertNotEqual(new_repo['name'], new_repo['label'])
 
     @run_only_on('sat')
     @data(
@@ -170,13 +158,8 @@ class TestRepository(CLITestCase):
             u'content-type': test_data['content-type'],
         })
         # Assert that urls and content types matches data passed
-        self.assertEqual(
-            new_repo['url'], test_data['url'], "Urls don't match")
-        self.assertEqual(
-            new_repo['content-type'],
-            test_data['content-type'],
-            "Content Types don't match"
-        )
+        self.assertEqual(new_repo['url'], test_data['url'])
+        self.assertEqual(new_repo['content-type'], test_data['content-type'])
 
     @run_only_on('sat')
     @data(
@@ -200,13 +183,8 @@ class TestRepository(CLITestCase):
             u'content-type': test_data['content-type'],
         })
         # Assert that urls and content types matches data passed
-        self.assertEqual(
-            new_repo['url'], test_data['url'], "Urls don't match")
-        self.assertEqual(
-            new_repo['content-type'],
-            test_data['content-type'],
-            "Content Types don't match"
-        )
+        self.assertEqual(new_repo['url'], test_data['url'])
+        self.assertEqual(new_repo['content-type'], test_data['content-type'])
 
     @run_only_on('sat')
     @data(
@@ -228,30 +206,14 @@ class TestRepository(CLITestCase):
         # Make a new gpg key
         new_gpg_key = make_gpg_key({'organization-id': self.org['id']})
 
-        new_repo = self._make_repository({
+        repository = self._make_repository({
             u'name': name,
             u'gpg-key-id': new_gpg_key['id'],
         })
 
-        # Fetch it again
-        result = Repository.info({'id': new_repo['id']})
-        self.assertEqual(
-            result.return_code,
-            0,
-            "Repository was not found")
-        self.assertEqual(
-            len(result.stderr), 0, "No error was expected")
         # Assert that data matches data passed
-        self.assertEqual(
-            result.stdout['gpg-key']['id'],
-            new_gpg_key['id'],
-            "GPG Keys ID don't match"
-        )
-        self.assertEqual(
-            result.stdout['gpg-key']['name'],
-            new_gpg_key['name'],
-            "GPG Keys name don't match"
-        )
+        self.assertEqual(repository['gpg-key']['id'], new_gpg_key['id'])
+        self.assertEqual(repository['gpg-key']['name'], new_gpg_key['name'])
 
     @run_only_on('sat')
     @skip_if_bug_open('bugzilla', 1103944)
@@ -280,16 +242,8 @@ class TestRepository(CLITestCase):
         })
 
         # Assert that data matches data passed
-        self.assertEqual(
-            new_repo['gpg-key']['id'],
-            new_gpg_key['id'],
-            "GPG Keys ID don't match"
-        )
-        self.assertEqual(
-            new_repo['gpg-key']['name'],
-            new_gpg_key['name'],
-            "GPG Keys name don't match"
-        )
+        self.assertEqual(new_repo['gpg-key']['id'], new_gpg_key['id'])
+        self.assertEqual(new_repo['gpg-key']['name'], new_gpg_key['name'])
 
     @run_only_on('sat')
     @data(u'true', u'yes', u'1')
@@ -301,23 +255,8 @@ class TestRepository(CLITestCase):
         @Assert: Repository is created and is published via http
 
         """
-
-        new_repo = self._make_repository({'publish-via-http': test_data})
-
-        # Fetch it again
-        result = Repository.info({'id': new_repo['id']})
-        self.assertEqual(
-            result.return_code,
-            0,
-            "Repository was not found")
-        self.assertEqual(
-            len(result.stderr), 0, "No error was expected")
-
-        self.assertEqual(
-            result.stdout['publish-via-http'],
-            u'yes',
-            "Publishing methods don't match"
-        )
+        repository = self._make_repository({'publish-via-http': test_data})
+        self.assertEqual(repository['publish-via-http'], u'yes')
 
     @run_only_on('sat')
     @data(u'false', u'no', u'0')
@@ -329,23 +268,8 @@ class TestRepository(CLITestCase):
         @Assert: Repository is created and is not published via http
 
         """
-
-        new_repo = self._make_repository({'publish-via-http': use_http})
-
-        # Fetch it again
-        result = Repository.info({'id': new_repo['id']})
-        self.assertEqual(
-            result.return_code,
-            0,
-            "Repository was not found")
-        self.assertEqual(
-            len(result.stderr), 0, "No error was expected")
-
-        self.assertEqual(
-            result.stdout['publish-via-http'],
-            u'no',
-            "Publishing methods don't match"
-        )
+        repository = self._make_repository({'publish-via-http': use_http})
+        self.assertEqual(repository['publish-via-http'], u'no')
 
     @skip_if_bug_open('bugzilla', 1155237)
     @run_only_on('sat')
@@ -464,26 +388,16 @@ class TestRepository(CLITestCase):
             u'content-type': test_data['content-type'],
         })
         # Assertion that repo is not yet synced
-        self.assertEqual(
-            new_repo['sync']['status'],
-            'Not Synced',
-            "The status of repository should be 'Not Synced'")
+        self.assertEqual(new_repo['sync']['status'], 'Not Synced')
 
         # Synchronize it
         result = Repository.synchronize({'id': new_repo['id']})
-        self.assertEqual(
-            result.return_code,
-            0,
-            "Repository was not synchronized")
-        self.assertEqual(
-            len(result.stderr), 0, "No error was expected")
+        self.assertEqual(result.return_code, 0)
+        self.assertEqual(len(result.stderr), 0)
 
         # Verify it has finished
         result = Repository.info({'id': new_repo['id']})
-        self.assertEqual(
-            result.stdout['sync']['status'],
-            'Finished',
-            "The new status of repository should be 'Finished'")
+        self.assertEqual(result.stdout['sync']['status'], 'Finished')
 
     @run_only_on('sat')
     @skip_if_bug_open('bugzilla', 1152237)
@@ -537,31 +451,15 @@ class TestRepository(CLITestCase):
             u'id': new_repo['id'],
             u'url': url,
         })
-        self.assertEqual(
-            result.return_code,
-            0,
-            "Repository was not updated")
-        self.assertEqual(
-            len(result.stderr), 0, "No error was expected")
+        self.assertEqual(result.return_code, 0)
+        self.assertEqual(len(result.stderr), 0)
 
         # Fetch it again
         result = Repository.info({'id': new_repo['id']})
-        self.assertEqual(
-            result.return_code,
-            0,
-            "Repository was not found")
-        self.assertEqual(
-            len(result.stderr), 0, "No error was expected")
-        self.assertNotEqual(
-            result.stdout['url'],
-            new_repo['url'],
-            "Urls should not match"
-        )
-        self.assertEqual(
-            result.stdout['url'],
-            url,
-            "Urls don't match"
-        )
+        self.assertEqual(result.return_code, 0)
+        self.assertEqual(len(result.stderr), 0)
+        self.assertNotEqual(result.stdout['url'], new_repo['url'])
+        self.assertEqual(result.stdout['url'], url)
 
     @run_only_on('sat')
     @stubbed()
@@ -630,10 +528,7 @@ class TestRepository(CLITestCase):
             result.stdout['checksum-type'],
             repository['checksum-type'],
         )
-        self.assertEqual(
-            result.stdout['checksum-type'],
-            checksum_type,
-        )
+        self.assertEqual(result.stdout['checksum-type'], checksum_type)
 
     @run_only_on('sat')
     @data(
@@ -655,31 +550,19 @@ class TestRepository(CLITestCase):
 
         new_repo = self._make_repository({u'name': name})
         # Assert that name matches data passed
-        self.assertEqual(new_repo['name'], name, "Names don't match")
+        self.assertEqual(new_repo['name'], name)
 
         # Delete it
         result = Repository.delete({u'id': new_repo['id']})
-        self.assertEqual(
-            result.return_code,
-            0,
-            "Repository was not deleted")
-        self.assertEqual(
-            len(result.stderr), 0, "No error was expected")
+        self.assertEqual(result.return_code, 0)
+        self.assertEqual(len(result.stderr), 0)
 
         # Fetch it
         result = Repository.info({
             u'id': new_repo['id'],
         })
-        self.assertNotEqual(
-            result.return_code,
-            0,
-            "Repository should not be found"
-        )
-        self.assertGreater(
-            len(result.stderr),
-            0,
-            "Expected an error here"
-        )
+        self.assertNotEqual(result.return_code, 0)
+        self.assertGreater(len(result.stderr), 0)
 
     def test_upload_content(self):
         """@Test: Create repository and upload content
@@ -703,11 +586,9 @@ class TestRepository(CLITestCase):
             'product-id': new_repo['product']['id'],
             'organization': new_repo['organization'],
         })
-        self.assertEqual(result.return_code, 0,
-                         "return code must be 0, instead got {0}"
-                         ''.format(result.return_code))
-        self.assertEqual(
-            len(result.stderr), 0, "No error was expected")
-        self.assertIn("Successfully uploaded file '{0}'"
-                      ''.format(RPM_TO_UPLOAD),
-                      result.stdout[0]['message'])
+        self.assertEqual(result.return_code, 0)
+        self.assertEqual(len(result.stderr), 0)
+        self.assertIn(
+            "Successfully uploaded file '{0}'".format(RPM_TO_UPLOAD),
+            result.stdout[0]['message']
+        )

--- a/tests/foreman/cli/test_subnet.py
+++ b/tests/foreman/cli/test_subnet.py
@@ -22,7 +22,7 @@ class TestSubnet(CLITestCase):
         gen_string(str_type='latin1'),
         gen_string(str_type='utf8'),
     )
-    def test_positive_create_1(self, test_name):
+    def test_positive_create_1(self, test_data):
         """@Test: Check if Subnet can be created with random names
 
         @Feature: Subnet - Create
@@ -31,20 +31,11 @@ class TestSubnet(CLITestCase):
 
         """
         try:
-            new_subnet = make_subnet({'name': test_name})
+            subnet = make_subnet({'name': test_data})
         except CLIFactoryError as err:
             self.fail(err)
 
-        # Fetch it
-        result = Subnet.info({'id': new_subnet['id']})
-        self.assertEqual(
-            result.return_code,
-            0,
-            "Subnet was not found")
-        self.assertEqual(
-            len(result.stderr), 0, "No error was expected")
-        self.assertEqual(
-            result.stdout['name'], new_subnet['name'], "Names don't match")
+        self.assertEqual(subnet['name'], test_data)
 
     @data(
         [gen_integer(min_value=1, max_value=255),
@@ -146,10 +137,7 @@ class TestSubnet(CLITestCase):
 
         # Fetch total again
         result = Subnet.list()
-        self.assertGreater(
-            len(result.stdout),
-            total_subnet,
-            "Total subnets should have increased")
+        self.assertGreater(len(result.stdout), total_subnet)
 
     @data(
         gen_string(str_type='alpha'),
@@ -166,44 +154,22 @@ class TestSubnet(CLITestCase):
         @Assert: Subnet name is updated
 
         """
-
         try:
             new_subnet = make_subnet()
         except CLIFactoryError as err:
             self.fail(err)
 
-        # Fetch it
-        result = Subnet.info({'id': new_subnet['id']})
-        self.assertEqual(
-            result.return_code,
-            0,
-            "Subnet was not found")
-        self.assertEqual(
-            len(result.stderr), 0, "No error was expected")
-
         # Update the name
-        result = Subnet.update(
-            {'id': new_subnet['id'], 'new-name': test_name})
-        self.assertEqual(
-            result.return_code,
-            0,
-            "Subnet was not updated")
-        self.assertEqual(
-            len(result.stderr), 0, "No error was expected")
+        result = Subnet.update({'id': new_subnet['id'], 'new-name': test_name})
+        self.assertEqual(result.return_code, 0)
+        self.assertEqual(len(result.stderr), 0)
 
         # Fetch it again
         result = Subnet.info({'id': new_subnet['id']})
-        self.assertEqual(
-            result.return_code,
-            0,
-            "Subnet was not found")
-        self.assertEqual(
-            len(result.stderr), 0, "No error was expected")
-        self.assertEqual(
-            result.stdout['name'], test_name, "Names should match")
-        self.assertNotEqual(
-            result.stdout['name'], new_subnet['name'], "Names should not match"
-        )
+        self.assertEqual(result.return_code, 0)
+        self.assertEqual(len(result.stderr), 0)
+        self.assertEqual(result.stdout['name'], test_name)
+        self.assertNotEqual(result.stdout['name'], new_subnet['name'])
 
     def test_positive_update_2(self):
         """@Test: Check if Subnet network and mask can be updated
@@ -355,35 +321,17 @@ class TestSubnet(CLITestCase):
         @Assert: Subnet is deleted
 
         """
-
         try:
-            new_subnet = make_subnet({'name': test_name})
+            subnet = make_subnet({'name': test_name})
         except CLIFactoryError as err:
             self.fail(err)
 
-        # Fetch it
-        result = Subnet.info({'id': new_subnet['id']})
-        self.assertEqual(
-            result.return_code,
-            0,
-            "Subnet was not found")
-        self.assertEqual(
-            len(result.stderr), 0, "No error was expected")
-
         # Delete it
-        result = Subnet.delete({'id': result.stdout['id']})
-        self.assertEqual(
-            result.return_code,
-            0,
-            "Subnet was not deleted")
-        self.assertEqual(
-            len(result.stderr), 0, "No error was expected")
+        result = Subnet.delete({'id': subnet['id']})
+        self.assertEqual(result.return_code, 0)
+        self.assertEqual(len(result.stderr), 0)
 
         # Fetch it again
-        result = Subnet.info({'id': new_subnet['id']})
-        self.assertGreater(
-            result.return_code,
-            0,
-            "Subnet should not be found")
-        self.assertGreater(
-            len(result.stderr), 0, "No error was expected")
+        result = Subnet.info({'id': subnet['id']})
+        self.assertGreater(result.return_code, 0)
+        self.assertGreater(len(result.stderr), 0)

--- a/tests/foreman/cli/test_syncplan.py
+++ b/tests/foreman/cli/test_syncplan.py
@@ -33,24 +33,7 @@ class TestSyncPlan(CLITestCase):
         if not options.get('organization-id', None):
             options[u'organization-id'] = self.org['id']
 
-        new_sync_plan = make_sync_plan(options)
-
-        # Fetch it
-        result = SyncPlan.info(
-            {
-                u'id': new_sync_plan['id']
-            }
-        )
-
-        self.assertEqual(
-            result.return_code,
-            0,
-            "Sync plan was not found")
-        self.assertEqual(
-            len(result.stderr), 0, "No error was expected")
-
-        # Return the sync plan dictionary
-        return new_sync_plan
+        return make_sync_plan(options)
 
     @data(
         {u'name': gen_string('alpha', 15)},

--- a/tests/foreman/cli/test_template.py
+++ b/tests/foreman/cli/test_template.py
@@ -26,24 +26,17 @@ class TestTemplate(CLITestCase):
         @Assert: Template is created
 
         """
-
-        content = gen_string("alpha", 10)
-        name = gen_string("alpha", 10)
+        name = gen_string("alpha")
 
         try:
-            new_obj = make_template(
-                {
-                    'name': name,
-                    'content': content,
-                }
-            )
+            new_obj = make_template({
+                'name': name,
+                'content': gen_string("alpha"),
+            })
         except CLIFactoryError as e:
             self.fail(e)
 
-        result = Template.info({'id': new_obj['id']})
-        self.assertEqual(result.return_code, 0)
-        self.assertEqual(len(result.stderr), 0)
-        self.assertEqual(new_obj['name'], result.stdout['name'])
+        self.assertEqual(new_obj['name'], name)
 
     def test_update_template_1(self):
         """@Test: Check if Template can be updated
@@ -53,27 +46,21 @@ class TestTemplate(CLITestCase):
         @Assert: Template is updated
 
         """
-
-        content = gen_string("alpha", 10)
-        name = gen_string("alpha", 10)
+        name = gen_string("alpha")
 
         try:
-            new_obj = make_template(
-                {
-                    'name': name,
-                    'content': content,
-                }
-            )
+            new_obj = make_template({
+                'name': name,
+                'content': gen_string("alpha"),
+            })
         except CLIFactoryError as e:
             self.fail(e)
 
-        result = Template.info({'id': new_obj['id']})
+        updated_name = gen_string("alpha")
+        result = Template.update({'id': new_obj['id'], 'name': updated_name})
         self.assertEqual(result.return_code, 0)
         self.assertEqual(len(result.stderr), 0)
-        self.assertEqual(new_obj['name'], result.stdout['name'])
 
-        updated_name = gen_string("alpha", 10)
-        Template.update({'id': new_obj['id'], 'name': updated_name})
         result = Template.info({'id': new_obj['id']})
         self.assertEqual(result.return_code, 0)
         self.assertEqual(len(result.stderr), 0)
@@ -90,7 +77,7 @@ class TestTemplate(CLITestCase):
         try:
             new_loc = make_location()
             new_template = make_template({
-                'name': gen_string('alpha', 10),
+                'name': gen_string('alpha'),
                 'location-ids': new_loc['id'],
             })
         except CLIFactoryError as err:
@@ -108,7 +95,7 @@ class TestTemplate(CLITestCase):
         """
         with self.assertRaises(CLIFactoryError):
             make_template({
-                'name': gen_string('alpha', 10),
+                'name': gen_string('alpha'),
                 'locked': 'true',
             })
 
@@ -123,7 +110,7 @@ class TestTemplate(CLITestCase):
         try:
             new_org = make_org()
             new_template = make_template({
-                'name': gen_string('alpha', 10),
+                'name': gen_string('alpha'),
                 'organization-ids': new_org['id'],
             })
         except CLIFactoryError as err:
@@ -140,8 +127,8 @@ class TestTemplate(CLITestCase):
 
         """
 
-        content = gen_string("alpha", 10)
-        name = gen_string("alpha", 10)
+        content = gen_string("alpha")
+        name = gen_string("alpha")
 
         try:
             new_template = make_template({
@@ -176,8 +163,8 @@ class TestTemplate(CLITestCase):
 
         """
 
-        content = gen_string("alpha", 10)
-        name = gen_string("alpha", 10)
+        content = gen_string("alpha")
+        name = gen_string("alpha")
 
         try:
             new_obj = make_template(
@@ -230,23 +217,16 @@ class TestTemplate(CLITestCase):
         @Assert: Template is created with specific content
 
         """
+        content = gen_string('alpha')
+        name = gen_string('alpha')
 
-        content = gen_string("alpha", 10)
-        name = gen_string("alpha", 10)
+        template = make_template({
+            'name': name,
+            'content': content,
+        })
 
-        new_obj = make_template(
-            {
-                'name': name,
-                'content': content,
-            }
-        )
-
-        result = Template.info({'id': new_obj['id']})
-        self.assertEqual(result.return_code, 0)
-        self.assertEqual(len(result.stderr), 0)
-        self.assertEqual(new_obj['name'], result.stdout['name'])
-
-        template_content = Template.dump({'id': new_obj['id']})
+        self.assertEqual(template['name'], name)
+        template_content = Template.dump({'id': template['id']})
         self.assertIn(content, template_content.stdout[0])
 
     @skip_if_bug_open('bugzilla', 1096333)
@@ -260,23 +240,16 @@ class TestTemplate(CLITestCase):
         @BZ: 1096333
 
         """
+        name = gen_string('alpha')
 
-        content = gen_string("alpha", 10)
-        name = gen_string("alpha", 10)
+        new_obj = make_template({
+            'name': name,
+            'content': gen_string('alpha'),
+        })
 
-        new_obj = make_template(
-            {
-                'name': name,
-                'content': content,
-            }
-        )
-
-        result = Template.info({'id': new_obj['id']})
+        result = Template.delete({'id': new_obj['id']})
         self.assertEqual(result.return_code, 0)
         self.assertEqual(len(result.stderr), 0)
-        self.assertEqual(new_obj['name'], result.stdout['name'])
-
-        Template.delete({'id': new_obj['id']})
 
         result = Template.info({'id': new_obj['id']})
         self.assertNotEqual(result.return_code, 0)

--- a/tests/foreman/cli/test_user.py
+++ b/tests/foreman/cli/test_user.py
@@ -103,11 +103,11 @@ class User(CLITestCase):
     # CRUD
 
     @data(
-        {'login': gen_string("latin1", 10)},
-        {'login': gen_string("utf8", 10)},
-        {'login': gen_string("alpha", 10)},
-        {'login': gen_string("alphanumeric", 10)},
-        {'login': gen_string("numeric", 10)},
+        {'login': gen_string("latin1")},
+        {'login': gen_string("utf8")},
+        {'login': gen_string("alpha")},
+        {'login': gen_string("alphanumeric")},
+        {'login': gen_string("numeric")},
         {'login': gen_string("alphanumeric", 100)}
     )
     def test_positive_create_user_1(self, data):
@@ -129,11 +129,11 @@ class User(CLITestCase):
         self.__assert_exists(args)
 
     @data(
-        {'firstname': gen_string("latin1", 10)},
-        {'firstname': gen_string("utf8", 10)},
-        {'firstname': gen_string("alpha", 10)},
-        {'firstname': gen_string("alphanumeric", 10)},
-        {'firstname': gen_string("numeric", 10)},
+        {'firstname': gen_string("latin1")},
+        {'firstname': gen_string("utf8")},
+        {'firstname': gen_string("alpha")},
+        {'firstname': gen_string("alphanumeric")},
+        {'firstname': gen_string("numeric")},
         {'firstname': gen_string("alphanumeric", 50)}
     )
     def test_positive_create_user_2(self, data):
@@ -155,11 +155,11 @@ class User(CLITestCase):
         self.__assert_exists(args)
 
     @data(
-        {'lastname': gen_string("latin1", 10)},
-        {'lastname': gen_string("utf8", 10)},
-        {'lastname': gen_string("alpha", 10)},
-        {'lastname': gen_string("alphanumeric", 10)},
-        {'lastname': gen_string("numeric", 10)},
+        {'lastname': gen_string("latin1")},
+        {'lastname': gen_string("utf8")},
+        {'lastname': gen_string("alpha")},
+        {'lastname': gen_string("alphanumeric")},
+        {'lastname': gen_string("numeric")},
         {'lastname': gen_string("alphanumeric", 50)}
     )
     def test_positive_create_user_3(self, data):
@@ -181,11 +181,11 @@ class User(CLITestCase):
         self.__assert_exists(args)
 
     @data(
-        u'{0}@example.com'.format(gen_string("latin1", 10)),
-        u'{0}@example.com'.format(gen_string("utf8", 10)),
-        u'{0}@example.com'.format(gen_string("alpha", 10)),
-        u'{0}@example.com'.format(gen_string("alphanumeric", 10)),
-        u'{0}@example.com'.format(gen_string("numeric", 10)),
+        u'{0}@example.com'.format(gen_string("latin1")),
+        u'{0}@example.com'.format(gen_string("utf8")),
+        u'{0}@example.com'.format(gen_string("alpha")),
+        u'{0}@example.com'.format(gen_string("alphanumeric")),
+        u'{0}@example.com'.format(gen_string("numeric")),
         u'{0}@example.com'.format(gen_string("alphanumeric", 48)),
         u'{0}+{1}@example.com'.format(gen_alphanumeric(), gen_alphanumeric()),
         u'{0}.{1}@example.com'.format(gen_alphanumeric(), gen_alphanumeric()),
@@ -209,11 +209,11 @@ class User(CLITestCase):
             self.fail(err)
         self.__assert_exists(args)
 
-    @data({'password': gen_string("latin1", 10)},
-          {'password': gen_string("utf8", 10)},
-          {'password': gen_string("alpha", 10)},
-          {'password': gen_string("alphanumeric", 10)},
-          {'password': gen_string("numeric", 10)},
+    @data({'password': gen_string("latin1")},
+          {'password': gen_string("utf8")},
+          {'password': gen_string("alpha")},
+          {'password': gen_string("alphanumeric")},
+          {'password': gen_string("numeric")},
           {'password': gen_string("alphanumeric", 3000)})
     def test_positive_create_user_5(self, data):
         """@Test: Create User for all variations of Password
@@ -560,9 +560,9 @@ class User(CLITestCase):
         pass
 
     @data({'login': ''},
-          {'login': 'space {0}'.format(gen_string('alpha', 10))},
+          {'login': 'space {0}'.format(gen_string('alpha'))},
           {'login': gen_string('alpha', 101)},
-          {'login': gen_string('html', 10)})
+          {'login': gen_string('html')})
     def test_negative_create_user_1(self, opts):
         """@Test: Create User with invalid Username
 
@@ -578,7 +578,7 @@ class User(CLITestCase):
         options = {
             'login': opts['login'],
             'mail': "root@localhost",
-            'password': gen_string("alpha", 10),
+            'password': gen_string("alpha"),
             'auth-source-id': 1
         }
         self.logger.debug(str(options))
@@ -587,7 +587,7 @@ class User(CLITestCase):
         self.assertTrue(result.stderr)
 
     @data({'firstname': gen_string("alpha", 51)},
-          {'firstname': gen_string("html", 10)})
+          {'firstname': gen_string("html")})
     def test_negative_create_user_2(self, opts):
         """@Test: Create User with invalid Firstname
 
@@ -601,10 +601,10 @@ class User(CLITestCase):
 
         """
         options = {
-            'login': gen_string("alpha", 10),
+            'login': gen_string("alpha"),
             'firstname': opts['firstname'],
             'mail': "root@localhost",
-            'password': gen_string("alpha", 10),
+            'password': gen_string("alpha"),
             'auth-source-id': 1
         }
         result = UserObj().create(options)
@@ -612,7 +612,7 @@ class User(CLITestCase):
         self.assertTrue(result.stderr)
 
     @data({'lastname': gen_string("alpha", 51)},
-          {'lastname': gen_string("html", 10)})
+          {'lastname': gen_string("html")})
     def test_negative_create_user_3(self, opts):
         """@Test: Create User with invalid Surname
 
@@ -626,10 +626,10 @@ class User(CLITestCase):
 
         """
         options = {
-            'login': gen_string("alpha", 10),
+            'login': gen_string("alpha"),
             'lastname': opts['lastname'],
             'mail': "root@localhost",
-            'password': gen_string("alpha", 10),
+            'password': gen_string("alpha"),
             'auth-source-id': 1
         }
         result = UserObj().create(options)
@@ -645,7 +645,7 @@ class User(CLITestCase):
         'email@brazil.b',
         '{0}@example.com'.format(
             gen_string('alpha', 49)),  # total length 61
-        '{0}@example.com'.format(gen_string('html', 10)),
+        '{0}@example.com'.format(gen_string('html')),
         's p a c e s@example.com',
         'dot..dot@example.com'
     )
@@ -662,11 +662,11 @@ class User(CLITestCase):
 
         """
         options = {
-            'login': gen_string("alpha", 10),
-            'firstname': gen_string("alpha", 10),
-            'lastname': gen_string("alpha", 10),
+            'login': gen_string("alpha"),
+            'firstname': gen_string("alpha"),
+            'lastname': gen_string("alpha"),
             'mail': email,
-            'password': gen_string("alpha", 10),
+            'password': gen_string("alpha"),
             'auth-source-id': 1
         }
         result = UserObj().create(options)
@@ -689,11 +689,11 @@ class User(CLITestCase):
 
         """
         options = {
-            'login': gen_string("alpha", 10),
-            'firstname': gen_string("alpha", 10),
-            'lastname': gen_string("alpha", 10),
+            'login': gen_string("alpha"),
+            'firstname': gen_string("alpha"),
+            'lastname': gen_string("alpha"),
             'mail': '',
-            'password': gen_string("alpha", 10),
+            'password': gen_string("alpha"),
             'auth-source-id': 1
         }
         result = UserObj().create(options)
@@ -714,7 +714,7 @@ class User(CLITestCase):
 
         """
         options = {
-            'login': gen_string("alpha", 10),
+            'login': gen_string("alpha"),
             'mail': "root@localhost",
             'auth-source-id': ''
         }
@@ -736,9 +736,9 @@ class User(CLITestCase):
 
         """
         options = {
-            'login': gen_string("alpha", 10),
+            'login': gen_string("alpha"),
             'mail': "root@localhost",
-            'password': gen_string("alpha", 10),
+            'password': gen_string("alpha"),
             'auth-source-id': ''
         }
         result = UserObj().create(options)
@@ -746,11 +746,11 @@ class User(CLITestCase):
         self.assertTrue(result.stderr)
 
     @data(
-        {'firstname': gen_string("latin1", 10)},
-        {'firstname': gen_string("utf8", 10)},
-        {'firstname': gen_string("alpha", 10)},
-        {'firstname': gen_string("alphanumeric", 10)},
-        {'firstname': gen_string("numeric", 10)},
+        {'firstname': gen_string("latin1")},
+        {'firstname': gen_string("utf8")},
+        {'firstname': gen_string("alpha")},
+        {'firstname': gen_string("alphanumeric")},
+        {'firstname': gen_string("numeric")},
     )
     def test_positive_update_user_1(self, test_data):
         """@Test: Update Username in User
@@ -768,18 +768,14 @@ class User(CLITestCase):
             new_obj = make_user()
         except CLIFactoryError as err:
             self.fail(err)
-        # Can we find the new object?
-        result = UserObj().info({'id': new_obj['id']})
-        self.assertEqual(result.return_code, 0)
-        self.assertEqual(len(result.stderr), 0)
-        self.assertEqual(new_obj['name'], result.stdout['name'])
 
         # Update the user name
-        result = UserObj().update({'id': new_obj['id'],
-                                   'firstname': test_data['firstname']})
+        result = UserObj().update({
+            'id': new_obj['id'],
+            'firstname': test_data['firstname'],
+        })
         self.assertEqual(result.return_code, 0)
-        self.assertEqual(
-            len(result.stderr), 0, "There should not be an error here")
+        self.assertEqual(len(result.stderr), 0)
 
         # Fetch the user again
         result = UserObj().info({'id': new_obj['id']})
@@ -793,11 +789,11 @@ class User(CLITestCase):
         )
 
     @data(
-        {'login': gen_string("latin1", 10)},
-        {'login': gen_string("utf8", 10)},
-        {'login': gen_string("alpha", 10)},
-        {'login': gen_string("alphanumeric", 10)},
-        {'login': gen_string("numeric", 10)},
+        {'login': gen_string("latin1")},
+        {'login': gen_string("utf8")},
+        {'login': gen_string("alpha")},
+        {'login': gen_string("alphanumeric")},
+        {'login': gen_string("numeric")},
         {'login': gen_string("alphanumeric", 100)}
     )
     def test_positive_update_user_2(self, test_data):
@@ -816,18 +812,14 @@ class User(CLITestCase):
             new_obj = make_user()
         except CLIFactoryError as err:
             self.fail(err)
-        # Can we find the new object?
-        result = UserObj().info({'id': new_obj['id']})
-        self.assertEqual(result.return_code, 0)
-        self.assertEqual(len(result.stderr), 0)
-        self.assertEqual(new_obj['login'], result.stdout['login'])
 
         # Update the user login
-        result = UserObj().update({'id': new_obj['id'],
-                                   'login': test_data['login']})
+        result = UserObj().update({
+            'id': new_obj['id'],
+            'login': test_data['login'],
+        })
         self.assertEqual(result.return_code, 0)
-        self.assertEqual(
-            len(result.stderr), 0, "There should not be an error here")
+        self.assertEqual(len(result.stderr), 0)
 
         # Fetch the user again
         result = UserObj().info({'id': new_obj['id']})
@@ -840,11 +832,11 @@ class User(CLITestCase):
         )
 
     @data(
-        {'lastname': gen_string("latin1", 10)},
-        {'lastname': gen_string("utf8", 10)},
-        {'lastname': gen_string("alpha", 10)},
-        {'lastname': gen_string("alphanumeric", 10)},
-        {'lastname': gen_string("numeric", 10)},
+        {'lastname': gen_string("latin1")},
+        {'lastname': gen_string("utf8")},
+        {'lastname': gen_string("alpha")},
+        {'lastname': gen_string("alphanumeric")},
+        {'lastname': gen_string("numeric")},
     )
     def test_positive_update_user_3(self, test_data):
         """@Test: Update Surname in User
@@ -862,18 +854,14 @@ class User(CLITestCase):
             new_obj = make_user()
         except CLIFactoryError as err:
             self.fail(err)
-        # Can we find the new object?
-        result = UserObj().info({'id': new_obj['id']})
-        self.assertEqual(result.return_code, 0)
-        self.assertEqual(len(result.stderr), 0)
-        self.assertEqual(new_obj['name'], result.stdout['name'])
 
         # Update the last name
-        result = UserObj().update({'id': new_obj['id'],
-                                   'lastname': test_data['lastname']})
+        result = UserObj().update({
+            'id': new_obj['id'],
+            'lastname': test_data['lastname'],
+        })
         self.assertEqual(result.return_code, 0)
-        self.assertEqual(
-            len(result.stderr), 0, "There should not be an error here")
+        self.assertEqual(len(result.stderr), 0)
 
         # Fetch the user again
         result = UserObj().info({'id': new_obj['id']})
@@ -889,9 +877,9 @@ class User(CLITestCase):
         )
 
     @data(
-        gen_string("alpha", 10),
-        gen_string("alphanumeric", 10),
-        gen_string("numeric", 10),
+        gen_string("alpha"),
+        gen_string("alphanumeric"),
+        gen_string("numeric"),
         '{0}+{1}'.format(gen_alphanumeric(), gen_alphanumeric()),
         '{0}.{1}'.format(gen_alphanumeric(), gen_alphanumeric()),
         r"!#$%&*+-/=?^`{|}~",
@@ -912,12 +900,6 @@ class User(CLITestCase):
             new_obj = make_user()
         except CLIFactoryError as err:
             self.fail(err)
-        # Can we find the new object?
-        result = UserObj().info({'id': new_obj['id']})
-        self.assertEqual(result.return_code, 0)
-        self.assertEqual(len(result.stderr), 0)
-        self.assertEqual(new_obj['name'], result.stdout['name'])
-        self.assertEqual(result.stdout['email'], new_obj['email'])
 
         # Update the mail
         email = '{0}@example.com'.format(test_data)
@@ -927,8 +909,7 @@ class User(CLITestCase):
             'mail': email.replace('`', r'\`'),
         })
         self.assertEqual(result.return_code, 0)
-        self.assertEqual(
-            len(result.stderr), 0, "There should not be an error here")
+        self.assertEqual(len(result.stderr), 0)
 
         # Fetch the user again
         result = UserObj().info({'id': new_obj['id']})
@@ -1349,7 +1330,7 @@ class User(CLITestCase):
         pass
 
     @data({'firstname': gen_string("alpha", 51)},
-          {'firstname': gen_string("html", 10)})
+          {'firstname': gen_string("html")})
     def test_negative_update_user_2(self, opts):
         """@Test: Update invalid Firstname in an User
 
@@ -1376,7 +1357,7 @@ class User(CLITestCase):
         self.assertEqual(updated_user.stdout['name'], new_user['name'])
 
     @data({'lastname': gen_string("alpha", 51)},
-          {'lastname': gen_string("html", 10)})
+          {'lastname': gen_string("html")})
     def test_negative_update_user_3(self, opts):
         """@Test: Update invalid Surname in an User
 
@@ -1411,7 +1392,7 @@ class User(CLITestCase):
         '{0}@example.com'.format(gen_string(
             'alpha', 49)),  # total length 61
         '',
-        '{0}@example.com'.format(gen_string('html', 10)),
+        '{0}@example.com'.format(gen_string('html')),
         's p a c e s@example.com',
         'dot..dot@example.com'
     )
@@ -1440,12 +1421,12 @@ class User(CLITestCase):
         self.assertEqual(updated_user.stdout['email'], new_user['email'])
 
     @data(
-        {'login': gen_string("latin1", 10)},
-        {'login': gen_string("utf8", 10)},
-        {'login': gen_string("alpha", 10)},
-        {'login': gen_string("alphanumeric", 10)},
-        {'login': gen_string("numeric", 10)},
-        {'login': gen_string("alphanumeric", 10)}
+        {'login': gen_string("latin1")},
+        {'login': gen_string("utf8")},
+        {'login': gen_string("alpha")},
+        {'login': gen_string("alphanumeric")},
+        {'login': gen_string("numeric")},
+        {'login': gen_string("alphanumeric")}
     )
     def test_positive_delete_user_1(self, test_data):
         """@Test: Delete a user
@@ -1473,12 +1454,12 @@ class User(CLITestCase):
         self.assertGreater(len(result.stderr), 0)
 
     @data(
-        {'login': gen_string("latin1", 10)},
-        {'login': gen_string("utf8", 10)},
-        {'login': gen_string("alpha", 10)},
-        {'login': gen_string("alphanumeric", 10)},
-        {'login': gen_string("numeric", 10)},
-        {'login': gen_string("alphanumeric", 10)}
+        {'login': gen_string("latin1")},
+        {'login': gen_string("utf8")},
+        {'login': gen_string("alpha")},
+        {'login': gen_string("alphanumeric")},
+        {'login': gen_string("numeric")},
+        {'login': gen_string("alphanumeric")}
     )
     def test_positive_delete_user_2(self, test_data):
         """@Test: Delete an admin user
@@ -1536,11 +1517,11 @@ class User(CLITestCase):
         self.assertTrue(result.stdout)
 
     @data(
-        {'login': gen_string("alpha", 10)},
-        {'login': gen_string("alphanumeric", 10)},
-        {'login': gen_string("numeric", 10)},
-        {'login': gen_string("latin1", 10)},
-        {'login': gen_string("utf8", 10)},
+        {'login': gen_string("alpha")},
+        {'login': gen_string("alphanumeric")},
+        {'login': gen_string("numeric")},
+        {'login': gen_string("latin1")},
+        {'login': gen_string("utf8")},
         {'login': gen_string("alphanumeric", 100)}
     )
     def test_list_user_1(self, test_data):
@@ -1574,11 +1555,11 @@ class User(CLITestCase):
             'email': user['email']}, result.stdout[0])
 
     @data(
-        {'firstname': gen_string("latin1", 10)},
-        {'firstname': gen_string("utf8", 10)},
-        {'firstname': gen_string("alpha", 10)},
-        {'firstname': gen_string("alphanumeric", 10)},
-        {'firstname': gen_string("numeric", 10)},
+        {'firstname': gen_string("latin1")},
+        {'firstname': gen_string("utf8")},
+        {'firstname': gen_string("alpha")},
+        {'firstname': gen_string("alphanumeric")},
+        {'firstname': gen_string("numeric")},
         {'firstname': gen_string("alphanumeric", 50)}
     )
     def test_list_user_2(self, test_data):
@@ -1611,11 +1592,11 @@ class User(CLITestCase):
             'email': user['email']} in result.stdout)
 
     @data(
-        {'lastname': gen_string("latin1", 10)},
-        {'lastname': gen_string("utf8", 10)},
-        {'lastname': gen_string("alpha", 10)},
-        {'lastname': gen_string("alphanumeric", 10)},
-        {'lastname': gen_string("numeric", 10)},
+        {'lastname': gen_string("latin1")},
+        {'lastname': gen_string("utf8")},
+        {'lastname': gen_string("alpha")},
+        {'lastname': gen_string("alphanumeric")},
+        {'lastname': gen_string("numeric")},
         {'lastname': gen_string("alphanumeric", 50)}
     )
     def test_list_user_3(self, test_data):
@@ -1648,10 +1629,10 @@ class User(CLITestCase):
             'email': user['email']} in result.stdout)
 
     @data(
-        {'mail': gen_string("alpha", 10) + "@somemail.com"},
+        {'mail': gen_string("alpha") + "@somemail.com"},
         {'mail': gen_string(
             "alphanumeric", 10) + "@somemail.com"},
-        {'mail': gen_string("numeric", 10) + "@somemail.com"},
+        {'mail': gen_string("numeric") + "@somemail.com"},
         {'mail': gen_string(
             "alphanumeric", 50) + "@somem.com"}
     )
@@ -1686,8 +1667,8 @@ class User(CLITestCase):
 
     @skip_if_bug_open('bugzilla', 1204667)
     @data(
-        {'mail': gen_string("latin1", 10) + "@somemail.com"},
-        {'mail': gen_string("utf8", 10) + "@somemail.com"}
+        {'mail': gen_string("latin1") + "@somemail.com"},
+        {'mail': gen_string("utf8") + "@somemail.com"}
     )
     def test_bugzilla_1204667(self, test_data):
         """@Test: List User for utf-8,latin variations of Email Address
@@ -1971,11 +1952,11 @@ class User(CLITestCase):
             self.assertNotEqual(str(result.stdout).find(user['login']), -1)
 
     @data(
-        {'name': gen_string("latin1", 10)},
-        {'name': gen_string("utf8", 10)},
-        {'name': gen_string("alpha", 10)},
-        {'name': gen_string("alphanumeric", 10)},
-        {'name': gen_string("numeric", 10)},
+        {'name': gen_string("latin1")},
+        {'name': gen_string("utf8")},
+        {'name': gen_string("alpha")},
+        {'name': gen_string("alphanumeric")},
+        {'name': gen_string("numeric")},
         {'name': gen_string("alphanumeric", 100)},
     )
     def test_user_add_role_1(self, data):
@@ -2009,11 +1990,11 @@ class User(CLITestCase):
         self.assertIn(role['name'], result.stdout['roles'])
 
     @data(
-        {'name': gen_string("latin1", 10)},
-        {'name': gen_string("utf8", 10)},
-        {'name': gen_string("alpha", 10)},
-        {'name': gen_string("alphanumeric", 10)},
-        {'name': gen_string("numeric", 10)},
+        {'name': gen_string("latin1")},
+        {'name': gen_string("utf8")},
+        {'name': gen_string("alpha")},
+        {'name': gen_string("alphanumeric")},
+        {'name': gen_string("numeric")},
         {'name': gen_string("alphanumeric", 100)},
     )
     def test_user_remove_role_1(self, data):


### PR DESCRIPTION
CLI create already run info command after creating the entity, because
this is not necessary to run info again.

Closes #870