### PR TITLE
Update valid email data for CLI user test

### DIFF
--- a/tests/foreman/cli/test_user.py
+++ b/tests/foreman/cli/test_user.py
@@ -187,17 +187,16 @@ class User(CLITestCase):
         self.__assert_exists(args)
 
     @data(
-        u'{0}@example.com'.format(gen_string("latin1")),
-        u'{0}@example.com'.format(gen_string("utf8")),
-        u'{0}@example.com'.format(gen_string("alpha")),
-        u'{0}@example.com'.format(gen_string("alphanumeric")),
-        u'{0}@example.com'.format(gen_string("numeric")),
-        u'{0}@example.com'.format(gen_string("alphanumeric", 48)),
+        u'{0}@example.com'.format(gen_string('alpha')),
+        u'{0}@example.com'.format(gen_string('alphanumeric')),
+        u'{0}@example.com'.format(gen_string('numeric')),
+        u'{0}@example.com'.format(gen_string('alphanumeric', 48)),
         u'{0}+{1}@example.com'.format(gen_alphanumeric(), gen_alphanumeric()),
         u'{0}.{1}@example.com'.format(gen_alphanumeric(), gen_alphanumeric()),
-        r"!#$%&*+-/=?^\`{|}~@example.com",
+        u'"():;"@example.com',
+        r'!#$%&*+-/=?^`{|}~@example.com',
     )
-    def test_positive_create_user_4(self, test_data):
+    def test_positive_create_user_4(self, email):
         """@Test: Create User for all variations of Email Address
 
         @Feature: User - Positive Create
@@ -209,11 +208,14 @@ class User(CLITestCase):
         @Assert: User is created
 
         """
+        # The email must be escaped because some characters to not fail the
+        # parsing of the generated shell command
+        escaped_email = email.replace('"', r'\"').replace('`', r'\`')
         try:
-            args = make_user({'mail': test_data})
+            user = make_user({'mail': escaped_email})
         except CLIFactoryError as err:
             self.fail(err)
-        self.__assert_exists(args)
+        self.assertEqual(user['email'], email)
 
     @data({'password': gen_string("latin1")},
           {'password': gen_string("utf8")},


### PR DESCRIPTION
The validation email regex does not accept UTF8 or Latin1 characters and
because this drop them from the valid email data.

Closes #2180

For more info about the regex: https://github.com/theforeman/foreman/blob/develop/app/models/user.rb#L66

And to play with the regex: http://rubular.com/r/Hp0FXkHnxk

Test results:

```
py.test tests/foreman/cli/test_user.py -ktest_positive_create_user_4
===================================== test session starts ======================================
platform darwin -- Python 2.7.6 -- py-1.4.26 -- pytest-2.6.4
collected 200 items

tests/foreman/cli/test_user.py .......

=================== 193 tests deselected by '-ktest_positive_create_user_4' ====================
========================== 7 passed, 193 deselected in 62.15 seconds ===========================
```