### PR TITLE
CLI: Add coverage for repository-set disable functionality - #2435

### DIFF
--- a/tests/foreman/cli/test_repository_set.py
+++ b/tests/foreman/cli/test_repository_set.py
@@ -273,3 +273,151 @@ class TestRepositorySet(CLITestCase):
             if repo['arch'] == 'x86_64' and repo['release'] == '6Server'
         ][0]
         self.assertEqual(enabled, 'true')
+
+    def test_repositoryset_disable_by_name(self):
+        """@Test: Disable repo from reposet by names of reposet, org and product
+
+        @Feature: Repository-set
+
+        @Assert: Repository was disabled
+
+        """
+        org = make_org()
+        manifest = manifests.clone()
+        upload_file(manifest, remote_file=manifest)
+        result = Subscription.upload({
+            u'file': manifest,
+            u'organization-id': org['id'],
+        })
+        self.assertEqual(result.return_code, 0)
+        result = RepositorySet.enable({
+            u'name': REPOSET['rhva6'],
+            u'organization': org['name'],
+            u'product': PRDS['rhel'],
+            u'releasever': '6Server',
+            u'basearch': 'x86_64',
+        })
+        self.assertEqual(result.return_code, 0)
+        result = RepositorySet.disable({
+            u'name': REPOSET['rhva6'],
+            u'organization': org['name'],
+            u'product': PRDS['rhel'],
+            u'releasever': '6Server',
+            u'basearch': 'x86_64',
+        })
+        self.assertEqual(result.return_code, 0)
+        result = RepositorySet.available_repositories({
+            u'name': REPOSET['rhva6'],
+            u'organization': org['name'],
+            u'product': PRDS['rhel'],
+        })
+        self.assertEqual(result.return_code, 0)
+        enabled = [
+            repo['enabled']
+            for repo
+            in result.stdout
+            if repo['arch'] == 'x86_64' and repo['release'] == '6Server'
+        ][0]
+        self.assertEqual(enabled, 'false')
+
+    def test_repositoryset_disable_by_label(self):
+        """@Test: Disable repo from reposet by org label, reposet and product
+        names
+
+        @Feature: Repository-set
+
+        @Assert: Repository was disabled
+
+        """
+        org = make_org()
+        manifest = manifests.clone()
+        upload_file(manifest, remote_file=manifest)
+        result = Subscription.upload({
+            u'file': manifest,
+            u'organization-id': org['id'],
+        })
+        self.assertEqual(result.return_code, 0)
+        result = RepositorySet.enable({
+            u'name': REPOSET['rhva6'],
+            u'organization-label': org['label'],
+            u'product': PRDS['rhel'],
+            u'releasever': '6Server',
+            u'basearch': 'x86_64',
+        })
+        self.assertEqual(result.return_code, 0)
+        result = RepositorySet.disable({
+            u'name': REPOSET['rhva6'],
+            u'organization-label': org['label'],
+            u'product': PRDS['rhel'],
+            u'releasever': '6Server',
+            u'basearch': 'x86_64',
+        })
+        self.assertEqual(result.return_code, 0)
+        result = RepositorySet.available_repositories({
+            u'name': REPOSET['rhva6'],
+            u'organization-label': org['label'],
+            u'product': PRDS['rhel'],
+        })
+        self.assertEqual(result.return_code, 0)
+        enabled = [
+            repo['enabled']
+            for repo
+            in result.stdout
+            if repo['arch'] == 'x86_64' and repo['release'] == '6Server'
+        ][0]
+        self.assertEqual(enabled, 'false')
+
+    def test_repositoryset_disable_by_id(self):
+        """@Test: Disable repo from reposet by IDs of reposet, org and product
+
+        @Feature: Repository-set
+
+        @Assert: Repository was disabled
+
+        """
+        org = make_org()
+        manifest = manifests.clone()
+        upload_file(manifest, remote_file=manifest)
+        result = Subscription.upload({
+            u'file': manifest,
+            u'organization-id': org['id'],
+        })
+        self.assertEqual(result.return_code, 0)
+        product_id = Product.info({
+            u'name': PRDS['rhel'],
+            u'organization-id': org['id'],
+        }).stdout['id']
+        reposet_id = RepositorySet.info({
+            u'name': REPOSET['rhva6'],
+            u'organization-id': org['id'],
+            u'product-id': product_id,
+        }).stdout['id']
+        result = RepositorySet.enable({
+            u'id': reposet_id,
+            u'organization-id': org['id'],
+            u'product-id': product_id,
+            u'releasever': '6Server',
+            u'basearch': 'x86_64',
+        })
+        self.assertEqual(result.return_code, 0)
+        result = RepositorySet.disable({
+            u'id': reposet_id,
+            u'organization-id': org['id'],
+            u'product-id': product_id,
+            u'releasever': '6Server',
+            u'basearch': 'x86_64',
+        })
+        self.assertEqual(result.return_code, 0)
+        result = RepositorySet.available_repositories({
+            u'id': reposet_id,
+            u'organization-id': org['id'],
+            u'product-id': product_id,
+        })
+        self.assertEqual(result.return_code, 0)
+        enabled = [
+            repo['enabled']
+            for repo
+            in result.stdout
+            if repo['arch'] == 'x86_64' and repo['release'] == '6Server'
+        ][0]
+        self.assertEqual(enabled, 'false')


### PR DESCRIPTION
Added coverage for ```hammer repository-set disable``` command.
```
$ hammer repository-set disable --help
Usage:
hammer repository-set disable [OPTIONS]

Options:
--basearch BASEARCH Basearch to disable
--id ID ID of the repository set to enable
--name NAME Repository set name to search by
--new-name NEW_NAME

--organization ORGANIZATION_NAME Organization name to search by
--organization-id ORGANIZATION_ID organization ID
--organization-label ORGANIZATION_LABEL Organization label to search by
--product PRODUCT_NAME Product name to search by
--product-id PRODUCT_ID product numeric identifier
--releasever RELEASEVER Releasever to disable
-h, --help print help
```
Closes #2435
Test results:
```
nosetests tests/foreman/cli/test_repository_set.py -m test_repositoryset_disable
...
----------------------------------------------------------------------
Ran 3 tests in 261.418s

OK
```
Will rebase as soon as PR #2457 gets merged.