### PR TITLE
Add CLI test for content-view remove

### DIFF
--- a/robottelo/cli/contentview.py
+++ b/robottelo/cli/contentview.py
@@ -158,3 +158,12 @@ class ContentView(Base):
         """Remove content-view from an enviornment"""
         cls.command_sub = 'remove-from-environment'
         return cls.execute(cls._construct_command(options))
+
+    @classmethod
+    def remove(cls, options=None):
+        """Remove versions and/or environments from a content view and
+        reassign content hosts and keys
+
+        """
+        cls.command_sub = 'remove'
+        return cls.execute(cls._construct_command(options))


### PR DESCRIPTION
Adding coverage for all necessary commands from the list
Closes #1707 
```
nosetests tests/foreman/cli/test_contentviews.py -m test_remove -s
....
----------------------------------------------------------------------
Ran 4 tests in 412.945s

OK
```