### PR TITLE
Support Python 2.7 and 3.4+

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,7 @@
 /foreman-results.xml
 /robottelo.log
 /test-*.pstats
+/.tox
 
 # Varies per-deployment.
 /robottelo.properties

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,15 @@
 sudo: false
 language: python
+env:
+    - TOXENV=py27
+    - TOXENV=py34
 install:
-    - pip install -r requirements.txt
-    - pip install -r requirements-optional.txt
+    - pip install flake8 sphinx testimony tox
 script:
     - flake8 .
     - make test-docstrings
-    - make test-robottelo
     - make docs
+    - tox
     # The `test-foreman-*` recipes require the presence of a Foreman
     # deployment, and they are lengthy. Don't run them on Travis.
 notifications:

--- a/requirements-optional.txt
+++ b/requirements-optional.txt
@@ -3,6 +3,7 @@ flake8
 mock
 nose
 testimony
+tox
 
 # Voluntary (recommended!) tool for checking code quality.
 pylint

--- a/robottelo/cli/factory.py
+++ b/robottelo/cli/factory.py
@@ -327,7 +327,7 @@ def make_gpg_key(options=None):
     # Create a fake gpg key file if none was provided
     if not options.get('key'):
         (_, key_filename) = mkstemp(text=True)
-        os.chmod(key_filename, 0700)
+        os.chmod(key_filename, 0o700)
         with open(key_filename, 'w') as gpg_key_file:
             gpg_key_file.write(gen_alphanumeric(gen_integer(20, 50)))
     else:
@@ -498,7 +498,7 @@ def make_partition_table(options=None):
     if options is None:
         options = {}
     (_, layout) = mkstemp(text=True)
-    os.chmod(layout, 0700)
+    os.chmod(layout, 0o700)
     with open(layout, 'w') as ptable:
         ptable.write(options.get('content', 'default ptable content'))
 
@@ -1641,7 +1641,7 @@ def make_template(options=None):
 
     # Special handling for template factory
     (_, layout) = mkstemp(text=True)
-    chmod(layout, 0700)
+    chmod(layout, 0o700)
     with open(layout, 'w') as ptable:
         ptable.write(content)
     # Upload file to server

--- a/robottelo/config/settings.py
+++ b/robottelo/config/settings.py
@@ -2,26 +2,17 @@
 import logging
 import os
 import sys
-import urlparse
-
-from nailgun import entities, entity_mixins
-from nailgun.config import ServerConfig
-
-try:
-    from ConfigParser import (
-        NoOptionError,
-        NoSectionError,
-        SafeConfigParser as ConfigParser,
-    )
-except ImportError:
-    from configparser import (
-        ConfigParser,
-        NoOptionError,
-        NoSectionError,
-    )
 
 from logging import config
+from nailgun import entities, entity_mixins
+from nailgun.config import ServerConfig
 from robottelo.config import casts
+from six.moves.urllib.parse import urlunsplit, urljoin
+from six.moves.configparser import (
+    NoOptionError,
+    NoSectionError,
+    ConfigParser
+)
 
 LOGGER = logging.getLogger(__name__)
 SETTINGS_FILE_NAME = 'robottelo.properties'
@@ -190,9 +181,9 @@ class ServerSettings(FeatureSettings):
             scheme = self.scheme
         # All anticipated error cases have been handled at this point.
         if not self.port:
-            return urlparse.urlunsplit((scheme, self.hostname, '', '', ''))
+            return urlunsplit((scheme, self.hostname, '', '', ''))
         else:
-            return urlparse.urlunsplit((
+            return urlunsplit((
                 scheme, '{0}:{1}'.format(self.hostname, self.port), '', '', ''
             ))
 
@@ -207,7 +198,7 @@ class ServerSettings(FeatureSettings):
         :rtype: str
 
         """
-        return urlparse.urlunsplit(('http', self.hostname, 'pub/', '', ''))
+        return urlunsplit(('http', self.hostname, 'pub/', '', ''))
 
     def get_cert_rpm_url(self):
         """Return the Katello cert RPM URL of the server being tested.
@@ -220,7 +211,7 @@ class ServerSettings(FeatureSettings):
         :rtype: str
 
         """
-        return urlparse.urljoin(
+        return urljoin(
             self.get_pub_url(), 'katello-ca-consumer-latest.noarch.rpm')
 
 

--- a/robottelo/decorators.py
+++ b/robottelo/decorators.py
@@ -1,6 +1,5 @@
 # -*- encoding: utf-8 -*-
 """Implements various decorators"""
-
 import bugzilla
 import logging
 import requests
@@ -9,8 +8,8 @@ import unittest2
 from functools import wraps
 from robottelo.config import settings
 from robottelo.constants import BZ_OPEN_STATUSES, NOT_IMPLEMENTED
+from six.moves.xmlrpc_client import Fault
 from xml.parsers.expat import ExpatError, errors
-from xmlrpclib import Fault
 
 BUGZILLA_URL = "https://bugzilla.redhat.com/xmlrpc.cgi"
 LOGGER = logging.getLogger(__name__)
@@ -255,7 +254,7 @@ def bz_bug_is_open(bug_id):
     try:
         bug = _get_bugzilla_bug(bug_id)
     except BugFetchError as err:
-        LOGGER.warning(err.message)
+        LOGGER.warning(err)
         return False
     if bug is None or bug.status not in BZ_OPEN_STATUSES:
         # if not upstream mode, verify whiteboard field for the presence of
@@ -282,7 +281,7 @@ def rm_bug_is_open(bug_id):
     try:
         status_id = _get_redmine_bug_status_id(bug_id)
     except BugFetchError as err:
-        LOGGER.warning(err.message)
+        LOGGER.warning(err)
     if status_id is None or status_id in _redmine_closed_issue_statuses():
         return False
     return True

--- a/robottelo/performance/candlepin.py
+++ b/robottelo/performance/candlepin.py
@@ -11,7 +11,7 @@ import time
 
 from robottelo import ssh
 from robottelo.config import settings
-from urlparse import urljoin
+from six.moves.urllib.parse import urljoin
 
 LOGGER = logging.getLogger(__name__)
 

--- a/setup.py
+++ b/setup.py
@@ -25,6 +25,7 @@ setup(
         'python-bugzilla',
         'requests',
         'selenium',
+        'six',
         'unittest2',
     ],
     license='GNU GPL v3.0',

--- a/tests/foreman/api/test_activationkey.py
+++ b/tests/foreman/api/test_activationkey.py
@@ -1,6 +1,4 @@
 """Unit tests for the ``activation_keys`` paths."""
-import httplib
-
 from fauxfactory import gen_integer, gen_string
 from nailgun import client, entities
 from requests.exceptions import HTTPError
@@ -8,6 +6,7 @@ from robottelo.config import settings
 from robottelo.datafactory import invalid_names_list, valid_data_list
 from robottelo.decorators import rm_bug_is_open, skip_if_bug_open
 from robottelo.test import APITestCase
+from six.moves import http_client
 
 
 def _good_max_content_hosts():
@@ -239,7 +238,7 @@ class ActivationKeysTestCase(APITestCase):
             auth=settings.server.get_credentials(),
             verify=False,
         )
-        status_code = httplib.OK
+        status_code = http_client.OK
         self.assertEqual(status_code, response.status_code)
         self.assertIn('application/json', response.headers['content-type'])
 

--- a/tests/foreman/api/test_contentviewfilter.py
+++ b/tests/foreman/api/test_contentviewfilter.py
@@ -4,8 +4,6 @@ A full API reference for content views can be found here:
 http://www.katello.org/docs/api/apidoc/content_view_filters.html
 
 """
-import httplib
-
 from fauxfactory import gen_integer, gen_string
 from nailgun import client, entities
 from random import randint
@@ -15,6 +13,7 @@ from robottelo.constants import DOCKER_REGISTRY_HUB
 from robottelo.datafactory import invalid_names_list, valid_data_list
 from robottelo.decorators import run_only_on, skip_if_bug_open
 from robottelo.test import APITestCase
+from six.moves import http_client
 
 
 class ContentViewFilterTestCase(APITestCase):
@@ -56,7 +55,7 @@ class ContentViewFilterTestCase(APITestCase):
         )
         self.assertIn(
             response.status_code,
-            (httplib.BAD_REQUEST, httplib.UNPROCESSABLE_ENTITY)
+            (http_client.BAD_REQUEST, http_client.UNPROCESSABLE_ENTITY)
         )
 
     @run_only_on('sat')
@@ -78,7 +77,7 @@ class ContentViewFilterTestCase(APITestCase):
         )
         self.assertIn(
             response.status_code,
-            (httplib.BAD_REQUEST, httplib.UNPROCESSABLE_ENTITY)
+            (http_client.BAD_REQUEST, http_client.UNPROCESSABLE_ENTITY)
         )
 
     @run_only_on('sat')

--- a/tests/foreman/api/test_host.py
+++ b/tests/foreman/api/test_host.py
@@ -5,13 +5,12 @@ An API reference can be found here:
 http://theforeman.org/api/apidoc/v2/hosts.html
 
 """
-import httplib
-
 from fauxfactory import gen_integer, gen_string
 from nailgun import client, entities
 from robottelo.config import settings
 from robottelo.decorators import bz_bug_is_open, run_only_on
 from robottelo.test import APITestCase
+from six.moves import http_client
 
 
 class HostsTestCase(APITestCase):
@@ -33,7 +32,7 @@ class HostsTestCase(APITestCase):
             data={u'search': query},
             verify=False,
         )
-        self.assertEqual(response.status_code, httplib.OK)
+        self.assertEqual(response.status_code, http_client.OK)
         self.assertEqual(response.json()['search'], query)
 
     @run_only_on('sat')
@@ -52,7 +51,7 @@ class HostsTestCase(APITestCase):
             data={u'per_page': per_page},
             verify=False,
         )
-        self.assertEqual(response.status_code, httplib.OK)
+        self.assertEqual(response.status_code, http_client.OK)
         self.assertEqual(response.json()['per_page'], per_page)
 
     @run_only_on('sat')

--- a/tests/foreman/api/test_multiple_paths.py
+++ b/tests/foreman/api/test_multiple_paths.py
@@ -1,5 +1,4 @@
 """Data-driven unit tests for multiple paths."""
-import httplib
 import logging
 
 from nailgun import client, entities, entity_fields
@@ -8,6 +7,7 @@ from robottelo.config import settings
 from robottelo.decorators import bz_bug_is_open, run_only_on, skip_if_bug_open
 from robottelo.helpers import get_nailgun_config
 from robottelo.test import APITestCase
+from six.moves import http_client
 
 logger = logging.getLogger(__name__)
 
@@ -168,7 +168,7 @@ class EntityTestCase(APITestCase):
                     verify=False,
                 )
                 response.raise_for_status()
-                self.assertEqual(httplib.OK, response.status_code)
+                self.assertEqual(http_client.OK, response.status_code)
                 self.assertIn(
                     'application/json',
                     response.headers['content-type']
@@ -194,7 +194,8 @@ class EntityTestCase(APITestCase):
                     auth=(),
                     verify=False
                 )
-                self.assertEqual(httplib.UNAUTHORIZED, response.status_code)
+                self.assertEqual(
+                    http_client.UNAUTHORIZED, response.status_code)
 
     def test_post_status_code(self):
         """@Test: Issue a POST request and check the returned status code.
@@ -221,7 +222,7 @@ class EntityTestCase(APITestCase):
                     self.skipTest('Bugzilla bug 1118015 is open.')
 
                 response = entity_cls().create_raw()
-                self.assertEqual(httplib.CREATED, response.status_code)
+                self.assertEqual(http_client.CREATED, response.status_code)
                 self.assertIn(
                     'application/json',
                     response.headers['content-type']
@@ -248,7 +249,7 @@ class EntityTestCase(APITestCase):
                 return_code = entity_cls(server_cfg).create_raw(
                     create_missing=False
                 ).status_code
-                self.assertEqual(httplib.UNAUTHORIZED, return_code)
+                self.assertEqual(http_client.UNAUTHORIZED, return_code)
 
 
 class EntityIdTestCase(APITestCase):
@@ -274,7 +275,7 @@ class EntityIdTestCase(APITestCase):
                 except HTTPError as err:
                     self.fail(err)
                 response = entity.read_raw()
-                self.assertEqual(httplib.OK, response.status_code)
+                self.assertEqual(http_client.OK, response.status_code)
                 self.assertIn(
                     'application/json',
                     response.headers['content-type']
@@ -312,7 +313,7 @@ class EntityIdTestCase(APITestCase):
                     auth=settings.server.get_credentials(),
                     verify=False,
                 )
-                self.assertEqual(httplib.OK, response.status_code)
+                self.assertEqual(http_client.OK, response.status_code)
                 self.assertIn(
                     'application/json',
                     response.headers['content-type']
@@ -348,13 +349,17 @@ class EntityIdTestCase(APITestCase):
                     self.skipTest('BZ 1187366 is open.')
                 self.assertIn(
                     response.status_code,
-                    (httplib.NO_CONTENT, httplib.OK, httplib.ACCEPTED)
+                    (
+                        http_client.NO_CONTENT,
+                        http_client.OK,
+                        http_client.ACCEPTED,
+                    )
                 )
 
                 # According to RFC 2616, HTTP 204 responses "MUST NOT include a
                 # message-body". If a message does not have a body, there is no
                 # need to set the content-type of the message.
-                if response.status_code is not httplib.NO_CONTENT:
+                if response.status_code is not http_client.NO_CONTENT:
                     self.assertIn(
                         'application/json',
                         response.headers['content-type']
@@ -476,7 +481,7 @@ class DoubleCheckTestCase(APITestCase):
                     self.fail(err)
                 entity.delete()
                 self.assertEqual(
-                    httplib.NOT_FOUND,
+                    http_client.NOT_FOUND,
                     entity.read_raw().status_code
                 )
 

--- a/tests/foreman/api/test_operatingsystem.py
+++ b/tests/foreman/api/test_operatingsystem.py
@@ -7,10 +7,10 @@ References for the relevant paths can be found here:
 
 """
 from fauxfactory import gen_integer, gen_utf8
-from httplib import NOT_FOUND
 from nailgun import entities
 from robottelo.decorators import run_only_on, skip_if_bug_open
 from robottelo.test import APITestCase
+from six.moves.http_client import NOT_FOUND
 
 
 class OSParameterTestCase(APITestCase):

--- a/tests/foreman/api/test_organization.py
+++ b/tests/foreman/api/test_organization.py
@@ -5,8 +5,6 @@ tested can be found here:
 http://theforeman.org/api/apidoc/v2/organizations.html
 
 """
-import httplib
-
 from fauxfactory import gen_alphanumeric, gen_string
 from nailgun import client, entities
 from random import randint
@@ -16,6 +14,7 @@ from robottelo.datafactory import invalid_values_list
 from robottelo.decorators import skip_if_bug_open
 from robottelo.helpers import get_nailgun_config
 from robottelo.test import APITestCase
+from six.moves import http_client
 
 
 def valid_org_data_list():
@@ -57,7 +56,8 @@ class OrganizationTestCase(APITestCase):
             headers={'content-type': 'text/plain'},
             verify=False,
         )
-        self.assertEqual(httplib.UNSUPPORTED_MEDIA_TYPE, response.status_code)
+        self.assertEqual(
+            http_client.UNSUPPORTED_MEDIA_TYPE, response.status_code)
 
     def test_positive_create_1(self):
         """@Test: Create an organization and provide a name.

--- a/tests/foreman/api/test_rhsm.py
+++ b/tests/foreman/api/test_rhsm.py
@@ -4,11 +4,10 @@ No API doc exists for the subscription manager path(s). However, bugzilla bug
 1112802 provides some relevant information.
 
 """
-import httplib
-
 from nailgun import client
 from robottelo.config import settings
 from robottelo.test import APITestCase
+from six.moves import http_client
 
 
 class RHSMTestCase(APITestCase):
@@ -31,6 +30,6 @@ class RHSMTestCase(APITestCase):
             auth=settings.server.get_credentials(),
             verify=False,
         )
-        self.assertEqual(response.status_code, httplib.OK)
+        self.assertEqual(response.status_code, http_client.OK)
         self.assertIn('application/json', response.headers['content-type'])
         self.assertIsInstance(response.json(), list)

--- a/tests/foreman/cli/test_ping.py
+++ b/tests/foreman/cli/test_ping.py
@@ -1,8 +1,8 @@
 """Test Class for hammer ping"""
-from itertools import izip
 from robottelo import ssh
 from robottelo.config import settings
 from robottelo.test import CLITestCase
+from six.moves import zip
 
 
 class PingTestCase(CLITestCase):
@@ -32,7 +32,7 @@ class PingTestCase(CLITestCase):
         # iterate over the lines grouping every 3 lines
         # example [1, 2, 3, 4, 5, 6] will return [(1, 2, 3), (4, 5, 6)]
         # only the status line is relevant for this test
-        for _, status, _ in izip(*[iter(result.stdout)] * 3):
+        for _, status, _ in zip(*[iter(result.stdout)] * 3):
             status_count += 1
 
             if status.split(':')[1].strip().lower() == 'ok':

--- a/tests/foreman/smoke/test_api_smoke.py
+++ b/tests/foreman/smoke/test_api_smoke.py
@@ -1,6 +1,5 @@
 # -*- encoding: utf-8 -*-
 """Smoke tests for the ``API`` end-to-end scenario."""
-import httplib
 import random
 
 from fauxfactory import gen_string
@@ -26,6 +25,7 @@ from robottelo.decorators import bz_bug_is_open, skip_if_bug_open
 from robottelo.helpers import get_nailgun_config
 from robottelo.vm import VirtualMachine
 from robottelo.test import TestCase
+from six.moves import http_client
 # (too many public methods) pylint: disable=R0904
 
 API_PATHS = {
@@ -680,7 +680,7 @@ class TestAvailableURLs(TestCase):
             auth=settings.server.get_credentials(),
             verify=False,
         )
-        self.assertEqual(response.status_code, httplib.OK)
+        self.assertEqual(response.status_code, http_client.OK)
         self.assertIn('application/json', response.headers['content-type'])
 
     @skip_if_bug_open('bugzilla', 1105773)

--- a/tests/foreman/smoke/test_smoke.py
+++ b/tests/foreman/smoke/test_smoke.py
@@ -1,12 +1,12 @@
 """Smoke tests to check installation health"""
 import re
 
-from itertools import izip
 from robottelo import ssh
 from robottelo.config import settings
 from robottelo.helpers import get_host_info
 from robottelo.log import LogFile
 from robottelo.test import TestCase
+from six.moves import zip
 
 
 class SELinuxTestCase(TestCase):
@@ -88,7 +88,7 @@ class SELinuxTestCase(TestCase):
 
         # iterate over the lines grouping every 3 lines
         # example [1, 2, 3, 4, 5, 6] will return [(1, 2, 3), (4, 5, 6)]
-        for service, status, server_response in izip(
+        for service, status, server_response in zip(
                 *[iter(result.stdout)] * 3):
             service = service.replace(':', '').strip()
             status = status.split(':')[1].strip().lower()

--- a/tests/robottelo/test_cli.py
+++ b/tests/robottelo/test_cli.py
@@ -1,7 +1,12 @@
-import mock
+import six
 import unittest2
 
 from robottelo.cli.base import Base
+
+if six.PY2:
+    import mock
+else:
+    from unittest import mock
 
 
 class CLIClass(Base):

--- a/tests/robottelo/test_datafactory.py
+++ b/tests/robottelo/test_datafactory.py
@@ -1,5 +1,6 @@
 """Tests for module ``robottelo.datafactory``."""
 import itertools
+import six
 import unittest2
 
 from robottelo.config import settings
@@ -91,9 +92,9 @@ class TestReturnTypes(unittest2.TestCase):
                 valid_labels_list(),
                 valid_names_list(),
                 valid_usernames_list(),):
-            self.assertIsInstance(item, unicode)
+            self.assertIsInstance(item, six.text_type)
         for item in invalid_id_list():
-            if not (isinstance(item, (unicode, int)) or item is None):
+            if not (isinstance(item, (six.text_type, int)) or item is None):
                 self.fail('Unexpected data type')
 
 

--- a/tests/robottelo/test_decorators.py
+++ b/tests/robottelo/test_decorators.py
@@ -1,11 +1,16 @@
 """Unit tests for :mod:`robottelo.decorators`."""
-import mock
+import six
 
 from fauxfactory import gen_integer
 from robottelo import decorators
 from robottelo.constants import BZ_CLOSED_STATUSES, BZ_OPEN_STATUSES
 from unittest2 import TestCase
 # (Too many public methods) pylint: disable=R0904
+
+if six.PY2:
+    import mock
+else:
+    from unittest import mock
 
 
 class BzBugIsOpenTestCase(TestCase):

--- a/tests/robottelo/test_helpers.py
+++ b/tests/robottelo/test_helpers.py
@@ -1,7 +1,12 @@
 """Tests for module ``robottelo.helpers``."""
 # (Too many public methods) pylint: disable=R0904
-import mock
+import six
 import unittest2
+
+if six.PY2:
+    import mock
+else:
+    from unittest import mock
 
 from robottelo.helpers import (
     HostInfoError,
@@ -67,7 +72,7 @@ class GetHostInfoTestCase(unittest2.TestCase):
         with self.assertRaises(HostInfoError) as context:
             get_host_info()
         self.assertEqual(
-            context.exception.message,
+            str(context.exception),
             'Not able to cat /etc/redhat-release "stderr"'
         )
 
@@ -76,8 +81,11 @@ class GetHostInfoTestCase(unittest2.TestCase):
         ssh.command = mock.MagicMock(return_value=FakeSSHResult([''], 0))
         with self.assertRaises(HostInfoError) as context:
             get_host_info()
-        self.assertEqual(
-            context.exception.message, 'Not able to parse release string ""')
+        if six.PY2:
+            message = context.exception.message
+        else:
+            message = str(context.exception)
+        self.assertEqual(message, 'Not able to parse release string ""')
 
 
 class FakeSSHResult(object):
@@ -90,7 +98,7 @@ class FakeSSHResult(object):
 class EscapeSearchTestCase(unittest2.TestCase):
     def test_return_type(self):
         """Tests if escape search returns a unicode string"""
-        self.assertIsInstance(escape_search('search term'), unicode)
+        self.assertIsInstance(escape_search('search term'), six.text_type)
 
     def test_escapes_double_quotes(self):
         """Tests if escape search escapes double quotes"""

--- a/tests/robottelo/test_ssh.py
+++ b/tests/robottelo/test_ssh.py
@@ -1,10 +1,15 @@
 """Tests for module ``robottelo.ssh``."""
 # (too-many-public-methods) pylint: disable=R0904
-import mock
 import os
+import six
 
 from robottelo import ssh
 from unittest2 import TestCase
+
+if six.PY2:
+    import mock
+else:
+    from unittest import mock
 
 
 class MockSSHClient(object):

--- a/tests/robottelo/test_vm.py
+++ b/tests/robottelo/test_vm.py
@@ -1,7 +1,12 @@
 """Tests for :mod:`robottelo.vm`."""
+import six
 import unittest2
 
-from mock import call, patch
+if six.PY2:
+    from mock import call, patch
+else:
+    from unittest.mock import call, patch
+
 from robottelo import ssh
 from robottelo.vm import VirtualMachine, VirtualMachineError
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,8 @@
+[tox]
+envlist = py27,py34
+[testenv]
+deps=
+    -rrequirements.txt
+    six
+    py27: mock
+commands=python -m unittest discover tests/robottelo


### PR DESCRIPTION
Add tox.ini file in order to test robottelo against Python 2.7 and
python 3.4. Also make robottelo support both Python 2.7 and 3.4+
versions.