### PR TITLE
Api fix for max length for Org and location entities

### DIFF
--- a/tests/foreman/api/test_location.py
+++ b/tests/foreman/api/test_location.py
@@ -9,8 +9,27 @@ from fauxfactory import gen_integer, gen_string
 from nailgun import entities
 from random import randint
 from requests.exceptions import HTTPError
-from robottelo.helpers import valid_data_list, invalid_values_list
+from robottelo.helpers import invalid_values_list
 from robottelo.test import APITestCase
+
+
+def valid_loc_data_list():
+    """List of valid data for input testing.
+
+    Note: The maximum allowed length of location name is 246 only. This is an
+    intended behavior (Also note that 255 is the standard across other
+    entities.)
+
+    """
+    return [
+        gen_string('alphanumeric', randint(1, 246)),
+        gen_string('alpha', randint(1, 246)),
+        gen_string('cjk', randint(1, 85)),
+        gen_string('latin1', randint(1, 246)),
+        gen_string('numeric', randint(1, 246)),
+        gen_string('utf8', randint(1, 85)),
+        gen_string('html', randint(1, 85)),
+    ]
 
 
 class LocationTestCase(APITestCase):
@@ -26,7 +45,7 @@ class LocationTestCase(APITestCase):
         @Feature: Location
 
         """
-        for name in valid_data_list():
+        for name in valid_loc_data_list():
             with self.subTest(name):
                 location = entities.Location(name=name).create()
                 self.assertEqual(location.name, name)
@@ -215,7 +234,7 @@ class LocationTestCase(APITestCase):
         @Feature: Location - Update
 
         """
-        for new_name in valid_data_list():
+        for new_name in valid_loc_data_list():
             with self.subTest(new_name):
                 location = entities.Location().create()
                 location.name = new_name
@@ -229,7 +248,7 @@ class LocationTestCase(APITestCase):
         @Feature: Location - Update
 
         """
-        for new_description in valid_data_list():
+        for new_description in valid_loc_data_list():
             with self.subTest(new_description):
                 location = entities.Location().create()
                 location.description = new_description

--- a/tests/foreman/api/test_organization.py
+++ b/tests/foreman/api/test_organization.py
@@ -9,15 +9,34 @@ import httplib
 
 from fauxfactory import gen_alphanumeric, gen_string
 from nailgun import client, entities
+from random import randint
 from requests.exceptions import HTTPError
 from robottelo.decorators import skip_if_bug_open
 from robottelo.helpers import (
     get_nailgun_config,
     get_server_credentials,
-    invalid_values_list,
-    valid_data_list,
+    invalid_values_list
 )
 from robottelo.test import APITestCase
+
+
+def valid_org_data_list():
+    """List of valid data for input testing.
+
+    Note: The maximum allowed length of org name is 242 only. This is an
+    intended behavior (Also note that 255 is the standard across other
+    entities.)
+
+    """
+    return [
+        gen_string('alphanumeric', randint(1, 242)),
+        gen_string('alpha', randint(1, 242)),
+        gen_string('cjk', randint(1, 85)),
+        gen_string('latin1', randint(1, 242)),
+        gen_string('numeric', randint(1, 242)),
+        gen_string('utf8', randint(1, 85)),
+        gen_string('html', randint(1, 85)),
+    ]
 
 
 class OrganizationTestCase(APITestCase):
@@ -96,7 +115,7 @@ class OrganizationTestCase(APITestCase):
         @Feature: Organization
 
         """
-        for name in valid_data_list():
+        for name in valid_org_data_list():
             with self.subTest(name):
                 org = entities.Organization(
                     name=name,
@@ -185,7 +204,7 @@ class OrganizationUpdateTestCase(APITestCase):
         @Feature: Organization
 
         """
-        for name in valid_data_list():
+        for name in valid_org_data_list():
             with self.subTest(name):
                 setattr(self.organization, 'name', name)
                 self.organization = self.organization.update(['name'])
@@ -199,7 +218,7 @@ class OrganizationUpdateTestCase(APITestCase):
         @Feature: Organization
 
         """
-        for desc in valid_data_list():
+        for desc in valid_org_data_list():
             with self.subTest(desc):
                 setattr(self.organization, 'description', desc)
                 self.organization = self.organization.update(['description'])


### PR DESCRIPTION
Test result:

test_location.py:
```sh
Finding files... done.
Importing test modules ... done.

----------------------------------------------------------------------
Ran 27 tests in 106.585s

OK
```

I ran the following values specifically for test_location.py and it worked fine:
```py
        gen_string('alphanumeric', 246),
        gen_string('alpha', 246),
        gen_string('cjk', 85),
        gen_string('latin1', 246),
        gen_string('numeric', 246),
        gen_string('utf8', 85),
        gen_string('html', 85),
```

test_organization.py:
```sh
Finding files... done.
Importing test modules ... done.

----------------------------------------------------------------------
Ran 17 tests in 67.240s

OK (skipped=2)
```

I ran the following values specifically for test_organization.py and it worked fine:
```py
        gen_string('alphanumeric', 242),
        gen_string('alpha', 242),
        gen_string('cjk', 85),
        gen_string('latin1', 242),
        gen_string('numeric', 242),
        gen_string('utf8', 82),
        gen_string('html', 82),
```