### PR TITLE
Fix API smoke test `test_get_links`

### DIFF
--- a/tests/foreman/smoke/test_api_smoke.py
+++ b/tests/foreman/smoke/test_api_smoke.py
@@ -570,8 +570,9 @@ API_PATHS = {
         u'/katello/api/organizations/:organization_id/products/:product_id/sync',
     ),
     u'system_errata': (
-        u'/katello/api/systems/:system_id/errata/apply',
+        u'/katello/api/systems/:system_id/errata',
         u'/katello/api/systems/:system_id/errata/:id',
+        u'/katello/api/systems/:system_id/errata/apply',
     ),
     u'system_packages': (
         u'/katello/api/systems/:system_id/packages/install',
@@ -597,7 +598,6 @@ API_PATHS = {
         u'/katello/api/systems/:id',
         u'/katello/api/systems/:id',
         u'/katello/api/systems/:id/available_host_collections',
-        u'/katello/api/systems/:id/errata',
         u'/katello/api/systems/:id/events',
         u'/katello/api/systems/:id/packages',
         u'/katello/api/systems/:id/pools',


### PR DESCRIPTION
The set of paths advertised by the API has changed. Test results against a
downstream system:

    $ nosetests tests/foreman/smoke/test_api_smoke.py -m test_get_links
    .
    ----------------------------------------------------------------------
    Ran 1 test in 3.038s

    OK

Note that upstream systems advertise a different set of paths. This test will
fail when run against one of them.