### PR TITLE
Add click helper method for UI

### DIFF
--- a/robottelo/ui/activationkey.py
+++ b/robottelo/ui/activationkey.py
@@ -8,80 +8,62 @@ from selenium.webdriver.support.select import Select
 
 
 class ActivationKey(Base):
-    """
-    Manipulates Activation keys from UI
-    """
+    """Manipulates Activation keys from UI."""
 
     def set_limit(self, limit):
-        """
-        Sets the finite limit of activation key
-        """
-        limit_checkbox_locator = locators["ak.usage_limit_checkbox"]
-        if limit == 'Unlimited':
-            self.find_element(limit_checkbox_locator).click()
-        else:
-            self.find_element(limit_checkbox_locator).click()
-            self.field_update("ak.usage_limit", limit)
+        """Sets the finite limit of activation key."""
+        self.click(locators['ak.usage_limit_checkbox'])
+        if limit != 'Unlimited':
+            self.field_update('ak.usage_limit', limit)
 
     def create(self, name, env, limit=None, description=None,
                content_view=None):
         """Creates new activation key from UI."""
-
         self.wait_for_ajax()
-        self.wait_until_element(locators["ak.new"]).click()
+        self.click(locators['ak.new'])
 
-        if self.wait_until_element(common_locators["name"]):
-            self.text_field_update(common_locators["name"], name)
+        if self.wait_until_element(common_locators['name']):
+            self.text_field_update(common_locators['name'], name)
             self.wait_for_ajax()
             if limit:
                 self.set_limit(limit)
                 self.wait_for_ajax()
             if description:
-                self.text_field_update(common_locators
-                                       ["description"], description)
+                self.text_field_update(
+                    common_locators['description'], description)
             if env:
-                strategy = locators["ak.env"][0]
-                value = locators["ak.env"][1]
-                element = self.wait_until_element((strategy, value % env))
-                if element:
-                    element.click()
-                    self.wait_for_ajax()
+                strategy, value = locators['ak.env']
+                self.click((strategy, value % env))
             else:
                 raise UIError(
                     'Could not create new activation key "{0}", without env'
                     .format(name)
                 )
             if content_view:
-                Select(self.find_element
-                       (locators["ak.content_view"]
-                        )).select_by_visible_text(content_view)
+                Select(
+                    self.find_element(locators['ak.content_view'])
+                ).select_by_visible_text(content_view)
             else:
-                Select(self.find_element
-                       (locators["ak.content_view"]
-                        )).select_by_value("0")
-            self.wait_until_element(common_locators["create"]).click()
-            self.wait_for_ajax()
+                Select(
+                    self.find_element(locators['ak.content_view'])
+                ).select_by_value('0')
+            self.click(common_locators['create'])
         else:
             raise UIError(
                 'Could not create new activation key "{0}"'.format(name)
             )
 
     def search_key(self, element_name):
-        """
-        Uses the search box to locate an element from a list of elements.
-        """
-
+        """Uses the search box to locate an element from a list of elements."""
         element = None
-
-        searchbox = self.wait_until_element(common_locators["kt_search"])
+        searchbox = self.wait_until_element(common_locators['kt_search'])
 
         if searchbox:
             searchbox.clear()
             searchbox.send_keys(escape_search(element_name))
             self.wait_for_ajax()
-            self.find_element(common_locators["kt_search_button"]).click()
-            strategy = locators["ak.ak_name"][0]
-            value = locators["ak.ak_name"][1]
+            self.click(common_locators['kt_search_button'])
+            strategy, value = locators['ak.ak_name']
             element = self.wait_until_element((strategy, value % element_name))
         return element
 
@@ -95,8 +77,7 @@ class ActivationKey(Base):
         self.wait_for_ajax()
         if self.wait_until_element(tab_locators['ak.subscriptions']) is None:
             raise UINoSuchElementError('Could not find Subscriptions tab')
-        self.find_element(tab_locators['ak.subscriptions']).click()
-        self.wait_for_ajax()
+        self.click(tab_locators['ak.subscriptions'])
         searchbox = self.wait_until_element(
             locators['ak.subscriptions.search'])
         if searchbox is None:
@@ -104,8 +85,7 @@ class ActivationKey(Base):
                 'Could not find Subscriptions search box')
         searchbox.clear()
         searchbox.send_keys(escape_search(subscription_name))
-        self.find_element(locators['ak.subscriptions.search_button']).click()
-        self.wait_for_ajax()
+        self.click(locators['ak.subscriptions.search_button'])
         strategy, value = locators['ak.get_subscription_name']
         element = self.wait_until_element(
             (strategy, value % subscription_name))
@@ -113,145 +93,104 @@ class ActivationKey(Base):
 
     def update(self, name, new_name=None, description=None,
                limit=None, content_view=None, env=None):
-        """
-        Updates an existing activation key
-        """
-
+        """Updates an existing activation key."""
         element = self.search_key(name)
 
         if element:
             element.click()
             self.wait_for_ajax()
             if new_name:
-                self.edit_entity(locators["ak.edit_name"],
-                                 locators["ak.edit_name_text"],
-                                 new_name, locators["ak.save_name"])
+                self.edit_entity(locators['ak.edit_name'],
+                                 locators['ak.edit_name_text'],
+                                 new_name, locators['ak.save_name'])
             if description:
-                self.edit_entity(locators["ak.edit_description"],
-                                 locators["ak.edit_description_text"],
-                                 description, locators["ak.save_description"])
+                self.edit_entity(locators['ak.edit_description'],
+                                 locators['ak.edit_description_text'],
+                                 description, locators['ak.save_description'])
             if limit:
-                self.find_element(locators["ak.edit_limit"]).click()
+                self.click(locators['ak.edit_limit'])
                 self.set_limit(limit)
-                if self.wait_until_element(locators["ak.save_limit"]
-                                           ).is_enabled():
-                    self.find_element(locators["ak.save_limit"]).click()
+                if self.wait_until_element(
+                        locators['ak.save_limit']).is_enabled():
+                    self.click(locators['ak.save_limit'])
                 else:
                     raise ValueError(
-                        "Please update content host "
-                        "limit with valid integer value")
+                        'Please update content host limit with valid integer '
+                        'value'
+                    )
             if content_view:
                 if env:
-                    strategy = locators["ak.env"][0]
-                    value = locators["ak.env"][1]
-                    element = self.wait_until_element((strategy, value % env))
-                    if element:
-                        element.click()
-                        self.wait_for_ajax()
-                    else:
-                        raise UIError(
-                            'Couldn not find the given env "{0}"'.format(env)
-                        )
+                    strategy, value = locators['ak.env']
+                    self.click((strategy, value % env))
                 # We need to select the CV, if we update the env and in this,
                 # case edit button disappears, but when we update only CV, then
                 # edit button appears; Following 'If' is just solving this
                 # purpose and hence no else required here
-                if self.wait_until_element(locators["ak.edit_content_view"]):
-                    self.find_element(locators["ak.edit_content_view"]).click()
-                    self.wait_for_ajax()
-                Select(self.find_element
-                       (locators["ak.edit_content_view_select"]
-                        )).select_by_visible_text(content_view)
-                self.find_element(locators["ak.save_cv"]).click()
-                self.wait_for_ajax()
+                if self.wait_until_element(locators['ak.edit_content_view']):
+                    self.click(locators['ak.edit_content_view'])
+                Select(
+                    self.find_element(locators['ak.edit_content_view_select'])
+                ).select_by_visible_text(content_view)
+                self.click(locators['ak.save_cv'])
         else:
             raise UIError(
                 'Could not update the activation key "{0}"'.format(name)
             )
 
     def delete(self, name, really):
-        """
-        Deletes an existing activation key
-        """
-
+        """Deletes an existing activation key."""
         element = self.search_key(name)
 
         if element:
             element.click()
             self.wait_for_ajax()
-            self.wait_until_element(locators["ak.remove"]).click()
-            self.wait_for_ajax()
+            self.click(locators['ak.remove'])
             if really:
-                self.wait_until_element(common_locators["confirm_remove"]
-                                        ).click()
+                self.click(common_locators['confirm_remove'])
             else:
-                self.wait_until_element(locators["ak.cancel"]).click()
+                self.click(locators['ak.cancel'])
 
     def associate_product(self, name, products):
-        """
-        associate an existing product with activation key
-        """
-
+        """Associate an existing product with activation key."""
         element = self.search_key(name)
 
-        if element:
-            element.click()
-            self.wait_for_ajax()
-            self.wait_until_element(tab_locators["ak.subscriptions"]).click()
-            self.wait_until_element(tab_locators
-                                    ["ak.subscriptions_add"]).click()
-            self.wait_for_ajax()
-            strategy, value = locators["ak.select_subscription"]
-            for product in products:
-                element = self.wait_until_element((strategy, value % product))
-                if element:
-                    element.click()
-                    self.wait_for_ajax()
-                else:
-                    raise UIError(
-                        'Could not find the product "{0}" subscription'
-                        .format(product)
-                    )
-            self.wait_until_element(locators
-                                    ["ak.add_selected_subscription"]).click()
-        else:
+        if not element:
             raise UIError(
                 'Could not find the selected activation key "{0}"'.format(name)
             )
 
+        element.click()
+        self.wait_for_ajax()
+        self.click(tab_locators['ak.subscriptions'])
+        self.click(tab_locators['ak.subscriptions_add'])
+        strategy, value = locators['ak.select_subscription']
+        for product in products:
+            self.click((strategy, value % product))
+        self.click(locators['ak.add_selected_subscription'])
+
     def enable_repos(self, name, repos, enable=True):
         """Enables repository via product_content tab of the activation_key."""
-
         element = self.search_key(name)
-        strategy, value = locators["ak.prd_content.edit_repo"]
-        strategy1, value1 = locators["ak.prd_content.select_repo"]
+        strategy, value = locators['ak.prd_content.edit_repo']
+        strategy1, value1 = locators['ak.prd_content.select_repo']
         if element is None:
             raise UINoSuchElementError(
                 "Couldn't find the selected activation key {0}".format(name))
         element.click()
         self.wait_for_ajax()
-        self.wait_until_element(tab_locators["ak.tab_prd_content"]).click()
-        self.wait_for_ajax()
+        self.click(tab_locators['ak.tab_prd_content'])
         for repo in repos:
-            repo_edit = self.wait_until_element((strategy, value % repo))
-            if repo_edit is None:
-                raise UIError('Could not find the repo: {0}'.format(repo))
-            repo_edit.click()
-            self.wait_for_ajax()
+            self.click((strategy, value % repo))
             repo_select = self.wait_until_element((strategy1, value1 % repo))
             if enable:
-                Select(repo_select).select_by_visible_text("Override to Yes")
+                Select(repo_select).select_by_visible_text('Override to Yes')
             else:
-                Select(repo_select).select_by_visible_text("Override to No")
-            self.wait_until_element(common_locators['save']).click()
-            self.wait_for_ajax(timeout=60)
+                Select(repo_select).select_by_visible_text('Override to No')
+            self.click(common_locators['save'], timeout=60)
             # FIXME: check for the success message
 
     def get_attribute(self, name, locator):
-        """
-        Get the attribute of selected locator
-        """
-
+        """Get the attribute of selected locator."""
         element = self.search_key(name)
 
         if element:
@@ -270,48 +209,27 @@ class ActivationKey(Base):
             )
 
     def add_host_collection(self, name, host_collection_name):
-        """
-        Associate an existing Host Collection with Activation Key
-        """
-
+        """Associate an existing Host Collection with Activation Key."""
         # find activation key
         activation_key = self.search_key(name)
         if activation_key:
             activation_key.click()
             self.wait_for_ajax()
-
-            self.wait_until_element(
-                tab_locators["ak.host_collections"]).click()
-            self.wait_for_ajax()
-
-            self.wait_until_element(
-                tab_locators["ak.host_collections.add"]).click()
-            self.wait_for_ajax()
+            self.click(tab_locators['ak.host_collections'])
+            self.click(tab_locators['ak.host_collections.add'])
 
             # select host collection
-            strategy, value = tab_locators["ak.host_collections.add.select"]
-            host_collection = self.wait_until_element((
-                strategy, value % host_collection_name))
-            if host_collection:
-                host_collection.click()
+            strategy, value = tab_locators['ak.host_collections.add.select']
+            self.click((strategy, value % host_collection_name))
 
-                # add host collection
-                add_btn = self.wait_until_element(
-                    tab_locators["ak.host_collections.add.add_selected"])
-                add_btn.click()
-                self.wait_for_ajax()
-            else:
-                raise UINoSuchElementError("Couldn't find host collection '%s'"
-                                           % host_collection_name)
+            # add host collection
+            self.click(tab_locators['ak.host_collections.add.add_selected'])
         else:
-            raise UINoSuchElementError("Couldn't find activation key '%s'" %
-                                       name)
+            raise UINoSuchElementError(
+                "Couldn't find activation key '{}'".format(name))
 
     def fetch_associated_content_host(self, name):
-        """
-        Fetch associated content host from selected activation key
-        """
-
+        """Fetch associated content host from selected activation key."""
         # find activation key
         activation_key = self.search_key(name)
         if not activation_key:
@@ -319,12 +237,10 @@ class ActivationKey(Base):
                 'Could not find activation key {0}'.format(name))
         activation_key.click()
         self.wait_for_ajax()
-        self.wait_until_element(tab_locators["ak.associations"]).click()
-        self.wait_for_ajax()
-        self.wait_until_element(locators["ak.content_hosts"]).click()
-        self.wait_for_ajax()
-        if self.wait_until_element(locators["ak.content_host_name"]):
-            result = self.find_element(locators["ak.content_host_name"]).text
+        self.click(tab_locators['ak.associations'])
+        self.click(locators['ak.content_hosts'])
+        if self.wait_until_element(locators['ak.content_host_name']):
+            result = self.find_element(locators['ak.content_host_name']).text
             return result
         else:
             raise UINoSuchElementError(
@@ -332,7 +248,6 @@ class ActivationKey(Base):
 
     def copy(self, name, new_name=None):
         """Copies an existing activation key"""
-
         element = self.search_key(name)
 
         if element and new_name:

--- a/robottelo/ui/base.py
+++ b/robottelo/ui/base.py
@@ -28,16 +28,12 @@ class UIPageSubmitionFailed(Exception):
 
 
 class Base(object):
-    """
-    Base class for UI
-    """
+    """Base class for UI"""
 
     logger = LOGGER
 
     def __init__(self, browser):
-        """
-        Sets up the browser object.
-        """
+        """Sets up the browser object."""
         self.browser = browser
 
     def find_element(self, locator):
@@ -70,17 +66,17 @@ class Base(object):
                       katello=None, timeout=None):
         """Uses the search box to locate an element from a list of elements."""
 
-        search_key = search_key or "name"
+        search_key = search_key or 'name'
         element = None
 
         if katello:
-            searchbox = self.wait_until_element(common_locators["kt_search"])
+            searchbox = self.wait_until_element(common_locators['kt_search'])
             search_button = self.wait_until_element(
-                common_locators["kt_search_button"])
+                common_locators['kt_search_button'])
         else:
-            searchbox = self.wait_until_element(common_locators["search"])
+            searchbox = self.wait_until_element(common_locators['search'])
             search_button = self.wait_until_element(
-                common_locators["search_button"])
+                common_locators['search_button'])
 
         # Do not proceed if searchbox is not found
         if searchbox is None:
@@ -122,40 +118,28 @@ class Base(object):
             alert.dismiss()
 
     def select_deselect_entity(self, filter_key, loc, entity_list):
-        """
-        Function to select and deselect entity like OS, Partition Table, Arch
-        from selection list or by selecting relevant checkbox.
+        """Function to select and deselect entity like OS, Partition Table,
+        Arch from selection list or by selecting relevant checkbox.
+
         """
         for entity in entity_list:
-            strategy, value = common_locators["filter"]
             # Scroll to top
             self.browser.execute_script('window.scroll(0, 0)')
+            strategy, value = common_locators['filter']
             txt_field = self.wait_until_element((strategy, value % filter_key))
             if txt_field:
                 txt_field.clear()
                 txt_field.send_keys(entity)
                 strategy, value = loc
-                select_element = self.wait_until_element((strategy,
-                                                          value % entity))
-                if select_element:
-                    select_element.click()
-                else:
-                    raise UINoSuchElementError(
-                        "Couldn't find element from selection list")
+                self.click((strategy, value % entity))
             else:
-                strategy1, value1 = common_locators["entity_checkbox"]
-                checkbox_element = self.wait_until_element((strategy1,
-                                                            value1 % entity))
-                if checkbox_element:
-                    checkbox_element.click()
-                else:
-                    raise UINoSuchElementError(
-                        "Couldn't find element from checkbox list.")
+                strategy, value = common_locators['entity_checkbox']
+                self.click((strategy, value % entity))
 
     def configure_entity(self, entity_list, filter_key, tab_locator=None,
                          new_entity_list=None, entity_select=True):
-        """
-        Configures entities like orgs, OS, ptable, Archs, Users, Usergroups.
+        """Configures entities like orgs, OS, ptable, Archs, Users, Usergroups.
+
         """
         if entity_list is None:
             entity_list = []
@@ -163,43 +147,33 @@ class Base(object):
             new_entity_list = []
         if entity_list:
             if tab_locator:
-                self.wait_until_element(tab_locator).click()
+                self.click(tab_locator)
             if entity_select:
-                entity_locator = common_locators["entity_select"]
+                entity_locator = common_locators['entity_select']
             else:
-                entity_locator = common_locators["entity_deselect"]
-            self.select_deselect_entity(filter_key,
-                                        entity_locator, entity_list)
+                entity_locator = common_locators['entity_deselect']
+            self.select_deselect_entity(
+                filter_key, entity_locator, entity_list)
         if new_entity_list:
             if tab_locator:
-                self.wait_until_element(tab_locator).click()
-            entity_locator = common_locators["entity_select"]
-            self.select_deselect_entity(filter_key,
-                                        entity_locator, new_entity_list)
+                self.click(tab_locator)
+            entity_locator = common_locators['entity_select']
+            self.select_deselect_entity(
+                filter_key, entity_locator, new_entity_list)
 
     def delete_entity(self, name, really, name_locator, del_locator,
                       drop_locator=None, search_key=None):
         """Delete an added entity, handles both with and without dropdown."""
         searched = self.search_entity(
             name, name_locator, search_key=search_key)
-        if searched:
-            if drop_locator:
-                strategy = drop_locator[0]
-                value = drop_locator[1]
-                dropdown = self.wait_until_element((strategy, value % name))
-                dropdown.click()
-            strategy1 = del_locator[0]
-            value1 = del_locator[1]
-            element = self.wait_until_element((strategy1, value1 % name))
-            if element is None:
-                raise UINoSuchElementError(
-                    u'Could not select the entity "{0}" for deletion.'
-                    .format(name)
-                )
-            element.click()
-            self.handle_alert(really)
-        else:
+        if not searched:
             raise UIError('Could not search the entity "{0}"'.format(name))
+        if drop_locator:
+            strategy, value = drop_locator
+            self.click((strategy, value % name))
+        strategy, value = del_locator
+        self.click((strategy, value % name))
+        self.handle_alert(really)
 
     def wait_until_element_exists(
             self, locator, timeout=12, poll_frequency=0.5):
@@ -256,8 +230,8 @@ class Base(object):
             return element
         except TimeoutException as err:
             self.logger.debug(
-                "%s: Timed out waiting for element '%s' to display or to be "
-                "clickable.",
+                '%s: Timed out waiting for element "%s" to display or to be '
+                'clickable.',
                 type(err).__name__,
                 locator[1]
             )
@@ -272,7 +246,7 @@ class Base(object):
         angular_active = False
 
         try:
-            jquery_active = driver.execute_script("return jQuery.active") > 0
+            jquery_active = driver.execute_script('return jQuery.active') > 0
         except WebDriverException:
             pass
 
@@ -290,14 +264,14 @@ class Base(object):
         WebDriverWait(
             self.browser, timeout, poll_frequency
         ).until(
-            self.ajax_complete, "Timeout waiting for page to load"
+            self.ajax_complete, 'Timeout waiting for page to load'
         )
 
     def scroll_page(self):
         """
         Scrolls page up
         """
-        self.browser.execute_script("scroll(350, 0);")
+        self.browser.execute_script('scroll(350, 0);')
 
     def scroll_right_pane(self):
         """
@@ -327,40 +301,31 @@ class Base(object):
         Function to set parameters for different
         entities like OS and Domain
         """
-        self.wait_until_element(common_locators["parameter_tab"]).click()
-        self.wait_until_element(common_locators["add_parameter"]).click()
-        if self.wait_until_element(common_locators["parameter_name"]):
-            pname = self.find_element(common_locators["parameter_name"])
+        self.click(common_locators['parameter_tab'])
+        self.click(common_locators['add_parameter'])
+        if self.wait_until_element(common_locators['parameter_name']):
+            pname = self.find_element(common_locators['parameter_name'])
             pname.send_keys(param_name)
-        if self.wait_until_element(common_locators["parameter_value"]):
-            pvalue = self.find_element(common_locators["parameter_value"])
+        if self.wait_until_element(common_locators['parameter_value']):
+            pvalue = self.find_element(common_locators['parameter_value'])
             pvalue.send_keys(param_value)
-        self.find_element(common_locators["submit"]).click()
-        self.wait_for_ajax()
+        self.click(common_locators['submit'])
 
     def remove_parameter(self, param_name):
+        """Function to remove parameters for different entities like OS and
+        Domain.
+
         """
-        Function to remove parameters for different
-        entities like OS and Domain
-        """
-        self.wait_until_element(common_locators["parameter_tab"]).click()
-        strategy = common_locators["parameter_remove"][0]
-        value = common_locators["parameter_remove"][1]
-        remove_element = self.wait_until_element((strategy,
-                                                  value % param_name))
-        if remove_element:
-            remove_element.click()
-        self.find_element(common_locators["submit"]).click()
+        self.click(common_locators['parameter_tab'])
+        strategy, value = common_locators['parameter_remove']
+        self.click((strategy, value % param_name))
+        self.click(common_locators['submit'])
 
     def edit_entity(self, edit_loc, edit_text_loc, entity_value, save_loc):
-        """
-        Function to edit the selected entity's  text and save it
-        """
-
-        self.wait_until_element(edit_loc).click()
+        """Function to edit the selected entity's  text and save it."""
+        self.click(edit_loc)
         self.text_field_update(edit_text_loc, entity_value)
-        self.wait_until_element(save_loc).click()
-        self.wait_for_ajax()
+        self.click(save_loc)
 
     def auto_complete_search(self, go_to_page, entity_locator, partial_name,
                              name, search_key):
@@ -377,24 +342,15 @@ class Base(object):
         """
         go_to_page()
         strategy1, value1 = entity_locator
-        searchbox = self.wait_until_element(common_locators["search"])
+        searchbox = self.wait_until_element(common_locators['search'])
         if searchbox is None:
-            raise UINoSuchElementError("Search box not found.")
+            raise UINoSuchElementError('Search box not found.')
         searchbox.clear()
         searchbox.send_keys(search_key + " = " + partial_name)
         self.wait_for_ajax()
-        strategy, value = common_locators["auto_search"]
-        element = self.wait_until_element((strategy, value % name))
-        if element is None:
-            raise UINoSuchElementError(
-                "Entity not found via auto search completion.")
-        element.click()
-        self.wait_for_ajax()
-        search_button = self.wait_until_element(
-            common_locators['search_button'])
-        if search_button is None:
-            raise UINoSuchElementError("Search button not found.")
-        search_button.click()
+        strategy, value = common_locators['auto_search']
+        self.click((strategy, value % name))
+        self.click(common_locators['search_button'])
         entity_elem = self.wait_until_element((strategy1, value1 % name))
         return entity_elem
 
@@ -414,14 +370,14 @@ class Base(object):
 
         """
         go_to_page()
-        strategy, value = common_locators['all_values']
         searched = self.search_entity(entity_name, entity_locator)
         if searched is None:
-            raise UINoSuchElementError("Entity not found via search.")
+            raise UINoSuchElementError('Entity not found via search.')
         searched.click()
-        self.wait_until_element(tab_locator).click()
-        selected = self.find_element((strategy,
-                                      value % context)).is_selected()
+        self.click(tab_locator)
+        strategy, value = common_locators['all_values']
+        selected = self.find_element(
+            (strategy, value % context)).is_selected()
         return selected
 
     def submit_and_validate(self, locator, validation=True):
@@ -433,10 +389,9 @@ class Base(object):
             set to False for the negative tests.
 
         """
-        self.wait_until_element(locator).click()
-        self.wait_for_ajax()
+        self.click(locator)
         if self.wait_until_element(locator) and validation:
-            raise UIPageSubmitionFailed("Page submission failed.")
+            raise UIPageSubmitionFailed('Page submission failed.')
 
     def is_element_enabled(self, locator):
         """Check whether UI element is enabled or disabled
@@ -463,3 +418,24 @@ class Base(object):
             return False
         self.wait_for_ajax()
         return element.is_displayed()
+
+    def click(self, locator, wait_for_ajax=True, timeout=30):
+        """Locate the element described by the ``locator`` and click on it.
+
+        :param locator: The locator that decribes the element.
+        :param wait_for_ajax: Flag that indicates if should wait for AJAX after
+            clicking on the element
+        :param timeout: The amount of time that wait_fox_ajax should wait. This
+            will have effect if ``wait_fox_ajax`` parameter is ``True``.
+        :raise: UINoSuchElementError if the element could not be found.
+
+        """
+        element = self.wait_until_element(locator)
+        if element is None:
+            raise UINoSuchElementError(
+                '{}: element with locator {} not found while trying to click.'
+                .format(type(self).__name__, locator)
+            )
+        element.click()
+        if wait_for_ajax:
+            self.wait_for_ajax(timeout)


### PR DESCRIPTION
The click method finds the element and then click on it. If the element
is not found then an exception is raised. This is intended to reduce the
amount of UI code needed to click on elements.

Refactor ui.base and ui.activationkey to use the new method to
illustrate how the click can save lines of code and provide better
logging if an element can not be found.

Bonus: Change double to single quote and some other code format
adjustments.