### PR TITLE
CLI: Add coverage for repository-set enable functionality - #2434

### DIFF
--- a/tests/foreman/cli/test_repository_set.py
+++ b/tests/foreman/cli/test_repository_set.py
@@ -1,10 +1,12 @@
-from robottelo.common.decorators import skip_if_bug_open
-from robottelo.test import CLITestCase
 from robottelo.cli.factory import make_org
-from robottelo.cli.subscription import Subscription
+from robottelo.cli.product import Product
 from robottelo.cli.repository_set import RepositorySet
+from robottelo.cli.subscription import Subscription
 from robottelo.common import manifests
+from robottelo.common.constants import PRDS, REPOSET
+from robottelo.common.decorators import skip_if_bug_open
 from robottelo.common.ssh import upload_file
+from robottelo.test import CLITestCase
 
 
 class TestRepositorySet(CLITestCase):
@@ -147,3 +149,127 @@ class TestRepositorySet(CLITestCase):
             sum(int(repo['enabled'] == u'true') for repo in result.stdout),
             0
         )
+
+    def test_repositoryset_enable_by_name(self):
+        """@Test: Enable repo from reposet by names of reposet, org and product
+
+        @Feature: Repository-set
+
+        @Assert: Repository was enabled
+
+        """
+        org = make_org()
+        manifest = manifests.clone()
+        upload_file(manifest, remote_file=manifest)
+        result = Subscription.upload({
+            u'file': manifest,
+            u'organization-id': org['id'],
+        })
+        self.assertEqual(result.return_code, 0)
+        result = RepositorySet.enable({
+            u'name': REPOSET['rhva6'],
+            u'organization': org['name'],
+            u'product': PRDS['rhel'],
+            u'releasever': '6Server',
+            u'basearch': 'x86_64',
+        })
+        self.assertEqual(result.return_code, 0)
+        result = RepositorySet.available_repositories({
+            u'name': REPOSET['rhva6'],
+            u'organization': org['name'],
+            u'product': PRDS['rhel'],
+        })
+        self.assertEqual(result.return_code, 0)
+        enabled = [
+            repo['enabled']
+            for repo
+            in result.stdout
+            if repo['arch'] == 'x86_64' and repo['release'] == '6Server'
+        ][0]
+        self.assertEqual(enabled, 'true')
+
+    def test_repositoryset_enable_by_label(self):
+        """@Test: Enable repo from reposet by org label, reposet and product
+        names
+
+        @Feature: Repository-set
+
+        @Assert: Repository was enabled
+
+        """
+        org = make_org()
+        manifest = manifests.clone()
+        upload_file(manifest, remote_file=manifest)
+        result = Subscription.upload({
+            u'file': manifest,
+            u'organization-id': org['id'],
+        })
+        self.assertEqual(result.return_code, 0)
+        result = RepositorySet.enable({
+            u'name': REPOSET['rhva6'],
+            u'organization-label': org['label'],
+            u'product': PRDS['rhel'],
+            u'releasever': '6Server',
+            u'basearch': 'x86_64',
+        })
+        self.assertEqual(result.return_code, 0)
+        result = RepositorySet.available_repositories({
+            u'name': REPOSET['rhva6'],
+            u'organization-label': org['label'],
+            u'product': PRDS['rhel'],
+        })
+        self.assertEqual(result.return_code, 0)
+        enabled = [
+            repo['enabled']
+            for repo
+            in result.stdout
+            if repo['arch'] == 'x86_64' and repo['release'] == '6Server'
+        ][0]
+        self.assertEqual(enabled, 'true')
+
+    def test_repositoryset_enable_by_id(self):
+        """@Test: Enable repo from reposet by IDs of reposet, org and product
+
+        @Feature: Repository-set
+
+        @Assert: Repository was enabled
+
+        """
+        org = make_org()
+        manifest = manifests.clone()
+        upload_file(manifest, remote_file=manifest)
+        result = Subscription.upload({
+            u'file': manifest,
+            u'organization-id': org['id'],
+        })
+        self.assertEqual(result.return_code, 0)
+        product_id = Product.info({
+            u'name': PRDS['rhel'],
+            u'organization-id': org['id'],
+        }).stdout['id']
+        reposet_id = RepositorySet.info({
+            u'name': REPOSET['rhva6'],
+            u'organization-id': org['id'],
+            u'product-id': product_id,
+        }).stdout['id']
+        result = RepositorySet.enable({
+            u'id': reposet_id,
+            u'organization-id': org['id'],
+            u'product-id': product_id,
+            u'releasever': '6Server',
+            u'basearch': 'x86_64',
+        })
+        self.assertEqual(result.return_code, 0)
+        result = RepositorySet.available_repositories({
+            u'id': reposet_id,
+            u'organization-id': org['id'],
+            u'product-id': product_id,
+        })
+        self.assertEqual(result.return_code, 0)
+        enabled = [
+            repo['enabled']
+            for repo
+            in result.stdout
+            if repo['arch'] == 'x86_64' and repo['release'] == '6Server'
+        ][0]
+        self.assertEqual(enabled, 'true')


### PR DESCRIPTION
Added coverage for ```hammer repository-set enable``` command.

```
$ hammer repository-set enable --help
Usage:
hammer repository-set enable [OPTIONS]

Options:
--basearch BASEARCH Basearch to enable
--id ID ID of the repository set to enable
--name NAME Repository set name to search by
--new-name NEW_NAME

--organization ORGANIZATION_NAME Organization name to search by
--organization-id ORGANIZATION_ID organization ID
--organization-label ORGANIZATION_LABEL Organization label to search by
--product PRODUCT_NAME Product name to search by
--product-id PRODUCT_ID product numeric identifier
--releasever RELEASEVER Releasever to enable
-h, --help print help
```
Closes #2434
Test results:
```
nosetests tests/foreman/cli/test_repository_set.py -m test_repositoryset_enable 
...
----------------------------------------------------------------------
Ran 3 tests in 249.510s

OK
```