### PR TITLE
Fix API smoke test

### DIFF
--- a/tests/foreman/smoke/test_api_smoke.py
+++ b/tests/foreman/smoke/test_api_smoke.py
@@ -9,6 +9,9 @@ from robottelo.common.constants import (
     DEFAULT_SUBSCRIPTION_NAME,
     FAKE_0_PUPPET_REPO,
     GOOGLE_CHROME_REPO,
+    PRDS,
+    REPOS,
+    REPOSET,
 )
 from robottelo.common.decorators import bz_bug_is_open, skip_if_bug_open
 from robottelo.common.helpers import (


### PR DESCRIPTION
Import the required constants. This was missed on #2581.