### PR TITLE
Add CLI test for proxy refresh-features - issue #1729

### DIFF
--- a/robottelo/cli/proxy.py
+++ b/robottelo/cli/proxy.py
@@ -74,3 +74,9 @@ class Proxy(Base):
         """Import puppet classes from puppet proxy."""
         cls.command_sub = 'import-classes'
         return cls.execute(cls._construct_command(options))
+
+    @classmethod
+    def refresh_features(cls, options=None):
+        """Refreshes smart proxy features"""
+        cls.command_sub = 'refresh-features'
+        return cls.execute(cls._construct_command(options))

--- a/tests/foreman/cli/test_proxy.py
+++ b/tests/foreman/cli/test_proxy.py
@@ -157,3 +157,33 @@ class TestProxy(CLITestCase):
             data['update'],
             "Proxy name should be updated"
         )
+
+    def test_proxy_refresh_features_by_id(self):
+        """@Test: Refresh smart proxy features, search for proxy by id
+
+        @Feature: Smart Proxy
+
+        @Assert: Proxy features are refreshed
+
+        """
+        try:
+            proxy = make_proxy()
+        except CLIFactoryError as err:
+            self.fail(err)
+        result = Proxy.refresh_features({u'id': proxy['id']})
+        self.assertEqual(result.return_code, 0)
+
+    def test_proxy_refresh_features_by_name(self):
+        """@Test: Refresh smart proxy features, search for proxy by name
+
+        @Feature: Smart Proxy
+
+        @Assert: Proxy features are refreshed
+
+        """
+        try:
+            proxy = make_proxy()
+        except CLIFactoryError as err:
+            self.fail(err)
+        result = Proxy.refresh_features({u'name': proxy['name']})
+        self.assertEqual(result.return_code, 0)


### PR DESCRIPTION
Added 2 CLI tests for proxy refresh-features command -
one to search for proxy by ID and one to search by name.
Resolves #1729
```
hammer proxy refresh-features --help

Usage:
    hammer proxy refresh-features [OPTIONS]

Options:
 --id ID                        
 --name NAME                   Name to search by
 -h, --help                    print help
```
No tests results here, as all proxy tests are ~~failed~~ skipped in the set up section. After commenting set up section and manually specifying proxy id (as factory.make_proxy() doesn't work too) tests are passing.