### PR TITLE
Make CLI _construct_command() work with lists of values (or even list of entities)

### DIFF
--- a/robottelo/cli/base.py
+++ b/robottelo/cli/base.py
@@ -370,11 +370,14 @@ class Base(object):
             options = {}
 
         for key, val in options.items():
-            if val is not None:
-                if val is True:
-                    tail += u' --{0}'.format(key)
-                elif val is not False:
-                    tail += u' --{0}="{1}"'.format(key, val)
+            if val is None:
+                continue
+            if val is True:
+                tail += u' --{0}'.format(key)
+            elif val is not False:
+                if isinstance(val, list):
+                    val = ','.join(str(el) for el in val)
+                tail += u' --{0}="{1}"'.format(key, val)
         cmd = u'{0} {1} {2}'.format(
             cls.command_base,
             cls.command_sub,

--- a/tests/foreman/cli/test_computeresource.py
+++ b/tests/foreman/cli/test_computeresource.py
@@ -195,9 +195,8 @@ class TestComputeResource(CLITestCase):
         try:
             locations_amount = random.randint(3, 5)
             locations = [make_location() for _ in range(locations_amount)]
-            location_ids = ','.join(location['id'] for location in locations)
             comp_resource = make_compute_resource({
-                'location-ids': location_ids,
+                'location-ids': [location['id'] for location in locations],
             })
         except CLIFactoryError as err:
             self.fail(err)

--- a/tests/foreman/cli/test_docker.py
+++ b/tests/foreman/cli/test_docker.py
@@ -533,10 +533,8 @@ class DockerContentViewTestCase(CLITestCase):
             'composite': True,
             'organization-id': self.org_id,
         })
-        cv_versions_ids = ','.join(
-            cv_version['id'] for cv_version in cv_versions)
         result = ContentView.update({
-            'component-ids': cv_versions_ids,
+            'component-ids': [cv_version['id'] for cv_version in cv_versions],
             'id': comp_content_view['id'],
         })
         self.assertEqual(result.return_code, 0)

--- a/tests/foreman/cli/test_location.py
+++ b/tests/foreman/cli/test_location.py
@@ -294,8 +294,7 @@ class TestLocation(CLITestCase):
         """
         envs_amount = randint(3, 5)
         envs = [make_environment() for _ in range(envs_amount)]
-        env_ids = ','.join(env['id'] for env in envs)
-        loc = make_location({'environment-ids': env_ids})
+        loc = make_location({'environment-ids': [env['id'] for env in envs]})
         self.assertEqual(len(loc['environments']), envs_amount)
         for env in envs:
             self.assertIn(env['name'], loc['environments'])
@@ -313,8 +312,9 @@ class TestLocation(CLITestCase):
         """
         domains_amount = randint(3, 5)
         domains = [make_domain() for _ in range(domains_amount)]
-        domain_names = ','.join(domain['name'] for domain in domains)
-        loc = make_location({'domains': domain_names})
+        loc = make_location({
+            'domains': [domain['name'] for domain in domains],
+        })
         self.assertEqual(len(loc['domains']), domains_amount)
         for domain in domains:
             self.assertIn(domain['name'], loc['domains'])
@@ -476,8 +476,9 @@ class TestLocation(CLITestCase):
         """
         resources_amount = randint(3, 5)
         resources = [make_compute_resource() for _ in range(resources_amount)]
-        resource_ids = ','.join(resource['id'] for resource in resources)
-        loc = make_location({'compute-resource-ids': resource_ids})
+        loc = make_location({
+            'compute-resource-ids': [resource['id'] for resource in resources],
+        })
         self.assertEqual(len(loc['compute-resources']), resources_amount)
         for resource in resources:
             self.assertIn(resource['name'], loc['compute-resources'])
@@ -508,17 +509,17 @@ class TestLocation(CLITestCase):
         """
 
         host_groups = [make_hostgroup() for _ in range(3)]
-        host_group_names = ','.join(hg['name'] for hg in host_groups)
-        loc = make_location({'hostgroups': host_group_names})
+        loc = make_location({
+            'hostgroups': [hg['name'] for hg in host_groups],
+            })
         self.assertEqual(len(loc['hostgroups']), 3)
         for host_group in host_groups:
             self.assertIn(host_group['name'], loc['hostgroups'])
 
         new_host_groups = [make_hostgroup() for _ in range(2)]
-        new_host_group_names = ','.join(hg['name'] for hg in new_host_groups)
         result = Location.update({
             'id': loc['id'],
-            'hostgroups': new_host_group_names,
+            'hostgroups': [hg['name'] for hg in new_host_groups],
         })
         self.assertEqual(result.return_code, 0)
 

--- a/tests/foreman/cli/test_org.py
+++ b/tests/foreman/cli/test_org.py
@@ -614,8 +614,10 @@ class TestOrg(CLITestCase):
         try:
             cr_amount = random.randint(3, 5)
             resources = [make_compute_resource() for _ in range(cr_amount)]
-            resource_ids = ','.join(resource['id'] for resource in resources)
-            org = make_org({'compute-resource-ids': resource_ids})
+            org = make_org({
+                'compute-resource-ids':
+                    [resource['id'] for resource in resources],
+            })
         except CLIFactoryError as err:
             self.fail(err)
         self.assertEqual(len(org['compute-resources']), cr_amount)
@@ -740,8 +742,10 @@ class TestOrg(CLITestCase):
         try:
             templates_amount = random.randint(3, 5)
             templates = [make_template() for _ in range(templates_amount)]
-            template_ids = ','.join(template['id'] for template in templates)
-            org = make_org({'config-template-ids': template_ids})
+            org = make_org({
+                'config-template-ids':
+                    [template['id'] for template in templates],
+            })
         except CLIFactoryError as err:
             self.fail(err)
         self.assertGreaterEqual(len(org['templates']), templates_amount)

--- a/tests/foreman/cli/test_subnet.py
+++ b/tests/foreman/cli/test_subnet.py
@@ -102,8 +102,9 @@ class TestSubnet(CLITestCase):
         try:
             domains_amount = random.randint(3, 5)
             domains = [make_domain() for _ in range(domains_amount)]
-            domain_ids = ','.join(domain['id'] for domain in domains)
-            subnet = make_subnet({'domain-ids': str(domain_ids)})
+            subnet = make_subnet({
+                'domain-ids': [domain['id'] for domain in domains],
+            })
         except CLIFactoryError as err:
             self.fail(err)
         self.assertEqual(len(subnet['domains']), domains_amount)


### PR DESCRIPTION
Was surprised when I saw test like this:
```python
    def test_create_compute_resource_with_multiple_locations(self):
        # [...]
        location_ids = ','.join(location['id'] for location in locations)
        comp_resource = make_compute_resource({
            'location-ids': location_ids,
        })
        # [...]
```
So, before CLI couldn't parse the list of values so some workarounds were applied on tests level to make it work.
I propose to change `_construct_command()` a little to accept lists and parse them. So following will work instead:
```python
    def test_create_compute_resource_with_multiple_locations(self):
        # [...]
        comp_resource = make_compute_resource({
            'location-ids': [location['id'] for location in locations],
        })
        # [...]
```
~~Furthermore, why don't we check if the list contains dictionaries? (As it's CLI, instead of entities class, we have just dictionaries). So, if list was passed, and it contains dictionaries, we can try to check wheter those dicts have 'id' key, or at least 'name' key, and parse them into a valid string of ids/names, separated by commas.
This will make much easier to work with command parameters, which accept multiple values. Previous example will look like this:~~
```python
    def test_create_compute_resource_with_multiple_locations(self):
        # [...]
        comp_resource = make_compute_resource({
            'location-ids': locations,
        })
        # [...]
```
~~Reminds me our API tests a lot :smile: 
And the best part about this change - it's backwards-compatible. As we were not using lists or dictionaries in values before, even if i forgot to change some test to the new style, it will still work as usual.~~