### PR TITLE
Fix for Content View entity in UI according to 6.2

### DIFF
--- a/robottelo/ui/contentviews.py
+++ b/robottelo/ui/contentviews.py
@@ -270,14 +270,7 @@ class ContentViews(Base):
         Filter_term can be used to filter the module by 'author'
         or by 'version'.
         """
-        element = self.search(cv_name)
-        if not element:
-            raise UIError(
-                'Could not find the selected CV "{0}"'.format(cv_name)
-            )
-
-        element.click()
-        self.wait_for_ajax()
+        self.click(self.search(cv_name))
         self.click(tab_locators['contentviews.tab_puppet_modules'])
         self.click(locators['contentviews.add_module'])
         self.text_field_update(common_locators['cv_filter'], module_name)
@@ -477,16 +470,10 @@ class ContentViews(Base):
 
     def fetch_puppet_module(self, cv_name, module_name):
         """Get added puppet module name from selected content-view"""
-        element = self.search(cv_name)
-
-        if element is None:
-            raise UINoSuchElementError(
-                'Could not find the %s content view.' % cv_name)
-        element.click()
-        self.wait_for_ajax()
+        self.click(self.search(cv_name))
         self.click(tab_locators['contentviews.tab_puppet_modules'])
         self.text_field_update(
-            common_locators['cv_filter'], module_name)
+            locators['contentviews.search_filters'], module_name)
         strategy, value = locators['contentviews.get_module_name']
         element = self.wait_until_element(
             (strategy, value % module_name))

--- a/robottelo/ui/locators.py
+++ b/robottelo/ui/locators.py
@@ -1998,7 +1998,7 @@ locators = LocatorDict({
     "contentviews.select_module": (
         By.XPATH,
         ("//tr/td[contains(., '%s')]/following-sibling::td"
-         "/button[@ng-click='selectVersion(item.module_name)']")),
+         "/button[@ng-click='selectVersion(item.name)']")),
     "contentviews.select_module_ver": (
         By.XPATH,
         ("//tr/td[contains(., '%s')]/following-sibling::td"

--- a/tests/foreman/ui/test_contentview.py
+++ b/tests/foreman/ui/test_contentview.py
@@ -164,16 +164,15 @@ class ContentViewTestCase(UITestCase):
             # Add repository to selected CV
             self.content_views.add_remove_repos(cv_name, [repo_name])
             self.assertIsNotNone(self.content_views.wait_until_element(
-                common_locators['alert.success']))
+                common_locators['alert.success_sub_form']))
             # Publish and promote CV to next environment
             self.content_views.publish(cv_name)
             self.assertIsNotNone(self.content_views.wait_until_element
-                                 (common_locators['alert.success']))
+                                 (common_locators['alert.success_sub_form']))
             self.content_views.promote(cv_name, 'Version 1', env_name)
             self.assertIsNotNone(self.content_views.wait_until_element
-                                 (common_locators['alert.success']))
+                                 (common_locators['alert.success_sub_form']))
 
-    @skip_if_bug_open('bugzilla', 1297308)
     @run_only_on('sat')
     @tier2
     def test_positive_add_puppet_module(self):
@@ -301,7 +300,7 @@ class ContentViewTestCase(UITestCase):
                 ['mammals']
             )
             self.assertIsNotNone(self.content_views.wait_until_element(
-                common_locators['alert.success']))
+                common_locators['alert.success_sub_form']))
 
     @run_only_on('sat')
     @tier2
@@ -331,7 +330,7 @@ class ContentViewTestCase(UITestCase):
             self.content_views.add_remove_errata_to_filter(
                 cv_name, filter_name, ['RHEA-2012:0001', 'RHEA-2012:0004'])
             self.assertIsNotNone(self.content_views.wait_until_element(
-                common_locators['alert.success']))
+                common_locators['alert.success_sub_form']))
 
     @run_only_on('sat')
     @tier1
@@ -377,7 +376,7 @@ class ContentViewTestCase(UITestCase):
                 with self.subTest(new_name):
                     self.content_views.update(name, new_name)
                     self.assertIsNotNone(self.content_views.wait_until_element(
-                        common_locators['alert.error']))
+                        common_locators['alert.error_sub_form']))
                     self.assertIsNone(self.content_views.search(new_name))
 
     @run_only_on('sat')
@@ -404,7 +403,7 @@ class ContentViewTestCase(UITestCase):
                 with self.subTest(new_desc):
                     self.content_views.update(name, new_description=new_desc)
                     self.assertIsNotNone(self.content_views.wait_until_element(
-                        common_locators['alert.success']))
+                        common_locators['alert.success_sub_form']))
 
     @stubbed()
     @run_only_on('sat')
@@ -514,7 +513,7 @@ class ContentViewTestCase(UITestCase):
             self.content_views.add_remove_cv(
                 composite_name, [cv_name1, cv_name2])
             self.assertIsNotNone(self.content_views.wait_until_element(
-                common_locators['alert.success']))
+                common_locators['alert.success_sub_form']))
 
     @run_only_on('sat')
     @skip_if_not_set('fake_manifest')
@@ -545,7 +544,7 @@ class ContentViewTestCase(UITestCase):
             self.assertIsNotNone(self.content_views.search(cv_name))
             self.content_views.add_remove_repos(cv_name, [rh_repo['name']])
             self.assertIsNotNone(self.content_views.wait_until_element(
-                common_locators['alert.success']))
+                common_locators['alert.success_sub_form']))
 
     @stubbed()
     @run_only_on('sat')
@@ -591,7 +590,7 @@ class ContentViewTestCase(UITestCase):
             self.assertIsNotNone(self.content_views.search(cv_name))
             self.content_views.add_remove_repos(cv_name, [repo_name])
             self.assertIsNotNone(self.content_views.wait_until_element(
-                common_locators['alert.success']))
+                common_locators['alert.success_sub_form']))
 
     @skip_if_bug_open('bugzilla', 1297308)
     @run_only_on('sat')
@@ -671,7 +670,7 @@ class ContentViewTestCase(UITestCase):
             self.assertIsNotNone(self.content_views.search(cv_name))
             self.content_views.add_remove_repos(cv_name, [repo_name])
             self.assertIsNotNone(self.content_views.wait_until_element(
-                common_locators['alert.success']))
+                common_locators['alert.success_sub_form']))
             with self.assertRaises(UIError) as context:
                 self.content_views.add_remove_repos(cv_name, [repo_name])
                 self.assertEqual(
@@ -730,13 +729,13 @@ class ContentViewTestCase(UITestCase):
             self.assertIsNotNone(self.content_views.search(cv_name))
             self.content_views.add_remove_repos(cv_name, [rh_repo['name']])
             self.assertIsNotNone(self.content_views.wait_until_element(
-                common_locators['alert.success']))
+                common_locators['alert.success_sub_form']))
             self.content_views.publish(cv_name)
             self.assertIsNotNone(self.content_views.wait_until_element(
-                common_locators['alert.success']))
+                common_locators['alert.success_sub_form']))
             self.content_views.promote(cv_name, 'Version 1', env_name)
             self.assertIsNotNone(self.content_views.wait_until_element(
-                common_locators['alert.success']))
+                common_locators['alert.success_sub_form']))
 
     @stubbed()
     @run_only_on('sat')
@@ -782,13 +781,13 @@ class ContentViewTestCase(UITestCase):
             self.assertIsNotNone(self.content_views.search(cv_name))
             self.content_views.add_remove_repos(cv_name, [repo_name])
             self.assertIsNotNone(self.content_views.wait_until_element(
-                common_locators['alert.success']))
+                common_locators['alert.success_sub_form']))
             self.content_views.publish(cv_name)
             self.assertIsNotNone(self.content_views.wait_until_element(
-                common_locators['alert.success']))
+                common_locators['alert.success_sub_form']))
             self.content_views.promote(cv_name, 'Version 1', env_name)
             self.assertIsNotNone(self.content_views.wait_until_element(
-                common_locators['alert.success']))
+                common_locators['alert.success_sub_form']))
 
     @stubbed()
     @run_only_on('sat')
@@ -856,10 +855,10 @@ class ContentViewTestCase(UITestCase):
             self.assertIsNotNone(self.content_views.search(cv_name))
             self.content_views.add_remove_repos(cv_name, [rh_repo['name']])
             self.assertIsNotNone(self.content_views.wait_until_element(
-                common_locators['alert.success']))
+                common_locators['alert.success_sub_form']))
             self.content_views.publish(cv_name)
             self.assertIsNotNone(self.content_views.wait_until_element(
-                common_locators['alert.success']))
+                common_locators['alert.success_sub_form']))
 
     @stubbed()
     @run_only_on('sat')
@@ -905,10 +904,10 @@ class ContentViewTestCase(UITestCase):
             self.assertIsNotNone(self.content_views.search(cv_name))
             self.content_views.add_remove_repos(cv_name, [repo_name])
             self.assertIsNotNone(self.content_views.wait_until_element(
-                common_locators['alert.success']))
+                common_locators['alert.success_sub_form']))
             self.content_views.publish(cv_name)
             self.assertIsNotNone(self.content_views.wait_until_element(
-                common_locators['alert.success']))
+                common_locators['alert.success_sub_form']))
 
     @stubbed()
     @run_only_on('sat')
@@ -1004,13 +1003,13 @@ class ContentViewTestCase(UITestCase):
             self.content_views.add_remove_repos(cv_name, [repo_name])
             self.assertIsNotNone(
                 self.content_views.wait_until_element(
-                    common_locators['alert.success'])
+                    common_locators['alert.success_sub_form'])
             )
             # Publish the CV
             self.content_views.publish(cv_name)
             self.assertIsNotNone(
                 self.content_views.wait_until_element(
-                    common_locators['alert.success'])
+                    common_locators['alert.success_sub_form'])
             )
             # Copy the CV
             self.content_views.copy_view(cv_name, copy_cv_name)

--- a/tests/foreman/ui/test_gpgkey.py
+++ b/tests/foreman/ui/test_gpgkey.py
@@ -704,7 +704,7 @@ class GPGKeyProductAssociateTestCase(UITestCase):
                     self.gpgkey.assert_product_repo(name, product=product_)
                 )
 
-    @skip_if_bug_open('bugzilla', 1085035)
+    @skip_if_bug_open('bugzilla', 1210180)
     @run_only_on('sat')
     @tier2
     def test_positive_add_product_using_repo_discovery(self):
@@ -1283,7 +1283,7 @@ class GPGKeyProductAssociateTestCase(UITestCase):
             self.assertIsNone(
                 self.gpgkey.assert_key_from_product(name, prd_element))
 
-    @skip_if_bug_open('bugzilla', 1085035)
+    @skip_if_bug_open('bugzilla', 1210180)
     @run_only_on('sat')
     @tier2
     def test_positive_delete_key_for_product_using_repo_discovery(self):


### PR DESCRIPTION
```
nosetests tests/foreman/ui/test_contentview.py
.S...SSS..S...EESSSS.ES.S....S.S.SESSSSSSS.SESSSSS.SSSSSSSSS..
======================================================================
----------------------------------------------------------------------
Ran 62 tests in 5421.327s

FAILED (SKIP=36, errors=5)

nosetests tests/foreman/ui/test_contentview.py -m test_positive_add_puppet_module
.
----------------------------------------------------------------------
Ran 1 test in 140.151s

OK

nosetests tests/foreman/ui/test_contentview.py -m rh_content
...
----------------------------------------------------------------------
Ran 3 tests in 367.850s

OK

nosetests tests/foreman/ui/test_contentview.py -m test_positive_create_composite
.
----------------------------------------------------------------------
Ran 1 test in 236.466s

OK
```

Bonus: quick fix for gpgkey bug decorators