### PR TITLE
Use create_json instead of create

### DIFF
--- a/tests/foreman/api/test_activationkey.py
+++ b/tests/foreman/api/test_activationkey.py
@@ -26,7 +26,7 @@ class ActivationKeysTestCase(APITestCase):
 
         """
         try:
-            attrs = entities.ActivationKey().create()
+            attrs = entities.ActivationKey().create_json()
         except HTTPError as err:
             self.fail(err)
         self.assertTrue(attrs['unlimited_content_hosts'])
@@ -47,7 +47,7 @@ class ActivationKeysTestCase(APITestCase):
             attrs = entities.ActivationKey(
                 unlimited_content_hosts=False,
                 max_content_hosts=max_content_hosts,
-            ).create()
+            ).create_json()
         except HTTPError as err:
             self.fail(err)
         # Assert that it defaults to limited content host...
@@ -79,7 +79,7 @@ class ActivationKeysTestCase(APITestCase):
 
         """
         try:
-            attrs = entities.ActivationKey(name=name).create()
+            attrs = entities.ActivationKey(name=name).create_json()
         except HTTPError as err:
             self.fail(err)
 
@@ -109,7 +109,7 @@ class ActivationKeysTestCase(APITestCase):
         try:
             entity_id = entities.ActivationKey(
                 description=description
-            ).create()['id']
+            ).create_json()['id']
         except HTTPError as err:
             self.fail(err)
 
@@ -127,7 +127,7 @@ class ActivationKeysTestCase(APITestCase):
 
         """
         with self.assertRaises(HTTPError):
-            entities.ActivationKey(unlimited_content_hosts=False).create()
+            entities.ActivationKey(unlimited_content_hosts=False).create_json()
 
     @data(
         gen_string(str_type='alpha'),
@@ -147,7 +147,7 @@ class ActivationKeysTestCase(APITestCase):
             entities.ActivationKey(
                 unlimited_content_hosts=False,
                 max_content_hosts=max_content_hosts
-            ).create()
+            ).create_json()
 
     @skip_if_bug_open('bugzilla', 1156555)
     @data(
@@ -168,7 +168,7 @@ class ActivationKeysTestCase(APITestCase):
             entities.ActivationKey(
                 unlimited_content_hosts=True,
                 max_content_hosts=max_content_hosts
-            ).create()
+            ).create_json()
 
     @data(
         gen_integer(min_value=1, max_value=30),
@@ -186,7 +186,7 @@ class ActivationKeysTestCase(APITestCase):
         # Create an activation key.
         try:
             activation_key = entities.ActivationKey(
-                id=entities.ActivationKey().create()['id']
+                id=entities.ActivationKey().create_json()['id']
             )
         except HTTPError as err:
             self.fail(err)
@@ -229,7 +229,7 @@ class ActivationKeysTestCase(APITestCase):
 
         """
         try:
-            attrs = entities.ActivationKey().create()
+            attrs = entities.ActivationKey().create_json()
         except HTTPError as err:
             self.fail(err)
         activationkey = entities.ActivationKey(id=attrs['id'])
@@ -269,7 +269,7 @@ class ActivationKeysTestCase(APITestCase):
         @Assert: The update fails with an HTTP 422 return code.
 
         """
-        attrs = entities.ActivationKey(max_content_hosts=1).create()
+        attrs = entities.ActivationKey(max_content_hosts=1).create_json()
         path = entities.ActivationKey(id=attrs['id']).path()
         new_attrs = attrs.copy()
         new_attrs['max_content_hosts'] = 'foo'
@@ -298,7 +298,7 @@ class ActivationKeysTestCase(APITestCase):
 
         """
         try:
-            attrs = entities.ActivationKey().create()
+            attrs = entities.ActivationKey().create_json()
         except HTTPError as err:
             self.fail(err)
         path = entities.ActivationKey(id=attrs['id']).path(which='releases')
@@ -324,7 +324,7 @@ class ActivationKeysTestCase(APITestCase):
 
         """
         try:
-            attrs = entities.ActivationKey().create()
+            attrs = entities.ActivationKey().create_json()
         except HTTPError as err:
             self.fail(err)
         response = client.get(
@@ -350,14 +350,16 @@ class ActivationKeysTestCase(APITestCase):
         """
         # Let's create an organization and re-use it in several places. Doing
         # so will speed up this test.
-        org = entities.Organization().create()
+        org = entities.Organization().create_json()
 
         # By default, an activation key should have no host collections.
-        act_key = entities.ActivationKey(organization=org['id']).create()
+        act_key = entities.ActivationKey(organization=org['id']).create_json()
         self.assertEqual(act_key['host_collections'], [])
 
         # Associate our activation key with one host collection.
-        host_coll_1 = entities.HostCollection(organization=org['id']).create()
+        host_coll_1 = entities.HostCollection(
+            organization=org['id']
+        ).create_json()
         client.put(
             entities.ActivationKey(id=act_key['id']).path(),
             verify=False,
@@ -374,7 +376,9 @@ class ActivationKeysTestCase(APITestCase):
         )
 
         # Associate our activation key with two host collections.
-        host_coll_2 = entities.HostCollection(organization=org['id']).create()
+        host_coll_2 = entities.HostCollection(
+            organization=org['id']
+        ).create_json()
         client.put(
             entities.ActivationKey(id=act_key['id']).path(),
             verify=False,

--- a/tests/foreman/api/test_architecture.py
+++ b/tests/foreman/api/test_architecture.py
@@ -22,7 +22,7 @@ class ArchitectureTestCase(APITestCase):
 
         """
         name = gen_utf8()
-        os_id = entities.OperatingSystem().create()['id']
+        os_id = entities.OperatingSystem().create_json()['id']
         response = client.post(
             entities.Architecture().path(),
             {u'name': name, u'operatingsystem_ids': [os_id]},
@@ -49,7 +49,7 @@ class ArchitectureTestCase(APITestCase):
 
         """
         # Create an architecture and an OS.
-        os_id = entities.OperatingSystem().create()['id']
+        os_id = entities.OperatingSystem().create_json()['id']
         arch_id = entities.Architecture(
             operatingsystem=[os_id]
         ).create_json()['id']

--- a/tests/foreman/api/test_contentview.py
+++ b/tests/foreman/api/test_contentview.py
@@ -36,11 +36,11 @@ class ContentViewTestCase(APITestCase):
         # ├── lifecycle environment
         # └── content view
         org = entities.Organization()
-        org.id = org.create()['id']
+        org.id = org.create_json()['id']
         lifecycle_env = entities.LifecycleEnvironment(organization=org.id)
-        lifecycle_env.id = lifecycle_env.create()['id']
+        lifecycle_env.id = lifecycle_env.create_json()['id']
         content_view = entities.ContentView(organization=org.id)
-        content_view.id = content_view.create()['id']
+        content_view.id = content_view.create_json()['id']
 
         # Publish the content view.
         content_view.publish()
@@ -69,7 +69,7 @@ class ContentViewTestCase(APITestCase):
             content_view=content_view.id,
             environment=lifecycle_env.id,
             organization=org.id,
-        ).create()
+        ).create_json()
 
         # See BZ #1151240
         self.assertEqual(system_attrs['content_view_id'], content_view.id)
@@ -88,11 +88,11 @@ class ContentViewTestCase(APITestCase):
 
         """
         org = entities.Organization()
-        org.id = org.create()['id']
+        org.id = org.create_json()['id']
         lifecycle_env = entities.LifecycleEnvironment(organization=org.id)
-        lifecycle_env.id = lifecycle_env.create()['id']
+        lifecycle_env.id = lifecycle_env.create_json()['id']
         content_view = entities.ContentView(organization=org.id)
-        content_view.id = content_view.create()['id']
+        content_view.id = content_view.create_json()['id']
 
         content_view.publish()
         entities.ContentViewVersion(
@@ -119,13 +119,13 @@ class ContentViewTestCase(APITestCase):
 
         """
         org = entities.Organization()
-        org.id = org.create()['id']
+        org.id = org.create_json()['id']
         lifecycle_env = entities.LifecycleEnvironment(organization=org.id)
-        lifecycle_env.id = lifecycle_env.create()['id']
+        lifecycle_env.id = lifecycle_env.create_json()['id']
         le_clone = entities.LifecycleEnvironment(organization=org.id)
-        le_clone.id = le_clone.create()['id']
+        le_clone.id = le_clone.create_json()['id']
         content_view = entities.ContentView(organization=org.id)
-        content_view.id = content_view.create()['id']
+        content_view.id = content_view.create_json()['id']
 
         content_view.publish()
         entities.ContentViewVersion(
@@ -154,7 +154,7 @@ class ContentViewCreateTestCase(APITestCase):
 
         """
         content_view = entities.ContentView(
-            id=entities.ContentView(composite=False).create()['id']
+            id=entities.ContentView(composite=False).create_json()['id']
         )
         self.assertFalse(content_view.read_json()['composite'])
 
@@ -167,7 +167,7 @@ class ContentViewCreateTestCase(APITestCase):
 
         """
         content_view = entities.ContentView(
-            id=entities.ContentView(composite=True).create()['id']
+            id=entities.ContentView(composite=True).create_json()['id']
         )
         self.assertTrue(content_view.read_json()['composite'])
 
@@ -190,7 +190,7 @@ class ContentViewCreateTestCase(APITestCase):
         """
         content_view = entities.ContentView(
             name=name
-        ).create()['id']
+        ).create_json()['id']
         attrs = entities.ContentView(id=content_view).read_json()
         self.assertEqual(attrs['name'], name)
 
@@ -213,7 +213,7 @@ class ContentViewCreateTestCase(APITestCase):
         """
         content_view = entities.ContentView(
             description=description
-        ).create()['id']
+        ).create_json()['id']
         attrs = entities.ContentView(id=content_view).read_json()
         self.assertEqual(attrs['description'], description)
 
@@ -437,7 +437,7 @@ class ContentViewUpdateTestCase(APITestCase):
     def setUpClass(cls):  # noqa
         """Create a content view."""
         cls.content_view = entities.ContentView(
-            id=entities.ContentView().create()['id']
+            id=entities.ContentView().create_json()['id']
         )
 
     @data(

--- a/tests/foreman/api/test_contentviewversion.py
+++ b/tests/foreman/api/test_contentviewversion.py
@@ -16,7 +16,7 @@ class CVVersionTestCase(APITestCase):
         @Feature: ContentViewVersion
 
         """
-        env_id = entities.Environment().create()['id']
+        env_id = entities.Environment().create_json()['id']
         with self.assertRaises(HTTPError):
             entities.ContentViewVersion(id=1).promote(env_id)
 

--- a/tests/foreman/api/test_environment.py
+++ b/tests/foreman/api/test_environment.py
@@ -33,7 +33,7 @@ class EnvironmentTestCase(APITestCase):
 
         """
         # Create an environment and validate the returned data.
-        attrs = entities.Environment(name=name).create()
+        attrs = entities.Environment(name=name).create_json()
         self.assertEqual(attrs['name'], name)
 
         # Let's double-check by reading the environment.
@@ -63,4 +63,4 @@ class EnvironmentTestCase(APITestCase):
 
         """
         with self.assertRaises(HTTPError):
-            entities.Environment(name=name).create()
+            entities.Environment(name=name).create_json()

--- a/tests/foreman/api/test_filter.py
+++ b/tests/foreman/api/test_filter.py
@@ -29,7 +29,7 @@ class FilterTestCase(APITestCase):
                 for permission
                 in ct_perms
             ]
-        ).create()['id']
+        ).create_json()['id']
 
         # Find all permissions assigned to filter `filter_id`.
         filter_perms = entities.Filter(id=filter_id).read_json()['permissions']
@@ -49,7 +49,7 @@ class FilterTestCase(APITestCase):
                 for permission
                 in entities.Permission(resource_type='ConfigTemplate').search()
             ],
-        ).create()['id'])
+        ).create_json()['id'])
         filter_.delete()
         with self.assertRaises(HTTPError):
             filter_.read_json()
@@ -62,12 +62,12 @@ class FilterTestCase(APITestCase):
         @Feature: Filter
 
         """
-        role = entities.Role(id=entities.Role().create()['id'])
+        role = entities.Role(id=entities.Role().create_json()['id'])
         ct_perms = entities.Permission(resource_type='ConfigTemplate').search()
         filter_ = entities.Filter(id=entities.Filter(
             permission=[permission['id'] for permission in ct_perms],
             role=role.id,
-        ).create()['id'])
+        ).create_json()['id'])
 
         # A filter depends on a role. Deleting a role implicitly deletes the
         # filter pointing at it.

--- a/tests/foreman/api/test_gpgkey.py
+++ b/tests/foreman/api/test_gpgkey.py
@@ -21,7 +21,7 @@ class GPGKeyTestCase(APITestCase):
         @Assert: HTTP 200 is returned with an ``application/json`` content-type
 
         """
-        org_attrs = entities.Organization().create()
+        org_attrs = entities.Organization().create_json()
         response = client.get(
             entities.GPGKey().path(),
             auth=get_server_credentials(),

--- a/tests/foreman/api/test_lifecycleenvironment.py
+++ b/tests/foreman/api/test_lifecycleenvironment.py
@@ -26,7 +26,7 @@ class LifecycleEnvironmentTestCase(APITestCase):
         @Assert: HTTP 200 is returned with an ``application/json`` content-type
 
         """
-        org_attrs = entities.Organization().create()
+        org_attrs = entities.Organization().create_json()
         response = client.get(
             entities.LifecycleEnvironment().path(),
             auth=get_server_credentials(),

--- a/tests/foreman/api/test_operatingsystem.py
+++ b/tests/foreman/api/test_operatingsystem.py
@@ -43,7 +43,7 @@ class OSParameterTestCase(APITestCase):
             name=name,
             operatingsystem=1,
             value=value,
-        ).create()['id']
+        ).create_json()['id']
         attrs = entities.OperatingSystemParameter(
             id=osp_id,
             operatingsystem=1,
@@ -65,8 +65,10 @@ class OSTestCase(APITestCase):
         @Feature: OperatingSystem
 
         """
-        arch_id = entities.Architecture().create()['id']
-        os_id = entities.OperatingSystem(architecture=[arch_id]).create()['id']
+        arch_id = entities.Architecture().create_json()['id']
+        os_id = entities.OperatingSystem(
+            architecture=[arch_id]
+        ).create_json()['id']
         attrs = entities.OperatingSystem(id=os_id).read_json()
         self.assertEqual(len(attrs['architectures']), 1)
         self.assertEqual(attrs['architectures'][0]['id'], arch_id)
@@ -80,8 +82,10 @@ class OSTestCase(APITestCase):
         @Feature: OperatingSystem
 
         """
-        ptable_id = entities.PartitionTable().create()['id']
-        os_id = entities.OperatingSystem(ptable=[ptable_id]).create()['id']
+        ptable_id = entities.PartitionTable().create_json()['id']
+        os_id = entities.OperatingSystem(
+            ptable=[ptable_id]
+        ).create_json()['id']
         attrs = entities.OperatingSystem(id=os_id).read_json()
         self.assertEqual(len(attrs['ptables']), 1)
         self.assertEqual(attrs['ptables'][0]['id'], ptable_id)

--- a/tests/foreman/api/test_organization.py
+++ b/tests/foreman/api/test_organization.py
@@ -254,7 +254,7 @@ class OrganizationUpdateTestCase(APITestCase):
         @Feature: Organization
 
         """
-        user_id = entities.User().create()['id']
+        user_id = entities.User().create_json()['id']
         client.put(
             self.organization.path(),
             {'organization': {'user_ids': [user_id]}},

--- a/tests/foreman/api/test_permission.py
+++ b/tests/foreman/api/test_permission.py
@@ -147,7 +147,7 @@ class UserRoleTestCase(APITestCase):
         self.user.id = entities.User(
             login=self.server_config.auth[0],
             password=self.server_config.auth[1],
-        ).create()['id']
+        ).create_json()['id']
 
     def give_user_permission(self, perm_name):
         """Give ``self.user`` the ``perm_name`` permission.
@@ -166,14 +166,14 @@ class UserRoleTestCase(APITestCase):
         :returns: Nothing.
 
         """
-        role_id = entities.Role().create()['id']
+        role_id = entities.Role().create_json()['id']
         permission_ids = [
             permission['id']
             for permission
             in entities.Permission(name=perm_name).search()
         ]
         self.assertEqual(len(permission_ids), 1)
-        entities.Filter(permission=permission_ids, role=role_id).create()
+        entities.Filter(permission=permission_ids, role=role_id).create_json()
         # NOTE: An extra hash is used due to an API bug.
         client.put(
             self.user.path(),

--- a/tests/foreman/api/test_product.py
+++ b/tests/foreman/api/test_product.py
@@ -43,7 +43,7 @@ class ProductsTestCase(APITestCase):
         @Feature: Product
 
         """
-        prod_id = entities.Product(**attrs).create()['id']
+        prod_id = entities.Product(**attrs).create_json()['id']
         prod_attrs = entities.Product(id=prod_id).read_json()
         for name, value in attrs.items():
             self.assertIn(name, prod_attrs.keys())
@@ -64,15 +64,15 @@ class ProductsTestCase(APITestCase):
         # * Product points to organization and GPG key
         #
         # Re-using an organization speeds up the test.
-        org_attrs = entities.Organization().create()
+        org_attrs = entities.Organization().create_json()
         gpgkey_attrs = entities.GPGKey(
             content=read_data_file(VALID_GPG_KEY_FILE),
             organization=org_attrs['id']
-        ).create()
+        ).create_json()
         product_attrs = entities.Product(
             gpg_key=gpgkey_attrs['id'],
             organization=org_attrs['id']
-        ).create()
+        ).create_json()
 
         # GET the product and verify it's GPG key ID.
         attrs = entities.Product(id=product_attrs['id']).read_json()
@@ -88,7 +88,7 @@ class ProductUpdateTestCase(APITestCase):
     def setUpClass(cls):  # noqa
         """Create a product."""
         cls.product_n = entities.Product(
-            id=entities.Product().create()['id']
+            id=entities.Product().create_json()['id']
         )
 
     @data(

--- a/tests/foreman/api/test_role.py
+++ b/tests/foreman/api/test_role.py
@@ -50,7 +50,7 @@ class RoleTestCase(APITestCase):
             self.skipTest('Bugzilla bug 1112657 is open.')
         name = name_generator()
         try:
-            role_id = entities.Role(name=name).create()['id']
+            role_id = entities.Role(name=name).create_json()['id']
         except HTTPError as err:
             self.fail(err)  # fail instead of error
 
@@ -80,7 +80,7 @@ class RoleTestCase(APITestCase):
             self.skipTest('Bugzilla bug 1112657 is open.')
         name = name_generator()
         try:
-            role_id = entities.Role(name=name).create()['id']
+            role_id = entities.Role(name=name).create_json()['id']
         except HTTPError as err:
             self.fail(err)  # fail instead of error
 
@@ -112,7 +112,7 @@ class RoleTestCase(APITestCase):
                 name_generator is gen_utf8):
             self.skipTest('Bugzilla bug 1112657 is open.')
         try:
-            role_id = entities.Role().create()['id']
+            role_id = entities.Role().create_json()['id']
         except HTTPError as err:
             self.fail(err)  # fail instead of error
 

--- a/tests/foreman/api/test_subscription.py
+++ b/tests/foreman/api/test_subscription.py
@@ -22,7 +22,7 @@ class SubscriptionsTestCase(APITestCase):
 
         """
         cloned_manifest_path = manifests.clone()
-        org_id = entities.Organization().create()['id']
+        org_id = entities.Organization().create_json()['id']
         entities.Organization(id=org_id).upload_manifest(
             path=cloned_manifest_path
         )
@@ -36,7 +36,7 @@ class SubscriptionsTestCase(APITestCase):
 
         """
         cloned_manifest_path = manifests.clone()
-        org_id = entities.Organization().create()['id']
+        org_id = entities.Organization().create_json()['id']
         entities.Organization(id=org_id).upload_manifest(
             path=cloned_manifest_path
         )

--- a/tests/foreman/api/test_user.py
+++ b/tests/foreman/api/test_user.py
@@ -56,7 +56,7 @@ class UsersTestCase(APITestCase):
 
         """
         # Create a user and validate its attributes.
-        user_id = entities.User(**attrs).create()['id']
+        user_id = entities.User(**attrs).create_json()['id']
         real_attrs = entities.User(id=user_id).read_json()
         for name, value in attrs.items():
             self.assertIn(name, real_attrs.keys())
@@ -72,7 +72,7 @@ class UsersTestCase(APITestCase):
 
         """
         # Create a user and delete it immediately afterward.
-        user_id = entities.User(**attrs).create()['id']
+        user_id = entities.User(**attrs).create_json()['id']
         entities.User(id=user_id).delete()
         with self.assertRaises(HTTPError):
             entities.User(id=user_id).read_json()

--- a/tests/foreman/smoke/test_api_smoke.py
+++ b/tests/foreman/smoke/test_api_smoke.py
@@ -837,34 +837,38 @@ class TestSmoke(TestCase):
         password = gen_string('alphanumeric')
 
         # step 1: Create a new user with admin permissions
-        entities.User(admin=True, login=login, password=password).create()
+        entities.User(admin=True, login=login, password=password).create_json()
 
         # step 2.1: Create a new organization
         server_config = get_nailgun_config()
         server_config.auth = (login, password)
-        org = entities.Organization(server_config).create()
+        org = entities.Organization(server_config).create_json()
 
         # step 2.2: Create 2 new lifecycle environments
-        le1 = entities.LifecycleEnvironment(organization=org['id']).create()
+        le1 = entities.LifecycleEnvironment(
+            organization=org['id']
+        ).create_json()
         le2 = entities.LifecycleEnvironment(
-            organization=org['id'], prior=le1['id']).create()
+            organization=org['id'],
+            prior=le1['id'],
+        ).create_json()
 
         # step 2.3: Create a custom product
-        prod = entities.Product(organization=org['id']).create()
+        prod = entities.Product(organization=org['id']).create_json()
 
         # step 2.4: Create custom YUM repository
         repo1 = entities.Repository(
             product=prod['id'],
             content_type=u'yum',
             url=GOOGLE_CHROME_REPO
-        ).create()
+        ).create_json()
 
         # step 2.5: Create custom PUPPET repository
         repo2 = entities.Repository(
             product=prod['id'],
             content_type=u'puppet',
             url=FAKE_0_PUPPET_REPO
-        ).create()
+        ).create_json()
 
         # step 2.6: Synchronize both repositories
         for repo in [repo1, repo2]:
@@ -881,7 +885,9 @@ class TestSmoke(TestCase):
             entities.ForemanTask(id=response['id']).poll()
 
         # step 2.7: Create content view
-        content_view = entities.ContentView(organization=org['id']).create()
+        content_view = entities.ContentView(
+            organization=org['id']
+        ).create_json()
 
         # step 2.8: Associate YUM repository to new content view
         response = client.put(
@@ -969,7 +975,7 @@ class TestSmoke(TestCase):
         content_host = entities.System(
             content_view=content_view['id'],
             environment=le2['id']
-        ).create()
+        ).create_json()
         # Check that content view matches what we passed
         self.assertEqual(
             content_host['content_view_id'],
@@ -1042,12 +1048,12 @@ class TestSmoke(TestCase):
         activation_key_name = gen_string('alpha')
 
         # step 1.1: Create a new organization
-        org = entities.Organization().create()
+        org = entities.Organization().create_json()
 
         # step 1.2: Create new lifecycle environments
         lifecycle_env = entities.LifecycleEnvironment(
             organization=org['id']
-        ).create()
+        ).create_json()
 
         # step 2: Upload manifest
         manifest_path = manifests.clone()
@@ -1065,7 +1071,9 @@ class TestSmoke(TestCase):
         entities.Repository(id=repo_id).sync()
 
         # step 4: Create content view
-        content_view = entities.ContentView(organization=org['id']).create()
+        content_view = entities.ContentView(
+            organization=org['id']
+        ).create_json()
         # step 5: Associate repository to new content view
         response = client.put(
             entities.ContentView(id=content_view['id']).path(),

--- a/tests/foreman/ui/test_activationkey.py
+++ b/tests/foreman/ui/test_activationkey.py
@@ -37,13 +37,14 @@ class ActivationKey(UITestCase):
 
     @classmethod
     def setUpClass(cls):  # noqa
-        org_attrs = entities.Organization().create()
+        org_attrs = entities.Organization().create_json()
         # org label is required for subcription-manager cmd.
         cls.org_label = org_attrs['label']
         cls.org_name = org_attrs['name']
         cls.org_id = org_attrs['id']
         cls.base_key_name = entities.ActivationKey(
-            organization=cls.org_id).create_json()['name']
+            organization=cls.org_id
+        ).create_json()['name']
 
         super(ActivationKey, cls).setUpClass()
 
@@ -56,13 +57,13 @@ class ActivationKey(UITestCase):
         product_attrs = entities.Product(
             name=product_name,
             organization=org_id or self.org_id
-        ).create()
+        ).create_json()
         repo_attrs = entities.Repository(
             name=repo_name,
             url=repo_url or FAKE_1_YUM_REPO,
             content_type=repo_type or REPO_TYPE['yum'],
             product=product_attrs['id'],
-        ).create()
+        ).create_json()
         repo_id = repo_attrs['id']
         # Sync repository
         entities.Repository(id=repo_id).sync()
@@ -88,13 +89,13 @@ class ActivationKey(UITestCase):
         env_attrs = entities.LifecycleEnvironment(
             name=env_name,
             organization=org_id or self.org_id
-        ).create()
+        ).create_json()
         # Create content view(CV)
         content_view = entities.ContentView(
             name=name,
             organization=org_id or self.org_id
         )
-        content_view.id = content_view.create()['id']
+        content_view.id = content_view.create_json()['id']
 
         # Associate YUM repo to created CV
         response = client.put(
@@ -248,7 +249,7 @@ class ActivationKey(UITestCase):
         host_col = entities.HostCollection(
             organization=self.org_id,
             name=hc_name
-        ).create()
+        ).create_json()
 
         with Session(self.browser) as session:
             make_activationkey(session, org=self.org_name,
@@ -1070,7 +1071,7 @@ class ActivationKey(UITestCase):
         }
         product_subscription = "Red Hat Employee Subscription"
         # Create new org to import manifest
-        org_attrs = entities.Organization().create()
+        org_attrs = entities.Organization().create_json()
         org_id = org_attrs['id']
         # Upload manifest
         manifest_path = manifests.clone()
@@ -1151,19 +1152,19 @@ class ActivationKey(UITestCase):
         custom_product_name = gen_string("alpha", 8)
         repo_name = gen_string("alpha", 8)
         # Create new org to import manifest
-        org_attrs = entities.Organization().create()
+        org_attrs = entities.Organization().create_json()
         org_id = org_attrs['id']
         # Creates new product and repository via API's
         product_attrs = entities.Product(
             name=custom_product_name,
             organization=org_id
-        ).create()
+        ).create_json()
         repo_attrs = entities.Repository(
             name=repo_name,
             url=FAKE_1_YUM_REPO,
             content_type=REPO_TYPE['yum'],
             product=product_attrs['id'],
-        ).create()
+        ).create_json()
         custom_repo_id = repo_attrs['id']
         # Upload manifest
         manifest_path = manifests.clone()

--- a/tests/foreman/ui/test_architecture.py
+++ b/tests/foreman/ui/test_architecture.py
@@ -32,7 +32,7 @@ class Architecture(UITestCase):
         @Assert: Architecture is created
 
         """
-        entities.OperatingSystem(name=test_data['os_name']).create()
+        entities.OperatingSystem(name=test_data['os_name']).create_json()
         with Session(self.browser) as session:
             make_arch(session, name=test_data['name'],
                       os_names=[test_data['os_name']])
@@ -114,7 +114,7 @@ class Architecture(UITestCase):
         @BZ: 1131815
 
         """
-        entities.OperatingSystem(name=test_data['os_name']).create()
+        entities.OperatingSystem(name=test_data['os_name']).create_json()
         with Session(self.browser) as session:
             make_arch(session, name=test_data['name'],
                       os_names=[test_data['os_name']])
@@ -143,7 +143,7 @@ class Architecture(UITestCase):
         @Assert: Architecture is updated
 
         """
-        entities.OperatingSystem(name=test_data['os_name']).create()
+        entities.OperatingSystem(name=test_data['os_name']).create_json()
         with Session(self.browser) as session:
             make_arch(session, name=test_data['old_name'])
             self.assertIsNotNone(self.architecture.search

--- a/tests/foreman/ui/test_contentenv.py
+++ b/tests/foreman/ui/test_contentenv.py
@@ -16,7 +16,7 @@ class ContentEnvironment(UITestCase):
 
     @classmethod
     def setUpClass(cls):  # noqa
-        cls.org_name = entities.Organization().create()['name']
+        cls.org_name = entities.Organization().create_json()['name']
         super(ContentEnvironment, cls).setUpClass()
 
     def test_positive_create_content_environment_1(self):

--- a/tests/foreman/ui/test_contentviews.py
+++ b/tests/foreman/ui/test_contentviews.py
@@ -29,7 +29,7 @@ class TestContentViewsUI(UITestCase):
 
     @classmethod
     def setUpClass(cls):  # noqa
-        org_attrs = entities.Organization().create()
+        org_attrs = entities.Organization().create_json()
         cls.org_name = org_attrs['name']
         cls.org_id = org_attrs['id']
 
@@ -45,7 +45,7 @@ class TestContentViewsUI(UITestCase):
             # Creates new custom product via API's
             product_attrs = entities.Product(
                 organization=org_id or self.org_id
-            ).create()
+            ).create_json()
 
             # Creates new custom repository via API's
             repo_attrs = entities.Repository(
@@ -53,7 +53,7 @@ class TestContentViewsUI(UITestCase):
                 url=(repo_url or FAKE_1_YUM_REPO),
                 content_type=(repo_type or REPO_TYPE['yum']),
                 product=product_attrs['id'],
-            ).create()
+            ).create_json()
             repo_id = repo_attrs['id']
         elif rh_repo:
             # Clone the manifest and fetch it's path.
@@ -476,7 +476,7 @@ class TestContentViewsUI(UITestCase):
             "releasever": "6.3",
         }
         # Create new org to import manifest
-        org_attrs = entities.Organization().create()
+        org_attrs = entities.Organization().create_json()
         org_id = org_attrs['id']
         org_name = org_attrs['name']
         with Session(self.browser) as session:
@@ -540,7 +540,7 @@ class TestContentViewsUI(UITestCase):
             'releasever': "6.3"
         }
         # Create new org to import manifest
-        org_attrs = entities.Organization().create()
+        org_attrs = entities.Organization().create_json()
         org_id = org_attrs['id']
         with Session(self.browser) as session:
             self.setup_to_create_cv(rh_repo=rh_repo, org_id=org_id)
@@ -708,7 +708,7 @@ class TestContentViewsUI(UITestCase):
         publish_version = "Version 1"
         strategy, value = locators["content_env.select_name"]
         # Create new org to import manifest
-        org_attrs = entities.Organization().create()
+        org_attrs = entities.Organization().create_json()
         org_id = org_attrs['id']
         org_name = org_attrs['name']
         with Session(self.browser) as session:
@@ -832,7 +832,7 @@ class TestContentViewsUI(UITestCase):
             'releasever': "6.3"
         }
         # Create new org to import manifest
-        org_attrs = entities.Organization().create()
+        org_attrs = entities.Organization().create_json()
         org_id = org_attrs['id']
         with Session(self.browser) as session:
             self.setup_to_create_cv(rh_repo=rh_repo, org_id=org_id)

--- a/tests/foreman/ui/test_gpgkey.py
+++ b/tests/foreman/ui/test_gpgkey.py
@@ -29,7 +29,7 @@ class GPGKey(UITestCase):
 
     @classmethod
     def setUpClass(cls):  # noqa
-        org_attrs = entities.Organization().create()
+        org_attrs = entities.Organization().create_json()
         cls.org_name = org_attrs['name']
         cls.org_id = org_attrs['id']
 
@@ -511,7 +511,7 @@ class GPGKeyProductAssociate(UITestCase):
 
     @classmethod
     def setUpClass(cls):  # noqa
-        org_attrs = entities.Organization().create()
+        org_attrs = entities.Organization().create_json()
         cls.org_name = org_attrs['name']
         cls.org_id = org_attrs['id']
 
@@ -533,13 +533,13 @@ class GPGKeyProductAssociate(UITestCase):
             name=name,
             content=key_content,
             organization=self.org_id
-        ).create()
+        ).create_json()
         # Creates new product and associate GPGKey with it
         entities.Product(
             name=product_name,
             gpg_key=gpgkey_attrs['id'],
             organization=self.org_id
-        ).create()
+        ).create_json()
         with Session(self.browser) as session:
             session.nav.go_to_select_org(self.org_name)
             session.nav.go_to_gpg_keys()
@@ -566,19 +566,19 @@ class GPGKeyProductAssociate(UITestCase):
             name=name,
             content=key_content,
             organization=self.org_id
-        ).create()
+        ).create_json()
         # Creates new product and associate GPGKey with it
         product_attrs = entities.Product(
             name=product_name,
             gpg_key=gpgkey_attrs['id'],
             organization=self.org_id
-        ).create()
+        ).create_json()
         # Creates new repository without GPGKey
         entities.Repository(
             name=repository_name,
             url=FAKE_1_YUM_REPO,
             product=product_attrs['id'],
-        ).create()
+        ).create_json()
         with Session(self.browser) as session:
             session.nav.go_to_select_org(self.org_name)
             session.nav.go_to_gpg_keys()
@@ -609,25 +609,25 @@ class GPGKeyProductAssociate(UITestCase):
             name=name,
             content=key_content,
             organization=self.org_id
-        ).create()
+        ).create_json()
         # Creates new product and associate GPGKey with it
         product_attrs = entities.Product(
             name=product_name,
             gpg_key=gpgkey_attrs['id'],
             organization=self.org_id
-        ).create()
+        ).create_json()
         # Creates new repository_1 without GPGKey
         entities.Repository(
             name=repository_1_name,
             url=FAKE_1_YUM_REPO,
             product=product_attrs['id']
-        ).create()
+        ).create_json()
         # Creates new repository_2 without GPGKey
         entities.Repository(
             name=repository_2_name,
             url=FAKE_2_YUM_REPO,
             product=product_attrs['id']
-        ).create()
+        ).create_json()
         with Session(self.browser) as session:
             session.nav.go_to_select_org(self.org_name)
             session.nav.go_to_gpg_keys()
@@ -690,19 +690,19 @@ class GPGKeyProductAssociate(UITestCase):
             name=name,
             content=key_content,
             organization=self.org_id
-        ).create()
+        ).create_json()
         # Creates new product without selecting GPGkey
         product_attrs = entities.Product(
             name=product_name,
             organization=self.org_id
-        ).create()
+        ).create_json()
         # Creates new repository with GPGKey
         entities.Repository(
             name=repository_name,
             url=FAKE_1_YUM_REPO,
             product=product_attrs['id'],
             gpg_key=gpgkey_attrs['id'],
-        ).create()
+        ).create_json()
         with Session(self.browser) as session:
             session.nav.go_to_select_org(self.org_name)
             session.nav.go_to_gpg_keys()
@@ -734,25 +734,25 @@ class GPGKeyProductAssociate(UITestCase):
             name=name,
             content=key_content,
             organization=self.org_id
-        ).create()
+        ).create_json()
         # Creates new product without selecting GPGkey
         product_attrs = entities.Product(
             name=product_name,
             organization=self.org_id
-        ).create()
+        ).create_json()
         # Creates new repository with GPGKey
         entities.Repository(
             name=repository_1_name,
             url=FAKE_1_YUM_REPO,
             product=product_attrs['id'],
             gpg_key=gpgkey_attrs['id'],
-        ).create()
+        ).create_json()
         # Creates new repository without GPGKey
         entities.Repository(
             name=repository_2_name,
             url=FAKE_2_YUM_REPO,
             product=product_attrs['id'],
-        ).create()
+        ).create_json()
         with Session(self.browser) as session:
             session.nav.go_to_select_org(self.org_name)
             session.nav.go_to_gpg_keys()
@@ -807,13 +807,13 @@ class GPGKeyProductAssociate(UITestCase):
             name=name,
             content=key_content,
             organization=self.org_id
-        ).create()
+        ).create_json()
         # Creates new product and associate GPGKey with it
         entities.Product(
             name=product_name,
             gpg_key=gpgkey_attrs['id'],
             organization=self.org_id
-        ).create()
+        ).create_json()
         with Session(self.browser) as session:
             session.nav.go_to_select_org(self.org_name)
             session.nav.go_to_gpg_keys()
@@ -847,19 +847,19 @@ class GPGKeyProductAssociate(UITestCase):
             name=name,
             content=key_content,
             organization=self.org_id
-        ).create()
+        ).create_json()
         # Creates new product and associate GPGKey with it
         product_attrs = entities.Product(
             name=product_name,
             gpg_key=gpgkey_attrs['id'],
             organization=self.org_id
-        ).create()
+        ).create_json()
         # Creates new repository without GPGKey
         entities.Repository(
             name=repository_name,
             url=FAKE_1_YUM_REPO,
             product=product_attrs['id'],
-        ).create()
+        ).create_json()
         with Session(self.browser) as session:
             session.nav.go_to_select_org(self.org_name)
             session.nav.go_to_gpg_keys()
@@ -899,25 +899,25 @@ class GPGKeyProductAssociate(UITestCase):
             name=name,
             content=key_content,
             organization=self.org_id
-        ).create()
+        ).create_json()
         # Creates new product and associate GPGKey with it
         product_attrs = entities.Product(
             name=product_name,
             gpg_key=gpgkey_attrs['id'],
             organization=self.org_id
-        ).create()
+        ).create_json()
         # Creates new repository_1 without GPGKey
         entities.Repository(
             name=repository_1_name,
             url=FAKE_1_YUM_REPO,
             product=product_attrs['id'],
-        ).create()
+        ).create_json()
         # Creates new repository_2 without GPGKey
         entities.Repository(
             name=repository_2_name,
             url=FAKE_2_YUM_REPO,
             product=product_attrs['id'],
-        ).create()
+        ).create_json()
         with Session(self.browser) as session:
             session.nav.go_to_select_org(self.org_name)
             session.nav.go_to_gpg_keys()
@@ -960,7 +960,7 @@ class GPGKeyProductAssociate(UITestCase):
             name=name,
             content=key_content,
             organization=self.org_id
-        ).create()
+        ).create_json()
         with Session(self.browser) as session:
             session.nav.go_to_select_org(self.org_name)
             session.nav.go_to_products()
@@ -999,19 +999,19 @@ class GPGKeyProductAssociate(UITestCase):
             name=name,
             content=key_content,
             organization=self.org_id
-        ).create()
+        ).create_json()
         # Creates new product without selecting GPGkey
         product_attrs = entities.Product(
             name=product_name,
             organization=self.org_id
-        ).create()
+        ).create_json()
         # Creates new repository with GPGKey
         entities.Repository(
             name=repository_name,
             url=FAKE_1_YUM_REPO,
             product=product_attrs['id'],
             gpg_key=gpgkey_attrs['id'],
-        ).create()
+        ).create_json()
         with Session(self.browser) as session:
             session.nav.go_to_select_org(self.org_name)
             session.nav.go_to_gpg_keys()
@@ -1052,25 +1052,25 @@ class GPGKeyProductAssociate(UITestCase):
             name=name,
             content=key_content,
             organization=self.org_id
-        ).create()
+        ).create_json()
         # Creates new product without selecting GPGkey
         product_attrs = entities.Product(
             name=product_name,
             organization=self.org_id
-        ).create()
+        ).create_json()
         # Creates new repository_1 with GPGKey
         entities.Repository(
             name=repository_1_name,
             url=FAKE_1_YUM_REPO,
             product=product_attrs['id'],
             gpg_key=gpgkey_attrs['id'],
-        ).create()
+        ).create_json()
         # Creates new repository_2 without GPGKey
         entities.Repository(
             name=repository_2_name,
             url=FAKE_2_YUM_REPO,
             product=product_attrs['id'],
-        ).create()
+        ).create_json()
         with Session(self.browser) as session:
             session.nav.go_to_select_org(self.org_name)
             session.nav.go_to_gpg_keys()
@@ -1136,13 +1136,13 @@ class GPGKeyProductAssociate(UITestCase):
             name=name,
             content=key_content,
             organization=self.org_id
-        ).create()
+        ).create_json()
         # Creates new product and associate GPGKey with it
         entities.Product(
             name=product_name,
             gpg_key=gpgkey_attrs['id'],
             organization=self.org_id
-        ).create()
+        ).create_json()
         with Session(self.browser) as session:
             session.nav.go_to_select_org(self.org_name)
             session.nav.go_to_gpg_keys()
@@ -1174,19 +1174,19 @@ class GPGKeyProductAssociate(UITestCase):
             name=name,
             content=key_content,
             organization=self.org_id
-        ).create()
+        ).create_json()
         # Creates new product and associate GPGKey with it
         product_attrs = entities.Product(
             name=product_name,
             gpg_key=gpgkey_attrs['id'],
             organization=self.org_id
-        ).create()
+        ).create_json()
         # Creates new repository without GPGKey
         entities.Repository(
             name=repository_name,
             url=FAKE_1_YUM_REPO,
             product=product_attrs['id'],
-        ).create()
+        ).create_json()
         with Session(self.browser) as session:
             session.nav.go_to_select_org(self.org_name)
             session.nav.go_to_gpg_keys()
@@ -1223,25 +1223,25 @@ class GPGKeyProductAssociate(UITestCase):
             name=name,
             content=key_content,
             organization=self.org_id
-        ).create()
+        ).create_json()
         # Creates new product and associate GPGKey with it
         product_attrs = entities.Product(
             name=product_name,
             gpg_key=gpgkey_attrs['id'],
             organization=self.org_id
-        ).create()
+        ).create_json()
         # Creates new repository_1 without GPGKey
         entities.Repository(
             name=repository_1_name,
             url=FAKE_1_YUM_REPO,
             product=product_attrs['id'],
-        ).create()
+        ).create_json()
         # Creates new repository_2 without GPGKey
         entities.Repository(
             name=repository_2_name,
             url=FAKE_2_YUM_REPO,
             product=product_attrs['id'],
-        ).create()
+        ).create_json()
         with Session(self.browser) as session:
             session.nav.go_to_select_org(self.org_name)
             session.nav.go_to_gpg_keys()
@@ -1281,7 +1281,7 @@ class GPGKeyProductAssociate(UITestCase):
             name=name,
             content=key_content,
             organization=self.org_id
-        ).create()
+        ).create_json()
         with Session(self.browser) as session:
             session.nav.go_to_select_org(self.org_name)
             session.nav.go_to_products()
@@ -1318,19 +1318,19 @@ class GPGKeyProductAssociate(UITestCase):
             name=name,
             content=key_content,
             organization=self.org_id
-        ).create()
+        ).create_json()
         # Creates new product without selecting GPGkey
         product_attrs = entities.Product(
             name=product_name,
             organization=self.org_id
-        ).create()
+        ).create_json()
         # Creates new repository with GPGKey
         entities.Repository(
             name=repository_name,
             url=FAKE_1_YUM_REPO,
             product=product_attrs['id'],
             gpg_key=gpgkey_attrs['id'],
-        ).create()
+        ).create_json()
         with Session(self.browser) as session:
             session.nav.go_to_select_org(self.org_name)
             session.nav.go_to_gpg_keys()
@@ -1369,25 +1369,25 @@ class GPGKeyProductAssociate(UITestCase):
             name=name,
             content=key_content,
             organization=self.org_id
-        ).create()
+        ).create_json()
         # Creates new product without GPGKey association
         product_attrs = entities.Product(
             name=product_name,
             organization=self.org_id
-        ).create()
+        ).create_json()
         # Creates new repository_1 with GPGKey association
         entities.Repository(
             name=repository_1_name,
             url=FAKE_1_YUM_REPO,
             product=product_attrs['id'],
             gpg_key=gpgkey_attrs['id'],
-        ).create()
+        ).create_json()
         entities.Repository(
             name=repository_2_name,
             url=FAKE_2_YUM_REPO,
             product=product_attrs['id'],
             # notice that we're not making this repo point to the GPG key
-        ).create()
+        ).create_json()
         with Session(self.browser) as session:
             session.nav.go_to_select_org(self.org_name)
             session.nav.go_to_gpg_keys()

--- a/tests/foreman/ui/test_location.py
+++ b/tests/foreman/ui/test_location.py
@@ -153,7 +153,7 @@ class Location(UITestCase):
         """
         org_name = test_data['org_name']
         loc_name = test_data['loc_name']
-        org = entities.Organization(name=org_name).create()
+        org = entities.Organization(name=org_name).create_json()
         self.assertEqual(org['name'], org_name)
         with Session(self.browser) as session:
             make_loc(session, name=loc_name)
@@ -239,7 +239,7 @@ class Location(UITestCase):
             name=subnet_name,
             network=subnet_network,
             mask=subnet_mask
-        ).create()
+        ).create_json()
         self.assertEqual(subnet['name'], subnet_name)
         with Session(self.browser) as session:
             make_loc(session, name=loc_name)
@@ -263,7 +263,7 @@ class Location(UITestCase):
         """
         strategy, value = common_locators["entity_deselect"]
         loc_name = gen_string("alpha", 8)
-        domain = entities.Domain(name=domain_name).create()
+        domain = entities.Domain(name=domain_name).create_json()
         self.assertEqual(domain['name'], domain_name)
         with Session(self.browser) as session:
             make_loc(session, name=loc_name)
@@ -297,7 +297,7 @@ class Location(UITestCase):
             login=user_name,
             firstname=user_name,
             lastname=user_name,
-            password=password).create()
+            password=password).create_json()
         self.assertEqual(user['login'], user_name)
         with Session(self.browser) as session:
             make_loc(session, name=loc_name)
@@ -340,7 +340,7 @@ class Location(UITestCase):
         """
         strategy, value = common_locators["all_values_selection"]
         loc_name = gen_string("alpha", 8)
-        host_grp = entities.HostGroup(name=host_grp_name).create()
+        host_grp = entities.HostGroup(name=host_grp_name).create_json()
         self.assertEqual(host_grp['name'], host_grp_name)
         with Session(self.browser) as session:
             make_loc(session, name=loc_name)
@@ -364,7 +364,7 @@ class Location(UITestCase):
         """
         strategy, value = common_locators["entity_deselect"]
         loc_name = gen_string("alpha", 8)
-        org = entities.Organization(name=org_name).create()
+        org = entities.Organization(name=org_name).create_json()
         self.assertEqual(org['name'], org_name)
         with Session(self.browser) as session:
             make_loc(session, name=loc_name)
@@ -390,7 +390,7 @@ class Location(UITestCase):
         """
         strategy, value = common_locators["entity_deselect"]
         loc_name = gen_string("alpha", 8)
-        env = entities.Environment(name=env_name).create()
+        env = entities.Environment(name=env_name).create_json()
         self.assertEqual(env['name'], env_name)
         with Session(self.browser) as session:
             make_loc(session, name=loc_name)
@@ -421,7 +421,7 @@ class Location(UITestCase):
             name=resource_name,
             provider='Libvirt',
             url=url
-        ).create()
+        ).create_json()
         self.assertEqual(resource['name'], resource_name)
         with Session(self.browser) as session:
             make_loc(session, name=loc_name)
@@ -450,7 +450,7 @@ class Location(UITestCase):
             name=medium_name,
             media_path=path,
             os_family='Redhat',
-        ).create()
+        ).create_json()
         self.assertEqual(medium['name'], medium_name)
         with Session(self.browser) as session:
             make_loc(session, name=loc_name)
@@ -522,7 +522,7 @@ class Location(UITestCase):
         strategy, value = common_locators["entity_select"]
         strategy1, value1 = common_locators["entity_deselect"]
         loc_name = gen_string("alpha", 8)
-        env = entities.Environment(name=env_name).create()
+        env = entities.Environment(name=env_name).create_json()
         self.assertEqual(env['name'], env_name)
         with Session(self.browser) as session:
             set_context(session, org=ANY_CONTEXT['org'])
@@ -561,7 +561,7 @@ class Location(UITestCase):
             name=subnet_name,
             network=subnet_network,
             mask=subnet_mask
-        ).create()
+        ).create_json()
         self.assertEqual(subnet['name'], subnet_name)
         with Session(self.browser) as session:
             set_context(session, org=ANY_CONTEXT['org'])
@@ -596,7 +596,7 @@ class Location(UITestCase):
         strategy, value = common_locators["entity_select"]
         strategy1, value1 = common_locators["entity_deselect"]
         loc_name = gen_string("alpha", 8)
-        domain = entities.Domain(name=domain_name).create()
+        domain = entities.Domain(name=domain_name).create_json()
         self.assertEqual(domain['name'], domain_name)
         with Session(self.browser) as session:
             set_context(session, org=ANY_CONTEXT['org'])
@@ -639,7 +639,7 @@ class Location(UITestCase):
             login=user_name,
             firstname=user_name,
             lastname=user_name,
-            password=password).create()
+            password=password).create_json()
         self.assertEqual(user['login'], user_name)
         with Session(self.browser) as session:
             set_context(session, org=ANY_CONTEXT['org'])
@@ -672,7 +672,7 @@ class Location(UITestCase):
         """
         strategy, value = common_locators["all_values_selection"]
         loc_name = gen_string("alpha", 8)
-        host_grp = entities.HostGroup(name=host_grp_name).create()
+        host_grp = entities.HostGroup(name=host_grp_name).create_json()
         self.assertEqual(host_grp['name'], host_grp_name)
         with Session(self.browser) as session:
             set_context(session, org=ANY_CONTEXT['org'])
@@ -712,7 +712,7 @@ class Location(UITestCase):
             name=resource_name,
             provider='Libvirt',
             url=url
-        ).create()
+        ).create_json()
         self.assertEqual(resource['name'], resource_name)
         with Session(self.browser) as session:
             set_context(session, org=ANY_CONTEXT['org'])
@@ -750,7 +750,7 @@ class Location(UITestCase):
             name=medium_name,
             media_path=path,
             os_family='Redhat',
-        ).create()
+        ).create_json()
         self.assertEqual(medium['name'], medium_name)
         with Session(self.browser) as session:
             set_context(session, org=ANY_CONTEXT['org'])

--- a/tests/foreman/ui/test_operatingsys.py
+++ b/tests/foreman/ui/test_operatingsys.py
@@ -290,7 +290,7 @@ class OperatingSys(UITestCase):
         @Assert: OS is deleted
 
         """
-        os_name = entities.OperatingSystem().create()['name']
+        os_name = entities.OperatingSystem().create_json()['name']
         with Session(self.browser) as session:
             session.nav.go_to_operating_systems()
             self.operatingsys.delete(os_name, really=True)
@@ -326,8 +326,8 @@ class OperatingSys(UITestCase):
 
         """
 
-        os_name = entities.OperatingSystem().create()['name']
-        arch_name = entities.Architecture().create()['name']
+        os_name = entities.OperatingSystem().create_json()['name']
+        arch_name = entities.Architecture().create_json()['name']
         with Session(self.browser):
             self.operatingsys.update(os_name, test_data['new_name'],
                                      test_data['new_major_version'],
@@ -376,8 +376,8 @@ class OperatingSys(UITestCase):
         entities.PartitionTable(
             name=ptable,
             layout=layout,
-        ).create()
-        os_name = entities.OperatingSystem().create()['name']
+        ).create_json()
+        os_name = entities.OperatingSystem().create_json()['name']
         with Session(self.browser):
             self.operatingsys.update(os_name, new_ptables=[ptable])
             result_obj = self.operatingsys.get_os_entities(os_name, "ptable")
@@ -418,7 +418,7 @@ class OperatingSys(UITestCase):
 
         param_name = gen_string("alpha", 4)
         param_value = gen_string("alpha", 3)
-        os_name = entities.OperatingSystem().create()['name']
+        os_name = entities.OperatingSystem().create_json()['name']
         with Session(self.browser):
             try:
                 self.operatingsys.set_os_parameter(os_name, param_name,
@@ -437,7 +437,7 @@ class OperatingSys(UITestCase):
 
         param_name = gen_string("alpha", 4)
         param_value = ""
-        os_name = entities.OperatingSystem().create()['name']
+        os_name = entities.OperatingSystem().create_json()['name']
         with Session(self.browser):
             try:
                 self.operatingsys.set_os_parameter(os_name, param_name,
@@ -456,7 +456,7 @@ class OperatingSys(UITestCase):
 
         param_name = gen_string("alpha", 4)
         param_value = gen_string("alpha", 3)
-        os_name = entities.OperatingSystem().create()['name']
+        os_name = entities.OperatingSystem().create_json()['name']
         with Session(self.browser):
             try:
                 self.operatingsys.set_os_parameter(os_name, param_name,
@@ -478,7 +478,7 @@ class OperatingSys(UITestCase):
 
         param_name = gen_string("alpha", 4)
         param_value = gen_string("alpha", 3)
-        os_name = entities.OperatingSystem().create()['name']
+        os_name = entities.OperatingSystem().create_json()['name']
         with Session(self.browser):
             try:
                 self.operatingsys.set_os_parameter(os_name, param_name,
@@ -503,7 +503,7 @@ class OperatingSys(UITestCase):
 
         param_name = " "
         param_value = " "
-        os_name = entities.OperatingSystem().create()['name']
+        os_name = entities.OperatingSystem().create_json()['name']
         with Session(self.browser):
             try:
                 self.operatingsys.set_os_parameter(os_name, param_name,
@@ -524,7 +524,7 @@ class OperatingSys(UITestCase):
 
         param_name = gen_string("alpha", 256)
         param_value = gen_string("alpha", 256)
-        os_name = entities.OperatingSystem().create()['name']
+        os_name = entities.OperatingSystem().create_json()['name']
         with Session(self.browser):
             try:
                 self.operatingsys.set_os_parameter(os_name, param_name,

--- a/tests/foreman/ui/test_org.py
+++ b/tests/foreman/ui/test_org.py
@@ -211,7 +211,7 @@ class Org(UITestCase):
         """
         org_name = test_data['org_name']
         loc_name = test_data['loc_name']
-        location = entities.Location(name=loc_name).create()
+        location = entities.Location(name=loc_name).create_json()
         self.assertEqual(location['name'], loc_name)
         with Session(self.browser) as session:
             make_org(session, org_name=org_name)
@@ -390,7 +390,7 @@ class Org(UITestCase):
         strategy, value = common_locators["entity_select"]
         strategy1, value1 = common_locators["entity_deselect"]
         org_name = gen_string("alpha", 8)
-        domain = entities.Domain(name=domain_name).create()
+        domain = entities.Domain(name=domain_name).create_json()
         self.assertEqual(domain['name'], domain_name)
         with Session(self.browser) as session:
             make_org(session, org_name=org_name, domains=[domain_name])
@@ -436,7 +436,7 @@ class Org(UITestCase):
             login=user_name,
             firstname=user_name,
             lastname=user_name,
-            password=password).create()
+            password=password).create_json()
         self.assertEqual(user['login'], user_name)
         with Session(self.browser) as session:
             make_org(session, org_name=org_name, users=[user_name])
@@ -470,7 +470,7 @@ class Org(UITestCase):
         strategy, value = common_locators["entity_select"]
         strategy1, value1 = common_locators["entity_deselect"]
         org_name = gen_string("alpha", 8)
-        host_grp = entities.HostGroup(name=host_grp_name).create()
+        host_grp = entities.HostGroup(name=host_grp_name).create_json()
         self.assertEqual(host_grp['name'], host_grp_name)
         with Session(self.browser) as session:
             make_org(session, org_name=org_name, hostgroups=[host_grp_name])
@@ -532,7 +532,7 @@ class Org(UITestCase):
             name=subnet_name,
             network=subnet_network,
             mask=subnet_mask
-        ).create()
+        ).create_json()
         self.assertEqual(subnet['name'], subnet_name)
         with Session(self.browser) as session:
             make_org(session, org_name=org_name)
@@ -557,7 +557,7 @@ class Org(UITestCase):
         """
         strategy, value = common_locators["entity_deselect"]
         org_name = gen_string("alpha", 8)
-        domain = entities.Domain(name=domain_name).create()
+        domain = entities.Domain(name=domain_name).create_json()
         self.assertEqual(domain['name'], domain_name)
         with Session(self.browser) as session:
             make_org(session, org_name=org_name)
@@ -594,7 +594,7 @@ class Org(UITestCase):
             login=user_name,
             firstname=user_name,
             lastname=user_name,
-            password=password).create()
+            password=password).create_json()
         self.assertEqual(user['login'], user_name)
         with Session(self.browser) as session:
             make_org(session, org_name=org_name)
@@ -620,7 +620,7 @@ class Org(UITestCase):
         """
         strategy, value = common_locators["entity_deselect"]
         org_name = gen_string("alpha", 8)
-        host_grp = entities.HostGroup(name=host_grp_name).create()
+        host_grp = entities.HostGroup(name=host_grp_name).create_json()
         self.assertEqual(host_grp['name'], host_grp_name)
         with Session(self.browser) as session:
             make_org(session, org_name=org_name)
@@ -646,7 +646,7 @@ class Org(UITestCase):
         """
         strategy, value = common_locators["entity_deselect"]
         org_name = gen_string("alpha", 8)
-        location = entities.Location(name=location_name).create()
+        location = entities.Location(name=location_name).create_json()
         self.assertEqual(location['name'], location_name)
         with Session(self.browser) as session:
             make_org(session, org_name=org_name)
@@ -679,7 +679,7 @@ class Org(UITestCase):
             name=resource_name,
             provider='Libvirt',
             url=url
-        ).create()
+        ).create_json()
         self.assertEqual(resource['name'], resource_name)
         with Session(self.browser) as session:
             make_org(session, org_name=org_name, resources=[resource_name])
@@ -718,7 +718,7 @@ class Org(UITestCase):
             name=medium_name,
             media_path=path,
             os_family='Redhat',
-        ).create()
+        ).create_json()
         self.assertEqual(medium['name'], medium_name)
         with Session(self.browser) as session:
             make_org(session, org_name=org_name,
@@ -756,7 +756,7 @@ class Org(UITestCase):
         strategy, value = common_locators["entity_select"]
         strategy1, value1 = common_locators["entity_deselect"]
         org_name = gen_string("alpha", 8)
-        entities.ConfigTemplate(name=template_name).create()
+        entities.ConfigTemplate(name=template_name).create_json()
         with Session(self.browser) as session:
             make_org(session, org_name=org_name, templates=[template_name])
             self.org.search(org_name).click()
@@ -789,7 +789,7 @@ class Org(UITestCase):
         """
         strategy, value = common_locators["entity_deselect"]
         org_name = gen_string("alpha", 8)
-        env = entities.Environment(name=env_name).create()
+        env = entities.Environment(name=env_name).create_json()
         self.assertEqual(env['name'], env_name)
         with Session(self.browser) as session:
             make_org(session, org_name=org_name)
@@ -845,7 +845,7 @@ class Org(UITestCase):
             name=resource_name,
             provider='Libvirt',
             url=url
-        ).create()
+        ).create_json()
         self.assertEqual(resource['name'], resource_name)
         with Session(self.browser) as session:
             make_org(session, org_name=org_name)
@@ -875,7 +875,7 @@ class Org(UITestCase):
             name=medium_name,
             media_path=path,
             os_family='Redhat',
-        ).create()
+        ).create_json()
         self.assertEqual(medium['name'], medium_name)
         with Session(self.browser) as session:
             make_org(session, org_name=org_name)
@@ -903,7 +903,7 @@ class Org(UITestCase):
         """
         strategy, value = common_locators["entity_deselect"]
         org_name = gen_string("alpha", 8)
-        entities.ConfigTemplate(name=template_name).create()
+        entities.ConfigTemplate(name=template_name).create_json()
 
         with Session(self.browser) as session:
             make_org(session, org_name=org_name)
@@ -931,7 +931,7 @@ class Org(UITestCase):
         strategy, value = common_locators["entity_select"]
         strategy1, value1 = common_locators["entity_deselect"]
         org_name = gen_string("alpha", 8)
-        env = entities.Environment(name=env_name).create()
+        env = entities.Environment(name=env_name).create_json()
         self.assertEqual(env['name'], env_name)
         with Session(self.browser) as session:
             make_org(session, org_name=org_name, envs=[env_name])
@@ -970,7 +970,7 @@ class Org(UITestCase):
             name=subnet_name,
             network=subnet_network,
             mask=subnet_mask
-        ).create()
+        ).create_json()
         self.assertEqual(subnet['name'], subnet_name)
         with Session(self.browser) as session:
             make_org(session, org_name=org_name, subnets=[subnet_name])

--- a/tests/foreman/ui/test_products.py
+++ b/tests/foreman/ui/test_products.py
@@ -17,8 +17,8 @@ class Products(UITestCase):
 
     @classmethod
     def setUpClass(cls):  # noqa
-        cls.org_name = entities.Organization().create()['name']
-        cls.loc_name = entities.Location().create()['name']
+        cls.org_name = entities.Organization().create_json()['name']
+        cls.loc_name = entities.Location().create_json()['name']
 
         super(Products, cls).setUpClass()
 
@@ -51,7 +51,7 @@ class Products(UITestCase):
         description = "test 123"
         org2_name = entities.Organization(
             name=gen_string("alpha", 8)
-        ).create()['name']
+        ).create_json()['name']
         with Session(self.browser) as session:
             make_product(session, org=self.org_name, loc=self.loc_name,
                          name=prd_name, description=description)

--- a/tests/foreman/ui/test_repository.py
+++ b/tests/foreman/ui/test_repository.py
@@ -29,8 +29,8 @@ class Repos(UITestCase):
 
     @classmethod
     def setUpClass(cls):  # noqa
-        org_attrs = entities.Organization().create()
-        loc_attrs = entities.Location().create()
+        org_attrs = entities.Organization().create_json()
+        loc_attrs = entities.Location().create_json()
         cls.org_name = org_attrs['name']
         cls.org_id = org_attrs['id']
         cls.loc_name = loc_attrs['name']
@@ -88,7 +88,7 @@ class Repos(UITestCase):
         # Creates new product
         product_name = entities.Product(
             organization=self.org_id
-        ).create()['name']
+        ).create_json()['name']
         with Session(self.browser) as session:
             make_repository(session, org=self.org_name, name=repo_name,
                             product=product_name, url=FAKE_1_YUM_REPO)
@@ -108,13 +108,13 @@ class Repos(UITestCase):
         # Creates new product_1
         product_1_name = entities.Product(
             organization=self.org_id,
-        ).create()['name']
+        ).create_json()['name']
 
         # Create new product_2 under new organization_2
-        org_2_id = entities.Organization(name=org_2_name).create()['id']
+        org_2_id = entities.Organization(name=org_2_name).create_json()['id']
         product_2_name = entities.Product(
             organization=org_2_id,
-        ).create()['name']
+        ).create_json()['name']
 
         with Session(self.browser) as session:
             make_repository(session, org=self.org_name, name=repo_name,
@@ -139,7 +139,7 @@ class Repos(UITestCase):
         # Creates new product
         product_name = entities.Product(
             organization=self.org_id
-        ).create()['name']
+        ).create_json()['name']
         with Session(self.browser) as session:
             make_repository(session, org=self.org_name,
                             name=repo_name, product=product_name,
@@ -163,7 +163,7 @@ class Repos(UITestCase):
         repo_name = gen_string("alpha", 8)
         product_name = entities.Product(
             organization=self.org_id
-        ).create()['name']
+        ).create_json()['name']
         with Session(self.browser) as session:
             make_repository(session, org=self.org_name,
                             name=repo_name, product=product_name,
@@ -191,7 +191,7 @@ class Repos(UITestCase):
         # Creates new product
         product_name = entities.Product(
             organization=self.org_id
-        ).create()['name']
+        ).create_json()['name']
         with Session(self.browser) as session:
             make_repository(session, org=self.org_name,
                             name=repo_name, product=product_name,
@@ -214,7 +214,7 @@ class Repos(UITestCase):
         # Creates new product
         product_name = entities.Product(
             organization=self.org_id
-        ).create()['name']
+        ).create_json()['name']
 
         with Session(self.browser) as session:
             make_repository(session, org=self.org_name,
@@ -237,7 +237,7 @@ class Repos(UITestCase):
         # Creates new product
         product_name = entities.Product(
             organization=self.org_id,
-        ).create()['name']
+        ).create_json()['name']
 
         with Session(self.browser) as session:
             make_repository(session, org=self.org_name,
@@ -264,7 +264,7 @@ class Repos(UITestCase):
         # Creates new product
         product_name = entities.Product(
             organization=self.org_id
-        ).create()['name']
+        ).create_json()['name']
 
         with Session(self.browser) as session:
             make_repository(session, org=self.org_name,
@@ -288,7 +288,7 @@ class Repos(UITestCase):
         # Creates new product
         product_name = entities.Product(
             organization=self.org_id
-        ).create()['name']
+        ).create_json()['name']
 
         with Session(self.browser) as session:
             make_repository(session, org=self.org_name,
@@ -322,16 +322,16 @@ class Repos(UITestCase):
         gpgkey_1_name = entities.GPGKey(
             content=key_1_content,
             organization=self.org_id
-        ).create()['name']
+        ).create_json()['name']
         gpgkey_2_name = entities.GPGKey(
             content=key_2_content,
             organization=self.org_id
-        ).create()['name']
+        ).create_json()['name']
 
         # Creates new product
         product_name = entities.Product(
             organization=self.org_id
-        ).create()['name']
+        ).create_json()['name']
 
         with Session(self.browser) as session:
             make_repository(session, org=self.org_name,
@@ -364,7 +364,7 @@ class Repos(UITestCase):
         # Creates new product
         product_name = entities.Product(
             organization=self.org_id
-        ).create()['name']
+        ).create_json()['name']
 
         with Session(self.browser) as session:
             make_repository(session, org=self.org_name,
@@ -395,7 +395,7 @@ class Repos(UITestCase):
         # Creates new product
         product_name = entities.Product(
             organization=self.org_id
-        ).create()['name']
+        ).create_json()['name']
 
         with Session(self.browser) as session:
             make_repository(session, org=self.org_name,
@@ -418,7 +418,7 @@ class Repos(UITestCase):
 
         product_name = entities.Product(
             organization=self.org_id
-        ).create()['name']
+        ).create_json()['name']
 
         with Session(self.browser) as session:
             session.nav.go_to_select_org(self.org_name)
@@ -461,13 +461,13 @@ class Repos(UITestCase):
         # Creates new product
         product_attrs = entities.Product(
             organization=self.org_id
-        ).create()
+        ).create_json()
         # Creates new repository
         entities.Repository(
             name=repository_name,
             url=FAKE_1_YUM_REPO,
             product=product_attrs['id']
-        ).create()
+        ).create_json()
         with Session(self.browser) as session:
             self.setup_navigate_syncnow(session,
                                         product_attrs['name'],
@@ -488,14 +488,14 @@ class Repos(UITestCase):
         # Creates new product
         product_attrs = entities.Product(
             organization=self.org_id
-        ).create()
+        ).create_json()
         # Creates new puppet repository
         entities.Repository(
             name=repository_name,
             url=FAKE_0_PUPPET_REPO,
             product=product_attrs['id'],
             content_type=REPO_TYPE['puppet'],
-        ).create()
+        ).create_json()
         with Session(self.browser) as session:
             self.setup_navigate_syncnow(session,
                                         product_attrs['name'],
@@ -521,14 +521,14 @@ class Repos(UITestCase):
         # Creates new product
         product_attrs = entities.Product(
             organization=self.org_id
-        ).create()
+        ).create_json()
         # Creates new puppet repository
         entities.Repository(
             name=repository_name,
             url=DOCKER_REGISTRY_HUB,
             product=product_attrs['id'],
             content_type=REPO_TYPE['docker'],
-        ).create()
+        ).create_json()
         with Session(self.browser) as session:
             self.setup_navigate_syncnow(session,
                                         product_attrs['name'],

--- a/tests/foreman/ui/test_role.py
+++ b/tests/foreman/ui/test_role.py
@@ -180,7 +180,7 @@ class Role(UITestCase):
         name = gen_string("alpha", 8)
         resource_type = 'Activation Keys'
         permission_list = ['view_activation_keys']
-        org_name = entities.Organization().create()['name']
+        org_name = entities.Organization().create_json()['name']
         with Session(self.browser) as session:
             make_role(session, name=name)
             self.assertIsNotNone(self.role.search(name))

--- a/tests/foreman/ui/test_subscription.py
+++ b/tests/foreman/ui/test_subscription.py
@@ -16,7 +16,7 @@ class SubscriptionTestCase(UITestCase):
 
     @classmethod
     def setUpClass(cls):  # noqa
-        cls.org_name = entities.Organization().create()['name']
+        cls.org_name = entities.Organization().create_json()['name']
 
         super(SubscriptionTestCase, cls).setUpClass()
 

--- a/tests/foreman/ui/test_sync.py
+++ b/tests/foreman/ui/test_sync.py
@@ -27,7 +27,7 @@ class Sync(UITestCase):
 
     @classmethod
     def setUpClass(cls):  # noqa
-        org_attrs = entities.Organization().create()
+        org_attrs = entities.Organization().create_json()
         cls.org_name = org_attrs['name']
         cls.org_id = org_attrs['id']
 
@@ -47,13 +47,13 @@ class Sync(UITestCase):
         # Creates new product
         product_attrs = entities.Product(
             organization=self.org_id
-        ).create()
+        ).create_json()
         # Creates new repository
         entities.Repository(
             name=repository_name,
             url=FAKE_1_YUM_REPO,
             product=product_attrs['id']
-        ).create()
+        ).create_json()
         with Session(self.browser) as session:
             session.nav.go_to_select_org(Sync.org_name)
             session.nav.go_to_sync_status()

--- a/tests/foreman/ui/test_syncplan.py
+++ b/tests/foreman/ui/test_syncplan.py
@@ -19,7 +19,7 @@ class Syncplan(UITestCase):
 
     @classmethod
     def setUpClass(cls):  # noqa
-        org_attrs = entities.Organization().create()
+        org_attrs = entities.Organization().create_json()
         cls.org_name = org_attrs['name']
         cls.org_id = org_attrs['id']
 
@@ -296,7 +296,7 @@ class Syncplan(UITestCase):
         strategy, value = locators["sp.prd_select"]
         product_name = entities.Product(
             organization=self.org_id
-        ).create()['name']
+        ).create_json()['name']
         entities.Organization(id=self.org_id).sync_plan(
             name=plan_name,
             interval=SYNC_INTERVAL['week']
@@ -327,7 +327,7 @@ class Syncplan(UITestCase):
         strategy, value = locators["sp.prd_select"]
         product_name = entities.Product(
             organization=self.org_id
-        ).create()['name']
+        ).create_json()['name']
         entities.Organization(id=self.org_id).sync_plan(
             name=plan_name,
             interval=SYNC_INTERVAL['week']

--- a/tests/foreman/ui/test_user.py
+++ b/tests/foreman/ui/test_user.py
@@ -97,7 +97,7 @@ class User(UITestCase):
 
         strategy, value = common_locators["entity_deselect"]
         name = gen_string("alpha", 6)
-        role_name = entities.Role().create()['name']
+        role_name = entities.Role().create_json()['name']
         with Session(self.browser) as session:
             make_user(session, username=name)
             self.user.search(name, search_key).click()
@@ -290,7 +290,7 @@ class User(UITestCase):
         """
         strategy, value = common_locators["entity_deselect"]
         name = gen_string("alpha", 6)
-        role_name = entities.Role().create()['name']
+        role_name = entities.Role().create_json()['name']
         with Session(self.browser) as session:
             make_user(session, username=name, roles=[role_name], edit=True)
             self.user.search(name, search_key).click()
@@ -316,7 +316,7 @@ class User(UITestCase):
         role1 = gen_string("alpha", 6)
         role2 = gen_string("alpha", 6)
         for role in [role1, role2]:
-            entities.Role(name=role).create()
+            entities.Role(name=role).create_json()
         with Session(self.browser) as session:
             make_user(session, username=name, roles=[role1, role2],
                       edit=True)
@@ -544,7 +544,7 @@ class User(UITestCase):
         strategy, value = common_locators["entity_deselect"]
         name = gen_string("alpha", 6)
         org_name = gen_string("alpha", 6)
-        entities.Organization(name=org_name).create()
+        entities.Organization(name=org_name).create_json()
         with Session(self.browser) as session:
             make_user(session, username=name, organizations=[org_name],
                       edit=True)
@@ -568,7 +568,7 @@ class User(UITestCase):
         org_name1 = gen_string("alpha", 6)
         org_name2 = gen_string("alpha", 6)
         for org_name in [org_name1, org_name2]:
-            entities.Organization(name=org_name).create()
+            entities.Organization(name=org_name).create_json()
         with Session(self.browser) as session:
             make_user(session, username=name,
                       organizations=[org_name1, org_name2],
@@ -636,7 +636,7 @@ class User(UITestCase):
         strategy, value = common_locators["entity_deselect"]
         name = gen_string("alpha", 6)
         org_name = gen_string("alpha", 6)
-        entities.Organization(name=org_name).create()
+        entities.Organization(name=org_name).create_json()
         with Session(self.browser) as session:
             make_user(session, username=name, organizations=[org_name],
                       edit=True, default_org=org_name)
@@ -663,7 +663,7 @@ class User(UITestCase):
         strategy, value = common_locators["entity_deselect"]
         name = gen_string("alpha", 6)
         loc_name = gen_string("alpha", 6)
-        entities.Location(name=loc_name).create()
+        entities.Location(name=loc_name).create_json()
         with Session(self.browser) as session:
             make_user(session, username=name, locations=[loc_name],
                       edit=True, default_loc=loc_name)

--- a/tests/foreman/ui/test_usergroup.py
+++ b/tests/foreman/ui/test_usergroup.py
@@ -39,7 +39,7 @@ class UserGroup(UITestCase):
         entities.User(
             login=user_name,
             password=password,
-        ).create()
+        ).create_json()
 
         with Session(self.browser) as session:
             make_usergroup(session, name=group_name, users=[user_name])
@@ -127,7 +127,7 @@ class UserGroup(UITestCase):
         user_name = gen_string("alpha", 6)
         password = gen_string("alpha", 6)
         # Create a new user
-        entities.User(login=user_name, password=password).create()
+        entities.User(login=user_name, password=password).create_json()
 
         with Session(self.browser) as session:
             make_usergroup(session, name=group_name, users=[user_name])
@@ -163,7 +163,7 @@ class UserGroup(UITestCase):
         user_name = gen_string("alpha", 6)
         password = gen_string("alpha", 6)
         # Create a new user
-        entities.User(login=user_name, password=password).create()
+        entities.User(login=user_name, password=password).create_json()
         with Session(self.browser) as session:
             make_usergroup(session, name=name)
             self.assertIsNotNone(self.usergroup.search(name))


### PR DESCRIPTION
Method `EntityCreateMixin.create_json` and `EntityCreateMixin.create` are
supposed to function significantly differently. The former returns a dict of
attributes from the server. The latter returns a full-blown object with methods
like `path`, `get_fields` and `get_values`, a private `ServerConfig` object,
"field" class attributes and corresponding instance attributes.

For quite some time, `create` has been an empty method that simply delegates to
`create_json`. This has been done for backward compatibility reasons. However, a
new release of NailGun that drops this backward compabibility may occur in the
near future, and Robottelo should be prepared. Use `create_json` instead of
`create`.

Sample test results against a downstream system and with a development version
of NailGun that drops backward compatibility:

    $ nosetests tests/foreman/api/test_{user,gpgkey}.py
    ...........................................
    ----------------------------------------------------------------------
    Ran 43 tests in 61.375s

    OK
    $ nosetests tests/foreman/smoke/test_api_smoke.py -m test_smoke
    .
    ----------------------------------------------------------------------
    Ran 1 test in 86.616s

    OK