### PR TITLE
Add rhel67 distro to available VM distros

### DIFF
--- a/robottelo/vm.py
+++ b/robottelo/vm.py
@@ -20,6 +20,7 @@ from robottelo.common.helpers import get_server_cert_rpm_url
 BASE_IMAGES = (
     'rhel65',
     'rhel66',
+    'rhel67',
     'rhel70',
     'rhel71',
 )


### PR DESCRIPTION
Automation infrastructure now offers rhel67 base image, allow virtual
machines to be created using it.

```python
In [1]: from robottelo.vm import VirtualMachine

In [2]: vm = VirtualMachine(distro='rhel67')

In [3]: vm.create()

In [5]: vm.run('cat /etc/redhat-release').stdout
Out[5]: [u'Red Hat Enterprise Linux Server release 6.7 (Santiago)', u'']

In [6]: vm.destroy()
```