### PR TITLE
Updated docstrings for few docker cli tests

### DIFF
--- a/tests/foreman/cli/test_docker.py
+++ b/tests/foreman/cli/test_docker.py
@@ -1060,6 +1060,8 @@ class DockerClientTestCase(CLITestCase):
         """@Test: A Docker-enabled client can use ``docker pull`` to pull a
         Docker image off a Satellite 6 instance.
 
+        @Feature: Docker
+
         @Steps:
 
         1. Publish and promote content view with Docker content
@@ -1078,6 +1080,8 @@ class DockerClientTestCase(CLITestCase):
         pointing to an existing Docker image from a Satellite 6 and modify it.
         Then, using ``docker build`` generate a new image which can then be
         uploaded back onto the Satellite 6 as a new repository.
+
+        @Feature: Docker
 
         @Steps:
 


### PR DESCRIPTION
with updated testimony (it is not in pypi yet):
```sh
# make test-docstrings
testimony validate_docstring tests/foreman/api
Total Number of invalid docstrings:  0/421 (0.00%)
Test cases with no docstrings:   0/421 (0.00%) 
Test cases missing minimal docstrings:  0/421 (0.00%)
Test cases with invalid tags 0/421 (0.00%)
testimony validate_docstring tests/foreman/cli
Total Number of invalid docstrings:  0/850 (0.00%)
Test cases with no docstrings:   0/850 (0.00%) 
Test cases missing minimal docstrings:  0/850 (0.00%)
Test cases with invalid tags 0/850 (0.00%)
testimony validate_docstring tests/foreman/rhci
Total Number of invalid docstrings:  0/3 (0.00%)
Test cases with no docstrings:   0/3 (0.00%) 
Test cases missing minimal docstrings:  0/3 (0.00%)
Test cases with invalid tags 0/3 (0.00%)
testimony validate_docstring tests/foreman/ui
Total Number of invalid docstrings:  0/691 (0.00%)
Test cases with no docstrings:   0/691 (0.00%) 
Test cases missing minimal docstrings:  0/691 (0.00%)
Test cases with invalid tags 0/691 (0.00%)
testimony validate_docstring tests/foreman/rhai
Total Number of invalid docstrings:  0/4 (0.00%)
Test cases with no docstrings:   0/4 (0.00%) 
Test cases missing minimal docstrings:  0/4 (0.00%)
Test cases with invalid tags 0/4 (0.00%)

# echo $?
0
```