### PR TITLE
Dropped deprecated entities.System and used entities.Host instead

### DIFF
--- a/robottelo/performance/candlepin.py
+++ b/robottelo/performance/candlepin.py
@@ -105,13 +105,13 @@ class Candlepin(object):
         return cls.get_real_time(result.stderr)
 
     @classmethod
-    def single_delete(cls, uuid, thread_id):
-        """Delete system from subscription"""
+    def single_delete(cls, id, thread_id):
+        """Delete host from subscription"""
         start = time.time()
         response = requests.delete(
             urljoin(
                 settings.server.get_url(),
-                '/katello/api/systems/{0}'.format(uuid)
+                '/katello/api/hosts/{0}'.format(id)
             ),
             auth=settings.server.get_credentials(),
             verify=False
@@ -119,12 +119,12 @@ class Candlepin(object):
 
         if response.status_code != 204:
             LOGGER.error(
-                'Fail to delete {0} on thread-{1}!'.format(uuid, thread_id)
+                'Fail to delete {0} on thread-{1}!'.format(id, thread_id)
             )
             LOGGER.error(response.content)
         else:
             LOGGER.info(
-                "Delete {0} on thread-{1} successful!".format(uuid, thread_id)
+                "Delete {0} on thread-{1} successful!".format(id, thread_id)
             )
         end = time.time()
         LOGGER.info('real  {0}s'.format(end-start))

--- a/tests/foreman/api/test_contentview.py
+++ b/tests/foreman/api/test_contentview.py
@@ -40,13 +40,13 @@ class ContentViewTestCase(APITestCase):
 
     @tier3
     @run_only_on('sat')
-    def test_positive_subscribe_system(self):
-        """Subscribe a system to a content view.
+    def test_positive_subscribe_host(self):
+        """Subscribe a host to a content view
 
         @Feature: ContentView
 
-        @Assert: It is possible to create a system and set its
-        'content_view_id' attribute.
+        @Assert: It is possible to create a host and set its 'content_view_id'
+        facet attribute
         """
         # organization
         # ├── lifecycle environment
@@ -63,22 +63,24 @@ class ContentViewTestCase(APITestCase):
         self.assertEqual(len(content_view.version), 1)
         promote(content_view.version[0], lc_env.id)
 
-        # Create a system that is subscribed to the published and promoted
-        # content view. Associating this system with the organization and
-        # environment created above is not particularly important, but doing so
-        # means a shorter test where fewer entities are created, as
-        # System.organization and System.environment are required attributes.
-        system = entities.System(
-            content_view=content_view,
-            environment=lc_env,
+        # Create a host that is subscribed to the published and promoted
+        # content view
+        host = entities.Host(
+            content_facet_attributes={
+                'content_view_id': content_view.id,
+                'lifecycle_environment_id': lc_env.id,
+            },
             organization=org,
         ).create()
-
         # See BZ #1151240
-        self.assertEqual(system.content_view.id, content_view.id)
-        self.assertEqual(system.environment.id, lc_env.id)
+        self.assertEqual(
+            host.content_facet_attributes['content_view_id'], content_view.id)
+        self.assertEqual(
+            host.content_facet_attributes['lifecycle_environment_id'],
+            lc_env.id
+        )
         if not bz_bug_is_open(1223494):
-            self.assertEqual(system.organization.id, org.id)
+            self.assertEqual(host.organization.id, org.id)
 
     @tier2
     @run_only_on('sat')
@@ -1115,12 +1117,14 @@ class ContentViewTestCaseStub(APITestCase):
 
     @tier3
     @stubbed()
-    def test_positive_subscribe_system(self):
-        """
-        attempt to  subscribe systems to content view(s)
-        @feature: Content Views
-        @assert: Systems can be subscribed to content view(s)
-        @status: Manual
+    def test_positive_subscribe_host(self):
+        """Attempt to  subscribe hosts to content view(s)
+
+        @Feature: Content Views
+
+        @Assert: Hosts can be subscribed to content view(s)
+
+        @Status: Manual
         """
         # Notes:
         # this should be limited to only those content views
@@ -1135,11 +1139,12 @@ class ContentViewTestCaseStub(APITestCase):
 
     @tier3
     @stubbed()
-    def test_positive_subscribe_system_custom_cv(self):
-        """
-        attempt to  subscribe systems to content view(s)
-        @feature: Content Views
-        @assert: Systems can be subscribed to content view(s)
+    def test_positive_subscribe_host_custom_cv(self):
+        """Attempt to subscribe hosts to content view(s)
+
+        @Feature: Content Views
+
+        @Assert: Hosts can be subscribed to content view(s)
         """
         # This test is implemented in tests/foreman/smoke/test_api_smoke.py.
         # See the end of method TestSmoke.test_smoke.

--- a/tests/foreman/api/test_errata.py
+++ b/tests/foreman/api/test_errata.py
@@ -20,7 +20,7 @@ class ErrataTestCase(APITestCase):
 
         @Steps:
 
-        1. PUT /katello/api/systems/bulk/update_content
+        1. PUT /katello/api/hosts/bulk/update_content
 
         @Assert: errata is installed in the host-collection.
 
@@ -83,7 +83,7 @@ class ErrataTestCase(APITestCase):
 
     @stubbed()
     @tier3
-    def test_positive_list_affected_systems(self):
+    def test_positive_list_affected_hosts(self):
         """View a list of affected content hosts for an erratum
 
         @Feature: Errata
@@ -92,7 +92,7 @@ class ErrataTestCase(APITestCase):
 
         @Steps:
 
-        1. GET /katello/api/systems
+        1. GET /katello/api/hosts
 
         @Assert: List of affected content hosts for the given erratum is
         retrieved.
@@ -102,7 +102,7 @@ class ErrataTestCase(APITestCase):
 
     @stubbed()
     @tier3
-    def test_positive_filter_by_affected_systems(self):
+    def test_positive_filter_by_affected_hosts(self):
         """Filter errata list based on affected content hosts
 
         @Feature: Errata
@@ -173,7 +173,7 @@ class ErrataTestCase(APITestCase):
 
         @Steps:
 
-        1. GET /katello/api/systems
+        1. GET /katello/api/hosts
 
         @Assert: The available errata count is retrieved.
 
@@ -218,7 +218,7 @@ class ErrataTestCase(APITestCase):
 
         @Steps:
 
-        1. POST /katello/api/systems/bulk/available_incremental_updates
+        1. POST /katello/api/hosts/bulk/available_incremental_updates
 
         @Assert: Selected errata are applied to multiple content views in
         multiple environments.

--- a/tests/foreman/api/test_multiple_paths.py
+++ b/tests/foreman/api/test_multiple_paths.py
@@ -22,8 +22,7 @@ BZ_1118015_ENTITIES = (
     entities.GPGKey, entities.Host, entities.HostCollection,
     entities.HostGroup, entities.LibvirtComputeResource,
     entities.LifecycleEnvironment, entities.OperatingSystem, entities.Product,
-    entities.Repository, entities.Role, entities.Subnet, entities.System,
-    entities.User,
+    entities.Repository, entities.Role, entities.Subnet, entities.User,
 )
 BZ_1154156_ENTITIES = (entities.ConfigTemplate, entities.Host, entities.User)
 BZ_1187366_ENTITIES = (entities.LifecycleEnvironment, entities.Organization)
@@ -57,7 +56,6 @@ def valid_entities():
         entities.Repository,
         entities.Role,
         entities.Subnet,
-        entities.System,
         entities.TemplateKind,
         entities.User,
         entities.UserGroup,
@@ -84,9 +82,6 @@ def _get_readable_attributes(entity):
         del attributes['name']  # FIXME: "Foo" in, "foo.example.com" out.
     if isinstance(entity, entities.User):
         del attributes['password']
-    if isinstance(entity, entities.System) and bz_bug_is_open(1202917):
-        del attributes['facts']
-        del attributes['type']
 
     # Drop foreign key attributes.
     for field_name in attributes.keys():
@@ -159,7 +154,6 @@ class EntityTestCase(APITestCase):
             entities.LifecycleEnvironment,  # need organization_id
             entities.Product,  # need organization_id
             entities.Repository,  # need organization_id
-            entities.System,  # need organization_id
         )
         for entity_cls in set(valid_entities()) - set(exclude_list):
             with self.subTest(entity_cls):
@@ -471,10 +465,6 @@ class DoubleCheckTestCase(APITestCase):
                 if (entity_cls in BZ_1187366_ENTITIES and
                         bz_bug_is_open(1187366)):
                     self.skipTest('BZ 1187366: Cannot delete orgs or envs.')
-                if entity_cls == entities.System and bz_bug_is_open(1133071):
-                    self.skipTest(
-                        'BZ 1133071: Receive HTTP 400s instead of 404s.'
-                    )
 
                 # Create an entity, delete it and get it.
                 try:
@@ -511,8 +501,6 @@ class EntityReadTestCase(APITestCase):
             with self.subTest(entity_cls):
                 logger.debug('test_entity_read arg: %s', entity_cls)
                 skip_if_sam(self, entity_cls)
-                if entity_cls == entities.System and bz_bug_is_open(1223494):
-                    self.skipTest('Cannot read all system attributes.')
                 entity_id = entity_cls().create_json()['id']
                 self.assertIsInstance(
                     entity_cls(id=entity_id).read(),

--- a/tests/foreman/longrun/test_inc_updates.py
+++ b/tests/foreman/longrun/test_inc_updates.py
@@ -5,8 +5,8 @@ from fauxfactory import gen_alpha
 from nailgun import entity_mixins
 from nailgun.entities import (
     ActivationKey, ContentView, ContentViewFilterRule, ContentViewVersion,
-    Errata, ErratumContentViewFilter, HostCollection, LifecycleEnvironment,
-    Organization, Repository, Subscription, System
+    Errata, ErratumContentViewFilter, Host, HostCollection,
+    LifecycleEnvironment, Organization, Repository, Subscription,
 )
 from robottelo import manifests
 from robottelo.api.utils import (
@@ -186,16 +186,17 @@ class IncrementalUpdateTestCase(TestCase):
         for i in range(1, 3):
             cls.setup_vm(cls.vm[i], rhel_6_partial_ak.name, cls.org.label)
 
-        # Find the content hosts (systems) and save them
-        systems = System(organization=cls.org).search()
-        cls.systems = []
-        cls.partial_systems = []
+        # Find the content hosts and save them
+        hosts = Host(organization=cls.org).search()
+        cls.hosts = []
+        cls.partial_hosts = []
 
-        for system in systems:
-            if system.content_view.read().name == cls.rhel_6_cv.name:
-                cls.systems.append(system)
+        for host in hosts:
+            if (host.read().content_facet_attributes['content_view_name'] ==
+                    cls.rhel_6_cv.name):
+                cls.hosts.append(host)
             else:
-                cls.partial_systems.append(system)
+                cls.partial_hosts.append(host)
 
     @classmethod
     def tearDownClass(cls):


### PR DESCRIPTION
One test which shows the change is valid:
```python
py.test -v tests/foreman/api/test_contentview.py -k 'test_positive_subscribe_host'
================================ test session starts =================================
platform linux2 -- Python 2.7.10, pytest-2.8.7, py-1.4.31, pluggy-0.3.1 -- /home/andrii/env/bin/python
cachedir: .cache
rootdir: /home/andrii/workspace/robottelo, inifile: 
plugins: xdist-1.13.1, repeat-0.2
collected 51 items 

tests/foreman/api/test_contentview.py::ContentViewTestCase::test_positive_subscribe_host <- robottelo/decorators.py PASSED
tests/foreman/api/test_contentview.py::ContentViewTestCaseStub::test_positive_subscribe_host <- ../../env/lib/python2.7/site-packages/unittest2/case.py SKIPPED
tests/foreman/api/test_contentview.py::ContentViewTestCaseStub::test_positive_subscribe_host_custom_cv <- ../../env/lib/python2.7/site-packages/unittest2/case.py SKIPPED

============== 48 tests deselected by '-ktest_positive_subscribe_host' ===============
================ 1 passed, 2 skipped, 48 deselected in 29.41 seconds =================
````
Unfortunately end-to-end and others are blocked by different issues, but they use absolutely the same approach so they should work.