### PR TITLE
increasing the wait time for unregister test

### DIFF
--- a/tests/foreman/rhai/test_rhai.py
+++ b/tests/foreman/rhai/test_rhai.py
@@ -135,10 +135,11 @@ class RHAITestCase(UITestCase):
                     locators['insights.unregister_button']
                 )
                 self.browser.refresh()
-                time.sleep(30)
+                time.sleep(60)
+                self.browser.refresh()
 
             result = vm.run('redhat-access-insights')
             self.assertEqual(result.return_code, 1,
                              "System has not been unregistered")
-            vm.get('/var/log/redhat-access-insights/'
-                   'redhat-access-insights.log', './insights_unregister.log')
+            vm.get('/var/log/redhat-access-insights/redhat-access'
+                   '-insights.log', './insights_unregister.log')

--- a/tests/foreman/rhai/test_rhai_client.py
+++ b/tests/foreman/rhai/test_rhai_client.py
@@ -69,4 +69,5 @@ class RHAIClientTestCase(TestCase):
                 'redhat-access-insights --test-connection')
             self.logger.info('Return code for --test-connection {0}'.format(
                 test_connection.return_code))
-            self.assertEqual(test_connection.return_code, 0)
+            self.assertEqual(test_connection.return_code, 0,
+                             '--test-connection check was not successful')


### PR DESCRIPTION
I have increased the wait time for the unregister test to 60 sec as we discovered that the tests were faster on Jenkins than run locally and there was a timing error. A particular test passes when run locally but it fails on Jenkins, so I think adding a 60 sec wait time should be okay.