### PR TITLE
Add SauceLabs browser

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -176,11 +176,29 @@ It is possible to run UI tests within a docker container. To do this:
   has permission to run docker commands. For more information check the docker
   installation guide https://docs.docker.com/engine/installation/.
 * Pull the ``selenium/standalone-firefox`` image
-* Set ``docker_browser=true`` at the ``[robottelo]`` section in the configuration file ``robottelo.properties``.
+* Set ``browser=docker`` at the ``[robottelo]`` section in the configuration
+  file ``robottelo.properties``.
 
 Once you've performed these steps, UI tests will no longer launch a web browser
 on your system. Instead, UI tests launch a web browser within a docker
 container.
+
+Running UI Tests On SauceLabs
+-----------------------------
+
+It is possible to run UI tests on SauceLabs. To do this:
+
+* Set ``browser=saucelabs`` at the ``[robottelo]`` section in the configuration
+  file ``robottelo.properties``.
+* Select the browser type by setting ``webdriver`` at the ``[robottelo]``
+  section in the configuration file. Valid values are ``firefox``, ``chrome``
+  and ``ie``.
+* Fill ``saucelabs_user`` and ``saucelabs_key`` at the ``[robottelo]`` section
+  in the configuration file with your Sauce OnDemand credentials.
+* If the machine where Satellite 6 is installed is on a VPN or behind a
+  firewall make sure to have SauceConnect running.
+* Optional: install ``sauceclient`` python package if you want robottelo to
+  report test success or failure back to SauceLabs.
 
 Miscellany
 ==========

--- a/requirements-optional.txt
+++ b/requirements-optional.txt
@@ -15,3 +15,6 @@ sphinx
 
 # For running UI tests within a docker browser
 docker-py
+
+# For reporting test results on SauceLabs
+sauceclient

--- a/robottelo.properties.sample
+++ b/robottelo.properties.sample
@@ -38,8 +38,23 @@ ssh_key=
 # upstream=true
 # Logging verbosity, one of debug, info, warning, error, critical
 # verbosity=debug
-# Selenium webdriver to use
+
+# browser tells robottelo which browser to use when testing UI. Valid values
+# are:
+# * selenium
+# * docker: to use a browser inside a docker container. In order to use this
+#   feature make sure that the docker daemon is running locally and has its
+#   unix socket published at unix://var/run/docker.sock. Also make sure that
+#   the docker image selenium/standalone-firefox is available.
+# * saucelabs: makes robottelo run tests on SauceLabs. The saucelabs_user and
+#   saucelabs_key are required and the browser used is the same specified on
+#   webdriver.  Supported values for webdriver are firefox, chrome and ie, the
+#   other valid webdriver values are going to be translated to firefox.
+# browser=selenium
+
+# Webdriver to use. Valid values are chrome, firefox, ie, phantomjs
 # webdriver=firefox
+
 # Binary location for selected wedriver
 # webdriver_binary=/usr/bin/firefox
 # webdriver_binary=/usr/bin/chromedriver
@@ -47,12 +62,8 @@ ssh_key=
 # Run one datapoint or multiple datapoints for tests
 # run_one_datapoint=false
 
-# docker_browser tells robottelo to use a browser inside a docker
-# container. In order to use this feature make sure that the docker
-# daemon is running locally and has its unix socket published at
-# unix://var/run/docker.sock. Also make sure that the docker image
-# selenium/standalone-firefox is available.
-# docker_browser=false
+# saucelabs_user=
+# saucelabs_key=
 
 # Provide link to rhel6/7 repo here, as puppet rpm would require packages from
 # RHEL 6/7 repo and syncing the entire repo on the fly would take longer for

--- a/robottelo/config/settings.py
+++ b/robottelo/config/settings.py
@@ -524,13 +524,15 @@ class Settings(object):
         self._all_features = None
         self._configured = False
         self._validation_errors = []
-        self.docker_browser = None
+        self.browser = None
         self.locale = None
         self.project = None
         self.reader = None
         self.rhel6_repo = None
         self.rhel7_repo = None
         self.screenshots_path = None
+        self.saucelabs_key = None
+        self.saucelabs_user = None
         self.server = ServerSettings()
         self.run_one_datapoint = None
         self.upstream = None
@@ -620,8 +622,8 @@ class Settings(object):
 
     def _read_robottelo_settings(self):
         """Read Robottelo's general settings."""
-        self.docker_browser = self.reader.get(
-            'robottelo', 'docker_browser', False, bool)
+        self.browser = self.reader.get(
+            'robottelo', 'browser', 'selenium')
         self.locale = self.reader.get('robottelo', 'locale', 'en_US.UTF-8')
         self.project = self.reader.get('robottelo', 'project', 'sat')
         self.rhel6_repo = self.reader.get('robottelo', 'rhel6_repo', None)
@@ -639,6 +641,10 @@ class Settings(object):
         )
         self.webdriver = self.reader.get(
             'robottelo', 'webdriver', 'firefox')
+        self.saucelabs_user = self.reader.get(
+            'robottelo', 'saucelabs_user', None)
+        self.saucelabs_key = self.reader.get(
+            'robottelo', 'saucelabs_key', None)
         self.webdriver_binary = self.reader.get(
             'robottelo', 'webdriver_binary', None)
         self.window_manager_command = self.reader.get(
@@ -647,12 +653,29 @@ class Settings(object):
     def _validate_robottelo_settings(self):
         """Validate Robottelo's general settings."""
         validation_errors = []
+        browsers = ('selenium', 'docker', 'saucelabs')
         webdrivers = ('chrome', 'firefox', 'ie', 'phantomjs', 'remote')
+        if self.browser not in browsers:
+            validation_errors.append(
+                '[robottelo] browser should be one of {0}.'
+                .format(', '.join(browsers))
+            )
         if self.webdriver not in webdrivers:
-            raise ImproperlyConfigured(
+            validation_errors.append(
                 '[robottelo] webdriver should be one of {0}.'
                 .format(', '.join(webdrivers))
             )
+        if self.browser == 'saucelabs':
+            if self.saucelabs_user is None:
+                validation_errors.append(
+                    '[robottelo] saucelabs_user must be provided when '
+                    'browser is saucelabs.'
+                )
+            if self.saucelabs_key is None:
+                validation_errors.append(
+                    '[robottelo] saucelabs_key must be provided when '
+                    'browser is saucelabs.'
+                )
         return validation_errors
 
     @property

--- a/robottelo/ui/browser.py
+++ b/robottelo/ui/browser.py
@@ -16,28 +16,50 @@ class DockerBrowserError(Exception):
     """Indicates any issue with DockerBrowser."""
 
 
+def _sauce_ondemand_url(saucelabs_user, saucelabs_key):
+    """Get sauce ondemand URL for a given user and key."""
+    return 'http://{0}:{1}@ondemand.saucelabs.com:80/wd/hub'.format(
+        saucelabs_user, saucelabs_key)
+
+
 def browser():
     """Creates a webdriver browser instance based on configuration."""
     webdriver_name = settings.webdriver.lower()
-    if webdriver_name == 'firefox':
-        return webdriver.Firefox(
-            firefox_binary=webdriver.firefox.firefox_binary.FirefoxBinary(
-                settings.webdriver_binary)
+    if settings.browser == 'selenium':
+        if webdriver_name == 'firefox':
+            return webdriver.Firefox(
+                firefox_binary=webdriver.firefox.firefox_binary.FirefoxBinary(
+                    settings.webdriver_binary)
+            )
+        elif webdriver_name == 'chrome':
+            return (
+                webdriver.Chrome() if settings.webdriver_binary is None
+                else webdriver.Chrome(
+                    executable_path=settings.webdriver_binary)
+            )
+        elif webdriver_name == 'ie':
+            return (
+                webdriver.Ie() if settings.webdriver_binary is None
+                else webdriver.Ie(executable_path=settings.webdriver_binary)
+            )
+        elif webdriver_name == 'phantomjs':
+            return webdriver.PhantomJS(
+                service_args=['--ignore-ssl-errors=true'])
+        elif webdriver_name == 'remote':
+            return webdriver.Remote()
+    elif settings.browser == 'saucelabs':
+        if webdriver_name == 'chrome':
+            desired_capabilities = webdriver.DesiredCapabilities.CHROME
+        elif webdriver_name == 'ie':
+            desired_capabilities = (
+                webdriver.DesiredCapabilities.INTERNETEXPLORER)
+        else:
+            desired_capabilities = webdriver.DesiredCapabilities.FIREFOX
+        return webdriver.Remote(
+            command_executor=_sauce_ondemand_url(
+                settings.saucelabs_user, settings.saucelabs_key),
+            desired_capabilities=desired_capabilities
         )
-    elif webdriver_name == 'chrome':
-        return (
-            webdriver.Chrome() if settings.webdriver_binary is None
-            else webdriver.Chrome(executable_path=settings.webdriver_binary)
-        )
-    elif webdriver_name == 'ie':
-        return (
-            webdriver.Ie() if settings.webdriver_binary is None
-            else webdriver.Ie(executable_path=settings.webdriver_binary)
-        )
-    elif webdriver_name == 'phantomjs':
-        return webdriver.PhantomJS(service_args=['--ignore-ssl-errors=true'])
-    elif webdriver_name == 'remote':
-        return webdriver.Remote()
 
 
 class DockerBrowser(object):

--- a/tests/robottelo/test_ui.py
+++ b/tests/robottelo/test_ui.py
@@ -15,6 +15,7 @@ class BrowserTestCase(unittest2.TestCase):
         self.webdriver_patcher = mock.patch('robottelo.ui.browser.webdriver')
         self.settings = self.settings_patcher.start()
         self.webdriver = self.webdriver_patcher.start()
+        self.settings.browser = 'selenium'
 
     def tearDown(self):
         self.settings_patcher.stop()


### PR DESCRIPTION
A while back we removed support for running UI tests via SauceLabs. This
is time to get it back with extra improvements. Now one is able to
select which browser is gonna be created selenium, docker or saucelabs.

Also when choosing to run on SauceLabs, setting the webdriver will also
choose the browser that is gonna be created on SauceLabs. Valid values
are firefox, chrome and ie.

Thanks @omaciel for the initial code added on #3300.