### PR TITLE
Fix issues with smoke tests triggered on CI server

### DIFF
--- a/tests/foreman/smoke/test_api_smoke.py
+++ b/tests/foreman/smoke/test_api_smoke.py
@@ -561,6 +561,10 @@ API_PATHS = {
     u'statistics': (
         u'/api/statistics',
     ),
+    u'subnet_disks': (
+        u'/bootdisk/api',
+        u'/bootdisk/api/subnets/:subnet_id',
+    ),
     u'subnets': (
         u'/api/subnets',
         u'/api/subnets',
@@ -683,7 +687,6 @@ class TestAvailableURLs(TestCase):
         self.assertEqual(response.status_code, http_client.OK)
         self.assertIn('application/json', response.headers['content-type'])
 
-    @skip_if_bug_open('bugzilla', 1105773)
     def test_get_links(self):
         """@Test: GET ``api/v2`` and check the links returned.
 

--- a/tests/foreman/smoke/test_ui_smoke.py
+++ b/tests/foreman/smoke/test_ui_smoke.py
@@ -82,10 +82,8 @@ class TestSmoke(UITestCase):
         @Assert: Admin User is found and has Admin role
 
         """
-        with Session(self.browser) as session:
-            session.nav.go_to_users()
-            self.assertIsNotNone(self.user.search('admin'))
-            self.assertTrue(self.user.admin_role_to_user('admin'))
+        with Session(self.browser):
+            self.assertTrue(self.user.user_admin_role_toggle('admin'))
 
     def test_smoke(self):
         """@Test: Check that basic content can be created
@@ -137,8 +135,7 @@ class TestSmoke(UITestCase):
                 password2=password
             )
             self.assertIsNotNone(self.user.search(user_name))
-            is_admin_role_selected = self.user.admin_role_to_user(user_name)
-            self.assertTrue(is_admin_role_selected)
+            self.assertTrue(self.user.user_admin_role_toggle(user_name))
 
         # FIX ME: UI doesn't authenticate user created via UI auto: Issue #1152
         # Once #1152 is fixed; need to pass user_name and password to Session
@@ -475,8 +472,8 @@ class TestSmoke(UITestCase):
                 vm.register_contenthost(activation_key_name, org_name)
                 vm.configure_puppet(rhel6_repo)
                 host = vm.hostname
-                session.nav.go_to_hosts()
                 set_context(session, org=ANY_CONTEXT['org'])
+                session.nav.go_to_hosts()
                 self.hosts.update_host_bulkactions(host=host, org=org_name)
                 self.hosts.update(
                     name=host,


### PR DESCRIPTION
Closes #3121
Closes #3122

```
nosetests tests/foreman/smoke/test_ui_smoke.py -m test_find_admin_user
.
----------------------------------------------------------------------
Ran 1 test in 15.665s

OK
```
```
nosetests tests/foreman/smoke/test_ui_smoke.py -m test_smoke
.
----------------------------------------------------------------------
Ran 1 test in 299.065s

OK
```
```
nosetests tests/foreman/smoke/test_api_smoke.py -m test_get_links
.
----------------------------------------------------------------------
Ran 1 test in 2.339s

OK
```

Also there is a chance that issue with `test_puppet_install` test case also will be fixed (tried to reproduce that and it seems that I found solution)