### PR TITLE
CLI/Import - add tests for import config-files

### DIFF
--- a/robottelo/cli/import_.py
+++ b/robottelo/cli/import_.py
@@ -345,7 +345,7 @@ class Import(Base):
             cls.read_transition_csv(ssh.command(cmd).stdout[:-1], key)
             for cmd, key
             in (
-                (u'ls -v ${HOME}/.transition_data/products*', u'sat5'),
+                (u'ls -v ${HOME}/.transition_data/products*', u'label'),
                 (
                     u'ls -v ${HOME}/.transition_data/puppet_repositories*',
                     u'org_id'


### PR DESCRIPTION
    * fixed subcommand `config_file_with_tr_data`
    * added 2 cases to `tests.foreman.cli.test_import`
    * modified `get_sat6_id()` to accept entity key as an optional parameter

```bash
$ nosetests -m test_import_config_files_default test_import.py -vs
@test: Import all Config Files from the default data set ... ok

----------------------------------------------------------------------
Ran 1 test in 205.435s

OK

$ nosetests -m test_reimport_config_files_negative test_import.py -vs
@test: Repetitive Import of all Config Files from the default ... 

ok

----------------------------------------------------------------------
Ran 1 test in 178.847s

OK

```