### PR TITLE
Added smoke test for puppet end_to_end.

### DIFF
--- a/robottelo.properties.sample
+++ b/robottelo.properties.sample
@@ -52,6 +52,13 @@ provisioning_server=
 # provisioning server.
 image_dir=/opt/robottelo/images
 
+# Provide link to rhel6/7 repo here, as puppet rpm
+# would require packages from RHEL 6/7 repo and syncing the entire repo
+# on the fly would take longer for tests to run
+# Specify the link to an internal repo for tests to execute properly
+rhel6_repo=http://example.org/RHEL-6/6.7/Server/x86_64/os/
+rhel7_repo=http://example.org/RHEL-7/7.1/Server/x86_64/os/
+
 [docker]
 # External docker URL in the format http[s]://<server>:<port>. The
 # {server_hostname} variable can be used and will be replaced by

--- a/robottelo/common/constants.py
+++ b/robottelo/common/constants.py
@@ -159,6 +159,7 @@ REPOSET = {
     ),
     # TODO: Remove 'Beta' after release
     'rhst7': 'Red Hat Satellite Tools 6 Beta (for RHEL 7 Server) (RPMs)',
+    'rhst6': 'Red Hat Satellite Tools 6.1 (for RHEL 6 Server) (RPMs)',
 }
 
 REPOS = {
@@ -166,6 +167,12 @@ REPOS = {
         'id': 'rhel-7-server-satellite-tools-6-beta-rpms',
         'name': (
             'Red Hat Satellite Tools 6 Beta for RHEL 7 Server RPMs x86_64'
+        ),
+    },
+    'rhst6': {
+        'id': 'rhel-6-server-satellite-tools-6-rpms',
+        'name': (
+            'Red Hat Satellite Tools 6.1 for RHEL 6 Server RPMs x86_64'
         ),
     },
     'rhva6': {
@@ -203,6 +210,13 @@ RHVA_REPO_TREE = [
     ('rhel', 'rhva6', 'rhva6S', 'repo_ver', '6Server')
 ]
 
+SAT6_TOOLS_TREE = [
+    ('rhel', 'rhst6', 'rhst6', 'repo_name',
+     'Red Hat Satellite Tools 6.1 for RHEL 6 Server RPMs x86_64'),
+    ('rhel', 'rhst6', 'rhst6', 'repo_arch', 'x86_64'),
+    ('rhel', 'rhst6', 'rhst6', 'repo_ver', '6.1'),
+]
+
 #: Name (not label!) of the default organization.
 DEFAULT_ORG = "Default Organization"
 #: Name (not label!) of the default location.
@@ -236,6 +250,7 @@ FAKE_2_PUPPET_REPO = "http://omaciel.fedorapeople.org/fakepuppet02"
 FAKE_3_PUPPET_REPO = "http://omaciel.fedorapeople.org/fakepuppet03"
 FAKE_4_PUPPET_REPO = "http://omaciel.fedorapeople.org/fakepuppet04"
 FAKE_5_PUPPET_REPO = "http://omaciel.fedorapeople.org/fakepuppet05"
+FAKE_6_PUPPET_REPO = "http://kbidarka.fedorapeople.org/repos/puppet-modules/"
 REPO_DISCOVERY_URL = "http://omaciel.fedorapeople.org/"
 FAKE_0_CUSTOM_PACKAGE = 'bear-4.1-1.noarch'
 FAKE_0_CUSTOM_PACKAGE_NAME = 'bear'

--- a/robottelo/ui/hosts.py
+++ b/robottelo/ui/hosts.py
@@ -12,82 +12,98 @@ class Hosts(Base):
                          domain=None, env=None, host_group=None, ip_addr=None,
                          lifecycle_env=None, mac=None, media=None, os=None,
                          ptable=None, puppet_ca=None, puppet_master=None,
+                         puppet_module=None, reset_puppetenv=True,
                          resource=None, root_pwd=None, subnet=None):
+        strategy1, value1 = locators['host.select_puppetmodule']
+        strategy2, value2 = locators['host.select_puppetclass']
         # Host tab
-        if lifecycle_env is not None:
+        if lifecycle_env:
             Select(
                 self.wait_until_element(locators['host.lifecycle_env'])
             ).select_by_visible_text(lifecycle_env)
-        if cv is not None:
+        if cv:
             Select(
                 self.wait_until_element(locators['host.cv'])
             ).select_by_visible_text(cv)
-        if host_group is not None:
+        if reset_puppetenv:
+            self.click(locators['host.reset_puppetenv'])
+        if host_group:
             Select(
                 self.wait_until_element(locators['host.group'])
             ).select_by_visible_text(host_group)
-        elif env is not None and host_group is None:
+        elif env and not host_group:
             # As selecting hostgroup changes env
             Select(
                 self.wait_until_element(locators['host.environment'])
             ).select_by_visible_text(env)
-        if puppet_ca is not None:
+        if puppet_ca:
             Select(
                 self.wait_until_element(locators['host.puppet_ca'])
             ).select_by_visible_text(puppet_ca)
-        if puppet_master is not None:
+        if puppet_master:
             Select(
                 self.wait_until_element(locators['host.puppet_master'])
             ).select_by_visible_text(puppet_master)
         # Network tab
-        self.wait_until_element(tab_locators['host.tab_network']).click()
-        if domain is not None:
+        if domain or mac or subnet or ip_addr:
+            self.click(tab_locators['host.tab_network'])
+        if domain:
             Select(
                 self.wait_until_element(locators['host.domain'])
             ).select_by_visible_text(domain)
-        if mac is not None:
+        if mac:
             self.wait_until_element(locators['host.mac']).send_keys(mac)
-        if subnet is not None:
+        if subnet:
             Select(
                 self.wait_until_element(locators['host.subnet'])
             ).select_by_visible_text(subnet)
-        if ip_addr is not None:
+        if ip_addr:
             self.wait_until_element(locators['host.ip']).send_keys(ip_addr)
         # Operating system tab
-        self.wait_until_element(tab_locators['host.tab_os']).click()
-        if arch is not None:
+        if arch or os or media or ptable or custom_ptable or root_pwd:
+            self.click(tab_locators['host.tab_os'])
+        if arch:
             Select(
                 self.wait_until_element(locators['host.arch'])
             ).select_by_visible_text(arch)
             self.wait_for_ajax()
-        if os is not None:
+        if os:
             Select(
                 self.wait_until_element(locators['host.os'])
             ).select_by_visible_text(os)
             self.wait_for_ajax()
-        if media is not None:
+        if media:
             Select(
                 self.wait_until_element(locators['host.media'])
             ).select_by_visible_text(media)
-        if ptable is not None:
+        if ptable:
             Select(
                 self.wait_until_element(locators['host.ptable'])
             ).select_by_visible_text(ptable)
-        if custom_ptable is not None:
+        if custom_ptable:
             self.wait_until_element(
                 locators['host.custom_ptables']).send_keys(custom_ptable)
-        if root_pwd is not None:
+        if root_pwd:
             self.wait_until_element(
                 locators['host.root_pass']).send_keys(root_pwd)
+        # Puppet tab
+        if puppet_module:
+            self.click(tab_locators['host.tab_puppet'])
+            self.wait_until_element(
+                (strategy1, value1 % puppet_module)
+            ).click()
+            self.wait_until_element(
+                (strategy2, value2 % puppet_module)
+            ).click()
 
     def create(self, arch=None, cpus='1', cv=None, custom_ptable=None,
                domain=None, env=None, host_group=None, ip_addr=None,
                lifecycle_env=None, loc=None, mac=None, media=None,
                memory='768 MB', name=None, org=None, os=None, ptable=None,
-               puppet_ca=None, puppet_master=None, resource=None,
-               root_pwd=None, subnet=None):
+               puppet_ca=None, puppet_master=None, reset_puppetenv=True,
+               resource=None, root_pwd=None, subnet=None):
         """Creates a host."""
-        self.wait_until_element(locators['host.new']).click()
+        self.click(locators['host.new'])
         self.wait_until_element(locators['host.name']).send_keys(name)
         if org is not None:
             Select(
@@ -124,53 +140,52 @@ class Hosts(Base):
             subnet=subnet,
         )
         if resource != RESOURCE_DEFAULT:
-            self.wait_until_element(tab_locators['host.tab_vm']).click()
+            self.click(tab_locators['host.tab_vm'])
             Select(
                 self.wait_until_element(locators['host.vm_cpus'])
             ).select_by_visible_text(cpus)
             Select(
                 self.wait_until_element(locators['host.vm_memory'])
             ).select_by_visible_text(memory)
-        self.wait_until_element(common_locators['submit']).click()
-        self.wait_for_ajax()
+        self.click(common_locators['submit'])
 
     def update(self, arch=None, cv=None, custom_ptable=None, domain=None,
                env=None, host_group=None, ip_addr=None, mac=None,
                lifecycle_env=None, media=None, name=None, new_name=None,
                os=None, ptable=None, puppet_ca=None, puppet_master=None,
-               resource=None, root_pwd=None, subnet=None):
+               puppet_module=None, reset_puppetenv=False, resource=None,
+               root_pwd=None, subnet=None):
         """Updates a Host."""
         element = self.search(name)
-        if element is not None:
-            element.click()
-            self.wait_until_element(locators['host.edit']).click()
-            self.wait_for_ajax()
-            if new_name is not None:
-                self.wait_until_element(locators['host.name'])
-                self.field_update('host.name', new_name)
-            self._configure_hosts(
-                arch=arch,
-                cv=cv,
-                custom_ptable=custom_ptable,
-                domain=domain,
-                env=env,
-                host_group=host_group,
-                ip_addr=ip_addr,
-                lifecycle_env=lifecycle_env,
-                mac=mac,
-                media=media,
-                os=os,
-                ptable=ptable,
-                puppet_ca=puppet_ca,
-                puppet_master=puppet_master,
-                resource=resource,
-                root_pwd=root_pwd,
-                subnet=subnet,
-            )
-            self.find_element(common_locators['submit']).click()
-            self.wait_for_ajax()
-        else:
-            raise UIError('Could not update the host "{0}"'.format(name))
+        if element is None:
+            raise UIError(u'Could not update the host {0}'.format(name))
+        element.click()
+        self.click(locators['host.edit'])
+        if new_name:
+            self.wait_until_element(locators['host.name'])
+            self.field_update('host.name', new_name)
+        self._configure_hosts(
+            arch=arch,
+            cv=cv,
+            custom_ptable=custom_ptable,
+            domain=domain,
+            env=env,
+            host_group=host_group,
+            ip_addr=ip_addr,
+            lifecycle_env=lifecycle_env,
+            mac=mac,
+            media=media,
+            os=os,
+            ptable=ptable,
+            puppet_ca=puppet_ca,
+            puppet_master=puppet_master,
+            puppet_module=puppet_module,
+            reset_puppetenv=reset_puppetenv,
+            resource=resource,
+            root_pwd=root_pwd,
+            subnet=subnet,
+        )
+        self.click(common_locators['submit'])
 
     def search(self, name):
         """Searches existing host from UI."""
@@ -185,3 +200,16 @@ class Hosts(Base):
             locators['host.delete'],
             drop_locator=locators['host.dropdown']
         )
+
+    def update_host_bulkactions(self, host=None, org=None):
+        """Updates host via bulkactions"""
+        strategy1, value1 = locators['host.checkbox']
+        self.wait_until_element((strategy1, value1 % host)).click()
+        self.click(locators['host.select_action'])
+        if org:
+            self.click(locators['host.assign_org'])
+            self.click(locators['host.fix_mismatch'])
+            Select(
+                self.wait_until_element(locators['host.select_org'])
+            ).select_by_visible_text(org)
+        self.click(locators['host.bulk_submit'])

--- a/robottelo/ui/locators.py
+++ b/robottelo/ui/locators.py
@@ -372,6 +372,7 @@ tab_locators = LocatorDict({
     # Host
     # Third level UI
 
+    "host.tab_puppet": (By.XPATH, "//a[@href='#puppet_klasses']"),
     "host.tab_network": (By.XPATH, "//a[@href='#network']"),
     "host.tab_os": (By.XPATH, "//a[@href='#os']"),
     "host.tab_vm": (By.XPATH, "//a[@href='#compute_resource']"),
@@ -861,13 +862,14 @@ locators = LocatorDict({
     "host.dropdown": (
         By.XPATH,
         ("//a[contains(@href,'%s')]"
-            "/../../a[contains(@data-toggle,'dropdown')]")),
+         "/../../a[contains(@data-toggle,'dropdown')]")),
     "host.select_name": (
         By.XPATH,
         ("//input[contains(@id,'host_ids')]"
-            "/../../td[@class='ellipsis']/a[contains(@href,'%s')]")),
+         "/../../td[@class='ellipsis']/a[contains(@href,'%s')]")),
     "host.lifecycle_env": (By.ID, "host_lifecycle_environment_id"),
     "host.cv": (By.ID, "host_content_view_id"),
+    "host.reset_puppetenv": (By.ID, "reset_puppet_environment"),
 
     # host.network
     "host.mac": (By.ID, "host_mac"),
@@ -902,6 +904,27 @@ locators = LocatorDict({
     "host.vm_addnic": (
         By.XPATH, "//fieldset[@id='network_interfaces']/a"),
 
+    # Host 'Select Action'/'Bulk Action.'
+    "host.checkbox": (
+        By.XPATH,
+        "//span[contains(@data-original-title, '%s')]/../../../td/input"),
+    "host.select_action": (
+        By.XPATH,
+        "//div[@id='submit_multiple']/a[contains(@class, 'dropdown-toggle')]"),
+    "host.assign_org": (
+        By.XPATH, "//a[contains(@href, 'select_multiple_organization')]"),
+    "host.fix_mismatch": (By.ID, "organization_optimistic_import_yes"),
+    "host.select_org": (By.ID, "organization_id"),
+    "host.bulk_submit": (
+        By.XPATH,
+        ("//form[contains(@action, 'multiple')]/../../../"
+         "div/button[contains(@class,'primary')]")),
+    "host.select_puppetmodule":
+        (By.XPATH, "//a[contains(.,'%s')]/i[contains(@class, 'glyphicon')]"),
+    "host.select_puppetclass": (
+        By.XPATH,
+        ("//span[contains(.,'%s')]"
+         "/a[not(contains(@data-original-title, '::'))]")),
 
     # Provisions
 

--- a/robottelo/ui/sync.py
+++ b/robottelo/ui/sync.py
@@ -216,6 +216,19 @@ class Sync(Base):
                             poll_frequency=2,
                         )
 
+    def sync_noversion_rh_repos(self, prd, repos):
+        """Syncs RedHat repositories which do not have version.
+
+        Selects Red Hat non version Repos to Synchronize from UI.
+
+        :param prd: The product which repositories belongs to.
+        :param repos: List of repositories to sync.
+        :return: Returns True if the sync was successful.
+        :rtype: bool
+
+        """
+        return self.sync_custom_repos(prd, repos)
+
     def sync_rh_repos(self, repos_tree):
         """Syncs RedHat repositories.
 

--- a/tests/foreman/smoke/test_ui_smoke.py
+++ b/tests/foreman/smoke/test_ui_smoke.py
@@ -4,6 +4,7 @@ from fauxfactory import gen_string, gen_ipaddr
 from robottelo.common import conf
 from robottelo.common import manifests
 from robottelo.common.constants import (
+    ANY_CONTEXT,
     DEFAULT_LOC,
     DEFAULT_ORG,
     DEFAULT_SUBSCRIPTION_NAME,
@@ -12,10 +13,13 @@ from robottelo.common.constants import (
     FOREMAN_PROVIDERS,
     GOOGLE_CHROME_REPO,
     LIBVIRT_RESOURCE_URL,
+    PRDS,
     REPOS,
     REPOSET,
     REPO_TYPE,
     RHVA_REPO_TREE,
+    SAT6_TOOLS_TREE,
+    FAKE_6_PUPPET_REPO,
 )
 from robottelo.common.decorators import bz_bug_is_open
 from robottelo.common.ssh import upload_file
@@ -32,6 +36,7 @@ from robottelo.ui.factory import (
     make_resource,
     make_subnet,
     make_user,
+    set_context,
 )
 from robottelo.ui.locators import common_locators, locators
 from robottelo.ui.session import Session
@@ -364,4 +369,142 @@ class TestSmoke(UITestCase):
                 self.assertEqual(result.return_code, 0)
                 # Verify if package is installed by query it
                 result = vm.run(u'rpm -q {0}'.format(package_name))
+                self.assertEqual(result.return_code, 0)
+
+    def test_puppet_install(self):
+        """@Test: Perform puppet end to end smoke tests using RH repos.
+
+        @Feature: Smoke test puppet install and configure on client
+
+        @Assert: Client should get configured by puppet-module.
+
+        """
+        activation_key_name = gen_string('alpha')
+        cloned_manifest_path = manifests.clone()
+        cv_name = gen_string('alpha')
+        env_name = gen_string('alpha')
+        org_name = gen_string('alpha')
+        product_name = gen_string('alpha')
+        puppet_module = 'motd'
+        puppet_repository_name = gen_string('alpha')
+        repos = self.sync.create_repos_tree(SAT6_TOOLS_TREE)
+        rhel_prd = DEFAULT_SUBSCRIPTION_NAME
+        rhel6_repo = conf.properties['clients.rhel6_repo']
+        upload_file(cloned_manifest_path)
+        with Session(self.browser) as session:
+            # Create New organization
+            make_org(session, org_name=org_name)
+            self.assertIsNotNone(self.org.search(org_name))
+            # Create New Lifecycle environment
+            make_lifecycle_environment(session, org=org_name, name=env_name)
+            strategy, value = locators['content_env.select_name']
+            self.assertIsNotNone(self.contentenv.wait_until_element(
+                (strategy, value % env_name)
+            ))
+            session.nav.go_to_red_hat_subscriptions()
+            # Upload manifest from webui
+            self.subscriptions.upload(cloned_manifest_path)
+            self.assertTrue(session.nav.wait_until_element(
+                common_locators['alert.success']
+            ))
+            session.nav.go_to_red_hat_repositories()
+            # List of dictionary passed to enable the redhat repos
+            # It selects Product->Reposet-> Repo
+            self.sync.enable_rh_repos(repos)
+            session.nav.go_to_sync_status()
+            # Sync the repos
+            # syn.sync_rh_repos returns boolean values and not objects
+            self.assertTrue(self.sync.sync_noversion_rh_repos(
+                PRDS['rhel'], [REPOS['rhst6']['name']]
+            ))
+            # Create custom product
+            make_product(session, org=org_name, name=product_name)
+            self.assertIsNotNone(self.products.search(product_name))
+            # Create a puppet Repository
+            make_repository(
+                session,
+                org=org_name,
+                name=puppet_repository_name,
+                product=product_name,
+                url=FAKE_6_PUPPET_REPO,
+                repo_type=REPO_TYPE['puppet']
+            )
+            self.assertIsNotNone(self.repository.search(
+                puppet_repository_name
+            ))
+            # Sync the repos
+            # syn.sync_rh_repos returns boolean values and not objects
+            session.nav.go_to_sync_status()
+            self.assertIsNotNone(self.sync.sync_custom_repos(
+                product_name,
+                [puppet_repository_name]
+            ))
+            # Create new content-view
+            make_contentview(session, org=org_name, name=cv_name)
+            self.assertIsNotNone(self.content_views.search(cv_name))
+            # Add YUM repository to content-view
+            self.content_views.add_remove_repos(
+                cv_name,
+                [REPOS['rhst6']['name']],
+            )
+            if not bz_bug_is_open(1191422):
+                self.assertIsNotNone(self.content_views.wait_until_element(
+                    common_locators['alert.success']
+                ))
+            # Add puppet-module to content-view
+            self.content_views.add_puppet_module(
+                cv_name, puppet_module, filter_term='Latest')
+            # Publish content-view
+            self.content_views.publish(cv_name)
+            if not bz_bug_is_open(1191422):
+                self.assertIsNotNone(self.content_views.wait_until_element(
+                    common_locators['alert.success']
+                ))
+            # Promote content-view to life-cycle environment.
+            self.content_views.promote(
+                cv_name, version='Version 1', env=env_name)
+            if not bz_bug_is_open(1191422):
+                self.assertIsNotNone(self.content_views.wait_until_element(
+                    common_locators['alert.success']
+                ))
+            # Create Activation-Key
+            make_activationkey(
+                session,
+                org=org_name,
+                name=activation_key_name,
+                env=env_name,
+                content_view=cv_name
+            )
+            self.activationkey.associate_product(
+                activation_key_name, [product_name, rhel_prd])
+            self.activationkey.enable_repos(
+                activation_key_name, [REPOSET['rhst6']]
+            )
+            if not bz_bug_is_open(1191541):
+                self.assertIsNotNone(self.activationkey.wait_until_element(
+                    common_locators['alert.success']
+                ))
+            # Create VM
+            with VirtualMachine(distro='rhel67') as vm:
+                vm.install_katello_cert()
+                vm.register_contenthost(activation_key_name, org_name)
+                vm.configure_puppet(rhel6_repo)
+                host = vm.fetch_hostname()
+                session.nav.go_to_hosts()
+                set_context(session, org=ANY_CONTEXT['org'])
+                self.hosts.update_host_bulkactions(host=host, org=org_name)
+                self.hosts.update(
+                    name=host,
+                    lifecycle_env=env_name,
+                    cv=cv_name,
+                    reset_puppetenv=True,
+                )
+                session.nav.go_to_hosts()
+                self.hosts.update(
+                    name=host,
+                    reset_puppetenv=False,
+                    puppet_module=puppet_module
+                )
+                vm.run(u'puppet agent -t')
+                result = vm.run(u'cat /etc/motd | grep FQDN')
                 self.assertEqual(result.return_code, 0)


### PR DESCRIPTION
*) Added locators to assign_orgs to hosts.
*) Added `fetch_hostname` under vm module to fetch client hostname.
*) Added `configure_puppet` under vm module for clients.
*) Added `configure_rhel_repo` under vm module for clients.
*) Installs puppet RPM on clients and configures puppet.
*) Updated ui/rhai.py to use vm.configure_rhel_repo()