### PR TITLE
cli activation key content override test update

### DIFF
--- a/robottelo/cli/activationkey.py
+++ b/robottelo/cli/activationkey.py
@@ -68,7 +68,10 @@ class ActivationKey(Base):
     def product_content(cls, options=None):
         """List associated products"""
         cls.command_sub = 'product-content'
-        return cls.execute(cls._construct_command(options))
+        return cls.execute(
+            cls._construct_command(options),
+            output_format='csv'
+        )
 
     @classmethod
     def remove_host_collection(cls, options=None):


### PR DESCRIPTION
Fixes https://github.com/SatelliteQE/robottelo/issues/3026

Test results:
1. upstream = True 
```sh
# nosetests tests/foreman/cli/test_activationkey.py:TestActivationKey.test_positive_content_override
.
----------------------------------------------------------------------
Ran 1 test in 183.830s

OK
```
2. upstream = False
```sh
nosetests tests/foreman/cli/test_activationkey.py:TestActivationKey.test_positive_content_override
.
----------------------------------------------------------------------
Ran 1 test in 6.695s

OK (skipped=1)
```