### PR TITLE
Dependant bug ID changed closes #2037

### DIFF
--- a/tests/foreman/ui/test_syncplan.py
+++ b/tests/foreman/ui/test_syncplan.py
@@ -122,7 +122,7 @@ class Syncplan(UITestCase):
             saved_starttime = str(starttime_text).rpartition(':')[0]
             self.assertEqual(saved_starttime, starttime)
 
-    @skip_if_bug_open('bugzilla', 1131661)
+    @skip_if_bug_open('bugzilla', 1202811)
     def test_positive_create_3(self):
         """@Test: Create Sync plan with specified start date
 


### PR DESCRIPTION
Changed the dependant bug ID to 1202811 as the test is blocked due to the issue of start date differs before adding and after adding the sync plan. This bug is currently POST state.