### PR TITLE
Re-work NailGun helper methods, again

### DIFF
--- a/tests/foreman/api/test_contentview.py
+++ b/tests/foreman/api/test_contentview.py
@@ -57,7 +57,7 @@ class ContentViewTestCase(APITestCase):
 
         # Promote the content view version.
         self.assertEqual(len(content_view.version), 1)
-        content_view.version[0].promote({u'environment_id': lc_env.id})
+        content_view.version[0].promote(data={u'environment_id': lc_env.id})
 
         # Create a system that is subscribed to the published and promoted
         # content view. Associating this system with the organization and
@@ -91,13 +91,17 @@ class ContentViewTestCase(APITestCase):
         lc_env = entities.LifecycleEnvironment(organization=org).create()
         content_view = entities.ContentView(organization=org).create()
         content_view.publish()
-        content_view.read().version[0].promote({u'environment_id': lc_env.id})
+        content_view.read().version[0].promote(data={
+            u'environment_id': lc_env.id
+        })
 
         cloned_cv = entities.ContentView(id=content_view.copy(
             {u'name': gen_string('alpha', gen_integer(3, 30))}
         )['id'])
         cloned_cv.publish()
-        cloned_cv.read().version[0].promote({u'environment_id': lc_env.id})
+        cloned_cv.read().version[0].promote(data={
+            u'environment_id': lc_env.id
+        })
 
     def test_cv_clone_within_diff_env(self):
         """@Test: attempt to create, publish and promote new content
@@ -115,12 +119,16 @@ class ContentViewTestCase(APITestCase):
         le_clone = entities.LifecycleEnvironment(organization=org).create()
         content_view = entities.ContentView(organization=org).create()
         content_view.publish()
-        content_view.read().version[0].promote({u'environment_id': lc_env.id})
+        content_view.read().version[0].promote(data={
+            u'environment_id': lc_env.id
+        })
         cloned_cv = entities.ContentView(id=content_view.copy(
             {u'name': gen_string('alpha', gen_integer(3, 30))}
         )['id'])
         cloned_cv.publish()
-        cloned_cv.read().version[0].promote({u'environment_id': le_clone.id})
+        cloned_cv.read().version[0].promote(data={
+            u'environment_id': le_clone.id
+        })
 
     def test_cv_associate_custom_content(self):
         """@Test: Associate custom content in a view
@@ -521,7 +529,7 @@ class CVPublishPromoteTestCase(APITestCase):
         # Promote the content view version several times.
         for _ in range(REPEAT):
             lce = entities.LifecycleEnvironment(organization=self.org).create()
-            content_view.version[0].promote({u'environment_id': lce.id})
+            content_view.version[0].promote(data={u'environment_id': lce.id})
 
         # Does it show up in the correct number of lifecycle environments?
         self.assertEqual(
@@ -549,7 +557,7 @@ class CVPublishPromoteTestCase(APITestCase):
         # Promote the content view version.
         for _ in range(REPEAT):
             lce = entities.LifecycleEnvironment(organization=self.org).create()
-            content_view.version[0].promote({u'environment_id': lce.id})
+            content_view.version[0].promote(data={u'environment_id': lce.id})
 
         # Everything's done - check some content view attributes...
         content_view = content_view.read()
@@ -584,7 +592,7 @@ class CVPublishPromoteTestCase(APITestCase):
         content_view.publish()
         content_view = content_view.read()
         lce = entities.LifecycleEnvironment(organization=self.org).create()
-        content_view.version[0].promote({u'environment_id': lce.id})
+        content_view.version[0].promote(data={u'environment_id': lce.id})
 
         content_view = content_view.read()
         self.assertEqual(len(content_view.version), 1)
@@ -621,7 +629,7 @@ class CVPublishPromoteTestCase(APITestCase):
         envs_amount = random.randint(3, 5)
         for _ in range(envs_amount):
             lce = entities.LifecycleEnvironment(organization=self.org).create()
-            content_view.version[0].promote({u'environment_id': lce.id})
+            content_view.version[0].promote(data={u'environment_id': lce.id})
 
         # Everything's done. Check some content view attributes...
         content_view = content_view.read()
@@ -708,7 +716,9 @@ class CVPublishPromoteTestCase(APITestCase):
         self.add_content_views_to_composite(composite_cv)
         composite_cv.publish()
         lce = entities.LifecycleEnvironment(organization=self.org).create()
-        composite_cv.read().version[0].promote({u'environment_id': lce.id})
+        composite_cv.read().version[0].promote(data={
+            u'environment_id': lce.id
+        })
         composite_cv = composite_cv.read()
         self.assertEqual(len(composite_cv.version), 1)
         self.assertEqual(len(composite_cv.version[0].read().environment), 2)
@@ -731,7 +741,9 @@ class CVPublishPromoteTestCase(APITestCase):
         self.add_content_views_to_composite(composite_cv, random.randint(3, 5))
         composite_cv.publish()
         lce = entities.LifecycleEnvironment(organization=self.org).create()
-        composite_cv.read().version[0].promote({u'environment_id': lce.id})
+        composite_cv.read().version[0].promote(data={
+            u'environment_id': lce.id
+        })
         composite_cv = composite_cv.read()
         self.assertEqual(len(composite_cv.version), 1)
         self.assertEqual(len(composite_cv.version[0].read().environment), 2)
@@ -758,7 +770,7 @@ class CVPublishPromoteTestCase(APITestCase):
         envs_amount = random.randint(3, 5)
         for _ in range(envs_amount):
             lce = entities.LifecycleEnvironment(organization=self.org).create()
-            composite_cv.version[0].promote({u'environment_id': lce.id})
+            composite_cv.version[0].promote(data={u'environment_id': lce.id})
         composite_cv = composite_cv.read()
         self.assertEqual(len(composite_cv.version), 1)
         self.assertEqual(
@@ -788,7 +800,7 @@ class CVPublishPromoteTestCase(APITestCase):
         envs_amount = random.randint(3, 5)
         for _ in range(envs_amount):
             lce = entities.LifecycleEnvironment(organization=self.org).create()
-            composite_cv.version[0].promote({u'environment_id': lce.id})
+            composite_cv.version[0].promote(data={u'environment_id': lce.id})
         composite_cv = composite_cv.read()
         self.assertEqual(len(composite_cv.version), 1)
         self.assertEqual(

--- a/tests/foreman/api/test_contentview.py
+++ b/tests/foreman/api/test_contentview.py
@@ -322,7 +322,7 @@ class CVPublishPromoteTestCase(APITestCase):
         ).create()
         cls.puppet_repo.sync()
         with open(get_data_file(PUPPET_MODULE_NTP_PUPPETLABS), 'rb') as handle:
-            cls.puppet_repo.upload_content(handle)
+            cls.puppet_repo.upload_content(files={'content': handle})
 
     def add_content_views_to_composite(self, composite_cv, cv_amount=1):
         """Add necessary number of content views to the composite one

--- a/tests/foreman/api/test_contentview.py
+++ b/tests/foreman/api/test_contentview.py
@@ -96,7 +96,7 @@ class ContentViewTestCase(APITestCase):
         })
 
         cloned_cv = entities.ContentView(id=content_view.copy(
-            {u'name': gen_string('alpha', gen_integer(3, 30))}
+            data={u'name': gen_string('alpha', gen_integer(3, 30))}
         )['id'])
         cloned_cv.publish()
         cloned_cv.read().version[0].promote(data={
@@ -123,7 +123,7 @@ class ContentViewTestCase(APITestCase):
             u'environment_id': lc_env.id
         })
         cloned_cv = entities.ContentView(id=content_view.copy(
-            {u'name': gen_string('alpha', gen_integer(3, 30))}
+            data={u'name': gen_string('alpha', gen_integer(3, 30))}
         )['id'])
         cloned_cv.publish()
         cloned_cv.read().version[0].promote(data={

--- a/tests/foreman/api/test_contentview.py
+++ b/tests/foreman/api/test_contentview.py
@@ -868,9 +868,11 @@ class CVRedHatContent(APITestCase):
         super(CVRedHatContent, cls).setUpClass()
 
         cls.org = entities.Organization().create()
-        sub = entities.Subscription()
         with open(manifests.clone(), 'rb') as manifest:
-            sub.upload({'organization_id': cls.org.id}, manifest)
+            entities.Subscription().upload(
+                data={'organization_id': cls.org.id},
+                files={'content': manifest},
+            )
         repo_id = utils.enable_rhrepo_and_fetchid(
             basearch='x86_64',
             org_id=cls.org.id,

--- a/tests/foreman/api/test_contentviewversion.py
+++ b/tests/foreman/api/test_contentviewversion.py
@@ -19,7 +19,9 @@ class CVVersionTestCase(APITestCase):
         """
         env = entities.Environment().create().id
         with self.assertRaises(HTTPError):
-            entities.ContentViewVersion(id=1).promote({u'environment_id': env})
+            entities.ContentViewVersion(id=1).promote(data={
+                u'environment_id': env
+            })
 
     def test_negative_promote_2(self):
         """@Test: Promote a content view version using an invalid environment.
@@ -30,7 +32,9 @@ class CVVersionTestCase(APITestCase):
 
         """
         with self.assertRaises(HTTPError):
-            entities.ContentViewVersion(id=1).promote({u'environment_id': -1})
+            entities.ContentViewVersion(id=1).promote(data={
+                u'environment_id': -1
+            })
 
     def test_delete_version(self):
         """@Test: Create content view and publish it. After that try to
@@ -98,7 +102,7 @@ class CVVersionTestCase(APITestCase):
         self.assertEqual(len(content_view.version), 1)
         self.assertEqual(len(content_view.version[0].read().environment), 1)
         lce = entities.LifecycleEnvironment(organization=org).create()
-        content_view.version[0].promote({u'environment_id': lce.id})
+        content_view.version[0].promote(data={u'environment_id': lce.id})
         cvv = content_view.version[0].read()
         self.assertEqual(len(cvv.environment), 2)
         # Delete the content-view version from selected environments

--- a/tests/foreman/api/test_docker.py
+++ b/tests/foreman/api/test_docker.py
@@ -796,7 +796,7 @@ class DockerContentViewTestCase(APITestCase):
         cvv = content_view.version[0].read()
         self.assertEqual(len(cvv.environment), 1)
 
-        cvv.promote({u'environment_id': lce.id})
+        cvv.promote(data={u'environment_id': lce.id})
         self.assertEqual(len(cvv.read().environment), 2)
 
     @run_only_on('sat')
@@ -829,7 +829,7 @@ class DockerContentViewTestCase(APITestCase):
 
         for i in range(1, randint(2, 5)):
             lce = entities.LifecycleEnvironment(organization=self.org).create()
-            cvv.promote({u'environment_id': lce.id})
+            cvv.promote(data={u'environment_id': lce.id})
             self.assertEqual(len(cvv.read().environment), i+1)
 
     @run_only_on('sat')
@@ -871,7 +871,7 @@ class DockerContentViewTestCase(APITestCase):
         comp_cvv = comp_content_view.read().version[0]
         self.assertEqual(len(comp_cvv.read().environment), 1)
 
-        comp_cvv.promote({u'environment_id': lce.id})
+        comp_cvv.promote(data={u'environment_id': lce.id})
         self.assertEqual(len(comp_cvv.read().environment), 2)
 
     @run_only_on('sat')
@@ -914,7 +914,7 @@ class DockerContentViewTestCase(APITestCase):
 
         for i in range(1, randint(2, 5)):
             lce = entities.LifecycleEnvironment(organization=self.org).create()
-            comp_cvv.promote({u'environment_id': lce.id})
+            comp_cvv.promote(data={u'environment_id': lce.id})
             self.assertEqual(len(comp_cvv.read().environment), i+1)
 
 
@@ -938,7 +938,7 @@ class DockerActivationKeyTestCase(APITestCase):
         cls.content_view = content_view.update(['repository'])
         cls.content_view.publish()
         cls.cvv = content_view.read().version[0].read()
-        cls.cvv.promote({u'environment_id': cls.lce.id})
+        cls.cvv.promote(data={u'environment_id': cls.lce.id})
 
     @run_only_on('sat')
     def test_add_docker_repo_to_activation_key(self):
@@ -1004,7 +1004,7 @@ class DockerActivationKeyTestCase(APITestCase):
 
         comp_content_view.publish()
         comp_cvv = comp_content_view.read().version[0].read()
-        comp_cvv.promote({u'environment_id': self.lce.id})
+        comp_cvv.promote(data={u'environment_id': self.lce.id})
 
         ak = entities.ActivationKey(
             environment=self.lce,
@@ -1038,7 +1038,7 @@ class DockerActivationKeyTestCase(APITestCase):
 
         comp_content_view.publish()
         comp_cvv = comp_content_view.read().version[0].read()
-        comp_cvv.promote({u'environment_id': self.lce.id})
+        comp_cvv.promote(data={u'environment_id': self.lce.id})
 
         ak = entities.ActivationKey(
             environment=self.lce,

--- a/tests/foreman/api/test_hostgroup.py
+++ b/tests/foreman/api/test_hostgroup.py
@@ -57,7 +57,7 @@ class HostGroupTestCase(APITestCase):
             name=gen_string('alpha'),
             organization=org,
         ).create()
-        content_view.version[0].promote({u'environment_id': lc_env.id})
+        content_view.version[0].promote(data={u'environment_id': lc_env.id})
         content_view = content_view.read()
         self.assertEqual(len(content_view.version), 1)
         self.assertEqual(len(content_view.puppet_module), 1)

--- a/tests/foreman/api/test_hostgroup.py
+++ b/tests/foreman/api/test_hostgroup.py
@@ -37,7 +37,7 @@ class HostGroupTestCase(APITestCase):
         # Working with 'ntp' module as we know for sure that it contains at
         # least few puppet classes
         with open(get_data_file(PUPPET_MODULE_NTP_PUPPETLABS), 'rb') as handle:
-            puppet_repo.upload_content(handle)
+            puppet_repo.upload_content(files={'content': handle})
 
         content_view = entities.ContentView(
             name=gen_string('alpha'),

--- a/tests/foreman/api/test_product.py
+++ b/tests/foreman/api/test_product.py
@@ -149,8 +149,8 @@ class RepositorySetsTestCase(APITestCase):
             name=REPOSET['rhva6'],
             product=product,
         ).search()[0]
-        reposet.enable({'basearch': 'x86_64', 'releasever': '6Server'})
-        repositories = reposet.available_repositories()
+        reposet.enable(data={'basearch': 'x86_64', 'releasever': '6Server'})
+        repositories = reposet.available_repositories()['results']
         self.assertTrue([
             repo['enabled']
             for repo
@@ -179,9 +179,9 @@ class RepositorySetsTestCase(APITestCase):
             name=REPOSET['rhva6'],
             product=product,
         ).search()[0]
-        reposet.enable({'basearch': 'x86_64', 'releasever': '6Server'})
-        reposet.disable({'basearch': 'x86_64', 'releasever': '6Server'})
-        repositories = reposet.available_repositories()
+        reposet.enable(data={'basearch': 'x86_64', 'releasever': '6Server'})
+        reposet.disable(data={'basearch': 'x86_64', 'releasever': '6Server'})
+        repositories = reposet.available_repositories()['results']
         self.assertFalse([
             repo['enabled']
             for repo

--- a/tests/foreman/api/test_product.py
+++ b/tests/foreman/api/test_product.py
@@ -138,9 +138,11 @@ class RepositorySetsTestCase(APITestCase):
 
         """
         org = entities.Organization().create()
-        sub = entities.Subscription()
         with open(manifests.clone(), 'rb') as manifest:
-            sub.upload({'organization_id': org.id}, manifest)
+            entities.Subscription().upload(
+                data={'organization_id': org.id},
+                files={'content': manifest},
+            )
         product = entities.Product(
             name=PRDS['rhel'],
             organization=org,
@@ -168,9 +170,11 @@ class RepositorySetsTestCase(APITestCase):
 
         """
         org = entities.Organization().create()
-        sub = entities.Subscription()
         with open(manifests.clone(), 'rb') as manifest:
-            sub.upload({'organization_id': org.id}, manifest)
+            entities.Subscription().upload(
+                data={'organization_id': org.id},
+                files={'content': manifest},
+            )
         product = entities.Product(
             name=PRDS['rhel'],
             organization=org,

--- a/tests/foreman/api/test_repository.py
+++ b/tests/foreman/api/test_repository.py
@@ -240,9 +240,11 @@ class RepositorySyncTestCase(APITestCase):
 
         """
         org = entities.Organization().create()
-        sub = entities.Subscription()
         with open(manifests.clone(), 'rb') as manifest:
-            sub.upload({'organization_id': org.id}, manifest)
+            entities.Subscription().upload(
+                data={'organization_id': org.id},
+                files={'content': manifest},
+            )
         repo_id = utils.enable_rhrepo_and_fetchid(
             basearch='x86_64',
             org_id=org.id,

--- a/tests/foreman/api/test_repository.py
+++ b/tests/foreman/api/test_repository.py
@@ -172,7 +172,7 @@ class RepositoryTestCase(APITestCase):
         # Create a repository and upload RPM content.
         repo = entities.Repository(product=self.product).create()
         with open(get_data_file(RPM_TO_UPLOAD), 'rb') as handle:
-            repo.upload_content(handle)
+            repo.upload_content(files={'content': handle})
         # Verify the repository's contents.
         self.assertEqual(repo.read_json()[u'content_counts'][u'rpm'], 1)
 

--- a/tests/foreman/api/test_subscription.py
+++ b/tests/foreman/api/test_subscription.py
@@ -22,9 +22,11 @@ class SubscriptionsTestCase(APITestCase):
 
         """
         org = entities.Organization().create()
-        sub = entities.Subscription()
         with open(manifests.clone(), 'rb') as manifest:
-            sub.upload({'organization_id': org.id}, manifest)
+            entities.Subscription().upload(
+                data={'organization_id': org.id},
+                files={'content': manifest},
+            )
 
     def test_positive_delete_1(self):
         """@Test: Delete an Uploaded manifest.
@@ -38,9 +40,9 @@ class SubscriptionsTestCase(APITestCase):
         sub = entities.Subscription(organization=org)
         payload = {'organization_id': org.id}
         with open(manifests.clone(), 'rb') as manifest:
-            sub.upload(payload, manifest)
+            sub.upload(data=payload, files={'content': manifest})
         self.assertGreater(len(sub.search()), 0)
-        sub.delete_manifest(payload)
+        sub.delete_manifest(data=payload)
         self.assertEqual(len(sub.search()), 0)
 
     def test_negative_create_1(self):
@@ -54,8 +56,9 @@ class SubscriptionsTestCase(APITestCase):
         orgs = [entities.Organization().create() for _ in range(2)]
         sub = entities.Subscription()
         with open(manifests.clone(), 'rb') as manifest:
-            sub.upload({'organization_id': orgs[0].id}, manifest)
+            files = {'content': manifest}
+            sub.upload(data={'organization_id': orgs[0].id}, files=files)
             with self.assertRaises(TaskFailedError):
-                sub.upload({'organization_id': orgs[1].id}, manifest)
+                sub.upload(data={'organization_id': orgs[1].id}, files=files)
         self.assertEqual(
             len(entities.Subscription(organization=orgs[1]).search()), 0)

--- a/tests/foreman/api/test_syncplan.py
+++ b/tests/foreman/api/test_syncplan.py
@@ -369,7 +369,7 @@ class SyncPlanProductTestCase(APITestCase):
         """
         syncplan = entities.SyncPlan(organization=self.org).create()
         product = entities.Product(organization=self.org).create()
-        syncplan.add_products({'product_ids': [product.id]})
+        syncplan.add_products(data={'product_ids': [product.id]})
         syncplan = syncplan.read()
         self.assertEqual(len(syncplan.product), 1)
         self.assertEqual(syncplan.product[0].id, product.id)
@@ -388,7 +388,7 @@ class SyncPlanProductTestCase(APITestCase):
         products = [
             entities.Product(organization=self.org).create() for _ in range(2)
         ]
-        syncplan.add_products({
+        syncplan.add_products(data={
             'product_ids': [product.id for product in products],
         })
         syncplan = syncplan.read()
@@ -414,11 +414,11 @@ class SyncPlanProductTestCase(APITestCase):
         products = [
             entities.Product(organization=self.org).create() for _ in range(2)
         ]
-        syncplan.add_products({
+        syncplan.add_products(data={
             'product_ids': [product.id for product in products],
         })
         self.assertEqual(len(syncplan.read().product), 2)
-        syncplan.remove_products({'product_ids': [products[0].id]})
+        syncplan.remove_products(data={'product_ids': [products[0].id]})
         syncplan = syncplan.read()
         self.assertEqual(len(syncplan.product), 1)
         self.assertEqual(syncplan.product[0].id, products[1].id)
@@ -438,11 +438,11 @@ class SyncPlanProductTestCase(APITestCase):
         products = [
             entities.Product(organization=self.org).create() for _ in range(2)
         ]
-        syncplan.add_products({
+        syncplan.add_products(data={
             'product_ids': [product.id for product in products],
         })
         self.assertEqual(len(syncplan.read().product), 2)
-        syncplan.remove_products({
+        syncplan.remove_products(data={
             'product_ids': [product.id for product in products],
         })
         self.assertEqual(len(syncplan.read().product), 0)
@@ -461,9 +461,9 @@ class SyncPlanProductTestCase(APITestCase):
         syncplan = entities.SyncPlan(organization=self.org).create()
         product = entities.Product(organization=self.org).create()
         for _ in range(5):
-            syncplan.add_products({'product_ids': [product.id]})
+            syncplan.add_products(data={'product_ids': [product.id]})
             self.assertEqual(len(syncplan.read().product), 1)
-            syncplan.remove_products({'product_ids': [product.id]})
+            syncplan.remove_products(data={'product_ids': [product.id]})
             self.assertEqual(len(syncplan.read().product), 0)
 
 
@@ -527,7 +527,7 @@ class SyncPlanDeleteTestCase(APITestCase):
         """
         sync_plan = entities.SyncPlan(organization=self.org).create()
         product = entities.Product(organization=self.org).create()
-        sync_plan.add_products({'product_ids': [product.id]})
+        sync_plan.add_products(data={'product_ids': [product.id]})
         sync_plan.delete()
         with self.assertRaises(HTTPError):
             sync_plan.read()
@@ -545,7 +545,7 @@ class SyncPlanDeleteTestCase(APITestCase):
         products = [
             entities.Product(organization=self.org).create() for _ in range(2)
         ]
-        sync_plan.add_products({
+        sync_plan.add_products(data={
             'product_ids': [product.id for product in products],
         })
         sync_plan.delete()
@@ -564,9 +564,7 @@ class SyncPlanDeleteTestCase(APITestCase):
         sync_plan = entities.SyncPlan(organization=self.org).create()
         product = entities.Product(organization=self.org).create()
         entities.Repository(product=product).create()
-        sync_plan.add_products({
-            'product_ids': [product.id],
-        })
+        sync_plan.add_products(data={'product_ids': [product.id]})
         product.sync()
         sync_plan.delete()
         with self.assertRaises(HTTPError):

--- a/tests/foreman/rhai/test_rhai.py
+++ b/tests/foreman/rhai/test_rhai.py
@@ -23,7 +23,10 @@ class RHAITestCase(UITestCase):
         # Upload manifest
         sub = entities.Subscription(organization=org)
         with open(manifests.clone(), 'rb') as manifest:
-            sub.upload({'organization_id': org.id}, manifest)
+            sub.upload(
+                data={'organization_id': org.id},
+                files={'content': manifest},
+            )
 
         # Create activation key using default CV and library environment
         activation_key = entities.ActivationKey(

--- a/tests/foreman/rhai/test_rhai.py
+++ b/tests/foreman/rhai/test_rhai.py
@@ -43,7 +43,7 @@ class RHAITestCase(UITestCase):
                 # values produce this error: "RuntimeError: Error: Only pools
                 # with multi-entitlement product subscriptions can be added to
                 # the activation key with a quantity greater than one."
-                activation_key.add_subscriptions({
+                activation_key.add_subscriptions(data={
                     'quantity': 1,
                     'subscription_id': subs.id,
                 })

--- a/tests/foreman/smoke/test_api_smoke.py
+++ b/tests/foreman/smoke/test_api_smoke.py
@@ -907,13 +907,13 @@ class TestSmoke(TestCase):
         self.assertEqual(len(content_view.version), 1)
         cv_version = content_view.version[0].read()
         self.assertEqual(len(cv_version.environment), 1)
-        cv_version.promote({u'environment_id': le1.id})
+        cv_version.promote(data={u'environment_id': le1.id})
         # Check that content view exists in 2 lifecycles
         content_view = content_view.read()
         self.assertEqual(len(content_view.version), 1)
         cv_version = cv_version.read()
         self.assertEqual(len(cv_version.environment), 2)
-        cv_version.promote({u'environment_id': le2.id})
+        cv_version.promote(data={u'environment_id': le2.id})
         # Check that content view exists in 2 lifecycles
         content_view = content_view.read()
         self.assertEqual(len(content_view.version), 1)
@@ -1014,7 +1014,9 @@ class TestSmoke(TestCase):
         # step 6.2: Promote content view to lifecycle_env
         content_view = content_view.read()
         self.assertEqual(len(content_view.version), 1)
-        content_view.version[0].promote({u'environment_id': lifecycle_env.id})
+        content_view.version[0].promote(data={
+            u'environment_id': lifecycle_env.id
+        })
 
         # step 7: Create activation key
         activation_key = entities.ActivationKey(

--- a/tests/foreman/smoke/test_api_smoke.py
+++ b/tests/foreman/smoke/test_api_smoke.py
@@ -988,7 +988,10 @@ class TestSmoke(TestCase):
         # step 2: Upload manifest
         sub = entities.Subscription(organization=org)
         with open(manifests.clone(), 'rb') as manifest:
-            sub.upload({'organization_id': org.id}, manifest)
+            sub.upload(
+                data={'organization_id': org.id},
+                files={'content': manifest},
+            )
         # step 3.1: Enable RH repo and fetch repository_id
         repository = entities.Repository(id=utils.enable_rhrepo_and_fetchid(
             basearch='x86_64',

--- a/tests/foreman/smoke/test_api_smoke.py
+++ b/tests/foreman/smoke/test_api_smoke.py
@@ -1032,13 +1032,13 @@ class TestSmoke(TestCase):
                 # values produce this error: "RuntimeError: Error: Only pools
                 # with multi-entitlement product subscriptions can be added to
                 # the activation key with a quantity greater than one."
-                activation_key.add_subscriptions({
+                activation_key.add_subscriptions(data={
                     'quantity': 1,
                     'subscription_id': subs.id,
                 })
                 break
         # step 7.2: Enable product content
-        activation_key.content_override({'content_override': {
+        activation_key.content_override(data={'content_override': {
             u'content_label': u'rhel-6-server-rhev-agent-rpms',
             u'value': u'1',
         }})

--- a/tests/foreman/ui/test_activationkey.py
+++ b/tests/foreman/ui/test_activationkey.py
@@ -1347,7 +1347,7 @@ class ActivationKey(UITestCase):
         # Associate a manifest to the activation key
         for subs in sub.search():
             if subs.read_json()['product_name'] == DEFAULT_SUBSCRIPTION_NAME:
-                activation_key.add_subscriptions({
+                activation_key.add_subscriptions(data={
                     'quantity': 1,
                     'subscription_id': subs.id,
                 })

--- a/tests/foreman/ui/test_activationkey.py
+++ b/tests/foreman/ui/test_activationkey.py
@@ -128,7 +128,7 @@ class ActivationKey(UITestCase):
         cv_version = entities.ContentViewVersion(id=results[0]['id'])
 
         # Promote the content view version.
-        cv_version.promote({u'environment_id': env_attrs.id})
+        cv_version.promote(data={u'environment_id': env_attrs.id})
 
     @data(*valid_data_list())
     def test_positive_create_activation_key_1(self, name):

--- a/tests/foreman/ui/test_activationkey.py
+++ b/tests/foreman/ui/test_activationkey.py
@@ -883,9 +883,11 @@ class ActivationKey(UITestCase):
             'releasever': '6Server',
         }
         org = entities.Organization().create()
-        sub = entities.Subscription()
         with open(manifests.clone(), 'rb') as manifest:
-            sub.upload({'organization_id': org.id}, manifest)
+            entities.Subscription().upload(
+                data={'organization_id': org.id},
+                files={'content': manifest},
+            )
         repo1_id = self.enable_sync_redhat_repo(rh_repo1, org.id)
         self.cv_publish_promote(cv1_name, env1_name, repo1_id, org.id)
         repo2_id = self.enable_sync_redhat_repo(rh_repo2, org.id)
@@ -1185,9 +1187,11 @@ class ActivationKey(UITestCase):
         org_attrs = entities.Organization().create_json()
         org_id = org_attrs['id']
         # Upload manifest
-        sub = entities.Subscription()
         with open(manifests.clone(), 'rb') as manifest:
-            sub.upload({'organization_id': org_id}, manifest)
+            entities.Subscription().upload(
+                data={'organization_id': org_id},
+                files={'content': manifest},
+            )
         # Helper function to create and promote CV to next environment
         repo_id = self.enable_sync_redhat_repo(rh_repo, org_id=org_id)
         self.cv_publish_promote(cv_name, env_name, repo_id, org_id)
@@ -1290,9 +1294,11 @@ class ActivationKey(UITestCase):
         ).create_json()
         custom_repo_id = repo_attrs['id']
         # Upload manifest
-        sub = entities.Subscription()
         with open(manifests.clone(), 'rb') as manifest:
-            sub.upload({'organization_id': org_id}, manifest)
+            entities.Subscription().upload(
+                data={'organization_id': org_id},
+                files={'content': manifest},
+            )
         # Enable RH repo and fetch repository_id
         rhel_repo_id = utils.enable_rhrepo_and_fetchid(
             basearch=rh_repo['basearch'],
@@ -1339,7 +1345,10 @@ class ActivationKey(UITestCase):
         org = entities.Organization().create()
         sub = entities.Subscription(organization=org)
         with open(manifests.clone(), 'rb') as manifest:
-            sub.upload({'organization_id': org.id}, manifest)
+            sub.upload(
+                data={'organization_id': org.id},
+                files={'content': manifest},
+            )
         # Create activation key
         activation_key = entities.ActivationKey(
             organization=org.id,

--- a/tests/foreman/ui/test_contentviews.py
+++ b/tests/foreman/ui/test_contentviews.py
@@ -70,9 +70,11 @@ class TestContentViewsUI(UITestCase):
             repo_id = repo_attrs['id']
         elif rh_repo:
             # Uploads the manifest and returns the result.
-            sub = entities.Subscription()
             with open(manifests.clone(), 'rb') as manifest:
-                sub.upload({'organization_id': org_id}, manifest)
+                entities.Subscription().upload(
+                    data={'organization_id': org_id},
+                    files={'content': manifest},
+                )
             # Enables the RedHat repo and fetches it's Id.
             repo_id = utils.enable_rhrepo_and_fetchid(
                 basearch=rh_repo['basearch'],

--- a/tests/foreman/ui/test_contentviews.py
+++ b/tests/foreman/ui/test_contentviews.py
@@ -1261,7 +1261,7 @@ class TestContentViewsUI(UITestCase):
         version = 'Version {0}'.format(cv_info['version'])
         cvv = entities.ContentViewVersion(id=cv_info['id'])
         lc_env = entities.LifecycleEnvironment(organization=org).create()
-        cvv.promote({u'environment_id': lc_env.id})
+        cvv.promote(data={u'environment_id': lc_env.id})
 
         with Session(self.browser) as session:
             session.nav.go_to_select_org(org.name)
@@ -1291,7 +1291,7 @@ class TestContentViewsUI(UITestCase):
         version = 'Version {0}'.format(cv_info['version'])
         cvv = entities.ContentViewVersion(id=cv_info['id'])
         lc_env = entities.LifecycleEnvironment(organization=org).create()
-        cvv.promote({u'environment_id': lc_env.id})
+        cvv.promote(data={u'environment_id': lc_env.id})
 
         ak = entities.ActivationKey(
             name=gen_string('alphanumeric'),

--- a/tests/foreman/ui/test_gpgkey.py
+++ b/tests/foreman/ui/test_gpgkey.py
@@ -424,9 +424,9 @@ class GPGKey(UITestCase):
         # step 6.2: Promote content view to lifecycle_env
         cv = entities.ContentView(id=content_view.id).read_json()
         self.assertEqual(len(cv['versions']), 1)
-        entities.ContentViewVersion(
-            id=cv['versions'][0]['id']
-        ).promote({u'environment_id': lc_env_id})
+        entities.ContentViewVersion(id=cv['versions'][0]['id']).promote(data={
+            u'environment_id': lc_env_id
+        })
         # step 7: Create activation key
         ak_id = entities.ActivationKey(
             name=activation_key_name,

--- a/tests/foreman/ui/test_gpgkey.py
+++ b/tests/foreman/ui/test_gpgkey.py
@@ -437,7 +437,7 @@ class GPGKey(UITestCase):
         for subscription in entities.Subscription(
                 organization=self.org_id).search():
             if subscription.read_json()['product_name'] == product_name:
-                entities.ActivationKey(id=ak_id).add_subscriptions({
+                entities.ActivationKey(id=ak_id).add_subscriptions(data={
                     'quantity': 1,
                     'subscription_id': subscription.id,
                 })

--- a/tests/foreman/ui/test_org.py
+++ b/tests/foreman/ui/test_org.py
@@ -239,9 +239,11 @@ class Org(UITestCase):
 
         """
         org = entities.Organization(name=org_name).create()
-        sub = entities.Subscription()
         with open(manifests.clone(), 'rb') as manifest:
-            sub.upload({'organization_id': org.id}, manifest)
+            entities.Subscription().upload(
+                data={'organization_id': org.id},
+                files={'content': manifest},
+            )
         with Session(self.browser) as session:
             make_lifecycle_environment(session, org_name, name='DEV')
             make_lifecycle_environment(

--- a/tests/foreman/ui/test_sync.py
+++ b/tests/foreman/ui/test_sync.py
@@ -71,9 +71,11 @@ class Sync(UITestCase):
         """
 
         repos = self.sync.create_repos_tree(RHCT)
-        sub = entities.Subscription()
         with open(manifests.clone(), 'rb') as manifest:
-            sub.upload({'organization_id': self.org_id}, manifest)
+            entities.Subscription().upload(
+                data={'organization_id': self.org_id},
+                files={'content': manifest},
+            )
         with Session(self.browser) as session:
             session.nav.go_to_select_org(self.org_name)
             session.nav.go_to_red_hat_repositories()


### PR DESCRIPTION
Make Robottelo use updated NailGun methods. Depends on SatelliteQE/nailgun#175.

Run some tests to verify the changes:

    $ make test-foreman-api-threaded
    python -m cProfile -o test-foreman-api-threaded.pstats $(which nosetests) --logging-filter=nailgun,robottelo --with-xunit --xunit-file=foreman-results.xml tests/foreman/api\
        --processes=-1 --process-timeout=300
    ......FFF..................S.........................E..............E....SSSSSSSSSSSSSSSSSSSSSSS...........................................................................................SSSSSSSSSSSSSSSSSSS....SS..............SS..SSSSSSSSS.....................S.SSSSSS................................................S.........SSSSSSSSSSSSS...S..S....S..SSSSSSSSS...............S...................................SSSSSSSS................S.................................................................................................................................................................S................................................................SSSSSSSSS..SSSSSS..SSS.S.SSSSSSSSSSSSSSSSSSSSSSSSSSSSS.....................SS...............SSSSSS......................................................................................................E.E....S................E.........................................SSSSSSSS.........................E.E..........................SS.S..S.........................................................................................
    ----------------------------------------------------------------------
    Ran 1086 tests in 2702.662s

    FAILED (SKIP=169, errors=7, failures=3)
    $ nosetests tests/foreman/ui/test_activationkey.py -m test_positive_create_activation_key_1
    .......
    ----------------------------------------------------------------------
    Ran 7 tests in 384.101s

    OK

Notes on the test results:

* The ten API errors and failures were due to things like database deadlocks and
  failed assertions, all unrelated to the changes.
* For the sake of speed, I elected to run just one of the updated UI tests as a
  sanity check.
* No CLI tests were updated.