### PR TITLE
Update travis requirements

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ env:
     - TOXENV=py27
     - TOXENV=py34
 install:
-    - pip install flake8 sphinx testimony tox
+    - pip install -r requirements.txt coveralls flake8 sphinx testimony tox
 script:
     - flake8 .
     - make test-docstrings


### PR DESCRIPTION
Update travis requirements to match current set of commands being
executed. Install robottelo itself to allow documentation generation
through sphinx autodoc. And install coveralls to allow coverage
reporting run for real.