### PR TITLE
Switch to unittest2. Refactor one module of tests.

### DIFF
--- a/robottelo/cli/metatest/__init__.py
+++ b/robottelo/cli/metatest/__init__.py
@@ -37,7 +37,7 @@ class MetaCLITest(type):
             MetaCLITest, cls).__new__(cls, name, bases, attributes)
 
         # When loading test classes for a test run, the Nose class
-        # loader "transplants" any class that inherits from unittest.TestCase
+        # loader "transplants" any class that inherits from unittest2.TestCase
         # into an internal class "C". If your test class uses MetaCLI,
         # then it will automatically also inherit from BaseCLI and
         # Nose will automatically see a new "C". We want to ignore

--- a/robottelo/decorators.py
+++ b/robottelo/decorators.py
@@ -5,7 +5,7 @@ import bugzilla
 import logging
 import random
 import requests
-import unittest
+import unittest2
 
 from ddt import data as ddt_data
 from functools import wraps
@@ -54,7 +54,7 @@ def stubbed(reason=None):
     # Assume 'not implemented' if no reason is given
     if reason is None:
         reason = NOT_IMPLEMENTED
-    return unittest.skip(reason)
+    return unittest2.skip(reason)
 
 
 def cacheable(func):
@@ -118,7 +118,7 @@ def run_only_on(project):
             # test code continues here
 
     :param str project: Enter 'sat' for Satellite and 'sam' for SAM
-    :returns: ``unittest.skipIf``
+    :returns: ``unittest2.skipIf``
     :raises: :meth:`ProjectModeError` if invalid `project` is given or invalid
         mode is specified in ``robottelo.properties`` file
 
@@ -144,7 +144,7 @@ def run_only_on(project):
         )
 
     # Preconditions PASS.  Now skip the test if modes does not match
-    return unittest.skipIf(
+    return unittest2.skipIf(
         project != robottelo_mode,
         'Server runs in "{0}" mode and this test will run '
         'only on "{1}" mode.'.format(robottelo_mode, project))
@@ -155,7 +155,7 @@ def skipRemote(func):  # noqa
     Remote in the sense whether it is Sauce Labs"""
 
     remote = int(conf.properties['main.remote'])
-    return unittest.skipIf(
+    return unittest2.skipIf(
         remote == 1,
         "Skipping as setup related to sauce labs is missing")(func)
 
@@ -343,7 +343,7 @@ class skip_if_bug_open(object):  # noqa pylint:disable=C0103,R0903
             open, skip test ``func``. Otherwise, run the test.
 
             :return: The return value of test method ``func``.
-            :raises unittest.SkipTest: If bug ``bug_id`` is open.
+            :raises unittest2.SkipTest: If bug ``bug_id`` is open.
             :raises BugTypeError: If ``bug_type`` is not recognized.
 
             """
@@ -359,7 +359,7 @@ class skip_if_bug_open(object):  # noqa pylint:disable=C0103,R0903
                     func.__module__,
                     self.bug_id
                 )
-                raise unittest.SkipTest(
+                raise unittest2.SkipTest(
                     'Skipping test due to open Bugzilla bug #{0}.'
                     ''.format(self.bug_id)
                 )
@@ -370,7 +370,7 @@ class skip_if_bug_open(object):  # noqa pylint:disable=C0103,R0903
                     func.__module__,
                     self.bug_id
                 )
-                raise unittest.SkipTest(
+                raise unittest2.SkipTest(
                     'Skipping test due to open Redmine bug #{0}.'
                     ''.format(self.bug_id)
                 )

--- a/robottelo/test.py
+++ b/robottelo/test.py
@@ -9,7 +9,7 @@ import logging
 import os
 import signal
 import sys
-import unittest
+import unittest2
 
 from datetime import datetime
 from robottelo import ssh
@@ -81,7 +81,7 @@ from selenium_factory.SeleniumFactory import SeleniumFactory
 SAUCE_URL = "http://%s:%s@ondemand.saucelabs.com:80/wd/hub"
 
 
-class TestCase(unittest.TestCase):
+class TestCase(unittest2.TestCase):
     """Robottelo test case"""
 
     @classmethod

--- a/setup.py
+++ b/setup.py
@@ -27,6 +27,7 @@ setup(
         'python-bugzilla',
         'requests',
         'selenium',
+        'unittest2',
     ],
     license='GNU GPL v3.0',
     # See https://pypi.python.org/pypi?%3Aaction=list_classifiers

--- a/tests/foreman/api/test_repository.py
+++ b/tests/foreman/api/test_repository.py
@@ -31,7 +31,7 @@ from robottelo.helpers import (
 from robottelo.test import APITestCase
 
 
-# FIXME: Use unittest's subTest context manager instead of this and @ddt.data.
+# FIXME: Use unittest2's subTest context manager instead of this and @ddt.data.
 # Only available in Python 3.2 and above.
 def _test_data():
     """Return a tuple of dicts. The dicts can be used to make products."""

--- a/tests/foreman/cli/test_contentviews.py
+++ b/tests/foreman/cli/test_contentviews.py
@@ -1,7 +1,7 @@
 # -*- encoding: utf-8 -*-
 """Test class for Content Views"""
 import random
-import unittest
+import unittest2
 
 from ddt import ddt
 from fauxfactory import gen_alphanumeric, gen_string
@@ -233,7 +233,7 @@ class TestContentView(CLITestCase):
         self.assertEqual(result.return_code, 0)
         self.assertEqual(result.stdout['name'], new_name)
 
-    @unittest.skip(NOT_IMPLEMENTED)
+    @unittest2.skip(NOT_IMPLEMENTED)
     def test_cv_edit_rh_custom_spin(self):
         # Variations might be:
         #   * A filter on errata date (only content that matches date
@@ -1136,7 +1136,7 @@ class TestContentView(CLITestCase):
         }
         self.assertIn(environment, result.stdout['lifecycle-environments'])
 
-    @unittest.skip(NOT_IMPLEMENTED)
+    @unittest2.skip(NOT_IMPLEMENTED)
     def test_cv_promote_rh_custom_spin(self):
         """@test: attempt to promote a content view containing a custom RH
         spin - i.e., contains filters.
@@ -1450,7 +1450,7 @@ class TestContentView(CLITestCase):
             'Publishing new version of CV was not successful'
         )
 
-    @unittest.skip(NOT_IMPLEMENTED)
+    @unittest2.skip(NOT_IMPLEMENTED)
     def test_cv_publish_rh_custom_spin(self):
         """@test: attempt to publish  a content view containing a custom RH
         spin - i.e., contains filters.
@@ -2239,7 +2239,7 @@ class TestContentView(CLITestCase):
         self.assertEqual(result.return_code, 0)
         self.assertEqual(result.stdout['content-host-count'], '1')
 
-    @unittest.skip(NOT_IMPLEMENTED)
+    @unittest2.skip(NOT_IMPLEMENTED)
     def test_cv_clone_within_same_env(self):
         # Dev note: "not implemented yet"
         """@test: attempt to create new content view based on existing
@@ -2252,7 +2252,7 @@ class TestContentView(CLITestCase):
 
         """
 
-    @unittest.skip(NOT_IMPLEMENTED)
+    @unittest2.skip(NOT_IMPLEMENTED)
     def test_cv_clone_within_diff_env(self):
         # Dev note: "not implemented yet"
         """@test: attempt to create new content view based on existing
@@ -2266,7 +2266,7 @@ class TestContentView(CLITestCase):
 
         """
 
-    @unittest.skip(NOT_IMPLEMENTED)
+    @unittest2.skip(NOT_IMPLEMENTED)
     def test_cv_refresh_errata_to_new_view_in_same_env(self):
         """@test: attempt to refresh errata in a new view, based on
         an existing view, from within the same  environment
@@ -2279,7 +2279,7 @@ class TestContentView(CLITestCase):
 
         """
 
-    @unittest.skip(NOT_IMPLEMENTED)
+    @unittest2.skip(NOT_IMPLEMENTED)
     def test_cv_dynflow_restart_promote(self):
         """@test: attempt to restart a promotion
 
@@ -2295,7 +2295,7 @@ class TestContentView(CLITestCase):
 
         """
 
-    @unittest.skip(NOT_IMPLEMENTED)
+    @unittest2.skip(NOT_IMPLEMENTED)
     def test_cv_dynflow_restart_publish(self):
         """@test: attempt to restart a publish
 

--- a/tests/foreman/longrun/test_inc_updates.py
+++ b/tests/foreman/longrun/test_inc_updates.py
@@ -16,7 +16,7 @@ from robottelo.cli.contentview import ContentView as ContentViewCLI
 from robottelo.constants import PRD_SETS
 from robottelo.decorators import run_only_on, skip_if_bug_open
 from robottelo.vm import VirtualMachine
-from unittest import TestCase
+from unittest2 import TestCase
 
 
 @run_only_on('sat')

--- a/tests/foreman/smoke/test_api_smoke.py
+++ b/tests/foreman/smoke/test_api_smoke.py
@@ -25,7 +25,7 @@ from robottelo.constants import (
 from robottelo.decorators import bz_bug_is_open, skip_if_bug_open
 from robottelo.helpers import get_nailgun_config
 from robottelo.vm import VirtualMachine
-from unittest import TestCase
+from unittest2 import TestCase
 # (too many public methods) pylint: disable=R0904
 
 API_PATHS = {

--- a/tests/robottelo/test_api_utils.py
+++ b/tests/robottelo/test_api_utils.py
@@ -1,6 +1,6 @@
 """Unit tests for :mod:`robottelo.api.utils`."""
 from robottelo.api import utils
-from unittest import TestCase
+from unittest2 import TestCase
 
 
 class UtilsTestCase(TestCase):

--- a/tests/robottelo/test_cli.py
+++ b/tests/robottelo/test_cli.py
@@ -1,4 +1,4 @@
-import unittest
+import unittest2
 
 from robottelo.cli.base import Base
 from robottelo.config import conf
@@ -11,7 +11,7 @@ class CLIClass(Base):
     foreman_admin_password = 'adminpassword'
 
 
-class BaseCliTestCase(unittest.TestCase):
+class BaseCliTestCase(unittest2.TestCase):
     """Tests for the Base cli class"""
     def setUp(self):  # noqa
         super(BaseCliTestCase, self).setUp()

--- a/tests/robottelo/test_decorators.py
+++ b/tests/robottelo/test_decorators.py
@@ -4,7 +4,7 @@ from fauxfactory import gen_integer
 from robottelo import decorators
 from robottelo.config import conf
 from robottelo.constants import BZ_CLOSED_STATUSES, BZ_OPEN_STATUSES
-from unittest import TestCase
+from unittest2 import TestCase
 # (Too many public methods) pylint: disable=R0904
 
 

--- a/tests/robottelo/test_hammer.py
+++ b/tests/robottelo/test_hammer.py
@@ -1,11 +1,11 @@
 # -*- encoding: utf-8 -*-
 """Tests for Robottelo's hammer helpers"""
-import unittest
+import unittest2
 
 from robottelo.cli import hammer
 
 
-class ParseCSVTestCase(unittest.TestCase):
+class ParseCSVTestCase(unittest2.TestCase):
     """Tests for parsing CSV hammer output"""
     def test_parse_csv(self):
         output_lines = [
@@ -38,7 +38,7 @@ class ParseCSVTestCase(unittest.TestCase):
         )
 
 
-class ParseHelpTestCase(unittest.TestCase):
+class ParseHelpTestCase(unittest2.TestCase):
     """Tests for parsing hammer help output"""
     def test_parse_help(self):
         """Can parse hammer help output"""
@@ -152,7 +152,7 @@ class ParseHelpTestCase(unittest.TestCase):
         )
 
 
-class ParseInfoTestCase(unittest.TestCase):
+class ParseInfoTestCase(unittest2.TestCase):
     """Tests for parsing info hammer output"""
     def test_parse_simple(self):
         """Can parse a simple info output"""

--- a/tests/robottelo/test_helpers.py
+++ b/tests/robottelo/test_helpers.py
@@ -1,7 +1,7 @@
 """Tests for module ``robottelo.helpers``."""
 # (Too many public methods) pylint: disable=R0904
 import mock
-import unittest
+import unittest2
 
 from robottelo.config import conf
 from robottelo.helpers import (
@@ -17,7 +17,7 @@ from robottelo.helpers import (
 )
 
 
-class GetServerURLTestCase(unittest.TestCase):
+class GetServerURLTestCase(unittest2.TestCase):
     """Tests for method ``get_server_url``.
 
     The methods in this class test ``get_server_url`` by setting different
@@ -89,7 +89,7 @@ class GetServerURLTestCase(unittest.TestCase):
         self.assertEqual(get_server_url(), 'telnet://example.com:1234')
 
 
-class GetServerCredentialsTestCase(unittest.TestCase):
+class GetServerCredentialsTestCase(unittest2.TestCase):
     """Tests for method ``get_server_credentials``."""
     def setUp(self):  # noqa pylint:disable=C0103
         """Back up and customize ``conf.properties``."""
@@ -118,7 +118,7 @@ class GetServerCredentialsTestCase(unittest.TestCase):
             get_server_credentials()
 
 
-class GetHostInfoTestCase(unittest.TestCase):
+class GetHostInfoTestCase(unittest2.TestCase):
     """Tests for method ``get_host_credentials``."""
 
     @mock.patch('robottelo.helpers.ssh')
@@ -167,35 +167,35 @@ class FakeSSHResult(object):
         self.return_code = return_code
 
 
-class ValidNamesListTestCase(unittest.TestCase):
+class ValidNamesListTestCase(unittest2.TestCase):
     def test_return_type(self):
         """Tests if valid names list returns a unicode string"""
         for name in valid_names_list():
             self.assertIsInstance(name, unicode)
 
 
-class ValidDataListTestCase(unittest.TestCase):
+class ValidDataListTestCase(unittest2.TestCase):
     def test_return_type(self):
         """Tests if valid data list returns a unicode string"""
         for data in valid_data_list():
             self.assertIsInstance(data, unicode)
 
 
-class InvalidNamesListTestCase(unittest.TestCase):
+class InvalidNamesListTestCase(unittest2.TestCase):
     def test_return_type(self):
         """Tests if invalid names list returns a unicode string"""
         for name in invalid_names_list():
             self.assertIsInstance(name, unicode)
 
 
-class GenerateStringListTestCase(unittest.TestCase):
+class GenerateStringListTestCase(unittest2.TestCase):
     def test_return_type(self):
         """Tests if generate string list returns a unicode string"""
         for string in generate_strings_list():
             self.assertIsInstance(string, unicode)
 
 
-class EscapeSearchTestCase(unittest.TestCase):
+class EscapeSearchTestCase(unittest2.TestCase):
     def test_return_type(self):
         """Tests if escape search returns a unicode string"""
         self.assertIsInstance(escape_search('search term'), unicode)

--- a/tests/robottelo/test_ssh.py
+++ b/tests/robottelo/test_ssh.py
@@ -4,7 +4,7 @@ import os
 
 from robottelo import ssh
 from robottelo.config import conf, get_app_root
-from unittest import TestCase
+from unittest2 import TestCase
 
 
 class MockSSHClient(object):

--- a/tests/robottelo/test_vm.py
+++ b/tests/robottelo/test_vm.py
@@ -1,5 +1,5 @@
 """Tests for :mod:`robottelo.vm`."""
-import unittest
+import unittest2
 
 from mock import call, patch
 from robottelo import ssh
@@ -7,7 +7,7 @@ from robottelo.config import conf
 from robottelo.vm import VirtualMachine, VirtualMachineError
 
 
-class VirtualMachineTestCase(unittest.TestCase):
+class VirtualMachineTestCase(unittest2.TestCase):
     """Tests for :class:`robottelo.vm.VirtualMachine`."""
 
     provisioning_server = 'provisioning.example.com'


### PR DESCRIPTION
In the first commit, switch from unittest to unittest2. This appear to have no ill effects. In the second commit, update one module by dropping DDT. I've bundled these two commits together because the second commit serves as a proof that the changes in the first commit are sane.

Please make sure to review the individual commits.