### PR TITLE
[DO NOT MERGE] Fix UI tests for Docker repos - issue #1887

### DIFF
--- a/tests/foreman/ui/test_repository.py
+++ b/tests/foreman/ui/test_repository.py
@@ -528,6 +528,7 @@ class Repos(UITestCase):
             url=DOCKER_REGISTRY_HUB,
             product=product_attrs['id'],
             content_type=REPO_TYPE['docker'],
+            docker_upstream_name=u'busybox',
         ).create_json()
         with Session(self.browser) as session:
             self.setup_navigate_syncnow(session,


### PR DESCRIPTION
Fixed ```test_syncnow_custom_repos_3```, added required parameter 'Upstream Repository Name'.
Closes #1887
Docker repos are currently used in 2 files of UI tests:
```
tests/foreman/ui/test_docker.py
tests/foreman/ui/test_repository.py
```
File ```test_docker.py``` contains only manual tests, ```test_repository.py``` contains 3 tests with docker:
```
test_create_repo_3
test_create_repo_4
test_syncnow_custom_repos_3
```
The first 2 tests are up-to-date (probably were fixed in scope of some other issue), so commit contains small fix for the last one.