### PR TITLE
Update run_only_on decorator test

### DIFF
--- a/tests/robottelo/test_decorators.py
+++ b/tests/robottelo/test_decorators.py
@@ -447,7 +447,7 @@ class RunOnlyOnTestCase(TestCase):
         def dummy():
             return 42
 
-        with self.assertRaises(decorators.ProjectModeError):
+        with self.assertRaises(SkipTest):
             dummy()
 
 


### PR DESCRIPTION
Expect the right exception in order to avoid skipping the test.