### PR TITLE
Fix for Org Test of BZ1225588, closes #2483

### DIFF
--- a/tests/foreman/ui/test_org.py
+++ b/tests/foreman/ui/test_org.py
@@ -10,7 +10,7 @@ from robottelo.common.constants import INSTALL_MEDIUM_URL, LIBVIRT_RESOURCE_URL
 from robottelo.common.helpers import (
     generate_strings_list, invalid_names_list, invalid_values_list)
 from robottelo.common.decorators import (
-    data, run_only_on, skip_if_bug_open, stubbed)
+    data, run_only_on, skip_if_bug_open, stubbed, bz_bug_is_open)
 from robottelo.test import UITestCase
 from robottelo.ui.factory import make_lifecycle_environment, make_org
 from robottelo.ui.locators import common_locators, locators, tab_locators
@@ -249,7 +249,14 @@ class Org(UITestCase):
             # So switching to Default Org and then deleting.
             session.nav.go_to_select_org('Default Organization')
             self.org.remove(org_name)
-            self.assertIsNone(self.org.search(org_name))
+            status = self.org.search(org_name)
+            if bz_bug_is_open(1251926):
+                # Check for at max Five times, the org is deleted
+                for _ in range(5):
+                    status = self.org.search(org_name)
+                    if status is None:
+                        break
+            self.assertIsNone(status)
 
     # Negative Delete
 


### PR DESCRIPTION
After trying multiple things, finally this fixes the long time issue related to Org test of BZ1225588.

The issue was occurring due to delay in deleting the org, not is deleting the org. The org reflects for almost 5-10 seconds even after its deletion for Manage Organization and we are checking success before that.

So to fix this checking for loop in 5 times, whether the org is deleted or not. 