### PR TITLE
Click element does not work after upgrade to selenium 2.48.0

### DIFF
--- a/robottelo/ui/base.py
+++ b/robottelo/ui/base.py
@@ -349,6 +349,14 @@ class Base(object):
         self.browser.execute_script("$('#panel_main').\
                                     data('jsp').scrollBy(0, 100);")
 
+    def scroll_into_view(self, element):
+        """ Scrolls current element into visible area of the browser window."""
+        # Here aligntoTop=False option is set.
+        self.browser.execute_script(
+            'arguments[0].scrollIntoView(false);',
+            element,
+        )
+
     def field_update(self, loc_string, newtext):
         """
         Function to replace the existing/default text from textbox
@@ -508,7 +516,7 @@ class Base(object):
         return element_type
 
     def click(self, locator, wait_for_ajax=True,
-              ajax_timeout=30, waiter_timeout=12):
+              ajax_timeout=30, waiter_timeout=12, scroll=False):
         """Locate the element described by the ``locator`` and click on it.
 
         :param locator: The locator that describes the element.
@@ -528,6 +536,11 @@ class Base(object):
                 '{0}: element with locator {1} not found while trying to click'
                 .format(type(self).__name__, locator)
             )
+        # Required since from seleniume 2.48.0. which makes Selenium more
+        # closely resemble a user when interacting with elements.
+        # Scrolling element into view before attempting to click solves this.
+        if scroll:
+            self.scroll_into_view(element)
         element.click()
         if wait_for_ajax:
             self.wait_for_ajax(ajax_timeout)

--- a/robottelo/ui/sync.py
+++ b/robottelo/ui/sync.py
@@ -146,6 +146,7 @@ class Sync(Base):
                 # Below loop helps when reposet checkbox is already expanded
                 # and when selecting multiple repos.
                 if rs_exp:
+                    self.scroll_into_view(rs_exp)
                     rs_exp.click()
                 elif rs_cb:
                     rs_cb.click()
@@ -171,7 +172,10 @@ class Sync(Base):
                     repo_name = repo_values['repo_name']
                     # UI is very slow here. Hence timeout is 120 seconds.
                     self.click(
-                        (strategy3, value3 % repo_name), waiter_timeout=120)
+                        (strategy3, value3 % repo_name),
+                        waiter_timeout=120,
+                        scroll=True,
+                    )
                     # Similar to above reposet checkbox spinner
                     repo_spinner = self.wait_until_element(
                         (strategy5, value5 % repo_name),


### PR DESCRIPTION
a) For clicking elements which are not in view is a problem with
   selenium 2.48.0 .
b) Reverting things back to selenium 2.47.3 gets it to work again.
c) But the choosen option here is to set scroll_intoview(false)
   which, scrolls the current element into the visible area of
   the browser window.