### PR TITLE
Quick fix for issue with compute resources (fixing 10 tests on CI)

### DIFF
--- a/tests/foreman/ui/test_computeresource.py
+++ b/tests/foreman/ui/test_computeresource.py
@@ -18,6 +18,7 @@ class ComputeResource(UITestCase):
 
     @classmethod
     def setUpClass(cls):
+        super(ComputeResource, cls).setUpClass()
         cls.current_libvirt_url = (
             LIBVIRT_RESOURCE_URL % settings.server.hostname
         )


### PR DESCRIPTION
For example:
```
nosetests tests/foreman/ui/test_computeresource.py -m test_access_docker_resource_via_compute_profile
.
----------------------------------------------------------------------
Ran 1 test in 24.893s

OK
```