### PR TITLE
[DO NOT MERGE] Fixed test_incremental_update_puppet api test

### DIFF
--- a/tests/foreman/api/test_contentviewversion.py
+++ b/tests/foreman/api/test_contentviewversion.py
@@ -1,4 +1,6 @@
 """Unit tests for the ``content_view_versions`` paths."""
+import time
+
 from nailgun import entities
 from requests.exceptions import HTTPError
 from robottelo.api.utils import promote
@@ -316,6 +318,17 @@ class ContentViewVersionIncrementalTestCase(APITestCase):
         # seem to create a task so we cannot pool it for status. We
         # should then check that we have some results back before
         # proceeding.
+        # This test sometimes fails in automation since uploading puppet
+        # modules take longer occasionally. To workaround, a delay of 10
+        # seconds is introduced together with polling every 2 seconds
+        for _ in range(5):
+            if len(puppet_modules) == 0:
+                time.sleep(2)
+                puppet_modules = content_view.available_puppet_modules()[
+                    'results']
+            else:
+                break
+        # Do not proceed if puppet module is not uploaded
         self.assertGreater(len(puppet_modules), 0)
         puppet_module = entities.PuppetModule(
             id=puppet_modules[0]['id']


### PR DESCRIPTION
Closed #3033 

Tested on a rhel7 box (the failure happened in rhel7 in jenkins)
```sh
# nosetests tests/foreman/api/test_contentviewversion.py:ContentViewVersionIncrementalTestCase.test_positive_incremental_update_puppet 
.
----------------------------------------------------------------------
Ran 1 test in 86.527s

OK

# py.test tests/foreman/api/test_contentviewversion.py::ContentViewVersionIncrementalTestCase::test_positive_incremental_update_puppet 
============================= test session starts ==============================
platform linux2 -- Python 2.7.5, pytest-2.8.0, py-1.4.30, pluggy-0.3.1
rootdir: /home/suresh/hacking/framework/robottelo, inifile: 
collected 2 items 

tests/foreman/api/test_contentviewversion.py .

========================== 1 passed in 84.25 seconds ===========================
```