### PR TITLE
Properly list dependencies

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,10 +1,5 @@
---editable .
-
-# For Installer tests.
-git+https://github.com/SatelliteQE/automation-tools.git
-
-# For UI tests.
+git+https://github.com/SatelliteQE/automation-tools.git#egg=automation-tools
+git+https://github.com/SatelliteQE/nailgun.git#egg=nailgun
 git+https://github.com/smartkiwi/SeleniumFactory-for-Python.git#egg=SeleniumFactory
 
-# For working with the API.
-git+https://github.com/SatelliteQE/nailgun.git
+--editable .

--- a/setup.py
+++ b/setup.py
@@ -2,17 +2,6 @@
 # -*- coding: utf-8 -*-
 from setuptools import find_packages, setup
 
-REQUIRES = [
-    'ddt',
-    'fauxfactory',
-    'nailgun',
-    'paramiko',
-    'python-bugzilla',
-    'requests',
-    'selenium',
-    'numpy',
-]
-
 with open('README.rst', 'r') as f:
     README = f.read()
 
@@ -26,7 +15,18 @@ setup(
     packages=find_packages(exclude=['tests*']),
     package_data={'': ['LICENSE']},
     include_package_data=True,
-    install_requires=REQUIRES,
+    install_requires=[
+        'SeleniumFactory',
+        'automation-tools',
+        'ddt',
+        'fauxfactory',
+        'nailgun',
+        'numpy',
+        'paramiko',
+        'python-bugzilla',
+        'requests',
+        'selenium',
+    ],
     license='GNU GPL v3.0',
     # See https://pypi.python.org/pypi?%3Aaction=list_classifiers
     classifiers=(


### PR DESCRIPTION
All of a project's dependencies should be listed in `setup.py`, regardless of
whether those dependencies are avaiable in PyPi or not. Dependencies listed in
`setup.py` should include only a dependency name and optionally a version
specifier, like so:

    install_requires=[
        'A>=1,<2',
        'B>=2'
    ]

A requirements file tells pip where dependencies should be installed from. This
is especially useful when — as in our case:

* Dependencies are not available via PyPi. (automation-tools, SeleniumFactory)
* Dependencies are available via PyPi but should be installed via other means.
  (nailgun)

List all dependencies in `setup.py`. Fix up `requirements.txt` so that it
correctly declares which depencies are being concretely satisfied by adding
`#egg=package-name` to each line.

Test script:

    $ virtualenv --python python2 env
    $ source env/bin/activate
    $ pip install -r requirements.txt
    $ python -c '
    import automation_tools
    import selenium_factory
    from nailgun.entities import Errata, SyncPlan
    for entity in (Errata, SyncPlan):
        print(hasattr(entity, "update"))
    '

Results before:

    False
    True

Results after:

    False
    False