### PR TITLE
cli.imprt all subcommands implemented + initial test added

### DIFF
--- a/robottelo.properties.sample
+++ b/robottelo.properties.sample
@@ -60,3 +60,9 @@ admin.password=changeme
 driver=firefox
 
 # NOTE: Candlepin url accepts just the hostname.
+
+# Section for declaring Sat5->Sat6 transition parameters
+[transitions]
+# URL of the  exported data archive (typically a .tgz containing a bunch of CSV
+# files together with repo data)
+#export_tar.url=http://example.org/sat5_export_data.tgz

--- a/robottelo/cli/import_.py
+++ b/robottelo/cli/import_.py
@@ -1,0 +1,161 @@
+# -*- encoding: utf-8 -*-
+"""
+Usage::
+
+    hammer import [OPTIONS] SUBCOMMAND [ARG] ...
+
+Parameters::
+
+    SUBCOMMAND                    subcommand
+    [ARG] ...                     subcommand arguments
+
+Subcommands::
+
+    activation-key                Import Activation Keys
+                                  (from spacewalk-report activation-keys).
+    all                           Load ALL data from a specified directory
+                                  that is in spacewalk-export format.
+    config-file                   Create puppet-modules from Configuration
+                                  Channel content (from spacewalk-report
+                                  config-files-latest).
+    content-host                  Import Content Hosts
+                                  (from spacewalk-report system-profiles).
+    content-view                  Create Content Views based on local/cloned
+                                  Channels (from spacewalk-export-channels).
+    host-collection               Import Host Collections
+                                  (from spacewalk-report system-groups).
+    organization                  Import Organizations
+                                  (from spacewalk-report users).
+    repository                    Import repositories
+                                  (from spacewalk-report repositories).
+    repository-enable             Enable any Red Hat repositories
+                                  accessible to any Organization
+                                  (from spacewalk-report channels).
+    template-snippet              Import template snippets
+                                  (from spacewalk-report kickstart-scripts).
+    user                          Import Users (from spacewalk-report users).
+
+"""
+from robottelo.cli.base import Base
+
+
+class Import(Base):
+    """Imports configurations from another Satellite instances."""
+    command_base = 'import'
+
+    @classmethod
+    def activation_key(cls, options=None):
+        """Import Activation Keys (from spacewalk-report activation-keys).
+        Requires organization.
+
+        """
+        cls.command_sub = 'activation-key'
+        return cls.execute(
+            cls._construct_command(options),
+            output_format='csv'
+        )
+
+    @classmethod
+    def organization(cls, options=None):
+        """Import Organizations (from spacewalk-report users)."""
+        cls.command_sub = 'organization'
+        return cls.execute(
+            cls._construct_command(options),
+            output_format=''
+        )
+
+    @classmethod
+    def user(cls, options=None):
+        """Import Users (from spacewalk-report users)."""
+        cls.command_sub = 'user'
+        return cls.execute(
+            cls._construct_command(options),
+            output_format=''
+        )
+
+    @classmethod
+    def host_collection(cls, options=None):
+        """Import Host Collections (from spacewalk-report system-groups)."""
+        cls.command_sub = 'host-collection'
+        return cls.execute(
+            cls._construct_command(options),
+            output_format=''
+        )
+
+    @classmethod
+    def config_file(cls, options=None):
+        """Create puppet-modules from Configuration Channel content (from
+        spacewalk-report config-files-latest).
+
+        """
+        cls.command_sub = 'config-file'
+        return cls.execute(
+            cls._construct_command(options),
+            output_format=''
+        )
+
+    @classmethod
+    def content_host(cls, options=None):
+        """Import Content Hosts (from spacewalk-report system-profiles)."""
+        cls.command_sub = 'content-host'
+        return cls.execute(
+            cls._construct_command(options),
+            output_format=''
+        )
+
+    @classmethod
+    def content_view(cls, options=None):
+        """Create Content Views based on local/cloned Channels (from
+        spacewalk-export-channels).
+
+        """
+        cls.command_sub = 'content-view'
+        return cls.execute(
+            cls._construct_command(options),
+            output_format=''
+        )
+
+    @classmethod
+    def repository(cls, options=None):
+        """Import repositories (from spacewalk-report repositories)."""
+        cls.command_sub = 'repository'
+        return cls.execute(
+            cls._construct_command(options),
+            output_format=''
+        )
+
+    @classmethod
+    def repository_enable(cls, options=None):
+        """Enable any Red Hat repositories accessible to any Organization
+        (from spacewalk-report channels).
+
+        """
+        cls.command_sub = 'repository-enable'
+        return cls.execute(
+            cls._construct_command(options),
+            output_format=''
+        )
+
+    @classmethod
+    def template_snippet(cls, options=None):
+        """Import template snippets (from spacewalk-report
+        kickstart-scripts).
+
+        """
+        cls.command_sub = 'template-snippet'
+        return cls.execute(
+            cls._construct_command(options),
+            output_format=''
+        )
+
+    @classmethod
+    def all(cls, options=None):
+        """Load ALL data from a specified directory that is in spacewalk-export
+        format.
+
+        """
+        cls.command_sub = 'all'
+        return cls.execute(
+            cls._construct_command(options),
+            output_format=''
+        )

--- a/tests/foreman/cli/test_import.py
+++ b/tests/foreman/cli/test_import.py
@@ -1,0 +1,104 @@
+# -*- encoding: utf-8 -*-
+"""Test class for Host Collection CLI"""
+from ddt import ddt
+from fauxfactory import gen_string
+from os.path import join
+from robottelo.common import ssh
+from robottelo.common.helpers import prepare_import_data
+from robottelo.test import CLITestCase
+from robottelo.cli.import_ import Import
+from robottelo.cli.org import Org
+
+
+@ddt
+def csv_to_dataset(csv):
+    """Converts the csv with header as a first entry to a python dict"""
+    keys = csv[0].split(',')
+    del csv[0]
+    return [
+        dict(zip(keys, val.split(',')))
+        for val
+        in csv
+    ]
+
+
+class TestImport(CLITestCase):
+    """Import CLI tests.
+
+    All default tests pass no options to the imprt object
+    In such case methods download a default data set from URL
+    specified in robottelo.properties.
+
+    """
+    def test_import_orgs_default(self):
+        """@test: Import all organizations from the default data set
+        (predefined source).
+
+        @feature: Import Organizations
+
+        @assert: 3 Organizations are created
+
+        """
+        files = prepare_import_data()[1]
+        ssh_import = Import.organization({'csv-file': files['users']})
+        ssh_cat = ssh.command('cat {0}'.format(files['users']))
+        # pop the array as ssh.command appends 1 empty item at the end
+        ssh_cat.stdout.pop()
+
+        # now to check whether the orgs from csv appeared in sattelite
+        orgs = set(org['name'] for org in Org.list().stdout)
+        imporgs = set(
+            org['organization'] for
+            org in csv_to_dataset(ssh_cat.stdout)
+        )
+
+        self.assertEqual(ssh_import.return_code, 0)
+        self.assertEqual(
+            ssh_import.stdout,
+            [
+                u'Summary',
+                u'  Created {0} organizations.'.format(len(imporgs)),
+                u''
+            ]
+        )
+        self.assertEqual(False in [org in orgs for org in imporgs], False)
+
+    def test_import_users_default(self):
+        """@test: Import all 3 users from the our default data set (predefined
+        source).
+
+        @feature: Import Users
+
+        @assert: 3 Users created
+
+        """
+        tmpdir, files = prepare_import_data()
+        pwdfile = join(tmpdir, gen_string('alpha', 6))
+
+        ssh_import = Import.user({
+            'csv-file': files['users'],
+            'new-passwords': pwdfile
+        })
+        self.assertEqual(ssh_import.return_code, 0)
+        self.assertEqual(
+            ssh_import.stdout,
+            [u'Summary', u'  Created 3 users.', u'']
+        )
+
+    def test_reimport_orgs_default(self):
+        """@test: Try to Import all organizations from the
+        predefined source and try to import them again
+
+        @feature: Import Organizations twice
+
+        @assert: 2nd Import will result in No Action Taken
+
+        """
+        files = prepare_import_data()[1]
+        self.assertEqual(
+            Import.organization({'csv-file': files['users']}).return_code, 0)
+        self.assertEqual(
+            Import.organization({
+                'csv-file': files['users']
+            }).stdout, [u'Summary', u'  No action taken.', u'']
+        )


### PR DESCRIPTION
Added robottelo.cli.imprt (`Import` class) to mimic `hammer import` subcommand and some initial tests.
This is will be mainly used to test sat5 -> sat6 transitioning.

Thanks for reviewing my code.