### PR TITLE
Create constant for default subscription name

### DIFF
--- a/robottelo/common/constants.py
+++ b/robottelo/common/constants.py
@@ -174,6 +174,7 @@ DEFAULT_ORG = "Default Organization"
 #: Name (not label!) of the default location.
 DEFAULT_LOC = "Default Location"
 DEFAULT_CV = "Default Organization View"
+DEFAULT_SUBSCRIPTION_NAME = 'Employee SKU'
 
 LANGUAGES = ["en", "en_GB",
              "fr", "gl",

--- a/tests/foreman/smoke/test_api_smoke.py
+++ b/tests/foreman/smoke/test_api_smoke.py
@@ -5,7 +5,12 @@ from nailgun import client, entities
 from robottelo.api import utils
 from robottelo.api.utils import status_code_error
 from robottelo.common.constants import (
-    DEFAULT_LOC, DEFAULT_ORG, FAKE_0_PUPPET_REPO, GOOGLE_CHROME_REPO)
+    DEFAULT_LOC,
+    DEFAULT_ORG,
+    DEFAULT_SUBSCRIPTION_NAME,
+    FAKE_0_PUPPET_REPO,
+    GOOGLE_CHROME_REPO,
+)
 from robottelo.common.decorators import bz_bug_is_open, skip_if_bug_open
 from robottelo.common.helpers import (
     get_distro_info,
@@ -1103,7 +1108,7 @@ class TestSmoke(TestCase):
         # Walk through the list of subscriptions. Find the "Red Hat Employee
         # Subscription" and attach it to the just-created activation key.
         for subscription in entities.Organization(id=org['id']).subscriptions():
-            if subscription['product_name'] == "Red Hat Employee Subscription":
+            if subscription['product_name'] == DEFAULT_SUBSCRIPTION_NAME:
                 # 'quantity' must be 1, not subscription['quantity']. Greater
                 # values produce this error: "RuntimeError: Error: Only pools
                 # with multi-entitlement product subscriptions can be added to

--- a/tests/foreman/smoke/test_cli_smoke.py
+++ b/tests/foreman/smoke/test_cli_smoke.py
@@ -21,7 +21,12 @@ from robottelo.cli.subnet import Subnet
 from robottelo.cli.subscription import Subscription
 from robottelo.cli.user import User
 from robottelo.common.constants import (
-    DEFAULT_LOC, DEFAULT_ORG, FAKE_0_PUPPET_REPO, GOOGLE_CHROME_REPO)
+    DEFAULT_LOC,
+    DEFAULT_ORG,
+    DEFAULT_SUBSCRIPTION_NAME,
+    FAKE_0_PUPPET_REPO,
+    GOOGLE_CHROME_REPO
+)
 from robottelo.common.helpers import generate_strings_list
 from robottelo.common import manifests
 from robottelo.common.ssh import upload_file
@@ -641,7 +646,7 @@ class TestSmoke(CLITestCase):
         )
         # Get the subscription ID from subscriptions list
         for subscription in result.stdout:
-            if subscription['name'] == "Red Hat Employee Subscription":
+            if subscription['name'] == DEFAULT_SUBSCRIPTION_NAME:
                 subscription_id = subscription['id']
                 subscription_quantity = int(subscription['quantity'])
         self.assertGreater(

--- a/tests/foreman/smoke/test_ui_smoke.py
+++ b/tests/foreman/smoke/test_ui_smoke.py
@@ -5,8 +5,17 @@ from fauxfactory import gen_string, gen_ipaddr
 from robottelo.common import conf
 from robottelo.common import manifests
 from robottelo.common.constants import (
-    FAKE_0_PUPPET_REPO, GOOGLE_CHROME_REPO, REPO_TYPE, FOREMAN_PROVIDERS,
-    DOMAIN, DEFAULT_ORG, DEFAULT_LOC, RHVA_REPO_TREE, REPOSET)
+    DEFAULT_LOC,
+    DEFAULT_ORG,
+    DEFAULT_SUBSCRIPTION_NAME,
+    DOMAIN,
+    FAKE_0_PUPPET_REPO,
+    FOREMAN_PROVIDERS,
+    GOOGLE_CHROME_REPO,
+    REPOSET,
+    REPO_TYPE,
+    RHVA_REPO_TREE,
+)
 from robottelo.common.decorators import bz_bug_is_open
 from robottelo.common.ssh import upload_file
 from robottelo.test import UITestCase
@@ -229,7 +238,7 @@ class TestSmoke(UITestCase):
         cv_name = gen_string("alpha", 6)
         activation_key_name = gen_string("alpha", 6)
         env_name = gen_string("alpha", 6)
-        product_name = "Red Hat Employee Subscription"
+        product_name = DEFAULT_SUBSCRIPTION_NAME
         repo_names = [
             "Red Hat Enterprise Virtualization Agents for RHEL 6 Server "
             "RPMs x86_64 6.5",

--- a/tests/foreman/ui/test_activationkey.py
+++ b/tests/foreman/ui/test_activationkey.py
@@ -7,7 +7,13 @@ from nailgun import client, entities
 from robottelo.api import utils
 from robottelo.common import manifests
 from robottelo.common.constants import (
-    ENVIRONMENT, FAKE_1_YUM_REPO, FAKE_2_YUM_REPO, DEFAULT_CV, REPO_TYPE)
+    DEFAULT_CV,
+    DEFAULT_SUBSCRIPTION_NAME,
+    ENVIRONMENT,
+    FAKE_1_YUM_REPO,
+    FAKE_2_YUM_REPO,
+    REPO_TYPE,
+)
 from robottelo.common.decorators import (
     data, run_only_on, skip_if_bug_open, stubbed)
 from robottelo.common.helpers import (
@@ -1068,7 +1074,7 @@ class ActivationKey(UITestCase):
             'basearch': "x86_64",
             'releasever': "6Server",
         }
-        product_subscription = "Red Hat Employee Subscription"
+        product_subscription = DEFAULT_SUBSCRIPTION_NAME
         # Create new org to import manifest
         org_attrs = entities.Organization().create_json()
         org_id = org_attrs['id']
@@ -1147,7 +1153,7 @@ class ActivationKey(UITestCase):
             'basearch': "x86_64",
             'releasever': "6Server",
         }
-        product_subscription = "Red Hat Employee Subscription"
+        product_subscription = DEFAULT_SUBSCRIPTION_NAME
         custom_product_name = gen_string("alpha", 8)
         repo_name = gen_string("alpha", 8)
         # Create new org to import manifest

--- a/tests/foreman/ui/test_subscription.py
+++ b/tests/foreman/ui/test_subscription.py
@@ -3,6 +3,7 @@
 from ddt import ddt
 from nailgun import entities
 from robottelo.common import manifests
+from robottelo.common.constants import DEFAULT_SUBSCRIPTION_NAME
 from robottelo.common.decorators import skipRemote
 from robottelo.common.ssh import upload_file
 from robottelo.test import UITestCase
@@ -86,4 +87,4 @@ class SubscriptionTestCase(UITestCase):
             self.assertTrue(self.subscriptions.wait_until_element(alert_loc))
             self.assertTrue(self.subscriptions.wait_until_element(del_mf))
             self.assertIsNone(
-                self.subscriptions.search("Red Hat Employee Subscription"))
+                self.subscriptions.search(DEFAULT_SUBSCRIPTION_NAME))


### PR DESCRIPTION
The subscription name needed to be updated. To help future updates a
constant was created and update the places where the subscription name
was used.

This change is required because the manifest was updated and the new subscription name is now `Employee SKU`.