### PR TITLE
Removed `test_available_repository_1` test.

### DIFF
--- a/tests/foreman/cli/test_repository_set.py
+++ b/tests/foreman/cli/test_repository_set.py
@@ -6,26 +6,12 @@ from robottelo.cli.repository_set import RepositorySet
 from robottelo.cli.subscription import Subscription
 from robottelo import manifests
 from robottelo.constants import PRDS, REPOSET
-from robottelo.decorators import skip_if_bug_open
 from robottelo.ssh import upload_file
 from robottelo.test import CLITestCase
 
 
 class TestRepositorySet(CLITestCase):
     """Repository Set CLI tests."""
-
-    @skip_if_bug_open('bugzilla', 1172171)
-    def test_available_repository_1(self):
-        """@Test: Check if repositories are available
-
-        @Feature: Repository-set
-
-        @Assert: List of available repositories is displayed
-
-        @BZ: 1172171
-
-        """
-        self.fail('This stubbed test should be fleshed out')
 
     def test_repositoryset_available_repositories(self):
         """@Test: List available repositories for repository-set


### PR DESCRIPTION
I noticed that the `test_available_repository_1` has been failing
for **109** builds!!! I investigated this a bit and realized that:

* This issue has been fixed (see [BZ
  1172171](https://bugzilla.redhat.com/show_bug.cgi?id=1172171) and [BZ
  1236193](https://bugzilla.redhat.com/show_bug.cgi?id=1236193) for more
  information)
* We do already have other tests that exercise this same feature.