### PR TITLE
[DONOTMERGE] Refactor cli factory module

### DIFF
--- a/robottelo/cli/factory.py
+++ b/robottelo/cli/factory.py
@@ -130,9 +130,9 @@ def make_activation_key(options=None):
     # Organization Name, Label or ID is a required field.
     if (
             not options or
-            not options.get('organization', None) and
-            not options.get('organization-label', None) and
-            not options.get('organization-id', None)):
+            not options.get('organization') and
+            not options.get('organization-label') and
+            not options.get('organization-id')):
         raise CLIFactoryError('Please provide a valid Organization.')
 
     args = {
@@ -280,7 +280,7 @@ def make_content_view(options=None):
 
     """
     # Organization ID is a required field.
-    if not options or not options.get('organization-id', None):
+    if not options or not options.get('organization-id'):
         raise CLIFactoryError('Please provide a valid ORG ID.')
 
     args = {
@@ -315,11 +315,11 @@ def make_gpg_key(options=None):
         -h, --help                    print help
     """
     # Organization ID is a required field.
-    if not options or not options.get('organization-id', None):
+    if not options or not options.get('organization-id'):
         raise CLIFactoryError('Please provide a valid ORG ID.')
 
     # Create a fake gpg key file if none was provided
-    if not options.get('key', None):
+    if not options.get('key'):
         (_, key_filename) = mkstemp(text=True)
         os.chmod(key_filename, 0700)
         with open(key_filename, 'w') as gpg_key_file:
@@ -530,7 +530,7 @@ def make_product(options=None):
         -h, --help                              print help
     """
     # Organization ID is a required field.
-    if not options or not options.get('organization-id', None):
+    if not options or not options.get('organization-id'):
         raise CLIFactoryError('Please provide a valid ORG ID.')
 
     args = {
@@ -617,7 +617,7 @@ def make_repository(options=None):
 
     """
     # Product ID is a required field.
-    if not options or not options.get('product-id', None):
+    if not options or not options.get('product-id'):
         raise CLIFactoryError('Please provide a valid Product ID.')
 
     args = {
@@ -749,7 +749,7 @@ def make_sync_plan(options=None):
 
     """
     # Organization ID is a required field.
-    if not options or not options.get('organization-id', None):
+    if not options or not options.get('organization-id'):
         raise CLIFactoryError('Please provide a valid ORG ID.')
 
     args = {
@@ -1036,7 +1036,7 @@ def make_host_collection(options=None):
 
     """
     # Organization ID is required
-    if not options or not options.get('organization-id', None):
+    if not options or not options.get('organization-id'):
         raise CLIFactoryError('Please provide a valid ORGANIZATION_ID.')
 
     # Assigning default values for attributes
@@ -1544,7 +1544,7 @@ def make_lifecycle_environment(options=None):
             'organization-id' not in options):
         raise CLIFactoryError('Please provide a valid Organization.')
 
-    if not options.get('prior', None):
+    if not options.get('prior'):
         options['prior'] = 'Library'
 
     # Assigning default values for attributes
@@ -1632,26 +1632,26 @@ def activationkey_add_subscription_to_repo(options=None):
     """
     if(
             not options or
-            not options.get('organization-id', None) or
-            not options.get('activationkey-id', None) or
-            not options.get('subscription', None)):
+            not options.get('organization-id') or
+            not options.get('activationkey-id') or
+            not options.get('subscription')):
         raise CLIFactoryError(
             'Please provide valid organization, activation key and '
             'subscription.'
         )
     # List the subscriptions in given org
     result = Subscription.list(
-        {u'organization-id': options.get('organization-id', None)},
+        {u'organization-id': options.get('organization-id')},
         per_page=False
     )
     # Add subscription to activation-key
     for subscription in result.stdout:
-        if subscription['name'] == options.get('subscription', None):
+        if subscription['name'] == options.get('subscription'):
             if int(subscription['quantity']) == 0:
                 raise CLIFactoryError(
                     'All the subscriptions are already consumed')
             result = ActivationKey.add_subscription({
-                u'id': options.get('activationkey-id', None),
+                u'id': options.get('activationkey-id'),
                 u'subscription-id': subscription['id'],
                 u'quantity': 1,
             })
@@ -1691,7 +1691,7 @@ def setup_org_for_a_custom_repo(options=None):
     """
     if(
             not options or
-            not options.get('url', None)):
+            not options.get('url')):
         raise CLIFactoryError('Please provide valid custom repo URL.')
     # Create new organization and lifecycle environment if needed
     org_id = options.get('organization-id', make_org()['id'])
@@ -1702,7 +1702,7 @@ def setup_org_for_a_custom_repo(options=None):
     # Create custom product and repository
     custom_product = make_product({u'organization-id': org_id})
     custom_repo = make_repository({
-        u'url': options.get('url', None),
+        u'url': options.get('url'),
         u'content-type': 'yum',
         u'product-id': custom_product['id'],
     })
@@ -1745,7 +1745,7 @@ def setup_org_for_a_custom_repo(options=None):
             u'organization-id': org_id,
         })['id']
     else:
-        activationkey_id = options.get('activationkey-id', None)
+        activationkey_id = options.get('activationkey-id')
         # Given activation key may have no (or different) CV associated.
         # Associate activation key with CV just to be sure
         result = ActivationKey.update({
@@ -1786,6 +1786,8 @@ def setup_org_for_a_rh_repo(options=None):
         product - RH product name
         repository-set - RH repository set name
         repository - RH repository name
+        releasever (optional) - Repository set release version, don't specify
+                                it if enabling the Satellite 6 Tools repo.
         organization-id (optional) - ID of organization to use (or create a new
                                     one if empty)
         lifecycle-environment-id (optional) - ID of lifecycle environment to
@@ -1798,9 +1800,9 @@ def setup_org_for_a_rh_repo(options=None):
     """
     if (
             not options or
-            not options.get('product', None) or
-            not options.get('repository-set', None) or
-            not options.get('repository', None)):
+            not options.get('product') or
+            not options.get('repository-set') or
+            not options.get('repository')):
         raise CLIFactoryError(
             'Please provide valid product, repository-set and repo.')
     # Create new organization and lifecycle environment if needed
@@ -1820,26 +1822,28 @@ def setup_org_for_a_rh_repo(options=None):
         raise CLIFactoryError('Failed to upload manifest')
     # Enable repo from Repository Set
     result = RepositorySet.enable({
-        u'name': options.get('repository-set', None),
+        u'name': options.get('repository-set'),
         u'organization-id': org_id,
-        u'product': options.get('product', None),
-        u'releasever': '7Server',
+        u'product': options.get('product'),
+        u'releasever': options.get('releasever'),
         u'basearch': 'x86_64',
     })
     if result.return_code != 0:
         raise CLIFactoryError('Failed to enable repository set')
     # Fetch repository info
     result = Repository.info({
-        u'name': options.get('repository', None),
-        u'product': options.get('product', None),
+        u'name': options.get('repository'),
+        u'product': options.get('product'),
         u'organization-id': org_id,
     })
+    if result.return_code != 0:
+        raise CLIFactoryError('Failed to fetch repository info')
     rhel_repo = result.stdout
     # Synchronize the RH repository
     result = Repository.synchronize({
-        u'name': options.get('repository', None),
+        u'name': options.get('repository'),
         u'organization-id': org_id,
-        u'product': options.get('product', None),
+        u'product': options.get('product'),
     })
     if result.return_code != 0:
         raise CLIFactoryError('Failed to synchronize repository')
@@ -1861,6 +1865,8 @@ def setup_org_for_a_rh_repo(options=None):
         raise CLIFactoryError('Failed to publish new version of content view')
     # Get the version id
     result = ContentView.info({u'id': cv_id})
+    if result.return_code != 0:
+        raise CLIFactoryError('Failed to fetch content view info')
     cvv = result.stdout['versions'][-1]
     # Promote version1 to next env
     result = ContentView.version_promote({
@@ -1878,7 +1884,7 @@ def setup_org_for_a_rh_repo(options=None):
             u'organization-id': org_id,
         })['id']
     else:
-        activationkey_id = options.get('activationkey-id', None)
+        activationkey_id = options.get('activationkey-id')
         # Given activation key may have no (or different) CV associated.
         # Associate activation key with CV just to be sure
         result = ActivationKey.update({
@@ -1887,8 +1893,7 @@ def setup_org_for_a_rh_repo(options=None):
             u'content-view-id': cv_id,
         })
         if result.return_code != 0:
-            raise CLIFactoryError(
-                'Failed to associate activation-key with CV')
+            raise CLIFactoryError('Failed to associate activation-key with CV')
     # Add subscription to activation-key
     activationkey_add_subscription_to_repo({
         u'organization-id': org_id,


### PR DESCRIPTION
The dict method get already returns None if the key is not present.
Drop all None values for the second argument on dict.get.

    In [1]: d = {}

    In [2]: print d.get('key')
    None

Also get the releasever from options on setup_org_for_a_rh_repo
function. This will avoid passing the releasever option when enabling
Satellite 6 Tools repo.

Check for every result return code in setup_org_for_a_rh_repo in order
to fail earlier.

Closes #2354 and closes #2353.