### PR TITLE
Add coverage for content view filter delete in CLI

### DIFF
--- a/robottelo/cli/contentview.py
+++ b/robottelo/cli/contentview.py
@@ -185,6 +185,31 @@ class ContentView(Base):
         return cls.execute(cls._construct_command(options))
 
     @classmethod
+    def filter_delete(cls, options):
+        """Delete existing content view filter entity.
+
+        Usage::
+
+            hammer content-view filter delete [OPTIONS]
+
+        Options::
+
+            --content-view CONTENT_VIEW_NAME    Content view name
+            --content-view-id CONTENT_VIEW_ID   Content view numeric identifier
+            --id ID                             filter identifier
+            --name NAME                         Name to search by
+            --organization ORGANIZATION_NAME    Organization name to search by
+            --organization-id ORGANIZATION_ID   Organization ID
+            --organization-label ORGANIZATION_LABEL   Organization label to
+                                                      search by
+
+        """
+        cls.command_sub = 'filter delete'
+        if options is None:
+            options = {}
+        return cls.execute(cls._construct_command(options))
+
+    @classmethod
     def filter_rule_create(cls, options):
         """Add new rule to content view filter."""
         cls.command_sub = 'filter rule create'

--- a/robottelo/ui/computeprofile.py
+++ b/robottelo/ui/computeprofile.py
@@ -14,7 +14,14 @@ class ComputeProfile(Base):
         return self.search_entity(name, locators['profile.select_name'])
 
     def select_resource(self, profile_name, res_name, res_type):
-        """Select necessary compute resource from specific compute profile"""
+        """Select necessary compute resource from specific compute profile
+
+        :param profile_name: Name of profile that contains required compute
+        resource (e.g. '2-Medium' or '1-Small')
+        :param res_name: Name of compute resource to select from the list
+        :param res_type: Type of compute resource (e.g. 'Libvirt' or 'Docker')
+
+        """
         profile = self.search(profile_name)
         if profile is None:
             raise UINoSuchElementError(

--- a/tests/foreman/cli/test_contentviewfilter.py
+++ b/tests/foreman/cli/test_contentviewfilter.py
@@ -806,3 +806,127 @@ class TestContentViewFilter(CLITestCase):
         })
         self.assertNotEqual(result.return_code, 0)
         self.assertNotEqual(len(result.stderr), 0)
+
+    @data(*valid_data_list())
+    def test_delete_cvf_with_different_names(self, name):
+        """Test: Create new content view filter and assign it to existing
+        content view by id. Try to delete that filter using different value
+        types as a name
+
+        @Feature: Content View Filter
+
+        @Assert: Content view filter deleted successfully
+
+        """
+        result = ContentView.filter_create({
+            'content-view-id': self.content_view['id'],
+            'type': 'rpm',
+            'name': name,
+        })
+        self.assertEqual(result.return_code, 0)
+
+        result = ContentView.filter_info({
+            u'content-view-id': self.content_view['id'],
+            u'name': name,
+        })
+        self.assertEqual(result.return_code, 0)
+
+        result = ContentView.filter_delete({
+            u'content-view-id': self.content_view['id'],
+            u'name': name,
+        })
+        self.assertEqual(result.return_code, 0)
+        self.assertEqual(len(result.stderr), 0)
+
+        result = ContentView.filter_info({
+            u'content-view-id': self.content_view['id'],
+            u'name': name,
+        })
+        self.assertNotEqual(result.return_code, 0)
+
+    def test_delete_cvf_by_id(self):
+        """Test: Create new content view filter and assign it to existing
+        content view by id. Try to delete that filter using its id as a
+        parameter
+
+        @Feature: Content View Filter
+
+        @Assert: Content view filter deleted successfully
+
+        """
+        result = ContentView.filter_create({
+            'content-view-id': self.content_view['id'],
+            'type': 'rpm',
+            'name': self.cvf_name,
+        })
+        self.assertEqual(result.return_code, 0)
+
+        result = ContentView.filter_info({
+            u'content-view-id': self.content_view['id'],
+            u'name': self.cvf_name,
+        })
+        self.assertEqual(result.return_code, 0)
+
+        result = ContentView.filter_delete({
+            u'id': result.stdout['filter-id'],
+        })
+        self.assertEqual(result.return_code, 0)
+        self.assertEqual(len(result.stderr), 0)
+
+        result = ContentView.filter_info({
+            u'content-view-id': self.content_view['id'],
+            u'name': self.cvf_name,
+        })
+        self.assertNotEqual(result.return_code, 0)
+
+    def test_delete_cvf_with_org(self):
+        """Test: Create new content view filter and assign it to existing
+        content view by id. Try to delete that filter using organization and
+        content view names where that filter was applied
+
+        @Feature: Content View Filter
+
+        @Assert: Content view filter deleted successfully
+
+        """
+        result = ContentView.filter_create({
+            'content-view-id': self.content_view['id'],
+            'type': 'rpm',
+            'name': self.cvf_name,
+        })
+        self.assertEqual(result.return_code, 0)
+
+        result = ContentView.filter_info({
+            u'content-view-id': self.content_view['id'],
+            u'name': self.cvf_name,
+        })
+        self.assertEqual(result.return_code, 0)
+
+        result = ContentView.filter_delete({
+            u'content-view': self.content_view['name'],
+            u'organization': self.org['name'],
+            u'name': self.cvf_name,
+        })
+        self.assertEqual(result.return_code, 0)
+        self.assertEqual(len(result.stderr), 0)
+
+        result = ContentView.filter_info({
+            u'content-view-id': self.content_view['id'],
+            u'name': self.cvf_name,
+        })
+        self.assertNotEqual(result.return_code, 0)
+
+    def test_delete_cvf_with_name_negative(self):
+        """Test: Try to delete non-existent filter using generated name
+
+        @Feature: Content View Filter
+
+        @Assert: System returned error
+
+        """
+        result = ContentView.filter_delete({
+            u'content-view-id': self.content_view['id'],
+            u'name': u'invalid_cv_filter',
+        })
+        self.assertNotEqual(result.return_code, 0)
+        self.assertGreater(len(result.stderr), 0)


### PR DESCRIPTION
Closes #2461

As a bonus, adding update to docstring suggested by @sthirugn in my last PR (don't want to create separate PR :smile_cat:)

```
nosetests tests/foreman/cli/test_contentviewfilter.py -m test_delete_cvf
..........
----------------------------------------------------------------------
Ran 10 tests in 296.903s

OK
```