### PR TITLE
Small fix for regression introduced by #2556

### DIFF
--- a/robottelo/ui/base.py
+++ b/robottelo/ui/base.py
@@ -172,7 +172,7 @@ class Base(object):
             strategy, value = drop_locator
             self.click((strategy, value % name))
         strategy, value = del_locator
-        self.click((strategy, value % name))
+        self.click((strategy, value % name), wait_for_ajax=False)
         self.handle_alert(really)
 
     def wait_until_element_exists(


### PR DESCRIPTION
```delete_entity``` method will always fail as ```handle_alert``` should always follow ```click``` action and any command should not be inserted in-between (e.g. ```wait_for_ajax```)