### PR TITLE
Fix hammer.parse_help function

### DIFF
--- a/robottelo/cli/hammer.py
+++ b/robottelo/cli/hammer.py
@@ -85,7 +85,7 @@ def parse_help(output):
                 continue
             if match.group('name') is None:
                 contents['subcommands'][-1]['description'] += (
-                    ' {0}'.format(match.group('description'))
+                    u' {0}'.format(match.group('description'))
                 )
             else:
                 contents['subcommands'].append({


### PR DESCRIPTION
Make sure to format over an unicode string in order to avoid decode
errors.