### PR TITLE
Finish hammer content-host CLI class

### DIFF
--- a/robottelo/cli/contenthost.py
+++ b/robottelo/cli/contenthost.py
@@ -11,39 +11,33 @@ Parameters::
 
 Subcommands::
 
-    create                        Register a system
-    delete                        Unregister a system
+    available-incremental-updates Given a set of systems and errata, lists the
+                                  content view versions and environments that
+                                  need updating.
+    create                        Register a content host
+    delete                        Unregister a content host
     errata                        Manage errata on your content hosts
-    info                          Show a system
-    list                          List systems
+    info                          Show a content host
+    list                          List content hosts
     package                       Manage packages on your content hosts
     package-group                 Manage package-groups on your content hosts
-    tasks                         List async tasks for the system
-    update                        Update system information
-"""
+    tasks
+    update                        Update content host information
 
+"""
 from robottelo.cli.base import Base
 
 
 class ContentHost(Base):
-    """
-    Manipulates Katello engine's content-host command.
-    """
-
+    """Manipulates Katello engine's content-host command."""
     command_base = 'content-host'
 
     @classmethod
-    def tasks(cls, options=None):
-        """
-        Lists async tasks for a content host
-        """
-
-        cls.command_sub = 'tasks'
-
-        result = cls.execute(
+    def errata_apply(cls, options):
+        """Schedule errata for installation"""
+        cls.command_sub = 'errata apply'
+        return cls.execute(
             cls._construct_command(options), output_format='csv')
-
-        return result
 
     @classmethod
     def errata_info(cls, options):
@@ -53,8 +47,57 @@ class ContentHost(Base):
             cls._construct_command(options), output_format='csv')
 
     @classmethod
-    def errata_apply(cls, options):
-        """Schedule errata for installation"""
-        cls.command_sub = 'errata apply'
+    def errata_list(cls, options):
+        """List errata available for the content host."""
+        cls.command_sub = 'errata list'
+        return cls.execute(
+            cls._construct_command(options), output_format='csv')
+
+    @classmethod
+    def package_install(cls, options):
+        """Install packages remotely."""
+        cls.command_sub = 'package install'
+        return cls.execute(
+            cls._construct_command(options), output_format='csv')
+
+    @classmethod
+    def package_remove(cls, options):
+        """Uninstall packages remotely."""
+        cls.command_sub = 'package remove'
+        return cls.execute(
+            cls._construct_command(options), output_format='csv')
+
+    @classmethod
+    def package_upgrade(cls, options):
+        """Update packages remotely."""
+        cls.command_sub = 'package upgrade'
+        return cls.execute(
+            cls._construct_command(options), output_format='csv')
+
+    @classmethod
+    def package_upgrade_all(cls, options):
+        """Update all packages remotely."""
+        cls.command_sub = 'package upgrade-all'
+        return cls.execute(
+            cls._construct_command(options), output_format='csv')
+
+    @classmethod
+    def package_group_install(cls, options):
+        """Install package groups remotely."""
+        cls.command_sub = 'package-group install'
+        return cls.execute(
+            cls._construct_command(options), output_format='csv')
+
+    @classmethod
+    def package_group_remove(cls, options):
+        """Uninstall package groups remotely."""
+        cls.command_sub = 'package-group remove'
+        return cls.execute(
+            cls._construct_command(options), output_format='csv')
+
+    @classmethod
+    def tasks(cls, options=None):
+        """Lists async tasks for a content host."""
+        cls.command_sub = 'tasks'
         return cls.execute(
             cls._construct_command(options), output_format='csv')


### PR DESCRIPTION
Add all missing content-host subcommands to the ContentHost CLI class.

Closes #1232

Follow the usage of all commands, they have failed due to no option provided, but robottelo is generating the right commands.

```
In [5]: ContentHost.errata_apply({})
2015-06-02 13:32:49 - robottelo.common.ssh - DEBUG - >>> [sat6server.com] LANG=en_US.UTF-8 hammer -v -u admin -p changeme --output=csv content-host errata apply
2015-06-02 13:32:53 - robottelo.common.ssh - DEBUG - <<< stderr
[ERROR 2015-06-02 12:32:52 Exception] Error: Could not find system, please set one of options --content-host, --content-host-id.
Could not apply errata:
  Error: Could not find system, please set one of options --content-host, --content-host-id.

In [6]: ContentHost.errata_info({})
2015-06-02 13:33:09 - robottelo.common.ssh - DEBUG - >>> [sat6server.com] LANG=en_US.UTF-8 hammer -v -u admin -p changeme --output=csv content-host errata info
2015-06-02 13:33:12 - robottelo.common.ssh - DEBUG - <<< stderr
[ERROR 2015-06-02 12:33:12 Exception] Error: Could not find system, please set one of options --content-host, --content-host-id.
Error: Could not find system, please set one of options --content-host, --content-host-id.

In [7]: ContentHost.errata_list({})
2015-06-02 13:33:18 - robottelo.common.ssh - DEBUG - >>> [sat6server.com] LANG=en_US.UTF-8 hammer -v -u admin -p changeme --output=csv content-host errata list
2015-06-02 13:33:21 - robottelo.common.ssh - DEBUG - <<< stderr
[ERROR 2015-06-02 12:33:21 Exception] missing param 'system_id' in parameters
missing param 'system_id' in parameters

In [8]: ContentHost.package_install({})
2015-06-02 13:33:32 - robottelo.common.ssh - DEBUG - >>> [sat6server.com] LANG=en_US.UTF-8 hammer -v -u admin -p changeme --output=csv content-host package install
2015-06-02 13:33:35 - robottelo.common.ssh - DEBUG - <<< stderr
[ERROR 2015-06-02 12:33:35 Exception] Error: Options --packages are required

See: 'hammer content-host package install --help'
Could not install packages:
  Error: Options --packages are required

  See: 'hammer content-host package install --help'

In [9]: ContentHost.package_remove({})
2015-06-02 13:33:43 - robottelo.common.ssh - DEBUG - >>> [sat6server.com] LANG=en_US.UTF-8 hammer -v -u admin -p changeme --output=csv content-host package remove
2015-06-02 13:33:46 - robottelo.common.ssh - DEBUG - <<< stderr
[ERROR 2015-06-02 12:33:46 Exception] Error: Options --packages are required

See: 'hammer content-host package remove --help'
Could not remove packages:
  Error: Options --packages are required

  See: 'hammer content-host package remove --help'

In [10]: ContentHost.package_upgrade({})
2015-06-02 13:33:55 - robottelo.common.ssh - DEBUG - >>> [sat6server.com] LANG=en_US.UTF-8 hammer -v -u admin -p changeme --output=csv content-host package upgrade
2015-06-02 13:33:58 - robottelo.common.ssh - DEBUG - <<< stderr
[ERROR 2015-06-02 12:33:58 Exception] Error: Could not find system, please set one of options --content-host, --content-host-id.
Could not upgrade packages:
  Error: Could not find system, please set one of options --content-host, --content-host-id.

In [11]: ContentHost.package_upgrade_all({})
2015-06-02 13:34:03 - robottelo.common.ssh - DEBUG - >>> [sat6server.com] LANG=en_US.UTF-8 hammer -v -u admin -p changeme --output=csv content-host package upgrade-all
2015-06-02 13:34:06 - robottelo.common.ssh - DEBUG - <<< stderr
[ERROR 2015-06-02 12:34:06 Exception] Error: Could not find system, please set one of options --content-host, --content-host-id.
Could not upgrade all packages:
  Error: Could not find system, please set one of options --content-host, --content-host-id.

In [12]: ContentHost.package_group_install({})
2015-06-02 13:34:17 - robottelo.common.ssh - DEBUG - >>> [sat6server.com] LANG=en_US.UTF-8 hammer -v -u admin -p changeme --output=csv content-host package-group install
2015-06-02 13:34:20 - robottelo.common.ssh - DEBUG - <<< stderr
[ERROR 2015-06-02 12:34:20 Exception] Error: Options --groups are required

See: 'hammer content-host package-group install --help'
Could not install package-groups:
  Error: Options --groups are required

  See: 'hammer content-host package-group install --help'

In [13]: ContentHost.package_group_remove({})
2015-06-02 13:34:27 - robottelo.common.ssh - DEBUG - >>> [sat6server.com] LANG=en_US.UTF-8 hammer -v -u admin -p changeme --output=csv content-host package-group remove
2015-06-02 13:34:30 - robottelo.common.ssh - DEBUG - <<< stderr
[ERROR 2015-06-02 12:34:30 Exception] Error: Options --groups are required

See: 'hammer content-host package-group remove --help'
Could not remove package-groups:
  Error: Options --groups are required

  See: 'hammer content-host package-group remove --help'

In [14]: ContentHost.tasks({})
2015-06-02 13:34:40 - robottelo.common.ssh - DEBUG - >>> [sat6server.com] LANG=en_US.UTF-8 hammer -v -u admin -p changeme --output=csv content-host tasks
2015-06-02 13:34:43 - robottelo.common.ssh - DEBUG - <<< stderr
[ERROR 2015-06-02 12:34:43 Exception] Error: The server does not support such operation.
Error: The server does not support such operation.

In [15]: ContentHost.create({})
2015-06-02 13:34:48 - robottelo.common.ssh - DEBUG - >>> [sat6server.com] LANG=en_US.UTF-8 hammer -v -u admin -p changeme --output=csv content-host create
2015-06-02 13:34:52 - robottelo.common.ssh - DEBUG - <<< stderr
[ERROR 2015-06-02 12:34:52 Exception] Error: Could not find organization, please set one of options --organization, --organization-label, --organization-id.
Could not create content host:
  Error: Could not find organization, please set one of options --organization, --organization-label, --organization-id.

In [16]: ContentHost.delete({})
2015-06-02 13:34:56 - robottelo.common.ssh - DEBUG - >>> [sat6server.com] LANG=en_US.UTF-8 hammer -v -u admin -p changeme  content-host delete
2015-06-02 13:34:59 - robottelo.common.ssh - DEBUG - <<< stderr
[ERROR 2015-06-02 12:34:59 Exception] missing param 'id' in parameters
Could not delete content host:
  missing param 'id' in parameters

In [17]: ContentHost.list({})
2015-06-02 13:35:03 - robottelo.common.ssh - DEBUG - >>> [sat6server.com] LANG=en_US.UTF-8 hammer -v -u admin -p changeme --output=csv content-host list --per-page="10000"
2015-06-02 13:35:06 - robottelo.common.ssh - DEBUG - <<< stderr
[ERROR 2015-06-02 12:35:06 Exception] Error: Could not find organization, please set one of options --organization, --organization-label, --organization-id.
Error: Could not find organization, please set one of options --organization, --organization-label, --organization-id.

In [18]: ContentHost.update({})
2015-06-02 13:35:12 - robottelo.common.ssh - DEBUG - >>> [sat6server.com] LANG=en_US.UTF-8 hammer -v -u admin -p changeme --output=csv content-host update
2015-06-02 13:35:15 - robottelo.common.ssh - DEBUG - <<< stderr
[ERROR 2015-06-02 12:35:15 Exception] missing param 'id' in parameters
Could not update content host:
  missing param 'id' in parameters
```