### PR TITLE
Updated API tests for Content View Version entity.

### DIFF
--- a/robottelo/api/utils.py
+++ b/robottelo/api/utils.py
@@ -41,18 +41,23 @@ def enable_rhrepo_and_fetchid(basearch, org_id, product, repo,
     return result[0].id
 
 
-def promote(content_view_version, environment_id):
+def promote(content_view_version, environment_id, force=False):
     """Call ``content_view_version.promote(…)``.
 
     :param content_view_version: A ``nailgun.entities.ContentViewVersion``
         object.
     :param environment_id: An environment ID.
+    :param force: Whether to force the promotion or not. Only needed if
+        promoting to a lifecycle environment that is not the next in order
+        of sequence.
     :returns: Whatever ``nailgun.entities.ContentViewVersion.promote`` returns.
 
     """
-    return content_view_version.promote(data={
-        u'environment_id': environment_id
-    })
+    data = {
+        u'environment_id': environment_id,
+        u'force': True if force else False,
+    }
+    return content_view_version.promote(data=data)
 
 
 def upload_manifest(organization_id, manifest):


### PR DESCRIPTION
This pull requests does the following:

* Removes blank lines from docstrings;
* Fixes tests that were using Puppet environments intead of Lifecycle Environments
  during promotions;
* Fixes tests that were using a hard-coded value when using the 'Default
  Organization View' to use the test's Organization view instead;
* Adds new tests that exercises the ability to promote content views to 'out of
  sequence' lifecycle environments;
* Updates `robottelo.api.utils.promote` to expose a `force` attribute, useful when
  one needs to promote a content view version to an 'out of sequence' lifecycle
  environment;

All tests passed against latest 6.1.4 build.