### PR TITLE
Puppet class update and delete tests from UI end, closes #1814

### DIFF
--- a/robottelo/ui/base.py
+++ b/robottelo/ui/base.py
@@ -94,7 +94,8 @@ class Base(object):
             searchbox.clear()
             if search_button:
                 searchbox.send_keys(
-                    '{0} = {1}'.format(search_key, escape_search(element_name))
+                    u'{0} = {1}'.format(
+                        search_key, escape_search(element_name))
                 )
                 search_button.click()
             else:

--- a/robottelo/ui/locators.py
+++ b/robottelo/ui/locators.py
@@ -531,7 +531,9 @@ tab_locators = LocatorDict({
         "//a[@data-toggle='tab' and contains(@href, 'ForemanTasks')]"),
     "settings.tab_provisioning": (
         By.XPATH,
-        "//a[@data-toggle='tab' and contains(@href, 'Provisioning')]")
+        "//a[@data-toggle='tab' and contains(@href, 'Provisioning')]"),
+    "puppetclass.parameters": (
+        By.XPATH, "//a[contains(@href,'class_param')]"),
 })
 
 common_locators = LocatorDict({
@@ -1040,7 +1042,20 @@ locators = LocatorDict({
                    " and contains(.,'%s')]")),
     "puppetclass.delete": (
         By.XPATH, "//a[@class='delete' and contains(@data-confirm, '%s')]"),
-
+    "puppetclass.import": (
+        By.XPATH, "//a[contains(@href,'import')]"),
+    "puppetclass.environment_default_check": (
+        By.XPATH, "//input[contains(@id,'KT_Default_Organization_Library')]"),
+    "puppetclass.update": (
+        By.XPATH, "//input[@value='Update']"),
+    "puppetclass.paramfilter": (
+        By.XPATH, "//input[contains(@placeholder,'Filter')]"),
+    "puppetclass.parameter": (
+        By.XPATH, "//li[@class='active search-marker']"),
+    "puppetclass.param_description": (
+        By.XPATH, "//textarea[contains(@id,'description')]"),
+    "puppetclass.cancel": (
+        By.XPATH, "//a[@class='btn btn-default']"),
     # Repository
     "repo.new": (By.XPATH, "//button[contains(@ui-sref,'repositories.new')]"),
     "repo.type": (By.ID, "content_type"),

--- a/robottelo/ui/puppetclasses.py
+++ b/robottelo/ui/puppetclasses.py
@@ -2,8 +2,8 @@
 Implements Puppet Classes UI
 """
 
-from robottelo.ui.base import Base
-from robottelo.ui.locators import locators, common_locators
+from robottelo.ui.base import Base, UINoSuchElementError
+from robottelo.ui.locators import locators, common_locators, tab_locators
 from robottelo.ui.navigator import Navigator
 
 
@@ -58,3 +58,64 @@ class PuppetClasses(Base):
 
         self.delete_entity(name, really, locators["puppetclass.select_name"],
                            locators['puppetclass.delete'])
+
+    def import_scap_client_puppet_classes(self):
+        """Imports puppet-foreman_scap_client puppet classes."""
+        Navigator(self.browser).go_to_puppet_classes()
+        self.wait_for_ajax()
+        self.find_element(locators['puppetclass.import']).click()
+        # Checking if the scap client puppet classes are already imported
+        if self.wait_until_element(
+                locators['puppetclass.environment_default_check']):
+            self.find_element(
+                locators['puppetclass.environment_default_check']
+            ).click()
+            self.find_element(locators['puppetclass.update']).click()
+        else:
+            self.find_element(locators['puppetclass.cancel']).click()
+
+    def update_class_parameter_description(
+            self, class_name=None, parameter_name=None, description=None):
+        """Updates the description field of a given puppet class parameter."""
+        puppet_class = self.search(class_name)
+        if puppet_class is None:
+            raise UINoSuchElementError(
+                "Couldn't find the puppet class '{0}'.".format(class_name)
+            )
+        puppet_class.click()
+        self.find_element(tab_locators['puppetclass.parameters']).click()
+        if self.wait_until_element(
+            locators['puppetclass.paramfilter']
+        ) and parameter_name:
+            self.field_update('puppetclass.paramfilter', parameter_name)
+        self.find_element(locators['puppetclass.parameter']).click()
+        if self.wait_until_element(
+            locators['puppetclass.param_description']
+        ) and description:
+            self.field_update('puppetclass.param_description', description)
+        self.find_element(common_locators['submit']).click()
+
+    def fetch_class_parameter_description(
+            self, class_name=None, parameter_name=None):
+        """Fetches the description of a given puppet class parameter."""
+        description = None
+        puppet_class = self.search(class_name)
+        if puppet_class is None:
+            raise UINoSuchElementError(
+                "Couldn't find the puppet class '{0}'.".format(class_name)
+            )
+        puppet_class.click()
+        self.find_element(tab_locators['puppetclass.parameters']).click()
+        if self.wait_until_element(
+            locators['puppetclass.paramfilter']
+        ) and parameter_name:
+            self.field_update('puppetclass.paramfilter', parameter_name)
+        self.find_element(locators['puppetclass.parameter']).click()
+        if self.wait_until_element(
+            locators['puppetclass.param_description']
+        ):
+            description = self.find_element(
+                locators['puppetclass.param_description']
+            ).text
+        self.find_element(locators['puppetclass.cancel']).click()
+        return description


### PR DESCRIPTION
This includes the update and delete puppet class tests from UI end.
Note : For creating a puppet class two ways are used,
                1. Dummy puppet class from API. - Used under delete test.
                2. From puppet-foreman_scap_client module. - Used under update test.

Passing Logs of Tests:
```
[root@jyejare robottelo]# nosetests ./tests/foreman/ui/test_puppet_classes.py
..
----------------------------------------------------------------------
Ran 2 tests in 101.821s

OK
```