### PR TITLE
Fixes `UnicodeEncodeError` which masks the real error for UI tests.

### DIFF
--- a/robottelo/ui/operatingsys.py
+++ b/robottelo/ui/operatingsys.py
@@ -98,10 +98,10 @@ class OperatingSys(Base):
                 )
                 self.click(common_locators['submit'])
             else:
-                raise UIError('Could not create OS without major_version')
+                raise UIError(u'Could not create OS without major_version')
         else:
             raise UIError(
-                'Could not create new operating system "{0}"'.format(name)
+                u'Could not create new operating system "{0}"'.format(name)
             )
 
     def delete(self, os_name, really=True):
@@ -147,7 +147,7 @@ class OperatingSys(Base):
             self.click(common_locators['submit'])
         else:
             raise UIError(
-                'Could not update the operating system "{0}"'.format(os_name)
+                u'Could not update the operating system "{0}"'.format(os_name)
             )
 
     def set_os_parameter(self, os_name, param_name, param_value):
@@ -157,7 +157,7 @@ class OperatingSys(Base):
             element.click()
             self.set_parameter(param_name, param_value)
         else:
-            raise UIError('Could not set parameter "{0}"'.format(param_name))
+            raise UIError(u'Could not set parameter "{0}"'.format(param_name))
 
     def remove_os_parameter(self, os_name, param_name):
         """Remove selected OS parameter."""
@@ -167,7 +167,7 @@ class OperatingSys(Base):
             self.remove_parameter(param_name)
         else:
             raise UIError(
-                'Could not remove parameter "{0}"'.format(param_name)
+                u'Could not remove parameter "{0}"'.format(param_name)
             )
 
     def get_selected_entities(self):
@@ -229,9 +229,9 @@ class OperatingSys(Base):
                 return result
             else:
                 raise UIError(
-                    'Could not find the OS name "{0}"'.format(os_name)
+                    u'Could not find the OS name "{0}"'.format(os_name)
                 )
         else:
             raise UIError(
-                'Could not find the operating system "{0}"'.format(os_name)
+                u'Could not find the operating system "{0}"'.format(os_name)
             )


### PR DESCRIPTION
Recent automation for Operating Systems via the UI have shown the following error:

    UnicodeEncodeError: 'ascii' codec can't encode characters in position
    0-29: ordinal not in range(128)

At a first glance, this may seem to be the real issue, but the real problem is that
we're forcing utf-8 string and non-utf-8 'together'. The real culprit is this:

    TimeoutException: Timed out waiting for element
    '//a[contains(., '𢲖𣂡䱅킳쩪𣉗瀧덙䘡𣦤𫉛馰肏𦚮𦡭𑂈𩉑鹐脵𩸜𢵗ﴌ𠂩𠟟𧥪𪡼𩉚鸆𥗙㢛')]'
    to display.

Since the exception being raised tries to display the name of the entity that could
not be found, '𢲖𣂡䱅킳쩪𣉗瀧덙䘡𣦤𫉛馰肏𦚮𦡭𑂈𩉑鹐脵𩸜𢵗ﴌ𠂩𠟟𧥪𪡼𩉚鸆𥗙㢛', we end
up with a unicode error, masking the real culprit.