### PR TITLE
Quick fix for test_bootstrap setup method

### DIFF
--- a/tests/foreman/cli/test_bootstrap_script.py
+++ b/tests/foreman/cli/test_bootstrap_script.py
@@ -5,12 +5,12 @@ from robottelo.test import CLITestCase
 
 
 class BootstrapScriptTestCase(CLITestCase):
-    """Test class for bootstrap scipt."""
+    """Test class for bootstrap script."""
 
-    @stubbed()
     @classmethod
     def setUpClass(cls):
-        """ create VM for testing """
+        """create VM for testing """
+        super(BootstrapScriptTestCase, cls).setUpClass()
 
     @tier1
     @stubbed()
@@ -127,7 +127,7 @@ class BootstrapScriptTestCase(CLITestCase):
         @Steps:
 
         1. create env without available sat tools repo
-           (AK or hostgroup being used dont provide CV having sattools)
+           (AK or hostgroup being used doesn't provide CV that have sattools)
         2. try to register a system
 
         @Assert: ends gracefully, reason displayed to user


### PR DESCRIPTION
I felt that can cause an issue when reviewed PR, but was not sure for 100%

Fixing:
```
Error Message:
collection failure

Stacktrace:

tests/foreman/cli/test_bootstrap_script.py:7: in <module>
    class BootstrapScriptTestCase(CLITestCase):
tests/foreman/cli/test_bootstrap_script.py:11: in BootstrapScriptTestCase
    @classmethod
robottelo/decorators.py:136: in wrapper
    return unittest2.skip(reason)(pytest.mark.stubbed(func))
../../shiningpanda/jobs/ad95a8e7/virtualenvs/d41d8cd9/lib/python2.7/site-packages/unittest2/case.py:107: in decorator
    @wraps(test_item)
/usr/lib64/python2.7/functools.py:33: in update_wrapper
    setattr(wrapper, attr, getattr(wrapped, attr))
E   AttributeError: MarkDecorator instance has no attribute '__name__'
```