### PR TITLE
Fix UI subnet tests according to sat6.2 changes

### DIFF
--- a/robottelo/ui/locators.py
+++ b/robottelo/ui/locators.py
@@ -1298,7 +1298,9 @@ locators = LocatorDict({
          "/following::td/div/a[@data-toggle='dropdown']")),
 
     # Subnet Page
-    "subnet.new": (By.XPATH, "//a[@class='btn btn-success']"),
+    "subnet.new": (
+        By.XPATH,
+        "//a[contains(@href, '/subnets/new') and contains(@class, 'btn')]"),
     "subnet.name": (By.ID, "subnet_name"),
     "subnet.network": (By.ID, "subnet_network"),
     "subnet.mask": (By.ID, "subnet_mask"),


### PR DESCRIPTION
For sat6.2 'New subnet' button class changed from `btn-success` to `btn-primary`, so subnet tests are failing. Updating the xpath to rely on valid href and a fact that it is a button instead of success/primary/etc.
Test results:
```python
py.test tests/foreman/ui/test_subnet.py -n 2
============================================================================================================ test session starts ============================================================================================================
platform linux2 -- Python 2.7.10, pytest-2.8.7, py-1.4.31, pluggy-0.3.1
rootdir: /home/andrii/workspace/robottelo, inifile: 
plugins: xdist-1.13.1, repeat-0.2
gw0 [10] / gw1 [10]
scheduling tests via LoadScheduling
....F.....
================================================================================================================= FAILURES ==================================================================================================================
____________________________________________________________________________________________ SubnetTestCase.test_positive_create_with_long_name _____________________________________________________________________________________________
=================================================================================================== 1 failed, 9 passed in 154.81 seconds ====================================================================================================
```
1 failure should be fixed by #3339