### PR TITLE
UI: OperatingSys search refactor #2

### DIFF
--- a/robottelo/ui/operatingsys.py
+++ b/robottelo/ui/operatingsys.py
@@ -10,8 +10,6 @@ from selenium.webdriver.support.select import Select
 class OperatingSys(Base):
     """Manipulates Foreman's operating system from UI."""
 
-    search_key = 'description'
-
     def navigate_to_entity(self):
         """Navigate to OS entity page"""
         Navigator(self.browser).go_to_operating_systems()

--- a/tests/foreman/ui/test_operatingsys.py
+++ b/tests/foreman/ui/test_operatingsys.py
@@ -93,6 +93,7 @@ class OperatingSys(UITestCase):
                         os_family=test_data['os_family'],
                         archs=['i386'],
                     )
+                    self.operatingsys.search_key = 'description'
                     self.assertIsNotNone(self.operatingsys.search(
                         test_data['desc']))
 


### PR DESCRIPTION
UI: OperatingSys search refactor #2

fix: only one test_method searches by description
(Part of #2930)