### PR TITLE
Fixing gpgkey and host_collection tests according to 6.2

### DIFF
--- a/robottelo/ui/locators.py
+++ b/robottelo/ui/locators.py
@@ -654,6 +654,12 @@ common_locators = LocatorDict({
         By.XPATH, "//div[contains(@class, 'alert-success')]"),
     "alert.error": (
         By.XPATH, "//div[contains(@class, 'alert-danger')]"),
+    "alert.success_sub_form": (
+        By.XPATH,
+        "//div[@ng-hide]//div[contains(@class, 'alert-success')]"),
+    "alert.error_sub_form": (
+        By.XPATH,
+        "//div[@ng-hide]//div[contains(@class, 'alert-danger')]"),
 
     "selected_entity": (
         By.XPATH,
@@ -742,13 +748,16 @@ common_locators = LocatorDict({
         ("//div[@class='ms-selection']//ul[@class='ms-list']/li"
          "/span[contains(.,'%s')]/..")),
     "usage_limit": (
-        By.XPATH, "//input[contains(@ng-model, 'max_content_hosts')]"),
+        By.XPATH,
+        "//input[contains(@ng-model, 'max')"
+        "and contains(@ng-model, 'hosts')]"),
     "usage_limit_checkbox": (
         By.XPATH,
-        "//input[contains(@ng-model, 'unlimited_content_hosts')]"),
+        "//input[contains(@ng-model, 'unlimited')"
+        "and contains(@ng-model, 'hosts')]"),
     "invalid_limit": (
         By.XPATH,
-        "//input[@id='max_content_hosts' and contains(@class, 'ng-invalid')]"),
+        "//input[contains(@id, 'max') and contains(@class, 'ng-invalid')]"),
 })
 
 locators = LocatorDict({
@@ -2541,15 +2550,15 @@ locators = LocatorDict({
         "/span[contains(., '%s')]"),
     "hostcollection.edit_limit": (
         By.XPATH,
-        ("//div[@bst-edit-custom='hostCollection.max_content_hosts']"
+        ("//div[@bst-edit-custom='hostCollection.max_hosts']"
          "//div/span/i")),
     "hostcollection.save_limit": (
         By.XPATH,
-        ("//div[@bst-edit-custom='hostCollection.max_content_hosts']"
+        ("//div[@bst-edit-custom='hostCollection.max_hosts']"
          "//button[@ng-click='save()']")),
     "hostcollection.limit_field": (
         By.XPATH,
-        "//div[@bst-edit-custom='hostCollection.max_content_hosts']"
+        "//div[@bst-edit-custom='hostCollection.max_hosts']"
         "//span[text()='%s']"),
     "hostcollection.remove": (
         By.XPATH, "//button[@ng-click='openModal()']"),

--- a/tests/foreman/ui/test_gpgkey.py
+++ b/tests/foreman/ui/test_gpgkey.py
@@ -285,7 +285,7 @@ class GPGKey(UITestCase):
             self.assertIsNotNone(self.gpgkey.search(name))
             self.gpgkey.update(name, new_name)
             self.assertIsNotNone(self.gpgkey.wait_until_element(
-                common_locators['alert.success']
+                common_locators['alert.success_sub_form']
             ))
 
     @run_only_on('sat')
@@ -311,7 +311,7 @@ class GPGKey(UITestCase):
             self.assertIsNotNone(self.gpgkey.search(name))
             self.gpgkey.update(name, new_key=new_key_path)
             self.assertIsNotNone(self.gpgkey.wait_until_element(
-                common_locators['alert.success']
+                common_locators['alert.success_sub_form']
             ))
 
     @run_only_on('sat')
@@ -336,7 +336,7 @@ class GPGKey(UITestCase):
             self.assertIsNotNone(self.gpgkey.search(name))
             self.gpgkey.update(name, new_name)
             self.assertIsNotNone(self.gpgkey.wait_until_element(
-                common_locators['alert.success']
+                common_locators['alert.success_sub_form']
             ))
 
     @run_only_on('sat')
@@ -361,7 +361,7 @@ class GPGKey(UITestCase):
             self.assertIsNotNone(self.gpgkey.search(name))
             self.gpgkey.update(name, new_key=new_key_path)
             self.assertIsNotNone(self.gpgkey.wait_until_element(
-                common_locators['alert.success']
+                common_locators['alert.success_sub_form']
             ))
 
     # Negative Update
@@ -390,10 +390,9 @@ class GPGKey(UITestCase):
                     length=300, **GEN_STRING_LIST_ARGS):
                 with self.subTest(new_name):
                     self.gpgkey.update(name, new_name)
-                    self.assertIsNotNone(
-                        self.gpgkey.wait_until_element(
-                            common_locators['alert.error'])
-                    )
+                    self.assertIsNotNone(self.gpgkey.wait_until_element(
+                        common_locators['alert.error_sub_form']
+                    ))
                     self.assertIsNone(self.gpgkey.search(new_name))
 
     @run_only_on('sat')

--- a/tests/foreman/ui/test_hostcollection.py
+++ b/tests/foreman/ui/test_hostcollection.py
@@ -161,7 +161,7 @@ class HostCollectionTestCase(UITestCase):
                     self.hostcollection.update(name, description=new_desc)
                     self.assertIsNotNone(
                         self.hostcollection.wait_until_element(
-                            common_locators['alert.success'])
+                            common_locators['alert.success_sub_form'])
                     )
                     self.assertTrue(self.hostcollection.validate_field_value(
                         name, 'description', new_desc))
@@ -181,7 +181,7 @@ class HostCollectionTestCase(UITestCase):
             self.assertIsNotNone(self.hostcollection.search(name))
             self.hostcollection.update(name, limit='25')
             self.assertIsNotNone(self.hostcollection.wait_until_element(
-                common_locators['alert.success']))
+                common_locators['alert.success_sub_form']))
             self.assertTrue(self.hostcollection.validate_field_value(
                 name, 'limit', '25'))
 
@@ -200,7 +200,7 @@ class HostCollectionTestCase(UITestCase):
             self.assertIsNotNone(self.hostcollection.search(name))
             self.hostcollection.update(name, limit='Unlimited')
             self.assertIsNotNone(self.hostcollection.wait_until_element(
-                common_locators['alert.success']))
+                common_locators['alert.success_sub_form']))
             self.assertTrue(self.hostcollection.validate_field_value(
                 name, 'limit', 'Unlimited'))
 
@@ -222,7 +222,7 @@ class HostCollectionTestCase(UITestCase):
                     self.hostcollection.update(name, new_name=new_name)
                     self.assertIsNotNone(
                         self.hostcollection.wait_until_element(
-                            common_locators['alert.error'])
+                            common_locators['alert.error_sub_form'])
                     )
 
     @tier1
@@ -296,7 +296,7 @@ class HostCollectionTestCase(UITestCase):
                     self.hostcollection.copy(name, new_name)
                     self.assertIsNotNone(
                         self.hostcollection.wait_until_element(
-                            common_locators['alert.error'])
+                            common_locators['alert.error_sub_form'])
                     )
 
     @tier3
@@ -363,4 +363,4 @@ class HostCollectionTestCase(UITestCase):
             with self.assertRaises(UIError):
                 self.hostcollection.add_content_host(name, new_systems[1])
             self.assertIsNotNone(self.hostcollection.wait_until_element(
-                common_locators['alert.error']))
+                common_locators['alert.error_sub_form']))


### PR DESCRIPTION
We have changes to alerts and now we have two types of them for gpgkeys
```
nosetests tests/foreman/ui/test_gpgkey.py -m content
..ESS......
======================================================================
ERROR: Hosts can install packages using gpg key associated with
----------------------------------------------------------------------
Ran 11 tests in 1395.997s

FAILED (SKIP=2, errors=1)
```
One failure related to another issue