### PR TITLE
[DO NOT MERGE] Skip a bug due to BZ 1242017

### DIFF
--- a/tests/foreman/api/test_product.py
+++ b/tests/foreman/api/test_product.py
@@ -11,7 +11,7 @@ from nailgun import entities
 from random import randint
 from robottelo.common import manifests
 from robottelo.common.constants import PRDS, REPOSET, VALID_GPG_KEY_FILE
-from robottelo.common.decorators import data, run_only_on
+from robottelo.common.decorators import data, run_only_on, skip_if_bug_open
 from robottelo.common.helpers import read_data_file, generate_strings_list
 from robottelo.test import APITestCase
 
@@ -161,6 +161,7 @@ class RepositorySetsTestCase(APITestCase):
                 repo['substitutions']['releasever'] == '6Server')
         ][0])
 
+    @skip_if_bug_open('bugzilla', 1242017)
     def test_repositoryset_disable(self):
         """@Test: Disable repo from reposet
 


### PR DESCRIPTION
From the bug:

> This API call:
>
>     GET /katello/api/products/:product_id/repository_sets/:id/available_repositories
>
> ...intermittently triggers an HTTP 500 error. It appears that the API call
> causes Satellite to talk to the CDN, and when the CDN returns an "access
> forbidden" error Satellite is unable to handle that response.

Test results:

    $ nosetests tests/foreman/api/test_product.py:RepositorySetsTestCase -m test_repositoryset_disable
    S
    ----------------------------------------------------------------------
    Ran 1 test in 0.647s

    OK (SKIP=1)

Fix #2557. See: https://bugzilla.redhat.com/show_bug.cgi?id=1242017