### PR TITLE
Simplify imports

### DIFF
--- a/robottelo/common/decorators.py
+++ b/robottelo/common/decorators.py
@@ -5,10 +5,7 @@ import bugzilla
 import logging
 import random
 import requests
-try:
-    import unittest
-except ImportError:
-    import unittest2 as unittest
+import unittest
 
 from ddt import data as ddt_data
 from functools import wraps

--- a/robottelo/test.py
+++ b/robottelo/test.py
@@ -9,10 +9,7 @@ import logging
 import os
 import signal
 import sys
-try:
-    import unittest
-except ImportError:
-    import unittest2 as unittest
+import unittest
 
 from automation_tools import product_install
 from datetime import datetime


### PR DESCRIPTION
`unittest2` is not listed as a requirement. Any reference to it is invalid.

`unittest` is included in the standard library. Importing `unittest2` when
`unittest` is not present is a no-op.