### PR TITLE
Fix encoding declaration error

### DIFF
--- a/tests/foreman/api/test_bookmarks.py
+++ b/tests/foreman/api/test_bookmarks.py
@@ -1,5 +1,5 @@
-"""Test classes for Bookmark tests"""
 # -*- encoding: utf-8 -*-
+"""Test classes for Bookmark tests"""
 from fauxfactory import gen_string
 from nailgun import entities
 from requests.exceptions import HTTPError


### PR DESCRIPTION
File encoding declarations must be on the first line, or the second if a
shebang is present. Before this commit:

    $ python -c 'from tests.foreman.api import test_bookmarks'
    Traceback (most recent call last):
      File "<string>", line 1, in <module>
      File "tests/foreman/api/test_bookmarks.py", line 198
    SyntaxError: Non-ASCII character '\xe2' in file tests/foreman/api/test_bookmarks.py on line 199, but no encoding declared; see http://python.org/dev/peps/pep-0263/ for details

After this commit:

    $ python -c 'from tests.foreman.api import test_bookmarks'