### PR TITLE
Fix failing content override tests

### DIFF
--- a/tests/foreman/cli/test_activationkey.py
+++ b/tests/foreman/cli/test_activationkey.py
@@ -119,14 +119,15 @@ class TestActivationKey(CLITestCase):
                     u'organization-id': TestActivationKey.pub_key['org_id']
                 })['id']
 
-                subscription_result = Subscription.list(
-                    {'organization-id': TestActivationKey.pub_key['org_id']},
+                subscription_result = Subscription.list({
+                    'organization-id': TestActivationKey.pub_key['org_id'],
+                    'order': 'id desc'},
                     per_page=False
                 )
 
                 ActivationKey.add_subscription({
                     u'id': TestActivationKey.pub_key['key_id'],
-                    u'subscription-id': subscription_result.stdout[0]['id'],
+                    u'subscription-id': subscription_result.stdout[-1]['id'],
                 })
             except CLIFactoryError as err:
                 TestActivationKey.pub_key = None


### PR DESCRIPTION
Previously, the _make_public_key method would add the very first subscription returned.
In cases where the custom subscription was listed before the other subscriptions available
in the manifest, this worked well. However, this is a naive approach and resulted in
numerous failures.
The new change forces the subscriptions to be ordered by id with the newly created
subscription being returned last. This ensures we select the subscription created within the
_make_public_key method. Tested 10 times; all passed.

nosetests -v tests/foreman/cli/test_activationkey.py:TestActivationKey.test_positive_content_override
@Test: Positive content override ... ok

Ran 1 test in 114.294s

OK

fixes #2598