### PR TITLE
Improve task status regex

### DIFF
--- a/robottelo/cli/base.py
+++ b/robottelo/cli/base.py
@@ -9,7 +9,7 @@ from robottelo.common import conf, ssh
 # Example for a task status message: "Task b18d3363-f4b8-44eb-871c-760e51444d22
 # success: 1.0/1, 100%, elapsed: 00:00:02\n"
 TASK_STATUS_REGEX = re.compile(
-    r'Task [\w-]+ \w+: [\d./]+, \d+%, elapsed: [\d:]+\n')
+    r'Task [\w-]+ \w+: [\d./]+, \d+%, elapsed: [\d:]+\n\n?')
 
 
 class CLIError(Exception):


### PR DESCRIPTION
The last line after printing the task status have an additional line
break character. Make task status regex remove it if present.

Test results for a failing test:

```python
$ py.test tests/foreman/cli/test_org.py -ktest_positive_delete_1
====================================== test session starts =======================================
platform darwin -- Python 2.7.6 -- py-1.4.26 -- pytest-2.6.4
collected 202 items

tests/foreman/cli/test_org.py ....

======================= 198 tests deselected by '-ktest_positive_delete_1' =======================
=========================== 4 passed, 198 deselected in 76.11 seconds ============================
```