### PR TITLE
Check documentation generation on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ script:
     - flake8 .
     - make test-docstrings
     - make test-robottelo
+    - make docs
     # The `test-foreman-*` recipes require the presence of a Foreman
     # deployment, and they are lengthy. Don't run them on Travis.
 notifications:


### PR DESCRIPTION
As MetaCLITestCase is now removed, is it possible to build documentation on travis to check if its generation don't break.

Closes #2973

Depends on #2978 