### PR TITLE
Fix failing DiscoveryRule tests

### DIFF
--- a/tests/foreman/api/test_multiple_paths.py
+++ b/tests/foreman/api/test_multiple_paths.py
@@ -65,9 +65,11 @@ def _get_readable_attributes(entity):
             del attributes[field_name]
 
     # The server deals with a field named "path", but we name the same field
-    # "path_" due to a naming conflict with a method by that name.
+    # path_ due to a naming conflict with a method by that name. Same w/search.
     if isinstance(entity, entities.Media):
         attributes['path'] = attributes.pop('path_')
+    if isinstance(entity, entities.DiscoveryRule):
+        attributes['search'] = attributes.pop('search_')
 
     return attributes
 


### PR DESCRIPTION
Fix two tests that are failing due to the unusually-named `search_` field. Test
results:

    $ nosetests tests/foreman/api/test_multiple_paths.py:DoubleCheckTestCase -m test_post_and_get_7_DiscoveryRule
    .
    ----------------------------------------------------------------------
    Ran 1 test in 1.712s

    OK
    $ nosetests tests/foreman/api/test_multiple_paths.py:DoubleCheckTestCase -m test_put_and_get_7_DiscoveryRule
    .
    ----------------------------------------------------------------------
    Ran 1 test in 3.124s

    OK