### PR TITLE
Update install docs and use latest Paramiko

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -17,14 +17,24 @@ Quickstart
 The following is only a brief setup guide for `Robottelo`_. The section on
 `Running the Tests`_ provides a more comprehensive guide to using Robottelo.
 
-Install Python header files. The package providing these files varies per
-distribution. For example:
+Robottelo requires SSH access to the Satellite 6 system under test, and this
+SSH access is implemented by Paramiko. Install the headers for the following to
+ensure that Paramiko's dependencies build correctly:
 
-* Fedora 20 provides header files in the
-  `python-devel <https://apps.fedoraproject.org/packages/python-devel>`_
-  package.
-* Ubuntu 14.04 provides header files in the
-  `python-dev <http://packages.ubuntu.com/trusty/python-dev>`_ package.
+* OpenSSL
+* Python development headers
+* libffi
+
+On Fedora, you can install these with the following command::
+
+    dnf install -y libffi-devel openssl-devel python-devel
+
+On Red Hat Enterprise Linux, you can install these with the following command::
+
+    yum install -y libffi-devel openssl-devel python-devel
+
+For more information, see `Paramiko: Installing
+<http://www.paramiko.org/installing.html>`_.
 
 Get the source code and install dependencies::
 
@@ -36,7 +46,8 @@ are a few other things you may wish to do before continuing:
 
 1. You may want to install development tools (such as gcc) for your OS. If
    running Fedora or Red Hat Enterprise Linux, execute ``yum groupinstall
-   "Development Tools"``.
+   "Development Tools"``. Make sure to use ``dnf`` instead of ``yum`` if
+   ``dnf`` is available on your system.
 2. You may wish to install the optional dependencies listed in
    ``requirements-optional.txt``. (Use pip, as shown above.) They are required
    for tasks like working with certificates, running the internal robottelo test

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ setup(
         'inflector',
         'nailgun',
         'numpy',
-        'paramiko==1.16.0',
+        'paramiko',
         'pygal',
         'pytest',
         'python-bugzilla',


### PR DESCRIPTION
Paramiko can be built on Sesame:

```
[root@sesame ~]# virtualenv test
New python executable in test/bin/python2
Also creating executable in test/bin/python
Installing setuptools, pip...done.
[root@sesame ~]# source test/bin/activate
(test)[root@sesame ~]# pip install paramiko
You are using pip version 6.1.1, however version 8.1.1 is available.
You should consider upgrading via the 'pip install --upgrade pip' command.
Collecting paramiko
  Using cached paramiko-2.0.0-py2.py3-none-any.whl
Collecting pyasn1>=0.1.7 (from paramiko)
  Using cached pyasn1-0.1.9-py2.py3-none-any.whl
Collecting cryptography>=1.1 (from paramiko)
  Using cached cryptography-1.3.1.tar.gz
Collecting idna>=2.0 (from cryptography>=1.1->paramiko)
  Using cached idna-2.1-py2.py3-none-any.whl
Collecting six>=1.4.1 (from cryptography>=1.1->paramiko)
  Using cached six-1.10.0-py2.py3-none-any.whl
Requirement already satisfied (use --upgrade to upgrade): setuptools>=11.3 in ./test/lib/python2.7/site-packages (from cryptography>=1.1->paramiko)
Collecting enum34 (from cryptography>=1.1->paramiko)
  Using cached enum34-1.1.4-py2.py3-none-any.whl
Collecting ipaddress (from cryptography>=1.1->paramiko)
  Using cached ipaddress-1.0.16-py27-none-any.whl
Collecting cffi>=1.4.1 (from cryptography>=1.1->paramiko)
  Using cached cffi-1.6.0.tar.gz
Collecting pycparser (from cffi>=1.4.1->cryptography>=1.1->paramiko)
  Using cached pycparser-2.14.tar.gz
Installing collected packages: pyasn1, idna, six, enum34, ipaddress, pycparser, cffi, cryptography, paramiko
  Running setup.py install for pycparser
  Running setup.py install for cffi
  Running setup.py install for cryptography
Successfully installed cffi-1.6.0 cryptography-1.3.1 enum34-1.1.4 idna-2.1 ipaddress-1.0.16 paramiko-2.0.0 pyasn1-0.1.9 pycparser-2.14 six-1.10.0
```

And I was able to run Robottelo ssh commands with latest paramiko:

```
In [1]: from robottelo.config import settings; settings.configure()
f
In [2]: from robottelo import ssh

In [3]: ssh.paramiko.__version__
Out[3]: '2.0.0'

In [4]: ssh.command('echo paramiko works')
2016-05-03 13:29:51 - robottelo.ssh - DEBUG - >>> [satserver.example.com] echo paramiko works
2016-05-03 13:29:53 - robottelo.ssh - INFO - Instantiated Paramiko client 0x7fd430f28a90
2016-05-03 13:29:53 - robottelo.ssh - INFO - Destroying Paramiko client 0x7fd430f28a90
2016-05-03 13:29:53 - robottelo.ssh - INFO - Destroyed Paramiko client 0x7fd430f28a90
2016-05-03 13:29:53 - robottelo.ssh - DEBUG - <<< stdout
paramiko works

Out[4]: <robottelo.ssh.SSHCommandResult at 0x7fd430f46470>
```

Thanks @Ichimonji10 for helping with wordsmith.