### PR TITLE
Assert that puppet modules are available.

### DIFF
--- a/tests/foreman/api/test_contentviewversion.py
+++ b/tests/foreman/api/test_contentviewversion.py
@@ -163,8 +163,15 @@ class CVVersionTestCase(APITestCase):
         ).create()
         with open(get_data_file(PUPPET_MODULE_NTP_PUPPETLABS), 'rb') as handle:
             puppet_repo.upload_content(files={'content': handle})
+        # Extract all the available puppet modules.
+        puppet_modules = content_view.available_puppet_modules()['results']
+        # Make sure that we have results. Uploading content does not
+        # seem to create a task so we cannot pool it for status. We
+        # should then check that we have some results back before
+        # proceeding.
+        self.assertGreater(len(puppet_modules), 0)
         puppet_module = entities.PuppetModule(
-            id=content_view.available_puppet_modules()['results'][0]['id']
+            id=puppet_modules[0]['id']
         )
 
         # Incrementally update the CVV with the puppet module.


### PR DESCRIPTION
The
`api.test_contentviewversion.CVVersionTestCase.test_incremental_update_puppet`
test has failed a few times with a `list index out of range` error.
There are two issues here:

1. Uploading a module does not seem to create a Foreman task that we can
pool, and the API call returns `HTTP 200 response:
{"status":"success"}`.
1. We should assert that 'something' is returned before proceeding with
the rest of the test.

This PR addresses the latter issue by adding an assertion.