### PR TITLE
Fix some flake8 warnings

### DIFF
--- a/robottelo/ui/login.py
+++ b/robottelo/ui/login.py
@@ -55,6 +55,6 @@ class Login(Base):
         )
         response.raise_for_status()
         return (
-            response.status_code != 302
-            or not response.headers['location'].endswith('/login')
+            response.status_code != 302 or
+            not response.headers['location'].endswith('/login')
         )

--- a/tests/foreman/api/test_operatingsystem.py
+++ b/tests/foreman/api/test_operatingsystem.py
@@ -30,8 +30,9 @@ class OperatingSystemParameterTestCase(APITestCase):
         @Assert: A parameter is created and can be read afterwards.
         """
         # Check whether OS 1 exists.
-        if (entities.OperatingSystem(id=1).read_raw().status_code == NOT_FOUND
-                and entities.OperatingSystem().create().id != 1):
+        os1 = entities.OperatingSystem(id=1).read_raw()
+        if (os1.status_code == NOT_FOUND and
+                entities.OperatingSystem().create().id != 1):
             self.skipTest(
                 'Cannot execute test, as operating system 1 is not available.'
             )

--- a/tests/robottelo/test_helpers.py
+++ b/tests/robottelo/test_helpers.py
@@ -2,18 +2,17 @@
 # (Too many public methods) pylint: disable=R0904
 import six
 import unittest2
-
-if six.PY2:
-    import mock
-else:
-    from unittest import mock
-
 from robottelo.helpers import (
     HostInfoError,
     escape_search,
     get_host_info,
     get_server_version,
 )
+
+if six.PY2:
+    import mock
+else:
+    from unittest import mock
 
 
 class GetServerVersionTestCase(unittest2.TestCase):

--- a/tests/robottelo/test_vm.py
+++ b/tests/robottelo/test_vm.py
@@ -1,14 +1,13 @@
 """Tests for :mod:`robottelo.vm`."""
 import six
 import unittest2
+from robottelo import ssh
+from robottelo.vm import VirtualMachine, VirtualMachineError
 
 if six.PY2:
     from mock import call, patch
 else:
     from unittest.mock import call, patch
-
-from robottelo import ssh
-from robottelo.vm import VirtualMachine, VirtualMachineError
 
 
 class VirtualMachineTestCase(unittest2.TestCase):


### PR DESCRIPTION
recently flake8 updated from 2.5.0 to 2.5.1 and it started failing travis checks with following errors:
```
./robottelo/ui/login.py:59:13: W503 line break before binary operator
./tests/foreman/api/test_operatingsystem.py:34:17: W503 line break before binary operator
./tests/robottelo/test_helpers.py:11:1: E402 module level import not at top of file
./tests/robottelo/test_vm.py:10:1: E402 module level import not at top of file
./tests/robottelo/test_vm.py:11:1: E402 module level import not at top of file
```
PR fixes these warnings to make flake8 happy again :)