### PR TITLE
Implement CLI content host stubs

### DIFF
--- a/robottelo/vm.py
+++ b/robottelo/vm.py
@@ -230,12 +230,15 @@ class VirtualMachine(object):
             raise VirtualMachineError(
                 'Failed to download and install the katello-ca rpm')
 
-    def register_contenthost(self, activation_key, org, releasever=None):
+    def register_contenthost(self, activation_key, org, force=True,
+                             releasever=None):
         """Registers content host on foreman server using activation-key.
 
         :param activation_key: Activation key name to register content host
             with.
         :param org: Organization name to register content host for.
+        :param force: Register the content host even if it's already registered
+        :param releasever: Set a release version
         :return: SSHCommandResult instance filled with the result of the
             registration.
 
@@ -246,7 +249,8 @@ class VirtualMachine(object):
         )
         if releasever is not None:
             cmd += u' --release {0}'.format(releasever)
-        cmd = cmd + u' --force'
+        if force:
+            cmd += u' --force'
         result = self.run(cmd)
         if result.return_code == 0:
             self._subscribed = True


### PR DESCRIPTION
```python
py.test -v tests/foreman/cli/test_contenthost.py -k 'test_positive_register_with_no_ak or test_negative_register_twice or test_positive_list or test_positive_unregister or test_negative_unregister_and_pull_content'
================================ test session starts =================================
platform linux2 -- Python 2.7.10, pytest-2.8.2, py-1.4.30, pluggy-0.3.1 -- /home/andrii/env/bin/python
cachedir: .cache
rootdir: /home/andrii/workspace/robottelo, inifile: 
plugins: xdist-1.13.1
collected 27 items 

tests/foreman/cli/test_contenthost.py::ContentHostTestCase::test_negative_register_twice PASSED
tests/foreman/cli/test_contenthost.py::ContentHostTestCase::test_positive_list PASSED
tests/foreman/cli/test_contenthost.py::ContentHostTestCase::test_positive_register_with_no_ak PASSED
tests/foreman/cli/test_contenthost.py::ContentHostTestCase::test_positive_unregister PASSED
tests/foreman/cli/test_contenthost.py::KatelloAgentTestCase::test_negative_unregister_and_pull_content PASSED

 22 tests deselected by '-ktest_positive_register_with_no_ak or test_negative_register_twice or test_positive_list or test_positive_unregister or test_negative_unregister_and_pull_content' 
===================== 5 passed, 22 deselected in 867.77 seconds ======================
```