### PR TITLE
Tests and implementation around host discovery

### DIFF
--- a/robottelo/test.py
+++ b/robottelo/test.py
@@ -42,6 +42,7 @@ from robottelo.ui.configgroups import ConfigGroups
 from robottelo.ui.contentenv import ContentEnvironment
 from robottelo.ui.contentviews import ContentViews
 from robottelo.ui.contentsearch import ContentSearch
+from robottelo.ui.discoveredhosts import DiscoveredHosts
 from robottelo.ui.discoveryrules import DiscoveryRules
 from robottelo.ui.domain import Domain
 from robottelo.ui.environment import Environment
@@ -210,6 +211,7 @@ class UITestCase(TestCase):
         self.content_views = ContentViews(self.browser)
         self.content_search = ContentSearch(self.browser)
         self.domain = Domain(self.browser)
+        self.discoveredhosts = DiscoveredHosts(self.browser)
         self.discoveryrules = DiscoveryRules(self.browser)
         self.environment = Environment(self.browser)
         self.gpgkey = GPGKey(self.browser)

--- a/robottelo/ui/discoveredhosts.py
+++ b/robottelo/ui/discoveredhosts.py
@@ -1,0 +1,26 @@
+# -*- encoding: utf-8 -*-
+"""Implements Discovered Hosts from UI."""
+from robottelo.ui.base import Base
+from robottelo.ui.locators import locators
+from robottelo.ui.navigator import Navigator
+
+
+class DiscoveredHosts(Base):
+    """Manipulates Discovered Hosts from UI"""
+
+    def search(self, host_name):
+        """Searches existing discovered hosts from UI"""
+        Navigator(self.browser).go_to_discovered_hosts()
+        strategy, value = locators['discoveredhosts.hostname']
+        return self.wait_until_element((strategy, value % host_name))
+
+    def delete(self, hostname, really=True):
+        """Delete existing discovered hosts from UI"""
+        Navigator(self.browser).go_to_discovered_hosts()
+        self.delete_entity(
+            hostname,
+            really,
+            locators['discoveredhosts.hostname'],
+            locators['discoveredhosts.delete'],
+            locators['discoveredhosts.dropdown'],
+        )

--- a/robottelo/ui/locators.py
+++ b/robottelo/ui/locators.py
@@ -147,6 +147,10 @@ menu_locators = LocatorDict({
         By.XPATH,
         ("//div[contains(@style,'static') or contains(@style,'fixed')]"
          "//a[@id='menu_item_hosts']")),
+    "menu.discovered_hosts": (
+        By.XPATH,
+        ("//div[contains(@style,'static') or contains(@style,'fixed')]"
+         "//a[@id='menu_item_discovered_hosts']")),
     "menu.content_hosts": (
         By.XPATH,
         ("//div[contains(@style,'static') or contains(@style, 'fixed')]"
@@ -1978,6 +1982,17 @@ locators = LocatorDict({
                    " and contains(., '%s')]")),
     "discoveryrules.rule_delete": (
         By.XPATH, "//a[contains(@data-confirm, '%s') and @class='delete']"),
+
+    # Discovered Hosts
+    "discoveredhosts.hostname": (
+        By.XPATH, ("//a[contains(@href, 'discovered_hosts')"
+                   " and contains(., '%s')]")),
+    "discoveredhosts.dropdown": (
+        By.XPATH, ("//a[contains(@href,'%s')]"
+                   "/following::a[@data-toggle='dropdown']")),
+    "discoveredhosts.delete": (
+        By.XPATH, ("//a[@class='delete' and contains(@data-confirm, '%s')]")),
+
     # LDAP Authentication
     "ldapsource.new": (
         By.XPATH, "//a[@href='/auth_source_ldaps/new']"),

--- a/robottelo/ui/navigator.py
+++ b/robottelo/ui/navigator.py
@@ -143,6 +143,12 @@ class Navigator(Base):
             menu_locators['menu.hosts'], menu_locators['menu.all_hosts'],
         )
 
+    def go_to_discovered_hosts(self):
+        self.menu_click(
+            menu_locators['menu.hosts'],
+            menu_locators['menu.discovered_hosts'],
+        )
+
     def go_to_content_hosts(self):
         self.menu_click(
             menu_locators['menu.hosts'],


### PR DESCRIPTION
- Implemented setUpClass for discoveredhosts that updates global params
- added teardown class to revert the default value of 'discovery_auto' param
- added a method to create a unknown host via pxe
- added a teardown method to delete the VM once test is completed
- added support around UI to search and delete a discovered host
- Implemented tests to discover a host and delete it
- Removed discovery-rules related test-stubs, already covered in test_discoveryrules.py