### PR TITLE
Add tests for BZ 1262037

### DIFF
--- a/tests/foreman/api/test_smartproxy.py
+++ b/tests/foreman/api/test_smartproxy.py
@@ -1,6 +1,54 @@
 """Tests for the ``smart_proxies`` paths."""
-from robottelo.common.decorators import run_only_on, stubbed
+from nailgun import entities
+from nailgun.entity_mixins import _get_entity_ids
+from robottelo.common.decorators import run_only_on, stubbed, skip_if_bug_open
 from robottelo.test import APITestCase
+
+
+@skip_if_bug_open('bugzilla', 1262037)
+class MissingAttrTestCase(APITestCase):
+    """Tests to see if the server returns the attributes it should.
+
+    Satellite should return a full description of an entity each time an entity
+    is created, read or updated. These tests verify that certain attributes
+    really are returned. Satellite may name a given attribute in one of several
+    ways, and the ``_get_entity_*`` methods know about all the names Satellite
+    may give to an attribute.
+
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        """Find a ``SmartProxy``.
+
+        Every Satellite has a built-in smart proxy, so searching for an
+        existing smart proxy should always succeed.
+
+        """
+        smart_proxies = entities.SmartProxy().search()
+        assert len(smart_proxies) > 0
+        cls.smart_proxy_attrs = smart_proxies[0].update_json([])
+
+    def test_location(self):
+        """@Test: Update a smart proxy. Inspect the server's response.
+
+        @Assert: The response contains some value for the ``location`` field.
+
+        @Feature: SmartProxy
+
+        """
+        _get_entity_ids('location', self.smart_proxy_attrs)
+
+    def test_organization(self):
+        """@Test: Update a smart proxy. Inspect the server's response.
+
+        @Assert: The response contains some value for the ``organization``
+        field.
+
+        @Feature: SmartProxy
+
+        """
+        _get_entity_ids('organization', self.smart_proxy_attrs)
 
 
 @run_only_on('sat')


### PR DESCRIPTION
Test results:

    $ nosetests tests/foreman/api/test_smartproxy.py:MissingAttrTestCase
    S
    ----------------------------------------------------------------------
    Ran 1 test in 0.549s

    OK (SKIP=1)

Test result without `skip_if_bug_open` decorator:

    $ nosetests tests/foreman/api/test_smartproxy.py:MissingAttrTestCase
    EE
    ======================================================================
    ERROR: @Test: Update a smart proxy. Inspect the server's response.
    ----------------------------------------------------------------------
    Traceback (most recent call last):
    File "/home/ichimonji10/code/robottelo/tests/foreman/api/test_smartproxy.py", line 39, in test_location
        _get_entity_ids('location', self.smart_proxy_attrs)
    File "/home/ichimonji10/code/nailgun/nailgun/entity_mixins.py", line 280, in _get_entity_ids
        attrs.keys()
    MissingValueError: Cannot find a value for the "location" field. Searched for keys named ('location_ids', 'location', 'locations'), but available keys are [u'name', u'url', u'created_at', u'updated_at', u'content_host_id', u'id'].

    ======================================================================
    ERROR: @Test: Update a smart proxy. Inspect the server's response.
    ----------------------------------------------------------------------
    Traceback (most recent call last):
    File "/home/ichimonji10/code/robottelo/tests/foreman/api/test_smartproxy.py", line 50, in test_organization
        _get_entity_ids('organization', self.smart_proxy_attrs)
    File "/home/ichimonji10/code/nailgun/nailgun/entity_mixins.py", line 280, in _get_entity_ids
        attrs.keys()
    MissingValueError: Cannot find a value for the "organization" field. Searched for keys named ('organization_ids', 'organization', 'organizations'), but available keys are [u'name', u'url', u'created_at', u'updated_at', u'content_host_id', u'id'].

    ----------------------------------------------------------------------
    Ran 2 tests in 0.912s

    FAILED (errors=2)