### PR TITLE
Fix more UI tests for 6.2 (activation_keys and sync_plans)

### DIFF
--- a/robottelo/ui/syncplan.py
+++ b/robottelo/ui/syncplan.py
@@ -1,5 +1,5 @@
 """Implements Sync Plans for UI."""
-from robottelo.ui.base import Base, UIError
+from robottelo.ui.base import Base
 from robottelo.ui.locators import common_locators, locators, tab_locators
 from robottelo.ui.navigator import Navigator
 
@@ -50,13 +50,7 @@ class Syncplan(Base):
                new_sync_interval=None, add_products=None,
                rm_products=None):
         """Updates Sync Plans from UI."""
-        sp_element = self.search(name)
-        if sp_element is None:
-            raise UIError(
-                'Unable to find the sync_plan "{0}" for update.'.format(name)
-            )
-        sp_element.click()
-        self.wait_for_ajax()
+        self.search(name).click()
         self.click(tab_locators['sp.tab_details'])
         if new_name:
             self.click(locators['sp.name_edit'])

--- a/tests/foreman/ui/test_activationkey.py
+++ b/tests/foreman/ui/test_activationkey.py
@@ -224,7 +224,7 @@ class ActivationKeyTestCase(UITestCase):
             # add Host Collection
             self.activationkey.add_host_collection(name, host_col.name)
             self.assertIsNotNone(self.activationkey.find_element(
-                common_locators['alert.success']))
+                common_locators['alert.success_sub_form']))
 
             # check added host collection is listed
             self.activationkey.click(tab_locators['ak.host_collections.list'])
@@ -340,6 +340,7 @@ class ActivationKeyTestCase(UITestCase):
                 org=self.organization.name,
                 name=name,
                 env=env_name,
+                content_view=cv_name,
             )
             self.assertIsNotNone(self.activationkey.search(name))
             self.activationkey.delete(name)
@@ -402,7 +403,7 @@ class ActivationKeyTestCase(UITestCase):
             self.assertIsNotNone(self.activationkey.search(name))
             self.activationkey.associate_product(name, [product_name])
             self.assertIsNotNone(self.activationkey.wait_until_element(
-                common_locators['alert.success']))
+                common_locators['alert.success_sub_form']))
             with VirtualMachine(distro=self.vm_distro) as vm:
                 vm.install_katello_ca()
                 result = vm.register_contenthost(name, self.organization.label)
@@ -480,7 +481,7 @@ class ActivationKeyTestCase(UITestCase):
                 with self.subTest(new_desc):
                     self.activationkey.update(name, description=new_desc)
                     self.assertIsNotNone(self.activationkey.wait_until_element(
-                        common_locators['alert.success']))
+                        common_locators['alert.success_sub_form']))
 
     @run_only_on('sat')
     @tier2
@@ -510,7 +511,7 @@ class ActivationKeyTestCase(UITestCase):
             self.assertEqual(ENVIRONMENT, selected_env)
             self.activationkey.update(name, content_view=cv_name, env=env_name)
             self.assertIsNotNone(self.activationkey.wait_until_element(
-                common_locators['alert.success']))
+                common_locators['alert.success_sub_form']))
             selected_env = self.activationkey.get_attribute(name, env_locator)
             self.assertEqual(env_name, selected_env)
 
@@ -555,7 +556,7 @@ class ActivationKeyTestCase(UITestCase):
             self.activationkey.update(
                 name, content_view=cv2_name, env=env2_name)
             self.assertIsNotNone(self.activationkey.wait_until_element(
-                common_locators['alert.success']))
+                common_locators['alert.success_sub_form']))
             selected_cv = self.activationkey.get_attribute(name, cv_locator)
             self.assertEqual(cv2_name, selected_cv)
 
@@ -623,7 +624,7 @@ class ActivationKeyTestCase(UITestCase):
             self.activationkey.update(
                 name, content_view=cv2_name, env=env2_name)
             self.assertIsNotNone(self.activationkey.wait_until_element(
-                common_locators['alert.success']))
+                common_locators['alert.success_sub_form']))
             selected_cv = self.activationkey.get_attribute(name, cv_locator)
             self.assertEqual(cv2_name, selected_cv)
 
@@ -646,7 +647,7 @@ class ActivationKeyTestCase(UITestCase):
             self.assertIsNotNone(self.activationkey.search(name))
             self.activationkey.update(name, limit='8')
             self.assertIsNotNone(self.activationkey.wait_until_element(
-                common_locators['alert.success']))
+                common_locators['alert.success_sub_form']))
 
     @tier1
     def test_positive_update_limit_to_unlimited(self):
@@ -668,7 +669,7 @@ class ActivationKeyTestCase(UITestCase):
             self.assertIsNotNone(self.activationkey.search(name))
             self.activationkey.update(name, limit='Unlimited')
             self.assertIsNotNone(self.activationkey.wait_until_element(
-                common_locators['alert.success']))
+                common_locators['alert.success_sub_form']))
 
     @tier1
     def test_negative_update_name(self):
@@ -691,7 +692,7 @@ class ActivationKeyTestCase(UITestCase):
                 with self.subTest(new_name):
                     self.activationkey.update(name, new_name)
                     self.assertIsNotNone(self.activationkey.wait_until_element(
-                        common_locators['alert.error']))
+                        common_locators['alert.error_sub_form']))
                     self.assertIsNone(self.activationkey.search(new_name))
 
     @tier1
@@ -749,7 +750,7 @@ class ActivationKeyTestCase(UITestCase):
             self.assertIsNotNone(self.activationkey.search(name))
             self.activationkey.update(name, limit=host_limit)
             self.assertIsNotNone(self.activationkey.wait_until_element(
-                common_locators['alert.success']))
+                common_locators['alert.success_sub_form']))
             with VirtualMachine(distro=self.vm_distro) as vm1:
                 with VirtualMachine(distro=self.vm_distro) as vm2:
                     vm1.install_katello_ca()
@@ -840,7 +841,7 @@ class ActivationKeyTestCase(UITestCase):
             self.assertIsNotNone(self.activationkey.search(name))
             self.activationkey.associate_product(name, [product_subscription])
             self.assertIsNotNone(self.activationkey.wait_until_element(
-                common_locators['alert.success']))
+                common_locators['alert.success_sub_form']))
 
     @run_only_on('sat')
     @tier2
@@ -869,7 +870,7 @@ class ActivationKeyTestCase(UITestCase):
             self.assertIsNotNone(self.activationkey.search(name))
             self.activationkey.associate_product(name, [product_name])
             self.assertIsNotNone(self.activationkey.wait_until_element(
-                common_locators['alert.success']))
+                common_locators['alert.success_sub_form']))
 
     @skip_if_not_set('fake_manifest')
     @run_only_on('sat')
@@ -940,7 +941,7 @@ class ActivationKeyTestCase(UITestCase):
             self.activationkey.associate_product(
                 name, [product_subscription, custom_product_name])
             self.assertIsNotNone(self.activationkey.wait_until_element(
-                common_locators['alert.success']))
+                common_locators['alert.success_sub_form']))
 
     @skip_if_not_set('fake_manifest')
     @tier2
@@ -986,7 +987,7 @@ class ActivationKeyTestCase(UITestCase):
             self.navigator.go_to_red_hat_subscriptions()
             self.subscriptions.delete()
             self.assertIsNotNone(self.subscriptions.wait_until_element(
-                common_locators['alert.success']))
+                common_locators['alert.success_sub_form']))
             # Verify the subscription was removed from the activation key
             self.navigator.go_to_activation_keys()
             self.assertIsNone(
@@ -1031,7 +1032,7 @@ class ActivationKeyTestCase(UITestCase):
             self.assertIsNotNone(self.activationkey.search(key_1_name))
             self.activationkey.associate_product(key_1_name, [product_1_name])
             self.assertIsNotNone(self.activationkey.wait_until_element(
-                common_locators['alert.success']))
+                common_locators['alert.success_sub_form']))
             # Create activation_key_2
             make_activationkey(
                 session,
@@ -1043,7 +1044,7 @@ class ActivationKeyTestCase(UITestCase):
             self.assertIsNotNone(self.activationkey.search(key_2_name))
             self.activationkey.associate_product(key_2_name, [product_2_name])
             self.assertIsNotNone(self.activationkey.wait_until_element(
-                common_locators['alert.success']))
+                common_locators['alert.success_sub_form']))
             # Create VM
             with VirtualMachine(distro=self.vm_distro) as vm:
                 vm.install_katello_ca()

--- a/tests/foreman/ui/test_syncplan.py
+++ b/tests/foreman/ui/test_syncplan.py
@@ -139,12 +139,7 @@ class SyncPlanTestCase(UITestCase):
         """
         plan_name = gen_string('alpha')
         startdate = datetime.now() + timedelta(minutes=10)
-        # Formatting current_date to web-UI format "%b %d, %Y %I:%M:%S %p" and
-        # removed zero-padded date(%-d) and hrs(%l) as fetching via web-UI
-        # doesn't have it
-        formatted_date_time = startdate.strftime("%b %-d, %Y %-l:%M:%S %p")
-        # Removed the seconds info as it would be too quick to validate via UI.
-        starttime = formatted_date_time.rpartition(':')[0]
+        starttime = startdate.strftime("%Y-%m-%d %H:%M")
         with Session(self.browser) as session:
             make_syncplan(
                 session,
@@ -156,13 +151,11 @@ class SyncPlanTestCase(UITestCase):
             )
             self.assertIsNotNone(self.syncplan.search(plan_name))
             self.syncplan.search(plan_name).click()
-            self.syncplan.wait_for_ajax()
             starttime_text = self.syncplan.wait_until_element(
                 locators['sp.fetch_startdate']).text
             # Removed the seconds info as it would be too quick
             # to validate via UI.
-            saved_starttime = str(starttime_text).rpartition(':')[0]
-            self.assertEqual(saved_starttime, starttime)
+            self.assertEqual(str(starttime_text).rpartition(':')[0], starttime)
 
     @tier2
     def test_positive_create_with_start_date(self):
@@ -175,9 +168,6 @@ class SyncPlanTestCase(UITestCase):
         plan_name = gen_string('alpha')
         startdate = datetime.now() + timedelta(days=10)
         startdate_str = startdate.strftime("%Y-%m-%d")
-        current_date_time = startdate.strftime("%b %-d, %Y %I:%M:%S %p")
-        # validating only for date
-        fetch_startdate = current_date_time.rpartition(',')[0]
         with Session(self.browser) as session:
             make_syncplan(
                 session,
@@ -188,11 +178,10 @@ class SyncPlanTestCase(UITestCase):
             )
             self.assertIsNotNone(self.syncplan.search(plan_name))
             self.syncplan.search(plan_name).click()
-            self.syncplan.wait_for_ajax()
             startdate_text = self.syncplan.wait_until_element(
                 locators['sp.fetch_startdate']).text
-            saved_startdate = str(startdate_text).rpartition(',')[0]
-            self.assertEqual(saved_startdate, fetch_startdate)
+            self.assertEqual(
+                str(startdate_text).partition(' ')[0], startdate_str)
 
     @tier1
     def test_negative_create_with_invalid_name(self):
@@ -277,9 +266,7 @@ class SyncPlanTestCase(UITestCase):
             for new_interval in valid_sync_intervals():
                 with self.subTest(new_interval):
                     session.nav.go_to_select_org(self.organization.name)
-                    session.nav.go_to_sync_plans()
                     self.syncplan.update(name, new_sync_interval=new_interval)
-                    session.nav.go_to_sync_plans()
                     self.syncplan.search(name).click()
                     # Assert updated sync interval
                     interval_text = self.syncplan.wait_until_element(
@@ -297,24 +284,22 @@ class SyncPlanTestCase(UITestCase):
         """
         strategy, value = locators['sp.prd_select']
         product = entities.Product(organization=self.organization).create()
+        plan_name = gen_string('alpha')
+        entities.SyncPlan(
+            name=plan_name,
+            interval=SYNC_INTERVAL['week'],
+            organization=self.organization,
+        ).create()
         with Session(self.browser) as session:
-            for plan_name in generate_strings_list():
-                with self.subTest(plan_name):
-                    entities.SyncPlan(
-                        name=plan_name,
-                        interval=SYNC_INTERVAL['week'],
-                        organization=self.organization,
-                    ).create()
-                    session.nav.go_to_select_org(self.organization.name)
-                    session.nav.go_to_sync_plans()
-                    self.syncplan.update(
-                        plan_name, add_products=[product.name])
-                    self.syncplan.search(plan_name).click()
-                    # Assert product is associated with sync plan
-                    self.syncplan.click(tab_locators['sp.tab_products'])
-                    element = self.syncplan.wait_until_element(
-                        (strategy, value % product.name))
-                    self.assertIsNotNone(element)
+            session.nav.go_to_select_org(self.organization.name)
+            self.syncplan.update(
+                plan_name, add_products=[product.name])
+            self.syncplan.search(plan_name).click()
+            # Assert product is associated with sync plan
+            self.syncplan.click(tab_locators['sp.tab_products'])
+            element = self.syncplan.wait_until_element(
+                (strategy, value % product.name))
+            self.assertIsNotNone(element)
 
     @tier2
     def test_positive_update_and_disassociate_product(self):
@@ -334,10 +319,8 @@ class SyncPlanTestCase(UITestCase):
         ).create()
         with Session(self.browser) as session:
             session.nav.go_to_select_org(self.organization.name)
-            session.nav.go_to_sync_plans()
             self.syncplan.update(plan_name, add_products=[product.name])
             self.syncplan.search(plan_name).click()
-            self.syncplan.wait_for_ajax()
             self.syncplan.click(tab_locators['sp.tab_products'])
             element = self.syncplan.wait_until_element(
                 (strategy, value % product.name))
@@ -346,7 +329,6 @@ class SyncPlanTestCase(UITestCase):
             # should automatically move from 'List/Remove` tab to 'Add' tab
             self.syncplan.update(plan_name, rm_products=[product.name])
             self.syncplan.search(plan_name).click()
-            self.syncplan.wait_for_ajax()
             self.syncplan.click(tab_locators['sp.tab_products'])
             self.syncplan.click(tab_locators['sp.add_prd'])
             element = self.syncplan.wait_until_element(


### PR DESCRIPTION
Few fixes for activation keys (was - 6+8+3=17, now - 9, but it can be more env specific issues as activation keys functionality affects most areas of application)
```
nosetests tests/foreman/ui/test_activationkey.py
.........E.F.E.E....EEEESE......
----------------------------------------------------------------------
Ran 32 tests in 8365.600s

FAILED (SKIP=1, errors=8, failures=1)
```
Fixed two test cases for sync plans, still there are more left, because of application defects themselves. Gonna add corresponding decorators soon
```
nosetests tests/foreman/ui/test_syncplan.py -m test_positive_create_with_start
..
----------------------------------------------------------------------
Ran 2 tests in 128.185s

OK

nosetests tests/foreman/ui/test_syncplan.py -m test_positive_update_product
.
----------------------------------------------------------------------
Ran 1 test in 77.887s

OK

nosetests tests/foreman/ui/test_syncplan.py -m test_positive_update_and_disassociate_product
.
----------------------------------------------------------------------
Ran 1 test in 110.199s

OK
```