### PR TITLE
API: Added coverage for location delete

### DIFF
--- a/tests/foreman/api/test_location.py
+++ b/tests/foreman/api/test_location.py
@@ -8,6 +8,7 @@ from ddt import ddt
 from fauxfactory import gen_string
 from nailgun import entities
 from random import randint
+from requests.exceptions import HTTPError
 from robottelo.common.decorators import data
 from robottelo.test import APITestCase
 
@@ -199,3 +200,16 @@ class LocationTestCase(APITestCase):
         self.assertEqual(len(location.organization), orgs_amount)
         for org in location.organization:
             self.assertIn(org.id, org_ids)
+
+    def test_delete_location(self):
+        """@Test: Delete location
+
+        @Assert: Location was deleted
+
+        @Feature: Location - Delete
+
+        """
+        location = entities.Location().create()
+        location.delete()
+        with self.assertRaises(HTTPError):
+            location.read()


### PR DESCRIPTION
Added coverage for ```DELETE /api/locations/:id```.
Closes #2428
Tests results:
```
nosetests tests/foreman/api/test_location.py -m test_delete
.
----------------------------------------------------------------------
Ran 1 test in 8.488s

OK
```