### PR TITLE
Refactor several API tests

### DIFF
--- a/tests/foreman/api/test_activationkey.py
+++ b/tests/foreman/api/test_activationkey.py
@@ -5,21 +5,13 @@ from fauxfactory import gen_integer, gen_string
 from nailgun import client, entities
 from requests.exceptions import HTTPError
 from robottelo.decorators import rm_bug_is_open, skip_if_bug_open
-from robottelo.helpers import get_server_credentials
+from robottelo.helpers import get_server_credentials, valid_data_list
 from robottelo.test import APITestCase
 
 
 def _good_max_content_hosts():
     """Return a generator yielding valid ``max_content_hosts`` values."""
     return (gen_integer(*limits) for limits in ((1, 20), (10000, 20000)))
-
-
-def _good_names():
-    """Return a generator yielding valid ``name`` values."""
-    return (
-        gen_string(str_type)
-        for str_type in ('alpha', 'alphanumeric', 'cjk', 'latin1')
-    )
 
 
 def _bad_max_content_hosts():
@@ -68,7 +60,7 @@ class ActivationKeysTestCase(APITestCase):
         @Feature: ActivationKey
 
         """
-        for name in _good_names():
+        for name in valid_data_list():
             with self.subTest(name):
                 act_key = entities.ActivationKey(name=name).create()
                 self.assertEqual(name, act_key.name)
@@ -81,7 +73,7 @@ class ActivationKeysTestCase(APITestCase):
         @Feature: ActivationKey
 
         """
-        for desc in _good_names():  # yes, _good_names pulls double duty
+        for desc in valid_data_list():
             with self.subTest(desc):
                 act_key = entities.ActivationKey(description=desc).create()
                 self.assertEqual(desc, act_key.description)

--- a/tests/foreman/api/test_architecture.py
+++ b/tests/foreman/api/test_architecture.py
@@ -46,16 +46,9 @@ class ArchitectureTestCase(APITestCase):
         @Feature: Architecture
 
         """
-        # Create an architecture and an OS.
-        os_id = entities.OperatingSystem().create_json()['id']
-        arch_id = entities.Architecture(
-            operatingsystem=[os_id]
-        ).create_json()['id']
-
-        # Read back the architecture and verify its attributes.
-        arch_attrs = entities.Architecture(id=arch_id).read_json()
-        self.assertIn('operatingsystems', arch_attrs)
+        operating_sys = entities.OperatingSystem().create()
+        arch = entities.Architecture(operatingsystem=[operating_sys]).create()
         self.assertEqual(
-            [os_id],
-            [os['id'] for os in arch_attrs['operatingsystems']],
+            {operating_sys.id},
+            {os.id for os in arch.operatingsystem},
         )

--- a/tests/foreman/api/test_contentview.py
+++ b/tests/foreman/api/test_contentview.py
@@ -15,7 +15,7 @@ from robottelo.constants import (
     REPOSET,
 )
 from robottelo.decorators import bz_bug_is_open, run_only_on, stubbed
-from robottelo.helpers import get_data_file
+from robottelo.helpers import get_data_file, valid_data_list
 from robottelo.test import APITestCase
 
 
@@ -23,19 +23,6 @@ from robottelo.test import APITestCase
 # How many times should that be done? A higher number means a more interesting
 # but longer test.
 REPEAT = 3
-
-
-def _strings():
-    """Return a generator yielding various kinds of strings."""
-    return (gen_string(str_type) for str_type in (
-        'alpha',
-        'alphanumeric',
-        'cjk',
-        'html',
-        'latin1',
-        'numeric',
-        'utf8',
-    ))
 
 
 @run_only_on('sat')
@@ -259,7 +246,7 @@ class ContentViewCreateTestCase(APITestCase):
         @Feature: ContentView
 
         """
-        for name in _strings():
+        for name in valid_data_list():
             self.assertEqual(
                 entities.ContentView(name=name).create().name,
                 name
@@ -273,7 +260,7 @@ class ContentViewCreateTestCase(APITestCase):
         @Feature: ContentView
 
         """
-        for desc in _strings():
+        for desc in valid_data_list():
             self.assertEqual(
                 desc,
                 entities.ContentView(description=desc).create().description,

--- a/tests/foreman/api/test_contentviewfilter.py
+++ b/tests/foreman/api/test_contentviewfilter.py
@@ -12,36 +12,12 @@ from random import randint
 from requests.exceptions import HTTPError
 from robottelo.constants import DOCKER_REGISTRY_HUB
 from robottelo.decorators import run_only_on, skip_if_bug_open
-from robottelo.helpers import get_server_credentials
+from robottelo.helpers import (
+    get_server_credentials,
+    invalid_names_list,
+    valid_data_list,
+)
 from robottelo.test import APITestCase
-
-
-def _positive_data():
-    """Random data for positive creation."""
-    return (
-        gen_string('alphanumeric', randint(1, 255)),
-        gen_string('alpha', randint(1, 255)),
-        gen_string('cjk', randint(1, 85)),
-        gen_string('latin1', randint(1, 255)),
-        gen_string('numeric', randint(1, 255)),
-        gen_string('utf8', randint(1, 85)),
-        gen_string('html', randint(1, 85)),
-    )
-
-
-def _negative_data():
-    """Random data for negative creation."""
-    return (
-        '',
-        ' ',
-        gen_string('alphanumeric', 300),
-        gen_string('alpha', 300),
-        gen_string('cjk', 300),
-        gen_string('latin1', 300),
-        gen_string('numeric', 300),
-        gen_string('utf8', 300),
-        gen_string('html', 300),
-    )
 
 
 @run_only_on('sat')
@@ -122,7 +98,7 @@ class ContentViewFilterTestCase(APITestCase):
         @Feature: Content View Filter - Create
 
         """
-        for name in _positive_data():
+        for name in valid_data_list():
             with self.subTest(name):
                 cvf = entities.ErratumContentViewFilter(
                     content_view=self.content_view,
@@ -141,7 +117,7 @@ class ContentViewFilterTestCase(APITestCase):
         @Feature: Content View Filter - Create
 
         """
-        for name in _positive_data():
+        for name in valid_data_list():
             with self.subTest(name):
                 cvf = entities.PackageGroupContentViewFilter(
                     content_view=self.content_view,
@@ -160,7 +136,7 @@ class ContentViewFilterTestCase(APITestCase):
         @Feature: Content View Filter - Create
 
         """
-        for name in _positive_data():
+        for name in valid_data_list():
             with self.subTest(name):
                 cvf = entities.RPMContentViewFilter(
                     content_view=self.content_view,
@@ -196,7 +172,7 @@ class ContentViewFilterTestCase(APITestCase):
         @Feature: Content View Filter - Create
 
         """
-        for description in _positive_data():
+        for description in valid_data_list():
             with self.subTest(description):
                 cvf = entities.RPMContentViewFilter(
                     content_view=self.content_view,
@@ -276,7 +252,7 @@ class ContentViewFilterTestCase(APITestCase):
         @Feature: Content View Filter - Create
 
         """
-        for name in _negative_data():
+        for name in invalid_names_list():
             with self.subTest(name):
                 with self.assertRaises(HTTPError):
                     entities.RPMContentViewFilter(
@@ -353,7 +329,7 @@ class ContentViewFilterTestCase(APITestCase):
         cvf = entities.RPMContentViewFilter(
             content_view=self.content_view,
         ).create()
-        for name in _positive_data():
+        for name in valid_data_list():
             with self.subTest(name):
                 cvf.name = name
                 self.assertEqual(cvf.update(['name']).name, name)
@@ -370,7 +346,7 @@ class ContentViewFilterTestCase(APITestCase):
         cvf = entities.RPMContentViewFilter(
             content_view=self.content_view,
         ).create()
-        for desc in _positive_data():
+        for desc in valid_data_list():
             with self.subTest(desc):
                 cvf.description = desc
                 self.assertEqual(cvf.update(['description']).description, desc)
@@ -507,7 +483,7 @@ class ContentViewFilterTestCase(APITestCase):
         cvf = entities.RPMContentViewFilter(
             content_view=self.content_view,
         ).create()
-        for name in _negative_data():
+        for name in invalid_names_list():
             with self.subTest(name):
                 cvf.name = name
                 with self.assertRaises(HTTPError):

--- a/tests/foreman/api/test_discoveredhost.py
+++ b/tests/foreman/api/test_discoveredhost.py
@@ -3,6 +3,7 @@
 from fauxfactory import gen_string, gen_ipaddr, gen_mac
 from nailgun import entities
 from robottelo.decorators import run_only_on, stubbed
+from robottelo.helpers import valid_data_list
 from robottelo.test import APITestCase
 
 
@@ -29,14 +30,6 @@ def _create_discovered_host(name=None, ipaddress=None, discovery_bootif=None):
             u'discovery_bootif': discovery_bootif,
         }
     })
-
-
-def _valid_strings():
-    """Return a variety of strings for use in positive creation tests."""
-    return (
-        gen_string(str_type) for str_type in
-        ('alpha', 'alphanumeric', 'html', 'latin1', 'numeric', 'utf8')
-    )
 
 
 class Discovery(APITestCase):
@@ -112,7 +105,7 @@ class Discovery(APITestCase):
         @Assert: Host should be created successfully
 
         """
-        for name in _valid_strings():
+        for name in valid_data_list():
             with self.subTest(name):
                 host = _create_discovered_host(name)
                 host_name = 'mac{0}'.format(host['mac'].replace(':', ''))


### PR DESCRIPTION
Drop custom data generation functions from the following modules and use
functions from `robottelo.helpers` instead:

* `tests.foreman.api.test_activationkey`
* `tests.foreman.api.test_contentview`
* `tests.foreman.api.test_contentviewfilter`
* `tests.foreman.api.test_discoveredhost`

Also, call `create` instead of `create_json` in
`tests.foreman.api.test_architecture`.

Test results:

    $ nosetests tests/foreman/api/test_activationkey.py -m test_positive_create_
    ....
    ----------------------------------------------------------------------
    Ran 4 tests in 62.180s

    OK
    $ nosetests tests/foreman/api/test_architecture.py -m test_associate_with_os
    .
    ----------------------------------------------------------------------
    Ran 1 test in 0.941s

    OK
    $ nosetests tests/foreman/api/test_contentview.py:ContentViewCreateTestCase
    ...
    ----------------------------------------------------------------------
    Ran 3 tests in 47.201s

    OK
    $ nosetests tests/foreman/api/test_contentviewfilter.py
    ...........................S..
    ----------------------------------------------------------------------
    Ran 30 tests in 201.041s

    OK (SKIP=1)
    $ nosetests tests/foreman/api/test_discoveredhost.py
    SSSSSSSSSSSSSSS.
    ----------------------------------------------------------------------
    Ran 16 tests in 3.428s

    OK (SKIP=15)