### PR TITLE
Skip tests failing due to BZ 1223494

### DIFF
--- a/tests/foreman/api/test_contentview.py
+++ b/tests/foreman/api/test_contentview.py
@@ -16,7 +16,12 @@ from robottelo.common.constants import (
     PRDS,
 )
 from robottelo.common.decorators import (
-    bz_bug_is_open, data, run_only_on, stubbed)
+    bz_bug_is_open,
+    data,
+    run_only_on,
+    skip_if_bug_open,
+    stubbed,
+)
 from robottelo.common.helpers import get_data_file, get_server_credentials
 from robottelo.test import APITestCase
 # (too-many-public-methods) pylint:disable=R0904
@@ -32,6 +37,7 @@ REPEAT = 3
 class ContentViewTestCase(APITestCase):
     """Tests for content views."""
 
+    @skip_if_bug_open('bugzilla', 1223494)
     def test_subscribe_system_to_cv(self):
         """@Test: Subscribe a system to a content view.
 

--- a/tests/foreman/api/test_multiple_paths.py
+++ b/tests/foreman/api/test_multiple_paths.py
@@ -441,7 +441,7 @@ class EntityIdTestCase(APITestCase):
         """
         logger.debug('test_delete_status_code arg: %s', entity_cls)
         skip_if_sam(self, entity_cls)
-        if entity_cls is entities.ConfigTemplate and bz_bug_is_open(1096333):
+        if entity_cls == entities.ConfigTemplate and bz_bug_is_open(1096333):
             self.skipTest('Cannot delete config templates.')
         try:
             entity = entity_cls(id=entity_cls().create_json()['id'])
@@ -692,6 +692,8 @@ class EntityReadTestCase(APITestCase):
         """
         logger.debug('test_entity_read arg: %s', entity_cls)
         skip_if_sam(self, entity_cls)
+        if entity_cls == entities.System and bz_bug_is_open(1223494):
+            self.skipTest('Cannot read all system attributes.')
         entity_id = entity_cls().create_json()['id']
         self.assertIsInstance(entity_cls(id=entity_id).read(), entity_cls)
 


### PR DESCRIPTION
Fix #2286.

Test results against an upstream and downstream system:

    $ nosetests tests/foreman/api/test_contentview.py -m test_subscribe_system_to_cv
    S
    ----------------------------------------------------------------------
    Ran 1 test in 0.712s

    OK (SKIP=1)
    $ nosetests tests/foreman/api/test_multiple_paths.py -m 'test_entity_read_21_System'
    S
    ----------------------------------------------------------------------
    Ran 1 test in 0.573s

    OK (SKIP=1)