### PR TITLE
Added improvements for ui.contentenv, ui.settings and ui.templates 

### DIFF
--- a/robottelo/ui/contentenv.py
+++ b/robottelo/ui/contentenv.py
@@ -1,8 +1,8 @@
 # -*- encoding: utf-8 -*-
-"""Implements Life cycle content environments."""
+"""Implements Lifecycle content environments."""
 
 from robottelo.ui.base import Base, UINoSuchElementError
-from robottelo.ui.locators import locators, common_locators
+from robottelo.ui.locators import common_locators, locators
 
 
 class ContentEnvironment(Base):
@@ -11,53 +11,40 @@ class ContentEnvironment(Base):
     def create(self, name, description=None, prior=None):
         """Creates new life cycle environment."""
         if prior:
-            strategy, value = locators["content_env.env_link"]
-            element = self.wait_until_element((strategy, value % prior))
-            if element:
-                element.click()
+            strategy, value = locators['content_env.env_link']
+            self.click((strategy, value % prior))
         else:
-            self.wait_for_ajax()
-            self.find_element(locators["content_env.new"]).click()
-        if self.wait_until_element(common_locators["name"]) is None:
+            self.click(locators['content_env.new'])
+        if self.wait_until_element(common_locators['name']) is None:
             raise UINoSuchElementError(
                 'Could not create new environment {0}'.format(name))
-        self.text_field_update(common_locators["name"], name)
+        self.text_field_update(common_locators['name'], name)
         if description:
-            self.text_field_update(common_locators["description"],
-                                   description)
-        self.wait_until_element(common_locators["create"]).click()
+            self.text_field_update(
+                common_locators['description'], description)
+        self.click(common_locators['create'])
 
     def delete(self, name):
         """Deletes an existing environment."""
-
-        strategy = locators["content_env.select_name"][0]
-        value = locators["content_env.select_name"][1]
-        element = self.wait_until_element((strategy, value % name))
-        if element is None:
-            raise UINoSuchElementError(
-                'Could not find the selected environment {0}'.format(name))
-        element.click()
-        self.wait_until_element(locators["content_env.remove"]).click()
+        strategy, value = locators['content_env.select_name']
+        self.click((strategy, value % name))
+        self.click(locators['content_env.remove'])
 
     def update(self, name, new_name=None, description=None):
         """Updates an existing environment."""
-
-        strategy = locators["content_env.select_name"][0]
-        value = locators["content_env.select_name"][1]
-        element = self.wait_until_element((strategy, value % name))
-        if element is None:
-            raise UINoSuchElementError(
-                'Could not update the selected environment {0}'.format(name))
-        element.click()
+        strategy, value = locators['content_env.select_name']
+        self.click((strategy, value % name))
         if new_name:
-            self.edit_entity(locators["content_env.edit_name"],
-                             locators["content_env.edit_name_text"],
-                             new_name,
-                             locators["content_env.edit_name_text.save"])
+            self.edit_entity(
+                locators['content_env.edit_name'],
+                locators['content_env.edit_name_text'],
+                new_name,
+                locators['content_env.edit_name_text.save']
+            )
         if description:
             self.edit_entity(
-                locators["content_env.edit_description"],
-                locators["content_env.edit_description_textarea"],
+                locators['content_env.edit_description'],
+                locators['content_env.edit_description_textarea'],
                 description,
-                locators["content_env.edit_description_textarea.save"]
+                locators['content_env.edit_description_textarea.save']
             )

--- a/robottelo/ui/settings.py
+++ b/robottelo/ui/settings.py
@@ -1,7 +1,5 @@
 # -*- encoding: utf-8 -*-
-"""
-Implements Settings UI
-"""
+"""Implements Settings UI"""
 
 from robottelo.ui.base import Base, UINoSuchElementError
 from robottelo.ui.locators import locators
@@ -13,20 +11,15 @@ class OptionError(ValueError):
 
 
 class Settings(Base):
-    """
-    Implements the Update function to edit/update settings
-    """
+    """Implements the Update function to edit/update settings"""
 
     def search(self, name):
-        """
-        Searches existing parameter from UI
-        """
-        element = self.search_entity(name, locators["settings.param"])
+        """Searches existing parameter from UI"""
+        element = self.search_entity(name, locators['settings.param'])
         return element
 
     def update(self, tab_locator, param_name, value_type, param_value):
-        """
-        Updates the value of selected parameter under settings
+        """Updates the value of selected parameter under settings
 
         @param tab_locator: Selenium locator to select appropriate tab.
         @param param_name: A valid parameter name.
@@ -37,43 +30,32 @@ class Settings(Base):
         than 'input' and 'dropdown'.
         @raise UINoSuchElementError: Raise an exception when UI element is
         not found
-        """
 
-        if self.wait_until_element(tab_locator):
-            self.find_element(tab_locator).click()
-            strategy, value = locators["settings.edit_param"]
-            element = self.wait_until_element((strategy,
-                                               value % param_name))
-            if element:
-                element.click()
-                if value_type == "dropdown":
-                    Select(self.find_element
-                           (locators["settings.select_value"])
-                           ).select_by_value(param_value)
-                elif value_type == "input":
-                    self.field_update("settings.input_value", param_value)
-                else:
-                    raise OptionError(
-                        "Please input appropriate value type")
-                self.wait_for_ajax()
-                self.wait_until_element(locators["settings.save"]).click()
-                self.wait_for_ajax()
-            else:
-                raise UINoSuchElementError(
-                    'Could not find edit button to update selected param'
-                )
-        else:
+        """
+        if self.wait_until_element(tab_locator) is None:
             raise UINoSuchElementError(
                 "Couldn't find the tab with name: '%s'" % tab_locator)
+        self.click(tab_locator)
+
+        strategy, value = locators['settings.edit_param']
+        self.click((strategy, value % param_name))
+
+        if value_type == 'dropdown':
+            Select(
+                self.find_element(locators['settings.select_value'])
+            ).select_by_value(param_value)
+        elif value_type == 'input':
+            self.field_update('settings.input_value', param_value)
+        else:
+            raise OptionError('Please input appropriate value type')
+        self.wait_for_ajax()
+        self.click(locators['settings.save'])
 
     def get_saved_value(self, tab_locator, param_name):
-        """
-        Fetch the updated value to assert
-        """
-
+        """Fetch the updated value to assert"""
         if self.wait_until_element(tab_locator):
-            self.find_element(tab_locator).click()
-            strategy, value = locators["settings.edit_param"]
+            self.click(tab_locator)
+            strategy, value = locators['settings.edit_param']
             element = self.wait_until_element((strategy,
                                                value % param_name))
             if element:

--- a/robottelo/ui/template.py
+++ b/robottelo/ui/template.py
@@ -1,10 +1,10 @@
 # -*- encoding: utf-8 -*-
 """Implements Template UI."""
+from robottelo.common.constants import FILTER
 from robottelo.ui.base import Base, UIError, UINoSuchElementError
 from robottelo.ui.locators import locators, common_locators, tab_locators
 from robottelo.ui.navigator import Navigator
 from selenium.webdriver.support.select import Select
-from robottelo.common.constants import FILTER
 
 
 class Template(Base):
@@ -14,35 +14,36 @@ class Template(Base):
                audit_comment=None, template_type=None, snippet=None,
                os_list=None):
         """Creates a provisioning template from UI."""
-        self.wait_until_element(locators["provision.template_new"]).click()
-        if not self.wait_until_element(locators["provision.template_name"]):
+        self.click(locators['provision.template_new'])
+        if self.wait_until_element(
+                locators['provision.template_name']) is None:
             raise UINoSuchElementError(
                 'Could not create new provisioning template "{0}"'
                 .format(name)
             )
-        self.find_element(locators["provision.template_name"]).send_keys(name)
-        if not template_path:
+        self.find_element(locators['provision.template_name']).send_keys(name)
+        if template_path is None:
             raise UIError(
                 'Could not create blank template "{0}"'.format(name)
             )
-        self.wait_until_element(tab_locators["tab_primary"]).click()
+        self.click(tab_locators['tab_primary'])
         self.find_element(
-            locators["provision.template_template"]
+            locators['provision.template_template']
         ).send_keys(template_path)
         self.handle_alert(custom_really)
         self.scroll_page()
         if audit_comment:
             self.find_element(
-                locators["provision.audit_comment"]
+                locators['provision.audit_comment']
             ).send_keys(audit_comment)
         if template_type:
-            self.wait_until_element(tab_locators["provision.tab_type"]).click()
+            self.click(tab_locators['provision.tab_type'])
             type_element = self.find_element(
-                locators["provision.template_type"])
+                locators['provision.template_type'])
             Select(type_element).select_by_visible_text(template_type)
         elif snippet:
-            self.wait_until_element(tab_locators["provision.tab_type"]).click()
-            self.find_element(locators["provision.template_snippet"]).click()
+            self.click(tab_locators['provision.tab_type'])
+            self.click(locators['provision.template_snippet'])
         else:
             raise UIError(
                 'Could not create template "{0}" without type'.format(name)
@@ -51,9 +52,8 @@ class Template(Base):
         self.configure_entity(
             os_list,
             FILTER['template_os'],
-            tab_locator=tab_locators["provision.tab_association"])
-        self.find_element(common_locators["submit"]).click()
-        self.wait_for_ajax()
+            tab_locator=tab_locators['provision.tab_association'])
+        self.click(common_locators['submit'])
 
     def search(self, name):
         """Searches existing template from UI."""
@@ -61,7 +61,7 @@ class Template(Base):
         nav = Navigator(self.browser)
         nav.go_to_provisioning_templates()
         element = self.search_entity(
-            name, locators["provision.template_select"])
+            name, locators['provision.template_select'])
         return element
 
     def update(self, name, custom_really=None, new_name=None,
@@ -69,78 +69,72 @@ class Template(Base):
                os_list=None, new_os_list=None, clone=False):
         """Updates a given template."""
         element = self.search(name)
-        if not element:
+        if element is None:
             raise UIError(
                 'Could not update the template "{0}"'.format(name)
             )
         element.click()
         self.wait_for_ajax()
         if new_name:
-            self.field_update("provision.template_name", new_name)
+            self.field_update('provision.template_name', new_name)
         if template_path:
             self.find_element(
-                locators["provision.template_template"]
+                locators['provision.template_template']
             ).send_keys(template_path)
             self.handle_alert(custom_really)
         if template_type:
-            self.wait_until_element(
-                tab_locators["provision.tab_type"]).click()
-            element = self.find_element(locators["provision.template_type"])
+            self.click(tab_locators['provision.tab_type'])
+            element = self.find_element(locators['provision.template_type'])
             Select(element).select_by_visible_text(template_type)
         if clone:
-            self.wait_until_element(
-                locators["provision.template_clone"]).click()
-            self.field_update("provision.template_name", new_name)
+            self.click(locators['provision.template_clone'])
+            self.field_update('provision.template_name', new_name)
         self.configure_entity(
             os_list,
             FILTER['template_os'],
-            tab_locator=tab_locators["provision.tab_association"],
+            tab_locator=tab_locators['provision.tab_association'],
             new_entity_list=new_os_list
         )
-        self.find_element(common_locators["submit"]).click()
-        self.wait_for_ajax()
+        self.click(common_locators['submit'])
 
     def clone(self, name, custom_really=None, clone_name=None,
               template_path=None, template_type=None,
               os_list=None):
         """Clones a given template."""
         self.search(name)
-        clone = self.wait_until_element(locators["provision.template_clone"])
-        if not clone:
+        clone = self.wait_until_element(locators['provision.template_clone'])
+        if clone is None:
             raise UINoSuchElementError(
                 'Could not locate the clone button for template "{0}"'
                 .format(name)
             )
         clone.click()
         self.wait_for_ajax()
-        self.field_update("provision.template_name", clone_name)
+        self.field_update('provision.template_name', clone_name)
         if template_path:
             self.find_element(
-                locators["provision.template_template"]
+                locators['provision.template_template']
             ).send_keys(template_path)
             self.handle_alert(custom_really)
         if template_type:
-            self.wait_until_element(
-                tab_locators["provision.tab_type"]
-            ).click()
+            self.click(tab_locators['provision.tab_type'])
             element = self.find_element(
-                locators["provision.template_type"])
+                locators['provision.template_type'])
             Select(element).select_by_visible_text(template_type)
         self.configure_entity(
             os_list,
             FILTER['template_os'],
-            tab_locator=tab_locators["provision.tab_association"]
+            tab_locator=tab_locators['provision.tab_association']
         )
-        self.find_element(common_locators["submit"]).click()
-        self.wait_for_ajax()
+        self.click(common_locators['submit'])
 
-    def delete(self, name, really):
+    def delete(self, name, really=True):
         """Deletes a template."""
         Navigator(self.browser).go_to_provisioning_templates()
         self.delete_entity(
             name,
             really,
-            locators["provision.template_select"],
-            locators["provision.template_delete"],
-            locators["provision.template_dropdown"]
+            locators['provision.template_select'],
+            locators['provision.template_delete'],
+            locators['provision.template_dropdown']
         )

--- a/tests/foreman/ui/test_contentenv.py
+++ b/tests/foreman/ui/test_contentenv.py
@@ -1,9 +1,11 @@
 # -*- encoding: utf-8 -*-
 """Test class for Life cycle environments UI"""
 
+from ddt import ddt
 from fauxfactory import gen_string
 from nailgun import entities
-from robottelo.common.decorators import run_only_on
+from robottelo.common.decorators import data, run_only_on
+from robottelo.common.helpers import generate_strings_list
 from robottelo.test import UITestCase
 from robottelo.ui.factory import make_lifecycle_environment
 from robottelo.ui.locators import locators
@@ -11,15 +13,17 @@ from robottelo.ui.session import Session
 
 
 @run_only_on('sat')
+@ddt
 class ContentEnvironment(UITestCase):
     """Implements Life cycle content environment tests in UI"""
 
     @classmethod
     def setUpClass(cls):  # noqa
-        cls.org_name = entities.Organization().create_json()['name']
+        cls.org_name = entities.Organization().create().name
         super(ContentEnvironment, cls).setUpClass()
 
-    def test_positive_create_content_environment_1(self):
+    @data(*generate_strings_list())
+    def test_positive_create_content_environment_basic(self, name):
         """@Test: Create content environment with minimal input parameters
 
         @Feature: Content Environment - Positive Create
@@ -27,16 +31,18 @@ class ContentEnvironment(UITestCase):
         @Assert: Environment is created
 
         """
-        name = gen_string("alpha", 6)
-        description = gen_string("alpha", 6)
-        strategy, value = locators["content_env.select_name"]
+        strategy, value = locators['content_env.select_name']
         with Session(self.browser) as session:
-            make_lifecycle_environment(session, org=self.org_name,
-                                       name=name, description=description)
+            make_lifecycle_environment(
+                session,
+                org=self.org_name,
+                name=name,
+                description=gen_string('alpha')
+            )
             self.assertIsNotNone(self.contentenv.wait_until_element
                                  ((strategy, value % name)))
 
-    def test_positive_create_content_environment_2(self):
+    def test_positive_create_content_environment_chain(self):
         """@Test: Create Content Environment in a chain
 
         @Feature: Content Environment - Positive Create
@@ -44,21 +50,24 @@ class ContentEnvironment(UITestCase):
         @Assert: Environment is created
 
         """
-        env1_name = gen_string("alpha", 6)
-        env2_name = gen_string("alpha", 6)
-        description = gen_string("alpha", 6)
-        strategy, value = locators["content_env.select_name"]
+        env1_name = gen_string('alpha')
+        env2_name = gen_string('alpha')
+        description = gen_string('alpha')
+        strategy, value = locators['content_env.select_name']
         with Session(self.browser) as session:
-            make_lifecycle_environment(session, org=self.org_name,
-                                       name=env1_name,
-                                       description=description)
+            make_lifecycle_environment(
+                session,
+                org=self.org_name,
+                name=env1_name,
+                description=description
+            )
             self.assertIsNotNone(self.contentenv.wait_until_element
                                  ((strategy, value % env1_name)))
             self.contentenv.create(env2_name, description, prior=env1_name)
             self.assertIsNotNone(self.contentenv.wait_until_element
                                  ((strategy, value % env2_name)))
 
-    def test_positive_delete_content_environment_1(self):
+    def test_positive_delete_content_environment(self):
         """@Test: Create Content Environment and delete it
 
         @Feature: Content Environment - Positive Delete
@@ -66,12 +75,15 @@ class ContentEnvironment(UITestCase):
         @Assert: Environment is deleted
 
         """
-        name = gen_string("alpha", 6)
-        description = gen_string("alpha", 6)
-        strategy, value = locators["content_env.select_name"]
+        name = gen_string('alpha')
+        strategy, value = locators['content_env.select_name']
         with Session(self.browser) as session:
-            make_lifecycle_environment(session, org=self.org_name,
-                                       name=name, description=description)
+            make_lifecycle_environment(
+                session,
+                org=self.org_name,
+                name=name,
+                description=gen_string('alpha')
+            )
             self.assertIsNotNone(self.contentenv.wait_until_element
                                  ((strategy, value % name)))
             self.contentenv.delete(name)
@@ -79,7 +91,7 @@ class ContentEnvironment(UITestCase):
             self.assertIsNone(self.contentenv.wait_until_element
                               ((strategy, value % name), 3))
 
-    def test_positive_update_content_environment_1(self):
+    def test_positive_update_content_environment(self):
         """@Test: Create Content Environment and update it
 
         @Feature: Content Environment - Positive Update
@@ -87,16 +99,15 @@ class ContentEnvironment(UITestCase):
         @Assert: Environment is updated
 
         """
-        name = gen_string("alpha", 6)
-        new_name = gen_string("alpha", 6)
-        description = gen_string("alpha", 6)
-        strategy, value = locators["content_env.select_name"]
+        name = gen_string('alpha')
+        new_name = gen_string('alpha')
+        strategy, value = locators['content_env.select_name']
         with Session(self.browser) as session:
-            make_lifecycle_environment(session, org=self.org_name,
-                                       name=name)
+            make_lifecycle_environment(
+                session, org=self.org_name, name=name)
             self.assertIsNotNone(self.contentenv.wait_until_element
                                  ((strategy, value % name)))
-            self.contentenv.update(name, new_name, description)
+            self.contentenv.update(name, new_name, gen_string('alpha'))
             session.nav.go_to_life_cycle_environments()
             self.assertIsNotNone(self.contentenv.wait_until_element
                                  ((strategy, value % new_name)))

--- a/tests/foreman/ui/test_settings.py
+++ b/tests/foreman/ui/test_settings.py
@@ -2,12 +2,12 @@
 """Test class for Setting Parameter values"""
 
 from ddt import ddt
-from fauxfactory import gen_string
+from fauxfactory import gen_email, gen_string, gen_url
 from robottelo.common.decorators import data, run_only_on, skip_if_bug_open
 from robottelo.test import UITestCase
 from robottelo.ui.base import UIError
 from robottelo.ui.factory import edit_param
-from robottelo.ui.locators import tab_locators, common_locators
+from robottelo.ui.locators import common_locators, tab_locators
 from robottelo.ui.session import Session
 
 
@@ -15,48 +15,40 @@ from robottelo.ui.session import Session
 class Settings(UITestCase):
     """Implements Boundary tests for Settings menu"""
 
-    @data({u'param_value': "true"},
-          {u'param_value': "false"})
-    def test_positive_update_general_param_1(self, test_data):
-        """@Test: Updates param "authorize_login_delegation"
-        under General tab
+    @data('true', 'false')
+    def test_positive_update_general_param_1(self, param_value):
+        """@Test: Updates param "authorize_login_delegation" under General tab
 
         @Feature: Settings - Update Parameters
 
         @Assert: Parameter is updated
 
         """
-
-        tab_locator = tab_locators["settings.tab_general"]
-        param_name = "authorize_login_delegation"
-        value_type = "dropdown"
+        tab_locator = tab_locators['settings.tab_general']
+        param_name = 'authorize_login_delegation'
         with Session(self.browser) as session:
-            edit_param(session, tab_locator=tab_locator,
-                       param_name=param_name,
-                       value_type=value_type,
-                       param_value=test_data['param_value'])
-            saved_element = self.settings.get_saved_value(tab_locator,
-                                                          param_name)
-            self.assertEqual(test_data['param_value'], saved_element)
+            edit_param(
+                session,
+                tab_locator=tab_locator,
+                param_name=param_name,
+                value_type='dropdown',
+                param_value=param_value,
+            )
+            saved_element = self.settings.get_saved_value(
+                tab_locator, param_name)
+            self.assertEqual(param_value, saved_element)
 
     @skip_if_bug_open('bugzilla', 1125181)
     @data(
-        {u'param_value': gen_string("latin1", 10) +
-         "@somemail.com"},
-        {u'param_value': gen_string("utf8", 10) +
-         "@somemail.com"},
-        {u'param_value': gen_string(
-            "alpha", 10) + "@somemail.com"},
-        {u'param_value': gen_string(
-            "html", 10) + "@somemail.com"},
-        {u'param_value': gen_string("alphanumeric", 10) +
-         "@somemail.com"},
-        {u'param_value': gen_string(
-            "numeric", 10) + "@somemail.com"},
-        {u'param_value': gen_string(
-            "alphanumeric", 50) + "@somem.com"}
+        gen_email(gen_string('alpha')),
+        gen_email(gen_string('alphanumeric')),
+        gen_email(gen_string('latin1')),
+        gen_email(gen_string('numeric')),
+        gen_email(gen_string('utf8')),
+        gen_email(gen_string('html')),
+        gen_email(gen_string('alphanumeric', 40)),
     )
-    def test_positive_update_general_param_2(self, test_data):
+    def test_positive_update_general_param_2(self, param_value):
         """@Test: Updates param "administrator" under General tab
 
         @Feature: Settings - Update Parameters
@@ -66,51 +58,49 @@ class Settings(UITestCase):
         @BZ: 1125181
 
         """
-
-        tab_locator = tab_locators["settings.tab_general"]
-        param_name = "administrator"
-        value_type = "input"
+        tab_locator = tab_locators['settings.tab_general']
+        param_name = 'administrator'
         with Session(self.browser) as session:
-            edit_param(session, tab_locator=tab_locator,
-                       param_name=param_name,
-                       value_type=value_type,
-                       param_value=test_data['param_value'])
-            saved_element = self.settings.get_saved_value(tab_locator,
-                                                          param_name)
-            self.assertEqual(test_data['param_value'], saved_element)
+            edit_param(
+                session,
+                tab_locator=tab_locator,
+                param_name=param_name,
+                value_type='input',
+                param_value=param_value,
+            )
+            saved_element = self.settings.get_saved_value(
+                tab_locator, param_name)
+            self.assertEqual(param_value, saved_element)
 
-    @data({u'param_value': "true"},
-          {u'param_value': "false"})
-    def test_positive_update_general_param_3(self, test_data):
-        """@Test: Updates param "authorize_login_delegation_api"
-        under General tab
+    @data('true', 'false')
+    def test_positive_update_general_param_3(self, param_value):
+        """@Test: Updates param "authorize_login_delegation_api" under General
+        tab
 
         @Feature: Settings - Update Parameters
 
         @Assert: Parameter is updated
 
         """
-
-        tab_locator = tab_locators["settings.tab_general"]
-        param_name = "authorize_login_delegation_api"
-        value_type = "dropdown"
+        tab_locator = tab_locators['settings.tab_general']
+        param_name = 'authorize_login_delegation_api'
         with Session(self.browser) as session:
-            edit_param(session, tab_locator=tab_locator,
-                       param_name=param_name,
-                       value_type=value_type,
-                       param_value=test_data['param_value'])
-            saved_element = self.settings.get_saved_value(tab_locator,
-                                                          param_name)
-            self.assertEqual(test_data['param_value'], saved_element)
+            edit_param(
+                session,
+                tab_locator=tab_locator,
+                param_name=param_name,
+                value_type='dropdown',
+                param_value=param_value,
+            )
+            saved_element = self.settings.get_saved_value(
+                tab_locator, param_name)
+            self.assertEqual(param_value, saved_element)
 
     @skip_if_bug_open('bugzilla', 1125156)
-    @data({u'param_value': " "},
-          {u'param_value': "-1"},
-          {u'param_value': "text"},
-          {u'param_value': "0"})
-    def test_negative_update_general_param_4(self, test_data):
-        """@Test: Updates param "entries_per_page"
-        under General tab with invalid values
+    @data(' ', '-1', 'text', '0')
+    def test_negative_update_general_param_4(self, param_value):
+        """@Test: Updates param "entries_per_page" under General tab with
+        invalid values
 
         @Feature: Settings - Negative Update Parameters
 
@@ -119,64 +109,60 @@ class Settings(UITestCase):
         @BZ: 1125156
 
         """
-
-        tab_locator = tab_locators["settings.tab_general"]
-        param_name = "entries_per_page"
-        value_type = "input"
+        tab_locator = tab_locators['settings.tab_general']
+        param_name = 'entries_per_page'
         with Session(self.browser) as session:
-            edit_param(session, tab_locator=tab_locator,
-                       param_name=param_name,
-                       value_type=value_type,
-                       param_value=test_data['param_value'])
-            self.assertIsNotNone(session.nav.wait_until_element
-                                 (common_locators["notif.error"]))
-            saved_element = self.settings.get_saved_value(tab_locator,
-                                                          param_name)
-            self.assertNotEqual(test_data['param_value'], saved_element)
+            edit_param(
+                session,
+                tab_locator=tab_locator,
+                param_name=param_name,
+                value_type='input',
+                param_value=param_value,
+            )
+            self.assertIsNotNone(
+                session.nav.wait_until_element(common_locators['notif.error']))
+            saved_element = self.settings.get_saved_value(
+                tab_locator, param_name)
+            self.assertNotEqual(param_value, saved_element)
 
     def test_positive_update_general_param_5(self):
-        """@Test: Updates param "entries_per_page"
-        under General tab
+        """@Test: Updates param "entries_per_page" under General tab
 
         @Feature: Settings - Positive Update Parameters
 
         @Assert: Parameter is updated
 
         """
-        param_value = gen_string("numeric", 5)
-        tab_locator = tab_locators["settings.tab_general"]
-        param_name = "entries_per_page"
-        value_type = "input"
+        param_value = gen_string('numeric', 5)
+        tab_locator = tab_locators['settings.tab_general']
+        param_name = 'entries_per_page'
         with Session(self.browser) as session:
-            edit_param(session, tab_locator=tab_locator,
-                       param_name=param_name,
-                       value_type=value_type, param_value=param_value)
-            saved_element = self.settings.get_saved_value(tab_locator,
-                                                          param_name)
+            edit_param(
+                session,
+                tab_locator=tab_locator,
+                param_name=param_name,
+                value_type='input',
+                param_value=param_value,
+            )
+            saved_element = self.settings.get_saved_value(
+                tab_locator, param_name)
             # UI automatically strips leading zeros on save,
             # e.g. If param_value = '01400' then UI saves it as '1400'
             # so using 'lstrip' to strip leading zeros from variable
             # 'param_value' too
-            self.assertEqual(param_value.lstrip("0"), saved_element)
+            self.assertEqual(param_value.lstrip('0'), saved_element)
 
     @skip_if_bug_open('bugzilla', 1125181)
     @data(
-        {u'param_value': gen_string("latin1", 10) +
-         "@somemail.com"},
-        {u'param_value': gen_string("utf8", 10) +
-         "@somemail.com"},
-        {u'param_value': gen_string(
-            "alpha", 10) + "@somemail.com"},
-        {u'param_value': gen_string(
-            "html", 10) + "@somemail.com"},
-        {u'param_value': gen_string("alphanumeric", 10) +
-         "@somemail.com"},
-        {u'param_value': gen_string(
-            "numeric", 10) + "@somemail.com"},
-        {u'param_value': gen_string(
-            "alphanumeric", 50) + "@somem.com"}
+        gen_email(gen_string('alpha')),
+        gen_email(gen_string('alphanumeric')),
+        gen_email(gen_string('latin1')),
+        gen_email(gen_string('numeric')),
+        gen_email(gen_string('utf8')),
+        gen_email(gen_string('html')),
+        gen_email(gen_string('alphanumeric', 40)),
     )
-    def test_positive_update_general_param_6(self, test_data):
+    def test_positive_update_general_param_6(self, param_value):
         """@Test: Updates param "email_reply_address" under General tab
 
         @Feature: Settings - Update Parameters
@@ -186,25 +172,24 @@ class Settings(UITestCase):
         @BZ: 1125181
 
         """
-
-        tab_locator = tab_locators["settings.tab_general"]
-        param_name = "email_reply_address"
-        value_type = "input"
+        tab_locator = tab_locators['settings.tab_general']
+        param_name = 'email_reply_address'
         with Session(self.browser) as session:
-            edit_param(session, tab_locator=tab_locator,
-                       param_name=param_name,
-                       value_type=value_type,
-                       param_value=test_data['param_value'])
-            saved_element = self.settings.get_saved_value(tab_locator,
-                                                          param_name)
-            self.assertEqual(test_data['param_value'], saved_element)
+            edit_param(
+                session,
+                tab_locator=tab_locator,
+                param_name=param_name,
+                value_type='input',
+                param_value=param_value,
+            )
+            saved_element = self.settings.get_saved_value(
+                tab_locator, param_name)
+            self.assertEqual(param_value, saved_element)
 
     @skip_if_bug_open('bugzilla', 1156195)
-    @data({u'param_value': "true"},
-          {u'param_value': "false"})
-    def test_positive_update_general_param_7(self, test_data):
-        """@Test: Updates param "fix_db_cache"
-        under General tab
+    @data('true', 'false')
+    def test_positive_update_general_param_7(self, param_value):
+        """@Test: Updates param "fix_db_cache" under General tab
 
         @Feature: Settings - Update Parameters
 
@@ -213,51 +198,48 @@ class Settings(UITestCase):
         @BZ: 1156195
 
         """
-
-        tab_locator = tab_locators["settings.tab_general"]
-        param_name = "fix_db_cache"
-        value_type = "dropdown"
+        tab_locator = tab_locators['settings.tab_general']
+        param_name = 'fix_db_cache'
         with Session(self.browser) as session:
-            edit_param(session, tab_locator=tab_locator,
-                       param_name=param_name,
-                       value_type=value_type,
-                       param_value=test_data['param_value'])
-            saved_element = self.settings.get_saved_value(tab_locator,
-                                                          param_name)
-            self.assertEqual(test_data['param_value'], saved_element)
+            edit_param(
+                session,
+                tab_locator=tab_locator,
+                param_name=param_name,
+                value_type='dropdown',
+                param_value=param_value,
+            )
+            saved_element = self.settings.get_saved_value(
+                tab_locator, param_name)
+            self.assertEqual(param_value, saved_element)
 
-    @data({u'param_value': "true"},
-          {u'param_value': "false"})
-    def test_positive_update_general_param_8(self, test_data):
-        """@Test: Updates param "use_gravatar"
-        under General tab
+    @data('true', 'false')
+    def test_positive_update_general_param_8(self, param_value):
+        """@Test: Updates param "use_gravatar" under General tab
 
         @Feature: Settings - Update Parameters
 
         @Assert: Parameter is updated
 
         """
-
-        tab_locator = tab_locators["settings.tab_general"]
-        param_name = "use_gravatar"
-        value_type = "dropdown"
+        tab_locator = tab_locators['settings.tab_general']
+        param_name = 'use_gravatar'
         with Session(self.browser) as session:
-            edit_param(session, tab_locator=tab_locator,
-                       param_name=param_name,
-                       value_type=value_type,
-                       param_value=test_data['param_value'])
-            saved_element = self.settings.get_saved_value(tab_locator,
-                                                          param_name)
-            self.assertEqual(test_data['param_value'], saved_element)
+            edit_param(
+                session,
+                tab_locator=tab_locator,
+                param_name=param_name,
+                value_type='dropdown',
+                param_value=param_value,
+            )
+            saved_element = self.settings.get_saved_value(
+                tab_locator, param_name)
+            self.assertEqual(param_value, saved_element)
 
     @skip_if_bug_open('bugzilla', 1125156)
-    @data({u'param_value': " "},
-          {u'param_value': "-1"},
-          {u'param_value': "text"},
-          {u'param_value': "0"})
-    def test_negative_update_general_param_9(self, test_data):
-        """@Test: Updates param "max_trend"
-        under General tab with invalid values
+    @data(' ', '-1', 'text', '0')
+    def test_negative_update_general_param_9(self, param_value):
+        """@Test: Updates param "max_trend" under General tab with invalid
+        values
 
         @Feature: Settings - Negative Update Parameters
 
@@ -266,60 +248,54 @@ class Settings(UITestCase):
         @BZ: 1125156
 
         """
-
-        tab_locator = tab_locators["settings.tab_general"]
-        param_name = "max_trend"
-        value_type = "input"
+        tab_locator = tab_locators['settings.tab_general']
+        param_name = 'max_trend'
         with Session(self.browser) as session:
-            edit_param(session, tab_locator=tab_locator,
-                       param_name=param_name,
-                       value_type=value_type,
-                       param_value=test_data['param_value'])
-            self.assertIsNotNone(session.nav.wait_until_element
-                                 (common_locators["notif.error"]))
-            saved_element = self.settings.get_saved_value(tab_locator,
-                                                          param_name)
-            self.assertNotEqual(test_data['param_value'], saved_element)
+            edit_param(
+                session,
+                tab_locator=tab_locator,
+                param_name=param_name,
+                value_type='input',
+                param_value=param_value,
+            )
+            self.assertIsNotNone(
+                session.nav.wait_until_element(common_locators['notif.error']))
+            saved_element = self.settings.get_saved_value(
+                tab_locator, param_name)
+            self.assertNotEqual(param_value, saved_element)
 
-    @data({'param_value': gen_string("numeric", 2)},
-          {'param_value': gen_string("numeric", 5)})
-    def test_positive_update_general_param_10(self, test_data):
-        """@Test: Updates param "max_trend"
-        under General tab
+    @data(gen_string('numeric', 2), gen_string('numeric', 5))
+    def test_positive_update_general_param_10(self, param_value):
+        """@Test: Updates param "max_trend" under General tab
 
         @Feature: Settings - Positive Update Parameters
 
         @Assert: Parameter is updated
 
         """
-
-        tab_locator = tab_locators["settings.tab_general"]
-        param_name = "max_trend"
-        value_type = "input"
+        tab_locator = tab_locators['settings.tab_general']
+        param_name = 'max_trend'
         with Session(self.browser) as session:
-            edit_param(session, tab_locator=tab_locator,
-                       param_name=param_name,
-                       value_type=value_type,
-                       param_value=test_data['param_value'])
-            saved_element = self.settings.get_saved_value(tab_locator,
-                                                          param_name)
+            edit_param(
+                session,
+                tab_locator=tab_locator,
+                param_name=param_name,
+                value_type='input',
+                param_value=param_value,
+            )
+            saved_element = self.settings.get_saved_value(
+                tab_locator, param_name)
             # UI automatically strips leading zeros on save,
             # e.g. If param_value = '01400' then UI saves it as '1400'
             # so using lstrip to strip leading zeros from variable
             # 'param_value' too
-            self.assertEqual(
-                test_data['param_value'].lstrip("0"),
-                saved_element
-            )
+            self.assertEqual(param_value.lstrip('0'), saved_element)
 
     @skip_if_bug_open('bugzilla', 1125156)
-    @data({u'param_value': " "},
-          {u'param_value': "-1"},
-          {u'param_value': "text"},
-          {u'param_value': "0"})
-    def test_negative_update_general_param_11(self, test_data):
-        """@Test: Updates param "idle_timeout"
-        under General tab with invalid values
+    @data(' ', '-1', 'text', '0')
+    def test_negative_update_general_param_11(self, param_value):
+        """@Test: Updates param "idle_timeout" under General tab with invalid
+        values
 
         @Feature: Settings - Negative Update Parameters
 
@@ -328,61 +304,55 @@ class Settings(UITestCase):
         @BZ: 1125156
 
         """
-
-        tab_locator = tab_locators["settings.tab_general"]
-        param_name = "idle_timeout"
-        value_type = "input"
+        tab_locator = tab_locators['settings.tab_general']
+        param_name = 'idle_timeout'
         with Session(self.browser) as session:
-            edit_param(session, tab_locator=tab_locator,
-                       param_name=param_name,
-                       value_type=value_type,
-                       param_value=test_data['param_value'])
-            self.assertIsNotNone(session.nav.wait_until_element
-                                 (common_locators["notif.error"]))
-            saved_element = self.settings.get_saved_value(tab_locator,
-                                                          param_name)
-            self.assertNotEqual(test_data['param_value'], saved_element)
+            edit_param(
+                session,
+                tab_locator=tab_locator,
+                param_name=param_name,
+                value_type='input',
+                param_value=param_value,
+            )
+            self.assertIsNotNone(
+                session.nav.wait_until_element(common_locators['notif.error']))
+            saved_element = self.settings.get_saved_value(
+                tab_locator, param_name)
+            self.assertNotEqual(param_value, saved_element)
 
-    @data({'param_value': gen_string("numeric", 1)},
-          {'param_value': gen_string("numeric", 5)})
-    def test_positive_update_general_param_12(self, test_data):
-        """@Test: Updates param "idle_timeout"
-        under General tab
+    @data(gen_string('numeric', 1), gen_string('numeric', 5))
+    def test_positive_update_general_param_12(self, param_value):
+        """@Test: Updates param "idle_timeout" under General tab
 
         @Feature: Settings - Positive Update Parameters
 
         @Assert: Parameter is updated
 
         """
-
-        tab_locator = tab_locators["settings.tab_general"]
-        param_name = "idle_timeout"
-        value_type = "input"
+        tab_locator = tab_locators['settings.tab_general']
+        param_name = 'idle_timeout'
         with Session(self.browser) as session:
-            edit_param(session, tab_locator=tab_locator,
-                       param_name=param_name,
-                       value_type=value_type,
-                       param_value=test_data['param_value'])
-            saved_element = self.settings.get_saved_value(tab_locator,
-                                                          param_name)
+            edit_param(
+                session,
+                tab_locator=tab_locator,
+                param_name=param_name,
+                value_type='input',
+                param_value=param_value,
+            )
+            saved_element = self.settings.get_saved_value(
+                tab_locator, param_name)
             # UI automatically strips leading zeros on save,
             # e.g. If param_value = '01400' then UI saves it as '1400'
             # so using lstrip to strip leading zeros from variable
             # 'param_value' too
-            self.assertEqual(
-                test_data['param_value'].lstrip("0"),
-                saved_element
-            )
+            self.assertEqual(param_value.lstrip('0'), saved_element)
 
     @data(
-        {u'param_value': "http://" + gen_string(
-            "alpha", 10) + ".dom.com"},
-        {u'param_value': "https://" + gen_string(
-            "alphanumeric", 10) + ".dom.com"},
-        {u'param_value': "http://" + gen_string(
-            "numeric", 10) + ".dom.com"}
+        gen_url(subdomain=gen_string('alpha')),
+        gen_url(subdomain=gen_string('alphanumeric')),
+        gen_url(subdomain=gen_string('numeric')),
     )
-    def test_positive_update_general_param_13(self, test_data):
+    def test_positive_update_general_param_13(self, param_value):
         """@Test: Updates param "foreman_url" under General tab
 
         @Feature: Settings - Update Parameters
@@ -390,32 +360,29 @@ class Settings(UITestCase):
         @Assert: Parameter is updated
 
         """
-
-        tab_locator = tab_locators["settings.tab_general"]
-        param_name = "foreman_url"
-        value_type = "input"
+        tab_locator = tab_locators['settings.tab_general']
+        param_name = 'foreman_url'
         with Session(self.browser) as session:
-            edit_param(session, tab_locator=tab_locator,
-                       param_name=param_name,
-                       value_type=value_type,
-                       param_value=test_data['param_value'])
-            saved_element = self.settings.get_saved_value(tab_locator,
-                                                          param_name)
-            self.assertEqual(test_data['param_value'], saved_element)
+            edit_param(
+                session,
+                tab_locator=tab_locator,
+                param_name=param_name,
+                value_type='input',
+                param_value=param_value,
+            )
+            saved_element = self.settings.get_saved_value(
+                tab_locator, param_name)
+            self.assertEqual(param_value, saved_element)
 
     @skip_if_bug_open('bugzilla', 1125156)
     @data(
-        {u'param_value': "http://\\" + gen_string(
-            "alpha", 10) + ".dom.com"},
-        {u'param_value': "http://" + gen_string(
-            "utf8", 10) + ".dom.com"},
-        {u'param_value': "http://" + gen_string(
-            "latin1", 10) + ".dom.com"},
-        {u'param_value': "http://" + gen_string(
-            "html", 10) + ".dom.com"},
-        {u'param_value': " "}
+        'http://\\' + gen_string('alpha') + '.dom.com',
+        'http://' + gen_string('utf8') + '.dom.com',
+        'http://' + gen_string('latin1') + '.dom.com',
+        'http://' + gen_string('html') + '.dom.com',
+        ' '
     )
-    def test_negative_update_general_param_14(self, test_data):
+    def test_negative_update_general_param_14(self, param_value):
         """@Test: Updates param "foreman_url" under General tab
 
         @Feature: Settings - Negative update Parameters
@@ -425,82 +392,81 @@ class Settings(UITestCase):
         @BZ: 1125156
 
         """
-
-        tab_locator = tab_locators["settings.tab_general"]
-        param_name = "foreman_url"
-        value_type = "input"
+        tab_locator = tab_locators['settings.tab_general']
+        param_name = 'foreman_url'
         with Session(self.browser) as session:
-            edit_param(session, tab_locator=tab_locator,
-                       param_name=param_name,
-                       value_type=value_type,
-                       param_value=test_data['param_value'])
-            self.assertIsNotNone(session.nav.wait_until_element
-                                 (common_locators["notif.error"]))
-            saved_element = self.settings.get_saved_value(tab_locator,
-                                                          param_name)
-            self.assertNotEqual(test_data['param_value'], saved_element)
+            edit_param(
+                session,
+                tab_locator=tab_locator,
+                param_name=param_name,
+                value_type='input',
+                param_value=param_value,
+            )
+            self.assertIsNotNone(
+                session.nav.wait_until_element(common_locators['notif.error']))
+            saved_element = self.settings.get_saved_value(
+                tab_locator, param_name)
+            self.assertNotEqual(param_value, saved_element)
 
-    @data({u'param_value': "true"},
-          {u'param_value': "false"})
-    def test_positive_update_foremantasks_param_15(self, test_data):
-        """@Test: Updates param "dynflow_enable_console"
-        under ForemanTasks tab
+    @data('true', 'false')
+    def test_positive_update_foremantasks_param_15(self, param_value):
+        """@Test: Updates param "dynflow_enable_console" under ForemanTasks tab
 
         @Feature: Settings - Update Parameters
 
         @Assert: Parameter is updated
 
         """
-
-        tab_locator = tab_locators["settings.tab_foremantasks"]
-        param_name = "dynflow_enable_console"
-        value_type = "dropdown"
+        tab_locator = tab_locators['settings.tab_foremantasks']
+        param_name = 'dynflow_enable_console'
         with Session(self.browser) as session:
-            edit_param(session, tab_locator=tab_locator,
-                       param_name=param_name,
-                       value_type=value_type,
-                       param_value=test_data['param_value'])
-            saved_element = self.settings.get_saved_value(tab_locator,
-                                                          param_name)
-            self.assertEqual(test_data['param_value'], saved_element)
-
-    @data({u'param_value': gen_string("latin1", 10)},
-          {u'param_value': gen_string("utf8", 10)},
-          {u'param_value': gen_string("alpha", 10)},
-          {u'param_value': gen_string("alphanumeric", 10)},
-          {u'param_value': gen_string("numeric", 10)})
-    def test_positive_update_auth_param_16(self, test_data):
-        """@Test: Updates param
-        "authorize_login_delegation_auth_source_user_autocreate"
-        under Auth tab
-
-        @Feature: Settings - Update Parameters
-
-        @Assert: Parameter is updated
-
-        """
-
-        tab_locator = tab_locators["settings.tab_auth"]
-        param_name = "authorize_login_delegation_auth_source_user_autocreate"
-        value_type = "input"
-        with Session(self.browser) as session:
-            edit_param(session, tab_locator=tab_locator,
-                       param_name=param_name,
-                       value_type=value_type,
-                       param_value=test_data['param_value'])
-            saved_element = self.settings.get_saved_value(tab_locator,
-                                                          param_name)
-            self.assertEqual(test_data['param_value'], saved_element)
+            edit_param(
+                session,
+                tab_locator=tab_locator,
+                param_name=param_name,
+                value_type='dropdown',
+                param_value=param_value,
+            )
+            saved_element = self.settings.get_saved_value(
+                tab_locator, param_name)
+            self.assertEqual(param_value, saved_element)
 
     @data(
-        {u'param_value': "http://" + gen_string(
-            "alpha", 10) + ".dom.com"},
-        {u'param_value': "https://" + gen_string(
-            "alphanumeric", 10) + ".dom.com"},
-        {u'param_value': "http://" + gen_string(
-            "numeric", 10) + ".dom.com"}
+        gen_string('latin1'),
+        gen_string('utf8'),
+        gen_string('alpha'),
+        gen_string('alphanumeric'),
+        gen_string('numeric'),
     )
-    def test_positive_update_auth_param_17(self, test_data):
+    def test_positive_update_auth_param_16(self, param_value):
+        """@Test: Updates param
+        "authorize_login_delegation_auth_source_user_autocreate" under Auth tab
+
+        @Feature: Settings - Update Parameters
+
+        @Assert: Parameter is updated
+
+        """
+        tab_locator = tab_locators['settings.tab_auth']
+        param_name = 'authorize_login_delegation_auth_source_user_autocreate'
+        with Session(self.browser) as session:
+            edit_param(
+                session,
+                tab_locator=tab_locator,
+                param_name=param_name,
+                value_type='input',
+                param_value=param_value,
+            )
+            saved_element = self.settings.get_saved_value(
+                tab_locator, param_name)
+            self.assertEqual(param_value, saved_element)
+
+    @data(
+        gen_url(subdomain=gen_string('alpha')),
+        gen_url(subdomain=gen_string('alphanumeric')),
+        gen_url(subdomain=gen_string('numeric')),
+    )
+    def test_positive_update_auth_param_17(self, param_value):
         """@Test: Updates param "login_delegation_logout_url" under Auth tab
 
         @Feature: Settings - Update Parameters
@@ -508,144 +474,147 @@ class Settings(UITestCase):
         @Assert: Parameter is updated
 
         """
-
-        tab_locator = tab_locators["settings.tab_auth"]
-        param_name = "login_delegation_logout_url"
-        value_type = "input"
+        tab_locator = tab_locators['settings.tab_auth']
+        param_name = 'login_delegation_logout_url'
         with Session(self.browser) as session:
-            edit_param(session, tab_locator=tab_locator,
-                       param_name=param_name,
-                       value_type=value_type,
-                       param_value=test_data['param_value'])
-            saved_element = self.settings.get_saved_value(tab_locator,
-                                                          param_name)
-            self.assertEqual(test_data['param_value'], saved_element)
+            edit_param(
+                session,
+                tab_locator=tab_locator,
+                param_name=param_name,
+                value_type='input',
+                param_value=param_value,
+            )
+            saved_element = self.settings.get_saved_value(
+                tab_locator, param_name)
+            self.assertEqual(param_value, saved_element)
 
-    @data({u'param_name': "oauth_active"},
-          {u'param_name': "oauth_consumer_key"},
-          {u'param_name': "oauth_consumer_secret"},
-          {u'param_name': "oauth_map_users"})
-    def test_positive_update_auth_param_18(self, test_data):
-        """@Test: Read-only param "oauth_active"
-        under Auth tab shouldn't be updated
+    @data(
+        'oauth_active',
+        'oauth_consumer_key',
+        'oauth_consumer_secret',
+        'oauth_map_users'
+    )
+    def test_positive_update_auth_param_18(self, param_name):
+        """@Test: Read-only param "oauth_active" under Auth tab shouldn't be
+        updated
 
         @Feature: Settings - Update Parameters
 
         @Assert: Parameter is not editable
 
         """
-        tab_locator = tab_locators["settings.tab_auth"]
+        tab_locator = tab_locators['settings.tab_auth']
         with Session(self.browser) as session:
             with self.assertRaises(UIError) as context:
                 edit_param(
                     session,
                     tab_locator=tab_locator,
-                    param_name=test_data['param_name']
+                    param_name=param_name,
                 )
                 self.assertEqual(
                     context.exception.message,
                     'Could not find edit button to update selected param'
                 )
 
-    @data({u'param_value': "true"},
-          {u'param_value': "false"})
-    def test_positive_update_auth_param_19(self, test_data):
-        """@Test: Updates param "require_ssl_puppetmasters"
-        under Auth tab
+    @data('true', 'false')
+    def test_positive_update_auth_param_19(self, param_value):
+        """@Test: Updates param "require_ssl_puppetmasters" under Auth tab
 
         @Feature: Settings - Update Parameters
 
         @Assert: Parameter is updated
 
         """
-
-        tab_locator = tab_locators["settings.tab_auth"]
-        param_name = "require_ssl_puppetmasters"
-        value_type = "dropdown"
+        tab_locator = tab_locators['settings.tab_auth']
+        param_name = 'require_ssl_puppetmasters'
+        value_type = 'dropdown'
         with Session(self.browser) as session:
             session.nav.go_to_settings()
-            default_value = self.settings.get_saved_value(tab_locator,
-                                                          param_name)
-            edit_param(session, tab_locator=tab_locator,
-                       param_name=param_name,
-                       value_type=value_type,
-                       param_value=test_data['param_value'])
-            saved_element = self.settings.get_saved_value(tab_locator,
-                                                          param_name)
-            self.assertEqual(test_data['param_value'], saved_element)
-            edit_param(session, tab_locator=tab_locator,
-                       param_name=param_name,
-                       value_type=value_type,
-                       param_value=default_value)
+            default_value = self.settings.get_saved_value(
+                tab_locator, param_name)
+            edit_param(
+                session,
+                tab_locator=tab_locator,
+                param_name=param_name,
+                value_type=value_type,
+                param_value=param_value,
+            )
+            saved_element = self.settings.get_saved_value(
+                tab_locator, param_name)
+            self.assertEqual(param_value, saved_element)
+            edit_param(
+                session,
+                tab_locator=tab_locator,
+                param_name=param_name,
+                value_type=value_type,
+                param_value=default_value,
+            )
 
-    @data({u'param_value': "true"},
-          {u'param_value': "false"})
-    def test_positive_update_auth_param_20(self, test_data):
-        """@Test: Updates param "restrict_registered_puppetmasters"
-        under Auth tab
+    @data('true', 'false')
+    def test_positive_update_auth_param_20(self, param_value):
+        """@Test: Updates param "restrict_registered_puppetmasters" under Auth
+        tab
 
         @Feature: Settings - Update Parameters
 
         @Assert: Parameter is updated
 
         """
-
-        tab_locator = tab_locators["settings.tab_auth"]
-        param_name = "restrict_registered_puppetmasters"
-        value_type = "dropdown"
+        tab_locator = tab_locators['settings.tab_auth']
+        param_name = 'restrict_registered_puppetmasters'
+        value_type = 'dropdown'
         with Session(self.browser) as session:
             session.nav.go_to_settings()
-            default_value = self.settings.get_saved_value(tab_locator,
-                                                          param_name)
-            edit_param(session, tab_locator=tab_locator,
-                       param_name=param_name,
-                       value_type=value_type,
-                       param_value=test_data['param_value'])
-            saved_element = self.settings.get_saved_value(tab_locator,
-                                                          param_name)
-            self.assertEqual(test_data['param_value'], saved_element)
-            edit_param(session, tab_locator=tab_locator,
-                       param_name=param_name,
-                       value_type=value_type,
-                       param_value=default_value)
+            default_value = self.settings.get_saved_value(
+                tab_locator, param_name)
+            edit_param(
+                session,
+                tab_locator=tab_locator,
+                param_name=param_name,
+                value_type=value_type,
+                param_value=param_value,
+            )
+            saved_element = self.settings.get_saved_value(
+                tab_locator, param_name)
+            self.assertEqual(param_value, saved_element)
+            edit_param(
+                session,
+                tab_locator=tab_locator,
+                param_name=param_name,
+                value_type=value_type,
+                param_value=default_value,
+            )
 
     @data(
-        {u'param_value': "[ " + gen_string(
-            "utf8", 10) + " ]"},
-        {u'param_value': "[ " + gen_string(
-            "alphanumeric", 10) + " ]"},
-        {u'param_value': "[ " + gen_string(
-            "numeric", 10) + " ]"}
+        '[ ' + gen_string('utf8') + ' ]',
+        '[ ' + gen_string('alphanumeric') + ' ]',
+        '[ ' + gen_string('numeric') + ' ]'
     )
-    def test_positive_update_auth_param_21(self, test_data):
-        """@Test: Updates param
-        "trusted_puppetmaster_hosts"
-        under Auth tab
+    def test_positive_update_auth_param_21(self, param_value):
+        """@Test: Updates param "trusted_puppetmaster_hosts" under Auth tab
 
         @Feature: Settings - Update Parameters
 
         @Assert: Parameter is updated
 
         """
-
-        tab_locator = tab_locators["settings.tab_auth"]
-        param_name = "trusted_puppetmaster_hosts"
-        value_type = "input"
+        tab_locator = tab_locators['settings.tab_auth']
+        param_name = 'trusted_puppetmaster_hosts'
         with Session(self.browser) as session:
-            edit_param(session, tab_locator=tab_locator,
-                       param_name=param_name,
-                       value_type=value_type,
-                       param_value=test_data['param_value'])
-            saved_element = self.settings.get_saved_value(tab_locator,
-                                                          param_name)
-            self.assertEqual(test_data['param_value'], saved_element)
+            edit_param(
+                session,
+                tab_locator=tab_locator,
+                param_name=param_name,
+                value_type='input',
+                param_value=param_value,
+            )
+            saved_element = self.settings.get_saved_value(
+                tab_locator, param_name)
+            self.assertEqual(param_value, saved_element)
 
     @skip_if_bug_open('bugzilla', 1125156)
-    @data({u'param_value': " "},
-          {u'param_value': "-1"},
-          {u'param_value': "text"},
-          {u'param_value': "0"})
-    def test_negative_update_auth_param_22(self, test_data):
+    @data(' ', '-1', 'text', '0')
+    def test_negative_update_auth_param_22(self, param_value):
         """@Test: Updates param "trusted_puppetmaster_hosts" under Auth tab
 
         @Feature: Settings - Negative update Parameters
@@ -655,153 +624,150 @@ class Settings(UITestCase):
         @BZ: 1125156
 
         """
-
-        tab_locator = tab_locators["settings.tab_auth"]
-        param_name = "trusted_puppetmaster_hosts"
-        value_type = "input"
+        tab_locator = tab_locators['settings.tab_auth']
+        param_name = 'trusted_puppetmaster_hosts'
         with Session(self.browser) as session:
-            edit_param(session, tab_locator=tab_locator,
-                       param_name=param_name,
-                       value_type=value_type,
-                       param_value=test_data['param_value'])
-            self.assertIsNotNone(session.nav.wait_until_element
-                                 (common_locators["notif.error"]))
-            saved_element = self.settings.get_saved_value(tab_locator,
-                                                          param_name)
-            self.assertNotEqual(test_data['param_value'], saved_element)
+            edit_param(
+                session,
+                tab_locator=tab_locator,
+                param_name=param_name,
+                value_type='input',
+                param_value=param_value,
+            )
+            self.assertIsNotNone(
+                session.nav.wait_until_element(common_locators['notif.error']))
+            saved_element = self.settings.get_saved_value(
+                tab_locator, param_name)
+            self.assertNotEqual(param_value, saved_element)
 
-    @data({u'param_value': "true"},
-          {u'param_value': "false"})
-    def test_positive_update_provisioning_param_23(self, test_data):
-        """@Test: Updates param "ignore_puppet_facts_for_provisioning"
-        under Provisioning tab
+    @data('true', 'false')
+    def test_positive_update_provisioning_param_23(self, param_value):
+        """@Test: Updates param "ignore_puppet_facts_for_provisioning" under
+        Provisioning tab
 
         @Feature: Settings - Update Parameters
 
         @Assert: Parameter is updated
 
         """
-
-        tab_locator = tab_locators["settings.tab_provisioning"]
-        param_name = "ignore_puppet_facts_for_provisioning"
-        value_type = "dropdown"
+        tab_locator = tab_locators['settings.tab_provisioning']
+        param_name = 'ignore_puppet_facts_for_provisioning'
         with Session(self.browser) as session:
-            edit_param(session, tab_locator=tab_locator,
-                       param_name=param_name,
-                       value_type=value_type,
-                       param_value=test_data['param_value'])
-            saved_element = self.settings.get_saved_value(tab_locator,
-                                                          param_name)
-            self.assertEqual(test_data['param_value'], saved_element)
+            edit_param(
+                session,
+                tab_locator=tab_locator,
+                param_name=param_name,
+                value_type='dropdown',
+                param_value=param_value,
+            )
+            saved_element = self.settings.get_saved_value(
+                tab_locator, param_name)
+            self.assertEqual(param_value, saved_element)
 
     @run_only_on('sat')
-    @data({u'param_value': "true"},
-          {u'param_value': "false"})
-    def test_positive_update_provisioning_param_24(self, test_data):
-        """@Test: Updates param "ignore_puppet_facts_for_provisioning"
-        under Provisioning tab
+    @data('true', 'false')
+    def test_positive_update_provisioning_param_24(self, param_value):
+        """@Test: Updates param "ignore_puppet_facts_for_provisioning" under
+        Provisioning tab
 
         @Feature: Settings - Update Parameters
 
         @Assert: Parameter is updated
 
         """
-
-        tab_locator = tab_locators["settings.tab_provisioning"]
-        param_name = "ignore_puppet_facts_for_provisioning"
-        value_type = "dropdown"
+        tab_locator = tab_locators['settings.tab_provisioning']
+        param_name = 'ignore_puppet_facts_for_provisioning'
         with Session(self.browser) as session:
-            edit_param(session, tab_locator=tab_locator,
-                       param_name=param_name,
-                       value_type=value_type,
-                       param_value=test_data['param_value'])
-            saved_element = self.settings.get_saved_value(tab_locator,
-                                                          param_name)
-            self.assertEqual(test_data['param_value'], saved_element)
+            edit_param(
+                session,
+                tab_locator=tab_locator,
+                param_name=param_name,
+                value_type='dropdown',
+                param_value=param_value,
+            )
+            saved_element = self.settings.get_saved_value(
+                tab_locator, param_name)
+            self.assertEqual(param_value, saved_element)
 
     @run_only_on('sat')
-    @data({u'param_value': "true"},
-          {u'param_value': "false"})
-    def test_positive_update_provisioning_param_25(self, test_data):
-        """@Test: Updates param "manage_puppetca"
-        under Provisioning tab
+    @data('true', 'false')
+    def test_positive_update_provisioning_param_25(self, param_value):
+        """@Test: Updates param "manage_puppetca" under Provisioning tab
 
         @Feature: Settings - Update Parameters
 
         @Assert: Parameter is updated
 
         """
-
-        tab_locator = tab_locators["settings.tab_provisioning"]
-        param_name = "manage_puppetca"
-        value_type = "dropdown"
+        tab_locator = tab_locators['settings.tab_provisioning']
+        param_name = 'manage_puppetca'
         with Session(self.browser) as session:
-            edit_param(session, tab_locator=tab_locator,
-                       param_name=param_name,
-                       value_type=value_type,
-                       param_value=test_data['param_value'])
-            saved_element = self.settings.get_saved_value(tab_locator,
-                                                          param_name)
-            self.assertEqual(test_data['param_value'], saved_element)
+            edit_param(
+                session,
+                tab_locator=tab_locator,
+                param_name=param_name,
+                value_type='dropdown',
+                param_value=param_value,
+            )
+            saved_element = self.settings.get_saved_value(
+                tab_locator, param_name)
+            self.assertEqual(param_value, saved_element)
 
     @run_only_on('sat')
-    @data({u'param_value': "true"},
-          {u'param_value': "false"})
-    def test_positive_update_provisioning_param_26(self, test_data):
-        """@Test: Updates param "query_local_nameservers"
-        under Provisioning tab
+    @data('true', 'false')
+    def test_positive_update_provisioning_param_26(self, param_value):
+        """@Test: Updates param "query_local_nameservers" under Provisioning
+        tab
 
         @Feature: Settings - Update Parameters
 
         @Assert: Parameter is updated
 
         """
-
-        tab_locator = tab_locators["settings.tab_provisioning"]
-        param_name = "query_local_nameservers"
-        value_type = "dropdown"
+        tab_locator = tab_locators['settings.tab_provisioning']
+        param_name = 'query_local_nameservers'
         with Session(self.browser) as session:
-            edit_param(session, tab_locator=tab_locator,
-                       param_name=param_name,
-                       value_type=value_type,
-                       param_value=test_data['param_value'])
-            saved_element = self.settings.get_saved_value(tab_locator,
-                                                          param_name)
-            self.assertEqual(test_data['param_value'], saved_element)
+            edit_param(
+                session,
+                tab_locator=tab_locator,
+                param_name=param_name,
+                value_type='dropdown',
+                param_value=param_value,
+            )
+            saved_element = self.settings.get_saved_value(
+                tab_locator, param_name)
+            self.assertEqual(param_value, saved_element)
 
     @run_only_on('sat')
-    @data({u'param_value': "true"},
-          {u'param_value': "false"})
-    def test_positive_update_provisioning_param_27(self, test_data):
-        """@Test: Updates param "safemode_render"
-        under Provisioning tab
+    @data('true', 'false')
+    def test_positive_update_provisioning_param_27(self, param_value):
+        """@Test: Updates param "safemode_render" under Provisioning tab
 
         @Feature: Settings - Update Parameters
 
         @Assert: Parameter is updated
 
         """
-
-        tab_locator = tab_locators["settings.tab_provisioning"]
-        param_name = "safemode_render"
-        value_type = "dropdown"
+        tab_locator = tab_locators['settings.tab_provisioning']
+        param_name = 'safemode_render'
         with Session(self.browser) as session:
-            edit_param(session, tab_locator=tab_locator,
-                       param_name=param_name,
-                       value_type=value_type,
-                       param_value=test_data['param_value'])
-            saved_element = self.settings.get_saved_value(tab_locator,
-                                                          param_name)
-            self.assertEqual(test_data['param_value'], saved_element)
+            edit_param(
+                session,
+                tab_locator=tab_locator,
+                param_name=param_name,
+                value_type='dropdown',
+                param_value=param_value,
+            )
+            saved_element = self.settings.get_saved_value(
+                tab_locator, param_name)
+            self.assertEqual(param_value, saved_element)
 
     @run_only_on('sat')
     @skip_if_bug_open('bugzilla', 1125156)
-    @data({u'param_value': " "},
-          {u'param_value': "-1"},
-          {u'param_value': "text"})
-    def test_negative_update_provisioning_param_28(self, test_data):
-        """@Test: Updates param "token_duration"
-        under Provisioning tab with invalid values
+    @data(' ', '-1', 'text')
+    def test_negative_update_provisioning_param_28(self, param_value):
+        """@Test: Updates param "token_duration" under Provisioning tab with
+        invalid values
 
         @Feature: Settings - Negative Update Parameters
 
@@ -810,23 +776,24 @@ class Settings(UITestCase):
         @BZ: 1125156
 
         """
-
-        tab_locator = tab_locators["settings.tab_provisioning"]
-        param_name = "token_duration"
-        value_type = "input"
+        tab_locator = tab_locators['settings.tab_provisioning']
+        param_name = 'token_duration'
         with Session(self.browser) as session:
-            edit_param(session, tab_locator=tab_locator,
-                       param_name=param_name,
-                       value_type=value_type,
-                       param_value=test_data['param_value'])
-            self.assertIsNotNone(session.nav.wait_until_element
-                                 (common_locators["notif.error"]))
-            saved_element = self.settings.get_saved_value(tab_locator,
-                                                          param_name)
-            self.assertNotEqual(test_data['param_value'], saved_element)
+            edit_param(
+                session,
+                tab_locator=tab_locator,
+                param_name=param_name,
+                value_type='input',
+                param_value=param_value,
+            )
+            self.assertIsNotNone(
+                session.nav.wait_until_element(common_locators['notif.error']))
+            saved_element = self.settings.get_saved_value(
+                tab_locator, param_name)
+            self.assertNotEqual(param_value, saved_element)
 
     @run_only_on('sat')
-    @data("90", "0")
+    @data('90', '0')
     def test_positive_update_provisioning_param_29(self, param_value):
         """@Test: Updates param "token_duration" under Provisioning tab
 
@@ -835,26 +802,31 @@ class Settings(UITestCase):
         @Assert: Parameter is updated
 
         """
-
-        tab_locator = tab_locators["settings.tab_provisioning"]
-        param_name = "token_duration"
-        value_type = "input"
+        tab_locator = tab_locators['settings.tab_provisioning']
+        param_name = 'token_duration'
+        value_type = 'input'
         with Session(self.browser) as session:
             session.nav.go_to_settings()
-            default_value = self.settings.get_saved_value(tab_locator,
-                                                          param_name)
-            edit_param(session, tab_locator=tab_locator,
-                       param_name=param_name,
-                       value_type=value_type,
-                       param_value=param_value)
-            saved_element = self.settings.get_saved_value(tab_locator,
-                                                          param_name)
+            default_value = self.settings.get_saved_value(
+                tab_locator, param_name)
+            edit_param(
+                session,
+                tab_locator=tab_locator,
+                param_name=param_name,
+                value_type=value_type,
+                param_value=param_value,
+            )
+            saved_element = self.settings.get_saved_value(
+                tab_locator, param_name)
             self.assertEqual(param_value, saved_element)
             # This is the time in minutes as for how long installation token
             # should be valid; '0' value is to disable it
             # Resetting the token_duration to its default value '60'
             if saved_element == '0':
-                edit_param(session, tab_locator=tab_locator,
-                           param_name=param_name,
-                           value_type=value_type,
-                           param_value=default_value)
+                edit_param(
+                    session,
+                    tab_locator=tab_locator,
+                    param_name=param_name,
+                    value_type=value_type,
+                    param_value=default_value,
+                )


### PR DESCRIPTION
Improved code corresponding to #2562 issue and our style in general
```
nosetests tests/foreman/ui/test_contentenv.py
..........
----------------------------------------------------------------------
Ran 10 tests in 529.838s

OK
```
```
nosetests tests/foreman/ui/test_settings.py
SSSSSSSSSSSSSSSSSSSSSSSS..............................SSSSSSS...SSSSSSSSS..............
----------------------------------------------------------------------
Ran 87 tests in 2346.889s

OK(SKIP=40)
```
```
nosetests tests/foreman/ui/test_template.py -m test_positive_create_template
.......
----------------------------------------------------------------------
Ran 7 tests in 156.684s

OK
```
```
nosetests tests/foreman/ui/test_template.py -m test_remove_template
.......
----------------------------------------------------------------------
Ran 7 tests in 245.547s

OK
```
```
nosetests tests/foreman/ui/test_template.py -m test_clone_template
.
----------------------------------------------------------------------
Ran 1 test in 49.901s

OK
```
```
nosetests tests/foreman/ui/test_template.py -m test_update_template_os
.
----------------------------------------------------------------------
Ran 1 test in 39.342s

OK
```