### PR TITLE
Support around pxe-less discovery and tests

### DIFF
--- a/robottelo/config/settings.py
+++ b/robottelo/config/settings.py
@@ -360,6 +360,26 @@ class LibvirtHostSettings(FeatureSettings):
         return validation_errors
 
 
+class DiscoveryISOSettings(FeatureSettings):
+    """Discovery ISO name settings definition."""
+    def __init__(self, *args, **kwargs):
+        super(DiscoveryISOSettings, self).__init__(*args, **kwargs)
+        self.discovery_iso = None
+
+    def read(self, reader):
+        """Read discovery iso setting."""
+        self.discovery_iso = reader.get('discovery', 'discovery_iso')
+
+    def validate(self):
+        """Validate discovery iso name setting."""
+        validation_errors = []
+        if self.discovery_iso is None:
+            validation_errors.append(
+                '[discovery] discovery iso name must be provided.'
+            )
+        return validation_errors
+
+
 class OscapSettings(FeatureSettings):
     """Oscap settings definitions."""
     def __init__(self, *args, **kwargs):
@@ -522,6 +542,7 @@ class Settings(object):
         # Features
         self.clients = ClientsSettings()
         self.compute_resources = LibvirtHostSettings()
+        self.discovery = DiscoveryISOSettings()
         self.docker = DockerSettings()
         self.fake_manifest = FakeManifestSettings()
         self.ldap = LDAPSettings()
@@ -559,6 +580,9 @@ class Settings(object):
         if self.reader.has_section('compute_resources'):
             self.compute_resources.read(self.reader)
             self._validation_errors.extend(self.compute_resources.validate())
+        if self.reader.has_section('discovery'):
+            self.discovery.read(self.reader)
+            self._validation_errors.extend(self.discovery.validate())
         if self.reader.has_section('docker'):
             self.docker.read(self.reader)
             self._validation_errors.extend(self.docker.validate())

--- a/robottelo/libvirt_discovery.py
+++ b/robottelo/libvirt_discovery.py
@@ -1,0 +1,194 @@
+"""Utilities to create virtual host on libvirt with and without PXE boot
+
+Hosts are virtual guests provisioned on a external ``libvirt_host``. All
+guests images are stored on the ``image_dir`` path on external libvirt
+server.
+
+Make sure to configure the ``compute_resources`` section on the configuration
+file. Also make sure that the ``vlan_networking`` section is properly
+configured.
+"""
+import logging
+import os
+
+from fauxfactory import gen_mac
+from robottelo import ssh
+from robottelo.config import settings
+
+logger = logging.getLogger(__name__)
+
+
+class LibvirtGuestError(Exception):
+    """Exception raised for failed virtual guests on external libvirt"""
+
+
+class LibvirtGuest(object):
+    """Manages a Libvirt guests to allow host discovery and provisioning
+
+    It expects that Libvirt host is defined with image path.
+    Make sure to call :meth:`destroy` to stop and clean the image on the
+    libvirt server, otherwise the virtual machine and its image will stay
+    on the server consuming hardware resources.
+
+    It is possible to customize the ``libvirt_host`` and ``image_dir``
+    as per virtual machine basis. Just set the expected values when
+    instantiating.
+    """
+
+    def __init__(
+            self, cpu=1, ram=1024, boot_iso=False, libvirt_server=None,
+            image_dir=None, mac=None, bridge=None):
+        self.cpu = cpu
+        self.ram = ram
+        if libvirt_server is None:
+            self.libvirt_server = settings.compute_resources.libvirt_hostname
+        else:
+            self.libvirt_server = libvirt_server
+        if self.libvirt_server is None or self.libvirt_server == '':
+            raise LibvirtGuestError(
+                'A libvirt server must be provided. Make sure to fill '
+                '"libvirt_server" on compute_resources section of your '
+                'robottelo configuration. Or provide a not None '
+                'libvirt_server argument.'
+            )
+        if image_dir is None:
+            self.image_dir = settings.compute_resources.libvirt_image_dir
+        else:
+            self.image_dir = image_dir
+        if mac is None:
+            self.mac = gen_mac(multicast=False, locally=True)
+        else:
+            self.mac = mac
+        if bridge is None:
+            self.bridge = settings.vlan_networking.bridge
+        else:
+            self.bridge = bridge
+        if not self.bridge:
+            raise LibvirtGuestError(
+                'A bridge name must be provided. Make sure to fill '
+                '"bridge" on vlan_networking section of your robottelo '
+                'configuration. Or provide a not None bridge '
+                'argument.'
+            )
+        self.boot_iso = boot_iso
+        self.hostname = None
+        self.ip_addr = None
+        self._domain = None
+        self._created = False
+        self.guest_name = 'mac{0}'.format(self.mac.replace(':', ""))
+
+    def create(self):
+        """Creates a virtual machine on the libvirt server using
+        virt-install
+
+        :raises robottelo.vm.LibvirtGuestError: Whenever a virtual guest
+            could not be executed.
+        """
+        if self._created:
+            return
+
+        command_args = [
+            'virt-install',
+            '--hvm',
+            '--network=bridge:{vm_bridge}',
+            '--mac={vm_mac}',
+            '--name={vm_name}',
+            '--ram={vm_ram}',
+            '--vcpus={vm_cpu}',
+            '--os-type=linux',
+            '--os-variant=rhel7',
+            '--disk path={image_name},size=8',
+            '--noautoconsole',
+        ]
+
+        if not self.boot_iso:
+            # Required for PXE-based host discovery
+            command_args.append('--pxe')
+        else:
+            # Required for PXE-less host discovery, where we boot the host
+            # with bootable discovery ISO
+            self.boot_iso_name = settings.discovery.discovery_iso
+            boot_iso_dir = u'{0}/{1}'.format(
+                self.image_dir, self.boot_iso_name)
+            command_args.append('--cdrom={0}'.format(boot_iso_dir))
+
+        if self._domain is None:
+            try:
+                self._domain = self.libvirt_server.split('.', 1)[1]
+            except IndexError:
+                raise LibvirtGuestError(
+                    u"Failed to fetch domain from libvirt server: {0} "
+                    .format(self.libvirt_server))
+
+        self.hostname = u'{0}.{1}'.format(self.guest_name, self._domain)
+        command = u' '.join(command_args).format(
+            vm_bridge=self.bridge,
+            vm_mac=self.mac,
+            vm_name=self.hostname,
+            vm_ram=self.ram,
+            vm_cpu=self.cpu,
+            image_name=u'{0}/{1}.img'.format(self.image_dir, self.hostname)
+        )
+
+        result = ssh.command(command, self.libvirt_server)
+
+        if result.return_code != 0:
+            raise LibvirtGuestError(
+                u'Failed to run virt-install: {0}'.format(result.stderr))
+
+        self._created = True
+
+    def destroy(self):
+        """Destroys the virtual machine on the provisioning server"""
+        if not self._created:
+            return
+
+        ssh.command(
+            u'virsh destroy {0}'.format(self.hostname),
+            hostname=self.libvirt_server
+        )
+        ssh.command(
+            u'virsh undefine {0}'.format(self.hostname),
+            hostname=self.libvirt_server
+        )
+        image_name = u'{0}.img'.format(self.hostname)
+        ssh.command(
+            u'rm {0}'.format(os.path.join(self.image_dir, image_name)),
+            hostname=self.libvirt_server
+        )
+
+    def attach_nic(self):
+        """Add a new NIC to existing host"""
+        if not self._created:
+            raise LibvirtGuestError(
+                'The virtual guest should be created before updating it'
+            )
+
+        command_args = [
+            'virsh attach-interface',
+            '--domain={vm_name}',
+            '--type=bridge',
+            '--source={vm_bridge}',
+            '--model=virtio',
+            '--mac={vm_mac}',
+            '--config',
+        ]
+        command = u' '.join(command_args).format(
+            vm_name=self.hostname,
+            vm_bridge=self.bridge,
+            vm_mac=self.mac,
+        )
+
+        result = ssh.command(command, self.libvirt_server)
+
+        if result.return_code != 0:
+            raise LibvirtGuestError(
+                u'Failed to run virsh attach-interface: {0}'
+                .format(result.stderr))
+
+    def __enter__(self):
+        self.create()
+        return self
+
+    def __exit__(self, *exc):
+        self.destroy()

--- a/robottelo/ui/discoveredhosts.py
+++ b/robottelo/ui/discoveredhosts.py
@@ -1,6 +1,6 @@
 # -*- encoding: utf-8 -*-
 """Implements Discovered Hosts from UI."""
-from robottelo.ui.base import Base
+from robottelo.ui.base import Base, UIError
 from robottelo.ui.locators import locators
 from robottelo.ui.navigator import Navigator
 
@@ -25,3 +25,72 @@ class DiscoveredHosts(Base):
             locators['discoveredhosts.delete'],
             drop_locator=locators['discoveredhosts.dropdown'],
         )
+
+    def delete_from_facts(self, hostname, really=True):
+        """Delete existing discovered host from facts page"""
+        host = self.search(hostname)
+        if not host:
+            raise UIError(
+                'Could not find the selected discovered host "{0}"'
+                .format(hostname)
+            )
+        host.click()
+        strategy, value = locators['discoveredhosts.delete_from_facts']
+        self.click((strategy, value % hostname), wait_for_ajax=False)
+        self.handle_alert(really)
+
+    def multi_delete(self, really=True):
+        """Bulk delete discovered hosts"""
+        select_all_element = locators['discoveredhosts.select_all']
+        select_action_element = locators['discoveredhosts.select_action']
+        multi_delete_element = locators['discoveredhosts.multi_delete']
+        bulk_submit_button = locators['discoveredhosts.bulk_submit_button']
+        if not self.find_element(select_all_element):
+            raise UIError(
+                'Could not find the check-box to select all discovered hosts'
+            )
+        self.click(select_all_element)
+        if not self.find_element(select_action_element):
+            raise UIError(
+                'Could not find the select_action dropdown for bulk operations'
+            )
+        self.click(select_action_element)
+        if not self.find_element(multi_delete_element):
+            raise UIError(
+                'Could not find the delete option from select_action dropdown'
+            )
+        self.click(multi_delete_element)
+        if not self.find_element(bulk_submit_button):
+            raise UIError(
+                'Could not find the bulk submit button'
+            )
+        self.click(bulk_submit_button)
+
+    def refresh_facts(self, hostname):
+        """Refresh the facts of discovered host"""
+        host = self.search(hostname)
+        if not host:
+            raise UIError(
+                'Could not find the selected discovered host "{0}"'
+                .format(hostname)
+            )
+        strategy, value = locators['discoveredhosts.dropdown']
+        self.click((strategy, value % hostname), wait_for_ajax=False)
+        strategy, value = locators['discoveredhosts.refresh_facts']
+        self.click((strategy, value % hostname), wait_for_ajax=False)
+
+    def fetch_fact_value(self, hostname, element):
+        """Fetch the value of selected fact from discovered hosts page"""
+        host = self.search(hostname)
+        if not host:
+            raise UIError(
+                'Could not find the selected discovered host "{0}"'
+                .format(hostname)
+            )
+        if not self.find_element(element):
+            raise UIError(
+                'Could not find element to fetch interfaces from facts page'
+            )
+        web_element = self.find_element(element)
+        element_value = web_element.text
+        return element_value

--- a/robottelo/ui/locators.py
+++ b/robottelo/ui/locators.py
@@ -2031,8 +2031,30 @@ locators = LocatorDict({
     "discoveredhosts.dropdown": (
         By.XPATH, ("//a[contains(@href,'%s')]"
                    "/following::a[@data-toggle='dropdown']")),
+    "discoveredhosts.refresh_facts": (
+        By.XPATH, ("//a[contains(@href,'%s') and "
+                   "contains(@data-id,'refresh_facts')]")),
     "discoveredhosts.delete": (
         By.XPATH, ("//a[@class='delete' and contains(@data-confirm, '%s')]")),
+    "discoveredhosts.delete_from_facts": (
+        By.XPATH, ("//a[contains(@href,'%s') and contains(.,'Delete')]")),
+    "discoveredhosts.select_all": (By.ID, "check_all"),
+    "discoveredhosts.select_action": (
+        By.XPATH, ("//div[@id='submit_multiple']/a[@data-toggle='dropdown']")),
+    "discoveredhosts.multi_delete": (
+        By.XPATH, ("//a[@href='/discovered_hosts/multiple_destroy']")),
+    "discoveredhosts.fetch_interfaces": (
+        By.XPATH, ("//div[@id='content']/table/tbody/tr[2]/"
+                   "td[contains(.,'eth')]")),
+    "discoveredhosts.fetch_bios": (
+        By.XPATH, ("//div[@id='content']/table/tbody/tr[2]"
+                   "/td[contains(.,'bios')]")),
+    "discoveredhosts.fetch_custom_fact": (
+        By.XPATH, ("//div[@id='content']/table/tbody/tr[2]/"
+                   "td[contains(.,'some')]")),
+    "discoveredhosts.bulk_submit_button": (
+        By.XPATH, ("//div[@id='confirmation-modal']"
+                   "//div[@class='modal-footer']/button[2]")),
 
     # LDAP Authentication
     "ldapsource.new": (


### PR DESCRIPTION
Changes includes:
- Support of pxe-less discovery along with pxe-based
- New tests based on both pxe-less and pxe-based.
- User can attach an interface to existing discovered host and see that newly added nic in discovered host via `refresh_fact` feature.
- User can validate custom facts defined while pxe-based as well as pxe-less discovery

Note: For Pxe-less discovery we need to re-build the iso with extra kernel options, so those ISO are already built and placed on external libvirt server. 

Default ISO name: `foreman-discovery-image-3.0.5-3.iso`
Downstream ISOs:
- foreman-discovery-image-3.0.5-3_unattended_down_el7.iso
- foreman-discovery-image-3.0.5-3_unattended_down_el6.iso
- foreman-discovery-image-3.0.5-3_unattended_iso_el6.iso
- foreman-discovery-image-3.0.5-3_unattended_iso_el7.iso

We are here just using iso names via `config/settings.py`.