### PR TITLE
Implement API hostgroup stubs

### DIFF
--- a/tests/foreman/api/test_hostgroup.py
+++ b/tests/foreman/api/test_hostgroup.py
@@ -7,9 +7,7 @@ from robottelo.config import settings
 from robottelo.constants import PUPPET_MODULE_NTP_PUPPETLABS
 from robottelo.decorators import (
     skip_if_bug_open,
-    stubbed,
     tier1,
-    tier2,
     tier3,
 )
 from robottelo.helpers import get_data_file
@@ -219,109 +217,3 @@ class HostGroupMissingAttrTestCase(APITestCase):
             1,
             'None of {0} are in {1}'.format(names, self.host_group_attrs)
         )
-
-
-class HostGroupTestCaseStub(APITestCase):
-    """Incomplete tests for host groups.
-
-    When implemented, each of these tests should probably be data-driven. A
-    decorator of this form might be used::
-
-        @data(
-            name is alpha,
-            name is alpha_numeric,
-            name is html,
-            name is latin1,
-            name is numeric,
-            name is utf-8,
-        )
-
-    """
-
-    @stubbed()
-    @tier2
-    def test_positive_remove_by_name_org_name(self):
-        """
-        @feature: Organizations
-        @test: Add a hostgroup and remove it by using the organization
-        name and hostgroup name
-        @assert: hostgroup is added to organization then removed
-        @status: manual
-        """
-
-    @stubbed()
-    @tier2
-    def test_positive_remove_by_name_org_id(self):
-        """
-        @feature: Organizations
-        @test: Add a hostgroup and remove it by using the organization
-        ID and hostgroup name
-        @assert: hostgroup is added to organization then removed
-        @status: manual
-        """
-
-    @stubbed()
-    @tier2
-    def test_positive_remove_by_id_org_name(self):
-        """
-        @feature: Organizations
-        @test: Add a hostgroup and remove it by using the organization
-        name and hostgroup ID
-        @assert: hostgroup is added to organization then removed
-        @status: manual
-        """
-
-    @stubbed()
-    @tier2
-    def test_positive_remove_by_id_org_id(self):
-        """
-        @feature: Organizations
-        @test: Add a hostgroup and remove it by using the organization
-        ID and hostgroup ID
-        @assert: hostgroup is added to organization then removed
-        @status: manual
-        """
-
-    @stubbed()
-    @tier2
-    def test_positive_add_hostgroup_by_name_org_name(self):
-        """
-        @feature: Organizations
-        @test: Add a hostgroup by using the organization
-        name and hostgroup name
-        @assert: hostgroup is added to organization
-        @status: manual
-        """
-
-    @stubbed()
-    @tier2
-    def test_positive_add_hostgroup_by_name_org_id(self):
-        """
-        @feature: Organizations
-        @test: Add a hostgroup by using the organization
-        ID and hostgroup name
-        @assert: hostgroup is added to organization
-        @status: manual
-        """
-
-    @stubbed()
-    @tier2
-    def test_positive_add_hostgroup_by_id_org_name(self):
-        """
-        @feature: Organizations
-        @test: Add a hostgroup by using the organization
-        name and hostgroup ID
-        @assert: hostgroup is added to organization
-        @status: manual
-        """
-
-    @stubbed()
-    @tier2
-    def test_positive_add_hostgroup_by_id_org_id(self):
-        """
-        @feature: Organizations
-        @test: Add a hostgroup by using the organization
-        ID and hostgroup ID
-        @assert: hostgroup is added to organization
-        @status: manual
-        """

--- a/tests/foreman/api/test_organization.py
+++ b/tests/foreman/api/test_organization.py
@@ -281,6 +281,38 @@ class OrganizationUpdateTestCase(APITestCase):
         self.assertEqual(len(self.organization.media), 1)
         self.assertEqual(self.organization.media[0].id, media.id)
 
+    @tier2
+    def test_positive_add_hostgroup(self):
+        """@Test: Add a hostgroup to an organization
+
+        @Feature: Organization
+
+        @Assert: Hostgroup is added to organization
+        """
+        org = entities.Organization().create()
+        hostgroup = entities.HostGroup().create()
+        org.hostgroup = [hostgroup]
+        org = org.update(['hostgroup'])
+        self.assertEqual(len(org.hostgroup), 1)
+        self.assertEqual(org.hostgroup[0].id, hostgroup.id)
+
+    @tier2
+    def test_positive_remove_hostgroup(self):
+        """@Test: Add a hostgroup to an organization and then remove it
+
+        @Feature: Organization
+
+        @Assert: Hostgroup is added to organization and then removed
+        """
+        org = entities.Organization().create()
+        hostgroup = entities.HostGroup().create()
+        org.hostgroup = [hostgroup]
+        org = org.update(['hostgroup'])
+        self.assertEqual(len(org.hostgroup), 1)
+        org.hostgroup = []
+        org = org.update(['hostgroup'])
+        self.assertEqual(len(org.hostgroup), 0)
+
     @tier1
     def test_negative_update(self):
         """@Test: Update an organization's attributes with invalid values.


### PR DESCRIPTION
Stubs were probably copied from CLI, as we can't test different name-id combinations via API - we can only work with ids. That also means there's no need in ddt (subtests) here, as we're associating via ids, 
no matter what the names are.
Tests results:
```python
py.test -v tests/foreman/api/test_hostgroup.py -k 'test_positive_add_to_org or test_positive_remove_from_org'
================================ test session starts =================================
platform linux2 -- Python 2.7.10, pytest-2.8.2, py-1.4.30, pluggy-0.3.1 -- /home/andrii/env/bin/python
cachedir: .cache
rootdir: /home/andrii/workspace/robottelo, inifile: 
plugins: xdist-1.13.1
collected 3 items 

tests/foreman/api/test_hostgroup.py::HostGroupTestCase::test_positive_add_to_org PASSED
tests/foreman/api/test_hostgroup.py::HostGroupTestCase::test_positive_remove_from_org PASSED

 1 tests deselected by '-ktest_positive_add_to_org or test_positive_remove_from_org' =
====================== 2 passed, 1 deselected in 30.41 seconds =======================
```