### PR TITLE
Performance improvement in WebUI for delete-like operations

### DIFF
--- a/robottelo/ui/architecture.py
+++ b/robottelo/ui/architecture.py
@@ -26,17 +26,15 @@ class Architecture(Base):
     def search(self, name):
         """Searches existing architecture from UI"""
         Navigator(self.browser).go_to_architectures()
-        element = self.search_entity(name, locators['arch.arch_name'])
-        return element
+        return self.search_entity(name, locators['arch.arch_name'])
 
     def delete(self, name, really=True):
         """Delete existing architecture from UI"""
-
         self.delete_entity(
             name,
             really,
             locators['arch.arch_name'],
-            locators['arch.delete']
+            locators['arch.delete'],
         )
 
     def update(self, old_name, new_name=None, os_names=None,

--- a/robottelo/ui/computeprofile.py
+++ b/robottelo/ui/computeprofile.py
@@ -10,7 +10,6 @@ class ComputeProfile(Base):
     def search(self, name):
         """Search for existing compute profile from UI."""
         Navigator(self.browser).go_to_compute_profiles()
-        self.wait_for_ajax()
         return self.search_entity(name, locators['profile.select_name'])
 
     def select_resource(self, profile_name, res_name, res_type):

--- a/robottelo/ui/computeresource.py
+++ b/robottelo/ui/computeresource.py
@@ -117,9 +117,7 @@ class ComputeResource(Base):
     def search(self, name):
         """Searches existing compute resource from UI."""
         Navigator(self.browser).go_to_compute_resources()
-        self.wait_for_ajax()
-        element = self.search_entity(name, locators['resource.select_name'])
-        return element
+        return self.search_entity(name, locators['resource.select_name'])
 
     def update(self, name, newname=None, parameter_list=None,
                orgs=None, org_select=None, locations=None, loc_select=None):
@@ -147,5 +145,5 @@ class ComputeResource(Base):
             really,
             locators['resource.select_name'],
             locators['resource.delete'],
-            drop_locator=locators['resource.dropdown']
+            drop_locator=locators['resource.dropdown'],
         )

--- a/robottelo/ui/configgroups.py
+++ b/robottelo/ui/configgroups.py
@@ -31,7 +31,6 @@ class ConfigGroups(Base):
     def search(self, name):
         """Searches existing config-groups from UI"""
         Navigator(self.browser).go_to_config_groups()
-        self.wait_for_ajax()
         if len(name) <= 30:
             element = self.search_entity(
                 name, locators['config_groups.select_name'])
@@ -40,13 +39,12 @@ class ConfigGroups(Base):
                 name, common_locators['select_filtered_entity'])
         return element
 
-    def delete(self, name, really=True, drop_locator=None):
+    def delete(self, name, really=True):
         """Deletes the config-groups."""
-
         self.delete_entity(
             name,
             really,
             locators['config_groups.select_name'],
             locators['config_groups.delete'],
-            drop_locator=drop_locator,
+            drop_locator=locators['config_groups.dropdown'],
         )

--- a/robottelo/ui/discoveryrules.py
+++ b/robottelo/ui/discoveryrules.py
@@ -59,11 +59,9 @@ class DiscoveryRules(Base):
 
     def search(self, rule_name):
         """Searches existing discovery rule from UI"""
-        self.wait_for_ajax()
         Navigator(self.browser).go_to_discovery_rules()
         strategy, value = locators['discoveryrules.rule_name']
-        element = self.wait_until_element((strategy, value % rule_name))
-        return element
+        return self.wait_until_element((strategy, value % rule_name))
 
     def delete(self, rule_name, really=True):
         """Delete existing discovery rule from UI"""

--- a/robottelo/ui/domain.py
+++ b/robottelo/ui/domain.py
@@ -32,18 +32,15 @@ class Domain(Base):
                 'Could not create new domain "{0}"'.format(name)
             )
 
-    def search(self, description, timeout=None):
+    def search(self, description):
         """Searches existing domain from UI"""
         Navigator(self.browser).go_to_domains()
-        self.wait_for_ajax()
         if len(description) <= 30:
             element = self.search_entity(
-                description, locators['domain.domain_description'],
-                timeout=timeout)
+                description, locators['domain.domain_description'])
         else:
             element = self.search_entity(
-                description, common_locators['select_filtered_entity'],
-                timeout=timeout)
+                description, common_locators['select_filtered_entity'])
         return element
 
     def delete(self, description, really=True):
@@ -52,7 +49,7 @@ class Domain(Base):
             description,
             really,
             locators['domain.domain_description'],
-            locators['domain.delete']
+            locators['domain.delete'],
         )
 
     def update(self, old_description, new_name=None, description=None,

--- a/robottelo/ui/environment.py
+++ b/robottelo/ui/environment.py
@@ -55,5 +55,5 @@ class Environment(Base):
             really,
             locators['env.env_name'],
             locators['env.delete'],
-            drop_locator=locators['env.dropdown']
+            drop_locator=locators['env.dropdown'],
         )

--- a/robottelo/ui/gpgkey.py
+++ b/robottelo/ui/gpgkey.py
@@ -41,7 +41,6 @@ class GPGKey(Base):
     def search(self, element_name):
         """Uses the search box to locate an element from a list of elements."""
         Navigator(self.browser).go_to_gpg_keys()
-        self.wait_for_ajax()
         element = None
         strategy, value = locators["gpgkey.key_name"]
         searchbox = self.wait_until_element(common_locators["kt_search"])
@@ -118,9 +117,7 @@ class GPGKey(Base):
 
     def assert_key_from_product(self, name, product, repo=None):
         """Assert the key association after deletion from product tab."""
-        nav = Navigator(self.browser)
-        nav.go_to_products()
-        self.wait_for_ajax()
+        Navigator(self.browser).go_to_products()
         prd_element = self.search_entity(
             product, locators["prd.select"], katello=True)
         if prd_element:

--- a/robottelo/ui/hardwaremodel.py
+++ b/robottelo/ui/hardwaremodel.py
@@ -49,7 +49,7 @@ class HardwareModel(Base):
             raise UINoSuchElementError(
                 "Could not find hardware-model '%s'" % old_name)
 
-    def search(self, name, timeout=None):
+    def search(self, name):
         """Searches existing Hardware-Models from UI.
 
         :param str name: Hardware-Model's name to search.
@@ -58,13 +58,10 @@ class HardwareModel(Base):
         Navigator(self.browser).go_to_hardware_models()
         if len(name) <= 30:
             element = self.search_entity(
-                name, locators['hwmodels.select_name'], timeout=timeout)
+                name, locators['hwmodels.select_name'])
         else:
             element = self.search_entity(
-                name,
-                common_locators['select_filtered_entity'],
-                timeout=timeout,
-            )
+                name, common_locators['select_filtered_entity'])
         return element
 
     def delete(self, name, really=True):

--- a/robottelo/ui/hostgroup.py
+++ b/robottelo/ui/hostgroup.py
@@ -30,8 +30,7 @@ class Hostgroup(Base):
     def search(self, name):
         """Searches existing hostgroup from UI."""
         Navigator(self.browser).go_to_host_groups()
-        element = self.search_entity(name, locators['hostgroups.hostgroup'])
-        return element
+        return self.search_entity(name, locators['hostgroups.hostgroup'])
 
     def delete(self, name, really=True):
         """Deletes existing hostgroup from UI."""
@@ -41,7 +40,7 @@ class Hostgroup(Base):
             really,
             locators['hostgroups.hostgroup'],
             locators['hostgroups.delete'],
-            drop_locator=locators['hostgroups.dropdown']
+            drop_locator=locators['hostgroups.dropdown'],
         )
 
     def update(self, name, new_name=None, parent=None, environment=None):

--- a/robottelo/ui/ldapauthsource.py
+++ b/robottelo/ui/ldapauthsource.py
@@ -58,7 +58,6 @@ class LdapAuthSource(Base):
     def search(self, name, really=False):
         """Searches existing ldap auth source from UI."""
         Navigator(self.browser).go_to_ldap_auth()
-        self.wait_for_ajax()
         strategy1, value1 = locators['ldapserver.ldap_servername']
         element = self.wait_until_element((strategy1, value1 % (name, name)))
         if element is None:
@@ -71,7 +70,6 @@ class LdapAuthSource(Base):
     def delete(self, name, really=False):
         """Deletes existing ldap auth source from UI."""
         Navigator(self.browser).go_to_ldap_auth()
-        self.wait_for_ajax()
         strategy1, value1 = locators['ldapserver.ldap_delete']
         element = self.wait_until_element((strategy1, value1 % name))
         if element is None:

--- a/robottelo/ui/location.py
+++ b/robottelo/ui/location.py
@@ -105,7 +105,6 @@ class Location(Base):
     def search(self, name):
         """Searches existing location from UI."""
         Navigator(self.browser).go_to_loc()
-        self.wait_for_ajax()
         element = self.search_entity(name, locators['location.select_name'])
         return element
 

--- a/robottelo/ui/login.py
+++ b/robottelo/ui/login.py
@@ -36,9 +36,7 @@ class Login(Base):
         if self.wait_until_element(locators['login.gravatar']) is None:
             raise UINoSuchElementError(
                 'could not find login.gravatar to sign out')
-        nav = Navigator(self.browser)
-        nav.go_to_sign_out()
-        self.wait_for_ajax()
+        Navigator(self.browser).go_to_sign_out()
 
     def is_logged(self):
         """Checks whether user is logged by validating a session cookie"""

--- a/robottelo/ui/medium.py
+++ b/robottelo/ui/medium.py
@@ -39,7 +39,6 @@ class Medium(Base):
     def search(self, name):
         """Searches existing medium from UI."""
         Navigator(self.browser).go_to_installation_media()
-        self.wait_for_ajax()
         if len(name) <= 30:
             element = self.search_entity(name, locators['medium.medium_name'])
         else:
@@ -53,7 +52,7 @@ class Medium(Base):
             name,
             really,
             locators['medium.medium_name'],
-            locators['medium.delete']
+            locators['medium.delete'],
         )
 
     def update(self, old_name, new_name=None, new_path=None, os_family=None):

--- a/robottelo/ui/org.py
+++ b/robottelo/ui/org.py
@@ -104,9 +104,7 @@ class Org(Base):
     def search(self, name):
         """Searches existing Organization from UI."""
         Navigator(self.browser).go_to_org()
-        self.wait_for_ajax()
-        element = self.search_entity(name, locators['org.org_name'])
-        return element
+        return self.search_entity(name, locators['org.org_name'])
 
     def update(self, org_name, new_parent_org=None, new_name=None, users=None,
                proxies=None, subnets=None, resources=None, medias=None,
@@ -155,12 +153,11 @@ class Org(Base):
 
     def remove(self, org_name, really=True):
         """Remove Organization in UI."""
-        searched = self.search(org_name)
-        if searched is None:
-            raise UINoSuchElementError(
-                u'Could not search the entity {0}'.format(org_name))
-        strategy, value = locators['org.dropdown']
-        self.click((strategy, value % org_name))
-        strategy1, value1 = locators['org.delete']
-        self.click((strategy1, value1 % org_name), wait_for_ajax=False)
-        self.handle_alert(really)
+        Navigator(self.browser).go_to_org()
+        self.delete_entity(
+            org_name,
+            really,
+            locators['org.org_name'],
+            locators['org.delete'],
+            drop_locator=locators['org.dropdown'],
+        )

--- a/robottelo/ui/oscapcontent.py
+++ b/robottelo/ui/oscapcontent.py
@@ -20,7 +20,6 @@ class OpenScapContent(Base):
 
     def search(self, name):
         """Searches existing oscap content from UI"""
-        self.wait_for_ajax()
         Navigator(self.browser).go_to_oscap_content()
         return self.search_entity(
             name,

--- a/robottelo/ui/oscappolicy.py
+++ b/robottelo/ui/oscappolicy.py
@@ -36,7 +36,6 @@ class OpenScapPolicy(Base):
 
     def search(self, name):
         """Searches existing oscap policy from UI"""
-        self.wait_for_ajax()
         Navigator(self.browser).go_to_oscap_policy()
         strategy, value = common_locators['search']
         return self.wait_until_element((strategy, value % name))

--- a/robottelo/ui/oscapreports.py
+++ b/robottelo/ui/oscapreports.py
@@ -10,7 +10,6 @@ class OpenScapReports(Base):
 
     def search(self, name):
         """Searches existing oscap reports from UI"""
-        self.wait_for_ajax()
         Navigator(self.browser).go_to_oscap_reports()
         return self.search_entity(
             name,

--- a/robottelo/ui/partitiontable.py
+++ b/robottelo/ui/partitiontable.py
@@ -40,8 +40,7 @@ class PartitionTable(Base):
     def search(self, name):
         """Searches existing partition table from UI."""
         Navigator(self.browser).go_to_partition_tables()
-        element = self.search_entity(name, locators['ptable.ptable_name'])
-        return element
+        return self.search_entity(name, locators['ptable.ptable_name'])
 
     def delete(self, name, really=True):
         """Removes existing partition table from UI."""
@@ -49,7 +48,7 @@ class PartitionTable(Base):
             name,
             really,
             locators['ptable.ptable_name'],
-            locators['ptable.delete']
+            locators['ptable.delete'],
         )
 
     def update(self, old_name, new_name=None,

--- a/robottelo/ui/puppetclasses.py
+++ b/robottelo/ui/puppetclasses.py
@@ -34,10 +34,7 @@ class PuppetClasses(Base):
     def search(self, name):
         """Searches existing puppet-classes from UI"""
         Navigator(self.browser).go_to_puppet_classes()
-        self.wait_for_ajax()
-        element = self.search_entity(
-            name, locators['puppetclass.select_name'])
-        return element
+        return self.search_entity(name, locators['puppetclass.select_name'])
 
     def delete(self, name, really=True):
         """Deletes the puppet-classes."""
@@ -51,7 +48,6 @@ class PuppetClasses(Base):
     def import_scap_client_puppet_classes(self):
         """Imports puppet-foreman_scap_client puppet classes."""
         Navigator(self.browser).go_to_puppet_classes()
-        self.wait_for_ajax()
         self.click(locators['puppetclass.import'])
         # Checking if the scap client puppet classes are already imported
         if self.wait_until_element(

--- a/robottelo/ui/role.py
+++ b/robottelo/ui/role.py
@@ -26,14 +26,14 @@ class Role(Base):
         element = self.search_entity(name, locators['roles.role'])
         return element
 
-    def remove(self, name, really=True):
+    def delete(self, name, really=True):
         """Delete existing role."""
         self.delete_entity(
             name,
             really,
             locators['roles.role'],
             locators['roles.delete'],
-            locators['roles.dropdown']
+            locators['roles.dropdown'],
         )
 
     def update(self, name, new_name=None, add_permission=False,

--- a/robottelo/ui/subnet.py
+++ b/robottelo/ui/subnet.py
@@ -64,17 +64,15 @@ class Subnet(Base):
             locators['subnet.delete'],
         )
 
-    def search_subnet(self, subnet_name, timeout=None):
+    def search_subnet(self, subnet_name):
         """Search Subnet name, network and mask to validate results."""
         result = None
         if len(subnet_name) <= 30:
             subnet_object = self.search_entity(
-                subnet_name, locators['subnet.display_name'],
-                timeout=timeout)
+                subnet_name, locators['subnet.display_name'])
         else:
             subnet_object = self.search_entity(
-                subnet_name, common_locators['select_filtered_entity'],
-                timeout=timeout)
+                subnet_name, common_locators['select_filtered_entity'])
         if subnet_object:
             subnet_object.click()
             if self.wait_until_element(locators['subnet.name']):

--- a/robottelo/ui/syncplan.py
+++ b/robottelo/ui/syncplan.py
@@ -43,7 +43,7 @@ class Syncplan(Base):
                rm_products=None):
         """Updates Sync Plans from UI."""
         sp_element = self.search_entity(
-            name, locators['sp.select'], katello=True, timeout=20)
+            name, locators['sp.select'], katello=True, result_timeout=20)
         if sp_element is None:
             raise UIError(
                 'Unable to find the sync_plan "{0}" for update.'.format(name)

--- a/robottelo/ui/template.py
+++ b/robottelo/ui/template.py
@@ -136,5 +136,5 @@ class Template(Base):
             really,
             locators['provision.template_select'],
             locators['provision.template_delete'],
-            locators['provision.template_dropdown']
+            locators['provision.template_dropdown'],
         )

--- a/robottelo/ui/trend.py
+++ b/robottelo/ui/trend.py
@@ -59,8 +59,7 @@ class Trend(Base):
         """
         Navigator(self.browser).go_to_trends()
         strategy, value = locators['trend.trend_name']
-        element = self.wait_until_element((strategy, value % tr_type))
-        return element
+        return self.wait_until_element((strategy, value % tr_type))
 
     def delete(self, trend_name, really=True):
         """Deletes the trend."""

--- a/robottelo/ui/user.py
+++ b/robottelo/ui/user.py
@@ -94,7 +94,6 @@ class User(Base):
     def search(self, name, search_key):
         """Searches existing user from UI."""
         Navigator(self.browser).go_to_users()
-        self.wait_for_ajax()
         return self.search_entity(
             name, locators['users.user'], search_key=search_key)
 
@@ -105,7 +104,7 @@ class User(Base):
             really,
             locators['users.user'],
             locators['users.delete'],
-            search_key=search_key
+            search_key=search_key,
         )
 
     def update(self, search_key, username, new_username=None,

--- a/robottelo/ui/usergroup.py
+++ b/robottelo/ui/usergroup.py
@@ -46,7 +46,7 @@ class UserGroup(Base):
             name,
             really,
             locators['usergroups.usergroup'],
-            locators['usergroups.delete']
+            locators['usergroups.delete'],
         )
 
     def update(self, old_name, new_name=None,

--- a/tests/foreman/ui/test_architecture.py
+++ b/tests/foreman/ui/test_architecture.py
@@ -3,7 +3,7 @@
 from ddt import ddt
 from fauxfactory import gen_string
 from nailgun import entities
-from robottelo.decorators import data, run_only_on, skip_if_bug_open
+from robottelo.decorators import data, run_only_on
 from robottelo.helpers import generate_strings_list, invalid_values_list
 from robottelo.test import UITestCase
 from robottelo.ui.factory import make_arch
@@ -82,7 +82,6 @@ class Architecture(UITestCase):
             self.assertIsNotNone(self.architecture.wait_until_element
                                  (common_locators['name_haserror']))
 
-    @skip_if_bug_open('bugzilla', 1123388)
     @data(*generate_strings_list())
     def test_remove_architecture(self, name):
         """@Test: Delete an existing Architecture
@@ -91,18 +90,13 @@ class Architecture(UITestCase):
 
         @Assert: Architecture is deleted
 
-        @BZ: 1131815
-
         """
-        os_name = gen_string('alpha')
-        entities.OperatingSystem(name=os_name).create()
+        os = entities.OperatingSystem(name=gen_string('alpha')).create()
+        entities.Architecture(name=name, operatingsystem=[os]).create()
         with Session(self.browser) as session:
-            make_arch(session, name=name, os_names=[os_name])
-            self.assertIsNotNone(self.architecture.search(name))
+            session.nav.go_to_architectures()
             self.architecture.delete(name)
-            self.assertIsNone(self.architecture.search(name))
 
-    @skip_if_bug_open('bugzilla', 1123388)
     @data(*generate_strings_list())
     def test_update_arch(self, name):
         """@Test: Update Architecture with new name and OS

--- a/tests/foreman/ui/test_computeresource.py
+++ b/tests/foreman/ui/test_computeresource.py
@@ -230,7 +230,6 @@ class ComputeResource(UITestCase):
             )
             self.assertIsNotNone(self.compute_resource.search(name))
             self.compute_resource.delete(name)
-            self.assertIsNone(self.compute_resource.search(name))
 
     def test_access_docker_resource_via_compute_profile(self):
         """@Test: Try to access docker compute resource via compute profile

--- a/tests/foreman/ui/test_config_groups.py
+++ b/tests/foreman/ui/test_config_groups.py
@@ -10,7 +10,7 @@ from robottelo.helpers import (
 )
 from robottelo.test import UITestCase
 from robottelo.ui.factory import make_config_groups
-from robottelo.ui.locators import common_locators, locators
+from robottelo.ui.locators import common_locators
 from robottelo.ui.session import Session
 
 
@@ -78,11 +78,6 @@ class ConfigGroups(UITestCase):
         @Assert: Config-Groups is deleted
 
         """
-
         with Session(self.browser) as session:
             make_config_groups(session, name=name)
-            search = self.configgroups.search(name)
-            self.assertIsNotNone(search)
-            self.configgroups.delete(
-                name, drop_locator=locators['config_groups.dropdown'])
-            self.assertIsNone(self.configgroups.search(name))
+            self.configgroups.delete(name)

--- a/tests/foreman/ui/test_domain.py
+++ b/tests/foreman/ui/test_domain.py
@@ -63,16 +63,10 @@ class Domain(UITestCase):
         @Assert: Domain is deleted
 
         """
-        name = gen_string('alpha')
-        domain_name = description = DOMAIN % name
+        domain_name = description = DOMAIN % gen_string('alpha')
         with Session(self.browser) as session:
             make_domain(session, name=domain_name, description=description)
-            element = self.domain.search(description)
-            self.assertIsNotNone(element)
-            self.domain.delete(description)
-            self.assertIsNotNone(self.user.wait_until_element(
-                common_locators['notif.success']))
-            self.assertIsNone(self.domain.search(description, timeout=5))
+            self.domain.delete(domain_name)
 
     @data({'name': gen_string('alpha', 10),
            'newname': gen_string('alpha', 10)},

--- a/tests/foreman/ui/test_environment.py
+++ b/tests/foreman/ui/test_environment.py
@@ -95,11 +95,10 @@ class Environment(UITestCase):
             search = self.environment.search(new_name)
             self.assertIsNotNone(search)
 
-    @skip_if_bug_open('bugzilla', 1126033)
     @data(
         gen_string('alpha'),
         gen_string('numeric'),
-        gen_string('alphanumeric')
+        gen_string('alphanumeric'),
     )
     def test_remove_env(self, name):
         """@Test: Delete an environment
@@ -112,4 +111,3 @@ class Environment(UITestCase):
         with Session(self.browser) as session:
             make_env(session, name=name)
             self.environment.delete(name)
-            self.assertIsNone(self.environment.search(name))

--- a/tests/foreman/ui/test_host.py
+++ b/tests/foreman/ui/test_host.py
@@ -374,10 +374,3 @@ class Host(UITestCase, Base):
             # Delete host
             self.hosts.delete(
                 u'{0}.{1}'.format(host.name, host.domain.name))
-            self.assertIsNotNone(
-                self.user.wait_until_element(common_locators['notif.success']))
-            # confirm the Host disappeared from the UI
-            search = self.hosts.search(
-                u'{0}.{1}'.format(host.name, host.domain.name)
-            )
-            self.assertIsNone(search)

--- a/tests/foreman/ui/test_hostgroup.py
+++ b/tests/foreman/ui/test_hostgroup.py
@@ -40,9 +40,7 @@ class Hostgroup(UITestCase):
         """
         with Session(self.browser) as session:
             make_hostgroup(session, name=name)
-            self.assertIsNotNone(self.hostgroup.search(name))
             self.hostgroup.delete(name)
-            self.assertIsNone(self.hostgroup.search(name))
 
     @data(*generate_strings_list(len1=4))
     def test_update_hostgroup(self, new_name):

--- a/tests/foreman/ui/test_hw_model.py
+++ b/tests/foreman/ui/test_hw_model.py
@@ -101,7 +101,4 @@ class HardwareModelTestCase(UITestCase):
 
             name = test_data['name']
             make_hw_model(session, name=name)
-            search = self.hardwaremodel.search(name)
-            self.assertIsNotNone(search)
             self.hardwaremodel.delete(name)
-            self.assertIsNone(self.hardwaremodel.search(name, timeout=3))

--- a/tests/foreman/ui/test_location.py
+++ b/tests/foreman/ui/test_location.py
@@ -200,11 +200,10 @@ class Location(UITestCase):
         @assert: Location is deleted
 
         """
+        entities.Location(name=loc_name).create()
         with Session(self.browser) as session:
-            make_loc(session, name=loc_name)
-            self.assertIsNotNone(self.location.search(loc_name))
+            session.nav.go_to_loc()
             self.location.delete(loc_name)
-            self.assertIsNone(self.location.search(loc_name))
 
     @data(*generate_strings_list())
     def test_add_subnet(self, subnet_name):
@@ -652,7 +651,7 @@ class Location(UITestCase):
                 (strategy, value % host_grp_name))
             # Item is listed in 'Selected Items' list and not 'All Items' list.
             self.assertIsNotNone(element)
-            self.hostgroup.delete(host_grp_name, True)
+            self.hostgroup.delete(host_grp_name)
             self.location.search(loc_name).click()
             session.nav.click(tab_locators['context.tab_hostgrps'])
             element = session.nav.wait_until_element(

--- a/tests/foreman/ui/test_medium.py
+++ b/tests/foreman/ui/test_medium.py
@@ -128,9 +128,7 @@ class Medium(UITestCase):
         path = INSTALL_MEDIUM_URL % name
         with Session(self.browser) as session:
             make_media(session, name=name, path=path, os_family='Red Hat')
-            self.assertIsNotNone(self.medium.search(name))
             self.medium.delete(name)
-            self.assertIsNone(self.medium.search(name))
 
     def test_update_medium(self):
         """@Test: Updates Install media with name, path, OS family

--- a/tests/foreman/ui/test_operatingsys.py
+++ b/tests/foreman/ui/test_operatingsys.py
@@ -250,7 +250,6 @@ class OperatingSys(UITestCase):
         with Session(self.browser) as session:
             session.nav.go_to_operating_systems()
             self.operatingsys.delete(os_name)
-            self.assertIsNone(self.operatingsys.search(os_name))
 
     @data(
         {u'new_name': gen_string('alpha', 10),

--- a/tests/foreman/ui/test_org.py
+++ b/tests/foreman/ui/test_org.py
@@ -223,11 +223,10 @@ class Org(UITestCase):
         @assert: Organization is deleted successfully
 
         """
+        entities.Organization(name=org_name).create()
         with Session(self.browser) as session:
-            make_org(session, org_name=org_name)
-            self.assertIsNotNone(self.org.search(org_name))
+            session.nav.go_to_org()
             self.org.remove(org_name)
-            self.assertIsNone(self.org.search(org_name))
 
     @skip_if_bug_open('bugzilla', 1225588)
     @data(*generate_strings_list())

--- a/tests/foreman/ui/test_partitiontable.py
+++ b/tests/foreman/ui/test_partitiontable.py
@@ -135,9 +135,7 @@ class PartitionTable(UITestCase):
             name = test_data['name']
             make_partitiontable(
                 session, name=name, layout='test layout', os_family='Red Hat')
-            self.assertIsNotNone(self.partitiontable.search(name))
             self.partitiontable.delete(name)
-            self.assertIsNone(self.partitiontable.search(name))
 
     @data({u'name': gen_string('alpha'),
            u'new_name': gen_string('alpha')},

--- a/tests/foreman/ui/test_puppet_classes.py
+++ b/tests/foreman/ui/test_puppet_classes.py
@@ -52,7 +52,6 @@ class PuppetClasses(UITestCase):
 
         """
         entities.PuppetClass(name=name).create()
-        with Session(self.browser):
-            self.assertIsNotNone(self.puppetclasses.search(name))
+        with Session(self.browser) as session:
+            session.nav.go_to_puppet_classes()
             self.puppetclasses.delete(name)
-            self.assertIsNone(self.puppetclasses.search(name))

--- a/tests/foreman/ui/test_role.py
+++ b/tests/foreman/ui/test_role.py
@@ -4,7 +4,8 @@
 from ddt import ddt
 from fauxfactory import gen_string
 from nailgun import entities
-from robottelo.decorators import bz_bug_is_open, data
+from robottelo.decorators import data
+from robottelo.helpers import generate_strings_list, invalid_names_list
 from robottelo.test import UITestCase
 from robottelo.ui.factory import make_role
 from robottelo.ui.locators import common_locators
@@ -15,18 +16,8 @@ from robottelo.ui.session import Session
 class Role(UITestCase):
     """Implements Roles tests from UI"""
 
-    @data(
-        {'name': gen_string('alpha')},
-        {'name': gen_string('numeric')},
-        {'name': gen_string('alphanumeric')},
-        {'name': gen_string('utf8'),
-         u'bz-bug': 1112657},
-        {'name': gen_string('latin1'),
-         u'bz-bug': 1112657},
-        {'name': gen_string('html'),
-         u'bz-bug': 1112657}
-    )
-    def test_create_role(self, test_data):
+    @data(*generate_strings_list(len1=10))
+    def test_create_role_basic(self, name):
         """@Test: Create new role
 
         @Feature: Role - Positive Create
@@ -34,16 +25,12 @@ class Role(UITestCase):
         @Assert: Role is created
 
         """
-        bug_id = test_data.pop('bz-bug', None)
-        if bug_id is not None and bz_bug_is_open(bug_id):
-            self.skipTest('Bugzilla bug {0} is open.'.format(bug_id))
-
         with Session(self.browser) as session:
-            make_role(session, name=test_data['name'])
-            self.assertIsNotNone(self.role.search(test_data['name']))
+            make_role(session, name=name)
+            self.assertIsNotNone(self.role.search(name))
 
     @data('', ' ')
-    def test_negative_create_role_1(self, name):
+    def test_negative_create_role_with_blank_name(self, name):
         """@Test: Create new role with blank and whitespace in name
 
         @Feature: Role - Negative Create
@@ -51,25 +38,13 @@ class Role(UITestCase):
         @Assert: Role is not created
 
         """
-
         with Session(self.browser) as session:
             make_role(session, name=name)
-            error = session.nav.wait_until_element(
-                common_locators['name_haserror'])
-            self.assertIsNotNone(error)
+            self.assertIsNotNone(session.nav.wait_until_element(
+                common_locators['name_haserror']))
 
-    @data(
-        {'name': gen_string('alpha', 256)},
-        {'name': gen_string('numeric', 256)},
-        {'name': gen_string('alphanumeric', 256)},
-        {'name': gen_string('utf8', 256),
-         u'bz-bug': 1112657},
-        {'name': gen_string('latin1', 256),
-         u'bz-bug': 1112657},
-        {'name': gen_string('html', 256),
-         u'bz-bug': 1112657}
-    )
-    def test_negative_create_role_2(self, test_data):
+    @data(*invalid_names_list())
+    def test_negative_create_role_with_too_long_names(self, name):
         """@Test: Create new role with 256 characters in name
 
         @Feature: Role - Negative Create
@@ -77,28 +52,13 @@ class Role(UITestCase):
         @Assert: Role is not created
 
         """
-        bug_id = test_data.pop('bz-bug', None)
-        if bug_id is not None and bz_bug_is_open(bug_id):
-            self.skipTest('Bugzilla bug {0} is open.'.format(bug_id))
-
         with Session(self.browser) as session:
-            make_role(session, name=test_data['name'])
-            error = session.nav.wait_until_element(
-                common_locators['name_haserror'])
-            self.assertIsNotNone(error)
+            make_role(session, name=name)
+            self.assertIsNotNone(session.nav.wait_until_element(
+                common_locators['name_haserror']))
 
-    @data(
-        {'name': gen_string('alpha')},
-        {'name': gen_string('numeric')},
-        {'name': gen_string('alphanumeric')},
-        {'name': gen_string('utf8'),
-         u'bz-bug': 1112657},
-        {'name': gen_string('latin1'),
-         u'bz-bug': 1112657},
-        {'name': gen_string('html'),
-         u'bz-bug': 1112657}
-    )
-    def test_remove_role(self, test_data):
+    @data(*generate_strings_list(len1=10))
+    def test_remove_role(self, name):
         """@Test: Delete an existing role
 
         @Feature: Role - Positive Delete
@@ -106,34 +66,12 @@ class Role(UITestCase):
         @Assert: Role is deleted
 
         """
-        bug_id = test_data.pop('bz-bug', None)
-        if bug_id is not None and bz_bug_is_open(bug_id):
-            self.skipTest('Bugzilla bug {0} is open.'.format(bug_id))
-
         with Session(self.browser) as session:
-            make_role(session, name=test_data['name'])
-            self.assertIsNotNone(self.role.search(test_data['name']))
-            self.role.remove(test_data['name'])
-            self.assertIsNone(self.role.search(test_data['name']))
+            make_role(session, name=name)
+            self.role.delete(name)
 
-    @data(
-        {'name': gen_string('alpha'),
-         'new_name': gen_string('alpha')},
-        {'name': gen_string('numeric'),
-         'new_name': gen_string('numeric')},
-        {'name': gen_string('alphanumeric'),
-         'new_name': gen_string('alphanumeric')},
-        {'name': gen_string('utf8'),
-         'new_name': gen_string('utf8'),
-         u'bz-bug': 1112657},
-        {'name': gen_string('latin1'),
-         'new_name': gen_string('latin1'),
-         u'bz-bug': 1112657},
-        {'name': gen_string('html'),
-         'new_name': gen_string('html'),
-         u'bz-bug': 1112657},
-    )
-    def test_update_role_name(self, test_data):
+    @data(*generate_strings_list(len1=10))
+    def test_update_role_name(self, new_name):
         """@Test: Update role name
 
         @Feature: Role - Positive Update
@@ -141,15 +79,12 @@ class Role(UITestCase):
         @Assert: Role is updated
 
         """
-        bug_id = test_data.pop('bz-bug', None)
-        if bug_id is not None and bz_bug_is_open(bug_id):
-            self.skipTest('Bugzilla bug {0} is open.'.format(bug_id))
-
+        name = gen_string('utf8')
         with Session(self.browser) as session:
-            make_role(session, name=test_data['name'])
-            self.assertIsNotNone(self.role.search(test_data['name']))
-            self.role.update(test_data['name'], test_data['new_name'])
-            self.assertIsNotNone(self.role.search(test_data['new_name']))
+            make_role(session, name=name)
+            self.assertIsNotNone(self.role.search(name))
+            self.role.update(name, new_name)
+            self.assertIsNotNone(self.role.search(new_name))
 
     def test_update_role_permission(self):
         """@Test: Update role permissions

--- a/tests/foreman/ui/test_subnet.py
+++ b/tests/foreman/ui/test_subnet.py
@@ -200,8 +200,6 @@ class Subnet(UITestCase):
                 subnet_mask=gen_netmask(),
             )
             self.subnet.delete(name)
-            self.assertIsNone(self.subnet.search_subnet(
-                subnet_name=name, timeout=5))
 
     def test_remove_subnet_and_cancel(self):
         """@Test: Delete subnet.
@@ -222,8 +220,6 @@ class Subnet(UITestCase):
                 subnet_mask=gen_netmask(),
             )
             self.subnet.delete(name, False)
-            self.assertIsNotNone(self.subnet.search_subnet(
-                subnet_name=name, timeout=5))
 
     @data(*generate_strings_list(len1=8))
     def test_update_subnet_with_name(self, new_name):

--- a/tests/foreman/ui/test_template.py
+++ b/tests/foreman/ui/test_template.py
@@ -4,7 +4,7 @@ from ddt import ddt
 from fauxfactory import gen_string
 from nailgun import entities
 from robottelo.constants import OS_TEMPLATE_DATA_FILE, SNIPPET_DATA_FILE
-from robottelo.decorators import data, run_only_on, skip_if_bug_open
+from robottelo.decorators import data, run_only_on
 from robottelo.helpers import generate_strings_list, get_data_file
 from robottelo.test import UITestCase
 from robottelo.ui.base import UIError
@@ -188,7 +188,6 @@ class Template(UITestCase):
             )
             self.assertIsNotNone(self.template.search(name))
 
-    @skip_if_bug_open('bugzilla', 1177756)
     @data(*generate_strings_list(len1=8))
     def test_remove_template(self, template_name):
         """@Test: Remove a template
@@ -197,15 +196,12 @@ class Template(UITestCase):
 
         @Assert: Template removed successfully
 
-        @BZ: 1177756
-
         """
         entities.ConfigTemplate(
             name=template_name, organization=[self.organization]).create()
         with Session(self.browser) as session:
             session.nav.go_to_select_org(self.organization.name)
             self.template.delete(template_name)
-            self.assertIsNone(self.template.search(template_name))
 
     def test_update_template(self):
         """@Test: Update template name and template type

--- a/tests/foreman/ui/test_user.py
+++ b/tests/foreman/ui/test_user.py
@@ -47,7 +47,6 @@ class User(UITestCase):
 
     """
 
-    @skip_if_bug_open('bugzilla', 1177097)
     @data(*valid_strings())
     def test_delete_user(self, user_name):
         """@Test: Delete a User
@@ -56,14 +55,10 @@ class User(UITestCase):
 
         @Assert: User is deleted
 
-        @BZ: 1177097
-
         """
         with Session(self.browser) as session:
             make_user(session, username=user_name)
-            self.assertIsNotNone(self.user.search(user_name, search_key))
             self.user.delete(user_name, search_key)
-            self.assertIsNone(self.user.search(user_name, search_key))
 
     @skip_if_bug_open('bugzilla', 1139616)
     def test_update_password(self):

--- a/tests/foreman/ui/test_usergroup.py
+++ b/tests/foreman/ui/test_usergroup.py
@@ -103,11 +103,7 @@ class UserGroup(UITestCase):
         with Session(self.browser) as session:
             make_usergroup(
                 session, org=self.organization.name, name=group_name)
-            self.assertIsNotNone(self.usergroup.search(group_name))
             self.usergroup.delete(group_name)
-            self.assertIsNotNone(self.usergroup.wait_until_element(
-                common_locators['notif.success']))
-            self.assertIsNone(self.usergroup.search(group_name))
 
     @skip_if_bug_open('bugzilla', 1142588)
     def test_remove_usergroup(self):
@@ -119,18 +115,22 @@ class UserGroup(UITestCase):
 
         """
         user_name = gen_string('alpha')
-        password = gen_string('alpha')
         group_name = gen_string('utf8')
         # Create a new user
-        entities.User(login=user_name, password=password).create()
+        entities.User(
+            login=user_name,
+            password=gen_string('alpha'),
+            organization=[self.organization],
+        ).create()
 
         with Session(self.browser) as session:
-            make_usergroup(session, name=group_name, users=[user_name])
-            self.assertIsNotNone(self.usergroup.search(group_name))
+            make_usergroup(
+                session,
+                name=group_name,
+                users=[user_name],
+                org=self.organization.name,
+            )
             self.usergroup.delete(group_name)
-            self.assertIsNotNone(self.usergroup.wait_until_element(
-                common_locators['notif.success']))
-            self.assertIsNone(self.usergroup.search(group_name))
             self.assertIsNotNone(self.user.search(
                 name=user_name, search_key='login'))
 


### PR DESCRIPTION
That is main part of improvement. There are still few modules that have completely another UI for delete operation (like 'content_view' or 'gpg_key') and will be covered in scope of another PR
Few random runs:
```
nosetests tests/foreman/ui/test_architecture.py -m test_remove_architecture
.
----------------------------------------------------------------------
Ran 1 test in 18.337s

OK
```
```
nosetests tests/foreman/ui/test_computeresource.py -m test_remove_resource
.
----------------------------------------------------------------------
Ran 1 test in 24.372s

OK
```
```
nosetests tests/foreman/ui/test_role.py
................................
----------------------------------------------------------------------
Ran 32 tests in 493.226s

OK
```
More detailed results will be provided in a table below