### PR TITLE
blocking tests to add puppet_module to cv with bz decorator

### DIFF
--- a/tests/foreman/api/test_contentview.py
+++ b/tests/foreman/api/test_contentview.py
@@ -18,6 +18,7 @@ from robottelo.datafactory import invalid_names_list, valid_data_list
 from robottelo.decorators import (
     bz_bug_is_open,
     run_only_on,
+    skip_if_bug_open,
     skip_if_not_set,
     stubbed,
     tier1,
@@ -147,6 +148,7 @@ class ContentViewTestCase(APITestCase):
         self.assertEqual(len(content_view.repository), 1)
         self.assertEqual(content_view.repository[0].read().name, yum_repo.name)
 
+    @skip_if_bug_open('bugzilla', 1297308)
     @tier2
     @run_only_on('sat')
     def test_negative_add_puppet_content(self):

--- a/tests/foreman/smoke/test_ui_smoke.py
+++ b/tests/foreman/smoke/test_ui_smoke.py
@@ -199,8 +199,10 @@ class SmokeTestCase(UITestCase):
                     common_locators['alert.success']
                 ))
             # Add puppet-module to content-view
-            self.content_views.add_puppet_module(
-                cv_name, 'httpd', filter_term='Latest')
+            if not bz_bug_is_open(1297308):
+                self.content_views.add_puppet_module(
+                    cv_name, 'httpd', filter_term='Latest'
+                )
 
             # Publish content-view
             self.content_views.publish(cv_name)

--- a/tests/foreman/ui/test_contentview.py
+++ b/tests/foreman/ui/test_contentview.py
@@ -173,6 +173,7 @@ class ContentViewTestCase(UITestCase):
             self.assertIsNotNone(self.content_views.wait_until_element
                                  (common_locators['alert.success']))
 
+    @skip_if_bug_open('bugzilla', 1297308)
     @run_only_on('sat')
     @tier2
     def test_positive_add_puppet_module(self):
@@ -467,6 +468,7 @@ class ContentViewTestCase(UITestCase):
                     )
                     self.content_views.delete(name)
 
+    @skip_if_bug_open('bugzilla', 1297308)
     @run_only_on('sat')
     @skip_if_not_set('fake_manifest')
     @tier3
@@ -611,6 +613,7 @@ class ContentViewTestCase(UITestCase):
             self.assertIsNotNone(self.content_views.wait_until_element(
                 common_locators['alert.success']))
 
+    @skip_if_bug_open('bugzilla', 1297308)
     @run_only_on('sat')
     @tier2
     def test_negative_add_puppet_repo_to_composite(self):


### PR DESCRIPTION
Affecting bz: https://bugzilla.redhat.com/show_bug.cgi?id=1297308