### PR TITLE
Added CLI tests for content-host package-group

### DIFF
--- a/robottelo/common/constants.py
+++ b/robottelo/common/constants.py
@@ -258,9 +258,17 @@ FAKE_1_CUSTOM_PACKAGE = 'walrus-0.71-1.noarch'
 FAKE_1_CUSTOM_PACKAGE_NAME = 'walrus'
 FAKE_2_CUSTOM_PACKAGE = 'walrus-5.21-1.noarch'
 FAKE_2_CUSTOM_PACKAGE_NAME = 'walrus'
+FAKE_0_CUSTOM_PACKAGE_GROUP_NAME = 'birds'
 FAKE_0_ERRATA_ID = 'RHEA-2012:0001'
 
 PUPPET_MODULE_NTP_PUPPETLABS = "puppetlabs-ntp-3.2.1.tar.gz"
+
+FAKE_0_CUSTOM_PACKAGE_GROUP = [
+    'cockateel-3.1-1.noarch',
+    'duck-0.6-1.noarch',
+    'penguin-0.9.1-1.noarch',
+    'stork-0.12-2.noarch',
+]
 
 #: All permissions exposed by the server.
 #: :mod:`tests.foreman.api.test_permission` makes use of this.

--- a/tests/foreman/cli/test_contenthost.py
+++ b/tests/foreman/cli/test_contenthost.py
@@ -19,6 +19,8 @@ from robottelo.cli.contentview import ContentView
 from robottelo.cli.lifecycleenvironment import LifecycleEnvironment
 from robottelo.common.constants import (
     FAKE_0_CUSTOM_PACKAGE,
+    FAKE_0_CUSTOM_PACKAGE_GROUP,
+    FAKE_0_CUSTOM_PACKAGE_GROUP_NAME,
     FAKE_0_CUSTOM_PACKAGE_NAME,
     FAKE_1_CUSTOM_PACKAGE,
     FAKE_1_CUSTOM_PACKAGE_NAME,
@@ -731,3 +733,42 @@ class TestCHKatelloAgent(CLITestCase):
         self.assertEqual(result.return_code, 0)
         result = self.vm.run('rpm -q {}'.format(FAKE_2_CUSTOM_PACKAGE))
         self.assertEqual(result.return_code, 0)
+
+    def test_contenthost_package_group_install(self):
+        """@Test: Install package group to content host remotely
+
+        @Feature: Content Host - Package group
+
+        @Assert: Package group was successfully installed
+
+        """
+        result = ContentHost.package_group_install({
+            u'organization-id': TestCHKatelloAgent.org['id'],
+            u'content-host': self.vm.hostname,
+            u'groups': FAKE_0_CUSTOM_PACKAGE_GROUP_NAME,
+        })
+        self.assertEqual(result.return_code, 0)
+        for package in FAKE_0_CUSTOM_PACKAGE_GROUP:
+            result = self.vm.run('rpm -q {}'.format(package))
+            self.assertEqual(result.return_code, 0)
+
+    def test_contenthost_package_group_remove(self):
+        """@Test: Remove package group from content host remotely
+
+        @Feature: Content Host - Package group
+
+        @Assert: Package group was successfully removed
+
+        """
+        hammer_args = {
+            u'organization-id': TestCHKatelloAgent.org['id'],
+            u'content-host': self.vm.hostname,
+            u'groups': FAKE_0_CUSTOM_PACKAGE_GROUP_NAME,
+        }
+        result = ContentHost.package_group_install(hammer_args)
+        self.assertEqual(result.return_code, 0)
+        result = ContentHost.package_group_remove(hammer_args)
+        self.assertEqual(result.return_code, 0)
+        for package in FAKE_0_CUSTOM_PACKAGE_GROUP:
+            result = self.vm.run('rpm -q {}'.format(package))
+            self.assertNotEqual(result.return_code, 0)


### PR DESCRIPTION
Added CLI tests for `content-host package-group install` and `content-host package-group remove`.
Closes #1710
Tests results:
```
nosetests tests/foreman/cli/test_contenthost.py -m test_contenthost_package_group
..
----------------------------------------------------------------------
Ran 2 tests in 1016.624s

OK
```