### PR TITLE
Add coverage for User entity in WebUI

### DIFF
--- a/robottelo/constants.py
+++ b/robottelo/constants.py
@@ -729,3 +729,22 @@ SEARCH_EXCEPTIONS_LIST = [
     'OpenScapPolicy',
     'Org',
 ]
+
+ROLES = [
+    'Access Insights Admin',
+    'Access Insights Viewer',
+    'Boot disk access',
+    'Discovery Manager',
+    'Discovery Reader',
+    'Edit compliance policies',
+    'Edit hosts',
+    'Edit partition tables',
+    'Red Hat Access Logs',
+    'Site manager',
+    'Tasks Manager',
+    'Tasks Reader',
+    'View compliance reports',
+    'View hosts',
+    'Manager',
+    'Viewer',
+]

--- a/robottelo/ui/factory.py
+++ b/robottelo/ui/factory.py
@@ -294,17 +294,18 @@ def make_domain(session, org=None, loc=None, force_context=True, **kwargs):
 def make_user(session, org=None, loc=None, force_context=True, **kwargs):
     """Creates a user"""
 
-    password = gen_string("alpha", 6)
+    password = gen_string('alpha', 6)
 
     create_args = {
+        u'admin': False,
         u'username': None,
         u'email': gen_email(),
         u'password1': password,
         u'password2': password,
         u'authorized_by': u'INTERNAL',
         u'locale': None,
-        u'first_name': gen_string("alpha", 6),
-        u'last_name': gen_string("alpha", 6),
+        u'first_name': gen_string('alpha'),
+        u'last_name': gen_string('alpha'),
         u'roles': None,
         u'locations': None,
         u'organizations': None,
@@ -312,6 +313,7 @@ def make_user(session, org=None, loc=None, force_context=True, **kwargs):
         u'select': True,
         u'default_org': None,
         u'default_loc': None,
+        u'submit': True,
     }
     page = session.nav.go_to_users
     core_factory(create_args, kwargs, session, page,

--- a/robottelo/ui/locators.py
+++ b/robottelo/ui/locators.py
@@ -641,10 +641,12 @@ common_locators = LocatorDict({
         By.XPATH, "//input[@checked='checked']/parent::label"),
     "entity_select": (
         By.XPATH,
-        "//div[@class='ms-selectable']//span[contains(.,'%s')]"),
+        ("//div[@class='ms-selectable']//"
+         "li[not(contains(@style, 'display: none'))]/span[contains(.,'%s')]")),
     "entity_deselect": (
         By.XPATH,
-        "//div[@class='ms-selection']//span[contains(.,'%s')]"),
+        ("//div[@class='ms-selection']//"
+         "li[not(contains(@style, 'display: none'))]/span[contains(.,'%s')]")),
     "entity_checkbox": (
         By.XPATH,
         "//label[normalize-space(.)='%s']/input[@type='checkbox']"),
@@ -671,6 +673,7 @@ common_locators = LocatorDict({
     "search": (By.ID, "search"),
     "auto_search": (By.XPATH, "//ul[@id='ui-id-1']/li/a[contains(., '%s')]"),
     "search_button": (By.XPATH, "//button[contains(@type,'submit')]"),
+    "cancel_form": (By.XPATH, "//a[text()='Cancel']"),
     "submit": (By.NAME, "commit"),
     "filter": (By.XPATH,
                ("//div[@id='ms-%s_ids']"
@@ -1038,6 +1041,7 @@ locators = LocatorDict({
     "users.password": (By.ID, "user_password"),
     "users.password_confirmation": (By.ID, "user_password_confirmation"),
     "users.user": (By.XPATH, "//a[contains(., '%s')]"),
+    "users.table_value": (By.XPATH, "//td[contains(., '%s')]"),
     "users.default_org": (By.ID, "user_default_organization_id"),
     "users.default_loc": (By.ID, "user_default_location_id"),
     "users.delete": (

--- a/tests/foreman/ui/test_host.py
+++ b/tests/foreman/ui/test_host.py
@@ -5,7 +5,7 @@ from nailgun import entities, entity_mixins
 from robottelo.api.utils import promote
 from robottelo.config import settings
 from robottelo.constants import ENVIRONMENT
-from robottelo.decorators import run_only_on
+from robottelo.decorators import run_only_on, stubbed
 from robottelo.test import UITestCase
 from robottelo.ui.base import Base
 from robottelo.ui.factory import make_host
@@ -378,3 +378,25 @@ class Host(UITestCase, Base):
             # Delete host
             self.hosts.delete(
                 u'{0}.{1}'.format(host.name, host.domain.name))
+
+    @stubbed()
+    def test_positive_create_with_user(self):
+        """@Test: Create Host with new user specified
+
+        @Feature: Host - Positive Create
+
+        @Assert: Host is created
+
+        @Status: Manual
+        """
+
+    @stubbed()
+    def test_positive_update_with_user(self):
+        """@Test: Update Host with new user specified
+
+        @Feature: Host - Positive Update
+
+        @Assert: Host is updated
+
+        @Status: Manual
+        """

--- a/tests/foreman/ui/test_user.py
+++ b/tests/foreman/ui/test_user.py
@@ -1,11 +1,17 @@
 # -*- encoding: utf-8 -*-
 """Test class for Users UI"""
 
+import random
 from fauxfactory import gen_string
 from nailgun import entities
-from robottelo.constants import LANGUAGES
-from robottelo.datafactory import invalid_names_list, invalid_values_list
-from robottelo.decorators import run_only_on, skip_if_bug_open, stubbed
+from robottelo.constants import DEFAULT_ORG, LANGUAGES, ROLES
+from robottelo.datafactory import (
+    invalid_emails_list,
+    invalid_names_list,
+    invalid_values_list,
+    valid_emails_list,
+)
+from robottelo.decorators import stubbed, tier1, tier2
 from robottelo.test import UITestCase
 from robottelo.ui.factory import make_user
 from robottelo.ui.locators import common_locators, locators, tab_locators
@@ -31,218 +37,89 @@ def valid_strings(len1=10):
 
 
 class User(UITestCase):
-    """ Implements Users tests in UI
+    """Implements Users tests in UI"""
 
-    [1] Positive Name variations - Alpha, Numeric, Alphanumeric, Symbols,
-    Latin1, Multibyte, Max length,  Min length, Max_db_size, html, css,
-    javascript, url, shell commands, sql, spaces in name
-
-    [2] Negative Name Variations -  Blank, Greater than Max Length,
-    Lesser than Min Length, Greater than Max DB size
-
-    """
-
-    def test_positive_delete_user(self):
-        """@Test: Delete a User
-
-        @Feature: User - Delete
-
-        @Assert: User is deleted
-
-        """
-        with Session(self.browser) as session:
-            for user_name in valid_strings():
-                with self.subTest(user_name):
-                    make_user(session, username=user_name)
-                    self.user.delete(user_name)
-
-    @skip_if_bug_open('bugzilla', 1139616)
-    def test_update_password(self):
-        """@Test: Update password for a user
-
-        @Feature: User - Update
-
-        @Assert: User password is updated
-
-        @BZ: 1139616
-
-        """
-        user_name = gen_string('alpha')
-        new_password = gen_string('alpha')
-        with Session(self.browser) as session:
-            # Role 'Site' meaning 'Site Manager' here
-            make_user(session, username=user_name, edit=True, roles=['Site'])
-            self.user.update(user_name, password=new_password)
-            self.login.logout()
-            self.login.login(user_name, new_password)
-            self.assertTrue(self.login.is_logged())
-
-    def test_update_role(self):
-        """@Test: Update role for a user
-
-        @Feature: User - Update
-
-        @Assert: User role is updated
-
-        """
-        strategy, value = common_locators['entity_deselect']
-        name = gen_string('alpha')
-        role_name = entities.Role().create_json()['name']
-        with Session(self.browser) as session:
-            make_user(session, username=name)
-            self.user.search(name).click()
-            self.user.click(tab_locators['users.tab_roles'])
-            element1 = self.user.wait_until_element((strategy,
-                                                     value % role_name))
-            self.assertIsNone(element1)
-            self.user.update(name, new_roles=[role_name])
-            self.user.search(name).click()
-            self.user.click(tab_locators['users.tab_roles'])
-            element2 = self.user.wait_until_element((strategy,
-                                                     value % role_name))
-            self.assertIsNotNone(element2)
-
-    def test_positive_create_user_different_usernames(self):
+    @tier1
+    def test_positive_create_with_usernames(self):
         """@Test: Create User for all variations of Username
 
         @Feature: User - Positive Create
 
-        @Steps:
-        1. Create User for all valid User name variation in [1] using
-        valid First Name, Surname, Email Address, Language, authorized by
-
-        @Assert: User is created
-
+        @Assert: User is created successfully
         """
         with Session(self.browser) as session:
             for user_name in valid_strings():
                 with self.subTest(user_name):
                     make_user(session, username=user_name)
-                    self.assertIsNotNone(
-                        self.user.search(user_name))
+                    self.assertIsNotNone(self.user.search(user_name))
 
-    def test_positive_create_user_different_first_names(self):
+    @tier1
+    def test_positive_create_with_first_names(self):
         """@Test: Create User for all variations of First Name
 
         @Feature: User - Positive Create
 
-        @Steps:
-        1. Create User for all valid First Name variation in [1] using
-        valid Username, Surname, Email Address, Language, authorized by
-
-        @Assert: User is created
-
+        @Assert: User is created successfully
         """
         with Session(self.browser) as session:
             for first_name in valid_strings():
                 with self.subTest(first_name):
                     name = gen_string('alpha')
                     make_user(session, username=name, first_name=first_name)
-                    element = self.user.search(name)
-                    self.assertIsNotNone(element)
-                    element.click()
-                    self.assertEqual(
-                        first_name,
-                        self.user.wait_until_element(
-                            locators['users.firstname']).get_attribute('value')
-                    )
+                    self.user.validate_user(name, 'firstname', first_name)
 
-    def test_positive_create_user_different_surnames(self):
+    @tier1
+    def test_positive_create_with_surnames(self):
         """@Test: Create User for all variations of Surname
 
         @Feature: User - Positive Create
 
-        @Steps:
-        1. Create User for all valid Surname variation in [1] using
-        valid User name, First Name, Email Address, Language, authorized by
-
-        @Assert: User is created
-
+        @Assert: User is created successfully
         """
         with Session(self.browser) as session:
             for last_name in valid_strings(50):
                 with self.subTest(last_name):
                     name = gen_string('alpha')
                     make_user(session, username=name, last_name=last_name)
-                    element = self.user.search(name)
-                    self.assertIsNotNone(element)
-                    element.click()
-                    self.assertEqual(
-                        last_name,
-                        self.user.wait_until_element(
-                            locators['users.lastname']).get_attribute('value')
-                    )
+                    self.user.validate_user(name, 'lastname', last_name)
 
-    @stubbed()
-    def test_positive_create_user_different_emails(self):
+    @tier1
+    def test_positive_create_with_emails(self):
         """@Test: Create User for all variations of Email Address
 
         @Feature: User - Positive Create
 
-        @Steps:
-        1. Create User for all valid Email Address variation in [1] using
-        valid Username, First Name, Surname, Language, authorized by
-
-        @Assert: User is created
-
-        @Status: Manual
-
+        @Assert: User is created successfully
         """
+        with Session(self.browser) as session:
+            for email in valid_emails_list():
+                with self.subTest(email):
+                    name = gen_string('alpha')
+                    make_user(session, username=name, email=email)
+                    self.user.validate_user(name, 'email', email)
 
-    def test_positive_create_user_different_languages(self):
+    @tier1
+    def test_positive_create_with_languages(self):
         """@Test: Create User for all variations of Language
 
         @Feature: User - Positive Create
 
-        @Steps:
-        1. Create User for all valid Language variations using
-        valid Username, First Name, Surname, Email Address, authorized by
-
-        @Assert: User is created
-
+        @Assert: User is created successfully
         """
         with Session(self.browser) as session:
             for language in LANGUAGES:
                 with self.subTest(language):
                     name = gen_string('alpha')
                     make_user(session, username=name, locale=language)
-                    element = self.user.search(name)
-                    self.assertIsNotNone(element)
-                    element.click()
-                    self.assertEqual(
-                        language,
-                        self.user.wait_until_element(
-                            locators['users.selected_lang']
-                        ).get_attribute('value')
-                    )
+                    self.user.validate_user(name, 'language', language, False)
 
-    @stubbed()
-    def test_positive_create_user_internal(self):
-        """@Test: Create User by choosing Authorized by - INTERNAL
-
-        @Feature: User - Positive Create
-
-        @Steps:
-        1. Create User by choosing Authorized by - INTERNAL using
-        valid Password/Verify fields
-
-        @Assert: User is created
-
-        @Status: Manual
-
-        """
-
-    def test_positive_create_user_different_pass(self):
+    @tier1
+    def test_positive_create_with_passwords(self):
         """@Test: Create User for all variations of Password
 
         @Feature: User - Positive Create
 
-        @Steps:
-        1. Create User for all valid Password variation in [1] using valid
-        Username, First Name, Surname, Email Address, Language, authorized by
-
-        @Assert: User is created
-
+        @Assert: User is created successfully
         """
         test_data = valid_strings()
         #  List is extended to test additional password data points
@@ -264,28 +141,26 @@ class User(UITestCase):
                     )
                     self.assertIsNotNone(self.user.search(name))
 
-    @stubbed()
-    def test_positive_create_user_admin(self):
+    @tier1
+    def test_positive_create_admin(self):
         """@Test: Create an Admin user
 
         @Feature: User - Positive Create
 
-        @Assert: Admin User is created
-
-        @Status: Manual
-
+        @Assert: Admin User is created successfully
         """
+        user_name = gen_string('alpha')
+        with Session(self.browser) as session:
+            make_user(session, username=user_name, admin=True)
+            self.assertIsNotNone(self.user.search(user_name))
 
-    def test_positive_create_user_with_one_role(self):
+    @tier1
+    def test_positive_create_with_one_role(self):
         """@Test: Create User with one role
 
         @Feature: User - Positive Create
 
-        @Steps:
-        1. Create User with one role assigned to it
-
-        @Assert: User is created
-
+        @Assert: User is created successfully
         """
         strategy, value = common_locators['entity_deselect']
         name = gen_string('alpha')
@@ -294,20 +169,17 @@ class User(UITestCase):
             make_user(session, username=name, roles=[role.name], edit=True)
             self.user.search(name).click()
             self.user.click(tab_locators['users.tab_roles'])
-            element = self.user.wait_until_element((strategy,
-                                                    value % role.name))
+            element = self.user.wait_until_element(
+                (strategy, value % role.name))
             self.assertIsNotNone(element)
 
-    def test_positive_create_user_with_multiple_roles(self):
+    @tier2
+    def test_positive_create_with_multiple_roles(self):
         """@Test: Create User with multiple roles
 
         @Feature: User - Positive Create
 
-        @Steps:
-        1. Create User with multiple roles assigned to it
-
-        @Assert: User is created
-
+        @Assert: User is created successfully
         """
         strategy, value = common_locators['entity_deselect']
         name = gen_string('alpha')
@@ -316,227 +188,41 @@ class User(UITestCase):
         for role in [role1, role2]:
             entities.Role(name=role).create()
         with Session(self.browser) as session:
-            make_user(session, username=name, roles=[role1, role2],
-                      edit=True)
+            make_user(session, username=name, roles=[role1, role2], edit=True)
             self.user.search(name).click()
             self.user.wait_for_ajax()
             self.user.click(tab_locators['users.tab_roles'])
             for role in [role1, role2]:
-                element = self.user.wait_until_element((strategy,
-                                                        value % role))
+                element = self.user.wait_until_element(
+                    (strategy, value % role))
                 self.assertIsNotNone(element)
 
-    @stubbed()
-    def test_positive_create_user_11(self):
+    @tier2
+    def test_positive_create_with_all_roles(self):
         """@Test: Create User and assign all available roles to it
 
         @Feature: User - Positive Create
 
-        @Steps:
-        1. Create User with all available roles assigned to it
-
-        @Assert: User is created
-
-        @Status: Manual
-
+        @Assert: User is created successfully
         """
-
-    @stubbed()
-    def test_positive_create_user_12(self):
-        """@Test: Create User with one owned host
-
-        @Feature: User - Positive Create
-
-        @Steps:
-        1. Create User with one owned host assigned to it
-
-        @Assert: User is created
-
-        @Status: Manual
-
-        """
-
-    @stubbed()
-    def test_positive_create_user_13(self):
-        """@Test: Create User with mutiple owned hosts
-
-        @Feature: User - Positive Create
-
-        @Steps:
-        1. Create User with multiple owned hosts assigned to it
-
-        @Assert: User is created
-
-        @Status: Manual
-
-        """
-
-    @stubbed()
-    def test_positive_create_user_14(self):
-        """@Test: Create User with all owned hosts
-
-        @Feature: User - Positive Create
-
-        @Steps:
-        1. Create User with all owned hosts assigned to it
-
-        @Assert: User is created
-
-        @Status: Manual
-
-        """
-
-    @run_only_on('sat')
-    @stubbed()
-    def test_positive_create_user_15(self):
-        """@Test: Create User with one Domain host
-
-        @Feature: User - Positive Create
-
-        @Steps:
-        1. Create User with one Domain host assigned to it
-
-        @Assert: User is created
-
-        @Status: Manual
-
-        """
-
-    @run_only_on('sat')
-    @stubbed()
-    def test_positive_create_user_16(self):
-        """@Test: Create User with mutiple Domain hosts
-
-        @Feature: User - Positive Create
-
-        @Steps:
-        1. Create User with multiple Domain hosts assigned to it
-
-        @Assert: User is created
-
-        @Status: Manual
-
-        """
-
-    @run_only_on('sat')
-    @stubbed()
-    def test_positive_create_user_17(self):
-        """@Test: Create User with all Domain hosts
-
-        @Feature: User - Positive Create
-
-        @Steps:
-        1. Create User with all Domain hosts assigned to it
-
-        @Assert: User is created
-
-        @Status: Manual
-
-        """
-
-    @run_only_on('sat')
-    @stubbed()
-    def test_positive_create_user_18(self):
-        """@Test: Create User with one Compute Resource
-
-        @Feature: User - Positive Create
-
-        @Steps:
-        1. Create User associated with one Compute Resource
-
-        @Assert: User is created
-
-        @Status: Manual
-
-        """
-
-    @run_only_on('sat')
-    @stubbed()
-    def test_positive_create_user_19(self):
-        """@Test: Create User with mutiple Compute Resources
-
-        @Feature: User - Positive Create
-
-        @Steps:
-        1. Create User associated with multiple Compute Resources
-
-        @Assert: User is created
-
-        @Status: Manual
-
-        """
-
-    @run_only_on('sat')
-    @stubbed()
-    def test_positive_create_user_20(self):
-        """@Test: Create User with all Compute Resources
-
-        @Feature: User - Positive Create
-
-        @Steps:
-        1. Create User associated with all Compute Resources
-
-        @Assert: User is created
-
-        @Status: Manual
-
-        """
-
-    @run_only_on('sat')
-    @stubbed()
-    def test_positive_create_user_21(self):
-        """@Test: Create User with one Host group
-
-        @Feature: User - Positive Create
-
-        @Steps:
-        1. Create User associated with one Host group
-
-        @Assert: User is created
-
-        @Status: Manual
-
-        """
-
-    @run_only_on('sat')
-    @stubbed()
-    def test_positive_create_user_22(self):
-        """@Test: Create User with multiple Host groups
-
-        @Feature: User - Positive Create
-
-        @Steps:
-        1. Create User associated with multiple Host groups
-
-        @Assert: User is created
-
-        @Status: Manual
-
-        """
-
-    @run_only_on('sat')
-    @stubbed()
-    def test_positive_create_user_23(self):
-        """@Test: Create User with all Host groups
-
-        @Feature: User - Positive Create
-
-        @Steps:
-        1. Create User associated with all available Host groups
-
-        @Assert: User is created
-
-        @Status: Manual
-
-        """
-
-    def test_positive_create_user_with_one_org(self):
+        strategy, value = common_locators['entity_deselect']
+        name = gen_string('alpha')
+        with Session(self.browser) as session:
+            make_user(session, username=name, roles=ROLES, edit=True)
+            self.user.search(name).click()
+            self.user.wait_for_ajax()
+            self.user.click(tab_locators['users.tab_roles'])
+            for role in ROLES:
+                self.assertIsNotNone(self.user.wait_until_element(
+                    (strategy, value % role)))
+
+    @tier1
+    def test_positive_create_with_one_org(self):
         """@Test: Create User associated to one Org
 
         @Feature: User - Positive Create
 
-        @Assert: User is created
-
+        @Assert: User is created successfully
         """
         strategy, value = common_locators['entity_deselect']
         name = gen_string('alpha')
@@ -547,17 +233,17 @@ class User(UITestCase):
                 session, username=name, organizations=[org_name], edit=True)
             self.user.search(name).click()
             self.user.click(tab_locators['users.tab_organizations'])
-            element = self.user.wait_until_element((strategy,
-                                                    value % org_name))
+            element = self.user.wait_until_element(
+                (strategy, value % org_name))
             self.assertIsNotNone(element)
 
-    def test_positive_create_user_with_multiple_orgs(self):
+    @tier2
+    def test_positive_create_with_multiple_orgs(self):
         """@Test: Create User associated to multiple Orgs
 
         @Feature: User - Positive Create
 
-        @Assert: User is created
-
+        @Assert: User is created successfully
         """
         strategy, value = common_locators['entity_deselect']
         name = gen_string('alpha')
@@ -574,48 +260,17 @@ class User(UITestCase):
             )
             self.user.search(name).click()
             self.user.click(tab_locators['users.tab_organizations'])
-            for org_name in [org_name1, org_name2]:
-                element = self.user.wait_until_element((strategy,
-                                                        value % org_name))
+            for org_name in [org_name1, org_name2, DEFAULT_ORG]:
+                element = self.user.wait_until_element(
+                    (strategy, value % org_name))
                 self.assertIsNotNone(element)
 
     @stubbed()
-    def test_positive_create_user_26(self):
-        """@Test: Create User associated to all available Orgs
+    def test_positive_create_in_ldap_modes(self):
+        """@Test: Create User in supported ldap modes - (Active Driectory, IPA,
+        Posix)
 
         @Feature: User - Positive Create
-
-        @Assert: User is created
-
-        @Status: Manual
-
-        """
-
-    @run_only_on('sat')
-    @stubbed()
-    def test_positive_create_user_27(self):
-        """@Test: Create User with a new Fact filter
-
-        @Feature: User - Positive Create
-
-        @Steps:
-        1. Create User associating it to a new Fact filter
-
-        @Assert: User is created
-
-        @Status: Manual
-
-        """
-
-    @stubbed()
-    def test_positive_create_user_28(self):
-        """@Test: Create User in supported ldap modes
-
-        @Feature: User - Positive Create
-
-        @Steps:
-        1. Create User in all supported ldap modes - (Active Driectory,
-        IPA, Posix)
 
         @Assert: User is created without specifying the password
 
@@ -623,13 +278,13 @@ class User(UITestCase):
 
         """
 
-    def test_positive_create_user_with_default_org(self):
+    @tier1
+    def test_positive_create_with_default_org(self):
         """@Test: Create User and has default organization associated with it
 
         @Feature: User - Positive Create.
 
         @Assert: User is created with default Org selected.
-
         """
         strategy, value = common_locators['entity_deselect']
         name = gen_string('alpha')
@@ -640,16 +295,16 @@ class User(UITestCase):
                       edit=True, default_org=org_name)
             self.user.search(name).click()
             session.nav.click(tab_locators['users.tab_organizations'])
-            element = session.nav.wait_until_element((strategy,
-                                                      value % org_name))
+            element = session.nav.wait_until_element(
+                (strategy, value % org_name))
             self.assertIsNotNone(element)
-            org_element = session.nav.find_element(
-                locators['users.default_org'])
             # Fetches currently selected option in a normal select.
-            option = Select(org_element).first_selected_option
+            option = Select(session.nav.find_element(
+                locators['users.default_org'])).first_selected_option
             self.assertEqual(org_name, option.text)
 
-    def test_positive_create_user_default_location(self):
+    @tier1
+    def test_positive_create_with_default_location(self):
         """@Test: Create User and associate a default Location.
 
         @Feature: User - Positive Create
@@ -666,43 +321,41 @@ class User(UITestCase):
                       edit=True, default_loc=loc_name)
             self.user.search(name).click()
             session.nav.click(tab_locators['users.tab_locations'])
-            element = session.nav.wait_until_element((strategy,
-                                                      value % loc_name))
+            element = session.nav.wait_until_element(
+                (strategy, value % loc_name))
             self.assertIsNotNone(element)
-            loc_element = session.nav.find_element(
-                locators['users.default_loc'])
             # Fetches currently selected option in a normal select.
-            option = Select(loc_element).first_selected_option
+            option = Select(session.nav.find_element(
+                locators['users.default_loc'])).first_selected_option
             self.assertEqual(loc_name, option.text)
 
-    @stubbed()
-    def test_negative_create_user_1(self):
+    @tier1
+    def test_negative_create(self):
         """@Test:[UI ONLY] Enter all User creation details and Cancel
 
         @Feature: User - Positive Create
 
-        @Steps:
-        1. Enter all valid Username, First Name, Surname, Email Address,
-        Language, authorized by.
-        2. Click Cancel
-
         @Assert: User is not created
-
-        @Status: Manual
-
         """
+        user_name = gen_string('alpha')
+        with Session(self.browser) as session:
+            make_user(
+                session,
+                username=user_name,
+                first_name=gen_string('alpha'),
+                last_name=gen_string('alpha'),
+                email=u'{0}@example.com'.format(gen_string('numeric')),
+                submit=False,
+            )
+            self.assertIsNone(self.user.search(user_name))
 
-    def test_negative_create_user_with_invalid_name(self):
+    @tier1
+    def test_negative_create_with_invalid_name(self):
         """@Test: Create User with invalid User Name
 
         @Feature: User - Negative Create
 
-        @Steps:
-        1. Create User for all invalid User names in [2]
-        using valid First Name, Surname, Email Address, Language, authorized by
-
         @Assert: User is not created. Appropriate error shown.
-
         """
         with Session(self.browser) as session:
             for user_name in invalid_values_list(interface='ui'):
@@ -713,17 +366,13 @@ class User(UITestCase):
                             common_locators['haserror'])
                     )
 
-    def test_negative_create_user_with_invalid_firstname(self):
+    @tier1
+    def test_negative_create_with_invalid_firstname(self):
         """@Test: Create User with invalid FirstName
 
         @Feature: User - Negative Create
 
-        @Steps:
-        1. Create User for all invalid First name in [2]
-        using valid User name, Surname, Email Address, Language, authorized by
-
         @Assert: User is not created. Appropriate error shown.
-
         """
         with Session(self.browser) as session:
             # invalid_values_list is not used here because first name is an
@@ -740,17 +389,13 @@ class User(UITestCase):
                             common_locators['haserror'])
                     )
 
-    def test_negative_create_user_with_invalid_surname(self):
+    @tier1
+    def test_negative_create_with_invalid_surname(self):
         """@Test: Create User with invalid Surname
 
         @Feature: User - Negative Create
 
-        @Steps:
-        1. Create User for all invalid Surname in [2]
-        using valid Username, First Name Email Address, Language, authorized by
-
         @Assert: User is not created. Appropriate error shown.
-
         """
         with Session(self.browser) as session:
             # invalid_values_list is not used here because sur name is an
@@ -767,51 +412,44 @@ class User(UITestCase):
                             common_locators['haserror'])
                     )
 
-    @stubbed()
-    def test_negative_create_user_5(self):
+    @tier1
+    def test_negative_create_with_invalid_emails(self):
         """@Test: Create User with invalid Email Address
 
         @Feature: User - Negative Create
 
-        @Steps:
-        1. Create User for all invalid Email Address in [2]
-        using valid Username, First Name, Surname, Language, authorized by
-
         @Assert: User is not created. Appropriate error shown.
-
-        @Status: Manual
-
         """
+        with Session(self.browser) as session:
+            for email in invalid_emails_list():
+                with self.subTest(email):
+                    name = gen_string('alpha')
+                    make_user(session, username=name, email=email)
+                    self.assertIsNotNone(
+                        self.user.wait_until_element(
+                            common_locators['haserror'])
+                    )
 
-    def test_negative_create_user_with_blank_auth(self):
-        """@Test: Create User with blank Authorized by
+    @tier1
+    def test_negative_create_with_blank_auth(self):
+        """@Test: Create User with blank value for 'Authorized by' field
 
         @Feature: User - Negative Create
 
-        @Steps:
-        1. Create User with blank Authorized by
-        using valid Username, First Name, Surname, Email Address, Language
-
         @Assert: User is not created. Appropriate error shown.
-
         """
         with Session(self.browser) as session:
             make_user(session, username=gen_string('alpha'), authorized_by='')
-            error = self.user.wait_until_element(common_locators['haserror'])
-            self.assertIsNotNone(error)
+            self.assertIsNotNone(
+                self.user.wait_until_element(common_locators['haserror']))
 
-    def test_negative_create_user_with_wrong_pass_confirmation(self):
+    @tier1
+    def test_negative_create_with_wrong_pass_confirmation(self):
         """@Test: Create User with non-matching values in Password and verify
 
         @Feature: User - Negative Create
 
-        @Steps:
-        1. Create User with non-matching values in Password and verify
-        using valid Username, First Name, Surname, Email Address, Language,
-        authorized by - INTERNAL
-
         @Assert: User is not created. Appropriate error shown.
-
         """
         with Session(self.browser) as session:
             make_user(
@@ -820,23 +458,16 @@ class User(UITestCase):
                 password1=gen_string('alpha'),
                 password2=gen_string('alpha'),
             )
-            error = self.user.wait_until_element(common_locators['haserror'])
-            self.assertIsNotNone(error)
+            self.assertIsNotNone(
+                self.user.wait_until_element(common_locators['haserror']))
 
-    @skip_if_bug_open('bugzilla', 1139616)
-    def test_positive_update_user_username(self):
+    @tier1
+    def test_positive_update_username(self):
         """@Test: Update Username in User
 
         @Feature: User - Positive Update
 
-        @Steps:
-        1. Create User
-        2. Update User name for all variations in [1]
-
-        @Assert: User is updated
-
-        @BZ: 1139616
-
+        @Assert: User is updated successfully
         """
         name = gen_string('alpha')
         password = gen_string('alpha')
@@ -861,498 +492,305 @@ class User(UITestCase):
                     self.assertTrue(self.login.is_logged())
                     name = new_username  # for next iteration
 
-    @stubbed()
-    def test_positive_update_user_firstname(self):
-        """@Test: Update Firstname in User
+    @tier1
+    def test_positive_update_firstname(self):
+        """@Test: Update first name in User
 
         @Feature: User - Positive Update
 
-        @Steps:
-        1. Create User
-        2. Update Firstname name for all variations in [1]
-
-        @Assert: User is updated
-
-        @Status: Manual
-
+        @Assert: User is updated successful
         """
+        first_name = gen_string('alpha')
+        new_first_name = gen_string('alpha')
+        username = gen_string('alpha')
+        with Session(self.browser) as session:
+            make_user(session, username=username, first_name=first_name)
+            self.user.update(username, first_name=new_first_name)
+            self.user.validate_user(username, 'firstname', new_first_name)
 
-    @stubbed()
-    def test_positive_update_user_surname(self):
-        """@Test: Update Surname in User
+    @tier1
+    def test_positive_update_surname(self):
+        """@Test: Update surname in User
 
         @Feature: User - Positive Update
 
-        @Steps:
-        1. Create User
-        2. Update Surname for all variations in [1]
-
-        @Assert: User is updated
-
-        @Status: Manual
-
+        @Assert: User is updated successful
         """
+        last_name = gen_string('alpha')
+        new_last_name = gen_string('alpha')
+        username = gen_string('alpha')
+        with Session(self.browser) as session:
+            make_user(session, username=username, last_name=last_name)
+            self.user.update(username, last_name=new_last_name)
+            self.user.validate_user(username, 'lastname', new_last_name)
 
-    @stubbed()
-    def test_positive_update_user_email(self):
+    @tier1
+    def test_positive_update_email(self):
         """@Test: Update Email Address in User
 
         @Feature: User - Positive Update
 
-        @Steps:
-        1. Create User
-        2. Update Email Address for all variations in [1]
-
-        @Assert: User is updated
-
-        @Status: Manual
-
+        @Assert: User is updated successfully
         """
+        email = u'{0}@example.com'.format(gen_string('alpha'))
+        new_email = u'{0}@myexample.com'.format(gen_string('alpha'))
+        username = gen_string('alpha')
+        with Session(self.browser) as session:
+            make_user(session, username=username, email=email)
+            self.user.update(username, email=new_email)
+            self.user.validate_user(username, 'email', new_email)
 
-    @stubbed()
-    def test_positive_update_user_language(self):
+    @tier1
+    def test_positive_update_language(self):
         """@Test: Update Language in User
 
         @Feature: User - Positive Update
 
-        @Steps:
-        1. Create User
-        2. Update User with all different Language options
+        @Assert: User is updated successfully
+        """
+        locale = random.choice(LANGUAGES)
+        username = gen_string('alpha')
+        with Session(self.browser) as session:
+            make_user(session, username=username)
+            self.user.update(username, locale=locale)
+            self.user.validate_user(username, 'language', locale, False)
 
-        @Assert: User is updated
+    @tier1
+    def test_positive_update_password(self):
+        """@Test: Update password for a user
 
-        @Status: Manual
+        @Feature: User - Update
+
+        @Assert: User password is updated successfully
 
         """
+        user_name = gen_string('alpha')
+        new_password = gen_string('alpha')
+        with Session(self.browser) as session:
+            # Role 'Site' meaning 'Site Manager' here
+            make_user(session, username=user_name, edit=True, roles=['Site'])
+            self.user.update(user_name, password=new_password)
+            self.login.logout()
+            self.login.login(user_name, new_password)
+            self.assertTrue(self.login.is_logged())
 
-    @stubbed()
-    def test_positive_update_user_password(self):
-        """@Test: Update Password/Verify fields in User
-
-        @Feature: User - Positive Update
-
-        @Steps:
-        1. Create User
-        2. Update Password/Verify fields
-
-        @Assert: User is updated
-
-        @Status: Manual
-
-        """
-
-    @stubbed()
-    def test_positive_update_user_7(self):
+    @tier1
+    def test_positive_update_to_non_admin(self):
         """@Test: Convert an user from an admin user to non-admin user
 
         @Feature: User - Positive Update
 
-        @Steps:
-        1. Create User with Administrator rights
-        2. Update the User to remove Administrator rights
-
-        @Assert: User is updated
-
-        @Status: Manual
-
+        @Assert: User is updated and has proper admin role value
         """
+        user_name = gen_string('alpha')
+        with Session(self.browser) as session:
+            make_user(session, username=user_name, admin=True)
+            self.assertIsNotNone(self.user.search(user_name))
+            self.assertFalse(
+                self.user.user_admin_role_toggle(user_name, False))
 
-    @stubbed()
-    def test_positive_update_user_8(self):
+    @tier1
+    def test_positive_update_to_admin(self):
         """@Test: Convert a user to an admin user
 
         @Feature: User - Positive Update
 
-        @Steps:
-        1. Create a regular (non-admin) user
-        2. Update the User to add Administrator rights
+        @Assert: User is updated and has proper admin role value
+        """
+        user_name = gen_string('alpha')
+        with Session(self.browser) as session:
+            make_user(session, username=user_name, admin=False)
+            self.assertIsNotNone(self.user.search(user_name))
+            self.assertTrue(self.user.user_admin_role_toggle(user_name, True))
 
-        @Assert: User is updated
+    @tier1
+    def test_positive_update_role(self):
+        """@Test: Update role for a user
 
-        @Status: Manual
+        @Feature: User - Update
+
+        @Assert: User role is updated
 
         """
+        strategy, value = common_locators['entity_deselect']
+        name = gen_string('alpha')
+        role_name = entities.Role().create().name
+        with Session(self.browser) as session:
+            make_user(session, username=name)
+            self.user.search(name).click()
+            self.user.click(tab_locators['users.tab_roles'])
+            self.assertIsNone(
+                self.user.wait_until_element((strategy, value % role_name)))
+            self.user.update(name, new_roles=[role_name])
+            self.user.search(name).click()
+            self.user.click(tab_locators['users.tab_roles'])
+            self.assertIsNotNone(
+                self.user.wait_until_element((strategy, value % role_name)))
 
-    @stubbed()
-    def test_positive_update_user_9(self):
-        """@Test: Update User with one role
-
-        @Feature: User - Positive Update
-
-        @Steps:
-        1. Create User
-        2. Assign one role to the user
-
-        @Assert: User is updated
-
-        @Status: Manual
-
-        """
-
-    @stubbed()
-    def test_positive_update_user_10(self):
+    @tier2
+    def test_positive_update_with_multiple_roles(self):
         """@Test: Update User with multiple roles
 
         @Feature: User - Positive Update
 
-        @Steps:
-        1. Create User
-        2. Assign multiple roles to the user
-
-        @Assert: User is updated
-
-        @Status: Manual
-
+        @Assert: User is updated successfully
         """
+        strategy, value = common_locators['entity_deselect']
+        name = gen_string('alpha')
+        role_names = [
+            entities.Role().create().name
+            for _ in range(3)
+        ]
+        with Session(self.browser) as session:
+            make_user(session, username=name)
+            self.user.update(name, new_roles=role_names)
+            self.user.search(name).click()
+            self.user.click(tab_locators['users.tab_roles'])
+            for role in role_names:
+                self.assertIsNotNone(
+                    self.user.wait_until_element((strategy, value % role)))
 
-    @stubbed()
-    def test_positive_update_user_11(self):
+    @tier2
+    def test_positive_update_with_all_roles(self):
         """@Test: Update User with all roles
 
         @Feature: User - Positive Update
 
-        @Steps:
-        1. Create User
-        2. Assign all available roles to the user
-
-        @Assert: User is updated
-
-        @Status: Manual
-
+        @Assert: User is updated successfully
         """
-
-    @stubbed()
-    def test_positive_update_user_12(self):
-        """@Test: Update User with one owned host
-
-        @Feature: User - Positive Update
-
-        @Steps:
-        1. Create User
-        2. Assign one host to the user
-
-        @Assert: User is updated
-
-        @Status: Manual
-
-        """
-
-    @stubbed()
-    def test_positive_update_user_13(self):
-        """@Test: Update User with multiple owned hosts
-
-        @Feature: User - Positive Update
-
-        @Steps:
-        1. Create User
-        2. Assign multiple owned hosts to the user
-
-        @Assert: User is updated
-
-        @Status: Manual
-
-        """
-
-    @stubbed()
-    def test_positive_update_user_14(self):
-        """@Test: Update User with all owned hosts
-
-        @Feature: User - Positive Update
-
-        @Steps:
-        1. Create User
-        2. Assign all available owned hosts to the user
-
-        @Assert: User is updated
-
-        @Status: Manual
-
-        """
-
-    @run_only_on('sat')
-    @stubbed()
-    def test_positive_update_user_15(self):
-        """@Test: Update User with one Domain host
-
-        @Feature: User - Positive Update
-
-        @Steps:
-        1. Create User
-        2. Assign one Domain host to the User
-
-        @Assert: User is updated
-
-        @Status: Manual
-
-        """
-
-    @run_only_on('sat')
-    @stubbed()
-    def test_positive_update_user_16(self):
-        """@Test: Update User with multiple Domain hosts
-
-        @Feature: User - Positive Update
-
-        @Steps:
-        1. Create User
-        2. Assign multiple Domain hosts to the User
-
-        @Assert: User is updated
-
-        @Status: Manual
-
-        """
-
-    @run_only_on('sat')
-    @stubbed()
-    def test_positive_update_user_17(self):
-        """@Test: Update User with all Domain hosts
-
-        @Feature: User - Positive Update
-
-        @Steps:
-        1. Create User
-        2. Assign all Domain hosts to the User
-
-        @Assert: User is updated
-
-        @Status: Manual
-
-        """
-
-    @run_only_on('sat')
-    @stubbed()
-    def test_positive_update_user_18(self):
-        """@Test: Update User with one Compute Resource
-
-        @Feature: User - Positive Update
-
-        @Steps:
-        1. Create User
-        2. Assign one Compute Resource to the User
-
-        @Assert: User is updated
-
-        @Status: Manual
-
-        """
-
-    @run_only_on('sat')
-    @stubbed()
-    def test_positive_update_user_19(self):
-        """@Test: Update User with multiple Compute Resources
-
-        @Feature: User - Positive Update
-
-        @Steps:
-        1. Create User
-        2. Assign multiple Compute Resources to the User
-
-        @Assert: User is updated
-
-        @Status: Manual
-
-        """
-
-    @run_only_on('sat')
-    @stubbed()
-    def test_positive_update_user_20(self):
-        """@Test: Update User with all Compute Resources
-
-        @Feature: User - Positive Update
-
-        @Steps:
-        1. Create User
-        2. Assign all Compute Resources to the User
-
-        @Assert: User is updated
-
-        @Status: Manual
-
-        """
-
-    @run_only_on('sat')
-    @stubbed()
-    def test_positive_update_user_21(self):
-        """@Test: Update User with one Host group
-
-        @Feature: User - Positive Update
-
-        @Steps:
-        1. Create User
-        2. Assign one Host group to the User
-
-        @Assert: User is updated
-
-        @Status: Manual
-
-        """
-
-    @run_only_on('sat')
-    @stubbed()
-    def test_positive_update_user_22(self):
-        """@Test: Update User with multiple Host groups
-
-        @Feature: User - Positive Update
-
-        @Steps:
-        1. Create User
-        2. Assign multiple Host groups to the User
-
-        @Assert: User is updated
-
-        @Status: Manual
-
-        """
-
-    @run_only_on('sat')
-    @stubbed()
-    def test_positive_update_user_23(self):
-        """@Test: Update User with all Host groups
-
-        @Feature: User - Positive Update
-
-        @Steps:
-        1. Create User
-        2. Assign all available Host groups to the User
-
-        @Assert: User is updated
-
-        @Status: Manual
-
-        """
-
-    @stubbed()
-    def test_positive_update_user_24(self):
+        strategy, value = common_locators['entity_deselect']
+        name = gen_string('alpha')
+        with Session(self.browser) as session:
+            make_user(session, username=name)
+            self.user.update(name, new_roles=ROLES)
+            self.user.search(name).click()
+            self.user.click(tab_locators['users.tab_roles'])
+            for role in ROLES:
+                self.assertIsNotNone(
+                    self.user.wait_until_element((strategy, value % role)))
+
+    @tier1
+    def test_positive_update_org(self):
         """@Test: Assign a User to an Org
 
         @Feature: User - Positive Update
 
-        @Steps:
-        1. Create User
-        2. Assign an Org to the User
-
-        @Assert: User is updated
-
-        @Status: Manual
-
+        @Assert: User is updated successfully
         """
+        strategy, value = common_locators['entity_deselect']
+        name = gen_string('alpha')
+        org_name = gen_string('alpha')
+        entities.Organization(name=org_name).create()
+        with Session(self.browser) as session:
+            make_user(session, username=name)
+            self.user.update(name, new_organizations=[org_name])
+            self.user.search(name).click()
+            self.user.click(tab_locators['users.tab_organizations'])
+            element = self.user.wait_until_element(
+                (strategy, value % org_name))
+            self.assertIsNotNone(element)
 
-    @stubbed()
-    def test_positive_update_user_25(self):
+    @tier2
+    def test_positive_update_orgs(self):
         """@Test: Assign a User to multiple Orgs
 
         @Feature: User - Positive Update
 
-        @Steps:
-        1. Create User
-        2. Assign multiple Orgs to the User
-
         @Assert: User is updated
-
-        @Status: Manual
-
         """
+        strategy, value = common_locators['entity_deselect']
+        name = gen_string('alpha')
+        org_names = [
+            entities.Organization().create().name
+            for _ in range(3)
+        ]
+        with Session(self.browser) as session:
+            make_user(session, username=name)
+            self.user.update(name, new_organizations=org_names)
+            self.user.search(name).click()
+            self.user.click(tab_locators['users.tab_organizations'])
+            for org in org_names:
+                self.assertIsNotNone(
+                    self.user.wait_until_element((strategy, value % org)))
 
-    @stubbed()
-    def test_positive_update_user_26(self):
-        """@Test: Assign a User to all available Orgs
-
-        @Feature: User - Positive Update
-
-        @Steps:
-        1. Create User
-        2. Assign all available Orgs to the User
-
-        @Assert: User is updated
-
-        @Status: Manual
-
-        """
-
-    @run_only_on('sat')
-    @stubbed()
-    def test_positive_update_user_28(self):
-        """@Test: Update User with a new Fact filter
-
-        @Feature: User - Positive Update
-
-        @Steps:
-        1. Create User
-        2. Create and assign a new Fact filter to the User
-
-        @Assert: User is update
-
-        @Status: Manual
-
-        """
-
-    @stubbed()
-    def test_negative_update_user_1(self):
+    @tier1
+    def test_negative_update_username(self):
         """@Test: Update invalid Username in an User
 
         @Feature: User - Negative Update
 
-        @Steps:
-        1. Create User
-        2. Update Username for all variations in [2]
-
         @Assert: User is not updated.  Appropriate error shown.
-
-        @Status: Manual
-
         """
+        name = gen_string('alpha')
+        with Session(self.browser) as session:
+            make_user(session, username=name)
+            for new_user_name in invalid_names_list():
+                with self.subTest(new_user_name):
+                    self.user.update(name, new_username=new_user_name)
+                    self.assertIsNotNone(
+                        self.user.wait_until_element(
+                            common_locators['haserror'])
+                    )
 
-    @stubbed()
-    def test_negative_update_user_2(self):
+    @tier1
+    def test_negative_update_firstname(self):
         """@Test: Update invalid Firstname in an User
 
         @Feature: User - Negative Update
 
-        @Steps:
-        1. Create User
-        2. Update Firstname for all variations in [2]
-
         @Assert: User is not updated.  Appropriate error shown.
-
-        @Status: Manual
-
         """
+        name = gen_string('alpha')
+        with Session(self.browser) as session:
+            make_user(session, username=name)
+            for new_first_name in invalid_names_list():
+                with self.subTest(new_first_name):
+                    self.user.update(name, first_name=new_first_name)
+                    self.assertIsNotNone(
+                        self.user.wait_until_element(
+                            common_locators['haserror'])
+                    )
 
-    @stubbed()
-    def test_negative_update_user_3(self):
+    @tier1
+    def test_negative_update_surname(self):
         """@Test: Update invalid Surname in an User
 
         @Feature: User - Negative Update
 
-        @Steps:
-        1. Create User
-        2. Update Surname for all variations in [2]
-
         @Assert: User is not updated.  Appropriate error shown.
-
-        @Status: Manual
-
         """
+        name = gen_string('alpha')
+        with Session(self.browser) as session:
+            make_user(session, username=name)
+            for new_surname in invalid_names_list():
+                with self.subTest(new_surname):
+                    self.user.update(name, last_name=new_surname)
+                    self.assertIsNotNone(
+                        self.user.wait_until_element(
+                            common_locators['haserror'])
+                    )
 
-    @stubbed()
-    def test_negative_update_user_4(self):
+    @tier1
+    def test_negative_update_email(self):
         """@Test: Update invalid Email Address in an User
 
         @Feature: User - Negative Update
 
-        @Steps:
-        1. Create User
-        2. Update Email Address for all variations in [2]
-
         @Assert: User is not updated.  Appropriate error shown.
-
-        @Status: Manual
-
         """
+        name = gen_string('alpha')
+        with Session(self.browser) as session:
+            make_user(session, username=name)
+            for new_email in invalid_emails_list():
+                with self.subTest(new_email):
+                    self.user.update(name, email=new_email)
+                    self.assertIsNotNone(
+                        self.user.wait_until_element(
+                            common_locators['haserror'])
+                    )
 
     @stubbed()
-    def test_negative_update_user_5(self):
+    def test_negative_update_password(self):
         """@Test: Update different values in Password and verify fields
 
         @Feature: User - Negative Update
@@ -1368,57 +806,74 @@ class User(UITestCase):
 
         """
 
-    @stubbed()
-    def test_negative_update_user_6(self):
+    def test_negative_update(self):
         """@Test: [UI ONLY] Attempt to update User info and Cancel
 
         @Feature: User - Negative Update
 
-        @Steps:
-        1. Update Current user with valid Firstname, Surname, Email Address,
-        Language, Password/Verify fields
-        2. Click Cancel
-
         @Assert: User is not updated.
+        """
+        new_first_name = gen_string('alpha')
+        new_last_name = gen_string('alpha')
+        username = gen_string('alpha')
+        new_username = gen_string('alpha')
+        with Session(self.browser) as session:
+            make_user(session, username=username)
+            self.user.update(
+                username,
+                new_username=new_username,
+                first_name=new_first_name,
+                last_name=new_last_name,
+                submit=False,
+            )
+            self.assertIsNotNone(self.user.search(username))
+            self.assertIsNone(self.user.search(new_username))
 
-        @Status: Manual
+    @tier1
+    def test_positive_delete_user(self):
+        """@Test: Delete a User
+
+        @Feature: User - Delete
+
+        @Assert: User is deleted
 
         """
+        with Session(self.browser) as session:
+            for user_name in valid_strings():
+                with self.subTest(user_name):
+                    make_user(session, username=user_name)
+                    self.user.delete(user_name)
 
-    @stubbed()
-    def test_positive_delete_user_2(self):
+    @tier1
+    def test_positive_delete_admin(self):
         """@Test: Delete an admin user
 
         @Feature: User - Positive Delete
 
-        @Steps:
-        1. Create an admin user
-        2. Delete the User
-
         @Assert: User is deleted
-
-        @Status: Manual
-
         """
+        user_name = gen_string('alpha')
+        with Session(self.browser) as session:
+            make_user(session, username=user_name, admin=True)
+            self.assertIsNotNone(self.user.search(user_name))
+            self.user.delete(user_name)
 
-    @stubbed()
-    def test_negative_delete_user_1(self):
+    @tier1
+    def test_negative_delete_user(self):
         """@Test: [UI ONLY] Attempt to delete an User and cancel
 
         @Feature: User - Negative Delete
 
-        @Steps:
-        1. Create a User
-        2. Attempt to delete the user and click Cancel on the confirmation
-
         @Assert: User is not deleted
-
-        @Status: Manual
-
         """
+        user_name = gen_string('alpha')
+        with Session(self.browser) as session:
+            make_user(session, username=user_name)
+            self.assertIsNotNone(self.user.search(user_name))
+            self.user.delete(user_name, really=False)
 
     @stubbed()
-    def test_negative_delete_user_2(self):
+    def test_negative_delete_last_admin(self):
         """@Test: Attempt to delete the last remaining admin user
 
         @Feature: User - Negative Delete
@@ -1429,261 +884,6 @@ class User(UITestCase):
         3. Attempt to delete the last admin user
 
         @Assert: User is not deleted
-
-        @Status: Manual
-
-        """
-
-    @stubbed()
-    def test_list_user_1(self):
-        """@Test: List User for all variations of Username
-
-        @Feature: User - list
-
-        @Steps:
-        1. Create User for all Username variations in [1] using valid
-        First Name, Surname, Email Address, Language, authorized by
-        2. List User
-
-        @Assert: User is listed
-
-        @Status: Manual
-
-        """
-
-    @stubbed()
-    def test_list_user_2(self):
-        """@Test: List User for all variations of Firstname
-
-        @Feature: User - list
-
-        @Steps:
-        1. Create User for all Firstname variations in [1] using valid
-        Username, Surname, Email Address, Language, authorized by
-        2. List User
-
-        @Assert: User is listed
-
-        @Status: Manual
-
-        """
-
-    @stubbed()
-    def test_list_user_3(self):
-        """@Test: List User for all variations of Surname
-
-        @Feature: User - list
-
-        @Steps:
-        1. Create User for all Surname variations in [1] using valid
-        Username, First Name, Email Address, Language, authorized by
-        2. List User
-
-        @Assert: User is listed
-
-        @Status: Manual
-
-        """
-
-    @stubbed()
-    def test_list_user_4(self):
-        """@Test: List User for all variations of Email Address
-
-        @Feature: User - list
-
-        @Steps:
-        1. Create User for all Email Address variations in [1] using valid
-        valid Username, First Name, Surname, Language, authorized by
-        2. List User
-
-        @Assert: User is listed
-
-        @Status: Manual
-
-        """
-
-    @stubbed()
-    def test_list_user_5(self):
-        """@Test: List User for all variations of Language
-
-        @Feature: User - list
-
-        @Steps:
-        1. Create User for all Language variations using valid
-        Username, First Name, Surname, Email Address, authorized by
-        2. List User
-
-        @Assert: User is listed
-
-        @Status: Manual
-
-        """
-
-    @stubbed()
-    def test_search_user_1(self):
-        """@Test: Search User for all variations of Username
-
-        @Feature: User - search
-
-        @Steps:
-        1. Create User for all Username variations in [1] using valid
-        First Name, Surname, Email Address, Language, authorized by
-        2. Search/Find User
-
-        @Assert: User is found
-
-        @Status: Manual
-
-        """
-
-    @stubbed()
-    def test_search_user_2(self):
-        """@Test: Search User for all variations of Firstname
-
-        @Feature: User - search
-
-        @Steps:
-        1. Create User for all Firstname variations in [1] using valid
-        Username, Surname, Email Address, Language, authorized by
-        2. Search/Find User
-
-        @Assert: User is found
-
-        @Status: Manual
-
-        """
-
-    @stubbed()
-    def test_search_user_3(self):
-        """@Test: Search User for all variations of Surname
-
-        @Feature: User - search
-
-        @Steps:
-        1. Create User for all Surname variations in [1] using valid
-        Username, First Name, Email Address, Language, authorized by
-        2. Search/Find User
-
-        @Assert: User is found
-
-        @Status: Manual
-
-        """
-
-    @stubbed()
-    def test_search_user_4(self):
-        """@Test: Search User for all variations of Email Address
-
-        @Feature: User - search
-
-        @Steps:
-        1. Create User for all Email Address variations in [1] using valid
-        valid Username, First Name, Surname, Language, authorized by
-        2. Search/Find User
-
-        @Assert: User is found
-
-        @Status: Manual
-
-        """
-
-    @stubbed()
-    def test_search_user_5(self):
-        """@Test: Search User for all variations of Language
-
-        @Feature: User - search
-
-        @Steps:
-        1. Create User for all Language variations using valid
-        Username, First Name, Surname, Email Address, authorized by
-        2. Search/Find User
-
-        @Assert: User is found
-
-        @Status: Manual
-
-        """
-
-    @stubbed()
-    def test_info_user_1(self):
-        """@Test: Get User info for all variations of Username
-
-        @Feature: User - info
-
-        @Steps:
-        1. Create User for all Username variations in [1] using valid
-        First Name, Surname, Email Address, Language, authorized by
-        2. Get info of the User
-
-        @Assert: User info is displayed
-
-        @Status: Manual
-
-        """
-
-    @stubbed()
-    def test_info_user_2(self):
-        """@Test: Search User for all variations of Firstname
-
-        @Feature: User - search
-
-        @Steps:
-        1. Create User for all Firstname variations in [1] using valid
-        Username, Surname, Email Address, Language, authorized by
-        2. Get info of the User
-
-        @Assert: User info is displayed
-
-        @Status: Manual
-
-        """
-
-    @stubbed()
-    def test_info_user_3(self):
-        """@Test: Search User for all variations of Surname
-
-        @Feature: User - search
-
-        @Steps:
-        1. Create User for all Surname variations in [1] using valid
-        Username, First Name, Email Address, Language, authorized by
-        2. Get info of the User
-
-        @Assert: User info is displayed
-
-        @Status: Manual
-
-        """
-
-    @stubbed()
-    def test_info_user_4(self):
-        """@Test: Search User for all variations of Email Address
-
-        @Feature: User - search
-
-        @Steps:
-        1. Create User for all Email Address variations in [1] using valid
-        valid Username, First Name, Surname, Language, authorized by
-        2. Get info of the User
-
-        @Assert: User info is displayed
-
-        @Status: Manual
-
-        """
-
-    @stubbed()
-    def test_info_user_5(self):
-        """@Test: Search User for all variations of Language
-
-        @Feature: User - search
-
-        @Steps:
-        1. Create User for all Language variations using valid
-        Username, First Name, Surname, Email Address, authorized by
-        2. Get info of the User
-
-        @Assert: User info is displayed
 
         @Status: Manual
 


### PR DESCRIPTION
- Affected 66 stubbs. All of them are implemented except:
    - Moved host related stubbs from `test_user` to `test_host` module as you can associate host with user only from host side
    - Removed all stubbs related to `Domain` entity as there are no way to associate domain and user entities from WebUI
    - Removed all stubbs related to `Compute Resource` entity as there are no way to associate compute resource and user entities from WebUI
    - Removed all stubbs related to `Host Group` entity as there are no way to associate host group and user entities from WebUI
    - Removed all stubbs related to `Facts` entity as there are no way to associate facts and user entities from WebUI
    - Removed `test_positive_create_user_internal` stubb as we are using `INTERNAL` auth in all tests already
    - Removed all stubbs related to `test_search_user_x` as we already performing all these operation in `create` and `update` procedures
    - Removed all stubbs related to `test_info_user_x` as these cases related to CLI specifically and have no meaning for WebUI
    - Removed all stubbs related to `test_list_user_x` as these cases related to CLI specifically and have no meaning for WebUI
- Improved user fields validation after performed operations
- Added tiers for all tests according to our standards
- Fixed names for all tests according our naming conventions

```
nosetests tests/foreman/ui/test_user.py
SS.SS......S....S...SSSSS............................
----------------------------------------------------------------------
Ran 53 tests in 2160.617s

OK (SKIP=11)
```