### PR TITLE
Skipping the test_positive_content_override

### DIFF
--- a/tests/foreman/cli/test_activationkey.py
+++ b/tests/foreman/cli/test_activationkey.py
@@ -1700,7 +1700,7 @@ class TestActivationKey(CLITestCase):
 
         self.assertIn(u"'--auto-attach': value must be one of", result.stderr)
 
-    @skip_if_bug_open('bugzilla', 1221778)
+    @stubbed()
     @data(
         u'1',
         u'0',


### PR DESCRIPTION
- This issue is being tracked in https://github.com/SatelliteQE/robottelo/issues/2598

```sh
nosetests tests/foreman/cli/test_activationkey.py:TestActivationKey.test_positive_content_override
S
----------------------------------------------------------------------
Ran 1 test in 0.001s

OK (SKIP=1)
```