### PR TITLE
Implement API smartproxy stubs

### DIFF
--- a/tests/foreman/api/test_organization.py
+++ b/tests/foreman/api/test_organization.py
@@ -313,6 +313,49 @@ class OrganizationUpdateTestCase(APITestCase):
         org = org.update(['hostgroup'])
         self.assertEqual(len(org.hostgroup), 0)
 
+    @tier2
+    def test_positive_add_smart_proxy(self):
+        """@Test: Add a smart proxy to an organization
+
+        @Feature: Organization
+
+        @Assert: Smart proxy is successfully added to organization
+        """
+        # Every Satellite has a built-in smart proxy, so let's find it
+        smart_proxies = entities.SmartProxy().search()
+        self.assertGreater(len(smart_proxies), 0)
+        smart_proxy = smart_proxies[0]
+        # By default, newly created organization uses built-in smart proxy,
+        # so we need to remove it first
+        org = entities.Organization().create()
+        org.smart_proxy = []
+        org = org.update(['smart_proxy'])
+        # Verify smart proxy was actually removed
+        self.assertEqual(len(org.smart_proxy), 0)
+        # Add smart proxy to organization
+        org.smart_proxy = [smart_proxy]
+        org = org.update(['smart_proxy'])
+        # Verify smart proxy was actually added
+        self.assertEqual(len(org.smart_proxy), 1)
+        self.assertEqual(org.smart_proxy[0].id, smart_proxy.id)
+
+    @tier2
+    def test_positive_remove_smart_proxy(self):
+        """@Test: Remove a smart proxy from an organization
+
+        @Feature: Organization
+
+        @Assert: Smart proxy is removed from organization
+        """
+        # By default, newly created organization uses built-in smart proxy,
+        # so we can remove it instead of adding and removing some another one
+        org = entities.Organization().create()
+        self.assertGreater(len(org.smart_proxy), 0)
+        org.smart_proxy = []
+        org = org.update(['smart_proxy'])
+        # Verify smart proxy was actually removed
+        self.assertEqual(len(org.smart_proxy), 0)
+
     @tier1
     def test_negative_update(self):
         """@Test: Update an organization's attributes with invalid values.

--- a/tests/foreman/api/test_smartproxy.py
+++ b/tests/foreman/api/test_smartproxy.py
@@ -1,11 +1,8 @@
 """Tests for the ``smart_proxies`` paths."""
 from nailgun import entities
 from robottelo.decorators import (
-    run_only_on,
     skip_if_bug_open,
-    stubbed,
     tier1,
-    tier2,
 )
 from robottelo.test import APITestCase
 from robottelo.api.utils import one_to_many_names
@@ -63,109 +60,3 @@ class SmartProxyMissingAttrTestCase(APITestCase):
             1,
             'None of {0} are in {1}'.format(names, self.smart_proxy_attrs),
         )
-
-
-class SmartProxyTestCaseStub(APITestCase):
-    """Incomplete tests for smart proxies.
-
-    When implemented, each of these tests should probably be data-driven. A
-    decorator of this form might be used::
-
-        @data(
-            medium name is alpha,
-            medium name is alpha_numeric,
-            medium name is html,
-            medium name is latin1,
-            medium name is numeric,
-            medium name is utf-8,
-        )
-
-    """
-
-    @run_only_on('sat')
-    @stubbed()
-    @tier2
-    def test_positive_add_by_name_org_name(self):
-        """
-        @feature: Organizations
-        @test: Add a smart proxy by using organization name and smartproxy name
-        @assert: smartproxy is added
-        @status: manual
-        """
-
-    @run_only_on('sat')
-    @stubbed()
-    @tier2
-    def test_positive_add_by_name_org_id(self):
-        """
-        @feature: Organizations
-        @test: Add a smart proxy by using organization ID and smartproxy name
-        @assert: smartproxy is added
-        @status: manual
-        """
-
-    @run_only_on('sat')
-    @stubbed()
-    @tier2
-    def test_positive_add_by_id_org_name(self):
-        """
-        @feature: Organizations
-        @test: Add a smart proxy by using organization name and smartproxy ID
-        @assert: smartproxy is added
-        @status: manual
-        """
-
-    @run_only_on('sat')
-    @stubbed()
-    @tier2
-    def test_positive_add_by_id_org_id(self):
-        """
-        @feature: Organizations
-        @test: Add a smart proxy by using organization ID and smartproxy ID
-        @assert: smartproxy is added
-        @status: manual
-        """
-
-    @run_only_on('sat')
-    @stubbed()
-    @tier2
-    def test_positive_remove_by_name_org_name(self):
-        """
-        @feature: Organizations
-        @test: Remove smartproxy by using organization name and smartproxy name
-        @assert: smartproxy is added then removed
-        @status: manual
-        """
-
-    @run_only_on('sat')
-    @stubbed()
-    @tier2
-    def test_positive_remove_by_name_org_id(self):
-        """
-        @feature: Organizations
-        @test: Remove smartproxy by using organization ID and smartproxy name
-        @assert: smartproxy is added then removed
-        @status: manual
-        """
-
-    @run_only_on('sat')
-    @stubbed()
-    @tier2
-    def test_positive_remove_by_id_org_name(self):
-        """
-        @feature: Organizations
-        @test: Remove smartproxy by using organization name and smartproxy ID
-        @assert: smartproxy is added then removed
-        @status: manual
-        """
-
-    @run_only_on('sat')
-    @stubbed()
-    @tier2
-    def test_positive_remove_by_id_org_id(self):
-        """
-        @feature: Organizations
-        @test: Remove smartproxy by using organization ID and smartproxy ID
-        @assert: smartproxy is added then removed
-        @status: manual
-        """


### PR DESCRIPTION
Similar to #3170 - stubs were probably copied from CLI, as we can't test different name-id combinations via API.
Tests are using built-in smart proxy as we can't use some fake one (validation occurs and connection to host gets verified  on creation step) and creating some real one would make the tests tier3 and definitely out of scope of simple association verification.
Tests results:
```python
py.test -v tests/foreman/api/test_organization.py -k 'test_positive_add_smart_proxy or test_positive_remove_smart_proxy'
================================ test session starts =================================
platform linux2 -- Python 2.7.10, pytest-2.8.2, py-1.4.30, pluggy-0.3.1 -- /home/andrii/env/bin/python
cachedir: .cache
rootdir: /home/andrii/workspace/robottelo, inifile: 
plugins: xdist-1.13.1
collected 21 items 

tests/foreman/api/test_organization.py::OrganizationUpdateTestCase::test_positive_add_smart_proxy PASSED
tests/foreman/api/test_organization.py::OrganizationUpdateTestCase::test_positive_remove_smart_proxy PASSED

 19 tests deselected by '-ktest_positive_add_smart_proxy or test_positive_remove_smart_proxy' 
====================== 2 passed, 19 deselected in 22.43 seconds ======================
```