### PR TITLE
Revert entries_per_page after test_positive_update_general_param_5 execution

### DIFF
--- a/tests/foreman/ui/test_settings.py
+++ b/tests/foreman/ui/test_settings.py
@@ -137,20 +137,33 @@ class Settings(UITestCase):
         tab_locator = tab_locators['settings.tab_general']
         param_name = 'entries_per_page'
         with Session(self.browser) as session:
-            edit_param(
-                session,
-                tab_locator=tab_locator,
-                param_name=param_name,
-                value_type='input',
-                param_value=param_value,
-            )
-            saved_element = self.settings.get_saved_value(
+            self.navigator.go_to_settings()
+            original_value = self.settings.get_saved_value(
                 tab_locator, param_name)
-            # UI automatically strips leading zeros on save,
-            # e.g. If param_value = '01400' then UI saves it as '1400'
-            # so using 'lstrip' to strip leading zeros from variable
-            # 'param_value' too
-            self.assertEqual(param_value.lstrip('0'), saved_element)
+            try:
+                edit_param(
+                    session,
+                    tab_locator=tab_locator,
+                    param_name=param_name,
+                    value_type='input',
+                    param_value=param_value,
+                )
+                saved_element = self.settings.get_saved_value(
+                    tab_locator, param_name)
+                # UI automatically strips leading zeros on save,
+                # e.g. If param_value = '01400' then UI saves it as '1400'
+                # so using 'lstrip' to strip leading zeros from variable
+                # 'param_value' too
+                self.assertEqual(param_value.lstrip('0'), saved_element)
+            finally:
+                # Restore previous value
+                edit_param(
+                    session,
+                    tab_locator=tab_locator,
+                    param_name=param_name,
+                    value_type='input',
+                    param_value=original_value,
+                )
 
     @skip_if_bug_open('bugzilla', 1125181)
     @data(


### PR DESCRIPTION
`test_positive_update_general_param_5` was updating `entries_per_page` to some huge value and was not reverting the changes after test execution. This could potentially lead to performance degradation in all the next tests, where big lists of entries were displayed.
This change will always try to revert `entries_per_page` to its previous state, even if the test has failed.

Test results:
```
nosetests tests/foreman/ui/test_settings.py -m test_positive_update_general_param_5
.
----------------------------------------------------------------------
Ran 1 test in 20.894s

OK
```