### PR TITLE
Install NailGun directly from git

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,6 @@ git+https://github.com/SatelliteQE/automation-tools.git
 
 # For UI tests.
 git+https://github.com/smartkiwi/SeleniumFactory-for-Python.git#egg=SeleniumFactory
+
+# For working with the API.
+git+https://github.com/SatelliteQE/nailgun.git

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import find_packages, setup
 REQUIRES = [
     'ddt',
     'fauxfactory',
-    'nailgun==0.18.2',
+    'nailgun',
     'paramiko',
     'python-bugzilla',
     'requests',


### PR DESCRIPTION
This change demonstrably installs nailgun from source:

    $ virtualenv --python python2 ~/tmp/env
    $ source ~/tmp/env/bin/activate
    $ pip install -r requirements.txt -r requirements-optional.txt
    $ pip list | grep packaging  # shows up

The most recent release of NailGun (0.18.2) depends on setuptools. The
development code depends on packaging instead. The fact that "packaging" shows
up in the list of installed packages indicates that nailgun was installed
directly from source.

Beware that there are several pitfalls to this change:

* We no longer get verification that the packages we upload to PyPi are in good
  shape.
* Breaking changes made to NailGun will immediately affect Robottelo. And there
  *are* going to be breaking changes. For example, just about every single
  custom method in module `nailgun.entities` (that is, every method not provided
  by one of the `Entity*Mixins`) is going to be dropped or rewritten. Mistakes
  are sometimes made. Dependencies sometimes change. And major changes that are
  easier to accomplish by temporarily breaking things will be made much harder.