### PR TITLE
Force the removal of a running container for UI tests

### DIFF
--- a/robottelo/ui/browser.py
+++ b/robottelo/ui/browser.py
@@ -163,7 +163,7 @@ class DockerBrowser(object):
             return
         self._client.stop(self.container['Id'])
         self._client.wait(self.container['Id'])
-        self._client.remove_container(self.container['Id'])
+        self._client.remove_container(self.container['Id'], force=True)
 
     def __enter__(self):
         self.start()


### PR DESCRIPTION
Today automation started failing because of lack of free space. 
`docker ps -a | grep Exited | awk '{print $1 }'` showed there were 149 docker containers not deleted on our automation box for some reason.
As we use 1 container per each ui test, i assume `remove_container()` deletes containers in most cases (as we have 800+ ui tests), but sometimes it doesn't (for example, container was in use or stopped responding).
I'm suggesting using `remove_container()` with `force=True`, which is equal to `docker rm --force`, which uses SIGKILL to stop & remove container.
It may help or maybe not, but, imo, it worth a try.