### PR TITLE
Updated locator for 'parameter_remove' to fix UI tests

### DIFF
--- a/robottelo/ui/locators.py
+++ b/robottelo/ui/locators.py
@@ -615,7 +615,7 @@ common_locators = LocatorDict({
     "parameter_name": (By.XPATH, "//input[@placeholder='Name']"),
     "parameter_value": (By.XPATH, "//textarea[@placeholder='Value']"),
     "parameter_remove": (
-        By.XPATH, "//div/input[@value='%s']/following-sibling::span/a/i"),
+        By.XPATH, "//tr/td/input[@value='%s']/following::td/span/a/i"),
 
     # Katello Common Locators
     "confirm_remove": (By.XPATH, "//button[contains(@ng-click,'ok')]"),

--- a/tests/foreman/ui/test_domain.py
+++ b/tests/foreman/ui/test_domain.py
@@ -262,7 +262,7 @@ class Domain(UITestCase):
 
     @data(*generate_strings_list(len1=4))
     def test_remove_domain_parameter(self, name):
-        """@Test: Remove a selected domain paramter
+        """@Test: Remove a selected domain parameter
 
         @Feature: Domain - Misc
 


### PR DESCRIPTION
This will fix two failed tests mentioned in #2584 
`test_remove_domain_parameter`
`test_remove_os_parameter`