### PR TITLE
CLI/Import - refactored assertions

### DIFF
--- a/robottelo/cli/factory.py
+++ b/robottelo/cli/factory.py
@@ -74,7 +74,7 @@ def create_object(cli_object, options, values):
     Creates <object> with dictionary of arguments.
 
     :param cli_object: A valid CLI object.
-    :param dict options: The defaults options accepted by the cli_object
+    :param dict options: The default options accepted by the cli_object
         create
     :param dict values: Custom values to override default ones.
     :raise robottelo.cli.factory.CLIFactoryError: Raise an exception if object

--- a/robottelo/common/helpers.py
+++ b/robottelo/common/helpers.py
@@ -378,10 +378,10 @@ def prepare_import_data(tar_path=None):
         for key in (
             'activation-keys',
             'channels',
-            'config-files-latest.csv',
+            'config-files-latest',
             'kickstart-scripts',
             'repositories',
-            'system-groups.csv'
+            'system-groups',
             'system-profiles',
             'users'
         ):


### PR DESCRIPTION
- addresses #2574
- fixes a bug in a `prepare_import_data` helper method
- applies some small cosmetic fixes

```bash
$ nosetests test_import.py --nocapture --verbose
@test: Check whether all supported Sat5 macros are being ... ok
@test: Import all organizations from the default data set ... ok
@test: Import all organizations from the default data set ... ok
@test: Try to Import organizations with the same name to invoke ... ok
@test: Import all 3 users from the our default data set (predefined ... ok
@test: Try to Merge users with the same name using 'merge-users' ... ok
@test: Try to Import users with the same name to invoke ... ok
@test: Try to Import all organizations and their users from CSV ... ok
@test: Try to Import all organizations from the ... ok
@test: Try to Import all users from the ... ok

----------------------------------------------------------------------
Ran 10 tests in 888.417s

OK
```