### PR TITLE
Include tier targets on Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,11 +6,13 @@ FOREMAN_LONGRUN_TESTS_PATH=$(join $(FOREMAN_TESTS_PATH), longrun)
 FOREMAN_RHAI_TESTS_PATH=$(join $(FOREMAN_TESTS_PATH), rhai)
 FOREMAN_RHCI_TESTS_PATH=$(join $(FOREMAN_TESTS_PATH), rhci)
 FOREMAN_SMOKE_TESTS_PATH=$(join $(FOREMAN_TESTS_PATH), smoke)
+FOREMAN_TIERS_TESTS_PATH=$(join $(FOREMAN_TESTS_PATH), {api,cli,ui})
 FOREMAN_TESTS_PATH=tests/foreman/
 FOREMAN_UI_TESTS_PATH=$(join $(FOREMAN_TESTS_PATH), ui)
 PYTEST=python -m cProfile -o $@.pstats $$(which py.test)
 PYTEST_OPTS=-v --junit-xml=foreman-results.xml -m 'not stubbed'
-PYTEST_XDIST_OPTS=$(PYTEST_OPTS) -n auto --boxed
+PYTEST_XDIST_NUMPROCESSES=auto
+PYTEST_XDIST_OPTS=$(PYTEST_OPTS) -n $(PYTEST_XDIST_NUMPROCESSES) --boxed
 ROBOTTELO_TESTS_PATH=tests/robottelo/
 
 # Commands --------------------------------------------------------------------
@@ -23,6 +25,9 @@ help:
 	@echo "  test-robottelo             to run internal robottelo tests"
 	@echo "  test-robottelo-coverage    to run internal robottelo tests with coverage report."
 	@echo "                             Requires pytest-cov"
+	@echo "  test-foreman-tier1         to run Foreman deployment tier1 tests"
+	@echo "  test-foreman-tier2         to run Foreman deployment tier2 tests"
+	@echo "  test-foreman-tier3         to run Foreman deployment tier3 tests"
 	@echo "  test-foreman-api           to test a Foreman deployment API"
 	@echo "  test-foreman-api-threaded  to do the above with threading."
 	@echo "                             Requires pytest-xdist"
@@ -86,6 +91,15 @@ test-foreman-ui-xvfb:
 test-foreman-smoke:
 	$(PYTEST) $(PYTEST_OPTS) $(FOREMAN_SMOKE_TESTS_PATH)
 
+test-foreman-tier1:
+	$(PYTEST) $(PYTEST_XDIST_OPTS) -m 'not stubbed and tier1' $(FOREMAN_TIERS_TESTS_PATH)
+
+test-foreman-tier2:
+	$(PYTEST) $(PYTEST_XDIST_OPTS) -m 'not stubbed and tier2' $(FOREMAN_TIERS_TESTS_PATH)
+
+test-foreman-tier3:
+	$(PYTEST) $(PYTEST_XDIST_OPTS) -m 'not stubbed and tier3' $(FOREMAN_TIERS_TESTS_PATH)
+
 graph-entities:
 	scripts/graph_entities.py | dot -Tsvg -o entities.svg
 
@@ -96,5 +110,6 @@ lint:
 
 .PHONY: help docs docs-clean test-docstrings test-robottelo \
         test-robottelo-coverage test-foreman-api test-foreman-cli \
-        test-foreman-rhai test-foreman-rhci test-foreman-ui  \
+        test-foreman-rhai test-foreman-rhci test-foreman-tier1 \
+        test-foreman-tier2 test-foreman-tier3 test-foreman-ui \
         test-foreman-ui-xvfb test-foreman-smoke graph-entities lint


### PR DESCRIPTION
Add targets to run tier based tests. Tier targets will be for default
running in multiprocess mode.

To control the number of process to run the variable
`PYTEST_XDIST_NUMPROCESSES` can be specified when running make, the
default value is `auto` which will use the number of cores available on
the machine where the tests are being run.

The below example shows how to define the number of process to 4:

    make test-foreman-tier1 PYTEST_XDIST_NUMPROCESSES=4