### PR TITLE
Fix `make test-robottelo` fail

### DIFF
--- a/robottelo/vm.py
+++ b/robottelo/vm.py
@@ -69,7 +69,7 @@ class VirtualMachine(object):
                 'clients.provisioning_server')
         else:
             self.provisioning_server = provisioning_server
-        if self.provisioning_server is None:
+        if self.provisioning_server is None or self.provisioning_server == '':
             raise VirtualMachineError(
                 'A provisioning server must be provided. Make sure to fill '
                 '"provisioning_server" on clients section of your robottelo '

--- a/tests/robottelo/test_vm.py
+++ b/tests/robottelo/test_vm.py
@@ -14,9 +14,10 @@ class VirtualMachineTestCase(unittest.TestCase):
     def setUp(self):
         super(VirtualMachineTestCase, self).setUp()
         self.properties_backup = conf.properties.copy()
+        conf.properties['clients.provisioning_server'] = None
 
     def tearDown(self):
-        super(VirtualMachineTestCase, self).setUp()
+        super(VirtualMachineTestCase, self).tearDown()
         conf.properties = self.properties_backup
 
     def configure_provisoning_server(self):


### PR DESCRIPTION
After changes itroduced by #2576, `make test-robottelo` is failing with following trace:
```
make test-robottelo
$(which nosetests) tests/robottelo/
.................................................F..
======================================================================
FAIL: Check if an exception is raised if missing provisioning_server
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/andriy/Downloads/robottelo/tests/robottelo/test_vm.py", line 60, in test_provisioning_server_not_configured
    vm = VirtualMachine()  # noqa
AssertionError: VirtualMachineError not raised

----------------------------------------------------------------------
Ran 52 tests in 0.015s

FAILED (failures=1)
make: *** [test-robottelo] Error 1
```
~~`test_provisioning_server_not_configured` is checking wheter assertion is rised if no vm `distro` is specified.
But as per #2576:~~
```python
self.distro = BASE_IMAGES[-1] if distro is None else distro
```
~~So, if no `distro` is specified, latest available will be selected. This change made the test useless, so i vote for deleting it :)
Result after the "fix":~~
```
make test-robottelo
$(which nosetests) tests/robottelo/
...................................................
----------------------------------------------------------------------
Ran 51 tests in 0.015s

OK
```