### PR TITLE
Updated filename in doc reference

### DIFF
--- a/docs/api/tests.foreman.cli.rst
+++ b/docs/api/tests.foreman.cli.rst
@@ -48,10 +48,10 @@
 
 .. automodule:: tests.foreman.cli.test_contentview
 
-:mod:`tests.foreman.cli.test_discovery`
----------------------------------------
+:mod:`tests.foreman.cli.test_discoveredhost`
+--------------------------------------------
 
-.. automodule:: tests.foreman.cli.test_discovery
+.. automodule:: tests.foreman.cli.test_discoveredhost
 
 :mod:`tests.foreman.cli.test_docker`
 ------------------------------------


### PR DESCRIPTION
Travis failing in PR #3260. Looks like because we renamed the `cli/test_discovery.py` to `test_discoveredhost.py`