### PR TITLE
[DONOTMERGE] Renamed tests for cli/test_system_registration.py.

### DIFF
--- a/tests/foreman/cli/test_system_registration.py
+++ b/tests/foreman/cli/test_system_registration.py
@@ -7,7 +7,7 @@ class SystemRegistrationTestCase(CLITestCase):
     """Tests for System Registration CLI"""
 
     @stubbed()
-    def test_rpm_install(self):
+    def test_positive_rpm_install(self):
         """@test: rpm can be retrieved
 
         @feature: system registration
@@ -21,7 +21,7 @@ class SystemRegistrationTestCase(CLITestCase):
         """
 
     @stubbed()
-    def test_register_no_ak(self):
+    def test_positive_register_no_ak(self):
         """@test: register system to sat without activation key
 
         @feature: system registration
@@ -32,7 +32,7 @@ class SystemRegistrationTestCase(CLITestCase):
         """
 
     @stubbed()
-    def test_register_with_ak(self):
+    def test_positive_register_with_ak(self):
         """@test: register system with activation key
 
         @feature: system registration
@@ -44,7 +44,7 @@ class SystemRegistrationTestCase(CLITestCase):
         """
 
     @stubbed()
-    def test_cannot_register_twice_negative(self):
+    def test_negative_register(self):
         """@test: Attempt to register a system twice to an instance
 
         @feature: system registration
@@ -55,7 +55,7 @@ class SystemRegistrationTestCase(CLITestCase):
         """
 
     @stubbed()
-    def test_registered_systems_pull_content(self):
+    def test_positive_pull_content(self):
         # variations:  RH rpms/errata; custom content repos
         """@test: assure RH RPM content can be installed
 
@@ -67,7 +67,7 @@ class SystemRegistrationTestCase(CLITestCase):
         """
 
     @stubbed()
-    def test_registered_system_can_be_listed_cli(self):
+    def test_positive_list(self):
         """@test: perform a system list for a given org
 
         @feature: system registration
@@ -78,7 +78,7 @@ class SystemRegistrationTestCase(CLITestCase):
         """
 
     @stubbed()
-    def test_system_deregister_cli(self):
+    def test_positive_deregister(self):
         """@test: deregister/delete system via RHSM
 
         @feature: system registration
@@ -90,7 +90,7 @@ class SystemRegistrationTestCase(CLITestCase):
         """
 
     @stubbed()
-    def test_deregistered_system_cannot_pull_content(self):
+    def test_negative_pull_content(self):
         """@test: try and retrieve content (via yum, etc.) after system has
         been removed from sat
 


### PR DESCRIPTION
Test case naming follows #3038 conventions.