### PR TITLE
Pinned paramiko version due to missing dependencies in latest.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ setup(
         'inflector',
         'nailgun',
         'numpy',
-        'paramiko',
+        'paramiko==1.16.0',
         'pygal',
         'pytest',
         'python-bugzilla',


### PR DESCRIPTION
* Paramiko upgraded its crypto dependencies, we should upgrade also, but before we need to make some further investigation and test
* For now pinning the paramiko version to the older
* Also we should pin all other deps