### PR TITLE
Separate Register+Attach and Add Graphing Module

### DIFF
--- a/robottelo/performance/constants.py
+++ b/robottelo/performance/constants.py
@@ -17,12 +17,14 @@ QUANTITY = 1
 ATTACH_ENV = 'Library'
 
 # parameters for csv data files
-RAW_AK_FILE_NAME = 'raw-ak-concurrent.csv'
-RAW_ATT_FILE_NAME = 'raw-att-concurrent.csv'
-RAW_DEL_FILE_NAME = 'raw-del-concurrent.csv'
-STAT_AK_FILE_NAME = 'stat-ak-concurrent.csv'
-STAT_ATT_FILE_NAME = 'stat-att-concurrent.csv'
-STAT_DEL_FILE_NAME = 'stat-del-concurrent.csv'
+RAW_AK_FILE_NAME = 'perf-raw-activationKey.csv'
+RAW_ATT_FILE_NAME = 'perf-raw-attach.csv'
+RAW_DEL_FILE_NAME = 'perf-raw-delete.csv'
+RAW_REG_FILE_NAME = 'perf-raw-register.csv'
+STAT_AK_FILE_NAME = 'perf-statistics-activationKey.csv'
+STAT_ATT_FILE_NAME = 'perf-statistics-attach.csv'
+STAT_DEL_FILE_NAME = 'perf-statistics-delete.csv'
+STAT_REG_FILE_NAME = 'perf-statistics-register.csv'
 
 # parameters for number of threads/clients
 NUM_THREADS = '1,2,4,6,8,10'

--- a/robottelo/performance/graph.py
+++ b/robottelo/performance/graph.py
@@ -1,0 +1,115 @@
+"""Test utilities for generating charts for both Candlepin and Pulp tests"""
+import pygal
+
+
+def generate_bar_chart_stat(stat_dict, head, filename, lengend):
+    """Generate Bar chart for stat on concurrent subscription
+
+    :param dict stat_dict: The dictionary containing min/median/max/std
+    :param str head: Titile of charts
+    :param str filename: The name of output svg chart
+    :param str lengend: The lengend of generated bar charts
+
+    """
+    bar_chart = pygal.Bar()
+    bar_chart.title = head
+    bar_chart.x_labels = ('min', 'median', 'max', 'std')
+    bar_chart.x_title = 'Statistics'
+    bar_chart.y_title = 'Time (s)'
+    for key in range(len(stat_dict)):
+        bar_chart.add('{0}-{1}'.format(lengend, key), stat_dict.get(key))
+    bar_chart.render_to_file(filename)
+
+
+def generate_line_chart_bucketized_stat(
+        stat_dict,
+        head,
+        filename,
+        bucket_size,
+        num_buckets):
+    """Generate Line chart for stat on concurrent subscription
+
+    Take a dictionary of statistic values on each client. For example::
+
+    0: [min, | median,max,std]
+    1: [min, | median,max,std]
+    2: [min, | median,max,std]
+    ...
+    9: [min, | median,max,std],
+
+    it would slice out all min, then all median, all max, and all std
+    sequentially, form 4 lines on the chart, where each line represented
+    by 10 timing points.
+
+    :param dict stat_dict: The dictionary containing min/median/max/std
+    :param str head: Titile of charts
+    :param str filename: The name of output svg chart
+    :param int bucket_size: Number of timing values grouped in each bucket
+    :param int num_buckets: Number of buckets of the test; default 10
+
+    """
+    if bucket_size == 0:
+        return
+
+    # parameters for formats on charts
+    lengend = ('min', 'median', 'max', 'std')
+    buckets = [
+        '{0}-{1}'.format(bucket_size * i + 1, bucket_size * (i + 1))
+        for i in range(num_buckets)
+    ]
+    line_chart = pygal.Line()
+    line_chart.title = head
+    line_chart.x_labels = buckets
+    line_chart.x_title = 'Buckets'
+    line_chart.y_title = 'Time (s)'
+    for i in len(lengend):
+        line_chart.add(lengend[i], (vlist[i] for vlist in stat_dict.values()))
+    line_chart.render_to_file(filename)
+
+
+def generate_stacked_line_chart_raw(time_result_dict, head, filename):
+    """Generate Stacked-Line chart for raw data of ak/att/del/reg
+
+    :param dict stat_dict: The dictionary containing min/median/max/std
+    :param str head: Titile of charts
+    :param str filename: The name of output svg chart
+
+    """
+    stackedline_chart = pygal.StackedLine(
+        fill=True,
+        show_dots=False,
+        range=(0, 60),
+    )
+    max_label = len(time_result_dict.get('thread-0'))
+    stackedline_chart.x_labels = [str(i) for i in range(1, max_label + 1)]
+    stackedline_chart.title = head
+    stackedline_chart.x_title = 'Iterations'
+    stackedline_chart.y_title = 'Time (s)'
+    # for each client, add time list into chart
+    for thread in range(len(time_result_dict)):
+        key = 'thread-{}'.format(thread)
+        time_list = time_result_dict.get(key)
+        stackedline_chart.add('client-{}'.format(thread), time_list)
+    stackedline_chart.render_to_file(filename)
+
+
+def generate_line_chart_raw(time_result_dict, head, filename):
+    """Generate Normal Line chart for raw data of ak/att/del/reg
+
+    :param dict stat_dict: The dictionary containing min/median/max/std
+    :param str head: Titile of charts
+    :param str filename: The name of output svg chart
+
+    """
+    line_chart = pygal.Line(show_dots=False, range=(0, 50))
+    max_label = len(time_result_dict.get('thread-0'))
+    line_chart.x_labels = [str(i) for i in range(1, max_label + 1)]
+    line_chart.title = head
+    line_chart.x_title = 'Iterations'
+    line_chart.y_title = 'Time (s)'
+    # for each client, add time list into chart
+    for thread in range(len(time_result_dict)):
+        key = 'thread-{}'.format(thread)
+        time_list = time_result_dict.get(key)
+        line_chart.add('client-{}'.format(thread), time_list)
+    line_chart.render_to_file(filename)

--- a/robottelo/performance/stat.py
+++ b/robottelo/performance/stat.py
@@ -12,6 +12,8 @@ def generate_stat_for_concurrent_thread(thread_name, time_list,
     else:
         num_buckets = len(time_list)/bucket_size
 
+    return_stat = {}
+
     # create list of bucket series
     buckets = ['{0}-{1}'.format(bucket_size * i + 1, bucket_size * (i + 1))
                for i in range(num_buckets)]
@@ -32,15 +34,28 @@ def generate_stat_for_concurrent_thread(thread_name, time_list,
             '99%'
         ])
         for i, bucket in enumerate(buckets):
+            # slice the given time-list into buckets
             time_list_slice = time_list[bucket_size * i:bucket_size * (i + 1)]
+
+            # variables for generating graphs only
+            gmin = numpy.amin(time_list_slice)
+            gmean = numpy.mean(time_list_slice)
+            gmedian = numpy.median(time_list_slice)
+            gmax = numpy.amax(time_list_slice)
+            gstd = numpy.std(time_list_slice)
+
             writer.writerow([
                 bucket,
-                numpy.amin(time_list_slice),
-                numpy.median(time_list_slice),
-                numpy.mean(time_list_slice),
-                numpy.amax(time_list_slice),
-                numpy.std(time_list_slice),
+                gmin,
+                gmedian,
+                gmean,
+                gmax,
+                gstd,
                 numpy.percentile(time_list_slice, 90),
                 numpy.percentile(time_list_slice, 95),
                 numpy.percentile(time_list_slice, 99)
             ])
+
+            # update a dictionary with key as each bucket and values as stat
+            return_stat.update({i: (gmin, gmedian, gmax, gstd)})
+        return return_stat

--- a/robottelo/performance/thread.py
+++ b/robottelo/performance/thread.py
@@ -37,8 +37,15 @@ class DeleteThread(PerformanceThread):
 
 
 class SubscribeAKThread(PerformanceThread):
-    def __init__(self, thread_id, thread_name, time_result_dict,
-                 num_iterations, ak_name, default_org, vm_ip):
+    def __init__(
+            self,
+            thread_id,
+            thread_name,
+            time_result_dict,
+            num_iterations,
+            ak_name,
+            default_org,
+            vm_ip):
         super(SubscribeAKThread, self).__init__(
             thread_id, thread_name, time_result_dict)
         self.num_iterations = num_iterations
@@ -60,11 +67,37 @@ class SubscribeAKThread(PerformanceThread):
 
 
 class SubscribeAttachThread(PerformanceThread):
-    def __init__(self, thread_id, thread_name, time_result_dict,
-                 num_iterations, sub_id, default_org, environment, vm_ip):
-        super(SubscribeAttachThread, self).__init__(
-            thread_id, thread_name, time_result_dict)
+    """Thread for Subscription by register and attach
 
+    separate `time_result_dictionary` into two new dictionaries:
+    time_result_dict_register, containing timing results of register step
+    time_result_dict_attach, containing timing results of attach step
+
+    The data structure of dictionaries now is::
+
+        dict-register: {client-0: [...], ..., client-9:[...]}
+        dict-attach: {client-0: [...], ..., client-9:[...]}
+
+    """
+    def __init__(
+            self,
+            thread_id,
+            thread_name,
+            time_result_dict,
+            time_result_dict_register,
+            time_result_dict_attach,
+            num_iterations,
+            sub_id,
+            default_org, environment,
+            vm_ip):
+        super(SubscribeAttachThread, self).__init__(
+            thread_id,
+            thread_name,
+            time_result_dict
+        )
+
+        self.time_result_dict_register = time_result_dict_register
+        self.time_result_dict_attach = time_result_dict_attach
         self.num_iterations = num_iterations
         self.sub_id = sub_id
         self.default_org = default_org
@@ -83,6 +116,13 @@ class SubscribeAttachThread(PerformanceThread):
                 self.environment,
                 self.vm_ip)
 
-            for index in range(3):
-                self.time_result_dict[self.thread_name][index].append(
-                    time_points[index])
+            # split original time_result_dict into two new dictionaries
+            # append each client's register timing data
+            self.time_result_dict_register.get(
+                self.thread_name, 'thread-0'
+            ).append(time_points[0])
+
+            # append each client's attach timing data
+            self.time_result_dict_attach.get(
+                self.thread_name, 'thread-0'
+            ).append(time_points[1])

--- a/setup.py
+++ b/setup.py
@@ -23,6 +23,7 @@ setup(
         'nailgun',
         'numpy',
         'paramiko',
+        'pygal',
         'python-bugzilla',
         'requests',
         'selenium',

--- a/tests/foreman/performance/test_candlepin_concurrent_subscription_attach.py
+++ b/tests/foreman/performance/test_candlepin_concurrent_subscription_attach.py
@@ -2,7 +2,9 @@
 from robottelo.performance.constants import (
     ATTACH_ENV,
     RAW_ATT_FILE_NAME,
+    RAW_REG_FILE_NAME,
     STAT_ATT_FILE_NAME,
+    STAT_REG_FILE_NAME,
 )
 from robottelo.test import ConcurrentTestCase
 
@@ -19,7 +21,9 @@ class ConcurrentSubAttachTestCase(ConcurrentTestCase):
         cls._set_testcase_parameters(
             'performance.test.savepoint2_enabled_repos',
             RAW_ATT_FILE_NAME,
-            STAT_ATT_FILE_NAME
+            STAT_ATT_FILE_NAME,
+            raw_reg=RAW_REG_FILE_NAME,
+            stat_reg=STAT_REG_FILE_NAME,
         )
 
         # parameters for attach step


### PR DESCRIPTION
1. `robottelo.performance.candlepin.py`
Collect time points of register and attach, discard total timing
note:
Running performance test would generate 4 sets of test results:
`activationKey/attach/delete/register`

2. `robottelo.performance.constants`
Rename file name into full names for clarity
add register raw and stat output file name

3. `robottelo.performance.graph`
Add graph module

4. `robottelo.performance.stat`
Revise stat module to return stat results as dictionary

5. `robottelo.performance.thread`
Change `SubscribeAttachThread` class to separate `time_result_dictionary`
into two new dictionaries

6. `robottelo.test.py`
Separate register and attach as two different dictionaries
    *data structure now:
    `att{client: []}, ak{client: []}, reg{client: []}`
Generate charts after computing stat:
    *raw-<test_type>-concurrent.csv
    *raw-<test_type>-#-clients-line.svg
    *statistics-<test_type>-per-client-#-clients.svg
    *statistics-<test_type>-per-test-#-clients.svg
    *statistics-<test_type>-test-bucketized-#-clients.svg
    *statistics-<test_type>-client-<id>-bucketized-#-clients.svg
    *statistics-<test_type>-concurrent.csv
`_set_testcase_parameters`:
    for subscription by register + attach test case,
    would set extra parameter of register (i.e. raw/stat output filename)
`_get_output_filename`:
    decide type of test (ak/att/del/reg) and set as chart file name

7. `tests.foreman.performance.test_candlepin_concurrent_subscription_attach`
Add filenames for register test