### PR TITLE
Display Type for Compute Resource is returned in lowercase.

### DIFF
--- a/tests/foreman/api/test_computeresource.py
+++ b/tests/foreman/api/test_computeresource.py
@@ -74,7 +74,7 @@ class ComputeResourceTestCase(APITestCase):
 
         @Assert: Compute resources are created with expected display_type value
         """
-        for display_type in ('SPICE', 'VNC'):
+        for display_type in ('spice', 'vnc'):
             with self.subTest(display_type):
                 compresource = entities.LibvirtComputeResource(
                     display_type=display_type,
@@ -200,7 +200,7 @@ class ComputeResourceTestCase(APITestCase):
             organization=[self.org],
             url=self.current_libvirt_url,
         ).create()
-        for display_type in ('SPICE', 'VNC'):
+        for display_type in ('spice', 'vnc'):
             with self.subTest(display_type):
                 compresource.display_type = display_type
                 compresource = compresource.update(['display_type'])


### PR DESCRIPTION
Some of our Compute Resource tests for Libvirt were failing because we expected
the field `display type` to return one of the following values in uppercase:
`SPICE` or `VNC`. Turns out that the API now returns these values in lowercase.
This changeset updates the 2 failing tests to use lowercase values.