### PR TITLE
UI: Update searching of 5 entities according to #2930

### DIFF
--- a/robottelo/ui/locators.py
+++ b/robottelo/ui/locators.py
@@ -1921,6 +1921,10 @@ locators = LocatorDict({
                   "//button[@ng-click='save()']"),
 
     # Manifests / subscriptions
+    "subs.select": (
+        By.XPATH, ("//tr[contains(@ng-repeat-start, 'groupedSubscriptions') "
+                   "and contains(., '%s')]/following-sibling::tr[1]/td/"
+                   "a[contains(@href, '/info')]")),
     "subs.delete_manifest": (
         By.XPATH, "//button[contains(@ng-click,'deleteManifest')]"),
     "subs.refresh_manifest": (

--- a/robottelo/ui/puppetclasses.py
+++ b/robottelo/ui/puppetclasses.py
@@ -8,6 +8,14 @@ from robottelo.ui.navigator import Navigator
 class PuppetClasses(Base):
     """Provides the CRUD functionality for Puppet-classes."""
 
+    def navigate_to_entity(self):
+        """Navigate to Puppet Classes entity page"""
+        Navigator(self.browser).go_to_puppet_classes()
+
+    def _search_locator(self):
+        """Specify locator for Puppet Classes entity search procedure"""
+        return locators['puppetclass.select_name']
+
     def create(self, name, environment=None):
         """Creates the Puppet-classes."""
         self.click(locators['puppetclass.new'])
@@ -31,17 +39,11 @@ class PuppetClasses(Base):
                                        new_env)
             self.click(common_locators['submit'])
 
-    def search(self, name):
-        """Searches existing puppet-classes from UI"""
-        Navigator(self.browser).go_to_puppet_classes()
-        return self.search_entity(name, locators['puppetclass.select_name'])
-
     def delete(self, name, really=True):
         """Deletes the puppet-classes."""
         self.delete_entity(
             name,
             really,
-            locators['puppetclass.select_name'],
             locators['puppetclass.delete'],
         )
 

--- a/robottelo/ui/role.py
+++ b/robottelo/ui/role.py
@@ -3,11 +3,20 @@
 from robottelo.constants import FILTER
 from robottelo.ui.base import Base, UIError
 from robottelo.ui.locators import common_locators, locators, tab_locators
+from robottelo.ui.navigator import Navigator
 from selenium.webdriver.support.select import Select
 
 
 class Role(Base):
     """Implements the CRUD functions for Roles."""
+
+    def navigate_to_entity(self):
+        """Navigate to Role entity page"""
+        Navigator(self.browser).go_to_roles()
+
+    def _search_locator(self):
+        """Specify locator for Role entity search procedure"""
+        return locators['roles.role']
 
     def create(self, name):
         """Creates new Role with default permissions."""
@@ -21,17 +30,11 @@ class Role(Base):
                 'Could not create new role "{0}"'.format(name)
             )
 
-    def search(self, name):
-        """Searches existing role from UI."""
-        element = self.search_entity(name, locators['roles.role'])
-        return element
-
     def delete(self, name, really=True):
         """Delete existing role."""
         self.delete_entity(
             name,
             really,
-            locators['roles.role'],
             locators['roles.delete'],
             locators['roles.dropdown'],
         )

--- a/robottelo/ui/subscription.py
+++ b/robottelo/ui/subscription.py
@@ -1,12 +1,21 @@
 """Implements Subscriptions/Manifest handling for the UI"""
 
-from robottelo.helpers import escape_search
 from robottelo.ui.base import Base
 from robottelo.ui.locators import common_locators, locators
+from robottelo.ui.navigator import Navigator
 
 
 class Subscriptions(Base):
     """Manipulates Subscriptions from UI"""
+    is_katello = True
+
+    def navigate_to_entity(self):
+        """Navigate to Subscription entity page"""
+        Navigator(self.browser).go_to_red_hat_subscriptions()
+
+    def _search_locator(self):
+        """Specify locator for Subscription entity search procedure"""
+        return locators['subs.select']
 
     def upload(self, path, repo_url=None):
         """Uploads Manifest/subscriptions via UI.
@@ -35,13 +44,3 @@ class Subscriptions(Base):
         """Refreshes Manifest/subscriptions via UI."""
         self.click(locators['subs.manage_manifest'])
         self.click(locators['subs.refresh_manifest'])
-
-    def search(self, element_name):
-        """Searches existing Subscription from UI"""
-        strategy, value = locators['subs.subscription_search']
-        searchbox = self.wait_until_element(common_locators['kt_search'])
-        if searchbox:
-            searchbox.clear()
-            searchbox.send_keys(escape_search(element_name))
-            self.click(common_locators['kt_search_button'])
-            return self.wait_until_element((strategy, value))

--- a/robottelo/ui/syncplan.py
+++ b/robottelo/ui/syncplan.py
@@ -1,11 +1,22 @@
 """Implements Sync Plans for UI."""
 from robottelo.ui.base import Base, UIError
 from robottelo.ui.locators import common_locators, locators, tab_locators
+from robottelo.ui.navigator import Navigator
 from selenium.webdriver.support.select import Select
 
 
 class Syncplan(Base):
     """Manipulates Sync Plans from UI."""
+    is_katello = True
+    result_timeout = 20
+
+    def navigate_to_entity(self):
+        """Navigate to Sync Plan entity page"""
+        Navigator(self.browser).go_to_sync_plans()
+
+    def _search_locator(self):
+        """Specify locator for Sync Plan entity search procedure"""
+        return locators['sp.select']
 
     def add_remove_products(self, products=None, tab_locator=None,
                             select_locator=None):
@@ -42,8 +53,7 @@ class Syncplan(Base):
                new_sync_interval=None, add_products=None,
                rm_products=None):
         """Updates Sync Plans from UI."""
-        sp_element = self.search_entity(
-            name, locators['sp.select'], katello=True, result_timeout=20)
+        sp_element = self.search(name)
         if sp_element is None:
             raise UIError(
                 'Unable to find the sync_plan "{0}" for update.'.format(name)
@@ -91,9 +101,3 @@ class Syncplan(Base):
             self.click(common_locators['confirm_remove'])
         else:
             self.click(common_locators['cancel'])
-
-    def search(self, name):
-        """Searches existing sync_plan from UI."""
-        element = self.search_entity(
-            name, locators['sp.select'], katello=True)
-        return element

--- a/robottelo/ui/template.py
+++ b/robottelo/ui/template.py
@@ -10,6 +10,14 @@ from selenium.webdriver.support.select import Select
 class Template(Base):
     """Provides the CRUD functionality for Templates."""
 
+    def navigate_to_entity(self):
+        """Navigate to Template entity page"""
+        Navigator(self.browser).go_to_provisioning_templates()
+
+    def _search_locator(self):
+        """Specify locator for Template entity search procedure"""
+        return locators['provision.template_select']
+
     def create(self, name, template_path=None, custom_really=None,
                audit_comment=None, template_type=None, snippet=None,
                os_list=None):
@@ -54,15 +62,6 @@ class Template(Base):
             FILTER['template_os'],
             tab_locator=tab_locators['provision.tab_association'])
         self.click(common_locators['submit'])
-
-    def search(self, name):
-        """Searches existing template from UI."""
-        self.scroll_page()
-        nav = Navigator(self.browser)
-        nav.go_to_provisioning_templates()
-        element = self.search_entity(
-            name, locators['provision.template_select'])
-        return element
 
     def update(self, name, custom_really=None, new_name=None,
                template_path=None, template_type=None,
@@ -130,11 +129,9 @@ class Template(Base):
 
     def delete(self, name, really=True):
         """Deletes a template."""
-        Navigator(self.browser).go_to_provisioning_templates()
         self.delete_entity(
             name,
             really,
-            locators['provision.template_select'],
             locators['provision.template_delete'],
             locators['provision.template_dropdown'],
         )

--- a/tests/foreman/smoke/test_ui_smoke.py
+++ b/tests/foreman/smoke/test_ui_smoke.py
@@ -136,7 +136,7 @@ class TestSmoke(UITestCase):
                 password1=password,
                 password2=password
             )
-            self.assertIsNotNone(self.user.search(user_name, 'login'))
+            self.assertIsNotNone(self.user.search(user_name))
             is_admin_role_selected = self.user.admin_role_to_user(user_name)
             self.assertTrue(is_admin_role_selected)
 

--- a/tests/foreman/ui/test_adusergroups.py
+++ b/tests/foreman/ui/test_adusergroups.py
@@ -56,8 +56,8 @@ class ADUserGroups(UITestCase):
                 self.usergroup.delete(self.usergroup_name2, True)
             set_context(session, org=ANY_CONTEXT['org'])
             session.nav.go_to_users()
-            if self.user.search(self.ldap_user_name, 'login'):
-                self.user.delete(self.ldap_user_name, 'login', True)
+            if self.user.search(self.ldap_user_name):
+                self.user.delete(self.ldap_user_name)
         super(ADUserGroups, self).tearDown()
 
     def test_adusergroup_admin_role(self):


### PR DESCRIPTION
Part of #2930
Puppet Classes:
```
nosetests tests/foreman/ui/test_puppet_classes.py  
..
----------------------------------------------------------------------
Ran 2 tests in 260.806s

OK
```
Roles:
```
nosetests tests/foreman/ui/test_role.py        
..EE...
======================================================================
ERROR: @Test: Delete an existing role
----------------------------------------------------------------------
======================================================================
ERROR: @Test: Delete an existing role
----------------------------------------------------------------------
Ran 6 tests in 300.593s

FAILED (errors=2)

nosetests tests/foreman/ui/test_role.py -m test_remove_role
.
----------------------------------------------------------------------
Ran 1 test in 121.381s

OK
```
Subscription:
```
nosetests tests/foreman/ui/test_subscription.py        
...
----------------------------------------------------------------------
Ran 3 tests in 213.062s

OK
```
Sync Plan:
```
nosetests tests/foreman/ui/test_syncplan.py            
...E.S......
======================================================================
ERROR: @Test: Create Sync Plan with valid name values
----------------------------------------------------------------------

Ran 12 tests in 1344.108s

FAILED (SKIP=1, errors=1)

nosetests tests/foreman/ui/test_syncplan.py -m test_positive_create_names
.
----------------------------------------------------------------------
Ran 1 test in 214.159s

OK
```
Template:
```
nosetests tests/foreman/ui/test_template.py 
........E..
======================================================================
ERROR: @Test: Remove a template
----------------------------------------------------------------------
Ran 11 tests in 475.956s

FAILED (errors=1)

nosetests tests/foreman/ui/test_template.py -m test_remove_template
.
----------------------------------------------------------------------
Ran 1 test in 108.231s

OK
```
+ found some originally missed user search occurrencies, updated them with new signature.