### PR TITLE
Add helper for getting Satellite version

### DIFF
--- a/robottelo/helpers.py
+++ b/robottelo/helpers.py
@@ -36,6 +36,25 @@ def get_server_software():
     return 'downstream' if return_code == 0 else 'upstream'
 
 
+def get_server_version():
+    """Read Satellite version.
+
+    Inspect server /usr/share/foreman/lib/satellite/version.rb in
+    order to get the installed Satellite version.
+
+    :return: Either a string containing the Satellite version or
+        ``None`` if the version.rb file is not present.
+    """
+    result = ''.join(ssh.command(
+        "cat /usr/share/foreman/lib/satellite/version.rb | grep VERSION | "
+        "awk '{print $3}'"
+    ).stdout)
+    result = result.replace('"', '').strip()
+    if len(result) == 0:
+        return None
+    return result
+
+
 def get_host_info(hostname=None):
     """Get remote host's distribution information
 

--- a/tests/robottelo/test_helpers.py
+++ b/tests/robottelo/test_helpers.py
@@ -7,7 +7,35 @@ from robottelo.helpers import (
     HostInfoError,
     escape_search,
     get_host_info,
+    get_server_version,
 )
+
+
+class GetServerVersionTestCase(unittest2.TestCase):
+    """Tests for method ``get_server_version``."""
+    @mock.patch('robottelo.helpers.ssh')
+    def test_return_version(self, ssh):
+        """get_server_version returns a proper version.
+
+        When the version.rb file is present.
+        """
+        ssh.command = mock.MagicMock(return_value=FakeSSHResult(
+            ['"6.1.4"'],
+            0
+        ))
+        self.assertEqual(get_server_version(), '6.1.4')
+
+    @mock.patch('robottelo.helpers.ssh')
+    def test_return_none(self, ssh):
+        """get_server_version returns None.
+
+        When the versions.rb file is not present.
+        """
+        ssh.command = mock.MagicMock(return_value=FakeSSHResult(
+            [],
+            0
+        ))
+        self.assertEqual(get_server_version(), None)
 
 
 class GetHostInfoTestCase(unittest2.TestCase):


### PR DESCRIPTION
Add get_server_version in order to get the Satellite version. It will
return None if the version.rb file is not available as it is only
available on downstream builds.

Closes #2414