### PR TITLE
Doc updates

### DIFF
--- a/docs/api/robottelo.cli.rst
+++ b/docs/api/robottelo.cli.rst
@@ -3,10 +3,6 @@
 
 Submodules:
 
-.. toctree::
-
-    robottelo.cli.metatest
-
 .. automodule:: robottelo.cli
 
 :mod:`robottelo.cli.activationkey`

--- a/robottelo/vm.py
+++ b/robottelo/vm.py
@@ -375,7 +375,7 @@ class VirtualMachine(object):
         service.
 
         :param activation_key: Activation key to be used to register the
-        system to satellite
+            system to satellite
         :param org: The org to which the system is required to be registered
         :param rhel_distro: rhel distribution for
         :return: None

--- a/tests/foreman/cli/test_import.py
+++ b/tests/foreman/cli/test_import.py
@@ -204,6 +204,7 @@ def get_sat6_id(
 ):
     """Updates the dictionary of the import entity with 'sat6' key/value pairs
     for keeping the Satellite 6 referrence to the imported entity
+
     :param entity_dict: A dictionary holding the info for an entity to be
         imported (typically a product of csv_to_dataset())
     :param transition_dict: A dictionary holding the transition data for the


### PR DESCRIPTION
This fixes the doc errors.

```sh
# make docs
make[1]: Entering directory `/framework/robottelo/docs'
sphinx-build -b html -d _build/doctrees   . _build/html
Running Sphinx v1.3b1
making output directory...
loading pickled environment... not yet created
building [mo]: targets for 0 po files that are out of date
building [html]: targets for 19 source files that are out of date
updating environment: 19 added, 0 changed, 0 removed
reading sources... [100%] reviewing_PRs                          
looking for now-outdated files... none found
pickling environment... done
checking consistency... done
preparing documents... done
writing output... [100%] reviewing_PRs                           
<autodoc>:None: WARNING: py:obj reference target not found: boolean
/framework/robottelo/docs/api/tests.foreman.cli.rst:37: WARNING: py:class reference target not found: Domain
generating indices... genindex py-modindex
highlighting module code... [  1%] tests.foreman.api.test_operatihighlighting module code... [  2%] tests.foreman.cli.test_syncplahighlighting module code... [  2%] tests.foreman.cli.test_host_syhighlighting module code... [  4%] tests.foreman.api.test_locatiohighlighting module code... [  5%] tests.foreman.cli.test_puppetmhighlighting module code... [  5%] tests.foreman.ui.test_activatihighlighting module code... [  6%] tests.foreman.ui.test_contentvhighlighting module code... [  7%] tests.foreman.performance.testhighlighting module code... [  7%] tests.foreman.api.test_subscrihighlighting module code... [  8%] tests.foreman.ui.test_operatinhighlighting module code... [  9%] tests.foreman.ui.test_subscriphighlighting module code... [  9%] tests.robottelo.test_decoratorhighlighting module code... [ 10%] tests.foreman.smoke.test_api_shighlighting module code... [ 11%] tests.foreman.cli.test_hostgrohighlighting module code... [ 12%] tests.foreman.cli.test_discovehighlighting module code... [ 13%] tests.foreman.ui.test_adusergrhighlighting module code... [ 15%] tests.foreman.api.test_discovehighlighting module code... [ 16%] tests.foreman.cli.test_globalphighlighting module code... [ 17%] tests.foreman.api.test_permisshighlighting module code... [ 20%] tests.foreman.cli.test_partitihighlighting module code... [ 21%] tests.foreman.ui.test_partitiohighlighting module code... [ 22%] tests.foreman.ui.test_puppet_chighlighting module code... [ 22%] tests.foreman.api.test_architehighlighting module code... [ 23%] tests.foreman.cli.test_installhighlighting module code... [ 25%] tests.foreman.ui.test_contentehighlighting module code... [ 25%] tests.foreman.api.test_activathighlighting module code... [ 26%] tests.foreman.cli.test_activathighlighting module code... [ 26%] tests.robottelo.test_datafactohighlighting module code... [ 27%] robottelo.cli.lifecycleenvironhighlighting module code... [ 28%] tests.foreman.cli.test_environhighlighting module code... [ 30%] tests.foreman.ui.test_ldapauthhighlighting module code... [ 31%] tests.foreman.cli.test_host_cohighlighting module code... [ 31%] tests.foreman.api.test_hostgrohighlighting module code... [ 32%] tests.foreman.performance.testhighlighting module code... [ 35%] tests.foreman.api.test_environhighlighting module code... [ 37%] tests.foreman.api.test_reposithighlighting module code... [ 38%] tests.foreman.ui.test_architechighlighting module code... [ 39%] tests.foreman.ui.test_computerhighlighting module code... [ 40%] tests.foreman.ui.test_system_rhighlighting module code... [ 40%] robottelo.performance.candlepihighlighting module code... [ 42%] tests.foreman.ui.test_isodownlhighlighting module code... [ 43%] tests.foreman.smoke.test_ui_smhighlighting module code... [ 47%] tests.foreman.cli.test_myaccouhighlighting module code... [ 48%] tests.foreman.ui.test_config_ghighlighting module code... [ 48%] tests.foreman.cli.test_templathighlighting module code... [ 48%] tests.foreman.api.test_discovehighlighting module code... [ 49%] tests.foreman.ui.test_environmhighlighting module code... [ 52%] tests.foreman.api.test_foremanhighlighting module code... [ 53%] tests.foreman.ui.test_discoverhighlighting module code... [ 53%] tests.foreman.cli.test_reposithighlighting module code... [ 54%] tests.foreman.cli.test_subscrihighlighting module code... [ 54%] tests.foreman.api.test_contenthighlighting module code... [ 55%] tests.foreman.api.test_hostcolhighlighting module code... [ 56%] tests.foreman.api.test_smartprhighlighting module code... [ 57%] tests.foreman.api.test_contenthighlighting module code... [ 58%] tests.foreman.cli.test_contenthighlighting module code... [ 58%] tests.foreman.cli.test_contenthighlighting module code... [ 61%] tests.foreman.api.test_partitihighlighting module code... [ 63%] tests.foreman.api.test_lifecychighlighting module code... [ 64%] tests.foreman.ui.test_host_syshighlighting module code... [ 64%] tests.foreman.cli.test_locatiohighlighting module code... [ 66%] tests.foreman.cli.test_system_highlighting module code... [ 66%] tests.foreman.ui.test_usergrouhighlighting module code... [ 69%] tests.foreman.cli.test_contenthighlighting module code... [ 70%] tests.foreman.ui.test_repositohighlighting module code... [ 71%] tests.foreman.cli.test_capsulehighlighting module code... [ 71%] tests.foreman.api.test_syncplahighlighting module code... [ 75%] tests.foreman.performance.testhighlighting module code... [ 76%] tests.foreman.api.test_contenthighlighting module code... [ 78%] tests.foreman.ui.test_ldap_authighlighting module code... [ 79%] tests.foreman.cli.test_reposithighlighting module code... [ 80%] tests.foreman.ui.test_myaccounhighlighting module code... [ 80%] tests.foreman.cli.test_architehighlighting module code... [ 82%] tests.foreman.cli.test_computehighlighting module code... [ 82%] tests.foreman.api.test_multiplhighlighting module code... [ 84%] tests.foreman.api.test_config_highlighting module code... [ 86%] tests.foreman.ui.test_discoverhighlighting module code... [ 88%] tests.foreman.ui.test_contentshighlighting module code... [ 89%] tests.foreman.api.test_organizhighlighting module code... [ 89%] tests.foreman.ui.test_multinethighlighting module code... [ 93%] tests.foreman.performance.testhighlighting module code... [ 94%] tests.foreman.ui.test_hostgrouhighlighting module code... [ 96%] tests.foreman.cli.test_lifecychighlighting module code... [ 99%] tests.foreman.smoke.test_cli_shighlighting module code... [100%] robottelo.datafactory         
writing additional pages... search
copying static files... done
copying extra files... done
dumping search index in English (code: en) ... done
dumping object inventory... done
build succeeded, 2 warnings.

Build finished. The HTML pages are in _build/html.
make[1]: Leaving directory `/framework/robottelo/docs'
```
The two warnings here are known old docs warnings (see http://stackoverflow.com/questions/11417221/sphinx-autodoc-gives-warning-pyclass-reference-target-not-found-type-warning) and not related to robottelo.