### PR TITLE
Add properties.sample description

### DIFF
--- a/robottelo.properties.sample
+++ b/robottelo.properties.sample
@@ -72,3 +72,10 @@ driver=firefox
 # URL of the  exported data archive (typically a .tgz containing a bunch of CSV
 # files together with repo data)
 #export_tar.url=http://example.org/sat5_export_data.tgz
+
+# Section for performance tests parameters.
+[performance]
+# Control whether or not to time on hammer commands in robottelo/cli/base.py
+# Default set to be 0, i.e. no timing of performance is measured and thus no
+# interference to original robottelo tests.
+test.foreman.perf=0

--- a/robottelo/cli/base.py
+++ b/robottelo/cli/base.py
@@ -195,7 +195,7 @@ class Base(object):
         user, password = cls._get_username_password(user, password)
 
         # add time to measure hammer performance
-        perf_test = conf.properties['performance.test.foreman.perf']
+        perf_test = conf.properties.get('performance.test.foreman.perf', '0')
         cmd = u'LANG={0} {1} hammer -v -u {2} -p {3} {4} {5}'.format(
             conf.properties['main.locale'],
             u'time -p' if perf_test == '1' else '',

--- a/robottelo/performance/candlepin.py
+++ b/robottelo/performance/candlepin.py
@@ -119,7 +119,7 @@ class Candlepin(object):
 
         if response.status_code != 204:
             LOGGER.error(
-                'Fail to delete {0} on thread-{}!'.format(uuid, thread_id))
+                'Fail to delete {0} on thread-{1}!'.format(uuid, thread_id))
             LOGGER.error(response.content)
             return
         LOGGER.info(

--- a/robottelo/test.py
+++ b/robottelo/test.py
@@ -396,7 +396,8 @@ class ConcurrentTestCase(TestCase):
     @classmethod
     def _set_testcase_parameters(cls, savepoint_name,
                                  raw_file_path, stat_file_path):
-        cls.savepoint = conf.properties[savepoint_name]
+        # note: set savepoint empty to continue test without restore
+        cls.savepoint = conf.properties.get(savepoint_name, '')
         cls.raw_file_name = conf.properties[raw_file_path]
         cls.stat_file_name = conf.properties[stat_file_path]
 
@@ -409,6 +410,9 @@ class ConcurrentTestCase(TestCase):
 
     def _restore_from_savepoint(self, savepoint):
         """Restore from savepoint"""
+        if savepoint == '':
+            self.logger.warning('No savepoint while continuing test!')
+            return
         self.logger.info('Reset db from /home/backup/{}'.format(savepoint))
         ssh.command('./reset-db.sh /home/backup/{}'.format(savepoint))
 

--- a/tests/foreman/performance/test_candlepin_concurrent_subscription_ak.py
+++ b/tests/foreman/performance/test_candlepin_concurrent_subscription_ak.py
@@ -33,7 +33,7 @@ class ConcurrentSubActivationKeyTestCase(ConcurrentTestCase):
 
         # Create activation key
         self.logger.info('Create activation key: ')
-        # (ak_id, ak_name) = self._create_activation_key()
+        (ak_id, ak_name) = self._create_activation_key()
 
         # Get subscription id
         self.logger.info('Get subscription id: ')
@@ -41,7 +41,7 @@ class ConcurrentSubActivationKeyTestCase(ConcurrentTestCase):
         self.sub_id = sub_id
 
         # Add activation key to subscription
-        # self._add_ak_to_subscription(ak_id, sub_id)
+        self._add_ak_to_subscription(ak_id, sub_id)
 
     def _create_activation_key(self):
         """Create a new activation key named ak-1"""

--- a/tests/foreman/performance/test_standard_prep.py
+++ b/tests/foreman/performance/test_standard_prep.py
@@ -32,7 +32,7 @@ class StandardPrepTestCase(TestCase):
             'performance.test.manifest.location']
 
         # parameters for uploading manifests
-        cls.manifest_file = conf.properties['performance.test.manifest.file']
+        cls.manifest_file = conf.properties.get('main.manifest.fake_url')
         cls.org_id = conf.properties['performance.test.organization.id']
 
         # parameters for changing cdn address


### PR DESCRIPTION
    Add properties.sample description
    
    Update config file. Fix a dict lookup.
    Fix missing format index in `robottelo.performance.candlepin.py`.
    
    Add new configuration section `performance` and option `test.foreman.perf`
    to the `robottelo.properties.sample` file.
    
    Use the `get` method in module `robottelo.cli.base` to avoid a "key not found"
    error.
    
    Use the `get` method in module `robottelo/test.py` to enable tests without
    resetting database.
    
    Read in manifest file entry to be existing one in
    `tests.foreman.performance.test_standard_prep`
    
    * For organization id, would automate in later p/r.
    * For product id, would automate in later p/r.
    * For constants, would reflect change in later p/r.