### PR TITLE
Improve UI screenshot naming

### DIFF
--- a/robottelo/test.py
+++ b/robottelo/test.py
@@ -223,12 +223,12 @@ class UITestCase(TestCase):
             path = os.path.join(
                 settings.screenshots_path,
                 now.strftime('%Y-%m-%d'),
-                type(self).__name__,
-                self._testMethodName,
             )
             if not os.path.exists(path):
                 os.makedirs(path)
-            filename = 'screenshot-{0}.png'.format(
+            filename = '{0}-{1}-screenshot-{2}.png'.format(
+                type(self).__name__,
+                self._testMethodName,
                 now.strftime('%Y-%m-%d_%H_%M_%S')
             )
             path = os.path.join(path, filename)


### PR DESCRIPTION
Robottelo takes screenshot just when an UI test fails and that happens just
once for every test. Because that is better to no create directories based on
the test class name and test method name. Instead put all the generated
screenshots under the same directory based on the current day and prepend the
ClassName-method_name- to the generated filename.