### PR TITLE
Skip several API tests due to BZs

### DIFF
--- a/tests/foreman/api/test_docker.py
+++ b/tests/foreman/api/test_docker.py
@@ -8,7 +8,11 @@ from random import randint, shuffle
 from requests.exceptions import HTTPError
 from robottelo.common.constants import DOCKER_REGISTRY_HUB
 from robottelo.common.decorators import (
-    data, run_only_on, skip_if_bug_open, stubbed)
+    data,
+    run_only_on,
+    skip_if_bug_open,
+    stubbed,
+)
 from robottelo.common.helpers import (
     get_external_docker_url,
     get_internal_docker_url,
@@ -258,6 +262,7 @@ class DockerRepositoryTestCase(APITestCase):
                 )
 
     @run_only_on('sat')
+    @skip_if_bug_open('bugzilla', 1217603)
     def test_sync_docker_repo(self):
         """@Test: Create and sync a Docker-type repository
 
@@ -540,6 +545,7 @@ class DockerContentViewTestCase(APITestCase):
 
         """
 
+    @skip_if_bug_open('bugzilla', 1217603)
     @run_only_on('sat')
     def test_add_synced_docker_repo_to_content_view(self):
         """@Test: Create and sync a Docker-type repository
@@ -705,6 +711,7 @@ class DockerContentViewTestCase(APITestCase):
         self.assertIsNotNone(new_attrs['last_published'])
         self.assertGreater(new_attrs['next_version'], 1)
 
+    @skip_if_bug_open('bugzilla', 1217635)
     @run_only_on('sat')
     def test_publish_once_docker_repo_composite_content_view(self):
         """@Test: Add Docker-type repository to composite

--- a/tests/foreman/api/test_repository.py
+++ b/tests/foreman/api/test_repository.py
@@ -14,7 +14,12 @@ from robottelo.common.constants import (
     VALID_GPG_KEY_BETA_FILE,
     VALID_GPG_KEY_FILE,
 )
-from robottelo.common.decorators import bz_bug_is_open, data, run_only_on
+from robottelo.common.decorators import (
+    bz_bug_is_open,
+    data,
+    run_only_on,
+    skip_if_bug_open,
+)
 from robottelo.common.helpers import (
     get_server_credentials, get_data_file, read_data_file)
 from robottelo.test import APITestCase
@@ -319,6 +324,7 @@ class DockerRepositoryTestCase(APITestCase):
         self.assertEqual(real_attrs['content_type'], content_type)
 
     @run_only_on('sat')
+    @skip_if_bug_open('bugzilla', 1217603)
     def test_sync_docker_repo(self):
         """@Test: Create and sync a Docker-type repository
 


### PR DESCRIPTION
Test `test_publish_once_docker_repo_composite_content_view` fails due to BZ
1217635:

> When a content view is published, the "last_published" attribute of that
> content view is updated. Unfortunately, the field is not immediately updated.
>
> Steps to Reproduce:
>
> 1. Publish a content view.
> 2. A response is received which includes a task ID. Poll that task until it
>    completes.
> 3. Read the content view and examine its "last_published" attribute. Discover
>    that "last_published" is nil.

Several other tests fail due to BZ 1217603:

> 1) Set up a custom repo with the following details
> Type -> Docker
> Registry Url -> https://registry.hub.docker.com
> Upstream Name -> busybox
>
> 2) Try to sync that repo.
>
> Expected:
> Repo syncing with the upstream repo
>
> Actual:
> Fails with the following trace
> …

Test results:

    $ nosetests tests/foreman/api/test_docker.py -m test_sync_docker_repo
    S
    ----------------------------------------------------------------------
    Ran 1 test in 1.962s

    OK (SKIP=1)
    $ nosetests tests/foreman/api/test_docker.py -m test_add_synced_docker_repo_to_content_view
    S
    ----------------------------------------------------------------------
    Ran 1 test in 1.745s

    OK (SKIP=1)
    $ nosetests tests/foreman/api/test_docker.py -m test_publish_once_docker_repo_composite_content_view
    S
    ----------------------------------------------------------------------
    Ran 1 test in 1.987s

    OK (SKIP=1)
    $ nosetests tests/foreman/api/test_repository.py -m test_sync_docker_repo
    S
    ----------------------------------------------------------------------
    Ran 1 test in 1.692s

    OK (SKIP=1)