### PR TITLE
Quick fix for robottelo documentation as per new modules names

### DIFF
--- a/docs/api/tests.foreman.cli.rst
+++ b/docs/api/tests.foreman.cli.rst
@@ -148,15 +148,15 @@
 
 .. automodule:: tests.foreman.cli.test_myaccount
 
-:mod:`tests.foreman.cli.test_org`
----------------------------------
+:mod:`tests.foreman.cli.test_organization`
+------------------------------------------
 
-.. automodule:: tests.foreman.cli.test_org
+.. automodule:: tests.foreman.cli.test_organization
 
-:mod:`tests.foreman.cli.test_os`
---------------------------------
+:mod:`tests.foreman.cli.test_operatingsystem`
+---------------------------------------------
 
-.. automodule:: tests.foreman.cli.test_os
+.. automodule:: tests.foreman.cli.test_operatingsystem
 
 :mod:`tests.foreman.cli.test_partitiontable`
 --------------------------------------------
@@ -172,11 +172,6 @@
 -------------------------------------
 
 .. automodule:: tests.foreman.cli.test_product
-
-:mod:`tests.foreman.cli.test_proxy`
------------------------------------
-
-.. automodule:: tests.foreman.cli.test_proxy
 
 :mod:`tests.foreman.cli.test_puppetmodule`
 ------------------------------------------
@@ -198,10 +193,10 @@
 
 .. automodule:: tests.foreman.cli.test_repository_set
 
-:mod:`tests.foreman.cli.test_roles`
------------------------------------
+:mod:`tests.foreman.cli.test_role`
+----------------------------------
 
-.. automodule:: tests.foreman.cli.test_roles
+.. automodule:: tests.foreman.cli.test_role
 
 :mod:`tests.foreman.cli.test_scparam`
 -------------------------------------


### PR DESCRIPTION
```
>make docs-clean docs

Running Sphinx v1.3.1
making output directory...
loading pickled environment... not yet created
building [mo]: targets for 0 po files that are out of date
building [html]: targets for 19 source files that are out of date
updating environment: 19 added, 0 changed, 0 removed
reading sources... [100%] reviewing_PRs                                                                                                                     
looking for now-outdated files... none found
pickling environment... done
checking consistency... done
preparing documents... done
writing output... [100%] reviewing_PRs                                                                                                                      
generating indices... genindex py-modindex
highlighting module code... [100%] robottelo.datafactory                                                                                                    
writing additional pages... search
copying static files... done
copying extra files... done
dumping search index in English (code: en) ... done
dumping object inventory... done
build succeeded.
```