### PR TITLE
Add coverage for content view filter update in CLI

### DIFF
--- a/robottelo/cli/contentview.py
+++ b/robottelo/cli/contentview.py
@@ -142,30 +142,62 @@ class ContentView(Base):
 
         """
         cls.command_sub = 'filter create'
-
         if options is None:
             options = {}
+        return cls.execute(cls._construct_command(options))
 
+    @classmethod
+    def filter_update(cls, options):
+        """Update existing content view filter entity.
+
+        Usage::
+
+            hammer content-view filter update [OPTIONS]
+
+        Options::
+
+            --content-view CONTENT_VIEW_NAME    Content view name
+            --content-view-id CONTENT_VIEW_ID   Content view numeric identifier
+            --id ID                             filter identifier
+            --inclusion INCLUSION               Specifies if content should be
+                                                included or excluded, default:
+                                                inclusion=false (One of yes/no,
+                                                1/0, true/false)
+            --name NAME                         Name to search by
+            --new-name NEW_NAME                 new name for the filter
+            --organization ORGANIZATION_NAME    Organization name to search by
+            --organization-id ORGANIZATION_ID   Organization ID
+            --organization-label ORGANIZATION_LABEL   Organization label to
+                                                      search by
+            --original-packages ORIGINAL_PACKAGES     Add all packages without
+                                                      Errata to the included/
+                                                      excluded list. (Package
+                                                      Filter only)
+            --repositories REPOSITORY_NAMES      Repository Name
+                                                 Comma separated list of values
+            --repository-ids REPOSITORY_IDS      Repository ID
+                                                 Comma separated list of values
+
+        """
+        cls.command_sub = 'filter update'
+        if options is None:
+            options = {}
         return cls.execute(cls._construct_command(options))
 
     @classmethod
     def filter_rule_create(cls, options):
         """Add new rule to content view filter."""
         cls.command_sub = 'filter rule create'
-
         if options is None:
             options = {}
-
         return cls.execute(cls._construct_command(options))
 
     @classmethod
     def version_list(cls, options):
         """Lists content-view's versions."""
         cls.command_sub = 'version list'
-
         if options is None:
             options = {}
-
         return cls.execute(
             cls._construct_command(options), output_format='csv')
 

--- a/robottelo/common/helpers.py
+++ b/robottelo/common/helpers.py
@@ -9,6 +9,7 @@ from fabric.api import execute, settings
 from fauxfactory import gen_string, gen_integer
 from nailgun import entities, entity_mixins
 from nailgun.config import ServerConfig
+from random import randint
 from robottelo.common import conf, ssh
 from robottelo.common.constants import VALID_GPG_KEY_FILE
 from robottelo.common.decorators import bz_bug_is_open
@@ -163,12 +164,13 @@ def valid_data_list():
     List of valid data for input testing.
     """
     return [
-        gen_string("alpha", 8),
-        gen_string("numeric", 8),
-        gen_string("alphanumeric", 8),
-        gen_string("utf8", 8),
-        gen_string("latin1", 8),
-        gen_string("html", 8)
+        gen_string('alphanumeric', randint(1, 255)),
+        gen_string('alpha', randint(1, 255)),
+        gen_string('cjk', randint(1, 85)),
+        gen_string('latin1', randint(1, 255)),
+        gen_string('numeric', randint(1, 255)),
+        gen_string('utf8', randint(1, 85)),
+        gen_string('html', randint(1, 85)),
     ]
 
 
@@ -177,14 +179,26 @@ def invalid_names_list():
     List of invalid names for input testing.
     """
     return [
-        gen_string("alpha", 300),
-        gen_string("numeric", 300),
-        gen_string("alphanumeric", 300),
-        gen_string("utf8", 300),
-        gen_string("latin1", 300),
-        gen_string("html", 300),
-        gen_string("alpha", 256)
+        gen_string('alphanumeric', 300),
+        gen_string('alpha', 300),
+        gen_string('cjk', 300),
+        gen_string('latin1', 300),
+        gen_string('numeric', 300),
+        gen_string('utf8', 300),
+        gen_string('html', 300),
     ]
+
+
+def invalid_values_list():
+    """List of invalid values for input testing which consists from invalid names
+    and few empty string examples. That method should be useful for CLI and API
+    tests primarily as we can pass such parameters to a server, but not in UI.
+    As we do not verify error messages, it is recommended to use current method
+    instead 'invalid_names_list' to have better coverage and prevent redundant
+    code.
+
+    """
+    return ['', ' ', '   '] + invalid_names_list()
 
 
 def generate_strings_list(len1=None, remove_str=None, bug_id=None):


### PR DESCRIPTION
Closes #2460 
```
nosetests tests/foreman/cli/test_contentviewfilter.py
......S.......................S...........................
----------------------------------------------------------------------
Ran 58 tests in 1635.287s

OK (SKIP=2)
```

Made changes to input data methods as it is more reliable to use another (wider) boundaries for generator functions. If that approach will be approved it will be necessary to make small refactor for few more modules to improve readability and remove redundant code. In that case necessary Github issue will be created. 
Re-run few methods to make sure that change will not introduce regression:
```
nosetests tests/foreman/ui/test_activationkey.py -m test_positive_create_activation_key_1
.......
----------------------------------------------------------------------
Ran 7 tests in 325.362s

OK
```
```
nosetests tests/foreman/ui/test_activationkey.py -m test_positive_create_activation_key_2
.......
----------------------------------------------------------------------
Ran 7 tests in 304.212s

OK
```
```
nosetests tests/foreman/ui/test_activationkey.py -m test_positive_create_activation_key_3
.......
----------------------------------------------------------------------
Ran 7 tests in 939.069s

OK
```
```
nosetests tests/foreman/ui/test_activationkey.py -m test_positive_create_activation_key_4
.......
----------------------------------------------------------------------
Ran 7 tests in 954.105s

OK
```
```
nosetests tests/foreman/ui/test_activationkey.py -m test_positive_create_activation_key_5
.......
----------------------------------------------------------------------
Ran 7 tests in 369.003s

OK
```
```
nosetests tests/foreman/ui/test_contentviews.py -m test_positive_cv_update_name
.......
----------------------------------------------------------------------
Ran 7 tests in 362.684s

OK
```