### PR TITLE
Skip tests that require a VM if not properly configure

### DIFF
--- a/tests/foreman/cli/test_contenthost.py
+++ b/tests/foreman/cli/test_contenthost.py
@@ -30,7 +30,13 @@ from robottelo.constants import (
     REPOSET,
 )
 from robottelo.datafactory import invalid_values_list, generate_strings_list
-from robottelo.decorators import run_only_on, skip_if_bug_open, tier1, tier2
+from robottelo.decorators import (
+    run_only_on,
+    skip_if_bug_open,
+    skip_if_not_set,
+    tier1,
+    tier2,
+)
 from robottelo.test import CLITestCase
 from robottelo.vm import VirtualMachine
 
@@ -401,6 +407,7 @@ class TestCHKatelloAgent(CLITestCase):
     activation_key = None
 
     @classmethod
+    @skip_if_not_set('clients')
     def setUpClass(cls):
         """Create Org, Lifecycle Environment, Content View, Activation key
 

--- a/tests/foreman/longrun/test_inc_updates.py
+++ b/tests/foreman/longrun/test_inc_updates.py
@@ -14,7 +14,7 @@ from robottelo.api.utils import (
 )
 from robottelo.cli.contentview import ContentView as ContentViewCLI
 from robottelo.constants import PRD_SETS
-from robottelo.decorators import run_only_on, skip_if_bug_open
+from robottelo.decorators import run_only_on, skip_if_bug_open, skip_if_not_set
 from robottelo.test import TestCase
 from robottelo.vm import VirtualMachine
 
@@ -23,6 +23,7 @@ class TestIncrementalUpdate(TestCase):
     """Tests for the Incremental Update feature"""
 
     @classmethod
+    @skip_if_not_set('clients')
     def setUpClass(cls):
         """Creates all the pre-requisites for the Incremental updates test"""
         super(TestIncrementalUpdate, cls).setUpClass()

--- a/tests/foreman/longrun/test_oscap.py
+++ b/tests/foreman/longrun/test_oscap.py
@@ -19,7 +19,7 @@ from robottelo.constants import (
     REPOS,
     REPOSET,
 )
-from robottelo.decorators import run_only_on
+from robottelo.decorators import run_only_on, skip_if_not_set
 from robottelo.test import UITestCase
 from robottelo.ui.factory import set_context, make_hostgroup, make_oscappolicy
 from robottelo.ui.session import Session
@@ -30,6 +30,7 @@ class OpenScap(UITestCase):
     """Implements Product tests in UI"""
 
     @classmethod
+    @skip_if_not_set('clients')
     def setUpClass(cls):
         """ Create an organization, environment, content view and activation key.
 

--- a/tests/foreman/rhai/test_rhai.py
+++ b/tests/foreman/rhai/test_rhai.py
@@ -7,6 +7,7 @@ from nailgun import entities
 from robottelo import manifests
 from robottelo.api.utils import upload_manifest
 from robottelo.constants import DEFAULT_SUBSCRIPTION_NAME
+from robottelo.decorators import skip_if_not_set
 from robottelo.test import UITestCase
 from robottelo.ui.locators import locators
 from robottelo.ui.navigator import Navigator
@@ -55,6 +56,7 @@ class RHAITestCase(UITestCase):
         cls.ak_name = activation_key.name
         cls.org_name = org.name
 
+    @skip_if_not_set('clients')
     def test_client_registration_to_rhai(self):
         """@Test: Check for client registration to redhat-access-insights
         service.
@@ -100,6 +102,7 @@ class RHAITestCase(UITestCase):
                 locators['insights.org_selection_msg']).text
             self.assertIn("Organization Selection Required", result)
 
+    @skip_if_not_set('clients')
     def test_unregister_system_from_rhai(self):
         """@Test: Verify that 'Unregister' a system from RHAI works correctly
 

--- a/tests/foreman/rhai/test_rhai_client.py
+++ b/tests/foreman/rhai/test_rhai_client.py
@@ -5,6 +5,7 @@ from nailgun import entities
 from robottelo import manifests
 from robottelo.api.utils import upload_manifest
 from robottelo.constants import DEFAULT_SUBSCRIPTION_NAME
+from robottelo.decorators import skip_if_not_set
 from robottelo.test import TestCase
 from robottelo.vm import VirtualMachine
 
@@ -12,6 +13,7 @@ from robottelo.vm import VirtualMachine
 class RHAIClientTestCase(TestCase):
 
     @classmethod
+    @skip_if_not_set('clients')
     def setUpClass(cls):  # noqa
         super(RHAIClientTestCase, cls).setUpClass()
         # Create a new organization with prefix 'insights'

--- a/tests/foreman/smoke/test_api_smoke.py
+++ b/tests/foreman/smoke/test_api_smoke.py
@@ -21,7 +21,11 @@ from robottelo.constants import (
     REPOS,
     REPOSET,
 )
-from robottelo.decorators import bz_bug_is_open, skip_if_bug_open
+from robottelo.decorators import (
+    bz_bug_is_open,
+    skip_if_bug_open,
+    skip_if_not_set,
+)
 from robottelo.helpers import get_nailgun_config
 from robottelo.vm import VirtualMachine
 from robottelo.test import TestCase
@@ -973,6 +977,7 @@ class TestSmoke(TestCase):
             subnet=subnet
         ).create()
 
+    @skip_if_not_set('clients')
     def test_end_to_end(self):
         """@Test: Perform end to end smoke tests using RH repos.
 

--- a/tests/foreman/smoke/test_cli_smoke.py
+++ b/tests/foreman/smoke/test_cli_smoke.py
@@ -34,6 +34,7 @@ from robottelo.constants import (
 )
 from robottelo.config import settings
 from robottelo.datafactory import generate_strings_list
+from robottelo.decorators import skip_if_not_set
 from robottelo.helpers import get_server_software
 from robottelo.test import CLITestCase
 from robottelo.vm import VirtualMachine
@@ -384,6 +385,7 @@ class TestSmoke(CLITestCase):
 
         return entity.info(attrs)
 
+    @skip_if_not_set('clients')
     def test_end_to_end(self):
         """@Test: Perform end to end smoke tests using RH repos.
 

--- a/tests/foreman/smoke/test_ui_smoke.py
+++ b/tests/foreman/smoke/test_ui_smoke.py
@@ -21,7 +21,7 @@ from robottelo.constants import (
     SAT6_TOOLS_TREE,
     FAKE_6_PUPPET_REPO,
 )
-from robottelo.decorators import bz_bug_is_open
+from robottelo.decorators import bz_bug_is_open, skip_if_not_set
 from robottelo.ssh import upload_file
 from robottelo.test import UITestCase
 from robottelo.ui.factory import (
@@ -260,6 +260,7 @@ class TestSmoke(UITestCase):
             make_hostgroup(session, name=hostgroup_name)
             self.assertIsNotNone(self.hostgroup.search(hostgroup_name))
 
+    @skip_if_not_set('clients')
     def test_end_to_end(self):
         """@Test: Perform end to end smoke tests using RH repos.
 
@@ -356,6 +357,7 @@ class TestSmoke(UITestCase):
                 result = vm.run(u'rpm -q {0}'.format(package_name))
                 self.assertEqual(result.return_code, 0)
 
+    @skip_if_not_set('clients')
     def test_puppet_install(self):
         """@Test: Perform puppet end to end smoke tests using RH repos.
 

--- a/tests/foreman/ui/test_gpgkey.py
+++ b/tests/foreman/ui/test_gpgkey.py
@@ -17,6 +17,7 @@ from robottelo.datafactory import generate_strings_list
 from robottelo.decorators import (
     run_only_on,
     skip_if_bug_open,
+    skip_if_not_set,
     stubbed,
     tier1,
     tier2,
@@ -400,6 +401,7 @@ class GPGKey(UITestCase):
 
     @run_only_on('sat')
     @tier3
+    @skip_if_not_set('clients')
     def test_positive_consume_content_using_repo(self):
         """@test: Hosts can install packages using gpg key associated with
         single custom repository


### PR DESCRIPTION
Added a decorator that allows us to skip a test if a Virtual
Machine is required but the system is not configured to handle
virtualization.