### PR TITLE
Add helpers to install & remove katello-ca, update docker container tests

### DIFF
--- a/tests/foreman/cli/test_contenthost.py
+++ b/tests/foreman/cli/test_contenthost.py
@@ -432,7 +432,7 @@ class TestCHKatelloAgent(CLITestCase):
         # Create VM and register content host
         self.client = VirtualMachine(distro='rhel71')
         self.client.create()
-        self.client.install_katello_cert()
+        self.client.install_katello_ca()
         # Register content host, install katello-agent
         self.client.register_contenthost(
             TestCHKatelloAgent.activation_key['name'],

--- a/tests/foreman/cli/test_docker.py
+++ b/tests/foreman/cli/test_docker.py
@@ -24,6 +24,7 @@ from robottelo.config import settings
 from robottelo.constants import DOCKER_REGISTRY_HUB
 from robottelo.datafactory import valid_data_list
 from robottelo.decorators import run_only_on, skip_if_bug_open, stubbed
+from robottelo.helpers import install_katello_ca, remove_katello_ca
 from robottelo.test import CLITestCase
 
 STRING_TYPES = ['alpha', 'alphanumeric', 'cjk', 'utf8', 'latin1']
@@ -1259,6 +1260,13 @@ class DockerContainersTestCase(CLITestCase):
             'provider': DOCKER_PROVIDER,
             'url': settings.docker.external_url,
         })
+        install_katello_ca()
+
+    @classmethod
+    def tearDownClass(cls):
+        """Remove katello-ca certificate"""
+        remove_katello_ca()
+        super(DockerContainersTestCase, cls).tearDownClass()
 
     @run_only_on('sat')
     def test_create_container(self):

--- a/tests/foreman/longrun/test_inc_updates.py
+++ b/tests/foreman/longrun/test_inc_updates.py
@@ -202,7 +202,7 @@ class TestIncrementalUpdate(TestCase):
     def setup_vm(client, act_key, org_name):
         """Creates the vm and registers it to the satellite"""
         client.create()
-        client.install_katello_cert()
+        client.install_katello_ca()
 
         # Register content host, install katello-agent
         result = client.register_contenthost(

--- a/tests/foreman/longrun/test_oscap.py
+++ b/tests/foreman/longrun/test_oscap.py
@@ -191,7 +191,7 @@ class OpenScap(UITestCase):
             for value in vm_values:
                 with VirtualMachine(distro=value['distro']) as vm:
                     host = vm.hostname
-                    vm.install_katello_cert()
+                    vm.install_katello_ca()
                     vm.register_contenthost(self.ak_name, self.org_name)
                     vm.configure_puppet(value['rhel_repo'])
                     session.nav.go_to_hosts()

--- a/tests/foreman/smoke/test_api_smoke.py
+++ b/tests/foreman/smoke/test_api_smoke.py
@@ -1062,7 +1062,7 @@ class TestSmoke(TestCase):
         # Create VM
         package_name = 'python-kitchen'
         with VirtualMachine(distro='rhel66') as vm:
-            vm.install_katello_cert()
+            vm.install_katello_ca()
             result = vm.register_contenthost(activation_key_name, org.label)
             self.assertEqual(result.return_code, 0)
             # Install contents from sat6 server

--- a/tests/foreman/smoke/test_ui_smoke.py
+++ b/tests/foreman/smoke/test_ui_smoke.py
@@ -347,7 +347,7 @@ class TestSmoke(UITestCase):
                 ))
             # Create VM
             with VirtualMachine(distro='rhel66') as vm:
-                vm.install_katello_cert()
+                vm.install_katello_ca()
                 result = vm.register_contenthost(activation_key_name, org_name)
                 self.assertEqual(result.return_code, 0)
 
@@ -471,7 +471,7 @@ class TestSmoke(UITestCase):
                 ))
             # Create VM
             with VirtualMachine(distro='rhel67') as vm:
-                vm.install_katello_cert()
+                vm.install_katello_ca()
                 vm.register_contenthost(activation_key_name, org_name)
                 vm.configure_puppet(rhel6_repo)
                 host = vm.hostname

--- a/tests/foreman/ui/test_activationkey.py
+++ b/tests/foreman/ui/test_activationkey.py
@@ -424,7 +424,7 @@ class ActivationKey(UITestCase):
             self.assertIsNotNone(self.activationkey.wait_until_element(
                 common_locators['alert.success']))
             with VirtualMachine(distro=self.vm_distro) as vm:
-                vm.install_katello_cert()
+                vm.install_katello_ca()
                 result = vm.register_contenthost(name, self.organization.label)
                 self.assertEqual(result.return_code, 0)
                 self.activationkey.delete(name)
@@ -798,11 +798,11 @@ class ActivationKey(UITestCase):
                 common_locators['alert.success']))
             with VirtualMachine(distro=self.vm_distro) as vm1:
                 with VirtualMachine(distro=self.vm_distro) as vm2:
-                    vm1.install_katello_cert()
+                    vm1.install_katello_ca()
                     result = vm1.register_contenthost(
                         name, self.organization.label)
                     self.assertEqual(result.return_code, 0)
-                    vm2.install_katello_cert()
+                    vm2.install_katello_ca()
                     result = vm2.register_contenthost(
                         name, self.organization.label)
                     self.assertNotEqual(result.return_code, 0)
@@ -837,7 +837,7 @@ class ActivationKey(UITestCase):
             self.assertIsNotNone(self.activationkey.search(key_name))
             # Creating VM
             with VirtualMachine(distro=self.vm_distro) as vm:
-                vm.install_katello_cert()
+                vm.install_katello_ca()
                 vm.register_contenthost(key_name, self.organization.label)
                 name = self.activationkey.fetch_associated_content_host(
                     key_name)
@@ -1087,7 +1087,7 @@ class ActivationKey(UITestCase):
                 common_locators['alert.success']))
             # Create VM
             with VirtualMachine(distro=self.vm_distro) as vm:
-                vm.install_katello_cert()
+                vm.install_katello_ca()
                 result = vm.register_contenthost(
                     '{0},{1}'.format(key_1_name, key_2_name),
                     self.organization.label

--- a/tests/foreman/ui/test_docker.py
+++ b/tests/foreman/ui/test_docker.py
@@ -12,6 +12,7 @@ from robottelo.constants import (
 )
 from robottelo.datafactory import valid_data_list
 from robottelo.decorators import run_only_on, skip_if_bug_open, stubbed
+from robottelo.helpers import install_katello_ca, remove_katello_ca
 from robottelo.test import UITestCase
 from robottelo.ui.factory import (
     make_activationkey,
@@ -1168,7 +1169,15 @@ class DockerContainersTestCase(UITestCase):
             {'main_tab_name': 'Image', 'sub_tab_name': 'Content View',
              'name': 'Tag', 'value': 'latest'},
         ]
+        install_katello_ca()
 
+    @classmethod
+    def tearDownClass(cls):
+        """Remove katello-ca certificate"""
+        remove_katello_ca()
+        super(DockerContainersTestCase, cls).tearDownClass()
+
+    @skip_if_bug_open('bugzilla', 1282431)
     @run_only_on('sat')
     def test_create_container_compute_resource(self):
         """@Test: Create containers for local and external compute resources
@@ -1189,6 +1198,7 @@ class DockerContainersTestCase(UITestCase):
                         parameter_list=self.parameter_list,
                     )
 
+    @skip_if_bug_open('bugzilla', 1282431)
     @skip_if_bug_open('bugzilla', 1273958)
     @run_only_on('sat')
     def test_create_container_compute_resource_power(self):
@@ -1232,6 +1242,7 @@ class DockerContainersTestCase(UITestCase):
 
         """
 
+    @skip_if_bug_open('bugzilla', 1282431)
     @skip_if_bug_open('bugzilla', 1273958)
     @run_only_on('sat')
     def test_delete_container_compute_resource(self):


### PR DESCRIPTION
This PR:
* moves `install_katello_ca` from `robottelo/vm.py` to `robottelo/helpers.py`
* makes `install_katello_ca` accept optional argument `hostname` to be able to install certificate on any host
* adds `remove_katello_ca` helper
* updates cli content-host tests to use new helper
* adds new api docker container test, which requires katello_ca to be installed
* updates api/cli/ui docker tests to install & remove katello_ca before/after tests execution accordingly
* skips ui docker container tests, which are failing due to opened BZ

Closes #3044 