### PR TITLE
Join all hammer output parsers in one module

### DIFF
--- a/robottelo/cli/base.py
+++ b/robottelo/cli/base.py
@@ -5,8 +5,8 @@ Generic base class for cli hammer commands
 
 import logging
 
+from robottelo.cli import hammer
 from robottelo.common import conf, ssh
-from robottelo.common.helpers import info_dictionary
 
 
 class CLIError(Exception):
@@ -230,11 +230,7 @@ class Base(object):
 
     @classmethod
     def info(cls, options=None):
-        """
-        Gets information by provided: options dictionary.
-        @param options: ID (sometimes name or id).
-        """
-
+        """Reads the entity information."""
         cls.command_sub = 'info'
 
         if options is None:
@@ -247,11 +243,8 @@ class Base(object):
             )
 
         result = cls.execute(cls._construct_command(options))
-
-        # info_dictionary required to convert result.stdout to dic format
-        updated_result = info_dictionary(result)
-
-        return updated_result
+        result.stdout = hammer.parse_info(result.stdout)
+        return result
 
     @classmethod
     def list(cls, options=None, per_page=True):

--- a/robottelo/cli/contentview.py
+++ b/robottelo/cli/contentview.py
@@ -32,8 +32,8 @@ Options::
     -h, --help                    print help
 """
 
+from robottelo.cli import hammer
 from robottelo.cli.base import Base
-from robottelo.common.helpers import info_dictionary
 
 
 class ContentView(Base):
@@ -75,10 +75,8 @@ class ContentView(Base):
             options = {}
 
         result = cls.execute(cls._construct_command(options))
-
-        # info_dictionary required to convert result.stdout
-        # to dictionary format
-        return info_dictionary(result)
+        result.stdout = hammer.parse_info(result.stdout)
+        return result
 
     @classmethod
     def puppet_module_add(cls, options):
@@ -96,10 +94,8 @@ class ContentView(Base):
             options = {}
 
         result = cls.execute(cls._construct_command(options))
-
-        # info_dictionary required to convert result.stdout
-        # to dictionary format
-        return info_dictionary(result)
+        result.stdout = hammer.parse_info(result.stdout)
+        return result
 
     @classmethod
     def filter_info(cls, options):
@@ -111,10 +107,8 @@ class ContentView(Base):
             options = {}
 
         result = cls.execute(cls._construct_command(options))
-
-        # info_dictionary required to convert result.stdout
-        # to dictionary format
-        return info_dictionary(result)
+        result.stdout = hammer.parse_info(result.stdout)
+        return result
 
     @classmethod
     def filter_create(cls, options):

--- a/robottelo/cli/hammer.py
+++ b/robottelo/cli/hammer.py
@@ -1,0 +1,165 @@
+"""Helpers to interact with hammer command line utility."""
+import re
+
+from itertools import izip
+
+
+def parse_csv(output):
+    """Parse CSV output from Hammer CLI and convert it to python dictionary."""
+    result = []
+    # Generate the key names, spaces will be converted to dashes "-"
+    keys = [
+        header.replace(' ', '-').lower() for header in output.pop(0).split(',')
+    ]
+
+    # For each entry, split the values and create a dict mapping each key with
+    # each value
+    for line in output:
+        if len(line) > 0:
+            result.append(dict(izip(keys, line.split(','))))
+
+    return result
+
+
+def parse_help(output):
+    """Parse the help output from a hammer command and return a dictionary
+    mapping the subcommands and options accepted by that command.
+
+    """
+    # Parsing states
+    state = 0
+    subcommands_section_state = 1
+    options_section_state = 2
+
+    contents = {
+        'subcommands': [],
+        'options': [],
+    }
+    option_regex = re.compile(
+        r'^ (-(?P<shortname>\w), )?(--(?P<name>[\w-]+))?( (?P<value>\w+))?\s+'
+        '(?P<help>.*)$'
+    )
+    subcommand_regex = re.compile(
+        r'^ (?P<name>[\w-]+)?\s+(?P<description>.*)$'
+    )
+
+    for line in output:
+        if len(line.strip()) == 0:
+            continue
+        if line.startswith('Subcommands:'):
+            state = subcommands_section_state
+            continue
+        if line.startswith('Options:'):
+            state = options_section_state
+            continue
+
+        if state == subcommands_section_state:
+            match = subcommand_regex.search(line)
+            if match is None:
+                continue
+            if match.group('name') is None:
+                contents['subcommands'][-1]['description'] += (
+                    ' {0}'.format(match.group('description'))
+                )
+            else:
+                contents['subcommands'].append({
+                    u'name': match.group('name'),
+                    u'description': match.group('description'),
+                })
+        if state == options_section_state:
+            match = option_regex.search(line)
+            if match is None:
+                continue
+            if match.group('name') is None:
+                contents['options'][-1]['help'] += (
+                    ' {0}'.format(match.group('help'))
+                )
+            else:
+                contents['options'].append({
+                    u'name': match.group('name'),
+                    u'shortname': match.group('shortname'),
+                    u'value': match.group('value'),
+                    u'help': match.group('help'),
+                })
+
+    return contents
+
+
+def parse_info(output):
+    """Parse the info output and returns a dict mapping the values."""
+    # info dictionary
+    contents = {}
+    sub_prop = None  # stores name of the last group of sub-properties
+    sub_num = None  # is not None when list of properties
+
+    for line in output:
+        # skip empty lines
+        if line == '':
+            continue
+        if line.startswith(' '):  # sub-properties are indented
+            # values are separated by ':' or '=>'
+            if line.find(':') != -1:
+                key, value = line.lstrip().split(":", 1)
+            elif line.find('=>') != -1:
+                key, value = line.lstrip().split(" =>", 1)
+            else:
+                key = value = None
+
+            if key is None and value is None:
+                # Parse single attribute collection properties
+                # Template
+                #  1) template1
+                #  2) template2
+                #
+                # or
+                # Template
+                #  template1
+                #  template2
+                match = re.match(r'\d+\)\s+(.+)$', line.lstrip())
+
+                if match is None:
+                    match = re.match(r'(.*)$', line.lstrip())
+
+                value = match.group(1)
+
+                if isinstance(contents[sub_prop], dict):
+                    contents[sub_prop] = []
+
+                contents[sub_prop].append(value)
+            else:
+                # some properties have many numbered values
+                # Example:
+                # Content:
+                #  1) Repo Name: repo1
+                #     URL:       /custom/4f84fc90-9ffa-...
+                #  2) Repo Name: puppet1
+                #     URL:       /custom/4f84fc90-9ffa-...
+                starts_with_number = re.match(r'(\d+)\)', key)
+                if starts_with_number:
+                    sub_num = int(starts_with_number.group(1))
+                    # no. 1) we need to change dict() to list()
+                    if sub_num == 1:
+                        contents[sub_prop] = []
+                    # remove number from key
+                    key = re.sub(r'\d+\)', '', key)
+                    # append empty dict to array
+                    contents[sub_prop].append({})
+
+                key = key.lstrip().replace(' ', '-').lower()
+
+                # add value to dictionary
+                if sub_num is not None:
+                    contents[sub_prop][-1][key] = value.lstrip()
+                else:
+                    contents[sub_prop][key] = value.lstrip()
+        else:
+            sub_num = None  # new property implies no sub property
+            key, value = line.lstrip().split(":", 1)
+            key = key.lstrip().replace(' ', '-').lower()
+            if value.lstrip() == '':  # 'key:' no value, new sub-property
+                sub_prop = key
+                contents[sub_prop] = {}
+            else:  # 'key: value' line
+                contents[key] = value.lstrip()
+
+    return contents

--- a/robottelo/common/ssh.py
+++ b/robottelo/common/ssh.py
@@ -1,21 +1,12 @@
-"""
-Utility module to handle the shared ssh connection
-"""
-
+"""Utility module to handle the shared ssh connection."""
 import json
 import logging
+import paramiko
 import re
-import sys
 
 from contextlib import contextmanager
+from robottelo.cli import hammer
 from robottelo.common import conf
-from robottelo.common.helpers import csv_to_dictionary
-
-try:
-    import paramiko
-except ImportError:
-    print "Please install paramiko."
-    sys.exit(-1)
 
 logger = logging.getLogger(__name__)
 
@@ -32,7 +23,7 @@ class SSHCommandResult(object):
         #  Does not make sense to return suspicious output if ($? <> 0)
         if output_format and self.return_code == 0:
             if output_format == 'csv':
-                self.stdout = csv_to_dictionary(stdout) if stdout else {}
+                self.stdout = hammer.parse_csv(stdout) if stdout else {}
             if output_format == 'json':
                 self.stdout = json.loads(stdout) if stdout else None
 

--- a/tests/robottelo/test_hammer.py
+++ b/tests/robottelo/test_hammer.py
@@ -1,0 +1,273 @@
+"""Tests for Robottelo's hammer helpers"""
+import unittest
+
+from robottelo.cli import hammer
+
+
+class ParseCSVTestCase(unittest.TestCase):
+    """Tests for parsing CSV hammer output"""
+    def test_parse_csv(self):
+        output_lines = [
+            'Header,Header with spaces',
+            'header value 1,header with spaces value',
+            'MixEd CaSe ValUe,ALL CAPS VALUE',
+        ]
+        self.assertEqual(
+            hammer.parse_csv(output_lines),
+            [
+                {
+                    'header': 'header value 1',
+                    'header-with-spaces': 'header with spaces value',
+                },
+                {
+                    'header': 'MixEd CaSe ValUe',
+                    'header-with-spaces': 'ALL CAPS VALUE',
+                },
+            ]
+        )
+
+
+class ParseHelpTestCase(unittest.TestCase):
+    """Tests for parsing hammer help output"""
+    def test_parse_help(self):
+        """Can parse hammer help output"""
+        self.maxDiff = None
+        output = [
+            'Usage:',
+            '    hammer [OPTIONS] SUBCOMMAND [ARG] ...',
+            '',
+            'Parameters:',
+            'SUBCOMMAND                    subcommand',
+            '[ARG] ...                     subcommand arguments',
+            '',
+            'Subcommands:',
+            ' activation-key                Manipulate activation keys.',
+            ' capsule                       Manipulate capsule',
+            ' compute-resource              Manipulate compute resources.',
+            ' content-host                  Manipulate content hosts on the',
+            '                               server',
+            ' gpg                           Manipulate GPG Key actions on the',
+            '                               server',
+
+            'Options:',
+            ' --autocomplete LINE           Get list of possible endings',
+            ' --csv                         Output as CSV (same as',
+            '                               --output=csv)',
+            ' --csv-separator SEPARATOR     Character to separate the values',
+            ' --output ADAPTER              Set output format. One of [base,',
+            '                               table, silent, csv, yaml, json]',
+            ' -p, --password PASSWORD       password to access the remote',
+            '                               system',
+            ' -r, --reload-cache            force reload of Apipie cache',
+        ]
+        self.assertEqual(
+            hammer.parse_help(output),
+            {
+                'subcommands': [
+                    {
+                        'name': 'activation-key',
+                        'description': 'Manipulate activation keys.',
+                    },
+                    {
+                        'name': 'capsule',
+                        'description': 'Manipulate capsule',
+                    },
+                    {
+                        'name': 'compute-resource',
+                        'description': 'Manipulate compute resources.',
+                    },
+                    {
+                        'name': 'content-host',
+                        'description': (
+                            'Manipulate content hosts on the server'
+                        ),
+                    },
+                    {
+                        'name': 'gpg',
+                        'description': (
+                            'Manipulate GPG Key actions on the server'
+                        ),
+                    },
+                ],
+                'options': [
+                    {
+                        'name': 'autocomplete',
+                        'shortname': None,
+                        'value': 'LINE',
+                        'help': 'Get list of possible endings',
+                    },
+                    {
+                        'name': 'csv',
+                        'shortname': None,
+                        'value': None,
+                        'help': 'Output as CSV (same as --output=csv)',
+                    },
+                    {
+                        'name': 'csv-separator',
+                        'shortname': None,
+                        'value': 'SEPARATOR',
+                        'help': 'Character to separate the values',
+                    },
+                    {
+                        'name': 'output',
+                        'shortname': None,
+                        'value': 'ADAPTER',
+                        'help': (
+                            'Set output format. One of [base, table, silent, '
+                            'csv, yaml, json]'
+                        ),
+                    },
+                    {
+                        'name': 'password',
+                        'shortname': 'p',
+                        'value': 'PASSWORD',
+                        'help': 'password to access the remote system',
+                    },
+                    {
+                        'name': 'reload-cache',
+                        'shortname': 'r',
+                        'value': None,
+                        'help': 'force reload of Apipie cache',
+                    },
+                ],
+            }
+        )
+
+
+class ParseInfoTestCase(unittest.TestCase):
+    """Tests for parsing info hammer output"""
+    def test_parse_simple(self):
+        """Can parse a simple info output"""
+        output = [
+            'Id:                 19',
+            'Full name:          4iv01o2u 10.5',
+            'Release name:',
+            '',
+            'Family:',
+            'Name:               4iv01o2u',
+            'Major version:      10',
+            'Minor version:      5',
+        ]
+        self.assertDictEqual(
+            hammer.parse_info(output),
+            {
+                'id': '19',
+                'full-name': '4iv01o2u 10.5',
+                'release-name': {},
+                'family': {},
+                'name': '4iv01o2u',
+                'major-version': '10',
+                'minor-version': '5',
+            }
+        )
+
+    def test_parse_numbered_list_attributes(self):
+        """Can parse numbered list attributes"""
+        output = [
+            'Partition tables:',
+            ' 1) ptable1',
+            ' 2) ptable2',
+            ' 3) ptable3',
+            ' 4) ptable4',
+        ]
+        self.assertDictEqual(
+            hammer.parse_info(output),
+            {
+                'partition-tables': [
+                    'ptable1',
+                    'ptable2',
+                    'ptable3',
+                    'ptable4',
+                ],
+            }
+        )
+
+    def test_parse_list_attributes(self):
+        """Can parse list attributes"""
+        output = [
+            'Partition tables:',
+            ' ptable1',
+            ' ptable2',
+            ' ptable3',
+            ' ptable4',
+        ]
+        self.assertDictEqual(
+            hammer.parse_info(output),
+            {
+                'partition-tables': [
+                    'ptable1',
+                    'ptable2',
+                    'ptable3',
+                    'ptable4',
+                ],
+            }
+        )
+
+    def test_parse_dict_attributes(self):
+        """Can parse dict attributes"""
+        output = [
+            'Content:',
+            ' 1) Repo Name: repo1',
+            '    URL:       /custom/url1',
+            ' 2) Repo Name: repo2',
+            '    URL:       /custom/url2',
+        ]
+        self.assertDictEqual(
+            hammer.parse_info(output),
+            {
+                'content': [
+                    {
+                        'repo-name': 'repo1',
+                        'url': '/custom/url1',
+                    },
+                    {
+                        'repo-name': 'repo2',
+                        'url': '/custom/url2',
+                    }
+                ],
+            }
+        )
+
+    def test_parse_info(self):
+        """Can parse info output"""
+        output = [
+            'Sync State:   not_synced',
+            'Sync Plan ID:',
+            'GPG:',
+            '    GPG Key ID: 1',
+            '    GPG Key: key name',
+            'Organizations:',
+            '    1) Org 1',
+            '    2) Org 2',
+            'Locations:',
+            '    Loc 1',
+            '    Loc 2',
+            'Repositories:',
+            ' 1) Repo Name: repo1',
+            '    Repo ID:   10',
+            ' 2) Repo Name: repo2',
+            '    Repo ID:   20',
+        ]
+        self.assertEqual(
+            hammer.parse_info(output),
+            {
+                'sync-state': 'not_synced',
+                'sync-plan-id': {},
+                'gpg': {
+                    'gpg-key-id': '1',
+                    'gpg-key': 'key name'
+                },
+                'organizations': [
+                    'Org 1',
+                    'Org 2',
+                ],
+                'locations': [
+                    'Loc 1',
+                    'Loc 2',
+                ],
+                'repositories': [
+                    {'repo-id': '10', 'repo-name': 'repo1'},
+                    {'repo-id': '20', 'repo-name': 'repo2'},
+                ],
+            }
+        )

--- a/tests/robottelo/test_helpers.py
+++ b/tests/robottelo/test_helpers.py
@@ -1,11 +1,16 @@
 """Tests for module ``robottelo.common.helpers``."""
 # (Too many public methods) pylint: disable=R0904
 import unittest
+
 from robottelo.common import conf
 from robottelo.common.helpers import (
-    escape_search, generate_strings_list, get_server_url,
-    get_server_credentials, info_dictionary, invalid_names_list,
-    valid_data_list, valid_names_list,
+    escape_search,
+    generate_strings_list,
+    get_server_credentials,
+    get_server_url,
+    invalid_names_list,
+    valid_data_list,
+    valid_names_list,
 )
 
 
@@ -166,90 +171,3 @@ class EscapeSearchTestCase(unittest.TestCase):
         term = escape_search('term')
         self.assertEqual(term[0], '"')
         self.assertEqual(term[-1], '"')
-
-
-class InfoDictionaryTestCase(unittest.TestCase):
-    def test_parse_simple(self):
-        """Can parse a simple info output"""
-        output = FakeSSHResult(stdout=[
-            'Id:                 19',
-            'Full name:          4iv01o2u 10.5',
-            'Release name:',
-            '',
-            'Family:',
-            'Name:               4iv01o2u',
-            'Major version:      10',
-            'Minor version:      5',
-        ])
-
-        result = info_dictionary(output)
-        self.assertDictEqual(result.stdout, {
-            'id': '19',
-            'full-name': '4iv01o2u 10.5',
-            'release-name': {},
-            'family': {},
-            'name': '4iv01o2u',
-            'major-version': '10',
-            'minor-version': '5',
-        })
-
-    def test_parse_numbered_list_attributes(self):
-        """Can parse numbered list attributes"""
-        output = FakeSSHResult(stdout=[
-            'Partition tables:',
-            ' 1) ptable1',
-            ' 2) ptable2',
-            ' 3) ptable3',
-            ' 4) ptable4',
-        ])
-
-        result = info_dictionary(output)
-        self.assertDictEqual(result.stdout, {
-            'partition-tables': [
-                'ptable1',
-                'ptable2',
-                'ptable3',
-                'ptable4',
-            ],
-        })
-
-    def test_parse_list_attributes(self):
-        """Can parse list attributes"""
-        output = FakeSSHResult(stdout=[
-            'Partition tables:',
-            ' ptable1',
-            ' ptable2',
-            ' ptable3',
-            ' ptable4',
-        ])
-
-        result = info_dictionary(output)
-        self.assertDictEqual(result.stdout, {
-            'partition-tables': [
-                'ptable1',
-                'ptable2',
-                'ptable3',
-                'ptable4',
-            ],
-        })
-
-    def test_parse_dict_attributes(self):
-        """Can parse dict attributes"""
-        output = FakeSSHResult(stdout=[
-            'Content:',
-            ' 1) Repo Name: repo1',
-            '    URL:       /custom/url1',
-            ' 2) Repo Name: repo2',
-            '    URL:       /custom/url2',
-        ])
-
-        result = info_dictionary(output)
-        self.assertDictEqual(result.stdout, {
-            'content': [{
-                'repo-name': 'repo1',
-                'url': '/custom/url1',
-            }, {
-                'repo-name': 'repo2',
-                'url': '/custom/url2',
-            }],
-        })


### PR DESCRIPTION
Move hammer output parsers from the common.helpers module to cli.hammer
module and add a new parse for help output. Also add and update tests
for the new changes.

The parser for help output will help implement #1862.