### PR TITLE
Implemented remove contents functionality from selected environment

### DIFF
--- a/robottelo/ui/base.py
+++ b/robottelo/ui/base.py
@@ -394,3 +394,14 @@ class Base(object):
         self.wait_for_ajax()
         if self.wait_until_element(locator) and validation:
             raise UIPageSubmitionFailed("Page submission failed.")
+
+    def is_element_enabled(self, locator):
+        """Check whether UI element is enabled or disabled
+
+        :param locator: The locator of the element.
+        :return: Returns True if element is enabled and False otherwise
+
+        """
+        element = self.wait_until_element(locator)
+        self.wait_for_ajax()
+        return element.is_enabled()

--- a/robottelo/ui/contentviews.py
+++ b/robottelo/ui/contentviews.py
@@ -768,3 +768,35 @@ class ContentViews(Base):
                 'Selected version "{0}" was not deleted successfully'
                 .format(version)
             )
+
+    def validate_version_cannot_be_deleted(self, name, version):
+        """Check that version cannot be deleted from selected CV, because it
+        has activation key or content host assigned to it
+
+        """
+        element = self.search(name)
+
+        if element is None:
+            raise UIError(
+                'Could not find the "{0}" content view.'.format(name)
+            )
+        element.click()
+        self.wait_for_ajax()
+        strategy, value = locators['contentviews.remove_ver']
+        remove_version = self.wait_until_element((strategy, value % version))
+        if remove_version is None:
+            raise UINoSuchElementError(
+                'Could not find button to delete version "{0}"'.format(version)
+            )
+        remove_version.click()
+        self.wait_for_ajax()
+        self.wait_until_element(locators['contentviews.next_button']).click()
+        self.wait_for_ajax()
+        self.wait_until_element(locators['contentviews.affected_button'])
+        self.wait_for_ajax()
+        self.wait_until_element(locators['contentviews.next_button'])
+        self.wait_for_ajax()
+        if self.is_element_enabled(locators['contentviews.next_button']):
+            raise UIError(
+                '"Next" button is enabled when it should not'
+            )

--- a/robottelo/ui/locators.py
+++ b/robottelo/ui/locators.py
@@ -1441,13 +1441,13 @@ locators = LocatorDict({
         By.XPATH, "//span/input[contains(@ng-model, 'deleteArchive')]"),
     "contentviews.next_button": (
         By.XPATH, "//button[@ng-click='processSelection()']"),
+    "contentviews.affected_button": (
+        By.XPATH, "//button[contains(@ng-show, '!show')]"),
     "contentviews.change_env": (
         By.XPATH,
         "//input[@ng-model='item.selected']/parent::label[contains(., '%s')]"),
     "contentviews.change_cv": (
         By.XPATH, "//select[@ng-model='selectedContentViewId']"),
-    "contentviews.remove_ver": (
-        By.XPATH, "//div[@class='fr']/button[@ng-click='performDeletion()']"),
     "contentviews.confirm_remove_ver": (
         By.XPATH, "//button[@ng-click='performDeletion()']"),
     "contentviews.confirm_remove": (


### PR DESCRIPTION
Added coverage for two more methods of removing content view version from application

Closes #797

```
nosetests tests/foreman/ui/test_contentviews.py -m test_delete_version_with_ak
.
----------------------------------------------------------------------
Ran 1 test in 206.396s

OK

nosetests tests/foreman/ui/test_contentviews.py -m test_delete_version_non_default
.
----------------------------------------------------------------------
Ran 1 test in 157.038s

OK
```