### PR TITLE
Add missing `skip_if_bug_open` decorator

### DIFF
--- a/tests/foreman/api/test_hostgroup.py
+++ b/tests/foreman/api/test_hostgroup.py
@@ -149,6 +149,7 @@ class HostGroupTestCase(APITestCase):
         self.assertEqual(host_attrs['all_puppetclasses'][0]['name'], 'ntp')
 
 
+@skip_if_bug_open('bugzilla', 1235377)
 class MissingAttrTestCase(APITestCase):
     """Tests to see if the server returns the attributes it should.
 


### PR DESCRIPTION
This decorator should have been added as part of #2757. See commit
e70c4eb4c35bd80234535294807658726dc89819