### PR TITLE
CLI: Move SSHCommandResult processing to Base class

### DIFF
--- a/robottelo/cli/base.py
+++ b/robottelo/cli/base.py
@@ -1,26 +1,32 @@
 # -*- encoding: utf-8 -*-
 """Generic base class for cli hammer commands."""
 import logging
-import re
 
 from robottelo import ssh
 from robottelo.cli import hammer
 from robottelo.config import conf
 
 
-# Task status message have two formats:
-#   * "Task b18d3363-f4b8-44eb-871c-760e51444d22 success: 1.0/1, 100%,
-#     elapsed: 00:00:02\n"
-#   * "Task 6ba9d82a-ea55-4934-8aab-0e057102ee11 running: 0.005/1, 0%, 0.0/s,
-#     elapsed: 00:00:02, ETA: 00:06:55\n"
-TASK_STATUS_REGEX = re.compile(
-    r'Task [\w-]+ \w+: [\d./]+, \d+%,( [\d./s]+,)? elapsed: [\d:]+'
-    '(, ETA: [\d:]+)?\n\n?'
-)
-
-
 class CLIError(Exception):
     """Indicates that a CLI command could not be run."""
+
+
+class CLIReturnCodeError(Exception):
+    """Indicates that a CLI command has finished with return code, different
+    from zero.
+
+    :param return_code: CLI command return code
+    :param stderr: contents of the ``stderr``
+    :param msg: explanation of the error
+
+    """
+    def __init__(self, return_code, stderr, msg):
+        self.return_code = return_code
+        self.stderr = stderr
+        self.msg = msg
+
+    def __str__(self):
+        return self.msg
 
 
 class Base(object):
@@ -86,6 +92,40 @@ class Base(object):
     logger = logging.getLogger('robottelo')
 
     @classmethod
+    def _handle_response(cls, response, ignore_stderr=None):
+        """Verify ``return_code`` of the CLI command.
+
+        Check for a non-zero return code or any stderr contents.
+
+        :param response: a ``SSHCommandResult`` object, returned by
+            :mod:`robottelo.ssh.command`.
+        :param ignore_stderr: indicates whether to throw a warning in logs if
+            ``stderr`` is not empty.
+        :returns: contents of ``stdout``.
+        :raises robottelo.cli.base.CLIReturnCodeError: If return code is
+            different from zero.
+        """
+        if response.return_code != 0:
+            raise CLIReturnCodeError(
+                response.return_code,
+                response.stderr,
+                "Command '{0} {1}' finished with return_code {2}\n"
+                "stderr contains following message:\n{3}"
+                .format(
+                    cls.command_base,
+                    cls.command_sub,
+                    response.return_code,
+                    response.stderr,
+                )
+            )
+        if len(response.stderr) != 0 and not ignore_stderr:
+            cls.logger.warning(
+                'stderr contains following message:\n{0}'
+                .format(response.stderr)
+            )
+        return response.stdout
+
+    @classmethod
     def add_operating_system(cls, options=None):
         """
         Adds OS to record.
@@ -112,8 +152,8 @@ class Base(object):
             cls._construct_command(options), output_format='csv')
 
         # Extract new object ID if it was successfully created
-        if len(result.stdout) > 0 and 'id' in result.stdout[0]:
-            obj_id = result.stdout[0]['id']
+        if len(result) > 0 and 'id' in result[0]:
+            obj_id = result[0]['id']
 
             # Fetch new object
             # Some Katello obj require the organization-id for subcommands
@@ -128,8 +168,8 @@ class Base(object):
 
             new_obj = cls.info(info_options)
             # stdout should be a dictionary containing the object
-            if len(new_obj.stdout) > 0:
-                result.stdout = new_obj.stdout
+            if len(new_obj) > 0:
+                result = new_obj
 
         return result
 
@@ -137,8 +177,10 @@ class Base(object):
     def delete(cls, options=None):
         """Deletes existing record."""
         cls.command_sub = 'delete'
-        return cls._remove_task_status(
-            cls.execute(cls._construct_command(options)))
+        return cls.execute(
+            cls._construct_command(options),
+            ignore_stderr=True,
+        )
 
     @classmethod
     def delete_parameter(cls, options=None):
@@ -192,7 +234,7 @@ class Base(object):
 
     @classmethod
     def execute(cls, command, user=None, password=None, output_format=None,
-                timeout=None):
+                timeout=None, ignore_stderr=None, return_raw_response=None):
         """Executes the cli ``command`` on the server via ssh"""
         user, password = cls._get_username_password(user, password)
 
@@ -206,9 +248,18 @@ class Base(object):
             u'--output={0}'.format(output_format) if output_format else u'',
             command,
         )
-
-        return ssh.command(
-            cmd.encode('utf-8'), output_format=output_format, timeout=timeout)
+        response = ssh.command(
+            cmd.encode('utf-8'),
+            output_format=output_format,
+            timeout=timeout,
+        )
+        if return_raw_response:
+            return response
+        else:
+            return cls._handle_response(
+                response,
+                ignore_stderr=ignore_stderr,
+            )
 
     @classmethod
     def exists(cls, options=None, search=None):
@@ -231,8 +282,8 @@ class Base(object):
 
         result = cls.list(options)
 
-        if result.stdout:
-            result.stdout = result.stdout[0]
+        if result:
+            result = result[0]
 
         return result
 
@@ -251,7 +302,7 @@ class Base(object):
             )
 
         result = cls.execute(cls._construct_command(options))
-        result.stdout = hammer.parse_info(result.stdout)
+        result = hammer.parse_info(result)
         return result
 
     @classmethod
@@ -387,13 +438,3 @@ class Base(object):
         )
 
         return cmd
-
-    @classmethod
-    def _remove_task_status(cls, result):
-        """Remove all task status entries from the stderr if command return
-        code is 0.
-
-        """
-        if result.return_code == 0:
-            result.stderr = TASK_STATUS_REGEX.sub('', result.stderr)
-        return result

--- a/robottelo/cli/contentview.py
+++ b/robottelo/cli/contentview.py
@@ -62,8 +62,11 @@ class ContentView(Base):
         # Publishing can take a while so try to wait a bit longer
         if timeout is None:
             timeout = 120
-        return cls._remove_task_status(
-            cls.execute(cls._construct_command(options), timeout=timeout))
+        return cls.execute(
+            cls._construct_command(options),
+            ignore_stderr=True,
+            timeout=timeout,
+        )
 
     @classmethod
     def version_info(cls, options):
@@ -73,9 +76,7 @@ class ContentView(Base):
         if options is None:
             options = {}
 
-        result = cls.execute(cls._construct_command(options))
-        result.stdout = hammer.parse_info(result.stdout)
-        return result
+        return hammer.parse_info(cls.execute(cls._construct_command(options)))
 
     @classmethod
     def version_incremental_update(cls, options):
@@ -103,9 +104,7 @@ class ContentView(Base):
         if options is None:
             options = {}
 
-        result = cls.execute(cls._construct_command(options))
-        result.stdout = hammer.parse_info(result.stdout)
-        return result
+        return hammer.parse_info(cls.execute(cls._construct_command(options)))
 
     @classmethod
     def filter_info(cls, options):
@@ -116,9 +115,7 @@ class ContentView(Base):
         if options is None:
             options = {}
 
-        result = cls.execute(cls._construct_command(options))
-        result.stdout = hammer.parse_info(result.stdout)
-        return result
+        return hammer.parse_info(cls.execute(cls._construct_command(options)))
 
     @classmethod
     def filter_create(cls, options):
@@ -241,22 +238,28 @@ class ContentView(Base):
     def version_promote(cls, options):
         """Promotes content-view version to next env."""
         cls.command_sub = 'version promote'
-        return cls._remove_task_status(
-            cls.execute(cls._construct_command(options)))
+        return cls.execute(
+            cls._construct_command(options),
+            ignore_stderr=True,
+        )
 
     @classmethod
     def version_delete(cls, options):
         """Removes content-view version."""
         cls.command_sub = 'version delete'
-        return cls._remove_task_status(
-            cls.execute(cls._construct_command(options)))
+        return cls.execute(
+            cls._construct_command(options),
+            ignore_stderr=True,
+        )
 
     @classmethod
     def remove_from_environment(cls, options=None):
-        """Remove content-view from an enviornment"""
+        """Remove content-view from an environment"""
         cls.command_sub = 'remove-from-environment'
-        return cls._remove_task_status(
-            cls.execute(cls._construct_command(options)))
+        return cls.execute(
+            cls._construct_command(options),
+            ignore_stderr=True,
+        )
 
     @classmethod
     def remove(cls, options=None):
@@ -265,5 +268,7 @@ class ContentView(Base):
 
         """
         cls.command_sub = 'remove'
-        return cls._remove_task_status(
-            cls.execute(cls._construct_command(options)))
+        return cls.execute(
+            cls._construct_command(options),
+            ignore_stderr=True,
+        )

--- a/robottelo/cli/gpgkey.py
+++ b/robottelo/cli/gpgkey.py
@@ -44,20 +44,19 @@ class GPGKey(Base):
         # First check for content key
         # id, name, content, organization, repositories
 
-        if len(result.stdout) > 0:
-            key_record = {}
+        if len(result) > 0:
 
             # First item should contain most fields
-            key_record = result.stdout.pop(0)
+            key_record = result.pop(0)
             if 'organization' not in key_record:
                 raise ValueError('Could not find GPG Key')
 
             # Remaining items belong to content
 
-            for item in result.stdout:
+            for item in result:
                 for _, val in item.items():
                     key_record['content'] += val
-            # Update stdout with dictionary
-            result.stdout = key_record
+            # Update result with dictionary
+            result = key_record
 
         return result

--- a/robottelo/cli/host.py
+++ b/robottelo/cli/host.py
@@ -64,8 +64,8 @@ class Host(Base):
 
         facts = []
 
-        if result.stdout:
-            facts = result.stdout
+        if result:
+            facts = result
 
         return facts
 
@@ -134,8 +134,8 @@ class Host(Base):
 
         reports = []
 
-        if result.stdout:
-            reports = result.stdout
+        if result:
+            reports = result
 
         return reports
 

--- a/robottelo/cli/import_.py
+++ b/robottelo/cli/import_.py
@@ -90,7 +90,8 @@ class Import(Base):
         cls.command_sub = 'activation-key'
         return cls.execute(
             cls._construct_command(options),
-            output_format='csv'
+            output_format='csv',
+            return_raw_response=True,
         )
 
     @classmethod
@@ -99,7 +100,8 @@ class Import(Base):
         cls.command_sub = 'organization'
         return cls.execute(
             cls._construct_command(options),
-            output_format=''
+            output_format='',
+            return_raw_response=True,
         )
 
     @classmethod
@@ -108,7 +110,8 @@ class Import(Base):
         cls.command_sub = 'user'
         return cls.execute(
             cls._construct_command(options),
-            output_format=''
+            output_format='',
+            return_raw_response=True,
         )
 
     @classmethod
@@ -117,7 +120,8 @@ class Import(Base):
         cls.command_sub = 'host-collection'
         return cls.execute(
             cls._construct_command(options),
-            output_format=''
+            output_format='',
+            return_raw_response=True,
         )
 
     @classmethod
@@ -129,7 +133,8 @@ class Import(Base):
         cls.command_sub = 'config-file'
         return cls.execute(
             cls._construct_command(options),
-            output_format=''
+            output_format='',
+            return_raw_response=True,
         )
 
     @classmethod
@@ -138,7 +143,8 @@ class Import(Base):
         cls.command_sub = 'content-host'
         return cls.execute(
             cls._construct_command(options),
-            output_format=''
+            output_format='',
+            return_raw_response=True,
         )
 
     @classmethod
@@ -150,7 +156,8 @@ class Import(Base):
         cls.command_sub = 'content-view'
         return cls.execute(
             cls._construct_command(options),
-            output_format=''
+            output_format='',
+            return_raw_response=True,
         )
 
     @classmethod
@@ -159,7 +166,8 @@ class Import(Base):
         cls.command_sub = 'repository'
         return cls.execute(
             cls._construct_command(options),
-            output_format=''
+            output_format='',
+            return_raw_response=True,
         )
 
     @classmethod
@@ -171,7 +179,8 @@ class Import(Base):
         cls.command_sub = 'repository-enable'
         return cls.execute(
             cls._construct_command(options),
-            output_format=''
+            output_format='',
+            return_raw_response=True,
         )
 
     @classmethod
@@ -183,7 +192,8 @@ class Import(Base):
         cls.command_sub = 'template-snippet'
         return cls.execute(
             cls._construct_command(options),
-            output_format=''
+            output_format='',
+            return_raw_response=True,
         )
 
     @classmethod
@@ -195,7 +205,8 @@ class Import(Base):
         cls.command_sub = 'all'
         return cls.execute(
             cls._construct_command(options),
-            output_format=''
+            output_format='',
+            return_raw_response=True,
         )
 
     @classmethod

--- a/robottelo/cli/product.py
+++ b/robottelo/cli/product.py
@@ -60,5 +60,7 @@ class Product(Base):
     def synchronize(cls, options=None):
         """Synchronize a product."""
         cls.command_sub = 'synchronize'
-        return cls._remove_task_status(
-            cls.execute(cls._construct_command(options)))
+        return cls.execute(
+            cls._construct_command(options),
+            ignore_stderr=True,
+        )

--- a/robottelo/cli/repository.py
+++ b/robottelo/cli/repository.py
@@ -56,13 +56,18 @@ class Repository(Base):
     def synchronize(cls, options):
         """Synchronizes a repository."""
         cls.command_sub = 'synchronize'
-        return cls._remove_task_status(
-            cls.execute(cls._construct_command(options), output_format='csv'))
+        return cls.execute(
+            cls._construct_command(options),
+            output_format='csv',
+            ignore_stderr=True,
+        )
 
     @classmethod
     def upload_content(cls, options):
         """Upload content to repository."""
         cls.command_sub = 'upload-content'
-        result = cls.execute(
-            cls._construct_command(options), output_format='csv')
-        return result
+        return cls.execute(
+            cls._construct_command(options),
+            output_format='csv',
+            ignore_stderr=True,
+        )

--- a/robottelo/cli/subscription.py
+++ b/robottelo/cli/subscription.py
@@ -34,22 +34,28 @@ class Subscription(Base):
     def upload(cls, options=None):
         """Upload a subscription manifest."""
         cls.command_sub = 'upload'
-        return cls._remove_task_status(
-            cls.execute(cls._construct_command(options)))
+        return cls.execute(
+            cls._construct_command(options),
+            ignore_stderr=True,
+        )
 
     @classmethod
     def delete_manifest(cls, options=None):
         """Deletes a subscription manifest."""
         cls.command_sub = 'delete-manifest'
-        return cls._remove_task_status(
-            cls.execute(cls._construct_command(options)))
+        return cls.execute(
+            cls._construct_command(options),
+            ignore_stderr=True,
+        )
 
     @classmethod
     def refresh_manifest(cls, options=None):
         """Refreshes a subscription manifest."""
         cls.command_sub = 'refresh-manifest'
-        return cls._remove_task_status(
-            cls.execute(cls._construct_command(options)))
+        return cls.execute(
+            cls._construct_command(options),
+            ignore_stderr=True,
+        )
 
     @classmethod
     def manifest_history(cls, options=None):

--- a/robottelo/cli/template.py
+++ b/robottelo/cli/template.py
@@ -45,8 +45,8 @@ class Template(Base):
 
         kinds = []
 
-        if result.stdout:
-            kinds = result.stdout
+        if result:
+            kinds = result
 
         return kinds
 

--- a/tests/robottelo/test_cli.py
+++ b/tests/robottelo/test_cli.py
@@ -2,7 +2,6 @@ import unittest
 
 from robottelo.cli.base import Base
 from robottelo.config import conf
-from robottelo.ssh import SSHCommandResult
 
 
 class CLIClass(Base):
@@ -69,23 +68,3 @@ class BaseCliTestCase(unittest.TestCase):
         self.assertEqual(new_class.foreman_admin_username, 'auser')
         self.assertEqual(new_class.foreman_admin_password, 'apass')
         self.assertIn(Base, new_class.__bases__)
-
-    def test_remove_task_status(self):
-        """Check if ``_remove_task_status`` method cleans the expected task
-        status messages.
-
-        """
-        data = (
-            u'Task 3af6fec3-2b7d-4e8a-93a4-082509e203fc running: 0.005/1, 0%, '
-            '0.0/s, elapsed: 00:00:02, ETA: 00:07:34\nTask '
-            '3af6fec3-2b7d-4e8a-93a4-082509e203fc success: 1.0/1, 100%, '
-            '0.1/s, elapsed: 00:00:11\nTask '
-            '3af6fec3-2b7d-4e8a-93a4-082509e203fc success: 1.0/1, 100%, '
-            '0.1/s, elapsed: 00:00:11\nTask '
-            '6ba9d82a-ea55-4934-8aab-0e057102ee11 running: 0.005/1, 0%, '
-            '0.0/s, elapsed: 00:00:02, ETA: 00:06:55\nTask '
-            '6ba9d82a-ea55-4934-8aab-0e057102ee11 running: 0.005/1, 0%, '
-            '0.0/s, elapsed: 00:00:02, ETA: 00:06:55\n\n'
-        )
-        result = SSHCommandResult(stderr=data, return_code=0)
-        self.assertEqual(Base._remove_task_status(result).stderr, '')


### PR DESCRIPTION
Core part of #2776

* Added new exception - `CLIReturnCodeError` which contains return_code, stderr and msg (message).
* Created `Base._handle_response()` func which checks `return_code` and raises `CLIReturnCodeError` if needed. Returns `stdout`.
* Injected `Base._handle_response()` in `Base.execute()` (that's the easiest place to inject, no existing commands won't be affected and nothing should be rewritten)
* By default, all CLI commands running with `Base.execute()` will be wrapped by `Base._handle_response()`, if raw response is needed, `Base.execute()` now accepts optional parameter `return_raw_response`.
* Removed `Base._remove_task_status()` in favour of `Base._handle_response()` `ignore_stderr` argument.