### PR TITLE
Cover location-ids parameter in factory.make_compute_resource (multiple values scenario)

### DIFF
--- a/robottelo/cli/factory.py
+++ b/robottelo/cli/factory.py
@@ -1078,11 +1078,11 @@ def make_compute_resource(options=None):
     Options::
 
         --description DESCRIPTION
-        --location-ids LOCATION_IDS   REPLACE locations with given ids
+        --location-ids LOCATION_IDS   Comma separated list of values.
+        --locations LOCATION_NAMES    Comma separated list of values.
         --name NAME
-        --organization-ids ORGANIZATION_IDS REPLACE organizations with
-                                            given ids.
-                                            Comma separated list of values.
+        --organization-ids ORGANIZATION_IDS  Comma separated list of values.
+        --organizations ORGANIZATION_NAMES   Comma separated list of values.
         --password PASSWORD           Password for Ovirt, EC2, Vmware,
                                       Openstack. Access Key for EC2.
         --provider PROVIDER           Providers include Libvirt, Ovirt, EC2,
@@ -1103,8 +1103,10 @@ def make_compute_resource(options=None):
     args = {
         u'description': None,
         u'location-ids': None,
+        u'locations': None,
         u'name': gen_alphanumeric(8),
         u'organization-ids': None,
+        u'organizations': None,
         u'password': None,
         u'provider': None,
         u'region': None,

--- a/tests/foreman/cli/test_computeresource.py
+++ b/tests/foreman/cli/test_computeresource.py
@@ -18,6 +18,8 @@ Subcommands::
     image                         View and manage compute resource's images
 
 """
+import random
+
 from ddt import ddt
 from fauxfactory import gen_string, gen_url
 from robottelo.cli.computeresource import ComputeResource
@@ -180,6 +182,28 @@ class TestComputeResource(CLITestCase):
             self.fail(err)
         self.assertEqual(1, len(comp_resource['locations']))
         self.assertEqual(comp_resource['locations'][0], location['name'])
+
+    def test_create_compute_resource_with_multiple_locations(self):
+        """@Test: Create Compute Resource with multiple locations
+
+        @Feature: Compute Resource - Location Create
+
+        @Assert: Compute resource is created and has multiple locations
+        assigned
+
+        """
+        try:
+            locations_amount = random.randint(3, 5)
+            locations = [make_location() for _ in range(locations_amount)]
+            location_ids = ','.join(location['id'] for location in locations)
+            comp_resource = make_compute_resource({
+                'location-ids': location_ids,
+            })
+        except CLIFactoryError as err:
+            self.fail(err)
+        self.assertEqual(len(comp_resource['locations']), locations_amount)
+        for location in locations:
+            self.assertIn(location['name'], comp_resource['locations'])
 
     @skip_if_bug_open('bugzilla', 1214312)
     @data(u'True', u'Yes', 1, u'False', u'No', 0)


### PR DESCRIPTION
Add CLI test for location-ids parameter in factory.make_compute_resource (multiple values scenario)

Closes #2109

```
nosetests tests/foreman/cli/test_computeresource.py -m test_create_compute_resource_with_multiple_locations
.
----------------------------------------------------------------------
Ran 1 test in 39.194s

OK
```