### PR TITLE
Update docker compute resource URLs

### DIFF
--- a/robottelo.properties.sample
+++ b/robottelo.properties.sample
@@ -53,12 +53,14 @@ provisioning_server=
 image_dir=/opt/robottelo/images
 
 [docker]
-# Internal docker URL in the format http[s]://<server>:<port>. The
+# External docker URL in the format http[s]://<server>:<port>. The
 # {server_hostname} variable can be used and will be replaced by
 # main.server.hostname value.
-internal_url=http://localhost:2375
-# External docker URL in the format http[s]://<server>:<port>.
-external_url=
+# An external docker is a docker daemon accessed using http, for testing
+# purposes accessing localhost via http will be the same as accessing an
+# external instance. Make sure that the target daemon can be accessed via http,
+# in other words, the daemon is initialized with `--host tcp://0.0.0.0:<port>`.
+external_url=http://localhost:2375
 
 [foreman]
 admin.username=admin

--- a/robottelo/common/constants.py
+++ b/robottelo/common/constants.py
@@ -16,7 +16,6 @@ FOREMAN_PROVIDERS = {
     'docker': 'Docker',
 }
 
-DOCKER_RESOURCE_URL = 'http://%s:2375'
 LIBVIRT_RESOURCE_URL = 'qemu+tcp://%s:16509/system'
 
 

--- a/robottelo/common/helpers.py
+++ b/robottelo/common/helpers.py
@@ -134,22 +134,27 @@ def get_nailgun_config():
 
 
 def get_internal_docker_url():
-    """Returns the docker internal server url config
+    """Use the unix socket connection to the local docker daemon. Make sure
+    that your Satellite server's docker is configured to allow foreman user
+    accessing it. This can be done by::
 
-    If the variable ``{server_hostname}`` is found in the string, it will be
-    replaced by ``main.server.hostname`` from the config file.
+        $ groupadd docker
+        $ usermod -aG docker foreman
+        # Add -G docker to the options for the docker daemon
+        $ systemctl restart docker
+        $ katello-service restart
 
     """
-    internal_url = conf.properties.get('docker.internal_url')
-    if internal_url is not None:
-        internal_url = internal_url.format(
-            server_hostname=conf.properties['main.server.hostname'])
-    return internal_url
+    return 'unix:///var/run/docker.sock'
 
 
 def get_external_docker_url():
     """Returns the docker external server url config"""
-    return conf.properties.get('docker.external_url')
+    external_url = conf.properties.get('docker.external_url')
+    if external_url is not None:
+        external_url = external_url.format(
+            server_hostname=conf.properties['main.server.hostname'])
+    return external_url
 
 
 def get_distro_info():

--- a/tests/foreman/ui/test_computeresource.py
+++ b/tests/foreman/ui/test_computeresource.py
@@ -4,12 +4,15 @@ from fauxfactory import gen_string
 from nailgun import entities
 from robottelo.common import conf
 from robottelo.common.constants import (
-    DOCKER_RESOURCE_URL,
     FOREMAN_PROVIDERS,
     LIBVIRT_RESOURCE_URL,
 )
 from robottelo.common.decorators import data, run_only_on
-from robottelo.common.helpers import invalid_names_list, valid_data_list
+from robottelo.common.helpers import (
+    get_external_docker_url,
+    invalid_names_list,
+    valid_data_list,
+)
 from robottelo.test import UITestCase
 from robottelo.ui.factory import make_resource
 from robottelo.ui.locators import common_locators
@@ -23,8 +26,6 @@ class ComputeResource(UITestCase):
 
     current_libvirt_url = (LIBVIRT_RESOURCE_URL
                            % conf.properties['main.server.hostname'])
-    current_docker_url = (DOCKER_RESOURCE_URL
-                          % conf.properties['main.server.hostname'])
 
     @data(*valid_data_list())
     def test_create_libvirt_resource_different_names(self, name):
@@ -246,7 +247,7 @@ class ComputeResource(UITestCase):
                 session,
                 name=name,
                 provider_type=FOREMAN_PROVIDERS['docker'],
-                parameter_list=[['URL', self.current_docker_url, 'field']],
+                parameter_list=[['URL', get_external_docker_url(), 'field']],
             )
             self.assertIsNotNone(self.compute_profile.select_resource(
                 '1-Small', name, 'Docker'))


### PR DESCRIPTION
Consider the internal docker daemon URL as the unix socket and the
external by accessing it using http. This is how the Satellite 6
recommends setting up docker as a internal compute resource (running on
the same machine as the Satellite) or a external compute resource
(running on a different machine and being accessed via http).

Test results:

```
$ py.test tests/foreman/cli/test_docker.py tests/foreman/api/test_docker.py tests/foreman/ui/test_docker.py
================================= test session starts ==================================
platform linux2 -- Python 2.7.5 -- py-1.4.30 -- pytest-2.7.2
rootdir: /home/elyezer/robottelo, inifile:
collected 154 items

tests/foreman/cli/test_docker.py .ssssssssssssssssssssssssssssssssssssssssssssssssss
tests/foreman/api/test_docker.py ..............s.sssssss.ssssss...sssssssssssssssssss
tests/foreman/ui/test_docker.py sssssssssssssssssssssssssssssssssssssssssssssssssss

======================= 20 passed, 134 skipped in 310.08 seconds =======================

$ py.test tests/foreman/ui/test_computeresource.py -ktest_access_docker_resource_via_compute_profile
================================= test session starts ==================================
platform linux2 -- Python 2.7.5 -- py-1.4.30 -- pytest-2.7.2
rootdir: /home/elyezer/robottelo, inifile:
collected 10 items

tests/foreman/ui/test_computeresource.py .

====== 9 tests deselected by '-ktest_access_docker_resource_via_compute_profile' =======
======================= 1 passed, 9 deselected in 16.92 seconds ========================
```
