### PR TITLE
Fixed Time format closes #2298

### DIFF
--- a/tests/foreman/ui/test_syncplan.py
+++ b/tests/foreman/ui/test_syncplan.py
@@ -106,7 +106,7 @@ class Syncplan(UITestCase):
         # Formatting current_date to web-UI format "%b %d, %Y %I:%M:%S %p" and
         # removed zero-padded date(%-d) and hrs(%l) as fetching via web-UI
         # doesn't have it
-        formatted_date_time = startdate.strftime("%b %-d, %Y %l:%M:%S %p")
+        formatted_date_time = startdate.strftime("%b %-d, %Y %-l:%M:%S %p")
         # Removed the seconds info as it would be too quick to validate via UI.
         starttime = formatted_date_time.rpartition(':')[0]
         with Session(self.browser) as session:


### PR DESCRIPTION
Fixed Time format due to which the date string comparison was failing and hence the Test.
%l formats the time and remove 0(Zero) if the hour is in format '04:34' but adds a space, due to which date comparison was failing. So used '%-l' which formats the time and also doesn't adds space. 

Now the test should pass on Jenkins.
Cant add my local logs for this test as there is bug for sync plan for different time Zones, the start date shows different. And so being in IST timezone this test will always fail for me locally till bug BZ1219263 get closed.