### PR TITLE
Add CLI test for ConfigTemplate-Organization association - issue #1302

### DIFF
--- a/tests/foreman/api/test_config_template.py
+++ b/tests/foreman/api/test_config_template.py
@@ -30,3 +30,57 @@ class ConfigTemplateTestCase(APITestCase):
         )
         response.raise_for_status()
         self.assertIsInstance(response.json(), dict)
+
+    def test_associate_config_template_with_organization(self):
+        """@Test: Associate config template with organization
+
+        @Assert: Config template is associated with organization
+
+        @Feature: ConfigTemplate
+
+        """
+        org_1 = entities.Organization().create()
+        org_2 = entities.Organization().create()
+
+        # By default, a configuration template should have no organizations.
+        conf_templ = entities.ConfigTemplate().create()
+        self.assertEqual(0, len(conf_templ.organization))
+
+        # Associate our configuration template with one organization.
+        client.put(
+            conf_templ.path(),
+            {'config_template': {'organization_ids': [org_1.id]}},
+            verify=False,
+            auth=get_server_credentials(),
+        ).raise_for_status()
+
+        # Verify that the association succeeded.
+        conf_templ = conf_templ.read()
+        self.assertEqual(1, len(conf_templ.organization))
+        self.assertEqual(org_1.id, conf_templ.organization[0].id)
+
+        # Associate our configuration template with two organizations.
+        client.put(
+            conf_templ.path(),
+            {'config_template': {'organization_ids': [org_1.id, org_2.id]}},
+            verify=False,
+            auth=get_server_credentials(),
+        ).raise_for_status()
+
+        # Verify that the association succeeded.
+        conf_templ = conf_templ.read()
+        self.assertEqual(2, len(conf_templ.organization))
+        for org in conf_templ.organization:
+            self.assertIn(org.id, (org_1.id, org_2.id))
+
+        # Finally, associate our config template with zero organizations.
+        client.put(
+            conf_templ.path(),
+            {'config_template': {'organization_ids': []}},
+            verify=False,
+            auth=get_server_credentials(),
+        ).raise_for_status()
+
+        # Verify that the association succeeded.
+        conf_templ = conf_templ.read()
+        self.assertEqual(conf_templ.organization, [])


### PR DESCRIPTION
Added CLI test to check ConfigTemplate-Organization association.
Test checks if no organizations are associated with ConfigTemplate
by default, whether it's possible to associate 1 organization,
multiple organizations or no organizations (remove all existing associations).
Resolves #1302
Test results:
```
$ nosetests tests/foreman/api/test_config_template.py -m test_associate_config_template_with_organization
.
----------------------------------------------------------------------
Ran 1 test in 13.352s

OK
```