### PR TITLE
Fixed issue #2101, Minor type issue.

### DIFF
--- a/tests/foreman/cli/test_model.py
+++ b/tests/foreman/cli/test_model.py
@@ -36,7 +36,7 @@ class TestModel(MetaCLITestCase):
         @Assert: Model is created with specific vendor class
 
         """
-        vendor_class = gen_string('utf8'),
+        vendor_class = gen_string('utf8')
         model = make_model({'vendor-class': vendor_class})
         self.assertEqual(model['vendor-class'], vendor_class)
 


### PR DESCRIPTION
Fixed minor type issue. Adding a comma(,) at the end of variable(vendor_class) value changed the type to tuple. For which the test case was failing. Removed the comma to make it string.