### PR TITLE
Updated manifest upload API way, closes #2309.

### DIFF
--- a/tests/foreman/ui/test_sync.py
+++ b/tests/foreman/ui/test_sync.py
@@ -75,10 +75,11 @@ class Sync(UITestCase):
         manifest_path = manifests.clone()
         # upload_file function should take care of uploading to sauce labs.
         upload_file(manifest_path, remote_file=manifest_path)
+        entities.Organization(
+            id=self.org_id
+        ).upload_manifest(path=manifest_path)
         with Session(self.browser) as session:
             session.nav.go_to_select_org(self.org_name)
-            session.nav.go_to_red_hat_subscriptions()
-            self.subscriptions.upload(manifest_path)
             session.nav.go_to_red_hat_repositories()
             self.sync.enable_rh_repos(repos)
             session.nav.go_to_sync_status()


### PR DESCRIPTION
Updated test_sync_rh_repos code. The test was failing due to rh repos was not displayed under redhat repositories.

Now the manifest has been uploaded from API end, which was from UI earlier.

Earlier the test was failing on Jenkins only, not locally so tried this way to fix it.

Local Logs after Change:
```
[root@jyejare robottelo]# nosetests -m test_sync_rh_repos ./tests/foreman/ui/test_sync.py
.
----------------------------------------------------------------------
Ran 1 test in 238.126s

OK
```