### PR TITLE
Fix some CLI failures

### DIFF
--- a/robottelo/cli/factory.py
+++ b/robottelo/cli/factory.py
@@ -803,50 +803,11 @@ def make_sync_plan(options=None):
 
 @cacheable
 def make_content_host(options=None):
-    """
-    Usage::
+    """Register a content host by running ``hammer host subscription
+    register``.
 
-        hammer content-host create [OPTIONS]
-
-    Options::
-
-        --content-view CONTENT_VIEW_NAME                    Content view name
-        --content-view-id CONTENT_VIEW_ID                   content view
-                                                            numeric identifier
-        --description DESCRIPTION                           Description of the
-                                                            content host
-        --guest-ids GUEST_IDS                               IDs of the virtual
-                                                            guests running on
-                                                            this content host
-                                                            Comma separated
-                                                            list of values.
-        --host-collection-ids HOST_COLLECTION_IDS           Specify the host
-                                                            collections as an
-                                                            array
-                                                            Comma separated
-                                                            list of values.
-        --last-checkin LAST_CHECKIN                         Last check-in time
-                                                            of this content
-                                                            host
-        --lifecycle-environment LIFECYCLE_ENVIRONMENT_NAME  Name to search by
-        --lifecycle-environment-id LIFECYCLE_ENVIRONMENT_ID
-        --location LOCATION                                 Physical location
-                                                            of the content host
-        --name NAME                                         Name of the content
-                                                            host
-        --organization ORGANIZATION_NAME                    Organization name
-                                                            to search by
-        --organization-id ORGANIZATION_ID                   organization ID
-        --organization-label ORGANIZATION_LABEL             Organization label
-                                                            to search by
-        --release-ver RELEASE_VER                           Release version of
-                                                            the content host
-        --service-level SERVICE_LEVEL                       A service level for
-                                                            auto-healing
-                                                            process, e.g.
-                                                            SELF-SUPPORT
-        -h, --help                                          print help
-
+    Return the information about the created content host by running ``hammer
+    content-host info``.
     """
     # Organization ID is a required field.
     if not options:
@@ -869,21 +830,17 @@ def make_content_host(options=None):
     args = {
         u'content-view': None,
         u'content-view-id': None,
-        u'description': None,
-        u'guest-ids': None,
-        u'host-collection-ids': None,
-        u'last-checkin': None,
+        u'hypervisor-guest-uuids': None,
         u'lifecycle-environment': None,
         u'lifecycle-environment-id': None,
-        u'location': None,
         u'name': gen_string('alpha', 20),
         u'organization': None,
         u'organization-id': None,
         u'organization-label': None,
-        u'release-ver': None,
+        u'release-version': None,
         u'service-level': None,
+        u'uuid': None,
     }
-
     return create_object(ContentHost, args, options)
 
 

--- a/robottelo/cli/host.py
+++ b/robottelo/cli/host.py
@@ -327,3 +327,19 @@ class Host(Base):
         if isinstance(result, list):
             result = result[0]
         return result
+
+    @classmethod
+    def subscription_unregister(cls, options=None):
+        """Unregister the host as a subscription consumer.
+
+        Usage:
+
+            hammer host subscription unregister [OPTIONS]
+
+        Options:
+
+            --host HOST_NAME              Name to search by
+            --host-id HOST_ID
+        """
+        cls.command_sub = 'subscription unregister'
+        return cls.execute(cls._construct_command(options))

--- a/robottelo/datafactory.py
+++ b/robottelo/datafactory.py
@@ -289,7 +289,7 @@ def valid_usernames_list():
     return generate_strings_list(
         exclude_types=['html'],
         min_length=1,
-        max_length=100
+        max_length=50
     )
 
 

--- a/tests/foreman/cli/test_activationkey.py
+++ b/tests/foreman/cli/test_activationkey.py
@@ -173,7 +173,7 @@ class ActivationKeyTestCase(CLITestCase):
         @Assert: Activation key is created
         """
         new_ak = self._make_activation_key()
-        self.assertEqual(new_ak['content-host-limit'], u'Unlimited')
+        self.assertEqual(new_ak['host-limit'], u'Unlimited')
 
     @tier1
     def test_positive_create_with_usage_limit_finite(self):
@@ -186,7 +186,7 @@ class ActivationKeyTestCase(CLITestCase):
         new_ak = self._make_activation_key({
             u'max-content-hosts': '10',
         })
-        self.assertEqual(new_ak['content-host-limit'], u'10')
+        self.assertEqual(new_ak['host-limit'], u'10')
 
     @run_only_on('sat')
     @tier1
@@ -443,14 +443,14 @@ class ActivationKeyTestCase(CLITestCase):
         @Assert: Activation key is updated
         """
         new_ak = self._make_activation_key()
-        self.assertEqual(new_ak['content-host-limit'], u'Unlimited')
+        self.assertEqual(new_ak['host-limit'], u'Unlimited')
         ActivationKey.update({
             u'max-content-hosts': '2147483647',
             u'name': new_ak['name'],
             u'organization-id': self.org['id'],
         })
         updated_ak = ActivationKey.info({'id': new_ak['id']})
-        self.assertEqual(updated_ak['content-host-limit'], u'2147483647')
+        self.assertEqual(updated_ak['host-limit'], u'2147483647')
 
     @tier1
     def test_positive_update_usage_limit_to_unlimited(self):
@@ -463,14 +463,14 @@ class ActivationKeyTestCase(CLITestCase):
         new_ak = self._make_activation_key({
             u'max-content-hosts': '10',
         })
-        self.assertEqual(new_ak['content-host-limit'], u'10')
+        self.assertEqual(new_ak['host-limit'], u'10')
         ActivationKey.update({
             u'unlimited-content-hosts': '1',
             u'name': new_ak['name'],
             u'organization-id': self.org['id'],
         })
         updated_ak = ActivationKey.info({'id': new_ak['id']})
-        self.assertEqual(updated_ak['content-host-limit'], u'Unlimited')
+        self.assertEqual(updated_ak['host-limit'], u'Unlimited')
 
     @tier1
     def test_negative_update_name(self):

--- a/tests/foreman/cli/test_contenthost.py
+++ b/tests/foreman/cli/test_contenthost.py
@@ -76,7 +76,6 @@ class ContentHostTestCase(CLITestCase):
         @Feature: Content Hosts
 
         @Assert: Content host is created and has random name
-
         """
         for name in generate_strings_list(15):
             with self.subTest(name):
@@ -90,33 +89,12 @@ class ContentHostTestCase(CLITestCase):
             self.assertEqual(new_system['name'], name)
 
     @tier1
-    def test_positive_create_with_description(self):
-        """Check if content host can be created with random description
-
-        @Feature: Content Hosts
-
-        @Assert: Content host is created and has random description
-
-        """
-        for desc in generate_strings_list(15):
-            with self.subTest(desc):
-                new_system = make_content_host({
-                    u'description': desc,
-                    u'content-view-id': self.DEFAULT_CV['id'],
-                    u'lifecycle-environment-id': self.LIBRARY['id'],
-                    u'organization-id': self.NEW_ORG['id'],
-                })
-                # Assert that description matches data passed
-                self.assertEqual(new_system['description'], desc)
-
-    @tier1
     def test_positive_create_with_org_name(self):
         """Check if content host can be created with organization name
 
         @Feature: Content Hosts
 
         @Assert: Content host is created using organization name
-
         """
         new_system = make_content_host({
             u'content-view-id': self.DEFAULT_CV['id'],
@@ -139,7 +117,6 @@ class ContentHostTestCase(CLITestCase):
         @Feature: Content Hosts
 
         @Assert: Content host is created using organization label
-
         """
         new_system = make_content_host({
             u'content-view-id': self.DEFAULT_CV['id'],
@@ -163,7 +140,6 @@ class ContentHostTestCase(CLITestCase):
         @Feature: Content Hosts
 
         @Assert: Content host is created using content view name
-
         """
         new_system = make_content_host({
             u'content-view': self.DEFAULT_CV['name'],
@@ -182,7 +158,6 @@ class ContentHostTestCase(CLITestCase):
         @Feature: Content Hosts
 
         @Assert: Content host is created using lifecycle name
-
         """
         new_system = make_content_host({
             u'content-view-id': self.DEFAULT_CV['id'],
@@ -204,7 +179,6 @@ class ContentHostTestCase(CLITestCase):
         @Feature: Content Hosts
 
         @Assert: Content host is created using new lifecycle
-
         """
         new_system = make_content_host({
             u'content-view-id': self.PROMOTED_CV['id'],
@@ -226,7 +200,6 @@ class ContentHostTestCase(CLITestCase):
         @Feature: Content Hosts
 
         @Assert: Content host is created using new published, promoted cv
-
         """
         if ContentHostTestCase.PROMOTED_CV is None:
             self.fail("Couldn't prepare promoted contentview for this test")
@@ -251,7 +224,6 @@ class ContentHostTestCase(CLITestCase):
         @Feature: Content Hosts
 
         @Assert: Content host is not created
-
         """
         for name in invalid_values_list():
             with self.subTest(name):
@@ -271,7 +243,6 @@ class ContentHostTestCase(CLITestCase):
         @Feature: Content Hosts
 
         @Assert: Content host is not created using new unpublished cv
-
         """
         con_view = make_content_view({
             u'organization-id': ContentHostTestCase.NEW_ORG['id'],
@@ -286,6 +257,7 @@ class ContentHostTestCase(CLITestCase):
             })
 
     @tier1
+    @skip_if_bug_open('bugzilla', 1318686)
     def test_positive_update_name(self):
         """Check if content host name can be updated
 
@@ -293,6 +265,7 @@ class ContentHostTestCase(CLITestCase):
 
         @Assert: Content host is created and name is updated
 
+        @BZ: 1318686
         """
         new_system = make_content_host({
             u'content-view-id': self.DEFAULT_CV['id'],
@@ -309,48 +282,47 @@ class ContentHostTestCase(CLITestCase):
                 self.assertEqual(result['name'], new_name)
 
     @tier1
-    def test_positive_update_description(self):
-        """Check if content host description can be updated
-
-        @Feature: Content Hosts
-
-        @Assert: Content host is created and description is updated
-
-        """
-        new_system = make_content_host({
-            u'content-view-id': self.DEFAULT_CV['id'],
-            u'lifecycle-environment-id': self.LIBRARY['id'],
-            u'organization-id': self.NEW_ORG['id'],
-        })
-        for new_desc in generate_strings_list():
-            with self.subTest(new_desc):
-                ContentHost.update({
-                    u'id': new_system['id'],
-                    u'description': new_desc,
-                })
-                result = ContentHost.info({'id': new_system['id']})
-                self.assertEqual(result['description'], new_desc)
-
-    @tier1
+    @skip_if_bug_open('bugzilla', 1328202)
     def test_positive_delete_by_id(self):
-        """Check if content host can be created and deleted
+        """Check if content host can be created and deleted by passing its ID
 
         @Feature: Content Hosts
 
         @Assert: Content host is created and then deleted
 
+        @BZ: 1328202
         """
         for name in generate_strings_list():
             with self.subTest(name):
-                new_system = make_content_host({
+                content_host = make_content_host({
                     u'content-view-id': self.DEFAULT_CV['id'],
                     u'lifecycle-environment-id': self.LIBRARY['id'],
                     u'name': name,
                     u'organization-id': self.NEW_ORG['id'],
                 })
-                ContentHost.delete({u'id': new_system['id']})
+                ContentHost.delete({u'host-id': content_host['id']})
                 with self.assertRaises(CLIReturnCodeError):
-                    ContentHost.info({'id': new_system['id']})
+                    ContentHost.info({'id': content_host['id']})
+
+    @tier1
+    def test_positive_delete_by_name(self):
+        """Check if content host can be created and deleted by passing its name
+
+        @Feature: Content Hosts
+
+        @Assert: Content host is created and then deleted
+        """
+        for name in generate_strings_list():
+            with self.subTest(name):
+                content_host = make_content_host({
+                    u'content-view-id': self.DEFAULT_CV['id'],
+                    u'lifecycle-environment-id': self.LIBRARY['id'],
+                    u'name': name,
+                    u'organization-id': self.NEW_ORG['id'],
+                })
+                ContentHost.delete({u'host': content_host['name']})
+                with self.assertRaises(CLIReturnCodeError):
+                    ContentHost.info({'id': content_host['id']})
 
     @tier1
     @skip_if_bug_open('bugzilla', 1154611)
@@ -363,7 +335,6 @@ class ContentHostTestCase(CLITestCase):
         @assert: Content Hosts with the same name are not allowed
 
         @bz: 1154611
-
         """
         name = gen_string('alpha', 15)
         result = make_content_host({
@@ -372,7 +343,7 @@ class ContentHostTestCase(CLITestCase):
             u'name': name,
             u'organization-id': self.NEW_ORG['id'],
         })
-        self.assertEqual(result['name'], name)
+        self.assertEqual(result['name'], name.lower())
         with self.assertRaises(CLIFactoryError):
             make_content_host({
                 u'content-view-id': self.DEFAULT_CV['id'],

--- a/tests/foreman/cli/test_host.py
+++ b/tests/foreman/cli/test_host.py
@@ -236,7 +236,7 @@ class HostUpdateTestCase(CLITestCase):
                 self.assertEqual(
                     u'{0}.{1}'.format(
                         new_name,
-                        self.host['domain'],
+                        self.host['network']['domain'],
                     ).lower(),
                     self.host['name'],
                 )
@@ -257,13 +257,13 @@ class HostUpdateTestCase(CLITestCase):
                     'new-name': new_name,
                 })
                 self.host = Host.info({
-                    'name': u'{0}.{1}'
-                            .format(new_name, self.host['domain']).lower()
+                    'name': u'{0}.{1}'.format(
+                        new_name, self.host['network']['domain']).lower(),
                 })
                 self.assertEqual(
                     u'{0}.{1}'.format(
                         new_name,
-                        self.host['domain'],
+                        self.host['network']['domain'],
                     ).lower(),
                     self.host['name'],
                 )
@@ -283,7 +283,7 @@ class HostUpdateTestCase(CLITestCase):
             'mac': new_mac,
         })
         self.host = Host.info({'id': self.host['id']})
-        self.assertEqual(self.host['mac'], new_mac)
+        self.assertEqual(self.host['network']['mac'], new_mac)
 
     @tier1
     def test_positive_update_mac_by_name(self):
@@ -300,7 +300,7 @@ class HostUpdateTestCase(CLITestCase):
             'name': self.host['name'],
         })
         self.host = Host.info({'name': self.host['name']})
-        self.assertEqual(self.host['mac'], new_mac)
+        self.assertEqual(self.host['network']['mac'], new_mac)
 
     @tier2
     def test_positive_update_domain_by_id(self):
@@ -320,7 +320,7 @@ class HostUpdateTestCase(CLITestCase):
             'id': self.host['id'],
         })
         self.host = Host.info({'id': self.host['id']})
-        self.assertEqual(self.host['domain'], new_domain['name'])
+        self.assertEqual(self.host['network']['domain'], new_domain['name'])
 
     @tier2
     def test_positive_update_domain_by_name(self):
@@ -345,7 +345,7 @@ class HostUpdateTestCase(CLITestCase):
                 new_domain['name'],
             )
         })
-        self.assertEqual(self.host['domain'], new_domain['name'])
+        self.assertEqual(self.host['network']['domain'], new_domain['name'])
 
     @tier2
     def test_positive_update_env_by_id(self):
@@ -552,7 +552,7 @@ class HostUpdateTestCase(CLITestCase):
                 self.assertNotEqual(
                     u'{0}.{1}'.format(
                         new_name,
-                        self.host['domain'],
+                        self.host['network']['domain'],
                     ).lower(),
                     self.host['name'],
                 )
@@ -573,7 +573,7 @@ class HostUpdateTestCase(CLITestCase):
                         'mac': new_mac,
                     })
                     self.host = Host.info({'id': self.host['id']})
-                    self.assertEqual(self.host['mac'], new_mac)
+                    self.assertEqual(self.host['network']['mac'], new_mac)
 
     @tier2
     def test_negative_update_arch(self):


### PR DESCRIPTION
I'm creating this PR because I'm analyzing latest Automation results and I'm updating all CLI tests that needs to be updated.

Please if you are planning to work on any CLI related failure let me know here on this PR and also make sure I am not already working on it.

The changes are:

* Update cli.test_host to match the new output of the info command for domain and
mac fields.

* Update cli.test_contenthost to follow the current status of the not completed
host unification.

* Update valid_usernames_list data factory max length to match the new length for
first name and surname fields. This fixes two failures on cli.test_user.

* Add subscription_unregister host subcommand to allow unregistering a host
subscription (previously content-host).

* Update make_content_host cli factory with the current accepted options.

Update cli.contenthost.ContentHost to use host subscription register for
ContentHost.create and host subscription unregister for CotnentHost.delete.

Test results:

Results for fixes in `tests/foreman/cli/test_activationkey.py`:

```
py.test tests/foreman/cli/test_activationkey.py -n auto --boxed -m "not stubbed" -v
==================== test session starts ====================
platform linux -- Python 3.4.2, pytest-2.9.1, py-1.4.31, pluggy-0.3.1 -- /home/elyezer/.virtualenvs/robottelo/bin/python3
cachedir: .cache
rootdir: /home/elyezer/code/robottelo, inifile: 
plugins: cov-2.2.1, testmon-0.8.2, xdist-1.14
[gw0] linux Python 3.4.2 cwd: /home/elyezer/code/robottelo
[gw1] linux Python 3.4.2 cwd: /home/elyezer/code/robottelo
[gw2] linux Python 3.4.2 cwd: /home/elyezer/code/robottelo
[gw3] linux Python 3.4.2 cwd: /home/elyezer/code/robottelo
[gw0] Python 3.4.2 (default, Jul  9 2015, 17:24:30)  -- [GCC 5.1.1 20150618 (Red Hat 5.1.1-4)]
[gw1] Python 3.4.2 (default, Jul  9 2015, 17:24:30)  -- [GCC 5.1.1 20150618 (Red Hat 5.1.1-4)]
[gw2] Python 3.4.2 (default, Jul  9 2015, 17:24:30)  -- [GCC 5.1.1 20150618 (Red Hat 5.1.1-4)]
[gw3] Python 3.4.2 (default, Jul  9 2015, 17:24:30)  -- [GCC 5.1.1 20150618 (Red Hat 5.1.1-4)]
gw0 [47] / gw1 [47] / gw2 [47] / gw3 [47]
scheduling tests via LoadScheduling
[gw1] PASSED tests/foreman/cli/test_activationkey.py::ActivationKeyTestCase::test_positive_create_with_usage_limit_default 
[gw1] PASSED tests/foreman/cli/test_activationkey.py::ActivationKeyTestCase::test_positive_create_with_usage_limit_finite 
[gw0] PASSED tests/foreman/cli/test_activationkey.py::ActivationKeyTestCase::test_positive_update_usage_limit_to_finite_number 
[gw2] PASSED tests/foreman/cli/test_activationkey.py::ActivationKeyTestCase::test_positive_update_usage_limit_to_unlimited 
Remaining of the output omitted...
```

Results for fixes in `tests/foreman/cli/test_host.py` and also for other tests that have failed on the latest build.

```
$ py.test tests/foreman/cli/test_host.py -n auto --boxed -v
==================== test session starts ====================
platform linux -- Python 3.4.2, pytest-2.9.1, py-1.4.31, pluggy-0.3.1 -- /home/elyezer/.virtualenvs/robottelo/bin/python3
cachedir: .cache
rootdir: /home/elyezer/code/robottelo, inifile: 
plugins: cov-2.2.1, testmon-0.8.2, xdist-1.14
[gw0] linux Python 3.4.2 cwd: /home/elyezer/code/robottelo
[gw1] linux Python 3.4.2 cwd: /home/elyezer/code/robottelo
[gw2] linux Python 3.4.2 cwd: /home/elyezer/code/robottelo
[gw3] linux Python 3.4.2 cwd: /home/elyezer/code/robottelo
[gw0] Python 3.4.2 (default, Jul  9 2015, 17:24:30)  -- [GCC 5.1.1 20150618 (Red Hat 5.1.1-4)]
[gw1] Python 3.4.2 (default, Jul  9 2015, 17:24:30)  -- [GCC 5.1.1 20150618 (Red Hat 5.1.1-4)]
[gw2] Python 3.4.2 (default, Jul  9 2015, 17:24:30)  -- [GCC 5.1.1 20150618 (Red Hat 5.1.1-4)]
[gw3] Python 3.4.2 (default, Jul  9 2015, 17:24:30)  -- [GCC 5.1.1 20150618 (Red Hat 5.1.1-4)]
gw0 [39] / gw1 [39] / gw2 [39] / gw3 [39]
scheduling tests via LoadScheduling
[gw1] PASSED tests/foreman/cli/test_host.py::HostDeleteTestCase::test_positive_delete_by_id 
[gw2] PASSED tests/foreman/cli/test_host.py::HostDeleteTestCase::test_positive_delete_by_name 
[gw1] PASSED tests/foreman/cli/test_host.py::HostUpdateTestCase::test_negative_update_name 
[gw3] PASSED tests/foreman/cli/test_host.py::HostUpdateTestCase::test_positive_update_mac_by_id 
[gw0] PASSED tests/foreman/cli/test_host.py::HostUpdateTestCase::test_positive_update_mac_by_name 
[gw3] PASSED tests/foreman/cli/test_host.py::HostUpdateTestCase::test_positive_update_name_by_id 
[gw2] PASSED tests/foreman/cli/test_host.py::HostUpdateTestCase::test_positive_update_name_by_name 
[gw3] SKIPPED tests/foreman/cli/test_host.py::HostCreateTestCase::test_positive_create_using_libvirt_without_mac 
Remaining of the output omitted...
```

Results for fixes in `tests/foreman/cli/test_user.py`

```
$ py.test tests/foreman/cli/test_user.py -k test_positive_create_with_firstname
==================== test session starts ====================
platform linux -- Python 3.4.2, pytest-2.9.1, py-1.4.31, pluggy-0.3.1
rootdir: /home/elyezer/code/robottelo, inifile: 
plugins: cov-2.2.1, testmon-0.8.2, xdist-1.14
collected 49 items 

tests/foreman/cli/test_user.py .

 48 tests deselected by '-ktest_positive_create_with_firstname' 
========= 1 passed, 48 deselected in 54.68 seconds ==========
```

```
$ py.test tests/foreman/cli/test_user.py -k test_positive_create_with_surname 
==================== test session starts ====================
platform linux -- Python 3.4.2, pytest-2.9.1, py-1.4.31, pluggy-0.3.1
rootdir: /home/elyezer/code/robottelo, inifile: 
plugins: cov-2.2.1, testmon-0.8.2, xdist-1.14
collected 49 items 

tests/foreman/cli/test_user.py .

 48 tests deselected by '-ktest_positive_create_with_surname' 
========= 1 passed, 48 deselected in 47.59 seconds ==========
```