### PR TITLE
Update test_bugzilla_1190122 Docker CLI test

### DIFF
--- a/tests/foreman/cli/test_docker.py
+++ b/tests/foreman/cli/test_docker.py
@@ -32,7 +32,7 @@ INTERNAL_DOCKER_URL = get_internal_docker_url()
 class DockerImageTestCase(CLITestCase):
     """Tests related to docker image command"""
 
-    @skip_if_bug_open('bugzilla', 1205826)
+    @skip_if_bug_open('bugzilla', 1221729)
     def test_bugzilla_1190122(self):
         """@Test: docker image displays tags information for a docker image
 
@@ -40,7 +40,7 @@ class DockerImageTestCase(CLITestCase):
 
         @Assert: docker image displays tags information for a docker image
 
-        @BZ: 1205826
+        @BZ: 1221729
 
         """
         try:
@@ -79,9 +79,10 @@ class DockerImageTestCase(CLITestCase):
             self.assertEqual(len(result.stderr), 0)
 
             # Extract the list of repository ids of the available image's tags
-            tag_repository_ids = [
-                tag['repository-id'] for tag in result.stdout['tags']
-            ]
+            tag_repository_ids = []
+            for tag in result.stdout['tags']:
+                tag_repository_ids.append(tag['repository-id'])
+                self.assertGreater(len(tag['name']), 0)
             self.assertIn(repository['id'], tag_repository_ids)
 
 


### PR DESCRIPTION
The test is failing because the tag count is not shown in the list
output, skip the test with the corresponding bug.

Update the test to check if that the tag name have some information
BZ#1221729 states that the tag name was not displayed, because this
should be asserted for a non-zero length tag name.

Closes #2235 

```
$ py.test tests/foreman/cli/test_docker.py -ktest_bugzilla_1190122
================================================= test session starts =================================================
platform darwin -- Python 2.7.6 -- py-1.4.26 -- pytest-2.6.4
collected 97 items

tests/foreman/cli/test_docker.py s

================================== 96 tests deselected by '-ktest_bugzilla_1190122' ===================================
====================================== 1 skipped, 96 deselected in 5.40 seconds =======================================
```