### PR TITLE
ddt removal in ui org tests

### DIFF
--- a/tests/foreman/ui/test_org.py
+++ b/tests/foreman/ui/test_org.py
@@ -1,8 +1,7 @@
 # -*- encoding: utf-8 -*-
-# pylint: disable=R0904
+# pylint: disable=too-many-public-methods, invalid-name
 """Test class for Organization UI"""
 
-from ddt import ddt, data
 from fauxfactory import gen_ipaddr, gen_string
 from nailgun import entities
 from robottelo import manifests
@@ -10,7 +9,10 @@ from robottelo.api.utils import upload_manifest
 from robottelo.config import settings
 from robottelo.constants import INSTALL_MEDIUM_URL, LIBVIRT_RESOURCE_URL
 from robottelo.helpers import (
-    generate_strings_list, invalid_names_list, invalid_values_list)
+    generate_strings_list,
+    invalid_names_list,
+    invalid_values_list,
+)
 from robottelo.decorators import run_only_on, skip_if_bug_open, stubbed
 from robottelo.test import UITestCase
 from robottelo.ui.factory import make_lifecycle_environment, make_org
@@ -18,7 +20,36 @@ from robottelo.ui.locators import common_locators, locators, tab_locators
 from robottelo.ui.session import Session
 
 
-@ddt
+def valid_labels():
+    """Returns a list of valid labels"""
+    return [
+        gen_string('alpha'),
+        gen_string('numeric'),
+        gen_string('alphanumeric'),
+    ]
+
+
+def valid_users():
+    """Returns a list of valid users"""
+    return[
+        gen_string('alpha'),
+        gen_string('numeric'),
+        gen_string('alphanumeric'),
+        gen_string('utf8'),
+        gen_string('latin1'),
+        # Note: HTML username is invalid as per the UI msg.
+    ]
+
+
+def valid_env_names():
+    """Returns a list of valid environment names"""
+    return [
+        gen_string('alpha'),
+        gen_string('numeric'),
+        gen_string('alphanumeric'),
+    ]
+
+
 class Org(UITestCase):
     """Implements Organization tests in UI"""
 
@@ -48,24 +79,22 @@ class Org(UITestCase):
 
     # Positive Create
 
-    @data(*generate_strings_list())
-    def test_positive_create_with_different_names(self, org_name):
+    def test_positive_create_with_different_names(self):
         """@test: Create organization with valid name only.
 
         @feature: Organizations
 
         @assert: Organization is created, label is auto-generated
 
-        @BZ: 1131469
-
         """
         with Session(self.browser) as session:
-            make_org(session, org_name=org_name)
-            self.assertIsNotNone(self.org.search(org_name))
+            for org_name in generate_strings_list():
+                with self.subTest(org_name):
+                    make_org(session, org_name=org_name)
+                    self.assertIsNotNone(self.org.search(org_name))
 
     @stubbed('parent_org feature is disabled currently')
-    @data(*generate_strings_list())
-    def test_positive_create_with_parent(self, parent_name):
+    def test_positive_create_with_parent(self):
         """@test: Create organization with valid name, label, parent_org, desc.
 
         @feature: Organizations
@@ -73,26 +102,22 @@ class Org(UITestCase):
         @assert: organization is created.
 
         """
-        org_name = gen_string('alpha')
         with Session(self.browser) as session:
-            make_org(session, org_name=parent_name)
-            make_org(
-                session,
-                org_name=org_name,
-                label=gen_string('alpha'),
-                desc=gen_string('alpha'),
-                parent_org=parent_name
-            )
-            self.assertIsNotNone(self.org.search(org_name))
+            for parent_name in generate_strings_list():
+                with self.subTest(parent_name):
+                    org_name = gen_string('alpha')
+                    make_org(session, org_name=parent_name)
+                    make_org(
+                        session,
+                        org_name=org_name,
+                        label=gen_string('alpha'),
+                        desc=gen_string('alpha'),
+                        parent_org=parent_name
+                    )
+                    self.assertIsNotNone(self.org.search(org_name))
 
-    @data({'name': gen_string('alpha'),
-           'label': gen_string('alpha')},
-          {'name': gen_string('numeric'),
-           'label': gen_string('numeric')},
-          {'name': gen_string('alphanumeric'),
-           'label': gen_string('alphanumeric')})
     # As label cannot contain chars other than ascii alpha numerals, '_', '-'.
-    def test_positive_create_with_diff_names_and_labels(self, test_data):
+    def test_positive_create_with_diff_names_and_labels(self):
         """@test: Create organization with valid unmatching name and label only
 
         @feature: Organizations
@@ -100,21 +125,21 @@ class Org(UITestCase):
         @assert: organization is created, label does not match name
 
         """
-        org_name = test_data['name']
         with Session(self.browser) as session:
-            make_org(session, org_name=org_name, label=test_data['label'])
-            self.org.search(org_name).click()
-            name = session.nav.wait_until_element(
-                locators['org.name']).get_attribute('value')
-            label = session.nav.wait_until_element(
-                locators['org.label']).get_attribute('value')
-            self.assertNotEqual(name, label)
+            for label in valid_labels():
+                with self.subTest(label):
+                    org_name = gen_string('alphanumeric')
+                    make_org(
+                        session, org_name=org_name, label=label)
+                    self.org.search(org_name).click()
+                    name = session.nav.wait_until_element(
+                        locators['org.name']).get_attribute('value')
+                    label = session.nav.wait_until_element(
+                        locators['org.label']).get_attribute('value')
+                    self.assertNotEqual(name, label)
 
-    @data(gen_string('alpha'),
-          gen_string('numeric'),
-          gen_string('alphanumeric'))
     # As label cannot contain chars other than ascii alpha numerals, '_', '-'.
-    def test_positive_create_with_same_names_and_labels(self, org_data):
+    def test_positive_create_with_same_names_and_labels(self):
         """@test: Create organization with valid matching name and label only.
 
         @feature: Organizations
@@ -123,18 +148,18 @@ class Org(UITestCase):
 
         """
         with Session(self.browser) as session:
-            make_org(session, org_name=org_data, label=org_data)
-            self.org.search(org_data).click()
-            name = self.org.wait_until_element(
-                locators['org.name']).get_attribute('value')
-            label = self.org.wait_until_element(
-                locators['org.label']).get_attribute('value')
-            self.assertEqual(name, label)
+            for item in valid_labels():
+                with self.subTest(item):
+                    make_org(session, org_name=item, label=item)
+                    self.org.search(item).click()
+                    name = self.org.wait_until_element(
+                        locators['org.name']).get_attribute('value')
+                    label = self.org.wait_until_element(
+                        locators['org.label']).get_attribute('value')
+                    self.assertEqual(name, label)
 
     @skip_if_bug_open('bugzilla', 1079482)
-    @skip_if_bug_open('bugzilla', 1131469)
-    @data(*generate_strings_list())
-    def test_positive_create_with_auto_gen_label(self, org_name):
+    def test_positive_create_with_auto_gen_label(self):
         """@test: Create organization with valid name. Check that organization
         label is auto-populated
 
@@ -144,19 +169,19 @@ class Org(UITestCase):
 
         @BZ: 1079482
 
-        @BZ: 1131469
-
         """
         with Session(self.browser) as session:
-            make_org(session, org_name=org_name)
-            self.assertIsNotNone(self.org.search(org_name))
-            self.org.search(org_name).click()
-            label = session.nav.wait_until_element(locators['org.label'])
-            label_value = label.get_attribute('value')
-            self.assertIsNotNone(label_value)
+            for org_name in generate_strings_list():
+                with self.subTest(org_name):
+                    make_org(session, org_name=org_name)
+                    self.assertIsNotNone(self.org.search(org_name))
+                    self.org.search(org_name).click()
+                    label = session.nav.wait_until_element(
+                        locators['org.label'])
+                    label_value = label.get_attribute('value')
+                    self.assertIsNotNone(label_value)
 
-    @data(*generate_strings_list())
-    def test_positive_create_with_both_location_and_org(self, name):
+    def test_positive_create_with_both_location_and_org(self):
         """@test: Select both organization and location.
 
         @feature: Organizations
@@ -164,18 +189,20 @@ class Org(UITestCase):
         @assert: Both organization and location are selected.
 
         """
-        location = entities.Location(name=name).create()
-        self.assertEqual(location.name, name)
         with Session(self.browser) as session:
-            make_org(session, org_name=name, locations=[name])
-            self.assertIsNotNone(self.org.search(name))
-            organization = session.nav.go_to_select_org(name)
-            location = session.nav.go_to_select_loc(name)
-            self.assertEqual(organization, name)
-            self.assertEqual(location, name)
+            for name in generate_strings_list():
+                with self.subTest(name):
+                    #  Use nailgun to create Location
+                    location = entities.Location(name=name).create()
+                    self.assertEqual(location.name, name)
+                    make_org(session, org_name=name, locations=[name])
+                    self.assertIsNotNone(self.org.search(name))
+                    organization = session.nav.go_to_select_org(name)
+                    location = session.nav.go_to_select_loc(name)
+                    self.assertEqual(organization, name)
+                    self.assertEqual(location, name)
 
-    @data(*invalid_values_list())
-    def test_negative_create_with_different_names(self, org_name):
+    def test_negative_create_with_different_names(self):
         """@test: Try to create organization and use whitespace, blank, tab
         symbol or too long string of different types as its name value
 
@@ -185,14 +212,14 @@ class Org(UITestCase):
 
         """
         with Session(self.browser) as session:
-            make_org(session, org_name=org_name)
-            error = session.nav.wait_until_element(
-                common_locators['name_haserror'])
-            self.assertIsNotNone(error)
+            for org_name in invalid_values_list(interface='ui'):
+                with self.subTest(org_name):
+                    make_org(session, org_name=org_name)
+                    error = session.nav.wait_until_element(
+                        common_locators['name_haserror'])
+                    self.assertIsNotNone(error)
 
-    @skip_if_bug_open('bugzilla', 1131469)
-    @data(*generate_strings_list())
-    def test_negative_create_with_same_name(self, org_name):
+    def test_negative_create_with_same_name(self):
         """@test: Create organization with valid values, then create a new one
         with same values.
 
@@ -200,21 +227,20 @@ class Org(UITestCase):
 
         @assert: organization is not created
 
-        @BZ: 1131469
-
         """
         with Session(self.browser) as session:
-            make_org(session, org_name=org_name)
-            self.assertIsNotNone(self.org.search(org_name))
-            self.org.create(org_name)
-            error = session.nav.wait_until_element(
-                common_locators['name_haserror'])
-            self.assertIsNotNone(error)
+            for org_name in generate_strings_list():
+                with self.subTest(org_name):
+                    make_org(session, org_name=org_name)
+                    self.assertIsNotNone(self.org.search(org_name))
+                    self.org.create(org_name)
+                    error = session.nav.wait_until_element(
+                        common_locators['name_haserror'])
+                    self.assertIsNotNone(error)
 
     # Positive Delete
 
-    @data(*generate_strings_list())
-    def test_positive_delete(self, org_name):
+    def test_positive_delete(self):
         """@test: Create organization with valid values then delete it.
 
         @feature: Organizations Positive Delete test.
@@ -222,14 +248,15 @@ class Org(UITestCase):
         @assert: Organization is deleted successfully
 
         """
-        entities.Organization(name=org_name).create()
         with Session(self.browser) as session:
-            session.nav.go_to_org()
-            self.org.remove(org_name)
+            for org_name in generate_strings_list():
+                with self.subTest(org_name):
+                    # Use nailgun to create org
+                    entities.Organization(name=org_name).create()
+                    session.nav.go_to_org()
+                    self.org.remove(org_name)
 
-    @skip_if_bug_open('bugzilla', 1225588)
-    @data(*generate_strings_list())
-    def test_positive_delete_bz1225588(self, org_name):
+    def test_positive_delete_bz1225588(self):
         """@test: Create Organization with valid values and upload manifest.
         Then try to delete that organization.
 
@@ -238,6 +265,7 @@ class Org(UITestCase):
         @assert: Organization is deleted successfully.
 
         """
+        org_name = gen_string('alphanumeric')
         org = entities.Organization(name=org_name).create()
         with open(manifests.clone(), 'rb') as manifest:
             upload_manifest(org.id, manifest)
@@ -291,30 +319,27 @@ class Org(UITestCase):
 
     # Positive Update
 
-    @skip_if_bug_open('bugzilla', 1131469)
-    @data(*generate_strings_list())
-    def test_positive_update_with_different_names(self, new_name):
+    def test_positive_update_with_different_names(self):
         """@test: Create organization with valid values then update its name.
 
         @feature: Organizations Positive Update test.
 
         @assert: Organization name is updated successfully
 
-        @BZ: 1131469
-
         """
         org_name = gen_string('alpha')
         with Session(self.browser) as session:
             make_org(session, org_name=org_name)
             self.assertIsNotNone(self.org.search(org_name))
-            self.org.update(org_name, new_name=new_name)
-            self.assertIsNotNone(self.org.search(new_name))
+            for new_name in generate_strings_list():
+                with self.subTest(new_name):
+                    self.org.update(org_name, new_name=new_name)
+                    self.assertIsNotNone(self.org.search(new_name))
+                    org_name = new_name  # for next iteration
 
     # Negative Update
 
-    @skip_if_bug_open('bugzilla', 1131469)
-    @data(*invalid_names_list())
-    def test_negative_update(self, new_name):
+    def test_negative_update(self):
         """@test: Create organization with valid values then try to update it
         using incorrect name values
 
@@ -322,41 +347,24 @@ class Org(UITestCase):
 
         @assert: Organization name is not updated
 
-        @BZ: 1131469
-
         """
         org_name = gen_string('alpha')
         with Session(self.browser) as session:
             make_org(session, org_name=org_name)
             self.assertIsNotNone(self.org.search(org_name))
-            self.org.update(org_name, new_name=new_name)
-            error = session.nav.wait_until_element(
-                common_locators['name_haserror'])
-            self.assertIsNotNone(error)
+            for new_name in invalid_names_list():
+                with self.subTest(new_name):
+                    self.org.update(org_name, new_name=new_name)
+                    error = session.nav.wait_until_element(
+                        common_locators['name_haserror'])
+                    self.assertIsNotNone(error)
 
     # Miscellaneous
-
-    @skip_if_bug_open('bugzilla', 1131469)
-    @data(*generate_strings_list())
-    def test_search_key(self, org_name):
-        """@test: Create organization and search/find it.
-
-        @feature: Organizations search.
-
-        @assert: Proper organization found
-
-        @BZ: 1131469
-
-        """
-        with Session(self.browser) as session:
-            make_org(session, org_name=org_name)
-            self.assertIsNotNone(self.org.search(org_name))
 
     # Associations
 
     @run_only_on('sat')
-    @data(*generate_strings_list())
-    def test_remove_domain(self, domain_name):
+    def test_remove_domain(self):
         """@test: Add a domain to an organization and remove it by organization
         name and domain name.
 
@@ -367,34 +375,30 @@ class Org(UITestCase):
         """
         strategy, value = common_locators['entity_select']
         strategy1, value1 = common_locators['entity_deselect']
-        org_name = gen_string('alpha')
-        domain = entities.Domain(name=domain_name).create()
-        self.assertEqual(domain.name, domain_name)
         with Session(self.browser) as session:
-            make_org(session, org_name=org_name, domains=[domain_name])
-            self.org.search(org_name).click()
-            session.nav.click(tab_locators['context.tab_domains'])
-            element = session.nav.wait_until_element((strategy1,
-                                                      value1 % domain_name))
-            # Item is listed in 'Selected Items' list and not 'All Items' list.
-            self.assertIsNotNone(element)
-            self.org.update(org_name, domains=[domain_name])
-            self.org.search(org_name).click()
-            session.nav.click(tab_locators['context.tab_domains'])
-            element = session.nav.wait_until_element((strategy,
-                                                      value % domain_name))
-            # Item is listed in 'All Items' list and not 'Selected Items' list.
-            self.assertIsNotNone(element)
+            for domain_name in generate_strings_list():
+                with self.subTest(domain_name):
+                    org_name = gen_string('alpha')
+                    domain = entities.Domain(name=domain_name).create()
+                    self.assertEqual(domain.name, domain_name)
+                    make_org(session, org_name=org_name, domains=[domain_name])
+                    self.org.search(org_name).click()
+                    session.nav.click(tab_locators['context.tab_domains'])
+                    element = session.nav.wait_until_element(
+                        (strategy1, value1 % domain_name))
+                    # Item is listed in 'Selected Items' list and not
+                    # 'All Items' list.
+                    self.assertIsNotNone(element)
+                    self.org.update(org_name, domains=[domain_name])
+                    self.org.search(org_name).click()
+                    session.nav.click(tab_locators['context.tab_domains'])
+                    element = session.nav.wait_until_element(
+                        (strategy, value % domain_name))
+                    # Item is listed in 'All Items' list and not
+                    # 'Selected Items' list.
+                    self.assertIsNotNone(element)
 
-    #  Note: HTML username is invalid as per the UI msg.
-    @data(
-        gen_string('alpha'),
-        gen_string('numeric'),
-        gen_string('alphanumeric'),
-        gen_string('utf8'),
-        gen_string('latin1'),
-    )
-    def test_remove_user(self, user_name):
+    def test_remove_user(self):
         """@test: Create admin users then add user and remove it
         by using the organization name.
 
@@ -405,33 +409,38 @@ class Org(UITestCase):
         """
         strategy, value = common_locators['entity_select']
         strategy1, value1 = common_locators['entity_deselect']
-        org_name = gen_string('alpha')
-        user = entities.User(
-            login=user_name,
-            firstname=user_name,
-            lastname=user_name,
-            password=gen_string('alpha'),
-        ).create()
-        self.assertEqual(user.login, user_name)
         with Session(self.browser) as session:
-            make_org(session, org_name=org_name, users=[user_name])
-            self.org.search(org_name).click()
-            session.nav.click(tab_locators['context.tab_users'])
-            element = session.nav.wait_until_element((strategy1,
-                                                      value1 % user_name))
-            # Item is listed in 'Selected Items' list and not 'All Items' list.
-            self.assertIsNotNone(element)
-            self.org.update(org_name, users=[user_name], new_users=None)
-            self.org.search(org_name).click()
-            session.nav.click(tab_locators['context.tab_users'])
-            element = session.nav.wait_until_element((strategy,
-                                                      value % user_name))
-            # Item is listed in 'All Items' list and not 'Selected Items' list.
-            self.assertIsNotNone(element)
+            for user_name in valid_users():
+                with self.subTest(user_name):
+                    org_name = gen_string('alpha')
+                    # Use nailgun to create user
+                    user = entities.User(
+                        login=user_name,
+                        firstname=user_name,
+                        lastname=user_name,
+                        password=gen_string('alpha'),
+                    ).create()
+                    self.assertEqual(user.login, user_name)
+                    make_org(session, org_name=org_name, users=[user_name])
+                    self.org.search(org_name).click()
+                    session.nav.click(tab_locators['context.tab_users'])
+                    element = session.nav.wait_until_element(
+                        (strategy1, value1 % user_name))
+                    # Item is listed in 'Selected Items' list and not
+                    # 'All Items' list.
+                    self.assertIsNotNone(element)
+                    self.org.update(
+                        org_name, users=[user_name], new_users=None)
+                    self.org.search(org_name).click()
+                    session.nav.click(tab_locators['context.tab_users'])
+                    element = session.nav.wait_until_element(
+                        (strategy, value % user_name))
+                    # Item is listed in 'All Items' list and not
+                    # 'Selected Items' list.
+                    self.assertIsNotNone(element)
 
     @run_only_on('sat')
-    @data(*generate_strings_list())
-    def test_remove_hostgroup(self, host_grp_name):
+    def test_remove_hostgroup(self):
         """@test: Add a hostgroup and remove it by using the organization
         name and hostgroup name.
 
@@ -442,37 +451,38 @@ class Org(UITestCase):
         """
         strategy, value = common_locators['entity_select']
         strategy1, value1 = common_locators['entity_deselect']
-        org_name = gen_string('alpha')
-        host_grp = entities.HostGroup(name=host_grp_name).create()
-        self.assertEqual(host_grp.name, host_grp_name)
         with Session(self.browser) as session:
-            make_org(session, org_name=org_name, hostgroups=[host_grp_name])
-            self.org.search(org_name).click()
-            session.nav.click(tab_locators['context.tab_hostgrps'])
-            element = session.nav.wait_until_element((strategy1,
-                                                      value1 % host_grp_name))
-            # Item is listed in 'Selected Items' list and not 'All Items' list.
-            self.assertIsNotNone(element)
-            self.org.update(org_name, hostgroups=[host_grp_name],
-                            new_hostgroups=None)
-            self.org.search(org_name).click()
-            session.nav.click(tab_locators['context.tab_hostgrps'])
-            element = session.nav.wait_until_element((strategy,
-                                                      value % host_grp_name))
-            # Item is listed in 'All Items' list and not 'Selected Items' list.
-            self.assertIsNotNone(element)
+            for host_grp_name in generate_strings_list():
+                with self.subTest(host_grp_name):
+                    org_name = gen_string('alpha')
+                    # Create hostgroup using nailgun
+                    host_grp = entities.HostGroup(name=host_grp_name).create()
+                    self.assertEqual(host_grp.name, host_grp_name)
+                    make_org(
+                        session, org_name=org_name, hostgroups=[host_grp_name])
+                    self.org.search(org_name).click()
+                    session.nav.click(tab_locators['context.tab_hostgrps'])
+                    element = session.nav.wait_until_element(
+                        (strategy1, value1 % host_grp_name))
+                    # Item is listed in 'Selected Items' list and not
+                    # 'All Items' list.
+                    self.assertIsNotNone(element)
+                    self.org.update(
+                        org_name,
+                        hostgroups=[host_grp_name],
+                        new_hostgroups=None
+                    )
+                    self.org.search(org_name).click()
+                    session.nav.click(tab_locators['context.tab_hostgrps'])
+                    element = session.nav.wait_until_element(
+                        (strategy, value % host_grp_name))
+                    # Item is listed in 'All Items' list and not
+                    # Selected Items' list.
+                    self.assertIsNotNone(element)
 
     @run_only_on('sat')
     @stubbed()
-    @data("""DATADRIVENGOESHERE
-        smartproxy name is alpha
-        smartproxy name is numeric
-        smartproxy name is alpha_numeric
-        smartproxy name  is utf-8
-        smartproxy name is latin1
-        smartproxy name is html
-    """)
-    def test_add_smartproxy_1(self, test_data):
+    def test_add_smartproxy_1(self):
         """@test: Add a smart proxy by using org and smartproxy name
 
         @feature: Organizations
@@ -486,8 +496,7 @@ class Org(UITestCase):
         pass
 
     @run_only_on('sat')
-    @data(*generate_strings_list())
-    def test_add_subnet(self, subnet_name):
+    def test_add_subnet(self):
         """@test: Add a subnet using organization name and subnet name.
 
         @feature: Organizations associate subnet.
@@ -496,26 +505,28 @@ class Org(UITestCase):
 
         """
         strategy, value = common_locators['entity_deselect']
-        org_name = gen_string('alpha')
-        subnet = entities.Subnet(
-            name=subnet_name,
-            network=gen_ipaddr(ip3=True),
-            mask='255.255.255.0'
-        ).create()
-        self.assertEqual(subnet.name, subnet_name)
         with Session(self.browser) as session:
-            make_org(session, org_name=org_name)
-            self.assertIsNotNone(self.org.search(org_name))
-            self.org.update(org_name, new_subnets=[subnet_name])
-            self.org.search(org_name).click()
-            session.nav.click(tab_locators['context.tab_subnets'])
-            element = session.nav.wait_until_element((strategy,
-                                                      value % subnet_name))
-            self.assertIsNotNone(element)
+            for subnet_name in generate_strings_list():
+                with self.subTest(subnet_name):
+                    org_name = gen_string('alpha')
+                    # Create subnet using nailgun
+                    subnet = entities.Subnet(
+                        name=subnet_name,
+                        network=gen_ipaddr(ip3=True),
+                        mask='255.255.255.0'
+                    ).create()
+                    self.assertEqual(subnet.name, subnet_name)
+                    make_org(session, org_name=org_name)
+                    self.assertIsNotNone(self.org.search(org_name))
+                    self.org.update(org_name, new_subnets=[subnet_name])
+                    self.org.search(org_name).click()
+                    session.nav.click(tab_locators['context.tab_subnets'])
+                    element = session.nav.wait_until_element(
+                        (strategy, value % subnet_name))
+                    self.assertIsNotNone(element)
 
     @run_only_on('sat')
-    @data(*generate_strings_list())
-    def test_add_domain(self, domain_name):
+    def test_add_domain(self):
         """@test: Add a domain to an organization.
 
         @feature: Organizations associate domain.
@@ -524,27 +535,22 @@ class Org(UITestCase):
 
         """
         strategy, value = common_locators['entity_deselect']
-        org_name = gen_string('alpha')
-        domain = entities.Domain(name=domain_name).create()
-        self.assertEqual(domain.name, domain_name)
         with Session(self.browser) as session:
-            make_org(session, org_name=org_name)
-            self.assertIsNotNone(self.org.search(org_name))
-            self.org.update(org_name, new_domains=[domain_name])
-            self.org.search(org_name).click()
-            session.nav.click(tab_locators['context.tab_domains'])
-            element = session.nav.wait_until_element((strategy,
-                                                      value % domain_name))
-            self.assertIsNotNone(element)
+            for domain_name in generate_strings_list():
+                with self.subTest(domain_name):
+                    org_name = gen_string('alpha')
+                    domain = entities.Domain(name=domain_name).create()
+                    self.assertEqual(domain.name, domain_name)
+                    make_org(session, org_name=org_name)
+                    self.assertIsNotNone(self.org.search(org_name))
+                    self.org.update(org_name, new_domains=[domain_name])
+                    self.org.search(org_name).click()
+                    session.nav.click(tab_locators['context.tab_domains'])
+                    element = session.nav.wait_until_element(
+                        (strategy, value % domain_name))
+                    self.assertIsNotNone(element)
 
-    @data(
-        gen_string('alpha'),
-        gen_string('numeric'),
-        gen_string('alphanumeric'),
-        gen_string('utf8'),
-        gen_string('latin1'),
-    )
-    def test_add_user(self, user_name):
+    def test_add_user(self):
         """@test: Create different types of users then add user using
         organization name.
 
@@ -554,27 +560,28 @@ class Org(UITestCase):
 
         """
         strategy, value = common_locators['entity_deselect']
-        org_name = gen_string('alpha')
-        user = entities.User(
-            login=user_name,
-            firstname=user_name,
-            lastname=user_name,
-            password=gen_string('alpha')
-        ).create()
-        self.assertEqual(user.login, user_name)
         with Session(self.browser) as session:
-            make_org(session, org_name=org_name)
-            self.assertIsNotNone(self.org.search(org_name))
-            self.org.update(org_name, new_users=[user_name])
-            self.org.search(org_name).click()
-            session.nav.click(tab_locators['context.tab_users'])
-            element = session.nav.wait_until_element((strategy,
-                                                      value % user_name))
-            self.assertIsNotNone(element)
+            for user_name in valid_users():
+                with self.subTest(user_name):
+                    org_name = gen_string('alpha')
+                    user = entities.User(
+                        login=user_name,
+                        firstname=user_name,
+                        lastname=user_name,
+                        password=gen_string('alpha')
+                    ).create()
+                    self.assertEqual(user.login, user_name)
+                    make_org(session, org_name=org_name)
+                    self.assertIsNotNone(self.org.search(org_name))
+                    self.org.update(org_name, new_users=[user_name])
+                    self.org.search(org_name).click()
+                    session.nav.click(tab_locators['context.tab_users'])
+                    element = session.nav.wait_until_element(
+                        (strategy, value % user_name))
+                    self.assertIsNotNone(element)
 
     @run_only_on('sat')
-    @data(*generate_strings_list())
-    def test_add_hostgroup(self, host_grp_name):
+    def test_add_hostgroup(self):
         """@test: Add a hostgroup by using the organization
         name and hostgroup name.
 
@@ -584,22 +591,24 @@ class Org(UITestCase):
 
         """
         strategy, value = common_locators['entity_deselect']
-        org_name = gen_string('alpha')
-        host_grp = entities.HostGroup(name=host_grp_name).create()
-        self.assertEqual(host_grp.name, host_grp_name)
         with Session(self.browser) as session:
-            make_org(session, org_name=org_name)
-            self.assertIsNotNone(self.org.search(org_name))
-            self.org.update(org_name, new_hostgroups=[host_grp_name])
-            self.org.search(org_name).click()
-            session.nav.click(tab_locators['context.tab_hostgrps'])
-            element = session.nav.wait_until_element((strategy,
-                                                      value % host_grp_name))
-            self.assertIsNotNone(element)
+            for host_grp_name in generate_strings_list():
+                with self.subTest(host_grp_name):
+                    org_name = gen_string('alpha')
+                    # Create host group using nailgun
+                    host_grp = entities.HostGroup(name=host_grp_name).create()
+                    self.assertEqual(host_grp.name, host_grp_name)
+                    make_org(session, org_name=org_name)
+                    self.assertIsNotNone(self.org.search(org_name))
+                    self.org.update(org_name, new_hostgroups=[host_grp_name])
+                    self.org.search(org_name).click()
+                    session.nav.click(tab_locators['context.tab_hostgrps'])
+                    element = session.nav.wait_until_element(
+                        (strategy, value % host_grp_name))
+                    self.assertIsNotNone(element)
 
     @run_only_on('sat')
-    @data(*generate_strings_list())
-    def test_add_location(self, location_name):
+    def test_add_location(self):
         """@test: Add a location by using the organization name and location
         name
 
@@ -609,22 +618,23 @@ class Org(UITestCase):
 
         """
         strategy, value = common_locators['entity_deselect']
-        org_name = gen_string('alpha')
-        location = entities.Location(name=location_name).create()
-        self.assertEqual(location.name, location_name)
         with Session(self.browser) as session:
-            make_org(session, org_name=org_name)
-            self.assertIsNotNone(self.org.search(org_name))
-            self.org.update(org_name, new_locations=[location_name])
-            self.org.search(org_name).click()
-            session.nav.click(tab_locators['context.tab_locations'])
-            element = session.nav.wait_until_element((strategy,
-                                                      value % location_name))
-            self.assertIsNotNone(element)
+            for location_name in generate_strings_list():
+                with self.subTest(location_name):
+                    org_name = gen_string('alpha')
+                    location = entities.Location(name=location_name).create()
+                    self.assertEqual(location.name, location_name)
+                    make_org(session, org_name=org_name)
+                    self.assertIsNotNone(self.org.search(org_name))
+                    self.org.update(org_name, new_locations=[location_name])
+                    self.org.search(org_name).click()
+                    session.nav.click(tab_locators['context.tab_locations'])
+                    element = session.nav.wait_until_element(
+                        (strategy, value % location_name))
+                    self.assertIsNotNone(element)
 
     @run_only_on('sat')
-    @data(*generate_strings_list())
-    def test_remove_computeresource(self, resource_name):
+    def test_remove_computeresource(self):
         """@test: Remove compute resource using the organization name and
         compute resource name.
 
@@ -635,33 +645,41 @@ class Org(UITestCase):
         """
         strategy, value = common_locators['entity_select']
         strategy1, value1 = common_locators['entity_deselect']
-        org_name = gen_string('alpha')
-        url = LIBVIRT_RESOURCE_URL % settings.server.hostname
-        resource = entities.LibvirtComputeResource(
-            name=resource_name,
-            url=url
-        ).create()
-        self.assertEqual(resource.name, resource_name)
         with Session(self.browser) as session:
-            make_org(session, org_name=org_name, resources=[resource_name])
-            self.org.search(org_name).click()
-            session.nav.click(tab_locators['context.tab_resources'])
-            element = session.nav.wait_until_element((strategy1,
-                                                      value1 % resource_name))
-            # Item is listed in 'Selected Items' list and not 'All Items' list.
-            self.assertIsNotNone(element)
-            self.org.update(org_name, resources=[resource_name],
-                            new_resources=None)
-            self.org.search(org_name).click()
-            session.nav.click(tab_locators['context.tab_resources'])
-            element = session.nav.wait_until_element((strategy,
-                                                      value % resource_name))
-            # Item is listed in 'All Items' list and not 'Selected Items' list.
-            self.assertIsNotNone(element)
+            for resource_name in generate_strings_list():
+                with self.subTest(resource_name):
+                    org_name = gen_string('alpha')
+                    url = LIBVIRT_RESOURCE_URL % settings.server.hostname
+                    # Create compute resource using nailgun
+                    resource = entities.LibvirtComputeResource(
+                        name=resource_name,
+                        url=url
+                    ).create()
+                    self.assertEqual(resource.name, resource_name)
+                    make_org(
+                        session, org_name=org_name, resources=[resource_name])
+                    self.org.search(org_name).click()
+                    session.nav.click(tab_locators['context.tab_resources'])
+                    element = session.nav.wait_until_element(
+                        (strategy1, value1 % resource_name))
+                    # Item is listed in 'Selected Items' list and not
+                    # 'All Items' list.
+                    self.assertIsNotNone(element)
+                    self.org.update(
+                        org_name,
+                        resources=[resource_name],
+                        new_resources=None
+                    )
+                    self.org.search(org_name).click()
+                    session.nav.click(tab_locators['context.tab_resources'])
+                    element = session.nav.wait_until_element(
+                        (strategy, value % resource_name))
+                    # Item is listed in 'All Items' list and not
+                    # 'Selected Items' list.
+                    self.assertIsNotNone(element)
 
     @run_only_on('sat')
-    @data(*generate_strings_list())
-    def test_remove_medium(self, medium_name):
+    def test_remove_medium(self):
         """@test: Remove medium by using organization name and medium name.
 
         @feature: Organizations disassociate installation media.
@@ -671,35 +689,38 @@ class Org(UITestCase):
         """
         strategy, value = common_locators['entity_select']
         strategy1, value1 = common_locators['entity_deselect']
-        org_name = gen_string('alpha')
-        medium = entities.Media(
-            name=medium_name,
-            path_=INSTALL_MEDIUM_URL % gen_string('alpha', 6),
-            os_family='Redhat',
-        ).create()
-        self.assertEqual(medium.name, medium_name)
         with Session(self.browser) as session:
-            make_org(session, org_name=org_name,
-                     medias=[medium_name])
-            self.org.search(org_name).click()
-            session.nav.click(tab_locators['context.tab_media'])
-            element = session.nav.wait_until_element((strategy1,
-                                                      value1 % medium_name))
-            # Item is listed in 'Selected Items' list and not 'All Items' list.
-            self.assertIsNotNone(element)
-            self.navigator.go_to_org()
-            self.org.update(org_name, medias=[medium_name],
-                            new_medias=None)
-            self.org.search(org_name).click()
-            session.nav.click(tab_locators['context.tab_media'])
-            element = session.nav.wait_until_element((strategy,
-                                                      value % medium_name))
-            # Item is listed in 'All Items' list and not 'Selected Items' list.
-            self.assertIsNotNone(element)
+            for medium_name in generate_strings_list():
+                with self.subTest(medium_name):
+                    org_name = gen_string('alpha')
+                    # Create media using nailgun
+                    medium = entities.Media(
+                        name=medium_name,
+                        path_=INSTALL_MEDIUM_URL % gen_string('alpha', 6),
+                        os_family='Redhat',
+                    ).create()
+                    self.assertEqual(medium.name, medium_name)
+                    make_org(session, org_name=org_name, medias=[medium_name])
+                    self.org.search(org_name).click()
+                    session.nav.click(tab_locators['context.tab_media'])
+                    element = session.nav.wait_until_element(
+                        (strategy1, value1 % medium_name))
+                    # Item is listed in 'Selected Items' list and not
+                    # 'All Items' list.
+                    self.assertIsNotNone(element)
+                    self.navigator.go_to_org()
+                    self.org.update(
+                        org_name, medias=[medium_name], new_medias=None)
+                    self.org.search(org_name).click()
+                    session.nav.click(tab_locators['context.tab_media'])
+                    element = session.nav.wait_until_element(
+                        (strategy, value % medium_name))
+                    # Item is listed in 'All Items' list and not
+                    # 'Selected Items' list.
+                    self.assertIsNotNone(element)
 
     @run_only_on('sat')
-    @data(*generate_strings_list())
-    def test_remove_configtemplate(self, template_name):
+    def test_remove_configtemplate(self):
         """@test: Remove config template.
 
         @feature: Organizations dissociate config templates.
@@ -711,31 +732,32 @@ class Org(UITestCase):
         """
         strategy, value = common_locators['entity_select']
         strategy1, value1 = common_locators['entity_deselect']
-        org_name = gen_string('alpha')
-        entities.ConfigTemplate(name=template_name).create()
         with Session(self.browser) as session:
-            make_org(session, org_name=org_name, templates=[template_name])
-            self.org.search(org_name).click()
-            session.nav.click(tab_locators['context.tab_template'])
-            element = session.nav.wait_until_element(
-                (strategy1, value1 % template_name))
-            # Item is listed in 'Selected Items' list and not 'All Items' list.
-            self.assertIsNotNone(element)
-            self.org.update(org_name, templates=[template_name])
-            self.org.search(org_name).click()
-            session.nav.click(tab_locators['context.tab_template'])
-            element = self.org.wait_until_element(
-                (strategy, value % template_name))
-            # Item is listed in 'All Items' list and not 'Selected Items' list.
-            self.assertIsNotNone(element)
+            for template_name in generate_strings_list():
+                with self.subTest(template_name):
+                    org_name = gen_string('alpha')
+                    # Create config template using nailgun
+                    entities.ConfigTemplate(name=template_name).create()
+                    make_org(
+                        session, org_name=org_name, templates=[template_name])
+                    self.org.search(org_name).click()
+                    session.nav.click(tab_locators['context.tab_template'])
+                    element = session.nav.wait_until_element(
+                        (strategy1, value1 % template_name))
+                    # Item is listed in 'Selected Items' list and not
+                    # 'All Items' list.
+                    self.assertIsNotNone(element)
+                    self.org.update(org_name, templates=[template_name])
+                    self.org.search(org_name).click()
+                    session.nav.click(tab_locators['context.tab_template'])
+                    element = self.org.wait_until_element(
+                        (strategy, value % template_name))
+                    # Item is listed in 'All Items' list and not
+                    # 'Selected Items' list.
+                    self.assertIsNotNone(element)
 
     @run_only_on('sat')
-    @data(
-        gen_string('alpha'),
-        gen_string('numeric'),
-        gen_string('alphanumeric'),
-    )
-    def test_add_environment(self, env_name):
+    def test_add_environment(self):
         """@test: Add environment by using organization name and env name.
 
         @feature: Organizations associate environment.
@@ -744,30 +766,24 @@ class Org(UITestCase):
 
         """
         strategy, value = common_locators['entity_deselect']
-        org_name = gen_string('alpha')
-        env = entities.Environment(name=env_name).create_json()
-        self.assertEqual(env['name'], env_name)
         with Session(self.browser) as session:
-            make_org(session, org_name=org_name)
-            self.assertIsNotNone(self.org.search(org_name))
-            self.org.update(org_name, new_envs=[env_name])
-            self.org.search(org_name).click()
-            session.nav.click(tab_locators['context.tab_env'])
-            element = session.nav.wait_until_element((strategy,
-                                                      value % env_name))
-            self.assertIsNotNone(element)
+            for env_name in valid_env_names():
+                with self.subTest(env_name):
+                    org_name = gen_string('alpha')
+                    env = entities.Environment(name=env_name).create_json()
+                    self.assertEqual(env['name'], env_name)
+                    make_org(session, org_name=org_name)
+                    self.assertIsNotNone(self.org.search(org_name))
+                    self.org.update(org_name, new_envs=[env_name])
+                    self.org.search(org_name).click()
+                    session.nav.click(tab_locators['context.tab_env'])
+                    element = session.nav.wait_until_element(
+                        (strategy, value % env_name))
+                    self.assertIsNotNone(element)
 
     @run_only_on('sat')
     @stubbed()
-    @data("""DATADRIVENGOESHERE
-        smartproxy name is alpha
-        smartproxy name is numeric
-        smartproxy name is alpha_numeric
-        smartproxy name  is utf-8
-        smartproxy name is latin1
-        smartproxy name is html
-    """)
-    def test_remove_smartproxy_1(self, test_data):
+    def test_remove_smartproxy_1(self):
         """@test: Remove smartproxy by using organization name and smartproxy
         name
 
@@ -782,8 +798,7 @@ class Org(UITestCase):
         pass
 
     @run_only_on('sat')
-    @data(*generate_strings_list())
-    def test_add_computeresource(self, resource_name):
+    def test_add_computeresource(self):
         """@test: Add compute resource using the organization
         name and compute resource name.
 
@@ -793,26 +808,28 @@ class Org(UITestCase):
 
         """
         strategy, value = common_locators['entity_deselect']
-        org_name = gen_string('alpha')
-        url = LIBVIRT_RESOURCE_URL % settings.server.hostname
-        resource = entities.LibvirtComputeResource(
-            name=resource_name,
-            url=url,
-        ).create()
-        self.assertEqual(resource.name, resource_name)
         with Session(self.browser) as session:
-            make_org(session, org_name=org_name)
-            self.assertIsNotNone(self.org.search(org_name))
-            self.org.update(org_name, new_resources=[resource_name])
-            self.org.search(org_name).click()
-            session.nav.click(tab_locators['context.tab_resources'])
-            element = session.nav.wait_until_element((strategy,
-                                                      value % resource_name))
-            self.assertIsNotNone(element)
+            for resource_name in generate_strings_list():
+                with self.subTest(resource_name):
+                    org_name = gen_string('alpha')
+                    url = LIBVIRT_RESOURCE_URL % settings.server.hostname
+                    # Create compute resource using nailgun
+                    resource = entities.LibvirtComputeResource(
+                        name=resource_name,
+                        url=url,
+                    ).create()
+                    self.assertEqual(resource.name, resource_name)
+                    make_org(session, org_name=org_name)
+                    self.assertIsNotNone(self.org.search(org_name))
+                    self.org.update(org_name, new_resources=[resource_name])
+                    self.org.search(org_name).click()
+                    session.nav.click(tab_locators['context.tab_resources'])
+                    element = session.nav.wait_until_element(
+                        (strategy, value % resource_name))
+                    self.assertIsNotNone(element)
 
     @run_only_on('sat')
-    @data(*generate_strings_list())
-    def test_add_medium(self, medium_name):
+    def test_add_medium(self):
         """@test: Add medium by using the organization name and medium name.
 
         @feature: Organizations associate medium.
@@ -821,26 +838,28 @@ class Org(UITestCase):
 
         """
         strategy, value = common_locators['entity_deselect']
-        org_name = gen_string('alpha')
-        medium = entities.Media(
-            name=medium_name,
-            path_=INSTALL_MEDIUM_URL % gen_string('alpha', 6),
-            os_family='Redhat',
-        ).create()
-        self.assertEqual(medium.name, medium_name)
         with Session(self.browser) as session:
-            make_org(session, org_name=org_name)
-            self.assertIsNotNone(self.org.search(org_name))
-            self.org.update(org_name, new_medias=[medium_name])
-            self.org.search(org_name).click()
-            session.nav.click(tab_locators['context.tab_media'])
-            element = session.nav.wait_until_element((strategy,
-                                                      value % medium_name))
-            self.assertIsNotNone(element)
+            for medium_name in generate_strings_list():
+                with self.subTest(medium_name):
+                    org_name = gen_string('alpha')
+                    # Create media using nailgun
+                    medium = entities.Media(
+                        name=medium_name,
+                        path_=INSTALL_MEDIUM_URL % gen_string('alpha', 6),
+                        os_family='Redhat',
+                    ).create()
+                    self.assertEqual(medium.name, medium_name)
+                    make_org(session, org_name=org_name)
+                    self.assertIsNotNone(self.org.search(org_name))
+                    self.org.update(org_name, new_medias=[medium_name])
+                    self.org.search(org_name).click()
+                    session.nav.click(tab_locators['context.tab_media'])
+                    element = session.nav.wait_until_element(
+                        (strategy, value % medium_name))
+                    self.assertIsNotNone(element)
 
     @run_only_on('sat')
-    @data(*generate_strings_list())
-    def test_add_configtemplate(self, template_name):
+    def test_add_configtemplate(self):
         """@test: Add config template by using organization name and
         config template name.
 
@@ -852,23 +871,23 @@ class Org(UITestCase):
 
         """
         strategy, value = common_locators['entity_deselect']
-        org_name = gen_string('alpha')
-        entities.ConfigTemplate(name=template_name).create()
         with Session(self.browser) as session:
-            make_org(session, org_name=org_name)
-            self.assertIsNotNone(self.org.search(org_name))
-            self.org.update(org_name, new_templates=[template_name])
-            self.org.search(org_name).click()
-            session.nav.click(tab_locators['context.tab_template'])
-            element = session.nav.wait_until_element(
-                (strategy, value % template_name))
-            self.assertIsNotNone(element)
+            for template_name in generate_strings_list():
+                with self.subTest(template_name):
+                    org_name = gen_string('alpha')
+                    # Create config template using nailgun
+                    entities.ConfigTemplate(name=template_name).create()
+                    make_org(session, org_name=org_name)
+                    self.assertIsNotNone(self.org.search(org_name))
+                    self.org.update(org_name, new_templates=[template_name])
+                    self.org.search(org_name).click()
+                    session.nav.click(tab_locators['context.tab_template'])
+                    element = session.nav.wait_until_element(
+                        (strategy, value % template_name))
+                    self.assertIsNotNone(element)
 
     @run_only_on('sat')
-    @data(gen_string('alpha'),
-          gen_string('numeric'),
-          gen_string('alphanumeric'))
-    def test_remove_environment(self, env_name):
+    def test_remove_environment(self):
         """@test: Remove environment by using org & environment name.
 
         @feature: Organizations dis-associate environment.
@@ -878,28 +897,32 @@ class Org(UITestCase):
         """
         strategy, value = common_locators['entity_select']
         strategy1, value1 = common_locators['entity_deselect']
-        org_name = gen_string('alpha')
-        env = entities.Environment(name=env_name).create_json()
-        self.assertEqual(env['name'], env_name)
         with Session(self.browser) as session:
-            make_org(session, org_name=org_name, envs=[env_name])
-            self.org.search(org_name).click()
-            session.nav.click(tab_locators['context.tab_env'])
-            element = session.nav.wait_until_element((strategy1,
-                                                      value1 % env_name))
-            # Item is listed in 'Selected Items' list and not 'All Items' list.
-            self.assertIsNotNone(element)
-            self.org.update(org_name, envs=[env_name])
-            self.org.search(org_name).click()
-            session.nav.click(tab_locators['context.tab_env'])
-            element = session.nav.wait_until_element((strategy,
-                                                      value % env_name))
-            # Item is listed in 'All Items' list and not 'Selected Items' list.
-            self.assertIsNotNone(element)
+            for env_name in valid_env_names():
+                with self.subTest(env_name):
+                    org_name = gen_string('alpha')
+                    # Create environment using nailgun
+                    env = entities.Environment(name=env_name).create_json()
+                    self.assertEqual(env['name'], env_name)
+                    make_org(session, org_name=org_name, envs=[env_name])
+                    self.org.search(org_name).click()
+                    session.nav.click(tab_locators['context.tab_env'])
+                    element = session.nav.wait_until_element(
+                        (strategy1, value1 % env_name))
+                    # Item is listed in 'Selected Items' list and not
+                    # 'All Items' list.
+                    self.assertIsNotNone(element)
+                    self.org.update(org_name, envs=[env_name])
+                    self.org.search(org_name).click()
+                    session.nav.click(tab_locators['context.tab_env'])
+                    element = session.nav.wait_until_element(
+                        (strategy, value % env_name))
+                    # Item is listed in 'All Items' list and not
+                    # 'Selected Items' list.
+                    self.assertIsNotNone(element)
 
     @run_only_on('sat')
-    @data(*generate_strings_list())
-    def test_remove_subnet(self, subnet_name):
+    def test_remove_subnet(self):
         """@test: Remove subnet by using organization name and subnet name.
 
         @feature: Organizations dis-associate subnet.
@@ -909,25 +932,30 @@ class Org(UITestCase):
         """
         strategy, value = common_locators['entity_select']
         strategy1, value1 = common_locators['entity_deselect']
-        org_name = gen_string('alpha')
-        subnet = entities.Subnet(
-            name=subnet_name,
-            network=gen_ipaddr(ip3=True),
-            mask='255.255.255.0',
-        ).create()
-        self.assertEqual(subnet.name, subnet_name)
         with Session(self.browser) as session:
-            make_org(session, org_name=org_name, subnets=[subnet_name])
-            self.org.search(org_name).click()
-            session.nav.click(tab_locators['context.tab_subnets'])
-            element = session.nav.wait_until_element((strategy1,
-                                                      value1 % subnet_name))
-            # Item is listed in 'Selected Items' list and not 'All Items' list.
-            self.assertIsNotNone(element)
-            self.org.update(org_name, subnets=[subnet_name])
-            self.org.search(org_name).click()
-            session.nav.click(tab_locators['context.tab_subnets'])
-            element = session.nav.wait_until_element((strategy,
-                                                      value % subnet_name))
-            # Item is listed in 'All Items' list and not 'Selected Items' list.
-            self.assertIsNotNone(element)
+            for subnet_name in generate_strings_list():
+                with self.subTest(subnet_name):
+                    org_name = gen_string('alpha')
+                    # Create subnet using nailgun
+                    subnet = entities.Subnet(
+                        name=subnet_name,
+                        network=gen_ipaddr(ip3=True),
+                        mask='255.255.255.0',
+                    ).create()
+                    self.assertEqual(subnet.name, subnet_name)
+                    make_org(session, org_name=org_name, subnets=[subnet_name])
+                    self.org.search(org_name).click()
+                    session.nav.click(tab_locators['context.tab_subnets'])
+                    element = session.nav.wait_until_element(
+                        (strategy1, value1 % subnet_name))
+                    # Item is listed in 'Selected Items' list and not
+                    # 'All Items' list.
+                    self.assertIsNotNone(element)
+                    self.org.update(org_name, subnets=[subnet_name])
+                    self.org.search(org_name).click()
+                    session.nav.click(tab_locators['context.tab_subnets'])
+                    element = session.nav.wait_until_element(
+                        (strategy, value % subnet_name))
+                    # Item is listed in 'All Items' list and not
+                    # 'Selected Items' list.
+                    self.assertIsNotNone(element)


### PR DESCRIPTION
Test results:
```sh
# nosetests tests/foreman/ui/test_org.py 
.......S...E..FS...S..........S..
======================================================================
ERROR: @test: Create organization with valid manifest. Download debug
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/sthirugn/workspace/robottelo/tests/foreman/ui/test_org.py", line 315, in test_manifest_refresh_bz1259248
    self.assertIsNotNone(org.download_debug_certificate())
AttributeError: 'Organization' object has no attribute 'download_debug_certificate'

======================================================================
FAIL: @test: Create organization with valid values then try to update it
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/sthirugn/workspace/robottelo/tests/foreman/ui/test_org.py", line 368, in test_negative_update
    self.assertIsNotNone(error)
AssertionError: unexpectedly None

----------------------------------------------------------------------
Ran 33 tests in 3424.602s

FAILED (SKIP=4, errors=1, failures=1)
```

Fixed and reran failed tests:

```sh
# nosetests tests/foreman/ui/test_org.py:Org.test_manifest_refresh_bz1259248
.
----------------------------------------------------------------------
Ran 1 test in 146.023s

OK


# nosetests tests/foreman/ui/test_org.py:Org.test_negative_update
.
----------------------------------------------------------------------
Ran 1 test in 69.743s

OK
```