### PR TITLE
Fixed CV Version delete closes #2586

### DIFF
--- a/tests/foreman/ui/test_contentviews.py
+++ b/tests/foreman/ui/test_contentviews.py
@@ -1235,6 +1235,7 @@ class TestContentViewsUI(UITestCase):
             session.nav.go_to_select_org(org.name)
             session.nav.go_to_content_views()
             self.content_views.delete_version(cv.name, version)
+            self.content_views.check_progress_bar_status(version)
             self.content_views.validate_version_deleted(cv.name, version)
 
     def test_delete_version_non_default(self):
@@ -1267,6 +1268,7 @@ class TestContentViewsUI(UITestCase):
             session.nav.go_to_select_org(org.name)
             session.nav.go_to_content_views()
             self.content_views.delete_version(cv.name, version)
+            self.content_views.check_progress_bar_status(version)
             self.content_views.validate_version_deleted(cv.name, version)
 
     def test_delete_version_with_ak(self):


### PR DESCRIPTION
Fixed the UI issue of deleting CV version by tracking progress bar.
After progress bar finishes, then it goes to verify that CV is deleted.

Test Results:
```
[root@jyejare robottelo]# nosetests -m test_delete_version_non_default ./tests/foreman/ui/test_contentviews.py
.
----------------------------------------------------------------------
Ran 1 test in 255.989s

OK

[root@jyejare robottelo]# nosetests -m test_delete_version_default ./tests/foreman/ui/test_contentviews.py
.
----------------------------------------------------------------------
Ran 1 test in 207.906s

OK
```