### PR TITLE
Update from NailGun 0.11.0 to 0.12.0

### DIFF
--- a/robottelo/common/helpers.py
+++ b/robottelo/common/helpers.py
@@ -249,6 +249,9 @@ def configure_entities():
 
     Do the following:
 
+    * Set ``entity_mixins.CREATE_MISSING`` to ``True``. This causes method
+      ``EntityCreateMixin.create_raw`` to generate values for empty and
+      required fields.
     * Set ``nailgun.entity_mixins.DEFAULT_SERVER_CONFIG`` to whatever is
       returned by :meth:`robottelo.common.helpers.get_nailgun_config`. See
       ``robottelo.entity_mixins.Entity`` for more information on the effects of
@@ -262,6 +265,7 @@ def configure_entities():
     configuration file is available.
 
     """
+    entity_mixins.CREATE_MISSING = True
     try:
         entity_mixins.DEFAULT_SERVER_CONFIG = get_nailgun_config()
     except KeyError:

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import find_packages, setup
 REQUIRES = [
     'ddt',
     'fauxfactory',
-    'nailgun==0.11.0',
+    'nailgun==0.12.0',
     'paramiko',
     'python-bugzilla',
     'requests',


### PR DESCRIPTION
NailGun 0.12.0 brings one significant change: missing values are no longer
created by default, and the signatures of the various `EntityCreateMixin`
methods have changed. Respond to this by overriding the default value of the new
`nailgun.entity_mixins.CREATE_MISSING` variable.

With NailGun 0.12.0 and this fix against an upstream system:

    $ nosetests tests/foreman/api/test_multiple_paths.py
    ...S...S......S...............................................................S...S..........................................................................................................................................SSSS.SSSSSS..S.S.SSSSSS...SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSS
    ----------------------------------------------------------------------
    Ran 278 tests in 407.958s

    OK (SKIP=54)

With NailGun 0.12.0 but not this fix against an upstream system:

    $ nosetests tests/foreman/api/test_multiple_paths.py
    FFFSFFFSFFFFFFSFFFFFFFFFFEEEEEEEEEE^C
    …
    Ran 36 tests in 13.920s

    FAILED (SKIP=3, errors=10, failures=22)