### PR TITLE
Update make file and docs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,7 @@
 
 FOREMAN_API_TESTS_PATH=$(join $(FOREMAN_TESTS_PATH), api)
 FOREMAN_CLI_TESTS_PATH=$(join $(FOREMAN_TESTS_PATH), cli)
+FOREMAN_RHCI_TESTS_PATH=$(join $(FOREMAN_TESTS_PATH), rhci)
 FOREMAN_SMOKE_TESTS_PATH=$(join $(FOREMAN_TESTS_PATH), smoke)
 FOREMAN_TESTS_PATH=tests/foreman/
 FOREMAN_UI_TESTS_PATH=$(join $(FOREMAN_TESTS_PATH), ui)
@@ -22,6 +23,7 @@ help:
 	@echo "  test-foreman-api-threaded  to do the above with threading"
 	@echo "  test-foreman-cli      to test a Foreman deployment CLI"
 	@echo "  test-foreman-cli-threaded  to do the above with threading"
+	@echo "  test-foreman-rhci     to test a Foreman deployment w/RHCI plugin"
 	@echo "  test-foreman-ui       to test a Foreman deployment UI"
 	@echo "  test-foreman-ui-xvfb  to test a Foreman deployment UI using xvfb-run"
 	@echo "  test-foreman-smoke    to perform a generic smoke test"
@@ -37,6 +39,7 @@ docs-clean:
 test-docstrings:
 	testimony validate_docstring tests/foreman/api
 	testimony validate_docstring tests/foreman/cli
+	testimony validate_docstring tests/foreman/rhci
 	testimony validate_docstring tests/foreman/ui
 
 test-robottelo:
@@ -56,6 +59,9 @@ test-foreman-cli-threaded:
 	$(NOSETESTS) $(NOSETESTS_OPTS) $(FOREMAN_CLI_TESTS_PATH)\
 	    --processes=-1 --process-timeout=300
 
+test-foreman-rhci:
+	$(NOSETESTS) $(NOSETESTS_OPTS) $(FOREMAN_RHCI_TESTS_PATH)
+
 test-foreman-ui:
 	$(NOSETESTS) $(NOSETESTS_OPTS) $(FOREMAN_UI_TESTS_PATH)
 
@@ -74,5 +80,5 @@ lint:
 # Special Targets -------------------------------------------------------------
 
 .PHONY: help docs docs-clean test-docstrings test-robottelo \
-        test-foreman-api test-foreman-cli test-foreman-ui \
+        test-foreman-api test-foreman-cli test-foreman-rhci test-foreman-ui \
         test-foreman-ui-xvfb test-foreman-smoke graph-entities lint

--- a/docs/api/robottelo.api.rst
+++ b/docs/api/robottelo.api.rst
@@ -3,11 +3,6 @@
 
 .. automodule:: robottelo.api
 
-:mod:`robottelo.api.inspect`
-----------------------------
-
-.. automodule:: robottelo.api.inspect
-
 :mod:`robottelo.api.utils`
 --------------------------
 

--- a/docs/api/tests.foreman.api.rst
+++ b/docs/api/tests.foreman.api.rst
@@ -138,11 +138,6 @@
 
 .. automodule:: tests.foreman.api.test_repository
 
-:mod:`tests.foreman.api.test_rhci`
-----------------------------------
-
-.. automodule:: tests.foreman.api.test_rhci
-
 :mod:`tests.foreman.api.test_rhsm`
 ----------------------------------
 

--- a/docs/api/tests.foreman.rhci.rst
+++ b/docs/api/tests.foreman.rhci.rst
@@ -1,0 +1,9 @@
+:mod:`tests.foreman.rhci`
+=========================
+
+.. automodule:: tests.foreman.rhci
+
+:mod:`tests.foreman.rhci.test_rhci`
+-----------------------------------
+
+.. automodule:: tests.foreman.rhci.test_rhci

--- a/docs/api/tests.foreman.rst
+++ b/docs/api/tests.foreman.rst
@@ -10,6 +10,7 @@ Submodules:
     tests.foreman.installer
     tests.foreman.performance
     tests.foreman.smoke
+    tests.foreman.rhci
     tests.foreman.ui
 
 .. automodule:: tests.foreman

--- a/docs/api/tests.robottelo.rst
+++ b/docs/api/tests.robottelo.rst
@@ -20,16 +20,6 @@ Submodules:
 
 .. automodule:: tests.robottelo.test_helpers
 
-:mod:`tests.robottelo.test_robottelo_api_inspect`
--------------------------------------------------
-
-.. automodule:: tests.robottelo.test_robottelo_api_inspect
-
-:mod:`tests.robottelo.test_robottelo_api_utils`
------------------------------------------------
-
-.. automodule:: tests.robottelo.test_robottelo_api_utils
-
 :mod:`tests.robottelo.test_ssh`
 -------------------------------
 


### PR DESCRIPTION
PR #2595 moves the RHCI tests to module `tests.foreman.rhci`. Add new make
targets for this new package and update the docs to handle the change.