### PR TITLE
Fix UI test names according to new naming conventions (part 2)

### DIFF
--- a/docs/api/tests.foreman.ui.rst
+++ b/docs/api/tests.foreman.ui.rst
@@ -158,30 +158,30 @@
 
 .. automodule:: tests.foreman.ui.test_oscapcontent
 
-:mod:`tests.foreman.ui.test_operatingsys`
+:mod:`tests.foreman.ui.test_operatingsystem`
+--------------------------------------------
+
+.. automodule:: tests.foreman.ui.test_operatingsystem
+
+:mod:`tests.foreman.ui.test_organization`
 -----------------------------------------
 
-.. automodule:: tests.foreman.ui.test_operatingsys
-
-:mod:`tests.foreman.ui.test_org`
---------------------------------
-
-.. automodule:: tests.foreman.ui.test_org
+.. automodule:: tests.foreman.ui.test_organization
 
 :mod:`tests.foreman.ui.test_partitiontable`
 -------------------------------------------
 
 .. automodule:: tests.foreman.ui.test_partitiontable
 
-:mod:`tests.foreman.ui.test_products`
+:mod:`tests.foreman.ui.test_product`
 -------------------------------------
 
-.. automodule:: tests.foreman.ui.test_products
+.. automodule:: tests.foreman.ui.test_product
 
-:mod:`tests.foreman.ui.test_puppet_classes`
+:mod:`tests.foreman.ui.test_puppetclass`
 -------------------------------------------
 
-.. automodule:: tests.foreman.ui.test_puppet_classes
+.. automodule:: tests.foreman.ui.test_puppetclass
 
 :mod:`tests.foreman.ui.test_repository`
 ---------------------------------------
@@ -193,10 +193,10 @@
 
 .. automodule:: tests.foreman.ui.test_role
 
-:mod:`tests.foreman.ui.test_settings`
+:mod:`tests.foreman.ui.test_setting`
 -------------------------------------
 
-.. automodule:: tests.foreman.ui.test_settings
+.. automodule:: tests.foreman.ui.test_setting
 
 :mod:`tests.foreman.ui.test_sso`
 --------------------------------

--- a/tests/foreman/ui/test_contentview.py
+++ b/tests/foreman/ui/test_contentview.py
@@ -105,7 +105,7 @@ class ContentViewTestCase(UITestCase):
 
     @run_only_on('sat')
     @tier1
-    def test_negative_create_with_name(self):
+    def test_negative_create_with_invalid_name(self):
         """@test: try to create content views using invalid names
 
         @feature: Content Views

--- a/tests/foreman/ui/test_discoveredhost.py
+++ b/tests/foreman/ui/test_discoveredhost.py
@@ -288,7 +288,7 @@ class DiscoveryTestCase(UITestCase):
 
     @stubbed()
     @tier3
-    def test_positive_create_discovery_rule_with_IP(self):
+    def test_positive_create_discovery_rule_with_simple_query(self):
         """@Test: Create a new discovery rule
 
         Set query as (e.g IP=IP_of_discovered_host)
@@ -305,7 +305,7 @@ class DiscoveryTestCase(UITestCase):
 
     @stubbed()
     @tier3
-    def test_positive_create_discovery_rule_with_cpu_count(self):
+    def test_positive_create_discovery_rule_with_complex_query(self):
         """@Test: Create a new discovery rule with (host_limit = 0)
         that applies to multi hosts.
         Set query as cpu_count = 1 OR mem > 500

--- a/tests/foreman/ui/test_discoveryrule.py
+++ b/tests/foreman/ui/test_discoveryrule.py
@@ -51,7 +51,7 @@ class DiscoveryRuleTestCase(UITestCase):
 
     @run_only_on('sat')
     @tier1
-    def test_negative_create_with_name(self):
+    def test_negative_create_with_invalid_name(self):
         """@Test: Create Discovery Rule with invalid names
 
         @Feature: Foreman Discovery

--- a/tests/foreman/ui/test_domain.py
+++ b/tests/foreman/ui/test_domain.py
@@ -123,7 +123,7 @@ class DomainTestCase(UITestCase):
 
     @run_only_on('sat')
     @tier1
-    def test_negative_create_with_name(self):
+    def test_negative_create_with_invalid_name(self):
         """@Test: Try to create domain and use whitespace, blank, tab symbol or
         too long string of different types as its name value
 

--- a/tests/foreman/ui/test_hostgroup.py
+++ b/tests/foreman/ui/test_hostgroup.py
@@ -30,7 +30,7 @@ class HostgroupTestCase(UITestCase):
 
     @run_only_on('sat')
     @tier1
-    def test_negative_create_with_name(self):
+    def test_negative_create_with_invalid_name(self):
         """@Test: Create new hostgroup with invalid names
 
         @Feature: Hostgroup - Negative Create

--- a/tests/foreman/ui/test_hw_model.py
+++ b/tests/foreman/ui/test_hw_model.py
@@ -41,7 +41,7 @@ class HardwareModelTestCase(UITestCase):
 
     @run_only_on('sat')
     @tier1
-    def test_negative_create_with_name(self):
+    def test_negative_create_with_invalid_name(self):
         """@test: Create new Hardware-Model with invalid names
 
         @feature: Hardware-Model - Negative Create

--- a/tests/foreman/ui/test_location.py
+++ b/tests/foreman/ui/test_location.py
@@ -5,7 +5,7 @@ from fauxfactory import gen_ipaddr, gen_string
 from nailgun import entities
 from robottelo.config import settings
 from robottelo.datafactory import generate_strings_list, invalid_values_list
-from robottelo.decorators import run_only_on, skip_if_bug_open, tier1, tier2
+from robottelo.decorators import run_only_on, tier1, tier2
 from robottelo.constants import (
     ANY_CONTEXT,
     INSTALL_MEDIUM_URL,
@@ -52,7 +52,6 @@ class LocationTestCase(UITestCase):
 
     # Auto Search
 
-    @skip_if_bug_open('bugzilla', 1177610)
     @run_only_on('sat')
     @tier1
     def test_positive_auto_search(self):
@@ -61,9 +60,6 @@ class LocationTestCase(UITestCase):
         @feature: Locations
 
         @assert: Created location can be auto search by its partial name
-
-        @BZ: 1177610
-
         """
         loc_name = gen_string('alpha')
         with Session(self.browser) as session:

--- a/tests/foreman/ui/test_multinetwork.py
+++ b/tests/foreman/ui/test_multinetwork.py
@@ -1,14 +1,15 @@
 # -*- encoding: utf-8 -*-
 """Test class for Multi-Network Support feature"""
-from robottelo.decorators import stubbed
+from robottelo.decorators import stubbed, tier3
 from robottelo.test import UITestCase
 
 
-class Multinetwork(UITestCase):
+class MultinetworkTestCase(UITestCase):
     """Implements Multi Network support tests in UI."""
 
     @stubbed()
-    def test_create_host_1(self):
+    @tier3
+    def test_positive_create_with_dhcp_ipam(self):
         """@Test: Create host with default interface and set 'DHCP' for IPAM
         and BootMode for provisioning subnet
 
@@ -25,11 +26,11 @@ class Multinetwork(UITestCase):
         /etc/sysconfig/network-scripts/ifcfg-<interface>
 
         @Status: Manual
-
         """
 
     @stubbed()
-    def test_create_host_2(self):
+    @tier3
+    def test_positive_create_with_non_specified_internal_db_ipam_dhcp(self):
         """@Test: Create host with default interface when IPAM set as
         'Internal DB' (without specifying start and end range) and BootMode
         set as 'DHCP' for provisioning subnet
@@ -49,11 +50,11 @@ class Multinetwork(UITestCase):
         /etc/sysconfig/network-scripts/ifcfg-<interface>
 
         @Status: Manual
-
         """
 
     @stubbed()
-    def test_create_host_3(self):
+    @tier3
+    def test_positive_create_with_specified_internal_db_ipam_dhcp(self):
         """@Test: Create host with default interface when IPAM set as
         'Internal DB' (with start and end IP range) and BootMode set as
         'DHCP' for provisioning subnet
@@ -73,11 +74,11 @@ class Multinetwork(UITestCase):
         /etc/sysconfig/network-scripts/ifcfg-<interface>
 
         @Status: Manual
-
         """
 
     @stubbed()
-    def test_create_host_4(self):
+    @tier3
+    def test_positive_create_with_specified_internal_db_ipam_static(self):
         """@Test: Create host with default interface when IPAM set as
         'Internal DB' (with start and end IP range) and BootMode set as
         'Static' for provisioning subnet
@@ -97,11 +98,11 @@ class Multinetwork(UITestCase):
         /etc/sysconfig/network-scripts/ifcfg-<interface>
 
         @Status: Manual
-
         """
 
     @stubbed()
-    def test_create_host_5(self):
+    @tier3
+    def test_positive_create_with_non_specified_internal_db_ipam_static(self):
         """@Test: Create host with default interface when IPAM set as
         'Internal DB' (without start and end IP range) and BootMode set
         as 'Static' for provisioning subnet
@@ -121,11 +122,11 @@ class Multinetwork(UITestCase):
         /etc/sysconfig/network-scripts/ifcfg-<interface>
 
         @Status: Manual
-
         """
 
     @stubbed()
-    def test_create_host_6(self):
+    @tier3
+    def test_positive_create_with_specified_dhcp_ipam_static(self):
         """@Test: Create host with default interface when IPAM set as 'DHCP'
         (with start and end IP range) and BootMode set as 'Static' for
         provisioning subnet
@@ -145,11 +146,11 @@ class Multinetwork(UITestCase):
         /etc/sysconfig/network-scripts/ifcfg-<interface>
 
         @Status: Manual
-
         """
 
     @stubbed()
-    def test_create_host_7(self):
+    @tier3
+    def test_positive_create_with_non_specified_dhcp_ipam_static(self):
         """@Test: Create host with default interface when IPAM set as 'DHCP'
         (without start and end IP range) and BootMode set as 'Static' for
         provisioning subnet
@@ -169,11 +170,11 @@ class Multinetwork(UITestCase):
         /etc/sysconfig/network-scripts/ifcfg-<interface>
 
         @Status: Manual
-
         """
 
     @stubbed()
-    def test_create_host_8(self):
+    @tier3
+    def test_positive_create_none_ipam_static(self):
         """@Test: Create host with default interface when IPAM set as 'None'
         and BootMode set as 'Static' for provisioning subnet
 
@@ -191,11 +192,11 @@ class Multinetwork(UITestCase):
         /etc/sysconfig/network-scripts/ifcfg-<interface>
 
         @Status: Manual
-
         """
 
     @stubbed()
-    def test_create_host_9(self):
+    @tier3
+    def test_positive_create_none_ipam_dhcp(self):
         """@Test: Create host with default interface when IPAM set as 'None'
         and BootMode set as 'DHCP' for provisioning subnet
 
@@ -213,12 +214,12 @@ class Multinetwork(UITestCase):
         /etc/sysconfig/network-scripts/ifcfg-<interface>
 
         @Status: Manual
-
         """
 
     @stubbed()
-    def test_add_alias_interface_1(self):
-        """@Test:  Add an alias interface(eth0:0) with mac different than
+    @tier3
+    def test_negative_add_alias_interface_with_mac(self):
+        """@Test: Add an alias interface(eth0:0) with mac different than
         primary interface's mac
 
         @Feature: Multi Network Support
@@ -241,12 +242,12 @@ class Multinetwork(UITestCase):
         interface should be same as of primary interface
 
         @Status: Manual
-
         """
 
     @stubbed()
-    def test_add_alias_interface_2(self):
-        """@Test:  Add an alias interface(eth0:0) without selecting virtual nic
+    @tier3
+    def test_negative_add_alias_interface_without_nic(self):
+        """@Test: Add an alias interface(eth0:0) without selecting virtual nic
 
         @Feature: Multi Network Support
 
@@ -266,12 +267,12 @@ class Multinetwork(UITestCase):
         same mac
 
         @Status: Manual
-
         """
 
     @stubbed()
-    def test_add_alias_interface_3(self):
-        """@Test:  Add an alias interface(eth0:0) without defining
+    @tier3
+    def test_negative_add_alias_interface_without_attached_to(self):
+        """@Test: Add an alias interface(eth0:0) without defining
         'attached_to' interface under 'Virtual Nic'
 
         @Feature: Multi Network Support
@@ -294,12 +295,12 @@ class Multinetwork(UITestCase):
         option to create alias interface
 
         @Status: Manual
-
         """
 
     @stubbed()
-    def test_add_alias_interface_4(self):
-        """@Test:  Add an alias interface(eth0:0) when bootMode set to 'DHCP'
+    @tier3
+    def test_negative_add_alias_interface_with_dhcp_bootmode(self):
+        """@Test: Add an alias interface(eth0:0) when bootMode set to 'DHCP'
         mode under selected subnet
 
         @Feature: Multi Network Support
@@ -325,12 +326,12 @@ class Multinetwork(UITestCase):
         interface in 'DHCP' mode.
 
         @Status: Manual
-
         """
 
     @stubbed()
-    def test_add_alias_interface_5(self):
-        """@Test:  Add an alias interface(eth0:0) when bootMode set to 'Static'
+    @tier3
+    def test_positive_add_alias_with_static_bootmode(self):
+        """@Test: Add an alias interface(eth0:0) when bootMode set to 'Static'
         mode under selected subnet
 
         @Feature: Multi Network Support
@@ -357,12 +358,12 @@ class Multinetwork(UITestCase):
         under /etc/sysconfig/network-scripts/ifcfg-<interface_name>
 
         @Status: Manual
-
         """
 
     @stubbed()
-    def test_add_alias_interface_6(self):
-        """@Test:  Add an interface with same identifier of exiting interface
+    @tier3
+    def test_negative_add_alias_interface_same(self):
+        """@Test: Add an interface with same identifier of exiting interface
         Like interfaces eth0, eth0:0 already exists and now create new
         interface with eth0:0 identifier
 
@@ -388,12 +389,12 @@ class Multinetwork(UITestCase):
         @Assert: Validation error should be raised on UI
 
         @Status: Manual
-
         """
 
     @stubbed()
-    def test_delete_alias_interface(self):
-        """@Test:  Delete an alias interface
+    @tier3
+    def test_positive_delete_alias_interface(self):
+        """@Test: Delete an alias interface
 
         @Feature: Multi Network Support
 
@@ -408,11 +409,11 @@ class Multinetwork(UITestCase):
         @Assert: Interface should be deleted successfully
 
         @Status: Manual
-
         """
 
     @stubbed()
-    def test_add_bond_interface_1(self):
+    @tier3
+    def test_positive_add_bond_interface_using_two_existing(self):
         """@Test: Add bond interface using existing two interfaces
 
         @Feature: Multi Network Support
@@ -437,11 +438,11 @@ class Multinetwork(UITestCase):
         @Assert: Interface should be configured successfully with name bond0
 
         @Status: Manual
-
         """
 
     @stubbed()
-    def test_add_bond_interface_2(self):
+    @tier3
+    def test_negative_add_bond_interface_without_mac(self):
         """@Test: Add bond interface using existing two interfaces without
         specifying mac
 
@@ -468,11 +469,11 @@ class Multinetwork(UITestCase):
         create bond interface without mac
 
         @Status: Manual
-
         """
 
     @stubbed()
-    def test_add_bond_interface_3(self):
+    @tier3
+    def test_positive_add_bond_interface_without_attached_device(self):
         """@Test: Add bond interface without specifying attached devices
 
         @Feature: Multi Network Support
@@ -498,11 +499,11 @@ class Multinetwork(UITestCase):
         any device to it.
 
         @Status: Manual
-
         """
 
     @stubbed()
-    def test_add_bond_interface_4(self):
+    @tier3
+    def test_positive_add_bond_interface(self):
         """@Test: Add bond interface with one alias interface
 
         @Feature: Multi Network Support
@@ -529,11 +530,11 @@ class Multinetwork(UITestCase):
         attached to eth0 eth0:0
 
         @Status: Manual
-
         """
 
     @stubbed()
-    def test_add_bmc_interface_1(self):
+    @tier3
+    def test_positive_add_bmc_interface(self):
         """@Test: Add bmc interface
 
         @Feature: Multi Network Support
@@ -561,7 +562,8 @@ class Multinetwork(UITestCase):
         """
 
     @stubbed()
-    def test_add_bmc_interface_2(self):
+    @tier3
+    def test_positive_add_bmc_interface_without_mac(self):
         """@Test: Add bmc interface without mac
 
         @Feature: Multi Network Support
@@ -584,5 +586,4 @@ class Multinetwork(UITestCase):
         @Assert: UI should raise validation error
 
         @Status: Manual
-
         """

--- a/tests/foreman/ui/test_myaccount.py
+++ b/tests/foreman/ui/test_myaccount.py
@@ -1,12 +1,12 @@
 # -*- encoding: utf-8 -*-
 """Test class for Users UI"""
 
-from robottelo.decorators import stubbed
+from robottelo.decorators import stubbed, tier1
 from robottelo.test import UITestCase
 
 
-class MyAccount(UITestCase):
-    """ Implements Users tests in UI
+class MyAccountTestCase(UITestCase):
+    """Implements Users tests in UI
 
     [1] Positive Name variations - Alpha, Numeric, Alphanumeric, Symbols,
     Latin1, Multibyte, Max length,  Min length, Max_db_size, html, css,
@@ -18,7 +18,8 @@ class MyAccount(UITestCase):
     """
 
     @stubbed()
-    def test_positive_update_my_account_1(self):
+    @tier1
+    def test_positive_update_firstname(self):
         """@Test: Update Firstname in My Account
 
         @Feature: My Account - Positive Update
@@ -29,12 +30,11 @@ class MyAccount(UITestCase):
         @Assert: Current User is updated
 
         @Status: Manual
-
         """
-        pass
 
     @stubbed()
-    def test_positive_update_my_account_2(self):
+    @tier1
+    def test_positive_update_surname(self):
         """@Test: Update Surname in My Account
 
         @Feature: My Account - Positive Update
@@ -45,12 +45,11 @@ class MyAccount(UITestCase):
         @Assert: Current User is updated
 
         @Status: Manual
-
         """
-        pass
 
     @stubbed()
-    def test_positive_update_my_account_3(self):
+    @tier1
+    def test_positive_update_email(self):
         """@Test: Update Email Address in My Account
 
         @Feature: My Account - Positive Update
@@ -61,12 +60,11 @@ class MyAccount(UITestCase):
         @Assert: Current User is updated
 
         @Status: Manual
-
         """
-        pass
 
     @stubbed()
-    def test_positive_update_my_account_4(self):
+    @tier1
+    def test_positive_update_language(self):
         """@Test: Update Language in My Account
 
         @Feature: My Account - Positive Update
@@ -77,12 +75,11 @@ class MyAccount(UITestCase):
         @Assert: Current User is updated
 
         @Status: Manual
-
         """
-        pass
 
     @stubbed()
-    def test_positive_update_my_account_5(self):
+    @tier1
+    def test_positive_update_password(self):
         """@Test: Update Password/Verify fields in My Account
 
         @Feature: My Account - Positive Update
@@ -93,12 +90,11 @@ class MyAccount(UITestCase):
         @Assert: User is updated
 
         @Status: Manual
-
         """
-        pass
 
     @stubbed()
-    def test_negative_update_my_account_1(self):
+    @tier1
+    def test_negative_update_firstname(self):
         """@Test: Update My Account with invalid FirstName
 
         @Feature: My Account - Negative Update
@@ -109,12 +105,11 @@ class MyAccount(UITestCase):
         @Assert: User is not updated. Appropriate error shown.
 
         @Status: Manual
-
         """
-        pass
 
     @stubbed()
-    def test_negative_update_my_account_2(self):
+    @tier1
+    def test_negative_update_surname(self):
         """@Test: Update My Account with invalid Surname
 
         @Feature: My Account - Negative Update
@@ -125,12 +120,11 @@ class MyAccount(UITestCase):
         @Assert: User is not updated. Appropriate error shown.
 
         @Status: Manual
-
         """
-        pass
 
     @stubbed()
-    def test_negative_update_my_account_3(self):
+    @tier1
+    def test_negative_update_email(self):
         """@Test: Update My Account with invalid Email Address
 
         @Feature: My Account - Negative Update
@@ -141,12 +135,11 @@ class MyAccount(UITestCase):
         @Assert: User is not updated. Appropriate error shown.
 
         @Status: Manual
-
         """
-        pass
 
     @stubbed()
-    def test_negative_update_my_account_4(self):
+    @tier1
+    def test_negative_update_password(self):
         """@Test: Update My Account with invalid Password/Verify fields
 
         @Feature: My Account - Negative Update
@@ -158,12 +151,11 @@ class MyAccount(UITestCase):
         @Assert: User is not updated. Appropriate error shown.
 
         @Status: Manual
-
         """
-        pass
 
     @stubbed()
-    def test_negative_update_my_account_5(self):
+    @tier1
+    def test_negative_update_password_mismatch(self):
         """@Test: Update My Account with non-matching values in Password and
         verify fields
 
@@ -176,12 +168,11 @@ class MyAccount(UITestCase):
         @Assert: User is not updated. Appropriate error shown.
 
         @Status: Manual
-
         """
-        pass
 
     @stubbed()
-    def test_negative_update_my_account_6(self):
+    @tier1
+    def test_negative_update(self):
         """@Test: [UI ONLY] Attempt to update all info in My Accounts page and
         Cancel
 
@@ -195,6 +186,4 @@ class MyAccount(UITestCase):
         @Assert: User is not updated.
 
         @Status: Manual
-
         """
-        pass

--- a/tests/foreman/ui/test_openscap.py
+++ b/tests/foreman/ui/test_openscap.py
@@ -1,13 +1,14 @@
 """Test class for OpenScap Feature"""
-from robottelo.decorators import stubbed
+from robottelo.decorators import stubbed, tier1, tier2, tier3
 from robottelo.test import UITestCase
 
 
-class OpenScap(UITestCase):
+class OpenScapTestCase(UITestCase):
     """Implements OpenScap feature tests in UI."""
 
     @stubbed()
-    def test_create_policies_1(self):
+    @tier1
+    def test_positive_create_policy(self):
         """@Test: Create policies for OpenScap.
 
         @Feature: OpenScap - Positive Create.
@@ -20,11 +21,11 @@ class OpenScap(UITestCase):
         @Assert: Whether creating policies for OpenScap is successful.
 
         @Status: Manual
-
         """
 
     @stubbed()
-    def test_create_policies_2(self):
+    @tier1
+    def test_negative_create_policy(self):
         """@Test: Create policies for OpenScap with 256 chars.
 
         @Feature: OpenScap - Negative Create.
@@ -32,11 +33,11 @@ class OpenScap(UITestCase):
         @Assert: Creating policies for OpenScap is unsuccessful.
 
         @Status: Manual
-
         """
 
     @stubbed()
-    def test_delete_policies(self):
+    @tier1
+    def test_positive_delete_policy(self):
         """@Test: Delete policies of OpenScap.
 
         @Feature: OpenScap - Delete.
@@ -50,11 +51,11 @@ class OpenScap(UITestCase):
         @Assert: Whether deleting policies for OpenScap is successful.
 
         @Status: Manual
-
         """
 
     @stubbed()
-    def test_create_content_1(self):
+    @tier1
+    def test_positive_create_content(self):
         """@Test: Create OpenScap content.
 
         @Feature: OpenScap - Positive Create.
@@ -67,11 +68,11 @@ class OpenScap(UITestCase):
         @Assert: Whether creating  content for OpenScap is successful
 
         @Status: Manual
-
         """
 
     @stubbed()
-    def test_create_content_2(self):
+    @tier1
+    def test_negative_create_content(self):
         """@Test: Create OpenScap content with 256 chars.
 
         @Feature: OpenScap - Negative Create.
@@ -79,11 +80,11 @@ class OpenScap(UITestCase):
         @Assert: Creating content for OpenScap is unsuccessful
 
         @Status: Manual
-
         """
 
     @stubbed()
-    def test_delete_content(self):
+    @tier1
+    def test_positive_delete_content(self):
         """@Test: Create OpenScap content and then delete it.
 
         @Feature: OpenScap - Delete
@@ -97,11 +98,11 @@ class OpenScap(UITestCase):
         @Assert: Deleting content for OpenScap is successful
 
         @Status: Manual
-
         """
 
     @stubbed()
-    def test_access_oscap_reports(self):
+    @tier1
+    def test_positive_access_oscap_reports(self):
         """@Test: OpenScap should have it's own Compliance Reporting page.
 
         @Feature: OpenScap - Compliance Reporting.
@@ -109,11 +110,11 @@ class OpenScap(UITestCase):
         @Assert: Whether separate Compliance Reporting page exists.
 
         @Status: Manual
-
         """
 
     @stubbed()
-    def test_periodic_audits(self):
+    @tier3
+    def test_positive_set_periodic_audit(self):
         """@Test: Should be able to periodically set OpenScap Audit.
 
         @Feature: OpenScap - Periodic Audit.
@@ -135,11 +136,11 @@ class OpenScap(UITestCase):
         intervals.
 
         @Status: Manual
-
         """
 
     @stubbed()
-    def test_custom_periodic_audits(self):
+    @tier3
+    def test_positive_set_custom_periodic_audit(self):
         """@Test: Should be able to periodically set custom OpenScap Audit.
 
         @Feature: OpenScap - Periodic Audit.
@@ -160,11 +161,11 @@ class OpenScap(UITestCase):
         custom intervals.
 
         @Status: Manual
-
         """
 
     @stubbed()
-    def test_search_audits(self):
+    @tier3
+    def test_positive_search_audit(self):
         """@Test: Should be able to search OpenScap audit results.
 
         @Feature: OpenScap - Search
@@ -183,11 +184,11 @@ class OpenScap(UITestCase):
         @Assert: Whether searching audit results is possible.
 
         @Status: Manual
-
         """
 
     @stubbed()
-    def test_audit_default_capsule(self):
+    @tier3
+    def test_positive_audit_default_capsule(self):
         """@Test: OpenScap should be able to audit foreman managed
         infrastructure(Reports from default Capsule.)
 
@@ -207,11 +208,11 @@ class OpenScap(UITestCase):
         (Hosts from default Capsule) are generated.
 
         @Status: Manual
-
         """
 
     @stubbed()
-    def test_audit_nondefault_capsule(self):
+    @tier3
+    def test_positive_audit_nondefault_capsule(self):
         """@Test: OpenScap should be able to audit foreman managed
         infrastructure (Reports from Non-Default Capsule)
 
@@ -231,11 +232,11 @@ class OpenScap(UITestCase):
         (Hosts from Non-Default Capsule) is possible.
 
         @Status: Manual
-
         """
 
     @stubbed()
-    def test_search_content(self):
+    @tier2
+    def test_positive_search_content(self):
         """@Test: Should be able to search OpenScap content.
 
         @Feature: OpenScap - Search.
@@ -249,11 +250,11 @@ class OpenScap(UITestCase):
         @Assert: Whether searching OpenScap content is possible.
 
         @Status: Manual
-
         """
 
     @stubbed()
-    def test_search_policies(self):
+    @tier2
+    def test_positive_search_policies(self):
         """@Test: Should be able to search OpenScap policies.
 
         @Feature: OpenScap - Search.
@@ -266,11 +267,11 @@ class OpenScap(UITestCase):
         @Assert: Whether searching OpenScap policies is possible.
 
         @Status: Manual
-
         """
 
     @stubbed()
-    def test_search_nonaudited_hosts(self):
+    @tier3
+    def test_positive_search_nonaudited_hosts(self):
         """@Test: Should be able to search Non-Audited Hosts/systems
 
         @Feature: OpenScap - Search.
@@ -289,11 +290,11 @@ class OpenScap(UITestCase):
         @Assert: Whether searching Non-Audited Hosts/Systems is possible.
 
         @Status: Manual
-
         """
 
     @stubbed()
-    def test_search_noncompliant_hosts(self):
+    @tier3
+    def test_positive_search_noncompliant_hosts(self):
         """@Test: Should be able to search Non-Compliant "Hosts"/systems
 
         @Feature: OpenScap - Search
@@ -312,11 +313,11 @@ class OpenScap(UITestCase):
         @Assert: Whether searching Non-Compliant systems is possible.
 
         @Status: Manual
-
         """
 
     @stubbed()
-    def test_compare_audit_results(self):
+    @tier3
+    def test_positive_compare_audit_results(self):
         """@Test: Should be able to compare multiple audit results of
         "Hosts"/systems.
 
@@ -337,11 +338,11 @@ class OpenScap(UITestCase):
         is possible.
 
         @Status: Manual
-
         """
 
     @stubbed()
-    def test_assign_policies_for_multiplehosts(self):
+    @tier3
+    def test_positive_assign_policies_for_hosts(self):
         """@Test: Should be able to assign policies for the hosts.
 
         @Feature: OpenScap - Assigning policies.
@@ -357,18 +358,17 @@ class OpenScap(UITestCase):
         @Assert: Whether assigning policies to multiple hosts is possible.
 
         @Status: Manual
-
         """
 
     @stubbed()
-    def test_dashboard_views(self):
+    @tier2
+    def test_positive_check_dashboard_views(self):
         """@Test: Dashboard views that can tell Audited/Un-Audited,
         Compliant/Non-Compliant and trends.
 
         @Feature: OpenScap - Dashboard.
 
-        @Assert: Whether the mentioned Dashboard views are visible.
+        @Assert: Expected Dashboard views are visible.
 
         @Status: Manual
-
         """

--- a/tests/foreman/ui/test_operatingsystem.py
+++ b/tests/foreman/ui/test_operatingsystem.py
@@ -6,7 +6,7 @@ from nailgun import entities
 from robottelo.constants import (
     INSTALL_MEDIUM_URL, PARTITION_SCRIPT_DATA_FILE)
 from robottelo.datafactory import invalid_values_list, valid_data_list
-from robottelo.decorators import run_only_on, skip_if_bug_open
+from robottelo.decorators import run_only_on, skip_if_bug_open, tier1, tier2
 from robottelo.helpers import get_data_file
 from robottelo.test import UITestCase
 from robottelo.ui.base import UIError
@@ -41,22 +41,22 @@ def valid_os_parameters():
     ]
 
 
-class OperatingSys(UITestCase):
+class OperatingSystemTestCase(UITestCase):
     """Implements Operating system tests from UI"""
 
     @classmethod
     def setUpClass(cls):
-        super(OperatingSys, cls).setUpClass()
+        super(OperatingSystemTestCase, cls).setUpClass()
         cls.organization = entities.Organization().create()
 
     @run_only_on('sat')
-    def test_create_os_with_different_names(self):
+    @tier1
+    def test_positive_create_with_name(self):
         """@Test: Create a new OS using different string types as a name
 
         @Feature: OS - Positive Create
 
         @Assert: OS is created
-
         """
         with Session(self.browser) as session:
             for name in valid_data_list():
@@ -72,13 +72,13 @@ class OperatingSys(UITestCase):
                     self.assertIsNotNone(self.operatingsys.search(name))
 
     @run_only_on('sat')
-    def test_create_os_with_random_params(self):
+    @tier1
+    def test_positive_create(self):
         """@Test: Create a new OS with different data values
 
         @Feature: OS - Positive Create
 
         @Assert: OS is created
-
         """
         with Session(self.browser) as session:
             for test_data in valid_os_parameters():
@@ -97,13 +97,13 @@ class OperatingSys(UITestCase):
                         test_data['desc']))
 
     @run_only_on('sat')
-    def test_negative_create_os_invalid_name(self):
+    @tier1
+    def test_negative_create_with_invalid_name(self):
         """@Test: OS - Create a new OS with invalid name
 
         @Feature: Create a new OS - Negative
 
         @Assert: OS is not created
-
         """
         with Session(self.browser) as session:
             for name in invalid_values_list(interface='ui'):
@@ -120,14 +120,14 @@ class OperatingSys(UITestCase):
                         common_locators['name_haserror']))
 
     @run_only_on('sat')
-    def test_negative_create_os_with_long_desc(self):
+    @tier1
+    def test_negative_create_with_too_long_description(self):
         """@Test: OS - Create a new OS with description containing
         256 characters
 
         @Feature: Create a new OS - Negative
 
         @Assert: OS is not created
-
         """
         name = gen_string('alpha')
         with Session(self.browser) as session:
@@ -145,14 +145,14 @@ class OperatingSys(UITestCase):
             self.assertIsNone(self.operatingsys.search(name))
 
     @run_only_on('sat')
-    def test_negative_create_os_with_wrong_major_version(self):
+    @tier1
+    def test_negative_create_with_invalid_major_version(self):
         """@Test: OS - Create a new OS with incorrect major version value
         (More than 5 characters, empty value, negative number)
 
         @Feature: Create a new OS - Negative
 
         @Assert: OS is not created
-
         """
         with Session(self.browser) as session:
             for major_version in gen_string('numeric', 6), '', '-6':
@@ -171,14 +171,14 @@ class OperatingSys(UITestCase):
                     self.assertIsNone(self.operatingsys.search(name))
 
     @run_only_on('sat')
-    def test_negative_create_os_with_wrong_minor_version(self):
+    @tier1
+    def test_negative_create_with_invalid_minor_version(self):
         """@Test: OS - Create a new OS with incorrect minor version value
         (More than 16 characters and negative number)
 
         @Feature: Create a new OS - Negative
 
         @Assert: OS is not created
-
         """
         name = gen_string('alpha')
         with Session(self.browser) as session:
@@ -198,14 +198,13 @@ class OperatingSys(UITestCase):
 
     @run_only_on('sat')
     @skip_if_bug_open('bugzilla', 1283548)
-    def test_negative_create_os_with_same_name_and_version(self):
+    @tier2
+    def test_negative_create_with_same_name_and_version(self):
         """@Test: OS - Create a new OS with same name and version
 
         @Feature: Create a new OS - Negative
 
         @Assert: OS is not created
-
-
         """
         name = gen_string('alpha')
         major_version = gen_string('numeric', 1)
@@ -232,27 +231,27 @@ class OperatingSys(UITestCase):
                                  (common_locators['haserror']))
 
     @run_only_on('sat')
+    @tier1
     def test_positive_delete(self):
         """@Test: Delete an existing OS
 
         @Feature: OS - Positive Delete
 
-        @Assert: OS is deleted
-
+        @Assert: OS is deleted successfully
         """
         os_name = entities.OperatingSystem().create().name
         with Session(self.browser):
             self.operatingsys.delete(os_name)
 
     @run_only_on('sat')
-    def test_update_os_basic_params(self):
+    @tier1
+    def test_positive_update(self):
         """@Test: Update OS name, major_version, minor_version, os_family
         and arch
 
         @Feature: OS - Positive Update
 
         @Assert: OS is updated
-
         """
         os_name = entities.OperatingSystem().create().name
         with Session(self.browser):
@@ -271,13 +270,13 @@ class OperatingSys(UITestCase):
                     os_name = test_data['name']
 
     @run_only_on('sat')
-    def test_update_os_medium(self):
+    @tier1
+    def test_positive_update_medium(self):
         """@Test: Update OS medium
 
         @Feature: OS - Positive Update
 
         @Assert: OS is updated
-
         """
         medium_name = gen_string('alpha')
         entities.Media(
@@ -293,15 +292,14 @@ class OperatingSys(UITestCase):
             self.assertEqual(medium_name, result_obj['medium'])
 
     @run_only_on('sat')
-    def test_update_os_partition_table(self):
+    @tier1
+    def test_positive_update_ptable(self):
         """@Test: Update OS partition table
 
         @Feature: OS - Positive Update
 
         @Assert: OS is updated
-
         """
-
         ptable = gen_string('alpha', 4)
         script_file = get_data_file(PARTITION_SCRIPT_DATA_FILE)
         with open(script_file, 'r') as file_contents:
@@ -317,14 +315,13 @@ class OperatingSys(UITestCase):
             self.assertEqual(ptable, result_obj['ptable'])
 
     @run_only_on('sat')
-    def test_update_os_template(self):
+    @tier1
+    def test_positive_update_template(self):
         """@Test: Update provisioning template
 
         @Feature: OS - Positive Update
 
         @Assert: OS is updated
-
-
         """
         os_name = gen_string('alpha')
         template_name = gen_string('alpha')
@@ -341,13 +338,13 @@ class OperatingSys(UITestCase):
             self.assertEqual(template_name, result_obj['template'])
 
     @run_only_on('sat')
-    def test_positive_set_os_parameter(self):
-        """@Test: Set OS parameter
+    @tier2
+    def test_positive_set_parameter(self):
+        """@Test: Set Operating System parameter
 
         @Feature: OS - Positive Update
 
-        @Assert: OS is updated
-
+        @Assert: OS is updated with new parameter
         """
         with Session(self.browser):
             try:
@@ -360,13 +357,13 @@ class OperatingSys(UITestCase):
                 self.fail(err)
 
     @run_only_on('sat')
-    def test_positive_set_os_parameter_with_blank_value(self):
+    @tier2
+    def test_positive_set_parameter_with_blank_value(self):
         """@Test: Set OS parameter with blank value
 
         @Feature: OS - Positive update
 
         @Assert: Parameter is created with blank value
-
         """
         with Session(self.browser):
             try:
@@ -379,13 +376,13 @@ class OperatingSys(UITestCase):
                 self.fail(err)
 
     @run_only_on('sat')
-    def test_remove_os_parameter(self):
+    @tier2
+    def test_positive_remove_parameter(self):
         """@Test: Remove selected OS parameter
 
         @Feature: OS - Positive Update
 
-        @Assert: OS is updated
-
+        @Assert: Expected OS parameter is removed
         """
         param_name = gen_string('alpha', 4)
         os_name = entities.OperatingSystem().create().name
@@ -398,13 +395,13 @@ class OperatingSys(UITestCase):
                 self.fail(err)
 
     @run_only_on('sat')
-    def test_negative_set_os_parameter_same_values(self):
+    @tier2
+    def test_negative_set_parameter_same_values(self):
         """@Test: Set same OS parameter again as it was set earlier
 
         @Feature: OS - Negative Update
 
-        @Assert: Proper error should be raised, Name already taken
-
+        @Assert: Proper error should be raised - Name is already taken
         """
         param_name = gen_string('alpha', 4)
         param_value = gen_string('alpha', 3)
@@ -421,13 +418,13 @@ class OperatingSys(UITestCase):
             ))
 
     @run_only_on('sat')
-    def test_negative_set_os_parameter_with_blank_value(self):
+    @tier2
+    def test_negative_set_parameter_with_blank_name_and_value(self):
         """@Test: Set OS parameter with blank name and value
 
         @Feature: OS - Negative Update
 
-        @Assert: Proper error should be raised, Name can't contain whitespaces
-
+        @Assert: Proper error should be raised - Name can't contain whitespaces
         """
         with Session(self.browser):
             try:
@@ -440,13 +437,13 @@ class OperatingSys(UITestCase):
             ))
 
     @run_only_on('sat')
-    def test_negative_set_os_parameter_with_long_values(self):
+    @tier2
+    def test_negative_set_parameter_with_too_long_values(self):
         """@Test: Set OS parameter with name and value exceeding 255 characters
 
         @Feature: OS - Negative Update
 
         @Assert: Proper error should be raised, Name should contain a value
-
         """
         os_name = entities.OperatingSystem().create().name
         with Session(self.browser):

--- a/tests/foreman/ui/test_oscapcontent.py
+++ b/tests/foreman/ui/test_oscapcontent.py
@@ -14,12 +14,12 @@ from robottelo.ui.locators import common_locators
 from robottelo.ui.session import Session
 
 
-class OpenScapContent(UITestCase):
+class OpenScapContentTestCase(UITestCase):
     """Implements Oscap Content tests in UI."""
 
     @classmethod
     def setUpClass(cls):
-        super(OpenScapContent, cls).setUpClass()
+        super(OpenScapContentTestCase, cls).setUpClass()
         path = settings.oscap.content_path
         cls.content_path = get_data_file(path)
 
@@ -48,9 +48,9 @@ class OpenScapContent(UITestCase):
                     self.assertIsNotNone(
                         self.oscapcontent.search(content_name))
 
-    @tier1
     @skip_if_bug_open('bugzilla', 1289571)
-    def test_negative_create(self):
+    @tier1
+    def test_negative_create_with_invalid_name(self):
         """@Test: Create OpenScap content with negative values
 
         @Feature: OpenScap - Negative Create.
@@ -60,7 +60,7 @@ class OpenScapContent(UITestCase):
         1. Create an openscap content.
         2. Provide all the appropriate parameters.
 
-        @Assert: Whether creating  content for OpenScap is not successful.
+        @Assert: Creating content for OpenScap is not successful.
         """
         with Session(self.browser) as session:
             for content_name in invalid_values_list(interface='ui'):

--- a/tests/foreman/ui/test_partitiontable.py
+++ b/tests/foreman/ui/test_partitiontable.py
@@ -3,7 +3,7 @@
 from fauxfactory import gen_string
 from robottelo.constants import PARTITION_SCRIPT_DATA_FILE
 from robottelo.datafactory import generate_strings_list, invalid_values_list
-from robottelo.decorators import bz_bug_is_open, run_only_on
+from robottelo.decorators import bz_bug_is_open, run_only_on, tier1
 from robottelo.helpers import read_data_file
 from robottelo.test import UITestCase
 from robottelo.ui.factory import make_partitiontable
@@ -33,17 +33,17 @@ def valid_partition_table_update_names():
     ]
 
 
-class PartitionTable(UITestCase):
+class PartitionTableTestCase(UITestCase):
     """Implements the partition table tests from UI"""
 
     @run_only_on('sat')
-    def test_positive_create_partition_table(self):
+    @tier1
+    def test_positive_create_with_name(self):
         """@Test: Create a new partition table
 
         @Feature: Partition table - Positive Create
 
         @Assert: Partition table is created
-
         """
         with Session(self.browser) as session:
             for name in generate_strings_list(length=10):
@@ -57,13 +57,13 @@ class PartitionTable(UITestCase):
                     self.assertIsNotNone(self.partitiontable.search(name))
 
     @run_only_on('sat')
-    def test_negative_create_partition_table_invalid_names(self):
+    @tier1
+    def test_negative_create_with_invalid_name(self):
         """@Test: Create partition table with invalid names
 
         @Feature: Partition table - Negative Create
 
         @Assert: Partition table is not created
-
         """
         with Session(self.browser) as session:
             for name in invalid_values_list(interface='ui'):
@@ -80,13 +80,13 @@ class PartitionTable(UITestCase):
                     )
 
     @run_only_on('sat')
-    def test_negative_create_partition_table_with_same_name(self):
+    @tier1
+    def test_negative_create_with_same_name(self):
         """@Test: Create a new partition table with same name
 
         @Feature: Partition table - Negative Create
 
         @Assert: Partition table is not created
-
         """
         name = gen_string('utf8')
         layout = read_data_file(PARTITION_SCRIPT_DATA_FILE)
@@ -101,13 +101,13 @@ class PartitionTable(UITestCase):
                                  (common_locators['name_haserror']))
 
     @run_only_on('sat')
-    def test_negative_create_partition_table_empty_layout(self):
+    @tier1
+    def test_negative_create_with_empty_layout(self):
         """@Test: Create a new partition table with empty layout
 
         @Feature: Partition table - Negative Create
 
         @Assert: Partition table is not created
-
         """
         name = gen_string('utf8')
         with Session(self.browser) as session:
@@ -118,13 +118,13 @@ class PartitionTable(UITestCase):
             self.assertIsNone(self.partitiontable.search(name))
 
     @run_only_on('sat')
+    @tier1
     def test_positive_delete(self):
         """@Test: Delete a partition table
 
         @Feature: Partition table - Positive Delete
 
         @Assert: Partition table is deleted
-
         """
         with Session(self.browser) as session:
             for test_data in valid_partition_table_names():
@@ -144,13 +144,13 @@ class PartitionTable(UITestCase):
                     self.partitiontable.delete(name)
 
     @run_only_on('sat')
-    def test_update_partition_table(self):
+    @tier1
+    def test_positive_update(self):
         """@Test: Update partition table with its name, layout and OS family
 
         @Feature: Partition table - Positive Update
 
         @Assert: Partition table is updated
-
         """
         name = gen_string('alphanumeric')
         with Session(self.browser) as session:

--- a/tests/foreman/ui/test_product.py
+++ b/tests/foreman/ui/test_product.py
@@ -4,30 +4,31 @@
 from fauxfactory import gen_string
 from nailgun import entities
 from robottelo.datafactory import generate_strings_list, invalid_values_list
-from robottelo.decorators import run_only_on
+from robottelo.decorators import run_only_on, tier1, tier2
 from robottelo.test import UITestCase
 from robottelo.ui.factory import make_product
 from robottelo.ui.locators import common_locators
 from robottelo.ui.session import Session
 
 
-class Products(UITestCase):
+class ProductTestCase(UITestCase):
     """Implements Product tests in UI"""
 
     @classmethod
     def setUpClass(cls):
-        super(Products, cls).setUpClass()
+        super(ProductTestCase, cls).setUpClass()
         cls.organization = entities.Organization().create()
         cls.loc = entities.Location().create()
 
     @run_only_on('sat')
-    def test_positive_create_basic(self):
-        """@Test: Create Content Product minimal input parameters
+    @tier1
+    def test_positive_create_with_name(self):
+        """@Test: Create Content Product providing different names and minimal
+        input parameters
 
         @Feature: Content Product - Positive Create
 
         @Assert: Product is created
-
         """
         with Session(self.browser) as session:
             for prd_name in generate_strings_list():
@@ -42,49 +43,36 @@ class Products(UITestCase):
                     self.assertIsNotNone(self.products.search(prd_name))
 
     @run_only_on('sat')
+    @tier2
     def test_positive_create_in_different_orgs(self):
         """@Test: Create Content Product with same name but in another org
 
         @Feature: Content Product - Positive Create
 
-        @Assert: Product is created successfully in both the orgs.
-
+        @Assert: Product is created successfully in both organizations.
         """
-        for prd_name in generate_strings_list():
-            with self.subTest(prd_name):
-                # Note 1: the second org is created before logging in to
-                # browser session otherwise this new org will not show up in
-                # org dropdown
-                # Note 2: Also note that the session is logged out and logged
-                # back in for every iteration unlike other subTest()
-                # implementations mainly for re-populating the org dropdown
-                org2 = entities.Organization().create()
-                with Session(self.browser) as session:
-                    make_product(
-                        session,
-                        org=self.organization.name,
-                        loc=self.loc.name,
-                        name=prd_name,
-                        description=gen_string('alphanumeric'),
-                    )
-                    self.assertIsNotNone(self.products.search(prd_name))
-                    make_product(
-                        session,
-                        org=org2.name,
-                        loc=self.loc.name,
-                        name=prd_name,
-                        description=gen_string('alphanumeric'),
-                    )
-                    self.assertIsNotNone(self.products.search(prd_name))
+        organization_2 = entities.Organization().create()
+        with Session(self.browser) as session:
+            for prd_name in generate_strings_list():
+                with self.subTest(prd_name):
+                    for org in [self.organization.name, organization_2.name]:
+                        make_product(
+                            session,
+                            org=org,
+                            loc=self.loc.name,
+                            name=prd_name,
+                            description=gen_string('alphanumeric'),
+                        )
+                        self.assertIsNotNone(self.products.search(prd_name))
 
     @run_only_on('sat')
+    @tier1
     def test_negative_create_with_invalid_name(self):
         """@Test: Create Content Product with invalid names
 
         @Feature: Content Product - Negative Create zero length
 
         @Assert: Product is not created
-
         """
         with Session(self.browser) as session:
             for name in invalid_values_list(interface='ui'):
@@ -100,13 +88,13 @@ class Products(UITestCase):
                         common_locators['common_invalid']))
 
     @run_only_on('sat')
+    @tier1
     def test_negative_create_with_same_name(self):
         """@Test: Create Content Product with same name input parameter
 
         @Feature: Content Product - Negative Create with same name
 
         @Assert: Product is not created
-
         """
         prd_name = gen_string('alphanumeric')
         description = gen_string('alphanumeric')
@@ -124,13 +112,13 @@ class Products(UITestCase):
                 common_locators['common_haserror']))
 
     @run_only_on('sat')
-    def test_positive_update_basic(self):
-        """@Test: Update Content Product with minimal input parameters
+    @tier1
+    def test_positive_update_name(self):
+        """@Test: Update Content Product name with minimal input parameters
 
         @Feature: Content Product - Positive Update
 
         @Assert: Product is updated
-
         """
         prd_name = gen_string('alpha')
         with Session(self.browser) as session:
@@ -149,13 +137,13 @@ class Products(UITestCase):
                     prd_name = new_prd_name  # for next iteration
 
     @run_only_on('sat')
+    @tier2
     def test_positive_update_to_original_name(self):
         """@Test: Rename Product back to original name.
 
         @Feature: Content Product - Positive Update
 
-        @Assert: Product Renamed to original.
-
+        @Assert: Product renamed to previous value.
         """
         prd_name = gen_string('alphanumeric')
         new_prd_name = gen_string('alphanumeric')
@@ -174,13 +162,13 @@ class Products(UITestCase):
             self.assertIsNotNone(self.products.search(prd_name))
 
     @run_only_on('sat')
+    @tier1
     def test_negative_update_with_too_long_name(self):
         """@Test: Update Content Product with too long input parameters
 
         @Feature: Content Product - Negative Update
 
         @Assert: Product is not updated
-
         """
         prd_name = gen_string('alpha')
         with Session(self.browser) as session:
@@ -197,13 +185,13 @@ class Products(UITestCase):
                 common_locators['alert.error']))
 
     @run_only_on('sat')
+    @tier1
     def test_positive_delete(self):
         """@Test: Delete Content Product
 
         @Feature: Content Product - Positive Delete
 
         @Assert: Product is deleted
-
         """
         with Session(self.browser) as session:
             for prd_name in generate_strings_list():

--- a/tests/foreman/ui/test_puppetclass.py
+++ b/tests/foreman/ui/test_puppetclass.py
@@ -3,22 +3,23 @@
 
 from nailgun import entities
 from robottelo.datafactory import valid_data_list
-from robottelo.decorators import run_only_on
+from robottelo.decorators import run_only_on, tier1
 from robottelo.test import UITestCase
 from robottelo.ui.session import Session
 
 
-class PuppetClasses(UITestCase):
+class PuppetClassTestCase(UITestCase):
     """Implements puppet classes tests in UI."""
 
     @run_only_on('sat')
-    def test_update_positive(self):
-        """@Test: Create new puppet-class
+    @tier1
+    def test_positive_update_description(self):
+        """@Test: Create new puppet-class and update its description to a valid
+        one
 
         @Feature: Puppet-Classes - Positive Update
 
-        @Assert: Puppet-Classes is updated.
-
+        @Assert: Puppet-Classes is updated successfully.
         """
         class_name = 'foreman_scap_client'
         param_name = 'ca file'
@@ -39,13 +40,13 @@ class PuppetClasses(UITestCase):
                     )
 
     @run_only_on('sat')
+    @tier1
     def test_positive_delete(self):
-        """@Test: Create new puppet-class
+        """@Test: Create new puppet-class and then delete it
 
         @Feature: Puppet-Classes - Positive delete
 
-        @Assert: Puppet-Class is deleted
-
+        @Assert: Puppet-Class is deleted successfully.
         """
         with Session(self.browser):
             for name in valid_data_list():

--- a/tests/foreman/ui/test_role.py
+++ b/tests/foreman/ui/test_role.py
@@ -4,22 +4,23 @@
 from fauxfactory import gen_string
 from nailgun import entities
 from robottelo.datafactory import generate_strings_list, invalid_values_list
+from robottelo.decorators import tier1
 from robottelo.test import UITestCase
 from robottelo.ui.factory import make_role
 from robottelo.ui.locators import common_locators
 from robottelo.ui.session import Session
 
 
-class Role(UITestCase):
+class RoleTestCase(UITestCase):
     """Implements Roles tests from UI"""
 
-    def test_create_role_basic(self):
-        """@Test: Create new role
+    @tier1
+    def test_positive_create_with_name(self):
+        """@Test: Create new role using different names
 
         @Feature: Role - Positive Create
 
-        @Assert: Role is created
-
+        @Assert: Role is created successfully
         """
         with Session(self.browser) as session:
             for name in generate_strings_list(length=10):
@@ -27,13 +28,13 @@ class Role(UITestCase):
                     make_role(session, name=name)
                     self.assertIsNotNone(self.role.search(name))
 
-    def test_negative_create_role_invalid_names(self):
-        """@Test: Create new role with invalid names
+    @tier1
+    def test_negative_create_with_invalid_name(self):
+        """@Test: Create new role using invalid names
 
         @Feature: Role - Negative Create
 
         @Assert: Role is not created
-
         """
         with Session(self.browser) as session:
             for name in invalid_values_list(interface='ui'):
@@ -42,13 +43,13 @@ class Role(UITestCase):
                     self.assertIsNotNone(session.nav.wait_until_element(
                         common_locators['name_haserror']))
 
+    @tier1
     def test_positive_delete(self):
         """@Test: Delete an existing role
 
         @Feature: Role - Positive Delete
 
-        @Assert: Role is deleted
-
+        @Assert: Role is deleted successfully
         """
         with Session(self.browser) as session:
             for name in generate_strings_list(length=10):
@@ -56,13 +57,13 @@ class Role(UITestCase):
                     make_role(session, name=name)
                     self.role.delete(name)
 
-    def test_update_role_name(self):
-        """@Test: Update role name
+    @tier1
+    def test_positive_update_name(self):
+        """@Test: Update existing role name
 
         @Feature: Role - Positive Update
 
         @Assert: Role is updated
-
         """
         name = gen_string('utf8')
         with Session(self.browser) as session:
@@ -74,13 +75,13 @@ class Role(UITestCase):
                     self.assertIsNotNone(self.role.search(new_name))
                     name = new_name  # for next iteration
 
-    def test_update_role_permission(self):
-        """@Test: Update role permissions
+    @tier1
+    def test_positive_update_permission(self):
+        """@Test: Update existing role permissions
 
         @Feature: Role - Positive Update
 
         @Assert: Role is updated
-
         """
         name = gen_string('alpha')
         with Session(self.browser) as session:
@@ -93,13 +94,13 @@ class Role(UITestCase):
                 permission_list=['view_architectures', 'create_architectures'],
             )
 
-    def test_update_role_org(self):
-        """@Test: Update organization under selected role
+    @tier1
+    def test_positive_update_org(self):
+        """@Test: Update organization for selected role
 
         @Feature: Role - Positive Update
 
         @Assert: Role is updated
-
         """
         name = gen_string('alpha')
         org = entities.Organization().create()

--- a/tests/foreman/ui/test_setting.py
+++ b/tests/foreman/ui/test_setting.py
@@ -2,7 +2,7 @@
 """Test class for Setting Parameter values"""
 
 from fauxfactory import gen_email, gen_string, gen_url
-from robottelo.decorators import run_only_on, skip_if_bug_open
+from robottelo.decorators import run_only_on, skip_if_bug_open, tier1
 from robottelo.test import UITestCase
 from robottelo.ui.base import UIError
 from robottelo.ui.factory import edit_param
@@ -104,16 +104,17 @@ def invalid_token_duration():
     return [' ', '-1', 'text']
 
 
-class Settings(UITestCase):
+class SettingTestCase(UITestCase):
     """Implements Boundary tests for Settings menu"""
 
-    def test_positive_update_general_param_1(self):
-        """@Test: Updates param "authorize_login_delegation" under General tab
+    @tier1
+    def test_positive_update_authorize_login_delegation_param(self):
+        """@Test: Updates parameter "authorize_login_delegation" under General
+        tab
 
         @Feature: Settings - Update Parameters
 
-        @Assert: Parameter is updated
-
+        @Assert: Parameter is updated successfully
         """
         tab_locator = tab_locators['settings.tab_general']
         param_name = 'authorize_login_delegation'
@@ -132,15 +133,15 @@ class Settings(UITestCase):
                     self.assertEqual(param_value, saved_element)
 
     @skip_if_bug_open('bugzilla', 1125181)
-    def test_positive_update_general_param_2(self):
-        """@Test: Updates param "administrator" under General tab
+    @tier1
+    def test_positive_update_administrator_param(self):
+        """@Test: Updates parameter "administrator" under General tab
 
         @Feature: Settings - Update Parameters
 
-        @Assert: Parameter is updated
+        @Assert: Parameter is updated successfully
 
         @BZ: 1125181
-
         """
         tab_locator = tab_locators['settings.tab_general']
         param_name = 'administrator'
@@ -158,14 +159,14 @@ class Settings(UITestCase):
                         tab_locator, param_name)
                     self.assertEqual(param_value, saved_element)
 
-    def test_positive_update_general_param_3(self):
-        """@Test: Updates param "authorize_login_delegation_api" under General
-        tab
+    @tier1
+    def test_positive_update_authorize_login_delegation_api_param(self):
+        """@Test: Updates parameter "authorize_login_delegation_api" under
+        General tab
 
         @Feature: Settings - Update Parameters
 
-        @Assert: Parameter is updated
-
+        @Assert: Parameter is updated successfully
         """
         tab_locator = tab_locators['settings.tab_general']
         param_name = 'authorize_login_delegation_api'
@@ -184,8 +185,9 @@ class Settings(UITestCase):
                     self.assertEqual(param_value, saved_element)
 
     @skip_if_bug_open('bugzilla', 1125156)
-    def test_negative_update_general_param_4(self):
-        """@Test: Updates param "entries_per_page" under General tab with
+    @tier1
+    def test_negative_update_entries_per_page_param(self):
+        """@Test: Updates parameter "entries_per_page" under General tab with
         invalid values
 
         @Feature: Settings - Negative Update Parameters
@@ -193,7 +195,6 @@ class Settings(UITestCase):
         @Assert: Parameter is not updated
 
         @BZ: 1125156
-
         """
         tab_locator = tab_locators['settings.tab_general']
         param_name = 'entries_per_page'
@@ -215,13 +216,13 @@ class Settings(UITestCase):
                         tab_locator, param_name)
                     self.assertNotEqual(param_value, saved_element)
 
-    def test_positive_update_general_param_5(self):
-        """@Test: Updates param "entries_per_page" under General tab
+    @tier1
+    def test_positive_update_entries_per_page_param(self):
+        """@Test: Updates parameter "entries_per_page" under General tab
 
         @Feature: Settings - Positive Update Parameters
 
-        @Assert: Parameter is updated
-
+        @Assert: Parameter is updated successfully
         """
         param_value = gen_string('numeric', 5)
         tab_locator = tab_locators['settings.tab_general']
@@ -256,15 +257,15 @@ class Settings(UITestCase):
                 )
 
     @skip_if_bug_open('bugzilla', 1125181)
-    def test_positive_update_general_param_6(self):
-        """@Test: Updates param "email_reply_address" under General tab
+    @tier1
+    def test_positive_update_email_reply_address_param(self):
+        """@Test: Updates parameter "email_reply_address" under General tab
 
         @Feature: Settings - Update Parameters
 
-        @Assert: Parameter is updated
+        @Assert: Parameter is updated successfully
 
         @BZ: 1125181
-
         """
         tab_locator = tab_locators['settings.tab_general']
         param_name = 'email_reply_address'
@@ -283,15 +284,15 @@ class Settings(UITestCase):
                     self.assertEqual(param_value, saved_element)
 
     @skip_if_bug_open('bugzilla', 1156195)
-    def test_positive_update_general_param_7(self):
-        """@Test: Updates param "fix_db_cache" under General tab
+    @tier1
+    def test_positive_update_fix_db_cache_param(self):
+        """@Test: Updates parameter "fix_db_cache" under General tab
 
         @Feature: Settings - Update Parameters
 
-        @Assert: Parameter is updated
+        @Assert: Parameter is updated successfully
 
         @BZ: 1156195
-
         """
         tab_locator = tab_locators['settings.tab_general']
         param_name = 'fix_db_cache'
@@ -309,13 +310,13 @@ class Settings(UITestCase):
                         tab_locator, param_name)
                     self.assertEqual(param_value, saved_element)
 
-    def test_positive_update_general_param_8(self):
-        """@Test: Updates param "use_gravatar" under General tab
+    @tier1
+    def test_positive_update_use_gravatar_param(self):
+        """@Test: Updates parameter "use_gravatar" under General tab
 
         @Feature: Settings - Update Parameters
 
-        @Assert: Parameter is updated
-
+        @Assert: Parameter is updated successfully
         """
         tab_locator = tab_locators['settings.tab_general']
         param_name = 'use_gravatar'
@@ -334,8 +335,9 @@ class Settings(UITestCase):
                     self.assertEqual(param_value, saved_element)
 
     @skip_if_bug_open('bugzilla', 1125156)
-    def test_negative_update_general_param_9(self):
-        """@Test: Updates param "max_trend" under General tab with invalid
+    @tier1
+    def test_negative_update_max_trend_param(self):
+        """@Test: Updates parameter "max_trend" under General tab with invalid
         values
 
         @Feature: Settings - Negative Update Parameters
@@ -343,7 +345,6 @@ class Settings(UITestCase):
         @Assert: Parameter is not updated
 
         @BZ: 1125156
-
         """
         tab_locator = tab_locators['settings.tab_general']
         param_name = 'max_trend'
@@ -365,13 +366,13 @@ class Settings(UITestCase):
                         tab_locator, param_name)
                     self.assertNotEqual(param_value, saved_element)
 
-    def test_positive_update_general_param_10(self):
-        """@Test: Updates param "max_trend" under General tab
+    @tier1
+    def test_positive_update_max_trend_param(self):
+        """@Test: Updates parameter "max_trend" under General tab
 
         @Feature: Settings - Positive Update Parameters
 
-        @Assert: Parameter is updated
-
+        @Assert: Parameter is updated successfully
         """
         tab_locator = tab_locators['settings.tab_general']
         param_name = 'max_trend'
@@ -394,16 +395,16 @@ class Settings(UITestCase):
                     self.assertEqual(param_value.lstrip('0'), saved_element)
 
     @skip_if_bug_open('bugzilla', 1125156)
-    def test_negative_update_general_param_11(self):
-        """@Test: Updates param "idle_timeout" under General tab with invalid
-        values
+    @tier1
+    def test_negative_update_idle_timeout_param(self):
+        """@Test: Updates parameter "idle_timeout" under General tab with
+        invalid values
 
         @Feature: Settings - Negative Update Parameters
 
         @Assert: Parameter is not updated
 
         @BZ: 1125156
-
         """
         tab_locator = tab_locators['settings.tab_general']
         param_name = 'idle_timeout'
@@ -425,13 +426,13 @@ class Settings(UITestCase):
                         tab_locator, param_name)
                     self.assertNotEqual(param_value, saved_element)
 
-    def test_positive_update_general_param_12(self):
-        """@Test: Updates param "idle_timeout" under General tab
+    @tier1
+    def test_positive_update_idle_timeout_param(self):
+        """@Test: Updates parameter "idle_timeout" under General tab
 
         @Feature: Settings - Positive Update Parameters
 
-        @Assert: Parameter is updated
-
+        @Assert: Parameter is updated successfully
         """
         tab_locator = tab_locators['settings.tab_general']
         param_name = 'idle_timeout'
@@ -453,13 +454,13 @@ class Settings(UITestCase):
                     # 'param_value' too
                     self.assertEqual(param_value.lstrip('0'), saved_element)
 
-    def test_positive_update_general_param_13(self):
-        """@Test: Updates param "foreman_url" under General tab
+    @tier1
+    def test_positive_update_foreman_url_param(self):
+        """@Test: Updates parameter "foreman_url" under General tab
 
         @Feature: Settings - Update Parameters
 
-        @Assert: Parameter is updated
-
+        @Assert: Parameter is updated successfully
         """
         tab_locator = tab_locators['settings.tab_general']
         param_name = 'foreman_url'
@@ -478,15 +479,15 @@ class Settings(UITestCase):
                     self.assertEqual(param_value, saved_element)
 
     @skip_if_bug_open('bugzilla', 1125156)
-    def test_negative_update_general_param_14(self):
-        """@Test: Updates param "foreman_url" under General tab
+    @tier1
+    def test_negative_update_foreman_url_param(self):
+        """@Test: Updates parameter "foreman_url" under General tab
 
         @Feature: Settings - Negative update Parameters
 
         @Assert: Parameter is not updated
 
         @BZ: 1125156
-
         """
         tab_locator = tab_locators['settings.tab_general']
         param_name = 'foreman_url'
@@ -508,13 +509,14 @@ class Settings(UITestCase):
                         tab_locator, param_name)
                     self.assertNotEqual(param_value, saved_element)
 
-    def test_positive_update_foremantasks_param_15(self):
-        """@Test: Updates param "dynflow_enable_console" under ForemanTasks tab
+    @tier1
+    def test_positive_update_dynflow_enable_console_param(self):
+        """@Test: Updates parameter "dynflow_enable_console" under ForemanTasks
+        tab
 
         @Feature: Settings - Update Parameters
 
-        @Assert: Parameter is updated
-
+        @Assert: Parameter is updated successfully
         """
         tab_locator = tab_locators['settings.tab_foremantasks']
         param_name = 'dynflow_enable_console'
@@ -532,14 +534,14 @@ class Settings(UITestCase):
                         tab_locator, param_name)
                     self.assertEqual(param_value, saved_element)
 
-    def test_positive_update_auth_param_16(self):
-        """@Test: Updates param
+    @tier1
+    def test_positive_update_auth_source_user_autocreate_param(self):
+        """@Test: Updates parameter
         "authorize_login_delegation_auth_source_user_autocreate" under Auth tab
 
         @Feature: Settings - Update Parameters
 
-        @Assert: Parameter is updated
-
+        @Assert: Parameter is updated successfully
         """
         tab_locator = tab_locators['settings.tab_auth']
         param_name = 'authorize_login_delegation_auth_source_user_autocreate'
@@ -557,13 +559,14 @@ class Settings(UITestCase):
                         tab_locator, param_name)
                     self.assertEqual(param_value, saved_element)
 
-    def test_positive_update_auth_param_17(self):
-        """@Test: Updates param "login_delegation_logout_url" under Auth tab
+    @tier1
+    def test_positive_update_login_delegation_logout_url_param(self):
+        """@Test: Updates parameter "login_delegation_logout_url" under Auth
+        tab
 
         @Feature: Settings - Update Parameters
 
-        @Assert: Parameter is updated
-
+        @Assert: Parameter is updated successfully
         """
         tab_locator = tab_locators['settings.tab_auth']
         param_name = 'login_delegation_logout_url'
@@ -581,14 +584,14 @@ class Settings(UITestCase):
                         tab_locator, param_name)
                     self.assertEqual(param_value, saved_element)
 
-    def test_positive_update_auth_param_18(self):
+    @tier1
+    def test_positive_update_oauth_active_param(self):
         """@Test: Read-only param "oauth_active" under Auth tab shouldn't be
         updated
 
         @Feature: Settings - Update Parameters
 
         @Assert: Parameter is not editable
-
         """
         tab_locator = tab_locators['settings.tab_auth']
         with Session(self.browser) as session:
@@ -605,13 +608,13 @@ class Settings(UITestCase):
                             'Could not find edit button to update param'
                         )
 
-    def test_positive_update_auth_param_19(self):
-        """@Test: Updates param "require_ssl_puppetmasters" under Auth tab
+    @tier1
+    def test_positive_update_require_ssl_puppetmasters_param(self):
+        """@Test: Updates parameter "require_ssl_puppetmasters" under Auth tab
 
         @Feature: Settings - Update Parameters
 
-        @Assert: Parameter is updated
-
+        @Assert: Parameter is updated successfully
         """
         tab_locator = tab_locators['settings.tab_auth']
         param_name = 'require_ssl_puppetmasters'
@@ -640,14 +643,14 @@ class Settings(UITestCase):
                         param_value=default_value,
                     )
 
-    def test_positive_update_auth_param_20(self):
-        """@Test: Updates param "restrict_registered_puppetmasters" under Auth
-        tab
+    @tier1
+    def test_positive_update_restrict_registered_puppetmasters_param(self):
+        """@Test: Updates parameter "restrict_registered_puppetmasters" under
+        Auth tab
 
         @Feature: Settings - Update Parameters
 
-        @Assert: Parameter is updated
-
+        @Assert: Parameter is updated successfully
         """
         tab_locator = tab_locators['settings.tab_auth']
         param_name = 'restrict_registered_puppetmasters'
@@ -676,13 +679,13 @@ class Settings(UITestCase):
                         param_value=default_value,
                     )
 
-    def test_positive_update_auth_param_21(self):
-        """@Test: Updates param "trusted_puppetmaster_hosts" under Auth tab
+    @tier1
+    def test_positive_update_trusted_puppetmaster_hosts_param(self):
+        """@Test: Updates parameter "trusted_puppetmaster_hosts" under Auth tab
 
         @Feature: Settings - Update Parameters
 
-        @Assert: Parameter is updated
-
+        @Assert: Parameter is updated successfully
         """
         tab_locator = tab_locators['settings.tab_auth']
         param_name = 'trusted_puppetmaster_hosts'
@@ -701,15 +704,15 @@ class Settings(UITestCase):
                     self.assertEqual(param_value, saved_element)
 
     @skip_if_bug_open('bugzilla', 1125156)
-    def test_negative_update_auth_param_22(self):
-        """@Test: Updates param "trusted_puppetmaster_hosts" under Auth tab
+    @tier1
+    def test_negative_update_trusted_puppetmaster_hosts_param(self):
+        """@Test: Updates parameter "trusted_puppetmaster_hosts" under Auth tab
 
         @Feature: Settings - Negative update Parameters
 
         @Assert: Parameter is not updated
 
         @BZ: 1125156
-
         """
         tab_locator = tab_locators['settings.tab_auth']
         param_name = 'trusted_puppetmaster_hosts'
@@ -731,14 +734,14 @@ class Settings(UITestCase):
                         tab_locator, param_name)
                     self.assertNotEqual(param_value, saved_element)
 
-    def test_positive_update_provisioning_param_23(self):
-        """@Test: Updates param "ignore_puppet_facts_for_provisioning" under
-        Provisioning tab
+    @tier1
+    def test_positive_update_ignore_puppet_facts_for_provisioning_param(self):
+        """@Test: Updates parameter "ignore_puppet_facts_for_provisioning"
+        under Provisioning tab
 
         @Feature: Settings - Update Parameters
 
-        @Assert: Parameter is updated
-
+        @Assert: Parameter is updated successfully
         """
         tab_locator = tab_locators['settings.tab_provisioning']
         param_name = 'ignore_puppet_facts_for_provisioning'
@@ -757,39 +760,13 @@ class Settings(UITestCase):
                     self.assertEqual(param_value, saved_element)
 
     @run_only_on('sat')
-    def test_positive_update_provisioning_param_24(self):
-        """@Test: Updates param "ignore_puppet_facts_for_provisioning" under
-        Provisioning tab
+    @tier1
+    def test_positive_update_manage_puppetca_param(self):
+        """@Test: Updates parameter "manage_puppetca" under Provisioning tab
 
         @Feature: Settings - Update Parameters
 
-        @Assert: Parameter is updated
-
-        """
-        tab_locator = tab_locators['settings.tab_provisioning']
-        param_name = 'ignore_puppet_facts_for_provisioning'
-        with Session(self.browser) as session:
-            for param_value in valid_boolean_values():
-                with self.subTest(param_value):
-                    edit_param(
-                        session,
-                        tab_locator=tab_locator,
-                        param_name=param_name,
-                        value_type='dropdown',
-                        param_value=param_value,
-                    )
-                    saved_element = self.settings.get_saved_value(
-                        tab_locator, param_name)
-                    self.assertEqual(param_value, saved_element)
-
-    @run_only_on('sat')
-    def test_positive_update_provisioning_param_25(self):
-        """@Test: Updates param "manage_puppetca" under Provisioning tab
-
-        @Feature: Settings - Update Parameters
-
-        @Assert: Parameter is updated
-
+        @Assert: Parameter is updated successfully
         """
         tab_locator = tab_locators['settings.tab_provisioning']
         param_name = 'manage_puppetca'
@@ -808,14 +785,14 @@ class Settings(UITestCase):
                     self.assertEqual(param_value, saved_element)
 
     @run_only_on('sat')
-    def test_positive_update_provisioning_param_26(self):
-        """@Test: Updates param "query_local_nameservers" under Provisioning
-        tab
+    @tier1
+    def test_positive_update_query_local_nameservers_param(self):
+        """@Test: Updates parameter "query_local_nameservers" under
+        Provisioning tab
 
         @Feature: Settings - Update Parameters
 
-        @Assert: Parameter is updated
-
+        @Assert: Parameter is updated successfully
         """
         tab_locator = tab_locators['settings.tab_provisioning']
         param_name = 'query_local_nameservers'
@@ -834,13 +811,13 @@ class Settings(UITestCase):
                     self.assertEqual(param_value, saved_element)
 
     @run_only_on('sat')
-    def test_positive_update_provisioning_param_27(self):
-        """@Test: Updates param "safemode_render" under Provisioning tab
+    @tier1
+    def test_positive_update_safemode_render_param(self):
+        """@Test: Updates parameter "safemode_render" under Provisioning tab
 
         @Feature: Settings - Update Parameters
 
-        @Assert: Parameter is updated
-
+        @Assert: Parameter is updated successfully
         """
         tab_locator = tab_locators['settings.tab_provisioning']
         param_name = 'safemode_render'
@@ -860,16 +837,16 @@ class Settings(UITestCase):
 
     @run_only_on('sat')
     @skip_if_bug_open('bugzilla', 1125156)
-    def test_negative_update_provisioning_param_28(self):
-        """@Test: Updates param "token_duration" under Provisioning tab with
-        invalid values
+    @tier1
+    def test_negative_update_token_duration_param(self):
+        """@Test: Updates parameter "token_duration" under Provisioning tab
+        with invalid values
 
         @Feature: Settings - Negative Update Parameters
 
         @Assert: Parameter is not updated
 
         @BZ: 1125156
-
         """
         tab_locator = tab_locators['settings.tab_provisioning']
         param_name = 'token_duration'
@@ -892,13 +869,13 @@ class Settings(UITestCase):
                     self.assertNotEqual(param_value, saved_element)
 
     @run_only_on('sat')
-    def test_positive_update_provisioning_param_29(self):
+    @tier1
+    def test_positive_update_token_duration_param(self):
         """@Test: Updates param "token_duration" under Provisioning tab
 
         @Feature: Settings - Positive Update Parameters
 
-        @Assert: Parameter is updated
-
+        @Assert: Parameter is updated successfully
         """
         tab_locator = tab_locators['settings.tab_provisioning']
         param_name = 'token_duration'

--- a/tests/foreman/ui/test_sso.py
+++ b/tests/foreman/ui/test_sso.py
@@ -1,11 +1,11 @@
 # -*- encoding: utf-8 -*-
 """Test class for SSO (UI)"""
 
-from robottelo.decorators import stubbed
+from robottelo.decorators import stubbed, tier3
 from robottelo.test import UITestCase
 
 
-class TestSSOUI(UITestCase):
+class SingleSignOnTestCase(UITestCase):
     """Implements SSO tests in UI"""
     # Notes for SSO testing:
     # Of interest... In some test cases I've placed a few comments prefaced
@@ -31,7 +31,8 @@ class TestSSOUI(UITestCase):
     # http://theforeman.org/manuals/1.8/index.html#4.1.1LDAPAuthentication
 
     @stubbed()
-    def test_sso_kerberos_basic_no_roles(self):
+    @tier3
+    def test_positive_sso_kerberos_basic_no_roles(self):
         """@test: SSO - kerberos (IdM or AD) login (basic) that has no roles
 
         @feature: SSO or External Authentication
@@ -47,11 +48,11 @@ class TestSSOUI(UITestCase):
         useful in UI
 
         @status: Manual
-
         """
 
     @stubbed()
-    def test_sso_kerberos_basic_roles(self):
+    @tier3
+    def test_positive_sso_kerberos_basic_roles(self):
         """@test: SSO - kerberos (IdM or AD) login (basic) that has roles
         assigned.
 
@@ -72,7 +73,8 @@ class TestSSOUI(UITestCase):
         """
 
     @stubbed()
-    def test_sso_kerberos_user_disabled(self):
+    @tier3
+    def test_negative_sso_kerberos_user_disabled(self):
         """@test: Kerberos (IdM or AD) user activity when kerb (IdM or AD)
         account has been deleted or deactivated.
 
@@ -86,5 +88,4 @@ class TestSSOUI(UITestCase):
         and no data corruption
 
         @status: Manual
-
         """

--- a/tests/foreman/ui/test_subnet.py
+++ b/tests/foreman/ui/test_subnet.py
@@ -4,7 +4,7 @@
 from fauxfactory import gen_ipaddr, gen_netmask, gen_string
 from nailgun import entities
 from robottelo.datafactory import generate_strings_list, invalid_values_list
-from robottelo.decorators import bz_bug_is_open, run_only_on
+from robottelo.decorators import bz_bug_is_open, run_only_on, tier1, tier2
 from robottelo.test import UITestCase
 from robottelo.ui.factory import make_subnet
 from robottelo.ui.locators import common_locators, locators, tab_locators
@@ -22,22 +22,22 @@ def valid_long_names():
     ]
 
 
-class Subnet(UITestCase):
+class SubnetTestCase(UITestCase):
     """Implements Subnet tests in UI"""
 
     @classmethod
     def setUpClass(cls):
-        super(Subnet, cls).setUpClass()
+        super(SubnetTestCase, cls).setUpClass()
         cls.organization = entities.Organization().create()
 
     @run_only_on('sat')
-    def test_create_subnet_with_different_names(self):
-        """@Test: Create new subnet
+    @tier1
+    def test_positive_create_with_name(self):
+        """@Test: Create new subnet using different names
 
         @Feature: Subnet - Positive Create
 
         @Assert: Subnet is created
-
         """
         with Session(self.browser) as session:
             for name in generate_strings_list(length=8):
@@ -51,13 +51,13 @@ class Subnet(UITestCase):
                     self.assertIsNotNone(self.subnet.search(name))
 
     @run_only_on('sat')
-    def test_create_subnet_with_long_strings(self):
+    @tier1
+    def test_positive_create_with_long_name(self):
         """@Test: Create new subnet with 255 characters in name
 
         @Feature: Subnet - Positive Create
 
         @Assert: Subnet is created with 255 chars
-
         """
         with Session(self.browser) as session:
             for test_data in valid_long_names():
@@ -77,13 +77,13 @@ class Subnet(UITestCase):
                         self.subnet.search(test_data['name']))
 
     @run_only_on('sat')
-    def test_create_subnet_with_domain(self):
+    @tier2
+    def test_positive_add_domain(self):
         """@Test: Create new subnet and associate domain with it
 
         @Feature: Subnet - Positive Create
 
         @Assert: Subnet is created with domain associated
-
         """
         strategy1, value1 = common_locators['entity_deselect']
         strategy2, value2 = common_locators['entity_checkbox']
@@ -118,13 +118,13 @@ class Subnet(UITestCase):
                 self.assertIsNotNone()
 
     @run_only_on('sat')
-    def test_create_subnet_negative_invalid_name(self):
+    @tier1
+    def test_negative_create_with_invalid_name(self):
         """@Test: Create new subnet with invalid names
 
         @Feature: Subnet - Negative Create
 
         @Assert: Subnet is not created
-
         """
         with Session(self.browser) as session:
             for name in invalid_values_list(interface='ui'):
@@ -139,13 +139,13 @@ class Subnet(UITestCase):
                         common_locators['haserror']))
 
     @run_only_on('sat')
-    def test_create_subnet_negative_values(self):
+    @tier1
+    def test_negative_create_with_invalid_params(self):
         """@Test: Create new subnet with negative values
 
         @Feature: Subnet - Negative Create.
 
-        @Assert: Subnet is not created with negative values
-
+        @Assert: Subnet is not created
         """
         with Session(self.browser) as session:
             make_subnet(
@@ -169,13 +169,13 @@ class Subnet(UITestCase):
                 locators['subnet.dnssecondary_haserror']))
 
     @run_only_on('sat')
+    @tier1
     def test_positive_delete(self):
-        """@Test: Delete a subnet
+        """@Test: Delete an existing subnet
 
         @Feature: Subnet - Positive Delete
 
         @Assert: Subnet is deleted
-
         """
         with Session(self.browser) as session:
             for name in generate_strings_list(length=8):
@@ -189,6 +189,7 @@ class Subnet(UITestCase):
                     self.subnet.delete(name)
 
     @run_only_on('sat')
+    @tier1
     def test_negative_delete(self):
         """@Test: Delete subnet. Attempt to delete subnet, but cancel in the
         confirmation dialog box.
@@ -196,7 +197,6 @@ class Subnet(UITestCase):
         @Feature: Subnet - Negative Delete
 
         @Assert: Subnet is not deleted
-
         """
         name = gen_string('utf8')
         with Session(self.browser) as session:
@@ -209,13 +209,13 @@ class Subnet(UITestCase):
             self.subnet.delete(name, really=False)
 
     @run_only_on('sat')
-    def test_update_subnet_with_name(self):
+    @tier1
+    def test_positive_update_name(self):
         """@Test: Update Subnet name
 
         @Feature: Subnet - Positive Update
 
         @Assert: Subnet name is updated
-
         """
         name = gen_string('alpha')
         with Session(self.browser) as session:
@@ -233,13 +233,13 @@ class Subnet(UITestCase):
                     name = new_name  # for next iteration
 
     @run_only_on('sat')
-    def test_update_subnet_with_network(self):
+    @tier1
+    def test_positive_update_network(self):
         """@Test: Update Subnet network
 
         @Feature: Subnet - Positive Update
 
         @Assert: Subnet network is updated
-
         """
         name = gen_string('alpha')
         new_network = gen_ipaddr(ip3=True)
@@ -255,13 +255,13 @@ class Subnet(UITestCase):
             self.assertEqual(new_network, result_object['network'])
 
     @run_only_on('sat')
-    def test_update_subnet_with_mask(self):
+    @tier1
+    def test_positive_update_mask(self):
         """@Test: Update Subnet mask
 
         @Feature: Subnet - Positive Update
 
         @Assert: Subnet mask is updated
-
         """
         name = gen_string('alpha')
         new_mask = gen_netmask(16, 31)

--- a/tests/foreman/ui/test_subscription.py
+++ b/tests/foreman/ui/test_subscription.py
@@ -2,6 +2,7 @@
 from nailgun import entities
 from robottelo import manifests
 from robottelo.constants import DEFAULT_SUBSCRIPTION_NAME
+from robottelo.decorators import skip_if_not_set, tier1
 from robottelo.ssh import upload_file
 from robottelo.test import UITestCase
 from robottelo.ui.locators import common_locators, locators
@@ -16,13 +17,14 @@ class SubscriptionTestCase(UITestCase):
         super(SubscriptionTestCase, cls).setUpClass()
         cls.organization = entities.Organization().create()
 
+    @skip_if_not_set('fake_manifest')
+    @tier1
     def test_positive_upload_basic(self):
         """@Test: Upload a manifest with minimal input parameters
 
         @Feature: Manifest/Subscription - Positive Create
 
-        @Assert: Manifest is uploaded
-
+        @Assert: Manifest is uploaded successfully
         """
         manifest_path = manifests.clone()
         # upload_file function should take care of uploading to sauce labs.
@@ -34,13 +36,14 @@ class SubscriptionTestCase(UITestCase):
             self.assertTrue(self.subscriptions.wait_until_element(
                 common_locators['alert.success']))
 
+    @skip_if_not_set('fake_manifest')
+    @tier1
     def test_positive_delete(self):
         """@Test: Upload a manifest and then delete it
 
         @Feature: Manifest/Subscription - Positive Delete
 
         @Assert: Manifest is deleted successfully
-
         """
         manifest_path = manifests.clone()
         # upload_file function should take care of uploading to sauce labs.
@@ -53,14 +56,15 @@ class SubscriptionTestCase(UITestCase):
             self.assertTrue(self.subscriptions.wait_until_element(
                 common_locators['alert.success']))
 
-    def test_assert_delete_button(self):
+    @skip_if_not_set('fake_manifest')
+    @tier1
+    def test_positive_assert_delete_button(self):
         """@Test: Upload and delete a manifest
 
         @Feature: Manifest/Subscription - Positive Delete
 
         @Assert: Manifest is Deleted. Delete button is asserted. Subscriptions
         is asserted
-
         """
         manifest_path = manifests.clone()
         # upload_file function should take care of uploading to sauce labs.

--- a/tests/foreman/ui/test_sync.py
+++ b/tests/foreman/ui/test_sync.py
@@ -5,7 +5,7 @@ from robottelo import manifests
 from robottelo.api.utils import upload_manifest
 from robottelo.constants import FAKE_1_YUM_REPO
 from robottelo.datafactory import generate_strings_list
-from robottelo.decorators import run_only_on
+from robottelo.decorators import run_only_on, skip_if_not_set, tier1, tier2
 from robottelo.test import UITestCase
 from robottelo.ui.session import Session
 
@@ -19,21 +19,21 @@ RHCT = [('rhel', 'rhct6', 'rhct65', 'repo_name',
         ('rhel', 'rhct6', 'rhct6S', 'repo_ver', '6Server')]
 
 
-class Sync(UITestCase):
+class SyncTestCase(UITestCase):
     """Implements Custom Sync tests in UI"""
 
     def setUp(self):  # noqa
-        super(Sync, self).setUp()
+        super(SyncTestCase, self).setUp()
         self.organization = entities.Organization().create()
 
     @run_only_on('sat')
-    def test_sync_custom_repos(self):
+    @tier1
+    def test_positive_sync_custom_repo(self):
         """@Test: Create Content Custom Sync with minimal input parameters
 
         @Feature: Content Custom Sync - Positive Create
 
-        @Assert: Whether Sync is successful
-
+        @Assert: Sync procedure is successful
         """
         # Creates new product
         product = entities.Product(organization=self.organization).create()
@@ -54,13 +54,14 @@ class Sync(UITestCase):
                     # sync.sync_custom_repos returns boolean value
                     self.assertTrue(sync)
 
-    def test_sync_rh_repos(self):
+    @skip_if_not_set('fake_manifest')
+    @tier2
+    def test_positive_sync_rh_repos(self):
         """@Test: Create Content RedHat Sync with two repos.
 
         @Feature: Content RedHat Sync - Positive Create
 
-        @Assert: Whether Syncing RedHat Repos is successful
-
+        @Assert: Sync procedure for RedHat Repos is successful
         """
         repos = self.sync.create_repos_tree(RHCT)
         with open(manifests.clone(), 'rb') as manifest:

--- a/tests/foreman/ui/test_syncplan.py
+++ b/tests/foreman/ui/test_syncplan.py
@@ -6,7 +6,7 @@ from nailgun import entities
 from random import randint
 from robottelo.constants import SYNC_INTERVAL
 from robottelo.datafactory import generate_strings_list, invalid_values_list
-from robottelo.decorators import skip_if_bug_open
+from robottelo.decorators import tier1, tier2
 from robottelo.test import UITestCase
 from robottelo.ui.factory import make_syncplan
 from robottelo.ui.locators import common_locators, locators, tab_locators
@@ -22,21 +22,21 @@ def valid_sync_intervals():
     ]
 
 
-class Syncplan(UITestCase):
+class SyncPlanTestCase(UITestCase):
     """Implements Sync Plan tests in UI"""
 
     @classmethod
     def setUpClass(cls):
-        super(Syncplan, cls).setUpClass()
+        super(SyncPlanTestCase, cls).setUpClass()
         cls.organization = entities.Organization().create()
 
-    def test_positive_create_names(self):
+    @tier1
+    def test_positive_create_with_name(self):
         """@Test: Create Sync Plan with valid name values
 
         @Feature: Content Sync Plan - Positive Create
 
         @Assert: Sync Plan is created
-
         """
         with Session(self.browser) as session:
             for name in generate_strings_list():
@@ -50,13 +50,13 @@ class Syncplan(UITestCase):
                     )
                     self.assertIsNotNone(self.syncplan.search(name))
 
-    def test_positive_create_descriptions(self):
+    @tier1
+    def test_positive_create_with_description(self):
         """@Test: Create Sync Plan with valid desc values
 
         @Feature: Content Sync Plan - Positive Create
 
         @Assert: Sync Plan is created
-
         """
         with Session(self.browser) as session:
             for desc in generate_strings_list():
@@ -71,13 +71,13 @@ class Syncplan(UITestCase):
                     )
                     self.assertIsNotNone(self.syncplan.search(name))
 
-    def test_positive_create_sync_intervals(self):
+    @tier1
+    def test_positive_create_with_sync_interval(self):
         """@Test: Create Sync Plan with valid sync intervals
 
         @Feature: Content Sync Plan - Positive Create
 
         @Assert: Sync Plan is created
-
         """
         with Session(self.browser) as session:
             for interval in valid_sync_intervals():
@@ -92,13 +92,13 @@ class Syncplan(UITestCase):
                     )
                     self.assertIsNotNone(self.syncplan.search(name))
 
+    @tier2
     def test_positive_create_with_start_time(self):
         """@Test: Create Sync plan with specified start time
 
         @Feature: Content Sync Plan - Positive Create
 
         @Assert: Sync Plan is created with the specified time.
-
         """
         plan_name = gen_string('alpha')
         startdate = datetime.now() + timedelta(minutes=10)
@@ -127,16 +127,13 @@ class Syncplan(UITestCase):
             saved_starttime = str(starttime_text).rpartition(':')[0]
             self.assertEqual(saved_starttime, starttime)
 
-    @skip_if_bug_open('bugzilla', 1246262)
+    @tier2
     def test_positive_create_with_start_date(self):
         """@Test: Create Sync plan with specified start date
 
         @Feature: Content Sync Plan - Positive Create
 
         @Assert: Sync Plan is created with the specified date
-
-        @BZ: 1246262
-
         """
         plan_name = gen_string('alpha')
         startdate = datetime.now() + timedelta(days=10)
@@ -160,13 +157,13 @@ class Syncplan(UITestCase):
             saved_startdate = str(startdate_text).rpartition(',')[0]
             self.assertEqual(saved_startdate, fetch_startdate)
 
-    def test_negative_create_invalid_name(self):
+    @tier1
+    def test_negative_create_with_invalid_name(self):
         """@Test: Create Sync Plan with invalid names
 
         @Feature: Content Sync Plan - Negative Create
 
         @Assert: Sync Plan is not created
-
         """
         with Session(self.browser) as session:
             for name in invalid_values_list(interface='ui'):
@@ -181,13 +178,13 @@ class Syncplan(UITestCase):
                     self.assertIsNotNone(self.syncplan.wait_until_element(
                         common_locators['common_invalid']))
 
+    @tier1
     def test_negative_create_with_same_name(self):
         """@Test: Create Sync Plan with an existing name
 
         @Feature: Content Sync Plan - Positive Create
 
         @Assert: Sync Plan cannot be created with existing name
-
         """
         name = gen_string('alphanumeric')
         with Session(self.browser) as session:
@@ -203,13 +200,13 @@ class Syncplan(UITestCase):
             self.assertIsNotNone(self.syncplan.wait_until_element(
                 common_locators['common_invalid']))
 
+    @tier1
     def test_positive_update_name(self):
         """@Test: Update Sync plan's name
 
         @Feature: Content Sync Plan - Positive Update name
 
         @Assert: Sync Plan's name is updated
-
         """
         plan_name = gen_string('alpha')
         entities.SyncPlan(
@@ -226,13 +223,13 @@ class Syncplan(UITestCase):
                     self.assertIsNotNone(self.syncplan.search(new_plan_name))
                     plan_name = new_plan_name  # for next iteration
 
+    @tier1
     def test_positive_update_interval(self):
         """@Test: Update Sync plan's interval
 
         @Feature: Content Sync Plan - Positive Update interval
 
         @Assert: Sync Plan's interval is updated
-
         """
         name = gen_string('alpha')
         entities.SyncPlan(
@@ -255,13 +252,13 @@ class Syncplan(UITestCase):
                     ).text
                     self.assertEqual(interval_text, new_interval)
 
+    @tier2
     def test_positive_update_product(self):
         """@Test: Update Sync plan and associate products
 
         @Feature: Content Sync Plan - Positive Update add products
 
         @Assert: Sync Plan has the associated product
-
         """
         strategy, value = locators['sp.prd_select']
         product = entities.Product(organization=self.organization).create()
@@ -284,13 +281,13 @@ class Syncplan(UITestCase):
                         (strategy, value % product.name))
                     self.assertIsNotNone(element)
 
+    @tier2
     def test_positive_update_and_disassociate_product(self):
         """@Test: Update Sync plan and disassociate products
 
         @Feature: Content Sync Plan - Positive Update remove products
 
         @Assert: Sync Plan does not have the associated product
-
         """
         plan_name = gen_string('utf8')
         strategy, value = locators['sp.prd_select']
@@ -321,13 +318,13 @@ class Syncplan(UITestCase):
                 (strategy, value % product.name))
             self.assertIsNotNone(element)
 
+    @tier1
     def test_positive_delete(self):
-        """@Test: Delete a Sync plan
+        """@Test: Delete an existing Sync plan
 
         @Feature: Content Sync Plan - Positive Delete
 
-        @Assert: Sync Plan is deleted
-
+        @Assert: Sync Plan is deleted successfully
         """
         with Session(self.browser) as session:
             for plan_name in generate_strings_list():

--- a/tests/foreman/ui/test_system_registration.py
+++ b/tests/foreman/ui/test_system_registration.py
@@ -1,5 +1,5 @@
 """Test module for System Registration UI"""
-from robottelo.decorators import stubbed
+from robottelo.decorators import stubbed, tier3
 from robottelo.test import UITestCase
 
 
@@ -7,7 +7,8 @@ class SystemRegistrationTestCase(UITestCase):
     """Tests for System Registration UI"""
 
     @stubbed()
-    def test_registered_system_get_pushed_content(self):
+    @tier3
+    def test_positive_get_pushed_content(self):
         # variations: content types - RH rpms/errata; custom content rpms;
         # puppet modules
         """@test: assure content types can be pushed down to client via UI
@@ -17,11 +18,11 @@ class SystemRegistrationTestCase(UITestCase):
         @assert: content is installed on client system
 
         @status: Manual
-
         """
 
     @stubbed()
-    def test_registered_system_can_be_listed_ui(self):
+    @tier3
+    def test_positive_list_system_for_org(self):
         """@test: perform a system list for a given org
 
         @feature: system registration
@@ -29,11 +30,11 @@ class SystemRegistrationTestCase(UITestCase):
         @assert: newly registered system can be found in Systems UI
 
         @status: Manual
-
         """
 
     @stubbed()
-    def test_system_deregister_ui(self):
+    @tier3
+    def test_positive_deregister_system(self):
         """@test: delete system via Systems UI
 
         @feature: system registration
@@ -41,11 +42,11 @@ class SystemRegistrationTestCase(UITestCase):
         @assert: after deleting, system no longer appears in system UI.
 
         @status: Manual
-
         """
 
     @stubbed()
-    def test_compliance_green(self):
+    @tier3
+    def test_positive_compliance_green(self):
         """@test: system with appropriate entitlements for subscriptions
 
         @feature: system registration
@@ -53,11 +54,11 @@ class SystemRegistrationTestCase(UITestCase):
         @assert: compliance status is green in UI
 
         @status: Manual
-
         """
 
     @stubbed()
-    def test_compliance_red(self):
+    @tier3
+    def test_positive_compliance_red(self):
         """@test: system without appropriate entitlements for subscriptions
 
         @feature: system registration
@@ -65,11 +66,11 @@ class SystemRegistrationTestCase(UITestCase):
         @assert: compliance status is red in UI
 
         @status: Manual
-
         """
 
     @stubbed()
-    def test_compliance_yellow(self):
+    @tier3
+    def test_positive_compliance_yellow(self):
         """@test: system with some, but not all, appropriate entitlements for
         subscriptions
 
@@ -78,5 +79,4 @@ class SystemRegistrationTestCase(UITestCase):
         @assert: compliance status is yellow in UI
 
         @status: Manual
-
         """

--- a/tests/foreman/ui/test_template.py
+++ b/tests/foreman/ui/test_template.py
@@ -4,7 +4,7 @@ from fauxfactory import gen_string
 from nailgun import entities
 from robottelo.constants import OS_TEMPLATE_DATA_FILE, SNIPPET_DATA_FILE
 from robottelo.datafactory import generate_strings_list, invalid_values_list
-from robottelo.decorators import run_only_on
+from robottelo.decorators import run_only_on, tier1, tier2
 from robottelo.helpers import get_data_file
 from robottelo.test import UITestCase
 from robottelo.ui.base import UIError
@@ -16,23 +16,23 @@ OS_TEMPLATE_DATA_FILE = get_data_file(OS_TEMPLATE_DATA_FILE)
 SNIPPET_DATA_FILE = get_data_file(SNIPPET_DATA_FILE)
 
 
-class Template(UITestCase):
+class TemplateTestCase(UITestCase):
     """Implements Provisioning Template tests from UI"""
 
     @classmethod
     def setUpClass(cls):
-        super(Template, cls).setUpClass()
+        super(TemplateTestCase, cls).setUpClass()
         cls.organization = entities.Organization().create()
 
     @run_only_on('sat')
-    def test_positive_create_template(self):
-        """@Test: Create new template
+    @tier1
+    def test_positive_create_with_name(self):
+        """@Test: Create new template using different valid names
 
         @Feature: Template - Positive Create
 
-        @Assert: New provisioning template of type 'provision'
-        should be created successfully
-
+        @Assert: New provisioning template of type 'provision' should be
+        created successfully
         """
         with Session(self.browser) as session:
             for name in generate_strings_list(length=8):
@@ -46,13 +46,14 @@ class Template(UITestCase):
                     )
                     self.assertIsNotNone(self.template.search(name))
 
-    def test_negative_create_template(self):
+    @run_only_on('sat')
+    @tier1
+    def test_negative_create_with_invalid_name(self):
         """@Test: Create a new template with invalid names
 
         @Feature: Template - Negative Create
 
         @Assert: Template is not created
-
         """
         with Session(self.browser) as session:
             for name in invalid_values_list(interface='ui'):
@@ -68,13 +69,13 @@ class Template(UITestCase):
                         common_locators['name_haserror']))
 
     @run_only_on('sat')
-    def test_negative_create_template_with_same_name(self):
+    @tier1
+    def test_negative_create_with_same_name(self):
         """@Test: Template - Create a new template with same name
 
         @Feature: Template - Negative Create
 
         @Assert: Template is not created
-
         """
         name = gen_string('alpha')
         with Session(self.browser) as session:
@@ -97,13 +98,13 @@ class Template(UITestCase):
                 common_locators['name_haserror']))
 
     @run_only_on('sat')
-    def test_negative_create_template_without_type(self):
+    @tier1
+    def test_negative_create_without_type(self):
         """@Test: Template - Create a new template without selecting its type
 
         @Feature: Template - Negative Create
 
         @Assert: Template is not created
-
         """
         name = gen_string('alpha')
         with Session(self.browser) as session:
@@ -121,13 +122,13 @@ class Template(UITestCase):
                 )
 
     @run_only_on('sat')
-    def test_negative_create_template_without_upload(self):
+    @tier1
+    def test_negative_create_without_upload(self):
         """@Test: Template - Create a new template without uploading a template
 
         @Feature: Template - Negative Create
 
         @Assert: Template is not created
-
         """
         name = gen_string('alpha')
         with Session(self.browser) as session:
@@ -145,13 +146,13 @@ class Template(UITestCase):
                 )
 
     @run_only_on('sat')
-    def test_negative_create_template_with_too_long_audit(self):
+    @tier1
+    def test_negative_create_with_too_long_audit(self):
         """@Test: Create a new template with 256 characters in audit comments
 
         @Feature: Template - Negative Create
 
         @Assert: Template is not created
-
         """
         with Session(self.browser) as session:
             make_templates(
@@ -166,14 +167,14 @@ class Template(UITestCase):
                 common_locators['haserror']))
 
     @run_only_on('sat')
-    def test_positive_create_snippet_template(self):
+    @tier1
+    def test_positive_create_with_snippet_type(self):
         """@Test: Create new template of type snippet
 
         @Feature: Template - Positive Create
 
-        @Assert: New provisioning template of type 'snippet'
-        should be created successfully
-
+        @Assert: New provisioning template of type 'snippet' should be created
+        successfully
         """
         with Session(self.browser) as session:
             for name in generate_strings_list(length=8):
@@ -188,13 +189,13 @@ class Template(UITestCase):
                     self.assertIsNotNone(self.template.search(name))
 
     @run_only_on('sat')
+    @tier1
     def test_positive_delete(self):
-        """@Test: Remove a template
+        """@Test: Delete an existing template
 
         @Feature: Template - Positive Delete
 
-        @Assert: Template is removed successfully
-
+        @Assert: Template is deleted successfully
         """
         with Session(self.browser) as session:
             for template_name in generate_strings_list(length=8):
@@ -207,13 +208,13 @@ class Template(UITestCase):
                     self.template.delete(template_name)
 
     @run_only_on('sat')
-    def test_update_template(self):
+    @tier1
+    def test_positive_update_name_and_type(self):
         """@Test: Update template name and template type
 
         @Feature: Template - Positive Update
 
         @Assert: The template name and type should be updated successfully
-
         """
         name = gen_string('alpha')
         new_name = gen_string('alpha')
@@ -230,15 +231,15 @@ class Template(UITestCase):
             self.assertIsNotNone(self.template.search(new_name))
 
     @run_only_on('sat')
-    def test_update_template_os(self):
-        """@Test: Creates new template, along with two OS's
-        and associate list of OS's with created template
+    @tier1
+    def test_positive_update_os(self):
+        """@Test: Creates new template, along with two OS's and associate list
+        of OS's with created template
 
         @Feature: Template - Positive Update
 
         @Assert: The template should be updated with newly created OS's
         successfully
-
         """
         name = gen_string('alpha')
         new_name = gen_string('alpha')
@@ -258,7 +259,8 @@ class Template(UITestCase):
             self.assertIsNotNone(self.template.search(new_name))
 
     @run_only_on('sat')
-    def test_clone_template(self):
+    @tier2
+    def test_positive_clone(self):
         """@Test: Assure ability to clone a provisioning template
 
         @Feature: Template - Clone
@@ -267,8 +269,7 @@ class Template(UITestCase):
          1.  Go to Provisioning template UI
          2.  Choose a template and attempt to clone it
 
-        @Assert: template is cloned
-
+        @Assert: The template is cloned
         """
         name = gen_string('alpha')
         clone_name = gen_string('alpha')

--- a/tests/foreman/ui/test_trend.py
+++ b/tests/foreman/ui/test_trend.py
@@ -3,6 +3,7 @@
 
 from fauxfactory import gen_string
 from robottelo.constants import TREND_TYPES
+from robottelo.decorators import tier1
 from robottelo.test import UITestCase
 from robottelo.ui.factory import make_trend
 from robottelo.ui.session import Session
@@ -17,29 +18,28 @@ class TrendTest(UITestCase):
     elements from corresponding lists.
     In most cases it will not be possible to re-run tests due condition of
     uniqueness described above.
-
     """
 
-    def test_create_trend_positive(self):
+    @tier1
+    def test_positive_create(self):
         """@Test: Create new trend
 
         @Feature: Trend - Positive Create
 
-        @Assert: Trend is created
-
+        @Assert: Trend is created successfully
         """
         with Session(self.browser) as session:
             make_trend(session, trend_type=TREND_TYPES['model'])
             search = self.trend.search(TREND_TYPES['model'])
             self.assertIsNotNone(search)
 
-    def test_update_trend_positive(self):
+    @tier1
+    def test_positive_update(self):
         """@Test: Update trend entity value
 
         @Feature: Trend - Positive Update
 
-        @Assert: Trend entity is updated
-
+        @Assert: Trend entity is updated successfully
         """
         name = gen_string('alphanumeric')
         new_name = gen_string('alphanumeric')
@@ -57,13 +57,13 @@ class TrendTest(UITestCase):
             search = self.trend.search(new_name)
             self.assertIsNotNone(search)
 
+    @tier1
     def test_positive_delete(self):
         """@Test: Delete existing trend
 
         @Feature: Trend - Positive Delete
 
         @Assert: Trend is deleted
-
         """
         with Session(self.browser) as session:
             make_trend(session, trend_type=TREND_TYPES['environment'])

--- a/tests/foreman/ui/test_user.py
+++ b/tests/foreman/ui/test_user.py
@@ -11,7 +11,7 @@ from robottelo.datafactory import (
     invalid_values_list,
     valid_emails_list,
 )
-from robottelo.decorators import stubbed, tier1, tier2
+from robottelo.decorators import stubbed, tier1, tier2, tier3
 from robottelo.test import UITestCase
 from robottelo.ui.factory import make_user
 from robottelo.ui.locators import common_locators, locators, tab_locators
@@ -36,11 +36,11 @@ def valid_strings(len1=10):
     ]
 
 
-class User(UITestCase):
+class UserTestCase(UITestCase):
     """Implements Users tests in UI"""
 
     @tier1
-    def test_positive_create_with_usernames(self):
+    def test_positive_create_with_username(self):
         """@Test: Create User for all variations of Username
 
         @Feature: User - Positive Create
@@ -54,7 +54,7 @@ class User(UITestCase):
                     self.assertIsNotNone(self.user.search(user_name))
 
     @tier1
-    def test_positive_create_with_first_names(self):
+    def test_positive_create_with_first_name(self):
         """@Test: Create User for all variations of First Name
 
         @Feature: User - Positive Create
@@ -69,7 +69,7 @@ class User(UITestCase):
                     self.user.validate_user(name, 'firstname', first_name)
 
     @tier1
-    def test_positive_create_with_surnames(self):
+    def test_positive_create_with_surname(self):
         """@Test: Create User for all variations of Surname
 
         @Feature: User - Positive Create
@@ -84,7 +84,7 @@ class User(UITestCase):
                     self.user.validate_user(name, 'lastname', last_name)
 
     @tier1
-    def test_positive_create_with_emails(self):
+    def test_positive_create_with_email(self):
         """@Test: Create User for all variations of Email Address
 
         @Feature: User - Positive Create
@@ -99,7 +99,7 @@ class User(UITestCase):
                     self.user.validate_user(name, 'email', email)
 
     @tier1
-    def test_positive_create_with_languages(self):
+    def test_positive_create_with_language(self):
         """@Test: Create User for all variations of Language
 
         @Feature: User - Positive Create
@@ -114,7 +114,7 @@ class User(UITestCase):
                     self.user.validate_user(name, 'language', language, False)
 
     @tier1
-    def test_positive_create_with_passwords(self):
+    def test_positive_create_with_password(self):
         """@Test: Create User for all variations of Password
 
         @Feature: User - Positive Create
@@ -266,6 +266,7 @@ class User(UITestCase):
                 self.assertIsNotNone(element)
 
     @stubbed()
+    @tier2
     def test_positive_create_in_ldap_modes(self):
         """@Test: Create User in supported ldap modes - (Active Driectory, IPA,
         Posix)
@@ -310,7 +311,6 @@ class User(UITestCase):
         @Feature: User - Positive Create
 
         @Assert: User is created with default Location selected.
-
         """
         strategy, value = common_locators['entity_deselect']
         name = gen_string('alpha')
@@ -610,7 +610,6 @@ class User(UITestCase):
         @Feature: User - Update
 
         @Assert: User role is updated
-
         """
         strategy, value = common_locators['entity_deselect']
         name = gen_string('alpha')
@@ -719,7 +718,7 @@ class User(UITestCase):
 
         @Feature: User - Negative Update
 
-        @Assert: User is not updated.  Appropriate error shown.
+        @Assert: User is not updated. Appropriate error shown.
         """
         name = gen_string('alpha')
         with Session(self.browser) as session:
@@ -738,7 +737,7 @@ class User(UITestCase):
 
         @Feature: User - Negative Update
 
-        @Assert: User is not updated.  Appropriate error shown.
+        @Assert: User is not updated. Appropriate error shown.
         """
         name = gen_string('alpha')
         with Session(self.browser) as session:
@@ -757,7 +756,7 @@ class User(UITestCase):
 
         @Feature: User - Negative Update
 
-        @Assert: User is not updated.  Appropriate error shown.
+        @Assert: User is not updated. Appropriate error shown.
         """
         name = gen_string('alpha')
         with Session(self.browser) as session:
@@ -776,7 +775,7 @@ class User(UITestCase):
 
         @Feature: User - Negative Update
 
-        @Assert: User is not updated.  Appropriate error shown.
+        @Assert: User is not updated. Appropriate error shown.
         """
         name = gen_string('alpha')
         with Session(self.browser) as session:
@@ -790,6 +789,7 @@ class User(UITestCase):
                     )
 
     @stubbed()
+    @tier1
     def test_negative_update_password(self):
         """@Test: Update different values in Password and verify fields
 
@@ -803,9 +803,9 @@ class User(UITestCase):
         @Assert: User is not updated.  Appropriate error shown.
 
         @Status: Manual
-
         """
 
+    @tier1
     def test_negative_update(self):
         """@Test: [UI ONLY] Attempt to update User info and Cancel
 
@@ -831,12 +831,11 @@ class User(UITestCase):
 
     @tier1
     def test_positive_delete_user(self):
-        """@Test: Delete a User
+        """@Test: Delete an existing User
 
         @Feature: User - Delete
 
-        @Assert: User is deleted
-
+        @Assert: User is deleted successfully
         """
         with Session(self.browser) as session:
             for user_name in valid_strings():
@@ -873,6 +872,7 @@ class User(UITestCase):
             self.user.delete(user_name, really=False)
 
     @stubbed()
+    @tier2
     def test_negative_delete_last_admin(self):
         """@Test: Attempt to delete the last remaining admin user
 
@@ -886,11 +886,11 @@ class User(UITestCase):
         @Assert: User is not deleted
 
         @Status: Manual
-
         """
 
     @stubbed()
-    def test_end_to_end_user_1(self):
+    @tier3
+    def test_end_to_end_scenario(self):
         """@Test: Create User and perform different operations
 
         @Feature: User - End to End
@@ -907,11 +907,11 @@ class User(UITestCase):
         @Assert: All actions passed
 
         @Status: Manual
-
         """
 
     @stubbed()
-    def test_end_to_end_user_2(self):
+    @tier3
+    def test_end_to_end_scenario_without_org(self):
         """@Test: Create User with no Org assigned and attempt different
         operations
 
@@ -928,11 +928,11 @@ class User(UITestCase):
         @Assert: All actions failed since the User is not assigned to any Org
 
         @Status: Manual
-
         """
 
     @stubbed()
-    def test_positive_create_bookmark_1(self):
+    @tier2
+    def test_positive_create_bookmark_default(self):
         """@Test: Create a bookmark with default values
 
         @Feature: Search bookmark - Positive Create
@@ -944,11 +944,11 @@ class User(UITestCase):
         @Assert: Search bookmark is created
 
         @Status: Manual
-
         """
 
     @stubbed()
-    def test_positive_create_bookmark_2(self):
+    @tier2
+    def test_positive_create_bookmark_alter_default(self):
         """@Test: Create a bookmark by altering the default values
 
         @Feature: Search bookmark - Positive Create
@@ -960,11 +960,11 @@ class User(UITestCase):
         @Assert: Search bookmark is created
 
         @Status: Manual
-
         """
 
     @stubbed()
-    def test_positive_create_bookmark_3(self):
+    @tier2
+    def test_positive_create_bookmark_public(self):
         """@Test: Create a bookmark in public mode
 
         @Feature: Search bookmark - Positive Create
@@ -977,11 +977,11 @@ class User(UITestCase):
         by other users
 
         @Status: Manual
-
         """
 
     @stubbed()
-    def test_positive_create_bookmark_4(self):
+    @tier2
+    def test_positive_create_bookmark_private(self):
         """@Test: Create a bookmark in private mode
 
         @Feature: Search bookmark - Positive Create
@@ -994,11 +994,11 @@ class User(UITestCase):
         accessible by other users
 
         @Status: Manual
-
         """
 
     @stubbed()
-    def test_negative_create_bookmark_1(self):
+    @tier2
+    def test_negative_create_bookmark_with_blank_name(self):
         """@Test: Create a bookmark with a blank bookmark name
 
         @Feature: Search bookmark - Negative Create
@@ -1010,11 +1010,11 @@ class User(UITestCase):
         @Assert: Search bookmark not created. Appropriate error shown.
 
         @Status: Manual
-
         """
 
     @stubbed()
-    def test_negative_create_bookmark_2(self):
+    @tier2
+    def test_negative_create_bookmark_with_blank_query(self):
         """@Test: Create a bookmark with a blank bookmark query
 
         @Feature: Search bookmark - Negative Create
@@ -1026,5 +1026,4 @@ class User(UITestCase):
         @Assert: Search bookmark not created. Appropriate error shown.
 
         @Status: Manual
-
         """

--- a/tests/foreman/ui/test_usergroup.py
+++ b/tests/foreman/ui/test_usergroup.py
@@ -3,28 +3,29 @@
 from fauxfactory import gen_string
 from nailgun import entities
 from robottelo.datafactory import generate_strings_list, invalid_values_list
-from robottelo.decorators import skip_if_bug_open
+from robottelo.decorators import skip_if_bug_open, tier1, tier2
 from robottelo.test import UITestCase
 from robottelo.ui.factory import make_usergroup
 from robottelo.ui.locators import common_locators
 from robottelo.ui.session import Session
 
 
-class UserGroup(UITestCase):
+class UserGroupTestCase(UITestCase):
     """Implements UserGroup tests from UI"""
 
     @classmethod
     def setUpClass(cls):
-        super(UserGroup, cls).setUpClass()
+        super(UserGroupTestCase, cls).setUpClass()
         cls.organization = entities.Organization().create()
 
     @skip_if_bug_open('bugzilla', 1142588)
-    def test_positive_create_usergroup(self):
-        """@Test: Create new Usergroup
+    @tier1
+    def test_positive_create_with_name(self):
+        """@Test: Create new Usergroup using different names
+
         @Feature: Usergroup - Positive Create
 
-        @Assert: Usergroup is created
-
+        @Assert: Usergroup is created successfully
         """
         user_name = gen_string('alpha')
         password = gen_string('alpha')
@@ -37,13 +38,13 @@ class UserGroup(UITestCase):
                     self.assertIsNotNone(self.usergroup.search(group_name))
 
     @skip_if_bug_open('bugzilla', 1142588)
-    def test_negative_create_usergroup(self):
+    @tier1
+    def test_negative_create_with_invalid_name(self):
         """@Test: Create a new UserGroup with invalid names
 
-        @Feature:  Usergroup - Negative Create
+        @Feature: Usergroup - Negative Create
 
-        @Assert:  Usergroup is not created
-
+        @Assert: Usergroup is not created
         """
         with Session(self.browser) as session:
             for group_name in invalid_values_list(interface='ui'):
@@ -54,13 +55,13 @@ class UserGroup(UITestCase):
                         common_locators['name_haserror']))
                     self.assertIsNone(self.usergroup.search(group_name))
 
-    def test_negative_create_usergroup_with_same_name(self):
+    @tier1
+    def test_negative_create_with_same_name(self):
         """@Test: Create a new UserGroup with same name
 
         @Feature: Usergroup - Negative Create
 
-        @Assert: Usergroup cannot be  created with existing name
-
+        @Assert: Usergroup cannot be created with existing name
         """
         group_name = gen_string('alphanumeric')
         with Session(self.browser) as session:
@@ -73,13 +74,13 @@ class UserGroup(UITestCase):
                 common_locators['name_haserror']))
 
     @skip_if_bug_open('bugzilla', 1142588)
+    @tier1
     def test_positive_delete_empty(self):
         """@Test: Delete an empty Usergroup
 
         @Feature: Usergroup - Positive Delete
 
         @Assert: Usergroup is deleted
-
         """
         with Session(self.browser) as session:
             for group_name in generate_strings_list():
@@ -89,13 +90,13 @@ class UserGroup(UITestCase):
                     self.usergroup.delete(group_name)
 
     @skip_if_bug_open('bugzilla', 1142588)
-    def test_positive_delete(self):
+    @tier2
+    def test_positive_delete_with_user(self):
         """@Test: Delete an Usergroup that contains a user
 
         @Feature: Usergroup - Positive Delete
 
         @Assert: Usergroup is deleted but not the added user
-
         """
         user_name = gen_string('alpha')
         group_name = gen_string('utf8')
@@ -117,13 +118,13 @@ class UserGroup(UITestCase):
             self.assertIsNotNone(self.user.search(user_name))
 
     @skip_if_bug_open('bugzilla', 1142588)
-    def test_update_usergroup(self):
-        """@Test: Update usergroup with name or users
+    @tier1
+    def test_positive_update_name(self):
+        """@Test: Update usergroup with new name
 
         @Feature: Usergroup - Positive Update
 
         @Assert: Usergroup is updated
-
         """
         name = gen_string('alpha')
         user_name = gen_string('alpha')


### PR DESCRIPTION
Fixed logic for one test:
```
nosetests tests/foreman/ui/test_product.py -m test_positive_create_in_different_orgs
.
----------------------------------------------------------------------
Ran 1 test in 233.625s

OK
```