### PR TITLE
Fix CLI content view lce remove tests

### DIFF
--- a/tests/foreman/cli/test_contentview.py
+++ b/tests/foreman/cli/test_contentview.py
@@ -456,7 +456,6 @@ class ContentViewTestCase(CLITestCase):
         ContentView.remove({
             u'id': new_cv['id'],
             u'environment-ids': env['id'],
-            u'organization-id': new_org['id'],
         })
         new_cv = ContentView.info({u'id': new_cv['id']})
         self.assertEqual(len(new_cv['lifecycle-environments']), 0)
@@ -570,8 +569,7 @@ class ContentViewTestCase(CLITestCase):
 
         ContentView.remove({
             u'environment-ids': env[0]['id'],
-            u'name': source_cv['name'],
-            u'organization': new_org['name'],
+            u'id': source_cv['id'],
             u'system-content-view-id': destination_cv['id'],
             u'system-environment-id': env[1]['id'],
         })
@@ -604,7 +602,6 @@ class ContentViewTestCase(CLITestCase):
         ContentView.remove({
             u'content-view-version-ids': cvv['id'],
             u'id': new_cv['id'],
-            u'organization-id': new_org['id'],
         })
         new_cv = ContentView.info({u'id': new_cv['id']})
         self.assertEqual(len(new_cv['versions']), 0)


### PR DESCRIPTION
For some reason hammer started failing to remove a lce from cv when both cv id and org id are specified. I've submitted  [BZ1325113](https://bugzilla.redhat.com/show_bug.cgi?id=1325113), but specifying both cv id and org id is not needed - cv id is unique and enough to determine desired cv. 
```python
py.test -v tests/foreman/cli/test_contentview.py -k 'test_positive_remove_lce_by_id or test_positive_remove_version_by_id'
================================ test session starts =================================
platform linux2 -- Python 2.7.10, pytest-2.8.7, py-1.4.31, pluggy-0.3.1 -- /home/andrii/env/bin/python
cachedir: .cache
rootdir: /home/andrii/workspace/robottelo, inifile: 
plugins: xdist-1.13.1, repeat-0.2
collected 49 items 

tests/foreman/cli/test_contentview.py::ContentViewTestCase::test_positive_remove_lce_by_id <- robottelo/decorators.py PASSED
tests/foreman/cli/test_contentview.py::ContentViewTestCase::test_positive_remove_lce_by_id_and_reassign_ak <- robottelo/decorators.py PASSED
tests/foreman/cli/test_contentview.py::ContentViewTestCase::test_positive_remove_lce_by_id_and_reassign_chost <- robottelo/decorators.py PASSED
tests/foreman/cli/test_contentview.py::ContentViewTestCase::test_positive_remove_version_by_id <- robottelo/decorators.py PASSED

 45 tests deselected by '-ktest_positive_remove_lce_by_id or test_positive_remove_version_by_id' 
===================== 4 passed, 45 deselected in 892.07 seconds ======================
```