### PR TITLE
Updated LDAP and External Authentication test-cases.

### DIFF
--- a/docs/api/tests.foreman.ui.rst
+++ b/docs/api/tests.foreman.ui.rst
@@ -102,6 +102,11 @@
 ----------------------------------------
 
 .. automodule:: tests.foreman.ui.test_isodownload
+   
+:mod:`tests.foreman.ui.test_ldap_auth`
+--------------------------------------
+
+.. automodule:: tests.foreman.ui.test_ldap_auth
 
 :mod:`tests.foreman.ui.test_location`
 -------------------------------------

--- a/tests/foreman/ui/test_adusergroups.py
+++ b/tests/foreman/ui/test_adusergroups.py
@@ -7,15 +7,15 @@ class ADUserGroups(UITestCase):
     """Implements Active Directory feature tests in UI."""
 
     @stubbed()
-    def test_create_ldap_auth_withAD(self):
+    def test_create_ldap_auth_withad(self):
         """@Test: Create LDAP authentication with AD
 
-        @Feature: Active Directory - create LDAP AD
+        @Feature: LDAP Authentication - Active Directory - create LDAP AD
 
         @steps:
 
-        1. Create a new LDAP Auth source with AD
-        2. Fill in all the fields appropriately for AD
+        1. Create a new LDAP Auth source with AD.
+        2. Fill in all the fields appropriately for AD.
 
         @Assert: Whether creating LDAP Auth with AD is successful.
 
@@ -24,15 +24,15 @@ class ADUserGroups(UITestCase):
         """
 
     @stubbed()
-    def test_delete_ldap_auth_withAD(self):
+    def test_delete_ldap_auth_withad(self):
         """@Test: Delete LDAP authentication with AD
 
-        @Feature: Active Directory - delete LDAP AD
+        @Feature: LDAP Authentication - Active Directory - delete LDAP AD
 
         @steps:
 
-        1. Delete LDAP Auth source with AD
-        2. Fill in all the fields appropriately for AD
+        1. Delete LDAP Auth source with AD.
+        2. Fill in all the fields appropriately for AD.
 
         @Assert: Whether deleting LDAP Auth with AD is successful.
 
@@ -45,7 +45,8 @@ class ADUserGroups(UITestCase):
         """@Test: Associate Admin role to User Group.
         [belonging to external AD User Group.]
 
-        @Feature: Active Directory - associate Admin role
+        @Feature: LDAP Authentication - Active Directory - associate Admin
+        role
 
         @Steps:
 
@@ -65,7 +66,8 @@ class ADUserGroups(UITestCase):
         """@Test: Associate foreman roles to User Group.
         [belonging to external AD User Group.]
 
-        @Feature: Active Directory - associate foreman roles.
+        @Feature: LDAP Authentication - Active Directory - associate foreman
+        roles.
 
         @Steps:
 
@@ -85,7 +87,8 @@ class ADUserGroups(UITestCase):
         """@Test: Associate katello roles to User Group.
         [belonging to external AD User Group.]
 
-        @Feature: Active Directory - associate katello roles
+        @Feature: LDAP Authentication - Active Directory - associate katello
+        roles
 
         @Steps:
 
@@ -104,13 +107,13 @@ class ADUserGroups(UITestCase):
     def test_create_external_adusergroup_1(self):
         """@Test: Create External AD User Group as per AD group
 
-        @Feature: Active Directory - create
+        @Feature: LDAP Authentication - Active Directory - create
 
         @Steps:
 
         1. Create an UserGroup.
-        2. Assign some foreman roles to UserGroup.
-        3. create an External AD UserGroup as per the usergroup name in AD
+        2. Assign some roles to UserGroup.
+        3. create an External AD UserGroup as per the UserGroup name in AD
 
         @Assert: Whether creation of External AD User Group is possible.
 
@@ -122,15 +125,15 @@ class ADUserGroups(UITestCase):
     def test_create_external_adusergroup_2(self):
         """@Test: Create another External AD User Group with same name
 
-        @Feature: Active Directory - create
+        @Feature: LDAP Authentication - Active Directory - create
 
         @Steps:
 
         1. Create an UserGroup.
-        2. Assign some foreman roles to UserGroup.
-        3. create an External AD UserGroup as per the usergroup name in AD
-        4. Repeat steps 1) and 2) and provide the same usergroup name for
-           step 3)
+        2. Assign some roles to UserGroup.
+        3. create an External AD UserGroup as per the UserGroup name in AD.
+        4. Repeat steps 1) and 2) and provide the same UserGroup name for
+           step 3).
 
         @Assert: Creation of External AD User Group should not be possible with
         same name.
@@ -143,17 +146,139 @@ class ADUserGroups(UITestCase):
     def test_create_external_adusergroup_3(self):
         """@Test: Create External AD User Group with random name
 
-        @Feature: Active Directory - create
+        @Feature: LDAP Authentication - Active Directory - create
 
         @Steps:
 
         1. Create an UserGroup.
-        2. Assign some foreman roles to UserGroup.
+        2. Assign some roles to UserGroup.
         3. create an External AD UserGroup with any random name.
 
         @Assert: Creation of External AD User Group should not be possible with
         random name.
 
         @Status: Manual
+
+        """
+
+    @stubbed()
+    def test_delete_external_adusergroup(self):
+        """@Test: Delete External AD User Group
+
+        @Feature: LDAP Authentication - Active Directory - delete
+
+        @Steps:
+
+        1. Create an UserGroup.
+        2. Assign some roles to UserGroup.
+        3. Create an External AD UserGroup as per the UserGroup name in AD.
+        4. Delete the External AD UserGroup.
+
+        Note:- Deletion as of sat6.1 is possible only via CLI and not via UI.
+
+        @Assert: Deletion of External AD User Group should be possible and the
+        user should not be able to perform the roles that were assigned to it
+        at the UserGroup level.
+
+        @Status: Manual
+
+        """
+
+    @stubbed()
+    def test_external_adusergroup_roles_update(self):
+        """@test: Added AD UserGroup roles get pushed down to user
+
+        @feature: LDAP Authentication - Active directory - update
+
+        @setup: assign additional roles to the UserGroup
+
+        @steps:
+        1. Create an UserGroup.
+        2. Assign some roles to UserGroup.
+        3. Create an External AD UserGroup as per the UserGroup name in AD.
+        4. Login to sat6 with the AD user.
+        5. Assign additional roles to the UserGroup.
+        6. Login to sat6 with LDAP user that is part of aforementioned
+        UserGroup.
+
+        @assert: User has access to all NEW functional areas that are assigned
+        to aforementioned UserGroup.
+
+        @status: Manual
+
+        """
+
+    @stubbed()
+    def test_external_adusergroup_roles_delete(self):
+        """@test: Deleted AD UserGroup roles get pushed down to user
+
+        @feature: LDAP Authentication - Active directory - update
+
+        @setup: delete roles from an AD UserGroup
+
+        @steps:
+        1. Create an UserGroup.
+        2. Assign some roles to UserGroup.
+        3. Create an External AD UserGroup as per the UserGroup name in AD.
+        4. Login to sat6 with the AD user.
+        5. Unassign some of the existing roles of the UserGroup.
+        6. Login to sat6 with LDAP user that is part of aforementioned
+        UserGroup.
+
+        @assert: User no longer has access to all deleted functional areas
+        that were assigned to aforementioned UserGroup.
+
+        @status: Manual
+
+        """
+
+    @stubbed()
+    def test_external_adUserGroup_additional_user_roles(self):
+        """@test: Assure that user has roles/can access feature areas for
+        additional roles assigned outside any roles assigned by his group
+
+        @feature: LDAP Authentication - Active directory - update
+
+        @setup: Assign roles to UserGroup and configure external
+        UserGroup subsequently assign specified roles to the user(s).
+        roles that are not part of the larger UserGroup
+
+        @steps:
+        1. Create an UserGroup.
+        2. Assign some roles to UserGroup.
+        3. Create an External AD UserGroup as per the UserGroup name in AD.
+        4. Assign some more roles to a User(which is part of external AD
+        UserGroup) at the User level.
+        5. Login to sat6 with the above AD user and attempt to access areas
+        assigned specifically to user.
+
+        @assert: User can access not only those feature areas in his
+        UserGroup but those additional feature areas / roles assigned
+        specifically to user
+
+        @status: Manual
+
+        """
+
+    @stubbed()
+    def test_external_adUserGroup_user_add(self):
+        """@test: New user added to UserGroup at AD side inherits roles in Sat6
+
+        @feature: LDAP Authentication - Active directory - update
+
+        @setup: UserGroup with specified roles.
+
+        @steps:
+        1. Create an UserGroup.
+        2. Assign some roles to UserGroup.
+        3. Create an External AD UserGroup as per the UserGroup name in AD.
+        4. On AD server side, assign a new user to a UserGroup.
+        5. Login to sat6 with the above new AD user and attempt to access the
+        functional areas assigned to the user.
+
+        @assert: User can access feature areas as defined by roles in the
+        UserGroup of which he is a part.
+
+        @status: Manual
 
         """

--- a/tests/foreman/ui/test_ldap_auth.py
+++ b/tests/foreman/ui/test_ldap_auth.py
@@ -1,0 +1,385 @@
+"""Test class for installer (UI)"""
+
+from robottelo.common.decorators import stubbed
+from robottelo.test import UITestCase
+
+
+class LDAPAuthUI(UITestCase):
+    # Notes for SSO testing:
+    # Of interest... In some test cases I've placed a few comments prefaced
+    # with "devnote:" These are -- obviously -- notes from developers that
+    # might help reiterate something important or a reminder of way(s) to test
+    # something.
+
+    # There may well be more cases that I have missed for this feature, and
+    # possibly other LDAP types. These (in particular, the LDAP variations)
+    # can be easily added later.
+
+    # More detailed information at:
+    # LDAP authentication:
+    # http://theforeman.org/manuals/1.8/index.html#4.1.1LDAPAuthentication
+    # LDAP Auth testing involves testing with RHDS(389), IdM(IPA) and AD ldap.
+
+    @stubbed()
+    def test_ldap_auth_ipa_basic_no_roles(self):
+        """@test: Login with LDAP Auth- IPA for user with no roles/rights
+
+        @feature: LDAP Authentication
+
+        @setup: assure properly functioning IPA server for authentication
+
+        @steps:
+        1. Login to server with an IPA user.
+
+        @assert: Log in to foreman UI successfully but cannot access
+        functional areas of UI
+
+        @status: Manual
+
+        """
+
+    @stubbed()
+    def test_ldap_auth_ipa_basic_roles(self):
+        """@test: Login with LDAP - IPA for user with roles/rights
+
+        @feature: LDAP Authentication
+
+        @setup: assure properly functioning IPA server for authentication
+
+        @steps:
+        1. Login to server with an IPA user.
+
+        @assert: Log in to foreman UI successfully and can access appropriate
+        functional areas in UI
+
+        @status: Manual
+
+        """
+
+    @stubbed()
+    def test_ldap_auth_ipa_user_disabled(self):
+        """@test: LDAP - IPA user activity when IPA user account has been
+        deleted or deactivated
+
+        @feature: LDAP Authentication
+
+        @steps:
+        1. Login to the foreman UI.
+        2. Delete or disable user on IPA server side.
+
+        @assert: This is handled gracefully (user is logged out perhaps?)
+        and no data corruption
+
+        @status: Manual
+
+        """
+
+    @stubbed()
+    def test_ldap_auth_ad_basic_no_roles(self):
+        """@test: Login with LDAP Auth- AD for user with no roles/rights
+
+        @feature: LDAP Authentication
+
+        @setup: assure properly functioning AD server for authentication
+
+        @steps:
+        1. Login to server with an AD user.
+
+        @assert: Log in to foreman UI successfully but cannot access
+        functional areas of UI
+
+        @status: Manual
+
+        """
+
+    @stubbed()
+    def test_ldap_auth_ad_basic_roles(self):
+        """@test: Login with LDAP - AD for user with roles/rights
+
+        @feature: LDAP Authentication
+
+        @setup: assure properly functioning AD server for authentication
+
+        @steps:
+        1. Login to server with an AD user.
+
+        @assert: Log in to foreman UI successfully and can access appropriate
+        functional areas in UI
+
+        @status: Manual
+
+        """
+
+    @stubbed()
+    def test_ldap_auth_ad_user_disabled(self):
+        """@test: LDAP - AD user activity when AD user account has been deleted
+        or deactivated
+
+        @feature: LDAP Authentication
+
+        @steps:
+        1. Login to the Sat6 UI.
+        2. Delete or disable userid on AD server side.
+
+        @assert: This is handled gracefully (user is logged out perhaps?)
+        and no data corruption
+
+        @status: Manual
+
+        """
+
+    @stubbed()
+    def test_ldap_auth_openldap_basic_no_roles(self):
+        """@test: Login with LDAP - RHDSLDAP that has no roles / rights
+
+        @feature: LDAP Authentication
+
+        @setup: assure properly functioning RHDSLDAP server for authentication
+
+        @steps:
+        1. Login to server with a RHDSLDAP user.
+
+        @assert: Log in to foreman UI successfully but has no access to
+        functional areas of UI.
+
+        @status: Manual
+
+        """
+
+    @stubbed()
+    def test_ldap_auth_rhdsldap_basic_roles(self):
+        """@test: Login with LDAP - RHDS LDAP for user with roles/rights
+        assigned.
+
+        @feature: LDAP Authentication
+
+        @setup: assure properly functioning RHDS LDAP server for authentication
+
+        @steps:
+        1. Login to server with a RHDS LDAP id.
+
+        @assert: Log in to foreman UI successfully and can access appropriate
+        functional areas in UI
+
+        @status: Manual
+
+        """
+
+    @stubbed()
+    def test_ldap_auth_rhdsldap_user_disabled(self):
+        """@test: LDAP - RHDSLDAP user activity when RHDS ldap account has been
+        deleted or deactivated
+
+        @feature: LDAP Authentication
+
+        @steps:
+        1. Login to the foreman UI.
+        2. Delete or disable userid on RHDS LDAP server side.
+
+        @assert: This is handled gracefully (user is logged out perhaps?) and
+        no data corruption
+
+        @status: Manual
+
+        """
+
+    @stubbed()
+    def test_ldap_auth_multiple_ldap_backends(self):
+        """@test: LDAP - multiple LDAP servers kafo instance
+
+        @feature: LDAP Authentication
+
+        @setup: Assure more than one ldap server backend is provided for
+        sat6
+
+        @steps:
+        1. Attempt to login with a user that exists on one ldap server.
+        2. Logout and attempt to login with a user that exists on other ldap
+        server(s).
+
+        @assert: Log in to foreman UI successfully for users on both LDAP
+        servers.
+
+        @status: Manual
+
+        """
+
+    @stubbed()
+    def test_ldap_auth_multiple_ldap_namespace_collision(self):
+        # devnote:
+        # users have auth_source which could distinguish them, but validation
+        # would fail atm
+        """@test: LDAP - multiple LDAP servers colliding namespace
+        (e.g "jsmith")
+
+        @feature: LDAP Authentication
+
+        @setup: more than 1 ldap server backend provide for instance with
+
+        @steps:
+        1. Attempt to login with a user that exists on one ldap server.
+        2. Logout and attempt to login with a user that exists on other
+        ldap server(s).
+
+        @assert: Foreman should have some method for distinguishing/specifying
+        which server a user comes from.
+
+        @status: Manual
+
+        """
+
+    @stubbed()
+    def test_ldap_auth_ldap_user_named_admin(self):
+        # devnote:
+        # shouldn't be a problem since admin from internal DB will be used at
+        # first, worth of testing thou, however if authentication is done by
+        # external system (IPA, ...) which can create users in foreman,
+        # I'm not sure about result
+        """@test: LDAP - what happens when we have an ldap user named "admin"?
+
+        @feature: LDAP Authentication
+
+        @steps:
+        1. Try to login with ldap user "admin".
+
+        @assert: Login from local db user "admin" overrides any ldap user
+        "admin"
+
+        @status: Manual
+
+        """
+
+    @stubbed()
+    def test_ldap_auth_ldap_server_down_before_session(self):
+        """@test: LDAP - what happens when we have an ldap server that goes
+        down before logging in?
+
+        @feature: LDAP Authentication
+
+        @steps:
+        1. Try to login with ldap user when server is non-responsive.
+
+        @assert: UI does handles situation gracefully, perhaps informing user
+        that LDAP instance is not responding
+
+        @status: Manual
+
+        """
+
+    @stubbed()
+    def test_ldap_auth_ldap_server_down_during_session(self):
+        """@test: LDAP - what happens when we have an ldap server that goes
+        down after login?
+
+        @feature: LDAP Authentication
+
+        @steps:
+        1. Try to login with ldap user.
+        2. While logged in with ldap user, disconnect access to ldap server.
+
+        @assert: Situation is handled gracefully and without serious data
+        loss on foreman server
+
+        @status: Manual
+
+        """
+
+    @stubbed()
+    def test_ldap_auth_UserGroup_roles_read(self):
+        """@test: Usergroups: group roles get pushed down to user
+
+        @feature: LDAP Authentication
+
+        @setup: assign roles to an LDAP UserGroup
+
+        @steps:
+        1. Login to sat6 with LDAP user that is part of aforementioned
+        UserGroup.
+
+        @assert: User has access to all functional areas that are assigned to
+        aforementioned UserGroup.
+
+        @status: Manual
+
+        """
+
+    @stubbed()
+    def test_ldap_auth_UserGroup_roles_update(self):
+        """@test: Usergroups: added UserGroup roles get pushed down to user
+
+        @feature: LDAP Authentication
+
+        @setup: assign additional roles to an LDAP UserGroup
+
+        @steps:
+        1. Login to sat6 with LDAP user that is part of aforementioned
+        UserGroup.
+
+        @assert: User has access to all NEW functional areas that are assigned
+        to aforementioned UserGroup.
+
+        @status: Manual
+
+        """
+
+    @stubbed()
+    def test_ldap_auth_UserGroup_roles_delete(self):
+        """@test: Usergroups: deleted UserGroup roles get pushed down to user
+
+        @feature: LDAP Authentication
+
+        @setup: delete roles from an LDAP UserGroup
+
+        @steps:
+        1. Login to sat6 with LDAP user that is part of aforementioned
+        UserGroup.
+
+        @assert: User no longer has access to all deleted functional areas
+        that were assigned to aforementioned UserGroup.
+
+        @status: Manual
+
+        """
+
+    @stubbed()
+    def test_ldap_auth_UserGroup_additional_user_roles(self):
+        """@test: Assure that user has roles/can access feature areas for
+        additional roles assigned outside any roles assigned by his group
+
+        @feature: LDAP Authentication
+
+        @setup: Assign roles to UserGroup and users to this group;
+        subsequently assign specified roles to the user(s) --
+        roles that are not part of the larger UserGroup
+
+        @steps:
+        1. Login to sat6 with LDAP user and attempt to access areas assigned
+        specifically to user.
+
+        @assert: User can access not only those feature areas in his
+        UserGroup but those additional feature areas / roles assigned
+        specifically to user
+
+        @status: Manual
+
+        """
+
+    @stubbed()
+    def test_ldap_auth_UserGroup_user_add(self):
+        """@test: Usergroups: new user added to UserGroup inherits roles
+
+        @feature: LDAP Authentication
+
+        @setup: UserGroup with specified roles.
+
+        @steps:
+        1. Login to sat6 with LDAP user that is not part of UserGroup.
+        2. On LDAP server, assign user to aforementioned UserGroup.
+        3. Attempt once more to sign in with user.
+
+        @assert: User can access feature areas as defined by roles in the
+        UserGroup of which he is a part.
+
+        @status: Manual
+
+        """

--- a/tests/foreman/ui/test_sso.py
+++ b/tests/foreman/ui/test_sso.py
@@ -16,18 +16,33 @@ class TestSSOUI(UITestCase):
     # possibly other LDAP types. These (in particular, the LDAP variations)
     # can be easily added later.
 
+    # What is SSO?
+    # Once (IPA or AD) user logs in to linux or windows client which is
+    # IPA/AD enrolled, there should be no need for the user to again
+    # authenticate at the Sat61 WebUI Login form with (IPA or AD user) login
+    # details. Instead the IPA or AD user should be able to simply log-in to
+    # the Sat61 WebUI automatically upon accessing the sat61 URL.
+
+    # More detailed information at:
+    # External authentication:
+    # http://theforeman.org/manuals/1.8/index.html#5.7ExternalAuthentication
+    # LDAP authentication:
+    # http://theforeman.org/manuals/1.8/index.html#4.1.1LDAPAuthentication
+
     @stubbed()
     def test_sso_kerberos_basic_no_roles(self):
-        """@test: SSO - kerberos login (basic) that has no rights
+        """@test: SSO - kerberos (IdM or AD) login (basic) that has no roles
 
-        @feature: SSO
+        @feature: SSO or External Authentication
 
-        @setup: assure SSO with kerberos is set up.
+        @setup: Assure SSO with kerberos (IdM or AD) is set up.
 
         @steps:
-        1.  attempt to login using a kerberos ID
+        1. Login using a kerberos (IdM or AD) ID to the client
+        2. Login to the Web-UI should be automatic without the need to fill in
+        the form.
 
-        @assert: Log in to foreman UI successfully but cannot access anything
+        @assert: Log in to sat6 UI successfully but cannot access anything
         useful in UI
 
         @status: Manual
@@ -36,16 +51,19 @@ class TestSSOUI(UITestCase):
 
     @stubbed()
     def test_sso_kerberos_basic_roles(self):
-        """@test: SSO - kerberos login (basic) that has rights assigned
+        """@test: SSO - kerberos (IdM or AD) login (basic) that has roles
+        assigned.
 
-        @feature: SSO
+        @feature: SSO or External Authentication
 
-        @setup: assure SSO with kerberos is set up.
+        @setup: Assure SSO with kerberos (IdM or AD) is set up.
 
         @steps:
-        1.  attempt to login using a kerberos ID
+        1. Login using a kerberos (IdM or AD) ID to the client
+        2. Login to the Web-UI should be automatic without the need to fill in
+        the form.
 
-        @assert: Log in to foreman UI successfully and can access functional
+        @assert: Log in to sat6 UI successfully and can access functional
         areas in UI
 
         @status: Manual
@@ -54,324 +72,17 @@ class TestSSOUI(UITestCase):
 
     @stubbed()
     def test_sso_kerberos_user_disabled(self):
-        """@test: Kerberos user activity when kerb account has been deleted or
-        deactivated
+        """@test: Kerberos (IdM or AD) user activity when kerb (IdM or AD)
+        account has been deleted or deactivated.
 
-        @feature: SSO
+        @feature: SSO or External Authentication
 
         @steps:
-        1.  Login to the foreman UI
-        2. Delete or disable userid on kerb server side
+        1. Login to the foreman UI
+        2. Delete or disable userid on IdM server or AD side.
 
         @assert: This is handled gracefully (user is logged out perhaps?)
         and no data corruption
-
-        @status: Manual
-
-        """
-
-    @stubbed()
-    def test_sso_ipa_basic_no_roles(self):
-        """@test: Login with LDAP - IPA for user with no roles/rights
-
-        @feature: SSO
-
-        @setup: assure properly functioning IPA server for authentication
-
-        @steps:
-        1. Login to server with an IPA id
-
-        @assert: Log in to foreman UI successfully but cannot access
-        functional areas of UI
-
-        @status: Manual
-
-        """
-
-    @stubbed()
-    def test_sso_ipa_basic_roles(self):
-        """@test: Login with LDAP - IPA for user with roles/rights
-
-        @feature: SSO
-
-        @setup: assure properly functioning IPA server for authentication
-
-        @steps:
-        1. Login to server with an IPA id
-
-        @assert: Log in to foreman UI successfully and can access appropriate
-        functional areas in UI
-
-        @status: Manual
-
-        """
-
-    @stubbed()
-    def test_sso_ipa_user_disabled(self):
-        """@test: LDAP - IPA user activity when IPA account has been deleted
-        or deactivated
-
-        @feature: SSO
-
-        @steps:
-        1.  Login to the foreman UI
-        2. Delete or disable userid on IPA server side
-
-        @assert: This is handled gracefully (user is logged out perhaps?)
-        and no data corruption
-
-        @status: Manual
-
-        """
-
-    @stubbed()
-    def test_sso_openldap_basic_no_roles(self):
-        """@test: Login with LDAP - OpenLDAP that has no roles / rights
-
-        @feature: SSO
-
-        @setup: assure properly functioning OpenLDAP server for authentication
-
-        @steps:
-        1. Login to server with an OpenLDAP id
-
-        @assert: Log in to foreman UI successfully but has no access to
-        functional areas of UI.
-
-        @status: Manual
-
-        """
-
-    @stubbed()
-    def test_sso_openldap_basic_roles(self):
-        """@test: Login with LDAP - OpenLDAP for user with roles/rights assigned
-
-        @feature: SSO
-
-        @setup: assure properly functioning OpenLDAP server for authentication
-
-        @steps:
-        1. Login to server with an OpenLDAP id
-
-        @assert: Log in to foreman UI successfully and can access appropriate
-        functional areas in UI
-
-        @status: Manual
-
-        """
-
-    @stubbed()
-    def test_sso_openldap_user_disabled(self):
-        """@test: LDAP - OpenLDAP user activity when OpenLDAP account has been
-        deleted or deactivated
-
-        @feature: SSO
-
-        @steps:
-        1.  Login to the foreman UI
-        2. Delete or disable userid on OpenLDAP server side
-
-        @assert: This is handled gracefully (user is logged out perhaps?) and
-        no data corruption
-
-        @status: Manual
-
-        """
-
-    @stubbed()
-    def test_sso_multiple_ldap_backends(self):
-        """@test: SSO - multiple LDAP servers kafo instance
-
-        @feature: SSO
-
-        @setup: assure more than one ldap server backend is provide for sat6 /
-
-        @steps:
-        1. Attempt to login with a user that exists on one ldap server
-        2. Logout and attempt to login with a user that exists on other ldap
-        server(s)
-
-        @assert: Log in to foreman UI successfully for users on both LDAP
-        servers.
-
-        @status: Manual
-
-        """
-
-    @stubbed()
-    def test_sso_multiple_ldap_namespace_collision(self):
-        # devnote:
-        # users have auth_source which could distinguish them, but validation
-        # would fail atm
-        """@test: SSO - multiple LDAP servers colliding namespace (i.e "jsmith")
-
-        @feature: SSO
-
-        @setup: more than 1 ldap server backend provide for instance with
-
-        @steps:
-        1. Attempt to login with a user that exists on one ldap server
-        2. Logout and attempt to login with a user that exists on other
-        ldap server(s)
-
-        @assert: Foreman should have some method for distinguishing/specifying
-        which server a user comes from.
-
-        @status: Manual
-
-        """
-
-    @stubbed()
-    def test_sso_ldap_user_named_admin(self):
-        # devnote:
-        # shouldn't be a problem since admin from internal DB will be used at
-        # first, worth of testing thou, however if authentication is done by
-        # external system (IPA, ...) which can create users in foreman,
-        # I'm not sure about result
-        """@test: SSO - what happens when we have an ldap user named "admin"?
-
-        @feature: SSO
-
-        @steps:
-        1. Try to login with ldap user "admin"
-
-        @assert: Login from local db user "admin" overrides any ldap user
-        "admin"
-
-        @status: Manual
-
-        """
-
-    @stubbed()
-    def test_sso_ldap_server_down_before_session(self):
-        """@test: SSO - what happens when we have an ldap server that goes down
-        before logging in?
-
-        @feature: SSO
-
-        @steps:
-        1. Try to login with ldap user when server is non-responsive
-
-        @assert: UI does handles situation gracefully, perhaps informing user
-        that LDAP instance is not responding
-
-        @status: Manual
-
-        """
-
-    @stubbed()
-    def test_sso_ldap_server_down_during_session(self):
-        """@test: SSO - what happens when we have an ldap server that goes down
-        after login?
-
-        @feature: SSO
-
-        @steps:
-        1. Try to login with ldap user
-        2. While logged in with ldap user, disconnect access to ldap server.
-
-        @assert: Situation is handled gracefully and without serious data
-        loss on foreman server
-
-        @status: Manual
-
-        """
-
-    @stubbed()
-    def test_sso_usergroup_roles_read(self):
-        """@test: Usergroups: group roles get pushed down to user
-
-        @feature: SSO
-
-        @setup: assign roles to an LDAP usergroup
-
-        @steps:
-        1.  Login to foreman with LDAP user that is part of aforementioned
-        usergroup
-
-        @assert: User has access to all functional areas that are assigned to
-        aforementioned usergroup.
-
-        @status: Manual
-
-        """
-
-    @stubbed()
-    def test_sso_usergroup_roles_update(self):
-        """@test: Usergroups: added usergroup roles get pushed down to user
-
-        @feature: SSO
-
-        @setup: assign additional roles to an LDAP usergroup
-
-        @steps:
-        1.  Login to foreman with LDAP user that is part of aforementioned
-        usergroup
-
-        @assert: User has access to all NEW functional areas that are assigned
-        to aforementioned usergroup.
-
-        @status: Manual
-
-        """
-
-    @stubbed()
-    def test_sso_usergroup_roles_delete(self):
-        """@test: Usergroups: deleted usergroup roles get pushed down to user
-
-        @feature: SSO
-
-        @setup: delete roles from an LDAP usergroup
-
-        @steps:
-        1.  Login to foreman with LDAP user that is part of aforementioned
-        usergroup
-
-        @assert: User no longer has access to all deleted functional areas
-        that were assigned to aforementioned usergroup.
-
-        @status: Manual
-
-        """
-
-    @stubbed()
-    def test_sso_usergroup_additional_user_roles(self):
-        """@test: Assure that user has roles/can access feature areas for
-        additional roles assigned outside any roles assigned by his group
-
-        @feature: SSO
-
-        @setup: Assign roles to usergroup and users to this group;
-        subsequently assign specified roles to the user(s) --
-        roles that are not part of the larger usergroup
-
-        @steps:
-        1. Login to foreman with LDAP user and attempt to access areas assigned
-        specifically to user.
-
-        @assert: User can access not only those feature areas in his
-        usergroup but those additional feature areas / roles assigned
-        specifically to user
-
-        @status: Manual
-
-        """
-
-    @stubbed()
-    def test_sso_usergroup_user_add(self):
-        """@test: Usergroups: new user added to usegroup inherits roles
-
-        @feature: SSO
-
-        @setup: usergroup with specified roles.
-
-        @steps:
-        1.  Login to foreman with LDAP user that is not part of usergroup.
-        2.  On LDAP server, assign user to aforementioned usergroup.
-        3.  Attempt once more to sign in with user
-
-        @assert: User can access feature areas as defined by roles in the
-        usergroup of which he is a part.
 
         @status: Manual
 


### PR DESCRIPTION
* test_sso module is now split into test_sso and test_ldap_auth.
* SSO or kerberos or External Authentication test-cases has been moved to
test_sso module.
* LDAP Authentication test-cases has now been moved to test_ldap_auth module.
* External AD UserGroup testcases have been moved to test_adusergroup module.