### PR TITLE
Add function to get webdriver browser instance

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -5,3 +5,4 @@ include =
     robottelo/cli/base.py
     robottelo/cli/hammer.py
     robottelo/ui/base.py
+    robottelo/ui/browser.py

--- a/robottelo/config/settings.py
+++ b/robottelo/config/settings.py
@@ -604,6 +604,12 @@ class Settings(object):
                 '[robottelo] virtual_display is enabled, '
                 'window_manager_command must be provided.'
             )
+        webdrivers = ('chrome', 'firefox', 'ie', 'phantomjs', 'remote')
+        if self.webdriver not in webdrivers:
+            raise ImproperlyConfigured(
+                '[robottelo] webdriver should be one of {0}.'
+                .format(', '.join(webdrivers.keys()))
+            )
         return validation_errors
 
     @property

--- a/robottelo/test.py
+++ b/robottelo/test.py
@@ -33,6 +33,7 @@ from robottelo.performance.thread import (
     SubscribeAKThread,
     SubscribeAttachThread
 )
+from robottelo.ui.browser import browser
 from robottelo.ui.activationkey import ActivationKey
 from robottelo.ui.architecture import Architecture
 from robottelo.ui.computeprofile import ComputeProfile
@@ -77,7 +78,6 @@ from robottelo.ui.template import Template
 from robottelo.ui.trend import Trend
 from robottelo.ui.usergroup import UserGroup
 from robottelo.ui.user import User
-from selenium import webdriver
 
 SAUCE_URL = "http://%s:%s@ondemand.saucelabs.com:80/wd/hub"
 
@@ -170,29 +170,7 @@ class UITestCase(TestCase):
 
     def setUp(self):  # noqa
         """We do want a new browser instance for every test."""
-        if self.driver_name.lower() == 'firefox':
-            self.browser = webdriver.Firefox(
-                firefox_binary=webdriver.firefox.firefox_binary.FirefoxBinary(
-                    self.driver_binary)
-            )
-        elif self.driver_name.lower() == 'chrome':
-            self.browser = (
-                webdriver.Chrome() if self.driver_binary is None
-                else webdriver.Chrome(executable_path=self.driver_binary)
-            )
-        elif self.driver_name.lower() == 'ie':
-            self.browser = (
-                webdriver.Ie() if self.driver_binary is None
-                else webdriver.Ie(executable_path=self.driver_binary)
-            )
-        elif self.driver_name.lower() == 'phantomjs':
-            service_args = ['--ignore-ssl-errors=true']
-            self.browser = webdriver.PhantomJS(
-                service_args=service_args
-            )
-        else:
-            self.browser = webdriver.Remote()
-
+        self.browser = browser()
         self.browser.maximize_window()
         self.browser.get(settings.server.get_url())
 

--- a/robottelo/ui/browser.py
+++ b/robottelo/ui/browser.py
@@ -1,0 +1,26 @@
+from robottelo.config import settings
+from selenium import webdriver
+
+
+def browser():
+    """Creates a webdriver browser instance based on configuration."""
+    webdriver_name = settings.webdriver.lower()
+    if webdriver_name == 'firefox':
+        return webdriver.Firefox(
+            firefox_binary=webdriver.firefox.firefox_binary.FirefoxBinary(
+                settings.webdriver_binary)
+        )
+    elif webdriver_name == 'chrome':
+        return (
+            webdriver.Chrome() if settings.webdriver_binary is None
+            else webdriver.Chrome(executable_path=settings.webdriver_binary)
+        )
+    elif webdriver_name == 'ie':
+        return (
+            webdriver.Ie() if settings.webdriver_binary is None
+            else webdriver.Ie(executable_path=settings.webdriver_binary)
+        )
+    elif webdriver_name == 'phantomjs':
+        return webdriver.PhantomJS(service_args=['--ignore-ssl-errors=true'])
+    elif webdriver_name == 'remote':
+        return webdriver.Remote()

--- a/tests/robottelo/test_ui.py
+++ b/tests/robottelo/test_ui.py
@@ -1,0 +1,51 @@
+import six
+import unittest2
+
+from robottelo.ui.browser import browser
+
+if six.PY2:
+    import mock
+else:
+    from unittest import mock
+
+
+class BrowserTestCase(unittest2.TestCase):
+    def setUp(self):
+        self.settings_patcher = mock.patch('robottelo.ui.browser.settings')
+        self.webdriver_patcher = mock.patch('robottelo.ui.browser.webdriver')
+        self.settings = self.settings_patcher.start()
+        self.webdriver = self.webdriver_patcher.start()
+
+    def tearDown(self):
+        self.settings_patcher.stop()
+        self.webdriver_patcher.stop()
+
+    def test_browser_firefox(self):
+        self.settings.webdriver = 'firefox'
+        self.webdriver.firefox.firefox_binary.FirefoxBinary.side_effect = [
+            None]
+        browser()
+        self.webdriver.Firefox.assert_called_once_with(firefox_binary=None)
+
+    def test_browser_chrome(self):
+        self.settings.webdriver = 'chrome'
+        self.settings.webdriver_binary = None
+        browser()
+        self.webdriver.Chrome.assert_called_once_with()
+
+    def test_browser_ie(self):
+        self.settings.webdriver = 'ie'
+        self.settings.webdriver_binary = None
+        browser()
+        self.webdriver.Ie.assert_called_once_with()
+
+    def test_browser_phantomjs(self):
+        self.settings.webdriver = 'phantomjs'
+        browser()
+        self.webdriver.PhantomJS.assert_called_once_with(
+            service_args=['--ignore-ssl-errors=true'])
+
+    def test_browser_remote(self):
+        self.settings.webdriver = 'remote'
+        browser()
+        self.webdriver.Remote.assert_called_once_with()


### PR DESCRIPTION
The `browser` function returns a webdriver browser, which allows easy
debug sessions from the python shell.

    >>> from robottelo.config import settings
    >>> from robottelo.ui.browser import browser
    >>> settings.configure()
    >>> b = browser()