### PR TITLE
Introducing pylint configuration for robottelo

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -1,0 +1,387 @@
+[MASTER]
+
+# Specify a configuration file.
+#rcfile=
+
+# Python code to execute, usually for sys.path manipulation such as
+# pygtk.require().
+#init-hook=
+
+# Profiled execution.
+profile=no
+
+# Add files or directories to the blacklist. They should be base names, not
+# paths.
+ignore=CVS
+
+# Pickle collected data for later comparisons.
+persistent=yes
+
+# List of plugins (as comma separated values of python modules names) to load,
+# usually to register additional checkers.
+load-plugins=
+
+# Use multiple processes to speed up Pylint.
+jobs=1
+
+# Allow loading of arbitrary C extensions. Extensions are imported into the
+# active Python interpreter and may run arbitrary code.
+unsafe-load-any-extension=no
+
+# A comma-separated list of package or module names from where C extensions may
+# be loaded. Extensions are loading into the active Python interpreter and may
+# run arbitrary code
+extension-pkg-whitelist=
+
+# Allow optimization of some AST trees. This will activate a peephole AST
+# optimizer, which will apply various small optimizations. For instance, it can
+# be used to obtain the result of joining multiple strings with the addition
+# operator. Joining a lot of strings can lead to a maximum recursion error in
+# Pylint and this flag can prevent that. It has one side effect, the resulting
+# AST will be different than the one from reality.
+optimize-ast=no
+
+
+[MESSAGES CONTROL]
+
+# Only show warnings with the listed confidence levels. Leave empty to show
+# all. Valid levels: HIGH, INFERENCE, INFERENCE_FAILURE, UNDEFINED
+confidence=
+
+# Enable the message, report, category or checker with the given id(s). You can
+# either give multiple identifier separated by comma (,) or put this option
+# multiple time. See also the "--disable" option for examples.
+#enable=
+
+# Disable the message, report, category or checker with the given id(s). You
+# can either give multiple identifiers separated by comma (,) or put this
+# option multiple times (only on the command line, not in the configuration
+# file where it should appear only once).You can also use "--disable=all" to
+# disable everything first and then reenable specific checks. For example, if
+# you want to run only the similarities checker, you can use "--disable=all
+# --enable=similarities". If you want to run only the classes checker, but have
+# no Warning level messages displayed, use"--disable=all --enable=classes
+# --disable=W"
+# Added the following for robottelo:
+# C0103 - invalid-name
+# C0302 - too-many-lines
+# R0904 - too-many-public-methods
+# R0914 - too-many-locals
+disable=C0103,C0302,E1608,W1627,E1601,E1603,E1602,E1605,E1604,E1607,E1606,R0904,R0914,W1621,W1620,W1623,W1622,W1625,W1624,W1609,W1608,W1607,W1606,W1605,W1604,W1603,W1602,W1601,W1639,W1640,I0021,W1638,I0020,W1618,W1619,W1630,W1626,W1637,W1634,W1635,W1610,W1611,W1612,W1613,W1614,W1615,W1616,W1617,W1632,W1633,W0704,W1628,W1629,W1636
+
+
+[REPORTS]
+
+# Set the output format. Available formats are text, parseable, colorized, msvs
+# (visual studio) and html. You can also give a reporter class, eg
+# mypackage.mymodule.MyReporterClass.
+output-format=text
+
+# Put messages in a separate file for each module / package specified on the
+# command line instead of printing them on stdout. Reports (if any) will be
+# written in a file name "pylint_global.[txt|html]".
+files-output=no
+
+# Tells whether to display a full report or only the messages
+reports=no
+
+# Python expression which should return a note less than 10 (10 is the highest
+# note). You have access to the variables errors warning, statement which
+# respectively contain the number of errors / warnings messages and the total
+# number of statements analyzed. This is used by the global evaluation report
+# (RP0004).
+evaluation=10.0 - ((float(5 * error + warning + refactor + convention) / statement) * 10)
+
+# Add a comment according to your evaluation note. This is used by the global
+# evaluation report (RP0004).
+comment=no
+
+# Template used to display messages. This is a python new-style format string
+# used to format the message information. See doc for all details
+#msg-template=
+
+
+[FORMAT]
+
+# Maximum number of characters on a single line.
+max-line-length=100
+
+# Regexp for a line that is allowed to be longer than the limit.
+ignore-long-lines=^\s*(# )?<?https?://\S+>?$
+
+# Allow the body of an if to be on the same line as the test if there is no
+# else.
+single-line-if-stmt=no
+
+# List of optional constructs for which whitespace checking is disabled
+no-space-check=trailing-comma,dict-separator
+
+# Maximum number of lines in a module
+max-module-lines=1000
+
+# String used as indentation unit. This is usually " " (4 spaces) or "\t" (1
+# tab).
+indent-string='    '
+
+# Number of spaces of indent required inside a hanging or continued line.
+indent-after-paren=4
+
+# Expected format of line ending, e.g. empty (any line ending), LF or CRLF.
+expected-line-ending-format=
+
+
+[TYPECHECK]
+
+# Tells whether missing members accessed in mixin class should be ignored. A
+# mixin class is detected if its name ends with "mixin" (case insensitive).
+ignore-mixin-members=yes
+
+# List of module names for which member attributes should not be checked
+# (useful for modules/projects where namespaces are manipulated during runtime
+# and thus existing member attributes cannot be deduced by static analysis
+ignored-modules=
+
+# List of classes names for which member attributes should not be checked
+# (useful for classes with attributes dynamically set).
+ignored-classes=SQLObject
+
+# When zope mode is activated, add a predefined set of Zope acquired attributes
+# to generated-members.
+zope=no
+
+# List of members which are set dynamically and missed by pylint inference
+# system, and so shouldn't trigger E0201 when accessed. Python regular
+# expressions are accepted.
+generated-members=REQUEST,acl_users,aq_parent
+
+
+[MISCELLANEOUS]
+
+# List of note tags to take in consideration, separated by a comma.
+notes=FIXME,XXX,TODO
+
+
+[VARIABLES]
+
+# Tells whether we should check for unused import in __init__ files.
+init-import=no
+
+# A regular expression matching the name of dummy variables (i.e. expectedly
+# not used).
+dummy-variables-rgx=_$|dummy
+
+# List of additional names supposed to be defined in builtins. Remember that
+# you should avoid to define new builtins when possible.
+additional-builtins=
+
+# List of strings which can identify a callback function by name. A callback
+# name must start or end with one of those strings.
+callbacks=cb_,_cb
+
+
+[BASIC]
+
+# Required attributes for module, separated by a comma
+required-attributes=
+
+# List of builtins function names that should not be used, separated by a comma
+bad-functions=map,filter,input
+
+# Good variable names which should always be accepted, separated by a comma
+good-names=i,j,k,ex,Run,_
+
+# Bad variable names which should always be refused, separated by a comma
+bad-names=foo,bar,baz,toto,tutu,tata
+
+# Colon-delimited sets of names that determine each other's naming style when
+# the name regexes allow several styles.
+name-group=
+
+# Include a hint for the correct naming format with invalid-name
+include-naming-hint=no
+
+# Regular expression matching correct function names
+function-rgx=[a-z_][a-z0-9_]{2,30}$
+
+# Naming hint for function names
+function-name-hint=[a-z_][a-z0-9_]{2,30}$
+
+# Regular expression matching correct variable names
+variable-rgx=[a-z_][a-z0-9_]{2,30}$
+
+# Naming hint for variable names
+variable-name-hint=[a-z_][a-z0-9_]{2,30}$
+
+# Regular expression matching correct constant names
+const-rgx=(([A-Z_][A-Z0-9_]*)|(__.*__))$
+
+# Naming hint for constant names
+const-name-hint=(([A-Z_][A-Z0-9_]*)|(__.*__))$
+
+# Regular expression matching correct attribute names
+attr-rgx=[a-z_][a-z0-9_]{2,30}$
+
+# Naming hint for attribute names
+attr-name-hint=[a-z_][a-z0-9_]{2,30}$
+
+# Regular expression matching correct argument names
+argument-rgx=[a-z_][a-z0-9_]{2,30}$
+
+# Naming hint for argument names
+argument-name-hint=[a-z_][a-z0-9_]{2,30}$
+
+# Regular expression matching correct class attribute names
+class-attribute-rgx=([A-Za-z_][A-Za-z0-9_]{2,30}|(__.*__))$
+
+# Naming hint for class attribute names
+class-attribute-name-hint=([A-Za-z_][A-Za-z0-9_]{2,30}|(__.*__))$
+
+# Regular expression matching correct inline iteration names
+inlinevar-rgx=[A-Za-z_][A-Za-z0-9_]*$
+
+# Naming hint for inline iteration names
+inlinevar-name-hint=[A-Za-z_][A-Za-z0-9_]*$
+
+# Regular expression matching correct class names
+class-rgx=[A-Z_][a-zA-Z0-9]+$
+
+# Naming hint for class names
+class-name-hint=[A-Z_][a-zA-Z0-9]+$
+
+# Regular expression matching correct module names
+module-rgx=(([a-z_][a-z0-9_]*)|([A-Z][a-zA-Z0-9]+))$
+
+# Naming hint for module names
+module-name-hint=(([a-z_][a-z0-9_]*)|([A-Z][a-zA-Z0-9]+))$
+
+# Regular expression matching correct method names
+method-rgx=[a-z_][a-z0-9_]{2,30}$
+
+# Naming hint for method names
+method-name-hint=[a-z_][a-z0-9_]{2,30}$
+
+# Regular expression which should only match function or class names that do
+# not require a docstring.
+no-docstring-rgx=__.*__
+
+# Minimum line length for functions/classes that require docstrings, shorter
+# ones are exempt.
+docstring-min-length=-1
+
+
+[SIMILARITIES]
+
+# Minimum lines number of a similarity.
+min-similarity-lines=4
+
+# Ignore comments when computing similarities.
+ignore-comments=yes
+
+# Ignore docstrings when computing similarities.
+ignore-docstrings=yes
+
+# Ignore imports when computing similarities.
+ignore-imports=yes
+
+
+[SPELLING]
+
+# Spelling dictionary name. Available dictionaries: none. To make it working
+# install python-enchant package.
+spelling-dict=
+
+# List of comma separated words that should not be checked.
+spelling-ignore-words=
+
+# A path to a file that contains private dictionary; one word per line.
+spelling-private-dict-file=
+
+# Tells whether to store unknown words to indicated private dictionary in
+# --spelling-private-dict-file option instead of raising a message.
+spelling-store-unknown-words=no
+
+
+[LOGGING]
+
+# Logging modules to check that the string format arguments are in logging
+# function parameter format
+logging-modules=logging
+
+
+[IMPORTS]
+
+# Deprecated modules which should not be used, separated by a comma
+deprecated-modules=regsub,TERMIOS,Bastion,rexec
+
+# Create a graph of every (i.e. internal and external) dependencies in the
+# given file (report RP0402 must not be disabled)
+import-graph=
+
+# Create a graph of external dependencies in the given file (report RP0402 must
+# not be disabled)
+ext-import-graph=
+
+# Create a graph of internal dependencies in the given file (report RP0402 must
+# not be disabled)
+int-import-graph=
+
+
+[DESIGN]
+
+# Maximum number of arguments for function / method
+max-args=5
+
+# Argument names that match this expression will be ignored. Default to name
+# with leading underscore
+ignored-argument-names=_.*
+
+# Maximum number of locals for function / method body
+max-locals=15
+
+# Maximum number of return / yield for function / method body
+max-returns=6
+
+# Maximum number of branch for function / method body
+max-branches=12
+
+# Maximum number of statements in function / method body
+max-statements=50
+
+# Maximum number of parents for a class (see R0901).
+max-parents=7
+
+# Maximum number of attributes for a class (see R0902).
+max-attributes=7
+
+# Minimum number of public methods for a class (see R0903).
+min-public-methods=2
+
+# Maximum number of public methods for a class (see R0904).
+max-public-methods=20
+
+
+[CLASSES]
+
+# List of interface methods to ignore, separated by a comma. This is used for
+# instance to not check methods defines in Zope's Interface base class.
+ignore-iface-methods=isImplementedBy,deferred,extends,names,namesAndDescriptions,queryDescriptionFor,getBases,getDescriptionFor,getDoc,getName,getTaggedValue,getTaggedValueTags,isEqualOrExtendedBy,setTaggedValue,isImplementedByInstancesOf,adaptWith,is_implemented_by
+
+# List of method names used to declare (i.e. assign) instance attributes.
+defining-attr-methods=__init__,__new__,setUp
+
+# List of valid names for the first argument in a class method.
+valid-classmethod-first-arg=cls
+
+# List of valid names for the first argument in a metaclass class method.
+valid-metaclass-classmethod-first-arg=mcs
+
+# List of member names, which should be excluded from the protected access
+# warning.
+exclude-protected=_asdict,_fields,_replace,_source,_make
+
+
+[EXCEPTIONS]
+
+# Exceptions that will emit a warning when being caught. Defaults to
+# "Exception"
+overgeneral-exceptions=Exception

--- a/tests/foreman/api/test_contentview.py
+++ b/tests/foreman/api/test_contentview.py
@@ -895,7 +895,6 @@ class ContentViewTestCaseStub(APITestCase):
     """Incomplete tests for content views."""
     # Each of these tests should be given a better name when they're
     # implemented. In the meantime, let's not worry about bad names.
-    # pylint:disable=invalid-name
 
     @stubbed()
     def test_cv_edit_rh_custom_spin(self):

--- a/tests/foreman/api/test_contentviewfilter.py
+++ b/tests/foreman/api/test_contentviewfilter.py
@@ -38,9 +38,6 @@ class ContentViewFilterTestCase(APITestCase):
         self.content_view.repository = [self.repo]
         self.content_view.update(['repository'])
 
-    # Test method names are long for descriptive purposes.
-    # pylint:disable=invalid-name
-
     @run_only_on('sat')
     def test_get_with_no_args(self):
         """@Test: Issue an HTTP GET to the base content view filters path.

--- a/tests/foreman/api/test_location.py
+++ b/tests/foreman/api/test_location.py
@@ -1,4 +1,3 @@
-# pylint: disable=too-many-public-methods
 """Unit tests for the ``locations`` paths.
 
 A full API reference for locations can be found here:

--- a/tests/foreman/api/test_multiple_paths.py
+++ b/tests/foreman/api/test_multiple_paths.py
@@ -1,4 +1,3 @@
-# pylint: disable=too-many-public-methods
 """Data-driven unit tests for multiple paths."""
 import httplib
 import logging
@@ -10,7 +9,7 @@ from robottelo.decorators import bz_bug_is_open, run_only_on, skip_if_bug_open
 from robottelo.helpers import get_nailgun_config
 from robottelo.test import APITestCase
 
-logger = logging.getLogger(__name__)  # pylint:disable=invalid-name
+logger = logging.getLogger(__name__)
 
 BZ_1118015_ENTITIES = (
     entities.ActivationKey, entities.Architecture, entities.ConfigTemplate,

--- a/tests/foreman/cli/test_activationkey.py
+++ b/tests/foreman/cli/test_activationkey.py
@@ -1,6 +1,5 @@
 # -*- encoding: utf-8 -*-
-# pylint: disable=too-many-public-methods, too-many-lines
-# pylint: disable=unexpected-keyword-arg, invalid-name
+# pylint: disable=unexpected-keyword-arg
 """Test class for Activation key CLI"""
 
 from fauxfactory import gen_string

--- a/tests/foreman/cli/test_capsule.py
+++ b/tests/foreman/cli/test_capsule.py
@@ -1,5 +1,4 @@
 # -*- encoding: utf-8 -*-
-# pylint: disable=invalid-name
 """Test class for the capsule CLI."""
 from robottelo.test import CLITestCase
 

--- a/tests/foreman/cli/test_capsule_installer.py
+++ b/tests/foreman/cli/test_capsule_installer.py
@@ -1,5 +1,4 @@
 # -*- encoding: utf-8 -*-
-# pylint: disable=invalid-name
 """Test for capsule installer CLI"""
 from robottelo.test import CLITestCase
 

--- a/tests/foreman/cli/test_contenthost.py
+++ b/tests/foreman/cli/test_contenthost.py
@@ -1,4 +1,3 @@
-# pylint: disable=too-many-public-methods
 """Test class for Content-Host CLI"""
 
 from fauxfactory import gen_string

--- a/tests/foreman/cli/test_contentviewfilter.py
+++ b/tests/foreman/cli/test_contentviewfilter.py
@@ -1,5 +1,4 @@
 # -*- encoding: utf-8 -*-
-# pylint: disable=too-many-public-methods
 """Test class for Content View Filters"""
 
 from fauxfactory import gen_choice, gen_string

--- a/tests/foreman/cli/test_contentviews.py
+++ b/tests/foreman/cli/test_contentviews.py
@@ -1,4 +1,3 @@
-# pylint: disable=too-many-public-methods, too-many-lines
 """Test class for Content Views"""
 import random
 

--- a/tests/foreman/cli/test_discovery.py
+++ b/tests/foreman/cli/test_discovery.py
@@ -1,5 +1,4 @@
 # -*- encoding: utf-8 -*-
-# pylint: disable=invalid-name
 """Test class for CLI Foreman Discovery"""
 from robottelo.decorators import stubbed
 from robottelo.test import CLITestCase

--- a/tests/foreman/cli/test_docker.py
+++ b/tests/foreman/cli/test_docker.py
@@ -1,5 +1,4 @@
-# pylint: disable=too-many-public-methods, too-many-lines
-# pylint: disable=invalid-name, attribute-defined-outside-init
+# pylint: attribute-defined-outside-init
 """Unit tests for the Docker feature."""
 from fauxfactory import gen_alpha, gen_choice, gen_string, gen_url
 from random import choice, randint

--- a/tests/foreman/cli/test_domain.py
+++ b/tests/foreman/cli/test_domain.py
@@ -1,5 +1,4 @@
 # -*- encoding: utf-8 -*-
-# pylint: disable=invalid-name
 """Test class for Domain  CLI"""
 from fauxfactory import gen_string
 from robottelo.cli.base import CLIReturnCodeError

--- a/tests/foreman/cli/test_environment.py
+++ b/tests/foreman/cli/test_environment.py
@@ -1,5 +1,4 @@
 # -*- encoding: utf-8 -*-
-# pylint: disable=invalid-name
 """Test for Environment  CLI"""
 from fauxfactory import gen_string
 from robottelo.cli.base import CLIReturnCodeError

--- a/tests/foreman/cli/test_errata.py
+++ b/tests/foreman/cli/test_errata.py
@@ -1,4 +1,3 @@
-# pylint: disable=too-many-public-methods
 """CLI Tests for the errata management feature"""
 
 # For ease of use hc refers to host-collection throughout this document

--- a/tests/foreman/cli/test_gpgkey.py
+++ b/tests/foreman/cli/test_gpgkey.py
@@ -1,5 +1,4 @@
 # -*- encoding: utf-8 -*-
-# pylint: disable=too-many-public-methods, too-many-lines
 """Test class for GPG Key CLI"""
 
 from fauxfactory import gen_string, gen_alphanumeric, gen_integer

--- a/tests/foreman/cli/test_host.py
+++ b/tests/foreman/cli/test_host.py
@@ -1,4 +1,3 @@
-# pylint: disable=invalid-name
 """CLI tests for ``hammer host``."""
 from fauxfactory import gen_string
 from nailgun import entities

--- a/tests/foreman/cli/test_host_collection.py
+++ b/tests/foreman/cli/test_host_collection.py
@@ -1,5 +1,4 @@
 # -*- encoding: utf-8 -*-
-# pylint: disable=invalid-name
 """Test class for Host Collection CLI"""
 
 from fauxfactory import gen_string

--- a/tests/foreman/cli/test_host_system_unification.py
+++ b/tests/foreman/cli/test_host_system_unification.py
@@ -1,5 +1,4 @@
 # -*- encoding: utf-8 -*-
-# pylint: disable=invalid-name
 """Test for Host/System Unification"""
 
 from robottelo.decorators import run_only_on, stubbed

--- a/tests/foreman/cli/test_hostgroup.py
+++ b/tests/foreman/cli/test_hostgroup.py
@@ -1,5 +1,4 @@
 # -*- encoding: utf-8 -*-
-# pylint: disable=invalid-name
 """Test class for :class:`robottelo.cli.hostgroup.HostGroup` CLI."""
 
 from robottelo.cli.base import CLIReturnCodeError

--- a/tests/foreman/cli/test_installer.py
+++ b/tests/foreman/cli/test_installer.py
@@ -1,5 +1,4 @@
 # -*- encoding: utf-8 -*-
-# pylint: disable=invalid-name
 """Tests for Installer"""
 from robottelo.decorators import run_only_on, stubbed
 from robottelo.test import CLITestCase

--- a/tests/foreman/cli/test_lifecycleenvironment.py
+++ b/tests/foreman/cli/test_lifecycleenvironment.py
@@ -1,5 +1,4 @@
 # -*- encoding: utf-8 -*-
-# pylint: disable=invalid-name
 """Test class for Host CLI"""
 
 from fauxfactory import gen_alphanumeric, gen_string

--- a/tests/foreman/cli/test_location.py
+++ b/tests/foreman/cli/test_location.py
@@ -1,5 +1,4 @@
 # -*- encoding: utf-8 -*-
-# pylint: disable=too-many-public-methods, invalid-name
 """Test class for Location CLI"""
 
 from fauxfactory import gen_string

--- a/tests/foreman/cli/test_medium.py
+++ b/tests/foreman/cli/test_medium.py
@@ -1,5 +1,4 @@
 # -*- encoding: utf-8 -*-
-# pylint: disable=invalid-name
 """Test for Medium  CLI"""
 
 from fauxfactory import gen_alphanumeric

--- a/tests/foreman/cli/test_myaccount.py
+++ b/tests/foreman/cli/test_myaccount.py
@@ -1,5 +1,4 @@
 # -*- encoding: utf-8 -*-
-# pylint: disable=invalid-name
 """Test class for Users CLI"""
 
 from robottelo.decorators import stubbed

--- a/tests/foreman/cli/test_org.py
+++ b/tests/foreman/cli/test_org.py
@@ -1,5 +1,5 @@
 # -*- encoding: utf-8 -*-
-# pylint: disable=too-many-public-methods, too-many-lines, no-self-use
+# pylint: disable=no-self-use
 """Test class for Organization CLI"""
 import random
 

--- a/tests/foreman/cli/test_os.py
+++ b/tests/foreman/cli/test_os.py
@@ -1,5 +1,4 @@
 # -*- encoding: utf-8 -*-
-# pylint: disable=invalid-name
 """Test class for Operating System CLI"""
 from fauxfactory import gen_alphanumeric, gen_string
 from robottelo.cli.base import CLIReturnCodeError

--- a/tests/foreman/cli/test_partitiontable.py
+++ b/tests/foreman/cli/test_partitiontable.py
@@ -1,5 +1,4 @@
 # -*- encoding: utf-8 -*-
-# pylint: disable=invalid-name
 """Test class for Partition table CLI"""
 from fauxfactory import gen_string, gen_alphanumeric
 from robottelo.cli.factory import make_os, make_partition_table

--- a/tests/foreman/cli/test_proxy.py
+++ b/tests/foreman/cli/test_proxy.py
@@ -1,5 +1,5 @@
 # -*- encoding: utf-8 -*-
-# pylint: disable=no-self-use, invalid-name
+# pylint: disable=no-self-use
 """proxy class for Smart proxy CLI"""
 
 import random

--- a/tests/foreman/cli/test_repository.py
+++ b/tests/foreman/cli/test_repository.py
@@ -1,5 +1,4 @@
 # -*- encoding: utf-8 -*-
-# pylint: disable=too-many-public-methods, invalid-name
 """Test class for Repository CLI"""
 
 from fauxfactory import gen_string

--- a/tests/foreman/cli/test_repository_set.py
+++ b/tests/foreman/cli/test_repository_set.py
@@ -1,4 +1,3 @@
-# pylint: disable=invalid-name
 """Tests for cli repository set"""
 from robottelo.cli.factory import make_org
 from robottelo.cli.product import Product

--- a/tests/foreman/cli/test_syncplan.py
+++ b/tests/foreman/cli/test_syncplan.py
@@ -1,5 +1,4 @@
 # -*- encoding: utf-8 -*-
-# pylint: disable=invalid-name
 """Test class for Product CLI"""
 
 from datetime import datetime, timedelta

--- a/tests/foreman/cli/test_system_registration.py
+++ b/tests/foreman/cli/test_system_registration.py
@@ -1,4 +1,3 @@
-# pylint: disable=invalid-name
 """Test module for System Registration CLI"""
 from robottelo.decorators import stubbed
 from robottelo.test import CLITestCase

--- a/tests/foreman/cli/test_user.py
+++ b/tests/foreman/cli/test_user.py
@@ -1,5 +1,4 @@
 # -*- encoding: utf-8 -*-
-# pylint: disable=too-many-public-methods, too-many-lines
 """Test class for Users CLI
 
 When testing email validation [1] and [2] should be taken into consideration.

--- a/tests/foreman/ui/test_activationkey.py
+++ b/tests/foreman/ui/test_activationkey.py
@@ -1,5 +1,4 @@
 # -*- encoding: utf-8 -*-
-# pylint: disable=too-many-public-methods, too-many-lines, invalid-name
 """Test class for Activation key UI"""
 
 from fauxfactory import gen_string
@@ -1038,7 +1037,6 @@ class ActivationKey(UITestCase):
                 )
             )
 
-    # pylint: disable=too-many-locals
     @run_only_on('sat')
     def test_multiple_activation_keys_to_system(self):
         """@Test: Check if multiple Activation keys can be attached to a system

--- a/tests/foreman/ui/test_adusergroups.py
+++ b/tests/foreman/ui/test_adusergroups.py
@@ -1,4 +1,3 @@
-# pylint: disable=invalid-name
 """Test class for Active Directory Feature"""
 from fauxfactory import gen_string
 from nailgun import entities

--- a/tests/foreman/ui/test_capsule.py
+++ b/tests/foreman/ui/test_capsule.py
@@ -5,6 +5,7 @@ from robottelo.test import UITestCase
 
 
 class CapsuleTestCase(UITestCase):
+    """Implements capsule tests in UI"""
 
     def capsule_errata_push(self):
         """@Test: User can push errata through to a client on

--- a/tests/foreman/ui/test_computeresource.py
+++ b/tests/foreman/ui/test_computeresource.py
@@ -1,5 +1,4 @@
 # -*- encoding: utf-8 -*-
-# pylint: disable=invalid-name
 """Test for Compute Resource UI"""
 from fauxfactory import gen_string
 from nailgun import entities

--- a/tests/foreman/ui/test_contentenv.py
+++ b/tests/foreman/ui/test_contentenv.py
@@ -1,4 +1,3 @@
-# pylint: disable=invalid-name
 # -*- encoding: utf-8 -*-
 """Test class for Life cycle environments UI"""
 

--- a/tests/foreman/ui/test_contentviews.py
+++ b/tests/foreman/ui/test_contentviews.py
@@ -1,5 +1,4 @@
 # -*- encoding: utf-8 -*-
-# pylint: disable=invalid-name, too-many-lines, too-many-public-methods
 """Test class for Host/System Unification
 
 Feature details: https://fedorahosted.org/katello/wiki/ContentViews

--- a/tests/foreman/ui/test_discoveryrule.py
+++ b/tests/foreman/ui/test_discoveryrule.py
@@ -1,5 +1,4 @@
 # -*- encoding: utf-8 -*-
-# pylint: disable=invalid-name
 """Test class for Foreman Discovery Rules"""
 from fauxfactory import gen_string
 from nailgun import entities

--- a/tests/foreman/ui/test_docker.py
+++ b/tests/foreman/ui/test_docker.py
@@ -22,7 +22,6 @@ from robottelo.ui.factory import (
 )
 from robottelo.ui.locators import common_locators, locators
 from robottelo.ui.session import Session
-# (too-many-public-methods) pylint:disable=R0904
 
 VALID_DOCKER_UPSTREAM_NAMES = (
     # boundaries

--- a/tests/foreman/ui/test_domain.py
+++ b/tests/foreman/ui/test_domain.py
@@ -1,5 +1,4 @@
 # -*- encoding: utf-8 -*-
-# pylint: disable=invalid-name
 """Test class for Domain UI"""
 from fauxfactory import gen_string
 from robottelo.constants import DOMAIN

--- a/tests/foreman/ui/test_gpgkey.py
+++ b/tests/foreman/ui/test_gpgkey.py
@@ -1,5 +1,4 @@
 # -*- encoding: utf-8 -*-
-# pylint: disable=too-many-public-methods, too-many-lines, invalid-name
 """Test class for GPG Key UI"""
 
 from fauxfactory import gen_string
@@ -170,7 +169,7 @@ class GPGKey(UITestCase):
         """
         with Session(self.browser) as session:
             for name in generate_strings_list(
-                    len1=300, remove_str='numeric', bug_id=1184480):
+                    length=300, remove_str='numeric', bug_id=1184480):
                 with self.subTest(name):
                     make_gpgkey(
                         session,
@@ -197,7 +196,7 @@ class GPGKey(UITestCase):
         """
         with Session(self.browser) as session:
             for name in generate_strings_list(
-                    len1=300, remove_str='numeric', bug_id=1184480):
+                    length=300, remove_str='numeric', bug_id=1184480):
                 with self.subTest(name):
                     make_gpgkey(
                         session,
@@ -395,7 +394,7 @@ class GPGKey(UITestCase):
             )
             self.assertIsNotNone(self.gpgkey.search(name))
             for new_name in generate_strings_list(
-                    len1=300, remove_str='numeric', bug_id=1184480):
+                    length=300, remove_str='numeric', bug_id=1184480):
                 with self.subTest(new_name):
                     self.gpgkey.update(name, new_name)
                     self.assertIsNotNone(

--- a/tests/foreman/ui/test_host.py
+++ b/tests/foreman/ui/test_host.py
@@ -1,4 +1,5 @@
 # -*- encoding: utf-8 -*-
+"""Test class for Hosts UI"""
 from fauxfactory import gen_string
 from nailgun import entities, entity_mixins
 from robottelo.api.utils import promote
@@ -13,6 +14,7 @@ from robottelo.ui.session import Session
 
 
 class Host(UITestCase, Base):
+    """Implements Host tests in UI"""
 
     hostname = gen_string('numeric')
 
@@ -122,7 +124,7 @@ class Host(UITestCase, Base):
         cls.subnet = entities.Subnet().search(
             query={u'search': u'network={0}'.format(network)}
         )
-        if (len(cls.subnet) == 1):
+        if len(cls.subnet) == 1:
             cls.subnet = cls.subnet[0]
             cls.subnet.domain = [cls.domain]
             cls.subnet.location = [cls.loc]
@@ -165,7 +167,7 @@ class Host(UITestCase, Base):
             provider='libvirt',
             url=resource_url
         ).search()
-        if (len(cls.computeresource) >= 1):
+        if len(cls.computeresource) >= 1:
             cls.computeresource = cls.computeresource[0]
             cls.computeresource.location = [cls.loc]
             cls.computeresource.organization = [cls.org]

--- a/tests/foreman/ui/test_host_system_unification.py
+++ b/tests/foreman/ui/test_host_system_unification.py
@@ -6,6 +6,7 @@ from robottelo.test import UITestCase
 
 
 class TestHostSystemUnificationUI(UITestCase):
+    """Implements Host System Unification tests in UI"""
     # Testing notes for host/system unification in katello/foreman
     # Basically assuring that hosts in foreman/katello bits are joined
     # and information can be associated across both parts of product.

--- a/tests/foreman/ui/test_hostgroup.py
+++ b/tests/foreman/ui/test_hostgroup.py
@@ -1,5 +1,4 @@
 # -*- encoding: utf-8 -*-
-# pylint: disable=invalid-name
 """Test class for Host Group UI"""
 
 from fauxfactory import gen_string

--- a/tests/foreman/ui/test_hw_model.py
+++ b/tests/foreman/ui/test_hw_model.py
@@ -1,4 +1,3 @@
-# pylint: disable=invalid-name
 """Test class for Config Groups UI"""
 
 from fauxfactory import gen_string

--- a/tests/foreman/ui/test_isodownload.py
+++ b/tests/foreman/ui/test_isodownload.py
@@ -1,3 +1,4 @@
+"""Test class for ISO downloads UI"""
 from robottelo.decorators import run_only_on, stubbed
 from robottelo.test import UITestCase
 

--- a/tests/foreman/ui/test_ldap_auth.py
+++ b/tests/foreman/ui/test_ldap_auth.py
@@ -5,6 +5,7 @@ from robottelo.test import UITestCase
 
 
 class LDAPAuthUI(UITestCase):
+    """Implements ldap tests in UI"""
     # Notes for SSO testing:
     # Of interest... In some test cases I've placed a few comments prefaced
     # with "devnote:" These are -- obviously -- notes from developers that

--- a/tests/foreman/ui/test_ldapauthsource.py
+++ b/tests/foreman/ui/test_ldapauthsource.py
@@ -1,4 +1,3 @@
-# pylint: disable=invalid-name
 """Test class for Active Directory Feature"""
 from robottelo.config import settings
 from robottelo.constants import LDAP_ATTR, LDAP_SERVER_TYPE

--- a/tests/foreman/ui/test_location.py
+++ b/tests/foreman/ui/test_location.py
@@ -1,5 +1,4 @@
 # -*- encoding: utf-8 -*-
-# pylint: disable=too-many-public-methods, invalid-name
 """Test class for Locations UI"""
 
 from fauxfactory import gen_ipaddr, gen_string

--- a/tests/foreman/ui/test_medium.py
+++ b/tests/foreman/ui/test_medium.py
@@ -1,5 +1,4 @@
 # -*- encoding: utf-8 -*-
-# pylint: disable=invalid-name
 """Test class for Medium UI"""
 
 from fauxfactory import gen_string

--- a/tests/foreman/ui/test_operatingsys.py
+++ b/tests/foreman/ui/test_operatingsys.py
@@ -1,5 +1,4 @@
 # -*- encoding: utf-8 -*-
-# pylint: disable=invalid-name
 """Test class for Operating System UI"""
 
 from fauxfactory import gen_string

--- a/tests/foreman/ui/test_org.py
+++ b/tests/foreman/ui/test_org.py
@@ -1,5 +1,4 @@
 # -*- encoding: utf-8 -*-
-# pylint: disable=too-many-public-methods, invalid-name
 """Test class for Organization UI"""
 
 from fauxfactory import gen_ipaddr, gen_string

--- a/tests/foreman/ui/test_partitiontable.py
+++ b/tests/foreman/ui/test_partitiontable.py
@@ -1,5 +1,4 @@
 # -*- encoding: utf-8 -*-
-# pylint: disable=invalid-name
 """Test class for Partition Table UI"""
 from fauxfactory import gen_string
 from robottelo.constants import PARTITION_SCRIPT_DATA_FILE

--- a/tests/foreman/ui/test_products.py
+++ b/tests/foreman/ui/test_products.py
@@ -1,5 +1,4 @@
 # -*- encoding: utf-8 -*-
-# pylint: disable=invalid-name
 """Test class for Products UI"""
 
 from fauxfactory import gen_string

--- a/tests/foreman/ui/test_repository.py
+++ b/tests/foreman/ui/test_repository.py
@@ -1,5 +1,4 @@
 # -*- encoding: utf-8 -*-
-# pylint: disable=invalid-name
 """Test class for Repository UI"""
 
 import time

--- a/tests/foreman/ui/test_role.py
+++ b/tests/foreman/ui/test_role.py
@@ -1,5 +1,4 @@
 # -*- encoding: utf-8 -*-
-# pylint: disable=invalid-name
 """Test class for Roles UI"""
 
 from fauxfactory import gen_string

--- a/tests/foreman/ui/test_settings.py
+++ b/tests/foreman/ui/test_settings.py
@@ -1,5 +1,4 @@
 # -*- encoding: utf-8 -*-
-# pylint: disable=too-many-public-methods, invalid-name
 """Test class for Setting Parameter values"""
 
 from fauxfactory import gen_email, gen_string, gen_url

--- a/tests/foreman/ui/test_sso.py
+++ b/tests/foreman/ui/test_sso.py
@@ -1,11 +1,12 @@
 # -*- encoding: utf-8 -*-
-"""Test class for installer (UI)"""
+"""Test class for SSO (UI)"""
 
 from robottelo.decorators import stubbed
 from robottelo.test import UITestCase
 
 
 class TestSSOUI(UITestCase):
+    """Implements SSO tests in UI"""
     # Notes for SSO testing:
     # Of interest... In some test cases I've placed a few comments prefaced
     # with "devnote:" These are -- obviously -- notes from developers that

--- a/tests/foreman/ui/test_subnet.py
+++ b/tests/foreman/ui/test_subnet.py
@@ -1,5 +1,4 @@
 # -*- encoding: utf-8 -*-
-# pylint: disable=invalid-name
 """Test class for Subnet UI"""
 
 from fauxfactory import gen_ipaddr, gen_netmask, gen_string

--- a/tests/foreman/ui/test_syncplan.py
+++ b/tests/foreman/ui/test_syncplan.py
@@ -1,5 +1,4 @@
 """Test class for Sync Plan UI"""
-# pylint: disable=invalid-name
 
 from datetime import datetime, timedelta
 from fauxfactory import gen_string

--- a/tests/foreman/ui/test_template.py
+++ b/tests/foreman/ui/test_template.py
@@ -1,5 +1,4 @@
 # -*- encoding: utf-8 -*-
-# pylint: disable=invalid-name
 """Test class for Template UI"""
 from fauxfactory import gen_string
 from nailgun import entities

--- a/tests/foreman/ui/test_user.py
+++ b/tests/foreman/ui/test_user.py
@@ -1,5 +1,4 @@
 # -*- encoding: utf-8 -*-
-# pylint: disable=too-many-public-methods, too-many-lines, invalid-name
 """Test class for Users UI"""
 
 from fauxfactory import gen_string

--- a/tests/foreman/ui/test_usergroup.py
+++ b/tests/foreman/ui/test_usergroup.py
@@ -1,5 +1,4 @@
 # -*- encoding: utf-8 -*-
-# pylint: disable=invalid-name
 """Test class for UserGroup UI"""
 from fauxfactory import gen_string
 from nailgun import entities


### PR DESCRIPTION
This PR introduces pylint config and disables some pylint errors which were already widely used across robottelo.  This will help focusing on any valid errors.