### PR TITLE
Bug ID mapped, actual failure closes #2293

### DIFF
--- a/tests/foreman/ui/test_repository.py
+++ b/tests/foreman/ui/test_repository.py
@@ -406,6 +406,7 @@ class Repos(UITestCase):
             self.assertIsNone(self.repository.search(repo_name))
 
     @run_only_on('sat')
+    @skip_if_bug_open('bugzilla', 1225740)
     def test_discover_repo_1(self):
         """@Test: Create repository via repo-discovery under existing product
 


### PR DESCRIPTION
Logged a bug BZ1225740, mapped to the test.
Skipping the test execution until fix.
Result:
```
[root@jyejare robottelo]# nosetests -m test_discover_repo_1 ./tests/foreman/ui/test_repository.py
S
----------------------------------------------------------------------
Ran 1 test in 33.276s

OK (SKIP=1)
```