### PR TITLE
Release version should be passed only necessary

### DIFF
--- a/robottelo/cli/factory.py
+++ b/robottelo/cli/factory.py
@@ -1823,7 +1823,6 @@ def setup_org_for_a_rh_repo(options=None):
         u'name': options.get('repository-set', None),
         u'organization-id': org_id,
         u'product': options.get('product', None),
-        u'releasever': '7Server',
         u'basearch': 'x86_64',
     })
     if result.return_code != 0:

--- a/robottelo/common/constants.py
+++ b/robottelo/common/constants.py
@@ -165,8 +165,7 @@ REPOS = {
     'rhst7': {  # TODO: Remove 'beta' after release
         'id': 'rhel-7-server-satellite-tools-6-beta-rpms',
         'name': (
-            'Red Hat Satellite Tools 6 Beta for RHEL 7 Server RPMs x86_64 '
-            '7Server'
+            'Red Hat Satellite Tools 6 Beta for RHEL 7 Server RPMs x86_64'
         ),
     },
     'rhva6': {

--- a/tests/foreman/api/test_contentview.py
+++ b/tests/foreman/api/test_contentview.py
@@ -865,7 +865,7 @@ class CVRedHatContent(APITestCase):
             product=PRDS['rhel'],
             repo=REPOS['rhst7']['name'],
             reposet=REPOSET['rhst7'],
-            releasever='7Server',
+            releasever=None,
         )
         cls.repo = entities.Repository(id=repo_id)
         cls.repo.sync()

--- a/tests/foreman/ui/test_contentviews.py
+++ b/tests/foreman/ui/test_contentviews.py
@@ -482,7 +482,7 @@ class TestContentViewsUI(UITestCase):
             'product': PRDS['rhel'],
             'reposet': REPOSET['rhst7'],
             'basearch': 'x86_64',
-            'releasever': '7Server',
+            'releasever': None,
         }
         # Create new org to import manifest
         org_attrs = entities.Organization().create_json()
@@ -544,7 +544,7 @@ class TestContentViewsUI(UITestCase):
             'product': PRDS['rhel'],
             'reposet': REPOSET['rhst7'],
             'basearch': 'x86_64',
-            'releasever': '7Server',
+            'releasever': None
         }
         # Create new org to import manifest
         org_attrs = entities.Organization().create_json()
@@ -714,7 +714,7 @@ class TestContentViewsUI(UITestCase):
             'product': PRDS['rhel'],
             'reposet': REPOSET['rhst7'],
             'basearch': 'x86_64',
-            'releasever': '7Server',
+            'releasever': None,
         }
         env_name = gen_string("alpha", 8)
         publish_version = "Version 1"
@@ -839,7 +839,7 @@ class TestContentViewsUI(UITestCase):
             'product': PRDS['rhel'],
             'reposet': REPOSET['rhst7'],
             'basearch': 'x86_64',
-            'releasever': '7Server',
+            'releasever': None,
         }
         # Create new org to import manifest
         org_attrs = entities.Organization().create_json()


### PR DESCRIPTION
Previously incorrect release versions were also accepted and silently ignored but now release version validation is done and invalid values will be errored.