### PR TITLE
UI: Update searching of repos and registries according to #2930

### DIFF
--- a/robottelo/ui/factory.py
+++ b/robottelo/ui/factory.py
@@ -213,7 +213,6 @@ def make_repository(session, org=None, loc=None,
 
     create_args = {
         u'name': None,
-        u'product': None,
         u'gpg_key': None,
         u'http': False,
         u'url': None,
@@ -221,7 +220,7 @@ def make_repository(session, org=None, loc=None,
         u'repo_checksum': CHECKSUM_TYPE['default'],
         u'upstream_repo_name': None,
     }
-    page = session.nav.go_to_products
+    page = Repos(session.browser).navigate_to_entity
     core_factory(create_args, kwargs, session, page,
                  org=org, loc=loc, force_context=force_context)
     Repos(session.browser).create(**create_args)

--- a/robottelo/ui/registry.py
+++ b/robottelo/ui/registry.py
@@ -9,6 +9,14 @@ from robottelo.ui.navigator import Navigator
 class Registry(Base):
     """Provides the CRUD functionality for Registry."""
 
+    def navigate_to_entity(self):
+        """Navigate to Registry entity page"""
+        Navigator(self.browser).go_to_registries()
+
+    def _search_locator(self):
+        """Specify locator for Registry entity search procedure"""
+        return locators['registry.select_name']
+
     def create(self, name, url, description=None, username=None, password=None,
                orgs=None, org_select=True, locs=None, loc_select=True):
         """Creates the registry."""
@@ -74,27 +82,10 @@ class Registry(Base):
         )
         self.click(common_locators['submit'])
 
-    def search(self, name):
-        """Searches existing registry from UI"""
-        Navigator(self.browser).go_to_registries()
-        if len(name) <= 30:
-            element = self.search_entity(
-                name, locators['registry.select_name'])
-        else:
-            element = self.search_entity(
-                name, common_locators['select_filtered_entity'])
-        return element
-
     def delete(self, name, really=True):
         """Deletes the registry"""
-        if len(name) <= 30:
-            loc = locators['registry.select_name']
-        else:
-            loc = common_locators['select_filtered_entity']
-
         self.delete_entity(
             name,
             really,
-            loc,
             locators['registry.delete'],
         )

--- a/robottelo/ui/repository.py
+++ b/robottelo/ui/repository.py
@@ -1,45 +1,47 @@
 """Implements Repos UI."""
 from robottelo.constants import CHECKSUM_TYPE, REPO_TYPE
 from robottelo.ui.base import Base, UIError
-from robottelo.ui.locators import common_locators, locators
+from robottelo.ui.locators import common_locators, locators, tab_locators
 from selenium.webdriver.support.select import Select
 
 
 class Repos(Base):
     """Manipulates Repos from UI."""
 
-    def create(self, name, product=None, gpg_key=None, http=False, url=None,
+    def navigate_to_entity(self):
+        """Navigate to Repository entity tab"""
+        self.click(tab_locators['prd.tab_repos'])
+
+    def _search_locator(self):
+        """Specify locator for Repository entity search procedure"""
+        return locators['repo.select']
+
+    def create(self, name, gpg_key=None, http=False, url=None,
                upstream_repo_name=None, repo_type=REPO_TYPE['yum'],
                repo_checksum=CHECKSUM_TYPE['default']):
         """Creates new repository from UI."""
-        prd_element = self.search_entity(
-            product, locators['prd.select'], katello=True)
-        if prd_element:
-            prd_element.click()
-            self.wait_for_ajax()
-            self.click(locators['repo.new'])
-            self.text_field_update(common_locators['name'], name)
-            # label takes long time for 256 char test, hence timeout of 60 sec
-            self.wait_for_ajax(timeout=60)
-            if repo_type:
-                type_ele = self.find_element(locators['repo.type'])
-                Select(type_ele).select_by_visible_text(repo_type)
-            if self.find_element(locators['repo.checksum']):
-                type_ele = self.find_element(locators['repo.checksum'])
-                Select(type_ele).select_by_visible_text(repo_checksum)
-            if gpg_key:
-                type_ele = self.find_element(common_locators['gpg_key'])
-                Select(type_ele).select_by_visible_text(gpg_key)
-            if url:
-                self.text_field_update(locators['repo.url'], url)
-            if upstream_repo_name:
-                self.text_field_update(
-                    locators['repo.upstream_name'], upstream_repo_name)
-            if http:
-                self.click(locators['repo.via_http'])
-            self.click(common_locators['create'])
-        else:
-            raise UIError('Unable to find the product "{0}"'.format(name))
+        self.click(locators['repo.new'])
+        self.text_field_update(common_locators['name'], name)
+        # label takes long time for 256 char test, hence timeout of 60 sec
+        self.wait_for_ajax(timeout=60)
+        if repo_type:
+            type_ele = self.find_element(locators['repo.type'])
+            Select(type_ele).select_by_visible_text(repo_type)
+        if repo_checksum:
+            Select(self.find_element(
+                locators['repo.checksum'])
+            ).select_by_visible_text(repo_checksum)
+        if gpg_key:
+            type_ele = self.find_element(common_locators['gpg_key'])
+            Select(type_ele).select_by_visible_text(gpg_key)
+        if url:
+            self.text_field_update(locators['repo.url'], url)
+        if upstream_repo_name:
+            self.text_field_update(
+                locators['repo.upstream_name'], upstream_repo_name)
+        if http:
+            self.click(locators['repo.via_http'])
+        self.click(common_locators['create'])
 
     def update(self, name, new_name=None, new_url=None, new_repo_checksum=None,
                new_gpg_key=None, http=False, new_upstream_name=None):
@@ -82,6 +84,7 @@ class Repos(Base):
 
     def delete(self, repo, really=True):
         """Delete a repository from UI."""
+        self.navigate_to_entity()
         strategy, value = locators['repo.select']
         self.click((strategy, value % repo))
         self.click(locators['repo.remove'])
@@ -92,8 +95,8 @@ class Repos(Base):
 
     def search(self, element_name):
         """Uses the search box to locate an element from a list of elements."""
-        element = None
-        strategy, value = locators['repo.select']
+        self.navigate_to_entity()
+        strategy, value = self._search_locator()
         searchbox = self.wait_until_element(locators['repo.search'])
         if searchbox:
             searchbox.clear()

--- a/tests/foreman/ui/test_repository.py
+++ b/tests/foreman/ui/test_repository.py
@@ -24,7 +24,7 @@ from robottelo.helpers import (
     read_data_file,
 )
 from robottelo.test import UITestCase
-from robottelo.ui.factory import make_repository
+from robottelo.ui.factory import make_repository, set_context
 from robottelo.ui.locators import common_locators, locators, tab_locators
 from robottelo.ui.session import Session
 
@@ -91,11 +91,11 @@ class Repos(UITestCase):
         with Session(self.browser) as session:
             for repo_name in generate_strings_list():
                 with self.subTest(repo_name):
+                    set_context(session, org=self.organization.name)
+                    self.products.search(prod.name).click()
                     make_repository(
                         session,
-                        org=self.organization.name,
                         name=repo_name,
-                        product=prod.name,
                         url=FAKE_1_YUM_REPO,
                     )
                     self.assertIsNotNone(self.repository.search(repo_name))
@@ -117,19 +117,19 @@ class Repos(UITestCase):
         with Session(self.browser) as session:
             for repo_name in generate_strings_list():
                 with self.subTest(repo_name):
+                    set_context(session, org=self.organization.name)
+                    self.products.search(product_1.name).click()
                     make_repository(
                         session,
-                        org=self.organization.name,
                         name=repo_name,
-                        product=product_1.name,
                         url=FAKE_1_YUM_REPO,
                     )
                     self.assertIsNotNone(self.repository.search(repo_name))
+                    set_context(session, org=org_2.name)
+                    self.products.search(product_2.name).click()
                     make_repository(
                         session,
-                        org=org_2.name,
                         name=repo_name,
-                        product=product_2.name,
                         url=FAKE_1_YUM_REPO,
                         force_context=True,
                     )
@@ -150,11 +150,11 @@ class Repos(UITestCase):
         with Session(self.browser) as session:
             for repo_name in generate_strings_list():
                 with self.subTest(repo_name):
+                    set_context(session, org=self.organization.name)
+                    self.products.search(product.name).click()
                     make_repository(
                         session,
-                        org=self.organization.name,
                         name=repo_name,
-                        product=product.name,
                         url=FAKE_1_YUM_REPO,
                         repo_checksum=checksum,
                     )
@@ -175,11 +175,11 @@ class Repos(UITestCase):
         for repo_name in invalid_values_list(interface='ui'):
             with self.subTest(repo_name):
                 with Session(self.browser) as session:
+                    set_context(session, org=self.organization.name)
+                    self.products.search(product.name).click()
                     make_repository(
                         session,
-                        org=self.organization.name,
                         name=repo_name,
-                        product=product.name,
                         url=FAKE_1_YUM_REPO,
                     )
                     invalid = self.products.wait_until_element(
@@ -198,19 +198,18 @@ class Repos(UITestCase):
         repo_name = gen_string('alphanumeric')
         product = entities.Product(organization=self.organization).create()
         with Session(self.browser) as session:
+            set_context(session, org=self.organization.name)
+            self.products.search(product.name).click()
             make_repository(
                 session,
-                org=self.organization.name,
                 name=repo_name,
-                product=product.name,
                 url=FAKE_1_YUM_REPO,
             )
             self.assertIsNotNone(self.repository.search(repo_name))
+            self.products.search(product.name).click()
             make_repository(
                 session,
-                org=self.organization.name,
                 name=repo_name,
-                product=product.name,
                 url=FAKE_1_YUM_REPO,
             )
             invalid = self.products.wait_until_element(
@@ -230,20 +229,18 @@ class Repos(UITestCase):
         with Session(self.browser) as session:
             for repo_name in generate_strings_list():
                 with self.subTest(repo_name):
+                    set_context(session, org=self.organization.name)
+                    self.products.search(product.name).click()
                     make_repository(
                         session,
-                        org=self.organization.name,
                         name=repo_name,
-                        product=product.name,
                         url=FAKE_1_YUM_REPO,
                     )
                     self.assertIsNotNone(self.repository.search(repo_name))
                     self.assertTrue(self.repository.validate_field(
                         repo_name, 'url', FAKE_1_YUM_REPO))
-                    self.navigator.go_to_products()
                     self.products.search(product.name).click()
                     self.repository.update(repo_name, new_url=FAKE_2_YUM_REPO)
-                    self.navigator.go_to_products()
                     self.products.search(product.name).click()
                     self.assertTrue(self.repository.validate_field(
                         repo_name, 'url', FAKE_2_YUM_REPO))
@@ -271,21 +268,19 @@ class Repos(UITestCase):
         ).create()
         product = entities.Product(organization=self.organization).create()
         with Session(self.browser) as session:
+            set_context(session, org=self.organization.name)
+            self.products.search(product.name).click()
             make_repository(
                 session,
-                org=self.organization.name,
                 name=repo_name,
-                product=product.name,
                 url=FAKE_1_YUM_REPO,
                 gpg_key=gpgkey_1.name,
             )
             self.assertIsNotNone(self.repository.search(repo_name))
             self.assertTrue(self.repository.validate_field(
                 repo_name, 'gpgkey', gpgkey_1.name))
-            self.navigator.go_to_products()
             self.products.search(product.name).click()
             self.repository.update(repo_name, new_gpg_key=gpgkey_2.name)
-            self.navigator.go_to_products()
             self.products.search(product.name).click()
             self.assertTrue(self.repository.validate_field(
                 repo_name, 'gpgkey', gpgkey_2.name))
@@ -304,21 +299,19 @@ class Repos(UITestCase):
         checksum_update = CHECKSUM_TYPE['sha1']
         product = entities.Product(organization=self.organization).create()
         with Session(self.browser) as session:
+            set_context(session, org=self.organization.name)
+            self.products.search(product.name).click()
             make_repository(
                 session,
-                org=self.organization.name,
                 name=repo_name,
-                product=product.name,
                 url=FAKE_1_YUM_REPO,
             )
             self.assertIsNotNone(self.repository.search(repo_name))
             self.assertTrue(self.repository.validate_field(
                 repo_name, 'checksum', checksum_default))
-            self.navigator.go_to_products()
             self.products.search(product.name).click()
             self.repository.update(
                 repo_name, new_repo_checksum=checksum_update)
-            self.navigator.go_to_products()
             self.products.search(product.name).click()
             self.assertTrue(self.repository.validate_field(
                 repo_name, 'checksum', checksum_update))
@@ -336,11 +329,11 @@ class Repos(UITestCase):
         with Session(self.browser) as session:
             for repo_name in generate_strings_list():
                 with self.subTest(repo_name):
+                    set_context(session, org=self.organization.name)
+                    self.products.search(product.name).click()
                     make_repository(
                         session,
-                        org=self.organization.name,
                         name=repo_name,
-                        product=product.name,
                         url=FAKE_1_YUM_REPO,
                     )
                     self.assertIsNotNone(self.repository.search(repo_name))


### PR DESCRIPTION
Part of #2930

Registry:
```
nosetests tests/foreman/ui/test_docker.py:DockerRegistriesTestCase
......
----------------------------------------------------------------------
Ran 6 tests in 268.582s

OK
```

Repos:
```
nosetests tests/foreman/ui/test_repository.py 
.......E...EEE
======================================================================
ERROR: @Test: Update content repository with new gpg-key
----------------------------------------------------------------------
======================================================================
ERROR: @Test: Create Custom docker repos and sync it via the repos page.
----------------------------------------------------------------------
======================================================================
ERROR: @Test: Create Custom puppet repos and sync it via the repos page.
----------------------------------------------------------------------
======================================================================
ERROR: @Test: Create Custom yum repos and sync it via the repos page.
----------------------------------------------------------------------
Ran 14 tests in 1358.859s

FAILED (errors=4)
```
Fixed failed tests:
```
nosetests tests/foreman/ui/test_repository.py -m test_positive_update_GPG
.
----------------------------------------------------------------------
Ran 1 test in 59.496s

OK

nosetests tests/foreman/ui/test_repository.py -m test_syncnow_custom_repos_docker
.
----------------------------------------------------------------------
Ran 1 test in 215.588s

OK

nosetests tests/foreman/ui/test_repository.py -m test_syncnow_custom_repos_puppet
.
----------------------------------------------------------------------
Ran 1 test in 265.747s

OK

nosetests tests/foreman/ui/test_repository.py -m test_syncnow_custom_repos_yum
.
----------------------------------------------------------------------
Ran 1 test in 275.862s

OK
```