### PR TITLE
Provision a rhel67 host on libvirt compute-resource

### DIFF
--- a/robottelo/ui/hosts.py
+++ b/robottelo/ui/hosts.py
@@ -60,7 +60,9 @@ class Hosts(Base):
         if ip_addr:
             self.wait_until_element(locators['host.ip']).send_keys(ip_addr)
         # Operating system tab
+        self.wait_for_ajax()
         if arch or os or media or ptable or custom_ptable or root_pwd:
+            self.scroll_page()
             self.click(tab_locators['host.tab_os'])
         if arch:
             Select(
@@ -97,7 +99,8 @@ class Hosts(Base):
                lifecycle_env=None, loc=None, mac=None, media=None,
                memory='768 MB', name=None, org=None, os=None, ptable=None,
                puppet_ca=None, puppet_master=None, reset_puppetenv=True,
-               resource=None, root_pwd=None, subnet=None):
+               resource=None, root_pwd=None, subnet=None, network_type=None,
+               network=None):
         """Creates a host."""
         self.click(locators['host.new'])
         self.wait_until_element(locators['host.name']).send_keys(name)
@@ -143,6 +146,14 @@ class Hosts(Base):
             Select(
                 self.wait_until_element(locators['host.vm_memory'])
             ).select_by_visible_text(memory)
+        if network_type is not None:
+            Select(
+                self.wait_until_element(locators['host.network_type'])
+            ).select_by_visible_text(network_type)
+        if network is not None:
+            Select(
+                self.wait_until_element(locators['host.network'])
+            ).select_by_visible_text(network)
         self.click(common_locators['submit'])
 
     def update(self, arch=None, cv=None, custom_ptable=None, domain=None,

--- a/robottelo/ui/locators.py
+++ b/robottelo/ui/locators.py
@@ -386,8 +386,9 @@ tab_locators = LocatorDict({
 
     "host.tab_puppet": (By.XPATH, "//a[@href='#puppet_klasses']"),
     "host.tab_network": (By.XPATH, "//a[@href='#network']"),
-    "host.tab_os": (By.XPATH, "//a[@href='#os']"),
-    "host.tab_vm": (By.XPATH, "//a[@href='#compute_resource']"),
+    "host.tab_os": (By.XPATH, "//form[@id='new_host']//a[@href='#os']"),
+    "host.tab_vm": (
+        By.XPATH, "//form[@id='new_host']//a[@href='#compute_resource']"),
     "host.tab_params": (By.XPATH, "//a[@href='#params']"),
     "host.tab_info": (By.XPATH, "//a[@href='#info']"),
 
@@ -910,6 +911,9 @@ locators = LocatorDict({
     # host.vm (NOTE:- visible only when selecting a compute resource)
     "host.vm_cpus": (By.ID, "host_compute_attributes_cpus"),
     "host.vm_memory": (By.ID, "host_compute_attributes_memory"),
+    "host.network_type": (
+        By.ID, "host_compute_attributes_nics_attributes_0_type"),
+    "host.network": (By.ID, "host_compute_attributes_nics_attributes_0_type"),
     "host.vm_start": (By.ID, "host_compute_attributes_start"),
     "host.vm_addstorage": (
         By.XPATH, "//fieldset[@id='storage_volumes']/a"),

--- a/tests/foreman/ui/test_host.py
+++ b/tests/foreman/ui/test_host.py
@@ -1,14 +1,306 @@
 # -*- encoding: utf-8 -*-
-from nailgun import entities
+from fauxfactory import gen_string
+from nailgun import entities, entity_mixins
+from robottelo.api.utils import promote
+from robottelo.config import conf
 from robottelo.constants import ENVIRONMENT
 from robottelo.decorators import run_only_on
 from robottelo.test import UITestCase
+from robottelo.ui.base import Base
 from robottelo.ui.locators import common_locators
 from robottelo.ui.session import Session
 
 
 @run_only_on('sat')
-class Host(UITestCase):
+class Host(UITestCase, Base):
+
+    hostname = gen_string('numeric')
+
+    @classmethod
+    def setUpClass(cls):
+        """Steps required to create a real host on libvirt
+
+        1. Creates new Organization and Location.
+        2. Creates new life-cycle environment.
+        3. Creates new product and rhel67 custom repository.
+        4. Creates new content-view by associating rhel67 repository.
+        5. Publish and promote the content-view to next environment.
+        6. Search for puppet environment and associate location.
+        7. Search for smart-proxy and associate location.
+        8. Search for domain and associate org, location and dns proxy.
+        9. Search for '192.168.100.0' network and associate org, location,
+        dns/dhcp/tftp proxy, and if its not there then creates new.
+        10. Search for existing compute-resource with 'libvirt' provider and
+        associate org.location, and if its not there then creates new.
+        11. Search 'Kickstart default' partition table and rhel67 OS along with
+        provisioning/PXE templates.
+        12. Associates org, location and OS with provisioning and PXE templates
+        13. Search for x86_64 architecture
+        14. Associate arch, partition table, provisioning/PXE templates with OS
+        15. Search for media and associate org/location
+        16. Create new host group with all required entities
+
+        """
+        # Create a new Organization and Location
+        cls.org = entities.Organization(name=gen_string('alpha')).create()
+        cls.org_name = cls.org.name
+        cls.loc = entities.Location(
+            name=gen_string('alpha'),
+            organization=[cls.org]
+        ).create()
+        cls.loc_name = cls.loc.name
+
+        # Create a new Life-Cycle environment
+        cls.lc_env = entities.LifecycleEnvironment(
+            name=gen_string('alpha'),
+            organization=cls.org
+        ).create()
+
+        # Create a Product, Repository for custom RHEL6 contents
+        cls.product = entities.Product(
+            name=gen_string('alpha'),
+            organization=cls.org
+        ).create()
+        cls.repo = entities.Repository(
+            name=gen_string('alpha'),
+            product=cls.product,
+            url=conf.properties['clients.rhel6_repo']
+        ).create()
+
+        # Increased timeout value for repo sync
+        cls.old_task_timeout = entity_mixins.TASK_TIMEOUT
+        entity_mixins.TASK_TIMEOUT = 3600
+        cls.repo.sync()
+
+        # Create, Publish and promote CV
+        cls.content_view = entities.ContentView(
+            name=gen_string('alpha'),
+            organization=cls.org
+        ).create()
+        cls.content_view.repository = [cls.repo]
+        cls.content_view = cls.content_view.update(['repository'])
+        cls.content_view.publish()
+        cls.content_view = cls.content_view.read()
+        promote(cls.content_view.version[0], cls.lc_env.id)
+        entity_mixins.TASK_TIMEOUT = cls.old_task_timeout
+        # Search for puppet environment and associate location
+        cls.environment = entities.Environment().search(
+            query={'organization_id': [cls.org.id]}
+        )[0]
+        cls.environment.location = [cls.loc]
+        cls.environment = cls.environment.update(['location'])
+
+        # Search for SmartProxy, and associate location
+        cls.proxy = entities.SmartProxy().search(
+            query={
+                u'search': u'name={0}'.format(
+                    conf.properties['main.server.hostname']
+                )
+            }
+        )[0]
+        cls.proxy.location = [cls.loc]
+        cls.proxy = cls.proxy.update(['location'])
+
+        # Search for domain and associate org, location
+        cls.domain = entities.Domain().search(
+            query={
+                u'search': u'name="usersys.redhat.com"'
+            }
+        )[0]
+        cls.domain_name = cls.domain.name
+        cls.domain.location = [cls.loc]
+        cls.domain.organization = [cls.org]
+        cls.domain.dns = cls.proxy
+        cls.domain = cls.domain.update(['dns', 'location', 'organization'])
+
+        # Search if subnet is defined with given network.
+        # If so, just update its relevant fields otherwise,
+        # Create new subnet
+        network = '192.168.100.0'
+        cls.subnet = entities.Subnet().search(
+            query={u'search': u'network={0}'.format(network)}
+        )
+        if (len(cls.subnet) == 1):
+            cls.subnet = cls.subnet[0]
+            cls.subnet.domain = [cls.domain]
+            cls.subnet.location = [cls.loc]
+            cls.subnet.organization = [cls.org]
+            cls.subnet.dns = cls.proxy
+            cls.subnet.dhcp = cls.proxy
+            cls.subnet.tftp = cls.proxy
+            cls.subnet.discovery = cls.proxy
+            cls.subnet = cls.subnet.update(
+                ['domain',
+                 'discovery',
+                 'dhcp',
+                 'dns',
+                 'location',
+                 'organization',
+                 'tftp']
+            )
+        else:
+            # Create new subnet
+            cls.subnet = entities.Subnet(
+                name=gen_string('alpha'),
+                network=network,
+                mask=u'255.255.255.0',
+                domain=[cls.domain],
+                location=[cls.loc],
+                organization=[cls.org],
+                dns=cls.proxy,
+                dhcp=cls.proxy,
+                tftp=cls.proxy,
+                discovery=cls.proxy
+            ).create()
+
+        # Search if Libvirt compute-resource already exists
+        # If so, just update its relevant fields otherwise,
+        # Create new compute-resource with 'libvirt' provider.
+        resource_url = u'qemu+tcp://{0}:16509/system'.format(
+            conf.properties['main.server.hostname']
+        )
+        cls.computeresource = entities.LibvirtComputeResource(
+            provider='libvirt',
+            url=resource_url
+        ).search()
+        if (len(cls.computeresource) >= 1):
+            cls.computeresource = cls.computeresource[0]
+            cls.computeresource.location = [cls.loc]
+            cls.computeresource.organization = [cls.org]
+            cls.computeresource = cls.computeresource.update(
+                ['location',
+                 'organization']
+            )
+        else:
+            # Create Libvirt compute-resource
+            cls.computeresource = entities.LibvirtComputeResource(
+                name=gen_string('alpha'),
+                provider=u'libvirt',
+                url=resource_url,
+                set_console_password=False,
+                display_type=u'VNC',
+                location=[cls.loc.id],
+                organization=[cls.org.id],
+            ).create()
+
+        # Get the Partition table ID
+        cls.ptable = entities.PartitionTable().search(
+            query={
+                u'search': u'name="Kickstart default"'
+            }
+        )[0]
+
+        # Get the OS ID
+        cls.os = entities.OperatingSystem().search(
+            query={u'search': u'name="RedHat" AND major="6" AND minor="7"'}
+        )[0]
+
+        # Get the Provisioning template_ID and update with OS, Org, Location
+        cls.provisioning_template = entities.ConfigTemplate().search(
+            query={
+                u'search': u'name="Satellite Kickstart Default"'
+            }
+        )[0]
+        cls.provisioning_template.operatingsystem = [cls.os]
+        cls.provisioning_template.organization = [cls.org]
+        cls.provisioning_template.location = [cls.loc]
+        cls.provisioning_template = cls.provisioning_template.update([
+            'location',
+            'operatingsystem',
+            'organization'
+        ])
+
+        # Get the PXE template ID and update with OS, Org, location
+        cls.pxe_template = entities.ConfigTemplate().search(
+            query={
+                u'search': u'name="Kickstart default PXELinux"'
+            }
+        )[0]
+        cls.pxe_template.operatingsystem = [cls.os]
+        cls.pxe_template.organization = [cls.org]
+        cls.pxe_template.location = [cls.loc]
+        cls.pxe_template = cls.pxe_template.update(
+            ['location', 'operatingsystem', 'organization']
+        )
+
+        # Get the arch ID
+        cls.arch = entities.Architecture().search(
+            query={u'search': u'name="x86_64"'}
+        )[0]
+        # Update the OS to associate arch, ptable, templates
+        cls.os.architecture = [cls.arch]
+        cls.os.ptable = [cls.ptable]
+        cls.os.config_template = [cls.provisioning_template]
+        cls.os.config_template = [cls.pxe_template]
+        cls.os = cls.os.update(['architecture', 'config_template', 'ptable'])
+
+        # Get the media and update its location
+        cls.media = entities.Media().search(
+            query={'organization_id': [cls.org.id]}
+        )[0]
+        cls.media.location = [cls.loc]
+        cls.media = cls.media.update(['location'])
+        # Create Hostgroup
+        cls.host_group = entities.HostGroup(
+            architecture=cls.arch,
+            domain=cls.domain.id,
+            subnet=cls.subnet.id,
+            lifecycle_environment=cls.lc_env.id,
+            content_view=cls.content_view.id,
+            location=[cls.loc.id],
+            name=gen_string('alpha'),
+            environment=cls.environment.id,
+            puppet_proxy=cls.proxy,
+            puppet_ca_proxy=cls.proxy,
+            content_source=cls.proxy,
+            medium=cls.media,
+            operatingsystem=cls.os.id,
+            organization=[cls.org.id],
+            ptable=cls.ptable.id,
+        ).create()
+        super(Host, cls).setUpClass()
+
+    def tearDown(self):
+        """Delete the host to free the resources"""
+        with Session(self.browser) as session:
+            session.nav.go_to_select_org(self.org_name)
+            session.nav.go_to_hosts()
+            host_name = u'{0}.{1}'.format(self.hostname, self.domain_name)
+            if self.hosts.search(host_name):
+                self.hosts.delete(host_name, True)
+                self.assertIsNotNone(
+                    self.hosts.wait_until_element(
+                        common_locators['notif.success']))
+        super(Host, self).tearDown()
+
+    def test_create_host_on_libvirt(self):
+        """@Test: Create a new Host on libvirt compute resource
+
+        @Feature: Host - Positive create
+
+        @Assert: Host is created
+
+        """
+        resource = '{0} (Libvirt)'.format(self.computeresource.name)
+        root_pwd = gen_string("alpha", 15)
+        with Session(self.browser) as session:
+            session.nav.go_to_select_org(self.org_name)
+            self.navigator.go_to_hosts()
+            self.hosts.create(
+                name=self.hostname,
+                loc=self.loc_name,
+                host_group=self.host_group.name,
+                resource=resource,
+                root_pwd=root_pwd,
+                memory="1 GB",
+                network_type="Virtual (NAT)",
+            )
+            self.scroll_page()
+            self.navigator.go_to_hosts()
+            search = self.hosts.search(
+                u'{0}.{1}'.format(self.hostname, self.domain_name)
+            )
+            self.assertIsNotNone(search)
 
     def test_create_host(self):
         """@Test: Create a new Host


### PR DESCRIPTION
- Added support to select network and network-type while creating host
- Implemented setUpClass for setting up libvirt provisioning via api
- Implemented a test to create host on libvirt
- Implemented teardown method to remove the host

Note: For now, I'm removing the host immediately after host creation. We can wait for host to come-up under content host and try package install tests via UI or other operations. However, I'm leaving that for next PR.