### PR TITLE
Drop pycrypto in favor of cryptography library

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -16,6 +16,7 @@ setup(
     package_data={'': ['LICENSE']},
     include_package_data=True,
     install_requires=[
+        'cryptography',
         'fauxfactory',
         'inflector',
         'nailgun',


### PR DESCRIPTION
cryptography is a new player in cryptographic world and it is really shinning
since very known libraries like Paramiko is using it now.

Before Robottelo relied on pycrypto in order to sign the cloned manifests
without listing it as a direct dependency. Drop that and add cryptography as a
new dependency.