### PR TITLE
Updated string type due to which failure was occuring closes #2305

### DIFF
--- a/tests/foreman/ui/test_trend.py
+++ b/tests/foreman/ui/test_trend.py
@@ -41,8 +41,8 @@ class TrendTest(UITestCase):
         @Assert: Trend entity is updated
 
         """
-        name = gen_string('utf8')
-        new_name = gen_string('utf8')
+        name = gen_string('alphanumeric')
+        new_name = gen_string('alphanumeric')
         with Session(self.browser) as session:
             make_trend(
                 session,


### PR DESCRIPTION
The name string has been used inside XPATH to search an edit button with respect to that trend name. But utf8 string is showing some random text inside HTML XPATH and so it could not search edit button for that utf8 string trend name. Giving 'alphanumeric' type(or other than utf8) for trend name works well.

Results:
```
[root@jyejare robottelo]# nosetests -m test_update_trend_positive ./tests/foreman/ui/test_trend.py
.
----------------------------------------------------------------------
Ran 1 test in 36.816s

OK
```