### PR TITLE
Add functions that wrap common API calls

### DIFF
--- a/robottelo/api/utils.py
+++ b/robottelo/api/utils.py
@@ -1,3 +1,4 @@
+# -*- encoding: utf-8 -*-
 """Module containing convenience functions for working with the API."""
 import time
 
@@ -37,3 +38,31 @@ def enable_rhrepo_and_fetchid(basearch, org_id, product, repo,
             result = entities.Repository(name=repo).search(
                 query={'organization_id': org_id})
     return result[0].id
+
+
+def promote(content_view_version, environment_id):
+    """Call ``content_view_version.promote(…)``.
+
+    :param content_view_version: A ``nailgun.entities.ContentViewVersion``
+        object.
+    :param environment_id: An environment ID.
+    :returns: Whatever ``nailgun.entities.ContentViewVersion.promote`` returns.
+
+    """
+    return content_view_version.promote(data={
+        u'environment_id': environment_id
+    })
+
+
+def upload_manifest(organization_id, manifest):
+    """Call ``nailgun.entities.Subscription.upload``.
+
+    :param organization_id: An organization ID.
+    :param manifest: A file object referencing a Red Hat Satellite 6 manifest.
+    :returns: Whatever ``nailgun.entities.Subscription.upload`` returns.
+
+    """
+    return entities.Subscription().upload(
+        data={'organization_id': organization_id},
+        files={'content': manifest},
+    )

--- a/tests/foreman/api/test_contentviewversion.py
+++ b/tests/foreman/api/test_contentviewversion.py
@@ -1,5 +1,6 @@
 """Unit tests for the ``content_view_versions`` paths."""
 from nailgun import entities
+from robottelo.api.utils import promote
 from robottelo.common.constants import FAKE_1_YUM_REPO, ZOO_CUSTOM_GPG_KEY
 from robottelo.common.helpers import read_data_file
 from requests.exceptions import HTTPError
@@ -17,11 +18,9 @@ class CVVersionTestCase(APITestCase):
         @Feature: ContentViewVersion
 
         """
-        env = entities.Environment().create().id
+        env = entities.Environment().create()
         with self.assertRaises(HTTPError):
-            entities.ContentViewVersion(id=1).promote(data={
-                u'environment_id': env
-            })
+            promote(entities.ContentViewVersion(id=1), env.id)
 
     def test_negative_promote_2(self):
         """@Test: Promote a content view version using an invalid environment.
@@ -32,9 +31,7 @@ class CVVersionTestCase(APITestCase):
 
         """
         with self.assertRaises(HTTPError):
-            entities.ContentViewVersion(id=1).promote(data={
-                u'environment_id': -1
-            })
+            promote(entities.ContentViewVersion(id=1), -1)
 
     def test_delete_version(self):
         """@Test: Create content view and publish it. After that try to
@@ -102,7 +99,7 @@ class CVVersionTestCase(APITestCase):
         self.assertEqual(len(content_view.version), 1)
         self.assertEqual(len(content_view.version[0].read().environment), 1)
         lce = entities.LifecycleEnvironment(organization=org).create()
-        content_view.version[0].promote(data={u'environment_id': lce.id})
+        promote(content_view.version[0], lce.id)
         cvv = content_view.version[0].read()
         self.assertEqual(len(cvv.environment), 2)
         # Delete the content-view version from selected environments

--- a/tests/foreman/api/test_docker.py
+++ b/tests/foreman/api/test_docker.py
@@ -5,6 +5,7 @@ from fauxfactory import gen_choice, gen_string, gen_url
 from nailgun import entities
 from random import randint, shuffle
 from requests.exceptions import HTTPError
+from robottelo.api.utils import promote
 from robottelo.common.constants import DOCKER_REGISTRY_HUB
 from robottelo.common.decorators import (
     data,
@@ -796,7 +797,7 @@ class DockerContentViewTestCase(APITestCase):
         cvv = content_view.version[0].read()
         self.assertEqual(len(cvv.environment), 1)
 
-        cvv.promote(data={u'environment_id': lce.id})
+        promote(cvv, lce.id)
         self.assertEqual(len(cvv.read().environment), 2)
 
     @run_only_on('sat')
@@ -829,7 +830,7 @@ class DockerContentViewTestCase(APITestCase):
 
         for i in range(1, randint(2, 5)):
             lce = entities.LifecycleEnvironment(organization=self.org).create()
-            cvv.promote(data={u'environment_id': lce.id})
+            promote(cvv, lce.id)
             self.assertEqual(len(cvv.read().environment), i+1)
 
     @run_only_on('sat')
@@ -871,7 +872,7 @@ class DockerContentViewTestCase(APITestCase):
         comp_cvv = comp_content_view.read().version[0]
         self.assertEqual(len(comp_cvv.read().environment), 1)
 
-        comp_cvv.promote(data={u'environment_id': lce.id})
+        promote(comp_cvv, lce.id)
         self.assertEqual(len(comp_cvv.read().environment), 2)
 
     @run_only_on('sat')
@@ -914,7 +915,7 @@ class DockerContentViewTestCase(APITestCase):
 
         for i in range(1, randint(2, 5)):
             lce = entities.LifecycleEnvironment(organization=self.org).create()
-            comp_cvv.promote(data={u'environment_id': lce.id})
+            promote(comp_cvv, lce.id)
             self.assertEqual(len(comp_cvv.read().environment), i+1)
 
 
@@ -938,7 +939,7 @@ class DockerActivationKeyTestCase(APITestCase):
         cls.content_view = content_view.update(['repository'])
         cls.content_view.publish()
         cls.cvv = content_view.read().version[0].read()
-        cls.cvv.promote(data={u'environment_id': cls.lce.id})
+        promote(cls.cvv, cls.lce.id)
 
     @run_only_on('sat')
     def test_add_docker_repo_to_activation_key(self):
@@ -1004,7 +1005,7 @@ class DockerActivationKeyTestCase(APITestCase):
 
         comp_content_view.publish()
         comp_cvv = comp_content_view.read().version[0].read()
-        comp_cvv.promote(data={u'environment_id': self.lce.id})
+        promote(comp_cvv, self.lce.id)
 
         ak = entities.ActivationKey(
             environment=self.lce,
@@ -1038,7 +1039,7 @@ class DockerActivationKeyTestCase(APITestCase):
 
         comp_content_view.publish()
         comp_cvv = comp_content_view.read().version[0].read()
-        comp_cvv.promote(data={u'environment_id': self.lce.id})
+        promote(comp_cvv, self.lce.id)
 
         ak = entities.ActivationKey(
             environment=self.lce,

--- a/tests/foreman/api/test_hostgroup.py
+++ b/tests/foreman/api/test_hostgroup.py
@@ -2,6 +2,7 @@
 """Tests for the ``hostgroups`` paths."""
 from fauxfactory import gen_string
 from nailgun import client, entities, entity_fields
+from robottelo.api.utils import promote
 from robottelo.common.constants import PUPPET_MODULE_NTP_PUPPETLABS
 from robottelo.common.decorators import skip_if_bug_open, stubbed
 from robottelo.common.helpers import get_data_file, get_server_credentials
@@ -57,7 +58,7 @@ class HostGroupTestCase(APITestCase):
             name=gen_string('alpha'),
             organization=org,
         ).create()
-        content_view.version[0].promote(data={u'environment_id': lc_env.id})
+        promote(content_view.version[0], lc_env.id)
         content_view = content_view.read()
         self.assertEqual(len(content_view.version), 1)
         self.assertEqual(len(content_view.puppet_module), 1)

--- a/tests/foreman/api/test_product.py
+++ b/tests/foreman/api/test_product.py
@@ -9,6 +9,7 @@ from ddt import ddt
 from fauxfactory import gen_string
 from nailgun import entities
 from random import randint
+from robottelo.api.utils import upload_manifest
 from robottelo.common import manifests
 from robottelo.common.constants import PRDS, REPOSET, VALID_GPG_KEY_FILE
 from robottelo.common.decorators import data, run_only_on
@@ -139,10 +140,7 @@ class RepositorySetsTestCase(APITestCase):
         """
         org = entities.Organization().create()
         with open(manifests.clone(), 'rb') as manifest:
-            entities.Subscription().upload(
-                data={'organization_id': org.id},
-                files={'content': manifest},
-            )
+            upload_manifest(org.id, manifest)
         product = entities.Product(
             name=PRDS['rhel'],
             organization=org,
@@ -171,10 +169,7 @@ class RepositorySetsTestCase(APITestCase):
         """
         org = entities.Organization().create()
         with open(manifests.clone(), 'rb') as manifest:
-            entities.Subscription().upload(
-                data={'organization_id': org.id},
-                files={'content': manifest},
-            )
+            upload_manifest(org.id, manifest)
         product = entities.Product(
             name=PRDS['rhel'],
             organization=org,

--- a/tests/foreman/api/test_repository.py
+++ b/tests/foreman/api/test_repository.py
@@ -4,7 +4,7 @@ from fauxfactory import gen_string
 from nailgun import client, entities
 from random import randint
 from requests.exceptions import HTTPError
-from robottelo.api import utils
+from robottelo.api.utils import enable_rhrepo_and_fetchid, upload_manifest
 from robottelo.common import manifests
 from robottelo.common.constants import (
     DOCKER_REGISTRY_HUB,
@@ -241,11 +241,8 @@ class RepositorySyncTestCase(APITestCase):
         """
         org = entities.Organization().create()
         with open(manifests.clone(), 'rb') as manifest:
-            entities.Subscription().upload(
-                data={'organization_id': org.id},
-                files={'content': manifest},
-            )
-        repo_id = utils.enable_rhrepo_and_fetchid(
+            upload_manifest(org.id, manifest)
+        repo_id = enable_rhrepo_and_fetchid(
             basearch='x86_64',
             org_id=org.id,
             product=PRDS['rhel'],

--- a/tests/foreman/rhai/test_rhai.py
+++ b/tests/foreman/rhai/test_rhai.py
@@ -3,6 +3,7 @@
 
 from nailgun import entities
 from fauxfactory import gen_string
+from robottelo.api.utils import upload_manifest
 from robottelo.common.constants import DEFAULT_SUBSCRIPTION_NAME
 from robottelo.common import manifests
 from robottelo.test import UITestCase
@@ -21,12 +22,8 @@ class RHAITestCase(UITestCase):
         ).create()
 
         # Upload manifest
-        sub = entities.Subscription(organization=org)
         with open(manifests.clone(), 'rb') as manifest:
-            sub.upload(
-                data={'organization_id': org.id},
-                files={'content': manifest},
-            )
+            upload_manifest(org.id, manifest)
 
         # Create activation key using default CV and library environment
         activation_key = entities.ActivationKey(
@@ -40,7 +37,7 @@ class RHAITestCase(UITestCase):
         # Walk through the list of subscriptions.
         # Find the "Red Hat Employee Subscription" and attach it to the
         # recently-created activation key.
-        for subs in sub.search():
+        for subs in entities.Subscription(organization=org).search():
             if subs.read_json()['product_name'] == DEFAULT_SUBSCRIPTION_NAME:
                 # 'quantity' must be 1, not subscription['quantity']. Greater
                 # values produce this error: "RuntimeError: Error: Only pools

--- a/tests/foreman/ui/test_contentviews.py
+++ b/tests/foreman/ui/test_contentviews.py
@@ -8,7 +8,7 @@ Feature details: https://fedorahosted.org/katello/wiki/ContentViews
 from ddt import ddt
 from fauxfactory import gen_string
 from nailgun import client, entities
-from robottelo.api import utils
+from robottelo.api.utils import enable_rhrepo_and_fetchid, upload_manifest
 from robottelo.common import manifests
 from robottelo.common.constants import (
     DEFAULT_CV,
@@ -71,12 +71,9 @@ class TestContentViewsUI(UITestCase):
         elif rh_repo:
             # Uploads the manifest and returns the result.
             with open(manifests.clone(), 'rb') as manifest:
-                entities.Subscription().upload(
-                    data={'organization_id': org_id},
-                    files={'content': manifest},
-                )
+                upload_manifest(org_id, manifest)
             # Enables the RedHat repo and fetches it's Id.
-            repo_id = utils.enable_rhrepo_and_fetchid(
+            repo_id = enable_rhrepo_and_fetchid(
                 basearch=rh_repo['basearch'],
                 org_id=str(org_id),  # OrgId is passed as data in API hence str
                 product=rh_repo['product'],

--- a/tests/foreman/ui/test_org.py
+++ b/tests/foreman/ui/test_org.py
@@ -5,6 +5,7 @@
 from ddt import ddt
 from fauxfactory import gen_ipaddr, gen_string
 from nailgun import entities
+from robottelo.api.utils import upload_manifest
 from robottelo.common import conf, manifests
 from robottelo.common.constants import INSTALL_MEDIUM_URL, LIBVIRT_RESOURCE_URL
 from robottelo.common.helpers import (
@@ -240,10 +241,7 @@ class Org(UITestCase):
         """
         org = entities.Organization(name=org_name).create()
         with open(manifests.clone(), 'rb') as manifest:
-            entities.Subscription().upload(
-                data={'organization_id': org.id},
-                files={'content': manifest},
-            )
+            upload_manifest(org.id, manifest)
         with Session(self.browser) as session:
             make_lifecycle_environment(session, org_name, name='DEV')
             make_lifecycle_environment(

--- a/tests/foreman/ui/test_sync.py
+++ b/tests/foreman/ui/test_sync.py
@@ -2,6 +2,7 @@
 
 from ddt import ddt
 from nailgun import entities
+from robottelo.api.utils import upload_manifest
 from robottelo.common.constants import FAKE_1_YUM_REPO
 from robottelo.common.decorators import data, run_only_on
 from robottelo.common.helpers import generate_strings_list
@@ -72,10 +73,7 @@ class Sync(UITestCase):
 
         repos = self.sync.create_repos_tree(RHCT)
         with open(manifests.clone(), 'rb') as manifest:
-            entities.Subscription().upload(
-                data={'organization_id': self.org_id},
-                files={'content': manifest},
-            )
+            upload_manifest(self.org_id, manifest)
         with Session(self.browser) as session:
             session.nav.go_to_select_org(self.org_name)
             session.nav.go_to_red_hat_repositories()


### PR DESCRIPTION
Fix #2683:

> Some modules call the same NailGun helper method with an identical set of
> arguments over and over. For example, module `test_contentview.py` calls
> `ContentViewVersion.promote` fifteen times! Each call looks something like
> this:
>
>     content_view.version[0].promote(data={u'environment_id': lc_env.id})
>
> It'd be nice if we didn't have to write out `{u'environment_id': ...}` in
> every single one of those calls.

Add the following functions to module `robottelo.api.utils`:

* promote (calls `ContentViewVersion.promote`)
* upload (calls `Subscription.upload`)

Use these functions to eliminate some redundant code. Test results:

    (robottelo2)[ichimonji10@beech:robottelo]$ nosetests tests/foreman/api/test_contentview.py:ContentViewTestCase -m test_subscribe_system_to_cv
    .
    ----------------------------------------------------------------------
    Ran 1 test in 38.112s

    OK
    (robottelo2)[ichimonji10@beech:robottelo]$ nosetests tests/foreman/api/test_contentview.py:ContentViewTestCase -m test_cv_clone_within_same_env
    .
    ----------------------------------------------------------------------
    Ran 1 test in 52.971s

    OK
    (robottelo2)[ichimonji10@beech:robottelo]$ nosetests tests/foreman/api/test_contentview.py:ContentViewTestCase -m test_cv_clone_within_diff_env
    .
    ----------------------------------------------------------------------
    Ran 1 test in 64.620s

    OK
    (robottelo2)[ichimonji10@beech:robottelo]$ nosetests tests/foreman/api/test_contentview.py:CVPublishPromoteTestCase -m test_positive_promote_
    ..
    ----------------------------------------------------------------------
    Ran 2 tests in 208.323s

    OK
    (robottelo2)[ichimonji10@beech:robottelo]$ nosetests tests/foreman/api/test_contentview.py:CVPublishPromoteTestCase -m test_promote_cv_with_puppet_once
    .
    ----------------------------------------------------------------------
    Ran 1 test in 81.161s

    OK
    (robottelo2)[ichimonji10@beech:robottelo]$ nosetests tests/foreman/api/test_contentview.py:CVPublishPromoteTestCase -m test_promote_cv_with_puppet_multiple
    .
    ----------------------------------------------------------------------
    Ran 1 test in 109.295s

    OK
    (robottelo2)[ichimonji10@beech:robottelo]$ nosetests tests/foreman/api/test_contentview.py:CVPublishPromoteTestCase -m test_promote_composite_cv_
    ....
    ----------------------------------------------------------------------
    Ran 4 tests in 403.297s

    OK

The above tests the `promote` function. The below tests all three functions in
module `robottelo.api.utils`:

    (robottelo2)[ichimonji10@beech:robottelo]$ nosetests tests/foreman/ui/test_activationkey.py
    EE.EFSE..............S...............SF.E.................................................................E.....

The errors are due to unrelated issues like no provisioning server being
configured.