### PR TITLE
Updated factory method for `make_syncplan`.

### DIFF
--- a/robottelo/ui/factory.py
+++ b/robottelo/ui/factory.py
@@ -606,7 +606,6 @@ def make_syncplan(session, org=None, loc=None,  force_context=True, **kwargs):
         u'sync_interval': None,
         u'start_hour': None,
         u'start_minute': None,
-        u'submit_validate': True,
     }
     page = session.nav.go_to_sync_plans
     core_factory(create_args, kwargs, session, page,


### PR DESCRIPTION
Current automation results show several issues with Sync Plan tests for the UI. The
Pull Request #3223 updated the `create` method for the `SyncPlan` class and removed
the `submit_validate` but the factory method was not updated.