### PR TITLE
API: Implemented sync plan tests

### DIFF
--- a/robottelo/common/helpers.py
+++ b/robottelo/common/helpers.py
@@ -229,7 +229,7 @@ def invalid_values_list():
     code.
 
     """
-    return ['', ' ', '   '] + invalid_names_list()
+    return ['', ' ', '\t'] + invalid_names_list()
 
 
 def generate_strings_list(len1=None, remove_str=None, bug_id=None):


### PR DESCRIPTION
Implemented stubbed sync plan tests and added few more for better coverage.
Closes #2445
Closes #2446
Tests results:
```
nosetests tests/foreman/api/test_syncplan.py
.............................................S.SSS.........................................
----------------------------------------------------------------------
Ran 91 tests in 177.606s

OK (SKIP=4)
```
`[DO NOT MERGE]` as it depends on SatelliteQE/nailgun#152