### PR TITLE
Remove negative description create/update tests

### DIFF
--- a/tests/foreman/api/test_computeresource.py
+++ b/tests/foreman/api/test_computeresource.py
@@ -11,11 +11,7 @@ from random import randint
 from requests.exceptions import HTTPError
 from robottelo.config import settings
 from robottelo.constants import LIBVIRT_RESOURCE_URL
-from robottelo.datafactory import (
-    invalid_names_list,
-    invalid_values_list,
-    valid_data_list,
-)
+from robottelo.datafactory import invalid_values_list, valid_data_list
 from robottelo.decorators import tier1, tier2
 from robottelo.test import APITestCase
 
@@ -370,24 +366,6 @@ class ComputeResourceTestCase(APITestCase):
                 organization=[self.org],
                 url=self.current_libvirt_url,
             ).create()
-
-    @tier1
-    def test_negative_create_with_description(self):
-        """Attempt to create compute resources with invalid descriptions
-
-        @Feature: Compute Resource
-
-        @Assert: Compute resources are not created
-        """
-        for description in invalid_names_list():
-            with self.subTest(description):
-                with self.assertRaises(HTTPError):
-                    entities.LibvirtComputeResource(
-                        description=description,
-                        location=[self.loc],
-                        organization=[self.org],
-                        url=self.current_libvirt_url,
-                    ).create()
 
     @tier1
     def test_negative_create_with_url(self):

--- a/tests/foreman/cli/test_activationkey.py
+++ b/tests/foreman/cli/test_activationkey.py
@@ -202,22 +202,6 @@ class ActivationKeyTestCase(CLITestCase):
                 with self.assertRaises(CLIFactoryError):
                     self._make_activation_key({u'name': name})
 
-    @run_only_on('sat')
-    @skip_if_bug_open('bugzilla', 1177158)
-    @tier1
-    def test_negative_create_with_invalid_description(self):
-        """Create Activation key with invalid Description
-
-        @Feature: Activation key - Negative Create
-
-        @BZ: 1177158
-
-        @Assert: Activation key is not created. Appropriate error shown.
-        """
-        with self.assertRaises(CLIFactoryError):
-            self._make_activation_key(
-                {u'description': gen_string('alpha', 1001)})
-
     @tier1
     def test_negative_create_with_usage_limit(self):
         """Create Activation key with invalid Usage Limit
@@ -489,26 +473,6 @@ class ActivationKeyTestCase(CLITestCase):
                         u'new-name': name,
                         u'organization-id': self.org['id'],
                     })
-
-    @skip_if_bug_open('bugzilla', 1177158)
-    @tier1
-    def test_negative_update_description(self):
-        """Try to update Activation Key using invalid value for its
-        description
-
-        @Feature: Activation key - Negative Update
-
-        @BZ: 1177158
-
-        @Assert: Activation key is not updated. Appropriate error shown.
-        """
-        new_ak = self._make_activation_key()
-        with self.assertRaises(CLIReturnCodeError):
-            ActivationKey.update({
-                u'id': new_ak['id'],
-                u'description': gen_string('alpha', 1001),
-                u'organization-id': self.org['id'],
-            })
 
     @tier1
     def test_negative_update_usage_limit(self):

--- a/tests/foreman/cli/test_computeresource.py
+++ b/tests/foreman/cli/test_computeresource.py
@@ -53,12 +53,9 @@ def valid_name_desc_data():
 
 
 def invalid_create_data():
-    """Random data for invalid name, description and url"""
+    """Random data for invalid name and url"""
     return(
         {u'name': gen_string('alphanumeric', 256)},
-        {u'description': gen_string('alphanumeric', 256)},
-        {u'name': 'white %s spaces' %
-                  gen_string(str_type='alphanumeric')},
         {u'name': ''},
         {u'url': 'invalid url'},
         {u'url': ''},
@@ -84,7 +81,6 @@ def invalid_update_data():
         {u'new-name': 'white spaces %s' %
                       gen_string(str_type='alphanumeric')},
         {u'new-name': ''},
-        {u'description': gen_string('utf8', 256)},
         {u'url': 'invalid url'},
         {u'url': ''},
     )
@@ -264,19 +260,17 @@ class ComputeResourceTestCase(CLITestCase):
 
     @tier1
     @run_only_on('sat')
-    def test_negative_create_with_name_description_url(self):
+    def test_negative_create_with_name_url(self):
         """Compute Resource negative create with invalid values
 
         @Feature: Compute Resource create
 
         @Assert: Compute resource not created
-
         """
         for options in invalid_create_data():
             with self.subTest(options):
                 with self.assertRaises(CLIReturnCodeError):
                     ComputeResource.create({
-                        u'description': options.get('description', ''),
                         u'name': options.get(
                             'name', gen_string(str_type='alphanumeric')),
                         u'provider': FOREMAN_PROVIDERS['libvirt'],

--- a/tests/foreman/cli/test_domain.py
+++ b/tests/foreman/cli/test_domain.py
@@ -27,7 +27,6 @@ def valid_create_params():
 def invalid_create_params():
     """Returns a list of invalid domain create parameters"""
     return [
-        {u'description': gen_string(str_type='utf8', length=256)},
         {u'dns-id': '-1'},
         {u'name': gen_string(str_type='utf8', length=256)},
     ]
@@ -52,7 +51,6 @@ def invalid_update_params():
     return [
         {u'name': ''},
         {u'name': gen_string(str_type='utf8', length=256)},
-        {u'description': gen_string(str_type='utf8', length=256)},
         {u'dns-id': '-1'},
     ]
 

--- a/tests/foreman/ui/test_activationkey.py
+++ b/tests/foreman/ui/test_activationkey.py
@@ -21,7 +21,6 @@ from robottelo.constants import (
 from robottelo.datafactory import invalid_names_list, valid_data_list
 from robottelo.decorators import (
     run_only_on,
-    skip_if_bug_open,
     skip_if_not_set,
     stubbed,
     tier1,
@@ -273,31 +272,6 @@ class ActivationKeyTestCase(UITestCase):
                     self.assertIsNotNone(self.activationkey.wait_until_element(
                         common_locators['common_invalid']))
                     self.assertIsNone(self.activationkey.search(name))
-
-    @skip_if_bug_open('bugzilla', 1177158)
-    @tier1
-    def test_negative_create_with_too_long_description(self):
-        """Create Activation key with too long description
-
-        @Feature: Activation key - Negative Create
-
-        @Assert: Activation key is not created. Appropriate error shown.
-
-        @BZ: 1177158
-        """
-        name = gen_string('alpha')
-        description = gen_string('alpha', 1001)
-        with Session(self.browser) as session:
-            make_activationkey(
-                session,
-                org=self.organization.name,
-                name=name,
-                env=ENVIRONMENT,
-                description=description,
-            )
-            self.assertIsNotNone(self.activationkey.wait_until_element(
-                common_locators['common_haserror']))
-            self.assertIsNone(self.activationkey.search(name))
 
     @tier2
     def test_negative_create_with_invalid_limit(self):
@@ -719,32 +693,6 @@ class ActivationKeyTestCase(UITestCase):
                     self.assertIsNotNone(self.activationkey.wait_until_element(
                         common_locators['alert.error']))
                     self.assertIsNone(self.activationkey.search(new_name))
-
-    @skip_if_bug_open('bugzilla', 1177158)
-    @tier1
-    def test_negative_update_description(self):
-        """Update invalid Description in an activation key
-
-        @Feature: Activation key - Negative Update
-
-        @Assert: Activation key is not updated.  Appropriate error shown.
-
-        @BZ: 1177158
-        """
-        name = gen_string('alpha')
-        new_description = gen_string('alpha', 1001)
-        with Session(self.browser) as session:
-            make_activationkey(
-                session,
-                org=self.organization.name,
-                name=name,
-                env=ENVIRONMENT,
-                description=gen_string('alpha'),
-            )
-            self.assertIsNotNone(self.activationkey.search(name))
-            self.activationkey.update(name, description=new_description)
-            self.assertIsNotNone(self.activationkey.wait_until_element(
-                common_locators['alert.error']))
 
     @tier1
     def test_negative_update_limit(self):

--- a/tests/foreman/ui/test_computeresource.py
+++ b/tests/foreman/ui/test_computeresource.py
@@ -152,31 +152,6 @@ class ComputeResourceTestCase(UITestCase):
 
     @run_only_on('sat')
     @tier1
-    def test_negative_create_libvirt_with_invalid_description(self):
-        """Create libvirt Compute Resource with incorrect description.
-
-        @Feature: Compute Resource - Create with long description.
-
-        @Assert: A libvirt Compute Resource is not created
-        """
-        with Session(self.browser) as session:
-            for description in invalid_names_list():
-                with self.subTest(description):
-                    make_resource(
-                        session,
-                        name=gen_string('alpha'),
-                        provider_type=FOREMAN_PROVIDERS['libvirt'],
-                        parameter_list=[
-                            ['URL', self.current_libvirt_url, 'field'],
-                            ['Description', description, 'field']
-                        ],
-                    )
-                    error_element = session.nav.wait_until_element(
-                        common_locators["haserror"])
-                    self.assertIsNotNone(error_element)
-
-    @run_only_on('sat')
-    @tier1
     def test_positive_update_libvirt_name(self):
         """Update a libvirt Compute Resource name
 

--- a/tests/foreman/ui/test_contentview.py
+++ b/tests/foreman/ui/test_contentview.py
@@ -406,26 +406,6 @@ class ContentViewTestCase(UITestCase):
                     self.assertIsNotNone(self.content_views.wait_until_element(
                         common_locators['alert.success']))
 
-    @run_only_on('sat')
-    @tier1
-    def test_negative_update_description(self):
-        """Try to update content views description to invalid one.
-
-        @feature: Content Views
-
-        @assert: Content View is not updated. Appropriate error shown.
-        """
-        name = gen_string('alpha', 8)
-        desc = gen_string('alpha', 15)
-        new_description = gen_string('alpha', 256)
-        with Session(self.browser) as session:
-            make_contentview(session, org=self.organization.name,
-                             name=name, description=desc)
-            self.assertIsNotNone(self.content_views.search(name))
-            self.content_views.update(name, new_description=new_description)
-            self.assertIsNotNone(self.content_views.wait_until_element(
-                common_locators['alert.error']))
-
     @stubbed()
     @run_only_on('sat')
     @tier3

--- a/tests/foreman/ui/test_operatingsystem.py
+++ b/tests/foreman/ui/test_operatingsystem.py
@@ -120,6 +120,7 @@ class OperatingSystemTestCase(UITestCase):
                         common_locators['name_haserror']))
 
     @run_only_on('sat')
+    @skip_if_bug_open('bugzilla', 1328935)
     @tier1
     def test_negative_create_with_too_long_description(self):
         """OS - Create a new OS with description containing


### PR DESCRIPTION
As per [BZ1177158](https://bugzilla.redhat.com/show_bug.cgi?id=1177158), we don't have any length limit for descriptions, removing corresponding tests