### PR TITLE
Fixing content hosts tests according to 6.2

### DIFF
--- a/robottelo/datafactory.py
+++ b/robottelo/datafactory.py
@@ -195,15 +195,18 @@ def valid_hosts_list(domain_length=10):
     Note::
     Host name format stored in db is 'fqdn=' + host_name + '.' + domain_name
     Host name max length is: 255 - 'fqdn=' - '.' - domain name length
-    (default is 10) = 239 chars (by default).
+    (default is 10) = 239 chars (by default). Name should be transformed into
+    lower case
 
     :param int domain_length: Domain name length (default is 10).
     :return: Returns the valid host names list
     """
     return [
         gen_string(
-            'alphanumeric', random.randint(1, (255 - 6 - domain_length))),
-        gen_string('alpha', random.randint(1, (255 - 6 - domain_length))),
+            'alphanumeric', random.randint(1, (255 - 6 - domain_length))
+        ).lower(),
+        gen_string(
+            'alpha', random.randint(1, (255 - 6 - domain_length))).lower(),
         gen_string('numeric', random.randint(1, (255 - 6 - domain_length))),
     ]
 

--- a/tests/foreman/api/test_host.py
+++ b/tests/foreman/api/test_host.py
@@ -109,7 +109,7 @@ class HostTestCase(APITestCase):
                 host = entities.Host(name=name).create()
                 self.assertEqual(
                     host.name,
-                    '{0}.{1}'.format(name, host.domain.read().name).lower()
+                    '{0}.{1}'.format(name, host.domain.read().name)
                 )
 
     @run_only_on('sat')
@@ -373,7 +373,7 @@ class HostTestCase(APITestCase):
                 host = host.update(['name'])
                 self.assertEqual(
                     host.name,
-                    '{0}.{1}'.format(new_name, host.domain.read().name).lower()
+                    '{0}.{1}'.format(new_name, host.domain.read().name)
                 )
 
     @run_only_on('sat')

--- a/tests/foreman/cli/test_host.py
+++ b/tests/foreman/cli/test_host.py
@@ -93,7 +93,7 @@ class HostCreateTestCase(CLITestCase):
                     u'root-pass': host.root_pass,
                 })
                 self.assertEqual(
-                    '{0}.{1}'.format(name, host.domain.read().name).lower(),
+                    '{0}.{1}'.format(name, host.domain.read().name),
                     result['name'],
                 )
 
@@ -235,10 +235,8 @@ class HostUpdateTestCase(CLITestCase):
                 self.host = Host.info({'id': self.host['id']})
                 self.assertEqual(
                     u'{0}.{1}'.format(
-                        new_name,
-                        self.host['network']['domain'],
-                    ).lower(),
-                    self.host['name'],
+                        new_name, self.host['network']['domain']),
+                    self.host['name']
                 )
 
     @tier1
@@ -258,13 +256,10 @@ class HostUpdateTestCase(CLITestCase):
                 })
                 self.host = Host.info({
                     'name': u'{0}.{1}'.format(
-                        new_name, self.host['network']['domain']).lower(),
-                })
+                        new_name, self.host['network']['domain'])})
                 self.assertEqual(
                     u'{0}.{1}'.format(
-                        new_name,
-                        self.host['network']['domain'],
-                    ).lower(),
+                        new_name, self.host['network']['domain']),
                     self.host['name'],
                 )
 


### PR DESCRIPTION
Should fix all failures that we have for content hosts for CLI
```
nosetests tests/foreman/cli/test_contenthost.py
......S.........SS
----------------------------------------------------------------------
Ran 18 tests in 759.450s

OK (SKIP=3)
```
```
nosetests tests/foreman/api/test_host.py -m test_positive_create_with_name
.
----------------------------------------------------------------------
Ran 1 test in 48.200s

OK
```
```
nosetests tests/foreman/api/test_host.py -m test_positive_update_name
.
----------------------------------------------------------------------
Ran 1 test in 23.322s

OK
```

Refer https://bugzilla.redhat.com/show_bug.cgi?id=1326357 for more details