### PR TITLE
Fixing issue with syncplan and remove redundant code

### DIFF
--- a/robottelo/ui/base.py
+++ b/robottelo/ui/base.py
@@ -471,19 +471,6 @@ class Base(object):
             (strategy, value % context)).is_selected()
         return selected
 
-    def submit_and_validate(self, locator, validation=True):
-        """
-        Submit the page and validate.
-
-        :param str locator: The locator used to submit the page.
-        :param bool validation: Helps enable or disable validation. Needs to be
-            set to False for the negative tests.
-
-        """
-        self.click(locator)
-        if self.wait_until_element(locator) and validation:
-            raise UIPageSubmitionFailed('Page submission failed.')
-
     def is_element_enabled(self, locator):
         """Check whether UI element is enabled or disabled
 

--- a/robottelo/ui/syncplan.py
+++ b/robottelo/ui/syncplan.py
@@ -29,8 +29,7 @@ class Syncplan(Base):
         self.click(select_locator)
 
     def create(self, name, description=None, startdate=None,
-               sync_interval=None, start_hour=None,
-               start_minute=None, submit_validate=True):
+               sync_interval=None, start_hour=None, start_minute=None,):
         """Creates new Sync Plans from UI."""
         self.click(locators['sp.new'])
         self.text_field_update(common_locators['name'], name)
@@ -46,8 +45,8 @@ class Syncplan(Base):
         if startdate:
             self.text_field_update(locators['sp.start_date'], startdate)
             self.wait_for_ajax()
-        self.submit_and_validate(
-            common_locators['create'], validation=submit_validate)
+        self.click(common_locators['name'])
+        self.click(common_locators['create'])
 
     def update(self, name, new_name=None, new_desc=None,
                new_sync_interval=None, add_products=None,

--- a/tests/foreman/ui/test_syncplan.py
+++ b/tests/foreman/ui/test_syncplan.py
@@ -173,7 +173,6 @@ class SyncPlanTestCase(UITestCase):
                         org=self.organization.name,
                         name=name,
                         description='invalid name',
-                        submit_validate=False,
                     )
                     self.assertIsNotNone(self.syncplan.wait_until_element(
                         common_locators['common_invalid']))
@@ -195,7 +194,6 @@ class SyncPlanTestCase(UITestCase):
                 org=self.organization.name,
                 name=name,
                 description='with same name',
-                submit_validate=False,
             )
             self.assertIsNotNone(self.syncplan.wait_until_element(
                 common_locators['common_invalid']))


### PR DESCRIPTION
That code change should resolve failure which is triggered on CI for `ui.test_syncplan.SyncPlanTestCase.test_positive_create_with_start_date` test.

Also, we have method that actually do nothing in terms of validation as we always verify whether corresponding plan is created or corresponding error message is displayed. We should not care about verifying whether submit button was really clicked or not. Of course, that code can help in debug procedure, but value of such help is doubtful. I decided to remove that code as it is not only redundant, but as it is also introduce performance degradation.

Before:
```
nosetests tests/foreman/ui/test_syncplan.py
............
----------------------------------------------------------------------
Ran 12 tests in 1380.247s

OK
```
After:
```
nosetests tests/foreman/ui/test_syncplan.py
............
----------------------------------------------------------------------
Ran 12 tests in 1045.185s

OK
```