### PR TITLE
ddt removal in ui discovery rule tests

### DIFF
--- a/tests/foreman/ui/test_discoveryrule.py
+++ b/tests/foreman/ui/test_discoveryrule.py
@@ -1,17 +1,16 @@
 # -*- encoding: utf-8 -*-
+# pylint: disable=invalid-name
 """Test class for Foreman Discovery Rules"""
-from ddt import ddt, data
 from fauxfactory import gen_string
 from nailgun import entities
 from robottelo.decorators import run_only_on
-from robottelo.helpers import generate_strings_list
+from robottelo.helpers import generate_strings_list, invalid_values_list
 from robottelo.test import UITestCase
 from robottelo.ui.factory import make_discoveryrule
 from robottelo.ui.locators import common_locators
 from robottelo.ui.session import Session
 
 
-@ddt
 class DiscoveryRules(UITestCase):
     """Implements Foreman discovery Rules in UI."""
 
@@ -35,9 +34,8 @@ class DiscoveryRules(UITestCase):
 
         super(DiscoveryRules, cls).tearDownClass()
 
-    @data(*generate_strings_list(len1=8))
     @run_only_on('sat')
-    def test_positive_create_discovery_rule_1(self, name):
+    def test_positive_create_discovery_rule_1(self):
         """@Test: Create Discovery Rule
 
         @Feature: Foreman Discovery
@@ -46,9 +44,11 @@ class DiscoveryRules(UITestCase):
 
         """
         with Session(self.browser) as session:
-            make_discoveryrule(session, name=name,
-                               hostgroup=self.host_group.name)
-            self.assertIsNotNone(self.discoveryrules.search(name))
+            for name in generate_strings_list(len1=8):
+                with self.subTest(name):
+                    make_discoveryrule(session, name=name,
+                                       hostgroup=self.host_group.name)
+                    self.assertIsNotNone(self.discoveryrules.search(name))
 
     @run_only_on('sat')
     def test_positive_create_discovery_rule_2(self):
@@ -67,26 +67,7 @@ class DiscoveryRules(UITestCase):
 
     @run_only_on('sat')
     def test_negative_create_discovery_rule_1(self):
-        """@Test: Create Discovery Rule with 256 characters in name
-
-        @Feature: Foreman Discovery
-
-        @Assert: Error should be raised and rule should not be created
-
-        """
-        name = gen_string('alpha', 256)
-        with Session(self.browser) as session:
-            make_discoveryrule(session, name=name,
-                               hostgroup=self.host_group.name)
-            self.assertIsNotNone(self.discoveryrules.wait_until_element(
-                common_locators['name_haserror']
-            ))
-            self.assertIsNone(self.discoveryrules.search(name))
-
-    @data("", "  ")
-    @run_only_on('sat')
-    def test_negative_create_discovery_rule_2(self, name):
-        """@Test: Create Discovery Rule with blank and whitespace in name
+        """@Test: Create Discovery Rule with invalid names
 
         @Feature: Foreman Discovery
 
@@ -94,16 +75,18 @@ class DiscoveryRules(UITestCase):
 
         """
         with Session(self.browser) as session:
-            make_discoveryrule(session, name=name,
-                               hostgroup=self.host_group.name)
-            self.assertIsNotNone(self.discoveryrules.wait_until_element(
-                common_locators['name_haserror']
-            ))
-            self.assertIsNone(self.discoveryrules.search(name))
+            for name in invalid_values_list(interface='ui'):
+                with self.subTest(name):
+                    make_discoveryrule(session, name=name,
+                                       hostgroup=self.host_group.name)
+                    self.assertIsNotNone(
+                        self.discoveryrules.wait_until_element(
+                            common_locators['name_haserror'])
+                    )
+                    self.assertIsNone(self.discoveryrules.search(name))
 
-    @data('-1', gen_string("alpha", 6))
     @run_only_on('sat')
-    def test_negative_create_discovery_rule_3(self, limit):
+    def test_negative_create_discovery_rule_2(self):
         """@Test: Create Discovery Rule with invalid host limit
 
         @Feature: Foreman Discovery
@@ -113,15 +96,18 @@ class DiscoveryRules(UITestCase):
         """
         name = gen_string("alpha", 6)
         with Session(self.browser) as session:
-            make_discoveryrule(session, name=name, host_limit=limit,
-                               hostgroup=self.host_group.name)
-            self.assertIsNotNone(self.discoveryrules.wait_until_element(
-                common_locators['haserror']
-            ))
-            self.assertIsNone(self.discoveryrules.search(name))
+            for limit in '-1', gen_string("alpha", 6):
+                with self.subTest(limit):
+                    make_discoveryrule(session, name=name, host_limit=limit,
+                                       hostgroup=self.host_group.name)
+                    self.assertIsNotNone(
+                        self.discoveryrules.wait_until_element(
+                            common_locators['haserror'])
+                    )
+                    self.assertIsNone(self.discoveryrules.search(name))
 
     @run_only_on('sat')
-    def test_negative_create_discovery_rule_4(self):
+    def test_negative_create_discovery_rule_3(self):
         """@Test: Create Discovery Rule with name that already exists
 
         @Feature: Foreman Discovery
@@ -141,7 +127,7 @@ class DiscoveryRules(UITestCase):
             ))
 
     @run_only_on('sat')
-    def test_negative_create_discovery_rule_5(self):
+    def test_negative_create_discovery_rule_4(self):
         """@Test: Create Discovery Rule with invalid priority
 
         @Feature: Foreman Discovery
@@ -174,9 +160,8 @@ class DiscoveryRules(UITestCase):
                                hostgroup=self.host_group.name, enable=True)
             self.assertIsNotNone(self.discoveryrules.search(name))
 
-    @data(*generate_strings_list(len1=8))
     @run_only_on('sat')
-    def test_delete_discovery_rule_1(self, name):
+    def test_delete_discovery_rule_1(self):
         """@Test: Delete Discovery Rule
 
         @Feature: Foreman Discovery
@@ -185,15 +170,16 @@ class DiscoveryRules(UITestCase):
 
         """
         with Session(self.browser) as session:
-            make_discoveryrule(session, name=name,
-                               hostgroup=self.host_group.name)
-            self.assertIsNotNone(self.discoveryrules.search(name))
-            self.discoveryrules.delete(name)
-            self.assertIsNone(self.discoveryrules.search(name))
+            for name in generate_strings_list(len1=8):
+                with self.subTest(name):
+                    make_discoveryrule(session, name=name,
+                                       hostgroup=self.host_group.name)
+                    self.assertIsNotNone(self.discoveryrules.search(name))
+                    self.discoveryrules.delete(name)
+                    self.assertIsNone(self.discoveryrules.search(name))
 
-    @data(*generate_strings_list(len1=8))
     @run_only_on('sat')
-    def test_update_discovery_rule_1(self, new_name):
+    def test_update_discovery_rule_1(self):
         """@Test: Update discovery rule name
 
         @Feature: Discovery Rule - Update
@@ -203,16 +189,11 @@ class DiscoveryRules(UITestCase):
         """
         name = gen_string("alpha", 6)
         with Session(self.browser) as session:
-            make_discoveryrule(
-                session, name=name,
-                hostgroup=self.host_group.name
-            )
-            self.assertIsNotNone(
-                self.discoveryrules.search(name)
-            )
-            self.discoveryrules.update(
-                name=name, new_name=new_name,
-            )
-            self.assertIsNotNone(
-                self.discoveryrules.search(new_name)
-            )
+            make_discoveryrule(session, name=name,
+                               hostgroup=self.host_group.name)
+            self.assertIsNotNone(self.discoveryrules.search(name))
+            for new_name in generate_strings_list(len1=8):
+                with self.subTest(new_name):
+                    self.discoveryrules.update(name=name, new_name=new_name)
+                    self.assertIsNotNone(self.discoveryrules.search(new_name))
+                    name = new_name  # for next iteration


### PR DESCRIPTION
Test results:
```sh
# nosetests tests/foreman/ui/test_discoveryrule.py:DiscoveryRules.test_positive_create_discovery_rule_1
.
----------------------------------------------------------------------
Ran 1 test in 31.983s

OK

# nosetests tests/foreman/ui/test_discoveryrule.py:DiscoveryRules.test_negative_create_discovery_rule_2
.
----------------------------------------------------------------------
Ran 1 test in 39.206s

OK

# nosetests tests/foreman/ui/test_discoveryrule.py:DiscoveryRules.test_negative_create_discovery_rule_3
.
----------------------------------------------------------------------
Ran 1 test in 39.648s

OK

# nosetests tests/foreman/ui/test_discoveryrule.py:DiscoveryRules.test_delete_discovery_rule_1
.
----------------------------------------------------------------------
Ran 1 test in 132.546s

OK

# nosetests tests/foreman/ui/test_discoveryrule.py:DiscoveryRules.test_update_discovery_rule_1
.
----------------------------------------------------------------------
Ran 1 test in 28.837s

OK
```