### PR TITLE
Update DEFAULT_SUBSCRIPTION_NAME constant

### DIFF
--- a/robottelo/constants.py
+++ b/robottelo/constants.py
@@ -255,7 +255,8 @@ DEFAULT_ORG = "Default Organization"
 #: Name (not label!) of the default location.
 DEFAULT_LOC = "Default Location"
 DEFAULT_CV = "Default Organization View"
-DEFAULT_SUBSCRIPTION_NAME = 'Employee SKU'
+DEFAULT_SUBSCRIPTION_NAME = (
+    'Red Hat Enterprise Linux Server Entry Level, Self-support')
 
 LANGUAGES = ["en", "en_GB",
              "fr", "gl",

--- a/tests/foreman/cli/test_subscription.py
+++ b/tests/foreman/cli/test_subscription.py
@@ -5,6 +5,7 @@ from robottelo.cli.factory import make_org
 from robottelo.cli.repository import Repository
 from robottelo.cli.repository_set import RepositorySet
 from robottelo.cli.subscription import Subscription
+from robottelo.constants import PRDS, REPOS, REPOSET
 from robottelo.decorators import skip_if_bug_open, tier1, tier2
 from robottelo.ssh import upload_file
 from robottelo.test import CLITestCase
@@ -84,22 +85,15 @@ class SubscriptionTestCase(CLITestCase):
         )
         RepositorySet.enable({
             'basearch': 'x86_64',
-            'name': (
-                'Red Hat Enterprise Virtualization Agents '
-                'for RHEL 6 Workstation (RPMs)'
-            ),
+            'name': REPOSET['rhva6'],
             'organization-id': self.org['id'],
-            'product': 'Red Hat Enterprise Linux Workstation',
-            'releasever': '6Workstation',
+            'product': PRDS['rhel'],
+            'releasever': '6Server',
         })
         Repository.synchronize({
-            'name': (
-                'Red Hat Enterprise Virtualization Agents '
-                'for RHEL 6 Workstation '
-                'RPMs x86_64 6Workstation'
-            ),
+            'name': REPOS['rhva6']['name'],
             'organization-id': self.org['id'],
-            'product': 'Red Hat Enterprise Linux Workstation',
+            'product': PRDS['rhel'],
         })
 
     @tier1

--- a/tests/foreman/smoke/test_cli_smoke.py
+++ b/tests/foreman/smoke/test_cli_smoke.py
@@ -474,12 +474,14 @@ class SmokeTestCase(CLITestCase):
             {u'organization-id': new_org['id']},
             per_page=False
         )
+        self.assertGreater(len(result), 0)
         # Get the subscription ID from subscriptions list
+        subscription_quantity = 0
         for subscription in result:
             if subscription['name'] == DEFAULT_SUBSCRIPTION_NAME:
                 subscription_id = subscription['id']
                 subscription_quantity = int(subscription['quantity'])
-        self.assertGreater(int(subscription_quantity), 0)
+        self.assertGreater(subscription_quantity, 0)
         # Add the subscriptions to activation-key
         ActivationKey.add_subscription({
             u'id': activation_key['id'],


### PR DESCRIPTION
Also use the products, repository sets and repositories constants when
enabling/syncing RH repositories. This will ensure valid ones and will
make it easy to update.