### PR TITLE
fixing issue #2443

### DIFF
--- a/tests/foreman/cli/test_import.py
+++ b/tests/foreman/cli/test_import.py
@@ -99,6 +99,14 @@ class TestImport(CLITestCase):
         )
         self.assertTrue(all((org in orgs for org in imp_orgs)))
 
+        # do the cleanup
+        ssh_delete = Import.organization({
+            'csv-file': files['users'],
+            'delete': True
+        })
+        ssh.command('rm -rf ${{HOME}}/.transition_data')
+        self.assertEqual(ssh_delete.return_code, 0)
+
     def test_import_orgs_manifests(self):
         """@test: Import all organizations from the default data set
         (predefined source) and upload manifests for each of them
@@ -145,6 +153,7 @@ class TestImport(CLITestCase):
             'csv-file': files['users'],
             'new-passwords': pwdfile
         })
+        ssh.command('rm -f ${{HOME}}/.transition_data {}'.format(pwdfile))
         self.assertEqual(ssh_import.return_code, 0)
         self.assertEqual(
             ssh_import.stdout,


### PR DESCRIPTION
Fixes https://github.com/SatelliteQE/robottelo/issues/2443.
Added the cleanup part to the tests as the import command leaves `~/.transition_data` dir containing mapping between the Sat5 and Sat6 entities.

```bash
$ nosetests test_import.py
.....
----------------------------------------------------------------------
Ran 5 tests in 56.026s

OK
```