### PR TITLE
Unchecking Snippet makes OS list visible in Config Template fixes #2252

### DIFF
--- a/tests/foreman/ui/test_operatingsys.py
+++ b/tests/foreman/ui/test_operatingsys.py
@@ -397,6 +397,7 @@ class OperatingSys(UITestCase):
         os = entities.OperatingSystem(name=os_name).create()
         entities.ConfigTemplate(
             name=template_name,
+            snippet=False,
             operatingsystem=[os],
             organization=[self.org_id],
         ).create()


### PR DESCRIPTION
For associating a Operating System to Configuration Template, unchecking Snippet option in Configuration Template was very much required. 
By unchecking snippet option, OS list is visible and now it can select the OS for that Configuration Template. 
So the NoneType object issue has been resolved. Test passing.

Result:
```
[root@jyejare robottelo]# nosetests -m test_update_os_template ./tests/foreman/ui/test_operatingsys.py
.
----------------------------------------------------------------------
Ran 1 test in 56.464s

OK
```