### PR TITLE
Update Product test_positive_delete_1 CLI test

### DIFF
--- a/tests/foreman/cli/test_product.py
+++ b/tests/foreman/cli/test_product.py
@@ -1,5 +1,6 @@
 # -*- encoding: utf-8 -*-
 """Test class for Product CLI"""
+import time
 
 from ddt import ddt
 from fauxfactory import gen_string
@@ -13,6 +14,7 @@ from robottelo.cli.factory import (
 )
 from robottelo.cli.product import Product
 from robottelo.common.decorators import data, run_only_on
+from robottelo.common.helpers import bz_bug_is_open
 from robottelo.test import CLITestCase
 
 
@@ -374,6 +376,16 @@ class TestProduct(CLITestCase):
             u'id': new_product['id'],
             u'organization-id': self.org['id'],
         })
+        if bz_bug_is_open(1219490):
+            for _ in range(5):
+                if result.return_code == 0:
+                    time.sleep(5)
+                    result = Product.info({
+                        u'id': new_product['id'],
+                        u'organization-id': self.org['id'],
+                    })
+                else:
+                    break
         self.assertNotEqual(result.return_code, 0)
         self.assertGreater(len(result.stderr), 0)
 


### PR DESCRIPTION
The test is failing in automation because the info command are being
issued immediately the delete command, but after some time the product
is really deleted and the info returns the expected result.

In order to avoid this failure, add workaround to sleep for a few
seconds before running the info command but just if BZ #1219490 is open.