### PR TITLE
Fix call to RepositorySet.enable in api.utils

### DIFF
--- a/robottelo/api/utils.py
+++ b/robottelo/api/utils.py
@@ -26,7 +26,7 @@ def enable_rhrepo_and_fetchid(basearch, org_id, product, repo,
         payload['basearch'] = basearch
     if releasever is not None:
         payload['releasever'] = releasever
-    r_set.enable(payload)
+    r_set.enable(data=payload)
     result = entities.Repository(name=repo).search(
         query={'organization_id': org_id})
     if bz_bug_is_open(1252101):


### PR DESCRIPTION
NailGun helper methods now expect that the data argument to be passed
explicitly.

This will fix the failures on jenkins:

```
$ py.test tests/foreman/api/test_repository.py -ktest_redhat_sync_1
============================ test session starts =============================
platform darwin -- Python 2.7.6 -- py-1.4.26 -- pytest-2.6.4
collected 48 items

tests/foreman/api/test_repository.py .

=============== 47 tests deselected by '-ktest_redhat_sync_1' ================
================= 1 passed, 47 deselected in 146.35 seconds ==================

$ py.test tests/foreman/api/test_contentview.py -kCVRedHatContent
============================ test session starts =============================
platform linux2 -- Python 2.7.5 -- py-1.4.30 -- pytest-2.7.2
rootdir: /home/elyezer/robottelo, inifile:
collected 55 items

tests/foreman/api/test_contentview.py ..

================= 53 tests deselected by '-kCVRedHatContent' =================
================== 2 passed, 53 deselected in 71.17 seconds ==================
```