### PR TITLE
CLI/syncplan - test bz1261122 - enabled_state_visible

### DIFF
--- a/tests/foreman/cli/test_syncplan.py
+++ b/tests/foreman/cli/test_syncplan.py
@@ -6,7 +6,7 @@ from ddt import ddt
 from fauxfactory import gen_string
 from robottelo.cli.factory import CLIFactoryError, make_org, make_sync_plan
 from robottelo.cli.syncplan import SyncPlan
-from robottelo.common.decorators import data
+from robottelo.common.decorators import data, skip_if_bug_open
 from robottelo.test import CLITestCase
 
 
@@ -491,3 +491,16 @@ class TestSyncPlan(CLITestCase):
             0,
             "Expected an error here"
         )
+
+    @skip_if_bug_open('bugzilla', 1261122)
+    def test_bz1261122_enabled_state_visible(self):
+        """@Test: Check if Enabled field is displayed in sync-plan info output
+
+        @Feature: Sync Plan Info
+
+        @Assert: Sync plan Enabled state is displayed
+
+        """
+        new_sync_plan = self._make_sync_plan()
+        result = SyncPlan.info({'id': new_sync_plan['id']})
+        self.assertIsNotNone(result.stdout.get('enabled'))


### PR DESCRIPTION
Added test for `hammer sync-plan info` - [BZ #1261122](https://bugzilla.redhat.com/show_bug.cgi?id=1261122).

```bash
$ nosetests -m test_bz1261122_enabled_state_visible test_syncplan.py
S
----------------------------------------------------------------------
Ran 1 test in 5.477s

OK (SKIP=1)
```
with no `skip_if_bz_open` decorator applied:
```bash
$ nosetests -m test_bz1261122_enabled_state_visible test_syncplan.py
F
======================================================================
FAIL: @Test: Check if Enabled field is displayed in sync-plan info output
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/rplevka/work/rplevka/robottelo/tests/foreman/cli/test_syncplan.py", line 508, in test_bz1261122_enabled_state_visible
    self.assertIsNotNone(result.stdout.get('enabled'))
AssertionError: unexpectedly None

----------------------------------------------------------------------
Ran 1 test in 9.270s

FAILED (failures=1)
```

There already is a PR containing a fix in the upstream:  [PR #312](https://github.com/Katello/hammer-cli-katello/pull/312) pending. With this PR applied:
```bash
$ nosetests -m test_bz1261122_enabled_state_visible test_syncplan.py
.
----------------------------------------------------------------------
Ran 1 test in 8.839s

OK
```
