### PR TITLE
Fixes #3375 - utf-8-encode the string before url-quoting

### DIFF
--- a/robottelo/datafactory.py
+++ b/robottelo/datafactory.py
@@ -399,8 +399,8 @@ def valid_http_credentials(url_encoded=False):
     ]
     if url_encoded:
         return [{
-                u'login': quote_plus(cred['login'], ''),
-                u'pass': quote_plus(cred['pass'], ''),
+                u'login': quote_plus(cred['login'].encode('utf-8'), ''),
+                u'pass': quote_plus(cred['pass'].encode('utf-8'), ''),
                 u'http_valid': cred['http_valid'],
                 } for cred in credentials]
     else:


### PR DESCRIPTION
fixes #3375 
This piece will encode (to utf-8) the generated unicode string before passing it to `urllib.quote` function.

before:
```python
In [1]: import urllib

In [2]: urllib.quote(u'čau')
---------------------------------------------------------------------------
KeyError                                  Traceback (most recent call last)
<ipython-input-2-f05e208c9b8b> in <module>()
----> 1 urllib.quote(u'čau')

/usr/lib64/python2.7/urllib.pyc in quote(s, safe)
   1301     if not s.rstrip(safe):
   1302         return s
-> 1303     return ''.join(map(quoter, s))
   1304 
   1305 def quote_plus(s, safe=''):

KeyError: u'\u010d'
```
after:
```python
In [1]: import urllib

In [2]: urllib.quote(u'čau'.encode('utf-8'))
Out[2]: '%C4%8Dau'
```