### PR TITLE
Fix test_negative_create_2 for cli/test_subnet

### DIFF
--- a/tests/foreman/cli/test_subnet.py
+++ b/tests/foreman/cli/test_subnet.py
@@ -172,9 +172,9 @@ class TestSubnet(CLITestCase):
         """
         mask = '255.255.255.0'
         network = gen_ipaddr()
-        opts = {u'mask': mask, u'network': network}
         for pool in invalid_addr_pools():
             with self.subTest(pool):
+                opts = {u'mask': mask, u'network': network}
                 # generate pool range from network address
                 for key, val in pool.iteritems():
                     opts[key] = re.sub(r'\d+$', str(val), network)


### PR DESCRIPTION
Closes #2899 

```
for i in {1..10}; do nosetests tests/foreman/cli/test_subnet.py -m test_negative_create_2; done
.
----------------------------------------------------------------------
Ran 1 test in 12.812s

OK
.
----------------------------------------------------------------------
Ran 1 test in 12.584s

OK
.
----------------------------------------------------------------------
Ran 1 test in 12.781s

OK
.
----------------------------------------------------------------------
Ran 1 test in 12.780s

OK
.
----------------------------------------------------------------------
Ran 1 test in 12.441s

OK
.
----------------------------------------------------------------------
Ran 1 test in 12.834s

OK
.
----------------------------------------------------------------------
Ran 1 test in 12.592s

OK
.
----------------------------------------------------------------------
Ran 1 test in 12.826s

OK
.
----------------------------------------------------------------------
Ran 1 test in 12.601s

OK
.
----------------------------------------------------------------------
Ran 1 test in 12.570s

OK
```