### PR TITLE
Fix host-collections max-content-host attribute name

### DIFF
--- a/tests/foreman/cli/test_host_collection.py
+++ b/tests/foreman/cli/test_host_collection.py
@@ -136,7 +136,7 @@ class TestHostCollection(CLITestCase):
             'max-content-hosts': test_data,
         })
         # Assert that limit matches data passed
-        self.assertEqual(new_host_col['max-content-hosts'], str(test_data))
+        self.assertEqual(new_host_col['limit'], str(test_data))
 
     @skip_if_bug_open('bugzilla', 1214675)
     @data(u'True', u'Yes', 1, u'False', u'No', 0)


### PR DESCRIPTION
```
$nosetests tests/foreman/cli/test_host_collection.py:TestHostCollection.test_positive_create_3
.
----------------------------------------------------------------------
Ran 1 test in 37.948s

OK
```
This fixes two cli failures in the recent automation run.