### PR TITLE
Use NailGun 0.18.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import find_packages, setup
 REQUIRES = [
     'ddt',
     'fauxfactory',
-    'nailgun==0.17.0',
+    'nailgun==0.18.0',
     'paramiko',
     'python-bugzilla',
     'requests',


### PR DESCRIPTION
Test results:

    $ make test-foreman-api-threaded
    python -m cProfile -o test-foreman-api-threaded.pstats $(which nosetests) --logging-filter=nailgun,robottelo --with-xunit --xunit-file=foreman-results.xml tests/foreman/api\
        --processes=-1 --process-timeout=300
    ...SSS.....................S....................................E..E....SSSSSSSSSSSSSSSSSSSSSSS.S.......................................................SSSSSSSSSSSSSSSSSSSSSSSSS..............SSSS.SSSSSSSSS............S.SSSSSSS.SSSSSS................................................S.........SSSSSSSSSSSSS...S...S...S..SSSSSSSSS..........S........SSSSSSSS......S...S.....S...........................................................................SS..............................................................................E.....S................................................................SSSSSSSS.SSSSSS.S..SSS.S...SSSSSSSSSSSSSSSSSSSSSSSSSSSSS...................S...S............................................................E....S................E.......................EEEEEEEE.E................SSSSSSSS...SSSSSSSSSSSSSSSSSSSSSSSSSSSSSS.E.ESS.SSSSSSSSSSSSSSSSSSSSSSSS..............................................
    […]
    Ran 922 tests in 1342.583s

    FAILED (SKIP=236, errors=16)

All test failures were either due to:

* Differences in RHCI
* Database inconsistency issues (they arise when running threaded tests).
* Long-running issues such as Robottelo's `fetch_reposet_id` function.