### PR TITLE
Dropped `content` from `activation-key` arguments in the CLI.

### DIFF
--- a/robottelo/cli/factory.py
+++ b/robottelo/cli/factory.py
@@ -125,13 +125,13 @@ def make_activation_key(options=None):
         --description DESCRIPTION     description
         --lifecycle-environment LIFECYCLE_ENVIRONMENT_NAME Name to search by
         --lifecycle-environment-id LIFECYCLE_ENVIRONMENT_ID
-        --max-content-hosts MAX_CONTENT_HOSTS maximum number of registered
+        --max-hosts MAX_CONTENT_HOSTS maximum number of registered
                                               content hosts
         --name NAME                   name
         --organization ORGANIZATION_NAME Organization name to search by
         --organization-id ORGANIZATION_ID
         --organization-label ORGANIZATION_LABEL Organization label to search by
-        --unlimited-content-hosts UNLIMITED_CONTENT_HOSTS can the activation
+        --unlimited-hosts UNLIMITED_CONTENT_HOSTS can the activation
                                                           key have unlimited
                                                           content hosts
     """
@@ -149,12 +149,12 @@ def make_activation_key(options=None):
         u'description': None,
         u'lifecycle-environment': None,
         u'lifecycle-environment-id': None,
-        u'max-content-hosts': None,
+        u'max-hosts': None,
         u'name': gen_alphanumeric(),
         u'organization': None,
         u'organization-id': None,
         u'organization-label': None,
-        u'unlimited-content-hosts': None,
+        u'unlimited-hosts': None,
     }
 
     return create_object(ActivationKey, args, options)

--- a/tests/foreman/cli/test_activationkey.py
+++ b/tests/foreman/cli/test_activationkey.py
@@ -184,7 +184,7 @@ class ActivationKeyTestCase(CLITestCase):
         @Assert: Activation key is created
         """
         new_ak = self._make_activation_key({
-            u'max-content-hosts': '10',
+            u'max-hosts': '10',
         })
         self.assertEqual(new_ak['host-limit'], u'10')
 
@@ -215,7 +215,7 @@ class ActivationKeyTestCase(CLITestCase):
             with self.subTest(limit):
                 with self.assertRaises(CLIFactoryError):
                     self._make_activation_key({
-                        u'max-content-hosts': limit,
+                        u'max-hosts': limit,
                     })
 
     @tier1
@@ -429,7 +429,7 @@ class ActivationKeyTestCase(CLITestCase):
         new_ak = self._make_activation_key()
         self.assertEqual(new_ak['host-limit'], u'Unlimited')
         ActivationKey.update({
-            u'max-content-hosts': '2147483647',
+            u'max-hosts': '2147483647',
             u'name': new_ak['name'],
             u'organization-id': self.org['id'],
         })
@@ -445,11 +445,11 @@ class ActivationKeyTestCase(CLITestCase):
         @Assert: Activation key is updated
         """
         new_ak = self._make_activation_key({
-            u'max-content-hosts': '10',
+            u'max-hosts': '10',
         })
         self.assertEqual(new_ak['host-limit'], u'10')
         ActivationKey.update({
-            u'unlimited-content-hosts': '1',
+            u'unlimited-hosts': True,
             u'name': new_ak['name'],
             u'organization-id': self.org['id'],
         })
@@ -486,7 +486,7 @@ class ActivationKeyTestCase(CLITestCase):
         new_ak = self._make_activation_key()
         with self.assertRaises(CLIReturnCodeError):
             ActivationKey.update({
-                u'max-content-hosts': int('9' * 20),
+                u'max-hosts': int('9' * 20),
                 u'id': new_ak['id'],
                 u'organization-id': self.org['id'],
             })
@@ -520,7 +520,7 @@ class ActivationKeyTestCase(CLITestCase):
             u'lifecycle-environment-id': env['id'],
             u'content-view': new_cv['name'],
             u'organization-id': self.org['id'],
-            u'max-content-hosts': '1',
+            u'max-hosts': '1',
         })
         with VirtualMachine(distro='rhel65') as vm1:
             with VirtualMachine(distro='rhel65') as vm2:

--- a/tests/foreman/data/hammer_commands.json
+++ b/tests/foreman/data/hammer_commands.json
@@ -354,7 +354,7 @@
             },
             {
               "help": "maximum number of registered content hosts",
-              "name": "max-content-hosts",
+              "name": "max-hosts",
               "shortname": null,
               "value": "MAX_CONTENT_HOSTS"
             },
@@ -384,7 +384,7 @@
             },
             {
               "help": "Set content hosts max to unlimited",
-              "name": "unlimited-content-hosts",
+              "name": "unlimited-hosts",
               "shortname": null,
               "value": null
             },
@@ -903,7 +903,7 @@
             },
             {
               "help": "maximum number of registered content hosts",
-              "name": "max-content-hosts",
+              "name": "max-hosts",
               "shortname": null,
               "value": "MAX_CONTENT_HOSTS"
             },
@@ -951,7 +951,7 @@
             },
             {
               "help": "can the activation key have unlimited content hosts One of true/false, yes/no, 1/0.",
-              "name": "unlimited-content-hosts",
+              "name": "unlimited-hosts",
               "shortname": null,
               "value": "UNLIMITED_CONTENT_HOSTS"
             },


### PR DESCRIPTION
The `activation-key` hammer command no longer uses the word `content` for two
of its attributes: `max-hosts` and `unlimited-hosts`.