### PR TITLE
Fixed UI tests

### DIFF
--- a/robottelo/ui/base.py
+++ b/robottelo/ui/base.py
@@ -193,7 +193,7 @@ class Base(object):
             element = self.wait_until_element((strategy1, value1 % name))
             if element is None:
                 raise UINoSuchElementError(
-                    'Could not select the entity "{0}" for deletion.'
+                    u'Could not select the entity "{0}" for deletion.'
                     .format(name)
                 )
             element.click()
@@ -202,8 +202,8 @@ class Base(object):
             raise UIError('Could not search the entity "{0}"'.format(name))
 
     def wait_until_element(self, locator, timeout=12, poll_frequency=0.5):
-        """Wrapper around Selenium's WebDriver that allows you to pause your test
-        until an element in the web page is present.
+        """Wrapper around Selenium's WebDriver that allows you to pause your
+        test until an element in the web page is present.
 
         """
         try:

--- a/robottelo/ui/contentviews.py
+++ b/robottelo/ui/contentviews.py
@@ -129,7 +129,7 @@ class ContentViews(Base):
             )
         element.click()
         self.wait_for_ajax()
-        strategy, value = locators['contentviews.remove']
+        strategy, value = locators['contentviews.remove_ver']
         remove_version = self.wait_until_element((strategy, value % version))
         if remove_version is None:
             raise UINoSuchElementError(
@@ -142,7 +142,7 @@ class ContentViews(Base):
         ).click()
         self.wait_until_element(locators['contentviews.next_button']).click()
         self.wait_for_ajax()
-        self.find_element(locators['contentviews.confirm_remove']).click()
+        self.find_element(locators['contentviews.confirm_remove_ver']).click()
         self.wait_for_ajax()
 
     def search(self, element_name):
@@ -494,7 +494,7 @@ class ContentViews(Base):
                 locators["contentviews.new_filter"]).click()
             if self.wait_until_element(common_locators["name"]):
                 self.find_element(
-                    common_locators["name"].send_keys(filter_name))
+                    common_locators["name"]).send_keys(filter_name)
                 if content_type:
                     Select(
                         self.find_element(

--- a/robottelo/ui/gpgkey.py
+++ b/robottelo/ui/gpgkey.py
@@ -28,7 +28,7 @@ class GPGKey(Base):
                     locators["gpgkey.content"]).send_keys(key_content)
             else:
                 raise UIError(
-                    'Could not create new gpgkey "{0}" without contents'
+                    u'Could not create new gpgkey "{0}" without contents'
                     .format(name)
                 )
             self.wait_until_element(common_locators["create"]).click()

--- a/robottelo/ui/locators.py
+++ b/robottelo/ui/locators.py
@@ -1429,6 +1429,8 @@ locators = LocatorDict({
         By.XPATH, "//div[contains(@class, 'has-error') and "
                   "contains(@class, 'form-group')]"),
     "contentviews.remove": (
+        By.XPATH, "//button[@ui-sref='content-views.details.deletion']"),
+    "contentviews.remove_ver": (
         By.XPATH, ("//td/a[contains(., '%s')]/following::td/"
                    "button[contains(@ui-sref, 'version-deletion')]")),
     "contentviews.remove_cv": (
@@ -1446,8 +1448,10 @@ locators = LocatorDict({
         By.XPATH, "//select[@ng-model='selectedContentViewId']"),
     "contentviews.remove_ver": (
         By.XPATH, "//div[@class='fr']/button[@ng-click='performDeletion()']"),
-    "contentviews.confirm_remove": (
+    "contentviews.confirm_remove_ver": (
         By.XPATH, "//button[@ng-click='performDeletion()']"),
+    "contentviews.confirm_remove": (
+        By.XPATH, "//button[@ng-click='delete()']"),
     "contentviews.version_name": (
         By.XPATH, "//td/a[contains(., '%s')]"),
     "contentviews.success_rm_alert": (

--- a/robottelo/ui/sync.py
+++ b/robottelo/ui/sync.py
@@ -152,9 +152,9 @@ class Sync(Base):
         strategy4, value4 = locators["rh.reposet_spinner"]
         strategy5, value5 = locators["rh.repo_spinner"]
         for prd in repos_tree:
-            # UI is slow here. Hence timeout is 90 seconds.
+            # UI is slow here. Hence timeout is 100 seconds.
             prd_element = self.wait_until_element(
-                (strategy, value % PRDS[prd]), 90)
+                (strategy, value % PRDS[prd]), 100)
             if prd_element:
                 prd_element.click()
             else:

--- a/tests/foreman/ui/test_partitiontable.py
+++ b/tests/foreman/ui/test_partitiontable.py
@@ -122,8 +122,6 @@ class PartitionTable(UITestCase):
                                 os_family=os_family)
             self.assertIsNotNone(self.partitiontable.search(name))
             self.partitiontable.delete(name, really=True)
-            self.assertIsNotNone(self.partitiontable.wait_until_element
-                                 (common_locators["notif.success"]))
             self.assertIsNone(self.partitiontable.search(name))
 
     @data({u'name': gen_string('alpha'),


### PR DESCRIPTION
Fixed `test_cv_delete` - Locator change
Fixed `test_create_errata_filter` test : Closing bracket was placed incorrectly and due which following tests were also failing:
 - test_create_package_filter 
 - test_create_package_group_filter
 - test_remove_filter
Fixed `test_remove_partition_table` : By removing the success notification check as anyways we are asserting the entity deletion via search. 
Fixed `test_negative_create_3` gpgkey test: was failing due to unicode error.