### PR TITLE
Add task status removal from stderr

### DIFF
--- a/robottelo/cli/contentview.py
+++ b/robottelo/cli/contentview.py
@@ -59,12 +59,11 @@ class ContentView(Base):
     def publish(cls, options, timeout=None):
         """Publishes a new version of content-view."""
         cls.command_sub = 'publish'
-
         # Publishing can take a while so try to wait a bit longer
         if timeout is None:
             timeout = 120
-
-        return cls.execute(cls._construct_command(options), timeout=timeout)
+        return cls._remove_task_status(
+            cls.execute(cls._construct_command(options), timeout=timeout))
 
     @classmethod
     def version_info(cls, options):

--- a/robottelo/cli/repository.py
+++ b/robottelo/cli/repository.py
@@ -19,7 +19,6 @@ Subcommands::
     update                        Update a repository
     upload-content                Upload content into the repository
 """
-
 from robottelo.cli.base import Base
 
 
@@ -55,16 +54,10 @@ class Repository(Base):
 
     @classmethod
     def synchronize(cls, options):
-        """
-        Synchronizes a repository.
-        """
-
+        """Synchronizes a repository."""
         cls.command_sub = 'synchronize'
-
-        result = cls.execute(
-            cls._construct_command(options), output_format='csv')
-
-        return result
+        return cls._remove_task_status(
+            cls.execute(cls._construct_command(options), output_format='csv'))
 
     @classmethod
     def upload_content(cls, options):

--- a/robottelo/cli/subscription.py
+++ b/robottelo/cli/subscription.py
@@ -32,15 +32,10 @@ class Subscription(Base):
 
     @classmethod
     def upload(cls, options=None):
-        """
-        Upload a subscription manifest
-        """
-
+        """Upload a subscription manifest."""
         cls.command_sub = 'upload'
-
-        result = cls.execute(cls._construct_command(options))
-
-        return result
+        return cls._remove_task_status(
+            cls.execute(cls._construct_command(options)))
 
     @classmethod
     def delete_manifest(cls, options=None):


### PR DESCRIPTION
Some commands prints on the stderr the task status if the return code is
0. Remove the task status from stderr in order to allow tests to check
if no other information is present on the stderr, for example, an
exception.