### PR TITLE
Use NailGun version 0.14.0

### DIFF
--- a/tests/foreman/ui/test_location.py
+++ b/tests/foreman/ui/test_location.py
@@ -448,7 +448,7 @@ class Location(UITestCase):
         path = INSTALL_MEDIUM_URL % gen_string("alpha", 6)
         medium = entities.Media(
             name=medium_name,
-            media_path=path,
+            path_=path,
             os_family='Redhat',
         ).create_json()
         self.assertEqual(medium['name'], medium_name)
@@ -748,7 +748,7 @@ class Location(UITestCase):
         path = INSTALL_MEDIUM_URL % gen_string("alpha", 6)
         medium = entities.Media(
             name=medium_name,
-            media_path=path,
+            path_=path,
             os_family='Redhat',
         ).create_json()
         self.assertEqual(medium['name'], medium_name)

--- a/tests/foreman/ui/test_operatingsys.py
+++ b/tests/foreman/ui/test_operatingsys.py
@@ -349,7 +349,7 @@ class OperatingSys(UITestCase):
         path = INSTALL_MEDIUM_URL % medium_name
         entities.Media(
             name=medium_name,
-            media_path=path,
+            path_=path,
             organization=[self.org_id],
         ).create_json()
         os_name = entities.OperatingSystem().create_json()['name']

--- a/tests/foreman/ui/test_org.py
+++ b/tests/foreman/ui/test_org.py
@@ -716,7 +716,7 @@ class Org(UITestCase):
         path = URL % gen_string("alpha", 6)
         medium = entities.Media(
             name=medium_name,
-            media_path=path,
+            path_=path,
             os_family='Redhat',
         ).create_json()
         self.assertEqual(medium['name'], medium_name)
@@ -873,7 +873,7 @@ class Org(UITestCase):
         path = URL % gen_string("alpha", 6)
         medium = entities.Media(
             name=medium_name,
-            media_path=path,
+            path_=path,
             os_family='Redhat',
         ).create_json()
         self.assertEqual(medium['name'], medium_name)


### PR DESCRIPTION
Respond to several changes:

* The `api_names` mappings on the entity classes have been dropped. In response,
  fix the reference to `Meta.api_names` in module `test_multiple_paths` and fix
  the references to `Media.media_path` (now called `Media.path_`).
* The inner `Meta` class on the entity classes has been changed to an instance
  attribute named `_meta`. In response, fix the reference to `Meta` in module
  `test_multiple_paths`.

Test results:

    $ nosetests tests/foreman/api/test_multiple_paths.py
    ...S...S......S.............................................................F.S...S..........................................................................................................................................SSS..S.S.SSSSSS.S..SS.SSSSSSSSSSSSSSSSSSSSSSSSSSSS
    …
    Ran 271 tests in 469.434s

    FAILED (SKIP=47, failures=1)

The one failed test is due to an HTTP 422 when creating a host. This is a known
issue.