### PR TITLE
Fixing docstring warning

### DIFF
--- a/robottelo/datafactory.py
+++ b/robottelo/datafactory.py
@@ -40,7 +40,7 @@ def generate_strings_list(length=None, exclude_types=None, bug_id=None,
     :param int length: Specifies the length of the strings to be
         be generated. If the len1 is None then the list is
         returned with string types of random length.
-    :param list exclude_types: Specify a list of data types to be removed from
+    :param exclude_types: Specify a list of data types to be removed from
         generated list. example: exclude_types=['html', 'cjk']
     :param int bug_id: Specify any bug id that is associated to the datapoint
         specified in remove_str.  This will be used only when remove_str is


### PR DESCRIPTION
We have next warning for our documentation:
```
../robottelo/robottelo/datafactory.py:docstring of robottelo.datafactory.generate_strings_list:None: WARNING: more than one target found for cross-reference u'list': robottelo.cli.docker.DockerRegistry.list, robottelo.cli.docker.DockerImage.list, robottelo.cli.docker.DockerTag.list, robottelo.cli.lifecycleenvironment.LifecycleEnvironment.list, robottelo.cli.docker.DockerContainer.list, robottelo.cli.base.Base.list
```

Removing that reference as description is self-informative enough

Tried some alternatives, but neither of them helps:
`list of str`, `list[str]`, `list(str)` or `list of (str)`, `List` and etc