### PR TITLE
Removed import_scap_client_puppet_classes call and updated locator

### DIFF
--- a/robottelo/ui/locators.py
+++ b/robottelo/ui/locators.py
@@ -2144,8 +2144,7 @@ locators = LocatorDict({
         By.XPATH, "//input[contains(@data-url, 'auto_complete_search')]"),
     "oscap.content_edit": (
         By.XPATH,
-        ("//td[contains(.,'%s')]/../td/div/ul/li/"
-         "a[contains(@data-id, 'edit')]")),
+        ("//td[contains(.,'%s')]/../td/div/span/a")),
     "oscap.content_dropdown": (
         By.XPATH,
         ("//td[contains(.,'%s')]/following-sibling::td/div/"

--- a/tests/foreman/longrun/test_oscap.py
+++ b/tests/foreman/longrun/test_oscap.py
@@ -167,7 +167,6 @@ class OpenScapTestCase(UITestCase):
             },
         ]
         with Session(self.browser) as session:
-            self.puppetclasses.import_scap_client_puppet_classes()
             set_context(session, org=ANY_CONTEXT['org'])
             # Creates oscap content for both rhel6 and rhel7
             for content in [rhel6_content, rhel7_content]:


### PR DESCRIPTION
a) Updated the oscap.content_edit locator as it seemed changed.
b) Removed the call to import_scap_client_puppet_classes as it is
   redundant calling it.