### PR TITLE
Use py.test decorators for CLI tests.

### DIFF
--- a/tests/foreman/cli/test_activationkey.py
+++ b/tests/foreman/cli/test_activationkey.py
@@ -19,7 +19,13 @@ from robottelo.cli.lifecycleenvironment import LifecycleEnvironment
 from robottelo.cli.repository import Repository
 from robottelo.cli.subscription import Subscription
 from robottelo.datafactory import valid_data_list
-from robottelo.decorators import run_only_on, skip_if_bug_open, stubbed
+from robottelo.decorators import (
+    run_only_on,
+    skip_if_bug_open,
+    stubbed,
+    tier1,
+    tier2,
+)
 from robottelo.ssh import upload_file
 from robottelo.test import CLITestCase
 
@@ -129,6 +135,7 @@ class TestActivationKey(CLITestCase):
                 TestActivationKey.pub_key = None
                 self.fail(err)
 
+    @tier1
     def test_positive_create_ak_1(self):
         """@Test: Create Activation key for all variations of Activation key
         name
@@ -150,6 +157,7 @@ class TestActivationKey(CLITestCase):
                 # Name should match passed data
                 self.assertEqual(new_ackey_name, name)
 
+    @tier1
     def test_positive_create_ak_2(self):
         """@Test: Create Activation key for all variations of Description
 
@@ -170,6 +178,7 @@ class TestActivationKey(CLITestCase):
                 # Description should match passed data
                 self.assertEqual(new_ackey_description, desc)
 
+    @tier2
     def test_positive_add_env_1(self):
         """@Test: Create Activation key and associate with Library environment
 
@@ -193,6 +202,7 @@ class TestActivationKey(CLITestCase):
                 self.assertEqual(new_ackey_env, self.library['name'])
 
     @run_only_on('sat')
+    @tier2
     def test_positive_add_env_2(self):
         """@Test: Create Activation key and associate with environment
 
@@ -215,6 +225,7 @@ class TestActivationKey(CLITestCase):
                 # Description should match passed data
                 self.assertEqual(new_ackey_env, self.env1['name'])
 
+    @tier2
     def test_positive_create_ak_3(self):
         """@Test: Create Activation key for all variations of Content Views
 
@@ -262,7 +273,6 @@ class TestActivationKey(CLITestCase):
         @Status: Manual
 
         """
-        pass
 
     @stubbed()
     def test_positive_create_ak_5(self):
@@ -280,7 +290,6 @@ class TestActivationKey(CLITestCase):
         @Status: Manual
 
         """
-        pass
 
     @stubbed()
     def test_positive_create_ak_6(self):
@@ -298,7 +307,6 @@ class TestActivationKey(CLITestCase):
         @Status: Manual
 
         """
-        pass
 
     @stubbed()
     def test_positive_create_ak_7(self):
@@ -316,8 +324,8 @@ class TestActivationKey(CLITestCase):
         @Status: Manual
 
         """
-        pass
 
+    @tier1
     @run_only_on('sat')
     def test_positive_create_ak_8(self):
         """@test: Create Activation key with environment name
@@ -358,7 +366,6 @@ class TestActivationKey(CLITestCase):
         @Status: Manual
 
         """
-        pass
 
     @stubbed()
     def test_negative_create_ak_2(self):
@@ -376,7 +383,6 @@ class TestActivationKey(CLITestCase):
         @Status: Manual
 
         """
-        pass
 
     @stubbed()
     def test_negative_create_ak_3(self):
@@ -394,8 +400,8 @@ class TestActivationKey(CLITestCase):
         @Status: Manual
 
         """
-        pass
 
+    @tier1
     def test_delete_ak_by_name(self):
         """@Test: Create Activation key and delete it for all variations of
         Activation key name
@@ -423,6 +429,7 @@ class TestActivationKey(CLITestCase):
                 with self.assertRaises(CLIReturnCodeError):
                     ActivationKey.info({'id': activation_key['id']})
 
+    @tier1
     def test_delete_ak_by_org_name(self):
         """@Test: Create Activation key and delete it using organization name
         for which that key was created
@@ -448,6 +455,7 @@ class TestActivationKey(CLITestCase):
         with self.assertRaises(CLIReturnCodeError):
             ActivationKey.info({'id': activation_key['id']})
 
+    @tier1
     def test_delete_ak_by_org_label(self):
         """@Test: Create Activation key and delete it using organization
         label for which that key was created
@@ -472,6 +480,7 @@ class TestActivationKey(CLITestCase):
         with self.assertRaises(CLIReturnCodeError):
             ActivationKey.info({'id': activation_key['id']})
 
+    @tier2
     def test_delete_ak_with_cv(self):
         """@Test: Create activation key with content view assigned to it and
         delete it using activation key id
@@ -497,6 +506,7 @@ class TestActivationKey(CLITestCase):
         with self.assertRaises(CLIReturnCodeError):
             ActivationKey.info({'id': activation_key['id']})
 
+    @tier2
     def test_delete_ak_with_env(self):
         """@Test: Create activation key with lifecycle environment assigned to
         it and delete it using activation key id
@@ -523,6 +533,7 @@ class TestActivationKey(CLITestCase):
         with self.assertRaises(CLIReturnCodeError):
             ActivationKey.info({'id': activation_key['id']})
 
+    @tier1
     def test_positive_update_ak_1(self):
         """@Test: Update Activation Key Name in Activation key searching by ID
 
@@ -549,6 +560,7 @@ class TestActivationKey(CLITestCase):
                 })
                 self.assertEqual(activation_key['name'], name)
 
+    @tier1
     def test_positive_update_ak_2(self):
         """@Test: Update Activation Key Name in an Activation key searching by
         name
@@ -576,6 +588,7 @@ class TestActivationKey(CLITestCase):
                 })
                 self.assertEqual(activation_key['name'], name)
 
+    @tier1
     def test_positive_update_ak_3(self):
         """@Test: Update Description in an Activation key
 
@@ -619,8 +632,8 @@ class TestActivationKey(CLITestCase):
         @Status: Manual
 
         """
-        pass
 
+    @tier2
     @run_only_on('sat')
     @skip_if_bug_open('bugzilla', 1109649)
     def test_positive_update_ak5(self):
@@ -671,7 +684,6 @@ class TestActivationKey(CLITestCase):
         @Status: Manual
 
         """
-        pass
 
     @stubbed()
     def test_positive_update_ak7(self):
@@ -689,7 +701,6 @@ class TestActivationKey(CLITestCase):
         @Status: Manual
 
         """
-        pass
 
     @stubbed()
     def test_negative_update_ak1(self):
@@ -707,7 +718,6 @@ class TestActivationKey(CLITestCase):
         @Status: Manual
 
         """
-        pass
 
     @stubbed()
     def test_negative_update_ak2(self):
@@ -725,7 +735,6 @@ class TestActivationKey(CLITestCase):
         @Status: Manual
 
         """
-        pass
 
     @stubbed()
     def test_negative_update_ak3(self):
@@ -743,7 +752,6 @@ class TestActivationKey(CLITestCase):
         @Status: Manual
 
         """
-        pass
 
     @stubbed()
     def test_usage_limit(self):
@@ -763,8 +771,8 @@ class TestActivationKey(CLITestCase):
         @Status: Manual
 
         """
-        pass
 
+    @tier2
     @skip_if_bug_open('bugzilla', 1110476)
     def test_associate_host(self):
         """@Test: Test that host collection can be associated to Activation
@@ -816,7 +824,6 @@ class TestActivationKey(CLITestCase):
         @Status: Manual
 
         """
-        pass
 
     @run_only_on('sat')
     @stubbed()
@@ -835,7 +842,6 @@ class TestActivationKey(CLITestCase):
         @Status: Manual
 
         """
-        pass
 
     @run_only_on('sat')
     @stubbed()
@@ -855,7 +861,6 @@ class TestActivationKey(CLITestCase):
         @Status: Manual
 
         """
-        pass
 
     @stubbed()
     def test_delete_manifest(self):
@@ -874,7 +879,6 @@ class TestActivationKey(CLITestCase):
         @Status: Manual
 
         """
-        pass
 
     @stubbed()
     def test_multiple_aks_to_system(self):
@@ -892,7 +896,6 @@ class TestActivationKey(CLITestCase):
         @Status: Manual
 
         """
-        pass
 
     @stubbed()
     def test_list_activation_keys_1(self):
@@ -911,7 +914,6 @@ class TestActivationKey(CLITestCase):
         @Status: Manual
 
         """
-        pass
 
     @stubbed()
     def test_list_activation_keys_2(self):
@@ -929,7 +931,6 @@ class TestActivationKey(CLITestCase):
         @Status: Manual
 
         """
-        pass
 
     @stubbed()
     def test_info_activation_keys_1(self):
@@ -949,7 +950,6 @@ class TestActivationKey(CLITestCase):
         @Status: Manual
 
         """
-        pass
 
     @stubbed()
     def test_info_activation_keys_2(self):
@@ -967,8 +967,8 @@ class TestActivationKey(CLITestCase):
         @Status: Manual
 
         """
-        pass
 
+    @tier1
     def test_bugzilla_1111723(self):
         """@test: Create activation key, rename it and create another with the
         initial name
@@ -1000,6 +1000,7 @@ class TestActivationKey(CLITestCase):
         })
         self.assertEqual(new_activation_key['name'], name)
 
+    @tier2
     def test_remove_hc_by_id(self):
         """@Test: Test that hosts associated to Activation Keys can be removed
         using id of that host collection
@@ -1037,6 +1038,7 @@ class TestActivationKey(CLITestCase):
         activation_key = ActivationKey.info({u'id': activation_key['id']})
         self.assertEqual(len(activation_key['host-collections']), 0)
 
+    @tier2
     def test_remove_hc_by_name(self):
         """@Test: Test that hosts associated to Activation Keys can be removed
         using name of that host collection
@@ -1086,6 +1088,7 @@ class TestActivationKey(CLITestCase):
                 })
                 self.assertEqual(len(activation_key['host-collections']), 0)
 
+    @tier2
     def test_add_subscription(self):
         """@Test: Test that subscription can be added to activation key
 
@@ -1117,6 +1120,7 @@ class TestActivationKey(CLITestCase):
         })
         self.assertIn('Subscription added to activation key', result)
 
+    @tier1
     def test_positive_copy_ak1(self):
         """@Test: Copy Activation key for all valid Activation Key name
            variations
@@ -1143,6 +1147,7 @@ class TestActivationKey(CLITestCase):
                 })
                 self.assertEqual(result[0], u'Activation key copied')
 
+    @tier1
     def test_positive_copy_ak2(self):
         """@Test: Copy Activation key by passing name of parent
 
@@ -1166,6 +1171,7 @@ class TestActivationKey(CLITestCase):
         })
         self.assertEqual(result[0], u'Activation key copied')
 
+    @tier1
     def test_negative_copy_ak(self):
         """@Test: Copy activation key with duplicate name
 
@@ -1191,6 +1197,7 @@ class TestActivationKey(CLITestCase):
         self.assertEqual(exe.exception.return_code, 65)
         self.assertIn(u'Name has already been taken', exe.exception.stderr)
 
+    @tier2
     def test_positive_copy_subscription(self):
         """@Test: Copy Activation key and verify contents
 
@@ -1240,6 +1247,7 @@ class TestActivationKey(CLITestCase):
             result[3]  # subscription list
         )
 
+    @tier1
     def test_update_autoattach_1(self):
         """@Test: Update Activation key with inverse auto-attach value
 
@@ -1273,6 +1281,7 @@ class TestActivationKey(CLITestCase):
         })['auto-attach']
         self.assertEqual(attach_value, new_value)
 
+    @tier1
     def test_update_autoattach_2(self):
         """@Test: Update Activation key with valid auto-attach values
 
@@ -1301,6 +1310,7 @@ class TestActivationKey(CLITestCase):
                 self.assertEqual(
                     u'Activation key updated', result[0]['message'])
 
+    @tier1
     def test_negative_update_auto_attach(self):
         """@Test: Attempt to update Activation key with bad auto-attach value
 
@@ -1328,6 +1338,7 @@ class TestActivationKey(CLITestCase):
         self.assertIn(
             u"'--auto-attach': value must be one of", exe.exception.stderr)
 
+    @tier1
     @skip_if_bug_open('bugzilla', 1180282)
     def test_positive_content_override(self):
         """@Test: Positive content override

--- a/tests/foreman/cli/test_architecture.py
+++ b/tests/foreman/cli/test_architecture.py
@@ -9,13 +9,14 @@ from robottelo.datafactory import (
     invalid_values_list,
     valid_data_list,
 )
-from robottelo.decorators import run_only_on
+from robottelo.decorators import run_only_on, tier1
 from robottelo.test import CLITestCase
 
 
 class TestArchitecture(CLITestCase):
     """Architecture CLI related tests."""
 
+    @tier1
     def test_positive_create(self):
         """@Test: Successfully creates an Architecture.
 
@@ -28,6 +29,7 @@ class TestArchitecture(CLITestCase):
                 architecture = make_architecture({'name': name})
                 self.assertEqual(architecture['name'], name)
 
+    @tier1
     def test_negative_create(self):
         """@Test: Don't create an Architecture with invalid data.
 
@@ -40,6 +42,7 @@ class TestArchitecture(CLITestCase):
                 with self.assertRaises(CLIReturnCodeError):
                     Architecture.create({'name': name})
 
+    @tier1
     def test_positive_update_name(self):
         """@Test: Successfully update an Architecture.
 
@@ -57,6 +60,7 @@ class TestArchitecture(CLITestCase):
                 architecture = Architecture.info({'id': architecture['id']})
                 self.assertEqual(architecture['name'], new_name)
 
+    @tier1
     @run_only_on('sat')
     def test_negative_update(self):
         """@test: Create Architecture then fail to update its name
@@ -76,6 +80,7 @@ class TestArchitecture(CLITestCase):
                 result = Architecture.info({'id': architecture['id']})
                 self.assertEqual(architecture['name'], result['name'])
 
+    @tier1
     @run_only_on('sat')
     def test_positive_delete(self):
         """@test: Create Architecture with valid values then delete it
@@ -92,6 +97,7 @@ class TestArchitecture(CLITestCase):
                 with self.assertRaises(CLIReturnCodeError):
                     Architecture.info({'id': architecture['id']})
 
+    @tier1
     @run_only_on('sat')
     def test_negative_delete(self):
         """@test: Create Architecture then delete it by wrong ID

--- a/tests/foreman/cli/test_computeresource.py
+++ b/tests/foreman/cli/test_computeresource.py
@@ -26,7 +26,7 @@ from robottelo.cli.computeresource import ComputeResource
 from robottelo.cli.factory import make_location, make_compute_resource
 from robottelo.config import settings
 from robottelo.constants import FOREMAN_PROVIDERS
-from robottelo.decorators import run_only_on, skip_if_bug_open
+from robottelo.decorators import run_only_on, skip_if_bug_open, tier1
 from robottelo.test import CLITestCase
 
 LIBVIRT_URL = 'qemu+tcp://{}:16509/system'.format(settings.server.hostname)
@@ -96,6 +96,7 @@ class TestComputeResource(CLITestCase):
     """ComputeResource CLI tests."""
 
     # pylint: disable=no-self-use
+    @tier1
     @run_only_on('sat')
     def test_create(self):
         """@Test: Create Compute Resource
@@ -111,6 +112,7 @@ class TestComputeResource(CLITestCase):
             'url': LIBVIRT_URL,
         })
 
+    @tier1
     @run_only_on('sat')
     def test_info(self):
         """@Test: Test Compute Resource Info
@@ -129,6 +131,7 @@ class TestComputeResource(CLITestCase):
         # factory already runs info, just check the data
         self.assertEquals(compute_resource['name'], name)
 
+    @tier1
     @run_only_on('sat')
     def test_list(self):
         """@Test: Test Compute Resource List
@@ -149,6 +152,7 @@ class TestComputeResource(CLITestCase):
         result = ComputeResource.exists(search=('name', comp_res['name']))
         self.assertTrue(result)
 
+    @tier1
     @run_only_on('sat')
     def test_delete(self):
         """@Test: Test Compute Resource delete
@@ -169,6 +173,7 @@ class TestComputeResource(CLITestCase):
 
     # Positive create
 
+    @tier1
     @run_only_on('sat')
     def test_create_positive_libvirt(self):
         """@Test: Test Compute Resource create
@@ -187,6 +192,7 @@ class TestComputeResource(CLITestCase):
                     u'url': gen_url(),
                 })
 
+    @tier1
     @run_only_on('sat')
     def test_create_cr_with_location(self):
         """@Test: Create Compute Resource with location
@@ -201,6 +207,7 @@ class TestComputeResource(CLITestCase):
         self.assertEqual(1, len(comp_resource['locations']))
         self.assertEqual(comp_resource['locations'][0], location['name'])
 
+    @tier1
     @run_only_on('sat')
     def test_create_cr_with_locations(self):
         """@Test: Create Compute Resource with multiple locations
@@ -220,6 +227,7 @@ class TestComputeResource(CLITestCase):
         for location in locations:
             self.assertIn(location['name'], comp_resource['locations'])
 
+    @tier1
     @run_only_on('sat')
     @skip_if_bug_open('bugzilla', 1214312)
     def test_create_cr_with_consolepwd(self):
@@ -249,6 +257,7 @@ class TestComputeResource(CLITestCase):
 
     # Negative create
 
+    @tier1
     @run_only_on('sat')
     def test_create_negative_1(self):
         """@Test: Compute Resource negative create with invalid values
@@ -269,6 +278,7 @@ class TestComputeResource(CLITestCase):
                         u'url': options.get('url', gen_url()),
                     })
 
+    @tier1
     @run_only_on('sat')
     def test_create_negative_2(self):
         """@Test: Compute Resource negative create with the same name
@@ -288,6 +298,7 @@ class TestComputeResource(CLITestCase):
 
     # Update Positive
 
+    @tier1
     @run_only_on('sat')
     def test_update_positive(self):
         """@Test: Compute Resource positive update
@@ -324,6 +335,7 @@ class TestComputeResource(CLITestCase):
 
     # Update Negative
 
+    @tier1
     @run_only_on('sat')
     def test_update_negative(self):
         """@Test: Compute Resource negative update
@@ -346,6 +358,7 @@ class TestComputeResource(CLITestCase):
                 for key in options.keys():
                     self.assertEqual(comp_res[key], result[key])
 
+    @tier1
     @run_only_on('sat')
     def test_set_console_password_v1(self):
         """@Test: Create a compute resource with ``--set-console-password``.
@@ -366,6 +379,7 @@ class TestComputeResource(CLITestCase):
                     'url': gen_url(),
                 })
 
+    @tier1
     @run_only_on('sat')
     def test_set_console_password_v2(self):
         """@Test: Update a compute resource with ``--set-console-password``.

--- a/tests/foreman/cli/test_contenthost.py
+++ b/tests/foreman/cli/test_contenthost.py
@@ -30,7 +30,7 @@ from robottelo.constants import (
     REPOSET,
 )
 from robottelo.datafactory import invalid_values_list, generate_strings_list
-from robottelo.decorators import run_only_on, skip_if_bug_open
+from robottelo.decorators import run_only_on, skip_if_bug_open, tier1, tier2
 from robottelo.test import CLITestCase
 from robottelo.vm import VirtualMachine
 
@@ -80,6 +80,7 @@ class TestContentHost(CLITestCase):
         })
         TestContentHost.PROMOTED_CV = TestContentHost.NEW_CV
 
+    @tier1
     def test_positive_create_1(self):
         """@Test: Check if content host can be created with random names
 
@@ -99,6 +100,7 @@ class TestContentHost(CLITestCase):
             # Assert that name matches data passed
             self.assertEqual(new_system['name'], name)
 
+    @tier1
     def test_positive_create_2(self):
         """@Test: Check if content host can be created with random description
 
@@ -118,6 +120,7 @@ class TestContentHost(CLITestCase):
                 # Assert that description matches data passed
                 self.assertEqual(new_system['description'], desc)
 
+    @tier1
     def test_positive_create_3(self):
         """@Test: Check if content host can be created with organization name
 
@@ -140,6 +143,7 @@ class TestContentHost(CLITestCase):
             self.LIBRARY['name'],
         )
 
+    @tier1
     def test_positive_create_4(self):
         """@Test: Check if content host can be created with organization label
 
@@ -163,6 +167,7 @@ class TestContentHost(CLITestCase):
         )
 
     @run_only_on('sat')
+    @tier1
     def test_positive_create_5(self):
         """@Test: Check if content host can be created with content view name
 
@@ -180,6 +185,7 @@ class TestContentHost(CLITestCase):
         # Assert that name matches data passed
         self.assertEqual(new_system['content-view'], self.DEFAULT_CV['name'])
 
+    @tier1
     @run_only_on('sat')
     def test_positive_create_6(self):
         """@Test: Check if content host can be created with lifecycle name
@@ -201,6 +207,7 @@ class TestContentHost(CLITestCase):
             self.LIBRARY['name'],
         )
 
+    @tier1
     @run_only_on('sat')
     def test_positive_create_7(self):
         """@Test: Check if content host can be created with new lifecycle
@@ -222,6 +229,7 @@ class TestContentHost(CLITestCase):
             self.NEW_LIFECYCLE['name'],
         )
 
+    @tier1
     @run_only_on('sat')
     def test_positive_create_8(self):
         """@Test: Check if content host can be created with new content view
@@ -246,6 +254,7 @@ class TestContentHost(CLITestCase):
             TestContentHost.PROMOTED_CV['name'],
         )
 
+    @tier1
     def test_negative_create_1(self):
         """@Test: Check if content host can be created with random long names
 
@@ -264,6 +273,7 @@ class TestContentHost(CLITestCase):
                         u'lifecycle-environment-id': self.LIBRARY['id'],
                     })
 
+    @tier1
     @run_only_on('sat')
     def test_negative_create_2(self):
         """@Test: Check if content host can be created with new content view
@@ -285,6 +295,7 @@ class TestContentHost(CLITestCase):
                 u'organization-id': TestContentHost.NEW_ORG['id'],
             })
 
+    @tier1
     def test_positive_update_1(self):
         """@Test: Check if content host name can be updated
 
@@ -307,6 +318,7 @@ class TestContentHost(CLITestCase):
                 result = ContentHost.info({'id': new_system['id']})
                 self.assertEqual(result['name'], new_name)
 
+    @tier1
     def test_positive_update_2(self):
         """@Test: Check if content host description can be updated
 
@@ -329,6 +341,7 @@ class TestContentHost(CLITestCase):
                 result = ContentHost.info({'id': new_system['id']})
                 self.assertEqual(result['description'], new_desc)
 
+    @tier1
     def test_positive_delete_1(self):
         """@Test: Check if content host can be created and deleted
 
@@ -349,6 +362,7 @@ class TestContentHost(CLITestCase):
                 with self.assertRaises(CLIReturnCodeError):
                     ContentHost.info({'id': new_system['id']})
 
+    @tier1
     @skip_if_bug_open('bugzilla', 1154611)
     def test_bugzilla_1154611(self):
         """@test: check if Content Host creation does not allow duplicated
@@ -445,6 +459,7 @@ class TestCHKatelloAgent(CLITestCase):
         self.client.destroy()
         super(TestCHKatelloAgent, self).tearDown()
 
+    @tier2
     @run_only_on('sat')
     def test_ch_get_errata_info(self):
         """@Test: Get errata info
@@ -466,6 +481,7 @@ class TestCHKatelloAgent(CLITestCase):
         self.assertEqual(result[0]['errata-id'], FAKE_0_ERRATA_ID)
         self.assertEqual(result[0]['packages'], FAKE_0_CUSTOM_PACKAGE)
 
+    @tier2
     @run_only_on('sat')
     def test_ch_apply_errata(self):
         """@Test: Apply errata to content host
@@ -485,6 +501,7 @@ class TestCHKatelloAgent(CLITestCase):
             u'organization-id': TestCHKatelloAgent.org['id'],
         })
 
+    @tier2
     @run_only_on('sat')
     def test_ch_package_install(self):
         """@Test: Install package to content host remotely
@@ -504,6 +521,7 @@ class TestCHKatelloAgent(CLITestCase):
         )
         self.assertEqual(result.return_code, 0)
 
+    @tier2
     @run_only_on('sat')
     def test_ch_package_remove(self):
         """@Test: Remove package from content host remotely
@@ -527,6 +545,7 @@ class TestCHKatelloAgent(CLITestCase):
         )
         self.assertNotEqual(result.return_code, 0)
 
+    @tier2
     @run_only_on('sat')
     def test_ch_package_upgrade(self):
         """@Test: Upgrade content host package remotely
@@ -545,6 +564,7 @@ class TestCHKatelloAgent(CLITestCase):
         result = self.client.run('rpm -q {0}'.format(FAKE_2_CUSTOM_PACKAGE))
         self.assertEqual(result.return_code, 0)
 
+    @tier2
     @run_only_on('sat')
     def test_ch_package_upgrade_all(self):
         """@Test: Upgrade all the content host packages remotely
@@ -563,6 +583,7 @@ class TestCHKatelloAgent(CLITestCase):
         result = self.client.run('rpm -q {0}'.format(FAKE_2_CUSTOM_PACKAGE))
         self.assertEqual(result.return_code, 0)
 
+    @tier2
     @run_only_on('sat')
     def test_ch_package_group_install(self):
         """@Test: Install package group to content host remotely
@@ -581,6 +602,7 @@ class TestCHKatelloAgent(CLITestCase):
             result = self.client.run('rpm -q {0}'.format(package))
             self.assertEqual(result.return_code, 0)
 
+    @tier2
     @run_only_on('sat')
     def test_ch_package_group_remove(self):
         """@Test: Remove package group from content host remotely

--- a/tests/foreman/cli/test_contentviewfilter.py
+++ b/tests/foreman/cli/test_contentviewfilter.py
@@ -13,7 +13,7 @@ from robottelo.cli.factory import (
 from robottelo.cli.repository import Repository
 from robottelo.constants import DOCKER_REGISTRY_HUB
 from robottelo.datafactory import invalid_values_list, valid_data_list
-from robottelo.decorators import skip_if_bug_open
+from robottelo.decorators import skip_if_bug_open, tier1, tier2
 from robottelo.test import CLITestCase
 
 
@@ -36,6 +36,7 @@ class TestContentViewFilter(CLITestCase):
             u'repository-id': cls.repo['id'],
         })
 
+    @tier1
     def test_create_cvf_different_names(self):
         """Test: Create new content view filter and assign it to existing
         content view by id. Use different value types as a name and random
@@ -66,6 +67,7 @@ class TestContentViewFilter(CLITestCase):
                 self.assertEqual(cvf['name'], name)
                 self.assertEqual(cvf['type'], filter_content_type)
 
+    @tier1
     def test_create_cvf_content_types(self):
         """Test: Create new content view filter and assign it to existing
         content view by id. Use different content types as a parameter
@@ -90,6 +92,7 @@ class TestContentViewFilter(CLITestCase):
                 })
                 self.assertEqual(cvf['type'], filter_content_type)
 
+    @tier1
     def test_create_cvf_inclusions(self):
         """Test: Create new content view filter and assign it to existing
         content view by id. Use different inclusions as a parameter
@@ -115,6 +118,7 @@ class TestContentViewFilter(CLITestCase):
                 })
                 self.assertEqual(cvf['inclusion'], inclusion)
 
+    @tier1
     @skip_if_bug_open('bugzilla', 1236532)
     def test_create_cvf_description(self):
         """Test: Create new content view filter with description and assign it
@@ -140,6 +144,7 @@ class TestContentViewFilter(CLITestCase):
         })
         self.assertEqual(cvf['description'], description)
 
+    @tier1
     def test_create_cvf_by_cv_name(self):
         """Test: Create new content view filter and assign it to existing
         content view by name. Use organization id for reference
@@ -162,6 +167,7 @@ class TestContentViewFilter(CLITestCase):
             u'name': cvf_name,
         })
 
+    @tier1
     def test_create_cvf_by_org_name(self):
         """Test: Create new content view filter and assign it to existing
         content view by name. Use organization name for reference
@@ -184,6 +190,7 @@ class TestContentViewFilter(CLITestCase):
             u'name': cvf_name,
         })
 
+    @tier1
     def test_create_cvf_by_org_label(self):
         """Test: Create new content view filter and assign it to existing
         content view by name. Use organization label for reference
@@ -206,6 +213,7 @@ class TestContentViewFilter(CLITestCase):
             u'name': cvf_name,
         })
 
+    @tier1
     def test_create_cvf_repo_by_id(self):
         """Test: Create new content view filter and assign it to existing
         content view that has repository assigned to it. Use that repository id
@@ -231,6 +239,7 @@ class TestContentViewFilter(CLITestCase):
         })
         self.assertEqual(cvf['repositories'][0]['name'], self.repo['name'])
 
+    @tier1
     @skip_if_bug_open('bugzilla', 1228890)
     def test_create_cvf_repo_by_name(self):
         """Test: Create new content view filter and assign it to existing
@@ -257,6 +266,7 @@ class TestContentViewFilter(CLITestCase):
         })
         self.assertEqual(cvf['repositories'][0]['name'], self.repo['name'])
 
+    @tier1
     def test_create_cvf_original_pkgs(self):
         """Test: Create new content view filter and assign it to existing
         content view that has repository assigned to it. Enable 'original
@@ -283,6 +293,7 @@ class TestContentViewFilter(CLITestCase):
         })
         self.assertEqual(cvf['repositories'][0]['name'], self.repo['name'])
 
+    @tier1
     def test_create_cvf_repos_docker(self):
         """Test: Create new docker repository and add to content view that has
         yum repo already assigned to it. Create new content view filter and
@@ -322,6 +333,7 @@ class TestContentViewFilter(CLITestCase):
         for repo in cvf['repositories']:
             self.assertIn(repo['id'], repos)
 
+    @tier1
     def test_create_cvf_names_negative(self):
         """@Test: Try to create content view filter using invalid names only
 
@@ -339,6 +351,7 @@ class TestContentViewFilter(CLITestCase):
                         'type': 'rpm',
                     })
 
+    @tier1
     def test_create_same_name_negative(self):
         """@Test: Try to create content view filter using same name twice
 
@@ -360,6 +373,7 @@ class TestContentViewFilter(CLITestCase):
                 'type': 'rpm',
             })
 
+    @tier1
     def test_create_no_type_negative(self):
         """@Test: Try to create content view filter without providing required
         parameter 'type'
@@ -375,6 +389,7 @@ class TestContentViewFilter(CLITestCase):
                 'name': gen_string('utf8'),
             })
 
+    @tier1
     def test_create_without_cv_negative(self):
         """@Test: Try to create content view filter without providing content
         view information which should be used as basis for filter
@@ -390,6 +405,7 @@ class TestContentViewFilter(CLITestCase):
                 'type': 'rpm',
             })
 
+    @tier1
     def test_create_repo_by_id_negative(self):
         """@Test: Try to create content view filter using incorrect repository
 
@@ -406,6 +422,7 @@ class TestContentViewFilter(CLITestCase):
                 'type': 'rpm',
             })
 
+    @tier2
     def test_update_cvf_different_names(self):
         """Test: Create new content view filter and assign it to existing
         content view by id. Try to update that filter using different value
@@ -437,6 +454,7 @@ class TestContentViewFilter(CLITestCase):
                 self.assertEqual(cvf['name'], new_name)
                 cvf_name = new_name  # updating cvf name for next iteration
 
+    @tier2
     def test_update_cvf_repo(self):
         """Test: Create new content view filter and apply it to existing
         content view that has repository assigned to it. Try to update that
@@ -482,6 +500,7 @@ class TestContentViewFilter(CLITestCase):
         self.assertNotEqual(cvf['repositories'][0]['name'], self.repo['name'])
         self.assertEqual(cvf['repositories'][0]['name'], new_repo['name'])
 
+    @tier2
     def test_update_cvf_repo_type(self):
         """Test: Create new content view filter and apply it to existing
         content view that has repository assigned to it. Try to update that
@@ -530,6 +549,7 @@ class TestContentViewFilter(CLITestCase):
         self.assertNotEqual(cvf['repositories'][0]['name'], self.repo['name'])
         self.assertEqual(cvf['repositories'][0]['name'], docker_repo['name'])
 
+    @tier2
     def test_update_cvf_inclusion(self):
         """Test: Create new content view filter and assign it to existing
         content view by id. Try to update that filter and assign opposite
@@ -564,6 +584,7 @@ class TestContentViewFilter(CLITestCase):
         })
         self.assertEqual(cvf['inclusion'], 'false')
 
+    @tier1
     def test_update_diffnames_negative(self):
         """@Test: Try to update content view filter using invalid names only
 
@@ -592,6 +613,7 @@ class TestContentViewFilter(CLITestCase):
                         u'name': new_name,
                     })
 
+    @tier1
     def test_update_samename_negative(self):
         """@Test: Try to update content view filter using name of already
         existing entity
@@ -620,6 +642,7 @@ class TestContentViewFilter(CLITestCase):
                 'new-name': cvf_name,
             })
 
+    @tier1
     def test_update_inclusion_negative(self):
         """Test: Try to update content view filter and assign incorrect
         inclusion value for it
@@ -648,6 +671,7 @@ class TestContentViewFilter(CLITestCase):
         })
         self.assertEqual(cvf['inclusion'], 'true')
 
+    @tier1
     def test_update_wrongrepo_negative(self):
         """Test: Try to update content view filter using non-existing
         repository ID
@@ -671,6 +695,7 @@ class TestContentViewFilter(CLITestCase):
                 'repository-ids': gen_string('numeric', 6),
             })
 
+    @tier1
     def test_update_new_repo_negative(self):
         """Test: Try to update filter and assign repository which does not
         belong to filter content view
@@ -695,6 +720,7 @@ class TestContentViewFilter(CLITestCase):
                 'repository-ids': new_repo['id'],
             })
 
+    @tier1
     def test_delete_cvf_different_names(self):
         """Test: Create new content view filter and assign it to existing
         content view by id. Try to delete that filter using different value
@@ -726,6 +752,7 @@ class TestContentViewFilter(CLITestCase):
                         u'name': name,
                     })
 
+    @tier1
     def test_delete_cvf_by_id(self):
         """Test: Create new content view filter and assign it to existing
         content view by id. Try to delete that filter using its id as a
@@ -753,6 +780,7 @@ class TestContentViewFilter(CLITestCase):
                 u'name': cvf_name,
             })
 
+    @tier1
     def test_delete_cvf_org(self):
         """Test: Create new content view filter and assign it to existing
         content view by id. Try to delete that filter using organization and
@@ -784,6 +812,7 @@ class TestContentViewFilter(CLITestCase):
                 u'name': cvf_name,
             })
 
+    @tier1
     def test_delete_cvf_name_negative(self):
         """Test: Try to delete non-existent filter using generated name
 

--- a/tests/foreman/cli/test_contentviews.py
+++ b/tests/foreman/cli/test_contentviews.py
@@ -21,7 +21,14 @@ from robottelo.cli.repository_set import RepositorySet
 from robottelo.cli.puppetmodule import PuppetModule
 from robottelo.cli.subscription import Subscription
 from robottelo.constants import DEFAULT_CV, ENVIRONMENT, FAKE_0_PUPPET_REPO
-from robottelo.decorators import run_only_on, skip_if_bug_open, stubbed
+from robottelo.decorators import (
+    run_only_on,
+    skip_if_bug_open,
+    stubbed,
+    tier1,
+    tier2,
+    tier3,
+)
 from robottelo.ssh import upload_file
 from robottelo.test import CLITestCase
 
@@ -142,6 +149,7 @@ class TestContentView(CLITestCase):
                 cached=True)
 
     # pylint: disable=unexpected-keyword-arg
+    @tier1
     @run_only_on('sat')
     def test_create_valid_names(self):
         """@test: create content views (positive)
@@ -158,6 +166,7 @@ class TestContentView(CLITestCase):
                 self.assertEqual(content_view['name'], test_data['name'])
 
     # pylint: disable=unexpected-keyword-arg
+    @tier1
     @run_only_on('sat')
     def test_create_invalid_names(self):
         """@test: create content views (negative)
@@ -174,6 +183,7 @@ class TestContentView(CLITestCase):
                 with self.assertRaises(CLIFactoryError):
                     make_content_view(test_data)
 
+    @tier1
     @run_only_on('sat')
     def test_create_invalid_org(self):
         # Use an invalid org name
@@ -189,6 +199,7 @@ class TestContentView(CLITestCase):
             ContentView.create({'organization-id': gen_string('alpha')})
 
     # pylint: disable=unexpected-keyword-arg
+    @tier1
     @run_only_on('sat')
     def test_cv_edit(self):
         """@test: edit content views - name, description, etc.
@@ -232,6 +243,7 @@ class TestContentView(CLITestCase):
         """
 
     # pylint: disable=unexpected-keyword-arg
+    @tier1
     @run_only_on('sat')
     def test_cv_delete(self):
         """@test: delete content views
@@ -249,6 +261,7 @@ class TestContentView(CLITestCase):
         with self.assertRaises(CLIReturnCodeError):
             ContentView.info({'id': con_view['id']})
 
+    @tier1
     def test_delete_cv_files(self):
         """@Test: Delete empty content view and verify it was actually deleted
         from hard drive.
@@ -287,6 +300,7 @@ class TestContentView(CLITestCase):
         self.assertEqual(result.return_code, 0)
         self.assertEqual(len(result.stdout), 0)
 
+    @tier1
     @skip_if_bug_open('bugzilla', 1265703)
     def test_delete_cv_custom_repo_files(self):
         """@Test: Delete content view containing custom repo and verify it was
@@ -337,6 +351,7 @@ class TestContentView(CLITestCase):
         self.assertEqual(result.return_code, 0)
         self.assertEqual(len(result.stdout), 0)
 
+    @tier2
     @run_only_on('sat')
     def test_delete_cv_version_name(self):
         """@test: Create content view and publish it. After that try to
@@ -367,6 +382,7 @@ class TestContentView(CLITestCase):
         content_view = ContentView.info({u'id': content_view['id']})
         self.assertEqual(len(content_view['versions']), 0)
 
+    @tier1
     @run_only_on('sat')
     def test_delete_cv_version_id(self):
         """@test: Create content view and publish it. After that try to
@@ -412,6 +428,7 @@ class TestContentView(CLITestCase):
         new_cv = ContentView.info({u'id': new_cv['id']})
         self.assertEqual(len(new_cv['versions']), 0)
 
+    @tier2
     @run_only_on('sat')
     def test_delete_cv_version_negative(self):
         """@test: Create content view and publish it. Try to delete content
@@ -435,6 +452,7 @@ class TestContentView(CLITestCase):
         content_view = ContentView.info({u'id': content_view['id']})
         self.assertEqual(len(content_view['versions']), 1)
 
+    @tier1
     @run_only_on('sat')
     def test_remove_cv_environment(self):
         """@Test: Remove content view from lifecycle environment assignment
@@ -457,6 +475,7 @@ class TestContentView(CLITestCase):
         new_cv = ContentView.info({u'id': new_cv['id']})
         self.assertEqual(len(new_cv['lifecycle-environments']), 0)
 
+    @tier2
     @run_only_on('sat')
     def test_remove_cv_and_reassign_ak(self):
         """Test: Remove content view environment and re-assign activation key
@@ -513,6 +532,7 @@ class TestContentView(CLITestCase):
         destination_cv = ContentView.info({u'id': destination_cv['id']})
         self.assertEqual(destination_cv['activation-keys'][0], ac_key['name'])
 
+    @tier2
     @run_only_on('sat')
     def test_remove_cv_reassign_ch(self):
         """Test: Remove content view environment and re-assign content host
@@ -574,6 +594,7 @@ class TestContentView(CLITestCase):
         destination_cv = ContentView.info({u'id': destination_cv['id']})
         self.assertEqual(destination_cv['content-host-count'], '1')
 
+    @tier1
     @run_only_on('sat')
     def test_remove_cv_version(self):
         """@Test: Delete content view version through 'remove' command
@@ -602,6 +623,7 @@ class TestContentView(CLITestCase):
         new_cv = ContentView.info({u'id': new_cv['id']})
         self.assertEqual(len(new_cv['versions']), 0)
 
+    @tier2
     @run_only_on('sat')
     def test_cv_composite_create(self):
         # Note: puppet repos cannot/should not be used in this test
@@ -655,10 +677,11 @@ class TestContentView(CLITestCase):
     # katello content definition add_filter --label=MyView
     #   --filter=stable --org=ACME
     # katello content definition add_product --label=MyView
-    #   --product=product1 --org=ACME
+    #   --product=productier1 --org=ACME
     # katello content definition add_repo --label=MyView
     #   --repo=repo1 --org=ACME
 
+    @tier2
     @run_only_on('sat')
     def test_associate_view_rh(self):
         """@test: associate Red Hat content in a view
@@ -688,6 +711,7 @@ class TestContentView(CLITestCase):
             'Repo was not associated to CV',
         )
 
+    @tier2
     @run_only_on('sat')
     def test_associate_rh_content(self):
         """@test: associate Red Hat content in a view
@@ -731,6 +755,7 @@ class TestContentView(CLITestCase):
             'name': 'walgrind',
         })
 
+    @tier2
     @run_only_on('sat')
     def test_associate_custom_content(self):
         """@test: associate Red Hat content in a view
@@ -759,6 +784,7 @@ class TestContentView(CLITestCase):
             'Repo was not associated to CV',
         )
 
+    @tier1
     @run_only_on('sat')
     def test_add_custom_repos_with_name(self):
         """@test: add custom repos to cv with names
@@ -787,6 +813,7 @@ class TestContentView(CLITestCase):
             'Repo was not associated to CV',
         )
 
+    @tier2
     @run_only_on('sat')
     def test_invalid_puppet_repo(self):
         # Again, individual modules should be ok.
@@ -812,6 +839,7 @@ class TestContentView(CLITestCase):
                 u'repository-id': new_repo['id'],
             })
 
+    @tier2
     @run_only_on('sat')
     def test_associate_comp_negative(self):
         """@test: attempt to associate components in a non-composite
@@ -846,6 +874,7 @@ class TestContentView(CLITestCase):
                 u'organization-id': self.org['id'],
             })
 
+    @tier2
     @run_only_on('sat')
     def test_add_dupe_repo(self):
         """@test: attempt to associate the same repo multiple times within a
@@ -885,6 +914,7 @@ class TestContentView(CLITestCase):
             'No new entry of same repo is expected',
         )
 
+    @tier2
     @run_only_on('sat')
     @skip_if_bug_open('bugzilla', 1222118)
     def test_add_dupe_puppet_module(self):
@@ -934,6 +964,7 @@ class TestContentView(CLITestCase):
     # katello content view promote --label=MyView --env=Dev --org=ACME
     # katello content view promote --view=MyView --env=Staging --org=ACME
 
+    @tier2
     @run_only_on('sat')
     def test_cv_promote_rh(self):
         """@test: attempt to promote a content view containing RH content
@@ -989,6 +1020,7 @@ class TestContentView(CLITestCase):
 
         """
 
+    @tier2
     @run_only_on('sat')
     def test_promote_custom_content(self):
         """@test: attempt to promote a content view containing custom content
@@ -1025,6 +1057,7 @@ class TestContentView(CLITestCase):
             new_cv['lifecycle-environments'],
         )
 
+    @tier2
     @run_only_on('sat')
     def test_promote_composite(self):
         # Variations:
@@ -1083,6 +1116,7 @@ class TestContentView(CLITestCase):
             con_view['lifecycle-environments'],
         )
 
+    @tier2
     @run_only_on('sat')
     def test_promote_defaultcv_negative(self):
         """@test: attempt to promote the default content views
@@ -1107,6 +1141,7 @@ class TestContentView(CLITestCase):
                 u'to-lifecycle-environment-id': self.env1['id'],
             })
 
+    @tier2
     @run_only_on('sat')
     def test_promote_invalid_env(self):
         """@test: attempt to promote a content view using an invalid
@@ -1143,6 +1178,7 @@ class TestContentView(CLITestCase):
     # Content Views: publish
     # katello content definition publish --label=MyView
 
+    @tier2
     @run_only_on('sat')
     def test_cv_publish_rh(self):
         """@test: attempt to publish a content view containing RH content
@@ -1193,6 +1229,7 @@ class TestContentView(CLITestCase):
 
         """
 
+    @tier2
     @run_only_on('sat')
     def test_cv_publish_custom_content(self):
         """@test: attempt to publish a content view containing custom content
@@ -1228,6 +1265,7 @@ class TestContentView(CLITestCase):
             'Publishing new version of CV was not successful',
         )
 
+    @tier2
     @run_only_on('sat')
     def test_cv_publish_composite(self):
         # Variations:
@@ -1292,6 +1330,7 @@ class TestContentView(CLITestCase):
             'Publishing new version of CV was not successful'
         )
 
+    @tier2
     @run_only_on('sat')
     def test_version_update_1(self):
         # Dev notes:
@@ -1378,6 +1417,7 @@ class TestContentView(CLITestCase):
             'Promotion of version2 not successful to the env',
         )
 
+    @tier2
     @run_only_on('sat')
     def test_version_update_2(self):
         # Dev notes:
@@ -1471,6 +1511,7 @@ class TestContentView(CLITestCase):
             'version1 still exists in the next env',
         )
 
+    @tier3
     @run_only_on('sat')
     def test_cv_subscribe_system(self):
         """@test: Attempt to subscribe content host to content view
@@ -1501,6 +1542,7 @@ class TestContentView(CLITestCase):
         content_view = ContentView.info({u'id': content_view['id']})
         self.assertEqual(content_view['content-host-count'], '1')
 
+    @tier3
     @run_only_on('sat')
     def test_cv_subscribe_rh1(self):
         """@test: Attempt to subscribe content host to content view that has
@@ -1547,6 +1589,7 @@ class TestContentView(CLITestCase):
         content_view = ContentView.info({u'id': content_view['id']})
         self.assertEqual(content_view['content-host-count'], '1')
 
+    @tier3
     @run_only_on('sat')
     def test_cv_subscribe_rh2(self):
         """@test: Attempt to subscribe content host to filtered content view
@@ -1610,6 +1653,7 @@ class TestContentView(CLITestCase):
         content_view = ContentView.info({u'id': content_view['id']})
         self.assertEqual(content_view['content-host-count'], '1')
 
+    @tier3
     @run_only_on('sat')
     def test_cv_subscribe_system_custom(self):
         """@test: Attempt to subscribe content host to content view that has
@@ -1653,6 +1697,7 @@ class TestContentView(CLITestCase):
         content_view = ContentView.info({u'id': content_view['id']})
         self.assertEqual(content_view['content-host-count'], '1')
 
+    @tier3
     @run_only_on('sat')
     def test_subscribe_system_ccv(self):
         """@test: Attempt to subscribe content host to composite content view
@@ -1688,6 +1733,7 @@ class TestContentView(CLITestCase):
         content_view = ContentView.info({u'id': content_view['id']})
         self.assertEqual(content_view['content-host-count'], '1')
 
+    @tier3
     @run_only_on('sat')
     @skip_if_bug_open('bugzilla', 1222118)
     def test_cv_subscribe_system_puppet(self):
@@ -1815,6 +1861,7 @@ class TestContentView(CLITestCase):
     # All this stuff is speculative at best.
 
     # pylint: disable=unexpected-keyword-arg
+    @tier1
     @run_only_on('sat')
     def test_cv_admin_user_negative(self):
         # Note:

--- a/tests/foreman/cli/test_docker.py
+++ b/tests/foreman/cli/test_docker.py
@@ -23,7 +23,14 @@ from robottelo.cli.repository import Repository
 from robottelo.config import settings
 from robottelo.constants import DOCKER_REGISTRY_HUB
 from robottelo.datafactory import valid_data_list
-from robottelo.decorators import run_only_on, skip_if_bug_open, stubbed
+from robottelo.decorators import (
+    run_only_on,
+    skip_if_bug_open,
+    stubbed,
+    tier1,
+    tier2,
+    tier3,
+)
 from robottelo.helpers import install_katello_ca, remove_katello_ca
 from robottelo.test import CLITestCase
 
@@ -57,6 +64,7 @@ def _make_docker_repo(product_id, name=None, upstream_name=None):
 class DockerImageTestCase(CLITestCase):
     """Tests related to docker image command"""
 
+    @tier2
     def test_bugzilla_1190122(self):
         """@Test: docker image displays tags information for a docker image
 
@@ -107,6 +115,7 @@ class DockerRepositoryTestCase(CLITestCase):
         super(DockerRepositoryTestCase, cls).setUpClass()
         cls.org_id = make_org()['id']
 
+    @tier1
     @run_only_on('sat')
     def test_create_one_docker_repo(self):
         """@Test: Create one Docker-type repository
@@ -127,6 +136,7 @@ class DockerRepositoryTestCase(CLITestCase):
                     repo['upstream-repository-name'], REPO_UPSTREAM_NAME)
                 self.assertEqual(repo['content-type'], REPO_CONTENT_TYPE)
 
+    @tier1
     @run_only_on('sat')
     def test_create_multiple_docker_repo(self):
         """@Test: Create multiple Docker-type repositories
@@ -151,6 +161,7 @@ class DockerRepositoryTestCase(CLITestCase):
             set([repo_['repo-name'] for repo_ in product['content']]),
         )
 
+    @tier1
     @run_only_on('sat')
     def test_create_multiple_docker_repo_multiple_products(self):
         """@Test: Create multiple Docker-type repositories on multiple
@@ -177,6 +188,7 @@ class DockerRepositoryTestCase(CLITestCase):
                 set([repo_['repo-name'] for repo_ in product['content']]),
             )
 
+    @tier1
     @run_only_on('sat')
     def test_sync_docker_repo(self):
         """@Test: Create and sync a Docker-type repository
@@ -195,6 +207,7 @@ class DockerRepositoryTestCase(CLITestCase):
         self.assertGreaterEqual(
             int(repo['content-counts']['docker-images']), 1)
 
+    @tier1
     @run_only_on('sat')
     def test_update_docker_repo_name(self):
         """@Test: Create a Docker-type repository and update its name.
@@ -217,6 +230,7 @@ class DockerRepositoryTestCase(CLITestCase):
                 repo = Repository.info({'id': repo['id']})
                 self.assertEqual(repo['name'], new_name)
 
+    @tier1
     @run_only_on('sat')
     def test_update_docker_repo_upstream_name(self):
         """@Test: Create a Docker-type repository and update its upstream name.
@@ -238,6 +252,7 @@ class DockerRepositoryTestCase(CLITestCase):
         repo = Repository.info({'id': repo['id']})
         self.assertEqual(repo['upstream-repository-name'], new_upstream_name)
 
+    @tier1
     @run_only_on('sat')
     def test_update_docker_repo_url(self):
         """@Test: Create a Docker-type repository and update its URL.
@@ -258,6 +273,7 @@ class DockerRepositoryTestCase(CLITestCase):
         repo = Repository.info({'id': repo['id']})
         self.assertEqual(repo['url'], new_url)
 
+    @tier1
     @run_only_on('sat')
     def test_delete_docker_repo(self):
         """@Test: Create and delete a Docker-type repository
@@ -273,6 +289,7 @@ class DockerRepositoryTestCase(CLITestCase):
         with self.assertRaises(CLIReturnCodeError):
             Repository.info({'id': repo['id']})
 
+    @tier1
     @run_only_on('sat')
     def test_delete_random_docker_repo(self):
         """@Test: Create Docker-type repositories on multiple products and
@@ -345,6 +362,7 @@ class DockerContentViewTestCase(CLITestCase):
             ],
         )
 
+    @tier1
     @run_only_on('sat')
     def test_add_docker_repo_to_content_view(self):
         """@Test: Add one Docker-type repository to a non-composite content view
@@ -371,6 +389,7 @@ class DockerContentViewTestCase(CLITestCase):
             [repo_['id'] for repo_ in content_view['docker-repositories']],
         )
 
+    @tier1
     @run_only_on('sat')
     def test_add_multiple_docker_repos_to_content_view(self):
         """@Test: Add multiple Docker-type repositories to a
@@ -403,6 +422,7 @@ class DockerContentViewTestCase(CLITestCase):
             set([repo['id'] for repo in content_view['docker-repositories']]),
         )
 
+    @tier2
     @run_only_on('sat')
     def test_add_synced_docker_repo_to_content_view(self):
         """@Test: Create and sync a Docker-type repository
@@ -433,6 +453,7 @@ class DockerContentViewTestCase(CLITestCase):
             [repo_['id'] for repo_ in content_view['docker-repositories']],
         )
 
+    @tier1
     @run_only_on('sat')
     def test_add_docker_repo_to_composite_content_view(self):
         """@Test: Add one Docker-type repository to a composite content view
@@ -465,6 +486,7 @@ class DockerContentViewTestCase(CLITestCase):
             [component['id'] for component in comp_content_view['components']],
         )
 
+    @tier1
     @run_only_on('sat')
     def test_add_multiple_docker_repos_to_composite_content_view(self):
         """@Test: Add multiple Docker-type repositories to a composite
@@ -514,6 +536,7 @@ class DockerContentViewTestCase(CLITestCase):
                 ],
             )
 
+    @tier2
     @run_only_on('sat')
     def test_publish_once_docker_repo_content_view(self):
         """@Test: Add Docker-type repository to content view and publish
@@ -533,6 +556,7 @@ class DockerContentViewTestCase(CLITestCase):
         })
         self.assertEqual(len(self.content_view['versions']), 1)
 
+    @tier2
     @run_only_on('sat')
     def test_publish_once_docker_repo_composite_content_view(self):
         """@Test: Add Docker-type repository to composite
@@ -577,6 +601,7 @@ class DockerContentViewTestCase(CLITestCase):
         })
         self.assertEqual(len(comp_content_view['versions']), 1)
 
+    @tier2
     @run_only_on('sat')
     def test_publish_multiple_docker_repo_content_view(self):
         """@Test: Add Docker-type repository to content view and publish it
@@ -598,6 +623,7 @@ class DockerContentViewTestCase(CLITestCase):
         })
         self.assertEqual(len(self.content_view['versions']), publish_amount)
 
+    @tier2
     @run_only_on('sat')
     def test_publish_multiple_docker_repo_composite_content_view(self):
         """@Test: Add Docker-type repository to content view and publish it
@@ -643,6 +669,7 @@ class DockerContentViewTestCase(CLITestCase):
         })
         self.assertEqual(len(comp_content_view['versions']), publish_amount)
 
+    @tier2
     @run_only_on('sat')
     def test_promote_docker_repo_content_view(self):
         """@Test: Add Docker-type repository to content view and publish it.
@@ -673,6 +700,7 @@ class DockerContentViewTestCase(CLITestCase):
         })
         self.assertEqual(len(cvv['lifecycle-environments']), 2)
 
+    @tier2
     @run_only_on('sat')
     def test_promote_multiple_docker_repo_content_view(self):
         """@Test: Add Docker-type repository to content view and publish it.
@@ -704,6 +732,7 @@ class DockerContentViewTestCase(CLITestCase):
             })
             self.assertEqual(len(cvv['lifecycle-environments']), i+1)
 
+    @tier2
     @run_only_on('sat')
     def test_promote_docker_repo_composite_content_view(self):
         """@Test: Add Docker-type repository to composite content view and
@@ -758,6 +787,7 @@ class DockerContentViewTestCase(CLITestCase):
         })
         self.assertEqual(len(cvv['lifecycle-environments']), 2)
 
+    @tier2
     @run_only_on('sat')
     def test_promote_multiple_docker_repo_composite_content_view(self):
         """@Test: Add Docker-type repository to composite content view and
@@ -854,6 +884,7 @@ class DockerActivationKeyTestCase(CLITestCase):
             'id': cls.content_view['versions'][0]['id'],
         })
 
+    @tier2
     @run_only_on('sat')
     def test_add_docker_repo_to_activation_key(self):
         """@Test: Add Docker-type repository to a non-composite content view
@@ -873,6 +904,7 @@ class DockerActivationKeyTestCase(CLITestCase):
         self.assertEqual(
             activation_key['content-view'], self.content_view['name'])
 
+    @tier2
     @run_only_on('sat')
     def test_remove_docker_repo_to_activation_key(self):
         """@Test: Add Docker-type repository to a non-composite content view
@@ -918,6 +950,7 @@ class DockerActivationKeyTestCase(CLITestCase):
         self.assertNotEqual(
             activation_key['content-view'], self.content_view['name'])
 
+    @tier2
     @run_only_on('sat')
     def test_add_docker_repo_composite_view_to_activation_key(self):
         """@Test: Add Docker-type repository to a non-composite content view
@@ -968,6 +1001,7 @@ class DockerActivationKeyTestCase(CLITestCase):
         self.assertEqual(
             activation_key['content-view'], comp_content_view['name'])
 
+    @tier1
     @run_only_on('sat')
     def test_remove_docker_repo_composite_view_to_activation_key(self):
         """@Test: Add Docker-type repository to a non-composite content view
@@ -1107,6 +1141,7 @@ class DockerComputeResourceTestCase(CLITestCase):
         super(DockerComputeResourceTestCase, cls).setUpClass()
         cls.org = make_org()
 
+    @tier3
     @run_only_on('sat')
     def test_create_internal_docker_compute_resource(self):
         """@Test: Create a Docker-based Compute Resource in the Satellite 6
@@ -1131,6 +1166,7 @@ class DockerComputeResourceTestCase(CLITestCase):
                     settings.docker.get_unix_socket_url()
                 )
 
+    @tier3
     @run_only_on('sat')
     def test_update_docker_compute_resource(self):
         """@Test: Create a Docker-based Compute Resource in the Satellite 6
@@ -1160,6 +1196,7 @@ class DockerComputeResourceTestCase(CLITestCase):
                 })
                 self.assertEqual(compute_resource['url'], new_url)
 
+    @tier3
     @run_only_on('sat')
     def test_list_containers_docker_compute_resource(self):
         """@Test: Create a Docker-based Compute Resource in the Satellite 6
@@ -1194,6 +1231,7 @@ class DockerComputeResourceTestCase(CLITestCase):
                 self.assertEqual(len(result), 1)
                 self.assertEqual(result[0]['name'], container['name'])
 
+    @tier3
     @run_only_on('sat')
     def test_create_external_docker_compute_resource(self):
         """@Test: Create a Docker-based Compute Resource using an external
@@ -1216,6 +1254,7 @@ class DockerComputeResourceTestCase(CLITestCase):
                 self.assertEqual(
                     compute_resource['url'], settings.docker.external_url)
 
+    @tier3
     @run_only_on('sat')
     def test_delete_docker_compute_resource(self):
         """@Test: Create a Docker-based Compute Resource then delete it.
@@ -1268,6 +1307,7 @@ class DockerContainersTestCase(CLITestCase):
         remove_katello_ca()
         super(DockerContainersTestCase, cls).tearDownClass()
 
+    @tier3
     @run_only_on('sat')
     def test_create_container(self):
         """@Test: Create containers for local and external compute resources
@@ -1286,6 +1326,7 @@ class DockerContainersTestCase(CLITestCase):
                 self.assertEqual(
                     container['compute-resource'], compute_resource['name'])
 
+    @tier3
     @run_only_on('sat')
     @skip_if_bug_open('bugzilla', 1282431)
     def test_create_container_content_view(self):
@@ -1334,6 +1375,7 @@ class DockerContainersTestCase(CLITestCase):
                 )
                 self.assertEqual(container['tag'], 'latest')
 
+    @tier3
     @run_only_on('sat')
     @skip_if_bug_open('bugzilla', 1230915)
     @skip_if_bug_open('bugzilla', 1269196)
@@ -1365,6 +1407,7 @@ class DockerContainersTestCase(CLITestCase):
                 status = Docker.container.status({'id': container['id']})
                 self.assertEqual(status[0], not_running_msg)
 
+    @tier3
     @run_only_on('sat')
     @skip_if_bug_open('bugzilla', 1230915)
     @skip_if_bug_open('bugzilla', 1269208)
@@ -1405,6 +1448,7 @@ class DockerContainersTestCase(CLITestCase):
 
         """
 
+    @tier3
     @run_only_on('sat')
     @skip_if_bug_open('bugzilla', 1230915)
     def test_delete_container(self):
@@ -1435,6 +1479,7 @@ class DockerRegistriesTestCase(CLITestCase):
 
     """
 
+    @tier1
     @run_only_on('sat')
     @skip_if_bug_open('bugzilla', 1259498)
     def test_create_registry(self):
@@ -1460,6 +1505,7 @@ class DockerRegistriesTestCase(CLITestCase):
                 self.assertEqual(registry['description'], description)
                 self.assertEqual(registry['url'], url)
 
+    @tier1
     @run_only_on('sat')
     @skip_if_bug_open('bugzilla', 1259498)
     def test_update_registry_name_by_id(self):
@@ -1483,6 +1529,7 @@ class DockerRegistriesTestCase(CLITestCase):
                 registry = Docker.registry.info({'id': registry['id']})
                 self.assertEqual(registry['name'], new_name)
 
+    @tier1
     @run_only_on('sat')
     def test_update_registry_name_by_name(self):
         """@Test: Create an external docker registry and update its name. Use
@@ -1503,6 +1550,7 @@ class DockerRegistriesTestCase(CLITestCase):
                 registry = Docker.registry.info({'name': new_name})
                 self.assertEqual(registry['name'], new_name)
 
+    @tier1
     @run_only_on('sat')
     @skip_if_bug_open('bugzilla', 1259498)
     def test_update_registry_url_by_id(self):
@@ -1525,6 +1573,7 @@ class DockerRegistriesTestCase(CLITestCase):
         registry = Docker.registry.info({'id': registry['id']})
         self.assertEqual(registry['url'], new_url)
 
+    @tier1
     @run_only_on('sat')
     def test_update_registry_url_by_name(self):
         """@Test: Create an external docker registry and update its URL. Use
@@ -1544,6 +1593,7 @@ class DockerRegistriesTestCase(CLITestCase):
         registry = Docker.registry.info({'name': registry['name']})
         self.assertEqual(registry['url'], new_url)
 
+    @tier1
     @run_only_on('sat')
     @skip_if_bug_open('bugzilla', 1259498)
     def test_update_registry_description_by_id(self):
@@ -1567,6 +1617,7 @@ class DockerRegistriesTestCase(CLITestCase):
                 registry = Docker.registry.info({'id': registry['id']})
                 self.assertEqual(registry['description'], new_desc)
 
+    @tier1
     @run_only_on('sat')
     @skip_if_bug_open('bugzilla', 1259498)
     def test_update_registry_description_by_name(self):
@@ -1590,6 +1641,7 @@ class DockerRegistriesTestCase(CLITestCase):
                 registry = Docker.registry.info({'name': registry['name']})
                 self.assertEqual(registry['description'], new_desc)
 
+    @tier1
     @run_only_on('sat')
     @skip_if_bug_open('bugzilla', 1259498)
     def test_update_registry_username_by_id(self):
@@ -1613,6 +1665,7 @@ class DockerRegistriesTestCase(CLITestCase):
                 registry = Docker.registry.info({'id': registry['id']})
                 self.assertEqual(registry['username'], new_user)
 
+    @tier1
     @run_only_on('sat')
     @skip_if_bug_open('bugzilla', 1259498)
     def test_update_registry_username_by_name(self):
@@ -1636,6 +1689,7 @@ class DockerRegistriesTestCase(CLITestCase):
                 registry = Docker.registry.info({'name': registry['name']})
                 self.assertEqual(registry['username'], new_user)
 
+    @tier1
     @run_only_on('sat')
     @skip_if_bug_open('bugzilla', 1259498)
     def test_delete_registry_by_id(self):
@@ -1654,6 +1708,7 @@ class DockerRegistriesTestCase(CLITestCase):
         with self.assertRaises(CLIReturnCodeError):
             Docker.registry.info({'id': registry['id']})
 
+    @tier1
     @run_only_on('sat')
     def test_delete_registry_by_name(self):
         """@Test: Create an external docker registry. Use registry name to

--- a/tests/foreman/cli/test_domain.py
+++ b/tests/foreman/cli/test_domain.py
@@ -6,7 +6,7 @@ from robottelo.cli.domain import Domain
 from robottelo.cli.factory import CLIFactoryError
 from robottelo.cli.factory import make_domain, make_location, make_org
 from robottelo.datafactory import invalid_id_list, valid_data_list
-from robottelo.decorators import run_only_on
+from robottelo.decorators import run_only_on, tier1
 from robottelo.test import CLITestCase
 
 
@@ -101,6 +101,7 @@ class TestDomain(CLITestCase):
     factory = make_domain
     factory_obj = Domain
 
+    @tier1
     @run_only_on('sat')
     def test_positive_create(self):
         """@Test: Create domain with valid name and description
@@ -117,6 +118,7 @@ class TestDomain(CLITestCase):
                 self.assertEqual(
                     domain['description'], options['description'])
 
+    @tier1
     @run_only_on('sat')
     def test_create_domain_with_location(self):
         """@Test: Check if domain with location can be created
@@ -130,6 +132,7 @@ class TestDomain(CLITestCase):
         domain = make_domain({'location-ids': location['id']})
         self.assertIn(location['name'], domain['locations'])
 
+    @tier1
     @run_only_on('sat')
     def test_create_domain_with_organization(self):
         """@Test: Check if domain with organization can be created
@@ -143,6 +146,7 @@ class TestDomain(CLITestCase):
         domain = make_domain({'organization-ids': org['id']})
         self.assertIn(org['name'], domain['organizations'])
 
+    @tier1
     @run_only_on('sat')
     def test_negative_create(self):
         """@Test: Create domain with invalid values
@@ -157,6 +161,7 @@ class TestDomain(CLITestCase):
                 with self.assertRaises(CLIFactoryError):
                     make_domain(options)
 
+    @tier1
     @run_only_on('sat')
     def test_positive_update(self):
         """@Test: Update domain with valid values
@@ -178,6 +183,7 @@ class TestDomain(CLITestCase):
                 for key, val in options.iteritems():
                     self.assertEqual(domain[key], val)
 
+    @tier1
     @run_only_on('sat')
     def test_negative_update(self):
         """@Test: Update domain with invalid values
@@ -197,6 +203,7 @@ class TestDomain(CLITestCase):
                 for key in options.keys():
                     self.assertEqual(result[key], domain[key])
 
+    @tier1
     @run_only_on('sat')
     def test_positive_set_parameter(self):
         """@Test: Domain set-parameter with valid key and value
@@ -218,6 +225,7 @@ class TestDomain(CLITestCase):
                 }
                 self.assertDictEqual(parameter, domain['parameters'])
 
+    @tier1
     @run_only_on('sat')
     def test_negative_set_parameter(self):
         """@Test: Domain set-parameter with invalid values
@@ -238,6 +246,7 @@ class TestDomain(CLITestCase):
                 domain = Domain.info({'id': domain['id']})
                 self.assertEqual(len(domain['parameters']), 0)
 
+    @tier1
     @run_only_on('sat')
     def test_positive_delete(self):
         """@test: Create Domain with valid values then delete it
@@ -254,6 +263,7 @@ class TestDomain(CLITestCase):
                 with self.assertRaises(CLIReturnCodeError):
                     Domain.info({'id': domain['id']})
 
+    @tier1
     @run_only_on('sat')
     def test_negative_delete(self):
         """@test: Create Domain then delete it by wrong ID
@@ -267,6 +277,7 @@ class TestDomain(CLITestCase):
                 with self.assertRaises(CLIReturnCodeError):
                     Domain.delete({'id': entity_id})
 
+    @tier1
     @run_only_on('sat')
     def test_positive_delete_parameter(self):
         """@Test: Domain delete-parameter removes parameter

--- a/tests/foreman/cli/test_environment.py
+++ b/tests/foreman/cli/test_environment.py
@@ -9,12 +9,19 @@ from robottelo.datafactory import (
     invalid_values_list,
     valid_environments_list,
 )
-from robottelo.decorators import bz_bug_is_open, run_only_on, skip_if_bug_open
+from robottelo.decorators import (
+    bz_bug_is_open,
+    run_only_on,
+    skip_if_bug_open,
+    tier1,
+    tier2,
+)
 from robottelo.test import CLITestCase
 
 
 class TestEnvironment(CLITestCase):
     """Test class for Environment CLI"""
+    @tier2
     @run_only_on('sat')
     def test_positive_list(self):
         """@Test: Test Environment List
@@ -32,6 +39,7 @@ class TestEnvironment(CLITestCase):
                 self.assertEqual(len(result), 1)
                 self.assertEqual(result[0]['name'], name)
 
+    @tier1
     def test_positive_create(self):
         """@Test: Successfully creates an Environment.
 
@@ -44,6 +52,7 @@ class TestEnvironment(CLITestCase):
                 environment = make_environment({'name': name})
                 self.assertEqual(environment['name'], name)
 
+    @tier1
     def test_negative_create(self):
         """@Test: Don't create an Environment with invalid data.
 
@@ -56,6 +65,7 @@ class TestEnvironment(CLITestCase):
                 with self.assertRaises(CLIReturnCodeError):
                     Environment.create({'name': name})
 
+    @tier1
     @run_only_on('sat')
     def test_create_environment_with_location(self):
         """@Test: Check if Environment with Location can be created
@@ -72,6 +82,7 @@ class TestEnvironment(CLITestCase):
         })
         self.assertIn(new_loc['name'], new_environment['locations'])
 
+    @tier1
     @run_only_on('sat')
     def test_create_environment_with_organization(self):
         """@Test: Check if Environment with Organization can be created
@@ -88,6 +99,7 @@ class TestEnvironment(CLITestCase):
         })
         self.assertIn(new_org['name'], new_environment['organizations'])
 
+    @tier1
     @run_only_on('sat')
     def test_positive_delete(self):
         """@test: Create Environment with valid values then delete it
@@ -104,6 +116,7 @@ class TestEnvironment(CLITestCase):
                 with self.assertRaises(CLIReturnCodeError):
                     Environment.info({'id': environment['id']})
 
+    @tier1
     @run_only_on('sat')
     def test_negative_delete(self):
         """@test: Create Environment then delete it by wrong ID
@@ -117,6 +130,7 @@ class TestEnvironment(CLITestCase):
                 with self.assertRaises(CLIReturnCodeError):
                     Environment.delete({'id': entity_id})
 
+    @tier1
     @run_only_on('sat')
     def test_positive_delete_by_name(self):
         """@Test: Delete the environment by its name.
@@ -130,6 +144,7 @@ class TestEnvironment(CLITestCase):
         with self.assertRaises(CLIReturnCodeError):
             Environment.info({'name': environment['name']})
 
+    @tier1
     @run_only_on('sat')
     def test_positive_update(self):
         """@Test: Update the environment
@@ -148,6 +163,7 @@ class TestEnvironment(CLITestCase):
                 environment = Environment.info({'id': environment['id']})
                 self.assertEqual(environment['name'], new_name)
 
+    @tier1
     @run_only_on('sat')
     def test_negative_update(self):
         """@Test: Update the Environment with invalid values
@@ -167,6 +183,7 @@ class TestEnvironment(CLITestCase):
                 result = Environment.info({'id': environment['id']})
                 self.assertEqual(environment['name'], result['name'])
 
+    @tier1
     @run_only_on('sat')
     def test_update_location(self):
         """@Test: Update environment location with new value
@@ -188,6 +205,7 @@ class TestEnvironment(CLITestCase):
         self.assertIn(new_loc['name'], new_env['locations'])
         self.assertNotIn(old_loc['name'], new_env['locations'])
 
+    @tier1
     @run_only_on('sat')
     def test_update_organization(self):
         """@Test: Update environment organization with new value
@@ -213,6 +231,7 @@ class TestEnvironment(CLITestCase):
         self.assertIn(new_org['name'], env['organizations'])
         self.assertNotIn(old_org['name'], env['organizations'])
 
+    @tier1
     @skip_if_bug_open('bugzilla', 1219934)
     @run_only_on('sat')
     def test_sc_params_by_environment_id(self):
@@ -233,6 +252,7 @@ class TestEnvironment(CLITestCase):
         if not bz_bug_is_open(1219934):
             self.fail('BZ #1219934 is closed, should assert the content')
 
+    @tier1
     @skip_if_bug_open('bugzilla', 1219934)
     @run_only_on('sat')
     def test_sc_params_by_environment_name(self):

--- a/tests/foreman/cli/test_fact.py
+++ b/tests/foreman/cli/test_fact.py
@@ -2,7 +2,7 @@
 
 from fauxfactory import gen_string
 from robottelo.cli.fact import Fact
-from robottelo.decorators import run_only_on, stubbed
+from robottelo.decorators import run_only_on, stubbed, tier1
 from robottelo.test import CLITestCase
 
 
@@ -11,6 +11,7 @@ class TestFact(CLITestCase):
 
     @stubbed('Need to create facts before we can check them.')
     @run_only_on('sat')
+    @tier1
     def test_list_success(self):
         """@Test: Test Fact List
 
@@ -27,6 +28,7 @@ class TestFact(CLITestCase):
                 self.assertEqual(facts[0]['fact'], fact)
 
     @run_only_on('sat')
+    @tier1
     def test_list_fail(self):
         """@Test: Test Fact List failure
 

--- a/tests/foreman/cli/test_globalparam.py
+++ b/tests/foreman/cli/test_globalparam.py
@@ -3,7 +3,7 @@
 
 from fauxfactory import gen_string
 from robottelo.cli.globalparam import GlobalParameter
-from robottelo.decorators import run_only_on
+from robottelo.decorators import run_only_on, tier1
 from robottelo.test import CLITestCase
 
 
@@ -12,6 +12,7 @@ class TestGlobalParameter(CLITestCase):
 
     # pylint: disable=no-self-use
     @run_only_on('sat')
+    @tier1
     def test_set(self):
         """@Test: Check if Global Param can be set
 
@@ -29,6 +30,7 @@ class TestGlobalParameter(CLITestCase):
         })
 
     @run_only_on('sat')
+    @tier1
     def test_list(self):
         """@Test: Test Global Param List
 
@@ -49,6 +51,7 @@ class TestGlobalParameter(CLITestCase):
         self.assertEqual(result[0]['value'], value)
 
     @run_only_on('sat')
+    @tier1
     def test_delete(self):
         """@Test: Check if Global Param can be deleted
 

--- a/tests/foreman/cli/test_gpgkey.py
+++ b/tests/foreman/cli/test_gpgkey.py
@@ -8,7 +8,12 @@ from robottelo.cli.factory import make_gpg_key, make_org
 from robottelo.cli.gpgkey import GPGKey
 from robottelo.cli.org import Org
 from robottelo.constants import VALID_GPG_KEY_FILE
-from robottelo.decorators import run_only_on, skip_if_bug_open, stubbed
+from robottelo.decorators import (
+    run_only_on,
+    skip_if_bug_open,
+    stubbed,
+    tier1,
+)
 from robottelo.helpers import get_data_file
 from robottelo.test import CLITestCase
 from tempfile import mkstemp
@@ -46,7 +51,6 @@ def negative_create_data():
 def create_gpg_key_file(content=None):
     """Creates a fake GPG Key file and returns its path or None if an error
     happens.
-
     """
 
     (_, key_filename) = mkstemp(text=True)
@@ -68,7 +72,6 @@ class TestGPGKey(CLITestCase):
     def setUpClass(cls):  # noqa
         """Create a shared organization for all tests to avoid generating
         hundreds of organizations
-
         """
         super(TestGPGKey, cls).setUpClass()
         # pylint: disable=unexpected-keyword-arg
@@ -78,6 +81,7 @@ class TestGPGKey(CLITestCase):
 
     @skip_if_bug_open('redmine', 4272)
     @run_only_on('sat')
+    @tier1
     def test_redmine_4272(self):
         """@Test: gpg info should display key content
 
@@ -86,7 +90,6 @@ class TestGPGKey(CLITestCase):
         @Assert: gpg info should display key content
 
         @BZ: Redmine#4272
-
         """
         # GPG Key data
         data = {
@@ -102,13 +105,13 @@ class TestGPGKey(CLITestCase):
         self.assertEqual(gpg_key['content'], content)
 
     @run_only_on('sat')
+    @tier1
     def test_info_by_name(self):
         """@Test: Create single gpg key and get its info by name
 
         @Feature: GPG Keys
 
         @Assert: specific information for GPG key matches the creation name
-
         """
         name = gen_string('utf8')
         gpg_key = make_gpg_key({
@@ -126,6 +129,7 @@ class TestGPGKey(CLITestCase):
 
     @skip_if_bug_open('bugzilla', 1172009)
     @run_only_on('sat')
+    @tier1
     def test_positive_create_1(self):
         """@test: Create gpg key with valid name and valid gpg key via file
         import using the default created organization
@@ -135,7 +139,6 @@ class TestGPGKey(CLITestCase):
         @assert: gpg key is created
 
         @BZ: 1172009
-
         """
         for test_data in positive_create_data():
             with self.subTest(test_data):
@@ -159,6 +162,7 @@ class TestGPGKey(CLITestCase):
 
     @skip_if_bug_open('bugzilla', 1172009)
     @run_only_on('sat')
+    @tier1
     def test_positive_create_2(self):
         """@test: Create gpg key with valid name and valid gpg key via file
         import using the a new organization
@@ -168,7 +172,6 @@ class TestGPGKey(CLITestCase):
         @assert: gpg key is created
 
         @BZ: 1172009
-
         """
         for test_data in positive_create_data():
             with self.subTest(test_data):
@@ -191,6 +194,7 @@ class TestGPGKey(CLITestCase):
 
     @skip_if_bug_open('bugzilla', 1172009)
     @run_only_on('sat')
+    @tier1
     def test_negative_create_1(self):
         """@test: Create gpg key with valid name and valid gpg key via file
         import then try to create new one with same name
@@ -200,7 +204,6 @@ class TestGPGKey(CLITestCase):
         @assert: gpg key is not created
 
         @BZ: 1172009
-
         """
         test_data = {'name': gen_string('alphanumeric')}
         # Setup data to pass to the factory
@@ -223,13 +226,13 @@ class TestGPGKey(CLITestCase):
             GPGKey().create(test_data)
 
     @run_only_on('sat')
+    @tier1
     def test_negative_create_2(self):
         """@test: Create gpg key with valid name and no gpg key
 
         @feature: GPG Keys
 
         @assert: gpg key is not created
-
         """
         # Setup data to pass to create
         for test_data in positive_create_data():
@@ -241,6 +244,7 @@ class TestGPGKey(CLITestCase):
                     GPGKey().create(test_data)
 
     @run_only_on('sat')
+    @tier1
     def test_negative_create_3(self):
         """@test: Create gpg key with invalid name and valid gpg key via
         file import
@@ -248,7 +252,6 @@ class TestGPGKey(CLITestCase):
         @feature: GPG Keys
 
         @assert: gpg key is not created
-
         """
         for test_data in negative_create_data():
             with self.subTest(test_data):
@@ -276,10 +279,7 @@ class TestGPGKey(CLITestCase):
         @assert: gpg key is deleted
 
         @status: manual
-
         """
-
-        pass
 
     @stubbed()
     @run_only_on('sat')
@@ -292,10 +292,7 @@ class TestGPGKey(CLITestCase):
         @assert: gpg key is deleted
 
         @status: manual
-
         """
-
-        pass
 
     # Negative Delete
     @stubbed()
@@ -309,10 +306,7 @@ class TestGPGKey(CLITestCase):
         @assert: gpg key is not deleted
 
         @status: manual
-
         """
-
-        pass
 
     @stubbed()
     @run_only_on('sat')
@@ -325,10 +319,7 @@ class TestGPGKey(CLITestCase):
         @assert: gpg key is not deleted
 
         @status: manual
-
         """
-
-        pass
 
     # Positive Update
 
@@ -343,10 +334,7 @@ class TestGPGKey(CLITestCase):
         @assert: gpg key is updated
 
         @status: manual
-
         """
-
-        pass
 
     @stubbed()
     @run_only_on('sat')
@@ -359,10 +347,7 @@ class TestGPGKey(CLITestCase):
         @assert: gpg key is updated
 
         @status: manual
-
         """
-
-        pass
 
     @stubbed()
     @run_only_on('sat')
@@ -375,10 +360,7 @@ class TestGPGKey(CLITestCase):
         @assert: gpg key is updated
 
         @status: manual
-
         """
-
-        pass
 
     @stubbed()
     @run_only_on('sat')
@@ -391,10 +373,7 @@ class TestGPGKey(CLITestCase):
         @assert: gpg key is updated
 
         @status: manual
-
         """
-
-        pass
 
     # Negative Update
     @stubbed()
@@ -408,10 +387,7 @@ class TestGPGKey(CLITestCase):
         @assert: gpg key is not updated
 
         @status: manual
-
         """
-
-        pass
 
     @stubbed()
     @run_only_on('sat')
@@ -424,10 +400,7 @@ class TestGPGKey(CLITestCase):
         @assert: gpg key is not updated
 
         @status: manual
-
         """
-
-        pass
 
     # Product association
     @stubbed()
@@ -441,10 +414,7 @@ class TestGPGKey(CLITestCase):
         @assert: gpg key is associated with product
 
         @status: manual
-
         """
-
-        pass
 
     @stubbed()
     @run_only_on('sat')
@@ -457,10 +427,7 @@ class TestGPGKey(CLITestCase):
         @assert: gpg key is associated with product but not the repository
 
         @status: manual
-
         """
-
-        pass
 
     @stubbed()
     @run_only_on('sat')
@@ -474,10 +441,7 @@ class TestGPGKey(CLITestCase):
         @assert: gpg key is associated with product but not the repositories
 
         @status: manual
-
         """
-
-        pass
 
     @stubbed()
     @run_only_on('sat')
@@ -491,10 +455,7 @@ class TestGPGKey(CLITestCase):
         @assert: gpg key is associated with product but not the repositories
 
         @status: manual
-
         """
-
-        pass
 
     @stubbed()
     @run_only_on('sat')
@@ -508,10 +469,7 @@ class TestGPGKey(CLITestCase):
         @assert: gpg key is associated with product and the repository
 
         @status: manual
-
         """
-
-        pass
 
     @stubbed()
     @run_only_on('sat')
@@ -527,10 +485,7 @@ class TestGPGKey(CLITestCase):
         @assert: gpg key is associated with the repository
 
         @status: manual
-
         """
-
-        pass
 
     @stubbed()
     @run_only_on('sat')
@@ -544,10 +499,7 @@ class TestGPGKey(CLITestCase):
         @assert: gpg key is associated with product and all the repositories
 
         @status: manual
-
         """
-
-        pass
 
     @stubbed()
     @run_only_on('sat')
@@ -561,10 +513,7 @@ class TestGPGKey(CLITestCase):
         @assert: gpg key is associated with product before/after update
 
         @status: manual
-
         """
-
-        pass
 
     @stubbed()
     @run_only_on('sat')
@@ -579,10 +528,7 @@ class TestGPGKey(CLITestCase):
         not the repository
 
         @status: manual
-
         """
-
-        pass
 
     @stubbed()
     @run_only_on('sat')
@@ -597,10 +543,7 @@ class TestGPGKey(CLITestCase):
         not the repositories
 
         @status: manual
-
         """
-
-        pass
 
     @stubbed()
     @run_only_on('sat')
@@ -615,10 +558,7 @@ class TestGPGKey(CLITestCase):
         not the repositories
 
         @status: manual
-
         """
-
-        pass
 
     @stubbed()
     @run_only_on('sat')
@@ -633,10 +573,7 @@ class TestGPGKey(CLITestCase):
         before/after update
 
         @status: manual
-
         """
-
-        pass
 
     @stubbed()
     @run_only_on('sat')
@@ -651,10 +588,7 @@ class TestGPGKey(CLITestCase):
         before/after update
 
         @status: manual
-
         """
-
-        pass
 
     @stubbed()
     @run_only_on('sat')
@@ -669,10 +603,7 @@ class TestGPGKey(CLITestCase):
         before/after update
 
         @status: manual
-
         """
-
-        pass
 
     @stubbed()
     @run_only_on('sat')
@@ -687,10 +618,7 @@ class TestGPGKey(CLITestCase):
         from product after deletion
 
         @status: manual
-
         """
-
-        pass
 
     @stubbed()
     @run_only_on('sat')
@@ -705,10 +633,7 @@ class TestGPGKey(CLITestCase):
         during creation but removed from product after deletion
 
         @status: manual
-
         """
-
-        pass
 
     @stubbed()
     @run_only_on('sat')
@@ -723,10 +648,7 @@ class TestGPGKey(CLITestCase):
         during creation but removed from product after deletion
 
         @status: manual
-
         """
-
-        pass
 
     @stubbed()
     @run_only_on('sat')
@@ -741,10 +663,7 @@ class TestGPGKey(CLITestCase):
         during creation but removed from product after deletion
 
         @status: manual
-
         """
-
-        pass
 
     @stubbed()
     @run_only_on('sat')
@@ -759,10 +678,7 @@ class TestGPGKey(CLITestCase):
         during creation but removed from product and repository after deletion
 
         @status: manual
-
         """
-
-        pass
 
     @stubbed()
     @run_only_on('sat')
@@ -777,10 +693,7 @@ class TestGPGKey(CLITestCase):
         during creation but removed from product and repository after deletion
 
         @status: manual
-
         """
-
-        pass
 
     @stubbed()
     @run_only_on('sat')
@@ -796,10 +709,7 @@ class TestGPGKey(CLITestCase):
         deletion
 
         @status: manual
-
         """
-
-        pass
 
     @stubbed()
     @run_only_on('sat')
@@ -813,10 +723,7 @@ class TestGPGKey(CLITestCase):
         @assert: gpg key is associated with product
 
         @status: manual
-
         """
-
-        pass
 
     @stubbed()
     @run_only_on('sat')
@@ -830,10 +737,7 @@ class TestGPGKey(CLITestCase):
         @assert: gpg key is associated with product but not the repository
 
         @status: manual
-
         """
-
-        pass
 
     @stubbed()
     @run_only_on('sat')
@@ -847,10 +751,7 @@ class TestGPGKey(CLITestCase):
         @assert: gpg key is associated with product but not the repositories
 
         @status: manual
-
         """
-
-        pass
 
     @stubbed()
     @run_only_on('sat')
@@ -864,10 +765,7 @@ class TestGPGKey(CLITestCase):
         @assert: gpg key is associated with product but not the repositories
 
         @status: manual
-
         """
-
-        pass
 
     @stubbed()
     @run_only_on('sat')
@@ -881,10 +779,7 @@ class TestGPGKey(CLITestCase):
         @assert: gpg key is associated with product and the repository
 
         @status: manual
-
         """
-
-        pass
 
     @stubbed()
     @run_only_on('sat')
@@ -898,10 +793,7 @@ class TestGPGKey(CLITestCase):
         @assert: gpg key is associated with product and one of the repositories
 
         @status: manual
-
         """
-
-        pass
 
     @stubbed()
     @run_only_on('sat')
@@ -915,10 +807,7 @@ class TestGPGKey(CLITestCase):
         @assert: gpg key is associated with product and all the repositories
 
         @status: manual
-
         """
-
-        pass
 
     @stubbed()
     @run_only_on('sat')
@@ -932,10 +821,7 @@ class TestGPGKey(CLITestCase):
         @assert: gpg key is associated with product before/after update
 
         @status: manual
-
         """
-
-        pass
 
     @stubbed()
     @run_only_on('sat')
@@ -950,10 +836,7 @@ class TestGPGKey(CLITestCase):
         but not the repository
 
         @status: manual
-
         """
-
-        pass
 
     @stubbed()
     @run_only_on('sat')
@@ -968,10 +851,7 @@ class TestGPGKey(CLITestCase):
         but not the repositories
 
         @status: manual
-
         """
-
-        pass
 
     @stubbed()
     @run_only_on('sat')
@@ -986,10 +866,7 @@ class TestGPGKey(CLITestCase):
         but not the repositories
 
         @status: manual
-
         """
-
-        pass
 
     @stubbed()
     @run_only_on('sat')
@@ -1004,10 +881,7 @@ class TestGPGKey(CLITestCase):
         before/after update
 
         @status: manual
-
         """
-
-        pass
 
     @stubbed()
     @run_only_on('sat')
@@ -1022,10 +896,7 @@ class TestGPGKey(CLITestCase):
         before/after update
 
         @status: manual
-
         """
-
-        pass
 
     @stubbed()
     @run_only_on('sat')
@@ -1040,10 +911,7 @@ class TestGPGKey(CLITestCase):
         before/after update
 
         @status: manual
-
         """
-
-        pass
 
     @stubbed()
     @run_only_on('sat')
@@ -1058,10 +926,7 @@ class TestGPGKey(CLITestCase):
         removed from product after deletion
 
         @status: manual
-
         """
-
-        pass
 
     @stubbed()
     @run_only_on('sat')
@@ -1076,10 +941,7 @@ class TestGPGKey(CLITestCase):
         during creation but removed from product after deletion
 
         @status: manual
-
         """
-
-        pass
 
     @stubbed()
     @run_only_on('sat')
@@ -1094,10 +956,7 @@ class TestGPGKey(CLITestCase):
         during creation but removed from product after deletion
 
         @status: manual
-
         """
-
-        pass
 
     @stubbed()
     @run_only_on('sat')
@@ -1112,10 +971,7 @@ class TestGPGKey(CLITestCase):
         during creation but removed from product after deletion
 
         @status: manual
-
         """
-
-        pass
 
     @stubbed()
     @run_only_on('sat')
@@ -1130,10 +986,7 @@ class TestGPGKey(CLITestCase):
         during creation but removed from product and repository after deletion
 
         @status: manual
-
         """
-
-        pass
 
     @stubbed()
     @run_only_on('sat')
@@ -1148,10 +1001,7 @@ class TestGPGKey(CLITestCase):
         during creation but removed from product and repository after deletion
 
         @status: manual
-
         """
-
-        pass
 
     @stubbed()
     @run_only_on('sat')
@@ -1167,10 +1017,7 @@ class TestGPGKey(CLITestCase):
         after deletion
 
         @status: manual
-
         """
-
-        pass
 
     # Content
 
@@ -1185,10 +1032,7 @@ class TestGPGKey(CLITestCase):
         @assert: host can install package from custom repository
 
         @status: manual
-
         """
-
-        pass
 
     @stubbed()
     @run_only_on('sat')
@@ -1201,10 +1045,7 @@ class TestGPGKey(CLITestCase):
         @assert: host can install package from custom repositories
 
         @status: manual
-
         """
-
-        pass
 
     @stubbed()
     @run_only_on('sat')
@@ -1217,10 +1058,7 @@ class TestGPGKey(CLITestCase):
         @assert: host can install package from custom repositories
 
         @status: manual
-
         """
-
-        pass
 
     # Miscelaneous
 
@@ -1234,10 +1072,7 @@ class TestGPGKey(CLITestCase):
         @assert: gpg key is displayed/listed
 
         @status: manual
-
         """
-
-        pass
 
     @stubbed()
     @run_only_on('sat')
@@ -1249,7 +1084,4 @@ class TestGPGKey(CLITestCase):
         @assert: gpg key can be found
 
         @status: manual
-
         """
-
-        pass

--- a/tests/foreman/cli/test_hammer.py
+++ b/tests/foreman/cli/test_hammer.py
@@ -3,7 +3,7 @@ import json
 
 from robottelo import ssh
 from robottelo.cli import hammer
-from robottelo.decorators import bz_bug_is_open
+from robottelo.decorators import bz_bug_is_open, tier1
 from robottelo.helpers import read_data_file
 from robottelo.test import CLITestCase
 
@@ -97,6 +97,7 @@ class HammerCommandsTestCase(CLITestCase):
                     '{0} {1}'.format(command, subcommand['name'])
                 )
 
+    @tier1
     def test_hammer_options(self):
         """@Test: check all provided options for every hammer command
 

--- a/tests/foreman/cli/test_host.py
+++ b/tests/foreman/cli/test_host.py
@@ -6,6 +6,7 @@ from robottelo.cli.host import Host
 from robottelo.cli.proxy import Proxy
 from robottelo.config import settings
 from robottelo.datafactory import invalid_values_list, valid_data_list
+from robottelo.decorators import tier1, tier2
 from robottelo.test import CLITestCase
 
 
@@ -23,6 +24,7 @@ class HostTestCase(CLITestCase):
         self.assertGreater(len(result), 0)
         self.puppet_proxy = result[0]
 
+    @tier1
     def test_positive_create_1(self):
         """@test: A host can be created with a random name
 
@@ -52,6 +54,7 @@ class HostTestCase(CLITestCase):
             result['name'],
         )
 
+    @tier2
     def test_create_libvirt_without_mac(self):
         """@Test: Create a libvirt host and not specify a MAC address.
 
@@ -114,6 +117,7 @@ class HostParameterTests(CLITestCase):
             u'root-pass': cls.host.root_pass,
         })
 
+    @tier1
     def test_add_parameter_diff_names(self):
         """@Test: Add host parameter with different valid names.
 
@@ -133,6 +137,7 @@ class HostParameterTests(CLITestCase):
                 self.host = Host.info({'id': self.host['id']})
                 self.assertIn(name, self.host['parameters'].keys())
 
+    @tier1
     def test_add_parameter_diff_values(self):
         """@Test: Add host parameter with different valid values.
 
@@ -153,6 +158,7 @@ class HostParameterTests(CLITestCase):
                 self.assertIn(name, self.host['parameters'].keys())
                 self.assertEqual(value, self.host['parameters'][name])
 
+    @tier1
     def test_add_parameter_by_host_name(self):
         """@Test: Add host parameter by specifying host name.
 
@@ -173,6 +179,7 @@ class HostParameterTests(CLITestCase):
         self.assertIn(name, self.host['parameters'].keys())
         self.assertEqual(value, self.host['parameters'][name])
 
+    @tier1
     def test_update_parameter_by_host_id(self):
         """@Test: Update existing host parameter by specifying host ID.
 
@@ -199,6 +206,7 @@ class HostParameterTests(CLITestCase):
                 self.assertIn(name, self.host['parameters'].keys())
                 self.assertEqual(new_value, self.host['parameters'][name])
 
+    @tier1
     def test_update_parameter_by_host_name(self):
         """@Test: Update existing host parameter by specifying host name.
 
@@ -225,6 +233,7 @@ class HostParameterTests(CLITestCase):
                 self.assertIn(name, self.host['parameters'].keys())
                 self.assertEqual(new_value, self.host['parameters'][name])
 
+    @tier1
     def test_delete_parameter_by_host_id(self):
         """@Test: Delete existing host parameter by specifying host ID.
 
@@ -248,6 +257,7 @@ class HostParameterTests(CLITestCase):
                 self.host = Host.info({'id': self.host['id']})
                 self.assertNotIn(name, self.host['parameters'].keys())
 
+    @tier1
     def test_delete_parameter_by_host_name(self):
         """@Test: Delete existing host parameter by specifying host name.
 
@@ -271,6 +281,7 @@ class HostParameterTests(CLITestCase):
                 self.host = Host.info({'id': self.host['id']})
                 self.assertNotIn(name, self.host['parameters'].keys())
 
+    @tier1
     def test_add_parameter_negative(self):
         """@Test: Try to add host parameter with different invalid names.
 

--- a/tests/foreman/cli/test_host_collection.py
+++ b/tests/foreman/cli/test_host_collection.py
@@ -11,7 +11,7 @@ from robottelo.cli.factory import (
 from robottelo.cli.hostcollection import HostCollection
 from robottelo.constants import DEFAULT_CV, ENVIRONMENT
 from robottelo.datafactory import valid_data_list, invalid_values_list
-from robottelo.decorators import skip_if_bug_open
+from robottelo.decorators import skip_if_bug_open, tier1, tier2
 from robottelo.test import CLITestCase
 
 
@@ -73,6 +73,7 @@ class TestHostCollection(CLITestCase):
 
         return make_host_collection(options)
 
+    @tier1
     def test_positive_create_1(self):
         """@Test: Check if host collection can be created with random names
 
@@ -86,6 +87,7 @@ class TestHostCollection(CLITestCase):
                 new_host_col = self._new_host_collection({'name': name})
                 self.assertEqual(new_host_col['name'], name)
 
+    @tier1
     def test_positive_create_2(self):
         """@Test: Check if host collection can be created with random
         description
@@ -100,6 +102,7 @@ class TestHostCollection(CLITestCase):
                 new_host_col = self._new_host_collection({'description': desc})
                 self.assertEqual(new_host_col['description'], desc)
 
+    @tier1
     def test_positive_create_3(self):
         """@Test: Check if host collection can be created with random limits
 
@@ -115,6 +118,7 @@ class TestHostCollection(CLITestCase):
                 self.assertEqual(new_host_col['limit'], str(limit))
 
     @skip_if_bug_open('bugzilla', 1214675)
+    @tier1
     def test_create_hc_with_unlimited_content_hosts(self):
         """@Test: Create Host Collection with different values of
         unlimited-content-hosts parameter
@@ -144,6 +148,7 @@ class TestHostCollection(CLITestCase):
                     self.assertEqual(
                         result['unlimited-content-hosts'], u'false')
 
+    @tier1
     def test_negative_create_1(self):
         """@Test: Check if host collection can be created with random names
 
@@ -157,6 +162,7 @@ class TestHostCollection(CLITestCase):
                 with self.assertRaises(CLIFactoryError):
                     self._new_host_collection({'name': name})
 
+    @tier1
     def test_positive_update_1(self):
         """@Test: Check if host collection name can be updated
 
@@ -176,6 +182,7 @@ class TestHostCollection(CLITestCase):
                 result = HostCollection.info({'id': new_host_col['id']})
                 self.assertEqual(result['name'], new_name)
 
+    @tier1
     def test_positive_update_2(self):
         """@Test: Check if host collection description can be updated
 
@@ -196,6 +203,7 @@ class TestHostCollection(CLITestCase):
                 self.assertEqual(result['description'], desc)
 
     @skip_if_bug_open('bugzilla', 1245334)
+    @tier1
     def test_positive_update_3(self):
         """@Test: Check if host collection limits be updated
 
@@ -217,6 +225,7 @@ class TestHostCollection(CLITestCase):
                 result = HostCollection.info({'id': new_host_col['id']})
                 self.assertEqual(result['limit'], limit)
 
+    @tier1
     def test_positive_delete_1(self):
         """@Test: Check if host collection can be created and deleted
 
@@ -235,6 +244,7 @@ class TestHostCollection(CLITestCase):
                 with self.assertRaises(CLIReturnCodeError):
                     HostCollection.info({'id': new_host_col['id']})
 
+    @tier2
     def test_add_content_host(self):
         """@Test: Check if content host can be added to host collection
 
@@ -263,6 +273,7 @@ class TestHostCollection(CLITestCase):
         })
         self.assertGreater(result['total-content-hosts'], no_of_content_host)
 
+    @tier2
     def test_remove_content_host(self):
         """@Test: Check if content host can be removed from host collection
 
@@ -299,6 +310,7 @@ class TestHostCollection(CLITestCase):
         })
         self.assertGreater(no_of_content_host, result['total-content-hosts'])
 
+    @tier2
     def test_content_hosts(self):
         """@Test: Check if content hosts added to host collection is listed
 

--- a/tests/foreman/cli/test_host_system_unification.py
+++ b/tests/foreman/cli/test_host_system_unification.py
@@ -33,9 +33,7 @@ class TestHostSystemUnificationCLI(CLITestCase):
         @assert: Hosts/Systems created in both places return in list
 
         @status: Manual
-
         """
-        pass
 
     @stubbed()
     @run_only_on('sat')
@@ -52,6 +50,4 @@ class TestHostSystemUnificationCLI(CLITestCase):
         @assert: Hosts/Systems created in both places return in list
 
         @status: Manual
-
         """
-        pass

--- a/tests/foreman/cli/test_hostgroup.py
+++ b/tests/foreman/cli/test_hostgroup.py
@@ -16,12 +16,13 @@ from robottelo.datafactory import (
     invalid_values_list,
     valid_data_list,
 )
-from robottelo.decorators import run_only_on
+from robottelo.decorators import run_only_on, tier1
 from robottelo.test import CLITestCase
 
 
 class TestHostGroup(CLITestCase):
     """Test class for Host Group CLI"""
+    @tier1
     def test_positive_create(self):
         """@Test: Successfully creates an HostGroup.
 
@@ -34,6 +35,7 @@ class TestHostGroup(CLITestCase):
                 hostgroup = make_hostgroup({'name': name})
                 self.assertEqual(hostgroup['name'], name)
 
+    @tier1
     def test_negative_create(self):
         """@Test: Don't create an HostGroup with invalid data.
 
@@ -47,6 +49,7 @@ class TestHostGroup(CLITestCase):
                     HostGroup.create({'name': name})
 
     @run_only_on('sat')
+    @tier1
     def test_create_hostgroup_with_environment(self):
         """@Test: Check if hostgroup with environment can be created
 
@@ -60,6 +63,7 @@ class TestHostGroup(CLITestCase):
         self.assertEqual(environment['name'], hostgroup['environment'])
 
     @run_only_on('sat')
+    @tier1
     def test_create_hostgroup_with_location(self):
         """@Test: Check if hostgroup with location can be created
 
@@ -73,6 +77,7 @@ class TestHostGroup(CLITestCase):
         self.assertIn(location['name'], hostgroup['locations'])
 
     @run_only_on('sat')
+    @tier1
     def test_create_hostgroup_with_operating_system(self):
         """@Test: Check if hostgroup with operating system can be created
 
@@ -86,6 +91,7 @@ class TestHostGroup(CLITestCase):
         self.assertEqual(hostgroup['operating-system'], os['title'])
 
     @run_only_on('sat')
+    @tier1
     def test_create_hostgroup_with_organization(self):
         """@Test: Check if hostgroup with organization can be created
 
@@ -99,6 +105,7 @@ class TestHostGroup(CLITestCase):
         self.assertIn(org['name'], hostgroup['organizations'])
 
     @run_only_on('sat')
+    @tier1
     def test_create_hostgroup_with_puppet_ca_proxy(self):
         """@Test: Check if hostgroup with puppet CA proxy server can be created
 
@@ -112,6 +119,7 @@ class TestHostGroup(CLITestCase):
         self.assertEqual(puppet_proxy['id'], hostgroup['puppet-ca-proxy-id'])
 
     @run_only_on('sat')
+    @tier1
     def test_create_hostgroup_with_puppet_proxy(self):
         """@Test: Check if hostgroup with puppet proxy server can be created
 
@@ -127,6 +135,7 @@ class TestHostGroup(CLITestCase):
             hostgroup['puppet-master-proxy-id'],
         )
 
+    @tier1
     def test_positive_update_name(self):
         """@Test: Successfully update an HostGroup.
 
@@ -145,6 +154,7 @@ class TestHostGroup(CLITestCase):
                 self.assertEqual(hostgroup['name'], new_name)
 
     @run_only_on('sat')
+    @tier1
     def test_negative_update(self):
         """@test: Create HostGroup then fail to update its name
 
@@ -164,6 +174,7 @@ class TestHostGroup(CLITestCase):
                 self.assertEqual(hostgroup['name'], result['name'])
 
     @run_only_on('sat')
+    @tier1
     def test_positive_delete(self):
         """@test: Create HostGroup with valid values then delete it
         by ID
@@ -180,6 +191,7 @@ class TestHostGroup(CLITestCase):
                     HostGroup.info({'id': hostgroup['id']})
 
     @run_only_on('sat')
+    @tier1
     def test_negative_delete(self):
         """@test: Create HostGroup then delete it by wrong ID
 

--- a/tests/foreman/cli/test_import.py
+++ b/tests/foreman/cli/test_import.py
@@ -22,7 +22,7 @@ from robottelo.cli.subscription import Subscription
 from robottelo.cli.template import Template
 from robottelo.cli.user import User
 from robottelo.config import settings
-from robottelo.decorators import bz_bug_is_open, skip_if_bug_open
+from robottelo.decorators import bz_bug_is_open, skip_if_bug_open, tier1
 from robottelo.test import CLITestCase
 
 
@@ -506,6 +506,7 @@ class TestImport(CLITestCase):
         ssh.command(u'rm -r {0}'.format(cls.default_dataset[0]))
         super(TestImport, cls).tearDownClass()
 
+    @tier1
     def test_import_orgs_default(self):
         """@test: Import all organizations from the default data set
         (predefined source).
@@ -526,6 +527,7 @@ class TestImport(CLITestCase):
                     Org.info({'name': org['organization']})
                 clean_transdata()
 
+    @tier1
     def test_import_orgs_manifests(self):
         """@test: Import all organizations from the default data set
         (predefined source) and upload manifests for each of them
@@ -557,6 +559,7 @@ class TestImport(CLITestCase):
                     self.assertIn('SUCCESS', manifest_history)
                 clean_transdata()
 
+    @tier1
     def test_reimport_orgs_default_negative(self):
         """@test: Try to Import all organizations from the predefined source
         and try to import them again
@@ -577,6 +580,7 @@ class TestImport(CLITestCase):
                 self.assertEqual(orgs_before, Org.list())
                 clean_transdata()
 
+    @tier1
     def test_import_orgs_recovery(self):
         """@test: Try to Import organizations with the same name to invoke
         usage of a recovery strategy (rename, map, none)
@@ -626,6 +630,7 @@ class TestImport(CLITestCase):
                 })
                 clean_transdata()
 
+    @tier1
     def test_merge_orgs(self):
         """@test: Try to Import all organizations and their users from CSV
         to a mapped organization.
@@ -663,6 +668,7 @@ class TestImport(CLITestCase):
                 self.assertTrue(all((user in logins for user in imp_users)))
                 clean_transdata()
 
+    @tier1
     def test_import_users_default(self):
         """@test: Import all 3 users from the default data set (predefined
         source).
@@ -692,6 +698,7 @@ class TestImport(CLITestCase):
                 self.assertTrue(imp_users.issubset(logins))
                 clean_transdata()
 
+    @tier1
     def test_reimport_users_default_negative(self):
         """@test: Try to Import all users from the
         predefined source and try to import them again
@@ -721,6 +728,7 @@ class TestImport(CLITestCase):
                 self.assertTrue(users_after.issubset(users_before))
                 clean_transdata()
 
+    @tier1
     def test_import_users_merge(self):
         """@test: Try to Merge users with the same name using 'merge-users'
         option.
@@ -759,6 +767,7 @@ class TestImport(CLITestCase):
                     self.assertNotEqual(User.info({'id': record['sat6']}), '')
                 clean_transdata()
 
+    @tier1
     def test_import_users_recovery(self):
         """@test: Try to Import users with the same name to invoke
         usage of a recovery strategy (rename, map, none)
@@ -820,6 +829,7 @@ class TestImport(CLITestCase):
                 ssh.command(u'rm -rf {0}'.format(' '.join(pwdfiles)))
                 clean_transdata()
 
+    @tier1
     def test_import_host_collections_default(self):
         """@test: Import all System Groups from the default data set
         (predefined source) as the Host Collections.
@@ -855,6 +865,7 @@ class TestImport(CLITestCase):
                     )
                 clean_transdata()
 
+    @tier1
     def test_reimport_host_collections_default_negative(self):
         """@test: Try to re-import all System Groups from the default data set
         (predefined source) as the Host Collections.
@@ -887,6 +898,7 @@ class TestImport(CLITestCase):
                 self.assertEqual(hcollections_before, hcollections_after)
                 clean_transdata()
 
+    @tier1
     def test_import_host_collections_recovery(self):
         """@test: Try to Import Collections with the same name to invoke
         usage of a recovery strategy (rename, map, none)
@@ -949,6 +961,7 @@ class TestImport(CLITestCase):
                     HostCollection.info({'id': record['sat6']})
                 clean_transdata()
 
+    @tier1
     def test_import_repo_default(self):
         """@test: Import and enable all Repositories from the default data set
         (predefined source)
@@ -987,6 +1000,7 @@ class TestImport(CLITestCase):
                     )
                 clean_transdata()
 
+    @tier1
     def test_reimport_repo_negative(self):
         """@test: Import and enable all Repositories from the default data set
         (predefined source), then try to Import Repositories from the same CSV
@@ -1037,6 +1051,7 @@ class TestImport(CLITestCase):
                 )
                 clean_transdata()
 
+    @tier1
     def test_import_repo_recovery(self):
         """@test: Try to Import Repos with the same name to invoke
         usage of a recovery strategy (rename, map, none)
@@ -1099,6 +1114,7 @@ class TestImport(CLITestCase):
                     Repository.info({'id': record['sat6']})
                 clean_transdata()
 
+    @tier1
     def test_import_cv_default(self):
         """@test: Import and enable all Content Views from the default data set
         (predefined source)
@@ -1142,6 +1158,7 @@ class TestImport(CLITestCase):
                     )
                 clean_transdata()
 
+    @tier1
     def test_reimport_cv_negative(self):
         """@test: Import and enable all Content Views from the default data set
         (predefined source), then try to Import them from the same CSV
@@ -1195,6 +1212,7 @@ class TestImport(CLITestCase):
                 )
                 clean_transdata()
 
+    @tier1
     def test_import_cv_recovery(self):
         """@test: Try to Import Content Views with the same name to invoke
         usage of a recovery strategy (rename, map, none)
@@ -1267,6 +1285,7 @@ class TestImport(CLITestCase):
                     ContentView.info({'id': record['sat6']})
                 clean_transdata()
 
+    @tier1
     def test_bz1160847_translate_macros(self):
         """@test: Check whether all supported Sat5 macros are being properly
         converted to the Puppet facts.
@@ -1380,6 +1399,7 @@ class TestImport(CLITestCase):
         )
         clean_transdata()
 
+    @tier1
     def test_import_enable_rh_repos(self):
         """@test: Import and enable all red hat repositories from predefined
         dataset
@@ -1428,6 +1448,7 @@ class TestImport(CLITestCase):
                     )
                 clean_transdata()
 
+    @tier1
     def test_reimport_enable_rh_repos_negative(self):
         """@test: Repetitive Import and enable of all red hat repositories from
         the predefined dataset
@@ -1472,6 +1493,7 @@ class TestImport(CLITestCase):
                 )
                 clean_transdata()
 
+    @tier1
     def test_import_content_hosts_default(self):
         """@test: Import all content hosts from
         the predefined dataset
@@ -1501,6 +1523,7 @@ class TestImport(CLITestCase):
                     )
                 clean_transdata()
 
+    @tier1
     def test_reimport_content_hosts_negative(self):
         """@test: Repetitive Import of all content hosts from
         the predefined dataset
@@ -1541,6 +1564,7 @@ class TestImport(CLITestCase):
                 clean_transdata()
 
     @skip_if_bug_open('bugzilla', 1267224)
+    @tier1
     def test_import_content_hosts_recovery_negative(self):
         """@test: Try to invoke usage of a recovery strategy
 
@@ -1571,6 +1595,7 @@ class TestImport(CLITestCase):
                     })
                 clean_transdata()
 
+    @tier1
     def test_import_snippets_default(self):
         """@test: Import template snippets from the default data set
         (predefined source)
@@ -1608,6 +1633,7 @@ class TestImport(CLITestCase):
                     self.assertTrue(template[u'type'] == u'snippet')
                 clean_transdata()
 
+    @tier1
     def test_import_config_files_default(self):
         """@test: Import all Config Files from the default data set
         (predefined source)
@@ -1646,6 +1672,7 @@ class TestImport(CLITestCase):
                     )
                 clean_transdata()
 
+    @tier1
     def test_reimport_config_files_negative(self):
         """@test: Repetitive Import of all Config Files from the default
         data set (predefined source)
@@ -1688,6 +1715,7 @@ class TestImport(CLITestCase):
                 self.assertEqual(cf_before, cf_after)
                 clean_transdata()
 
+    @tier1
     def test_import_ak_default(self):
         """@test: Import AKs from the default data set
         (predefined source)

--- a/tests/foreman/cli/test_installer.py
+++ b/tests/foreman/cli/test_installer.py
@@ -26,9 +26,7 @@ class TestSSOCLI(CLITestCase):
         mongod} are started
 
         @status: Manual
-
         """
-        pass
 
     @stubbed()
     @run_only_on('sat')
@@ -45,9 +43,7 @@ class TestSSOCLI(CLITestCase):
         postgresql, mongod} logfiles.
 
         @status: Manual
-
         """
-        pass
 
     @stubbed()
     @run_only_on('sat')
@@ -60,9 +56,7 @@ class TestSSOCLI(CLITestCase):
         commences, through to completion
 
         @status: Manual
-
         """
-        pass
 
     @stubbed()
     @run_only_on('sat')
@@ -74,9 +68,7 @@ class TestSSOCLI(CLITestCase):
         @assert: Install from ISO is sucessful.
 
         @status: Manual
-
         """
-        pass
 
     @stubbed()
     @run_only_on('sat')
@@ -88,9 +80,7 @@ class TestSSOCLI(CLITestCase):
         @assert: Install of main instance successful.
 
         @status: Manual
-
         """
-        pass
 
     @stubbed()
     @run_only_on('sat')
@@ -102,9 +92,7 @@ class TestSSOCLI(CLITestCase):
         @assert: Install of node successful.
 
         @status: Manual
-
         """
-        pass
 
     @stubbed()
     @run_only_on('sat')
@@ -116,9 +104,7 @@ class TestSSOCLI(CLITestCase):
         @assert: Install of smart-proxy successful.
 
         @status: Manual
-
         """
-        pass
 
     @stubbed()
     @run_only_on('sat')
@@ -131,9 +117,7 @@ class TestSSOCLI(CLITestCase):
         @assert: Install of disconnected utility successful.
 
         @status: Manual
-
         """
-        pass
 
     @stubbed()
     @run_only_on('sat')
@@ -147,9 +131,7 @@ class TestSSOCLI(CLITestCase):
         following install.
 
         @status: Manual
-
         """
-        pass
 
     @stubbed()
     @run_only_on('sat')
@@ -163,6 +145,4 @@ class TestSSOCLI(CLITestCase):
         @bz: 1072780
 
         @status: Manual
-
         """
-        pass

--- a/tests/foreman/cli/test_lifecycleenvironment.py
+++ b/tests/foreman/cli/test_lifecycleenvironment.py
@@ -7,7 +7,7 @@ from robottelo.cli.factory import make_lifecycle_environment, make_org
 from robottelo.cli.lifecycleenvironment import LifecycleEnvironment
 from robottelo.constants import ENVIRONMENT
 from robottelo.datafactory import valid_data_list
-from robottelo.decorators import run_only_on
+from robottelo.decorators import run_only_on, tier1
 from robottelo.test import CLITestCase
 
 
@@ -26,6 +26,7 @@ class TestLifeCycleEnvironment(CLITestCase):
 
     # Issues validation
     @run_only_on('sat')
+    @tier1
     def test_bugzilla_1077386(self):
         """@Test: List subcommand returns standard output
 
@@ -47,6 +48,7 @@ class TestLifeCycleEnvironment(CLITestCase):
         self.assertGreater(len(result), 0)
 
     @run_only_on('sat')
+    @tier1
     def test_bugzilla_1077333(self):
         """@Test: Search lifecycle environment via its name containing UTF-8
         chars
@@ -69,6 +71,7 @@ class TestLifeCycleEnvironment(CLITestCase):
 
     # CRUD
     @run_only_on('sat')
+    @tier1
     def test_positive_create_1(self):
         """@Test: Create lifecycle environment with valid name, prior to
         Library
@@ -88,6 +91,7 @@ class TestLifeCycleEnvironment(CLITestCase):
                     lc_env['prior-lifecycle-environment'], ENVIRONMENT)
 
     @run_only_on('sat')
+    @tier1
     def test_positive_create_2(self):
         """@Test: Create lifecycle environment with valid description prior to
         Library
@@ -111,6 +115,7 @@ class TestLifeCycleEnvironment(CLITestCase):
                     lc_env['prior-lifecycle-environment'], ENVIRONMENT)
 
     @run_only_on('sat')
+    @tier1
     def test_create_lifecycle_environment_by_label(self):
         """@Test: Create lifecycle environment with valid name and label
 
@@ -130,6 +135,7 @@ class TestLifeCycleEnvironment(CLITestCase):
                 self.assertEqual(new_lce['label'], label)
 
     @run_only_on('sat')
+    @tier1
     def test_create_lifecycle_environment_by_organization_name(self):
         """@Test: Create lifecycle environment, specifying organization name
 
@@ -145,6 +151,7 @@ class TestLifeCycleEnvironment(CLITestCase):
         self.assertEqual(new_lce['organization'], self.org['name'])
 
     @run_only_on('sat')
+    @tier1
     def test_create_lifecycle_environment_by_organization_label(self):
         """@Test: Create lifecycle environment, specifying organization label
 
@@ -160,6 +167,7 @@ class TestLifeCycleEnvironment(CLITestCase):
         self.assertEqual(new_lce['organization'], self.org['name'])
 
     @run_only_on('sat')
+    @tier1
     def test_positive_delete_1(self):
         """@Test: Create lifecycle environment with valid name, prior to
         Library
@@ -183,6 +191,7 @@ class TestLifeCycleEnvironment(CLITestCase):
                     })
 
     @run_only_on('sat')
+    @tier1
     def test_positive_update_1(self):
         """@Test: Create lifecycle environment then update its name
 
@@ -210,6 +219,7 @@ class TestLifeCycleEnvironment(CLITestCase):
                 self.assertEqual(result['name'], new_name)
 
     @run_only_on('sat')
+    @tier1
     def test_positive_update_2(self):
         """@Test: Create lifecycle environment then update its description
 
@@ -237,6 +247,7 @@ class TestLifeCycleEnvironment(CLITestCase):
                 self.assertEqual(result['description'], new_desc)
 
     @run_only_on('sat')
+    @tier1
     def test_environment_paths(self):
         """@Test: List the environment paths under a given organization
 

--- a/tests/foreman/cli/test_location.py
+++ b/tests/foreman/cli/test_location.py
@@ -18,7 +18,7 @@ from robottelo.cli.factory import (
 )
 from robottelo.cli.location import Location
 from robottelo.datafactory import invalid_values_list
-from robottelo.decorators import skip_if_bug_open
+from robottelo.decorators import skip_if_bug_open, tier1
 from robottelo.test import CLITestCase
 
 
@@ -45,6 +45,7 @@ class TestLocation(CLITestCase):
     """Tests for Location via Hammer CLI"""
     # TODO Add coverage for smart_proxy and realm once we can create ssh tunnel
 
+    @tier1
     def test_create_location_with_different_names_positive(self):
         """@Test: Try to create location using different value types as a name
 
@@ -59,6 +60,7 @@ class TestLocation(CLITestCase):
                 self.assertEqual(loc['name'], name)
 
     @skip_if_bug_open('bugzilla', 1233612)
+    @tier1
     def test_create_location_with_description(self):
         """@Test: Create new location with custom description
 
@@ -72,6 +74,7 @@ class TestLocation(CLITestCase):
         loc = make_location({'description': description})
         self.assertEqual(loc['description'], description)
 
+    @tier1
     def test_create_location_with_user_by_id(self):
         """@Test: Create new location with assigned user to it. Use user id as
         a parameter
@@ -86,6 +89,7 @@ class TestLocation(CLITestCase):
         loc = make_location({'user-ids': user['id']})
         self.assertEqual(loc['users'][0], user['login'])
 
+    @tier1
     def test_create_location_with_user_by_name(self):
         """@Test: Create new location with assigned user to it. Use user login
         as a parameter
@@ -100,6 +104,7 @@ class TestLocation(CLITestCase):
         loc = make_location({'users': user['login']})
         self.assertEqual(loc['users'][0], user['login'])
 
+    @tier1
     def test_create_location_with_comp_resource_by_id(self):
         """@Test: Create new location with compute resource assigned to it. Use
         compute resource id as a parameter
@@ -114,6 +119,7 @@ class TestLocation(CLITestCase):
         loc = make_location({'compute-resource-ids': comp_resource['id']})
         self.assertEqual(loc['compute-resources'][0], comp_resource['name'])
 
+    @tier1
     def test_create_location_with_comp_resource_by_name(self):
         """@Test: Create new location with compute resource assigned to it. Use
         compute resource name as a parameter
@@ -128,6 +134,7 @@ class TestLocation(CLITestCase):
         loc = make_location({'compute-resources': comp_resource['name']})
         self.assertEqual(loc['compute-resources'][0], comp_resource['name'])
 
+    @tier1
     def test_create_location_with_template_by_id(self):
         """@Test: Create new location with config template assigned to it. Use
         config template id as a parameter
@@ -146,6 +153,7 @@ class TestLocation(CLITestCase):
             loc['templates']
         )
 
+    @tier1
     def test_create_location_with_template_by_name(self):
         """@Test: Create new location with config template assigned to it. Use
         config template name as a parameter
@@ -164,6 +172,7 @@ class TestLocation(CLITestCase):
             loc['templates']
         )
 
+    @tier1
     def test_create_location_with_domain_by_id(self):
         """@Test: Create new location with assigned domain to it. Use domain id
         as a parameter
@@ -178,6 +187,7 @@ class TestLocation(CLITestCase):
         loc = make_location({'domain-ids': domain['id']})
         self.assertEqual(loc['domains'][0], domain['name'])
 
+    @tier1
     def test_create_location_with_domain_by_name(self):
         """@Test: Create new location with assigned domain to it. Use domain
         name as a parameter
@@ -192,6 +202,7 @@ class TestLocation(CLITestCase):
         loc = make_location({'domains': domain['name']})
         self.assertEqual(loc['domains'][0], domain['name'])
 
+    @tier1
     def test_create_location_with_subnet_by_id(self):
         """@Test: Create new location with assigned subnet to it. Use subnet id
         as a parameter
@@ -207,6 +218,7 @@ class TestLocation(CLITestCase):
         self.assertIn(subnet['name'], loc['subnets'][0])
         self.assertIn(subnet['network'], loc['subnets'][0])
 
+    @tier1
     def test_create_location_with_subnet_by_name(self):
         """@Test: Create new location with assigned subnet to it. Use subnet
         name as a parameter
@@ -222,6 +234,7 @@ class TestLocation(CLITestCase):
         self.assertIn(subnet['name'], loc['subnets'][0])
         self.assertIn(subnet['network'], loc['subnets'][0])
 
+    @tier1
     def test_create_location_with_environment_by_id(self):
         """@Test: Create new location with assigned environment to it. Use
         environment id as a parameter
@@ -236,6 +249,7 @@ class TestLocation(CLITestCase):
         loc = make_location({'environment-ids': env['id']})
         self.assertEqual(loc['environments'][0], env['name'])
 
+    @tier1
     def test_create_location_with_environment_by_name(self):
         """@Test: Create new location with assigned environment to it. Use
         environment name as a parameter
@@ -250,6 +264,7 @@ class TestLocation(CLITestCase):
         loc = make_location({'environments': env['name']})
         self.assertEqual(loc['environments'][0], env['name'])
 
+    @tier1
     def test_create_location_with_host_group_by_id(self):
         """@Test: Create new location with assigned host group to it. Use host
         group id as a parameter
@@ -264,6 +279,7 @@ class TestLocation(CLITestCase):
         loc = make_location({'hostgroup-ids': host_group['id']})
         self.assertEqual(loc['hostgroups'][0], host_group['name'])
 
+    @tier1
     def test_create_location_with_host_group_by_name(self):
         """@Test: Create new location with assigned host group to it. Use host
         group name as a parameter
@@ -279,6 +295,7 @@ class TestLocation(CLITestCase):
         self.assertEqual(loc['hostgroups'][0], host_group['name'])
 
     @skip_if_bug_open('bugzilla', 1234287)
+    @tier1
     def test_create_location_with_medium(self):
         """@Test: Create new location with assigned media to it.
 
@@ -293,6 +310,7 @@ class TestLocation(CLITestCase):
         self.assertGreater(len(loc['installation-media']), 0)
         self.assertEqual(loc['installation-media'][0], medium['name'])
 
+    @tier1
     def test_create_location_with_multiple_environments_by_id(self):
         """@Test: Basically, verifying that location with multiple entities
         assigned to it by id can be created in the system. Environments were
@@ -311,6 +329,7 @@ class TestLocation(CLITestCase):
         for env in envs:
             self.assertIn(env['name'], loc['environments'])
 
+    @tier1
     def test_create_location_with_multiple_domains_by_name(self):
         """@Test: Basically, verifying that location with multiple entities
         assigned to it by name can be created in the system. Domains were
@@ -331,6 +350,7 @@ class TestLocation(CLITestCase):
         for domain in domains:
             self.assertIn(domain['name'], loc['domains'])
 
+    @tier1
     def test_create_location_with_different_names_negative(self):
         """@Test: Try to create location using invalid names only
 
@@ -344,6 +364,7 @@ class TestLocation(CLITestCase):
                 with self.assertRaises(CLIFactoryError):
                     make_location({'name': invalid_name})
 
+    @tier1
     def test_create_location_with_same_names_negative(self):
         """@Test: Try to create location using same name twice
 
@@ -358,6 +379,7 @@ class TestLocation(CLITestCase):
         with self.assertRaises(CLIFactoryError):
             make_location({'name': name})
 
+    @tier1
     def test_create_location_with_comp_resource_by_id_negative(self):
         """@Test: Try to create new location with incorrect compute resource
         assigned to it. Use compute resource id as a parameter
@@ -370,6 +392,7 @@ class TestLocation(CLITestCase):
         with self.assertRaises(CLIFactoryError):
             make_location({'compute-resource-ids': gen_string('numeric', 6)})
 
+    @tier1
     def test_create_location_with_user_by_name_negative(self):
         """@Test: Try to create new location with incorrect user assigned to it
         Use user login as a parameter
@@ -382,6 +405,7 @@ class TestLocation(CLITestCase):
         with self.assertRaises(CLIFactoryError):
             make_location({'users': gen_string('utf8', 80)})
 
+    @tier1
     def test_update_location_with_different_names(self):
         """@Test: Try to update location using different value types as a name
 
@@ -401,6 +425,7 @@ class TestLocation(CLITestCase):
                 loc = Location.info({'id': loc['id']})
                 self.assertEqual(loc['name'], new_name)
 
+    @tier1
     def test_update_location_with_user_by_id(self):
         """@Test: Create new location with assigned user to it. Try to update
         that location and change assigned user on another one. Use user id as a
@@ -422,6 +447,7 @@ class TestLocation(CLITestCase):
         loc = Location.info({'id': loc['id']})
         self.assertEqual(loc['users'][0], user[1]['login'])
 
+    @tier1
     def test_update_location_with_subnet_by_name(self):
         """@Test: Create new location with assigned subnet to it. Try to update
         that location and change assigned subnet on another one. Use subnet
@@ -445,6 +471,7 @@ class TestLocation(CLITestCase):
         self.assertIn(subnet[1]['name'], loc['subnets'][0])
         self.assertIn(subnet[1]['network'], loc['subnets'][0])
 
+    @tier1
     def test_update_location_with_multiple_comp_resources_to_single(self):
         """@Test: Create location with multiple (not less than three) compute
         resources assigned to it. Try to update location and overwrite all
@@ -476,6 +503,7 @@ class TestLocation(CLITestCase):
         self.assertEqual(len(loc['compute-resources']), 1)
         self.assertEqual(loc['compute-resources'][0], new_resource['name'])
 
+    @tier1
     def test_update_location_with_multiple_host_group_to_multiple(self):
         """@Test: Create location with multiple (three) host groups assigned to
         it. Try to update location and overwrite all host groups by new
@@ -504,6 +532,7 @@ class TestLocation(CLITestCase):
         for host_group in new_host_groups:
             self.assertIn(host_group['name'], loc['hostgroups'])
 
+    @tier1
     def test_update_location_with_different_names_negative(self):
         """@Test: Try to update location using invalid names only
 
@@ -521,6 +550,7 @@ class TestLocation(CLITestCase):
                         'new-name': invalid_name,
                     })
 
+    @tier1
     def test_update_location_with_domain_by_id_negative(self):
         """@Test: Try to update existing location with incorrect domain. Use
         domain id as a parameter
@@ -537,6 +567,7 @@ class TestLocation(CLITestCase):
                 'id': loc['id'],
             })
 
+    @tier1
     def test_update_location_with_template_by_name_negative(self):
         """@Test: Try to update existing location with incorrect config
         template. Use template name as a parameter
@@ -553,6 +584,7 @@ class TestLocation(CLITestCase):
                 'id': loc['id'],
             })
 
+    @tier1
     def test_delete_location_by_name(self):
         """@Test: Try to delete location using name of that location as a
         parameter. Use different value types for testing.
@@ -570,6 +602,7 @@ class TestLocation(CLITestCase):
                 with self.assertRaises(CLIReturnCodeError):
                     Location.info({'id': loc['id']})
 
+    @tier1
     def test_delete_location_by_id(self):
         """@Test: Try to delete location using id of that location as a
         parameter

--- a/tests/foreman/cli/test_medium.py
+++ b/tests/foreman/cli/test_medium.py
@@ -6,7 +6,7 @@ from robottelo.cli.base import CLIReturnCodeError
 from robottelo.cli.factory import make_location, make_medium, make_org, make_os
 from robottelo.cli.medium import Medium
 from robottelo.datafactory import valid_data_list
-from robottelo.decorators import run_only_on
+from robottelo.decorators import run_only_on, tier1, tier2
 from robottelo.test import CLITestCase
 
 URL = "http://mirror.fakeos.org/%s/$major.$minor/os/$arch"
@@ -24,6 +24,7 @@ OSES = [
 class TestMedium(CLITestCase):
     """Test class for Medium CLI"""
     @run_only_on('sat')
+    @tier1
     def test_positive_create_1(self):
         """@Test: Check if Medium can be created
 
@@ -38,6 +39,7 @@ class TestMedium(CLITestCase):
                 self.assertEqual(medium['name'], name)
 
     @run_only_on('sat')
+    @tier1
     def test_create_medium_with_location(self):
         """@Test: Check if medium with location can be created
 
@@ -51,6 +53,7 @@ class TestMedium(CLITestCase):
         self.assertIn(location['name'], medium['locations'])
 
     @run_only_on('sat')
+    @tier1
     def test_create_medium_with_organization(self):
         """@Test: Check if medium with organization can be created
 
@@ -64,6 +67,7 @@ class TestMedium(CLITestCase):
         self.assertIn(org['name'], medium['organizations'])
 
     @run_only_on('sat')
+    @tier1
     def test_positive_delete_1(self):
         """@Test: Check if Medium can be deleted
 
@@ -81,6 +85,7 @@ class TestMedium(CLITestCase):
 
     # pylint: disable=no-self-use
     @run_only_on('sat')
+    @tier2
     def test_add_operatingsystem_medium(self):
         """@Test: Check if Medium can be associated with operating system
 
@@ -97,6 +102,7 @@ class TestMedium(CLITestCase):
         })
 
     @run_only_on('sat')
+    @tier2
     def test_removeoperatingsystem_medium(self):
         """@Test: Check if operating system can be removed from media
 
@@ -121,6 +127,7 @@ class TestMedium(CLITestCase):
         self.assertNotIn(os['name'], medium['operating-systems'])
 
     @run_only_on('sat')
+    @tier1
     def test_medium_update(self):
         """@Test: Check if medium can be updated
 

--- a/tests/foreman/cli/test_model.py
+++ b/tests/foreman/cli/test_model.py
@@ -10,12 +10,13 @@ from robottelo.datafactory import (
     invalid_values_list,
     valid_data_list,
 )
-from robottelo.decorators import run_only_on
+from robottelo.decorators import run_only_on, tier1
 from robottelo.test import CLITestCase
 
 
 class TestModel(CLITestCase):
     """Test class for Model CLI"""
+    @tier1
     def test_positive_create(self):
         """@Test: Successfully creates an Model.
 
@@ -29,6 +30,7 @@ class TestModel(CLITestCase):
                 self.assertEqual(model['name'], name)
 
     @run_only_on('sat')
+    @tier1
     def test_create_model_vendor_class(self):
         """@Test: Check if Model can be created with specific vendor class
 
@@ -40,6 +42,7 @@ class TestModel(CLITestCase):
         model = make_model({'vendor-class': vendor_class})
         self.assertEqual(model['vendor-class'], vendor_class)
 
+    @tier1
     def test_negative_create(self):
         """@Test: Don't create an Model with invalid data.
 
@@ -52,6 +55,7 @@ class TestModel(CLITestCase):
                 with self.assertRaises(CLIReturnCodeError):
                     Model.create({'name': name})
 
+    @tier1
     def test_positive_update_name(self):
         """@Test: Successfully update an Model.
 
@@ -70,6 +74,7 @@ class TestModel(CLITestCase):
                 self.assertEqual(model['name'], new_name)
 
     @run_only_on('sat')
+    @tier1
     def test_negative_update(self):
         """@test: Create Model then fail to update its name
 
@@ -89,6 +94,7 @@ class TestModel(CLITestCase):
                 self.assertEqual(model['name'], result['name'])
 
     @run_only_on('sat')
+    @tier1
     def test_positive_delete(self):
         """@test: Create Model with valid values then delete it
         by ID
@@ -105,6 +111,7 @@ class TestModel(CLITestCase):
                     Model.info({'id': model['id']})
 
     @run_only_on('sat')
+    @tier1
     def test_negative_delete(self):
         """@test: Create Model then delete it by wrong ID
 

--- a/tests/foreman/cli/test_myaccount.py
+++ b/tests/foreman/cli/test_myaccount.py
@@ -14,7 +14,6 @@ class MyAccount(CLITestCase):
 
     [2] Negative Name Variations -  Blank, Greater than Max Length,
     Lesser than Min Length, Greater than Max DB size
-
     """
 
     @stubbed()
@@ -29,7 +28,6 @@ class MyAccount(CLITestCase):
         @Assert: Current User is updated
 
         @Status: Manual
-
         """
 
     @stubbed()
@@ -44,7 +42,6 @@ class MyAccount(CLITestCase):
         @Assert: Current User is updated
 
         @Status: Manual
-
         """
 
     @stubbed()
@@ -59,7 +56,6 @@ class MyAccount(CLITestCase):
         @Assert: Current User is updated
 
         @Status: Manual
-
         """
 
     @stubbed()
@@ -74,7 +70,6 @@ class MyAccount(CLITestCase):
         @Assert: Current User is updated
 
         @Status: Manual
-
         """
 
     @stubbed()
@@ -89,7 +84,6 @@ class MyAccount(CLITestCase):
         @Assert: User is updated
 
         @Status: Manual
-
         """
 
     @stubbed()
@@ -104,7 +98,6 @@ class MyAccount(CLITestCase):
         @Assert: User is not updated. Appropriate error shown.
 
         @Status: Manual
-
         """
 
     @stubbed()
@@ -119,7 +112,6 @@ class MyAccount(CLITestCase):
         @Assert: User is not updated. Appropriate error shown.
 
         @Status: Manual
-
         """
 
     @stubbed()
@@ -134,7 +126,6 @@ class MyAccount(CLITestCase):
         @Assert: User is not updated. Appropriate error shown.
 
         @Status: Manual
-
         """
 
     @stubbed()
@@ -150,7 +141,6 @@ class MyAccount(CLITestCase):
         @Assert: User is not updated. Appropriate error shown.
 
         @Status: Manual
-
         """
 
     @stubbed()
@@ -167,7 +157,6 @@ class MyAccount(CLITestCase):
         @Assert: User is not updated. Appropriate error shown.
 
         @Status: Manual
-
         """
 
     @stubbed()
@@ -184,5 +173,4 @@ class MyAccount(CLITestCase):
         @Assert: User is not updated.
 
         @Status: Manual
-
         """

--- a/tests/foreman/cli/test_org.py
+++ b/tests/foreman/cli/test_org.py
@@ -14,7 +14,13 @@ from robottelo.cli.lifecycleenvironment import LifecycleEnvironment
 from robottelo.cli.org import Org
 from robottelo.config import settings
 from robottelo.constants import FOREMAN_PROVIDERS
-from robottelo.decorators import run_only_on, skip_if_bug_open, stubbed
+from robottelo.decorators import (
+    run_only_on,
+    skip_if_bug_open,
+    stubbed,
+    tier1,
+    tier2,
+)
 from robottelo.test import CLITestCase
 
 
@@ -24,7 +30,6 @@ def valid_names():
     Note: The maximum allowed length of org name is 242 only. This is an
     intended behavior (Also note that 255 is the standard across other
     entities.)
-
     """
     return (
         {'name': gen_string("latin1")},
@@ -42,7 +47,6 @@ def valid_name_label_combo():
     Use this when name and label must match. Labels cannot contain the same
     data type as names, so this is a bit limited compared to other tests.
     Label cannot contain characters other than ascii alpha numerals, '_', '-'.
-
     """
     return (
         {'name': gen_string("alpha")},
@@ -61,7 +65,6 @@ def valid_names_simple():
     Note: The maximum allowed length of org name is 242 only. This is an
     intended behavior (Also note that 255 is the standard across other
     entities.)
-
     """
     return(
         gen_string('alpha', randint(1, 242)),
@@ -76,7 +79,6 @@ def valid_names_simple_all():
     Note: The maximum allowed length of org name is 242 only. This is an
     intended behavior (Also note that 255 is the standard across other
     entities.)
-
     """
     return(
         gen_string('alpha', randint(1, 242)),
@@ -95,7 +97,6 @@ def valid_name_label():
     Note: The maximum allowed length of org name is 242 only. This is an
     intended behavior (Also note that 255 is the standard across other
     entities.)
-
     """
     return (
         {'name': gen_string("latin1"),
@@ -119,7 +120,6 @@ def valid_name_desc():
     Note: The maximum allowed length of org name is 242 only. This is an
     intended behavior (Also note that 255 is the standard across other
     entities.)
-
     """
     return (
         {'name': gen_string("latin1"),
@@ -143,7 +143,6 @@ def valid_name_desc_label():
     Note: The maximum allowed length of org name is 242 only. This is an
     intended behavior (Also note that 255 is the standard across other
     entities.)
-
     """
     return (
         {'name': gen_string("alpha", randint(1, 242)),
@@ -210,13 +209,13 @@ class TestOrg(CLITestCase):
     # Tests for issues
 
     # This test also covers the redmine bug 4443
+    @tier1
     def test_redmine_4486(self):
         """@test: Can search for an organization by name
 
         @feature: Organizations
 
         @assert: organization is created and can be searched by name
-
         """
         for test_data in valid_names():
             with self.subTest(test_data):
@@ -226,13 +225,13 @@ class TestOrg(CLITestCase):
                 self.assertEqual(org['name'], result['name'])
 
     @run_only_on('sat')
+    @tier2
     def test_remove_domain(self):
         """@Test: Check if a Domain can be removed from an Org
 
         @Feature: Org - Domain
 
         @Assert: Domain is removed from the org
-
         """
         org = make_org()
         domain = make_domain()
@@ -245,13 +244,13 @@ class TestOrg(CLITestCase):
             'name': org['name'],
         })
 
+    @tier1
     def test_bugzilla_1079587(self):
         """@test: Search for an organization by label
 
         @feature: Organizations
 
         @assert: organization is created and can be searched by label
-
         """
         for test_data in valid_names():
             with self.subTest(test_data):
@@ -260,13 +259,13 @@ class TestOrg(CLITestCase):
                 result = Org.exists(search=('label', org['label']))
                 self.assertEqual(org['name'], result['name'])
 
+    @tier1
     def test_bugzilla_1076568_1(self):
         """@test: Delete organization by name
 
         @feature: Organizations
 
         @assert: Organization is deleted
-
         """
         org = make_org()
         Org.delete({'name': org['name']})
@@ -274,13 +273,13 @@ class TestOrg(CLITestCase):
         with self.assertRaises(CLIReturnCodeError):
             Org.info({'id': org['id']})
 
+    @tier1
     def test_bugzilla_1076568_2(self):
         """@test: Delete organization by ID
 
         @feature: Organizations
 
         @assert: Organization is deleted
-
         """
         org = make_org()
         Org.delete({'id': org['id']})
@@ -288,13 +287,13 @@ class TestOrg(CLITestCase):
         with self.assertRaises(CLIReturnCodeError):
             Org.info({'id': org['id']})
 
+    @tier1
     def test_bugzilla_1076568_3(self):
         """@test: Delete organization by label
 
         @feature: Organizations
 
         @assert: Organization is deleted
-
         """
         org = make_org()
         Org.delete({'label': org['label']})
@@ -302,13 +301,13 @@ class TestOrg(CLITestCase):
         with self.assertRaises(CLIReturnCodeError):
             Org.info({'id': org['id']})
 
+    @tier1
     def test_bugzilla_1076541(self):
         """@test: Cannot update organization name via CLI
 
         @feature: Organizations
 
         @assert: Organization name is updated
-
         """
         org = make_org()
         # Update the org name
@@ -321,6 +320,7 @@ class TestOrg(CLITestCase):
         org = Org.info({'id': org['id']})
         self.assertEqual(org['name'], new_name)
 
+    @tier1
     def test_bugzilla_1075163(self):
         """@Test: Add --label as a valid argument to organization info command
 
@@ -328,12 +328,12 @@ class TestOrg(CLITestCase):
 
         @Assert: Organization is created and info can be obtained by its label
         graciously
-
         """
         org = make_org()
         result = Org.info({'label': org['label']})
         self.assertEqual(org['id'], result['id'])
 
+    @tier1
     def test_bugzilla_1075156(self):
         """@Test: Cannot use CLI info for organizations by name
 
@@ -341,20 +341,19 @@ class TestOrg(CLITestCase):
 
         @Assert: Organization is created and info can be obtained by its name
         graciously
-
         """
         org = make_org()
         result = Org.info({'name': org['name']})
         self.assertEqual(org['id'], result['id'])
 
     @run_only_on('sat')
+    @tier2
     def test_bugzilla_1062295_1(self):
         """@Test: Foreman Cli : Add_Config template fails
 
         @Feature: Org
 
         @Assert: Config Template is added to the org
-
         """
         org = make_org()
         template = make_template()
@@ -364,13 +363,13 @@ class TestOrg(CLITestCase):
         })
 
     @run_only_on('sat')
+    @tier2
     def test_bugzilla_1062295_2(self):
         """@Test: Foreman Cli : Add_Config template fails
 
         @Feature: Org
 
         @Assert: ConfigTemplate is removed from the org
-
         """
         org = make_org()
         template = make_template()
@@ -383,6 +382,7 @@ class TestOrg(CLITestCase):
             'name': org['name'],
         })
 
+    @tier1
     def test_bugzilla_1023125(self):
         """@Test: hammer-cli: trying to create duplicate org throws unhandled
         ISE
@@ -391,7 +391,6 @@ class TestOrg(CLITestCase):
 
         @Assert: Organization is created once and second attempt is handled
         graciously
-
         """
         org = make_org()
         # Create new org with the same name as before
@@ -400,6 +399,7 @@ class TestOrg(CLITestCase):
             make_org({'name': org['name']})
 
     # This Bugzilla bug is private. It is impossible to fetch info about it.
+    @tier1
     def test_bugzilla_1078866(self):
         """@Test: hammer organization <info,list> --help types information
         doubled
@@ -407,7 +407,6 @@ class TestOrg(CLITestCase):
         @Feature: org info/list
 
         @Assert: no duplicated lines in usage message
-
         """
         # org list --help:
         result = Org.list({'help': True})
@@ -424,26 +423,26 @@ class TestOrg(CLITestCase):
 
     # CRUD
 
+    @tier1
     def test_positive_create_1(self):
         """@test: Create organization with valid name only
 
         @feature: Organizations
 
         @assert: organization is created, label is auto-generated
-
         """
         for test_data in valid_names():
             with self.subTest(test_data):
                 org = make_org(test_data)
                 self.assertEqual(org['name'], test_data['name'])
 
+    @tier1
     def test_positive_create_2(self):
         """@test: Create organization with valid matching name and label only
 
         @feature: Organizations
 
         @assert: organization is created, label matches name
-
         """
         for test_data in valid_name_label_combo():
             with self.subTest(test_data):
@@ -452,6 +451,7 @@ class TestOrg(CLITestCase):
                 self.assertEqual(org['name'], org['label'])
 
     @skip_if_bug_open('bugzilla', 1142821)
+    @tier1
     def test_positive_create_3(self):
         """@test: Create organization with valid unmatching name and label only
 
@@ -460,7 +460,6 @@ class TestOrg(CLITestCase):
         @assert: organization is created, label does not match name
 
         @bz: 1142821
-
         """
         for test_data in valid_name_label():
             with self.subTest(test_data):
@@ -469,13 +468,13 @@ class TestOrg(CLITestCase):
                 self.assertEqual(org['name'], test_data['name'])
                 self.assertEqual(org['label'], test_data['label'])
 
+    @tier1
     def test_positive_create_4(self):
         """@test: Create organization with valid name and description only
 
         @feature: Organizations
 
         @assert: organization is created, label is auto-generated
-
         """
         for test_data in valid_name_desc():
             with self.subTest(test_data):
@@ -485,6 +484,7 @@ class TestOrg(CLITestCase):
                 self.assertEqual(org['description'], test_data['description'])
 
     @skip_if_bug_open('bugzilla', 1142821)
+    @tier1
     def test_positive_create_5(self):
         """@test: Create organization with valid name, label and description
 
@@ -493,7 +493,6 @@ class TestOrg(CLITestCase):
         @assert: organization is created
 
         @bz: 1142821
-
         """
         for test_data in valid_name_desc():
             with self.subTest(test_data):
@@ -503,24 +502,24 @@ class TestOrg(CLITestCase):
                 self.assertEqual(org['description'], test_data['description'])
                 self.assertEqual(org['label'], test_data['label'])
 
+    @tier1
     def test_list_org(self):
         """@Test: Check if Org can be listed
 
         @Feature: Org - List
 
         @Assert: Org is listed
-
         """
         Org.list()
 
     @run_only_on('sat')
+    @tier2
     def test_add_subnet(self):
         """@Test: Check if a subnet can be added to an Org
 
         @Feature: Org - Subnet
 
         @Assert: Subnet is added to the org
-
         """
         org = make_org()
         subnet = make_subnet()
@@ -530,13 +529,13 @@ class TestOrg(CLITestCase):
         })
 
     @run_only_on('sat')
+    @tier2
     def test_remove_subnet(self):
         """@Test: Check if a subnet can be removed from an Org
 
         @Feature: Org - Subnet
 
         @Assert: Subnet is removed from the org
-
         """
         org = make_org()
         subnet = make_subnet()
@@ -549,13 +548,13 @@ class TestOrg(CLITestCase):
             'subnet': subnet['name'],
         })
 
+    @tier2
     def test_add_user(self):
         """@Test: Check if a User can be added to an Org
 
         @Feature: Org - User
 
         @Assert: User is added to the org
-
         """
         org = make_org()
         user = make_user()
@@ -564,13 +563,13 @@ class TestOrg(CLITestCase):
             'user-id': user['id'],
         })
 
+    @tier2
     def test_remove_user(self):
         """@Test: Check if a User can be removed from an Org
 
         @Feature: Org - User
 
         @Assert: User is removed from the org
-
         """
         org = make_org()
         user = make_user()
@@ -584,13 +583,13 @@ class TestOrg(CLITestCase):
         })
 
     @run_only_on('sat')
+    @tier2
     def test_add_hostgroup(self):
         """@Test: Check if a hostgroup can be added to an Org
 
         @Feature: Org - Hostgroup
 
         @Assert: Hostgroup is added to the org
-
         """
         org = make_org()
         hostgroup = make_hostgroup()
@@ -600,13 +599,13 @@ class TestOrg(CLITestCase):
         })
 
     @run_only_on('sat')
+    @tier2
     def test_remove_hostgroup(self):
         """@Test: Check if a hostgroup can be removed from an Org
 
         @Feature: Org - Subnet
 
         @Assert: Hostgroup is removed from the org
-
         """
         org = make_org()
         hostgroup = make_hostgroup()
@@ -620,13 +619,13 @@ class TestOrg(CLITestCase):
         })
 
     @run_only_on('sat')
+    @tier2
     def test_add_computeresource(self):
         """@Test: Check if a Compute Resource can be added to an Org
 
         @Feature: Org - Compute Resource
 
         @Assert: Compute Resource is added to the org
-
         """
         org = make_org()
         compute_res = make_compute_resource({
@@ -640,6 +639,7 @@ class TestOrg(CLITestCase):
         org = Org.info({'id': org['id']})
         self.assertEqual(org['compute-resources'][0], compute_res['name'])
 
+    @tier2
     def test_add_compute_resource_by_id(self):
         """@Test: Check that new organization with compute resource associated
         to it can be created in the system
@@ -647,13 +647,13 @@ class TestOrg(CLITestCase):
         @Feature: Org - Compute Resource
 
         @Assert: Organization with compute resource created successfully
-
         """
         compute_res = make_compute_resource()
         org = make_org({'compute-resource-ids': compute_res['id']})
         self.assertEqual(len(org['compute-resources']), 1)
         self.assertEqual(org['compute-resources'][0], compute_res['name'])
 
+    @tier2
     def test_add_compute_resources(self):
         """@Test: Check if Organization can be created with multiple compute
         resources
@@ -661,7 +661,6 @@ class TestOrg(CLITestCase):
         @Feature: Org - Compute Resource
 
         @Assert: Organization with compute resources created successfully
-
         """
         cr_amount = random.randint(3, 5)
         resources = [make_compute_resource() for _ in range(cr_amount)]
@@ -683,18 +682,16 @@ class TestOrg(CLITestCase):
         @Assert: ComputeResource is removed from the org
 
         @status: manual
-
         """
-        pass
 
     @run_only_on('sat')
+    @tier2
     def test_add_medium(self):
         """@Test: Check if a Medium can be added to an Org
 
         @Feature: Org - Medium
 
         @Assert: Medium is added to the org
-
         """
         org = make_org()
         medium = make_medium()
@@ -706,13 +703,13 @@ class TestOrg(CLITestCase):
         self.assertIn(medium['name'], org['installation-media'])
 
     @run_only_on('sat')
+    @tier2
     def test_remove_medium(self):
         """@Test: Check if a Medium can be removed from an Org
 
         @Feature: Org - Medium
 
         @Assert: Medium is removed from the org
-
         """
         org = make_org()
         medium = make_medium()
@@ -728,13 +725,13 @@ class TestOrg(CLITestCase):
         self.assertNotIn(medium['name'], org['installation-media'])
 
     @run_only_on('sat')
+    @tier2
     def test_add_configtemplate(self):
         """@Test: Check if a Config Template can be added to an Org
 
         @Feature: Org - Config Template
 
         @Assert: Config Template is added to the org
-
         """
         for name in valid_names_simple_all():
             with self.subTest(name):
@@ -753,6 +750,7 @@ class TestOrg(CLITestCase):
                     org['templates']
                 )
 
+    @tier2
     def test_add_configtemplate_by_id(self):
         """@Test: Check that new organization with config template associated
         to it can be created in the system
@@ -760,7 +758,6 @@ class TestOrg(CLITestCase):
         @Feature: Org - Config Template
 
         @Assert: Organization with config template created successfully
-
         """
         conf_templ = make_template()
         org = make_org({'config-template-ids': conf_templ['id']})
@@ -769,6 +766,7 @@ class TestOrg(CLITestCase):
             org['templates']
         )
 
+    @tier2
     def test_add_configtemplates(self):
         """@Test: Check that new organization with multiple config templates
         associated to it can be created in the system
@@ -776,7 +774,6 @@ class TestOrg(CLITestCase):
         @Feature: Org - Config Template
 
         @Assert: Organization with config templates created successfully
-
         """
         templates_amount = random.randint(3, 5)
         templates = [make_template() for _ in range(templates_amount)]
@@ -792,13 +789,13 @@ class TestOrg(CLITestCase):
             )
 
     @run_only_on('sat')
+    @tier2
     def test_remove_configtemplate(self):
         """@Test: Check if a ConfigTemplate can be removed from an Org
 
         @Feature: Org - ConfigTemplate
 
         @Assert: ConfigTemplate is removed from the org
-
         """
         for name in valid_names_simple_all():
             with self.subTest(name):
@@ -829,13 +826,13 @@ class TestOrg(CLITestCase):
                 )
 
     @run_only_on('sat')
+    @tier2
     def test_add_environment(self):
         """@Test: Check if an environment can be added to an Org
 
         @Feature: Org - Environment
 
         @Assert: Environment is added to the org
-
         """
         # Create a lifecycle environment.
         org_id = make_org()['id']
@@ -850,13 +847,13 @@ class TestOrg(CLITestCase):
         self.assertEqual(response[0]['name'], lc_env_name)
 
     @run_only_on('sat')
+    @tier2
     def test_remove_environment(self):
         """@Test: Check if an Environment can be removed from an Org
 
         @Feature: Org - Environment
 
         @Assert: Environment is removed from the org
-
         """
         # Create a lifecycle environment.
         org_id = make_org()['id']
@@ -884,7 +881,6 @@ class TestOrg(CLITestCase):
         @Feature: Org - Smartproxy
 
         @Assert: Smartproxy is added to the org
-
         """
         org = make_org()
         proxy = make_proxy()
@@ -901,7 +897,6 @@ class TestOrg(CLITestCase):
         @Feature: Org - Smartproxy
 
         @Assert: Smartproxy is removed from the org
-
         """
         org = make_org()
         proxy = make_proxy()
@@ -916,6 +911,7 @@ class TestOrg(CLITestCase):
 
     # Negative Create
 
+    @tier1
     def test_negative_create_0(self):
         """@test: Create organization with valid label and description, name is
         too long
@@ -923,7 +919,6 @@ class TestOrg(CLITestCase):
         @feature: Organizations
 
         @assert: organization is not created
-
         """
         for test_data in invalid_name_label():
             with self.subTest(test_data):
@@ -934,6 +929,7 @@ class TestOrg(CLITestCase):
                         'name': test_data['name'],
                     })
 
+    @tier1
     def test_negative_create_1(self):
         """@test: Create organization with valid label and description, name is
         blank
@@ -941,7 +937,6 @@ class TestOrg(CLITestCase):
         @feature: Organizations
 
         @assert: organization is not created
-
         """
         for test_data in valid_names_simple():
             with self.subTest(test_data):
@@ -952,6 +947,7 @@ class TestOrg(CLITestCase):
                         'name': '',
                     })
 
+    @tier1
     def test_negative_create_2(self):
         """@test: Create organization with valid label and description, name is
         whitespace
@@ -959,7 +955,6 @@ class TestOrg(CLITestCase):
         @feature: Organizations
 
         @assert: organization is not created
-
         """
         for test_data in valid_names_simple():
             with self.subTest(test_data):
@@ -970,6 +965,7 @@ class TestOrg(CLITestCase):
                         'name': ' \t',
                     })
 
+    @tier1
     def test_negative_create_3(self):
         """@test: Create organization with valid values, then create a new one
         with same values.
@@ -977,7 +973,6 @@ class TestOrg(CLITestCase):
         @feature: Organizations
 
         @assert: organization is not created
-
         """
         for test_data in valid_names_simple():
             with self.subTest(test_data):
@@ -995,6 +990,7 @@ class TestOrg(CLITestCase):
 
     # Positive Delete
 
+    @tier1
     def test_positive_delete_1(self):
         """@test: Create organization with valid values then delete it
         by ID
@@ -1002,7 +998,6 @@ class TestOrg(CLITestCase):
         @feature: Organizations
 
         @assert: organization is deleted
-
         """
         for test_data in valid_name_desc_label():
             with self.subTest(test_data):
@@ -1012,6 +1007,7 @@ class TestOrg(CLITestCase):
                 with self.assertRaises(CLIReturnCodeError):
                     Org.info({'id': org['id']})
 
+    @tier1
     def test_positive_delete_2(self):
         """@test: Create organization with valid values then delete it
         by label
@@ -1019,7 +1015,6 @@ class TestOrg(CLITestCase):
         @feature: Organizations
 
         @assert: organization is deleted
-
         """
         for test_data in valid_name_desc_label():
             with self.subTest(test_data):
@@ -1029,6 +1024,7 @@ class TestOrg(CLITestCase):
                 with self.assertRaises(CLIReturnCodeError):
                     Org.info({'id': org['id']})
 
+    @tier1
     def test_positive_delete_3(self):
         """@test: Create organization with valid values then delete it
         by name
@@ -1036,7 +1032,6 @@ class TestOrg(CLITestCase):
         @feature: Organizations
 
         @assert: organization is deleted
-
         """
         for test_data in valid_name_desc_label():
             with self.subTest(test_data):
@@ -1046,13 +1041,13 @@ class TestOrg(CLITestCase):
                 with self.assertRaises(CLIReturnCodeError):
                     Org.info({'id': org['id']})
 
+    @tier1
     def test_positive_update_1(self):
         """@test: Create organization with valid values then update its name
 
         @feature: Organizations
 
         @assert: organization name is updated
-
         """
         for test_data in valid_names():
             with self.subTest(test_data):
@@ -1066,6 +1061,7 @@ class TestOrg(CLITestCase):
                 org = Org.info({'id': org['id']})
                 self.assertEqual(org['name'], test_data['name'])
 
+    @tier1
     def test_positive_update_3(self):
         """@test: Create organization with valid values then update its
         description
@@ -1073,7 +1069,6 @@ class TestOrg(CLITestCase):
         @feature: Organizations
 
         @assert: organization description is updated
-
         """
         for test_data in positive_desc_data():
             with self.subTest(test_data):
@@ -1087,13 +1082,13 @@ class TestOrg(CLITestCase):
                 org = Org.info({'id': org['id']})
                 self.assertEqual(org['description'], test_data['description'])
 
+    @tier1
     def test_positive_update_4(self):
         """@test: Create organization with valid values then update all values
 
         @feature: Organizations
 
         @assert: organization name and description are updated
-
         """
         for test_data in valid_name_desc():
             with self.subTest(test_data):
@@ -1111,6 +1106,7 @@ class TestOrg(CLITestCase):
 
     # Negative Update
 
+    @tier1
     def test_negative_update_1(self):
         """@test: Create organization then fail to update
         its name
@@ -1118,7 +1114,6 @@ class TestOrg(CLITestCase):
         @feature: Organizations
 
         @assert: organization name is not updated
-
         """
         for test_data in invalid_name_data():
             with self.subTest(test_data):
@@ -1141,10 +1136,7 @@ class TestOrg(CLITestCase):
         @assert: organization is displayed/listed
 
         @status: manual
-
         """
-
-        pass
 
     @stubbed()
     def test_search_key_1(self):
@@ -1155,10 +1147,7 @@ class TestOrg(CLITestCase):
         @assert: organization can be found
 
         @status: manual
-
         """
-
-        pass
 
     @stubbed()
     def test_info_key_1(self):
@@ -1170,10 +1159,7 @@ class TestOrg(CLITestCase):
         creation values
 
         @status: manual
-
         """
-
-        pass
 
     # Associations
 
@@ -1187,10 +1173,7 @@ class TestOrg(CLITestCase):
         @assert: the domain is removed from the organization
 
         @status: manual
-
         """
-
-        pass
 
     @stubbed()
     def test_remove_domain_2(self):
@@ -1202,10 +1185,7 @@ class TestOrg(CLITestCase):
         @assert: the domain is removed from the organization
 
         @status: manual
-
         """
-
-        pass
 
     @stubbed()
     def test_remove_domain_3(self):
@@ -1217,10 +1197,7 @@ class TestOrg(CLITestCase):
         @assert: the domain is removed from the organization
 
         @status: manual
-
         """
-
-        pass
 
     @stubbed()
     def test_remove_domain_4(self):
@@ -1232,10 +1209,7 @@ class TestOrg(CLITestCase):
         @assert: the domain is removed from the organization
 
         @status: manual
-
         """
-
-        pass
 
     @stubbed()
     def test_remove_user_1(self):
@@ -1247,10 +1221,7 @@ class TestOrg(CLITestCase):
         @assert: User is added and then removed from organization
 
         @status: manual
-
         """
-
-        pass
 
     @stubbed()
     def test_remove_user_2(self):
@@ -1262,10 +1233,7 @@ class TestOrg(CLITestCase):
         @assert: The user is added then removed from the organization
 
         @status: manual
-
         """
-
-        pass
 
     @stubbed()
     def test_remove_user_3(self):
@@ -1277,10 +1245,7 @@ class TestOrg(CLITestCase):
         @assert: The user is added then removed from the organization
 
         @status: manual
-
         """
-
-        pass
 
     @run_only_on('sat')
     @stubbed()
@@ -1293,10 +1258,7 @@ class TestOrg(CLITestCase):
         @assert: hostgroup is added to organization then removed
 
         @status: manual
-
         """
-
-        pass
 
     @run_only_on('sat')
     @stubbed()
@@ -1309,10 +1271,7 @@ class TestOrg(CLITestCase):
         @assert: hostgroup is added to organization then removed
 
         @status: manual
-
         """
-
-        pass
 
     @run_only_on('sat')
     @stubbed()
@@ -1325,10 +1284,7 @@ class TestOrg(CLITestCase):
         @assert: hostgroup is added to organization then removed
 
         @status: manual
-
         """
-
-        pass
 
     @run_only_on('sat')
     @stubbed()
@@ -1341,10 +1297,7 @@ class TestOrg(CLITestCase):
         @assert: hostgroup is added to organization then removed
 
         @status: manual
-
         """
-
-        pass
 
     @run_only_on('sat')
     @stubbed()
@@ -1357,10 +1310,7 @@ class TestOrg(CLITestCase):
         @assert: smartproxy is added
 
         @status: manual
-
         """
-
-        pass
 
     @run_only_on('sat')
     @stubbed()
@@ -1373,10 +1323,7 @@ class TestOrg(CLITestCase):
         @assert: smartproxy is added
 
         @status: manual
-
         """
-
-        pass
 
     @run_only_on('sat')
     @stubbed()
@@ -1389,10 +1336,7 @@ class TestOrg(CLITestCase):
         @assert: smartproxy is added
 
         @status: manual
-
         """
-
-        pass
 
     @run_only_on('sat')
     @stubbed()
@@ -1404,19 +1348,16 @@ class TestOrg(CLITestCase):
         @assert: smartproxy is added
 
         @status: manual
-
         """
 
-        pass
-
     @run_only_on('sat')
+    @tier2
     def test_add_subnet_1(self):
         """@test: Add a subnet by using organization name and subnet name
 
         @feature: Organizations
 
         @assert: subnet is added
-
         """
         for name in (gen_string('alpha'), gen_string('numeric'),
                      gen_string('alphanumeric'), gen_string('utf8'),
@@ -1441,10 +1382,7 @@ class TestOrg(CLITestCase):
         @assert: subnet is added
 
         @status: manual
-
         """
-
-        pass
 
     @run_only_on('sat')
     @stubbed()
@@ -1456,10 +1394,7 @@ class TestOrg(CLITestCase):
         @assert: subnet is added
 
         @status: manual
-
         """
-
-        pass
 
     @run_only_on('sat')
     @stubbed()
@@ -1471,10 +1406,7 @@ class TestOrg(CLITestCase):
         @assert: subnet is added
 
         @status: manual
-
         """
-
-        pass
 
     @run_only_on('sat')
     @stubbed()
@@ -1486,10 +1418,7 @@ class TestOrg(CLITestCase):
         @assert: Domain is added to organization
 
         @status: manual
-
         """
-
-        pass
 
     @stubbed()
     def test_add_user_1(self):
@@ -1501,10 +1430,7 @@ class TestOrg(CLITestCase):
         @assert: User is added to organization
 
         @status: manual
-
         """
-
-        pass
 
     @stubbed()
     def test_add_user_2(self):
@@ -1516,10 +1442,7 @@ class TestOrg(CLITestCase):
         @assert: User is added to organization
 
         @status: manual
-
         """
-
-        pass
 
     @stubbed()
     def test_add_user_3(self):
@@ -1531,10 +1454,7 @@ class TestOrg(CLITestCase):
         @assert: User is added to organization
 
         @status: manual
-
         """
-
-        pass
 
     @run_only_on('sat')
     @stubbed()
@@ -1547,10 +1467,7 @@ class TestOrg(CLITestCase):
         @assert: hostgroup is added to organization
 
         @status: manual
-
         """
-
-        pass
 
     @run_only_on('sat')
     @stubbed()
@@ -1563,10 +1480,7 @@ class TestOrg(CLITestCase):
         @assert: hostgroup is added to organization
 
         @status: manual
-
         """
-
-        pass
 
     @run_only_on('sat')
     @stubbed()
@@ -1579,10 +1493,7 @@ class TestOrg(CLITestCase):
         @assert: hostgroup is added to organization
 
         @status: manual
-
         """
-
-        pass
 
     @run_only_on('sat')
     @stubbed()
@@ -1595,10 +1506,7 @@ class TestOrg(CLITestCase):
         @assert: hostgroup is added to organization
 
         @status: manual
-
         """
-
-        pass
 
     @run_only_on('sat')
     @stubbed()
@@ -1611,10 +1519,7 @@ class TestOrg(CLITestCase):
         @assert: computeresource is added then removed
 
         @status: manual
-
         """
-
-        pass
 
     @run_only_on('sat')
     @stubbed()
@@ -1627,10 +1532,7 @@ class TestOrg(CLITestCase):
         @assert: computeresource is added then removed
 
         @status: manual
-
         """
-
-        pass
 
     @run_only_on('sat')
     @stubbed()
@@ -1643,10 +1545,7 @@ class TestOrg(CLITestCase):
         @assert: computeresource is added then removed
 
         @status: manual
-
         """
-
-        pass
 
     @run_only_on('sat')
     @stubbed()
@@ -1659,10 +1558,7 @@ class TestOrg(CLITestCase):
         @assert: computeresource is added then removed
 
         @status: manual
-
         """
-
-        pass
 
     @run_only_on('sat')
     @stubbed()
@@ -1674,10 +1570,7 @@ class TestOrg(CLITestCase):
         @assert: medium is added then removed
 
         @status: manual
-
         """
-
-        pass
 
     @run_only_on('sat')
     @stubbed()
@@ -1689,10 +1582,7 @@ class TestOrg(CLITestCase):
         @assert: medium is added then removed
 
         @status: manual
-
         """
-
-        pass
 
     @run_only_on('sat')
     @stubbed()
@@ -1704,10 +1594,7 @@ class TestOrg(CLITestCase):
         @assert: medium is added then removed
 
         @status: manual
-
         """
-
-        pass
 
     @run_only_on('sat')
     @stubbed()
@@ -1719,10 +1606,7 @@ class TestOrg(CLITestCase):
         @assert: medium is added then removed
 
         @status: manual
-
         """
-
-        pass
 
     @run_only_on('sat')
     @stubbed()
@@ -1734,10 +1618,7 @@ class TestOrg(CLITestCase):
         @assert: configtemplate is added then removed
 
         @status: manual
-
         """
-
-        pass
 
     @run_only_on('sat')
     @stubbed()
@@ -1750,10 +1631,7 @@ class TestOrg(CLITestCase):
         @assert: environment is added then removed
 
         @status: manual
-
         """
-
-        pass
 
     @run_only_on('sat')
     @stubbed()
@@ -1766,10 +1644,7 @@ class TestOrg(CLITestCase):
         @assert: environment is added then removed
 
         @status: manual
-
         """
-
-        pass
 
     @run_only_on('sat')
     @stubbed()
@@ -1782,10 +1657,7 @@ class TestOrg(CLITestCase):
         @assert: environment is added then removed
 
         @status: manual
-
         """
-
-        pass
 
     @run_only_on('sat')
     @stubbed()
@@ -1798,10 +1670,7 @@ class TestOrg(CLITestCase):
         @assert: environment is added then removed
 
         @status: manual
-
         """
-
-        pass
 
     @run_only_on('sat')
     @stubbed()
@@ -1814,10 +1683,7 @@ class TestOrg(CLITestCase):
         @assert: smartproxy is added then removed
 
         @status: manual
-
         """
-
-        pass
 
     @run_only_on('sat')
     @stubbed()
@@ -1830,10 +1696,7 @@ class TestOrg(CLITestCase):
         @assert: smartproxy is added then removed
 
         @status: manual
-
         """
-
-        pass
 
     @run_only_on('sat')
     @stubbed()
@@ -1846,10 +1709,7 @@ class TestOrg(CLITestCase):
         @assert: smartproxy is added then removed
 
         @status: manual
-
         """
-
-        pass
 
     @run_only_on('sat')
     @stubbed()
@@ -1861,10 +1721,7 @@ class TestOrg(CLITestCase):
         @assert: smartproxy is added then removed
 
         @status: manual
-
         """
-
-        pass
 
     @run_only_on('sat')
     @stubbed()
@@ -1877,10 +1734,7 @@ class TestOrg(CLITestCase):
         @assert: computeresource is added
 
         @status: manual
-
         """
-
-        pass
 
     @run_only_on('sat')
     @stubbed()
@@ -1893,10 +1747,7 @@ class TestOrg(CLITestCase):
         @assert: computeresource is added
 
         @status: manual
-
         """
-
-        pass
 
     @run_only_on('sat')
     @stubbed()
@@ -1909,10 +1760,7 @@ class TestOrg(CLITestCase):
         @assert: computeresource is added
 
         @status: manual
-
         """
-
-        pass
 
     @run_only_on('sat')
     @stubbed()
@@ -1925,10 +1773,7 @@ class TestOrg(CLITestCase):
         @assert: computeresource is added
 
         @status: manual
-
         """
-
-        pass
 
     @run_only_on('sat')
     @stubbed()
@@ -1940,10 +1785,7 @@ class TestOrg(CLITestCase):
         @assert: medium is added
 
         @status: manual
-
         """
-
-        pass
 
     @run_only_on('sat')
     @stubbed()
@@ -1955,10 +1797,7 @@ class TestOrg(CLITestCase):
         @assert: medium is added
 
         @status: manual
-
         """
-
-        pass
 
     @run_only_on('sat')
     @stubbed()
@@ -1970,10 +1809,7 @@ class TestOrg(CLITestCase):
         @assert: medium is added
 
         @status: manual
-
         """
-
-        pass
 
     @run_only_on('sat')
     @stubbed()
@@ -1985,10 +1821,7 @@ class TestOrg(CLITestCase):
         @assert: medium is added
 
         @status: manual
-
         """
-
-        pass
 
     @run_only_on('sat')
     @stubbed()
@@ -2001,10 +1834,7 @@ class TestOrg(CLITestCase):
         @assert: configtemplate is added
 
         @status: manual
-
         """
-
-        pass
 
     @run_only_on('sat')
     @stubbed()
@@ -2017,10 +1847,7 @@ class TestOrg(CLITestCase):
         @assert: configtemplate is added
 
         @status: manual
-
         """
-
-        pass
 
     @run_only_on('sat')
     @stubbed()
@@ -2033,10 +1860,7 @@ class TestOrg(CLITestCase):
         @assert: configtemplate is added
 
         @status: manual
-
         """
-
-        pass
 
     @run_only_on('sat')
     @stubbed()
@@ -2049,10 +1873,7 @@ class TestOrg(CLITestCase):
         @assert: configtemplate is added
 
         @status: manual
-
         """
-
-        pass
 
     @run_only_on('sat')
     @stubbed()
@@ -2065,10 +1886,7 @@ class TestOrg(CLITestCase):
         @assert: environment is added
 
         @status: manual
-
         """
-
-        pass
 
     @run_only_on('sat')
     @stubbed()
@@ -2080,10 +1898,7 @@ class TestOrg(CLITestCase):
         @assert: environment is added
 
         @status: manual
-
         """
-
-        pass
 
     @run_only_on('sat')
     @stubbed()
@@ -2095,10 +1910,7 @@ class TestOrg(CLITestCase):
         @assert: environment is added
 
         @status: manual
-
         """
-
-        pass
 
     @run_only_on('sat')
     @stubbed()
@@ -2110,10 +1922,7 @@ class TestOrg(CLITestCase):
         @assert: environment is added
 
         @status: manual
-
         """
-
-        pass
 
     @run_only_on('sat')
     @stubbed()
@@ -2125,10 +1934,7 @@ class TestOrg(CLITestCase):
         @assert: subnet is added then removed
 
         @status: manual
-
         """
-
-        pass
 
     @run_only_on('sat')
     @stubbed()
@@ -2140,10 +1946,7 @@ class TestOrg(CLITestCase):
         @assert: subnet is added then removed
 
         @status: manual
-
         """
-
-        pass
 
     @run_only_on('sat')
     @stubbed()
@@ -2155,10 +1958,7 @@ class TestOrg(CLITestCase):
         @assert: subnet is added then removed
 
         @status: manual
-
         """
-
-        pass
 
     @run_only_on('sat')
     @stubbed()
@@ -2170,7 +1970,4 @@ class TestOrg(CLITestCase):
         @assert: subnet is added then removed
 
         @status: manual
-
         """
-
-        pass

--- a/tests/foreman/cli/test_os.py
+++ b/tests/foreman/cli/test_os.py
@@ -12,7 +12,7 @@ from robottelo.cli.factory import (
     make_template,
 )
 from robottelo.datafactory import valid_data_list, invalid_values_list
-from robottelo.decorators import run_only_on, skip_if_bug_open
+from robottelo.decorators import run_only_on, skip_if_bug_open, tier1, tier2
 from robottelo.test import CLITestCase
 
 NEGATIVE_DELETE_DATA = (
@@ -30,6 +30,7 @@ class TestOperatingSystem(CLITestCase):
     # Issues
     @skip_if_bug_open('redmine', 4547)
     @run_only_on('sat')
+    @tier1
     def test_redmine_4547(self):
         """@test: Search for newly created OS by name
 
@@ -49,6 +50,7 @@ class TestOperatingSystem(CLITestCase):
         self.assertGreater(len(os_list_after), len(os_list_before))
 
     @run_only_on('sat')
+    @tier1
     def test_bugzilla_1051557(self):
         """@test: Update an Operating System's major version.
 
@@ -70,6 +72,7 @@ class TestOperatingSystem(CLITestCase):
         self.assertEqual(int(os['major-version']), major)
 
     @run_only_on('sat')
+    @tier1
     def test_bugzilla_1203457(self):
         """@test: Create an OS pointing to an arch, medium and partition table.
 
@@ -98,6 +101,7 @@ class TestOperatingSystem(CLITestCase):
             operating_system['partition-tables'][0], ptable['name'])
 
     @run_only_on('sat')
+    @tier1
     def test_list_1(self):
         """@test: Displays list for operating system
 
@@ -116,6 +120,7 @@ class TestOperatingSystem(CLITestCase):
         self.assertGreater(len(os_list_after), len(os_list_before))
 
     @run_only_on('sat')
+    @tier1
     def test_info_1(self):
         """@test: Displays info for operating system
 
@@ -134,6 +139,7 @@ class TestOperatingSystem(CLITestCase):
         self.assertEqual(str(os['minor-version']), os_info['minor-version'])
 
     @run_only_on('sat')
+    @tier1
     def test_positive_create_1(self):
         """@test: Create Operating System for all variations of name
 
@@ -148,6 +154,7 @@ class TestOperatingSystem(CLITestCase):
                 self.assertEqual(os['name'], name)
 
     @run_only_on('sat')
+    @tier1
     def test_negative_create_1(self):
         """@test: Create Operating System using invalid names
 
@@ -162,6 +169,7 @@ class TestOperatingSystem(CLITestCase):
                     make_os({'name': name})
 
     @run_only_on('sat')
+    @tier1
     def test_positive_update_1(self):
         """@test: Positive update of system name
 
@@ -182,6 +190,7 @@ class TestOperatingSystem(CLITestCase):
                 self.assertNotEqual(result['name'], os['name'])
 
     @run_only_on('sat')
+    @tier1
     def test_negative_update_1(self):
         """@test: Negative update of system name
 
@@ -202,6 +211,7 @@ class TestOperatingSystem(CLITestCase):
                 self.assertEqual(result['name'], os['name'])
 
     @run_only_on('sat')
+    @tier1
     def test_positive_delete_1(self):
         """@test: Successfully deletes Operating System
 
@@ -218,6 +228,7 @@ class TestOperatingSystem(CLITestCase):
                     OperatingSys.info({'id': os['id']})
 
     @run_only_on('sat')
+    @tier1
     def test_negative_delete_1(self):
         """@test: Not delete Operating System for invalid data
 
@@ -238,6 +249,7 @@ class TestOperatingSystem(CLITestCase):
                 self.assertEqual(os['name'], result['name'])
 
     @run_only_on('sat')
+    @tier2
     def test_add_architecture(self):
         """@test: Add Architecture to os
 
@@ -257,6 +269,7 @@ class TestOperatingSystem(CLITestCase):
         self.assertEqual(architecture['name'], os['architectures'][0])
 
     @run_only_on('sat')
+    @tier2
     def test_add_configtemplate(self):
         """@test: Add configtemplate to os
 
@@ -277,6 +290,7 @@ class TestOperatingSystem(CLITestCase):
         self.assertTrue(template_name.startswith(template['name']))
 
     @run_only_on('sat')
+    @tier2
     def test_add_ptable(self):
         """@test: Add ptable to os
 

--- a/tests/foreman/cli/test_partitiontable.py
+++ b/tests/foreman/cli/test_partitiontable.py
@@ -4,7 +4,7 @@ from fauxfactory import gen_string, gen_alphanumeric
 from robottelo.cli.factory import make_os, make_partition_table
 from robottelo.cli.operatingsys import OperatingSys
 from robottelo.cli.partitiontable import PartitionTable
-from robottelo.decorators import run_only_on
+from robottelo.decorators import run_only_on, tier1, tier2
 from robottelo.test import CLITestCase
 
 
@@ -20,6 +20,7 @@ class TestPartitionTableUpdateCreate(CLITestCase):
                      'content': self.content}
 
     @run_only_on('sat')
+    @tier1
     def test_create_ptable(self):
         """@Test: Check if Partition Table can be created
 
@@ -32,6 +33,7 @@ class TestPartitionTableUpdateCreate(CLITestCase):
         self.assertEqual(ptable['name'], self.name)
 
     @run_only_on('sat')
+    @tier1
     def test_update_ptable(self):
         """@Test: Check if Partition Table can be updated
 
@@ -53,6 +55,7 @@ class TestPartitionTableUpdateCreate(CLITestCase):
 class TestPartitionTableDelete(CLITestCase):
     """Test case for Dump/Delete CLI tests."""
 
+    @tier1
     def test_dump_ptable_1(self):
         """@Test: Check if Partition Table can be created with specific content
 
@@ -66,6 +69,7 @@ class TestPartitionTableDelete(CLITestCase):
         ptable_content = PartitionTable().dump({'id': ptable['id']})
         self.assertTrue(content in ptable_content[0])
 
+    @tier1
     def test_delete_ptable_1(self):
         """@Test: Check if Partition Table can be deleted
 
@@ -81,6 +85,7 @@ class TestPartitionTableDelete(CLITestCase):
         self.assertFalse(PartitionTable().exists(search=('name', name)))
 
     # pylint: disable=no-self-use
+    @tier2
     def test_addoperatingsystem_ptable(self):
         """@Test: Check if Partition Table can be associated
                   with operating system
@@ -98,6 +103,7 @@ class TestPartitionTableDelete(CLITestCase):
             'operatingsystem-id': os_list[0]['id']
         })
 
+    @tier2
     def test_remove_os_ptable(self):
         """@Test: Check if associated operating system can be removed
 

--- a/tests/foreman/cli/test_ping.py
+++ b/tests/foreman/cli/test_ping.py
@@ -1,6 +1,7 @@
 """Test Class for hammer ping"""
 from robottelo import ssh
 from robottelo.config import settings
+from robottelo.decorators import tier1
 from robottelo.test import CLITestCase
 from six.moves import zip
 
@@ -8,6 +9,7 @@ from six.moves import zip
 class PingTestCase(CLITestCase):
     """Tests related to the hammer ping command"""
 
+    @tier1
     def test_hammer_ping(self):
         """@test: hammer ping return code
 
@@ -18,7 +20,6 @@ class PingTestCase(CLITestCase):
         2. Check its return code, should be 0 if all services are ok else != 0
 
         @assert: hammer ping returns a right return code
-
         """
         result = ssh.command('hammer -u {0} -p {1} ping'.format(
             settings.server.admin_username,

--- a/tests/foreman/cli/test_product.py
+++ b/tests/foreman/cli/test_product.py
@@ -19,7 +19,7 @@ from robottelo.datafactory import (
     valid_labels_list,
     invalid_values_list,
 )
-from robottelo.decorators import bz_bug_is_open, run_only_on
+from robottelo.decorators import bz_bug_is_open, run_only_on, tier1, tier2
 from robottelo.test import CLITestCase
 
 
@@ -38,13 +38,13 @@ class TestProduct(CLITestCase):
             TestProduct.org = make_org(cached=True)
 
     @run_only_on('sat')
+    @tier1
     def test_positive_create_1(self):
         """@Test: Check if product can be created with random names
 
         @Feature: Product
 
         @Assert: Product is created and has random name
-
         """
         for name in valid_data_list():
             with self.subTest(name):
@@ -56,13 +56,13 @@ class TestProduct(CLITestCase):
                 self.assertGreater(len(product['label']), 0)
 
     @run_only_on('sat')
+    @tier1
     def test_positive_create_2(self):
         """@Test: Check if product can be created with random labels
 
         @Feature: Product
 
         @Assert: Product is created and has random label
-
         """
         for label in valid_labels_list():
             with self.subTest(label):
@@ -76,13 +76,13 @@ class TestProduct(CLITestCase):
                 self.assertEqual(product['label'], label)
 
     @run_only_on('sat')
+    @tier1
     def test_positive_create_3(self):
         """@Test: Check if product can be created with random description
 
         @Feature: Product
 
         @Assert: Product is created and has random description
-
         """
         for desc in valid_data_list():
             with self.subTest(desc):
@@ -95,13 +95,13 @@ class TestProduct(CLITestCase):
                 self.assertEqual(product['name'], product_name)
                 self.assertEqual(product['description'], desc)
 
+    @tier1
     def test_positive_create_4(self):
         """@Test: Check if product can be created with gpg key
 
         @Feature: Product
 
         @Assert: Product is created and has gpg key
-
         """
         gpg_key = make_gpg_key({u'organization-id': self.org['id']})
         for name in valid_data_list():
@@ -114,13 +114,13 @@ class TestProduct(CLITestCase):
                 self.assertEqual(product['name'], name)
                 self.assertEqual(product['gpg']['gpg-key-id'], gpg_key['id'])
 
+    @tier1
     def test_positive_create_5(self):
         """@Test: Check if product can be created with sync plan
 
         @Feature: Product
 
         @Assert: Product is created and has random sync plan
-
         """
         sync_plan = make_sync_plan({
             u'organization-id': self.org['id']
@@ -135,13 +135,13 @@ class TestProduct(CLITestCase):
                 self.assertEqual(product['name'], name)
                 self.assertEqual(product['sync-plan-id'], sync_plan['id'])
 
+    @tier1
     def test_negative_create_1(self):
         """@Test: Check that only valid names can be used
 
         @Feature: Product
 
         @Assert: Product is not created
-
         """
         for invalid_name in invalid_values_list():
             with self.subTest(invalid_name):
@@ -151,13 +151,13 @@ class TestProduct(CLITestCase):
                         u'organization-id': self.org['id'],
                     })
 
+    @tier1
     def test_negative_create_2(self):
         """@Test: Check that only valid labels can be used
 
         @Feature: Product
 
         @Assert: Product is not created
-
         """
         product_name = gen_alphanumeric()
         for invalid_label in (gen_string('latin1', 15), gen_string('utf8', 15),
@@ -170,13 +170,13 @@ class TestProduct(CLITestCase):
                         u'organization-id': self.org['id'],
                     })
 
+    @tier1
     def test_positive_update_1(self):
         """@Test: Update the description of a product
 
         @Feature: Product
 
         @Assert: Product description is updated
-
         """
         product = make_product({u'organization-id': self.org['id']})
         for desc in valid_data_list():
@@ -192,13 +192,13 @@ class TestProduct(CLITestCase):
                 self.assertEqual(result['description'], desc)
 
     @run_only_on('sat')
+    @tier1
     def test_positive_update_2(self):
         """@Test: Update product's gpg keys
 
         @Feature: Product
 
         @Assert: Product gpg key is updated
-
         """
         first_gpg_key = make_gpg_key({u'organization-id': self.org['id']})
         second_gpg_key = make_gpg_key({u'organization-id': self.org['id']})
@@ -220,13 +220,13 @@ class TestProduct(CLITestCase):
         self.assertNotEqual(product['gpg']['gpg-key-id'], first_gpg_key['id'])
 
     @run_only_on('sat')
+    @tier1
     def test_positive_update_3(self):
         """@Test: Update product's sync plan
 
         @Feature: Product
 
         @Assert: Product sync plan is updated
-
         """
         first_sync_plan = make_sync_plan({u'organization-id': self.org['id']})
         second_sync_plan = make_sync_plan({u'organization-id': self.org['id']})
@@ -248,13 +248,13 @@ class TestProduct(CLITestCase):
         self.assertNotEqual(product['sync-plan-id'], first_sync_plan['id'])
 
     @run_only_on('sat')
+    @tier1
     def test_positive_update_4(self):
         """@Test: Rename Product back to original name
 
         @Feature: Product
 
         @Assert: Product Renamed to original
-
         """
         for prod_name in generate_strings_list():
             with self.subTest(prod_name):
@@ -287,13 +287,13 @@ class TestProduct(CLITestCase):
                 self.assertEqual(prod['name'], prod_name)
 
     @run_only_on('sat')
+    @tier1
     def test_positive_delete_1(self):
         """@Test: Check if product can be deleted
 
         @Feature: Product
 
         @Assert: Product is deleted
-
         """
         new_product = make_product({u'organization-id': self.org['id']})
         Product.delete({u'id': new_product['id']})
@@ -310,13 +310,13 @@ class TestProduct(CLITestCase):
                         u'organization-id': self.org['id'],
                     })
 
+    @tier2
     def test_add_syncplan_1(self):
         """@Test: Check if product can be assigned a syncplan
 
         @Feature: Product
 
         @Assert: Product has syncplan
-
         """
         new_product = make_product({u'organization-id': self.org['id']})
         sync_plan = make_sync_plan({'organization-id': self.org['id']})
@@ -330,13 +330,13 @@ class TestProduct(CLITestCase):
         })
         self.assertEqual(new_product['sync-plan-id'], sync_plan['id'])
 
+    @tier2
     def test_remove_syncplan_1(self):
         """@Test: Check if product can be assigned a syncplan
 
         @Feature: Product
 
         @Assert: Product has syncplan
-
         """
         product = make_product({u'organization-id': self.org['id']})
         sync_plan = make_sync_plan({'organization-id': self.org['id']})
@@ -356,6 +356,7 @@ class TestProduct(CLITestCase):
         })
         self.assertEqual(len(product['sync-plan-id']), 0)
 
+    @tier2
     def test_product_sync_by_id(self):
         """@Test: Check if product can be synchronized.
         Searches for product and organization by their IDs
@@ -363,7 +364,6 @@ class TestProduct(CLITestCase):
         @Feature: Product
 
         @Assert: Product was synchronized
-
         """
         org = make_org()
         product = make_product({'organization-id': org['id']})
@@ -378,6 +378,7 @@ class TestProduct(CLITestCase):
         })
         self.assertEqual(u'Syncing Complete.', product['sync-state'])
 
+    @tier2
     def test_product_sync_by_name(self):
         """@Test: Check if product can be synchronized.
         Searches for product and organization by their Names
@@ -385,7 +386,6 @@ class TestProduct(CLITestCase):
         @Feature: Product
 
         @Assert: Product was synchronized
-
         """
         org = make_org()
         product = make_product({'organization-id': org['id']})
@@ -400,6 +400,7 @@ class TestProduct(CLITestCase):
         })
         self.assertEqual(u'Syncing Complete.', product['sync-state'])
 
+    @tier2
     def test_product_sync_by_label(self):
         """@Test: Check if product can be synchronized.
         Searches for organization by its label
@@ -407,7 +408,6 @@ class TestProduct(CLITestCase):
         @Feature: Product
 
         @Assert: Product was synchronized
-
         """
         org = make_org()
         product = make_product({'organization-id': org['id']})

--- a/tests/foreman/cli/test_proxy.py
+++ b/tests/foreman/cli/test_proxy.py
@@ -9,7 +9,7 @@ from robottelo.cli.base import CLIReturnCodeError
 from robottelo.cli.factory import CLIFactoryError, make_proxy
 from robottelo.cli.proxy import Proxy, default_url_on_new_port
 from robottelo.datafactory import valid_data_list
-from robottelo.decorators import run_only_on
+from robottelo.decorators import run_only_on, tier1, tier2
 from robottelo.test import CLITestCase
 
 
@@ -21,13 +21,13 @@ class TestProxy(CLITestCase):
         self.skipTest('Skipping tests until we can create ssh tunnels')
 
     @run_only_on('sat')
+    @tier1
     def test_redmine_3875(self):
         """@Test: Proxy creation with random URL
 
         @Feature: Smart Proxy
 
         @Assert: Proxy is not created
-
         """
         # Create a random proxy
         with self.assertRaises(CLIFactoryError):
@@ -38,13 +38,13 @@ class TestProxy(CLITestCase):
             })
 
     @run_only_on('sat')
+    @tier1
     def test_proxy_create(self):
         """@Test: Proxy creation with the home proxy
 
         @Feature: Smart Proxy
 
         @Assert: Proxy is created
-
         """
         for name in valid_data_list():
             with self.subTest(name):
@@ -52,13 +52,13 @@ class TestProxy(CLITestCase):
                 self.assertEquals(proxy['name'], name)
 
     @run_only_on('sat')
+    @tier1
     def test_proxy_delete(self):
         """@Test: Proxy deletion with the home proxy
 
         @Feature: Smart Proxy
 
         @Assert: Proxy is deleted
-
         """
         for name in valid_data_list():
             with self.subTest(name):
@@ -68,13 +68,13 @@ class TestProxy(CLITestCase):
                     Proxy.info({u'id': proxy['id']})
 
     @run_only_on('sat')
+    @tier1
     def test_proxy_update(self):
         """@Test: Proxy name update with the home proxy
 
         @Feature: Smart Proxy
 
         @Assert: Proxy has the name updated
-
         """
         proxy = make_proxy({u'name': gen_alphanumeric()})
         newport = random.randint(9091, 49090)
@@ -90,25 +90,25 @@ class TestProxy(CLITestCase):
                     self.assertEqual(proxy['name'], new_name)
 
     @run_only_on('sat')
+    @tier2
     def test_refresh_refresh_features_by_id(self):
         """@Test: Refresh smart proxy features, search for proxy by id
 
         @Feature: Smart Proxy
 
         @Assert: Proxy features are refreshed
-
         """
         proxy = make_proxy()
         Proxy.refresh_features({u'id': proxy['id']})
 
     @run_only_on('sat')
+    @tier2
     def test_proxy_refresh_features_by_name(self):
         """@Test: Refresh smart proxy features, search for proxy by name
 
         @Feature: Smart Proxy
 
         @Assert: Proxy features are refreshed
-
         """
         proxy = make_proxy()
         Proxy.refresh_features({u'name': proxy['name']})

--- a/tests/foreman/cli/test_puppetmodule.py
+++ b/tests/foreman/cli/test_puppetmodule.py
@@ -5,7 +5,7 @@ from robottelo.cli.factory import make_org, make_product, make_repository
 from robottelo.cli.puppetmodule import PuppetModule
 from robottelo.cli.repository import Repository
 from robottelo.constants import FAKE_0_PUPPET_REPO
-from robottelo.decorators import run_only_on, skip_if_bug_open
+from robottelo.decorators import run_only_on, skip_if_bug_open, tier1
 from robottelo.test import CLITestCase
 
 
@@ -29,6 +29,7 @@ class TestPuppetModule(CLITestCase):
 
     @run_only_on('sat')
     @skip_if_bug_open('bugzilla', 1283173)
+    @tier1
     def test_puppet_module_list(self):
         """@Test: Check if puppet-module list retrieves puppet-modules of
         the given org
@@ -36,13 +37,13 @@ class TestPuppetModule(CLITestCase):
         @Feature: Puppet-module
 
         @Assert: Puppet-modules are retrieved for the given org
-
         """
         result = PuppetModule.list({'organization-id': self.org['id']})
         # There are 4 puppet modules in the test puppet-module url
         self.assertEqual(len(result), 4)
 
     @run_only_on('sat')
+    @tier1
     def test_puppet_module_info(self):
         """@Test: Check if puppet-module info retrieves info for the given
         puppet-module id
@@ -50,7 +51,6 @@ class TestPuppetModule(CLITestCase):
         @Feature: Puppet-module
 
         @Assert: The puppet-module info is retrieved
-
         """
         return_value = PuppetModule.list({
             'organization-id': self.org['id'],

--- a/tests/foreman/cli/test_report.py
+++ b/tests/foreman/cli/test_report.py
@@ -7,7 +7,7 @@ import random
 from robottelo import ssh
 from robottelo.cli.base import CLIReturnCodeError
 from robottelo.cli.report import Report
-from robottelo.decorators import run_only_on
+from robottelo.decorators import run_only_on, tier1
 from robottelo.test import CLITestCase
 
 
@@ -18,34 +18,32 @@ class TestReport(CLITestCase):
         super(TestReport, self).setUp()
         self.run_puppet_agent()
 
-    @run_only_on('sat')
     def run_puppet_agent(self):
         """Retrieves the client configuration from the puppet master and
         applies it to the local host. This is required to make sure
         that we have reports available.
-
         """
         ssh.command('puppet agent -t')
 
     @run_only_on('sat')
+    @tier1
     def test_list(self):
         """@Test: Test list for Puppet report
 
         @Feature: Puppet Report - list
 
         @Assert: Puppert Report List is displayed
-
         """
         Report.list()
 
     @run_only_on('sat')
+    @tier1
     def test_info(self):
         """@Test: Test Info for Puppet report
 
         @Feature: Puppet Report - Info
 
         @Assert: Puppet Report Info is displayed
-
         """
         result = Report.list()
         self.assertGreater(len(result), 0)
@@ -55,13 +53,13 @@ class TestReport(CLITestCase):
         self.assertEqual(report['id'], result['id'])
 
     @run_only_on('sat')
+    @tier1
     def test_delete(self):
         """@Test: Check if Puppet Report can be deleted
 
         @Feature: Puppet Report - Delete
 
         @Assert: Puppet Report is deleted
-
         """
         result = Report.list()
         self.assertGreater(len(result), 0)

--- a/tests/foreman/cli/test_repository.py
+++ b/tests/foreman/cli/test_repository.py
@@ -26,7 +26,13 @@ from robottelo.constants import (
     FAKE_5_PUPPET_REPO,
     RPM_TO_UPLOAD,
 )
-from robottelo.decorators import run_only_on, skip_if_bug_open, stubbed
+from robottelo.decorators import (
+    run_only_on,
+    skip_if_bug_open,
+    stubbed,
+    tier1,
+    tier2,
+)
 from robottelo.datafactory import valid_data_list, invalid_values_list
 from robottelo.helpers import get_data_file
 from robottelo.test import CLITestCase
@@ -61,6 +67,7 @@ class TestRepository(CLITestCase):
 
         return make_repository(options)
 
+    @tier1
     def test_bugzilla_1189289(self):
         """@Test: Check if repository docker-upstream-name is shown
         in repository info
@@ -69,7 +76,6 @@ class TestRepository(CLITestCase):
 
         @Assert: repository info command returns upstream-repository-name
         value
-
         """
         repository = self._make_repository({
             u'content-type': u'docker',
@@ -81,19 +87,20 @@ class TestRepository(CLITestCase):
             repository['upstream-repository-name'], u'fedora/rabbitmq')
 
     @run_only_on('sat')
+    @tier1
     def test_positive_create_1(self):
         """@Test: Check if repository can be created with random names
 
         @Feature: Repository
 
         @Assert: Repository is created and has random name
-
         """
         for name in valid_data_list():
             with self.subTest(name):
                 new_repo = self._make_repository({u'name': name})
                 self.assertEqual(new_repo['name'], name)
 
+    @tier1
     def test_positive_create_2(self):
         """@Test: Check if repository can be created with random names and
         labels
@@ -101,7 +108,6 @@ class TestRepository(CLITestCase):
         @Feature: Repository
 
         @Assert: Repository is created and has random name and labels
-
         """
         for name in valid_data_list():
             with self.subTest(name):
@@ -115,13 +121,13 @@ class TestRepository(CLITestCase):
                 self.assertNotEqual(new_repo['name'], new_repo['label'])
 
     @run_only_on('sat')
+    @tier1
     def test_positive_create_3(self):
         """@Test: Create YUM repository
 
         @Feature: Repository
 
         @Assert: YUM repository is created
-
         """
         for url in (FAKE_0_YUM_REPO, FAKE_1_YUM_REPO, FAKE_2_YUM_REPO,
                     FAKE_3_YUM_REPO, FAKE_4_YUM_REPO):
@@ -133,13 +139,13 @@ class TestRepository(CLITestCase):
                 self.assertEqual(new_repo['url'], url)
                 self.assertEqual(new_repo['content-type'], u'yum')
 
+    @tier1
     def test_positive_create_4(self):
         """@Test: Create Puppet repository
 
         @Feature: Repository
 
         @Assert: Puppet repository is created
-
         """
         for url in (FAKE_1_PUPPET_REPO, FAKE_2_PUPPET_REPO, FAKE_3_PUPPET_REPO,
                     FAKE_4_PUPPET_REPO, FAKE_5_PUPPET_REPO):
@@ -152,13 +158,13 @@ class TestRepository(CLITestCase):
                 self.assertEqual(new_repo['content-type'], u'puppet')
 
     @run_only_on('sat')
+    @tier1
     def test_positive_create_5(self):
         """@Test: Check if repository can be created with gpg key ID
 
         @Feature: Repository
 
         @Assert: Repository is created and has gpg key
-
         """
         # Make a new gpg key
         gpg_key = make_gpg_key({'organization-id': self.org['id']})
@@ -173,6 +179,7 @@ class TestRepository(CLITestCase):
 
     @run_only_on('sat')
     @skip_if_bug_open('bugzilla', 1103944)
+    @tier1
     def test_positive_create_6(self):
         """@Test: Check if repository can be created with gpg key name
 
@@ -181,7 +188,6 @@ class TestRepository(CLITestCase):
         @Assert: Repository is created and has gpg key
 
         @BZ: 1103944
-
         """
         gpg_key = make_gpg_key({'organization-id': self.org['id']})
         for name in valid_data_list():
@@ -194,13 +200,13 @@ class TestRepository(CLITestCase):
                 self.assertEqual(new_repo['gpg-key']['name'], gpg_key['name'])
 
     @run_only_on('sat')
+    @tier1
     def test_positive_create_7(self):
         """@Test: Create repository published via http
 
         @Feature: Repository
 
         @Assert: Repository is created and is published via http
-
         """
         for use_http in u'true', u'yes', u'1':
             with self.subTest(use_http):
@@ -208,13 +214,13 @@ class TestRepository(CLITestCase):
                 self.assertEqual(repo['publish-via-http'], u'yes')
 
     @run_only_on('sat')
+    @tier1
     def test_positive_create_8(self):
         """@Test: Create repository not published via http
 
         @Feature: Repository
 
         @Assert: Repository is created and is not published via http
-
         """
         for use_http in u'false', u'no', u'0':
             with self.subTest(use_http):
@@ -222,6 +228,7 @@ class TestRepository(CLITestCase):
                 self.assertEqual(repo['publish-via-http'], u'no')
 
     @run_only_on('sat')
+    @tier1
     def test_positive_create_9(self):
         """@Test: Create a YUM repository with a checksum type
 
@@ -229,8 +236,6 @@ class TestRepository(CLITestCase):
 
         @Assert: A YUM repository is created and contains the correct checksum
         type
-
-
         """
         for checksum_type in u'sha1', u'sha256':
             with self.subTest(checksum_type):
@@ -243,13 +248,13 @@ class TestRepository(CLITestCase):
                 self.assertEqual(repository['checksum-type'], checksum_type)
 
     @run_only_on('sat')
+    @tier1
     def test_positive_create_docker_repo_1(self):
         """@Test: Create a Docker repository with upstream name.
 
         @Feature: Repository
 
         @Assert: Docker repository is created and contains correct values.
-
         """
         content_type = u'docker'
         new_repo = self._make_repository({
@@ -264,13 +269,13 @@ class TestRepository(CLITestCase):
         self.assertEqual(new_repo['name'], u'busybox')
 
     @run_only_on('sat')
+    @tier1
     def test_positive_create_docker_repo_2(self):
         """@Test: Create a Docker repository with a random name.
 
         @Feature: Repository
 
         @Assert: Docker repository is created and contains correct values.
-
         """
         for name in valid_data_list():
             with self.subTest(name):
@@ -286,13 +291,13 @@ class TestRepository(CLITestCase):
                 self.assertEqual(new_repo['content-type'], content_type)
                 self.assertEqual(new_repo['name'], name)
 
+    @tier1
     def test_negative_create_1(self):
         """@Test: Repository name cannot be 300-characters long
 
         @Feature: Repository
 
         @Assert: Repository cannot be created
-
         """
         for name in invalid_values_list():
             with self.subTest(name):
@@ -301,13 +306,13 @@ class TestRepository(CLITestCase):
 
     @run_only_on('sat')
     @skip_if_bug_open('bugzilla', 1152237)
+    @tier2
     def test_positive_synchronize_1(self):
         """@Test: Check if repository can be created and synced
 
         @Feature: Repository
 
         @Assert: Repository is created and synced
-
         """
         for url in FAKE_1_YUM_REPO, FAKE_3_YUM_REPO, FAKE_4_YUM_REPO:
             with self.subTest(url):
@@ -325,13 +330,13 @@ class TestRepository(CLITestCase):
 
     @run_only_on('sat')
     @skip_if_bug_open('bugzilla', 1152237)
+    @tier2
     def test_positive_synchronize_2(self):
         """@Test: Check if Docker repository can be created and synced
 
         @Feature: Repository
 
         @Assert: Docker repository is created and synced
-
         """
         new_repo = self._make_repository({
             u'content-type': u'docker',
@@ -347,13 +352,13 @@ class TestRepository(CLITestCase):
         self.assertEqual(new_repo['sync']['status'], 'Finished')
 
     @run_only_on('sat')
+    @tier1
     def test_positive_update_1(self):
         """@Test: Update the original url for a repository
 
         @Feature: Repository
 
         @Assert: Repository url is updated
-
         """
         new_repo = self._make_repository()
         for url in (FAKE_4_YUM_REPO, FAKE_1_PUPPET_REPO, FAKE_2_PUPPET_REPO,
@@ -378,7 +383,6 @@ class TestRepository(CLITestCase):
         @Assert: Repository gpg key is updated
 
         @Status: manual
-
         """
 
     @run_only_on('sat')
@@ -391,11 +395,11 @@ class TestRepository(CLITestCase):
         @Assert: Repository publishing method is updated
 
         @Status: manual
-
         """
 
     @skip_if_bug_open('bugzilla', 1208305)
     @run_only_on('sat')
+    @tier1
     def test_positive_update_4(self):
         """@Test: Create a YUM repository and update the checksum type
 
@@ -405,7 +409,6 @@ class TestRepository(CLITestCase):
         type
 
         @BZ: 1208305
-
         """
         content_type = u'yum'
         repository = self._make_repository({
@@ -425,13 +428,13 @@ class TestRepository(CLITestCase):
                 self.assertEqual(result['checksum-type'], checksum_type)
 
     @run_only_on('sat')
+    @tier1
     def test_positive_delete_1(self):
         """@Test: Check if repository can be created and deleted
 
         @Feature: Repository
 
         @Assert: Repository is created and then deleted
-
         """
         for name in valid_data_list():
             with self.subTest(name):
@@ -440,13 +443,13 @@ class TestRepository(CLITestCase):
                 with self.assertRaises(CLIReturnCodeError):
                     Repository.info({u'id': new_repo['id']})
 
+    @tier1
     def test_upload_content(self):
         """@Test: Create repository and upload content
 
         @Feature: Repository
 
         @Assert: upload content is successful
-
         """
         new_repo = self._make_repository({'name': gen_string('alpha', 15)})
         ssh.upload_file(local_file=get_data_file(RPM_TO_UPLOAD),

--- a/tests/foreman/cli/test_repository_set.py
+++ b/tests/foreman/cli/test_repository_set.py
@@ -5,6 +5,7 @@ from robottelo.cli.repository_set import RepositorySet
 from robottelo.cli.subscription import Subscription
 from robottelo import manifests
 from robottelo.constants import PRDS, REPOSET
+from robottelo.decorators import tier1
 from robottelo.ssh import upload_file
 from robottelo.test import CLITestCase
 
@@ -12,6 +13,7 @@ from robottelo.test import CLITestCase
 class TestRepositorySet(CLITestCase):
     """Repository Set CLI tests."""
 
+    @tier1
     def test_repositoryset_available_repositories(self):
         """@Test: List available repositories for repository-set
 
@@ -19,7 +21,6 @@ class TestRepositorySet(CLITestCase):
 
         @Assert: List of available repositories is displayed, with
         valid amount of enabled repositories
-
         """
         rhel_product_name = PRDS['rhel']
         rhel_repo_set = REPOSET['rhva6']
@@ -124,13 +125,13 @@ class TestRepositorySet(CLITestCase):
             0
         )
 
+    @tier1
     def test_repositoryset_enable_by_name(self):
         """@Test: Enable repo from reposet by names of reposet, org and product
 
         @Feature: Repository-set
 
         @Assert: Repository was enabled
-
         """
         org = make_org()
         manifest = manifests.clone()
@@ -159,6 +160,7 @@ class TestRepositorySet(CLITestCase):
         ][0]
         self.assertEqual(enabled, 'true')
 
+    @tier1
     def test_repositoryset_enable_by_label(self):
         """@Test: Enable repo from reposet by org label, reposet and product
         names
@@ -166,7 +168,6 @@ class TestRepositorySet(CLITestCase):
         @Feature: Repository-set
 
         @Assert: Repository was enabled
-
         """
         org = make_org()
         manifest = manifests.clone()
@@ -195,13 +196,13 @@ class TestRepositorySet(CLITestCase):
         ][0]
         self.assertEqual(enabled, 'true')
 
+    @tier1
     def test_repositoryset_enable_by_id(self):
         """@Test: Enable repo from reposet by IDs of reposet, org and product
 
         @Feature: Repository-set
 
         @Assert: Repository was enabled
-
         """
         org = make_org()
         manifest = manifests.clone()
@@ -239,6 +240,7 @@ class TestRepositorySet(CLITestCase):
         ][0]
         self.assertEqual(enabled, 'true')
 
+    @tier1
     def test_repositoryset_disable_by_name(self):
         """@Test: Disable repo from reposet by names of reposet, org and
         product
@@ -246,7 +248,6 @@ class TestRepositorySet(CLITestCase):
         @Feature: Repository-set
 
         @Assert: Repository was disabled
-
         """
         org = make_org()
         manifest = manifests.clone()
@@ -282,6 +283,7 @@ class TestRepositorySet(CLITestCase):
         ][0]
         self.assertEqual(enabled, 'false')
 
+    @tier1
     def test_repositoryset_disable_by_label(self):
         """@Test: Disable repo from reposet by org label, reposet and product
         names
@@ -289,7 +291,6 @@ class TestRepositorySet(CLITestCase):
         @Feature: Repository-set
 
         @Assert: Repository was disabled
-
         """
         org = make_org()
         manifest = manifests.clone()
@@ -325,13 +326,13 @@ class TestRepositorySet(CLITestCase):
         ][0]
         self.assertEqual(enabled, 'false')
 
+    @tier1
     def test_repositoryset_disable_by_id(self):
         """@Test: Disable repo from reposet by IDs of reposet, org and product
 
         @Feature: Repository-set
 
         @Assert: Repository was disabled
-
         """
         org = make_org()
         manifest = manifests.clone()

--- a/tests/foreman/cli/test_roles.py
+++ b/tests/foreman/cli/test_roles.py
@@ -5,7 +5,7 @@ from robottelo.cli.base import CLIReturnCodeError
 from robottelo.cli.factory import make_role
 from robottelo.cli.role import Role
 from robottelo.datafactory import generate_strings_list
-from robottelo.decorators import skip_if_bug_open, stubbed
+from robottelo.decorators import skip_if_bug_open, stubbed, tier1
 from robottelo.test import CLITestCase
 
 
@@ -13,6 +13,7 @@ class TestRole(CLITestCase):
     """Test class for Roles CLI"""
 
     @skip_if_bug_open('bugzilla', 1138553)
+    @tier1
     def test_positive_create_role_1(self):
         """@Test: Create new roles and assign to the custom user
 
@@ -21,7 +22,6 @@ class TestRole(CLITestCase):
         @Assert: Assert creation of roles
 
         @BZ: 1138553
-
         """
         for name in generate_strings_list(length=10):
             with self.subTest(name):
@@ -33,23 +33,21 @@ class TestRole(CLITestCase):
     def test_create_role_permission_1(self):
         """@test: Create new roles Use different set of permission
 
-           @feature: Roles
+        @feature: Roles
 
-           @assert: Assert creation of roles with set of permission
+        @assert: Assert creation of roles with set of permission
 
-           @status: manual
-
+        @status: manual
         """
-        pass
 
     @skip_if_bug_open('bugzilla', 1138553)
+    @tier1
     def test_positive_delete_role_1(self):
         """@Test: Delete roles after creating them
 
         @Feature: Roles
 
         @Assert: Assert deletion of roles
-
         """
         for name in generate_strings_list(length=10):
             with self.subTest(name):
@@ -60,13 +58,13 @@ class TestRole(CLITestCase):
                     Role.info({'id': role['id']})
 
     @skip_if_bug_open('bugzilla', 1138553)
+    @tier1
     def test_positive_update_role_1(self):
         """@Test: Update roles after creating them
 
         @Feature: Roles
 
         @Assert: Assert updating of roles
-
         """
         role = make_role({'name': gen_string('alpha', 15)})
         for new_name in generate_strings_list(length=10):

--- a/tests/foreman/cli/test_scparam.py
+++ b/tests/foreman/cli/test_scparam.py
@@ -3,7 +3,7 @@
 
 from robottelo import ssh
 from robottelo.cli.smartclass import SmartClassParameter
-from robottelo.decorators import run_only_on
+from robottelo.decorators import run_only_on, tier1
 from robottelo.test import CLITestCase
 
 
@@ -11,7 +11,6 @@ from robottelo.test import CLITestCase
 class TestSmartClassParameter(CLITestCase):
     """Test class for Smart Class Parameter CLI."""
 
-    @run_only_on('sat')
     def run_puppet_module(self):
         """Import some parameterized puppet class. This is required to make
         sure that we have smart class variable available.
@@ -20,6 +19,7 @@ class TestSmartClassParameter(CLITestCase):
         ssh.command('puppet module install --force puppetlabs/ntp')
 
     @run_only_on('sat')
+    @tier1
     def test_bugzilla_1047794(self):
         """@Test: Check if SmartClass Paramter Info generates an error
 

--- a/tests/foreman/cli/test_sso.py
+++ b/tests/foreman/cli/test_sso.py
@@ -29,9 +29,7 @@ class TestSSOCLI(CLITestCase):
         @assert: Log in to hammer cli successfully
 
         @status: Manual
-
         """
-        pass
 
     @stubbed()
     def test_sso_ipa_cli(self):
@@ -44,9 +42,7 @@ class TestSSOCLI(CLITestCase):
         @assert: Log in to hammer cli successfully
 
         @status: Manual
-
         """
-        pass
 
     @stubbed()
     def test_sso_openldap_cli(self):
@@ -59,6 +55,4 @@ class TestSSOCLI(CLITestCase):
         @assert: Log in to hammer cli successfully
 
         @status: Manual
-
         """
-        pass

--- a/tests/foreman/cli/test_subnet.py
+++ b/tests/foreman/cli/test_subnet.py
@@ -10,7 +10,7 @@ from robottelo.cli.factory import make_domain, make_subnet, CLIFactoryError
 from robottelo.cli.subnet import Subnet
 from robottelo.constants import SUBNET_IPAM_TYPES
 from robottelo.datafactory import valid_data_list
-from robottelo.decorators import run_only_on, skip_if_bug_open
+from robottelo.decorators import run_only_on, skip_if_bug_open, tier1
 from robottelo.test import CLITestCase
 
 
@@ -51,13 +51,13 @@ class TestSubnet(CLITestCase):
     """Subnet CLI tests."""
 
     @run_only_on('sat')
+    @tier1
     def test_positive_create_1(self):
         """@Test: Check if Subnet can be created with random names
 
         @Feature: Subnet - Create
 
         @Assert: Subnet is created and has random name
-
         """
         for name in valid_data_list():
             with self.subTest(name):
@@ -65,13 +65,13 @@ class TestSubnet(CLITestCase):
                 self.assertEqual(subnet['name'], name)
 
     @run_only_on('sat')
+    @tier1
     def test_positive_create_2(self):
         """@Test: Create subnet with valid address pool
 
         @Feature: Subnet positive create
 
         @Assert: Subnet is created and address pool is set
-
         """
         for pool in valid_addr_pools():
             with self.subTest(pool):
@@ -91,19 +91,20 @@ class TestSubnet(CLITestCase):
                 self.assertEqual(subnet['to'], to_ip)
 
     @run_only_on('sat')
+    @tier1
     def test_create_subnet_with_domain(self):
         """@Test: Check if subnet with domain can be created
 
         @Feature: Subnet - Positive create
 
         @Assert: Subnet is created and has new domain assigned
-
         """
         domain = make_domain()
         subnet = make_subnet({'domain-ids': domain['id']})
         self.assertIn(domain['name'], subnet['domains'])
 
     @run_only_on('sat')
+    @tier1
     def test_create_subnet_with_domains(self):
         """@Test: Check if subnet with different amount of domains can be
         created in the system
@@ -111,7 +112,6 @@ class TestSubnet(CLITestCase):
         @Feature: Subnet - Positive create
 
         @Assert: Subnet is created and has new domains assigned
-
         """
         domains_amount = random.randint(3, 5)
         domains = [make_domain() for _ in range(domains_amount)]
@@ -123,13 +123,13 @@ class TestSubnet(CLITestCase):
             self.assertIn(domain['name'], subnet['domains'])
 
     @run_only_on('sat')
+    @tier1
     def test_create_subnet_with_gateway(self):
         """@Test: Check if subnet with gateway can be created
 
         @Feature: Subnet - Positive create
 
         @Assert: Subnet is created and has gateway assigned
-
         """
         gateway = gen_ipaddr(ip3=True)
         subnet = make_subnet({'gateway': gateway})
@@ -137,6 +137,7 @@ class TestSubnet(CLITestCase):
 
     @skip_if_bug_open('bugzilla', 1213437)
     @run_only_on('sat')
+    @tier1
     def test_create_subnet_with_ipam(self):
         """@Test: Check if subnet with different ipam types can be created
 
@@ -145,7 +146,6 @@ class TestSubnet(CLITestCase):
         @Assert: Subnet is created and correct ipam type is assigned
 
         @BZ: 1213437
-
         """
         for ipam_type in (SUBNET_IPAM_TYPES['dhcp'],
                           SUBNET_IPAM_TYPES['internal'],
@@ -155,13 +155,13 @@ class TestSubnet(CLITestCase):
                 self.assertIn(ipam_type, subnet['ipam'])
 
     @run_only_on('sat')
+    @tier1
     def test_negative_create_1(self):
         """@Test: Create subnet with invalid or missing required attributes
 
         @Feature: Subnet create
 
         @Assert: Subnet is not created
-
         """
         for options in invalid_missing_attributes():
             with self.subTest(options):
@@ -169,13 +169,13 @@ class TestSubnet(CLITestCase):
                     make_subnet(options)
 
     @run_only_on('sat')
+    @tier1
     def test_negative_create_2(self):
         """@Test: Create subnet with invalid address pool range
 
         @Feature: Create subnet negative
 
         @Assert: Subnet is not created
-
         """
         mask = '255.255.255.0'
         network = gen_ipaddr()
@@ -189,13 +189,13 @@ class TestSubnet(CLITestCase):
                     make_subnet(opts)
 
     @run_only_on('sat')
+    @tier1
     def test_list(self):
         """@Test: Check if Subnet can be listed
 
         @Feature: Subnet - List
 
         @Assert: Subnet is listed
-
         """
         # Fetch current total
         subnets_before = Subnet.list()
@@ -206,13 +206,13 @@ class TestSubnet(CLITestCase):
         self.assertGreater(len(subnets_after), len(subnets_before))
 
     @run_only_on('sat')
+    @tier1
     def test_positive_update_1(self):
         """@Test: Check if Subnet name can be updated
 
         @Feature: Subnet - Update
 
         @Assert: Subnet name is updated
-
         """
         new_subnet = make_subnet()
         for new_name in valid_data_list():
@@ -222,13 +222,13 @@ class TestSubnet(CLITestCase):
                 self.assertEqual(result['name'], new_name)
 
     @run_only_on('sat')
+    @tier1
     def test_positive_update_2(self):
         """@Test: Check if Subnet network and mask can be updated
 
         @Feature: Subnet - Update
 
         @Assert: Subnet network and mask are updated
-
         """
         network = gen_ipaddr()
         mask = '255.255.255.0'
@@ -249,13 +249,13 @@ class TestSubnet(CLITestCase):
         self.assertEqual(subnet['mask'], new_mask)
 
     @run_only_on('sat')
+    @tier1
     def test_positive_update_3(self):
         """@Test: Check if Subnet address pool can be updated
 
         @Feature: Subnet - Update
 
         @Assert: Subnet address pool is updated
-
         """
         subnet = make_subnet({u'mask': '255.255.255.0'})
         for pool in valid_addr_pools():
@@ -274,13 +274,13 @@ class TestSubnet(CLITestCase):
                 self.assertEqual(subnet['to'], ip_to)
 
     @run_only_on('sat')
+    @tier1
     def test_negative_update_1(self):
         """@Test: Update subnet with invalid or missing required attributes
 
         @Feature: Subnet - Update
 
         @Assert: Subnet is not updated
-
         """
         subnet = make_subnet()
         for options in invalid_missing_attributes():
@@ -294,13 +294,13 @@ class TestSubnet(CLITestCase):
                         self.assertEqual(subnet[key], result[key])
 
     @run_only_on('sat')
+    @tier1
     def test_negative_update_2(self):
         """@Test: Update subnet with invalid address pool
 
         @Feature: Subnet - Update
 
         @Assert: Subnet is not updated
-
         """
         subnet = make_subnet()
         for options in invalid_addr_pools():
@@ -317,13 +317,13 @@ class TestSubnet(CLITestCase):
                     self.assertEqual(result[key], subnet[key])
 
     @run_only_on('sat')
+    @tier1
     def test_positive_delete_1(self):
         """@Test: Check if Subnet can be deleted
 
         @Feature: Subnet - Delete
 
         @Assert: Subnet is deleted
-
         """
         for name in valid_data_list():
             with self.subTest(name):

--- a/tests/foreman/cli/test_subscription.py
+++ b/tests/foreman/cli/test_subscription.py
@@ -5,7 +5,7 @@ from robottelo.cli.factory import make_org
 from robottelo.cli.repository import Repository
 from robottelo.cli.repository_set import RepositorySet
 from robottelo.cli.subscription import Subscription
-from robottelo.decorators import skip_if_bug_open
+from robottelo.decorators import skip_if_bug_open, tier1, tier2
 from robottelo.ssh import upload_file
 from robottelo.test import CLITestCase
 
@@ -28,13 +28,13 @@ class TestSubscription(CLITestCase):
             'organization-id': org_id,
         })
 
+    @tier1
     def test_manifest_upload(self):
         """@Test: upload manifest (positive)
 
         @Feature: Subscriptions/Manifest Upload
 
         @Assert: Manifest are uploaded properly
-
         """
         self._upload_manifest(self.manifest, self.org['id'])
         Subscription.list(
@@ -42,13 +42,13 @@ class TestSubscription(CLITestCase):
             per_page=False,
         )
 
+    @tier1
     def test_manifest_delete(self):
         """@Test: Delete uploaded manifest (positive)
 
         @Feature: Subscriptions/Manifest Delete
 
         @Assert: Manifest are deleted properly
-
         """
         self._upload_manifest(self.manifest, self.org['id'])
         Subscription.list(
@@ -63,6 +63,7 @@ class TestSubscription(CLITestCase):
             per_page=False,
         )
 
+    @tier2
     def test_enable_manifest_reposet(self):
         """@Test: enable repository set (positive)
 
@@ -70,7 +71,6 @@ class TestSubscription(CLITestCase):
 
         @Assert: you are able to enable and synchronize
         repository contained in a manifest
-
         """
         self._upload_manifest(self.manifest, self.org['id'])
         Subscription.list(
@@ -97,13 +97,13 @@ class TestSubscription(CLITestCase):
             'product': 'Red Hat Enterprise Linux Workstation',
         })
 
+    @tier1
     def test_manifest_history(self):
         """@Test: upload manifest (positive) and check history
 
         @Feature: Subscriptions/Manifest History
 
         @Assert: Manifest history is shown properly
-
         """
         self._upload_manifest(self.manifest, self.org['id'])
         Subscription.list(
@@ -118,13 +118,13 @@ class TestSubscription(CLITestCase):
             ''.join(history),
         )
 
+    @tier1
     def test_manifest_refresh(self):
         """@Test: upload manifest (positive) and refresh
 
         @Feature: Subscriptions/Manifest refresh
 
         @Assert: Manifests can be refreshed
-
         """
         self._upload_manifest(
             manifests.download_manifest_template(), self.org['id'])
@@ -140,6 +140,7 @@ class TestSubscription(CLITestCase):
         })
 
     @skip_if_bug_open('bugzilla', 1226425)
+    @tier1
     def test_invalid_manifest_refresh(self):
         """@Test: manifest refresh must fail with a cloned manifest
 
@@ -148,7 +149,6 @@ class TestSubscription(CLITestCase):
         @Assert: the refresh command returns a non-zero return code
 
         @BZ: 1226425
-
         """
         self._upload_manifest(self.manifest, self.org['id'])
         Subscription.list(

--- a/tests/foreman/cli/test_syncplan.py
+++ b/tests/foreman/cli/test_syncplan.py
@@ -7,7 +7,7 @@ from robottelo.cli.base import CLIReturnCodeError
 from robottelo.cli.factory import CLIFactoryError, make_org, make_sync_plan
 from robottelo.cli.syncplan import SyncPlan
 from robottelo.datafactory import valid_data_list, invalid_values_list
-from robottelo.decorators import skip_if_bug_open
+from robottelo.decorators import skip_if_bug_open, tier1
 from robottelo.test import CLITestCase
 
 
@@ -102,39 +102,39 @@ class TestSyncPlan(CLITestCase):
 
         return make_sync_plan(options)
 
+    @tier1
     def test_positive_create_1(self):
         """@Test: Check if syncplan can be created with random names
 
         @Feature: Sync Plan
 
         @Assert: Sync plan is created and has random name
-
         """
         for name in valid_data_list():
             with self.subTest(name):
                 new_sync_plan = self._make_sync_plan({u'name': name})
                 self.assertEqual(new_sync_plan['name'], name)
 
+    @tier1
     def test_positive_create_2(self):
         """@Test: Check if syncplan can be created with random description
 
         @Feature: Sync Plan
 
         @Assert: Sync plan is created and has random description
-
         """
         for desc in valid_data_list():
             with self.subTest(desc):
                 new_sync_plan = self._make_sync_plan({u'description': desc})
                 self.assertEqual(new_sync_plan['description'], desc)
 
+    @tier1
     def test_positive_create_3(self):
         """@Test: Check if syncplan can be created with varied intervals
 
         @Feature: Sync Plan
 
         @Assert: Sync plan is created and has selected interval
-
         """
         for test_data in valid_name_interval_create_tests():
             with self.subTest(test_data):
@@ -148,26 +148,26 @@ class TestSyncPlan(CLITestCase):
                     test_data['interval']
                 )
 
+    @tier1
     def test_negative_create_1(self):
         """@Test: Check if syncplan can be created with random names
 
         @Feature: Sync Plan
 
         @Assert: Sync plan is created and has random name
-
         """
         for name in invalid_values_list():
             with self.subTest(name):
                 with self.assertRaises(CLIFactoryError):
                     self._make_sync_plan({u'name': name})
 
+    @tier1
     def test_positive_update_1(self):
         """@Test: Check if syncplan description can be updated
 
         @Feature: Sync Plan
 
         @Assert: Sync plan is created and description is updated
-
         """
         new_sync_plan = self._make_sync_plan()
         for new_desc in valid_data_list():
@@ -179,13 +179,13 @@ class TestSyncPlan(CLITestCase):
                 result = SyncPlan.info({u'id': new_sync_plan['id']})
                 self.assertEqual(result['description'], new_desc)
 
+    @tier1
     def test_positive_update_2(self):
         """@Test: Check if syncplan interval be updated
 
         @Feature: Sync Plan
 
         @Assert: Sync plan interval is updated
-
         """
         for test_data in valid_name_interval_update_tests():
             with self.subTest(test_data):
@@ -200,13 +200,13 @@ class TestSyncPlan(CLITestCase):
                 result = SyncPlan.info({u'id': new_sync_plan['id']})
                 self.assertEqual(result['interval'], test_data['new-interval'])
 
+    @tier1
     def test_positive_update_3(self):
         """@Test: Check if syncplan sync date can be updated
 
         @Feature: Sync Plan
 
         @Assert: Sync plan is created and sync plan is updated
-
         """
         # Set the sync date to today/right now
         today = datetime.now()
@@ -244,13 +244,13 @@ class TestSyncPlan(CLITestCase):
             'Sync date was not updated',
         )
 
+    @tier1
     def test_positive_delete_1(self):
         """@Test: Check if syncplan can be created and deleted
 
         @Feature: Sync Plan
 
         @Assert: Sync plan is created and then deleted
-
         """
         for name in valid_data_list():
             with self.subTest(name):
@@ -260,6 +260,7 @@ class TestSyncPlan(CLITestCase):
                     SyncPlan.info({'id': new_sync_plan['id']})
 
     @skip_if_bug_open('bugzilla', 1261122)
+    @tier1
     def test_bz1261122_enabled_state_visible(self):
         """@Test: Check if Enabled field is displayed in sync-plan info output
 
@@ -268,7 +269,6 @@ class TestSyncPlan(CLITestCase):
         @Assert: Sync plan Enabled state is displayed
 
         @BZ: 1261122
-
         """
         new_sync_plan = self._make_sync_plan()
         result = SyncPlan.info({'id': new_sync_plan['id']})

--- a/tests/foreman/cli/test_system_registration.py
+++ b/tests/foreman/cli/test_system_registration.py
@@ -18,7 +18,6 @@ class SystemRegistrationTestCase(CLITestCase):
         @assert: rhsm.conf has been updated appropriately.
 
         @status: Manual
-
         """
 
     @stubbed()
@@ -30,7 +29,6 @@ class SystemRegistrationTestCase(CLITestCase):
         @assert: system successfully registered to appropriate org
 
         @status: Manual
-
         """
 
     @stubbed()
@@ -43,7 +41,6 @@ class SystemRegistrationTestCase(CLITestCase):
         subscribed to content as listed in key
 
         @status: Manual
-
         """
 
     @stubbed()
@@ -55,7 +52,6 @@ class SystemRegistrationTestCase(CLITestCase):
         @assert: system cannot be registered twice via RHSM
 
         @status: Manual
-
         """
 
     @stubbed()
@@ -68,7 +64,6 @@ class SystemRegistrationTestCase(CLITestCase):
         @assert: RH RPM/errata content can be retrieved/installed via sat
 
         @status: Manual
-
         """
 
     @stubbed()
@@ -80,7 +75,6 @@ class SystemRegistrationTestCase(CLITestCase):
         @assert: newly registered system appears in system list
 
         @status: Manual
-
         """
 
     @stubbed()
@@ -93,7 +87,6 @@ class SystemRegistrationTestCase(CLITestCase):
         assures system no longer appears in CLI
 
         @status: Manual
-
         """
 
     @stubbed()
@@ -106,5 +99,4 @@ class SystemRegistrationTestCase(CLITestCase):
         @assert: system can no longer retrieve content from satellite
 
         @status: Manual
-
         """

--- a/tests/foreman/cli/test_template.py
+++ b/tests/foreman/cli/test_template.py
@@ -11,7 +11,7 @@ from robottelo.cli.factory import (
     make_template,
 )
 from robottelo.cli.template import Template
-from robottelo.decorators import run_only_on
+from robottelo.decorators import run_only_on, tier1, tier2
 from robottelo.test import CLITestCase
 
 
@@ -19,26 +19,26 @@ class TestTemplate(CLITestCase):
     """Test class for Config Template CLI."""
 
     @run_only_on('sat')
+    @tier1
     def test_create_template_1(self):
         """@Test: Check if Template can be created
 
         @Feature: Template - Create
 
         @Assert: Template is created
-
         """
         name = gen_string('alpha')
         template = make_template({'name': name})
         self.assertEqual(template['name'], name)
 
     @run_only_on('sat')
+    @tier1
     def test_update_template_1(self):
         """@Test: Check if Template can be updated
 
         @Feature: Template - Update
 
         @Assert: Template is updated
-
         """
         template = make_template()
         updated_name = gen_string('alpha')
@@ -50,26 +50,26 @@ class TestTemplate(CLITestCase):
         self.assertEqual(updated_name, template['name'])
 
     @run_only_on('sat')
+    @tier1
     def test_create_template_with_loc(self):
         """@Test: Check if Template with Location can be created
 
         @Feature: Template - Create
 
         @Assert: Template is created and new Location has been assigned
-
         """
         new_loc = make_location()
         new_template = make_template({'location-ids': new_loc['id']})
         self.assertIn(new_loc['name'], new_template['locations'])
 
     @run_only_on('sat')
+    @tier1
     def test_create_template_locked(self):
         """@Test: Check that locked Template cannot be created
 
         @Feature: Template - Create
 
         @Assert: It is not allowed to create locked Template
-
         """
         with self.assertRaises(CLIFactoryError):
             make_template({
@@ -78,13 +78,13 @@ class TestTemplate(CLITestCase):
             })
 
     @run_only_on('sat')
+    @tier1
     def test_create_template_with_org(self):
         """@Test: Check if Template with Organization can be created
 
         @Feature: Template - Create
 
         @Assert: Template is created and new Organization has been assigned
-
         """
         new_org = make_org()
         new_template = make_template({
@@ -94,13 +94,13 @@ class TestTemplate(CLITestCase):
         self.assertIn(new_org['name'], new_template['organizations'])
 
     @run_only_on('sat')
+    @tier2
     def test_add_operating_system_1(self):
         """@Test: Check if Template can be assigned operating system
 
         @Feature: Template - Add Operating System
 
         @Assert: Template has an operating system
-
         """
         new_template = make_template()
         new_os = make_os()
@@ -114,13 +114,13 @@ class TestTemplate(CLITestCase):
         self.assertIn(os_string, new_template['operating-systems'])
 
     @run_only_on('sat')
+    @tier2
     def test_remove_operating_system_1(self):
         """@Test: Check if OS can be removed Template
 
         @Feature: Template - Remove Operating System
 
         @Assert: Template no longer has an operating system
-
         """
         template = make_template()
         new_os = make_os()
@@ -141,13 +141,13 @@ class TestTemplate(CLITestCase):
         self.assertNotIn(os_string, template['operating-systems'])
 
     @run_only_on('sat')
+    @tier1
     def test_dump_template_1(self):
         """@Test: Check if Template can be created with specific content
 
         @Feature: Template - Create
 
         @Assert: Template is created with specific content
-
         """
         content = gen_string('alpha')
         name = gen_string('alpha')
@@ -160,13 +160,13 @@ class TestTemplate(CLITestCase):
         self.assertIn(content, template_content[0])
 
     @run_only_on('sat')
+    @tier1
     def test_delete_template_1(self):
         """@Test: Check if Template can be deleted
 
         @Feature: Template - Delete
 
         @Assert: Template is deleted
-
         """
         template = make_template()
         Template.delete({'id': template['id']})

--- a/tests/foreman/cli/test_user.py
+++ b/tests/foreman/cli/test_user.py
@@ -17,7 +17,7 @@ from robottelo.datafactory import (
     valid_emails_list,
     valid_usernames_list,
 )
-from robottelo.decorators import stubbed, skip_if_bug_open
+from robottelo.decorators import stubbed, skip_if_bug_open, tier1, tier2
 from robottelo.test import CLITestCase
 
 
@@ -46,6 +46,7 @@ class User(CLITestCase):
         self.assertEqual(result[0]['email'], user['email'])
 
     # Issues
+    @tier1
     def test_bugzilla_1079649_1(self):
         """@Test: Delete a user by it's name
 
@@ -56,7 +57,6 @@ class User(CLITestCase):
         2. Delete the User
 
         @Assert: User is deleted
-
         """
         user = make_user()
         self.__assert_exists(user)
@@ -65,6 +65,7 @@ class User(CLITestCase):
         with self.assertRaises(CLIReturnCodeError):
             UserObj.info({'login': user['login']})
 
+    @tier1
     def test_bugzilla_1079649_2(self):
         """@Test: Delete a user by it's ID
 
@@ -77,7 +78,6 @@ class User(CLITestCase):
         @Assert: User is deleted
 
         @BZ: 1079649
-
         """
         user = make_user()
         self.__assert_exists(user)
@@ -87,6 +87,7 @@ class User(CLITestCase):
             UserObj.info({'login': user['login']})
 
     # CRUD
+    @tier1
     def test_positive_create_user_1(self):
         """@Test: Create User for all variations of Username
 
@@ -97,7 +98,6 @@ class User(CLITestCase):
         valid First Name, Surname, Email Address, Language, authorized by
 
         @Assert: User is created
-
         """
         include_list = [gen_string("alphanumeric", 100)]
         for login in valid_usernames_list() + include_list:
@@ -105,6 +105,7 @@ class User(CLITestCase):
                 user = make_user({'login': login})
                 self.__assert_exists(user)
 
+    @tier1
     def test_positive_create_user_2(self):
         """@Test: Create User for all variations of First Name
 
@@ -115,7 +116,6 @@ class User(CLITestCase):
         valid Username, Surname, Email Address, Language, authorized by
 
         @Assert: User is created
-
         """
         include_list = [gen_string("alphanumeric", 50)]
         for firstname in valid_usernames_list() + include_list:
@@ -123,6 +123,7 @@ class User(CLITestCase):
                 user = make_user({'firstname': firstname})
                 self.__assert_exists(user)
 
+    @tier1
     def test_positive_create_user_3(self):
         """@Test: Create User for all variations of Surname
 
@@ -133,7 +134,6 @@ class User(CLITestCase):
         valid Username, First Name, Email Address, Language, authorized by
 
         @Assert: User is created
-
         """
         include_list = [gen_string("alphanumeric", 50)]
         for lastname in valid_usernames_list() + include_list:
@@ -141,6 +141,7 @@ class User(CLITestCase):
                 user = make_user({'lastname': lastname})
                 self.__assert_exists(user)
 
+    @tier1
     def test_positive_create_user_4(self):
         """@Test: Create User for all variations of Email Address
 
@@ -151,7 +152,6 @@ class User(CLITestCase):
         valid Username, First Name, Surname, Language, authorized by
 
         @Assert: User is created
-
         """
         for email in valid_emails_list():
             with self.subTest(email):
@@ -161,6 +161,7 @@ class User(CLITestCase):
                 user = make_user({'mail': escaped_email})
                 self.assertEqual(user['email'], email)
 
+    @tier1
     def test_positive_create_user_5(self):
         """@Test: Create User for all variations of Password
 
@@ -171,7 +172,6 @@ class User(CLITestCase):
         Username, First Name, Surname, Email Address, Language, authorized by
 
         @Assert: User is created
-
         """
         include_list = [gen_string("alphanumeric", 3000)]
         for password in valid_usernames_list() + include_list:
@@ -179,24 +179,24 @@ class User(CLITestCase):
                 user = make_user({'password': password})
                 self.__assert_exists(user)
 
+    @tier1
     def test_positive_create_user_6(self):
         """@Test: Create an Admin user
 
         @Feature: User - Positive Create
 
         @Assert: Admin User is created
-
         """
         user = make_user({'admin': '1'})
         self.__assert_exists(user)
 
+    @tier1
     def test_create_user_default_loc(self):
         """@Test: Check if user with default location can be created
 
         @Feature: User - Positive create
 
         @Assert: User is created and has new default location assigned
-
         """
         location = make_location()
         user = make_user({
@@ -206,13 +206,13 @@ class User(CLITestCase):
         self.assertIn(location['name'], user['locations'])
         self.assertEqual(location['name'], user['default-location'])
 
+    @tier1
     def test_create_user_defaut_org(self):
         """@Test: Check if user with default organization can be created
 
         @Feature: User - Positive create
 
         @Assert: User is created and has new default organization assigned
-
         """
         org = make_org()
         user = make_user({
@@ -234,9 +234,7 @@ class User(CLITestCase):
         @Assert: User is created
 
         @Status: Manual
-
         """
-        pass
 
     @stubbed()
     def test_positive_create_user_10(self):
@@ -250,9 +248,7 @@ class User(CLITestCase):
         @Assert: User is created
 
         @Status: Manual
-
         """
-        pass
 
     @stubbed()
     def test_positive_create_user_11(self):
@@ -266,9 +262,7 @@ class User(CLITestCase):
         @Assert: User is created
 
         @Status: Manual
-
         """
-        pass
 
     @stubbed()
     def test_positive_create_user_12(self):
@@ -282,9 +276,7 @@ class User(CLITestCase):
         @Assert: User is created
 
         @Status: Manual
-
         """
-        pass
 
     @stubbed()
     def test_positive_create_user_13(self):
@@ -298,9 +290,7 @@ class User(CLITestCase):
         @Assert: User is created
 
         @Status: Manual
-
         """
-        pass
 
     @stubbed()
     def test_positive_create_user_14(self):
@@ -314,9 +304,7 @@ class User(CLITestCase):
         @Assert: User is created
 
         @Status: Manual
-
         """
-        pass
 
     @stubbed()
     def test_positive_create_user_15(self):
@@ -330,9 +318,7 @@ class User(CLITestCase):
         @Assert: User is created
 
         @Status: Manual
-
         """
-        pass
 
     @stubbed()
     def test_positive_create_user_16(self):
@@ -346,9 +332,7 @@ class User(CLITestCase):
         @Assert: User is created
 
         @Status: Manual
-
         """
-        pass
 
     @stubbed()
     def test_positive_create_user_17(self):
@@ -362,9 +346,7 @@ class User(CLITestCase):
         @Assert: User is created
 
         @Status: Manual
-
         """
-        pass
 
     @stubbed()
     def test_positive_create_user_18(self):
@@ -378,9 +360,7 @@ class User(CLITestCase):
         @Assert: User is created
 
         @Status: Manual
-
         """
-        pass
 
     @stubbed()
     def test_positive_create_user_19(self):
@@ -394,9 +374,7 @@ class User(CLITestCase):
         @Assert: User is created
 
         @Status: Manual
-
         """
-        pass
 
     @stubbed()
     def test_positive_create_user_20(self):
@@ -410,9 +388,7 @@ class User(CLITestCase):
         @Assert: User is created
 
         @Status: Manual
-
         """
-        pass
 
     @stubbed()
     def test_positive_create_user_21(self):
@@ -426,9 +402,7 @@ class User(CLITestCase):
         @Assert: User is created
 
         @Status: Manual
-
         """
-        pass
 
     @stubbed()
     def test_positive_create_user_22(self):
@@ -442,9 +416,7 @@ class User(CLITestCase):
         @Assert: User is created
 
         @Status: Manual
-
         """
-        pass
 
     @stubbed()
     def test_positive_create_user_23(self):
@@ -458,9 +430,7 @@ class User(CLITestCase):
         @Assert: User is created
 
         @Status: Manual
-
         """
-        pass
 
     @stubbed()
     def test_positive_create_user_24(self):
@@ -471,9 +441,7 @@ class User(CLITestCase):
         @Assert: User is created
 
         @Status: Manual
-
         """
-        pass
 
     @stubbed()
     def test_positive_create_user_25(self):
@@ -484,9 +452,7 @@ class User(CLITestCase):
         @Assert: User is created
 
         @Status: Manual
-
         """
-        pass
 
     @stubbed()
     def test_positive_create_user_26(self):
@@ -497,9 +463,7 @@ class User(CLITestCase):
         @Assert: User is created
 
         @Status: Manual
-
         """
-        pass
 
     @stubbed()
     def test_positive_create_user_27(self):
@@ -513,9 +477,7 @@ class User(CLITestCase):
         @Assert: User is created
 
         @Status: Manual
-
         """
-        pass
 
     @stubbed()
     def test_positive_create_user_28(self):
@@ -530,10 +492,9 @@ class User(CLITestCase):
         @Assert: User is created without specifying the password
 
         @Status: Manual
-
         """
-        pass
 
+    @tier1
     def test_negative_create_user_1(self):
         """@Test: Create User with invalid Username
 
@@ -544,7 +505,6 @@ class User(CLITestCase):
         using valid First Name, Surname, Email Address, Language, authorized by
 
         @Assert: User is not created. Appropriate error shown.
-
         """
         for invalid_name in ('',
                              'space {0}'.format(gen_string('alpha')),
@@ -561,6 +521,7 @@ class User(CLITestCase):
                 with self.assertRaises(CLIReturnCodeError):
                     UserObj.create(options)
 
+    @tier1
     def test_negative_create_user_2(self):
         """@Test: Create User with invalid Firstname
 
@@ -571,7 +532,6 @@ class User(CLITestCase):
         using valid Username, Surname, Email Address, Language, authorized by
 
         @Assert: User is not created. Appropriate error shown.
-
         """
         for invalid_firstname in (gen_string("alpha", 51),
                                   gen_string("html")):
@@ -585,6 +545,7 @@ class User(CLITestCase):
                         'password': gen_string('alpha'),
                     })
 
+    @tier1
     def test_negative_create_user_3(self):
         """@Test: Create User with invalid lastname
 
@@ -595,7 +556,6 @@ class User(CLITestCase):
         using valid Username, First Name Email Address, Language, authorized by
 
         @Assert: User is not created. Appropriate error shown.
-
         """
         for invalid_lastname in (gen_string("alpha", 51),
                                  gen_string("html")):
@@ -609,6 +569,7 @@ class User(CLITestCase):
                         'password': gen_string('alpha'),
                     })
 
+    @tier1
     def test_negative_create_user_4(self):
         """@Test: Create User with invalid Email Address
 
@@ -619,7 +580,6 @@ class User(CLITestCase):
         using valid Username, First Name, Surname, Language, authorized by
 
         @Assert: User is not created. Appropriate error shown.
-
         """
         for email in invalid_emails_list():
             with self.subTest(email):
@@ -634,6 +594,7 @@ class User(CLITestCase):
                     })
 
     @skip_if_bug_open('bugzilla', 1204686)
+    @tier1
     def test_bugzilla_1204686(self):
         """@Test: Create User with Empty Email Address
 
@@ -646,7 +607,6 @@ class User(CLITestCase):
         @Assert: User is not created. Appropriate error shown.
 
         @BZ: 1204686
-
         """
         with self.assertRaises(CLIReturnCodeError):
             UserObj.create({
@@ -658,6 +618,7 @@ class User(CLITestCase):
                 'password': gen_string('alpha'),
             })
 
+    @tier1
     def test_negative_create_user_5(self):
         """@Test: Create User with blank Authorized by
 
@@ -668,7 +629,6 @@ class User(CLITestCase):
         using valid Username, First Name, Surname, Email Address, Language
 
         @Assert: User is not created. Appropriate error shown.
-
         """
         with self.assertRaises(CLIReturnCodeError):
             UserObj.create({
@@ -677,6 +637,7 @@ class User(CLITestCase):
                 'mail': 'root@localhost',
             })
 
+    @tier1
     def test_negative_create_user_6(self):
         """@Test: Create User with blank Authorized by but values in
 
@@ -688,7 +649,6 @@ class User(CLITestCase):
         Surname, Email Address, Language
 
         @Assert: User is not created. Appropriate error shown.
-
         """
         with self.assertRaises(CLIReturnCodeError):
             UserObj.create({
@@ -698,6 +658,7 @@ class User(CLITestCase):
                 'password': gen_string('alpha'),
             })
 
+    @tier1
     def test_positive_update_user_1(self):
         """@Test: Update firstname in User
 
@@ -708,7 +669,6 @@ class User(CLITestCase):
         2. Update first name for all variations in [1]
 
         @Assert: User is updated
-
         """
         user = make_user()
         for new_firstname in valid_usernames_list():
@@ -721,6 +681,7 @@ class User(CLITestCase):
                 user_name = result['name'].split(' ')
                 self.assertEqual(user_name[0], new_firstname)
 
+    @tier1
     def test_positive_update_user_2(self):
         """@Test: Update Login in User
 
@@ -731,7 +692,6 @@ class User(CLITestCase):
         2. Update User login for all variations in [1]
 
         @Assert: User login is updated
-
         """
         user = make_user()
         include_list = [gen_string("alphanumeric", 100)]
@@ -744,6 +704,7 @@ class User(CLITestCase):
                 user = UserObj.info({'id': user['id']})
                 self.assertEqual(user['login'], new_login)
 
+    @tier1
     def test_positive_update_user_3(self):
         """@Test: Update Lastname in User
 
@@ -754,7 +715,6 @@ class User(CLITestCase):
         2. Update Lastname for all variations in [1]
 
         @Assert: User is updated
-
         """
         user = make_user()
         for new_lastname in valid_usernames_list():
@@ -767,6 +727,7 @@ class User(CLITestCase):
                 last_name_after = user['name'].split(' ')
                 self.assertEqual(last_name_after[1], new_lastname)
 
+    @tier1
     def test_positive_update_user_4(self):
         """@Test: Update Email Address in User
 
@@ -777,7 +738,6 @@ class User(CLITestCase):
         2. Update Email Address for all variations in [1]
 
         @Assert: User is updated
-
         """
         user = make_user()
         for data in (gen_string("alpha"),
@@ -809,9 +769,7 @@ class User(CLITestCase):
         @Assert: User is updated
 
         @Status: Manual
-
         """
-        pass
 
     @stubbed()
     def test_positive_update_user_6(self):
@@ -826,9 +784,7 @@ class User(CLITestCase):
         @Assert: User is updated
 
         @Status: Manual
-
         """
-        pass
 
     @stubbed()
     def test_positive_update_user_7(self):
@@ -843,9 +799,7 @@ class User(CLITestCase):
         @Assert: User is updated
 
         @Status: Manual
-
         """
-        pass
 
     @stubbed()
     def test_positive_update_user_8(self):
@@ -860,9 +814,7 @@ class User(CLITestCase):
         @Assert: User is updated
 
         @Status: Manual
-
         """
-        pass
 
     @stubbed()
     def test_positive_update_user_9(self):
@@ -877,9 +829,7 @@ class User(CLITestCase):
         @Assert: User is updated
 
         @Status: Manual
-
         """
-        pass
 
     @stubbed()
     def test_positive_update_user_10(self):
@@ -894,9 +844,7 @@ class User(CLITestCase):
         @Assert: User is updated
 
         @Status: Manual
-
         """
-        pass
 
     @stubbed()
     def test_positive_update_user_11(self):
@@ -911,9 +859,7 @@ class User(CLITestCase):
         @Assert: User is updated
 
         @Status: Manual
-
         """
-        pass
 
     @stubbed()
     def test_positive_update_user_12(self):
@@ -928,9 +874,7 @@ class User(CLITestCase):
         @Assert: User is updated
 
         @Status: Manual
-
         """
-        pass
 
     @stubbed()
     def test_positive_update_user_13(self):
@@ -945,9 +889,7 @@ class User(CLITestCase):
         @Assert: User is updated
 
         @Status: Manual
-
         """
-        pass
 
     @stubbed()
     def test_positive_update_user_14(self):
@@ -962,9 +904,7 @@ class User(CLITestCase):
         @Assert: User is updated
 
         @Status: Manual
-
         """
-        pass
 
     @stubbed()
     def test_positive_update_user_15(self):
@@ -979,9 +919,7 @@ class User(CLITestCase):
         @Assert: User is updated
 
         @Status: Manual
-
         """
-        pass
 
     @stubbed()
     def test_positive_update_user_16(self):
@@ -996,9 +934,7 @@ class User(CLITestCase):
         @Assert: User is updated
 
         @Status: Manual
-
         """
-        pass
 
     @stubbed()
     def test_positive_update_user_17(self):
@@ -1013,9 +949,7 @@ class User(CLITestCase):
         @Assert: User is updated
 
         @Status: Manual
-
         """
-        pass
 
     @stubbed()
     def test_positive_update_user_18(self):
@@ -1030,9 +964,7 @@ class User(CLITestCase):
         @Assert: User is updated
 
         @Status: Manual
-
         """
-        pass
 
     @stubbed()
     def test_positive_update_user_19(self):
@@ -1047,9 +979,7 @@ class User(CLITestCase):
         @Assert: User is updated
 
         @Status: Manual
-
         """
-        pass
 
     @stubbed()
     def test_positive_update_user_20(self):
@@ -1064,9 +994,7 @@ class User(CLITestCase):
         @Assert: User is updated
 
         @Status: Manual
-
         """
-        pass
 
     @stubbed()
     def test_positive_update_user_21(self):
@@ -1081,9 +1009,7 @@ class User(CLITestCase):
         @Assert: User is updated
 
         @Status: Manual
-
         """
-        pass
 
     @stubbed()
     def test_positive_update_user_22(self):
@@ -1098,9 +1024,7 @@ class User(CLITestCase):
         @Assert: User is updated
 
         @Status: Manual
-
         """
-        pass
 
     @stubbed()
     def test_positive_update_user_23(self):
@@ -1114,9 +1038,7 @@ class User(CLITestCase):
         @Assert: User is updated
 
         @Status: Manual
-
         """
-        pass
 
     @stubbed()
     def test_positive_update_user_24(self):
@@ -1131,9 +1053,7 @@ class User(CLITestCase):
         @Assert: User is updated
 
         @Status: Manual
-
         """
-        pass
 
     @stubbed()
     def test_positive_update_user_25(self):
@@ -1148,9 +1068,7 @@ class User(CLITestCase):
         @Assert: User is updated
 
         @Status: Manual
-
         """
-        pass
 
     @stubbed()
     def test_positive_update_user_26(self):
@@ -1165,9 +1083,7 @@ class User(CLITestCase):
         @Assert: User is updated
 
         @Status: Manual
-
         """
-        pass
 
     @stubbed()
     def test_positive_update_user_28(self):
@@ -1182,9 +1098,7 @@ class User(CLITestCase):
         @Assert: User is update
 
         @Status: Manual
-
         """
-        pass
 
     @stubbed()
     def test_negative_update_user_1(self):
@@ -1199,10 +1113,9 @@ class User(CLITestCase):
         @Assert: User is not updated.  Appropriate error shown.
 
         @Status: Manual
-
         """
-        pass
 
+    @tier1
     def test_negative_update_user_2(self):
         """@Test: Update invalid Firstname in an User
 
@@ -1213,7 +1126,6 @@ class User(CLITestCase):
         2. Update Firstname for all variations in [2]
 
         @Assert: User is not updated.  Appropriate error shown.
-
         """
         new_user = make_user()
         for invalid_firstname in (gen_string("alpha", 51),
@@ -1228,6 +1140,7 @@ class User(CLITestCase):
                         search=('login', new_user['login']))
                     self.assertEqual(updated_user['name'], new_user['name'])
 
+    @tier1
     def test_negative_update_user_3(self):
         """@Test: Update invalid lastname in an User
 
@@ -1238,7 +1151,6 @@ class User(CLITestCase):
         2. Update Surname for all variations in [2]
 
         @Assert: User is not updated.  Appropriate error shown.
-
         """
         new_user = make_user()
         for invalid_lastname in (gen_string("alpha", 51),
@@ -1253,6 +1165,7 @@ class User(CLITestCase):
                         search=('login', new_user['login']))
                     self.assertEqual(updated_user['name'], new_user['name'])
 
+    @tier1
     def test_negative_update_user_4(self):
         """@Test: Update invalid Email Address in an User
 
@@ -1263,7 +1176,6 @@ class User(CLITestCase):
         2. Update Email Address for all variations in [2]
 
         @Assert: User is not updated.  Appropriate error shown.
-
         """
         new_user = make_user()
         for email in invalid_emails_list():
@@ -1277,6 +1189,7 @@ class User(CLITestCase):
                         search=('login', new_user['login']))
                     self.assertEqual(updated_user['email'], new_user['email'])
 
+    @tier1
     def test_positive_delete_user_1(self):
         """@Test: Delete a user
 
@@ -1287,7 +1200,6 @@ class User(CLITestCase):
         2. Delete the User
 
         @Assert: User is deleted
-
         """
         for login in valid_usernames_list():
             with self.subTest(login):
@@ -1297,6 +1209,7 @@ class User(CLITestCase):
                 with self.assertRaises(CLIReturnCodeError):
                     UserObj.info({'login': user['login']})
 
+    @tier1
     def test_positive_delete_user_2(self):
         """@Test: Delete an admin user
 
@@ -1307,7 +1220,6 @@ class User(CLITestCase):
         2. Delete the User
 
         @Assert: User is deleted
-
         """
         for login in valid_usernames_list():
             with self.subTest(login):
@@ -1317,6 +1229,7 @@ class User(CLITestCase):
                 with self.assertRaises(CLIReturnCodeError):
                     UserObj.info({'login': user['login']})
 
+    @tier1
     def test_negative_delete_user_1(self):
         """@Test: Attempt to delete internal admin user
 
@@ -1326,7 +1239,6 @@ class User(CLITestCase):
         1. Attempt to delete the last admin user
 
         @Assert: User is not deleted
-
         """
         for opts in ({'admin': 'true'},
                      {'login': 'admin', 'password': 'changeme'}):
@@ -1342,6 +1254,7 @@ class User(CLITestCase):
                     result = UserObj.exists(search=('login', 'admin'))
                     self.assertTrue(result)
 
+    @tier1
     def test_list_user_1(self):
         """@Test: List User for all variations of Username
 
@@ -1353,7 +1266,6 @@ class User(CLITestCase):
         2. List User
 
         @Assert: User is listed
-
         """
         include_list = [gen_string("alphanumeric", 100)]
         for login in valid_usernames_list() + include_list:
@@ -1372,6 +1284,7 @@ class User(CLITestCase):
                     'name': user['name'],
                 }, result[0])
 
+    @tier1
     def test_list_user_2(self):
         """@Test: List User for all variations of Firstname
 
@@ -1383,7 +1296,6 @@ class User(CLITestCase):
         2. List User
 
         @Assert: User is listed
-
         """
         include_list = [gen_string("alphanumeric", 50)]
         for firstname in valid_usernames_list() + include_list:
@@ -1401,6 +1313,7 @@ class User(CLITestCase):
                     'name': user['name'],
                 }, result)
 
+    @tier1
     def test_list_user_3(self):
         """@Test: List User for all variations of Surname
 
@@ -1412,7 +1325,6 @@ class User(CLITestCase):
         2. List User
 
         @Assert: User is listed
-
         """
         include_list = [gen_string("alphanumeric", 50)]
         for lastname in valid_usernames_list() + include_list:
@@ -1430,6 +1342,7 @@ class User(CLITestCase):
                     'name': user['name'],
                 }, result)
 
+    @tier1
     def test_list_user_4(self):
         """@Test: List User for all variations of Email Address
 
@@ -1441,7 +1354,6 @@ class User(CLITestCase):
         2. List User
 
         @Assert: User is listed
-
         """
         for mail in (gen_string("alpha") + "@somemail.com",
                      gen_string("alphanumeric", 10) + "@somemail.com",
@@ -1462,6 +1374,7 @@ class User(CLITestCase):
                 }, result)
 
     @skip_if_bug_open('bugzilla', 1204667)
+    @tier1
     def test_bugzilla_1204667(self):
         """@Test: List User for utf-8,latin variations of Email Address
 
@@ -1475,7 +1388,6 @@ class User(CLITestCase):
         @Assert: User is listed
 
         @BZ: 1204667
-
         """
         for mail in (gen_string("latin1") + "@somemail.com",
                      gen_string("utf8") + "@somemail.com"):
@@ -1507,9 +1419,7 @@ class User(CLITestCase):
         @Assert: User is found
 
         @Status: Manual
-
         """
-        pass
 
     @stubbed()
     def test_search_user_2(self):
@@ -1525,9 +1435,7 @@ class User(CLITestCase):
         @Assert: User is found
 
         @Status: Manual
-
         """
-        pass
 
     @stubbed()
     def test_search_user_3(self):
@@ -1543,9 +1451,7 @@ class User(CLITestCase):
         @Assert: User is found
 
         @Status: Manual
-
         """
-        pass
 
     @stubbed()
     def test_search_user_4(self):
@@ -1561,9 +1467,7 @@ class User(CLITestCase):
         @Assert: User is found
 
         @Status: Manual
-
         """
-        pass
 
     @stubbed()
     def test_search_user_5(self):
@@ -1579,9 +1483,7 @@ class User(CLITestCase):
         @Assert: User is found
 
         @Status: Manual
-
         """
-        pass
 
     @stubbed()
     def test_info_user_1(self):
@@ -1597,9 +1499,7 @@ class User(CLITestCase):
         @Assert: User info is displayed
 
         @Status: Manual
-
         """
-        pass
 
     @stubbed()
     def test_info_user_2(self):
@@ -1615,9 +1515,7 @@ class User(CLITestCase):
         @Assert: User info is displayed
 
         @Status: Manual
-
         """
-        pass
 
     @stubbed()
     def test_info_user_3(self):
@@ -1633,9 +1531,7 @@ class User(CLITestCase):
         @Assert: User info is displayed
 
         @Status: Manual
-
         """
-        pass
 
     @stubbed()
     def test_info_user_4(self):
@@ -1651,9 +1547,7 @@ class User(CLITestCase):
         @Assert: User info is displayed
 
         @Status: Manual
-
         """
-        pass
 
     @stubbed()
     def test_info_user_5(self):
@@ -1669,9 +1563,7 @@ class User(CLITestCase):
         @Assert: User info is displayed
 
         @Status: Manual
-
         """
-        pass
 
     @stubbed()
     def test_end_to_end_user_1(self):
@@ -1691,9 +1583,7 @@ class User(CLITestCase):
         @Assert: All actions passed
 
         @Status: Manual
-
         """
-        pass
 
     @stubbed()
     def test_end_to_end_user_2(self):
@@ -1713,17 +1603,15 @@ class User(CLITestCase):
         @Assert: All actions failed since the User is not assigned to any Org
 
         @Status: Manual
-
         """
-        pass
 
+    @tier1
     def test_automation_bz_1110337(self):
         """@Test: Automation of BZ 1110337
 
         @Feature: User - info, list BZ
 
         @Assert: No undefined method exception
-
         """
         users = [make_user() for _ in range(4)]
         # non-existing user info
@@ -1736,6 +1624,7 @@ class User(CLITestCase):
             self.assertNotEqual(str(result).find(user['login']), -1)
 
     @skip_if_bug_open('bugzilla', 1138553)
+    @tier2
     def test_user_add_role_1(self):
         """@Test: Add role to User for all variations of role names
 
@@ -1747,7 +1636,6 @@ class User(CLITestCase):
         @Assert: Role is added to user
 
         @BZ: 1138553
-
         """
         user = make_user()
         include_list = [gen_string("alphanumeric", 100)]
@@ -1763,6 +1651,7 @@ class User(CLITestCase):
                 self.assertIn(role_name, user['roles'])
 
     @skip_if_bug_open('bugzilla', 1138553)
+    @tier2
     def test_user_remove_role_1(self):
         """@Test: Remove role to User for all variations of role names
 
@@ -1774,7 +1663,6 @@ class User(CLITestCase):
         @Assert: Role is removed
 
         @BZ: 1138553
-
         """
         user = make_user()
         include_list = [gen_string("alphanumeric", 100)]


### PR DESCRIPTION
This pull request adds `py.test` markers for all existing automated tests. It also
removes blank lines from docstrings (for some modules) and removes the `pass`
argument from many `stubbed` tests.