### PR TITLE
Ensure unicode string when operating over stderr

### DIFF
--- a/robottelo/vm.py
+++ b/robottelo/vm.py
@@ -110,7 +110,7 @@ class VirtualMachine(object):
 
         if result.return_code != 0:
             raise VirtualMachineError(
-                'Failed to run snap-guest: {0}'.format(result.stderr))
+                u'Failed to run snap-guest: {0}'.format(result.stderr))
 
         # Give some time to machine boot
         time.sleep(60)

--- a/tests/foreman/cli/test_activationkey.py
+++ b/tests/foreman/cli/test_activationkey.py
@@ -1698,7 +1698,7 @@ class TestActivationKey(CLITestCase):
         except CLIFactoryError as err:
             self.fail(err)
 
-        self.assertIn("'--auto-attach': value must be one of", result.stderr)
+        self.assertIn(u"'--auto-attach': value must be one of", result.stderr)
 
     @skip_if_bug_open('bugzilla', 1221778)
     @data(

--- a/tests/foreman/cli/test_host.py
+++ b/tests/foreman/cli/test_host.py
@@ -87,8 +87,8 @@ class HostTestCase(CLITestCase):
             u'root-pass': host.root_pass,
         })
         self.assertNotEqual(result.return_code, 0)
-        self.assertNotIn('mac value is blank', result.stderr)
+        self.assertNotIn(u'mac value is blank', result.stderr)
         self.assertIn(
-            'you must specify either compute attributes or a compute profile',
+            u'you must specify either compute attributes or a compute profile',
             result.stderr
         )

--- a/tests/foreman/cli/test_user.py
+++ b/tests/foreman/cli/test_user.py
@@ -1993,7 +1993,7 @@ class User(CLITestCase):
         # non-existing user info
         result = UserObj.info({'id': 0})
         self.assertNotEqual(result.return_code, 0)
-        self.assertNotRegexpMatches(str(result.stderr), 'undefined method')
+        self.assertNotRegexpMatches(result.stderr, 'undefined method')
 
         # list users
         result = UserObj.list()


### PR DESCRIPTION
ssh stderr is now being converted to unicode string. Make sure to use
unicode strings when operating over stderr.