### PR TITLE
Fix typo for hostgroup class

### DIFF
--- a/robottelo/constants.py
+++ b/robottelo/constants.py
@@ -723,7 +723,7 @@ OSCAP_PROFILE = {
 
 SEARCH_EXCEPTIONS_LIST = [
     'ComputeResource',
-    'HostGroup',
+    'Hostgroup',
     'Location',
     'OpenScapContent',
     'OpenScapPolicy',


### PR DESCRIPTION
General test:
```
# nosetests tests/foreman/ui/test_location.py:Location.test_remove_hostgroup
.
----------------------------------------------------------------------
Ran 1 test in 214.615s

OK
```


Tested specifically with `host_grp_name = "<frameset123>QwnzbSDnvoalN</frameset123>"`
```
----------------------------------------------------------------------
Ran 1 test in 34.038s

OK
```