### PR TITLE
Locking selenium version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ setup(
         'pytest',
         'python-bugzilla',
         'requests',
-        'selenium',
+        'selenium<2.49',
         'six',
         'unittest2',
     ],


### PR DESCRIPTION
It is necessary to stay with selenium 2.48 as with 2.49 we are introducing unnecessary regression into our code.

Example of the error:
```
self = <json.decoder.JSONDecoder object at 0x14f9090>
s = 'Element is not clickable at point (1047.1666870117188, 288.3999938964844). Other element would receive the click: <a tabindex="-1" class="ui-corner-all" id="ui-id-3"></a>'
idx = 0

    def raw_decode(self, s, idx=0):
        """Decode a JSON document from ``s`` (a ``str`` or ``unicode``
            beginning with a JSON document) and return a 2-tuple of the Python
            representation and the index in ``s`` where the document ended.
    
            This can be used to decode a JSON document from a string that may
            have extraneous data at the end.
    
            """
        try:
            obj, end = self.scan_once(s, idx)
        except StopIteration:
>           raise ValueError("No JSON object could be decoded")
E           ValueError: No JSON object could be decoded

/usr/lib64/python2.7/json/decoder.py:383: ValueError
```