### PR TITLE
Add webdriver_desired_capabilities setting

### DIFF
--- a/robottelo.properties.sample
+++ b/robottelo.properties.sample
@@ -58,12 +58,26 @@ ssh_key=
 # Binary location for selected wedriver
 # webdriver_binary=/usr/bin/firefox
 # webdriver_binary=/usr/bin/chromedriver
-# cdn=true
-# Run one datapoint or multiple datapoints for tests
-# run_one_datapoint=false
+
+# webdriver_desired_capabilities accepts extra configuration to be passed to
+# saucelabs in order to configure the test options. You can use the platform
+# configurator (see link below) to get the information about the environment
+# you want to test.
+# https://wiki.saucelabs.com/display/DOCS/Platform+Configurator/
+# Or you can visit
+# https://wiki.saucelabs.com/display/DOCS/Test+Configuration+Options for a
+# complete set of options.
+# PS.: the base DesiredCapabilities dict will be get by the browser
+# specified by webdriver config. If you override browserName then that
+# browser will be used instead.
+#webdriver_desired_capabilities=platform=OS X 10.11,version=44.0,...
 
 # saucelabs_user=
 # saucelabs_key=
+
+# cdn=true
+# Run one datapoint or multiple datapoints for tests
+# run_one_datapoint=false
 
 # Provide link to rhel6/7 repo here, as puppet rpm would require packages from
 # RHEL 6/7 repo and syncing the entire repo on the fly would take longer for

--- a/robottelo/config/casts.py
+++ b/robottelo/config/casts.py
@@ -70,3 +70,31 @@ class Tuple(List):
     """
     def __call__(self, value):
         return tuple(super(Tuple, self).__call__(value))
+
+
+class Dict(List):
+    """Cast a comma separated list of key=value to a dict.
+
+    :param str value: A comma separated string to cast to a dict.
+    """
+    def __call__(self, value):
+        return dict(v.split('=') for v in super(Dict, self).__call__(value))
+
+
+class WebdriverDesiredCapabilities(Dict):
+    """Cast a comma separated list of key=value to a
+    webdriver.DesiredCapabilities dict.
+
+    Convert values ``true`` and ``false`` (ignore case) to a proper boolean.
+
+    :param str value: A comma separated string to cast to a
+        webdriver.DesiredCapabilities dict.
+    """
+    def __call__(self, value):
+        desired_capabilities = super(
+            WebdriverDesiredCapabilities, self).__call__(value)
+        for k, v in desired_capabilities.items():
+            v = v.lower()
+            if v in ('true', 'false'):
+                desired_capabilities[k] = v == 'true'
+        return desired_capabilities

--- a/robottelo/config/settings.py
+++ b/robottelo/config/settings.py
@@ -43,9 +43,11 @@ class INIReader(object):
     """ConfigParser wrapper able to cast value when reading INI options."""
     # Helper casters
     cast_boolean = casts.Boolean()
+    cast_dict = casts.Dict()
     cast_list = casts.List()
     cast_logging_level = casts.LoggingLevel()
     cast_tuple = casts.Tuple()
+    cast_webdriver_desired_capabilities = casts.WebdriverDesiredCapabilities()
 
     def __init__(self, path):
         self.config_parser = ConfigParser()
@@ -78,6 +80,8 @@ class INIReader(object):
             if cast is not None:
                 if cast is bool:
                     value = self.cast_boolean(value)
+                elif cast is dict:
+                    value = self.cast_dict(value)
                 elif cast is list:
                     value = self.cast_list(value)
                 elif cast is tuple:
@@ -539,6 +543,7 @@ class Settings(object):
         self.verbosity = None
         self.webdriver = None
         self.webdriver_binary = None
+        self.webdriver_desired_capabilities = None
 
         # Features
         self.clients = ClientsSettings()
@@ -647,6 +652,12 @@ class Settings(object):
             'robottelo', 'saucelabs_key', None)
         self.webdriver_binary = self.reader.get(
             'robottelo', 'webdriver_binary', None)
+        self.webdriver_desired_capabilities = self.reader.get(
+            'robottelo',
+            'webdriver_desired_capabilities',
+            None,
+            cast=INIReader.cast_webdriver_desired_capabilities
+        )
         self.window_manager_command = self.reader.get(
             'robottelo', 'window_manager_command', None)
 

--- a/robottelo/ui/browser.py
+++ b/robottelo/ui/browser.py
@@ -53,12 +53,15 @@ def browser():
             return webdriver.Remote()
     elif settings.browser == 'saucelabs':
         if webdriver_name == 'chrome':
-            desired_capabilities = webdriver.DesiredCapabilities.CHROME
+            desired_capabilities = webdriver.DesiredCapabilities.CHROME.copy()
         elif webdriver_name == 'ie':
             desired_capabilities = (
-                webdriver.DesiredCapabilities.INTERNETEXPLORER)
+                webdriver.DesiredCapabilities.INTERNETEXPLORER.copy())
         else:
-            desired_capabilities = webdriver.DesiredCapabilities.FIREFOX
+            desired_capabilities = webdriver.DesiredCapabilities.FIREFOX.copy()
+        if settings.webdriver_desired_capabilities:
+            desired_capabilities.update(
+                settings.webdriver_desired_capabilities)
         return webdriver.Remote(
             command_executor=_sauce_ondemand_url(
                 settings.saucelabs_user, settings.saucelabs_key),

--- a/tests/robottelo/test_config_casts.py
+++ b/tests/robottelo/test_config_casts.py
@@ -1,0 +1,112 @@
+"""Tests for module ``robottelo.config.casts``."""
+import logging
+
+from robottelo.config import casts
+from unittest2 import TestCase
+
+
+class BooleanTestCase(TestCase):
+    def setUp(self):
+        self.cast_boolean = casts.Boolean()
+
+    def test_cast_true(self):
+        self.assertTrue(all([
+            self.cast_boolean(value)
+            for value in ('1', 'yes', 'true', 'on', 'yEs', 'True', 'On')
+        ]))
+
+    def test_cast_false(self):
+        self.assertFalse(any([
+            self.cast_boolean(value)
+            for value in ('0', 'no', 'false', 'off', 'No', 'False', 'OfF')
+        ]))
+
+    def test_cast_type(self):
+        self.assertIsInstance(self.cast_boolean('true'), bool)
+
+    def test_raise_value_error(self):
+        with self.assertRaises(ValueError):
+            self.cast_boolean('notaboolean')
+
+
+class ListTestCase(TestCase):
+    def setUp(self):
+        self.cast_list = casts.List()
+
+    def test_cast_list(self):
+        self.assertEqual(
+            self.cast_list('a, "b,c", d'),
+            ['a', 'b,c', 'd']
+        )
+
+    def test_cast_type(self):
+        self.assertIsInstance(self.cast_list('a,b,c'), list)
+
+
+class TupleTestCase(TestCase):
+    def setUp(self):
+        self.cast_tuple = casts.Tuple()
+
+    def test_cast_list(self):
+        self.assertEqual(
+            self.cast_tuple('a, "b,c", d'),
+            ('a', 'b,c', 'd')
+        )
+
+    def test_cast_type(self):
+        self.assertIsInstance(self.cast_tuple('a,b,c'), tuple)
+
+
+class LoggingLevelTestCase(TestCase):
+    def setUp(self):
+        self.cast_logging_level = casts.LoggingLevel()
+
+    def test_cast_logging_level(self):
+        self.assertEqual([
+            logging.CRITICAL,
+            logging.DEBUG,
+            logging.ERROR,
+            logging.INFO,
+            logging.WARNING,
+        ], [
+            self.cast_logging_level(value)
+            for value in (
+                'critical',
+                'debug',
+                'error',
+                'info',
+                'warning',
+            )
+        ])
+
+    def test_raise_value_error(self):
+        with self.assertRaises(ValueError):
+            self.cast_logging_level('notalogginglevel')
+
+
+class DictTestCase(TestCase):
+    def setUp(self):
+        self.cast_dict = casts.Dict()
+
+    def test_cast_dict(self):
+        self.assertEqual(
+            self.cast_dict('a=1,"b=2,3,4",c=5'),
+            {'a': '1', 'b': '2,3,4', 'c': '5'}
+        )
+
+    def test_cast_type(self):
+        self.assertIsInstance(self.cast_dict('a=1,b=2,c=3'), dict)
+
+
+class WebdriverDesiredCapabilitiesTestCase(TestCase):
+    def setUp(self):
+        self.cast_desired_capabilities = casts.WebdriverDesiredCapabilities()
+
+    def test_cast_dict(self):
+        self.assertEqual(
+            self.cast_desired_capabilities('a=TruE,"b=2,3,4",c=FaLse'),
+            {'a': True, 'b': '2,3,4', 'c': False}
+        )
+
+    def test_cast_type(self):
+        self.assertIsInstance(self.cast_desired_capabilities('a=1'), dict)


### PR DESCRIPTION
Add webdriver_desired_capabilities setting in order to allow specifying
additional platform configuration for saucelabs browser.

Create Dict and WebdriverDesiredCapabilities casts types for the
configuration in order to support the definition of the added setting.

Also tests for the `robottelo.config.casts` module. They cover 100% of
the module.

Thanks to @rochacbruno for the pair programming session and also for the design of the solution.