### PR TITLE
UI: Write UI test for test_delete_manifest - issue #721

### DIFF
--- a/robottelo/ui/activationkey.py
+++ b/robottelo/ui/activationkey.py
@@ -85,6 +85,32 @@ class ActivationKey(Base):
             element = self.wait_until_element((strategy, value % element_name))
         return element
 
+    def search_key_subscriptions(self, ak_name, subscription_name):
+        """Fetch associated subscriptions from selected activation key"""
+        activation_key = self.search_key(ak_name)
+        if activation_key is None:
+            raise UINoSuchElementError(
+                u'Could not find activation key {0}'.format(ak_name))
+        activation_key.click()
+        self.wait_for_ajax()
+        if self.wait_until_element(tab_locators['ak.subscriptions']) is None:
+            raise UINoSuchElementError('Could not find Subscriptions tab')
+        self.find_element(tab_locators['ak.subscriptions']).click()
+        self.wait_for_ajax()
+        searchbox = self.wait_until_element(
+            locators['ak.subscriptions.search'])
+        if searchbox is None:
+            raise UINoSuchElementError(
+                'Could not find Subscriptions search box')
+        searchbox.clear()
+        searchbox.send_keys(escape_search(subscription_name))
+        self.find_element(locators['ak.subscriptions.search_button']).click()
+        self.wait_for_ajax()
+        strategy, value = locators['ak.get_subscription_name']
+        element = self.wait_until_element(
+            (strategy, value % subscription_name))
+        return element
+
     def update(self, name, new_name=None, description=None,
                limit=None, content_view=None, env=None):
         """

--- a/robottelo/ui/locators.py
+++ b/robottelo/ui/locators.py
@@ -1243,6 +1243,10 @@ locators = LocatorDict({
          "/td/input[@ng-model='subscription.selected']")),
     "ak.add_selected_subscription": (
         By.XPATH, "//button[@ng-click='addSelected()']"),
+    "ak.get_subscription_name": (
+        By.XPATH,
+        "//tr[@ng-repeat-start='(name, subscriptions) in "
+        "groupedSubscriptions']/td/a[contains(., '%s')]"),
     "ak.selected_cv": (
         By.XPATH,
         ("//form[@bst-edit-select='activationKey.content_view.name']"
@@ -1259,6 +1263,13 @@ locators = LocatorDict({
     "ak.prd_content.select_repo": (
         By.XPATH,
         "//u[contains(.,'%s')]/../../div/form/div/select"),
+    "ak.subscriptions.search": (
+        By.XPATH,
+        "//input[@ng-model='subscriptionsTable.searchTerm']"),
+    "ak.subscriptions.search_button": (
+        By.XPATH,
+        "//button[@ng-click='subscriptionsTable."
+        "search(subscriptionsTable.searchTerm)']"),
 
     # Sync Status
     "sync.prd_expander": (

--- a/robottelo/ui/navigator.py
+++ b/robottelo/ui/navigator.py
@@ -43,6 +43,7 @@ class Navigator(Base):
                 "arguments[0].click();",
                 tertiary_element,
             )
+        self.wait_for_ajax()
 
     def go_to_dashboard(self):
         self.menu_click(


### PR DESCRIPTION
Added implementation of ```test_delete_manifest```. 
Resolves #721
Test results:
```
nosetests tests/foreman/ui/test_activationkey.py -m test_delete_manifest
.
----------------------------------------------------------------------
Ran 1 test in 182.919s

OK
```