### PR TITLE
Cover config-template-ids parameter in factory.make_org (multiple values)

### DIFF
--- a/robottelo/cli/factory.py
+++ b/robottelo/cli/factory.py
@@ -1139,7 +1139,13 @@ def make_org(options=None):
         --compute-resource-ids COMPUTE_RESOURCE_IDS Compute resource IDs
                                                     Comma separated list
                                                     of values.
+        --compute-resources COMPUTE_RESOURCE_NAMES  Compute resource Names
+                                                    Comma separated list
+                                                    of values.
         --config-template-ids CONFIG_TEMPLATE_IDS   Provisioning template IDs
+                                                    Comma separated list
+                                                    of values.
+        --config-templates CONFIG_TEMPLATE_NAMES    Provisioning template Names
                                                     Comma separated list
                                                     of values.
         --description DESCRIPTION                   description
@@ -1149,15 +1155,30 @@ def make_org(options=None):
         --environment-ids ENVIRONMENT_IDS           Environment IDs
                                                     Comma separated list
                                                     of values.
+        --environments ENVIRONMENT_NAMES            Environment Names
+                                                    Comma separated list
+                                                    of values.
         --hostgroup-ids HOSTGROUP_IDS               Host group IDs
                                                     Comma separated list
                                                     of values.
+        --hostgroups HOSTGROUP_NAMES                Host group Names
+                                                    Comma separated list
+                                                    of values.
         --label LABEL                               unique label
+        --media MEDIUM_NAMES                        Media Names
+                                                    Comma separated list
+                                                    of values.
         --media-ids MEDIA_IDS                       Media IDs
                                                     Comma separated list
                                                     of values.
         --name NAME                                 name
+        --realms REALM_NAMES                        Realm Names
+                                                    Comma separated list
+                                                    of values.
         --realm-ids REALM_IDS                       Realm IDs
+                                                    Comma separated list
+                                                    of values.
+        --smart-proxies SMART_PROXY_NAMES           Smart proxy Names
                                                     Comma separated list
                                                     of values.
         --smart-proxy-ids SMART_PROXY_IDS           Smart proxy IDs
@@ -1166,7 +1187,13 @@ def make_org(options=None):
         --subnet-ids SUBNET_IDS                     Subnet IDs
                                                     Comma separated list
                                                     of values.
+        --subnets SUBNET_NAMES                      Subnet Names
+                                                    Comma separated list
+                                                    of values.
         --user-ids USER_IDS                         User IDs
+                                                    Comma separated list
+                                                    of values.
+        --users USER_NAMES                          User Names
                                                     Comma separated list
                                                     of values.
         -h, --help                                  print help
@@ -1175,18 +1202,27 @@ def make_org(options=None):
     # Assigning default values for attributes
     args = {
         u'compute-resource-ids': None,
+        u'compute-resources': None,
         u'config-template-ids': None,
+        u'config-templates': None,
         u'description': None,
         u'domain-ids': None,
         u'environment-ids': None,
+        u'environments': None,
         u'hostgroup-ids': None,
+        u'hostgroups': None,
         u'label': None,
         u'media-ids': None,
+        u'media': None,
         u'name': gen_alphanumeric(6),
         u'realm-ids': None,
+        u'realms': None,
         u'smart-proxy-ids': None,
+        u'smart-proxies': None,
         u'subnet-ids': None,
+        u'subnets': None,
         u'user-ids': None,
+        u'users': None,
     }
 
     return create_object(Org, args, options)

--- a/tests/foreman/cli/test_org.py
+++ b/tests/foreman/cli/test_org.py
@@ -1,6 +1,7 @@
 # -*- encoding: utf-8 -*-
 # pylint: disable=R0904
 """Test class for Organization CLI"""
+import random
 
 from ddt import ddt
 from fauxfactory import gen_string
@@ -688,11 +689,12 @@ class TestOrg(CLITestCase):
         )
 
     def test_add_configtemplate_by_id(self):
-        """@Test: Check if a Config Template can be added to an Org by ID
+        """@Test: Check that new organization with config template associated
+        to it can be created in the system
 
         @Feature: Org - Config Template
 
-        @Assert: Config Template is added to the org
+        @Assert: Organization with config template created successfully
 
         """
         try:
@@ -704,6 +706,29 @@ class TestOrg(CLITestCase):
             u'{0} ({1})'.format(conf_templ['name'], conf_templ['type']),
             org['templates']
         )
+
+    def test_add_multiple_configtemplate_by_id(self):
+        """@Test: Check that new organization with multiple config templates
+        associated to it can be created in the system
+
+        @Feature: Org - Config Template
+
+        @Assert: Organization with config templates created successfully
+
+        """
+        try:
+            templates_amount = random.randint(3, 5)
+            templates = [make_template() for _ in range(templates_amount)]
+            template_ids = ','.join(template['id'] for template in templates)
+            org = make_org({'config-template-ids': template_ids})
+        except CLIFactoryError as err:
+            self.fail(err)
+        self.assertGreaterEqual(len(org['templates']), templates_amount)
+        for template in templates:
+            self.assertIn(
+                u'{0} ({1})'.format(template['name'], template['type']),
+                org['templates']
+            )
 
     @run_only_on('sat')
     @data(


### PR DESCRIPTION
Add CLI test for config-template-ids parameter in factory.make_org (multiple values scenario)

Closes #2099

```
nosetests tests/foreman/cli/test_org.py -m test_add_multiple_configtemplate_by_id
.
----------------------------------------------------------------------
Ran 1 test in 56.271s

OK
```