### PR TITLE
Fixing API part for Activations Key entity according to 6.2 GA

### DIFF
--- a/tests/foreman/api/test_hostcollection.py
+++ b/tests/foreman/api/test_hostcollection.py
@@ -250,7 +250,7 @@ class HostCollectionTestCase(APITestCase):
 
     @skip_if_bug_open('bugzilla', 1325989)
     @tier1
-    def test_positive_update_chost(self):
+    def test_positive_update_host(self):
         """Update host collection's host.
 
         @Feature: Host Collection


### PR DESCRIPTION
```
nosetests tests/foreman/api/test_activationkey.py
....S...F..........
======================================================================
FAIL: Associate an activation key with several host collections.
----------------------------------------------------------------------
----------------------------------------------------------------------
Ran 19 tests in 348.603s

FAILED (SKIP=1, failures=1)

nosetests tests/foreman/api/test_activationkey.py -m test_positive_add_host_collections
.
----------------------------------------------------------------------
Ran 1 test in 12.668s

OK
```