### PR TITLE
Work on improvements for ui.operatingsys and ui.partitiontable

### DIFF
--- a/robottelo/ui/locators.py
+++ b/robottelo/ui/locators.py
@@ -646,8 +646,10 @@ common_locators = LocatorDict({
     "parameter_tab": (By.XPATH, "//a[contains(., 'Parameters')]"),
     "add_parameter": (
         By.XPATH, "//a[contains(text(),'+ Add Parameter')]"),
-    "parameter_name": (By.XPATH, "//input[@placeholder='Name']"),
-    "parameter_value": (By.XPATH, "//textarea[@placeholder='Value']"),
+    "parameter_name": (
+        By.XPATH, "//input[@placeholder='Name' and not(@value)]"),
+    "parameter_value": (
+        By.XPATH, "//textarea[@placeholder='Value' and not(text())]"),
     "parameter_remove": (
         By.XPATH, "//tr/td/input[@value='%s']/following::td/span/a/i"),
 

--- a/robottelo/ui/operatingsys.py
+++ b/robottelo/ui/operatingsys.py
@@ -1,10 +1,10 @@
 # -*- encoding: utf-8 -*-
 """Implements Operating System UI."""
 from robottelo.ui.base import Base, UIError
-from robottelo.ui.locators import locators, common_locators, tab_locators
+from robottelo.common.constants import FILTER
+from robottelo.ui.locators import common_locators, locators, tab_locators
 from robottelo.ui.navigator import Navigator
 from selenium.webdriver.support.select import Select
-from robottelo.common.constants import FILTER
 
 
 class OperatingSys(Base):
@@ -15,21 +15,21 @@ class OperatingSys(Base):
                       template=None, arch_list=None, ptable_list=None,
                       medium_list=None):
         """Configures the operating system details."""
-        tab_primary_locator = tab_locators["tab_primary"]
-        tab_ptable_locator = tab_locators["operatingsys.tab_ptable"]
-        tab_medium_locator = tab_locators["operatingsys.tab_medium"]
+        tab_primary_locator = tab_locators['tab_primary']
+        tab_ptable_locator = tab_locators['operatingsys.tab_ptable']
+        tab_medium_locator = tab_locators['operatingsys.tab_medium']
 
         if minor_version:
             if self.wait_until_element(
-                    locators["operatingsys.minor_version"]):
-                self.field_update("operatingsys.minor_version", minor_version)
+                    locators['operatingsys.minor_version']):
+                self.field_update('operatingsys.minor_version', minor_version)
         if description:
             if self.wait_until_element(
-                    locators["operatingsys.description"]):
-                self.field_update("operatingsys.description", description)
+                    locators['operatingsys.description']):
+                self.field_update('operatingsys.description', description)
         if os_family:
             Select(
-                self.find_element(locators["operatingsys.family"])
+                self.find_element(locators['operatingsys.family'])
             ).select_by_visible_text(os_family)
         if archs or arch_list:
             self.configure_entity(
@@ -56,11 +56,9 @@ class OperatingSys(Base):
                 entity_select=select
             )
         if template:
-            self.wait_until_element(
-                tab_locators["operatingsys.tab_templates"]).click()
-            self.wait_for_ajax()
+            self.click(tab_locators['operatingsys.tab_templates'])
             Select(
-                self.find_element(locators["operatingsys.template"])
+                self.find_element(locators['operatingsys.template'])
             ).select_by_visible_text(template)
 
     def create(self, name, major_version=None,
@@ -68,11 +66,11 @@ class OperatingSys(Base):
                archs=None, ptables=None, mediums=None, select=True,
                template=None):
         """Create operating system from UI."""
-        new_os = self.wait_until_element(locators["operatingsys.new"])
+        new_os = self.wait_until_element(locators['operatingsys.new'])
         if new_os:
             new_os.click()
-            os_name_locator = locators["operatingsys.name"]
-            os_major_locator = locators["operatingsys.major_version"]
+            os_name_locator = locators['operatingsys.name']
+            os_major_locator = locators['operatingsys.major_version']
             if self.wait_until_element(os_name_locator):
                 self.find_element(os_name_locator).send_keys(name)
             if self.wait_until_element(os_major_locator):
@@ -90,8 +88,7 @@ class OperatingSys(Base):
                     ptable_list=None,
                     medium_list=None
                 )
-                self.find_element(common_locators["submit"]).click()
-                self.wait_for_ajax()
+                self.click(common_locators['submit'])
             else:
                 raise UIError('Could not create OS without major_version')
         else:
@@ -110,7 +107,7 @@ class OperatingSys(Base):
                 name, common_locators['select_filtered_entity'], search_key)
         return element
 
-    def delete(self, os_name, really):
+    def delete(self, os_name, really=True):
         """Delete operating system from UI."""
         self.delete_entity(
             os_name,
@@ -131,13 +128,13 @@ class OperatingSys(Base):
         if element:
             element.click()
             if new_name:
-                if self.wait_until_element(locators["operatingsys.name"]):
-                    self.field_update("operatingsys.name", new_name)
+                if self.wait_until_element(locators['operatingsys.name']):
+                    self.field_update('operatingsys.name', new_name)
             if major_version:
                 if self.wait_until_element(
-                        locators["operatingsys.major_version"]):
+                        locators['operatingsys.major_version']):
                     self.field_update(
-                        "operatingsys.major_version", major_version)
+                        'operatingsys.major_version', major_version)
             self._configure_os(
                 archs,
                 ptables,
@@ -151,8 +148,7 @@ class OperatingSys(Base):
                 ptable_list=new_ptables,
                 medium_list=new_mediums
             )
-            self.find_element(common_locators["submit"]).click()
-            self.wait_for_ajax()
+            self.click(common_locators['submit'])
         else:
             raise UIError(
                 'Could not update the operating system "{0}"'.format(os_name)
@@ -201,44 +197,38 @@ class OperatingSys(Base):
         """
 
         result = None
-        name_loc = locators["operatingsys.name"]
-        major_ver_loc = locators["operatingsys.major_version"]
-        minor_ver_loc = locators["operatingsys.minor_version"]
-        os_family_loc = locators["operatingsys.family"]
+        name_loc = locators['operatingsys.name']
+        major_ver_loc = locators['operatingsys.major_version']
+        minor_ver_loc = locators['operatingsys.minor_version']
+        os_family_loc = locators['operatingsys.family']
         os_object = self.search_entity(
-            os_name, locators["operatingsys.operatingsys_name"])
+            os_name, locators['operatingsys.operatingsys_name'])
         if os_object:
             os_object.click()
-            if self.wait_until_element(locators["operatingsys.name"]):
+            if self.wait_until_element(locators['operatingsys.name']):
                 result = dict([('name', None), ('major', None),
                                ('minor', None), ('os_family', None),
                                ('ptable', None), ('template', None),
                                ('medium', None)])
                 result['name'] = self.find_element(
-                    name_loc).get_attribute("value")
+                    name_loc).get_attribute('value')
                 result['major'] = self.find_element(
-                    major_ver_loc).get_attribute("value")
+                    major_ver_loc).get_attribute('value')
                 result['minor'] = self.find_element(
-                    minor_ver_loc).get_attribute("value")
+                    minor_ver_loc).get_attribute('value')
                 result['os_family'] = Select(
                     self.find_element(os_family_loc)
                 ).first_selected_option.text
-                if entity_name == "ptable":
-                    self.wait_until_element(
-                        tab_locators["operatingsys.tab_ptable"]).click()
-                    self.wait_for_ajax()
+                if entity_name == 'ptable':
+                    self.click(tab_locators['operatingsys.tab_ptable'])
                     result['ptable'] = self.get_selected_entities()
-                elif entity_name == "medium":
-                    self.wait_until_element(
-                        tab_locators["operatingsys.tab_medium"]).click()
-                    self.wait_for_ajax()
+                elif entity_name == 'medium':
+                    self.click(tab_locators['operatingsys.tab_medium'])
                     result['medium'] = self.get_selected_entities()
-                elif entity_name == "template":
-                    self.wait_until_element(
-                        tab_locators["operatingsys.tab_templates"]).click()
-                    self.wait_for_ajax()
+                elif entity_name == 'template':
+                    self.click(tab_locators['operatingsys.tab_templates'])
                     result['template'] = Select(
-                        self.find_element(locators["operatingsys.template"])
+                        self.find_element(locators['operatingsys.template'])
                     ).first_selected_option.text
                 return result
             else:

--- a/robottelo/ui/partitiontable.py
+++ b/robottelo/ui/partitiontable.py
@@ -2,7 +2,7 @@
 """Implements Partition Table UI."""
 
 from robottelo.ui.base import Base, UIError
-from robottelo.ui.locators import locators, common_locators
+from robottelo.ui.locators import common_locators, locators
 from robottelo.ui.navigator import Navigator
 from selenium.webdriver.support.select import Select
 
@@ -14,20 +14,19 @@ class PartitionTable(Base):
         """Configures the os family of partition table."""
         if os_family:
             Select(
-                self.find_element(locators["ptable.os_family"])
+                self.find_element(locators['ptable.os_family'])
             ).select_by_visible_text(os_family)
 
     def create(self, name, layout=None, os_family=None):
         """Creates new partition table from UI."""
-        self.wait_until_element(locators["ptable.new"]).click()
+        self.click(locators['ptable.new'])
 
-        if self.wait_until_element(locators["ptable.name"]):
-            self.find_element(locators["ptable.name"]).send_keys(name)
-            if self.wait_until_element(locators["ptable.layout"]):
-                self.find_element(locators["ptable.layout"]).send_keys(layout)
+        if self.wait_until_element(locators['ptable.name']):
+            self.find_element(locators['ptable.name']).send_keys(name)
+            if self.wait_until_element(locators['ptable.layout']):
+                self.find_element(locators['ptable.layout']).send_keys(layout)
                 self._configure_partition_table(os_family)
-                self.find_element(common_locators["submit"]).click()
-                self.wait_for_ajax()
+                self.click(common_locators['submit'])
             else:
                 raise UIError(
                     'Could not create partition table "{0}", missing layout'
@@ -41,15 +40,15 @@ class PartitionTable(Base):
     def search(self, name):
         """Searches existing partition table from UI."""
         Navigator(self.browser).go_to_partition_tables()
-        element = self.search_entity(name, locators["ptable.ptable_name"])
+        element = self.search_entity(name, locators['ptable.ptable_name'])
         return element
 
-    def delete(self, name, really):
+    def delete(self, name, really=True):
         """Removes existing partition table from UI."""
         self.delete_entity(
             name,
             really,
-            locators["ptable.ptable_name"],
+            locators['ptable.ptable_name'],
             locators['ptable.delete']
         )
 
@@ -60,14 +59,13 @@ class PartitionTable(Base):
 
         if element:
             element.click()
-            if self.wait_until_element(locators["ptable.name"]):
-                self.field_update("ptable.name", new_name)
+            if self.wait_until_element(locators['ptable.name']):
+                self.field_update('ptable.name', new_name)
             if new_layout:
-                if self.wait_until_element(locators["ptable.layout"]):
-                    self.field_update("ptable.layout", new_layout)
+                if self.wait_until_element(locators['ptable.layout']):
+                    self.field_update('ptable.layout', new_layout)
             self._configure_partition_table(os_family)
-            self.find_element(common_locators["submit"]).click()
-            self.wait_for_ajax()
+            self.click(common_locators['submit'])
         else:
             raise UIError(
                 'Could not update partition table "{0}"'.format(old_name)

--- a/tests/foreman/ui/test_operatingsys.py
+++ b/tests/foreman/ui/test_operatingsys.py
@@ -6,9 +6,9 @@ from fauxfactory import gen_string
 from nailgun import entities
 from robottelo.common.constants import (
     INSTALL_MEDIUM_URL, PARTITION_SCRIPT_DATA_FILE)
-from robottelo.common.decorators import data
-from robottelo.common.decorators import run_only_on, skip_if_bug_open
-from robottelo.common.helpers import get_data_file
+from robottelo.common.decorators import data, run_only_on, skip_if_bug_open
+from robottelo.common.helpers import (
+    get_data_file, invalid_names_list, valid_data_list)
 from robottelo.test import UITestCase
 from robottelo.ui.base import UIError
 from robottelo.ui.factory import make_os
@@ -23,53 +23,46 @@ class OperatingSys(UITestCase):
 
     @classmethod
     def setUpClass(cls):  # noqa
-        org_attrs = entities.Organization().create_json()
-        cls.org_name = org_attrs['name']
-        cls.org_id = org_attrs['id']
+        cls.organization = entities.Organization().create()
         super(OperatingSys, cls).setUpClass()
 
-    def test_create_os(self):
-        """@Test: Create a new OS
+    @data(*valid_data_list())
+    def test_create_os_with_different_names(self, name):
+        """@Test: Create a new OS using different string types as a name
 
         @Feature: OS - Positive Create
 
         @Assert: OS is created
 
         """
-
-        name = gen_string("alpha", 6)
-        major_version = gen_string('numeric', 1)
-        minor_version = gen_string('numeric', 1)
-        os_family = "Red Hat"
-        arch = "x86_64"
         with Session(self.browser) as session:
-            make_os(session, name=name,
-                    major_version=major_version,
-                    minor_version=minor_version,
-                    os_family=os_family, archs=[arch])
+            make_os(
+                session,
+                name=name,
+                major_version=gen_string('numeric', 1),
+                minor_version=gen_string('numeric', 1),
+                os_family='Red Hat',
+                archs=['x86_64'],
+            )
             self.assertIsNotNone(self.operatingsys.search(name))
 
-    @data({u'name': gen_string('alpha', 10),
-           u'major_version': gen_string('numeric', 1),
+    @data({u'major_version': gen_string('numeric', 1),
            u'minor_version': gen_string('numeric', 1),
            u'desc': gen_string('alpha', 10),
-           u'os_family': "Red Hat"},
-          {u'name': gen_string('html', 10),
-           u'major_version': gen_string('numeric', 4),
+           u'os_family': 'Red Hat'},
+          {u'major_version': gen_string('numeric', 4),
            u'minor_version': gen_string('numeric', 4),
            u'desc': gen_string('html', 10),
-           u'os_family': "Gentoo"},
-          {u'name': gen_string('utf8', 10),
-           u'major_version': gen_string('numeric', 5),
+           u'os_family': 'Gentoo'},
+          {u'major_version': gen_string('numeric', 5),
            u'minor_version': gen_string('numeric', 16),
            u'desc': gen_string('utf8', 10),
-           u'os_family': "SUSE"},
-          {u'name': gen_string('alphanumeric', 255),
-           u'major_version': gen_string('numeric', 5),
+           u'os_family': 'SUSE'},
+          {u'major_version': gen_string('numeric', 5),
            u'minor_version': gen_string('numeric', 1),
            u'desc': gen_string('alphanumeric', 255),
-           u'os_family': "SUSE"})
-    def test_positive_create_os(self, test_data):
+           u'os_family': 'SUSE'})
+    def test_create_os_with_random_params(self, test_data):
         """@Test: Create a new OS with different data values
 
         @Feature: OS - Positive Create
@@ -79,19 +72,24 @@ class OperatingSys(UITestCase):
         @BZ: 1120568
 
         """
-
-        arch = "i386"
+        name = gen_string('alpha')
         with Session(self.browser) as session:
-            make_os(session, name=test_data['name'],
-                    major_version=test_data['major_version'],
-                    minor_version=test_data['minor_version'],
-                    description=test_data['desc'],
-                    os_family=test_data['os_family'], archs=[arch])
+            make_os(
+                session,
+                name=name,
+                major_version=test_data['major_version'],
+                minor_version=test_data['minor_version'],
+                description=test_data['desc'],
+                os_family=test_data['os_family'],
+                archs=['i386'],
+            )
             self.assertIsNotNone(self.operatingsys.search
-                                 (test_data['desc'], search_key="description"))
+                                 (test_data['desc'], search_key='description'))
 
-    def test_negative_create_os_1(self):
-        """@Test: OS - Create a new OS with 256 characters in name
+    @data(*invalid_names_list())
+    def test_negative_create_os_with_long_names(self, name):
+        """@Test: OS - Create a new OS with too long string of different types
+        as its name value
 
         @Feature: Create a new OS - Negative
 
@@ -100,22 +98,20 @@ class OperatingSys(UITestCase):
         @BZ: 1120181
 
         """
-
-        name = gen_string("alpha", 256)
-        major_version = gen_string('numeric', 1)
-        minor_version = gen_string('numeric', 1)
-        os_family = "Red Hat"
-        arch = "x86_64"
         with Session(self.browser) as session:
-            make_os(session, name=name,
-                    major_version=major_version,
-                    minor_version=minor_version,
-                    os_family=os_family, archs=[arch])
+            make_os(
+                session,
+                name=name,
+                major_version=gen_string('numeric', 1),
+                minor_version=gen_string('numeric', 1),
+                os_family='Red Hat',
+                archs=['x86_64']
+            )
             self.assertIsNotNone(self.operatingsys.wait_until_element
-                                 (common_locators["name_haserror"]))
+                                 (common_locators['name_haserror']))
             self.assertIsNone(self.operatingsys.search(name))
 
-    def test_negative_create_os_2(self):
+    def test_negative_create_os_with_blank_name(self):
         """@Test: OS - Create a new OS with blank name
 
         @Feature: Create a new OS - Negative
@@ -123,20 +119,19 @@ class OperatingSys(UITestCase):
         @Assert: OS is not created
 
         """
-        name = ""
-        major_version = gen_string('numeric', 1)
-        minor_version = gen_string('numeric', 1)
-        os_family = "Red Hat"
-        arch = "x86_64"
         with Session(self.browser) as session:
-            make_os(session, name=name,
-                    major_version=major_version,
-                    minor_version=minor_version,
-                    os_family=os_family, archs=[arch])
+            make_os(
+                session,
+                name='',
+                major_version=gen_string('numeric', 1),
+                minor_version=gen_string('numeric', 1),
+                os_family='Red Hat',
+                archs=['x86_64']
+            )
             self.assertIsNotNone(self.operatingsys.wait_until_element
-                                 (common_locators["name_haserror"]))
+                                 (common_locators['name_haserror']))
 
-    def test_negative_create_os_3(self):
+    def test_negative_create_os_with_long_desc(self):
         """@Test: OS - Create a new OS with description containing
         256 characters
 
@@ -145,116 +140,71 @@ class OperatingSys(UITestCase):
         @Assert: OS is not created
 
         """
-        name = gen_string("alpha", 6)
-        major_version = gen_string('numeric', 1)
-        minor_version = gen_string('numeric', 1)
-        description = gen_string("alphanumeric", 256)
-        os_family = "Red Hat"
-        arch = "x86_64"
+        name = gen_string('alpha')
         with Session(self.browser) as session:
-            make_os(session, name=name,
-                    major_version=major_version,
-                    minor_version=minor_version,
-                    description=description,
-                    os_family=os_family, archs=[arch])
+            make_os(
+                session,
+                name=gen_string('alpha', 6),
+                major_version=gen_string('numeric', 1),
+                minor_version=gen_string('numeric', 1),
+                description=gen_string('alphanumeric', 256),
+                os_family='Red Hat',
+                archs=['x86_64']
+            )
             self.assertIsNotNone(self.operatingsys.wait_until_element
-                                 (common_locators["haserror"]))
+                                 (common_locators['haserror']))
             self.assertIsNone(self.operatingsys.search(name))
 
-    def test_negative_create_os_4(self):
-        """@Test: OS - Create a new OS with long major version (More than 5
-        characters in major version)
+    @data(gen_string('numeric', 6), '', '-6')
+    def test_negative_create_os_with_wrong_major_version(self, major_version):
+        """@Test: OS - Create a new OS with incorrect major version value(More than 5
+        characters, empty value, negative number)
 
         @Feature: Create a new OS - Negative
 
         @Assert: OS is not created
 
         """
-        name = gen_string("alpha", 6)
-        major_version = gen_string('numeric', 6)
-        minor_version = gen_string('numeric', 1)
-        os_family = "Red Hat"
-        arch = "x86_64"
+        name = gen_string('alpha')
         with Session(self.browser) as session:
-            make_os(session, name=name,
-                    major_version=major_version,
-                    minor_version=minor_version,
-                    os_family=os_family, archs=[arch])
+            make_os(
+                session,
+                name=name,
+                major_version=major_version,
+                minor_version=gen_string('numeric', 1),
+                os_family='Red Hat',
+                archs=['x86_64']
+            )
             self.assertIsNotNone(self.operatingsys.wait_until_element
-                                 (common_locators["haserror"]))
+                                 (common_locators['haserror']))
             self.assertIsNone(self.operatingsys.search(name))
 
-    def test_negative_create_os_5(self):
-        """@Test: OS - Create a new OS with long minor version (More than 16
-        characters in minor version)
+    @data(gen_string('numeric', 17), '-5')
+    def test_negative_create_os_with_wrong_minor_version(self, minor_version):
+        """@Test: OS - Create a new OS with incorrect minor version value(More than 16
+        characters and negative number)
 
         @Feature: Create a new OS - Negative
 
         @Assert: OS is not created
 
         """
-        name = gen_string("alpha", 6)
-        major_version = gen_string('numeric', 1)
-        minor_version = gen_string('numeric', 17)
-        os_family = "Red Hat"
-        arch = "x86_64"
+        name = gen_string('alpha')
         with Session(self.browser) as session:
-            make_os(session, name=name,
-                    major_version=major_version,
-                    minor_version=minor_version,
-                    os_family=os_family, archs=[arch])
+            make_os(
+                session,
+                name=name,
+                major_version=gen_string('numeric', 1),
+                minor_version=minor_version,
+                os_family='Red Hat',
+                archs=['x86_64']
+            )
             self.assertIsNotNone(self.operatingsys.wait_until_element
-                                 (common_locators["haserror"]))
-            self.assertIsNone(self.operatingsys.search(name))
-
-    def test_negative_create_os_6(self):
-        """@Test: OS - Create a new OS without major version
-
-        @Feature: Create a new OS - Negative
-
-        @Assert: OS is not created
-
-        """
-        name = gen_string("alpha", 6)
-        major_version = " "
-        minor_version = gen_string('numeric', 6)
-        os_family = "Red Hat"
-        arch = "x86_64"
-        with Session(self.browser) as session:
-            make_os(session, name=name,
-                    major_version=major_version,
-                    minor_version=minor_version,
-                    os_family=os_family, archs=[arch])
-            self.assertIsNotNone(self.operatingsys.wait_until_element
-                                 (common_locators["haserror"]))
-            self.assertIsNone(self.operatingsys.search(name))
-
-    def test_negative_create_os_7(self):
-        """@Test: OS - Create a new OS with -ve value of major version
-
-        @Feature: Create a new OS - Negative
-
-        @Assert: OS is not created
-
-        @BZ: 1120199
-
-        """
-        name = gen_string("alpha", 6)
-        major_version = "-6"
-        minor_version = "-5"
-        os_family = "Red Hat"
-        arch = "x86_64"
-        with Session(self.browser) as session:
-            make_os(session, name=name,
-                    major_version=major_version,
-                    minor_version=minor_version,
-                    os_family=os_family, archs=[arch])
-            self.assertIsNotNone(self.operatingsys.wait_until_element
-                                 (common_locators["haserror"]))
+                                 (common_locators['haserror']))
             self.assertIsNone(self.operatingsys.search(name))
 
     @skip_if_bug_open('bugzilla', 1120985)
-    def test_negative_create_os_8(self):
+    def test_negative_create_os_with_same_name_and_version(self):
         """@Test: OS - Create a new OS with same name and version
 
         @Feature: Create a new OS - Negative
@@ -264,24 +214,29 @@ class OperatingSys(UITestCase):
         @BZ: 1120985
 
         """
-        name = gen_string("alpha", 6)
+        name = gen_string('alpha')
         major_version = gen_string('numeric', 1)
         minor_version = gen_string('numeric', 1)
-        os_family = "Red Hat"
-        arch = "x86_64"
         with Session(self.browser) as session:
-            make_os(session, name=name,
-                    major_version=major_version,
-                    minor_version=minor_version,
-                    os_family=os_family, archs=[arch])
+            make_os(
+                session,
+                name=name,
+                major_version=major_version,
+                minor_version=minor_version,
+                os_family='Red Hat',
+                archs=['x86_64']
+            )
             self.assertIsNotNone(self.operatingsys.search(name))
-            make_os(session, name=name,
-                    major_version=major_version,
-                    minor_version=minor_version,
-                    os_family=os_family, archs=[arch])
+            make_os(
+                session,
+                name=name,
+                major_version=major_version,
+                minor_version=minor_version,
+                os_family='Red Hat',
+                archs=['x86_64']
+            )
             self.assertIsNotNone(self.operatingsys.wait_until_element
-                                 (common_locators["haserror"]))
-            self.assertIsNone(self.operatingsys.search(name))
+                                 (common_locators['haserror']))
 
     def test_remove_os(self):
         """@Test: Delete an existing OS
@@ -291,31 +246,31 @@ class OperatingSys(UITestCase):
         @Assert: OS is deleted
 
         """
-        os_name = entities.OperatingSystem().create_json()['name']
+        os_name = entities.OperatingSystem().create().name
         with Session(self.browser) as session:
             session.nav.go_to_operating_systems()
-            self.operatingsys.delete(os_name, really=True)
+            self.operatingsys.delete(os_name)
             self.assertIsNone(self.operatingsys.search(os_name))
 
     @data(
         {u'new_name': gen_string('alpha', 10),
          u'new_major_version': gen_string('numeric', 1),
          u'new_minor_version': gen_string('numeric', 1),
-         u'new_os_family': "Red Hat"},
+         u'new_os_family': 'Red Hat'},
         {u'new_name': gen_string('html', 10),
          u'new_major_version': gen_string('numeric', 4),
          u'new_minor_version': gen_string('numeric', 4),
-         u'new_os_family': "Gentoo"},
+         u'new_os_family': 'Gentoo'},
         {u'new_name': gen_string('utf8', 10),
          u'new_major_version': gen_string('numeric', 5),
          u'new_minor_version': gen_string('numeric', 16),
-         u'new_os_family': "SUSE"},
+         u'new_os_family': 'SUSE'},
         {u'new_name': gen_string('alphanumeric', 255),
          u'new_major_version': gen_string('numeric', 5),
          u'new_minor_version': gen_string('numeric', 1),
-         u'new_os_family': "SUSE"}
+         u'new_os_family': 'SUSE'}
     )
-    def test_update_os_1(self, test_data):
+    def test_update_os_basic_params(self, test_data):
         """@Test: Update OS name, major_version, minor_version, os_family
         and arch
 
@@ -324,15 +279,15 @@ class OperatingSys(UITestCase):
         @Assert: OS is updated
 
         """
-
-        os_name = entities.OperatingSystem().create_json()['name']
-        arch_name = entities.Architecture().create_json()['name']
         with Session(self.browser):
-            self.operatingsys.update(os_name, test_data['new_name'],
-                                     test_data['new_major_version'],
-                                     test_data['new_minor_version'],
-                                     os_family=test_data['new_os_family'],
-                                     new_archs=[arch_name])
+            self.operatingsys.update(
+                entities.OperatingSystem().create().name,
+                test_data['new_name'],
+                test_data['new_major_version'],
+                test_data['new_minor_version'],
+                os_family=test_data['new_os_family'],
+                new_archs=[entities.Architecture().create().name]
+            )
             self.assertIsNotNone(self.operatingsys.search(
                 test_data['new_name']))
 
@@ -344,19 +299,17 @@ class OperatingSys(UITestCase):
         @Assert: OS is updated
 
         """
-
-        medium_name = gen_string("alpha", 4)
-        path = INSTALL_MEDIUM_URL % medium_name
+        medium_name = gen_string('alpha')
         entities.Media(
             name=medium_name,
-            path_=path,
-            organization=[self.org_id],
-        ).create_json()
-        os_name = entities.OperatingSystem().create_json()['name']
+            path_=INSTALL_MEDIUM_URL % medium_name,
+            organization=[self.organization],
+        ).create()
+        os_name = entities.OperatingSystem().create().name
         with Session(self.browser) as session:
-            session.nav.go_to_select_org(self.org_name)
+            session.nav.go_to_select_org(self.organization.name)
             self.operatingsys.update(os_name, new_mediums=[medium_name])
-            result_obj = self.operatingsys.get_os_entities(os_name, "medium")
+            result_obj = self.operatingsys.get_os_entities(os_name, 'medium')
             self.assertEqual(medium_name, result_obj['medium'])
 
     def test_update_os_partition_table(self):
@@ -368,18 +321,18 @@ class OperatingSys(UITestCase):
 
         """
 
-        ptable = gen_string("alpha", 4)
+        ptable = gen_string('alpha', 4)
         script_file = get_data_file(PARTITION_SCRIPT_DATA_FILE)
         with open(script_file, 'r') as file_contents:
             layout = file_contents.read()
         entities.PartitionTable(
             name=ptable,
             layout=layout,
-        ).create_json()
-        os_name = entities.OperatingSystem().create_json()['name']
+        ).create()
+        os_name = entities.OperatingSystem().create().name
         with Session(self.browser):
             self.operatingsys.update(os_name, new_ptables=[ptable])
-            result_obj = self.operatingsys.get_os_entities(os_name, "ptable")
+            result_obj = self.operatingsys.get_os_entities(os_name, 'ptable')
             self.assertEqual(ptable, result_obj['ptable'])
 
     def test_update_os_template(self):
@@ -392,22 +345,21 @@ class OperatingSys(UITestCase):
         @BZ: 1129612
 
         """
-        os_name = gen_string("alpha", 4)
-        template_name = gen_string("alpha", 4)
-        os = entities.OperatingSystem(name=os_name).create()
+        os_name = gen_string('alpha')
+        template_name = gen_string('alpha')
         entities.ConfigTemplate(
             name=template_name,
             snippet=False,
-            operatingsystem=[os],
-            organization=[self.org_id],
+            operatingsystem=[entities.OperatingSystem(name=os_name).create()],
+            organization=[self.organization],
         ).create()
         with Session(self.browser) as session:
-            session.nav.go_to_select_org(self.org_name)
+            session.nav.go_to_select_org(self.organization.name)
             self.operatingsys.update(os_name, template=template_name)
-            result_obj = self.operatingsys.get_os_entities(os_name, "template")
+            result_obj = self.operatingsys.get_os_entities(os_name, 'template')
             self.assertEqual(template_name, result_obj['template'])
 
-    def test_positive_set_os_parameter_1(self):
+    def test_positive_set_os_parameter(self):
         """@Test: Set OS parameter
 
         @Feature: OS - Positive Update
@@ -415,17 +367,17 @@ class OperatingSys(UITestCase):
         @Assert: OS is updated
 
         """
-        param_name = gen_string("alpha", 4)
-        param_value = gen_string("alpha", 3)
-        os_name = entities.OperatingSystem().create_json()['name']
         with Session(self.browser):
             try:
                 self.operatingsys.set_os_parameter(
-                    os_name, param_name, param_value)
+                    entities.OperatingSystem().create().name,
+                    gen_string('alpha', 4),
+                    gen_string('alpha', 3),
+                )
             except UIError as err:
                 self.fail(err)
 
-    def test_positive_set_os_parameter_2(self):
+    def test_positive_set_os_parameter_with_blank_value(self):
         """@Test: Set OS parameter with blank value
 
         @Feature: OS - Positive update
@@ -433,13 +385,13 @@ class OperatingSys(UITestCase):
         @Assert: Parameter is created with blank value
 
         """
-        param_name = gen_string("alpha", 4)
-        param_value = ""
-        os_name = entities.OperatingSystem().create_json()['name']
         with Session(self.browser):
             try:
                 self.operatingsys.set_os_parameter(
-                    os_name, param_name, param_value)
+                    entities.OperatingSystem().create().name,
+                    gen_string('alpha', 4),
+                    '',
+                )
             except UIError as err:
                 self.fail(err)
 
@@ -451,66 +403,58 @@ class OperatingSys(UITestCase):
         @Assert: OS is updated
 
         """
-        param_name = gen_string("alpha", 4)
-        param_value = gen_string("alpha", 3)
-        os_name = entities.OperatingSystem().create_json()['name']
+        param_name = gen_string('alpha', 4)
+        os_name = entities.OperatingSystem().create().name
         with Session(self.browser):
             try:
                 self.operatingsys.set_os_parameter(
-                    os_name, param_name, param_value)
+                    os_name, param_name, gen_string('alpha', 3))
                 self.operatingsys.remove_os_parameter(os_name, param_name)
             except UIError as err:
                 self.fail(err)
 
-    def test_negative_set_os_parameter_1(self):
+    def test_negative_set_os_parameter_same_values(self):
         """@Test: Set same OS parameter again as it was set earlier
 
         @Feature: OS - Negative Update
 
         @Assert: Proper error should be raised, Name already taken
 
-        @BZ: 1120663
-
         """
-        param_name = gen_string("alpha", 4)
-        param_value = gen_string("alpha", 3)
-        os_name = entities.OperatingSystem().create_json()['name']
+        param_name = gen_string('alpha', 4)
+        param_value = gen_string('alpha', 3)
+        os_name = entities.OperatingSystem().create().name
         with Session(self.browser):
             try:
-                self.operatingsys.set_os_parameter(
-                    os_name, param_name, param_value)
-                self.operatingsys.set_os_parameter(
-                    os_name, param_name, param_value)
+                for _ in range(2):
+                    self.operatingsys.set_os_parameter(
+                        os_name, param_name, param_value)
             except UIError as err:
                 self.fail(err)
             self.assertIsNotNone(self.operatingsys.wait_until_element(
-                common_locators["common_param_error"]
+                common_locators['common_param_error']
             ))
 
-    def test_negative_set_os_parameter_2(self):
+    def test_negative_set_os_parameter_with_blank_value(self):
         """@Test: Set OS parameter with blank name and value
 
         @Feature: OS - Negative Update
 
         @Assert: Proper error should be raised, Name can't contain whitespaces
 
-        @BZ: 1120663
-
         """
-        param_name = " "
-        param_value = " "
-        os_name = entities.OperatingSystem().create_json()['name']
         with Session(self.browser):
             try:
                 self.operatingsys.set_os_parameter(
-                    os_name, param_name, param_value)
+                    entities.OperatingSystem().create().name, '', '')
             except UIError as err:
                 self.fail(err)
             self.assertIsNotNone(self.operatingsys.wait_until_element(
-                common_locators["common_param_error"]
+                common_locators['common_param_error']
             ))
 
-    def test_negative_set_os_parameter_3(self):
+    @data(*invalid_names_list())
+    def test_negative_set_os_parameter_with_long_values(self, param):
         """@Test: Set OS parameter with name and value exceeding 255 characters
 
         @Feature: OS - Negative Update
@@ -518,15 +462,12 @@ class OperatingSys(UITestCase):
         @Assert: Proper error should be raised, Name should contain a value
 
         """
-        param_name = gen_string("alpha", 256)
-        param_value = gen_string("alpha", 256)
-        os_name = entities.OperatingSystem().create_json()['name']
         with Session(self.browser):
             try:
                 self.operatingsys.set_os_parameter(
-                    os_name, param_name, param_value)
+                    entities.OperatingSystem().create().name, param, param)
             except UIError as err:
                 self.fail(err)
             self.assertIsNotNone(self.operatingsys.wait_until_element(
-                common_locators["common_param_error"]
+                common_locators['common_param_error']
             ))

--- a/tests/foreman/ui/test_partitiontable.py
+++ b/tests/foreman/ui/test_partitiontable.py
@@ -2,10 +2,10 @@
 """Test class for Partition Table UI"""
 from ddt import ddt
 from fauxfactory import gen_string
-from robottelo.common.decorators import (
-    data, run_only_on, skip_if_bug_open, bz_bug_is_open)
 from robottelo.common.constants import PARTITION_SCRIPT_DATA_FILE
-from robottelo.common.helpers import read_data_file, generate_strings_list
+from robottelo.common.decorators import (
+    bz_bug_is_open, data, run_only_on, skip_if_bug_open)
+from robottelo.common.helpers import generate_strings_list, read_data_file
 from robottelo.test import UITestCase
 from robottelo.ui.factory import make_partitiontable
 from robottelo.ui.locators import common_locators
@@ -26,15 +26,17 @@ class PartitionTable(UITestCase):
         @Assert: Partition table is created
 
         """
-        layout = read_data_file(PARTITION_SCRIPT_DATA_FILE)
-        os_family = "Red Hat"
         with Session(self.browser) as session:
-            make_partitiontable(session, name=name, layout=layout,
-                                os_family=os_family)
+            make_partitiontable(
+                session,
+                name=name,
+                layout=read_data_file(PARTITION_SCRIPT_DATA_FILE),
+                os_family='Red Hat'
+            )
             self.assertIsNotNone(self.partitiontable.search(name))
 
     @data(*generate_strings_list(len1=256))
-    def test_negative_create_partition_table_1(self, name):
+    def test_negative_create_partition_table_with_long_names(self, name):
         """@Test: Create a new partition table with 256 characters in name
 
         @Feature: Partition table - Negative Create
@@ -42,17 +44,19 @@ class PartitionTable(UITestCase):
         @Assert: Partition table is not created
 
         """
-        layout = read_data_file(PARTITION_SCRIPT_DATA_FILE)
-        os_family = "Red Hat"
         with Session(self.browser) as session:
-            make_partitiontable(session, name=name, layout=layout,
-                                os_family=os_family)
+            make_partitiontable(
+                session,
+                name=name,
+                layout=read_data_file(PARTITION_SCRIPT_DATA_FILE),
+                os_family='Red Hat'
+            )
             self.assertIsNotNone(self.partitiontable.wait_until_element
-                                 (common_locators["name_haserror"]))
+                                 (common_locators['name_haserror']))
             self.assertIsNone(self.partitiontable.search(name))
 
-    @data("", "  ")
-    def test_negative_create_partition_table_2(self, name):
+    @data('', '  ')
+    def test_negative_create_partition_table_with_empty_name(self, name):
         """@Test: Create partition table with blank and whitespace in name
 
         @Feature: Partition table - Negative Create
@@ -60,16 +64,17 @@ class PartitionTable(UITestCase):
         @Assert: Partition table is not created
 
         """
-        layout = read_data_file(PARTITION_SCRIPT_DATA_FILE)
-        os_family = "Red Hat"
         with Session(self.browser) as session:
-            make_partitiontable(session, name=name, layout=layout,
-                                os_family=os_family)
+            make_partitiontable(
+                session,
+                name=name,
+                layout=read_data_file(PARTITION_SCRIPT_DATA_FILE),
+                os_family='Red Hat'
+            )
             self.assertIsNotNone(self.partitiontable.wait_until_element
-                                 (common_locators["name_haserror"]))
+                                 (common_locators['name_haserror']))
 
-    @data(*generate_strings_list(len1=10))
-    def test_negative_create_partition_table_3(self, name):
+    def test_negative_create_partition_table_with_same_name(self):
         """@Test: Create a new partition table with same name
 
         @Feature: Partition table - Negative Create
@@ -77,19 +82,19 @@ class PartitionTable(UITestCase):
         @Assert: Partition table is not created
 
         """
+        name = gen_string('utf8')
         layout = read_data_file(PARTITION_SCRIPT_DATA_FILE)
-        os_family = "Red Hat"
+        os_family = 'Red Hat'
         with Session(self.browser) as session:
-            make_partitiontable(session, name=name, layout=layout,
-                                os_family=os_family)
+            make_partitiontable(
+                session, name=name, layout=layout, os_family=os_family)
             self.assertIsNotNone(self.partitiontable.search(name))
-            make_partitiontable(session, name=name, layout=layout,
-                                os_family=os_family)
+            make_partitiontable(
+                session, name=name, layout=layout, os_family=os_family)
             self.assertIsNotNone(self.partitiontable.wait_until_element
-                                 (common_locators["name_haserror"]))
+                                 (common_locators['name_haserror']))
 
-    @data(*generate_strings_list(len1=10))
-    def test_negative_create_partition_table_4(self, name):
+    def test_negative_create_partition_table_empty_layout(self):
         """@Test: Create a new partition table with empty layout
 
         @Feature: Partition table - Negative Create
@@ -97,17 +102,16 @@ class PartitionTable(UITestCase):
         @Assert: Partition table is not created
 
         """
-        layout = ""
-        os_family = "Red Hat"
+        name = gen_string('utf8')
         with Session(self.browser) as session:
-            make_partitiontable(session, name=name, layout=layout,
-                                os_family=os_family)
+            make_partitiontable(
+                session, name=name, layout='', os_family='Red Hat')
             self.assertIsNotNone(self.partitiontable.wait_until_element
-                                 (common_locators["haserror"]))
+                                 (common_locators['haserror']))
             self.assertIsNone(self.partitiontable.search(name))
 
     @skip_if_bug_open('bugzilla', 1177591)
-    @data(*generate_strings_list(len1=10))
+    @data(*generate_strings_list())
     def test_remove_partition_table(self, name):
         """@Test: Delete a partition table
 
@@ -116,13 +120,11 @@ class PartitionTable(UITestCase):
         @Assert: Partition table is deleted
 
         """
-        layout = "test layout"
-        os_family = "Red Hat"
         with Session(self.browser) as session:
-            make_partitiontable(session, name=name, layout=layout,
-                                os_family=os_family)
+            make_partitiontable(
+                session, name=name, layout='test layout', os_family='Red Hat')
             self.assertIsNotNone(self.partitiontable.search(name))
-            self.partitiontable.delete(name, really=True)
+            self.partitiontable.delete(name)
             self.assertIsNone(self.partitiontable.search(name))
 
     @data({u'name': gen_string('alpha'),
@@ -146,16 +148,19 @@ class PartitionTable(UITestCase):
             self.skipTest(
                 'Bugzilla bug {0} is open for html data.'.format(bug_id)
             )
-        layout = "test layout"
-        new_layout = read_data_file(PARTITION_SCRIPT_DATA_FILE)
-        os_family = "Debian"
-        new_os_family = "Red Hat"
         with Session(self.browser) as session:
-            make_partitiontable(session, name=test_data['name'], layout=layout,
-                                os_family=os_family)
+            make_partitiontable(
+                session,
+                name=test_data['name'],
+                layout='test layout',
+                os_family='Debian',
+            )
             self.assertIsNotNone(self.partitiontable.search(test_data['name']))
-            self.partitiontable.update(test_data['name'],
-                                       test_data['new_name'],
-                                       new_layout, new_os_family)
+            self.partitiontable.update(
+                test_data['name'],
+                test_data['new_name'],
+                read_data_file(PARTITION_SCRIPT_DATA_FILE),
+                'Red Hat',
+            )
             self.assertIsNotNone(self.partitiontable.search
                                  (test_data['new_name']))


### PR DESCRIPTION
Added more improvements for UI part corresponding to #2562 issue and our style in general. Fixed critical bug in logic for `test_set_domain_parameter_negative_2` and `test_negative_set_os_parameter_same_values` methods
```
nosetests tests/foreman/ui/test_operatingsys.py
....................S.........................
----------------------------------------------------------------------
Ran 46 tests in 1228.700s

OK (SKIP=1)
```
```
nosetests tests/foreman/ui/test_partitiontable.py
.....................EE.E..S..
======================================================================
FAILED (SKIP=1, errors=3)
```
These 3 errors related to my local environment issues with alerts