### PR TITLE
Use NailGun 0.18.1

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import find_packages, setup
 REQUIRES = [
     'ddt',
     'fauxfactory',
-    'nailgun==0.18.0',
+    'nailgun==0.18.1',
     'paramiko',
     'python-bugzilla',
     'requests',


### PR DESCRIPTION
The new version shouldn't totally bork Robottelo:

    $ nosetests tests/foreman/api/test_activationkey.py
    ......SSS....................
    ----------------------------------------------------------------------
    Ran 29 tests in 118.521s

    OK (SKIP=3)

See: https://github.com/SatelliteQE/nailgun/releases/tag/0.18.1