### PR TITLE
Fix datafactory bug when functions returned one datapoint

### DIFF
--- a/tests/foreman/ui/test_activationkey.py
+++ b/tests/foreman/ui/test_activationkey.py
@@ -1,9 +1,9 @@
 # -*- encoding: utf-8 -*-
 """Test class for Activation key UI"""
 
+import random
 from fauxfactory import gen_string
 from nailgun import entities
-from random import randint
 from robottelo import manifests
 from robottelo.api.utils import (
     enable_rhrepo_and_fetchid,
@@ -552,7 +552,7 @@ class ActivationKey(UITestCase):
         """
         # Pick one of the valid data list items - data driven tests is not
         # necessary for this test
-        cv2_name = (valid_data_list())[randint(0, 6)]
+        cv2_name = random.choice(valid_data_list())
         name = gen_string('alpha')
         env1_name = gen_string('alpha')
         env2_name = gen_string('alpha')
@@ -598,7 +598,7 @@ class ActivationKey(UITestCase):
         """
         # Pick one of the valid data list items - data driven tests is not
         # necessary for this test
-        cv2_name = (valid_data_list())[randint(0, 6)]
+        cv2_name = random.choice(valid_data_list())
         name = gen_string('alpha')
         env1_name = gen_string('alpha')
         env2_name = gen_string('alpha')


### PR DESCRIPTION
Earlier the tests failed when valid_data_list() returned one datapoint. Now it is fixed.
Test:
```sh
In [17]: valid_data = [0,1,2,3]
In [18]: print random.choice(valid_data)
1
In [19]: valid_data = [0]
In [20]: print random.choice(valid_data)
0
```