### PR TITLE
Fixed CLI Repository tests

### DIFF
--- a/tests/foreman/cli/test_repository.py
+++ b/tests/foreman/cli/test_repository.py
@@ -383,7 +383,6 @@ class RepositoryTestCase(CLITestCase):
                     self._make_repository({u'url': url})
 
     @run_only_on('sat')
-    @skip_if_bug_open('bugzilla', 1152237)
     @tier2
     def test_positive_synchronize_yum_repo(self):
         """Check if repository can be created and synced
@@ -404,10 +403,10 @@ class RepositoryTestCase(CLITestCase):
                 Repository.synchronize({'id': new_repo['id']})
                 # Verify it has finished
                 new_repo = Repository.info({'id': new_repo['id']})
-                self.assertEqual(new_repo['sync']['status'], 'Finished')
+                self.assertEqual(new_repo['sync']['status'], 'Success')
 
     @run_only_on('sat')
-    @skip_if_bug_open('bugzilla', 1152237)
+    @skip_if_bug_open('bugzilla', 1328092)
     @tier2
     def test_positive_synchronize_auth_yum_repo(self):
         """Check if secured repository can be created and synced
@@ -433,9 +432,10 @@ class RepositoryTestCase(CLITestCase):
                 Repository.synchronize({'id': new_repo['id']})
                 # Verify it has finished
                 new_repo = Repository.info({'id': new_repo['id']})
-                self.assertEqual(new_repo['sync']['status'], 'Finished')
+                self.assertEqual(new_repo['sync']['status'], 'Success')
 
     @run_only_on('sat')
+    @skip_if_bug_open('bugzilla', 1328092)
     @tier2
     def test_negative_synchronize_auth_yum_repo(self):
         """Check if secured repo fails to synchronize with invalid credentials
@@ -466,7 +466,7 @@ class RepositoryTestCase(CLITestCase):
                 )
 
     @run_only_on('sat')
-    @skip_if_bug_open('bugzilla', 1152237)
+    @skip_if_bug_open('bugzilla', 1328092)
     @tier2
     def test_positive_synchronize_auth_puppet_repo(self):
         """Check if secured puppet repository can be created and synced
@@ -490,10 +490,9 @@ class RepositoryTestCase(CLITestCase):
                 Repository.synchronize({'id': new_repo['id']})
                 # Verify it has finished
                 new_repo = Repository.info({'id': new_repo['id']})
-                self.assertEqual(new_repo['sync']['status'], 'Finished')
+                self.assertEqual(new_repo['sync']['status'], 'Success')
 
     @run_only_on('sat')
-    @skip_if_bug_open('bugzilla', 1152237)
     @tier2
     def test_positive_synchronize_docker_repo(self):
         """Check if Docker repository can be created and synced
@@ -513,7 +512,7 @@ class RepositoryTestCase(CLITestCase):
         Repository.synchronize({'id': new_repo['id']})
         # Verify it has finished
         new_repo = Repository.info({'id': new_repo['id']})
-        self.assertEqual(new_repo['sync']['status'], 'Finished')
+        self.assertEqual(new_repo['sync']['status'], 'Success')
 
     @run_only_on('sat')
     @tier1


### PR DESCRIPTION
```python
py.test tests/foreman/cli/test_repository.py                                                           
================================ test session starts =================================
platform linux2 -- Python 2.7.10, pytest-2.8.7, py-1.4.31, pluggy-0.3.1
rootdir: /home/andrii/workspace/robottelo, inifile: 
plugins: xdist-1.13.1, repeat-0.2
collected 30 items 

tests/foreman/cli/test_repository.py ...s................ss...ss...

====================== 25 passed, 5 skipped in 1389.49 seconds =======================
```