### PR TITLE
Fixed invalid test names in few cli tests

### DIFF
--- a/tests/foreman/cli/test_capsule.py
+++ b/tests/foreman/cli/test_capsule.py
@@ -1,12 +1,14 @@
 # -*- encoding: utf-8 -*-
 """Test class for the capsule CLI."""
+from robottelo.decorators import stubbed
 from robottelo.test import CLITestCase
 
 
 class CapsuleTestCase(CLITestCase):
     """Tests for capsule functionality."""
 
-    def provision_through_capsule(self):
+    @stubbed()
+    def test_provision_through_capsule(self):
         """@Test: User can provision through a capsule
 
         @Feature: Capsules
@@ -28,7 +30,8 @@ class CapsuleTestCase(CLITestCase):
 
         """
 
-    def register_through_capsule(self):
+    @stubbed()
+    def test_register_through_capsule(self):
         """@Test: User can register system through proxy-enabled capsule
 
         @Feature: Capsules
@@ -43,7 +46,8 @@ class CapsuleTestCase(CLITestCase):
 
         """
 
-    def deregister_through_capsule(self):
+    @stubbed()
+    def test_deregister_through_capsule(self):
         """@Test: User can unregister system through proxy-enabled capsule
 
         @Feature: Capsules
@@ -58,7 +62,8 @@ class CapsuleTestCase(CLITestCase):
 
         """
 
-    def subscribe_content_through_capsule(self):
+    @stubbed()
+    def test_subscribe_content_through_capsule(self):
         """@Test: User can subscribe system to content through proxy-enabled
         capsule
 
@@ -78,7 +83,8 @@ class CapsuleTestCase(CLITestCase):
 
         """
 
-    def consume_content_through_capsule(self):
+    @stubbed()
+    def test_consume_content_through_capsule(self):
         """@Test: User can consume content on system, from a content source,
         through proxy-enabled capsule
 
@@ -100,7 +106,8 @@ class CapsuleTestCase(CLITestCase):
 
         """
 
-    def unsusbscribe_content_through_capsule(self):
+    @stubbed()
+    def test_unsusbscribe_content_through_capsule(self):
         """@Test: User can unsubscribe system from content through
         proxy-enabled capsule
 
@@ -122,7 +129,8 @@ class CapsuleTestCase(CLITestCase):
 
         """
 
-    def reregister_with_capsule_cert(self):
+    @stubbed()
+    def test_reregister_with_capsule_cert(self):
         """@Test: system can register via capsule using cert provided by
         the capsule itself.
 
@@ -144,6 +152,7 @@ class CapsuleTestCase(CLITestCase):
 
         """
 
+    @stubbed()
     def test_ssl_capsule(self):
         """@Test: Assure SSL functionality for capsules
 
@@ -164,6 +173,7 @@ class CapsuleTestCase(CLITestCase):
 
         """
 
+    @stubbed()
     def test_enable_bmc(self):
         """@Test: Enable BMC feature on smart-proxy
 

--- a/tests/foreman/cli/test_capsule_installer.py
+++ b/tests/foreman/cli/test_capsule_installer.py
@@ -1,11 +1,14 @@
 # -*- encoding: utf-8 -*-
 """Test for capsule installer CLI"""
+from robottelo.decorators import stubbed
 from robottelo.test import CLITestCase
 
 
 class TestCapsuleInstaller(CLITestCase):
     """Test class for capsule installer CLI"""
-    def capsule_installer_basic_test(self):
+
+    @stubbed()
+    def test_capsule_installer_basic_test(self):
         """@Test: perform a basic install of capsule.
 
         @Feature: Capsule Installer
@@ -23,7 +26,8 @@ class TestCapsuleInstaller(CLITestCase):
 
         """
 
-    def capsule_installer_qpid(self):
+    @stubbed()
+    def test_capsule_installer_qpid(self):
         """@Test: assure the --qpid-router flag can be used in
         capsule-installer to enable katello-agent functionality via
         remote clients
@@ -41,7 +45,8 @@ class TestCapsuleInstaller(CLITestCase):
 
         """
 
-    def capsule_installer_reverse_proxy(self):
+    @stubbed()
+    def test_capsule_installer_reverse_proxy(self):
         """@Test:  assure the --reverse-proxy flag can be used in
         capsule-installer to enable katello-agent functionality via
         remote clients
@@ -59,7 +64,8 @@ class TestCapsuleInstaller(CLITestCase):
 
         """
 
-    def capsule_installer_parent_reverse_proxy_neg(self):
+    @stubbed()
+    def test_capsule_installer_parent_reverse_proxy_neg(self):
         """@Test: invalid (non-boolean) parameters cannot be passed to flag
 
         @Feature: Capsule Installer
@@ -76,7 +82,8 @@ class TestCapsuleInstaller(CLITestCase):
 
         """
 
-    def capsule_installer_parent_reverse_proxy_port_neg(self):
+    @stubbed()
+    def test_capsule_installer_parent_reverse_proxy_port_neg(self):
         """@Test: invalid (non-integer) parameters cannot be passed to flag
 
         @Feature: Capsule Installer
@@ -95,7 +102,8 @@ class TestCapsuleInstaller(CLITestCase):
 
         """
 
-    def capsule_installer_parent_reverse_proxy_pos(self):
+    @stubbed()
+    def test_capsule_installer_parent_reverse_proxy_pos(self):
         """@Test:  valid parameters can be passed to --parent-reverse-proxy (true)
 
         @Feature: Capsule Installer
@@ -112,7 +120,8 @@ class TestCapsuleInstaller(CLITestCase):
 
         """
 
-    def capsule_installer_parent_reverse_proxy_port_pos(self):
+    @stubbed()
+    def test_capsule_installer_parent_reverse_proxy_port_pos(self):
         """@Test: valid parameters can be passed to
         --parent-reverse-proxy-port (integer)
 

--- a/tests/foreman/cli/test_contentviews.py
+++ b/tests/foreman/cli/test_contentviews.py
@@ -75,7 +75,6 @@ class TestContentView(CLITestCase):
     rhel_repo = None
     rhel_product_name = 'Red Hat Enterprise Linux Workstation'
 
-    @run_only_on('sat')
     def create_rhel_content(self):
         """Enable/Synchronize rhel content"""
         if TestContentView.rhel_content_org is not None:

--- a/tests/foreman/cli/test_docker.py
+++ b/tests/foreman/cli/test_docker.py
@@ -316,7 +316,6 @@ class DockerContentViewTestCase(CLITestCase):
         super(DockerContentViewTestCase, cls).setUpClass()
         cls.org_id = make_org()['id']
 
-    @run_only_on('sat')
     def _create_and_associate_repo_with_cv(self):
         """Create a Docker-based repository and content view and associate
         them.

--- a/tests/foreman/ui/test_capsule.py
+++ b/tests/foreman/ui/test_capsule.py
@@ -1,13 +1,15 @@
 # -*- encoding: utf-8 -*-
 """Test class for UI functions against an isolated capsule"""
 
+from robottelo.decorators import stubbed
 from robottelo.test import UITestCase
 
 
 class CapsuleTestCase(UITestCase):
     """Implements capsule tests in UI"""
 
-    def capsule_errata_push(self):
+    @stubbed()
+    def test_capsule_errata_push(self):
         """@Test: User can push errata through to a client on
         an isolated capsule
 
@@ -27,7 +29,8 @@ class CapsuleTestCase(UITestCase):
 
         """
 
-    def capsule_rpm_push(self):
+    @stubbed()
+    def test_capsule_rpm_push(self):
         """@Test: User can install a new errata on a client through
         an isolated capsule - this is a satellite-initiated action
 
@@ -47,7 +50,8 @@ class CapsuleTestCase(UITestCase):
 
         """
 
-    def capsule_puppet_push(self):
+    @stubbed()
+    def test_capsule_puppet_push(self):
         """@Test: user can install new puppet module on a client
         through an isolated capsule
 
@@ -65,7 +69,9 @@ class CapsuleTestCase(UITestCase):
         @Status: Manual
 
         """
-    def capsule_content_host_selector(self):
+
+    @stubbed()
+    def test_capsule_content_host_selector(self):
         """@Test: User can choose, or is given an indication within
         the content hosts UI, any referenced capsule in order to
         learn/setup registration against said capsule(s).


### PR DESCRIPTION
```py
# nosetests tests/foreman/cli/test_capsule.py
SSSSSSSSS
----------------------------------------------------------------------
Ran 9 tests in 0.003s

OK (SKIP=9)

# nosetests tests/foreman/cli/test_capsule_installer.py
SSSSSSS
----------------------------------------------------------------------
Ran 7 tests in 0.003s

OK (SKIP=7)

# nosetests tests/foreman/ui/test_capsule.py
SSSS
----------------------------------------------------------------------
Ran 4 tests in 0.003s

OK (SKIP=4)
```