### PR TITLE
Update UI test Host domain search

### DIFF
--- a/tests/foreman/ui/test_host.py
+++ b/tests/foreman/ui/test_host.py
@@ -106,9 +106,10 @@ class Host(UITestCase, Base):
         cls.proxy = cls.proxy.update(['location'])
 
         # Search for domain and associate org, location
+        _, _, domain = settings.server.hostname.partition('.')
         cls.domain = entities.Domain().search(
             query={
-                u'search': u'name="usersys.redhat.com"'
+                u'search': u'name="{0}"'.format(domain)
             }
         )[0]
         cls.domain_name = cls.domain.name


### PR DESCRIPTION
Drop hard coded domain in favor of getting the domain from settings.server.hostname.

```python
In [1]: settings.server.hostname
Out[1]: 'qe-sat6-rhel71.domain.example.com'

In [2]: _, _, domain = settings.server.hostname.partition('.')

In [3]: domain
Out[3]: 'domain.example.com'
```

Closes #3009