### PR TITLE
API: Add coverage for content view filter delete & update

### DIFF
--- a/tests/foreman/api/test_contentviewfilter.py
+++ b/tests/foreman/api/test_contentviewfilter.py
@@ -317,3 +317,275 @@ class ContentViewFilterTestCase(APITestCase):
                 content_view=self.content_view,
                 repository=[gen_integer(10000, 99999)],
             ).create()
+
+    def test_delete_cvf_by_id(self):
+        """@Test: Delete content view filter
+
+        @Assert: Content view filter was deleted
+
+        @Feature: Content View Filter - Delete
+
+        """
+        cvf = entities.RPMContentViewFilter(
+            content_view=self.content_view,
+        ).create()
+        cvf.delete()
+        with self.assertRaises(HTTPError):
+            cvf.read()
+
+    @data(*_positive_data())
+    def test_update_cvf_with_new_name(self, new_name):
+        """@Test: Update content view filter with new name
+
+        @Assert: Content view filter updated successfully and name was changed
+
+        @Feature: Content View Filter - Update
+
+        """
+        cvf = entities.RPMContentViewFilter(
+            content_view=self.content_view,
+        ).create()
+        cvf.name = new_name
+        self.assertEqual(cvf.update(['name']).name, new_name)
+
+    @data(*_positive_data())
+    def test_update_cvf_with_new_description(self, new_description):
+        """@Test: Update content view filter with new description
+
+        @Assert: Content view filter updated successfully and description was
+        changed
+
+        @Feature: Content View Filter - Update
+
+        """
+        cvf = entities.RPMContentViewFilter(
+            content_view=self.content_view,
+            description=gen_string('alpha'),
+        ).create()
+        cvf.description = new_description
+        self.assertEqual(
+            cvf.update(['description']).description,
+            new_description
+        )
+
+    @data(True, False)
+    def test_update_cvf_with_new_inclusion(self, new_inclusion):
+        """Test: Update content view filter with new inclusion value
+
+        @Assert: Content view filter updated successfully and inclusion value
+        was changed
+
+        @Feature: Content View Filter - Update
+
+        """
+        cvf = entities.RPMContentViewFilter(
+            content_view=self.content_view,
+            inclusion=not new_inclusion,
+        ).create()
+        cvf.inclusion = new_inclusion
+        self.assertEqual(cvf.update(['inclusion']).inclusion, new_inclusion)
+
+    def test_update_cvf_with_new_repo(self):
+        """Test: Update content view filter with new repository
+
+        @Assert: Content view filter updated successfully and has new
+        repository assigned
+
+        @Feature: Content View Filter - Update
+
+        """
+        cvf = entities.RPMContentViewFilter(
+            content_view=self.content_view,
+            inclusion=True,
+            repository=[self.repo],
+        ).create()
+        new_repo = entities.Repository(product=self.product).create()
+        new_repo.sync()
+        self.content_view.set_repository_ids(repo_ids=[new_repo.id])
+        cvf.repository = [new_repo]
+        cvf = cvf.update(['repository'])
+        self.assertEqual(len(cvf.repository), 1)
+        self.assertEqual(cvf.repository[0].id, new_repo.id)
+
+    def test_update_cvf_with_multiple_repos(self):
+        """Test: Update content view filter with multiple repositories
+
+        @Assert: Content view filter updated successfully and has new
+        repositories assigned
+
+        @Feature: Content View Filter - Update
+
+        """
+        cvf = entities.RPMContentViewFilter(
+            content_view=self.content_view,
+            inclusion=True,
+            repository=[self.repo],
+        ).create()
+        repos = [
+            entities.Repository(product=self.product).create()
+            for _
+            in range(randint(3, 5))
+        ]
+        for repo in repos:
+            repo.sync()
+        self.content_view.set_repository_ids(
+            repo_ids=[repo.id for repo in repos],
+        )
+        cvf.repository = repos
+        cvf = cvf.update(['repository'])
+        self.assertEqual(
+            set([repo.id for repo in cvf.repository]),
+            set([repo.id for repo in repos])
+        )
+
+    @data(True, False)
+    def test_update_cvf_original_packages(self, new_original_packages):
+        """Test: Update content view filter with new 'original packages' option
+        value
+
+        @Assert: Content view filter updated successfully and 'original
+        packages' value was changed
+
+        @Feature: Content View Filter - Update
+
+        """
+        cvf = entities.RPMContentViewFilter(
+            content_view=self.content_view,
+            inclusion=True,
+            repository=[self.repo],
+            original_packages=not new_original_packages,
+        ).create()
+        cvf.original_packages = new_original_packages
+        self.assertEqual(
+            cvf.update(['original_packages']).original_packages,
+            new_original_packages
+        )
+
+    def test_update_cvf_with_repo_with_docker(self):
+        """Test: Update existing content view filter which has yum repository
+        assigned with new docker repository
+
+        @Assert: Content view filter was updated successfully and has both
+        repositories assigned (yum and docker)
+
+        @Feature: Content View Filter - Update
+
+        """
+        cvf = entities.RPMContentViewFilter(
+            content_view=self.content_view,
+            inclusion=True,
+            repository=[self.repo],
+        ).create()
+        docker_repository = entities.Repository(
+            content_type='docker',
+            docker_upstream_name='busybox',
+            product=self.product.id,
+            url=DOCKER_REGISTRY_HUB,
+        ).create()
+        self.content_view.set_repository_ids(
+            repo_ids=[self.repo.id, docker_repository.id]
+        )
+        cvf.repository = [self.repo, docker_repository]
+        cvf = cvf.update(['repository'])
+        self.assertEqual(len(cvf.repository), 2)
+        for repo in cvf.repository:
+            self.assertIn(repo.id, [self.repo.id, docker_repository.id])
+
+    @data(
+        '',
+        ' ',
+        gen_string('alphanumeric', 300),
+        gen_string('alpha', 300),
+        gen_string('cjk', 300),
+        gen_string('latin1', 300),
+        gen_string('numeric', 300),
+        gen_string('utf8', 300),
+        gen_string('html', 300),
+    )
+    def test_update_cvf_with_different_names_negative(self, new_name):
+        """@Test: Try to update content view filter using invalid names only
+
+        @Assert: Content view filter was not updated
+
+        @Feature: Content View Filter - Update
+
+        """
+        cvf = entities.RPMContentViewFilter(
+            content_view=self.content_view,
+        ).create()
+        cvf.name = new_name
+        with self.assertRaises(HTTPError):
+            cvf.update(['name'])
+
+    def test_update_cvf_with_already_used_name_negative(self):
+        """@Test: Try to update content view filter's name to already used one
+
+        @Assert: Content view filter was not updated
+
+        @Feature: Content View Filter - Update
+
+        """
+        name = gen_string('alpha', 8)
+        entities.RPMContentViewFilter(
+            content_view=self.content_view,
+            name=name,
+        ).create()
+        cvf = entities.RPMContentViewFilter(
+            content_view=self.content_view,
+        ).create()
+        cvf.name = name
+        with self.assertRaises(HTTPError):
+            cvf.update(['name'])
+
+    def test_update_cvf_with_cv_by_id_negative(self):
+        """@Test: Try to update content view filter using incorrect content
+        view ID
+
+        @Assert: Content view filter was not updated
+
+        @Feature: Content View Filter - Update
+
+        """
+        cvf = entities.RPMContentViewFilter(
+            content_view=self.content_view,
+        ).create()
+        cvf.content_view.id = gen_integer(10000, 99999)
+        with self.assertRaises(HTTPError):
+            cvf.update(['content_view'])
+
+    def test_update_cvf_with_repo_by_id_negative(self):
+        """@Test: Try to update content view filter using incorrect repository
+        ID
+
+        @Assert: Content view filter was not updated
+
+        @Feature: Content View Filter - Update
+
+        """
+        cvf = entities.RPMContentViewFilter(
+            content_view=self.content_view,
+            repository=[self.repo],
+        ).create()
+        cvf.repository[0].id = gen_integer(10000, 99999)
+        with self.assertRaises(HTTPError):
+            cvf.update(['repository'])
+
+    def test_update_cvf_with_new_repo_negative(self):
+        """Test: Try to update content view filter with new repository which
+        doesn't belong to filter's content view
+
+        @Assert: Content view filter was not updated
+
+        @Feature: Content View Filter - Update
+
+        """
+        cvf = entities.RPMContentViewFilter(
+            content_view=self.content_view,
+            inclusion=True,
+            repository=[self.repo],
+        ).create()
+        new_repo = entities.Repository(product=self.product).create()
+        new_repo.sync()
+        cvf.repository = [new_repo]
+        with self.assertRaises(HTTPError):
+            cvf.update(['repository'])


### PR DESCRIPTION
Added coverage for content view filter delete & update
Closes #2463
Closes #2464
Tests results:
```
nosetests tests/foreman/api/test_contentviewfilter.py -m test_update
..................................
----------------------------------------------------------------------
Ran 34 tests in 563.480s

OK
```
```
nosetests tests/foreman/api/test_contentviewfilter.py -m test_delete
.
----------------------------------------------------------------------
Ran 1 test in 44.494s

OK
```
```[DO NOT MERGE]``` tag until SatelliteQE/nailgun#138 gets merged and released.