### PR TITLE
Bug fix for passing None to Release Version

### DIFF
--- a/tests/foreman/api/test_repository.py
+++ b/tests/foreman/api/test_repository.py
@@ -249,7 +249,7 @@ class RepositorySyncTestCase(APITestCase):
             product=PRDS['rhel'],
             repo=REPOS['rhst7']['name'],
             reposet=REPOSET['rhst7'],
-            releasever='None',
+            releasever=None,
         )
         entities.Repository(id=repo_id).sync()
 


### PR DESCRIPTION
```
# nosetests tests.foreman.api.test_repository:RepositorySyncTestCase.test_redhat_sync_1
.
----------------------------------------------------------------------
Ran 1 test in 104.300s

OK
```