### PR TITLE
Fix CLI ContentHost delete tests

### DIFF
--- a/robottelo/cli/contenthost.py
+++ b/robottelo/cli/contenthost.py
@@ -62,6 +62,10 @@ class ContentHost(Base):
         """Work around host unification not being completed in order to delete
         a content host which is now a host subscription.
         """
+        # Replace content host id with host id if passed
+        if 'host-id' in options:
+            name = ContentHost.info({'id': options['host-id']})['name'].lower()
+            options['host-id'] = Host.info({'name': name})['id']
         return Host.subscription_unregister(options)
 
     @classmethod

--- a/tests/foreman/cli/test_contenthost.py
+++ b/tests/foreman/cli/test_contenthost.py
@@ -14,7 +14,6 @@ from robottelo.cli.contenthost import ContentHost
 from robottelo.cli.contentview import ContentView
 from robottelo.cli.lifecycleenvironment import LifecycleEnvironment
 from robottelo.datafactory import (
-    generate_strings_list,
     invalid_values_list,
     valid_hosts_list,
 )
@@ -296,7 +295,7 @@ class ContentHostTestCase(CLITestCase):
 
         @BZ: 1328202
         """
-        for name in generate_strings_list():
+        for name in valid_hosts_list():
             with self.subTest(name):
                 content_host = make_content_host({
                     u'content-view-id': self.DEFAULT_CV['id'],


### PR DESCRIPTION
```python
py.test tests/foreman/cli/test_contenthost.py -k test_positive_delete  
================================ test session starts =================================
platform linux2 -- Python 2.7.10, pytest-2.9.1, py-1.4.31, pluggy-0.3.1
rootdir: /home/andrii/workspace/robottelo, inifile: 
plugins: xdist-1.13.1, repeat-0.2
collected 17 items 

tests/foreman/cli/test_contenthost.py ..

================== 15 tests deselected by '-ktest_positive_delete' ===================
====================== 2 passed, 15 deselected in 68.11 seconds ======================
```