### PR TITLE
Fix remaining LDAP password settings usage

### DIFF
--- a/robottelo.properties.sample
+++ b/robottelo.properties.sample
@@ -70,7 +70,7 @@ ssh_key=
 # [ldap]
 # hostname=
 # username=
-# passwd=
+# password=
 # basedn=
 # grpbasedn=
 

--- a/tests/foreman/ui/test_adusergroups.py
+++ b/tests/foreman/ui/test_adusergroups.py
@@ -21,7 +21,7 @@ class ADUserGroups(UITestCase):
         super(ADUserGroups, cls).setUpClass()
         # TODO: handle when the ldap config is not available
         cls.ldap_user_name = settings.ldap.username
-        cls.ldap_user_passwd = settings.ldap.passwd
+        cls.ldap_user_passwd = settings.ldap.password
         cls.base_dn = settings.ldap.basedn
         cls.group_base_dn = settings.ldap.grpbasedn
         cls.ldap_hostname = settings.ldap.hostname


### PR DESCRIPTION
Fix spelling for the LDAP password settings from passwd to password.

This should fix `<nose.suite.ContextSuite context=ADUserGroups>:setup` failure on latest automation UI run.