### PR TITLE
Add ptable tests targeting BZ1229384 & update CLI ptable tests

### DIFF
--- a/tests/foreman/api/test_partitiontable.py
+++ b/tests/foreman/api/test_partitiontable.py
@@ -4,7 +4,7 @@ A full API reference for patition tables can be found here:
 http://theforeman.org/api/apidoc/v2/ptables.html
 
 """
-from fauxfactory import gen_integer, gen_string
+from fauxfactory import gen_integer
 from nailgun import entities
 from random import randint
 from requests.exceptions import HTTPError
@@ -18,25 +18,13 @@ from robottelo.decorators import skip_if_bug_open, tier1
 from robottelo.test import APITestCase
 
 
-def valid_single_character_names():
-    """Returns a tuple of single character names"""
-    return(
-        gen_string('alphanumeric', 1),
-        gen_string('alpha', 1),
-        gen_string('cjk', 1),
-        gen_string('latin1', 1),
-        gen_string('numeric', 1),
-        gen_string('utf8', 1),
-    )
-
-
 class PartitionTableTestCase(APITestCase):
     """Tests for the ``ptables`` path."""
 
     @skip_if_bug_open('bugzilla', 1229384)
     @tier1
-    def test_verify_bugzilla_1229384(self):
-        """Create Partition table with 1 symbol in name
+    def test_positive_create_with_one_character_name(self):
+        """Create Partition table with 1 character in name
 
         @Assert: Partition table was created
 
@@ -44,7 +32,7 @@ class PartitionTableTestCase(APITestCase):
 
         @BZ: 1229384
         """
-        for name in valid_single_character_names():
+        for name in generate_strings_list(length=1):
             with self.subTest(name):
                 ptable = entities.PartitionTable(name=name).create()
                 self.assertEqual(ptable.name, name)

--- a/tests/foreman/cli/test_partitiontable.py
+++ b/tests/foreman/cli/test_partitiontable.py
@@ -1,35 +1,46 @@
 # -*- encoding: utf-8 -*-
 """Test class for Partition table CLI"""
-from fauxfactory import gen_string, gen_alphanumeric
+from random import randint
+from robottelo.datafactory import generate_strings_list
+from robottelo.cli.base import CLIReturnCodeError
 from robottelo.cli.factory import make_os, make_partition_table
-from robottelo.cli.operatingsys import OperatingSys
 from robottelo.cli.partitiontable import PartitionTable
-from robottelo.decorators import run_only_on, tier1, tier2
+from robottelo.decorators import run_only_on, skip_if_bug_open, tier1, tier2
 from robottelo.test import CLITestCase
 
 
 class PartitionTableUpdateCreateTestCase(CLITestCase):
-    """Test case for CLI tests."""
+    """Partition Table CLI tests."""
 
-    def setUp(self):  # noqa
-        """Set up file"""
-        super(PartitionTableUpdateCreateTestCase, self).setUp()
-        self.content = "Fake ptable"
-        self.name = gen_alphanumeric(6)
-        self.args = {'name': self.name,
-                     'content': self.content}
+    @skip_if_bug_open('bugzilla', 1229384)
+    @tier1
+    def test_positive_create_with_one_character_name(self):
+        """Create Partition table with 1 character in name
+
+        @Assert: Partition table was created
+
+        @Feature: Partition Table - Create
+
+        @BZ: 1229384
+        """
+        for name in generate_strings_list(length=1):
+            with self.subTest(name):
+                ptable = make_partition_table({'name': name})
+                self.assertEqual(ptable['name'], name)
 
     @run_only_on('sat')
     @tier1
-    def test_positive_create_with_name_content(self):
-        """Create a Partition Table with name and content
+    def test_positive_create_with_name(self):
+        """Create Partition Tables with different names
 
-        @Assert: Partition Table is created and has correct name and content
+        @Assert: Partition Table is created and has correct name
 
         @Feature: Partition Table
         """
-        ptable = make_partition_table(self.args)
-        self.assertEqual(ptable['name'], self.name)
+        for name in generate_strings_list(length=randint(4, 30)):
+            with self.subTest(name):
+                ptable = make_partition_table({'name': name})
+                self.assertEqual(ptable['name'], name)
 
     @tier1
     def test_positive_create_with_content(self):
@@ -39,7 +50,7 @@ class PartitionTableUpdateCreateTestCase(CLITestCase):
 
         @Assert: Partition Table is created and has correct content
         """
-        content = "Fake ptable"
+        content = 'Fake ptable'
         ptable = make_partition_table({'content': content})
         ptable_content = PartitionTable().dump({'id': ptable['id']})
         self.assertTrue(content in ptable_content[0])
@@ -53,18 +64,15 @@ class PartitionTableUpdateCreateTestCase(CLITestCase):
 
         @Assert: Partition Table is created and its name can be updated
         """
-        ptable = make_partition_table(self.args)
-        self.assertEqual(ptable['name'], self.name)
-        new_name = gen_alphanumeric(6)
-        PartitionTable().update({
-            'name': self.name,
-            'new-name': new_name,
-        })
-        PartitionTable().exists(search=('name', new_name))
-
-
-class PartitionTableDeleteTestCase(CLITestCase):
-    """Test case for Dump/Delete CLI tests."""
+        ptable = make_partition_table()
+        for new_name in generate_strings_list(length=randint(4, 30)):
+            with self.subTest(new_name):
+                PartitionTable.update({
+                    'id': ptable['id'],
+                    'new-name': new_name,
+                })
+                ptable = PartitionTable.info({'id': ptable['id']})
+                self.assertEqual(ptable['name'], new_name)
 
     @tier1
     def test_positive_delete_by_id(self):
@@ -74,39 +82,34 @@ class PartitionTableDeleteTestCase(CLITestCase):
 
         @Assert: Partition Table is deleted
         """
-        content = "Fake ptable"
-        name = gen_alphanumeric(6)
-        ptable = make_partition_table({'name': name, 'content': content})
-        PartitionTable().delete({'id': ptable['id']})
-        self.assertFalse(PartitionTable().exists(search=('name', name)))
+        ptable = make_partition_table()
+        PartitionTable.delete({'id': ptable['id']})
+        with self.assertRaises(CLIReturnCodeError):
+            PartitionTable.info({'id': ptable['id']})
 
-    # pylint: disable=no-self-use
+    @tier1
+    def test_positive_delete_by_name(self):
+        """Create a Partition Table then delete it by its name
+
+        @Feature: Partition Table
+
+        @Assert: Partition Table is deleted
+        """
+        ptable = make_partition_table()
+        PartitionTable.delete({'name': ptable['name']})
+        with self.assertRaises(CLIReturnCodeError):
+            PartitionTable.info({'name': ptable['name']})
+
     @tier2
     def test_positive_add_os_by_id(self):
-        """Create a partition table then add an operating system to it
+        """Create a partition table then add an operating system to it using
+        IDs for association
 
         @Feature: Partition Table
 
         @Assert: Operating system is added to partition table
-
         """
-        content = "Fake ptable"
-        ptable = make_partition_table({'content': content})
-        os_list = OperatingSys.list()
-        PartitionTable().add_operating_system({
-            'id': ptable['id'],
-            'operatingsystem-id': os_list[0]['id']
-        })
-
-    @tier2
-    def test_positive_remove_os_by_id(self):
-        """Add an operating system to a partition table then remove it
-
-        @Feature: Partition Table
-
-        @Assert: Operating system is added then removed from partition table
-        """
-        ptable = make_partition_table({'content': gen_string("alpha", 10)})
+        ptable = make_partition_table()
         os = make_os()
         PartitionTable.add_operating_system({
             'id': ptable['id'],
@@ -114,9 +117,67 @@ class PartitionTableDeleteTestCase(CLITestCase):
         })
         ptable = PartitionTable.info({'id': ptable['id']})
         self.assertIn(os['title'], ptable['operating-systems'])
+
+    @tier2
+    def test_positive_add_os_by_name(self):
+        """Create a partition table then add an operating system to it using
+        names for association
+
+        @Feature: Partition Table
+
+        @Assert: Operating system is added to partition table
+        """
+        ptable = make_partition_table()
+        os = make_os()
+        PartitionTable.add_operating_system({
+            'name': ptable['name'],
+            'operatingsystem': os['title'],
+        })
+        ptable = PartitionTable.info({'name': ptable['name']})
+        self.assertIn(os['title'], ptable['operating-systems'])
+
+    @tier2
+    def test_positive_remove_os_by_id(self):
+        """Add an operating system to a partition table then remove it. Use IDs
+        for removal
+
+        @Feature: Partition Table
+
+        @Assert: Operating system is added then removed from partition table
+        """
+        ptable = make_partition_table()
+        os = make_os()
+        PartitionTable.add_operating_system({
+            'id': ptable['id'],
+            'operatingsystem-id': os['id'],
+        })
+        ptable = PartitionTable.info({'id': ptable['id']})
         PartitionTable.remove_operating_system({
             'id': ptable['id'],
             'operatingsystem-id': os['id'],
         })
         ptable = PartitionTable.info({'id': ptable['id']})
+        self.assertNotIn(os['title'], ptable['operating-systems'])
+
+    @tier2
+    def test_positive_remove_os_by_name(self):
+        """Add an operating system to a partition table then remove it. Use
+        names for removal
+
+        @Feature: Partition Table
+
+        @Assert: Operating system is added then removed from partition table
+        """
+        ptable = make_partition_table()
+        os = make_os()
+        PartitionTable.add_operating_system({
+            'name': ptable['name'],
+            'operatingsystem': os['title'],
+        })
+        ptable = PartitionTable.info({'name': ptable['name']})
+        PartitionTable.remove_operating_system({
+            'name': ptable['name'],
+            'operatingsystem': os['title'],
+        })
+        ptable = PartitionTable.info({'name': ptable['name']})
         self.assertNotIn(os['title'], ptable['operating-systems'])

--- a/tests/foreman/ui/test_partitiontable.py
+++ b/tests/foreman/ui/test_partitiontable.py
@@ -3,7 +3,12 @@
 from fauxfactory import gen_string
 from robottelo.constants import PARTITION_SCRIPT_DATA_FILE
 from robottelo.datafactory import generate_strings_list, invalid_values_list
-from robottelo.decorators import bz_bug_is_open, run_only_on, tier1
+from robottelo.decorators import (
+    bz_bug_is_open,
+    run_only_on,
+    skip_if_bug_open,
+    tier1,
+)
 from robottelo.helpers import read_data_file
 from robottelo.test import UITestCase
 from robottelo.ui.factory import make_partitiontable
@@ -35,6 +40,29 @@ def valid_partition_table_update_names():
 
 class PartitionTableTestCase(UITestCase):
     """Implements the partition table tests from UI"""
+
+    @run_only_on('sat')
+    @skip_if_bug_open('bugzilla', 1229384)
+    @tier1
+    def test_positive_create_with_one_character_name(self):
+        """Create a Partition table with 1 character in name
+
+        @Assert: Partition table is created
+
+        @Feature: Partition Table - Positive Create
+
+        @BZ: 1229384
+        """
+        with Session(self.browser) as session:
+            for name in generate_strings_list(length=1):
+                with self.subTest(name):
+                    make_partitiontable(
+                        session,
+                        name=name,
+                        layout=read_data_file(PARTITION_SCRIPT_DATA_FILE),
+                        os_family='Red Hat'
+                    )
+                    self.assertIsNotNone(self.partitiontable.search(name))
 
     @run_only_on('sat')
     @tier1


### PR DESCRIPTION
Added CLI & UI tests targeting BZ1229384.
Closes #2520 
As a bonus, updated existing CLI ptable tests + slightly increased coverage.

Tests results:
```python
py.test tests/foreman/cli/test_partitiontable.py -n auto
================================ test session starts =================================
platform linux2 -- Python 2.7.10, pytest-2.8.7, py-1.4.31, pluggy-0.3.1
rootdir: /home/andrii/workspace/robottelo, inifile: 
plugins: xdist-1.13.1, repeat-0.2
gw0 [10] / gw1 [10] / gw2 [10] / gw3 [10]
scheduling tests via LoadScheduling
......s...
======================= 9 passed, 1 skipped in 159.27 seconds ========================
py.test tests/foreman/ui/test_partitiontable.py -k 'test_verify_bugzilla_1229384'
================================ test session starts =================================
platform linux2 -- Python 2.7.10, pytest-2.8.7, py-1.4.31, pluggy-0.3.1
rootdir: /home/andrii/workspace/robottelo, inifile: 
plugins: xdist-1.13.1, repeat-0.2
collected 7 items 

tests/foreman/ui/test_partitiontable.py s

=============== 6 tests deselected by '-ktest_verify_bugzilla_1229384' ===============
====================== 1 skipped, 6 deselected in 19.00 seconds ======================
py.test tests/foreman/api/test_partitiontable.py -k 'test_verify_bugzilla_1229384'
================================ test session starts =================================
platform linux2 -- Python 2.7.10, pytest-2.8.7, py-1.4.31, pluggy-0.3.1
rootdir: /home/andrii/workspace/robottelo, inifile: 
plugins: xdist-1.13.1, repeat-0.2
collected 12 items 

tests/foreman/api/test_partitiontable.py s

============== 11 tests deselected by '-ktest_verify_bugzilla_1229384' ===============
====================== 1 skipped, 11 deselected in 1.75 seconds ======================
```