### PR TITLE
Fixed UI test failures

### DIFF
--- a/robottelo/ui/locators.py
+++ b/robottelo/ui/locators.py
@@ -1050,9 +1050,7 @@ locators = LocatorDict({
     "repo.via_http": (By.ID, "unprotected"),
     "repo.search": (By.XPATH, "//input[@ng-model='repositorySearch']"),
     "repo.remove": (
-        By.XPATH,
-        ("//script[contains(@bst-modal,'removeRepository(repository)')]"
-         "/../button[contains(@ng-show, 'repository')]")),
+        By.XPATH, "//button[contains(@ng-show, 'canRemove')]"),
     "repo.sync_now": (
         By.XPATH, "//button[contains(@ng-click, 'syncSelectedRepositories')]"),
     "repo.select_checkbox": (
@@ -1120,7 +1118,7 @@ locators = LocatorDict({
                    "/div/span[contains(@class,'editable-value')]")),
     "repo.fetch_gpgkey": (
         By.XPATH, ("//form[@selector='repository.gpg_key_id']"
-                   "/div[@class='bst-edit']/div/span")),
+                   "/div[@class='bst-edit']/div/span[2]")),
     "repo.fetch_checksum": (
         By.XPATH, ("//form[@selector='repository.checksum_type']"
                    "/div/div/span[contains(@class,'value')]")),

--- a/tests/foreman/ui/test_config_groups.py
+++ b/tests/foreman/ui/test_config_groups.py
@@ -93,7 +93,7 @@ class ConfigGroups(UITestCase):
           {'name': gen_string('latin1', 20),
            'new_name': gen_string('latin1', 10)})
     def test_update_positive_1(self, testdata):
-        """@Test: Create new config-group
+        """@Test: Update selected config-group
 
         @Feature: Config-Groups - Positive Update
 
@@ -112,7 +112,7 @@ class ConfigGroups(UITestCase):
 
     @data(*generate_strings_list(len1=8))
     def test_delete_positive_1(self, name):
-        """@Test: Create new config-groups
+        """@Test: Delete selected config-groups
 
         @Feature: Config-Groups - Positive delete
 
@@ -126,6 +126,4 @@ class ConfigGroups(UITestCase):
             self.assertIsNotNone(search)
             self.configgroups.delete(
                 name, True, drop_locator=locators["config_groups.dropdown"])
-            self.assertIsNotNone(session.nav.wait_until_element
-                                 (common_locators["notif.success"]))
             self.assertIsNone(self.configgroups.search(name))

--- a/tests/foreman/ui/test_environment.py
+++ b/tests/foreman/ui/test_environment.py
@@ -130,6 +130,4 @@ class Environment(UITestCase):
         with Session(self.browser) as session:
             make_env(session, name=name)
             self.environment.delete(name, really=True)
-            notif = session.nav.wait_until_element(
-                common_locators["notif.success"])
-            self.assertTrue(notif)
+            self.assertIsNone(self.environment.search(name))

--- a/tests/foreman/ui/test_operatingsys.py
+++ b/tests/foreman/ui/test_operatingsys.py
@@ -395,12 +395,14 @@ class OperatingSys(UITestCase):
         """
         os_name = gen_string("alpha", 4)
         template_name = gen_string("alpha", 4)
-        os_attrs = entities.OperatingSystem(name=os_name).create()
+        os_attrs = entities.OperatingSystem(name=os_name).create_json()
         entities.ConfigTemplate(
             name=template_name,
-            operatingsystem=[os_attrs['id']]
-        ).create()
-        with Session(self.browser):
+            operatingsystem=[os_attrs['id']],
+            organization=[self.org_id],
+        ).create_json()
+        with Session(self.browser) as session:
+            session.nav.go_to_select_org(self.org_name)
             self.operatingsys.update(os_name, template=template_name)
             result_obj = self.operatingsys.get_os_entities(os_name, "template")
             self.assertEqual(template_name, result_obj['template'])

--- a/tests/foreman/ui/test_usergroup.py
+++ b/tests/foreman/ui/test_usergroup.py
@@ -18,8 +18,8 @@ class UserGroup(UITestCase):
 
     @classmethod
     def setUpClass(cls):  # noqa
-        cls.org_name = entities.Organization().create()
-
+        org_attrs = entities.Organization().create_json()
+        cls.org_name = org_attrs['name']
         super(UserGroup, cls).setUpClass()
 
     @skip_if_bug_open('bugzilla', 1142588)


### PR DESCRIPTION
- Fixed `test_remove_env` by asserting the removed entity via search instead of success notification
- Fixed `test_remove_repo by updating locator for 'Remove_repository' button
- Fixed `test_delete_positive_1` config group test
- Fixed `test_positive_upate_2` by updating locator for `repo.fetch_gpgkey`
- Fixed `test_negative_create_usergroup_{2,3}` by updating `setUpClass`
- Fixed `test_update_os_template` by updating org association with config template