### PR TITLE
Update URL for Docker Hub.

### DIFF
--- a/robottelo/constants.py
+++ b/robottelo/constants.py
@@ -276,7 +276,7 @@ FILTER_CONTENT_TYPE = {
 FILTER_TYPE = {'include': "Include",
                'exclude': "Exclude"}
 
-DOCKER_REGISTRY_HUB = u'https://registry.hub.docker.com/'
+DOCKER_REGISTRY_HUB = u'https://registry-1.docker.io'
 GOOGLE_CHROME_REPO = u'http://dl.google.com/linux/chrome/rpm/stable/x86_64'
 FAKE_0_YUM_REPO = "http://inecas.fedorapeople.org/fakerepos/zoo/"
 FAKE_1_YUM_REPO = "http://inecas.fedorapeople.org/fakerepos/zoo3/"


### PR DESCRIPTION
With Satellite 6.2 we will effectively stop supporting Docker Hub's
v1 API and support only v2. Currently, Docker Hub decided to drop
their support for v2 and went back to v1, but eventually decided to
support both, and to do that there's a new API endpoint. This PR
 provides a new URL which will allows us to continue synchronizing
content from Docker Hub.