### PR TITLE
First performance tests merge - 20150710

### DIFF
--- a/robottelo/cli/base.py
+++ b/robottelo/cli/base.py
@@ -194,12 +194,15 @@ class Base(object):
         """Executes the cli ``command`` on the server via ssh"""
         user, password = cls._get_username_password(user, password)
 
-        cmd = u'LANG={0} hammer -v -u {1} -p {2} {3} {4}'.format(
+        # add time to measure hammer performance
+        perf_test = conf.properties['performance.test.foreman.perf']
+        cmd = u'LANG={0} {1} hammer -v -u {2} -p {3} {4} {5}'.format(
             conf.properties['main.locale'],
+            u'time -p' if perf_test == '1' else '',
             user,
             password,
             u'--output={0}'.format(output_format) if output_format else u'',
-            command
+            command,
         )
 
         return ssh.command(

--- a/robottelo/performance/__init__.py
+++ b/robottelo/performance/__init__.py
@@ -1,0 +1,9 @@
+"""This package contains helper code used by tests.foreman.performance.
+
+This module is subservient to tests.foreman.performance, and exists soley for
+the sake of helping that module get its work done. For example,
+tests.foreman.performance.test_candlepin_concurrent_delete relies upon
+perf_stat to generate csv files. More generally: code in test calls code
+in this common module, but not the other way around.
+
+"""

--- a/robottelo/performance/candlepin.py
+++ b/robottelo/performance/candlepin.py
@@ -1,0 +1,129 @@
+"""Test utilities for writing Candlepin tests
+
+Part of functionalities of Candlepin are defined in this module
+and have utilities of single register by activation-key, single
+register and attach, single subscription deletion.
+
+"""
+import logging
+import requests
+import time
+
+from robottelo.common import conf, ssh
+from robottelo.common.helpers import get_server_credentials, get_server_url
+from urlparse import urljoin
+
+LOGGER = logging.getLogger(__name__)
+
+
+class Candlepin(object):
+    """Measures performance of RH Satellite 6
+
+    Candlepin Subscription functionality
+
+    """
+
+    # parameters for Candlepin Authentication
+    username = conf.properties['foreman.admin.username']
+    password = conf.properties['foreman.admin.password']
+    serverhost = conf.properties['main.server.hostname']
+
+    @classmethod
+    def single_register_activation_key(cls, ak_name, default_org, vm):
+        """Subscribe VM to Satellite by Register + ActivationKey"""
+
+        # note: must create ssh keys for vm if running on local
+        result = ssh.command('subscription-manager clean', hostname=vm)
+        result = ssh.command(
+            'time -p subscription-manager register --activationkey={0} '
+            '--org={1}'.format(ak_name, default_org),
+            hostname=vm
+        )
+
+        if result.return_code != 0:
+            LOGGER.error('Fail to subscribe {} by ak!'.format(vm))
+            return
+        LOGGER.info('Subscribe client {} successfully'.format(vm))
+        real_time = [
+            real
+            for real in result.stderr.split('\n')
+            if real.startswith('real')
+        ]
+        return float(real_time[0].split(' ')[1])
+
+    @classmethod
+    def single_register_attach(cls, sub_id, default_org, environment, vm):
+        """Subscribe VM to Satellite by Register + Attach"""
+        ssh.command('subscription-manager clean', hostname=vm)
+
+        time_reg = cls.sub_mgr_register_authentication(
+            default_org, environment, vm)
+
+        time_att = cls.sub_mgr_attach(sub_id, vm)
+
+        if time_reg is None or time_att is None:
+            total_time = 0
+        else:
+            total_time = time_reg + time_att
+        return time_reg, time_att, total_time
+
+    @classmethod
+    def sub_mgr_register_authentication(cls, default_org, environment, vm):
+        """subscription-manager register -u -p --org --environment"""
+        result = ssh.command(
+            'time -p subscription-manager register --username={0} '
+            '--password={1} '
+            '--org={2} '
+            '--environment={3}'
+            .format(cls.username, cls.password, default_org, environment),
+            hostname=vm
+        )
+
+        if result.return_code != 0:
+            LOGGER.error(
+                'Fail to register client {} by sub-mgr!'.format(vm)
+            )
+            return
+        LOGGER.info('Register client {} successfully'.format(vm))
+        real_time = [real for real in result.stderr.split('\n')
+                     if real.startswith('real')]
+        real_time = real_time[0].split(' ')[1]
+        return float(real_time)
+
+    @classmethod
+    def sub_mgr_attach(cls, pool_id, vm):
+        """subscription-manager attach --pool=pool_id"""
+        result = ssh.command(
+            'time -p subscription-manager attach --pool={}'.format(pool_id),
+            hostname=vm
+        )
+
+        if result.return_code != 0:
+            LOGGER.error('Fail to attach client {}'.format(vm))
+            return
+        LOGGER.info('Attach client {} successfully'.format(vm))
+        real_time = [real for real in result.stderr.split('\n')
+                     if real.startswith('real')]
+        real_time = real_time[0].split(' ')[1]
+        return float(real_time)
+
+    @classmethod
+    def single_delete(cls, uuid, thread_id):
+        """Delete system from subscription"""
+        start = time.time()
+        response = requests.delete(
+            urljoin(get_server_url(), '/katello/api/systems/{0}'.format(uuid)),
+            auth=get_server_credentials(),
+            verify=False
+        )
+
+        if response.status_code != 204:
+            LOGGER.error(
+                'Fail to delete {0} on thread-{}!'.format(uuid, thread_id))
+            LOGGER.error(response.content)
+            return
+        LOGGER.info(
+            "Delete {0} on thread-{1} successful!".format(uuid, thread_id))
+        end = time.time()
+        LOGGER.info('real  {}s'.format(end-start))
+        return end - start

--- a/robottelo/performance/stat.py
+++ b/robottelo/performance/stat.py
@@ -1,0 +1,42 @@
+"""Test utilities for writing csv files"""
+import csv
+import numpy
+
+
+def generate_stat_for_concurrent_thread(thread_name, time_list,
+                                        stat_file_name, bucket_size,
+                                        num_buckets):
+    num_buckets = len(time_list)/bucket_size
+
+    # create list of bucket series
+    buckets = ['{0}-{1}'.format(bucket_size * i + 1, bucket_size * (i + 1))
+               for i in range(num_buckets)]
+
+    with open(stat_file_name, 'a') as handler:
+        writer = csv.writer(handler)
+        writer.writerow([])
+        writer.writerow(['{}'.format(thread_name)])
+        writer.writerow([
+            'bucket',
+            'min',
+            'median',
+            'mean',
+            'max',
+            'std',
+            '90%',
+            '95%',
+            '99%'
+        ])
+        for i, bucket in enumerate(buckets):
+            time_list_slice = time_list[bucket_size * i:bucket_size * (i + 1)]
+            writer.writerow([
+                bucket,
+                numpy.amin(time_list_slice),
+                numpy.median(time_list_slice),
+                numpy.mean(time_list_slice),
+                numpy.amax(time_list_slice),
+                numpy.std(time_list_slice),
+                numpy.percentile(time_list_slice, 90),
+                numpy.percentile(time_list_slice, 95),
+                numpy.percentile(time_list_slice, 99)
+            ])

--- a/robottelo/performance/thread.py
+++ b/robottelo/performance/thread.py
@@ -1,0 +1,88 @@
+"""Test utilities for multi-threading programming"""
+import logging
+import threading
+import time
+
+from robottelo.performance.candlepin import Candlepin
+
+LOGGER = logging.getLogger(__name__)
+
+
+class PerformanceThread(threading.Thread):
+    def __init__(self, thread_id, thread_name, time_result_dict):
+        threading.Thread.__init__(self)
+        self.thread_id = thread_id
+        self.thread_name = thread_name
+        self.time_result_dict = time_result_dict
+        self.logger = LOGGER
+
+
+class DeleteThread(PerformanceThread):
+    def __init__(self, thread_id, thread_name, sublist, time_result_dict):
+        super(DeleteThread, self).__init__(
+            thread_id, thread_name, time_result_dict)
+        self.sublist = sublist
+
+    def run(self):
+        time.sleep(5)
+        self.logger.debug('Start timing in thread {}'.format(self.thread_id))
+        for idx, uuid in enumerate(self.sublist):
+            if uuid != '':
+                self.logger.debug(
+                    'deletion attempt # {0} in thread {1}-uuid: {2}'
+                    .format(idx, self.thread_id, uuid))
+                # conduct one request by the id
+                time_point = Candlepin.single_delete(uuid, self.thread_id)
+                self.time_result_dict[self.thread_name].append(time_point)
+
+
+class SubscribeAKThread(PerformanceThread):
+    def __init__(self, thread_id, thread_name, time_result_dict,
+                 num_iterations, ak_name, default_org, vm_ip):
+        super(SubscribeAKThread, self).__init__(
+            thread_id, thread_name, time_result_dict)
+        self.num_iterations = num_iterations
+        self.ak_name = ak_name
+        self.default_org = default_org
+        self.vm_ip = vm_ip
+
+    def run(self):
+        time.sleep(5)
+        for i in range(self.num_iterations):
+            self.logger.debug(
+                "{0}: register with ak {1} on {2} attempt {3}"
+                .format(self.thread_name, self.ak_name, self.vm_ip, i))
+            time_point = Candlepin.single_register_activation_key(
+                self.ak_name,
+                self.default_org,
+                self.vm_ip)
+            self.time_result_dict[self.thread_name].append(time_point)
+
+
+class SubscribeAttachThread(PerformanceThread):
+    def __init__(self, thread_id, thread_name, time_result_dict,
+                 num_iterations, sub_id, default_org, environment, vm_ip):
+        super(SubscribeAttachThread, self).__init__(
+            thread_id, thread_name, time_result_dict)
+
+        self.num_iterations = num_iterations
+        self.sub_id = sub_id
+        self.default_org = default_org
+        self.environment = environment
+        self.vm_ip = vm_ip
+
+    def run(self):
+        for i in range(self.num_iterations):
+            self.logger.debug(
+                "{0}: register with subscription {1} on vm {2} attempt {3}"
+                .format(self.thread_name, self.sub_id, self.vm_ip, i))
+
+            time_points = Candlepin.single_register_attach(
+                self.sub_id,
+                self.default_org,
+                self.environment,
+                self.vm_ip)
+
+            for index in range(3):
+                self.time_result_dict[self.thread_name][index].append(
+                    time_points[index])

--- a/robottelo/test.py
+++ b/robottelo/test.py
@@ -4,6 +4,7 @@ All test cases for foreman tests are defined in this module and have utilities
 to help writting API, CLI and UI tests.
 
 """
+import csv
 import logging
 import os
 import signal
@@ -18,7 +19,7 @@ from datetime import datetime
 from fabric.api import execute, settings
 from robottelo.cli.metatest import MetaCLITest
 from robottelo.common.helpers import get_server_url
-from robottelo.common import conf
+from robottelo.common import conf, ssh
 from robottelo.ui.activationkey import ActivationKey
 from robottelo.ui.architecture import Architecture
 from robottelo.ui.computeresource import ComputeResource
@@ -59,6 +60,12 @@ from robottelo.vm import VirtualMachine
 from selenium_factory.SeleniumFactory import SeleniumFactory
 from selenium import webdriver
 
+from robottelo.performance.stat import generate_stat_for_concurrent_thread
+from robottelo.performance.thread import (
+    DeleteThread,
+    SubscribeAKThread,
+    SubscribeAttachThread
+)
 
 SAUCE_URL = "http://%s:%s@ondemand.saucelabs.com:80/wd/hub"
 
@@ -323,3 +330,431 @@ class InstallerTestCase(TestCase):
     def tearDownClass(cls):  # noqa
         super(InstallerTestCase, cls).tearDownClass()
         cls.vm.destroy()
+
+
+class ConcurrentTestCase(TestCase):
+    """Test utilities for writing performance tests.
+
+    Define ConcurrentTestCase as base class of performance test case:
+    1) concurrent subscription by AK,
+    2) concurrent subscription by register and attach,
+    3) concurrent subscription deletion.
+
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        """Make sure to only read configuration values once."""
+        super(ConcurrentTestCase, cls).setUpClass()
+
+        # general running parameters
+        cls.num_threads = conf.properties['performance.csv.num_threads']
+        cls.num_buckets = conf.properties['performance.csv.num_buckets']
+        cls.vm_list = []
+        cls.num_iterations = 0     # depend on # of threads or clients
+        cls.bucket_size = 0        # depend on # of iterations on each thread
+        cls._convert_to_numbers()  # read in string type, convert to numbers
+        cls._get_vm_list()         # read in list of virtual machines
+
+        # parameters for creating activation key
+        cls.ak_name = conf.properties[
+            'performance.test.activation_key.name']
+        cls.org_id = conf.properties[
+            'performance.test.organization.id']
+        cls.default_org = conf.properties[
+            'performance.test.default.organization']
+        cls.content_view = conf.properties[
+            'performance.test.content.view']
+        cls.life_cycle_env = conf.properties[
+            'performance.test.life.cycle.env']
+
+        # parameters for adding ak to subscription
+        cls.add_ak_subscription_qty = conf.properties[
+            'performance.test.add_ak_subscription_qty']
+        cls.sub_id = ''
+
+        # parameters for attach step
+        cls.environment = conf.properties['performance.test.attach.env']
+
+    @classmethod
+    def _convert_to_numbers(cls):
+        """read in string type series, convert to numbers"""
+        cls.num_threads = [int(x) for x in cls.num_threads.split(',')]
+        cls.num_buckets = int(cls.num_buckets)
+
+    @classmethod
+    def _get_vm_list(cls):
+        """read in a list of virtual machines ip address"""
+        vm_list_string = conf.properties[
+            'performance.test.virtual_machines_list']
+        cls.vm_list = vm_list_string.split(',')
+        cls.logger.debug('VM list: {}'.format(cls.vm_list))
+
+    @classmethod
+    def _set_testcase_parameters(cls, savepoint_name,
+                                 raw_file_path, stat_file_path):
+        cls.savepoint = conf.properties[savepoint_name]
+        cls.raw_file_name = conf.properties[raw_file_path]
+        cls.stat_file_name = conf.properties[stat_file_path]
+
+    def setUp(self):
+        self.logger.debug(
+            'Running test %s/%s', type(self).__name__, self._testMethodName)
+
+        # Restore database before concurrent subscription/deletion
+        self._restore_from_savepoint(self.savepoint)
+
+    def _restore_from_savepoint(self, savepoint):
+        """Restore from savepoint"""
+        self.logger.info('Reset db from /home/backup/{}'.format(savepoint))
+        ssh.command('./reset-db.sh /home/backup/{}'.format(savepoint))
+
+    def _set_num_iterations(self, total_iterations, current_num_threads):
+        """Set # of iterations each thread will conduct.
+
+        :param int total_iterations: total # of iterations for a test case
+        :param int current_num_threads: number of clients or threads
+
+        Example:
+        1) split 5k total_iterations evenly between 10 clients,
+           thus each client would conduct 500 iterations concurrently;
+        2) split 6k evenly between 6 clients,
+           thus each client would conduct 1000 iterations concurrently;
+
+        """
+        self.num_iterations = total_iterations / current_num_threads
+
+    def _set_bucket_size(self):
+        """Set size for each bucket"""
+        self.bucket_size = self.num_iterations / self.num_buckets
+
+    def _join_all_threads(self, thread_list):
+        """Wait for all threads to complete"""
+        for thread in thread_list:
+            thread.join()
+
+    def _write_raw_csv_file(self, raw_file_name, time_result_dict,
+                            current_num_threads, test_case_name):
+        """Write raw timing ak/del results to csv file"""
+        self.logger.debug(
+            'Timing result is: {}'.format(time_result_dict))
+
+        with open(raw_file_name, 'a') as handler:
+            writer = csv.writer(handler)
+            writer.writerow([test_case_name])
+
+            # for each thread, write its head and data
+            for i in range(current_num_threads):
+                writer.writerow([
+                    'client-{}'.format(i)
+                ])
+                writer.writerow(time_result_dict.get('thread-{}'.format(i)))
+            writer.writerow([])
+
+    def _write_raw_att_csv_file(self, raw_file_name, time_result_dict,
+                                current_num_threads, test_case_name):
+        """Write raw timing att results to csv file"""
+        self.logger.debug("Timing result is: {}".format(time_result_dict))
+        with open(raw_file_name, 'a') as handler:
+            writer = csv.writer(handler)
+            writer.writerow([test_case_name])
+
+            # for each thread, write its head and data
+            for i in range(current_num_threads):
+                writer.writerow(['client-{}'.format(i)])
+                for index in range(3):
+                    writer.writerow(
+                        time_result_dict.get('thread-{}'.format(i))[index])
+                    writer.writerow([])
+
+    def _write_stat_csv_file(self, stat_file_name, time_result_dict,
+                             current_num_threads, test_case_name, is_attach):
+        """Generate statistical result of concurrent ak/del/att"""
+        with open(stat_file_name, 'a') as handler:
+            writer = csv.writer(handler)
+            writer.writerow([test_case_name])
+
+            # 1) write stat-per-client-bucketized result of ak/del/att
+            writer.writerow(['stat-per-client-bucketized'])
+            self._write_stat_per_client_bucketized(
+                stat_file_name,
+                time_result_dict,
+                current_num_threads,
+                is_attach
+            )
+            writer.writerow([])
+
+            # 2) write stat-per-test-bucketized result of ak/del/att
+            writer.writerow(['stat-per-test-bucketized'])
+            self._write_stat_per_test_bucketized(
+                stat_file_name,
+                time_result_dict,
+                is_attach)
+            writer.writerow([])
+
+            # 3) write stat-per-client result of ak/del/att
+            writer.writerow(['stat-per-client'])
+            self._write_stat_per_client(
+                stat_file_name,
+                time_result_dict,
+                current_num_threads,
+                is_attach)
+            writer.writerow([])
+
+            # 4) write stat-per-test result of ak/del/att
+            writer.writerow(['stat-per-test'])
+            self._write_stat_per_test(
+                stat_file_name,
+                time_result_dict,
+                is_attach)
+            writer.writerow([])
+
+    def _write_stat_per_client_bucketized(
+            self, stat_file_name,
+            time_result_dict,
+            current_num_threads,
+            is_attach):
+        """Write bucketized stat of per-client results to csv file
+
+        note: each bucket is a split of a client i
+
+        """
+        for i in range(current_num_threads):
+            if is_attach:
+                time_list = time_result_dict.get('thread-{}'.format(i))[2]
+            else:
+                time_list = time_result_dict.get('thread-{}'.format(i))
+            thread_name = 'client-{}'.format(i)
+            generate_stat_for_concurrent_thread(
+                thread_name,
+                time_list,
+                stat_file_name,
+                self.bucket_size,
+                self.num_buckets)
+
+    def _write_stat_per_test_bucketized(
+            self, stat_file_name,
+            time_result_dict,
+            is_attach):
+        """Write bucketized stat of per-test to csv file
+
+        note: each bucket of all clients would merge into a chunk;
+        generate stat for each such chunk. For example:
+
+            Input: # of clients = 10
+            thread-0: [(50 data) | (50 data)|...]
+            thread-1: [(50 data) | (50 data)|...]
+            ...
+            thread-9: [(50 data) | (50 data)|...]
+            Output:
+            sublist [500 data in all first buckets of each thread]
+                    [500]...[500]
+
+        """
+        for i in range(self.num_buckets):
+            chunks_bucket_i = []
+            for j in range(len(time_result_dict)):
+                if is_attach:
+                    time_list = time_result_dict.get('thread-{}'.format(j))[2]
+                else:
+                    time_list = time_result_dict.get('thread-{}'.format(j))
+                # slice out bucket-size from each client's result and merge
+                chunks_bucket_i += time_list[
+                    i * self.bucket_size: (i + 1) * self.bucket_size
+                ]
+
+            generate_stat_for_concurrent_thread(
+                'bucket-{}'.format(i),
+                chunks_bucket_i,
+                stat_file_name,
+                len(chunks_bucket_i), 1)
+
+    def _write_stat_per_client(self, stat_file_name, time_result_dict,
+                               current_num_threads, is_attach):
+        """Write stat of per-client results to csv file
+
+        note: take the full list of a client i; calculate stat on the list
+
+        """
+        for i in range(current_num_threads):
+            if is_attach:
+                time_list = time_result_dict.get('thread-{}'.format(i))[2]
+            else:
+                time_list = time_result_dict.get('thread-{}'.format(i))
+            thread_name = 'client-{}'.format(i)
+            generate_stat_for_concurrent_thread(
+                thread_name,
+                time_list,
+                stat_file_name,
+                len(time_list), 1)
+
+    def _write_stat_per_test(self, stat_file_name,
+                             time_result_dict, is_attach):
+        """Write stat of per-test results to csv file
+
+        note: take the full dictionary of test and calculate overall stat
+
+        """
+        full_list = []
+        for i in range(len(time_result_dict)):
+            if is_attach:
+                time_list = time_result_dict.get('thread-{}'.format(i))[2]
+            else:
+                time_list = time_result_dict.get('thread-{}'.format(i))
+            full_list += time_list
+
+        generate_stat_for_concurrent_thread(
+            'test-{}'.format(len(time_result_dict)),
+            full_list,
+            stat_file_name,
+            len(full_list), 1)
+
+    def kick_off_ak_test(self, current_num_threads, total_iterations):
+        """Refactor out concurrent register by ak test case
+
+        :param int current_num_threads: number of threads
+        :param int total_iterations: # of iterations a test case would run
+
+        """
+        # check if number of threads are mapped with number of vms
+        current_vm_list = self.vm_list[:current_num_threads]
+        self.assertEqual(len(current_vm_list), current_num_threads)
+
+        # Parameter for statistics files
+        self._set_num_iterations(total_iterations, current_num_threads)
+        self._set_bucket_size()
+
+        # Create a list to store all threads
+        thread_list = []
+        # Create a dictionary to store all timing results from each client
+        time_result_dict = {}
+
+        # Create new threads and start each thread mapped with a vm
+        for i in range(current_num_threads):
+            thread_name = 'thread-{}'.format(i)
+            time_result_dict[thread_name] = []
+            thread = SubscribeAKThread(
+                i, thread_name, time_result_dict,
+                self.num_iterations, self.ak_name,
+                self.default_org, current_vm_list[i])
+            thread.start()
+            thread_list.append(thread)
+
+        # wait all threads in thread list
+        self._join_all_threads(thread_list)
+
+        # write raw result of ak
+        self._write_raw_csv_file(
+            self.raw_file_name,
+            time_result_dict,
+            current_num_threads,
+            'raw-ak-{}-clients'.format(current_num_threads))
+
+        # write stat result of ak
+        self._write_stat_csv_file(
+            self.stat_file_name,
+            time_result_dict,
+            current_num_threads,
+            'stat-ak-{}-clients'.format(current_num_threads), False)
+
+    def kick_off_att_test(self, current_num_threads, total_iterations):
+        """Refactor out concurrent register and attach test case
+
+        :param int current_num_threads: number of threads
+        :param int total_iterations: # of deletions a test case would run
+
+        """
+        # check if number of threads are mapped with number of vms
+        current_vm_list = self.vm_list[:current_num_threads]
+        self.assertEqual(len(current_vm_list), current_num_threads)
+
+        # Parameter for statistics files
+        self._set_num_iterations(total_iterations, current_num_threads)
+        self._set_bucket_size()
+
+        # Create a list to store all threads
+        thread_list = []
+        # Create a dictionary to store all timing results from each client
+        time_result_dict = {}
+
+        # Create new threads and start each thread mapped with a vm
+        for i in range(current_num_threads):
+            thread_name = 'thread-{}'.format(i)
+            time_result_dict[thread_name] = [[], [], []]
+
+            thread = SubscribeAttachThread(
+                i, thread_name, time_result_dict,
+                self.num_iterations, self.sub_id,
+                self.default_org, self.environment,
+                current_vm_list[i])
+            thread.start()
+            thread_list.append(thread)
+
+        # wait all threads in thread list
+        self._join_all_threads(thread_list)
+
+        # write raw result of att
+        self._write_raw_att_csv_file(
+            self.raw_file_name,
+            time_result_dict,
+            current_num_threads,
+            'raw-att-{}-clients'.format(current_num_threads))
+
+        # write stat result of att
+        self._write_stat_csv_file(
+            self.stat_file_name,
+            time_result_dict,
+            current_num_threads,
+            'stat-att-{}-clients'.format(current_num_threads), True)
+
+    def kick_off_del_test(self, current_num_threads):
+        """Refactor out concurrent system deletion test case
+
+        :param int current_num_threads: number of threads
+        :param int total_iterations
+
+        """
+        # Get list of all uuids of registered systems
+
+        self.logger.info('Retrieve list of uuids of all registered systems:')
+        uuid_list = self._get_registered_uuids()
+
+        # Parameter for statistics files
+        total_iterations = len(uuid_list)
+
+        self._set_num_iterations(total_iterations, current_num_threads)
+        self._set_bucket_size()
+
+        # Create a list to store all threads
+        thread_list = []
+        # Create a dictionary to store all timing results from each thread
+        time_result_dict = {}
+
+        # Create new threads and start the thread which has sublist of uuids
+        for i in range(current_num_threads):
+            time_result_dict['thread-{}'.format(i)] = []
+            thread = DeleteThread(
+                i, 'thread-{}'.format(i),
+                uuid_list[self.num_iterations * i:
+                          self.num_iterations * (i + 1)],
+                time_result_dict
+            )
+            thread.start()
+            thread_list.append(thread)
+
+        # wait all threads in thread list
+        self._join_all_threads(thread_list)
+
+        # write raw result of del
+        self._write_raw_csv_file(
+            self.raw_file_name,
+            time_result_dict,
+            current_num_threads,
+            'raw-del-{}-clients'.format(current_num_threads))
+
+        # write stat result of del
+        self._write_stat_csv_file(
+            self.stat_file_name,
+            time_result_dict,
+            current_num_threads,
+            'stat-del-{}-clients'.format(current_num_threads), False)

--- a/setup.py
+++ b/setup.py
@@ -10,6 +10,7 @@ REQUIRES = [
     'python-bugzilla',
     'requests',
     'selenium',
+    'numpy',
 ]
 
 with open('README.rst', 'r') as f:

--- a/tests/foreman/performance/__init__.py
+++ b/tests/foreman/performance/__init__.py
@@ -1,0 +1,5 @@
+"""Test utilities for writing foreman/performance tests.
+
+All test cases for performance tests are defined in this module
+
+"""

--- a/tests/foreman/performance/test_candlepin_concurrent_delete.py
+++ b/tests/foreman/performance/test_candlepin_concurrent_delete.py
@@ -1,0 +1,116 @@
+"""Test class for concurrent subscription deletion"""
+from datetime import date
+from robottelo.common import ssh
+
+from robottelo.test import ConcurrentTestCase
+
+
+class ConcurrentDeleteTestCase(ConcurrentTestCase):
+    """Concurrent Deleting subscriptions tests"""
+
+    @classmethod
+    def setUpClass(cls):
+        super(ConcurrentDeleteTestCase, cls).setUpClass()
+        # parameters for concurrent activation key test
+        # note: may need to change savepoint name
+        cls._set_testcase_parameters(
+            'performance.test.savepoint2_enabled_repos',
+            'performance.csv.raw_del_file_name',
+            'performance.csv.stat_del_file_name'
+        )
+
+        # add date to csv files names
+        today = date.today()
+        today_str = today.strftime('%Y%m%d')
+        cls.raw_file_name = '{0}-{1}'.format(today_str, cls.raw_file_name)
+        cls.stat_file_name = '{0}-{1}'.format(today_str, cls.stat_file_name)
+
+    def setUp(self):
+        super(ConcurrentTestCase, self).setUp()
+
+    def _get_registered_uuids(self):
+        """Get all registered systems' uuids from Postgres"""
+        self.logger.info('Get UUID from database:')
+
+        result = ssh.command(
+            """su postgres -c 'psql -A -t -d candlepin -c """
+            """"SELECT uuid FROM cp_consumer;"'""")
+
+        if result.return_code != 0:
+            self.logger.error('Fail to fetch uuids.')
+            return None
+        return result.stdout
+
+    def test_delete_sequential(self):
+        """@Test: Delete subscriptions using 1 thread
+
+        @Steps:
+
+        1. get list of all registered systems' uuid
+        2. create result dictionary
+        3. create thread names
+        4. run by only one thread as deleting sequentially
+        5. produce result of timing
+
+        @Assert: Restoring from database would have 5k registered systems.
+
+        """
+        self.kick_off_del_test(self.num_threads[0])
+
+    def test_delete_2_clients(self):
+        """@Test: Delete subscriptions concurrently using 2 threads
+
+        @Steps:
+
+        1. get list of all registered systems' uuid
+        2. create result dictionary
+        3. create a list of thread names
+        4. concurrent run by multiple threads;
+           each thread delete only a sublist of uuids
+        5. produce result of timing
+
+        @Assert: Restoring from database would have 5k registered systems.
+
+        """
+        self.kick_off_del_test(self.num_threads[1])
+
+    def test_delete_4_clients(self):
+        """@Test: Delete subscriptions concurrently using 4 threads
+
+        @Assert: Restoring from database would have 5k registered systems.
+
+        """
+        self.kick_off_del_test(self.num_threads[2])
+
+    def test_delete_6_clients(self):
+        """@Test: Delete subscriptions concurrently using 6 threads
+
+        @Assert: Restoring from database would have 5k registered systems.
+
+        """
+        self.kick_off_del_test(self.num_threads[3])
+
+    def test_delete_8_clients(self):
+        """@Test: Delete subscriptions concurrently using 8 threads
+
+        @Assert: Restoring from database would have 5k registered systems.
+
+        """
+        self.kick_off_del_test(self.num_threads[4])
+
+    def test_delete_10_clients(self):
+        """@Test: Delete subscriptions concurrently using 10 virtual machines
+
+        @Steps:
+
+        1. get list of all registered systems' uuid
+        2. create result dictionary
+        3. create a list of thread names
+        4. concurrent run by multiple threads;
+           each thread delete only a sublist of uuids
+        5. produce result of timing
+
+        @Assert: Restoring from database would have 5k registered systems.
+
+        """
+        self.kick_off_del_test(self.num_threads[5])

--- a/tests/foreman/performance/test_candlepin_concurrent_subscription_ak.py
+++ b/tests/foreman/performance/test_candlepin_concurrent_subscription_ak.py
@@ -1,0 +1,174 @@
+"""Test class for concurrent subscription by Activation Key"""
+from datetime import date
+from robottelo.cli.activationkey import ActivationKey
+from robottelo.cli.factory import (make_activation_key)
+from robottelo.cli.subscription import Subscription
+
+from robottelo.test import ConcurrentTestCase
+
+
+class ConcurrentSubActivationKeyTestCase(ConcurrentTestCase):
+    """Concurrently Subscribe to Satellite Server by activation-key tests"""
+
+    @classmethod
+    def setUpClass(cls):
+        super(ConcurrentSubActivationKeyTestCase, cls).setUpClass()
+
+        # parameters for concurrent activation key test only
+        # note: may need to change savepoint name
+        cls._set_testcase_parameters(
+            'performance.test.savepoint2_enabled_repos',
+            'performance.csv.raw_ak_file_name',
+            'performance.csv.stat_ak_file_name'
+        )
+
+        # add date to csv files names
+        today = date.today()
+        today_str = today.strftime('%Y%m%d')
+        cls.raw_file_name = '{0}-{1}'.format(today_str, cls.raw_file_name)
+        cls.stat_file_name = '{0}-{1}'.format(today_str, cls.stat_file_name)
+
+    def setUp(self):
+        super(ConcurrentSubActivationKeyTestCase, self).setUp()
+
+        # Create activation key
+        self.logger.info('Create activation key: ')
+        # (ak_id, ak_name) = self._create_activation_key()
+
+        # Get subscription id
+        self.logger.info('Get subscription id: ')
+        (sub_id, sub_name) = self._get_subscription_id()
+        self.sub_id = sub_id
+
+        # Add activation key to subscription
+        # self._add_ak_to_subscription(ak_id, sub_id)
+
+    def _create_activation_key(self):
+        """Create a new activation key named ak-1"""
+        make_activation_key({
+            'organization-id': self.org_id,
+            'content-view': self.content_view,
+            'lifecycle-environment': self.life_cycle_env,
+            'name': self.ak_name
+        })
+
+        # output activation key informatin
+        self.logger.info('Retrieve activation keys info list:')
+        result = ActivationKey.list(
+            {'organization-id': self.org_id},
+            per_page=False
+        )
+
+        if result.return_code != 0:
+            self.logger.error('Fail to make new activation key!')
+            return
+        self.logger.info(
+            'New activation key is: {}.'.format(result.stdout[0]['name']))
+        return result.stdout[0]['id'], result.stdout[0]['name']
+
+    def _get_subscription_id(self):
+        """Get subscription id"""
+        result = Subscription.list(
+            {'organization-id': self.org_id},
+            per_page=False
+        )
+
+        if result.return_code != 0:
+            self.logger.error('Fail to get subscription id!')
+            return
+        subscription_id = result.stdout[0]['id']
+        subscription_name = result.stdout[0]['name']
+        self.logger.info('Subscribed to {0} with subscription id {1}'
+                         .format(subscription_name, subscription_id))
+        return subscription_id, subscription_name
+
+    def _add_ak_to_subscription(self, ak_id, sub_id):
+        """Add activation key to subscription"""
+        result = ActivationKey.add_subscription({
+            'id': ak_id,
+            'subscription-id': sub_id,
+            'quantity': self.add_ak_subscription_qty
+        })
+
+        if result.return_code != 0:
+            self.logger.error('Fail to add activation-key to subscription')
+            return
+        self.logger.info('Subscription added to this activation key.')
+
+    def test_subscribe_ak_sequential(self):
+        """@Test: Subscribe system sequentially using 1 virtual machine
+
+        @Steps:
+
+        1. create activation key (setup)
+        2. get subscription id (setup)
+        3. add activation key to subscription (setup)
+        4. create result dictionary
+        5. sequentially run by one thread;
+           the thread iterates all total number of iterations
+        6. produce result of timing
+
+        @Assert: Restoring where there's no activation key or registration
+
+        """
+        self.kick_off_ak_test(self.num_threads[0], 5000)
+
+    def test_subscribe_ak_2_clients(self):
+        """@Test: Subscribe system concurrently using 2 virtual machines
+
+        @Steps:
+
+        1. create activation key (setup)
+        2. get subscription id (setup)
+        3. add activation key to subscription (setup)
+        4. create result dictionary
+        5. concurrent run by multiple threads;
+           each thread iterates a limited number of times
+        6. produce result of timing
+
+        @Assert: Restoring where there's no activation key or registration
+
+        """
+        self.kick_off_ak_test(self.num_threads[1], 5000)
+
+    def test_subscribe_ak_4_clients(self):
+        """@Test: Subscribe system concurrently using 4 virtual machines
+
+        @Assert: Restoring where there's no activation key or registration
+
+        """
+        self.kick_off_ak_test(self.num_threads[2], 5000)
+
+    def test_subscribe_ak_6_clients(self):
+        """@Test: Subscribe system concurrently using 6 virtual machines
+
+        @Assert: Restoring where there's no activation key or registration
+
+        """
+        self.kick_off_ak_test(self.num_threads[3], 6000)
+
+    def test_subscribe_ak_8_clients(self):
+        """@Test: Subscribe system concurrently using 8 virtual machines
+
+        @Assert: Restoring where there's no activation key or registration
+
+        """
+        self.kick_off_ak_test(self.num_threads[4], 5000)
+
+    def test_subscribe_ak_10_clients(self):
+        """@Test: Subscribe system concurrently using 10 virtual machines
+
+        @Steps:
+
+        1. create activation key (setup)
+        2. get subscription id (setup)
+        3. add activation key to subscription (setup)
+        4. create result dictionary
+        5. concurrent run by multiple threads
+           each thread iterates a limited number of times
+        6. produce result of timing
+
+        @Assert: Restoring where there's no activation key or registration
+
+        """
+        self.kick_off_ak_test(self.num_threads[5], 5000)

--- a/tests/foreman/performance/test_candlepin_concurrent_subscription_attach.py
+++ b/tests/foreman/performance/test_candlepin_concurrent_subscription_attach.py
@@ -1,0 +1,120 @@
+"""Test class for concurrent subscription by register and attach"""
+from datetime import date
+from robottelo.cli.subscription import Subscription
+
+from robottelo.test import ConcurrentTestCase
+
+
+class ConcurrentSubAttachTestCase(ConcurrentTestCase):
+    """Concurrent Subscribe to Red Hat Satellite 6 Server by attach tests"""
+
+    @classmethod
+    def setUpClass(cls):
+        super(ConcurrentSubAttachTestCase, cls).setUpClass()
+
+        # parameters for concurrent register and attach test
+        # note: may need to change savepoint name
+        cls._set_testcase_parameters(
+            'performance.test.savepoint2_enabled_repos',
+            'performance.csv.raw_att_file_name',
+            'performance.csv.stat_att_file_name'
+        )
+
+        # add date to csv files names
+        today = date.today()
+        today_str = today.strftime('%Y%m%d')
+        cls.raw_file_name = '{0}-{1}'.format(today_str, cls.raw_file_name)
+        cls.stat_file_name = '{0}-{1}'.format(today_str, cls.stat_file_name)
+
+    def setUp(self):
+        super(ConcurrentSubAttachTestCase, self).setUp()
+
+        # Get subscription id
+        (self.sub_id, sub_name) = self._get_subscription_id()
+        self.logger.debug(
+            'subscription {0} id is: {1}'.format(sub_name, self.sub_id))
+
+    def _get_subscription_id(self):
+        """Get subscription pool id"""
+        result = Subscription.list(
+            {'organization-id': self.org_id},
+            per_page=False
+        )
+
+        if result.return_code != 0:
+            self.logger.error('Fail to retrieve subscription id!')
+            return
+        subscription_id = result.stdout[0]['id']
+        subscription_name = result.stdout[0]['name']
+        self.logger.info('Subscribed to {0} with subscription id {1}'
+                         .format(subscription_name, subscription_id))
+        return subscription_id, subscription_name
+
+    def test_subscribe_ak_sequential(self):
+        """@Test: Subscribe system sequentially using 1 virtual machine
+
+        @Steps:
+
+        1. create result dictionary
+        2. sequentially run by one thread;
+           the thread iterates all total number of iterations
+        3. produce result of timing
+
+        @Assert: Restoring where there's no system registered
+
+        """
+        self.kick_off_ak_test(self.num_threads[0], 5000)
+
+    def test_register_attach_2_clients(self):
+        """@Test: Subscribe system concurrently using 2 virtual machines
+
+        @Steps:
+
+        1. create result dictionary
+        2. concurrent run by multiple threads;
+           each thread iterates a limited number of times
+        3. produce result of timing
+
+        @Assert: Restoring from database without any registered systems.
+
+        """
+        self.kick_off_att_test(self.num_threads[1], 5000)
+
+    def test_register_attach_4_clients(self):
+        """@Test: Subscribe system concurrently using 4 virtual machines
+
+        @Assert: Restoring from database without any registered systems.
+
+        """
+        self.kick_off_att_test(self.num_threads[2], 5000)
+
+    def test_register_attach_6_clients(self):
+        """@Test: Subscribe system concurrently using 6 virtual machines
+
+        @Assert: Restoring from database without any registered systems.
+
+        """
+        self.kick_off_att_test(self.num_threads[3], 6000)
+
+    def test_register_attach_8_clients(self):
+        """@Test: Subscribe system concurrently using 8 virtual machines
+
+        @Assert: Restoring from database without any registered systems.
+
+        """
+        self.kick_off_att_test(self.num_threads[4], 5000)
+
+    def test_register_attach_10_clients(self):
+        """@Test: Subscribe system concurrently using 10 virtual machines
+
+        @Steps:
+
+        1. create result dictionary
+        2. concurrent run by multiple threads;
+           and each thread iterates a limited number of times
+        3. produce result of timing
+
+        @Assert: Restoring from database without any registered systems.
+
+        """
+        self.kick_off_att_test(self.num_threads[5], 5000)

--- a/tests/foreman/performance/test_standard_prep.py
+++ b/tests/foreman/performance/test_standard_prep.py
@@ -1,0 +1,170 @@
+"""Test class for Environment Preparation after a fresh installation"""
+from robottelo.common import conf, ssh
+from robottelo.cli.org import Org
+from robottelo.cli.repository import Repository
+from robottelo.cli.repository_set import RepositorySet
+from robottelo.cli.subscription import Subscription
+
+from robottelo.test import TestCase
+
+
+class StandardPrepTestCase(TestCase):
+    """Standard process of preparation after fresh install Sattellite 6.
+
+    Standard Preparation Process:
+    1) upload manifest,
+    2) change CDN address,
+    3) enable repositories,
+    4) make savepoint
+
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        super(StandardPrepTestCase, cls).setUpClass()
+
+        # parameters for standard process test
+        # note: may need to change savepoint name
+        cls.savepoint = conf.properties[
+            'performance.test.savepoint1_fresh_install']
+        cls.manifest_location = conf.properties[
+            'performance.test.manifest.location']
+
+        # parameters for uploading manifests
+        cls.manifest_file = conf.properties['performance.test.manifest.file']
+        cls.org_id = conf.properties['performance.test.organization.id']
+
+        # parameters for changing cdn address
+        cls.target_url = conf.properties['performance.test.cdn.address']
+
+        # parameters for enabling repositories
+        cls.pid = conf.properties['performance.test.pid']
+
+        # [repo-id,$basearch,$releasever]
+        cls.repository_list = [
+            [168, 'x86_64', '6Server'],
+            [2456, 'x86_64', '7Server'],
+            [1952, 'x86_64', '6.6'],
+            [2455, 'x86_64', '7.1'],
+            [166, 'x86_64', '6Server'],
+            [2463, 'x86_64', '7Server'],
+            [167, 'x86_64', '6Server'],
+            [2464, 'x86_64', '7Server'],
+            [165, 'x86_64', '6Server'],
+            [2462, 'x86_64', '7Server']
+        ]
+
+    def setUp(self):
+        self.logger.debug('Running test %s/%s',
+                          type(self).__name__, self._testMethodName)
+
+        # Restore database to clean state
+        self._restore_from_savepoint(self.savepoint)
+
+    def _restore_from_savepoint(self, savepoint):
+        """Restore from a given savepoint"""
+        self.logger.info('Reset db from /home/backup/{}'.format(savepoint))
+        ssh.command('./reset-db.sh /home/backup/{}'.format(savepoint))
+
+    def _download_manifest(self):
+        self.logger.info(
+            'Start downloading required manifest: {}'
+            .format(self.manifest_location + self.manifest_file))
+
+        result = ssh.command(
+            'rm -f {0}; curl {1} -o /root/{0}'
+            .format(self.manifest_file,
+                    self.manifest_location + self.manifest_file))
+
+        if result.return_code != 0:
+            self.logger.error('Fail to download manifest!')
+            return
+        self.logger.info('Downloading manifest complete.')
+
+    def _upload_manifest(self):
+        result = Subscription.upload({
+            'file': '/root/{}'.format(self.manifest_file),
+            'organization-id': self.org_id
+        })
+
+        if result.return_code != 0:
+            self.logger.error('Fail to upload manifest!')
+            return
+        (self.sub_id, self.sub_name) = self._get_subscription_id()
+        self.logger.info('Upload successful!')
+
+    def _get_subscription_id(self):
+        result = Subscription.list(
+            {'organization-id': self.org_id},
+            per_page=False
+        )
+
+        if result.return_code != 0:
+            self.logger.error('Fail to list subscriptions!')
+            return
+        subscription_id = result.stdout[0]['id']
+        subscription_name = result.stdout[0]['name']
+        self.logger.info('Subscribe to {0} with subscription id: {1}'
+                         .format(subscription_name, subscription_id))
+        return (subscription_id, subscription_name)
+
+    def _update_cdn_address(self):
+        Org.update({
+            'id': self.org_id,
+            'redhat-repository-url': self.target_url
+        })
+        result = Org.info({'id': self.org_id})
+
+        if result.return_code != 0:
+            self.logger.error('Fail to update CDN address!')
+            return
+        self.logger.info(
+            'RH CDN URL: {}'
+            .format(result.stdout['red-hat-repository-url']))
+
+    def _enable_repositories(self):
+        for i, repo in enumerate(self.repository_list):
+            repo_id = repo[0]
+            basearch = repo[1]
+            releasever = repo[2]
+            self.logger.info(
+                'Enabling product {0}: repository id {1} '
+                'with baserach {2} and release {3}'
+                .format(i, repo_id, basearch, releasever))
+
+            # Enable repos from Repository Set
+            result = RepositorySet.enable({
+                'product-id': self.pid,
+                'basearch': basearch,
+                'releasever': releasever,
+                'id': repo_id
+            })
+
+        # verify enabled repository list
+        result = Repository.list(
+            {'organization-id': self.org_id},
+            per_page=False
+        )
+
+        # repo_list_ids would contain all repositories in the hammer repo list
+        repo_list_ids = [repo['id'] for repo in result.stdout]
+        self.logger.debug(repo_list_ids)
+
+    def test_standard_prep(self):
+        """@Test: add Manifest to Satellite Server
+
+        @Steps:
+
+        1. download manifest
+        2. upload to subscription
+        3. update Red Hat CDN URL
+        4. enable repositories
+        5. take db snapshot backup
+
+        @Assert: Restoring from database where its status is clean
+
+        """
+        self._download_manifest()
+        self._upload_manifest()
+        self._update_cdn_address()
+        self._enable_repositories()


### PR DESCRIPTION
<h5>I. Critical change to core component <code>robottelo/cli/base.py</code>:</h5>
In order to measure the time performance of Satellite 6 concurrent system subscription/deletion , a <code>time</code> command is added before <code>hammer</code>. The time output is received through standard error. To control whether or not to start performance tests, i.e. timing latency of hammer, please change corresponding entry <code>test.foreman.perf</code> in the internal properties configuration file under <code>[performance]</code> section.

<h5>II. Critical change to <code>robottelo/test.py</code></h5>
Add <code>ConcurrentTestCase</code> class which supports as base class of performance test case. 

<h5>III. Files</h5>

1) <code>robottelo/performance/candlepin.py</code>:
Provide Candlepin functionality: single register by activation-key, single register and attach, single deletion from subscription;

2) <code>robottelo/performance/pulp.py</code>:
Provide Pulp functionality: single repository synchronization, sequential repository synchronization, sequential repository re-synchronization

3) <code>robottelo/performance/stat.py</code>:
Provide function to write a list of time point into csv files.

4) <code>robottelo/performance/thread.py</code>:
Create and Inherit Python threads to start concurrent system subscription by activation-key, concurrent subscription by register and attach, concurrent system deletion;

5) <code>tests/foreman/performance/test_standard_prep.py</code>:
Standard process of preparation after fresh install Red Hat Satellite 6: upload manifest, change CDN address, enable repositories;

6) <code>tests/foreman/performance/test_candlepin_concurrent_delete.py</code>:
Unit test for concurrent deleting of hosts through REST API, using 2, 4, 6, 8, 10 threads separately;

7) <code>tests/foreman/performance/test_candlepin_concurrent_subscription_ak.py</code>
Unit test for concurrent subscription by activation-key tests, using 2, 4, 6, 8, 10 clients separately;

8) <code>tests/foreman/performance/test_candlepin_concurrent_subscription_attach.py</code>
Unit test for concurrent subscription by subscription-manager register and attach, using 2, 4, 6, 8, 10 clients separately;

<h5>IV.  Output</h5>

Running each of the three test cases would generate some csv data files. Later on the ultimate output would be charts directly.

Take running concurrent system subscription by activation-key using 10 clients, with 5,000 total iterations as example. All output files are:
1) raw-ak-concurrent.csv
This raw data file would record all 5,000 timing data points. Each client would be evenly distributed 500 iterations; therefore each would product 500 timings.
Example output chart:
https://docs.google.com/spreadsheets/d/11MrlwSYXWBW17LCZwBnOoOQYinRAoC_GC4dfbf05G38/pubchart?oid=488926973&format=interactive

2) stat-ak-concurrent.csv
This statistics data file would produce stat calculation results, as implemented in <code> robottelo/test.py </code>. 
Example output chart:
https://docs.google.com/spreadsheets/d/11MrlwSYXWBW17LCZwBnOoOQYinRAoC_GC4dfbf05G38/pubchart?oid=1467003845&format=interactive

Similarly, running tests on deletion or subscription by register and attach would also product the above two files, with name changed to del/att.
