### PR TITLE
Provide a default value for ComputeResource.url

### DIFF
--- a/robottelo/common/helpers.py
+++ b/robottelo/common/helpers.py
@@ -373,6 +373,7 @@ def configure_entities():
       ``robottelo.entity_mixins.Entity`` for more information on the effects of
       this.
     * Set ``nailgun.entities.GPGKey.content.default``.
+    * Try to set ``nailgun.entities.ComputeResource.url.default``.
 
     Emit a warning and do not set anything if no ``robottelo.properties``
     configuration file is available.
@@ -391,3 +392,9 @@ def configure_entities():
             'NailGun configuration profile labeled "default".'
         )
     entities.GPGKey.content.default = read_data_file(VALID_GPG_KEY_FILE)
+    # If neither `docker.internal_url` or `docker.external_url` are set, let
+    # NailGun try to provide a value.
+    if conf.properties.get('docker.internal_url', '') != '':
+        entities.ComputeResource.url.default = get_internal_docker_url()
+    elif conf.properties.get('docker.external_url', '') != '':
+        entities.ComputeResource.url.default = get_external_docker_url()


### PR DESCRIPTION
Set `ComputeResource.url.default` if either "docker.internal_url" or
"docker.external_url" is set in the configuration file. This makes it possible
to work with docker compute resources as part of the test suite.

This fix only works if module `robottelo` is imported before a docker compute
resource is created. To illustrate:

    >>> from nailgun import entities
    >>> hasattr(entities.ComputeResource.url, 'default')
    False

    >>> from nailgun.entities import ComputeResource
    >>> hasattr(ComputeResource.url, 'default')
    False

    >>> import robottelo
    >>> from nailgun import entities
    >>> hasattr(entities.ComputeResource.url, 'default')
    True

    >>> import robottelo
    >>> from nailgun.entities import ComputeResource
    >>> hasattr(ComputeResource.url, 'default')
    True

This is a bit of a hack, and it will not work well in all cases. This works
because Robottelo only currently creates libvirt and docker compute resources,
and the `url` attribute has no apparent effect when creating a libvirt compute
resource. A longer-term solution is to make `ComputeResource` a base class and
have subclasses such as `LibvirtComputeResource` and `DockerComputeResource`. It
will then be possible to set `DockerComputeResource.url.default` and not affect
all types of compute resources managed by the test suite.