### PR TITLE
Fix 'Error: too many arguments' issue for activation keys in CLI

### DIFF
--- a/robottelo/cli/factory.py
+++ b/robottelo/cli/factory.py
@@ -153,7 +153,7 @@ def make_activation_key(options=None):
         u'organization': None,
         u'organization-id': None,
         u'organization-label': None,
-        u'unlimited-content-hosts': 'true',
+        u'unlimited-content-hosts': None,
     }
 
     return create_object(ActivationKey, args, options)

--- a/tests/foreman/cli/test_activationkey.py
+++ b/tests/foreman/cli/test_activationkey.py
@@ -176,17 +176,6 @@ class ActivationKeyTestCase(CLITestCase):
         self.assertEqual(new_ak['content-host-limit'], u'Unlimited')
 
     @tier1
-    def test_positive_create_with_usage_limit_default_explicitly(self):
-        """Create Activation key with default Usage limit (Unlimited)
-
-        @Feature: Activation key - Positive Create
-
-        @Assert: Activation key is created
-        """
-        new_ak = self._make_activation_key({u'unlimited-content-hosts': '1'})
-        self.assertEqual(new_ak['content-host-limit'], u'Unlimited')
-
-    @tier1
     def test_positive_create_with_usage_limit_finite(self):
         """Create Activation key with finite Usage limit
 
@@ -195,7 +184,6 @@ class ActivationKeyTestCase(CLITestCase):
         @Assert: Activation key is created
         """
         new_ak = self._make_activation_key({
-            u'unlimited-content-hosts': '0',
             u'max-content-hosts': '10',
         })
         self.assertEqual(new_ak['content-host-limit'], u'10')
@@ -243,7 +231,6 @@ class ActivationKeyTestCase(CLITestCase):
             with self.subTest(limit):
                 with self.assertRaises(CLIFactoryError):
                     self._make_activation_key({
-                        u'unlimited-content-hosts': '0',
                         u'max-content-hosts': limit,
                     })
 
@@ -458,7 +445,6 @@ class ActivationKeyTestCase(CLITestCase):
         new_ak = self._make_activation_key()
         self.assertEqual(new_ak['content-host-limit'], u'Unlimited')
         ActivationKey.update({
-            u'unlimited-content-hosts': '0',
             u'max-content-hosts': '2147483647',
             u'name': new_ak['name'],
             u'organization-id': self.org['id'],
@@ -475,7 +461,6 @@ class ActivationKeyTestCase(CLITestCase):
         @Assert: Activation key is updated
         """
         new_ak = self._make_activation_key({
-            u'unlimited-content-hosts': '0',
             u'max-content-hosts': '10',
         })
         self.assertEqual(new_ak['content-host-limit'], u'10')
@@ -537,7 +522,6 @@ class ActivationKeyTestCase(CLITestCase):
         new_ak = self._make_activation_key()
         with self.assertRaises(CLIReturnCodeError):
             ActivationKey.update({
-                u'unlimited-content-hosts': '0',
                 u'max-content-hosts': int('9' * 20),
                 u'id': new_ak['id'],
                 u'organization-id': self.org['id'],
@@ -572,7 +556,6 @@ class ActivationKeyTestCase(CLITestCase):
             u'lifecycle-environment-id': env['id'],
             u'content-view': new_cv['name'],
             u'organization-id': self.org['id'],
-            u'unlimited-content-hosts': '0',
             u'max-content-hosts': '1',
         })
         with VirtualMachine(distro='rhel65') as vm1:


### PR DESCRIPTION
Closes #3347

Fixes bunch of tests.
`unlimited-content-hosts` is not mandatory parameter anymore and should be used only in case we like update activation key `max-content-hosts` to `Unlimited` value
```
nosetests tests/foreman/cli/test_activationkey.py
.S...S...FE.S................SF..F.EEES....S.....E
----------------------------------------------------------------------
Ran 50 tests in 1748.328s

FAILED (SKIP=6, errors=5, failures=3)
```
All failures are not related to mention issue