### PR TITLE
Fix current CLI failures

### DIFF
--- a/tests/foreman/data/hammer_commands.json
+++ b/tests/foreman/data/hammer_commands.json
@@ -7203,7 +7203,7 @@
                 },
                 {
                   "help": "",
-                  "name": "cpu-sets",
+                  "name": "cpu-set",
                   "shortname": null,
                   "value": "CPU_SETS"
                 },


### PR DESCRIPTION
Created two commits in order to accomplish:

* Update hammer commands and options
* Make VM destroy unregister if registered. This is an attempt to avoid running out of subscriptions when destroying a virtual machine. It should fix the failures related to vms not having available subscriptions.