### PR TITLE
Removing `skip_if_bug_open` decorator for resolved BZs

### DIFF
--- a/robottelo/cli/environment.py
+++ b/robottelo/cli/environment.py
@@ -31,4 +31,5 @@ class Environment(Base):
     def sc_params(cls, options=None):
         """List all smart class parameters."""
         cls.command_sub = 'sc-params'
-        return cls.execute(cls._construct_command(options))
+        return cls.execute(cls._construct_command(options),
+                           output_format='csv')

--- a/tests/foreman/api/test_foremantask.py
+++ b/tests/foreman/api/test_foremantask.py
@@ -1,7 +1,7 @@
 """Unit tests for the ``foreman_tasks/api/v2/tasks`` paths."""
 from nailgun import entities
 from requests.exceptions import HTTPError
-from robottelo.decorators import run_only_on, skip_if_bug_open, tier1
+from robottelo.decorators import run_only_on, tier1
 from robottelo.test import APITestCase
 
 
@@ -10,15 +10,12 @@ class ForemanTaskTestCase(APITestCase):
 
     @tier1
     @run_only_on('sat')
-    @skip_if_bug_open('bugzilla', 1131702)
     def test_negative_fetch_non_existent_task(self):
         """Fetch a non-existent task.
 
         @Assert: An HTTP 4XX or 5XX message is returned.
 
         @Feature: ForemanTask
-
-        @bz: 1131702
         """
         with self.assertRaises(HTTPError):
             entities.ForemanTask(id='abc123').read()

--- a/tests/foreman/api/test_hostcollection.py
+++ b/tests/foreman/api/test_hostcollection.py
@@ -156,7 +156,6 @@ class HostCollectionTestCase(APITestCase):
         host_collection = host_collection.update(['host'])
         self.assertEqual(len(host_collection.host), len(self.hosts))
 
-    @skip_if_bug_open('bugzilla', 1203323)
     @skip_if_bug_open('bugzilla', 1325989)
     @tier1
     def test_positive_read_host_ids(self):
@@ -249,7 +248,6 @@ class HostCollectionTestCase(APITestCase):
                 self.assertEqual(
                     host_collection.unlimited_hosts, unlimited)
 
-    @skip_if_bug_open('bugzilla', 1203323)
     @skip_if_bug_open('bugzilla', 1325989)
     @tier1
     def test_positive_update_chost(self):
@@ -267,7 +265,6 @@ class HostCollectionTestCase(APITestCase):
         host_collection = host_collection.update(['host'])
         self.assertEqual(host_collection.host[0].id, self.hosts[1].id)
 
-    @skip_if_bug_open('bugzilla', 1203323)
     @skip_if_bug_open('bugzilla', 1325989)
     @tier1
     def test_positive_update_hosts(self):

--- a/tests/foreman/cli/test_activationkey.py
+++ b/tests/foreman/cli/test_activationkey.py
@@ -1148,7 +1148,6 @@ class ActivationKeyTestCase(CLITestCase):
         self.assertIn(
             u"'--auto-attach': value must be one of", exe.exception.stderr)
 
-    @skip_if_bug_open('bugzilla', 1180282)
     @tier3
     def test_positive_content_override(self):
         """Positive content override
@@ -1161,8 +1160,6 @@ class ActivationKeyTestCase(CLITestCase):
         2. Get the first product's label
         3. Override the product's content enabled state
         4. Verify that the command succeeded
-
-        @BZ: 1180282
 
         @Assert: Activation key content override was successful
         """

--- a/tests/foreman/cli/test_environment.py
+++ b/tests/foreman/cli/test_environment.py
@@ -10,9 +10,7 @@ from robottelo.datafactory import (
     valid_environments_list,
 )
 from robottelo.decorators import (
-    bz_bug_is_open,
     run_only_on,
-    skip_if_bug_open,
     tier1,
     tier2,
 )
@@ -232,7 +230,6 @@ class EnvironmentTestCase(CLITestCase):
         self.assertNotIn(old_org['name'], env['organizations'])
 
     @tier1
-    @skip_if_bug_open('bugzilla', 1219934)
     @run_only_on('sat')
     def test_positive_sc_params_by_id(self):
         """Check if environment sc-param subcommand works passing
@@ -242,18 +239,11 @@ class EnvironmentTestCase(CLITestCase):
 
         @Assert: The command runs without raising an error
 
-        @BZ: 1219934
-
         """
         environment = make_environment()
-        Environment.sc_params({
-            'environment-id': environment['id'],
-        })
-        if not bz_bug_is_open(1219934):
-            self.fail('BZ #1219934 is closed, should assert the content')
+        Environment.sc_params({'environment-id': environment['id']})
 
     @tier1
-    @skip_if_bug_open('bugzilla', 1219934)
     @run_only_on('sat')
     def test_positive_sc_params_by_name(self):
         """Check if environment sc-param subcommand works passing
@@ -263,12 +253,6 @@ class EnvironmentTestCase(CLITestCase):
 
         @Assert: The command runs without raising an error
 
-        @BZ: 1219934
-
         """
         environment = make_environment()
-        Environment.sc_params({
-            'environment': environment['name'],
-        })
-        if not bz_bug_is_open(1219934):
-            self.fail('BZ #1219934 is closed, should assert the content')
+        Environment.sc_params({'environment': environment['name']})

--- a/tests/foreman/cli/test_gpgkey.py
+++ b/tests/foreman/cli/test_gpgkey.py
@@ -24,7 +24,6 @@ from robottelo.constants import VALID_GPG_KEY_FILE
 from robottelo.datafactory import invalid_values_list, valid_data_list
 from robottelo.decorators import (
     run_only_on,
-    skip_if_bug_open,
     stubbed,
     tier1,
     tier2,
@@ -111,7 +110,6 @@ class TestGPGKey(CLITestCase):
 
     # Positive Create
 
-    @skip_if_bug_open('bugzilla', 1172009)
     @run_only_on('sat')
     @tier1
     def test_positive_create_with_default_org(self):
@@ -121,8 +119,6 @@ class TestGPGKey(CLITestCase):
         @feature: GPG Keys
 
         @assert: gpg key is created
-
-        @BZ: 1172009
         """
         result = Org.list()
         self.assertGreater(len(result), 0, 'No organization found')
@@ -144,7 +140,6 @@ class TestGPGKey(CLITestCase):
                     result[self.search_key]
                 )
 
-    @skip_if_bug_open('bugzilla', 1172009)
     @run_only_on('sat')
     @tier1
     def test_positive_create_with_custom_org(self):
@@ -154,8 +149,6 @@ class TestGPGKey(CLITestCase):
         @feature: GPG Keys
 
         @assert: gpg key is created
-
-        @BZ: 1172009
         """
         for name in valid_data_list():
             with self.subTest(name):
@@ -176,7 +169,6 @@ class TestGPGKey(CLITestCase):
 
     # Negative Create
 
-    @skip_if_bug_open('bugzilla', 1172009)
     @run_only_on('sat')
     @tier1
     def test_negative_create_with_same_name(self):
@@ -186,8 +178,6 @@ class TestGPGKey(CLITestCase):
         @feature: GPG Keys
 
         @assert: gpg key is not created
-
-        @BZ: 1172009
         """
         name = gen_string('alphanumeric')
         gpg_key = make_gpg_key({

--- a/tests/foreman/cli/test_organization.py
+++ b/tests/foreman/cli/test_organization.py
@@ -29,7 +29,6 @@ from robottelo.datafactory import (
 )
 from robottelo.decorators import (
     run_only_on,
-    skip_if_bug_open,
     tier1,
     tier2,
 )
@@ -111,7 +110,6 @@ class OrganizationTestCase(CLITestCase):
                 })
                 self.assertEqual(org['name'], org['label'])
 
-    @skip_if_bug_open('bugzilla', 1142821)
     @tier1
     def test_positive_create_with_unmatched_name_label(self):
         """Create organization with valid unmatching name and label only
@@ -119,8 +117,6 @@ class OrganizationTestCase(CLITestCase):
         @feature: Organization
 
         @assert: organization is created, label does not match name
-
-        @bz: 1142821
         """
         for name in valid_org_names_list():
             with self.subTest(name):
@@ -150,7 +146,6 @@ class OrganizationTestCase(CLITestCase):
                 self.assertEqual(org['name'], name)
                 self.assertEqual(org['description'], desc)
 
-    @skip_if_bug_open('bugzilla', 1142821)
     @tier1
     def test_positive_create_with_name_label_description(self):
         """Create organization with valid name, label and description
@@ -158,8 +153,6 @@ class OrganizationTestCase(CLITestCase):
         @feature: Organization
 
         @assert: organization is created
-
-        @bz: 1142821
         """
         for description in valid_data_list():
             with self.subTest(description):

--- a/tests/foreman/cli/test_repository.py
+++ b/tests/foreman/cli/test_repository.py
@@ -633,8 +633,6 @@ class RepositoryTestCase(CLITestCase):
 
         @Assert: A YUM repository is updated and contains the correct checksum
         type
-
-        @BZ: 1208305
         """
         content_type = u'yum'
         repository = self._make_repository({

--- a/tests/foreman/cli/test_subnet.py
+++ b/tests/foreman/cli/test_subnet.py
@@ -10,7 +10,7 @@ from robottelo.cli.factory import make_domain, make_subnet, CLIFactoryError
 from robottelo.cli.subnet import Subnet
 from robottelo.constants import SUBNET_IPAM_TYPES
 from robottelo.datafactory import valid_data_list
-from robottelo.decorators import run_only_on, skip_if_bug_open, tier1
+from robottelo.decorators import run_only_on, tier1
 from robottelo.test import CLITestCase
 
 
@@ -135,7 +135,6 @@ class SubnetTestCase(CLITestCase):
         subnet = make_subnet({'gateway': gateway})
         self.assertIn(gateway, subnet['gateway'])
 
-    @skip_if_bug_open('bugzilla', 1213437)
     @run_only_on('sat')
     @tier1
     def test_positive_create_with_ipam(self):
@@ -144,8 +143,6 @@ class SubnetTestCase(CLITestCase):
         @Feature: Subnet - Positive create
 
         @Assert: Subnet is created and correct ipam type is assigned
-
-        @BZ: 1213437
         """
         for ipam_type in (SUBNET_IPAM_TYPES['dhcp'],
                           SUBNET_IPAM_TYPES['internal'],

--- a/tests/foreman/cli/test_syncplan.py
+++ b/tests/foreman/cli/test_syncplan.py
@@ -20,7 +20,7 @@ from robottelo.cli.subscription import Subscription
 from robottelo.cli.syncplan import SyncPlan
 from robottelo.constants import PRDS, REPOS, REPOSET
 from robottelo.datafactory import valid_data_list, invalid_values_list
-from robottelo.decorators import skip_if_bug_open, stubbed, tier1, tier4
+from robottelo.decorators import stubbed, tier1, tier4
 from robottelo.ssh import upload_file
 from robottelo.test import CLITestCase
 from time import sleep
@@ -305,16 +305,13 @@ class SyncPlanTestCase(CLITestCase):
                 with self.assertRaises(CLIReturnCodeError):
                     SyncPlan.info({'id': new_sync_plan['id']})
 
-    @skip_if_bug_open('bugzilla', 1261122)
     @tier1
-    def test_verify_bugzilla_1261122(self):
+    def test_positive_info_enabled_field_is_displayed(self):
         """Check if Enabled field is displayed in sync-plan info output
 
         @Feature: Sync Plan Info
 
         @Assert: Sync plan Enabled state is displayed
-
-        @BZ: 1261122
         """
         new_sync_plan = self._make_sync_plan()
         result = SyncPlan.info({'id': new_sync_plan['id']})


### PR DESCRIPTION
* Removed `skip_if_bug_open`  decorator for resolved BZs
* Removed `@bz` identifier on docstrings
* Renamed `test_verify_bugzilla_1261122` to `test_positive_info_enabled_field_is_displayed`