### PR TITLE
Improve content host and host collection setup

### DIFF
--- a/tests/foreman/cli/test_contenthost.py
+++ b/tests/foreman/cli/test_contenthost.py
@@ -43,7 +43,6 @@ class TestContentHost(CLITestCase):
 
     def setUp(self):  # noqa
         """Tests for Content Host via Hammer CLI"""
-
         super(TestContentHost, self).setUp()
 
         if TestContentHost.NEW_ORG is None:
@@ -53,34 +52,38 @@ class TestContentHost(CLITestCase):
                 {u'organization-id': TestContentHost.NEW_ORG['id']},
                 cached=True)
         if TestContentHost.LIBRARY is None:
-            library_result = LifecycleEnvironment.info(
-                {u'organization-id': TestContentHost.NEW_ORG['id'],
-                 u'name': u'Library'}
-            )
-            TestContentHost.LIBRARY = library_result.stdout
+            result = LifecycleEnvironment.info({
+                u'organization-id': TestContentHost.NEW_ORG['id'],
+                u'name': u'Library',
+            })
+            self.assertEqual(result.return_code, 0)
+            TestContentHost.LIBRARY = result.stdout
         if TestContentHost.DEFAULT_CV is None:
-            cv_result = ContentView.info(
-                {u'organization-id': TestContentHost.NEW_ORG['id'],
-                 u'name': u'Default Organization View'}
-            )
-            TestContentHost.DEFAULT_CV = cv_result.stdout
+            result = ContentView.info({
+                u'organization-id': TestContentHost.NEW_ORG['id'],
+                u'name': u'Default Organization View',
+            })
+            self.assertEqual(result.return_code, 0)
+            TestContentHost.DEFAULT_CV = result.stdout
         if TestContentHost.NEW_CV is None:
-            TestContentHost.NEW_CV = make_content_view(
-                {u'organization-id': TestContentHost.NEW_ORG['id']}
-            )
+            TestContentHost.NEW_CV = make_content_view({
+                u'organization-id': TestContentHost.NEW_ORG['id'],
+            })
             TestContentHost.PROMOTED_CV = None
             cv_id = TestContentHost.NEW_CV['id']
-            ContentView.publish({u'id': cv_id})
+            result = ContentView.publish({u'id': cv_id})
+            self.assertEqual(result.return_code, 0)
             result = ContentView.version_list({u'content-view-id': cv_id})
+            self.assertEqual(result.return_code, 0)
             version_id = result.stdout[0]['id']
-            promotion = ContentView.version_promote({
+            result = ContentView.version_promote({
                 u'id': version_id,
                 u'to-lifecycle-environment-id': TestContentHost.NEW_LIFECYCLE[
                     'id'],
                 u'organization-id': TestContentHost.NEW_ORG['id']
             })
-            if promotion.stderr == []:
-                TestContentHost.PROMOTED_CV = TestContentHost.NEW_CV
+            self.assertEqual(result.return_code, 0)
+            TestContentHost.PROMOTED_CV = TestContentHost.NEW_CV
 
     @data(
         {u'name': gen_string('alpha', 15)},

--- a/tests/foreman/cli/test_host_collection.py
+++ b/tests/foreman/cli/test_host_collection.py
@@ -26,7 +26,6 @@ class TestHostCollection(CLITestCase):
 
     def setUp(self):  # noqa
         """Tests for Host Collections via Hammer CLI"""
-
         super(TestHostCollection, self).setUp()
 
         if TestHostCollection.org is None:
@@ -34,36 +33,41 @@ class TestHostCollection(CLITestCase):
         if TestHostCollection.new_lifecycle is None:
             TestHostCollection.new_lifecycle = make_lifecycle_environment(
                 {u'organization-id': TestHostCollection.org['id']},
-                cached=True)
-        if TestHostCollection.library is None:
-            library_result = LifecycleEnvironment.info(
-                {u'organization-id': TestHostCollection.org['id'],
-                 u'name': u'Library'}
+                cached=True
             )
-            TestHostCollection.library = library_result.stdout
+        if TestHostCollection.library is None:
+            result = LifecycleEnvironment.info({
+                u'organization-id': TestHostCollection.org['id'],
+                u'name': u'Library',
+            })
+            self.assertEqual(result.return_code, 0)
+            TestHostCollection.library = result.stdout
         if TestHostCollection.default_cv is None:
-            cv_result = ContentView.info(
+            result = ContentView.info(
                 {u'organization-id': TestHostCollection.org['id'],
                  u'name': u'Default Organization View'}
             )
-            TestHostCollection.default_cv = cv_result.stdout
+            self.assertEqual(result.return_code, 0)
+            TestHostCollection.default_cv = result.stdout
         if TestHostCollection.new_cv is None:
             TestHostCollection.new_cv = make_content_view(
                 {u'organization-id': TestHostCollection.org['id']}
             )
             TestHostCollection.promoted_cv = None
             cv_id = TestHostCollection.new_cv['id']
-            ContentView.publish({u'id': cv_id})
+            result = ContentView.publish({u'id': cv_id})
+            self.assertEqual(result.return_code, 0)
             result = ContentView.version_list({u'content-view-id': cv_id})
+            self.assertEqual(result.return_code, 0)
             version_id = result.stdout[0]['id']
-            promotion = ContentView.version_promote({
+            result = ContentView.version_promote({
                 u'id': version_id,
                 u'to-lifecycle-environment-id': (
                     TestHostCollection.new_lifecycle['id']),
                 u'organization-id': TestHostCollection.org['id']
             })
-            if promotion.stderr == []:
-                TestHostCollection.promoted_cv = TestHostCollection.new_cv
+            self.assertEqual(result.return_code, 0)
+            TestHostCollection.promoted_cv = TestHostCollection.new_cv
 
     def _new_host_collection(self, options=None):
         """Make a host collection and asserts its success"""


### PR DESCRIPTION
Make sure that the commands return a 0 return code to avoid progressing
on the test even if an error occurred.

I have run one test from each module in order to make sure that the setup is not broken:

```
$ py.test tests/foreman/cli/test_contenthost.py -ktest_positive_create_1
================================== test session starts ==================================
platform darwin -- Python 2.7.6 -- py-1.4.26 -- pytest-2.6.4
collected 46 items

tests/foreman/cli/test_contenthost.py ......

=================== 40 tests deselected by '-ktest_positive_create_1' ===================
======================= 6 passed, 40 deselected in 116.46 seconds =======================

================================== test session starts ==================================


$ py.test tests/foreman/cli/test_host_collection.py -ktest_positive_create_1
================================== test session starts ==================================
platform darwin -- Python 2.7.6 -- py-1.4.26 -- pytest-2.6.4
collected 57 items

tests/foreman/cli/test_host_collection.py ......

=================== 51 tests deselected by '-ktest_positive_create_1' ===================
======================= 6 passed, 51 deselected in 99.51 seconds ========================
```