### PR TITLE
Fixes label length to be 128

### DIFF
--- a/robottelo/helpers.py
+++ b/robottelo/helpers.py
@@ -246,8 +246,8 @@ def valid_data_list():
 def valid_labels_list():
     """List of valid labels for input testing."""
     return [
-        gen_string('alphanumeric', randint(1, 255)),
-        gen_string('alpha', randint(1, 255)),
+        gen_string('alphanumeric', randint(1, 128)),
+        gen_string('alpha', randint(1, 128)),
     ]
 
 

--- a/tests/foreman/cli/test_product.py
+++ b/tests/foreman/cli/test_product.py
@@ -85,7 +85,7 @@ class TestProduct(CLITestCase):
         @Assert: Product is created and has random description
 
         """
-        for desc in valid_labels_list():
+        for desc in valid_data_list():
             with self.subTest(desc):
                 product_name = gen_alphanumeric()
                 product = make_product({


### PR DESCRIPTION
This fixes one of the jenkins failures.

Test results for this PR:
```sh
# nosetests tests/foreman/cli/test_product.py:TestProduct.test_positive_create_2
.
----------------------------------------------------------------------
Ran 1 test in 12.991s

OK

# nosetests tests/foreman/cli/test_product.py:TestProduct.test_positive_create_3
.
----------------------------------------------------------------------
Ran 1 test in 36.212s

OK
```

I also stubbed valid_labels_list and tested to check maximum value:
```py
def valid_labels_list():
    """List of valid labels for input testing."""
    return [
        gen_string('alphanumeric', 128),
        gen_string('alpha', 128),
    ]
```
Test result:
```sh
# nosetests tests/foreman/cli/test_product.py:TestProduct.test_positive_create_2
.
----------------------------------------------------------------------
Ran 1 test in 13.525s

OK
```