### PR TITLE
Fixed various docstrings

### DIFF
--- a/robottelo/datafactory.py
+++ b/robottelo/datafactory.py
@@ -111,7 +111,6 @@ def invalid_values_list(interface=None):
 
     :param str interface: Interface name (one of api/cli/ui).
     :return: Returns the invalid values list
-    :rtype: list
     :raises: :meth:`InvalidArgumentError`: If an invalid interface is received.
 
     """

--- a/robottelo/decorators.py
+++ b/robottelo/decorators.py
@@ -66,7 +66,7 @@ def skip_if_not_set(*options):
     supported.
 
     :param options: List of valid `robottelo.properties` section names.
-    :raises unittest2.SkipTest: If expected configuration section is not fully
+    :raises: unittest2.SkipTest: If expected configuration section is not fully
         set in the `robottelo.properties` file. All required attributes must be
         set. For example, if the `server` section is enabled but its `hostname`
         attribute is not set, then a test that expects it will be skipped.

--- a/robottelo/helpers.py
+++ b/robottelo/helpers.py
@@ -149,9 +149,10 @@ def install_katello_ca(hostname=None):
         """Downloads and installs katello-ca rpm
 
         :param str hostname: Hostname or IP address of the remote host. If
-        ``None`` the hostname will be get from ``main.server.hostname`` config.
+         ``None`` the hostname will be get from ``main.server.hostname`` config
         :return: None.
-        :raises AssertionError: If katello-ca wasn't installed.
+        :raises: AssertionError: If katello-ca wasn't installed.
+
         """
         ssh.command(
             u'rpm -Uvh {0}'.format(settings.server.get_cert_rpm_url()),
@@ -174,9 +175,10 @@ def remove_katello_ca(hostname=None):
         """Removes katello-ca rpm
 
         :param str hostname: Hostname or IP address of the remote host. If
-        ``None`` the hostname will be get from ``main.server.hostname`` config.
+         ``None`` the hostname will be get from ``main.server.hostname`` config
         :return: None.
-        :raises AssertionError: If katello-ca wasn't removed.
+        :raises: AssertionError: If katello-ca wasn't removed.
+
         """
         # Not checking the return_code here, as rpm can be not even installed
         # and deleting may fail

--- a/tests/foreman/cli/test_domain.py
+++ b/tests/foreman/cli/test_domain.py
@@ -98,9 +98,6 @@ def valid_delete_params():
 class TestDomain(CLITestCase):
     """Domain CLI tests"""
 
-    factory = make_domain
-    factory_obj = Domain
-
     @tier1
     @run_only_on('sat')
     def test_positive_create(self):

--- a/tests/robottelo/test_decorators.py
+++ b/tests/robottelo/test_decorators.py
@@ -222,7 +222,7 @@ class RmBugIsOpenTestCase(TestCase):
 
 
 class GetBugzillaBugStatusIdTestCase(TestCase):
-    """Tests for :func:`robottelo.decorators._get_bugzilla_bug`."""
+    """Tests for ``robottelo.decorators._get_bugzilla_bug``."""
     def setUp(self):
         self.bugzilla_patcher = mock.patch('robottelo.decorators.bugzilla')
         self.bugzilla = self.bugzilla_patcher.start()
@@ -299,7 +299,7 @@ class GetBugzillaBugStatusIdTestCase(TestCase):
 
 
 class GetRedmineBugStatusIdTestCase(TestCase):
-    """Tests for :func:`robottelo.decorators._get_redmine_bug_status_id`."""
+    """Tests for ``robottelo.decorators._get_redmine_bug_status_id``."""
     def test_cached_bug(self):
         """Return bug status from the cache."""
         with mock.patch.dict(
@@ -348,9 +348,7 @@ class GetRedmineBugStatusIdTestCase(TestCase):
 
 
 class RedmineClosedIssueStatusesTestCase(TestCase):
-    """Tests for
-    :func:`robottelo.decorators._redmine_closed_issue_statuses`.
-    """
+    """Tests for ``robottelo.decorators._redmine_closed_issue_statuses``."""
     @mock.patch('robottelo.decorators.requests')
     def test_build_cache(self, requests):
         """Build closed issue statuses cache."""


### PR DESCRIPTION
Following 8 warnings were present in `make docs` results:
```
/home/travis/build/SatelliteQE/robottelo/robottelo/helpers.py:docstring of robottelo.helpers.install_katello_ca:4: WARNING: Field list ends without a blank line; unexpected unindent.
/home/travis/build/SatelliteQE/robottelo/robottelo/helpers.py:docstring of robottelo.helpers.remove_katello_ca:4: WARNING: Field list ends without a blank line; unexpected unindent.
/home/travis/build/SatelliteQE/robottelo/robottelo/datafactory.py:docstring of robottelo.datafactory.invalid_values_list:None: WARNING: more than one target found for cross-reference u'list': robottelo.cli.docker.DockerRegistry.list, robottelo.cli.docker.DockerImage.list, robottelo.cli.docker.DockerTag.list, robottelo.cli.lifecycleenvironment.LifecycleEnvironment.list, robottelo.cli.docker.DockerContainer.list, robottelo.cli.base.Base.list
/home/travis/build/SatelliteQE/robottelo/robottelo/decorators.py:docstring of robottelo.decorators.skip_if_not_set:None: WARNING: py:exc reference target not found: unittest2.SkipTest
/home/travis/build/SatelliteQE/robottelo/docs/api/tests.foreman.cli.rst:37: WARNING: py:class reference target not found: Domain
/home/travis/build/SatelliteQE/robottelo/tests/robottelo/test_decorators.py:docstring of tests.robottelo.test_decorators.GetBugzillaBugStatusIdTestCase:1: WARNING: py:func reference target not found: robottelo.decorators._get_bugzilla_bug
/home/travis/build/SatelliteQE/robottelo/tests/robottelo/test_decorators.py:docstring of tests.robottelo.test_decorators.GetRedmineBugStatusIdTestCase:1: WARNING: py:func reference target not found: robottelo.decorators._get_redmine_bug_status_id
/home/travis/build/SatelliteQE/robottelo/tests/robottelo/test_decorators.py:docstring of tests.robottelo.test_decorators.RedmineClosedIssueStatusesTestCase:1: WARNING: py:func reference target not found: robottelo.decorators._redmine_closed_issue_statuses
```