### PR TITLE
Test BZ 1242534

### DIFF
--- a/tests/foreman/api/test_contentviewfilter.py
+++ b/tests/foreman/api/test_contentviewfilter.py
@@ -11,7 +11,7 @@ from nailgun import client, entities
 from random import randint
 from requests.exceptions import HTTPError
 from robottelo.common.constants import DOCKER_REGISTRY_HUB
-from robottelo.common.decorators import data, run_only_on
+from robottelo.common.decorators import data, run_only_on, skip_if_bug_open
 from robottelo.common.helpers import get_server_credentials
 from robottelo.test import APITestCase
 
@@ -588,3 +588,52 @@ class ContentViewFilterTestCase(APITestCase):
         cvf.repository = [new_repo]
         with self.assertRaises(HTTPError):
             cvf.update(['repository'])
+
+
+class SearchTestCase(APITestCase):
+    """Tests that search through content view filters."""
+
+    @classmethod
+    def setUpClass(cls):
+        """Create a content view as ``cls.content_view``."""
+        cls.content_view = entities.ContentView().create()
+
+    @skip_if_bug_open('bugzilla', 1242534)
+    def test_search_erratum(self):
+        """@Test: Search for an erratum content view filter's rules.
+
+        @Assert: The search completes with no errors.
+
+        @Feature: Content View Filter
+
+        """
+        cv_filter = entities.ErratumContentViewFilter(
+            content_view=self.content_view
+        ).create()
+        entities.ContentViewFilterRule(content_view_filter=cv_filter).search()
+
+    def test_search_package_group(self):
+        """@Test: Search for an package group content view filter's rules.
+
+        @Assert: The search completes with no errors.
+
+        @Feature: Content View Filter
+
+        """
+        cv_filter = entities.PackageGroupContentViewFilter(
+            content_view=self.content_view
+        ).create()
+        entities.ContentViewFilterRule(content_view_filter=cv_filter).search()
+
+    def test_search_rpm(self):
+        """@Test: Search for an rpm content view filter's rules.
+
+        @Assert: The search completes with no errors.
+
+        @Feature: Content View Filter
+
+        """
+        cv_filter = entities.RPMContentViewFilter(
+            content_view=self.content_view
+        ).create()
+        entities.ContentViewFilterRule(content_view_filter=cv_filter).search()


### PR DESCRIPTION
Listing a content view filter's rules succeeds when the content view filter is
of type "rpm" or "package_group". It fails when the content view filter is of
type "erratum".

Test results without `@skip_if_bug_open` decorator:

    $ nosetests tests/foreman/api/test_contentviewfilter.py:BZ1242534TestCase
    E..
    ======================================================================
    ERROR: @Test: Search for an erratum content view filter's rules.
    ----------------------------------------------------------------------
    Traceback (most recent call last):
    File "/home/ichimonji10/code/robottelo/robottelo/common/decorators.py", line 372, in wrapper_func
        return func(*args, **kwargs)
    File "/home/ichimonji10/code/robottelo/tests/foreman/api/test_contentviewfilter.py", line 617, in test_search_erratum
        entities.ContentViewFilterRule(content_view_filter=cv_filter).search()
    File "/home/ichimonji10/code/nailgun/nailgun/entity_mixins.py", line 1243, in search
        results = self.search_json(fields, query)['results']
    File "/home/ichimonji10/code/nailgun/nailgun/entity_mixins.py", line 1096, in search_json
        response.raise_for_status()
    File "/home/ichimonji10/.virtualenvs/robottelo2/lib/python2.7/site-packages/requests/models.py", line 851, in raise_for_status
        raise HTTPError(http_error_msg, response=self)
    HTTPError: 500 Server Error: Internal Server Error

    ----------------------------------------------------------------------
    Ran 3 tests in 10.545s

    FAILED (errors=1)

Test results with decorator applied:

    (robottelo2)[ichimonji10@beech:robottelo]$ nosetests tests/foreman/api/test_contentviewfilter.py:BZ1242534TestCase
    S..
    ----------------------------------------------------------------------
    Ran 3 tests in 6.881s

    OK (SKIP=1)

See: https://bugzilla.redhat.com/show_bug.cgi?id=1242534#c5