### PR TITLE
Get to one standard for delete operations in WebUI

### DIFF
--- a/robottelo/ui/activationkey.py
+++ b/robottelo/ui/activationkey.py
@@ -131,16 +131,11 @@ class ActivationKey(Base):
 
     def delete(self, name, really=True):
         """Deletes an existing activation key."""
-        element = self.search(name)
-
-        if element:
-            element.click()
-            self.wait_for_ajax()
-            self.click(locators['ak.remove'])
-            if really:
-                self.click(common_locators['confirm_remove'])
-            else:
-                self.click(locators['ak.cancel'])
+        self.delete_entity(
+            name,
+            really,
+            locators['ak.remove'],
+        )
 
     def associate_product(self, name, products):
         """Associate an existing product with activation key."""

--- a/robottelo/ui/base.py
+++ b/robottelo/ui/base.py
@@ -191,12 +191,21 @@ class Base(object):
         searched = self.search(name)
         if not searched:
             raise UIError('Could not search the entity "{0}"'.format(name))
-        if drop_locator:
-            strategy, value = drop_locator
-            self.click((strategy, value % name))
-        strategy, value = del_locator
-        self.click((strategy, value % name), wait_for_ajax=False)
-        self.handle_alert(really)
+        if self.is_katello:
+            searched.click()
+            self.wait_for_ajax()
+            self.click(del_locator)
+            if really:
+                self.click(common_locators['confirm_remove'])
+            else:
+                self.click(common_locators['cancel'])
+        else:
+            if drop_locator:
+                strategy, value = drop_locator
+                self.click((strategy, value % name))
+            strategy, value = del_locator
+            self.click((strategy, value % name), wait_for_ajax=False)
+            self.handle_alert(really)
         # Make sure that element is really removed from UI. It is necessary to
         # verify that fact few times as sometimes 1 second is not enough for
         # element to be actually deleted from DB

--- a/robottelo/ui/contentenv.py
+++ b/robottelo/ui/contentenv.py
@@ -44,7 +44,9 @@ class ContentEnvironment(Base):
         return self.wait_until_element((strategy, value % name))
 
     def delete(self, name):
-        """Deletes an existing environment."""
+        """Deletes an existing environment. We don't have confirmation dialog
+        for current operation, so it is necessary to use custom method
+        """
         element = self.search(name)
         if not element:
             raise UINoSuchElementError(

--- a/robottelo/ui/contentviews.py
+++ b/robottelo/ui/contentviews.py
@@ -57,16 +57,14 @@ class ContentViews(Base):
 
     def delete(self, name, really=True):
         """Deletes an existing content view."""
-        element = self.search(name)
-        if element:
-            element.click()
-            self.wait_for_ajax()
-            self.click(locators['contentviews.remove'])
-            if really:
-                self.click(locators['contentviews.confirm_remove'])
-            else:
-                raise UIError(
-                    'Could not delete the "{0}" content view.'.format(name))
+        if not really:
+            raise UIError(
+                'Could not delete the "{0}" content view.'.format(name))
+        self.delete_entity(
+            name,
+            really,
+            locators['contentviews.remove'],
+        )
 
     def move_affected_components(self, env, cv):
         """Move affected components to another environment or content view.

--- a/robottelo/ui/discoveredhosts.py
+++ b/robottelo/ui/discoveredhosts.py
@@ -23,5 +23,5 @@ class DiscoveredHosts(Base):
             hostname,
             really,
             locators['discoveredhosts.delete'],
-            locators['discoveredhosts.dropdown'],
+            drop_locator=locators['discoveredhosts.dropdown'],
         )

--- a/robottelo/ui/gpgkey.py
+++ b/robottelo/ui/gpgkey.py
@@ -46,20 +46,13 @@ class GPGKey(Base):
                 'Could not create new gpg key "{0}"'.format(name)
             )
 
-    def delete(self, name, really):
+    def delete(self, name, really=True):
         """Deletes an existing gpg key."""
-        element = self.search(name)
-
-        if element:
-            element.click()
-            self.wait_for_ajax()
-            self.click(locators["gpgkey.remove"])
-            if really:
-                self.click(common_locators["confirm_remove"])
-            else:
-                raise UIError(
-                    'Could not delete the selected key "{0}".'.format(name)
-                )
+        self.delete_entity(
+            name,
+            really,
+            locators['gpgkey.remove'],
+        )
 
     def update(self, name, new_name=None, new_key=None):
         """Updates an existing GPG key."""

--- a/robottelo/ui/hostgroup.py
+++ b/robottelo/ui/hostgroup.py
@@ -37,7 +37,6 @@ class Hostgroup(Base):
 
     def delete(self, name, really=True):
         """Deletes existing hostgroup from UI."""
-        Navigator(self.browser).go_to_host_groups()
         self.delete_entity(
             name,
             really,

--- a/robottelo/ui/locators.py
+++ b/robottelo/ui/locators.py
@@ -686,12 +686,13 @@ common_locators = LocatorDict({
         By.XPATH, "//tr/td/input[@value='%s']/following::td/span/a/i"),
 
     # Katello Common Locators
-    "confirm_remove": (By.XPATH, "//button[contains(@ng-click,'ok')]"),
+    "confirm_remove": (
+        By.XPATH, "//button[@ng-click='ok()' or @ng-click='delete()']"),
     "create": (By.XPATH, "//button[contains(@ng-click,'Save')]"),
     "save": (
         By.XPATH, ("//button[contains(@ng-click,'save')"
                    "and not(contains(@class,'ng-hide'))]")),
-    "cancel": (By.XPATH, "//button[contains(@ng-click,'Cancel')]"),
+    "cancel": (By.XPATH, "//button[@aria-label='Close']"),
     "name": (By.ID, "name"),
     "label": (By.ID, "label"),
     "description": (By.ID, "description"),
@@ -1407,9 +1408,6 @@ locators = LocatorDict({
         By.XPATH, "//input[@ng-model='copyName']"),
     "ak.copy_create": (
         By.XPATH, "//button[@ng-click='copy(copyName)']"),
-    "ak.cancel": (
-        By.XPATH, ("//div[@class='modal-dialog']"
-                   "//button[@ng-click='cancel()']")),
     "ak.save_cv": (
         By.XPATH,
         ("//form[@bst-edit-select='activationKey.content_view.name']"
@@ -1657,8 +1655,6 @@ locators = LocatorDict({
         By.XPATH, "//select[@ng-model='selectedContentViewId']"),
     "contentviews.confirm_remove_ver": (
         By.XPATH, "//button[@ng-click='performDeletion()']"),
-    "contentviews.confirm_remove": (
-        By.XPATH, "//button[@ng-click='delete()']"),
     "contentviews.version_name": (
         By.XPATH, "//td/a[contains(., '%s')]"),
     "contentviews.success_rm_alert": (
@@ -1884,8 +1880,6 @@ locators = LocatorDict({
 
     "system-groups.remove": (
         By.XPATH, "//button[@ng-disabled='!group.permissions.deletable']"),
-    "system-groups.confirm_remove": (
-        By.XPATH, "//button[@ng-click='ok()']"),
 
     "system-groups.search": (
         By.XPATH, "//a[contains(@href,'system-groups') and contains(.,'%s')]"),

--- a/robottelo/ui/org.py
+++ b/robottelo/ui/org.py
@@ -154,9 +154,8 @@ class Org(Base):
         )
         self.click(common_locators['submit'])
 
-    def remove(self, org_name, really=True):
+    def delete(self, org_name, really=True):
         """Remove Organization in UI."""
-        Navigator(self.browser).go_to_org()
         self.delete_entity(
             org_name,
             really,

--- a/robottelo/ui/oscapcontent.py
+++ b/robottelo/ui/oscapcontent.py
@@ -33,7 +33,7 @@ class OpenScapContent(Base):
             name,
             really,
             locators['oscap.content_delete'],
-            locators['oscap.content_dropdown']
+            drop_locator=locators['oscap.content_dropdown'],
         )
 
     def update(self, name, new_name=None, content_org=None, content_loc=None):

--- a/robottelo/ui/products.py
+++ b/robottelo/ui/products.py
@@ -70,12 +70,10 @@ class Products(Base):
                 Select(type_ele).select_by_visible_text(new_sync_plan)
                 self.click(common_locators['create'])
 
-    def delete(self, product, really=True):
+    def delete(self, name, really=True):
         """Delete a product from UI"""
-        strategy, value = locators['prd.select']
-        self.click((strategy, value % product))
-        self.click(locators['prd.remove'])
-        if really:
-            self.click(common_locators['confirm_remove'])
-        else:
-            self.click(common_locators['cancel'])
+        self.delete_entity(
+            name,
+            really,
+            locators['prd.remove'],
+        )

--- a/robottelo/ui/repository.py
+++ b/robottelo/ui/repository.py
@@ -7,6 +7,7 @@ from selenium.webdriver.support.select import Select
 
 class Repos(Base):
     """Manipulates Repos from UI."""
+    is_katello = True
 
     def navigate_to_entity(self):
         """Navigate to Repository entity tab"""
@@ -81,16 +82,13 @@ class Repos(Base):
                 locators['repo.upstream_update'], new_upstream_name)
             self.click(common_locators['save'])
 
-    def delete(self, repo, really=True):
+    def delete(self, name, really=True):
         """Delete a repository from UI."""
-        self.navigate_to_entity()
-        strategy, value = locators['repo.select']
-        self.click((strategy, value % repo))
-        self.click(locators['repo.remove'])
-        if really:
-            self.click(common_locators['confirm_remove'])
-        else:
-            self.click(common_locators['cancel'])
+        self.delete_entity(
+            name,
+            really,
+            locators['repo.remove'],
+        )
 
     def search(self, element_name):
         """Uses the search box to locate an element from a list of elements.

--- a/robottelo/ui/subscription.py
+++ b/robottelo/ui/subscription.py
@@ -32,11 +32,10 @@ class Subscriptions(Base):
         browse_element = self.wait_until_element(locators['subs.file_path'])
         browse_element.send_keys(path)
         self.click(locators['subs.upload'])
-        # Waits till the below locator is visible or until 180 seconds.
         self.wait_until_element(locators['subs.manifest_exists'], 180)
 
     def delete(self):
-        """Uploads Manifest/subscriptions via UI."""
+        """Deletes Manifest/subscriptions via UI."""
         self.click(locators['subs.manage_manifest'])
         self.click(locators['subs.delete_manifest'])
 

--- a/robottelo/ui/syncplan.py
+++ b/robottelo/ui/syncplan.py
@@ -92,12 +92,10 @@ class Syncplan(Base):
                 select_locator=select_loc
             )
 
-    def delete(self, sync_plan, really=True):
+    def delete(self, name, really=True):
         """Deletes a sync_plan from UI."""
-        strategy, value = locators['sp.select']
-        self.click((strategy, value % sync_plan))
-        self.click(locators['sp.remove'])
-        if really:
-            self.click(common_locators['confirm_remove'])
-        else:
-            self.click(common_locators['cancel'])
+        self.delete_entity(
+            name,
+            really,
+            locators['sp.remove'],
+        )

--- a/robottelo/ui/systemgroup.py
+++ b/robottelo/ui/systemgroup.py
@@ -68,12 +68,10 @@ class SystemGroup(Base):
                 self.field_update("system-groups.update_limit_field", limit)
                 self.click(locators["system-groups.update_limit_save"])
 
-    def remove(self, name):
+    def delete(self, name, really=True):
         """Removes existing System Group from UI"""
-        system_group = self.search(name)
-        self.wait_for_ajax()
-        if system_group:
-            system_group.click()
-            self.wait_for_ajax()
-            self.click(locators["system-groups.remove"])
-            self.click(locators["system-groups.confirm_remove"])
+        self.delete_entity(
+            name,
+            really,
+            locators['system-groups.remove'],
+        )

--- a/robottelo/ui/template.py
+++ b/robottelo/ui/template.py
@@ -133,5 +133,5 @@ class Template(Base):
             name,
             really,
             locators['provision.template_delete'],
-            locators['provision.template_dropdown'],
+            drop_locator=locators['provision.template_dropdown'],
         )

--- a/robottelo/ui/trend.py
+++ b/robottelo/ui/trend.py
@@ -75,5 +75,5 @@ class Trend(Base):
             name,
             really,
             locators['trend.delete'],
-            locators['trend.dropdown'],
+            drop_locator=locators['trend.dropdown'],
         )

--- a/tests/foreman/ui/test_activationkey.py
+++ b/tests/foreman/ui/test_activationkey.py
@@ -336,7 +336,6 @@ class ActivationKey(UITestCase):
                     )
                     self.assertIsNotNone(self.activationkey.search(name))
                     self.activationkey.delete(name)
-                    self.assertIsNone(self.activationkey.search(name))
 
     @run_only_on('sat')
     def test_positive_delete_activation_key_with_env(self):
@@ -362,7 +361,6 @@ class ActivationKey(UITestCase):
             )
             self.assertIsNotNone(self.activationkey.search(name))
             self.activationkey.delete(name)
-            self.assertIsNone(self.activationkey.search(name))
 
     @run_only_on('sat')
     def test_positive_delete_activation_key_with_cv(self):
@@ -389,7 +387,6 @@ class ActivationKey(UITestCase):
             )
             self.assertIsNotNone(self.activationkey.search(name))
             self.activationkey.delete(name)
-            self.assertIsNone(self.activationkey.search(name))
 
     def test_positive_delete_activation_key_with_system(self):
         """@Test: Delete an Activation key which has registered systems
@@ -428,7 +425,6 @@ class ActivationKey(UITestCase):
                 result = vm.register_contenthost(name, self.organization.label)
                 self.assertEqual(result.return_code, 0)
                 self.activationkey.delete(name)
-                self.assertIsNone(self.activationkey.search(name))
 
     def test_negative_delete_activation_key(self):
         """@Test: [UI ONLY] Attempt to delete an Activation Key and cancel it
@@ -453,7 +449,6 @@ class ActivationKey(UITestCase):
             )
             self.assertIsNotNone(self.activationkey.search(name))
             self.activationkey.delete(name, really=False)
-            self.assertIsNotNone(self.activationkey.search(name))
 
     def test_positive_update_ak_with_different_names(self):
         """@Test: Update Activation Key Name in an Activation key

--- a/tests/foreman/ui/test_computeresource.py
+++ b/tests/foreman/ui/test_computeresource.py
@@ -231,7 +231,7 @@ class ComputeResource(UITestCase):
             )
 
     @run_only_on('sat')
-    def test_remove_resource(self):
+    def test_positive_delete(self):
         """@Test: Delete a Compute Resource
 
         @Feature: Compute Resource - Delete

--- a/tests/foreman/ui/test_contentviews.py
+++ b/tests/foreman/ui/test_contentviews.py
@@ -458,11 +458,6 @@ class TestContentViewsUI(UITestCase):
                             name, self.organization.name)
                     )
                     self.content_views.delete(name)
-                    self.assertIsNone(
-                        self.content_views.search(name),
-                        'Content view %s from %s org was not deleted' % (
-                            name, self.organization.name)
-                    )
 
     @run_only_on('sat')
     def test_cv_composite_create(self):

--- a/tests/foreman/ui/test_discoveryrule.py
+++ b/tests/foreman/ui/test_discoveryrule.py
@@ -160,7 +160,7 @@ class DiscoveryRules(UITestCase):
             self.assertIsNotNone(self.discoveryrules.search(name))
 
     @run_only_on('sat')
-    def test_delete_discovery_rule_1(self):
+    def test_positive_delete(self):
         """@Test: Delete Discovery Rule
 
         @Feature: Foreman Discovery
@@ -175,7 +175,6 @@ class DiscoveryRules(UITestCase):
                                        hostgroup=self.host_group.name)
                     self.assertIsNotNone(self.discoveryrules.search(name))
                     self.discoveryrules.delete(name)
-                    self.assertIsNone(self.discoveryrules.search(name))
 
     @run_only_on('sat')
     def test_update_discovery_rule_1(self):

--- a/tests/foreman/ui/test_environment.py
+++ b/tests/foreman/ui/test_environment.py
@@ -95,7 +95,7 @@ class Environment(UITestCase):
                     name = new_name  # for next iteration
 
     @run_only_on('sat')
-    def test_remove_env(self):
+    def test_positive_delete(self):
         """@Test: Delete an environment
 
         @Feature: Environment - Positive Delete
@@ -108,4 +108,3 @@ class Environment(UITestCase):
                 with self.subTest(name):
                     make_env(session, name=name)
                     self.environment.delete(name)
-                    self.assertIsNone(self.environment.search(name))

--- a/tests/foreman/ui/test_gpgkey.py
+++ b/tests/foreman/ui/test_gpgkey.py
@@ -213,7 +213,7 @@ class GPGKey(UITestCase):
     # Positive Delete
 
     @run_only_on('sat')
-    def test_positive_delete_1(self):
+    def test_positive_delete_for_uploaded_content(self):
         """@test: Create gpg key with valid name and valid gpg key via file
         import then delete it
 
@@ -234,11 +234,10 @@ class GPGKey(UITestCase):
                         upload_key=True,
                     )
                     self.assertIsNotNone(self.gpgkey.search(name))
-                    self.gpgkey.delete(name, True)
-                    self.assertIsNone(self.gpgkey.search(name))
+                    self.gpgkey.delete(name)
 
     @run_only_on('sat')
-    def test_positive_delete_2(self):
+    def test_positive_delete_for_pasted_content(self):
         """@test: Create gpg key with valid name and valid gpg key text via
         cut and paste/string then delete it
 
@@ -258,8 +257,7 @@ class GPGKey(UITestCase):
                         org=self.organization.name,
                     )
                     self.assertIsNotNone(self.gpgkey.search(name))
-                    self.gpgkey.delete(name, True)
-                    self.assertIsNone(self.gpgkey.search(name))
+                    self.gpgkey.delete(name)
 
     # Positive Update
 
@@ -1159,9 +1157,8 @@ class GPGKeyProductAssociate(UITestCase):
 
     @run_only_on('sat')
     def test_key_associate_15(self):
-        """@test: Create gpg key with valid name and valid gpg key
-        then associate it with empty (no repos) custom
-        product then delete it
+        """@test: Create gpg key with valid name and valid gpg key then
+        associate it with empty (no repos) custom product then delete it
 
         @feature: GPG Keys
 
@@ -1188,9 +1185,8 @@ class GPGKeyProductAssociate(UITestCase):
             self.assertIsNotNone(
                 self.gpgkey.assert_product_repo(name, product=True)
             )
-            self.gpgkey.delete(name, True)
-            # Assert GPGKey cannot be found and isn't associated with product
-            self.assertIsNone(self.gpgkey.search(name))
+            self.gpgkey.delete(name)
+            # Assert GPGKey isn't associated with product
             prd_element = self.products.search(product.name)
             self.assertIsNone(
                 self.gpgkey.assert_key_from_product(name, prd_element))
@@ -1232,9 +1228,8 @@ class GPGKeyProductAssociate(UITestCase):
                 self.assertIsNotNone(
                     self.gpgkey.assert_product_repo(name, product=product_)
                 )
-            self.gpgkey.delete(name, True)
-            # Assert GPGKey cannot be found and isn't associated with product
-            self.assertIsNone(self.gpgkey.search(name))
+            self.gpgkey.delete(name)
+            # Assert GPGKey isn't associated with product
             prd_element = self.products.search(product.name)
             self.assertIsNone(
                 self.gpgkey.assert_key_from_product(name, prd_element))
@@ -1283,9 +1278,8 @@ class GPGKeyProductAssociate(UITestCase):
                 self.assertIsNotNone(
                     self.gpgkey.assert_product_repo(name, product=product_)
                 )
-            self.gpgkey.delete(name, True)
-            # Assert GPGKey cannot be found and isn't associated with product
-            self.assertIsNone(self.gpgkey.search(name))
+            self.gpgkey.delete(name)
+            # Assert GPGKey isn't associated with product
             prd_element = self.products.search(product.name)
             self.assertIsNone(
                 self.gpgkey.assert_key_from_product(name, prd_element))
@@ -1327,8 +1321,7 @@ class GPGKeyProductAssociate(UITestCase):
                 self.assertIsNotNone(
                     self.gpgkey.assert_product_repo(name, product=product_)
                 )
-            self.gpgkey.delete(name, True)
-            self.assertIsNone(self.gpgkey.search(name))
+            self.gpgkey.delete(name)
             prd_element = self.products.search(product_name)
             self.assertIsNone(
                 self.gpgkey.assert_key_from_product(name, prd_element))
@@ -1374,8 +1367,7 @@ class GPGKeyProductAssociate(UITestCase):
             self.assertIsNotNone(
                 self.gpgkey.assert_product_repo(name, product=False)
             )
-            self.gpgkey.delete(name, True)
-            self.assertIsNone(self.gpgkey.search(name))
+            self.gpgkey.delete(name)
             # Assert that after deletion GPGKey is not associated with product
             prd_element = self.products.search(product.name)
             self.assertIsNone(self.gpgkey.assert_key_from_product(
@@ -1429,8 +1421,7 @@ class GPGKeyProductAssociate(UITestCase):
             self.assertIsNotNone(
                 self.gpgkey.assert_product_repo(name, product=False)
             )
-            self.gpgkey.delete(name, True)
-            self.assertIsNone(self.gpgkey.search(name))
+            self.gpgkey.delete(name)
             # Assert key shouldn't be associated with product or repository
             # after deletion
             prd_element = self.products.search(product.name)

--- a/tests/foreman/ui/test_host.py
+++ b/tests/foreman/ui/test_host.py
@@ -344,7 +344,7 @@ class Host(UITestCase, Base):
             self.assertIsNotNone(search)
 
     @run_only_on('sat')
-    def test_delete_host(self):
+    def test_positive_delete_host(self):
         """@Test: Delete a Host
 
         @Feature: Host - Positive Delete

--- a/tests/foreman/ui/test_hw_model.py
+++ b/tests/foreman/ui/test_hw_model.py
@@ -83,7 +83,7 @@ class HardwareModelTestCase(UITestCase):
                     name = test_data['name']  # for next iteration
 
     @run_only_on('sat')
-    def test_delete_positive(self):
+    def test_positive_delete(self):
         """@test: Deletes the Hardware-Model
 
         @feature: Hardware-Model - Positive delete
@@ -102,5 +102,3 @@ class HardwareModelTestCase(UITestCase):
                         )
                     make_hw_model(session, name=test_data['name'])
                     self.hardwaremodel.delete(test_data['name'])
-                    self.assertIsNone(self.hardwaremodel.search(
-                        test_data['name']))

--- a/tests/foreman/ui/test_ldapauthsource.py
+++ b/tests/foreman/ui/test_ldapauthsource.py
@@ -54,7 +54,7 @@ class LDAPAuthSource(UITestCase):
                         self.ldapauthsource.search(server_name)
                     )
 
-    def test_delete_ldap_auth_withad(self):
+    def test_positive_delete_ldap_auth_withad(self):
         """@Test: Delete LDAP authentication with AD
 
         @Feature: LDAP Authentication - Active Directory - delete LDAP AD

--- a/tests/foreman/ui/test_medium.py
+++ b/tests/foreman/ui/test_medium.py
@@ -125,7 +125,7 @@ class Medium(UITestCase):
             self.assertIsNone(self.medium.search(new_name))
 
     @run_only_on('sat')
-    def test_remove_medium(self):
+    def test_positive_delete(self):
         """@Test: Delete a media
 
         @Feature: Media - Delete

--- a/tests/foreman/ui/test_operatingsys.py
+++ b/tests/foreman/ui/test_operatingsys.py
@@ -232,7 +232,7 @@ class OperatingSys(UITestCase):
                                  (common_locators['haserror']))
 
     @run_only_on('sat')
-    def test_remove_os(self):
+    def test_positive_delete(self):
         """@Test: Delete an existing OS
 
         @Feature: OS - Positive Delete
@@ -241,8 +241,7 @@ class OperatingSys(UITestCase):
 
         """
         os_name = entities.OperatingSystem().create().name
-        with Session(self.browser) as session:
-            session.nav.go_to_operating_systems()
+        with Session(self.browser):
             self.operatingsys.delete(os_name)
 
     @run_only_on('sat')

--- a/tests/foreman/ui/test_org.py
+++ b/tests/foreman/ui/test_org.py
@@ -247,13 +247,12 @@ class Org(UITestCase):
         @assert: Organization is deleted successfully
 
         """
-        with Session(self.browser) as session:
+        with Session(self.browser):
             for org_name in generate_strings_list():
                 with self.subTest(org_name):
                     # Use nailgun to create org
                     entities.Organization(name=org_name).create()
-                    session.nav.go_to_org()
-                    self.org.remove(org_name)
+                    self.org.delete(org_name)
 
     def test_positive_delete_bz1225588(self):
         """@test: Create Organization with valid values and upload manifest.
@@ -276,10 +275,7 @@ class Org(UITestCase):
             # Org cannot be deleted when selected,
             # So switching to Default Org and then deleting.
             session.nav.go_to_select_org('Default Organization')
-            self.org.remove(org_name)
-            session.nav.go_to_dashboard()
-            status = self.org.search(org_name)
-            # Check for at least ten times that org is deleted due #1225588
+            self.org.delete(org_name)
             for _ in range(10):
                 status = self.org.search(org_name)
                 if status is None:

--- a/tests/foreman/ui/test_partitiontable.py
+++ b/tests/foreman/ui/test_partitiontable.py
@@ -118,7 +118,7 @@ class PartitionTable(UITestCase):
             self.assertIsNone(self.partitiontable.search(name))
 
     @run_only_on('sat')
-    def test_remove_partition_table(self):
+    def test_positive_delete(self):
         """@Test: Delete a partition table
 
         @Feature: Partition table - Positive Delete

--- a/tests/foreman/ui/test_products.py
+++ b/tests/foreman/ui/test_products.py
@@ -197,7 +197,7 @@ class Products(UITestCase):
                 common_locators['alert.error']))
 
     @run_only_on('sat')
-    def test_remove_prd(self):
+    def test_positive_delete(self):
         """@Test: Delete Content Product
 
         @Feature: Content Product - Positive Delete
@@ -217,7 +217,3 @@ class Products(UITestCase):
                     )
                     self.assertIsNotNone(self.products.search(prd_name))
                     self.products.delete(prd_name)
-                    # Note: refresh is used here because sometimes selenium
-                    # is too fast to check the deleted object and it fails
-                    self.browser.refresh()
-                    self.assertIsNone(self.products.search(prd_name))

--- a/tests/foreman/ui/test_puppet_classes.py
+++ b/tests/foreman/ui/test_puppet_classes.py
@@ -39,7 +39,7 @@ class PuppetClasses(UITestCase):
                     )
 
     @run_only_on('sat')
-    def test_delete_positive(self):
+    def test_positive_delete(self):
         """@Test: Create new puppet-class
 
         @Feature: Puppet-Classes - Positive delete
@@ -47,9 +47,8 @@ class PuppetClasses(UITestCase):
         @Assert: Puppet-Class is deleted
 
         """
-        with Session(self.browser) as session:
+        with Session(self.browser):
             for name in generate_strings_list(length=8):
                 with self.subTest(name):
                     entities.PuppetClass(name=name).create()
-                    session.nav.go_to_puppet_classes()
                     self.puppetclasses.delete(name)

--- a/tests/foreman/ui/test_repository.py
+++ b/tests/foreman/ui/test_repository.py
@@ -313,7 +313,7 @@ class Repos(UITestCase):
                 repo_name, 'checksum', checksum_update))
 
     @run_only_on('sat')
-    def test_remove_repo(self):
+    def test_positive_delete(self):
         """@Test: Create content repository and remove it
 
         @Feature: Content Repos - Positive Delete
@@ -334,7 +334,6 @@ class Repos(UITestCase):
                     )
                     self.assertIsNotNone(self.repository.search(repo_name))
                     self.repository.delete(repo_name)
-                    self.assertIsNone(self.repository.search(repo_name))
 
     @run_only_on('sat')
     def test_discover_repo_via_existing_product(self):

--- a/tests/foreman/ui/test_role.py
+++ b/tests/foreman/ui/test_role.py
@@ -42,7 +42,7 @@ class Role(UITestCase):
                     self.assertIsNotNone(session.nav.wait_until_element(
                         common_locators['name_haserror']))
 
-    def test_remove_role(self):
+    def test_positive_delete(self):
         """@Test: Delete an existing role
 
         @Feature: Role - Positive Delete

--- a/tests/foreman/ui/test_subnet.py
+++ b/tests/foreman/ui/test_subnet.py
@@ -169,7 +169,7 @@ class Subnet(UITestCase):
                 locators['subnet.dnssecondary_haserror']))
 
     @run_only_on('sat')
-    def test_remove_subnet(self):
+    def test_positive_delete(self):
         """@Test: Delete a subnet
 
         @Feature: Subnet - Positive Delete
@@ -189,10 +189,9 @@ class Subnet(UITestCase):
                     self.subnet.delete(name)
 
     @run_only_on('sat')
-    def test_remove_subnet_and_cancel(self):
-        """@Test: Delete subnet.
-
-        Attempt to delete subnet but cancel in the confirmation dialog box.
+    def test_negative_delete(self):
+        """@Test: Delete subnet. Attempt to delete subnet, but cancel in the
+        confirmation dialog box.
 
         @Feature: Subnet - Negative Delete
 
@@ -207,7 +206,7 @@ class Subnet(UITestCase):
                 subnet_network=gen_ipaddr(ip3=True),
                 subnet_mask=gen_netmask(),
             )
-            self.subnet.delete(name, False)
+            self.subnet.delete(name, really=False)
 
     @run_only_on('sat')
     def test_update_subnet_with_name(self):

--- a/tests/foreman/ui/test_syncplan.py
+++ b/tests/foreman/ui/test_syncplan.py
@@ -338,6 +338,4 @@ class Syncplan(UITestCase):
                         organization=self.organization,
                     ).create()
                     session.nav.go_to_select_org(self.organization.name)
-                    session.nav.go_to_sync_plans()
                     self.syncplan.delete(plan_name)
-                    self.assertIsNone(self.syncplan.search(plan_name))

--- a/tests/foreman/ui/test_template.py
+++ b/tests/foreman/ui/test_template.py
@@ -188,12 +188,12 @@ class Template(UITestCase):
                     self.assertIsNotNone(self.template.search(name))
 
     @run_only_on('sat')
-    def test_remove_template(self):
+    def test_positive_delete(self):
         """@Test: Remove a template
 
         @Feature: Template - Positive Delete
 
-        @Assert: Template removed successfully
+        @Assert: Template is removed successfully
 
         """
         with Session(self.browser) as session:

--- a/tests/foreman/ui/test_trend.py
+++ b/tests/foreman/ui/test_trend.py
@@ -57,7 +57,7 @@ class TrendTest(UITestCase):
             search = self.trend.search(new_name)
             self.assertIsNotNone(search)
 
-    def test_delete_trend_positive(self):
+    def test_positive_delete(self):
         """@Test: Delete existing trend
 
         @Feature: Trend - Positive Delete
@@ -68,5 +68,3 @@ class TrendTest(UITestCase):
         with Session(self.browser) as session:
             make_trend(session, trend_type=TREND_TYPES['environment'])
             self.trend.delete(TREND_TYPES['environment'])
-            search = self.trend.search(TREND_TYPES['environment'])
-            self.assertIsNone(search)

--- a/tests/foreman/ui/test_user.py
+++ b/tests/foreman/ui/test_user.py
@@ -42,7 +42,7 @@ class User(UITestCase):
 
     """
 
-    def test_delete_user(self):
+    def test_positive_delete_user(self):
         """@Test: Delete a User
 
         @Feature: User - Delete
@@ -1380,22 +1380,6 @@ class User(UITestCase):
         2. Click Cancel
 
         @Assert: User is not updated.
-
-        @Status: Manual
-
-        """
-
-    @stubbed()
-    def test_positive_delete_user_1(self):
-        """@Test: Delete a user
-
-        @Feature: User - Positive Delete
-
-        @Steps:
-        1. Create User
-        2. Delete the User
-
-        @Assert: User is deleted
 
         @Status: Manual
 

--- a/tests/foreman/ui/test_usergroup.py
+++ b/tests/foreman/ui/test_usergroup.py
@@ -73,7 +73,7 @@ class UserGroup(UITestCase):
                 common_locators['name_haserror']))
 
     @skip_if_bug_open('bugzilla', 1142588)
-    def test_remove_empty_usergroup(self):
+    def test_positive_delete_empty(self):
         """@Test: Delete an empty Usergroup
 
         @Feature: Usergroup - Positive Delete
@@ -89,7 +89,7 @@ class UserGroup(UITestCase):
                     self.usergroup.delete(group_name)
 
     @skip_if_bug_open('bugzilla', 1142588)
-    def test_remove_usergroup(self):
+    def test_positive_delete(self):
         """@Test: Delete an Usergroup that contains a user
 
         @Feature: Usergroup - Positive Delete


### PR DESCRIPTION
Closes #2750

As a bonus:
- Fixed some tests names
- Improved performance for at least on 15 minutes for overall run

```
nosetests tests/foreman/ui/test_activationkey.py -m test_positive_delete_activation_key_with_different_names
.
----------------------------------------------------------------------
Ran 1 test in 266.173s

OK

nosetests tests/foreman/ui/test_activationkey.py -m test_negative_delete_activation_key
.
----------------------------------------------------------------------
Ran 1 test in 50.160s

OK
```
```
nosetests tests/foreman/ui/test_architecture.py -m test_delete_architecture
.
----------------------------------------------------------------------
Ran 1 test in 93.138s

OK
```
```
nosetests tests/foreman/ui/test_computeresource.py -m test_positive_delete_resource
.
----------------------------------------------------------------------
Ran 1 test in 117.956s

OK
```
```
nosetests tests/foreman/ui/test_config_groups.py -m test_delete_positive
.
----------------------------------------------------------------------
Ran 1 test in 82.365s

OK
```
```
nosetests tests/foreman/ui/test_contentviews.py -m test_cv_delete
.
----------------------------------------------------------------------
Ran 1 test in 176.677s

OK
```
```
nosetests tests/foreman/ui/test_discoveryrule.py -m test_positive_delete_discovery_rule
.
----------------------------------------------------------------------
Ran 1 test in 165.295s

OK
```
```
nosetests tests/foreman/ui/test_domain.py -m test_delete_domain
.
----------------------------------------------------------------------
Ran 1 test in 22.444s

OK
```
```
nosetests tests/foreman/ui/test_environment.py -m test_positive_delete_env
.
----------------------------------------------------------------------
Ran 1 test in 42.736s

OK
```
```
nosetests tests/foreman/ui/test_gpgkey.py -m test_positive_delete_for_uploaded_content
.
----------------------------------------------------------------------
Ran 1 test in 167.289s

OK

nosetests tests/foreman/ui/test_gpgkey.py -m test_positive_delete_for_pasted_content
.
----------------------------------------------------------------------
Ran 1 test in 215.631s

OK

nosetests tests/foreman/ui/test_gpgkey.py -m test_key_associate_15
.
----------------------------------------------------------------------
Ran 1 test in 70.726s

OK

nosetests tests/foreman/ui/test_gpgkey.py -m test_key_associate_16
.
----------------------------------------------------------------------
Ran 1 test in 81.877s

OK

nosetests tests/foreman/ui/test_gpgkey.py -m test_key_associate_17
.
----------------------------------------------------------------------
Ran 1 test in 88.845s

OK
```
```
nosetests tests/foreman/ui/test_hw_model.py -m test_positive_delete
S
----------------------------------------------------------------------
Ran 1 test in 46.032s

OK (SKIP=1)
```
```
nosetests tests/foreman/ui/test_hostgroup.py -m test_delete_hostgroup
.
----------------------------------------------------------------------
Ran 1 test in 77.444s

OK
```
```
nosetests tests/foreman/ui/test_ldapauthsource.py -m test_positive_delete_ldap_auth_withad
.
----------------------------------------------------------------------
Ran 1 test in 196.968s

OK
```
```
nosetests tests/foreman/ui/test_medium.py -m test_positive_delete
.
----------------------------------------------------------------------
Ran 1 test in 27.539s

OK
```
```
nosetests tests/foreman/ui/test_operatingsys.py -m test_positive_delete
.
----------------------------------------------------------------------
Ran 1 test in 33.183s

OK
```
```
nosetests tests/foreman/ui/test_partitiontable.py -m test_positive_delete
S
----------------------------------------------------------------------
Ran 1 test in 43.458s

OK (SKIP=1)
```
```
nosetests tests/foreman/ui/test_products.py -m test_positive_delete
.
----------------------------------------------------------------------
Ran 1 test in 219.233s

OK
```
```
nosetests tests/foreman/ui/test_puppet_classes.py -m test_positive_delete
.
----------------------------------------------------------------------
Ran 1 test in 79.033s

OK
```
```
nosetests tests/foreman/ui/test_repository.py -m test_positive_delete
.
----------------------------------------------------------------------
Ran 1 test in 288.601s

OK
```
```
nosetests tests/foreman/ui/test_role.py -m test_positive_delete
.
----------------------------------------------------------------------
Ran 1 test in 140.155s

OK
```
```
nosetests tests/foreman/ui/test_subnet.py -m test_positive_delete
.
----------------------------------------------------------------------
Ran 1 test in 94.035s

OK

nosetests tests/foreman/ui/test_subnet.py -m test_negative_delete
.
----------------------------------------------------------------------
Ran 1 test in 25.689s

OK
```
```
nosetests tests/foreman/ui/test_syncplan.py -m test_positive_delete
.
----------------------------------------------------------------------
Ran 1 test in 144.361s

OK
```
```
nosetests tests/foreman/ui/test_template.py -m test_positive_delete
.
----------------------------------------------------------------------
Ran 1 test in 108.324s

OK
```
```
nosetests tests/foreman/ui/test_trend.py -m test_positive_delete
.
----------------------------------------------------------------------
Ran 1 test in 29.338s

OK
```
```
nosetests tests/foreman/ui/test_user.py -m test_positive_delete_user
.S
----------------------------------------------------------------------
Ran 2 tests in 197.374s

OK (SKIP=1)
```
```
nosetests tests/foreman/ui/test_subscription.py -m test_positive_delete
.
----------------------------------------------------------------------
Ran 1 test in 95.796s

OK
```