### PR TITLE
API: Move repository set tests to a separate module

### DIFF
--- a/docs/api/tests.foreman.api.rst
+++ b/docs/api/tests.foreman.api.rst
@@ -138,6 +138,11 @@
 
 .. automodule:: tests.foreman.api.test_repository
 
+:mod:`tests.foreman.api.test_repository_set`
+--------------------------------------------
+
+.. automodule:: tests.foreman.api.test_repository_set
+
 :mod:`tests.foreman.api.test_rhsm`
 ----------------------------------
 

--- a/tests/foreman/api/test_product.py
+++ b/tests/foreman/api/test_product.py
@@ -8,9 +8,7 @@ http://theforeman.org/api/apidoc/v2/products.html
 from fauxfactory import gen_string
 from nailgun import entities
 from random import randint
-from robottelo import manifests
-from robottelo.api.utils import upload_manifest
-from robottelo.constants import PRDS, REPOSET, VALID_GPG_KEY_FILE
+from robottelo.constants import VALID_GPG_KEY_FILE
 from robottelo.datafactory import generate_strings_list
 from robottelo.decorators import run_only_on, tier1, tier2
 from robottelo.helpers import read_data_file
@@ -128,68 +126,3 @@ class ProductUpdateTestCase(APITestCase):
                     self.product.name,
                     self.product.update(['name']).name
                 )
-
-
-class RepositorySetTestCase(APITestCase):
-    """Tests for ``katello/api/v2/products/<product_id>/repository_sets``."""
-
-    @tier1
-    @run_only_on('sat')
-    def test_positive_reposet_enable(self):
-        """Enable repo from reposet
-
-        @Feature: Repository-set
-
-        @Assert: Repository was enabled
-        """
-        org = entities.Organization().create()
-        with manifests.clone() as manifest:
-            upload_manifest(org.id, manifest.content)
-        product = entities.Product(
-            name=PRDS['rhel'],
-            organization=org,
-        ).search()[0]
-        reposet = entities.RepositorySet(
-            name=REPOSET['rhva6'],
-            product=product,
-        ).search()[0]
-        reposet.enable(data={'basearch': 'x86_64', 'releasever': '6Server'})
-        repositories = reposet.available_repositories()['results']
-        self.assertTrue([
-            repo['enabled']
-            for repo
-            in repositories
-            if (repo['substitutions']['basearch'] == 'x86_64' and
-                repo['substitutions']['releasever'] == '6Server')
-        ][0])
-
-    @tier1
-    @run_only_on('sat')
-    def test_positive_reposet_disable(self):
-        """Disable repo from reposet
-
-        @Feature: Repository-set
-
-        @Assert: Repository was disabled
-        """
-        org = entities.Organization().create()
-        with manifests.clone() as manifest:
-            upload_manifest(org.id, manifest.content)
-        product = entities.Product(
-            name=PRDS['rhel'],
-            organization=org,
-        ).search()[0]
-        reposet = entities.RepositorySet(
-            name=REPOSET['rhva6'],
-            product=product,
-        ).search()[0]
-        reposet.enable(data={'basearch': 'x86_64', 'releasever': '6Server'})
-        reposet.disable(data={'basearch': 'x86_64', 'releasever': '6Server'})
-        repositories = reposet.available_repositories()['results']
-        self.assertFalse([
-            repo['enabled']
-            for repo
-            in repositories
-            if (repo['substitutions']['basearch'] == 'x86_64' and
-                repo['substitutions']['releasever'] == '6Server')
-        ][0])

--- a/tests/foreman/api/test_repository_set.py
+++ b/tests/foreman/api/test_repository_set.py
@@ -1,0 +1,78 @@
+# -*- encoding: utf-8 -*-
+"""Unit tests for the ``repository_sets`` paths.
+
+A full API reference for products can be found here:
+http://www.katello.org/docs/api/apidoc/repository_sets.html
+
+"""
+from nailgun import entities
+from robottelo import manifests
+from robottelo.api.utils import upload_manifest
+from robottelo.constants import PRDS, REPOSET
+from robottelo.decorators import run_only_on, tier1
+from robottelo.test import APITestCase
+
+
+class RepositorySetTestCase(APITestCase):
+    """Tests for ``katello/api/v2/products/<product_id>/repository_sets``."""
+
+    @tier1
+    @run_only_on('sat')
+    def test_positive_reposet_enable(self):
+        """Enable repo from reposet
+
+        @Feature: Repository-set
+
+        @Assert: Repository was enabled
+        """
+        org = entities.Organization().create()
+        with manifests.clone() as manifest:
+            upload_manifest(org.id, manifest.content)
+        product = entities.Product(
+            name=PRDS['rhel'],
+            organization=org,
+        ).search()[0]
+        reposet = entities.RepositorySet(
+            name=REPOSET['rhva6'],
+            product=product,
+        ).search()[0]
+        reposet.enable(data={'basearch': 'x86_64', 'releasever': '6Server'})
+        repositories = reposet.available_repositories()['results']
+        self.assertTrue([
+            repo['enabled']
+            for repo
+            in repositories
+            if (repo['substitutions']['basearch'] == 'x86_64' and
+                repo['substitutions']['releasever'] == '6Server')
+        ][0])
+
+    @tier1
+    @run_only_on('sat')
+    def test_positive_reposet_disable(self):
+        """Disable repo from reposet
+
+        @Feature: Repository-set
+
+        @Assert: Repository was disabled
+        """
+        org = entities.Organization().create()
+        with manifests.clone() as manifest:
+            upload_manifest(org.id, manifest.content)
+        product = entities.Product(
+            name=PRDS['rhel'],
+            organization=org,
+        ).search()[0]
+        reposet = entities.RepositorySet(
+            name=REPOSET['rhva6'],
+            product=product,
+        ).search()[0]
+        reposet.enable(data={'basearch': 'x86_64', 'releasever': '6Server'})
+        reposet.disable(data={'basearch': 'x86_64', 'releasever': '6Server'})
+        repositories = reposet.available_repositories()['results']
+        self.assertFalse([
+            repo['enabled']
+            for repo
+            in repositories
+            if (repo['substitutions']['basearch'] == 'x86_64' and
+                repo['substitutions']['releasever'] == '6Server')
+        ][0])


### PR DESCRIPTION
For UI/CLI we have separate module `test_repository_set.py` for repository set tests.
Making API consistent with other interfaces.
Closes #3148