### PR TITLE
Use custom admin user for UI bookmark tests

### DIFF
--- a/tests/foreman/api/test_bookmarks.py
+++ b/tests/foreman/api/test_bookmarks.py
@@ -35,6 +35,7 @@ class BookmarkTestCase(APITestCase):
                         bm = entities.Bookmark(
                             controller=entity['controller'],
                             name=name,
+                            public=False,
                         ).create()
                         self.assertEqual(bm.controller, entity['controller'])
                         self.assertEqual(bm.name, name)
@@ -111,6 +112,7 @@ class BookmarkTestCase(APITestCase):
                             entities.Bookmark(
                                 controller=entity['controller'],
                                 name=name,
+                                public=False,
                             ).create()
                         result = entities.Bookmark().search(
                             query={'search': u'name="{0}"'.format(name)})
@@ -231,7 +233,9 @@ class BookmarkTestCase(APITestCase):
         for entity in BOOKMARK_ENTITIES:
             with self.subTest(entity['controller']):
                 bm = entities.Bookmark(
-                    controller=entity['controller']).create()
+                    controller=entity['controller'],
+                    public=False,
+                ).create()
                 for new_name in valid_data_list():
                     with self.subTest(new_name):
                         bm.name = new_name
@@ -292,6 +296,7 @@ class BookmarkTestCase(APITestCase):
             with self.subTest(entity['controller']):
                 bm = entities.Bookmark(
                     controller=entity['controller'],
+                    public=False,
                 ).create()
                 for new_name in invalid_values_list():
                     with self.subTest(new_name):

--- a/tests/foreman/ui/test_bookmark.py
+++ b/tests/foreman/ui/test_bookmark.py
@@ -21,8 +21,8 @@ class BookmarkTestCase(UITestCase):
 
     @classmethod
     def setUpClass(cls):
-        """Display all the bookmarks on the same page and create entities for
-        testing.
+        """Display all the bookmarks on the same page, create user and entities
+        for testing.
         """
         super(BookmarkTestCase, cls).setUpClass()
         cls.per_page = entities.Setting().search(
@@ -35,6 +35,14 @@ class BookmarkTestCase(UITestCase):
             name=gen_string('alphanumeric')).create()
 
         cls.entities = []
+
+        cls.username = gen_string('alphanumeric')
+        cls.password = gen_string('alphanumeric')
+        entities.User(
+            admin=True,
+            login=cls.username,
+            password=cls.password,
+        ).create()
 
         for entity in BOOKMARK_ENTITIES:
             # Skip the entities, which can't be tested ATM (require framework
@@ -89,7 +97,8 @@ class BookmarkTestCase(UITestCase):
         """
         for entity in self.entities:
             with self.subTest(entity):
-                with Session(self.browser) as session:
+                with Session(
+                        self.browser, self.username, self.password) as session:
                     name = gen_string(choice(STRING_TYPES))
                     session.nav.go_to_select_org(self.org_.name)
                     ui_lib = getattr(self, entity['name'].lower())
@@ -122,7 +131,8 @@ class BookmarkTestCase(UITestCase):
         """
         for entity in self.entities:
             with self.subTest(entity):
-                with Session(self.browser) as session:
+                with Session(
+                        self.browser, self.username, self.password) as session:
                     name = gen_string(choice(STRING_TYPES))
                     session.nav.go_to_select_org(self.org_.name)
                     ui_lib = getattr(self, entity['name'].lower())
@@ -196,7 +206,8 @@ class BookmarkTestCase(UITestCase):
         """
         for entity in self.entities:
             with self.subTest(entity):
-                with Session(self.browser) as session:
+                with Session(
+                        self.browser, self.username, self.password) as session:
                     name = ''
                     session.nav.go_to_select_org(self.org_.name)
                     ui_lib = getattr(self, entity['name'].lower())
@@ -233,7 +244,8 @@ class BookmarkTestCase(UITestCase):
         """
         for entity in self.entities:
             with self.subTest(entity):
-                with Session(self.browser) as session:
+                with Session(
+                        self.browser, self.username, self.password) as session:
                     name = gen_string(choice(STRING_TYPES))
                     session.nav.go_to_select_org(self.org_.name)
                     ui_lib = getattr(self, entity['name'].lower())
@@ -269,7 +281,8 @@ class BookmarkTestCase(UITestCase):
         """
         for entity in self.entities:
             with self.subTest(entity):
-                with Session(self.browser) as session:
+                with Session(
+                        self.browser, self.username, self.password) as session:
                     name = gen_string(choice(STRING_TYPES))
                     session.nav.go_to_select_org(self.org_.name)
                     ui_lib = getattr(self, entity['name'].lower())
@@ -309,7 +322,8 @@ class BookmarkTestCase(UITestCase):
         """
         for entity in self.entities:
             with self.subTest(entity):
-                with Session(self.browser) as session:
+                with Session(
+                        self.browser, self.username, self.password) as session:
                     name = gen_string(choice(STRING_TYPES))
                     query = gen_string(choice(STRING_TYPES))
                     session.nav.go_to_select_org(self.org_.name)
@@ -346,7 +360,8 @@ class BookmarkTestCase(UITestCase):
         """
         for entity in self.entities:
             with self.subTest(entity):
-                with Session(self.browser) as session:
+                with Session(
+                        self.browser, self.username, self.password) as session:
                     bm1_name = gen_string(choice(STRING_TYPES))
                     bm2_name = gen_string(choice(STRING_TYPES))
                     session.nav.go_to_select_org(self.org_.name)
@@ -391,7 +406,8 @@ class BookmarkTestCase(UITestCase):
         """
         for entity in self.entities:
             with self.subTest(entity):
-                with Session(self.browser) as session:
+                with Session(
+                        self.browser, self.username, self.password) as session:
                     name = gen_string(choice(STRING_TYPES))
                     query = gen_string(choice(STRING_TYPES))
                     session.nav.go_to_select_org(self.org_.name)
@@ -432,7 +448,8 @@ class BookmarkTestCase(UITestCase):
         """
         for entity in self.entities:
             with self.subTest(entity):
-                with Session(self.browser) as session:
+                with Session(
+                        self.browser, self.username, self.password) as session:
                     name = gen_string(choice(STRING_TYPES))
                     session.nav.go_to_select_org(self.org_.name)
                     ui_lib = getattr(self, entity['name'].lower())
@@ -473,7 +490,8 @@ class BookmarkTestCase(UITestCase):
         """
         for entity in self.entities:
             with self.subTest(entity):
-                with Session(self.browser) as session:
+                with Session(
+                        self.browser, self.username, self.password) as session:
                     name = gen_string(choice(STRING_TYPES))
                     query = gen_string(choice(STRING_TYPES))
                     session.nav.go_to_select_org(self.org_.name)
@@ -558,7 +576,8 @@ class BookmarkTestCase(UITestCase):
         """
         for entity in self.entities:
             with self.subTest(entity):
-                with Session(self.browser) as session:
+                with Session(
+                        self.browser, self.username, self.password) as session:
                     name = gen_string(choice(STRING_TYPES))
                     session.nav.go_to_select_org(self.org_.name)
                     ui_lib = getattr(self, entity['name'].lower())


### PR DESCRIPTION
Currently we have open [BZ1322003](https://bugzilla.redhat.com/show_bug.cgi?id=1322003) which basically blocks using bookmarks when we have entities with long names.
Bookmark tests are working fine on isolated environment, but on jenkins we have a lot of entities with long names created before executing these tests, and it results in this:
![unspecified](https://cloud.githubusercontent.com/assets/11719030/14851139/9922b406-0c86-11e6-87ad-bd8af5846d8e.png)
Skipping all the bookmark tests until BZ is closed.
```python
py.test tests/foreman/ui/test_bookmark.py
================================ test session starts =================================
platform linux2 -- Python 2.7.10, pytest-2.8.7, py-1.4.31, pluggy-0.3.1
rootdir: /home/andrii/workspace/robottelo, inifile: 
plugins: xdist-1.13.1, repeat-0.2
collected 14 items 

tests/foreman/ui/test_bookmark.py ssssssssssssss

============================= 14 skipped in 1.89 seconds =============================
```