### PR TITLE
Use NailGun version 0.16.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import find_packages, setup
 REQUIRES = [
     'ddt',
     'fauxfactory',
-    'nailgun==0.15.0',
+    'nailgun==0.16.0',
     'paramiko',
     'python-bugzilla',
     'requests',

--- a/tests/foreman/api/test_contentviewfilter.py
+++ b/tests/foreman/api/test_contentviewfilter.py
@@ -28,7 +28,7 @@ class ContentViewFilterTestCase(APITestCase):
 
         """
         response = client.get(
-            entities.ContentViewFilter().path(),
+            entities.AbstractContentViewFilter().path(),
             auth=get_server_credentials(),
             verify=False,
         )
@@ -49,7 +49,7 @@ class ContentViewFilterTestCase(APITestCase):
 
         """
         response = client.get(
-            entities.ContentViewFilter().path(),
+            entities.AbstractContentViewFilter().path(),
             auth=get_server_credentials(),
             verify=False,
             data={'foo': 'bar'},


### PR DESCRIPTION
There are several breaking changes in NailGun 0.16.0. Among them is that the
`ContentViewFilter` class has been dropped and the following added in its stead:

    AbstractContentViewFilter
    ├── ErratumContentViewFilter
    ├── PackageGroupContentViewFilter
    └── RPMContentViewFilter

Update Robottelo to respond to this change. Test results against a downstream
system:

    $ nosetests tests/foreman/api/test_contentviewfilter.py
    ..
    ----------------------------------------------------------------------
    Ran 2 tests in 1.563s

    OK
    $ nosetests tests/foreman/api/test_contentview.py:CVRedHatContent
    ..
    ----------------------------------------------------------------------
    Ran 2 tests in 68.555s

    OK