### PR TITLE
CLI: Move SSHCommandResult processing to Base class

### DIFF
--- a/robottelo/cli/contentview.py
+++ b/robottelo/cli/contentview.py
@@ -62,8 +62,11 @@ class ContentView(Base):
         # Publishing can take a while so try to wait a bit longer
         if timeout is None:
             timeout = 120
-        return cls._remove_task_status(
-            cls.execute(cls._construct_command(options), timeout=timeout))
+        return cls.execute(
+            cls._construct_command(options),
+            ignore_stderr=True,
+            timeout=timeout,
+        )
 
     @classmethod
     def version_info(cls, options):
@@ -73,9 +76,7 @@ class ContentView(Base):
         if options is None:
             options = {}
 
-        result = cls.execute(cls._construct_command(options))
-        result.stdout = hammer.parse_info(result.stdout)
-        return result
+        return hammer.parse_info(cls.execute(cls._construct_command(options)))
 
     @classmethod
     def version_incremental_update(cls, options):
@@ -103,9 +104,7 @@ class ContentView(Base):
         if options is None:
             options = {}
 
-        result = cls.execute(cls._construct_command(options))
-        result.stdout = hammer.parse_info(result.stdout)
-        return result
+        return hammer.parse_info(cls.execute(cls._construct_command(options)))
 
     @classmethod
     def filter_info(cls, options):
@@ -116,9 +115,7 @@ class ContentView(Base):
         if options is None:
             options = {}
 
-        result = cls.execute(cls._construct_command(options))
-        result.stdout = hammer.parse_info(result.stdout)
-        return result
+        return hammer.parse_info(cls.execute(cls._construct_command(options)))
 
     @classmethod
     def filter_create(cls, options):
@@ -241,22 +238,28 @@ class ContentView(Base):
     def version_promote(cls, options):
         """Promotes content-view version to next env."""
         cls.command_sub = 'version promote'
-        return cls._remove_task_status(
-            cls.execute(cls._construct_command(options)))
+        return cls.execute(
+            cls._construct_command(options),
+            ignore_stderr=True,
+        )
 
     @classmethod
     def version_delete(cls, options):
         """Removes content-view version."""
         cls.command_sub = 'version delete'
-        return cls._remove_task_status(
-            cls.execute(cls._construct_command(options)))
+        return cls.execute(
+            cls._construct_command(options),
+            ignore_stderr=True,
+        )
 
     @classmethod
     def remove_from_environment(cls, options=None):
-        """Remove content-view from an enviornment"""
+        """Remove content-view from an environment"""
         cls.command_sub = 'remove-from-environment'
-        return cls._remove_task_status(
-            cls.execute(cls._construct_command(options)))
+        return cls.execute(
+            cls._construct_command(options),
+            ignore_stderr=True,
+        )
 
     @classmethod
     def remove(cls, options=None):
@@ -265,5 +268,7 @@ class ContentView(Base):
 
         """
         cls.command_sub = 'remove'
-        return cls._remove_task_status(
-            cls.execute(cls._construct_command(options)))
+        return cls.execute(
+            cls._construct_command(options),
+            ignore_stderr=True,
+        )

--- a/robottelo/cli/factory.py
+++ b/robottelo/cli/factory.py
@@ -17,6 +17,7 @@ from os import chmod
 from robottelo import manifests, ssh
 from robottelo.cli.activationkey import ActivationKey
 from robottelo.cli.architecture import Architecture
+from robottelo.cli.base import CLIReturnCodeError
 from robottelo.cli.computeresource import ComputeResource
 from robottelo.cli.contenthost import ContentHost
 from robottelo.cli.contentview import ContentView
@@ -83,23 +84,24 @@ def create_object(cli_object, options, values):
 
     """
     update_dictionary(options, values)
-    result = cli_object.create(options)
-
-    # If the object is not created, raise exception, stop the show.
-    if result.return_code != 0:
+    try:
+        result = cli_object.create(options)
+    except CLIReturnCodeError as err:
+        # If the object is not created, raise exception, stop the show.
         raise CLIFactoryError(
-            'Failed to create {0} with data:\n{1}'.format(
+            'Failed to create {0} with data:\n{1}\n{2}'.format(
                 cli_object.__name__,
-                json.dumps(options, indent=2, sort_keys=True)
+                json.dumps(options, indent=2, sort_keys=True),
+                err.msg,
             )
         )
 
     # Sometimes we get a list with a dictionary and not
     # a dictionary.
-    if type(result.stdout) is list and len(result.stdout) > 0:
-        result.stdout = result.stdout[0]
+    if type(result) is list and len(result) > 0:
+        result = result[0]
 
-    return result.stdout
+    return result
 
 
 @cacheable
@@ -1638,24 +1640,27 @@ def activationkey_add_subscription_to_repo(options=None):
             'subscription.'
         )
     # List the subscriptions in given org
-    result = Subscription.list(
+    subscriptions = Subscription.list(
         {u'organization-id': options['organization-id']},
         per_page=False
     )
     # Add subscription to activation-key
-    for subscription in result.stdout:
+    for subscription in subscriptions:
         if subscription['name'] == options['subscription']:
             if int(subscription['quantity']) == 0:
                 raise CLIFactoryError(
                     'All the subscriptions are already consumed')
-            result = ActivationKey.add_subscription({
-                u'id': options['activationkey-id'],
-                u'subscription-id': subscription['id'],
-                u'quantity': 1,
-            })
-            if result.return_code != 0:
+            try:
+                ActivationKey.add_subscription({
+                    u'id': options['activationkey-id'],
+                    u'subscription-id': subscription['id'],
+                    u'quantity': 1,
+                })
+            except CLIReturnCodeError as err:
                 raise CLIFactoryError(
-                    'Failed to add subscription to activation key')
+                    'Failed to add subscription to activation key\n{0}'
+                    .format(err.msg)
+                )
 
 
 def setup_org_for_a_custom_repo(options=None):
@@ -1702,41 +1707,52 @@ def setup_org_for_a_custom_repo(options=None):
     # Create custom product and repository
     custom_product = make_product({u'organization-id': org_id})
     custom_repo = make_repository({
-        u'url': options.get('url'),
         u'content-type': 'yum',
         u'product-id': custom_product['id'],
+        u'url': options.get('url'),
     })
     # Synchronize custom repository
-    result = Repository.synchronize({'id': custom_repo['id']})
-    if result.return_code != 0:
-        raise CLIFactoryError('Failed to synchronize repository')
+    try:
+        Repository.synchronize({'id': custom_repo['id']})
+    except CLIReturnCodeError as err:
+        raise CLIFactoryError(
+            'Failed to synchronize repository\n{0}'.format(err.msg))
     # Create CV if needed and associate repo with it
     if options.get('content-view-id') is None:
         cv_id = make_content_view({u'organization-id': org_id})['id']
     else:
         cv_id = options['content-view-id']
-    result = ContentView.add_repository({
-        u'id': cv_id,
-        u'repository-id': custom_repo['id'],
-        u'organization-id': org_id,
-    })
-    if result.return_code != 0:
-        raise CLIFactoryError('Failed to add repository to content view')
+    try:
+        ContentView.add_repository({
+            u'id': cv_id,
+            u'organization-id': org_id,
+            u'repository-id': custom_repo['id'],
+        })
+    except CLIReturnCodeError as err:
+        raise CLIFactoryError(
+            'Failed to add repository to content view\n{0}'.format(err.msg))
     # Publish a new version of CV
-    result = ContentView.publish({u'id': cv_id})
-    if result.return_code != 0:
-        raise CLIFactoryError('Failed to publish new version of content view')
+    try:
+        ContentView.publish({u'id': cv_id})
+    except CLIReturnCodeError as err:
+        raise CLIFactoryError(
+            'Failed to publish new version of content view\n{0}'
+            .format(err.msg)
+        )
     # Get the version id
-    result = ContentView.info({u'id': cv_id})
-    cvv = result.stdout['versions'][-1]
+    cvv = ContentView.info({u'id': cv_id})['versions'][-1]
     # Promote version to next env
-    result = ContentView.version_promote({
-        u'id': cvv['id'],
-        u'to-lifecycle-environment-id': env_id,
-        u'organization-id': org_id,
-    })
-    if result.return_code != 0:
-        raise CLIFactoryError('Failed to promote version to next environment')
+    try:
+        ContentView.version_promote({
+            u'id': cvv['id'],
+            u'organization-id': org_id,
+            u'to-lifecycle-environment-id': env_id,
+        })
+    except CLIReturnCodeError as err:
+        raise CLIFactoryError(
+            'Failed to promote version to next environment\n{0}'
+            .format(err.msg)
+        )
     # Create activation key if needed and associate content view with it
     if options.get('activationkey-id') is None:
         activationkey_id = make_activation_key({
@@ -1748,18 +1764,21 @@ def setup_org_for_a_custom_repo(options=None):
         activationkey_id = options['activationkey-id']
         # Given activation key may have no (or different) CV associated.
         # Associate activation key with CV just to be sure
-        result = ActivationKey.update({
-            u'id': activationkey_id,
-            u'organization-id': org_id,
-            u'content-view-id': cv_id,
-        })
-        if result.return_code != 0:
+        try:
+            ActivationKey.update({
+                u'content-view-id': cv_id,
+                u'id': activationkey_id,
+                u'organization-id': org_id,
+            })
+        except CLIReturnCodeError as err:
             raise CLIFactoryError(
-                'Failed to associate activation-key with CV')
+                'Failed to associate activation-key with CV\n{0}'
+                .format(err.msg)
+            )
     # Add subscription to activation-key
     activationkey_add_subscription_to_repo({
-        u'organization-id': org_id,
         u'activationkey-id': activationkey_id,
+        u'organization-id': org_id,
         u'subscription': custom_product['name'],
     })
 
@@ -1816,68 +1835,85 @@ def setup_org_for_a_rh_repo(options=None):
     # Clone manifest and upload it
     manifest = manifests.clone()
     upload_file(manifest, remote_file=manifest)
-    result = Subscription.upload({
-        u'file': manifest,
-        u'organization-id': org_id,
-    })
-    if result.return_code != 0:
-        raise CLIFactoryError('Failed to upload manifest')
+    try:
+        Subscription.upload({
+            u'file': manifest,
+            u'organization-id': org_id,
+        })
+    except CLIReturnCodeError as err:
+        raise CLIFactoryError('Failed to upload manifest\n{0}'.format(err.msg))
     # Enable repo from Repository Set
-    result = RepositorySet.enable({
-        u'name': options['repository-set'],
-        u'organization-id': org_id,
-        u'product': options['product'],
-        u'releasever': options.get('releasever'),
-        u'basearch': 'x86_64',
-    })
-    if result.return_code != 0:
-        raise CLIFactoryError('Failed to enable repository set')
+    try:
+        RepositorySet.enable({
+            u'basearch': 'x86_64',
+            u'name': options['repository-set'],
+            u'organization-id': org_id,
+            u'product': options['product'],
+            u'releasever': options.get('releasever'),
+        })
+    except CLIReturnCodeError as err:
+        raise CLIFactoryError(
+            'Failed to enable repository set\n{0}'.format(err.msg))
     # Fetch repository info
-    result = Repository.info({
-        u'name': options['repository'],
-        u'product': options['product'],
-        u'organization-id': org_id,
-    })
-    if result.return_code != 0:
-        raise CLIFactoryError('Failed to fetch repository info')
-    rhel_repo = result.stdout
+    try:
+        rhel_repo = Repository.info({
+            u'name': options['repository'],
+            u'organization-id': org_id,
+            u'product': options['product'],
+        })
+    except CLIReturnCodeError as err:
+        raise CLIFactoryError(
+            'Failed to fetch repository info\n{0}'.format(err.msg))
     # Synchronize the RH repository
-    result = Repository.synchronize({
-        u'name': options['repository'],
-        u'organization-id': org_id,
-        u'product': options['product'],
-    })
-    if result.return_code != 0:
-        raise CLIFactoryError('Failed to synchronize repository')
+    try:
+        Repository.synchronize({
+            u'name': options['repository'],
+            u'organization-id': org_id,
+            u'product': options['product'],
+        })
+    except CLIReturnCodeError as err:
+        raise CLIFactoryError(
+            'Failed to synchronize repository\n{0}'.format(err.msg))
     # Create CV if needed and associate repo with it
     if options.get('content-view-id') is None:
         cv_id = make_content_view({u'organization-id': org_id})['id']
     else:
         cv_id = options['content-view-id']
-    result = ContentView.add_repository({
-        u'id': cv_id,
-        u'repository-id': rhel_repo['id'],
-        u'organization-id': org_id,
-    })
-    if result.return_code != 0:
-        raise CLIFactoryError('Failed to add repository to content view')
+    try:
+        ContentView.add_repository({
+            u'id': cv_id,
+            u'organization-id': org_id,
+            u'repository-id': rhel_repo['id'],
+        })
+    except CLIReturnCodeError as err:
+        raise CLIFactoryError(
+            'Failed to add repository to content view\n{0}'.format(err.msg))
     # Publish a new version of CV
-    result = ContentView.publish({u'id': cv_id})
-    if result.return_code != 0:
-        raise CLIFactoryError('Failed to publish new version of content view')
+    try:
+        ContentView.publish({u'id': cv_id})
+    except CLIReturnCodeError as err:
+        raise CLIFactoryError(
+            'Failed to publish new version of content view\n{0}'
+            .format(err.msg)
+        )
     # Get the version id
-    result = ContentView.info({u'id': cv_id})
-    if result.return_code != 0:
-        raise CLIFactoryError('Failed to fetch content view info')
-    cvv = result.stdout['versions'][-1]
+    try:
+        cvv = ContentView.info({u'id': cv_id})['versions'][-1]
+    except CLIReturnCodeError as err:
+        raise CLIFactoryError(
+            'Failed to fetch content view info\n{0}'.format(err.msg))
     # Promote version1 to next env
-    result = ContentView.version_promote({
-        u'id': cvv['id'],
-        u'to-lifecycle-environment-id': env_id,
-        u'organization-id': org_id,
-    })
-    if result.return_code != 0:
-        raise CLIFactoryError('Failed to promote version to next environment')
+    try:
+        ContentView.version_promote({
+            u'id': cvv['id'],
+            u'organization-id': org_id,
+            u'to-lifecycle-environment-id': env_id,
+        })
+    except CLIReturnCodeError as err:
+        raise CLIFactoryError(
+            'Failed to promote version to next environment\n{0}'
+            .format(err.msg)
+        )
     # Create activation key if needed and associate content view with it
     if options.get('activationkey-id') is None:
         activationkey_id = make_activation_key({
@@ -1889,13 +1925,17 @@ def setup_org_for_a_rh_repo(options=None):
         activationkey_id = options['activationkey-id']
         # Given activation key may have no (or different) CV associated.
         # Associate activation key with CV just to be sure
-        result = ActivationKey.update({
-            u'id': activationkey_id,
-            u'organization-id': org_id,
-            u'content-view-id': cv_id,
-        })
-        if result.return_code != 0:
-            raise CLIFactoryError('Failed to associate activation-key with CV')
+        try:
+            ActivationKey.update({
+                u'id': activationkey_id,
+                u'organization-id': org_id,
+                u'content-view-id': cv_id,
+            })
+        except CLIReturnCodeError as err:
+            raise CLIFactoryError(
+                'Failed to associate activation-key with CV\n{0}'
+                .format(err.msg)
+            )
     # Add subscription to activation-key
     activationkey_add_subscription_to_repo({
         u'organization-id': org_id,

--- a/robottelo/cli/gpgkey.py
+++ b/robottelo/cli/gpgkey.py
@@ -44,20 +44,19 @@ class GPGKey(Base):
         # First check for content key
         # id, name, content, organization, repositories
 
-        if len(result.stdout) > 0:
-            key_record = {}
+        if len(result) > 0:
 
             # First item should contain most fields
-            key_record = result.stdout.pop(0)
+            key_record = result.pop(0)
             if 'organization' not in key_record:
                 raise ValueError('Could not find GPG Key')
 
             # Remaining items belong to content
 
-            for item in result.stdout:
+            for item in result:
                 for _, val in item.items():
                     key_record['content'] += val
-            # Update stdout with dictionary
-            result.stdout = key_record
+            # Update result with dictionary
+            result = key_record
 
         return result

--- a/robottelo/cli/host.py
+++ b/robottelo/cli/host.py
@@ -64,8 +64,8 @@ class Host(Base):
 
         facts = []
 
-        if result.stdout:
-            facts = result.stdout
+        if result:
+            facts = result
 
         return facts
 
@@ -134,8 +134,8 @@ class Host(Base):
 
         reports = []
 
-        if result.stdout:
-            reports = result.stdout
+        if result:
+            reports = result
 
         return reports
 

--- a/robottelo/cli/import_.py
+++ b/robottelo/cli/import_.py
@@ -127,7 +127,8 @@ class Import(Base):
         cls.command_sub = 'activation-key'
         return cls.execute(
             cls._construct_command(options),
-            output_format='csv'
+            output_format='csv',
+            return_raw_response=True,
         )
 
     @classmethod
@@ -136,7 +137,8 @@ class Import(Base):
         cls.command_sub = 'organization'
         return cls.execute(
             cls._construct_command(options),
-            output_format=''
+            output_format='',
+            return_raw_response=True,
         )
 
     @classmethod
@@ -145,7 +147,8 @@ class Import(Base):
         cls.command_sub = 'user'
         return cls.execute(
             cls._construct_command(options),
-            output_format=''
+            output_format='',
+            return_raw_response=True,
         )
 
     @classmethod
@@ -154,7 +157,8 @@ class Import(Base):
         cls.command_sub = 'host-collection'
         return cls.execute(
             cls._construct_command(options),
-            output_format=''
+            output_format='',
+            return_raw_response=True,
         )
 
     @classmethod
@@ -166,7 +170,8 @@ class Import(Base):
         cls.command_sub = 'config-file'
         return cls.execute(
             cls._construct_command(options),
-            output_format=''
+            output_format='',
+            return_raw_response=True,
         )
 
     @classmethod
@@ -175,7 +180,8 @@ class Import(Base):
         cls.command_sub = 'content-host'
         return cls.execute(
             cls._construct_command(options),
-            output_format=''
+            output_format='',
+            return_raw_response=True,
         )
 
     @classmethod
@@ -187,7 +193,8 @@ class Import(Base):
         cls.command_sub = 'content-view'
         return cls.execute(
             cls._construct_command(options),
-            output_format=''
+            output_format='',
+            return_raw_response=True,
         )
 
     @classmethod
@@ -196,7 +203,8 @@ class Import(Base):
         cls.command_sub = 'repository'
         return cls.execute(
             cls._construct_command(options),
-            output_format=''
+            output_format='',
+            return_raw_response=True,
         )
 
     @classmethod
@@ -208,7 +216,8 @@ class Import(Base):
         cls.command_sub = 'repository-enable'
         return cls.execute(
             cls._construct_command(options),
-            output_format=''
+            output_format='',
+            return_raw_response=True,
         )
 
     @classmethod
@@ -220,7 +229,8 @@ class Import(Base):
         cls.command_sub = 'template-snippet'
         return cls.execute(
             cls._construct_command(options),
-            output_format=''
+            output_format='',
+            return_raw_response=True,
         )
 
     @classmethod
@@ -232,7 +242,8 @@ class Import(Base):
         cls.command_sub = 'all'
         return cls.execute(
             cls._construct_command(options),
-            output_format=''
+            output_format='',
+            return_raw_response=True,
         )
 
     @classmethod

--- a/robottelo/cli/product.py
+++ b/robottelo/cli/product.py
@@ -60,5 +60,7 @@ class Product(Base):
     def synchronize(cls, options=None):
         """Synchronize a product."""
         cls.command_sub = 'synchronize'
-        return cls._remove_task_status(
-            cls.execute(cls._construct_command(options)))
+        return cls.execute(
+            cls._construct_command(options),
+            ignore_stderr=True,
+        )

--- a/robottelo/cli/repository.py
+++ b/robottelo/cli/repository.py
@@ -53,16 +53,22 @@ class Repository(Base):
         return result
 
     @classmethod
-    def synchronize(cls, options):
+    def synchronize(cls, options, return_raw_response=None):
         """Synchronizes a repository."""
         cls.command_sub = 'synchronize'
-        return cls._remove_task_status(
-            cls.execute(cls._construct_command(options), output_format='csv'))
+        return cls.execute(
+            cls._construct_command(options),
+            output_format='csv',
+            ignore_stderr=True,
+            return_raw_response=return_raw_response,
+        )
 
     @classmethod
     def upload_content(cls, options):
         """Upload content to repository."""
         cls.command_sub = 'upload-content'
-        result = cls.execute(
-            cls._construct_command(options), output_format='csv')
-        return result
+        return cls.execute(
+            cls._construct_command(options),
+            output_format='csv',
+            ignore_stderr=True,
+        )

--- a/robottelo/cli/subscription.py
+++ b/robottelo/cli/subscription.py
@@ -34,22 +34,28 @@ class Subscription(Base):
     def upload(cls, options=None):
         """Upload a subscription manifest."""
         cls.command_sub = 'upload'
-        return cls._remove_task_status(
-            cls.execute(cls._construct_command(options)))
+        return cls.execute(
+            cls._construct_command(options),
+            ignore_stderr=True,
+        )
 
     @classmethod
     def delete_manifest(cls, options=None):
         """Deletes a subscription manifest."""
         cls.command_sub = 'delete-manifest'
-        return cls._remove_task_status(
-            cls.execute(cls._construct_command(options)))
+        return cls.execute(
+            cls._construct_command(options),
+            ignore_stderr=True,
+        )
 
     @classmethod
     def refresh_manifest(cls, options=None):
         """Refreshes a subscription manifest."""
         cls.command_sub = 'refresh-manifest'
-        return cls._remove_task_status(
-            cls.execute(cls._construct_command(options)))
+        return cls.execute(
+            cls._construct_command(options),
+            ignore_stderr=True,
+        )
 
     @classmethod
     def manifest_history(cls, options=None):

--- a/robottelo/cli/template.py
+++ b/robottelo/cli/template.py
@@ -45,8 +45,8 @@ class Template(Base):
 
         kinds = []
 
-        if result.stdout:
-            kinds = result.stdout
+        if result:
+            kinds = result
 
         return kinds
 

--- a/robottelo/test.py
+++ b/robottelo/test.py
@@ -13,6 +13,7 @@ import unittest2
 
 from datetime import datetime
 from robottelo import ssh
+from robottelo.cli.base import CLIReturnCodeError
 from robottelo.cli.metatest import MetaCLITest
 from robottelo.cli.org import Org as OrgCli
 from robottelo.cli.subscription import Subscription
@@ -406,11 +407,12 @@ class ConcurrentTestCase(TestCase):
     @classmethod
     def _get_organization_id(cls):
         """Get organization id"""
-        result = OrgCli.list(per_page=False)
-        if result.return_code != 0:
+        try:
+            result = OrgCli.list(per_page=False)
+        except CLIReturnCodeError:
             cls.logger.error('Fail to get organization id.')
             raise RuntimeError('Invalid organization id. Stop!')
-        return result.stdout[0]['id']
+        return result[0]['id']
 
     def setUp(self):
         self.logger.debug(
@@ -429,16 +431,16 @@ class ConcurrentTestCase(TestCase):
 
     def _get_subscription_id(self):
         """Get subscription id"""
-        result = Subscription.list(
-            {'organization-id': self.org_id},
-            per_page=False
-        )
-
-        if result.return_code != 0:
+        try:
+            result = Subscription.list(
+                {'organization-id': self.org_id},
+                per_page=False
+            )
+        except CLIReturnCodeError:
             self.logger.error('Fail to get subscription id!')
             raise RuntimeError('Invalid subscription id. Stop!')
-        subscription_id = result.stdout[0]['id']
-        subscription_name = result.stdout[0]['name']
+        subscription_id = result[0]['id']
+        subscription_name = result[0]['name']
         self.logger.info(
             'Subscribed to {0} with subscription id {1}'
             .format(subscription_name, subscription_id)

--- a/tests/foreman/cli/test_architecture.py
+++ b/tests/foreman/cli/test_architecture.py
@@ -2,7 +2,8 @@
 """Test class for Architecture CLI"""
 
 from robottelo.cli.architecture import Architecture
-from robottelo.cli.factory import make_architecture, CLIFactoryError
+from robottelo.cli.base import CLIReturnCodeError
+from robottelo.cli.factory import make_architecture
 from robottelo.decorators import run_only_on
 from robottelo.helpers import invalid_values_list, valid_data_list
 from robottelo.test import MetaCLITestCase
@@ -24,19 +25,15 @@ class TestArchitecture(MetaCLITestCase):
         @assert: architecture name is not updated
 
         """
-        try:
-            new_obj = make_architecture()
-        except CLIFactoryError as err:
-            self.fail(err)
-        for data in invalid_values_list():
-            with self.subTest(data):
-                # Update the architecture name
-                result = Architecture.update({
-                    'id': new_obj['id'],
-                    'new-name': data,
-                })
-                self.assertNotEqual(result.return_code, 0)
-                self.assertGreater(len(result.stderr), 0)
+        arch = make_architecture()
+        # Update the architecture name
+        for new_name in invalid_values_list():
+            with self.subTest(new_name):
+                with self.assertRaises(CLIReturnCodeError):
+                    Architecture.update({
+                        'id': arch['id'],
+                        'new-name': new_name,
+                    })
 
     def test_positive_delete(self):
         """@test: Create architecture with valid values then delete it
@@ -47,19 +44,10 @@ class TestArchitecture(MetaCLITestCase):
         @assert: architecture is deleted
 
         """
-        for data in valid_data_list():
-            with self.subTest(data):
-                try:
-                    new_obj = make_architecture({'name': data})
-                except CLIFactoryError as err:
-                    self.fail(err)
-
-                return_value = Architecture.delete({'id': new_obj['id']})
-                self.assertEqual(return_value.return_code, 0)
-                self.assertEqual(len(return_value.stderr), 0)
-
+        for name in valid_data_list():
+            with self.subTest(name):
+                arch = make_architecture({'name': name})
+                Architecture.delete({'id': arch['id']})
                 # Can we find the object?
-                result = Architecture.info({'id': new_obj['id']})
-                self.assertNotEqual(result.return_code, 0)
-                self.assertGreater(len(result.stderr), 0)
-                self.assertEqual(len(result.stdout), 0)
+                with self.assertRaises(CLIReturnCodeError):
+                    Architecture.info({'id': arch['id']})

--- a/tests/foreman/cli/test_contentviewfilter.py
+++ b/tests/foreman/cli/test_contentviewfilter.py
@@ -3,9 +3,9 @@
 """Test class for Content View Filters"""
 
 from fauxfactory import gen_choice, gen_string
+from robottelo.cli.base import CLIReturnCodeError
 from robottelo.cli.contentview import ContentView
 from robottelo.cli.factory import (
-    CLIFactoryError,
     make_content_view,
     make_org,
     make_product,
@@ -55,21 +55,17 @@ class TestContentViewFilter(CLITestCase):
                     'package_group',
                     'erratum',
                 ])
-                result = ContentView.filter_create({
+                ContentView.filter_create({
                     'content-view-id': self.content_view['id'],
-                    'type': filter_content_type,
                     'name': name,
+                    'type': filter_content_type,
                 })
-                self.assertEqual(result.return_code, 0)
-                self.assertEqual(len(result.stderr), 0)
-
-                result = ContentView.filter_info({
+                cvf = ContentView.filter_info({
                     u'content-view-id': self.content_view['id'],
                     u'name': name,
                 })
-                self.assertEqual(result.return_code, 0)
-                self.assertEqual(result.stdout['name'], name)
-                self.assertEqual(result.stdout['type'], filter_content_type)
+                self.assertEqual(cvf['name'], name)
+                self.assertEqual(cvf['type'], filter_content_type)
 
     def test_create_cvf_content_types(self):
         """Test: Create new content view filter and assign it to existing
@@ -84,20 +80,16 @@ class TestContentViewFilter(CLITestCase):
         for filter_content_type in ('rpm', 'package_group', 'erratum'):
             with self.subTest(filter_content_type):
                 cvf_name = gen_string('utf8')
-                result = ContentView.filter_create({
+                ContentView.filter_create({
                     'content-view-id': self.content_view['id'],
-                    'type': filter_content_type,
                     'name': cvf_name,
+                    'type': filter_content_type,
                 })
-                self.assertEqual(result.return_code, 0)
-                self.assertEqual(len(result.stderr), 0)
-
-                result = ContentView.filter_info({
+                cvf = ContentView.filter_info({
                     u'content-view-id': self.content_view['id'],
                     u'name': cvf_name,
                 })
-                self.assertEqual(result.return_code, 0)
-                self.assertEqual(result.stdout['type'], filter_content_type)
+                self.assertEqual(cvf['type'], filter_content_type)
 
     def test_create_cvf_inclusions(self):
         """Test: Create new content view filter and assign it to existing
@@ -112,21 +104,17 @@ class TestContentViewFilter(CLITestCase):
         for inclusion in ('true', 'false'):
             with self.subTest(inclusion):
                 cvf_name = gen_string('utf8')
-                result = ContentView.filter_create({
+                ContentView.filter_create({
                     'content-view-id': self.content_view['id'],
-                    'type': 'rpm',
                     'inclusion': inclusion,
                     'name': cvf_name,
+                    'type': 'rpm',
                 })
-                self.assertEqual(result.return_code, 0)
-                self.assertEqual(len(result.stderr), 0)
-
-                result = ContentView.filter_info({
+                cvf = ContentView.filter_info({
                     u'content-view-id': self.content_view['id'],
                     u'name': cvf_name,
                 })
-                self.assertEqual(result.return_code, 0)
-                self.assertEqual(result.stdout['inclusion'], inclusion)
+                self.assertEqual(cvf['inclusion'], inclusion)
 
     @skip_if_bug_open('bugzilla', 1236532)
     def test_create_cvf_description(self):
@@ -141,21 +129,17 @@ class TestContentViewFilter(CLITestCase):
         """
         description = gen_string('utf8')
         cvf_name = gen_string('utf8')
-        result = ContentView.filter_create({
+        ContentView.filter_create({
             'content-view-id': self.content_view['id'],
             'description': description,
-            'type': 'package_group',
             'name': cvf_name,
+            'type': 'package_group',
         })
-        self.assertEqual(result.return_code, 0)
-        self.assertEqual(len(result.stderr), 0)
-
-        result = ContentView.filter_info({
+        cvf = ContentView.filter_info({
             u'content-view-id': self.content_view['id'],
             u'name': cvf_name,
         })
-        self.assertEqual(result.return_code, 0)
-        self.assertEqual(result.stdout['description'], description)
+        self.assertEqual(cvf['description'], description)
 
     def test_create_cvf_by_cv_name(self):
         """Test: Create new content view filter and assign it to existing
@@ -167,21 +151,17 @@ class TestContentViewFilter(CLITestCase):
 
         """
         cvf_name = gen_string('utf8')
-        result = ContentView.filter_create({
+        ContentView.filter_create({
             'content-view': self.content_view['name'],
-            'organization-id': self.org['id'],
-            'type': 'package_group',
             'inclusion': 'true',
             'name': cvf_name,
+            'organization-id': self.org['id'],
+            'type': 'package_group',
         })
-        self.assertEqual(result.return_code, 0)
-        self.assertEqual(len(result.stderr), 0)
-
-        result = ContentView.filter_info({
+        ContentView.filter_info({
             u'content-view-id': self.content_view['id'],
             u'name': cvf_name,
         })
-        self.assertEqual(result.return_code, 0)
 
     def test_create_cvf_by_org_name(self):
         """Test: Create new content view filter and assign it to existing
@@ -193,21 +173,17 @@ class TestContentViewFilter(CLITestCase):
 
         """
         cvf_name = gen_string('utf8')
-        result = ContentView.filter_create({
+        ContentView.filter_create({
             'content-view': self.content_view['name'],
-            'organization': self.org['name'],
-            'type': 'erratum',
             'inclusion': 'false',
             'name': cvf_name,
+            'organization': self.org['name'],
+            'type': 'erratum',
         })
-        self.assertEqual(result.return_code, 0)
-        self.assertEqual(len(result.stderr), 0)
-
-        result = ContentView.filter_info({
+        ContentView.filter_info({
             u'content-view-id': self.content_view['id'],
             u'name': cvf_name,
         })
-        self.assertEqual(result.return_code, 0)
 
     def test_create_cvf_by_org_label(self):
         """Test: Create new content view filter and assign it to existing
@@ -219,21 +195,17 @@ class TestContentViewFilter(CLITestCase):
 
         """
         cvf_name = gen_string('utf8')
-        result = ContentView.filter_create({
+        ContentView.filter_create({
             'content-view': self.content_view['name'],
-            'organization-label': self.org['label'],
-            'type': 'erratum',
             'inclusion': 'true',
             'name': cvf_name,
+            'organization-label': self.org['label'],
+            'type': 'erratum',
         })
-        self.assertEqual(result.return_code, 0)
-        self.assertEqual(len(result.stderr), 0)
-
-        result = ContentView.filter_info({
+        ContentView.filter_info({
             u'content-view-id': self.content_view['id'],
             u'name': cvf_name,
         })
-        self.assertEqual(result.return_code, 0)
 
     def test_create_cvf_repo_by_id(self):
         """Test: Create new content view filter and assign it to existing
@@ -247,23 +219,18 @@ class TestContentViewFilter(CLITestCase):
 
         """
         cvf_name = gen_string('utf8')
-        result = ContentView.filter_create({
+        ContentView.filter_create({
             'content-view-id': self.content_view['id'],
-            'type': 'rpm',
             'inclusion': 'true',
             'name': cvf_name,
             'repository-ids': self.repo['id'],
+            'type': 'rpm',
         })
-        self.assertEqual(result.return_code, 0)
-        self.assertEqual(len(result.stderr), 0)
-
-        result = ContentView.filter_info({
+        cvf = ContentView.filter_info({
             u'content-view-id': self.content_view['id'],
             u'name': cvf_name,
         })
-        self.assertEqual(result.return_code, 0)
-        self.assertEqual(
-            result.stdout['repositories'][0]['name'], self.repo['name'])
+        self.assertEqual(cvf['repositories'][0]['name'], self.repo['name'])
 
     @skip_if_bug_open('bugzilla', 1228890)
     def test_create_cvf_repo_by_name(self):
@@ -278,23 +245,18 @@ class TestContentViewFilter(CLITestCase):
 
         """
         cvf_name = gen_string('utf8')
-        result = ContentView.filter_create({
+        ContentView.filter_create({
             'content-view-id': self.content_view['id'],
-            'type': 'rpm',
             'inclusion': 'false',
             'name': cvf_name,
             'repositories': self.repo['name'],
+            'type': 'rpm',
         })
-        self.assertEqual(result.return_code, 0)
-        self.assertEqual(len(result.stderr), 0)
-
-        result = ContentView.filter_info({
+        cvf = ContentView.filter_info({
             u'content-view-id': self.content_view['id'],
             u'name': cvf_name,
         })
-        self.assertEqual(result.return_code, 0)
-        self.assertEqual(
-            result.stdout['repositories'][0]['name'], self.repo['name'])
+        self.assertEqual(cvf['repositories'][0]['name'], self.repo['name'])
 
     def test_create_cvf_original_pkgs(self):
         """Test: Create new content view filter and assign it to existing
@@ -308,24 +270,19 @@ class TestContentViewFilter(CLITestCase):
 
         """
         cvf_name = gen_string('utf8')
-        result = ContentView.filter_create({
+        ContentView.filter_create({
             'content-view-id': self.content_view['id'],
-            'type': 'rpm',
             'inclusion': 'true',
             'name': cvf_name,
-            'repository-ids': self.repo['id'],
             'original-packages': 'true',
+            'repository-ids': self.repo['id'],
+            'type': 'rpm',
         })
-        self.assertEqual(result.return_code, 0)
-        self.assertEqual(len(result.stderr), 0)
-
-        result = ContentView.filter_info({
+        cvf = ContentView.filter_info({
             u'content-view-id': self.content_view['id'],
             u'name': cvf_name,
         })
-        self.assertEqual(result.return_code, 0)
-        self.assertEqual(
-            result.stdout['repositories'][0]['name'], self.repo['name'])
+        self.assertEqual(cvf['repositories'][0]['name'], self.repo['name'])
 
     def test_create_cvf_repos_docker(self):
         """Test: Create new docker repository and add to content view that has
@@ -339,43 +296,32 @@ class TestContentViewFilter(CLITestCase):
         repositories affected (yum and docker)
 
         """
-        try:
-            docker_repository = make_repository({
-                u'content-type': u'docker',
-                u'docker-upstream-name': u'busybox',
-                u'product-id': self.product['id'],
-                u'url': DOCKER_REGISTRY_HUB,
-            })
-        except CLIFactoryError as err:
-            self.fail(err)
-
-        result = ContentView.add_repository({
+        docker_repository = make_repository({
+            u'content-type': u'docker',
+            u'docker-upstream-name': u'busybox',
+            u'product-id': self.product['id'],
+            u'url': DOCKER_REGISTRY_HUB,
+        })
+        ContentView.add_repository({
             u'id': self.content_view['id'],
             u'repository-id': docker_repository['id'],
         })
-        self.assertEqual(result.return_code, 0)
-
-        repos = '{0},{1}'.format(self.repo['id'], docker_repository['id'])
-
+        repos = [self.repo['id'], docker_repository['id']]
         cvf_name = gen_string('utf8')
-        result = ContentView.filter_create({
+        ContentView.filter_create({
             'content-view-id': self.content_view['id'],
-            'type': 'rpm',
             'inclusion': 'true',
             'name': cvf_name,
             'repository-ids': repos,
+            'type': 'rpm',
         })
-        self.assertEqual(result.return_code, 0)
-        self.assertEqual(len(result.stderr), 0)
-
-        result = ContentView.filter_info({
+        cvf = ContentView.filter_info({
             u'content-view-id': self.content_view['id'],
             u'name': cvf_name,
         })
-        self.assertEqual(result.return_code, 0)
-        self.assertEqual(len(result.stdout['repositories']), 2)
-        for i in range(2):
-            self.assertIn(result.stdout['repositories'][i]['id'], repos)
+        self.assertEqual(len(cvf['repositories']), 2)
+        for repo in cvf['repositories']:
+            self.assertIn(repo['id'], repos)
 
     def test_create_cvf_names_negative(self):
         """@Test: Try to create content view filter using invalid names only
@@ -387,13 +333,12 @@ class TestContentViewFilter(CLITestCase):
         """
         for name in invalid_values_list():
             with self.subTest(name):
-                result = ContentView.filter_create({
-                    'content-view-id': self.content_view['id'],
-                    'type': 'rpm',
-                    'name': name,
-                })
-                self.assertNotEqual(result.return_code, 0)
-                self.assertNotEqual(len(result.stderr), 0)
+                with self.assertRaises(CLIReturnCodeError):
+                    ContentView.filter_create({
+                        'content-view-id': self.content_view['id'],
+                        'name': name,
+                        'type': 'rpm',
+                    })
 
     def test_create_same_name_negative(self):
         """@Test: Try to create content view filter using same name twice
@@ -404,21 +349,17 @@ class TestContentViewFilter(CLITestCase):
 
         """
         cvf_name = gen_string('utf8')
-        result = ContentView.filter_create({
+        ContentView.filter_create({
             'content-view-id': self.content_view['id'],
-            'type': 'rpm',
             'name': cvf_name,
-        })
-        self.assertEqual(result.return_code, 0)
-        self.assertEqual(len(result.stderr), 0)
-
-        result = ContentView.filter_create({
-            'content-view-id': self.content_view['id'],
             'type': 'rpm',
-            'name': cvf_name,
         })
-        self.assertNotEqual(result.return_code, 0)
-        self.assertNotEqual(len(result.stderr), 0)
+        with self.assertRaises(CLIReturnCodeError):
+            ContentView.filter_create({
+                'content-view-id': self.content_view['id'],
+                'name': cvf_name,
+                'type': 'rpm',
+            })
 
     def test_create_no_type_negative(self):
         """@Test: Try to create content view filter without providing required
@@ -429,13 +370,11 @@ class TestContentViewFilter(CLITestCase):
         @Assert: Content view filter is not created
 
         """
-        cvf_name = gen_string('utf8')
-        result = ContentView.filter_create({
-            'content-view-id': self.content_view['id'],
-            'name': cvf_name,
-        })
-        self.assertNotEqual(result.return_code, 0)
-        self.assertNotEqual(len(result.stderr), 0)
+        with self.assertRaises(CLIReturnCodeError):
+            ContentView.filter_create({
+                'content-view-id': self.content_view['id'],
+                'name': gen_string('utf8'),
+            })
 
     def test_create_without_cv_negative(self):
         """@Test: Try to create content view filter without providing content
@@ -446,13 +385,11 @@ class TestContentViewFilter(CLITestCase):
         @Assert: Content view filter is not created
 
         """
-        cvf_name = gen_string('utf8')
-        result = ContentView.filter_create({
-            'type': 'rpm',
-            'name': cvf_name,
-        })
-        self.assertNotEqual(result.return_code, 0)
-        self.assertNotEqual(len(result.stderr), 0)
+        with self.assertRaises(CLIReturnCodeError):
+            ContentView.filter_create({
+                'name': gen_string('utf8'),
+                'type': 'rpm',
+            })
 
     def test_create_repo_by_id_negative(self):
         """@Test: Try to create content view filter using incorrect repository
@@ -462,15 +399,13 @@ class TestContentViewFilter(CLITestCase):
         @Assert: Content view filter is not created
 
         """
-        cvf_name = gen_string('utf8')
-        result = ContentView.filter_create({
-            'content-view-id': self.content_view['id'],
-            'type': 'rpm',
-            'name': cvf_name,
-            'repository-ids': gen_string('numeric', 6),
-        })
-        self.assertNotEqual(result.return_code, 0)
-        self.assertNotEqual(len(result.stderr), 0)
+        with self.assertRaises(CLIReturnCodeError):
+            ContentView.filter_create({
+                'content-view-id': self.content_view['id'],
+                'name': gen_string('utf8'),
+                'repository-ids': gen_string('numeric', 6),
+                'type': 'rpm',
+            })
 
     def test_update_cvf_different_names(self):
         """Test: Create new content view filter and assign it to existing
@@ -486,25 +421,21 @@ class TestContentViewFilter(CLITestCase):
         cvf_name = gen_string('utf8')
         ContentView.filter_create({
             'content-view-id': self.content_view['id'],
-            'type': 'rpm',
             'name': cvf_name,
+            'type': 'rpm',
         })
         for new_name in valid_data_list():
             with self.subTest(new_name):
-                result = ContentView.filter_update({
+                ContentView.filter_update({
                     'content-view-id': self.content_view['id'],
                     'name': cvf_name,
                     'new-name': new_name,
                 })
-                self.assertEqual(result.return_code, 0)
-                self.assertEqual(len(result.stderr), 0)
-
-                result = ContentView.filter_info({
+                cvf = ContentView.filter_info({
                     u'content-view-id': self.content_view['id'],
                     u'name': new_name,
                 })
-                self.assertEqual(result.return_code, 0)
-                self.assertEqual(result.stdout['name'], new_name)
+                self.assertEqual(cvf['name'], new_name)
                 cvf_name = new_name  # updating cvf name for next iteration
 
     def test_update_cvf_repo(self):
@@ -519,48 +450,38 @@ class TestContentViewFilter(CLITestCase):
 
         """
         cvf_name = gen_string('utf8')
-        result = ContentView.filter_create({
+        ContentView.filter_create({
             'content-view-id': self.content_view['id'],
-            'type': 'rpm',
             'name': cvf_name,
             'repository-ids': self.repo['id'],
+            'type': 'rpm',
         })
-        self.assertEqual(result.return_code, 0)
-
-        result = ContentView.filter_info({
+        cvf = ContentView.filter_info({
             u'content-view-id': self.content_view['id'],
             u'name': cvf_name,
         })
-        self.assertEqual(result.return_code, 0)
-        self.assertEqual(len(result.stdout['repositories']), 1)
-        self.assertEqual(
-            result.stdout['repositories'][0]['name'], self.repo['name'])
+        self.assertEqual(len(cvf['repositories']), 1)
+        self.assertEqual(cvf['repositories'][0]['name'], self.repo['name'])
 
         new_repo = make_repository({u'product-id': self.product['id']})
-        result = ContentView.add_repository({
+        ContentView.add_repository({
             u'id': self.content_view['id'],
             u'repository-id': new_repo['id'],
         })
-        self.assertEqual(result.return_code, 0)
 
-        result = ContentView.filter_update({
+        ContentView.filter_update({
             'content-view-id': self.content_view['id'],
             'name': cvf_name,
             'repository-ids': new_repo['id'],
         })
-        self.assertEqual(result.return_code, 0)
-        self.assertEqual(len(result.stderr), 0)
 
-        result = ContentView.filter_info({
+        cvf = ContentView.filter_info({
             u'content-view-id': self.content_view['id'],
             u'name': cvf_name,
         })
-        self.assertEqual(result.return_code, 0)
-        self.assertEqual(len(result.stdout['repositories']), 1)
-        self.assertNotEqual(
-            result.stdout['repositories'][0]['name'], self.repo['name'])
-        self.assertEqual(
-            result.stdout['repositories'][0]['name'], new_repo['name'])
+        self.assertEqual(len(cvf['repositories']), 1)
+        self.assertNotEqual(cvf['repositories'][0]['name'], self.repo['name'])
+        self.assertEqual(cvf['repositories'][0]['name'], new_repo['name'])
 
     def test_update_cvf_repo_type(self):
         """Test: Create new content view filter and apply it to existing
@@ -575,57 +496,40 @@ class TestContentViewFilter(CLITestCase):
 
         """
         cvf_name = gen_string('utf8')
-        result = ContentView.filter_create({
+        ContentView.filter_create({
             'content-view-id': self.content_view['id'],
-            'type': 'rpm',
             'name': cvf_name,
             'repository-ids': self.repo['id'],
+            'type': 'rpm',
         })
-        self.assertEqual(result.return_code, 0)
-
-        result = ContentView.filter_info({
+        cvf = ContentView.filter_info({
             u'content-view-id': self.content_view['id'],
             u'name': cvf_name,
         })
-        self.assertEqual(result.return_code, 0)
-        self.assertEqual(len(result.stdout['repositories']), 1)
-        self.assertEqual(
-            result.stdout['repositories'][0]['name'], self.repo['name'])
-
-        try:
-            docker_repo = make_repository({
-                u'content-type': u'docker',
-                u'docker-upstream-name': u'busybox',
-                u'product-id': self.product['id'],
-                u'url': DOCKER_REGISTRY_HUB,
-            })
-        except CLIFactoryError as err:
-            self.fail(err)
-
-        result = ContentView.add_repository({
+        self.assertEqual(len(cvf['repositories']), 1)
+        self.assertEqual(cvf['repositories'][0]['name'], self.repo['name'])
+        docker_repo = make_repository({
+            u'content-type': u'docker',
+            u'docker-upstream-name': u'busybox',
+            u'product-id': self.product['id'],
+            u'url': DOCKER_REGISTRY_HUB,
+        })
+        ContentView.add_repository({
             u'id': self.content_view['id'],
             u'repository-id': docker_repo['id'],
         })
-        self.assertEqual(result.return_code, 0)
-
-        result = ContentView.filter_update({
+        ContentView.filter_update({
             'content-view-id': self.content_view['id'],
             'name': cvf_name,
             'repository-ids': docker_repo['id'],
         })
-        self.assertEqual(result.return_code, 0)
-        self.assertEqual(len(result.stderr), 0)
-
-        result = ContentView.filter_info({
+        cvf = ContentView.filter_info({
             u'content-view-id': self.content_view['id'],
             u'name': cvf_name,
         })
-        self.assertEqual(result.return_code, 0)
-        self.assertEqual(len(result.stdout['repositories']), 1)
-        self.assertNotEqual(
-            result.stdout['repositories'][0]['name'], self.repo['name'])
-        self.assertEqual(
-            result.stdout['repositories'][0]['name'], docker_repo['name'])
+        self.assertEqual(len(cvf['repositories']), 1)
+        self.assertNotEqual(cvf['repositories'][0]['name'], self.repo['name'])
+        self.assertEqual(cvf['repositories'][0]['name'], docker_repo['name'])
 
     def test_update_cvf_inclusion(self):
         """Test: Create new content view filter and assign it to existing
@@ -639,35 +543,27 @@ class TestContentViewFilter(CLITestCase):
 
         """
         cvf_name = gen_string('utf8')
-        result = ContentView.filter_create({
+        ContentView.filter_create({
             'content-view-id': self.content_view['id'],
             'inclusion': 'true',
-            'type': 'rpm',
             'name': cvf_name,
+            'type': 'rpm',
         })
-        self.assertEqual(result.return_code, 0)
-
-        result = ContentView.filter_info({
+        cvf = ContentView.filter_info({
             u'content-view-id': self.content_view['id'],
             u'name': cvf_name,
         })
-        self.assertEqual(result.return_code, 0)
-        self.assertEqual(result.stdout['inclusion'], 'true')
-
-        result = ContentView.filter_update({
+        self.assertEqual(cvf['inclusion'], 'true')
+        ContentView.filter_update({
             'content-view-id': self.content_view['id'],
             'name': cvf_name,
             'inclusion': 'false',
         })
-        self.assertEqual(result.return_code, 0)
-        self.assertEqual(len(result.stderr), 0)
-
-        result = ContentView.filter_info({
+        cvf = ContentView.filter_info({
             u'content-view-id': self.content_view['id'],
             u'name': cvf_name,
         })
-        self.assertEqual(result.return_code, 0)
-        self.assertEqual(result.stdout['inclusion'], 'false')
+        self.assertEqual(cvf['inclusion'], 'false')
 
     def test_update_diffnames_negative(self):
         """@Test: Try to update content view filter using invalid names only
@@ -678,27 +574,24 @@ class TestContentViewFilter(CLITestCase):
 
         """
         cvf_name = gen_string('utf8')
-        result = ContentView.filter_create({
+        ContentView.filter_create({
             'content-view-id': self.content_view['id'],
-            'type': 'rpm',
             'name': cvf_name,
+            'type': 'rpm',
         })
-        self.assertEqual(result.return_code, 0)
         for new_name in invalid_values_list():
             with self.subTest(new_name):
-                result = ContentView.filter_update({
-                    'content-view-id': self.content_view['id'],
-                    'name': cvf_name,
-                    'new-name': new_name,
-                })
-                self.assertNotEqual(result.return_code, 0)
-                self.assertNotEqual(len(result.stderr), 0)
-
-                result = ContentView.filter_info({
-                    u'content-view-id': self.content_view['id'],
-                    u'name': new_name,
-                })
-                self.assertNotEqual(result.return_code, 0)
+                with self.assertRaises(CLIReturnCodeError):
+                    ContentView.filter_update({
+                        'content-view-id': self.content_view['id'],
+                        'name': cvf_name,
+                        'new-name': new_name,
+                    })
+                with self.assertRaises(CLIReturnCodeError):
+                    ContentView.filter_info({
+                        u'content-view-id': self.content_view['id'],
+                        u'name': new_name,
+                    })
 
     def test_update_samename_negative(self):
         """@Test: Try to update content view filter using name of already
@@ -710,28 +603,23 @@ class TestContentViewFilter(CLITestCase):
 
         """
         cvf_name = gen_string('utf8')
-        result = ContentView.filter_create({
+        ContentView.filter_create({
             'content-view-id': self.content_view['id'],
-            'type': 'rpm',
             'name': cvf_name,
-        })
-        self.assertEqual(result.return_code, 0)
-
-        new_name = gen_string('alpha', 100)
-        result = ContentView.filter_create({
-            'content-view-id': self.content_view['id'],
             'type': 'rpm',
-            'name': new_name,
         })
-        self.assertEqual(result.return_code, 0)
-
-        result = ContentView.filter_update({
+        new_name = gen_string('alpha', 100)
+        ContentView.filter_create({
             'content-view-id': self.content_view['id'],
             'name': new_name,
-            'new-name': cvf_name,
+            'type': 'rpm',
         })
-        self.assertNotEqual(result.return_code, 0)
-        self.assertNotEqual(len(result.stderr), 0)
+        with self.assertRaises(CLIReturnCodeError):
+            ContentView.filter_update({
+                'content-view-id': self.content_view['id'],
+                'name': new_name,
+                'new-name': cvf_name,
+            })
 
     def test_update_inclusion_negative(self):
         """Test: Try to update content view filter and assign incorrect
@@ -743,28 +631,23 @@ class TestContentViewFilter(CLITestCase):
 
         """
         cvf_name = gen_string('utf8')
-        result = ContentView.filter_create({
+        ContentView.filter_create({
             'content-view-id': self.content_view['id'],
             'inclusion': 'true',
+            'name': cvf_name,
             'type': 'rpm',
-            'name': cvf_name,
         })
-        self.assertEqual(result.return_code, 0)
-
-        result = ContentView.filter_update({
-            'content-view-id': self.content_view['id'],
-            'name': cvf_name,
-            'inclusion': 'wrong_value',
-        })
-        self.assertNotEqual(result.return_code, 0)
-        self.assertNotEqual(len(result.stderr), 0)
-
-        result = ContentView.filter_info({
+        with self.assertRaises(CLIReturnCodeError):
+            ContentView.filter_update({
+                'content-view-id': self.content_view['id'],
+                'inclusion': 'wrong_value',
+                'name': cvf_name,
+            })
+        cvf = ContentView.filter_info({
             u'content-view-id': self.content_view['id'],
             u'name': cvf_name,
         })
-        self.assertEqual(result.return_code, 0)
-        self.assertEqual(result.stdout['inclusion'], 'true')
+        self.assertEqual(cvf['inclusion'], 'true')
 
     def test_update_wrongrepo_negative(self):
         """Test: Try to update content view filter using non-existing
@@ -776,21 +659,18 @@ class TestContentViewFilter(CLITestCase):
 
         """
         cvf_name = gen_string('utf8')
-        result = ContentView.filter_create({
+        ContentView.filter_create({
             'content-view-id': self.content_view['id'],
-            'type': 'rpm',
             'name': cvf_name,
             'repository-ids': self.repo['id'],
+            'type': 'rpm',
         })
-        self.assertEqual(result.return_code, 0)
-
-        result = ContentView.filter_update({
-            'content-view-id': self.content_view['id'],
-            'name': cvf_name,
-            'repository-ids': gen_string('numeric', 6),
-        })
-        self.assertNotEqual(result.return_code, 0)
-        self.assertNotEqual(len(result.stderr), 0)
+        with self.assertRaises(CLIReturnCodeError):
+            ContentView.filter_update({
+                'content-view-id': self.content_view['id'],
+                'name': cvf_name,
+                'repository-ids': gen_string('numeric', 6),
+            })
 
     def test_update_new_repo_negative(self):
         """Test: Try to update filter and assign repository which does not
@@ -802,23 +682,19 @@ class TestContentViewFilter(CLITestCase):
 
         """
         cvf_name = gen_string('utf8')
-        result = ContentView.filter_create({
+        ContentView.filter_create({
             'content-view-id': self.content_view['id'],
-            'type': 'rpm',
             'name': cvf_name,
             'repository-ids': self.repo['id'],
+            'type': 'rpm',
         })
-        self.assertEqual(result.return_code, 0)
-
         new_repo = make_repository({u'product-id': self.product['id']})
-
-        result = ContentView.filter_update({
-            'content-view-id': self.content_view['id'],
-            'name': cvf_name,
-            'repository-ids': new_repo['id'],
-        })
-        self.assertNotEqual(result.return_code, 0)
-        self.assertNotEqual(len(result.stderr), 0)
+        with self.assertRaises(CLIReturnCodeError):
+            ContentView.filter_update({
+                'content-view-id': self.content_view['id'],
+                'name': cvf_name,
+                'repository-ids': new_repo['id'],
+            })
 
     def test_delete_cvf_different_names(self):
         """Test: Create new content view filter and assign it to existing
@@ -832,31 +708,24 @@ class TestContentViewFilter(CLITestCase):
         """
         for name in valid_data_list():
             with self.subTest(name):
-                result = ContentView.filter_create({
+                ContentView.filter_create({
                     'content-view-id': self.content_view['id'],
-                    'type': 'rpm',
                     'name': name,
+                    'type': 'rpm',
                 })
-                self.assertEqual(result.return_code, 0)
-
-                result = ContentView.filter_info({
+                ContentView.filter_info({
                     u'content-view-id': self.content_view['id'],
                     u'name': name,
                 })
-                self.assertEqual(result.return_code, 0)
-
-                result = ContentView.filter_delete({
+                ContentView.filter_delete({
                     u'content-view-id': self.content_view['id'],
                     u'name': name,
                 })
-                self.assertEqual(result.return_code, 0)
-                self.assertEqual(len(result.stderr), 0)
-
-                result = ContentView.filter_info({
-                    u'content-view-id': self.content_view['id'],
-                    u'name': name,
-                })
-                self.assertNotEqual(result.return_code, 0)
+                with self.assertRaises(CLIReturnCodeError):
+                    ContentView.filter_info({
+                        u'content-view-id': self.content_view['id'],
+                        u'name': name,
+                    })
 
     def test_delete_cvf_by_id(self):
         """Test: Create new content view filter and assign it to existing
@@ -869,30 +738,21 @@ class TestContentViewFilter(CLITestCase):
 
         """
         cvf_name = gen_string('utf8')
-        result = ContentView.filter_create({
+        ContentView.filter_create({
             'content-view-id': self.content_view['id'],
-            'type': 'rpm',
             'name': cvf_name,
+            'type': 'rpm',
         })
-        self.assertEqual(result.return_code, 0)
-
-        result = ContentView.filter_info({
+        cvf = ContentView.filter_info({
             u'content-view-id': self.content_view['id'],
             u'name': cvf_name,
         })
-        self.assertEqual(result.return_code, 0)
-
-        result = ContentView.filter_delete({
-            u'id': result.stdout['filter-id'],
-        })
-        self.assertEqual(result.return_code, 0)
-        self.assertEqual(len(result.stderr), 0)
-
-        result = ContentView.filter_info({
-            u'content-view-id': self.content_view['id'],
-            u'name': cvf_name,
-        })
-        self.assertNotEqual(result.return_code, 0)
+        ContentView.filter_delete({'id': cvf['filter-id']})
+        with self.assertRaises(CLIReturnCodeError):
+            ContentView.filter_info({
+                u'content-view-id': self.content_view['id'],
+                u'name': cvf_name,
+            })
 
     def test_delete_cvf_org(self):
         """Test: Create new content view filter and assign it to existing
@@ -905,32 +765,25 @@ class TestContentViewFilter(CLITestCase):
 
         """
         cvf_name = gen_string('utf8')
-        result = ContentView.filter_create({
+        ContentView.filter_create({
             'content-view-id': self.content_view['id'],
-            'type': 'rpm',
             'name': cvf_name,
+            'type': 'rpm',
         })
-        self.assertEqual(result.return_code, 0)
-
-        result = ContentView.filter_info({
+        ContentView.filter_info({
             u'content-view-id': self.content_view['id'],
             u'name': cvf_name,
         })
-        self.assertEqual(result.return_code, 0)
-
-        result = ContentView.filter_delete({
+        ContentView.filter_delete({
             u'content-view': self.content_view['name'],
+            u'name': cvf_name,
             u'organization': self.org['name'],
-            u'name': cvf_name,
         })
-        self.assertEqual(result.return_code, 0)
-        self.assertEqual(len(result.stderr), 0)
-
-        result = ContentView.filter_info({
-            u'content-view-id': self.content_view['id'],
-            u'name': cvf_name,
-        })
-        self.assertNotEqual(result.return_code, 0)
+        with self.assertRaises(CLIReturnCodeError):
+            ContentView.filter_info({
+                u'content-view-id': self.content_view['id'],
+                u'name': cvf_name,
+            })
 
     def test_delete_cvf_name_negative(self):
         """Test: Try to delete non-existent filter using generated name
@@ -940,9 +793,8 @@ class TestContentViewFilter(CLITestCase):
         @Assert: System returned error
 
         """
-        result = ContentView.filter_delete({
-            u'content-view-id': self.content_view['id'],
-            u'name': u'invalid_cv_filter',
-        })
-        self.assertNotEqual(result.return_code, 0)
-        self.assertGreater(len(result.stderr), 0)
+        with self.assertRaises(CLIReturnCodeError):
+            ContentView.filter_delete({
+                u'content-view-id': self.content_view['id'],
+                u'name': u'invalid_cv_filter',
+            })

--- a/tests/foreman/cli/test_docker.py
+++ b/tests/foreman/cli/test_docker.py
@@ -2,9 +2,9 @@
 from fauxfactory import gen_alpha, gen_choice, gen_string, gen_url
 from nailgun import entities
 from random import choice, randint
+from robottelo.cli.base import CLIReturnCodeError
 from robottelo.cli.docker import Docker, DockerContainer
 from robottelo.cli.factory import (
-    CLIFactoryError,
     make_activation_key,
     make_compute_resource,
     make_container,
@@ -20,7 +20,7 @@ from robottelo.cli.contentview import ContentView
 from robottelo.cli.product import Product
 from robottelo.cli.repository import Repository
 from robottelo.constants import DOCKER_REGISTRY_HUB
-from robottelo.decorators import run_only_on, skip_if_bug_open, stubbed
+from robottelo.decorators import run_only_on, stubbed
 from robottelo.helpers import (
     get_external_docker_url,
     get_internal_docker_url,
@@ -61,7 +61,6 @@ def _make_docker_repo(product_id, name=None, upstream_name=None):
 class DockerImageTestCase(CLITestCase):
     """Tests related to docker image command"""
 
-    @skip_if_bug_open('bugzilla', 1221729)
     def test_bugzilla_1190122(self):
         """@Test: docker image displays tags information for a docker image
 
@@ -69,47 +68,32 @@ class DockerImageTestCase(CLITestCase):
 
         @Assert: docker image displays tags information for a docker image
 
-        @BZ: 1221729
-
         """
-        try:
-            organization = make_org()
-            product = make_product({
-                u'organization-id': organization['id'],
-            })
-            repository = make_repository({
-                u'content-type': REPO_CONTENT_TYPE,
-                u'docker-upstream-name': REPO_UPSTREAM_NAME,
-                u'product-id': product['id'],
-                u'url': DOCKER_REGISTRY_HUB,
-            })
-        except CLIFactoryError as err:
-            self.fail(err)
-
-        result = Repository.synchronize({'id': repository['id']})
-        self.assertEqual(result.return_code, 0)
-        self.assertEqual(len(result.stderr), 0)
-
+        organization = make_org()
+        product = make_product({
+            u'organization-id': organization['id'],
+        })
+        repository = make_repository({
+            u'content-type': REPO_CONTENT_TYPE,
+            u'docker-upstream-name': REPO_UPSTREAM_NAME,
+            u'product-id': product['id'],
+            u'url': DOCKER_REGISTRY_HUB,
+        })
+        Repository.synchronize({'id': repository['id']})
         # Grab all available images related to repository
-        result = Docker.image.list({
+        images_list = Docker.image.list({
             u'repository-id': repository['id'],
         })
-        self.assertEqual(result.return_code, 0)
-        self.assertEqual(len(result.stderr), 0)
-
         # Some images do not have tags associated with it, ignore those because
         # we want to check the tag information
         images = [
-            image for image in result.stdout if int(image['tag-count']) > 0
+            image for image in images_list if int(image['tag-count']) > 0
         ]
         for image in images:
             result = Docker.image.info({'id': image['id']})
-            self.assertEqual(result.return_code, 0)
-            self.assertEqual(len(result.stderr), 0)
-
             # Extract the list of repository ids of the available image's tags
             tag_repository_ids = []
-            for tag in result.stdout['tags']:
+            for tag in result['tags']:
                 tag_repository_ids.append(tag['repository-id'])
                 self.assertGreater(len(tag['tag']), 0)
             self.assertIn(repository['id'], tag_repository_ids)
@@ -164,7 +148,7 @@ class DockerRepositoryTestCase(CLITestCase):
         product = Product.info({
             'id': product['id'],
             'organization-id': self.org_id,
-        }).stdout
+        })
         self.assertEqual(
             repo_names,
             set([repo_['repo-name'] for repo_ in product['content']]),
@@ -188,7 +172,7 @@ class DockerRepositoryTestCase(CLITestCase):
             product = Product.info({
                 'id': product['id'],
                 'organization-id': self.org_id,
-            }).stdout
+            })
             self.assertEqual(
                 repo_names,
                 set([repo_['repo-name'] for repo_ in product['content']]),
@@ -206,9 +190,8 @@ class DockerRepositoryTestCase(CLITestCase):
         repo = _make_docker_repo(
             make_product({'organization-id': self.org_id})['id'])
         self.assertEqual(int(repo['content-counts']['docker-images']), 0)
-        result = Repository.synchronize({'id': repo['id']})
-        self.assertEqual(result.return_code, 0)
-        repo = Repository.info({'id': repo['id']}).stdout
+        Repository.synchronize({'id': repo['id']})
+        repo = Repository.info({'id': repo['id']})
         self.assertGreaterEqual(
             int(repo['content-counts']['docker-images']), 1)
 
@@ -223,16 +206,14 @@ class DockerRepositoryTestCase(CLITestCase):
         """
         repo = _make_docker_repo(
             make_product({'organization-id': self.org_id})['id'])
-
         for new_name in valid_data_list():
             with self.subTest(new_name):
-                result = Repository.update({
+                Repository.update({
                     'id': repo['id'],
                     'new-name': new_name,
                     'url': repo['url'],
                 })
-                self.assertEqual(result.return_code, 0)
-                repo = Repository.info({'id': repo['id']}).stdout
+                repo = Repository.info({'id': repo['id']})
                 self.assertEqual(repo['name'], new_name)
 
     def test_update_docker_repo_upstream_name(self):
@@ -247,13 +228,12 @@ class DockerRepositoryTestCase(CLITestCase):
         new_upstream_name = 'fedora/ssh'
         repo = _make_docker_repo(
             make_product({'organization-id': self.org_id})['id'])
-        result = Repository.update({
+        Repository.update({
             'docker-upstream-name': new_upstream_name,
             'id': repo['id'],
             'url': repo['url'],
         })
-        self.assertEqual(result.return_code, 0)
-        repo = Repository.info({'id': repo['id']}).stdout
+        repo = Repository.info({'id': repo['id']})
         self.assertEqual(repo['upstream-repository-name'], new_upstream_name)
 
     def test_update_docker_repo_url(self):
@@ -268,12 +248,11 @@ class DockerRepositoryTestCase(CLITestCase):
         new_url = gen_url()
         repo = _make_docker_repo(
             make_product({'organization-id': self.org_id})['id'])
-        result = Repository.update({
+        Repository.update({
             'id': repo['id'],
             'url': new_url,
         })
-        self.assertEqual(result.return_code, 0)
-        repo = Repository.info({'id': repo['id']}).stdout
+        repo = Repository.info({'id': repo['id']})
         self.assertEqual(repo['url'], new_url)
 
     def test_delete_docker_repo(self):
@@ -286,10 +265,9 @@ class DockerRepositoryTestCase(CLITestCase):
         """
         repo = _make_docker_repo(
             make_product({'organization-id': self.org_id})['id'])
-        result = Repository.delete({'id': repo['id']})
-        self.assertEqual(result.return_code, 0)
-        result = Repository.info({'id': repo['id']})
-        self.assertNotEqual(result.return_code, 0)
+        Repository.delete({'id': repo['id']})
+        with self.assertRaises(CLIReturnCodeError):
+            Repository.info({'id': repo['id']})
 
     def test_delete_random_docker_repo(self):
         """@Test: Create Docker-type repositories on multiple products and
@@ -313,16 +291,14 @@ class DockerRepositoryTestCase(CLITestCase):
         # Select random repository and delete it
         repo = choice(repos)
         repos.remove(repo)
-        result = Repository.delete({'id': repo['id']})
-        self.assertEqual(result.return_code, 0)
-        result = Repository.info({'id': repo['id']})
-        self.assertNotEqual(result.return_code, 0)
+        Repository.delete({'id': repo['id']})
+        with self.assertRaises(CLIReturnCodeError):
+            Repository.info({'id': repo['id']})
         # Verify other repositories were not touched
         for repo in repos:
             result = Repository.info({'id': repo['id']})
-            self.assertEqual(result.return_code, 0)
             self.assertIn(
-                result.stdout['product']['id'],
+                result['product']['id'],
                 [product['id'] for product in products],
             )
 
@@ -348,14 +324,13 @@ class DockerContentViewTestCase(CLITestCase):
             'composite': False,
             'organization-id': self.org_id,
         })
-        result = ContentView.add_repository({
+        ContentView.add_repository({
             'id': self.content_view['id'],
             'repository-id': self.repo['id'],
         })
-        self.assertEqual(result.return_code, 0)
         self.content_view = ContentView.info({
             'id': self.content_view['id']
-        }).stdout
+        })
         self.assertIn(
             self.repo['id'],
             [
@@ -380,12 +355,11 @@ class DockerContentViewTestCase(CLITestCase):
             'composite': False,
             'organization-id': self.org_id,
         })
-        result = ContentView.add_repository({
+        ContentView.add_repository({
             'id': content_view['id'],
             'repository-id': repo['id'],
         })
-        self.assertEqual(result.return_code, 0)
-        content_view = ContentView.info({'id': content_view['id']}).stdout
+        content_view = ContentView.info({'id': content_view['id']})
         self.assertIn(
             repo['id'],
             [repo_['id'] for repo_ in content_view['docker-repositories']],
@@ -412,12 +386,11 @@ class DockerContentViewTestCase(CLITestCase):
             'organization-id': self.org_id,
         })
         for repo in repos:
-            result = ContentView.add_repository({
+            ContentView.add_repository({
                 'id': content_view['id'],
                 'repository-id': repo['id'],
             })
-            self.assertEqual(result.return_code, 0)
-        content_view = ContentView.info({'id': content_view['id']}).stdout
+        content_view = ContentView.info({'id': content_view['id']})
         self.assertEqual(
             set([repo['id'] for repo in repos]),
             set([repo['id'] for repo in content_view['docker-repositories']]),
@@ -434,21 +407,19 @@ class DockerContentViewTestCase(CLITestCase):
         """
         repo = _make_docker_repo(
             make_product({'organization-id': self.org_id})['id'])
-        result = Repository.synchronize({'id': repo['id']})
-        self.assertEqual(result.return_code, 0)
-        repo = Repository.info({'id': repo['id']}).stdout
+        Repository.synchronize({'id': repo['id']})
+        repo = Repository.info({'id': repo['id']})
         self.assertGreaterEqual(
             int(repo['content-counts']['docker-images']), 1)
         content_view = make_content_view({
             'composite': False,
             'organization-id': self.org_id,
         })
-        result = ContentView.add_repository({
+        ContentView.add_repository({
             'id': content_view['id'],
             'repository-id': repo['id'],
         })
-        self.assertEqual(result.return_code, 0)
-        content_view = ContentView.info({'id': content_view['id']}).stdout
+        content_view = ContentView.info({'id': content_view['id']})
         self.assertIn(
             repo['id'],
             [repo_['id'] for repo_ in content_view['docker-repositories']],
@@ -465,23 +436,21 @@ class DockerContentViewTestCase(CLITestCase):
 
         """
         self._create_and_associate_repo_with_cv()
-        result = ContentView.publish({'id': self.content_view['id']})
-        self.assertEqual(result.return_code, 0)
+        ContentView.publish({'id': self.content_view['id']})
         self.content_view = ContentView.info({
-            'id': self.content_view['id']}).stdout
+            'id': self.content_view['id']})
         self.assertEqual(len(self.content_view['versions']), 1)
         comp_content_view = make_content_view({
             'composite': True,
             'organization-id': self.org_id,
         })
-        result = ContentView.update({
+        ContentView.update({
             'id': comp_content_view['id'],
             'component-ids': self.content_view['versions'][0]['id'],
         })
-        self.assertEqual(result.return_code, 0)
         comp_content_view = ContentView.info({
             'id': comp_content_view['id'],
-        }).stdout
+        })
         self.assertIn(
             self.content_view['versions'][0]['id'],
             [component['id'] for component in comp_content_view['components']],
@@ -506,28 +475,25 @@ class DockerContentViewTestCase(CLITestCase):
                 'organization-id': self.org_id,
             })
             repo = _make_docker_repo(product['id'])
-            result = ContentView.add_repository({
+            ContentView.add_repository({
                 'id': content_view['id'],
                 'repository-id': repo['id'],
             })
-            self.assertEqual(result.return_code, 0)
-            result = ContentView.publish({'id': content_view['id']})
-            self.assertEqual(result.return_code, 0)
-            content_view = ContentView.info({'id': content_view['id']}).stdout
+            ContentView.publish({'id': content_view['id']})
+            content_view = ContentView.info({'id': content_view['id']})
             self.assertEqual(len(content_view['versions']), 1)
             cv_versions.append(content_view['versions'][0])
         comp_content_view = make_content_view({
             'composite': True,
             'organization-id': self.org_id,
         })
-        result = ContentView.update({
+        ContentView.update({
             'component-ids': [cv_version['id'] for cv_version in cv_versions],
             'id': comp_content_view['id'],
         })
-        self.assertEqual(result.return_code, 0)
         comp_content_view = ContentView.info({
             'id': comp_content_view['id'],
-        }).stdout
+        })
         for cv_version in cv_versions:
             self.assertIn(
                 cv_version['id'],
@@ -550,11 +516,10 @@ class DockerContentViewTestCase(CLITestCase):
         """
         self._create_and_associate_repo_with_cv()
         self.assertEqual(len(self.content_view['versions']), 0)
-        result = ContentView.publish({'id': self.content_view['id']})
-        self.assertEqual(result.return_code, 0)
+        ContentView.publish({'id': self.content_view['id']})
         self.content_view = ContentView.info({
-            'id': self.content_view['id']
-        }).stdout
+            'id': self.content_view['id'],
+        })
         self.assertEqual(len(self.content_view['versions']), 1)
 
     def test_publish_once_docker_repo_composite_content_view(self):
@@ -570,24 +535,22 @@ class DockerContentViewTestCase(CLITestCase):
         """
         self._create_and_associate_repo_with_cv()
         self.assertEqual(len(self.content_view['versions']), 0)
-        result = ContentView.publish({'id': self.content_view['id']})
-        self.assertEqual(result.return_code, 0)
+        ContentView.publish({'id': self.content_view['id']})
         self.content_view = ContentView.info({
-            'id': self.content_view['id']
-        }).stdout
+            'id': self.content_view['id'],
+        })
         self.assertEqual(len(self.content_view['versions']), 1)
         comp_content_view = make_content_view({
             'composite': True,
             'organization-id': self.org_id,
         })
-        result = ContentView.update({
+        ContentView.update({
             'component-ids': self.content_view['versions'][0]['id'],
             'id': comp_content_view['id'],
         })
-        self.assertEqual(result.return_code, 0)
         comp_content_view = ContentView.info({
             'id': comp_content_view['id'],
-        }).stdout
+        })
         self.assertIn(
             self.content_view['versions'][0]['id'],
             [
@@ -596,11 +559,10 @@ class DockerContentViewTestCase(CLITestCase):
                 in comp_content_view['components']
             ],
         )
-        result = ContentView.publish({'id': comp_content_view['id']})
-        self.assertEqual(result.return_code, 0)
+        ContentView.publish({'id': comp_content_view['id']})
         comp_content_view = ContentView.info({
             'id': comp_content_view['id'],
-        }).stdout
+        })
         self.assertEqual(len(comp_content_view['versions']), 1)
 
     def test_publish_multiple_docker_repo_content_view(self):
@@ -617,11 +579,10 @@ class DockerContentViewTestCase(CLITestCase):
         self.assertEqual(len(self.content_view['versions']), 0)
         publish_amount = randint(2, 5)
         for _ in range(publish_amount):
-            result = ContentView.publish({'id': self.content_view['id']})
-            self.assertEqual(result.return_code, 0)
+            ContentView.publish({'id': self.content_view['id']})
         self.content_view = ContentView.info({
             'id': self.content_view['id'],
-        }).stdout
+        })
         self.assertEqual(len(self.content_view['versions']), publish_amount)
 
     def test_publish_multiple_docker_repo_composite_content_view(self):
@@ -637,23 +598,21 @@ class DockerContentViewTestCase(CLITestCase):
         """
         self._create_and_associate_repo_with_cv()
         self.assertEqual(len(self.content_view['versions']), 0)
-        result = ContentView.publish({'id': self.content_view['id']})
-        self.assertEqual(result.return_code, 0)
+        ContentView.publish({'id': self.content_view['id']})
         self.content_view = ContentView.info({
-            'id': self.content_view['id']}).stdout
+            'id': self.content_view['id']})
         self.assertEqual(len(self.content_view['versions']), 1)
         comp_content_view = make_content_view({
             'composite': True,
             'organization-id': self.org_id,
         })
-        result = ContentView.update({
+        ContentView.update({
             'component-ids': self.content_view['versions'][0]['id'],
             'id': comp_content_view['id'],
         })
-        self.assertEqual(result.return_code, 0)
         comp_content_view = ContentView.info({
             'id': comp_content_view['id'],
-        }).stdout
+        })
         self.assertIn(
             self.content_view['versions'][0]['id'],
             [
@@ -664,11 +623,10 @@ class DockerContentViewTestCase(CLITestCase):
         )
         publish_amount = randint(2, 5)
         for _ in range(publish_amount):
-            result = ContentView.publish({'id': comp_content_view['id']})
-            self.assertEqual(result.return_code, 0)
+            ContentView.publish({'id': comp_content_view['id']})
         comp_content_view = ContentView.info({
             'id': comp_content_view['id'],
-        }).stdout
+        })
         self.assertEqual(len(comp_content_view['versions']), publish_amount)
 
     def test_promote_docker_repo_content_view(self):
@@ -683,23 +641,21 @@ class DockerContentViewTestCase(CLITestCase):
         """
         lce = make_lifecycle_environment({'organization-id': self.org_id})
         self._create_and_associate_repo_with_cv()
-        result = ContentView.publish({'id': self.content_view['id']})
-        self.assertEqual(result.return_code, 0)
+        ContentView.publish({'id': self.content_view['id']})
         self.content_view = ContentView.info({
-            'id': self.content_view['id']}).stdout
+            'id': self.content_view['id']})
         self.assertEqual(len(self.content_view['versions']), 1)
         cvv = ContentView.version_info({
             'id': self.content_view['versions'][0]['id'],
-        }).stdout
+        })
         self.assertEqual(len(cvv['lifecycle-environments']), 1)
-        result = ContentView.version_promote({
+        ContentView.version_promote({
             'id': cvv['id'],
             'lifecycle-environment-id': lce['id'],
         })
-        self.assertEqual(result.return_code, 0)
         cvv = ContentView.version_info({
             'id': self.content_view['versions'][0]['id'],
-        }).stdout
+        })
         self.assertEqual(len(cvv['lifecycle-environments']), 2)
 
     def test_promote_multiple_docker_repo_content_view(self):
@@ -713,25 +669,23 @@ class DockerContentViewTestCase(CLITestCase):
 
         """
         self._create_and_associate_repo_with_cv()
-        result = ContentView.publish({'id': self.content_view['id']})
-        self.assertEqual(result.return_code, 0)
+        ContentView.publish({'id': self.content_view['id']})
         self.content_view = ContentView.info({
-            'id': self.content_view['id']}).stdout
+            'id': self.content_view['id']})
         self.assertEqual(len(self.content_view['versions']), 1)
         cvv = ContentView.version_info({
             'id': self.content_view['versions'][0]['id'],
-        }).stdout
+        })
         self.assertEqual(len(cvv['lifecycle-environments']), 1)
         for i in range(1, randint(3, 6)):
             lce = make_lifecycle_environment({'organization-id': self.org_id})
-            result = ContentView.version_promote({
+            ContentView.version_promote({
                 'id': cvv['id'],
                 'lifecycle-environment-id': lce['id'],
             })
-            self.assertEqual(result.return_code, 0)
             cvv = ContentView.version_info({
                 'id': self.content_view['versions'][0]['id'],
-            }).stdout
+            })
             self.assertEqual(len(cvv['lifecycle-environments']), i+1)
 
     def test_promote_docker_repo_composite_content_view(self):
@@ -746,23 +700,21 @@ class DockerContentViewTestCase(CLITestCase):
 
         """
         self._create_and_associate_repo_with_cv()
-        result = ContentView.publish({'id': self.content_view['id']})
-        self.assertEqual(result.return_code, 0)
+        ContentView.publish({'id': self.content_view['id']})
         self.content_view = ContentView.info({
-            'id': self.content_view['id']}).stdout
+            'id': self.content_view['id']})
         self.assertEqual(len(self.content_view['versions']), 1)
         comp_content_view = make_content_view({
             'composite': True,
             'organization-id': self.org_id,
         })
-        result = ContentView.update({
+        ContentView.update({
             'component-ids': self.content_view['versions'][0]['id'],
             'id': comp_content_view['id'],
         })
-        self.assertEqual(result.return_code, 0)
         comp_content_view = ContentView.info({
             'id': comp_content_view['id'],
-        }).stdout
+        })
         self.assertIn(
             self.content_view['versions'][0]['id'],
             [
@@ -771,24 +723,22 @@ class DockerContentViewTestCase(CLITestCase):
                 in comp_content_view['components']
             ],
         )
-        result = ContentView.publish({'id': comp_content_view['id']})
-        self.assertEqual(result.return_code, 0)
+        ContentView.publish({'id': comp_content_view['id']})
         comp_content_view = ContentView.info({
             'id': comp_content_view['id'],
-        }).stdout
+        })
         cvv = ContentView.version_info({
             'id': comp_content_view['versions'][0]['id'],
-        }).stdout
+        })
         self.assertEqual(len(cvv['lifecycle-environments']), 1)
         lce = make_lifecycle_environment({'organization-id': self.org_id})
-        result = ContentView.version_promote({
+        ContentView.version_promote({
             'id': comp_content_view['versions'][0]['id'],
             'lifecycle-environment-id': lce['id'],
         })
-        self.assertEqual(result.return_code, 0)
         cvv = ContentView.version_info({
             'id': comp_content_view['versions'][0]['id'],
-        }).stdout
+        })
         self.assertEqual(len(cvv['lifecycle-environments']), 2)
 
     def test_promote_multiple_docker_repo_composite_content_view(self):
@@ -803,23 +753,21 @@ class DockerContentViewTestCase(CLITestCase):
 
         """
         self._create_and_associate_repo_with_cv()
-        result = ContentView.publish({'id': self.content_view['id']})
-        self.assertEqual(result.return_code, 0)
+        ContentView.publish({'id': self.content_view['id']})
         self.content_view = ContentView.info({
-            'id': self.content_view['id']}).stdout
+            'id': self.content_view['id']})
         self.assertEqual(len(self.content_view['versions']), 1)
         comp_content_view = make_content_view({
             'composite': True,
             'organization-id': self.org_id,
         })
-        result = ContentView.update({
+        ContentView.update({
             'component-ids': self.content_view['versions'][0]['id'],
             'id': comp_content_view['id'],
         })
-        self.assertEqual(result.return_code, 0)
         comp_content_view = ContentView.info({
             'id': comp_content_view['id'],
-        }).stdout
+        })
         self.assertIn(
             self.content_view['versions'][0]['id'],
             [
@@ -828,25 +776,23 @@ class DockerContentViewTestCase(CLITestCase):
                 in comp_content_view['components']
             ],
         )
-        result = ContentView.publish({'id': comp_content_view['id']})
-        self.assertEqual(result.return_code, 0)
+        ContentView.publish({'id': comp_content_view['id']})
         comp_content_view = ContentView.info({
             'id': comp_content_view['id'],
-        }).stdout
+        })
         cvv = ContentView.version_info({
             'id': comp_content_view['versions'][0]['id'],
-        }).stdout
+        })
         self.assertEqual(len(cvv['lifecycle-environments']), 1)
         for i in range(1, randint(3, 6)):
             lce = make_lifecycle_environment({'organization-id': self.org_id})
-            result = ContentView.version_promote({
+            ContentView.version_promote({
                 'id': comp_content_view['versions'][0]['id'],
                 'lifecycle-environment-id': lce['id'],
             })
-            self.assertEqual(result.return_code, 0)
             cvv = ContentView.version_info({
                 'id': comp_content_view['versions'][0]['id'],
-            }).stdout
+            })
             self.assertEqual(len(cvv['lifecycle-environments']), i+1)
 
 
@@ -876,20 +822,20 @@ class DockerActivationKeyTestCase(CLITestCase):
         })
         cls.content_view = ContentView.info({
             'id': cls.content_view['id']
-        }).stdout
+        })
         ContentView.publish({'id': cls.content_view['id']})
         cls.content_view = ContentView.info({
-            'id': cls.content_view['id']}).stdout
+            'id': cls.content_view['id']})
         cls.cvv = ContentView.version_info({
             'id': cls.content_view['versions'][0]['id'],
-        }).stdout
+        })
         ContentView.version_promote({
             'id': cls.content_view['versions'][0]['id'],
             'lifecycle-environment-id': cls.lce['id'],
         })
         cls.cvv = ContentView.version_info({
             'id': cls.content_view['versions'][0]['id'],
-        }).stdout
+        })
 
     def test_add_docker_repo_to_activation_key(self):
         """@Test: Add Docker-type repository to a non-composite content view
@@ -936,21 +882,20 @@ class DockerActivationKeyTestCase(CLITestCase):
         })
         ContentView.publish({'id': another_cv['id']})
         another_cv = ContentView.info({
-            'id': another_cv['id']}).stdout
+            'id': another_cv['id']})
         ContentView.version_promote({
             'id': another_cv['versions'][0]['id'],
             'lifecycle-environment-id': self.lce['id'],
         })
 
-        result = ActivationKey.update({
+        ActivationKey.update({
             'id': activation_key['id'],
             'organization-id': self.org['id'],
             'content-view-id': another_cv['id'],
         })
-        self.assertEqual(result.return_code, 0)
         activation_key = ActivationKey.info({
             'id': activation_key['id'],
-        }).stdout
+        })
         self.assertNotEqual(
             activation_key['content-view'], self.content_view['name'])
 
@@ -969,14 +914,13 @@ class DockerActivationKeyTestCase(CLITestCase):
             'composite': True,
             'organization-id': self.org['id'],
         })
-        result = ContentView.update({
+        ContentView.update({
             'component-ids': self.content_view['versions'][0]['id'],
             'id': comp_content_view['id'],
         })
-        self.assertEqual(result.return_code, 0)
         comp_content_view = ContentView.info({
             'id': comp_content_view['id'],
-        }).stdout
+        })
         self.assertIn(
             self.content_view['versions'][0]['id'],
             [
@@ -985,14 +929,13 @@ class DockerActivationKeyTestCase(CLITestCase):
                 in comp_content_view['components']
             ],
         )
-        result = ContentView.publish({'id': comp_content_view['id']})
-        self.assertEqual(result.return_code, 0)
+        ContentView.publish({'id': comp_content_view['id']})
         comp_content_view = ContentView.info({
             'id': comp_content_view['id'],
-        }).stdout
+        })
         comp_cvv = ContentView.version_info({
             'id': comp_content_view['versions'][0]['id'],
-        }).stdout
+        })
         ContentView.version_promote({
             'id': comp_cvv['id'],
             'lifecycle-environment-id': self.lce['id'],
@@ -1022,14 +965,13 @@ class DockerActivationKeyTestCase(CLITestCase):
             'composite': True,
             'organization-id': self.org['id'],
         })
-        result = ContentView.update({
+        ContentView.update({
             'component-ids': self.content_view['versions'][0]['id'],
             'id': comp_content_view['id'],
         })
-        self.assertEqual(result.return_code, 0)
         comp_content_view = ContentView.info({
             'id': comp_content_view['id'],
-        }).stdout
+        })
         self.assertIn(
             self.content_view['versions'][0]['id'],
             [
@@ -1038,14 +980,13 @@ class DockerActivationKeyTestCase(CLITestCase):
                 in comp_content_view['components']
             ],
         )
-        result = ContentView.publish({'id': comp_content_view['id']})
-        self.assertEqual(result.return_code, 0)
+        ContentView.publish({'id': comp_content_view['id']})
         comp_content_view = ContentView.info({
             'id': comp_content_view['id'],
-        }).stdout
+        })
         comp_cvv = ContentView.version_info({
             'id': comp_content_view['versions'][0]['id'],
-        }).stdout
+        })
         ContentView.version_promote({
             'id': comp_cvv['id'],
             'lifecycle-environment-id': self.lce['id'],
@@ -1065,21 +1006,20 @@ class DockerActivationKeyTestCase(CLITestCase):
         })
         ContentView.publish({'id': another_cv['id']})
         another_cv = ContentView.info({
-            'id': another_cv['id']}).stdout
+            'id': another_cv['id']})
         ContentView.version_promote({
             'id': another_cv['versions'][0]['id'],
             'lifecycle-environment-id': self.lce['id'],
         })
 
-        result = ActivationKey.update({
+        ActivationKey.update({
             'id': activation_key['id'],
             'organization-id': self.org['id'],
             'content-view-id': another_cv['id'],
         })
-        self.assertEqual(result.return_code, 0)
         activation_key = ActivationKey.info({
             'id': activation_key['id'],
-        }).stdout
+        })
         self.assertNotEqual(
             activation_key['content-view'], comp_content_view['name'])
 
@@ -1181,14 +1121,13 @@ class DockerComputeResourceTestCase(CLITestCase):
                 })
                 self.assertEqual(compute_resource['url'], url)
                 new_url = gen_url(subdomain=gen_alpha())
-                result = ComputeResource.update({
+                ComputeResource.update({
                     'id': compute_resource['id'],
                     'url': new_url,
                 })
-                self.assertEqual(result.return_code, 0)
                 compute_resource = ComputeResource.info({
                     'id': compute_resource['id'],
-                }).stdout
+                })
                 self.assertEqual(compute_resource['url'], new_url)
 
     def test_list_containers_docker_compute_resource(self):
@@ -1212,7 +1151,7 @@ class DockerComputeResourceTestCase(CLITestCase):
                 result = DockerContainer.list({
                     'compute-resource-id': compute_resource['id'],
                 })
-                self.assertEqual(len(result.stdout), 0)
+                self.assertEqual(len(result), 0)
                 container = make_container({
                     'compute-resource-id': compute_resource['id'],
                     'organization-ids': [self.org['id']],
@@ -1220,8 +1159,8 @@ class DockerComputeResourceTestCase(CLITestCase):
                 result = DockerContainer.list({
                     'compute-resource-id': compute_resource['id'],
                 })
-                self.assertEqual(len(result.stdout), 1)
-                self.assertEqual(result.stdout[0]['name'], container['name'])
+                self.assertEqual(len(result), 1)
+                self.assertEqual(result[0]['name'], container['name'])
 
     def test_create_external_docker_compute_resource(self):
         """@Test: Create a Docker-based Compute Resource using an external
@@ -1259,10 +1198,9 @@ class DockerComputeResourceTestCase(CLITestCase):
                 })
                 self.assertEqual(compute_resource['url'], url)
                 self.assertEqual(compute_resource['provider'], DOCKER_PROVIDER)
-                result = ComputeResource.delete({'id': compute_resource['id']})
-                self.assertEqual(result.return_code, 0)
-                result = ComputeResource.info({'id': compute_resource['id']})
-                self.assertNotEqual(result.return_code, 0)
+                ComputeResource.delete({'id': compute_resource['id']})
+                with self.assertRaises(CLIReturnCodeError):
+                    ComputeResource.info({'id': compute_resource['id']})
 
 
 class DockerContainersTestCase(CLITestCase):

--- a/tests/foreman/cli/test_environment.py
+++ b/tests/foreman/cli/test_environment.py
@@ -2,11 +2,11 @@
 """Test class for Environment  CLI"""
 
 from fauxfactory import gen_string
-from robottelo.cli.factory import CLIFactoryError
+from robottelo.cli.base import CLIReturnCodeError
 from robottelo.cli.environment import Environment
 from robottelo.cli.factory import make_environment, make_location, make_org
 from robottelo.decorators import data, run_only_on, skip_if_bug_open
-from robottelo.helpers import bz_bug_is_open
+from robottelo.helpers import bz_bug_is_open, invalid_values_list
 from robottelo.test import MetaCLITestCase
 
 
@@ -17,37 +17,37 @@ class TestEnvironment(MetaCLITestCase):
     factory_obj = Environment
 
     POSITIVE_CREATE_DATA = (
-        {'name': gen_string("alpha", 10)},
-        {'name': gen_string("alphanumeric", 10)},
-        {'name': gen_string("numeric", 10)},
+        {'name': gen_string('alpha', 10)},
+        {'name': gen_string('alphanumeric', 10)},
+        {'name': gen_string('numeric', 10)},
     )
 
     POSITIVE_UPDATE_DATA = (
-        ({'name': gen_string("alpha", 10)},
-         {'new-name': gen_string("alpha", 10)}),
-        ({'name': gen_string("alphanumeric", 10)},
-         {'new-name': gen_string("alphanumeric", 10)}),
-        ({'name': gen_string("numeric", 10)},
-         {'new-name': gen_string("numeric", 10)}),
+        ({'name': gen_string('alpha', 10)},
+         {'new-name': gen_string('alpha', 10)}),
+        ({'name': gen_string('alphanumeric', 10)},
+         {'new-name': gen_string('alphanumeric', 10)}),
+        ({'name': gen_string('numeric', 10)},
+         {'new-name': gen_string('numeric', 10)}),
     )
 
     NEGATIVE_UPDATE_DATA = (
-        ({'name': gen_string("alphanumeric", 10)},
-         {'new-name': gen_string("alphanumeric", 300)}),
-        ({'name': gen_string("alphanumeric", 10)},
-         {'new-name': gen_string("latin1", 10)}),
-        ({'name': gen_string("alphanumeric", 10)},
-         {'new-name': gen_string("utf8", 10)}),
-        ({'name': gen_string("alphanumeric", 10)},
-         {'new-name': gen_string("html", 6)}),
-        ({'name': gen_string("alphanumeric", 10)},
-         {'new-name': ""}),
+        ({'name': gen_string('alphanumeric', 10)},
+         {'new-name': gen_string('alphanumeric', 300)}),
+        ({'name': gen_string('alphanumeric', 10)},
+         {'new-name': gen_string('latin1', 10)}),
+        ({'name': gen_string('alphanumeric', 10)},
+         {'new-name': gen_string('utf8', 10)}),
+        ({'name': gen_string('alphanumeric', 10)},
+         {'new-name': gen_string('html', 6)}),
+        ({'name': gen_string('alphanumeric', 10)},
+         {'new-name': ''}),
     )
 
     POSITIVE_DELETE_DATA = (
-        {'name': gen_string("alpha", 10)},
-        {'name': gen_string("alphanumeric", 10)},
-        {'name': gen_string("numeric", 10)},
+        {'name': gen_string('alpha', 10)},
+        {'name': gen_string('alphanumeric', 10)},
+        {'name': gen_string('numeric', 10)},
     )
 
     def test_info(self):
@@ -58,15 +58,9 @@ class TestEnvironment(MetaCLITestCase):
         @Assert: Environment Info is displayed
 
         """
-        name = gen_string("alpha", 10)
-        Environment().create({'name': name})
-        result = Environment().info({'name': name})
-
-        self.assertTrue(result.return_code == 0,
-                        "Environment info - retcode")
-
-        self.assertEquals(result.stdout['name'], name,
-                          "Environment info - stdout contains 'Name'")
+        name = gen_string('alpha', 10)
+        env = make_environment({'name': name})
+        self.assertEquals(env['name'], name)
 
     def test_list(self):
         """@Test: Test Environment List
@@ -76,11 +70,10 @@ class TestEnvironment(MetaCLITestCase):
         @Assert: Environment List is displayed
 
         """
-        name = gen_string("alpha", 10)
+        name = gen_string('alpha', 10)
         Environment().create({'name': name})
         result = Environment().list({'search': name})
-        self.assertTrue(len(result.stdout) == 1,
-                        "Environment list - stdout contains 'Name'")
+        self.assertEqual(len(result), 1)
 
     def test_create_environment_with_location(self):
         """@Test: Check if Environment with Location can be created
@@ -90,16 +83,11 @@ class TestEnvironment(MetaCLITestCase):
         @Assert: Environment is created and has new Location assigned
 
         """
-        name = gen_string("alpha", 10)
-        try:
-            new_loc = make_location()
-            new_environment = make_environment({
-                'name': name,
-                'location-ids': new_loc["id"],
-            })
-        except CLIFactoryError as err:
-            self.fail(err)
-
+        new_loc = make_location()
+        new_environment = make_environment({
+            'location-ids': new_loc['id'],
+            'name': gen_string('alpha'),
+        })
         self.assertIn(new_loc['name'], new_environment['locations'])
 
     def test_create_environment_with_organization(self):
@@ -110,16 +98,11 @@ class TestEnvironment(MetaCLITestCase):
         @Assert: Environment is created and has new Organization assigned
 
         """
-        name = gen_string("alpha", 10)
-        try:
-            new_org = make_org()
-            new_environment = make_environment({
-                'name': name,
-                'organization-ids': new_org["id"],
-            })
-        except CLIFactoryError as err:
-            self.fail(err)
-
+        new_org = make_org()
+        new_environment = make_environment({
+            'name': gen_string('alpha'),
+            'organization-ids': new_org['id'],
+        })
         self.assertIn(new_org['name'], new_environment['organizations'])
 
     def test_delete(self):
@@ -130,26 +113,18 @@ class TestEnvironment(MetaCLITestCase):
         @Assert: Environment Delete is displayed
 
         """
+        name = gen_string('alphanumeric', 10)
+        make_environment({'name': name})
+        Environment().delete({'name': name})
+        with self.assertRaises(CLIReturnCodeError):
+            Environment().info({'name': name})
 
-        name = gen_string("alphanumeric", 10)
-        try:
-            make_environment({'name': name})
-        except CLIFactoryError as err:
-            self.fail(err)
-
-        result = Environment().delete({'name': name})
-        self.assertEqual(result.return_code, 0, "Deletion failed")
-        self.assertEqual(
-            len(result.stderr), 0, "There should not be an error here")
-
-        result = Environment().info({'name': name})
-        self.assertNotEqual(
-            result.return_code, 0, "Environment should be deleted")
-        self.assertGreater(len(result.stderr), 0,
-                           "There should be an exception here")
-
-    @data(*POSITIVE_UPDATE_DATA)
-    def test_update(self, test_data):
+    @data(
+        gen_string('alpha', 10),
+        gen_string('numeric', 10),
+        gen_string('alphanumeric', 10),
+    )
+    def test_update(self, new_name):
         """@Test: Update the environment
 
         @Feature: Environment - Update
@@ -157,26 +132,17 @@ class TestEnvironment(MetaCLITestCase):
         @Assert: Environment Update is displayed
 
         """
-        orig_dict, updates_dict = test_data
-        try:
-            make_environment({'name': orig_dict['name']})
-        except CLIFactoryError as err:
-            self.fail(err)
-
-        result = Environment.update({
-            'name': orig_dict['name'],
-            'new-name': updates_dict['new-name']
+        name = gen_string('alphanumeric')
+        make_environment({'name': name})
+        Environment.update({
+            'name': name,
+            'new-name': new_name,
         })
-        self.assertEqual(result.return_code, 0)
-        self.assertEqual(len(result.stderr), 0)
+        env = Environment.info({'name': new_name})
+        self.assertEqual(env['name'], new_name)
 
-        result = Environment.info({'name': updates_dict['new-name']})
-        self.assertEqual(result.return_code, 0)
-        self.assertEqual(len(result.stderr), 0)
-        self.assertEqual(result.stdout['name'], updates_dict['new-name'])
-
-    @data(*NEGATIVE_UPDATE_DATA)
-    def test_update_negative(self, test_data):
+    @data(*invalid_values_list())
+    def test_update_negative(self, new_name):
         """@Test: Update the environment with invalid values
 
         @Feature: Environment - Update
@@ -184,24 +150,18 @@ class TestEnvironment(MetaCLITestCase):
         @Assert: Environment is not updated
 
         """
-        orig_dict, updates_dict = test_data
-        try:
-            env = make_environment({'name': orig_dict['name']})
-        except CLIFactoryError as err:
-            self.fail(err)
-
-        result = Environment.update({
-            'name': orig_dict['name'],
-            'new-name': updates_dict['new-name']
-        })
-        self.assertNotEqual(result.return_code, 0)
-        self.assertNotEqual(len(result.stderr), 0)
-
-        result = Environment.info({'id': env['id']})
+        name = gen_string('alphanumeric')
+        env = make_environment({'name': name})
+        with self.assertRaises(CLIReturnCodeError):
+            Environment.update({
+                'name': name,
+                'new-name': new_name,
+            })
+        env = Environment.info({'id': env['id']})
         # Verify that value is not updated and left as it was before update
         # command was executed
-        self.assertEqual(result.stdout['name'], orig_dict['name'])
-        self.assertNotEqual(result.stdout['name'], updates_dict['new-name'])
+        self.assertEqual(env['name'], name)
+        self.assertNotEqual(env['name'], new_name)
 
     def test_update_location(self):
         """@Test: Update environment location with new value
@@ -211,28 +171,17 @@ class TestEnvironment(MetaCLITestCase):
         @Assert: Environment Update finished and new location is assigned
 
         """
-        try:
-            old_loc = make_location()
-            new_loc = make_location()
-            env_name = gen_string('alphanumeric', 10)
-            make_environment({
-                'name': env_name,
-                'location-ids': old_loc['id'],
-            })
-        except CLIFactoryError as err:
-            self.fail(err)
-        result = Environment.info({'name': env_name})
-        self.assertIn(old_loc['name'], result.stdout['locations'])
-
-        result = Environment.update({
-            'name': env_name,
-            'location-ids': new_loc['id']
+        old_loc = make_location()
+        new_loc = make_location()
+        new_env = make_environment({'location-ids': old_loc['id']})
+        self.assertIn(old_loc['name'], new_env['locations'])
+        Environment.update({
+            'location-ids': new_loc['id'],
+            'name': new_env['name'],
         })
-        self.assertEqual(result.return_code, 0)
-
-        result = Environment.info({'name': env_name})
-        self.assertIn(new_loc['name'], result.stdout['locations'])
-        self.assertNotIn(old_loc['name'], result.stdout['locations'])
+        new_env = Environment.info({'name': new_env['name']})
+        self.assertIn(new_loc['name'], new_env['locations'])
+        self.assertNotIn(old_loc['name'], new_env['locations'])
 
     def test_update_organization(self):
         """@Test: Update environment organization with new value
@@ -242,28 +191,21 @@ class TestEnvironment(MetaCLITestCase):
         @Assert: Environment Update finished and new organization is assigned
 
         """
-        try:
-            old_org = make_org()
-            new_org = make_org()
-            env_name = gen_string('alphanumeric', 10)
-            make_environment({
-                'name': env_name,
-                'organization-ids': old_org['id'],
-            })
-        except CLIFactoryError as err:
-            self.fail(err)
-        result = Environment.info({'name': env_name})
-        self.assertIn(old_org['name'], result.stdout['organizations'])
-
-        result = Environment.update({
+        old_org = make_org()
+        new_org = make_org()
+        env_name = gen_string('alphanumeric', 10)
+        env = make_environment({
+            'name': env_name,
+            'organization-ids': old_org['id'],
+        })
+        self.assertIn(old_org['name'], env['organizations'])
+        Environment.update({
             'name': env_name,
             'organization-ids': new_org['id']
         })
-        self.assertEqual(result.return_code, 0)
-
-        result = Environment.info({'name': env_name})
-        self.assertIn(new_org['name'], result.stdout['organizations'])
-        self.assertNotIn(old_org['name'], result.stdout['organizations'])
+        env = Environment.info({'name': env_name})
+        self.assertIn(new_org['name'], env['organizations'])
+        self.assertNotIn(old_org['name'], env['organizations'])
 
     @skip_if_bug_open('bugzilla', 1219934)
     def test_sc_params_by_environment_id(self):
@@ -278,12 +220,9 @@ class TestEnvironment(MetaCLITestCase):
 
         """
         environment = make_environment()
-        result = Environment.sc_params({
+        Environment.sc_params({
             'environment-id': environment['id'],
         })
-        self.assertEqual(result.return_code, 0)
-        self.assertEqual(len(result.stderr), 0)
-
         if not bz_bug_is_open(1219934):
             self.fail('BZ #1219934 is closed, should assert the content')
 
@@ -300,11 +239,8 @@ class TestEnvironment(MetaCLITestCase):
 
         """
         environment = make_environment()
-        result = Environment.sc_params({
+        Environment.sc_params({
             'environment': environment['name'],
         })
-        self.assertEqual(result.return_code, 0)
-        self.assertEqual(len(result.stderr), 0)
-
         if not bz_bug_is_open(1219934):
             self.fail('BZ #1219934 is closed, should assert the content')

--- a/tests/foreman/cli/test_fact.py
+++ b/tests/foreman/cli/test_fact.py
@@ -30,16 +30,15 @@ class TestFact(CLITestCase):
             'search': "fact='%s'" % fact,
         }
 
-        result = Fact().list(args)
-        stdout = result.stdout
+        facts = Fact().list(args)
 
-        self.assertEqual(stdout[0]['fact'], fact)
+        self.assertEqual(facts[0]['fact'], fact)
 
     @data(
-        gen_string("alpha", 10),
-        gen_string("alpha", 10),
-        gen_string("alpha", 10),
-        gen_string("alpha", 10),
+        gen_string('alpha', 10),
+        gen_string('alpha', 10),
+        gen_string('alpha', 10),
+        gen_string('alpha', 10),
     )
     def test_list_fail(self, fact):
         """@Test: Test Fact List failure
@@ -54,4 +53,4 @@ class TestFact(CLITestCase):
             'search': "fact='%s'" % fact,
         }
         self.assertEqual(
-            Fact().list(args).stdout, [], "No records should be returned")
+            Fact().list(args), [], 'No records should be returned')

--- a/tests/foreman/cli/test_globalparam.py
+++ b/tests/foreman/cli/test_globalparam.py
@@ -19,16 +19,13 @@ class TestGlobalParameter(CLITestCase):
         @Assert: Global Param is set
 
         """
-        name = "opt-%s" % gen_string("alpha", 10)
-        val_part1 = gen_string("alpha", 10)
-        val_part2 = gen_string("alpha", 10)
-        value = "val-%s %s" % (val_part1, val_part2)
-        result = GlobalParameter().set({
+        name = 'opt-%s' % gen_string('alpha', 10)
+        value = 'val-%s %s' % (
+            gen_string('alpha', 10), gen_string('alpha', 10))
+        GlobalParameter().set({
             'name': name,
-            'value': value})
-        self.assertEquals(result.return_code, 0,
-                          "GlobalParameter set - exit code %d" %
-                          result.return_code)
+            'value': value,
+        })
 
     def test_list(self):
         """@Test: Test Global Param List
@@ -38,24 +35,16 @@ class TestGlobalParameter(CLITestCase):
         @Assert: Global Param List is displayed
 
         """
-        name = "opt-%s" % gen_string("alpha", 10)
-        val_part1 = gen_string("alpha", 10)
-        val_part2 = gen_string("alpha", 10)
-        value = "val-%s %s" % (val_part1, val_part2)
-        result = GlobalParameter().set({
+        name = 'opt-%s' % gen_string('alpha', 10)
+        value = 'val-%s %s' % (
+            gen_string('alpha', 10), gen_string('alpha', 10))
+        GlobalParameter().set({
             'name': name,
-            'value': value})
-        self.assertEquals(result.return_code, 0,
-                          "GlobalParameter set - exit code %d" %
-                          result.return_code)
+            'value': value,
+        })
         result = GlobalParameter().list({'search': name})
-        self.assertEquals(result.return_code, 0,
-                          "GlobalParameter list - exit code %d" %
-                          result.return_code)
-        self.assertEquals(len(result.stdout), 1,
-                          "GlobalParameter list - stdout has one record")
-        self.assertEquals(result.stdout[0]['value'], value,
-                          "GlobalParameter list - value matches")
+        self.assertEqual(len(result), 1)
+        self.assertEqual(result[0]['value'], value)
 
     def test_delete(self):
         """@Test: Check if Global Param can be deleted
@@ -65,20 +54,13 @@ class TestGlobalParameter(CLITestCase):
         @Assert: Global Param is deleted
 
         """
-        name = "opt-%s" % gen_string("alpha", 10)
-        val_part1 = gen_string("alpha", 10)
-        val_part2 = gen_string("alpha", 10)
-        value = "val-%s %s" % (val_part1, val_part2)
-        result = GlobalParameter().set({
+        name = 'opt-%s' % gen_string('alpha', 10)
+        value = 'val-%s %s' % (
+            gen_string('alpha', 10), gen_string('alpha', 10))
+        GlobalParameter().set({
             'name': name,
-            'value': value})
-        self.assertEquals(result.return_code, 0,
-                          "GlobalParameter set - exit code %d" %
-                          result.return_code)
-        result = GlobalParameter().delete({'name': name})
-        self.assertEquals(result.return_code, 0,
-                          "GlobalParameter delete - exit code %d" %
-                          result.return_code)
+            'value': value,
+        })
+        GlobalParameter().delete({'name': name})
         result = GlobalParameter().list({'search': name})
-        self.assertTrue(len(result.stdout) == 0,
-                        "GlobalParameter list - deleted item is not listed")
+        self.assertEqual(len(result), 0)

--- a/tests/foreman/cli/test_host.py
+++ b/tests/foreman/cli/test_host.py
@@ -17,10 +17,8 @@ class HostTestCase(CLITestCase):
         """
         # Use the default installation smart proxy
         result = Proxy.list()
-        self.assertEqual(result.return_code, 0)
-        self.assertEqual(len(result.stderr), 0)
-        self.assertGreater(len(result.stdout), 0)
-        self.puppet_proxy = result.stdout[0]
+        self.assertGreater(len(result), 0)
+        self.puppet_proxy = result[0]
 
     def test_positive_create_1(self):
         """@test: A host can be created with a random name
@@ -46,11 +44,9 @@ class HostTestCase(CLITestCase):
             u'puppet-proxy-id': self.puppet_proxy['id'],
             u'root-pass': host.root_pass,
         })
-        self.assertEqual(result.return_code, 0)
-        self.assertEqual(len(result.stderr), 0)
         self.assertEqual(
             '{0}.{1}'.format(host.name, host.domain.read().name).lower(),
-            result.stdout['name'],
+            result['name'],
         )
 
     def test_create_libvirt_without_mac(self):
@@ -68,7 +64,7 @@ class HostTestCase(CLITestCase):
         ).create()
         host = entities.Host()
         host.create_missing()
-        result = Host.create({
+        Host.create({
             u'architecture-id': host.architecture.id,
             u'compute-resource-id': compute_resource.id,
             u'domain-id': host.domain.id,
@@ -83,5 +79,3 @@ class HostTestCase(CLITestCase):
             u'puppet-proxy-id': self.puppet_proxy['id'],
             u'root-pass': host.root_pass,
         })
-        self.assertEqual(result.return_code, 0)
-        self.assertEqual(len(result.stderr), 0)

--- a/tests/foreman/cli/test_hostgroup.py
+++ b/tests/foreman/cli/test_hostgroup.py
@@ -5,7 +5,6 @@ from fauxfactory import gen_string
 from robottelo.cli.hostgroup import HostGroup
 from robottelo.cli.proxy import Proxy
 from robottelo.cli.factory import (
-    CLIFactoryError,
     make_environment,
     make_hostgroup,
     make_location,
@@ -23,25 +22,25 @@ class TestHostGroup(MetaCLITestCase):
     factory_obj = HostGroup
 
     POSITIVE_UPDATE_DATA = (
-        ({'id': gen_string("latin1", 10)},
-         {'name': gen_string("latin1", 10)}),
-        ({'id': gen_string("utf8", 10)},
-         {'name': gen_string("utf8", 10)}),
-        ({'id': gen_string("alpha", 10)},
-         {'name': gen_string("alpha", 10)}),
-        ({'id': gen_string("alphanumeric", 10)},
-         {'name': gen_string("alphanumeric", 10)}),
-        ({'id': gen_string("numeric", 10)},
-         {'name': gen_string("numeric", 10)}),
-        ({'id': gen_string("utf8", 10)},
-         {'name': gen_string("html", 6)}),
+        ({'id': gen_string('latin1', 10)},
+         {'name': gen_string('latin1', 10)}),
+        ({'id': gen_string('utf8', 10)},
+         {'name': gen_string('utf8', 10)}),
+        ({'id': gen_string('alpha', 10)},
+         {'name': gen_string('alpha', 10)}),
+        ({'id': gen_string('alphanumeric', 10)},
+         {'name': gen_string('alphanumeric', 10)}),
+        ({'id': gen_string('numeric', 10)},
+         {'name': gen_string('numeric', 10)}),
+        ({'id': gen_string('utf8', 10)},
+         {'name': gen_string('html', 6)}),
     )
 
     NEGATIVE_UPDATE_DATA = (
-        ({'id': gen_string("utf8", 10)},
-         {'name': gen_string("utf8", 300)}),
-        ({'id': gen_string("utf8", 10)},
-         {'name': ""}),
+        ({'id': gen_string('utf8', 10)},
+         {'name': gen_string('utf8', 300)}),
+        ({'id': gen_string('utf8', 10)},
+         {'name': ''}),
     )
 
     def test_create_hostgroup_with_environment(self):
@@ -52,11 +51,8 @@ class TestHostGroup(MetaCLITestCase):
         @Assert: Hostgroup is created and has new environment assigned
 
         """
-        try:
-            environment = make_environment()
-            hostgroup = make_hostgroup({'environment-id': environment['id']})
-        except CLIFactoryError as err:
-            self.fail(err)
+        environment = make_environment()
+        hostgroup = make_hostgroup({'environment-id': environment['id']})
         self.assertEqual(environment['name'], hostgroup['environment'])
 
     def test_create_hostgroup_with_location(self):
@@ -67,11 +63,8 @@ class TestHostGroup(MetaCLITestCase):
         @Assert: Hostgroup is created and has new location assigned
 
         """
-        try:
-            location = make_location()
-            hostgroup = make_hostgroup({'location-ids': location['id']})
-        except CLIFactoryError as err:
-            self.fail(err)
+        location = make_location()
+        hostgroup = make_hostgroup({'location-ids': location['id']})
         self.assertIn(location['name'], hostgroup['locations'])
 
     def test_create_hostgroup_with_operating_system(self):
@@ -82,11 +75,8 @@ class TestHostGroup(MetaCLITestCase):
         @Assert: Hostgroup is created and has operating system assigned
 
         """
-        try:
-            os = make_os()
-            hostgroup = make_hostgroup({'operatingsystem-id': os['id']})
-        except CLIFactoryError as err:
-            self.fail(err)
+        os = make_os()
+        hostgroup = make_hostgroup({'operatingsystem-id': os['id']})
         self.assertEqual(hostgroup['operating-system'], os['title'])
 
     def test_create_hostgroup_with_organization(self):
@@ -97,11 +87,8 @@ class TestHostGroup(MetaCLITestCase):
         @Assert: Hostgroup is created and has new organization assigned
 
         """
-        try:
-            org = make_org()
-            hostgroup = make_hostgroup({'organization-ids': org['id']})
-        except CLIFactoryError as err:
-            self.fail(err)
+        org = make_org()
+        hostgroup = make_hostgroup({'organization-ids': org['id']})
         self.assertIn(org['name'], hostgroup['organizations'])
 
     def test_create_hostgroup_with_puppet_ca_proxy(self):
@@ -112,19 +99,9 @@ class TestHostGroup(MetaCLITestCase):
         @Assert: Hostgroup is created and has puppet CA proxy server assigned
 
         """
-        proxy_list = Proxy.list()
-        self.assertEqual(proxy_list.return_code, 0)
-        puppet_proxy = proxy_list.stdout[0]
-
-        try:
-            hostgroup = make_hostgroup(
-                {'puppet-ca-proxy': puppet_proxy['name']})
-        except CLIFactoryError as err:
-            self.fail(err)
-        self.assertEqual(
-            puppet_proxy['id'],
-            hostgroup['puppet-ca-proxy-id'],
-        )
+        puppet_proxy = Proxy.list()[0]
+        hostgroup = make_hostgroup({'puppet-ca-proxy': puppet_proxy['name']})
+        self.assertEqual(puppet_proxy['id'], hostgroup['puppet-ca-proxy-id'])
 
     def test_create_hostgroup_with_puppet_proxy(self):
         """@Test: Check if hostgroup with puppet proxy server can be created
@@ -134,15 +111,8 @@ class TestHostGroup(MetaCLITestCase):
         @Assert: Hostgroup is created and has puppet proxy server assigned
 
         """
-        proxy_list = Proxy.list()
-        self.assertEqual(proxy_list.return_code, 0)
-        puppet_proxy = proxy_list.stdout[0]
-
-        try:
-            hostgroup = make_hostgroup(
-                {'puppet-proxy': puppet_proxy['name']})
-        except CLIFactoryError as err:
-            self.fail(err)
+        puppet_proxy = Proxy.list()[0]
+        hostgroup = make_hostgroup({'puppet-proxy': puppet_proxy['name']})
         self.assertEqual(
             puppet_proxy['id'],
             hostgroup['puppet-master-proxy-id'],

--- a/tests/foreman/cli/test_model.py
+++ b/tests/foreman/cli/test_model.py
@@ -2,7 +2,6 @@
 """Test class for Model CLI"""
 
 from fauxfactory import gen_string
-from robottelo.cli.factory import CLIFactoryError
 from robottelo.cli.model import Model
 from robottelo.cli.factory import make_model
 from robottelo.decorators import run_only_on
@@ -23,10 +22,7 @@ class TestModel(MetaCLITestCase):
         @Assert: Model is created
 
         """
-        try:
-            make_model()
-        except CLIFactoryError as err:
-            self.fail(err)
+        make_model()
 
     def test_create_model_2(self):
         """@Test: Check if Model can be created with specific vendor class
@@ -49,25 +45,10 @@ class TestModel(MetaCLITestCase):
 
         """
 
-        name = gen_string("alpha")
-        try:
-            model = self.factory({'name': name})
-        except CLIFactoryError as err:
-            self.fail(err)
-
+        name = gen_string('alpha')
+        model = self.factory({'name': name})
         self.assertEqual(name, model['name'])
-
-        new_name = gen_string("alpha")
-        result = Model().update({'name': model['name'], 'new-name': new_name})
-        self.assertEqual(result.return_code, 0)
-        self.assertEqual(
-            len(result.stderr), 0, "There should not be an error here")
-
-        result = Model.info({'name': new_name})
-        self.assertEqual(result.return_code, 0)
-        self.assertEqual(len(result.stderr), 0)
-        self.assertEqual(
-            result.stdout['name'],
-            new_name,
-            "Model name was not updated"
-        )
+        new_name = gen_string('alpha')
+        Model.update({'name': model['name'], 'new-name': new_name})
+        model = Model.info({'name': new_name})
+        self.assertEqual(model['name'], new_name)

--- a/tests/foreman/cli/test_org.py
+++ b/tests/foreman/cli/test_org.py
@@ -4,6 +4,7 @@
 import random
 
 from fauxfactory import gen_string
+from robottelo.cli.base import CLIReturnCodeError
 from robottelo.cli.factory import (
     make_domain, make_hostgroup, make_lifecycle_environment,
     make_medium, make_org, make_proxy, make_subnet, make_template, make_user,
@@ -184,12 +185,10 @@ class TestOrg(CLITestCase):
         """
         for test_data in valid_names():
             with self.subTest(test_data):
-                new_obj = make_org(test_data)
+                org = make_org(test_data)
                 # Can we find the new object?
-                result = Org.exists(search=('name', new_obj['name']))
-                self.assertEqual(result.return_code, 0)
-                self.assertEqual(len(result.stderr), 0)
-                self.assertEqual(new_obj['name'], result.stdout['name'])
+                result = Org.exists(search=('name', org['name']))
+                self.assertEqual(org['name'], result['name'])
 
     @run_only_on('sat')
     def test_remove_domain(self):
@@ -200,14 +199,16 @@ class TestOrg(CLITestCase):
         @Assert: Domain is removed from the org
 
         """
-        org_result = make_org()
-        domain_result = make_domain()
-        Org.add_domain(
-            {'name': org_result['name'], 'domain': domain_result['name']})
-        return_value = Org.remove_domain(
-            {'name': org_result['name'], 'domain': domain_result['name']})
-        self.assertEqual(return_value.return_code, 0)
-        self.assertEqual(len(return_value.stderr), 0)
+        org = make_org()
+        domain = make_domain()
+        Org.add_domain({
+            'domain': domain['name'],
+            'name': org['name'],
+        })
+        Org.remove_domain({
+            'domain': domain['name'],
+            'name': org['name'],
+        })
 
     def test_bugzilla_1079587(self):
         """@test: Search for an organization by label
@@ -219,12 +220,10 @@ class TestOrg(CLITestCase):
         """
         for test_data in valid_names():
             with self.subTest(test_data):
-                new_obj = make_org(test_data)
+                org = make_org(test_data)
                 # Can we find the new object?
-                result = Org.exists(search=('label', new_obj['label']))
-                self.assertEqual(result.return_code, 0)
-                self.assertEqual(len(result.stderr), 0)
-                self.assertEqual(new_obj['name'], result.stdout['name'])
+                result = Org.exists(search=('label', org['label']))
+                self.assertEqual(org['name'], result['name'])
 
     def test_bugzilla_1076568_1(self):
         """@test: Delete organization by name
@@ -235,16 +234,10 @@ class TestOrg(CLITestCase):
 
         """
         org = make_org()
-
-        result = Org.delete({'name': org['name']})
-        self.assertEqual(result.return_code, 0)
-        self.assertEqual(len(result.stderr), 0)
-
+        Org.delete({'name': org['name']})
         # Can we find the object?
-        result = Org.info({'id': org['id']})
-        self.assertNotEqual(result.return_code, 0)
-        self.assertGreater(len(result.stderr), 0)
-        self.assertEqual(len(result.stdout), 0)
+        with self.assertRaises(CLIReturnCodeError):
+            Org.info({'id': org['id']})
 
     def test_bugzilla_1076568_2(self):
         """@test: Delete organization by ID
@@ -255,16 +248,10 @@ class TestOrg(CLITestCase):
 
         """
         org = make_org()
-
-        result = Org.delete({'id': org['id']})
-        self.assertEqual(result.return_code, 0)
-        self.assertEqual(len(result.stderr), 0)
-
+        Org.delete({'id': org['id']})
         # Can we find the object?
-        result = Org.info({'id': org['id']})
-        self.assertNotEqual(result.return_code, 0)
-        self.assertGreater(len(result.stderr), 0)
-        self.assertEqual(len(result.stdout), 0)
+        with self.assertRaises(CLIReturnCodeError):
+            Org.info({'id': org['id']})
 
     def test_bugzilla_1076568_3(self):
         """@test: Delete organization by label
@@ -275,16 +262,10 @@ class TestOrg(CLITestCase):
 
         """
         org = make_org()
-
-        result = Org.delete({'label': org['label']})
-        self.assertEqual(result.return_code, 0)
-        self.assertEqual(len(result.stderr), 0)
-
+        Org.delete({'label': org['label']})
         # Can we find the object?
-        result = Org.info({'id': org['id']})
-        self.assertNotEqual(result.return_code, 0)
-        self.assertGreater(len(result.stderr), 0)
-        self.assertEqual(len(result.stdout), 0)
+        with self.assertRaises(CLIReturnCodeError):
+            Org.info({'id': org['id']})
 
     def test_bugzilla_1076541(self):
         """@test: Cannot update organization name via CLI
@@ -294,20 +275,16 @@ class TestOrg(CLITestCase):
         @assert: Organization name is updated
 
         """
-        new_obj = make_org()
-
+        org = make_org()
         # Update the org name
         new_name = gen_string('utf8', 15)
-        result = Org.update({'id': new_obj['id'], 'new-name': new_name})
-
-        self.assertEqual(result.return_code, 0)
-        self.assertEqual(len(result.stderr), 0)
-
+        Org.update({
+            'id': org['id'],
+            'new-name': new_name,
+        })
         # Fetch the org again
-        result = Org.info({'id': new_obj['id']})
-        self.assertEqual(result.return_code, 0)
-        self.assertEqual(len(result.stderr), 0)
-        self.assertEqual(result.stdout['name'], new_name)
+        org = Org.info({'id': org['id']})
+        self.assertEqual(org['name'], new_name)
 
     def test_bugzilla_1075163(self):
         """@Test: Add --label as a valid argument to organization info command
@@ -320,9 +297,7 @@ class TestOrg(CLITestCase):
         """
         org = make_org()
         result = Org.info({'label': org['label']})
-        self.assertEqual(result.return_code, 0)
-        self.assertEqual(len(result.stderr), 0)
-        self.assertEqual(org['id'], result.stdout['id'])
+        self.assertEqual(org['id'], result['id'])
 
     def test_bugzilla_1075156(self):
         """@Test: Cannot use CLI info for organizations by name
@@ -335,9 +310,7 @@ class TestOrg(CLITestCase):
         """
         org = make_org()
         result = Org.info({'name': org['name']})
-        self.assertEqual(result.return_code, 0)
-        self.assertEqual(len(result.stderr), 0)
-        self.assertEqual(org['id'], result.stdout['id'])
+        self.assertEqual(org['id'], result['id'])
 
     @run_only_on('sat')
     def test_bugzilla_1062295_1(self):
@@ -348,13 +321,12 @@ class TestOrg(CLITestCase):
         @Assert: Config Template is added to the org
 
         """
-        org_result = make_org()
-        template_result = make_template()
-        return_value = Org.add_config_template({
-            'name': org_result['name'],
-            'config-template': template_result['name']})
-        self.assertEqual(return_value.return_code, 0)
-        self.assertEqual(len(return_value.stderr), 0)
+        org = make_org()
+        template = make_template()
+        Org.add_config_template({
+            'config-template': template['name'],
+            'name': org['name'],
+        })
 
     @run_only_on('sat')
     def test_bugzilla_1062295_2(self):
@@ -365,16 +337,16 @@ class TestOrg(CLITestCase):
         @Assert: ConfigTemplate is removed from the org
 
         """
-        org_result = make_org()
-        template_result = make_template()
+        org = make_org()
+        template = make_template()
         Org.add_config_template({
-            'name': org_result['name'],
-            'config-template': template_result['name']})
-        return_value = Org.remove_config_template({
-            'name': org_result['name'],
-            'config-template': template_result['name']})
-        self.assertEqual(return_value.return_code, 0)
-        self.assertEqual(len(return_value.stderr), 0)
+            'config-template': template['name'],
+            'name': org['name'],
+        })
+        Org.remove_config_template({
+            'config-template': template['name'],
+            'name': org['name'],
+        })
 
     def test_bugzilla_1023125(self):
         """@Test: hammer-cli: trying to create duplicate org throws unhandled
@@ -387,7 +359,6 @@ class TestOrg(CLITestCase):
 
         """
         org = make_org()
-
         # Create new org with the same name as before
         # should yield an exception
         with self.assertRaises(CLIFactoryError):
@@ -406,14 +377,14 @@ class TestOrg(CLITestCase):
         # org list --help:
         result = Org.list({'help': True})
         # get list of lines and check they all are unique
-        lines = [line['message'] for line in result.stdout]
+        lines = [line['message'] for line in result]
         self.assertEqual(len(set(lines)), len(lines))
 
         # org info --help:info returns more lines (obviously), ignore exception
         result = Org.info({'help': True})
 
         # get list of lines and check they all are unique
-        lines = [line for line in result.stdout['options']]
+        lines = [line for line in result['options']]
         self.assertEqual(len(set(lines)), len(lines))
 
     # CRUD
@@ -505,9 +476,7 @@ class TestOrg(CLITestCase):
         @Assert: Org is listed
 
         """
-        return_value = Org.list()
-        self.assertEqual(return_value.return_code, 0)
-        self.assertEqual(len(return_value.stderr), 0)
+        Org.list()
 
     @run_only_on('sat')
     def test_add_subnet(self):
@@ -518,12 +487,12 @@ class TestOrg(CLITestCase):
         @Assert: Subnet is added to the org
 
         """
-        org_result = make_org()
-        subnet_result = make_subnet()
-        return_value = Org.add_subnet(
-            {'name': org_result['name'], 'subnet': subnet_result['name']})
-        self.assertEqual(return_value.return_code, 0)
-        self.assertEqual(len(return_value.stderr), 0)
+        org = make_org()
+        subnet = make_subnet()
+        Org.add_subnet({
+            'name': org['name'],
+            'subnet': subnet['name'],
+        })
 
     @run_only_on('sat')
     def test_remove_subnet(self):
@@ -534,14 +503,16 @@ class TestOrg(CLITestCase):
         @Assert: Subnet is removed from the org
 
         """
-        org_result = make_org()
-        subnet_result = make_subnet()
-        Org.add_subnet(
-            {'name': org_result['name'], 'subnet': subnet_result['name']})
-        return_value = Org.remove_subnet(
-            {'name': org_result['name'], 'subnet': subnet_result['name']})
-        self.assertEqual(return_value.return_code, 0)
-        self.assertEqual(len(return_value.stderr), 0)
+        org = make_org()
+        subnet = make_subnet()
+        Org.add_subnet({
+            'name': org['name'],
+            'subnet': subnet['name'],
+        })
+        Org.remove_subnet({
+            'name': org['name'],
+            'subnet': subnet['name'],
+        })
 
     def test_add_user(self):
         """@Test: Check if a User can be added to an Org
@@ -551,12 +522,12 @@ class TestOrg(CLITestCase):
         @Assert: User is added to the org
 
         """
-        org_result = make_org()
-        user_result = make_user()
-        return_value = Org.add_user(
-            {'name': org_result['name'], 'user-id': user_result['id']})
-        self.assertEqual(return_value.return_code, 0)
-        self.assertEqual(len(return_value.stderr), 0)
+        org = make_org()
+        user = make_user()
+        Org.add_user({
+            'name': org['name'],
+            'user-id': user['id'],
+        })
 
     def test_remove_user(self):
         """@Test: Check if a User can be removed from an Org
@@ -566,31 +537,32 @@ class TestOrg(CLITestCase):
         @Assert: User is removed from the org
 
         """
-        org_result = make_org()
-        user_result = make_user()
-        Org.add_user(
-            {'name': org_result['name'], 'user-id': user_result['login']})
-        return_value = Org.remove_user(
-            {'name': org_result['name'], 'user-id': user_result['login']})
-        self.assertEqual(return_value.return_code, 0)
-        self.assertEqual(len(return_value.stderr), 0)
+        org = make_org()
+        user = make_user()
+        Org.add_user({
+            'name': org['name'],
+            'user-id': user['id'],
+        })
+        Org.remove_user({
+            'name': org['name'],
+            'user-id': user['id'],
+        })
 
     @run_only_on('sat')
     def test_add_hostgroup(self):
         """@Test: Check if a hostgroup can be added to an Org
 
-        @Feature: Org - Hostrgroup
+        @Feature: Org - Hostgroup
 
         @Assert: Hostgroup is added to the org
 
         """
-        org_result = make_org()
-        hostgroup_result = make_hostgroup()
-        return_value = Org.add_hostgroup({
-            'name': org_result['name'],
-            'hostgroup': hostgroup_result['name']})
-        self.assertEqual(return_value.return_code, 0)
-        self.assertEqual(len(return_value.stderr), 0)
+        org = make_org()
+        hostgroup = make_hostgroup()
+        Org.add_hostgroup({
+            'hostgroup': hostgroup['name'],
+            'name': org['name'],
+        })
 
     @run_only_on('sat')
     def test_remove_hostgroup(self):
@@ -601,16 +573,16 @@ class TestOrg(CLITestCase):
         @Assert: Hostgroup is removed from the org
 
         """
-        org_result = make_org()
-        hostgroup_result = make_hostgroup()
+        org = make_org()
+        hostgroup = make_hostgroup()
         Org.add_hostgroup({
-            'name': org_result['name'],
-            'hostgroup': hostgroup_result['name']})
-        return_value = Org.remove_hostgroup({
-            'name': org_result['name'],
-            'hostgroup': hostgroup_result['name']})
-        self.assertEqual(return_value.return_code, 0)
-        self.assertEqual(len(return_value.stderr), 0)
+            'hostgroup': hostgroup['name'],
+            'name': org['name'],
+        })
+        Org.remove_hostgroup({
+            'hostgroup': hostgroup['name'],
+            'name': org['name'],
+        })
 
     @run_only_on('sat')
     def test_add_computeresource(self):
@@ -621,24 +593,19 @@ class TestOrg(CLITestCase):
         @Assert: Compute Resource is added to the org
 
         """
-        try:
-            org = make_org()
-            compute_res = make_compute_resource({
-                'provider': FOREMAN_PROVIDERS['libvirt'],
-                'url': "qemu+tcp://%s:16509/system" % conf.properties[
-                    'main.server.hostname'
-                ]
-            })
-        except CLIFactoryError as err:
-            self.fail(err)
-        return_value = Org.add_compute_resource({
+        org = make_org()
+        compute_res = make_compute_resource({
+            'provider': FOREMAN_PROVIDERS['libvirt'],
+            'url': "qemu+tcp://%s:16509/system" % conf.properties[
+                'main.server.hostname'
+            ]
+        })
+        Org.add_compute_resource({
+            'compute-resource': compute_res['name'],
             'name': org['name'],
-            'compute-resource': compute_res['name']})
-        self.assertEqual(return_value.return_code, 0)
-        self.assertEqual(len(return_value.stderr), 0)
-        result = Org.info({'id': org['id']})
-        self.assertEqual(
-            result.stdout['compute-resources'][0], compute_res['name'])
+        })
+        org = Org.info({'id': org['id']})
+        self.assertEqual(org['compute-resources'][0], compute_res['name'])
 
     def test_add_compute_resource_by_id(self):
         """@Test: Check that new organization with compute resource associated
@@ -649,12 +616,9 @@ class TestOrg(CLITestCase):
         @Assert: Organization with compute resource created successfully
 
         """
-        try:
-            compute_res = make_compute_resource()
-            org = make_org({'compute-resource-ids': compute_res['id']})
-        except CLIFactoryError as err:
-            self.fail(err)
-        self.assertEqual(1, len(org['compute-resources']))
+        compute_res = make_compute_resource()
+        org = make_org({'compute-resource-ids': compute_res['id']})
+        self.assertEqual(len(org['compute-resources']), 1)
         self.assertEqual(org['compute-resources'][0], compute_res['name'])
 
     def test_add_compute_resources(self):
@@ -666,15 +630,12 @@ class TestOrg(CLITestCase):
         @Assert: Organization with compute resources created successfully
 
         """
-        try:
-            cr_amount = random.randint(3, 5)
-            resources = [make_compute_resource() for _ in range(cr_amount)]
-            org = make_org({
-                'compute-resource-ids':
-                    [resource['id'] for resource in resources],
-            })
-        except CLIFactoryError as err:
-            self.fail(err)
+        cr_amount = random.randint(3, 5)
+        resources = [make_compute_resource() for _ in range(cr_amount)]
+        org = make_org({
+            'compute-resource-ids':
+                [resource['id'] for resource in resources],
+        })
         self.assertEqual(len(org['compute-resources']), cr_amount)
         for resource in resources:
             self.assertIn(resource['name'], org['compute-resources'])
@@ -702,13 +663,14 @@ class TestOrg(CLITestCase):
         @Assert: Medium is added to the org
 
         """
-        org_result = make_org()
-        medium_result = make_medium()
-        return_value = Org.add_medium({
-            'name': org_result['name'],
-            'medium': medium_result['name']})
-        self.assertEqual(return_value.return_code, 0)
-        self.assertEqual(len(return_value.stderr), 0)
+        org = make_org()
+        medium = make_medium()
+        Org.add_medium({
+            'name': org['name'],
+            'medium': medium['name'],
+        })
+        org = Org.info({'id': org['id']})
+        self.assertIn(medium['name'], org['installation-media'])
 
     @run_only_on('sat')
     def test_remove_medium(self):
@@ -719,16 +681,18 @@ class TestOrg(CLITestCase):
         @Assert: Medium is removed from the org
 
         """
-        org_result = make_org()
-        medium_result = make_medium()
+        org = make_org()
+        medium = make_medium()
         Org.add_medium({
-            'name': org_result['name'],
-            'medium': medium_result['name']})
-        return_value = Org.remove_medium({
-            'name': org_result['name'],
-            'medium': medium_result['name']})
-        self.assertEqual(return_value.return_code, 0)
-        self.assertEqual(len(return_value.stderr), 0)
+            'name': org['name'],
+            'medium': medium['name']
+        })
+        Org.remove_medium({
+            'name': org['name'],
+            'medium': medium['name']
+        })
+        org = Org.info({'id': org['id']})
+        self.assertNotIn(medium['name'], org['installation-media'])
 
     @run_only_on('sat')
     def test_add_configtemplate(self):
@@ -739,26 +703,21 @@ class TestOrg(CLITestCase):
         @Assert: Config Template is added to the org
 
         """
-        for data in valid_names_simple_all():
-            with self.subTest(data):
-                try:
-                    org = make_org()
-                    template = make_template({
-                        'name': data,
-                        'content': gen_string('alpha'),
-                    })
-                except CLIFactoryError as err:
-                    self.fail(err)
-                result = Org.add_config_template({
-                    'name': org['name'],
-                    'config-template': template['name']
+        for name in valid_names_simple_all():
+            with self.subTest(name):
+                org = make_org()
+                template = make_template({
+                    'content': gen_string('alpha'),
+                    'name': name,
                 })
-                self.assertEqual(result.return_code, 0)
-                self.assertEqual(len(result.stderr), 0)
-                result = Org.info({'id': org['id']})
+                Org.add_config_template({
+                    'config-template': template['name'],
+                    'name': org['name'],
+                })
+                org = Org.info({'id': org['id']})
                 self.assertIn(
                     u'{0} ({1})'. format(template['name'], template['type']),
-                    result.stdout['templates']
+                    org['templates']
                 )
 
     def test_add_configtemplate_by_id(self):
@@ -770,11 +729,8 @@ class TestOrg(CLITestCase):
         @Assert: Organization with config template created successfully
 
         """
-        try:
-            conf_templ = make_template()
-            org = make_org({'config-template-ids': conf_templ['id']})
-        except CLIFactoryError as err:
-            self.fail(err)
+        conf_templ = make_template()
+        org = make_org({'config-template-ids': conf_templ['id']})
         self.assertIn(
             u'{0} ({1})'.format(conf_templ['name'], conf_templ['type']),
             org['templates']
@@ -789,15 +745,12 @@ class TestOrg(CLITestCase):
         @Assert: Organization with config templates created successfully
 
         """
-        try:
-            templates_amount = random.randint(3, 5)
-            templates = [make_template() for _ in range(templates_amount)]
-            org = make_org({
-                'config-template-ids':
-                    [template['id'] for template in templates],
-            })
-        except CLIFactoryError as err:
-            self.fail(err)
+        templates_amount = random.randint(3, 5)
+        templates = [make_template() for _ in range(templates_amount)]
+        org = make_org({
+            'config-template-ids':
+                [template['id'] for template in templates],
+        })
         self.assertGreaterEqual(len(org['templates']), templates_amount)
         for template in templates:
             self.assertIn(
@@ -814,41 +767,32 @@ class TestOrg(CLITestCase):
         @Assert: ConfigTemplate is removed from the org
 
         """
-        for data in valid_names_simple_all():
-            with self.subTest(data):
-                try:
-                    org = make_org()
-                    tmplt = make_template({
-                        'name': data,
-                        'content': gen_string('alpha')
-                    })
-                except CLIFactoryError as err:
-                    self.fail(err)
-
-                # Add config-template
-                result = Org.add_config_template({
-                    'name': org['name'],
-                    'config-template': tmplt['name']
+        for name in valid_names_simple_all():
+            with self.subTest(name):
+                org = make_org()
+                template = make_template({
+                    'content': gen_string('alpha'),
+                    'name': name,
                 })
-                self.assertEqual(result.return_code, 0)
-                self.assertEqual(len(result.stderr), 0)
+                # Add config-template
+                Org.add_config_template({
+                    'name': org['name'],
+                    'config-template': template['name']
+                })
                 result = Org.info({'id': org['id']})
                 self.assertIn(
-                    u'{0} ({1})'. format(tmplt['name'], tmplt['type']),
-                    result.stdout['templates']
+                    u'{0} ({1})'. format(template['name'], template['type']),
+                    result['templates'],
                 )
-
                 # Remove config-template
-                result = Org.remove_config_template({
+                Org.remove_config_template({
+                    'config-template': template['name'],
                     'name': org['name'],
-                    'config-template': tmplt['name']
                 })
-                self.assertEqual(result.return_code, 0)
-                self.assertEqual(len(result.stderr), 0)
                 result = Org.info({'id': org['id']})
                 self.assertNotIn(
-                    u'{0} ({1})'. format(tmplt['name'], tmplt['type']),
-                    result.stdout['templates']
+                    u'{0} ({1})'. format(template['name'], template['type']),
+                    result['templates'],
                 )
 
     @run_only_on('sat')
@@ -864,15 +808,13 @@ class TestOrg(CLITestCase):
         org_id = make_org()['id']
         lc_env_name = make_lifecycle_environment(
             {'organization-id': org_id})['name']
-
         # Read back information about the lifecycle environment. Verify the
         # sanity of that information.
         response = LifecycleEnvironment.list({
             'name': lc_env_name,
             'organization-id': org_id,
         })
-        self.assertEqual(response.return_code, 0)
-        self.assertEqual(response.stdout[0]['name'], lc_env_name)
+        self.assertEqual(response[0]['name'], lc_env_name)
 
     @run_only_on('sat')
     def test_remove_environment(self):
@@ -891,21 +833,15 @@ class TestOrg(CLITestCase):
             'name': lc_env_name,
             'organization-id': org_id,
         }
-
         # Read back information about the lifecycle environment. Verify the
         # sanity of that information.
         response = LifecycleEnvironment.list(lc_env_attrs)
-        self.assertEqual(response.return_code, 0)
-        self.assertEqual(response.stdout[0]['name'], lc_env_name)
-
+        self.assertEqual(response[0]['name'], lc_env_name)
         # Delete it.
-        response = LifecycleEnvironment.delete(lc_env_attrs)
-        self.assertEqual(response.return_code, 0)
-
+        LifecycleEnvironment.delete(lc_env_attrs)
         # We should get a zero-length response when searcing for the LC env.
         response = LifecycleEnvironment.list(lc_env_attrs)
-        self.assertEqual(response.return_code, 0)
-        self.assertEqual(len(response.stdout), 0)
+        self.assertEqual(len(response), 0)
 
     @run_only_on('sat')
     @stubbed("Needs to be re-worked!")
@@ -917,13 +853,12 @@ class TestOrg(CLITestCase):
         @Assert: Smartproxy is added to the org
 
         """
-        org_result = make_org()
-        proxy_result = make_proxy()
-        return_value = Org.add_smart_proxy({
-            'name': org_result['name'],
-            'smart-proxy': proxy_result['name']})
-        self.assertEqual(return_value.return_code, 0)
-        self.assertEqual(len(return_value.stderr), 0)
+        org = make_org()
+        proxy = make_proxy()
+        Org.add_smart_proxy({
+            'name': org['name'],
+            'smart-proxy': proxy['name'],
+        })
 
     @run_only_on('sat')
     @stubbed("Needs to be re-worked!")
@@ -935,16 +870,16 @@ class TestOrg(CLITestCase):
         @Assert: Smartproxy is removed from the org
 
         """
-        org_result = make_org()
-        proxy_result = make_proxy()
+        org = make_org()
+        proxy = make_proxy()
         Org.add_smart_proxy({
-            'name': org_result['name'],
-            'smart-proxy': proxy_result['name']})
-        return_value = Org.remove_smart_proxy({
-            'name': org_result['name'],
-            'smart-proxy': proxy_result['name']})
-        self.assertEqual(return_value.return_code, 0)
-        self.assertEqual(len(return_value.stderr), 0)
+            'name': org['name'],
+            'smart-proxy': proxy['name'],
+        })
+        Org.remove_smart_proxy({
+            'name': org['name'],
+            'smart-proxy': proxy['name'],
+        })
 
     # Negative Create
 
@@ -959,13 +894,12 @@ class TestOrg(CLITestCase):
         """
         for test_data in invalid_name_label():
             with self.subTest(test_data):
-                result = Org.create({
-                    'description': test_data['label'],
-                    'label': test_data['label'],
-                    'name': test_data['name'],
-                })
-                self.assertGreater(len(result.stderr), 0)
-                self.assertNotEqual(result.return_code, 0)
+                with self.assertRaises(CLIReturnCodeError):
+                    Org.create({
+                        'description': test_data['label'],
+                        'label': test_data['label'],
+                        'name': test_data['name'],
+                    })
 
     def test_negative_create_1(self):
         """@test: Create organization with valid label and description, name is
@@ -978,13 +912,12 @@ class TestOrg(CLITestCase):
         """
         for test_data in valid_names_simple():
             with self.subTest(test_data):
-                result = Org.create({
-                    'description': test_data,
-                    'label': test_data,
-                    'name': '',
-                })
-                self.assertTrue(result.stderr)
-                self.assertNotEqual(result.return_code, 0)
+                with self.assertRaises(CLIReturnCodeError):
+                    Org.create({
+                        'description': test_data,
+                        'label': test_data,
+                        'name': '',
+                    })
 
     def test_negative_create_2(self):
         """@test: Create organization with valid label and description, name is
@@ -997,13 +930,12 @@ class TestOrg(CLITestCase):
         """
         for test_data in valid_names_simple():
             with self.subTest(test_data):
-                result = Org.create({
-                    'label': test_data,
-                    'description': test_data,
-                    'name': ' \t',
-                })
-                self.assertGreater(len(result.stderr), 0)
-                self.assertNotEqual(result.return_code, 0)
+                with self.assertRaises(CLIReturnCodeError):
+                    Org.create({
+                        'description': test_data,
+                        'label': test_data,
+                        'name': ' \t',
+                    })
 
     def test_negative_create_3(self):
         """@test: Create organization with valid values, then create a new one
@@ -1016,20 +948,17 @@ class TestOrg(CLITestCase):
         """
         for test_data in valid_names_simple():
             with self.subTest(test_data):
-                result = Org.create({
+                Org.create({
                     'description': test_data,
                     'label': test_data,
                     'name': test_data,
                 })
-                self.assertFalse(result.stderr)
-                self.assertEqual(result.return_code, 0)
-                result = Org.create({
-                    'description': test_data,
-                    'label': test_data,
-                    'name': test_data,
-                })
-        self.assertGreater(len(result.stderr), 0)
-        self.assertNotEqual(result.return_code, 0)
+                with self.assertRaises(CLIReturnCodeError):
+                    Org.create({
+                        'description': test_data,
+                        'label': test_data,
+                        'name': test_data,
+                    })
 
     # Positive Delete
 
@@ -1045,16 +974,10 @@ class TestOrg(CLITestCase):
         for test_data in valid_name_desc_label():
             with self.subTest(test_data):
                 org = make_org(test_data)
-
-                result = Org.delete({'id': org['id']})
-                self.assertEqual(result.return_code, 0)
-                self.assertEqual(len(result.stderr), 0)
-
+                Org.delete({'id': org['id']})
                 # Can we find the object?
-                result = Org.info({'id': org['id']})
-                self.assertNotEqual(result.return_code, 0)
-                self.assertGreater(len(result.stderr), 0)
-                self.assertEqual(len(result.stdout), 0)
+                with self.assertRaises(CLIReturnCodeError):
+                    Org.info({'id': org['id']})
 
     def test_positive_delete_2(self):
         """@test: Create organization with valid values then delete it
@@ -1068,15 +991,10 @@ class TestOrg(CLITestCase):
         for test_data in valid_name_desc_label():
             with self.subTest(test_data):
                 org = make_org(test_data)
-                return_value = Org.delete({'label': org['label']})
-                self.assertEqual(return_value.return_code, 0)
-                self.assertEqual(len(return_value.stderr), 0)
-
+                Org.delete({'label': org['label']})
                 # Can we find the object?
-                result = Org.info({'id': org['id']})
-                self.assertNotEqual(result.return_code, 0)
-                self.assertGreater(len(result.stderr), 0)
-                self.assertEqual(len(result.stdout), 0)
+                with self.assertRaises(CLIReturnCodeError):
+                    Org.info({'id': org['id']})
 
     def test_positive_delete_3(self):
         """@test: Create organization with valid values then delete it
@@ -1090,15 +1008,10 @@ class TestOrg(CLITestCase):
         for test_data in valid_name_desc_label():
             with self.subTest(test_data):
                 org = make_org(test_data)
-                return_value = Org.delete({'name': org['name']})
-                self.assertEqual(return_value.return_code, 0)
-                self.assertEqual(len(return_value.stderr), 0)
-
+                Org.delete({'name': org['name']})
                 # Can we find the object?
-                result = Org.info({'id': org['id']})
-                self.assertNotEqual(result.return_code, 0)
-                self.assertGreater(len(result.stderr), 0)
-                self.assertEqual(len(result.stdout), 0)
+                with self.assertRaises(CLIReturnCodeError):
+                    Org.info({'id': org['id']})
 
     def test_positive_update_1(self):
         """@test: Create organization with valid values then update its name
@@ -1111,20 +1024,14 @@ class TestOrg(CLITestCase):
         for test_data in valid_names():
             with self.subTest(test_data):
                 org = make_org()
-
                 # Update the org name
-                result = Org.update({
+                Org.update({
                     'id': org['id'],
                     'new-name': test_data['name'],
                 })
-                self.assertEqual(result.return_code, 0)
-                self.assertEqual(len(result.stderr), 0)
-
                 # Fetch the org again
-                result = Org.info({'id': org['id']})
-                self.assertEqual(result.return_code, 0)
-                self.assertEqual(len(result.stderr), 0)
-                self.assertEqual(result.stdout['name'], test_data['name'])
+                org = Org.info({'id': org['id']})
+                self.assertEqual(org['name'], test_data['name'])
 
     def test_positive_update_3(self):
         """@test: Create organization with valid values then update its
@@ -1138,23 +1045,14 @@ class TestOrg(CLITestCase):
         for test_data in positive_desc_data():
             with self.subTest(test_data):
                 org = make_org()
-
                 # Update the org name
-                result = Org.update({
-                    'id': org['id'],
+                Org.update({
                     'description': test_data['description'],
+                    'id': org['id'],
                 })
-                self.assertEqual(result.return_code, 0)
-                self.assertEqual(len(result.stderr), 0)
-
                 # Fetch the org again
-                result = Org.info({'id': org['id']})
-                self.assertEqual(result.return_code, 0)
-                self.assertEqual(len(result.stderr), 0)
-                self.assertEqual(
-                    result.stdout['description'],
-                    test_data['description']
-                )
+                org = Org.info({'id': org['id']})
+                self.assertEqual(org['description'], test_data['description'])
 
     def test_positive_update_4(self):
         """@test: Create organization with valid values then update all values
@@ -1167,25 +1065,16 @@ class TestOrg(CLITestCase):
         for test_data in valid_name_desc():
             with self.subTest(test_data):
                 org = make_org()
-
                 # Update the org name
-                result = Org.update({
+                Org.update({
+                    'description': test_data['description'],
                     'id': org['id'],
                     'new-name': test_data['name'],
-                    'description': test_data['description'],
                 })
-                self.assertEqual(result.return_code, 0)
-                self.assertEqual(len(result.stderr), 0)
-
                 # Fetch the org again
-                result = Org.info({'id': org['id']})
-                self.assertEqual(result.return_code, 0)
-                self.assertEqual(len(result.stderr), 0)
-                self.assertEqual(
-                    result.stdout['description'],
-                    test_data['description']
-                )
-                self.assertEqual(result.stdout['name'], test_data['name'])
+                org = Org.info({'id': org['id']})
+                self.assertEqual(org['description'], test_data['description'])
+                self.assertEqual(org['name'], test_data['name'])
 
     # Negative Update
 
@@ -1201,14 +1090,12 @@ class TestOrg(CLITestCase):
         for test_data in invalid_name_data():
             with self.subTest(test_data):
                 org = make_org()
-
                 # Update the org name
-                result = Org.update({
-                    'id': org['id'],
-                    'new-name': test_data['name'],
-                })
-                self.assertNotEqual(result.return_code, 0)
-                self.assertGreater(len(result.stderr), 0)
+                with self.assertRaises(CLIReturnCodeError):
+                    Org.update({
+                        'id': org['id'],
+                        'new-name': test_data['name'],
+                    })
 
     # Miscelaneous
 
@@ -1502,20 +1389,14 @@ class TestOrg(CLITestCase):
                      gen_string('alphanumeric'), gen_string('utf8'),
                      gen_string('latin1')):
             with self.subTest(name):
-                try:
-                    org = make_org()
-                    new_subnet = make_subnet({'name': name})
-                except CLIFactoryError as err:
-                    self.fail(err)
-
-                result = Org.add_subnet({
+                org = make_org()
+                new_subnet = make_subnet({'name': name})
+                Org.add_subnet({
                     'name': org['name'],
                     'subnet': new_subnet['name'],
                 })
-                self.assertEqual(result.return_code, 0)
-
-                result = Org.info({'id': org['id']})
-                self.assertIn(name, result.stdout['subnets'][0])
+                org = Org.info({'id': org['id']})
+                self.assertIn(name, org['subnets'][0])
 
     @run_only_on('sat')
     @stubbed()

--- a/tests/foreman/cli/test_product.py
+++ b/tests/foreman/cli/test_product.py
@@ -4,6 +4,7 @@ import time
 
 from ddt import ddt
 from fauxfactory import gen_string
+from robottelo.cli.base import CLIReturnCodeError
 from robottelo.cli.factory import (
     CLIFactoryError,
     make_gpg_key,
@@ -24,7 +25,7 @@ class TestProduct(CLITestCase):
 
     org = None
 
-    def setUp(self):  # noqa
+    def setUp(self):
         """Tests for Lifecycle Environment via Hammer CLI"""
 
         super(TestProduct, self).setUp()
@@ -81,8 +82,8 @@ class TestProduct(CLITestCase):
 
         """
         product = make_product({
-            u'name': test_data['name'],
             u'label': test_data['label'],
+            u'name': test_data['name'],
             u'organization-id': self.org['id']
         })
 
@@ -113,9 +114,9 @@ class TestProduct(CLITestCase):
 
         """
         product = make_product({
-            u'name': test_data['name'],
             u'description': test_data['description'],
-            u'organization-id': self.org['id']
+            u'name': test_data['name'],
+            u'organization-id': self.org['id'],
         })
 
         self.assertEqual(product['name'], test_data['name'])
@@ -138,13 +139,11 @@ class TestProduct(CLITestCase):
         @Assert: Product is created and has gpg key
 
         """
-        gpg_key = make_gpg_key(
-            {u'organization-id': self.org['id']}
-        )
+        gpg_key = make_gpg_key({u'organization-id': self.org['id']})
         product = make_product({
-            u'name': test_data['name'],
             u'gpg-key-id': gpg_key['id'],
-            u'organization-id': self.org['id']
+            u'name': test_data['name'],
+            u'organization-id': self.org['id'],
         })
 
         self.assertEqual(product['name'], test_data['name'])
@@ -194,14 +193,11 @@ class TestProduct(CLITestCase):
         @Assert: Product is not created
 
         """
-
         with self.assertRaises(CLIFactoryError):
-            make_product(
-                {
-                    u'name': test_name['name'],
-                    u'organization-id': self.org['id']
-                }
-            )
+            make_product({
+                u'name': test_name['name'],
+                u'organization-id': self.org['id'],
+            })
 
     @run_only_on('sat')
     @data(
@@ -220,15 +216,12 @@ class TestProduct(CLITestCase):
         @Assert: Product is not created
 
         """
-
         with self.assertRaises(CLIFactoryError):
-            make_product(
-                {
-                    u'name': test_name['name'],
-                    u'label': test_name['label'],
-                    u'organization-id': self.org['id']
-                }
-            )
+            make_product({
+                u'label': test_name['label'],
+                u'name': test_name['name'],
+                u'organization-id': self.org['id'],
+            })
 
     @run_only_on('sat')
     @data(
@@ -247,27 +240,19 @@ class TestProduct(CLITestCase):
         @Assert: Product description is updated
 
         """
-        product = make_product({
-            u'organization-id': self.org['id'],
-        })
-
+        product = make_product({u'organization-id': self.org['id']})
         # Update the Descriptions
-        result = Product.update({
-            u'id': product['id'],
+        Product.update({
             u'description': test_data['description'],
+            u'id': product['id'],
         })
-
         # Fetch it
         result = Product.info({
             u'id': product['id'],
             u'organization-id': self.org['id'],
         })
-        self.assertEqual(result.return_code, 0)
-        self.assertEqual(len(result.stderr), 0)
-        self.assertEqual(
-            result.stdout['description'], test_data['description'])
-        self.assertNotEqual(
-            product['description'], result.stdout['description'])
+        self.assertEqual(result['description'], test_data['description'])
+        self.assertNotEqual(product['description'], result['description'])
 
     @run_only_on('sat')
     def test_positive_update_2(self):
@@ -278,38 +263,24 @@ class TestProduct(CLITestCase):
         @Assert: Product gpg key is updated
 
         """
-        first_gpg_key = make_gpg_key(
-            {u'organization-id': self.org['id']}
-        )
-        second_gpg_key = make_gpg_key(
-            {u'organization-id': self.org['id']}
-        )
+        first_gpg_key = make_gpg_key({u'organization-id': self.org['id']})
+        second_gpg_key = make_gpg_key({u'organization-id': self.org['id']})
         product = make_product({
-            u'organization-id': self.org['id'],
             u'gpg-key-id': first_gpg_key['id'],
+            u'organization-id': self.org['id'],
         })
-
         # Update the Descriptions
-        result = Product.update({
-            u'id': product['id'],
+        Product.update({
             u'gpg-key-id': second_gpg_key['id'],
+            u'id': product['id'],
         })
-
         # Fetch it
-        result = Product.info({
+        product = Product.info({
             u'id': product['id'],
             u'organization-id': self.org['id'],
         })
-        self.assertEqual(result.return_code, 0)
-        self.assertEqual(len(result.stderr), 0)
-        self.assertEqual(
-            result.stdout['gpg']['gpg-key-id'],
-            second_gpg_key['id'],
-        )
-        self.assertNotEqual(
-            result.stdout['gpg']['gpg-key-id'],
-            first_gpg_key['id'],
-        )
+        self.assertEqual(product['gpg']['gpg-key-id'], second_gpg_key['id'])
+        self.assertNotEqual(product['gpg']['gpg-key-id'], first_gpg_key['id'])
 
     @run_only_on('sat')
     def test_positive_update_3(self):
@@ -320,38 +291,24 @@ class TestProduct(CLITestCase):
         @Assert: Product sync plan is updated
 
         """
-        first_sync_plan = make_sync_plan({
-            u'organization-id': self.org['id'],
-        })
-        second_sync_plan = make_sync_plan({
-            u'organization-id': self.org['id'],
-        })
+        first_sync_plan = make_sync_plan({u'organization-id': self.org['id']})
+        second_sync_plan = make_sync_plan({u'organization-id': self.org['id']})
         product = make_product({
             u'organization-id': self.org['id'],
             u'sync-plan-id': first_sync_plan['id'],
         })
-
         # Update the Descriptions
-        result = Product.update({
+        Product.update({
             u'id': product['id'],
             u'sync-plan-id': second_sync_plan['id'],
         })
-
         # Fetch it
-        result = Product.info({
+        product = Product.info({
             u'id': product['id'],
             u'organization-id': self.org['id'],
         })
-        self.assertEqual(result.return_code, 0)
-        self.assertEqual(len(result.stderr), 0)
-        self.assertEqual(
-            result.stdout['sync-plan-id'],
-            second_sync_plan['id'],
-        )
-        self.assertNotEqual(
-            result.stdout['sync-plan-id'],
-            first_sync_plan['id'],
-        )
+        self.assertEqual(product['sync-plan-id'], second_sync_plan['id'])
+        self.assertNotEqual(product['sync-plan-id'], first_sync_plan['id'])
 
     @run_only_on('sat')
     @data(*generate_strings_list())
@@ -374,26 +331,22 @@ class TestProduct(CLITestCase):
             u'name': new_prod_name,
         })
         # Verify Updated
-        result = Product.info({
+        prod = Product.info({
             u'id': prod['id'],
             u'organization-id': self.org['id'],
         })
-        self.assertEqual(result.return_code, 0)
-        self.assertEqual(len(result.stderr), 0)
-        self.assertEqual(result.stdout['name'], new_prod_name)
+        self.assertEqual(prod['name'], new_prod_name)
         # Now, Rename product to original
         Product.update({
             u'id': prod['id'],
             u'name': prod_name,
         })
-        result = Product.info({
+        prod = Product.info({
             u'id': prod['id'],
             u'organization-id': self.org['id'],
         })
         # Verify renamed back to Original name.
-        self.assertEqual(result.return_code, 0)
-        self.assertEqual(len(result.stderr), 0)
-        self.assertEqual(result.stdout['name'], prod_name)
+        self.assertEqual(prod['name'], prod_name)
 
     @run_only_on('sat')
     def test_positive_delete_1(self):
@@ -404,32 +357,22 @@ class TestProduct(CLITestCase):
         @Assert: Product is deleted
 
         """
-        new_product = make_product({
-            u'organization-id': self.org['id']
-        })
-
+        new_product = make_product({u'organization-id': self.org['id']})
         # Delete it
-        result = Product.delete({u'id': new_product['id']})
-        self.assertEqual(result.return_code, 0)
-        self.assertEqual(len(result.stderr), 0)
-
+        Product.delete({u'id': new_product['id']})
         # Fetch it
-        result = Product.info({
-            u'id': new_product['id'],
-            u'organization-id': self.org['id'],
-        })
-        if bz_bug_is_open(1219490):
-            for _ in range(5):
-                if result.return_code == 0:
+        with self.assertRaises(CLIReturnCodeError):
+            Product.info({
+                u'id': new_product['id'],
+                u'organization-id': self.org['id'],
+            })
+            if bz_bug_is_open(1219490):
+                for _ in range(5):
                     time.sleep(5)
-                    result = Product.info({
+                    Product.info({
                         u'id': new_product['id'],
                         u'organization-id': self.org['id'],
                     })
-                else:
-                    break
-        self.assertNotEqual(result.return_code, 0)
-        self.assertGreater(len(result.stderr), 0)
 
     def test_add_syncplan_1(self):
         """@Test: Check if product can be assigned a syncplan
@@ -439,27 +382,17 @@ class TestProduct(CLITestCase):
         @Assert: Product has syncplan
 
         """
-        try:
-            new_product = make_product({
-                u'organization-id': self.org['id']
-            })
-            sync_plan = make_sync_plan({'organization-id': self.org['id']})
-        except CLIFactoryError as err:
-            self.fail(err)
-
-        result = Product.set_sync_plan({
-            'sync-plan-id': sync_plan['id'],
+        new_product = make_product({u'organization-id': self.org['id']})
+        sync_plan = make_sync_plan({'organization-id': self.org['id']})
+        Product.set_sync_plan({
             'id': new_product['id'],
+            'sync-plan-id': sync_plan['id'],
         })
-        self.assertEqual(result.return_code, 0)
-        self.assertEqual(len(result.stderr), 0)
-        result = Product.info({
+        new_product = Product.info({
             'id': new_product['id'],
             'organization-id': self.org['id'],
         })
-        self.assertEqual(result.return_code, 0)
-        self.assertEqual(len(result.stderr), 0)
-        self.assertEqual(result.stdout['sync-plan-id'], sync_plan['id'])
+        self.assertEqual(new_product['sync-plan-id'], sync_plan['id'])
 
     def test_remove_syncplan_1(self):
         """@Test: Check if product can be assigned a syncplan
@@ -469,37 +402,23 @@ class TestProduct(CLITestCase):
         @Assert: Product has syncplan
 
         """
-        try:
-            product = make_product({u'organization-id': self.org['id']})
-            sync_plan = make_sync_plan({'organization-id': self.org['id']})
-        except CLIFactoryError as err:
-            self.fail(err)
-
-        result = Product.set_sync_plan({
+        product = make_product({u'organization-id': self.org['id']})
+        sync_plan = make_sync_plan({'organization-id': self.org['id']})
+        Product.set_sync_plan({
+            'id': product['id'],
             'sync-plan-id': sync_plan['id'],
-            'id': product['id'],
         })
-        self.assertEqual(result.return_code, 0)
-        self.assertEqual(len(result.stderr), 0)
-        result = Product.info({
+        product = Product.info({
             'id': product['id'],
             'organization-id': self.org['id'],
         })
-        self.assertEqual(result.return_code, 0)
-        self.assertEqual(len(result.stderr), 0)
-        self.assertEqual(result.stdout['sync-plan-id'], sync_plan['id'])
-        result = Product.remove_sync_plan({
-            'id': product['id'],
-        })
-        self.assertEqual(result.return_code, 0)
-        self.assertEqual(len(result.stderr), 0)
-        result = Product.info({
+        self.assertEqual(product['sync-plan-id'], sync_plan['id'])
+        Product.remove_sync_plan({'id': product['id']})
+        product = Product.info({
             'id': product['id'],
             'organization-id': self.org['id'],
         })
-        self.assertEqual(result.return_code, 0)
-        self.assertEqual(len(result.stderr), 0)
-        self.assertEqual(len(result.stdout['sync-plan-id']), 0)
+        self.assertEqual(len(product['sync-plan-id']), 0)
 
     def test_product_synchronize_by_id(self):
         """@Test: Check if product can be synchronized.
@@ -510,25 +429,18 @@ class TestProduct(CLITestCase):
         @Assert: Product was synchronized
 
         """
-        try:
-            org = make_org()
-            product = make_product({'organization-id': org['id']})
-            make_repository({'product-id': product['id']})
-        except CLIFactoryError as err:
-            self.fail(err)
-
-        result = Product.synchronize({
+        org = make_org()
+        product = make_product({'organization-id': org['id']})
+        make_repository({'product-id': product['id']})
+        Product.synchronize({
             'id': product['id'],
             'organization-id': org['id'],
         })
-        self.assertEqual(result.return_code, 0)
-
-        result = Product.info({
+        product = Product.info({
             'id': product['id'],
             'organization-id': org['id'],
         })
-        self.assertEqual(result.return_code, 0)
-        self.assertEqual(u'Syncing Complete.', result.stdout['sync-state'])
+        self.assertEqual(u'Syncing Complete.', product['sync-state'])
 
     def test_product_synchronize_by_name(self):
         """@Test: Check if product can be synchronized.
@@ -539,25 +451,18 @@ class TestProduct(CLITestCase):
         @Assert: Product was synchronized
 
         """
-        try:
-            org = make_org()
-            product = make_product({'organization-id': org['id']})
-            make_repository({'product-id': product['id']})
-        except CLIFactoryError as err:
-            self.fail(err)
-
-        result = Product.synchronize({
+        org = make_org()
+        product = make_product({'organization-id': org['id']})
+        make_repository({'product-id': product['id']})
+        Product.synchronize({
             'name': product['name'],
             'organization': org['name'],
         })
-        self.assertEqual(result.return_code, 0)
-
-        result = Product.info({
+        product = Product.info({
             'id': product['id'],
             'organization-id': org['id'],
         })
-        self.assertEqual(result.return_code, 0)
-        self.assertEqual(u'Syncing Complete.', result.stdout['sync-state'])
+        self.assertEqual(u'Syncing Complete.', product['sync-state'])
 
     def test_product_synchronize_by_label(self):
         """@Test: Check if product can be synchronized.
@@ -568,22 +473,15 @@ class TestProduct(CLITestCase):
         @Assert: Product was synchronized
 
         """
-        try:
-            org = make_org()
-            product = make_product({'organization-id': org['id']})
-            make_repository({'product-id': product['id']})
-        except CLIFactoryError as err:
-            self.fail(err)
-
-        result = Product.synchronize({
+        org = make_org()
+        product = make_product({'organization-id': org['id']})
+        make_repository({'product-id': product['id']})
+        Product.synchronize({
             'id': product['id'],
             'organization-label': org['label'],
         })
-        self.assertEqual(result.return_code, 0)
-
-        result = Product.info({
+        product = Product.info({
             'id': product['id'],
             'organization-id': org['id'],
         })
-        self.assertEqual(result.return_code, 0)
-        self.assertEqual(u'Syncing Complete.', result.stdout['sync-state'])
+        self.assertEqual(u'Syncing Complete.', product['sync-state'])

--- a/tests/foreman/cli/test_proxy.py
+++ b/tests/foreman/cli/test_proxy.py
@@ -5,6 +5,7 @@ import random
 
 from ddt import ddt
 from fauxfactory import gen_string
+from robottelo.cli.base import CLIReturnCodeError
 from robottelo.cli.factory import CLIFactoryError, make_proxy
 from robottelo.cli.proxy import Proxy, default_url_on_new_port
 from robottelo.decorators import data, run_only_on
@@ -15,7 +16,7 @@ from robottelo.test import CLITestCase
 @ddt
 class TestProxy(CLITestCase):
 
-    def setUp(self):  # noqa
+    def setUp(self):
         """Skipping tests until we can create ssh tunnels"""
         self.skipTest('Skipping tests until we can create ssh tunnels')
 
@@ -27,7 +28,6 @@ class TestProxy(CLITestCase):
         @Assert: Proxy is not created
 
         """
-
         # Create a random proxy
         with self.assertRaises(CLIFactoryError):
             make_proxy({
@@ -43,7 +43,7 @@ class TestProxy(CLITestCase):
         {u'name': gen_string('latin1', 15)},
         {u'name': gen_string('utf8', 15)},
     )
-    def test_proxy_create(self, data):
+    def test_proxy_create(self, test_data):
         """@Test: Proxy creation with the home proxy
 
         @Feature: Smart Proxy
@@ -51,14 +51,8 @@ class TestProxy(CLITestCase):
         @Assert: Proxy is created
 
         """
-        try:
-            proxy = make_proxy({u'name': data['name']})
-        except CLIFactoryError as err:
-            self.fail(err)
-
-        self.assertEquals(
-            proxy['name'],
-            data['name'], "Input and output name should be consistent")
+        proxy = make_proxy({u'name': test_data['name']})
+        self.assertEquals(proxy['name'], test_data['name'])
 
     @data(
         {u'name': gen_string('alpha', 15)},
@@ -67,7 +61,7 @@ class TestProxy(CLITestCase):
         {u'name': gen_string('latin1', 15)},
         {u'name': gen_string('utf8', 15)},
     )
-    def test_proxy_delete(self, data):
+    def test_proxy_delete(self, test_data):
         """@Test: Proxy deletion with the home proxy
 
         @Feature: Smart Proxy
@@ -75,38 +69,11 @@ class TestProxy(CLITestCase):
         @Assert: Proxy is deleted
 
         """
-        try:
-            proxy = make_proxy({u'name': data['name']})
-        except CLIFactoryError as err:
-            self.fail(err)
-
-        self.assertEquals(
-            proxy['name'],
-            data['name'], "Input and output name should be consistent")
-
-        result = Proxy.delete({u'id': proxy['id']})
-        self.assertEqual(
-            result.return_code,
-            0,
-            "Proxy should be deleted"
-        )
-        self.assertEqual(
-            len(result.stderr),
-            0,
-            "No error excepted"
-        )
-
-        result = Proxy.info({u'id': proxy['id']})
-        self.assertNotEqual(
-            result.return_code,
-            0,
-            "Proxy should not be found"
-        )
-        self.assertGreater(
-            len(result.stderr),
-            0,
-            "Expected an error here"
-        )
+        proxy = make_proxy({u'name': test_data['name']})
+        self.assertEquals(proxy['name'], test_data['name'])
+        Proxy.delete({u'id': proxy['id']})
+        with self.assertRaises(CLIReturnCodeError):
+            Proxy.info({u'id': proxy['id']})
 
     @data(
         {u'name': gen_string('alpha', 15),
@@ -120,7 +87,7 @@ class TestProxy(CLITestCase):
         {u'name': gen_string('utf8', 15),
          u'update': gen_string('alpha', 15)},
     )
-    def test_proxy_update(self, data):
+    def test_proxy_update(self, test_data):
         """@Test: Proxy name update with the home proxy
 
         @Feature: Smart Proxy
@@ -128,36 +95,16 @@ class TestProxy(CLITestCase):
         @Assert: Proxy has the name updated
 
         """
-        try:
-            proxy = make_proxy({u'name': data['name']})
-        except CLIFactoryError as err:
-            self.fail(err)
-
-        self.assertEquals(
-            proxy['name'],
-            data['name'], "Input and output name should be consistent")
-
+        proxy = make_proxy({u'name': test_data['name']})
+        self.assertEquals(proxy['name'], test_data['name'])
         with default_url_on_new_port(9090, random.randint(9091, 49090)) as url:
-            result = Proxy.update({
+            Proxy.update({
                 u'id': proxy['id'],
-                u'name': data['update'],
-                u'url': url})
-        self.assertEqual(
-            result.return_code,
-            0,
-            "Proxy should be updated"
-        )
-        result = Proxy.info({u'id': proxy['id']})
-        self.assertEqual(
-            result.return_code,
-            0,
-            "Proxy should be found"
-        )
-        self.assertEqual(
-            result.stdout['name'],
-            data['update'],
-            "Proxy name should be updated"
-        )
+                u'name': test_data['update'],
+                u'url': url,
+            })
+        proxy = Proxy.info({u'id': proxy['id']})
+        self.assertEqual(proxy['name'], test_data['update'])
 
     def test_proxy_refresh_features_by_id(self):
         """@Test: Refresh smart proxy features, search for proxy by id
@@ -167,12 +114,8 @@ class TestProxy(CLITestCase):
         @Assert: Proxy features are refreshed
 
         """
-        try:
-            proxy = make_proxy()
-        except CLIFactoryError as err:
-            self.fail(err)
-        result = Proxy.refresh_features({u'id': proxy['id']})
-        self.assertEqual(result.return_code, 0)
+        proxy = make_proxy()
+        Proxy.refresh_features({u'id': proxy['id']})
 
     def test_proxy_refresh_features_by_name(self):
         """@Test: Refresh smart proxy features, search for proxy by name
@@ -182,9 +125,5 @@ class TestProxy(CLITestCase):
         @Assert: Proxy features are refreshed
 
         """
-        try:
-            proxy = make_proxy()
-        except CLIFactoryError as err:
-            self.fail(err)
-        result = Proxy.refresh_features({u'name': proxy['name']})
-        self.assertEqual(result.return_code, 0)
+        proxy = make_proxy()
+        Proxy.refresh_features({u'name': proxy['name']})

--- a/tests/foreman/cli/test_puppetmodule.py
+++ b/tests/foreman/cli/test_puppetmodule.py
@@ -38,10 +38,8 @@ class TestPuppetModule(CLITestCase):
 
         """
         result = PuppetModule.list({'organization-id': self.org['id']})
-        self.assertEqual(result.return_code, 0)
-        self.assertEqual(len(result.stderr), 0)
         # There are 4 puppet modules in the test puppet-module url
-        self.assertEqual(len(result.stdout), 4)
+        self.assertEqual(len(result), 4)
 
     def test_puppet_module_info(self):
         """@Test: Check if puppet-module info retrieves info for the given
@@ -53,14 +51,12 @@ class TestPuppetModule(CLITestCase):
 
         """
         return_value = PuppetModule.list({
-            'organization-id': self.org['id']
+            'organization-id': self.org['id'],
         })
         # There are 4 puppet modules in the test puppet-module url
         for i in range(4):
             result = PuppetModule.info(
-                {'id': return_value.stdout[i]['id']},
+                {'id': return_value[i]['id']},
                 output_format='json'
             )
-            self.assertEqual(result.return_code, 0)
-            self.assertEqual(len(result.stderr), 0)
-            self.assertEqual(result.stdout['ID'], return_value.stdout[i]['id'])
+            self.assertEqual(result['ID'], return_value[i]['id'])

--- a/tests/foreman/cli/test_report.py
+++ b/tests/foreman/cli/test_report.py
@@ -4,6 +4,7 @@
 import random
 
 from robottelo import ssh
+from robottelo.cli.base import CLIReturnCodeError
 from robottelo.cli.report import Report
 from robottelo.decorators import run_only_on
 from robottelo.test import CLITestCase
@@ -13,7 +14,7 @@ from robottelo.test import CLITestCase
 class TestReport(CLITestCase):
     """Test class for Reports CLI. """
 
-    def setUp(self):  # noqa
+    def setUp(self):
         super(TestReport, self).setUp()
         self.run_puppet_agent()
 
@@ -23,7 +24,6 @@ class TestReport(CLITestCase):
         that we have reports available.
 
         """
-
         ssh.command('puppet agent -t')
 
     def test_list(self):
@@ -34,10 +34,7 @@ class TestReport(CLITestCase):
         @Assert: Puppert Report List is displayed
 
         """
-
-        result = Report.list()
-        self.assertEqual(result.return_code, 0)
-        self.assertGreater(len(result.stdout), 0)
+        Report.list()
 
     def test_info(self):
         """@Test: Test Info for Puppet report
@@ -47,16 +44,12 @@ class TestReport(CLITestCase):
         @Assert: Puppet Report Info is displayed
 
         """
-
         result = Report.list()
-        self.assertEqual(result.return_code, 0)
-        self.assertGreater(len(result.stdout), 0)
-
+        self.assertGreater(len(result), 0)
         # Grab a random report
-        report = random.choice(result.stdout)
+        report = random.choice(result)
         result = Report.info({'id': report['id']})
-        self.assertEqual(result.return_code, 0)
-        self.assertEqual(report['id'], result.stdout['id'])
+        self.assertEqual(report['id'], result['id'])
 
     def test_delete(self):
         """@Test: Check if Puppet Report can be deleted
@@ -66,16 +59,10 @@ class TestReport(CLITestCase):
         @Assert: Puppet Report is deleted
 
         """
-
         result = Report.list()
-        self.assertEqual(result.return_code, 0)
-        self.assertGreater(len(result.stdout), 0)
-
+        self.assertGreater(len(result), 0)
         # Grab a random report
-        report = random.choice(result.stdout)
-        result = Report.delete({'id': report['id']})
-        self.assertEqual(result.return_code, 0)
-
-        result = Report.info({'id': report['id']})
-        self.assertGreater(result.return_code, 0)
-        self.assertGreater(len(result.stderr), 0)
+        report = random.choice(result)
+        Report.delete({'id': report['id']})
+        with self.assertRaises(CLIReturnCodeError):
+            Report.info({'id': report['id']})

--- a/tests/foreman/cli/test_repository.py
+++ b/tests/foreman/cli/test_repository.py
@@ -4,6 +4,7 @@
 from ddt import ddt
 from fauxfactory import gen_string
 from robottelo import ssh
+from robottelo.cli.base import CLIReturnCodeError
 from robottelo.cli.factory import (
     make_gpg_key,
     make_org,
@@ -43,8 +44,8 @@ class TestRepository(CLITestCase):
     org = None
     product = None
 
-    def setUp(self):  # noqa
-        """Tests for Repositiry via Hammer CLI"""
+    def setUp(self):
+        """Tests for Repository via Hammer CLI"""
 
         super(TestRepository, self).setUp()
 
@@ -76,11 +77,10 @@ class TestRepository(CLITestCase):
 
         """
         repository = self._make_repository({
-            u'name': gen_string('alpha'),
             u'content-type': u'docker',
+            u'name': gen_string('alpha'),
             u'docker-upstream-name': u'fedora/rabbitmq',
         })
-
         self.assertIn(u'upstream-repository-name', repository)
         self.assertEqual(
             repository['upstream-repository-name'], u'fedora/rabbitmq')
@@ -102,7 +102,6 @@ class TestRepository(CLITestCase):
         @Assert: Repository is created and has random name
 
         """
-
         new_repo = self._make_repository({u'name': name})
         # Assert that name matches data passed
         self.assertEqual(new_repo['name'], name)
@@ -124,13 +123,11 @@ class TestRepository(CLITestCase):
         @Assert: Repository is created and has random name and labels
 
         """
-
         # Generate a random, 'safe' label
         label = gen_string('alpha', 20)
-
         new_repo = self._make_repository({
-            u'name': name,
             u'label': label,
+            u'name': name,
         })
         # Assert that name matches data passed
         self.assertEqual(new_repo['name'], name)
@@ -152,10 +149,9 @@ class TestRepository(CLITestCase):
         @Assert: YUM repository is created
 
         """
-
         new_repo = self._make_repository({
-            u'url': test_data['url'],
             u'content-type': test_data['content-type'],
+            u'url': test_data['url'],
         })
         # Assert that urls and content types matches data passed
         self.assertEqual(new_repo['url'], test_data['url'])
@@ -177,10 +173,9 @@ class TestRepository(CLITestCase):
         @Assert: Puppet repository is created
 
         """
-
         new_repo = self._make_repository({
-            u'url': test_data['url'],
             u'content-type': test_data['content-type'],
+            u'url': test_data['url'],
         })
         # Assert that urls and content types matches data passed
         self.assertEqual(new_repo['url'], test_data['url'])
@@ -205,12 +200,10 @@ class TestRepository(CLITestCase):
         """
         # Make a new gpg key
         new_gpg_key = make_gpg_key({'organization-id': self.org['id']})
-
         repository = self._make_repository({
-            u'name': name,
             u'gpg-key-id': new_gpg_key['id'],
+            u'name': name,
         })
-
         # Assert that data matches data passed
         self.assertEqual(repository['gpg-key']['id'], new_gpg_key['id'])
         self.assertEqual(repository['gpg-key']['name'], new_gpg_key['name'])
@@ -237,10 +230,9 @@ class TestRepository(CLITestCase):
         """
         new_gpg_key = make_gpg_key({'organization-id': self.org['id']})
         new_repo = self._make_repository({
-            u'name': name,
             u'gpg-key': new_gpg_key['name'],
+            u'name': name,
         })
-
         # Assert that data matches data passed
         self.assertEqual(new_repo['gpg-key']['id'], new_gpg_key['id'])
         self.assertEqual(new_repo['gpg-key']['name'], new_gpg_key['name'])
@@ -290,8 +282,8 @@ class TestRepository(CLITestCase):
         """
         content_type = u'yum'
         repository = self._make_repository({
-            u'content-type': content_type,
             u'checksum-type': checksum_type,
+            u'content-type': content_type,
         })
         self.assertEqual(repository['content-type'], content_type)
         self.assertEqual(repository['checksum-type'], checksum_type)
@@ -307,10 +299,10 @@ class TestRepository(CLITestCase):
         """
         content_type = u'docker'
         new_repo = self._make_repository({
-            u'name': u'busybox',
-            u'docker-upstream-name': u'busybox',
-            u'url': DOCKER_REGISTRY_HUB,
             u'content-type': content_type,
+            u'docker-upstream-name': u'busybox',
+            u'name': u'busybox',
+            u'url': DOCKER_REGISTRY_HUB,
         })
         # Assert that urls and content types matches data passed
         self.assertEqual(new_repo['url'], DOCKER_REGISTRY_HUB)
@@ -327,7 +319,7 @@ class TestRepository(CLITestCase):
         gen_string('html', 15),
     )
     def test_positive_create_docker_repo_2(self, name):
-        """@Test: Create a Docker repository with a randon name.
+        """@Test: Create a Docker repository with a random name.
 
         @Feature: Repository
 
@@ -336,10 +328,10 @@ class TestRepository(CLITestCase):
         """
         content_type = u'docker'
         new_repo = self._make_repository({
-            u'name': name,
-            u'docker-upstream-name': u'busybox',
-            u'url': DOCKER_REGISTRY_HUB,
             u'content-type': content_type,
+            u'docker-upstream-name': u'busybox',
+            u'name': name,
+            u'url': DOCKER_REGISTRY_HUB,
         })
         # Assert that urls, content types and name matches data passed
         self.assertEqual(new_repo['url'], DOCKER_REGISTRY_HUB)
@@ -381,22 +373,17 @@ class TestRepository(CLITestCase):
         @Assert: Repository is created and synced
 
         """
-
         new_repo = self._make_repository({
-            u'url': test_data['url'],
             u'content-type': test_data['content-type'],
+            u'url': test_data['url'],
         })
         # Assertion that repo is not yet synced
         self.assertEqual(new_repo['sync']['status'], 'Not Synced')
-
         # Synchronize it
-        result = Repository.synchronize({'id': new_repo['id']})
-        self.assertEqual(result.return_code, 0)
-        self.assertEqual(len(result.stderr), 0)
-
+        Repository.synchronize({'id': new_repo['id']})
         # Verify it has finished
-        result = Repository.info({'id': new_repo['id']})
-        self.assertEqual(result.stdout['sync']['status'], 'Finished')
+        new_repo = Repository.info({'id': new_repo['id']})
+        self.assertEqual(new_repo['sync']['status'], 'Finished')
 
     @run_only_on('sat')
     @skip_if_bug_open('bugzilla', 1152237)
@@ -408,23 +395,18 @@ class TestRepository(CLITestCase):
         @Assert: Docker repository is created and synced
 
         """
-
         new_repo = self._make_repository({
+            u'content-type': u'docker',
             u'docker-upstream-name': u'busybox',
             u'url': DOCKER_REGISTRY_HUB,
-            u'content-type': u'docker',
         })
         # Assertion that repo is not yet synced
         self.assertEqual(new_repo['sync']['status'], 'Not Synced')
-
         # Synchronize it
-        result = Repository.synchronize({'id': new_repo['id']})
-        self.assertEqual(result.return_code, 0)
-        self.assertEqual(len(result.stderr), 0)
-
+        Repository.synchronize({'id': new_repo['id']})
         # Verify it has finished
-        result = Repository.info({'id': new_repo['id']})
-        self.assertEqual(result.stdout['sync']['status'], 'Finished')
+        new_repo = Repository.info({'id': new_repo['id']})
+        self.assertEqual(new_repo['sync']['status'], 'Finished')
 
     @run_only_on('sat')
     @data(
@@ -442,23 +424,16 @@ class TestRepository(CLITestCase):
         @Assert: Repository url is updated
 
         """
-
         new_repo = self._make_repository()
-
         # Update the url
-        result = Repository.update({
+        Repository.update({
             u'id': new_repo['id'],
             u'url': url,
         })
-        self.assertEqual(result.return_code, 0)
-        self.assertEqual(len(result.stderr), 0)
-
         # Fetch it again
         result = Repository.info({'id': new_repo['id']})
-        self.assertEqual(result.return_code, 0)
-        self.assertEqual(len(result.stderr), 0)
-        self.assertNotEqual(result.stdout['url'], new_repo['url'])
-        self.assertEqual(result.stdout['url'], url)
+        self.assertNotEqual(result['url'], new_repo['url'])
+        self.assertEqual(result['url'], url)
 
     @run_only_on('sat')
     @stubbed()
@@ -504,30 +479,21 @@ class TestRepository(CLITestCase):
 
         """
         content_type = u'yum'
-        repository = self._make_repository({
-            u'content-type': content_type,
-        })
-
+        repository = self._make_repository({u'content-type': content_type})
         self.assertEqual(repository['content-type'], content_type)
         self.assertEqual(repository['checksum-type'], '')
-
         # Update the url
-        result = Repository.update({
-            u'id': repository['id'],
+        Repository.update({
             u'checksum-type': checksum_type,
+            u'id': repository['id'],
         })
-        self.assertEqual(result.return_code, 0)
-        self.assertEqual(len(result.stderr), 0)
-
         # Fetch it again
         result = Repository.info({'id': repository['id']})
-        self.assertEqual(result.return_code, 0)
-        self.assertEqual(len(result.stderr), 0)
         self.assertNotEqual(
-            result.stdout['checksum-type'],
+            result['checksum-type'],
             repository['checksum-type'],
         )
-        self.assertEqual(result.stdout['checksum-type'], checksum_type)
+        self.assertEqual(result['checksum-type'], checksum_type)
 
     @run_only_on('sat')
     @data(
@@ -546,22 +512,14 @@ class TestRepository(CLITestCase):
         @Assert: Repository is created and then deleted
 
         """
-
         new_repo = self._make_repository({u'name': name})
         # Assert that name matches data passed
         self.assertEqual(new_repo['name'], name)
-
         # Delete it
-        result = Repository.delete({u'id': new_repo['id']})
-        self.assertEqual(result.return_code, 0)
-        self.assertEqual(len(result.stderr), 0)
-
+        Repository.delete({u'id': new_repo['id']})
         # Fetch it
-        result = Repository.info({
-            u'id': new_repo['id'],
-        })
-        self.assertNotEqual(result.return_code, 0)
-        self.assertGreater(len(result.stderr), 0)
+        with self.assertRaises(CLIReturnCodeError):
+            Repository.info({u'id': new_repo['id']})
 
     def test_upload_content(self):
         """@Test: Create repository and upload content
@@ -571,23 +529,16 @@ class TestRepository(CLITestCase):
         @Assert: upload content is successful
 
         """
-        name = gen_string('alpha', 15)
-        try:
-            new_repo = self._make_repository({'name': name})
-        except CLIFactoryError as err:
-            self.fail(err)
-
+        new_repo = self._make_repository({'name': gen_string('alpha', 15)})
         ssh.upload_file(local_file=get_data_file(RPM_TO_UPLOAD),
                         remote_file="/tmp/{0}".format(RPM_TO_UPLOAD))
         result = Repository.upload_content({
             'name': new_repo['name'],
+            'organization': new_repo['organization'],
             'path': "/tmp/{0}".format(RPM_TO_UPLOAD),
             'product-id': new_repo['product']['id'],
-            'organization': new_repo['organization'],
         })
-        self.assertEqual(result.return_code, 0)
-        self.assertEqual(len(result.stderr), 0)
         self.assertIn(
             "Successfully uploaded file '{0}'".format(RPM_TO_UPLOAD),
-            result.stdout[0]['message']
+            result[0]['message'],
         )

--- a/tests/foreman/cli/test_repository_set.py
+++ b/tests/foreman/cli/test_repository_set.py
@@ -34,21 +34,17 @@ class TestRepositorySet(CLITestCase):
         valid amount of enabled repositories
 
         """
-        rhel_product_name = 'Red Hat Enterprise Linux Server'
-        rhel_repo_set = (
-            'Red Hat Enterprise Virtualization Agents '
-            'for RHEL 6 Server (RPMs)'
-        )
+        rhel_product_name = PRDS['rhel']
+        rhel_repo_set = REPOSET['rhva6']
 
         # Clone manifest and upload it
         org = make_org()
         manifest = manifests.clone()
         upload_file(manifest, remote_file=manifest)
-        result = Subscription.upload({
+        Subscription.upload({
             u'file': manifest,
             u'organization-id': org['id'],
         })
-        self.assertEqual(result.return_code, 0)
 
         # No repos should be enabled by default
         result = RepositorySet.available_repositories({
@@ -56,21 +52,19 @@ class TestRepositorySet(CLITestCase):
             u'organization-id': org['id'],
             u'product': rhel_product_name,
         })
-        self.assertEqual(result.return_code, 0)
         self.assertEqual(
-            sum(int(repo['enabled'] == u'true') for repo in result.stdout),
+            sum(int(repo['enabled'] == u'true') for repo in result),
             0
         )
 
         # Enable repo from Repository Set
-        result = RepositorySet.enable({
+        RepositorySet.enable({
+            u'basearch': 'x86_64',
             u'name': rhel_repo_set,
             u'organization-id': org['id'],
             u'product': rhel_product_name,
             u'releasever': '6Server',
-            u'basearch': 'x86_64',
         })
-        self.assertEqual(result.return_code, 0)
 
         # Only 1 repo should be enabled
         result = RepositorySet.available_repositories({
@@ -78,21 +72,19 @@ class TestRepositorySet(CLITestCase):
             u'organization': org['name'],
             u'product': rhel_product_name,
         })
-        self.assertEqual(result.return_code, 0)
         self.assertEqual(
-            sum(int(repo['enabled'] == u'true') for repo in result.stdout),
+            sum(int(repo['enabled'] == u'true') for repo in result),
             1
         )
 
         # Enable one more repo
-        result = RepositorySet.enable({
+        RepositorySet.enable({
+            u'basearch': 'i386',
             u'name': rhel_repo_set,
             u'organization-id': org['id'],
             u'product': rhel_product_name,
             u'releasever': '6Server',
-            u'basearch': 'i386',
         })
-        self.assertEqual(result.return_code, 0)
 
         # 2 repos should be enabled
         result = RepositorySet.available_repositories({
@@ -100,21 +92,19 @@ class TestRepositorySet(CLITestCase):
             u'organization-label': org['label'],
             u'product': rhel_product_name,
         })
-        self.assertEqual(result.return_code, 0)
         self.assertEqual(
-            sum(int(repo['enabled'] == u'true') for repo in result.stdout),
+            sum(int(repo['enabled'] == u'true') for repo in result),
             2
         )
 
         # Disable one repo
-        result = RepositorySet.disable({
+        RepositorySet.disable({
+            u'basearch': 'i386',
             u'name': rhel_repo_set,
             u'organization-id': org['id'],
             u'product': rhel_product_name,
             u'releasever': '6Server',
-            u'basearch': 'i386',
         })
-        self.assertEqual(result.return_code, 0)
 
         # There should remain only 1 enabled repo
         result = RepositorySet.available_repositories({
@@ -122,21 +112,19 @@ class TestRepositorySet(CLITestCase):
             u'organization-id': org['id'],
             u'product': rhel_product_name,
         })
-        self.assertEqual(result.return_code, 0)
         self.assertEqual(
-            sum(int(repo['enabled'] == u'true') for repo in result.stdout),
+            sum(int(repo['enabled'] == u'true') for repo in result),
             1
         )
 
         # Disable the last enabled repo
-        result = RepositorySet.disable({
+        RepositorySet.disable({
+            u'basearch': 'x86_64',
             u'name': rhel_repo_set,
             u'organization-id': org['id'],
             u'product': rhel_product_name,
             u'releasever': '6Server',
-            u'basearch': 'x86_64',
         })
-        self.assertEqual(result.return_code, 0)
 
         # There should be no enabled repos
         result = RepositorySet.available_repositories({
@@ -144,9 +132,8 @@ class TestRepositorySet(CLITestCase):
             u'organization-id': org['id'],
             u'product': rhel_product_name,
         })
-        self.assertEqual(result.return_code, 0)
         self.assertEqual(
-            sum(int(repo['enabled'] == u'true') for repo in result.stdout),
+            sum(int(repo['enabled'] == u'true') for repo in result),
             0
         )
 
@@ -161,29 +148,26 @@ class TestRepositorySet(CLITestCase):
         org = make_org()
         manifest = manifests.clone()
         upload_file(manifest, remote_file=manifest)
-        result = Subscription.upload({
+        Subscription.upload({
             u'file': manifest,
             u'organization-id': org['id'],
         })
-        self.assertEqual(result.return_code, 0)
-        result = RepositorySet.enable({
+        RepositorySet.enable({
+            u'basearch': 'x86_64',
             u'name': REPOSET['rhva6'],
             u'organization': org['name'],
             u'product': PRDS['rhel'],
             u'releasever': '6Server',
-            u'basearch': 'x86_64',
         })
-        self.assertEqual(result.return_code, 0)
         result = RepositorySet.available_repositories({
             u'name': REPOSET['rhva6'],
             u'organization': org['name'],
             u'product': PRDS['rhel'],
         })
-        self.assertEqual(result.return_code, 0)
         enabled = [
             repo['enabled']
             for repo
-            in result.stdout
+            in result
             if repo['arch'] == 'x86_64' and repo['release'] == '6Server'
         ][0]
         self.assertEqual(enabled, 'true')
@@ -200,29 +184,26 @@ class TestRepositorySet(CLITestCase):
         org = make_org()
         manifest = manifests.clone()
         upload_file(manifest, remote_file=manifest)
-        result = Subscription.upload({
+        Subscription.upload({
             u'file': manifest,
             u'organization-id': org['id'],
         })
-        self.assertEqual(result.return_code, 0)
-        result = RepositorySet.enable({
+        RepositorySet.enable({
+            u'basearch': 'x86_64',
             u'name': REPOSET['rhva6'],
             u'organization-label': org['label'],
             u'product': PRDS['rhel'],
             u'releasever': '6Server',
-            u'basearch': 'x86_64',
         })
-        self.assertEqual(result.return_code, 0)
         result = RepositorySet.available_repositories({
             u'name': REPOSET['rhva6'],
             u'organization-label': org['label'],
             u'product': PRDS['rhel'],
         })
-        self.assertEqual(result.return_code, 0)
         enabled = [
             repo['enabled']
             for repo
-            in result.stdout
+            in result
             if repo['arch'] == 'x86_64' and repo['release'] == '6Server'
         ][0]
         self.assertEqual(enabled, 'true')
@@ -238,44 +219,42 @@ class TestRepositorySet(CLITestCase):
         org = make_org()
         manifest = manifests.clone()
         upload_file(manifest, remote_file=manifest)
-        result = Subscription.upload({
+        Subscription.upload({
             u'file': manifest,
             u'organization-id': org['id'],
         })
-        self.assertEqual(result.return_code, 0)
         product_id = Product.info({
             u'name': PRDS['rhel'],
             u'organization-id': org['id'],
-        }).stdout['id']
+        })['id']
         reposet_id = RepositorySet.info({
             u'name': REPOSET['rhva6'],
             u'organization-id': org['id'],
             u'product-id': product_id,
-        }).stdout['id']
-        result = RepositorySet.enable({
+        })['id']
+        RepositorySet.enable({
+            u'basearch': 'x86_64',
             u'id': reposet_id,
             u'organization-id': org['id'],
             u'product-id': product_id,
             u'releasever': '6Server',
-            u'basearch': 'x86_64',
         })
-        self.assertEqual(result.return_code, 0)
         result = RepositorySet.available_repositories({
             u'id': reposet_id,
             u'organization-id': org['id'],
             u'product-id': product_id,
         })
-        self.assertEqual(result.return_code, 0)
         enabled = [
             repo['enabled']
             for repo
-            in result.stdout
+            in result
             if repo['arch'] == 'x86_64' and repo['release'] == '6Server'
         ][0]
         self.assertEqual(enabled, 'true')
 
     def test_repositoryset_disable_by_name(self):
-        """@Test: Disable repo from reposet by names of reposet, org and product
+        """@Test: Disable repo from reposet by names of reposet, org and
+        product
 
         @Feature: Repository-set
 
@@ -285,37 +264,33 @@ class TestRepositorySet(CLITestCase):
         org = make_org()
         manifest = manifests.clone()
         upload_file(manifest, remote_file=manifest)
-        result = Subscription.upload({
+        Subscription.upload({
             u'file': manifest,
             u'organization-id': org['id'],
         })
-        self.assertEqual(result.return_code, 0)
-        result = RepositorySet.enable({
+        RepositorySet.enable({
+            u'basearch': 'x86_64',
             u'name': REPOSET['rhva6'],
             u'organization': org['name'],
             u'product': PRDS['rhel'],
             u'releasever': '6Server',
-            u'basearch': 'x86_64',
         })
-        self.assertEqual(result.return_code, 0)
-        result = RepositorySet.disable({
+        RepositorySet.disable({
+            u'basearch': 'x86_64',
             u'name': REPOSET['rhva6'],
             u'organization': org['name'],
             u'product': PRDS['rhel'],
             u'releasever': '6Server',
-            u'basearch': 'x86_64',
         })
-        self.assertEqual(result.return_code, 0)
         result = RepositorySet.available_repositories({
             u'name': REPOSET['rhva6'],
             u'organization': org['name'],
             u'product': PRDS['rhel'],
         })
-        self.assertEqual(result.return_code, 0)
         enabled = [
             repo['enabled']
             for repo
-            in result.stdout
+            in result
             if repo['arch'] == 'x86_64' and repo['release'] == '6Server'
         ][0]
         self.assertEqual(enabled, 'false')
@@ -332,37 +307,33 @@ class TestRepositorySet(CLITestCase):
         org = make_org()
         manifest = manifests.clone()
         upload_file(manifest, remote_file=manifest)
-        result = Subscription.upload({
+        Subscription.upload({
             u'file': manifest,
             u'organization-id': org['id'],
         })
-        self.assertEqual(result.return_code, 0)
-        result = RepositorySet.enable({
+        RepositorySet.enable({
+            u'basearch': 'x86_64',
             u'name': REPOSET['rhva6'],
             u'organization-label': org['label'],
             u'product': PRDS['rhel'],
             u'releasever': '6Server',
-            u'basearch': 'x86_64',
         })
-        self.assertEqual(result.return_code, 0)
-        result = RepositorySet.disable({
+        RepositorySet.disable({
+            u'basearch': 'x86_64',
             u'name': REPOSET['rhva6'],
             u'organization-label': org['label'],
             u'product': PRDS['rhel'],
             u'releasever': '6Server',
-            u'basearch': 'x86_64',
         })
-        self.assertEqual(result.return_code, 0)
         result = RepositorySet.available_repositories({
             u'name': REPOSET['rhva6'],
             u'organization-label': org['label'],
             u'product': PRDS['rhel'],
         })
-        self.assertEqual(result.return_code, 0)
         enabled = [
             repo['enabled']
             for repo
-            in result.stdout
+            in result
             if repo['arch'] == 'x86_64' and repo['release'] == '6Server'
         ][0]
         self.assertEqual(enabled, 'false')
@@ -378,46 +349,42 @@ class TestRepositorySet(CLITestCase):
         org = make_org()
         manifest = manifests.clone()
         upload_file(manifest, remote_file=manifest)
-        result = Subscription.upload({
+        Subscription.upload({
             u'file': manifest,
             u'organization-id': org['id'],
         })
-        self.assertEqual(result.return_code, 0)
         product_id = Product.info({
             u'name': PRDS['rhel'],
             u'organization-id': org['id'],
-        }).stdout['id']
+        })['id']
         reposet_id = RepositorySet.info({
             u'name': REPOSET['rhva6'],
             u'organization-id': org['id'],
             u'product-id': product_id,
-        }).stdout['id']
-        result = RepositorySet.enable({
+        })['id']
+        RepositorySet.enable({
+            u'basearch': 'x86_64',
             u'id': reposet_id,
             u'organization-id': org['id'],
             u'product-id': product_id,
             u'releasever': '6Server',
-            u'basearch': 'x86_64',
         })
-        self.assertEqual(result.return_code, 0)
-        result = RepositorySet.disable({
+        RepositorySet.disable({
+            u'basearch': 'x86_64',
             u'id': reposet_id,
             u'organization-id': org['id'],
             u'product-id': product_id,
             u'releasever': '6Server',
-            u'basearch': 'x86_64',
         })
-        self.assertEqual(result.return_code, 0)
         result = RepositorySet.available_repositories({
             u'id': reposet_id,
             u'organization-id': org['id'],
             u'product-id': product_id,
         })
-        self.assertEqual(result.return_code, 0)
         enabled = [
             repo['enabled']
             for repo
-            in result.stdout
+            in result
             if repo['arch'] == 'x86_64' and repo['release'] == '6Server'
         ][0]
         self.assertEqual(enabled, 'false')

--- a/tests/foreman/cli/test_scparam.py
+++ b/tests/foreman/cli/test_scparam.py
@@ -29,8 +29,4 @@ class TestSmartClassParameter(CLITestCase):
         """
 
         self.run_puppet_module()
-        result = SmartClassParameter().list()
-        self.assertEqual(
-            result.return_code, 0, "Command should have succeeded")
-        self.assertEqual(
-            len(result.stderr), 0, "Should not have raised an error")
+        SmartClassParameter.list()

--- a/tests/foreman/cli/test_subnet.py
+++ b/tests/foreman/cli/test_subnet.py
@@ -6,11 +6,11 @@ import re
 
 from ddt import ddt
 from fauxfactory import gen_string, gen_integer, gen_ipaddr
+from robottelo.cli.base import CLIReturnCodeError
 from robottelo.cli.factory import make_domain, make_subnet, CLIFactoryError
 from robottelo.cli.subnet import Subnet
 from robottelo.constants import SUBNET_IPAM_TYPES
 from robottelo.decorators import (
-    bz_bug_is_open,
     data,
     run_only_on,
     skip_if_bug_open,
@@ -38,11 +38,7 @@ class TestSubnet(CLITestCase):
         @Assert: Subnet is created and has random name
 
         """
-        try:
-            subnet = make_subnet({'name': test_data})
-        except CLIFactoryError as err:
-            self.fail(err)
-
+        subnet = make_subnet({'name': test_data})
         self.assertEqual(subnet['name'], test_data)
 
     @data(
@@ -64,15 +60,12 @@ class TestSubnet(CLITestCase):
         network = gen_ipaddr()       # generate pool range from network address
         from_ip = re.sub('\d+$', str(pool[0]), network)
         to_ip = re.sub('\d+$', str(pool[1]), network)
-        try:
-            subnet = make_subnet({
-                u'mask': mask,
-                u'network': network,
-                u'from': from_ip,
-                u'to': to_ip,
-            })
-        except CLIFactoryError as err:
-            self.fail(err)
+        subnet = make_subnet({
+            u'from': from_ip,
+            u'mask': mask,
+            u'network': network,
+            u'to': to_ip,
+        })
         self.assertEqual(subnet['from'], from_ip)
         self.assertEqual(subnet['to'], to_ip)
 
@@ -84,11 +77,8 @@ class TestSubnet(CLITestCase):
         @Assert: Subnet is created and has new domain assigned
 
         """
-        try:
-            domain = make_domain()
-            subnet = make_subnet({'domain-ids': domain['id']})
-        except CLIFactoryError as err:
-            self.fail(err)
+        domain = make_domain()
+        subnet = make_subnet({'domain-ids': domain['id']})
         self.assertIn(domain['name'], subnet['domains'])
 
     def test_create_subnet_with_multiple_domains(self):
@@ -100,14 +90,11 @@ class TestSubnet(CLITestCase):
         @Assert: Subnet is created and has new domains assigned
 
         """
-        try:
-            domains_amount = random.randint(3, 5)
-            domains = [make_domain() for _ in range(domains_amount)]
-            subnet = make_subnet({
-                'domain-ids': [domain['id'] for domain in domains],
-            })
-        except CLIFactoryError as err:
-            self.fail(err)
+        domains_amount = random.randint(3, 5)
+        domains = [make_domain() for _ in range(domains_amount)]
+        subnet = make_subnet({
+            'domain-ids': [domain['id'] for domain in domains],
+        })
         self.assertEqual(len(subnet['domains']), domains_amount)
         for domain in domains:
             self.assertIn(domain['name'], subnet['domains'])
@@ -120,11 +107,8 @@ class TestSubnet(CLITestCase):
         @Assert: Subnet is created and has gateway assigned
 
         """
-        try:
-            gateway = gen_ipaddr(ip3=True)
-            subnet = make_subnet({'gateway': gateway})
-        except CLIFactoryError as err:
-            self.fail(err)
+        gateway = gen_ipaddr(ip3=True)
+        subnet = make_subnet({'gateway': gateway})
         self.assertIn(gateway, subnet['gateway'])
 
     @skip_if_bug_open('bugzilla', 1213437)
@@ -143,10 +127,7 @@ class TestSubnet(CLITestCase):
         @BZ: 1213437
 
         """
-        try:
-            subnet = make_subnet({'ipam': ipam_type})
-        except CLIFactoryError as err:
-            self.fail(err)
+        subnet = make_subnet({'ipam': ipam_type})
         self.assertIn(ipam_type, subnet['ipam'])
 
     @data(
@@ -155,7 +136,7 @@ class TestSubnet(CLITestCase):
         {u'network': ''},
         {u'mask': '256.0.0.0'},
         {u'mask': ''},
-        {u'mask': '255.0.255.0', u'bz-bug': 1136088}
+        {u'mask': '255.0.255.0'}
     )
     def test_negative_create_1(self, options):
         """@Test: Create subnet with invalid or missing required attributes
@@ -165,10 +146,6 @@ class TestSubnet(CLITestCase):
         @Assert: Subnet is not created
 
         """
-        bug_id = options.pop('bz-bug', None)
-        if bug_id is not None and bz_bug_is_open(bug_id):
-            self.skipTest('Bugzilla bug {0} is open.'.format(bug_id))
-
         with self.assertRaises(CLIFactoryError):
             make_subnet(options)
 
@@ -193,7 +170,6 @@ class TestSubnet(CLITestCase):
         # generate pool range from network address
         for key, val in pool.iteritems():
             opts[key] = re.sub('\d+$', str(val), network)
-
         with self.assertRaises(CLIFactoryError):
             make_subnet(opts)
 
@@ -205,20 +181,13 @@ class TestSubnet(CLITestCase):
         @Assert: Subnet is listed
 
         """
-
         # Fetch current total
-        result = Subnet.list()
-        total_subnet = len(result.stdout)
-
+        subnets_before = Subnet.list()
         # Make a new subnet
-        try:
-            make_subnet()
-        except CLIFactoryError as err:
-            self.fail(err)
-
+        make_subnet()
         # Fetch total again
-        result = Subnet.list()
-        self.assertGreater(len(result.stdout), total_subnet)
+        subnets_after = Subnet.list()
+        self.assertGreater(len(subnets_after), len(subnets_before))
 
     @data(
         gen_string(str_type='alpha'),
@@ -235,22 +204,13 @@ class TestSubnet(CLITestCase):
         @Assert: Subnet name is updated
 
         """
-        try:
-            new_subnet = make_subnet()
-        except CLIFactoryError as err:
-            self.fail(err)
-
+        new_subnet = make_subnet()
         # Update the name
-        result = Subnet.update({'id': new_subnet['id'], 'new-name': test_name})
-        self.assertEqual(result.return_code, 0)
-        self.assertEqual(len(result.stderr), 0)
-
+        Subnet.update({'id': new_subnet['id'], 'new-name': test_name})
         # Fetch it again
         result = Subnet.info({'id': new_subnet['id']})
-        self.assertEqual(result.return_code, 0)
-        self.assertEqual(len(result.stderr), 0)
-        self.assertEqual(result.stdout['name'], test_name)
-        self.assertNotEqual(result.stdout['name'], new_subnet['name'])
+        self.assertEqual(result['name'], test_name)
+        self.assertNotEqual(result['name'], new_subnet['name'])
 
     def test_positive_update_2(self):
         """@Test: Check if Subnet network and mask can be updated
@@ -260,29 +220,23 @@ class TestSubnet(CLITestCase):
         @Assert: Subnet network and mask are updated
 
         """
-
         network = gen_ipaddr()
         mask = '255.255.255.0'
-        try:
-            subnet = make_subnet({
-                u'network': network,
-                u'mask': mask,
-            })
-        except CLIFactoryError as err:
-            self.fail(err)
+        subnet = make_subnet({
+            u'mask': mask,
+            u'network': network,
+        })
         new_network = gen_ipaddr()
         new_mask = '255.255.192.0'
-        result = Subnet.update({
+        Subnet.update({
             u'id': subnet['id'],
-            u'network': new_network,
             u'mask': new_mask,
+            u'network': new_network,
         })
-        self.assertEqual(result.return_code, 0)
-
         # check - subnet is updated
-        result = Subnet.info({u'id': subnet['id']})
-        self.assertEqual(result.stdout['network'], new_network)
-        self.assertEqual(result.stdout['mask'], new_mask)
+        subnet = Subnet.info({u'id': subnet['id']})
+        self.assertEqual(subnet['network'], new_network)
+        self.assertEqual(subnet['mask'], new_mask)
 
     @data(
         [gen_integer(min_value=1, max_value=255),
@@ -299,26 +253,19 @@ class TestSubnet(CLITestCase):
 
         """
         pool.sort()
-        try:
-            subnet = make_subnet({u'mask': '255.255.255.0'})
-        except CLIFactoryError as err:
-            self.fail(err)
+        subnet = make_subnet({u'mask': '255.255.255.0'})
         # generate pool range from network address
         ip_from = re.sub('\d+$', str(pool[0]), subnet['network'])
         ip_to = re.sub('\d+$', str(pool[1]), subnet['network'])
-        result = Subnet.update({
-            u'id': subnet['id'],
+        Subnet.update({
             u'from': ip_from,
+            u'id': subnet['id'],
             u'to': ip_to,
         })
-        self.assertEqual(result.return_code, 0)
-        self.assertEqual(len(result.stderr), 0)
-
         # check - subnet is updated
-        result = Subnet.info({u'id': subnet['id']})
-        self.assertEqual(result.return_code, 0)
-        self.assertEqual(result.stdout['from'], ip_from)
-        self.assertEqual(result.stdout['to'], ip_to)
+        subnet = Subnet.info({u'id': subnet['id']})
+        self.assertEqual(subnet['from'], ip_from)
+        self.assertEqual(subnet['to'], ip_to)
 
     @data(
         {u'name': ''},
@@ -326,7 +273,7 @@ class TestSubnet(CLITestCase):
         {u'network': ''},
         {u'mask': '256.0.0.0'},
         {u'mask': ''},
-        {u'mask': '255.0.255.0', u'bz-bug': 1136088}
+        {u'mask': '255.0.255.0'}
     )
     def test_negative_update_1(self, options):
         """@Test: Update subnet with invalid or missing required attributes
@@ -336,24 +283,14 @@ class TestSubnet(CLITestCase):
         @Assert: Subnet is not updated
 
         """
-
-        bug_id = options.pop('bz-bug', None)
-        if bug_id is not None and bz_bug_is_open(bug_id):
-            self.skipTest('Bugzilla bug {0} is open.'.format(bug_id))
-
-        try:
-            subnet = make_subnet()
-        except CLIFactoryError as err:
-            self.fail(err)
+        subnet = make_subnet()
         options['id'] = subnet['id']
-        result = Subnet.update(options)
-        self.assertNotEqual(result.return_code, 0)
-        self.assertNotEqual(len(result.stderr), 0)
-
+        with self.assertRaises(CLIReturnCodeError):
+            Subnet.update(options)
         # check - subnet is not updated
         result = Subnet.info({u'id': subnet['id']})
         for key in options.keys():
-            self.assertEqual(subnet[key], result.stdout[key])
+            self.assertEqual(subnet[key], result[key])
 
     @data(
         {u'from': gen_integer(min_value=1, max_value=255)},
@@ -370,22 +307,17 @@ class TestSubnet(CLITestCase):
         @Assert: Subnet is not updated
 
         """
-        try:
-            subnet = make_subnet()
-        except CLIFactoryError as err:
-            self.fail(err)
-
+        subnet = make_subnet()
         opts = {u'id': subnet['id']}
         # generate pool range from network address
         for key, val in options.iteritems():
             opts[key] = re.sub('\d+$', str(val), subnet['network'])
-        result = Subnet.update(opts)
-        self.assertNotEqual(result.return_code, 0)
-
+        with self.assertRaises(CLIReturnCodeError):
+            Subnet.update(opts)
         # check - subnet is not updated
         result = Subnet.info({u'id': subnet['id']})
         for key in options.keys():
-            self.assertEqual(result.stdout[key], subnet[key])
+            self.assertEqual(result[key], subnet[key])
 
     @data(
         gen_string(str_type='alpha'),
@@ -402,17 +334,9 @@ class TestSubnet(CLITestCase):
         @Assert: Subnet is deleted
 
         """
-        try:
-            subnet = make_subnet({'name': test_name})
-        except CLIFactoryError as err:
-            self.fail(err)
-
+        subnet = make_subnet({'name': test_name})
         # Delete it
-        result = Subnet.delete({'id': subnet['id']})
-        self.assertEqual(result.return_code, 0)
-        self.assertEqual(len(result.stderr), 0)
-
+        Subnet.delete({'id': subnet['id']})
         # Fetch it again
-        result = Subnet.info({'id': subnet['id']})
-        self.assertGreater(result.return_code, 0)
-        self.assertGreater(len(result.stderr), 0)
+        with self.assertRaises(CLIReturnCodeError):
+            Subnet.info({'id': subnet['id']})

--- a/tests/foreman/longrun/test_inc_updates.py
+++ b/tests/foreman/longrun/test_inc_updates.py
@@ -289,13 +289,11 @@ class TestIncrementalUpdate(TestCase):
         self.assertGreater(len(errata_list), 0)
 
         # Apply incremental update using the first applicable errata
-        result = ContentViewCLI.version_incremental_update({
+        ContentViewCLI.version_incremental_update({
             u'content-view-version-id': cv_versions[-1].id,
+            u'environment-ids': self.qe_lce.id,
             u'errata-ids': errata_list[0].id,
-            u'environment-ids': self.qe_lce.id
         })
-
-        self.assertEqual(result.return_code, 0)
 
         # Re-read the content view to get the latest versions
         self.rhel_6_partial_cv = self.rhel_6_partial_cv.read()

--- a/tests/foreman/performance/test_candlepin_concurrent_subscription_ak.py
+++ b/tests/foreman/performance/test_candlepin_concurrent_subscription_ak.py
@@ -1,5 +1,6 @@
 """Test class for concurrent subscription by Activation Key"""
 from robottelo.cli.activationkey import ActivationKey
+from robottelo.cli.base import CLIReturnCodeError
 from robottelo.cli.factory import (make_activation_key)
 from robottelo.performance.constants import (
     ACTIVATION_KEY,
@@ -63,27 +64,27 @@ class ConcurrentSubActivationKeyTestCase(ConcurrentTestCase):
             'name': self.ak_name
         })
 
-        # output activation key informatin
+        # output activation key information
         self.logger.info('Retrieve activation keys info list:')
-        result = ActivationKey.list(
-            {'organization-id': self.org_id},
-            per_page=False
-        )
-
-        if result.return_code != 0:
+        try:
+            result = ActivationKey.list(
+                {'organization-id': self.org_id},
+                per_page=False
+            )
+        except CLIReturnCodeError:
             self.logger.error('Fail to make new activation key!')
             return
-        return result.stdout[0]['id'], result.stdout[0]['name']
+        return result[0]['id'], result[0]['name']
 
     def _add_ak_to_subscription(self, ak_id, sub_id):
         """Add activation key to subscription"""
-        result = ActivationKey.add_subscription({
-            'id': ak_id,
-            'subscription-id': sub_id,
-            'quantity': self.add_ak_subscription_qty
-        })
-
-        if result.return_code != 0:
+        try:
+            ActivationKey.add_subscription({
+                'id': ak_id,
+                'quantity': self.add_ak_subscription_qty,
+                'subscription-id': sub_id,
+            })
+        except CLIReturnCodeError:
             self.logger.error('Fail to add activation-key to subscription')
             return
         self.logger.info('Subscription added to this activation key.')

--- a/tests/robottelo/test_cli.py
+++ b/tests/robottelo/test_cli.py
@@ -2,7 +2,6 @@ import unittest2
 
 from robottelo.cli.base import Base
 from robottelo.config import conf
-from robottelo.ssh import SSHCommandResult
 
 
 class CLIClass(Base):
@@ -69,23 +68,3 @@ class BaseCliTestCase(unittest2.TestCase):
         self.assertEqual(new_class.foreman_admin_username, 'auser')
         self.assertEqual(new_class.foreman_admin_password, 'apass')
         self.assertIn(Base, new_class.__bases__)
-
-    def test_remove_task_status(self):
-        """Check if ``_remove_task_status`` method cleans the expected task
-        status messages.
-
-        """
-        data = (
-            u'Task 3af6fec3-2b7d-4e8a-93a4-082509e203fc running: 0.005/1, 0%, '
-            '0.0/s, elapsed: 00:00:02, ETA: 00:07:34\nTask '
-            '3af6fec3-2b7d-4e8a-93a4-082509e203fc success: 1.0/1, 100%, '
-            '0.1/s, elapsed: 00:00:11\nTask '
-            '3af6fec3-2b7d-4e8a-93a4-082509e203fc success: 1.0/1, 100%, '
-            '0.1/s, elapsed: 00:00:11\nTask '
-            '6ba9d82a-ea55-4934-8aab-0e057102ee11 running: 0.005/1, 0%, '
-            '0.0/s, elapsed: 00:00:02, ETA: 00:06:55\nTask '
-            '6ba9d82a-ea55-4934-8aab-0e057102ee11 running: 0.005/1, 0%, '
-            '0.0/s, elapsed: 00:00:02, ETA: 00:06:55\n\n'
-        )
-        result = SSHCommandResult(stderr=data, return_code=0)
-        self.assertEqual(Base._remove_task_status(result).stderr, '')


### PR DESCRIPTION
Closes #2776
Please, check #2776 for more details.

Commit summary:
* Added new exception - `CLIReturnCodeError` which contains return_code, stderr and msg (message).
* Created `Base._handle_response()` func which checks `return_code` and raises `CLIReturnCodeError` if needed. Returns `stdout`.
* Injected `Base._handle_response()` in `Base.execute()` (that's the easiest place to inject, no existing commands won't be affected and nothing should be rewritten)
* By default, all CLI commands running with `Base.execute()` will be wrapped by `Base._handle_response()`, if raw response is needed, `Base.execute()` now accepts optional parameter `return_raw_response`.
* Removed `Base._remove_task_status()` in favour of `Base._handle_response()` `ignore_stderr` argument.
* Updated all the CLI tests, removed `return_code` and `stderr` verification
* Some minor tests updates like update of indentation, variable names, typos, removing of single-use variables, sorting argument alphabetically etc.


Starting from now, there's no need to check for `return_code`, `stderr` and grab `stdout` when executing CLI commands, robottelo will do that for you:
```python
# Before
result = ContentView.info({'id': 123})
self.assertEqual(result.return_code, 0, "Failed to fetch object")
self.assertEqual(len(result.stderr), 0,
    "There should not be an exception here")
content_view = result.stdout

# Now
content_view = ContentView.info({'id': 123})
```
For negative tests, when non-zero `return_code` is expected, catch `CLICommandExecutionError` exception:
```python
# Before
result = ContentView.info({'id': 123})
self.assertNotEqual(result.return_code, 0, "Expected an error here")

# Now
with self.assertRaises(CLICommandExecutionError):
    result = ContentView.info({'id': 123})
```
If `return_code` or contains of `stderr` is needed, both are included in `CLICommandExecutionError`:
```python
# Before
result = ContentView.info({'id': 123})
self.assertEqual(result.return_code, 1, "Expected return_code 1 here")
self.assertGreater(len(result.sdterr), 0, "Expected errors in stderr")

# Now
with self.assertRaises(CLICommandExecutionError) as e:
    ContentView.info({'id': 123})
self.assertEqual(e.exception.return_code, 1)
self.assertGreater(len(e.exception.stderr), 0)
```