### PR TITLE
Add test for foreman tasks

### DIFF
--- a/tests/foreman/api/test_foremantask.py
+++ b/tests/foreman/api/test_foremantask.py
@@ -22,3 +22,16 @@ class ForemanTasksIdTestCase(APITestCase):
         """
         with self.assertRaises(HTTPError):
             entities.ForemanTask(id='abc123').read()
+
+    def test_summary(self):
+        """@Test: Get a summary of foreman tasks.
+
+        @Assert: A list of dicts is returned.
+
+        @Feature: ForemanTask
+
+        """
+        summary = entities.ForemanTask().summary()
+        self.assertIsInstance(summary, list)
+        for item in summary:
+            self.assertIsInstance(item, dict)


### PR DESCRIPTION
Test that it is possible to get a summary of information about foreman tasks.

Test results:

    $ nosetests tests/foreman/api/test_foremantask.py
    S.
    ----------------------------------------------------------------------
    Ran 2 tests in 1.037s

    OK (SKIP=1)