### PR TITLE
Improve hammer csv output parsing

### DIFF
--- a/robottelo/cli/hammer.py
+++ b/robottelo/cli/hammer.py
@@ -1,4 +1,5 @@
 """Helpers to interact with hammer command line utility."""
+import csv
 import re
 
 from itertools import izip
@@ -6,19 +7,14 @@ from itertools import izip
 
 def parse_csv(output):
     """Parse CSV output from Hammer CLI and convert it to python dictionary."""
-    result = []
+    reader = csv.reader(output)
     # Generate the key names, spaces will be converted to dashes "-"
     keys = [
-        header.replace(' ', '-').lower() for header in output.pop(0).split(',')
+        header.replace(' ', '-').lower() for header in reader.next()
     ]
 
-    # For each entry, split the values and create a dict mapping each key with
-    # each value
-    for line in output:
-        if len(line) > 0:
-            result.append(dict(izip(keys, line.split(','))))
-
-    return result
+    # For each entry, create a dict mapping each key with each value
+    return [dict(izip(keys, values)) for values in reader if len(values) > 0]
 
 
 def parse_help(output):

--- a/tests/robottelo/test_hammer.py
+++ b/tests/robottelo/test_hammer.py
@@ -11,6 +11,7 @@ class ParseCSVTestCase(unittest.TestCase):
             'Header,Header with spaces',
             'header value 1,header with spaces value',
             'MixEd CaSe ValUe,ALL CAPS VALUE',
+            '"""double quote escaped value""","," escaped value',
         ]
         self.assertEqual(
             hammer.parse_csv(output_lines),
@@ -22,6 +23,10 @@ class ParseCSVTestCase(unittest.TestCase):
                 {
                     'header': 'MixEd CaSe ValUe',
                     'header-with-spaces': 'ALL CAPS VALUE',
+                },
+                {
+                    'header': '"double quote escaped value"',
+                    'header-with-spaces': ', escaped value',
                 },
             ]
         )


### PR DESCRIPTION
Use the builtin csv module to parse the hammer csv output. The module
will deal better with escaped values.

This should not make CLI tests fail because the previous robottelo's tests still passing. (Travis should confirm this :smile:)