### PR TITLE
[DO NOT MERGE] Updated "notif.error" locator to 'jnotify-notification-danger'

### DIFF
--- a/robottelo/ui/locators.py
+++ b/robottelo/ui/locators.py
@@ -644,7 +644,7 @@ common_locators = LocatorDict({
 
     # Notifications
     "notif.error": (
-        By.XPATH, "//div[contains(@class, 'jnotify-notification-error')]"),
+        By.XPATH, "//div[contains(@class, 'jnotify-notification-danger')]"),
     "notif.warning": (
         By.XPATH, "//div[contains(@class, 'jnotify-notification-warning')]"),
     "notif.success": (


### PR DESCRIPTION
For some reason, this locator has been omitted in locators updates for 6.2.