### PR TITLE
Fix cli/test_repository/test_positive_update_checksum_type

### DIFF
--- a/tests/foreman/cli/test_repository.py
+++ b/tests/foreman/cli/test_repository.py
@@ -624,7 +624,6 @@ class RepositoryTestCase(CLITestCase):
         @Status: manual
         """
 
-    @skip_if_bug_open('bugzilla', 1208305)
     @run_only_on('sat')
     @tier1
     def test_positive_update_checksum_type(self):
@@ -642,7 +641,6 @@ class RepositoryTestCase(CLITestCase):
             u'content-type': content_type
         })
         self.assertEqual(repository['content-type'], content_type)
-        self.assertEqual(repository['checksum-type'], '')
         for checksum_type in u'sha1', u'sha256':
             with self.subTest(checksum_type):
                 # Update the checksum


### PR DESCRIPTION
```python
py.test -v tests/foreman/cli/test_repository.py -k 'test_positive_update_checksum_type'
================================ test session starts =================================
platform linux2 -- Python 2.7.10, pytest-2.8.7, py-1.4.31, pluggy-0.3.1 -- /home/andrii/env/bin/python
cachedir: .cache
rootdir: /home/andrii/workspace/robottelo, inifile: 
plugins: xdist-1.13.1, repeat-0.2
collected 30 items 

tests/foreman/cli/test_repository.py::RepositoryTestCase::test_positive_update_checksum_type <- robottelo/decorators.py PASSED

=========== 29 tests deselected by '-ktest_positive_update_checksum_type' ============
====================== 1 passed, 29 deselected in 34.52 seconds ======================
```