### PR TITLE
Added functional testcases for 'Active Directory' UserGroups.

### DIFF
--- a/docs/api/tests.foreman.ui.rst
+++ b/docs/api/tests.foreman.ui.rst
@@ -118,6 +118,11 @@
 
 .. automodule:: tests.foreman.ui.test_ldap_auth
 
+:mod:`tests.foreman.ui.test_ldapauthsource`
+-------------------------------------------
+
+.. automodule:: tests.foreman.ui.test_ldapauthsource
+
 :mod:`tests.foreman.ui.test_location`
 -------------------------------------
 

--- a/robottelo/common/constants.py
+++ b/robottelo/common/constants.py
@@ -98,6 +98,7 @@ FILTER = {
     'user_org': 'user_organization',
     'user_role': 'user_role',
     'usergroup_user': 'usergroup_user',
+    'usergroup_role': "usergroup_role",
 }
 
 RESOURCE_DEFAULT = 'Bare Metal'
@@ -603,9 +604,9 @@ TREND_TYPES = {
 }
 
 LDAP_SERVER_TYPE = {
-    'ipa': 'FreeIPA',
-    'ad': 'Active Directory',
-    'posix': 'POSIX',
+    'ipa': 'free_ipa',
+    'ad': 'active_directory',
+    'posix': 'posix',
 }
 
 LDAP_ATTR = {

--- a/robottelo/test.py
+++ b/robottelo/test.py
@@ -38,7 +38,7 @@ from robottelo.ui.gpgkey import GPGKey
 from robottelo.ui.hardwaremodel import HardwareModel
 from robottelo.ui.hostgroup import Hostgroup
 from robottelo.ui.hosts import Hosts
-from robottelo.ui.ldapusergroups import LdapAuth
+from robottelo.ui.ldapauthsource import LdapAuthSource
 from robottelo.ui.location import Location
 from robottelo.ui.login import Login
 from robottelo.ui.medium import Medium
@@ -135,11 +135,6 @@ class UITestCase(TestCase):
         cls.verbosity = int(conf.properties['main.verbosity'])
         cls.remote = int(conf.properties['main.remote'])
         cls.server_name = conf.properties.get('main.server.hostname')
-        cls.ldap_hostname = conf.properties.get('main.ldap.hostname')
-        cls.ldap_username = conf.properties.get('main.ldap.username')
-        cls.ldap_passwd = conf.properties.get('main.ldap.passwd')
-        cls.ldap_basedn = conf.properties.get('main.ldap.basedn')
-        cls.ldap_grpbasedn = conf.properties.get('main.ldap.grpbasedn')
         cls.screenshots_dir = conf.properties.get('main.screenshots.base_path')
 
         if int(conf.properties.get('main.virtual_display', '0')):
@@ -215,7 +210,7 @@ class UITestCase(TestCase):
         self.hardwaremodel = HardwareModel(self.browser)
         self.hostgroup = Hostgroup(self.browser)
         self.hosts = Hosts(self.browser)
-        self.ldapusergroups = LdapAuth(self.browser)
+        self.ldapauthsource = LdapAuthSource(self.browser)
         self.location = Location(self.browser)
         self.login = Login(self.browser)
         self.medium = Medium(self.browser)

--- a/robottelo/ui/factory.py
+++ b/robottelo/ui/factory.py
@@ -33,7 +33,7 @@ from robottelo.ui.template import Template
 from robottelo.ui.trend import Trend
 from robottelo.ui.user import User
 from robottelo.ui.usergroup import UserGroup
-from robottelo.ui.ldapusergroups import LdapAuth
+from robottelo.ui.ldapauthsource import LdapAuthSource
 
 
 def core_factory(create_args, kwargs, session, page, org=None, loc=None,
@@ -333,7 +333,10 @@ def make_usergroup(session, org=None, loc=None, force_context=True, **kwargs):
 
     create_args = {
         u'name': None,
-        u'users': None
+        u'users': None,
+        u'roles': None,
+        u'ext_usergrp': None,
+        u'ext_authsourceid': None,
     }
     page = session.nav.go_to_user_groups
     core_factory(create_args, kwargs, session, page,
@@ -603,4 +606,4 @@ def make_ldapauth(session, **kwargs):
     }
     page = session.nav.go_to_ldap_auth
     core_factory(create_args, kwargs, session, page)
-    LdapAuth(session.browser).create(**create_args)
+    LdapAuthSource(session.browser).create(**create_args)

--- a/robottelo/ui/ldapauthsource.py
+++ b/robottelo/ui/ldapauthsource.py
@@ -6,7 +6,7 @@ from robottelo.ui.navigator import Navigator
 from selenium.webdriver.support.select import Select
 
 
-class LdapAuth(Base):
+class LdapAuthSource(Base):
     """Implements CRUD functions from UI."""
 
     def create(self, name=None, server=None, ldaps=False, port=None,

--- a/robottelo/ui/locators.py
+++ b/robottelo/ui/locators.py
@@ -572,6 +572,12 @@ tab_locators = LocatorDict({
         By.XPATH, "//a[@data-toggle='tab' and contains(@href, 'account')]"),
     "ldapserver.tab_attributes": (
         By.XPATH, "//a[@data-toggle='tab' and contains(@href, 'attributes')]"),
+
+    # UserGroups
+    "usergroups.tab_roles": (
+        By.XPATH, "//a[@data-toggle='tab' and contains(@href, 'roles')]"),
+    "usergroups.tab_external": (
+        By.XPATH, "//a[@data-toggle='tab' and contains(@href, 'external')]"),
 })
 
 common_locators = LocatorDict({
@@ -697,6 +703,9 @@ locators = LocatorDict({
     "login.username": (By.ID, "login_login"),
     "login.password": (By.ID, "login_password"),
     "login.gravatar": (By.XPATH, "//img[contains(@class, 'avatar')]"),
+    "login.loggedin": (
+        By.XPATH,
+        "//a[@id='account_menu' and contains(., '%s')]"),
 
     # Organizations
     "org.new": (
@@ -978,6 +987,20 @@ locators = LocatorDict({
     "usergroups.usergroup": (By.XPATH, "//a[contains(., '%s')]"),
     "usergroups.delete": (
         By.XPATH, "//a[@class='delete' and contains(@data-confirm, '%s')]"),
+    "usergroups.admin": (
+        By.ID, "usergroup_admin"),
+    "usergroups.addexternal_usergrp": (
+        By.XPATH, "//a[@data-association='external_usergroups']"),
+    "usergroups.ext_usergroup_name": (
+        By.XPATH,
+        ("//input[not(contains(@id, 'new_external_usergroups')) and "
+         "contains(@name, 'name') and contains(@id, "
+         "'external_usergroups_attributes_new')]")),
+    "usergroups.ext_authsource_id": (
+        By.XPATH,
+        ("//select[not(contains(@id, 'new_external_usergroups')) and "
+         "contains(@name, 'auth_source_id') and contains(@id, "
+         "'external_usergroups_attributes_new')]")),
 
     # Roles
     "roles.new": (By.XPATH, "//a[contains(@href, '/roles/new')]"),
@@ -1948,10 +1971,13 @@ locators = LocatorDict({
         By.XPATH, "//a[@data-confirm='Delete %s?']"),
     "ldapserver.ldap_servername": (
         By.XPATH, "//a[contains(@href, 'edit') and contains(@href, '%s')]"),
+    "ldapserver.refresh": (
+        By.XPATH,
+        ("//td[contains(.,'foobargroup')]/../td/"
+         "a[contains(@data-id, 'refresh')]")),
 
     # Red Hat Access Insights locators
     "insights.registered_systems": (
         By.XPATH,
         ("//div[@class='system-summary']/p")),
-
 })

--- a/robottelo/ui/usergroup.py
+++ b/robottelo/ui/usergroup.py
@@ -2,26 +2,40 @@
 """Implements User groups UI."""
 
 from robottelo.ui.base import Base, UIError
-from robottelo.ui.locators import locators, common_locators
+from robottelo.ui.locators import locators, common_locators, tab_locators
 from robottelo.common.constants import FILTER
+from selenium.webdriver.support.select import Select
 
 
 class UserGroup(Base):
     """Implements the CRUD functions for User groups."""
 
-    def create(self, name, users=None):
+    def create(self, name, users=None, roles=None,
+               ext_usergrp=None, ext_authsourceid=None):
         """Creates new usergroup."""
-        self.wait_until_element(locators['usergroups.new']).click()
+        self.click(locators['usergroups.new'])
 
-        if self.wait_until_element(locators['usergroups.name']):
-            self.find_element(locators['usergroups.name']).send_keys(name)
-            self.configure_entity(users, FILTER['usergroup_user'])
-            self.find_element(common_locators['submit']).click()
-            self.wait_for_ajax()
-        else:
-            raise UIError(
-                'Could not create new usergroup "{0}"'.format(name)
+        if self.wait_until_element(locators['usergroups.name']) is None:
+            raise UIError('Could not create new usergroup "{0}"'.format(name))
+        self.find_element(locators['usergroups.name']).send_keys(name)
+        self.configure_entity(users, FILTER['usergroup_user'])
+        if roles:
+            self.click(tab_locators['usergroups.tab_roles'])
+            if "admin" in roles:
+                self.click(locators['usergroups.admin'])
+            else:
+                self.configure_entity(roles, FILTER['usergroup_role'])
+        if ext_usergrp:
+            self.click(tab_locators['usergroups.tab_external'])
+            self.click(locators['usergroups.addexternal_usergrp'])
+            self.text_field_update(
+                locators['usergroups.ext_usergroup_name'],
+                ext_usergrp
             )
+            Select(
+                self.find_element(locators['usergroups.ext_authsource_id'])
+            ).select_by_visible_text(ext_authsourceid)
+        self.click(common_locators['submit'])
 
     def search(self, name):
         """Searches existing usergroup from UI."""
@@ -37,8 +51,13 @@ class UserGroup(Base):
         )
 
     def update(self, old_name, new_name=None,
-               users=None, new_users=None):
+               users=None, new_users=None, roles=None, new_roles=None,
+               entity_select=None, refresh_extusrgp=False):
         """Update usergroup name and its users."""
+        if roles is None:
+            roles = []
+        if new_roles is None:
+            new_roles = []
         element = self.search(old_name)
 
         if element:
@@ -49,7 +68,21 @@ class UserGroup(Base):
                     self.field_update('usergroups.name', new_name)
             self.configure_entity(
                 users, FILTER['usergroup_user'], new_entity_list=new_users)
-            self.find_element(common_locators['submit']).click()
-            self.wait_for_ajax()
+            if roles or new_roles:
+                self.click(tab_locators['usergroups.tab_roles'])
+                if "admin" in roles or "admin" in new_roles:
+                    self.click(locators['usergroups.admin'])
+                else:
+                    self.configure_entity(
+                        entity_list=roles,
+                        new_entity_list=new_roles,
+                        filter_key=FILTER['usergroup_role'],
+                        entity_select=entity_select,
+                    )
+            if refresh_extusrgp:
+                self.click(tab_locators['usergroups.tab_external'])
+                self.click(locators['ldapserver.refresh'])
+            else:
+                self.click(common_locators['submit'])
         else:
             raise UIError('Could not find usergroup "{0}"'.format(old_name))

--- a/tests/foreman/ui/test_adusergroups.py
+++ b/tests/foreman/ui/test_adusergroups.py
@@ -1,81 +1,64 @@
 """Test class for Active Directory Feature"""
 from ddt import ddt
-from robottelo.common.constants import LDAP_SERVER_TYPE, LDAP_ATTR
-from robottelo.common.decorators import data, stubbed
-from robottelo.common.helpers import generate_strings_list
+from fauxfactory import gen_string
+from nailgun import entities
+from robottelo.common import conf
+from robottelo.common.constants import (
+    LDAP_SERVER_TYPE, LDAP_ATTR, PERMISSIONS, ANY_CONTEXT)
+from robottelo.common.decorators import stubbed, skip_if_bug_open
 from robottelo.test import UITestCase
-from robottelo.ui.factory import make_ldapauth
+from robottelo.ui.factory import (
+    make_role, make_usergroup, make_loc, make_org, set_context)
+from robottelo.ui.locators import locators, menu_locators
 from robottelo.ui.session import Session
+from selenium.webdriver.common.action_chains import ActionChains
 
 
 @ddt
 class ADUserGroups(UITestCase):
     """Implements Active Directory feature tests in UI."""
 
-    @data(*generate_strings_list())
-    def test_create_ldap_auth_withad(self, server_name):
-        """@Test: Create LDAP authentication with AD
+    ldap_user_name = conf.properties['main.ldap.username']
+    ldap_user_passwd = conf.properties['main.ldap.passwd']
+    base_dn = conf.properties['main.ldap.basedn']
+    group_base_dn = conf.properties['main.ldap.grpbasedn']
+    usergroup_name = gen_string("alpha")
+    usergroup_name2 = gen_string("alpha")
 
-        @Feature: LDAP Authentication - Active Directory - create LDAP AD
+    @classmethod
+    def setUpClass(cls):  # noqa
+        authsource_attrs = entities.AuthSourceLDAP(
+            onthefly_register=True,
+            account=cls.ldap_user_name,
+            account_password=cls.ldap_user_passwd,
+            base_dn=cls.base_dn,
+            groups_base=cls.group_base_dn,
+            attr_firstname=LDAP_ATTR['firstname'],
+            attr_lastname=LDAP_ATTR['surname'],
+            attr_login=LDAP_ATTR['login_ad'],
+            server_type=LDAP_SERVER_TYPE['ad'],
+            attr_mail=LDAP_ATTR['mail'],
+            name=gen_string("alpha", 8),
+            host=conf.properties['main.ldap.hostname'],
+            tls=False,
+            port="389",
+        ).create()
+        cls.ldap_server_name = authsource_attrs.name
+        super(ADUserGroups, cls).setUpClass()
 
-        @steps:
-
-        1. Create a new LDAP Auth source with AD.
-        2. Fill in all the fields appropriately for AD.
-
-        @Assert: Whether creating LDAP Auth with AD is successful.
-
-        """
+    def tearDown(self):
         with Session(self.browser) as session:
-            make_ldapauth(
-                session,
-                name=server_name,
-                server=self.ldap_hostname,
-                server_type=LDAP_SERVER_TYPE['ad'],
-                login_name=LDAP_ATTR['login_ad'],
-                first_name=LDAP_ATTR['firstname'],
-                surname=LDAP_ATTR['surname'],
-                mail=LDAP_ATTR['mail'],
-                account_user=self.ldap_username,
-                account_passwd=self.ldap_passwd,
-                account_basedn=self.ldap_basedn,
-                account_grpbasedn=self.ldap_grpbasedn
-            )
-            self.assertIsNotNone(self.ldapusergroups.search(server_name))
+            session.nav.go_to_user_groups()
+            if self.usergroup.search(self.usergroup_name):
+                self.usergroup.delete(self.usergroup_name, True)
+            if self.usergroup.search(self.usergroup_name2):
+                self.usergroup.delete(self.usergroup_name2, True)
+            set_context(session, org=ANY_CONTEXT['org'])
+            session.nav.go_to_users()
+            if self.user.search(self.ldap_user_name, "login"):
+                self.user.delete(self.ldap_user_name, "login", True)
+        super(ADUserGroups, self).tearDown()
 
-    @data(*generate_strings_list())
-    def test_delete_ldap_auth_withad(self, server_name):
-        """@Test: Delete LDAP authentication with AD
-
-        @Feature: LDAP Authentication - Active Directory - delete LDAP AD
-
-        @steps:
-
-        1. Delete LDAP Auth source with AD.
-        2. Fill in all the fields appropriately for AD.
-
-        @Assert: Whether deleting LDAP Auth with AD is successful.
-
-        """
-        with Session(self.browser) as session:
-            make_ldapauth(
-                session,
-                name=server_name,
-                server=self.ldap_hostname,
-                server_type=LDAP_SERVER_TYPE['ad'],
-                login_name=LDAP_ATTR['login_ad'],
-                first_name=LDAP_ATTR['firstname'],
-                surname=LDAP_ATTR['surname'],
-                mail=LDAP_ATTR['mail'],
-                account_user=self.ldap_username,
-                account_passwd=self.ldap_passwd,
-                account_basedn=self.ldap_basedn,
-                account_grpbasedn=self.ldap_grpbasedn
-            )
-            self.assertIsNotNone(self.ldapusergroups.search(server_name))
-            self.ldapusergroups.delete(server_name)
-
-    @stubbed()
     def test_adusergroup_admin_role(self):
         """@Test: Associate Admin role to User Group.
         [belonging to external AD User Group.]
@@ -91,12 +74,26 @@ class ADUserGroups(UITestCase):
 
         @Assert: Whether a User belonging to User Group is able to
         access all the pages.
-
-        @Status: Manual
-
         """
+        strategy, value = locators['login.loggedin']
+        with Session(self.browser) as session:
+            make_usergroup(
+                session,
+                name=self.usergroup_name,
+                roles=["admin"],
+                ext_usergrp="foobargroup",
+                ext_authsourceid="LDAP-" + self.ldap_server_name,
+            )
+            self.assertIsNotNone(self.usergroup.search(self.usergroup_name))
+        with Session(
+            self.browser,
+            self.ldap_user_name,
+            self.ldap_user_passwd,
+        ) as session:
+            self.assertIsNotNone(self.login.wait_until_element(
+                (strategy, value % self.ldap_user_name)
+            ))
 
-    @stubbed()
     def test_adusergroup_foreman_role(self):
         """@Test: Associate foreman roles to User Group.
         [belonging to external AD User Group.]
@@ -112,12 +109,37 @@ class ADUserGroups(UITestCase):
 
         @Assert: Whether a User belonging to User Group is able to
         access foreman entities as per roles.
-
-        @Status: Manual
-
         """
+        strategy, value = locators['login.loggedin']
+        foreman_role = gen_string("alpha")
+        location_name = gen_string("alpha")
+        with Session(self.browser) as session:
+            make_role(session, name=foreman_role)
+            self.role.update(
+                foreman_role,
+                add_permission=True,
+                permission_list=PERMISSIONS['Location'],
+                resource_type='Location',
+            )
+            make_usergroup(
+                session,
+                name=self.usergroup_name,
+                roles=[foreman_role],
+                ext_usergrp="foobargroup",
+                ext_authsourceid="LDAP-" + self.ldap_server_name,
+            )
+            self.assertIsNotNone(self.usergroup.search(self.usergroup_name))
+        with Session(
+            self.browser,
+            self.ldap_user_name,
+            self.ldap_user_passwd,
+        ) as session:
+            self.assertIsNotNone(self.login.wait_until_element(
+                (strategy, value % self.ldap_user_name)
+            ))
+            make_loc(session, name=location_name)
+            self.assertIsNotNone(self.location.search(location_name))
 
-    @stubbed()
     def test_adusergroup_katello_role(self):
         """@Test: Associate katello roles to User Group.
         [belonging to external AD User Group.]
@@ -134,11 +156,37 @@ class ADUserGroups(UITestCase):
         @Assert: Whether a User belonging to User Group is able to access
         katello entities as per roles.
 
-        @Status: Manual
-
         """
+        strategy, value = locators['login.loggedin']
+        katello_role = gen_string("alpha")
+        org_name = gen_string("alpha")
+        with Session(self.browser) as session:
+            make_role(session, name=katello_role)
+            self.role.update(
+                katello_role,
+                add_permission=True,
+                permission_list=PERMISSIONS['Organization'],
+                resource_type='Organization',
+            )
+            make_usergroup(
+                session,
+                name=self.usergroup_name,
+                roles=[katello_role],
+                ext_usergrp="foobargroup",
+                ext_authsourceid="LDAP-" + self.ldap_server_name,
+            )
+            self.assertIsNotNone(self.usergroup.search(self.usergroup_name))
+        with Session(
+            self.browser,
+            self.ldap_user_name,
+            self.ldap_user_passwd,
+        ) as session:
+            self.assertIsNotNone(self.login.wait_until_element(
+                (strategy, value % self.ldap_user_name)
+            ))
+            make_org(session, org_name=org_name)
+            self.assertIsNotNone(self.org.search(org_name))
 
-    @stubbed()
     def test_create_external_adusergroup_1(self):
         """@Test: Create External AD User Group as per AD group
 
@@ -151,12 +199,17 @@ class ADUserGroups(UITestCase):
         3. create an External AD UserGroup as per the UserGroup name in AD
 
         @Assert: Whether creation of External AD User Group is possible.
-
-        @Status: Manual
-
         """
+        with Session(self.browser) as session:
+            make_usergroup(
+                session,
+                name=self.usergroup_name,
+                roles=["admin"],
+                ext_usergrp="foobargroup",
+                ext_authsourceid="LDAP-" + self.ldap_server_name,
+            )
+            self.assertIsNotNone(self.usergroup.search(self.usergroup_name))
 
-    @stubbed()
     def test_create_external_adusergroup_2(self):
         """@Test: Create another External AD User Group with same name
 
@@ -172,12 +225,25 @@ class ADUserGroups(UITestCase):
 
         @Assert: Creation of External AD User Group should not be possible with
         same name.
-
-        @Status: Manual
-
         """
+        with Session(self.browser) as session:
+            make_usergroup(
+                session,
+                name=self.usergroup_name,
+                roles=['admin'],
+                ext_usergrp="foobargroup",
+                ext_authsourceid="LDAP-" + self.ldap_server_name,
+            )
+            self.assertIsNotNone(self.usergroup.search(self.usergroup_name))
+            make_usergroup(
+                session,
+                name=self.usergroup_name2,
+                roles=['admin'],
+                ext_usergrp="foobargroup",
+                ext_authsourceid="LDAP-" + self.ldap_server_name,
+            )
+            self.assertIsNone(self.usergroup.search(self.usergroup_name2))
 
-    @stubbed()
     def test_create_external_adusergroup_3(self):
         """@Test: Create External AD User Group with random name
 
@@ -191,10 +257,16 @@ class ADUserGroups(UITestCase):
 
         @Assert: Creation of External AD User Group should not be possible with
         random name.
-
-        @Status: Manual
-
         """
+        with Session(self.browser) as session:
+            make_usergroup(
+                session,
+                name=self.usergroup_name,
+                roles=['admin'],
+                ext_usergrp=gen_string("alpha"),
+                ext_authsourceid="LDAP-" + self.ldap_server_name,
+            )
+            self.assertIsNone(self.usergroup.search(self.usergroup_name))
 
     @stubbed()
     def test_delete_external_adusergroup(self):
@@ -218,8 +290,7 @@ class ADUserGroups(UITestCase):
         @Status: Manual
 
         """
-
-    @stubbed()
+    @skip_if_bug_open('bugzilla', '1221971')
     def test_external_adusergroup_roles_update(self):
         """@test: Added AD UserGroup roles get pushed down to user
 
@@ -239,11 +310,67 @@ class ADUserGroups(UITestCase):
         @assert: User has access to all NEW functional areas that are assigned
         to aforementioned UserGroup.
 
-        @status: Manual
-
         """
+        strategy, value = locators['login.loggedin']
+        foreman_role = gen_string("alpha")
+        katello_role = gen_string("alpha")
+        org_name = gen_string("alpha")
+        loc_name = gen_string("alpha")
+        with Session(self.browser) as session:
+            make_role(session, name=foreman_role)
+            self.role.update(
+                foreman_role,
+                add_permission=True,
+                permission_list=PERMISSIONS['Location'],
+                resource_type='Location',
+            )
+            make_usergroup(
+                session,
+                name=self.usergroup_name,
+                roles=[foreman_role],
+                ext_usergrp="foobargroup",
+                ext_authsourceid="LDAP-" + self.ldap_server_name,
+            )
+            self.assertIsNotNone(self.usergroup.search(self.usergroup_name))
+        with Session(
+            self.browser,
+            self.ldap_user_name,
+            self.ldap_user_passwd,
+        ) as session:
+            self.assertIsNotNone(self.login.wait_until_element(
+                (strategy, value % self.ldap_user_name)
+            ))
+            make_loc(session, name=loc_name)
+            self.assertIsNotNone(self.location.search(loc_name))
+        with Session(self.browser) as session:
+            make_role(session, name=katello_role)
+            self.role.update(
+                katello_role,
+                add_permission=True,
+                permission_list=PERMISSIONS['Organization'],
+                resource_type='Organization',
+            )
+            session.nav.go_to_user_groups()
+            self.usergroup.update(
+                self.usergroup_name,
+                new_roles=[katello_role],
+                entity_select=True,
+            )
+            self.usergroup.update(
+                self.usergroup_name,
+                refresh_extusrgp=True,
+            )
+        with Session(
+            self.browser,
+            self.ldap_user_name,
+            self.ldap_user_passwd,
+        ) as session:
+            self.assertIsNotNone(self.login.wait_until_element(
+                (strategy, value % self.ldap_user_name)
+            ))
+            make_org(session, name=org_name)
+            self.assertIsNotNone(self.org.search(org_name))
 
-    @stubbed()
     def test_external_adusergroup_roles_delete(self):
         """@test: Deleted AD UserGroup roles get pushed down to user
 
@@ -263,9 +390,55 @@ class ADUserGroups(UITestCase):
         @assert: User no longer has access to all deleted functional areas
         that were assigned to aforementioned UserGroup.
 
-        @status: Manual
-
         """
+        strategy, value = locators['login.loggedin']
+        foreman_role = gen_string("alpha")
+        with Session(self.browser) as session:
+            make_role(session, name=foreman_role)
+            self.role.update(
+                foreman_role,
+                add_permission=True,
+                permission_list=PERMISSIONS['Location'],
+                resource_type='Location',
+            )
+            make_usergroup(
+                session,
+                name=self.usergroup_name,
+                roles=[foreman_role],
+                ext_usergrp="foobargroup",
+                ext_authsourceid="LDAP-" + self.ldap_server_name,
+            )
+            self.assertIsNotNone(self.usergroup.search(self.usergroup_name))
+        with Session(
+            self.browser,
+            self.ldap_user_name,
+            self.ldap_user_passwd,
+        ) as session:
+            self.assertIsNotNone(self.login.wait_until_element(
+                (strategy, value % self.ldap_user_name)
+            ))
+        with Session(self.browser) as session:
+            session.nav.go_to_user_groups()
+            self.usergroup.update(
+                self.usergroup_name,
+                roles=[foreman_role],
+                entity_select=False)
+        with Session(
+            self.browser,
+            self.ldap_user_name,
+            self.ldap_user_passwd,
+        ) as session:
+            self.assertIsNotNone(self.login.wait_until_element(
+                (strategy, value % self.ldap_user_name)
+            ))
+            ActionChains(
+                self.browser
+            ).move_to_element(session.nav.wait_until_element(
+                menu_locators['menu.any_context']
+            )).perform()
+            self.assertIsNone(session.nav.wait_until_element(
+                menu_locators['loc.manage_loc']
+            ))
 
     @stubbed()
     def test_external_adUserGroup_additional_user_roles(self):

--- a/tests/foreman/ui/test_ldapauthsource.py
+++ b/tests/foreman/ui/test_ldapauthsource.py
@@ -1,0 +1,76 @@
+"""Test class for Active Directory Feature"""
+from ddt import ddt
+from robottelo.common.constants import LDAP_SERVER_TYPE, LDAP_ATTR
+from robottelo.common.decorators import data
+from robottelo.common.helpers import generate_strings_list
+from robottelo.test import UITestCase
+from robottelo.ui.factory import make_ldapauth
+from robottelo.ui.session import Session
+
+
+@ddt
+class LDAPAuthSource(UITestCase):
+    """Implements Active Directory feature tests in UI."""
+
+    @data(*generate_strings_list())
+    def test_create_ldap_authsource_withad(self, server_name):
+        """@Test: Create LDAP authentication with AD
+
+        @Feature: LDAP Authentication - Active Directory - create LDAP AD
+
+        @steps:
+
+        1. Create a new LDAP Auth source with AD.
+        2. Fill in all the fields appropriately for AD.
+
+        @Assert: Whether creating LDAP Auth with AD is successful.
+
+        """
+        with Session(self.browser) as session:
+            make_ldapauth(
+                session,
+                name=server_name,
+                server=self.ldap_hostname,
+                server_type=LDAP_SERVER_TYPE['ad'],
+                login_name=LDAP_ATTR['login_ad'],
+                first_name=LDAP_ATTR['firstname'],
+                surname=LDAP_ATTR['surname'],
+                mail=LDAP_ATTR['mail'],
+                account_user=self.ldap_username,
+                account_passwd=self.ldap_passwd,
+                account_basedn=self.ldap_basedn,
+                account_grpbasedn=self.ldap_grpbasedn
+            )
+            self.assertIsNotNone(self.ldapusergroups.search(server_name))
+
+    @data(*generate_strings_list())
+    def test_delete_ldap_auth_withad(self, server_name):
+        """@Test: Delete LDAP authentication with AD
+
+        @Feature: LDAP Authentication - Active Directory - delete LDAP AD
+
+        @steps:
+
+        1. Delete LDAP Auth source with AD.
+        2. Fill in all the fields appropriately for AD.
+
+        @Assert: Whether deleting LDAP Auth with AD is successful.
+
+        """
+        with Session(self.browser) as session:
+            make_ldapauth(
+                session,
+                name=server_name,
+                server=self.ldap_hostname,
+                server_type=LDAP_SERVER_TYPE['ad'],
+                login_name=LDAP_ATTR['login_ad'],
+                first_name=LDAP_ATTR['firstname'],
+                surname=LDAP_ATTR['surname'],
+                mail=LDAP_ATTR['mail'],
+                account_user=self.ldap_username,
+                account_passwd=self.ldap_passwd,
+                account_basedn=self.ldap_basedn,
+                account_grpbasedn=self.ldap_grpbasedn
+            )
+            self.assertIsNotNone(self.ldapusergroups.search(server_name))
+            self.ldapusergroups.delete(server_name)


### PR DESCRIPTION
*) Renamed ldapusergroups to ldapauthsource to group with FreeIPA
   and Directory Services scenarios.
*) Automated many new functional testcases related external
   ad-usergroups.
*) Used tearDown to delete UserGroups and Users for isolating
   permissions of the external user.
*) Ldap auth source is added once via the setUpClass and all
   the tests use it for accessing the users of Active Directory.
*) Active Directory details are fetch from the robottelo.prop file.