### PR TITLE
Update get_value for UI settings

### DIFF
--- a/robottelo/ui/settings.py
+++ b/robottelo/ui/settings.py
@@ -61,6 +61,8 @@ class Settings(Base):
             strategy, value = locators['settings.edit_param']
             element = self.wait_until_element((strategy, value % param_name))
             if element:
+                if element.text.lower().startswith('click to edit'):
+                    return ''
                 return element.text
             else:
                 raise UINoSuchElementError(


### PR DESCRIPTION
Make sure to return a blank value if `Click to edit..` is the text of the
settings because that text will be present just for blank setting value.