### PR TITLE
Refactor API tests for missing attributes

### DIFF
--- a/robottelo/api/utils.py
+++ b/robottelo/api/utils.py
@@ -2,6 +2,7 @@
 """Module containing convenience functions for working with the API."""
 import time
 
+from inflector import Inflector
 from nailgun import entities
 from robottelo.helpers import bz_bug_is_open
 
@@ -66,3 +67,33 @@ def upload_manifest(organization_id, manifest):
         data={'organization_id': organization_id},
         files={'content': manifest},
     )
+
+
+def one_to_one_names(name):
+    """Generate the names Satellite might use for a one to one field.
+
+    Example of usage::
+
+        >>> one_to_many_names('person') == {'person', 'person_id'}
+        True
+
+    :param name: A field name.
+    :returns: A set including both ``name`` and variations on ``name``.
+
+    """
+    return set((name, name + '_id'))
+
+
+def one_to_many_names(name):
+    """Generate the names Satellite might use for a one to many field.
+
+    Example of usage::
+
+        >>> one_to_many_names('person') == {'person', 'person_ids', 'people'}
+        True
+
+    :param name: A field name.
+    :returns: A set including both ``name`` and variations on ``name``.
+
+    """
+    return set((name, name + '_ids', Inflector().pluralize(name)))

--- a/setup.py
+++ b/setup.py
@@ -19,6 +19,7 @@ setup(
         'SeleniumFactory',
         'ddt',
         'fauxfactory',
+        'inflector',
         'nailgun',
         'numpy',
         'paramiko',

--- a/tests/foreman/api/test_environment.py
+++ b/tests/foreman/api/test_environment.py
@@ -9,8 +9,8 @@ import random
 from ddt import ddt
 from fauxfactory import gen_string
 from nailgun import entities
-from nailgun.entity_mixins import _get_entity_ids
 from requests.exceptions import HTTPError
+from robottelo.api.utils import one_to_many_names
 from robottelo.decorators import data, run_only_on, skip_if_bug_open
 from robottelo.test import APITestCase
 
@@ -73,9 +73,8 @@ class MissingAttrTestCase(APITestCase):
 
     Satellite should return a full description of an entity each time an entity
     is created, read or updated. These tests verify that certain attributes
-    really are returned. Satellite may name a given attribute in one of several
-    ways, and the ``_get_entity_*`` methods know about all the names Satellite
-    may give to an attribute.
+    really are returned. The ``one_to_*_names`` functions know what names
+    Satellite may assign to fields.
 
     """
 
@@ -83,7 +82,7 @@ class MissingAttrTestCase(APITestCase):
     def setUpClass(cls):
         """Create an ``Environment``."""
         env = entities.Environment().create()
-        cls.env_attrs = env.update_json([])
+        cls.env_attrs = set(env.update_json([]).keys())
 
     def test_location(self):
         """@Test: Update an environment. Inspect the server's response.
@@ -93,7 +92,12 @@ class MissingAttrTestCase(APITestCase):
         @Feature: Environment
 
         """
-        _get_entity_ids('location', self.env_attrs)
+        names = one_to_many_names('location')
+        self.assertGreater(
+            len(names & self.env_attrs),
+            1,
+            'None of {0} are in {1}'.format(names, self.env_attrs),
+        )
 
     def test_organization(self):
         """@Test: Update an environment. Inspect the server's response.
@@ -104,4 +108,9 @@ class MissingAttrTestCase(APITestCase):
         @Feature: Environment
 
         """
-        _get_entity_ids('organization', self.env_attrs)
+        names = one_to_many_names('organization')
+        self.assertGreater(
+            len(names & self.env_attrs),
+            1,
+            'None of {0} are in {1}'.format(names, self.env_attrs),
+        )

--- a/tests/foreman/api/test_hostgroup.py
+++ b/tests/foreman/api/test_hostgroup.py
@@ -2,8 +2,7 @@
 """Tests for the ``hostgroups`` paths."""
 from fauxfactory import gen_string
 from nailgun import client, entities, entity_fields
-from nailgun.entity_mixins import _get_entity_id
-from robottelo.api.utils import promote
+from robottelo.api.utils import promote, one_to_one_names
 from robottelo.constants import PUPPET_MODULE_NTP_PUPPETLABS
 from robottelo.decorators import skip_if_bug_open, stubbed
 from robottelo.helpers import get_data_file, get_server_credentials
@@ -155,11 +154,8 @@ class MissingAttrTestCase(APITestCase):
 
     Satellite should return a full description of an entity each time an entity
     is created, read or updated. These tests verify that certain attributes
-    really are returned. Satellite may name a given attribute in one of several
-    ways, and the ``_get_entity_id`` method knows about all the names that may
-    be assigned to an attribute. For example, this will return ``5``::
-
-        _get_entity_id('content_source', {'content_source_id': 5})
+    really are returned. The ``one_to_*_names`` functions know what names
+    Satellite may assign to fields.
 
     """
 
@@ -167,7 +163,7 @@ class MissingAttrTestCase(APITestCase):
     def setUpClass(cls):
         """Create a ``HostGroup``."""
         host_group = entities.HostGroup().create()
-        cls.host_group_attrs = host_group.read_json()
+        cls.host_group_attrs = set(host_group.read_json().keys())
 
     def test_get_content_source(self):
         """@Test: Read a host group. Inspect the server's response.
@@ -178,7 +174,12 @@ class MissingAttrTestCase(APITestCase):
         @Feature: HostGroup
 
         """
-        _get_entity_id('content_source', self.host_group_attrs)
+        names = one_to_one_names('content_source')
+        self.assertGreater(
+            len(names & self.host_group_attrs),
+            1,
+            'None of {0} are in {1}'.format(names, self.host_group_attrs)
+        )
 
     def test_get_content_view(self):
         """@Test: Read a host group. Inspect the server's response.
@@ -189,7 +190,12 @@ class MissingAttrTestCase(APITestCase):
         @Feature: HostGroup
 
         """
-        _get_entity_id('content_view', self.host_group_attrs)
+        names = one_to_one_names('content_view')
+        self.assertGreater(
+            len(names & self.host_group_attrs),
+            1,
+            'None of {0} are in {1}'.format(names, self.host_group_attrs)
+        )
 
     def test_get_lifecycle_environment(self):
         """@Test: Read a host group. Inspect the server's response.
@@ -200,7 +206,12 @@ class MissingAttrTestCase(APITestCase):
         @Feature: HostGroup
 
         """
-        _get_entity_id('lifecycle_environment', self.host_group_attrs)
+        names = one_to_one_names('lifecycle_environment')
+        self.assertGreater(
+            len(names & self.host_group_attrs),
+            1,
+            'None of {0} are in {1}'.format(names, self.host_group_attrs)
+        )
 
 
 class HostGroupTestCaseStub(APITestCase):

--- a/tests/foreman/api/test_smartproxy.py
+++ b/tests/foreman/api/test_smartproxy.py
@@ -1,8 +1,8 @@
 """Tests for the ``smart_proxies`` paths."""
 from nailgun import entities
-from nailgun.entity_mixins import _get_entity_ids
 from robottelo.decorators import run_only_on, stubbed, skip_if_bug_open
 from robottelo.test import APITestCase
+from robottelo.api.utils import one_to_many_names
 
 
 @skip_if_bug_open('bugzilla', 1262037)
@@ -11,9 +11,8 @@ class MissingAttrTestCase(APITestCase):
 
     Satellite should return a full description of an entity each time an entity
     is created, read or updated. These tests verify that certain attributes
-    really are returned. Satellite may name a given attribute in one of several
-    ways, and the ``_get_entity_*`` methods know about all the names Satellite
-    may give to an attribute.
+    really are returned. The ``one_to_*_names`` functions know what names
+    Satellite may assign to fields.
 
     """
 
@@ -27,7 +26,7 @@ class MissingAttrTestCase(APITestCase):
         """
         smart_proxies = entities.SmartProxy().search()
         assert len(smart_proxies) > 0
-        cls.smart_proxy_attrs = smart_proxies[0].update_json([])
+        cls.smart_proxy_attrs = set(smart_proxies[0].update_json([]).keys())
 
     def test_location(self):
         """@Test: Update a smart proxy. Inspect the server's response.
@@ -37,7 +36,12 @@ class MissingAttrTestCase(APITestCase):
         @Feature: SmartProxy
 
         """
-        _get_entity_ids('location', self.smart_proxy_attrs)
+        names = one_to_many_names('location')
+        self.assertGreater(
+            len(names & self.smart_proxy_attrs),
+            1,
+            'None of {0} are in {1}'.format(names, self.smart_proxy_attrs),
+        )
 
     def test_organization(self):
         """@Test: Update a smart proxy. Inspect the server's response.
@@ -48,7 +52,12 @@ class MissingAttrTestCase(APITestCase):
         @Feature: SmartProxy
 
         """
-        _get_entity_ids('organization', self.smart_proxy_attrs)
+        names = one_to_many_names('organization')
+        self.assertGreater(
+            len(names & self.smart_proxy_attrs),
+            1,
+            'None of {0} are in {1}'.format(names, self.smart_proxy_attrs),
+        )
 
 
 @run_only_on('sat')

--- a/tests/robottelo/test_api_utils.py
+++ b/tests/robottelo/test_api_utils.py
@@ -1,0 +1,21 @@
+"""Unit tests for :mod:`robottelo.api.utils`."""
+from robottelo.api import utils
+from unittest import TestCase
+
+
+class UtilsTestCase(TestCase):
+    """Tests for the functions in :mod:`robottelo.api.utils`."""
+
+    def test_one_to_one_names(self):
+        """Test :func:`robottelo.api.utils.one_to_one_names`."""
+        self.assertEqual(
+            utils.one_to_one_names('person'),
+            {'person', 'person_id'},
+        )
+
+    def test_one_to_many_names(self):
+        """Test :func:`robottelo.api.utils.one_to_many_names`."""
+        self.assertEqual(
+            utils.one_to_many_names('person'),
+            {'person', 'person_ids', 'people'},
+        )


### PR DESCRIPTION
Add the following functions, and unit test them too:

* `robottelo.api.utils.one_to_one_names`
* `robottelo.api.utils.one_to_many_names`

Update the "missing attribute" API tests. Use these new functions in place of
the `nailgun.entity_mixins._get_entity_id` and
`nailgun.entity_mixins._get_entity_ids` functions.

Test results:

    $ nosetests tests/foreman/api/test_{environment,hostgroup,smartproxy}.py:MissingAttrTestCase
    SSS
    ----------------------------------------------------------------------
    Ran 3 tests in 4.672s

    OK (SKIP=3)