### PR TITLE
Fixes ui test failure for location - test_auto_search

### DIFF
--- a/robottelo/ui/base.py
+++ b/robottelo/ui/base.py
@@ -438,6 +438,9 @@ class Base(object):
         self.wait_for_ajax()
         strategy, value = common_locators['auto_search']
         self.click((strategy, value % name))
+        # Intentionally clicking second time because sometimes first time
+        # click just selects/highlights the item but not clicking it
+        self.click((strategy, value % name))
         self.click(common_locators['search_button'])
         entity_elem = self.wait_until_element((strategy1, value1 % name))
         return entity_elem


### PR DESCRIPTION
Closed #3098 

Sometimes clicking on an unordered list just highlights the list and not selecting it.  This pr fixes it by clicking it second time to make sure that the unordered list item is selected for sure.

Test results:
```sh
# nosetests tests/foreman/ui/test_location.py:Location.test_auto_search
.
----------------------------------------------------------------------
Ran 1 test in 21.760s

OK

# nosetests tests/foreman/ui/test_org.py:Org.test_auto_search
.
----------------------------------------------------------------------
Ran 1 test in 13.626s

OK
```