### PR TITLE
Re-factor code corresponding to #41 issue in Nailgun

### DIFF
--- a/tests/foreman/api/test_contentviewfilter.py
+++ b/tests/foreman/api/test_contentviewfilter.py
@@ -49,7 +49,8 @@ class ContentViewFilterTestCase(APITestCase):
         self.content_view = entities.ContentView(
             organization=self.org,
         ).create()
-        self.content_view.set_repository_ids(repo_ids=[self.repo.id])
+        self.content_view.repository = [self.repo]
+        self.content_view.update(['repository'])
 
     def test_get_with_no_args(self):
         """@Test: Issue an HTTP GET to the base content view filters path.
@@ -233,9 +234,8 @@ class ContentViewFilterTestCase(APITestCase):
             product=self.product.id,
             url=DOCKER_REGISTRY_HUB,
         ).create()
-        self.content_view.set_repository_ids(
-            repo_ids=[self.repo.id, docker_repository.id]
-        )
+        self.content_view.repository = [self.repo, docker_repository]
+        self.content_view.update(['repository'])
         cvf = entities.RPMContentViewFilter(
             content_view=self.content_view,
             inclusion=True,
@@ -401,7 +401,8 @@ class ContentViewFilterTestCase(APITestCase):
         ).create()
         new_repo = entities.Repository(product=self.product).create()
         new_repo.sync()
-        self.content_view.set_repository_ids(repo_ids=[new_repo.id])
+        self.content_view.repository = [new_repo]
+        self.content_view.update(['repository'])
         cvf.repository = [new_repo]
         cvf = cvf.update(['repository'])
         self.assertEqual(len(cvf.repository), 1)
@@ -428,9 +429,8 @@ class ContentViewFilterTestCase(APITestCase):
         ]
         for repo in repos:
             repo.sync()
-        self.content_view.set_repository_ids(
-            repo_ids=[repo.id for repo in repos],
-        )
+        self.content_view.repository = repos
+        self.content_view.update(['repository'])
         cvf.repository = repos
         cvf = cvf.update(['repository'])
         self.assertEqual(
@@ -482,9 +482,8 @@ class ContentViewFilterTestCase(APITestCase):
             product=self.product.id,
             url=DOCKER_REGISTRY_HUB,
         ).create()
-        self.content_view.set_repository_ids(
-            repo_ids=[self.repo.id, docker_repository.id]
-        )
+        self.content_view.repository = [self.repo, docker_repository]
+        self.content_view = self.content_view.update(['repository'])
         cvf.repository = [self.repo, docker_repository]
         cvf = cvf.update(['repository'])
         self.assertEqual(len(cvf.repository), 2)

--- a/tests/foreman/api/test_contentviewversion.py
+++ b/tests/foreman/api/test_contentviewversion.py
@@ -17,9 +17,9 @@ class CVVersionTestCase(APITestCase):
         @Feature: ContentViewVersion
 
         """
-        env = entities.Environment().create()
+        env = entities.Environment().create().id
         with self.assertRaises(HTTPError):
-            entities.ContentViewVersion(id=1).promote(env.id)
+            entities.ContentViewVersion(id=1).promote({u'environment_id': env})
 
     def test_negative_promote_2(self):
         """@Test: Promote a content view version using an invalid environment.
@@ -30,7 +30,7 @@ class CVVersionTestCase(APITestCase):
 
         """
         with self.assertRaises(HTTPError):
-            entities.ContentViewVersion(id=1).promote(-1)
+            entities.ContentViewVersion(id=1).promote({u'environment_id': -1})
 
     def test_delete_version(self):
         """@Test: Create content view and publish it. After that try to
@@ -97,9 +97,8 @@ class CVVersionTestCase(APITestCase):
         content_view = content_view.read()
         self.assertEqual(len(content_view.version), 1)
         self.assertEqual(len(content_view.version[0].read().environment), 1)
-        content_view.version[0].promote(
-            entities.LifecycleEnvironment(organization=org).create().id
-        )
+        lce = entities.LifecycleEnvironment(organization=org).create()
+        content_view.version[0].promote({u'environment_id': lce.id})
         cvv = content_view.version[0].read()
         self.assertEqual(len(cvv.environment), 2)
         # Delete the content-view version from selected environments

--- a/tests/foreman/api/test_hostgroup.py
+++ b/tests/foreman/api/test_hostgroup.py
@@ -46,15 +46,18 @@ class HostGroupTestCase(APITestCase):
 
         result = content_view.available_puppet_modules()['results']
         self.assertEqual(len(result), 1)
-        content_view.add_puppet_module(result[0]['author'], result[0]['name'])
-
+        entities.ContentViewPuppetModule(
+            author=result[0]['author'],
+            name=result[0]['name'],
+            content_view=content_view,
+        ).create()
         content_view.publish()
         content_view = content_view.read()
         lc_env = entities.LifecycleEnvironment(
             name=gen_string('alpha'),
             organization=org,
         ).create()
-        content_view.version[0].promote(lc_env.id)
+        content_view.version[0].promote({u'environment_id': lc_env.id})
         content_view = content_view.read()
         self.assertEqual(len(content_view.version), 1)
         self.assertEqual(len(content_view.puppet_module), 1)

--- a/tests/foreman/api/test_product.py
+++ b/tests/foreman/api/test_product.py
@@ -138,7 +138,9 @@ class RepositorySetsTestCase(APITestCase):
 
         """
         org = entities.Organization().create()
-        org.upload_manifest(path=manifests.clone())
+        sub = entities.Subscription()
+        with open(manifests.clone(), 'rb') as manifest:
+            sub.upload({'organization_id': org.id}, manifest)
         prd_id = entities.Product().fetch_rhproduct_id(
             name=PRDS['rhel'],
             org_id=org.id,
@@ -170,7 +172,9 @@ class RepositorySetsTestCase(APITestCase):
 
         """
         org = entities.Organization().create()
-        org.upload_manifest(path=manifests.clone())
+        sub = entities.Subscription()
+        with open(manifests.clone(), 'rb') as manifest:
+            sub.upload({'organization_id': org.id}, manifest)
         prd_id = entities.Product().fetch_rhproduct_id(
             name=PRDS['rhel'],
             org_id=org.id,

--- a/tests/foreman/api/test_repository.py
+++ b/tests/foreman/api/test_repository.py
@@ -245,9 +245,10 @@ class RepositorySyncTestCase(APITestCase):
         @Assert: Repository synced should fetch the data successfully.
 
         """
-        cloned_manifest_path = manifests.clone()
         org = entities.Organization().create()
-        org.upload_manifest(path=cloned_manifest_path)
+        sub = entities.Subscription()
+        with open(manifests.clone(), 'rb') as manifest:
+            sub.upload({'organization_id': org.id}, manifest)
         repo_id = utils.enable_rhrepo_and_fetchid(
             'x86_64',
             org.id,

--- a/tests/foreman/cli/test_activationkey.py
+++ b/tests/foreman/cli/test_activationkey.py
@@ -3,7 +3,6 @@
 
 from ddt import ddt
 from fauxfactory import gen_string
-from nailgun.entities import Organization
 from robottelo.cli.activationkey import ActivationKey
 from robottelo.cli.contentview import ContentView
 from robottelo.cli.lifecycleenvironment import LifecycleEnvironment
@@ -84,9 +83,12 @@ class TestActivationKey(CLITestCase):
                     'organization-id': organization_id,
                 })['id']
                 TestActivationKey.pub_key['manifest'] = manifests.clone()
-                Organization(
-                    id=TestActivationKey.pub_key['org_id']
-                ).upload_manifest(TestActivationKey.pub_key['manifest'])
+
+                upload_file(TestActivationKey.pub_key['manifest'])
+                Subscription.upload({
+                    'file': TestActivationKey.pub_key['manifest'],
+                    'organization-id': TestActivationKey.pub_key['org_id'],
+                })
 
                 # create content view
                 TestActivationKey.pub_key['content_view_id'] = (

--- a/tests/foreman/cli/test_contentviews.py
+++ b/tests/foreman/cli/test_contentviews.py
@@ -5,7 +5,6 @@ import unittest
 
 from ddt import ddt
 from fauxfactory import gen_alphanumeric, gen_string
-from nailgun.entities import Organization
 from robottelo.cli.contentview import ContentView
 from robottelo.cli.factory import (
     CLIFactoryError,
@@ -22,6 +21,7 @@ from robottelo.common import manifests
 from robottelo.cli.repository import Repository
 from robottelo.cli.repository_set import RepositorySet
 from robottelo.cli.puppetmodule import PuppetModule
+from robottelo.cli.subscription import Subscription
 from robottelo.common.constants import FAKE_0_PUPPET_REPO, NOT_IMPLEMENTED
 from robottelo.common.decorators import (
     data,
@@ -29,6 +29,7 @@ from robottelo.common.decorators import (
     skip_if_bug_open,
     stubbed,
 )
+from robottelo.common.ssh import upload_file
 from robottelo.test import CLITestCase
 
 
@@ -89,11 +90,13 @@ class TestContentView(CLITestCase):
 
         TestContentView.rhel_content_org = make_org()
         manifest = manifests.clone()
-        Organization(
-            id=TestContentView.rhel_content_org['id']
-        ).upload_manifest(manifest)
+        upload_file(manifest)
+        Subscription.upload({
+            'file': manifest,
+            'organization-id': TestContentView.rhel_content_org['id'],
+        })
 
-        result = RepositorySet.enable({
+        RepositorySet.enable({
             'name': (
                 'Red Hat Enterprise Virtualization Agents '
                 'for RHEL 6 Workstation (RPMs)'

--- a/tests/foreman/ui/test_contentsearch.py
+++ b/tests/foreman/ui/test_contentsearch.py
@@ -38,8 +38,9 @@ class TestContentSearchUI(UITestCase):
             name=gen_string('alpha'),
             organization=org,
         ).create()
-        content_view.set_repository_ids([yum_repo.id])
-        self.assertEqual(len(content_view.read_json()['repositories']), 1)
+        content_view.repository = [yum_repo]
+        content_view = content_view.update(['repository'])
+        self.assertEqual(len(content_view.repository), 1)
         content_view.publish()
 
         with Session(self.browser) as session:

--- a/tests/foreman/ui/test_gpgkey.py
+++ b/tests/foreman/ui/test_gpgkey.py
@@ -426,20 +426,20 @@ class GPGKey(UITestCase):
         self.assertEqual(len(cv['versions']), 1)
         entities.ContentViewVersion(
             id=cv['versions'][0]['id']
-        ).promote(lc_env_id)
+        ).promote({u'environment_id': lc_env_id})
         # step 7: Create activation key
         ak_id = entities.ActivationKey(
             name=activation_key_name,
             environment=lc_env_id,
             organization=self.org_id,
             content_view=content_view.id,
-        ).create_json()['id']
-        for subscription in entities.Organization(
-                id=self.org_id).subscriptions():
-            if subscription['product_name'] == product_name:
+        ).create().id
+        for subscription in entities.Subscription(
+                organization=self.org_id).search():
+            if subscription.read_json()['product_name'] == product_name:
                 entities.ActivationKey(id=ak_id).add_subscriptions({
                     'quantity': 1,
-                    'subscription_id': subscription['id'],
+                    'subscription_id': subscription.id,
                 })
                 break
         # Create VM

--- a/tests/foreman/ui/test_org.py
+++ b/tests/foreman/ui/test_org.py
@@ -238,8 +238,10 @@ class Org(UITestCase):
         @assert: Organization is deleted successfully.
 
         """
-        entities.Organization(name=org_name).create().upload_manifest(
-            path=manifests.clone())
+        org = entities.Organization(name=org_name).create()
+        sub = entities.Subscription()
+        with open(manifests.clone(), 'rb') as manifest:
+            sub.upload({'organization_id': org.id}, manifest)
         with Session(self.browser) as session:
             make_lifecycle_environment(session, org_name, name='DEV')
             make_lifecycle_environment(

--- a/tests/foreman/ui/test_sync.py
+++ b/tests/foreman/ui/test_sync.py
@@ -6,7 +6,6 @@ from robottelo.common.constants import FAKE_1_YUM_REPO
 from robottelo.common.decorators import data, run_only_on
 from robottelo.common.helpers import generate_strings_list
 from robottelo.common import manifests
-from robottelo.common.ssh import upload_file
 from robottelo.test import UITestCase
 from robottelo.ui.session import Session
 
@@ -72,12 +71,9 @@ class Sync(UITestCase):
         """
 
         repos = self.sync.create_repos_tree(RHCT)
-        manifest_path = manifests.clone()
-        # upload_file function should take care of uploading to sauce labs.
-        upload_file(manifest_path, remote_file=manifest_path)
-        entities.Organization(
-            id=self.org_id
-        ).upload_manifest(path=manifest_path)
+        sub = entities.Subscription()
+        with open(manifests.clone(), 'rb') as manifest:
+            sub.upload({'organization_id': self.org_id}, manifest)
         with Session(self.browser) as session:
             session.nav.go_to_select_org(self.org_name)
             session.nav.go_to_red_hat_repositories()

--- a/tests/foreman/ui/test_syncplan.py
+++ b/tests/foreman/ui/test_syncplan.py
@@ -211,10 +211,11 @@ class Syncplan(UITestCase):
 
         """
         new_plan_name = gen_string("alpha", 8)
-        entities.Organization(id=self.org_id).sync_plan(
+        entities.SyncPlan(
             name=plan_name,
-            interval=SYNC_INTERVAL['day']
-        )
+            interval=SYNC_INTERVAL['day'],
+            organization=self.org_id,
+        ).create()
         with Session(self.browser) as session:
             session.nav.go_to_select_org(self.org_name)
             session.nav.go_to_sync_plans()
@@ -260,10 +261,11 @@ class Syncplan(UITestCase):
 
         """
         locator = locators["sp.fetch_interval"]
-        entities.Organization(id=self.org_id).sync_plan(
+        entities.SyncPlan(
             name=test_data['name'],
-            interval=SYNC_INTERVAL['day']
-        )
+            interval=SYNC_INTERVAL['day'],
+            organization=self.org_id,
+        ).create()
         with Session(self.browser) as session:
             session.nav.go_to_select_org(self.org_name)
             session.nav.go_to_sync_plans()
@@ -289,10 +291,11 @@ class Syncplan(UITestCase):
         product_name = entities.Product(
             organization=self.org_id
         ).create_json()['name']
-        entities.Organization(id=self.org_id).sync_plan(
+        entities.SyncPlan(
             name=plan_name,
-            interval=SYNC_INTERVAL['week']
-        )
+            interval=SYNC_INTERVAL['week'],
+            organization=self.org_id,
+        ).create()
         with Session(self.browser) as session:
             session.nav.go_to_select_org(self.org_name)
             session.nav.go_to_sync_plans()
@@ -320,10 +323,11 @@ class Syncplan(UITestCase):
         product_name = entities.Product(
             organization=self.org_id
         ).create_json()['name']
-        entities.Organization(id=self.org_id).sync_plan(
+        entities.SyncPlan(
             name=plan_name,
-            interval=SYNC_INTERVAL['week']
-        )
+            interval=SYNC_INTERVAL['week'],
+            organization=self.org_id,
+        ).create()
         with Session(self.browser) as session:
             session.nav.go_to_select_org(self.org_name)
             session.nav.go_to_sync_plans()
@@ -360,10 +364,11 @@ class Syncplan(UITestCase):
         @Assert: Sync Plan is deleted
 
         """
-        entities.Organization(id=self.org_id).sync_plan(
+        entities.SyncPlan(
             name=plan_name,
-            interval=SYNC_INTERVAL['day']
-        )
+            interval=SYNC_INTERVAL['day'],
+            organization=self.org_id,
+        ).create()
         with Session(self.browser) as session:
             session.nav.go_to_select_org(self.org_name)
             session.nav.go_to_sync_plans()


### PR DESCRIPTION
Current fix should be merged right after SatelliteQE/nailgun#165 get to the master branch
Also, all tests need to be executed. List of tests that are run at that moment:
```
nosetests tests/foreman/api/test_contentview.py
...........................................SSSSSSSSSSSSSSSSSSSSSSS...
----------------------------------------------------------------------
Ran 69 tests in 2192.104s

OK (SKIP=23)
```
```
nosetests tests/foreman/smoke/test_api_smoke.py -m test_smoke
.
----------------------------------------------------------------------
Ran 1 test in 175.020s

OK
```
```
nosetests tests/foreman/api/test_contentviewversion.py -m test_negative_promote_
..
----------------------------------------------------------------------
Ran 2 tests in 5.735s

OK
```
```
nosetests tests/foreman/api/test_contentviewversion.py -m test_delete_version_non_default
.
----------------------------------------------------------------------
Ran 1 test in 63.522s

OK
```
```
nosetests tests/foreman/smoke/test_api_smoke.py -m test_end_to_end
.
----------------------------------------------------------------------
Ran 1 test in 212.078s

OK
```
```
nosetests tests/foreman/ui/test_contentviews.py -m test_delete_version_non_default
.
----------------------------------------------------------------------
Ran 1 test in 140.471s

OK
```
```
nosetests tests/foreman/ui/test_contentviews.py -m test_delete_version_with_ak
.
----------------------------------------------------------------------
Ran 1 test in 130.853s

OK
```
```
nosetests tests/foreman/api/test_contentviewfilter.py -m test_create_rpm_cvf_with_different_names
.......
----------------------------------------------------------------------
Ran 7 tests in 85.158s

OK
```
```
nosetests tests/foreman/api/test_contentviewfilter.py -m test_create_cvf_with_multiple_repos_with_docker
.
----------------------------------------------------------------------
Ran 1 test in 48.061s

OK
```
```
nosetests tests/foreman/api/test_contentviewfilter.py -m test_update_cvf_with_new_repo
..
----------------------------------------------------------------------
Ran 2 tests in 100.559s

OK
```
```
nosetests tests/foreman/api/test_contentviewfilter.py -m test_update_cvf_with_multiple_repos
.
----------------------------------------------------------------------
Ran 1 test in 136.849s

OK
```
```
nosetests tests/foreman/api/test_contentviewfilter.py -m test_update_cvf_with_repo_with_docker
.
----------------------------------------------------------------------
Ran 1 test in 50.284s

OK
```
```
nosetests tests/foreman/ui/test_contentsearch.py -m test_search_content_view
.
----------------------------------------------------------------------
Ran 1 test in 97.228s

OK
```
```
nosetests tests/foreman/api/test_product.py -m test_repositoryset_enable
.
----------------------------------------------------------------------
Ran 1 test in 87.175s

OK
```
```
nosetests tests/foreman/api/test_product.py -m test_repositoryset_disable
.
----------------------------------------------------------------------
Ran 1 test in 108.823s

OK
```
```
nosetests tests/foreman/api/test_subscription.py
...
----------------------------------------------------------------------
Ran 3 tests in 213.186s

OK
```
```
nosetests tests/foreman/ui/test_syncplan.py -m test_positive_update_2
...............
----------------------------------------------------------------------
Ran 15 tests in 515.254s

OK
```
```
nosetests tests/foreman/ui/test_syncplan.py -m test_positive_delete_1
.......
----------------------------------------------------------------------
Ran 7 tests in 293.525s

OK
```