### PR TITLE
Add test for checking all hammer subcommands

### DIFF
--- a/tests/foreman/cli/test_hammer.py
+++ b/tests/foreman/cli/test_hammer.py
@@ -1,0 +1,82 @@
+"""Tests related to hammer command and its options and subcommands."""
+import json
+
+from robottelo.cli import hammer
+from robottelo.common import ssh
+from robottelo.common.helpers import read_data_file
+from robottelo.test import CLITestCase
+
+HAMMER_COMMANDS = json.loads(read_data_file('hammer_commands.json'))
+
+
+class HammerCommandsTestCase(CLITestCase):
+    """Tests for ensuring that  all expected hammer subcommands and its options
+    are present.
+
+    """
+    def _fetch_command_info(self, command):
+        """Fetch command info from expected commands info dictionary."""
+        info = HAMMER_COMMANDS
+        if command != 'hammer':
+            found = False
+            parts = command.split(' ')[1:]  # exclude hammer
+            for part in parts:
+                for command in info['subcommands']:
+                    if command['name'] == part:
+                        info = command
+                        found = True
+                        break
+            if not found:
+                self.fail(
+                    'Was not possible to fetch information for "{0}" command.'
+                    .format(command)
+                )
+        return info
+
+    def _traverse_command_tree(self, command):
+        """Recursively walk through the hammer commands tree and assert that
+        the expected options are present.
+
+        """
+        output = hammer.parse_help(
+            ssh.command('{0} --help'.format(command)).stdout
+        )
+        info = self._fetch_command_info(command)
+        for option in output['options']:
+            if (command == 'hammer sync-plan create' and
+                    option['name'] == 'sync-date'):
+                # sync-date option use the current server time as the default
+                # value in help text. As we use a previous created json file
+                # with the commands information we need a special treatment for
+                # this option.
+                info_option = None
+                for opt in info['options']:
+                    if opt['name'] == 'sync-date':
+                        info_option = opt
+                        break
+                self.assertIsNotNone(info_option)
+                self.assertEqual(option['name'], opt['name'])
+                self.assertEqual(option['shortname'], opt['shortname'])
+                self.assertEqual(option['value'], opt['value'])
+                # Drop the default value, and assert if the remaining string is
+                # present on the help text.
+                help = option['help'][:option['help'].find('Default: "')]
+                self.assertIn(help, opt['help'])
+            else:
+                self.assertIn(option, info['options'])
+        if len(info['subcommands']) > 0:
+            for subcommand in info['subcommands']:
+                self._traverse_command_tree(
+                    '{0} {1}'.format(command, subcommand['name'])
+                )
+
+    def test_hammer_options(self):
+        """@Test: check all provided options for every hammer command
+
+        @Feature: Hammer
+
+        @Assert: All expected options are present
+
+        """
+        self.maxDiff = None
+        self._traverse_command_tree('hammer')

--- a/tests/foreman/data/hammer_commands.json
+++ b/tests/foreman/data/hammer_commands.json
@@ -1,0 +1,21717 @@
+{
+  "options": [
+    {
+      "help": "Get list of possible endings",
+      "name": "autocomplete",
+      "shortname": null,
+      "value": "LINE"
+    },
+    {
+      "help": "Output as CSV (same as --output=csv)",
+      "name": "csv",
+      "shortname": null,
+      "value": null
+    },
+    {
+      "help": "Character to separate the values",
+      "name": "csv-separator",
+      "shortname": null,
+      "value": "SEPARATOR"
+    },
+    {
+      "help": "Explicitly turn interactive mode on/off One of true/false, yes/no, 1/0.",
+      "name": "interactive",
+      "shortname": null,
+      "value": "INTERACTIVE"
+    },
+    {
+      "help": "Set output format. One of [base, table, silent, csv, yaml, json]",
+      "name": "output",
+      "shortname": null,
+      "value": "ADAPTER"
+    },
+    {
+      "help": "Show ids of associated resources",
+      "name": "show-ids",
+      "shortname": null,
+      "value": null
+    },
+    {
+      "help": "show version",
+      "name": "version",
+      "shortname": null,
+      "value": null
+    },
+    {
+      "help": "path to custom config file",
+      "name": "config",
+      "shortname": "c",
+      "value": "CFG_FILE"
+    },
+    {
+      "help": "show debugging output",
+      "name": "debug",
+      "shortname": "d",
+      "value": null
+    },
+    {
+      "help": "print help",
+      "name": "help",
+      "shortname": "h",
+      "value": null
+    },
+    {
+      "help": "password to access the remote system",
+      "name": "password",
+      "shortname": "p",
+      "value": "PASSWORD"
+    },
+    {
+      "help": "force reload of Apipie cache",
+      "name": "reload-cache",
+      "shortname": "r",
+      "value": null
+    },
+    {
+      "help": "remote system address",
+      "name": "server",
+      "shortname": "s",
+      "value": "SERVER"
+    },
+    {
+      "help": "username to access the remote system",
+      "name": "username",
+      "shortname": "u",
+      "value": "USERNAME"
+    },
+    {
+      "help": "be verbose",
+      "name": "verbose",
+      "shortname": "v",
+      "value": null
+    }
+  ],
+  "subcommands": [
+    {
+      "description": "Manipulate activation keys.",
+      "name": "activation-key",
+      "options": [
+        {
+          "help": "print help",
+          "name": "help",
+          "shortname": "h",
+          "value": null
+        }
+      ],
+      "subcommands": [
+        {
+          "description": "Associate a resource",
+          "name": "add-host-collection",
+          "options": [
+            {
+              "help": "Host collection name to search by",
+              "name": "host-collection",
+              "shortname": null,
+              "value": "HOST_COLLECTION_NAME"
+            },
+            {
+              "help": "Id of the host collection",
+              "name": "host-collection-id",
+              "shortname": null,
+              "value": "HOST_COLLECTION_ID"
+            },
+            {
+              "help": "ID of the activation key",
+              "name": "id",
+              "shortname": null,
+              "value": "ID"
+            },
+            {
+              "help": "Activation key name to search by",
+              "name": "name",
+              "shortname": null,
+              "value": "NAME"
+            },
+            {
+              "help": "Organization name to search by",
+              "name": "organization",
+              "shortname": null,
+              "value": "ORGANIZATION_NAME"
+            },
+            {
+              "help": "organization ID",
+              "name": "organization-id",
+              "shortname": null,
+              "value": "ORGANIZATION_ID"
+            },
+            {
+              "help": "Organization label to search by",
+              "name": "organization-label",
+              "shortname": null,
+              "value": "ORGANIZATION_LABEL"
+            },
+            {
+              "help": "print help",
+              "name": "help",
+              "shortname": "h",
+              "value": null
+            }
+          ],
+          "subcommands": []
+        },
+        {
+          "description": "Add subscription",
+          "name": "add-subscription",
+          "options": [
+            {
+              "help": "ID of the activation key",
+              "name": "id",
+              "shortname": null,
+              "value": "ID"
+            },
+            {
+              "help": "Activation key name to search by",
+              "name": "name",
+              "shortname": null,
+              "value": "NAME"
+            },
+            {
+              "help": "Organization name to search by",
+              "name": "organization",
+              "shortname": null,
+              "value": "ORGANIZATION_NAME"
+            },
+            {
+              "help": "organization ID",
+              "name": "organization-id",
+              "shortname": null,
+              "value": "ORGANIZATION_ID"
+            },
+            {
+              "help": "Organization label to search by",
+              "name": "organization-label",
+              "shortname": null,
+              "value": "ORGANIZATION_LABEL"
+            },
+            {
+              "help": "Quantity of this subscription to add",
+              "name": "quantity",
+              "shortname": null,
+              "value": "QUANTITY"
+            },
+            {
+              "help": "ID of subscription",
+              "name": "subscription-id",
+              "shortname": null,
+              "value": "SUBSCRIPTION_ID"
+            },
+            {
+              "help": "print help",
+              "name": "help",
+              "shortname": "h",
+              "value": null
+            }
+          ],
+          "subcommands": []
+        },
+        {
+          "description": "Override product content defaults",
+          "name": "content-override",
+          "options": [
+            {
+              "help": "Label of the content",
+              "name": "content-label",
+              "shortname": null,
+              "value": "CONTENT_LABEL"
+            },
+            {
+              "help": "ID of the activation key",
+              "name": "id",
+              "shortname": null,
+              "value": "ID"
+            },
+            {
+              "help": "Activation key name to search by",
+              "name": "name",
+              "shortname": null,
+              "value": "NAME"
+            },
+            {
+              "help": "Organization name to search by",
+              "name": "organization",
+              "shortname": null,
+              "value": "ORGANIZATION_NAME"
+            },
+            {
+              "help": "organization ID",
+              "name": "organization-id",
+              "shortname": null,
+              "value": "ORGANIZATION_ID"
+            },
+            {
+              "help": "Organization label to search by",
+              "name": "organization-label",
+              "shortname": null,
+              "value": "ORGANIZATION_LABEL"
+            },
+            {
+              "help": "Override to 0/1, or 'default'",
+              "name": "value",
+              "shortname": null,
+              "value": "VALUE"
+            },
+            {
+              "help": "print help",
+              "name": "help",
+              "shortname": "h",
+              "value": null
+            }
+          ],
+          "subcommands": []
+        },
+        {
+          "description": "Copy an activation key",
+          "name": "copy",
+          "options": [
+            {
+              "help": "ID of the activation key",
+              "name": "id",
+              "shortname": null,
+              "value": "ID"
+            },
+            {
+              "help": "Activation key name to search by",
+              "name": "name",
+              "shortname": null,
+              "value": "NAME"
+            },
+            {
+              "help": "Name of new activation key",
+              "name": "new-name",
+              "shortname": null,
+              "value": "NEW_NAME"
+            },
+            {
+              "help": "Organization name to search by",
+              "name": "organization",
+              "shortname": null,
+              "value": "ORGANIZATION_NAME"
+            },
+            {
+              "help": "organization ID",
+              "name": "organization-id",
+              "shortname": null,
+              "value": "ORGANIZATION_ID"
+            },
+            {
+              "help": "Organization label to search by",
+              "name": "organization-label",
+              "shortname": null,
+              "value": "ORGANIZATION_LABEL"
+            },
+            {
+              "help": "print help",
+              "name": "help",
+              "shortname": "h",
+              "value": null
+            }
+          ],
+          "subcommands": []
+        },
+        {
+          "description": "Create an activation key",
+          "name": "create",
+          "options": [
+            {
+              "help": "Content view name",
+              "name": "content-view",
+              "shortname": null,
+              "value": "CONTENT_VIEW_NAME"
+            },
+            {
+              "help": "content view numeric identifier",
+              "name": "content-view-id",
+              "shortname": null,
+              "value": "CONTENT_VIEW_ID"
+            },
+            {
+              "help": "description",
+              "name": "description",
+              "shortname": null,
+              "value": "DESCRIPTION"
+            },
+            {
+              "help": "Name to search by",
+              "name": "lifecycle-environment",
+              "shortname": null,
+              "value": "LIFECYCLE_ENVIRONMENT_NAME"
+            },
+            {
+              "help": "",
+              "name": "lifecycle-environment-id",
+              "shortname": null,
+              "value": "LIFECYCLE_ENVIRONMENT_ID"
+            },
+            {
+              "help": "maximum number of registered content hosts",
+              "name": "max-content-hosts",
+              "shortname": null,
+              "value": "MAX_CONTENT_HOSTS"
+            },
+            {
+              "help": "name",
+              "name": "name",
+              "shortname": null,
+              "value": "NAME"
+            },
+            {
+              "help": "Organization name to search by",
+              "name": "organization",
+              "shortname": null,
+              "value": "ORGANIZATION_NAME"
+            },
+            {
+              "help": "organization ID",
+              "name": "organization-id",
+              "shortname": null,
+              "value": "ORGANIZATION_ID"
+            },
+            {
+              "help": "Organization label to search by",
+              "name": "organization-label",
+              "shortname": null,
+              "value": "ORGANIZATION_LABEL"
+            },
+            {
+              "help": "can the activation key have unlimited content hosts One of true/false, yes/no, 1/0.",
+              "name": "unlimited-content-hosts",
+              "shortname": null,
+              "value": "UNLIMITED_CONTENT_HOSTS"
+            },
+            {
+              "help": "print help",
+              "name": "help",
+              "shortname": "h",
+              "value": null
+            }
+          ],
+          "subcommands": []
+        },
+        {
+          "description": "Destroy an activation key",
+          "name": "delete",
+          "options": [
+            {
+              "help": "ID of the activation key",
+              "name": "id",
+              "shortname": null,
+              "value": "ID"
+            },
+            {
+              "help": "Activation key name to search by",
+              "name": "name",
+              "shortname": null,
+              "value": "NAME"
+            },
+            {
+              "help": "Organization name to search by",
+              "name": "organization",
+              "shortname": null,
+              "value": "ORGANIZATION_NAME"
+            },
+            {
+              "help": "organization ID",
+              "name": "organization-id",
+              "shortname": null,
+              "value": "ORGANIZATION_ID"
+            },
+            {
+              "help": "Organization label to search by",
+              "name": "organization-label",
+              "shortname": null,
+              "value": "ORGANIZATION_LABEL"
+            },
+            {
+              "help": "print help",
+              "name": "help",
+              "shortname": "h",
+              "value": null
+            }
+          ],
+          "subcommands": []
+        },
+        {
+          "description": "List associated host collections",
+          "name": "host-collections",
+          "options": [
+            {
+              "help": "ID of activation key",
+              "name": "id",
+              "shortname": null,
+              "value": "ID"
+            },
+            {
+              "help": "Name of activation key",
+              "name": "name",
+              "shortname": null,
+              "value": "NAME"
+            },
+            {
+              "help": "Organization name to search by",
+              "name": "organization",
+              "shortname": null,
+              "value": "ORGANIZATION_NAME"
+            },
+            {
+              "help": "organization ID",
+              "name": "organization-id",
+              "shortname": null,
+              "value": "ORGANIZATION_ID"
+            },
+            {
+              "help": "Organization label to search by",
+              "name": "organization-label",
+              "shortname": null,
+              "value": "ORGANIZATION_LABEL"
+            },
+            {
+              "help": "print help",
+              "name": "help",
+              "shortname": "h",
+              "value": null
+            }
+          ],
+          "subcommands": []
+        },
+        {
+          "description": "Show an activation key",
+          "name": "info",
+          "options": [
+            {
+              "help": "ID of the activation key",
+              "name": "id",
+              "shortname": null,
+              "value": "ID"
+            },
+            {
+              "help": "Activation key name to search by",
+              "name": "name",
+              "shortname": null,
+              "value": "NAME"
+            },
+            {
+              "help": "Organization name to search by",
+              "name": "organization",
+              "shortname": null,
+              "value": "ORGANIZATION_NAME"
+            },
+            {
+              "help": "organization ID",
+              "name": "organization-id",
+              "shortname": null,
+              "value": "ORGANIZATION_ID"
+            },
+            {
+              "help": "Organization label to search by",
+              "name": "organization-label",
+              "shortname": null,
+              "value": "ORGANIZATION_LABEL"
+            },
+            {
+              "help": "print help",
+              "name": "help",
+              "shortname": "h",
+              "value": null
+            }
+          ],
+          "subcommands": []
+        },
+        {
+          "description": "List activation keys",
+          "name": "list",
+          "options": [
+            {
+              "help": "Field to sort the results on",
+              "name": "by",
+              "shortname": null,
+              "value": "BY"
+            },
+            {
+              "help": "Content view name",
+              "name": "content-view",
+              "shortname": null,
+              "value": "CONTENT_VIEW_NAME"
+            },
+            {
+              "help": "content view numeric identifier",
+              "name": "content-view-id",
+              "shortname": null,
+              "value": "CONTENT_VIEW_ID"
+            },
+            {
+              "help": "Whether or not to show all results One of true/false, yes/no, 1/0.",
+              "name": "full-results",
+              "shortname": null,
+              "value": "FULL_RESULTS"
+            },
+            {
+              "help": "Name to search by",
+              "name": "lifecycle-environment",
+              "shortname": null,
+              "value": "LIFECYCLE_ENVIRONMENT_NAME"
+            },
+            {
+              "help": "",
+              "name": "lifecycle-environment-id",
+              "shortname": null,
+              "value": "LIFECYCLE_ENVIRONMENT_ID"
+            },
+            {
+              "help": "activation key name to filter by",
+              "name": "name",
+              "shortname": null,
+              "value": "NAME"
+            },
+            {
+              "help": "Sort field and order, eg. 'name DESC'",
+              "name": "order",
+              "shortname": null,
+              "value": "ORDER"
+            },
+            {
+              "help": "Organization name to search by",
+              "name": "organization",
+              "shortname": null,
+              "value": "ORGANIZATION_NAME"
+            },
+            {
+              "help": "organization ID",
+              "name": "organization-id",
+              "shortname": null,
+              "value": "ORGANIZATION_ID"
+            },
+            {
+              "help": "Organization label to search by",
+              "name": "organization-label",
+              "shortname": null,
+              "value": "ORGANIZATION_LABEL"
+            },
+            {
+              "help": "Page number, starting at 1",
+              "name": "page",
+              "shortname": null,
+              "value": "PAGE"
+            },
+            {
+              "help": "Number of results per page to return",
+              "name": "per-page",
+              "shortname": null,
+              "value": "PER_PAGE"
+            },
+            {
+              "help": "Search string",
+              "name": "search",
+              "shortname": null,
+              "value": "SEARCH"
+            },
+            {
+              "help": "print help",
+              "name": "help",
+              "shortname": "h",
+              "value": null
+            }
+          ],
+          "subcommands": []
+        },
+        {
+          "description": "List associated products",
+          "name": "product-content",
+          "options": [
+            {
+              "help": "ID of the activation key",
+              "name": "id",
+              "shortname": null,
+              "value": "ID"
+            },
+            {
+              "help": "Activation key name to search by",
+              "name": "name",
+              "shortname": null,
+              "value": "NAME"
+            },
+            {
+              "help": "Organization name to search by",
+              "name": "organization",
+              "shortname": null,
+              "value": "ORGANIZATION_NAME"
+            },
+            {
+              "help": "organization ID",
+              "name": "organization-id",
+              "shortname": null,
+              "value": "ORGANIZATION_ID"
+            },
+            {
+              "help": "Organization label to search by",
+              "name": "organization-label",
+              "shortname": null,
+              "value": "ORGANIZATION_LABEL"
+            },
+            {
+              "help": "print help",
+              "name": "help",
+              "shortname": "h",
+              "value": null
+            }
+          ],
+          "subcommands": []
+        },
+        {
+          "description": "Disassociate a resource",
+          "name": "remove-host-collection",
+          "options": [
+            {
+              "help": "Host collection name to search by",
+              "name": "host-collection",
+              "shortname": null,
+              "value": "HOST_COLLECTION_NAME"
+            },
+            {
+              "help": "Id of the host collection",
+              "name": "host-collection-id",
+              "shortname": null,
+              "value": "HOST_COLLECTION_ID"
+            },
+            {
+              "help": "ID of the activation key",
+              "name": "id",
+              "shortname": null,
+              "value": "ID"
+            },
+            {
+              "help": "Activation key name to search by",
+              "name": "name",
+              "shortname": null,
+              "value": "NAME"
+            },
+            {
+              "help": "Organization name to search by",
+              "name": "organization",
+              "shortname": null,
+              "value": "ORGANIZATION_NAME"
+            },
+            {
+              "help": "organization ID",
+              "name": "organization-id",
+              "shortname": null,
+              "value": "ORGANIZATION_ID"
+            },
+            {
+              "help": "Organization label to search by",
+              "name": "organization-label",
+              "shortname": null,
+              "value": "ORGANIZATION_LABEL"
+            },
+            {
+              "help": "print help",
+              "name": "help",
+              "shortname": "h",
+              "value": null
+            }
+          ],
+          "subcommands": []
+        },
+        {
+          "description": "Remove subscription",
+          "name": "remove-subscription",
+          "options": [
+            {
+              "help": "ID of the activation key",
+              "name": "id",
+              "shortname": null,
+              "value": "ID"
+            },
+            {
+              "help": "Activation key name to search by",
+              "name": "name",
+              "shortname": null,
+              "value": "NAME"
+            },
+            {
+              "help": "Organization name to search by",
+              "name": "organization",
+              "shortname": null,
+              "value": "ORGANIZATION_NAME"
+            },
+            {
+              "help": "organization ID",
+              "name": "organization-id",
+              "shortname": null,
+              "value": "ORGANIZATION_ID"
+            },
+            {
+              "help": "Organization label to search by",
+              "name": "organization-label",
+              "shortname": null,
+              "value": "ORGANIZATION_LABEL"
+            },
+            {
+              "help": "ID of subscription",
+              "name": "subscription-id",
+              "shortname": null,
+              "value": "SUBSCRIPTION_ID"
+            },
+            {
+              "help": "print help",
+              "name": "help",
+              "shortname": "h",
+              "value": null
+            }
+          ],
+          "subcommands": []
+        },
+        {
+          "description": "List associated subscriptions",
+          "name": "subscriptions",
+          "options": [
+            {
+              "help": "ID of activation key",
+              "name": "id",
+              "shortname": null,
+              "value": "ID"
+            },
+            {
+              "help": "Name of activation key",
+              "name": "name",
+              "shortname": null,
+              "value": "NAME"
+            },
+            {
+              "help": "Organization name to search by",
+              "name": "organization",
+              "shortname": null,
+              "value": "ORGANIZATION_NAME"
+            },
+            {
+              "help": "organization ID",
+              "name": "organization-id",
+              "shortname": null,
+              "value": "ORGANIZATION_ID"
+            },
+            {
+              "help": "Organization label to search by",
+              "name": "organization-label",
+              "shortname": null,
+              "value": "ORGANIZATION_LABEL"
+            },
+            {
+              "help": "print help",
+              "name": "help",
+              "shortname": "h",
+              "value": null
+            }
+          ],
+          "subcommands": []
+        },
+        {
+          "description": "Update an activation key",
+          "name": "update",
+          "options": [
+            {
+              "help": "auto attach subscriptions upon registration One of true/false, yes/no, 1/0.",
+              "name": "auto-attach",
+              "shortname": null,
+              "value": "AUTO_ATTACH"
+            },
+            {
+              "help": "Content view name",
+              "name": "content-view",
+              "shortname": null,
+              "value": "CONTENT_VIEW_NAME"
+            },
+            {
+              "help": "content view numeric identifier",
+              "name": "content-view-id",
+              "shortname": null,
+              "value": "CONTENT_VIEW_ID"
+            },
+            {
+              "help": "description",
+              "name": "description",
+              "shortname": null,
+              "value": "DESCRIPTION"
+            },
+            {
+              "help": "ID of the activation key",
+              "name": "id",
+              "shortname": null,
+              "value": "ID"
+            },
+            {
+              "help": "Name to search by",
+              "name": "lifecycle-environment",
+              "shortname": null,
+              "value": "LIFECYCLE_ENVIRONMENT_NAME"
+            },
+            {
+              "help": "",
+              "name": "lifecycle-environment-id",
+              "shortname": null,
+              "value": "LIFECYCLE_ENVIRONMENT_ID"
+            },
+            {
+              "help": "maximum number of registered content hosts",
+              "name": "max-content-hosts",
+              "shortname": null,
+              "value": "MAX_CONTENT_HOSTS"
+            },
+            {
+              "help": "Activation key name to search by",
+              "name": "name",
+              "shortname": null,
+              "value": "NAME"
+            },
+            {
+              "help": "name",
+              "name": "new-name",
+              "shortname": null,
+              "value": "NEW_NAME"
+            },
+            {
+              "help": "Organization name to search by",
+              "name": "organization",
+              "shortname": null,
+              "value": "ORGANIZATION_NAME"
+            },
+            {
+              "help": "organization ID",
+              "name": "organization-id",
+              "shortname": null,
+              "value": "ORGANIZATION_ID"
+            },
+            {
+              "help": "Organization label to search by",
+              "name": "organization-label",
+              "shortname": null,
+              "value": "ORGANIZATION_LABEL"
+            },
+            {
+              "help": "content release version",
+              "name": "release-version",
+              "shortname": null,
+              "value": "RELEASE_VERSION"
+            },
+            {
+              "help": "service level",
+              "name": "service-level",
+              "shortname": null,
+              "value": "SERVICE_LEVEL"
+            },
+            {
+              "help": "can the activation key have unlimited content hosts One of true/false, yes/no, 1/0.",
+              "name": "unlimited-content-hosts",
+              "shortname": null,
+              "value": "UNLIMITED_CONTENT_HOSTS"
+            },
+            {
+              "help": "print help",
+              "name": "help",
+              "shortname": "h",
+              "value": null
+            }
+          ],
+          "subcommands": []
+        }
+      ]
+    },
+    {
+      "description": "Manipulate architectures.",
+      "name": "architecture",
+      "options": [
+        {
+          "help": "print help",
+          "name": "help",
+          "shortname": "h",
+          "value": null
+        }
+      ],
+      "subcommands": [
+        {
+          "description": "Associate an operating system",
+          "name": "add-operatingsystem",
+          "options": [
+            {
+              "help": "",
+              "name": "id",
+              "shortname": null,
+              "value": "ID"
+            },
+            {
+              "help": "Architecture name",
+              "name": "name",
+              "shortname": null,
+              "value": "NAME"
+            },
+            {
+              "help": "Operating system title",
+              "name": "operatingsystem",
+              "shortname": null,
+              "value": "OPERATINGSYSTEM_TITLE"
+            },
+            {
+              "help": "",
+              "name": "operatingsystem-id",
+              "shortname": null,
+              "value": "OPERATINGSYSTEM_ID"
+            },
+            {
+              "help": "print help",
+              "name": "help",
+              "shortname": "h",
+              "value": null
+            }
+          ],
+          "subcommands": []
+        },
+        {
+          "description": "Create an architecture",
+          "name": "create",
+          "options": [
+            {
+              "help": "",
+              "name": "name",
+              "shortname": null,
+              "value": "NAME"
+            },
+            {
+              "help": "Operating system IDs Comma separated list of values.",
+              "name": "operatingsystem-ids",
+              "shortname": null,
+              "value": "OPERATINGSYSTEM_IDS"
+            },
+            {
+              "help": "Comma separated list of values.",
+              "name": "operatingsystems",
+              "shortname": null,
+              "value": "OPERATINGSYSTEM_TITLES"
+            },
+            {
+              "help": "print help",
+              "name": "help",
+              "shortname": "h",
+              "value": null
+            }
+          ],
+          "subcommands": []
+        },
+        {
+          "description": "Delete an architecture",
+          "name": "delete",
+          "options": [
+            {
+              "help": "",
+              "name": "id",
+              "shortname": null,
+              "value": "ID"
+            },
+            {
+              "help": "Architecture name",
+              "name": "name",
+              "shortname": null,
+              "value": "NAME"
+            },
+            {
+              "help": "print help",
+              "name": "help",
+              "shortname": "h",
+              "value": null
+            }
+          ],
+          "subcommands": []
+        },
+        {
+          "description": "Show an architecture",
+          "name": "info",
+          "options": [
+            {
+              "help": "",
+              "name": "id",
+              "shortname": null,
+              "value": "ID"
+            },
+            {
+              "help": "Architecture name",
+              "name": "name",
+              "shortname": null,
+              "value": "NAME"
+            },
+            {
+              "help": "print help",
+              "name": "help",
+              "shortname": "h",
+              "value": null
+            }
+          ],
+          "subcommands": []
+        },
+        {
+          "description": "List all architectures",
+          "name": "list",
+          "options": [
+            {
+              "help": "Operating system title",
+              "name": "operatingsystem",
+              "shortname": null,
+              "value": "OPERATINGSYSTEM_TITLE"
+            },
+            {
+              "help": "",
+              "name": "operatingsystem-id",
+              "shortname": null,
+              "value": "OPERATINGSYSTEM_ID"
+            },
+            {
+              "help": "sort results",
+              "name": "order",
+              "shortname": null,
+              "value": "ORDER"
+            },
+            {
+              "help": "paginate results",
+              "name": "page",
+              "shortname": null,
+              "value": "PAGE"
+            },
+            {
+              "help": "number of entries per request",
+              "name": "per-page",
+              "shortname": null,
+              "value": "PER_PAGE"
+            },
+            {
+              "help": "filter results",
+              "name": "search",
+              "shortname": null,
+              "value": "SEARCH"
+            },
+            {
+              "help": "print help",
+              "name": "help",
+              "shortname": "h",
+              "value": null
+            }
+          ],
+          "subcommands": []
+        },
+        {
+          "description": "Disassociate an operating system",
+          "name": "remove-operatingsystem",
+          "options": [
+            {
+              "help": "",
+              "name": "id",
+              "shortname": null,
+              "value": "ID"
+            },
+            {
+              "help": "Architecture name",
+              "name": "name",
+              "shortname": null,
+              "value": "NAME"
+            },
+            {
+              "help": "Operating system title",
+              "name": "operatingsystem",
+              "shortname": null,
+              "value": "OPERATINGSYSTEM_TITLE"
+            },
+            {
+              "help": "",
+              "name": "operatingsystem-id",
+              "shortname": null,
+              "value": "OPERATINGSYSTEM_ID"
+            },
+            {
+              "help": "print help",
+              "name": "help",
+              "shortname": "h",
+              "value": null
+            }
+          ],
+          "subcommands": []
+        },
+        {
+          "description": "Update an architecture",
+          "name": "update",
+          "options": [
+            {
+              "help": "",
+              "name": "id",
+              "shortname": null,
+              "value": "ID"
+            },
+            {
+              "help": "Architecture name",
+              "name": "name",
+              "shortname": null,
+              "value": "NAME"
+            },
+            {
+              "help": "",
+              "name": "new-name",
+              "shortname": null,
+              "value": "NEW_NAME"
+            },
+            {
+              "help": "Operating system IDs Comma separated list of values.",
+              "name": "operatingsystem-ids",
+              "shortname": null,
+              "value": "OPERATINGSYSTEM_IDS"
+            },
+            {
+              "help": "Comma separated list of values.",
+              "name": "operatingsystems",
+              "shortname": null,
+              "value": "OPERATINGSYSTEM_TITLES"
+            },
+            {
+              "help": "print help",
+              "name": "help",
+              "shortname": "h",
+              "value": null
+            }
+          ],
+          "subcommands": []
+        }
+      ]
+    },
+    {
+      "description": "Foreman connection login/logout.",
+      "name": "auth",
+      "options": [
+        {
+          "help": "print help",
+          "name": "help",
+          "shortname": "h",
+          "value": null
+        }
+      ],
+      "subcommands": [
+        {
+          "description": "Set credentials",
+          "name": "login",
+          "options": [
+            {
+              "help": "print help",
+              "name": "help",
+              "shortname": "h",
+              "value": null
+            }
+          ],
+          "subcommands": []
+        },
+        {
+          "description": "Wipe your credentials",
+          "name": "logout",
+          "options": [
+            {
+              "help": "print help",
+              "name": "help",
+              "shortname": "h",
+              "value": null
+            }
+          ],
+          "subcommands": []
+        },
+        {
+          "description": "Information about current connections",
+          "name": "status",
+          "options": [
+            {
+              "help": "print help",
+              "name": "help",
+              "shortname": "h",
+              "value": null
+            }
+          ],
+          "subcommands": []
+        }
+      ]
+    },
+    {
+      "description": "Manipulate auth sources.",
+      "name": "auth-source",
+      "options": [
+        {
+          "help": "print help",
+          "name": "help",
+          "shortname": "h",
+          "value": null
+        }
+      ],
+      "subcommands": [
+        {
+          "description": "Manage LDAP auth sources.",
+          "name": "ldap",
+          "options": [
+            {
+              "help": "print help",
+              "name": "help",
+              "shortname": "h",
+              "value": null
+            }
+          ],
+          "subcommands": [
+            {
+              "description": "Create an LDAP authentication source",
+              "name": "create",
+              "options": [
+                {
+                  "help": "",
+                  "name": "account",
+                  "shortname": null,
+                  "value": "ACCOUNT"
+                },
+                {
+                  "help": "required if onthefly_register is true",
+                  "name": "account-password",
+                  "shortname": null,
+                  "value": "ACCOUNT_PASSWORD"
+                },
+                {
+                  "help": "required if onthefly_register is true",
+                  "name": "attr-firstname",
+                  "shortname": null,
+                  "value": "ATTR_FIRSTNAME"
+                },
+                {
+                  "help": "required if onthefly_register is true",
+                  "name": "attr-lastname",
+                  "shortname": null,
+                  "value": "ATTR_LASTNAME"
+                },
+                {
+                  "help": "required if onthefly_register is true",
+                  "name": "attr-login",
+                  "shortname": null,
+                  "value": "ATTR_LOGIN"
+                },
+                {
+                  "help": "required if onthefly_register is true",
+                  "name": "attr-mail",
+                  "shortname": null,
+                  "value": "ATTR_MAIL"
+                },
+                {
+                  "help": "",
+                  "name": "attr-photo",
+                  "shortname": null,
+                  "value": "ATTR_PHOTO"
+                },
+                {
+                  "help": "",
+                  "name": "base-dn",
+                  "shortname": null,
+                  "value": "BASE_DN"
+                },
+                {
+                  "help": "",
+                  "name": "host",
+                  "shortname": null,
+                  "value": "HOST"
+                },
+                {
+                  "help": "",
+                  "name": "name",
+                  "shortname": null,
+                  "value": "NAME"
+                },
+                {
+                  "help": "One of true/false, yes/no, 1/0.",
+                  "name": "onthefly-register",
+                  "shortname": null,
+                  "value": "ONTHEFLY_REGISTER"
+                },
+                {
+                  "help": "defaults to 389",
+                  "name": "port",
+                  "shortname": null,
+                  "value": "PORT"
+                },
+                {
+                  "help": "One of true/false, yes/no, 1/0.",
+                  "name": "tls",
+                  "shortname": null,
+                  "value": "TLS"
+                },
+                {
+                  "help": "print help",
+                  "name": "help",
+                  "shortname": "h",
+                  "value": null
+                }
+              ],
+              "subcommands": []
+            },
+            {
+              "description": "Delete an LDAP authentication source",
+              "name": "delete",
+              "options": [
+                {
+                  "help": "",
+                  "name": "id",
+                  "shortname": null,
+                  "value": "ID"
+                },
+                {
+                  "help": "Name to search by",
+                  "name": "name",
+                  "shortname": null,
+                  "value": "NAME"
+                },
+                {
+                  "help": "print help",
+                  "name": "help",
+                  "shortname": "h",
+                  "value": null
+                }
+              ],
+              "subcommands": []
+            },
+            {
+              "description": "Show an LDAP authentication source",
+              "name": "info",
+              "options": [
+                {
+                  "help": "",
+                  "name": "id",
+                  "shortname": null,
+                  "value": "ID"
+                },
+                {
+                  "help": "Name to search by",
+                  "name": "name",
+                  "shortname": null,
+                  "value": "NAME"
+                },
+                {
+                  "help": "print help",
+                  "name": "help",
+                  "shortname": "h",
+                  "value": null
+                }
+              ],
+              "subcommands": []
+            },
+            {
+              "description": "List all LDAP authentication sources",
+              "name": "list",
+              "options": [
+                {
+                  "help": "paginate results",
+                  "name": "page",
+                  "shortname": null,
+                  "value": "PAGE"
+                },
+                {
+                  "help": "number of entries per request",
+                  "name": "per-page",
+                  "shortname": null,
+                  "value": "PER_PAGE"
+                },
+                {
+                  "help": "print help",
+                  "name": "help",
+                  "shortname": "h",
+                  "value": null
+                }
+              ],
+              "subcommands": []
+            },
+            {
+              "description": "Update an LDAP authentication source",
+              "name": "update",
+              "options": [
+                {
+                  "help": "",
+                  "name": "account",
+                  "shortname": null,
+                  "value": "ACCOUNT"
+                },
+                {
+                  "help": "required if onthefly_register is true",
+                  "name": "account-password",
+                  "shortname": null,
+                  "value": "ACCOUNT_PASSWORD"
+                },
+                {
+                  "help": "required if onthefly_register is true",
+                  "name": "attr-firstname",
+                  "shortname": null,
+                  "value": "ATTR_FIRSTNAME"
+                },
+                {
+                  "help": "required if onthefly_register is true",
+                  "name": "attr-lastname",
+                  "shortname": null,
+                  "value": "ATTR_LASTNAME"
+                },
+                {
+                  "help": "required if onthefly_register is true",
+                  "name": "attr-login",
+                  "shortname": null,
+                  "value": "ATTR_LOGIN"
+                },
+                {
+                  "help": "required if onthefly_register is true",
+                  "name": "attr-mail",
+                  "shortname": null,
+                  "value": "ATTR_MAIL"
+                },
+                {
+                  "help": "",
+                  "name": "attr-photo",
+                  "shortname": null,
+                  "value": "ATTR_PHOTO"
+                },
+                {
+                  "help": "",
+                  "name": "base-dn",
+                  "shortname": null,
+                  "value": "BASE_DN"
+                },
+                {
+                  "help": "",
+                  "name": "host",
+                  "shortname": null,
+                  "value": "HOST"
+                },
+                {
+                  "help": "",
+                  "name": "id",
+                  "shortname": null,
+                  "value": "ID"
+                },
+                {
+                  "help": "Name to search by",
+                  "name": "name",
+                  "shortname": null,
+                  "value": "NAME"
+                },
+                {
+                  "help": "",
+                  "name": "new-name",
+                  "shortname": null,
+                  "value": "NEW_NAME"
+                },
+                {
+                  "help": "One of true/false, yes/no, 1/0.",
+                  "name": "onthefly-register",
+                  "shortname": null,
+                  "value": "ONTHEFLY_REGISTER"
+                },
+                {
+                  "help": "defaults to 389",
+                  "name": "port",
+                  "shortname": null,
+                  "value": "PORT"
+                },
+                {
+                  "help": "One of true/false, yes/no, 1/0.",
+                  "name": "tls",
+                  "shortname": null,
+                  "value": "TLS"
+                },
+                {
+                  "help": "print help",
+                  "name": "help",
+                  "shortname": "h",
+                  "value": null
+                }
+              ],
+              "subcommands": []
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "Download boot disks",
+      "name": "bootdisk",
+      "options": [
+        {
+          "help": "print help",
+          "name": "help",
+          "shortname": "h",
+          "value": null
+        }
+      ],
+      "subcommands": [
+        {
+          "description": "Download generic image",
+          "name": "generic",
+          "options": [
+            {
+              "help": "File or device to write image to",
+              "name": "file",
+              "shortname": null,
+              "value": "PATH"
+            },
+            {
+              "help": "Force writing to existing destination (device etc.)",
+              "name": "force",
+              "shortname": null,
+              "value": null
+            },
+            {
+              "help": "Use sudo to write to device",
+              "name": "sudo",
+              "shortname": null,
+              "value": null
+            },
+            {
+              "help": "print help",
+              "name": "help",
+              "shortname": "h",
+              "value": null
+            }
+          ],
+          "subcommands": []
+        },
+        {
+          "description": "Download host image",
+          "name": "host",
+          "options": [
+            {
+              "help": "File or device to write image to",
+              "name": "file",
+              "shortname": null,
+              "value": "PATH"
+            },
+            {
+              "help": "Force writing to existing destination (device etc.)",
+              "name": "force",
+              "shortname": null,
+              "value": null
+            },
+            {
+              "help": "True for full, false for basic reusable image One of true/false, yes/no, 1/0.",
+              "name": "full",
+              "shortname": null,
+              "value": "FULL"
+            },
+            {
+              "help": "Host name",
+              "name": "host",
+              "shortname": null,
+              "value": "HOST_NAME"
+            },
+            {
+              "help": "",
+              "name": "host-id",
+              "shortname": null,
+              "value": "HOST_ID"
+            },
+            {
+              "help": "Use sudo to write to device",
+              "name": "sudo",
+              "shortname": null,
+              "value": null
+            },
+            {
+              "help": "print help",
+              "name": "help",
+              "shortname": "h",
+              "value": null
+            }
+          ],
+          "subcommands": []
+        }
+      ]
+    },
+    {
+      "description": "Manipulate capsule",
+      "name": "capsule",
+      "options": [
+        {
+          "help": "print help",
+          "name": "help",
+          "shortname": "h",
+          "value": null
+        }
+      ],
+      "subcommands": [
+        {
+          "description": "Manage the capsule content",
+          "name": "content",
+          "options": [
+            {
+              "help": "print help",
+              "name": "help",
+              "shortname": "h",
+              "value": null
+            }
+          ],
+          "subcommands": [
+            {
+              "description": "Add lifecycle environments to the capsule",
+              "name": "add-lifecycle-environment",
+              "options": [
+                {
+                  "help": "Name to search by",
+                  "name": "environment",
+                  "shortname": null,
+                  "value": "ENVIRONMENT_NAME"
+                },
+                {
+                  "help": "",
+                  "name": "environment-id",
+                  "shortname": null,
+                  "value": "ENVIRONMENT_ID"
+                },
+                {
+                  "help": "Id of the capsule",
+                  "name": "id",
+                  "shortname": null,
+                  "value": "ID"
+                },
+                {
+                  "help": "Name to search by",
+                  "name": "name",
+                  "shortname": null,
+                  "value": "NAME"
+                },
+                {
+                  "help": "print help",
+                  "name": "help",
+                  "shortname": "h",
+                  "value": null
+                }
+              ],
+              "subcommands": []
+            },
+            {
+              "description": "List the lifecycle environments not attached to the capsule",
+              "name": "available-lifecycle-environments",
+              "options": [
+                {
+                  "help": "Id of the capsule",
+                  "name": "id",
+                  "shortname": null,
+                  "value": "ID"
+                },
+                {
+                  "help": "Name to search by",
+                  "name": "name",
+                  "shortname": null,
+                  "value": "NAME"
+                },
+                {
+                  "help": "Organization name to search by",
+                  "name": "organization",
+                  "shortname": null,
+                  "value": "ORGANIZATION_NAME"
+                },
+                {
+                  "help": "organization ID",
+                  "name": "organization-id",
+                  "shortname": null,
+                  "value": "ORGANIZATION_ID"
+                },
+                {
+                  "help": "Organization label to search by",
+                  "name": "organization-label",
+                  "shortname": null,
+                  "value": "ORGANIZATION_LABEL"
+                },
+                {
+                  "help": "print help",
+                  "name": "help",
+                  "shortname": "h",
+                  "value": null
+                }
+              ],
+              "subcommands": []
+            },
+            {
+              "description": "List the lifecycle environments attached to the capsule",
+              "name": "lifecycle-environments",
+              "options": [
+                {
+                  "help": "Id of the capsule",
+                  "name": "id",
+                  "shortname": null,
+                  "value": "ID"
+                },
+                {
+                  "help": "Name to search by",
+                  "name": "name",
+                  "shortname": null,
+                  "value": "NAME"
+                },
+                {
+                  "help": "Organization name to search by",
+                  "name": "organization",
+                  "shortname": null,
+                  "value": "ORGANIZATION_NAME"
+                },
+                {
+                  "help": "organization ID",
+                  "name": "organization-id",
+                  "shortname": null,
+                  "value": "ORGANIZATION_ID"
+                },
+                {
+                  "help": "Organization label to search by",
+                  "name": "organization-label",
+                  "shortname": null,
+                  "value": "ORGANIZATION_LABEL"
+                },
+                {
+                  "help": "print help",
+                  "name": "help",
+                  "shortname": "h",
+                  "value": null
+                }
+              ],
+              "subcommands": []
+            },
+            {
+              "description": "Remove lifecycle environments from the capsule",
+              "name": "remove-lifecycle-environment",
+              "options": [
+                {
+                  "help": "Name to search by",
+                  "name": "environment",
+                  "shortname": null,
+                  "value": "ENVIRONMENT_NAME"
+                },
+                {
+                  "help": "",
+                  "name": "environment-id",
+                  "shortname": null,
+                  "value": "ENVIRONMENT_ID"
+                },
+                {
+                  "help": "Id of the capsule",
+                  "name": "id",
+                  "shortname": null,
+                  "value": "ID"
+                },
+                {
+                  "help": "Name to search by",
+                  "name": "name",
+                  "shortname": null,
+                  "value": "NAME"
+                },
+                {
+                  "help": "print help",
+                  "name": "help",
+                  "shortname": "h",
+                  "value": null
+                }
+              ],
+              "subcommands": []
+            },
+            {
+              "description": "Synchronize the content to the capsule",
+              "name": "synchronize",
+              "options": [
+                {
+                  "help": "Do not wait for the task",
+                  "name": "async",
+                  "shortname": null,
+                  "value": null
+                },
+                {
+                  "help": "Environment name",
+                  "name": "environment",
+                  "shortname": null,
+                  "value": "ENVIRONMENT_NAME"
+                },
+                {
+                  "help": "",
+                  "name": "environment-id",
+                  "shortname": null,
+                  "value": "ENVIRONMENT_ID"
+                },
+                {
+                  "help": "Id of the capsule",
+                  "name": "id",
+                  "shortname": null,
+                  "value": "ID"
+                },
+                {
+                  "help": "Name to search by",
+                  "name": "name",
+                  "shortname": null,
+                  "value": "NAME"
+                },
+                {
+                  "help": "print help",
+                  "name": "help",
+                  "shortname": "h",
+                  "value": null
+                }
+              ],
+              "subcommands": []
+            }
+          ]
+        },
+        {
+          "description": "Show the capsule details",
+          "name": "info",
+          "options": [
+            {
+              "help": "Id of the capsule",
+              "name": "id",
+              "shortname": null,
+              "value": "ID"
+            },
+            {
+              "help": "Capsule name to search by",
+              "name": "name",
+              "shortname": null,
+              "value": "NAME"
+            },
+            {
+              "help": "print help",
+              "name": "help",
+              "shortname": "h",
+              "value": null
+            }
+          ],
+          "subcommands": []
+        },
+        {
+          "description": "List all capsules",
+          "name": "list",
+          "options": [
+            {
+              "help": "Field to sort the results on",
+              "name": "by",
+              "shortname": null,
+              "value": "BY"
+            },
+            {
+              "help": "Whether or not to show all results One of true/false, yes/no, 1/0.",
+              "name": "full-results",
+              "shortname": null,
+              "value": "FULL_RESULTS"
+            },
+            {
+              "help": "Sort field and order, eg. 'name DESC'",
+              "name": "order",
+              "shortname": null,
+              "value": "ORDER"
+            },
+            {
+              "help": "Page number, starting at 1",
+              "name": "page",
+              "shortname": null,
+              "value": "PAGE"
+            },
+            {
+              "help": "Number of results per page to return",
+              "name": "per-page",
+              "shortname": null,
+              "value": "PER_PAGE"
+            },
+            {
+              "help": "Search string",
+              "name": "search",
+              "shortname": null,
+              "value": "SEARCH"
+            },
+            {
+              "help": "print help",
+              "name": "help",
+              "shortname": "h",
+              "value": null
+            }
+          ],
+          "subcommands": []
+        }
+      ]
+    },
+    {
+      "description": "Manipulate compute resources.",
+      "name": "compute-resource",
+      "options": [
+        {
+          "help": "print help",
+          "name": "help",
+          "shortname": "h",
+          "value": null
+        }
+      ],
+      "subcommands": [
+        {
+          "description": "Create a compute resource",
+          "name": "create",
+          "options": [
+            {
+              "help": "",
+              "name": "description",
+              "shortname": null,
+              "value": "DESCRIPTION"
+            },
+            {
+              "help": "REPLACE locations with given ids Comma separated list of values.",
+              "name": "location-ids",
+              "shortname": null,
+              "value": "LOCATION_IDS"
+            },
+            {
+              "help": "Comma separated list of values.",
+              "name": "locations",
+              "shortname": null,
+              "value": "LOCATION_NAMES"
+            },
+            {
+              "help": "",
+              "name": "name",
+              "shortname": null,
+              "value": "NAME"
+            },
+            {
+              "help": "REPLACE organizations with given ids. Comma separated list of values.",
+              "name": "organization-ids",
+              "shortname": null,
+              "value": "ORGANIZATION_IDS"
+            },
+            {
+              "help": "Comma separated list of values.",
+              "name": "organizations",
+              "shortname": null,
+              "value": "ORGANIZATION_NAMES"
+            },
+            {
+              "help": "Password for RHEV, EC2, Vmware, Openstack. Secret key for EC2",
+              "name": "password",
+              "shortname": null,
+              "value": "PASSWORD"
+            },
+            {
+              "help": "Providers include ",
+              "name": "provider",
+              "shortname": null,
+              "value": "PROVIDER"
+            },
+            {
+              "help": "for EC2 only",
+              "name": "region",
+              "shortname": null,
+              "value": "REGION"
+            },
+            {
+              "help": "for Vmware",
+              "name": "server",
+              "shortname": null,
+              "value": "SERVER"
+            },
+            {
+              "help": "for Libvirt and Vmware only One of true/false, yes/no, 1/0.",
+              "name": "set-console-password",
+              "shortname": null,
+              "value": "SET_CONSOLE_PASSWORD"
+            },
+            {
+              "help": "for Openstack only",
+              "name": "tenant",
+              "shortname": null,
+              "value": "TENANT"
+            },
+            {
+              "help": "URL for Libvirt, RHEV, and Openstack",
+              "name": "url",
+              "shortname": null,
+              "value": "URL"
+            },
+            {
+              "help": "Username for RHEV, EC2, Vmware, Openstack. Access Key for EC2.",
+              "name": "user",
+              "shortname": null,
+              "value": "USER"
+            },
+            {
+              "help": "for RHEV, Vmware Datacenter",
+              "name": "uuid",
+              "shortname": null,
+              "value": "UUID"
+            },
+            {
+              "help": "print help",
+              "name": "help",
+              "shortname": "h",
+              "value": null
+            }
+          ],
+          "subcommands": []
+        },
+        {
+          "description": "Delete a compute resource",
+          "name": "delete",
+          "options": [
+            {
+              "help": "",
+              "name": "id",
+              "shortname": null,
+              "value": "ID"
+            },
+            {
+              "help": "Compute resource name",
+              "name": "name",
+              "shortname": null,
+              "value": "NAME"
+            },
+            {
+              "help": "print help",
+              "name": "help",
+              "shortname": "h",
+              "value": null
+            }
+          ],
+          "subcommands": []
+        },
+        {
+          "description": "View and manage compute resource's images",
+          "name": "image",
+          "options": [
+            {
+              "help": "print help",
+              "name": "help",
+              "shortname": "h",
+              "value": null
+            }
+          ],
+          "subcommands": [
+            {
+              "description": "Show images available for addition",
+              "name": "available",
+              "options": [
+                {
+                  "help": "",
+                  "name": "compute-resource",
+                  "shortname": null,
+                  "value": "NAME"
+                },
+                {
+                  "help": "",
+                  "name": "compute-resource-id",
+                  "shortname": null,
+                  "value": "ID"
+                },
+                {
+                  "help": "",
+                  "name": "id",
+                  "shortname": null,
+                  "value": "ID"
+                },
+                {
+                  "help": "Compute resource name",
+                  "name": "name",
+                  "shortname": null,
+                  "value": "NAME"
+                },
+                {
+                  "help": "print help",
+                  "name": "help",
+                  "shortname": "h",
+                  "value": null
+                }
+              ],
+              "subcommands": []
+            },
+            {
+              "description": "Create an image",
+              "name": "create",
+              "options": [
+                {
+                  "help": "Architecture name",
+                  "name": "architecture",
+                  "shortname": null,
+                  "value": "ARCHITECTURE_NAME"
+                },
+                {
+                  "help": "",
+                  "name": "architecture-id",
+                  "shortname": null,
+                  "value": "ARCHITECTURE_ID"
+                },
+                {
+                  "help": "Compute resource name",
+                  "name": "compute-resource",
+                  "shortname": null,
+                  "value": "COMPUTE_RESOURCE_NAME"
+                },
+                {
+                  "help": "",
+                  "name": "compute-resource-id",
+                  "shortname": null,
+                  "value": "COMPUTE_RESOURCE_ID"
+                },
+                {
+                  "help": "",
+                  "name": "name",
+                  "shortname": null,
+                  "value": "NAME"
+                },
+                {
+                  "help": "Operating system title",
+                  "name": "operatingsystem",
+                  "shortname": null,
+                  "value": "OPERATINGSYSTEM_TITLE"
+                },
+                {
+                  "help": "",
+                  "name": "operatingsystem-id",
+                  "shortname": null,
+                  "value": "OPERATINGSYSTEM_ID"
+                },
+                {
+                  "help": "",
+                  "name": "username",
+                  "shortname": null,
+                  "value": "USERNAME"
+                },
+                {
+                  "help": "",
+                  "name": "uuid",
+                  "shortname": null,
+                  "value": "UUID"
+                },
+                {
+                  "help": "print help",
+                  "name": "help",
+                  "shortname": "h",
+                  "value": null
+                }
+              ],
+              "subcommands": []
+            },
+            {
+              "description": "Delete an image",
+              "name": "delete",
+              "options": [
+                {
+                  "help": "Compute resource name",
+                  "name": "compute-resource",
+                  "shortname": null,
+                  "value": "COMPUTE_RESOURCE_NAME"
+                },
+                {
+                  "help": "",
+                  "name": "compute-resource-id",
+                  "shortname": null,
+                  "value": "COMPUTE_RESOURCE_ID"
+                },
+                {
+                  "help": "",
+                  "name": "id",
+                  "shortname": null,
+                  "value": "ID"
+                },
+                {
+                  "help": "Name to search by",
+                  "name": "name",
+                  "shortname": null,
+                  "value": "NAME"
+                },
+                {
+                  "help": "print help",
+                  "name": "help",
+                  "shortname": "h",
+                  "value": null
+                }
+              ],
+              "subcommands": []
+            },
+            {
+              "description": "Show an image",
+              "name": "info",
+              "options": [
+                {
+                  "help": "Architecture name",
+                  "name": "architecture",
+                  "shortname": null,
+                  "value": "ARCHITECTURE_NAME"
+                },
+                {
+                  "help": "",
+                  "name": "architecture-id",
+                  "shortname": null,
+                  "value": "ARCHITECTURE_ID"
+                },
+                {
+                  "help": "Compute resource name",
+                  "name": "compute-resource",
+                  "shortname": null,
+                  "value": "COMPUTE_RESOURCE_NAME"
+                },
+                {
+                  "help": "",
+                  "name": "compute-resource-id",
+                  "shortname": null,
+                  "value": "COMPUTE_RESOURCE_ID"
+                },
+                {
+                  "help": "",
+                  "name": "id",
+                  "shortname": null,
+                  "value": "ID"
+                },
+                {
+                  "help": "Name to search by",
+                  "name": "name",
+                  "shortname": null,
+                  "value": "NAME"
+                },
+                {
+                  "help": "Operating system title",
+                  "name": "operatingsystem",
+                  "shortname": null,
+                  "value": "OPERATINGSYSTEM_TITLE"
+                },
+                {
+                  "help": "",
+                  "name": "operatingsystem-id",
+                  "shortname": null,
+                  "value": "OPERATINGSYSTEM_ID"
+                },
+                {
+                  "help": "print help",
+                  "name": "help",
+                  "shortname": "h",
+                  "value": null
+                }
+              ],
+              "subcommands": []
+            },
+            {
+              "description": "List all images for a compute resource",
+              "name": "list",
+              "options": [
+                {
+                  "help": "Architecture name",
+                  "name": "architecture",
+                  "shortname": null,
+                  "value": "ARCHITECTURE_NAME"
+                },
+                {
+                  "help": "",
+                  "name": "architecture-id",
+                  "shortname": null,
+                  "value": "ARCHITECTURE_ID"
+                },
+                {
+                  "help": "Compute resource name",
+                  "name": "compute-resource",
+                  "shortname": null,
+                  "value": "COMPUTE_RESOURCE_NAME"
+                },
+                {
+                  "help": "",
+                  "name": "compute-resource-id",
+                  "shortname": null,
+                  "value": "COMPUTE_RESOURCE_ID"
+                },
+                {
+                  "help": "Operating system title",
+                  "name": "operatingsystem",
+                  "shortname": null,
+                  "value": "OPERATINGSYSTEM_TITLE"
+                },
+                {
+                  "help": "",
+                  "name": "operatingsystem-id",
+                  "shortname": null,
+                  "value": "OPERATINGSYSTEM_ID"
+                },
+                {
+                  "help": "sort results",
+                  "name": "order",
+                  "shortname": null,
+                  "value": "ORDER"
+                },
+                {
+                  "help": "paginate results",
+                  "name": "page",
+                  "shortname": null,
+                  "value": "PAGE"
+                },
+                {
+                  "help": "number of entries per request",
+                  "name": "per-page",
+                  "shortname": null,
+                  "value": "PER_PAGE"
+                },
+                {
+                  "help": "filter results",
+                  "name": "search",
+                  "shortname": null,
+                  "value": "SEARCH"
+                },
+                {
+                  "help": "print help",
+                  "name": "help",
+                  "shortname": "h",
+                  "value": null
+                }
+              ],
+              "subcommands": []
+            },
+            {
+              "description": "Update an image",
+              "name": "update",
+              "options": [
+                {
+                  "help": "Architecture name",
+                  "name": "architecture",
+                  "shortname": null,
+                  "value": "ARCHITECTURE_NAME"
+                },
+                {
+                  "help": "",
+                  "name": "architecture-id",
+                  "shortname": null,
+                  "value": "ARCHITECTURE_ID"
+                },
+                {
+                  "help": "Compute resource name",
+                  "name": "compute-resource",
+                  "shortname": null,
+                  "value": "COMPUTE_RESOURCE_NAME"
+                },
+                {
+                  "help": "",
+                  "name": "compute-resource-id",
+                  "shortname": null,
+                  "value": "COMPUTE_RESOURCE_ID"
+                },
+                {
+                  "help": "",
+                  "name": "id",
+                  "shortname": null,
+                  "value": "ID"
+                },
+                {
+                  "help": "Name to search by",
+                  "name": "name",
+                  "shortname": null,
+                  "value": "NAME"
+                },
+                {
+                  "help": "",
+                  "name": "new-name",
+                  "shortname": null,
+                  "value": "NEW_NAME"
+                },
+                {
+                  "help": "Operating system title",
+                  "name": "operatingsystem",
+                  "shortname": null,
+                  "value": "OPERATINGSYSTEM_TITLE"
+                },
+                {
+                  "help": "",
+                  "name": "operatingsystem-id",
+                  "shortname": null,
+                  "value": "OPERATINGSYSTEM_ID"
+                },
+                {
+                  "help": "",
+                  "name": "username",
+                  "shortname": null,
+                  "value": "USERNAME"
+                },
+                {
+                  "help": "",
+                  "name": "uuid",
+                  "shortname": null,
+                  "value": "UUID"
+                },
+                {
+                  "help": "print help",
+                  "name": "help",
+                  "shortname": "h",
+                  "value": null
+                }
+              ],
+              "subcommands": []
+            }
+          ]
+        },
+        {
+          "description": "Show a compute resource",
+          "name": "info",
+          "options": [
+            {
+              "help": "",
+              "name": "id",
+              "shortname": null,
+              "value": "ID"
+            },
+            {
+              "help": "Compute resource name",
+              "name": "name",
+              "shortname": null,
+              "value": "NAME"
+            },
+            {
+              "help": "print help",
+              "name": "help",
+              "shortname": "h",
+              "value": null
+            }
+          ],
+          "subcommands": []
+        },
+        {
+          "description": "List all compute resources",
+          "name": "list",
+          "options": [
+            {
+              "help": "Location name",
+              "name": "location",
+              "shortname": null,
+              "value": "LOCATION_NAME"
+            },
+            {
+              "help": "",
+              "name": "location-id",
+              "shortname": null,
+              "value": "LOCATION_ID"
+            },
+            {
+              "help": "sort results",
+              "name": "order",
+              "shortname": null,
+              "value": "ORDER"
+            },
+            {
+              "help": "Organization name",
+              "name": "organization",
+              "shortname": null,
+              "value": "ORGANIZATION_NAME"
+            },
+            {
+              "help": "organization ID",
+              "name": "organization-id",
+              "shortname": null,
+              "value": "ORGANIZATION_ID"
+            },
+            {
+              "help": "paginate results",
+              "name": "page",
+              "shortname": null,
+              "value": "PAGE"
+            },
+            {
+              "help": "number of entries per request",
+              "name": "per-page",
+              "shortname": null,
+              "value": "PER_PAGE"
+            },
+            {
+              "help": "filter results",
+              "name": "search",
+              "shortname": null,
+              "value": "SEARCH"
+            },
+            {
+              "help": "print help",
+              "name": "help",
+              "shortname": "h",
+              "value": null
+            }
+          ],
+          "subcommands": []
+        },
+        {
+          "description": "Update a compute resource",
+          "name": "update",
+          "options": [
+            {
+              "help": "",
+              "name": "description",
+              "shortname": null,
+              "value": "DESCRIPTION"
+            },
+            {
+              "help": "",
+              "name": "id",
+              "shortname": null,
+              "value": "ID"
+            },
+            {
+              "help": "REPLACE locations with given ids Comma separated list of values.",
+              "name": "location-ids",
+              "shortname": null,
+              "value": "LOCATION_IDS"
+            },
+            {
+              "help": "Comma separated list of values.",
+              "name": "locations",
+              "shortname": null,
+              "value": "LOCATION_NAMES"
+            },
+            {
+              "help": "Compute resource name",
+              "name": "name",
+              "shortname": null,
+              "value": "NAME"
+            },
+            {
+              "help": "",
+              "name": "new-name",
+              "shortname": null,
+              "value": "NEW_NAME"
+            },
+            {
+              "help": "REPLACE organizations with given ids. Comma separated list of values.",
+              "name": "organization-ids",
+              "shortname": null,
+              "value": "ORGANIZATION_IDS"
+            },
+            {
+              "help": "Comma separated list of values.",
+              "name": "organizations",
+              "shortname": null,
+              "value": "ORGANIZATION_NAMES"
+            },
+            {
+              "help": "Password for RHEV, EC2, Vmware, Openstack. Secret key for EC2",
+              "name": "password",
+              "shortname": null,
+              "value": "PASSWORD"
+            },
+            {
+              "help": "Providers include ",
+              "name": "provider",
+              "shortname": null,
+              "value": "PROVIDER"
+            },
+            {
+              "help": "for EC2 only",
+              "name": "region",
+              "shortname": null,
+              "value": "REGION"
+            },
+            {
+              "help": "for Vmware",
+              "name": "server",
+              "shortname": null,
+              "value": "SERVER"
+            },
+            {
+              "help": "for Libvirt and Vmware only One of true/false, yes/no, 1/0.",
+              "name": "set-console-password",
+              "shortname": null,
+              "value": "SET_CONSOLE_PASSWORD"
+            },
+            {
+              "help": "for Openstack only",
+              "name": "tenant",
+              "shortname": null,
+              "value": "TENANT"
+            },
+            {
+              "help": "URL for Libvirt, RHEV, and Openstack",
+              "name": "url",
+              "shortname": null,
+              "value": "URL"
+            },
+            {
+              "help": "Username for RHEV, EC2, Vmware, Openstack. Access Key for EC2.",
+              "name": "user",
+              "shortname": null,
+              "value": "USER"
+            },
+            {
+              "help": "for RHEV, Vmware Datacenter",
+              "name": "uuid",
+              "shortname": null,
+              "value": "UUID"
+            },
+            {
+              "help": "print help",
+              "name": "help",
+              "shortname": "h",
+              "value": null
+            }
+          ],
+          "subcommands": []
+        }
+      ]
+    },
+    {
+      "description": "Manipulate content hosts on the server",
+      "name": "content-host",
+      "options": [
+        {
+          "help": "print help",
+          "name": "help",
+          "shortname": "h",
+          "value": null
+        }
+      ],
+      "subcommands": [
+        {
+          "description": "Given a set of systems and errata, lists the content view versions                                                                   and environments that need updating.",
+          "name": "available-incremental-updates",
+          "options": [
+            {
+              "help": "List of Errata ids Comma separated list of values.",
+              "name": "errata-ids",
+              "shortname": null,
+              "value": "ERRATA_IDS"
+            },
+            {
+              "help": "ID of a content host",
+              "name": "id",
+              "shortname": null,
+              "value": "ID"
+            },
+            {
+              "help": "List of system ids to perform an action on Comma separated list of values.",
+              "name": "ids",
+              "shortname": null,
+              "value": "IDS"
+            },
+            {
+              "help": "Organization name to search by",
+              "name": "organization",
+              "shortname": null,
+              "value": "ORGANIZATION_NAME"
+            },
+            {
+              "help": "organization ID",
+              "name": "organization-id",
+              "shortname": null,
+              "value": "ORGANIZATION_ID"
+            },
+            {
+              "help": "Organization label to search by",
+              "name": "organization-label",
+              "shortname": null,
+              "value": "ORGANIZATION_LABEL"
+            },
+            {
+              "help": "Search string for systems to perform an action on",
+              "name": "search",
+              "shortname": null,
+              "value": "SEARCH"
+            },
+            {
+              "help": "print help",
+              "name": "help",
+              "shortname": "h",
+              "value": null
+            }
+          ],
+          "subcommands": []
+        },
+        {
+          "description": "Register a content host",
+          "name": "create",
+          "options": [
+            {
+              "help": "Content view name",
+              "name": "content-view",
+              "shortname": null,
+              "value": "CONTENT_VIEW_NAME"
+            },
+            {
+              "help": "content view numeric identifier",
+              "name": "content-view-id",
+              "shortname": null,
+              "value": "CONTENT_VIEW_ID"
+            },
+            {
+              "help": "Description of the content host",
+              "name": "description",
+              "shortname": null,
+              "value": "DESCRIPTION"
+            },
+            {
+              "help": "IDs of the virtual guests running on this content host Comma separated list of values.",
+              "name": "guest-ids",
+              "shortname": null,
+              "value": "GUEST_IDS"
+            },
+            {
+              "help": "Specify the host collections as an array Comma separated list of values.",
+              "name": "host-collection-ids",
+              "shortname": null,
+              "value": "HOST_COLLECTION_IDS"
+            },
+            {
+              "help": "Comma separated list of values.",
+              "name": "host-collections",
+              "shortname": null,
+              "value": "HOST_COLLECTION_NAMES"
+            },
+            {
+              "help": "Last check-in time of this content host",
+              "name": "last-checkin",
+              "shortname": null,
+              "value": "LAST_CHECKIN"
+            },
+            {
+              "help": "Name to search by",
+              "name": "lifecycle-environment",
+              "shortname": null,
+              "value": "LIFECYCLE_ENVIRONMENT_NAME"
+            },
+            {
+              "help": "",
+              "name": "lifecycle-environment-id",
+              "shortname": null,
+              "value": "LIFECYCLE_ENVIRONMENT_ID"
+            },
+            {
+              "help": "Physical location of the content host",
+              "name": "location",
+              "shortname": null,
+              "value": "LOCATION"
+            },
+            {
+              "help": "Name of the content host",
+              "name": "name",
+              "shortname": null,
+              "value": "NAME"
+            },
+            {
+              "help": "Organization name to search by",
+              "name": "organization",
+              "shortname": null,
+              "value": "ORGANIZATION_NAME"
+            },
+            {
+              "help": "organization ID",
+              "name": "organization-id",
+              "shortname": null,
+              "value": "ORGANIZATION_ID"
+            },
+            {
+              "help": "Organization label to search by",
+              "name": "organization-label",
+              "shortname": null,
+              "value": "ORGANIZATION_LABEL"
+            },
+            {
+              "help": "Release version of the content host",
+              "name": "release-ver",
+              "shortname": null,
+              "value": "RELEASE_VER"
+            },
+            {
+              "help": "A service level for auto-healing process, e.g. SELF-SUPPORT",
+              "name": "service-level",
+              "shortname": null,
+              "value": "SERVICE_LEVEL"
+            },
+            {
+              "help": "print help",
+              "name": "help",
+              "shortname": "h",
+              "value": null
+            }
+          ],
+          "subcommands": []
+        },
+        {
+          "description": "Unregister a content host",
+          "name": "delete",
+          "options": [
+            {
+              "help": "ID of the content host",
+              "name": "id",
+              "shortname": null,
+              "value": "ID"
+            },
+            {
+              "help": "Name to search by",
+              "name": "name",
+              "shortname": null,
+              "value": "NAME"
+            },
+            {
+              "help": "Organization name to search by",
+              "name": "organization",
+              "shortname": null,
+              "value": "ORGANIZATION_NAME"
+            },
+            {
+              "help": "organization ID",
+              "name": "organization-id",
+              "shortname": null,
+              "value": "ORGANIZATION_ID"
+            },
+            {
+              "help": "Organization label to search by",
+              "name": "organization-label",
+              "shortname": null,
+              "value": "ORGANIZATION_LABEL"
+            },
+            {
+              "help": "print help",
+              "name": "help",
+              "shortname": "h",
+              "value": null
+            }
+          ],
+          "subcommands": []
+        },
+        {
+          "description": "Manage errata on your content hosts",
+          "name": "errata",
+          "options": [
+            {
+              "help": "print help",
+              "name": "help",
+              "shortname": "h",
+              "value": null
+            }
+          ],
+          "subcommands": [
+            {
+              "description": "Schedule errata for installation",
+              "name": "apply",
+              "options": [
+                {
+                  "help": "Name to search by",
+                  "name": "content-host",
+                  "shortname": null,
+                  "value": "CONTENT_HOST_NAME"
+                },
+                {
+                  "help": "UUID of the content host",
+                  "name": "content-host-id",
+                  "shortname": null,
+                  "value": "CONTENT_HOST_ID"
+                },
+                {
+                  "help": "List of Errata ids to install Comma separated list of values.",
+                  "name": "errata-ids",
+                  "shortname": null,
+                  "value": "ERRATA_IDS"
+                },
+                {
+                  "help": "Organization name to search by",
+                  "name": "organization",
+                  "shortname": null,
+                  "value": "ORGANIZATION_NAME"
+                },
+                {
+                  "help": "organization ID",
+                  "name": "organization-id",
+                  "shortname": null,
+                  "value": "ORGANIZATION_ID"
+                },
+                {
+                  "help": "Organization label to search by",
+                  "name": "organization-label",
+                  "shortname": null,
+                  "value": "ORGANIZATION_LABEL"
+                },
+                {
+                  "help": "print help",
+                  "name": "help",
+                  "shortname": "h",
+                  "value": null
+                }
+              ],
+              "subcommands": []
+            },
+            {
+              "description": "Retrieve a single errata for a system",
+              "name": "info",
+              "options": [
+                {
+                  "help": "Name to search by",
+                  "name": "content-host",
+                  "shortname": null,
+                  "value": "CONTENT_HOST_NAME"
+                },
+                {
+                  "help": "UUID of the content host",
+                  "name": "content-host-id",
+                  "shortname": null,
+                  "value": "CONTENT_HOST_ID"
+                },
+                {
+                  "help": "Errata id of the erratum (RHSA-2012:108)",
+                  "name": "id",
+                  "shortname": null,
+                  "value": "ID"
+                },
+                {
+                  "help": "Name to search by",
+                  "name": "name",
+                  "shortname": null,
+                  "value": "NAME"
+                },
+                {
+                  "help": "Organization name to search by",
+                  "name": "organization",
+                  "shortname": null,
+                  "value": "ORGANIZATION_NAME"
+                },
+                {
+                  "help": "organization ID",
+                  "name": "organization-id",
+                  "shortname": null,
+                  "value": "ORGANIZATION_ID"
+                },
+                {
+                  "help": "Organization label to search by",
+                  "name": "organization-label",
+                  "shortname": null,
+                  "value": "ORGANIZATION_LABEL"
+                },
+                {
+                  "help": "print help",
+                  "name": "help",
+                  "shortname": "h",
+                  "value": null
+                }
+              ],
+              "subcommands": []
+            },
+            {
+              "description": "List errata available for the content host",
+              "name": "list",
+              "options": [
+                {
+                  "help": "Field to sort the results on",
+                  "name": "by",
+                  "shortname": null,
+                  "value": "BY"
+                },
+                {
+                  "help": "Content view name",
+                  "name": "content-view",
+                  "shortname": null,
+                  "value": "CONTENT_VIEW_NAME"
+                },
+                {
+                  "help": "content view numeric identifier",
+                  "name": "content-view-id",
+                  "shortname": null,
+                  "value": "CONTENT_VIEW_ID"
+                },
+                {
+                  "help": "Name to search by",
+                  "name": "environment",
+                  "shortname": null,
+                  "value": "ENVIRONMENT_NAME"
+                },
+                {
+                  "help": "",
+                  "name": "environment-id",
+                  "shortname": null,
+                  "value": "ENVIRONMENT_ID"
+                },
+                {
+                  "help": "Whether or not to show all results One of true/false, yes/no, 1/0.",
+                  "name": "full-results",
+                  "shortname": null,
+                  "value": "FULL_RESULTS"
+                },
+                {
+                  "help": "UUID of the content host",
+                  "name": "id",
+                  "shortname": null,
+                  "value": "ID"
+                },
+                {
+                  "help": "Name to search by",
+                  "name": "name",
+                  "shortname": null,
+                  "value": "NAME"
+                },
+                {
+                  "help": "Sort field and order, eg. 'name DESC'",
+                  "name": "order",
+                  "shortname": null,
+                  "value": "ORDER"
+                },
+                {
+                  "help": "Organization name to search by",
+                  "name": "organization",
+                  "shortname": null,
+                  "value": "ORGANIZATION_NAME"
+                },
+                {
+                  "help": "organization ID",
+                  "name": "organization-id",
+                  "shortname": null,
+                  "value": "ORGANIZATION_ID"
+                },
+                {
+                  "help": "Organization label to search by",
+                  "name": "organization-label",
+                  "shortname": null,
+                  "value": "ORGANIZATION_LABEL"
+                },
+                {
+                  "help": "Page number, starting at 1",
+                  "name": "page",
+                  "shortname": null,
+                  "value": "PAGE"
+                },
+                {
+                  "help": "Number of results per page to return",
+                  "name": "per-page",
+                  "shortname": null,
+                  "value": "PER_PAGE"
+                },
+                {
+                  "help": "Search string",
+                  "name": "search",
+                  "shortname": null,
+                  "value": "SEARCH"
+                },
+                {
+                  "help": "print help",
+                  "name": "help",
+                  "shortname": "h",
+                  "value": null
+                }
+              ],
+              "subcommands": []
+            }
+          ]
+        },
+        {
+          "description": "Show a content host",
+          "name": "info",
+          "options": [
+            {
+              "help": "ID of the content host",
+              "name": "id",
+              "shortname": null,
+              "value": "ID"
+            },
+            {
+              "help": "Name to search by",
+              "name": "name",
+              "shortname": null,
+              "value": "NAME"
+            },
+            {
+              "help": "Organization name to search by",
+              "name": "organization",
+              "shortname": null,
+              "value": "ORGANIZATION_NAME"
+            },
+            {
+              "help": "organization ID",
+              "name": "organization-id",
+              "shortname": null,
+              "value": "ORGANIZATION_ID"
+            },
+            {
+              "help": "Organization label to search by",
+              "name": "organization-label",
+              "shortname": null,
+              "value": "ORGANIZATION_LABEL"
+            },
+            {
+              "help": "print help",
+              "name": "help",
+              "shortname": "h",
+              "value": null
+            }
+          ],
+          "subcommands": []
+        },
+        {
+          "description": "List content hosts",
+          "name": "list",
+          "options": [
+            {
+              "help": "Field to sort the results on",
+              "name": "by",
+              "shortname": null,
+              "value": "BY"
+            },
+            {
+              "help": "Filter by systems that need any one of multiple Errata by uuid Comma separated list of values.",
+              "name": "errata-ids",
+              "shortname": null,
+              "value": "ERRATA_IDS"
+            },
+            {
+              "help": "Filter by systems that need an Erratum by uuid",
+              "name": "erratum-id",
+              "shortname": null,
+              "value": "ERRATUM_ID"
+            },
+            {
+              "help": "Return only systems where the Erratum specified by erratum_id or errata_ids is available to systems (default False)",
+              "name": "erratum-restrict-installable",
+              "shortname": null,
+              "value": "ERRATUM_RESTRICT_INSTALLABLE"
+            },
+            {
+              "help": "Return only systems where the Erratum specified by erratum_id or errata_ids is unavailable to systems (default False)",
+              "name": "erratum-restrict-non-installable",
+              "shortname": null,
+              "value": "ERRATUM_RESTRICT_NON_INSTALLABLE"
+            },
+            {
+              "help": "Whether or not to show all results One of true/false, yes/no, 1/0.",
+              "name": "full-results",
+              "shortname": null,
+              "value": "FULL_RESULTS"
+            },
+            {
+              "help": "Host collection name to search by",
+              "name": "host-collection",
+              "shortname": null,
+              "value": "HOST_COLLECTION_NAME"
+            },
+            {
+              "help": "Id of the host collection",
+              "name": "host-collection-id",
+              "shortname": null,
+              "value": "HOST_COLLECTION_ID"
+            },
+            {
+              "help": "Name to search by",
+              "name": "lifecycle-environment",
+              "shortname": null,
+              "value": "LIFECYCLE_ENVIRONMENT_NAME"
+            },
+            {
+              "help": "",
+              "name": "lifecycle-environment-id",
+              "shortname": null,
+              "value": "LIFECYCLE_ENVIRONMENT_ID"
+            },
+            {
+              "help": "Filter content host by name",
+              "name": "name",
+              "shortname": null,
+              "value": "NAME"
+            },
+            {
+              "help": "Sort field and order, eg. 'name DESC'",
+              "name": "order",
+              "shortname": null,
+              "value": "ORDER"
+            },
+            {
+              "help": "Organization name to search by",
+              "name": "organization",
+              "shortname": null,
+              "value": "ORGANIZATION_NAME"
+            },
+            {
+              "help": "organization ID",
+              "name": "organization-id",
+              "shortname": null,
+              "value": "ORGANIZATION_ID"
+            },
+            {
+              "help": "Organization label to search by",
+              "name": "organization-label",
+              "shortname": null,
+              "value": "ORGANIZATION_LABEL"
+            },
+            {
+              "help": "Page number, starting at 1",
+              "name": "page",
+              "shortname": null,
+              "value": "PAGE"
+            },
+            {
+              "help": "Number of results per page to return",
+              "name": "per-page",
+              "shortname": null,
+              "value": "PER_PAGE"
+            },
+            {
+              "help": "Filter content host by subscribed pool",
+              "name": "pool-id",
+              "shortname": null,
+              "value": "POOL_ID"
+            },
+            {
+              "help": "Search string",
+              "name": "search",
+              "shortname": null,
+              "value": "SEARCH"
+            },
+            {
+              "help": "Filter content host by uuid",
+              "name": "uuid",
+              "shortname": null,
+              "value": "UUID"
+            },
+            {
+              "help": "print help",
+              "name": "help",
+              "shortname": "h",
+              "value": null
+            }
+          ],
+          "subcommands": []
+        },
+        {
+          "description": "Manage packages on your content hosts",
+          "name": "package",
+          "options": [
+            {
+              "help": "print help",
+              "name": "help",
+              "shortname": "h",
+              "value": null
+            }
+          ],
+          "subcommands": [
+            {
+              "description": "Install packages remotely",
+              "name": "install",
+              "options": [
+                {
+                  "help": "Do not wait for the task",
+                  "name": "async",
+                  "shortname": null,
+                  "value": null
+                },
+                {
+                  "help": "Name to search by",
+                  "name": "content-host",
+                  "shortname": null,
+                  "value": "CONTENT_HOST_NAME"
+                },
+                {
+                  "help": "UUID of the content host",
+                  "name": "content-host-id",
+                  "shortname": null,
+                  "value": "CONTENT_HOST_ID"
+                },
+                {
+                  "help": "Organization name to search by",
+                  "name": "organization",
+                  "shortname": null,
+                  "value": "ORGANIZATION_NAME"
+                },
+                {
+                  "help": "organization ID",
+                  "name": "organization-id",
+                  "shortname": null,
+                  "value": "ORGANIZATION_ID"
+                },
+                {
+                  "help": "Organization label to search by",
+                  "name": "organization-label",
+                  "shortname": null,
+                  "value": "ORGANIZATION_LABEL"
+                },
+                {
+                  "help": "List of package names Comma separated list of values.",
+                  "name": "packages",
+                  "shortname": null,
+                  "value": "PACKAGES"
+                },
+                {
+                  "help": "print help",
+                  "name": "help",
+                  "shortname": "h",
+                  "value": null
+                }
+              ],
+              "subcommands": []
+            },
+            {
+              "description": "Uninstall packages remotely",
+              "name": "remove",
+              "options": [
+                {
+                  "help": "Do not wait for the task",
+                  "name": "async",
+                  "shortname": null,
+                  "value": null
+                },
+                {
+                  "help": "Name to search by",
+                  "name": "content-host",
+                  "shortname": null,
+                  "value": "CONTENT_HOST_NAME"
+                },
+                {
+                  "help": "UUID of the content host",
+                  "name": "content-host-id",
+                  "shortname": null,
+                  "value": "CONTENT_HOST_ID"
+                },
+                {
+                  "help": "Organization name to search by",
+                  "name": "organization",
+                  "shortname": null,
+                  "value": "ORGANIZATION_NAME"
+                },
+                {
+                  "help": "organization ID",
+                  "name": "organization-id",
+                  "shortname": null,
+                  "value": "ORGANIZATION_ID"
+                },
+                {
+                  "help": "Organization label to search by",
+                  "name": "organization-label",
+                  "shortname": null,
+                  "value": "ORGANIZATION_LABEL"
+                },
+                {
+                  "help": "List of package names Comma separated list of values.",
+                  "name": "packages",
+                  "shortname": null,
+                  "value": "PACKAGES"
+                },
+                {
+                  "help": "print help",
+                  "name": "help",
+                  "shortname": "h",
+                  "value": null
+                }
+              ],
+              "subcommands": []
+            },
+            {
+              "description": "Update packages remotely",
+              "name": "upgrade",
+              "options": [
+                {
+                  "help": "Do not wait for the task",
+                  "name": "async",
+                  "shortname": null,
+                  "value": null
+                },
+                {
+                  "help": "Name to search by",
+                  "name": "content-host",
+                  "shortname": null,
+                  "value": "CONTENT_HOST_NAME"
+                },
+                {
+                  "help": "UUID of the content host",
+                  "name": "content-host-id",
+                  "shortname": null,
+                  "value": "CONTENT_HOST_ID"
+                },
+                {
+                  "help": "Organization name to search by",
+                  "name": "organization",
+                  "shortname": null,
+                  "value": "ORGANIZATION_NAME"
+                },
+                {
+                  "help": "organization ID",
+                  "name": "organization-id",
+                  "shortname": null,
+                  "value": "ORGANIZATION_ID"
+                },
+                {
+                  "help": "Organization label to search by",
+                  "name": "organization-label",
+                  "shortname": null,
+                  "value": "ORGANIZATION_LABEL"
+                },
+                {
+                  "help": "list of packages names Comma separated list of values.",
+                  "name": "packages",
+                  "shortname": null,
+                  "value": "PACKAGES"
+                },
+                {
+                  "help": "print help",
+                  "name": "help",
+                  "shortname": "h",
+                  "value": null
+                }
+              ],
+              "subcommands": []
+            },
+            {
+              "description": "Update packages remotely",
+              "name": "upgrade-all",
+              "options": [
+                {
+                  "help": "Do not wait for the task",
+                  "name": "async",
+                  "shortname": null,
+                  "value": null
+                },
+                {
+                  "help": "Name to search by",
+                  "name": "content-host",
+                  "shortname": null,
+                  "value": "CONTENT_HOST_NAME"
+                },
+                {
+                  "help": "UUID of the content host",
+                  "name": "content-host-id",
+                  "shortname": null,
+                  "value": "CONTENT_HOST_ID"
+                },
+                {
+                  "help": "Organization name to search by",
+                  "name": "organization",
+                  "shortname": null,
+                  "value": "ORGANIZATION_NAME"
+                },
+                {
+                  "help": "organization ID",
+                  "name": "organization-id",
+                  "shortname": null,
+                  "value": "ORGANIZATION_ID"
+                },
+                {
+                  "help": "Organization label to search by",
+                  "name": "organization-label",
+                  "shortname": null,
+                  "value": "ORGANIZATION_LABEL"
+                },
+                {
+                  "help": "print help",
+                  "name": "help",
+                  "shortname": "h",
+                  "value": null
+                }
+              ],
+              "subcommands": []
+            }
+          ]
+        },
+        {
+          "description": "Manage package-groups on your content hosts",
+          "name": "package-group",
+          "options": [
+            {
+              "help": "print help",
+              "name": "help",
+              "shortname": "h",
+              "value": null
+            }
+          ],
+          "subcommands": [
+            {
+              "description": "Install packages remotely",
+              "name": "install",
+              "options": [
+                {
+                  "help": "Do not wait for the task",
+                  "name": "async",
+                  "shortname": null,
+                  "value": null
+                },
+                {
+                  "help": "Name to search by",
+                  "name": "content-host",
+                  "shortname": null,
+                  "value": "CONTENT_HOST_NAME"
+                },
+                {
+                  "help": "UUID of the content host",
+                  "name": "content-host-id",
+                  "shortname": null,
+                  "value": "CONTENT_HOST_ID"
+                },
+                {
+                  "help": "List of package group names Comma separated list of values.",
+                  "name": "groups",
+                  "shortname": null,
+                  "value": "GROUPS"
+                },
+                {
+                  "help": "Organization name to search by",
+                  "name": "organization",
+                  "shortname": null,
+                  "value": "ORGANIZATION_NAME"
+                },
+                {
+                  "help": "organization ID",
+                  "name": "organization-id",
+                  "shortname": null,
+                  "value": "ORGANIZATION_ID"
+                },
+                {
+                  "help": "Organization label to search by",
+                  "name": "organization-label",
+                  "shortname": null,
+                  "value": "ORGANIZATION_LABEL"
+                },
+                {
+                  "help": "print help",
+                  "name": "help",
+                  "shortname": "h",
+                  "value": null
+                }
+              ],
+              "subcommands": []
+            },
+            {
+              "description": "Uninstall packages remotely",
+              "name": "remove",
+              "options": [
+                {
+                  "help": "Do not wait for the task",
+                  "name": "async",
+                  "shortname": null,
+                  "value": null
+                },
+                {
+                  "help": "Name to search by",
+                  "name": "content-host",
+                  "shortname": null,
+                  "value": "CONTENT_HOST_NAME"
+                },
+                {
+                  "help": "UUID of the content host",
+                  "name": "content-host-id",
+                  "shortname": null,
+                  "value": "CONTENT_HOST_ID"
+                },
+                {
+                  "help": "List of package group names Comma separated list of values.",
+                  "name": "groups",
+                  "shortname": null,
+                  "value": "GROUPS"
+                },
+                {
+                  "help": "Organization name to search by",
+                  "name": "organization",
+                  "shortname": null,
+                  "value": "ORGANIZATION_NAME"
+                },
+                {
+                  "help": "organization ID",
+                  "name": "organization-id",
+                  "shortname": null,
+                  "value": "ORGANIZATION_ID"
+                },
+                {
+                  "help": "Organization label to search by",
+                  "name": "organization-label",
+                  "shortname": null,
+                  "value": "ORGANIZATION_LABEL"
+                },
+                {
+                  "help": "print help",
+                  "name": "help",
+                  "shortname": "h",
+                  "value": null
+                }
+              ],
+              "subcommands": []
+            }
+          ]
+        },
+        {
+          "description": "",
+          "name": "tasks",
+          "options": [
+            {
+              "help": "ID of the content host",
+              "name": "id",
+              "shortname": null,
+              "value": "ID"
+            },
+            {
+              "help": "print help",
+              "name": "help",
+              "shortname": "h",
+              "value": null
+            }
+          ],
+          "subcommands": []
+        },
+        {
+          "description": "Update content host information",
+          "name": "update",
+          "options": [
+            {
+              "help": "Content view name",
+              "name": "content-view",
+              "shortname": null,
+              "value": "CONTENT_VIEW_NAME"
+            },
+            {
+              "help": "content view numeric identifier",
+              "name": "content-view-id",
+              "shortname": null,
+              "value": "CONTENT_VIEW_ID"
+            },
+            {
+              "help": "Description of the content host",
+              "name": "description",
+              "shortname": null,
+              "value": "DESCRIPTION"
+            },
+            {
+              "help": "IDs of the virtual guests running on this content host Comma separated list of values.",
+              "name": "guest-ids",
+              "shortname": null,
+              "value": "GUEST_IDS"
+            },
+            {
+              "help": "Specify the host collections as an array Comma separated list of values.",
+              "name": "host-collection-ids",
+              "shortname": null,
+              "value": "HOST_COLLECTION_IDS"
+            },
+            {
+              "help": "Comma separated list of values.",
+              "name": "host-collections",
+              "shortname": null,
+              "value": "HOST_COLLECTION_NAMES"
+            },
+            {
+              "help": "ID of the content host",
+              "name": "id",
+              "shortname": null,
+              "value": "ID"
+            },
+            {
+              "help": "Last check-in time of this content host",
+              "name": "last-checkin",
+              "shortname": null,
+              "value": "LAST_CHECKIN"
+            },
+            {
+              "help": "Name to search by",
+              "name": "lifecycle-environment",
+              "shortname": null,
+              "value": "LIFECYCLE_ENVIRONMENT_NAME"
+            },
+            {
+              "help": "",
+              "name": "lifecycle-environment-id",
+              "shortname": null,
+              "value": "LIFECYCLE_ENVIRONMENT_ID"
+            },
+            {
+              "help": "Physical location of the content host",
+              "name": "location",
+              "shortname": null,
+              "value": "LOCATION"
+            },
+            {
+              "help": "Name to search by",
+              "name": "name",
+              "shortname": null,
+              "value": "NAME"
+            },
+            {
+              "help": "Name of the content host",
+              "name": "new-name",
+              "shortname": null,
+              "value": "NEW_NAME"
+            },
+            {
+              "help": "Organization name to search by",
+              "name": "organization",
+              "shortname": null,
+              "value": "ORGANIZATION_NAME"
+            },
+            {
+              "help": "organization ID",
+              "name": "organization-id",
+              "shortname": null,
+              "value": "ORGANIZATION_ID"
+            },
+            {
+              "help": "Organization label to search by",
+              "name": "organization-label",
+              "shortname": null,
+              "value": "ORGANIZATION_LABEL"
+            },
+            {
+              "help": "Release version of the content host",
+              "name": "release-ver",
+              "shortname": null,
+              "value": "RELEASE_VER"
+            },
+            {
+              "help": "A service level for auto-healing process, e.g. SELF-SUPPORT",
+              "name": "service-level",
+              "shortname": null,
+              "value": "SERVICE_LEVEL"
+            },
+            {
+              "help": "print help",
+              "name": "help",
+              "shortname": "h",
+              "value": null
+            }
+          ],
+          "subcommands": []
+        }
+      ]
+    },
+    {
+      "description": "View Content Reports",
+      "name": "content-report",
+      "options": [
+        {
+          "help": "print help",
+          "name": "help",
+          "shortname": "h",
+          "value": null
+        }
+      ],
+      "subcommands": [
+        {
+          "description": "Show the latest subscription status for a list of content hosts that have reported their subscription status during a specified time period. Running this report with minimal parameters will return all status records for all reported content hosts.",
+          "name": "content-host-status",
+          "options": [
+            {
+              "help": "Do not wait for the task",
+              "name": "async",
+              "shortname": null,
+              "value": null
+            },
+            {
+              "help": "Name to search by",
+              "name": "content-host",
+              "shortname": null,
+              "value": "CONTENT_HOST_NAME"
+            },
+            {
+              "help": "UUID of the content host",
+              "name": "content-host-id",
+              "shortname": null,
+              "value": "CONTENT_HOST_ID"
+            },
+            {
+              "help": "Date to filter on. If not given, defaults to NOW. Results will be limited to status records that were last reported before or on the given date. Must be a date in the form of YYYY-MM-DD.",
+              "name": "on-date",
+              "shortname": null,
+              "value": "ON_DATE"
+            },
+            {
+              "help": "Organization name to search by",
+              "name": "organization",
+              "shortname": null,
+              "value": "ORGANIZATION_NAME"
+            },
+            {
+              "help": "organization ID",
+              "name": "organization-id",
+              "shortname": null,
+              "value": "ORGANIZATION_ID"
+            },
+            {
+              "help": "Organization label to search by",
+              "name": "organization-label",
+              "shortname": null,
+              "value": "ORGANIZATION_LABEL"
+            },
+            {
+              "help": "Filter results on content host status.",
+              "name": "status",
+              "shortname": null,
+              "value": "STATUS"
+            },
+            {
+              "help": "print help",
+              "name": "help",
+              "shortname": "h",
+              "value": null
+            }
+          ],
+          "subcommands": []
+        },
+        {
+          "description": "Show a listing of all subscription status snapshots from content hosts which have reported their subscription status in the specified time period.",
+          "name": "content-host-trend",
+          "options": [
+            {
+              "help": "Do not wait for the task",
+              "name": "async",
+              "shortname": null,
+              "value": null
+            },
+            {
+              "help": "Name to search by",
+              "name": "content-host",
+              "shortname": null,
+              "value": "CONTENT_HOST_NAME"
+            },
+            {
+              "help": "UUID of the content host",
+              "name": "content-host-id",
+              "shortname": null,
+              "value": "CONTENT_HOST_ID"
+            },
+            {
+              "help": "End date. Used in conjunction with start_date. Must be a date in the form of YYYY-MM-DD.",
+              "name": "end-date",
+              "shortname": null,
+              "value": "END_DATE"
+            },
+            {
+              "help": "Show a trend between HOURS and now. Used independently of start_date/end_date.",
+              "name": "hours",
+              "shortname": null,
+              "value": "HOURS"
+            },
+            {
+              "help": "Organization name to search by",
+              "name": "organization",
+              "shortname": null,
+              "value": "ORGANIZATION_NAME"
+            },
+            {
+              "help": "organization ID",
+              "name": "organization-id",
+              "shortname": null,
+              "value": "ORGANIZATION_ID"
+            },
+            {
+              "help": "Organization label to search by",
+              "name": "organization-label",
+              "shortname": null,
+              "value": "ORGANIZATION_LABEL"
+            },
+            {
+              "help": "Start date. Used in conjunction with end_date. Must be a date in the form of YYYY-MM-DD.",
+              "name": "start-date",
+              "shortname": null,
+              "value": "START_DATE"
+            },
+            {
+              "help": "print help",
+              "name": "help",
+              "shortname": "h",
+              "value": null
+            }
+          ],
+          "subcommands": []
+        },
+        {
+          "description": "Show the per-day counts of content-hosts, grouped by subscription status, optionally limited to a date range.",
+          "name": "status-trend",
+          "options": [
+            {
+              "help": "Do not wait for the task",
+              "name": "async",
+              "shortname": null,
+              "value": null
+            },
+            {
+              "help": "End date. Used in conjunction with start_date. Must be a date in the form of YYYY-MM-DD.",
+              "name": "end-date",
+              "shortname": null,
+              "value": "END_DATE"
+            },
+            {
+              "help": "Organization name to search by",
+              "name": "organization",
+              "shortname": null,
+              "value": "ORGANIZATION_NAME"
+            },
+            {
+              "help": "organization ID",
+              "name": "organization-id",
+              "shortname": null,
+              "value": "ORGANIZATION_ID"
+            },
+            {
+              "help": "Organization label to search by",
+              "name": "organization-label",
+              "shortname": null,
+              "value": "ORGANIZATION_LABEL"
+            },
+            {
+              "help": "Start date. Used in conjunction with end_date. Must be a date in the form of YYYY-MM-DD.",
+              "name": "start-date",
+              "shortname": null,
+              "value": "START_DATE"
+            },
+            {
+              "help": "print help",
+              "name": "help",
+              "shortname": "h",
+              "value": null
+            }
+          ],
+          "subcommands": []
+        }
+      ]
+    },
+    {
+      "description": "Manipulate content views.",
+      "name": "content-view",
+      "options": [
+        {
+          "help": "print help",
+          "name": "help",
+          "shortname": "h",
+          "value": null
+        }
+      ],
+      "subcommands": [
+        {
+          "description": "Associate a resource",
+          "name": "add-repository",
+          "options": [
+            {
+              "help": "content view numeric identifier",
+              "name": "id",
+              "shortname": null,
+              "value": "ID"
+            },
+            {
+              "help": "Content view name",
+              "name": "name",
+              "shortname": null,
+              "value": "NAME"
+            },
+            {
+              "help": "Organization name to search by",
+              "name": "organization",
+              "shortname": null,
+              "value": "ORGANIZATION_NAME"
+            },
+            {
+              "help": "organization ID",
+              "name": "organization-id",
+              "shortname": null,
+              "value": "ORGANIZATION_ID"
+            },
+            {
+              "help": "Organization label to search by",
+              "name": "organization-label",
+              "shortname": null,
+              "value": "ORGANIZATION_LABEL"
+            },
+            {
+              "help": "Product name to search by",
+              "name": "product",
+              "shortname": null,
+              "value": "PRODUCT_NAME"
+            },
+            {
+              "help": "product numeric identifier",
+              "name": "product-id",
+              "shortname": null,
+              "value": "PRODUCT_ID"
+            },
+            {
+              "help": "Repository name to search by",
+              "name": "repository",
+              "shortname": null,
+              "value": "REPOSITORY_NAME"
+            },
+            {
+              "help": "repository ID",
+              "name": "repository-id",
+              "shortname": null,
+              "value": "REPOSITORY_ID"
+            },
+            {
+              "help": "print help",
+              "name": "help",
+              "shortname": "h",
+              "value": null
+            }
+          ],
+          "subcommands": []
+        },
+        {
+          "description": "Update a content view",
+          "name": "add-version",
+          "options": [
+            {
+              "help": "Content view version number",
+              "name": "content-view-version",
+              "shortname": null,
+              "value": "CONTENT_VIEW_VERSION_VERSION"
+            },
+            {
+              "help": "Content view version identifier",
+              "name": "content-view-version-id",
+              "shortname": null,
+              "value": "CONTENT_VIEW_VERSION_ID"
+            },
+            {
+              "help": "content view numeric identifier",
+              "name": "id",
+              "shortname": null,
+              "value": "ID"
+            },
+            {
+              "help": "Content view name",
+              "name": "name",
+              "shortname": null,
+              "value": "NAME"
+            },
+            {
+              "help": "Organization name to search by",
+              "name": "organization",
+              "shortname": null,
+              "value": "ORGANIZATION_NAME"
+            },
+            {
+              "help": "organization ID",
+              "name": "organization-id",
+              "shortname": null,
+              "value": "ORGANIZATION_ID"
+            },
+            {
+              "help": "Organization label to search by",
+              "name": "organization-label",
+              "shortname": null,
+              "value": "ORGANIZATION_LABEL"
+            },
+            {
+              "help": "print help",
+              "name": "help",
+              "shortname": "h",
+              "value": null
+            }
+          ],
+          "subcommands": []
+        },
+        {
+          "description": "Create a content view",
+          "name": "create",
+          "options": [
+            {
+              "help": "List of component content view version ids for composite views Comma separated list of values.",
+              "name": "component-ids",
+              "shortname": null,
+              "value": "COMPONENT_IDS"
+            },
+            {
+              "help": "Create a composite content view",
+              "name": "composite",
+              "shortname": null,
+              "value": null
+            },
+            {
+              "help": "Description for the content view",
+              "name": "description",
+              "shortname": null,
+              "value": "DESCRIPTION"
+            },
+            {
+              "help": "Content view label",
+              "name": "label",
+              "shortname": null,
+              "value": "LABEL"
+            },
+            {
+              "help": "Name of the content view",
+              "name": "name",
+              "shortname": null,
+              "value": "NAME"
+            },
+            {
+              "help": "Organization name to search by",
+              "name": "organization",
+              "shortname": null,
+              "value": "ORGANIZATION_NAME"
+            },
+            {
+              "help": "organization ID",
+              "name": "organization-id",
+              "shortname": null,
+              "value": "ORGANIZATION_ID"
+            },
+            {
+              "help": "Organization label to search by",
+              "name": "organization-label",
+              "shortname": null,
+              "value": "ORGANIZATION_LABEL"
+            },
+            {
+              "help": "Comma separated list of values.",
+              "name": "repositories",
+              "shortname": null,
+              "value": "REPOSITORY_NAMES"
+            },
+            {
+              "help": "List of repository ids Comma separated list of values.",
+              "name": "repository-ids",
+              "shortname": null,
+              "value": "REPOSITORY_IDS"
+            },
+            {
+              "help": "print help",
+              "name": "help",
+              "shortname": "h",
+              "value": null
+            }
+          ],
+          "subcommands": []
+        },
+        {
+          "description": "Delete a content view",
+          "name": "delete",
+          "options": [
+            {
+              "help": "Do not wait for the task",
+              "name": "async",
+              "shortname": null,
+              "value": null
+            },
+            {
+              "help": "content view numeric identifier",
+              "name": "id",
+              "shortname": null,
+              "value": "ID"
+            },
+            {
+              "help": "Content view name",
+              "name": "name",
+              "shortname": null,
+              "value": "NAME"
+            },
+            {
+              "help": "Organization name to search by",
+              "name": "organization",
+              "shortname": null,
+              "value": "ORGANIZATION_NAME"
+            },
+            {
+              "help": "organization ID",
+              "name": "organization-id",
+              "shortname": null,
+              "value": "ORGANIZATION_ID"
+            },
+            {
+              "help": "Organization label to search by",
+              "name": "organization-label",
+              "shortname": null,
+              "value": "ORGANIZATION_LABEL"
+            },
+            {
+              "help": "print help",
+              "name": "help",
+              "shortname": "h",
+              "value": null
+            }
+          ],
+          "subcommands": []
+        },
+        {
+          "description": "View and manage filters",
+          "name": "filter",
+          "options": [
+            {
+              "help": "print help",
+              "name": "help",
+              "shortname": "h",
+              "value": null
+            }
+          ],
+          "subcommands": [
+            {
+              "description": "Associate a resource",
+              "name": "add-repository",
+              "options": [
+                {
+                  "help": "Content view name",
+                  "name": "content-view",
+                  "shortname": null,
+                  "value": "CONTENT_VIEW_NAME"
+                },
+                {
+                  "help": "content view numeric identifier",
+                  "name": "content-view-id",
+                  "shortname": null,
+                  "value": "CONTENT_VIEW_ID"
+                },
+                {
+                  "help": "filter identifier",
+                  "name": "id",
+                  "shortname": null,
+                  "value": "ID"
+                },
+                {
+                  "help": "Name to search by",
+                  "name": "name",
+                  "shortname": null,
+                  "value": "NAME"
+                },
+                {
+                  "help": "Organization name to search by",
+                  "name": "organization",
+                  "shortname": null,
+                  "value": "ORGANIZATION_NAME"
+                },
+                {
+                  "help": "organization ID",
+                  "name": "organization-id",
+                  "shortname": null,
+                  "value": "ORGANIZATION_ID"
+                },
+                {
+                  "help": "Organization label to search by",
+                  "name": "organization-label",
+                  "shortname": null,
+                  "value": "ORGANIZATION_LABEL"
+                },
+                {
+                  "help": "Product name to search by",
+                  "name": "product",
+                  "shortname": null,
+                  "value": "PRODUCT_NAME"
+                },
+                {
+                  "help": "product numeric identifier",
+                  "name": "product-id",
+                  "shortname": null,
+                  "value": "PRODUCT_ID"
+                },
+                {
+                  "help": "Repository name to search by",
+                  "name": "repository",
+                  "shortname": null,
+                  "value": "REPOSITORY_NAME"
+                },
+                {
+                  "help": "repository ID",
+                  "name": "repository-id",
+                  "shortname": null,
+                  "value": "REPOSITORY_ID"
+                },
+                {
+                  "help": "print help",
+                  "name": "help",
+                  "shortname": "h",
+                  "value": null
+                }
+              ],
+              "subcommands": []
+            },
+            {
+              "description": "Create a filter for a content view",
+              "name": "create",
+              "options": [
+                {
+                  "help": "Content view name",
+                  "name": "content-view",
+                  "shortname": null,
+                  "value": "CONTENT_VIEW_NAME"
+                },
+                {
+                  "help": "content view numeric identifier",
+                  "name": "content-view-id",
+                  "shortname": null,
+                  "value": "CONTENT_VIEW_ID"
+                },
+                {
+                  "help": "description of the filter",
+                  "name": "description",
+                  "shortname": null,
+                  "value": "DESCRIPTION"
+                },
+                {
+                  "help": "specifies if content should be included or excluded, default: inclusion=false One of true/false, yes/no, 1/0.",
+                  "name": "inclusion",
+                  "shortname": null,
+                  "value": "INCLUSION"
+                },
+                {
+                  "help": "name of the filter",
+                  "name": "name",
+                  "shortname": null,
+                  "value": "NAME"
+                },
+                {
+                  "help": "Organization name to search by",
+                  "name": "organization",
+                  "shortname": null,
+                  "value": "ORGANIZATION_NAME"
+                },
+                {
+                  "help": "organization ID",
+                  "name": "organization-id",
+                  "shortname": null,
+                  "value": "ORGANIZATION_ID"
+                },
+                {
+                  "help": "Organization label to search by",
+                  "name": "organization-label",
+                  "shortname": null,
+                  "value": "ORGANIZATION_LABEL"
+                },
+                {
+                  "help": "Add all packages without Errata to the included/excluded list. (Package Filter only) One of true/false, yes/no, 1/0.",
+                  "name": "original-packages",
+                  "shortname": null,
+                  "value": "ORIGINAL_PACKAGES"
+                },
+                {
+                  "help": "Comma separated list of values.",
+                  "name": "repositories",
+                  "shortname": null,
+                  "value": "REPOSITORY_NAMES"
+                },
+                {
+                  "help": "list of repository ids Comma separated list of values.",
+                  "name": "repository-ids",
+                  "shortname": null,
+                  "value": "REPOSITORY_IDS"
+                },
+                {
+                  "help": "type of filter (e.g. rpm, package_group, erratum)",
+                  "name": "type",
+                  "shortname": null,
+                  "value": "TYPE"
+                },
+                {
+                  "help": "print help",
+                  "name": "help",
+                  "shortname": "h",
+                  "value": null
+                }
+              ],
+              "subcommands": []
+            },
+            {
+              "description": "Delete a filter",
+              "name": "delete",
+              "options": [
+                {
+                  "help": "Content view name",
+                  "name": "content-view",
+                  "shortname": null,
+                  "value": "CONTENT_VIEW_NAME"
+                },
+                {
+                  "help": "content view numeric identifier",
+                  "name": "content-view-id",
+                  "shortname": null,
+                  "value": "CONTENT_VIEW_ID"
+                },
+                {
+                  "help": "filter identifier",
+                  "name": "id",
+                  "shortname": null,
+                  "value": "ID"
+                },
+                {
+                  "help": "Name to search by",
+                  "name": "name",
+                  "shortname": null,
+                  "value": "NAME"
+                },
+                {
+                  "help": "Organization name to search by",
+                  "name": "organization",
+                  "shortname": null,
+                  "value": "ORGANIZATION_NAME"
+                },
+                {
+                  "help": "organization ID",
+                  "name": "organization-id",
+                  "shortname": null,
+                  "value": "ORGANIZATION_ID"
+                },
+                {
+                  "help": "Organization label to search by",
+                  "name": "organization-label",
+                  "shortname": null,
+                  "value": "ORGANIZATION_LABEL"
+                },
+                {
+                  "help": "print help",
+                  "name": "help",
+                  "shortname": "h",
+                  "value": null
+                }
+              ],
+              "subcommands": []
+            },
+            {
+              "description": "Show filter info",
+              "name": "info",
+              "options": [
+                {
+                  "help": "Content view name",
+                  "name": "content-view",
+                  "shortname": null,
+                  "value": "CONTENT_VIEW_NAME"
+                },
+                {
+                  "help": "content view numeric identifier",
+                  "name": "content-view-id",
+                  "shortname": null,
+                  "value": "CONTENT_VIEW_ID"
+                },
+                {
+                  "help": "filter identifier",
+                  "name": "id",
+                  "shortname": null,
+                  "value": "ID"
+                },
+                {
+                  "help": "Name to search by",
+                  "name": "name",
+                  "shortname": null,
+                  "value": "NAME"
+                },
+                {
+                  "help": "Organization name to search by",
+                  "name": "organization",
+                  "shortname": null,
+                  "value": "ORGANIZATION_NAME"
+                },
+                {
+                  "help": "organization ID",
+                  "name": "organization-id",
+                  "shortname": null,
+                  "value": "ORGANIZATION_ID"
+                },
+                {
+                  "help": "Organization label to search by",
+                  "name": "organization-label",
+                  "shortname": null,
+                  "value": "ORGANIZATION_LABEL"
+                },
+                {
+                  "help": "print help",
+                  "name": "help",
+                  "shortname": "h",
+                  "value": null
+                }
+              ],
+              "subcommands": []
+            },
+            {
+              "description": "List filters",
+              "name": "list",
+              "options": [
+                {
+                  "help": "Content view name",
+                  "name": "content-view",
+                  "shortname": null,
+                  "value": "CONTENT_VIEW_NAME"
+                },
+                {
+                  "help": "content view numeric identifier",
+                  "name": "content-view-id",
+                  "shortname": null,
+                  "value": "CONTENT_VIEW_ID"
+                },
+                {
+                  "help": "Filter content view filters by name",
+                  "name": "name",
+                  "shortname": null,
+                  "value": "NAME"
+                },
+                {
+                  "help": "Organization name to search by",
+                  "name": "organization",
+                  "shortname": null,
+                  "value": "ORGANIZATION_NAME"
+                },
+                {
+                  "help": "organization ID",
+                  "name": "organization-id",
+                  "shortname": null,
+                  "value": "ORGANIZATION_ID"
+                },
+                {
+                  "help": "Organization label to search by",
+                  "name": "organization-label",
+                  "shortname": null,
+                  "value": "ORGANIZATION_LABEL"
+                },
+                {
+                  "help": "print help",
+                  "name": "help",
+                  "shortname": "h",
+                  "value": null
+                }
+              ],
+              "subcommands": []
+            },
+            {
+              "description": "Disassociate a resource",
+              "name": "remove-repository",
+              "options": [
+                {
+                  "help": "Content view name",
+                  "name": "content-view",
+                  "shortname": null,
+                  "value": "CONTENT_VIEW_NAME"
+                },
+                {
+                  "help": "content view numeric identifier",
+                  "name": "content-view-id",
+                  "shortname": null,
+                  "value": "CONTENT_VIEW_ID"
+                },
+                {
+                  "help": "filter identifier",
+                  "name": "id",
+                  "shortname": null,
+                  "value": "ID"
+                },
+                {
+                  "help": "Name to search by",
+                  "name": "name",
+                  "shortname": null,
+                  "value": "NAME"
+                },
+                {
+                  "help": "Organization name to search by",
+                  "name": "organization",
+                  "shortname": null,
+                  "value": "ORGANIZATION_NAME"
+                },
+                {
+                  "help": "organization ID",
+                  "name": "organization-id",
+                  "shortname": null,
+                  "value": "ORGANIZATION_ID"
+                },
+                {
+                  "help": "Organization label to search by",
+                  "name": "organization-label",
+                  "shortname": null,
+                  "value": "ORGANIZATION_LABEL"
+                },
+                {
+                  "help": "Product name to search by",
+                  "name": "product",
+                  "shortname": null,
+                  "value": "PRODUCT_NAME"
+                },
+                {
+                  "help": "product numeric identifier",
+                  "name": "product-id",
+                  "shortname": null,
+                  "value": "PRODUCT_ID"
+                },
+                {
+                  "help": "Repository name to search by",
+                  "name": "repository",
+                  "shortname": null,
+                  "value": "REPOSITORY_NAME"
+                },
+                {
+                  "help": "repository ID",
+                  "name": "repository-id",
+                  "shortname": null,
+                  "value": "REPOSITORY_ID"
+                },
+                {
+                  "help": "print help",
+                  "name": "help",
+                  "shortname": "h",
+                  "value": null
+                }
+              ],
+              "subcommands": []
+            },
+            {
+              "description": "View and manage filter rules",
+              "name": "rule",
+              "options": [
+                {
+                  "help": "print help",
+                  "name": "help",
+                  "shortname": "h",
+                  "value": null
+                }
+              ],
+              "subcommands": [
+                {
+                  "description": "Create a filter rule. The parameters included should be based upon the filter type.",
+                  "name": "create",
+                  "options": [
+                    {
+                      "help": "Content view name",
+                      "name": "content-view",
+                      "shortname": null,
+                      "value": "CONTENT_VIEW_NAME"
+                    },
+                    {
+                      "help": "Name to search by",
+                      "name": "content-view-filter",
+                      "shortname": null,
+                      "value": "CONTENT_VIEW_FILTER_NAME"
+                    },
+                    {
+                      "help": "filter identifier",
+                      "name": "content-view-filter-id",
+                      "shortname": null,
+                      "value": "CONTENT_VIEW_FILTER_ID"
+                    },
+                    {
+                      "help": "content view numeric identifier",
+                      "name": "content-view-id",
+                      "shortname": null,
+                      "value": "CONTENT_VIEW_ID"
+                    },
+                    {
+                      "help": "erratum: end date (YYYY-MM-DD)",
+                      "name": "end-date",
+                      "shortname": null,
+                      "value": "END_DATE"
+                    },
+                    {
+                      "help": "erratum: id",
+                      "name": "errata-id",
+                      "shortname": null,
+                      "value": "ERRATA_ID"
+                    },
+                    {
+                      "help": "erratum: IDs or a select all object Comma separated list of values.",
+                      "name": "errata-ids",
+                      "shortname": null,
+                      "value": "ERRATA_IDS"
+                    },
+                    {
+                      "help": "package: maximum version",
+                      "name": "max-version",
+                      "shortname": null,
+                      "value": "MAX_VERSION"
+                    },
+                    {
+                      "help": "package: minimum version",
+                      "name": "min-version",
+                      "shortname": null,
+                      "value": "MIN_VERSION"
+                    },
+                    {
+                      "help": "package or package group: name",
+                      "name": "name",
+                      "shortname": null,
+                      "value": "NAME"
+                    },
+                    {
+                      "help": "Organization name to search by",
+                      "name": "organization",
+                      "shortname": null,
+                      "value": "ORGANIZATION_NAME"
+                    },
+                    {
+                      "help": "organization ID",
+                      "name": "organization-id",
+                      "shortname": null,
+                      "value": "ORGANIZATION_ID"
+                    },
+                    {
+                      "help": "Organization label to search by",
+                      "name": "organization-label",
+                      "shortname": null,
+                      "value": "ORGANIZATION_LABEL"
+                    },
+                    {
+                      "help": "erratum: start date (YYYY-MM-DD)",
+                      "name": "start-date",
+                      "shortname": null,
+                      "value": "START_DATE"
+                    },
+                    {
+                      "help": "erratum: types (enhancement, bugfix, security) Comma separated list of values.",
+                      "name": "types",
+                      "shortname": null,
+                      "value": "TYPES"
+                    },
+                    {
+                      "help": "package: version",
+                      "name": "version",
+                      "shortname": null,
+                      "value": "VERSION"
+                    },
+                    {
+                      "help": "print help",
+                      "name": "help",
+                      "shortname": "h",
+                      "value": null
+                    }
+                  ],
+                  "subcommands": []
+                },
+                {
+                  "description": "Delete a filter rule",
+                  "name": "delete",
+                  "options": [
+                    {
+                      "help": "Content view name",
+                      "name": "content-view",
+                      "shortname": null,
+                      "value": "CONTENT_VIEW_NAME"
+                    },
+                    {
+                      "help": "Name to search by",
+                      "name": "content-view-filter",
+                      "shortname": null,
+                      "value": "CONTENT_VIEW_FILTER_NAME"
+                    },
+                    {
+                      "help": "filter identifier",
+                      "name": "content-view-filter-id",
+                      "shortname": null,
+                      "value": "CONTENT_VIEW_FILTER_ID"
+                    },
+                    {
+                      "help": "content view numeric identifier",
+                      "name": "content-view-id",
+                      "shortname": null,
+                      "value": "CONTENT_VIEW_ID"
+                    },
+                    {
+                      "help": "rule identifier",
+                      "name": "id",
+                      "shortname": null,
+                      "value": "ID"
+                    },
+                    {
+                      "help": "Name to search by",
+                      "name": "name",
+                      "shortname": null,
+                      "value": "NAME"
+                    },
+                    {
+                      "help": "Organization name to search by",
+                      "name": "organization",
+                      "shortname": null,
+                      "value": "ORGANIZATION_NAME"
+                    },
+                    {
+                      "help": "organization ID",
+                      "name": "organization-id",
+                      "shortname": null,
+                      "value": "ORGANIZATION_ID"
+                    },
+                    {
+                      "help": "Organization label to search by",
+                      "name": "organization-label",
+                      "shortname": null,
+                      "value": "ORGANIZATION_LABEL"
+                    },
+                    {
+                      "help": "print help",
+                      "name": "help",
+                      "shortname": "h",
+                      "value": null
+                    }
+                  ],
+                  "subcommands": []
+                },
+                {
+                  "description": "Show filter rule info",
+                  "name": "info",
+                  "options": [
+                    {
+                      "help": "Content view name",
+                      "name": "content-view",
+                      "shortname": null,
+                      "value": "CONTENT_VIEW_NAME"
+                    },
+                    {
+                      "help": "Name to search by",
+                      "name": "content-view-filter",
+                      "shortname": null,
+                      "value": "CONTENT_VIEW_FILTER_NAME"
+                    },
+                    {
+                      "help": "filter identifier",
+                      "name": "content-view-filter-id",
+                      "shortname": null,
+                      "value": "CONTENT_VIEW_FILTER_ID"
+                    },
+                    {
+                      "help": "content view numeric identifier",
+                      "name": "content-view-id",
+                      "shortname": null,
+                      "value": "CONTENT_VIEW_ID"
+                    },
+                    {
+                      "help": "rule identifier",
+                      "name": "id",
+                      "shortname": null,
+                      "value": "ID"
+                    },
+                    {
+                      "help": "Name to search by",
+                      "name": "name",
+                      "shortname": null,
+                      "value": "NAME"
+                    },
+                    {
+                      "help": "Organization name to search by",
+                      "name": "organization",
+                      "shortname": null,
+                      "value": "ORGANIZATION_NAME"
+                    },
+                    {
+                      "help": "organization ID",
+                      "name": "organization-id",
+                      "shortname": null,
+                      "value": "ORGANIZATION_ID"
+                    },
+                    {
+                      "help": "Organization label to search by",
+                      "name": "organization-label",
+                      "shortname": null,
+                      "value": "ORGANIZATION_LABEL"
+                    },
+                    {
+                      "help": "print help",
+                      "name": "help",
+                      "shortname": "h",
+                      "value": null
+                    }
+                  ],
+                  "subcommands": []
+                },
+                {
+                  "description": "List filter rules",
+                  "name": "list",
+                  "options": [
+                    {
+                      "help": "Content view name",
+                      "name": "content-view",
+                      "shortname": null,
+                      "value": "CONTENT_VIEW_NAME"
+                    },
+                    {
+                      "help": "Name to search by",
+                      "name": "content-view-filter",
+                      "shortname": null,
+                      "value": "CONTENT_VIEW_FILTER_NAME"
+                    },
+                    {
+                      "help": "filter identifier",
+                      "name": "content-view-filter-id",
+                      "shortname": null,
+                      "value": "CONTENT_VIEW_FILTER_ID"
+                    },
+                    {
+                      "help": "content view numeric identifier",
+                      "name": "content-view-id",
+                      "shortname": null,
+                      "value": "CONTENT_VIEW_ID"
+                    },
+                    {
+                      "help": "Organization name to search by",
+                      "name": "organization",
+                      "shortname": null,
+                      "value": "ORGANIZATION_NAME"
+                    },
+                    {
+                      "help": "organization ID",
+                      "name": "organization-id",
+                      "shortname": null,
+                      "value": "ORGANIZATION_ID"
+                    },
+                    {
+                      "help": "Organization label to search by",
+                      "name": "organization-label",
+                      "shortname": null,
+                      "value": "ORGANIZATION_LABEL"
+                    },
+                    {
+                      "help": "print help",
+                      "name": "help",
+                      "shortname": "h",
+                      "value": null
+                    }
+                  ],
+                  "subcommands": []
+                },
+                {
+                  "description": "Update a filter rule. The parameters included should be based upon the filter type.",
+                  "name": "update",
+                  "options": [
+                    {
+                      "help": "Content view name",
+                      "name": "content-view",
+                      "shortname": null,
+                      "value": "CONTENT_VIEW_NAME"
+                    },
+                    {
+                      "help": "Name to search by",
+                      "name": "content-view-filter",
+                      "shortname": null,
+                      "value": "CONTENT_VIEW_FILTER_NAME"
+                    },
+                    {
+                      "help": "filter identifier",
+                      "name": "content-view-filter-id",
+                      "shortname": null,
+                      "value": "CONTENT_VIEW_FILTER_ID"
+                    },
+                    {
+                      "help": "content view numeric identifier",
+                      "name": "content-view-id",
+                      "shortname": null,
+                      "value": "CONTENT_VIEW_ID"
+                    },
+                    {
+                      "help": "erratum: end date (YYYY-MM-DD)",
+                      "name": "end-date",
+                      "shortname": null,
+                      "value": "END_DATE"
+                    },
+                    {
+                      "help": "erratum: id",
+                      "name": "errata-id",
+                      "shortname": null,
+                      "value": "ERRATA_ID"
+                    },
+                    {
+                      "help": "rule identifier",
+                      "name": "id",
+                      "shortname": null,
+                      "value": "ID"
+                    },
+                    {
+                      "help": "package: maximum version",
+                      "name": "max-version",
+                      "shortname": null,
+                      "value": "MAX_VERSION"
+                    },
+                    {
+                      "help": "package: minimum version",
+                      "name": "min-version",
+                      "shortname": null,
+                      "value": "MIN_VERSION"
+                    },
+                    {
+                      "help": "Name to search by",
+                      "name": "name",
+                      "shortname": null,
+                      "value": "NAME"
+                    },
+                    {
+                      "help": "package or package group: name",
+                      "name": "new-name",
+                      "shortname": null,
+                      "value": "NEW_NAME"
+                    },
+                    {
+                      "help": "Organization name to search by",
+                      "name": "organization",
+                      "shortname": null,
+                      "value": "ORGANIZATION_NAME"
+                    },
+                    {
+                      "help": "organization ID",
+                      "name": "organization-id",
+                      "shortname": null,
+                      "value": "ORGANIZATION_ID"
+                    },
+                    {
+                      "help": "Organization label to search by",
+                      "name": "organization-label",
+                      "shortname": null,
+                      "value": "ORGANIZATION_LABEL"
+                    },
+                    {
+                      "help": "erratum: start date (YYYY-MM-DD)",
+                      "name": "start-date",
+                      "shortname": null,
+                      "value": "START_DATE"
+                    },
+                    {
+                      "help": "erratum: types (enhancement, bugfix, security) Comma separated list of values.",
+                      "name": "types",
+                      "shortname": null,
+                      "value": "TYPES"
+                    },
+                    {
+                      "help": "package: version",
+                      "name": "version",
+                      "shortname": null,
+                      "value": "VERSION"
+                    },
+                    {
+                      "help": "print help",
+                      "name": "help",
+                      "shortname": "h",
+                      "value": null
+                    }
+                  ],
+                  "subcommands": []
+                }
+              ]
+            },
+            {
+              "description": "Update a filter",
+              "name": "update",
+              "options": [
+                {
+                  "help": "Content view name",
+                  "name": "content-view",
+                  "shortname": null,
+                  "value": "CONTENT_VIEW_NAME"
+                },
+                {
+                  "help": "content view numeric identifier",
+                  "name": "content-view-id",
+                  "shortname": null,
+                  "value": "CONTENT_VIEW_ID"
+                },
+                {
+                  "help": "filter identifier",
+                  "name": "id",
+                  "shortname": null,
+                  "value": "ID"
+                },
+                {
+                  "help": "specifies if content should be included or excluded, default: inclusion=false One of true/false, yes/no, 1/0.",
+                  "name": "inclusion",
+                  "shortname": null,
+                  "value": "INCLUSION"
+                },
+                {
+                  "help": "Name to search by",
+                  "name": "name",
+                  "shortname": null,
+                  "value": "NAME"
+                },
+                {
+                  "help": "new name for the filter",
+                  "name": "new-name",
+                  "shortname": null,
+                  "value": "NEW_NAME"
+                },
+                {
+                  "help": "Organization name to search by",
+                  "name": "organization",
+                  "shortname": null,
+                  "value": "ORGANIZATION_NAME"
+                },
+                {
+                  "help": "organization ID",
+                  "name": "organization-id",
+                  "shortname": null,
+                  "value": "ORGANIZATION_ID"
+                },
+                {
+                  "help": "Organization label to search by",
+                  "name": "organization-label",
+                  "shortname": null,
+                  "value": "ORGANIZATION_LABEL"
+                },
+                {
+                  "help": "Add all packages without Errata to the included/excluded list. (Package Filter only) One of true/false, yes/no, 1/0.",
+                  "name": "original-packages",
+                  "shortname": null,
+                  "value": "ORIGINAL_PACKAGES"
+                },
+                {
+                  "help": "Comma separated list of values.",
+                  "name": "repositories",
+                  "shortname": null,
+                  "value": "REPOSITORY_NAMES"
+                },
+                {
+                  "help": "list of repository ids Comma separated list of values.",
+                  "name": "repository-ids",
+                  "shortname": null,
+                  "value": "REPOSITORY_IDS"
+                },
+                {
+                  "help": "print help",
+                  "name": "help",
+                  "shortname": "h",
+                  "value": null
+                }
+              ],
+              "subcommands": []
+            }
+          ]
+        },
+        {
+          "description": "Show a content view",
+          "name": "info",
+          "options": [
+            {
+              "help": "content view numeric identifier",
+              "name": "id",
+              "shortname": null,
+              "value": "ID"
+            },
+            {
+              "help": "Content view name",
+              "name": "name",
+              "shortname": null,
+              "value": "NAME"
+            },
+            {
+              "help": "Organization name to search by",
+              "name": "organization",
+              "shortname": null,
+              "value": "ORGANIZATION_NAME"
+            },
+            {
+              "help": "organization ID",
+              "name": "organization-id",
+              "shortname": null,
+              "value": "ORGANIZATION_ID"
+            },
+            {
+              "help": "Organization label to search by",
+              "name": "organization-label",
+              "shortname": null,
+              "value": "ORGANIZATION_LABEL"
+            },
+            {
+              "help": "print help",
+              "name": "help",
+              "shortname": "h",
+              "value": null
+            }
+          ],
+          "subcommands": []
+        },
+        {
+          "description": "List content views",
+          "name": "list",
+          "options": [
+            {
+              "help": "Field to sort the results on",
+              "name": "by",
+              "shortname": null,
+              "value": "BY"
+            },
+            {
+              "help": "Whether or not to show all results One of true/false, yes/no, 1/0.",
+              "name": "full-results",
+              "shortname": null,
+              "value": "FULL_RESULTS"
+            },
+            {
+              "help": "Name to search by",
+              "name": "lifecycle-environment",
+              "shortname": null,
+              "value": "LIFECYCLE_ENVIRONMENT_NAME"
+            },
+            {
+              "help": "",
+              "name": "lifecycle-environment-id",
+              "shortname": null,
+              "value": "LIFECYCLE_ENVIRONMENT_ID"
+            },
+            {
+              "help": "Name of the content view",
+              "name": "name",
+              "shortname": null,
+              "value": "NAME"
+            },
+            {
+              "help": "Filter out composite content views One of true/false, yes/no, 1/0.",
+              "name": "noncomposite",
+              "shortname": null,
+              "value": "NONCOMPOSITE"
+            },
+            {
+              "help": "Filter out default content views One of true/false, yes/no, 1/0.",
+              "name": "nondefault",
+              "shortname": null,
+              "value": "NONDEFAULT"
+            },
+            {
+              "help": "Sort field and order, eg. 'name DESC'",
+              "name": "order",
+              "shortname": null,
+              "value": "ORDER"
+            },
+            {
+              "help": "Organization name to search by",
+              "name": "organization",
+              "shortname": null,
+              "value": "ORGANIZATION_NAME"
+            },
+            {
+              "help": "organization ID",
+              "name": "organization-id",
+              "shortname": null,
+              "value": "ORGANIZATION_ID"
+            },
+            {
+              "help": "Organization label to search by",
+              "name": "organization-label",
+              "shortname": null,
+              "value": "ORGANIZATION_LABEL"
+            },
+            {
+              "help": "Page number, starting at 1",
+              "name": "page",
+              "shortname": null,
+              "value": "PAGE"
+            },
+            {
+              "help": "Number of results per page to return",
+              "name": "per-page",
+              "shortname": null,
+              "value": "PER_PAGE"
+            },
+            {
+              "help": "Search string",
+              "name": "search",
+              "shortname": null,
+              "value": "SEARCH"
+            },
+            {
+              "help": "Do not include this array of content views Comma separated list of values.",
+              "name": "without",
+              "shortname": null,
+              "value": "WITHOUT"
+            },
+            {
+              "help": "print help",
+              "name": "help",
+              "shortname": "h",
+              "value": null
+            }
+          ],
+          "subcommands": []
+        },
+        {
+          "description": "Publish a content view",
+          "name": "publish",
+          "options": [
+            {
+              "help": "Do not wait for the task",
+              "name": "async",
+              "shortname": null,
+              "value": null
+            },
+            {
+              "help": "Description for the new published content view version",
+              "name": "description",
+              "shortname": null,
+              "value": "DESCRIPTION"
+            },
+            {
+              "help": "Content view identifier",
+              "name": "id",
+              "shortname": null,
+              "value": "ID"
+            },
+            {
+              "help": "Content view name",
+              "name": "name",
+              "shortname": null,
+              "value": "NAME"
+            },
+            {
+              "help": "Organization name to search by",
+              "name": "organization",
+              "shortname": null,
+              "value": "ORGANIZATION_NAME"
+            },
+            {
+              "help": "organization ID",
+              "name": "organization-id",
+              "shortname": null,
+              "value": "ORGANIZATION_ID"
+            },
+            {
+              "help": "Organization label to search by",
+              "name": "organization-label",
+              "shortname": null,
+              "value": "ORGANIZATION_LABEL"
+            },
+            {
+              "help": "print help",
+              "name": "help",
+              "shortname": "h",
+              "value": null
+            }
+          ],
+          "subcommands": []
+        },
+        {
+          "description": "View and manage puppet modules",
+          "name": "puppet-module",
+          "options": [
+            {
+              "help": "print help",
+              "name": "help",
+              "shortname": "h",
+              "value": null
+            }
+          ],
+          "subcommands": [
+            {
+              "description": "Add a puppet module to the content view",
+              "name": "add",
+              "options": [
+                {
+                  "help": "author of the puppet module",
+                  "name": "author",
+                  "shortname": null,
+                  "value": "AUTHOR"
+                },
+                {
+                  "help": "Content view name",
+                  "name": "content-view",
+                  "shortname": null,
+                  "value": "CONTENT_VIEW_NAME"
+                },
+                {
+                  "help": "content view numeric identifier",
+                  "name": "content-view-id",
+                  "shortname": null,
+                  "value": "CONTENT_VIEW_ID"
+                },
+                {
+                  "help": "id of the puppet module to associate",
+                  "name": "id",
+                  "shortname": null,
+                  "value": "ID"
+                },
+                {
+                  "help": "name of the puppet module",
+                  "name": "name",
+                  "shortname": null,
+                  "value": "NAME"
+                },
+                {
+                  "help": "Organization name to search by",
+                  "name": "organization",
+                  "shortname": null,
+                  "value": "ORGANIZATION_NAME"
+                },
+                {
+                  "help": "organization ID",
+                  "name": "organization-id",
+                  "shortname": null,
+                  "value": "ORGANIZATION_ID"
+                },
+                {
+                  "help": "Organization label to search by",
+                  "name": "organization-label",
+                  "shortname": null,
+                  "value": "ORGANIZATION_LABEL"
+                },
+                {
+                  "help": "print help",
+                  "name": "help",
+                  "shortname": "h",
+                  "value": null
+                }
+              ],
+              "subcommands": []
+            },
+            {
+              "description": "List content view puppet modules",
+              "name": "list",
+              "options": [
+                {
+                  "help": "author of the puppet module",
+                  "name": "author",
+                  "shortname": null,
+                  "value": "AUTHOR"
+                },
+                {
+                  "help": "Content view name",
+                  "name": "content-view",
+                  "shortname": null,
+                  "value": "CONTENT_VIEW_NAME"
+                },
+                {
+                  "help": "content view numeric identifier",
+                  "name": "content-view-id",
+                  "shortname": null,
+                  "value": "CONTENT_VIEW_ID"
+                },
+                {
+                  "help": "name of the puppet module",
+                  "name": "name",
+                  "shortname": null,
+                  "value": "NAME"
+                },
+                {
+                  "help": "Organization name to search by",
+                  "name": "organization",
+                  "shortname": null,
+                  "value": "ORGANIZATION_NAME"
+                },
+                {
+                  "help": "organization ID",
+                  "name": "organization-id",
+                  "shortname": null,
+                  "value": "ORGANIZATION_ID"
+                },
+                {
+                  "help": "Organization label to search by",
+                  "name": "organization-label",
+                  "shortname": null,
+                  "value": "ORGANIZATION_LABEL"
+                },
+                {
+                  "help": "the uuid of the puppet module to associate",
+                  "name": "uuid",
+                  "shortname": null,
+                  "value": "UUID"
+                },
+                {
+                  "help": "print help",
+                  "name": "help",
+                  "shortname": "h",
+                  "value": null
+                }
+              ],
+              "subcommands": []
+            },
+            {
+              "description": "Remove a puppet module from the content view",
+              "name": "remove",
+              "options": [
+                {
+                  "help": "Puppet module's author to search by",
+                  "name": "author",
+                  "shortname": null,
+                  "value": "AUTHOR"
+                },
+                {
+                  "help": "Content view name",
+                  "name": "content-view",
+                  "shortname": null,
+                  "value": "CONTENT_VIEW_NAME"
+                },
+                {
+                  "help": "content view numeric identifier",
+                  "name": "content-view-id",
+                  "shortname": null,
+                  "value": "CONTENT_VIEW_ID"
+                },
+                {
+                  "help": "puppet module ID",
+                  "name": "id",
+                  "shortname": null,
+                  "value": "ID"
+                },
+                {
+                  "help": "Puppet module name to search by",
+                  "name": "name",
+                  "shortname": null,
+                  "value": "NAME"
+                },
+                {
+                  "help": "Organization name to search by",
+                  "name": "organization",
+                  "shortname": null,
+                  "value": "ORGANIZATION_NAME"
+                },
+                {
+                  "help": "organization ID",
+                  "name": "organization-id",
+                  "shortname": null,
+                  "value": "ORGANIZATION_ID"
+                },
+                {
+                  "help": "Organization label to search by",
+                  "name": "organization-label",
+                  "shortname": null,
+                  "value": "ORGANIZATION_LABEL"
+                },
+                {
+                  "help": "Puppet module's UUID to search by",
+                  "name": "uuid",
+                  "shortname": null,
+                  "value": "UUID"
+                },
+                {
+                  "help": "print help",
+                  "name": "help",
+                  "shortname": "h",
+                  "value": null
+                }
+              ],
+              "subcommands": []
+            }
+          ]
+        },
+        {
+          "description": "Remove versions and/or environments from a content view and reassign systems and keys",
+          "name": "remove",
+          "options": [
+            {
+              "help": "Do not wait for the task",
+              "name": "async",
+              "shortname": null,
+              "value": null
+            },
+            {
+              "help": "Comma separated list of version ids to remove",
+              "name": "content-view-version-ids",
+              "shortname": null,
+              "value": "VERSION_IDS"
+            },
+            {
+              "help": "Comma separated list of values.",
+              "name": "content-view-versions",
+              "shortname": null,
+              "value": "CONTENT_VIEW_VERSION_VERSIONS"
+            },
+            {
+              "help": "Comma separated list of environment ids to remove",
+              "name": "environment-ids",
+              "shortname": null,
+              "value": "ENVIRONMENT_IDS"
+            },
+            {
+              "help": "Comma separated list of values.",
+              "name": "environments",
+              "shortname": null,
+              "value": "LIFECYCLE_ENVIRONMENT_NAMES"
+            },
+            {
+              "help": "content view numeric identifier",
+              "name": "id",
+              "shortname": null,
+              "value": "ID"
+            },
+            {
+              "help": "content view to reassign orphaned activation keys to",
+              "name": "key-content-view-id",
+              "shortname": null,
+              "value": "KEY_CONTENT_VIEW_ID"
+            },
+            {
+              "help": "environment to reassign orphaned activation keys to",
+              "name": "key-environment-id",
+              "shortname": null,
+              "value": "KEY_ENVIRONMENT_ID"
+            },
+            {
+              "help": "Content view name",
+              "name": "name",
+              "shortname": null,
+              "value": "NAME"
+            },
+            {
+              "help": "Organization name to search by",
+              "name": "organization",
+              "shortname": null,
+              "value": "ORGANIZATION_NAME"
+            },
+            {
+              "help": "organization ID",
+              "name": "organization-id",
+              "shortname": null,
+              "value": "ORGANIZATION_ID"
+            },
+            {
+              "help": "Organization label to search by",
+              "name": "organization-label",
+              "shortname": null,
+              "value": "ORGANIZATION_LABEL"
+            },
+            {
+              "help": "content view to reassign orphaned systems to",
+              "name": "system-content-view-id",
+              "shortname": null,
+              "value": "SYSTEM_CONTENT_VIEW_ID"
+            },
+            {
+              "help": "environment to reassign orphaned systems to",
+              "name": "system-environment-id",
+              "shortname": null,
+              "value": "SYSTEM_ENVIRONMENT_ID"
+            },
+            {
+              "help": "print help",
+              "name": "help",
+              "shortname": "h",
+              "value": null
+            }
+          ],
+          "subcommands": []
+        },
+        {
+          "description": "Remove a content view from an environment",
+          "name": "remove-from-environment",
+          "options": [
+            {
+              "help": "Do not wait for the task",
+              "name": "async",
+              "shortname": null,
+              "value": null
+            },
+            {
+              "help": "content view numeric identifier",
+              "name": "id",
+              "shortname": null,
+              "value": "ID"
+            },
+            {
+              "help": "Name to search by",
+              "name": "lifecycle-environment",
+              "shortname": null,
+              "value": "LIFECYCLE_ENVIRONMENT_NAME"
+            },
+            {
+              "help": "",
+              "name": "lifecycle-environment-id",
+              "shortname": null,
+              "value": "LIFECYCLE_ENVIRONMENT_ID"
+            },
+            {
+              "help": "Content view name",
+              "name": "name",
+              "shortname": null,
+              "value": "NAME"
+            },
+            {
+              "help": "Organization name to search by",
+              "name": "organization",
+              "shortname": null,
+              "value": "ORGANIZATION_NAME"
+            },
+            {
+              "help": "organization ID",
+              "name": "organization-id",
+              "shortname": null,
+              "value": "ORGANIZATION_ID"
+            },
+            {
+              "help": "Organization label to search by",
+              "name": "organization-label",
+              "shortname": null,
+              "value": "ORGANIZATION_LABEL"
+            },
+            {
+              "help": "print help",
+              "name": "help",
+              "shortname": "h",
+              "value": null
+            }
+          ],
+          "subcommands": []
+        },
+        {
+          "description": "Disassociate a resource",
+          "name": "remove-repository",
+          "options": [
+            {
+              "help": "content view numeric identifier",
+              "name": "id",
+              "shortname": null,
+              "value": "ID"
+            },
+            {
+              "help": "Content view name",
+              "name": "name",
+              "shortname": null,
+              "value": "NAME"
+            },
+            {
+              "help": "Organization name to search by",
+              "name": "organization",
+              "shortname": null,
+              "value": "ORGANIZATION_NAME"
+            },
+            {
+              "help": "organization ID",
+              "name": "organization-id",
+              "shortname": null,
+              "value": "ORGANIZATION_ID"
+            },
+            {
+              "help": "Organization label to search by",
+              "name": "organization-label",
+              "shortname": null,
+              "value": "ORGANIZATION_LABEL"
+            },
+            {
+              "help": "Product name to search by",
+              "name": "product",
+              "shortname": null,
+              "value": "PRODUCT_NAME"
+            },
+            {
+              "help": "product numeric identifier",
+              "name": "product-id",
+              "shortname": null,
+              "value": "PRODUCT_ID"
+            },
+            {
+              "help": "Repository name to search by",
+              "name": "repository",
+              "shortname": null,
+              "value": "REPOSITORY_NAME"
+            },
+            {
+              "help": "repository ID",
+              "name": "repository-id",
+              "shortname": null,
+              "value": "REPOSITORY_ID"
+            },
+            {
+              "help": "print help",
+              "name": "help",
+              "shortname": "h",
+              "value": null
+            }
+          ],
+          "subcommands": []
+        },
+        {
+          "description": "Update a content view",
+          "name": "remove-version",
+          "options": [
+            {
+              "help": "Content view version number",
+              "name": "content-view-version",
+              "shortname": null,
+              "value": "CONTENT_VIEW_VERSION_VERSION"
+            },
+            {
+              "help": "Content view version identifier",
+              "name": "content-view-version-id",
+              "shortname": null,
+              "value": "CONTENT_VIEW_VERSION_ID"
+            },
+            {
+              "help": "content view numeric identifier",
+              "name": "id",
+              "shortname": null,
+              "value": "ID"
+            },
+            {
+              "help": "Content view name",
+              "name": "name",
+              "shortname": null,
+              "value": "NAME"
+            },
+            {
+              "help": "Organization name to search by",
+              "name": "organization",
+              "shortname": null,
+              "value": "ORGANIZATION_NAME"
+            },
+            {
+              "help": "organization ID",
+              "name": "organization-id",
+              "shortname": null,
+              "value": "ORGANIZATION_ID"
+            },
+            {
+              "help": "Organization label to search by",
+              "name": "organization-label",
+              "shortname": null,
+              "value": "ORGANIZATION_LABEL"
+            },
+            {
+              "help": "print help",
+              "name": "help",
+              "shortname": "h",
+              "value": null
+            }
+          ],
+          "subcommands": []
+        },
+        {
+          "description": "Update a content view",
+          "name": "update",
+          "options": [
+            {
+              "help": "List of component content view version ids for composite views Comma separated list of values.",
+              "name": "component-ids",
+              "shortname": null,
+              "value": "COMPONENT_IDS"
+            },
+            {
+              "help": "Description for the content view",
+              "name": "description",
+              "shortname": null,
+              "value": "DESCRIPTION"
+            },
+            {
+              "help": "Content view identifier",
+              "name": "id",
+              "shortname": null,
+              "value": "ID"
+            },
+            {
+              "help": "Content view name",
+              "name": "name",
+              "shortname": null,
+              "value": "NAME"
+            },
+            {
+              "help": "New name for the content view",
+              "name": "new-name",
+              "shortname": null,
+              "value": "NEW_NAME"
+            },
+            {
+              "help": "Organization name to search by",
+              "name": "organization",
+              "shortname": null,
+              "value": "ORGANIZATION_NAME"
+            },
+            {
+              "help": "organization ID",
+              "name": "organization-id",
+              "shortname": null,
+              "value": "ORGANIZATION_ID"
+            },
+            {
+              "help": "Organization label to search by",
+              "name": "organization-label",
+              "shortname": null,
+              "value": "ORGANIZATION_LABEL"
+            },
+            {
+              "help": "Comma separated list of values.",
+              "name": "repositories",
+              "shortname": null,
+              "value": "REPOSITORY_NAMES"
+            },
+            {
+              "help": "List of repository ids Comma separated list of values.",
+              "name": "repository-ids",
+              "shortname": null,
+              "value": "REPOSITORY_IDS"
+            },
+            {
+              "help": "print help",
+              "name": "help",
+              "shortname": "h",
+              "value": null
+            }
+          ],
+          "subcommands": []
+        },
+        {
+          "description": "View and manage content view versions",
+          "name": "version",
+          "options": [
+            {
+              "help": "print help",
+              "name": "help",
+              "shortname": "h",
+              "value": null
+            }
+          ],
+          "subcommands": [
+            {
+              "description": "Remove content view version",
+              "name": "delete",
+              "options": [
+                {
+                  "help": "Do not wait for the task",
+                  "name": "async",
+                  "shortname": null,
+                  "value": null
+                },
+                {
+                  "help": "Name to search by",
+                  "name": "environment",
+                  "shortname": null,
+                  "value": "ENVIRONMENT_NAME"
+                },
+                {
+                  "help": "",
+                  "name": "environment-id",
+                  "shortname": null,
+                  "value": "ENVIRONMENT_ID"
+                },
+                {
+                  "help": "Content view version identifier",
+                  "name": "id",
+                  "shortname": null,
+                  "value": "ID"
+                },
+                {
+                  "help": "Content view version number",
+                  "name": "version",
+                  "shortname": null,
+                  "value": "VERSION"
+                },
+                {
+                  "help": "print help",
+                  "name": "help",
+                  "shortname": "h",
+                  "value": null
+                }
+              ],
+              "subcommands": []
+            },
+            {
+              "description": "Perform an Incremental Update on one or more Content View Versions",
+              "name": "incremental-update",
+              "options": [
+                {
+                  "help": "Do not wait for the task",
+                  "name": "async",
+                  "shortname": null,
+                  "value": null
+                },
+                {
+                  "help": "Content view version number",
+                  "name": "content-view-version",
+                  "shortname": null,
+                  "value": "CONTENT_VIEW_VERSION_VERSION"
+                },
+                {
+                  "help": "Comma separated list of values.",
+                  "name": "content-view-version-environments",
+                  "shortname": null,
+                  "value": "CONTENT_VIEW_VERSION_ENVIRONMENTS"
+                },
+                {
+                  "help": "Content view version identifier",
+                  "name": "content-view-version-id",
+                  "shortname": null,
+                  "value": "CONTENT_VIEW_VERSION_ID"
+                },
+                {
+                  "help": "The description for the new generated Content View Versions",
+                  "name": "description",
+                  "shortname": null,
+                  "value": "DESCRIPTION"
+                },
+                {
+                  "help": "list of environment IDs to update the content view version in Comma separated list of values.",
+                  "name": "environment-ids",
+                  "shortname": null,
+                  "value": "ENVIRONMENTS"
+                },
+                {
+                  "help": "Comma separated list of values.",
+                  "name": "environments",
+                  "shortname": null,
+                  "value": "ENVIRONMENT_NAMES"
+                },
+                {
+                  "help": "Errata uuids to copy into the new versions. Comma separated list of values.",
+                  "name": "errata-ids",
+                  "shortname": null,
+                  "value": "ERRATA_IDS"
+                },
+                {
+                  "help": "ID of a content view version to incrementally update",
+                  "name": "id",
+                  "shortname": null,
+                  "value": "ID"
+                },
+                {
+                  "help": "List of system ids to perform an action on Comma separated list of values.",
+                  "name": "ids",
+                  "shortname": null,
+                  "value": "IDS"
+                },
+                {
+                  "help": "Package uuids to copy into the new versions. Comma separated list of values.",
+                  "name": "package-ids",
+                  "shortname": null,
+                  "value": "PACKAGE_IDS"
+                },
+                {
+                  "help": "Comma separated list of values.",
+                  "name": "packages",
+                  "shortname": null,
+                  "value": "PACKAGE_NAMES"
+                },
+                {
+                  "help": "If true, will publish a new composite version using any specified content_view_version_id that has been promoted to a lifecycle environment. One of true/false, yes/no, 1/0.",
+                  "name": "propagate-all-composites",
+                  "shortname": null,
+                  "value": "PROPAGATE_ALL_COMPOSITES"
+                },
+                {
+                  "help": "Puppet Modules to copy into the new versions. Comma separated list of values.",
+                  "name": "puppet-module-ids",
+                  "shortname": null,
+                  "value": "PUPPET_MODULE_IDS"
+                },
+                {
+                  "help": "Comma separated list of values.",
+                  "name": "puppet-modules",
+                  "shortname": null,
+                  "value": "PUPPET_MODULE_NAMES"
+                },
+                {
+                  "help": "If true, when adding the specified errata or packages, any needed dependencies will be copied as well. One of true/false, yes/no, 1/0.",
+                  "name": "resolve-dependencies",
+                  "shortname": null,
+                  "value": "RESOLVE_DEPENDENCIES"
+                },
+                {
+                  "help": "Search string for systems to perform an action on",
+                  "name": "search",
+                  "shortname": null,
+                  "value": "SEARCH"
+                },
+                {
+                  "help": "Update all editable and applicable systems, not just ones using the selected Content View Versions and Environments One of true/false, yes/no, 1/0.",
+                  "name": "update-all-systems",
+                  "shortname": null,
+                  "value": "UPDATE_ALL_SYSTEMS"
+                },
+                {
+                  "help": "print help",
+                  "name": "help",
+                  "shortname": "h",
+                  "value": null
+                }
+              ],
+              "subcommands": []
+            },
+            {
+              "description": "Show content view version",
+              "name": "info",
+              "options": [
+                {
+                  "help": "Name to search by",
+                  "name": "environment",
+                  "shortname": null,
+                  "value": "ENVIRONMENT_NAME"
+                },
+                {
+                  "help": "",
+                  "name": "environment-id",
+                  "shortname": null,
+                  "value": "ENVIRONMENT_ID"
+                },
+                {
+                  "help": "Content view version identifier",
+                  "name": "id",
+                  "shortname": null,
+                  "value": "ID"
+                },
+                {
+                  "help": "Content view version number",
+                  "name": "version",
+                  "shortname": null,
+                  "value": "VERSION"
+                },
+                {
+                  "help": "print help",
+                  "name": "help",
+                  "shortname": "h",
+                  "value": null
+                }
+              ],
+              "subcommands": []
+            },
+            {
+              "description": "List content view versions",
+              "name": "list",
+              "options": [
+                {
+                  "help": "Filter versions that are components in the specified composite version",
+                  "name": "composite-version-id",
+                  "shortname": null,
+                  "value": "COMPOSITE_VERSION_ID"
+                },
+                {
+                  "help": "Content view name",
+                  "name": "content-view",
+                  "shortname": null,
+                  "value": "CONTENT_VIEW_NAME"
+                },
+                {
+                  "help": "content view numeric identifier",
+                  "name": "content-view-id",
+                  "shortname": null,
+                  "value": "CONTENT_VIEW_ID"
+                },
+                {
+                  "help": "Name to search by",
+                  "name": "environment",
+                  "shortname": null,
+                  "value": "ENVIRONMENT_NAME"
+                },
+                {
+                  "help": "",
+                  "name": "environment-id",
+                  "shortname": null,
+                  "value": "ENVIRONMENT_ID"
+                },
+                {
+                  "help": "Filter versions by version number",
+                  "name": "version",
+                  "shortname": null,
+                  "value": "VERSION"
+                },
+                {
+                  "help": "print help",
+                  "name": "help",
+                  "shortname": "h",
+                  "value": null
+                }
+              ],
+              "subcommands": []
+            },
+            {
+              "description": "Promote a content view version",
+              "name": "promote",
+              "options": [
+                {
+                  "help": "Do not wait for the task",
+                  "name": "async",
+                  "shortname": null,
+                  "value": null
+                },
+                {
+                  "help": "Content view name",
+                  "name": "content-view",
+                  "shortname": null,
+                  "value": "CONTENT_VIEW_NAME"
+                },
+                {
+                  "help": "content view numeric identifier",
+                  "name": "content-view-id",
+                  "shortname": null,
+                  "value": "CONTENT_VIEW_ID"
+                },
+                {
+                  "help": "force content view promotion and bypass lifecycle environment restriction",
+                  "name": "force",
+                  "shortname": null,
+                  "value": null
+                },
+                {
+                  "help": "Content view version identifier",
+                  "name": "id",
+                  "shortname": null,
+                  "value": "ID"
+                },
+                {
+                  "help": "Organization name to search by",
+                  "name": "organization",
+                  "shortname": null,
+                  "value": "ORGANIZATION_NAME"
+                },
+                {
+                  "help": "organization ID",
+                  "name": "organization-id",
+                  "shortname": null,
+                  "value": "ORGANIZATION_ID"
+                },
+                {
+                  "help": "Organization label to search by",
+                  "name": "organization-label",
+                  "shortname": null,
+                  "value": "ORGANIZATION_LABEL"
+                },
+                {
+                  "help": "Name of the target environment",
+                  "name": "to-lifecycle-environment",
+                  "shortname": null,
+                  "value": "TO_ENVIRONMENT"
+                },
+                {
+                  "help": "Id of the target environment",
+                  "name": "to-lifecycle-environment-id",
+                  "shortname": null,
+                  "value": "TO_ENVIRONMENT_ID"
+                },
+                {
+                  "help": "Content view version number",
+                  "name": "version",
+                  "shortname": null,
+                  "value": "VERSION"
+                },
+                {
+                  "help": "print help",
+                  "name": "help",
+                  "shortname": "h",
+                  "value": null
+                }
+              ],
+              "subcommands": []
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "Discovery related actions.",
+      "name": "discovery",
+      "options": [
+        {
+          "help": "print help",
+          "name": "help",
+          "shortname": "h",
+          "value": null
+        }
+      ],
+      "subcommands": [
+        {
+          "description": "Auto provision a host",
+          "name": "auto-provision",
+          "options": [
+            {
+              "help": "",
+              "name": "id",
+              "shortname": null,
+              "value": "ID"
+            },
+            {
+              "help": "Name to search by",
+              "name": "name",
+              "shortname": null,
+              "value": "NAME"
+            },
+            {
+              "help": "print help",
+              "name": "help",
+              "shortname": "h",
+              "value": null
+            }
+          ],
+          "subcommands": []
+        },
+        {
+          "description": "Delete a discovered host",
+          "name": "delete",
+          "options": [
+            {
+              "help": "",
+              "name": "id",
+              "shortname": null,
+              "value": "ID"
+            },
+            {
+              "help": "Name to search by",
+              "name": "name",
+              "shortname": null,
+              "value": "NAME"
+            },
+            {
+              "help": "print help",
+              "name": "help",
+              "shortname": "h",
+              "value": null
+            }
+          ],
+          "subcommands": []
+        },
+        {
+          "description": "Show a discovered host",
+          "name": "facts",
+          "options": [
+            {
+              "help": "",
+              "name": "id",
+              "shortname": null,
+              "value": "ID"
+            },
+            {
+              "help": "Name to search by",
+              "name": "name",
+              "shortname": null,
+              "value": "NAME"
+            },
+            {
+              "help": "print help",
+              "name": "help",
+              "shortname": "h",
+              "value": null
+            }
+          ],
+          "subcommands": []
+        },
+        {
+          "description": "Show a discovered host",
+          "name": "info",
+          "options": [
+            {
+              "help": "",
+              "name": "id",
+              "shortname": null,
+              "value": "ID"
+            },
+            {
+              "help": "Name to search by",
+              "name": "name",
+              "shortname": null,
+              "value": "NAME"
+            },
+            {
+              "help": "print help",
+              "name": "help",
+              "shortname": "h",
+              "value": null
+            }
+          ],
+          "subcommands": []
+        },
+        {
+          "description": "List all discovered hosts",
+          "name": "list",
+          "options": [
+            {
+              "help": "sort results",
+              "name": "order",
+              "shortname": null,
+              "value": "ORDER"
+            },
+            {
+              "help": "paginate results",
+              "name": "page",
+              "shortname": null,
+              "value": "PAGE"
+            },
+            {
+              "help": "number of entries per request",
+              "name": "per-page",
+              "shortname": null,
+              "value": "PER_PAGE"
+            },
+            {
+              "help": "filter results",
+              "name": "search",
+              "shortname": null,
+              "value": "SEARCH"
+            },
+            {
+              "help": "print help",
+              "name": "help",
+              "shortname": "h",
+              "value": null
+            }
+          ],
+          "subcommands": []
+        },
+        {
+          "description": "Provision a discovered host",
+          "name": "provision",
+          "options": [
+            {
+              "help": "Architecture name",
+              "name": "architecture",
+              "shortname": null,
+              "value": "ARCHITECTURE_NAME"
+            },
+            {
+              "help": "",
+              "name": "architecture-id",
+              "shortname": null,
+              "value": "ARCHITECTURE_ID"
+            },
+            {
+              "help": "One of true/false, yes/no, 1/0.",
+              "name": "ask-root-password",
+              "shortname": null,
+              "value": "ASK_ROOT_PW"
+            },
+            {
+              "help": "One of true/false, yes/no, 1/0.",
+              "name": "build",
+              "shortname": null,
+              "value": "BUILD"
+            },
+            {
+              "help": "",
+              "name": "capabilities",
+              "shortname": null,
+              "value": "CAPABILITIES"
+            },
+            {
+              "help": "Domain name",
+              "name": "domain",
+              "shortname": null,
+              "value": "DOMAIN_NAME"
+            },
+            {
+              "help": "Numerical ID or domain name",
+              "name": "domain-id",
+              "shortname": null,
+              "value": "DOMAIN_ID"
+            },
+            {
+              "help": "One of true/false, yes/no, 1/0.",
+              "name": "enabled",
+              "shortname": null,
+              "value": "ENABLED"
+            },
+            {
+              "help": "Environment name",
+              "name": "environment",
+              "shortname": null,
+              "value": "ENVIRONMENT_NAME"
+            },
+            {
+              "help": "",
+              "name": "environment-id",
+              "shortname": null,
+              "value": "ENVIRONMENT_ID"
+            },
+            {
+              "help": "Comma separated list of values.",
+              "name": "host-parameters-attributes",
+              "shortname": null,
+              "value": "HOST_PARAMETERS_ATTRIBUTES"
+            },
+            {
+              "help": "Hostgroup name",
+              "name": "hostgroup",
+              "shortname": null,
+              "value": "HOSTGROUP_NAME"
+            },
+            {
+              "help": "",
+              "name": "hostgroup-id",
+              "shortname": null,
+              "value": "HOSTGROUP_ID"
+            },
+            {
+              "help": "",
+              "name": "id",
+              "shortname": null,
+              "value": "ID"
+            },
+            {
+              "help": "Name to search by",
+              "name": "image",
+              "shortname": null,
+              "value": "IMAGE_NAME"
+            },
+            {
+              "help": "",
+              "name": "image-id",
+              "shortname": null,
+              "value": "IMAGE_ID"
+            },
+            {
+              "help": "Interface parameters Comma-separated list of key=value. Can be specified multiple times.",
+              "name": "interface",
+              "shortname": null,
+              "value": "INTERFACE"
+            },
+            {
+              "help": "not required if using a subnet with DHCP proxy",
+              "name": "ip",
+              "shortname": null,
+              "value": "IP"
+            },
+            {
+              "help": "not required if it's a virtual machine",
+              "name": "mac",
+              "shortname": null,
+              "value": "MAC"
+            },
+            {
+              "help": "One of true/false, yes/no, 1/0.",
+              "name": "managed",
+              "shortname": null,
+              "value": "MANAGED"
+            },
+            {
+              "help": "Medium name",
+              "name": "medium",
+              "shortname": null,
+              "value": "MEDIUM_NAME"
+            },
+            {
+              "help": "",
+              "name": "medium-id",
+              "shortname": null,
+              "value": "MEDIUM_ID"
+            },
+            {
+              "help": "Model name",
+              "name": "model",
+              "shortname": null,
+              "value": "MODEL_NAME"
+            },
+            {
+              "help": "",
+              "name": "model-id",
+              "shortname": null,
+              "value": "MODEL_ID"
+            },
+            {
+              "help": "Name to search by",
+              "name": "name",
+              "shortname": null,
+              "value": "NAME"
+            },
+            {
+              "help": "",
+              "name": "new-name",
+              "shortname": null,
+              "value": "NEW_NAME"
+            },
+            {
+              "help": "Operating system title",
+              "name": "operatingsystem",
+              "shortname": null,
+              "value": "OPERATINGSYSTEM_TITLE"
+            },
+            {
+              "help": "",
+              "name": "operatingsystem-id",
+              "shortname": null,
+              "value": "OPERATINGSYSTEM_ID"
+            },
+            {
+              "help": "",
+              "name": "owner-id",
+              "shortname": null,
+              "value": "OWNER_ID"
+            },
+            {
+              "help": "Host parameters Comma-separated list of key=value.",
+              "name": "parameters",
+              "shortname": null,
+              "value": "PARAMS"
+            },
+            {
+              "help": "Partition table name",
+              "name": "partition-table",
+              "shortname": null,
+              "value": "PARTITION_TABLE_NAME"
+            },
+            {
+              "help": "",
+              "name": "partition-table-id",
+              "shortname": null,
+              "value": "PARTITION_TABLE_ID"
+            },
+            {
+              "help": "UUID to track orchestration tasks status, GET /api/orchestration/:UUID/tasks",
+              "name": "progress-report-id",
+              "shortname": null,
+              "value": "PROGRESS_REPORT_ID"
+            },
+            {
+              "help": "One of 'build', 'image'",
+              "name": "provision-method",
+              "shortname": null,
+              "value": "METHOD"
+            },
+            {
+              "help": "",
+              "name": "puppet-ca-proxy-id",
+              "shortname": null,
+              "value": "PUPPET_CA_PROXY_ID"
+            },
+            {
+              "help": "",
+              "name": "puppet-proxy-id",
+              "shortname": null,
+              "value": "PUPPET_PROXY_ID"
+            },
+            {
+              "help": "Comma separated list of values.",
+              "name": "puppetclass-ids",
+              "shortname": null,
+              "value": "PUPPETCLASS_IDS"
+            },
+            {
+              "help": "",
+              "name": "root-password",
+              "shortname": null,
+              "value": "ROOT_PW"
+            },
+            {
+              "help": "",
+              "name": "sp-subnet-id",
+              "shortname": null,
+              "value": "SP_SUBNET_ID"
+            },
+            {
+              "help": "Subnet name",
+              "name": "subnet",
+              "shortname": null,
+              "value": "SUBNET_NAME"
+            },
+            {
+              "help": "",
+              "name": "subnet-id",
+              "shortname": null,
+              "value": "SUBNET_ID"
+            },
+            {
+              "help": "print help",
+              "name": "help",
+              "shortname": "h",
+              "value": null
+            }
+          ],
+          "subcommands": []
+        },
+        {
+          "description": "Reboot a host",
+          "name": "reboot",
+          "options": [
+            {
+              "help": "",
+              "name": "id",
+              "shortname": null,
+              "value": "ID"
+            },
+            {
+              "help": "Name to search by",
+              "name": "name",
+              "shortname": null,
+              "value": "NAME"
+            },
+            {
+              "help": "print help",
+              "name": "help",
+              "shortname": "h",
+              "value": null
+            }
+          ],
+          "subcommands": []
+        },
+        {
+          "description": "Refresh the facts of a host",
+          "name": "refresh-facts",
+          "options": [
+            {
+              "help": "",
+              "name": "id",
+              "shortname": null,
+              "value": "ID"
+            },
+            {
+              "help": "Name to search by",
+              "name": "name",
+              "shortname": null,
+              "value": "NAME"
+            },
+            {
+              "help": "print help",
+              "name": "help",
+              "shortname": "h",
+              "value": null
+            }
+          ],
+          "subcommands": []
+        }
+      ]
+    },
+    {
+      "description": "Manipulate domains.",
+      "name": "domain",
+      "options": [
+        {
+          "help": "print help",
+          "name": "help",
+          "shortname": "h",
+          "value": null
+        }
+      ],
+      "subcommands": [
+        {
+          "description": "Create a domain",
+          "name": "create",
+          "options": [
+            {
+              "help": "Full name describing the domain",
+              "name": "description",
+              "shortname": null,
+              "value": "DESC"
+            },
+            {
+              "help": "Name of DNS proxy to use within this domain",
+              "name": "dns",
+              "shortname": null,
+              "value": "DNS_NAME"
+            },
+            {
+              "help": "ID of DNS proxy to use within this domain",
+              "name": "dns-id",
+              "shortname": null,
+              "value": "DNS_ID"
+            },
+            {
+              "help": "REPLACE locations with given ids Comma separated list of values.",
+              "name": "location-ids",
+              "shortname": null,
+              "value": "LOCATION_IDS"
+            },
+            {
+              "help": "Comma separated list of values.",
+              "name": "locations",
+              "shortname": null,
+              "value": "LOCATION_NAMES"
+            },
+            {
+              "help": "The full DNS domain name",
+              "name": "name",
+              "shortname": null,
+              "value": "NAME"
+            },
+            {
+              "help": "REPLACE organizations with given ids. Comma separated list of values.",
+              "name": "organization-ids",
+              "shortname": null,
+              "value": "ORGANIZATION_IDS"
+            },
+            {
+              "help": "Comma separated list of values.",
+              "name": "organizations",
+              "shortname": null,
+              "value": "ORGANIZATION_NAMES"
+            },
+            {
+              "help": "print help",
+              "name": "help",
+              "shortname": "h",
+              "value": null
+            }
+          ],
+          "subcommands": []
+        },
+        {
+          "description": "Delete a domain",
+          "name": "delete",
+          "options": [
+            {
+              "help": "",
+              "name": "id",
+              "shortname": null,
+              "value": "ID"
+            },
+            {
+              "help": "Domain name",
+              "name": "name",
+              "shortname": null,
+              "value": "NAME"
+            },
+            {
+              "help": "print help",
+              "name": "help",
+              "shortname": "h",
+              "value": null
+            }
+          ],
+          "subcommands": []
+        },
+        {
+          "description": "Delete parameter for a domain.",
+          "name": "delete-parameter",
+          "options": [
+            {
+              "help": "Domain name",
+              "name": "domain",
+              "shortname": null,
+              "value": "DOMAIN_NAME"
+            },
+            {
+              "help": "Numerical ID or domain name",
+              "name": "domain-id",
+              "shortname": null,
+              "value": "DOMAIN_ID"
+            },
+            {
+              "help": "parameter name",
+              "name": "name",
+              "shortname": null,
+              "value": "NAME"
+            },
+            {
+              "help": "print help",
+              "name": "help",
+              "shortname": "h",
+              "value": null
+            }
+          ],
+          "subcommands": []
+        },
+        {
+          "description": "Show a domain",
+          "name": "info",
+          "options": [
+            {
+              "help": "Numerical ID or domain name",
+              "name": "id",
+              "shortname": null,
+              "value": "ID"
+            },
+            {
+              "help": "Domain name",
+              "name": "name",
+              "shortname": null,
+              "value": "NAME"
+            },
+            {
+              "help": "print help",
+              "name": "help",
+              "shortname": "h",
+              "value": null
+            }
+          ],
+          "subcommands": []
+        },
+        {
+          "description": "List of domains",
+          "name": "list",
+          "options": [
+            {
+              "help": "Location name",
+              "name": "location",
+              "shortname": null,
+              "value": "LOCATION_NAME"
+            },
+            {
+              "help": "",
+              "name": "location-id",
+              "shortname": null,
+              "value": "LOCATION_ID"
+            },
+            {
+              "help": "sort results",
+              "name": "order",
+              "shortname": null,
+              "value": "ORDER"
+            },
+            {
+              "help": "Organization name",
+              "name": "organization",
+              "shortname": null,
+              "value": "ORGANIZATION_NAME"
+            },
+            {
+              "help": "organization ID",
+              "name": "organization-id",
+              "shortname": null,
+              "value": "ORGANIZATION_ID"
+            },
+            {
+              "help": "paginate results",
+              "name": "page",
+              "shortname": null,
+              "value": "PAGE"
+            },
+            {
+              "help": "number of entries per request",
+              "name": "per-page",
+              "shortname": null,
+              "value": "PER_PAGE"
+            },
+            {
+              "help": "filter results",
+              "name": "search",
+              "shortname": null,
+              "value": "SEARCH"
+            },
+            {
+              "help": "Subnet name",
+              "name": "subnet",
+              "shortname": null,
+              "value": "SUBNET_NAME"
+            },
+            {
+              "help": "",
+              "name": "subnet-id",
+              "shortname": null,
+              "value": "SUBNET_ID"
+            },
+            {
+              "help": "print help",
+              "name": "help",
+              "shortname": "h",
+              "value": null
+            }
+          ],
+          "subcommands": []
+        },
+        {
+          "description": "Create or update parameter for a domain.",
+          "name": "set-parameter",
+          "options": [
+            {
+              "help": "Domain name",
+              "name": "domain",
+              "shortname": null,
+              "value": "DOMAIN_NAME"
+            },
+            {
+              "help": "Numerical ID or domain name",
+              "name": "domain-id",
+              "shortname": null,
+              "value": "DOMAIN_ID"
+            },
+            {
+              "help": "parameter name",
+              "name": "name",
+              "shortname": null,
+              "value": "NAME"
+            },
+            {
+              "help": "parameter value",
+              "name": "value",
+              "shortname": null,
+              "value": "VALUE"
+            },
+            {
+              "help": "print help",
+              "name": "help",
+              "shortname": "h",
+              "value": null
+            }
+          ],
+          "subcommands": []
+        },
+        {
+          "description": "Update a domain",
+          "name": "update",
+          "options": [
+            {
+              "help": "Full name describing the domain",
+              "name": "description",
+              "shortname": null,
+              "value": "DESC"
+            },
+            {
+              "help": "Name of DNS proxy to use within this domain",
+              "name": "dns",
+              "shortname": null,
+              "value": "DNS_NAME"
+            },
+            {
+              "help": "ID of DNS proxy to use within this domain",
+              "name": "dns-id",
+              "shortname": null,
+              "value": "DNS_ID"
+            },
+            {
+              "help": "",
+              "name": "id",
+              "shortname": null,
+              "value": "ID"
+            },
+            {
+              "help": "REPLACE locations with given ids Comma separated list of values.",
+              "name": "location-ids",
+              "shortname": null,
+              "value": "LOCATION_IDS"
+            },
+            {
+              "help": "Comma separated list of values.",
+              "name": "locations",
+              "shortname": null,
+              "value": "LOCATION_NAMES"
+            },
+            {
+              "help": "Domain name",
+              "name": "name",
+              "shortname": null,
+              "value": "NAME"
+            },
+            {
+              "help": "The full DNS domain name",
+              "name": "new-name",
+              "shortname": null,
+              "value": "NEW_NAME"
+            },
+            {
+              "help": "REPLACE organizations with given ids. Comma separated list of values.",
+              "name": "organization-ids",
+              "shortname": null,
+              "value": "ORGANIZATION_IDS"
+            },
+            {
+              "help": "Comma separated list of values.",
+              "name": "organizations",
+              "shortname": null,
+              "value": "ORGANIZATION_NAMES"
+            },
+            {
+              "help": "print help",
+              "name": "help",
+              "shortname": "h",
+              "value": null
+            }
+          ],
+          "subcommands": []
+        }
+      ]
+    },
+    {
+      "description": "Manipulate environments.",
+      "name": "environment",
+      "options": [
+        {
+          "help": "print help",
+          "name": "help",
+          "shortname": "h",
+          "value": null
+        }
+      ],
+      "subcommands": [
+        {
+          "description": "Create an environment",
+          "name": "create",
+          "options": [
+            {
+              "help": "REPLACE locations with given ids Comma separated list of values.",
+              "name": "location-ids",
+              "shortname": null,
+              "value": "LOCATION_IDS"
+            },
+            {
+              "help": "Comma separated list of values.",
+              "name": "locations",
+              "shortname": null,
+              "value": "LOCATION_NAMES"
+            },
+            {
+              "help": "",
+              "name": "name",
+              "shortname": null,
+              "value": "NAME"
+            },
+            {
+              "help": "REPLACE organizations with given ids. Comma separated list of values.",
+              "name": "organization-ids",
+              "shortname": null,
+              "value": "ORGANIZATION_IDS"
+            },
+            {
+              "help": "Comma separated list of values.",
+              "name": "organizations",
+              "shortname": null,
+              "value": "ORGANIZATION_NAMES"
+            },
+            {
+              "help": "print help",
+              "name": "help",
+              "shortname": "h",
+              "value": null
+            }
+          ],
+          "subcommands": []
+        },
+        {
+          "description": "Delete an environment",
+          "name": "delete",
+          "options": [
+            {
+              "help": "",
+              "name": "id",
+              "shortname": null,
+              "value": "ID"
+            },
+            {
+              "help": "Environment name",
+              "name": "name",
+              "shortname": null,
+              "value": "NAME"
+            },
+            {
+              "help": "print help",
+              "name": "help",
+              "shortname": "h",
+              "value": null
+            }
+          ],
+          "subcommands": []
+        },
+        {
+          "description": "Show an environment",
+          "name": "info",
+          "options": [
+            {
+              "help": "",
+              "name": "id",
+              "shortname": null,
+              "value": "ID"
+            },
+            {
+              "help": "Environment name",
+              "name": "name",
+              "shortname": null,
+              "value": "NAME"
+            },
+            {
+              "help": "print help",
+              "name": "help",
+              "shortname": "h",
+              "value": null
+            }
+          ],
+          "subcommands": []
+        },
+        {
+          "description": "List all environments",
+          "name": "list",
+          "options": [
+            {
+              "help": "Location name",
+              "name": "location",
+              "shortname": null,
+              "value": "LOCATION_NAME"
+            },
+            {
+              "help": "",
+              "name": "location-id",
+              "shortname": null,
+              "value": "LOCATION_ID"
+            },
+            {
+              "help": "sort results",
+              "name": "order",
+              "shortname": null,
+              "value": "ORDER"
+            },
+            {
+              "help": "Organization name",
+              "name": "organization",
+              "shortname": null,
+              "value": "ORGANIZATION_NAME"
+            },
+            {
+              "help": "organization ID",
+              "name": "organization-id",
+              "shortname": null,
+              "value": "ORGANIZATION_ID"
+            },
+            {
+              "help": "paginate results",
+              "name": "page",
+              "shortname": null,
+              "value": "PAGE"
+            },
+            {
+              "help": "number of entries per request",
+              "name": "per-page",
+              "shortname": null,
+              "value": "PER_PAGE"
+            },
+            {
+              "help": "Puppet class name",
+              "name": "puppet-class",
+              "shortname": null,
+              "value": "PUPPET_CLASS_NAME"
+            },
+            {
+              "help": "ID of Puppet class",
+              "name": "puppet-class-id",
+              "shortname": null,
+              "value": "PUPPET_CLASS_ID"
+            },
+            {
+              "help": "filter results",
+              "name": "search",
+              "shortname": null,
+              "value": "SEARCH"
+            },
+            {
+              "help": "print help",
+              "name": "help",
+              "shortname": "h",
+              "value": null
+            }
+          ],
+          "subcommands": []
+        },
+        {
+          "description": "List all smart class parameters",
+          "name": "sc-params",
+          "options": [
+            {
+              "help": "Environment name",
+              "name": "environment",
+              "shortname": null,
+              "value": "ENVIRONMENT_NAME"
+            },
+            {
+              "help": "",
+              "name": "environment-id",
+              "shortname": null,
+              "value": "ENVIRONMENT_ID"
+            },
+            {
+              "help": "Host name",
+              "name": "host",
+              "shortname": null,
+              "value": "HOST_NAME"
+            },
+            {
+              "help": "",
+              "name": "host-id",
+              "shortname": null,
+              "value": "HOST_ID"
+            },
+            {
+              "help": "Hostgroup name",
+              "name": "hostgroup",
+              "shortname": null,
+              "value": "HOSTGROUP_NAME"
+            },
+            {
+              "help": "",
+              "name": "hostgroup-id",
+              "shortname": null,
+              "value": "HOSTGROUP_ID"
+            },
+            {
+              "help": "",
+              "name": "id",
+              "shortname": null,
+              "value": "ID"
+            },
+            {
+              "help": "Environment name",
+              "name": "name",
+              "shortname": null,
+              "value": "NAME"
+            },
+            {
+              "help": "sort results",
+              "name": "order",
+              "shortname": null,
+              "value": "ORDER"
+            },
+            {
+              "help": "paginate results",
+              "name": "page",
+              "shortname": null,
+              "value": "PAGE"
+            },
+            {
+              "help": "number of entries per request",
+              "name": "per-page",
+              "shortname": null,
+              "value": "PER_PAGE"
+            },
+            {
+              "help": "Puppet class name",
+              "name": "puppet-class",
+              "shortname": null,
+              "value": "PUPPET_CLASS_NAME"
+            },
+            {
+              "help": "ID of Puppet class",
+              "name": "puppet-class-id",
+              "shortname": null,
+              "value": "PUPPET_CLASS_ID"
+            },
+            {
+              "help": "filter results",
+              "name": "search",
+              "shortname": null,
+              "value": "SEARCH"
+            },
+            {
+              "help": "print help",
+              "name": "help",
+              "shortname": "h",
+              "value": null
+            }
+          ],
+          "subcommands": []
+        },
+        {
+          "description": "Update an environment",
+          "name": "update",
+          "options": [
+            {
+              "help": "",
+              "name": "id",
+              "shortname": null,
+              "value": "ID"
+            },
+            {
+              "help": "REPLACE locations with given ids Comma separated list of values.",
+              "name": "location-ids",
+              "shortname": null,
+              "value": "LOCATION_IDS"
+            },
+            {
+              "help": "Comma separated list of values.",
+              "name": "locations",
+              "shortname": null,
+              "value": "LOCATION_NAMES"
+            },
+            {
+              "help": "Environment name",
+              "name": "name",
+              "shortname": null,
+              "value": "NAME"
+            },
+            {
+              "help": "",
+              "name": "new-name",
+              "shortname": null,
+              "value": "NEW_NAME"
+            },
+            {
+              "help": "REPLACE organizations with given ids. Comma separated list of values.",
+              "name": "organization-ids",
+              "shortname": null,
+              "value": "ORGANIZATION_IDS"
+            },
+            {
+              "help": "Comma separated list of values.",
+              "name": "organizations",
+              "shortname": null,
+              "value": "ORGANIZATION_NAMES"
+            },
+            {
+              "help": "print help",
+              "name": "help",
+              "shortname": "h",
+              "value": null
+            }
+          ],
+          "subcommands": []
+        }
+      ]
+    },
+    {
+      "description": "Manipulate errata",
+      "name": "erratum",
+      "options": [
+        {
+          "help": "print help",
+          "name": "help",
+          "shortname": "h",
+          "value": null
+        }
+      ],
+      "subcommands": [
+        {
+          "description": "Show an erratum",
+          "name": "info",
+          "options": [
+            {
+              "help": "an erratum identifier",
+              "name": "id",
+              "shortname": null,
+              "value": "ID"
+            },
+            {
+              "help": "Name to search by",
+              "name": "name",
+              "shortname": null,
+              "value": "NAME"
+            },
+            {
+              "help": "Repository name to search by",
+              "name": "repository",
+              "shortname": null,
+              "value": "REPOSITORY_NAME"
+            },
+            {
+              "help": "repository ID",
+              "name": "repository-id",
+              "shortname": null,
+              "value": "REPOSITORY_ID"
+            },
+            {
+              "help": "print help",
+              "name": "help",
+              "shortname": "h",
+              "value": null
+            }
+          ],
+          "subcommands": []
+        },
+        {
+          "description": "List errata",
+          "name": "list",
+          "options": [
+            {
+              "help": "Field to sort the results on",
+              "name": "by",
+              "shortname": null,
+              "value": "BY"
+            },
+            {
+              "help": "Content view name",
+              "name": "content-view",
+              "shortname": null,
+              "value": "CONTENT_VIEW_NAME"
+            },
+            {
+              "help": "Name to search by",
+              "name": "content-view-filter",
+              "shortname": null,
+              "value": "CONTENT_VIEW_FILTER_NAME"
+            },
+            {
+              "help": "filter identifier",
+              "name": "content-view-filter-id",
+              "shortname": null,
+              "value": "CONTENT_VIEW_FILTER_ID"
+            },
+            {
+              "help": "content view numeric identifier",
+              "name": "content-view-id",
+              "shortname": null,
+              "value": "CONTENT_VIEW_ID"
+            },
+            {
+              "help": "Content view version number",
+              "name": "content-view-version",
+              "shortname": null,
+              "value": "CONTENT_VIEW_VERSION_VERSION"
+            },
+            {
+              "help": "Content view version identifier",
+              "name": "content-view-version-id",
+              "shortname": null,
+              "value": "CONTENT_VIEW_VERSION_ID"
+            },
+            {
+              "help": "CVE identifier",
+              "name": "cve",
+              "shortname": null,
+              "value": "CVE"
+            },
+            {
+              "help": "Name to search by",
+              "name": "environment",
+              "shortname": null,
+              "value": "ENVIRONMENT_NAME"
+            },
+            {
+              "help": "",
+              "name": "environment-id",
+              "shortname": null,
+              "value": "ENVIRONMENT_ID"
+            },
+            {
+              "help": "show only errata with one or more applicable systems One of true/false, yes/no, 1/0.",
+              "name": "errata-restrict-applicable",
+              "shortname": null,
+              "value": "ERRATA_RESTRICT_APPLICABLE"
+            },
+            {
+              "help": "show only errata with one or more installable systems One of true/false, yes/no, 1/0.",
+              "name": "errata-restrict-installable",
+              "shortname": null,
+              "value": "ERRATA_RESTRICT_INSTALLABLE"
+            },
+            {
+              "help": "Whether or not to show all results One of true/false, yes/no, 1/0.",
+              "name": "full-results",
+              "shortname": null,
+              "value": "FULL_RESULTS"
+            },
+            {
+              "help": "Sort field and order, eg. 'name DESC'",
+              "name": "order",
+              "shortname": null,
+              "value": "ORDER"
+            },
+            {
+              "help": "Organization name to search by",
+              "name": "organization",
+              "shortname": null,
+              "value": "ORGANIZATION_NAME"
+            },
+            {
+              "help": "organization ID",
+              "name": "organization-id",
+              "shortname": null,
+              "value": "ORGANIZATION_ID"
+            },
+            {
+              "help": "Organization label to search by",
+              "name": "organization-label",
+              "shortname": null,
+              "value": "ORGANIZATION_LABEL"
+            },
+            {
+              "help": "Page number, starting at 1",
+              "name": "page",
+              "shortname": null,
+              "value": "PAGE"
+            },
+            {
+              "help": "Number of results per page to return",
+              "name": "per-page",
+              "shortname": null,
+              "value": "PER_PAGE"
+            },
+            {
+              "help": "Product name to search by",
+              "name": "product",
+              "shortname": null,
+              "value": "PRODUCT_NAME"
+            },
+            {
+              "help": "product numeric identifier",
+              "name": "product-id",
+              "shortname": null,
+              "value": "PRODUCT_ID"
+            },
+            {
+              "help": "Repository name to search by",
+              "name": "repository",
+              "shortname": null,
+              "value": "REPOSITORY_NAME"
+            },
+            {
+              "help": "repository ID",
+              "name": "repository-id",
+              "shortname": null,
+              "value": "REPOSITORY_ID"
+            },
+            {
+              "help": "Search string",
+              "name": "search",
+              "shortname": null,
+              "value": "SEARCH"
+            },
+            {
+              "help": "print help",
+              "name": "help",
+              "shortname": "h",
+              "value": null
+            }
+          ],
+          "subcommands": []
+        }
+      ]
+    },
+    {
+      "description": "Search facts.",
+      "name": "fact",
+      "options": [
+        {
+          "help": "print help",
+          "name": "help",
+          "shortname": "h",
+          "value": null
+        }
+      ],
+      "subcommands": [
+        {
+          "description": "List all fact values",
+          "name": "list",
+          "options": [
+            {
+              "help": "sort results",
+              "name": "order",
+              "shortname": null,
+              "value": "ORDER"
+            },
+            {
+              "help": "paginate results",
+              "name": "page",
+              "shortname": null,
+              "value": "PAGE"
+            },
+            {
+              "help": "number of entries per request",
+              "name": "per-page",
+              "shortname": null,
+              "value": "PER_PAGE"
+            },
+            {
+              "help": "filter results",
+              "name": "search",
+              "shortname": null,
+              "value": "SEARCH"
+            },
+            {
+              "help": "print help",
+              "name": "help",
+              "shortname": "h",
+              "value": null
+            }
+          ],
+          "subcommands": []
+        }
+      ]
+    },
+    {
+      "description": "Manage permission filters.",
+      "name": "filter",
+      "options": [
+        {
+          "help": "print help",
+          "name": "help",
+          "shortname": "h",
+          "value": null
+        }
+      ],
+      "subcommands": [
+        {
+          "description": "List all permissions",
+          "name": "available-permissions",
+          "options": [
+            {
+              "help": "",
+              "name": "name",
+              "shortname": null,
+              "value": "NAME"
+            },
+            {
+              "help": "paginate results",
+              "name": "page",
+              "shortname": null,
+              "value": "PAGE"
+            },
+            {
+              "help": "number of entries per request",
+              "name": "per-page",
+              "shortname": null,
+              "value": "PER_PAGE"
+            },
+            {
+              "help": "",
+              "name": "resource-type",
+              "shortname": null,
+              "value": "RESOURCE_TYPE"
+            },
+            {
+              "help": "print help",
+              "name": "help",
+              "shortname": "h",
+              "value": null
+            }
+          ],
+          "subcommands": []
+        },
+        {
+          "description": "List available resource types.",
+          "name": "available-resources",
+          "options": [
+            {
+              "help": "print help",
+              "name": "help",
+              "shortname": "h",
+              "value": null
+            }
+          ],
+          "subcommands": []
+        },
+        {
+          "description": "Create a filter",
+          "name": "create",
+          "options": [
+            {
+              "help": "Comma separated list of values.",
+              "name": "location-ids",
+              "shortname": null,
+              "value": "LOCATION_IDS"
+            },
+            {
+              "help": "Comma separated list of values.",
+              "name": "locations",
+              "shortname": null,
+              "value": "LOCATION_NAMES"
+            },
+            {
+              "help": "Comma separated list of values.",
+              "name": "organization-ids",
+              "shortname": null,
+              "value": "ORGANIZATION_IDS"
+            },
+            {
+              "help": "Comma separated list of values.",
+              "name": "organizations",
+              "shortname": null,
+              "value": "ORGANIZATION_NAMES"
+            },
+            {
+              "help": "Comma separated list of values.",
+              "name": "permission-ids",
+              "shortname": null,
+              "value": "PERMISSION_IDS"
+            },
+            {
+              "help": "Comma separated list of values.",
+              "name": "permissions",
+              "shortname": null,
+              "value": "PERMISSION_NAMES"
+            },
+            {
+              "help": "User role name",
+              "name": "role",
+              "shortname": null,
+              "value": "ROLE_NAME"
+            },
+            {
+              "help": "",
+              "name": "role-id",
+              "shortname": null,
+              "value": "ROLE_ID"
+            },
+            {
+              "help": "",
+              "name": "search",
+              "shortname": null,
+              "value": "SEARCH"
+            },
+            {
+              "help": "print help",
+              "name": "help",
+              "shortname": "h",
+              "value": null
+            }
+          ],
+          "subcommands": []
+        },
+        {
+          "description": "Delete a filter",
+          "name": "delete",
+          "options": [
+            {
+              "help": "",
+              "name": "id",
+              "shortname": null,
+              "value": "ID"
+            },
+            {
+              "help": "print help",
+              "name": "help",
+              "shortname": "h",
+              "value": null
+            }
+          ],
+          "subcommands": []
+        },
+        {
+          "description": "Show a filter",
+          "name": "info",
+          "options": [
+            {
+              "help": "",
+              "name": "id",
+              "shortname": null,
+              "value": "ID"
+            },
+            {
+              "help": "print help",
+              "name": "help",
+              "shortname": "h",
+              "value": null
+            }
+          ],
+          "subcommands": []
+        },
+        {
+          "description": "List all filters",
+          "name": "list",
+          "options": [
+            {
+              "help": "sort results",
+              "name": "order",
+              "shortname": null,
+              "value": "ORDER"
+            },
+            {
+              "help": "paginate results",
+              "name": "page",
+              "shortname": null,
+              "value": "PAGE"
+            },
+            {
+              "help": "number of entries per request",
+              "name": "per-page",
+              "shortname": null,
+              "value": "PER_PAGE"
+            },
+            {
+              "help": "filter results",
+              "name": "search",
+              "shortname": null,
+              "value": "SEARCH"
+            },
+            {
+              "help": "print help",
+              "name": "help",
+              "shortname": "h",
+              "value": null
+            }
+          ],
+          "subcommands": []
+        },
+        {
+          "description": "Update a filter",
+          "name": "update",
+          "options": [
+            {
+              "help": "",
+              "name": "id",
+              "shortname": null,
+              "value": "ID"
+            },
+            {
+              "help": "Comma separated list of values.",
+              "name": "location-ids",
+              "shortname": null,
+              "value": "LOCATION_IDS"
+            },
+            {
+              "help": "Comma separated list of values.",
+              "name": "locations",
+              "shortname": null,
+              "value": "LOCATION_NAMES"
+            },
+            {
+              "help": "Comma separated list of values.",
+              "name": "organization-ids",
+              "shortname": null,
+              "value": "ORGANIZATION_IDS"
+            },
+            {
+              "help": "Comma separated list of values.",
+              "name": "organizations",
+              "shortname": null,
+              "value": "ORGANIZATION_NAMES"
+            },
+            {
+              "help": "Comma separated list of values.",
+              "name": "permission-ids",
+              "shortname": null,
+              "value": "PERMISSION_IDS"
+            },
+            {
+              "help": "Comma separated list of values.",
+              "name": "permissions",
+              "shortname": null,
+              "value": "PERMISSION_NAMES"
+            },
+            {
+              "help": "User role name",
+              "name": "role",
+              "shortname": null,
+              "value": "ROLE_NAME"
+            },
+            {
+              "help": "",
+              "name": "role-id",
+              "shortname": null,
+              "value": "ROLE_ID"
+            },
+            {
+              "help": "",
+              "name": "search",
+              "shortname": null,
+              "value": "SEARCH"
+            },
+            {
+              "help": "print help",
+              "name": "help",
+              "shortname": "h",
+              "value": null
+            }
+          ],
+          "subcommands": []
+        }
+      ]
+    },
+    {
+      "description": "Manipulate global parameters.",
+      "name": "global-parameter",
+      "options": [
+        {
+          "help": "print help",
+          "name": "help",
+          "shortname": "h",
+          "value": null
+        }
+      ],
+      "subcommands": [
+        {
+          "description": "Delete a global parameter",
+          "name": "delete",
+          "options": [
+            {
+              "help": "Common parameter name",
+              "name": "name",
+              "shortname": null,
+              "value": "NAME"
+            },
+            {
+              "help": "print help",
+              "name": "help",
+              "shortname": "h",
+              "value": null
+            }
+          ],
+          "subcommands": []
+        },
+        {
+          "description": "List all global parameters.",
+          "name": "list",
+          "options": [
+            {
+              "help": "sort results",
+              "name": "order",
+              "shortname": null,
+              "value": "ORDER"
+            },
+            {
+              "help": "paginate results",
+              "name": "page",
+              "shortname": null,
+              "value": "PAGE"
+            },
+            {
+              "help": "number of entries per request",
+              "name": "per-page",
+              "shortname": null,
+              "value": "PER_PAGE"
+            },
+            {
+              "help": "filter results",
+              "name": "search",
+              "shortname": null,
+              "value": "SEARCH"
+            },
+            {
+              "help": "print help",
+              "name": "help",
+              "shortname": "h",
+              "value": null
+            }
+          ],
+          "subcommands": []
+        },
+        {
+          "description": "Set a global parameter.",
+          "name": "set",
+          "options": [
+            {
+              "help": "parameter name",
+              "name": "name",
+              "shortname": null,
+              "value": "NAME"
+            },
+            {
+              "help": "parameter value",
+              "name": "value",
+              "shortname": null,
+              "value": "VALUE"
+            },
+            {
+              "help": "print help",
+              "name": "help",
+              "shortname": "h",
+              "value": null
+            }
+          ],
+          "subcommands": []
+        }
+      ]
+    },
+    {
+      "description": "Manipulate GPG Key actions on the server",
+      "name": "gpg",
+      "options": [
+        {
+          "help": "print help",
+          "name": "help",
+          "shortname": "h",
+          "value": null
+        }
+      ],
+      "subcommands": [
+        {
+          "description": "Create a gpg key",
+          "name": "create",
+          "options": [
+            {
+              "help": "GPG Key file",
+              "name": "key",
+              "shortname": null,
+              "value": "GPG_KEY_FILE"
+            },
+            {
+              "help": "identifier of the gpg key",
+              "name": "name",
+              "shortname": null,
+              "value": "NAME"
+            },
+            {
+              "help": "Organization name to search by",
+              "name": "organization",
+              "shortname": null,
+              "value": "ORGANIZATION_NAME"
+            },
+            {
+              "help": "organization ID",
+              "name": "organization-id",
+              "shortname": null,
+              "value": "ORGANIZATION_ID"
+            },
+            {
+              "help": "Organization label to search by",
+              "name": "organization-label",
+              "shortname": null,
+              "value": "ORGANIZATION_LABEL"
+            },
+            {
+              "help": "print help",
+              "name": "help",
+              "shortname": "h",
+              "value": null
+            }
+          ],
+          "subcommands": []
+        },
+        {
+          "description": "Destroy a gpg key",
+          "name": "delete",
+          "options": [
+            {
+              "help": "gpg key numeric identifier",
+              "name": "id",
+              "shortname": null,
+              "value": "ID"
+            },
+            {
+              "help": "Name to search by",
+              "name": "name",
+              "shortname": null,
+              "value": "NAME"
+            },
+            {
+              "help": "Organization name to search by",
+              "name": "organization",
+              "shortname": null,
+              "value": "ORGANIZATION_NAME"
+            },
+            {
+              "help": "organization ID",
+              "name": "organization-id",
+              "shortname": null,
+              "value": "ORGANIZATION_ID"
+            },
+            {
+              "help": "Organization label to search by",
+              "name": "organization-label",
+              "shortname": null,
+              "value": "ORGANIZATION_LABEL"
+            },
+            {
+              "help": "print help",
+              "name": "help",
+              "shortname": "h",
+              "value": null
+            }
+          ],
+          "subcommands": []
+        },
+        {
+          "description": "Show a gpg key",
+          "name": "info",
+          "options": [
+            {
+              "help": "gpg key numeric identifier",
+              "name": "id",
+              "shortname": null,
+              "value": "ID"
+            },
+            {
+              "help": "Name to search by",
+              "name": "name",
+              "shortname": null,
+              "value": "NAME"
+            },
+            {
+              "help": "Organization name to search by",
+              "name": "organization",
+              "shortname": null,
+              "value": "ORGANIZATION_NAME"
+            },
+            {
+              "help": "organization ID",
+              "name": "organization-id",
+              "shortname": null,
+              "value": "ORGANIZATION_ID"
+            },
+            {
+              "help": "Organization label to search by",
+              "name": "organization-label",
+              "shortname": null,
+              "value": "ORGANIZATION_LABEL"
+            },
+            {
+              "help": "print help",
+              "name": "help",
+              "shortname": "h",
+              "value": null
+            }
+          ],
+          "subcommands": []
+        },
+        {
+          "description": "List gpg keys",
+          "name": "list",
+          "options": [
+            {
+              "help": "Field to sort the results on",
+              "name": "by",
+              "shortname": null,
+              "value": "BY"
+            },
+            {
+              "help": "Whether or not to show all results One of true/false, yes/no, 1/0.",
+              "name": "full-results",
+              "shortname": null,
+              "value": "FULL_RESULTS"
+            },
+            {
+              "help": "name of the GPG key",
+              "name": "name",
+              "shortname": null,
+              "value": "NAME"
+            },
+            {
+              "help": "Sort field and order, eg. 'name DESC'",
+              "name": "order",
+              "shortname": null,
+              "value": "ORDER"
+            },
+            {
+              "help": "Organization name to search by",
+              "name": "organization",
+              "shortname": null,
+              "value": "ORGANIZATION_NAME"
+            },
+            {
+              "help": "organization ID",
+              "name": "organization-id",
+              "shortname": null,
+              "value": "ORGANIZATION_ID"
+            },
+            {
+              "help": "Organization label to search by",
+              "name": "organization-label",
+              "shortname": null,
+              "value": "ORGANIZATION_LABEL"
+            },
+            {
+              "help": "Page number, starting at 1",
+              "name": "page",
+              "shortname": null,
+              "value": "PAGE"
+            },
+            {
+              "help": "Number of results per page to return",
+              "name": "per-page",
+              "shortname": null,
+              "value": "PER_PAGE"
+            },
+            {
+              "help": "Search string",
+              "name": "search",
+              "shortname": null,
+              "value": "SEARCH"
+            },
+            {
+              "help": "print help",
+              "name": "help",
+              "shortname": "h",
+              "value": null
+            }
+          ],
+          "subcommands": []
+        },
+        {
+          "description": "Update a repository",
+          "name": "update",
+          "options": [
+            {
+              "help": "gpg key numeric identifier",
+              "name": "id",
+              "shortname": null,
+              "value": "ID"
+            },
+            {
+              "help": "GPG Key file",
+              "name": "key",
+              "shortname": null,
+              "value": "GPG_KEY_FILE"
+            },
+            {
+              "help": "Name to search by",
+              "name": "name",
+              "shortname": null,
+              "value": "NAME"
+            },
+            {
+              "help": "identifier of the gpg key",
+              "name": "new-name",
+              "shortname": null,
+              "value": "NEW_NAME"
+            },
+            {
+              "help": "Organization name to search by",
+              "name": "organization",
+              "shortname": null,
+              "value": "ORGANIZATION_NAME"
+            },
+            {
+              "help": "organization ID",
+              "name": "organization-id",
+              "shortname": null,
+              "value": "ORGANIZATION_ID"
+            },
+            {
+              "help": "Organization label to search by",
+              "name": "organization-label",
+              "shortname": null,
+              "value": "ORGANIZATION_LABEL"
+            },
+            {
+              "help": "print help",
+              "name": "help",
+              "shortname": "h",
+              "value": null
+            }
+          ],
+          "subcommands": []
+        }
+      ]
+    },
+    {
+      "description": "Manipulate hosts.",
+      "name": "host",
+      "options": [
+        {
+          "help": "print help",
+          "name": "help",
+          "shortname": "h",
+          "value": null
+        }
+      ],
+      "subcommands": [
+        {
+          "description": "Create a host",
+          "name": "create",
+          "options": [
+            {
+              "help": "Architecture name",
+              "name": "architecture",
+              "shortname": null,
+              "value": "ARCHITECTURE_NAME"
+            },
+            {
+              "help": "",
+              "name": "architecture-id",
+              "shortname": null,
+              "value": "ARCHITECTURE_ID"
+            },
+            {
+              "help": "One of true/false, yes/no, 1/0.",
+              "name": "ask-root-password",
+              "shortname": null,
+              "value": "ASK_ROOT_PW"
+            },
+            {
+              "help": "One of true/false, yes/no, 1/0. Default: \"true\"",
+              "name": "build",
+              "shortname": null,
+              "value": "BUILD"
+            },
+            {
+              "help": "Additional information about this host",
+              "name": "comment",
+              "shortname": null,
+              "value": "COMMENT"
+            },
+            {
+              "help": "Compute resource attributes. Comma-separated list of key=value.",
+              "name": "compute-attributes",
+              "shortname": null,
+              "value": "COMPUTE_ATTRS"
+            },
+            {
+              "help": "Name to search by",
+              "name": "compute-profile",
+              "shortname": null,
+              "value": "COMPUTE_PROFILE_NAME"
+            },
+            {
+              "help": "",
+              "name": "compute-profile-id",
+              "shortname": null,
+              "value": "COMPUTE_PROFILE_ID"
+            },
+            {
+              "help": "Compute resource name",
+              "name": "compute-resource",
+              "shortname": null,
+              "value": "COMPUTE_RESOURCE_NAME"
+            },
+            {
+              "help": "",
+              "name": "compute-resource-id",
+              "shortname": null,
+              "value": "COMPUTE_RESOURCE_ID"
+            },
+            {
+              "help": "Domain name",
+              "name": "domain",
+              "shortname": null,
+              "value": "DOMAIN_NAME"
+            },
+            {
+              "help": "Numerical ID or domain name",
+              "name": "domain-id",
+              "shortname": null,
+              "value": "DOMAIN_ID"
+            },
+            {
+              "help": "One of true/false, yes/no, 1/0. Default: \"true\"",
+              "name": "enabled",
+              "shortname": null,
+              "value": "ENABLED"
+            },
+            {
+              "help": "Environment name",
+              "name": "environment",
+              "shortname": null,
+              "value": "ENVIRONMENT_NAME"
+            },
+            {
+              "help": "",
+              "name": "environment-id",
+              "shortname": null,
+              "value": "ENVIRONMENT_ID"
+            },
+            {
+              "help": "Hostgroup name",
+              "name": "hostgroup",
+              "shortname": null,
+              "value": "HOSTGROUP_NAME"
+            },
+            {
+              "help": "",
+              "name": "hostgroup-id",
+              "shortname": null,
+              "value": "HOSTGROUP_ID"
+            },
+            {
+              "help": "Name to search by",
+              "name": "image",
+              "shortname": null,
+              "value": "IMAGE_NAME"
+            },
+            {
+              "help": "",
+              "name": "image-id",
+              "shortname": null,
+              "value": "IMAGE_ID"
+            },
+            {
+              "help": "Interface parameters. Comma-separated list of key=value. Can be specified multiple times.",
+              "name": "interface",
+              "shortname": null,
+              "value": "INTERFACE"
+            },
+            {
+              "help": "not required if using a subnet with DHCP proxy",
+              "name": "ip",
+              "shortname": null,
+              "value": "IP"
+            },
+            {
+              "help": "Location name",
+              "name": "location",
+              "shortname": null,
+              "value": "LOCATION_NAME"
+            },
+            {
+              "help": "",
+              "name": "location-id",
+              "shortname": null,
+              "value": "LOCATION_ID"
+            },
+            {
+              "help": "required for managed host that is bare metal, not required if it's a virtual machine",
+              "name": "mac",
+              "shortname": null,
+              "value": "MAC"
+            },
+            {
+              "help": "One of true/false, yes/no, 1/0. Default: \"true\"",
+              "name": "managed",
+              "shortname": null,
+              "value": "MANAGED"
+            },
+            {
+              "help": "Medium name",
+              "name": "medium",
+              "shortname": null,
+              "value": "MEDIUM_NAME"
+            },
+            {
+              "help": "",
+              "name": "medium-id",
+              "shortname": null,
+              "value": "MEDIUM_ID"
+            },
+            {
+              "help": "Model name",
+              "name": "model",
+              "shortname": null,
+              "value": "MODEL_NAME"
+            },
+            {
+              "help": "",
+              "name": "model-id",
+              "shortname": null,
+              "value": "MODEL_ID"
+            },
+            {
+              "help": "",
+              "name": "name",
+              "shortname": null,
+              "value": "NAME"
+            },
+            {
+              "help": "Operating system title",
+              "name": "operatingsystem",
+              "shortname": null,
+              "value": "OPERATINGSYSTEM_TITLE"
+            },
+            {
+              "help": "",
+              "name": "operatingsystem-id",
+              "shortname": null,
+              "value": "OPERATINGSYSTEM_ID"
+            },
+            {
+              "help": "Organization name",
+              "name": "organization",
+              "shortname": null,
+              "value": "ORGANIZATION_NAME"
+            },
+            {
+              "help": "organization ID",
+              "name": "organization-id",
+              "shortname": null,
+              "value": "ORGANIZATION_ID"
+            },
+            {
+              "help": "Login of the owner",
+              "name": "owner",
+              "shortname": null,
+              "value": "OWNER_LOGIN"
+            },
+            {
+              "help": "ID of the owner",
+              "name": "owner-id",
+              "shortname": null,
+              "value": "OWNER_ID"
+            },
+            {
+              "help": "Host's owner type",
+              "name": "owner-type",
+              "shortname": null,
+              "value": "OWNER_TYPE"
+            },
+            {
+              "help": "Host parameters. Comma-separated list of key=value.",
+              "name": "parameters",
+              "shortname": null,
+              "value": "PARAMS"
+            },
+            {
+              "help": "Partition table name",
+              "name": "partition-table",
+              "shortname": null,
+              "value": "PARTITION_TABLE_NAME"
+            },
+            {
+              "help": "",
+              "name": "partition-table-id",
+              "shortname": null,
+              "value": "PARTITION_TABLE_ID"
+            },
+            {
+              "help": "UUID to track orchestration tasks status, GET /api/orchestration/:UUID/tasks",
+              "name": "progress-report-id",
+              "shortname": null,
+              "value": "PROGRESS_REPORT_ID"
+            },
+            {
+              "help": "One of 'build', 'image'",
+              "name": "provision-method",
+              "shortname": null,
+              "value": "METHOD"
+            },
+            {
+              "help": "",
+              "name": "puppet-ca-proxy",
+              "shortname": null,
+              "value": "PUPPET_CA_PROXY_NAME"
+            },
+            {
+              "help": "",
+              "name": "puppet-ca-proxy-id",
+              "shortname": null,
+              "value": "PUPPET_CA_PROXY_ID"
+            },
+            {
+              "help": "Comma separated list of values.",
+              "name": "puppet-class-ids",
+              "shortname": null,
+              "value": "PUPPET_CLASS_IDS"
+            },
+            {
+              "help": "Comma separated list of values.",
+              "name": "puppet-classes",
+              "shortname": null,
+              "value": "PUPPET_CLASS_NAMES"
+            },
+            {
+              "help": "",
+              "name": "puppet-proxy",
+              "shortname": null,
+              "value": "PUPPET_PROXY_NAME"
+            },
+            {
+              "help": "",
+              "name": "puppet-proxy-id",
+              "shortname": null,
+              "value": "PUPPET_PROXY_ID"
+            },
+            {
+              "help": "Name to search by",
+              "name": "realm",
+              "shortname": null,
+              "value": "REALM_NAME"
+            },
+            {
+              "help": "Numerical ID or realm name",
+              "name": "realm-id",
+              "shortname": null,
+              "value": "REALM_ID"
+            },
+            {
+              "help": "required if host is managed and value is not inherited from host group or default password in settings",
+              "name": "root-pass",
+              "shortname": null,
+              "value": "ROOT_PASS"
+            },
+            {
+              "help": "",
+              "name": "root-password",
+              "shortname": null,
+              "value": "ROOT_PW"
+            },
+            {
+              "help": "Subnet name",
+              "name": "subnet",
+              "shortname": null,
+              "value": "SUBNET_NAME"
+            },
+            {
+              "help": "",
+              "name": "subnet-id",
+              "shortname": null,
+              "value": "SUBNET_ID"
+            },
+            {
+              "help": "Volume parameters Comma-separated list of key=value. Can be specified multiple times.",
+              "name": "volume",
+              "shortname": null,
+              "value": "VOLUME"
+            },
+            {
+              "help": "print help",
+              "name": "help",
+              "shortname": "h",
+              "value": null
+            }
+          ],
+          "subcommands": []
+        },
+        {
+          "description": "Delete a host",
+          "name": "delete",
+          "options": [
+            {
+              "help": "",
+              "name": "id",
+              "shortname": null,
+              "value": "ID"
+            },
+            {
+              "help": "Host name",
+              "name": "name",
+              "shortname": null,
+              "value": "NAME"
+            },
+            {
+              "help": "print help",
+              "name": "help",
+              "shortname": "h",
+              "value": null
+            }
+          ],
+          "subcommands": []
+        },
+        {
+          "description": "Delete parameter for a host.",
+          "name": "delete-parameter",
+          "options": [
+            {
+              "help": "Host name",
+              "name": "host",
+              "shortname": null,
+              "value": "HOST_NAME"
+            },
+            {
+              "help": "",
+              "name": "host-id",
+              "shortname": null,
+              "value": "HOST_ID"
+            },
+            {
+              "help": "parameter name",
+              "name": "name",
+              "shortname": null,
+              "value": "NAME"
+            },
+            {
+              "help": "print help",
+              "name": "help",
+              "shortname": "h",
+              "value": null
+            }
+          ],
+          "subcommands": []
+        },
+        {
+          "description": "List all fact values",
+          "name": "facts",
+          "options": [
+            {
+              "help": "",
+              "name": "id",
+              "shortname": null,
+              "value": "ID"
+            },
+            {
+              "help": "Host name",
+              "name": "name",
+              "shortname": null,
+              "value": "NAME"
+            },
+            {
+              "help": "sort results",
+              "name": "order",
+              "shortname": null,
+              "value": "ORDER"
+            },
+            {
+              "help": "paginate results",
+              "name": "page",
+              "shortname": null,
+              "value": "PAGE"
+            },
+            {
+              "help": "number of entries per request",
+              "name": "per-page",
+              "shortname": null,
+              "value": "PER_PAGE"
+            },
+            {
+              "help": "filter results",
+              "name": "search",
+              "shortname": null,
+              "value": "SEARCH"
+            },
+            {
+              "help": "print help",
+              "name": "help",
+              "shortname": "h",
+              "value": null
+            }
+          ],
+          "subcommands": []
+        },
+        {
+          "description": "Show a host",
+          "name": "info",
+          "options": [
+            {
+              "help": "",
+              "name": "id",
+              "shortname": null,
+              "value": "ID"
+            },
+            {
+              "help": "Host name",
+              "name": "name",
+              "shortname": null,
+              "value": "NAME"
+            },
+            {
+              "help": "print help",
+              "name": "help",
+              "shortname": "h",
+              "value": null
+            }
+          ],
+          "subcommands": []
+        },
+        {
+          "description": "List all hosts",
+          "name": "list",
+          "options": [
+            {
+              "help": "Environment name",
+              "name": "environment",
+              "shortname": null,
+              "value": "ENVIRONMENT_NAME"
+            },
+            {
+              "help": "",
+              "name": "environment-id",
+              "shortname": null,
+              "value": "ENVIRONMENT_ID"
+            },
+            {
+              "help": "Hostgroup name",
+              "name": "hostgroup",
+              "shortname": null,
+              "value": "HOSTGROUP_NAME"
+            },
+            {
+              "help": "",
+              "name": "hostgroup-id",
+              "shortname": null,
+              "value": "HOSTGROUP_ID"
+            },
+            {
+              "help": "Location name",
+              "name": "location",
+              "shortname": null,
+              "value": "LOCATION_NAME"
+            },
+            {
+              "help": "",
+              "name": "location-id",
+              "shortname": null,
+              "value": "LOCATION_ID"
+            },
+            {
+              "help": "sort results",
+              "name": "order",
+              "shortname": null,
+              "value": "ORDER"
+            },
+            {
+              "help": "Organization name",
+              "name": "organization",
+              "shortname": null,
+              "value": "ORGANIZATION_NAME"
+            },
+            {
+              "help": "organization ID",
+              "name": "organization-id",
+              "shortname": null,
+              "value": "ORGANIZATION_ID"
+            },
+            {
+              "help": "paginate results",
+              "name": "page",
+              "shortname": null,
+              "value": "PAGE"
+            },
+            {
+              "help": "number of entries per request",
+              "name": "per-page",
+              "shortname": null,
+              "value": "PER_PAGE"
+            },
+            {
+              "help": "filter results",
+              "name": "search",
+              "shortname": null,
+              "value": "SEARCH"
+            },
+            {
+              "help": "print help",
+              "name": "help",
+              "shortname": "h",
+              "value": null
+            }
+          ],
+          "subcommands": []
+        },
+        {
+          "description": "List all Puppet classes",
+          "name": "puppet-classes",
+          "options": [
+            {
+              "help": "Host name",
+              "name": "host",
+              "shortname": null,
+              "value": "HOST_NAME"
+            },
+            {
+              "help": "",
+              "name": "host-id",
+              "shortname": null,
+              "value": "HOST_ID"
+            },
+            {
+              "help": "sort results",
+              "name": "order",
+              "shortname": null,
+              "value": "ORDER"
+            },
+            {
+              "help": "paginate results",
+              "name": "page",
+              "shortname": null,
+              "value": "PAGE"
+            },
+            {
+              "help": "number of entries per request",
+              "name": "per-page",
+              "shortname": null,
+              "value": "PER_PAGE"
+            },
+            {
+              "help": "filter results",
+              "name": "search",
+              "shortname": null,
+              "value": "SEARCH"
+            },
+            {
+              "help": "print help",
+              "name": "help",
+              "shortname": "h",
+              "value": null
+            }
+          ],
+          "subcommands": []
+        },
+        {
+          "description": "Force a Puppet agent run on the host",
+          "name": "puppetrun",
+          "options": [
+            {
+              "help": "",
+              "name": "id",
+              "shortname": null,
+              "value": "ID"
+            },
+            {
+              "help": "Host name",
+              "name": "name",
+              "shortname": null,
+              "value": "NAME"
+            },
+            {
+              "help": "print help",
+              "name": "help",
+              "shortname": "h",
+              "value": null
+            }
+          ],
+          "subcommands": []
+        },
+        {
+          "description": "Reboot a host",
+          "name": "reboot",
+          "options": [
+            {
+              "help": "",
+              "name": "id",
+              "shortname": null,
+              "value": "ID"
+            },
+            {
+              "help": "Host name",
+              "name": "name",
+              "shortname": null,
+              "value": "NAME"
+            },
+            {
+              "help": "print help",
+              "name": "help",
+              "shortname": "h",
+              "value": null
+            }
+          ],
+          "subcommands": []
+        },
+        {
+          "description": "List all reports",
+          "name": "reports",
+          "options": [
+            {
+              "help": "",
+              "name": "id",
+              "shortname": null,
+              "value": "ID"
+            },
+            {
+              "help": "Host name",
+              "name": "name",
+              "shortname": null,
+              "value": "NAME"
+            },
+            {
+              "help": "sort results",
+              "name": "order",
+              "shortname": null,
+              "value": "ORDER"
+            },
+            {
+              "help": "paginate results",
+              "name": "page",
+              "shortname": null,
+              "value": "PAGE"
+            },
+            {
+              "help": "number of entries per request",
+              "name": "per-page",
+              "shortname": null,
+              "value": "PER_PAGE"
+            },
+            {
+              "help": "filter results",
+              "name": "search",
+              "shortname": null,
+              "value": "SEARCH"
+            },
+            {
+              "help": "print help",
+              "name": "help",
+              "shortname": "h",
+              "value": null
+            }
+          ],
+          "subcommands": []
+        },
+        {
+          "description": "List all smart class parameters",
+          "name": "sc-params",
+          "options": [
+            {
+              "help": "Environment name",
+              "name": "environment",
+              "shortname": null,
+              "value": "ENVIRONMENT_NAME"
+            },
+            {
+              "help": "",
+              "name": "environment-id",
+              "shortname": null,
+              "value": "ENVIRONMENT_ID"
+            },
+            {
+              "help": "Host name",
+              "name": "host",
+              "shortname": null,
+              "value": "HOST_NAME"
+            },
+            {
+              "help": "",
+              "name": "host-id",
+              "shortname": null,
+              "value": "HOST_ID"
+            },
+            {
+              "help": "Hostgroup name",
+              "name": "hostgroup",
+              "shortname": null,
+              "value": "HOSTGROUP_NAME"
+            },
+            {
+              "help": "",
+              "name": "hostgroup-id",
+              "shortname": null,
+              "value": "HOSTGROUP_ID"
+            },
+            {
+              "help": "",
+              "name": "id",
+              "shortname": null,
+              "value": "ID"
+            },
+            {
+              "help": "Host name",
+              "name": "name",
+              "shortname": null,
+              "value": "NAME"
+            },
+            {
+              "help": "sort results",
+              "name": "order",
+              "shortname": null,
+              "value": "ORDER"
+            },
+            {
+              "help": "paginate results",
+              "name": "page",
+              "shortname": null,
+              "value": "PAGE"
+            },
+            {
+              "help": "number of entries per request",
+              "name": "per-page",
+              "shortname": null,
+              "value": "PER_PAGE"
+            },
+            {
+              "help": "Puppet class name",
+              "name": "puppet-class",
+              "shortname": null,
+              "value": "PUPPET_CLASS_NAME"
+            },
+            {
+              "help": "ID of Puppet class",
+              "name": "puppet-class-id",
+              "shortname": null,
+              "value": "PUPPET_CLASS_ID"
+            },
+            {
+              "help": "filter results",
+              "name": "search",
+              "shortname": null,
+              "value": "SEARCH"
+            },
+            {
+              "help": "print help",
+              "name": "help",
+              "shortname": "h",
+              "value": null
+            }
+          ],
+          "subcommands": []
+        },
+        {
+          "description": "Create or update parameter for a host.",
+          "name": "set-parameter",
+          "options": [
+            {
+              "help": "Host name",
+              "name": "host",
+              "shortname": null,
+              "value": "HOST_NAME"
+            },
+            {
+              "help": "",
+              "name": "host-id",
+              "shortname": null,
+              "value": "HOST_ID"
+            },
+            {
+              "help": "parameter name",
+              "name": "name",
+              "shortname": null,
+              "value": "NAME"
+            },
+            {
+              "help": "parameter value",
+              "name": "value",
+              "shortname": null,
+              "value": "VALUE"
+            },
+            {
+              "help": "print help",
+              "name": "help",
+              "shortname": "h",
+              "value": null
+            }
+          ],
+          "subcommands": []
+        },
+        {
+          "description": "Power a host on",
+          "name": "start",
+          "options": [
+            {
+              "help": "",
+              "name": "id",
+              "shortname": null,
+              "value": "ID"
+            },
+            {
+              "help": "Host name",
+              "name": "name",
+              "shortname": null,
+              "value": "NAME"
+            },
+            {
+              "help": "print help",
+              "name": "help",
+              "shortname": "h",
+              "value": null
+            }
+          ],
+          "subcommands": []
+        },
+        {
+          "description": "Get status of host",
+          "name": "status",
+          "options": [
+            {
+              "help": "",
+              "name": "id",
+              "shortname": null,
+              "value": "ID"
+            },
+            {
+              "help": "Host name",
+              "name": "name",
+              "shortname": null,
+              "value": "NAME"
+            },
+            {
+              "help": "print help",
+              "name": "help",
+              "shortname": "h",
+              "value": null
+            }
+          ],
+          "subcommands": []
+        },
+        {
+          "description": "Power a host off",
+          "name": "stop",
+          "options": [
+            {
+              "help": "Force turning off a host",
+              "name": "force",
+              "shortname": null,
+              "value": null
+            },
+            {
+              "help": "",
+              "name": "id",
+              "shortname": null,
+              "value": "ID"
+            },
+            {
+              "help": "Host name",
+              "name": "name",
+              "shortname": null,
+              "value": "NAME"
+            },
+            {
+              "help": "print help",
+              "name": "help",
+              "shortname": "h",
+              "value": null
+            }
+          ],
+          "subcommands": []
+        },
+        {
+          "description": "Update a host",
+          "name": "update",
+          "options": [
+            {
+              "help": "Architecture name",
+              "name": "architecture",
+              "shortname": null,
+              "value": "ARCHITECTURE_NAME"
+            },
+            {
+              "help": "",
+              "name": "architecture-id",
+              "shortname": null,
+              "value": "ARCHITECTURE_ID"
+            },
+            {
+              "help": "One of true/false, yes/no, 1/0.",
+              "name": "ask-root-password",
+              "shortname": null,
+              "value": "ASK_ROOT_PW"
+            },
+            {
+              "help": "One of true/false, yes/no, 1/0.",
+              "name": "build",
+              "shortname": null,
+              "value": "BUILD"
+            },
+            {
+              "help": "Additional information about this host",
+              "name": "comment",
+              "shortname": null,
+              "value": "COMMENT"
+            },
+            {
+              "help": "Compute resource attributes. Comma-separated list of key=value.",
+              "name": "compute-attributes",
+              "shortname": null,
+              "value": "COMPUTE_ATTRS"
+            },
+            {
+              "help": "Name to search by",
+              "name": "compute-profile",
+              "shortname": null,
+              "value": "COMPUTE_PROFILE_NAME"
+            },
+            {
+              "help": "",
+              "name": "compute-profile-id",
+              "shortname": null,
+              "value": "COMPUTE_PROFILE_ID"
+            },
+            {
+              "help": "Compute resource name",
+              "name": "compute-resource",
+              "shortname": null,
+              "value": "COMPUTE_RESOURCE_NAME"
+            },
+            {
+              "help": "",
+              "name": "compute-resource-id",
+              "shortname": null,
+              "value": "COMPUTE_RESOURCE_ID"
+            },
+            {
+              "help": "Domain name",
+              "name": "domain",
+              "shortname": null,
+              "value": "DOMAIN_NAME"
+            },
+            {
+              "help": "Numerical ID or domain name",
+              "name": "domain-id",
+              "shortname": null,
+              "value": "DOMAIN_ID"
+            },
+            {
+              "help": "One of true/false, yes/no, 1/0.",
+              "name": "enabled",
+              "shortname": null,
+              "value": "ENABLED"
+            },
+            {
+              "help": "Environment name",
+              "name": "environment",
+              "shortname": null,
+              "value": "ENVIRONMENT_NAME"
+            },
+            {
+              "help": "",
+              "name": "environment-id",
+              "shortname": null,
+              "value": "ENVIRONMENT_ID"
+            },
+            {
+              "help": "Hostgroup name",
+              "name": "hostgroup",
+              "shortname": null,
+              "value": "HOSTGROUP_NAME"
+            },
+            {
+              "help": "",
+              "name": "hostgroup-id",
+              "shortname": null,
+              "value": "HOSTGROUP_ID"
+            },
+            {
+              "help": "",
+              "name": "id",
+              "shortname": null,
+              "value": "ID"
+            },
+            {
+              "help": "Name to search by",
+              "name": "image",
+              "shortname": null,
+              "value": "IMAGE_NAME"
+            },
+            {
+              "help": "",
+              "name": "image-id",
+              "shortname": null,
+              "value": "IMAGE_ID"
+            },
+            {
+              "help": "Interface parameters. Comma-separated list of key=value. Can be specified multiple times.",
+              "name": "interface",
+              "shortname": null,
+              "value": "INTERFACE"
+            },
+            {
+              "help": "not required if using a subnet with DHCP proxy",
+              "name": "ip",
+              "shortname": null,
+              "value": "IP"
+            },
+            {
+              "help": "Location name",
+              "name": "location",
+              "shortname": null,
+              "value": "LOCATION_NAME"
+            },
+            {
+              "help": "",
+              "name": "location-id",
+              "shortname": null,
+              "value": "LOCATION_ID"
+            },
+            {
+              "help": "required for managed host that is bare metal, not required if it's a virtual machine",
+              "name": "mac",
+              "shortname": null,
+              "value": "MAC"
+            },
+            {
+              "help": "One of true/false, yes/no, 1/0.",
+              "name": "managed",
+              "shortname": null,
+              "value": "MANAGED"
+            },
+            {
+              "help": "Medium name",
+              "name": "medium",
+              "shortname": null,
+              "value": "MEDIUM_NAME"
+            },
+            {
+              "help": "",
+              "name": "medium-id",
+              "shortname": null,
+              "value": "MEDIUM_ID"
+            },
+            {
+              "help": "Model name",
+              "name": "model",
+              "shortname": null,
+              "value": "MODEL_NAME"
+            },
+            {
+              "help": "",
+              "name": "model-id",
+              "shortname": null,
+              "value": "MODEL_ID"
+            },
+            {
+              "help": "Host name",
+              "name": "name",
+              "shortname": null,
+              "value": "NAME"
+            },
+            {
+              "help": "",
+              "name": "new-name",
+              "shortname": null,
+              "value": "NEW_NAME"
+            },
+            {
+              "help": "Operating system title",
+              "name": "operatingsystem",
+              "shortname": null,
+              "value": "OPERATINGSYSTEM_TITLE"
+            },
+            {
+              "help": "",
+              "name": "operatingsystem-id",
+              "shortname": null,
+              "value": "OPERATINGSYSTEM_ID"
+            },
+            {
+              "help": "Organization name",
+              "name": "organization",
+              "shortname": null,
+              "value": "ORGANIZATION_NAME"
+            },
+            {
+              "help": "organization ID",
+              "name": "organization-id",
+              "shortname": null,
+              "value": "ORGANIZATION_ID"
+            },
+            {
+              "help": "Login of the owner",
+              "name": "owner",
+              "shortname": null,
+              "value": "OWNER_LOGIN"
+            },
+            {
+              "help": "ID of the owner",
+              "name": "owner-id",
+              "shortname": null,
+              "value": "OWNER_ID"
+            },
+            {
+              "help": "Host's owner type",
+              "name": "owner-type",
+              "shortname": null,
+              "value": "OWNER_TYPE"
+            },
+            {
+              "help": "Host parameters. Comma-separated list of key=value.",
+              "name": "parameters",
+              "shortname": null,
+              "value": "PARAMS"
+            },
+            {
+              "help": "Partition table name",
+              "name": "partition-table",
+              "shortname": null,
+              "value": "PARTITION_TABLE_NAME"
+            },
+            {
+              "help": "",
+              "name": "partition-table-id",
+              "shortname": null,
+              "value": "PARTITION_TABLE_ID"
+            },
+            {
+              "help": "UUID to track orchestration tasks status, GET /api/orchestration/:UUID/tasks",
+              "name": "progress-report-id",
+              "shortname": null,
+              "value": "PROGRESS_REPORT_ID"
+            },
+            {
+              "help": "One of 'build', 'image'",
+              "name": "provision-method",
+              "shortname": null,
+              "value": "METHOD"
+            },
+            {
+              "help": "",
+              "name": "puppet-ca-proxy",
+              "shortname": null,
+              "value": "PUPPET_CA_PROXY_NAME"
+            },
+            {
+              "help": "",
+              "name": "puppet-ca-proxy-id",
+              "shortname": null,
+              "value": "PUPPET_CA_PROXY_ID"
+            },
+            {
+              "help": "Comma separated list of values.",
+              "name": "puppet-class-ids",
+              "shortname": null,
+              "value": "PUPPET_CLASS_IDS"
+            },
+            {
+              "help": "Comma separated list of values.",
+              "name": "puppet-classes",
+              "shortname": null,
+              "value": "PUPPET_CLASS_NAMES"
+            },
+            {
+              "help": "",
+              "name": "puppet-proxy",
+              "shortname": null,
+              "value": "PUPPET_PROXY_NAME"
+            },
+            {
+              "help": "",
+              "name": "puppet-proxy-id",
+              "shortname": null,
+              "value": "PUPPET_PROXY_ID"
+            },
+            {
+              "help": "Name to search by",
+              "name": "realm",
+              "shortname": null,
+              "value": "REALM_NAME"
+            },
+            {
+              "help": "Numerical ID or realm name",
+              "name": "realm-id",
+              "shortname": null,
+              "value": "REALM_ID"
+            },
+            {
+              "help": "required if host is managed and value is not inherited from host group or default password in settings",
+              "name": "root-pass",
+              "shortname": null,
+              "value": "ROOT_PASS"
+            },
+            {
+              "help": "",
+              "name": "root-password",
+              "shortname": null,
+              "value": "ROOT_PW"
+            },
+            {
+              "help": "Subnet name",
+              "name": "subnet",
+              "shortname": null,
+              "value": "SUBNET_NAME"
+            },
+            {
+              "help": "",
+              "name": "subnet-id",
+              "shortname": null,
+              "value": "SUBNET_ID"
+            },
+            {
+              "help": "Volume parameters Comma-separated list of key=value. Can be specified multiple times.",
+              "name": "volume",
+              "shortname": null,
+              "value": "VOLUME"
+            },
+            {
+              "help": "print help",
+              "name": "help",
+              "shortname": "h",
+              "value": null
+            }
+          ],
+          "subcommands": []
+        }
+      ]
+    },
+    {
+      "description": "Manipulate host collections",
+      "name": "host-collection",
+      "options": [
+        {
+          "help": "print help",
+          "name": "help",
+          "shortname": "h",
+          "value": null
+        }
+      ],
+      "subcommands": [
+        {
+          "description": "Add content host to the host collection",
+          "name": "add-content-host",
+          "options": [
+            {
+              "help": "Array of content host ids Comma separated list of values.",
+              "name": "content-host-ids",
+              "shortname": null,
+              "value": "CONTENT_HOST_IDS"
+            },
+            {
+              "help": "Id of the host collection",
+              "name": "id",
+              "shortname": null,
+              "value": "ID"
+            },
+            {
+              "help": "Host collection name to search by",
+              "name": "name",
+              "shortname": null,
+              "value": "NAME"
+            },
+            {
+              "help": "Organization name to search by",
+              "name": "organization",
+              "shortname": null,
+              "value": "ORGANIZATION_NAME"
+            },
+            {
+              "help": "organization ID",
+              "name": "organization-id",
+              "shortname": null,
+              "value": "ORGANIZATION_ID"
+            },
+            {
+              "help": "Organization label to search by",
+              "name": "organization-label",
+              "shortname": null,
+              "value": "ORGANIZATION_LABEL"
+            },
+            {
+              "help": "Comma separated list of values.",
+              "name": "systems",
+              "shortname": null,
+              "value": "CONTENT_HOST_NAMES"
+            },
+            {
+              "help": "print help",
+              "name": "help",
+              "shortname": "h",
+              "value": null
+            }
+          ],
+          "subcommands": []
+        },
+        {
+          "description": "List content hosts in the host collection",
+          "name": "content-hosts",
+          "options": [
+            {
+              "help": "Id of the host collection",
+              "name": "id",
+              "shortname": null,
+              "value": "ID"
+            },
+            {
+              "help": "Host collection name to search by",
+              "name": "name",
+              "shortname": null,
+              "value": "NAME"
+            },
+            {
+              "help": "Organization name to search by",
+              "name": "organization",
+              "shortname": null,
+              "value": "ORGANIZATION_NAME"
+            },
+            {
+              "help": "organization ID",
+              "name": "organization-id",
+              "shortname": null,
+              "value": "ORGANIZATION_ID"
+            },
+            {
+              "help": "Organization label to search by",
+              "name": "organization-label",
+              "shortname": null,
+              "value": "ORGANIZATION_LABEL"
+            },
+            {
+              "help": "print help",
+              "name": "help",
+              "shortname": "h",
+              "value": null
+            }
+          ],
+          "subcommands": []
+        },
+        {
+          "description": "Make copy of a host collection",
+          "name": "copy",
+          "options": [
+            {
+              "help": "ID of the host collection",
+              "name": "id",
+              "shortname": null,
+              "value": "ID"
+            },
+            {
+              "help": "Host collection name to search by",
+              "name": "name",
+              "shortname": null,
+              "value": "NAME"
+            },
+            {
+              "help": "Organization name to search by",
+              "name": "organization",
+              "shortname": null,
+              "value": "ORGANIZATION_NAME"
+            },
+            {
+              "help": "organization ID",
+              "name": "organization-id",
+              "shortname": null,
+              "value": "ORGANIZATION_ID"
+            },
+            {
+              "help": "Organization label to search by",
+              "name": "organization-label",
+              "shortname": null,
+              "value": "ORGANIZATION_LABEL"
+            },
+            {
+              "help": "print help",
+              "name": "help",
+              "shortname": "h",
+              "value": null
+            }
+          ],
+          "subcommands": []
+        },
+        {
+          "description": "Create a host collection",
+          "name": "create",
+          "options": [
+            {
+              "help": "List of content host uuids to be in the host collection Comma separated list of values.",
+              "name": "content-host-ids",
+              "shortname": null,
+              "value": "CONTENT_HOST_IDS"
+            },
+            {
+              "help": "",
+              "name": "description",
+              "shortname": null,
+              "value": "DESCRIPTION"
+            },
+            {
+              "help": "Array of content host ids to replace the content hosts in host collection Comma separated list of values.",
+              "name": "host-collection-ids",
+              "shortname": null,
+              "value": "HOST_COLLECTION_IDS"
+            },
+            {
+              "help": "Maximum number of content hosts in the host collection",
+              "name": "max-content-hosts",
+              "shortname": null,
+              "value": "MAX_CONTENT_HOSTS"
+            },
+            {
+              "help": "Host Collection name",
+              "name": "name",
+              "shortname": null,
+              "value": "NAME"
+            },
+            {
+              "help": "Organization name to search by",
+              "name": "organization",
+              "shortname": null,
+              "value": "ORGANIZATION_NAME"
+            },
+            {
+              "help": "organization ID",
+              "name": "organization-id",
+              "shortname": null,
+              "value": "ORGANIZATION_ID"
+            },
+            {
+              "help": "Organization label to search by",
+              "name": "organization-label",
+              "shortname": null,
+              "value": "ORGANIZATION_LABEL"
+            },
+            {
+              "help": "Comma separated list of values.",
+              "name": "systems",
+              "shortname": null,
+              "value": "CONTENT_HOST_NAMES"
+            },
+            {
+              "help": "Whether or not the host collection may have unlimited content hosts One of true/false, yes/no, 1/0.",
+              "name": "unlimited-content-hosts",
+              "shortname": null,
+              "value": "UNLIMITED_CONTENT_HOSTS"
+            },
+            {
+              "help": "print help",
+              "name": "help",
+              "shortname": "h",
+              "value": null
+            }
+          ],
+          "subcommands": []
+        },
+        {
+          "description": "Destroy a host collection",
+          "name": "delete",
+          "options": [
+            {
+              "help": "Id of the host collection",
+              "name": "id",
+              "shortname": null,
+              "value": "ID"
+            },
+            {
+              "help": "Host collection name to search by",
+              "name": "name",
+              "shortname": null,
+              "value": "NAME"
+            },
+            {
+              "help": "Organization name to search by",
+              "name": "organization",
+              "shortname": null,
+              "value": "ORGANIZATION_NAME"
+            },
+            {
+              "help": "organization ID",
+              "name": "organization-id",
+              "shortname": null,
+              "value": "ORGANIZATION_ID"
+            },
+            {
+              "help": "Organization label to search by",
+              "name": "organization-label",
+              "shortname": null,
+              "value": "ORGANIZATION_LABEL"
+            },
+            {
+              "help": "print help",
+              "name": "help",
+              "shortname": "h",
+              "value": null
+            }
+          ],
+          "subcommands": []
+        },
+        {
+          "description": "Manipulate errata for a host collection",
+          "name": "erratum",
+          "options": [
+            {
+              "help": "print help",
+              "name": "help",
+              "shortname": "h",
+              "value": null
+            }
+          ],
+          "subcommands": [
+            {
+              "description": "Install errata on content hosts contained within a host collection",
+              "name": "install",
+              "options": [
+                {
+                  "help": "List of Errata to install Comma separated list of values.",
+                  "name": "errata",
+                  "shortname": null,
+                  "value": "ERRATA"
+                },
+                {
+                  "help": "Id of the host collection",
+                  "name": "id",
+                  "shortname": null,
+                  "value": "ID"
+                },
+                {
+                  "help": "Host collection name to search by",
+                  "name": "name",
+                  "shortname": null,
+                  "value": "NAME"
+                },
+                {
+                  "help": "Organization name to search by",
+                  "name": "organization",
+                  "shortname": null,
+                  "value": "ORGANIZATION_NAME"
+                },
+                {
+                  "help": "organization ID",
+                  "name": "organization-id",
+                  "shortname": null,
+                  "value": "ORGANIZATION_ID"
+                },
+                {
+                  "help": "Organization label to search by",
+                  "name": "organization-label",
+                  "shortname": null,
+                  "value": "ORGANIZATION_LABEL"
+                },
+                {
+                  "help": "print help",
+                  "name": "help",
+                  "shortname": "h",
+                  "value": null
+                }
+              ],
+              "subcommands": []
+            }
+          ]
+        },
+        {
+          "description": "Show a host collection",
+          "name": "info",
+          "options": [
+            {
+              "help": "Id of the host collection",
+              "name": "id",
+              "shortname": null,
+              "value": "ID"
+            },
+            {
+              "help": "Host collection name to search by",
+              "name": "name",
+              "shortname": null,
+              "value": "NAME"
+            },
+            {
+              "help": "Organization name to search by",
+              "name": "organization",
+              "shortname": null,
+              "value": "ORGANIZATION_NAME"
+            },
+            {
+              "help": "organization ID",
+              "name": "organization-id",
+              "shortname": null,
+              "value": "ORGANIZATION_ID"
+            },
+            {
+              "help": "Organization label to search by",
+              "name": "organization-label",
+              "shortname": null,
+              "value": "ORGANIZATION_LABEL"
+            },
+            {
+              "help": "print help",
+              "name": "help",
+              "shortname": "h",
+              "value": null
+            }
+          ],
+          "subcommands": []
+        },
+        {
+          "description": "List host collections",
+          "name": "list",
+          "options": [
+            {
+              "help": "Activation key name to search by",
+              "name": "activation-key",
+              "shortname": null,
+              "value": "ACTIVATION_KEY_NAME"
+            },
+            {
+              "help": "ID of the activation key",
+              "name": "activation-key-id",
+              "shortname": null,
+              "value": "ACTIVATION_KEY_ID"
+            },
+            {
+              "help": "Field to sort the results on",
+              "name": "by",
+              "shortname": null,
+              "value": "BY"
+            },
+            {
+              "help": "Name to search by",
+              "name": "content-host",
+              "shortname": null,
+              "value": "CONTENT_HOST_NAME"
+            },
+            {
+              "help": "UUID of the content host",
+              "name": "content-host-id",
+              "shortname": null,
+              "value": "CONTENT_HOST_ID"
+            },
+            {
+              "help": "Whether or not to show all results One of true/false, yes/no, 1/0.",
+              "name": "full-results",
+              "shortname": null,
+              "value": "FULL_RESULTS"
+            },
+            {
+              "help": "host collection name to filter by",
+              "name": "name",
+              "shortname": null,
+              "value": "NAME"
+            },
+            {
+              "help": "Sort field and order, eg. 'name DESC'",
+              "name": "order",
+              "shortname": null,
+              "value": "ORDER"
+            },
+            {
+              "help": "Organization name to search by",
+              "name": "organization",
+              "shortname": null,
+              "value": "ORGANIZATION_NAME"
+            },
+            {
+              "help": "organization ID",
+              "name": "organization-id",
+              "shortname": null,
+              "value": "ORGANIZATION_ID"
+            },
+            {
+              "help": "Organization label to search by",
+              "name": "organization-label",
+              "shortname": null,
+              "value": "ORGANIZATION_LABEL"
+            },
+            {
+              "help": "Page number, starting at 1",
+              "name": "page",
+              "shortname": null,
+              "value": "PAGE"
+            },
+            {
+              "help": "Number of results per page to return",
+              "name": "per-page",
+              "shortname": null,
+              "value": "PER_PAGE"
+            },
+            {
+              "help": "Search string",
+              "name": "search",
+              "shortname": null,
+              "value": "SEARCH"
+            },
+            {
+              "help": "print help",
+              "name": "help",
+              "shortname": "h",
+              "value": null
+            }
+          ],
+          "subcommands": []
+        },
+        {
+          "description": "Manipulate packages for a host collection",
+          "name": "package",
+          "options": [
+            {
+              "help": "print help",
+              "name": "help",
+              "shortname": "h",
+              "value": null
+            }
+          ],
+          "subcommands": [
+            {
+              "description": "Install packages on content hosts contained within a host collection",
+              "name": "install",
+              "options": [
+                {
+                  "help": "Id of the host collection",
+                  "name": "id",
+                  "shortname": null,
+                  "value": "ID"
+                },
+                {
+                  "help": "Host collection name to search by",
+                  "name": "name",
+                  "shortname": null,
+                  "value": "NAME"
+                },
+                {
+                  "help": "Organization name to search by",
+                  "name": "organization",
+                  "shortname": null,
+                  "value": "ORGANIZATION_NAME"
+                },
+                {
+                  "help": "organization ID",
+                  "name": "organization-id",
+                  "shortname": null,
+                  "value": "ORGANIZATION_ID"
+                },
+                {
+                  "help": "Organization label to search by",
+                  "name": "organization-label",
+                  "shortname": null,
+                  "value": "ORGANIZATION_LABEL"
+                },
+                {
+                  "help": "comma-separated list of packages to install Comma separated list of values.",
+                  "name": "packages",
+                  "shortname": null,
+                  "value": "PACKAGES"
+                },
+                {
+                  "help": "print help",
+                  "name": "help",
+                  "shortname": "h",
+                  "value": null
+                }
+              ],
+              "subcommands": []
+            },
+            {
+              "description": "Remove packages on content hosts contained within a host collection",
+              "name": "remove",
+              "options": [
+                {
+                  "help": "Id of the host collection",
+                  "name": "id",
+                  "shortname": null,
+                  "value": "ID"
+                },
+                {
+                  "help": "Host collection name to search by",
+                  "name": "name",
+                  "shortname": null,
+                  "value": "NAME"
+                },
+                {
+                  "help": "Organization name to search by",
+                  "name": "organization",
+                  "shortname": null,
+                  "value": "ORGANIZATION_NAME"
+                },
+                {
+                  "help": "organization ID",
+                  "name": "organization-id",
+                  "shortname": null,
+                  "value": "ORGANIZATION_ID"
+                },
+                {
+                  "help": "Organization label to search by",
+                  "name": "organization-label",
+                  "shortname": null,
+                  "value": "ORGANIZATION_LABEL"
+                },
+                {
+                  "help": "comma-separated list of packages to install Comma separated list of values.",
+                  "name": "packages",
+                  "shortname": null,
+                  "value": "PACKAGES"
+                },
+                {
+                  "help": "print help",
+                  "name": "help",
+                  "shortname": "h",
+                  "value": null
+                }
+              ],
+              "subcommands": []
+            },
+            {
+              "description": "Update packages on content hosts contained within a host collection",
+              "name": "update",
+              "options": [
+                {
+                  "help": "Id of the host collection",
+                  "name": "id",
+                  "shortname": null,
+                  "value": "ID"
+                },
+                {
+                  "help": "Host collection name to search by",
+                  "name": "name",
+                  "shortname": null,
+                  "value": "NAME"
+                },
+                {
+                  "help": "Organization name to search by",
+                  "name": "organization",
+                  "shortname": null,
+                  "value": "ORGANIZATION_NAME"
+                },
+                {
+                  "help": "organization ID",
+                  "name": "organization-id",
+                  "shortname": null,
+                  "value": "ORGANIZATION_ID"
+                },
+                {
+                  "help": "Organization label to search by",
+                  "name": "organization-label",
+                  "shortname": null,
+                  "value": "ORGANIZATION_LABEL"
+                },
+                {
+                  "help": "comma-separated list of packages to install Comma separated list of values.",
+                  "name": "packages",
+                  "shortname": null,
+                  "value": "PACKAGES"
+                },
+                {
+                  "help": "print help",
+                  "name": "help",
+                  "shortname": "h",
+                  "value": null
+                }
+              ],
+              "subcommands": []
+            }
+          ]
+        },
+        {
+          "description": "Manipulate package-groups for a host collection",
+          "name": "package-group",
+          "options": [
+            {
+              "help": "print help",
+              "name": "help",
+              "shortname": "h",
+              "value": null
+            }
+          ],
+          "subcommands": [
+            {
+              "description": "Install package-groups on content hosts contained within a host collection",
+              "name": "install",
+              "options": [
+                {
+                  "help": "Id of the host collection",
+                  "name": "id",
+                  "shortname": null,
+                  "value": "ID"
+                },
+                {
+                  "help": "Host collection name to search by",
+                  "name": "name",
+                  "shortname": null,
+                  "value": "NAME"
+                },
+                {
+                  "help": "Organization name to search by",
+                  "name": "organization",
+                  "shortname": null,
+                  "value": "ORGANIZATION_NAME"
+                },
+                {
+                  "help": "organization ID",
+                  "name": "organization-id",
+                  "shortname": null,
+                  "value": "ORGANIZATION_ID"
+                },
+                {
+                  "help": "Organization label to search by",
+                  "name": "organization-label",
+                  "shortname": null,
+                  "value": "ORGANIZATION_LABEL"
+                },
+                {
+                  "help": "PACKAGE-GROUPS         comma-separated list of package-groups to install Comma separated list of values.",
+                  "name": "package-groups",
+                  "shortname": null,
+                  "value": null
+                },
+                {
+                  "help": "print help",
+                  "name": "help",
+                  "shortname": "h",
+                  "value": null
+                }
+              ],
+              "subcommands": []
+            },
+            {
+              "description": "Remove package-groups on content hosts contained within a host collection",
+              "name": "remove",
+              "options": [
+                {
+                  "help": "Id of the host collection",
+                  "name": "id",
+                  "shortname": null,
+                  "value": "ID"
+                },
+                {
+                  "help": "Host collection name to search by",
+                  "name": "name",
+                  "shortname": null,
+                  "value": "NAME"
+                },
+                {
+                  "help": "Organization name to search by",
+                  "name": "organization",
+                  "shortname": null,
+                  "value": "ORGANIZATION_NAME"
+                },
+                {
+                  "help": "organization ID",
+                  "name": "organization-id",
+                  "shortname": null,
+                  "value": "ORGANIZATION_ID"
+                },
+                {
+                  "help": "Organization label to search by",
+                  "name": "organization-label",
+                  "shortname": null,
+                  "value": "ORGANIZATION_LABEL"
+                },
+                {
+                  "help": "PACKAGE-GROUPS         comma-separated list of package-groups to install Comma separated list of values.",
+                  "name": "package-groups",
+                  "shortname": null,
+                  "value": null
+                },
+                {
+                  "help": "print help",
+                  "name": "help",
+                  "shortname": "h",
+                  "value": null
+                }
+              ],
+              "subcommands": []
+            },
+            {
+              "description": "Update package-groups on content hosts contained within a host collection",
+              "name": "update",
+              "options": [
+                {
+                  "help": "Id of the host collection",
+                  "name": "id",
+                  "shortname": null,
+                  "value": "ID"
+                },
+                {
+                  "help": "Host collection name to search by",
+                  "name": "name",
+                  "shortname": null,
+                  "value": "NAME"
+                },
+                {
+                  "help": "Organization name to search by",
+                  "name": "organization",
+                  "shortname": null,
+                  "value": "ORGANIZATION_NAME"
+                },
+                {
+                  "help": "organization ID",
+                  "name": "organization-id",
+                  "shortname": null,
+                  "value": "ORGANIZATION_ID"
+                },
+                {
+                  "help": "Organization label to search by",
+                  "name": "organization-label",
+                  "shortname": null,
+                  "value": "ORGANIZATION_LABEL"
+                },
+                {
+                  "help": "PACKAGE-GROUPS         comma-separated list of package-groups to install Comma separated list of values.",
+                  "name": "package-groups",
+                  "shortname": null,
+                  "value": null
+                },
+                {
+                  "help": "print help",
+                  "name": "help",
+                  "shortname": "h",
+                  "value": null
+                }
+              ],
+              "subcommands": []
+            }
+          ]
+        },
+        {
+          "description": "Remove content hosts from the host collection",
+          "name": "remove-content-host",
+          "options": [
+            {
+              "help": "Array of content host ids Comma separated list of values.",
+              "name": "content-host-ids",
+              "shortname": null,
+              "value": "CONTENT_HOST_IDS"
+            },
+            {
+              "help": "Id of the host collection",
+              "name": "id",
+              "shortname": null,
+              "value": "ID"
+            },
+            {
+              "help": "Host collection name to search by",
+              "name": "name",
+              "shortname": null,
+              "value": "NAME"
+            },
+            {
+              "help": "Organization name to search by",
+              "name": "organization",
+              "shortname": null,
+              "value": "ORGANIZATION_NAME"
+            },
+            {
+              "help": "organization ID",
+              "name": "organization-id",
+              "shortname": null,
+              "value": "ORGANIZATION_ID"
+            },
+            {
+              "help": "Organization label to search by",
+              "name": "organization-label",
+              "shortname": null,
+              "value": "ORGANIZATION_LABEL"
+            },
+            {
+              "help": "Comma separated list of values.",
+              "name": "systems",
+              "shortname": null,
+              "value": "CONTENT_HOST_NAMES"
+            },
+            {
+              "help": "print help",
+              "name": "help",
+              "shortname": "h",
+              "value": null
+            }
+          ],
+          "subcommands": []
+        },
+        {
+          "description": "Update a host collection",
+          "name": "update",
+          "options": [
+            {
+              "help": "List of content host uuids to be in the host collection Comma separated list of values.",
+              "name": "content-host-ids",
+              "shortname": null,
+              "value": "CONTENT_HOST_IDS"
+            },
+            {
+              "help": "",
+              "name": "description",
+              "shortname": null,
+              "value": "DESCRIPTION"
+            },
+            {
+              "help": "Array of content host ids to replace the content hosts in host collection Comma separated list of values.",
+              "name": "host-collection-ids",
+              "shortname": null,
+              "value": "HOST_COLLECTION_IDS"
+            },
+            {
+              "help": "Id of the host collection",
+              "name": "id",
+              "shortname": null,
+              "value": "ID"
+            },
+            {
+              "help": "Maximum number of content hosts in the host collection",
+              "name": "max-content-hosts",
+              "shortname": null,
+              "value": "MAX_CONTENT_HOSTS"
+            },
+            {
+              "help": "Host collection name to search by",
+              "name": "name",
+              "shortname": null,
+              "value": "NAME"
+            },
+            {
+              "help": "Host Collection name",
+              "name": "new-name",
+              "shortname": null,
+              "value": "NEW_NAME"
+            },
+            {
+              "help": "Organization name to search by",
+              "name": "organization",
+              "shortname": null,
+              "value": "ORGANIZATION_NAME"
+            },
+            {
+              "help": "organization ID",
+              "name": "organization-id",
+              "shortname": null,
+              "value": "ORGANIZATION_ID"
+            },
+            {
+              "help": "Organization label to search by",
+              "name": "organization-label",
+              "shortname": null,
+              "value": "ORGANIZATION_LABEL"
+            },
+            {
+              "help": "Comma separated list of values.",
+              "name": "systems",
+              "shortname": null,
+              "value": "CONTENT_HOST_NAMES"
+            },
+            {
+              "help": "Whether or not the host collection may have unlimited content hosts One of true/false, yes/no, 1/0.",
+              "name": "unlimited-content-hosts",
+              "shortname": null,
+              "value": "UNLIMITED_CONTENT_HOSTS"
+            },
+            {
+              "help": "print help",
+              "name": "help",
+              "shortname": "h",
+              "value": null
+            }
+          ],
+          "subcommands": []
+        }
+      ]
+    },
+    {
+      "description": "Manipulate hostgroups.",
+      "name": "hostgroup",
+      "options": [
+        {
+          "help": "print help",
+          "name": "help",
+          "shortname": "h",
+          "value": null
+        }
+      ],
+      "subcommands": [
+        {
+          "description": "Create a host group",
+          "name": "create",
+          "options": [
+            {
+              "help": "Architecture name",
+              "name": "architecture",
+              "shortname": null,
+              "value": "ARCHITECTURE_NAME"
+            },
+            {
+              "help": "",
+              "name": "architecture-id",
+              "shortname": null,
+              "value": "ARCHITECTURE_ID"
+            },
+            {
+              "help": "",
+              "name": "content-source-id",
+              "shortname": null,
+              "value": "CONTENT_SOURCE_ID"
+            },
+            {
+              "help": "Name to search by",
+              "name": "content-view",
+              "shortname": null,
+              "value": "CONTENT_VIEW_NAME"
+            },
+            {
+              "help": "content view numeric identifier",
+              "name": "content-view-id",
+              "shortname": null,
+              "value": "CONTENT_VIEW_ID"
+            },
+            {
+              "help": "Domain name",
+              "name": "domain",
+              "shortname": null,
+              "value": "DOMAIN_NAME"
+            },
+            {
+              "help": "Numerical ID or domain name",
+              "name": "domain-id",
+              "shortname": null,
+              "value": "DOMAIN_ID"
+            },
+            {
+              "help": "Environment name",
+              "name": "environment",
+              "shortname": null,
+              "value": "ENVIRONMENT_NAME"
+            },
+            {
+              "help": "",
+              "name": "environment-id",
+              "shortname": null,
+              "value": "ENVIRONMENT_ID"
+            },
+            {
+              "help": "Name to search by",
+              "name": "lifecycle-environment",
+              "shortname": null,
+              "value": "LIFECYCLE_ENVIRONMENT_NAME"
+            },
+            {
+              "help": "ID of the environment",
+              "name": "lifecycle-environment-id",
+              "shortname": null,
+              "value": "LIFECYCLE_ENVIRONMENT_ID"
+            },
+            {
+              "help": "REPLACE locations with given ids Comma separated list of values.",
+              "name": "location-ids",
+              "shortname": null,
+              "value": "LOCATION_IDS"
+            },
+            {
+              "help": "Comma separated list of values.",
+              "name": "locations",
+              "shortname": null,
+              "value": "LOCATION_NAMES"
+            },
+            {
+              "help": "Medium name",
+              "name": "medium",
+              "shortname": null,
+              "value": "MEDIUM_NAME"
+            },
+            {
+              "help": "",
+              "name": "medium-id",
+              "shortname": null,
+              "value": "MEDIUM_ID"
+            },
+            {
+              "help": "",
+              "name": "name",
+              "shortname": null,
+              "value": "NAME"
+            },
+            {
+              "help": "Operating system title",
+              "name": "operatingsystem",
+              "shortname": null,
+              "value": "OPERATINGSYSTEM_TITLE"
+            },
+            {
+              "help": "",
+              "name": "operatingsystem-id",
+              "shortname": null,
+              "value": "OPERATINGSYSTEM_ID"
+            },
+            {
+              "help": "REPLACE organizations with given ids. Comma separated list of values.",
+              "name": "organization-ids",
+              "shortname": null,
+              "value": "ORGANIZATION_IDS"
+            },
+            {
+              "help": "Comma separated list of values.",
+              "name": "organizations",
+              "shortname": null,
+              "value": "ORGANIZATION_NAMES"
+            },
+            {
+              "help": "Name of parent hostgroup",
+              "name": "parent",
+              "shortname": null,
+              "value": "PARENT_NAME"
+            },
+            {
+              "help": "",
+              "name": "parent-id",
+              "shortname": null,
+              "value": "PARENT_ID"
+            },
+            {
+              "help": "Partition table name",
+              "name": "partition-table",
+              "shortname": null,
+              "value": "PARTITION_TABLE_NAME"
+            },
+            {
+              "help": "",
+              "name": "partition-table-id",
+              "shortname": null,
+              "value": "PARTITION_TABLE_ID"
+            },
+            {
+              "help": "Name of puppet CA proxy",
+              "name": "puppet-ca-proxy",
+              "shortname": null,
+              "value": "PUPPET_CA_PROXY_NAME"
+            },
+            {
+              "help": "",
+              "name": "puppet-ca-proxy-id",
+              "shortname": null,
+              "value": "PUPPET_CA_PROXY_ID"
+            },
+            {
+              "help": "List of puppetclass ids Comma separated list of values.",
+              "name": "puppet-class-ids",
+              "shortname": null,
+              "value": "PUPPETCLASS_IDS"
+            },
+            {
+              "help": "Comma separated list of values.",
+              "name": "puppet-classes",
+              "shortname": null,
+              "value": "PUPPET_CLASS_NAMES"
+            },
+            {
+              "help": "Name of puppet proxy",
+              "name": "puppet-proxy",
+              "shortname": null,
+              "value": "PUPPET_PROXY_NAME"
+            },
+            {
+              "help": "",
+              "name": "puppet-proxy-id",
+              "shortname": null,
+              "value": "PUPPET_PROXY_ID"
+            },
+            {
+              "help": "Name to search by",
+              "name": "realm",
+              "shortname": null,
+              "value": "REALM_NAME"
+            },
+            {
+              "help": "Numerical ID or realm name",
+              "name": "realm-id",
+              "shortname": null,
+              "value": "REALM_ID"
+            },
+            {
+              "help": "Subnet name",
+              "name": "subnet",
+              "shortname": null,
+              "value": "SUBNET_NAME"
+            },
+            {
+              "help": "",
+              "name": "subnet-id",
+              "shortname": null,
+              "value": "SUBNET_ID"
+            },
+            {
+              "help": "print help",
+              "name": "help",
+              "shortname": "h",
+              "value": null
+            }
+          ],
+          "subcommands": []
+        },
+        {
+          "description": "Delete a host group",
+          "name": "delete",
+          "options": [
+            {
+              "help": "",
+              "name": "id",
+              "shortname": null,
+              "value": "ID"
+            },
+            {
+              "help": "Hostgroup name",
+              "name": "name",
+              "shortname": null,
+              "value": "NAME"
+            },
+            {
+              "help": "print help",
+              "name": "help",
+              "shortname": "h",
+              "value": null
+            }
+          ],
+          "subcommands": []
+        },
+        {
+          "description": "Delete parameter for a hostgroup.",
+          "name": "delete-parameter",
+          "options": [
+            {
+              "help": "Hostgroup name",
+              "name": "hostgroup",
+              "shortname": null,
+              "value": "HOSTGROUP_NAME"
+            },
+            {
+              "help": "",
+              "name": "hostgroup-id",
+              "shortname": null,
+              "value": "HOSTGROUP_ID"
+            },
+            {
+              "help": "parameter name",
+              "name": "name",
+              "shortname": null,
+              "value": "NAME"
+            },
+            {
+              "help": "print help",
+              "name": "help",
+              "shortname": "h",
+              "value": null
+            }
+          ],
+          "subcommands": []
+        },
+        {
+          "description": "Show a host group",
+          "name": "info",
+          "options": [
+            {
+              "help": "",
+              "name": "id",
+              "shortname": null,
+              "value": "ID"
+            },
+            {
+              "help": "Hostgroup name",
+              "name": "name",
+              "shortname": null,
+              "value": "NAME"
+            },
+            {
+              "help": "print help",
+              "name": "help",
+              "shortname": "h",
+              "value": null
+            }
+          ],
+          "subcommands": []
+        },
+        {
+          "description": "List all host groups",
+          "name": "list",
+          "options": [
+            {
+              "help": "Location name",
+              "name": "location",
+              "shortname": null,
+              "value": "LOCATION_NAME"
+            },
+            {
+              "help": "",
+              "name": "location-id",
+              "shortname": null,
+              "value": "LOCATION_ID"
+            },
+            {
+              "help": "sort results",
+              "name": "order",
+              "shortname": null,
+              "value": "ORDER"
+            },
+            {
+              "help": "Organization name",
+              "name": "organization",
+              "shortname": null,
+              "value": "ORGANIZATION_NAME"
+            },
+            {
+              "help": "organization ID",
+              "name": "organization-id",
+              "shortname": null,
+              "value": "ORGANIZATION_ID"
+            },
+            {
+              "help": "paginate results",
+              "name": "page",
+              "shortname": null,
+              "value": "PAGE"
+            },
+            {
+              "help": "number of entries per request",
+              "name": "per-page",
+              "shortname": null,
+              "value": "PER_PAGE"
+            },
+            {
+              "help": "Puppet class name",
+              "name": "puppet-class",
+              "shortname": null,
+              "value": "PUPPET_CLASS_NAME"
+            },
+            {
+              "help": "ID of Puppet class",
+              "name": "puppet-class-id",
+              "shortname": null,
+              "value": "PUPPET_CLASS_ID"
+            },
+            {
+              "help": "filter results",
+              "name": "search",
+              "shortname": null,
+              "value": "SEARCH"
+            },
+            {
+              "help": "print help",
+              "name": "help",
+              "shortname": "h",
+              "value": null
+            }
+          ],
+          "subcommands": []
+        },
+        {
+          "description": "List all Puppet classes",
+          "name": "puppet-classes",
+          "options": [
+            {
+              "help": "Hostgroup name",
+              "name": "hostgroup",
+              "shortname": null,
+              "value": "HOSTGROUP_NAME"
+            },
+            {
+              "help": "",
+              "name": "hostgroup-id",
+              "shortname": null,
+              "value": "HOSTGROUP_ID"
+            },
+            {
+              "help": "sort results",
+              "name": "order",
+              "shortname": null,
+              "value": "ORDER"
+            },
+            {
+              "help": "paginate results",
+              "name": "page",
+              "shortname": null,
+              "value": "PAGE"
+            },
+            {
+              "help": "number of entries per request",
+              "name": "per-page",
+              "shortname": null,
+              "value": "PER_PAGE"
+            },
+            {
+              "help": "filter results",
+              "name": "search",
+              "shortname": null,
+              "value": "SEARCH"
+            },
+            {
+              "help": "print help",
+              "name": "help",
+              "shortname": "h",
+              "value": null
+            }
+          ],
+          "subcommands": []
+        },
+        {
+          "description": "List all smart class parameters",
+          "name": "sc-params",
+          "options": [
+            {
+              "help": "Environment name",
+              "name": "environment",
+              "shortname": null,
+              "value": "ENVIRONMENT_NAME"
+            },
+            {
+              "help": "",
+              "name": "environment-id",
+              "shortname": null,
+              "value": "ENVIRONMENT_ID"
+            },
+            {
+              "help": "Host name",
+              "name": "host",
+              "shortname": null,
+              "value": "HOST_NAME"
+            },
+            {
+              "help": "",
+              "name": "host-id",
+              "shortname": null,
+              "value": "HOST_ID"
+            },
+            {
+              "help": "Hostgroup name",
+              "name": "hostgroup",
+              "shortname": null,
+              "value": "HOSTGROUP_NAME"
+            },
+            {
+              "help": "",
+              "name": "hostgroup-id",
+              "shortname": null,
+              "value": "HOSTGROUP_ID"
+            },
+            {
+              "help": "",
+              "name": "id",
+              "shortname": null,
+              "value": "ID"
+            },
+            {
+              "help": "Hostgroup name",
+              "name": "name",
+              "shortname": null,
+              "value": "NAME"
+            },
+            {
+              "help": "sort results",
+              "name": "order",
+              "shortname": null,
+              "value": "ORDER"
+            },
+            {
+              "help": "paginate results",
+              "name": "page",
+              "shortname": null,
+              "value": "PAGE"
+            },
+            {
+              "help": "number of entries per request",
+              "name": "per-page",
+              "shortname": null,
+              "value": "PER_PAGE"
+            },
+            {
+              "help": "Puppet class name",
+              "name": "puppet-class",
+              "shortname": null,
+              "value": "PUPPET_CLASS_NAME"
+            },
+            {
+              "help": "ID of Puppet class",
+              "name": "puppet-class-id",
+              "shortname": null,
+              "value": "PUPPET_CLASS_ID"
+            },
+            {
+              "help": "filter results",
+              "name": "search",
+              "shortname": null,
+              "value": "SEARCH"
+            },
+            {
+              "help": "print help",
+              "name": "help",
+              "shortname": "h",
+              "value": null
+            }
+          ],
+          "subcommands": []
+        },
+        {
+          "description": "Create or update parameter for a hostgroup.",
+          "name": "set-parameter",
+          "options": [
+            {
+              "help": "Hostgroup name",
+              "name": "hostgroup",
+              "shortname": null,
+              "value": "HOSTGROUP_NAME"
+            },
+            {
+              "help": "",
+              "name": "hostgroup-id",
+              "shortname": null,
+              "value": "HOSTGROUP_ID"
+            },
+            {
+              "help": "parameter name",
+              "name": "name",
+              "shortname": null,
+              "value": "NAME"
+            },
+            {
+              "help": "parameter value",
+              "name": "value",
+              "shortname": null,
+              "value": "VALUE"
+            },
+            {
+              "help": "print help",
+              "name": "help",
+              "shortname": "h",
+              "value": null
+            }
+          ],
+          "subcommands": []
+        },
+        {
+          "description": "Update a host group",
+          "name": "update",
+          "options": [
+            {
+              "help": "Architecture name",
+              "name": "architecture",
+              "shortname": null,
+              "value": "ARCHITECTURE_NAME"
+            },
+            {
+              "help": "",
+              "name": "architecture-id",
+              "shortname": null,
+              "value": "ARCHITECTURE_ID"
+            },
+            {
+              "help": "",
+              "name": "content-source-id",
+              "shortname": null,
+              "value": "CONTENT_SOURCE_ID"
+            },
+            {
+              "help": "Name to search by",
+              "name": "content-view",
+              "shortname": null,
+              "value": "CONTENT_VIEW_NAME"
+            },
+            {
+              "help": "content view numeric identifier",
+              "name": "content-view-id",
+              "shortname": null,
+              "value": "CONTENT_VIEW_ID"
+            },
+            {
+              "help": "Domain name",
+              "name": "domain",
+              "shortname": null,
+              "value": "DOMAIN_NAME"
+            },
+            {
+              "help": "Numerical ID or domain name",
+              "name": "domain-id",
+              "shortname": null,
+              "value": "DOMAIN_ID"
+            },
+            {
+              "help": "Environment name",
+              "name": "environment",
+              "shortname": null,
+              "value": "ENVIRONMENT_NAME"
+            },
+            {
+              "help": "",
+              "name": "environment-id",
+              "shortname": null,
+              "value": "ENVIRONMENT_ID"
+            },
+            {
+              "help": "",
+              "name": "id",
+              "shortname": null,
+              "value": "ID"
+            },
+            {
+              "help": "Name to search by",
+              "name": "lifecycle-environment",
+              "shortname": null,
+              "value": "LIFECYCLE_ENVIRONMENT_NAME"
+            },
+            {
+              "help": "ID of the environment",
+              "name": "lifecycle-environment-id",
+              "shortname": null,
+              "value": "LIFECYCLE_ENVIRONMENT_ID"
+            },
+            {
+              "help": "REPLACE locations with given ids Comma separated list of values.",
+              "name": "location-ids",
+              "shortname": null,
+              "value": "LOCATION_IDS"
+            },
+            {
+              "help": "Comma separated list of values.",
+              "name": "locations",
+              "shortname": null,
+              "value": "LOCATION_NAMES"
+            },
+            {
+              "help": "Medium name",
+              "name": "medium",
+              "shortname": null,
+              "value": "MEDIUM_NAME"
+            },
+            {
+              "help": "",
+              "name": "medium-id",
+              "shortname": null,
+              "value": "MEDIUM_ID"
+            },
+            {
+              "help": "Hostgroup name",
+              "name": "name",
+              "shortname": null,
+              "value": "NAME"
+            },
+            {
+              "help": "",
+              "name": "new-name",
+              "shortname": null,
+              "value": "NEW_NAME"
+            },
+            {
+              "help": "Operating system title",
+              "name": "operatingsystem",
+              "shortname": null,
+              "value": "OPERATINGSYSTEM_TITLE"
+            },
+            {
+              "help": "",
+              "name": "operatingsystem-id",
+              "shortname": null,
+              "value": "OPERATINGSYSTEM_ID"
+            },
+            {
+              "help": "REPLACE organizations with given ids. Comma separated list of values.",
+              "name": "organization-ids",
+              "shortname": null,
+              "value": "ORGANIZATION_IDS"
+            },
+            {
+              "help": "Comma separated list of values.",
+              "name": "organizations",
+              "shortname": null,
+              "value": "ORGANIZATION_NAMES"
+            },
+            {
+              "help": "Name of parent hostgroup",
+              "name": "parent",
+              "shortname": null,
+              "value": "PARENT_NAME"
+            },
+            {
+              "help": "",
+              "name": "parent-id",
+              "shortname": null,
+              "value": "PARENT_ID"
+            },
+            {
+              "help": "Partition table name",
+              "name": "partition-table",
+              "shortname": null,
+              "value": "PARTITION_TABLE_NAME"
+            },
+            {
+              "help": "",
+              "name": "partition-table-id",
+              "shortname": null,
+              "value": "PARTITION_TABLE_ID"
+            },
+            {
+              "help": "Name of puppet CA proxy",
+              "name": "puppet-ca-proxy",
+              "shortname": null,
+              "value": "PUPPET_CA_PROXY_NAME"
+            },
+            {
+              "help": "",
+              "name": "puppet-ca-proxy-id",
+              "shortname": null,
+              "value": "PUPPET_CA_PROXY_ID"
+            },
+            {
+              "help": "List of puppetclass ids Comma separated list of values.",
+              "name": "puppet-class-ids",
+              "shortname": null,
+              "value": "PUPPETCLASS_IDS"
+            },
+            {
+              "help": "Comma separated list of values.",
+              "name": "puppet-classes",
+              "shortname": null,
+              "value": "PUPPET_CLASS_NAMES"
+            },
+            {
+              "help": "Name of puppet proxy",
+              "name": "puppet-proxy",
+              "shortname": null,
+              "value": "PUPPET_PROXY_NAME"
+            },
+            {
+              "help": "",
+              "name": "puppet-proxy-id",
+              "shortname": null,
+              "value": "PUPPET_PROXY_ID"
+            },
+            {
+              "help": "Name to search by",
+              "name": "realm",
+              "shortname": null,
+              "value": "REALM_NAME"
+            },
+            {
+              "help": "Numerical ID or realm name",
+              "name": "realm-id",
+              "shortname": null,
+              "value": "REALM_ID"
+            },
+            {
+              "help": "Subnet name",
+              "name": "subnet",
+              "shortname": null,
+              "value": "SUBNET_NAME"
+            },
+            {
+              "help": "",
+              "name": "subnet-id",
+              "shortname": null,
+              "value": "SUBNET_ID"
+            },
+            {
+              "help": "print help",
+              "name": "help",
+              "shortname": "h",
+              "value": null
+            }
+          ],
+          "subcommands": []
+        }
+      ]
+    },
+    {
+      "description": "Import data exported from a Red Hat Satellite 5 instance",
+      "name": "import",
+      "options": [
+        {
+          "help": "print help",
+          "name": "help",
+          "shortname": "h",
+          "value": null
+        }
+      ],
+      "subcommands": [
+        {
+          "description": "Import Activation Keys (from spacewalk-report activation-keys).",
+          "name": "activation-key",
+          "options": [
+            {
+              "help": "CSV file with data to be imported",
+              "name": "csv-file",
+              "shortname": null,
+              "value": "FILE_NAME"
+            },
+            {
+              "help": "Turn on debugging-information Default: false",
+              "name": "debug",
+              "shortname": null,
+              "value": null
+            },
+            {
+              "help": "Delete entities from CSV file Default: false",
+              "name": "delete",
+              "shortname": null,
+              "value": null
+            },
+            {
+              "help": "Where output is logged to Default: \"/root/import.log\"",
+              "name": "logfile",
+              "shortname": null,
+              "value": "LOGFILE"
+            },
+            {
+              "help": "Be silent - no output to STDOUT Default: false",
+              "name": "quiet",
+              "shortname": null,
+              "value": null
+            },
+            {
+              "help": "Recover strategy, can be: rename (default), map, none Default: :rename",
+              "name": "recover",
+              "shortname": null,
+              "value": "RECOVER"
+            },
+            {
+              "help": "Be noisy - everything goes to STDOUT and to a logfile Default: false",
+              "name": "verbose",
+              "shortname": null,
+              "value": null
+            },
+            {
+              "help": "print help",
+              "name": "help",
+              "shortname": "h",
+              "value": null
+            }
+          ],
+          "subcommands": []
+        },
+        {
+          "description": "Load ALL data from a specified directory that is in spacewalk-export format.",
+          "name": "all",
+          "options": [
+            {
+              "help": "Turn on debugging-information Default: false",
+              "name": "debug",
+              "shortname": null,
+              "value": null
+            },
+            {
+              "help": "Delete entities instead of importing them Default: false",
+              "name": "delete",
+              "shortname": null,
+              "value": null
+            },
+            {
+              "help": "stargate-export directory Default: \"/tmp/exports\"",
+              "name": "directory",
+              "shortname": null,
+              "value": "DIR_PATH"
+            },
+            {
+              "help": "Show what we would have done, if we'd been allowed Default: false",
+              "name": "dry-run",
+              "shortname": null,
+              "value": null
+            },
+            {
+              "help": "entity[,entity...] Import specific entities Default: \"all\"",
+              "name": "entities",
+              "shortname": null,
+              "value": null
+            },
+            {
+              "help": "Import all organizations into one specified by id",
+              "name": "into-org-id",
+              "shortname": null,
+              "value": "ORG_ID"
+            },
+            {
+              "help": "List entities we understand Default: false",
+              "name": "list-entities",
+              "shortname": null,
+              "value": null
+            },
+            {
+              "help": "Where output is logged to Default: \"/root/import.log\"",
+              "name": "logfile",
+              "shortname": null,
+              "value": "LOGFILE"
+            },
+            {
+              "help": "Mapping of Satellite-5 config-file-macros to puppet facts",
+              "name": "macro_mapping",
+              "shortname": null,
+              "value": "FILE"
+            },
+            {
+              "help": "Directory holding manifests",
+              "name": "manifest-directory",
+              "shortname": null,
+              "value": "DIR_PATH"
+            },
+            {
+              "help": "Merge pre-created users (except admin) Default: false",
+              "name": "merge-users",
+              "shortname": null,
+              "value": null
+            },
+            {
+              "help": "Wait for async tasks in foreground Default: false",
+              "name": "no-async",
+              "shortname": null,
+              "value": null
+            },
+            {
+              "help": "Be silent - no output to STDOUT Default: false",
+              "name": "quiet",
+              "shortname": null,
+              "value": null
+            },
+            {
+              "help": "Synchronize imported repositories Default: false",
+              "name": "synchronize",
+              "shortname": null,
+              "value": null
+            },
+            {
+              "help": "Be noisy - everything goes to STDOUT and to a logfile Default: false",
+              "name": "verbose",
+              "shortname": null,
+              "value": null
+            },
+            {
+              "help": "Wait for repository synchronization to finish Default: false",
+              "name": "wait",
+              "shortname": null,
+              "value": null
+            },
+            {
+              "help": "print help",
+              "name": "help",
+              "shortname": "h",
+              "value": null
+            }
+          ],
+          "subcommands": []
+        },
+        {
+          "description": "Create puppet-modules from Configuration Channel content (from spacewalk-report config-files-latest).",
+          "name": "config-file",
+          "options": [
+            {
+              "help": "Answers to the puppet-generate-module interview questions Default: \"/etc/hammer/cli.modules.d/import/interview_answers.yml\"",
+              "name": "answers-file",
+              "shortname": null,
+              "value": "FILE_NAME"
+            },
+            {
+              "help": "CSV file with data to be imported",
+              "name": "csv-file",
+              "shortname": null,
+              "value": "FILE_NAME"
+            },
+            {
+              "help": "Turn on debugging-information Default: false",
+              "name": "debug",
+              "shortname": null,
+              "value": null
+            },
+            {
+              "help": "Delete entities from CSV file Default: false",
+              "name": "delete",
+              "shortname": null,
+              "value": null
+            },
+            {
+              "help": "Create and fill puppet-modules, but DO NOT upload anything Default: false",
+              "name": "generate-only",
+              "shortname": null,
+              "value": null
+            },
+            {
+              "help": "Where output is logged to Default: \"/root/import.log\"",
+              "name": "logfile",
+              "shortname": null,
+              "value": "LOGFILE"
+            },
+            {
+              "help": "Mapping of Satellite-5 config-file-macros to puppet facts Default: \"/etc/hammer/cli.modules.d/import/config_macros.yml\"",
+              "name": "macro-mapping",
+              "shortname": null,
+              "value": "FILE_NAME"
+            },
+            {
+              "help": "Be silent - no output to STDOUT Default: false",
+              "name": "quiet",
+              "shortname": null,
+              "value": null
+            },
+            {
+              "help": "Recover strategy, can be: rename (default), map, none Default: :rename",
+              "name": "recover",
+              "shortname": null,
+              "value": "RECOVER"
+            },
+            {
+              "help": "Be noisy - everything goes to STDOUT and to a logfile Default: false",
+              "name": "verbose",
+              "shortname": null,
+              "value": null
+            },
+            {
+              "help": "Location for building puppet modules (will be created if it doesn't exist Default: \"/root/puppet_work_dir\"",
+              "name": "working-directory",
+              "shortname": null,
+              "value": "FILE_NAME"
+            },
+            {
+              "help": "print help",
+              "name": "help",
+              "shortname": "h",
+              "value": null
+            }
+          ],
+          "subcommands": []
+        },
+        {
+          "description": "Import Content Hosts (from spacewalk-report system-profiles).",
+          "name": "content-host",
+          "options": [
+            {
+              "help": "CSV file with data to be imported",
+              "name": "csv-file",
+              "shortname": null,
+              "value": "FILE_NAME"
+            },
+            {
+              "help": "Turn on debugging-information Default: false",
+              "name": "debug",
+              "shortname": null,
+              "value": null
+            },
+            {
+              "help": "Delete entities from CSV file Default: false",
+              "name": "delete",
+              "shortname": null,
+              "value": null
+            },
+            {
+              "help": "Directory to export rpmbuild structure",
+              "name": "export-directory",
+              "shortname": null,
+              "value": "DIR_PATH"
+            },
+            {
+              "help": "Where output is logged to Default: \"/root/import.log\"",
+              "name": "logfile",
+              "shortname": null,
+              "value": "LOGFILE"
+            },
+            {
+              "help": "Be silent - no output to STDOUT Default: false",
+              "name": "quiet",
+              "shortname": null,
+              "value": null
+            },
+            {
+              "help": "Recover strategy, can be: rename (default), map, none Default: :rename",
+              "name": "recover",
+              "shortname": null,
+              "value": "RECOVER"
+            },
+            {
+              "help": "Be noisy - everything goes to STDOUT and to a logfile Default: false",
+              "name": "verbose",
+              "shortname": null,
+              "value": null
+            },
+            {
+              "help": "print help",
+              "name": "help",
+              "shortname": "h",
+              "value": null
+            }
+          ],
+          "subcommands": []
+        },
+        {
+          "description": "Create Content Views based on local/cloned Channels (from spacewalk-export-channels).",
+          "name": "content-view",
+          "options": [
+            {
+              "help": "CSV file with data to be imported",
+              "name": "csv-file",
+              "shortname": null,
+              "value": "FILE_NAME"
+            },
+            {
+              "help": "Turn on debugging-information Default: false",
+              "name": "debug",
+              "shortname": null,
+              "value": null
+            },
+            {
+              "help": "Delete entities from CSV file Default: false",
+              "name": "delete",
+              "shortname": null,
+              "value": null
+            },
+            {
+              "help": "Export directory",
+              "name": "dir",
+              "shortname": null,
+              "value": "DIR"
+            },
+            {
+              "help": "Filter content-views for package names present in Sat5 channel Default: false",
+              "name": "filter",
+              "shortname": null,
+              "value": null
+            },
+            {
+              "help": "Where output is logged to Default: \"/root/import.log\"",
+              "name": "logfile",
+              "shortname": null,
+              "value": "LOGFILE"
+            },
+            {
+              "help": "Wait for async tasks in foreground Default: false",
+              "name": "no-async",
+              "shortname": null,
+              "value": null
+            },
+            {
+              "help": "Be silent - no output to STDOUT Default: false",
+              "name": "quiet",
+              "shortname": null,
+              "value": null
+            },
+            {
+              "help": "Recover strategy, can be: rename (default), map, none Default: :rename",
+              "name": "recover",
+              "shortname": null,
+              "value": "RECOVER"
+            },
+            {
+              "help": "Synchronize imported repositories Default: false",
+              "name": "synchronize",
+              "shortname": null,
+              "value": null
+            },
+            {
+              "help": "Be noisy - everything goes to STDOUT and to a logfile Default: false",
+              "name": "verbose",
+              "shortname": null,
+              "value": null
+            },
+            {
+              "help": "Wait for repository synchronization to finish Default: false",
+              "name": "wait",
+              "shortname": null,
+              "value": null
+            },
+            {
+              "help": "print help",
+              "name": "help",
+              "shortname": "h",
+              "value": null
+            }
+          ],
+          "subcommands": []
+        },
+        {
+          "description": "Import Host Collections (from spacewalk-report system-groups).",
+          "name": "host-collection",
+          "options": [
+            {
+              "help": "CSV file with data to be imported",
+              "name": "csv-file",
+              "shortname": null,
+              "value": "FILE_NAME"
+            },
+            {
+              "help": "Turn on debugging-information Default: false",
+              "name": "debug",
+              "shortname": null,
+              "value": null
+            },
+            {
+              "help": "Delete entities from CSV file Default: false",
+              "name": "delete",
+              "shortname": null,
+              "value": null
+            },
+            {
+              "help": "Where output is logged to Default: \"/root/import.log\"",
+              "name": "logfile",
+              "shortname": null,
+              "value": "LOGFILE"
+            },
+            {
+              "help": "Be silent - no output to STDOUT Default: false",
+              "name": "quiet",
+              "shortname": null,
+              "value": null
+            },
+            {
+              "help": "Recover strategy, can be: rename (default), map, none Default: :rename",
+              "name": "recover",
+              "shortname": null,
+              "value": "RECOVER"
+            },
+            {
+              "help": "Be noisy - everything goes to STDOUT and to a logfile Default: false",
+              "name": "verbose",
+              "shortname": null,
+              "value": null
+            },
+            {
+              "help": "print help",
+              "name": "help",
+              "shortname": "h",
+              "value": null
+            }
+          ],
+          "subcommands": []
+        },
+        {
+          "description": "Import Organizations (from spacewalk-report users).",
+          "name": "organization",
+          "options": [
+            {
+              "help": "CSV file with data to be imported",
+              "name": "csv-file",
+              "shortname": null,
+              "value": "FILE_NAME"
+            },
+            {
+              "help": "Turn on debugging-information Default: false",
+              "name": "debug",
+              "shortname": null,
+              "value": null
+            },
+            {
+              "help": "Delete entities from CSV file Default: false",
+              "name": "delete",
+              "shortname": null,
+              "value": null
+            },
+            {
+              "help": "Import all organizations into one specified by id",
+              "name": "into-org-id",
+              "shortname": null,
+              "value": "ORG_ID"
+            },
+            {
+              "help": "Where output is logged to Default: \"/root/import.log\"",
+              "name": "logfile",
+              "shortname": null,
+              "value": "LOGFILE"
+            },
+            {
+              "help": "Be silent - no output to STDOUT Default: false",
+              "name": "quiet",
+              "shortname": null,
+              "value": null
+            },
+            {
+              "help": "Recover strategy, can be: rename (default), map, none Default: :rename",
+              "name": "recover",
+              "shortname": null,
+              "value": "RECOVER"
+            },
+            {
+              "help": "Upload manifests found at MANIFEST_DIR. Assumes manifest for \"ORG NAME\" will be of the form ORG_NAME.zip",
+              "name": "upload-manifests-from",
+              "shortname": null,
+              "value": "MANIFEST_DIR"
+            },
+            {
+              "help": "Be noisy - everything goes to STDOUT and to a logfile Default: false",
+              "name": "verbose",
+              "shortname": null,
+              "value": null
+            },
+            {
+              "help": "print help",
+              "name": "help",
+              "shortname": "h",
+              "value": null
+            }
+          ],
+          "subcommands": []
+        },
+        {
+          "description": "Import repositories (from spacewalk-report repositories).",
+          "name": "repository",
+          "options": [
+            {
+              "help": "CSV file with data to be imported",
+              "name": "csv-file",
+              "shortname": null,
+              "value": "FILE_NAME"
+            },
+            {
+              "help": "Turn on debugging-information Default: false",
+              "name": "debug",
+              "shortname": null,
+              "value": null
+            },
+            {
+              "help": "Delete entities from CSV file Default: false",
+              "name": "delete",
+              "shortname": null,
+              "value": null
+            },
+            {
+              "help": "Where output is logged to Default: \"/root/import.log\"",
+              "name": "logfile",
+              "shortname": null,
+              "value": "LOGFILE"
+            },
+            {
+              "help": "Wait for async tasks in foreground Default: false",
+              "name": "no-async",
+              "shortname": null,
+              "value": null
+            },
+            {
+              "help": "Be silent - no output to STDOUT Default: false",
+              "name": "quiet",
+              "shortname": null,
+              "value": null
+            },
+            {
+              "help": "Recover strategy, can be: rename (default), map, none Default: :rename",
+              "name": "recover",
+              "shortname": null,
+              "value": "RECOVER"
+            },
+            {
+              "help": "Synchronize imported repositories Default: false",
+              "name": "synchronize",
+              "shortname": null,
+              "value": null
+            },
+            {
+              "help": "Be noisy - everything goes to STDOUT and to a logfile Default: false",
+              "name": "verbose",
+              "shortname": null,
+              "value": null
+            },
+            {
+              "help": "Wait for repository synchronization to finish Default: false",
+              "name": "wait",
+              "shortname": null,
+              "value": null
+            },
+            {
+              "help": "print help",
+              "name": "help",
+              "shortname": "h",
+              "value": null
+            }
+          ],
+          "subcommands": []
+        },
+        {
+          "description": "Enable any Red Hat repositories accessible to any Organization (from spacewalk-report channels).",
+          "name": "repository-enable",
+          "options": [
+            {
+              "help": "CSV file with data to be imported",
+              "name": "csv-file",
+              "shortname": null,
+              "value": "FILE_NAME"
+            },
+            {
+              "help": "Turn on debugging-information Default: false",
+              "name": "debug",
+              "shortname": null,
+              "value": null
+            },
+            {
+              "help": "Delete entities from CSV file Default: false",
+              "name": "delete",
+              "shortname": null,
+              "value": null
+            },
+            {
+              "help": "Only show the repositories that would be enabled Default: false",
+              "name": "dry-run",
+              "shortname": null,
+              "value": null
+            },
+            {
+              "help": "Where output is logged to Default: \"/root/import.log\"",
+              "name": "logfile",
+              "shortname": null,
+              "value": "LOGFILE"
+            },
+            {
+              "help": "Wait for async tasks in foreground Default: false",
+              "name": "no-async",
+              "shortname": null,
+              "value": null
+            },
+            {
+              "help": "Be silent - no output to STDOUT Default: false",
+              "name": "quiet",
+              "shortname": null,
+              "value": null
+            },
+            {
+              "help": "Recover strategy, can be: rename (default), map, none Default: :rename",
+              "name": "recover",
+              "shortname": null,
+              "value": "RECOVER"
+            },
+            {
+              "help": "JSON file mapping channel-labels to repository information Default: \"/usr/share/gems/gems/hammer_cli_import-0.10.6.3/channel_data_pretty.json\"",
+              "name": "repository-map",
+              "shortname": null,
+              "value": "FILE_NAME"
+            },
+            {
+              "help": "Synchronize imported repositories Default: false",
+              "name": "synchronize",
+              "shortname": null,
+              "value": null
+            },
+            {
+              "help": "Be noisy - everything goes to STDOUT and to a logfile Default: false",
+              "name": "verbose",
+              "shortname": null,
+              "value": null
+            },
+            {
+              "help": "Wait for repository synchronization to finish Default: false",
+              "name": "wait",
+              "shortname": null,
+              "value": null
+            },
+            {
+              "help": "print help",
+              "name": "help",
+              "shortname": "h",
+              "value": null
+            }
+          ],
+          "subcommands": []
+        },
+        {
+          "description": "Import template snippets (from spacewalk-report kickstart-scripts).",
+          "name": "template-snippet",
+          "options": [
+            {
+              "help": "CSV file with data to be imported",
+              "name": "csv-file",
+              "shortname": null,
+              "value": "FILE_NAME"
+            },
+            {
+              "help": "Turn on debugging-information Default: false",
+              "name": "debug",
+              "shortname": null,
+              "value": null
+            },
+            {
+              "help": "Delete entities from CSV file Default: false",
+              "name": "delete",
+              "shortname": null,
+              "value": null
+            },
+            {
+              "help": "Where output is logged to Default: \"/root/import.log\"",
+              "name": "logfile",
+              "shortname": null,
+              "value": "LOGFILE"
+            },
+            {
+              "help": "Be silent - no output to STDOUT Default: false",
+              "name": "quiet",
+              "shortname": null,
+              "value": null
+            },
+            {
+              "help": "Recover strategy, can be: rename (default), map, none Default: :rename",
+              "name": "recover",
+              "shortname": null,
+              "value": "RECOVER"
+            },
+            {
+              "help": "Be noisy - everything goes to STDOUT and to a logfile Default: false",
+              "name": "verbose",
+              "shortname": null,
+              "value": null
+            },
+            {
+              "help": "print help",
+              "name": "help",
+              "shortname": "h",
+              "value": null
+            }
+          ],
+          "subcommands": []
+        },
+        {
+          "description": "Import Users (from spacewalk-report users).",
+          "name": "user",
+          "options": [
+            {
+              "help": "CSV file with data to be imported",
+              "name": "csv-file",
+              "shortname": null,
+              "value": "FILE_NAME"
+            },
+            {
+              "help": "Turn on debugging-information Default: false",
+              "name": "debug",
+              "shortname": null,
+              "value": null
+            },
+            {
+              "help": "Delete entities from CSV file Default: false",
+              "name": "delete",
+              "shortname": null,
+              "value": null
+            },
+            {
+              "help": "Where output is logged to Default: \"/root/import.log\"",
+              "name": "logfile",
+              "shortname": null,
+              "value": "LOGFILE"
+            },
+            {
+              "help": "Merge pre-created users (except admin) Default: false",
+              "name": "merge-users",
+              "shortname": null,
+              "value": null
+            },
+            {
+              "help": "Output for new passwords",
+              "name": "new-passwords",
+              "shortname": null,
+              "value": "FILE_NAME"
+            },
+            {
+              "help": "Be silent - no output to STDOUT Default: false",
+              "name": "quiet",
+              "shortname": null,
+              "value": null
+            },
+            {
+              "help": "Recover strategy, can be: rename (default), map, none Default: :rename",
+              "name": "recover",
+              "shortname": null,
+              "value": "RECOVER"
+            },
+            {
+              "help": "Mapping of Satellite-5 role names to Satellite-6 defined roles Default: \"/etc/hammer/cli.modules.d/import/role_map.yml\"",
+              "name": "role-mapping",
+              "shortname": null,
+              "value": "FILE_NAME"
+            },
+            {
+              "help": "Be noisy - everything goes to STDOUT and to a logfile Default: false",
+              "name": "verbose",
+              "shortname": null,
+              "value": null
+            },
+            {
+              "help": "print help",
+              "name": "help",
+              "shortname": "h",
+              "value": null
+            }
+          ],
+          "subcommands": []
+        }
+      ]
+    },
+    {
+      "description": "Manipulate lifecycle_environments on the server",
+      "name": "lifecycle-environment",
+      "options": [
+        {
+          "help": "print help",
+          "name": "help",
+          "shortname": "h",
+          "value": null
+        }
+      ],
+      "subcommands": [
+        {
+          "description": "Create an environment",
+          "name": "create",
+          "options": [
+            {
+              "help": "description of the environment",
+              "name": "description",
+              "shortname": null,
+              "value": "DESCRIPTION"
+            },
+            {
+              "help": "label of the environment",
+              "name": "label",
+              "shortname": null,
+              "value": "LABEL"
+            },
+            {
+              "help": "name of the environment",
+              "name": "name",
+              "shortname": null,
+              "value": "NAME"
+            },
+            {
+              "help": "Organization name to search by",
+              "name": "organization",
+              "shortname": null,
+              "value": "ORGANIZATION_NAME"
+            },
+            {
+              "help": "organization ID",
+              "name": "organization-id",
+              "shortname": null,
+              "value": "ORGANIZATION_ID"
+            },
+            {
+              "help": "Organization label to search by",
+              "name": "organization-label",
+              "shortname": null,
+              "value": "ORGANIZATION_LABEL"
+            },
+            {
+              "help": "ID of an environment that is prior to the new environment in the chain. It has to be either the ID of Library or the ID of an environment at the end of a chain.",
+              "name": "prior",
+              "shortname": null,
+              "value": "PRIOR"
+            },
+            {
+              "help": "print help",
+              "name": "help",
+              "shortname": "h",
+              "value": null
+            }
+          ],
+          "subcommands": []
+        },
+        {
+          "description": "Destroy an environment",
+          "name": "delete",
+          "options": [
+            {
+              "help": "ID of the environment",
+              "name": "id",
+              "shortname": null,
+              "value": "ID"
+            },
+            {
+              "help": "Lifecycle environment name to search by",
+              "name": "name",
+              "shortname": null,
+              "value": "NAME"
+            },
+            {
+              "help": "Organization name to search by",
+              "name": "organization",
+              "shortname": null,
+              "value": "ORGANIZATION_NAME"
+            },
+            {
+              "help": "organization ID",
+              "name": "organization-id",
+              "shortname": null,
+              "value": "ORGANIZATION_ID"
+            },
+            {
+              "help": "Organization label to search by",
+              "name": "organization-label",
+              "shortname": null,
+              "value": "ORGANIZATION_LABEL"
+            },
+            {
+              "help": "print help",
+              "name": "help",
+              "shortname": "h",
+              "value": null
+            }
+          ],
+          "subcommands": []
+        },
+        {
+          "description": "Show an environment",
+          "name": "info",
+          "options": [
+            {
+              "help": "ID of the environment",
+              "name": "id",
+              "shortname": null,
+              "value": "ID"
+            },
+            {
+              "help": "Lifecycle environment name to search by",
+              "name": "name",
+              "shortname": null,
+              "value": "NAME"
+            },
+            {
+              "help": "Organization name to search by",
+              "name": "organization",
+              "shortname": null,
+              "value": "ORGANIZATION_NAME"
+            },
+            {
+              "help": "organization ID",
+              "name": "organization-id",
+              "shortname": null,
+              "value": "ORGANIZATION_ID"
+            },
+            {
+              "help": "Organization label to search by",
+              "name": "organization-label",
+              "shortname": null,
+              "value": "ORGANIZATION_LABEL"
+            },
+            {
+              "help": "print help",
+              "name": "help",
+              "shortname": "h",
+              "value": null
+            }
+          ],
+          "subcommands": []
+        },
+        {
+          "description": "List environments in an organization",
+          "name": "list",
+          "options": [
+            {
+              "help": "set true if you want to see only library environments",
+              "name": "library",
+              "shortname": null,
+              "value": "LIBRARY"
+            },
+            {
+              "help": "filter only environments containing this name",
+              "name": "name",
+              "shortname": null,
+              "value": "NAME"
+            },
+            {
+              "help": "Organization name to search by",
+              "name": "organization",
+              "shortname": null,
+              "value": "ORGANIZATION_NAME"
+            },
+            {
+              "help": "organization ID",
+              "name": "organization-id",
+              "shortname": null,
+              "value": "ORGANIZATION_ID"
+            },
+            {
+              "help": "Organization label to search by",
+              "name": "organization-label",
+              "shortname": null,
+              "value": "ORGANIZATION_LABEL"
+            },
+            {
+              "help": "print help",
+              "name": "help",
+              "shortname": "h",
+              "value": null
+            }
+          ],
+          "subcommands": []
+        },
+        {
+          "description": "List environment paths",
+          "name": "paths",
+          "options": [
+            {
+              "help": "Organization name to search by",
+              "name": "organization",
+              "shortname": null,
+              "value": "ORGANIZATION_NAME"
+            },
+            {
+              "help": "organization ID",
+              "name": "organization-id",
+              "shortname": null,
+              "value": "ORGANIZATION_ID"
+            },
+            {
+              "help": "Organization label to search by",
+              "name": "organization-label",
+              "shortname": null,
+              "value": "ORGANIZATION_LABEL"
+            },
+            {
+              "help": "The associated permission type. One of (readable | promotable) Default: readable",
+              "name": "permission-type",
+              "shortname": null,
+              "value": "PERMISSION_TYPE"
+            },
+            {
+              "help": "print help",
+              "name": "help",
+              "shortname": "h",
+              "value": null
+            }
+          ],
+          "subcommands": []
+        },
+        {
+          "description": "Update an environment",
+          "name": "update",
+          "options": [
+            {
+              "help": "description of the environment",
+              "name": "description",
+              "shortname": null,
+              "value": "DESCRIPTION"
+            },
+            {
+              "help": "ID of the environment",
+              "name": "id",
+              "shortname": null,
+              "value": "ID"
+            },
+            {
+              "help": "Lifecycle environment name to search by",
+              "name": "name",
+              "shortname": null,
+              "value": "NAME"
+            },
+            {
+              "help": "new name to be given to the environment",
+              "name": "new-name",
+              "shortname": null,
+              "value": "NEW_NAME"
+            },
+            {
+              "help": "Organization name to search by",
+              "name": "organization",
+              "shortname": null,
+              "value": "ORGANIZATION_NAME"
+            },
+            {
+              "help": "organization ID",
+              "name": "organization-id",
+              "shortname": null,
+              "value": "ORGANIZATION_ID"
+            },
+            {
+              "help": "Organization label to search by",
+              "name": "organization-label",
+              "shortname": null,
+              "value": "ORGANIZATION_LABEL"
+            },
+            {
+              "help": "ID of an environment that is prior to the new environment in the chain. It has to be either the ID of Library or the ID of an environment at the end of a chain.",
+              "name": "prior",
+              "shortname": null,
+              "value": "PRIOR"
+            },
+            {
+              "help": "print help",
+              "name": "help",
+              "shortname": "h",
+              "value": null
+            }
+          ],
+          "subcommands": []
+        }
+      ]
+    },
+    {
+      "description": "Manipulate locations.",
+      "name": "location",
+      "options": [
+        {
+          "help": "print help",
+          "name": "help",
+          "shortname": "h",
+          "value": null
+        }
+      ],
+      "subcommands": [
+        {
+          "description": "Associate a compute resource",
+          "name": "add-compute-resource",
+          "options": [
+            {
+              "help": "Compute resource name",
+              "name": "compute-resource",
+              "shortname": null,
+              "value": "COMPUTE_RESOURCE_NAME"
+            },
+            {
+              "help": "",
+              "name": "compute-resource-id",
+              "shortname": null,
+              "value": "COMPUTE_RESOURCE_ID"
+            },
+            {
+              "help": "",
+              "name": "id",
+              "shortname": null,
+              "value": "ID"
+            },
+            {
+              "help": "Location name",
+              "name": "name",
+              "shortname": null,
+              "value": "NAME"
+            },
+            {
+              "help": "print help",
+              "name": "help",
+              "shortname": "h",
+              "value": null
+            }
+          ],
+          "subcommands": []
+        },
+        {
+          "description": "Associate a configuration template",
+          "name": "add-config-template",
+          "options": [
+            {
+              "help": "Name to search by",
+              "name": "config-template",
+              "shortname": null,
+              "value": "CONFIG_TEMPLATE_NAME"
+            },
+            {
+              "help": "",
+              "name": "config-template-id",
+              "shortname": null,
+              "value": "CONFIG_TEMPLATE_ID"
+            },
+            {
+              "help": "",
+              "name": "id",
+              "shortname": null,
+              "value": "ID"
+            },
+            {
+              "help": "Location name",
+              "name": "name",
+              "shortname": null,
+              "value": "NAME"
+            },
+            {
+              "help": "print help",
+              "name": "help",
+              "shortname": "h",
+              "value": null
+            }
+          ],
+          "subcommands": []
+        },
+        {
+          "description": "Associate a domain",
+          "name": "add-domain",
+          "options": [
+            {
+              "help": "Domain name",
+              "name": "domain",
+              "shortname": null,
+              "value": "DOMAIN_NAME"
+            },
+            {
+              "help": "Numerical ID or domain name",
+              "name": "domain-id",
+              "shortname": null,
+              "value": "DOMAIN_ID"
+            },
+            {
+              "help": "",
+              "name": "id",
+              "shortname": null,
+              "value": "ID"
+            },
+            {
+              "help": "Location name",
+              "name": "name",
+              "shortname": null,
+              "value": "NAME"
+            },
+            {
+              "help": "print help",
+              "name": "help",
+              "shortname": "h",
+              "value": null
+            }
+          ],
+          "subcommands": []
+        },
+        {
+          "description": "Associate an environment",
+          "name": "add-environment",
+          "options": [
+            {
+              "help": "Environment name",
+              "name": "environment",
+              "shortname": null,
+              "value": "ENVIRONMENT_NAME"
+            },
+            {
+              "help": "",
+              "name": "environment-id",
+              "shortname": null,
+              "value": "ENVIRONMENT_ID"
+            },
+            {
+              "help": "",
+              "name": "id",
+              "shortname": null,
+              "value": "ID"
+            },
+            {
+              "help": "Location name",
+              "name": "name",
+              "shortname": null,
+              "value": "NAME"
+            },
+            {
+              "help": "print help",
+              "name": "help",
+              "shortname": "h",
+              "value": null
+            }
+          ],
+          "subcommands": []
+        },
+        {
+          "description": "Associate a hostgroup",
+          "name": "add-hostgroup",
+          "options": [
+            {
+              "help": "Hostgroup name",
+              "name": "hostgroup",
+              "shortname": null,
+              "value": "HOSTGROUP_NAME"
+            },
+            {
+              "help": "",
+              "name": "hostgroup-id",
+              "shortname": null,
+              "value": "HOSTGROUP_ID"
+            },
+            {
+              "help": "",
+              "name": "id",
+              "shortname": null,
+              "value": "ID"
+            },
+            {
+              "help": "Location name",
+              "name": "name",
+              "shortname": null,
+              "value": "NAME"
+            },
+            {
+              "help": "print help",
+              "name": "help",
+              "shortname": "h",
+              "value": null
+            }
+          ],
+          "subcommands": []
+        },
+        {
+          "description": "Associate a medium",
+          "name": "add-medium",
+          "options": [
+            {
+              "help": "",
+              "name": "id",
+              "shortname": null,
+              "value": "ID"
+            },
+            {
+              "help": "Medium name",
+              "name": "medium",
+              "shortname": null,
+              "value": "MEDIUM_NAME"
+            },
+            {
+              "help": "",
+              "name": "medium-id",
+              "shortname": null,
+              "value": "MEDIUM_ID"
+            },
+            {
+              "help": "Location name",
+              "name": "name",
+              "shortname": null,
+              "value": "NAME"
+            },
+            {
+              "help": "print help",
+              "name": "help",
+              "shortname": "h",
+              "value": null
+            }
+          ],
+          "subcommands": []
+        },
+        {
+          "description": "Associate an organization",
+          "name": "add-organization",
+          "options": [
+            {
+              "help": "",
+              "name": "id",
+              "shortname": null,
+              "value": "ID"
+            },
+            {
+              "help": "Location name",
+              "name": "name",
+              "shortname": null,
+              "value": "NAME"
+            },
+            {
+              "help": "Organization name",
+              "name": "organization",
+              "shortname": null,
+              "value": "ORGANIZATION_NAME"
+            },
+            {
+              "help": "organization ID",
+              "name": "organization-id",
+              "shortname": null,
+              "value": "ORGANIZATION_ID"
+            },
+            {
+              "help": "print help",
+              "name": "help",
+              "shortname": "h",
+              "value": null
+            }
+          ],
+          "subcommands": []
+        },
+        {
+          "description": "Associate a smart proxy",
+          "name": "add-smart-proxy",
+          "options": [
+            {
+              "help": "",
+              "name": "id",
+              "shortname": null,
+              "value": "ID"
+            },
+            {
+              "help": "Location name",
+              "name": "name",
+              "shortname": null,
+              "value": "NAME"
+            },
+            {
+              "help": "Name to search by",
+              "name": "smart-proxy",
+              "shortname": null,
+              "value": "SMART_PROXY_NAME"
+            },
+            {
+              "help": "",
+              "name": "smart-proxy-id",
+              "shortname": null,
+              "value": "SMART_PROXY_ID"
+            },
+            {
+              "help": "print help",
+              "name": "help",
+              "shortname": "h",
+              "value": null
+            }
+          ],
+          "subcommands": []
+        },
+        {
+          "description": "Associate a subnet",
+          "name": "add-subnet",
+          "options": [
+            {
+              "help": "",
+              "name": "id",
+              "shortname": null,
+              "value": "ID"
+            },
+            {
+              "help": "Location name",
+              "name": "name",
+              "shortname": null,
+              "value": "NAME"
+            },
+            {
+              "help": "Subnet name",
+              "name": "subnet",
+              "shortname": null,
+              "value": "SUBNET_NAME"
+            },
+            {
+              "help": "",
+              "name": "subnet-id",
+              "shortname": null,
+              "value": "SUBNET_ID"
+            },
+            {
+              "help": "print help",
+              "name": "help",
+              "shortname": "h",
+              "value": null
+            }
+          ],
+          "subcommands": []
+        },
+        {
+          "description": "Associate an user",
+          "name": "add-user",
+          "options": [
+            {
+              "help": "",
+              "name": "id",
+              "shortname": null,
+              "value": "ID"
+            },
+            {
+              "help": "Location name",
+              "name": "name",
+              "shortname": null,
+              "value": "NAME"
+            },
+            {
+              "help": "User's login to search by",
+              "name": "user",
+              "shortname": null,
+              "value": "USER_LOGIN"
+            },
+            {
+              "help": "",
+              "name": "user-id",
+              "shortname": null,
+              "value": "USER_ID"
+            },
+            {
+              "help": "print help",
+              "name": "help",
+              "shortname": "h",
+              "value": null
+            }
+          ],
+          "subcommands": []
+        },
+        {
+          "description": "Create a location",
+          "name": "create",
+          "options": [
+            {
+              "help": "Compute resource IDs Comma separated list of values.",
+              "name": "compute-resource-ids",
+              "shortname": null,
+              "value": "COMPUTE_RESOURCE_IDS"
+            },
+            {
+              "help": "Comma separated list of values.",
+              "name": "compute-resources",
+              "shortname": null,
+              "value": "COMPUTE_RESOURCE_NAMES"
+            },
+            {
+              "help": "Provisioning template IDs Comma separated list of values.",
+              "name": "config-template-ids",
+              "shortname": null,
+              "value": "CONFIG_TEMPLATE_IDS"
+            },
+            {
+              "help": "Comma separated list of values.",
+              "name": "config-templates",
+              "shortname": null,
+              "value": "CONFIG_TEMPLATE_NAMES"
+            },
+            {
+              "help": "",
+              "name": "description",
+              "shortname": null,
+              "value": "DESCRIPTION"
+            },
+            {
+              "help": "Domain IDs Comma separated list of values.",
+              "name": "domain-ids",
+              "shortname": null,
+              "value": "DOMAIN_IDS"
+            },
+            {
+              "help": "Comma separated list of values.",
+              "name": "domains",
+              "shortname": null,
+              "value": "DOMAIN_NAMES"
+            },
+            {
+              "help": "Environment IDs Comma separated list of values.",
+              "name": "environment-ids",
+              "shortname": null,
+              "value": "ENVIRONMENT_IDS"
+            },
+            {
+              "help": "Comma separated list of values.",
+              "name": "environments",
+              "shortname": null,
+              "value": "ENVIRONMENT_NAMES"
+            },
+            {
+              "help": "Host group IDs Comma separated list of values.",
+              "name": "hostgroup-ids",
+              "shortname": null,
+              "value": "HOSTGROUP_IDS"
+            },
+            {
+              "help": "Comma separated list of values.",
+              "name": "hostgroups",
+              "shortname": null,
+              "value": "HOSTGROUP_NAMES"
+            },
+            {
+              "help": "Comma separated list of values.",
+              "name": "media",
+              "shortname": null,
+              "value": "MEDIUM_NAMES"
+            },
+            {
+              "help": "Media IDs Comma separated list of values.",
+              "name": "media-ids",
+              "shortname": null,
+              "value": "MEDIA_IDS"
+            },
+            {
+              "help": "",
+              "name": "name",
+              "shortname": null,
+              "value": "NAME"
+            },
+            {
+              "help": "Realm IDs Comma separated list of values.",
+              "name": "realm-ids",
+              "shortname": null,
+              "value": "REALM_IDS"
+            },
+            {
+              "help": "Comma separated list of values.",
+              "name": "realms",
+              "shortname": null,
+              "value": "REALM_NAMES"
+            },
+            {
+              "help": "Comma separated list of values.",
+              "name": "smart-proxies",
+              "shortname": null,
+              "value": "SMART_PROXY_NAMES"
+            },
+            {
+              "help": "Smart proxy IDs Comma separated list of values.",
+              "name": "smart-proxy-ids",
+              "shortname": null,
+              "value": "SMART_PROXY_IDS"
+            },
+            {
+              "help": "Subnet IDs Comma separated list of values.",
+              "name": "subnet-ids",
+              "shortname": null,
+              "value": "SUBNET_IDS"
+            },
+            {
+              "help": "Comma separated list of values.",
+              "name": "subnets",
+              "shortname": null,
+              "value": "SUBNET_NAMES"
+            },
+            {
+              "help": "User IDs Comma separated list of values.",
+              "name": "user-ids",
+              "shortname": null,
+              "value": "USER_IDS"
+            },
+            {
+              "help": "Comma separated list of values.",
+              "name": "users",
+              "shortname": null,
+              "value": "USER_LOGINS"
+            },
+            {
+              "help": "print help",
+              "name": "help",
+              "shortname": "h",
+              "value": null
+            }
+          ],
+          "subcommands": []
+        },
+        {
+          "description": "Delete a location",
+          "name": "delete",
+          "options": [
+            {
+              "help": "Location numeric id to search by",
+              "name": "id",
+              "shortname": null,
+              "value": "ID"
+            },
+            {
+              "help": "Organization name",
+              "name": "name",
+              "shortname": null,
+              "value": "NAME"
+            },
+            {
+              "help": "print help",
+              "name": "help",
+              "shortname": "h",
+              "value": null
+            }
+          ],
+          "subcommands": []
+        },
+        {
+          "description": "Show a location",
+          "name": "info",
+          "options": [
+            {
+              "help": "Location numeric id to search by",
+              "name": "id",
+              "shortname": null,
+              "value": "ID"
+            },
+            {
+              "help": "Organization name",
+              "name": "name",
+              "shortname": null,
+              "value": "NAME"
+            },
+            {
+              "help": "print help",
+              "name": "help",
+              "shortname": "h",
+              "value": null
+            }
+          ],
+          "subcommands": []
+        },
+        {
+          "description": "List all locations",
+          "name": "list",
+          "options": [
+            {
+              "help": "sort results",
+              "name": "order",
+              "shortname": null,
+              "value": "ORDER"
+            },
+            {
+              "help": "paginate results",
+              "name": "page",
+              "shortname": null,
+              "value": "PAGE"
+            },
+            {
+              "help": "number of entries per request",
+              "name": "per-page",
+              "shortname": null,
+              "value": "PER_PAGE"
+            },
+            {
+              "help": "filter results",
+              "name": "search",
+              "shortname": null,
+              "value": "SEARCH"
+            },
+            {
+              "help": "print help",
+              "name": "help",
+              "shortname": "h",
+              "value": null
+            }
+          ],
+          "subcommands": []
+        },
+        {
+          "description": "Disassociate a compute resource",
+          "name": "remove-compute-resource",
+          "options": [
+            {
+              "help": "Compute resource name",
+              "name": "compute-resource",
+              "shortname": null,
+              "value": "COMPUTE_RESOURCE_NAME"
+            },
+            {
+              "help": "",
+              "name": "compute-resource-id",
+              "shortname": null,
+              "value": "COMPUTE_RESOURCE_ID"
+            },
+            {
+              "help": "",
+              "name": "id",
+              "shortname": null,
+              "value": "ID"
+            },
+            {
+              "help": "Location name",
+              "name": "name",
+              "shortname": null,
+              "value": "NAME"
+            },
+            {
+              "help": "print help",
+              "name": "help",
+              "shortname": "h",
+              "value": null
+            }
+          ],
+          "subcommands": []
+        },
+        {
+          "description": "Disassociate a configuration template",
+          "name": "remove-config-template",
+          "options": [
+            {
+              "help": "Name to search by",
+              "name": "config-template",
+              "shortname": null,
+              "value": "CONFIG_TEMPLATE_NAME"
+            },
+            {
+              "help": "",
+              "name": "config-template-id",
+              "shortname": null,
+              "value": "CONFIG_TEMPLATE_ID"
+            },
+            {
+              "help": "",
+              "name": "id",
+              "shortname": null,
+              "value": "ID"
+            },
+            {
+              "help": "Location name",
+              "name": "name",
+              "shortname": null,
+              "value": "NAME"
+            },
+            {
+              "help": "print help",
+              "name": "help",
+              "shortname": "h",
+              "value": null
+            }
+          ],
+          "subcommands": []
+        },
+        {
+          "description": "Disassociate a domain",
+          "name": "remove-domain",
+          "options": [
+            {
+              "help": "Domain name",
+              "name": "domain",
+              "shortname": null,
+              "value": "DOMAIN_NAME"
+            },
+            {
+              "help": "Numerical ID or domain name",
+              "name": "domain-id",
+              "shortname": null,
+              "value": "DOMAIN_ID"
+            },
+            {
+              "help": "",
+              "name": "id",
+              "shortname": null,
+              "value": "ID"
+            },
+            {
+              "help": "Location name",
+              "name": "name",
+              "shortname": null,
+              "value": "NAME"
+            },
+            {
+              "help": "print help",
+              "name": "help",
+              "shortname": "h",
+              "value": null
+            }
+          ],
+          "subcommands": []
+        },
+        {
+          "description": "Disassociate an environment",
+          "name": "remove-environment",
+          "options": [
+            {
+              "help": "Environment name",
+              "name": "environment",
+              "shortname": null,
+              "value": "ENVIRONMENT_NAME"
+            },
+            {
+              "help": "",
+              "name": "environment-id",
+              "shortname": null,
+              "value": "ENVIRONMENT_ID"
+            },
+            {
+              "help": "",
+              "name": "id",
+              "shortname": null,
+              "value": "ID"
+            },
+            {
+              "help": "Location name",
+              "name": "name",
+              "shortname": null,
+              "value": "NAME"
+            },
+            {
+              "help": "print help",
+              "name": "help",
+              "shortname": "h",
+              "value": null
+            }
+          ],
+          "subcommands": []
+        },
+        {
+          "description": "Disassociate a hostgroup",
+          "name": "remove-hostgroup",
+          "options": [
+            {
+              "help": "Hostgroup name",
+              "name": "hostgroup",
+              "shortname": null,
+              "value": "HOSTGROUP_NAME"
+            },
+            {
+              "help": "",
+              "name": "hostgroup-id",
+              "shortname": null,
+              "value": "HOSTGROUP_ID"
+            },
+            {
+              "help": "",
+              "name": "id",
+              "shortname": null,
+              "value": "ID"
+            },
+            {
+              "help": "Location name",
+              "name": "name",
+              "shortname": null,
+              "value": "NAME"
+            },
+            {
+              "help": "print help",
+              "name": "help",
+              "shortname": "h",
+              "value": null
+            }
+          ],
+          "subcommands": []
+        },
+        {
+          "description": "Disassociate a medium",
+          "name": "remove-medium",
+          "options": [
+            {
+              "help": "",
+              "name": "id",
+              "shortname": null,
+              "value": "ID"
+            },
+            {
+              "help": "Medium name",
+              "name": "medium",
+              "shortname": null,
+              "value": "MEDIUM_NAME"
+            },
+            {
+              "help": "",
+              "name": "medium-id",
+              "shortname": null,
+              "value": "MEDIUM_ID"
+            },
+            {
+              "help": "Location name",
+              "name": "name",
+              "shortname": null,
+              "value": "NAME"
+            },
+            {
+              "help": "print help",
+              "name": "help",
+              "shortname": "h",
+              "value": null
+            }
+          ],
+          "subcommands": []
+        },
+        {
+          "description": "Disassociate an organization",
+          "name": "remove-organization",
+          "options": [
+            {
+              "help": "",
+              "name": "id",
+              "shortname": null,
+              "value": "ID"
+            },
+            {
+              "help": "Location name",
+              "name": "name",
+              "shortname": null,
+              "value": "NAME"
+            },
+            {
+              "help": "Organization name",
+              "name": "organization",
+              "shortname": null,
+              "value": "ORGANIZATION_NAME"
+            },
+            {
+              "help": "organization ID",
+              "name": "organization-id",
+              "shortname": null,
+              "value": "ORGANIZATION_ID"
+            },
+            {
+              "help": "print help",
+              "name": "help",
+              "shortname": "h",
+              "value": null
+            }
+          ],
+          "subcommands": []
+        },
+        {
+          "description": "Disassociate a smart proxy",
+          "name": "remove-smart-proxy",
+          "options": [
+            {
+              "help": "",
+              "name": "id",
+              "shortname": null,
+              "value": "ID"
+            },
+            {
+              "help": "Location name",
+              "name": "name",
+              "shortname": null,
+              "value": "NAME"
+            },
+            {
+              "help": "Name to search by",
+              "name": "smart-proxy",
+              "shortname": null,
+              "value": "SMART_PROXY_NAME"
+            },
+            {
+              "help": "",
+              "name": "smart-proxy-id",
+              "shortname": null,
+              "value": "SMART_PROXY_ID"
+            },
+            {
+              "help": "print help",
+              "name": "help",
+              "shortname": "h",
+              "value": null
+            }
+          ],
+          "subcommands": []
+        },
+        {
+          "description": "Disassociate a subnet",
+          "name": "remove-subnet",
+          "options": [
+            {
+              "help": "",
+              "name": "id",
+              "shortname": null,
+              "value": "ID"
+            },
+            {
+              "help": "Location name",
+              "name": "name",
+              "shortname": null,
+              "value": "NAME"
+            },
+            {
+              "help": "Subnet name",
+              "name": "subnet",
+              "shortname": null,
+              "value": "SUBNET_NAME"
+            },
+            {
+              "help": "",
+              "name": "subnet-id",
+              "shortname": null,
+              "value": "SUBNET_ID"
+            },
+            {
+              "help": "print help",
+              "name": "help",
+              "shortname": "h",
+              "value": null
+            }
+          ],
+          "subcommands": []
+        },
+        {
+          "description": "Disassociate an user",
+          "name": "remove-user",
+          "options": [
+            {
+              "help": "",
+              "name": "id",
+              "shortname": null,
+              "value": "ID"
+            },
+            {
+              "help": "Location name",
+              "name": "name",
+              "shortname": null,
+              "value": "NAME"
+            },
+            {
+              "help": "User's login to search by",
+              "name": "user",
+              "shortname": null,
+              "value": "USER_LOGIN"
+            },
+            {
+              "help": "",
+              "name": "user-id",
+              "shortname": null,
+              "value": "USER_ID"
+            },
+            {
+              "help": "print help",
+              "name": "help",
+              "shortname": "h",
+              "value": null
+            }
+          ],
+          "subcommands": []
+        },
+        {
+          "description": "Update a location",
+          "name": "update",
+          "options": [
+            {
+              "help": "Compute resource IDs Comma separated list of values.",
+              "name": "compute-resource-ids",
+              "shortname": null,
+              "value": "COMPUTE_RESOURCE_IDS"
+            },
+            {
+              "help": "Comma separated list of values.",
+              "name": "compute-resources",
+              "shortname": null,
+              "value": "COMPUTE_RESOURCE_NAMES"
+            },
+            {
+              "help": "Provisioning template IDs Comma separated list of values.",
+              "name": "config-template-ids",
+              "shortname": null,
+              "value": "CONFIG_TEMPLATE_IDS"
+            },
+            {
+              "help": "Comma separated list of values.",
+              "name": "config-templates",
+              "shortname": null,
+              "value": "CONFIG_TEMPLATE_NAMES"
+            },
+            {
+              "help": "",
+              "name": "description",
+              "shortname": null,
+              "value": "DESCRIPTION"
+            },
+            {
+              "help": "Domain IDs Comma separated list of values.",
+              "name": "domain-ids",
+              "shortname": null,
+              "value": "DOMAIN_IDS"
+            },
+            {
+              "help": "Comma separated list of values.",
+              "name": "domains",
+              "shortname": null,
+              "value": "DOMAIN_NAMES"
+            },
+            {
+              "help": "Environment IDs Comma separated list of values.",
+              "name": "environment-ids",
+              "shortname": null,
+              "value": "ENVIRONMENT_IDS"
+            },
+            {
+              "help": "Comma separated list of values.",
+              "name": "environments",
+              "shortname": null,
+              "value": "ENVIRONMENT_NAMES"
+            },
+            {
+              "help": "Host group IDs Comma separated list of values.",
+              "name": "hostgroup-ids",
+              "shortname": null,
+              "value": "HOSTGROUP_IDS"
+            },
+            {
+              "help": "Comma separated list of values.",
+              "name": "hostgroups",
+              "shortname": null,
+              "value": "HOSTGROUP_NAMES"
+            },
+            {
+              "help": "Location numeric id to search by",
+              "name": "id",
+              "shortname": null,
+              "value": "ID"
+            },
+            {
+              "help": "Comma separated list of values.",
+              "name": "media",
+              "shortname": null,
+              "value": "MEDIUM_NAMES"
+            },
+            {
+              "help": "Media IDs Comma separated list of values.",
+              "name": "media-ids",
+              "shortname": null,
+              "value": "MEDIA_IDS"
+            },
+            {
+              "help": "",
+              "name": "name",
+              "shortname": null,
+              "value": "NAME"
+            },
+            {
+              "help": "",
+              "name": "new-name",
+              "shortname": null,
+              "value": "NEW_NAME"
+            },
+            {
+              "help": "Realm IDs Comma separated list of values.",
+              "name": "realm-ids",
+              "shortname": null,
+              "value": "REALM_IDS"
+            },
+            {
+              "help": "Comma separated list of values.",
+              "name": "realms",
+              "shortname": null,
+              "value": "REALM_NAMES"
+            },
+            {
+              "help": "Comma separated list of values.",
+              "name": "smart-proxies",
+              "shortname": null,
+              "value": "SMART_PROXY_NAMES"
+            },
+            {
+              "help": "Smart proxy IDs Comma separated list of values.",
+              "name": "smart-proxy-ids",
+              "shortname": null,
+              "value": "SMART_PROXY_IDS"
+            },
+            {
+              "help": "Subnet IDs Comma separated list of values.",
+              "name": "subnet-ids",
+              "shortname": null,
+              "value": "SUBNET_IDS"
+            },
+            {
+              "help": "Comma separated list of values.",
+              "name": "subnets",
+              "shortname": null,
+              "value": "SUBNET_NAMES"
+            },
+            {
+              "help": "User IDs Comma separated list of values.",
+              "name": "user-ids",
+              "shortname": null,
+              "value": "USER_IDS"
+            },
+            {
+              "help": "Comma separated list of values.",
+              "name": "users",
+              "shortname": null,
+              "value": "USER_LOGINS"
+            },
+            {
+              "help": "print help",
+              "name": "help",
+              "shortname": "h",
+              "value": null
+            }
+          ],
+          "subcommands": []
+        }
+      ]
+    },
+    {
+      "description": "Manipulate installation media.",
+      "name": "medium",
+      "options": [
+        {
+          "help": "print help",
+          "name": "help",
+          "shortname": "h",
+          "value": null
+        }
+      ],
+      "subcommands": [
+        {
+          "description": "Associate an operating system",
+          "name": "add-operatingsystem",
+          "options": [
+            {
+              "help": "",
+              "name": "id",
+              "shortname": null,
+              "value": "ID"
+            },
+            {
+              "help": "Medium name",
+              "name": "name",
+              "shortname": null,
+              "value": "NAME"
+            },
+            {
+              "help": "Operating system title",
+              "name": "operatingsystem",
+              "shortname": null,
+              "value": "OPERATINGSYSTEM_TITLE"
+            },
+            {
+              "help": "",
+              "name": "operatingsystem-id",
+              "shortname": null,
+              "value": "OPERATINGSYSTEM_ID"
+            },
+            {
+              "help": "print help",
+              "name": "help",
+              "shortname": "h",
+              "value": null
+            }
+          ],
+          "subcommands": []
+        },
+        {
+          "description": "Create a medium",
+          "name": "create",
+          "options": [
+            {
+              "help": "REPLACE locations with given ids Comma separated list of values.",
+              "name": "location-ids",
+              "shortname": null,
+              "value": "LOCATION_IDS"
+            },
+            {
+              "help": "Comma separated list of values.",
+              "name": "locations",
+              "shortname": null,
+              "value": "LOCATION_NAMES"
+            },
+            {
+              "help": "Name of media",
+              "name": "name",
+              "shortname": null,
+              "value": "NAME"
+            },
+            {
+              "help": "Comma separated list of values.",
+              "name": "operatingsystem-ids",
+              "shortname": null,
+              "value": "OPERATINGSYSTEM_IDS"
+            },
+            {
+              "help": "Comma separated list of values.",
+              "name": "operatingsystems",
+              "shortname": null,
+              "value": "OPERATINGSYSTEM_TITLES"
+            },
+            {
+              "help": "REPLACE organizations with given ids. Comma separated list of values.",
+              "name": "organization-ids",
+              "shortname": null,
+              "value": "ORGANIZATION_IDS"
+            },
+            {
+              "help": "Comma separated list of values.",
+              "name": "organizations",
+              "shortname": null,
+              "value": "ORGANIZATION_NAMES"
+            },
+            {
+              "help": "Operating system family, available values: ",
+              "name": "os-family",
+              "shortname": null,
+              "value": "OS_FAMILY"
+            },
+            {
+              "help": "The path to the medium, can be a URL or a valid NFS server (exclusive of the architecture). for example mirror.centos.org/centos/$version/os/$arch where $arch will be substituted for the host's actual OS architecture and $version, $major and $minor will be substituted for the version of the operating system. Solaris and Debian media may also use $release.",
+              "name": "path",
+              "shortname": null,
+              "value": "PATH"
+            },
+            {
+              "help": "print help",
+              "name": "help",
+              "shortname": "h",
+              "value": null
+            }
+          ],
+          "subcommands": []
+        },
+        {
+          "description": "Delete a medium",
+          "name": "delete",
+          "options": [
+            {
+              "help": "",
+              "name": "id",
+              "shortname": null,
+              "value": "ID"
+            },
+            {
+              "help": "Medium name",
+              "name": "name",
+              "shortname": null,
+              "value": "NAME"
+            },
+            {
+              "help": "print help",
+              "name": "help",
+              "shortname": "h",
+              "value": null
+            }
+          ],
+          "subcommands": []
+        },
+        {
+          "description": "Show a medium",
+          "name": "info",
+          "options": [
+            {
+              "help": "",
+              "name": "id",
+              "shortname": null,
+              "value": "ID"
+            },
+            {
+              "help": "Medium name",
+              "name": "name",
+              "shortname": null,
+              "value": "NAME"
+            },
+            {
+              "help": "print help",
+              "name": "help",
+              "shortname": "h",
+              "value": null
+            }
+          ],
+          "subcommands": []
+        },
+        {
+          "description": "List all installation media",
+          "name": "list",
+          "options": [
+            {
+              "help": "Location name",
+              "name": "location",
+              "shortname": null,
+              "value": "LOCATION_NAME"
+            },
+            {
+              "help": "",
+              "name": "location-id",
+              "shortname": null,
+              "value": "LOCATION_ID"
+            },
+            {
+              "help": "Operating system title",
+              "name": "operatingsystem",
+              "shortname": null,
+              "value": "OPERATINGSYSTEM_TITLE"
+            },
+            {
+              "help": "",
+              "name": "operatingsystem-id",
+              "shortname": null,
+              "value": "OPERATINGSYSTEM_ID"
+            },
+            {
+              "help": "sort results",
+              "name": "order",
+              "shortname": null,
+              "value": "ORDER"
+            },
+            {
+              "help": "Organization name",
+              "name": "organization",
+              "shortname": null,
+              "value": "ORGANIZATION_NAME"
+            },
+            {
+              "help": "organization ID",
+              "name": "organization-id",
+              "shortname": null,
+              "value": "ORGANIZATION_ID"
+            },
+            {
+              "help": "paginate results",
+              "name": "page",
+              "shortname": null,
+              "value": "PAGE"
+            },
+            {
+              "help": "number of entries per request",
+              "name": "per-page",
+              "shortname": null,
+              "value": "PER_PAGE"
+            },
+            {
+              "help": "filter results",
+              "name": "search",
+              "shortname": null,
+              "value": "SEARCH"
+            },
+            {
+              "help": "print help",
+              "name": "help",
+              "shortname": "h",
+              "value": null
+            }
+          ],
+          "subcommands": []
+        },
+        {
+          "description": "Disassociate an operating system",
+          "name": "remove-operatingsystem",
+          "options": [
+            {
+              "help": "",
+              "name": "id",
+              "shortname": null,
+              "value": "ID"
+            },
+            {
+              "help": "Medium name",
+              "name": "name",
+              "shortname": null,
+              "value": "NAME"
+            },
+            {
+              "help": "Operating system title",
+              "name": "operatingsystem",
+              "shortname": null,
+              "value": "OPERATINGSYSTEM_TITLE"
+            },
+            {
+              "help": "",
+              "name": "operatingsystem-id",
+              "shortname": null,
+              "value": "OPERATINGSYSTEM_ID"
+            },
+            {
+              "help": "print help",
+              "name": "help",
+              "shortname": "h",
+              "value": null
+            }
+          ],
+          "subcommands": []
+        },
+        {
+          "description": "Update a medium",
+          "name": "update",
+          "options": [
+            {
+              "help": "",
+              "name": "id",
+              "shortname": null,
+              "value": "ID"
+            },
+            {
+              "help": "REPLACE locations with given ids Comma separated list of values.",
+              "name": "location-ids",
+              "shortname": null,
+              "value": "LOCATION_IDS"
+            },
+            {
+              "help": "Comma separated list of values.",
+              "name": "locations",
+              "shortname": null,
+              "value": "LOCATION_NAMES"
+            },
+            {
+              "help": "Medium name",
+              "name": "name",
+              "shortname": null,
+              "value": "NAME"
+            },
+            {
+              "help": "Name of media",
+              "name": "new-name",
+              "shortname": null,
+              "value": "NEW_NAME"
+            },
+            {
+              "help": "Comma separated list of values.",
+              "name": "operatingsystem-ids",
+              "shortname": null,
+              "value": "OPERATINGSYSTEM_IDS"
+            },
+            {
+              "help": "Comma separated list of values.",
+              "name": "operatingsystems",
+              "shortname": null,
+              "value": "OPERATINGSYSTEM_TITLES"
+            },
+            {
+              "help": "REPLACE organizations with given ids. Comma separated list of values.",
+              "name": "organization-ids",
+              "shortname": null,
+              "value": "ORGANIZATION_IDS"
+            },
+            {
+              "help": "Comma separated list of values.",
+              "name": "organizations",
+              "shortname": null,
+              "value": "ORGANIZATION_NAMES"
+            },
+            {
+              "help": "Operating system family, available values: ",
+              "name": "os-family",
+              "shortname": null,
+              "value": "OS_FAMILY"
+            },
+            {
+              "help": "The path to the medium, can be a URL or a valid NFS server (exclusive of the architecture). for example mirror.centos.org/centos/$version/os/$arch where $arch will be substituted for the host's actual OS architecture and $version, $major and $minor will be substituted for the version of the operating system. Solaris and Debian media may also use $release.",
+              "name": "path",
+              "shortname": null,
+              "value": "PATH"
+            },
+            {
+              "help": "print help",
+              "name": "help",
+              "shortname": "h",
+              "value": null
+            }
+          ],
+          "subcommands": []
+        }
+      ]
+    },
+    {
+      "description": "Manipulate hardware models.",
+      "name": "model",
+      "options": [
+        {
+          "help": "print help",
+          "name": "help",
+          "shortname": "h",
+          "value": null
+        }
+      ],
+      "subcommands": [
+        {
+          "description": "Create a hardware model",
+          "name": "create",
+          "options": [
+            {
+              "help": "",
+              "name": "hardware-model",
+              "shortname": null,
+              "value": "HARDWARE_MODEL"
+            },
+            {
+              "help": "",
+              "name": "info",
+              "shortname": null,
+              "value": "INFO"
+            },
+            {
+              "help": "",
+              "name": "name",
+              "shortname": null,
+              "value": "NAME"
+            },
+            {
+              "help": "",
+              "name": "vendor-class",
+              "shortname": null,
+              "value": "VENDOR_CLASS"
+            },
+            {
+              "help": "print help",
+              "name": "help",
+              "shortname": "h",
+              "value": null
+            }
+          ],
+          "subcommands": []
+        },
+        {
+          "description": "Delete a hardware model",
+          "name": "delete",
+          "options": [
+            {
+              "help": "",
+              "name": "id",
+              "shortname": null,
+              "value": "ID"
+            },
+            {
+              "help": "Model name",
+              "name": "name",
+              "shortname": null,
+              "value": "NAME"
+            },
+            {
+              "help": "print help",
+              "name": "help",
+              "shortname": "h",
+              "value": null
+            }
+          ],
+          "subcommands": []
+        },
+        {
+          "description": "Show a hardware model",
+          "name": "info",
+          "options": [
+            {
+              "help": "",
+              "name": "id",
+              "shortname": null,
+              "value": "ID"
+            },
+            {
+              "help": "Model name",
+              "name": "name",
+              "shortname": null,
+              "value": "NAME"
+            },
+            {
+              "help": "print help",
+              "name": "help",
+              "shortname": "h",
+              "value": null
+            }
+          ],
+          "subcommands": []
+        },
+        {
+          "description": "List all hardware models",
+          "name": "list",
+          "options": [
+            {
+              "help": "sort results",
+              "name": "order",
+              "shortname": null,
+              "value": "ORDER"
+            },
+            {
+              "help": "paginate results",
+              "name": "page",
+              "shortname": null,
+              "value": "PAGE"
+            },
+            {
+              "help": "number of entries per request",
+              "name": "per-page",
+              "shortname": null,
+              "value": "PER_PAGE"
+            },
+            {
+              "help": "filter results",
+              "name": "search",
+              "shortname": null,
+              "value": "SEARCH"
+            },
+            {
+              "help": "print help",
+              "name": "help",
+              "shortname": "h",
+              "value": null
+            }
+          ],
+          "subcommands": []
+        },
+        {
+          "description": "Update a hardware model",
+          "name": "update",
+          "options": [
+            {
+              "help": "",
+              "name": "hardware-model",
+              "shortname": null,
+              "value": "HARDWARE_MODEL"
+            },
+            {
+              "help": "",
+              "name": "id",
+              "shortname": null,
+              "value": "ID"
+            },
+            {
+              "help": "",
+              "name": "info",
+              "shortname": null,
+              "value": "INFO"
+            },
+            {
+              "help": "Model name",
+              "name": "name",
+              "shortname": null,
+              "value": "NAME"
+            },
+            {
+              "help": "",
+              "name": "new-name",
+              "shortname": null,
+              "value": "NEW_NAME"
+            },
+            {
+              "help": "",
+              "name": "vendor-class",
+              "shortname": null,
+              "value": "VENDOR_CLASS"
+            },
+            {
+              "help": "print help",
+              "name": "help",
+              "shortname": "h",
+              "value": null
+            }
+          ],
+          "subcommands": []
+        }
+      ]
+    },
+    {
+      "description": "Manipulate organizations",
+      "name": "organization",
+      "options": [
+        {
+          "help": "print help",
+          "name": "help",
+          "shortname": "h",
+          "value": null
+        }
+      ],
+      "subcommands": [
+        {
+          "description": "Associate a compute resource",
+          "name": "add-compute-resource",
+          "options": [
+            {
+              "help": "Compute resource name",
+              "name": "compute-resource",
+              "shortname": null,
+              "value": "COMPUTE_RESOURCE_NAME"
+            },
+            {
+              "help": "",
+              "name": "compute-resource-id",
+              "shortname": null,
+              "value": "COMPUTE_RESOURCE_ID"
+            },
+            {
+              "help": "organization ID",
+              "name": "id",
+              "shortname": null,
+              "value": "ID"
+            },
+            {
+              "help": "Organization name",
+              "name": "name",
+              "shortname": null,
+              "value": "NAME"
+            },
+            {
+              "help": "print help",
+              "name": "help",
+              "shortname": "h",
+              "value": null
+            }
+          ],
+          "subcommands": []
+        },
+        {
+          "description": "Associate a configuration template",
+          "name": "add-config-template",
+          "options": [
+            {
+              "help": "Name to search by",
+              "name": "config-template",
+              "shortname": null,
+              "value": "CONFIG_TEMPLATE_NAME"
+            },
+            {
+              "help": "",
+              "name": "config-template-id",
+              "shortname": null,
+              "value": "CONFIG_TEMPLATE_ID"
+            },
+            {
+              "help": "organization ID",
+              "name": "id",
+              "shortname": null,
+              "value": "ID"
+            },
+            {
+              "help": "Organization name",
+              "name": "name",
+              "shortname": null,
+              "value": "NAME"
+            },
+            {
+              "help": "print help",
+              "name": "help",
+              "shortname": "h",
+              "value": null
+            }
+          ],
+          "subcommands": []
+        },
+        {
+          "description": "Associate a domain",
+          "name": "add-domain",
+          "options": [
+            {
+              "help": "Domain name",
+              "name": "domain",
+              "shortname": null,
+              "value": "DOMAIN_NAME"
+            },
+            {
+              "help": "Numerical ID or domain name",
+              "name": "domain-id",
+              "shortname": null,
+              "value": "DOMAIN_ID"
+            },
+            {
+              "help": "organization ID",
+              "name": "id",
+              "shortname": null,
+              "value": "ID"
+            },
+            {
+              "help": "Organization name",
+              "name": "name",
+              "shortname": null,
+              "value": "NAME"
+            },
+            {
+              "help": "print help",
+              "name": "help",
+              "shortname": "h",
+              "value": null
+            }
+          ],
+          "subcommands": []
+        },
+        {
+          "description": "Associate an environment",
+          "name": "add-environment",
+          "options": [
+            {
+              "help": "Environment name",
+              "name": "environment",
+              "shortname": null,
+              "value": "ENVIRONMENT_NAME"
+            },
+            {
+              "help": "",
+              "name": "environment-id",
+              "shortname": null,
+              "value": "ENVIRONMENT_ID"
+            },
+            {
+              "help": "organization ID",
+              "name": "id",
+              "shortname": null,
+              "value": "ID"
+            },
+            {
+              "help": "Organization name",
+              "name": "name",
+              "shortname": null,
+              "value": "NAME"
+            },
+            {
+              "help": "print help",
+              "name": "help",
+              "shortname": "h",
+              "value": null
+            }
+          ],
+          "subcommands": []
+        },
+        {
+          "description": "Associate a hostgroup",
+          "name": "add-hostgroup",
+          "options": [
+            {
+              "help": "Hostgroup name",
+              "name": "hostgroup",
+              "shortname": null,
+              "value": "HOSTGROUP_NAME"
+            },
+            {
+              "help": "",
+              "name": "hostgroup-id",
+              "shortname": null,
+              "value": "HOSTGROUP_ID"
+            },
+            {
+              "help": "organization ID",
+              "name": "id",
+              "shortname": null,
+              "value": "ID"
+            },
+            {
+              "help": "Organization name",
+              "name": "name",
+              "shortname": null,
+              "value": "NAME"
+            },
+            {
+              "help": "print help",
+              "name": "help",
+              "shortname": "h",
+              "value": null
+            }
+          ],
+          "subcommands": []
+        },
+        {
+          "description": "Associate a medium",
+          "name": "add-medium",
+          "options": [
+            {
+              "help": "organization ID",
+              "name": "id",
+              "shortname": null,
+              "value": "ID"
+            },
+            {
+              "help": "Medium name",
+              "name": "medium",
+              "shortname": null,
+              "value": "MEDIUM_NAME"
+            },
+            {
+              "help": "",
+              "name": "medium-id",
+              "shortname": null,
+              "value": "MEDIUM_ID"
+            },
+            {
+              "help": "Organization name",
+              "name": "name",
+              "shortname": null,
+              "value": "NAME"
+            },
+            {
+              "help": "print help",
+              "name": "help",
+              "shortname": "h",
+              "value": null
+            }
+          ],
+          "subcommands": []
+        },
+        {
+          "description": "Associate a smart proxy",
+          "name": "add-smart-proxy",
+          "options": [
+            {
+              "help": "organization ID",
+              "name": "id",
+              "shortname": null,
+              "value": "ID"
+            },
+            {
+              "help": "Organization name",
+              "name": "name",
+              "shortname": null,
+              "value": "NAME"
+            },
+            {
+              "help": "Name to search by",
+              "name": "smart-proxy",
+              "shortname": null,
+              "value": "SMART_PROXY_NAME"
+            },
+            {
+              "help": "",
+              "name": "smart-proxy-id",
+              "shortname": null,
+              "value": "SMART_PROXY_ID"
+            },
+            {
+              "help": "print help",
+              "name": "help",
+              "shortname": "h",
+              "value": null
+            }
+          ],
+          "subcommands": []
+        },
+        {
+          "description": "Associate a subnet",
+          "name": "add-subnet",
+          "options": [
+            {
+              "help": "organization ID",
+              "name": "id",
+              "shortname": null,
+              "value": "ID"
+            },
+            {
+              "help": "Organization name",
+              "name": "name",
+              "shortname": null,
+              "value": "NAME"
+            },
+            {
+              "help": "Subnet name",
+              "name": "subnet",
+              "shortname": null,
+              "value": "SUBNET_NAME"
+            },
+            {
+              "help": "",
+              "name": "subnet-id",
+              "shortname": null,
+              "value": "SUBNET_ID"
+            },
+            {
+              "help": "print help",
+              "name": "help",
+              "shortname": "h",
+              "value": null
+            }
+          ],
+          "subcommands": []
+        },
+        {
+          "description": "Associate an user",
+          "name": "add-user",
+          "options": [
+            {
+              "help": "organization ID",
+              "name": "id",
+              "shortname": null,
+              "value": "ID"
+            },
+            {
+              "help": "Organization name",
+              "name": "name",
+              "shortname": null,
+              "value": "NAME"
+            },
+            {
+              "help": "User's login to search by",
+              "name": "user",
+              "shortname": null,
+              "value": "USER_LOGIN"
+            },
+            {
+              "help": "",
+              "name": "user-id",
+              "shortname": null,
+              "value": "USER_ID"
+            },
+            {
+              "help": "print help",
+              "name": "help",
+              "shortname": "h",
+              "value": null
+            }
+          ],
+          "subcommands": []
+        },
+        {
+          "description": "Create organization",
+          "name": "create",
+          "options": [
+            {
+              "help": "Compute resource IDs Comma separated list of values.",
+              "name": "compute-resource-ids",
+              "shortname": null,
+              "value": "COMPUTE_RESOURCE_IDS"
+            },
+            {
+              "help": "Comma separated list of values.",
+              "name": "compute-resources",
+              "shortname": null,
+              "value": "COMPUTE_RESOURCE_NAMES"
+            },
+            {
+              "help": "Provisioning template IDs Comma separated list of values.",
+              "name": "config-template-ids",
+              "shortname": null,
+              "value": "CONFIG_TEMPLATE_IDS"
+            },
+            {
+              "help": "Comma separated list of values.",
+              "name": "config-templates",
+              "shortname": null,
+              "value": "CONFIG_TEMPLATE_NAMES"
+            },
+            {
+              "help": "description",
+              "name": "description",
+              "shortname": null,
+              "value": "DESCRIPTION"
+            },
+            {
+              "help": "Domain IDs Comma separated list of values.",
+              "name": "domain-ids",
+              "shortname": null,
+              "value": "DOMAIN_IDS"
+            },
+            {
+              "help": "Comma separated list of values.",
+              "name": "domains",
+              "shortname": null,
+              "value": "DOMAIN_NAMES"
+            },
+            {
+              "help": "Environment IDs Comma separated list of values.",
+              "name": "environment-ids",
+              "shortname": null,
+              "value": "ENVIRONMENT_IDS"
+            },
+            {
+              "help": "Comma separated list of values.",
+              "name": "environments",
+              "shortname": null,
+              "value": "ENVIRONMENT_NAMES"
+            },
+            {
+              "help": "Host group IDs Comma separated list of values.",
+              "name": "hostgroup-ids",
+              "shortname": null,
+              "value": "HOSTGROUP_IDS"
+            },
+            {
+              "help": "Comma separated list of values.",
+              "name": "hostgroups",
+              "shortname": null,
+              "value": "HOSTGROUP_NAMES"
+            },
+            {
+              "help": "unique label",
+              "name": "label",
+              "shortname": null,
+              "value": "LABEL"
+            },
+            {
+              "help": "Comma separated list of values.",
+              "name": "media",
+              "shortname": null,
+              "value": "MEDIUM_NAMES"
+            },
+            {
+              "help": "Media IDs Comma separated list of values.",
+              "name": "media-ids",
+              "shortname": null,
+              "value": "MEDIA_IDS"
+            },
+            {
+              "help": "name",
+              "name": "name",
+              "shortname": null,
+              "value": "NAME"
+            },
+            {
+              "help": "Realm IDs Comma separated list of values.",
+              "name": "realm-ids",
+              "shortname": null,
+              "value": "REALM_IDS"
+            },
+            {
+              "help": "Comma separated list of values.",
+              "name": "realms",
+              "shortname": null,
+              "value": "REALM_NAMES"
+            },
+            {
+              "help": "Comma separated list of values.",
+              "name": "smart-proxies",
+              "shortname": null,
+              "value": "SMART_PROXY_NAMES"
+            },
+            {
+              "help": "Smart proxy IDs Comma separated list of values.",
+              "name": "smart-proxy-ids",
+              "shortname": null,
+              "value": "SMART_PROXY_IDS"
+            },
+            {
+              "help": "Subnet IDs Comma separated list of values.",
+              "name": "subnet-ids",
+              "shortname": null,
+              "value": "SUBNET_IDS"
+            },
+            {
+              "help": "Comma separated list of values.",
+              "name": "subnets",
+              "shortname": null,
+              "value": "SUBNET_NAMES"
+            },
+            {
+              "help": "User IDs Comma separated list of values.",
+              "name": "user-ids",
+              "shortname": null,
+              "value": "USER_IDS"
+            },
+            {
+              "help": "Comma separated list of values.",
+              "name": "users",
+              "shortname": null,
+              "value": "USER_NAMES"
+            },
+            {
+              "help": "print help",
+              "name": "help",
+              "shortname": "h",
+              "value": null
+            }
+          ],
+          "subcommands": []
+        },
+        {
+          "description": "Delete an organization",
+          "name": "delete",
+          "options": [
+            {
+              "help": "Do not wait for the task",
+              "name": "async",
+              "shortname": null,
+              "value": null
+            },
+            {
+              "help": "",
+              "name": "id",
+              "shortname": null,
+              "value": "ID"
+            },
+            {
+              "help": "Organization label to search by",
+              "name": "label",
+              "shortname": null,
+              "value": "LABEL"
+            },
+            {
+              "help": "Organization name",
+              "name": "name",
+              "shortname": null,
+              "value": "NAME"
+            },
+            {
+              "help": "print help",
+              "name": "help",
+              "shortname": "h",
+              "value": null
+            }
+          ],
+          "subcommands": []
+        },
+        {
+          "description": "Show organization",
+          "name": "info",
+          "options": [
+            {
+              "help": "",
+              "name": "id",
+              "shortname": null,
+              "value": "ID"
+            },
+            {
+              "help": "Organization label to search by",
+              "name": "label",
+              "shortname": null,
+              "value": "LABEL"
+            },
+            {
+              "help": "Organization name",
+              "name": "name",
+              "shortname": null,
+              "value": "NAME"
+            },
+            {
+              "help": "print help",
+              "name": "help",
+              "shortname": "h",
+              "value": null
+            }
+          ],
+          "subcommands": []
+        },
+        {
+          "description": "List all organizations",
+          "name": "list",
+          "options": [
+            {
+              "help": "Field to sort the results on",
+              "name": "by",
+              "shortname": null,
+              "value": "BY"
+            },
+            {
+              "help": "Whether or not to show all results One of true/false, yes/no, 1/0.",
+              "name": "full-results",
+              "shortname": null,
+              "value": "FULL_RESULTS"
+            },
+            {
+              "help": "Sort field and order, eg. 'name DESC'",
+              "name": "order",
+              "shortname": null,
+              "value": "ORDER"
+            },
+            {
+              "help": "Page number, starting at 1",
+              "name": "page",
+              "shortname": null,
+              "value": "PAGE"
+            },
+            {
+              "help": "Number of results per page to return",
+              "name": "per-page",
+              "shortname": null,
+              "value": "PER_PAGE"
+            },
+            {
+              "help": "Search string",
+              "name": "search",
+              "shortname": null,
+              "value": "SEARCH"
+            },
+            {
+              "help": "print help",
+              "name": "help",
+              "shortname": "h",
+              "value": null
+            }
+          ],
+          "subcommands": []
+        },
+        {
+          "description": "Disassociate a compute resource",
+          "name": "remove-compute-resource",
+          "options": [
+            {
+              "help": "Compute resource name",
+              "name": "compute-resource",
+              "shortname": null,
+              "value": "COMPUTE_RESOURCE_NAME"
+            },
+            {
+              "help": "",
+              "name": "compute-resource-id",
+              "shortname": null,
+              "value": "COMPUTE_RESOURCE_ID"
+            },
+            {
+              "help": "organization ID",
+              "name": "id",
+              "shortname": null,
+              "value": "ID"
+            },
+            {
+              "help": "Organization name",
+              "name": "name",
+              "shortname": null,
+              "value": "NAME"
+            },
+            {
+              "help": "print help",
+              "name": "help",
+              "shortname": "h",
+              "value": null
+            }
+          ],
+          "subcommands": []
+        },
+        {
+          "description": "Disassociate a configuration template",
+          "name": "remove-config-template",
+          "options": [
+            {
+              "help": "Name to search by",
+              "name": "config-template",
+              "shortname": null,
+              "value": "CONFIG_TEMPLATE_NAME"
+            },
+            {
+              "help": "",
+              "name": "config-template-id",
+              "shortname": null,
+              "value": "CONFIG_TEMPLATE_ID"
+            },
+            {
+              "help": "organization ID",
+              "name": "id",
+              "shortname": null,
+              "value": "ID"
+            },
+            {
+              "help": "Organization name",
+              "name": "name",
+              "shortname": null,
+              "value": "NAME"
+            },
+            {
+              "help": "print help",
+              "name": "help",
+              "shortname": "h",
+              "value": null
+            }
+          ],
+          "subcommands": []
+        },
+        {
+          "description": "Disassociate a domain",
+          "name": "remove-domain",
+          "options": [
+            {
+              "help": "Domain name",
+              "name": "domain",
+              "shortname": null,
+              "value": "DOMAIN_NAME"
+            },
+            {
+              "help": "Numerical ID or domain name",
+              "name": "domain-id",
+              "shortname": null,
+              "value": "DOMAIN_ID"
+            },
+            {
+              "help": "organization ID",
+              "name": "id",
+              "shortname": null,
+              "value": "ID"
+            },
+            {
+              "help": "Organization name",
+              "name": "name",
+              "shortname": null,
+              "value": "NAME"
+            },
+            {
+              "help": "print help",
+              "name": "help",
+              "shortname": "h",
+              "value": null
+            }
+          ],
+          "subcommands": []
+        },
+        {
+          "description": "Disassociate an environment",
+          "name": "remove-environment",
+          "options": [
+            {
+              "help": "Environment name",
+              "name": "environment",
+              "shortname": null,
+              "value": "ENVIRONMENT_NAME"
+            },
+            {
+              "help": "",
+              "name": "environment-id",
+              "shortname": null,
+              "value": "ENVIRONMENT_ID"
+            },
+            {
+              "help": "organization ID",
+              "name": "id",
+              "shortname": null,
+              "value": "ID"
+            },
+            {
+              "help": "Organization name",
+              "name": "name",
+              "shortname": null,
+              "value": "NAME"
+            },
+            {
+              "help": "print help",
+              "name": "help",
+              "shortname": "h",
+              "value": null
+            }
+          ],
+          "subcommands": []
+        },
+        {
+          "description": "Disassociate a hostgroup",
+          "name": "remove-hostgroup",
+          "options": [
+            {
+              "help": "Hostgroup name",
+              "name": "hostgroup",
+              "shortname": null,
+              "value": "HOSTGROUP_NAME"
+            },
+            {
+              "help": "",
+              "name": "hostgroup-id",
+              "shortname": null,
+              "value": "HOSTGROUP_ID"
+            },
+            {
+              "help": "organization ID",
+              "name": "id",
+              "shortname": null,
+              "value": "ID"
+            },
+            {
+              "help": "Organization name",
+              "name": "name",
+              "shortname": null,
+              "value": "NAME"
+            },
+            {
+              "help": "print help",
+              "name": "help",
+              "shortname": "h",
+              "value": null
+            }
+          ],
+          "subcommands": []
+        },
+        {
+          "description": "Disassociate a medium",
+          "name": "remove-medium",
+          "options": [
+            {
+              "help": "organization ID",
+              "name": "id",
+              "shortname": null,
+              "value": "ID"
+            },
+            {
+              "help": "Medium name",
+              "name": "medium",
+              "shortname": null,
+              "value": "MEDIUM_NAME"
+            },
+            {
+              "help": "",
+              "name": "medium-id",
+              "shortname": null,
+              "value": "MEDIUM_ID"
+            },
+            {
+              "help": "Organization name",
+              "name": "name",
+              "shortname": null,
+              "value": "NAME"
+            },
+            {
+              "help": "print help",
+              "name": "help",
+              "shortname": "h",
+              "value": null
+            }
+          ],
+          "subcommands": []
+        },
+        {
+          "description": "Disassociate a smart proxy",
+          "name": "remove-smart-proxy",
+          "options": [
+            {
+              "help": "organization ID",
+              "name": "id",
+              "shortname": null,
+              "value": "ID"
+            },
+            {
+              "help": "Organization name",
+              "name": "name",
+              "shortname": null,
+              "value": "NAME"
+            },
+            {
+              "help": "Name to search by",
+              "name": "smart-proxy",
+              "shortname": null,
+              "value": "SMART_PROXY_NAME"
+            },
+            {
+              "help": "",
+              "name": "smart-proxy-id",
+              "shortname": null,
+              "value": "SMART_PROXY_ID"
+            },
+            {
+              "help": "print help",
+              "name": "help",
+              "shortname": "h",
+              "value": null
+            }
+          ],
+          "subcommands": []
+        },
+        {
+          "description": "Disassociate a subnet",
+          "name": "remove-subnet",
+          "options": [
+            {
+              "help": "organization ID",
+              "name": "id",
+              "shortname": null,
+              "value": "ID"
+            },
+            {
+              "help": "Organization name",
+              "name": "name",
+              "shortname": null,
+              "value": "NAME"
+            },
+            {
+              "help": "Subnet name",
+              "name": "subnet",
+              "shortname": null,
+              "value": "SUBNET_NAME"
+            },
+            {
+              "help": "",
+              "name": "subnet-id",
+              "shortname": null,
+              "value": "SUBNET_ID"
+            },
+            {
+              "help": "print help",
+              "name": "help",
+              "shortname": "h",
+              "value": null
+            }
+          ],
+          "subcommands": []
+        },
+        {
+          "description": "Disassociate an user",
+          "name": "remove-user",
+          "options": [
+            {
+              "help": "organization ID",
+              "name": "id",
+              "shortname": null,
+              "value": "ID"
+            },
+            {
+              "help": "Organization name",
+              "name": "name",
+              "shortname": null,
+              "value": "NAME"
+            },
+            {
+              "help": "User's login to search by",
+              "name": "user",
+              "shortname": null,
+              "value": "USER_LOGIN"
+            },
+            {
+              "help": "",
+              "name": "user-id",
+              "shortname": null,
+              "value": "USER_ID"
+            },
+            {
+              "help": "print help",
+              "name": "help",
+              "shortname": "h",
+              "value": null
+            }
+          ],
+          "subcommands": []
+        },
+        {
+          "description": "Update organization",
+          "name": "update",
+          "options": [
+            {
+              "help": "Compute resource IDs Comma separated list of values.",
+              "name": "compute-resource-ids",
+              "shortname": null,
+              "value": "COMPUTE_RESOURCE_IDS"
+            },
+            {
+              "help": "Comma separated list of values.",
+              "name": "compute-resources",
+              "shortname": null,
+              "value": "COMPUTE_RESOURCE_NAMES"
+            },
+            {
+              "help": "Provisioning template IDs Comma separated list of values.",
+              "name": "config-template-ids",
+              "shortname": null,
+              "value": "CONFIG_TEMPLATE_IDS"
+            },
+            {
+              "help": "Comma separated list of values.",
+              "name": "config-templates",
+              "shortname": null,
+              "value": "CONFIG_TEMPLATE_NAMES"
+            },
+            {
+              "help": "",
+              "name": "description",
+              "shortname": null,
+              "value": "DESCRIPTION"
+            },
+            {
+              "help": "Domain IDs Comma separated list of values.",
+              "name": "domain-ids",
+              "shortname": null,
+              "value": "DOMAIN_IDS"
+            },
+            {
+              "help": "Comma separated list of values.",
+              "name": "domains",
+              "shortname": null,
+              "value": "DOMAIN_NAMES"
+            },
+            {
+              "help": "Environment IDs Comma separated list of values.",
+              "name": "environment-ids",
+              "shortname": null,
+              "value": "ENVIRONMENT_IDS"
+            },
+            {
+              "help": "Comma separated list of values.",
+              "name": "environments",
+              "shortname": null,
+              "value": "ENVIRONMENT_NAMES"
+            },
+            {
+              "help": "Host group IDs Comma separated list of values.",
+              "name": "hostgroup-ids",
+              "shortname": null,
+              "value": "HOSTGROUP_IDS"
+            },
+            {
+              "help": "Comma separated list of values.",
+              "name": "hostgroups",
+              "shortname": null,
+              "value": "HOSTGROUP_NAMES"
+            },
+            {
+              "help": "",
+              "name": "id",
+              "shortname": null,
+              "value": "ID"
+            },
+            {
+              "help": "Organization label to search by",
+              "name": "label",
+              "shortname": null,
+              "value": "LABEL"
+            },
+            {
+              "help": "Comma separated list of values.",
+              "name": "media",
+              "shortname": null,
+              "value": "MEDIUM_NAMES"
+            },
+            {
+              "help": "Media IDs Comma separated list of values.",
+              "name": "media-ids",
+              "shortname": null,
+              "value": "MEDIA_IDS"
+            },
+            {
+              "help": "Organization name",
+              "name": "name",
+              "shortname": null,
+              "value": "NAME"
+            },
+            {
+              "help": "",
+              "name": "new-name",
+              "shortname": null,
+              "value": "NEW_NAME"
+            },
+            {
+              "help": "Realm IDs Comma separated list of values.",
+              "name": "realm-ids",
+              "shortname": null,
+              "value": "REALM_IDS"
+            },
+            {
+              "help": "Comma separated list of values.",
+              "name": "realms",
+              "shortname": null,
+              "value": "REALM_NAMES"
+            },
+            {
+              "help": "Red Hat Docker Registry URL",
+              "name": "redhat-docker-registry-url",
+              "shortname": null,
+              "value": "REDHAT_DOCKER_REGISTRY_URL"
+            },
+            {
+              "help": "Red Hat CDN URL",
+              "name": "redhat-repository-url",
+              "shortname": null,
+              "value": "REDHAT_REPOSITORY_URL"
+            },
+            {
+              "help": "Comma separated list of values.",
+              "name": "smart-proxies",
+              "shortname": null,
+              "value": "SMART_PROXY_NAMES"
+            },
+            {
+              "help": "Smart proxy IDs Comma separated list of values.",
+              "name": "smart-proxy-ids",
+              "shortname": null,
+              "value": "SMART_PROXY_IDS"
+            },
+            {
+              "help": "Subnet IDs Comma separated list of values.",
+              "name": "subnet-ids",
+              "shortname": null,
+              "value": "SUBNET_IDS"
+            },
+            {
+              "help": "Comma separated list of values.",
+              "name": "subnets",
+              "shortname": null,
+              "value": "SUBNET_NAMES"
+            },
+            {
+              "help": "User IDs Comma separated list of values.",
+              "name": "user-ids",
+              "shortname": null,
+              "value": "USER_IDS"
+            },
+            {
+              "help": "Comma separated list of values.",
+              "name": "users",
+              "shortname": null,
+              "value": "USER_LOGINS"
+            },
+            {
+              "help": "print help",
+              "name": "help",
+              "shortname": "h",
+              "value": null
+            }
+          ],
+          "subcommands": []
+        }
+      ]
+    },
+    {
+      "description": "Manipulate operating system.",
+      "name": "os",
+      "options": [
+        {
+          "help": "print help",
+          "name": "help",
+          "shortname": "h",
+          "value": null
+        }
+      ],
+      "subcommands": [
+        {
+          "description": "Associate an architecture",
+          "name": "add-architecture",
+          "options": [
+            {
+              "help": "Architecture name",
+              "name": "architecture",
+              "shortname": null,
+              "value": "ARCHITECTURE_NAME"
+            },
+            {
+              "help": "",
+              "name": "architecture-id",
+              "shortname": null,
+              "value": "ARCHITECTURE_ID"
+            },
+            {
+              "help": "",
+              "name": "id",
+              "shortname": null,
+              "value": "ID"
+            },
+            {
+              "help": "Operating system title",
+              "name": "title",
+              "shortname": null,
+              "value": "TITLE"
+            },
+            {
+              "help": "print help",
+              "name": "help",
+              "shortname": "h",
+              "value": null
+            }
+          ],
+          "subcommands": []
+        },
+        {
+          "description": "Associate a configuration template",
+          "name": "add-config-template",
+          "options": [
+            {
+              "help": "Name to search by",
+              "name": "config-template",
+              "shortname": null,
+              "value": "CONFIG_TEMPLATE_NAME"
+            },
+            {
+              "help": "",
+              "name": "config-template-id",
+              "shortname": null,
+              "value": "CONFIG_TEMPLATE_ID"
+            },
+            {
+              "help": "",
+              "name": "id",
+              "shortname": null,
+              "value": "ID"
+            },
+            {
+              "help": "Operating system title",
+              "name": "title",
+              "shortname": null,
+              "value": "TITLE"
+            },
+            {
+              "help": "print help",
+              "name": "help",
+              "shortname": "h",
+              "value": null
+            }
+          ],
+          "subcommands": []
+        },
+        {
+          "description": "Associate a partition table",
+          "name": "add-ptable",
+          "options": [
+            {
+              "help": "",
+              "name": "id",
+              "shortname": null,
+              "value": "ID"
+            },
+            {
+              "help": "Partition table name",
+              "name": "partition-table",
+              "shortname": null,
+              "value": "PARTITION_TABLE_NAME"
+            },
+            {
+              "help": "",
+              "name": "partition-table-id",
+              "shortname": null,
+              "value": "PARTITION_TABLE_ID"
+            },
+            {
+              "help": "Operating system title",
+              "name": "title",
+              "shortname": null,
+              "value": "TITLE"
+            },
+            {
+              "help": "print help",
+              "name": "help",
+              "shortname": "h",
+              "value": null
+            }
+          ],
+          "subcommands": []
+        },
+        {
+          "description": "Create an operating system",
+          "name": "create",
+          "options": [
+            {
+              "help": "",
+              "name": "description",
+              "shortname": null,
+              "value": "DESCRIPTION"
+            },
+            {
+              "help": "",
+              "name": "family",
+              "shortname": null,
+              "value": "FAMILY"
+            },
+            {
+              "help": "",
+              "name": "major",
+              "shortname": null,
+              "value": "MAJOR"
+            },
+            {
+              "help": "",
+              "name": "minor",
+              "shortname": null,
+              "value": "MINOR"
+            },
+            {
+              "help": "",
+              "name": "name",
+              "shortname": null,
+              "value": "NAME"
+            },
+            {
+              "help": "Root password hash function to use, one of MD5, SHA256, SHA512",
+              "name": "password-hash",
+              "shortname": null,
+              "value": "PASSWORD_HASH"
+            },
+            {
+              "help": "",
+              "name": "release-name",
+              "shortname": null,
+              "value": "RELEASE_NAME"
+            },
+            {
+              "help": "print help",
+              "name": "help",
+              "shortname": "h",
+              "value": null
+            }
+          ],
+          "subcommands": []
+        },
+        {
+          "description": "Delete an operating system",
+          "name": "delete",
+          "options": [
+            {
+              "help": "",
+              "name": "id",
+              "shortname": null,
+              "value": "ID"
+            },
+            {
+              "help": "Operating system title",
+              "name": "title",
+              "shortname": null,
+              "value": "TITLE"
+            },
+            {
+              "help": "print help",
+              "name": "help",
+              "shortname": "h",
+              "value": null
+            }
+          ],
+          "subcommands": []
+        },
+        {
+          "description": "",
+          "name": "delete-default-template",
+          "options": [
+            {
+              "help": "ID                    operatingsystem id",
+              "name": "id",
+              "shortname": null,
+              "value": "OS"
+            },
+            {
+              "help": "TYPE               Type of the config template",
+              "name": "type",
+              "shortname": null,
+              "value": "TPL"
+            },
+            {
+              "help": "print help",
+              "name": "help",
+              "shortname": "h",
+              "value": null
+            }
+          ],
+          "subcommands": []
+        },
+        {
+          "description": "Delete parameter for an operating system.",
+          "name": "delete-parameter",
+          "options": [
+            {
+              "help": "parameter name",
+              "name": "name",
+              "shortname": null,
+              "value": "NAME"
+            },
+            {
+              "help": "Operating system title",
+              "name": "operatingsystem",
+              "shortname": null,
+              "value": "OPERATINGSYSTEM_TITLE"
+            },
+            {
+              "help": "",
+              "name": "operatingsystem-id",
+              "shortname": null,
+              "value": "OPERATINGSYSTEM_ID"
+            },
+            {
+              "help": "print help",
+              "name": "help",
+              "shortname": "h",
+              "value": null
+            }
+          ],
+          "subcommands": []
+        },
+        {
+          "description": "Show an operating system",
+          "name": "info",
+          "options": [
+            {
+              "help": "",
+              "name": "id",
+              "shortname": null,
+              "value": "ID"
+            },
+            {
+              "help": "Operating system title",
+              "name": "title",
+              "shortname": null,
+              "value": "TITLE"
+            },
+            {
+              "help": "print help",
+              "name": "help",
+              "shortname": "h",
+              "value": null
+            }
+          ],
+          "subcommands": []
+        },
+        {
+          "description": "List all operating systems",
+          "name": "list",
+          "options": [
+            {
+              "help": "Architecture name",
+              "name": "architecture",
+              "shortname": null,
+              "value": "ARCHITECTURE_NAME"
+            },
+            {
+              "help": "",
+              "name": "architecture-id",
+              "shortname": null,
+              "value": "ARCHITECTURE_ID"
+            },
+            {
+              "help": "Name to search by",
+              "name": "config-template",
+              "shortname": null,
+              "value": "CONFIG_TEMPLATE_NAME"
+            },
+            {
+              "help": "",
+              "name": "config-template-id",
+              "shortname": null,
+              "value": "CONFIG_TEMPLATE_ID"
+            },
+            {
+              "help": "Medium name",
+              "name": "medium",
+              "shortname": null,
+              "value": "MEDIUM_NAME"
+            },
+            {
+              "help": "",
+              "name": "medium-id",
+              "shortname": null,
+              "value": "MEDIUM_ID"
+            },
+            {
+              "help": "sort results",
+              "name": "order",
+              "shortname": null,
+              "value": "ORDER"
+            },
+            {
+              "help": "paginate results",
+              "name": "page",
+              "shortname": null,
+              "value": "PAGE"
+            },
+            {
+              "help": "Partition table name",
+              "name": "partition-table",
+              "shortname": null,
+              "value": "PARTITION_TABLE_NAME"
+            },
+            {
+              "help": "",
+              "name": "partition-table-id",
+              "shortname": null,
+              "value": "PARTITION_TABLE_ID"
+            },
+            {
+              "help": "number of entries per request",
+              "name": "per-page",
+              "shortname": null,
+              "value": "PER_PAGE"
+            },
+            {
+              "help": "filter results",
+              "name": "search",
+              "shortname": null,
+              "value": "SEARCH"
+            },
+            {
+              "help": "print help",
+              "name": "help",
+              "shortname": "h",
+              "value": null
+            }
+          ],
+          "subcommands": []
+        },
+        {
+          "description": "Disassociate an architecture",
+          "name": "remove-architecture",
+          "options": [
+            {
+              "help": "Architecture name",
+              "name": "architecture",
+              "shortname": null,
+              "value": "ARCHITECTURE_NAME"
+            },
+            {
+              "help": "",
+              "name": "architecture-id",
+              "shortname": null,
+              "value": "ARCHITECTURE_ID"
+            },
+            {
+              "help": "",
+              "name": "id",
+              "shortname": null,
+              "value": "ID"
+            },
+            {
+              "help": "Operating system title",
+              "name": "title",
+              "shortname": null,
+              "value": "TITLE"
+            },
+            {
+              "help": "print help",
+              "name": "help",
+              "shortname": "h",
+              "value": null
+            }
+          ],
+          "subcommands": []
+        },
+        {
+          "description": "Disassociate a configuration template",
+          "name": "remove-config-template",
+          "options": [
+            {
+              "help": "Name to search by",
+              "name": "config-template",
+              "shortname": null,
+              "value": "CONFIG_TEMPLATE_NAME"
+            },
+            {
+              "help": "",
+              "name": "config-template-id",
+              "shortname": null,
+              "value": "CONFIG_TEMPLATE_ID"
+            },
+            {
+              "help": "",
+              "name": "id",
+              "shortname": null,
+              "value": "ID"
+            },
+            {
+              "help": "Operating system title",
+              "name": "title",
+              "shortname": null,
+              "value": "TITLE"
+            },
+            {
+              "help": "print help",
+              "name": "help",
+              "shortname": "h",
+              "value": null
+            }
+          ],
+          "subcommands": []
+        },
+        {
+          "description": "Disassociate a partition table",
+          "name": "remove-ptable",
+          "options": [
+            {
+              "help": "",
+              "name": "id",
+              "shortname": null,
+              "value": "ID"
+            },
+            {
+              "help": "Partition table name",
+              "name": "partition-table",
+              "shortname": null,
+              "value": "PARTITION_TABLE_NAME"
+            },
+            {
+              "help": "",
+              "name": "partition-table-id",
+              "shortname": null,
+              "value": "PARTITION_TABLE_ID"
+            },
+            {
+              "help": "Operating system title",
+              "name": "title",
+              "shortname": null,
+              "value": "TITLE"
+            },
+            {
+              "help": "print help",
+              "name": "help",
+              "shortname": "h",
+              "value": null
+            }
+          ],
+          "subcommands": []
+        },
+        {
+          "description": "",
+          "name": "set-default-template",
+          "options": [
+            {
+              "help": "ID   config template id to be set",
+              "name": "config-template-id",
+              "shortname": null,
+              "value": "TPL"
+            },
+            {
+              "help": "ID                    operatingsystem id",
+              "name": "id",
+              "shortname": null,
+              "value": "OS"
+            },
+            {
+              "help": "print help",
+              "name": "help",
+              "shortname": "h",
+              "value": null
+            }
+          ],
+          "subcommands": []
+        },
+        {
+          "description": "Create or update parameter for an operating system.",
+          "name": "set-parameter",
+          "options": [
+            {
+              "help": "parameter name",
+              "name": "name",
+              "shortname": null,
+              "value": "NAME"
+            },
+            {
+              "help": "Operating system title",
+              "name": "operatingsystem",
+              "shortname": null,
+              "value": "OPERATINGSYSTEM_TITLE"
+            },
+            {
+              "help": "",
+              "name": "operatingsystem-id",
+              "shortname": null,
+              "value": "OPERATINGSYSTEM_ID"
+            },
+            {
+              "help": "parameter value",
+              "name": "value",
+              "shortname": null,
+              "value": "VALUE"
+            },
+            {
+              "help": "print help",
+              "name": "help",
+              "shortname": "h",
+              "value": null
+            }
+          ],
+          "subcommands": []
+        },
+        {
+          "description": "Update an operating system",
+          "name": "update",
+          "options": [
+            {
+              "help": "",
+              "name": "description",
+              "shortname": null,
+              "value": "DESCRIPTION"
+            },
+            {
+              "help": "",
+              "name": "family",
+              "shortname": null,
+              "value": "FAMILY"
+            },
+            {
+              "help": "",
+              "name": "id",
+              "shortname": null,
+              "value": "ID"
+            },
+            {
+              "help": "",
+              "name": "major",
+              "shortname": null,
+              "value": "MAJOR"
+            },
+            {
+              "help": "",
+              "name": "minor",
+              "shortname": null,
+              "value": "MINOR"
+            },
+            {
+              "help": "",
+              "name": "name",
+              "shortname": null,
+              "value": "NAME"
+            },
+            {
+              "help": "Root password hash function to use, one of MD5, SHA256, SHA512",
+              "name": "password-hash",
+              "shortname": null,
+              "value": "PASSWORD_HASH"
+            },
+            {
+              "help": "",
+              "name": "release-name",
+              "shortname": null,
+              "value": "RELEASE_NAME"
+            },
+            {
+              "help": "Operating system title",
+              "name": "title",
+              "shortname": null,
+              "value": "TITLE"
+            },
+            {
+              "help": "print help",
+              "name": "help",
+              "shortname": "h",
+              "value": null
+            }
+          ],
+          "subcommands": []
+        }
+      ]
+    },
+    {
+      "description": "Manipulate packages.",
+      "name": "package",
+      "options": [
+        {
+          "help": "print help",
+          "name": "help",
+          "shortname": "h",
+          "value": null
+        }
+      ],
+      "subcommands": [
+        {
+          "description": "Show a package",
+          "name": "info",
+          "options": [
+            {
+              "help": "a package identifier",
+              "name": "id",
+              "shortname": null,
+              "value": "ID"
+            },
+            {
+              "help": "Name to search by",
+              "name": "name",
+              "shortname": null,
+              "value": "NAME"
+            },
+            {
+              "help": "Repository name to search by",
+              "name": "repository",
+              "shortname": null,
+              "value": "REPOSITORY_NAME"
+            },
+            {
+              "help": "repository ID",
+              "name": "repository-id",
+              "shortname": null,
+              "value": "REPOSITORY_ID"
+            },
+            {
+              "help": "print help",
+              "name": "help",
+              "shortname": "h",
+              "value": null
+            }
+          ],
+          "subcommands": []
+        },
+        {
+          "description": "List packages",
+          "name": "list",
+          "options": [
+            {
+              "help": "Field to sort the results on",
+              "name": "by",
+              "shortname": null,
+              "value": "BY"
+            },
+            {
+              "help": "Content view name",
+              "name": "content-view",
+              "shortname": null,
+              "value": "CONTENT_VIEW_NAME"
+            },
+            {
+              "help": "content view numeric identifier",
+              "name": "content-view-id",
+              "shortname": null,
+              "value": "CONTENT_VIEW_ID"
+            },
+            {
+              "help": "Content view version number",
+              "name": "content-view-version",
+              "shortname": null,
+              "value": "CONTENT_VIEW_VERSION_VERSION"
+            },
+            {
+              "help": "Content view version identifier",
+              "name": "content-view-version-id",
+              "shortname": null,
+              "value": "CONTENT_VIEW_VERSION_ID"
+            },
+            {
+              "help": "Whether or not to show all results One of true/false, yes/no, 1/0.",
+              "name": "full-results",
+              "shortname": null,
+              "value": "FULL_RESULTS"
+            },
+            {
+              "help": "Sort field and order, eg. 'name DESC'",
+              "name": "order",
+              "shortname": null,
+              "value": "ORDER"
+            },
+            {
+              "help": "Organization name to search by",
+              "name": "organization",
+              "shortname": null,
+              "value": "ORGANIZATION_NAME"
+            },
+            {
+              "help": "organization ID",
+              "name": "organization-id",
+              "shortname": null,
+              "value": "ORGANIZATION_ID"
+            },
+            {
+              "help": "Organization label to search by",
+              "name": "organization-label",
+              "shortname": null,
+              "value": "ORGANIZATION_LABEL"
+            },
+            {
+              "help": "Page number, starting at 1",
+              "name": "page",
+              "shortname": null,
+              "value": "PAGE"
+            },
+            {
+              "help": "Number of results per page to return",
+              "name": "per-page",
+              "shortname": null,
+              "value": "PER_PAGE"
+            },
+            {
+              "help": "Product name to search by",
+              "name": "product",
+              "shortname": null,
+              "value": "PRODUCT_NAME"
+            },
+            {
+              "help": "product numeric identifier",
+              "name": "product-id",
+              "shortname": null,
+              "value": "PRODUCT_ID"
+            },
+            {
+              "help": "Repository name to search by",
+              "name": "repository",
+              "shortname": null,
+              "value": "REPOSITORY_NAME"
+            },
+            {
+              "help": "repository ID",
+              "name": "repository-id",
+              "shortname": null,
+              "value": "REPOSITORY_ID"
+            },
+            {
+              "help": "Search string",
+              "name": "search",
+              "shortname": null,
+              "value": "SEARCH"
+            },
+            {
+              "help": "print help",
+              "name": "help",
+              "shortname": "h",
+              "value": null
+            }
+          ],
+          "subcommands": []
+        }
+      ]
+    },
+    {
+      "description": "Manipulate package groups",
+      "name": "package-group",
+      "options": [
+        {
+          "help": "print help",
+          "name": "help",
+          "shortname": "h",
+          "value": null
+        }
+      ],
+      "subcommands": [
+        {
+          "description": "Show a package group",
+          "name": "info",
+          "options": [
+            {
+              "help": "a package group identifier",
+              "name": "id",
+              "shortname": null,
+              "value": "ID"
+            },
+            {
+              "help": "Name to search by",
+              "name": "name",
+              "shortname": null,
+              "value": "NAME"
+            },
+            {
+              "help": "Repository name to search by",
+              "name": "repository",
+              "shortname": null,
+              "value": "REPOSITORY_NAME"
+            },
+            {
+              "help": "repository ID",
+              "name": "repository-id",
+              "shortname": null,
+              "value": "REPOSITORY_ID"
+            },
+            {
+              "help": "print help",
+              "name": "help",
+              "shortname": "h",
+              "value": null
+            }
+          ],
+          "subcommands": []
+        },
+        {
+          "description": "List package_groups",
+          "name": "list",
+          "options": [
+            {
+              "help": "Field to sort the results on",
+              "name": "by",
+              "shortname": null,
+              "value": "BY"
+            },
+            {
+              "help": "Content view name",
+              "name": "content-view",
+              "shortname": null,
+              "value": "CONTENT_VIEW_NAME"
+            },
+            {
+              "help": "Name to search by",
+              "name": "content-view-filter",
+              "shortname": null,
+              "value": "CONTENT_VIEW_FILTER_NAME"
+            },
+            {
+              "help": "filter identifier",
+              "name": "content-view-filter-id",
+              "shortname": null,
+              "value": "CONTENT_VIEW_FILTER_ID"
+            },
+            {
+              "help": "content view numeric identifier",
+              "name": "content-view-id",
+              "shortname": null,
+              "value": "CONTENT_VIEW_ID"
+            },
+            {
+              "help": "Content view version number",
+              "name": "content-view-version",
+              "shortname": null,
+              "value": "CONTENT_VIEW_VERSION_VERSION"
+            },
+            {
+              "help": "Content view version identifier",
+              "name": "content-view-version-id",
+              "shortname": null,
+              "value": "CONTENT_VIEW_VERSION_ID"
+            },
+            {
+              "help": "Name to search by",
+              "name": "environment",
+              "shortname": null,
+              "value": "ENVIRONMENT_NAME"
+            },
+            {
+              "help": "",
+              "name": "environment-id",
+              "shortname": null,
+              "value": "ENVIRONMENT_ID"
+            },
+            {
+              "help": "Whether or not to show all results One of true/false, yes/no, 1/0.",
+              "name": "full-results",
+              "shortname": null,
+              "value": "FULL_RESULTS"
+            },
+            {
+              "help": "ids to filter content by Comma separated list of values.",
+              "name": "ids",
+              "shortname": null,
+              "value": "IDS"
+            },
+            {
+              "help": "Sort field and order, eg. 'name DESC'",
+              "name": "order",
+              "shortname": null,
+              "value": "ORDER"
+            },
+            {
+              "help": "Organization name to search by",
+              "name": "organization",
+              "shortname": null,
+              "value": "ORGANIZATION_NAME"
+            },
+            {
+              "help": "organization ID",
+              "name": "organization-id",
+              "shortname": null,
+              "value": "ORGANIZATION_ID"
+            },
+            {
+              "help": "Organization label to search by",
+              "name": "organization-label",
+              "shortname": null,
+              "value": "ORGANIZATION_LABEL"
+            },
+            {
+              "help": "Page number, starting at 1",
+              "name": "page",
+              "shortname": null,
+              "value": "PAGE"
+            },
+            {
+              "help": "Number of results per page to return",
+              "name": "per-page",
+              "shortname": null,
+              "value": "PER_PAGE"
+            },
+            {
+              "help": "Product name to search by",
+              "name": "product",
+              "shortname": null,
+              "value": "PRODUCT_NAME"
+            },
+            {
+              "help": "product numeric identifier",
+              "name": "product-id",
+              "shortname": null,
+              "value": "PRODUCT_ID"
+            },
+            {
+              "help": "Repository name to search by",
+              "name": "repository",
+              "shortname": null,
+              "value": "REPOSITORY_NAME"
+            },
+            {
+              "help": "repository ID",
+              "name": "repository-id",
+              "shortname": null,
+              "value": "REPOSITORY_ID"
+            },
+            {
+              "help": "Search string",
+              "name": "search",
+              "shortname": null,
+              "value": "SEARCH"
+            },
+            {
+              "help": "print help",
+              "name": "help",
+              "shortname": "h",
+              "value": null
+            }
+          ],
+          "subcommands": []
+        }
+      ]
+    },
+    {
+      "description": "Manipulate partition tables.",
+      "name": "partition-table",
+      "options": [
+        {
+          "help": "print help",
+          "name": "help",
+          "shortname": "h",
+          "value": null
+        }
+      ],
+      "subcommands": [
+        {
+          "description": "Associate an operating system",
+          "name": "add-operatingsystem",
+          "options": [
+            {
+              "help": "",
+              "name": "id",
+              "shortname": null,
+              "value": "ID"
+            },
+            {
+              "help": "Partition table name",
+              "name": "name",
+              "shortname": null,
+              "value": "NAME"
+            },
+            {
+              "help": "Operating system title",
+              "name": "operatingsystem",
+              "shortname": null,
+              "value": "OPERATINGSYSTEM_TITLE"
+            },
+            {
+              "help": "",
+              "name": "operatingsystem-id",
+              "shortname": null,
+              "value": "OPERATINGSYSTEM_ID"
+            },
+            {
+              "help": "print help",
+              "name": "help",
+              "shortname": "h",
+              "value": null
+            }
+          ],
+          "subcommands": []
+        },
+        {
+          "description": "Create a partition table",
+          "name": "create",
+          "options": [
+            {
+              "help": "Path to a file that contains the partition layout",
+              "name": "file",
+              "shortname": null,
+              "value": "LAYOUT"
+            },
+            {
+              "help": "",
+              "name": "name",
+              "shortname": null,
+              "value": "NAME"
+            },
+            {
+              "help": "",
+              "name": "os-family",
+              "shortname": null,
+              "value": "OS_FAMILY"
+            },
+            {
+              "help": "print help",
+              "name": "help",
+              "shortname": "h",
+              "value": null
+            }
+          ],
+          "subcommands": []
+        },
+        {
+          "description": "Delete a partition table",
+          "name": "delete",
+          "options": [
+            {
+              "help": "",
+              "name": "id",
+              "shortname": null,
+              "value": "ID"
+            },
+            {
+              "help": "Partition table name",
+              "name": "name",
+              "shortname": null,
+              "value": "NAME"
+            },
+            {
+              "help": "print help",
+              "name": "help",
+              "shortname": "h",
+              "value": null
+            }
+          ],
+          "subcommands": []
+        },
+        {
+          "description": "View partition table content.",
+          "name": "dump",
+          "options": [
+            {
+              "help": "",
+              "name": "id",
+              "shortname": null,
+              "value": "ID"
+            },
+            {
+              "help": "Partition table name",
+              "name": "name",
+              "shortname": null,
+              "value": "NAME"
+            },
+            {
+              "help": "print help",
+              "name": "help",
+              "shortname": "h",
+              "value": null
+            }
+          ],
+          "subcommands": []
+        },
+        {
+          "description": "Show a partition table",
+          "name": "info",
+          "options": [
+            {
+              "help": "",
+              "name": "id",
+              "shortname": null,
+              "value": "ID"
+            },
+            {
+              "help": "Partition table name",
+              "name": "name",
+              "shortname": null,
+              "value": "NAME"
+            },
+            {
+              "help": "print help",
+              "name": "help",
+              "shortname": "h",
+              "value": null
+            }
+          ],
+          "subcommands": []
+        },
+        {
+          "description": "List all partition tables",
+          "name": "list",
+          "options": [
+            {
+              "help": "Operating system title",
+              "name": "operatingsystem",
+              "shortname": null,
+              "value": "OPERATINGSYSTEM_TITLE"
+            },
+            {
+              "help": "",
+              "name": "operatingsystem-id",
+              "shortname": null,
+              "value": "OPERATINGSYSTEM_ID"
+            },
+            {
+              "help": "sort results",
+              "name": "order",
+              "shortname": null,
+              "value": "ORDER"
+            },
+            {
+              "help": "paginate results",
+              "name": "page",
+              "shortname": null,
+              "value": "PAGE"
+            },
+            {
+              "help": "number of entries per request",
+              "name": "per-page",
+              "shortname": null,
+              "value": "PER_PAGE"
+            },
+            {
+              "help": "filter results",
+              "name": "search",
+              "shortname": null,
+              "value": "SEARCH"
+            },
+            {
+              "help": "print help",
+              "name": "help",
+              "shortname": "h",
+              "value": null
+            }
+          ],
+          "subcommands": []
+        },
+        {
+          "description": "Disassociate an operating system",
+          "name": "remove-operatingsystem",
+          "options": [
+            {
+              "help": "",
+              "name": "id",
+              "shortname": null,
+              "value": "ID"
+            },
+            {
+              "help": "Partition table name",
+              "name": "name",
+              "shortname": null,
+              "value": "NAME"
+            },
+            {
+              "help": "Operating system title",
+              "name": "operatingsystem",
+              "shortname": null,
+              "value": "OPERATINGSYSTEM_TITLE"
+            },
+            {
+              "help": "",
+              "name": "operatingsystem-id",
+              "shortname": null,
+              "value": "OPERATINGSYSTEM_ID"
+            },
+            {
+              "help": "print help",
+              "name": "help",
+              "shortname": "h",
+              "value": null
+            }
+          ],
+          "subcommands": []
+        },
+        {
+          "description": "Update a partition table",
+          "name": "update",
+          "options": [
+            {
+              "help": "Path to a file that contains the partition layout",
+              "name": "file",
+              "shortname": null,
+              "value": "LAYOUT"
+            },
+            {
+              "help": "",
+              "name": "id",
+              "shortname": null,
+              "value": "ID"
+            },
+            {
+              "help": "Partition table name",
+              "name": "name",
+              "shortname": null,
+              "value": "NAME"
+            },
+            {
+              "help": "",
+              "name": "new-name",
+              "shortname": null,
+              "value": "NEW_NAME"
+            },
+            {
+              "help": "",
+              "name": "os-family",
+              "shortname": null,
+              "value": "OS_FAMILY"
+            },
+            {
+              "help": "print help",
+              "name": "help",
+              "shortname": "h",
+              "value": null
+            }
+          ],
+          "subcommands": []
+        }
+      ]
+    },
+    {
+      "description": "Get the status of the server",
+      "name": "ping",
+      "options": [
+        {
+          "help": "print help",
+          "name": "help",
+          "shortname": "h",
+          "value": null
+        }
+      ],
+      "subcommands": []
+    },
+    {
+      "description": "Manipulate products.",
+      "name": "product",
+      "options": [
+        {
+          "help": "print help",
+          "name": "help",
+          "shortname": "h",
+          "value": null
+        }
+      ],
+      "subcommands": [
+        {
+          "description": "Create a product",
+          "name": "create",
+          "options": [
+            {
+              "help": "Product description",
+              "name": "description",
+              "shortname": null,
+              "value": "DESCRIPTION"
+            },
+            {
+              "help": "Name to search by",
+              "name": "gpg-key",
+              "shortname": null,
+              "value": "GPG_KEY_NAME"
+            },
+            {
+              "help": "gpg key numeric identifier",
+              "name": "gpg-key-id",
+              "shortname": null,
+              "value": "GPG_KEY_ID"
+            },
+            {
+              "help": "",
+              "name": "label",
+              "shortname": null,
+              "value": "LABEL"
+            },
+            {
+              "help": "Product name",
+              "name": "name",
+              "shortname": null,
+              "value": "NAME"
+            },
+            {
+              "help": "Organization name to search by",
+              "name": "organization",
+              "shortname": null,
+              "value": "ORGANIZATION_NAME"
+            },
+            {
+              "help": "organization ID",
+              "name": "organization-id",
+              "shortname": null,
+              "value": "ORGANIZATION_ID"
+            },
+            {
+              "help": "Organization label to search by",
+              "name": "organization-label",
+              "shortname": null,
+              "value": "ORGANIZATION_LABEL"
+            },
+            {
+              "help": "Sync plan name to search by",
+              "name": "sync-plan",
+              "shortname": null,
+              "value": "SYNC_PLAN_NAME"
+            },
+            {
+              "help": "sync plan numeric identifier",
+              "name": "sync-plan-id",
+              "shortname": null,
+              "value": "SYNC_PLAN_ID"
+            },
+            {
+              "help": "print help",
+              "name": "help",
+              "shortname": "h",
+              "value": null
+            }
+          ],
+          "subcommands": []
+        },
+        {
+          "description": "Destroy a product",
+          "name": "delete",
+          "options": [
+            {
+              "help": "product numeric identifier",
+              "name": "id",
+              "shortname": null,
+              "value": "ID"
+            },
+            {
+              "help": "Product name to search by",
+              "name": "name",
+              "shortname": null,
+              "value": "NAME"
+            },
+            {
+              "help": "Organization name to search by",
+              "name": "organization",
+              "shortname": null,
+              "value": "ORGANIZATION_NAME"
+            },
+            {
+              "help": "organization ID",
+              "name": "organization-id",
+              "shortname": null,
+              "value": "ORGANIZATION_ID"
+            },
+            {
+              "help": "Organization label to search by",
+              "name": "organization-label",
+              "shortname": null,
+              "value": "ORGANIZATION_LABEL"
+            },
+            {
+              "help": "print help",
+              "name": "help",
+              "shortname": "h",
+              "value": null
+            }
+          ],
+          "subcommands": []
+        },
+        {
+          "description": "Show a product",
+          "name": "info",
+          "options": [
+            {
+              "help": "product numeric identifier",
+              "name": "id",
+              "shortname": null,
+              "value": "ID"
+            },
+            {
+              "help": "Product name to search by",
+              "name": "name",
+              "shortname": null,
+              "value": "NAME"
+            },
+            {
+              "help": "Organization name to search by",
+              "name": "organization",
+              "shortname": null,
+              "value": "ORGANIZATION_NAME"
+            },
+            {
+              "help": "organization ID",
+              "name": "organization-id",
+              "shortname": null,
+              "value": "ORGANIZATION_ID"
+            },
+            {
+              "help": "Organization label to search by",
+              "name": "organization-label",
+              "shortname": null,
+              "value": "ORGANIZATION_LABEL"
+            },
+            {
+              "help": "print help",
+              "name": "help",
+              "shortname": "h",
+              "value": null
+            }
+          ],
+          "subcommands": []
+        },
+        {
+          "description": "List products",
+          "name": "list",
+          "options": [
+            {
+              "help": "Field to sort the results on",
+              "name": "by",
+              "shortname": null,
+              "value": "BY"
+            },
+            {
+              "help": "Filter products by custom One of true/false, yes/no, 1/0.",
+              "name": "custom",
+              "shortname": null,
+              "value": "CUSTOM"
+            },
+            {
+              "help": "Filter products by enabled or disabled One of true/false, yes/no, 1/0.",
+              "name": "enabled",
+              "shortname": null,
+              "value": "ENABLED"
+            },
+            {
+              "help": "Whether or not to show all results One of true/false, yes/no, 1/0.",
+              "name": "full-results",
+              "shortname": null,
+              "value": "FULL_RESULTS"
+            },
+            {
+              "help": "Filter products by name",
+              "name": "name",
+              "shortname": null,
+              "value": "NAME"
+            },
+            {
+              "help": "Sort field and order, eg. 'name DESC'",
+              "name": "order",
+              "shortname": null,
+              "value": "ORDER"
+            },
+            {
+              "help": "Organization name to search by",
+              "name": "organization",
+              "shortname": null,
+              "value": "ORGANIZATION_NAME"
+            },
+            {
+              "help": "organization ID",
+              "name": "organization-id",
+              "shortname": null,
+              "value": "ORGANIZATION_ID"
+            },
+            {
+              "help": "Organization label to search by",
+              "name": "organization-label",
+              "shortname": null,
+              "value": "ORGANIZATION_LABEL"
+            },
+            {
+              "help": "Page number, starting at 1",
+              "name": "page",
+              "shortname": null,
+              "value": "PAGE"
+            },
+            {
+              "help": "Number of results per page to return",
+              "name": "per-page",
+              "shortname": null,
+              "value": "PER_PAGE"
+            },
+            {
+              "help": "Search string",
+              "name": "search",
+              "shortname": null,
+              "value": "SEARCH"
+            },
+            {
+              "help": "Subscription name to search by",
+              "name": "subscription",
+              "shortname": null,
+              "value": "SUBSCRIPTION_NAME"
+            },
+            {
+              "help": "Subscription identifier",
+              "name": "subscription-id",
+              "shortname": null,
+              "value": "SUBSCRIPTION_ID"
+            },
+            {
+              "help": "print help",
+              "name": "help",
+              "shortname": "h",
+              "value": null
+            }
+          ],
+          "subcommands": []
+        },
+        {
+          "description": "Delete assignment sync plan and product.",
+          "name": "remove-sync-plan",
+          "options": [
+            {
+              "help": "Product description",
+              "name": "description",
+              "shortname": null,
+              "value": "DESCRIPTION"
+            },
+            {
+              "help": "Name to search by",
+              "name": "gpg-key",
+              "shortname": null,
+              "value": "GPG_KEY_NAME"
+            },
+            {
+              "help": "gpg key numeric identifier",
+              "name": "gpg-key-id",
+              "shortname": null,
+              "value": "GPG_KEY_ID"
+            },
+            {
+              "help": "product numeric identifier",
+              "name": "id",
+              "shortname": null,
+              "value": "ID"
+            },
+            {
+              "help": "Product name to search by",
+              "name": "name",
+              "shortname": null,
+              "value": "NAME"
+            },
+            {
+              "help": "Product name",
+              "name": "new-name",
+              "shortname": null,
+              "value": "NEW_NAME"
+            },
+            {
+              "help": "Organization name to search by",
+              "name": "organization",
+              "shortname": null,
+              "value": "ORGANIZATION_NAME"
+            },
+            {
+              "help": "organization ID",
+              "name": "organization-id",
+              "shortname": null,
+              "value": "ORGANIZATION_ID"
+            },
+            {
+              "help": "Organization label to search by",
+              "name": "organization-label",
+              "shortname": null,
+              "value": "ORGANIZATION_LABEL"
+            },
+            {
+              "help": "print help",
+              "name": "help",
+              "shortname": "h",
+              "value": null
+            }
+          ],
+          "subcommands": []
+        },
+        {
+          "description": "Assign sync plan to product.",
+          "name": "set-sync-plan",
+          "options": [
+            {
+              "help": "Name to search by",
+              "name": "gpg-key",
+              "shortname": null,
+              "value": "GPG_KEY_NAME"
+            },
+            {
+              "help": "gpg key numeric identifier",
+              "name": "gpg-key-id",
+              "shortname": null,
+              "value": "GPG_KEY_ID"
+            },
+            {
+              "help": "product numeric identifier",
+              "name": "id",
+              "shortname": null,
+              "value": "ID"
+            },
+            {
+              "help": "Product name to search by",
+              "name": "name",
+              "shortname": null,
+              "value": "NAME"
+            },
+            {
+              "help": "Product name",
+              "name": "new-name",
+              "shortname": null,
+              "value": "NEW_NAME"
+            },
+            {
+              "help": "Organization name to search by",
+              "name": "organization",
+              "shortname": null,
+              "value": "ORGANIZATION_NAME"
+            },
+            {
+              "help": "organization ID",
+              "name": "organization-id",
+              "shortname": null,
+              "value": "ORGANIZATION_ID"
+            },
+            {
+              "help": "Organization label to search by",
+              "name": "organization-label",
+              "shortname": null,
+              "value": "ORGANIZATION_LABEL"
+            },
+            {
+              "help": "Sync plan name to search by",
+              "name": "sync-plan",
+              "shortname": null,
+              "value": "SYNC_PLAN_NAME"
+            },
+            {
+              "help": "sync plan numeric identifier",
+              "name": "sync-plan-id",
+              "shortname": null,
+              "value": "SYNC_PLAN_ID"
+            },
+            {
+              "help": "print help",
+              "name": "help",
+              "shortname": "h",
+              "value": null
+            }
+          ],
+          "subcommands": []
+        },
+        {
+          "description": "Sync a repository",
+          "name": "synchronize",
+          "options": [
+            {
+              "help": "Do not wait for the task",
+              "name": "async",
+              "shortname": null,
+              "value": null
+            },
+            {
+              "help": "product ID",
+              "name": "id",
+              "shortname": null,
+              "value": "ID"
+            },
+            {
+              "help": "Product name to search by",
+              "name": "name",
+              "shortname": null,
+              "value": "NAME"
+            },
+            {
+              "help": "Organization name to search by",
+              "name": "organization",
+              "shortname": null,
+              "value": "ORGANIZATION_NAME"
+            },
+            {
+              "help": "organization ID",
+              "name": "organization-id",
+              "shortname": null,
+              "value": "ORGANIZATION_ID"
+            },
+            {
+              "help": "Organization label to search by",
+              "name": "organization-label",
+              "shortname": null,
+              "value": "ORGANIZATION_LABEL"
+            },
+            {
+              "help": "print help",
+              "name": "help",
+              "shortname": "h",
+              "value": null
+            }
+          ],
+          "subcommands": []
+        },
+        {
+          "description": "Updates a product",
+          "name": "update",
+          "options": [
+            {
+              "help": "Product description",
+              "name": "description",
+              "shortname": null,
+              "value": "DESCRIPTION"
+            },
+            {
+              "help": "Name to search by",
+              "name": "gpg-key",
+              "shortname": null,
+              "value": "GPG_KEY_NAME"
+            },
+            {
+              "help": "gpg key numeric identifier",
+              "name": "gpg-key-id",
+              "shortname": null,
+              "value": "GPG_KEY_ID"
+            },
+            {
+              "help": "product numeric identifier",
+              "name": "id",
+              "shortname": null,
+              "value": "ID"
+            },
+            {
+              "help": "Product name to search by",
+              "name": "name",
+              "shortname": null,
+              "value": "NAME"
+            },
+            {
+              "help": "Product name",
+              "name": "new-name",
+              "shortname": null,
+              "value": "NEW_NAME"
+            },
+            {
+              "help": "Organization name to search by",
+              "name": "organization",
+              "shortname": null,
+              "value": "ORGANIZATION_NAME"
+            },
+            {
+              "help": "organization ID",
+              "name": "organization-id",
+              "shortname": null,
+              "value": "ORGANIZATION_ID"
+            },
+            {
+              "help": "Organization label to search by",
+              "name": "organization-label",
+              "shortname": null,
+              "value": "ORGANIZATION_LABEL"
+            },
+            {
+              "help": "Sync plan name to search by",
+              "name": "sync-plan",
+              "shortname": null,
+              "value": "SYNC_PLAN_NAME"
+            },
+            {
+              "help": "sync plan numeric identifier",
+              "name": "sync-plan-id",
+              "shortname": null,
+              "value": "SYNC_PLAN_ID"
+            },
+            {
+              "help": "print help",
+              "name": "help",
+              "shortname": "h",
+              "value": null
+            }
+          ],
+          "subcommands": []
+        }
+      ]
+    },
+    {
+      "description": "Manipulate smart proxies.",
+      "name": "proxy",
+      "options": [
+        {
+          "help": "print help",
+          "name": "help",
+          "shortname": "h",
+          "value": null
+        }
+      ],
+      "subcommands": [
+        {
+          "description": "Create a Capsule",
+          "name": "create",
+          "options": [
+            {
+              "help": "REPLACE locations with given ids Comma separated list of values.",
+              "name": "location-ids",
+              "shortname": null,
+              "value": "LOCATION_IDS"
+            },
+            {
+              "help": "Comma separated list of values.",
+              "name": "locations",
+              "shortname": null,
+              "value": "LOCATION_NAMES"
+            },
+            {
+              "help": "",
+              "name": "name",
+              "shortname": null,
+              "value": "NAME"
+            },
+            {
+              "help": "REPLACE organizations with given ids. Comma separated list of values.",
+              "name": "organization-ids",
+              "shortname": null,
+              "value": "ORGANIZATION_IDS"
+            },
+            {
+              "help": "Comma separated list of values.",
+              "name": "organizations",
+              "shortname": null,
+              "value": "ORGANIZATION_NAMES"
+            },
+            {
+              "help": "",
+              "name": "url",
+              "shortname": null,
+              "value": "URL"
+            },
+            {
+              "help": "print help",
+              "name": "help",
+              "shortname": "h",
+              "value": null
+            }
+          ],
+          "subcommands": []
+        },
+        {
+          "description": "Delete a Capsule",
+          "name": "delete",
+          "options": [
+            {
+              "help": "",
+              "name": "id",
+              "shortname": null,
+              "value": "ID"
+            },
+            {
+              "help": "Name to search by",
+              "name": "name",
+              "shortname": null,
+              "value": "NAME"
+            },
+            {
+              "help": "print help",
+              "name": "help",
+              "shortname": "h",
+              "value": null
+            }
+          ],
+          "subcommands": []
+        },
+        {
+          "description": "Import puppet classes from puppet proxy.",
+          "name": "import-classes",
+          "options": [
+            {
+              "help": "Do not run the import",
+              "name": "dryrun",
+              "shortname": null,
+              "value": null
+            },
+            {
+              "help": "Environment name",
+              "name": "environment",
+              "shortname": null,
+              "value": "ENVIRONMENT_NAME"
+            },
+            {
+              "help": "",
+              "name": "environment-id",
+              "shortname": null,
+              "value": "ENVIRONMENT_ID"
+            },
+            {
+              "help": "Optional comma-delimited string containing either 'new', 'updated', or 'obsolete' that is used to limit the imported Puppet classes",
+              "name": "except",
+              "shortname": null,
+              "value": "EXCEPT"
+            },
+            {
+              "help": "",
+              "name": "id",
+              "shortname": null,
+              "value": "ID"
+            },
+            {
+              "help": "Name to search by",
+              "name": "name",
+              "shortname": null,
+              "value": "NAME"
+            },
+            {
+              "help": "print help",
+              "name": "help",
+              "shortname": "h",
+              "value": null
+            }
+          ],
+          "subcommands": []
+        },
+        {
+          "description": "Show a Capsule",
+          "name": "info",
+          "options": [
+            {
+              "help": "",
+              "name": "id",
+              "shortname": null,
+              "value": "ID"
+            },
+            {
+              "help": "Name to search by",
+              "name": "name",
+              "shortname": null,
+              "value": "NAME"
+            },
+            {
+              "help": "print help",
+              "name": "help",
+              "shortname": "h",
+              "value": null
+            }
+          ],
+          "subcommands": []
+        },
+        {
+          "description": "List all smart proxies",
+          "name": "list",
+          "options": [
+            {
+              "help": "Location name",
+              "name": "location",
+              "shortname": null,
+              "value": "LOCATION_NAME"
+            },
+            {
+              "help": "",
+              "name": "location-id",
+              "shortname": null,
+              "value": "LOCATION_ID"
+            },
+            {
+              "help": "sort results",
+              "name": "order",
+              "shortname": null,
+              "value": "ORDER"
+            },
+            {
+              "help": "Organization name",
+              "name": "organization",
+              "shortname": null,
+              "value": "ORGANIZATION_NAME"
+            },
+            {
+              "help": "organization ID",
+              "name": "organization-id",
+              "shortname": null,
+              "value": "ORGANIZATION_ID"
+            },
+            {
+              "help": "paginate results",
+              "name": "page",
+              "shortname": null,
+              "value": "PAGE"
+            },
+            {
+              "help": "number of entries per request",
+              "name": "per-page",
+              "shortname": null,
+              "value": "PER_PAGE"
+            },
+            {
+              "help": "filter results",
+              "name": "search",
+              "shortname": null,
+              "value": "SEARCH"
+            },
+            {
+              "help": "print help",
+              "name": "help",
+              "shortname": "h",
+              "value": null
+            }
+          ],
+          "subcommands": []
+        },
+        {
+          "description": "Refresh Capsule features",
+          "name": "refresh-features",
+          "options": [
+            {
+              "help": "",
+              "name": "id",
+              "shortname": null,
+              "value": "ID"
+            },
+            {
+              "help": "Name to search by",
+              "name": "name",
+              "shortname": null,
+              "value": "NAME"
+            },
+            {
+              "help": "print help",
+              "name": "help",
+              "shortname": "h",
+              "value": null
+            }
+          ],
+          "subcommands": []
+        },
+        {
+          "description": "Update a Capsule",
+          "name": "update",
+          "options": [
+            {
+              "help": "",
+              "name": "id",
+              "shortname": null,
+              "value": "ID"
+            },
+            {
+              "help": "REPLACE locations with given ids Comma separated list of values.",
+              "name": "location-ids",
+              "shortname": null,
+              "value": "LOCATION_IDS"
+            },
+            {
+              "help": "Comma separated list of values.",
+              "name": "locations",
+              "shortname": null,
+              "value": "LOCATION_NAMES"
+            },
+            {
+              "help": "Name to search by",
+              "name": "name",
+              "shortname": null,
+              "value": "NAME"
+            },
+            {
+              "help": "",
+              "name": "new-name",
+              "shortname": null,
+              "value": "NEW_NAME"
+            },
+            {
+              "help": "REPLACE organizations with given ids. Comma separated list of values.",
+              "name": "organization-ids",
+              "shortname": null,
+              "value": "ORGANIZATION_IDS"
+            },
+            {
+              "help": "Comma separated list of values.",
+              "name": "organizations",
+              "shortname": null,
+              "value": "ORGANIZATION_NAMES"
+            },
+            {
+              "help": "",
+              "name": "url",
+              "shortname": null,
+              "value": "URL"
+            },
+            {
+              "help": "print help",
+              "name": "help",
+              "shortname": "h",
+              "value": null
+            }
+          ],
+          "subcommands": []
+        }
+      ]
+    },
+    {
+      "description": "Search puppet modules.",
+      "name": "puppet-class",
+      "options": [
+        {
+          "help": "print help",
+          "name": "help",
+          "shortname": "h",
+          "value": null
+        }
+      ],
+      "subcommands": [
+        {
+          "description": "Show a Puppet class",
+          "name": "info",
+          "options": [
+            {
+              "help": "Environment name",
+              "name": "environment",
+              "shortname": null,
+              "value": "ENVIRONMENT_NAME"
+            },
+            {
+              "help": "",
+              "name": "environment-id",
+              "shortname": null,
+              "value": "ENVIRONMENT_ID"
+            },
+            {
+              "help": "Host name",
+              "name": "host",
+              "shortname": null,
+              "value": "HOST_NAME"
+            },
+            {
+              "help": "",
+              "name": "host-id",
+              "shortname": null,
+              "value": "HOST_ID"
+            },
+            {
+              "help": "Hostgroup name",
+              "name": "hostgroup",
+              "shortname": null,
+              "value": "HOSTGROUP_NAME"
+            },
+            {
+              "help": "",
+              "name": "hostgroup-id",
+              "shortname": null,
+              "value": "HOSTGROUP_ID"
+            },
+            {
+              "help": "ID of Puppet class",
+              "name": "id",
+              "shortname": null,
+              "value": "ID"
+            },
+            {
+              "help": "Puppet class name",
+              "name": "name",
+              "shortname": null,
+              "value": "NAME"
+            },
+            {
+              "help": "print help",
+              "name": "help",
+              "shortname": "h",
+              "value": null
+            }
+          ],
+          "subcommands": []
+        },
+        {
+          "description": "List all Puppet classes",
+          "name": "list",
+          "options": [
+            {
+              "help": "Environment name",
+              "name": "environment",
+              "shortname": null,
+              "value": "ENVIRONMENT_NAME"
+            },
+            {
+              "help": "",
+              "name": "environment-id",
+              "shortname": null,
+              "value": "ENVIRONMENT_ID"
+            },
+            {
+              "help": "Host name",
+              "name": "host",
+              "shortname": null,
+              "value": "HOST_NAME"
+            },
+            {
+              "help": "",
+              "name": "host-id",
+              "shortname": null,
+              "value": "HOST_ID"
+            },
+            {
+              "help": "Hostgroup name",
+              "name": "hostgroup",
+              "shortname": null,
+              "value": "HOSTGROUP_NAME"
+            },
+            {
+              "help": "",
+              "name": "hostgroup-id",
+              "shortname": null,
+              "value": "HOSTGROUP_ID"
+            },
+            {
+              "help": "sort results",
+              "name": "order",
+              "shortname": null,
+              "value": "ORDER"
+            },
+            {
+              "help": "paginate results",
+              "name": "page",
+              "shortname": null,
+              "value": "PAGE"
+            },
+            {
+              "help": "number of entries per request",
+              "name": "per-page",
+              "shortname": null,
+              "value": "PER_PAGE"
+            },
+            {
+              "help": "filter results",
+              "name": "search",
+              "shortname": null,
+              "value": "SEARCH"
+            },
+            {
+              "help": "print help",
+              "name": "help",
+              "shortname": "h",
+              "value": null
+            }
+          ],
+          "subcommands": []
+        },
+        {
+          "description": "List all smart class parameters",
+          "name": "sc-params",
+          "options": [
+            {
+              "help": "Environment name",
+              "name": "environment",
+              "shortname": null,
+              "value": "ENVIRONMENT_NAME"
+            },
+            {
+              "help": "",
+              "name": "environment-id",
+              "shortname": null,
+              "value": "ENVIRONMENT_ID"
+            },
+            {
+              "help": "Host name",
+              "name": "host",
+              "shortname": null,
+              "value": "HOST_NAME"
+            },
+            {
+              "help": "",
+              "name": "host-id",
+              "shortname": null,
+              "value": "HOST_ID"
+            },
+            {
+              "help": "Hostgroup name",
+              "name": "hostgroup",
+              "shortname": null,
+              "value": "HOSTGROUP_NAME"
+            },
+            {
+              "help": "",
+              "name": "hostgroup-id",
+              "shortname": null,
+              "value": "HOSTGROUP_ID"
+            },
+            {
+              "help": "ID of Puppet class",
+              "name": "id",
+              "shortname": null,
+              "value": "ID"
+            },
+            {
+              "help": "Puppet class name",
+              "name": "name",
+              "shortname": null,
+              "value": "NAME"
+            },
+            {
+              "help": "sort results",
+              "name": "order",
+              "shortname": null,
+              "value": "ORDER"
+            },
+            {
+              "help": "paginate results",
+              "name": "page",
+              "shortname": null,
+              "value": "PAGE"
+            },
+            {
+              "help": "number of entries per request",
+              "name": "per-page",
+              "shortname": null,
+              "value": "PER_PAGE"
+            },
+            {
+              "help": "Puppet class name",
+              "name": "puppet-class",
+              "shortname": null,
+              "value": "PUPPET_CLASS_NAME"
+            },
+            {
+              "help": "ID of Puppet class",
+              "name": "puppet-class-id",
+              "shortname": null,
+              "value": "PUPPET_CLASS_ID"
+            },
+            {
+              "help": "filter results",
+              "name": "search",
+              "shortname": null,
+              "value": "SEARCH"
+            },
+            {
+              "help": "print help",
+              "name": "help",
+              "shortname": "h",
+              "value": null
+            }
+          ],
+          "subcommands": []
+        }
+      ]
+    },
+    {
+      "description": "View Puppet Module details.",
+      "name": "puppet-module",
+      "options": [
+        {
+          "help": "print help",
+          "name": "help",
+          "shortname": "h",
+          "value": null
+        }
+      ],
+      "subcommands": [
+        {
+          "description": "Show a puppet module",
+          "name": "info",
+          "options": [
+            {
+              "help": "a puppet module identifier",
+              "name": "id",
+              "shortname": null,
+              "value": "ID"
+            },
+            {
+              "help": "Name to search by",
+              "name": "name",
+              "shortname": null,
+              "value": "NAME"
+            },
+            {
+              "help": "Repository name to search by",
+              "name": "repository",
+              "shortname": null,
+              "value": "REPOSITORY_NAME"
+            },
+            {
+              "help": "repository ID",
+              "name": "repository-id",
+              "shortname": null,
+              "value": "REPOSITORY_ID"
+            },
+            {
+              "help": "print help",
+              "name": "help",
+              "shortname": "h",
+              "value": null
+            }
+          ],
+          "subcommands": []
+        },
+        {
+          "description": "List puppet_modules",
+          "name": "list",
+          "options": [
+            {
+              "help": "Field to sort the results on",
+              "name": "by",
+              "shortname": null,
+              "value": "BY"
+            },
+            {
+              "help": "Name to search by",
+              "name": "content-view-filter",
+              "shortname": null,
+              "value": "CONTENT_VIEW_FILTER_NAME"
+            },
+            {
+              "help": "filter identifier",
+              "name": "content-view-filter-id",
+              "shortname": null,
+              "value": "CONTENT_VIEW_FILTER_ID"
+            },
+            {
+              "help": "Content view version number",
+              "name": "content-view-version",
+              "shortname": null,
+              "value": "CONTENT_VIEW_VERSION_VERSION"
+            },
+            {
+              "help": "Content view version identifier",
+              "name": "content-view-version-id",
+              "shortname": null,
+              "value": "CONTENT_VIEW_VERSION_ID"
+            },
+            {
+              "help": "Name to search by",
+              "name": "environment",
+              "shortname": null,
+              "value": "ENVIRONMENT_NAME"
+            },
+            {
+              "help": "",
+              "name": "environment-id",
+              "shortname": null,
+              "value": "ENVIRONMENT_ID"
+            },
+            {
+              "help": "Whether or not to show all results One of true/false, yes/no, 1/0.",
+              "name": "full-results",
+              "shortname": null,
+              "value": "FULL_RESULTS"
+            },
+            {
+              "help": "ids to filter content by Comma separated list of values.",
+              "name": "ids",
+              "shortname": null,
+              "value": "IDS"
+            },
+            {
+              "help": "Sort field and order, eg. 'name DESC'",
+              "name": "order",
+              "shortname": null,
+              "value": "ORDER"
+            },
+            {
+              "help": "Page number, starting at 1",
+              "name": "page",
+              "shortname": null,
+              "value": "PAGE"
+            },
+            {
+              "help": "Number of results per page to return",
+              "name": "per-page",
+              "shortname": null,
+              "value": "PER_PAGE"
+            },
+            {
+              "help": "Repository name to search by",
+              "name": "repository",
+              "shortname": null,
+              "value": "REPOSITORY_NAME"
+            },
+            {
+              "help": "repository ID",
+              "name": "repository-id",
+              "shortname": null,
+              "value": "REPOSITORY_ID"
+            },
+            {
+              "help": "Search string",
+              "name": "search",
+              "shortname": null,
+              "value": "SEARCH"
+            },
+            {
+              "help": "print help",
+              "name": "help",
+              "shortname": "h",
+              "value": null
+            }
+          ],
+          "subcommands": []
+        }
+      ]
+    },
+    {
+      "description": "Browse and read reports.",
+      "name": "report",
+      "options": [
+        {
+          "help": "print help",
+          "name": "help",
+          "shortname": "h",
+          "value": null
+        }
+      ],
+      "subcommands": [
+        {
+          "description": "Delete a report",
+          "name": "delete",
+          "options": [
+            {
+              "help": "",
+              "name": "id",
+              "shortname": null,
+              "value": "ID"
+            },
+            {
+              "help": "Report name",
+              "name": "name",
+              "shortname": null,
+              "value": "NAME"
+            },
+            {
+              "help": "print help",
+              "name": "help",
+              "shortname": "h",
+              "value": null
+            }
+          ],
+          "subcommands": []
+        },
+        {
+          "description": "Show a report",
+          "name": "info",
+          "options": [
+            {
+              "help": "",
+              "name": "id",
+              "shortname": null,
+              "value": "ID"
+            },
+            {
+              "help": "Report name",
+              "name": "name",
+              "shortname": null,
+              "value": "NAME"
+            },
+            {
+              "help": "print help",
+              "name": "help",
+              "shortname": "h",
+              "value": null
+            }
+          ],
+          "subcommands": []
+        },
+        {
+          "description": "List all reports",
+          "name": "list",
+          "options": [
+            {
+              "help": "sort results",
+              "name": "order",
+              "shortname": null,
+              "value": "ORDER"
+            },
+            {
+              "help": "paginate results",
+              "name": "page",
+              "shortname": null,
+              "value": "PAGE"
+            },
+            {
+              "help": "number of entries per request",
+              "name": "per-page",
+              "shortname": null,
+              "value": "PER_PAGE"
+            },
+            {
+              "help": "filter results",
+              "name": "search",
+              "shortname": null,
+              "value": "SEARCH"
+            },
+            {
+              "help": "print help",
+              "name": "help",
+              "shortname": "h",
+              "value": null
+            }
+          ],
+          "subcommands": []
+        }
+      ]
+    },
+    {
+      "description": "Manipulate repositories",
+      "name": "repository",
+      "options": [
+        {
+          "help": "print help",
+          "name": "help",
+          "shortname": "h",
+          "value": null
+        }
+      ],
+      "subcommands": [
+        {
+          "description": "Create a custom repository",
+          "name": "create",
+          "options": [
+            {
+              "help": "checksum of the repository, currently 'sha1' &amp; 'sha256' are supported.'",
+              "name": "checksum-type",
+              "shortname": null,
+              "value": "CHECKSUM_TYPE"
+            },
+            {
+              "help": "type of repo (either 'yum', 'puppet' or 'docker')",
+              "name": "content-type",
+              "shortname": null,
+              "value": "CONTENT_TYPE"
+            },
+            {
+              "help": "name of the upstream docker repository",
+              "name": "docker-upstream-name",
+              "shortname": null,
+              "value": "DOCKER_UPSTREAM_NAME"
+            },
+            {
+              "help": "Name to search by",
+              "name": "gpg-key",
+              "shortname": null,
+              "value": "GPG_KEY_NAME"
+            },
+            {
+              "help": "gpg key numeric identifier",
+              "name": "gpg-key-id",
+              "shortname": null,
+              "value": "GPG_KEY_ID"
+            },
+            {
+              "help": "",
+              "name": "label",
+              "shortname": null,
+              "value": "LABEL"
+            },
+            {
+              "help": "",
+              "name": "name",
+              "shortname": null,
+              "value": "NAME"
+            },
+            {
+              "help": "Organization name to search by",
+              "name": "organization",
+              "shortname": null,
+              "value": "ORGANIZATION_NAME"
+            },
+            {
+              "help": "organization ID",
+              "name": "organization-id",
+              "shortname": null,
+              "value": "ORGANIZATION_ID"
+            },
+            {
+              "help": "Organization label to search by",
+              "name": "organization-label",
+              "shortname": null,
+              "value": "ORGANIZATION_LABEL"
+            },
+            {
+              "help": "Product name to search by",
+              "name": "product",
+              "shortname": null,
+              "value": "PRODUCT_NAME"
+            },
+            {
+              "help": "product numeric identifier",
+              "name": "product-id",
+              "shortname": null,
+              "value": "PRODUCT_ID"
+            },
+            {
+              "help": "Publish Via HTTP One of true/false, yes/no, 1/0.",
+              "name": "publish-via-http",
+              "shortname": null,
+              "value": "ENABLE"
+            },
+            {
+              "help": "repository source url",
+              "name": "url",
+              "shortname": null,
+              "value": "URL"
+            },
+            {
+              "help": "print help",
+              "name": "help",
+              "shortname": "h",
+              "value": null
+            }
+          ],
+          "subcommands": []
+        },
+        {
+          "description": "Destroy a custom repository",
+          "name": "delete",
+          "options": [
+            {
+              "help": "",
+              "name": "id",
+              "shortname": null,
+              "value": "ID"
+            },
+            {
+              "help": "Repository name to search by",
+              "name": "name",
+              "shortname": null,
+              "value": "NAME"
+            },
+            {
+              "help": "Organization name to search by",
+              "name": "organization",
+              "shortname": null,
+              "value": "ORGANIZATION_NAME"
+            },
+            {
+              "help": "organization ID",
+              "name": "organization-id",
+              "shortname": null,
+              "value": "ORGANIZATION_ID"
+            },
+            {
+              "help": "Organization label to search by",
+              "name": "organization-label",
+              "shortname": null,
+              "value": "ORGANIZATION_LABEL"
+            },
+            {
+              "help": "Product name to search by",
+              "name": "product",
+              "shortname": null,
+              "value": "PRODUCT_NAME"
+            },
+            {
+              "help": "product numeric identifier",
+              "name": "product-id",
+              "shortname": null,
+              "value": "PRODUCT_ID"
+            },
+            {
+              "help": "print help",
+              "name": "help",
+              "shortname": "h",
+              "value": null
+            }
+          ],
+          "subcommands": []
+        },
+        {
+          "description": "Show a custom repository",
+          "name": "info",
+          "options": [
+            {
+              "help": "repository ID",
+              "name": "id",
+              "shortname": null,
+              "value": "ID"
+            },
+            {
+              "help": "Repository name to search by",
+              "name": "name",
+              "shortname": null,
+              "value": "NAME"
+            },
+            {
+              "help": "Organization name to search by",
+              "name": "organization",
+              "shortname": null,
+              "value": "ORGANIZATION_NAME"
+            },
+            {
+              "help": "organization ID",
+              "name": "organization-id",
+              "shortname": null,
+              "value": "ORGANIZATION_ID"
+            },
+            {
+              "help": "Organization label to search by",
+              "name": "organization-label",
+              "shortname": null,
+              "value": "ORGANIZATION_LABEL"
+            },
+            {
+              "help": "Product name to search by",
+              "name": "product",
+              "shortname": null,
+              "value": "PRODUCT_NAME"
+            },
+            {
+              "help": "product numeric identifier",
+              "name": "product-id",
+              "shortname": null,
+              "value": "PRODUCT_ID"
+            },
+            {
+              "help": "print help",
+              "name": "help",
+              "shortname": "h",
+              "value": null
+            }
+          ],
+          "subcommands": []
+        },
+        {
+          "description": "List of enabled repositories",
+          "name": "list",
+          "options": [
+            {
+              "help": "Field to sort the results on",
+              "name": "by",
+              "shortname": null,
+              "value": "BY"
+            },
+            {
+              "help": "limit to only repositories of this time",
+              "name": "content-type",
+              "shortname": null,
+              "value": "CONTENT_TYPE"
+            },
+            {
+              "help": "Content view name",
+              "name": "content-view",
+              "shortname": null,
+              "value": "CONTENT_VIEW_NAME"
+            },
+            {
+              "help": "content view numeric identifier",
+              "name": "content-view-id",
+              "shortname": null,
+              "value": "CONTENT_VIEW_ID"
+            },
+            {
+              "help": "Content view version number",
+              "name": "content-view-version",
+              "shortname": null,
+              "value": "CONTENT_VIEW_VERSION_VERSION"
+            },
+            {
+              "help": "Content view version identifier",
+              "name": "content-view-version-id",
+              "shortname": null,
+              "value": "CONTENT_VIEW_VERSION_ID"
+            },
+            {
+              "help": "Name to search by",
+              "name": "environment",
+              "shortname": null,
+              "value": "ENVIRONMENT_NAME"
+            },
+            {
+              "help": "",
+              "name": "environment-id",
+              "shortname": null,
+              "value": "ENVIRONMENT_ID"
+            },
+            {
+              "help": "Whether or not to show all results One of true/false, yes/no, 1/0.",
+              "name": "full-results",
+              "shortname": null,
+              "value": "FULL_RESULTS"
+            },
+            {
+              "help": "show repositories in Library and the default content view One of true/false, yes/no, 1/0.",
+              "name": "library",
+              "shortname": null,
+              "value": "LIBRARY"
+            },
+            {
+              "help": "name of the repository",
+              "name": "name",
+              "shortname": null,
+              "value": "NAME"
+            },
+            {
+              "help": "Sort field and order, eg. 'name DESC'",
+              "name": "order",
+              "shortname": null,
+              "value": "ORDER"
+            },
+            {
+              "help": "Organization name to search by",
+              "name": "organization",
+              "shortname": null,
+              "value": "ORGANIZATION_NAME"
+            },
+            {
+              "help": "organization ID",
+              "name": "organization-id",
+              "shortname": null,
+              "value": "ORGANIZATION_ID"
+            },
+            {
+              "help": "Organization label to search by",
+              "name": "organization-label",
+              "shortname": null,
+              "value": "ORGANIZATION_LABEL"
+            },
+            {
+              "help": "Page number, starting at 1",
+              "name": "page",
+              "shortname": null,
+              "value": "PAGE"
+            },
+            {
+              "help": "Number of results per page to return",
+              "name": "per-page",
+              "shortname": null,
+              "value": "PER_PAGE"
+            },
+            {
+              "help": "Product name to search by",
+              "name": "product",
+              "shortname": null,
+              "value": "PRODUCT_NAME"
+            },
+            {
+              "help": "product numeric identifier",
+              "name": "product-id",
+              "shortname": null,
+              "value": "PRODUCT_ID"
+            },
+            {
+              "help": "Search string",
+              "name": "search",
+              "shortname": null,
+              "value": "SEARCH"
+            },
+            {
+              "help": "print help",
+              "name": "help",
+              "shortname": "h",
+              "value": null
+            }
+          ],
+          "subcommands": []
+        },
+        {
+          "description": "",
+          "name": "remove-content",
+          "options": [
+            {
+              "help": "Comma separated list of package/puppet module/docker image ids Comma separated list of values.",
+              "name": "content-ids",
+              "shortname": null,
+              "value": "CONTENT_IDS"
+            },
+            {
+              "help": "repository ID",
+              "name": "id",
+              "shortname": null,
+              "value": "ID"
+            },
+            {
+              "help": "Repository name to search by",
+              "name": "name",
+              "shortname": null,
+              "value": "NAME"
+            },
+            {
+              "help": "Organization name to search by",
+              "name": "organization",
+              "shortname": null,
+              "value": "ORGANIZATION_NAME"
+            },
+            {
+              "help": "organization ID",
+              "name": "organization-id",
+              "shortname": null,
+              "value": "ORGANIZATION_ID"
+            },
+            {
+              "help": "Organization label to search by",
+              "name": "organization-label",
+              "shortname": null,
+              "value": "ORGANIZATION_LABEL"
+            },
+            {
+              "help": "print help",
+              "name": "help",
+              "shortname": "h",
+              "value": null
+            }
+          ],
+          "subcommands": []
+        },
+        {
+          "description": "Sync a repository",
+          "name": "synchronize",
+          "options": [
+            {
+              "help": "Do not wait for the task",
+              "name": "async",
+              "shortname": null,
+              "value": null
+            },
+            {
+              "help": "repository ID",
+              "name": "id",
+              "shortname": null,
+              "value": "ID"
+            },
+            {
+              "help": "Repository name to search by",
+              "name": "name",
+              "shortname": null,
+              "value": "NAME"
+            },
+            {
+              "help": "Organization name to search by",
+              "name": "organization",
+              "shortname": null,
+              "value": "ORGANIZATION_NAME"
+            },
+            {
+              "help": "organization ID",
+              "name": "organization-id",
+              "shortname": null,
+              "value": "ORGANIZATION_ID"
+            },
+            {
+              "help": "Organization label to search by",
+              "name": "organization-label",
+              "shortname": null,
+              "value": "ORGANIZATION_LABEL"
+            },
+            {
+              "help": "Product name to search by",
+              "name": "product",
+              "shortname": null,
+              "value": "PRODUCT_NAME"
+            },
+            {
+              "help": "product numeric identifier",
+              "name": "product-id",
+              "shortname": null,
+              "value": "PRODUCT_ID"
+            },
+            {
+              "help": "print help",
+              "name": "help",
+              "shortname": "h",
+              "value": null
+            }
+          ],
+          "subcommands": []
+        },
+        {
+          "description": "Update a custom repository",
+          "name": "update",
+          "options": [
+            {
+              "help": "checksum of the repository, currently 'sha1' &amp; 'sha256' are supported.'",
+              "name": "checksum-type",
+              "shortname": null,
+              "value": "CHECKSUM_TYPE"
+            },
+            {
+              "help": "name of the upstream docker repository",
+              "name": "docker-upstream-name",
+              "shortname": null,
+              "value": "DOCKER_UPSTREAM_NAME"
+            },
+            {
+              "help": "Name to search by",
+              "name": "gpg-key",
+              "shortname": null,
+              "value": "GPG_KEY_NAME"
+            },
+            {
+              "help": "gpg key numeric identifier",
+              "name": "gpg-key-id",
+              "shortname": null,
+              "value": "GPG_KEY_ID"
+            },
+            {
+              "help": "repository ID",
+              "name": "id",
+              "shortname": null,
+              "value": "ID"
+            },
+            {
+              "help": "Repository name to search by",
+              "name": "name",
+              "shortname": null,
+              "value": "NAME"
+            },
+            {
+              "help": "New name for the repository",
+              "name": "new-name",
+              "shortname": null,
+              "value": "NEW_NAME"
+            },
+            {
+              "help": "Organization name to search by",
+              "name": "organization",
+              "shortname": null,
+              "value": "ORGANIZATION_NAME"
+            },
+            {
+              "help": "organization ID",
+              "name": "organization-id",
+              "shortname": null,
+              "value": "ORGANIZATION_ID"
+            },
+            {
+              "help": "Organization label to search by",
+              "name": "organization-label",
+              "shortname": null,
+              "value": "ORGANIZATION_LABEL"
+            },
+            {
+              "help": "Product name to search by",
+              "name": "product",
+              "shortname": null,
+              "value": "PRODUCT_NAME"
+            },
+            {
+              "help": "product numeric identifier",
+              "name": "product-id",
+              "shortname": null,
+              "value": "PRODUCT_ID"
+            },
+            {
+              "help": "Publish Via HTTP One of true/false, yes/no, 1/0.",
+              "name": "publish-via-http",
+              "shortname": null,
+              "value": "ENABLE"
+            },
+            {
+              "help": "the feed url of the original repository",
+              "name": "url",
+              "shortname": null,
+              "value": "URL"
+            },
+            {
+              "help": "print help",
+              "name": "help",
+              "shortname": "h",
+              "value": null
+            }
+          ],
+          "subcommands": []
+        },
+        {
+          "description": "Upload content into the repository",
+          "name": "upload-content",
+          "options": [
+            {
+              "help": "repository ID",
+              "name": "id",
+              "shortname": null,
+              "value": "ID"
+            },
+            {
+              "help": "Repository name to search by",
+              "name": "name",
+              "shortname": null,
+              "value": "NAME"
+            },
+            {
+              "help": "Organization name to search by",
+              "name": "organization",
+              "shortname": null,
+              "value": "ORGANIZATION_NAME"
+            },
+            {
+              "help": "organization ID",
+              "name": "organization-id",
+              "shortname": null,
+              "value": "ORGANIZATION_ID"
+            },
+            {
+              "help": "Organization label to search by",
+              "name": "organization-label",
+              "shortname": null,
+              "value": "ORGANIZATION_LABEL"
+            },
+            {
+              "help": "Upload file or directory of files as content for a repository",
+              "name": "path",
+              "shortname": null,
+              "value": "PATH"
+            },
+            {
+              "help": "Product name to search by",
+              "name": "product",
+              "shortname": null,
+              "value": "PRODUCT_NAME"
+            },
+            {
+              "help": "product numeric identifier",
+              "name": "product-id",
+              "shortname": null,
+              "value": "PRODUCT_ID"
+            },
+            {
+              "help": "print help",
+              "name": "help",
+              "shortname": "h",
+              "value": null
+            }
+          ],
+          "subcommands": []
+        }
+      ]
+    },
+    {
+      "description": "Manipulate repository sets on the server",
+      "name": "repository-set",
+      "options": [
+        {
+          "help": "print help",
+          "name": "help",
+          "shortname": "h",
+          "value": null
+        }
+      ],
+      "subcommands": [
+        {
+          "description": "Get list or available repositories for the repository set",
+          "name": "available-repositories",
+          "options": [
+            {
+              "help": "ID of the repository set",
+              "name": "id",
+              "shortname": null,
+              "value": "ID"
+            },
+            {
+              "help": "Repository set name to search by",
+              "name": "name",
+              "shortname": null,
+              "value": "NAME"
+            },
+            {
+              "help": "Organization name to search by",
+              "name": "organization",
+              "shortname": null,
+              "value": "ORGANIZATION_NAME"
+            },
+            {
+              "help": "organization ID",
+              "name": "organization-id",
+              "shortname": null,
+              "value": "ORGANIZATION_ID"
+            },
+            {
+              "help": "Organization label to search by",
+              "name": "organization-label",
+              "shortname": null,
+              "value": "ORGANIZATION_LABEL"
+            },
+            {
+              "help": "Product name to search by",
+              "name": "product",
+              "shortname": null,
+              "value": "PRODUCT_NAME"
+            },
+            {
+              "help": "product numeric identifier",
+              "name": "product-id",
+              "shortname": null,
+              "value": "PRODUCT_ID"
+            },
+            {
+              "help": "print help",
+              "name": "help",
+              "shortname": "h",
+              "value": null
+            }
+          ],
+          "subcommands": []
+        },
+        {
+          "description": "Disable a repository form the set",
+          "name": "disable",
+          "options": [
+            {
+              "help": "Basearch to disable",
+              "name": "basearch",
+              "shortname": null,
+              "value": "BASEARCH"
+            },
+            {
+              "help": "ID of the repository set to enable",
+              "name": "id",
+              "shortname": null,
+              "value": "ID"
+            },
+            {
+              "help": "Repository set name to search by",
+              "name": "name",
+              "shortname": null,
+              "value": "NAME"
+            },
+            {
+              "help": "",
+              "name": "new-name",
+              "shortname": null,
+              "value": "NEW_NAME"
+            },
+            {
+              "help": "Organization name to search by",
+              "name": "organization",
+              "shortname": null,
+              "value": "ORGANIZATION_NAME"
+            },
+            {
+              "help": "organization ID",
+              "name": "organization-id",
+              "shortname": null,
+              "value": "ORGANIZATION_ID"
+            },
+            {
+              "help": "Organization label to search by",
+              "name": "organization-label",
+              "shortname": null,
+              "value": "ORGANIZATION_LABEL"
+            },
+            {
+              "help": "Product name to search by",
+              "name": "product",
+              "shortname": null,
+              "value": "PRODUCT_NAME"
+            },
+            {
+              "help": "product numeric identifier",
+              "name": "product-id",
+              "shortname": null,
+              "value": "PRODUCT_ID"
+            },
+            {
+              "help": "Releasever to disable",
+              "name": "releasever",
+              "shortname": null,
+              "value": "RELEASEVER"
+            },
+            {
+              "help": "print help",
+              "name": "help",
+              "shortname": "h",
+              "value": null
+            }
+          ],
+          "subcommands": []
+        },
+        {
+          "description": "Enable a repository from the set",
+          "name": "enable",
+          "options": [
+            {
+              "help": "Basearch to enable",
+              "name": "basearch",
+              "shortname": null,
+              "value": "BASEARCH"
+            },
+            {
+              "help": "ID of the repository set to enable",
+              "name": "id",
+              "shortname": null,
+              "value": "ID"
+            },
+            {
+              "help": "Repository set name to search by",
+              "name": "name",
+              "shortname": null,
+              "value": "NAME"
+            },
+            {
+              "help": "",
+              "name": "new-name",
+              "shortname": null,
+              "value": "NEW_NAME"
+            },
+            {
+              "help": "Organization name to search by",
+              "name": "organization",
+              "shortname": null,
+              "value": "ORGANIZATION_NAME"
+            },
+            {
+              "help": "organization ID",
+              "name": "organization-id",
+              "shortname": null,
+              "value": "ORGANIZATION_ID"
+            },
+            {
+              "help": "Organization label to search by",
+              "name": "organization-label",
+              "shortname": null,
+              "value": "ORGANIZATION_LABEL"
+            },
+            {
+              "help": "Product name to search by",
+              "name": "product",
+              "shortname": null,
+              "value": "PRODUCT_NAME"
+            },
+            {
+              "help": "product numeric identifier",
+              "name": "product-id",
+              "shortname": null,
+              "value": "PRODUCT_ID"
+            },
+            {
+              "help": "Releasever to enable",
+              "name": "releasever",
+              "shortname": null,
+              "value": "RELEASEVER"
+            },
+            {
+              "help": "print help",
+              "name": "help",
+              "shortname": "h",
+              "value": null
+            }
+          ],
+          "subcommands": []
+        },
+        {
+          "description": "Get info about a repository set",
+          "name": "info",
+          "options": [
+            {
+              "help": "ID of the repository set",
+              "name": "id",
+              "shortname": null,
+              "value": "ID"
+            },
+            {
+              "help": "Repository set name to search by",
+              "name": "name",
+              "shortname": null,
+              "value": "NAME"
+            },
+            {
+              "help": "Organization name to search by",
+              "name": "organization",
+              "shortname": null,
+              "value": "ORGANIZATION_NAME"
+            },
+            {
+              "help": "organization ID",
+              "name": "organization-id",
+              "shortname": null,
+              "value": "ORGANIZATION_ID"
+            },
+            {
+              "help": "Organization label to search by",
+              "name": "organization-label",
+              "shortname": null,
+              "value": "ORGANIZATION_LABEL"
+            },
+            {
+              "help": "Product name to search by",
+              "name": "product",
+              "shortname": null,
+              "value": "PRODUCT_NAME"
+            },
+            {
+              "help": "product numeric identifier",
+              "name": "product-id",
+              "shortname": null,
+              "value": "PRODUCT_ID"
+            },
+            {
+              "help": "print help",
+              "name": "help",
+              "shortname": "h",
+              "value": null
+            }
+          ],
+          "subcommands": []
+        },
+        {
+          "description": "List repository sets for a product.",
+          "name": "list",
+          "options": [
+            {
+              "help": "Repository set name to search on",
+              "name": "name",
+              "shortname": null,
+              "value": "NAME"
+            },
+            {
+              "help": "Organization name to search by",
+              "name": "organization",
+              "shortname": null,
+              "value": "ORGANIZATION_NAME"
+            },
+            {
+              "help": "organization ID",
+              "name": "organization-id",
+              "shortname": null,
+              "value": "ORGANIZATION_ID"
+            },
+            {
+              "help": "Organization label to search by",
+              "name": "organization-label",
+              "shortname": null,
+              "value": "ORGANIZATION_LABEL"
+            },
+            {
+              "help": "Product name to search by",
+              "name": "product",
+              "shortname": null,
+              "value": "PRODUCT_NAME"
+            },
+            {
+              "help": "product numeric identifier",
+              "name": "product-id",
+              "shortname": null,
+              "value": "PRODUCT_ID"
+            },
+            {
+              "help": "print help",
+              "name": "help",
+              "shortname": "h",
+              "value": null
+            }
+          ],
+          "subcommands": []
+        }
+      ]
+    },
+    {
+      "description": "Manage user roles.",
+      "name": "role",
+      "options": [
+        {
+          "help": "print help",
+          "name": "help",
+          "shortname": "h",
+          "value": null
+        }
+      ],
+      "subcommands": [
+        {
+          "description": "Create a role",
+          "name": "create",
+          "options": [
+            {
+              "help": "",
+              "name": "name",
+              "shortname": null,
+              "value": "NAME"
+            },
+            {
+              "help": "print help",
+              "name": "help",
+              "shortname": "h",
+              "value": null
+            }
+          ],
+          "subcommands": []
+        },
+        {
+          "description": "Delete a role",
+          "name": "delete",
+          "options": [
+            {
+              "help": "",
+              "name": "id",
+              "shortname": null,
+              "value": "ID"
+            },
+            {
+              "help": "User role name",
+              "name": "name",
+              "shortname": null,
+              "value": "NAME"
+            },
+            {
+              "help": "print help",
+              "name": "help",
+              "shortname": "h",
+              "value": null
+            }
+          ],
+          "subcommands": []
+        },
+        {
+          "description": "List all filters",
+          "name": "filters",
+          "options": [
+            {
+              "help": "User role id",
+              "name": "id",
+              "shortname": null,
+              "value": "ID"
+            },
+            {
+              "help": "User role name",
+              "name": "name",
+              "shortname": null,
+              "value": "NAME"
+            },
+            {
+              "help": "sort results",
+              "name": "order",
+              "shortname": null,
+              "value": "ORDER"
+            },
+            {
+              "help": "paginate results",
+              "name": "page",
+              "shortname": null,
+              "value": "PAGE"
+            },
+            {
+              "help": "number of entries per request",
+              "name": "per-page",
+              "shortname": null,
+              "value": "PER_PAGE"
+            },
+            {
+              "help": "print help",
+              "name": "help",
+              "shortname": "h",
+              "value": null
+            }
+          ],
+          "subcommands": []
+        },
+        {
+          "description": "List all roles",
+          "name": "list",
+          "options": [
+            {
+              "help": "sort results",
+              "name": "order",
+              "shortname": null,
+              "value": "ORDER"
+            },
+            {
+              "help": "paginate results",
+              "name": "page",
+              "shortname": null,
+              "value": "PAGE"
+            },
+            {
+              "help": "number of entries per request",
+              "name": "per-page",
+              "shortname": null,
+              "value": "PER_PAGE"
+            },
+            {
+              "help": "filter results",
+              "name": "search",
+              "shortname": null,
+              "value": "SEARCH"
+            },
+            {
+              "help": "print help",
+              "name": "help",
+              "shortname": "h",
+              "value": null
+            }
+          ],
+          "subcommands": []
+        },
+        {
+          "description": "Update a role",
+          "name": "update",
+          "options": [
+            {
+              "help": "",
+              "name": "id",
+              "shortname": null,
+              "value": "ID"
+            },
+            {
+              "help": "User role name",
+              "name": "name",
+              "shortname": null,
+              "value": "NAME"
+            },
+            {
+              "help": "",
+              "name": "new-name",
+              "shortname": null,
+              "value": "NEW_NAME"
+            },
+            {
+              "help": "print help",
+              "name": "help",
+              "shortname": "h",
+              "value": null
+            }
+          ],
+          "subcommands": []
+        }
+      ]
+    },
+    {
+      "description": "Manipulate smart class parameters.",
+      "name": "sc-param",
+      "options": [
+        {
+          "help": "print help",
+          "name": "help",
+          "shortname": "h",
+          "value": null
+        }
+      ],
+      "subcommands": [
+        {
+          "description": "Show a smart class parameter",
+          "name": "info",
+          "options": [
+            {
+              "help": "",
+              "name": "id",
+              "shortname": null,
+              "value": "ID"
+            },
+            {
+              "help": "Smart class parameter name",
+              "name": "name",
+              "shortname": null,
+              "value": "NAME"
+            },
+            {
+              "help": "print help",
+              "name": "help",
+              "shortname": "h",
+              "value": null
+            }
+          ],
+          "subcommands": []
+        },
+        {
+          "description": "List all smart class parameters",
+          "name": "list",
+          "options": [
+            {
+              "help": "Environment name",
+              "name": "environment",
+              "shortname": null,
+              "value": "ENVIRONMENT_NAME"
+            },
+            {
+              "help": "",
+              "name": "environment-id",
+              "shortname": null,
+              "value": "ENVIRONMENT_ID"
+            },
+            {
+              "help": "Host name",
+              "name": "host",
+              "shortname": null,
+              "value": "HOST_NAME"
+            },
+            {
+              "help": "",
+              "name": "host-id",
+              "shortname": null,
+              "value": "HOST_ID"
+            },
+            {
+              "help": "Hostgroup name",
+              "name": "hostgroup",
+              "shortname": null,
+              "value": "HOSTGROUP_NAME"
+            },
+            {
+              "help": "",
+              "name": "hostgroup-id",
+              "shortname": null,
+              "value": "HOSTGROUP_ID"
+            },
+            {
+              "help": "sort results",
+              "name": "order",
+              "shortname": null,
+              "value": "ORDER"
+            },
+            {
+              "help": "paginate results",
+              "name": "page",
+              "shortname": null,
+              "value": "PAGE"
+            },
+            {
+              "help": "number of entries per request",
+              "name": "per-page",
+              "shortname": null,
+              "value": "PER_PAGE"
+            },
+            {
+              "help": "Puppet class name",
+              "name": "puppet-class",
+              "shortname": null,
+              "value": "PUPPET_CLASS_NAME"
+            },
+            {
+              "help": "ID of Puppet class",
+              "name": "puppet-class-id",
+              "shortname": null,
+              "value": "PUPPET_CLASS_ID"
+            },
+            {
+              "help": "filter results",
+              "name": "search",
+              "shortname": null,
+              "value": "SEARCH"
+            },
+            {
+              "help": "print help",
+              "name": "help",
+              "shortname": "h",
+              "value": null
+            }
+          ],
+          "subcommands": []
+        },
+        {
+          "description": "Update a smart class parameter",
+          "name": "update",
+          "options": [
+            {
+              "help": "One of true/false, yes/no, 1/0.",
+              "name": "avoid-duplicates",
+              "shortname": null,
+              "value": "AVOID_DUPLICATES"
+            },
+            {
+              "help": "",
+              "name": "default-value",
+              "shortname": null,
+              "value": "DEFAULT_VALUE"
+            },
+            {
+              "help": "",
+              "name": "description",
+              "shortname": null,
+              "value": "DESCRIPTION"
+            },
+            {
+              "help": "",
+              "name": "id",
+              "shortname": null,
+              "value": "ID"
+            },
+            {
+              "help": "One of true/false, yes/no, 1/0.",
+              "name": "merge-overrides",
+              "shortname": null,
+              "value": "MERGE_OVERRIDES"
+            },
+            {
+              "help": "Smart class parameter name",
+              "name": "name",
+              "shortname": null,
+              "value": "NAME"
+            },
+            {
+              "help": "",
+              "name": "new-name",
+              "shortname": null,
+              "value": "NEW_NAME"
+            },
+            {
+              "help": "Override this parameter. One of true/false, yes/no, 1/0.",
+              "name": "override",
+              "shortname": null,
+              "value": "OVERRIDE"
+            },
+            {
+              "help": "",
+              "name": "override-value-order",
+              "shortname": null,
+              "value": "OVERRIDE_VALUE_ORDER"
+            },
+            {
+              "help": "Type of the parameter. One of 'string', 'boolean', 'integer', 'real', 'array', 'hash', 'yaml', 'json'",
+              "name": "parameter-type",
+              "shortname": null,
+              "value": "PARAMETER_TYPE"
+            },
+            {
+              "help": "",
+              "name": "path",
+              "shortname": null,
+              "value": "PATH"
+            },
+            {
+              "help": "This parameter is required. One of true/false, yes/no, 1/0.",
+              "name": "required",
+              "shortname": null,
+              "value": "REQUIRED"
+            },
+            {
+              "help": "One of true/false, yes/no, 1/0.",
+              "name": "use-puppet-default",
+              "shortname": null,
+              "value": "USE_PUPPET_DEFAULT"
+            },
+            {
+              "help": "",
+              "name": "validator-rule",
+              "shortname": null,
+              "value": "VALIDATOR_RULE"
+            },
+            {
+              "help": "Type of the validator. One of 'regexp', 'list', ''",
+              "name": "validator-type",
+              "shortname": null,
+              "value": "VALIDATOR_TYPE"
+            },
+            {
+              "help": "print help",
+              "name": "help",
+              "shortname": "h",
+              "value": null
+            }
+          ],
+          "subcommands": []
+        }
+      ]
+    },
+    {
+      "description": "Interactive shell",
+      "name": "shell",
+      "options": [
+        {
+          "help": "print help",
+          "name": "help",
+          "shortname": "h",
+          "value": null
+        }
+      ],
+      "subcommands": []
+    },
+    {
+      "description": "Manipulate subnets.",
+      "name": "subnet",
+      "options": [
+        {
+          "help": "print help",
+          "name": "help",
+          "shortname": "h",
+          "value": null
+        }
+      ],
+      "subcommands": [
+        {
+          "description": "Create a subnet",
+          "name": "create",
+          "options": [
+            {
+              "help": "Default boot mode for interfaces assigned to this subnet, valid values are \"Static\", \"DHCP\"",
+              "name": "boot-mode",
+              "shortname": null,
+              "value": "BOOT_MODE"
+            },
+            {
+              "help": "DHCP Proxy to use within this subnet",
+              "name": "dhcp-id",
+              "shortname": null,
+              "value": "DHCP_ID"
+            },
+            {
+              "help": "DNS Proxy to use within this subnet",
+              "name": "dns-id",
+              "shortname": null,
+              "value": "DNS_ID"
+            },
+            {
+              "help": "Primary DNS for this subnet",
+              "name": "dns-primary",
+              "shortname": null,
+              "value": "DNS_PRIMARY"
+            },
+            {
+              "help": "Secondary DNS for this subnet",
+              "name": "dns-secondary",
+              "shortname": null,
+              "value": "DNS_SECONDARY"
+            },
+            {
+              "help": "Domains in which this subnet is part Comma separated list of values.",
+              "name": "domain-ids",
+              "shortname": null,
+              "value": "DOMAIN_IDS"
+            },
+            {
+              "help": "Comma separated list of values.",
+              "name": "domains",
+              "shortname": null,
+              "value": "DOMAIN_NAMES"
+            },
+            {
+              "help": "Starting IP Address for IP auto suggestion",
+              "name": "from",
+              "shortname": null,
+              "value": "FROM"
+            },
+            {
+              "help": "Primary DNS for this subnet",
+              "name": "gateway",
+              "shortname": null,
+              "value": "GATEWAY"
+            },
+            {
+              "help": "IP Address auto suggestion mode for this subnet, valid values are \"DHCP\", \"Internal DB\", \"None\"",
+              "name": "ipam",
+              "shortname": null,
+              "value": "IPAM"
+            },
+            {
+              "help": "REPLACE locations with given ids Comma separated list of values.",
+              "name": "location-ids",
+              "shortname": null,
+              "value": "LOCATION_IDS"
+            },
+            {
+              "help": "Comma separated list of values.",
+              "name": "locations",
+              "shortname": null,
+              "value": "LOCATION_NAMES"
+            },
+            {
+              "help": "Netmask for this subnet",
+              "name": "mask",
+              "shortname": null,
+              "value": "MASK"
+            },
+            {
+              "help": "Subnet name",
+              "name": "name",
+              "shortname": null,
+              "value": "NAME"
+            },
+            {
+              "help": "Subnet network",
+              "name": "network",
+              "shortname": null,
+              "value": "NETWORK"
+            },
+            {
+              "help": "REPLACE organizations with given ids. Comma separated list of values.",
+              "name": "organization-ids",
+              "shortname": null,
+              "value": "ORGANIZATION_IDS"
+            },
+            {
+              "help": "Comma separated list of values.",
+              "name": "organizations",
+              "shortname": null,
+              "value": "ORGANIZATION_NAMES"
+            },
+            {
+              "help": "TFTP Proxy to use within this subnet",
+              "name": "tftp-id",
+              "shortname": null,
+              "value": "TFTP_ID"
+            },
+            {
+              "help": "Ending IP Address for IP auto suggestion",
+              "name": "to",
+              "shortname": null,
+              "value": "TO"
+            },
+            {
+              "help": "VLAN ID for this subnet",
+              "name": "vlanid",
+              "shortname": null,
+              "value": "VLANID"
+            },
+            {
+              "help": "print help",
+              "name": "help",
+              "shortname": "h",
+              "value": null
+            }
+          ],
+          "subcommands": []
+        },
+        {
+          "description": "Delete a subnet",
+          "name": "delete",
+          "options": [
+            {
+              "help": "Subnet numeric identifier",
+              "name": "id",
+              "shortname": null,
+              "value": "ID"
+            },
+            {
+              "help": "Subnet name",
+              "name": "name",
+              "shortname": null,
+              "value": "NAME"
+            },
+            {
+              "help": "print help",
+              "name": "help",
+              "shortname": "h",
+              "value": null
+            }
+          ],
+          "subcommands": []
+        },
+        {
+          "description": "Show a subnet",
+          "name": "info",
+          "options": [
+            {
+              "help": "",
+              "name": "id",
+              "shortname": null,
+              "value": "ID"
+            },
+            {
+              "help": "Subnet name",
+              "name": "name",
+              "shortname": null,
+              "value": "NAME"
+            },
+            {
+              "help": "print help",
+              "name": "help",
+              "shortname": "h",
+              "value": null
+            }
+          ],
+          "subcommands": []
+        },
+        {
+          "description": "List of subnets",
+          "name": "list",
+          "options": [
+            {
+              "help": "Domain name",
+              "name": "domain",
+              "shortname": null,
+              "value": "DOMAIN_NAME"
+            },
+            {
+              "help": "Numerical ID or domain name",
+              "name": "domain-id",
+              "shortname": null,
+              "value": "DOMAIN_ID"
+            },
+            {
+              "help": "Location name",
+              "name": "location",
+              "shortname": null,
+              "value": "LOCATION_NAME"
+            },
+            {
+              "help": "",
+              "name": "location-id",
+              "shortname": null,
+              "value": "LOCATION_ID"
+            },
+            {
+              "help": "sort results",
+              "name": "order",
+              "shortname": null,
+              "value": "ORDER"
+            },
+            {
+              "help": "Organization name",
+              "name": "organization",
+              "shortname": null,
+              "value": "ORGANIZATION_NAME"
+            },
+            {
+              "help": "organization ID",
+              "name": "organization-id",
+              "shortname": null,
+              "value": "ORGANIZATION_ID"
+            },
+            {
+              "help": "paginate results",
+              "name": "page",
+              "shortname": null,
+              "value": "PAGE"
+            },
+            {
+              "help": "number of entries per request",
+              "name": "per-page",
+              "shortname": null,
+              "value": "PER_PAGE"
+            },
+            {
+              "help": "filter results",
+              "name": "search",
+              "shortname": null,
+              "value": "SEARCH"
+            },
+            {
+              "help": "print help",
+              "name": "help",
+              "shortname": "h",
+              "value": null
+            }
+          ],
+          "subcommands": []
+        },
+        {
+          "description": "Update a subnet",
+          "name": "update",
+          "options": [
+            {
+              "help": "Default boot mode for interfaces assigned to this subnet, valid values are \"Static\", \"DHCP\"",
+              "name": "boot-mode",
+              "shortname": null,
+              "value": "BOOT_MODE"
+            },
+            {
+              "help": "DHCP Proxy to use within this subnet",
+              "name": "dhcp-id",
+              "shortname": null,
+              "value": "DHCP_ID"
+            },
+            {
+              "help": "DNS Proxy to use within this subnet",
+              "name": "dns-id",
+              "shortname": null,
+              "value": "DNS_ID"
+            },
+            {
+              "help": "Primary DNS for this subnet",
+              "name": "dns-primary",
+              "shortname": null,
+              "value": "DNS_PRIMARY"
+            },
+            {
+              "help": "Secondary DNS for this subnet",
+              "name": "dns-secondary",
+              "shortname": null,
+              "value": "DNS_SECONDARY"
+            },
+            {
+              "help": "Domains in which this subnet is part Comma separated list of values.",
+              "name": "domain-ids",
+              "shortname": null,
+              "value": "DOMAIN_IDS"
+            },
+            {
+              "help": "Comma separated list of values.",
+              "name": "domains",
+              "shortname": null,
+              "value": "DOMAIN_NAMES"
+            },
+            {
+              "help": "Starting IP Address for IP auto suggestion",
+              "name": "from",
+              "shortname": null,
+              "value": "FROM"
+            },
+            {
+              "help": "Primary DNS for this subnet",
+              "name": "gateway",
+              "shortname": null,
+              "value": "GATEWAY"
+            },
+            {
+              "help": "Subnet numeric identifier",
+              "name": "id",
+              "shortname": null,
+              "value": "ID"
+            },
+            {
+              "help": "IP Address auto suggestion mode for this subnet, valid values are \"DHCP\", \"Internal DB\", \"None\"",
+              "name": "ipam",
+              "shortname": null,
+              "value": "IPAM"
+            },
+            {
+              "help": "REPLACE locations with given ids Comma separated list of values.",
+              "name": "location-ids",
+              "shortname": null,
+              "value": "LOCATION_IDS"
+            },
+            {
+              "help": "Comma separated list of values.",
+              "name": "locations",
+              "shortname": null,
+              "value": "LOCATION_NAMES"
+            },
+            {
+              "help": "Netmask for this subnet",
+              "name": "mask",
+              "shortname": null,
+              "value": "MASK"
+            },
+            {
+              "help": "Subnet name",
+              "name": "name",
+              "shortname": null,
+              "value": "NAME"
+            },
+            {
+              "help": "Subnet network",
+              "name": "network",
+              "shortname": null,
+              "value": "NETWORK"
+            },
+            {
+              "help": "Subnet name",
+              "name": "new-name",
+              "shortname": null,
+              "value": "NEW_NAME"
+            },
+            {
+              "help": "REPLACE organizations with given ids. Comma separated list of values.",
+              "name": "organization-ids",
+              "shortname": null,
+              "value": "ORGANIZATION_IDS"
+            },
+            {
+              "help": "Comma separated list of values.",
+              "name": "organizations",
+              "shortname": null,
+              "value": "ORGANIZATION_NAMES"
+            },
+            {
+              "help": "TFTP Proxy to use within this subnet",
+              "name": "tftp-id",
+              "shortname": null,
+              "value": "TFTP_ID"
+            },
+            {
+              "help": "Ending IP Address for IP auto suggestion",
+              "name": "to",
+              "shortname": null,
+              "value": "TO"
+            },
+            {
+              "help": "VLAN ID for this subnet",
+              "name": "vlanid",
+              "shortname": null,
+              "value": "VLANID"
+            },
+            {
+              "help": "print help",
+              "name": "help",
+              "shortname": "h",
+              "value": null
+            }
+          ],
+          "subcommands": []
+        }
+      ]
+    },
+    {
+      "description": "Manipulate subscriptions.",
+      "name": "subscription",
+      "options": [
+        {
+          "help": "print help",
+          "name": "help",
+          "shortname": "h",
+          "value": null
+        }
+      ],
+      "subcommands": [
+        {
+          "description": "Delete manifest from Red Hat provider",
+          "name": "delete-manifest",
+          "options": [
+            {
+              "help": "Do not wait for the task",
+              "name": "async",
+              "shortname": null,
+              "value": null
+            },
+            {
+              "help": "Name to search by",
+              "name": "content-host",
+              "shortname": null,
+              "value": "CONTENT_HOST_NAME"
+            },
+            {
+              "help": "UUID of the content host",
+              "name": "content-host-id",
+              "shortname": null,
+              "value": "CONTENT_HOST_ID"
+            },
+            {
+              "help": "Organization name to search by",
+              "name": "organization",
+              "shortname": null,
+              "value": "ORGANIZATION_NAME"
+            },
+            {
+              "help": "organization ID",
+              "name": "organization-id",
+              "shortname": null,
+              "value": "ORGANIZATION_ID"
+            },
+            {
+              "help": "Organization label to search by",
+              "name": "organization-label",
+              "shortname": null,
+              "value": "ORGANIZATION_LABEL"
+            },
+            {
+              "help": "print help",
+              "name": "help",
+              "shortname": "h",
+              "value": null
+            }
+          ],
+          "subcommands": []
+        },
+        {
+          "description": "List organization subscriptions",
+          "name": "list",
+          "options": [
+            {
+              "help": "Activation key name to search by",
+              "name": "activation-key",
+              "shortname": null,
+              "value": "ACTIVATION_KEY_NAME"
+            },
+            {
+              "help": "ID of the activation key",
+              "name": "activation-key-id",
+              "shortname": null,
+              "value": "ACTIVATION_KEY_ID"
+            },
+            {
+              "help": "Field to sort the results on",
+              "name": "by",
+              "shortname": null,
+              "value": "BY"
+            },
+            {
+              "help": "Name to search by",
+              "name": "content-host",
+              "shortname": null,
+              "value": "CONTENT_HOST_NAME"
+            },
+            {
+              "help": "UUID of the content host",
+              "name": "content-host-id",
+              "shortname": null,
+              "value": "CONTENT_HOST_ID"
+            },
+            {
+              "help": "Whether or not to show all results One of true/false, yes/no, 1/0.",
+              "name": "full-results",
+              "shortname": null,
+              "value": "FULL_RESULTS"
+            },
+            {
+              "help": "Sort field and order, eg. 'name DESC'",
+              "name": "order",
+              "shortname": null,
+              "value": "ORDER"
+            },
+            {
+              "help": "Organization name to search by",
+              "name": "organization",
+              "shortname": null,
+              "value": "ORGANIZATION_NAME"
+            },
+            {
+              "help": "organization ID",
+              "name": "organization-id",
+              "shortname": null,
+              "value": "ORGANIZATION_ID"
+            },
+            {
+              "help": "Organization label to search by",
+              "name": "organization-label",
+              "shortname": null,
+              "value": "ORGANIZATION_LABEL"
+            },
+            {
+              "help": "Page number, starting at 1",
+              "name": "page",
+              "shortname": null,
+              "value": "PAGE"
+            },
+            {
+              "help": "Number of results per page to return",
+              "name": "per-page",
+              "shortname": null,
+              "value": "PER_PAGE"
+            },
+            {
+              "help": "Search string",
+              "name": "search",
+              "shortname": null,
+              "value": "SEARCH"
+            },
+            {
+              "help": "print help",
+              "name": "help",
+              "shortname": "h",
+              "value": null
+            }
+          ],
+          "subcommands": []
+        },
+        {
+          "description": "obtain manifest history for subscriptions",
+          "name": "manifest-history",
+          "options": [
+            {
+              "help": "Organization name to search by",
+              "name": "organization",
+              "shortname": null,
+              "value": "ORGANIZATION_NAME"
+            },
+            {
+              "help": "organization ID",
+              "name": "organization-id",
+              "shortname": null,
+              "value": "ORGANIZATION_ID"
+            },
+            {
+              "help": "Organization label to search by",
+              "name": "organization-label",
+              "shortname": null,
+              "value": "ORGANIZATION_LABEL"
+            },
+            {
+              "help": "print help",
+              "name": "help",
+              "shortname": "h",
+              "value": null
+            }
+          ],
+          "subcommands": []
+        },
+        {
+          "description": "Refresh previously imported manifest for Red Hat provider",
+          "name": "refresh-manifest",
+          "options": [
+            {
+              "help": "Do not wait for the task",
+              "name": "async",
+              "shortname": null,
+              "value": null
+            },
+            {
+              "help": "Organization name to search by",
+              "name": "organization",
+              "shortname": null,
+              "value": "ORGANIZATION_NAME"
+            },
+            {
+              "help": "organization ID",
+              "name": "organization-id",
+              "shortname": null,
+              "value": "ORGANIZATION_ID"
+            },
+            {
+              "help": "Organization label to search by",
+              "name": "organization-label",
+              "shortname": null,
+              "value": "ORGANIZATION_LABEL"
+            },
+            {
+              "help": "print help",
+              "name": "help",
+              "shortname": "h",
+              "value": null
+            }
+          ],
+          "subcommands": []
+        },
+        {
+          "description": "Upload a subscription manifest",
+          "name": "upload",
+          "options": [
+            {
+              "help": "Do not wait for the task",
+              "name": "async",
+              "shortname": null,
+              "value": null
+            },
+            {
+              "help": "Subscription manifest file",
+              "name": "file",
+              "shortname": null,
+              "value": "MANIFEST"
+            },
+            {
+              "help": "Organization name to search by",
+              "name": "organization",
+              "shortname": null,
+              "value": "ORGANIZATION_NAME"
+            },
+            {
+              "help": "organization ID",
+              "name": "organization-id",
+              "shortname": null,
+              "value": "ORGANIZATION_ID"
+            },
+            {
+              "help": "Organization label to search by",
+              "name": "organization-label",
+              "shortname": null,
+              "value": "ORGANIZATION_LABEL"
+            },
+            {
+              "help": "repository url",
+              "name": "repository-url",
+              "shortname": null,
+              "value": "REPOSITORY_URL"
+            },
+            {
+              "help": "print help",
+              "name": "help",
+              "shortname": "h",
+              "value": null
+            }
+          ],
+          "subcommands": []
+        }
+      ]
+    },
+    {
+      "description": "Manipulate sync plans",
+      "name": "sync-plan",
+      "options": [
+        {
+          "help": "print help",
+          "name": "help",
+          "shortname": "h",
+          "value": null
+        }
+      ],
+      "subcommands": [
+        {
+          "description": "Create a sync plan",
+          "name": "create",
+          "options": [
+            {
+              "help": "sync plan description",
+              "name": "description",
+              "shortname": null,
+              "value": "DESCRIPTION"
+            },
+            {
+              "help": "enables or disables synchronization One of true/false, yes/no, 1/0.",
+              "name": "enabled",
+              "shortname": null,
+              "value": "ENABLED"
+            },
+            {
+              "help": "how often synchronization should run One of 'none', 'hourly', 'daily', 'weekly' Default: \"none\"",
+              "name": "interval",
+              "shortname": null,
+              "value": "INTERVAL"
+            },
+            {
+              "help": "sync plan name",
+              "name": "name",
+              "shortname": null,
+              "value": "NAME"
+            },
+            {
+              "help": "Organization name to search by",
+              "name": "organization",
+              "shortname": null,
+              "value": "ORGANIZATION_NAME"
+            },
+            {
+              "help": "organization ID",
+              "name": "organization-id",
+              "shortname": null,
+              "value": "ORGANIZATION_ID"
+            },
+            {
+              "help": "Organization label to search by",
+              "name": "organization-label",
+              "shortname": null,
+              "value": "ORGANIZATION_LABEL"
+            },
+            {
+              "help": "start date and time of the synchronization defaults to now Date and time in YYYY-MM-DD HH:MM:SS or ISO 8601 format Default: \"2015-04-23 14:44:59\"",
+              "name": "sync-date",
+              "shortname": null,
+              "value": "SYNC_DATE"
+            },
+            {
+              "help": "print help",
+              "name": "help",
+              "shortname": "h",
+              "value": null
+            }
+          ],
+          "subcommands": []
+        },
+        {
+          "description": "Destroy a sync plan",
+          "name": "delete",
+          "options": [
+            {
+              "help": "sync plan numeric identifier",
+              "name": "id",
+              "shortname": null,
+              "value": "ID"
+            },
+            {
+              "help": "Sync plan name to search by",
+              "name": "name",
+              "shortname": null,
+              "value": "NAME"
+            },
+            {
+              "help": "Organization name to search by",
+              "name": "organization",
+              "shortname": null,
+              "value": "ORGANIZATION_NAME"
+            },
+            {
+              "help": "organization ID",
+              "name": "organization-id",
+              "shortname": null,
+              "value": "ORGANIZATION_ID"
+            },
+            {
+              "help": "Organization label to search by",
+              "name": "organization-label",
+              "shortname": null,
+              "value": "ORGANIZATION_LABEL"
+            },
+            {
+              "help": "print help",
+              "name": "help",
+              "shortname": "h",
+              "value": null
+            }
+          ],
+          "subcommands": []
+        },
+        {
+          "description": "Show a sync plan",
+          "name": "info",
+          "options": [
+            {
+              "help": "sync plan numeric identifier",
+              "name": "id",
+              "shortname": null,
+              "value": "ID"
+            },
+            {
+              "help": "Sync plan name to search by",
+              "name": "name",
+              "shortname": null,
+              "value": "NAME"
+            },
+            {
+              "help": "Organization name to search by",
+              "name": "organization",
+              "shortname": null,
+              "value": "ORGANIZATION_NAME"
+            },
+            {
+              "help": "organization ID",
+              "name": "organization-id",
+              "shortname": null,
+              "value": "ORGANIZATION_ID"
+            },
+            {
+              "help": "Organization label to search by",
+              "name": "organization-label",
+              "shortname": null,
+              "value": "ORGANIZATION_LABEL"
+            },
+            {
+              "help": "print help",
+              "name": "help",
+              "shortname": "h",
+              "value": null
+            }
+          ],
+          "subcommands": []
+        },
+        {
+          "description": "List sync plans",
+          "name": "list",
+          "options": [
+            {
+              "help": "filter by interval",
+              "name": "interval",
+              "shortname": null,
+              "value": "INTERVAL"
+            },
+            {
+              "help": "filter by name",
+              "name": "name",
+              "shortname": null,
+              "value": "NAME"
+            },
+            {
+              "help": "Organization name to search by",
+              "name": "organization",
+              "shortname": null,
+              "value": "ORGANIZATION_NAME"
+            },
+            {
+              "help": "organization ID",
+              "name": "organization-id",
+              "shortname": null,
+              "value": "ORGANIZATION_ID"
+            },
+            {
+              "help": "Organization label to search by",
+              "name": "organization-label",
+              "shortname": null,
+              "value": "ORGANIZATION_LABEL"
+            },
+            {
+              "help": "filter by sync date",
+              "name": "sync-date",
+              "shortname": null,
+              "value": "SYNC_DATE"
+            },
+            {
+              "help": "print help",
+              "name": "help",
+              "shortname": "h",
+              "value": null
+            }
+          ],
+          "subcommands": []
+        },
+        {
+          "description": "Update a sync plan",
+          "name": "update",
+          "options": [
+            {
+              "help": "sync plan description",
+              "name": "description",
+              "shortname": null,
+              "value": "DESCRIPTION"
+            },
+            {
+              "help": "enables or disables synchronization One of true/false, yes/no, 1/0.",
+              "name": "enabled",
+              "shortname": null,
+              "value": "ENABLED"
+            },
+            {
+              "help": "sync plan numeric identifier",
+              "name": "id",
+              "shortname": null,
+              "value": "ID"
+            },
+            {
+              "help": "how often synchronization should run One of 'none', 'hourly', 'daily', 'weekly'",
+              "name": "interval",
+              "shortname": null,
+              "value": "INTERVAL"
+            },
+            {
+              "help": "Sync plan name to search by",
+              "name": "name",
+              "shortname": null,
+              "value": "NAME"
+            },
+            {
+              "help": "sync plan name",
+              "name": "new-name",
+              "shortname": null,
+              "value": "NEW_NAME"
+            },
+            {
+              "help": "Organization name to search by",
+              "name": "organization",
+              "shortname": null,
+              "value": "ORGANIZATION_NAME"
+            },
+            {
+              "help": "organization ID",
+              "name": "organization-id",
+              "shortname": null,
+              "value": "ORGANIZATION_ID"
+            },
+            {
+              "help": "Organization label to search by",
+              "name": "organization-label",
+              "shortname": null,
+              "value": "ORGANIZATION_LABEL"
+            },
+            {
+              "help": "start date and time of the synchronization Date and time in YYYY-MM-DD HH:MM:SS or ISO 8601 format",
+              "name": "sync-date",
+              "shortname": null,
+              "value": "SYNC_DATE"
+            },
+            {
+              "help": "print help",
+              "name": "help",
+              "shortname": "h",
+              "value": null
+            }
+          ],
+          "subcommands": []
+        }
+      ]
+    },
+    {
+      "description": "Tasks related actions.",
+      "name": "task",
+      "options": [
+        {
+          "help": "print help",
+          "name": "help",
+          "shortname": "h",
+          "value": null
+        }
+      ],
+      "subcommands": [
+        {
+          "description": "Show the progress of the task",
+          "name": "progress",
+          "options": [
+            {
+              "help": "UUID of the task",
+              "name": "id",
+              "shortname": null,
+              "value": "ID"
+            },
+            {
+              "help": "Name to search by",
+              "name": "name",
+              "shortname": null,
+              "value": "NAME"
+            },
+            {
+              "help": "print help",
+              "name": "help",
+              "shortname": "h",
+              "value": null
+            }
+          ],
+          "subcommands": []
+        }
+      ]
+    },
+    {
+      "description": "Manipulate config templates.",
+      "name": "template",
+      "options": [
+        {
+          "help": "print help",
+          "name": "help",
+          "shortname": "h",
+          "value": null
+        }
+      ],
+      "subcommands": [
+        {
+          "description": "Associate an operating system",
+          "name": "add-operatingsystem",
+          "options": [
+            {
+              "help": "",
+              "name": "id",
+              "shortname": null,
+              "value": "ID"
+            },
+            {
+              "help": "Name to search by",
+              "name": "name",
+              "shortname": null,
+              "value": "NAME"
+            },
+            {
+              "help": "Operating system title",
+              "name": "operatingsystem",
+              "shortname": null,
+              "value": "OPERATINGSYSTEM_TITLE"
+            },
+            {
+              "help": "",
+              "name": "operatingsystem-id",
+              "shortname": null,
+              "value": "OPERATINGSYSTEM_ID"
+            },
+            {
+              "help": "print help",
+              "name": "help",
+              "shortname": "h",
+              "value": null
+            }
+          ],
+          "subcommands": []
+        },
+        {
+          "description": "Create a provisioning template",
+          "name": "create",
+          "options": [
+            {
+              "help": "",
+              "name": "audit-comment",
+              "shortname": null,
+              "value": "AUDIT_COMMENT"
+            },
+            {
+              "help": "Path to a file that contains the template",
+              "name": "file",
+              "shortname": null,
+              "value": "TEMPLATE"
+            },
+            {
+              "help": "REPLACE locations with given ids Comma separated list of values.",
+              "name": "location-ids",
+              "shortname": null,
+              "value": "LOCATION_IDS"
+            },
+            {
+              "help": "Comma separated list of values.",
+              "name": "locations",
+              "shortname": null,
+              "value": "LOCATION_NAMES"
+            },
+            {
+              "help": "Whether or not the template is locked for editing One of true/false, yes/no, 1/0.",
+              "name": "locked",
+              "shortname": null,
+              "value": "LOCKED"
+            },
+            {
+              "help": "template name",
+              "name": "name",
+              "shortname": null,
+              "value": "NAME"
+            },
+            {
+              "help": "Array of operating system IDs to associate with the template Comma separated list of values.",
+              "name": "operatingsystem-ids",
+              "shortname": null,
+              "value": "OPERATINGSYSTEM_IDS"
+            },
+            {
+              "help": "Comma separated list of values.",
+              "name": "operatingsystems",
+              "shortname": null,
+              "value": "OPERATINGSYSTEM_TITLES"
+            },
+            {
+              "help": "REPLACE organizations with given ids. Comma separated list of values.",
+              "name": "organization-ids",
+              "shortname": null,
+              "value": "ORGANIZATION_IDS"
+            },
+            {
+              "help": "Comma separated list of values.",
+              "name": "organizations",
+              "shortname": null,
+              "value": "ORGANIZATION_NAMES"
+            },
+            {
+              "help": "Template type. Eg. snippet, script, provision",
+              "name": "type",
+              "shortname": null,
+              "value": "TYPE"
+            },
+            {
+              "help": "print help",
+              "name": "help",
+              "shortname": "h",
+              "value": null
+            }
+          ],
+          "subcommands": []
+        },
+        {
+          "description": "Delete a provisioning template",
+          "name": "delete",
+          "options": [
+            {
+              "help": "",
+              "name": "id",
+              "shortname": null,
+              "value": "ID"
+            },
+            {
+              "help": "Name to search by",
+              "name": "name",
+              "shortname": null,
+              "value": "NAME"
+            },
+            {
+              "help": "print help",
+              "name": "help",
+              "shortname": "h",
+              "value": null
+            }
+          ],
+          "subcommands": []
+        },
+        {
+          "description": "View config template content.",
+          "name": "dump",
+          "options": [
+            {
+              "help": "",
+              "name": "id",
+              "shortname": null,
+              "value": "ID"
+            },
+            {
+              "help": "Name to search by",
+              "name": "name",
+              "shortname": null,
+              "value": "NAME"
+            },
+            {
+              "help": "print help",
+              "name": "help",
+              "shortname": "h",
+              "value": null
+            }
+          ],
+          "subcommands": []
+        },
+        {
+          "description": "Show provisioning template details",
+          "name": "info",
+          "options": [
+            {
+              "help": "",
+              "name": "id",
+              "shortname": null,
+              "value": "ID"
+            },
+            {
+              "help": "Name to search by",
+              "name": "name",
+              "shortname": null,
+              "value": "NAME"
+            },
+            {
+              "help": "print help",
+              "name": "help",
+              "shortname": "h",
+              "value": null
+            }
+          ],
+          "subcommands": []
+        },
+        {
+          "description": "List available config template kinds.",
+          "name": "kinds",
+          "options": [
+            {
+              "help": "print help",
+              "name": "help",
+              "shortname": "h",
+              "value": null
+            }
+          ],
+          "subcommands": []
+        },
+        {
+          "description": "List provisioning templates",
+          "name": "list",
+          "options": [
+            {
+              "help": "Location name",
+              "name": "location",
+              "shortname": null,
+              "value": "LOCATION_NAME"
+            },
+            {
+              "help": "",
+              "name": "location-id",
+              "shortname": null,
+              "value": "LOCATION_ID"
+            },
+            {
+              "help": "Operating system title",
+              "name": "operatingsystem",
+              "shortname": null,
+              "value": "OPERATINGSYSTEM_TITLE"
+            },
+            {
+              "help": "",
+              "name": "operatingsystem-id",
+              "shortname": null,
+              "value": "OPERATINGSYSTEM_ID"
+            },
+            {
+              "help": "sort results",
+              "name": "order",
+              "shortname": null,
+              "value": "ORDER"
+            },
+            {
+              "help": "Organization name",
+              "name": "organization",
+              "shortname": null,
+              "value": "ORGANIZATION_NAME"
+            },
+            {
+              "help": "organization ID",
+              "name": "organization-id",
+              "shortname": null,
+              "value": "ORGANIZATION_ID"
+            },
+            {
+              "help": "paginate results",
+              "name": "page",
+              "shortname": null,
+              "value": "PAGE"
+            },
+            {
+              "help": "number of entries per request",
+              "name": "per-page",
+              "shortname": null,
+              "value": "PER_PAGE"
+            },
+            {
+              "help": "filter results",
+              "name": "search",
+              "shortname": null,
+              "value": "SEARCH"
+            },
+            {
+              "help": "print help",
+              "name": "help",
+              "shortname": "h",
+              "value": null
+            }
+          ],
+          "subcommands": []
+        },
+        {
+          "description": "Disassociate an operating system",
+          "name": "remove-operatingsystem",
+          "options": [
+            {
+              "help": "",
+              "name": "id",
+              "shortname": null,
+              "value": "ID"
+            },
+            {
+              "help": "Name to search by",
+              "name": "name",
+              "shortname": null,
+              "value": "NAME"
+            },
+            {
+              "help": "Operating system title",
+              "name": "operatingsystem",
+              "shortname": null,
+              "value": "OPERATINGSYSTEM_TITLE"
+            },
+            {
+              "help": "",
+              "name": "operatingsystem-id",
+              "shortname": null,
+              "value": "OPERATINGSYSTEM_ID"
+            },
+            {
+              "help": "print help",
+              "name": "help",
+              "shortname": "h",
+              "value": null
+            }
+          ],
+          "subcommands": []
+        },
+        {
+          "description": "Update a provisioning template",
+          "name": "update",
+          "options": [
+            {
+              "help": "",
+              "name": "audit-comment",
+              "shortname": null,
+              "value": "AUDIT_COMMENT"
+            },
+            {
+              "help": "Path to a file that contains the template",
+              "name": "file",
+              "shortname": null,
+              "value": "TEMPLATE"
+            },
+            {
+              "help": "",
+              "name": "id",
+              "shortname": null,
+              "value": "ID"
+            },
+            {
+              "help": "REPLACE locations with given ids Comma separated list of values.",
+              "name": "location-ids",
+              "shortname": null,
+              "value": "LOCATION_IDS"
+            },
+            {
+              "help": "Comma separated list of values.",
+              "name": "locations",
+              "shortname": null,
+              "value": "LOCATION_NAMES"
+            },
+            {
+              "help": "Whether or not the template is locked for editing One of true/false, yes/no, 1/0.",
+              "name": "locked",
+              "shortname": null,
+              "value": "LOCKED"
+            },
+            {
+              "help": "Name to search by",
+              "name": "name",
+              "shortname": null,
+              "value": "NAME"
+            },
+            {
+              "help": "template name",
+              "name": "new-name",
+              "shortname": null,
+              "value": "NEW_NAME"
+            },
+            {
+              "help": "Array of operating system IDs to associate with the template Comma separated list of values.",
+              "name": "operatingsystem-ids",
+              "shortname": null,
+              "value": "OPERATINGSYSTEM_IDS"
+            },
+            {
+              "help": "Comma separated list of values.",
+              "name": "operatingsystems",
+              "shortname": null,
+              "value": "OPERATINGSYSTEM_TITLES"
+            },
+            {
+              "help": "REPLACE organizations with given ids. Comma separated list of values.",
+              "name": "organization-ids",
+              "shortname": null,
+              "value": "ORGANIZATION_IDS"
+            },
+            {
+              "help": "Comma separated list of values.",
+              "name": "organizations",
+              "shortname": null,
+              "value": "ORGANIZATION_NAMES"
+            },
+            {
+              "help": "Template type. Eg. snippet, script, provision",
+              "name": "type",
+              "shortname": null,
+              "value": "TYPE"
+            },
+            {
+              "help": "print help",
+              "name": "help",
+              "shortname": "h",
+              "value": null
+            }
+          ],
+          "subcommands": []
+        }
+      ]
+    },
+    {
+      "description": "Manipulate users.",
+      "name": "user",
+      "options": [
+        {
+          "help": "print help",
+          "name": "help",
+          "shortname": "h",
+          "value": null
+        }
+      ],
+      "subcommands": [
+        {
+          "description": "Assign a user role",
+          "name": "add-role",
+          "options": [
+            {
+              "help": "",
+              "name": "id",
+              "shortname": null,
+              "value": "ID"
+            },
+            {
+              "help": "User's login to search by",
+              "name": "login",
+              "shortname": null,
+              "value": "LOGIN"
+            },
+            {
+              "help": "User role name",
+              "name": "role",
+              "shortname": null,
+              "value": "ROLE_NAME"
+            },
+            {
+              "help": "",
+              "name": "role-id",
+              "shortname": null,
+              "value": "ROLE_ID"
+            },
+            {
+              "help": "print help",
+              "name": "help",
+              "shortname": "h",
+              "value": null
+            }
+          ],
+          "subcommands": []
+        },
+        {
+          "description": "Create a user",
+          "name": "create",
+          "options": [
+            {
+              "help": "is an admin account One of true/false, yes/no, 1/0.",
+              "name": "admin",
+              "shortname": null,
+              "value": "ADMIN"
+            },
+            {
+              "help": "",
+              "name": "auth-source-id",
+              "shortname": null,
+              "value": "AUTH_SOURCE_ID"
+            },
+            {
+              "help": "",
+              "name": "default-location-id",
+              "shortname": null,
+              "value": "DEFAULT_LOCATION_ID"
+            },
+            {
+              "help": "",
+              "name": "default-organization-id",
+              "shortname": null,
+              "value": "DEFAULT_ORGANIZATION_ID"
+            },
+            {
+              "help": "",
+              "name": "firstname",
+              "shortname": null,
+              "value": "FIRSTNAME"
+            },
+            {
+              "help": "",
+              "name": "lastname",
+              "shortname": null,
+              "value": "LASTNAME"
+            },
+            {
+              "help": "REPLACE locations with given ids Comma separated list of values.",
+              "name": "location-ids",
+              "shortname": null,
+              "value": "LOCATION_IDS"
+            },
+            {
+              "help": "Comma separated list of values.",
+              "name": "locations",
+              "shortname": null,
+              "value": "LOCATION_NAMES"
+            },
+            {
+              "help": "",
+              "name": "login",
+              "shortname": null,
+              "value": "LOGIN"
+            },
+            {
+              "help": "",
+              "name": "mail",
+              "shortname": null,
+              "value": "MAIL"
+            },
+            {
+              "help": "REPLACE organizations with given ids. Comma separated list of values.",
+              "name": "organization-ids",
+              "shortname": null,
+              "value": "ORGANIZATION_IDS"
+            },
+            {
+              "help": "Comma separated list of values.",
+              "name": "organizations",
+              "shortname": null,
+              "value": "ORGANIZATION_NAMES"
+            },
+            {
+              "help": "",
+              "name": "password",
+              "shortname": null,
+              "value": "PASSWORD"
+            },
+            {
+              "help": "print help",
+              "name": "help",
+              "shortname": "h",
+              "value": null
+            }
+          ],
+          "subcommands": []
+        },
+        {
+          "description": "Delete a user",
+          "name": "delete",
+          "options": [
+            {
+              "help": "",
+              "name": "id",
+              "shortname": null,
+              "value": "ID"
+            },
+            {
+              "help": "User's login to search by",
+              "name": "login",
+              "shortname": null,
+              "value": "LOGIN"
+            },
+            {
+              "help": "print help",
+              "name": "help",
+              "shortname": "h",
+              "value": null
+            }
+          ],
+          "subcommands": []
+        },
+        {
+          "description": "Show a user",
+          "name": "info",
+          "options": [
+            {
+              "help": "",
+              "name": "id",
+              "shortname": null,
+              "value": "ID"
+            },
+            {
+              "help": "User's login to search by",
+              "name": "login",
+              "shortname": null,
+              "value": "LOGIN"
+            },
+            {
+              "help": "print help",
+              "name": "help",
+              "shortname": "h",
+              "value": null
+            }
+          ],
+          "subcommands": []
+        },
+        {
+          "description": "List all users",
+          "name": "list",
+          "options": [
+            {
+              "help": "Name to search by",
+              "name": "auth-source-ldap",
+              "shortname": null,
+              "value": "AUTH_SOURCE_LDAP_NAME"
+            },
+            {
+              "help": "",
+              "name": "auth-source-ldap-id",
+              "shortname": null,
+              "value": "AUTH_SOURCE_LDAP_ID"
+            },
+            {
+              "help": "Location name",
+              "name": "location",
+              "shortname": null,
+              "value": "LOCATION_NAME"
+            },
+            {
+              "help": "",
+              "name": "location-id",
+              "shortname": null,
+              "value": "LOCATION_ID"
+            },
+            {
+              "help": "sort results",
+              "name": "order",
+              "shortname": null,
+              "value": "ORDER"
+            },
+            {
+              "help": "Organization name",
+              "name": "organization",
+              "shortname": null,
+              "value": "ORGANIZATION_NAME"
+            },
+            {
+              "help": "organization ID",
+              "name": "organization-id",
+              "shortname": null,
+              "value": "ORGANIZATION_ID"
+            },
+            {
+              "help": "paginate results",
+              "name": "page",
+              "shortname": null,
+              "value": "PAGE"
+            },
+            {
+              "help": "number of entries per request",
+              "name": "per-page",
+              "shortname": null,
+              "value": "PER_PAGE"
+            },
+            {
+              "help": "User role name",
+              "name": "role",
+              "shortname": null,
+              "value": "ROLE_NAME"
+            },
+            {
+              "help": "",
+              "name": "role-id",
+              "shortname": null,
+              "value": "ROLE_ID"
+            },
+            {
+              "help": "filter results",
+              "name": "search",
+              "shortname": null,
+              "value": "SEARCH"
+            },
+            {
+              "help": "Name to search by",
+              "name": "user-group",
+              "shortname": null,
+              "value": "USER_GROUP_NAME"
+            },
+            {
+              "help": "",
+              "name": "user-group-id",
+              "shortname": null,
+              "value": "USER_GROUP_ID"
+            },
+            {
+              "help": "print help",
+              "name": "help",
+              "shortname": "h",
+              "value": null
+            }
+          ],
+          "subcommands": []
+        },
+        {
+          "description": "Remove a user role",
+          "name": "remove-role",
+          "options": [
+            {
+              "help": "",
+              "name": "id",
+              "shortname": null,
+              "value": "ID"
+            },
+            {
+              "help": "User's login to search by",
+              "name": "login",
+              "shortname": null,
+              "value": "LOGIN"
+            },
+            {
+              "help": "User role name",
+              "name": "role",
+              "shortname": null,
+              "value": "ROLE_NAME"
+            },
+            {
+              "help": "",
+              "name": "role-id",
+              "shortname": null,
+              "value": "ROLE_ID"
+            },
+            {
+              "help": "print help",
+              "name": "help",
+              "shortname": "h",
+              "value": null
+            }
+          ],
+          "subcommands": []
+        },
+        {
+          "description": "Update a user",
+          "name": "update",
+          "options": [
+            {
+              "help": "is an admin account One of true/false, yes/no, 1/0.",
+              "name": "admin",
+              "shortname": null,
+              "value": "ADMIN"
+            },
+            {
+              "help": "",
+              "name": "auth-source-id",
+              "shortname": null,
+              "value": "AUTH_SOURCE_ID"
+            },
+            {
+              "help": "",
+              "name": "default-location-id",
+              "shortname": null,
+              "value": "DEFAULT_LOCATION_ID"
+            },
+            {
+              "help": "",
+              "name": "default-organization-id",
+              "shortname": null,
+              "value": "DEFAULT_ORGANIZATION_ID"
+            },
+            {
+              "help": "",
+              "name": "firstname",
+              "shortname": null,
+              "value": "FIRSTNAME"
+            },
+            {
+              "help": "",
+              "name": "id",
+              "shortname": null,
+              "value": "ID"
+            },
+            {
+              "help": "",
+              "name": "lastname",
+              "shortname": null,
+              "value": "LASTNAME"
+            },
+            {
+              "help": "REPLACE locations with given ids Comma separated list of values.",
+              "name": "location-ids",
+              "shortname": null,
+              "value": "LOCATION_IDS"
+            },
+            {
+              "help": "Comma separated list of values.",
+              "name": "locations",
+              "shortname": null,
+              "value": "LOCATION_NAMES"
+            },
+            {
+              "help": "User's login to search by",
+              "name": "login",
+              "shortname": null,
+              "value": "LOGIN"
+            },
+            {
+              "help": "",
+              "name": "mail",
+              "shortname": null,
+              "value": "MAIL"
+            },
+            {
+              "help": "",
+              "name": "new-login",
+              "shortname": null,
+              "value": "NEW_LOGIN"
+            },
+            {
+              "help": "REPLACE organizations with given ids. Comma separated list of values.",
+              "name": "organization-ids",
+              "shortname": null,
+              "value": "ORGANIZATION_IDS"
+            },
+            {
+              "help": "Comma separated list of values.",
+              "name": "organizations",
+              "shortname": null,
+              "value": "ORGANIZATION_NAMES"
+            },
+            {
+              "help": "",
+              "name": "password",
+              "shortname": null,
+              "value": "PASSWORD"
+            },
+            {
+              "help": "print help",
+              "name": "help",
+              "shortname": "h",
+              "value": null
+            }
+          ],
+          "subcommands": []
+        }
+      ]
+    },
+    {
+      "description": "Manage user groups.",
+      "name": "user-group",
+      "options": [
+        {
+          "help": "print help",
+          "name": "help",
+          "shortname": "h",
+          "value": null
+        }
+      ],
+      "subcommands": [
+        {
+          "description": "Assign a user role",
+          "name": "add-role",
+          "options": [
+            {
+              "help": "",
+              "name": "id",
+              "shortname": null,
+              "value": "ID"
+            },
+            {
+              "help": "Name to search by",
+              "name": "name",
+              "shortname": null,
+              "value": "NAME"
+            },
+            {
+              "help": "User role name",
+              "name": "role",
+              "shortname": null,
+              "value": "ROLE_NAME"
+            },
+            {
+              "help": "",
+              "name": "role-id",
+              "shortname": null,
+              "value": "ROLE_ID"
+            },
+            {
+              "help": "print help",
+              "name": "help",
+              "shortname": "h",
+              "value": null
+            }
+          ],
+          "subcommands": []
+        },
+        {
+          "description": "Associate an user",
+          "name": "add-user",
+          "options": [
+            {
+              "help": "",
+              "name": "id",
+              "shortname": null,
+              "value": "ID"
+            },
+            {
+              "help": "Name to search by",
+              "name": "name",
+              "shortname": null,
+              "value": "NAME"
+            },
+            {
+              "help": "User's login to search by",
+              "name": "user",
+              "shortname": null,
+              "value": "USER_LOGIN"
+            },
+            {
+              "help": "",
+              "name": "user-id",
+              "shortname": null,
+              "value": "USER_ID"
+            },
+            {
+              "help": "print help",
+              "name": "help",
+              "shortname": "h",
+              "value": null
+            }
+          ],
+          "subcommands": []
+        },
+        {
+          "description": "Associate an user group",
+          "name": "add-user-group",
+          "options": [
+            {
+              "help": "",
+              "name": "id",
+              "shortname": null,
+              "value": "ID"
+            },
+            {
+              "help": "Name to search by",
+              "name": "name",
+              "shortname": null,
+              "value": "NAME"
+            },
+            {
+              "help": "Name to search by",
+              "name": "user-group",
+              "shortname": null,
+              "value": "USER_GROUP_NAME"
+            },
+            {
+              "help": "",
+              "name": "user-group-id",
+              "shortname": null,
+              "value": "USER_GROUP_ID"
+            },
+            {
+              "help": "print help",
+              "name": "help",
+              "shortname": "h",
+              "value": null
+            }
+          ],
+          "subcommands": []
+        },
+        {
+          "description": "Create a user group",
+          "name": "create",
+          "options": [
+            {
+              "help": "",
+              "name": "name",
+              "shortname": null,
+              "value": "NAME"
+            },
+            {
+              "help": "Comma separated list of values.",
+              "name": "role-ids",
+              "shortname": null,
+              "value": "ROLE_IDS"
+            },
+            {
+              "help": "Comma separated list of values.",
+              "name": "roles",
+              "shortname": null,
+              "value": "ROLE_NAMES"
+            },
+            {
+              "help": "Comma separated list of values.",
+              "name": "user-group-ids",
+              "shortname": null,
+              "value": "USER_GROUP_IDS"
+            },
+            {
+              "help": "Comma separated list of values.",
+              "name": "user-groups",
+              "shortname": null,
+              "value": "USER_GROUP_NAMES"
+            },
+            {
+              "help": "Comma separated list of values.",
+              "name": "user-ids",
+              "shortname": null,
+              "value": "USER_IDS"
+            },
+            {
+              "help": "Comma separated list of values.",
+              "name": "users",
+              "shortname": null,
+              "value": "USER_LOGINS"
+            },
+            {
+              "help": "print help",
+              "name": "help",
+              "shortname": "h",
+              "value": null
+            }
+          ],
+          "subcommands": []
+        },
+        {
+          "description": "Delete a user group",
+          "name": "delete",
+          "options": [
+            {
+              "help": "",
+              "name": "id",
+              "shortname": null,
+              "value": "ID"
+            },
+            {
+              "help": "Name to search by",
+              "name": "name",
+              "shortname": null,
+              "value": "NAME"
+            },
+            {
+              "help": "print help",
+              "name": "help",
+              "shortname": "h",
+              "value": null
+            }
+          ],
+          "subcommands": []
+        },
+        {
+          "description": "View and manage user group's external user groups",
+          "name": "external",
+          "options": [
+            {
+              "help": "print help",
+              "name": "help",
+              "shortname": "h",
+              "value": null
+            }
+          ],
+          "subcommands": [
+            {
+              "description": "Create an external user group linked to a user group",
+              "name": "create",
+              "options": [
+                {
+                  "help": "ID of linked authentication source",
+                  "name": "auth-source-id",
+                  "shortname": null,
+                  "value": "AUTH_SOURCE_ID"
+                },
+                {
+                  "help": "External user group name",
+                  "name": "name",
+                  "shortname": null,
+                  "value": "NAME"
+                },
+                {
+                  "help": "Name to search by",
+                  "name": "user-group",
+                  "shortname": null,
+                  "value": "USER_GROUP_NAME"
+                },
+                {
+                  "help": "",
+                  "name": "user-group-id",
+                  "shortname": null,
+                  "value": "USER_GROUP_ID"
+                },
+                {
+                  "help": "print help",
+                  "name": "help",
+                  "shortname": "h",
+                  "value": null
+                }
+              ],
+              "subcommands": []
+            },
+            {
+              "description": "Delete an external user group",
+              "name": "delete",
+              "options": [
+                {
+                  "help": "ID or name external user group",
+                  "name": "id",
+                  "shortname": null,
+                  "value": "ID"
+                },
+                {
+                  "help": "Name to search by",
+                  "name": "name",
+                  "shortname": null,
+                  "value": "NAME"
+                },
+                {
+                  "help": "Name to search by",
+                  "name": "user-group",
+                  "shortname": null,
+                  "value": "USER_GROUP_NAME"
+                },
+                {
+                  "help": "",
+                  "name": "user-group-id",
+                  "shortname": null,
+                  "value": "USER_GROUP_ID"
+                },
+                {
+                  "help": "print help",
+                  "name": "help",
+                  "shortname": "h",
+                  "value": null
+                }
+              ],
+              "subcommands": []
+            },
+            {
+              "description": "Show an external user group for user group",
+              "name": "info",
+              "options": [
+                {
+                  "help": "ID or name of external user group",
+                  "name": "id",
+                  "shortname": null,
+                  "value": "ID"
+                },
+                {
+                  "help": "Name to search by",
+                  "name": "name",
+                  "shortname": null,
+                  "value": "NAME"
+                },
+                {
+                  "help": "Name to search by",
+                  "name": "user-group",
+                  "shortname": null,
+                  "value": "USER_GROUP_NAME"
+                },
+                {
+                  "help": "",
+                  "name": "user-group-id",
+                  "shortname": null,
+                  "value": "USER_GROUP_ID"
+                },
+                {
+                  "help": "print help",
+                  "name": "help",
+                  "shortname": "h",
+                  "value": null
+                }
+              ],
+              "subcommands": []
+            },
+            {
+              "description": "List all external user groups for user group",
+              "name": "list",
+              "options": [
+                {
+                  "help": "Name to search by",
+                  "name": "user-group",
+                  "shortname": null,
+                  "value": "USER_GROUP_NAME"
+                },
+                {
+                  "help": "",
+                  "name": "user-group-id",
+                  "shortname": null,
+                  "value": "USER_GROUP_ID"
+                },
+                {
+                  "help": "print help",
+                  "name": "help",
+                  "shortname": "h",
+                  "value": null
+                }
+              ],
+              "subcommands": []
+            },
+            {
+              "description": "Refresh external user group",
+              "name": "refresh",
+              "options": [
+                {
+                  "help": "ID or name of external user group",
+                  "name": "id",
+                  "shortname": null,
+                  "value": "ID"
+                },
+                {
+                  "help": "Name to search by",
+                  "name": "name",
+                  "shortname": null,
+                  "value": "NAME"
+                },
+                {
+                  "help": "Name to search by",
+                  "name": "user-group",
+                  "shortname": null,
+                  "value": "USER_GROUP_NAME"
+                },
+                {
+                  "help": "",
+                  "name": "user-group-id",
+                  "shortname": null,
+                  "value": "USER_GROUP_ID"
+                },
+                {
+                  "help": "print help",
+                  "name": "help",
+                  "shortname": "h",
+                  "value": null
+                }
+              ],
+              "subcommands": []
+            },
+            {
+              "description": "Update external user group",
+              "name": "update",
+              "options": [
+                {
+                  "help": "ID of linked authentication source",
+                  "name": "auth-source-id",
+                  "shortname": null,
+                  "value": "AUTH_SOURCE_ID"
+                },
+                {
+                  "help": "ID or name of external user group",
+                  "name": "id",
+                  "shortname": null,
+                  "value": "ID"
+                },
+                {
+                  "help": "Name to search by",
+                  "name": "name",
+                  "shortname": null,
+                  "value": "NAME"
+                },
+                {
+                  "help": "External user group name",
+                  "name": "new-name",
+                  "shortname": null,
+                  "value": "NEW_NAME"
+                },
+                {
+                  "help": "Name to search by",
+                  "name": "user-group",
+                  "shortname": null,
+                  "value": "USER_GROUP_NAME"
+                },
+                {
+                  "help": "",
+                  "name": "user-group-id",
+                  "shortname": null,
+                  "value": "USER_GROUP_ID"
+                },
+                {
+                  "help": "print help",
+                  "name": "help",
+                  "shortname": "h",
+                  "value": null
+                }
+              ],
+              "subcommands": []
+            }
+          ]
+        },
+        {
+          "description": "Show a user group",
+          "name": "info",
+          "options": [
+            {
+              "help": "",
+              "name": "id",
+              "shortname": null,
+              "value": "ID"
+            },
+            {
+              "help": "Name to search by",
+              "name": "name",
+              "shortname": null,
+              "value": "NAME"
+            },
+            {
+              "help": "print help",
+              "name": "help",
+              "shortname": "h",
+              "value": null
+            }
+          ],
+          "subcommands": []
+        },
+        {
+          "description": "List all user groups",
+          "name": "list",
+          "options": [
+            {
+              "help": "sort results",
+              "name": "order",
+              "shortname": null,
+              "value": "ORDER"
+            },
+            {
+              "help": "paginate results",
+              "name": "page",
+              "shortname": null,
+              "value": "PAGE"
+            },
+            {
+              "help": "number of entries per request",
+              "name": "per-page",
+              "shortname": null,
+              "value": "PER_PAGE"
+            },
+            {
+              "help": "filter results",
+              "name": "search",
+              "shortname": null,
+              "value": "SEARCH"
+            },
+            {
+              "help": "print help",
+              "name": "help",
+              "shortname": "h",
+              "value": null
+            }
+          ],
+          "subcommands": []
+        },
+        {
+          "description": "Remove a user role",
+          "name": "remove-role",
+          "options": [
+            {
+              "help": "",
+              "name": "id",
+              "shortname": null,
+              "value": "ID"
+            },
+            {
+              "help": "Name to search by",
+              "name": "name",
+              "shortname": null,
+              "value": "NAME"
+            },
+            {
+              "help": "User role name",
+              "name": "role",
+              "shortname": null,
+              "value": "ROLE_NAME"
+            },
+            {
+              "help": "",
+              "name": "role-id",
+              "shortname": null,
+              "value": "ROLE_ID"
+            },
+            {
+              "help": "print help",
+              "name": "help",
+              "shortname": "h",
+              "value": null
+            }
+          ],
+          "subcommands": []
+        },
+        {
+          "description": "Disassociate an user",
+          "name": "remove-user",
+          "options": [
+            {
+              "help": "",
+              "name": "id",
+              "shortname": null,
+              "value": "ID"
+            },
+            {
+              "help": "Name to search by",
+              "name": "name",
+              "shortname": null,
+              "value": "NAME"
+            },
+            {
+              "help": "User's login to search by",
+              "name": "user",
+              "shortname": null,
+              "value": "USER_LOGIN"
+            },
+            {
+              "help": "",
+              "name": "user-id",
+              "shortname": null,
+              "value": "USER_ID"
+            },
+            {
+              "help": "print help",
+              "name": "help",
+              "shortname": "h",
+              "value": null
+            }
+          ],
+          "subcommands": []
+        },
+        {
+          "description": "Disassociate an user group",
+          "name": "remove-user-group",
+          "options": [
+            {
+              "help": "",
+              "name": "id",
+              "shortname": null,
+              "value": "ID"
+            },
+            {
+              "help": "Name to search by",
+              "name": "name",
+              "shortname": null,
+              "value": "NAME"
+            },
+            {
+              "help": "Name to search by",
+              "name": "user-group",
+              "shortname": null,
+              "value": "USER_GROUP_NAME"
+            },
+            {
+              "help": "",
+              "name": "user-group-id",
+              "shortname": null,
+              "value": "USER_GROUP_ID"
+            },
+            {
+              "help": "print help",
+              "name": "help",
+              "shortname": "h",
+              "value": null
+            }
+          ],
+          "subcommands": []
+        },
+        {
+          "description": "Update a user group",
+          "name": "update",
+          "options": [
+            {
+              "help": "",
+              "name": "id",
+              "shortname": null,
+              "value": "ID"
+            },
+            {
+              "help": "Name to search by",
+              "name": "name",
+              "shortname": null,
+              "value": "NAME"
+            },
+            {
+              "help": "",
+              "name": "new-name",
+              "shortname": null,
+              "value": "NEW_NAME"
+            },
+            {
+              "help": "Comma separated list of values.",
+              "name": "role-ids",
+              "shortname": null,
+              "value": "ROLE_IDS"
+            },
+            {
+              "help": "Comma separated list of values.",
+              "name": "roles",
+              "shortname": null,
+              "value": "ROLE_NAMES"
+            },
+            {
+              "help": "Comma separated list of values.",
+              "name": "user-group-ids",
+              "shortname": null,
+              "value": "USER_GROUP_IDS"
+            },
+            {
+              "help": "Comma separated list of values.",
+              "name": "user-groups",
+              "shortname": null,
+              "value": "USER_GROUP_NAMES"
+            },
+            {
+              "help": "Comma separated list of values.",
+              "name": "user-ids",
+              "shortname": null,
+              "value": "USER_IDS"
+            },
+            {
+              "help": "Comma separated list of values.",
+              "name": "users",
+              "shortname": null,
+              "value": "USER_LOGINS"
+            },
+            {
+              "help": "print help",
+              "name": "help",
+              "shortname": "h",
+              "value": null
+            }
+          ],
+          "subcommands": []
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
Created two logically separated commits to accomplish the following:

* Add hammer_command_tree script:
  The script generate a json file with hammer subcommands and options by
  recursively getting the help from each command.
* Add test for checking all hammer subcommands:
  Check if all expected subcommands and options are available on hammer.
  The checking is accomplished by using a previous created json file which
  maps all expected information. Closes #1862

This PR depends on the changes introduced by #2115, make sure that it is merged before merging this.