### PR TITLE
Fix few API tests

### DIFF
--- a/tests/foreman/api/test_host.py
+++ b/tests/foreman/api/test_host.py
@@ -182,8 +182,17 @@ class HostTestCase(APITestCase):
 
         @assert: A host is created with expected subnet assigned
         """
-        subnet = entities.Subnet().create()
-        host = entities.Host(subnet=subnet).create()
+        org = entities.Organization().create()
+        loc = entities.Location(organization=[org]).create()
+        subnet = entities.Subnet(
+            location=[loc],
+            organization=[org],
+        ).create()
+        host = entities.Host(
+            location=loc,
+            organization=org,
+            subnet=subnet,
+        ).create()
         self.assertEqual(host.subnet.read().name, subnet.name)
 
     @run_only_on('sat')
@@ -560,8 +569,21 @@ class HostTestCase(APITestCase):
 
         @assert: A host is updated with a new subnet
         """
-        host = entities.Host(subnet=entities.Subnet().create()).create()
-        new_subnet = entities.Subnet().create()
+        org = entities.Organization().create()
+        loc = entities.Location(organization=[org]).create()
+        old_subnet = entities.Subnet(
+            location=[loc],
+            organization=[org],
+        ).create()
+        host = entities.Host(
+            location=loc,
+            organization=org,
+            subnet=old_subnet,
+        ).create()
+        new_subnet = entities.Subnet(
+            location=[loc],
+            organization=[org],
+        ).create()
         host.subnet = new_subnet
         host = host.update(['subnet'])
         self.assertEqual(host.subnet.read().name, new_subnet.name)

--- a/tests/foreman/api/test_syncplan.py
+++ b/tests/foreman/api/test_syncplan.py
@@ -178,7 +178,7 @@ class SyncPlanCreateTestCase(APITestCase):
                     sync_date=syncdate,
                 ).create()
                 self.assertEqual(
-                    syncdate.strftime('%Y-%m-%dT%H:%M:%SZ'),
+                    syncdate.strftime('%Y-%m-%d %H:%M:%S UTC'),
                     sync_plan.sync_date
                 )
 
@@ -342,7 +342,7 @@ class SyncPlanUpdateTestCase(APITestCase):
             with self.subTest(syncdate):
                 sync_plan.sync_date = syncdate
                 self.assertEqual(
-                    syncdate.strftime('%Y-%m-%dT%H:%M:%SZ'),
+                    syncdate.strftime('%Y-%m-%d %H:%M:%S UTC'),
                     sync_plan.update(['sync_date']).sync_date
                 )
 

--- a/tests/foreman/cli/test_template.py
+++ b/tests/foreman/cli/test_template.py
@@ -64,7 +64,7 @@ class TemplateTestCase(CLITestCase):
 
     @run_only_on('sat')
     @tier1
-    def test_positive_create_locked(self):
+    def test_negative_create_locked(self):
         """Check that locked Template cannot be created
 
         @Feature: Template - Create


### PR DESCRIPTION
Validation for Subnet entity was added, now Subnet needs to belong the same
organization and location as Host for association.

SyncPlan's entity sync_date format has changed a bit, updating tests accordingly.

```python
py.test tests/foreman/api/test_host.py -k 'test_positive_create_with_subnet or test_positive_update_subnet' -n 4
================================ test session starts =================================
platform linux2 -- Python 2.7.10, pytest-2.8.7, py-1.4.31, pluggy-0.3.1
rootdir: /home/andrii/workspace/robottelo, inifile: 
plugins: xdist-1.13.1, repeat-0.2
gw0 [2] / gw1 [2] / gw2 [2] / gw3 [2]
scheduling tests via LoadScheduling
..
============================= 2 passed in 61.04 seconds ==============================

py.test tests/foreman/api/test_syncplan.py -k 'test_positive_create_with_sync_date or test_positive_update_sync_date' -n 4
================================ test session starts =================================
platform linux2 -- Python 2.7.10, pytest-2.8.7, py-1.4.31, pluggy-0.3.1
rootdir: /home/andrii/workspace/robottelo, inifile: 
plugins: xdist-1.13.1, repeat-0.2
gw0 [2] / gw1 [2] / gw2 [2] / gw3 [2]
scheduling tests via LoadScheduling
..
============================= 2 passed in 35.73 seconds ==============================
```