### PR TITLE
UI: Fix test_positive_update_user_username

### DIFF
--- a/tests/foreman/ui/test_user.py
+++ b/tests/foreman/ui/test_user.py
@@ -853,8 +853,9 @@ class User(UITestCase):
                 edit=True,
                 roles=['Site'],
             )
-            for new_username in valid_strings():
-                with self.subTest(new_username):
+        for new_username in valid_strings():
+            with self.subTest(new_username):
+                with Session(self.browser):
                     self.user.update(search_key, name, new_username)
                     self.assertIsNotNone(
                         self.user.search(new_username, search_key))


### PR DESCRIPTION
The test was designed to be run as admin user.
In the end of each sub-test we're verifying changes actually
applied by logging in as our custom user.
But logging out was missing, causing test to fail.
Resolved this by starting a new session for each subtest.
Test results:
```
nosetests tests/foreman/ui/test_user.py -m test_positive_update_user_username
.
----------------------------------------------------------------------
Ran 1 test in 217.426s

OK
```