### PR TITLE
Update run_only_on decorator

### DIFF
--- a/tests/foreman/api/test_contentview.py
+++ b/tests/foreman/api/test_contentview.py
@@ -25,10 +25,10 @@ from robottelo.test import APITestCase
 REPEAT = 3
 
 
-@run_only_on('sat')
 class ContentViewTestCase(APITestCase):
     """Tests for content views."""
 
+    @run_only_on('sat')
     def test_subscribe_system_to_cv(self):
         """@Test: Subscribe a system to a content view.
 
@@ -70,6 +70,7 @@ class ContentViewTestCase(APITestCase):
         if not bz_bug_is_open(1223494):
             self.assertEqual(system.organization.id, org.id)
 
+    @run_only_on('sat')
     def test_cv_clone_within_same_env(self):
         """@Test: attempt to create, publish and promote new content view
         based on existing view within the same environment as the
@@ -93,6 +94,7 @@ class ContentViewTestCase(APITestCase):
         cloned_cv.publish()
         promote(cloned_cv.read().version[0], lc_env.id)
 
+    @run_only_on('sat')
     def test_cv_clone_within_diff_env(self):
         """@Test: attempt to create, publish and promote new content
         view based on existing view but promoted to a
@@ -116,6 +118,7 @@ class ContentViewTestCase(APITestCase):
         cloned_cv.publish()
         promote(cloned_cv.read().version[0], le_clone.id)
 
+    @run_only_on('sat')
     def test_cv_associate_custom_content(self):
         """@Test: Associate custom content in a view
 
@@ -135,6 +138,7 @@ class ContentViewTestCase(APITestCase):
         self.assertEqual(len(content_view.repository), 1)
         self.assertEqual(content_view.repository[0].read().name, yum_repo.name)
 
+    @run_only_on('sat')
     def test_cv_associate_puppet_repo_negative(self):
         """@Test: Attempt to associate puppet repos within a custom
         content view directly
@@ -159,6 +163,7 @@ class ContentViewTestCase(APITestCase):
                 repository=[puppet_repo.id],
             ).create()
 
+    @run_only_on('sat')
     def test_cv_associate_composite_dupe_repos_negative(self):
         """@Test: Attempt to associate the same repo multiple times within a
         content view
@@ -180,6 +185,7 @@ class ContentViewTestCase(APITestCase):
             content_view.update(['repository'])
         self.assertEqual(len(content_view.read().repository), 0)
 
+    @run_only_on('sat')
     def test_cv_associate_composite_dupe_modules_negative(self):
         """@Test: Attempt to associate duplicate puppet modules within a
         content view
@@ -884,7 +890,6 @@ class CVRedHatContent(APITestCase):
         self.assertEqual(cv_filter.id, cv_filter_rule.content_view_filter.id)
 
 
-@run_only_on('sat')
 class ContentViewTestCaseStub(APITestCase):
     """Incomplete tests for content views."""
     # Each of these tests should be given a better name when they're

--- a/tests/foreman/api/test_contentviewfilter.py
+++ b/tests/foreman/api/test_contentviewfilter.py
@@ -17,7 +17,6 @@ from robottelo.helpers import invalid_names_list, valid_data_list
 from robottelo.test import APITestCase
 
 
-@run_only_on('sat')
 class ContentViewFilterTestCase(APITestCase):
     """Tests for content view filters."""
 
@@ -42,6 +41,7 @@ class ContentViewFilterTestCase(APITestCase):
     # Test method names are long for descriptive purposes.
     # pylint:disable=invalid-name
 
+    @run_only_on('sat')
     def test_get_with_no_args(self):
         """@Test: Issue an HTTP GET to the base content view filters path.
 
@@ -63,6 +63,7 @@ class ContentViewFilterTestCase(APITestCase):
             (httplib.BAD_REQUEST, httplib.UNPROCESSABLE_ENTITY)
         )
 
+    @run_only_on('sat')
     def test_get_with_bad_args(self):
         """@Test: Issue an HTTP GET to the base content view filters path.
 
@@ -85,6 +86,7 @@ class ContentViewFilterTestCase(APITestCase):
             (httplib.BAD_REQUEST, httplib.UNPROCESSABLE_ENTITY)
         )
 
+    @run_only_on('sat')
     def test_create_erratum_cvf_with_different_names(self):
         """Test: Create new erratum content filter using different inputs as
         a name
@@ -104,6 +106,7 @@ class ContentViewFilterTestCase(APITestCase):
                 self.assertEqual(cvf.name, name)
                 self.assertEqual(cvf.type, 'erratum')
 
+    @run_only_on('sat')
     def test_create_pck_group_cvf_with_different_names(self):
         """Test: Create new package group content filter using different inputs
         as a name
@@ -123,6 +126,7 @@ class ContentViewFilterTestCase(APITestCase):
                 self.assertEqual(cvf.name, name)
                 self.assertEqual(cvf.type, 'package_group')
 
+    @run_only_on('sat')
     def test_create_rpm_cvf_with_different_names(self):
         """Test: Create new RPM content filter using different inputs as
         a name
@@ -142,6 +146,7 @@ class ContentViewFilterTestCase(APITestCase):
                 self.assertEqual(cvf.name, name)
                 self.assertEqual(cvf.type, 'rpm')
 
+    @run_only_on('sat')
     def test_create_cvf_with_inclusion(self):
         """Test: Create new content view filter with different inclusion values
 
@@ -159,6 +164,7 @@ class ContentViewFilterTestCase(APITestCase):
                 ).create()
                 self.assertEqual(cvf.inclusion, inclusion)
 
+    @run_only_on('sat')
     def test_create_cvf_with_description(self):
         """Test: Create new content filter using different inputs as a
         description
@@ -177,6 +183,7 @@ class ContentViewFilterTestCase(APITestCase):
                 ).create()
                 self.assertEqual(cvf.description, description)
 
+    @run_only_on('sat')
     def test_create_cvf_with_repo(self):
         """Test: Create new content filter with repository assigned
 
@@ -193,6 +200,7 @@ class ContentViewFilterTestCase(APITestCase):
         ).create()
         self.assertEqual(cvf.repository[0].id, self.repo.id)
 
+    @run_only_on('sat')
     def test_create_cvf_with_original_packages(self):
         """Test: Create new content view filter with different 'original
         packages' option values
@@ -213,6 +221,7 @@ class ContentViewFilterTestCase(APITestCase):
                 ).create()
                 self.assertEqual(cvf.original_packages, original_packages)
 
+    @run_only_on('sat')
     def test_create_cvf_with_multiple_repos_with_docker(self):
         """Test: Create new docker repository and add to content view that has
         yum repo already assigned to it. Create new content view filter and
@@ -241,6 +250,7 @@ class ContentViewFilterTestCase(APITestCase):
         for repo in cvf.repository:
             self.assertIn(repo.id, [self.repo.id, docker_repository.id])
 
+    @run_only_on('sat')
     def test_create_cvf_with_different_names_negative(self):
         """@Test: Try to create content view filter using invalid names only
 
@@ -257,6 +267,7 @@ class ContentViewFilterTestCase(APITestCase):
                         name=name,
                     ).create()
 
+    @run_only_on('sat')
     def test_create_cvf_with_same_names_negative(self):
         """@Test: Try to create content view filter using same name twice
 
@@ -273,6 +284,7 @@ class ContentViewFilterTestCase(APITestCase):
         with self.assertRaises(HTTPError):
             entities.RPMContentViewFilter(**kwargs).create()
 
+    @run_only_on('sat')
     def test_create_cvf_without_cv_negative(self):
         """@Test: Try to create content view filter without providing content
         view
@@ -285,6 +297,7 @@ class ContentViewFilterTestCase(APITestCase):
         with self.assertRaises(HTTPError):
             entities.RPMContentViewFilter(content_view=None).create()
 
+    @run_only_on('sat')
     def test_create_cvf_with_repo_by_id_negative(self):
         """@Test: Try to create content view filter using incorrect repository
         id
@@ -300,6 +313,7 @@ class ContentViewFilterTestCase(APITestCase):
                 repository=[gen_integer(10000, 99999)],
             ).create()
 
+    @run_only_on('sat')
     def test_delete_cvf_by_id(self):
         """@Test: Delete content view filter
 
@@ -315,6 +329,7 @@ class ContentViewFilterTestCase(APITestCase):
         with self.assertRaises(HTTPError):
             cvf.read()
 
+    @run_only_on('sat')
     def test_update_cvf_with_new_name(self):
         """@Test: Update content view filter with new name
 
@@ -331,6 +346,7 @@ class ContentViewFilterTestCase(APITestCase):
                 cvf.name = name
                 self.assertEqual(cvf.update(['name']).name, name)
 
+    @run_only_on('sat')
     def test_update_cvf_with_new_description(self):
         """@Test: Update content view filter with new description
 
@@ -348,6 +364,7 @@ class ContentViewFilterTestCase(APITestCase):
                 cvf.description = desc
                 self.assertEqual(cvf.update(['description']).description, desc)
 
+    @run_only_on('sat')
     def test_update_cvf_with_new_inclusion(self):
         """Test: Update content view filter with new inclusion value
 
@@ -366,6 +383,7 @@ class ContentViewFilterTestCase(APITestCase):
                 cvf = cvf.update(['inclusion'])
                 self.assertEqual(cvf.inclusion, inclusion)
 
+    @run_only_on('sat')
     def test_update_cvf_with_new_repo(self):
         """Test: Update content view filter with new repository
 
@@ -389,6 +407,7 @@ class ContentViewFilterTestCase(APITestCase):
         self.assertEqual(len(cvf.repository), 1)
         self.assertEqual(cvf.repository[0].id, new_repo.id)
 
+    @run_only_on('sat')
     def test_update_cvf_with_multiple_repos(self):
         """Test: Update content view filter with multiple repositories
 
@@ -419,6 +438,7 @@ class ContentViewFilterTestCase(APITestCase):
             set([repo.id for repo in repos])
         )
 
+    @run_only_on('sat')
     def test_update_cvf_original_packages(self):
         """Test: Update content view filter with new 'original packages' option
         value
@@ -440,6 +460,7 @@ class ContentViewFilterTestCase(APITestCase):
                 cvf = cvf.update(['original_packages'])
                 self.assertEqual(cvf.original_packages, original_packages)
 
+    @run_only_on('sat')
     def test_update_cvf_with_repo_with_docker(self):
         """Test: Update existing content view filter which has yum repository
         assigned with new docker repository
@@ -469,6 +490,7 @@ class ContentViewFilterTestCase(APITestCase):
         for repo in cvf.repository:
             self.assertIn(repo.id, [self.repo.id, docker_repository.id])
 
+    @run_only_on('sat')
     def test_update_cvf_with_different_names_negative(self):
         """@Test: Try to update content view filter using invalid names only
 
@@ -486,6 +508,7 @@ class ContentViewFilterTestCase(APITestCase):
                 with self.assertRaises(HTTPError):
                     cvf.update(['name'])
 
+    @run_only_on('sat')
     def test_update_cvf_with_already_used_name_negative(self):
         """@Test: Try to update content view filter's name to already used one
 
@@ -506,6 +529,7 @@ class ContentViewFilterTestCase(APITestCase):
         with self.assertRaises(HTTPError):
             cvf.update(['name'])
 
+    @run_only_on('sat')
     def test_update_cvf_with_cv_by_id_negative(self):
         """@Test: Try to update content view filter using incorrect content
         view ID
@@ -522,6 +546,7 @@ class ContentViewFilterTestCase(APITestCase):
         with self.assertRaises(HTTPError):
             cvf.update(['content_view'])
 
+    @run_only_on('sat')
     def test_update_cvf_with_repo_by_id_negative(self):
         """@Test: Try to update content view filter using incorrect repository
         ID
@@ -539,6 +564,7 @@ class ContentViewFilterTestCase(APITestCase):
         with self.assertRaises(HTTPError):
             cvf.update(['repository'])
 
+    @run_only_on('sat')
     def test_update_cvf_with_new_repo_negative(self):
         """Test: Try to update content view filter with new repository which
         doesn't belong to filter's content view

--- a/tests/foreman/api/test_docker.py
+++ b/tests/foreman/api/test_docker.py
@@ -12,8 +12,6 @@ from robottelo.helpers import valid_data_list
 from robottelo.test import APITestCase
 
 DOCKER_PROVIDER = 'Docker'
-EXTERNAL_DOCKER_URL = settings.docker.external_url
-INTERNAL_DOCKER_URL = settings.docker.get_unix_socket_url()
 STRING_TYPES = ['alpha', 'alphanumeric', 'cjk', 'utf8', 'latin1']
 
 
@@ -110,7 +108,6 @@ def _create_repository(product, name=None, upstream_name=None):
     ).create()
 
 
-@run_only_on('sat')
 class DockerRepositoryTestCase(APITestCase):
     """Tests specific to performing CRUD methods against ``Docker``
     repositories.
@@ -123,6 +120,7 @@ class DockerRepositoryTestCase(APITestCase):
         super(DockerRepositoryTestCase, cls).setUpClass()
         cls.org = entities.Organization().create()
 
+    @run_only_on('sat')
     def test_create_one_docker_repo(self):
         """@Test: Create one Docker-type repository
 
@@ -141,6 +139,7 @@ class DockerRepositoryTestCase(APITestCase):
                 self.assertEqual(repo.docker_upstream_name, 'busybox')
                 self.assertEqual(repo.content_type, 'docker')
 
+    @run_only_on('sat')
     def test_create_docker_repo_valid_upstream_name(self):
         """@Test: Create a Docker-type repository with a valid docker upstream
         name
@@ -159,6 +158,7 @@ class DockerRepositoryTestCase(APITestCase):
                 self.assertEqual(repo.docker_upstream_name, upstream_name)
                 self.assertEqual(repo.content_type, u'docker')
 
+    @run_only_on('sat')
     def test_create_docker_repo_invalid_upstream_name(self):
         """@Test: Create a Docker-type repository with a invalid docker
         upstream name.
@@ -174,6 +174,7 @@ class DockerRepositoryTestCase(APITestCase):
                 with self.assertRaises(HTTPError):
                     _create_repository(product, upstream_name=upstream_name)
 
+    @run_only_on('sat')
     def test_create_multiple_docker_repo(self):
         """@Test: Create multiple Docker-type repositories
 
@@ -189,6 +190,7 @@ class DockerRepositoryTestCase(APITestCase):
             product = product.read()
             self.assertIn(repo.id, [repo_.id for repo_ in product.repository])
 
+    @run_only_on('sat')
     def test_create_multiple_docker_repo_multiple_products(self):
         """@Test: Create multiple Docker-type repositories on multiple products.
 
@@ -208,6 +210,7 @@ class DockerRepositoryTestCase(APITestCase):
                     [repo_.id for repo_ in product.repository],
                 )
 
+    @run_only_on('sat')
     def test_sync_docker_repo(self):
         """@Test: Create and sync a Docker-type repository
 
@@ -224,6 +227,7 @@ class DockerRepositoryTestCase(APITestCase):
         repo = repo.read()
         self.assertGreaterEqual(repo.content_counts['docker_image'], 1)
 
+    @run_only_on('sat')
     def test_update_docker_repo_name(self):
         """@Test: Create a Docker-type repository and update its name.
 
@@ -243,6 +247,7 @@ class DockerRepositoryTestCase(APITestCase):
                 repo = repo.update()
                 self.assertEqual(repo.name, new_name)
 
+    @run_only_on('sat')
     def test_update_docker_repo_upstream_name(self):
         """@Test: Create a Docker-type repository and update its upstream name.
 
@@ -262,6 +267,7 @@ class DockerRepositoryTestCase(APITestCase):
         repo = repo.update()
         self.assertEqual(repo.docker_upstream_name, new_upstream_name)
 
+    @run_only_on('sat')
     def test_update_docker_repo_url(self):
         """@Test: Create a Docker-type repository and update its URL.
 
@@ -282,6 +288,7 @@ class DockerRepositoryTestCase(APITestCase):
         self.assertEqual(repo.url, new_url)
         self.assertNotEqual(repo.url, DOCKER_REGISTRY_HUB)
 
+    @run_only_on('sat')
     def test_delete_docker_repo(self):
         """@Test: Create and delete a Docker-type repository
 
@@ -297,6 +304,7 @@ class DockerRepositoryTestCase(APITestCase):
         with self.assertRaises(HTTPError):
             repo.read()
 
+    @run_only_on('sat')
     def test_delete_random_docker_repo(self):
         """@Test: Create Docker-type repositories on multiple products and
         delete a random repository from a random product.
@@ -331,7 +339,6 @@ class DockerRepositoryTestCase(APITestCase):
             self.assertIn(repo.product.id, [prod.id for prod in products])
 
 
-@run_only_on('sat')
 class DockerContentViewTestCase(APITestCase):
     """Tests specific to using ``Docker`` repositories with Content Views."""
 
@@ -341,6 +348,7 @@ class DockerContentViewTestCase(APITestCase):
         super(DockerContentViewTestCase, cls).setUpClass()
         cls.org = entities.Organization().create()
 
+    @run_only_on('sat')
     def test_add_docker_repo_to_content_view(self):
         """@Test: Add one Docker-type repository to a non-composite content view
 
@@ -361,6 +369,7 @@ class DockerContentViewTestCase(APITestCase):
         content_view = content_view.update(['repository'])
         self.assertIn(repo.id, [repo_.id for repo_ in content_view.repository])
 
+    @run_only_on('sat')
     def test_add_multiple_docker_repos_to_content_view(self):
         """@Test: Add multiple Docker-type repositories to a
         non-composite content view.
@@ -401,6 +410,7 @@ class DockerContentViewTestCase(APITestCase):
             self.assertEqual(repo.content_type, u'docker')
             self.assertEqual(repo.docker_upstream_name, u'busybox')
 
+    @run_only_on('sat')
     def test_add_synced_docker_repo_to_content_view(self):
         """@Test: Create and sync a Docker-type repository
 
@@ -425,6 +435,7 @@ class DockerContentViewTestCase(APITestCase):
         content_view = content_view.update(['repository'])
         self.assertIn(repo.id, [repo_.id for repo_ in content_view.repository])
 
+    @run_only_on('sat')
     def test_add_docker_repo_to_composite_content_view(self):
         """@Test: Add one Docker-type repository to a composite content view
 
@@ -464,6 +475,7 @@ class DockerContentViewTestCase(APITestCase):
             [component.id for component in comp_content_view.component]
         )
 
+    @run_only_on('sat')
     def test_add_multiple_docker_repos_to_composite_content_view(self):
         """@Test: Add multiple Docker-type repositories to a composite
         content view.
@@ -509,6 +521,7 @@ class DockerContentViewTestCase(APITestCase):
                 [component.id for component in comp_content_view.component]
             )
 
+    @run_only_on('sat')
     def test_publish_once_docker_repo_content_view(self):
         """@Test: Add Docker-type repository to content view and publish
         it once.
@@ -541,6 +554,7 @@ class DockerContentViewTestCase(APITestCase):
         self.assertIsNotNone(content_view.last_published)
         self.assertGreater(content_view.next_version, 1)
 
+    @run_only_on('sat')
     @skip_if_bug_open('bugzilla', 1217635)
     def test_publish_once_docker_repo_composite_content_view(self):
         """@Test: Add Docker-type repository to composite
@@ -592,6 +606,7 @@ class DockerContentViewTestCase(APITestCase):
         self.assertIsNotNone(comp_content_view.last_published)
         self.assertGreater(comp_content_view.next_version, 1)
 
+    @run_only_on('sat')
     def test_publish_multiple_docker_repo_content_view(self):
         """@Test: Add Docker-type repository to content view and publish it
         multiple times.
@@ -621,6 +636,7 @@ class DockerContentViewTestCase(APITestCase):
         self.assertIsNotNone(content_view.last_published)
         self.assertEqual(len(content_view.version), publish_amount)
 
+    @run_only_on('sat')
     def test_publish_multiple_docker_repo_composite_content_view(self):
         """@Test: Add Docker-type repository to content view and publish it
         multiple times.
@@ -667,6 +683,7 @@ class DockerContentViewTestCase(APITestCase):
         self.assertIsNotNone(comp_content_view.last_published)
         self.assertEqual(len(comp_content_view.version), publish_amount)
 
+    @run_only_on('sat')
     def test_promote_docker_repo_content_view(self):
         """@Test: Add Docker-type repository to content view and publish it.
         Then promote it to the next available lifecycle-environment.
@@ -698,6 +715,7 @@ class DockerContentViewTestCase(APITestCase):
         promote(cvv, lce.id)
         self.assertEqual(len(cvv.read().environment), 2)
 
+    @run_only_on('sat')
     def test_promote_multiple_docker_repo_content_view(self):
         """@Test: Add Docker-type repository to content view and publish it.
         Then promote it to multiple available lifecycle-environments.
@@ -729,6 +747,7 @@ class DockerContentViewTestCase(APITestCase):
             promote(cvv, lce.id)
             self.assertEqual(len(cvv.read().environment), i+1)
 
+    @run_only_on('sat')
     def test_promote_docker_repo_composite_content_view(self):
         """@Test: Add Docker-type repository to content view and publish it.
         Then add that content view to composite one. Publish and promote that
@@ -770,6 +789,7 @@ class DockerContentViewTestCase(APITestCase):
         promote(comp_cvv, lce.id)
         self.assertEqual(len(comp_cvv.read().environment), 2)
 
+    @run_only_on('sat')
     def test_promote_multiple_docker_repo_composite_content_view(self):
         """@Test: Add Docker-type repository to content view and publish it.
         Then add that content view to composite one. Publish and promote that
@@ -813,7 +833,6 @@ class DockerContentViewTestCase(APITestCase):
             self.assertEqual(len(comp_cvv.read().environment), i+1)
 
 
-@run_only_on('sat')
 class DockerActivationKeyTestCase(APITestCase):
     """Tests specific to adding ``Docker`` repositories to Activation Keys."""
 
@@ -835,6 +854,7 @@ class DockerActivationKeyTestCase(APITestCase):
         cls.cvv = content_view.read().version[0].read()
         promote(cls.cvv, cls.lce.id)
 
+    @run_only_on('sat')
     def test_add_docker_repo_to_activation_key(self):
         """@Test: Add Docker-type repository to a non-composite content view
         and publish it. Then create an activation key and associate it with the
@@ -853,6 +873,7 @@ class DockerActivationKeyTestCase(APITestCase):
         self.assertEqual(ak.content_view.id, self.content_view.id)
         self.assertEqual(ak.content_view.read().repository[0].id, self.repo.id)
 
+    @run_only_on('sat')
     def test_remove_docker_repo_to_activation_key(self):
         """@Test: Add Docker-type repository to a non-composite content view
         and publish it. Create an activation key and associate it with the
@@ -874,6 +895,7 @@ class DockerActivationKeyTestCase(APITestCase):
         ak.content_view = None
         self.assertIsNone(ak.update(['content_view']).content_view)
 
+    @run_only_on('sat')
     def test_add_docker_repo_composite_view_to_activation_key(self):
         """@Test:Add Docker-type repository to a non-composite content view and
         publish it. Then add this content view to a composite content view and
@@ -904,6 +926,7 @@ class DockerActivationKeyTestCase(APITestCase):
         ).create()
         self.assertEqual(ak.content_view.id, comp_content_view.id)
 
+    @run_only_on('sat')
     def test_remove_docker_repo_composite_view_to_activation_key(self):
         """@Test: Add Docker-type repository to a non-composite content view
         and publish it. Then add this content view to a composite content view
@@ -939,7 +962,6 @@ class DockerActivationKeyTestCase(APITestCase):
         self.assertIsNone(ak.update(['content_view']).content_view)
 
 
-@run_only_on('sat')
 class DockerComputeResourceTestCase(APITestCase):
     """Tests specific to managing Docker-based Compute Resources."""
 
@@ -949,6 +971,7 @@ class DockerComputeResourceTestCase(APITestCase):
         super(DockerComputeResourceTestCase, cls).setUpClass()
         cls.org = entities.Organization().create()
 
+    @run_only_on('sat')
     def test_create_internal_docker_compute_resource(self):
         """@Test: Create a Docker-based Compute Resource in the Satellite 6
         instance.
@@ -962,12 +985,16 @@ class DockerComputeResourceTestCase(APITestCase):
             with self.subTest(name):
                 compute_resource = entities.DockerComputeResource(
                     name=name,
-                    url=INTERNAL_DOCKER_URL,
+                    url=settings.docker.get_unix_socket_url(),
                 ).create()
                 self.assertEqual(compute_resource.name, name)
                 self.assertEqual(compute_resource.provider, DOCKER_PROVIDER)
-                self.assertEqual(compute_resource.url, INTERNAL_DOCKER_URL)
+                self.assertEqual(
+                    compute_resource.url,
+                    settings.docker.get_unix_socket_url()
+                )
 
+    @run_only_on('sat')
     def test_update_docker_compute_resource(self):
         """@Test: Create a Docker-based Compute Resource in the Satellite 6
         instance then edit its attributes.
@@ -978,7 +1005,8 @@ class DockerComputeResourceTestCase(APITestCase):
         @Feature: Docker
 
         """
-        for url in (EXTERNAL_DOCKER_URL, INTERNAL_DOCKER_URL):
+        for url in (settings.docker.external_url,
+                    settings.docker.get_unix_socket_url()):
             with self.subTest(url):
                 compute_resource = entities.DockerComputeResource(
                     organization=[self.org],
@@ -991,6 +1019,7 @@ class DockerComputeResourceTestCase(APITestCase):
                     compute_resource.update(['url']).url,
                 )
 
+    @run_only_on('sat')
     def test_list_containers_internal_docker_compute_resource(self):
         """@Test: Create a Docker-based Compute Resource in the Satellite 6
         instance then list its running containers.
@@ -1001,7 +1030,8 @@ class DockerComputeResourceTestCase(APITestCase):
         @Feature: Docker
 
         """
-        for url in (EXTERNAL_DOCKER_URL, INTERNAL_DOCKER_URL):
+        for url in (settings.docker.external_url,
+                    settings.docker.get_unix_socket_url()):
             with self.subTest(url):
                 compute_resource = entities.DockerComputeResource(
                     organization=[self.org],
@@ -1020,6 +1050,7 @@ class DockerComputeResourceTestCase(APITestCase):
                 self.assertEqual(len(result), 1)
                 self.assertEqual(result[0].name, container.name)
 
+    @run_only_on('sat')
     def test_create_external_docker_compute_resource(self):
         """@Test: Create a Docker-based Compute Resource using an external
         Docker-enabled system.
@@ -1033,12 +1064,14 @@ class DockerComputeResourceTestCase(APITestCase):
             with self.subTest(name):
                 compute_resource = entities.DockerComputeResource(
                     name=name,
-                    url=EXTERNAL_DOCKER_URL,
+                    url=settings.docker.external_url,
                 ).create()
                 self.assertEqual(compute_resource.name, name)
                 self.assertEqual(compute_resource.provider, DOCKER_PROVIDER)
-                self.assertEqual(compute_resource.url, EXTERNAL_DOCKER_URL)
+                self.assertEqual(
+                    compute_resource.url, settings.docker.external_url)
 
+    @run_only_on('sat')
     def test_delete_docker_compute_resource(self):
         """@Test: Create a Docker-based Compute Resource then delete it.
 
@@ -1047,7 +1080,8 @@ class DockerComputeResourceTestCase(APITestCase):
         @Feature: Docker
 
         """
-        for url in (EXTERNAL_DOCKER_URL, INTERNAL_DOCKER_URL):
+        for url in (settings.docker.external_url,
+                    settings.docker.get_unix_socket_url()):
             with self.subTest(url):
                 resource = entities.DockerComputeResource(url=url).create()
                 self.assertEqual(resource.url, url)
@@ -1057,7 +1091,6 @@ class DockerComputeResourceTestCase(APITestCase):
                     resource.read()
 
 
-@run_only_on('sat')
 class DockerContainersTestCase(APITestCase):
     """Tests specific to using ``Containers`` in local and external Docker
     Compute Resources
@@ -1072,14 +1105,15 @@ class DockerContainersTestCase(APITestCase):
         cls.cr_internal = entities.DockerComputeResource(
             name=gen_string('alpha'),
             organization=[cls.org],
-            url=INTERNAL_DOCKER_URL,
+            url=settings.docker.get_unix_socket_url(),
         ).create()
         cls.cr_external = entities.DockerComputeResource(
             name=gen_string('alpha'),
             organization=[cls.org],
-            url=EXTERNAL_DOCKER_URL,
+            url=settings.docker.external_url,
         ).create()
 
+    @run_only_on('sat')
     def test_create_container_compute_resource(self):
         """@Test: Create containers for local and external compute resources
 
@@ -1100,6 +1134,7 @@ class DockerContainersTestCase(APITestCase):
                     compute_resource.name,
                 )
 
+    @run_only_on('sat')
     def test_create_container_compute_resource_power(self):
         """@Test: Create containers for local and external compute resource,
         then power them on and finally power them off
@@ -1133,6 +1168,7 @@ class DockerContainersTestCase(APITestCase):
                     False
                 )
 
+    @run_only_on('sat')
     def test_create_container_compute_resource_read_log(self):
         """@Test: Create containers for local and external compute resource and
         read their logs
@@ -1152,6 +1188,7 @@ class DockerContainersTestCase(APITestCase):
                 ).create()
                 self.assertTrue(container.logs()['logs'])
 
+    @run_only_on('sat')
     @stubbed()
     # Return to that case once BZ 1230710 is fixed (with adding
     # DockerRegistryContainer class to Nailgun)
@@ -1168,6 +1205,7 @@ class DockerContainersTestCase(APITestCase):
 
         """
 
+    @run_only_on('sat')
     def test_delete_container_compute_resource(self):
         """@Test: Delete containers in local and external compute resources
 
@@ -1189,13 +1227,13 @@ class DockerContainersTestCase(APITestCase):
                     container.read()
 
 
-@run_only_on('sat')
 class DockerRegistriesTestCase(APITestCase):
     """Tests specific to performing CRUD methods against ``Registries``
     repositories.
 
     """
 
+    @run_only_on('sat')
     def test_create_registry(self):
         """@Test: Create an external docker registry
 
@@ -1217,6 +1255,7 @@ class DockerRegistriesTestCase(APITestCase):
                 self.assertEqual(registry.url, url)
                 self.assertEqual(registry.description, description)
 
+    @run_only_on('sat')
     def test_update_registry_name(self):
         """@Test: Create an external docker registry and update its name
 
@@ -1232,6 +1271,7 @@ class DockerRegistriesTestCase(APITestCase):
                 registry = registry.update()
                 self.assertEqual(registry.name, new_name)
 
+    @run_only_on('sat')
     def test_update_registry_url(self):
         """@Test: Create an external docker registry and update its URL
 
@@ -1248,6 +1288,7 @@ class DockerRegistriesTestCase(APITestCase):
         registry = registry.update()
         self.assertEqual(registry.url, new_url)
 
+    @run_only_on('sat')
     def test_update_registry_description(self):
         """@Test: Create an external docker registry and update its description
 
@@ -1263,6 +1304,7 @@ class DockerRegistriesTestCase(APITestCase):
                 registry = registry.update()
                 self.assertEqual(registry.description, new_desc)
 
+    @run_only_on('sat')
     def test_update_registry_username(self):
         """@Test: Create an external docker registry and update its username
 
@@ -1282,6 +1324,7 @@ class DockerRegistriesTestCase(APITestCase):
         registry = registry.update()
         self.assertEqual(registry.username, new_username)
 
+    @run_only_on('sat')
     def test_delete_registry(self):
         """@Test: Create an external docker registry and then delete it
 

--- a/tests/foreman/api/test_environment.py
+++ b/tests/foreman/api/test_environment.py
@@ -13,10 +13,10 @@ from robottelo.helpers import invalid_names_list
 from robottelo.test import APITestCase
 
 
-@run_only_on('sat')
 class EnvironmentTestCase(APITestCase):
     """Tests for environments."""
 
+    @run_only_on('sat')
     def test_positive_create_1(self):
         """@Test: Create an environment and provide a valid name.
 
@@ -34,6 +34,7 @@ class EnvironmentTestCase(APITestCase):
                 env = env.read()  # check sat isn't blindly handing back data
                 self.assertEqual(env.name, name)
 
+    @run_only_on('sat')
     def test_negative_create_1(self):
         """@Test: Create an environment and provide an invalid name.
 
@@ -49,6 +50,7 @@ class EnvironmentTestCase(APITestCase):
                 with self.assertRaises(HTTPError):
                     entities.Environment(name=name).create()
 
+    @run_only_on('sat')
     def test_negative_create_2(self):
         """@Test: Create an environment and provide an illegal name.
 

--- a/tests/foreman/api/test_foremantask.py
+++ b/tests/foreman/api/test_foremantask.py
@@ -5,10 +5,10 @@ from robottelo.decorators import run_only_on, skip_if_bug_open
 from robottelo.test import APITestCase
 
 
-@run_only_on('sat')
 class ForemanTasksIdTestCase(APITestCase):
     """Tests for the ``foreman_tasks/api/v2/tasks/:id`` path."""
 
+    @run_only_on('sat')
     @skip_if_bug_open('bugzilla', 1131702)
     def test_no_such_task(self):
         """@Test: Fetch a non-existent task.
@@ -23,6 +23,7 @@ class ForemanTasksIdTestCase(APITestCase):
         with self.assertRaises(HTTPError):
             entities.ForemanTask(id='abc123').read()
 
+    @run_only_on('sat')
     def test_summary(self):
         """@Test: Get a summary of foreman tasks.
 

--- a/tests/foreman/api/test_gpgkey.py
+++ b/tests/foreman/api/test_gpgkey.py
@@ -4,10 +4,10 @@ from robottelo.decorators import run_only_on
 from robottelo.test import APITestCase
 
 
-@run_only_on('sat')
 class GPGKeyTestCase(APITestCase):
     """Tests for ``katello/api/v2/gpg_keys``."""
 
+    @run_only_on('sat')
     def test_get_all(self):
         """@Test: Search for a GPG key and specify just ``organization_id``.
 

--- a/tests/foreman/api/test_host.py
+++ b/tests/foreman/api/test_host.py
@@ -14,10 +14,10 @@ from robottelo.decorators import bz_bug_is_open, run_only_on
 from robottelo.test import APITestCase
 
 
-@run_only_on('sat')
 class HostsTestCase(APITestCase):
     """Tests for ``entities.Host().path()``."""
 
+    @run_only_on('sat')
     def test_get_search(self):
         """@Test: GET ``api/v2/hosts`` and specify the ``search`` parameter.
 
@@ -36,6 +36,7 @@ class HostsTestCase(APITestCase):
         self.assertEqual(response.status_code, httplib.OK)
         self.assertEqual(response.json()['search'], query)
 
+    @run_only_on('sat')
     def test_get_per_page(self):
         """@Test: GET ``api/v2/hosts`` and specify the ``per_page`` parameter.
 
@@ -54,6 +55,7 @@ class HostsTestCase(APITestCase):
         self.assertEqual(response.status_code, httplib.OK)
         self.assertEqual(response.json()['per_page'], per_page)
 
+    @run_only_on('sat')
     def test_create_owner_type(self):
         """@Test: Create a host and specify an ``owner_type``.
 
@@ -73,6 +75,7 @@ class HostsTestCase(APITestCase):
                 host = host.create(create_missing=False)
                 self.assertEqual(host.owner_type, owner_type)
 
+    @run_only_on('sat')
     def test_update_owner_type(self):
         """@Test: Update a host's ``owner_type``.
 

--- a/tests/foreman/api/test_lifecycleenvironment.py
+++ b/tests/foreman/api/test_lifecycleenvironment.py
@@ -9,10 +9,10 @@ from robottelo.decorators import run_only_on
 from robottelo.test import APITestCase
 
 
-@run_only_on('sat')
 class LifecycleEnvironmentTestCase(APITestCase):
     """Tests for ``katello/api/v2/environments``."""
 
+    @run_only_on('sat')
     def test_get_all(self):
         """@Test: Search for a lifecycle environment and specify an org ID.
 

--- a/tests/foreman/api/test_media.py
+++ b/tests/foreman/api/test_media.py
@@ -3,7 +3,6 @@ from robottelo.decorators import run_only_on, stubbed
 from robottelo.test import APITestCase
 
 
-@run_only_on('sat')
 class MediaTestCase(APITestCase):
     """Incomplete tests for media.
 
@@ -21,6 +20,7 @@ class MediaTestCase(APITestCase):
 
     """
 
+    @run_only_on('sat')
     @stubbed()
     def test_remove_medium_1(self, test_data):
         """
@@ -30,6 +30,7 @@ class MediaTestCase(APITestCase):
         @status: manual
         """
 
+    @run_only_on('sat')
     @stubbed()
     def test_remove_medium_2(self, test_data):
         """
@@ -39,6 +40,7 @@ class MediaTestCase(APITestCase):
         @status: manual
         """
 
+    @run_only_on('sat')
     @stubbed()
     def test_remove_medium_3(self, test_data):
         """
@@ -48,6 +50,7 @@ class MediaTestCase(APITestCase):
         @status: manual
         """
 
+    @run_only_on('sat')
     @stubbed()
     def test_remove_medium_4(self, test_data):
         """
@@ -57,6 +60,7 @@ class MediaTestCase(APITestCase):
         @status: manual
         """
 
+    @run_only_on('sat')
     @stubbed()
     def test_add_medium_1(self, test_data):
         """
@@ -66,6 +70,7 @@ class MediaTestCase(APITestCase):
         @status: manual
         """
 
+    @run_only_on('sat')
     @stubbed()
     def test_add_medium_2(self, test_data):
         """
@@ -75,6 +80,7 @@ class MediaTestCase(APITestCase):
         @status: manual
         """
 
+    @run_only_on('sat')
     @stubbed()
     def test_add_medium_3(self, test_data):
         """
@@ -84,6 +90,7 @@ class MediaTestCase(APITestCase):
         @status: manual
         """
 
+    @run_only_on('sat')
     @stubbed()
     def test_add_medium_4(self, test_data):
         """

--- a/tests/foreman/api/test_operatingsystem.py
+++ b/tests/foreman/api/test_operatingsystem.py
@@ -13,10 +13,10 @@ from robottelo.decorators import run_only_on, skip_if_bug_open
 from robottelo.test import APITestCase
 
 
-@run_only_on('sat')
 class OSParameterTestCase(APITestCase):
     """Tests for operating system parameters."""
 
+    @run_only_on('sat')
     def test_bz_1114640(self):
         """@Test: Create a parameter for operating system 1.
 
@@ -47,10 +47,10 @@ class OSParameterTestCase(APITestCase):
         self.assertEqual(os_param.value, value)
 
 
-@run_only_on('sat')
 class OSTestCase(APITestCase):
     """Tests for operating systems."""
 
+    @run_only_on('sat')
     def test_point_to_arch(self):
         """@Test: Create an operating system that points at an architecture.
 
@@ -65,6 +65,7 @@ class OSTestCase(APITestCase):
         self.assertEqual(len(operating_sys.architecture), 1)
         self.assertEqual(operating_sys.architecture[0].id, arch.id)
 
+    @run_only_on('sat')
     def test_point_to_ptable(self):
         """@Test: Create an operating system that points at a partition table.
 
@@ -79,6 +80,7 @@ class OSTestCase(APITestCase):
         self.assertEqual(len(operating_sys.ptable), 1)
         self.assertEqual(operating_sys.ptable[0].id, ptable.id)
 
+    @run_only_on('sat')
     @skip_if_bug_open('bugzilla', 1230902)
     def test_create_with_minor(self):
         """@Test: Create an operating system with an integer minor version.

--- a/tests/foreman/api/test_product.py
+++ b/tests/foreman/api/test_product.py
@@ -76,7 +76,6 @@ class ProductsTestCase(APITestCase):
         self.assertEqual(product.gpg_key.id, gpg_key.id)
 
 
-@run_only_on('sat')
 class ProductUpdateTestCase(APITestCase):
     """Tests for updating a product."""
 
@@ -86,6 +85,7 @@ class ProductUpdateTestCase(APITestCase):
         super(ProductUpdateTestCase, cls).setUpClass()
         cls.product = entities.Product().create()
 
+    @run_only_on('sat')
     def test_positive_update_1(self):
         """@Test: Update a product with a new name or description.
 
@@ -103,6 +103,7 @@ class ProductUpdateTestCase(APITestCase):
                     attrs.values()[0]
                 )
 
+    @run_only_on('sat')
     def test_positive_update_2(self):
         """@Test: Rename Product back to original name
 
@@ -128,10 +129,10 @@ class ProductUpdateTestCase(APITestCase):
                 )
 
 
-@run_only_on('sat')
 class RepositorySetsTestCase(APITestCase):
     """Tests for ``katello/api/v2/products/<product_id>/repository_sets``."""
 
+    @run_only_on('sat')
     def test_repositoryset_enable(self):
         """@Test: Enable repo from reposet
 
@@ -161,6 +162,7 @@ class RepositorySetsTestCase(APITestCase):
                 repo['substitutions']['releasever'] == '6Server')
         ][0])
 
+    @run_only_on('sat')
     def test_repositoryset_disable(self):
         """@Test: Disable repo from reposet
 

--- a/tests/foreman/api/test_smartproxy.py
+++ b/tests/foreman/api/test_smartproxy.py
@@ -61,7 +61,6 @@ class MissingAttrTestCase(APITestCase):
         )
 
 
-@run_only_on('sat')
 class SmartProxyTestCaseStub(APITestCase):
     """Incomplete tests for smart proxies.
 
@@ -79,6 +78,7 @@ class SmartProxyTestCaseStub(APITestCase):
 
     """
 
+    @run_only_on('sat')
     @stubbed()
     def test_add_smartproxy_1(self, test_data):
         """
@@ -88,6 +88,7 @@ class SmartProxyTestCaseStub(APITestCase):
         @status: manual
         """
 
+    @run_only_on('sat')
     @stubbed()
     def test_add_smartproxy_2(self, test_data):
         """
@@ -97,6 +98,7 @@ class SmartProxyTestCaseStub(APITestCase):
         @status: manual
         """
 
+    @run_only_on('sat')
     @stubbed()
     def test_add_smartproxy_3(self, test_data):
         """
@@ -106,6 +108,7 @@ class SmartProxyTestCaseStub(APITestCase):
         @status: manual
         """
 
+    @run_only_on('sat')
     @stubbed()
     def test_add_smartproxy_4(self, test_data):
         """
@@ -115,6 +118,7 @@ class SmartProxyTestCaseStub(APITestCase):
         @status: manual
         """
 
+    @run_only_on('sat')
     @stubbed()
     def test_remove_smartproxy_1(self, test_data):
         """
@@ -124,6 +128,7 @@ class SmartProxyTestCaseStub(APITestCase):
         @status: manual
         """
 
+    @run_only_on('sat')
     @stubbed()
     def test_remove_smartproxy_2(self, test_data):
         """
@@ -133,6 +138,7 @@ class SmartProxyTestCaseStub(APITestCase):
         @status: manual
         """
 
+    @run_only_on('sat')
     @stubbed()
     def test_remove_smartproxy_3(self, test_data):
         """
@@ -142,6 +148,7 @@ class SmartProxyTestCaseStub(APITestCase):
         @status: manual
         """
 
+    @run_only_on('sat')
     @stubbed()
     def test_remove_smartproxy_4(self, test_data):
         """

--- a/tests/foreman/api/test_syncplan.py
+++ b/tests/foreman/api/test_syncplan.py
@@ -73,7 +73,6 @@ class SyncPlanTestCase(APITestCase):
         )
 
 
-@run_only_on('sat')
 class SyncPlanCreateTestCase(APITestCase):
     """Tests specific to creating new sync plans."""
 
@@ -83,6 +82,7 @@ class SyncPlanCreateTestCase(APITestCase):
         super(SyncPlanCreateTestCase, cls).setUpClass()
         cls.org = entities.Organization().create()
 
+    @run_only_on('sat')
     def test_create_enabled_disabled(self):
         """@Test: Create sync plan with different 'enabled' field values.
 
@@ -99,6 +99,7 @@ class SyncPlanCreateTestCase(APITestCase):
                 ).create()
                 self.assertEqual(sync_plan.enabled, enabled)
 
+    @run_only_on('sat')
     def test_create_random_name(self):
         """@Test: Create a sync plan with a random name.
 
@@ -115,6 +116,7 @@ class SyncPlanCreateTestCase(APITestCase):
                 ).create()
                 self.assertEqual(syncplan.name, name)
 
+    @run_only_on('sat')
     def test_create_random_description(self):
         """@Test: Create a sync plan with a random description.
 
@@ -131,6 +133,7 @@ class SyncPlanCreateTestCase(APITestCase):
                 ).create()
                 self.assertEqual(sync_plan.description, description)
 
+    @run_only_on('sat')
     def test_create_random_interval(self):
         """@Test: Create a sync plan with a random interval.
 
@@ -147,6 +150,7 @@ class SyncPlanCreateTestCase(APITestCase):
                 ).create()
                 self.assertEqual(sync_plan.interval, interval)
 
+    @run_only_on('sat')
     def test_create_random_sync_date(self):
         """@Test: Create a sync plan and update its sync date.
 
@@ -166,6 +170,7 @@ class SyncPlanCreateTestCase(APITestCase):
                     sync_plan.sync_date
                 )
 
+    @run_only_on('sat')
     def test_create_invalid_name(self):
         """@Test: Create a sync plan with an invalid name.
 
@@ -182,6 +187,7 @@ class SyncPlanCreateTestCase(APITestCase):
                         organization=self.org
                     ).create()
 
+    @run_only_on('sat')
     def test_create_invalid_interval(self):
         """@Test: Create a sync plan with invalid interval specified.
 
@@ -198,6 +204,7 @@ class SyncPlanCreateTestCase(APITestCase):
                         organization=self.org,
                     ).create()
 
+    @run_only_on('sat')
     def test_create_empty_interval(self):
         """@Test: Create a sync plan with no interval specified.
 
@@ -213,7 +220,6 @@ class SyncPlanCreateTestCase(APITestCase):
             sync_plan.create(False)
 
 
-@run_only_on('sat')
 class SyncPlanUpdateTestCase(APITestCase):
     """Tests specific to updating a sync plan."""
 
@@ -223,6 +229,7 @@ class SyncPlanUpdateTestCase(APITestCase):
         super(SyncPlanUpdateTestCase, cls).setUpClass()
         cls.org = entities.Organization().create()
 
+    @run_only_on('sat')
     def test_update_enabled_disabled(self):
         """@Test: Create sync plan and update it with opposite 'enabled' value.
 
@@ -243,6 +250,7 @@ class SyncPlanUpdateTestCase(APITestCase):
                     enabled
                 )
 
+    @run_only_on('sat')
     def test_update_random_name(self):
         """@Test: Create a sync plan and update its name.
 
@@ -258,6 +266,7 @@ class SyncPlanUpdateTestCase(APITestCase):
                 sync_plan.name = name
                 self.assertEqual(sync_plan.update(['name']).name, name)
 
+    @run_only_on('sat')
     def test_update_random_description(self):
         """@Test: Create a sync plan and update its description.
 
@@ -279,6 +288,7 @@ class SyncPlanUpdateTestCase(APITestCase):
                     description
                 )
 
+    @run_only_on('sat')
     def test_update_random_interval(self):
         """@Test: Create a sync plan and update its interval.
 
@@ -303,6 +313,7 @@ class SyncPlanUpdateTestCase(APITestCase):
                     interval
                 )
 
+    @run_only_on('sat')
     def test_update_random_sync_date(self):
         """@Test: Updated sync plan's sync date.
 
@@ -323,6 +334,7 @@ class SyncPlanUpdateTestCase(APITestCase):
                     sync_plan.update(['sync_date']).sync_date
                 )
 
+    @run_only_on('sat')
     def test_update_invalid_name(self):
         """@Test: Try to update a sync plan with an invalid name.
 
@@ -338,6 +350,7 @@ class SyncPlanUpdateTestCase(APITestCase):
                 with self.assertRaises(HTTPError):
                     sync_plan.update(['name'])
 
+    @run_only_on('sat')
     def test_update_invalid_interval(self):
         """@Test: Try to update a sync plan with invalid interval.
 
@@ -514,7 +527,6 @@ class SyncPlanSynchronizeTestCase(APITestCase):
         """
 
 
-@run_only_on('sat')
 class SyncPlanDeleteTestCase(APITestCase):
     """Tests specific to deleting sync plans."""
 
@@ -524,6 +536,7 @@ class SyncPlanDeleteTestCase(APITestCase):
         super(SyncPlanDeleteTestCase, cls).setUpClass()
         cls.org = entities.Organization().create()
 
+    @run_only_on('sat')
     def test_delete_one_product(self):
         """@Test: Create a sync plan with one product and delete it.
 
@@ -540,6 +553,7 @@ class SyncPlanDeleteTestCase(APITestCase):
         with self.assertRaises(HTTPError):
             sync_plan.read()
 
+    @run_only_on('sat')
     def test_delete_two_products(self):
         """@Test: Create a sync plan with two products and delete them.
 
@@ -560,6 +574,7 @@ class SyncPlanDeleteTestCase(APITestCase):
         with self.assertRaises(HTTPError):
             sync_plan.read()
 
+    @run_only_on('sat')
     def test_delete_one_synced_product(self):
         """@Test: Create a sync plan with one synced product and delete it.
 

--- a/tests/foreman/cli/test_architecture.py
+++ b/tests/foreman/cli/test_architecture.py
@@ -9,13 +9,13 @@ from robottelo.helpers import invalid_values_list, valid_data_list
 from robottelo.test import MetaCLITestCase
 
 
-@run_only_on('sat')
 class TestArchitecture(MetaCLITestCase):
     """Architecture CLI related tests. """
 
     factory = make_architecture
     factory_obj = Architecture
 
+    @run_only_on('sat')
     def test_negative_update(self):
         """@test: Create architecture then fail to update
         its name
@@ -35,6 +35,7 @@ class TestArchitecture(MetaCLITestCase):
                         'new-name': new_name,
                     })
 
+    @run_only_on('sat')
     def test_positive_delete(self):
         """@test: Create architecture with valid values then delete it
         by ID

--- a/tests/foreman/cli/test_computeresource.py
+++ b/tests/foreman/cli/test_computeresource.py
@@ -92,11 +92,11 @@ def invalid_update_data():
     )
 
 
-@run_only_on('sat')
 class TestComputeResource(CLITestCase):
     """ComputeResource CLI tests."""
 
     # pylint: disable=no-self-use
+    @run_only_on('sat')
     def test_create(self):
         """@Test: Create Compute Resource
 
@@ -111,6 +111,7 @@ class TestComputeResource(CLITestCase):
             'url': LIBVIRT_URL,
         })
 
+    @run_only_on('sat')
     def test_info(self):
         """@Test: Test Compute Resource Info
 
@@ -128,6 +129,7 @@ class TestComputeResource(CLITestCase):
         # factory already runs info, just check the data
         self.assertEquals(compute_resource['name'], name)
 
+    @run_only_on('sat')
     def test_list(self):
         """@Test: Test Compute Resource List
 
@@ -147,6 +149,7 @@ class TestComputeResource(CLITestCase):
         result = ComputeResource.exists(search=('name', comp_res['name']))
         self.assertTrue(result)
 
+    @run_only_on('sat')
     def test_delete(self):
         """@Test: Test Compute Resource delete
 
@@ -166,6 +169,7 @@ class TestComputeResource(CLITestCase):
 
     # Positive create
 
+    @run_only_on('sat')
     def test_create_positive_libvirt(self):
         """@Test: Test Compute Resource create
 
@@ -183,6 +187,7 @@ class TestComputeResource(CLITestCase):
                     u'url': gen_url(),
                 })
 
+    @run_only_on('sat')
     def test_create_cr_with_location(self):
         """@Test: Create Compute Resource with location
 
@@ -196,6 +201,7 @@ class TestComputeResource(CLITestCase):
         self.assertEqual(1, len(comp_resource['locations']))
         self.assertEqual(comp_resource['locations'][0], location['name'])
 
+    @run_only_on('sat')
     def test_create_cr_with_locations(self):
         """@Test: Create Compute Resource with multiple locations
 
@@ -214,6 +220,7 @@ class TestComputeResource(CLITestCase):
         for location in locations:
             self.assertIn(location['name'], comp_resource['locations'])
 
+    @run_only_on('sat')
     @skip_if_bug_open('bugzilla', 1214312)
     def test_create_cr_with_consolepwd(self):
         """@Test: Create Compute Resource with different values of
@@ -242,6 +249,7 @@ class TestComputeResource(CLITestCase):
 
     # Negative create
 
+    @run_only_on('sat')
     def test_create_negative_1(self):
         """@Test: Compute Resource negative create with invalid values
 
@@ -261,6 +269,7 @@ class TestComputeResource(CLITestCase):
                         u'url': options.get('url', gen_url()),
                     })
 
+    @run_only_on('sat')
     def test_create_negative_2(self):
         """@Test: Compute Resource negative create with the same name
 
@@ -279,6 +288,7 @@ class TestComputeResource(CLITestCase):
 
     # Update Positive
 
+    @run_only_on('sat')
     def test_update_positive(self):
         """@Test: Compute Resource positive update
 
@@ -314,6 +324,7 @@ class TestComputeResource(CLITestCase):
 
     # Update Negative
 
+    @run_only_on('sat')
     def test_update_negative(self):
         """@Test: Compute Resource negative update
 
@@ -335,6 +346,7 @@ class TestComputeResource(CLITestCase):
                 for key in options.keys():
                     self.assertEqual(comp_res[key], result[key])
 
+    @run_only_on('sat')
     def test_set_console_password_v1(self):
         """@Test: Create a compute resource with ``--set-console-password``.
 
@@ -354,6 +366,7 @@ class TestComputeResource(CLITestCase):
                     'url': gen_url(),
                 })
 
+    @run_only_on('sat')
     def test_set_console_password_v2(self):
         """@Test: Update a compute resource with ``--set-console-password``.
 

--- a/tests/foreman/cli/test_contenthost.py
+++ b/tests/foreman/cli/test_contenthost.py
@@ -379,7 +379,6 @@ class TestContentHost(CLITestCase):
             })
 
 
-@run_only_on('sat')
 class TestCHKatelloAgent(CLITestCase):
     """Content-host tests, which require VM with installed katello-agent."""
 
@@ -447,6 +446,7 @@ class TestCHKatelloAgent(CLITestCase):
         self.client.destroy()
         super(TestCHKatelloAgent, self).tearDown()
 
+    @run_only_on('sat')
     def test_ch_get_errata_info(self):
         """@Test: Get errata info
 
@@ -467,6 +467,7 @@ class TestCHKatelloAgent(CLITestCase):
         self.assertEqual(result[0]['errata-id'], FAKE_0_ERRATA_ID)
         self.assertEqual(result[0]['packages'], FAKE_0_CUSTOM_PACKAGE)
 
+    @run_only_on('sat')
     def test_ch_apply_errata(self):
         """@Test: Apply errata to content host
 
@@ -485,6 +486,7 @@ class TestCHKatelloAgent(CLITestCase):
             u'organization-id': TestCHKatelloAgent.org['id'],
         })
 
+    @run_only_on('sat')
     def test_ch_package_install(self):
         """@Test: Install package to content host remotely
 
@@ -503,6 +505,7 @@ class TestCHKatelloAgent(CLITestCase):
         )
         self.assertEqual(result.return_code, 0)
 
+    @run_only_on('sat')
     def test_ch_package_remove(self):
         """@Test: Remove package from content host remotely
 
@@ -525,6 +528,7 @@ class TestCHKatelloAgent(CLITestCase):
         )
         self.assertNotEqual(result.return_code, 0)
 
+    @run_only_on('sat')
     def test_ch_package_upgrade(self):
         """@Test: Upgrade content host package remotely
 
@@ -542,6 +546,7 @@ class TestCHKatelloAgent(CLITestCase):
         result = self.client.run('rpm -q {0}'.format(FAKE_2_CUSTOM_PACKAGE))
         self.assertEqual(result.return_code, 0)
 
+    @run_only_on('sat')
     def test_ch_package_upgrade_all(self):
         """@Test: Upgrade all the content host packages remotely
 
@@ -559,6 +564,7 @@ class TestCHKatelloAgent(CLITestCase):
         result = self.client.run('rpm -q {0}'.format(FAKE_2_CUSTOM_PACKAGE))
         self.assertEqual(result.return_code, 0)
 
+    @run_only_on('sat')
     def test_ch_package_group_install(self):
         """@Test: Install package group to content host remotely
 
@@ -576,6 +582,7 @@ class TestCHKatelloAgent(CLITestCase):
             result = self.client.run('rpm -q {0}'.format(package))
             self.assertEqual(result.return_code, 0)
 
+    @run_only_on('sat')
     def test_ch_package_group_remove(self):
         """@Test: Remove package group from content host remotely
 

--- a/tests/foreman/cli/test_contentviews.py
+++ b/tests/foreman/cli/test_contentviews.py
@@ -54,7 +54,6 @@ def negative_create_data():
     )
 
 
-@run_only_on('sat')
 class TestContentView(CLITestCase):
     """Content View CLI tests"""
 
@@ -77,6 +76,7 @@ class TestContentView(CLITestCase):
     rhel_repo = None
     rhel_product_name = 'Red Hat Enterprise Linux Workstation'
 
+    @run_only_on('sat')
     def create_rhel_content(self):
         """Enable/Synchronize rhel content"""
         if TestContentView.rhel_content_org is not None:
@@ -143,6 +143,7 @@ class TestContentView(CLITestCase):
                 cached=True)
 
     # pylint: disable=unexpected-keyword-arg
+    @run_only_on('sat')
     def test_create_valid_names(self):
         """@test: create content views (positive)
 
@@ -158,6 +159,7 @@ class TestContentView(CLITestCase):
                 self.assertEqual(content_view['name'], test_data['name'])
 
     # pylint: disable=unexpected-keyword-arg
+    @run_only_on('sat')
     def test_create_invalid_names(self):
         """@test: create content views (negative)
 
@@ -173,6 +175,7 @@ class TestContentView(CLITestCase):
                 with self.assertRaises(CLIFactoryError):
                     make_content_view(test_data)
 
+    @run_only_on('sat')
     def test_create_invalid_org(self):
         # Use an invalid org name
         """@test: create content views (negative)
@@ -187,6 +190,7 @@ class TestContentView(CLITestCase):
             ContentView.create({'organization-id': gen_string('alpha')})
 
     # pylint: disable=unexpected-keyword-arg
+    @run_only_on('sat')
     def test_cv_edit(self):
         """@test: edit content views - name, description, etc.
 
@@ -208,6 +212,7 @@ class TestContentView(CLITestCase):
         con_view = ContentView.info({'id': con_view['id']})
         self.assertEqual(con_view['name'], new_name)
 
+    @run_only_on('sat')
     @stubbed
     def test_edit_rh_custom_spin(self):
         # Variations might be:
@@ -228,6 +233,7 @@ class TestContentView(CLITestCase):
         """
 
     # pylint: disable=unexpected-keyword-arg
+    @run_only_on('sat')
     def test_cv_delete(self):
         """@test: delete content views
 
@@ -244,6 +250,7 @@ class TestContentView(CLITestCase):
         with self.assertRaises(CLIReturnCodeError):
             ContentView.info({'id': con_view['id']})
 
+    @run_only_on('sat')
     def test_delete_cv_version_name(self):
         """@test: Create content view and publish it. After that try to
         disassociate content view from 'Library' environment through
@@ -273,6 +280,7 @@ class TestContentView(CLITestCase):
         content_view = ContentView.info({u'id': content_view['id']})
         self.assertEqual(len(content_view['versions']), 0)
 
+    @run_only_on('sat')
     def test_delete_cv_version_id(self):
         """@test: Create content view and publish it. After that try to
         disassociate content view from 'Library' environment through
@@ -317,6 +325,7 @@ class TestContentView(CLITestCase):
         new_cv = ContentView.info({u'id': new_cv['id']})
         self.assertEqual(len(new_cv['versions']), 0)
 
+    @run_only_on('sat')
     def test_delete_cv_version_negative(self):
         """@test: Create content view and publish it. Try to delete content
         view version while content view is still associated with lifecycle
@@ -339,6 +348,7 @@ class TestContentView(CLITestCase):
         content_view = ContentView.info({u'id': content_view['id']})
         self.assertEqual(len(content_view['versions']), 1)
 
+    @run_only_on('sat')
     def test_remove_cv_environment(self):
         """@Test: Remove content view from lifecycle environment assignment
 
@@ -360,6 +370,7 @@ class TestContentView(CLITestCase):
         new_cv = ContentView.info({u'id': new_cv['id']})
         self.assertEqual(len(new_cv['lifecycle-environments']), 0)
 
+    @run_only_on('sat')
     def test_remove_cv_and_reassign_ak(self):
         """Test: Remove content view environment and re-assign activation key
         to another environment and content view
@@ -415,6 +426,7 @@ class TestContentView(CLITestCase):
         destination_cv = ContentView.info({u'id': destination_cv['id']})
         self.assertEqual(destination_cv['activation-keys'][0], ac_key['name'])
 
+    @run_only_on('sat')
     def test_remove_cv_reassign_ch(self):
         """Test: Remove content view environment and re-assign content host
         to another environment and content view
@@ -475,6 +487,7 @@ class TestContentView(CLITestCase):
         destination_cv = ContentView.info({u'id': destination_cv['id']})
         self.assertEqual(destination_cv['content-host-count'], '1')
 
+    @run_only_on('sat')
     def test_remove_cv_version(self):
         """@Test: Delete content view version through 'remove' command
 
@@ -502,6 +515,7 @@ class TestContentView(CLITestCase):
         new_cv = ContentView.info({u'id': new_cv['id']})
         self.assertEqual(len(new_cv['versions']), 0)
 
+    @run_only_on('sat')
     def test_cv_composite_create(self):
         # Note: puppet repos cannot/should not be used in this test
         # It shouldn't work - and that is tested in a different case.
@@ -558,6 +572,7 @@ class TestContentView(CLITestCase):
     # katello content definition add_repo --label=MyView
     #   --repo=repo1 --org=ACME
 
+    @run_only_on('sat')
     def test_associate_view_rh(self):
         """@test: associate Red Hat content in a view
 
@@ -586,6 +601,7 @@ class TestContentView(CLITestCase):
             'Repo was not associated to CV',
         )
 
+    @run_only_on('sat')
     def test_associate_rh_content(self):
         """@test: associate Red Hat content in a view
 
@@ -628,6 +644,7 @@ class TestContentView(CLITestCase):
             'name': 'walgrind',
         })
 
+    @run_only_on('sat')
     def test_associate_custom_content(self):
         """@test: associate Red Hat content in a view
 
@@ -655,6 +672,7 @@ class TestContentView(CLITestCase):
             'Repo was not associated to CV',
         )
 
+    @run_only_on('sat')
     def test_add_custom_repos_with_name(self):
         """@test: add custom repos to cv with names
 
@@ -682,6 +700,7 @@ class TestContentView(CLITestCase):
             'Repo was not associated to CV',
         )
 
+    @run_only_on('sat')
     def test_invalid_puppet_repo(self):
         # Again, individual modules should be ok.
         """@test: attempt to associate puppet repos within a custom content
@@ -706,6 +725,7 @@ class TestContentView(CLITestCase):
                 u'repository-id': new_repo['id'],
             })
 
+    @run_only_on('sat')
     def test_associate_comp_negative(self):
         """@test: attempt to associate components in a non-composite
         content view
@@ -739,6 +759,7 @@ class TestContentView(CLITestCase):
                 u'organization-id': self.org['id'],
             })
 
+    @run_only_on('sat')
     def test_add_dupe_repo(self):
         """@test: attempt to associate the same repo multiple times within a
         content view
@@ -777,6 +798,7 @@ class TestContentView(CLITestCase):
             'No new entry of same repo is expected',
         )
 
+    @run_only_on('sat')
     @skip_if_bug_open('bugzilla', 1222118)
     def test_add_dupe_puppet_module(self):
         """@test: attempt to associate duplicate puppet module(s) within a
@@ -825,6 +847,7 @@ class TestContentView(CLITestCase):
     # katello content view promote --label=MyView --env=Dev --org=ACME
     # katello content view promote --view=MyView --env=Staging --org=ACME
 
+    @run_only_on('sat')
     def test_cv_promote_rh(self):
         """@test: attempt to promote a content view containing RH content
 
@@ -863,6 +886,7 @@ class TestContentView(CLITestCase):
         }
         self.assertIn(environment, new_cv['lifecycle-environments'])
 
+    @run_only_on('sat')
     @stubbed
     def test_promote_rh_custom_spin(self):
         """@test: attempt to promote a content view containing a custom RH
@@ -878,6 +902,7 @@ class TestContentView(CLITestCase):
 
         """
 
+    @run_only_on('sat')
     def test_promote_custom_content(self):
         """@test: attempt to promote a content view containing custom content
 
@@ -913,6 +938,7 @@ class TestContentView(CLITestCase):
             new_cv['lifecycle-environments'],
         )
 
+    @run_only_on('sat')
     def test_promote_composite(self):
         # Variations:
         # RHEL, custom content (i.e., google repos), puppet modules
@@ -970,6 +996,7 @@ class TestContentView(CLITestCase):
             con_view['lifecycle-environments'],
         )
 
+    @run_only_on('sat')
     def test_promote_defaultcv_negative(self):
         """@test: attempt to promote the default content views
 
@@ -993,6 +1020,7 @@ class TestContentView(CLITestCase):
                 u'to-lifecycle-environment-id': self.env1['id'],
             })
 
+    @run_only_on('sat')
     def test_promote_invalid_env(self):
         """@test: attempt to promote a content view using an invalid
         environment
@@ -1028,6 +1056,7 @@ class TestContentView(CLITestCase):
     # Content Views: publish
     # katello content definition publish --label=MyView
 
+    @run_only_on('sat')
     def test_cv_publish_rh(self):
         """@test: attempt to publish a content view containing RH content
 
@@ -1061,6 +1090,7 @@ class TestContentView(CLITestCase):
             'Publishing new version of CV was not successful'
         )
 
+    @run_only_on('sat')
     @stubbed
     def test_cv_publish_rh_custom_spin(self):
         """@test: attempt to publish  a content view containing a custom RH
@@ -1076,6 +1106,7 @@ class TestContentView(CLITestCase):
 
         """
 
+    @run_only_on('sat')
     def test_cv_publish_custom_content(self):
         """@test: attempt to publish a content view containing custom content
 
@@ -1110,6 +1141,7 @@ class TestContentView(CLITestCase):
             'Publishing new version of CV was not successful',
         )
 
+    @run_only_on('sat')
     def test_cv_publish_composite(self):
         # Variations:
         # RHEL, custom content (i.e., google repos), puppet modules
@@ -1173,6 +1205,7 @@ class TestContentView(CLITestCase):
             'Publishing new version of CV was not successful'
         )
 
+    @run_only_on('sat')
     def test_version_update_1(self):
         # Dev notes:
         # If Dev has version x, then when I promote version y into
@@ -1258,6 +1291,7 @@ class TestContentView(CLITestCase):
             'Promotion of version2 not successful to the env',
         )
 
+    @run_only_on('sat')
     def test_version_update_2(self):
         # Dev notes:
         # Similarly when I publish version y, version x goes away from
@@ -1350,6 +1384,7 @@ class TestContentView(CLITestCase):
             'version1 still exists in the next env',
         )
 
+    @run_only_on('sat')
     def test_cv_subscribe_system(self):
         """@test: Attempt to subscribe content host to content view
 
@@ -1379,6 +1414,7 @@ class TestContentView(CLITestCase):
         content_view = ContentView.info({u'id': content_view['id']})
         self.assertEqual(content_view['content-host-count'], '1')
 
+    @run_only_on('sat')
     def test_cv_subscribe_rh1(self):
         """@test: Attempt to subscribe content host to content view that has
         Red Hat repository assigned to it
@@ -1424,6 +1460,7 @@ class TestContentView(CLITestCase):
         content_view = ContentView.info({u'id': content_view['id']})
         self.assertEqual(content_view['content-host-count'], '1')
 
+    @run_only_on('sat')
     def test_cv_subscribe_rh2(self):
         """@test: Attempt to subscribe content host to filtered content view
         that has Red Hat repository assigned to it
@@ -1486,6 +1523,7 @@ class TestContentView(CLITestCase):
         content_view = ContentView.info({u'id': content_view['id']})
         self.assertEqual(content_view['content-host-count'], '1')
 
+    @run_only_on('sat')
     def test_cv_subscribe_system_custom(self):
         """@test: Attempt to subscribe content host to content view that has
         custom repository assigned to it
@@ -1528,6 +1566,7 @@ class TestContentView(CLITestCase):
         content_view = ContentView.info({u'id': content_view['id']})
         self.assertEqual(content_view['content-host-count'], '1')
 
+    @run_only_on('sat')
     def test_subscribe_system_ccv(self):
         """@test: Attempt to subscribe content host to composite content view
 
@@ -1562,6 +1601,7 @@ class TestContentView(CLITestCase):
         content_view = ContentView.info({u'id': content_view['id']})
         self.assertEqual(content_view['content-host-count'], '1')
 
+    @run_only_on('sat')
     @skip_if_bug_open('bugzilla', 1222118)
     def test_cv_subscribe_system_puppet(self):
         """@test: Attempt to subscribe content host to content view that has
@@ -1621,6 +1661,7 @@ class TestContentView(CLITestCase):
         content_view = ContentView.info({u'id': content_view['id']})
         self.assertEqual(content_view['content-host-count'], '1')
 
+    @run_only_on('sat')
     @stubbed
     def test_cv_clone_within_same_env(self):
         # Dev note: "not implemented yet"
@@ -1634,6 +1675,7 @@ class TestContentView(CLITestCase):
 
         """
 
+    @run_only_on('sat')
     @stubbed
     def test_cv_clone_within_diff_env(self):
         # Dev note: "not implemented yet"
@@ -1648,6 +1690,7 @@ class TestContentView(CLITestCase):
 
         """
 
+    @run_only_on('sat')
     @stubbed
     def test_cv_dynflow_restart_promote(self):
         """@test: attempt to restart a promotion
@@ -1664,6 +1707,7 @@ class TestContentView(CLITestCase):
 
         """
 
+    @run_only_on('sat')
     @stubbed
     def test_cv_dynflow_restart_publish(self):
         """@test: attempt to restart a publish
@@ -1684,6 +1728,7 @@ class TestContentView(CLITestCase):
     # All this stuff is speculative at best.
 
     # pylint: disable=unexpected-keyword-arg
+    @run_only_on('sat')
     def test_cv_admin_user_negative(self):
         # Note:
         # Obviously all of this stuff should work with 'admin' user
@@ -1726,6 +1771,7 @@ class TestContentView(CLITestCase):
                         no_rights_user['password'],
                     ).info({'id': con_view['id']})
 
+    @run_only_on('sat')
     @stubbed()
     def test_cv_readonly_user_1(self):
         # Note:
@@ -1750,6 +1796,7 @@ class TestContentView(CLITestCase):
 
         """
 
+    @run_only_on('sat')
     @stubbed()
     def test_cv_readonly_user_2(self):
         # Note:

--- a/tests/foreman/cli/test_docker.py
+++ b/tests/foreman/cli/test_docker.py
@@ -27,8 +27,6 @@ from robottelo.decorators import run_only_on, skip_if_bug_open, stubbed
 from robottelo.helpers import valid_data_list
 from robottelo.test import CLITestCase
 
-EXTERNAL_DOCKER_URL = settings.docker.external_url
-INTERNAL_DOCKER_URL = settings.docker.get_unix_socket_url()
 STRING_TYPES = ['alpha', 'alphanumeric', 'cjk', 'utf8', 'latin1']
 
 DOCKER_PROVIDER = 'Docker'
@@ -97,7 +95,6 @@ class DockerImageTestCase(CLITestCase):
             self.assertIn(repository['id'], tag_repository_ids)
 
 
-@run_only_on('sat')
 class DockerRepositoryTestCase(CLITestCase):
     """Tests specific to performing CRUD methods against ``Docker``
     repositories.
@@ -110,6 +107,7 @@ class DockerRepositoryTestCase(CLITestCase):
         super(DockerRepositoryTestCase, cls).setUpClass()
         cls.org_id = make_org()['id']
 
+    @run_only_on('sat')
     def test_create_one_docker_repo(self):
         """@Test: Create one Docker-type repository
 
@@ -129,6 +127,7 @@ class DockerRepositoryTestCase(CLITestCase):
                     repo['upstream-repository-name'], REPO_UPSTREAM_NAME)
                 self.assertEqual(repo['content-type'], REPO_CONTENT_TYPE)
 
+    @run_only_on('sat')
     def test_create_multiple_docker_repo(self):
         """@Test: Create multiple Docker-type repositories
 
@@ -152,6 +151,7 @@ class DockerRepositoryTestCase(CLITestCase):
             set([repo_['repo-name'] for repo_ in product['content']]),
         )
 
+    @run_only_on('sat')
     def test_create_multiple_docker_repo_multiple_products(self):
         """@Test: Create multiple Docker-type repositories on multiple
         products.
@@ -177,6 +177,7 @@ class DockerRepositoryTestCase(CLITestCase):
                 set([repo_['repo-name'] for repo_ in product['content']]),
             )
 
+    @run_only_on('sat')
     def test_sync_docker_repo(self):
         """@Test: Create and sync a Docker-type repository
 
@@ -194,6 +195,7 @@ class DockerRepositoryTestCase(CLITestCase):
         self.assertGreaterEqual(
             int(repo['content-counts']['docker-images']), 1)
 
+    @run_only_on('sat')
     def test_update_docker_repo_name(self):
         """@Test: Create a Docker-type repository and update its name.
 
@@ -215,6 +217,7 @@ class DockerRepositoryTestCase(CLITestCase):
                 repo = Repository.info({'id': repo['id']})
                 self.assertEqual(repo['name'], new_name)
 
+    @run_only_on('sat')
     def test_update_docker_repo_upstream_name(self):
         """@Test: Create a Docker-type repository and update its upstream name.
 
@@ -235,6 +238,7 @@ class DockerRepositoryTestCase(CLITestCase):
         repo = Repository.info({'id': repo['id']})
         self.assertEqual(repo['upstream-repository-name'], new_upstream_name)
 
+    @run_only_on('sat')
     def test_update_docker_repo_url(self):
         """@Test: Create a Docker-type repository and update its URL.
 
@@ -254,6 +258,7 @@ class DockerRepositoryTestCase(CLITestCase):
         repo = Repository.info({'id': repo['id']})
         self.assertEqual(repo['url'], new_url)
 
+    @run_only_on('sat')
     def test_delete_docker_repo(self):
         """@Test: Create and delete a Docker-type repository
 
@@ -268,6 +273,7 @@ class DockerRepositoryTestCase(CLITestCase):
         with self.assertRaises(CLIReturnCodeError):
             Repository.info({'id': repo['id']})
 
+    @run_only_on('sat')
     def test_delete_random_docker_repo(self):
         """@Test: Create Docker-type repositories on multiple products and
         delete a random repository from a random product.
@@ -302,7 +308,6 @@ class DockerRepositoryTestCase(CLITestCase):
             )
 
 
-@run_only_on('sat')
 class DockerContentViewTestCase(CLITestCase):
     """Tests specific to using ``Docker`` repositories with Content Views."""
 
@@ -312,6 +317,7 @@ class DockerContentViewTestCase(CLITestCase):
         super(DockerContentViewTestCase, cls).setUpClass()
         cls.org_id = make_org()['id']
 
+    @run_only_on('sat')
     def _create_and_associate_repo_with_cv(self):
         """Create a Docker-based repository and content view and associate
         them.
@@ -339,6 +345,7 @@ class DockerContentViewTestCase(CLITestCase):
             ],
         )
 
+    @run_only_on('sat')
     def test_add_docker_repo_to_content_view(self):
         """@Test: Add one Docker-type repository to a non-composite content view
 
@@ -364,6 +371,7 @@ class DockerContentViewTestCase(CLITestCase):
             [repo_['id'] for repo_ in content_view['docker-repositories']],
         )
 
+    @run_only_on('sat')
     def test_add_multiple_docker_repos_to_content_view(self):
         """@Test: Add multiple Docker-type repositories to a
         non-composite content view.
@@ -395,6 +403,7 @@ class DockerContentViewTestCase(CLITestCase):
             set([repo['id'] for repo in content_view['docker-repositories']]),
         )
 
+    @run_only_on('sat')
     def test_add_synced_docker_repo_to_content_view(self):
         """@Test: Create and sync a Docker-type repository
 
@@ -424,6 +433,7 @@ class DockerContentViewTestCase(CLITestCase):
             [repo_['id'] for repo_ in content_view['docker-repositories']],
         )
 
+    @run_only_on('sat')
     def test_add_docker_repo_to_composite_content_view(self):
         """@Test: Add one Docker-type repository to a composite content view
 
@@ -455,6 +465,7 @@ class DockerContentViewTestCase(CLITestCase):
             [component['id'] for component in comp_content_view['components']],
         )
 
+    @run_only_on('sat')
     def test_add_multiple_docker_repos_to_composite_content_view(self):
         """@Test: Add multiple Docker-type repositories to a composite
         content view.
@@ -503,6 +514,7 @@ class DockerContentViewTestCase(CLITestCase):
                 ],
             )
 
+    @run_only_on('sat')
     def test_publish_once_docker_repo_content_view(self):
         """@Test: Add Docker-type repository to content view and publish
         it once.
@@ -521,6 +533,7 @@ class DockerContentViewTestCase(CLITestCase):
         })
         self.assertEqual(len(self.content_view['versions']), 1)
 
+    @run_only_on('sat')
     def test_publish_once_docker_repo_composite_content_view(self):
         """@Test: Add Docker-type repository to composite
         content view and publish it once.
@@ -564,6 +577,7 @@ class DockerContentViewTestCase(CLITestCase):
         })
         self.assertEqual(len(comp_content_view['versions']), 1)
 
+    @run_only_on('sat')
     def test_publish_multiple_docker_repo_content_view(self):
         """@Test: Add Docker-type repository to content view and publish it
         multiple times.
@@ -584,6 +598,7 @@ class DockerContentViewTestCase(CLITestCase):
         })
         self.assertEqual(len(self.content_view['versions']), publish_amount)
 
+    @run_only_on('sat')
     def test_publish_multiple_docker_repo_composite_content_view(self):
         """@Test: Add Docker-type repository to content view and publish it
         multiple times.
@@ -628,6 +643,7 @@ class DockerContentViewTestCase(CLITestCase):
         })
         self.assertEqual(len(comp_content_view['versions']), publish_amount)
 
+    @run_only_on('sat')
     def test_promote_docker_repo_content_view(self):
         """@Test: Add Docker-type repository to content view and publish it.
         Then promote it to the next available lifecycle-environment.
@@ -657,6 +673,7 @@ class DockerContentViewTestCase(CLITestCase):
         })
         self.assertEqual(len(cvv['lifecycle-environments']), 2)
 
+    @run_only_on('sat')
     def test_promote_multiple_docker_repo_content_view(self):
         """@Test: Add Docker-type repository to content view and publish it.
         Then promote it to multiple available lifecycle-environments.
@@ -687,6 +704,7 @@ class DockerContentViewTestCase(CLITestCase):
             })
             self.assertEqual(len(cvv['lifecycle-environments']), i+1)
 
+    @run_only_on('sat')
     def test_promote_docker_repo_composite_content_view(self):
         """@Test: Add Docker-type repository to composite content view and
         publish it. Then promote it to the next available
@@ -740,6 +758,7 @@ class DockerContentViewTestCase(CLITestCase):
         })
         self.assertEqual(len(cvv['lifecycle-environments']), 2)
 
+    @run_only_on('sat')
     def test_promote_multiple_docker_repo_composite_content_view(self):
         """@Test: Add Docker-type repository to composite content view and
         publish it. Then promote it to the multiple available
@@ -795,7 +814,6 @@ class DockerContentViewTestCase(CLITestCase):
             self.assertEqual(len(cvv['lifecycle-environments']), i+1)
 
 
-@run_only_on('sat')
 class DockerActivationKeyTestCase(CLITestCase):
     """Tests specific to adding ``Docker`` repositories to Activation Keys."""
 
@@ -836,6 +854,7 @@ class DockerActivationKeyTestCase(CLITestCase):
             'id': cls.content_view['versions'][0]['id'],
         })
 
+    @run_only_on('sat')
     def test_add_docker_repo_to_activation_key(self):
         """@Test: Add Docker-type repository to a non-composite content view
         and publish it. Then create an activation key and associate it with the
@@ -854,6 +873,7 @@ class DockerActivationKeyTestCase(CLITestCase):
         self.assertEqual(
             activation_key['content-view'], self.content_view['name'])
 
+    @run_only_on('sat')
     def test_remove_docker_repo_to_activation_key(self):
         """@Test: Add Docker-type repository to a non-composite content view
         and publish it. Create an activation key and associate it with the
@@ -898,6 +918,7 @@ class DockerActivationKeyTestCase(CLITestCase):
         self.assertNotEqual(
             activation_key['content-view'], self.content_view['name'])
 
+    @run_only_on('sat')
     def test_add_docker_repo_composite_view_to_activation_key(self):
         """@Test: Add Docker-type repository to a non-composite content view
         and publish it. Then add this content view to a composite content view
@@ -947,6 +968,7 @@ class DockerActivationKeyTestCase(CLITestCase):
         self.assertEqual(
             activation_key['content-view'], comp_content_view['name'])
 
+    @run_only_on('sat')
     def test_remove_docker_repo_composite_view_to_activation_key(self):
         """@Test: Add Docker-type repository to a non-composite content view
         and publish it. Then add this content view to a composite content view
@@ -1072,7 +1094,6 @@ class DockerClientTestCase(CLITestCase):
         """
 
 
-@run_only_on('sat')
 class DockerComputeResourceTestCase(CLITestCase):
     """Tests specific to managing Docker-based Compute Resources."""
 
@@ -1082,6 +1103,7 @@ class DockerComputeResourceTestCase(CLITestCase):
         super(DockerComputeResourceTestCase, cls).setUpClass()
         cls.org = make_org()
 
+    @run_only_on('sat')
     def test_create_internal_docker_compute_resource(self):
         """@Test: Create a Docker-based Compute Resource in the Satellite 6
         instance.
@@ -1096,12 +1118,16 @@ class DockerComputeResourceTestCase(CLITestCase):
                 compute_resource = make_compute_resource({
                     'name': name,
                     'provider': DOCKER_PROVIDER,
-                    'url': INTERNAL_DOCKER_URL,
+                    'url': settings.docker.get_unix_socket_url(),
                 })
                 self.assertEqual(compute_resource['name'], name)
                 self.assertEqual(compute_resource['provider'], DOCKER_PROVIDER)
-                self.assertEqual(compute_resource['url'], INTERNAL_DOCKER_URL)
+                self.assertEqual(
+                    compute_resource['url'],
+                    settings.docker.get_unix_socket_url()
+                )
 
+    @run_only_on('sat')
     def test_update_docker_compute_resource(self):
         """@Test: Create a Docker-based Compute Resource in the Satellite 6
         instance then edit its attributes.
@@ -1112,7 +1138,8 @@ class DockerComputeResourceTestCase(CLITestCase):
         @Feature: Docker
 
         """
-        for url in (EXTERNAL_DOCKER_URL, INTERNAL_DOCKER_URL):
+        for url in (settings.docker.external_url,
+                    settings.docker.get_unix_socket_url()):
             with self.subTest(url):
                 compute_resource = make_compute_resource({
                     'provider': DOCKER_PROVIDER,
@@ -1129,6 +1156,7 @@ class DockerComputeResourceTestCase(CLITestCase):
                 })
                 self.assertEqual(compute_resource['url'], new_url)
 
+    @run_only_on('sat')
     def test_list_containers_docker_compute_resource(self):
         """@Test: Create a Docker-based Compute Resource in the Satellite 6
         instance then list its running containers.
@@ -1139,7 +1167,8 @@ class DockerComputeResourceTestCase(CLITestCase):
         @Feature: Docker
 
         """
-        for url in (EXTERNAL_DOCKER_URL, INTERNAL_DOCKER_URL):
+        for url in (settings.docker.external_url,
+                    settings.docker.get_unix_socket_url()):
             with self.subTest(url):
                 compute_resource = make_compute_resource({
                     'organization-ids': [self.org['id']],
@@ -1161,6 +1190,7 @@ class DockerComputeResourceTestCase(CLITestCase):
                 self.assertEqual(len(result), 1)
                 self.assertEqual(result[0]['name'], container['name'])
 
+    @run_only_on('sat')
     def test_create_external_docker_compute_resource(self):
         """@Test: Create a Docker-based Compute Resource using an external
         Docker-enabled system.
@@ -1175,12 +1205,14 @@ class DockerComputeResourceTestCase(CLITestCase):
                 compute_resource = make_compute_resource({
                     'name': name,
                     'provider': DOCKER_PROVIDER,
-                    'url': EXTERNAL_DOCKER_URL,
+                    'url': settings.docker.external_url,
                 })
                 self.assertEqual(compute_resource['name'], name)
                 self.assertEqual(compute_resource['provider'], DOCKER_PROVIDER)
-                self.assertEqual(compute_resource['url'], EXTERNAL_DOCKER_URL)
+                self.assertEqual(
+                    compute_resource['url'], settings.docker.external_url)
 
+    @run_only_on('sat')
     def test_delete_docker_compute_resource(self):
         """@Test: Create a Docker-based Compute Resource then delete it.
 
@@ -1189,7 +1221,8 @@ class DockerComputeResourceTestCase(CLITestCase):
         @Feature: Docker
 
         """
-        for url in (EXTERNAL_DOCKER_URL, INTERNAL_DOCKER_URL):
+        for url in (settings.docker.external_url,
+                    settings.docker.get_unix_socket_url()):
             with self.subTest(url):
                 compute_resource = make_compute_resource({
                     'provider': DOCKER_PROVIDER,
@@ -1202,7 +1235,6 @@ class DockerComputeResourceTestCase(CLITestCase):
                     ComputeResource.info({'id': compute_resource['id']})
 
 
-@run_only_on('sat')
 class DockerContainersTestCase(CLITestCase):
     """Tests specific to using ``Containers`` in local and external Docker
     Compute Resources
@@ -1217,14 +1249,15 @@ class DockerContainersTestCase(CLITestCase):
         cls.cr_internal = make_compute_resource({
             'organization-ids': [cls.org['id']],
             'provider': DOCKER_PROVIDER,
-            'url': INTERNAL_DOCKER_URL,
+            'url': settings.docker.get_unix_socket_url(),
         })
         cls.cr_external = make_compute_resource({
             'organization-ids': [cls.org['id']],
             'provider': DOCKER_PROVIDER,
-            'url': EXTERNAL_DOCKER_URL,
+            'url': settings.docker.external_url,
         })
 
+    @run_only_on('sat')
     def test_create_container(self):
         """@Test: Create containers for local and external compute resources
 
@@ -1242,6 +1275,7 @@ class DockerContainersTestCase(CLITestCase):
                 self.assertEqual(
                     container['compute-resource'], compute_resource['name'])
 
+    @run_only_on('sat')
     @skip_if_bug_open('bugzilla', 1230915)
     @skip_if_bug_open('bugzilla', 1269196)
     def test_container_power(self):
@@ -1272,6 +1306,7 @@ class DockerContainersTestCase(CLITestCase):
                 status = Docker.container.status({'id': container['id']})
                 self.assertEqual(status[0], not_running_msg)
 
+    @run_only_on('sat')
     @skip_if_bug_open('bugzilla', 1230915)
     @skip_if_bug_open('bugzilla', 1269208)
     def test_container_read_log(self):
@@ -1296,6 +1331,7 @@ class DockerContainersTestCase(CLITestCase):
                 logs = Docker.container.logs({'id': container['id']})
                 self.assertTrue(logs['logs'])
 
+    @run_only_on('sat')
     @stubbed()
     def test_create_container_external_registry(self):
         """@Test: Create a container pulling an image from a custom external
@@ -1310,6 +1346,7 @@ class DockerContainersTestCase(CLITestCase):
 
         """
 
+    @run_only_on('sat')
     @skip_if_bug_open('bugzilla', 1230915)
     def test_delete_container(self):
         """@Test: Delete containers in local and external compute resources
@@ -1333,13 +1370,13 @@ class DockerContainersTestCase(CLITestCase):
                     Docker.container.info({'id': container['id']})
 
 
-@run_only_on('sat')
 class DockerRegistriesTestCase(CLITestCase):
     """Tests specific to performing CRUD methods against ``Registries``
     repositories.
 
     """
 
+    @run_only_on('sat')
     @skip_if_bug_open('bugzilla', 1259498)
     def test_create_registry(self):
         """@Test: Create an external docker registry
@@ -1364,6 +1401,7 @@ class DockerRegistriesTestCase(CLITestCase):
                 self.assertEqual(registry['description'], description)
                 self.assertEqual(registry['url'], url)
 
+    @run_only_on('sat')
     @skip_if_bug_open('bugzilla', 1259498)
     def test_update_registry_name_by_id(self):
         """@Test: Create an external docker registry and update its name. Use
@@ -1386,6 +1424,7 @@ class DockerRegistriesTestCase(CLITestCase):
                 registry = Docker.registry.info({'id': registry['id']})
                 self.assertEqual(registry['name'], new_name)
 
+    @run_only_on('sat')
     def test_update_registry_name_by_name(self):
         """@Test: Create an external docker registry and update its name. Use
         registry name to search by
@@ -1405,6 +1444,7 @@ class DockerRegistriesTestCase(CLITestCase):
                 registry = Docker.registry.info({'name': new_name})
                 self.assertEqual(registry['name'], new_name)
 
+    @run_only_on('sat')
     @skip_if_bug_open('bugzilla', 1259498)
     def test_update_registry_url_by_id(self):
         """@Test: Create an external docker registry and update its URL. Use
@@ -1426,6 +1466,7 @@ class DockerRegistriesTestCase(CLITestCase):
         registry = Docker.registry.info({'id': registry['id']})
         self.assertEqual(registry['url'], new_url)
 
+    @run_only_on('sat')
     def test_update_registry_url_by_name(self):
         """@Test: Create an external docker registry and update its URL. Use
         registry name to search by
@@ -1444,6 +1485,7 @@ class DockerRegistriesTestCase(CLITestCase):
         registry = Docker.registry.info({'name': registry['name']})
         self.assertEqual(registry['url'], new_url)
 
+    @run_only_on('sat')
     @skip_if_bug_open('bugzilla', 1259498)
     def test_update_registry_description_by_id(self):
         """@Test: Create an external docker registry and update its
@@ -1466,6 +1508,7 @@ class DockerRegistriesTestCase(CLITestCase):
                 registry = Docker.registry.info({'id': registry['id']})
                 self.assertEqual(registry['description'], new_desc)
 
+    @run_only_on('sat')
     @skip_if_bug_open('bugzilla', 1259498)
     def test_update_registry_description_by_name(self):
         """@Test: Create an external docker registry and update its
@@ -1488,6 +1531,7 @@ class DockerRegistriesTestCase(CLITestCase):
                 registry = Docker.registry.info({'name': registry['name']})
                 self.assertEqual(registry['description'], new_desc)
 
+    @run_only_on('sat')
     @skip_if_bug_open('bugzilla', 1259498)
     def test_update_registry_username_by_id(self):
         """@Test: Create an external docker registry and update its username.
@@ -1510,6 +1554,7 @@ class DockerRegistriesTestCase(CLITestCase):
                 registry = Docker.registry.info({'id': registry['id']})
                 self.assertEqual(registry['username'], new_user)
 
+    @run_only_on('sat')
     @skip_if_bug_open('bugzilla', 1259498)
     def test_update_registry_username_by_name(self):
         """@Test: Create an external docker registry and update its username.
@@ -1532,6 +1577,7 @@ class DockerRegistriesTestCase(CLITestCase):
                 registry = Docker.registry.info({'name': registry['name']})
                 self.assertEqual(registry['username'], new_user)
 
+    @run_only_on('sat')
     @skip_if_bug_open('bugzilla', 1259498)
     def test_delete_registry_by_id(self):
         """@Test: Create an external docker registry. Use registry ID to search
@@ -1549,6 +1595,7 @@ class DockerRegistriesTestCase(CLITestCase):
         with self.assertRaises(CLIReturnCodeError):
             Docker.registry.info({'id': registry['id']})
 
+    @run_only_on('sat')
     def test_delete_registry_by_name(self):
         """@Test: Create an external docker registry. Use registry name to
         search by

--- a/tests/foreman/cli/test_domain.py
+++ b/tests/foreman/cli/test_domain.py
@@ -11,7 +11,6 @@ from robottelo.decorators import run_only_on
 from robottelo.test import MetaCLITestCase
 
 
-@run_only_on('sat')
 class TestDomain(MetaCLITestCase):
     """Domain CLI tests"""
 
@@ -28,6 +27,7 @@ class TestDomain(MetaCLITestCase):
         {u'name': gen_string(str_type='utf8', length=255),
          u'description': gen_string(str_type='utf8', length=255)},
     )
+    @run_only_on('sat')
     def test_positive_create(self, options):
         """@Test: Create domain with valid name and description
 
@@ -40,6 +40,7 @@ class TestDomain(MetaCLITestCase):
         self.assertEqual(domain['name'], options['name'])
         self.assertEqual(domain['description'], options['description'])
 
+    @run_only_on('sat')
     def test_create_domain_with_location(self):
         """@Test: Check if domain with location can be created
 
@@ -52,6 +53,7 @@ class TestDomain(MetaCLITestCase):
         domain = make_domain({'location-ids': location['id']})
         self.assertIn(location['name'], domain['locations'])
 
+    @run_only_on('sat')
     def test_create_domain_with_organization(self):
         """@Test: Check if domain with organization can be created
 
@@ -69,6 +71,7 @@ class TestDomain(MetaCLITestCase):
         {u'dns-id': '-1'},
         {u'name': gen_string(str_type='utf8', length=256)},
     )
+    @run_only_on('sat')
     def test_negative_create(self, options):
         """@Test: Create domain with invalid values
 
@@ -90,6 +93,7 @@ class TestDomain(MetaCLITestCase):
         {u'name': gen_string(str_type='utf8', length=255),
          u'description': gen_string(str_type='utf8', length=255)},
     )
+    @run_only_on('sat')
     def test_positive_update(self, options):
         """@Test: Update domain with valid values
 
@@ -114,6 +118,7 @@ class TestDomain(MetaCLITestCase):
         {u'description': gen_string(str_type='utf8', length=256)},
         {u'dns-id': '-1'},
     )
+    @run_only_on('sat')
     def test_negative_update(self, options):
         """@Test: Update domain with invalid values
 
@@ -141,6 +146,7 @@ class TestDomain(MetaCLITestCase):
         {'name': gen_string(str_type='utf8'),
          'value': ''},
     )
+    @run_only_on('sat')
     def test_positive_set_parameter(self, options):
         """@Test: Domain set-parameter with valid key and value
 
@@ -169,6 +175,7 @@ class TestDomain(MetaCLITestCase):
         {'name': gen_string(str_type='utf8', length=256),
          'value': gen_string(str_type='utf8')},
     )
+    @run_only_on('sat')
     def test_negative_set_parameter(self, options):
         """@Test: Domain set-parameter with invalid values
 
@@ -194,6 +201,7 @@ class TestDomain(MetaCLITestCase):
         {'name': gen_string(str_type='utf8'),
          'value': ''},
     )
+    @run_only_on('sat')
     def test_positive_delete_parameter(self, options):
         """@Test: Domain delete-parameter removes parameter
 

--- a/tests/foreman/cli/test_environment.py
+++ b/tests/foreman/cli/test_environment.py
@@ -11,7 +11,6 @@ from robottelo.helpers import bz_bug_is_open, invalid_values_list
 from robottelo.test import MetaCLITestCase
 
 
-@run_only_on('sat')
 class TestEnvironment(MetaCLITestCase):
     """Test class for Environment CLI"""
     factory = make_environment
@@ -51,6 +50,7 @@ class TestEnvironment(MetaCLITestCase):
         {'name': gen_string('numeric', 10)},
     )
 
+    @run_only_on('sat')
     def test_info(self):
         """@Test: Test Environment Info
 
@@ -63,6 +63,7 @@ class TestEnvironment(MetaCLITestCase):
         env = make_environment({'name': name})
         self.assertEquals(env['name'], name)
 
+    @run_only_on('sat')
     def test_list(self):
         """@Test: Test Environment List
 
@@ -76,6 +77,7 @@ class TestEnvironment(MetaCLITestCase):
         result = Environment().list({'search': name})
         self.assertEqual(len(result), 1)
 
+    @run_only_on('sat')
     def test_create_environment_with_location(self):
         """@Test: Check if Environment with Location can be created
 
@@ -91,6 +93,7 @@ class TestEnvironment(MetaCLITestCase):
         })
         self.assertIn(new_loc['name'], new_environment['locations'])
 
+    @run_only_on('sat')
     def test_create_environment_with_organization(self):
         """@Test: Check if Environment with Organization can be created
 
@@ -106,6 +109,7 @@ class TestEnvironment(MetaCLITestCase):
         })
         self.assertIn(new_org['name'], new_environment['organizations'])
 
+    @run_only_on('sat')
     def test_delete(self):
         """@Test: Delete the environment
 
@@ -125,6 +129,7 @@ class TestEnvironment(MetaCLITestCase):
         gen_string('numeric', 10),
         gen_string('alphanumeric', 10),
     )
+    @run_only_on('sat')
     def test_update(self, new_name):
         """@Test: Update the environment
 
@@ -143,6 +148,7 @@ class TestEnvironment(MetaCLITestCase):
         self.assertEqual(env['name'], new_name)
 
     @data(*invalid_values_list())
+    @run_only_on('sat')
     def test_update_negative(self, new_name):
         """@Test: Update the environment with invalid values
 
@@ -164,6 +170,7 @@ class TestEnvironment(MetaCLITestCase):
         self.assertEqual(env['name'], name)
         self.assertNotEqual(env['name'], new_name)
 
+    @run_only_on('sat')
     def test_update_location(self):
         """@Test: Update environment location with new value
 
@@ -184,6 +191,7 @@ class TestEnvironment(MetaCLITestCase):
         self.assertIn(new_loc['name'], new_env['locations'])
         self.assertNotIn(old_loc['name'], new_env['locations'])
 
+    @run_only_on('sat')
     def test_update_organization(self):
         """@Test: Update environment organization with new value
 
@@ -209,6 +217,7 @@ class TestEnvironment(MetaCLITestCase):
         self.assertNotIn(old_org['name'], env['organizations'])
 
     @skip_if_bug_open('bugzilla', 1219934)
+    @run_only_on('sat')
     def test_sc_params_by_environment_id(self):
         """@Test: Check if environment sc-param subcommand works passing
         an environment id
@@ -228,6 +237,7 @@ class TestEnvironment(MetaCLITestCase):
             self.fail('BZ #1219934 is closed, should assert the content')
 
     @skip_if_bug_open('bugzilla', 1219934)
+    @run_only_on('sat')
     def test_sc_params_by_environment_name(self):
         """@Test: Check if environment sc-param subcommand works passing
         an environment name

--- a/tests/foreman/cli/test_fact.py
+++ b/tests/foreman/cli/test_fact.py
@@ -6,11 +6,11 @@ from robottelo.decorators import run_only_on, stubbed
 from robottelo.test import CLITestCase
 
 
-@run_only_on('sat')
 class TestFact(CLITestCase):
     """Fact related tests."""
 
     @stubbed('Need to create facts before we can check them.')
+    @run_only_on('sat')
     def test_list_success(self):
         """@Test: Test Fact List
 
@@ -26,6 +26,7 @@ class TestFact(CLITestCase):
                 facts = Fact().list(args)
                 self.assertEqual(facts[0]['fact'], fact)
 
+    @run_only_on('sat')
     def test_list_fail(self):
         """@Test: Test Fact List failure
 

--- a/tests/foreman/cli/test_globalparam.py
+++ b/tests/foreman/cli/test_globalparam.py
@@ -7,11 +7,11 @@ from robottelo.decorators import run_only_on
 from robottelo.test import CLITestCase
 
 
-@run_only_on('sat')
 class TestGlobalParameter(CLITestCase):
     """GlobalParameter related CLI tests."""
 
     # pylint: disable=no-self-use
+    @run_only_on('sat')
     def test_set(self):
         """@Test: Check if Global Param can be set
 
@@ -28,6 +28,7 @@ class TestGlobalParameter(CLITestCase):
             'value': value,
         })
 
+    @run_only_on('sat')
     def test_list(self):
         """@Test: Test Global Param List
 
@@ -47,6 +48,7 @@ class TestGlobalParameter(CLITestCase):
         self.assertEqual(len(result), 1)
         self.assertEqual(result[0]['value'], value)
 
+    @run_only_on('sat')
     def test_delete(self):
         """@Test: Check if Global Param can be deleted
 

--- a/tests/foreman/cli/test_gpgkey.py
+++ b/tests/foreman/cli/test_gpgkey.py
@@ -60,7 +60,6 @@ def create_gpg_key_file(content=None):
     return None
 
 
-@run_only_on('sat')
 class TestGPGKey(CLITestCase):
     """Tests for GPG Keys via Hammer CLI"""
 
@@ -79,6 +78,7 @@ class TestGPGKey(CLITestCase):
     # Bug verification
 
     @skip_if_bug_open('redmine', 4272)
+    @run_only_on('sat')
     def test_redmine_4272(self):
         """@Test: gpg info should display key content
 
@@ -102,6 +102,7 @@ class TestGPGKey(CLITestCase):
         gpg_key = make_gpg_key(data)
         self.assertEqual(gpg_key['content'], content)
 
+    @run_only_on('sat')
     def test_info_by_name(self):
         """@Test: Create single gpg key and get its info by name
 
@@ -125,6 +126,7 @@ class TestGPGKey(CLITestCase):
     # Positive Create
 
     @skip_if_bug_open('bugzilla', 1172009)
+    @run_only_on('sat')
     def test_positive_create_1(self):
         """@test: Create gpg key with valid name and valid gpg key via file
         import using the default created organization
@@ -157,6 +159,7 @@ class TestGPGKey(CLITestCase):
                 )
 
     @skip_if_bug_open('bugzilla', 1172009)
+    @run_only_on('sat')
     def test_positive_create_2(self):
         """@test: Create gpg key with valid name and valid gpg key via file
         import using the a new organization
@@ -188,6 +191,7 @@ class TestGPGKey(CLITestCase):
     # Negative Create
 
     @skip_if_bug_open('bugzilla', 1172009)
+    @run_only_on('sat')
     def test_negative_create_1(self):
         """@test: Create gpg key with valid name and valid gpg key via file
         import then try to create new one with same name
@@ -219,6 +223,7 @@ class TestGPGKey(CLITestCase):
         with self.assertRaises(CLIReturnCodeError):
             GPGKey().create(test_data)
 
+    @run_only_on('sat')
     def test_negative_create_2(self):
         """@test: Create gpg key with valid name and no gpg key
 
@@ -236,6 +241,7 @@ class TestGPGKey(CLITestCase):
                 with self.assertRaises(CLIReturnCodeError):
                     GPGKey().create(test_data)
 
+    @run_only_on('sat')
     def test_negative_create_3(self):
         """@test: Create gpg key with invalid name and valid gpg key via
         file import
@@ -261,6 +267,7 @@ class TestGPGKey(CLITestCase):
 
     # Positive Delete
     @stubbed()
+    @run_only_on('sat')
     def test_positive_delete_1(self):
         """@test: Create gpg key with valid name and valid gpg key via file
         import then delete it
@@ -276,6 +283,7 @@ class TestGPGKey(CLITestCase):
         pass
 
     @stubbed()
+    @run_only_on('sat')
     def test_positive_delete_2(self):
         """@test: Create gpg key with valid name and valid gpg key text via
         cut and paste/string then delete it
@@ -292,6 +300,7 @@ class TestGPGKey(CLITestCase):
 
     # Negative Delete
     @stubbed()
+    @run_only_on('sat')
     def test_negative_delete_1(self):
         """@test: Create gpg key with valid name and valid gpg key via file
         import then fail to delete it
@@ -307,6 +316,7 @@ class TestGPGKey(CLITestCase):
         pass
 
     @stubbed()
+    @run_only_on('sat')
     def test_negative_delete_2(self):
         """@test: Create gpg key with valid name and valid gpg key text via
         cut and paste/string then fail to delete it
@@ -324,6 +334,7 @@ class TestGPGKey(CLITestCase):
     # Positive Update
 
     @stubbed()
+    @run_only_on('sat')
     def test_positive_update_1(self):
         """@test: Create gpg key with valid name and valid gpg key via file
         import then update its name
@@ -339,6 +350,7 @@ class TestGPGKey(CLITestCase):
         pass
 
     @stubbed()
+    @run_only_on('sat')
     def test_positive_update_2(self):
         """@test: Create gpg key with valid name and valid gpg key via file
         import then update its gpg key file
@@ -354,6 +366,7 @@ class TestGPGKey(CLITestCase):
         pass
 
     @stubbed()
+    @run_only_on('sat')
     def test_positive_update_3(self):
         """@test: Create gpg key with valid name and valid gpg key text via
         cut and paste/string then update its name
@@ -369,6 +382,7 @@ class TestGPGKey(CLITestCase):
         pass
 
     @stubbed()
+    @run_only_on('sat')
     def test_positive_update_4(self):
         """@test: Create gpg key with valid name and valid gpg key text via
         cut and paste/string then update its gpg key text
@@ -385,6 +399,7 @@ class TestGPGKey(CLITestCase):
 
     # Negative Update
     @stubbed()
+    @run_only_on('sat')
     def test_negative_update_1(self):
         """@test: Create gpg key with valid name and valid gpg key via file
         import then fail to update its name
@@ -400,6 +415,7 @@ class TestGPGKey(CLITestCase):
         pass
 
     @stubbed()
+    @run_only_on('sat')
     def test_negative_update_2(self):
         """@test: Create gpg key with valid name and valid gpg key text via
         cut and paste/string then fail to update its name
@@ -416,6 +432,7 @@ class TestGPGKey(CLITestCase):
 
     # Product association
     @stubbed()
+    @run_only_on('sat')
     def test_key_associate_1(self):
         """@test: Create gpg key with valid name and valid gpg key via file
         import then associate it with empty (no repos) custom product
@@ -431,6 +448,7 @@ class TestGPGKey(CLITestCase):
         pass
 
     @stubbed()
+    @run_only_on('sat')
     def test_key_associate_2(self):
         """@test: Create gpg key with valid name and valid gpg key via file
         import then associate it with custom product that has one repository
@@ -446,6 +464,7 @@ class TestGPGKey(CLITestCase):
         pass
 
     @stubbed()
+    @run_only_on('sat')
     def test_key_associate_3(self):
         """@test: Create gpg key with valid name and valid gpg key via file
         import then associate it with custom product that has more than one
@@ -462,6 +481,7 @@ class TestGPGKey(CLITestCase):
         pass
 
     @stubbed()
+    @run_only_on('sat')
     def test_key_associate_4(self):
         """@test: Create gpg key with valid name and valid gpg key via file
         import then associate it with custom product using Repo discovery
@@ -478,6 +498,7 @@ class TestGPGKey(CLITestCase):
         pass
 
     @stubbed()
+    @run_only_on('sat')
     def test_key_associate_5(self):
         """@test: Create gpg key with valid name and valid gpg key via file
         import then associate it to repository from custom product that has
@@ -494,6 +515,7 @@ class TestGPGKey(CLITestCase):
         pass
 
     @stubbed()
+    @run_only_on('sat')
     def test_key_associate_6(self):
         """@test: Create gpg key via file import and associate with custom repo
 
@@ -512,6 +534,7 @@ class TestGPGKey(CLITestCase):
         pass
 
     @stubbed()
+    @run_only_on('sat')
     def test_key_associate_7(self):
         """@test: Create gpg key with valid name and valid gpg key via file
         import then associate it to repos from custom product using Repo
@@ -528,6 +551,7 @@ class TestGPGKey(CLITestCase):
         pass
 
     @stubbed()
+    @run_only_on('sat')
     def test_key_associate_8(self):
         """@test: Create gpg key with valid name and valid gpg key via file
         import then associate it with empty (no repos) custom product then
@@ -544,6 +568,7 @@ class TestGPGKey(CLITestCase):
         pass
 
     @stubbed()
+    @run_only_on('sat')
     def test_key_associate_9(self):
         """@test: Create gpg key with valid name and valid gpg key via file
         import then associate it with custom product that has one repository
@@ -561,6 +586,7 @@ class TestGPGKey(CLITestCase):
         pass
 
     @stubbed()
+    @run_only_on('sat')
     def test_key_associate_10(self):
         """@test: Create gpg key with valid name and valid gpg key via file
         import then associate it with custom product that has more than one
@@ -578,6 +604,7 @@ class TestGPGKey(CLITestCase):
         pass
 
     @stubbed()
+    @run_only_on('sat')
     def test_key_associate_11(self):
         """@test: Create gpg key with valid name and valid gpg key via file
         import then associate it with custom product using Repo discovery
@@ -595,6 +622,7 @@ class TestGPGKey(CLITestCase):
         pass
 
     @stubbed()
+    @run_only_on('sat')
     def test_key_associate_12(self):
         """@test: Create gpg key with valid name and valid gpg key via file
         import then associate it to repository from custom product that has
@@ -612,6 +640,7 @@ class TestGPGKey(CLITestCase):
         pass
 
     @stubbed()
+    @run_only_on('sat')
     def test_key_associate_13(self):
         """@test: Create gpg key with valid name and valid gpg key via file
         import then associate it to repository from custom product that has
@@ -629,6 +658,7 @@ class TestGPGKey(CLITestCase):
         pass
 
     @stubbed()
+    @run_only_on('sat')
     def test_key_associate_14(self):
         """@test: Create gpg key with valid name and valid gpg key via file
         import then associate it to repos from custom product using Repo
@@ -646,6 +676,7 @@ class TestGPGKey(CLITestCase):
         pass
 
     @stubbed()
+    @run_only_on('sat')
     def test_key_associate_15(self):
         """@test: Create gpg key with valid name and valid gpg key via file
         import then associate it with empty (no repos) custom product
@@ -663,6 +694,7 @@ class TestGPGKey(CLITestCase):
         pass
 
     @stubbed()
+    @run_only_on('sat')
     def test_key_associate_16(self):
         """@test: Create gpg key with valid name and valid gpg key via file
         import then associate it with custom product that has one repository
@@ -680,6 +712,7 @@ class TestGPGKey(CLITestCase):
         pass
 
     @stubbed()
+    @run_only_on('sat')
     def test_key_associate_17(self):
         """@test: Create gpg key with valid name and valid gpg key via file
         import then associate it with custom product that has more than one
@@ -697,6 +730,7 @@ class TestGPGKey(CLITestCase):
         pass
 
     @stubbed()
+    @run_only_on('sat')
     def test_key_associate_18(self):
         """@test: Create gpg key with valid name and valid gpg key via file
         import then associate it with custom product using Repo discovery
@@ -714,6 +748,7 @@ class TestGPGKey(CLITestCase):
         pass
 
     @stubbed()
+    @run_only_on('sat')
     def test_key_associate_19(self):
         """@test: Create gpg key with valid name and valid gpg key via file
         import then associate it to repository from custom product that has
@@ -731,6 +766,7 @@ class TestGPGKey(CLITestCase):
         pass
 
     @stubbed()
+    @run_only_on('sat')
     def test_key_associate_20(self):
         """@test: Create gpg key with valid name and valid gpg key via file
         import then associate it to repository from custom product that has
@@ -748,6 +784,7 @@ class TestGPGKey(CLITestCase):
         pass
 
     @stubbed()
+    @run_only_on('sat')
     def test_key_associate_21(self):
         """@test: Create gpg key with valid name and valid gpg key via file
         import then associate it to repos from custom product using Repo
@@ -766,6 +803,7 @@ class TestGPGKey(CLITestCase):
         pass
 
     @stubbed()
+    @run_only_on('sat')
     def test_key_associate_22(self):
         """@test: Create gpg key with valid name and valid gpg key text via
         cut and paste/string then associate it with empty (no repos)
@@ -782,6 +820,7 @@ class TestGPGKey(CLITestCase):
         pass
 
     @stubbed()
+    @run_only_on('sat')
     def test_key_associate_23(self):
         """@test: Create gpg key with valid name and valid gpg key text via
         cut and paste/string then associate it with custom product that has
@@ -798,6 +837,7 @@ class TestGPGKey(CLITestCase):
         pass
 
     @stubbed()
+    @run_only_on('sat')
     def test_key_associate_24(self):
         """@test: Create gpg key with valid name and valid gpg key text via
         cut and paste/string then associate it with custom product that has
@@ -814,6 +854,7 @@ class TestGPGKey(CLITestCase):
         pass
 
     @stubbed()
+    @run_only_on('sat')
     def test_key_associate_25(self):
         """@test: Create gpg key with valid name and valid gpg key via text via
         cut and paste/string then associate it with custom product using
@@ -830,6 +871,7 @@ class TestGPGKey(CLITestCase):
         pass
 
     @stubbed()
+    @run_only_on('sat')
     def test_key_associate_26(self):
         """@test: Create gpg key with valid name and valid gpg key text via
         cut and paste/string then associate it to repository from custom
@@ -846,6 +888,7 @@ class TestGPGKey(CLITestCase):
         pass
 
     @stubbed()
+    @run_only_on('sat')
     def test_key_associate_27(self):
         """@test: Create gpg key with valid name and valid gpg key text via
         cut and paste/string then associate it to repository from custom
@@ -862,6 +905,7 @@ class TestGPGKey(CLITestCase):
         pass
 
     @stubbed()
+    @run_only_on('sat')
     def test_key_associate_28(self):
         """@test: Create gpg key with valid name and valid gpg key text via
         cut and paste/string then associate it to repos from custom product
@@ -878,6 +922,7 @@ class TestGPGKey(CLITestCase):
         pass
 
     @stubbed()
+    @run_only_on('sat')
     def test_key_associate_29(self):
         """@test: Create gpg key with valid name and valid gpg key text via
         cut and paste/string then associate it with empty (no repos)
@@ -894,6 +939,7 @@ class TestGPGKey(CLITestCase):
         pass
 
     @stubbed()
+    @run_only_on('sat')
     def test_key_associate_30(self):
         """@test: Create gpg key with valid name and valid gpg key text via
         cut and paste/string then associate it with custom product that has
@@ -911,6 +957,7 @@ class TestGPGKey(CLITestCase):
         pass
 
     @stubbed()
+    @run_only_on('sat')
     def test_key_associate_31(self):
         """@test: Create gpg key with valid name and valid gpg key text via
         cut and paste/string then associate it with custom product that has
@@ -928,6 +975,7 @@ class TestGPGKey(CLITestCase):
         pass
 
     @stubbed()
+    @run_only_on('sat')
     def test_key_associate_32(self):
         """@test: Create gpg key with valid name and valid gpg key text via
         cut and paste/string then associate it with custom product using
@@ -945,6 +993,7 @@ class TestGPGKey(CLITestCase):
         pass
 
     @stubbed()
+    @run_only_on('sat')
     def test_key_associate_33(self):
         """@test: Create gpg key with valid name and valid gpg key text via
         cut and paste/string then associate it to repository from custom
@@ -962,6 +1011,7 @@ class TestGPGKey(CLITestCase):
         pass
 
     @stubbed()
+    @run_only_on('sat')
     def test_key_associate_34(self):
         """@test: Create gpg key with valid name and valid gpg key text via
         cut and paste/string then associate it to repository from custom
@@ -979,6 +1029,7 @@ class TestGPGKey(CLITestCase):
         pass
 
     @stubbed()
+    @run_only_on('sat')
     def test_key_associate_35(self):
         """@test: Create gpg key with valid name and valid gpg key text via
         cut and paste/string then associate it to repos from custom product
@@ -996,6 +1047,7 @@ class TestGPGKey(CLITestCase):
         pass
 
     @stubbed()
+    @run_only_on('sat')
     def test_key_associate_36(self):
         """@test: Create gpg key with valid name and valid gpg key text via
         cut and paste/string then associate it with empty (no repos) custom
@@ -1013,6 +1065,7 @@ class TestGPGKey(CLITestCase):
         pass
 
     @stubbed()
+    @run_only_on('sat')
     def test_key_associate_37(self):
         """@test: Create gpg key with valid name and valid gpg key text via
         cut and paste/string then associate it with custom product that has
@@ -1030,6 +1083,7 @@ class TestGPGKey(CLITestCase):
         pass
 
     @stubbed()
+    @run_only_on('sat')
     def test_key_associate_38(self):
         """@test: Create gpg key with valid name and valid gpg key text via
         cut and paste/string then associate it with custom product that has
@@ -1047,6 +1101,7 @@ class TestGPGKey(CLITestCase):
         pass
 
     @stubbed()
+    @run_only_on('sat')
     def test_key_associate_39(self):
         """@test: Create gpg key with valid name and valid gpg key text via
         cut and paste/string then associate it with custom product using
@@ -1064,6 +1119,7 @@ class TestGPGKey(CLITestCase):
         pass
 
     @stubbed()
+    @run_only_on('sat')
     def test_key_associate_40(self):
         """@test: Create gpg key with valid name and valid gpg key text via
         cut and paste/string then associate it to repository from custom
@@ -1081,6 +1137,7 @@ class TestGPGKey(CLITestCase):
         pass
 
     @stubbed()
+    @run_only_on('sat')
     def test_key_associate_41(self):
         """@test: Create gpg key with valid name and valid gpg key text via
         cut and paste/string then associate it to repository from custom
@@ -1098,6 +1155,7 @@ class TestGPGKey(CLITestCase):
         pass
 
     @stubbed()
+    @run_only_on('sat')
     def test_key_associate_42(self):
         """@test: Create gpg key with valid name and valid gpg key text via
         cut and paste/string then associate it to repos from custom product
@@ -1118,6 +1176,7 @@ class TestGPGKey(CLITestCase):
     # Content
 
     @stubbed()
+    @run_only_on('sat')
     def test_consume_content_1(self):
         """@test: Hosts can install packages using gpg key associated with
         single custom repository
@@ -1133,6 +1192,7 @@ class TestGPGKey(CLITestCase):
         pass
 
     @stubbed()
+    @run_only_on('sat')
     def test_consume_content_2(self):
         """@test: Hosts can install packages using gpg key associated with
         multiple custom repositories
@@ -1148,6 +1208,7 @@ class TestGPGKey(CLITestCase):
         pass
 
     @stubbed()
+    @run_only_on('sat')
     def test_consume_content_3(self):
         """@test:Hosts can install packages using different gpg keys associated
         with multiple custom repositories
@@ -1165,6 +1226,7 @@ class TestGPGKey(CLITestCase):
     # Miscelaneous
 
     @stubbed()
+    @run_only_on('sat')
     def test_list_key_1(self):
         """@test: Create gpg key and list it
 
@@ -1179,6 +1241,7 @@ class TestGPGKey(CLITestCase):
         pass
 
     @stubbed()
+    @run_only_on('sat')
     def test_search_key_1(self):
         """@test: Create gpg key and search/find it
 

--- a/tests/foreman/cli/test_host_system_unification.py
+++ b/tests/foreman/cli/test_host_system_unification.py
@@ -6,7 +6,6 @@ from robottelo.decorators import run_only_on, stubbed
 from robottelo.test import CLITestCase
 
 
-@run_only_on('sat')
 class TestHostSystemUnificationCLI(CLITestCase):
     """Test Class for Host/System Unification CLI"""
     # Testing notes for host/system unification in katello/foreman:
@@ -21,6 +20,7 @@ class TestHostSystemUnificationCLI(CLITestCase):
     # fuzzy like hostname"
 
     @stubbed()
+    @run_only_on('sat')
     def test_all_hosts_appear_in_foreman(self):
         """@test: Hosts registered to Katello via rhsm appear in foreman
 
@@ -39,6 +39,7 @@ class TestHostSystemUnificationCLI(CLITestCase):
         pass
 
     @stubbed()
+    @run_only_on('sat')
     def test_all_hosts_appear_in_katello(self):
         """@test: Hosts provisioned in foreman via appear in katello
 

--- a/tests/foreman/cli/test_hostgroup.py
+++ b/tests/foreman/cli/test_hostgroup.py
@@ -16,7 +16,6 @@ from robottelo.decorators import run_only_on
 from robottelo.test import MetaCLITestCase
 
 
-@run_only_on('sat')
 class TestHostGroup(MetaCLITestCase):
     """Test class for Host Group CLI"""
     factory = make_hostgroup
@@ -44,6 +43,7 @@ class TestHostGroup(MetaCLITestCase):
          {'name': ''}),
     )
 
+    @run_only_on('sat')
     def test_create_hostgroup_with_environment(self):
         """@Test: Check if hostgroup with environment can be created
 
@@ -56,6 +56,7 @@ class TestHostGroup(MetaCLITestCase):
         hostgroup = make_hostgroup({'environment-id': environment['id']})
         self.assertEqual(environment['name'], hostgroup['environment'])
 
+    @run_only_on('sat')
     def test_create_hostgroup_with_location(self):
         """@Test: Check if hostgroup with location can be created
 
@@ -68,6 +69,7 @@ class TestHostGroup(MetaCLITestCase):
         hostgroup = make_hostgroup({'location-ids': location['id']})
         self.assertIn(location['name'], hostgroup['locations'])
 
+    @run_only_on('sat')
     def test_create_hostgroup_with_operating_system(self):
         """@Test: Check if hostgroup with operating system can be created
 
@@ -80,6 +82,7 @@ class TestHostGroup(MetaCLITestCase):
         hostgroup = make_hostgroup({'operatingsystem-id': os['id']})
         self.assertEqual(hostgroup['operating-system'], os['title'])
 
+    @run_only_on('sat')
     def test_create_hostgroup_with_organization(self):
         """@Test: Check if hostgroup with organization can be created
 
@@ -92,6 +95,7 @@ class TestHostGroup(MetaCLITestCase):
         hostgroup = make_hostgroup({'organization-ids': org['id']})
         self.assertIn(org['name'], hostgroup['organizations'])
 
+    @run_only_on('sat')
     def test_create_hostgroup_with_puppet_ca_proxy(self):
         """@Test: Check if hostgroup with puppet CA proxy server can be created
 
@@ -104,6 +108,7 @@ class TestHostGroup(MetaCLITestCase):
         hostgroup = make_hostgroup({'puppet-ca-proxy': puppet_proxy['name']})
         self.assertEqual(puppet_proxy['id'], hostgroup['puppet-ca-proxy-id'])
 
+    @run_only_on('sat')
     def test_create_hostgroup_with_puppet_proxy(self):
         """@Test: Check if hostgroup with puppet proxy server can be created
 

--- a/tests/foreman/cli/test_installer.py
+++ b/tests/foreman/cli/test_installer.py
@@ -5,7 +5,6 @@ from robottelo.decorators import run_only_on, stubbed
 from robottelo.test import CLITestCase
 
 
-@run_only_on('sat')
 class TestSSOCLI(CLITestCase):
     """Test class for installer"""
     # Notes for installer testing:
@@ -14,6 +13,7 @@ class TestSSOCLI(CLITestCase):
     # error-prone) than simply grepping for ERROR/FATAL
 
     @stubbed()
+    @run_only_on('sat')
     def test_installer_check_services(self):
         # devnote:
         # maybe `hammer ping` command might be useful here to check
@@ -32,6 +32,7 @@ class TestSSOCLI(CLITestCase):
         pass
 
     @stubbed()
+    @run_only_on('sat')
     def test_installer_logfile_check(self):
         """@test: Look for ERROR or FATAL references in logfiles
 
@@ -50,6 +51,7 @@ class TestSSOCLI(CLITestCase):
         pass
 
     @stubbed()
+    @run_only_on('sat')
     def test_installer_check_progress_meter(self):
         """@test:  Assure progress indicator/meter "works"
 
@@ -64,6 +66,7 @@ class TestSSOCLI(CLITestCase):
         pass
 
     @stubbed()
+    @run_only_on('sat')
     def test_installer_from_iso(self):
         """@test:  Can install product from ISO
 
@@ -77,6 +80,7 @@ class TestSSOCLI(CLITestCase):
         pass
 
     @stubbed()
+    @run_only_on('sat')
     def test_installer_server_install(self):
         """@test:  Can install main satellite instance successfully via RPM
 
@@ -90,6 +94,7 @@ class TestSSOCLI(CLITestCase):
         pass
 
     @stubbed()
+    @run_only_on('sat')
     def test_installer_node_install(self):
         """@test:  Can install node successfully via RPM
 
@@ -103,6 +108,7 @@ class TestSSOCLI(CLITestCase):
         pass
 
     @stubbed()
+    @run_only_on('sat')
     def test_installer_smartproxy_install(self):
         """@test:  Can install smart-proxy successfully via RPM
 
@@ -116,6 +122,7 @@ class TestSSOCLI(CLITestCase):
         pass
 
     @stubbed()
+    @run_only_on('sat')
     def test_installer_disconnected_util_install(self):
         """@test:  Can install  satellite disconnected utility successfully
         via RPM
@@ -130,6 +137,7 @@ class TestSSOCLI(CLITestCase):
         pass
 
     @stubbed()
+    @run_only_on('sat')
     def test_installer_smartproxy_registers(self):
         """@test: Upon installation, smart-proxy instance self-registers
         itself to parent instance
@@ -145,6 +153,7 @@ class TestSSOCLI(CLITestCase):
         pass
 
     @stubbed()
+    @run_only_on('sat')
     def test_installer_clear_data(self):
         """@test:  User can run installer to clear existing data
 

--- a/tests/foreman/cli/test_lifecycleenvironment.py
+++ b/tests/foreman/cli/test_lifecycleenvironment.py
@@ -12,7 +12,6 @@ from robottelo.helpers import valid_data_list
 from robottelo.test import CLITestCase
 
 
-@run_only_on('sat')
 class TestLifeCycleEnvironment(CLITestCase):
     """Test class for Lifecycle Environment CLI"""
 
@@ -27,6 +26,7 @@ class TestLifeCycleEnvironment(CLITestCase):
             TestLifeCycleEnvironment.org = make_org()
 
     # Issues validation
+    @run_only_on('sat')
     def test_bugzilla_1077386(self):
         """@Test: List subcommand returns standard output
 
@@ -47,6 +47,7 @@ class TestLifeCycleEnvironment(CLITestCase):
         )
         self.assertGreater(len(result), 0)
 
+    @run_only_on('sat')
     def test_bugzilla_1077333(self):
         """@Test: Search lifecycle environment via its name containing UTF-8
         chars
@@ -68,6 +69,7 @@ class TestLifeCycleEnvironment(CLITestCase):
         self.assertEqual(result['name'], test_data['name'])
 
     # CRUD
+    @run_only_on('sat')
     def test_positive_create_1(self):
         """@Test: Create lifecycle environment with valid name, prior to
         Library
@@ -86,6 +88,7 @@ class TestLifeCycleEnvironment(CLITestCase):
                 self.assertEqual(
                     lc_env['prior-lifecycle-environment'], ENVIRONMENT)
 
+    @run_only_on('sat')
     def test_positive_create_2(self):
         """@Test: Create lifecycle environment with valid description prior to
         Library
@@ -108,6 +111,7 @@ class TestLifeCycleEnvironment(CLITestCase):
                 self.assertEqual(
                     lc_env['prior-lifecycle-environment'], ENVIRONMENT)
 
+    @run_only_on('sat')
     def test_create_lifecycle_environment_by_label(self):
         """@Test: Create lifecycle environment with valid name and label
 
@@ -126,6 +130,7 @@ class TestLifeCycleEnvironment(CLITestCase):
                 })
                 self.assertEqual(new_lce['label'], label)
 
+    @run_only_on('sat')
     def test_create_lifecycle_environment_by_organization_name(self):
         """@Test: Create lifecycle environment, specifying organization name
 
@@ -140,6 +145,7 @@ class TestLifeCycleEnvironment(CLITestCase):
         })
         self.assertEqual(new_lce['organization'], self.org['name'])
 
+    @run_only_on('sat')
     def test_create_lifecycle_environment_by_organization_label(self):
         """@Test: Create lifecycle environment, specifying organization label
 
@@ -154,6 +160,7 @@ class TestLifeCycleEnvironment(CLITestCase):
         })
         self.assertEqual(new_lce['organization'], self.org['name'])
 
+    @run_only_on('sat')
     def test_positive_delete_1(self):
         """@Test: Create lifecycle environment with valid name, prior to
         Library
@@ -176,6 +183,7 @@ class TestLifeCycleEnvironment(CLITestCase):
                         'organization-id': self.org['id'],
                     })
 
+    @run_only_on('sat')
     def test_positive_update_1(self):
         """@Test: Create lifecycle environment then update its name
 
@@ -202,6 +210,7 @@ class TestLifeCycleEnvironment(CLITestCase):
                 self.assertGreater(len(result), 0)
                 self.assertEqual(result['name'], new_name)
 
+    @run_only_on('sat')
     def test_positive_update_2(self):
         """@Test: Create lifecycle environment then update its description
 
@@ -228,6 +237,7 @@ class TestLifeCycleEnvironment(CLITestCase):
                 self.assertGreater(len(result), 0)
                 self.assertEqual(result['description'], new_desc)
 
+    @run_only_on('sat')
     def test_environment_paths(self):
         """@Test: List the environment paths under a given organization
 

--- a/tests/foreman/cli/test_medium.py
+++ b/tests/foreman/cli/test_medium.py
@@ -22,9 +22,9 @@ OSES = [
 ]
 
 
-@run_only_on('sat')
 class TestMedium(CLITestCase):
     """Test class for Medium CLI"""
+    @run_only_on('sat')
     def test_positive_create_1(self):
         """@Test: Check if Medium can be created
 
@@ -38,6 +38,7 @@ class TestMedium(CLITestCase):
                 medium = make_medium({'name': name})
                 self.assertEqual(medium['name'], name)
 
+    @run_only_on('sat')
     def test_create_medium_with_location(self):
         """@Test: Check if medium with location can be created
 
@@ -50,6 +51,7 @@ class TestMedium(CLITestCase):
         medium = make_medium({'location-ids': location['id']})
         self.assertIn(location['name'], medium['locations'])
 
+    @run_only_on('sat')
     def test_create_medium_with_organization(self):
         """@Test: Check if medium with organization can be created
 
@@ -62,6 +64,7 @@ class TestMedium(CLITestCase):
         medium = make_medium({'organization-ids': org['id']})
         self.assertIn(org['name'], medium['organizations'])
 
+    @run_only_on('sat')
     def test_positive_delete_1(self):
         """@Test: Check if Medium can be deleted
 
@@ -78,6 +81,7 @@ class TestMedium(CLITestCase):
                     Medium.info({'id': medium['id']})
 
     # pylint: disable=no-self-use
+    @run_only_on('sat')
     def test_add_operatingsystem_medium(self):
         """@Test: Check if Medium can be associated with operating system
 
@@ -93,6 +97,7 @@ class TestMedium(CLITestCase):
             'operatingsystem-id': os['id'],
         })
 
+    @run_only_on('sat')
     def test_removeoperatingsystem_medium(self):
         """@Test: Check if operating system can be removed from media
 
@@ -116,6 +121,7 @@ class TestMedium(CLITestCase):
         medium = Medium.info({'id': medium['id']})
         self.assertNotIn(os['name'], medium['operating-systems'])
 
+    @run_only_on('sat')
     def test_medium_update(self):
         """@Test: Check if medium can be updated
 

--- a/tests/foreman/cli/test_model.py
+++ b/tests/foreman/cli/test_model.py
@@ -8,13 +8,13 @@ from robottelo.decorators import run_only_on
 from robottelo.test import MetaCLITestCase
 
 
-@run_only_on('sat')
 class TestModel(MetaCLITestCase):
     """Test class for Model CLI"""
     factory = make_model
     factory_obj = Model
 
     # pylint: disable=no-self-use
+    @run_only_on('sat')
     def test_create_model_1(self):
         """@Test: Check if Model can be created
 
@@ -25,6 +25,7 @@ class TestModel(MetaCLITestCase):
         """
         make_model()
 
+    @run_only_on('sat')
     def test_create_model_2(self):
         """@Test: Check if Model can be created with specific vendor class
 
@@ -37,6 +38,7 @@ class TestModel(MetaCLITestCase):
         model = make_model({'vendor-class': vendor_class})
         self.assertEqual(model['vendor-class'], vendor_class)
 
+    @run_only_on('sat')
     def test_update_model(self):
         """@Test: Check if Model can be updated
 

--- a/tests/foreman/cli/test_os.py
+++ b/tests/foreman/cli/test_os.py
@@ -25,12 +25,12 @@ NEGATIVE_DELETE_DATA = (
 )
 
 
-@run_only_on('sat')
 class TestOperatingSystem(CLITestCase):
     """Test class for Operating System CLI."""
 
     # Issues
     @skip_if_bug_open('redmine', 4547)
+    @run_only_on('sat')
     def test_redmine_4547(self):
         """@test: Search for newly created OS by name
 
@@ -49,6 +49,7 @@ class TestOperatingSystem(CLITestCase):
         os_list_after = OperatingSys.list()
         self.assertGreater(len(os_list_after), len(os_list_before))
 
+    @run_only_on('sat')
     def test_bugzilla_1051557(self):
         """@test: Update an Operating System's major version.
 
@@ -69,6 +70,7 @@ class TestOperatingSystem(CLITestCase):
         })
         self.assertEqual(int(os['major-version']), major)
 
+    @run_only_on('sat')
     def test_bugzilla_1203457(self):
         """@test: Create an OS pointing to an arch, medium and partition table.
 
@@ -96,6 +98,7 @@ class TestOperatingSystem(CLITestCase):
         self.assertEqual(
             operating_system['partition-tables'][0], ptable['name'])
 
+    @run_only_on('sat')
     def test_list_1(self):
         """@test: Displays list for operating system
 
@@ -113,6 +116,7 @@ class TestOperatingSystem(CLITestCase):
         os_list_after = OperatingSys.list()
         self.assertGreater(len(os_list_after), len(os_list_before))
 
+    @run_only_on('sat')
     def test_info_1(self):
         """@test: Displays info for operating system
 
@@ -130,6 +134,7 @@ class TestOperatingSystem(CLITestCase):
         self.assertEqual(str(os['major-version']), os_info['major-version'])
         self.assertEqual(str(os['minor-version']), os_info['minor-version'])
 
+    @run_only_on('sat')
     def test_positive_create_1(self):
         """@test: Create Operating System for all variations of name
 
@@ -143,6 +148,7 @@ class TestOperatingSystem(CLITestCase):
                 os = make_os({'name': name})
                 self.assertEqual(os['name'], name)
 
+    @run_only_on('sat')
     def test_negative_create_1(self):
         """@test: Create Operating System using invalid names
 
@@ -156,6 +162,7 @@ class TestOperatingSystem(CLITestCase):
                 with self.assertRaises(CLIFactoryError):
                     make_os({'name': name})
 
+    @run_only_on('sat')
     def test_positive_update_1(self):
         """@test: Positive update of system name
 
@@ -175,6 +182,7 @@ class TestOperatingSystem(CLITestCase):
                 self.assertEqual(result['id'], os['id'], )
                 self.assertNotEqual(result['name'], os['name'])
 
+    @run_only_on('sat')
     def test_negative_update_1(self):
         """@test: Negative update of system name
 
@@ -194,6 +202,7 @@ class TestOperatingSystem(CLITestCase):
                 result = OperatingSys.info({'id': os['id']})
                 self.assertEqual(result['name'], os['name'])
 
+    @run_only_on('sat')
     def test_positive_delete_1(self):
         """@test: Successfully deletes Operating System
 
@@ -209,6 +218,7 @@ class TestOperatingSystem(CLITestCase):
                 with self.assertRaises(CLIReturnCodeError):
                     OperatingSys.info({'id': os['id']})
 
+    @run_only_on('sat')
     def test_negative_delete_1(self):
         """@test: Not delete Operating System for invalid data
 
@@ -228,6 +238,7 @@ class TestOperatingSystem(CLITestCase):
                 self.assertEqual(os['id'], result['id'])
                 self.assertEqual(os['name'], result['name'])
 
+    @run_only_on('sat')
     def test_add_architecture(self):
         """@test: Add Architecture to os
 
@@ -246,6 +257,7 @@ class TestOperatingSystem(CLITestCase):
         self.assertEqual(len(os['architectures']), 1)
         self.assertEqual(architecture['name'], os['architectures'][0])
 
+    @run_only_on('sat')
     def test_add_configtemplate(self):
         """@test: Add configtemplate to os
 
@@ -265,6 +277,7 @@ class TestOperatingSystem(CLITestCase):
         template_name = os['templates'][0]
         self.assertTrue(template_name.startswith(template['name']))
 
+    @run_only_on('sat')
     def test_add_ptable(self):
         """@test: Add ptable to os
 

--- a/tests/foreman/cli/test_partitiontable.py
+++ b/tests/foreman/cli/test_partitiontable.py
@@ -9,7 +9,6 @@ from robottelo.decorators import run_only_on
 from robottelo.test import CLITestCase
 
 
-@run_only_on('sat')
 class TestPartitionTableUpdateCreate(CLITestCase):
     """Test case for CLI tests."""
 
@@ -21,6 +20,7 @@ class TestPartitionTableUpdateCreate(CLITestCase):
         self.args = {'name': self.name,
                      'content': self.content}
 
+    @run_only_on('sat')
     def test_create_ptable(self):
         """@Test: Check if Partition Table can be created
 
@@ -32,6 +32,7 @@ class TestPartitionTableUpdateCreate(CLITestCase):
         ptable = make_partition_table(self.args)
         self.assertEqual(ptable['name'], self.name)
 
+    @run_only_on('sat')
     def test_update_ptable(self):
         """@Test: Check if Partition Table can be updated
 

--- a/tests/foreman/cli/test_proxy.py
+++ b/tests/foreman/cli/test_proxy.py
@@ -13,7 +13,6 @@ from robottelo.helpers import valid_data_list
 from robottelo.test import CLITestCase
 
 
-@run_only_on('sat')
 class TestProxy(CLITestCase):
     """Proxy cli tests"""
 
@@ -21,6 +20,7 @@ class TestProxy(CLITestCase):
         """Skipping tests until we can create ssh tunnels"""
         self.skipTest('Skipping tests until we can create ssh tunnels')
 
+    @run_only_on('sat')
     def test_redmine_3875(self):
         """@Test: Proxy creation with random URL
 
@@ -37,6 +37,7 @@ class TestProxy(CLITestCase):
                     gen_string('numeric', 4)),
             })
 
+    @run_only_on('sat')
     def test_proxy_create(self):
         """@Test: Proxy creation with the home proxy
 
@@ -50,6 +51,7 @@ class TestProxy(CLITestCase):
                 proxy = make_proxy({u'name': name})
                 self.assertEquals(proxy['name'], name)
 
+    @run_only_on('sat')
     def test_proxy_delete(self):
         """@Test: Proxy deletion with the home proxy
 
@@ -65,6 +67,7 @@ class TestProxy(CLITestCase):
                 with self.assertRaises(CLIReturnCodeError):
                     Proxy.info({u'id': proxy['id']})
 
+    @run_only_on('sat')
     def test_proxy_update(self):
         """@Test: Proxy name update with the home proxy
 
@@ -86,6 +89,7 @@ class TestProxy(CLITestCase):
                     proxy = Proxy.info({u'id': proxy['id']})
                     self.assertEqual(proxy['name'], new_name)
 
+    @run_only_on('sat')
     def test_refresh_refresh_features_by_id(self):
         """@Test: Refresh smart proxy features, search for proxy by id
 
@@ -97,6 +101,7 @@ class TestProxy(CLITestCase):
         proxy = make_proxy()
         Proxy.refresh_features({u'id': proxy['id']})
 
+    @run_only_on('sat')
     def test_proxy_refresh_features_by_name(self):
         """@Test: Refresh smart proxy features, search for proxy by name
 

--- a/tests/foreman/cli/test_puppetmodule.py
+++ b/tests/foreman/cli/test_puppetmodule.py
@@ -9,7 +9,6 @@ from robottelo.decorators import run_only_on
 from robottelo.test import CLITestCase
 
 
-@run_only_on('sat')
 class TestPuppetModule(CLITestCase):
     """Tests for PuppetModule via Hammer CLI"""
 
@@ -28,6 +27,7 @@ class TestPuppetModule(CLITestCase):
         })
         Repository.synchronize({'id': cls.repo['id']})
 
+    @run_only_on('sat')
     def test_puppet_module_list(self):
         """@Test: Check if puppet-module list retrieves puppet-modules of
         the given org
@@ -41,6 +41,7 @@ class TestPuppetModule(CLITestCase):
         # There are 4 puppet modules in the test puppet-module url
         self.assertEqual(len(result), 4)
 
+    @run_only_on('sat')
     def test_puppet_module_info(self):
         """@Test: Check if puppet-module info retrieves info for the given
         puppet-module id

--- a/tests/foreman/cli/test_report.py
+++ b/tests/foreman/cli/test_report.py
@@ -11,7 +11,6 @@ from robottelo.decorators import run_only_on
 from robottelo.test import CLITestCase
 
 
-@run_only_on('sat')
 class TestReport(CLITestCase):
     """Test class for Reports CLI. """
 
@@ -19,6 +18,7 @@ class TestReport(CLITestCase):
         super(TestReport, self).setUp()
         self.run_puppet_agent()
 
+    @run_only_on('sat')
     def run_puppet_agent(self):
         """Retrieves the client configuration from the puppet master and
         applies it to the local host. This is required to make sure
@@ -27,6 +27,7 @@ class TestReport(CLITestCase):
         """
         ssh.command('puppet agent -t')
 
+    @run_only_on('sat')
     def test_list(self):
         """@Test: Test list for Puppet report
 
@@ -37,6 +38,7 @@ class TestReport(CLITestCase):
         """
         Report.list()
 
+    @run_only_on('sat')
     def test_info(self):
         """@Test: Test Info for Puppet report
 
@@ -52,6 +54,7 @@ class TestReport(CLITestCase):
         result = Report.info({'id': report['id']})
         self.assertEqual(report['id'], result['id'])
 
+    @run_only_on('sat')
     def test_delete(self):
         """@Test: Check if Puppet Report can be deleted
 

--- a/tests/foreman/cli/test_scparam.py
+++ b/tests/foreman/cli/test_scparam.py
@@ -8,10 +8,10 @@ from robottelo.test import CLITestCase
 
 
 # pylint: disable=no-self-use
-@run_only_on('sat')
 class TestSmartClassParameter(CLITestCase):
     """Test class for Smart Class Parameter CLI."""
 
+    @run_only_on('sat')
     def run_puppet_module(self):
         """Import some parameterized puppet class. This is required to make
         sure that we have smart class variable available.
@@ -19,6 +19,7 @@ class TestSmartClassParameter(CLITestCase):
         """
         ssh.command('puppet module install --force puppetlabs/ntp')
 
+    @run_only_on('sat')
     def test_bugzilla_1047794(self):
         """@Test: Check if SmartClass Paramter Info generates an error
 

--- a/tests/foreman/cli/test_subnet.py
+++ b/tests/foreman/cli/test_subnet.py
@@ -47,10 +47,10 @@ def invalid_missing_attributes():
     )
 
 
-@run_only_on('sat')
 class TestSubnet(CLITestCase):
     """Subnet CLI tests."""
 
+    @run_only_on('sat')
     def test_positive_create_1(self):
         """@Test: Check if Subnet can be created with random names
 
@@ -64,6 +64,7 @@ class TestSubnet(CLITestCase):
                 subnet = make_subnet({'name': name})
                 self.assertEqual(subnet['name'], name)
 
+    @run_only_on('sat')
     def test_positive_create_2(self):
         """@Test: Create subnet with valid address pool
 
@@ -89,6 +90,7 @@ class TestSubnet(CLITestCase):
                 self.assertEqual(subnet['from'], from_ip)
                 self.assertEqual(subnet['to'], to_ip)
 
+    @run_only_on('sat')
     def test_create_subnet_with_domain(self):
         """@Test: Check if subnet with domain can be created
 
@@ -101,6 +103,7 @@ class TestSubnet(CLITestCase):
         subnet = make_subnet({'domain-ids': domain['id']})
         self.assertIn(domain['name'], subnet['domains'])
 
+    @run_only_on('sat')
     def test_create_subnet_with_domains(self):
         """@Test: Check if subnet with different amount of domains can be
         created in the system
@@ -119,6 +122,7 @@ class TestSubnet(CLITestCase):
         for domain in domains:
             self.assertIn(domain['name'], subnet['domains'])
 
+    @run_only_on('sat')
     def test_create_subnet_with_gateway(self):
         """@Test: Check if subnet with gateway can be created
 
@@ -132,6 +136,7 @@ class TestSubnet(CLITestCase):
         self.assertIn(gateway, subnet['gateway'])
 
     @skip_if_bug_open('bugzilla', 1213437)
+    @run_only_on('sat')
     def test_create_subnet_with_ipam(self):
         """@Test: Check if subnet with different ipam types can be created
 
@@ -149,6 +154,7 @@ class TestSubnet(CLITestCase):
                 subnet = make_subnet({'ipam': ipam_type})
                 self.assertIn(ipam_type, subnet['ipam'])
 
+    @run_only_on('sat')
     def test_negative_create_1(self):
         """@Test: Create subnet with invalid or missing required attributes
 
@@ -162,6 +168,7 @@ class TestSubnet(CLITestCase):
                 with self.assertRaises(CLIFactoryError):
                     make_subnet(options)
 
+    @run_only_on('sat')
     def test_negative_create_2(self):
         """@Test: Create subnet with invalid address pool range
 
@@ -181,6 +188,7 @@ class TestSubnet(CLITestCase):
                 with self.assertRaises(CLIFactoryError):
                     make_subnet(opts)
 
+    @run_only_on('sat')
     def test_list(self):
         """@Test: Check if Subnet can be listed
 
@@ -197,6 +205,7 @@ class TestSubnet(CLITestCase):
         subnets_after = Subnet.list()
         self.assertGreater(len(subnets_after), len(subnets_before))
 
+    @run_only_on('sat')
     def test_positive_update_1(self):
         """@Test: Check if Subnet name can be updated
 
@@ -212,6 +221,7 @@ class TestSubnet(CLITestCase):
                 result = Subnet.info({'id': new_subnet['id']})
                 self.assertEqual(result['name'], new_name)
 
+    @run_only_on('sat')
     def test_positive_update_2(self):
         """@Test: Check if Subnet network and mask can be updated
 
@@ -238,6 +248,7 @@ class TestSubnet(CLITestCase):
         self.assertEqual(subnet['network'], new_network)
         self.assertEqual(subnet['mask'], new_mask)
 
+    @run_only_on('sat')
     def test_positive_update_3(self):
         """@Test: Check if Subnet address pool can be updated
 
@@ -262,6 +273,7 @@ class TestSubnet(CLITestCase):
                 self.assertEqual(subnet['from'], ip_from)
                 self.assertEqual(subnet['to'], ip_to)
 
+    @run_only_on('sat')
     def test_negative_update_1(self):
         """@Test: Update subnet with invalid or missing required attributes
 
@@ -281,6 +293,7 @@ class TestSubnet(CLITestCase):
                     for key in options.keys():
                         self.assertEqual(subnet[key], result[key])
 
+    @run_only_on('sat')
     def test_negative_update_2(self):
         """@Test: Update subnet with invalid address pool
 
@@ -303,6 +316,7 @@ class TestSubnet(CLITestCase):
                 for key in options.keys():
                     self.assertEqual(result[key], subnet[key])
 
+    @run_only_on('sat')
     def test_positive_delete_1(self):
         """@Test: Check if Subnet can be deleted
 

--- a/tests/foreman/cli/test_template.py
+++ b/tests/foreman/cli/test_template.py
@@ -15,10 +15,10 @@ from robottelo.decorators import run_only_on
 from robottelo.test import CLITestCase
 
 
-@run_only_on('sat')
 class TestTemplate(CLITestCase):
     """Test class for Config Template CLI."""
 
+    @run_only_on('sat')
     def test_create_template_1(self):
         """@Test: Check if Template can be created
 
@@ -31,6 +31,7 @@ class TestTemplate(CLITestCase):
         template = make_template({'name': name})
         self.assertEqual(template['name'], name)
 
+    @run_only_on('sat')
     def test_update_template_1(self):
         """@Test: Check if Template can be updated
 
@@ -48,6 +49,7 @@ class TestTemplate(CLITestCase):
         template = Template.info({'id': template['id']})
         self.assertEqual(updated_name, template['name'])
 
+    @run_only_on('sat')
     def test_create_template_with_loc(self):
         """@Test: Check if Template with Location can be created
 
@@ -60,6 +62,7 @@ class TestTemplate(CLITestCase):
         new_template = make_template({'location-ids': new_loc['id']})
         self.assertIn(new_loc['name'], new_template['locations'])
 
+    @run_only_on('sat')
     def test_create_template_locked(self):
         """@Test: Check that locked Template cannot be created
 
@@ -74,6 +77,7 @@ class TestTemplate(CLITestCase):
                 'name': gen_string('alpha'),
             })
 
+    @run_only_on('sat')
     def test_create_template_with_org(self):
         """@Test: Check if Template with Organization can be created
 
@@ -89,6 +93,7 @@ class TestTemplate(CLITestCase):
         })
         self.assertIn(new_org['name'], new_template['organizations'])
 
+    @run_only_on('sat')
     def test_add_operating_system_1(self):
         """@Test: Check if Template can be assigned operating system
 
@@ -108,6 +113,7 @@ class TestTemplate(CLITestCase):
             new_os['name'], new_os['major-version'], new_os['minor-version'])
         self.assertIn(os_string, new_template['operating-systems'])
 
+    @run_only_on('sat')
     def test_remove_operating_system_1(self):
         """@Test: Check if OS can be removed Template
 
@@ -134,6 +140,7 @@ class TestTemplate(CLITestCase):
         template = Template.info({'id': template['id']})
         self.assertNotIn(os_string, template['operating-systems'])
 
+    @run_only_on('sat')
     def test_dump_template_1(self):
         """@Test: Check if Template can be created with specific content
 
@@ -152,6 +159,7 @@ class TestTemplate(CLITestCase):
         template_content = Template.dump({'id': template['id']})
         self.assertIn(content, template_content[0])
 
+    @run_only_on('sat')
     def test_delete_template_1(self):
         """@Test: Check if Template can be deleted
 

--- a/tests/foreman/longrun/test_inc_updates.py
+++ b/tests/foreman/longrun/test_inc_updates.py
@@ -19,7 +19,6 @@ from robottelo.test import TestCase
 from robottelo.vm import VirtualMachine
 
 
-@run_only_on('sat')
 class TestIncrementalUpdate(TestCase):
     """Tests for the Incremental Update feature"""
 
@@ -223,6 +222,7 @@ class TestIncrementalUpdate(TestCase):
             query={'errata_restrict_applicable': True}
         )
 
+    @run_only_on('sat')
     def test_api_inc_update_noapply(self):
         """@Test: Check if api incremental update can be done without
         actually applying it
@@ -269,6 +269,7 @@ class TestIncrementalUpdate(TestCase):
         )
 
     @skip_if_bug_open('bugzilla', 1259057)
+    @run_only_on('sat')
     def test_cli_inc_update_noapply(self):
         """@Test: Check if cli incremental update can be done without
         actually applying it

--- a/tests/foreman/longrun/test_oscap.py
+++ b/tests/foreman/longrun/test_oscap.py
@@ -26,7 +26,6 @@ from robottelo.ui.session import Session
 from robottelo.vm import VirtualMachine
 
 
-@run_only_on('sat')
 class OpenScap(UITestCase):
     """Implements Product tests in UI"""
 
@@ -118,6 +117,7 @@ class OpenScap(UITestCase):
                 u'value': u'1',
             }})
 
+    @run_only_on('sat')
     def test_oscap_reports(self):
         """@Test: Perform end to end oscap test.
 

--- a/tests/foreman/ui/test_architecture.py
+++ b/tests/foreman/ui/test_architecture.py
@@ -11,7 +11,6 @@ from robottelo.ui.locators import common_locators
 from robottelo.ui.session import Session
 
 
-@run_only_on('sat')
 @ddt
 class Architecture(UITestCase):
     """Implements Architecture tests from UI"""
@@ -24,6 +23,7 @@ class Architecture(UITestCase):
            u'os_name': gen_string('utf8')},
           {u'name': gen_string('alphanumeric'),
            u'os_name': gen_string('alphanumeric')})
+    @run_only_on('sat')
     def test_positive_create_arch_with_os(self, test_data):
         """@Test: Create a new Architecture with OS
 
@@ -39,6 +39,7 @@ class Architecture(UITestCase):
             self.assertIsNotNone(self.architecture.search(test_data['name']))
 
     @data(*generate_strings_list())
+    @run_only_on('sat')
     def test_positive_create_arch_with_different_names(self, name):
         """@Test: Create a new Architecture with different data
 
@@ -52,6 +53,7 @@ class Architecture(UITestCase):
             self.assertIsNotNone(self.architecture.search(name))
 
     @data(*invalid_values_list())
+    @run_only_on('sat')
     def test_negative_create_arch(self, name):
         """@Test: Try to create architecture and use whitespace, blank, tab
         symbol or too long string of different types as its name value
@@ -67,6 +69,7 @@ class Architecture(UITestCase):
                                  (common_locators['name_haserror']))
 
     @data(*generate_strings_list())
+    @run_only_on('sat')
     def test_negative_create_arch_with_same_name(self, name):
         """@Test: Create a new Architecture with same name
 
@@ -83,6 +86,7 @@ class Architecture(UITestCase):
                                  (common_locators['name_haserror']))
 
     @data(*generate_strings_list())
+    @run_only_on('sat')
     def test_remove_architecture(self, name):
         """@Test: Delete an existing Architecture
 
@@ -98,6 +102,7 @@ class Architecture(UITestCase):
             self.architecture.delete(name)
 
     @data(*generate_strings_list())
+    @run_only_on('sat')
     def test_update_arch(self, name):
         """@Test: Update Architecture with new name and OS
 

--- a/tests/foreman/ui/test_computeresource.py
+++ b/tests/foreman/ui/test_computeresource.py
@@ -13,7 +13,6 @@ from robottelo.ui.locators import common_locators
 from robottelo.ui.session import Session
 
 
-@run_only_on('sat')
 class ComputeResource(UITestCase):
     """Implements Compute Resource tests in UI"""
 
@@ -23,6 +22,7 @@ class ComputeResource(UITestCase):
             LIBVIRT_RESOURCE_URL % settings.server.hostname
         )
 
+    @run_only_on('sat')
     def test_create_libvirt_resource_different_names(self):
         """@Test: Create a new libvirt Compute Resource using different value
         types as a name
@@ -46,6 +46,7 @@ class ComputeResource(UITestCase):
                     search = self.compute_resource.search(name)
                     self.assertIsNotNone(search)
 
+    @run_only_on('sat')
     def test_create_libvirt_resource_description(self):
         """@Test: Create libvirt Compute Resource with description.
 
@@ -70,6 +71,7 @@ class ComputeResource(UITestCase):
                     search = self.compute_resource.search(name)
                     self.assertIsNotNone(search)
 
+    @run_only_on('sat')
     def test_create_libvirt_resource_display_type(self):
         """@Test: Create libvirt Compute Resource with different display types.
 
@@ -94,6 +96,7 @@ class ComputeResource(UITestCase):
                     search = self.compute_resource.search(name)
                     self.assertIsNotNone(search)
 
+    @run_only_on('sat')
     def test_create_libvirt_resource_console_pass(self):
         """@Test: Create libvirt Compute Resource with checked/unchecked
         console password checkbox
@@ -119,6 +122,7 @@ class ComputeResource(UITestCase):
                     search = self.compute_resource.search(name)
                     self.assertIsNotNone(search)
 
+    @run_only_on('sat')
     def test_create_libvirt_resource_different_names_negative(self):
         """@Test: Create a new libvirt Compute Resource with incorrect values
         only
@@ -146,6 +150,7 @@ class ComputeResource(UITestCase):
                         )
                     )
 
+    @run_only_on('sat')
     def test_create_libvirt_resource_description_negative(self):
         """@Test: Create libvirt Compute Resource with incorrect description.
 
@@ -170,6 +175,7 @@ class ComputeResource(UITestCase):
                         common_locators["haserror"])
                     self.assertIsNotNone(error_element)
 
+    @run_only_on('sat')
     def test_update_libvirt_resource_different_name(self):
         """@Test: Update a libvirt Compute Resource name
 
@@ -196,6 +202,7 @@ class ComputeResource(UITestCase):
                     search = self.compute_resource.search(newname)
                     self.assertIsNotNone(search)
 
+    @run_only_on('sat')
     def test_update_libvirt_resource_organization(self):
         """@Test: Update a libvirt Compute Resource organization
 
@@ -223,6 +230,7 @@ class ComputeResource(UITestCase):
                 org_select=True
             )
 
+    @run_only_on('sat')
     def test_remove_resource(self):
         """@Test: Delete a Compute Resource
 
@@ -245,6 +253,7 @@ class ComputeResource(UITestCase):
                     self.assertIsNotNone(self.compute_resource.search(name))
                     self.compute_resource.delete(name)
 
+    @run_only_on('sat')
     def test_access_docker_resource_via_compute_profile(self):
         """@Test: Try to access docker compute resource via compute profile
         (1-Small) screen

--- a/tests/foreman/ui/test_config_groups.py
+++ b/tests/foreman/ui/test_config_groups.py
@@ -13,10 +13,10 @@ from robottelo.ui.locators import common_locators
 from robottelo.ui.session import Session
 
 
-@run_only_on('sat')
 class ConfigGroups(UITestCase):
     """Implements Config Groups tests in UI."""
 
+    @run_only_on('sat')
     def test_create_positive(self):
         """@Test: Create new Config-Group
 
@@ -32,6 +32,7 @@ class ConfigGroups(UITestCase):
                     search = self.configgroups.search(name)
                     self.assertIsNotNone(search)
 
+    @run_only_on('sat')
     def test_create_negative(self):
         """@Test: Try to create config group and use whitespace, blank, tab
         symbol or too long string of different types as its name value
@@ -51,6 +52,7 @@ class ConfigGroups(UITestCase):
                     search = self.configgroups.search(name)
                     self.assertIsNone(search)
 
+    @run_only_on('sat')
     def test_update_positive(self):
         """@Test: Update selected config-group
 
@@ -70,6 +72,7 @@ class ConfigGroups(UITestCase):
                     search = self.configgroups.search(new_name)
                     self.assertIsNotNone(search)
 
+    @run_only_on('sat')
     def test_delete_positive(self):
         """@Test: Delete selected config-groups
 

--- a/tests/foreman/ui/test_contentenv.py
+++ b/tests/foreman/ui/test_contentenv.py
@@ -12,7 +12,6 @@ from robottelo.ui.locators import locators
 from robottelo.ui.session import Session
 
 
-@run_only_on('sat')
 class ContentEnvironment(UITestCase):
     """Implements Life cycle content environment tests in UI"""
 
@@ -20,6 +19,7 @@ class ContentEnvironment(UITestCase):
     def setUpClass(cls):
         cls.org_name = entities.Organization().create().name
 
+    @run_only_on('sat')
     def test_positive_create_content_environment_basic(self):
         """@Test: Create content environment with minimal input parameters
 
@@ -41,6 +41,7 @@ class ContentEnvironment(UITestCase):
                     self.assertIsNotNone(self.contentenv.wait_until_element((
                         strategy, value % name)))
 
+    @run_only_on('sat')
     def test_positive_create_content_environment_chain(self):
         """@Test: Create Content Environment in a chain
 
@@ -66,6 +67,7 @@ class ContentEnvironment(UITestCase):
             self.assertIsNotNone(self.contentenv.wait_until_element
                                  ((strategy, value % env2_name)))
 
+    @run_only_on('sat')
     def test_positive_delete_content_environment(self):
         """@Test: Create Content Environment and delete it
 
@@ -90,6 +92,7 @@ class ContentEnvironment(UITestCase):
             self.assertIsNone(self.contentenv.wait_until_element
                               ((strategy, value % name), 3))
 
+    @run_only_on('sat')
     def test_positive_update_content_environment(self):
         """@Test: Create Content Environment and update it
 

--- a/tests/foreman/ui/test_contentviews.py
+++ b/tests/foreman/ui/test_contentviews.py
@@ -33,7 +33,6 @@ from robottelo.ui.session import Session
 from robottelo.test import UITestCase
 
 
-@run_only_on('sat')
 @ddt
 class TestContentViewsUI(UITestCase):
     """Implement tests for content view via UI"""
@@ -78,6 +77,7 @@ class TestContentViewsUI(UITestCase):
         entities.Repository(id=repo_id).sync()
 
     @data(*valid_data_list())
+    @run_only_on('sat')
     def test_cv_create(self, name):
         """@test: create content views (positive)
 
@@ -95,6 +95,7 @@ class TestContentViewsUI(UITestCase):
                     name, self.organization.name))
 
     @data(*invalid_names_list())
+    @run_only_on('sat')
     def test_cv_create_negative(self, name):
         # variations (subject to change):
         # zero length, symbols, html, etc.
@@ -116,6 +117,7 @@ class TestContentViewsUI(UITestCase):
                     name, self.organization.name))
             self.assertIsNone(self.content_views.search(name))
 
+    @run_only_on('sat')
     def test_cv_end_to_end(self):
         """@test: create content view with yum repo, publish it
         and promote it to Library +1 env
@@ -160,6 +162,7 @@ class TestContentViewsUI(UITestCase):
             self.assertIsNotNone(self.content_views.wait_until_element
                                  (common_locators['alert.success']))
 
+    @run_only_on('sat')
     def test_associate_puppet_module(self):
         """@test: create content view with puppet repository
 
@@ -196,6 +199,7 @@ class TestContentViewsUI(UITestCase):
                 cv_name, puppet_module)
             self.assertIsNotNone(module)
 
+    @run_only_on('sat')
     def test_remove_filter(self):
         """@test: create empty content views filter and remove it(positive)
 
@@ -220,6 +224,7 @@ class TestContentViewsUI(UITestCase):
             self.assertIsNone(self.content_views.search_filter(
                 cv_name, filter_name))
 
+    @run_only_on('sat')
     def test_create_package_filter(self):
         """@test: create content views package filter(positive)
 
@@ -253,6 +258,7 @@ class TestContentViewsUI(UITestCase):
                 [None, None, None, '4.6'],
             )
 
+    @run_only_on('sat')
     def test_create_package_group_filter(self):
         """@test: create content views package group filter(positive)
 
@@ -285,6 +291,7 @@ class TestContentViewsUI(UITestCase):
             self.assertIsNotNone(self.content_views.wait_until_element(
                 common_locators['alert.success']))
 
+    @run_only_on('sat')
     def test_create_errata_filter(self):
         """@test: create content views errata filter(positive)
 
@@ -315,6 +322,7 @@ class TestContentViewsUI(UITestCase):
                 common_locators['alert.success']))
 
     @data(*valid_data_list())
+    @run_only_on('sat')
     def test_positive_cv_update_name(self, new_name):
         """@test: Positive update content views - name.
 
@@ -337,6 +345,7 @@ class TestContentViewsUI(UITestCase):
             self.assertIsNotNone(self.content_views.search(new_name))
 
     @data(*invalid_names_list())
+    @run_only_on('sat')
     def test_negative_cv_update_name(self, new_name):
         """@test: Negative update content views - name.
 
@@ -356,6 +365,7 @@ class TestContentViewsUI(UITestCase):
             self.assertIsNone(self.content_views.search(new_name))
 
     @data(*valid_data_list())
+    @run_only_on('sat')
     def test_positive_cv_update_description(self, new_description):
         """@test: Positive update content views - description.
 
@@ -379,6 +389,7 @@ class TestContentViewsUI(UITestCase):
             self.assertIsNotNone(self.content_views.wait_until_element(
                 common_locators['alert.success']))
 
+    @run_only_on('sat')
     def test_negative_cv_update_description(self):
         """@test: Negative update content views - description.
 
@@ -399,6 +410,7 @@ class TestContentViewsUI(UITestCase):
                 common_locators['alert.error']))
 
     @stubbed()
+    @run_only_on('sat')
     def test_cv_edit_rh_custom_spin(self):
         # Variations might be:
         #   * A filter on errata date (only content that matches date
@@ -418,6 +430,7 @@ class TestContentViewsUI(UITestCase):
         """
 
     @data(*valid_data_list())
+    @run_only_on('sat')
     def test_cv_delete(self, name):
         """@test: delete content views
 
@@ -440,6 +453,7 @@ class TestContentViewsUI(UITestCase):
                 'Content view %s from %s org was not deleted' % (
                     name, self.organization.name))
 
+    @run_only_on('sat')
     def test_cv_composite_create(self):
         # Note: puppet repos cannot/should not be used in this test
         # It shouldn't work - and that is tested in a different case.
@@ -505,6 +519,7 @@ class TestContentViewsUI(UITestCase):
             self.assertIsNotNone(self.content_views.wait_until_element(
                 common_locators['alert.success']))
 
+    @run_only_on('sat')
     def test_associate_view_rh(self):
         """@test: associate Red Hat content in a view
 
@@ -535,6 +550,7 @@ class TestContentViewsUI(UITestCase):
                 common_locators['alert.success']))
 
     @stubbed()
+    @run_only_on('sat')
     def test_associate_view_rh_custom_spin(self):
         # Variations might be:
         #   * A filter on errata date (only content that matches date
@@ -555,6 +571,7 @@ class TestContentViewsUI(UITestCase):
 
         """
 
+    @run_only_on('sat')
     def test_associate_view_custom_content(self):
         """@test: associate custom content in a view
 
@@ -576,6 +593,7 @@ class TestContentViewsUI(UITestCase):
             self.assertIsNotNone(self.content_views.wait_until_element(
                 common_locators['alert.success']))
 
+    @run_only_on('sat')
     def test_cv_associate_puppet_repo_negative(self):
         # Again, individual modules should be ok.
         """@test: attempt to associate puppet repos within a composite
@@ -604,6 +622,7 @@ class TestContentViewsUI(UITestCase):
                     'Could not find tab to add puppet_modules'
                 )
 
+    @run_only_on('sat')
     def test_cv_associate_components_composite_negative(self):
         """@test: attempt to associate components to a non-composite
         content view
@@ -631,6 +650,7 @@ class TestContentViewsUI(UITestCase):
                 )
 
     @skip_if_bug_open('bugzilla', 1232270)
+    @run_only_on('sat')
     def test_cv_associate_composite_dupe_repos_negative(self):
         """@test: attempt to associate the same repo multiple times within a
         content view
@@ -659,6 +679,7 @@ class TestContentViewsUI(UITestCase):
                 )
 
     @stubbed()
+    @run_only_on('sat')
     def test_cv_associate_composite_dupe_modules_negative(self):
         """@test: attempt to associate duplicate puppet module(s) within a
         content view
@@ -671,6 +692,7 @@ class TestContentViewsUI(UITestCase):
 
         """
 
+    @run_only_on('sat')
     def test_cv_promote_rh(self):
         """@test: attempt to promote a content view containing RH content
 
@@ -713,6 +735,7 @@ class TestContentViewsUI(UITestCase):
                 common_locators['alert.success']))
 
     @stubbed()
+    @run_only_on('sat')
     def test_cv_promote_rh_custom_spin(self):
         """@test: attempt to promote a content view containing a custom RH
         spin - i.e., contains filters.
@@ -727,6 +750,7 @@ class TestContentViewsUI(UITestCase):
 
         """
 
+    @run_only_on('sat')
     def test_cv_promote_custom_content(self):
         """@test: attempt to promote a content view containing custom content
 
@@ -761,6 +785,7 @@ class TestContentViewsUI(UITestCase):
                 common_locators['alert.success']))
 
     @stubbed()
+    @run_only_on('sat')
     def test_cv_promote_composite(self):
         # Variations:
         # RHEL, custom content (i.e., google repos), puppet modules
@@ -781,6 +806,7 @@ class TestContentViewsUI(UITestCase):
         """
 
     @stubbed()
+    @run_only_on('sat')
     def test_cv_promote_default_negative(self):
         """@test: attempt to promote a the default content views
 
@@ -792,6 +818,7 @@ class TestContentViewsUI(UITestCase):
 
         """
 
+    @run_only_on('sat')
     def test_cv_publish_rh(self):
         """@test: attempt to publish a content view containing RH content
 
@@ -825,6 +852,7 @@ class TestContentViewsUI(UITestCase):
                 common_locators['alert.success']))
 
     @stubbed()
+    @run_only_on('sat')
     def test_cv_publish_rh_custom_spin(self):
         """@test: attempt to publish  a content view containing a custom RH
         spin - i.e., contains filters.
@@ -839,6 +867,7 @@ class TestContentViewsUI(UITestCase):
 
         """
 
+    @run_only_on('sat')
     def test_cv_publish_custom_content(self):
         """@test: attempt to publish a content view containing custom content
 
@@ -870,6 +899,7 @@ class TestContentViewsUI(UITestCase):
                 common_locators['alert.success']))
 
     @stubbed()
+    @run_only_on('sat')
     def test_cv_publish_composite(self):
         # Variations:
         # RHEL, custom content (i.e., google repos), puppet modules
@@ -888,6 +918,7 @@ class TestContentViewsUI(UITestCase):
         """
 
     @stubbed()
+    @run_only_on('sat')
     def test_cv_publish_version_changes_in_target_env(self):
         # Dev notes:
         # If Dev has version x, then when I promote version y into
@@ -912,6 +943,7 @@ class TestContentViewsUI(UITestCase):
         """
 
     @stubbed()
+    @run_only_on('sat')
     def test_cv_publish_version_changes_in_source_env(self):
         # Dev notes:
         # Similarly when I publish version y, version x goes away from
@@ -934,6 +966,7 @@ class TestContentViewsUI(UITestCase):
 
         """
 
+    @run_only_on('sat')
     def test_cv_clone_within_same_env(self):
         # Dev note: "not implemented yet"
         """@test: attempt to create new content view based on existing
@@ -973,6 +1006,7 @@ class TestContentViewsUI(UITestCase):
             )
 
     @stubbed()
+    @run_only_on('sat')
     def test_cv_clone_within_diff_env(self):
         # Dev note: "not implemented yet"
         """@test: attempt to create new content view based on existing
@@ -987,6 +1021,7 @@ class TestContentViewsUI(UITestCase):
         """
 
     @stubbed()
+    @run_only_on('sat')
     def test_cv_refresh_errata_to_new_view_in_same_env(self):
         """@test: attempt to refresh errata in a new view, based on
         an existing view, from within the same  environment
@@ -1000,6 +1035,7 @@ class TestContentViewsUI(UITestCase):
         """
 
     @stubbed()
+    @run_only_on('sat')
     def test_cv_subscribe_system(self):
         # Notes:
         # this should be limited to only those content views
@@ -1022,6 +1058,7 @@ class TestContentViewsUI(UITestCase):
         """
 
     @stubbed()
+    @run_only_on('sat')
     def test_cv_dynflow_restart_promote(self):
         """@test: attempt to restart a promotion
 
@@ -1038,6 +1075,7 @@ class TestContentViewsUI(UITestCase):
         """
 
     @stubbed()
+    @run_only_on('sat')
     def test_cv_dynflow_restart_publish(self):
         """@test: attempt to restart a publish
 
@@ -1057,6 +1095,7 @@ class TestContentViewsUI(UITestCase):
     # All this stuff is speculative at best.
 
     @stubbed()
+    @run_only_on('sat')
     def test_cv_roles_admin_user(self):
         # Note:
         # Obviously all of this stuff should work with 'admin' user
@@ -1080,6 +1119,7 @@ class TestContentViewsUI(UITestCase):
         """
 
     @stubbed()
+    @run_only_on('sat')
     def test_cv_roles_readonly_user(self):
         # Note:
         # Obviously all of this stuff should work with 'admin' user
@@ -1104,6 +1144,7 @@ class TestContentViewsUI(UITestCase):
         """
 
     @stubbed()
+    @run_only_on('sat')
     def test_cv_roles_admin_user_negative(self):
         # Note:
         # Obviously all of this stuff should work with 'admin' user
@@ -1127,6 +1168,7 @@ class TestContentViewsUI(UITestCase):
         """
 
     @stubbed()
+    @run_only_on('sat')
     def test_cv_roles_readonly_user_negative(self):
         # Note:
         # Obviously all of this stuff should work with 'admin' user
@@ -1150,6 +1192,7 @@ class TestContentViewsUI(UITestCase):
 
         """
 
+    @run_only_on('sat')
     def test_delete_version_default(self):
         """@Test: Delete a content-view version associated to 'Library'
 
@@ -1195,6 +1238,7 @@ class TestContentViewsUI(UITestCase):
             self.content_views.check_progress_bar_status(version)
             self.content_views.validate_version_deleted(cv.name, version)
 
+    @run_only_on('sat')
     def test_delete_version_non_default(self):
         """@Test: Delete a content-view version associated to non-default
         environment
@@ -1229,6 +1273,7 @@ class TestContentViewsUI(UITestCase):
             self.content_views.check_progress_bar_status(version)
             self.content_views.validate_version_deleted(cv.name, version)
 
+    @run_only_on('sat')
     def test_delete_version_with_ak(self):
         """@Test: Delete a content-view version that had associated activation
         key to it

--- a/tests/foreman/ui/test_discoveryrule.py
+++ b/tests/foreman/ui/test_discoveryrule.py
@@ -11,7 +11,6 @@ from robottelo.ui.locators import common_locators
 from robottelo.ui.session import Session
 
 
-@run_only_on('sat')
 @ddt
 class DiscoveryRules(UITestCase):
     """Implements Foreman discovery Rules in UI."""
@@ -37,6 +36,7 @@ class DiscoveryRules(UITestCase):
         super(DiscoveryRules, cls).tearDownClass()
 
     @data(*generate_strings_list(len1=8))
+    @run_only_on('sat')
     def test_positive_create_discovery_rule_1(self, name):
         """@Test: Create Discovery Rule
 
@@ -50,6 +50,7 @@ class DiscoveryRules(UITestCase):
                                hostgroup=self.host_group.name)
             self.assertIsNotNone(self.discoveryrules.search(name))
 
+    @run_only_on('sat')
     def test_positive_create_discovery_rule_2(self):
         """@Test: Create Discovery Rule with 255 characters in name
 
@@ -64,6 +65,7 @@ class DiscoveryRules(UITestCase):
                                hostgroup=self.host_group.name)
             self.assertIsNotNone(self.discoveryrules.search(name))
 
+    @run_only_on('sat')
     def test_negative_create_discovery_rule_1(self):
         """@Test: Create Discovery Rule with 256 characters in name
 
@@ -82,6 +84,7 @@ class DiscoveryRules(UITestCase):
             self.assertIsNone(self.discoveryrules.search(name))
 
     @data("", "  ")
+    @run_only_on('sat')
     def test_negative_create_discovery_rule_2(self, name):
         """@Test: Create Discovery Rule with blank and whitespace in name
 
@@ -99,6 +102,7 @@ class DiscoveryRules(UITestCase):
             self.assertIsNone(self.discoveryrules.search(name))
 
     @data('-1', gen_string("alpha", 6))
+    @run_only_on('sat')
     def test_negative_create_discovery_rule_3(self, limit):
         """@Test: Create Discovery Rule with invalid host limit
 
@@ -116,6 +120,7 @@ class DiscoveryRules(UITestCase):
             ))
             self.assertIsNone(self.discoveryrules.search(name))
 
+    @run_only_on('sat')
     def test_negative_create_discovery_rule_4(self):
         """@Test: Create Discovery Rule with name that already exists
 
@@ -135,6 +140,7 @@ class DiscoveryRules(UITestCase):
                 common_locators['name_haserror']
             ))
 
+    @run_only_on('sat')
     def test_negative_create_discovery_rule_5(self):
         """@Test: Create Discovery Rule with invalid priority
 
@@ -153,6 +159,7 @@ class DiscoveryRules(UITestCase):
             ))
             self.assertIsNone(self.discoveryrules.search(name))
 
+    @run_only_on('sat')
     def test_disable_discovery_rule_1(self):
         """@Test: Disable Discovery Rule while creation
 
@@ -168,6 +175,7 @@ class DiscoveryRules(UITestCase):
             self.assertIsNotNone(self.discoveryrules.search(name))
 
     @data(*generate_strings_list(len1=8))
+    @run_only_on('sat')
     def test_delete_discovery_rule_1(self, name):
         """@Test: Delete Discovery Rule
 
@@ -184,6 +192,7 @@ class DiscoveryRules(UITestCase):
             self.assertIsNone(self.discoveryrules.search(name))
 
     @data(*generate_strings_list(len1=8))
+    @run_only_on('sat')
     def test_update_discovery_rule_1(self, new_name):
         """@Test: Update discovery rule name
 

--- a/tests/foreman/ui/test_docker.py
+++ b/tests/foreman/ui/test_docker.py
@@ -23,9 +23,6 @@ from robottelo.ui.locators import common_locators, locators
 from robottelo.ui.session import Session
 # (too-many-public-methods) pylint:disable=R0904
 
-EXTERNAL_DOCKER_URL = settings.docker.external_url
-INTERNAL_DOCKER_URL = settings.docker.get_unix_socket_url()
-
 VALID_DOCKER_UPSTREAM_NAMES = (
     # boundaries
     gen_string('alphanumeric', 3).lower(),
@@ -993,7 +990,11 @@ class DockerComputeResourceTestCase(UITestCase):
                         session,
                         name=comp_name,
                         provider_type=FOREMAN_PROVIDERS['docker'],
-                        parameter_list=[['URL', INTERNAL_DOCKER_URL, 'field']],
+                        parameter_list=[[
+                            'URL',
+                            settings.docker.get_unix_socket_url(),
+                            'field'
+                        ]],
                     )
                     self.assertIsNotNone(
                         self.compute_resource.search(comp_name))
@@ -1015,7 +1016,11 @@ class DockerComputeResourceTestCase(UITestCase):
                 session,
                 name=comp_name,
                 provider_type=FOREMAN_PROVIDERS['docker'],
-                parameter_list=[['URL', INTERNAL_DOCKER_URL, 'field']],
+                parameter_list=[[
+                    'URL',
+                    settings.docker.get_unix_socket_url(),
+                    'field'
+                ]],
             )
             self.compute_resource.update(
                 name=comp_name,
@@ -1056,7 +1061,11 @@ class DockerComputeResourceTestCase(UITestCase):
                         session,
                         name=comp_name,
                         provider_type=FOREMAN_PROVIDERS['docker'],
-                        parameter_list=[['URL', EXTERNAL_DOCKER_URL, 'field']],
+                        parameter_list=[[
+                            'URL',
+                            settings.docker.external_url,
+                            'field'
+                        ]],
                     )
                     self.assertIsNotNone(
                         self.compute_resource.search(comp_name))
@@ -1078,7 +1087,11 @@ class DockerComputeResourceTestCase(UITestCase):
                 session,
                 name=comp_name,
                 provider_type=FOREMAN_PROVIDERS['docker'],
-                parameter_list=[['URL', EXTERNAL_DOCKER_URL, 'field']],
+                parameter_list=[[
+                    'URL',
+                    settings.docker.external_url,
+                    'field'
+                ]],
             )
             self.compute_resource.update(
                 name=comp_name,
@@ -1114,7 +1127,8 @@ class DockerComputeResourceTestCase(UITestCase):
         """
         comp_name = gen_string('alphanumeric')
         with Session(self.browser) as session:
-            for url in (EXTERNAL_DOCKER_URL, INTERNAL_DOCKER_URL):
+            for url in (settings.docker.external_url,
+                        settings.docker.get_unix_socket_url()):
                 with self.subTest(url):
                     make_resource(
                         session,

--- a/tests/foreman/ui/test_domain.py
+++ b/tests/foreman/ui/test_domain.py
@@ -13,12 +13,12 @@ from robottelo.ui.locators import common_locators
 from robottelo.ui.session import Session
 
 
-@run_only_on('sat')
 @ddt
 class Domain(UITestCase):
     """Implements Domain tests in UI"""
 
     @data(*generate_strings_list(len1=4))
+    @run_only_on('sat')
     def test_create_domain_1(self, name):
         """@Test: Create a new domain
 
@@ -41,6 +41,7 @@ class Domain(UITestCase):
         gen_string('latin1', 243),
         gen_string('utf8', 243),
     )
+    @run_only_on('sat')
     def test_create_domain_2(self, name):
         """@Test: Create a new domain
 
@@ -55,6 +56,7 @@ class Domain(UITestCase):
             element = self.domain.search(description)
             self.assertIsNotNone(element)
 
+    @run_only_on('sat')
     def test_remove_domain(self):
         """@Test: Delete a domain
 
@@ -80,6 +82,7 @@ class Domain(UITestCase):
            'newname': gen_string('latin1', 10)},
           {'name': gen_string('html', 10),
            'newname': gen_string('html', 10), 'bugzilla': 1220104})
+    @run_only_on('sat')
     def test_update_domain(self, testdata):
         """@Test: Update a domain with name and description
 
@@ -102,6 +105,7 @@ class Domain(UITestCase):
             self.assertIsNotNone(self.domain.search(new_description))
 
     @data(*invalid_values_list())
+    @run_only_on('sat')
     def test_negative_create_domain(self, name):
         """@Test: Try to create domain and use whitespace, blank, tab symbol or
         too long string of different types as its name value
@@ -118,6 +122,7 @@ class Domain(UITestCase):
             self.assertIsNotNone(error)
 
     @data(*generate_strings_list(len1=4))
+    @run_only_on('sat')
     def test_positive_set_domain_parameter_1(self, name):
         """@Test: Set parameter name and value for domain
 
@@ -139,6 +144,7 @@ class Domain(UITestCase):
             except UIError as err:
                 self.fail(err)
 
+    @run_only_on('sat')
     def test_positive_set_domain_parameter_2(self):
         """@Test: Set a parameter in a domain with 255 chars in name and value.
 
@@ -161,6 +167,7 @@ class Domain(UITestCase):
             except UIError as err:
                 self.fail(err)
 
+    @run_only_on('sat')
     def test_positive_set_domain_parameter_3(self):
         """@Test: Set a parameter in a domain with blank value.
 
@@ -183,6 +190,7 @@ class Domain(UITestCase):
             except UIError as err:
                 self.fail(err)
 
+    @run_only_on('sat')
     def test_set_domain_parameter_negative_1(self):
         """@Test: Set a parameter in a domain with 256 chars in name and value.
 
@@ -208,6 +216,7 @@ class Domain(UITestCase):
                 common_locators['common_param_error']))
 
     @skip_if_bug_open('bugzilla', 1123360)
+    @run_only_on('sat')
     def test_set_domain_parameter_negative_2(self):
         """@Test: Again set the same parameter for domain with name and value.
 
@@ -237,6 +246,7 @@ class Domain(UITestCase):
                 common_locators['common_param_error']))
 
     @data(*generate_strings_list(len1=4))
+    @run_only_on('sat')
     def test_remove_domain_parameter(self, name):
         """@Test: Remove a selected domain parameter
 

--- a/tests/foreman/ui/test_environment.py
+++ b/tests/foreman/ui/test_environment.py
@@ -11,7 +11,6 @@ from robottelo.ui.locators import common_locators
 from robottelo.ui.session import Session
 
 
-@run_only_on('sat')
 @ddt
 class Environment(UITestCase):
     """Implements environment tests in UI.
@@ -25,6 +24,7 @@ class Environment(UITestCase):
         gen_string('numeric'),
         gen_string('alphanumeric')
     )
+    @run_only_on('sat')
     def test_create_env_positive_1(self, name):
         """@Test: Create new environment
 
@@ -43,6 +43,7 @@ class Environment(UITestCase):
         gen_string('numeric', 255),
         gen_string('alphanumeric', 255)
     )
+    @run_only_on('sat')
     def test_create_env_positive_2(self, name):
         """@Test: Create new environment with 255 chars
 
@@ -57,6 +58,7 @@ class Environment(UITestCase):
             self.assertIsNotNone(search)
 
     @data(*invalid_values_list())
+    @run_only_on('sat')
     def test_create_env_negative(self, name):
         """@Test: Try to create environment and use whitespace, blank, tab
         symbol or too long string of different types as its name value
@@ -78,6 +80,7 @@ class Environment(UITestCase):
         gen_string('numeric'),
         gen_string('alphanumeric'),
     )
+    @run_only_on('sat')
     def test_update_env(self, new_name):
         """@Test: Update an environment and associated OS
 
@@ -100,6 +103,7 @@ class Environment(UITestCase):
         gen_string('numeric'),
         gen_string('alphanumeric'),
     )
+    @run_only_on('sat')
     def test_remove_env(self, name):
         """@Test: Delete an environment
 

--- a/tests/foreman/ui/test_gpgkey.py
+++ b/tests/foreman/ui/test_gpgkey.py
@@ -33,7 +33,6 @@ from robottelo.ui.session import Session
 from robottelo.vm import VirtualMachine
 
 
-@run_only_on('sat')
 @ddt
 class GPGKey(UITestCase):
     """Implements tests for GPG Keys via UI"""
@@ -48,6 +47,7 @@ class GPGKey(UITestCase):
     # Positive Create
 
     @data(*generate_strings_list(remove_str='numeric', bug_id=1184480))
+    @run_only_on('sat')
     def test_positive_create_1(self, name):
         """@test: Create gpg key with valid name and valid gpg key
         via file import
@@ -68,6 +68,7 @@ class GPGKey(UITestCase):
             self.assertIsNotNone(self.gpgkey.search(name))
 
     @data(*generate_strings_list(remove_str='numeric', bug_id=1184480))
+    @run_only_on('sat')
     def test_positive_create_2(self, name):
         """@test: Create gpg key with valid name and valid gpg key text via
         cut and paste/string
@@ -89,6 +90,7 @@ class GPGKey(UITestCase):
     # Negative Create
 
     @data(*generate_strings_list(remove_str='numeric', bug_id=1184480))
+    @run_only_on('sat')
     def test_negative_create_1(self, name):
         """@test: Create gpg key with valid name and valid gpg key via
         file import then try to create new one with same name
@@ -113,6 +115,7 @@ class GPGKey(UITestCase):
             )
 
     @data(*generate_strings_list(remove_str='numeric', bug_id=1184480))
+    @run_only_on('sat')
     def test_negative_create_2(self, name):
         """@test: Create gpg key with valid name and valid gpg key text via
         cut and paste/string import then try to create new one with same name
@@ -136,6 +139,7 @@ class GPGKey(UITestCase):
             )
 
     @data(*generate_strings_list(remove_str='numeric', bug_id=1184480))
+    @run_only_on('sat')
     def test_negative_create_3(self, name):
         """@test: Create gpg key with valid name and no gpg key
 
@@ -150,6 +154,7 @@ class GPGKey(UITestCase):
             self.assertIsNone(self.gpgkey.search(name))
 
     @data(*invalid_names_list())
+    @run_only_on('sat')
     def test_negative_create_4(self, name):
         """@test: Create gpg key with invalid name and valid gpg key via
         file import
@@ -172,6 +177,7 @@ class GPGKey(UITestCase):
             )
             self.assertIsNone(self.gpgkey.search(name))
 
+    @run_only_on('sat')
     def test_negative_create_5(self):
         """@test: Create gpg key with blank name and valid gpg key via
         file import
@@ -196,6 +202,7 @@ class GPGKey(UITestCase):
             self.assertIsNone(self.gpgkey.search(name))
 
     @data(*invalid_names_list())
+    @run_only_on('sat')
     def test_negative_create_6(self, name):
         """@test: Create gpg key with invalid name and valid gpg key text via
         cut and paste/string
@@ -220,6 +227,7 @@ class GPGKey(UITestCase):
     # Positive Delete
 
     @data(*valid_data_list())
+    @run_only_on('sat')
     def test_positive_delete_1(self, name):
         """@test: Create gpg key with valid name and valid gpg key via file
         import then delete it
@@ -242,6 +250,7 @@ class GPGKey(UITestCase):
             self.assertIsNone(self.gpgkey.search(name))
 
     @data(*valid_data_list())
+    @run_only_on('sat')
     def test_positive_delete_2(self, name):
         """@test: Create gpg key with valid name and valid gpg key text via
         cut and paste/string then delete it
@@ -264,6 +273,7 @@ class GPGKey(UITestCase):
 
     # Positive Update
 
+    @run_only_on('sat')
     def test_positive_update_1(self):
         """@test: Create gpg key with valid name and valid gpg key via file
         import then update its name
@@ -290,6 +300,7 @@ class GPGKey(UITestCase):
             ))
 
     @skip_if_bug_open('bugzilla', 1204602)
+    @run_only_on('sat')
     def test_positive_update_2(self):
         """@test: Create gpg key with valid name and valid gpg key via file
         import then update its gpg key file
@@ -317,6 +328,7 @@ class GPGKey(UITestCase):
                 common_locators['alert.success']
             ))
 
+    @run_only_on('sat')
     def test_positive_update_3(self):
         """@test: Create gpg key with valid name and valid gpg key text via
         cut and paste/string then update its name
@@ -342,6 +354,7 @@ class GPGKey(UITestCase):
             ))
 
     @skip_if_bug_open('bugzilla', 1204602)
+    @run_only_on('sat')
     def test_positive_update_4(self):
         """@test: Create gpg key with valid name and valid gpg key text via
         cut and paste/string then update its gpg key text
@@ -371,6 +384,7 @@ class GPGKey(UITestCase):
     # Negative Update
 
     @data(*invalid_names_list())
+    @run_only_on('sat')
     def test_negative_update_1(self, new_name):
         """@test: Create gpg key with valid name and valid gpg key via file
         import then fail to update its name
@@ -397,6 +411,7 @@ class GPGKey(UITestCase):
             self.assertIsNone(self.gpgkey.search(new_name))
 
     @data(*invalid_names_list())
+    @run_only_on('sat')
     def test_negative_update_2(self, new_name):
         """@test: Create gpg key with valid name and valid gpg key text via
         cut and paste/string then fail to update its name
@@ -422,6 +437,7 @@ class GPGKey(UITestCase):
             self.assertIsNone(self.gpgkey.search(new_name))
 
     @data(*valid_data_list())
+    @run_only_on('sat')
     def test_consume_content_1(self, key_name):
         """@test: Hosts can install packages using gpg key associated with
         single custom repository
@@ -545,6 +561,7 @@ class GPGKey(UITestCase):
         name is html
         gpg key file is valid always
 """)
+    @run_only_on('sat')
     def test_consume_content_2(self):
         """@test: Hosts can install packages using gpg key associated with
         multiple custom repositories
@@ -569,6 +586,7 @@ class GPGKey(UITestCase):
         name is html
         gpg key file is valid always
 """)
+    @run_only_on('sat')
     def test_consume_content_3(self):
         """@test: Hosts can install packages using different gpg keys
         associated with multiple custom repositories
@@ -593,6 +611,7 @@ class GPGKey(UITestCase):
         name is html
         gpg key file is valid always
 """)
+    @run_only_on('sat')
     def test_list_key_1(self):
         """@test: Create gpg key and list it
 
@@ -616,6 +635,7 @@ class GPGKey(UITestCase):
         name is html
         gpg key file is valid always
 """)
+    @run_only_on('sat')
     def test_search_key_1(self):
         """@test: Create gpg key and search/find it
 
@@ -639,6 +659,7 @@ class GPGKey(UITestCase):
         name is html
         gpg key file is valid always
 """)
+    @run_only_on('sat')
     def test_info_key_1(self):
         """@test: Create single gpg key and get its info
 
@@ -653,7 +674,6 @@ class GPGKey(UITestCase):
         pass
 
 
-@run_only_on('sat')
 @ddt
 class GPGKeyProductAssociate(UITestCase):
     """Implements Product Association tests for GPG Keys via UI"""
@@ -666,6 +686,7 @@ class GPGKeyProductAssociate(UITestCase):
         cls.organization = entities.Organization().create()
 
     @data(*generate_strings_list(remove_str='numeric', bug_id=1184480))
+    @run_only_on('sat')
     def test_key_associate_1(self, name):
         """@test: Create gpg key with valid name and valid gpg key
         then associate it with empty (no repos) custom product
@@ -695,6 +716,7 @@ class GPGKeyProductAssociate(UITestCase):
             )
 
     @data(*generate_strings_list(remove_str='numeric', bug_id=1184480))
+    @run_only_on('sat')
     def test_key_associate_2(self, name):
         """@test: Create gpg key with valid name and valid gpg key
         then associate it with custom product that has one repository
@@ -732,6 +754,7 @@ class GPGKeyProductAssociate(UITestCase):
                 )
 
     @data(*generate_strings_list(remove_str='numeric', bug_id=1184480))
+    @run_only_on('sat')
     def test_key_associate_3(self, name):
         """@test: Create gpg key with valid name and valid gpg key
         then associate it with custom product that has more than one repository
@@ -776,6 +799,7 @@ class GPGKeyProductAssociate(UITestCase):
 
     @skip_if_bug_open('bugzilla', 1085035)
     @data(*generate_strings_list(remove_str='numeric', bug_id=1184480))
+    @run_only_on('sat')
     def test_key_associate_4(self, name):
         """@test: Create gpg key with valid name and valid gpg key
         then associate it with custom product using Repo discovery method
@@ -810,6 +834,7 @@ class GPGKeyProductAssociate(UITestCase):
                 )
 
     @data(*generate_strings_list(remove_str='numeric', bug_id=1184480))
+    @run_only_on('sat')
     def test_key_associate_5(self, name):
         """@test: Create gpg key with valid name and valid gpg key then
         associate it to repository from custom product that has one repository
@@ -850,6 +875,7 @@ class GPGKeyProductAssociate(UITestCase):
             )
 
     @data(*generate_strings_list(remove_str='numeric', bug_id=1184480))
+    @run_only_on('sat')
     def test_key_associate_6(self, name):
         """@test: Create gpg key with valid name and valid gpg key then
         associate it to repository from custom product that has more than
@@ -907,6 +933,7 @@ class GPGKeyProductAssociate(UITestCase):
         name is html
         gpg key file is valid always
 """)
+    @run_only_on('sat')
     def test_key_associate_7(self):
         """@test: Create gpg key with valid name and valid gpg key then
         associate it to repos from custom product using Repo discovery method
@@ -924,6 +951,7 @@ class GPGKeyProductAssociate(UITestCase):
         pass
 
     @data(*generate_strings_list(remove_str='numeric', bug_id=1184480))
+    @run_only_on('sat')
     def test_key_associate_8(self, name):
         """@test: Create gpg key with valid name and valid gpg key then
         associate it with empty (no repos) custom product then update the key
@@ -961,6 +989,7 @@ class GPGKeyProductAssociate(UITestCase):
             )
 
     @data(*generate_strings_list(remove_str='numeric', bug_id=1184480))
+    @run_only_on('sat')
     def test_key_associate_9(self, name):
         """@test: Create gpg key with valid name and valid gpg key
         then associate it with custom product that has one repository
@@ -1007,6 +1036,7 @@ class GPGKeyProductAssociate(UITestCase):
                 )
 
     @data(*generate_strings_list(remove_str='numeric', bug_id=1184480))
+    @run_only_on('sat')
     def test_key_associate_10(self, name):
         """@test: Create gpg key with valid name and valid gpg key
         then associate it with custom product that has more than one
@@ -1060,6 +1090,7 @@ class GPGKeyProductAssociate(UITestCase):
 
     @skip_if_bug_open('bugzilla', 1210180)
     @data(*generate_strings_list(remove_str='numeric', bug_id=1184480))
+    @run_only_on('sat')
     def test_key_associate_11(self, name):
         """@test: Create gpg key with valid name and valid gpg key
         then associate it with custom product using Repo discovery
@@ -1101,6 +1132,7 @@ class GPGKeyProductAssociate(UITestCase):
                 )
 
     @data(*generate_strings_list(remove_str='numeric', bug_id=1184480))
+    @run_only_on('sat')
     def test_key_associate_12(self, name):
         """@test: Create gpg key with valid name and valid gpg key then
         associate it to repository from custom product that has one repository
@@ -1154,6 +1186,7 @@ class GPGKeyProductAssociate(UITestCase):
             )
 
     @data(*generate_strings_list(remove_str='numeric', bug_id=1184480))
+    @run_only_on('sat')
     def test_key_associate_13(self, name):
         """@test: Create gpg key with valid name and valid gpg key then
         associate it to repository from custom product that has more than
@@ -1222,6 +1255,7 @@ class GPGKeyProductAssociate(UITestCase):
         name is html
         gpg key file is valid always
 """)
+    @run_only_on('sat')
     def test_key_associate_14(self):
         """@test: Create gpg key with valid name and valid gpg key
         then associate it to repos from custom product
@@ -1241,6 +1275,7 @@ class GPGKeyProductAssociate(UITestCase):
         pass
 
     @data(*generate_strings_list(remove_str='numeric', bug_id=1184480))
+    @run_only_on('sat')
     def test_key_associate_15(self, name):
         """@test: Create gpg key with valid name and valid gpg key
         then associate it with empty (no repos) custom
@@ -1278,6 +1313,7 @@ class GPGKeyProductAssociate(UITestCase):
                 self.assertIsNone(result)
 
     @data(*generate_strings_list(remove_str='numeric', bug_id=1184480))
+    @run_only_on('sat')
     def test_key_associate_16(self, name):
         """@test: Create gpg key with valid name and valid gpg key then
         associate it with custom product that has one repository then delete it
@@ -1321,6 +1357,7 @@ class GPGKeyProductAssociate(UITestCase):
                 self.assertIsNone(result)
 
     @data(*generate_strings_list(remove_str='numeric', bug_id=1184480))
+    @run_only_on('sat')
     def test_key_associate_17(self, name):
         """@test: Create gpg key with valid name and valid gpg key
         then associate it with custom product that has
@@ -1372,6 +1409,7 @@ class GPGKeyProductAssociate(UITestCase):
 
     @skip_if_bug_open('bugzilla', 1085035)
     @data(*generate_strings_list(remove_str='numeric', bug_id=1184480))
+    @run_only_on('sat')
     def test_key_associate_18(self, name):
         """@test: Create gpg key with valid name and valid gpg then associate
         it with custom product using Repo discovery method then delete it
@@ -1413,6 +1451,7 @@ class GPGKeyProductAssociate(UITestCase):
                 self.assertIsNone(result)
 
     @data(*generate_strings_list(remove_str='numeric', bug_id=1184480))
+    @run_only_on('sat')
     def test_key_associate_19(self, name):
         """@test: Create gpg key with valid name and valid gpg key then
         associate it to repository from custom product that has one repository
@@ -1462,6 +1501,7 @@ class GPGKeyProductAssociate(UITestCase):
             ))
 
     @data(*generate_strings_list(remove_str='numeric', bug_id=1184480))
+    @run_only_on('sat')
     def test_key_associate_20(self, name):
         """@test: Create gpg key with valid name and valid gpg key then
         associate it to repository from custom product that has more than
@@ -1530,6 +1570,7 @@ class GPGKeyProductAssociate(UITestCase):
         name is html
         gpg key file is valid always
 """)
+    @run_only_on('sat')
     def test_key_associate_21(self):
         """  @test: Create gpg key with valid name and valid gpg key then
         associate it to repos from custom product using Repo discovery method

--- a/tests/foreman/ui/test_host.py
+++ b/tests/foreman/ui/test_host.py
@@ -12,7 +12,6 @@ from robottelo.ui.locators import common_locators
 from robottelo.ui.session import Session
 
 
-@run_only_on('sat')
 class Host(UITestCase, Base):
 
     hostname = gen_string('numeric')
@@ -275,6 +274,7 @@ class Host(UITestCase, Base):
                         common_locators['notif.success']))
         super(Host, self).tearDown()
 
+    @run_only_on('sat')
     def test_create_host_on_libvirt(self):
         """@Test: Create a new Host on libvirt compute resource
 
@@ -304,6 +304,7 @@ class Host(UITestCase, Base):
             )
             self.assertIsNotNone(search)
 
+    @run_only_on('sat')
     def test_create_host(self):
         """@Test: Create a new Host
 
@@ -341,6 +342,7 @@ class Host(UITestCase, Base):
             )
             self.assertIsNotNone(search)
 
+    @run_only_on('sat')
     def test_delete_host(self):
         """@Test: Delete a Host
 

--- a/tests/foreman/ui/test_host_system_unification.py
+++ b/tests/foreman/ui/test_host_system_unification.py
@@ -5,7 +5,6 @@ from robottelo.decorators import run_only_on, stubbed
 from robottelo.test import UITestCase
 
 
-@run_only_on('sat')
 class TestHostSystemUnificationUI(UITestCase):
     # Testing notes for host/system unification in katello/foreman
     # Basically assuring that hosts in foreman/katello bits are joined
@@ -16,6 +15,7 @@ class TestHostSystemUnificationUI(UITestCase):
     # fuzzy like hostname"
 
     @stubbed()
+    @run_only_on('sat')
     def test_katello_host_in_foreman(self):
         """@test: Hosts registered to Katello via rhsm appear in foreman
 
@@ -34,6 +34,7 @@ class TestHostSystemUnificationUI(UITestCase):
         pass
 
     @stubbed()
+    @run_only_on('sat')
     def test_foreman_host_in_katello(self):
         """@test: Hosts provisioned in foreman via appear in katello
 
@@ -52,6 +53,7 @@ class TestHostSystemUnificationUI(UITestCase):
         pass
 
     @stubbed()
+    @run_only_on('sat')
     def test_renamed_host_foreman(self):
         """@test: Hosts renamed in foreman appear in katello
 
@@ -70,6 +72,7 @@ class TestHostSystemUnificationUI(UITestCase):
         pass
 
     @stubbed()
+    @run_only_on('sat')
     def test_renamed_host_katello(self):
         """@test: Hosts renamed in katello via appear in foreman
 
@@ -88,6 +91,7 @@ class TestHostSystemUnificationUI(UITestCase):
         pass
 
     @stubbed()
+    @run_only_on('sat')
     def test_deleted_host_foreman(self):
         """@test: Hosts delete in foreman disappear from both sides of UI
 
@@ -106,6 +110,7 @@ class TestHostSystemUnificationUI(UITestCase):
         pass
 
     @stubbed()
+    @run_only_on('sat')
     def test_deleted_host_katello(self):
         """@test: Hosts delete in katello disappear from both sides of UI
 

--- a/tests/foreman/ui/test_hostgroup.py
+++ b/tests/foreman/ui/test_hostgroup.py
@@ -11,12 +11,12 @@ from robottelo.ui.locators import common_locators
 from robottelo.ui.session import Session
 
 
-@run_only_on('sat')
 @ddt
 class Hostgroup(UITestCase):
     """Implements HostGroup tests from UI"""
 
     @data(*generate_strings_list(len1=4))
+    @run_only_on('sat')
     def test_create_hostgroup(self, name):
         """@Test: Create new hostgroup
 
@@ -30,6 +30,7 @@ class Hostgroup(UITestCase):
             self.assertIsNotNone(self.hostgroup.search(name))
 
     @data(*generate_strings_list(len1=4))
+    @run_only_on('sat')
     def test_delete_hostgroup(self, name):
         """@Test: Delete a hostgroup
 
@@ -43,6 +44,7 @@ class Hostgroup(UITestCase):
             self.hostgroup.delete(name)
 
     @data(*generate_strings_list(len1=4))
+    @run_only_on('sat')
     def test_update_hostgroup(self, new_name):
         """@Test: Update hostgroup with a new name
 
@@ -59,6 +61,7 @@ class Hostgroup(UITestCase):
             self.assertIsNotNone(self.hostgroup.search(new_name))
 
     @data(*generate_strings_list(len1=256))
+    @run_only_on('sat')
     def test_negative_create_hostgroup_with_too_long_name(self, name):
         """@Test: Create new hostgroup with 256 chars in name
 
@@ -72,6 +75,7 @@ class Hostgroup(UITestCase):
             self.assertIsNotNone(self.hostgroup.wait_until_element
                                  (common_locators['name_haserror']))
 
+    @run_only_on('sat')
     def test_negative_create_hostgroup_with_same_name(self):
         """@Test: Create new hostgroup with same name
 
@@ -89,6 +93,7 @@ class Hostgroup(UITestCase):
                                  (common_locators['name_haserror']))
 
     @data('', '  ')
+    @run_only_on('sat')
     def test_negative_create_hostgroup_with_blank_name(self, name):
         """@Test: Create new hostgroup with whitespaces in name
 

--- a/tests/foreman/ui/test_hw_model.py
+++ b/tests/foreman/ui/test_hw_model.py
@@ -10,12 +10,12 @@ from robottelo.ui.locators import common_locators
 from robottelo.ui.session import Session
 
 
-@run_only_on('sat')
 @ddt
 class HardwareModelTestCase(UITestCase):
     """Implements Hardware Model tests in UI."""
 
     @data(*valid_data_list())
+    @run_only_on('sat')
     def test_create_positive_different_names(self, name):
         """@test: Create new Hardware-Model
 
@@ -30,6 +30,7 @@ class HardwareModelTestCase(UITestCase):
             self.assertIsNotNone(search)
 
     @data(*generate_strings_list(len1=256))
+    @run_only_on('sat')
     def test_create_negative_with_too_long_names(self, name):
         """@test: Create new Hardware-Model with 256 chars
 
@@ -45,6 +46,7 @@ class HardwareModelTestCase(UITestCase):
             self.assertIsNotNone(error)
 
     @data('', '   ')
+    @run_only_on('sat')
     def test_create_negative_with_blank_name(self, name):
         """@test: Create new Hardware-Model with blank name
 
@@ -60,6 +62,7 @@ class HardwareModelTestCase(UITestCase):
             self.assertIsNotNone(error)
 
     @data(*valid_data_list())
+    @run_only_on('sat')
     def test_update_positive(self, new_name):
         """@test: Updates the Hardware-Model
 
@@ -84,6 +87,7 @@ class HardwareModelTestCase(UITestCase):
         {u'name': gen_string('html'), 'bugzilla': 1265150},
         {u'name': gen_string('latin1')},
         {u'name': gen_string('utf8')})
+    @run_only_on('sat')
     def test_delete_positive(self, test_data):
         """@test: Deletes the Hardware-Model
 

--- a/tests/foreman/ui/test_isodownload.py
+++ b/tests/foreman/ui/test_isodownload.py
@@ -2,11 +2,11 @@ from robottelo.decorators import run_only_on, stubbed
 from robottelo.test import UITestCase
 
 
-@run_only_on('sat')
 class TestISODownloads(UITestCase):
     """Test class for iso download feature"""
 
     @stubbed()
+    @run_only_on('sat')
     def test_iso_download_1(self):
         """@test: Downloading ISO from export
 
@@ -25,6 +25,7 @@ class TestISODownloads(UITestCase):
         """
 
     @stubbed()
+    @run_only_on('sat')
     def test_iso_download_2(self):
         """@test: Uploadng the iso successfully to the sat6 system
 
@@ -42,6 +43,7 @@ class TestISODownloads(UITestCase):
         """
 
     @stubbed()
+    @run_only_on('sat')
     def test_iso_download_3(self):
         """@test: Mounting iso to directory accessible to satellite6 works
 
@@ -60,6 +62,7 @@ class TestISODownloads(UITestCase):
         """
 
     @stubbed()
+    @run_only_on('sat')
     def test_iso_download_4(self):
         """@test: Validate that cdn url to file:///path/to/mount works
 
@@ -78,6 +81,7 @@ class TestISODownloads(UITestCase):
         """
 
     @stubbed()
+    @run_only_on('sat')
     def test_iso_download_5(self):
         """@test: Check if proper message is displayed after successful upload
 
@@ -96,6 +100,7 @@ class TestISODownloads(UITestCase):
         """
 
     @stubbed()
+    @run_only_on('sat')
     def test_iso_download_6(self):
         """@test: Enable the repositories
 
@@ -116,6 +121,7 @@ class TestISODownloads(UITestCase):
         """
 
     @stubbed()
+    @run_only_on('sat')
     def test_iso_download_7(self):
         """@test: Check if enabling the checkbox works
 
@@ -137,6 +143,7 @@ class TestISODownloads(UITestCase):
         """
 
     @stubbed()
+    @run_only_on('sat')
     def test_iso_download_8(self):
         """@test: Sync repos to local iso's
 
@@ -157,6 +164,7 @@ class TestISODownloads(UITestCase):
         """
 
     @stubbed()
+    @run_only_on('sat')
     def test_iso_download_9(self):
         """@test: Disabling the repo works
 

--- a/tests/foreman/ui/test_location.py
+++ b/tests/foreman/ui/test_location.py
@@ -24,7 +24,6 @@ from robottelo.ui.locators import common_locators, locators, tab_locators
 from robottelo.ui.session import Session
 
 
-@run_only_on('sat')
 @ddt
 class Location(UITestCase):
     """Implements Location tests in UI"""
@@ -33,6 +32,7 @@ class Location(UITestCase):
     # Auto Search
 
     @skip_if_bug_open('bugzilla', 1177610)
+    @run_only_on('sat')
     def test_auto_search(self):
         """@test: Can auto-complete search for location by partial name
 
@@ -59,6 +59,7 @@ class Location(UITestCase):
     # Positive Create
 
     @data(*generate_strings_list())
+    @run_only_on('sat')
     def test_positive_create_with_different_names(self, loc_name):
         """@test: Create Location with valid name only
 
@@ -72,6 +73,7 @@ class Location(UITestCase):
             self.assertIsNotNone(self.location.search(loc_name))
 
     @data(*generate_strings_list(len1=247))
+    @run_only_on('sat')
     def test_negative_create_with_too_long_names(self, loc_name):
         """@test: Create location with name as too long
 
@@ -87,6 +89,7 @@ class Location(UITestCase):
             self.assertIsNotNone(error)
 
     @data('', '  ')
+    @run_only_on('sat')
     def test_negative_create_with_blank_name(self, loc_name):
         """@test: Create location with name as blank
 
@@ -101,6 +104,7 @@ class Location(UITestCase):
                 common_locators['name_haserror'])
             self.assertIsNotNone(error)
 
+    @run_only_on('sat')
     def test_negative_create_with_same_name(self):
         """@test: Create location with valid values, then create a new one
         with same values.
@@ -131,6 +135,7 @@ class Location(UITestCase):
            'loc_name': gen_string('latin1', 10)},
           {'org_name': gen_string('html', 20),
            'loc_name': gen_string('html', 10)})
+    @run_only_on('sat')
     def test_positive_create_with_location_and_org(self, test_data):
         """@test: Select both organization and location.
 
@@ -154,6 +159,7 @@ class Location(UITestCase):
     # Positive Update
 
     @data(*generate_strings_list())
+    @run_only_on('sat')
     def test_positive_update_with_different_names(self, new_name):
         """@test: Create Location with valid values then update its name
 
@@ -171,6 +177,7 @@ class Location(UITestCase):
 
     # Negative Update
 
+    @run_only_on('sat')
     def test_negative_update_with_too_long_name(self):
         """@test: Create Location with valid values then fail to update
         its name
@@ -191,6 +198,7 @@ class Location(UITestCase):
             self.assertIsNotNone(error)
 
     @data(*generate_strings_list())
+    @run_only_on('sat')
     def test_positive_delete(self, loc_name):
         """@test: Create location with valid values then delete it.
 
@@ -205,6 +213,7 @@ class Location(UITestCase):
             self.location.delete(loc_name)
 
     @data(*generate_strings_list())
+    @run_only_on('sat')
     def test_add_subnet(self, subnet_name):
         """@test: Add a subnet by using location name and subnet name
 
@@ -232,6 +241,7 @@ class Location(UITestCase):
             self.assertIsNotNone(element)
 
     @data(*generate_strings_list())
+    @run_only_on('sat')
     def test_add_domain(self, domain_name):
         """@test: Add a domain to a Location
 
@@ -261,6 +271,7 @@ class Location(UITestCase):
         gen_string('utf8'),
         gen_string('latin1')
     )
+    @run_only_on('sat')
     def test_add_user(self, user_name):
         """@test: Create user then add that user by using the location name
 
@@ -289,6 +300,7 @@ class Location(UITestCase):
                 (strategy, value % user_name))
             self.assertIsNotNone(element)
 
+    @run_only_on('sat')
     def test_allvalues_hostgroup(self):
         """@test: check whether host group has the 'All values' checked.
 
@@ -311,6 +323,7 @@ class Location(UITestCase):
             self.assertIsNotNone(selected)
 
     @data(*generate_strings_list())
+    @run_only_on('sat')
     def test_add_hostgroup(self, host_grp_name):
         """@test: Add a hostgroup by using the location name and hostgroup name
 
@@ -333,6 +346,7 @@ class Location(UITestCase):
             self.assertIsNotNone(element)
 
     @data(*generate_strings_list())
+    @run_only_on('sat')
     def test_add_org(self, org_name):
         """@test: Add a organization by using the location name
 
@@ -360,6 +374,7 @@ class Location(UITestCase):
         gen_string('numeric'),
         gen_string('alphanumeric')
     )
+    @run_only_on('sat')
     def test_add_environment(self, env_name):
         """@test: Add environment by using location name and environment name
 
@@ -383,6 +398,7 @@ class Location(UITestCase):
             self.assertIsNotNone(element)
 
     @data(*generate_strings_list())
+    @run_only_on('sat')
     def test_add_computeresource(self, resource_name):
         """@test: Add compute resource using the location name and
         compute resource name
@@ -409,6 +425,7 @@ class Location(UITestCase):
             self.assertIsNotNone(element)
 
     @data(*generate_strings_list())
+    @run_only_on('sat')
     def test_add_medium(self, medium_name):
         """@test: Add medium by using the location name and medium name
 
@@ -435,6 +452,7 @@ class Location(UITestCase):
                 (strategy, value % medium_name))
             self.assertIsNotNone(element)
 
+    @run_only_on('sat')
     def test_allvalues_configtemplate(self):
         """@test: check whether config template has the 'All values' checked.
 
@@ -454,6 +472,7 @@ class Location(UITestCase):
             self.assertIsNotNone(selected)
 
     @data(*generate_strings_list())
+    @run_only_on('sat')
     def test_add_configtemplate(self, template):
         """@test: Add config template by using location name and config
         template name.
@@ -487,6 +506,7 @@ class Location(UITestCase):
         gen_string('numeric'),
         gen_string('alphanumeric')
     )
+    @run_only_on('sat')
     def test_remove_environment(self, env_name):
         """@test: Remove environment by using location name & environment name
 
@@ -518,6 +538,7 @@ class Location(UITestCase):
             self.assertIsNotNone(element)
 
     @data(*generate_strings_list())
+    @run_only_on('sat')
     def test_remove_subnet(self, subnet_name):
         """@test: Remove subnet by using location name and subnet name
 
@@ -553,6 +574,7 @@ class Location(UITestCase):
             self.assertIsNotNone(element)
 
     @data(*generate_strings_list())
+    @run_only_on('sat')
     def test_remove_domain(self, domain_name):
         """@test: Add a domain to an location and remove it by location name
         and domain name
@@ -591,6 +613,7 @@ class Location(UITestCase):
         gen_string('utf8'),
         gen_string('latin1')
     )
+    @run_only_on('sat')
     def test_remove_user(self, user_name):
         """@test: Create admin users then add user and remove it by using the
         location name
@@ -628,6 +651,7 @@ class Location(UITestCase):
             self.assertIsNotNone(element)
 
     @data(*generate_strings_list())
+    @run_only_on('sat')
     def test_remove_hostgroup(self, host_grp_name):
         """@test: Add a hostgroup and remove it by using the location name and
         hostgroup name
@@ -659,6 +683,7 @@ class Location(UITestCase):
             self.assertIsNone(element)
 
     @data(*generate_strings_list())
+    @run_only_on('sat')
     def test_remove_computeresource(self, resource_name):
         """@test: Remove compute resource by using the location name and
         compute resource name
@@ -693,6 +718,7 @@ class Location(UITestCase):
             self.assertIsNotNone(element)
 
     @data(*generate_strings_list())
+    @run_only_on('sat')
     def test_remove_medium(self, medium_name):
         """@test: Remove medium by using location name and medium name
 
@@ -734,6 +760,7 @@ class Location(UITestCase):
         {u'user_name': gen_string('utf8', 8), 'bugzilla': 1164247},
         {u'user_name': gen_string('latin1', 8)},
         {u'user_name': gen_string('html', 8)},)
+    @run_only_on('sat')
     def test_remove_configtemplate(self, testdata):
         """
         @test: Remove config template

--- a/tests/foreman/ui/test_medium.py
+++ b/tests/foreman/ui/test_medium.py
@@ -12,12 +12,12 @@ from robottelo.ui.locators import common_locators
 from robottelo.ui.session import Session
 
 
-@run_only_on('sat')
 @ddt
 class Medium(UITestCase):
     """Implements all Installation Media tests"""
 
     @data(*valid_data_list())
+    @run_only_on('sat')
     def test_positive_create_medium(self, name):
         """@Test: Create a new media
 
@@ -31,6 +31,7 @@ class Medium(UITestCase):
             make_media(session, name=name, path=path, os_family='Red Hat')
             self.assertIsNotNone(self.medium.search(name))
 
+    @run_only_on('sat')
     def test_negative_create_medium_with_long_names(self):
         """@Test: Create a new install media with 256 characters in name
 
@@ -48,6 +49,7 @@ class Medium(UITestCase):
             self.assertIsNone(self.medium.search(name))
 
     @data('', '  ')
+    @run_only_on('sat')
     def test_negative_create_medium_with_empty_strings(self, name):
         """@Test: Create a new install media with blank and whitespace in name
 
@@ -63,6 +65,7 @@ class Medium(UITestCase):
             self.assertIsNotNone(self.medium.wait_until_element
                                  (common_locators['name_haserror']))
 
+    @run_only_on('sat')
     def test_negative_create_medium_with_same_name(self):
         """@Test: Create a new install media with same name
 
@@ -81,6 +84,7 @@ class Medium(UITestCase):
             self.assertIsNotNone(self.medium.wait_until_element
                                  (common_locators['name_haserror']))
 
+    @run_only_on('sat')
     def test_negative_create_medium_without_path(self):
         """@Test: Create a new install media without media URL
 
@@ -96,6 +100,7 @@ class Medium(UITestCase):
                                  (common_locators['haserror']))
             self.assertIsNone(self.medium.search(name))
 
+    @run_only_on('sat')
     def test_negative_create_medium_with_same_path(self):
         """@Test: Create an install media with an existing URL
 
@@ -116,6 +121,7 @@ class Medium(UITestCase):
                                  (common_locators['haserror']))
             self.assertIsNone(self.medium.search(new_name))
 
+    @run_only_on('sat')
     def test_remove_medium(self):
         """@Test: Delete a media
 
@@ -130,6 +136,7 @@ class Medium(UITestCase):
             make_media(session, name=name, path=path, os_family='Red Hat')
             self.medium.delete(name)
 
+    @run_only_on('sat')
     def test_update_medium(self):
         """@Test: Updates Install media with name, path, OS family
 

--- a/tests/foreman/ui/test_operatingsys.py
+++ b/tests/foreman/ui/test_operatingsys.py
@@ -16,7 +16,6 @@ from robottelo.ui.locators import common_locators
 from robottelo.ui.session import Session
 
 
-@run_only_on('sat')
 @ddt
 class OperatingSys(UITestCase):
     """Implements Operating system tests from UI"""
@@ -27,6 +26,7 @@ class OperatingSys(UITestCase):
         cls.organization = entities.Organization().create()
 
     @data(*valid_data_list())
+    @run_only_on('sat')
     def test_create_os_with_different_names(self, name):
         """@Test: Create a new OS using different string types as a name
 
@@ -62,6 +62,7 @@ class OperatingSys(UITestCase):
            u'minor_version': gen_string('numeric', 1),
            u'desc': gen_string('alphanumeric', 255),
            u'os_family': 'SUSE'})
+    @run_only_on('sat')
     def test_create_os_with_random_params(self, test_data):
         """@Test: Create a new OS with different data values
 
@@ -87,6 +88,7 @@ class OperatingSys(UITestCase):
                                  (test_data['desc'], search_key='description'))
 
     @data(*invalid_names_list())
+    @run_only_on('sat')
     def test_negative_create_os_with_long_names(self, name):
         """@Test: OS - Create a new OS with too long string of different types
         as its name value
@@ -111,6 +113,7 @@ class OperatingSys(UITestCase):
                                  (common_locators['name_haserror']))
             self.assertIsNone(self.operatingsys.search(name))
 
+    @run_only_on('sat')
     def test_negative_create_os_with_blank_name(self):
         """@Test: OS - Create a new OS with blank name
 
@@ -131,6 +134,7 @@ class OperatingSys(UITestCase):
             self.assertIsNotNone(self.operatingsys.wait_until_element
                                  (common_locators['name_haserror']))
 
+    @run_only_on('sat')
     def test_negative_create_os_with_long_desc(self):
         """@Test: OS - Create a new OS with description containing
         256 characters
@@ -156,6 +160,7 @@ class OperatingSys(UITestCase):
             self.assertIsNone(self.operatingsys.search(name))
 
     @data(gen_string('numeric', 6), '', '-6')
+    @run_only_on('sat')
     def test_negative_create_os_with_wrong_major_version(self, major_version):
         """@Test: OS - Create a new OS with incorrect major version value(More than 5
         characters, empty value, negative number)
@@ -180,6 +185,7 @@ class OperatingSys(UITestCase):
             self.assertIsNone(self.operatingsys.search(name))
 
     @data(gen_string('numeric', 17), '-5')
+    @run_only_on('sat')
     def test_negative_create_os_with_wrong_minor_version(self, minor_version):
         """@Test: OS - Create a new OS with incorrect minor version value(More than 16
         characters and negative number)
@@ -204,6 +210,7 @@ class OperatingSys(UITestCase):
             self.assertIsNone(self.operatingsys.search(name))
 
     @skip_if_bug_open('bugzilla', 1120985)
+    @run_only_on('sat')
     def test_negative_create_os_with_same_name_and_version(self):
         """@Test: OS - Create a new OS with same name and version
 
@@ -238,6 +245,7 @@ class OperatingSys(UITestCase):
             self.assertIsNotNone(self.operatingsys.wait_until_element
                                  (common_locators['haserror']))
 
+    @run_only_on('sat')
     def test_remove_os(self):
         """@Test: Delete an existing OS
 
@@ -269,6 +277,7 @@ class OperatingSys(UITestCase):
          u'new_minor_version': gen_string('numeric', 1),
          u'new_os_family': 'SUSE'}
     )
+    @run_only_on('sat')
     def test_update_os_basic_params(self, test_data):
         """@Test: Update OS name, major_version, minor_version, os_family
         and arch
@@ -290,6 +299,7 @@ class OperatingSys(UITestCase):
             self.assertIsNotNone(self.operatingsys.search(
                 test_data['new_name']))
 
+    @run_only_on('sat')
     def test_update_os_medium(self):
         """@Test: Update OS medium
 
@@ -311,6 +321,7 @@ class OperatingSys(UITestCase):
             result_obj = self.operatingsys.get_os_entities(os_name, 'medium')
             self.assertEqual(medium_name, result_obj['medium'])
 
+    @run_only_on('sat')
     def test_update_os_partition_table(self):
         """@Test: Update OS partition table
 
@@ -334,6 +345,7 @@ class OperatingSys(UITestCase):
             result_obj = self.operatingsys.get_os_entities(os_name, 'ptable')
             self.assertEqual(ptable, result_obj['ptable'])
 
+    @run_only_on('sat')
     def test_update_os_template(self):
         """@Test: Update provisioning template
 
@@ -358,6 +370,7 @@ class OperatingSys(UITestCase):
             result_obj = self.operatingsys.get_os_entities(os_name, 'template')
             self.assertEqual(template_name, result_obj['template'])
 
+    @run_only_on('sat')
     def test_positive_set_os_parameter(self):
         """@Test: Set OS parameter
 
@@ -376,6 +389,7 @@ class OperatingSys(UITestCase):
             except UIError as err:
                 self.fail(err)
 
+    @run_only_on('sat')
     def test_positive_set_os_parameter_with_blank_value(self):
         """@Test: Set OS parameter with blank value
 
@@ -394,6 +408,7 @@ class OperatingSys(UITestCase):
             except UIError as err:
                 self.fail(err)
 
+    @run_only_on('sat')
     def test_remove_os_parameter(self):
         """@Test: Remove selected OS parameter
 
@@ -412,6 +427,7 @@ class OperatingSys(UITestCase):
             except UIError as err:
                 self.fail(err)
 
+    @run_only_on('sat')
     def test_negative_set_os_parameter_same_values(self):
         """@Test: Set same OS parameter again as it was set earlier
 
@@ -434,6 +450,7 @@ class OperatingSys(UITestCase):
                 common_locators['common_param_error']
             ))
 
+    @run_only_on('sat')
     def test_negative_set_os_parameter_with_blank_value(self):
         """@Test: Set OS parameter with blank name and value
 
@@ -453,6 +470,7 @@ class OperatingSys(UITestCase):
             ))
 
     @data(*invalid_names_list())
+    @run_only_on('sat')
     def test_negative_set_os_parameter_with_long_values(self, param):
         """@Test: Set OS parameter with name and value exceeding 255 characters
 

--- a/tests/foreman/ui/test_partitiontable.py
+++ b/tests/foreman/ui/test_partitiontable.py
@@ -11,12 +11,12 @@ from robottelo.ui.locators import common_locators
 from robottelo.ui.session import Session
 
 
-@run_only_on('sat')
 @ddt
 class PartitionTable(UITestCase):
     """Implements the partition table tests from UI"""
 
     @data(*generate_strings_list(len1=10))
+    @run_only_on('sat')
     def test_positive_create_partition_table(self, name):
         """@Test: Create a new partition table
 
@@ -35,6 +35,7 @@ class PartitionTable(UITestCase):
             self.assertIsNotNone(self.partitiontable.search(name))
 
     @data(*generate_strings_list(len1=256))
+    @run_only_on('sat')
     def test_negative_create_partition_table_with_long_names(self, name):
         """@Test: Create a new partition table with 256 characters in name
 
@@ -55,6 +56,7 @@ class PartitionTable(UITestCase):
             self.assertIsNone(self.partitiontable.search(name))
 
     @data('', '  ')
+    @run_only_on('sat')
     def test_negative_create_partition_table_with_empty_name(self, name):
         """@Test: Create partition table with blank and whitespace in name
 
@@ -73,6 +75,7 @@ class PartitionTable(UITestCase):
             self.assertIsNotNone(self.partitiontable.wait_until_element
                                  (common_locators['name_haserror']))
 
+    @run_only_on('sat')
     def test_negative_create_partition_table_with_same_name(self):
         """@Test: Create a new partition table with same name
 
@@ -93,6 +96,7 @@ class PartitionTable(UITestCase):
             self.assertIsNotNone(self.partitiontable.wait_until_element
                                  (common_locators['name_haserror']))
 
+    @run_only_on('sat')
     def test_negative_create_partition_table_empty_layout(self):
         """@Test: Create a new partition table with empty layout
 
@@ -117,6 +121,7 @@ class PartitionTable(UITestCase):
         {u'name': gen_string('latin1')},
         {u'name': gen_string('utf8')})
     @data(*generate_strings_list())
+    @run_only_on('sat')
     def test_remove_partition_table(self, test_data):
         """@Test: Delete a partition table
 
@@ -145,6 +150,7 @@ class PartitionTable(UITestCase):
            u'new_name': gen_string('utf8')},
           {u'name': gen_string('alphanumeric'),
            u'new_name': gen_string('alphanumeric')})
+    @run_only_on('sat')
     def test_update_partition_table(self, test_data):
         """@Test: Update partition table with its name, layout and OS family
 

--- a/tests/foreman/ui/test_puppet_classes.py
+++ b/tests/foreman/ui/test_puppet_classes.py
@@ -8,12 +8,12 @@ from robottelo.test import UITestCase
 from robottelo.ui.session import Session
 
 
-@run_only_on('sat')
 @ddt
 class PuppetClasses(UITestCase):
     """Implements puppet classes tests in UI."""
 
     @data(*generate_strings_list(len1=8))
+    @run_only_on('sat')
     def test_update_positive(self, description):
         """@Test: Create new puppet-class
 
@@ -43,6 +43,7 @@ class PuppetClasses(UITestCase):
             )
 
     @data(*generate_strings_list(len1=8))
+    @run_only_on('sat')
     def test_delete_positive(self, name):
         """@Test: Create new puppet-class
 

--- a/tests/foreman/ui/test_subnet.py
+++ b/tests/foreman/ui/test_subnet.py
@@ -12,7 +12,6 @@ from robottelo.ui.locators import common_locators, locators, tab_locators
 from robottelo.ui.session import Session
 
 
-@run_only_on('sat')
 @ddt
 class Subnet(UITestCase):
     """Implements Subnet tests in UI"""
@@ -23,6 +22,7 @@ class Subnet(UITestCase):
         cls.organization = entities.Organization().create()
 
     @data(*generate_strings_list(len1=8))
+    @run_only_on('sat')
     def test_create_subnet_with_different_names(self, name):
         """@Test: Create new subnet
 
@@ -48,6 +48,7 @@ class Subnet(UITestCase):
         {'name': gen_string('utf8', 255),
          u'bz-bug': 1180066}
     )
+    @run_only_on('sat')
     def test_create_subnet_with_long_strings(self, test_data):
         """@Test: Create new subnet with 255 characters in name
 
@@ -70,6 +71,7 @@ class Subnet(UITestCase):
             self.assertIsNotNone(
                 self.subnet.search_subnet(subnet_name=test_data['name']))
 
+    @run_only_on('sat')
     def test_create_subnet_with_domain(self):
         """@Test: Create new subnet and associate domain with it
 
@@ -111,6 +113,7 @@ class Subnet(UITestCase):
                 self.assertIsNotNone()
 
     @data(*generate_strings_list(len1=256))
+    @run_only_on('sat')
     def test_create_subnet_negative_with_too_long_name(self, name):
         """@Test: Create new subnet with 256 characters in name
 
@@ -130,6 +133,7 @@ class Subnet(UITestCase):
                 common_locators['haserror']))
 
     @data('', ' ')
+    @run_only_on('sat')
     def test_create_subnet_negative_with_blank_name(self, name):
         """@Test: Create new subnet with whitespace and blank in name.
 
@@ -148,6 +152,7 @@ class Subnet(UITestCase):
             self.assertIsNotNone(session.nav.wait_until_element(
                 common_locators['haserror']))
 
+    @run_only_on('sat')
     def test_create_subnet_negative_values(self):
         """@Test: Create new subnet with negative values
 
@@ -183,6 +188,7 @@ class Subnet(UITestCase):
             self.assertIsNotNone(secondarydns_element)
 
     @data(*generate_strings_list(len1=8))
+    @run_only_on('sat')
     def test_remove_subnet(self, name):
         """@Test: Delete a subnet
 
@@ -200,6 +206,7 @@ class Subnet(UITestCase):
             )
             self.subnet.delete(name)
 
+    @run_only_on('sat')
     def test_remove_subnet_and_cancel(self):
         """@Test: Delete subnet.
 
@@ -221,6 +228,7 @@ class Subnet(UITestCase):
             self.subnet.delete(name, False)
 
     @data(*generate_strings_list(len1=8))
+    @run_only_on('sat')
     def test_update_subnet_with_name(self, new_name):
         """@Test: Update Subnet name
 
@@ -241,6 +249,7 @@ class Subnet(UITestCase):
             result_object = self.subnet.search_subnet(new_name)
             self.assertEqual(new_name, result_object['name'])
 
+    @run_only_on('sat')
     def test_update_subnet_with_network(self):
         """@Test: Update Subnet network
 
@@ -262,6 +271,7 @@ class Subnet(UITestCase):
             result_object = self.subnet.search_subnet(name)
             self.assertEqual(new_network, result_object['network'])
 
+    @run_only_on('sat')
     def test_update_subnet_with_mask(self):
         """@Test: Update Subnet mask
 

--- a/tests/foreman/ui/test_template.py
+++ b/tests/foreman/ui/test_template.py
@@ -13,7 +13,6 @@ from robottelo.ui.locators import common_locators
 from robottelo.ui.session import Session
 
 
-@run_only_on('sat')
 @ddt
 class Template(UITestCase):
     """Implements Provisioning Template tests from UI"""
@@ -24,6 +23,7 @@ class Template(UITestCase):
         cls.organization = entities.Organization().create()
 
     @data(*generate_strings_list(len1=8))
+    @run_only_on('sat')
     def test_positive_create_template(self, name):
         """@Test: Create new template
 
@@ -43,6 +43,7 @@ class Template(UITestCase):
             )
             self.assertIsNotNone(self.template.search(name))
 
+    @run_only_on('sat')
     def test_negative_create_template_with_too_long_name(self):
         """@Test: Template - Create a new template with 256 characters in name
 
@@ -63,6 +64,7 @@ class Template(UITestCase):
                                  (common_locators['name_haserror']))
 
     @data(' ', '')
+    @run_only_on('sat')
     def test_negative_create_template_with_blank_name(self, name):
         """@Test: Create a new template with blank and whitespace in name
 
@@ -82,6 +84,7 @@ class Template(UITestCase):
             self.assertIsNotNone(self.template.wait_until_element
                                  (common_locators['name_haserror']))
 
+    @run_only_on('sat')
     def test_negative_create_template_with_same_name(self):
         """@Test: Template - Create a new template with same name
 
@@ -102,6 +105,7 @@ class Template(UITestCase):
             self.assertIsNotNone(self.template.wait_until_element
                                  (common_locators['name_haserror']))
 
+    @run_only_on('sat')
     def test_negative_create_template_without_type(self):
         """@Test: Template - Create a new template without selecting its type
 
@@ -125,6 +129,7 @@ class Template(UITestCase):
                     'Could not create template "{0}" without type'.format(name)
                 )
 
+    @run_only_on('sat')
     def test_negative_create_template_without_upload(self):
         """@Test: Template - Create a new template without uploading a template
 
@@ -148,6 +153,7 @@ class Template(UITestCase):
                     'Could not create blank template "{0}"'.format(name)
                 )
 
+    @run_only_on('sat')
     def test_negative_create_template_with_too_long_audit(self):
         """@Test: Create a new template with 256 characters in audit comments
 
@@ -169,6 +175,7 @@ class Template(UITestCase):
                                  (common_locators['haserror']))
 
     @data(*generate_strings_list(len1=8))
+    @run_only_on('sat')
     def test_positive_create_snippet_template(self, name):
         """@Test: Create new template of type snippet
 
@@ -189,6 +196,7 @@ class Template(UITestCase):
             self.assertIsNotNone(self.template.search(name))
 
     @data(*generate_strings_list(len1=8))
+    @run_only_on('sat')
     def test_remove_template(self, template_name):
         """@Test: Remove a template
 
@@ -203,6 +211,7 @@ class Template(UITestCase):
             session.nav.go_to_select_org(self.organization.name)
             self.template.delete(template_name)
 
+    @run_only_on('sat')
     def test_update_template(self):
         """@Test: Update template name and template type
 
@@ -225,6 +234,7 @@ class Template(UITestCase):
             self.template.update(name, False, new_name, None, 'PXELinux')
             self.assertIsNotNone(self.template.search(new_name))
 
+    @run_only_on('sat')
     def test_update_template_os(self):
         """@Test: Creates new template, along with two OS's
         and associate list of OS's with created template
@@ -252,6 +262,7 @@ class Template(UITestCase):
             self.template.update(name, False, new_name, new_os_list=os_list)
             self.assertIsNotNone(self.template.search(new_name))
 
+    @run_only_on('sat')
     def test_clone_template(self):
         """@Test: Assure ability to clone a provisioning template
 

--- a/tests/robottelo/test_decorators.py
+++ b/tests/robottelo/test_decorators.py
@@ -204,13 +204,23 @@ class RunOnlyOnTestCase(TestCase):
     def test_invalid_project(self, dec_settings):
         """Assert error is thrown when project has invalid value."""
         dec_settings.project = 'sam'
+
+        @decorators.run_only_on('satddfddffdf')
+        def dummy():
+            pass
+
         with self.assertRaises(decorators.ProjectModeError):
-            decorators.run_only_on('satddfddffdf')
+            dummy()
 
     @mock.patch('robottelo.decorators.settings')
     def test_invalid_mode(self, dec_settings):
         """Assert error is thrown when mode has invalid value."""
         # Invalid value for robottelo mode
         dec_settings.project = 'samtdd'
+
+        @decorators.run_only_on('sat')
+        def dummy():
+            pass
+
         with self.assertRaises(decorators.ProjectModeError):
-            decorators.run_only_on('sat')
+            dummy()


### PR DESCRIPTION
Make the decorator evaluate at run time in order to ready configured
settings.

Also drop docker external and internal compute resource URL constants
and use the settings values on the test.

Closes #2908