### PR TITLE
Update cli.test_computeresource

### DIFF
--- a/tests/foreman/cli/test_computeresource.py
+++ b/tests/foreman/cli/test_computeresource.py
@@ -67,6 +67,8 @@ def valid_update_data():
     return(
         {u'new-name': gen_string('utf8', 255)},
         {u'new-name': gen_string('alphanumeric')},
+        {u'new-name': 'white spaces %s' %
+                      gen_string(str_type='alphanumeric')},
         {u'description': gen_string('utf8', 255)},
         {u'description': gen_string('alphanumeric')},
         {u'url': gen_url()},
@@ -78,8 +80,6 @@ def invalid_update_data():
     """Random data for invalid update"""
     return(
         {u'new-name': gen_string('utf8', 256)},
-        {u'new-name': 'white spaces %s' %
-                      gen_string(str_type='alphanumeric')},
         {u'new-name': ''},
         {u'url': 'invalid url'},
         {u'url': ''},
@@ -108,7 +108,7 @@ class ComputeResourceTestCase(CLITestCase):
 
         """
         ComputeResource.create({
-            'name': gen_string(str_type='alpha'),
+            'name': 'cr {0}'.format(gen_string(str_type='alpha')),
             'provider': 'Libvirt',
             'url': self.current_libvirt_url,
         })


### PR DESCRIPTION
Adjust the invalid and valid data generators to match the new behavior.

Test results:

```
$ py.test tests/foreman/cli/test_computeresource.py -n auto --boxed       
========================== test session starts ===========================
platform linux -- Python 3.4.2, pytest-2.9.1, py-1.4.31, pluggy-0.3.1
rootdir: /home/elyezer/code/robottelo, inifile: 
plugins: cov-2.2.1, testmon-0.8.2, xdist-1.14
gw0 [14] / gw1 [14] / gw2 [14] / gw3 [14]
scheduling tests via LoadScheduling
s.............
================= 13 passed, 1 skipped in 228.97 seconds =================
```