### PR TITLE
Add constants module and Reduce config options

### DIFF
--- a/robottelo.properties.sample
+++ b/robottelo.properties.sample
@@ -86,3 +86,42 @@ rhel7_repo=http://example.org/released/RHEL-7/7.x/Server/x86_64/os/
 # Default set to be 0, i.e. no timing of performance is measured and thus no
 # interference to original robottelo tests.
 test.foreman.perf=0
+
+# Folowing entries are used for preparation of performance tests after a fresh
+# install. They will be used by
+# `test/foreman/performance/test_standard_prep.py`, which supports:
+#
+# 1. downloading manifest,
+# 2. uploading manifest to subscription,
+# 3. updating Red Hat CDN URL,
+# 4. enabling key repositories: rhel6-rpms, rhel7-rpms, rhel6-kickstart-rpms,
+#    rhel7-kickstart-rpms, rhel6-optional-rpms, rhel7-optional-rpms,
+#    rhel6-optional-source-rpms, rhel7-optional-source-rpms,
+#    rhel6-optional-debug-rpms, r7-optional-debug-rpms
+#
+# Note that this preparation step is not required as long as satellite server
+# is already configured.
+#test.cdn.address=http://cdn.example.com/pub
+
+# A list of VM IP addresses or hostnames. Each system should already be
+# provisioned. They will be used in concurrent system subscription tests.
+test.virtual_machines_list=127.0.0.1,127.0.0.1,127.0.0.1,127.0.0.1,127.0.0.1
+
+# Savepoint utility to restore the database. For example, after conducting
+# 5,000 concurrent subscription by activation-key using 10 clients, in order to
+# start next 5k test case of subscription by register and attach, the
+# performance test would restore the database back to the state where there's
+# no client registered. All performance test cases would use this setting
+#
+# User should create savepoint-1 immediately after a fresh installation of
+# Satellite.
+#test.savepoint1_fresh_install=
+
+# User should create savepoint-2 after enabling repositories, but before
+# any system subscription or repository synchronization.
+#test.savepoint2_enabled_repos=
+
+# Parameter for number of buckets to be sliced by csv generating function
+# Class `ConcurrentTestCase` and its subclasses use this setting when
+# computing statistics of each performance test case, grouped in buckets.
+csv.num_buckets=10

--- a/robottelo/performance/candlepin.py
+++ b/robottelo/performance/candlepin.py
@@ -85,8 +85,11 @@ class Candlepin(object):
             )
             return
         LOGGER.info('Register client {} successfully'.format(vm))
-        real_time = [real for real in result.stderr.split('\n')
-                     if real.startswith('real')]
+        real_time = [
+            real
+            for real in result.stderr.split('\n')
+            if real.startswith('real')
+        ]
         real_time = real_time[0].split(' ')[1]
         return float(real_time)
 
@@ -102,8 +105,11 @@ class Candlepin(object):
             LOGGER.error('Fail to attach client {}'.format(vm))
             return
         LOGGER.info('Attach client {} successfully'.format(vm))
-        real_time = [real for real in result.stderr.split('\n')
-                     if real.startswith('real')]
+        real_time = [
+            real
+            for real in result.stderr.split('\n')
+            if real.startswith('real')
+        ]
         real_time = real_time[0].split(' ')[1]
         return float(real_time)
 
@@ -121,7 +127,7 @@ class Candlepin(object):
             LOGGER.error(
                 'Fail to delete {0} on thread-{1}!'.format(uuid, thread_id))
             LOGGER.error(response.content)
-            return
+            return 0
         LOGGER.info(
             "Delete {0} on thread-{1} successful!".format(uuid, thread_id))
         end = time.time()

--- a/robottelo/performance/constants.py
+++ b/robottelo/performance/constants.py
@@ -1,0 +1,28 @@
+"""Define constants for performance test utilities"""
+
+
+# parameter for manifest file name
+MANIFEST_FILE_NAME = 'perf-manifest.zip'
+
+# parameters for creating activation key
+ACTIVATION_KEY = 'ak-1'
+CONTENT_VIEW = 'Default Organization View'
+DEFAULT_ORG = 'Default_Organization'
+LIFE_CYCLE_ENV = 'Library'
+
+# parameters for adding ak to subscription
+QUANTITY = 1
+
+# parameters for register and attach step
+ATTACH_ENV = 'Library'
+
+# parameters for csv data files
+RAW_AK_FILE_NAME = 'raw-ak-concurrent.csv'
+RAW_ATT_FILE_NAME = 'raw-att-concurrent.csv'
+RAW_DEL_FILE_NAME = 'raw-del-concurrent.csv'
+STAT_AK_FILE_NAME = 'stat-ak-concurrent.csv'
+STAT_ATT_FILE_NAME = 'stat-att-concurrent.csv'
+STAT_DEL_FILE_NAME = 'stat-del-concurrent.csv'
+
+# parameters for number of threads/clients
+NUM_THREADS = '1,2,4,6,8,10'

--- a/robottelo/performance/stat.py
+++ b/robottelo/performance/stat.py
@@ -6,7 +6,11 @@ import numpy
 def generate_stat_for_concurrent_thread(thread_name, time_list,
                                         stat_file_name, bucket_size,
                                         num_buckets):
-    num_buckets = len(time_list)/bucket_size
+    # check empty case: empty bucket has no need to compute stat
+    if bucket_size == 0:
+        return
+    else:
+        num_buckets = len(time_list)/bucket_size
 
     # create list of bucket series
     buckets = ['{0}-{1}'.format(bucket_size * i + 1, bucket_size * (i + 1))

--- a/tests/foreman/performance/test_candlepin_concurrent_delete.py
+++ b/tests/foreman/performance/test_candlepin_concurrent_delete.py
@@ -1,7 +1,9 @@
 """Test class for concurrent subscription deletion"""
-from datetime import date
 from robottelo.common import ssh
-
+from robottelo.performance.constants import (
+    RAW_DEL_FILE_NAME,
+    STAT_DEL_FILE_NAME,
+)
 from robottelo.test import ConcurrentTestCase
 
 
@@ -14,31 +16,25 @@ class ConcurrentDeleteTestCase(ConcurrentTestCase):
         # parameters for concurrent activation key test
         # note: may need to change savepoint name
         cls._set_testcase_parameters(
-            'performance.test.savepoint2_enabled_repos',
-            'performance.csv.raw_del_file_name',
-            'performance.csv.stat_del_file_name'
+            'performance.test.savepoint3_after_registered',
+            RAW_DEL_FILE_NAME,
+            STAT_DEL_FILE_NAME
         )
 
-        # add date to csv files names
-        today = date.today()
-        today_str = today.strftime('%Y%m%d')
-        cls.raw_file_name = '{0}-{1}'.format(today_str, cls.raw_file_name)
-        cls.stat_file_name = '{0}-{1}'.format(today_str, cls.stat_file_name)
-
     def setUp(self):
-        super(ConcurrentTestCase, self).setUp()
+        super(ConcurrentDeleteTestCase, self).setUp()
 
     def _get_registered_uuids(self):
         """Get all registered systems' uuids from Postgres"""
         self.logger.info('Get UUID from database:')
 
         result = ssh.command(
-            """su postgres -c 'psql -A -t -d candlepin -c """
-            """"SELECT uuid FROM cp_consumer;"'""")
+            """su postgres -c 'psql -A -t -d foreman -c """
+            """"SELECT uuid FROM katello_systems;"'""")
 
         if result.return_code != 0:
             self.logger.error('Fail to fetch uuids.')
-            return None
+            raise RuntimeError('Invalid uuids. Stop!')
         return result.stdout
 
     def test_delete_sequential(self):

--- a/tests/foreman/performance/test_candlepin_concurrent_subscription_attach.py
+++ b/tests/foreman/performance/test_candlepin_concurrent_subscription_attach.py
@@ -1,7 +1,9 @@
 """Test class for concurrent subscription by register and attach"""
-from datetime import date
-from robottelo.cli.subscription import Subscription
-
+from robottelo.performance.constants import (
+    ATTACH_ENV,
+    RAW_ATT_FILE_NAME,
+    STAT_ATT_FILE_NAME,
+)
 from robottelo.test import ConcurrentTestCase
 
 
@@ -16,15 +18,12 @@ class ConcurrentSubAttachTestCase(ConcurrentTestCase):
         # note: may need to change savepoint name
         cls._set_testcase_parameters(
             'performance.test.savepoint2_enabled_repos',
-            'performance.csv.raw_att_file_name',
-            'performance.csv.stat_att_file_name'
+            RAW_ATT_FILE_NAME,
+            STAT_ATT_FILE_NAME
         )
 
-        # add date to csv files names
-        today = date.today()
-        today_str = today.strftime('%Y%m%d')
-        cls.raw_file_name = '{0}-{1}'.format(today_str, cls.raw_file_name)
-        cls.stat_file_name = '{0}-{1}'.format(today_str, cls.stat_file_name)
+        # parameters for attach step
+        cls.environment = ATTACH_ENV
 
     def setUp(self):
         super(ConcurrentSubAttachTestCase, self).setUp()
@@ -33,22 +32,6 @@ class ConcurrentSubAttachTestCase(ConcurrentTestCase):
         (self.sub_id, sub_name) = self._get_subscription_id()
         self.logger.debug(
             'subscription {0} id is: {1}'.format(sub_name, self.sub_id))
-
-    def _get_subscription_id(self):
-        """Get subscription pool id"""
-        result = Subscription.list(
-            {'organization-id': self.org_id},
-            per_page=False
-        )
-
-        if result.return_code != 0:
-            self.logger.error('Fail to retrieve subscription id!')
-            return
-        subscription_id = result.stdout[0]['id']
-        subscription_name = result.stdout[0]['name']
-        self.logger.info('Subscribed to {0} with subscription id {1}'
-                         .format(subscription_name, subscription_id))
-        return subscription_id, subscription_name
 
     def test_subscribe_ak_sequential(self):
         """@Test: Subscribe system sequentially using 1 virtual machine

--- a/tests/foreman/performance/test_standard_prep.py
+++ b/tests/foreman/performance/test_standard_prep.py
@@ -1,9 +1,11 @@
 """Test class for Environment Preparation after a fresh installation"""
-from robottelo.common import conf, ssh
 from robottelo.cli.org import Org
+from robottelo.cli.product import Product
 from robottelo.cli.repository import Repository
 from robottelo.cli.repository_set import RepositorySet
 from robottelo.cli.subscription import Subscription
+from robottelo.common import conf, ssh
+from robottelo.performance.constants import MANIFEST_FILE_NAME
 
 from robottelo.test import TestCase
 
@@ -26,20 +28,23 @@ class StandardPrepTestCase(TestCase):
 
         # parameters for standard process test
         # note: may need to change savepoint name
-        cls.savepoint = conf.properties[
-            'performance.test.savepoint1_fresh_install']
-        cls.manifest_location = conf.properties[
-            'performance.test.manifest.location']
+        cls.savepoint = conf.properties.get(
+            'performance.test.savepoint1_fresh_install',
+            ''
+        )
 
         # parameters for uploading manifests
         cls.manifest_file = conf.properties.get('main.manifest.fake_url')
-        cls.org_id = conf.properties['performance.test.organization.id']
+        cls.org_id = ''
 
         # parameters for changing cdn address
-        cls.target_url = conf.properties['performance.test.cdn.address']
+        cls.target_url = conf.properties.get(
+            'performance.test.cdn.address',
+            ''
+        )
 
         # parameters for enabling repositories
-        cls.pid = conf.properties['performance.test.pid']
+        cls.pid = ''
 
         # [repo-id,$basearch,$releasever]
         cls.repository_list = [
@@ -61,38 +66,67 @@ class StandardPrepTestCase(TestCase):
 
         # Restore database to clean state
         self._restore_from_savepoint(self.savepoint)
+        # Get organization-id
+        self.org_id = self._get_organization_id()
 
     def _restore_from_savepoint(self, savepoint):
         """Restore from a given savepoint"""
+        if savepoint == '':
+            self.logger.warning('No savepoint while continuing test!')
+            return
         self.logger.info('Reset db from /home/backup/{}'.format(savepoint))
         ssh.command('./reset-db.sh /home/backup/{}'.format(savepoint))
 
     def _download_manifest(self):
         self.logger.info(
-            'Start downloading required manifest: {}'
-            .format(self.manifest_location + self.manifest_file))
+            'Start downloading manifest: {}'.format(MANIFEST_FILE_NAME))
 
         result = ssh.command(
             'rm -f {0}; curl {1} -o /root/{0}'
-            .format(self.manifest_file,
-                    self.manifest_location + self.manifest_file))
+            .format(MANIFEST_FILE_NAME, self.manifest_file))
 
         if result.return_code != 0:
             self.logger.error('Fail to download manifest!')
-            return
+            raise RuntimeError('Unable to download manifest. Stop!')
         self.logger.info('Downloading manifest complete.')
 
     def _upload_manifest(self):
+        self.logger.debug('org-id is {}'.format(self.org_id))
+
         result = Subscription.upload({
-            'file': '/root/{}'.format(self.manifest_file),
+            'file': '/root/{}'.format(MANIFEST_FILE_NAME),
             'organization-id': self.org_id
         })
 
         if result.return_code != 0:
             self.logger.error('Fail to upload manifest!')
-            return
-        (self.sub_id, self.sub_name) = self._get_subscription_id()
+            raise RuntimeError('Invalid manifest. Stop!')
         self.logger.info('Upload successful!')
+
+        # after uploading manifest, get all default parameters
+        self.pid = self._get_production_id()
+        (self.sub_id, self.sub_name) = self._get_subscription_id()
+        self.logger.debug('product id is {}'.format(self.pid))
+
+    def _get_organization_id(self):
+        """Get organization id"""
+        result = Org.list(per_page=False)
+
+        if result.return_code != 0:
+            self.logger.error('Fail to list default organization.')
+            raise RuntimeError('Invalid organization id. Stop!')
+        return result.stdout[0]['id']
+
+    def _get_production_id(self):
+        """Get organization id"""
+        result = Product.list({'organization-id': self.org_id}, per_page=False)
+
+        if result.return_code != 0:
+            self.logger.error('Fail to list default products.')
+            raise RuntimeError('Invalid product id. Stop!')
+        for item in result.stdout:
+            if item['name'] == u'Red Hat Enterprise Linux Server':
+                return item['id']
 
     def _get_subscription_id(self):
         result = Subscription.list(
@@ -102,14 +136,22 @@ class StandardPrepTestCase(TestCase):
 
         if result.return_code != 0:
             self.logger.error('Fail to list subscriptions!')
-            return
+            raise RuntimeError('Invalid subscription id. Stop!')
+        if not result.stdout:
+            self.logger.error('Fail to get subscription id!')
+            raise RuntimeError('Manifest has no subscription!')
         subscription_id = result.stdout[0]['id']
         subscription_name = result.stdout[0]['name']
-        self.logger.info('Subscribe to {0} with subscription id: {1}'
-                         .format(subscription_name, subscription_id))
+        self.logger.info(
+            'Subscribe to {0} with subscription id: {1}'
+            .format(subscription_name, subscription_id)
+        )
         return (subscription_id, subscription_name)
 
     def _update_cdn_address(self):
+        if self.target_url == '':
+            raise RuntimeError('Invalid CDN address. Stop!')
+
         Org.update({
             'id': self.org_id,
             'redhat-repository-url': self.target_url


### PR DESCRIPTION
    1. Add essential config options into `robottelo.properties.sample`
    * note: most options can be set as default; but they are variables
      for the test and thus cannot be set as constants.
    
    2. Add `robottelo.performance.constants` module to serve as test parameters;
    also change correspoding parts in all scripts to read from constant
    
    3. Change hard-coding of IDS to use CLI-based script.
    
    4. Move config options closer to the place where they are used.
    
    5. Refactor out `_get_subscription_id` and `_get_organization_id` into
    `robottelo.test` as shared by all sub-test cases
    
    6. Remove appending date to head of csv data files to improve clarity;
    also read csv file names from constant
    
    7. Change `test/foreman/performance/test_standard_prep` to read
    its variables from constant and get all IDs automatically
    
    8. Adjust properties options and move `num_threads` to `constant`
    
    9. Raise exception if required IDs fail to read
    
    10. Change SQL statement and fix super() bug in
    `tests.foreman.performance.test_candlepin_concurrent_delete`
    
    11. Check empty or 0 case for uneven iterations for each client