### PR TITLE
Provide coverage for functionality mentioned in 1259248 BZ

### DIFF
--- a/robottelo/ui/locators.py
+++ b/robottelo/ui/locators.py
@@ -749,6 +749,7 @@ locators = LocatorDict({
     "org.parent": (By.ID, "organization_parent_id"),
     "org.label": (By.ID, "organization_label"),
     "org.desc": (By.ID, "organization_description"),
+    "org.cert": (By.ID, "download_debug_cert_key"),
     "org.proceed_to_edit": (
         By.XPATH,
         "//a[@class='btn btn-default' and contains(@href, '/edit')]"),


### PR DESCRIPTION
Closes #2910

Nailgun part implemented in:
https://github.com/SatelliteQE/nailgun/pull/230

Reproduced successfully

6.1.2 early build(before fix):
```
>nosetests tests/foreman/ui/test_org.py -m test_manifest_refresh_bz1259248
nailgun.client: WARNING: Received HTTP 500 response: {
  "error": {"message":"Katello::Resources::Candlepin::Owner: 500 Internal Server Error {\"displayMessage\":\"Runtime Error Index: 0, Size: 0 at java.util.ArrayList.rangeCheck:635\",\"requestUuid\":\"64b97c18-b206-48fe-9186-e1e992be1b11\"} (GET /candlepin/owners/1b5a7857-ef92-4202-a844-ad09911608a2/uebercert)"}
}

Ran 1 test in 167.391s

FAILED (errors=1)
```
6.1.3 (latest compose):
```
>nosetests tests/foreman/ui/test_org.py -m test_manifest_refresh_bz1259248
.
----------------------------------------------------------------------
Ran 1 test in 219.891s

OK
```