### PR TITLE
Add CLI test for unlimited-content-hosts parameter in make_host_collection

### DIFF
--- a/tests/foreman/cli/test_host_collection.py
+++ b/tests/foreman/cli/test_host_collection.py
@@ -134,6 +134,38 @@ class TestHostCollection(CLITestCase):
         # Assert that limit matches data passed
         self.assertEqual(new_host_col['max-content-hosts'], str(test_data))
 
+    @skip_if_bug_open('bugzilla', 1214675)
+    @data(u'True', u'Yes', 1, u'False', u'No', 0)
+    def test_create_hc_with_unlimited_content_hosts(self, unlimited):
+        """@Test: Create Host Collection with different values of
+        unlimited-content-hosts parameter
+
+        @Feature: Host Collection - Unlimited Content Hosts
+
+        @Assert: Host Collection is created and unlimited-content-hosts
+        parameter is set
+
+        @BZ: 1214675
+
+        """
+        try:
+            host_collection = make_host_collection({
+                u'organization-id': self.org['id'],
+                u'unlimited-content-hosts': unlimited,
+            })
+        except CLIFactoryError as err:
+            self.fail(err)
+        result = HostCollection.info({
+            u'id': host_collection['id'],
+            u'organization-id': self.org['id'],
+        })
+        if unlimited in (u'True', u'Yes', 1):
+            self.assertEqual(
+                result.stdout['unlimited-content-hosts'], u'true')
+        else:
+            self.assertEqual(
+                result.stdout['unlimited-content-hosts'], u'false')
+
     @data(
         {'name': gen_string('alpha', 300)},
         {'name': gen_string('alphanumeric', 300)},


### PR DESCRIPTION
Added CLI test for unlimited-content-hosts parameter in 
factory.make_host_collection:
```
 --unlimited-content-hosts UNLIMITED_CONTENT_HOSTS Whether or not the host collection may have unlimited content hosts
                                                   One of true/false, yes/no, 1/0.
```
Resolves #1713