### PR TITLE
Update cli puppet module test_positive_info

### DIFF
--- a/tests/foreman/cli/test_puppetmodule.py
+++ b/tests/foreman/cli/test_puppetmodule.py
@@ -60,4 +60,4 @@ class PuppetModuleTestCase(CLITestCase):
                 {'id': return_value[i]['id']},
                 output_format='json'
             )
-            self.assertEqual(result['ID'], return_value[i]['id'])
+            self.assertEqual(result['ID'], int(return_value[i]['id']))


### PR DESCRIPTION
Make sure to match the python type when doing the assertion. This because JSON
output returns integers for integers instead of strings when not using JSON
output.