### PR TITLE
Small fix for rpm querying

### DIFF
--- a/tests/foreman/smoke/test_api_smoke.py
+++ b/tests/foreman/smoke/test_api_smoke.py
@@ -1165,4 +1165,4 @@ class TestSmoke(TestCase):
             )
             # Verify if package is installed by query it
             result = vm.run('rpm -q {0}'.format(package_name))
-            self.assertIn(package_name, result.stdout[0])
+            self.assertEqual(result.return_code, 0)

--- a/tests/foreman/smoke/test_cli_smoke.py
+++ b/tests/foreman/smoke/test_cli_smoke.py
@@ -730,4 +730,4 @@ class TestSmoke(CLITestCase):
             )
             # Verify if package is installed by query it
             result = vm.run('rpm -q {0}'.format(package_name))
-            self.assertIn(package_name, result.stdout[0])
+            self.assertEqual(result.return_code, 0)

--- a/tests/foreman/smoke/test_ui_smoke.py
+++ b/tests/foreman/smoke/test_ui_smoke.py
@@ -352,4 +352,4 @@ class TestSmoke(UITestCase):
                 )
                 # Verify if package is installed by query it
                 result = vm.run('rpm -q {0}'.format(package_name))
-                self.assertIn(package_name, result.stdout[0])
+                self.assertEqual(result.return_code, 0)

--- a/tests/foreman/ui/test_gpgkey.py
+++ b/tests/foreman/ui/test_gpgkey.py
@@ -494,7 +494,7 @@ class GPGKey(UITestCase):
             )
             # Verify if package is installed by query it
             result = vm.run('rpm -q {0}'.format(package_name))
-            self.assertIn(package_name, result.stdout[0])
+            self.assertEqual(result.return_code, 0)
 
     @stubbed()
     @data("""DATADRIVENGOESHERE


### PR DESCRIPTION
Accidentally found it while debugging. ```rpm -q foo``` returns following line when package is found:
```foo-1.2.3 ``` 
But when package isn't found, it returns not empty string, but following:
```package foo is not installed```
As a result ```assertIn('foo', result.stdout[0])``` will always pass - 'foo' is always present in output.
I suggest changing command to ```rpm -qa | grep foo```. In case package was not found this command won't return anything and test will fail.
