### PR TITLE
Updating 'host-collection' hammer command.

### DIFF
--- a/robottelo/cli/factory.py
+++ b/robottelo/cli/factory.py
@@ -1046,27 +1046,26 @@ def make_host_collection(options=None):
 
     Options::
 
-        --content-host-ids CONTENT_HOST_IDS  List of content host uuids to be
-                                             in the host collection
         --description DESCRIPTION
         --host-collection-ids HOST_COLLECTION_IDS  Array of content host ids to
                                                    replace the content hosts in
                                                    host collection
-                                                   Comma separated list of vals
-
-        --max-content-hosts MAX_CONTENT_HOSTS Maximum number of content hosts
-                                              in the host collection
-        --name NAME                           Host Collection name
+                                                   Comma separated list of
+                                                   values
+        --hosts HOST_NAMES                         Comma separated list of
+                                                   values
+        --max-hosts MAX_CONTENT_HOSTS              Maximum number of content
+                                                   hosts in the host collection
+        --name NAME                                Host Collection name
         --organization ORGANIZATION_NAME
-        --organization-id ORGANIZATION_ID     organization identifier
+        --organization-id ORGANIZATION_ID          Organization identifier
         --organization-label ORGANIZATION_LABEL
-        --unlimited-content-hosts UNLIMITED_CONTENT_HOSTS Whether or not the
-                                                          host collection may
-                                                          have unlimited
-                                                          content hosts
-                                                          One of true/false,
-                                                          yes/no, 1/0.
-         -h, --help                                       print help
+        --unlimited-hosts UNLIMITED_CONTENT_HOSTS  Whether or not the host
+                                                   collection may have
+                                                   unlimited content hosts
+                                                   One of true/false, yes/no,
+                                                   1/0.
+         -h, --help                                print help
 
     """
     # Organization ID is required
@@ -1075,15 +1074,15 @@ def make_host_collection(options=None):
 
     # Assigning default values for attributes
     args = {
-        u'content-host-ids': None,
         u'description': None,
         u'host-collection-ids': None,
-        u'max-content-hosts': None,
+        u'hosts': None,
+        u'max-hosts': None,
         u'name': gen_string('alpha', 15),
         u'organization': None,
         u'organization-id': None,
         u'organization-label': None,
-        u'unlimited-content-hosts': None,
+        u'unlimited-hosts': None,
     }
 
     return create_object(HostCollection, args, options)

--- a/robottelo/cli/hostcollection.py
+++ b/robottelo/cli/hostcollection.py
@@ -6,20 +6,23 @@ Usage::
 
 Parameters::
 
-    SUBCOMMAND                    subcommand
-    [ARG] ...                     subcommand arguments
+ SUBCOMMAND                    subcommand
+ [ARG] ...                     subcommand arguments
 
 Subcommands::
 
-    add-content-host              Add content host to the host collection
-    content-hosts                 List content hosts in the host collection
-    copy                          Make copy of a host collection
-    create                        Create a host collection
-    delete                        Destroy a host collection
-    info                          Show a host collection
-    list                          List host collections
-    remove-content-host           Remove content hosts from the host collection
-    update                        Update a host collection
+ add-host                      Add host to the host collection
+ copy                          Make copy of a host collection
+ create                        Create a host collection
+ delete                        Destroy a host collection
+ erratum                       Manipulate errata for a host collection
+ hosts
+ info                          Show a host collection
+ list                          List host collections
+ package                       Manipulate packages for a host collection
+ package-group                 Manipulate package-groups for a host collection
+ remove-host                   Remove hosts from the host collection
+ update                        Update a host collection
 
 """
 
@@ -32,19 +35,19 @@ class HostCollection(Base):
     command_base = 'host-collection'
 
     @classmethod
-    def add_content_host(cls, options=None):
-        """Associate a content-host"""
-        cls.command_sub = 'add-content-host'
+    def add_host(cls, options=None):
+        """Add host to the host collection"""
+        cls.command_sub = 'add-host'
         return cls.execute(cls._construct_command(options))
 
     @classmethod
-    def remove_content_host(cls, options=None):
-        """Remove a content-host"""
-        cls.command_sub = 'remove-content-host'
+    def remove_host(cls, options=None):
+        """Remove hosts from the host collection"""
+        cls.command_sub = 'remove-host'
         return cls.execute(cls._construct_command(options))
 
     @classmethod
-    def content_hosts(cls, options=None):
+    def hosts(cls, options=None):
         """
         List content-hosts added to the host collection
 
@@ -60,6 +63,6 @@ class HostCollection(Base):
             --organization-id ORGANIZATION_ID
             --organization-label Organization label to search by
         """
-        cls.command_sub = 'content-hosts'
+        cls.command_sub = 'hosts'
         return cls.execute(
             cls._construct_command(options), output_format='csv')

--- a/tests/foreman/cli/test_host_collection.py
+++ b/tests/foreman/cli/test_host_collection.py
@@ -114,18 +114,18 @@ class HostCollectionTestCase(CLITestCase):
         for limit in ('1', '3', '5', '10', '20'):
             with self.subTest(limit):
                 new_host_col = self._new_host_collection(
-                    {'max-content-hosts': limit})
+                    {'max-hosts': limit})
                 self.assertEqual(new_host_col['limit'], str(limit))
 
     @skip_if_bug_open('bugzilla', 1214675)
     @tier1
-    def test_positive_create_with_unlimited_chosts(self):
+    def test_positive_create_with_unlimited_hosts(self):
         """Create Host Collection with different values of
-        unlimited-content-hosts parameter
+        unlimited-hosts parameter
 
-        @Feature: Host Collection - Unlimited Content Hosts
+        @Feature: Host Collection - Unlimited Hosts
 
-        @Assert: Host Collection is created and unlimited-content-hosts
+        @Assert: Host Collection is created and unlimited-hosts
         parameter is set
 
         @BZ: 1214675
@@ -135,7 +135,7 @@ class HostCollectionTestCase(CLITestCase):
             with self.subTest(unlimited):
                 host_collection = make_host_collection({
                     u'organization-id': self.org['id'],
-                    u'unlimited-content-hosts': unlimited,
+                    u'unlimited-hosts': unlimited,
                 })
                 result = HostCollection.info({
                     u'id': host_collection['id'],
@@ -143,10 +143,10 @@ class HostCollectionTestCase(CLITestCase):
                 })
                 if unlimited in (u'True', u'Yes', 1):
                     self.assertEqual(
-                        result['unlimited-content-hosts'], u'true')
+                        result['unlimited-hosts'], u'true')
                 else:
                     self.assertEqual(
-                        result['unlimited-content-hosts'], u'false')
+                        result['unlimited-hosts'], u'false')
 
     @tier1
     def test_negative_create_with_name(self):
@@ -219,7 +219,7 @@ class HostCollectionTestCase(CLITestCase):
             with self.subTest(limit):
                 HostCollection.update({
                     'id': new_host_col['id'],
-                    'max-content-hosts': limit,
+                    'max-hosts': limit,
                     'organization-id': self.org['id'],
                 })
                 result = HostCollection.info({'id': new_host_col['id']})
@@ -245,7 +245,7 @@ class HostCollectionTestCase(CLITestCase):
                     HostCollection.info({'id': new_host_col['id']})
 
     @tier2
-    def test_positive_add_chost_by_id(self):
+    def test_positive_add_host_by_id(self):
         """Check if content host can be added to host collection
 
         @Feature: Host Collection
@@ -261,9 +261,9 @@ class HostCollectionTestCase(CLITestCase):
             u'name': gen_string('alpha', 15),
             u'organization-id': self.org['id'],
         })
-        no_of_content_host = new_host_col['total-content-hosts']
-        HostCollection.add_content_host({
-            u'content-host-ids': new_system['id'],
+        no_of_content_host = new_host_col['total-hosts']
+        HostCollection.add_host({
+            u'hosts': new_system['id'],
             u'id': new_host_col['id'],
             u'organization-id': self.org['id'],
         })
@@ -271,7 +271,7 @@ class HostCollectionTestCase(CLITestCase):
             u'id': new_host_col['id'],
             u'organization-id': self.org['id']
         })
-        self.assertGreater(result['total-content-hosts'], no_of_content_host)
+        self.assertGreater(result['total-hosts'], no_of_content_host)
 
     @tier2
     def test_positive_remove_chost_by_id(self):
@@ -290,17 +290,17 @@ class HostCollectionTestCase(CLITestCase):
             u'name': gen_string('alpha', 15),
             u'organization-id': self.org['id'],
         })
-        HostCollection.add_content_host({
-            u'content-host-ids': new_system['id'],
+        HostCollection.add_host({
+            u'hosts': new_system['id'],
             u'id': new_host_col['id'],
             u'organization-id': self.org['id'],
         })
         no_of_content_host = HostCollection.info({
             u'id': new_host_col['id'],
             u'organization-id': self.org['id']
-        })['total-content-hosts']
-        HostCollection.remove_content_host({
-            u'content-host-ids': new_system['id'],
+        })['total-hosts']
+        HostCollection.remove_host({
+            u'hosts': new_system['id'],
             u'id': new_host_col['id'],
             u'organization-id': self.org['id'],
         })
@@ -308,10 +308,10 @@ class HostCollectionTestCase(CLITestCase):
             u'id': new_host_col['id'],
             u'organization-id': self.org['id'],
         })
-        self.assertGreater(no_of_content_host, result['total-content-hosts'])
+        self.assertGreater(no_of_content_host, result['total-hosts'])
 
     @tier2
-    def test_positive_list_chosts(self):
+    def test_positive_list_hosts(self):
         """Check if content hosts added to host collection is listed
 
         @Feature: Host Collection
@@ -327,9 +327,9 @@ class HostCollectionTestCase(CLITestCase):
             u'name': gen_string('alpha', 15),
             u'organization-id': self.org['id'],
         })
-        no_of_content_host = new_host_col['total-content-hosts']
-        HostCollection.add_content_host({
-            u'content-host-ids': new_system['id'],
+        no_of_content_host = new_host_col['total-hosts']
+        HostCollection.add_host({
+            u'hosts': new_system['id'],
             u'id': new_host_col['id'],
             u'organization-id': self.org['id'],
         })
@@ -337,7 +337,7 @@ class HostCollectionTestCase(CLITestCase):
             u'id': new_host_col['id'],
             u'organization-id': self.org['id']
         })
-        self.assertGreater(result['total-content-hosts'], no_of_content_host)
+        self.assertGreater(result['total-hosts'], no_of_content_host)
         result = HostCollection.content_hosts({
             u'name': host_col_name,
             u'organization-id': self.org['id']


### PR DESCRIPTION
Latest version of Hammer shows that all references to 'content-host'
have been dropped in favor of 'host'. This pull requests updates
the CLI module, factory and tests that use this command.