### PR TITLE
Fix UI repo discovery tests

### DIFF
--- a/robottelo/ui/locators.py
+++ b/robottelo/ui/locators.py
@@ -1551,7 +1551,7 @@ locators = LocatorDict({
                    "/../../span[contains(@class, 'info-value')]")),
     "repo.repo_discover": (
         By.XPATH, "//button[@ui-sref='products.discovery.scan']"),
-    "repo.discover_url": (By.XPATH, "//input[@type='url']"),
+    "repo.discover_url": (By.XPATH, "//input[@ng-model='discovery.url']"),
     "repo.discover_button": (By.XPATH, "//button[@type='submit']"),
     "repo.discovered_url_checkbox": (
         By.XPATH, ("//table[@bst-table='discoveryTable']"


### PR DESCRIPTION
```python
py.test tests/foreman/ui/test_repository.py -k 'discover_repo'
================================ test session starts =================================
platform linux2 -- Python 2.7.10, pytest-2.9.1, py-1.4.31, pluggy-0.3.1
rootdir: /home/andrii/workspace/robottelo, inifile: 
plugins: xdist-1.13.1, repeat-0.2
collected 18 items 

tests/foreman/ui/test_repository.py ..

====================== 16 tests deselected by '-kdiscover_repo' ======================
====================== 2 passed, 16 deselected in 95.45 seconds ======================
```