### PR TITLE
cli.Proxy - fixed ssh tunnelling

### DIFF
--- a/tests/foreman/cli/test_capsule.py
+++ b/tests/foreman/cli/test_capsule.py
@@ -1,6 +1,7 @@
 # -*- encoding: utf-8 -*-
 """Test class for the capsule CLI."""
 import random
+import re
 
 from fauxfactory import gen_alphanumeric, gen_string
 from robottelo.cli.base import CLIReturnCodeError
@@ -14,13 +15,9 @@ from robottelo.test import CLITestCase
 class CapsuleTestCase(CLITestCase):
     """Proxy cli tests"""
 
-    def setUp(self):
-        """Skipping tests until we can create ssh tunnels"""
-        self.skipTest('Skipping tests until we can create ssh tunnels')
-
     @run_only_on('sat')
     @tier1
-    def test_positive_create_with_url(self):
+    def test_negative_create_with_url(self):
         """Proxy creation with random URL
 
         @Feature: Smart Proxy
@@ -97,7 +94,14 @@ class CapsuleTestCase(CLITestCase):
         @Assert: Proxy features are refreshed
         """
         proxy = make_proxy()
-        Proxy.refresh_features({u'id': proxy['id']})
+        # parse the port number so we can reopen the SSH tunnel
+        port_regexp = re.search(u':([0-9]+)', proxy['url'])
+        if port_regexp:
+            port = port_regexp.group(1)
+            with default_url_on_new_port(9090, port):
+                Proxy.refresh_features({u'id': proxy['id']})
+        else:
+            raise ValueError('Unable to parse port number from proxy URL')
 
     @run_only_on('sat')
     @tier2
@@ -109,7 +113,14 @@ class CapsuleTestCase(CLITestCase):
         @Assert: Proxy features are refreshed
         """
         proxy = make_proxy()
-        Proxy.refresh_features({u'name': proxy['name']})
+        # parse the port number so we can reopen the SSH tunnel
+        port_regexp = re.search(u':([0-9]+)', proxy['url'])
+        if port_regexp:
+            port = port_regexp.group(1)
+            with default_url_on_new_port(9090, port):
+                Proxy.refresh_features({u'name': proxy['name']})
+        else:
+            raise ValueError('Unable to parse port number from proxy URL')
 
 
 class CapsuleIntegrationTestCase(CLITestCase):

--- a/tests/foreman/cli/test_organization.py
+++ b/tests/foreman/cli/test_organization.py
@@ -30,7 +30,6 @@ from robottelo.datafactory import (
 from robottelo.decorators import (
     run_only_on,
     skip_if_bug_open,
-    stubbed,
     tier1,
     tier2,
 )
@@ -972,7 +971,6 @@ class OrganizationTestCase(CLITestCase):
 
     @run_only_on('sat')
     @tier2
-    @stubbed("Needs to be re-worked!")
     def test_positive_add_capsule_by_name(self):
         """Add a capsule to organization by its name
 
@@ -990,7 +988,6 @@ class OrganizationTestCase(CLITestCase):
         self.assertIn(proxy['name'], org['smart-proxies'])
 
     @run_only_on('sat')
-    @stubbed()
     @tier2
     def test_positive_add_capsule_by_id(self):
         """Add a capsule to organization by its ID
@@ -998,12 +995,17 @@ class OrganizationTestCase(CLITestCase):
         @feature: Organization
 
         @assert: Capsule is added to the org
-
-        @status: manual
         """
+        org = make_org()
+        proxy = make_proxy()
+        Org.add_smart_proxy({
+            'name': org['name'],
+            'smart-proxy-id': proxy['id'],
+        })
+        org = Org.info({'name': org['name']})
+        self.assertIn(proxy['name'], org['smart-proxies'])
 
     @run_only_on('sat')
-    @stubbed("Needs to be re-worked!")
     @tier2
     def test_positive_remove_capsule_by_name(self):
         """Remove a capsule from organization by its name


### PR DESCRIPTION
https://github.com/SatelliteQE/automation-tools/pull/287 needs to be merged first, otherwise the`make_proxy()` factory method will fail with unable to connect. - :white_check_mark: 

cli.test_organization - unstubbed and completed capsule tests cases

partially addresses issue https://github.com/SatelliteQE/robottelo/issues/3139
```bash
$ nosetests -m capsule test_organization.py --with-progressive

OK!  3 tests, 0 failures, 0 errors in 161.4s
```