### PR TITLE
Fix CLI failures Round 2

### DIFF
--- a/robottelo/cli/contentview.py
+++ b/robottelo/cli/contentview.py
@@ -156,12 +156,15 @@ class ContentView(Base):
             --repository-ids REPOSITORY_IDS      Repository ID
             --type TYPE                          type of filter (e.g. rpm,
                                                  package_group, erratum)
-
         """
         cls.command_sub = 'filter create'
         if options is None:
             options = {}
-        return cls.execute(cls._construct_command(options))
+        result = cls.execute(
+            cls._construct_command(options), output_format='csv')
+        if isinstance(result, list):
+            result = result[0]
+        return result
 
     @classmethod
     def filter_update(cls, options):

--- a/tests/foreman/cli/test_host.py
+++ b/tests/foreman/cli/test_host.py
@@ -118,7 +118,6 @@ class HostCreateTestCase(CLITestCase):
             u'compute-resource-id': compute_resource.id,
             u'domain-id': host.domain.id,
             u'environment-id': host.environment.id,
-            u'interface': 'type=network',
             u'location-id': host.location.id,  # pylint:disable=no-member
             u'medium-id': host.medium.id,
             u'name': host.name,

--- a/tests/foreman/cli/test_host_collection.py
+++ b/tests/foreman/cli/test_host_collection.py
@@ -118,6 +118,7 @@ class HostCollectionTestCase(CLITestCase):
                 self.assertEqual(new_host_col['limit'], str(limit))
 
     @skip_if_bug_open('bugzilla', 1214675)
+    @skip_if_bug_open('bugzilla', 1328925)
     @tier1
     def test_positive_create_with_unlimited_hosts(self):
         """Create Host Collection with different values of
@@ -128,8 +129,7 @@ class HostCollectionTestCase(CLITestCase):
         @Assert: Host Collection is created and unlimited-hosts
         parameter is set
 
-        @BZ: 1214675
-
+        @BZ: 1214675, 1328925
         """
         for unlimited in (u'True', u'Yes', 1, u'False', u'No', 0):
             with self.subTest(unlimited):
@@ -163,6 +163,7 @@ class HostCollectionTestCase(CLITestCase):
                     self._new_host_collection({'name': name})
 
     @tier1
+    @skip_if_bug_open('bugzilla', 1328925)
     def test_positive_update_name(self):
         """Check if host collection name can be updated
 
@@ -170,6 +171,7 @@ class HostCollectionTestCase(CLITestCase):
 
         @Assert: Host collection is created and name is updated
 
+        @BZ: 1328925
         """
         new_host_col = self._new_host_collection()
         for new_name in valid_data_list():
@@ -183,6 +185,7 @@ class HostCollectionTestCase(CLITestCase):
                 self.assertEqual(result['name'], new_name)
 
     @tier1
+    @skip_if_bug_open('bugzilla', 1328925)
     def test_positive_update_description(self):
         """Check if host collection description can be updated
 
@@ -190,6 +193,7 @@ class HostCollectionTestCase(CLITestCase):
 
         @Assert: Host collection is created and description is updated
 
+        @BZ: 1328925
         """
         new_host_col = self._new_host_collection()
         for desc in valid_data_list():
@@ -226,6 +230,7 @@ class HostCollectionTestCase(CLITestCase):
                 self.assertEqual(result['limit'], limit)
 
     @tier1
+    @skip_if_bug_open('bugzilla', 1328925)
     def test_positive_delete_by_id(self):
         """Check if host collection can be created and deleted
 
@@ -233,6 +238,7 @@ class HostCollectionTestCase(CLITestCase):
 
         @Assert: Host collection is created and then deleted
 
+        @BZ: 1328925
         """
         for name in valid_data_list():
             with self.subTest(name):
@@ -245,6 +251,7 @@ class HostCollectionTestCase(CLITestCase):
                     HostCollection.info({'id': new_host_col['id']})
 
     @tier2
+    @skip_if_bug_open('bugzilla', 1328925)
     def test_positive_add_host_by_id(self):
         """Check if content host can be added to host collection
 
@@ -252,6 +259,7 @@ class HostCollectionTestCase(CLITestCase):
 
         @Assert: Host collection is created and content-host is added
 
+        @BZ: 1328925
         """
         new_host_col = self._new_host_collection({
             'name': gen_string('alpha', 15)})
@@ -274,6 +282,7 @@ class HostCollectionTestCase(CLITestCase):
         self.assertGreater(result['total-hosts'], no_of_content_host)
 
     @tier2
+    @skip_if_bug_open('bugzilla', 1328925)
     def test_positive_remove_chost_by_id(self):
         """Check if content host can be removed from host collection
 
@@ -281,6 +290,7 @@ class HostCollectionTestCase(CLITestCase):
 
         @Assert: Host collection is created and content-host is removed
 
+        @BZ: 1328925
         """
         new_host_col = self._new_host_collection({
             'name': gen_string('alpha', 15)})
@@ -311,6 +321,7 @@ class HostCollectionTestCase(CLITestCase):
         self.assertGreater(no_of_content_host, result['total-hosts'])
 
     @tier2
+    @skip_if_bug_open('bugzilla', 1328925)
     def test_positive_list_hosts(self):
         """Check if content hosts added to host collection is listed
 
@@ -318,6 +329,7 @@ class HostCollectionTestCase(CLITestCase):
 
         @Assert: Content-host added to host-collection is listed
 
+        @BZ: 1328925
         """
         host_col_name = gen_string('alpha', 15)
         new_host_col = self._new_host_collection({'name': host_col_name})

--- a/tests/foreman/cli/test_lifecycleenvironment.py
+++ b/tests/foreman/cli/test_lifecycleenvironment.py
@@ -209,7 +209,6 @@ class LifeCycleEnvironmentTestCase(CLITestCase):
                     'id': new_lce['id'],
                     'new-name': new_name,
                     'organization-id': self.org['id'],
-                    'prior': new_lce['prior-lifecycle-environment'],
                 })
                 result = LifecycleEnvironment.info({
                     'id': new_lce['id'],
@@ -237,7 +236,6 @@ class LifeCycleEnvironmentTestCase(CLITestCase):
                     'description': new_desc,
                     'id': new_lce['id'],
                     'organization-id': self.org['id'],
-                    'prior': new_lce['prior-lifecycle-environment'],
                 })
                 result = LifecycleEnvironment.info({
                     'id': new_lce['id'],

--- a/tests/foreman/cli/test_repository.py
+++ b/tests/foreman/cli/test_repository.py
@@ -242,6 +242,7 @@ class RepositoryTestCase(CLITestCase):
                 new_repo = self._make_repository({
                     u'gpg-key': gpg_key['name'],
                     u'name': name,
+                    u'organization-id': self.org['id'],
                 })
                 self.assertEqual(new_repo['gpg-key']['id'], gpg_key['id'])
                 self.assertEqual(new_repo['gpg-key']['name'], gpg_key['name'])

--- a/tests/foreman/cli/test_template.py
+++ b/tests/foreman/cli/test_template.py
@@ -11,7 +11,7 @@ from robottelo.cli.factory import (
     make_template,
 )
 from robottelo.cli.template import Template
-from robottelo.decorators import run_only_on, tier1, tier2
+from robottelo.decorators import run_only_on, skip_if_bug_open, tier1, tier2
 from robottelo.test import CLITestCase
 
 
@@ -64,12 +64,15 @@ class TemplateTestCase(CLITestCase):
 
     @run_only_on('sat')
     @tier1
+    @skip_if_bug_open('bugzilla', 1328976)
     def test_negative_create_locked(self):
         """Check that locked Template cannot be created
 
         @Feature: Template - Create
 
         @Assert: It is not allowed to create locked Template
+
+        @BZ: 1328976
         """
         with self.assertRaises(CLIFactoryError):
             make_template({


### PR DESCRIPTION
Add workaround for cli.test_contentviewfilter test_negative_update_with_name
because BZ 1328943.

Test results:

Results for `cli.test_contentview`:

```
$ py.test tests/foreman/cli/test_contentview.py -k test_positive_delete_with_custom_repo_by_name_and_verify_files
==================== test session starts ====================
platform linux -- Python 3.4.2, pytest-2.9.1, py-1.4.31, pluggy-0.3.1
rootdir: /home/elyezer/code/robottelo, inifile: 
plugins: cov-2.2.1, testmon-0.8.2, xdist-1.14
collected 49 items 

tests/foreman/cli/test_contentview.py s

 48 tests deselected by '-ktest_positive_delete_with_custom_repo_by_name_and_verify_files' 
========= 1 skipped, 48 deselected in 39.69 seconds =========
```

Results for `cli.test_contentviewfilter`:

```
$ py.test tests/foreman/cli/test_contentviewfilter.py -ktest_negative_update_with_name
==================== test session starts ====================
platform linux -- Python 3.4.2, pytest-2.9.1, py-1.4.31, pluggy-0.3.1
rootdir: /home/elyezer/code/robottelo, inifile: 
plugins: cov-2.2.1, testmon-0.8.2, xdist-1.14
collected 29 items 

tests/foreman/cli/test_contentviewfilter.py .

= 28 tests deselected by '-ktest_negative_update_with_name' =
========= 1 passed, 28 deselected in 72.72 seconds ==========
```

Results for `cli.test_host`:

```
 (robottelo) ~/code/robottelo   fix-cli-failures-round2 ●  py.test tests/foreman/cli/test_host.py -k test_positive_create_using_libvirt_without_mac
==================== test session starts ====================
platform linux -- Python 3.4.2, pytest-2.9.1, py-1.4.31, pluggy-0.3.1
rootdir: /home/elyezer/code/robottelo, inifile: 
plugins: cov-2.2.1, testmon-0.8.2, xdist-1.14
collected 39 items 

tests/foreman/cli/test_host.py .

 38 tests deselected by '-ktest_positive_create_using_libvirt_without_mac' 
========= 1 passed, 38 deselected in 32.04 seconds ==========
```

Results for `cli.test_hostcollection`:

```
$ py.test tests/foreman/cli/test_host_collection.py -n auto --boxed -m "not stubbed"
==================== test session starts ====================
platform linux -- Python 3.4.2, pytest-2.9.1, py-1.4.31, pluggy-0.3.1
rootdir: /home/elyezer/code/robottelo, inifile: 
plugins: cov-2.2.1, testmon-0.8.2, xdist-1.14
gw0 [12] / gw1 [12] / gw2 [12] / gw3 [12]
scheduling tests via LoadScheduling
s...ss.sssss
=========== 4 passed, 8 skipped in 193.39 seconds ===========
```

Results for `cli.test_lifecycleenvironment`:

```
$ py.test tests/foreman/cli/test_lifecycleenvironment.py -n auto --boxed -m "not stubbed" 
==================== test session starts ====================
platform linux -- Python 3.4.2, pytest-2.9.1, py-1.4.31, pluggy-0.3.1
rootdir: /home/elyezer/code/robottelo, inifile: 
plugins: cov-2.2.1, testmon-0.8.2, xdist-1.14
gw0 [11] / gw1 [11] / gw2 [11] / gw3 [11]
scheduling tests via LoadScheduling
...........
================ 11 passed in 75.73 seconds =================
```

Results for `cli.test_repository`:

```
$ py.test tests/foreman/cli/test_repository.py -k test_positive_create_with_gpg_key_by_name
==================== test session starts ====================
platform linux -- Python 3.4.2, pytest-2.9.1, py-1.4.31, pluggy-0.3.1
rootdir: /home/elyezer/code/robottelo, inifile: 
plugins: cov-2.2.1, testmon-0.8.2, xdist-1.14
collected 30 items 

tests/foreman/cli/test_repository.py .

 29 tests deselected by '-ktest_positive_create_with_gpg_key_by_name' 
========= 1 passed, 29 deselected in 39.72 seconds ==========
```

Results for `cli.test_template`:

```
$ py.test tests/foreman/cli/test_template.py -n auto --boxed -m "not stubbed"
==================== test session starts ====================
platform linux -- Python 3.4.2, pytest-2.9.1, py-1.4.31, pluggy-0.3.1
rootdir: /home/elyezer/code/robottelo, inifile: 
plugins: cov-2.2.1, testmon-0.8.2, xdist-1.14
gw0 [9] / gw1 [9] / gw2 [9] / gw3 [9]
scheduling tests via LoadScheduling
s........
=========== 8 passed, 1 skipped in 59.75 seconds ============
```