### PR TITLE
Removing not actual content view filters test cases

### DIFF
--- a/tests/foreman/api/test_contentviewfilter.py
+++ b/tests/foreman/api/test_contentviewfilter.py
@@ -5,15 +5,13 @@ http://www.katello.org/docs/api/apidoc/content_view_filters.html
 
 """
 from fauxfactory import gen_integer, gen_string
-from nailgun import client, entities
+from nailgun import entities
 from random import randint
 from requests.exceptions import HTTPError
-from robottelo.config import settings
 from robottelo.constants import DOCKER_REGISTRY_HUB
 from robottelo.datafactory import invalid_names_list, valid_data_list
 from robottelo.decorators import run_only_on, skip_if_bug_open, tier1, tier2
 from robottelo.test import APITestCase
-from six.moves import http_client
 
 
 class ContentViewFilterTestCase(APITestCase):
@@ -36,51 +34,6 @@ class ContentViewFilterTestCase(APITestCase):
         ).create()
         self.content_view.repository = [self.repo]
         self.content_view.update(['repository'])
-
-    @tier2
-    @run_only_on('sat')
-    def test_negative_get_with_no_args(self):
-        """Issue an HTTP GET to the base content view filters path.
-
-        @Feature: ContentViewFilter
-
-        @Assert: An HTTP 400 or 422 response is received if a GET request is
-        issued with no arguments specified.
-
-        This test targets bugzilla bug #1102120.
-        """
-        response = client.get(
-            entities.AbstractContentViewFilter().path(),
-            auth=settings.server.get_credentials(),
-            verify=False,
-        )
-        self.assertIn(
-            response.status_code,
-            (http_client.BAD_REQUEST, http_client.UNPROCESSABLE_ENTITY)
-        )
-
-    @tier2
-    @run_only_on('sat')
-    def test_negative_get_with_bad_args(self):
-        """Issue an HTTP GET to the base content view filters path.
-
-        @Feature: ContentViewFilter
-
-        @Assert: An HTTP 400 or 422 response is received if a GET request is
-        issued with bad arguments specified.
-
-        This test targets bugzilla bug #1102120.
-        """
-        response = client.get(
-            entities.AbstractContentViewFilter().path(),
-            auth=settings.server.get_credentials(),
-            verify=False,
-            data={'foo': 'bar'},
-        )
-        self.assertIn(
-            response.status_code,
-            (http_client.BAD_REQUEST, http_client.UNPROCESSABLE_ENTITY)
-        )
 
     @tier2
     @run_only_on('sat')


### PR DESCRIPTION
It seems that functionality was changed a long time ago. All GET calls to the server for Content View Filter entity work as it should, but it seems just ignore incorrect parameters. Behavior mentioned in https://bugzilla.redhat.com/show_bug.cgi?id=1102120 is not actual anymore and is not reproducible:
```
2016-05-12 04:49:02 [app] [I] Started GET "/katello/api/v2/content_view_filters" for 10.36.5.150 at 2016-05-12 04:49:02 -0400
2016-05-12 04:49:02 [app] [I] Processing by Katello::Api::V2::ContentViewFiltersController#index as */*
2016-05-12 04:49:02 [app] [I]   Parameters: {"foo"=>"bar", "api_version"=>"v2", "content_view_filter"=>{}}
2016-05-12 04:49:02 [app] [I] Authorized user admin(Admin User)
2016-05-12 04:49:02 [app] [I]   Rendered /opt/theforeman/tfm/root/usr/share/gems/gems/katello-3.0.0.26/app/views/katello/api/v2/content_view_filters/index.json.rabl within katello/api/v2/layouts/collection (2.1ms)
2016-05-12 04:49:02 [app] [I] Completed 200 OK in 26ms (Views: 2.3ms | ActiveRecord: 11.1ms)
```
Correspondingly:
```
Making HTTP GET request to https://server/katello/api/v2/content_view_filters with options {'verify': False, 'data': '{"foo": "bar"}', 'auth': ('admin', 'changeme'), 'headers': {'content-type': 'application/json'}} and no data.
Received HTTP 200 response: {"total":2,"subtotal":2,"page":1,"per_page":20,"error":null,"search":null,"sort":{"by":null,"order":null},"results":[{"inclusion":false,"id":2,"name":"ᇿ것𧑙良풝잞嫏","description":null,"created_at":"2016-05-12 09:05:47 UTC","updated_at":"2016-05-12 09:05:47 UTC","content_view":{"composite":false,"repository_ids":[12],"component_ids":[],"default":false,"next_version":1,"id":131,"name":"콦貰𢢿읬ⵂ𢮫","label":"8aec9c1b-b4b8-4ec3-a96a-3ec9e09eace7","description":null,"organization":{"name":"𒍏𦅥醼झ짧謫讠","label":"53d54c04-2b74-49fb-a187-cb20372a116a","id":129},"created_at":"2016-05-12 09:05:29 UTC","updated_at":"2016-05-12 09:05:29 UTC","environments":[],"repositories":[{"id":12,"name":"췇𠈇𩰼곹镈","label":"9e052cfb-b439-4b7e-a04c-2b69ebb7b35e","content_type":"yum"}],"puppet_modules":[],"versions":[],"components":[],"activation_keys":[],"last_published":null,"permissions":{"view_content_views":true,"edit_content_views":true,"destroy_content_views":true,"publish_content_views":true,"promote_or_remove_content_views":true}},"repositories":[],"type":"rpm","rules":[]},{"inclusion":true,"id":1,"name":"첬𩌅𩱺𤝃薾𨸁𡢚廨譩𧵵𩱡","description":null,"created_at":"2016-05-12 09:05:32 UTC","updated_at":"2016-05-12 09:05:32 UTC","content_view":{"composite":false,"repository_ids":[12],"component_ids":[],"default":false,"next_version":1,"id":131,"name":"콦貰𢢿읬ⵂ𢮫","label":"8aec9c1b-b4b8-4ec3-a96a-3ec9e09eace7","description":null,"organization":{"name":"𒍏𦅥醼झ짧謫讠","label":"53d54c04-2b74-49fb-a187-cb20372a116a","id":129},"created_at":"2016-05-12 09:05:29 UTC","updated_at":"2016-05-12 09:05:29 UTC","environments":[],"repositories":[{"id":12,"name":"췇𠈇𩰼곹镈","label":"9e052cfb-b439-4b7e-a04c-2b69ebb7b35e","content_type":"yum"}],"puppet_modules":[],"versions":[],"components":[],"activation_keys":[],"last_published":null,"permissions":{"view_content_views":true,"edit_content_views":true,"destroy_content_views":true,"publish_content_views":true,"promote_or_remove_content_views":true}},"repositories":[],"type":"rpm","rules":[]}]}
```