### PR TITLE
Fix for pylint errors in cli tests

### DIFF
--- a/tests/foreman/cli/test_abrt.py
+++ b/tests/foreman/cli/test_abrt.py
@@ -1,3 +1,4 @@
+"""Test for abrt report"""
 from robottelo.test import CLITestCase
 
 

--- a/tests/foreman/cli/test_activationkey.py
+++ b/tests/foreman/cli/test_activationkey.py
@@ -1,6 +1,6 @@
 # -*- encoding: utf-8 -*-
 # pylint: disable=too-many-public-methods, too-many-lines
-# pylint: disable=unexpected-keyword-arg
+# pylint: disable=unexpected-keyword-arg, invalid-name
 """Test class for Activation key CLI"""
 
 from fauxfactory import gen_string
@@ -1188,14 +1188,14 @@ class TestActivationKey(CLITestCase):
             {u'organization-id': self.org['id']},
             cached=True,
         )['name']
-        with self.assertRaises(CLIReturnCodeError) as e:
+        with self.assertRaises(CLIReturnCodeError) as exe:
             ActivationKey.copy({
                 u'name': parent_name,
                 u'new-name': parent_name,
                 u'organization-id': self.org['id'],
             })
-        self.assertEqual(e.exception.return_code, 65)
-        self.assertIn(u'Name has already been taken', e.exception.stderr)
+        self.assertEqual(exe.exception.return_code, 65)
+        self.assertIn(u'Name has already been taken', exe.exception.stderr)
 
     def test_positive_copy_subscription(self):
         """@Test: Copy Activation key and verify contents
@@ -1325,14 +1325,14 @@ class TestActivationKey(CLITestCase):
             {u'organization-id': org_id},
             cached=True,
         )['id']
-        with self.assertRaises(CLIReturnCodeError) as e:
+        with self.assertRaises(CLIReturnCodeError) as exe:
             ActivationKey.update({
                 u'auto-attach': gen_string('utf8'),
                 u'id': key_id,
                 u'organization-id': org_id,
             })
         self.assertIn(
-            u"'--auto-attach': value must be one of", e.exception.stderr)
+            u"'--auto-attach': value must be one of", exe.exception.stderr)
 
     def test_positive_content_override(self):
         """@Test: Positive content override

--- a/tests/foreman/cli/test_capsule.py
+++ b/tests/foreman/cli/test_capsule.py
@@ -1,4 +1,5 @@
 # -*- encoding: utf-8 -*-
+# pylint: disable=invalid-name
 """Test class for the capsule CLI."""
 from robottelo.test import CLITestCase
 

--- a/tests/foreman/cli/test_capsule_installer.py
+++ b/tests/foreman/cli/test_capsule_installer.py
@@ -1,10 +1,11 @@
 # -*- encoding: utf-8 -*-
-"""Test class for capsule installer CLI"""
+# pylint: disable=invalid-name
+"""Test for capsule installer CLI"""
 from robottelo.test import CLITestCase
 
 
 class TestCapsuleInstaller(CLITestCase):
-
+    """Test class for capsule installer CLI"""
     def capsule_installer_basic_test(self):
         """@Test: perform a basic install of capsule.
 

--- a/tests/foreman/cli/test_computeresource.py
+++ b/tests/foreman/cli/test_computeresource.py
@@ -98,6 +98,7 @@ LIBVIRT_URL = 'qemu+tcp://{0}:16509/system'.format(
 class TestComputeResource(CLITestCase):
     """ComputeResource CLI tests."""
 
+    # pylint: disable=no-self-use
     def test_create(self):
         """@Test: Create Compute Resource
 

--- a/tests/foreman/cli/test_discovery.py
+++ b/tests/foreman/cli/test_discovery.py
@@ -1,4 +1,5 @@
 # -*- encoding: utf-8 -*-
+# pylint: disable=invalid-name
 """Test class for CLI Foreman Discovery"""
 from robottelo.decorators import stubbed
 from robottelo.test import CLITestCase

--- a/tests/foreman/cli/test_docker.py
+++ b/tests/foreman/cli/test_docker.py
@@ -1,3 +1,5 @@
+# pylint: disable=too-many-public-methods, too-many-lines
+# pylint: disable=invalid-name, attribute-defined-outside-init
 """Unit tests for the Docker feature."""
 from fauxfactory import gen_alpha, gen_choice, gen_string, gen_url
 from nailgun import entities
@@ -27,7 +29,6 @@ from robottelo.helpers import (
     valid_data_list,
 )
 from robottelo.test import CLITestCase
-# (too-many-public-methods) pylint:disable=R0904
 
 EXTERNAL_DOCKER_URL = get_external_docker_url()
 INTERNAL_DOCKER_URL = get_internal_docker_url()

--- a/tests/foreman/cli/test_domain.py
+++ b/tests/foreman/cli/test_domain.py
@@ -1,4 +1,5 @@
 # -*- encoding: utf-8 -*-
+# pylint: disable=invalid-name
 """Test class for Domain  CLI"""
 
 from fauxfactory import gen_string

--- a/tests/foreman/cli/test_environment.py
+++ b/tests/foreman/cli/test_environment.py
@@ -1,5 +1,6 @@
 # -*- encoding: utf-8 -*-
-"""Test class for Environment  CLI"""
+# pylint: disable=invalid-name
+"""Test for Environment  CLI"""
 
 from fauxfactory import gen_string
 from robottelo.cli.base import CLIReturnCodeError
@@ -12,7 +13,7 @@ from robottelo.test import MetaCLITestCase
 
 @run_only_on('sat')
 class TestEnvironment(MetaCLITestCase):
-
+    """Test class for Environment CLI"""
     factory = make_environment
     factory_obj = Environment
 

--- a/tests/foreman/cli/test_errata.py
+++ b/tests/foreman/cli/test_errata.py
@@ -1,3 +1,4 @@
+# pylint: disable=too-many-public-methods
 """CLI Tests for the errata management feature"""
 
 # For ease of use hc refers to host-collection throughout this document

--- a/tests/foreman/cli/test_globalparam.py
+++ b/tests/foreman/cli/test_globalparam.py
@@ -11,6 +11,7 @@ from robottelo.test import CLITestCase
 class TestGlobalParameter(CLITestCase):
     """GlobalParameter related CLI tests."""
 
+    # pylint: disable=no-self-use
     def test_set(self):
         """@Test: Check if Global Param can be set
 

--- a/tests/foreman/cli/test_hammer.py
+++ b/tests/foreman/cli/test_hammer.py
@@ -18,6 +18,7 @@ class HammerCommandsTestCase(CLITestCase):
         super(HammerCommandsTestCase, self).__init__(*args, **kwargs)
         self.differences = {}
 
+    # pylint: disable=no-self-use
     def _fetch_command_info(self, command):
         """Fetch command info from expected commands info dictionary."""
         info = HAMMER_COMMANDS

--- a/tests/foreman/cli/test_host_collection.py
+++ b/tests/foreman/cli/test_host_collection.py
@@ -1,4 +1,5 @@
 # -*- encoding: utf-8 -*-
+# pylint: disable=invalid-name
 """Test class for Host Collection CLI"""
 
 from ddt import ddt
@@ -26,6 +27,7 @@ class TestHostCollection(CLITestCase):
     library = None
     default_cv = None
 
+    # pylint: disable=unexpected-keyword-arg
     def setUp(self):
         """Tests for Host Collections via Hammer CLI"""
         super(TestHostCollection, self).setUp()

--- a/tests/foreman/cli/test_host_system_unification.py
+++ b/tests/foreman/cli/test_host_system_unification.py
@@ -1,5 +1,6 @@
 # -*- encoding: utf-8 -*-
-"""Test class for Host/System Unification"""
+# pylint: disable=invalid-name
+"""Test for Host/System Unification"""
 
 from robottelo.decorators import run_only_on, stubbed
 from robottelo.test import CLITestCase
@@ -7,6 +8,7 @@ from robottelo.test import CLITestCase
 
 @run_only_on('sat')
 class TestHostSystemUnificationCLI(CLITestCase):
+    """Test Class for Host/System Unification CLI"""
     # Testing notes for host/system unification in katello/foreman:
     # Basically assuring that hosts in foreman/katello bits are joined
     # and information can be associated across both parts of product.
@@ -37,7 +39,7 @@ class TestHostSystemUnificationCLI(CLITestCase):
         pass
 
     @stubbed()
-    def all_hosts_appear_in_katello(self):
+    def test_all_hosts_appear_in_katello(self):
         """@test: Hosts provisioned in foreman via appear in katello
 
         @feature: Host/System Unification

--- a/tests/foreman/cli/test_hostgroup.py
+++ b/tests/foreman/cli/test_hostgroup.py
@@ -1,4 +1,5 @@
 # -*- encoding: utf-8 -*-
+# pylint: disable=invalid-name
 """Test class for :class:`robottelo.cli.hostgroup.HostGroup` CLI."""
 
 from fauxfactory import gen_string
@@ -17,7 +18,7 @@ from robottelo.test import MetaCLITestCase
 
 @run_only_on('sat')
 class TestHostGroup(MetaCLITestCase):
-
+    """Test class for Host Group CLI"""
     factory = make_hostgroup
     factory_obj = HostGroup
 

--- a/tests/foreman/cli/test_installer.py
+++ b/tests/foreman/cli/test_installer.py
@@ -1,11 +1,13 @@
 # -*- encoding: utf-8 -*-
+# pylint: disable=invalid-name
+"""Tests for Installer"""
 from robottelo.decorators import run_only_on, stubbed
 from robottelo.test import CLITestCase
 
 
 @run_only_on('sat')
 class TestSSOCLI(CLITestCase):
-
+    """Test class for installer"""
     # Notes for installer testing:
     # Perhaps there is a convenient log analyzer library out there
     # that can parse logs? It would be better (and possibly less

--- a/tests/foreman/cli/test_lifecycleenvironment.py
+++ b/tests/foreman/cli/test_lifecycleenvironment.py
@@ -1,4 +1,5 @@
 # -*- encoding: utf-8 -*-
+# pylint: disable=invalid-name
 """Test class for Host CLI"""
 
 from ddt import ddt

--- a/tests/foreman/cli/test_location.py
+++ b/tests/foreman/cli/test_location.py
@@ -1,4 +1,5 @@
 # -*- encoding: utf-8 -*-
+# pylint: disable=too-many-public-methods, invalid-name
 """Test class for Location CLI"""
 
 from ddt import ddt

--- a/tests/foreman/cli/test_medium.py
+++ b/tests/foreman/cli/test_medium.py
@@ -1,5 +1,6 @@
 # -*- encoding: utf-8 -*-
-"""Test class for Medium  CLI"""
+# pylint: disable=invalid-name
+"""Test for Medium  CLI"""
 
 from ddt import ddt
 from fauxfactory import gen_string, gen_alphanumeric
@@ -24,7 +25,7 @@ OSES = [
 @run_only_on('sat')
 @ddt
 class TestMedium(CLITestCase):
-
+    """Test class for Medium CLI"""
     @data({'name': gen_string("latin1")},
           {'name': gen_string("utf8")},
           {'name': gen_string("alpha")},
@@ -85,6 +86,7 @@ class TestMedium(CLITestCase):
         with self.assertRaises(CLIReturnCodeError):
             Medium.info({'id': medium['id']})
 
+    # pylint: disable=no-self-use
     def test_add_operatingsystem_medium(self):
         """@Test: Check if Medium can be associated with operating system
 

--- a/tests/foreman/cli/test_model.py
+++ b/tests/foreman/cli/test_model.py
@@ -1,5 +1,5 @@
 # -*- encoding: utf-8 -*-
-"""Test class for Model CLI"""
+"""Test for Model CLI"""
 
 from fauxfactory import gen_string
 from robottelo.cli.model import Model
@@ -10,10 +10,11 @@ from robottelo.test import MetaCLITestCase
 
 @run_only_on('sat')
 class TestModel(MetaCLITestCase):
-
+    """Test class for Model CLI"""
     factory = make_model
     factory_obj = Model
 
+    # pylint: disable=no-self-use
     def test_create_model_1(self):
         """@Test: Check if Model can be created
 
@@ -44,8 +45,8 @@ class TestModel(MetaCLITestCase):
         @Assert: Model is updated
 
         """
-
         name = gen_string('alpha')
+        # pylint: disable=too-many-function-args
         model = self.factory({'name': name})
         self.assertEqual(name, model['name'])
         new_name = gen_string('alpha')

--- a/tests/foreman/cli/test_myaccount.py
+++ b/tests/foreman/cli/test_myaccount.py
@@ -1,4 +1,5 @@
 # -*- encoding: utf-8 -*-
+# pylint: disable=invalid-name
 """Test class for Users CLI"""
 
 from robottelo.decorators import stubbed

--- a/tests/foreman/cli/test_org.py
+++ b/tests/foreman/cli/test_org.py
@@ -1,5 +1,5 @@
 # -*- encoding: utf-8 -*-
-# pylint: disable=too-many-public-methods, too-many-lines
+# pylint: disable=too-many-public-methods, too-many-lines, no-self-use
 """Test class for Organization CLI"""
 import random
 

--- a/tests/foreman/cli/test_os.py
+++ b/tests/foreman/cli/test_os.py
@@ -1,4 +1,5 @@
 # -*- encoding: utf-8 -*-
+# pylint: disable=invalid-name
 """Test class for Operating System CLI"""
 from ddt import ddt
 from fauxfactory import gen_string

--- a/tests/foreman/cli/test_partitiontable.py
+++ b/tests/foreman/cli/test_partitiontable.py
@@ -1,4 +1,5 @@
 # -*- encoding: utf-8 -*-
+# pylint: disable=invalid-name
 """Test class for Partition table CLI"""
 from fauxfactory import gen_string, gen_alphanumeric
 from robottelo.cli.factory import make_os, make_partition_table
@@ -79,6 +80,7 @@ class TestPartitionTableDelete(CLITestCase):
         PartitionTable().delete({'id': ptable['id']})
         self.assertFalse(PartitionTable().exists(search=('name', name)))
 
+    # pylint: disable=no-self-use
     def test_addoperatingsystem_ptable(self):
         """@Test: Check if Partition Table can be associated
                   with operating system
@@ -96,7 +98,7 @@ class TestPartitionTableDelete(CLITestCase):
             'operatingsystem-id': os_list[0]['id']
         })
 
-    def test_removeoperatingsystem_ptable(self):
+    def test_remove_os_ptable(self):
         """@Test: Check if associated operating system can be removed
 
         @Feature: Partition Table - Add operating system

--- a/tests/foreman/cli/test_ping.py
+++ b/tests/foreman/cli/test_ping.py
@@ -1,3 +1,4 @@
+"""Test Class for hammer ping"""
 from itertools import izip
 from robottelo import ssh
 from robottelo.config import conf

--- a/tests/foreman/cli/test_product.py
+++ b/tests/foreman/cli/test_product.py
@@ -25,6 +25,7 @@ class TestProduct(CLITestCase):
 
     org = None
 
+    # pylint: disable=unexpected-keyword-arg
     def setUp(self):
         """Tests for Lifecycle Environment via Hammer CLI"""
 
@@ -420,7 +421,7 @@ class TestProduct(CLITestCase):
         })
         self.assertEqual(len(product['sync-plan-id']), 0)
 
-    def test_product_synchronize_by_id(self):
+    def test_product_sync_by_id(self):
         """@Test: Check if product can be synchronized.
         Searches for product and organization by their IDs
 
@@ -442,7 +443,7 @@ class TestProduct(CLITestCase):
         })
         self.assertEqual(u'Syncing Complete.', product['sync-state'])
 
-    def test_product_synchronize_by_name(self):
+    def test_product_sync_by_name(self):
         """@Test: Check if product can be synchronized.
         Searches for product and organization by their Names
 
@@ -464,7 +465,7 @@ class TestProduct(CLITestCase):
         })
         self.assertEqual(u'Syncing Complete.', product['sync-state'])
 
-    def test_product_synchronize_by_label(self):
+    def test_product_sync_by_label(self):
         """@Test: Check if product can be synchronized.
         Searches for organization by its label
 

--- a/tests/foreman/cli/test_proxy.py
+++ b/tests/foreman/cli/test_proxy.py
@@ -1,4 +1,5 @@
 # -*- encoding: utf-8 -*-
+# pylint: disable=no-self-use, invalid-name
 """proxy class for Smart proxy CLI"""
 
 import random
@@ -15,6 +16,7 @@ from robottelo.test import CLITestCase
 @run_only_on('sat')
 @ddt
 class TestProxy(CLITestCase):
+    """Proxy cli tests"""
 
     def setUp(self):
         """Skipping tests until we can create ssh tunnels"""
@@ -106,7 +108,7 @@ class TestProxy(CLITestCase):
         proxy = Proxy.info({u'id': proxy['id']})
         self.assertEqual(proxy['name'], test_data['update'])
 
-    def test_proxy_refresh_features_by_id(self):
+    def test_refresh_refresh_features_by_id(self):
         """@Test: Refresh smart proxy features, search for proxy by id
 
         @Feature: Smart Proxy

--- a/tests/foreman/cli/test_report.py
+++ b/tests/foreman/cli/test_report.py
@@ -1,4 +1,5 @@
 # -*- encoding: utf-8 -*-
+# pylint: disable=no-self-use
 """Test class for Reports CLI."""
 
 import random

--- a/tests/foreman/cli/test_repository.py
+++ b/tests/foreman/cli/test_repository.py
@@ -1,4 +1,5 @@
 # -*- encoding: utf-8 -*-
+# pylint: disable=too-many-public-methods, invalid-name
 """Test class for Repository CLI"""
 
 from ddt import ddt
@@ -44,6 +45,7 @@ class TestRepository(CLITestCase):
     org = None
     product = None
 
+    # pylint: disable=unexpected-keyword-arg
     def setUp(self):
         """Tests for Repository via Hammer CLI"""
 

--- a/tests/foreman/cli/test_repository_set.py
+++ b/tests/foreman/cli/test_repository_set.py
@@ -1,3 +1,5 @@
+# pylint: disable=invalid-name
+"""Tests for cli repository set"""
 from robottelo.cli.factory import make_org
 from robottelo.cli.product import Product
 from robottelo.cli.repository_set import RepositorySet

--- a/tests/foreman/cli/test_roles.py
+++ b/tests/foreman/cli/test_roles.py
@@ -1,5 +1,5 @@
 # -*- encoding: utf-8 -*-
-"""Test class for Roles CLI"""
+"""Test for Roles CLI"""
 from ddt import ddt
 from fauxfactory import gen_string
 from robottelo.cli.base import CLIReturnCodeError
@@ -12,6 +12,7 @@ from robottelo.test import CLITestCase
 
 @ddt
 class TestRole(CLITestCase):
+    """Test class for Roles CLI"""
 
     @skip_if_bug_open('bugzilla', 1138553)
     @data(

--- a/tests/foreman/cli/test_scparam.py
+++ b/tests/foreman/cli/test_scparam.py
@@ -7,16 +7,16 @@ from robottelo.decorators import run_only_on
 from robottelo.test import CLITestCase
 
 
+# pylint: disable=no-self-use
 @run_only_on('sat')
 class TestSmartClassParameter(CLITestCase):
     """Test class for Smart Class Parameter CLI."""
 
     def run_puppet_module(self):
-        """Import some parameterized puppet class. This is required to make sure
-        that we have smart class variable available.
+        """Import some parameterized puppet class. This is required to make
+        sure that we have smart class variable available.
 
         """
-
         ssh.command('puppet module install --force puppetlabs/ntp')
 
     def test_bugzilla_1047794(self):
@@ -27,6 +27,5 @@ class TestSmartClassParameter(CLITestCase):
         @Assert: SmartClass Paramter Info does not generate an error
 
         """
-
         self.run_puppet_module()
         SmartClassParameter.list()

--- a/tests/foreman/cli/test_sso.py
+++ b/tests/foreman/cli/test_sso.py
@@ -6,6 +6,7 @@ from robottelo.test import CLITestCase
 
 
 class TestSSOCLI(CLITestCase):
+    """Test Class for SSO CLI"""
 
     # Notes for SSO testing:
     # Of interest... In some testcases I've placed a few comments prefaced with

--- a/tests/foreman/cli/test_subnet.py
+++ b/tests/foreman/cli/test_subnet.py
@@ -57,9 +57,9 @@ class TestSubnet(CLITestCase):
         """
         pool.sort()
         mask = '255.255.255.0'
-        network = gen_ipaddr()       # generate pool range from network address
-        from_ip = re.sub('\d+$', str(pool[0]), network)
-        to_ip = re.sub('\d+$', str(pool[1]), network)
+        network = gen_ipaddr()  # generate pool range from network address
+        from_ip = re.sub(r'\d+$', str(pool[0]), network)
+        to_ip = re.sub(r'\d+$', str(pool[1]), network)
         subnet = make_subnet({
             u'from': from_ip,
             u'mask': mask,
@@ -81,7 +81,7 @@ class TestSubnet(CLITestCase):
         subnet = make_subnet({'domain-ids': domain['id']})
         self.assertIn(domain['name'], subnet['domains'])
 
-    def test_create_subnet_with_multiple_domains(self):
+    def test_create_subnet_with_domains(self):
         """@Test: Check if subnet with different amount of domains can be
         created in the system
 
@@ -169,7 +169,7 @@ class TestSubnet(CLITestCase):
         opts = {u'mask': mask, u'network': network}
         # generate pool range from network address
         for key, val in pool.iteritems():
-            opts[key] = re.sub('\d+$', str(val), network)
+            opts[key] = re.sub(r'\d+$', str(val), network)
         with self.assertRaises(CLIFactoryError):
             make_subnet(opts)
 
@@ -255,8 +255,8 @@ class TestSubnet(CLITestCase):
         pool.sort()
         subnet = make_subnet({u'mask': '255.255.255.0'})
         # generate pool range from network address
-        ip_from = re.sub('\d+$', str(pool[0]), subnet['network'])
-        ip_to = re.sub('\d+$', str(pool[1]), subnet['network'])
+        ip_from = re.sub(r'\d+$', str(pool[0]), subnet['network'])
+        ip_to = re.sub(r'\d+$', str(pool[1]), subnet['network'])
         Subnet.update({
             u'from': ip_from,
             u'id': subnet['id'],
@@ -311,7 +311,7 @@ class TestSubnet(CLITestCase):
         opts = {u'id': subnet['id']}
         # generate pool range from network address
         for key, val in options.iteritems():
-            opts[key] = re.sub('\d+$', str(val), subnet['network'])
+            opts[key] = re.sub(r'\d+$', str(val), subnet['network'])
         with self.assertRaises(CLIReturnCodeError):
             Subnet.update(opts)
         # check - subnet is not updated

--- a/tests/foreman/cli/test_subscription.py
+++ b/tests/foreman/cli/test_subscription.py
@@ -21,6 +21,7 @@ class TestSubscription(CLITestCase):
         self.org = make_org()
         self.manifest = manifests.clone()
 
+    # pylint: disable=no-self-use
     def _upload_manifest(self, manifest, org_id):
         """Uploads a manifest file and import it into an organization"""
         upload_file(manifest, remote_file=manifest)
@@ -64,7 +65,7 @@ class TestSubscription(CLITestCase):
             per_page=False,
         )
 
-    def test_enable_manifest_repository_set(self):
+    def test_enable_manifest_reposet(self):
         """@Test: enable repository set (positive)
 
         @Feature: Subscriptions/Repository Sets

--- a/tests/foreman/cli/test_syncplan.py
+++ b/tests/foreman/cli/test_syncplan.py
@@ -1,4 +1,5 @@
 # -*- encoding: utf-8 -*-
+# pylint: disable=invalid-name
 """Test class for Product CLI"""
 
 from datetime import datetime, timedelta
@@ -17,6 +18,7 @@ class TestSyncPlan(CLITestCase):
 
     org = None
 
+    # pylint: disable=unexpected-keyword-arg
     def setUp(self):
         """Tests for Sync Plans via Hammer CLI"""
 

--- a/tests/foreman/cli/test_system_registration.py
+++ b/tests/foreman/cli/test_system_registration.py
@@ -1,3 +1,4 @@
+# pylint: disable=invalid-name
 """Test module for System Registration CLI"""
 from robottelo.decorators import stubbed
 from robottelo.test import CLITestCase
@@ -22,7 +23,7 @@ class SystemRegistrationTestCase(CLITestCase):
         """
 
     @stubbed()
-    def test_register_no_activation_key(self):
+    def test_register_no_ak(self):
         """@test: register system to sat without activation key
 
         @feature: system registration
@@ -34,7 +35,7 @@ class SystemRegistrationTestCase(CLITestCase):
         """
 
     @stubbed()
-    def test_register_with_activation_key(self):
+    def test_register_with_ak(self):
         """@test: register system with activation key
 
         @feature: system registration

--- a/tests/foreman/cli/test_template.py
+++ b/tests/foreman/cli/test_template.py
@@ -48,7 +48,7 @@ class TestTemplate(CLITestCase):
         template = Template.info({'id': template['id']})
         self.assertEqual(updated_name, template['name'])
 
-    def test_create_template_with_location(self):
+    def test_create_template_with_loc(self):
         """@Test: Check if Template with Location can be created
 
         @Feature: Template - Create
@@ -74,7 +74,7 @@ class TestTemplate(CLITestCase):
                 'name': gen_string('alpha'),
             })
 
-    def test_create_template_with_organization(self):
+    def test_create_template_with_org(self):
         """@Test: Check if Template with Organization can be created
 
         @Feature: Template - Create

--- a/tests/foreman/cli/test_user.py
+++ b/tests/foreman/cli/test_user.py
@@ -1,4 +1,5 @@
 # -*- encoding: utf-8 -*-
+# pylint: disable=too-many-public-methods, too-many-lines
 """Test class for Users CLI
 
 When testing email validation [1] and [2] should be taken into consideration.
@@ -219,7 +220,7 @@ class User(CLITestCase):
         user = make_user({'admin': '1'})
         self.__assert_exists(user)
 
-    def test_create_user_with_default_location(self):
+    def test_create_user_default_loc(self):
         """@Test: Check if user with default location can be created
 
         @Feature: User - Positive create
@@ -235,7 +236,7 @@ class User(CLITestCase):
         self.assertIn(location['name'], user['locations'])
         self.assertEqual(location['name'], user['default-location'])
 
-    def test_create_user_with_defaut_org(self):
+    def test_create_user_defaut_org(self):
         """@Test: Check if user with default organization can be created
 
         @Feature: User - Positive create
@@ -1851,9 +1852,9 @@ class User(CLITestCase):
         """
         users = [make_user() for _ in range(4)]
         # non-existing user info
-        with self.assertRaises(CLIReturnCodeError) as e:
+        with self.assertRaises(CLIReturnCodeError) as exe:
             UserObj.info({'id': 0})
-        self.assertNotRegexpMatches(e.exception.stderr, 'undefined method')
+        self.assertNotRegexpMatches(exe.exception.stderr, 'undefined method')
         # list users
         result = UserObj.list()
         for user in users:


### PR DESCRIPTION
Reason for this PR:
* I like to run pylint in the code in addition to flake8 as it has more interesting rules in addition to flake8.
* As I am working on ddt removal effort, I am going through each test - removing ddt, optimizing the code and running flake8/pylint to validate my code.  This PR will help me finish ddt removal task sooner.

Approach:
* For long method names - when possible I fixed the method names and in some cases I disabled the pylint
* I did not fix test_import.py

Output: (without including test_import.py)
```sh
# pylint tests/foreman/cli/*.py
...
...
Global evaluation
-----------------
Your code has been rated at 9.88/10 (previous run: 9.95/10, -0.07)
```

Note: The result is not 10/10 as there are few todos left.