### PR TITLE
Enable skipping downstream test cases only:

### DIFF
--- a/robottelo.properties.sample
+++ b/robottelo.properties.sample
@@ -26,6 +26,8 @@ project=sat
 locale=en_US.UTF-8
 remote=0
 smoke=0
+# Update upstream=0 for downstream run
+upstream=1
 
 # For testing with fake manifests, zipfile containing valid manifest is required,
 # as well as key/cert pair. All of these settings are urls.

--- a/robottelo/constants.py
+++ b/robottelo/constants.py
@@ -3,6 +3,19 @@
 Defines various constants
 """
 
+# Bugzilla
+BZ_OPEN_STATUSES = [
+    'NEW',
+    'ASSIGNED',
+    'POST',
+    'MODIFIED'
+]
+BZ_CLOSED_STATUSES = [
+    'ON_QA',
+    'VERIFIED',
+    'RELEASE_PENDING',
+    'CLOSED'
+]
 ROBOTTELO_PROPERTIES = "robottelo.properties"
 
 FOREMAN_PROVIDERS = {


### PR DESCRIPTION
Proposed process:
1. Update 'Verified in Upstream' in Bugzilla Whiteboard field when bug is verified in upstream
2. Skip downstream tests even though they are in closed status if Whiteboard field has the expected text

Closed #2772