### PR TITLE
[DO NOT MERGE] Refactor content-host katello-agent tests and add more coverage

### DIFF
--- a/robottelo/cli/factory.py
+++ b/robottelo/cli/factory.py
@@ -1618,7 +1618,6 @@ def make_template(options=None):
     return create_object(Template, args, options)
 
 
-@cacheable
 def activationkey_add_subscription_to_repo(options=None):
     """
     Adds subscription to activation key.
@@ -1632,26 +1631,26 @@ def activationkey_add_subscription_to_repo(options=None):
     """
     if(
             not options or
-            not options.get('organization-id', None) or
-            not options.get('activationkey-id', None) or
-            not options.get('subscription', None)):
+            not options.get('organization-id') or
+            not options.get('activationkey-id') or
+            not options.get('subscription')):
         raise CLIFactoryError(
             'Please provide valid organization, activation key and '
             'subscription.'
         )
     # List the subscriptions in given org
     result = Subscription.list(
-        {u'organization-id': options.get('organization-id', None)},
+        {u'organization-id': options['organization-id']},
         per_page=False
     )
     # Add subscription to activation-key
     for subscription in result.stdout:
-        if subscription['name'] == options.get('subscription', None):
+        if subscription['name'] == options['subscription']:
             if int(subscription['quantity']) == 0:
                 raise CLIFactoryError(
                     'All the subscriptions are already consumed')
             result = ActivationKey.add_subscription({
-                u'id': options.get('activationkey-id', None),
+                u'id': options['activationkey-id'],
                 u'subscription-id': subscription['id'],
                 u'quantity': 1,
             })
@@ -1660,7 +1659,6 @@ def activationkey_add_subscription_to_repo(options=None):
                     'Failed to add subscription to activation key')
 
 
-@cacheable
 def setup_org_for_a_custom_repo(options=None):
     """
     Sets up Org for the given custom repo by:
@@ -1694,11 +1692,14 @@ def setup_org_for_a_custom_repo(options=None):
             not options.get('url', None)):
         raise CLIFactoryError('Please provide valid custom repo URL.')
     # Create new organization and lifecycle environment if needed
-    org_id = options.get('organization-id', make_org()['id'])
-    env_id = options.get(
-        'lifecycle-environment-id',
-        make_lifecycle_environment({u'organization-id': org_id})['id']
-    )
+    if options.get('organization-id') is None:
+        org_id = make_org()['id']
+    else:
+        org_id = options['organization-id']
+    if options.get('lifecycle-environment-id') is None:
+        env_id = make_lifecycle_environment({u'organization-id': org_id})['id']
+    else:
+        env_id = options['lifecycle-environment-id']
     # Create custom product and repository
     custom_product = make_product({u'organization-id': org_id})
     custom_repo = make_repository({
@@ -1711,10 +1712,10 @@ def setup_org_for_a_custom_repo(options=None):
     if result.return_code != 0:
         raise CLIFactoryError('Failed to synchronize repository')
     # Create CV if needed and associate repo with it
-    cv_id = options.get(
-        'content-view-id',
-        make_content_view({u'organization-id': org_id})['id']
-    )
+    if options.get('content-view-id') is None:
+        cv_id = make_content_view({u'organization-id': org_id})['id']
+    else:
+        cv_id = options['content-view-id']
     result = ContentView.add_repository({
         u'id': cv_id,
         u'repository-id': custom_repo['id'],
@@ -1738,14 +1739,14 @@ def setup_org_for_a_custom_repo(options=None):
     if result.return_code != 0:
         raise CLIFactoryError('Failed to promote version to next environment')
     # Create activation key if needed and associate content view with it
-    if 'activationkey-id' not in options:
+    if options.get('activationkey-id') is None:
         activationkey_id = make_activation_key({
             u'content-view-id': cv_id,
             u'lifecycle-environment-id': env_id,
             u'organization-id': org_id,
         })['id']
     else:
-        activationkey_id = options.get('activationkey-id', None)
+        activationkey_id = options['activationkey-id']
         # Given activation key may have no (or different) CV associated.
         # Associate activation key with CV just to be sure
         result = ActivationKey.update({
@@ -1764,7 +1765,6 @@ def setup_org_for_a_custom_repo(options=None):
     })
 
 
-@cacheable
 def setup_org_for_a_rh_repo(options=None):
     """
     Sets up Org for the given Red Hat repository by:
@@ -1798,17 +1798,20 @@ def setup_org_for_a_rh_repo(options=None):
     """
     if (
             not options or
-            not options.get('product', None) or
-            not options.get('repository-set', None) or
-            not options.get('repository', None)):
+            not options.get('product') or
+            not options.get('repository-set') or
+            not options.get('repository')):
         raise CLIFactoryError(
             'Please provide valid product, repository-set and repo.')
     # Create new organization and lifecycle environment if needed
-    org_id = options.get('organization-id', make_org()['id'])
-    env_id = options.get(
-        'lifecycle-environment-id',
-        make_lifecycle_environment({u'organization-id': org_id})['id']
-    )
+    if options.get('organization-id') is None:
+        org_id = make_org()['id']
+    else:
+        org_id = options['organization-id']
+    if options.get('lifecycle-environment-id') is None:
+        env_id = make_lifecycle_environment({u'organization-id': org_id})['id']
+    else:
+        env_id = options['lifecycle-environment-id']
     # Clone manifest and upload it
     manifest = manifests.clone()
     upload_file(manifest, remote_file=manifest)
@@ -1820,34 +1823,34 @@ def setup_org_for_a_rh_repo(options=None):
         raise CLIFactoryError('Failed to upload manifest')
     # Enable repo from Repository Set
     result = RepositorySet.enable({
-        u'name': options.get('repository-set', None),
+        u'name': options['repository-set'],
         u'organization-id': org_id,
-        u'product': options.get('product', None),
-        u'releasever': '7Server',
+        u'product': options['product'],
+        # u'releasever': '7Server',
         u'basearch': 'x86_64',
     })
     if result.return_code != 0:
         raise CLIFactoryError('Failed to enable repository set')
     # Fetch repository info
     result = Repository.info({
-        u'name': options.get('repository', None),
-        u'product': options.get('product', None),
+        u'name': options['repository'],
+        u'product': options['product'],
         u'organization-id': org_id,
     })
     rhel_repo = result.stdout
     # Synchronize the RH repository
     result = Repository.synchronize({
-        u'name': options.get('repository', None),
+        u'name': options['repository'],
         u'organization-id': org_id,
-        u'product': options.get('product', None),
+        u'product': options['product'],
     })
     if result.return_code != 0:
         raise CLIFactoryError('Failed to synchronize repository')
     # Create CV if needed and associate repo with it
-    cv_id = options.get(
-        'content-view-id',
-        make_content_view({u'organization-id': org_id})['id']
-    )
+    if options.get('content-view-id') is None:
+        cv_id = make_content_view({u'organization-id': org_id})['id']
+    else:
+        cv_id = options['content-view-id']
     result = ContentView.add_repository({
         u'id': cv_id,
         u'repository-id': rhel_repo['id'],
@@ -1871,14 +1874,14 @@ def setup_org_for_a_rh_repo(options=None):
     if result.return_code != 0:
         raise CLIFactoryError('Failed to promote version to next environment')
     # Create activation key if needed and associate content view with it
-    if 'activationkey-id' not in options:
+    if options.get('activationkey-id') is None:
         activationkey_id = make_activation_key({
             u'content-view-id': cv_id,
             u'lifecycle-environment-id': env_id,
             u'organization-id': org_id,
         })['id']
     else:
-        activationkey_id = options.get('activationkey-id', None)
+        activationkey_id = options['activationkey-id']
         # Given activation key may have no (or different) CV associated.
         # Associate activation key with CV just to be sure
         result = ActivationKey.update({

--- a/robottelo/common/constants.py
+++ b/robottelo/common/constants.py
@@ -165,8 +165,7 @@ REPOS = {
     'rhst7': {  # TODO: Remove 'beta' after release
         'id': 'rhel-7-server-satellite-tools-6-beta-rpms',
         'name': (
-            'Red Hat Satellite Tools 6 Beta for RHEL 7 Server RPMs x86_64 '
-            '7Server'
+            'Red Hat Satellite Tools 6 Beta for RHEL 7 Server RPMs x86_64'
         ),
     },
     'rhva6': {
@@ -233,6 +232,11 @@ FAKE_4_PUPPET_REPO = "http://omaciel.fedorapeople.org/fakepuppet04"
 FAKE_5_PUPPET_REPO = "http://omaciel.fedorapeople.org/fakepuppet05"
 REPO_DISCOVERY_URL = "http://omaciel.fedorapeople.org/"
 FAKE_0_CUSTOM_PACKAGE = 'bear-4.1-1.noarch'
+FAKE_0_CUSTOM_PACKAGE_NAME = 'bear'
+FAKE_1_CUSTOM_PACKAGE = 'walrus-0.71-1.noarch'
+FAKE_1_CUSTOM_PACKAGE_NAME = 'walrus'
+FAKE_2_CUSTOM_PACKAGE = 'walrus-5.21-1.noarch'
+FAKE_2_CUSTOM_PACKAGE_NAME = 'walrus'
 FAKE_0_ERRATA_ID = 'RHEA-2012:0001'
 
 PUPPET_MODULE_NTP_PUPPETLABS = "puppetlabs-ntp-3.2.1.tar.gz"


### PR DESCRIPTION
1. Replaced `options.get('foo', make_foo())` with `if ... else` statements. Short explanation:
    ```
>>> def foo():
...     print 'foo'
...     return 'foo [2]'
...
>>> bar = {'test': 'bar'}
>>> bar.get('test', foo())
foo
'bar'
```
    Function, passed as `default=` value, was always executing, so each test was creating a lot of redundant entities.

2. Updated tests logic. Before we had something like this
    ```
def setUp():
# Enable RHEL repo
# Create activation key with subscription to repo with katello-agent
# Register content-host

def test_...():
# Create custom repo
# Update activation key with subscription to repo
# Test things
```
    As per one email discussion, updating activation key with new subscription doesn't update subscriptions on existing content host, updated activation key will only affect newly registered content hosts. So creation of custom repo and updating of activation key was moved _before_ content-host registration.
    In addition, as all the tests were creating custom repo for testing purposes, so i moved custom repo, upd of AK & registering of content-host to setUp section, which should add readability.

3. Added tests for remote package install/remove/upgrade.
    Closes #1709

    ```
nosetests tests/foreman/cli/test_contenthost.py -m test_contenthost_
......
----------------------------------------------------------------------
Ran 6 tests in 2188.351s

OK
```