### PR TITLE
Pass organization id when creating content view filter by repo name.

### DIFF
--- a/tests/foreman/cli/test_contentviewfilter.py
+++ b/tests/foreman/cli/test_contentviewfilter.py
@@ -258,6 +258,7 @@ class ContentViewFilterTestCase(CLITestCase):
             'inclusion': 'false',
             'name': cvf_name,
             'repositories': self.repo['name'],
+            'organization-id': self.org['id'],
             'type': 'rpm',
         })
         cvf = ContentView.filter_info({


### PR DESCRIPTION
Seems that when you try to create a new content view filter by providing a
repository name (instead of its ID, for example), you must also pass
information for the organization as well.