### PR TITLE
Docker CLI: Add DockerContainersTestCase and DockerRegistriesTestCase

### DIFF
--- a/robottelo/cli/docker.py
+++ b/robottelo/cli/docker.py
@@ -303,6 +303,120 @@ class DockerImage(Base):
         return super(DockerImage, cls).list(options, per_page)
 
 
+class DockerRegistry(Base):
+    """Manipulates Docker registries
+
+    Usage::
+
+        hammer docker registry [OPTIONS] SUBCOMMAND [ARG] ...
+
+    Parameters::
+
+        SUBCOMMAND                    subcommand
+        [ARG] ...                     subcommand arguments
+
+    Subcommands::
+
+        create                        Create a docker registry
+        delete                        Delete a docker registry
+        info                          Show a docker registry
+        list                          List all docker registries
+        update                        Update a docker registry
+
+    """
+    command_base = 'docker registry'
+
+    @classmethod
+    def create(cls, options=None):
+        """Creates a docker registry
+
+        Usage::
+
+            hammer docker registry create [OPTIONS]
+
+        Options::
+
+            --description DESCRIPTION
+            --name NAME
+            --password PASSWORD
+            --url URL
+            --username USERNAME
+
+        """
+        return super(DockerRegistry, cls).create(options)
+
+    @classmethod
+    def delete(cls, options=None):
+        """Deletes a docker registry
+
+        Usage::
+
+            hammer docker registry delete [OPTIONS]
+
+        Options::
+
+            --id ID
+            --name NAME                               Name to search by
+
+        """
+        return super(DockerRegistry, cls).delete(options)
+
+    @classmethod
+    def info(cls, options=None):
+        """Gets information about docker registry
+
+        Usage::
+
+            hammer docker registry info [OPTIONS]
+
+        Options::
+
+            --id ID
+            --name NAME                   Name to search by
+
+        """
+        return super(DockerRegistry, cls).info(options)
+
+    @classmethod
+    def list(cls, options=None, per_page=True):
+        """List docker registries
+
+        Usage::
+
+            hammer docker registry list [OPTIONS]
+
+        Options::
+
+            --order ORDER                 sort results
+            --page PAGE                   paginate results
+            --per-page PER_PAGE           number of entries per request
+            --search SEARCH               filter results
+
+        """
+        return super(DockerRegistry, cls).list(options, per_page)
+
+    @classmethod
+    def update(cls, options=None):
+        """Updates a docker registry
+
+        Usage::
+
+            hammer docker registry update [OPTIONS]
+
+        Options::
+
+            --description DESCRIPTION
+            --id ID
+            --name NAME                               Name to search by
+            --new-name NEW_NAME
+            --password PASSWORD
+            --url URL
+            --username USERNAME
+
+        """
+        return super(DockerRegistry, cls).update(options)
+
+
 class DockerTag(Base):
     """Manipulates Docker tags
 
@@ -412,4 +526,5 @@ class Docker(Base):
     # class, import the Docker class and use it like this: Docker.image.list()
     container = DockerContainer
     image = DockerImage
+    registry = DockerRegistry
     tag = DockerTag

--- a/robottelo/cli/factory.py
+++ b/robottelo/cli/factory.py
@@ -10,8 +10,13 @@ import os
 import random
 
 from fauxfactory import (
-    gen_alphanumeric, gen_integer, gen_ipaddr,
-    gen_mac, gen_netmask, gen_string
+    gen_alphanumeric,
+    gen_integer,
+    gen_ipaddr,
+    gen_mac,
+    gen_netmask,
+    gen_string,
+    gen_url,
 )
 from os import chmod
 from robottelo import manifests, ssh
@@ -21,7 +26,7 @@ from robottelo.cli.base import CLIReturnCodeError
 from robottelo.cli.computeresource import ComputeResource
 from robottelo.cli.contenthost import ContentHost
 from robottelo.cli.contentview import ContentView
-from robottelo.cli.docker import DockerContainer
+from robottelo.cli.docker import DockerContainer, DockerRegistry
 from robottelo.cli.domain import Domain
 from robottelo.cli.environment import Environment
 from robottelo.cli.gpgkey import GPGKey
@@ -219,7 +224,7 @@ def make_container(options=None):
                                                   1/0.
 
     """
-    # Organization ID is a required field.
+    # Compute resource ID is a required field.
     if (not options or (
             u'compute-resource' not in options and
             u'compute-resource-id' not in options
@@ -583,6 +588,33 @@ def make_proxy(options=None):
                 'Failed to create ssh tunnel: {0}'.format(err))
 
     return create_object(Proxy, args, options)
+
+
+def make_registry(options=None):
+    """Creates a docker registry
+
+        Usage::
+
+            hammer docker registry create [OPTIONS]
+
+        Options::
+
+            --description DESCRIPTION
+            --name NAME
+            --password PASSWORD
+            --url URL
+            --username USERNAME
+
+    """
+    args = {
+        u'description': None,
+        u'name': gen_string('alphanumeric'),
+        u'password': None,
+        u'url': gen_url(subdomain=gen_string('alpha')),
+        u'username': None,
+    }
+
+    return create_object(DockerRegistry, args, options)
 
 
 @cacheable


### PR DESCRIPTION
* Implemented `DockerContainersTestCase` and `DockerRegistriesTestCase` stubs.
* Updated corresponding API tests as well
* Added new `make_registry()` factory function
* Added DockerRegistry CLI entity

Part of #2705