### PR TITLE
Add automated tests for repository export via CLI

### DIFF
--- a/docs/api/robottelo.cli.rst
+++ b/docs/api/robottelo.cli.rst
@@ -170,6 +170,11 @@ Submodules:
 
 .. automodule:: robottelo.cli.role
 
+:mod:`robottelo.cli.settings`
+-----------------------------
+
+.. automodule:: robottelo.cli.settings
+
 :mod:`robottelo.cli.smartclass`
 -------------------------------
 

--- a/robottelo/cli/factory.py
+++ b/robottelo/cli/factory.py
@@ -658,6 +658,7 @@ def make_repository(options=None):
         u'checksum-type': None,
         u'content-type': u'yum',
         u'docker-upstream-name': None,
+        u'download-policy': None,
         u'gpg-key': None,
         u'gpg-key-id': None,
         u'label': None,

--- a/robottelo/cli/repository.py
+++ b/robottelo/cli/repository.py
@@ -32,6 +32,7 @@ class Repository(Base):
 
     @classmethod
     def create(cls, options=None):
+        """Create a custom repository"""
         cls.command_requires_org = False
 
         try:
@@ -42,7 +43,18 @@ class Repository(Base):
         return result
 
     @classmethod
+    def export(cls, options=None):
+        """Export a repository"""
+        cls.command_sub = 'export'
+        return cls.execute(
+            cls._construct_command(options),
+            output_format='csv',
+            ignore_stderr=True,
+        )
+
+    @classmethod
     def info(cls, options=None):
+        """Show a custom repository"""
         cls.command_requires_org = False
 
         try:

--- a/robottelo/cli/settings.py
+++ b/robottelo/cli/settings.py
@@ -1,0 +1,32 @@
+# -*- encoding: utf-8 -*-
+"""
+Usage::
+
+    hammer settings [OPTIONS] SUBCOMMAND [ARG] ...
+
+Parameters::
+
+    SUBCOMMAND                    subcommand
+    [ARG] ...                     subcommand arguments
+
+Subcommands::
+
+    list                          List all settings
+    set                           Update a setting
+
+"""
+
+from robottelo.cli.base import Base
+
+
+class Settings(Base):
+    """Manipulates Foreman's settings."""
+
+    command_base = 'settings'
+
+    @classmethod
+    def set(cls, options=None):
+        """Update a setting"""
+        cls.command_sub = 'set'
+
+        return cls.execute(cls._construct_command(options))

--- a/tests/foreman/cli/test_satellitesync.py
+++ b/tests/foreman/cli/test_satellitesync.py
@@ -1,8 +1,199 @@
 ﻿# -*- encoding: utf-8 -*-
 """Test class for InterSatellite Sync"""
 
-from robottelo.decorators import run_only_on, stubbed, tier3
+from fauxfactory import gen_string
+from robottelo import manifests, ssh
+from robottelo.constants import (
+    ENVIRONMENT,
+    PRDS,
+    REPOS,
+    REPOSET,
+)
+from robottelo.cli.factory import (
+    make_org,
+    make_product,
+    make_repository,
+)
+from robottelo.cli.repository import Repository
+from robottelo.cli.repository_set import RepositorySet
+from robottelo.cli.settings import Settings
+from robottelo.cli.subscription import Subscription
+from robottelo.decorators import run_only_on, skip_if_not_set, stubbed, tier3
 from robottelo.test import CLITestCase
+
+
+class RepositoryExportTestCase(CLITestCase):
+    """Tests for exporting a repository via CLI"""
+
+    export_dir = None
+    is_set_up = False
+    org = None
+
+    def setUp(self):
+        """Create a directory for export, configure permissions and satellite
+        settings
+        """
+        super(RepositoryExportTestCase, self).setUp()
+
+        if not RepositoryExportTestCase.is_set_up:
+            RepositoryExportTestCase.export_dir = gen_string('alphanumeric')
+
+            # Create a new 'export' directory on the Satellite system
+            result = ssh.command('mkdir /mnt/{0}'.format(self.export_dir))
+            self.assertEqual(result.return_code, 0)
+
+            result = ssh.command(
+                'chown foreman.foreman /mnt/{0}'.format(self.export_dir))
+            self.assertEqual(result.return_code, 0)
+
+            result = ssh.command(
+                'ls -Z /mnt/ | grep {0}'.format(self.export_dir))
+            self.assertEqual(result.return_code, 0)
+            self.assertGreaterEqual(len(result.stdout), 1)
+            self.assertIn('unconfined_u:object_r:mnt_t:s0', result.stdout[0])
+
+            # Fix SELinux policy for new directory
+            result = ssh.command(
+                'semanage fcontext -a -t foreman_var_run_t "/mnt/{0}(/.*)?"'
+                .format(self.export_dir)
+            )
+            self.assertEqual(result.return_code, 0)
+
+            result = ssh.command(
+                'restorecon -Rv /mnt/{0}'.format(self.export_dir))
+            self.assertEqual(result.return_code, 0)
+
+            # Assert that we have the correct policy
+            result = ssh.command(
+                'ls -Z /mnt/ | grep {0}'.format(self.export_dir))
+            self.assertEqual(result.return_code, 0)
+            self.assertGreaterEqual(len(result.stdout), 1)
+            self.assertIn(
+                'unconfined_u:object_r:foreman_var_run_t:s0', result.stdout[0])
+
+            # Update the 'pulp_export_destination' settings to new directory
+            Settings.set({
+                'name': 'pulp_export_destination',
+                'value': '/mnt/{0}'.format(self.export_dir),
+            })
+            # Create an organization to reuse in tests
+            RepositoryExportTestCase.org = make_org()
+
+            RepositoryExportTestCase.is_set_up = True
+
+    @classmethod
+    def tearDownClass(cls):
+        """Remove the export directory with all exported repository archives"""
+        ssh.command(
+            'rm -rf /mnt/{0}'.format(RepositoryExportTestCase.export_dir))
+        super(RepositoryExportTestCase, cls).tearDownClass()
+
+    @tier3
+    def test_positive_export_custom_product(self):
+        """Export a repository from the custom product
+
+        @Feature: Repository - Export
+
+        @Assert: Repository was successfully exported, rpm files are present on
+        satellite machine
+        """
+        # Create custom product and repository
+        product = make_product({'organization-id': self.org['id']})
+        repo = make_repository({
+            'download-policy': 'immediate',
+            'organization-id': self.org['id'],
+            'product-id': product['id'],
+        })
+        repo_export_dir = '/mnt/{0}/{1}-{2}-{3}/{1}/{4}/custom/{2}/{3}'.format(
+            self.export_dir,
+            self.org['label'],
+            product['label'],
+            repo['label'],
+            ENVIRONMENT,
+        )
+
+        # Export the repository
+        Repository.export({'id': repo['id']})
+
+        # Verify export directory is empty
+        result = ssh.command('ls -l {0} | grep .rpm'.format(repo_export_dir))
+        self.assertEqual(len(result.stdout), 0)
+
+        # Synchronize the repository
+        Repository.synchronize({'id': repo['id']})
+
+        # Export the repository once again
+        Repository.export({'id': repo['id']})
+
+        # Verify RPMs were successfully exported
+        result = ssh.command('ls -l {0} | grep .rpm'.format(repo_export_dir))
+        self.assertEqual(result.return_code, 0)
+        self.assertGreaterEqual(len(result.stdout), 1)
+
+    @skip_if_not_set('fake_manifest')
+    @tier3
+    def test_positive_export_rh_product(self):
+        """Export a repository from the Red Hat product
+
+        @Feature: Repository - Export
+
+        @Assert: Repository was successfully exported, rpm files are present on
+        satellite machine
+        """
+        # Enable RH repository
+        with manifests.clone() as manifest:
+            ssh.upload_file(manifest.content, manifest.filename)
+        Subscription.upload({
+            'file': manifest.filename,
+            'organization-id': self.org['id'],
+        })
+        RepositorySet.enable({
+            'basearch': 'x86_64',
+            'name': REPOSET['rhva6'],
+            'organization-id': self.org['id'],
+            'product': PRDS['rhel'],
+            'releasever': '6Server',
+        })
+        repo = Repository.info({
+            'name': REPOS['rhva6']['name'],
+            'organization-id': self.org['id'],
+            'product': PRDS['rhel'],
+        })
+        repo_export_dir = (
+            '/mnt/{0}/{1}-{2}-{3}/{1}/{4}/content/dist/rhel/server/6/6Server/'
+            'x86_64/rhev-agent/3/os'
+            .format(
+                self.export_dir,
+                self.org['label'],
+                PRDS['rhel'].replace(' ', '_'),
+                repo['label'],
+                ENVIRONMENT,
+            )
+        )
+
+        # Update the download policy to 'immediate'
+        Repository.update({
+            'download-policy': 'immediate',
+            'id': repo['id'],
+        })
+
+        # Export the repository
+        Repository.export({'id': repo['id']})
+
+        # Verify export directory is empty
+        result = ssh.command('ls -l {0} | grep .rpm'.format(repo_export_dir))
+        self.assertEqual(len(result.stdout), 0)
+
+        # Synchronize the repository
+        Repository.synchronize({'id': repo['id']})
+
+        # Export the repository once again
+        Repository.export({'id': repo['id']})
+
+        # Verify RPMs were successfully exported
+        result = ssh.command('ls -l {0} | grep .rpm'.format(repo_export_dir))
+        self.assertEqual(result.return_code, 0)
+        self.assertGreaterEqual(len(result.stdout), 1)
 
 
 class InterSatelliteSyncTestCase(CLITestCase):


### PR DESCRIPTION
Closes #3357

```python
py.test tests/foreman/cli/test_repository.py -k 'RepositoryExportTestCase'    
============================= test session starts ==============================
platform linux2 -- Python 2.7.5, pytest-2.9.1, py-1.4.31, pluggy-0.3.1
rootdir: /home/andriy/Downloads/robottelo, inifile: 
plugins: xdist-1.14
collected 32 items 

tests/foreman/cli/test_repository.py ..

============= 30 tests deselected by '-kRepositoryExportTestCase' ==============
================== 2 passed, 30 deselected in 238.94 seconds ===================
```