### PR TITLE
Fix version spec for nailgun in requirements file

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 # For all tests.
 ddt
 fauxfactory
-nailgun~=0.8.0
+nailgun==0.8.1
 python-bugzilla
 
 # For API tests.


### PR DESCRIPTION
Even though pip documentation [1] states that it support requirements
specifiers as implemented in pkg_resources [2] it fails when find the
`~=` comparison operator. Using `>=` comparison operator in order to
avoid breaking jenkins jobs due to requirements resolution.

Facing the below exception:

```
ValueError: ('Expected version spec in', 'nailgun~=0.8.0', 'at', '~=0.8.0')
```

[1]
https://pip.pypa.io/en/stable/reference/pip_install.html#requirement-specifiers
[2]
https://pythonhosted.org/setuptools/pkg_resources.html#requirement-objects