### PR TITLE
Improve manifest cloning

### DIFF
--- a/robottelo/cli/factory.py
+++ b/robottelo/cli/factory.py
@@ -1940,11 +1940,11 @@ def setup_org_for_a_rh_repo(options=None):
     else:
         env_id = options['lifecycle-environment-id']
     # Clone manifest and upload it
-    manifest = manifests.clone()
-    upload_file(manifest, remote_file=manifest)
+    with manifests.clone() as manifest:
+        upload_file(manifest.content, manifest.filename)
     try:
         Subscription.upload({
-            u'file': manifest,
+            u'file': manifest.filename,
             u'organization-id': org_id,
         })
     except CLIReturnCodeError as err:

--- a/robottelo/cli/import_.py
+++ b/robottelo/cli/import_.py
@@ -284,10 +284,12 @@ class Import(Base):
         for org in set([rec['organization'] for rec in csv_records]):
             for char in [' ', '.', '#']:
                 org = org.replace(char, '_')
-            man_file = manifests.clone()
-            ssh.upload_file(man_file, u'{0}/{1}.zip'.format(man_dir, org))
+            with manifests.clone() as manifest:
+                ssh.upload_file(
+                    manifest.content,
+                    u'{0}/{1}.zip'.format(man_dir, org)
+                )
             manifest_list.append(u'{0}/{1}.zip'.format(man_dir, org))
-            os.remove(man_file)
         options.update({'upload-manifests-from': man_dir})
 
         result = cls.organization(options)

--- a/robottelo/ssh.py
+++ b/robottelo/ssh.py
@@ -95,17 +95,24 @@ def _get_connection(
         logger.info('Destroyed Paramiko client {0}'.format(client_id))
 
 
-def upload_file(local_file, remote_file=None, hostname=None):
-    """Upload a local file to a remote machine. If ``hostname`` is not provided
-    will be used the server.hostname from the cofiguration.
+def upload_file(local_file, remote_file, hostname=None):
+    """Upload a local file to a remote machine
 
+    :param local_file: either a file path or a file-like object to be uploaded.
+    :param remote_file: a remote file path where the uploaded file will be
+        placed.
+    :param hostname: target machine hostname. If not provided will be used the
+        ``server.hostname`` from the configuration.
     """
-    if not remote_file:
-        remote_file = local_file
     with _get_connection(hostname=hostname) as connection:
         try:
             sftp = connection.open_sftp()
-            sftp.put(local_file, remote_file)
+            # Check if local_file is a file-like object and use the proper
+            # paramiko function to upload it to the remote machine.
+            if hasattr(local_file, 'read'):
+                sftp.putfo(local_file, remote_file)
+            else:
+                sftp.put(local_file, remote_file)
         finally:
             sftp.close()
 

--- a/robottelo/ui/subscription.py
+++ b/robottelo/ui/subscription.py
@@ -1,4 +1,5 @@
 """Implements Subscriptions/Manifest handling for the UI"""
+import os
 
 from robottelo.ui.base import Base
 from robottelo.ui.locators import common_locators, locators
@@ -17,10 +18,10 @@ class Subscriptions(Base):
         """Specify locator for Subscription entity search procedure"""
         return locators['subs.select']
 
-    def upload(self, path, repo_url=None):
+    def upload(self, manifest, repo_url=None):
         """Uploads Manifest/subscriptions via UI.
 
-        :param str path: The manifest path to upload.
+        :param Manifest manifest: The manifest to upload.
         :param str repo_url: The RedHat URL to sync content from.
 
         """
@@ -30,9 +31,14 @@ class Subscriptions(Base):
             self.text_field_update(locators['subs.repo_url_update'], repo_url)
             self.click(common_locators['save'])
         browse_element = self.wait_until_element(locators['subs.file_path'])
-        browse_element.send_keys(path)
+        # File fields requires a file path in order to upload it. Create an
+        # actual file on filesystem and fill the path on the file field.
+        with open(manifest.filename, 'wb') as handler:
+            handler.write(manifest.content.read())
+        browse_element.send_keys(manifest.filename)
         self.click(locators['subs.upload'])
         self.wait_until_element(locators['subs.manifest_exists'], 180)
+        os.remove(manifest.filename)
 
     def delete(self):
         """Deletes Manifest/subscriptions via UI."""

--- a/tests/foreman/api/test_contentview.py
+++ b/tests/foreman/api/test_contentview.py
@@ -909,10 +909,10 @@ class ContentViewRedHatContent(APITestCase):
         super(ContentViewRedHatContent, cls).setUpClass()
 
         cls.org = entities.Organization().create()
-        with open(manifests.clone(), 'rb') as manifest:
+        with manifests.clone() as manifest:
             entities.Subscription().upload(
                 data={'organization_id': cls.org.id},
-                files={'content': manifest},
+                files={'content': manifest.content},
             )
         repo_id = enable_rhrepo_and_fetchid(
             basearch='x86_64',

--- a/tests/foreman/api/test_product.py
+++ b/tests/foreman/api/test_product.py
@@ -143,8 +143,8 @@ class RepositorySetTestCase(APITestCase):
         @Assert: Repository was enabled
         """
         org = entities.Organization().create()
-        with open(manifests.clone(), 'rb') as manifest:
-            upload_manifest(org.id, manifest)
+        with manifests.clone() as manifest:
+            upload_manifest(org.id, manifest.content)
         product = entities.Product(
             name=PRDS['rhel'],
             organization=org,
@@ -173,8 +173,8 @@ class RepositorySetTestCase(APITestCase):
         @Assert: Repository was disabled
         """
         org = entities.Organization().create()
-        with open(manifests.clone(), 'rb') as manifest:
-            upload_manifest(org.id, manifest)
+        with manifests.clone() as manifest:
+            upload_manifest(org.id, manifest.content)
         product = entities.Product(
             name=PRDS['rhel'],
             organization=org,

--- a/tests/foreman/api/test_repository.py
+++ b/tests/foreman/api/test_repository.py
@@ -262,8 +262,8 @@ class RepositorySyncTestCase(APITestCase):
         @Assert: Repository synced should fetch the data successfully.
         """
         org = entities.Organization().create()
-        with open(manifests.clone(), 'rb') as manifest:
-            upload_manifest(org.id, manifest)
+        with manifests.clone() as manifest:
+            upload_manifest(org.id, manifest.content)
         repo_id = enable_rhrepo_and_fetchid(
             basearch='x86_64',
             org_id=org.id,

--- a/tests/foreman/api/test_subscription.py
+++ b/tests/foreman/api/test_subscription.py
@@ -25,8 +25,8 @@ class SubscriptionsTestCase(APITestCase):
         @Feature: Subscriptions
         """
         org = entities.Organization().create()
-        with open(manifests.clone(), 'rb') as manifest:
-            upload_manifest(org.id, manifest)
+        with manifests.clone() as manifest:
+            upload_manifest(org.id, manifest.content)
 
     @skip_if_not_set('fake_manifest')
     @tier1
@@ -39,8 +39,8 @@ class SubscriptionsTestCase(APITestCase):
         """
         org = entities.Organization().create()
         sub = entities.Subscription(organization=org)
-        with open(manifests.clone(), 'rb') as manifest:
-            upload_manifest(org.id, manifest)
+        with manifests.clone() as manifest:
+            upload_manifest(org.id, manifest.content)
         self.assertGreater(len(sub.search()), 0)
         sub.delete_manifest(data={'organization_id': org.id})
         self.assertEqual(len(sub.search()), 0)
@@ -55,9 +55,9 @@ class SubscriptionsTestCase(APITestCase):
         @Feature: Subscriptions
         """
         orgs = [entities.Organization().create() for _ in range(2)]
-        with open(manifests.clone(), 'rb') as manifest:
-            upload_manifest(orgs[0].id, manifest)
+        with manifests.clone() as manifest:
+            upload_manifest(orgs[0].id, manifest.content)
             with self.assertRaises(TaskFailedError):
-                upload_manifest(orgs[1].id, manifest)
+                upload_manifest(orgs[1].id, manifest.content)
         self.assertEqual(
             len(entities.Subscription(organization=orgs[1]).search()), 0)

--- a/tests/foreman/cli/test_activationkey.py
+++ b/tests/foreman/cli/test_activationkey.py
@@ -731,10 +731,10 @@ class ActivationKeyTestCase(CLITestCase):
         @Assert: Deleting subscription removes it from the Activation key
         """
         new_ak = self._make_activation_key()
-        manifest = manifests.clone()
-        upload_file(manifest)
+        with manifests.clone() as manifest:
+            upload_file(manifest.content, manifest.filename)
         Subscription.upload({
-            'file': manifest,
+            'file': manifest.filename,
             'organization-id': self.org['id'],
         })
         subscription_result = Subscription.list({
@@ -977,12 +977,12 @@ class ActivationKeyTestCase(CLITestCase):
 
         @Assert: Subscription successfully added to activation key
         """
-        manifest = manifests.clone()
-        upload_file(manifest, remote_file=manifest)
+        with manifests.clone() as manifest:
+            upload_file(manifest.content, manifest.filename)
         org_id = make_org()['id']
         ackey_id = self._make_activation_key()['id']
         Subscription.upload({
-            'file': manifest,
+            'file': manifest.filename,
             'organization-id': org_id,
         })
         subs_id = Subscription.list(
@@ -1064,10 +1064,10 @@ class ActivationKeyTestCase(CLITestCase):
         """
         # Begin test setup
         parent_ak = self._make_activation_key()
-        manifest = manifests.clone()
-        upload_file(manifest, remote_file=manifest)
+        with manifests.clone() as manifest:
+            upload_file(manifest.content, manifest.filename)
         Subscription.upload({
-            'file': manifest,
+            'file': manifest.filename,
             'organization-id': self.org['id'],
         })
         subscription_result = Subscription.list(

--- a/tests/foreman/cli/test_contentviews.py
+++ b/tests/foreman/cli/test_contentviews.py
@@ -78,10 +78,10 @@ class ContentViewTestCase(CLITestCase):
             return
 
         ContentViewTestCase.rhel_content_org = make_org()
-        manifest = manifests.clone()
-        upload_file(manifest)
+        with manifests.clone() as manifest:
+            upload_file(manifest.content, manifest.filename)
         Subscription.upload({
-            'file': manifest,
+            'file': manifest.filename,
             'organization-id': ContentViewTestCase.rhel_content_org['id'],
         })
 

--- a/tests/foreman/cli/test_repository_set.py
+++ b/tests/foreman/cli/test_repository_set.py
@@ -27,10 +27,10 @@ class RepositorySetTestCase(CLITestCase):
 
         # Clone manifest and upload it
         org = make_org()
-        manifest = manifests.clone()
-        upload_file(manifest, remote_file=manifest)
+        with manifests.clone() as manifest:
+            upload_file(manifest.content, manifest.filename)
         Subscription.upload({
-            u'file': manifest,
+            u'file': manifest.filename,
             u'organization-id': org['id'],
         })
 
@@ -134,10 +134,10 @@ class RepositorySetTestCase(CLITestCase):
         @Assert: Repository was enabled
         """
         org = make_org()
-        manifest = manifests.clone()
-        upload_file(manifest, remote_file=manifest)
+        with manifests.clone() as manifest:
+            upload_file(manifest.content, manifest.filename)
         Subscription.upload({
-            u'file': manifest,
+            u'file': manifest.filename,
             u'organization-id': org['id'],
         })
         RepositorySet.enable({
@@ -170,10 +170,10 @@ class RepositorySetTestCase(CLITestCase):
         @Assert: Repository was enabled
         """
         org = make_org()
-        manifest = manifests.clone()
-        upload_file(manifest, remote_file=manifest)
+        with manifests.clone() as manifest:
+            upload_file(manifest.content, manifest.filename)
         Subscription.upload({
-            u'file': manifest,
+            u'file': manifest.filename,
             u'organization-id': org['id'],
         })
         RepositorySet.enable({
@@ -205,10 +205,10 @@ class RepositorySetTestCase(CLITestCase):
         @Assert: Repository was enabled
         """
         org = make_org()
-        manifest = manifests.clone()
-        upload_file(manifest, remote_file=manifest)
+        with manifests.clone() as manifest:
+            upload_file(manifest.content, manifest.filename)
         Subscription.upload({
-            u'file': manifest,
+            u'file': manifest.filename,
             u'organization-id': org['id'],
         })
         product_id = Product.info({
@@ -250,10 +250,10 @@ class RepositorySetTestCase(CLITestCase):
         @Assert: Repository was disabled
         """
         org = make_org()
-        manifest = manifests.clone()
-        upload_file(manifest, remote_file=manifest)
+        with manifests.clone() as manifest:
+            upload_file(manifest.content, manifest.filename)
         Subscription.upload({
-            u'file': manifest,
+            u'file': manifest.filename,
             u'organization-id': org['id'],
         })
         RepositorySet.enable({
@@ -293,10 +293,10 @@ class RepositorySetTestCase(CLITestCase):
         @Assert: Repository was disabled
         """
         org = make_org()
-        manifest = manifests.clone()
-        upload_file(manifest, remote_file=manifest)
+        with manifests.clone() as manifest:
+            upload_file(manifest.content, manifest.filename)
         Subscription.upload({
-            u'file': manifest,
+            u'file': manifest.filename,
             u'organization-id': org['id'],
         })
         RepositorySet.enable({
@@ -335,10 +335,10 @@ class RepositorySetTestCase(CLITestCase):
         @Assert: Repository was disabled
         """
         org = make_org()
-        manifest = manifests.clone()
-        upload_file(manifest, remote_file=manifest)
+        with manifests.clone() as manifest:
+            upload_file(manifest.content, manifest.filename)
         Subscription.upload({
-            u'file': manifest,
+            u'file': manifest.filename,
             u'organization-id': org['id'],
         })
         product_id = Product.info({

--- a/tests/foreman/cli/test_subscription.py
+++ b/tests/foreman/cli/test_subscription.py
@@ -17,16 +17,21 @@ class SubscriptionTestCase(CLITestCase):
         """Tests for content-view via Hammer CLI"""
         super(SubscriptionTestCase, self).setUp()
         self.org = make_org()
-        self.manifest = manifests.clone()
 
     # pylint: disable=no-self-use
-    def _upload_manifest(self, manifest, org_id):
-        """Uploads a manifest file and import it into an organization"""
-        upload_file(manifest, remote_file=manifest)
+    def _upload_manifest(self, org_id, manifest=None):
+        """Uploads a manifest into an organization.
+
+        A cloned manifest will be used if ``manifest`` is None.
+        """
+        if manifest is None:
+            manifest = manifests.clone()
+        upload_file(manifest.content, manifest.filename)
         Subscription.upload({
-            'file': manifest,
+            u'file': manifest.filename,
             'organization-id': org_id,
         })
+        manifest.content.close()
 
     @tier1
     def test_positive_manifest_upload(self):
@@ -36,7 +41,7 @@ class SubscriptionTestCase(CLITestCase):
 
         @Assert: Manifest are uploaded properly
         """
-        self._upload_manifest(self.manifest, self.org['id'])
+        self._upload_manifest(self.org['id'])
         Subscription.list(
             {'organization-id': self.org['id']},
             per_page=False,
@@ -50,7 +55,7 @@ class SubscriptionTestCase(CLITestCase):
 
         @Assert: Manifest are deleted properly
         """
-        self._upload_manifest(self.manifest, self.org['id'])
+        self._upload_manifest(self.org['id'])
         Subscription.list(
             {'organization-id': self.org['id']},
             per_page=False,
@@ -72,7 +77,7 @@ class SubscriptionTestCase(CLITestCase):
         @Assert: you are able to enable and synchronize
         repository contained in a manifest
         """
-        self._upload_manifest(self.manifest, self.org['id'])
+        self._upload_manifest(self.org['id'])
         Subscription.list(
             {'organization-id': self.org['id']},
             per_page=False,
@@ -105,7 +110,7 @@ class SubscriptionTestCase(CLITestCase):
 
         @Assert: Manifest history is shown properly
         """
-        self._upload_manifest(self.manifest, self.org['id'])
+        self._upload_manifest(self.org['id'])
         Subscription.list(
             {'organization-id': self.org['id']},
             per_page=None,
@@ -127,7 +132,7 @@ class SubscriptionTestCase(CLITestCase):
         @Assert: Manifests can be refreshed
         """
         self._upload_manifest(
-            manifests.download_manifest_template(), self.org['id'])
+            self.org['id'], manifests.original_manifest())
         Subscription.list(
             {'organization-id': self.org['id']},
             per_page=False,
@@ -150,7 +155,7 @@ class SubscriptionTestCase(CLITestCase):
 
         @BZ: 1226425
         """
-        self._upload_manifest(self.manifest, self.org['id'])
+        self._upload_manifest(self.org['id'])
         Subscription.list(
             {'organization-id': self.org['id']},
             per_page=False,

--- a/tests/foreman/longrun/test_inc_updates.py
+++ b/tests/foreman/longrun/test_inc_updates.py
@@ -42,8 +42,8 @@ class IncrementalUpdateTestCase(TestCase):
         ).create()
 
         # Step 3: Upload manifest
-        with open(manifests.clone(), 'rb') as manifest:
-            upload_manifest(cls.org.id, manifest)
+        with manifests.clone() as manifest:
+            upload_manifest(cls.org.id, manifest.content)
 
         # Step 4: Enable repositories - 6Server and rhel6 sat6tools
         rhel_66_repo_id = enable_rhrepo_and_fetchid(

--- a/tests/foreman/longrun/test_oscap.py
+++ b/tests/foreman/longrun/test_oscap.py
@@ -60,8 +60,8 @@ class OpenScapTestCase(UITestCase):
         cls.env_name = env.name
 
         # step 2: Clone and Upload manifest
-        with open(manifests.clone(), 'rb') as manifest:
-            upload_manifest(org.id, manifest)
+        with manifests.clone() as manifest:
+            upload_manifest(org.id, manifest.content)
 
         # step 3: Sync RedHat Sattools RHEL6 ad RHEL7 repository
         repos = [

--- a/tests/foreman/rhai/test_rhai.py
+++ b/tests/foreman/rhai/test_rhai.py
@@ -26,8 +26,8 @@ class RHAITestCase(UITestCase):
         ).create()
 
         # Upload manifest
-        with open(manifests.clone(), 'rb') as manifest:
-            upload_manifest(org.id, manifest)
+        with manifests.clone() as manifest:
+            upload_manifest(org.id, manifest.content)
 
         # Create activation key using default CV and library environment
         activation_key = entities.ActivationKey(

--- a/tests/foreman/rhai/test_rhai_client.py
+++ b/tests/foreman/rhai/test_rhai_client.py
@@ -22,8 +22,8 @@ class RHAIClientTestCase(TestCase):
         ).create()
 
         # Upload manifest
-        with open(manifests.clone(), 'rb') as manifest:
-            upload_manifest(org.id, manifest)
+        with manifests.clone() as manifest:
+            upload_manifest(org.id, manifest.content)
 
         # Create activation key using default CV and library environment
         activation_key = entities.ActivationKey(

--- a/tests/foreman/smoke/test_api_smoke.py
+++ b/tests/foreman/smoke/test_api_smoke.py
@@ -1011,8 +1011,8 @@ class SmokeTestCase(TestCase):
         ).create()
 
         # step 2: Upload manifest
-        with open(manifests.clone(), 'rb') as manifest:
-            upload_manifest(org.id, manifest)
+        with manifests.clone() as manifest:
+            upload_manifest(org.id, manifest.content)
         # step 3.1: Enable RH repo and fetch repository_id
         repository = entities.Repository(id=enable_rhrepo_and_fetchid(
             basearch='x86_64',

--- a/tests/foreman/smoke/test_cli_smoke.py
+++ b/tests/foreman/smoke/test_cli_smoke.py
@@ -419,10 +419,10 @@ class SmokeTestCase(CLITestCase):
             u'organization-id': new_org['id'],
         })
         # Clone manifest and upload it
-        manifest = manifests.clone()
-        ssh.upload_file(manifest, remote_file=manifest)
+        with manifests.clone() as manifest:
+            ssh.upload_file(manifest.content, manifest.filename)
         Subscription.upload({
-            u'file': manifest,
+            u'file': manifest.filename,
             u'organization-id': new_org['id'],
         })
         # Enable repo from Repository Set

--- a/tests/foreman/smoke/test_ui_smoke.py
+++ b/tests/foreman/smoke/test_ui_smoke.py
@@ -22,7 +22,6 @@ from robottelo.constants import (
     FAKE_6_PUPPET_REPO,
 )
 from robottelo.decorators import bz_bug_is_open, skip_if_not_set
-from robottelo.ssh import upload_file
 from robottelo.test import UITestCase
 from robottelo.ui.factory import (
     make_activationkey,
@@ -275,9 +274,6 @@ class SmokeTestCase(UITestCase):
         activation_key_name = gen_string('alpha', 6)
         env_name = gen_string('alpha', 6)
         repos = self.sync.create_repos_tree(RHVA_REPO_TREE)
-        cloned_manifest_path = manifests.clone()
-        # upload_file function should take care of uploading to sauce labs.
-        upload_file(cloned_manifest_path)
         with Session(self.browser) as session:
             # Create New organization
             make_org(session, org_name=org_name)
@@ -289,7 +285,8 @@ class SmokeTestCase(UITestCase):
             session.nav.go_to_select_org(org_name)
             session.nav.go_to_red_hat_subscriptions()
             # Upload manifest from webui
-            self.subscriptions.upload(cloned_manifest_path)
+            with manifests.clone() as manifest:
+                self.subscriptions.upload(manifest)
             self.assertTrue(session.nav.wait_until_element(
                 common_locators['alert.success']
             ))
@@ -367,7 +364,6 @@ class SmokeTestCase(UITestCase):
 
         """
         activation_key_name = gen_string('alpha')
-        cloned_manifest_path = manifests.clone()
         cv_name = gen_string('alpha')
         env_name = gen_string('alpha')
         org_name = gen_string('alpha')
@@ -377,7 +373,6 @@ class SmokeTestCase(UITestCase):
         repos = self.sync.create_repos_tree(SAT6_TOOLS_TREE)
         rhel_prd = DEFAULT_SUBSCRIPTION_NAME
         rhel6_repo = settings.rhel6_repo
-        upload_file(cloned_manifest_path)
         with Session(self.browser) as session:
             # Create New organization
             make_org(session, org_name=org_name)
@@ -387,7 +382,8 @@ class SmokeTestCase(UITestCase):
             self.assertIsNotNone(self.lifecycleenvironment.search(env_name))
             session.nav.go_to_red_hat_subscriptions()
             # Upload manifest from webui
-            self.subscriptions.upload(cloned_manifest_path)
+            with manifests.clone() as manifest:
+                self.subscriptions.upload(manifest)
             self.assertTrue(session.nav.wait_until_element(
                 common_locators['alert.success']
             ))

--- a/tests/foreman/ui/test_activationkey.py
+++ b/tests/foreman/ui/test_activationkey.py
@@ -627,8 +627,8 @@ class ActivationKeyTestCase(UITestCase):
             'releasever': '6Server',
         }
         org = entities.Organization().create()
-        with open(manifests.clone(), 'rb') as manifest:
-            upload_manifest(org.id, manifest)
+        with manifests.clone() as manifest:
+            upload_manifest(org.id, manifest.content)
         repo1_id = self.enable_sync_redhat_repo(rh_repo1, org.id)
         self.cv_publish_promote(cv1_name, env1_name, repo1_id, org.id)
         repo2_id = self.enable_sync_redhat_repo(rh_repo2, org.id)
@@ -876,8 +876,8 @@ class ActivationKeyTestCase(UITestCase):
         # Create new org to import manifest
         org = entities.Organization().create()
         # Upload manifest
-        with open(manifests.clone(), 'rb') as manifest:
-            upload_manifest(org.id, manifest)
+        with manifests.clone() as manifest:
+            upload_manifest(org.id, manifest.content)
         # Helper function to create and promote CV to next environment
         repo_id = self.enable_sync_redhat_repo(rh_repo, org_id=org.id)
         self.cv_publish_promote(cv_name, env_name, repo_id, org.id)
@@ -966,8 +966,8 @@ class ActivationKeyTestCase(UITestCase):
             product=product,
         ).create()
         # Upload manifest
-        with open(manifests.clone(), 'rb') as manifest:
-            upload_manifest(org.id, manifest)
+        with manifests.clone() as manifest:
+            upload_manifest(org.id, manifest.content)
         # Enable RH repo and fetch repository_id
         rhel_repo_id = enable_rhrepo_and_fetchid(
             basearch=rh_repo['basearch'],
@@ -1011,8 +1011,8 @@ class ActivationKeyTestCase(UITestCase):
         # Upload manifest
         org = entities.Organization().create()
         sub = entities.Subscription(organization=org)
-        with open(manifests.clone(), 'rb') as manifest:
-            upload_manifest(org.id, manifest)
+        with manifests.clone() as manifest:
+            upload_manifest(org.id, manifest.content)
         # Create activation key
         activation_key = entities.ActivationKey(
             organization=org,

--- a/tests/foreman/ui/test_contentview.py
+++ b/tests/foreman/ui/test_contentview.py
@@ -69,8 +69,8 @@ class ContentViewTestCase(UITestCase):
             ).create().id
         elif rh_repo:
             # Uploads the manifest and returns the result.
-            with open(manifests.clone(), 'rb') as manifest:
-                upload_manifest(org_id, manifest)
+            with manifests.clone() as manifest:
+                upload_manifest(org_id, manifest.content)
             # Enables the RedHat repo and fetches it's Id.
             repo_id = enable_rhrepo_and_fetchid(
                 basearch=rh_repo['basearch'],

--- a/tests/foreman/ui/test_organization.py
+++ b/tests/foreman/ui/test_organization.py
@@ -264,8 +264,8 @@ class OrganizationTestCase(UITestCase):
         """
         org_name = gen_string('alphanumeric')
         org = entities.Organization(name=org_name).create()
-        with open(manifests.clone(), 'rb') as manifest:
-            upload_manifest(org.id, manifest)
+        with manifests.clone() as manifest:
+            upload_manifest(org.id, manifest.content)
         with Session(self.browser) as session:
             make_lifecycle_environment(session, org_name, name='DEV')
             make_lifecycle_environment(

--- a/tests/foreman/ui/test_subscription.py
+++ b/tests/foreman/ui/test_subscription.py
@@ -3,7 +3,6 @@ from nailgun import entities
 from robottelo import manifests
 from robottelo.constants import DEFAULT_SUBSCRIPTION_NAME
 from robottelo.decorators import skip_if_not_set, tier1
-from robottelo.ssh import upload_file
 from robottelo.test import UITestCase
 from robottelo.ui.locators import common_locators, locators
 from robottelo.ui.session import Session
@@ -26,13 +25,11 @@ class SubscriptionTestCase(UITestCase):
 
         @Assert: Manifest is uploaded successfully
         """
-        manifest_path = manifests.clone()
-        # upload_file function should take care of uploading to sauce labs.
-        upload_file(manifest_path, remote_file=manifest_path)
         with Session(self.browser) as session:
             session.nav.go_to_select_org(self.organization.name)
             session.nav.go_to_red_hat_subscriptions()
-            self.subscriptions.upload(manifest_path)
+            with manifests.clone() as manifest:
+                self.subscriptions.upload(manifest)
             self.assertTrue(self.subscriptions.wait_until_element(
                 common_locators['alert.success']))
 
@@ -45,13 +42,11 @@ class SubscriptionTestCase(UITestCase):
 
         @Assert: Manifest is deleted successfully
         """
-        manifest_path = manifests.clone()
-        # upload_file function should take care of uploading to sauce labs.
-        upload_file(manifest_path, remote_file=manifest_path)
         with Session(self.browser) as session:
             session.nav.go_to_select_org(self.organization.name)
             session.nav.go_to_red_hat_subscriptions()
-            self.subscriptions.upload(manifest_path)
+            with manifests.clone() as manifest:
+                self.subscriptions.upload(manifest)
             self.subscriptions.delete()
             self.assertTrue(self.subscriptions.wait_until_element(
                 common_locators['alert.success']))
@@ -66,13 +61,11 @@ class SubscriptionTestCase(UITestCase):
         @Assert: Manifest is Deleted. Delete button is asserted. Subscriptions
         is asserted
         """
-        manifest_path = manifests.clone()
-        # upload_file function should take care of uploading to sauce labs.
-        upload_file(manifest_path, remote_file=manifest_path)
         with Session(self.browser) as session:
             session.nav.go_to_select_org(self.organization.name)
             session.nav.go_to_red_hat_subscriptions()
-            self.subscriptions.upload(manifest_path)
+            with manifests.clone() as manifest:
+                self.subscriptions.upload(manifest)
             self.subscriptions.delete()
             self.assertTrue(self.subscriptions.wait_until_element(
                 common_locators['alert.success']))

--- a/tests/foreman/ui/test_sync.py
+++ b/tests/foreman/ui/test_sync.py
@@ -64,8 +64,8 @@ class SyncTestCase(UITestCase):
         @Assert: Sync procedure for RedHat Repos is successful
         """
         repos = self.sync.create_repos_tree(RHCT)
-        with open(manifests.clone(), 'rb') as manifest:
-            upload_manifest(self.organization.id, manifest)
+        with manifests.clone() as manifest:
+            upload_manifest(self.organization.id, manifest.content)
         with Session(self.browser) as session:
             session.nav.go_to_select_org(self.organization.name)
             session.nav.go_to_red_hat_repositories()


### PR DESCRIPTION
Avoid creating files on the filesystem, instead use in-memory file like
object.

Closes #3180