### PR TITLE
Update test that synchronizes Docker-based repository closes #2058

### DIFF
--- a/tests/foreman/cli/test_repository.py
+++ b/tests/foreman/cli/test_repository.py
@@ -497,7 +497,7 @@ class TestRepository(CLITestCase):
         """
 
         new_repo = self._make_repository({
-            u'name': u'busybox',
+            u'docker-upstream-name': u'busybox',
             u'url': DOCKER_REGISTRY_HUB,
             u'content-type': u'docker',
         })


### PR DESCRIPTION
Updated argument to docker_upstream_name for creating a repository on docker.