### PR TITLE
Add DockerBrowser

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -165,25 +165,22 @@ module::
 
     $ nosetests -m test_positive_create_1 tests.foreman.cli.test_org
 
-Running UI Tests On a Headless Server
--------------------------------------
+Running UI Tests On a Docker Browser
+------------------------------------
 
-It is possible to run UI tests on a headless server. To do this:
+It is possible to run UI tests within a docker container. To do this:
 
-* Install Xvfb. It is provided by the ``xorg-x11-server-Xvfb`` package on
-  Fedora and Red Hat.
-* Install the ``PyVirtualDisplay`` Python package. (It is listed in
-  ``requirements-optional.txt``.)
-* Set ``virtual_display=1`` in the configuration file ``robottelo.properties``.
-* Optionally, set the ``window_manager_command`` option in the configuration
-  file. This option should be set to the name of a window manager executable.
-  For example, ``fluxbox`` or ``openbox`` are suitable values if you have
-  Fluxbox or Openbox installed, respectively. Setting this option causes a
-  window manager to be launched before the web browser, thus allowing the web
-  browser to be maximized.
+* Install docker. It is provided by the ``docker`` package on Fedora and Red
+  Hat. Be aware that the package may call ``docker-io`` on old OS releases.
+* Make sure that docker is up and running and the user that will run robottelo
+  has permission to run docker commands. For more information check the docker
+  installation guide https://docs.docker.com/engine/installation/.
+* Pull the ``selenium/standalone-firefox`` image
+* Set ``docker_browser=true`` at the ``[robottelo]`` section in the configuration file ``robottelo.properties``.
 
-This done, UI tests no longer launch a visible web browser. Instead, UI tests
-launch a web browser within a virtual display.
+Once you've performed these steps, UI tests will no longer launch a web browser
+on your system. Instead, UI tests launch a web browser within a docker
+container.
 
 Miscellany
 ==========

--- a/requirements-optional.txt
+++ b/requirements-optional.txt
@@ -13,6 +13,5 @@ pylint
 # For generating documentation.
 sphinx
 
-# For running UI tests in a headless mode
-# PyVirtualDisplay requires xvfb
-PyVirtualDisplay
+# For running UI tests within a docker browser
+docker-py

--- a/robottelo.properties.sample
+++ b/robottelo.properties.sample
@@ -47,13 +47,12 @@ ssh_key=
 # Run one datapoint or multiple datapoints for tests
 # run_one_datapoint=false
 
-# Virtual display controls if PyVirtualDisplay should be used to run UI tests
-# when setting it to true then make sure to install required dependencies
-# virtual_display=false
-
-# If virtual_display=true and window_manager_command is set, the window manager
-# command will be run before opening any browser window
-# window_manager_command=
+# docker_browser tells robottelo to use a browser inside a docker
+# container. In order to use this feature make sure that the docker
+# daemon is running locally and has its unix socket published at
+# unix://var/run/docker.sock. Also make sure that the docker image
+# selenium/standalone-firefox is available.
+# docker_browser=false
 
 # Provide link to rhel6/7 repo here, as puppet rpm would require packages from
 # RHEL 6/7 repo and syncing the entire repo on the fly would take longer for

--- a/robottelo/config/settings.py
+++ b/robottelo/config/settings.py
@@ -524,6 +524,7 @@ class Settings(object):
         self._all_features = None
         self._configured = False
         self._validation_errors = []
+        self.docker_browser = None
         self.locale = None
         self.project = None
         self.reader = None
@@ -534,10 +535,8 @@ class Settings(object):
         self.run_one_datapoint = None
         self.upstream = None
         self.verbosity = None
-        self.virtual_display = None
         self.webdriver = None
         self.webdriver_binary = None
-        self.window_manager_command = None
 
         # Features
         self.clients = ClientsSettings()
@@ -621,6 +620,8 @@ class Settings(object):
 
     def _read_robottelo_settings(self):
         """Read Robottelo's general settings."""
+        self.docker_browser = self.reader.get(
+            'robottelo', 'docker_browser', False, bool)
         self.locale = self.reader.get('robottelo', 'locale', 'en_US.UTF-8')
         self.project = self.reader.get('robottelo', 'project', 'sat')
         self.rhel6_repo = self.reader.get('robottelo', 'rhel6_repo', None)
@@ -636,8 +637,6 @@ class Settings(object):
             INIReader.cast_logging_level('debug'),
             INIReader.cast_logging_level
         )
-        self.virtual_display = self.reader.get(
-            'robottelo', 'virtual_display', False, bool)
         self.webdriver = self.reader.get(
             'robottelo', 'webdriver', 'firefox')
         self.webdriver_binary = self.reader.get(
@@ -648,16 +647,11 @@ class Settings(object):
     def _validate_robottelo_settings(self):
         """Validate Robottelo's general settings."""
         validation_errors = []
-        if self.virtual_display and not self.window_manager_command:
-            validation_errors.append(
-                '[robottelo] virtual_display is enabled, '
-                'window_manager_command must be provided.'
-            )
         webdrivers = ('chrome', 'firefox', 'ie', 'phantomjs', 'remote')
         if self.webdriver not in webdrivers:
             raise ImproperlyConfigured(
                 '[robottelo] webdriver should be one of {0}.'
-                .format(', '.join(webdrivers.keys()))
+                .format(', '.join(webdrivers))
             )
         return validation_errors
 
@@ -760,7 +754,6 @@ class Settings(object):
             'bugzilla',
             'easyprocess',
             'paramiko',
-            'pyvirtualdisplay',
             'requests.packages.urllib3.connectionpool',
             'selenium.webdriver.remote.remote_connection',
         )

--- a/robottelo/ui/browser.py
+++ b/robottelo/ui/browser.py
@@ -1,5 +1,19 @@
+"""Tools to help getting a browser instance to run UI tests."""
+import six
+import time
+
 from robottelo.config import settings
 from selenium import webdriver
+
+try:
+    import docker
+except ImportError:
+    # Let if fail later if not installed
+    docker = None
+
+
+class DockerBrowserError(Exception):
+    """Indicates any issue with DockerBrowser."""
 
 
 def browser():
@@ -24,3 +38,136 @@ def browser():
         return webdriver.PhantomJS(service_args=['--ignore-ssl-errors=true'])
     elif webdriver_name == 'remote':
         return webdriver.Remote()
+
+
+class DockerBrowser(object):
+    """Provide a browser instance running inside a docker container."""
+    def __init__(self):
+        if docker is None:
+            raise DockerBrowserError(
+                'Package docker-py is not installed. Install it in order to '
+                'use DockerBrowser.'
+            )
+        self.webdriver = None
+        self.container = None
+        self._client = None
+        self._started = False
+
+    def start(self):
+        """Start all machinery needed to run a browser inside a docker
+        container.
+        """
+        if self._started:
+            return
+        self._init_client()
+        self._create_container()
+        self._init_webdriver()
+        self._started = True
+
+    def stop(self):
+        self._quit_webdriver()
+        self._remove_container()
+        self._close_client()
+        self.webdriver = None
+        self.container = None
+        self._client = None
+        self._started = False
+
+    def _init_webdriver(self):
+        """Init the selenium Remote webdriver."""
+        if self.webdriver or not self.container:
+            return
+        exception = None
+        # An exception can be raised while the container is not ready
+        # yet. Give up to 10 seconds for a container being ready.
+        for attempt in range(20):
+            try:
+                self.webdriver = webdriver.Remote(
+                    command_executor='http://127.0.0.1:{0}/wd/hub'.format(
+                        self.container['HostPort']),
+                    desired_capabilities=webdriver.DesiredCapabilities.FIREFOX
+                )
+            except Exception as err:
+                # Capture the raised exception for later usage and wait
+                # a few for the next attempt.
+                exception = err
+                time.sleep(.5)
+            else:
+                # Connection succeeded time to leave the for loop
+                break
+        else:
+            # Reraise the captured exception.
+            # For more info about raise from syntax:
+            # https://docs.python.org/3/reference/simple_stmts.html#grammar-token-raise_stmt
+            six.raise_from(
+                DockerBrowserError(
+                    'Failed to connect the webdriver to the containerized '
+                    'selenium.'
+                ),
+                exception
+            )
+
+    def _quit_webdriver(self):
+        """Quit the selenium Remote webdriver."""
+        if not self.webdriver:
+            return
+        self.webdriver.quit()
+
+    def _init_client(self):
+        """Init docker Client.
+
+        Make sure that docker service to be published under the
+        unix://var/run/docker.sock unix socket.
+
+        Use auto for version in order to allow docker client to
+        automatically figure out the server version.
+        """
+        if self._client:
+            return
+        self._client = docker.Client(
+            base_url='unix://var/run/docker.sock', version='auto')
+
+    def _close_client(self):
+        """Close docker Client."""
+        if not self._client:
+            return
+        self._client.close()
+
+    def _create_container(self):
+        """Create a docker container running a standalone-firefox
+        selenium.
+
+        Make sure to have the image selenium/standalone-firefox already
+        pulled.
+        """
+        if self.container:
+            return
+        self.container = self._client.create_container(
+            detach=True,
+            environment={
+                'SCREEN_WIDTH': '1920',
+                'SCREEN_HEIGHT': '1080',
+            },
+            host_config=self._client.create_host_config(
+                publish_all_ports=True),
+            image='selenium/standalone-firefox',
+            ports=[4444],
+        )
+        self._client.start(self.container['Id'])
+        self.container.update(
+            self._client.port(self.container['Id'], 4444)[0])
+
+    def _remove_container(self):
+        """Turn off and clean up container from system."""
+        if not self.container:
+            return
+        self._client.stop(self.container['Id'])
+        self._client.wait(self.container['Id'])
+        self._client.remove_container(self.container['Id'])
+
+    def __enter__(self):
+        self.start()
+        return self
+
+    def __exit__(self, *exc):
+        self.stop()


### PR DESCRIPTION
This class allows running UI tests withing a docker containers.

Update all related information about the old way to run UI tests without
opening browser windows. With that said, old machinery is dropped since
is far easier to run a container than spin up a window manager or even
manage Xvfb.