### PR TITLE
Verify Product rename to original name

### DIFF
--- a/tests/foreman/api/test_product.py
+++ b/tests/foreman/api/test_product.py
@@ -12,7 +12,7 @@ from random import randint
 from robottelo.common import manifests
 from robottelo.common.constants import PRDS, REPOSET, VALID_GPG_KEY_FILE
 from robottelo.common.decorators import data, run_only_on
-from robottelo.common.helpers import read_data_file
+from robottelo.common.helpers import read_data_file, generate_strings_list
 from robottelo.test import APITestCase
 
 
@@ -106,6 +106,23 @@ class ProductUpdateTestCase(APITestCase):
         setattr(self.product, attrs[0], attrs[1])
         self.product = self.product.update()
         self.assertEqual(getattr(self.product, attrs[0]), attrs[1])
+
+    @data(*generate_strings_list())
+    def test_positive_update_2(self, new_name):
+        """@Test: Rename Product back to original name
+
+        @Feature: Product
+
+        @Assert: Product Renamed to original
+
+        """
+        old_name = self.product.name
+        # Update new product name
+        self.product.name = new_name
+        self.assertEqual(self.product.name, self.product.update(['name']).name)
+        # Rename product to old name and verify
+        self.product.name = old_name
+        self.assertEqual(self.product.name, self.product.update(['name']).name)
 
 
 @run_only_on('sat')

--- a/tests/foreman/cli/test_product.py
+++ b/tests/foreman/cli/test_product.py
@@ -14,7 +14,7 @@ from robottelo.cli.factory import (
 )
 from robottelo.cli.product import Product
 from robottelo.common.decorators import data, run_only_on
-from robottelo.common.helpers import bz_bug_is_open
+from robottelo.common.helpers import bz_bug_is_open, generate_strings_list
 from robottelo.test import CLITestCase
 
 
@@ -352,6 +352,48 @@ class TestProduct(CLITestCase):
             result.stdout['sync-plan-id'],
             first_sync_plan['id'],
         )
+
+    @run_only_on('sat')
+    @data(*generate_strings_list())
+    def test_positive_update_4(self, prod_name):
+        """@Test: Rename Product back to original name
+
+        @Feature: Product
+
+        @Assert: Product Renamed to original
+
+        """
+        prod = make_product({
+            u'name': prod_name,
+            u'organization-id': self.org['id'],
+        })
+        new_prod_name = gen_string('alpha', 8)
+        # Update the product name
+        Product.update({
+            u'id': prod['id'],
+            u'name': new_prod_name,
+        })
+        # Verify Updated
+        result = Product.info({
+            u'id': prod['id'],
+            u'organization-id': self.org['id'],
+        })
+        self.assertEqual(result.return_code, 0)
+        self.assertEqual(len(result.stderr), 0)
+        self.assertEqual(result.stdout['name'], new_prod_name)
+        # Now, Rename product to original
+        Product.update({
+            u'id': prod['id'],
+            u'name': prod_name,
+        })
+        result = Product.info({
+            u'id': prod['id'],
+            u'organization-id': self.org['id'],
+        })
+        # Verify renamed back to Original name.
+        self.assertEqual(result.return_code, 0)
+        self.assertEqual(len(result.stderr), 0)
+        self.assertEqual(result.stdout['name'], prod_name)
 
     @run_only_on('sat')
     def test_positive_delete_1(self):

--- a/tests/foreman/ui/test_products.py
+++ b/tests/foreman/ui/test_products.py
@@ -156,6 +156,27 @@ class Products(UITestCase):
 
     @run_only_on('sat')
     @data(*generate_strings_list())
+    def test_positive_update_2(self, prd_name):
+        """@Test: Rename Product back to original name.
+
+        @Feature: Content Product - Positive Update
+
+        @Assert: Product Renamed to original.
+
+        """
+        new_prd_name = gen_string("alpha", 8)
+        with Session(self.browser) as session:
+            make_product(
+                session, org=self.org_name, loc=self.loc_name, name=prd_name)
+            self.assertIsNotNone(self.products.search(prd_name))
+            self.products.update(prd_name, new_name=new_prd_name)
+            self.assertIsNotNone(self.products.search(new_prd_name))
+            # Rename Product to original and verify
+            self.products.update(new_prd_name, new_name=prd_name)
+            self.assertIsNotNone(self.products.search(prd_name))
+
+    @run_only_on('sat')
+    @data(*generate_strings_list())
     def test_negative_update_1(self, prd_name):
         """@Test: Update Content Product with too long input parameters
 


### PR DESCRIPTION
The PR verifies the renaming product name to original name doesn't fails.
This includes changes in all CLI, API and UI product tests.

CLOSES issue #2515 .

Logs:
```
API:-
[root@jyejare robottelo]# nosetests -m test_positive_update_2 ./tests/foreman/api/test_product.py
......
----------------------------------------------------------------------
Ran 6 tests in 63.364s

OK
=============================================================================
UI:-
[root@jyejare robottelo]# nosetests -m test_positive_update_2 ./tests/foreman/ui/test_products.py
.......
----------------------------------------------------------------------
Ran 7 tests in 878.529s

OK
=============================================================================
CLI:
[root@jyejare robottelo]# nosetests -m test_positive_update_4 ./tests/foreman/cli/test_product.py
.......
----------------------------------------------------------------------
Ran 7 tests in 2222.636s

OK
=============================================================================
```