### PR TITLE
Re-implement whole Activation Key test module. Remove all stubs

### DIFF
--- a/robottelo/cli/factory.py
+++ b/robottelo/cli/factory.py
@@ -1759,8 +1759,7 @@ def activationkey_add_subscription_to_repo(options=None):
 
 
 def setup_org_for_a_custom_repo(options=None):
-    """
-    Sets up Org for the given custom repo by:
+    """Sets up Org for the given custom repo by:
 
     1. Checks if organization and lifecycle environment were given, otherwise
         creates new ones.
@@ -1773,7 +1772,7 @@ def setup_org_for_a_custom_repo(options=None):
         associates it with the content view.
     5. Adds the custom repo subscription to the activation key
 
-    Args::
+    Options::
 
         url - URL to custom repository
         organization-id (optional) - ID of organization to use (or create a new
@@ -1784,6 +1783,9 @@ def setup_org_for_a_custom_repo(options=None):
                                     one if empty)
         activationkey-id (optional) - ID of activation key (or create a new one
                                     if empty)
+
+    :return: A dictionary with the entity ids of Activation key, Content view,
+        Lifecycle Environment, Organization, Product and Repository
 
     """
     if(
@@ -1876,11 +1878,18 @@ def setup_org_for_a_custom_repo(options=None):
         u'organization-id': org_id,
         u'subscription': custom_product['name'],
     })
+    return {
+        u'activationkey-id': activationkey_id,
+        u'content-view-id': cv_id,
+        u'lifecycle-environment-id': env_id,
+        u'organization-id': org_id,
+        u'product-id': custom_product['id'],
+        u'repository-id': custom_repo['id'],
+    }
 
 
 def setup_org_for_a_rh_repo(options=None):
-    """
-    Sets up Org for the given Red Hat repository by:
+    """Sets up Org for the given Red Hat repository by:
 
     1. Checks if organization and lifecycle environment were given, otherwise
         creates new ones.
@@ -1894,7 +1903,7 @@ def setup_org_for_a_rh_repo(options=None):
         associates it with the content view.
     6. Adds the RH repo subscription to the activation key
 
-    Args::
+    Options::
 
         product - RH product name
         repository-set - RH repository set name
@@ -1909,6 +1918,9 @@ def setup_org_for_a_rh_repo(options=None):
                                     one if empty)
         activationkey-id (optional) - ID of activation key (or create a new one
                                     if empty)
+
+    :return: A dictionary with the entity ids of Activation key, Content view,
+        Lifecycle Environment, Organization and Repository
 
     """
     if (
@@ -2038,3 +2050,10 @@ def setup_org_for_a_rh_repo(options=None):
         u'activationkey-id': activationkey_id,
         u'subscription': DEFAULT_SUBSCRIPTION_NAME,
     })
+    return {
+        u'activationkey-id': activationkey_id,
+        u'content-view-id': cv_id,
+        u'lifecycle-environment-id': env_id,
+        u'organization-id': org_id,
+        u'repository-id': rhel_repo['id'],
+    }


### PR DESCRIPTION
Closes #3176

```
nosetests tests/foreman/cli/test_activationkey.py
.F...F....SS.E..........................S.......
======================================================================
ERROR: @Test: Positive content override
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/oshtaier/Desktop/robottelo/robottelo/decorators.py", line 445, in wrapper_func
    return func(*args, **kwargs)
  File "/home/oshtaier/Desktop/robottelo/tests/foreman/cli/test_activationkey.py", line 1145, in test_positive_content_override
    self.assertEqual(content[0]['enabled?'], override_value)
KeyError: 'enabled?'
======================================================================
FAIL: @Test: Create Activation key with invalid Description
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/oshtaier/Desktop/robottelo/robottelo/decorators.py", line 224, in wrapper
    return func(*args, **kwargs)
  File "/home/oshtaier/Desktop/robottelo/robottelo/decorators.py", line 445, in wrapper_func
    return func(*args, **kwargs)
  File "/home/oshtaier/Desktop/robottelo/tests/foreman/cli/test_activationkey.py", line 219, in test_negative_create_with_description
    {u'description': gen_string('alpha', 1001)})
AssertionError: CLIFactoryError not raised
======================================================================
FAIL: @Test: Try to update Activation Key using invalid value for its
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/oshtaier/Desktop/robottelo/robottelo/decorators.py", line 445, in wrapper_func
    return func(*args, **kwargs)
  File "/home/oshtaier/Desktop/robottelo/tests/foreman/cli/test_activationkey.py", line 511, in test_negative_update_description
    u'organization-id': self.org['id'],
AssertionError: CLIReturnCodeError not raised
----------------------------------------------------------------------
Ran 47 tests in 2138.697s

FAILED (SKIP=3, errors=1, failures=2)
```

1 Error is raised due 1180282 BZ which is VERIFIED in Upstream
2 Failures are raised due 1177158 BZ which is also VERIFIED in Upstream
