### PR TITLE
Updated `valid_labels_list` to return 128 characters.

### DIFF
--- a/robottelo/datafactory.py
+++ b/robottelo/datafactory.py
@@ -184,8 +184,8 @@ def valid_environments_list():
 def valid_labels_list():
     """Generates a list of valid labels."""
     return [
-        gen_string('alphanumeric', random.randint(1, 255)),
-        gen_string('alpha', random.randint(1, 255)),
+        gen_string('alphanumeric', random.randint(1, 128)),
+        gen_string('alpha', random.randint(1, 128)),
     ]
 
 


### PR DESCRIPTION
Our automation has shown that when creating new Products and providing `labels` via the `valid_labels_list` heper, we get an error claiming that 'Label cannot contain more than 128 characters'.

Since this helper seems to be used only by one test, I have updated it to return 128 character strings.