### PR TITLE
Another task status removal round

### DIFF
--- a/robottelo/cli/base.py
+++ b/robottelo/cli/base.py
@@ -6,10 +6,15 @@ import re
 from robottelo.cli import hammer
 from robottelo.common import conf, ssh
 
-# Example for a task status message: "Task b18d3363-f4b8-44eb-871c-760e51444d22
-# success: 1.0/1, 100%, elapsed: 00:00:02\n"
+# Task status message have two formats:
+#   * "Task b18d3363-f4b8-44eb-871c-760e51444d22 success: 1.0/1, 100%,
+#     elapsed: 00:00:02\n"
+#   * "Task 6ba9d82a-ea55-4934-8aab-0e057102ee11 running: 0.005/1, 0%, 0.0/s,
+#     elapsed: 00:00:02, ETA: 00:06:55\n"
 TASK_STATUS_REGEX = re.compile(
-    r'Task [\w-]+ \w+: [\d./]+, \d+%, elapsed: [\d:]+\n\n?')
+    r'Task [\w-]+ \w+: [\d./]+, \d+%,( [\d./s]+,)? elapsed: [\d:]+'
+    '(, ETA: [\d:]+)?\n\n?'
+)
 
 
 class CLIError(Exception):

--- a/robottelo/cli/contentview.py
+++ b/robottelo/cli/contentview.py
@@ -144,19 +144,22 @@ class ContentView(Base):
     def version_promote(cls, options):
         """Promotes content-view version to next env."""
         cls.command_sub = 'version promote'
-        return cls.execute(cls._construct_command(options))
+        return cls._remove_task_status(
+            cls.execute(cls._construct_command(options)))
 
     @classmethod
     def version_delete(cls, options):
         """Removes content-view version."""
         cls.command_sub = 'version delete'
-        return cls.execute(cls._construct_command(options))
+        return cls._remove_task_status(
+            cls.execute(cls._construct_command(options)))
 
     @classmethod
     def remove_from_environment(cls, options=None):
         """Remove content-view from an enviornment"""
         cls.command_sub = 'remove-from-environment'
-        return cls.execute(cls._construct_command(options))
+        return cls._remove_task_status(
+            cls.execute(cls._construct_command(options)))
 
     @classmethod
     def remove(cls, options=None):
@@ -165,4 +168,5 @@ class ContentView(Base):
 
         """
         cls.command_sub = 'remove'
-        return cls.execute(cls._construct_command(options))
+        return cls._remove_task_status(
+            cls.execute(cls._construct_command(options)))

--- a/robottelo/cli/product.py
+++ b/robottelo/cli/product.py
@@ -60,5 +60,5 @@ class Product(Base):
     def synchronize(cls, options=None):
         """Synchronize a product."""
         cls.command_sub = 'synchronize'
-        result = cls.execute(cls._construct_command(options))
-        return result
+        return cls._remove_task_status(
+            cls.execute(cls._construct_command(options)))

--- a/robottelo/cli/subscription.py
+++ b/robottelo/cli/subscription.py
@@ -39,27 +39,17 @@ class Subscription(Base):
 
     @classmethod
     def delete_manifest(cls, options=None):
-        """
-        Deletes a subscription manifest
-        """
-
+        """Deletes a subscription manifest."""
         cls.command_sub = 'delete-manifest'
-
-        result = cls.execute(cls._construct_command(options))
-
-        return result
+        return cls._remove_task_status(
+            cls.execute(cls._construct_command(options)))
 
     @classmethod
     def refresh_manifest(cls, options=None):
-        """
-        Refreshes a subscription manifest
-        """
-
+        """Refreshes a subscription manifest."""
         cls.command_sub = 'refresh-manifest'
-
-        result = cls.execute(cls._construct_command(options))
-
-        return result
+        return cls._remove_task_status(
+            cls.execute(cls._construct_command(options)))
 
     @classmethod
     def manifest_history(cls, options=None):

--- a/tests/foreman/cli/test_product.py
+++ b/tests/foreman/cli/test_product.py
@@ -398,36 +398,26 @@ class TestProduct(CLITestCase):
 
         """
         try:
-            new_product = make_product(
-                {
-                    u'organization-id': self.org['id']
-                }
-            )
+            new_product = make_product({
+                u'organization-id': self.org['id']
+            })
             sync_plan = make_sync_plan({'organization-id': self.org['id']})
         except CLIFactoryError as err:
             self.fail(err)
 
-        result = Product.set_sync_plan(
-            {
-                'sync-plan-id': sync_plan['id'],
-                'id': new_product['id']
-            }
-        )
+        result = Product.set_sync_plan({
+            'sync-plan-id': sync_plan['id'],
+            'id': new_product['id'],
+        })
         self.assertEqual(result.return_code, 0)
-        self.assertEqual(
-            len(result.stderr), 0,
-            "Running set_sync_plan should cause no errors.")
+        self.assertEqual(len(result.stderr), 0)
         result = Product.info({
             'id': new_product['id'],
             'organization-id': self.org['id'],
         })
         self.assertEqual(result.return_code, 0)
-        self.assertEqual(
-            result.stderr, [],
-            "Running product info should cause no errors.")
-        self.assertEqual(
-            result.stdout['sync-plan-id'], sync_plan['id'],
-            "Info should have consistent sync ids.")
+        self.assertEqual(len(result.stderr), 0)
+        self.assertEqual(result.stdout['sync-plan-id'], sync_plan['id'])
 
     def test_remove_syncplan_1(self):
         """@Test: Check if product can be assigned a syncplan
@@ -440,48 +430,34 @@ class TestProduct(CLITestCase):
         try:
             product = make_product({u'organization-id': self.org['id']})
             sync_plan = make_sync_plan({'organization-id': self.org['id']})
-            result = Product.set_sync_plan({
-                'sync-plan-id': sync_plan['id'],
-                'id': product['id'],
-            })
         except CLIFactoryError as err:
             self.fail(err)
 
-        self.assertEqual(
-            result.stderr, [],
-            'Running set_sync_plan should cause no errors.'
-        )
+        result = Product.set_sync_plan({
+            'sync-plan-id': sync_plan['id'],
+            'id': product['id'],
+        })
+        self.assertEqual(result.return_code, 0)
+        self.assertEqual(len(result.stderr), 0)
         result = Product.info({
             'id': product['id'],
             'organization-id': self.org['id'],
         })
-        self.assertEqual(
-            result.stderr, [],
-            'Running product info should cause no errors.'
-        )
-        self.assertEqual(
-            result.stdout['sync-plan-id'], sync_plan['id'],
-            'Info should have consistent sync ids.'
-        )
-        r_result = Product.remove_sync_plan({
+        self.assertEqual(result.return_code, 0)
+        self.assertEqual(len(result.stderr), 0)
+        self.assertEqual(result.stdout['sync-plan-id'], sync_plan['id'])
+        result = Product.remove_sync_plan({
             'id': product['id'],
         })
-        self.assertEqual(
-            r_result.stderr, [],
-            'Running product remove_sync_plan should cause no errors.'
-        )
+        self.assertEqual(result.return_code, 0)
+        self.assertEqual(len(result.stderr), 0)
         result = Product.info({
             'id': product['id'],
             'organization-id': self.org['id'],
         })
-        self.assertEqual(
-            result.stderr, [],
-            'Running product info should cause no errors.'
-        )
-        self.assertEqual(
-            len(result.stdout['sync-plan-id']), 0,
-            'Info should have no sync id.'
-        )
+        self.assertEqual(result.return_code, 0)
+        self.assertEqual(len(result.stderr), 0)
+        self.assertEqual(len(result.stdout['sync-plan-id']), 0)
 
     def test_product_synchronize_by_id(self):
         """@Test: Check if product can be synchronized.

--- a/tests/robottelo/test_cli.py
+++ b/tests/robottelo/test_cli.py
@@ -1,7 +1,8 @@
 import unittest
 
-from robottelo.common import conf
 from robottelo.cli.base import Base
+from robottelo.common import conf
+from robottelo.common.ssh import SSHCommandResult
 
 
 class CLIClass(Base):
@@ -68,3 +69,23 @@ class BaseCliTestCase(unittest.TestCase):
         self.assertEqual(new_class.foreman_admin_username, 'auser')
         self.assertEqual(new_class.foreman_admin_password, 'apass')
         self.assertIn(Base, new_class.__bases__)
+
+    def test_remove_task_status(self):
+        """Check if ``_remove_task_status`` method cleans the expected task
+        status messages.
+
+        """
+        data = (
+            u'Task 3af6fec3-2b7d-4e8a-93a4-082509e203fc running: 0.005/1, 0%, '
+            '0.0/s, elapsed: 00:00:02, ETA: 00:07:34\nTask '
+            '3af6fec3-2b7d-4e8a-93a4-082509e203fc success: 1.0/1, 100%, '
+            '0.1/s, elapsed: 00:00:11\nTask '
+            '3af6fec3-2b7d-4e8a-93a4-082509e203fc success: 1.0/1, 100%, '
+            '0.1/s, elapsed: 00:00:11\nTask '
+            '6ba9d82a-ea55-4934-8aab-0e057102ee11 running: 0.005/1, 0%, '
+            '0.0/s, elapsed: 00:00:02, ETA: 00:06:55\nTask '
+            '6ba9d82a-ea55-4934-8aab-0e057102ee11 running: 0.005/1, 0%, '
+            '0.0/s, elapsed: 00:00:02, ETA: 00:06:55\n\n'
+        )
+        result = SSHCommandResult(stderr=data, return_code=0)
+        self.assertEqual(Base._remove_task_status(result).stderr, '')


### PR DESCRIPTION
* Handle the two types of task status messages.
* Call _remove_task_status on all commands that expects a task. This
  information is available on hammer help, every command that expects
  the `--async` option expects a task.
* Add test for the _remove_task_status in order to ensure that it can
  remove messages from stderr.
* Update test_{add,remove}_syncplan_1 to assert for the commands return
  code and check the length of the stderr.

Result for the new robottelo test:

```python
$ py.test tests/robottelo/test_cli.py
================================== test session starts ==================================
platform darwin -- Python 2.7.6 -- py-1.4.26 -- pytest-2.6.4
collected 6 items

tests/robottelo/test_cli.py ......

=============================== 6 passed in 2.64 seconds ================================
```

I've run tests that were failing in the current compose CLI results:

```python
$ py.test tests/foreman/smoke/test_cli_smoke.py -k test_smoke
================================== test session starts ==================================
platform darwin -- Python 2.7.6 -- py-1.4.26 -- pytest-2.6.4
collected 6 items

tests/foreman/smoke/test_cli_smoke.py .

========================= 5 tests deselected by '-ktest_smoke' ==========================
======================= 1 passed, 5 deselected in 217.03 seconds ========================

$ py.test tests/foreman/cli/test_contentviews.py
================================== test session starts ==================================
platform darwin -- Python 2.7.6 -- py-1.4.26 -- pytest-2.6.4
collected 62 items

tests/foreman/cli/test_contentviews.py .....s..ss................ss.s.....s...s..s......ss...s.......

======================= 50 passed, 12 skipped in 2418.52 seconds ========================

$ py.test tests/foreman/cli/test_product.py
================================== test session starts ==================================
platform darwin -- Python 2.7.6 -- py-1.4.26 -- pytest-2.6.4
collected 53 items

tests/foreman/cli/test_product.py .....................................................

============================== 53 passed in 810.60 seconds ==============================

$ py.test tests/foreman/cli/test_subscription.py
================================== test session starts ==================================
platform darwin -- Python 2.7.6 -- py-1.4.26 -- pytest-2.6.4
collected 5 items

tests/foreman/cli/test_subscription.py .s.F.

======================================= FAILURES ========================================
________________________ TestSubscription.test_manifest_refresh _________________________

tests/foreman/cli/test_subscription.py:172: in test_manifest_refresh
    self.assertEqual(len(result.stderr), 0)
E   AssertionError: 74 != 0
--------------------------------- Captured stdout call ----------------------------------
# Omited stdout...

2015-05-29 14:37:57 - robottelo.common.ssh - DEBUG - >>> [satserver.com] LANG=en_US.UTF-8 hammer -v -u admin -p changeme  subscription refresh-manifest --organization-id="355"
2015-05-29 14:37:58 - robottelo.common.ssh - INFO - Instantiated Paramiko client 0x1030b13d0
2015-05-29 14:38:02 - robottelo.common.ssh - INFO - Destroying Paramiko client 0x1030b13d0
2015-05-29 14:38:02 - robottelo.common.ssh - INFO - Destroyed Paramiko client 0x1030b13d0
2015-05-29 14:38:02 - robottelo.common.ssh - DEBUG - <<< stderr
Task 76f401bb-22de-47d9-be16-f9e9bcd1143f running: 0.0/1, 0%, elapsed: 00:00:00
Task 76f401bb-22de-47d9-be16-f9e9bcd1143f warning: 1.0/1, 100%, 0.5/s, elapsed: 00:00:02
Task 76f401bb-22de-47d9-be16-f9e9bcd1143f warning: 1.0/1, 100%, 0.5/s, elapsed: 00:00:02
Consumer with id 3b398145-0629-11e5-9ece-3c075427b721 could not be found.

==================== 1 failed, 3 passed, 1 skipped in 434.00 seconds ====================
```

The only failure on the subscriptions is an expected failure because the command returned a zero return code but the stderr presented an error and because that the return code should be non zero.