### PR TITLE
Add and fix existing coverage for repository entity in API

### DIFF
--- a/tests/foreman/api/test_repository.py
+++ b/tests/foreman/api/test_repository.py
@@ -1,15 +1,16 @@
 """Unit tests for the ``repositories`` paths."""
 from fauxfactory import gen_string
-from nailgun import client, entities
-from random import randint
+from nailgun import entities
+from nailgun.entity_mixins import TaskFailedError
 from requests.exceptions import HTTPError
-from robottelo.api.utils import enable_rhrepo_and_fetchid, upload_manifest
 from robottelo import manifests
-from robottelo.config import settings
+from robottelo.api.utils import enable_rhrepo_and_fetchid, upload_manifest
 from robottelo.constants import (
     DOCKER_REGISTRY_HUB,
     FAKE_0_PUPPET_REPO,
+    FAKE_7_PUPPET_REPO,
     FAKE_2_YUM_REPO,
+    FAKE_5_YUM_REPO,
     PRDS,
     REPOS,
     REPOSET,
@@ -17,48 +18,23 @@ from robottelo.constants import (
     VALID_GPG_KEY_BETA_FILE,
     VALID_GPG_KEY_FILE,
 )
+from robottelo.datafactory import (
+    invalid_http_credentials,
+    invalid_names_list,
+    invalid_values_list,
+    valid_data_list,
+    valid_http_credentials,
+    valid_labels_list,
+)
 from robottelo.decorators import (
-    bz_bug_is_open,
     run_only_on,
     skip_if_bug_open,
     skip_if_not_set,
     tier1,
     tier2,
 )
-from robottelo.helpers import (
-    get_data_file,
-    read_data_file,
-)
+from robottelo.helpers import get_data_file, read_data_file
 from robottelo.test import APITestCase
-
-
-def _test_data():
-    """Return a tuple of dicts. The dicts can be used to make products."""
-    return (
-        {'content_type': 'puppet', 'url': FAKE_0_PUPPET_REPO},
-        {'checksum_type': 'sha1'},
-        {'checksum_type': 'sha256'},
-        {'name': gen_string('alphanumeric', randint(10, 50))},
-        {'name': gen_string('alpha', randint(10, 50))},
-        {'name': gen_string('cjk', randint(10, 50))},
-        {'name': gen_string('latin1', randint(10, 50))},
-        {'name': gen_string('numeric', randint(10, 50))},
-        {'name': gen_string('utf8', randint(10, 50))},
-        {'unprotected': True},
-        {'url': FAKE_2_YUM_REPO},
-    )
-
-
-def _valid_names():
-    """Returns a tuple of valid repo names."""
-    return(
-        gen_string('alpha', 15),
-        gen_string('alphanumeric', 15),
-        gen_string('numeric', 15),
-        gen_string('latin1', 15),
-        gen_string('utf8', 15),
-        gen_string('html', 15),
-    )
 
 
 class RepositoryTestCase(APITestCase):
@@ -73,23 +49,139 @@ class RepositoryTestCase(APITestCase):
 
     @tier1
     @run_only_on('sat')
-    def test_positive_create(self):
-        """Create a repository and provide valid attributes.
+    def test_positive_create_name(self):
+        """Create a repository with valid name.
 
-        @Assert: A repository is created with the given attributes.
+        @Assert: A repository is created with the given name.
 
         @Feature: Repository
         """
-        for attrs in _test_data():
-            with self.subTest(attrs):
+        for name in valid_data_list():
+            with self.subTest(name):
+                repo = entities.Repository(
+                    product=self.product, name=name).create()
+                self.assertEqual(name, repo.name)
+
+    @tier1
+    @run_only_on('sat')
+    def test_positive_create_with_label(self):
+        """Create a repository providing label which is different from its name
+
+        @Assert: A repository is created with expected label.
+
+        @Feature: Repository
+        """
+        for label in valid_labels_list():
+            with self.subTest(label):
+                repo = entities.Repository(
+                    product=self.product, label=label).create()
+                self.assertEqual(repo.label, label)
+                self.assertNotEqual(repo.name, label)
+
+    @tier1
+    @run_only_on('sat')
+    def test_positive_create_yum(self):
+        """Create yum repository.
+
+        @Assert: A repository is created and has yum type.
+
+        @Feature: Repository
+        """
+        repo = entities.Repository(
+            product=self.product,
+            content_type='yum',
+            url=FAKE_2_YUM_REPO,
+        ).create()
+        self.assertEqual(repo.content_type, 'yum')
+        self.assertEqual(repo.url, FAKE_2_YUM_REPO)
+
+    @tier1
+    @run_only_on('sat')
+    def test_positive_create_puppet(self):
+        """Create puppet repository.
+
+        @Assert: A repository is created and has puppet type.
+
+        @Feature: Repository
+        """
+        repo = entities.Repository(
+            product=self.product,
+            content_type='puppet',
+            url=FAKE_0_PUPPET_REPO,
+        ).create()
+        self.assertEqual(repo.content_type, 'puppet')
+
+    @tier1
+    @run_only_on('sat')
+    def test_positive_create_with_auth_yum_repo(self):
+        """Create yum repository with basic HTTP authentication
+
+        @Assert: yum repository is created
+
+        @Feature: HTTP Authentication Repository
+        """
+        url = FAKE_5_YUM_REPO
+        for creds in valid_http_credentials(url_encoded=True):
+            url_encoded = url.format(creds['login'], creds['pass'])
+            with self.subTest(url):
                 repo = entities.Repository(
                     product=self.product,
-                    **attrs
+                    content_type='yum',
+                    url=url_encoded,
                 ).create()
-                repo_attrs = repo.read_json()
-                for name, value in attrs.items():
-                    self.assertIn(name, repo_attrs.keys())
-                    self.assertEqual(value, repo_attrs[name])
+                self.assertEqual(repo.content_type, 'yum')
+                self.assertEqual(repo.url, url_encoded)
+
+    @tier1
+    @run_only_on('sat')
+    def test_positive_create_with_auth_puppet_repo(self):
+        """Create Puppet repository with basic HTTP authentication
+
+        @Assert: Puppet repository is created
+
+        @Feature: HTTP Authentication Repository
+        """
+        url = FAKE_7_PUPPET_REPO
+        for creds in valid_http_credentials(url_encoded=True):
+            url_encoded = url.format(creds['login'], creds['pass'])
+            with self.subTest(url):
+                repo = entities.Repository(
+                    product=self.product,
+                    content_type='puppet',
+                    url=url_encoded,
+                ).create()
+                self.assertEqual(repo.content_type, 'puppet')
+                self.assertEqual(repo.url, url_encoded)
+
+    @tier1
+    @run_only_on('sat')
+    def test_positive_create_checksum(self):
+        """Create a repository with valid checksum type.
+
+        @Assert: A repository is created and has expected checksum type.
+
+        @Feature: Repository
+        """
+        for checksum_type in 'sha1', 'sha256':
+            with self.subTest(checksum_type):
+                repo = entities.Repository(
+                    product=self.product, checksum_type=checksum_type).create()
+                self.assertEqual(checksum_type, repo.checksum_type)
+
+    @tier1
+    @run_only_on('sat')
+    def test_positive_create_unprotected(self):
+        """Create a repository with valid unprotected flag values.
+
+        @Assert: A repository is created and has expected unprotected flag
+        state.
+
+        @Feature: Repository
+        """
+        for unprotected in True, False:
+            repo = entities.Repository(
+                product=self.product, unprotected=unprotected).create()
+            self.assertEqual(repo.unprotected, unprotected)
 
     @tier2
     @run_only_on('sat')
@@ -100,11 +192,6 @@ class RepositoryTestCase(APITestCase):
 
         @Feature: Repository
         """
-        # Create this dependency tree:
-        #
-        # repository -> product -.
-        #           `-> gpg key --`-> organization
-        #
         gpg_key = entities.GPGKey(
             content=read_data_file(VALID_GPG_KEY_FILE),
             organization=self.org,
@@ -113,43 +200,181 @@ class RepositoryTestCase(APITestCase):
             gpg_key=gpg_key,
             product=self.product,
         ).create()
-
         # Verify that the given GPG key ID is used.
-        self.assertEqual(gpg_key.id, repo.read().gpg_key.id)
+        self.assertEqual(gpg_key.id, repo.gpg_key.id)
 
     @tier2
     @run_only_on('sat')
     def test_positive_create_same_name_different_orgs(self):
-        """Create two repos with the same name in two organizations.
+        """Create two repos with the same name in two different organizations.
 
-        @Assert: The two repositories are successfully created and use the
-        given name.
+        @Assert: The two repositories are successfully created and have given
+        name.
 
         @Feature: Repository
         """
-        repo1 = entities.Repository().create()
+        repo1 = entities.Repository(product=self.product).create()
         repo2 = entities.Repository(name=repo1.name).create()
-        for repo in (repo1, repo2, repo1.read(), repo2.read()):
-            self.assertEqual(repo.name, repo1.name)
+        self.assertEqual(repo1.name, repo2.name)
 
     @tier1
     @run_only_on('sat')
-    def test_positive_delete(self):
-        """Create a repository with attributes ``attrs`` and delete it.
+    def test_negative_create_name(self):
+        """Attempt to create repository with invalid names only.
 
-        @Assert: The repository cannot be fetched after deletion.
+        @Assert: A repository is not created and error is raised.
 
         @Feature: Repository
         """
-        for attrs in _test_data():
-            with self.subTest(attrs):
-                repo = entities.Repository(
-                    product=self.product,
-                    **attrs
-                ).create()
-                repo.delete()
+        for name in invalid_values_list():
+            with self.subTest(name):
                 with self.assertRaises(HTTPError):
-                    repo.read()
+                    entities.Repository(name=name).create()
+
+    @run_only_on('sat')
+    @tier1
+    def test_negative_create_with_same_name(self):
+        """Attempt to create a repository providing a name of already existent
+        entity
+
+        @Assert: Second repository is not created
+
+        @Feature: Repository
+        """
+        name = gen_string('alphanumeric')
+        entities.Repository(product=self.product, name=name).create()
+        with self.assertRaises(HTTPError):
+            entities.Repository(product=self.product, name=name).create()
+
+    @tier1
+    @run_only_on('sat')
+    def test_negative_create_label(self):
+        """Attempt to create repository with invalid label.
+
+        @Assert: A repository is not created and error is raised.
+
+        @Feature: Repository
+        """
+        with self.assertRaises(HTTPError):
+            entities.Repository(label=gen_string('utf8')).create()
+
+    @tier1
+    @run_only_on('sat')
+    def test_negative_create_url(self):
+        """Attempt to create repository with invalid url.
+
+        @Assert: A repository is not created and error is raised.
+
+        @Feature: Repository
+        """
+        for url in invalid_names_list():
+            with self.subTest(url):
+                with self.assertRaises(HTTPError):
+                    entities.Repository(url=url).create()
+
+    @tier1
+    @run_only_on('sat')
+    def test_negative_create_with_auth_url_with_special_characters(self):
+        """Verify that repository URL cannot contain unquoted special characters
+
+        @Assert: A repository is not created and error is raised.
+
+        @Feature: HTTP Authentication Repository
+        """
+        # get a list of valid credentials without quoting them
+        for cred in [creds for creds in valid_http_credentials()
+                     if creds['quote'] is True]:
+            with self.subTest(cred):
+                url = FAKE_5_YUM_REPO.format(cred['login'], cred['pass'])
+                with self.assertRaises(HTTPError):
+                    entities.Repository(url=url).create()
+
+    @tier1
+    @run_only_on('sat')
+    def test_negative_create_with_auth_url_too_long(self):
+        """Verify that repository URL length is limited
+
+        @Assert: A repository is not created and error is raised.
+
+        @Feature: HTTP Authentication Repository
+        """
+        for cred in invalid_http_credentials():
+            with self.subTest(cred):
+                url = FAKE_5_YUM_REPO.format(cred['login'], cred['pass'])
+                with self.assertRaises(HTTPError):
+                    entities.Repository(url=url).create()
+
+    @tier1
+    @run_only_on('sat')
+    def test_negative_create_checksum(self):
+        """Attempt to create repository with invalid checksum type.
+
+        @Assert: A repository is not created and error is raised.
+
+        @Feature: Repository
+        """
+        with self.assertRaises(HTTPError):
+            entities.Repository(checksum_type=gen_string('alpha')).create()
+
+    @tier1
+    @run_only_on('sat')
+    def test_positive_update_name(self):
+        """Update repository name to another valid name.
+
+        @Assert: The repository name can be updated.
+
+        @Feature: Repository
+        """
+        repo = entities.Repository(product=self.product).create()
+        for new_name in valid_data_list():
+            with self.subTest(new_name):
+                repo.name = new_name
+                repo = repo.update(['name'])
+                self.assertEqual(new_name, repo.name)
+
+    @tier1
+    @run_only_on('sat')
+    def test_positive_update_checksum(self):
+        """Update repository checksum type to another valid one.
+
+        @Assert: The repository checksum type can be updated.
+
+        @Feature: Repository
+        """
+        repo = entities.Repository(
+            product=self.product, checksum_type='sha1').create()
+        repo.checksum_type = 'sha256'
+        repo = repo.update(['checksum_type'])
+        self.assertEqual(repo.checksum_type, 'sha256')
+
+    @tier1
+    @run_only_on('sat')
+    def test_positive_update_url(self):
+        """Update repository url to another valid one.
+
+        @Assert: The repository url can be updated.
+
+        @Feature: Repository
+        """
+        repo = entities.Repository(product=self.product).create()
+        repo.url = FAKE_2_YUM_REPO
+        repo = repo.update(['url'])
+        self.assertEqual(repo.url, FAKE_2_YUM_REPO)
+
+    @tier1
+    @run_only_on('sat')
+    def test_positive_update_unprotected(self):
+        """Update repository unprotected flag to another valid one.
+
+        @Assert: The repository unprotected flag can be updated.
+
+        @Feature: Repository
+        """
+        repo = entities.Repository(
+            product=self.product, unprotected=False).create()
+        repo.unprotected = True
+        repo = repo.update(['unprotected'])
+        self.assertEqual(repo.unprotected, True)
 
     @tier2
     @run_only_on('sat')
@@ -193,59 +418,192 @@ class RepositoryTestCase(APITestCase):
         with open(get_data_file(RPM_TO_UPLOAD), 'rb') as handle:
             repo.upload_content(files={'content': handle})
         # Verify the repository's contents.
-        self.assertEqual(repo.read_json()[u'content_counts'][u'rpm'], 1)
+        self.assertEqual(repo.read().content_counts['rpm'], 1)
+
+    @run_only_on('sat')
+    @tier1
+    def test_negative_update_name(self):
+        """Attempt to update repository name to invalid one
+
+        @Assert: Repository is not updated
+
+        @Feature: Repository
+        """
+        repo = entities.Repository(product=self.product).create()
+        for new_name in invalid_values_list():
+            repo.name = new_name
+            with self.subTest(new_name):
+                with self.assertRaises(HTTPError):
+                    repo.update(['name'])
+
+    @run_only_on('sat')
+    @skip_if_bug_open('bugzilla', 1311113)
+    @tier1
+    def test_negative_update_label(self):
+        """Attempt to update repository label to another one.
+
+        @Assert: Repository is not updated and error is raised
+
+        @Feature: Repository
+        """
+        repo = entities.Repository(product=self.product).create()
+        repo.label = gen_string('alpha')
+        with self.assertRaises(HTTPError):
+            repo.update(['label'])
+
+    @run_only_on('sat')
+    @tier1
+    def test_negative_update_auth_url_with_special_characters(self):
+        """Verify that repository URL credentials cannot be updated to contain
+        the forbidden characters
+
+        @Assert: Repository url not updated
+
+        @Feature: HTTP Authentication Repository
+        """
+        new_repo = entities.Repository(product=self.product).create()
+        # get auth repos with credentials containing unquoted special chars
+        auth_repos = [
+            repo.format(cred['login'], cred['pass'])
+            for cred in valid_http_credentials() if cred['quote']
+            for repo in (FAKE_5_YUM_REPO, FAKE_7_PUPPET_REPO)
+        ]
+
+        for url in auth_repos:
+            with self.subTest(url):
+                new_repo.url = url
+                with self.assertRaises(HTTPError):
+                    new_repo = new_repo.update()
+
+    @run_only_on('sat')
+    @tier1
+    def test_negative_update_auth_url_too_long(self):
+        """Update the original url for a repository to value which is too long
+
+        @Assert: Repository url not updated
+
+        @Feature: HTTP Authentication Repository
+        """
+        new_repo = entities.Repository(product=self.product).create()
+        # get auth repos with credentials containing unquoted special chars
+        auth_repos = [
+            repo.format(cred['login'], cred['pass'])
+            for cred in invalid_http_credentials()
+            for repo in (FAKE_5_YUM_REPO, FAKE_7_PUPPET_REPO)
+        ]
+
+        for url in auth_repos:
+            with self.subTest(url):
+                new_repo.url = url
+                with self.assertRaises(HTTPError):
+                    new_repo = new_repo.update()
 
     @tier2
     def test_positive_synchronize(self):
         """Create a repo and sync it.
 
-        @Assert: The repo has more than one RPM.
+        @Assert: The repo has at least one RPM.
 
         @Feature: Repository
         """
         repo = entities.Repository(product=self.product).create()
         repo.sync()
-        self.assertGreaterEqual(repo.read_json()[u'content_counts'][u'rpm'], 1)
+        self.assertGreaterEqual(repo.read().content_counts['rpm'], 1)
 
+    @run_only_on('sat')
+    @tier2
+    def test_positive_synchronize_auth_yum_repo(self):
+        """Check if secured repository can be created and synced
 
-class RepositoryUpdateTestCase(APITestCase):
-    """Tests for updating repositories."""
+        @Assert: Repository is created and synced
 
-    @classmethod
-    def setUpClass(cls):  # noqa
-        """Create a repository which can be repeatedly updated."""
-        super(RepositoryUpdateTestCase, cls).setUpClass()
-        cls.repository = entities.Repository().create()
+        @Feature: HTTP Authentication Repository
+        """
+        url = FAKE_5_YUM_REPO
+        for creds in [cred for cred in valid_http_credentials(url_encoded=True)
+                      if cred['http_valid']]:
+            url_encoded = url.format(creds['login'], creds['pass'])
+            with self.subTest(url):
+                repo = entities.Repository(
+                    product=self.product,
+                    content_type='yum',
+                    url=url_encoded,
+                ).create()
+                # Assertion that repo is not yet synced
+                self.assertEqual(repo.content_counts['rpm'], 0)
+                # Synchronize it
+                repo.sync()
+                # Verify it has finished
+                self.assertGreaterEqual(repo.read().content_counts['rpm'], 1)
+
+    @run_only_on('sat')
+    @tier2
+    def test_negative_synchronize_auth_yum_repo(self):
+        """Check if secured repo fails to synchronize with invalid credentials
+
+        @Assert: Repository is created but synchronization fails
+
+        @Feature: HTTP Authentication Repository
+        """
+        url = FAKE_5_YUM_REPO
+        for creds in [cred for cred in valid_http_credentials(url_encoded=True)
+                      if not cred['http_valid']]:
+            url_encoded = url.format(
+                creds['login'], creds['pass']
+            )
+            with self.subTest(url):
+                repo = entities.Repository(
+                    product=self.product,
+                    content_type='yum',
+                    url=url_encoded,
+                ).create()
+                # Try to synchronize it
+                with self.assertRaises(TaskFailedError):
+                    repo.sync()
+
+    @run_only_on('sat')
+    @tier2
+    def test_positive_synchronize_auth_puppet_repo(self):
+        """Check if secured puppet repository can be created and synced
+
+        @Assert: Repository is created and synced
+
+        @Feature: HTTP Authentication Repository
+        """
+        url = FAKE_7_PUPPET_REPO
+        for creds in [cred for cred in valid_http_credentials(url_encoded=True)
+                      if cred['http_valid']]:
+            url_encoded = url.format(creds['login'], creds['pass'])
+            with self.subTest(url):
+                repo = entities.Repository(
+                    product=self.product,
+                    content_type='puppet',
+                    url=url_encoded,
+                ).create()
+                # Assertion that repo is not yet synced
+                self.assertEqual(repo.content_counts['puppet_module'], 0)
+                # Synchronize it
+                repo.sync()
+                # Verify it has finished
+                self.assertEqual(
+                    repo.read().content_counts['puppet_module'], 1)
 
     @tier1
     @run_only_on('sat')
-    def test_positive_update(self):
-        """Create a repository and update its attributes.
+    def test_positive_delete(self):
+        """Create a repository with different names and then delete it.
 
-        @Assert: The repository's attributes are updated.
+        @Assert: The repository deleted successfully.
 
         @Feature: Repository
         """
-        for attrs in _test_data():
-            with self.subTest(attrs):
-                client.put(
-                    self.repository.path(),
-                    attrs,
-                    auth=settings.server.get_credentials(),
-                    verify=False,
-                ).raise_for_status()
-                real_attrs = self.repository.read_json()
-                for name, value in attrs.items():
-                    self.assertIn(name, real_attrs.keys())
-                    if name == 'content_type':
-                        # Cannot update a repository's content type.
-                        con_type = self.repository.get_fields()['content_type']
-                        self.assertEqual(
-                            con_type.default,
-                            real_attrs[name]
-                        )
-                    else:
-                        self.assertEqual(value, real_attrs[name])
+        for name in valid_data_list():
+            with self.subTest(name):
+                repo = entities.Repository(
+                    product=self.product, name=name).create()
+                repo.delete()
+                with self.assertRaises(HTTPError):
+                    repo.read()
 
 
 class RepositorySyncTestCase(APITestCase):
@@ -254,12 +612,12 @@ class RepositorySyncTestCase(APITestCase):
     @tier2
     @run_only_on('sat')
     @skip_if_not_set('fake_manifest')
-    def test_positive_redhat_synchronize(self):
+    def test_positive_sync_rh(self):
         """Sync RedHat Repository.
 
         @Feature: Repositories
 
-        @Assert: Repository synced should fetch the data successfully.
+        @Assert: Synced repo should fetch the data successfully.
         """
         org = entities.Organization().create()
         with manifests.clone() as manifest:
@@ -294,7 +652,7 @@ class DockerRepositoryTestCase(APITestCase):
         @Feature: Repository
         """
         product = entities.Product(organization=self.org).create()
-        for name in _valid_names():
+        for name in valid_data_list():
             with self.subTest(name):
                 repo = entities.Repository(
                     content_type=u'docker',
@@ -303,62 +661,47 @@ class DockerRepositoryTestCase(APITestCase):
                     product=product,
                     url=DOCKER_REGISTRY_HUB,
                 ).create()
-                repo2 = repo.read()
-                self.assertEqual(repo.name, repo2.name)
+                self.assertEqual(repo.name, name)
                 self.assertEqual(
-                    repo.docker_upstream_name,
-                    repo2.docker_upstream_name
-                )
-                self.assertEqual(repo.content_type, repo2.content_type)
+                    repo.docker_upstream_name, u'busybox')
+                self.assertEqual(repo.content_type, u'docker')
 
     @tier2
     @run_only_on('sat')
-    @skip_if_bug_open('bugzilla', 1217603)
     def test_positive_synchronize(self):
         """Create and sync a Docker-type repository
 
-        @Assert: A repository is created with a Docker repository
-        and it is synchronized.
+        @Assert: A repository is created with a Docker repository and it is
+        synchronized.
 
         @Feature: Repository
         """
-        from pprint import PrettyPrinter
-        printer = PrettyPrinter().pprint
-
         product = entities.Product(organization=self.org).create()
-        repository = entities.Repository(
+        repo = entities.Repository(
             content_type=u'docker',
             docker_upstream_name=u'busybox',
             name=u'busybox',
             product=product,
             url=DOCKER_REGISTRY_HUB,
         ).create()
-        printer(repository.id)
-        printer(repository.sync())
-        self.assertGreaterEqual(
-            repository.read_json()[u'content_counts'][u'docker_image'],
-            1
-        )
+        repo.sync()
+        self.assertGreaterEqual(repo.read().content_counts['docker_image'], 1)
 
     @tier1
+    @skip_if_bug_open('bugzilla', 1194476)
     def test_positive_update_name(self):
         """Update a repository's name.
 
         @Assert: The repository's name is updated.
 
         @Feature: Repository
-
-        The only data provided with the PUT request is a name. No other
-        information about the repository (such as its URL) is provided.
         """
-        for content_type in ('yum', 'docker'):
-            with self.subTest(content_type):
-                if content_type == 'docker' and bz_bug_is_open(1194476):
-                    self.skipTest(1194476)
-                repository = entities.Repository(
-                    content_type=content_type
-                ).create()
-                name = repository.get_fields()['name'].gen_value()
-                repository.name = name
-                repository = repository.update()
-                self.assertEqual(repository.name, name)
+        repository = entities.Repository(
+            content_type='docker'
+        ).create()
+        # The only data provided with the PUT request is a name. No other
+        # information about the repository (such as its URL) is provided.
+        new_name = gen_string('alpha')
+        repository.name = new_name
+        repository = repository.update(['name'])
+        self.assertEqual(new_name, repository.name)

--- a/tests/foreman/cli/test_repository.py
+++ b/tests/foreman/cli/test_repository.py
@@ -475,7 +475,8 @@ class RepositoryTestCase(CLITestCase):
         @Assert: Repository is created and synced
         """
         url = FAKE_7_PUPPET_REPO
-        for creds in valid_http_credentials(url_encoded=True):
+        for creds in [cred for cred in valid_http_credentials(url_encoded=True)
+                      if cred['http_valid']]:
             url_encoded = url.format(creds['login'], creds['pass'])
             with self.subTest(url):
                 new_repo = self._make_repository({


### PR DESCRIPTION
Closes #3311
Part of #2837

```
nosetests tests/foreman/api/test_repository.py
..SE..........S.....................
======================================================================
ERROR: Sync RedHat Repository.
----------------------------------------------------------------------
Ran 36 tests in 1420.033s

FAILED (SKIP=2, errors=1)
```
Fail doesn't relate to changes in current PR