### PR TITLE
Make stubbed decorator mark tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ FOREMAN_SMOKE_TESTS_PATH=$(join $(FOREMAN_TESTS_PATH), smoke)
 FOREMAN_TESTS_PATH=tests/foreman/
 FOREMAN_UI_TESTS_PATH=$(join $(FOREMAN_TESTS_PATH), ui)
 PYTEST=python -m cProfile -o $@.pstats $$(which py.test)
-PYTEST_OPTS=-v --junit-xml=foreman-results.xml
+PYTEST_OPTS=-v --junit-xml=foreman-results.xml -m 'not stubbed'
 PYTEST_XDIST_OPTS=$(PYTEST_OPTS) -n auto --boxed
 ROBOTTELO_TESTS_PATH=tests/robottelo/
 

--- a/robottelo/decorators.py
+++ b/robottelo/decorators.py
@@ -121,11 +121,19 @@ def skip_if_not_set(*options):
 
 def stubbed(reason=None):
     """Skips test due to non-implentation or some other reason."""
-
     # Assume 'not implemented' if no reason is given
     if reason is None:
         reason = NOT_IMPLEMENTED
-    return unittest2.skip(reason)
+
+    def wrapper(func):
+        # Replicate the same behaviour as doing:
+        #
+        # @unittest2.skip(reason)
+        # @pytest.mark.stubbed
+        # def func(...):
+        #     ...
+        return unittest2.skip(reason)(pytest.mark.stubbed(func))
+    return wrapper
 
 
 def cacheable(func):


### PR DESCRIPTION
Stubbed decorator will mark tests using `pytest.mark.subbed` in order to
allow deselect stubbed tests when running with py.test.

Other runners will report them as skipped still.