### PR TITLE
Skip API repository upload content tests due to open BZ

### DIFF
--- a/tests/foreman/api/test_contentview.py
+++ b/tests/foreman/api/test_contentview.py
@@ -27,6 +27,7 @@ from robottelo.decorators import (
 )
 from robottelo.helpers import get_data_file
 from robottelo.test import APITestCase
+from unittest import skipIf
 
 
 # Some tests repeatedly publish content views or promote content view versions.
@@ -306,6 +307,7 @@ class ContentViewCreateTestCase(APITestCase):
                     entities.ContentView(name=name).create()
 
 
+@skipIf(bz_bug_is_open(1329292), 'Skipping due to open Bugzilla bug #1329292')
 class ContentViewPublishPromoteTestCase(APITestCase):
     """Tests for publishing and promoting content views."""
 

--- a/tests/foreman/api/test_contentviewversion.py
+++ b/tests/foreman/api/test_contentviewversion.py
@@ -8,7 +8,7 @@ from robottelo.constants import (
     PUPPET_MODULE_NTP_PUPPETLABS,
     ZOO_CUSTOM_GPG_KEY,
 )
-from robottelo.decorators import tier2
+from robottelo.decorators import skip_if_bug_open, tier2
 from robottelo.helpers import get_data_file, read_data_file
 from robottelo.test import APITestCase
 
@@ -281,6 +281,7 @@ class ContentViewVersionDeleteTestCase(APITestCase):
 class ContentViewVersionIncrementalTestCase(APITestCase):
     """Tests for content view version promotion."""
 
+    @skip_if_bug_open('bugzilla', 1329292)
     @tier2
     def test_positive_incremental_update_puppet(self):
         """Incrementally update a CVV with a puppet module.

--- a/tests/foreman/api/test_hostgroup.py
+++ b/tests/foreman/api/test_hostgroup.py
@@ -28,8 +28,9 @@ class HostGroupTestCase(APITestCase):
         cls.org = entities.Organization().create()
         cls.loc = entities.Location(organization=[cls.org]).create()
 
-    @tier3
     @skip_if_bug_open('bugzilla', 1222118)
+    @skip_if_bug_open('bugzilla', 1329292)
+    @tier3
     def test_verify_bugzilla_1107708(self):
         """Host that created from HostGroup entity with PuppetClass
         assigned to it should inherit such puppet class information under

--- a/tests/foreman/api/test_puppetmodule.py
+++ b/tests/foreman/api/test_puppetmodule.py
@@ -1,9 +1,10 @@
 """Unit tests for the ``katello/api/v2/puppet_modules`` paths."""
 from nailgun import entities
 from robottelo.constants import PUPPET_MODULE_NTP_PUPPETLABS
-from robottelo.decorators import skip_if_bug_open, tier1
+from robottelo.decorators import bz_bug_is_open, skip_if_bug_open, tier1
 from robottelo.helpers import get_data_file
 from robottelo.test import APITestCase
+from unittest import skipIf
 
 
 class RepositorySearchTestCase(APITestCase):
@@ -37,8 +38,9 @@ class RepositorySearchTestCase(APITestCase):
         query = {'repository_id': self.repository.id}
         self.assertEqual(len(entities.PuppetModule().search(query=query)), 0)
 
-    @tier1
     @skip_if_bug_open('bugzilla', 1260206)
+    @skip_if_bug_open('bugzilla', 1329292)
+    @tier1
     def test_positive_search_single_result(self):
         """Search for puppet modules in a non-empty repository.
 
@@ -52,6 +54,7 @@ class RepositorySearchTestCase(APITestCase):
         self.assertEqual(len(entities.PuppetModule().search(query=query)), 1)
 
 
+@skipIf(bz_bug_is_open(1329292), 'Skipping due to open Bugzilla bug #1329292')
 class ContentViewVersionSearchTestCase(APITestCase):
     """Tests that search for puppet modules and filter by content view ver."""
 

--- a/tests/foreman/api/test_repository.py
+++ b/tests/foreman/api/test_repository.py
@@ -404,8 +404,9 @@ class RepositoryTestCase(APITestCase):
         repo = repo.update()
         self.assertEqual(repo.gpg_key.id, gpg_key_2.id)
 
-    @tier2
     @run_only_on('sat')
+    @skip_if_bug_open('bugzilla', 1329292)
+    @tier2
     def test_positive_update_contents(self):
         """Create a repository and upload RPM contents.
 


### PR DESCRIPTION
`entites.Repository().upload_content()` is broken as per [BZ1329292](https://bugzilla.redhat.com/show_bug.cgi?id=1329292), skipping all affected tests.