### PR TITLE
Update from NailGun 0.10.0 to 0.11.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import find_packages, setup
 REQUIRES = [
     'ddt',
     'fauxfactory',
-    'nailgun==0.10.0',
+    'nailgun==0.11.0',
     'paramiko',
     'python-bugzilla',
     'requests',

--- a/tests/foreman/api/test_activationkey.py
+++ b/tests/foreman/api/test_activationkey.py
@@ -184,15 +184,13 @@ class ActivationKeysTestCase(APITestCase):
         """
         # Create an activation key.
         try:
-            activation_key = entities.ActivationKey(
-                id=entities.ActivationKey().create_json()['id']
-            )
+            activation_key = entities.ActivationKey().create()
         except HTTPError as err:
             self.fail(err)
 
         # Update the activation key.
-        description = entities.ActivationKey.description.gen_value()
-        response = client.put(
+        description = activation_key.get_fields()['description'].gen_value()
+        client.put(
             activation_key.path(),
             {
                 'description': description,
@@ -201,14 +199,13 @@ class ActivationKeysTestCase(APITestCase):
             },
             auth=get_server_credentials(),
             verify=False,
-        )
-        response.raise_for_status()
+        ).raise_for_status()
 
         # Fetch the activation key. Assert that values have been updated.
-        real_attrs = activation_key.read_json()
-        self.assertEqual(real_attrs['description'], description)
-        self.assertEqual(real_attrs['max_content_hosts'], max_content_hosts)
-        self.assertFalse(real_attrs['unlimited_content_hosts'])
+        activation_key = activation_key.read()
+        self.assertEqual(activation_key.description, description)
+        self.assertEqual(activation_key.max_content_hosts, max_content_hosts)
+        self.assertFalse(activation_key.unlimited_content_hosts)
 
     @data(
         gen_string(str_type='alpha'),

--- a/tests/foreman/api/test_contentview.py
+++ b/tests/foreman/api/test_contentview.py
@@ -785,13 +785,14 @@ class ContentViewUpdateTestCase(APITestCase):
     @classmethod
     def setUpClass(cls):  # noqa
         """Create a content view."""
-        cls.content_view = entities.ContentView(
-            id=entities.ContentView().create_json()['id']
-        )
+        cls.content_view = entities.ContentView().create()
 
     @data(
-        {u'name': entities.ContentView.name.gen_value()},
-        {u'description': entities.ContentView.description.gen_value()},
+        {u'name': entities.ContentView().get_fields()['name'].gen_value()},
+        {
+            u'description':
+            entities.ContentView().get_fields()['description'].gen_value()
+        },
     )
     def test_positive_update(self, attrs):
         """@Test: Update a content view and provide valid attributes.

--- a/tests/foreman/api/test_permission.py
+++ b/tests/foreman/api/test_permission.py
@@ -262,14 +262,14 @@ class UserRoleTestCase(APITestCase):
         with self.assertRaises(HTTPError):
             client.put(
                 entity.path(),
-                {u'name': entity_cls.name.gen_value()},
+                {u'name': entity.get_fields()['name'].gen_value()},
                 auth=self.server_config.auth,
                 verify=self.server_config.verify,
             ).raise_for_status()
         self.give_user_permission(_permission_name(entity_cls, 'update'))
         client.put(
             entity.path(),
-            {u'name': entity_cls.name.gen_value()},
+            {u'name': entity.get_fields()['name'].gen_value()},
             auth=self.server_config.auth,
             verify=self.server_config.verify,
         ).raise_for_status()


### PR DESCRIPTION
NailGun 0.11.0 brings a major change: ServerConfig objects now have a
``version`` attribute denoting the version of software the remote server is
running, and this allows entity objects to vary their definitions based on the
software version the remote server is running. Why is this useful? As an
example, Satellite 6.1.0 added support for docker, and as a result, the
definition of the `Repository` entity is different before and after:

    >>> from nailgun.config import ServerConfig
    >>> from nailgun.entities import Repository
    >>> sat608_cfg = ServerConfig('http://old-sat.example.com', version='6.0.8')
    >>> sat610_cfg = ServerConfig('http://new-sat.example.com', version='6.1')
    >>> set(Repository(sat608_cfg).get_fields().keys()) == set((
    ...     'content_type',
    ...     'gpg_key',
    ...     'id',
    ...     'label',
    ...     'name',
    ...     'product',
    ...     'unprotected',
    ...     'url',
    ... ))
    True
    >>> set(Repository(sat610_cfg).get_fields().keys()) == set((
    ...     'checksum_type',
    ...     'content_type',
    ...     'docker_upstream_name',
    ...     'gpg_key',
    ...     'id',
    ...     'label',
    ...     'name',
    ...     'product',
    ...     'unprotected',
    ...     'url',
    ... ))
    True

Test results when run against an upstream system:

    $ nosetests tests/foreman/api/test_multiple_paths.py
    ...S...S......S...............................................................S...S..........................................................................................................................................SSSS.SSSSSS..S.S.SSSSSS...SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSS
    ----------------------------------------------------------------------
    Ran 278 tests in 471.324s

    OK (SKIP=54)

All occurrences of `gen_value` had to be refactored:

    $ nosetests tests/foreman/api/test_repository.py -m test_update_name
    .S
    ----------------------------------------------------------------------
    Ran 2 tests in 9.307s

    OK (SKIP=1)
    $ nosetests tests/foreman/api/test_repository.py -m test_create_same_name
    .
    ----------------------------------------------------------------------
    Ran 1 test in 15.817s

    OK
    $ nosetests tests/foreman/api/test_organization.py
    ..................S...............
    ----------------------------------------------------------------------
    Ran 34 tests in 55.092s

    OK (SKIP=1)
    $ nosetests tests/foreman/api/test_contentview.py:ContentViewUpdateTestCase
    S...
    ----------------------------------------------------------------------
    Ran 4 tests in 6.253s

    OK (SKIP=1)
    $ nosetests tests/foreman/api/test_activationkey.py -m test_positive_update_1
    ..
    ----------------------------------------------------------------------
    Ran 2 tests in 8.211s

    OK