### PR TITLE
Added `skip_if_not_set` decorator for CLI Docker tests.

### DIFF
--- a/tests/foreman/cli/test_docker.py
+++ b/tests/foreman/cli/test_docker.py
@@ -26,6 +26,7 @@ from robottelo.datafactory import valid_data_list
 from robottelo.decorators import (
     run_only_on,
     skip_if_bug_open,
+    skip_if_not_set,
     stubbed,
     tier1,
     tier2,
@@ -1135,6 +1136,7 @@ class DockerComputeResourceTestCase(CLITestCase):
     """Tests specific to managing Docker-based Compute Resources."""
 
     @classmethod
+    @skip_if_not_set('docker')
     def setUpClass(cls):
         """Create an organization and product which can be re-used in tests."""
         super(DockerComputeResourceTestCase, cls).setUpClass()
@@ -1284,6 +1286,7 @@ class DockerContainersTestCase(CLITestCase):
     """
 
     @classmethod
+    @skip_if_not_set('docker')
     def setUpClass(cls):
         """Create an organization and product which can be re-used in tests."""
         super(DockerContainersTestCase, cls).setUpClass()


### PR DESCRIPTION
Make sure that Docker tests for CLI are skipped if properties file is not properly
configured to support Docker Compute Resources. The same already exists for API and
UI.