### PR TITLE
Drop CLI Host Collection overridden methods

### DIFF
--- a/robottelo/cli/hostcollection.py
+++ b/robottelo/cli/hostcollection.py
@@ -63,15 +63,3 @@ class HostCollection(Base):
         cls.command_sub = 'content-hosts'
         return cls.execute(
             cls._construct_command(options), output_format='csv')
-
-    @classmethod
-    def info(cls, options=None):
-        """Show a host collection"""
-        cls.command_sub = 'info'
-        return cls.execute(cls._construct_command(options))
-
-    @classmethod
-    def list(cls, options=None):
-        """List host collections"""
-        cls.command_sub = 'list'
-        return cls.execute(cls._construct_command(options))


### PR DESCRIPTION
PR #2673 have added the overridden methods info and list but they are
breaking the expected behaviour of the entire CLI. Reverting that change
in order to get back the common behaviour.

Checked the test_import after the changes and it still 100% green:

```
$ py.test tests/foreman/cli/test_import.py
================================== test session starts ==================================
platform darwin -- Python 2.7.6 -- py-1.4.26 -- pytest-2.6.4
collected 13 items

tests/foreman/cli/test_import.py .............

============================== 13 passed in 872.51 seconds ==============================
```