### PR TITLE
Depend on NailGun version 0.13.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import find_packages, setup
 REQUIRES = [
     'ddt',
     'fauxfactory',
-    'nailgun==0.12.0',
+    'nailgun==0.13.0',
     'paramiko',
     'python-bugzilla',
     'requests',


### PR DESCRIPTION
NailGun version 0.13.0 has been released. Release notes are available on GitHub.
[1] Example test results against a downstream system:

    $ nosetests tests/foreman/api/test_multiple_paths.py
    ...S...S......S...............................................................S...S..........................................................................................................................................SSSS.SSSSSS..S.S.SSSSSS...SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSS
    ----------------------------------------------------------------------
    Ran 278 tests in 461.405s

    OK (SKIP=54)

[1] https://github.com/SatelliteQE/nailgun/releases/tag/0.13.0