### PR TITLE
Fixing Docker Registry tests according to new validation model in 6.2

### DIFF
--- a/robottelo/cli/factory.py
+++ b/robottelo/cli/factory.py
@@ -16,7 +16,6 @@ from fauxfactory import (
     gen_mac,
     gen_netmask,
     gen_string,
-    gen_url,
 )
 from os import chmod
 from robottelo import manifests, ssh
@@ -53,6 +52,7 @@ from robottelo.cli.user import User
 from robottelo.cli.usergroup import UserGroup, UserGroupExternal
 from robottelo.constants import (
     DEFAULT_SUBSCRIPTION_NAME,
+    DOCKER_0_EXTERNAL_REGISTRY,
     FAKE_1_YUM_REPO,
     FOREMAN_PROVIDERS,
     OPERATING_SYSTEMS,
@@ -611,7 +611,7 @@ def make_registry(options=None):
         u'description': None,
         u'name': gen_string('alphanumeric'),
         u'password': None,
-        u'url': gen_url(subdomain=gen_string('alpha')),
+        u'url': DOCKER_0_EXTERNAL_REGISTRY,
         u'username': None,
     }
 

--- a/robottelo/constants.py
+++ b/robottelo/constants.py
@@ -277,6 +277,8 @@ FILTER_TYPE = {'include': "Include",
                'exclude': "Exclude"}
 
 DOCKER_REGISTRY_HUB = u'https://registry-1.docker.io'
+DOCKER_0_EXTERNAL_REGISTRY = u'https://registry.access.redhat.com'
+DOCKER_1_EXTERNAL_REGISTRY = u'http://satqe-docker-registry.usersys.redhat.com:5000/'  # noqa
 GOOGLE_CHROME_REPO = u'http://dl.google.com/linux/chrome/rpm/stable/x86_64'
 FAKE_0_YUM_REPO = u'http://inecas.fedorapeople.org/fakerepos/zoo/'
 FAKE_1_YUM_REPO = u'http://inecas.fedorapeople.org/fakerepos/zoo3/'

--- a/robottelo/ui/locators.py
+++ b/robottelo/ui/locators.py
@@ -2485,7 +2485,8 @@ locators = LocatorDict({
     "container.new": (By.XPATH, "//a[contains(@href, '/containers/new')]"),
     "container.resource_name": (
         By.XPATH,
-        "//select[contains(@id, 'preliminary_compute_resource_id')]"),
+        ("//div[contains(@id, 'preliminary_compute_resource_id')]/a"
+         "/span[contains(@class, 'arrow')]")),
     "container.next_section": (By.ID, "next"),
     "container.content_view_tab": (By.ID, "katello_tab"),
     "container.content_view_tab_next": (By.ID, "next_katello"),
@@ -2494,11 +2495,25 @@ locators = LocatorDict({
     "container.external_registry_tab": (By.ID, "registry_tab"),
     "container.external_registry_tab_next": (By.ID, "next_registry"),
     "container.lifecycle_environment": (
-        By.XPATH, "//select[@id='kt_environment_id']"),
-    "container.content_view": (By.XPATH, "//select[@id='content_view_id']"),
-    "container.repository": (By.XPATH, "//select[@id='repository_id']"),
-    "container.tag": (By.XPATH, "//select[@id='tag_id']"),
-    "container.capsule": (By.XPATH, "//select[@id='capsule_id']"),
+        By.XPATH,
+        ("//div[contains(@id, 'kt_environment_id')]/a"
+         "/span[contains(@class, 'arrow')]")),
+    "container.content_view": (
+        By.XPATH,
+        ("//div[contains(@id, 'kt_environment_id')]/a"
+         "/span[contains(@class, 'arrow')]")),
+    "container.repository": (
+        By.XPATH,
+        ("//div[contains(@id, 'repository_id')]/a"
+         "/span[contains(@class, 'arrow')]")),
+    "container.tag": (
+        By.XPATH,
+        ("//div[contains(@id, 'tag_id')]/a"
+         "/span[contains(@class, 'arrow')]")),
+    "container.capsule": (
+        By.XPATH,
+        ("//div[contains(@id, 'capsule_id')]/a"
+         "/span[contains(@class, 'arrow')]")),
     "container.docker_hub_tag": (
         By.ID, "hub_docker_container_wizard_states_image_tag"),
     "container.name": (

--- a/tests/foreman/cli/test_docker.py
+++ b/tests/foreman/cli/test_docker.py
@@ -21,7 +21,11 @@ from robottelo.cli.contentview import ContentView
 from robottelo.cli.product import Product
 from robottelo.cli.repository import Repository
 from robottelo.config import settings
-from robottelo.constants import DOCKER_REGISTRY_HUB
+from robottelo.constants import (
+    DOCKER_0_EXTERNAL_REGISTRY,
+    DOCKER_1_EXTERNAL_REGISTRY,
+    DOCKER_REGISTRY_HUB,
+)
 from robottelo.datafactory import valid_data_list
 from robottelo.decorators import (
     run_only_on,
@@ -1477,38 +1481,35 @@ class DockerContainersTestCase(CLITestCase):
 class DockerRegistryTestCase(CLITestCase):
     """Tests specific to performing CRUD methods against ``Registries``
     repositories.
-
     """
 
     @tier1
     @run_only_on('sat')
-    @skip_if_bug_open('bugzilla', 1259498)
     def test_positive_create_with_name(self):
         """Create an external docker registry
 
         @Feature: Docker
 
         @Assert: the external registry is created
-
-        @BZ: 1259498
-
         """
         for name in valid_data_list():
             with self.subTest(name):
-                url = gen_url(subdomain=gen_string('alpha'))
                 description = gen_string('alphanumeric')
                 registry = make_registry({
                     'description': description,
                     'name': name,
-                    'url': url,
+                    'url': DOCKER_0_EXTERNAL_REGISTRY,
                 })
-                self.assertEqual(registry['name'], name)
-                self.assertEqual(registry['description'], description)
-                self.assertEqual(registry['url'], url)
+                try:
+                    self.assertEqual(registry['name'], name)
+                    self.assertEqual(registry['description'], description)
+                    self.assertEqual(
+                        registry['url'], DOCKER_0_EXTERNAL_REGISTRY)
+                finally:
+                    Docker.registry.delete({'id': registry['id']})
 
     @tier1
     @run_only_on('sat')
-    @skip_if_bug_open('bugzilla', 1259498)
     def test_positive_update_name_by_id(self):
         """Create an external docker registry and update its name. Use registry
         ID to search by
@@ -1516,19 +1517,19 @@ class DockerRegistryTestCase(CLITestCase):
         @Feature: Docker
 
         @Assert: the external registry is updated with the new name
-
-        @BZ: 1259498
-
         """
         registry = make_registry()
-        for new_name in valid_data_list():
-            with self.subTest(new_name):
-                Docker.registry.update({
-                    'id': registry['id'],
-                    'new-name': new_name,
-                })
-                registry = Docker.registry.info({'id': registry['id']})
-                self.assertEqual(registry['name'], new_name)
+        try:
+            for new_name in valid_data_list():
+                with self.subTest(new_name):
+                    Docker.registry.update({
+                        'id': registry['id'],
+                        'new-name': new_name,
+                    })
+                    registry = Docker.registry.info({'id': registry['id']})
+                    self.assertEqual(registry['name'], new_name)
+        finally:
+            Docker.registry.delete({'id': registry['id']})
 
     @tier1
     @run_only_on('sat')
@@ -1539,21 +1540,22 @@ class DockerRegistryTestCase(CLITestCase):
         @Feature: Docker
 
         @Assert: the external registry is updated with the new name
-
         """
         registry = make_registry()
-        for new_name in valid_data_list():
-            with self.subTest(new_name):
-                Docker.registry.update({
-                    'name': registry['name'],
-                    'new-name': new_name,
-                })
-                registry = Docker.registry.info({'name': new_name})
-                self.assertEqual(registry['name'], new_name)
+        try:
+            for new_name in valid_data_list():
+                with self.subTest(new_name):
+                    Docker.registry.update({
+                        'name': registry['name'],
+                        'new-name': new_name,
+                    })
+                    registry = Docker.registry.info({'name': new_name})
+                    self.assertEqual(registry['name'], new_name)
+        finally:
+            Docker.registry.delete({'id': registry['id']})
 
     @tier1
     @run_only_on('sat')
-    @skip_if_bug_open('bugzilla', 1259498)
     def test_positive_update_url_by_id(self):
         """Create an external docker registry and update its URL. Use registry
         ID to search by
@@ -1561,18 +1563,18 @@ class DockerRegistryTestCase(CLITestCase):
         @Feature: Docker
 
         @Assert: the external registry is updated with the new URL
-
-        @BZ: 1259498
-
         """
         registry = make_registry()
-        new_url = gen_url(subdomain=gen_string('alpha'))
-        Docker.registry.update({
-            'id': registry['id'],
-            'url': new_url,
-        })
-        registry = Docker.registry.info({'id': registry['id']})
-        self.assertEqual(registry['url'], new_url)
+        try:
+            new_url = DOCKER_1_EXTERNAL_REGISTRY
+            Docker.registry.update({
+                'id': registry['id'],
+                'url': new_url,
+            })
+            registry = Docker.registry.info({'id': registry['id']})
+            self.assertEqual(registry['url'], new_url)
+        finally:
+            Docker.registry.delete({'id': registry['id']})
 
     @tier1
     @run_only_on('sat')
@@ -1583,20 +1585,21 @@ class DockerRegistryTestCase(CLITestCase):
         @Feature: Docker
 
         @Assert: the external registry is updated with the new URL
-
         """
         registry = make_registry()
-        new_url = gen_url(subdomain=gen_string('alpha'))
-        Docker.registry.update({
-            'name': registry['name'],
-            'url': new_url,
-        })
-        registry = Docker.registry.info({'name': registry['name']})
-        self.assertEqual(registry['url'], new_url)
+        try:
+            new_url = DOCKER_1_EXTERNAL_REGISTRY
+            Docker.registry.update({
+                'name': registry['name'],
+                'url': new_url,
+            })
+            registry = Docker.registry.info({'name': registry['name']})
+            self.assertEqual(registry['url'], new_url)
+        finally:
+            Docker.registry.delete({'id': registry['id']})
 
     @tier1
     @run_only_on('sat')
-    @skip_if_bug_open('bugzilla', 1259498)
     def test_positive_update_description_by_id(self):
         """Create an external docker registry and update its description. Use
         registry ID to search by
@@ -1604,23 +1607,22 @@ class DockerRegistryTestCase(CLITestCase):
         @Feature: Docker
 
         @Assert: the external registry is updated with the new description
-
-        @BZ: 1259498
-
         """
         registry = make_registry({'description': gen_string('alpha')})
-        for new_desc in valid_data_list():
-            with self.subTest(new_desc):
-                Docker.registry.update({
-                    'description': new_desc,
-                    'id': registry['id'],
-                })
-                registry = Docker.registry.info({'id': registry['id']})
-                self.assertEqual(registry['description'], new_desc)
+        try:
+            for new_desc in valid_data_list():
+                with self.subTest(new_desc):
+                    Docker.registry.update({
+                        'description': new_desc,
+                        'id': registry['id'],
+                    })
+                    registry = Docker.registry.info({'id': registry['id']})
+                    self.assertEqual(registry['description'], new_desc)
+        finally:
+            Docker.registry.delete({'id': registry['id']})
 
     @tier1
     @run_only_on('sat')
-    @skip_if_bug_open('bugzilla', 1259498)
     def test_positive_update_description_by_name(self):
         """Create an external docker registry and update its description. Use
         registry name to search by
@@ -1628,23 +1630,22 @@ class DockerRegistryTestCase(CLITestCase):
         @Feature: Docker
 
         @Assert: the external registry is updated with the new description
-
-        @BZ: 1259498
-
         """
         registry = make_registry({'description': gen_string('alpha')})
-        for new_desc in valid_data_list():
-            with self.subTest(new_desc):
-                Docker.registry.update({
-                    'description': new_desc,
-                    'name': registry['name'],
-                })
-                registry = Docker.registry.info({'name': registry['name']})
-                self.assertEqual(registry['description'], new_desc)
+        try:
+            for new_desc in valid_data_list():
+                with self.subTest(new_desc):
+                    Docker.registry.update({
+                        'description': new_desc,
+                        'name': registry['name'],
+                    })
+                    registry = Docker.registry.info({'name': registry['name']})
+                    self.assertEqual(registry['description'], new_desc)
+        finally:
+            Docker.registry.delete({'id': registry['id']})
 
     @tier1
     @run_only_on('sat')
-    @skip_if_bug_open('bugzilla', 1259498)
     def test_positive_update_username_by_id(self):
         """Create an external docker registry and update its username. Use
         registry ID to search by
@@ -1652,23 +1653,22 @@ class DockerRegistryTestCase(CLITestCase):
         @Feature: Docker
 
         @Assert: the external registry is updated with the new username
-
-        @BZ: 1259498
-
         """
         registry = make_registry({'username': gen_string('alpha')})
-        for new_user in valid_data_list():
-            with self.subTest(new_user):
-                Docker.registry.update({
-                    'id': registry['id'],
-                    'username': new_user,
-                })
-                registry = Docker.registry.info({'id': registry['id']})
-                self.assertEqual(registry['username'], new_user)
+        try:
+            for new_user in valid_data_list():
+                with self.subTest(new_user):
+                    Docker.registry.update({
+                        'id': registry['id'],
+                        'username': new_user,
+                    })
+                    registry = Docker.registry.info({'id': registry['id']})
+                    self.assertEqual(registry['username'], new_user)
+        finally:
+            Docker.registry.delete({'id': registry['id']})
 
     @tier1
     @run_only_on('sat')
-    @skip_if_bug_open('bugzilla', 1259498)
     def test_positive_update_username_by_name(self):
         """Create an external docker registry and update its username. Use
         registry name to search by
@@ -1676,32 +1676,28 @@ class DockerRegistryTestCase(CLITestCase):
         @Feature: Docker
 
         @Assert: the external registry is updated with the new username
-
-        @BZ: 1259498
-
         """
         registry = make_registry({'username': gen_string('alpha')})
-        for new_user in valid_data_list():
-            with self.subTest(new_user):
-                Docker.registry.update({
-                    'name': registry['name'],
-                    'username': new_user,
-                })
-                registry = Docker.registry.info({'name': registry['name']})
-                self.assertEqual(registry['username'], new_user)
+        try:
+            for new_user in valid_data_list():
+                with self.subTest(new_user):
+                    Docker.registry.update({
+                        'name': registry['name'],
+                        'username': new_user,
+                    })
+                    registry = Docker.registry.info({'name': registry['name']})
+                    self.assertEqual(registry['username'], new_user)
+        finally:
+            Docker.registry.delete({'id': registry['id']})
 
     @tier1
     @run_only_on('sat')
-    @skip_if_bug_open('bugzilla', 1259498)
     def test_positive_delete_by_id(self):
         """Create an external docker registry. Use registry ID to search by
 
         @Feature: Docker
 
         @Assert: the external registry is created
-
-        @BZ: 1259498
-
         """
         registry = make_registry()
         Docker.registry.delete({'id': registry['id']})
@@ -1716,7 +1712,6 @@ class DockerRegistryTestCase(CLITestCase):
         @Feature: Docker
 
         @Assert: the external registry is created
-
         """
         for name in valid_data_list():
             with self.subTest(name):

--- a/tests/foreman/ui/test_docker.py
+++ b/tests/foreman/ui/test_docker.py
@@ -6,6 +6,8 @@ from random import randint, shuffle
 from robottelo.api.utils import promote
 from robottelo.config import settings
 from robottelo.constants import (
+    DOCKER_0_EXTERNAL_REGISTRY,
+    DOCKER_1_EXTERNAL_REGISTRY,
     DOCKER_REGISTRY_HUB,
     FOREMAN_PROVIDERS,
     REPO_TYPE,
@@ -1315,7 +1317,6 @@ class DockerContainerTestCase(UITestCase):
 class DockerRegistryTestCase(UITestCase):
     """Tests specific to performing CRUD methods against ``Registries``
     repositories.
-
     """
 
     @run_only_on('sat')
@@ -1333,10 +1334,13 @@ class DockerRegistryTestCase(UITestCase):
                     make_registry(
                         session,
                         name=name,
-                        url=gen_url(subdomain=gen_string('alpha')),
+                        url=DOCKER_0_EXTERNAL_REGISTRY,
                         description=gen_string('utf8'),
                     )
-                    self.assertIsNotNone(self.registry.search(name))
+                    try:
+                        self.assertIsNotNone(self.registry.search(name))
+                    finally:
+                        entities.Registry(name=name).search()[0].delete()
 
     @run_only_on('sat')
     @tier1
@@ -1352,15 +1356,19 @@ class DockerRegistryTestCase(UITestCase):
             make_registry(
                 session,
                 name=name,
-                url=gen_url(subdomain=gen_string('alpha')),
+                url=DOCKER_0_EXTERNAL_REGISTRY,
                 description=gen_string('utf8'),
             )
-            self.assertIsNotNone(self.registry.search(name))
-            for new_name in valid_data_list():
-                with self.subTest(new_name):
-                    self.registry.update(name, new_name=new_name)
-                    self.assertIsNotNone(self.registry.search(new_name))
-                    name = new_name
+            try:
+                registry_entity = entities.Registry(name=name).search()[0]
+                self.assertIsNotNone(self.registry.search(name))
+                for new_name in valid_data_list():
+                    with self.subTest(new_name):
+                        self.registry.update(name, new_name=new_name)
+                        self.assertIsNotNone(self.registry.search(new_name))
+                        name = new_name
+            finally:
+                registry_entity.delete()
 
     @run_only_on('sat')
     @tier1
@@ -1376,15 +1384,18 @@ class DockerRegistryTestCase(UITestCase):
             make_registry(
                 session,
                 name=name,
-                url=gen_url(subdomain=gen_string('alpha')),
+                url=DOCKER_0_EXTERNAL_REGISTRY,
             )
-            self.assertIsNotNone(self.registry.search(name))
-
-            new_url = gen_url(subdomain=gen_string('alpha'))
-            self.registry.update(name, new_url=new_url)
-            self.registry.search(name).click()
-            self.assertIsNotNone(self.registry.wait_until_element(
-                locators['registry.url']).text, new_url)
+            try:
+                registry_entity = entities.Registry(name=name).search()[0]
+                self.assertIsNotNone(self.registry.search(name))
+                new_url = DOCKER_1_EXTERNAL_REGISTRY
+                self.registry.update(name, new_url=new_url)
+                self.registry.search(name).click()
+                self.assertIsNotNone(self.registry.wait_until_element(
+                    locators['registry.url']).text, new_url)
+            finally:
+                registry_entity.delete()
 
     @run_only_on('sat')
     @tier1
@@ -1400,16 +1411,19 @@ class DockerRegistryTestCase(UITestCase):
             make_registry(
                 session,
                 name=name,
-                url=gen_url(subdomain=gen_string('alpha')),
+                url=DOCKER_0_EXTERNAL_REGISTRY,
                 description=gen_string('alphanumeric'),
             )
-            self.assertIsNotNone(self.registry.search(name))
-
-            new_description = gen_string('utf8')
-            self.registry.update(name, new_desc=new_description)
-            self.registry.search(name).click()
-            self.assertIsNotNone(self.registry.wait_until_element(
-                locators['registry.description']).text, new_description)
+            try:
+                registry_entity = entities.Registry(name=name).search()[0]
+                self.assertIsNotNone(self.registry.search(name))
+                new_description = gen_string('utf8')
+                self.registry.update(name, new_desc=new_description)
+                self.registry.search(name).click()
+                self.assertIsNotNone(self.registry.wait_until_element(
+                    locators['registry.description']).text, new_description)
+            finally:
+                registry_entity.delete()
 
     @run_only_on('sat')
     @tier1
@@ -1425,16 +1439,19 @@ class DockerRegistryTestCase(UITestCase):
             make_registry(
                 session,
                 name=name,
-                url=gen_url(subdomain=gen_string('alpha')),
+                url=DOCKER_0_EXTERNAL_REGISTRY,
                 username=gen_string('alphanumeric'),
             )
-            self.assertIsNotNone(self.registry.search(name))
-
-            new_username = gen_string('utf8')
-            self.registry.update(name, new_username=new_username)
-            self.registry.search(name).click()
-            self.assertIsNotNone(self.registry.wait_until_element(
-                locators['registry.username']).text, new_username)
+            try:
+                registry_entity = entities.Registry(name=name).search()[0]
+                self.assertIsNotNone(self.registry.search(name))
+                new_username = gen_string('utf8')
+                self.registry.update(name, new_username=new_username)
+                self.registry.search(name).click()
+                self.assertIsNotNone(self.registry.wait_until_element(
+                    locators['registry.username']).text, new_username)
+            finally:
+                registry_entity.delete()
 
     @run_only_on('sat')
     @tier1
@@ -1451,7 +1468,7 @@ class DockerRegistryTestCase(UITestCase):
                     make_registry(
                         session,
                         name=name,
-                        url=gen_url(subdomain=gen_string('alpha')),
+                        url=DOCKER_0_EXTERNAL_REGISTRY,
                         description=gen_string('utf8'),
                     )
                     self.registry.delete(name)


### PR DESCRIPTION
Start to use real Docker Registry servers and make sure that corresponding entity is deleted after each test as we have to have unique URL per each Registry
Depends on https://github.com/SatelliteQE/nailgun/pull/278

Bonus: Fixed some Docker Container locators, but functionality still require some polishing.

```
nosetests tests/foreman/cli/test_docker.py:DockerRegistryTestCase
...........
----------------------------------------------------------------------
Ran 11 tests in 752.800s

OK

nosetests tests/foreman/api/test_docker.py:DockerRegistryTestCase
......
----------------------------------------------------------------------
Ran 6 tests in 43.113s

OK

nosetests tests/foreman/ui/test_docker.py:DockerRegistryTestCase
......
----------------------------------------------------------------------
Ran 6 tests in 494.443s

OK
```