### PR TITLE
Quick fix for Location entity possible name length boundaries

### DIFF
--- a/tests/foreman/api/test_location.py
+++ b/tests/foreman/api/test_location.py
@@ -19,11 +19,11 @@ class LocationTestCase(APITestCase):
     # TODO Add coverage for media, smart_proxy, realms once they implemented
 
     @data(
-        gen_string('alphanumeric', randint(1, 255)),
-        gen_string('alpha', randint(1, 255)),
+        gen_string('alphanumeric', randint(1, 246)),
+        gen_string('alpha', randint(1, 246)),
         gen_string('cjk', randint(1, 85)),
-        gen_string('latin1', randint(1, 255)),
-        gen_string('numeric', randint(1, 255)),
+        gen_string('latin1', randint(1, 246)),
+        gen_string('numeric', randint(1, 246)),
         gen_string('utf8', randint(1, 85)),
     )
     def test_create_location_with_different_names(self, name):

--- a/tests/foreman/cli/test_location.py
+++ b/tests/foreman/cli/test_location.py
@@ -27,15 +27,15 @@ class TestLocation(CLITestCase):
     # TODO Add coverage for smart_proxy and realm once we can create ssh tunnel
 
     @data(
-        gen_string('alphanumeric', randint(1, 255)),
-        gen_string('alpha', randint(1, 255)),
+        gen_string('alphanumeric', randint(1, 246)),
+        gen_string('alpha', randint(1, 246)),
         gen_string('cjk', randint(1, 85)),
-        gen_string('latin1', randint(1, 255)),
-        gen_string('numeric', randint(1, 255)),
+        gen_string('latin1', randint(1, 246)),
+        gen_string('numeric', randint(1, 246)),
         gen_string('utf8', randint(1, 85)),
         gen_string('html', randint(1, 85)),
     )
-    def test_create_location_with_different_names(self, name):
+    def test_create_location_with_different_names_positive(self, name):
         """@Test: Try to create location using different value types as a name
 
         @Feature: Location
@@ -380,11 +380,11 @@ class TestLocation(CLITestCase):
             make_location({'users': gen_string('utf8', 80)})
 
     @data(
-        gen_string('alphanumeric', randint(1, 255)),
-        gen_string('alpha', randint(1, 255)),
+        gen_string('alphanumeric', randint(1, 246)),
+        gen_string('alpha', randint(1, 246)),
         gen_string('cjk', randint(1, 85)),
-        gen_string('latin1', randint(1, 255)),
-        gen_string('numeric', randint(1, 255)),
+        gen_string('latin1', randint(1, 246)),
+        gen_string('numeric', randint(1, 246)),
         gen_string('utf8', randint(1, 85)),
         gen_string('html', randint(1, 85)),
     )
@@ -591,11 +591,11 @@ class TestLocation(CLITestCase):
         self.assertGreater(len(result.stderr), 0)
 
     @data(
-        gen_string('alphanumeric', randint(1, 255)),
-        gen_string('alpha', randint(1, 255)),
+        gen_string('alphanumeric', randint(1, 246)),
+        gen_string('alpha', randint(1, 246)),
         gen_string('cjk', randint(1, 85)),
-        gen_string('latin1', randint(1, 255)),
-        gen_string('numeric', randint(1, 255)),
+        gen_string('latin1', randint(1, 246)),
+        gen_string('numeric', randint(1, 246)),
         gen_string('utf8', randint(1, 85)),
         gen_string('html', randint(1, 85)),
     )


### PR DESCRIPTION
Closes #2525

```
nosetests tests/foreman/cli/test_location.py -m test_create_location_with_different_names_positive
.......
----------------------------------------------------------------------
Ran 7 tests in 59.121s

OK
```