### PR TITLE
Update cli.test_contenthost test

### DIFF
--- a/tests/foreman/cli/test_contenthost.py
+++ b/tests/foreman/cli/test_contenthost.py
@@ -329,15 +329,22 @@ class ContentHostTestCase(CLITestCase):
                     ContentHost.info({'id': content_host['id']})
 
     @tier1
-    def test_negative_create_with_same_name(self):
-        """Check if Content Host creation does not allow duplicated
-        names
+    def test_positive_create_with_same_name(self):
+        """Registering the same content host generates a new UUID.
 
         @Feature: Content Hosts
 
-        @Assert: Content Hosts with the same name are not allowed
+        @Assert: The UUID generated is different when registering the same
+        content host.
         """
         name = gen_string('alpha', 15).lower()
+        content_host = make_content_host({
+            u'content-view-id': self.DEFAULT_CV['id'],
+            u'lifecycle-environment-id': self.LIBRARY['id'],
+            u'name': name,
+            u'organization-id': self.NEW_ORG['id'],
+        })
+        self.assertEqual(content_host['name'], name)
         result = make_content_host({
             u'content-view-id': self.DEFAULT_CV['id'],
             u'lifecycle-environment-id': self.LIBRARY['id'],
@@ -345,13 +352,9 @@ class ContentHostTestCase(CLITestCase):
             u'organization-id': self.NEW_ORG['id'],
         })
         self.assertEqual(result['name'], name)
-        with self.assertRaises(CLIFactoryError):
-            make_content_host({
-                u'content-view-id': self.DEFAULT_CV['id'],
-                u'lifecycle-environment-id': self.LIBRARY['id'],
-                u'name': name,
-                u'organization-id': self.NEW_ORG['id'],
-            })
+        self.assertEqual(result['lifecycle-environment'], self.LIBRARY['name'])
+        self.assertEqual(result['content-view'], self.DEFAULT_CV['name'])
+        self.assertNotEqual(result['id'], content_host['id'])
 
     @tier3
     def test_positive_register_with_no_ak(self):


### PR DESCRIPTION
Rename test_negative_create_with_same_name to
test_positive_create_with_same_name. On new version of Satellite is it possible
to register with the same name, but when that happen a new UUID is generated.

I've missed pasting the results, here they are:

```
$ py.test tests/foreman/cli/test_contenthost.py -k test_positive_create_with_same_name
========================== test session starts ===========================
platform linux -- Python 3.4.2, pytest-2.9.1, py-1.4.31, pluggy-0.3.1
rootdir: /home/elyezer/code/robottelo, inifile: 
plugins: cov-2.2.1, testmon-0.8.2, xdist-1.14
collected 17 items 

tests/foreman/cli/test_contenthost.py .

===== 16 tests deselected by '-ktest_positive_create_with_same_name' =====
================ 1 passed, 16 deselected in 73.80 seconds ================
```