### PR TITLE
Use py.test to tag API tests into tiers.

### DIFF
--- a/robottelo/decorators.py
+++ b/robottelo/decorators.py
@@ -2,6 +2,7 @@
 """Implements various decorators"""
 import bugzilla
 import logging
+import pytest
 import requests
 import unittest2
 
@@ -15,6 +16,15 @@ BUGZILLA_URL = "https://bugzilla.redhat.com/xmlrpc.cgi"
 LOGGER = logging.getLogger(__name__)
 OBJECT_CACHE = {}
 REDMINE_URL = 'http://projects.theforeman.org'
+
+# Test Tier Decorators
+# CRUD tests
+tier1 = pytest.mark.tier1
+# Association tests
+tier2 = pytest.mark.tier2
+# Systems integration and long-running tests
+tier3 = pytest.mark.tier3
+
 
 # A dict mapping bug IDs to python-bugzilla bug objects.
 _bugzilla = {}

--- a/setup.py
+++ b/setup.py
@@ -22,6 +22,7 @@ setup(
         'numpy',
         'paramiko',
         'pygal',
+        'pytest',
         'python-bugzilla',
         'requests',
         'selenium',

--- a/tests/foreman/api/test_activationkey.py
+++ b/tests/foreman/api/test_activationkey.py
@@ -4,7 +4,7 @@ from nailgun import client, entities
 from requests.exceptions import HTTPError
 from robottelo.config import settings
 from robottelo.datafactory import invalid_names_list, valid_data_list
-from robottelo.decorators import rm_bug_is_open, skip_if_bug_open
+from robottelo.decorators import rm_bug_is_open, skip_if_bug_open, tier1, tier2
 from robottelo.test import APITestCase
 from six.moves import http_client
 
@@ -22,6 +22,7 @@ def _bad_max_content_hosts():
 class ActivationKeysTestCase(APITestCase):
     """Tests for the ``activation_keys`` path."""
 
+    @tier2
     def test_positive_create_unlimited_content_hosts(self):
         """@Test: Create a plain vanilla activation key.
 
@@ -34,6 +35,7 @@ class ActivationKeysTestCase(APITestCase):
             entities.ActivationKey().create().unlimited_content_hosts
         )
 
+    @tier2
     def test_positive_create_limited_content_hosts(self):
         """@Test: Create an activation key with limited content hosts.
 
@@ -50,6 +52,7 @@ class ActivationKeysTestCase(APITestCase):
                 self.assertEqual(act_key.max_content_hosts, mch)
                 self.assertFalse(act_key.unlimited_content_hosts)
 
+    @tier1
     def test_positive_create_name(self):
         """@Test: Create an activation key providing the initial name.
 
@@ -62,6 +65,7 @@ class ActivationKeysTestCase(APITestCase):
                 act_key = entities.ActivationKey(name=name).create()
                 self.assertEqual(name, act_key.name)
 
+    @tier2
     def test_positive_create_description(self):
         """@Test: Create an activation key and provide a description.
 
@@ -74,6 +78,7 @@ class ActivationKeysTestCase(APITestCase):
                 act_key = entities.ActivationKey(description=desc).create()
                 self.assertEqual(desc, act_key.description)
 
+    @tier2
     def test_negative_create_no_content_host_limit(self):
         """@Test: Create activation key with limited content hosts but no limit
         set.
@@ -85,6 +90,7 @@ class ActivationKeysTestCase(APITestCase):
         with self.assertRaises(HTTPError):
             entities.ActivationKey(unlimited_content_hosts=False).create()
 
+    @tier2
     def test_negative_create_invalid_content_host_limit(self):
         """@Test: Create activation key with limited content hosts but with
         invalid limit values.
@@ -101,6 +107,7 @@ class ActivationKeysTestCase(APITestCase):
                         unlimited_content_hosts=False,
                     ).create()
 
+    @tier2
     @skip_if_bug_open('bugzilla', 1156555)
     def test_negative_create_no_content_host_limit_with_set_max(self):
         """@Test Create activation key with unlimited content hosts and set max
@@ -118,6 +125,7 @@ class ActivationKeysTestCase(APITestCase):
                         unlimited_content_hosts=True,
                     ).create()
 
+    @tier1
     def test_negative_create_invalid_name(self):
         """@Test: Create activation key providing an invalid name.
 
@@ -130,6 +138,7 @@ class ActivationKeysTestCase(APITestCase):
                 with self.assertRaises(HTTPError):
                     entities.ActivationKey(name=name).create()
 
+    @tier2
     def test_positive_update_limited_content_host(self):
         """@Test: Create activation key then update it to limited content
         hosts.
@@ -149,6 +158,7 @@ class ActivationKeysTestCase(APITestCase):
                 actual = {attr: getattr(act_key, attr) for attr in want.keys()}
                 self.assertEqual(want, actual)
 
+    @tier1
     def test_positive_update_name(self):
         """@Test: Create activation key providing the initial name, then update
         its name to another valid name.
@@ -165,6 +175,7 @@ class ActivationKeysTestCase(APITestCase):
                     id=act_key.id, name=new_name).update(['name'])
                 self.assertEqual(new_name, updated.name)
 
+    @tier2
     def test_negative_update_invalid_limit(self):
         """@Test: Create activation key then update its limit to invalid value.
 
@@ -191,6 +202,7 @@ class ActivationKeysTestCase(APITestCase):
                 actual = {attr: getattr(act_key, attr) for attr in want.keys()}
                 self.assertEqual(want, actual)
 
+    @tier1
     def test_negative_update_invalid_name(self):
         """@Test: Create activation key then update its name to an invalid name.
 
@@ -208,6 +220,7 @@ class ActivationKeysTestCase(APITestCase):
                 self.assertNotEqual(new_key.name, new_name)
                 self.assertEqual(new_key.name, act_key.name)
 
+    @tier2
     def test_negative_update_max_content_hosts(self):
         """@Test: Create an activation key with ``max_content_hosts == 1``,
         then update that field with a string value.
@@ -224,6 +237,7 @@ class ActivationKeysTestCase(APITestCase):
             ).update(['max_content_hosts'])
         self.assertEqual(act_key.read().max_content_hosts, 1)
 
+    @tier2
     def test_get_releases_status_code(self):
         """@Test: Get an activation key's releases. Check response format.
 
@@ -242,6 +256,7 @@ class ActivationKeysTestCase(APITestCase):
         self.assertEqual(status_code, response.status_code)
         self.assertIn('application/json', response.headers['content-type'])
 
+    @tier2
     def test_get_releases_content(self):
         """@Test: Get an activation key's releases. Check response contents.
 
@@ -258,6 +273,7 @@ class ActivationKeysTestCase(APITestCase):
         self.assertIn('results', response.keys())
         self.assertEqual(type(response['results']), list)
 
+    @tier2
     def test_set_host_collection(self):
         """@Test: Associate an activation key with several host collections.
 
@@ -296,6 +312,7 @@ class ActivationKeysTestCase(APITestCase):
         act_key = act_key.update(['host_collection'])
         self.assertEqual(len(act_key.host_collection), 0)
 
+    @tier2
     def test_positive_update_auto_attach(self):
         """@Test: Create an activation key, then update the auto_attach
         field with the inverse boolean value.
@@ -311,6 +328,7 @@ class ActivationKeysTestCase(APITestCase):
         ).update(['auto_attach'])
         self.assertNotEqual(act_key.auto_attach, act_key_2.auto_attach)
 
+    @tier1
     def test_positive_delete(self):
         """@Test: Create activation key and then delete it.
 
@@ -338,6 +356,7 @@ class SearchTestCase(APITestCase):
         if rm_bug_is_open(4638):
             cls.act_key.read()  # Wait for elasticsearch to index new act key.
 
+    @tier1
     def test_search_by_org(self):
         """@Test: Search for all activation keys in an organization.
 

--- a/tests/foreman/api/test_architecture.py
+++ b/tests/foreman/api/test_architecture.py
@@ -4,13 +4,14 @@ from nailgun import client, entities
 from requests.exceptions import HTTPError
 from robottelo.config import settings
 from robottelo.datafactory import invalid_names_list, valid_data_list
-from robottelo.decorators import skip_if_bug_open
+from robottelo.decorators import skip_if_bug_open, tier1, tier2
 from robottelo.test import APITestCase
 
 
 class ArchitectureTestCase(APITestCase):
     """Tests for architectures."""
 
+    @tier2
     @skip_if_bug_open('bugzilla', 1151220)
     def test_post_hash(self):
         """@Test: Do not wrap API calls in an extra hash.
@@ -38,6 +39,7 @@ class ArchitectureTestCase(APITestCase):
         self.assertIn('operatingsystems', attrs)
         self.assertEqual([os_id], attrs['operatingsystems'])
 
+    @tier2
     def test_associate_with_os(self):
         """@Test: Create an architecture and associate it with an OS.
 
@@ -53,6 +55,7 @@ class ArchitectureTestCase(APITestCase):
             {os.id for os in arch.operatingsystem},
         )
 
+    @tier1
     def test_positive_create_name(self):
         """@Test: Create an architecture providing the initial name.
 
@@ -65,6 +68,7 @@ class ArchitectureTestCase(APITestCase):
                 arch = entities.Architecture(name=name).create()
                 self.assertEqual(name, arch.name)
 
+    @tier1
     def test_negative_create_name(self):
         """@Test: Create architecture providing an invalid initial name.
         set.
@@ -78,6 +82,7 @@ class ArchitectureTestCase(APITestCase):
                 with self.assertRaises(HTTPError):
                     entities.Architecture(name=name).create()
 
+    @tier1
     def test_positive_update_name(self):
         """@Test: Create architecture then update its name to another
         valid name.
@@ -96,6 +101,7 @@ class ArchitectureTestCase(APITestCase):
                 updated = entities.Architecture(id=arch.id).read()
                 self.assertEqual(new_name, updated.name)
 
+    @tier1
     def test_negative_update_name(self):
         """@Test: Create architecture then update its name to an invalid name.
 
@@ -112,6 +118,7 @@ class ArchitectureTestCase(APITestCase):
                 arch = entities.Architecture(id=arch.id).read()
                 self.assertNotEqual(arch.name, new_name)
 
+    @tier1
     def test_positive_delete(self):
         """@Test: Create architecture and then delete it.
 

--- a/tests/foreman/api/test_config_template.py
+++ b/tests/foreman/api/test_config_template.py
@@ -8,13 +8,14 @@ from nailgun import client, entities
 from requests.exceptions import HTTPError
 from robottelo.config import settings
 from robottelo.datafactory import invalid_names_list, valid_data_list
-from robottelo.decorators import skip_if_bug_open
+from robottelo.decorators import skip_if_bug_open, tier1, tier2
 from robottelo.test import APITestCase
 
 
 class ConfigTemplateTestCase(APITestCase):
     """Tests for config templates."""
 
+    @tier2
     @skip_if_bug_open('bugzilla', 1202564)
     def test_build_pxe_default(self):
         """@Test: Call the "build_pxe_default" path.
@@ -31,6 +32,7 @@ class ConfigTemplateTestCase(APITestCase):
         response.raise_for_status()
         self.assertIsInstance(response.json(), dict)
 
+    @tier2
     def test_config_template_orgs(self):
         """@Test: Associate a config template with organizations.
 
@@ -64,6 +66,7 @@ class ConfigTemplateTestCase(APITestCase):
         conf_templ = conf_templ.update(['organization'])
         self.assertEqual(len(conf_templ.organization), 0)
 
+    @tier1
     def test_positive_create_name(self):
         """@Test: Create a configuration template providing the initial name.
 
@@ -76,6 +79,7 @@ class ConfigTemplateTestCase(APITestCase):
                 c_temp = entities.ConfigTemplate(name=name).create()
                 self.assertEqual(name, c_temp.name)
 
+    @tier1
     def test_negative_create_name(self):
         """@Test: Create configuration template providing an invalid name.
 
@@ -88,6 +92,7 @@ class ConfigTemplateTestCase(APITestCase):
                 with self.assertRaises(HTTPError):
                     entities.ConfigTemplate(name=name).create()
 
+    @tier1
     def test_positive_update_name(self):
         """@Test: Create configuration template providing the initial name,
         then update its name to another valid name.
@@ -105,6 +110,7 @@ class ConfigTemplateTestCase(APITestCase):
                     id=c_temp.id, name=new_name).update(['name'])
                 self.assertEqual(new_name, updated.name)
 
+    @tier1
     def test_negative_update_name(self):
         """@Test: Create configuration template then update its name to an
         invalid name.
@@ -123,6 +129,7 @@ class ConfigTemplateTestCase(APITestCase):
                 c_temp = entities.ConfigTemplate(id=c_temp.id).read()
                 self.assertNotEqual(c_temp.name, new_name)
 
+    @tier1
     def test_positive_delete(self):
         """@Test: Create configuration template and then delete it.
 

--- a/tests/foreman/api/test_contentview.py
+++ b/tests/foreman/api/test_contentview.py
@@ -15,7 +15,14 @@ from robottelo.constants import (
     REPOSET,
 )
 from robottelo.datafactory import invalid_names_list, valid_data_list
-from robottelo.decorators import bz_bug_is_open, run_only_on, stubbed
+from robottelo.decorators import (
+    bz_bug_is_open,
+    run_only_on,
+    stubbed,
+    tier1,
+    tier2,
+    tier3,
+)
 from robottelo.helpers import get_data_file
 from robottelo.test import APITestCase
 
@@ -29,6 +36,7 @@ REPEAT = 3
 class ContentViewTestCase(APITestCase):
     """Tests for content views."""
 
+    @tier3
     @run_only_on('sat')
     def test_subscribe_system_to_cv(self):
         """@Test: Subscribe a system to a content view.
@@ -70,6 +78,7 @@ class ContentViewTestCase(APITestCase):
         if not bz_bug_is_open(1223494):
             self.assertEqual(system.organization.id, org.id)
 
+    @tier2
     @run_only_on('sat')
     def test_positive_clone_within_same_env(self):
         """@Test: attempt to create, publish and promote new content view
@@ -93,6 +102,7 @@ class ContentViewTestCase(APITestCase):
         cloned_cv.publish()
         promote(cloned_cv.read().version[0], lc_env.id)
 
+    @tier2
     @run_only_on('sat')
     def test_positive_clone_with_diff_env(self):
         """@Test: attempt to create, publish and promote new content
@@ -116,6 +126,7 @@ class ContentViewTestCase(APITestCase):
         cloned_cv.publish()
         promote(cloned_cv.read().version[0], le_clone.id)
 
+    @tier2
     @run_only_on('sat')
     def test_positive_associate_custom_content(self):
         """@Test: Associate custom content in a view
@@ -135,6 +146,7 @@ class ContentViewTestCase(APITestCase):
         self.assertEqual(len(content_view.repository), 1)
         self.assertEqual(content_view.repository[0].read().name, yum_repo.name)
 
+    @tier2
     @run_only_on('sat')
     def test_negative_associate_puppet_content(self):
         """@Test: Attempt to associate puppet repos within a custom
@@ -159,6 +171,7 @@ class ContentViewTestCase(APITestCase):
                 repository=[puppet_repo.id],
             ).create()
 
+    @tier2
     @run_only_on('sat')
     def test_negative_associate_dupe_content(self):
         """@Test: Attempt to associate the same repo multiple times within a
@@ -180,6 +193,7 @@ class ContentViewTestCase(APITestCase):
             content_view.update(['repository'])
         self.assertEqual(len(content_view.read().repository), 0)
 
+    @tier2
     @run_only_on('sat')
     def test_negative_associate_dupe_modules(self):
         """@Test: Attempt to associate duplicate puppet modules within a
@@ -223,6 +237,7 @@ class ContentViewTestCase(APITestCase):
 class ContentViewCreateTestCase(APITestCase):
     """Create tests for content views."""
 
+    @tier1
     def test_positive_create_composite(self):
         """@Test: Create composite and non-composite content views.
 
@@ -240,6 +255,7 @@ class ContentViewCreateTestCase(APITestCase):
                     ).create().composite,
                 )
 
+    @tier1
     def test_positive_create_name(self):
         """@Test: Create empty content-view with random names.
 
@@ -254,6 +270,7 @@ class ContentViewCreateTestCase(APITestCase):
                     name
                 )
 
+    @tier2
     def test_positive_create_description(self):
         """@Test: Create empty content view with random description.
 
@@ -270,6 +287,7 @@ class ContentViewCreateTestCase(APITestCase):
                     ).create().description,
                 )
 
+    @tier1
     def test_negative_create_name(self):
         """@Test: Create content view providing an invalid name.
 
@@ -303,6 +321,7 @@ class CVPublishPromoteTestCase(APITestCase):
         with open(get_data_file(PUPPET_MODULE_NTP_PUPPETLABS), 'rb') as handle:
             cls.puppet_repo.upload_content(files={'content': handle})
 
+    @tier2
     def add_content_views_to_composite(
             self, composite_cv, cv_amount=1):
         """Add necessary number of content views to the composite one
@@ -319,6 +338,7 @@ class CVPublishPromoteTestCase(APITestCase):
         composite_cv = composite_cv.update(['component'])
         self.assertEqual(len(composite_cv.component), cv_amount)
 
+    @tier2
     def test_positive_publish_multiple(self):
         """@Test: Publish a content view several times.
 
@@ -332,6 +352,7 @@ class CVPublishPromoteTestCase(APITestCase):
             content_view.publish()
         self.assertEqual(len(content_view.read().version), REPEAT)
 
+    @tier2
     def test_positive_publish_with_content_multiple(self):
         """@Test: Give a content view yum packages and publish it repeatedly.
 
@@ -355,6 +376,7 @@ class CVPublishPromoteTestCase(APITestCase):
         for cvv in content_view.read().version:
             self.assertGreater(cvv.read_json()['package_count'], 0)
 
+    @tier2
     def test_positive_publish_composite_single_content_once(self):
         """@Test: Create empty composite view and assign one normal content
         view to it. After that publish that composite content view once.
@@ -372,6 +394,7 @@ class CVPublishPromoteTestCase(APITestCase):
         composite_cv.publish()
         self.assertEqual(len(composite_cv.read().version), 1)
 
+    @tier2
     def test_positive_publish_composite_multiple_content_once(self):
         """@Test: Create empty composite view and assign random number of
         normal content views to it. After that publish that composite content
@@ -390,6 +413,7 @@ class CVPublishPromoteTestCase(APITestCase):
         composite_cv.publish()
         self.assertEqual(len(composite_cv.read().version), 1)
 
+    @tier2
     def test_positive_publish_composite_single_content_multiple(self):
         """@Test: Create empty composite view and assign one normal content
         view to it. After that publish that composite content view several
@@ -410,6 +434,7 @@ class CVPublishPromoteTestCase(APITestCase):
             composite_cv.publish()
             self.assertEqual(len(composite_cv.read().version), i + 1)
 
+    @tier2
     def test_positive_publish_composite_multiple_content_multiple(self):
         """@Test: Create empty composite view and assign random number of
         normal content views to it. After that publish that composite content
@@ -430,6 +455,7 @@ class CVPublishPromoteTestCase(APITestCase):
             composite_cv.publish()
             self.assertEqual(len(composite_cv.read().version), i + 1)
 
+    @tier2
     def test_positive_publish_with_puppet_once(self):
         """@Test: Publish a content view that has puppet module once.
 
@@ -453,6 +479,7 @@ class CVPublishPromoteTestCase(APITestCase):
         self.assertEqual(len(content_view.version), 1)
         self.assertEqual(len(content_view.puppet_module), 1)
 
+    @tier2
     def test_positive_publish_with_puppet_multiple(self):
         """@Test: Publish a content view that has puppet module
         several times.
@@ -484,6 +511,7 @@ class CVPublishPromoteTestCase(APITestCase):
         for cvv in content_view.read().version:
             self.assertEqual(len(cvv.read().puppet_module), 1)
 
+    @tier2
     def test_positive_promote_empty_multiple(self):
         """@Test: Promote a content view version ``REPEAT`` times.
 
@@ -507,6 +535,7 @@ class CVPublishPromoteTestCase(APITestCase):
             REPEAT + 1,
         )
 
+    @tier2
     def test_positive_promote_with_yum_multiple(self):
         """@Test: Give a content view a yum repo, publish it once and promote
         the content view version ``REPEAT + 1`` times.
@@ -538,6 +567,7 @@ class CVPublishPromoteTestCase(APITestCase):
         self.assertEqual(len(cvv_attrs['environments']), REPEAT + 1)
         self.assertGreater(cvv_attrs['package_count'], 0)
 
+    @tier2
     def test_positive_promote_with_puppet_once(self):
         """@Test: Give content view a puppet module. Publish
         and promote it once
@@ -570,6 +600,7 @@ class CVPublishPromoteTestCase(APITestCase):
         self.assertEqual(len(cvv.environment), 2)
         self.assertEqual(len(cvv.puppet_module), 1)
 
+    @tier2
     def test_positive_promote_with_puppet_multiple(self):
         """@Test: Give a content view a puppet module, publish it once and
         promote the content view version ``Library + random`` times.
@@ -608,6 +639,7 @@ class CVPublishPromoteTestCase(APITestCase):
         self.assertEqual(len(cvv.environment), envs_amount + 1)
         self.assertEqual(len(cvv.puppet_module), 1)
 
+    @tier2
     def test_positive_add_to_composite(self):
         """@Test: Create normal content view, publish and add it to a new
         composite content view
@@ -641,6 +673,7 @@ class CVPublishPromoteTestCase(APITestCase):
             content_view.id,
         )
 
+    @tier2
     def test_negative_associate_components_to_composite(self):
         """@Test: Attempt to associate components in a non-composite content
         view
@@ -664,6 +697,7 @@ class CVPublishPromoteTestCase(APITestCase):
             non_composite_cv.update(['component'])
         self.assertEqual(len(non_composite_cv.read().component), 0)
 
+    @tier2
     def test_positive_promote_composite_single_content_once(self):
         """@Test: Create empty composite view and assign one normal content
         view to it. After that promote that composite content view once.
@@ -685,6 +719,7 @@ class CVPublishPromoteTestCase(APITestCase):
         self.assertEqual(len(composite_cv.version), 1)
         self.assertEqual(len(composite_cv.version[0].read().environment), 2)
 
+    @tier2
     def test_positive_promote_composite_multiple_content_once(self):
         """@Test: Create empty composite view and assign random number of
         normal content views to it. After that promote that composite
@@ -707,6 +742,7 @@ class CVPublishPromoteTestCase(APITestCase):
         self.assertEqual(len(composite_cv.version), 1)
         self.assertEqual(len(composite_cv.version[0].read().environment), 2)
 
+    @tier2
     def test_positive_promote_composite_single_content_multiple(self):
         """@Test: Create empty composite view and assign one normal content
         view to it. After that promote that composite content view
@@ -736,6 +772,7 @@ class CVPublishPromoteTestCase(APITestCase):
             len(composite_cv.version[0].read().environment),
         )
 
+    @tier2
     def test_positive_promote_composite_multiple_content_multiple(self):
         """@Test: Create empty composite view and assign random number of
         normal content views to it. After that promote that composite content
@@ -775,6 +812,7 @@ class ContentViewUpdateTestCase(APITestCase):
         super(ContentViewUpdateTestCase, cls).setUpClass()
         cls.content_view = entities.ContentView().create()
 
+    @tier1
     def test_positive_update_attributes(self):
         """@Test: Update a content view and provide valid attributes.
 
@@ -789,6 +827,7 @@ class ContentViewUpdateTestCase(APITestCase):
                 self.content_view = self.content_view.update({key})
                 self.assertEqual(getattr(self.content_view, key), value)
 
+    @tier1
     def test_positive_update_name(self):
         """@Test: Create content view providing the initial name, then update
         its name to another valid name.
@@ -804,6 +843,7 @@ class ContentViewUpdateTestCase(APITestCase):
                     id=self.content_view.id, name=new_name).update(['name'])
                 self.assertEqual(new_name, updated.name)
 
+    @tier1
     def test_negative_update_name(self):
         """@Test: Create content view then update its name to an
         invalid name.
@@ -822,6 +862,7 @@ class ContentViewUpdateTestCase(APITestCase):
                 cv = entities.ContentView(id=self.content_view.id).read()
                 self.assertNotEqual(cv.name, new_name)
 
+    @tier1
     def test_negative_update_attributes(self):
         """@Test: Update a content view and provide an invalid attribute.
 
@@ -842,6 +883,7 @@ class ContentViewUpdateTestCase(APITestCase):
 class ContentViewDeleteTestCase(APITestCase):
     """Tests for deleting content views."""
 
+    @tier1
     def test_positive_delete(self):
         """@Test: Create content view and then delete it.
 
@@ -882,6 +924,7 @@ class CVRedHatContent(APITestCase):
         cls.repo = entities.Repository(id=repo_id)
         cls.repo.sync()
 
+    @tier2
     def test_positive_associate_rh(self):
         """@Test: associate Red Hat content in a view
 
@@ -899,6 +942,7 @@ class CVRedHatContent(APITestCase):
             REPOS['rhst7']['name'],
         )
 
+    @tier2
     def test_positive_associate_rh_custom_spin(self):
         """@Test: Associate Red Hat content in a view and filter it using rule
 
@@ -934,6 +978,7 @@ class ContentViewTestCaseStub(APITestCase):
     # Each of these tests should be given a better name when they're
     # implemented. In the meantime, let's not worry about bad names.
 
+    @tier2
     @stubbed()
     def test_cv_edit_rh_custom_spin(self):
         """

--- a/tests/foreman/api/test_contentviewfilter.py
+++ b/tests/foreman/api/test_contentviewfilter.py
@@ -11,7 +11,7 @@ from requests.exceptions import HTTPError
 from robottelo.config import settings
 from robottelo.constants import DOCKER_REGISTRY_HUB
 from robottelo.datafactory import invalid_names_list, valid_data_list
-from robottelo.decorators import run_only_on, skip_if_bug_open
+from robottelo.decorators import run_only_on, skip_if_bug_open, tier1, tier2
 from robottelo.test import APITestCase
 from six.moves import http_client
 
@@ -37,6 +37,7 @@ class ContentViewFilterTestCase(APITestCase):
         self.content_view.repository = [self.repo]
         self.content_view.update(['repository'])
 
+    @tier2
     @run_only_on('sat')
     def test_get_with_no_args(self):
         """@Test: Issue an HTTP GET to the base content view filters path.
@@ -58,6 +59,7 @@ class ContentViewFilterTestCase(APITestCase):
             (http_client.BAD_REQUEST, http_client.UNPROCESSABLE_ENTITY)
         )
 
+    @tier2
     @run_only_on('sat')
     def test_get_with_bad_args(self):
         """@Test: Issue an HTTP GET to the base content view filters path.
@@ -80,6 +82,7 @@ class ContentViewFilterTestCase(APITestCase):
             (http_client.BAD_REQUEST, http_client.UNPROCESSABLE_ENTITY)
         )
 
+    @tier1
     @run_only_on('sat')
     def test_positive_create_erratum_with_different_names(self):
         """Test: Create new erratum content filter using different inputs as
@@ -99,6 +102,7 @@ class ContentViewFilterTestCase(APITestCase):
                 self.assertEqual(cvf.name, name)
                 self.assertEqual(cvf.type, 'erratum')
 
+    @tier2
     @run_only_on('sat')
     def test_positive_create_pkg_group_with_different_names(self):
         """Test: Create new package group content filter using different inputs
@@ -118,6 +122,7 @@ class ContentViewFilterTestCase(APITestCase):
                 self.assertEqual(cvf.name, name)
                 self.assertEqual(cvf.type, 'package_group')
 
+    @tier2
     @run_only_on('sat')
     def test_positive_create_rpm_with_different_names(self):
         """Test: Create new RPM content filter using different inputs as
@@ -137,6 +142,7 @@ class ContentViewFilterTestCase(APITestCase):
                 self.assertEqual(cvf.name, name)
                 self.assertEqual(cvf.type, 'rpm')
 
+    @tier2
     @run_only_on('sat')
     def test_positive_create_with_inclusion(self):
         """Test: Create new content view filter with different inclusion values
@@ -154,6 +160,7 @@ class ContentViewFilterTestCase(APITestCase):
                 ).create()
                 self.assertEqual(cvf.inclusion, inclusion)
 
+    @tier2
     @run_only_on('sat')
     def test_positive_create_with_description(self):
         """Test: Create new content filter using different inputs as a
@@ -172,6 +179,7 @@ class ContentViewFilterTestCase(APITestCase):
                 ).create()
                 self.assertEqual(cvf.description, description)
 
+    @tier2
     @run_only_on('sat')
     def test_positive_create_with_repo(self):
         """Test: Create new content filter with repository assigned
@@ -188,6 +196,7 @@ class ContentViewFilterTestCase(APITestCase):
         ).create()
         self.assertEqual(cvf.repository[0].id, self.repo.id)
 
+    @tier2
     @run_only_on('sat')
     def test_positive_create_with_original_packages(self):
         """Test: Create new content view filter with different 'original
@@ -209,6 +218,7 @@ class ContentViewFilterTestCase(APITestCase):
                 ).create()
                 self.assertEqual(cvf.original_packages, original_packages)
 
+    @tier2
     @run_only_on('sat')
     def test_positive_create_with_multiple_repos_with_docker(self):
         """Test: Create new docker repository and add to content view that has
@@ -237,6 +247,7 @@ class ContentViewFilterTestCase(APITestCase):
         for repo in cvf.repository:
             self.assertIn(repo.id, [self.repo.id, docker_repository.id])
 
+    @tier1
     @run_only_on('sat')
     def test_negative_create_with_different_names(self):
         """@Test: Try to create content view filter using invalid names only
@@ -253,6 +264,7 @@ class ContentViewFilterTestCase(APITestCase):
                         name=name,
                     ).create()
 
+    @tier2
     @run_only_on('sat')
     def test_negative_create_with_same_names(self):
         """@Test: Try to create content view filter using same name twice
@@ -269,6 +281,7 @@ class ContentViewFilterTestCase(APITestCase):
         with self.assertRaises(HTTPError):
             entities.RPMContentViewFilter(**kwargs).create()
 
+    @tier2
     @run_only_on('sat')
     def test_negative_create_without_cv(self):
         """@Test: Try to create content view filter without providing content
@@ -281,6 +294,7 @@ class ContentViewFilterTestCase(APITestCase):
         with self.assertRaises(HTTPError):
             entities.RPMContentViewFilter(content_view=None).create()
 
+    @tier2
     @run_only_on('sat')
     def test_negative_create_with_repo_by_id(self):
         """@Test: Try to create content view filter using incorrect repository
@@ -296,6 +310,7 @@ class ContentViewFilterTestCase(APITestCase):
                 repository=[gen_integer(10000, 99999)],
             ).create()
 
+    @tier1
     @run_only_on('sat')
     def test_positive_delete_by_id(self):
         """@Test: Delete content view filter
@@ -311,6 +326,7 @@ class ContentViewFilterTestCase(APITestCase):
         with self.assertRaises(HTTPError):
             cvf.read()
 
+    @tier1
     @run_only_on('sat')
     def test_positive_update_with_new_name(self):
         """@Test: Update content view filter with new name
@@ -327,6 +343,7 @@ class ContentViewFilterTestCase(APITestCase):
                 cvf.name = name
                 self.assertEqual(cvf.update(['name']).name, name)
 
+    @tier2
     @run_only_on('sat')
     def test_positive_update_with_new_description(self):
         """@Test: Update content view filter with new description
@@ -344,6 +361,7 @@ class ContentViewFilterTestCase(APITestCase):
                 cvf.description = desc
                 self.assertEqual(cvf.update(['description']).description, desc)
 
+    @tier2
     @run_only_on('sat')
     def test_positive_update_with_new_inclusion(self):
         """Test: Update content view filter with new inclusion value
@@ -362,6 +380,7 @@ class ContentViewFilterTestCase(APITestCase):
                 cvf = cvf.update(['inclusion'])
                 self.assertEqual(cvf.inclusion, inclusion)
 
+    @tier2
     @run_only_on('sat')
     def test_positive_update_with_new_repo(self):
         """Test: Update content view filter with new repository
@@ -385,6 +404,7 @@ class ContentViewFilterTestCase(APITestCase):
         self.assertEqual(len(cvf.repository), 1)
         self.assertEqual(cvf.repository[0].id, new_repo.id)
 
+    @tier2
     @run_only_on('sat')
     def test_positive_update_with_multiple_repos(self):
         """Test: Update content view filter with multiple repositories
@@ -415,6 +435,7 @@ class ContentViewFilterTestCase(APITestCase):
             set([repo.id for repo in repos])
         )
 
+    @tier2
     @run_only_on('sat')
     def test_positive_update_original_packages(self):
         """Test: Update content view filter with new 'original packages' option
@@ -436,6 +457,7 @@ class ContentViewFilterTestCase(APITestCase):
                 cvf = cvf.update(['original_packages'])
                 self.assertEqual(cvf.original_packages, original_packages)
 
+    @tier2
     @run_only_on('sat')
     def test_positive_update_with_repo_with_docker(self):
         """Test: Update existing content view filter which has yum repository
@@ -465,6 +487,7 @@ class ContentViewFilterTestCase(APITestCase):
         for repo in cvf.repository:
             self.assertIn(repo.id, [self.repo.id, docker_repository.id])
 
+    @tier1
     @run_only_on('sat')
     def test_negative_update_with_different_names(self):
         """@Test: Try to update content view filter using invalid names only
@@ -482,6 +505,7 @@ class ContentViewFilterTestCase(APITestCase):
                 with self.assertRaises(HTTPError):
                     cvf.update(['name'])
 
+    @tier2
     @run_only_on('sat')
     def test_negative_update_with_already_used_name(self):
         """@Test: Try to update content view filter's name to already used one
@@ -502,6 +526,7 @@ class ContentViewFilterTestCase(APITestCase):
         with self.assertRaises(HTTPError):
             cvf.update(['name'])
 
+    @tier2
     @run_only_on('sat')
     def test_negative_update_with_cv_by_id(self):
         """@Test: Try to update content view filter using incorrect content
@@ -518,6 +543,7 @@ class ContentViewFilterTestCase(APITestCase):
         with self.assertRaises(HTTPError):
             cvf.update(['content_view'])
 
+    @tier2
     @run_only_on('sat')
     def test_negative_update_with_repo_by_id(self):
         """@Test: Try to update content view filter using incorrect repository
@@ -535,6 +561,7 @@ class ContentViewFilterTestCase(APITestCase):
         with self.assertRaises(HTTPError):
             cvf.update(['repository'])
 
+    @tier2
     @run_only_on('sat')
     def test_negative_update_with_new_repo(self):
         """Test: Try to update content view filter with new repository which
@@ -565,6 +592,7 @@ class SearchTestCase(APITestCase):
         super(SearchTestCase, cls).setUpClass()
         cls.content_view = entities.ContentView().create()
 
+    @tier1
     @skip_if_bug_open('bugzilla', 1242534)
     def test_positive_search_erratum(self):
         """@Test: Search for an erratum content view filter's rules.
@@ -578,6 +606,7 @@ class SearchTestCase(APITestCase):
         ).create()
         entities.ContentViewFilterRule(content_view_filter=cv_filter).search()
 
+    @tier1
     def test_positive_search_package_group(self):
         """@Test: Search for an package group content view filter's rules.
 
@@ -590,6 +619,7 @@ class SearchTestCase(APITestCase):
         ).create()
         entities.ContentViewFilterRule(content_view_filter=cv_filter).search()
 
+    @tier1
     def test_positive_search_rpm(self):
         """@Test: Search for an rpm content view filter's rules.
 

--- a/tests/foreman/api/test_contentviewversion.py
+++ b/tests/foreman/api/test_contentviewversion.py
@@ -8,6 +8,7 @@ from robottelo.constants import (
     PUPPET_MODULE_NTP_PUPPETLABS,
     ZOO_CUSTOM_GPG_KEY,
 )
+from robottelo.decorators import tier1, tier2
 from robottelo.helpers import get_data_file, read_data_file
 from robottelo.test import APITestCase
 
@@ -28,6 +29,7 @@ class ContentViewVersionCreateTestCase(APITestCase):
             organization=self.org,
         ).create()
 
+    @tier1
     def test_positive_create(self):
         """@Test: Create a content view version.
 
@@ -46,6 +48,7 @@ class ContentViewVersionCreateTestCase(APITestCase):
         cv = cv.read()
         self.assertGreater(len(cv.version), 0)
 
+    @tier1
     def test_negative_create(self):
         """@Test: Create content view version using the 'Default Content View'.
 
@@ -87,6 +90,7 @@ class ContentViewVersionPromoteTestCase(APITestCase):
         assert len(default_cv[0].version) == 1
         cls.default_cv = default_cv[0].version[0].read()
 
+    @tier2
     def test_positive_promote_valid_environment(self):
         """@Test: Promote a content view version to 'next in sequence'
         lifecycle environment.
@@ -114,6 +118,7 @@ class ContentViewVersionPromoteTestCase(APITestCase):
         version = version.read()
         self.assertEqual(len(version.environment), 2)
 
+    @tier2
     def test_positive_promote_out_of_sequence_environment(self):
         """@Test: Promote a content view version to a lifecycle environment that
         is 'out of sequence'.
@@ -138,6 +143,7 @@ class ContentViewVersionPromoteTestCase(APITestCase):
         version = version.read()
         self.assertEqual(len(version.environment), 2)
 
+    @tier2
     def test_negative_promote_valid_environment(self):
         """@Test: Promote the default content view version.
 
@@ -148,6 +154,7 @@ class ContentViewVersionPromoteTestCase(APITestCase):
         with self.assertRaises(HTTPError):
             promote(self.default_cv, self.lce1.id)
 
+    @tier2
     def test_negative_promote_out_of_sequence_environment(self):
         """@Test: Promote a content view version to a lifecycle environment that
         is 'out of sequence'.
@@ -173,6 +180,7 @@ class ContentViewVersionPromoteTestCase(APITestCase):
 class ContentViewVersionDeleteTestCase(APITestCase):
     """Tests for content view version promotion."""
 
+    @tier2
     def test_positive_delete_version(self):
         """@Test: Create content view and publish it. After that try to
         disassociate content view from 'Library' environment through
@@ -219,6 +227,7 @@ class ContentViewVersionDeleteTestCase(APITestCase):
         # Make sure that content view version is really removed
         self.assertEqual(len(content_view.read().version), 0)
 
+    @tier2
     def test_positive_delete_version_non_default(self):
         """@Test: Create content view and publish and promote it to new
         environment. After that try to disassociate content view from 'Library'
@@ -247,6 +256,7 @@ class ContentViewVersionDeleteTestCase(APITestCase):
         # Make sure that content view version is really removed
         self.assertEqual(len(content_view.read().version), 0)
 
+    @tier1
     def test_negative_delete_version(self):
         """@Test: Create content view and publish it. Try to delete content
         view version while content view is still associated with lifecycle
@@ -271,6 +281,7 @@ class ContentViewVersionDeleteTestCase(APITestCase):
 class ContentViewVersionIncremnentalTestCase(APITestCase):
     """Tests for content view version promotion."""
 
+    @tier2
     def test_positive_incremental_update_puppet(self):
         """@Test: Incrementally update a CVV with a puppet module.
 

--- a/tests/foreman/api/test_discoveredhost.py
+++ b/tests/foreman/api/test_discoveredhost.py
@@ -3,7 +3,7 @@
 from fauxfactory import gen_string, gen_ipaddr, gen_mac
 from nailgun import entities
 from robottelo.datafactory import valid_data_list
-from robottelo.decorators import run_only_on, stubbed
+from robottelo.decorators import run_only_on, stubbed, tier2
 from robottelo.test import APITestCase
 
 
@@ -92,6 +92,7 @@ class Discovery(APITestCase):
 
         """
 
+    @tier2
     @run_only_on('sat')
     def test_upload_facts(self):
         """@Test: Upload fake facts to create a discovered host

--- a/tests/foreman/api/test_discoveryrule.py
+++ b/tests/foreman/api/test_discoveryrule.py
@@ -4,7 +4,7 @@ from fauxfactory import gen_choice, gen_integer, gen_string
 from nailgun import entities
 from requests.exceptions import HTTPError
 from robottelo.datafactory import valid_data_list
-from robottelo.decorators import run_only_on
+from robottelo.decorators import run_only_on, tier1, tier2
 from robottelo.test import APITestCase
 
 
@@ -41,6 +41,7 @@ class DiscoveryRule(APITestCase):
             'myhost-<%= rand(99999) %>'
         )
 
+    @tier1
     @run_only_on('sat')
     def test_create_discovery_rule_basic(self):
         """@Test: Create a new discovery rule.
@@ -62,6 +63,7 @@ class DiscoveryRule(APITestCase):
                     discovery_rule.search_,
                 )
 
+    @tier1
     @run_only_on('sat')
     def test_delete_discovery_rule(self):
         """@Test: Delete a discovery rule
@@ -79,6 +81,7 @@ class DiscoveryRule(APITestCase):
                 with self.assertRaises(HTTPError):
                     discovery_rule.read()
 
+    @tier1
     def test_create_rule_with_invalid_name(self):
         """@Test: Create a discovery rule with more than 255 char in name
 
@@ -95,6 +98,7 @@ class DiscoveryRule(APITestCase):
                 with self.assertRaises(HTTPError):
                     self.discovery_rule.create()
 
+    @tier2
     def test_create_rule_with_invalid_host_limit(self):
         """@Test: Create a discovery rule with invalid host limit
 
@@ -107,6 +111,7 @@ class DiscoveryRule(APITestCase):
         with self.assertRaises(HTTPError):
             self.discovery_rule.create()
 
+    @tier2
     def test_create_rule_with_invalid_priority(self):
         """@Test: Create a discovery rule with invalid priority
 
@@ -119,6 +124,7 @@ class DiscoveryRule(APITestCase):
         with self.assertRaises(HTTPError):
             self.discovery_rule.create()
 
+    @tier1
     @run_only_on('sat')
     def test_update_discovery_rule_name(self):
         """@Test: Update an existing discovery rule name
@@ -135,6 +141,7 @@ class DiscoveryRule(APITestCase):
                 discovery_rule = discovery_rule.update(['name'])
                 self.assertEqual(discovery_rule.name, name)
 
+    @tier1
     def test_update_search_rule(self):
         """@Test: Update an existing discovery search rule
 
@@ -150,6 +157,7 @@ class DiscoveryRule(APITestCase):
             discovery_rule.update(['search_']).search_,
         )
 
+    @tier2
     def test_update_host_limit(self):
         """@Test: Update an existing rule with valid host limit.
 
@@ -165,6 +173,7 @@ class DiscoveryRule(APITestCase):
             discovery_rule.update(['max_count']).max_count,
         )
 
+    @tier1
     def test_disable_rule(self):
         """@Test: Disable an existing enabled discovery rule.
 
@@ -181,6 +190,7 @@ class DiscoveryRule(APITestCase):
             discovery_rule.update(['enabled']).enabled,
         )
 
+    @tier2
     def test_update_rule_hostgroup(self):
         """@Test: Update host group of an existing rule.
 

--- a/tests/foreman/api/test_docker.py
+++ b/tests/foreman/api/test_docker.py
@@ -8,7 +8,13 @@ from robottelo.api.utils import promote
 from robottelo.config import settings
 from robottelo.constants import DOCKER_REGISTRY_HUB
 from robottelo.datafactory import valid_data_list
-from robottelo.decorators import run_only_on, skip_if_bug_open, stubbed
+from robottelo.decorators import (
+    run_only_on,
+    skip_if_bug_open,
+    stubbed,
+    tier1,
+    tier2,
+)
 from robottelo.helpers import install_katello_ca, remove_katello_ca
 from robottelo.test import APITestCase
 
@@ -121,6 +127,7 @@ class DockerRepositoryTestCase(APITestCase):
         super(DockerRepositoryTestCase, cls).setUpClass()
         cls.org = entities.Organization().create()
 
+    @tier1
     @run_only_on('sat')
     def test_create_one_docker_repo(self):
         """@Test: Create one Docker-type repository
@@ -140,6 +147,7 @@ class DockerRepositoryTestCase(APITestCase):
                 self.assertEqual(repo.docker_upstream_name, 'busybox')
                 self.assertEqual(repo.content_type, 'docker')
 
+    @tier1
     @run_only_on('sat')
     def test_create_docker_repo_valid_upstream_name(self):
         """@Test: Create a Docker-type repository with a valid docker upstream
@@ -159,6 +167,7 @@ class DockerRepositoryTestCase(APITestCase):
                 self.assertEqual(repo.docker_upstream_name, upstream_name)
                 self.assertEqual(repo.content_type, u'docker')
 
+    @tier1
     @run_only_on('sat')
     def test_create_docker_repo_invalid_upstream_name(self):
         """@Test: Create a Docker-type repository with a invalid docker
@@ -175,6 +184,7 @@ class DockerRepositoryTestCase(APITestCase):
                 with self.assertRaises(HTTPError):
                     _create_repository(product, upstream_name=upstream_name)
 
+    @tier2
     @run_only_on('sat')
     def test_create_multiple_docker_repo(self):
         """@Test: Create multiple Docker-type repositories
@@ -191,6 +201,7 @@ class DockerRepositoryTestCase(APITestCase):
             product = product.read()
             self.assertIn(repo.id, [repo_.id for repo_ in product.repository])
 
+    @tier2
     @run_only_on('sat')
     def test_create_multiple_docker_repo_multiple_products(self):
         """@Test: Create multiple Docker-type repositories on multiple products.
@@ -211,6 +222,7 @@ class DockerRepositoryTestCase(APITestCase):
                     [repo_.id for repo_ in product.repository],
                 )
 
+    @tier2
     @run_only_on('sat')
     def test_sync_docker_repo(self):
         """@Test: Create and sync a Docker-type repository
@@ -228,6 +240,7 @@ class DockerRepositoryTestCase(APITestCase):
         repo = repo.read()
         self.assertGreaterEqual(repo.content_counts['docker_image'], 1)
 
+    @tier1
     @run_only_on('sat')
     def test_update_docker_repo_name(self):
         """@Test: Create a Docker-type repository and update its name.
@@ -248,6 +261,7 @@ class DockerRepositoryTestCase(APITestCase):
                 repo = repo.update()
                 self.assertEqual(repo.name, new_name)
 
+    @tier1
     @run_only_on('sat')
     def test_update_docker_repo_upstream_name(self):
         """@Test: Create a Docker-type repository and update its upstream name.
@@ -268,6 +282,7 @@ class DockerRepositoryTestCase(APITestCase):
         repo = repo.update()
         self.assertEqual(repo.docker_upstream_name, new_upstream_name)
 
+    @tier2
     @run_only_on('sat')
     def test_update_docker_repo_url(self):
         """@Test: Create a Docker-type repository and update its URL.
@@ -289,6 +304,7 @@ class DockerRepositoryTestCase(APITestCase):
         self.assertEqual(repo.url, new_url)
         self.assertNotEqual(repo.url, DOCKER_REGISTRY_HUB)
 
+    @tier1
     @run_only_on('sat')
     def test_delete_docker_repo(self):
         """@Test: Create and delete a Docker-type repository
@@ -305,6 +321,7 @@ class DockerRepositoryTestCase(APITestCase):
         with self.assertRaises(HTTPError):
             repo.read()
 
+    @tier2
     @run_only_on('sat')
     def test_delete_random_docker_repo(self):
         """@Test: Create Docker-type repositories on multiple products and
@@ -349,6 +366,7 @@ class DockerContentViewTestCase(APITestCase):
         super(DockerContentViewTestCase, cls).setUpClass()
         cls.org = entities.Organization().create()
 
+    @tier2
     @run_only_on('sat')
     def test_add_docker_repo_to_content_view(self):
         """@Test: Add one Docker-type repository to a non-composite content view
@@ -370,6 +388,7 @@ class DockerContentViewTestCase(APITestCase):
         content_view = content_view.update(['repository'])
         self.assertIn(repo.id, [repo_.id for repo_ in content_view.repository])
 
+    @tier2
     @run_only_on('sat')
     def test_add_multiple_docker_repos_to_content_view(self):
         """@Test: Add multiple Docker-type repositories to a
@@ -411,6 +430,7 @@ class DockerContentViewTestCase(APITestCase):
             self.assertEqual(repo.content_type, u'docker')
             self.assertEqual(repo.docker_upstream_name, u'busybox')
 
+    @tier2
     @run_only_on('sat')
     def test_add_synced_docker_repo_to_content_view(self):
         """@Test: Create and sync a Docker-type repository
@@ -436,6 +456,7 @@ class DockerContentViewTestCase(APITestCase):
         content_view = content_view.update(['repository'])
         self.assertIn(repo.id, [repo_.id for repo_ in content_view.repository])
 
+    @tier2
     @run_only_on('sat')
     def test_add_docker_repo_to_composite_content_view(self):
         """@Test: Add one Docker-type repository to a composite content view
@@ -476,6 +497,7 @@ class DockerContentViewTestCase(APITestCase):
             [component.id for component in comp_content_view.component]
         )
 
+    @tier2
     @run_only_on('sat')
     def test_add_multiple_docker_repos_to_composite_content_view(self):
         """@Test: Add multiple Docker-type repositories to a composite
@@ -522,6 +544,7 @@ class DockerContentViewTestCase(APITestCase):
                 [component.id for component in comp_content_view.component]
             )
 
+    @tier2
     @run_only_on('sat')
     def test_publish_once_docker_repo_content_view(self):
         """@Test: Add Docker-type repository to content view and publish
@@ -555,6 +578,7 @@ class DockerContentViewTestCase(APITestCase):
         self.assertIsNotNone(content_view.last_published)
         self.assertGreater(content_view.next_version, 1)
 
+    @tier2
     @run_only_on('sat')
     @skip_if_bug_open('bugzilla', 1217635)
     def test_publish_once_docker_repo_composite_content_view(self):
@@ -607,6 +631,7 @@ class DockerContentViewTestCase(APITestCase):
         self.assertIsNotNone(comp_content_view.last_published)
         self.assertGreater(comp_content_view.next_version, 1)
 
+    @tier2
     @run_only_on('sat')
     def test_publish_multiple_docker_repo_content_view(self):
         """@Test: Add Docker-type repository to content view and publish it
@@ -637,6 +662,7 @@ class DockerContentViewTestCase(APITestCase):
         self.assertIsNotNone(content_view.last_published)
         self.assertEqual(len(content_view.version), publish_amount)
 
+    @tier2
     @run_only_on('sat')
     def test_publish_multiple_docker_repo_composite_content_view(self):
         """@Test: Add Docker-type repository to content view and publish it
@@ -684,6 +710,7 @@ class DockerContentViewTestCase(APITestCase):
         self.assertIsNotNone(comp_content_view.last_published)
         self.assertEqual(len(comp_content_view.version), publish_amount)
 
+    @tier2
     @run_only_on('sat')
     def test_promote_docker_repo_content_view(self):
         """@Test: Add Docker-type repository to content view and publish it.
@@ -716,6 +743,7 @@ class DockerContentViewTestCase(APITestCase):
         promote(cvv, lce.id)
         self.assertEqual(len(cvv.read().environment), 2)
 
+    @tier2
     @run_only_on('sat')
     def test_promote_multiple_docker_repo_content_view(self):
         """@Test: Add Docker-type repository to content view and publish it.
@@ -748,6 +776,7 @@ class DockerContentViewTestCase(APITestCase):
             promote(cvv, lce.id)
             self.assertEqual(len(cvv.read().environment), i+1)
 
+    @tier2
     @run_only_on('sat')
     def test_promote_docker_repo_composite_content_view(self):
         """@Test: Add Docker-type repository to content view and publish it.
@@ -790,6 +819,7 @@ class DockerContentViewTestCase(APITestCase):
         promote(comp_cvv, lce.id)
         self.assertEqual(len(comp_cvv.read().environment), 2)
 
+    @tier2
     @run_only_on('sat')
     def test_promote_multiple_docker_repo_composite_content_view(self):
         """@Test: Add Docker-type repository to content view and publish it.
@@ -855,6 +885,7 @@ class DockerActivationKeyTestCase(APITestCase):
         cls.cvv = content_view.read().version[0].read()
         promote(cls.cvv, cls.lce.id)
 
+    @tier2
     @run_only_on('sat')
     def test_add_docker_repo_to_activation_key(self):
         """@Test: Add Docker-type repository to a non-composite content view
@@ -874,6 +905,7 @@ class DockerActivationKeyTestCase(APITestCase):
         self.assertEqual(ak.content_view.id, self.content_view.id)
         self.assertEqual(ak.content_view.read().repository[0].id, self.repo.id)
 
+    @tier2
     @run_only_on('sat')
     def test_remove_docker_repo_to_activation_key(self):
         """@Test: Add Docker-type repository to a non-composite content view
@@ -896,6 +928,7 @@ class DockerActivationKeyTestCase(APITestCase):
         ak.content_view = None
         self.assertIsNone(ak.update(['content_view']).content_view)
 
+    @tier2
     @run_only_on('sat')
     def test_add_docker_repo_composite_view_to_activation_key(self):
         """@Test:Add Docker-type repository to a non-composite content view and
@@ -927,6 +960,7 @@ class DockerActivationKeyTestCase(APITestCase):
         ).create()
         self.assertEqual(ak.content_view.id, comp_content_view.id)
 
+    @tier2
     @run_only_on('sat')
     def test_remove_docker_repo_composite_view_to_activation_key(self):
         """@Test: Add Docker-type repository to a non-composite content view
@@ -972,6 +1006,7 @@ class DockerComputeResourceTestCase(APITestCase):
         super(DockerComputeResourceTestCase, cls).setUpClass()
         cls.org = entities.Organization().create()
 
+    @tier2
     @run_only_on('sat')
     def test_create_internal_docker_compute_resource(self):
         """@Test: Create a Docker-based Compute Resource in the Satellite 6
@@ -995,6 +1030,7 @@ class DockerComputeResourceTestCase(APITestCase):
                     settings.docker.get_unix_socket_url()
                 )
 
+    @tier2
     @run_only_on('sat')
     def test_update_docker_compute_resource(self):
         """@Test: Create a Docker-based Compute Resource in the Satellite 6
@@ -1020,6 +1056,7 @@ class DockerComputeResourceTestCase(APITestCase):
                     compute_resource.update(['url']).url,
                 )
 
+    @tier2
     @run_only_on('sat')
     def test_list_containers_internal_docker_compute_resource(self):
         """@Test: Create a Docker-based Compute Resource in the Satellite 6
@@ -1051,6 +1088,7 @@ class DockerComputeResourceTestCase(APITestCase):
                 self.assertEqual(len(result), 1)
                 self.assertEqual(result[0].name, container.name)
 
+    @tier2
     @run_only_on('sat')
     def test_create_external_docker_compute_resource(self):
         """@Test: Create a Docker-based Compute Resource using an external
@@ -1072,6 +1110,7 @@ class DockerComputeResourceTestCase(APITestCase):
                 self.assertEqual(
                     compute_resource.url, settings.docker.external_url)
 
+    @tier1
     @run_only_on('sat')
     def test_delete_docker_compute_resource(self):
         """@Test: Create a Docker-based Compute Resource then delete it.
@@ -1121,6 +1160,7 @@ class DockerContainersTestCase(APITestCase):
         remove_katello_ca()
         super(DockerContainersTestCase, cls).tearDownClass()
 
+    @tier2
     @run_only_on('sat')
     def test_create_container_compute_resource(self):
         """@Test: Create containers for local and external compute resources
@@ -1142,6 +1182,7 @@ class DockerContainersTestCase(APITestCase):
                     compute_resource.name,
                 )
 
+    @tier2
     @run_only_on('sat')
     @skip_if_bug_open('bugzilla', 1282431)
     def test_create_container_content_view(self):
@@ -1215,6 +1256,7 @@ class DockerContainersTestCase(APITestCase):
                 self.assertFalse(container.power(
                     data={u'power_action': 'status'})['running'])
 
+    @tier2
     @run_only_on('sat')
     def test_create_container_compute_resource_read_log(self):
         """@Test: Create containers for local and external compute resource and
@@ -1252,6 +1294,7 @@ class DockerContainersTestCase(APITestCase):
 
         """
 
+    @tier1
     @run_only_on('sat')
     def test_delete_container_compute_resource(self):
         """@Test: Delete containers in local and external compute resources
@@ -1280,6 +1323,7 @@ class DockerRegistriesTestCase(APITestCase):
 
     """
 
+    @tier1
     @run_only_on('sat')
     def test_create_registry(self):
         """@Test: Create an external docker registry
@@ -1302,6 +1346,7 @@ class DockerRegistriesTestCase(APITestCase):
                 self.assertEqual(registry.url, url)
                 self.assertEqual(registry.description, description)
 
+    @tier1
     @run_only_on('sat')
     def test_update_registry_name(self):
         """@Test: Create an external docker registry and update its name
@@ -1318,6 +1363,7 @@ class DockerRegistriesTestCase(APITestCase):
                 registry = registry.update()
                 self.assertEqual(registry.name, new_name)
 
+    @tier2
     @run_only_on('sat')
     def test_update_registry_url(self):
         """@Test: Create an external docker registry and update its URL
@@ -1335,6 +1381,7 @@ class DockerRegistriesTestCase(APITestCase):
         registry = registry.update()
         self.assertEqual(registry.url, new_url)
 
+    @tier2
     @run_only_on('sat')
     def test_update_registry_description(self):
         """@Test: Create an external docker registry and update its description
@@ -1351,6 +1398,7 @@ class DockerRegistriesTestCase(APITestCase):
                 registry = registry.update()
                 self.assertEqual(registry.description, new_desc)
 
+    @tier2
     @run_only_on('sat')
     def test_update_registry_username(self):
         """@Test: Create an external docker registry and update its username
@@ -1371,6 +1419,7 @@ class DockerRegistriesTestCase(APITestCase):
         registry = registry.update()
         self.assertEqual(registry.username, new_username)
 
+    @tier1
     @run_only_on('sat')
     def test_delete_registry(self):
         """@Test: Create an external docker registry and then delete it

--- a/tests/foreman/api/test_environment.py
+++ b/tests/foreman/api/test_environment.py
@@ -9,13 +9,14 @@ from nailgun import entities
 from requests.exceptions import HTTPError
 from robottelo.api.utils import one_to_many_names
 from robottelo.datafactory import invalid_names_list
-from robottelo.decorators import run_only_on, skip_if_bug_open
+from robottelo.decorators import run_only_on, skip_if_bug_open, tier1, tier2
 from robottelo.test import APITestCase
 
 
 class EnvironmentTestCase(APITestCase):
     """Tests for environments."""
 
+    @tier1
     @run_only_on('sat')
     def test_positive_create_1(self):
         """@Test: Create an environment and provide a valid name.
@@ -34,6 +35,7 @@ class EnvironmentTestCase(APITestCase):
                 env = env.read()  # check sat isn't blindly handing back data
                 self.assertEqual(env.name, name)
 
+    @tier1
     @run_only_on('sat')
     def test_negative_create_1(self):
         """@Test: Create an environment and provide an invalid name.
@@ -50,6 +52,7 @@ class EnvironmentTestCase(APITestCase):
                 with self.assertRaises(HTTPError):
                     entities.Environment(name=name).create()
 
+    @tier2
     @run_only_on('sat')
     def test_negative_create_2(self):
         """@Test: Create an environment and provide an illegal name.
@@ -87,6 +90,7 @@ class MissingAttrTestCase(APITestCase):
         env = entities.Environment().create()
         cls.env_attrs = set(env.update_json([]).keys())
 
+    @tier2
     def test_location(self):
         """@Test: Update an environment. Inspect the server's response.
 
@@ -102,6 +106,7 @@ class MissingAttrTestCase(APITestCase):
             'None of {0} are in {1}'.format(names, self.env_attrs),
         )
 
+    @tier2
     def test_organization(self):
         """@Test: Update an environment. Inspect the server's response.
 

--- a/tests/foreman/api/test_filter.py
+++ b/tests/foreman/api/test_filter.py
@@ -6,6 +6,7 @@ http://theforeman.org/api/apidoc/v2/filters.html
 """
 from nailgun import entities
 from requests.exceptions import HTTPError
+from robottelo.decorators import tier1
 from robottelo.test import APITestCase
 
 
@@ -20,6 +21,7 @@ class FilterTestCase(APITestCase):
             entities.Permission(resource_type='ConfigTemplate').search()
         )
 
+    @tier1
     def test_create_filter_with_perms(self):
         """@Test: Create a filter and assign it some permissions.
 
@@ -35,6 +37,7 @@ class FilterTestCase(APITestCase):
             [perm.id for perm in self.ct_perms],
         )
 
+    @tier1
     def test_directly_delete_filter(self):
         """@Test: Create a filter and delete it.
 
@@ -48,6 +51,7 @@ class FilterTestCase(APITestCase):
         with self.assertRaises(HTTPError):
             filter_.read()
 
+    @tier1
     def test_implicitly_delete_filter(self):
         """@Test: Create a filter and delete the role it points at.
 

--- a/tests/foreman/api/test_foremantask.py
+++ b/tests/foreman/api/test_foremantask.py
@@ -1,13 +1,14 @@
 """Unit tests for the ``foreman_tasks/api/v2/tasks`` paths."""
 from nailgun import entities
 from requests.exceptions import HTTPError
-from robottelo.decorators import run_only_on, skip_if_bug_open
+from robottelo.decorators import run_only_on, skip_if_bug_open, tier1
 from robottelo.test import APITestCase
 
 
 class ForemanTasksIdTestCase(APITestCase):
     """Tests for the ``foreman_tasks/api/v2/tasks/:id`` path."""
 
+    @tier1
     @run_only_on('sat')
     @skip_if_bug_open('bugzilla', 1131702)
     def test_no_such_task(self):
@@ -23,6 +24,7 @@ class ForemanTasksIdTestCase(APITestCase):
         with self.assertRaises(HTTPError):
             entities.ForemanTask(id='abc123').read()
 
+    @tier1
     @run_only_on('sat')
     def test_summary(self):
         """@Test: Get a summary of foreman tasks.

--- a/tests/foreman/api/test_gpgkey.py
+++ b/tests/foreman/api/test_gpgkey.py
@@ -1,12 +1,13 @@
 """Unit tests for the ``gpgkeys`` paths."""
 from nailgun import entities
-from robottelo.decorators import run_only_on
+from robottelo.decorators import run_only_on, tier1
 from robottelo.test import APITestCase
 
 
 class GPGKeyTestCase(APITestCase):
     """Tests for ``katello/api/v2/gpg_keys``."""
 
+    @tier1
     @run_only_on('sat')
     def test_get_all(self):
         """@Test: Search for a GPG key and specify just ``organization_id``.

--- a/tests/foreman/api/test_host.py
+++ b/tests/foreman/api/test_host.py
@@ -8,7 +8,7 @@ http://theforeman.org/api/apidoc/v2/hosts.html
 from fauxfactory import gen_integer, gen_string
 from nailgun import client, entities
 from robottelo.config import settings
-from robottelo.decorators import bz_bug_is_open, run_only_on
+from robottelo.decorators import bz_bug_is_open, run_only_on, tier1
 from robottelo.test import APITestCase
 from six.moves import http_client
 
@@ -16,6 +16,7 @@ from six.moves import http_client
 class HostsTestCase(APITestCase):
     """Tests for ``entities.Host().path()``."""
 
+    @tier1
     @run_only_on('sat')
     def test_get_search(self):
         """@Test: GET ``api/v2/hosts`` and specify the ``search`` parameter.
@@ -35,6 +36,7 @@ class HostsTestCase(APITestCase):
         self.assertEqual(response.status_code, http_client.OK)
         self.assertEqual(response.json()['search'], query)
 
+    @tier1
     @run_only_on('sat')
     def test_get_per_page(self):
         """@Test: GET ``api/v2/hosts`` and specify the ``per_page`` parameter.
@@ -54,6 +56,7 @@ class HostsTestCase(APITestCase):
         self.assertEqual(response.status_code, http_client.OK)
         self.assertEqual(response.json()['per_page'], per_page)
 
+    @tier1
     @run_only_on('sat')
     def test_create_owner_type(self):
         """@Test: Create a host and specify an ``owner_type``.
@@ -74,6 +77,7 @@ class HostsTestCase(APITestCase):
                 host = host.create(create_missing=False)
                 self.assertEqual(host.owner_type, owner_type)
 
+    @tier1
     @run_only_on('sat')
     def test_update_owner_type(self):
         """@Test: Update a host's ``owner_type``.

--- a/tests/foreman/api/test_hostcollection.py
+++ b/tests/foreman/api/test_hostcollection.py
@@ -1,6 +1,6 @@
 """Unit tests for host collections."""
 from nailgun import entities
-from robottelo.decorators import skip_if_bug_open
+from robottelo.decorators import skip_if_bug_open, tier1
 from robottelo.test import APITestCase
 
 
@@ -18,6 +18,7 @@ class HostCollectionTestCase(APITestCase):
             in range(2)
         ]
 
+    @tier1
     def test_create_with_system(self):
         """@Test: Create a host collection that contains a content host.
 
@@ -33,6 +34,7 @@ class HostCollectionTestCase(APITestCase):
         ).create()
         self.assertEqual(len(host_collection.system), 1)
 
+    @tier1
     def test_create_with_systems(self):
         """@Test: Create a host collection that contains content hosts.
 
@@ -48,6 +50,7 @@ class HostCollectionTestCase(APITestCase):
         ).create()
         self.assertEqual(len(host_collection.system), len(self.systems))
 
+    @tier1
     @skip_if_bug_open('bugzilla', 1203323)
     def test_read_system_ids(self):
         """@Test: Read a host collection and look at the ``system_ids`` field.

--- a/tests/foreman/api/test_hostgroup.py
+++ b/tests/foreman/api/test_hostgroup.py
@@ -5,7 +5,7 @@ from nailgun import client, entities, entity_fields
 from robottelo.api.utils import promote, one_to_one_names
 from robottelo.config import settings
 from robottelo.constants import PUPPET_MODULE_NTP_PUPPETLABS
-from robottelo.decorators import skip_if_bug_open, stubbed
+from robottelo.decorators import skip_if_bug_open, stubbed, tier1, tier3
 from robottelo.helpers import get_data_file
 from robottelo.test import APITestCase
 
@@ -13,6 +13,7 @@ from robottelo.test import APITestCase
 class HostGroupTestCase(APITestCase):
     """Tests for host group entity."""
 
+    @tier3
     @skip_if_bug_open('bugzilla', 1222118)
     def test_bz_1107708(self):
         """@Test: Host that created from HostGroup entity with PuppetClass
@@ -167,6 +168,7 @@ class MissingAttrTestCase(APITestCase):
         host_group = entities.HostGroup().create()
         cls.host_group_attrs = set(host_group.read_json().keys())
 
+    @tier1
     def test_get_content_source(self):
         """@Test: Read a host group. Inspect the server's response.
 
@@ -183,6 +185,7 @@ class MissingAttrTestCase(APITestCase):
             'None of {0} are in {1}'.format(names, self.host_group_attrs)
         )
 
+    @tier1
     def test_get_content_view(self):
         """@Test: Read a host group. Inspect the server's response.
 
@@ -199,6 +202,7 @@ class MissingAttrTestCase(APITestCase):
             'None of {0} are in {1}'.format(names, self.host_group_attrs)
         )
 
+    @tier1
     def test_get_lifecycle_environment(self):
         """@Test: Read a host group. Inspect the server's response.
 

--- a/tests/foreman/api/test_lifecycleenvironment.py
+++ b/tests/foreman/api/test_lifecycleenvironment.py
@@ -9,7 +9,7 @@ from nailgun import entities
 from requests.exceptions import HTTPError
 from robottelo.constants import ENVIRONMENT
 from robottelo.datafactory import invalid_values_list, valid_data_list
-from robottelo.decorators import run_only_on
+from robottelo.decorators import run_only_on, tier1, tier2
 from robottelo.test import APITestCase
 
 
@@ -22,6 +22,7 @@ class LifecycleEnvironmentTestCase(APITestCase):
         super(LifecycleEnvironmentTestCase, cls).setUpClass()
         cls.org = entities.Organization().create()
 
+    @tier1
     @run_only_on('sat')
     def test_positive_create_different_names(self):
         """@Test: Create lifecycle environment with valid name only
@@ -39,6 +40,7 @@ class LifecycleEnvironmentTestCase(APITestCase):
                 ).create()
                 self.assertEqual(lc_env.name, name)
 
+    @tier2
     @run_only_on('sat')
     def test_positive_create_description(self):
         """@Test: Create lifecycle environment with valid description
@@ -55,6 +57,7 @@ class LifecycleEnvironmentTestCase(APITestCase):
         ).create()
         self.assertEqual(lc_env.description, description)
 
+    @tier1
     @run_only_on('sat')
     def test_positive_create_prior(self):
         """@Test: Create lifecycle environment with valid name, prior to
@@ -70,6 +73,7 @@ class LifecycleEnvironmentTestCase(APITestCase):
         ).create()
         self.assertEqual(lc_env.prior.read().name, ENVIRONMENT)
 
+    @tier1
     @run_only_on('sat')
     def test_negative_create_different_names(self):
         """@Test: Create lifecycle environment providing an invalid name
@@ -84,6 +88,7 @@ class LifecycleEnvironmentTestCase(APITestCase):
                 with self.assertRaises(HTTPError):
                     entities.LifecycleEnvironment(name=name).create()
 
+    @tier1
     @run_only_on('sat')
     def test_positive_update_different_names(self):
         """@Test: Create lifecycle environment providing the initial name, then
@@ -101,6 +106,7 @@ class LifecycleEnvironmentTestCase(APITestCase):
                     id=lc_env.id, name=new_name).update(['name'])
                 self.assertEqual(lc_env.name, new_name)
 
+    @tier2
     @run_only_on('sat')
     def test_positive_update_description(self):
         """@Test: Create lifecycle environment providing the initial
@@ -120,6 +126,7 @@ class LifecycleEnvironmentTestCase(APITestCase):
             id=lc_env.id, description=new_description).update(['description'])
         self.assertEqual(lc_env.description, new_description)
 
+    @tier1
     @run_only_on('sat')
     def test_negative_update_different_names(self):
         """@Test: Update lifecycle environment providing an invalid name
@@ -142,6 +149,7 @@ class LifecycleEnvironmentTestCase(APITestCase):
                         id=lc_env.id, name=new_name).update(['name'])
                     self.assertEqual(lc_env.read().name, name)
 
+    @tier1
     @run_only_on('sat')
     def test_positive_delete(self):
         """@Test: Create lifecycle environment and then delete it.
@@ -156,6 +164,7 @@ class LifecycleEnvironmentTestCase(APITestCase):
         with self.assertRaises(HTTPError):
             lc_env.read()
 
+    @tier2
     @run_only_on('sat')
     def test_get_all(self):
         """@Test: Search for a lifecycle environment and specify an org ID.

--- a/tests/foreman/api/test_location.py
+++ b/tests/foreman/api/test_location.py
@@ -8,6 +8,7 @@ from fauxfactory import gen_integer, gen_string
 from nailgun import entities
 from random import randint
 from requests.exceptions import HTTPError
+from robottelo.decorators import tier1, tier2
 from robottelo.datafactory import invalid_values_list
 from robottelo.test import APITestCase
 
@@ -35,6 +36,7 @@ class LocationTestCase(APITestCase):
     """Tests for the ``locations`` path."""
     # TODO Add coverage for media, smart_proxy, realms once they implemented
 
+    @tier1
     def test_create_loc_diff_names(self):
         """@Test: Create new locations using different inputs as a name
 
@@ -49,6 +51,7 @@ class LocationTestCase(APITestCase):
                 location = entities.Location(name=name).create()
                 self.assertEqual(location.name, name)
 
+    @tier2
     def test_create_loc_with_desc(self):
         """@Test: Create new location with custom description
 
@@ -62,6 +65,7 @@ class LocationTestCase(APITestCase):
         location = entities.Location(description=description).create()
         self.assertEqual(location.description, description)
 
+    @tier2
     def test_create_loc_with_user(self):
         """@Test: Create new location with assigned user to it
 
@@ -76,6 +80,7 @@ class LocationTestCase(APITestCase):
         self.assertEqual(location.user[0].id, user.id)
         self.assertEqual(location.user[0].read().login, user.login)
 
+    @tier2
     def test_create_loc_libvirt_cr(self):
         """@Test: Create new location with Libvirt compute resource assigned to
         it
@@ -92,6 +97,7 @@ class LocationTestCase(APITestCase):
         self.assertEqual(
             location.compute_resource[0].read().provider, 'Libvirt')
 
+    @tier2
     def test_create_loc_docker_cr(self):
         """@Test: Create new location with Docker compute resource assigned to
         it
@@ -108,6 +114,7 @@ class LocationTestCase(APITestCase):
         self.assertEqual(
             location.compute_resource[0].read().provider, 'Docker')
 
+    @tier2
     def test_create_loc_with_template(self):
         """@Test: Create new location with config template assigned to it
 
@@ -125,6 +132,7 @@ class LocationTestCase(APITestCase):
             []
         )
 
+    @tier2
     def test_create_loc_with_domain(self):
         """@Test: Create new location with assigned domain to it
 
@@ -138,6 +146,7 @@ class LocationTestCase(APITestCase):
         location = entities.Location(domain=[domain]).create()
         self.assertEqual(location.domain[0].id, domain.id)
 
+    @tier2
     def test_create_loc_with_subnet(self):
         """@Test: Create new location with assigned subnet to it
 
@@ -152,6 +161,7 @@ class LocationTestCase(APITestCase):
         self.assertEqual(location.subnet[0].id, subnet.id)
         self.assertEqual(subnet.network, location.subnet[0].read().network)
 
+    @tier2
     def test_create_loc_with_env(self):
         """@Test: Create new location with assigned environment to it
 
@@ -165,6 +175,7 @@ class LocationTestCase(APITestCase):
         location = entities.Location(environment=[env]).create()
         self.assertEqual(location.environment[0].id, env.id)
 
+    @tier2
     def test_create_loc_with_host_group(self):
         """@Test: Create new location with assigned host group to it
 
@@ -178,6 +189,7 @@ class LocationTestCase(APITestCase):
         location = entities.Location(hostgroup=[host_group]).create()
         self.assertEqual(location.hostgroup[0].id, host_group.id)
 
+    @tier2
     def test_create_loc_with_org(self):
         """@Test: Create new location with assigned organization to it
 
@@ -192,6 +204,7 @@ class LocationTestCase(APITestCase):
         self.assertEqual(location.organization[0].id, org.id)
         self.assertEqual(location.organization[0].read().title, org.title)
 
+    @tier2
     def test_create_loc_multiple_org(self):
         """@Test: Basically, verifying that location with multiple entities
         assigned to it can be created in the system. Organizations were chosen
@@ -212,6 +225,7 @@ class LocationTestCase(APITestCase):
         for org in location.organization:
             self.assertIn(org.id, org_ids)
 
+    @tier1
     def test_delete_location(self):
         """@Test: Delete location
 
@@ -225,6 +239,7 @@ class LocationTestCase(APITestCase):
         with self.assertRaises(HTTPError):
             location.read()
 
+    @tier1
     def test_update_loc_name(self):
         """@Test: Update location with new name
 
@@ -239,6 +254,7 @@ class LocationTestCase(APITestCase):
                 location.name = new_name
                 self.assertEqual(location.update(['name']).name, new_name)
 
+    @tier2
     def test_update_loc_desc(self):
         """@Test: Update location with new description
 
@@ -256,6 +272,7 @@ class LocationTestCase(APITestCase):
                     new_description
                 )
 
+    @tier2
     def test_update_loc_user(self):
         """@Test: Update location with new user
 
@@ -269,6 +286,7 @@ class LocationTestCase(APITestCase):
         location.user = [new_user]
         self.assertEqual(location.update(['user']).user[0].id, new_user.id)
 
+    @tier2
     def test_update_loc_libvirt_cr(self):
         """@Test: Update location with new Libvirt compute resource
 
@@ -290,6 +308,7 @@ class LocationTestCase(APITestCase):
         self.assertEqual(
             location.compute_resource[0].read().provider, 'Libvirt')
 
+    @tier2
     def test_update_loc_docker_cr(self):
         """@Test: Update location with new Docker compute resource
 
@@ -311,6 +330,7 @@ class LocationTestCase(APITestCase):
         self.assertEqual(
             location.compute_resource[0].read().provider, 'Docker')
 
+    @tier2
     def test_update_loc_template(self):
         """@Test: Update location with new config template
 
@@ -333,6 +353,7 @@ class LocationTestCase(APITestCase):
         ]
         self.assertEqual(len(ct_list), 1)
 
+    @tier2
     def test_update_loc_domain(self):
         """@Test: Update location with new domain
 
@@ -348,6 +369,7 @@ class LocationTestCase(APITestCase):
         location.domain = [domain]
         self.assertEqual(location.update(['domain']).domain[0].id, domain.id)
 
+    @tier2
     def test_update_loc_subnet(self):
         """@Test: Update location with new subnet
 
@@ -363,6 +385,7 @@ class LocationTestCase(APITestCase):
         location.subnet = [subnet]
         self.assertEqual(location.update(['subnet']).subnet[0].id, subnet.id)
 
+    @tier2
     def test_update_loc_env(self):
         """@Test: Update location with new environment
 
@@ -382,6 +405,7 @@ class LocationTestCase(APITestCase):
             env.id
         )
 
+    @tier2
     def test_update_loc_hostgroup(self):
         """@Test: Update location with new host group
 
@@ -401,6 +425,7 @@ class LocationTestCase(APITestCase):
             host_group.id
         )
 
+    @tier2
     def test_update_loc_org(self):
         """@Test: Update location with new organization
 
@@ -420,6 +445,7 @@ class LocationTestCase(APITestCase):
             org.id
         )
 
+    @tier2
     def test_update_loc_multiple_orgs(self):
         """@Test: Update location with with multiple organizations
 
@@ -440,6 +466,7 @@ class LocationTestCase(APITestCase):
             set([org.id for org in location.organization]),
         )
 
+    @tier1
     def test_update_loc_name_negative(self):
         """@Test: Try to update location using invalid names only
 
@@ -458,6 +485,7 @@ class LocationTestCase(APITestCase):
                         new_name
                     )
 
+    @tier2
     def test_update_loc_domain_negative(self):
         """@Test: Try to update existing location with incorrect domain. Use
         domain id

--- a/tests/foreman/api/test_media.py
+++ b/tests/foreman/api/test_media.py
@@ -5,7 +5,7 @@ from nailgun import entities
 from requests.exceptions import HTTPError
 from robottelo.constants import OPERATING_SYSTEMS
 from robottelo.datafactory import invalid_values_list, valid_data_list
-from robottelo.decorators import run_only_on
+from robottelo.decorators import run_only_on, tier1, tier2
 from robottelo.test import APITestCase
 
 
@@ -18,6 +18,7 @@ class MediaTestCase(APITestCase):
         super(MediaTestCase, cls).setUpClass()
         cls.org = entities.Organization().create()
 
+    @tier1
     @run_only_on('sat')
     def test_positive_create_different_names(self):
         """@Test: Create media with valid name only
@@ -35,6 +36,7 @@ class MediaTestCase(APITestCase):
                 ).create()
                 self.assertEqual(media.name, name)
 
+    @tier2
     @run_only_on('sat')
     def test_positive_create_different_os_family(self):
         """@Test: Create media with every OS family possible
@@ -52,6 +54,7 @@ class MediaTestCase(APITestCase):
                 ).create()
                 self.assertEqual(media.os_family, os_family)
 
+    @tier2
     @run_only_on('sat')
     def test_positive_create_with_location(self):
         """@Test: Create media entity assigned to non-default location
@@ -68,6 +71,7 @@ class MediaTestCase(APITestCase):
         ).create()
         self.assertEqual(media.location[0].read().name, location.name)
 
+    @tier2
     @run_only_on('sat')
     def test_positive_create_with_operating_system(self):
         """@Test: Create media entity assigned to operation system entity
@@ -84,6 +88,7 @@ class MediaTestCase(APITestCase):
         ).create()
         self.assertEqual(os.read().medium[0].read().name, media.name)
 
+    @tier1
     @run_only_on('sat')
     def test_negative_create_different_names(self):
         """@Test: Try to create media entity providing an invalid name
@@ -98,6 +103,7 @@ class MediaTestCase(APITestCase):
                 with self.assertRaises(HTTPError):
                     entities.Media(name=name).create()
 
+    @tier2
     @run_only_on('sat')
     def test_negative_create_with_wrong_url(self):
         """@Test: Try to create media entity providing an invalid URL
@@ -110,6 +116,7 @@ class MediaTestCase(APITestCase):
         with self.assertRaises(HTTPError):
             entities.Media(path_='NON_EXISTENT_URL').create()
 
+    @tier2
     @run_only_on('sat')
     def test_negative_create_with_wrong_os_family(self):
         """@Test: Try to create media entity providing an invalid OS family
@@ -122,6 +129,7 @@ class MediaTestCase(APITestCase):
         with self.assertRaises(HTTPError):
             entities.Media(os_family='NON_EXISTENT_OS').create()
 
+    @tier1
     @run_only_on('sat')
     def test_positive_update_different_names(self):
         """@Test: Create media entity providing the initial name, then update
@@ -139,6 +147,7 @@ class MediaTestCase(APITestCase):
                     id=media.id, name=new_name).update(['name'])
                 self.assertEqual(media.name, new_name)
 
+    @tier2
     @run_only_on('sat')
     def test_positive_update_url(self):
         """@Test: Create media entity providing the initial url path, then
@@ -154,6 +163,7 @@ class MediaTestCase(APITestCase):
         media = entities.Media(id=media.id, path_=new_url).update(['path_'])
         self.assertEqual(media.path_, new_url)
 
+    @tier2
     @run_only_on('sat')
     def test_positive_update_os_family(self):
         """@Test: Create media entity providing the initial os family, then
@@ -173,6 +183,7 @@ class MediaTestCase(APITestCase):
         media.os_family = new_os_family
         self.assertEqual(media.update(['os_family']).os_family, new_os_family)
 
+    @tier1
     @run_only_on('sat')
     def test_negative_update_different_names(self):
         """@Test: Create media entity providing the initial name, then try to
@@ -189,6 +200,7 @@ class MediaTestCase(APITestCase):
                 with self.assertRaises(HTTPError):
                     entities.Media(id=media.id, name=new_name).update(['name'])
 
+    @tier2
     @run_only_on('sat')
     def test_negative_update_with_wrong_url(self):
         """@Test: Try to update media with invalid url.
@@ -203,6 +215,7 @@ class MediaTestCase(APITestCase):
             entities.Media(
                 id=media.id, path_='NON_EXISTENT_URL').update(['path_'])
 
+    @tier2
     @run_only_on('sat')
     def test_negative_update_with_wrong_os_family(self):
         """@Test: Try to update media with invalid operation system.
@@ -217,6 +230,7 @@ class MediaTestCase(APITestCase):
             entities.Media(
                 id=media.id, os_family='NON_EXISTENT_OS').update(['os_family'])
 
+    @tier1
     @run_only_on('sat')
     def test_positive_delete(self):
         """@Test: Create new media entity and then delete it.

--- a/tests/foreman/api/test_multiple_paths.py
+++ b/tests/foreman/api/test_multiple_paths.py
@@ -4,7 +4,12 @@ import logging
 from nailgun import client, entities, entity_fields
 from requests.exceptions import HTTPError
 from robottelo.config import settings
-from robottelo.decorators import bz_bug_is_open, run_only_on, skip_if_bug_open
+from robottelo.decorators import (
+    bz_bug_is_open,
+    run_only_on,
+    skip_if_bug_open,
+    tier1,
+)
 from robottelo.helpers import get_nailgun_config
 from robottelo.test import APITestCase
 from six.moves import http_client
@@ -140,6 +145,7 @@ def skip_if_sam(self, entity):
 class EntityTestCase(APITestCase):
     """Issue HTTP requests to various ``entity/`` paths."""
 
+    @tier1
     def test_get_status_code(self):
         """@Test: GET an entity-dependent path.
 
@@ -174,6 +180,7 @@ class EntityTestCase(APITestCase):
                     response.headers['content-type']
                 )
 
+    @tier1
     def test_get_unauthorized(self):
         """@Test: GET an entity-dependent path without credentials.
 
@@ -197,6 +204,7 @@ class EntityTestCase(APITestCase):
                 self.assertEqual(
                     http_client.UNAUTHORIZED, response.status_code)
 
+    @tier1
     def test_post_status_code(self):
         """@Test: Issue a POST request and check the returned status code.
 
@@ -228,6 +236,7 @@ class EntityTestCase(APITestCase):
                     response.headers['content-type']
                 )
 
+    @tier1
     @skip_if_bug_open('bugzilla', 1122257)
     def test_post_unauthorized(self):
         """@Test: POST to an entity-dependent path without credentials.
@@ -255,6 +264,7 @@ class EntityTestCase(APITestCase):
 class EntityIdTestCase(APITestCase):
     """Issue HTTP requests to various ``entity/:id`` paths."""
 
+    @tier1
     def test_get_status_code(self):
         """@Test: Create an entity and GET it.
 
@@ -281,6 +291,7 @@ class EntityIdTestCase(APITestCase):
                     response.headers['content-type']
                 )
 
+    @tier1
     def test_put_status_code(self):
         """@Test Issue a PUT request and check the returned status code.
 
@@ -319,6 +330,7 @@ class EntityIdTestCase(APITestCase):
                     response.headers['content-type']
                 )
 
+    @tier1
     def test_delete_status_code(self):
         """@Test Issue an HTTP DELETE request and check the returned status
         code.
@@ -376,6 +388,7 @@ class DoubleCheckTestCase(APITestCase):
     """
     longMessage = True
 
+    @tier1
     def test_put_and_get(self):
         """@Test: Update an entity, then read it back.
 
@@ -418,6 +431,7 @@ class DoubleCheckTestCase(APITestCase):
                     self.assertIn(key, entity_attrs.keys())
                     self.assertEqual(value, entity_attrs[key], key)
 
+    @tier1
     def test_post_and_get(self):
         """@Test: Create an entity, then read it back.
 
@@ -448,6 +462,7 @@ class DoubleCheckTestCase(APITestCase):
                     self.assertIn(key, entity_attrs.keys())
                     self.assertEqual(value, entity_attrs[key], key)
 
+    @tier1
     def test_delete_and_get(self):
         """@Test: Issue an HTTP DELETE request and GET the deleted entity.
 
@@ -491,6 +506,7 @@ class EntityReadTestCase(APITestCase):
     Check that classes inheriting from
     ``nailgun.entity_mixins.EntityReadMixin`` function correctly.
     """
+    @tier1
     def test_entity_read(self):
         """@Test: Create an entity and get it using
         ``nailgun.entity_mixins.EntityReadMixin.read``.
@@ -517,6 +533,7 @@ class EntityReadTestCase(APITestCase):
                     entity_cls
                 )
 
+    @tier1
     def test_architecture_read(self):
         """@Test: Create an arch that points to an OS, and read the arch.
 
@@ -534,6 +551,7 @@ class EntityReadTestCase(APITestCase):
         self.assertEqual(len(architecture.operatingsystem), 1)
         self.assertEqual(architecture.operatingsystem[0].id, os_id)
 
+    @tier1
     def test_syncplan_read(self):
         """@Test: Create a SyncPlan and read it back using
         ``nailgun.entity_mixins.EntityReadMixin.read``.
@@ -552,6 +570,7 @@ class EntityReadTestCase(APITestCase):
             entities.SyncPlan
         )
 
+    @tier1
     @run_only_on('sat')
     def test_osparameter_read(self):
         """@Test: Create an OperatingSystemParameter and get it using
@@ -574,6 +593,7 @@ class EntityReadTestCase(APITestCase):
             entities.OperatingSystemParameter
         )
 
+    @tier1
     @run_only_on('sat')
     def test_permission_read(self):
         """@Test: Create an Permission entity and get it using
@@ -589,6 +609,7 @@ class EntityReadTestCase(APITestCase):
         self.assertGreater(len(perm.name), 0)
         self.assertGreater(len(perm.resource_type), 0)
 
+    @tier1
     def test_media_read(self):
         """@Test: Create a media pointing at an OS and read the media.
 

--- a/tests/foreman/api/test_operatingsystem.py
+++ b/tests/foreman/api/test_operatingsystem.py
@@ -12,7 +12,7 @@ from nailgun import entities
 from requests.exceptions import HTTPError
 from robottelo.constants import OPERATING_SYSTEMS
 from robottelo.datafactory import invalid_values_list, valid_data_list
-from robottelo.decorators import run_only_on, skip_if_bug_open
+from robottelo.decorators import run_only_on, skip_if_bug_open, tier1, tier2
 from robottelo.test import APITestCase
 from six.moves.http_client import NOT_FOUND
 
@@ -20,6 +20,7 @@ from six.moves.http_client import NOT_FOUND
 class OSParameterTestCase(APITestCase):
     """Tests for operating system parameters."""
 
+    @tier1
     @run_only_on('sat')
     def test_bz_1114640(self):
         """@Test: Create a parameter for operating system 1.
@@ -59,6 +60,7 @@ class OSTestCase(APITestCase):
         super(OSTestCase, cls).setUpClass()
         cls.org = entities.Organization().create()
 
+    @tier1
     @run_only_on('sat')
     def test_positive_create_different_names(self):
         """@Test: Create operating system with valid name only
@@ -72,6 +74,7 @@ class OSTestCase(APITestCase):
                 os = entities.OperatingSystem(name=name).create()
                 self.assertEqual(os.name, name)
 
+    @tier1
     @run_only_on('sat')
     def test_positive_create_different_os_family(self):
         """@Test: Create operating system with every OS family possible
@@ -86,6 +89,7 @@ class OSTestCase(APITestCase):
                 os = entities.OperatingSystem(family=os_family).create()
                 self.assertEqual(os.family, os_family)
 
+    @tier1
     @run_only_on('sat')
     def test_positive_create_with_minor(self):
         """@Test: Create operating system with minor version
@@ -99,6 +103,7 @@ class OSTestCase(APITestCase):
         os = entities.OperatingSystem(minor=minor_version).create()
         self.assertEqual(os.minor, minor_version)
 
+    @tier1
     @run_only_on('sat')
     @skip_if_bug_open('bugzilla', 1230902)
     def test_create_with_minor_1230902(self):
@@ -112,6 +117,7 @@ class OSTestCase(APITestCase):
         operating_sys = entities.OperatingSystem(minor=minor).create()
         self.assertEqual(operating_sys.minor, str(minor))
 
+    @tier1
     @run_only_on('sat')
     def test_positive_create_with_description(self):
         """@Test: Create operating system with description
@@ -128,6 +134,7 @@ class OSTestCase(APITestCase):
                 self.assertEqual(os.name, name)
                 self.assertEqual(os.description, desc)
 
+    @tier1
     @run_only_on('sat')
     def test_positive_create_with_hash(self):
         """@Test: Create operating system with valid password hash option
@@ -142,6 +149,7 @@ class OSTestCase(APITestCase):
                 os = entities.OperatingSystem(password_hash=pass_hash).create()
                 self.assertEqual(os.password_hash, pass_hash)
 
+    @tier2
     @run_only_on('sat')
     def test_positive_create_with_arch(self):
         """@Test: Create an operating system that points at an architecture.
@@ -156,6 +164,7 @@ class OSTestCase(APITestCase):
         self.assertEqual(len(operating_sys.architecture), 1)
         self.assertEqual(operating_sys.architecture[0].id, arch.id)
 
+    @tier2
     @run_only_on('sat')
     def test_positive_create_with_multiple_archs(self):
         """@Test: Create an operating system that points at multiple different
@@ -175,6 +184,7 @@ class OSTestCase(APITestCase):
             set([arch.id for arch in archs])
         )
 
+    @tier1
     @run_only_on('sat')
     def test_positive_create_with_ptable(self):
         """@Test: Create an operating system that points at a partition table.
@@ -189,6 +199,7 @@ class OSTestCase(APITestCase):
         self.assertEqual(len(operating_sys.ptable), 1)
         self.assertEqual(operating_sys.ptable[0].id, ptable.id)
 
+    @tier1
     @run_only_on('sat')
     def test_positive_create_with_multiple_ptables(self):
         """@Test: Create an operating system that points at multiple different
@@ -208,6 +219,7 @@ class OSTestCase(APITestCase):
             set([ptable.id for ptable in ptables])
         )
 
+    @tier1
     @run_only_on('sat')
     def test_positive_create_with_media(self):
         """@Test: Create an operating system that points at a media.
@@ -221,6 +233,7 @@ class OSTestCase(APITestCase):
         self.assertEqual(len(operating_sys.medium), 1)
         self.assertEqual(operating_sys.medium[0].id, medium.id)
 
+    @tier1
     @run_only_on('sat')
     def test_positive_create_with_template(self):
         """@Test: Create an operating system that points at a config template.
@@ -236,6 +249,7 @@ class OSTestCase(APITestCase):
         self.assertEqual(len(operating_sys.config_template), 1)
         self.assertEqual(operating_sys.config_template[0].id, template.id)
 
+    @tier1
     @run_only_on('sat')
     def test_negative_create_different_names(self):
         """@Test: Try to create operating system entity providing an invalid
@@ -250,6 +264,7 @@ class OSTestCase(APITestCase):
                 with self.assertRaises(HTTPError):
                     entities.OperatingSystem(name=name).create()
 
+    @tier1
     @run_only_on('sat')
     def test_negative_create_os_family(self):
         """@Test: Try to create operating system entity providing an invalid
@@ -262,6 +277,7 @@ class OSTestCase(APITestCase):
         with self.assertRaises(HTTPError):
             entities.OperatingSystem(family='NON_EXISTENT_OS').create()
 
+    @tier1
     @run_only_on('sat')
     def test_negative_create_with_too_long_description(self):
         """@Test: Try to create operating system entity providing too long
@@ -275,6 +291,7 @@ class OSTestCase(APITestCase):
             entities.OperatingSystem(
                 description=gen_string('alphanumeric', 256)).create()
 
+    @tier1
     @run_only_on('sat')
     def test_negative_create_with_wrong_major_version(self):
         """@Test: Try to create operating system entity providing incorrect
@@ -290,6 +307,7 @@ class OSTestCase(APITestCase):
                 with self.assertRaises(HTTPError):
                     entities.OperatingSystem(major=major_version).create()
 
+    @tier1
     @run_only_on('sat')
     def test_negative_create_with_wrong_minor_version(self):
         """@Test: Try to create operating system entity providing incorrect
@@ -304,6 +322,7 @@ class OSTestCase(APITestCase):
                 with self.assertRaises(HTTPError):
                     entities.OperatingSystem(minor=minor_version).create()
 
+    @tier1
     @run_only_on('sat')
     def test_negative_create_with_wrong_hash(self):
         """@Test: Try to create operating system entity providing invalid
@@ -316,6 +335,7 @@ class OSTestCase(APITestCase):
         with self.assertRaises(HTTPError):
             entities.OperatingSystem(password_hash='INVALID_HASH').create()
 
+    @tier1
     @run_only_on('sat')
     def test_negative_create_with_same_name_and_version(self):
         """@Test: Create operating system providing valid name and major
@@ -330,6 +350,7 @@ class OSTestCase(APITestCase):
         with self.assertRaises(HTTPError):
             entities.OperatingSystem(name=os.name, major=os.major).create()
 
+    @tier1
     @run_only_on('sat')
     def test_positive_update_different_names(self):
         """@Test: Create operating system entity providing the initial name,
@@ -346,6 +367,7 @@ class OSTestCase(APITestCase):
                     id=os.id, name=new_name).update(['name'])
                 self.assertEqual(os.name, new_name)
 
+    @tier1
     @run_only_on('sat')
     def test_positive_update_description(self):
         """@Test: Create operating entity providing the initial description,
@@ -362,6 +384,7 @@ class OSTestCase(APITestCase):
                     id=os.id, description=new_desc).update(['description'])
                 self.assertEqual(os.description, new_desc)
 
+    @tier1
     @run_only_on('sat')
     def test_positive_update_major_version(self):
         """@Test: Create operating entity providing the initial major version,
@@ -377,6 +400,7 @@ class OSTestCase(APITestCase):
             id=os.id, major=new_major_version).update(['major'])
         self.assertEqual(os.major, new_major_version)
 
+    @tier1
     @run_only_on('sat')
     def test_positive_update_minor_version(self):
         """@Test: Create operating entity providing the initial minor version,
@@ -392,6 +416,7 @@ class OSTestCase(APITestCase):
             id=os.id, minor=new_minor_version).update(['minor'])
         self.assertEqual(os.minor, new_minor_version)
 
+    @tier1
     @run_only_on('sat')
     def test_positive_update_os_family(self):
         """@Test: Create operating entity providing the initial os family, then
@@ -408,6 +433,7 @@ class OSTestCase(APITestCase):
             id=os.id, family=new_os_family).update(['family'])
         self.assertEqual(os.family, new_os_family)
 
+    @tier1
     @run_only_on('sat')
     def test_positive_update_with_arch(self):
         """@Test: Create an operating system that points at an architecture and
@@ -428,6 +454,7 @@ class OSTestCase(APITestCase):
         self.assertEqual(len(os.architecture), 1)
         self.assertEqual(os.architecture[0].id, arch_2.id)
 
+    @tier1
     @run_only_on('sat')
     def test_positive_update_with_ptable(self):
         """@Test: Create an operating system that points at partition table and
@@ -448,6 +475,7 @@ class OSTestCase(APITestCase):
         self.assertEqual(len(os.ptable), 1)
         self.assertEqual(os.ptable[0].id, ptable_2.id)
 
+    @tier1
     @run_only_on('sat')
     def test_positive_update_with_media(self):
         """@Test: Create an operating system that points at media entity and
@@ -468,6 +496,7 @@ class OSTestCase(APITestCase):
         self.assertEqual(len(os.medium), 1)
         self.assertEqual(os.medium[0].id, media_2.id)
 
+    @tier1
     @run_only_on('sat')
     def test_positive_update_with_multiple_medias(self):
         """@Test: Create an operating system that points at media entity and
@@ -492,6 +521,7 @@ class OSTestCase(APITestCase):
             set([medium.id for medium in medias])
         )
 
+    @tier1
     @run_only_on('sat')
     def test_positive_update_with_template(self):
         """@Test: Create an operating system that points at config template and
@@ -512,6 +542,7 @@ class OSTestCase(APITestCase):
         self.assertEqual(len(os.config_template), 1)
         self.assertEqual(os.config_template[0].id, template_2.id)
 
+    @tier1
     @run_only_on('sat')
     def test_negative_update_different_names(self):
         """@Test: Create operating system entity providing the initial name,
@@ -528,6 +559,7 @@ class OSTestCase(APITestCase):
                     os = entities.OperatingSystem(
                         id=os.id, name=new_name).update(['name'])
 
+    @tier1
     @run_only_on('sat')
     def test_negative_update_major_version(self):
         """@Test: Create operating entity providing the initial major version,
@@ -541,6 +573,7 @@ class OSTestCase(APITestCase):
         with self.assertRaises(HTTPError):
             entities.OperatingSystem(id=os.id, major='-20').update(['major'])
 
+    @tier1
     @run_only_on('sat')
     def test_negative_update_minor_version(self):
         """@Test: Create operating entity providing the initial minor version,
@@ -555,6 +588,7 @@ class OSTestCase(APITestCase):
             entities.OperatingSystem(
                 id=os.id, minor='INVALID_VERSION').update(['minor'])
 
+    @tier1
     @run_only_on('sat')
     def test_negative_update_os_family(self):
         """@Test: Create operating entity providing the initial os family, then
@@ -569,6 +603,7 @@ class OSTestCase(APITestCase):
             entities.OperatingSystem(
                 id=os.id, family='NON_EXISTENT_OS').update(['family'])
 
+    @tier1
     @run_only_on('sat')
     def test_positive_delete(self):
         """@Test: Create new operating system entity and then delete it.

--- a/tests/foreman/api/test_organization.py
+++ b/tests/foreman/api/test_organization.py
@@ -11,7 +11,7 @@ from random import randint
 from requests.exceptions import HTTPError
 from robottelo.config import settings
 from robottelo.datafactory import invalid_values_list
-from robottelo.decorators import skip_if_bug_open
+from robottelo.decorators import skip_if_bug_open, tier1, tier2
 from robottelo.helpers import get_nailgun_config
 from robottelo.test import APITestCase
 from six.moves import http_client
@@ -39,6 +39,7 @@ def valid_org_data_list():
 class OrganizationTestCase(APITestCase):
     """Tests for the ``organizations`` path."""
 
+    @tier1
     def test_create_text_plain(self):
         """@Test Create an organization using a 'text/plain' content-type.
 
@@ -59,6 +60,7 @@ class OrganizationTestCase(APITestCase):
         self.assertEqual(
             http_client.UNSUPPORTED_MEDIA_TYPE, response.status_code)
 
+    @tier1
     def test_positive_create_1(self):
         """@Test: Create an organization and provide a name.
 
@@ -72,6 +74,7 @@ class OrganizationTestCase(APITestCase):
         self.assertTrue(hasattr(org, 'label'))
         self.assertIsInstance(org.label, type(u''))
 
+    @tier1
     def test_positive_create_2(self):
         """@Test: Create an org and provide a name and identical label.
 
@@ -89,6 +92,7 @@ class OrganizationTestCase(APITestCase):
         self.assertEqual(name_label, org.name)
         self.assertEqual(name_label, org.label)
 
+    @tier1
     def test_positive_create_3(self):
         """@Test: Create an organization and provide a name and label.
 
@@ -104,6 +108,7 @@ class OrganizationTestCase(APITestCase):
         self.assertEqual(name, org.name)
         self.assertEqual(label, org.label)
 
+    @tier1
     def test_positive_create_4(self):
         """@Test: Create an organization and provide a name and description.
 
@@ -127,6 +132,7 @@ class OrganizationTestCase(APITestCase):
                 self.assertIsInstance(org.label, type(u''))
                 self.assertGreater(len(org.label), 0)
 
+    @tier1
     def test_positive_create_5(self):
         """@Test: Create an org and provide a name, label and description.
 
@@ -144,6 +150,7 @@ class OrganizationTestCase(APITestCase):
         self.assertEqual(org.label, label)
         self.assertEqual(org.description, desc)
 
+    @tier1
     def test_negative_create_name(self):
         """@Test: Create an org with an incorrect name.
 
@@ -157,6 +164,7 @@ class OrganizationTestCase(APITestCase):
                 with self.assertRaises(HTTPError):
                     entities.Organization(name=name).create()
 
+    @tier1
     def test_negative_create_duplicate(self):
         """@Test: Create two organizations with identical names.
 
@@ -169,6 +177,7 @@ class OrganizationTestCase(APITestCase):
         with self.assertRaises(HTTPError):
             entities.Organization(name=name).create()
 
+    @tier1
     def test_positive_search(self):
         """@Test: Create an organization, then search for it by name.
 
@@ -195,6 +204,7 @@ class OrganizationUpdateTestCase(APITestCase):
         super(OrganizationUpdateTestCase, cls).setUpClass()
         cls.organization = entities.Organization().create()
 
+    @tier1
     def test_update_name(self):
         """@Test: Update an organization's name with valid values.
 
@@ -209,6 +219,7 @@ class OrganizationUpdateTestCase(APITestCase):
                 self.organization = self.organization.update(['name'])
                 self.assertEqual(self.organization.name, name)
 
+    @tier1
     def test_update_desc(self):
         """@Test: Update an organization's description with valid values.
 
@@ -223,6 +234,7 @@ class OrganizationUpdateTestCase(APITestCase):
                 self.organization = self.organization.update(['description'])
                 self.assertEqual(self.organization.description, desc)
 
+    @tier1
     def test_update_name_desc(self):
         """@Test: Update an organization with new name and description.
 
@@ -239,6 +251,7 @@ class OrganizationUpdateTestCase(APITestCase):
         self.assertEqual(self.organization.name, name)
         self.assertEqual(self.organization.description, desc)
 
+    @tier2
     def test_associate_with_user(self):
         """@Test: Update an organization, associate user with it.
 
@@ -253,6 +266,7 @@ class OrganizationUpdateTestCase(APITestCase):
         self.assertEqual(len(self.organization.user), 1)
         self.assertEqual(self.organization.user[0].id, user.id)
 
+    @tier2
     def test_associate_with_subnet(self):
         """@Test: Update an organization, associate subnet with it.
 
@@ -267,6 +281,7 @@ class OrganizationUpdateTestCase(APITestCase):
         self.assertEqual(len(self.organization.subnet), 1)
         self.assertEqual(self.organization.subnet[0].id, subnet.id)
 
+    @tier2
     @skip_if_bug_open('bugzilla', 1230865)
     def test_associate_with_media(self):
         """@Test: Update an organization and associate it with a media.
@@ -282,6 +297,7 @@ class OrganizationUpdateTestCase(APITestCase):
         self.assertEqual(len(self.organization.media), 1)
         self.assertEqual(self.organization.media[0].id, media.id)
 
+    @tier1
     def test_negative_update(self):
         """@Test: Update an organization's attributes with invalid values.
 
@@ -303,6 +319,7 @@ class OrganizationUpdateTestCase(APITestCase):
                         **attrs
                     ).update(attrs.keys())
 
+    @tier2
     @skip_if_bug_open('bugzilla', 1103157)
     def test_bugzilla_1103157(self):
         """@Test: Create organization and add two compute resources one by one

--- a/tests/foreman/api/test_partitiontable.py
+++ b/tests/foreman/api/test_partitiontable.py
@@ -14,7 +14,7 @@ from robottelo.datafactory import (
     invalid_values_list,
     valid_data_list,
 )
-from robottelo.decorators import skip_if_bug_open
+from robottelo.decorators import skip_if_bug_open, tier1, tier2
 from robottelo.test import APITestCase
 
 
@@ -34,6 +34,7 @@ class PartitionTableTestCase(APITestCase):
     """Tests for the ``ptables`` path."""
 
     @skip_if_bug_open('bugzilla', 1229384)
+    @tier1
     def test_bugzilla_1229384(self):
         """@Test: Create Partition table with 1 symbol in name
 
@@ -49,6 +50,7 @@ class PartitionTableTestCase(APITestCase):
                 ptable = entities.PartitionTable(name=name).create()
                 self.assertEqual(ptable.name, name)
 
+    @tier1
     def test_create_different_names(self):
         """@Test: Create new partition tables using different inputs as a name
 
@@ -62,6 +64,7 @@ class PartitionTableTestCase(APITestCase):
                 ptable = entities.PartitionTable(name=name).create()
                 self.assertEqual(ptable.name, name)
 
+    @tier2
     def test_create_different_layouts(self):
         """@Test: Create new partition tables using different inputs as a
         layout
@@ -76,6 +79,7 @@ class PartitionTableTestCase(APITestCase):
                 ptable = entities.PartitionTable(layout=layout).create()
                 self.assertEqual(ptable.layout, layout)
 
+    @tier2
     def test_create_with_os(self):
         """@Test: Create new partition table with random operating system
 
@@ -89,6 +93,7 @@ class PartitionTableTestCase(APITestCase):
         ptable = entities.PartitionTable(os_family=os_family).create()
         self.assertEqual(ptable.os_family, os_family)
 
+    @tier1
     def test_create_invalid_name(self):
         """@Test: Try to create partition table using invalid names only
 
@@ -102,6 +107,7 @@ class PartitionTableTestCase(APITestCase):
                 with self.assertRaises(HTTPError):
                     entities.PartitionTable(name=name).create()
 
+    @tier2
     def test_create_invalid_layout(self):
         """@Test: Try to create partition table with empty layout
 
@@ -115,6 +121,7 @@ class PartitionTableTestCase(APITestCase):
                 with self.assertRaises(HTTPError):
                     entities.PartitionTable(layout=layout).create()
 
+    @tier1
     def test_delete_ptable(self):
         """@Test: Delete partition table
 
@@ -128,6 +135,7 @@ class PartitionTableTestCase(APITestCase):
         with self.assertRaises(HTTPError):
             ptable.read()
 
+    @tier1
     def test_update_with_new_name(self):
         """@Test: Update partition tables with new name
 
@@ -142,6 +150,7 @@ class PartitionTableTestCase(APITestCase):
                 ptable.name = new_name
                 self.assertEqual(ptable.update(['name']).name, new_name)
 
+    @tier2
     def test_update_with_new_layout(self):
         """@Test: Update partition table with new layout
 
@@ -156,6 +165,7 @@ class PartitionTableTestCase(APITestCase):
                 ptable.layout = new_layout
                 self.assertEqual(ptable.update(['layout']).layout, new_layout)
 
+    @tier2
     def test_update_with_new_os(self):
         """@Test: Update partition table with new random operating system
 
@@ -172,6 +182,7 @@ class PartitionTableTestCase(APITestCase):
         ptable.os_family = new_os_family
         self.assertEqual(ptable.update(['os_family']).os_family, new_os_family)
 
+    @tier1
     def test_update_invalid_name(self):
         """@Test: Try to update partition table using invalid names only
 
@@ -187,6 +198,7 @@ class PartitionTableTestCase(APITestCase):
                 with self.assertRaises(HTTPError):
                     self.assertNotEqual(ptable.update(['name']).name, new_name)
 
+    @tier2
     def test_update_invalid_layout(self):
         """@Test: Try to update partition table with empty layout
 

--- a/tests/foreman/api/test_permission.py
+++ b/tests/foreman/api/test_permission.py
@@ -13,7 +13,7 @@ from itertools import chain
 from nailgun import entities
 from requests.exceptions import HTTPError
 from robottelo.constants import PERMISSIONS
-from robottelo.decorators import run_only_on
+from robottelo.decorators import run_only_on, tier1
 from robottelo.helpers import get_nailgun_config, get_server_software
 from robottelo.test import APITestCase
 
@@ -41,6 +41,7 @@ class PermissionsTestCase(APITestCase):
             chain.from_iterable(cls.permissions.values()))
 
     @run_only_on('sat')
+    @tier1
     def test_search_by_name(self):
         """@test: Search for a permission by name.
 
@@ -64,6 +65,7 @@ class PermissionsTestCase(APITestCase):
             self.fail(json.dumps(failures, indent=True, sort_keys=True))
 
     @run_only_on('sat')
+    @tier1
     def test_search_by_resource_type(self):
         """@test: Search for permissions by resource type.
 
@@ -95,6 +97,7 @@ class PermissionsTestCase(APITestCase):
             self.fail(json.dumps(failures, indent=True, sort_keys=True))
 
     @run_only_on('sat')
+    @tier1
     def test_search_permissions(self):
         """@test: search with no parameters return all permissions
 
@@ -201,6 +204,7 @@ class UserRoleTestCase(APITestCase):
         self.user.role = [role]
         self.user = self.user.update(['role'])
 
+    @tier1
     def test_create(self):
         """@Test: Check whether the "create_*" role has an effect.
 
@@ -220,6 +224,7 @@ class UserRoleTestCase(APITestCase):
                 entity_id = entity_cls(self.cfg).create_json()['id']
                 entity_cls(id=entity_id).read()  # As admin user.
 
+    @tier1
     def test_read(self):
         """@Test: Check whether the "view_*" role has an effect.
 
@@ -237,6 +242,7 @@ class UserRoleTestCase(APITestCase):
                 self.give_user_permission(_permission_name(entity_cls, 'read'))
                 entity_cls(self.cfg, id=entity_id).read()
 
+    @tier1
     def test_delete(self):
         """@Test: Check whether the "destroy_*" role has an effect.
 
@@ -258,6 +264,7 @@ class UserRoleTestCase(APITestCase):
                 with self.assertRaises(HTTPError):
                     entity.read()  # As admin user
 
+    @tier1
     def test_update(self):
         """@Test: Check whether the "edit_*" role has an effect.
 

--- a/tests/foreman/api/test_product.py
+++ b/tests/foreman/api/test_product.py
@@ -12,7 +12,7 @@ from robottelo import manifests
 from robottelo.api.utils import upload_manifest
 from robottelo.constants import PRDS, REPOSET, VALID_GPG_KEY_FILE
 from robottelo.datafactory import generate_strings_list
-from robottelo.decorators import run_only_on
+from robottelo.decorators import run_only_on, tier1, tier2
 from robottelo.helpers import read_data_file
 from robottelo.test import APITestCase
 
@@ -38,6 +38,7 @@ def valid_name_desc_list():
 class ProductsTestCase(APITestCase):
     """Tests for ``katello/api/v2/products``."""
 
+    @tier1
     @run_only_on('sat')
     def test_positive_create_1(self):
         """@Test: Create a product and provide a name or description.
@@ -53,6 +54,7 @@ class ProductsTestCase(APITestCase):
                 for name, value in attr.items():
                     self.assertEqual(getattr(product, name), value)
 
+    @tier2
     @run_only_on('sat')
     def test_positive_create_2(self):
         """@Test: Create a product and provide a GPG key.
@@ -86,6 +88,7 @@ class ProductUpdateTestCase(APITestCase):
         super(ProductUpdateTestCase, cls).setUpClass()
         cls.product = entities.Product().create()
 
+    @tier1
     @run_only_on('sat')
     def test_positive_update_1(self):
         """@Test: Update a product with a new name or description.
@@ -104,6 +107,7 @@ class ProductUpdateTestCase(APITestCase):
                     attrs.values()[0]
                 )
 
+    @tier1
     @run_only_on('sat')
     def test_positive_update_2(self):
         """@Test: Rename Product back to original name
@@ -133,6 +137,7 @@ class ProductUpdateTestCase(APITestCase):
 class RepositorySetsTestCase(APITestCase):
     """Tests for ``katello/api/v2/products/<product_id>/repository_sets``."""
 
+    @tier1
     @run_only_on('sat')
     def test_repositoryset_enable(self):
         """@Test: Enable repo from reposet
@@ -163,6 +168,7 @@ class RepositorySetsTestCase(APITestCase):
                 repo['substitutions']['releasever'] == '6Server')
         ][0])
 
+    @tier1
     @run_only_on('sat')
     def test_repositoryset_disable(self):
         """@Test: Disable repo from reposet

--- a/tests/foreman/api/test_puppetmodule.py
+++ b/tests/foreman/api/test_puppetmodule.py
@@ -1,7 +1,7 @@
 """Unit tests for the ``katello/api/v2/puppet_modules`` paths."""
 from nailgun import entities
 from robottelo.constants import PUPPET_MODULE_NTP_PUPPETLABS
-from robottelo.decorators import skip_if_bug_open
+from robottelo.decorators import skip_if_bug_open, tier1
 from robottelo.helpers import get_data_file
 from robottelo.test import APITestCase
 
@@ -26,6 +26,7 @@ class RepositorySearchTestCase(APITestCase):
             product=self.product,
         ).create()
 
+    @tier1
     @skip_if_bug_open('bugzilla', 1260206)
     def test_0_search_results(self):
         """@Test: Search for puppet modules in an empty repository.
@@ -38,6 +39,7 @@ class RepositorySearchTestCase(APITestCase):
         query = {'repository_id': self.repository.id}
         self.assertEqual(len(entities.PuppetModule().search(query=query)), 0)
 
+    @tier1
     @skip_if_bug_open('bugzilla', 1260206)
     def test_1_search_result(self):
         """@Test: Search for puppet modules in a non-empty repository.
@@ -78,6 +80,7 @@ class CVVSearchTestCase(APITestCase):
             organization=self.product.organization,
         ).create()
 
+    @tier1
     def test_0_search_results(self):
         """@Test: Search for puppet modules in an emtpy content view version.
 
@@ -91,6 +94,7 @@ class CVVSearchTestCase(APITestCase):
         query = {'content_view_version_id': self.content_view.version[0].id}
         self.assertEqual(len(entities.PuppetModule().search(query=query)), 0)
 
+    @tier1
     def test_1_search_result(self):
         """@Test: Search for puppet modules in a CVV with one puppet module.
 

--- a/tests/foreman/api/test_repository.py
+++ b/tests/foreman/api/test_repository.py
@@ -21,6 +21,8 @@ from robottelo.decorators import (
     bz_bug_is_open,
     run_only_on,
     skip_if_bug_open,
+    tier1,
+    tier2,
 )
 from robottelo.helpers import (
     get_data_file,
@@ -68,6 +70,7 @@ class RepositoryTestCase(APITestCase):
         cls.org = entities.Organization().create()
         cls.product = entities.Product(organization=cls.org).create()
 
+    @tier1
     @run_only_on('sat')
     def test_create_attrs(self):
         """@Test: Create a repository and provide valid attributes.
@@ -88,6 +91,7 @@ class RepositoryTestCase(APITestCase):
                     self.assertIn(name, repo_attrs.keys())
                     self.assertEqual(value, repo_attrs[name])
 
+    @tier2
     @run_only_on('sat')
     def test_create_gpgkey(self):
         """@Test: Create a repository and provide a GPG key ID.
@@ -114,6 +118,7 @@ class RepositoryTestCase(APITestCase):
         # Verify that the given GPG key ID is used.
         self.assertEqual(gpg_key.id, repo.read().gpg_key.id)
 
+    @tier2
     @run_only_on('sat')
     def test_create_same_name(self):
         """@Test: Create two repos with the same name in two organizations.
@@ -129,6 +134,7 @@ class RepositoryTestCase(APITestCase):
         for repo in (repo1, repo2, repo1.read(), repo2.read()):
             self.assertEqual(repo.name, repo1.name)
 
+    @tier1
     @run_only_on('sat')
     def test_delete(self):
         """@Test: Create a repository with attributes ``attrs`` and delete it.
@@ -148,6 +154,7 @@ class RepositoryTestCase(APITestCase):
                 with self.assertRaises(HTTPError):
                     repo.read()
 
+    @tier2
     @run_only_on('sat')
     def test_update_gpgkey(self):
         """@Test: Create a repository and update its GPGKey
@@ -176,6 +183,7 @@ class RepositoryTestCase(APITestCase):
         repo = repo.update()
         self.assertEqual(repo.gpg_key.id, gpg_key_2.id)
 
+    @tier2
     @run_only_on('sat')
     def test_update_contents(self):
         """@Test: Create a repository and upload RPM contents.
@@ -192,6 +200,7 @@ class RepositoryTestCase(APITestCase):
         # Verify the repository's contents.
         self.assertEqual(repo.read_json()[u'content_counts'][u'rpm'], 1)
 
+    @tier2
     def test_sync(self):
         """@Test: Create a repo and sync it.
 
@@ -214,6 +223,7 @@ class RepositoryUpdateTestCase(APITestCase):
         super(RepositoryUpdateTestCase, cls).setUpClass()
         cls.repository = entities.Repository().create()
 
+    @tier1
     @run_only_on('sat')
     def test_update(self):
         """@Test: Create a repository and update its attributes.
@@ -248,6 +258,7 @@ class RepositoryUpdateTestCase(APITestCase):
 class RepositorySyncTestCase(APITestCase):
     """Tests for ``/katello/api/repositories/:id/sync``."""
 
+    @tier2
     @run_only_on('sat')
     def test_redhat_sync_1(self):
         """@Test: Sync RedHat Repository.
@@ -280,6 +291,7 @@ class DockerRepositoryTestCase(APITestCase):
         super(DockerRepositoryTestCase, cls).setUpClass()
         cls.org = entities.Organization().create()
 
+    @tier1
     @run_only_on('sat')
     def test_create_docker_repo(self):
         """@Test: Create a Docker-type repository
@@ -307,6 +319,7 @@ class DockerRepositoryTestCase(APITestCase):
                 )
                 self.assertEqual(repo.content_type, repo2.content_type)
 
+    @tier2
     @run_only_on('sat')
     @skip_if_bug_open('bugzilla', 1217603)
     def test_sync_docker_repo(self):
@@ -336,6 +349,7 @@ class DockerRepositoryTestCase(APITestCase):
             1
         )
 
+    @tier1
     def test_update_name(self):
         """@Test: Update a repository's name.
 

--- a/tests/foreman/api/test_rhsm.py
+++ b/tests/foreman/api/test_rhsm.py
@@ -6,6 +6,7 @@ No API doc exists for the subscription manager path(s). However, bugzilla bug
 """
 from nailgun import client
 from robottelo.config import settings
+from robottelo.decorators import tier1
 from robottelo.test import APITestCase
 from six.moves import http_client
 
@@ -13,6 +14,7 @@ from six.moves import http_client
 class RHSMTestCase(APITestCase):
     """Tests for the ``/rhsm`` path."""
 
+    @tier1
     def test_path_exists(self):
         """@Test: Check whether the path exists.
 

--- a/tests/foreman/api/test_role.py
+++ b/tests/foreman/api/test_role.py
@@ -15,7 +15,7 @@ from fauxfactory import (
 )
 from nailgun import entities
 from requests.exceptions import HTTPError
-from robottelo.decorators import bz_bug_is_open
+from robottelo.decorators import bz_bug_is_open, tier1
 from robottelo.test import APITestCase
 
 
@@ -34,6 +34,7 @@ def data_generator():
 class RoleTestCase(APITestCase):
     """Tests for ``api/v2/roles``."""
 
+    @tier1
     def test_positive_create_1(self):
         """@Test: Create a role with name ``name_generator()``.
 
@@ -53,6 +54,7 @@ class RoleTestCase(APITestCase):
                 name = name_generator()
                 self.assertEqual(entities.Role(name=name).create().name, name)
 
+    @tier1
     def test_positive_delete_1(self):
         """@Test: Delete a role with name ``name_generator()``.
 
@@ -75,6 +77,7 @@ class RoleTestCase(APITestCase):
                 with self.assertRaises(HTTPError):
                     role.read()
 
+    @tier1
     def test_positive_update_1(self):
         """@Test: Update a role with and give a name of ``name_generator()``.
 

--- a/tests/foreman/api/test_smartproxy.py
+++ b/tests/foreman/api/test_smartproxy.py
@@ -1,6 +1,6 @@
 """Tests for the ``smart_proxies`` paths."""
 from nailgun import entities
-from robottelo.decorators import run_only_on, stubbed, skip_if_bug_open
+from robottelo.decorators import run_only_on, stubbed, skip_if_bug_open, tier1
 from robottelo.test import APITestCase
 from robottelo.api.utils import one_to_many_names
 
@@ -29,6 +29,7 @@ class MissingAttrTestCase(APITestCase):
         assert len(smart_proxies) > 0
         cls.smart_proxy_attrs = set(smart_proxies[0].update_json([]).keys())
 
+    @tier1
     def test_location(self):
         """@Test: Update a smart proxy. Inspect the server's response.
 
@@ -44,6 +45,7 @@ class MissingAttrTestCase(APITestCase):
             'None of {0} are in {1}'.format(names, self.smart_proxy_attrs),
         )
 
+    @tier1
     def test_organization(self):
         """@Test: Update a smart proxy. Inspect the server's response.
 

--- a/tests/foreman/api/test_subscription.py
+++ b/tests/foreman/api/test_subscription.py
@@ -8,12 +8,14 @@ from nailgun import entities
 from nailgun.entity_mixins import TaskFailedError
 from robottelo.api.utils import upload_manifest
 from robottelo import manifests
+from robottelo.decorators import tier1
 from robottelo.test import APITestCase
 
 
 class SubscriptionsTestCase(APITestCase):
     """Tests for the ``subscriptions`` path."""
 
+    @tier1
     def test_positive_create_1(self):
         """@Test: Upload a manifest.
 
@@ -26,6 +28,7 @@ class SubscriptionsTestCase(APITestCase):
         with open(manifests.clone(), 'rb') as manifest:
             upload_manifest(org.id, manifest)
 
+    @tier1
     def test_positive_delete_1(self):
         """@Test: Delete an Uploaded manifest.
 
@@ -42,6 +45,7 @@ class SubscriptionsTestCase(APITestCase):
         sub.delete_manifest(data={'organization_id': org.id})
         self.assertEqual(len(sub.search()), 0)
 
+    @tier1
     def test_negative_create_1(self):
         """@Test: Upload the same manifest to two organizations.
 

--- a/tests/foreman/api/test_syncplan.py
+++ b/tests/foreman/api/test_syncplan.py
@@ -11,7 +11,7 @@ from random import sample
 from robottelo.config import settings
 from robottelo.datafactory import invalid_values_list, valid_data_list
 from requests.exceptions import HTTPError
-from robottelo.decorators import run_only_on, skip_if_bug_open, stubbed
+from robottelo.decorators import run_only_on, skip_if_bug_open, stubbed, tier1
 from robottelo.test import APITestCase
 
 
@@ -39,6 +39,7 @@ def valid_sync_interval():
 class SyncPlanTestCase(APITestCase):
     """Miscellaneous tests for sync plans."""
 
+    @tier1
     def test_get_routes(self):
         """@Test: Issue an HTTP GET response to both available routes.
 
@@ -83,6 +84,7 @@ class SyncPlanCreateTestCase(APITestCase):
         cls.org = entities.Organization().create()
 
     @run_only_on('sat')
+    @tier1
     def test_create_enabled_disabled(self):
         """@Test: Create sync plan with different 'enabled' field values.
 
@@ -100,6 +102,7 @@ class SyncPlanCreateTestCase(APITestCase):
                 self.assertEqual(sync_plan.enabled, enabled)
 
     @run_only_on('sat')
+    @tier1
     def test_create_random_name(self):
         """@Test: Create a sync plan with a random name.
 
@@ -117,6 +120,7 @@ class SyncPlanCreateTestCase(APITestCase):
                 self.assertEqual(syncplan.name, name)
 
     @run_only_on('sat')
+    @tier1
     def test_create_random_description(self):
         """@Test: Create a sync plan with a random description.
 
@@ -134,6 +138,7 @@ class SyncPlanCreateTestCase(APITestCase):
                 self.assertEqual(sync_plan.description, description)
 
     @run_only_on('sat')
+    @tier1
     def test_create_random_interval(self):
         """@Test: Create a sync plan with a random interval.
 
@@ -151,6 +156,7 @@ class SyncPlanCreateTestCase(APITestCase):
                 self.assertEqual(sync_plan.interval, interval)
 
     @run_only_on('sat')
+    @tier1
     def test_create_random_sync_date(self):
         """@Test: Create a sync plan and update its sync date.
 
@@ -171,6 +177,7 @@ class SyncPlanCreateTestCase(APITestCase):
                 )
 
     @run_only_on('sat')
+    @tier1
     def test_create_invalid_name(self):
         """@Test: Create a sync plan with an invalid name.
 
@@ -188,6 +195,7 @@ class SyncPlanCreateTestCase(APITestCase):
                     ).create()
 
     @run_only_on('sat')
+    @tier1
     def test_create_invalid_interval(self):
         """@Test: Create a sync plan with invalid interval specified.
 
@@ -205,6 +213,7 @@ class SyncPlanCreateTestCase(APITestCase):
                     ).create()
 
     @run_only_on('sat')
+    @tier1
     def test_create_empty_interval(self):
         """@Test: Create a sync plan with no interval specified.
 
@@ -230,6 +239,7 @@ class SyncPlanUpdateTestCase(APITestCase):
         cls.org = entities.Organization().create()
 
     @run_only_on('sat')
+    @tier1
     def test_update_enabled_disabled(self):
         """@Test: Create sync plan and update it with opposite 'enabled' value.
 
@@ -251,6 +261,7 @@ class SyncPlanUpdateTestCase(APITestCase):
                 )
 
     @run_only_on('sat')
+    @tier1
     def test_update_random_name(self):
         """@Test: Create a sync plan and update its name.
 
@@ -266,6 +277,7 @@ class SyncPlanUpdateTestCase(APITestCase):
                 sync_plan.name = name
                 self.assertEqual(sync_plan.update(['name']).name, name)
 
+    @tier1
     @run_only_on('sat')
     def test_update_random_description(self):
         """@Test: Create a sync plan and update its description.
@@ -288,6 +300,7 @@ class SyncPlanUpdateTestCase(APITestCase):
                     description
                 )
 
+    @tier1
     @run_only_on('sat')
     def test_update_random_interval(self):
         """@Test: Create a sync plan and update its interval.
@@ -313,6 +326,7 @@ class SyncPlanUpdateTestCase(APITestCase):
                     interval
                 )
 
+    @tier1
     @run_only_on('sat')
     def test_update_random_sync_date(self):
         """@Test: Updated sync plan's sync date.
@@ -334,6 +348,7 @@ class SyncPlanUpdateTestCase(APITestCase):
                     sync_plan.update(['sync_date']).sync_date
                 )
 
+    @tier1
     @run_only_on('sat')
     def test_update_invalid_name(self):
         """@Test: Try to update a sync plan with an invalid name.
@@ -350,6 +365,7 @@ class SyncPlanUpdateTestCase(APITestCase):
                 with self.assertRaises(HTTPError):
                     sync_plan.update(['name'])
 
+    @tier1
     @run_only_on('sat')
     def test_update_invalid_interval(self):
         """@Test: Try to update a sync plan with invalid interval.
@@ -379,6 +395,7 @@ class SyncPlanProductTestCase(APITestCase):
         super(SyncPlanProductTestCase, cls).setUpClass()
         cls.org = entities.Organization().create()
 
+    @tier1
     @run_only_on('sat')
     def test_add_product(self):
         """@Test: Create a sync plan and add one product to it.
@@ -395,6 +412,7 @@ class SyncPlanProductTestCase(APITestCase):
         self.assertEqual(len(syncplan.product), 1)
         self.assertEqual(syncplan.product[0].id, product.id)
 
+    @tier1
     @run_only_on('sat')
     def test_add_products(self):
         """@Test: Create a sync plan and add two products to it.
@@ -419,6 +437,7 @@ class SyncPlanProductTestCase(APITestCase):
             set((product.id for product in syncplan.product)),
         )
 
+    @tier1
     @skip_if_bug_open('bugzilla', 1199150)
     @run_only_on('sat')
     def test_remove_product(self):
@@ -444,6 +463,7 @@ class SyncPlanProductTestCase(APITestCase):
         self.assertEqual(len(syncplan.product), 1)
         self.assertEqual(syncplan.product[0].id, products[1].id)
 
+    @tier1
     @run_only_on('sat')
     def test_remove_products(self):
         """@Test: Create a sync plan with two products and then remove both
@@ -468,6 +488,7 @@ class SyncPlanProductTestCase(APITestCase):
         })
         self.assertEqual(len(syncplan.read().product), 0)
 
+    @tier1
     @skip_if_bug_open('bugzilla', 1199150)
     @run_only_on('sat')
     def test_repeatedly_add_remove(self):
@@ -536,6 +557,7 @@ class SyncPlanDeleteTestCase(APITestCase):
         super(SyncPlanDeleteTestCase, cls).setUpClass()
         cls.org = entities.Organization().create()
 
+    @tier1
     @run_only_on('sat')
     def test_delete_one_product(self):
         """@Test: Create a sync plan with one product and delete it.
@@ -553,6 +575,7 @@ class SyncPlanDeleteTestCase(APITestCase):
         with self.assertRaises(HTTPError):
             sync_plan.read()
 
+    @tier1
     @run_only_on('sat')
     def test_delete_two_products(self):
         """@Test: Create a sync plan with two products and delete them.
@@ -574,6 +597,7 @@ class SyncPlanDeleteTestCase(APITestCase):
         with self.assertRaises(HTTPError):
             sync_plan.read()
 
+    @tier1
     @run_only_on('sat')
     def test_delete_one_synced_product(self):
         """@Test: Create a sync plan with one synced product and delete it.

--- a/tests/foreman/api/test_user.py
+++ b/tests/foreman/api/test_user.py
@@ -9,6 +9,7 @@ from fauxfactory import gen_string
 from nailgun import entities
 from random import randint
 from requests.exceptions import HTTPError
+from robottelo.decorators import tier1
 from robottelo.test import APITestCase
 
 
@@ -43,6 +44,7 @@ def _user_attrs():
 class UsersTestCase(APITestCase):
     """Tests for the ``users`` path."""
 
+    @tier1
     def test_create(self):
         """@Test: Create a user with attributes ``attrs`` and delete it.
 
@@ -57,6 +59,7 @@ class UsersTestCase(APITestCase):
                 for name, value in attr.items():
                     self.assertEqual(getattr(user, name), value)
 
+    @tier1
     def test_delete(self):
         """@Test: Create a user with attributes ``attrs`` and delete it.
 
@@ -72,6 +75,7 @@ class UsersTestCase(APITestCase):
                 with self.assertRaises(HTTPError):
                     user.read()
 
+    @tier1
     def test_update_admin(self):
         """@Test: Update a user and provide the ``admin`` attribute.
 
@@ -98,6 +102,7 @@ class UserRoleTestCase(APITestCase):
         roles = entities.Role().search(query={'search': 'name="Anonymous"'})
         cls.anon_role = roles[0]
 
+    @tier1
     def test_create_with_role(self):
         """@Test: Create a user with the ``role`` attribute.
 
@@ -119,6 +124,7 @@ class UserRoleTestCase(APITestCase):
                 set([role.id for role in chosen_roles] + [self.anon_role.id]),
             )
 
+    @tier1
     def test_update_with_role(self):
         """@Test: Update an existing user and give it roles.
 


### PR DESCRIPTION
* Added `pytest` as a dependency in `setup.py`
* Created 3 new alias decorators to represent different tiers:
  * t1: CRUD
  * t2: Associations
  * t3: System integration / Long-running tests
* Added decorators to all existing, non-stubbed, test cases