### PR TITLE
Isolated one user per session / thread in UI test cases

### DIFF
--- a/robottelo/ui/session.py
+++ b/robottelo/ui/session.py
@@ -16,10 +16,16 @@ class Session(object):
         self.user = user
 
         if self.user is None:
-            self.user = settings.server.admin_username
+            self.user = getattr(
+                self.browser, 'foreman_user', settings.server.admin_username
+            )
 
         if self.password is None:
-            self.password = settings.server.admin_password
+            self.password = getattr(
+                self.browser,
+                'foreman_password',
+                settings.server.admin_password
+            )
 
     def __enter__(self):
         self.login()

--- a/tests/foreman/cli/test_contenthost.py
+++ b/tests/foreman/cli/test_contenthost.py
@@ -372,8 +372,8 @@ class ContentHostTestCase(CLITestCase):
                     self.NEW_ORG['label'],
                     self.NEW_LIFECYCLE['label'],
                     self.PROMOTED_CV['label'],
-                    self.katello_user,
-                    self.katello_passwd
+                    self.foreman_user,
+                    self.foreman_password
                 )
             )
             self.assertEqual(result.return_code, 0)

--- a/tests/foreman/cli/test_ping.py
+++ b/tests/foreman/cli/test_ping.py
@@ -1,6 +1,5 @@
 """Test Class for hammer ping"""
 from robottelo import ssh
-from robottelo.config import settings
 from robottelo.decorators import tier1
 from robottelo.test import CLITestCase
 from six.moves import zip
@@ -22,8 +21,8 @@ class PingTestCase(CLITestCase):
         @assert: hammer ping returns a right return code
         """
         result = ssh.command('hammer -u {0} -p {1} ping'.format(
-            settings.server.admin_username,
-            settings.server.admin_password
+            self.foreman_user,
+            self.foreman_password
         ))
         self.assertEqual(len(result.stderr), 0)
 

--- a/tests/foreman/cli/test_user.py
+++ b/tests/foreman/cli/test_user.py
@@ -12,7 +12,6 @@ from fauxfactory import gen_string
 from robottelo.cli.base import CLIReturnCodeError
 from robottelo.cli.factory import make_location, make_org, make_role, make_user
 from robottelo.cli.user import User
-from robottelo.config import settings
 from robottelo.datafactory import (
     invalid_emails_list,
     invalid_names_list,
@@ -725,10 +724,9 @@ class UserTestCase(CLITestCase):
 
         @Assert: User is not deleted
         """
-        login = settings.server.admin_username
         with self.assertRaises(CLIReturnCodeError):
-            User.delete({'login': login})
-        self.assertTrue(User.info({'login': login}))
+            User.delete({'login': self.foreman_user})
+        self.assertTrue(User.info({'login': self.foreman_user}))
 
     @tier1
     def test_positive_list_username(self):

--- a/tests/foreman/ui/test_login.py
+++ b/tests/foreman/ui/test_login.py
@@ -29,7 +29,8 @@ class LoginTestCase(UITestCase):
 
         @Assert: Successfully logged in as an admin user
         """
-        self.login.login(self.katello_user, self.katello_passwd)
+        self.login.login(self.foreman_user,
+                         self.foreman_password)
         self.assertTrue(self.login.is_logged())
 
     @tier1


### PR DESCRIPTION
Changed UITestCase to isolate user per session/thread and fix the problem of conflicting organization context between simultaneous sessions when multithreading UI tests.

1. In setUpClass (once per thread) create a new random admin user via API
2. In setUp class (for each test_case) create a new browser instance and store previous created credentials as browser attribute
3. Keep using Session as a context manager to avoid further changes in all the test cases and keep the behavior of login/logout
4. Use the random user to login in to session unless an user is explicitly given
5. Fixed test_login to the new variables
6. Delete the created random admin user in tearDownClass (asynchronously once per thread)

Proven to be thread safe, During the test run, locally, in saucelabs and in CI with "-n 4" only 4 users were active, and for successful and skipped tested they were removed after the test.


![active_users_during_test_session](https://cloud.githubusercontent.com/assets/458654/15271520/1a0d087c-1a25-11e6-9ab9-6e73d944b0ce.png)


I'll provide the results of the build 75 of standalone automation here once it is finished.

