### PR TITLE
Implement CRUD tests for compute resources for API

### DIFF
--- a/docs/api/tests.foreman.api.rst
+++ b/docs/api/tests.foreman.api.rst
@@ -13,6 +13,11 @@
 
 .. automodule:: tests.foreman.api.test_architecture
 
+:mod:`tests.foreman.api.test_computeresource`
+---------------------------------------------
+
+.. automodule:: tests.foreman.api.test_computeresource
+
 :mod:`tests.foreman.api.test_contentview`
 -----------------------------------------
 

--- a/robottelo/ui/computeresource.py
+++ b/robottelo/ui/computeresource.py
@@ -3,7 +3,6 @@ from robottelo.constants import FILTER
 from robottelo.ui.base import Base, UINoSuchElementError
 from robottelo.ui.locators import common_locators, locators, tab_locators
 from robottelo.ui.navigator import Navigator
-from selenium.webdriver.support.select import Select
 
 
 class ComputeResource(Base):
@@ -47,9 +46,7 @@ class ComputeResource(Base):
 
         """
         if provider_type:
-            Select(
-                self.find_element(locators['resource.provider_type'])
-            ).select_by_visible_text(provider_type)
+            self.select(locators['resource.provider_type'], provider_type)
         if parameter_list is None:
             return
         for parameter_name, parameter_value, parameter_type in parameter_list:
@@ -62,9 +59,7 @@ class ComputeResource(Base):
                 self.text_field_update(
                     locators[param_locator], parameter_value)
             elif parameter_type == 'select':
-                Select(
-                    self.find_element(locators[param_locator])
-                ).select_by_visible_text(parameter_value)
+                self.select(locators[param_locator], parameter_value)
             elif parameter_type == 'checkbox':
                 if (self.find_element(locators[param_locator]).is_selected() !=
                         parameter_value):

--- a/robottelo/ui/locators.py
+++ b/robottelo/ui/locators.py
@@ -877,8 +877,7 @@ locators = LocatorDict({
     "resource.new": (
         By.XPATH, "//a[contains(@href, '/compute_resources/new')]"),
     "resource.name": (By.ID, "compute_resource_name"),
-    "resource.provider_type": (
-        By.XPATH, "//select[@id='compute_resource_provider']"),
+    "resource.provider_type": (By.ID, "s2id_compute_resource_provider"),
     "resource.description": (By.ID, "compute_resource_description"),
     "resource.url": (By.XPATH, "//input[@id='compute_resource_url']"),
     "resource.display_type": (By.ID, "compute_resource_display_type"),

--- a/tests/foreman/api/test_computeresource.py
+++ b/tests/foreman/api/test_computeresource.py
@@ -1,0 +1,474 @@
+# -*- encoding: utf-8 -*-
+"""Unit tests for the ``compute_resource`` paths.
+
+A full API reference for compute resources can be found here:
+http://www.katello.org/docs/api/apidoc/compute_resources.html
+
+"""
+from fauxfactory import gen_string
+from nailgun import entities
+from random import randint
+from requests.exceptions import HTTPError
+from robottelo.config import settings
+from robottelo.constants import LIBVIRT_RESOURCE_URL
+from robottelo.datafactory import (
+    invalid_names_list,
+    invalid_values_list,
+    valid_data_list,
+)
+from robottelo.decorators import tier1, tier2
+from robottelo.test import APITestCase
+
+
+class ComputeResourceTestCase(APITestCase):
+    """Tests for ``katello/api/v2/compute_resources``."""
+
+    @classmethod
+    def setUpClass(cls):
+        """Set up organization and location for tests."""
+        super(ComputeResourceTestCase, cls).setUpClass()
+        cls.org = entities.Organization().create()
+        cls.loc = entities.Location(organization=[cls.org]).create()
+        cls.current_libvirt_url = (
+            LIBVIRT_RESOURCE_URL % settings.server.hostname
+        )
+
+    @tier1
+    def test_positive_create_with_name(self):
+        """Create compute resources with different names
+
+        @Feature: Compute Resource
+
+        @Assert: Compute resources are created with expected names
+        """
+        for name in valid_data_list():
+            with self.subTest(name):
+                compresource = entities.LibvirtComputeResource(
+                    location=[self.loc],
+                    name=name,
+                    organization=[self.org],
+                    url=self.current_libvirt_url,
+                ).create()
+                self.assertEqual(compresource.name, name)
+
+    @tier1
+    def test_positive_create_with_description(self):
+        """Create compute resources with different descriptions
+
+        @Feature: Compute Resource
+
+        @Assert: Compute resources are created with expected descriptions
+        """
+        for description in valid_data_list():
+            with self.subTest(description):
+                compresource = entities.LibvirtComputeResource(
+                    description=description,
+                    location=[self.loc],
+                    organization=[self.org],
+                    url=self.current_libvirt_url,
+                ).create()
+                self.assertEqual(compresource.description, description)
+
+    @tier1
+    def test_positive_create_libvirt_with_display_type(self):
+        """Create a libvirt compute resources with different values of
+        'display_type' parameter
+
+        @Feature: Compute Resource
+
+        @Assert: Compute resources are created with expected display_type value
+        """
+        for display_type in ('SPICE', 'VNC'):
+            with self.subTest(display_type):
+                compresource = entities.LibvirtComputeResource(
+                    display_type=display_type,
+                    location=[self.loc],
+                    organization=[self.org],
+                    url=self.current_libvirt_url,
+                ).create()
+                self.assertEqual(compresource.display_type, display_type)
+
+    @tier1
+    def test_positive_create_with_provider(self):
+        """Create compute resources with different providers. Testing only
+        Libvirt and Docker as other providers require valid credentials
+
+        @Feature: Compute Resource
+
+        @Assert: Compute resources are created with expected providers
+        """
+        for entity in (entities.DockerComputeResource(),
+                       entities.LibvirtComputeResource()):
+            with self.subTest(entity):
+                entity.location = [self.loc]
+                entity.organization = [self.org]
+                result = entity.create()
+                self.assertEqual(result.provider, entity.provider)
+
+    @tier2
+    def test_positive_create_with_locs(self):
+        """Create a compute resource with multiple locations
+
+        @Feature: Compute Resource
+
+        @Assert: A compute resource is created with expected multiple locations
+        assigned
+        """
+        locs = [
+            entities.Location(organization=[self.org]).create()
+            for _ in range(randint(3, 5))
+        ]
+        compresource = entities.LibvirtComputeResource(
+            location=locs,
+            organization=[self.org],
+            url=self.current_libvirt_url,
+        ).create()
+        self.assertEqual(
+            set(loc.name for loc in locs),
+            set(loc.read().name for loc in compresource.location)
+        )
+
+    @tier2
+    def test_positive_create_with_orgs(self):
+        """Create a compute resource with multiple organizations
+
+        @Feature: Compute Resource
+
+        @Assert: A compute resource is created with expected multiple
+        organizations assigned
+        """
+        orgs = [
+            entities.Organization().create()
+            for _ in range(randint(3, 5))
+        ]
+        compresource = entities.LibvirtComputeResource(
+            organization=orgs,
+            url=self.current_libvirt_url,
+        ).create()
+        self.assertEqual(
+            set(org.name for org in orgs),
+            set(org.read().name for org in compresource.organization)
+        )
+
+    @tier1
+    def test_positive_update_name(self):
+        """Update a compute resource with different names
+
+        @Feature: Compute Resource
+
+        @Assert: Compute resource is updated with expected names
+        """
+        compresource = entities.LibvirtComputeResource(
+            location=[self.loc],
+            organization=[self.org],
+            url=self.current_libvirt_url,
+        ).create()
+        for new_name in valid_data_list():
+            with self.subTest(new_name):
+                compresource.name = new_name
+                compresource = compresource.update(['name'])
+                self.assertEqual(compresource.name, new_name)
+
+    @tier1
+    def test_positive_update_description(self):
+        """Update a compute resource with different descriptions
+
+        @Feature: Compute Resource
+
+        @Assert: Compute resource is updated with expected descriptions
+        """
+        compresource = entities.LibvirtComputeResource(
+            description=gen_string('alpha'),
+            location=[self.loc],
+            organization=[self.org],
+            url=self.current_libvirt_url,
+        ).create()
+        for new_description in valid_data_list():
+            with self.subTest(new_description):
+                compresource.description = new_description
+                compresource = compresource.update(['description'])
+                self.assertEqual(compresource.description, new_description)
+
+    @tier1
+    def test_positive_update_libvirt_display_type(self):
+        """Update a libvirt compute resource with different values of
+        'display_type' parameter
+
+        @Feature: Compute Resource
+
+        @Assert: Compute resource is updated with expected display_type value
+        """
+        compresource = entities.LibvirtComputeResource(
+            display_type='VNC',
+            location=[self.loc],
+            organization=[self.org],
+            url=self.current_libvirt_url,
+        ).create()
+        for display_type in ('SPICE', 'VNC'):
+            with self.subTest(display_type):
+                compresource.display_type = display_type
+                compresource = compresource.update(['display_type'])
+                self.assertEqual(compresource.display_type, display_type)
+
+    @tier1
+    def test_positive_update_url(self):
+        """Update a compute resource's url field
+
+        @Feature: Compute Resource
+
+        @Assert: Compute resource is updated with expected url
+        """
+        new_url = 'qemu+tcp://localhost:16509/system'
+
+        compresource = entities.LibvirtComputeResource(
+            location=[self.loc],
+            organization=[self.org],
+            url=self.current_libvirt_url,
+        ).create()
+        compresource.url = new_url
+        compresource = compresource.update(['url'])
+        self.assertEqual(compresource.url, new_url)
+
+    @tier2
+    def test_positive_update_loc(self):
+        """Update a compute resource's location
+
+        @Feature: Compute Resource
+
+        @Assert: Compute resource is updated with expected location
+        """
+        compresource = entities.LibvirtComputeResource(
+            location=[self.loc],
+            organization=[self.org],
+            url=self.current_libvirt_url,
+        ).create()
+        new_loc = entities.Location(organization=[self.org]).create()
+        compresource.location = [new_loc]
+        compresource = compresource.update(['location'])
+        self.assertEqual(len(compresource.location), 1)
+        self.assertEqual(compresource.location[0].id, new_loc.id)
+
+    @tier2
+    def test_positive_update_locs(self):
+        """Update a compute resource with new multiple locations
+
+        @Feature: Compute Resource
+
+        @Assert: Compute resource is updated with expected locations
+        """
+        compresource = entities.LibvirtComputeResource(
+            location=[self.loc],
+            organization=[self.org],
+            url=self.current_libvirt_url,
+        ).create()
+        new_locs = [
+            entities.Location(organization=[self.org]).create()
+            for _ in range(randint(3, 5))
+        ]
+        compresource.location = new_locs
+        compresource = compresource.update(['location'])
+        self.assertEqual(
+            set(location.id for location in compresource.location),
+            set(location.id for location in new_locs),
+        )
+
+    @tier2
+    def test_positive_update_org(self):
+        """Update a compute resource's organization
+
+        @Feature: Compute Resource
+
+        @Assert: Compute resource is updated with expected organization
+        """
+        compresource = entities.LibvirtComputeResource(
+            organization=[self.org],
+            url=self.current_libvirt_url,
+        ).create()
+        new_org = entities.Organization().create()
+        compresource.organization = [new_org]
+        compresource = compresource.update(['organization'])
+        self.assertEqual(len(compresource.organization), 1)
+        self.assertEqual(compresource.organization[0].id, new_org.id)
+
+    @tier2
+    def test_positive_update_orgs(self):
+        """Update a compute resource with new multiple organizations
+
+        @Feature: Compute Resource
+
+        @Assert: Compute resource is updated with expected organizations
+        """
+        compresource = entities.LibvirtComputeResource(
+            organization=[self.org],
+            url=self.current_libvirt_url,
+        ).create()
+        new_orgs = [
+            entities.Organization().create()
+            for _ in range(randint(3, 5))
+        ]
+        compresource.organization = new_orgs
+        compresource = compresource.update(['organization'])
+        self.assertEqual(
+            set(organization.id for organization in compresource.organization),
+            set(organization.id for organization in new_orgs),
+        )
+
+    @tier1
+    def test_positive_delete(self):
+        """Delete a compute resource
+
+        @Feature: Compute Resource
+
+        @Assert: Compute resources is successfully deleted
+        """
+        compresource = entities.LibvirtComputeResource(
+            location=[self.loc],
+            organization=[self.org],
+            url=self.current_libvirt_url,
+        ).create()
+        compresource.delete()
+        with self.assertRaises(HTTPError):
+            compresource.read()
+
+    @tier1
+    def test_negative_create_with_invalid_name(self):
+        """Attempt to create compute resources with invalid names
+
+        @Feature: Compute Resource
+
+        @Assert: Compute resources are not created
+        """
+        for name in invalid_values_list():
+            with self.subTest(name):
+                with self.assertRaises(HTTPError):
+                    entities.LibvirtComputeResource(
+                        location=[self.loc],
+                        name=name,
+                        organization=[self.org],
+                        url=self.current_libvirt_url,
+                    ).create()
+
+    @tier1
+    def test_negative_create_with_same_name(self):
+        """Attempt to create a compute resource with already existing name
+
+        @Feature: Compute Resource
+
+        @Assert: Compute resources is not created
+        """
+        name = gen_string('alphanumeric')
+        entities.LibvirtComputeResource(
+            location=[self.loc],
+            name=name,
+            organization=[self.org],
+            url=self.current_libvirt_url,
+        ).create()
+        with self.assertRaises(HTTPError):
+            entities.LibvirtComputeResource(
+                location=[self.loc],
+                name=name,
+                organization=[self.org],
+                url=self.current_libvirt_url,
+            ).create()
+
+    @tier1
+    def test_negative_create_with_description(self):
+        """Attempt to create compute resources with invalid descriptions
+
+        @Feature: Compute Resource
+
+        @Assert: Compute resources are not created
+        """
+        for description in invalid_names_list():
+            with self.subTest(description):
+                with self.assertRaises(HTTPError):
+                    entities.LibvirtComputeResource(
+                        description=description,
+                        location=[self.loc],
+                        organization=[self.org],
+                        url=self.current_libvirt_url,
+                    ).create()
+
+    @tier1
+    def test_negative_create_with_url(self):
+        """Attempt to create compute resources with invalid url
+
+        @Feature: Compute Resource
+
+        @Assert: Compute resources are not created
+        """
+        for url in ('', gen_string('alpha')):
+            with self.subTest(url):
+                with self.assertRaises(HTTPError):
+                    entities.LibvirtComputeResource(
+                        location=[self.loc],
+                        organization=[self.org],
+                        url=url,
+                    ).create()
+
+    @tier1
+    def test_negative_update_invalid_name(self):
+        """Attempt to update compute resource with invalid names
+
+        @Feature: Compute Resource
+
+        @Assert: Compute resource is not updated
+        """
+        name = gen_string('alphanumeric')
+        compresource = entities.LibvirtComputeResource(
+            location=[self.loc],
+            name=name,
+            organization=[self.org],
+            url=self.current_libvirt_url,
+        ).create()
+        for new_name in invalid_values_list():
+            with self.subTest(new_name):
+                with self.assertRaises(HTTPError):
+                    compresource.name = new_name
+                    compresource.update(['name'])
+                self.assertEqual(compresource.read().name, name)
+
+    @tier1
+    def test_negative_update_same_name(self):
+        """Attempt to update a compute resource with already existing name
+
+        @Feature: Compute Resource
+
+        @Assert: Compute resources is not updated
+        """
+        name = gen_string('alphanumeric')
+        entities.LibvirtComputeResource(
+            location=[self.loc],
+            name=name,
+            organization=[self.org],
+            url=self.current_libvirt_url,
+        ).create()
+        new_compresource = entities.LibvirtComputeResource(
+            location=[self.loc],
+            organization=[self.org],
+            url=self.current_libvirt_url,
+        ).create()
+        with self.assertRaises(HTTPError):
+            new_compresource.name = name
+            new_compresource.update(['name'])
+        self.assertNotEqual(new_compresource.read().name, name)
+
+    @tier1
+    def test_negative_update_url(self):
+        """Attempt to update a compute resource with invalid url
+
+        @Feature: Compute Resource
+
+        @Assert: Compute resources is not updated
+        """
+        compresource = entities.LibvirtComputeResource(
+            location=[self.loc],
+            organization=[self.org],
+            url=self.current_libvirt_url,
+        ).create()
+        for url in ('', gen_string('alpha')):
+            with self.subTest(url):
+                with self.assertRaises(HTTPError):
+                    compresource.url = url
+                    compresource.update(['url'])
+            self.assertNotEqual(compresource.read().url, url)

--- a/tests/foreman/cli/test_computeresource.py
+++ b/tests/foreman/cli/test_computeresource.py
@@ -25,11 +25,9 @@ from robottelo.cli.base import CLIReturnCodeError
 from robottelo.cli.computeresource import ComputeResource
 from robottelo.cli.factory import make_location, make_compute_resource
 from robottelo.config import settings
-from robottelo.constants import FOREMAN_PROVIDERS
+from robottelo.constants import FOREMAN_PROVIDERS, LIBVIRT_RESOURCE_URL
 from robottelo.decorators import run_only_on, skip_if_bug_open, tier1
 from robottelo.test import CLITestCase
-
-LIBVIRT_URL = 'qemu+tcp://{}:16509/system'.format(settings.server.hostname)
 
 
 def valid_name_desc_data():
@@ -95,6 +93,13 @@ def invalid_update_data():
 class ComputeResourceTestCase(CLITestCase):
     """ComputeResource CLI tests."""
 
+    @classmethod
+    def setUpClass(cls):
+        super(ComputeResourceTestCase, cls).setUpClass()
+        cls.current_libvirt_url = (
+            LIBVIRT_RESOURCE_URL % settings.server.hostname
+        )
+
     # pylint: disable=no-self-use
     @tier1
     @run_only_on('sat')
@@ -109,7 +114,7 @@ class ComputeResourceTestCase(CLITestCase):
         ComputeResource.create({
             'name': gen_string(str_type='alpha'),
             'provider': 'Libvirt',
-            'url': LIBVIRT_URL,
+            'url': self.current_libvirt_url,
         })
 
     @tier1
@@ -126,7 +131,7 @@ class ComputeResourceTestCase(CLITestCase):
         compute_resource = make_compute_resource({
             'name': name,
             'provider': FOREMAN_PROVIDERS['libvirt'],
-            'url': LIBVIRT_URL,
+            'url': self.current_libvirt_url,
         })
         # factory already runs info, just check the data
         self.assertEquals(compute_resource['name'], name)
@@ -143,7 +148,7 @@ class ComputeResourceTestCase(CLITestCase):
         """
         comp_res = make_compute_resource({
             'provider': FOREMAN_PROVIDERS['libvirt'],
-            'url': LIBVIRT_URL,
+            'url': self.current_libvirt_url,
         })
         self.assertTrue(comp_res['name'])
         result_list = ComputeResource.list({
@@ -164,7 +169,7 @@ class ComputeResourceTestCase(CLITestCase):
         """
         comp_res = make_compute_resource({
             'provider': FOREMAN_PROVIDERS['libvirt'],
-            'url': LIBVIRT_URL,
+            'url': self.current_libvirt_url,
         })
         self.assertTrue(comp_res['name'])
         ComputeResource.delete({'name': comp_res['name']})


### PR DESCRIPTION
Closes #3258 
```python
py.test tests/foreman/api/test_computeresource.py -n auto
================================ test session starts =================================
platform linux2 -- Python 2.7.10, pytest-2.8.7, py-1.4.31, pluggy-0.3.1
rootdir: /home/andrii/workspace/robottelo, inifile: 
plugins: xdist-1.13.1, repeat-0.2
gw0 [20] / gw1 [20] / gw2 [20] / gw3 [20]
scheduling tests via LoadScheduling
....................
============================ 20 passed in 102.06 seconds =============================
```