### PR TITLE
Rename longrun tests as per issue #3083

### DIFF
--- a/tests/foreman/longrun/test_inc_updates.py
+++ b/tests/foreman/longrun/test_inc_updates.py
@@ -19,14 +19,14 @@ from robottelo.test import TestCase
 from robottelo.vm import VirtualMachine
 
 
-class TestIncrementalUpdate(TestCase):
+class IncrementalUpdateTestCase(TestCase):
     """Tests for the Incremental Update feature"""
 
     @classmethod
     @skip_if_not_set('clients')
     def setUpClass(cls):
         """Creates all the pre-requisites for the Incremental updates test"""
-        super(TestIncrementalUpdate, cls).setUpClass()
+        super(IncrementalUpdateTestCase, cls).setUpClass()
         # Step 1 - Create a new Organization
         cls.org = Organization(name=gen_alpha()).create()
 
@@ -223,7 +223,7 @@ class TestIncrementalUpdate(TestCase):
         )
 
     @run_only_on('sat')
-    def test_api_inc_update_noapply(self):
+    def test_positive_noapply_api(self):
         """@Test: Check if api incremental update can be done without
         actually applying it
 
@@ -270,7 +270,7 @@ class TestIncrementalUpdate(TestCase):
 
     @skip_if_bug_open('bugzilla', 1259057)
     @run_only_on('sat')
-    def test_cli_inc_update_noapply(self):
+    def test_positive_noapply_cli(self):
         """@Test: Check if cli incremental update can be done without
         actually applying it
 

--- a/tests/foreman/longrun/test_oscap.py
+++ b/tests/foreman/longrun/test_oscap.py
@@ -26,7 +26,7 @@ from robottelo.ui.session import Session
 from robottelo.vm import VirtualMachine
 
 
-class OpenScap(UITestCase):
+class OpenScapTestCase(UITestCase):
     """Implements Product tests in UI"""
 
     @classmethod
@@ -44,7 +44,7 @@ class OpenScap(UITestCase):
         8. Add product to activation-key
 
         """
-        super(OpenScap, cls).setUpClass()
+        super(OpenScapTestCase, cls).setUpClass()
         repo_values = [
             {'repo': REPOS['rhst6']['name'], 'reposet': REPOSET['rhst6']},
             {'repo': REPOS['rhst7']['name'], 'reposet': REPOSET['rhst7']},
@@ -125,7 +125,7 @@ class OpenScap(UITestCase):
             }})
 
     @run_only_on('sat')
-    def test_oscap_reports(self):
+    def test_positive_upload_to_satellite(self):
         """@Test: Perform end to end oscap test.
 
         @Feature: Oscap End to End.


### PR DESCRIPTION
Reviewers: The long run tests are not arranged like other regular tests.  So some of the test name conventions may not fit here.