### PR TITLE
Cleanup fake capsules after cli capsule tests

### DIFF
--- a/robottelo/cleanup.py
+++ b/robottelo/cleanup.py
@@ -1,0 +1,19 @@
+# -*- encoding: utf-8 -*-
+"""Cleanup module for different entities"""
+from nailgun import entities
+from robottelo.cli.proxy import Proxy
+
+
+def capsule_cleanup(proxy_id=None):
+    """Deletes the capsule with the given id"""
+    Proxy.delete({'id': proxy_id})
+
+
+def location_cleanup(loc_id=None):
+    """Deletes the location with the given id"""
+    entities.Location(id=loc_id).delete()
+
+
+def org_cleanup(org_id=None):
+    """Deletes the Org with the given id"""
+    entities.Organization(id=org_id).delete()

--- a/tests/foreman/api/test_location.py
+++ b/tests/foreman/api/test_location.py
@@ -8,6 +8,7 @@ from fauxfactory import gen_integer, gen_string
 from nailgun import entities
 from random import randint
 from requests.exceptions import HTTPError
+from robottelo.cleanup import capsule_cleanup, location_cleanup
 from robottelo.cli.factory import make_proxy
 from robottelo.decorators import tier1, tier2
 from robottelo.datafactory import invalid_values_list
@@ -223,8 +224,15 @@ class LocationTestCase(APITestCase):
 
         @Feature: Location
         """
-        proxy = entities.SmartProxy(id=make_proxy()['id']).search()[0]
+        proxy_id = make_proxy()['id']
+        # Add capsule to cleanup list
+        self.addCleanup(capsule_cleanup, proxy_id)
+
+        proxy = entities.SmartProxy(id=proxy_id).search()[0]
         location = entities.Location(smart_proxy=[proxy]).create()
+        # Add location to cleanup list
+        self.addCleanup(location_cleanup, location.id)
+
         self.assertEqual(location.smart_proxy[0].id, proxy.id)
         self.assertEqual(location.smart_proxy[0].read().name, proxy.name)
 
@@ -502,9 +510,18 @@ class LocationTestCase(APITestCase):
 
         @Feature: Location - Update
         """
-        proxy = entities.SmartProxy(id=make_proxy()['id']).search()[0]
+        proxy_id_1 = make_proxy()['id']
+        proxy_id_2 = make_proxy()['id']
+        # Add capsules to cleanup list
+        self.addCleanup(capsule_cleanup, proxy_id_1)
+        self.addCleanup(capsule_cleanup, proxy_id_2)
+
+        proxy = entities.SmartProxy(id=proxy_id_1).search()[0]
         location = entities.Location(smart_proxy=[proxy]).create()
-        new_proxy = entities.SmartProxy(id=make_proxy()['id']).search()[0]
+        # Add location to cleanup list
+        self.addCleanup(location_cleanup, location.id)
+
+        new_proxy = entities.SmartProxy(id=proxy_id_2).search()[0]
         location.smart_proxy = [new_proxy]
         location = location.update(['smart_proxy'])
         self.assertEqual(location.smart_proxy[0].id, new_proxy.id)
@@ -556,8 +573,15 @@ class LocationTestCase(APITestCase):
 
         @Feature: Location - Update
         """
-        proxy = entities.SmartProxy(id=make_proxy()['id']).search()[0]
+        proxy_id = make_proxy()['id']
+        # Add capsule to cleanup list
+        self.addCleanup(capsule_cleanup, proxy_id)
+
+        proxy = entities.SmartProxy(id=proxy_id).search()[0]
         location = entities.Location(smart_proxy=[proxy]).create()
+        # Add location to cleanup list
+        self.addCleanup(location_cleanup, location.id)
+
         location.smart_proxy = []
         location = location.update(['smart_proxy'])
         self.assertEqual(len(location.smart_proxy), 0)

--- a/tests/foreman/cli/test_capsule.py
+++ b/tests/foreman/cli/test_capsule.py
@@ -4,6 +4,7 @@ import random
 import re
 
 from fauxfactory import gen_alphanumeric, gen_string
+from robottelo.cleanup import capsule_cleanup
 from robottelo.cli.base import CLIReturnCodeError
 from robottelo.cli.factory import CLIFactoryError, make_proxy
 from robottelo.cli.proxy import Proxy, default_url_on_new_port
@@ -45,6 +46,8 @@ class CapsuleTestCase(CLITestCase):
             with self.subTest(name):
                 proxy = make_proxy({u'name': name})
                 self.assertEquals(proxy['name'], name)
+                # Add capsule id to cleanup list
+                self.addCleanup(capsule_cleanup, proxy['id'])
 
     @run_only_on('sat')
     @tier1
@@ -83,6 +86,8 @@ class CapsuleTestCase(CLITestCase):
                     })
                     proxy = Proxy.info({u'id': proxy['id']})
                     self.assertEqual(proxy['name'], new_name)
+        # Add capsule id to cleanup list
+        self.addCleanup(capsule_cleanup, proxy['id'])
 
     @run_only_on('sat')
     @tier2
@@ -102,6 +107,8 @@ class CapsuleTestCase(CLITestCase):
                 Proxy.refresh_features({u'id': proxy['id']})
         else:
             raise ValueError('Unable to parse port number from proxy URL')
+        # Add capsule id to cleanup list
+        self.addCleanup(capsule_cleanup, proxy['id'])
 
     @run_only_on('sat')
     @tier2
@@ -121,6 +128,8 @@ class CapsuleTestCase(CLITestCase):
                 Proxy.refresh_features({u'name': proxy['name']})
         else:
             raise ValueError('Unable to parse port number from proxy URL')
+        # Add capsule id to cleanup list
+        self.addCleanup(capsule_cleanup, proxy['id'])
 
 
 class CapsuleIntegrationTestCase(CLITestCase):

--- a/tests/foreman/cli/test_location.py
+++ b/tests/foreman/cli/test_location.py
@@ -3,6 +3,7 @@
 
 from fauxfactory import gen_string
 from random import randint
+from robottelo.cleanup import capsule_cleanup, location_cleanup
 from robottelo.cli.base import CLIReturnCodeError
 from robottelo.cli.factory import (
     CLIFactoryError,
@@ -588,7 +589,7 @@ class LocationTestCase(CLITestCase):
     @run_only_on('sat')
     @tier2
     def test_positive_add_capsule_by_name(self):
-        """Add a capsule to organization by its name
+        """Add a capsule to location by its name
 
         @Feature: Organization
 
@@ -596,6 +597,10 @@ class LocationTestCase(CLITestCase):
         """
         loc = make_location()
         proxy = make_proxy()
+        # Add capsule and location to cleanup list
+        self.addCleanup(capsule_cleanup, proxy['id'])
+        self.addCleanup(location_cleanup, loc['id'])
+
         Location.add_smart_proxy({
             'name': loc['name'],
             'smart-proxy': proxy['name'],
@@ -606,7 +611,7 @@ class LocationTestCase(CLITestCase):
     @run_only_on('sat')
     @tier2
     def test_positive_add_capsule_by_id(self):
-        """Add a capsule to organization by its ID
+        """Add a capsule to location by its ID
 
         @feature: Organization
 
@@ -614,6 +619,10 @@ class LocationTestCase(CLITestCase):
         """
         loc = make_location()
         proxy = make_proxy()
+        # Add capsule and location to cleanup list
+        self.addCleanup(capsule_cleanup, proxy['id'])
+        self.addCleanup(location_cleanup, loc['id'])
+
         Location.add_smart_proxy({
             'name': loc['name'],
             'smart-proxy-id': proxy['id'],
@@ -632,6 +641,10 @@ class LocationTestCase(CLITestCase):
         """
         loc = make_location()
         proxy = make_proxy()
+        # Add capsule and location to cleanup list
+        self.addCleanup(capsule_cleanup, proxy['id'])
+        self.addCleanup(location_cleanup, loc['id'])
+
         Location.add_smart_proxy({
             'id': loc['id'],
             'smart-proxy-id': proxy['id'],
@@ -654,6 +667,10 @@ class LocationTestCase(CLITestCase):
         """
         loc = make_location()
         proxy = make_proxy()
+        # Add capsule and location to cleanup list
+        self.addCleanup(capsule_cleanup, proxy['id'])
+        self.addCleanup(location_cleanup, loc['id'])
+
         Location.add_smart_proxy({
             'name': loc['name'],
             'smart-proxy': proxy['name'],

--- a/tests/foreman/cli/test_organization.py
+++ b/tests/foreman/cli/test_organization.py
@@ -5,6 +5,7 @@ import random
 
 from fauxfactory import gen_string
 from itertools import cycle
+from robottelo.cleanup import capsule_cleanup, org_cleanup
 from robottelo.cli.base import CLIReturnCodeError
 from robottelo.cli.factory import (
     make_compute_resource,
@@ -973,6 +974,10 @@ class OrganizationTestCase(CLITestCase):
         """
         org = make_org()
         proxy = make_proxy()
+        # Add capsule and org to cleanup list
+        self.addCleanup(capsule_cleanup, proxy['id'])
+        self.addCleanup(org_cleanup, org['id'])
+
         Org.add_smart_proxy({
             'name': org['name'],
             'smart-proxy': proxy['name'],
@@ -991,6 +996,10 @@ class OrganizationTestCase(CLITestCase):
         """
         org = make_org()
         proxy = make_proxy()
+        # Add capsule and org to cleanup list
+        self.addCleanup(capsule_cleanup, proxy['id'])
+        self.addCleanup(org_cleanup, org['id'])
+
         Org.add_smart_proxy({
             'name': org['name'],
             'smart-proxy-id': proxy['id'],
@@ -1009,6 +1018,10 @@ class OrganizationTestCase(CLITestCase):
         """
         org = make_org()
         proxy = make_proxy()
+        # Add capsule and org to cleanup list
+        self.addCleanup(capsule_cleanup, proxy['id'])
+        self.addCleanup(org_cleanup, org['id'])
+
         Org.add_smart_proxy({
             'id': org['id'],
             'smart-proxy-id': proxy['id'],
@@ -1031,6 +1044,10 @@ class OrganizationTestCase(CLITestCase):
         """
         org = make_org()
         proxy = make_proxy()
+        # Add capsule and org to cleanup list
+        self.addCleanup(capsule_cleanup, proxy['id'])
+        self.addCleanup(org_cleanup, org['id'])
+
         Org.add_smart_proxy({
             'name': org['name'],
             'smart-proxy': proxy['name'],


### PR DESCRIPTION
Tests are running and I will paste the results once done.

Background: Leaving the fake capsules running creates other issues while syncing, loading UI capsules page, etc.