### PR TITLE
Replaced RH Common with Red Hat Satellite Tools repository - issue #2244

### DIFF
--- a/robottelo/common/constants.py
+++ b/robottelo/common/constants.py
@@ -144,7 +144,6 @@ PRDS = {'rhcf': "Red Hat CloudForms",
 REPOSET = {
     'rhct6': "Red Hat CloudForms Tools for RHEL 6 (RPMs)",
     'rhel6': "Red Hat Enterprise Linux 6 Server (RPMs)",
-    'rhelc6': "Red Hat Enterprise Linux 6 Server - RH Common (RPMs)",
     'rhva6': "Red Hat Enterprise Virtualization Agents "
     "for RHEL 6 Server (RPMs)",
     # TODO: Remove 'Beta' after release
@@ -152,7 +151,6 @@ REPOSET = {
 }
 
 REPOS = {
-    'rhelc6': "Red Hat Enterprise Linux 6 Server - RH Common RPMs x86_64 6.3",
     'rhst7': {  # TODO: Remove 'beta' after release
         'id': "rhel-7-server-satellite-tools-6-beta-rpms",
         'name': "Red Hat Satellite Tools 6 Beta for RHEL 7 Server "

--- a/tests/foreman/api/test_contentview.py
+++ b/tests/foreman/api/test_contentview.py
@@ -998,9 +998,9 @@ class CVRedHatContent(APITestCase):
             basearch='x86_64',
             org_id=cls.org.id,
             product=PRDS['rhel'],
-            repo=REPOS['rhelc6'],
-            reposet=REPOSET['rhelc6'],
-            releasever='6.3',
+            repo=REPOS['rhst7']['name'],
+            reposet=REPOSET['rhst7'],
+            releasever='7Server',
         )
         cls.repo = entities.Repository(id=repo_id)
         cls.repo.sync()
@@ -1020,7 +1020,7 @@ class CVRedHatContent(APITestCase):
         self.assertEqual(len(content_view.repository), 1)
         self.assertEqual(
             content_view.repository[0].read().name,
-            REPOS['rhelc6'],
+            REPOS['rhst7']['name'],
         )
 
     def test_cv_associate_rh_custom_spin(self):

--- a/tests/foreman/api/test_repository.py
+++ b/tests/foreman/api/test_repository.py
@@ -10,6 +10,9 @@ from robottelo.common.constants import (
     DOCKER_REGISTRY_HUB,
     FAKE_0_PUPPET_REPO,
     FAKE_2_YUM_REPO,
+    PRDS,
+    REPOS,
+    REPOSET,
     RPM_TO_UPLOAD,
     VALID_GPG_KEY_BETA_FILE,
     VALID_GPG_KEY_FILE,
@@ -255,10 +258,10 @@ class RepositorySyncTestCase(APITestCase):
         repo_id = utils.enable_rhrepo_and_fetchid(
             'x86_64',
             org.id,
-            'Red Hat Enterprise Linux Server',
-            'Red Hat Enterprise Linux 6 Server - RH Common RPMs x86_64 6.3',
-            'Red Hat Enterprise Linux 6 Server - RH Common (RPMs)',
-            '6.3',
+            PRDS['rhel'],
+            REPOS['rhst7']['name'],
+            REPOSET['rhst7'],
+            '7Server',
         )
         entities.Repository(id=repo_id).sync()
 

--- a/tests/foreman/ui/test_contentviews.py
+++ b/tests/foreman/ui/test_contentviews.py
@@ -17,6 +17,9 @@ from robottelo.common.constants import (
     FAKE_1_YUM_REPO,
     FILTER_CONTENT_TYPE,
     FILTER_TYPE,
+    PRDS,
+    REPOS,
+    REPOSET,
     REPO_TYPE,
     ZOO_CUSTOM_GPG_KEY,
 )
@@ -477,13 +480,11 @@ class TestContentViewsUI(UITestCase):
         cv_name2 = gen_string("alpha", 8)
         composite_name = gen_string("alpha", 8)
         rh_repo = {
-            "name": ("Red Hat Enterprise Linux 6 Server "
-                     "- RH Common RPMs x86_64 6.3"),
-            "product": "Red Hat Enterprise Linux Server",
-            "reposet": ("Red Hat Enterprise Linux 6 Server "
-                        "- RH Common (RPMs)"),
-            "basearch": "x86_64",
-            "releasever": "6.3",
+            'name': REPOS['rhst7']['name'],
+            'product': PRDS['rhel'],
+            'reposet': REPOSET['rhst7'],
+            'basearch': 'x86_64',
+            'releasever': '7Server',
         }
         # Create new org to import manifest
         org_attrs = entities.Organization().create_json()
@@ -541,13 +542,11 @@ class TestContentViewsUI(UITestCase):
         """
         cv_name = gen_string("alpha", 8)
         rh_repo = {
-            'name': ("Red Hat Enterprise Linux 6 Server "
-                     "- RH Common RPMs x86_64 6.3"),
-            'product': "Red Hat Enterprise Linux Server",
-            'reposet': ("Red Hat Enterprise Linux 6 Server "
-                        "- RH Common (RPMs)"),
-            'basearch': "x86_64",
-            'releasever': "6.3"
+            'name': REPOS['rhst7']['name'],
+            'product': PRDS['rhel'],
+            'reposet': REPOSET['rhst7'],
+            'basearch': 'x86_64',
+            'releasever': '7Server',
         }
         # Create new org to import manifest
         org_attrs = entities.Organization().create_json()
@@ -712,13 +711,11 @@ class TestContentViewsUI(UITestCase):
         """
         cv_name = gen_string("alpha", 8)
         rh_repo = {
-            'name': ("Red Hat Enterprise Linux 6 Server "
-                     "- RH Common RPMs x86_64 6.3"),
-            'product': "Red Hat Enterprise Linux Server",
-            'reposet': ("Red Hat Enterprise Linux 6 Server "
-                        "- RH Common (RPMs)"),
-            'basearch': "x86_64",
-            'releasever': "6.3"
+            'name': REPOS['rhst7']['name'],
+            'product': PRDS['rhel'],
+            'reposet': REPOSET['rhst7'],
+            'basearch': 'x86_64',
+            'releasever': '7Server',
         }
         env_name = gen_string("alpha", 8)
         publish_version = "Version 1"
@@ -839,13 +836,11 @@ class TestContentViewsUI(UITestCase):
         """
         cv_name = gen_string("alpha", 8)
         rh_repo = {
-            'name': ("Red Hat Enterprise Linux 6 Server "
-                     "- RH Common RPMs x86_64 6.3"),
-            'product': "Red Hat Enterprise Linux Server",
-            'reposet': ("Red Hat Enterprise Linux 6 Server "
-                        "- RH Common (RPMs)"),
-            'basearch': "x86_64",
-            'releasever': "6.3"
+            'name': REPOS['rhst7']['name'],
+            'product': PRDS['rhel'],
+            'reposet': REPOSET['rhst7'],
+            'basearch': 'x86_64',
+            'releasever': '7Server',
         }
         # Create new org to import manifest
         org_attrs = entities.Organization().create_json()


### PR DESCRIPTION
As ```Red Hat Enterprise Linux 6 Server - RH Common (RPMs)``` will become "obsolete", I've replaced it with ```Red Hat Satellite Tools 6 Beta (for RHEL 7 Server) (RPMs)``` in tests.
Closes #2244 
Tests results:
```
nosetests tests/foreman/api/test_repository.py -m test_redhat_sync_1
.
----------------------------------------------------------------------
Ran 1 test in 117.957s

OK

nosetests tests/foreman/ui/test_contentviews.py -m test_cv_composite_create
.
----------------------------------------------------------------------
Ran 1 test in 532.037s

OK

nosetests tests/foreman/ui/test_contentviews.py -m test_associate_view_rh_1
.
----------------------------------------------------------------------
Ran 1 test in 218.964s

OK

nosetests tests/foreman/ui/test_contentviews.py -m test_cv_promote_rh_1   
.
----------------------------------------------------------------------
Ran 1 test in 349.994s

OK

nosetests tests/foreman/ui/test_contentviews.py -m test_cv_publish_rh_1
.
----------------------------------------------------------------------
Ran 1 test in 252.921s

OK
```