### PR TITLE
test_contentenv - fixed setUpClass setUpClass() method

### DIFF
--- a/tests/foreman/ui/test_contentenv.py
+++ b/tests/foreman/ui/test_contentenv.py
@@ -16,6 +16,7 @@ class ContentEnvironment(UITestCase):
 
     @classmethod
     def setUpClass(cls):
+        super(ContentEnvironment, cls).setUpClass()
         cls.org_name = entities.Organization().create().name
 
     @run_only_on('sat')


### PR DESCRIPTION
The call to `super.setUpClass` was deleted in commit: https://github.com/SatelliteQE/robottelo/commit/3ff62a08e008002b49360c7cad082635cecfb75c
And the `contentEnv` tests have been failing since then. This PR reintroduces the line back to the code.

fixes the failures of the following test units:
```
tests.foreman.ui.test_contentenv.ContentEnvironment.test_positive_create_content_environment_basic
tests.foreman.ui.test_contentenv.ContentEnvironment.test_positive_create_content_environment_chain
tests.foreman.ui.test_contentenv.ContentEnvironment.test_positive_delete_content_environment
tests.foreman.ui.test_contentenv.ContentEnvironment.test_positive_update_content_environment
<nose.suite.ContextSuite context=ContentEnvironment>:teardown
```

```bash
$ nosetests test_contentenv.py
....
----------------------------------------------------------------------
Ran 4 tests in 123.464s

OK

```
