### PR TITLE
Fix hammer csv output parser

### DIFF
--- a/robottelo/cli/hammer.py
+++ b/robottelo/cli/hammer.py
@@ -7,7 +7,12 @@ from itertools import izip
 
 def parse_csv(output):
     """Parse CSV output from Hammer CLI and convert it to python dictionary."""
-    reader = csv.reader(output)
+    # From python docs "Note: This version of the csv module doesn't support
+    # Unicode input. Also, there are currently some issues regarding ASCII NUL
+    # characters. Accordingly, all input should be UTF-8 or printable ASCII to
+    # be safe;"
+    reader = csv.reader([line.encode('utf8') for line in output])
+
     # Generate the key names, spaces will be converted to dashes "-"
     keys = [
         header.replace(' ', '-').lower() for header in reader.next()

--- a/tests/robottelo/test_hammer.py
+++ b/tests/robottelo/test_hammer.py
@@ -1,3 +1,4 @@
+# -*- encoding: utf-8 -*-
 """Tests for Robottelo's hammer helpers"""
 import unittest
 
@@ -8,25 +9,30 @@ class ParseCSVTestCase(unittest.TestCase):
     """Tests for parsing CSV hammer output"""
     def test_parse_csv(self):
         output_lines = [
-            'Header,Header with spaces',
-            'header value 1,header with spaces value',
-            'MixEd CaSe ValUe,ALL CAPS VALUE',
-            '"""double quote escaped value""","," escaped value',
+            u'Header,Header 2',
+            u'header value 1,header with spaces value',
+            u'MixEd CaSe ValUe,ALL CAPS VALUE',
+            u'"""double quote escaped value""","," escaped value',
+            u'unicode,chårs',
         ]
         self.assertEqual(
             hammer.parse_csv(output_lines),
             [
                 {
                     'header': 'header value 1',
-                    'header-with-spaces': 'header with spaces value',
+                    'header-2': 'header with spaces value',
                 },
                 {
                     'header': 'MixEd CaSe ValUe',
-                    'header-with-spaces': 'ALL CAPS VALUE',
+                    'header-2': 'ALL CAPS VALUE',
                 },
                 {
                     'header': '"double quote escaped value"',
-                    'header-with-spaces': ', escaped value',
+                    'header-2': ', escaped value',
+                },
+                {
+                    'header': 'unicode',
+                    'header-2': 'chårs',
                 },
             ]
         )


### PR DESCRIPTION
Robottelo converts all hammer output to unicode strings and the stdlib
csv parser, that the hammer csv output parser is using, does not support
reading unicode strings, from python docs:

    Note: This version of the csv module doesn't support Unicode input.
    Also, there are currently some issues regarding ASCII NUL
    characters. Accordingly, all input should be UTF-8 or printable
    ASCII to be safe;"

Fix the issue and also add test to ensure that this will not break.