### PR TITLE
Improve coverage for org & loc with smart proxy association tests

### DIFF
--- a/tests/foreman/api/test_location.py
+++ b/tests/foreman/api/test_location.py
@@ -8,6 +8,7 @@ from fauxfactory import gen_integer, gen_string
 from nailgun import entities
 from random import randint
 from requests.exceptions import HTTPError
+from robottelo.cli.factory import make_proxy
 from robottelo.decorators import tier1, tier2
 from robottelo.datafactory import invalid_values_list
 from robottelo.test import APITestCase
@@ -34,7 +35,7 @@ def valid_loc_data_list():
 
 class LocationTestCase(APITestCase):
     """Tests for the ``locations`` path."""
-    # TODO Add coverage for media, smart_proxy, realms once they implemented
+    # TODO Add coverage for media, realms as soon as they're implemented
 
     @tier1
     def test_positive_create_with_name(self):
@@ -212,6 +213,20 @@ class LocationTestCase(APITestCase):
         self.assertEqual(len(location.organization), orgs_amount)
         for org in location.organization:
             self.assertIn(org.id, org_ids)
+
+    @tier2
+    def test_positive_create_with_capsule(self):
+        """Create new location with assigned capsule to it
+
+        @Assert: Location created successfully and has correct capsule assigned
+        to it
+
+        @Feature: Location
+        """
+        proxy = entities.SmartProxy(id=make_proxy()['id']).search()[0]
+        location = entities.Location(smart_proxy=[proxy]).create()
+        self.assertEqual(location.smart_proxy[0].id, proxy.id)
+        self.assertEqual(location.smart_proxy[0].read().name, proxy.name)
 
     @tier1
     def test_positive_delete(self):
@@ -479,6 +494,22 @@ class LocationTestCase(APITestCase):
             set([org.id for org in location.organization]),
         )
 
+    @tier2
+    def test_positive_update_capsule(self):
+        """Update location with new capsule
+
+        @Assert: Location updated successfully and has correct capsule assigned
+
+        @Feature: Location - Update
+        """
+        proxy = entities.SmartProxy(id=make_proxy()['id']).search()[0]
+        location = entities.Location(smart_proxy=[proxy]).create()
+        new_proxy = entities.SmartProxy(id=make_proxy()['id']).search()[0]
+        location.smart_proxy = [new_proxy]
+        location = location.update(['smart_proxy'])
+        self.assertEqual(location.smart_proxy[0].id, new_proxy.id)
+        self.assertEqual(location.smart_proxy[0].read().name, new_proxy.name)
+
     @tier1
     def test_negative_update_name(self):
         """Try to update location using invalid names only
@@ -516,3 +547,17 @@ class LocationTestCase(APITestCase):
                 location.update(['domain']).domain[0].id,
                 domain.id
             )
+
+    @tier2
+    def test_positive_remove_capsule(self):
+        """Remove a capsule from location
+
+        @Assert: Capsule was removed successfully
+
+        @Feature: Location - Update
+        """
+        proxy = entities.SmartProxy(id=make_proxy()['id']).search()[0]
+        location = entities.Location(smart_proxy=[proxy]).create()
+        location.smart_proxy = []
+        location = location.update(['smart_proxy'])
+        self.assertEqual(len(location.smart_proxy), 0)

--- a/tests/foreman/cli/test_location.py
+++ b/tests/foreman/cli/test_location.py
@@ -12,13 +12,14 @@ from robottelo.cli.factory import (
     make_hostgroup,
     make_location,
     make_medium,
+    make_proxy,
     make_subnet,
     make_template,
     make_user,
 )
 from robottelo.cli.location import Location
 from robottelo.datafactory import invalid_values_list
-from robottelo.decorators import skip_if_bug_open, tier1
+from robottelo.decorators import skip_if_bug_open, run_only_on, tier1, tier2
 from robottelo.test import CLITestCase
 
 
@@ -43,7 +44,7 @@ def valid_loc_data_list():
 
 class LocationTestCase(CLITestCase):
     """Tests for Location via Hammer CLI"""
-    # TODO Add coverage for smart_proxy and realm once we can create ssh tunnel
+    # TODO Add coverage for realms as soon as they're supported
 
     @tier1
     def test_positive_create_with_name(self):
@@ -583,6 +584,86 @@ class LocationTestCase(CLITestCase):
                 'config-templates': gen_string('utf8', 80),
                 'id': loc['id'],
             })
+
+    @run_only_on('sat')
+    @tier2
+    def test_positive_add_capsule_by_name(self):
+        """Add a capsule to organization by its name
+
+        @Feature: Organization
+
+        @Assert: Capsule is added to the org
+        """
+        loc = make_location()
+        proxy = make_proxy()
+        Location.add_smart_proxy({
+            'name': loc['name'],
+            'smart-proxy': proxy['name'],
+        })
+        loc = Location.info({'name': loc['name']})
+        self.assertIn(proxy['name'], loc['smart-proxies'])
+
+    @run_only_on('sat')
+    @tier2
+    def test_positive_add_capsule_by_id(self):
+        """Add a capsule to organization by its ID
+
+        @feature: Organization
+
+        @assert: Capsule is added to the org
+        """
+        loc = make_location()
+        proxy = make_proxy()
+        Location.add_smart_proxy({
+            'name': loc['name'],
+            'smart-proxy-id': proxy['id'],
+        })
+        loc = Location.info({'name': loc['name']})
+        self.assertIn(proxy['name'], loc['smart-proxies'])
+
+    @run_only_on('sat')
+    @tier2
+    def test_positive_remove_capsule_by_id(self):
+        """Remove a capsule from organization by its id
+
+        @Feature: Organization
+
+        @Assert: Capsule is removed from the org
+        """
+        loc = make_location()
+        proxy = make_proxy()
+        Location.add_smart_proxy({
+            'id': loc['id'],
+            'smart-proxy-id': proxy['id'],
+        })
+        Location.remove_smart_proxy({
+            'id': loc['id'],
+            'smart-proxy-id': proxy['id'],
+        })
+        loc = Location.info({'id': loc['id']})
+        self.assertNotIn(proxy['name'], loc['smart-proxies'])
+
+    @run_only_on('sat')
+    @tier2
+    def test_positive_remove_capsule_by_name(self):
+        """Remove a capsule from organization by its name
+
+        @Feature: Organization
+
+        @Assert: Capsule is removed from the org
+        """
+        loc = make_location()
+        proxy = make_proxy()
+        Location.add_smart_proxy({
+            'name': loc['name'],
+            'smart-proxy': proxy['name'],
+        })
+        Location.remove_smart_proxy({
+            'name': loc['name'],
+            'smart-proxy': proxy['name'],
+        })
+        loc = Location.info({'name': loc['name']})
+        self.assertNotIn(proxy['name'], loc['smart-proxies'])
 
     @tier1
     def test_positive_delete_by_name(self):

--- a/tests/foreman/cli/test_organization.py
+++ b/tests/foreman/cli/test_organization.py
@@ -1007,6 +1007,28 @@ class OrganizationTestCase(CLITestCase):
 
     @run_only_on('sat')
     @tier2
+    def test_positive_remove_capsule_by_id(self):
+        """Remove a capsule from organization by its id
+
+        @Feature: Organization
+
+        @Assert: Capsule is removed from the org
+        """
+        org = make_org()
+        proxy = make_proxy()
+        Org.add_smart_proxy({
+            'id': org['id'],
+            'smart-proxy-id': proxy['id'],
+        })
+        Org.remove_smart_proxy({
+            'id': org['id'],
+            'smart-proxy-id': proxy['id'],
+        })
+        org = Org.info({'id': org['id']})
+        self.assertNotIn(proxy['name'], org['smart-proxies'])
+
+    @run_only_on('sat')
+    @tier2
     def test_positive_remove_capsule_by_name(self):
         """Remove a capsule from organization by its name
 
@@ -1024,6 +1046,8 @@ class OrganizationTestCase(CLITestCase):
             'name': org['name'],
             'smart-proxy': proxy['name'],
         })
+        org = Org.info({'name': org['name']})
+        self.assertNotIn(proxy['name'], org['smart-proxies'])
 
     # Negative Create
 


### PR DESCRIPTION
Added missing smartproxy w/ organization and smartproxy w/ location association tests.
Closes #2487

```python
py.test tests/foreman/api/test_location.py -k 'capsule' -n auto
================================ test session starts =================================
platform linux2 -- Python 2.7.10, pytest-2.8.7, py-1.4.31, pluggy-0.3.1
rootdir: /home/andrii/workspace/robottelo, inifile: 
plugins: xdist-1.13.1, repeat-0.2
gw0 [3] / gw1 [3] / gw2 [3] / gw3 [3]
scheduling tests via LoadScheduling
...
============================= 3 passed in 78.21 seconds ==============================
py.test tests/foreman/cli/test_location.py -k 'capsule' -n auto
================================ test session starts =================================
platform linux2 -- Python 2.7.10, pytest-2.8.7, py-1.4.31, pluggy-0.3.1
rootdir: /home/andrii/workspace/robottelo, inifile: 
plugins: xdist-1.13.1, repeat-0.2
gw0 [4] / gw1 [4] / gw2 [4] / gw3 [4]
scheduling tests via LoadScheduling
....
============================= 4 passed in 93.52 seconds ==============================
py.test tests/foreman/cli/test_organization.py -k 'capsule' -n auto 
================================ test session starts =================================
platform linux2 -- Python 2.7.10, pytest-2.8.7, py-1.4.31, pluggy-0.3.1
rootdir: /home/andrii/workspace/robottelo, inifile: 
plugins: xdist-1.13.1, repeat-0.2
gw0 [4] / gw1 [4] / gw2 [4] / gw3 [4]
scheduling tests via LoadScheduling
....
============================= 4 passed in 90.31 seconds ==============================
```