### PR TITLE
Skip test_cv_subscribe_system_puppet

### DIFF
--- a/tests/foreman/cli/test_contentviews.py
+++ b/tests/foreman/cli/test_contentviews.py
@@ -2096,6 +2096,7 @@ class TestContentView(CLITestCase):
         self.assertEqual(result.return_code, 0)
         self.assertEqual(result.stdout['content-host-count'], '1')
 
+    @skip_if_bug_open('bugzilla', 1222118)
     def test_cv_subscribe_system_puppet(self):
         """@test: Attempt to subscribe content host to content view that has
         puppet module assigned to it
@@ -2104,6 +2105,8 @@ class TestContentView(CLITestCase):
 
         @assert: Content Host can be subscribed to content view with puppet
         module
+
+        @bz: 1222118
 
         """
         new_org = make_org()


### PR DESCRIPTION
BZ 1222118 affects this test because the puppet-module list returns
puppet modules that are not related to the content view. This will not
fail on a clean machine, but in the automation one it will fail because
other tests synchronize different puppet modules.