### PR TITLE
Change Search approach to be more flexible

### DIFF
--- a/robottelo/constants.py
+++ b/robottelo/constants.py
@@ -729,15 +729,6 @@ OSCAP_PROFILE = {
     'usgcb': 'United States Government Configuration Baseline (USGCB)',
 }
 
-SEARCH_EXCEPTIONS_LIST = [
-    'ComputeResource',
-    'Hostgroup',
-    'Location',
-    'OpenScapContent',
-    'OpenScapPolicy',
-    'Org',
-]
-
 ROLES = [
     'Access Insights Admin',
     'Access Insights Viewer',


### PR DESCRIPTION
Closes #3333 

Decided to get rid all these complex conditions and length restrictions. Proposed solution will handle situations more dynamically and easier face any new scenario

```
with Session(self.browser) as session:
    for name in generate_strings_list(length=150):
        with self.subTest(name):
            make_arch(session, name=name)
            self.assertIsNotNone(self.architecture.search(name))
```
```
nosetests tests/foreman/ui/test_architecture.py -m test_positive_create_with_name
.
----------------------------------------------------------------------
Ran 1 test in 77.958s

OK
```

```
def valid_hw_model_names():
    """Returns a list of valid hw model names"""
    return [
        {u'name': gen_string('alpha', 150)},
        {u'name': gen_string('numeric', 150)},
        {u'name': gen_string('alphanumeric', 150)},
        {u'name': gen_string('html'), 'bugzilla': 1265150},
        {u'name': gen_string('latin1', 150)},
        {u'name': gen_string('utf8', 150)}
    ]
```
```
nosetests tests/foreman/ui/test_hw_model.py -m test_positive_create_with_name
.
----------------------------------------------------------------------
Ran 1 test in 73.666s

OK
```
```
for length=180
nosetests tests/foreman/ui/test_domain.py -m test_positive_create_with_name
.
----------------------------------------------------------------------
Ran 1 test in 83.672s

OK
```
```
nosetests tests/foreman/ui/test_contentview.py -m test_positive_create_wth_name
.
----------------------------------------------------------------------
Ran 1 test in 256.818s

OK
```
```
nosetests tests/foreman/ui/test_lifecycleenvironment.py -m test_positive_update
.
----------------------------------------------------------------------
Ran 1 test in 71.253s

OK
```