### PR TITLE
Skip client provisioning on end to end tests

### DIFF
--- a/robottelo/decorators.py
+++ b/robottelo/decorators.py
@@ -41,6 +41,18 @@ _redmine = {
 }
 
 
+def setting_is_set(option):
+    """Return either ``True`` or ``False`` if a Robottelo section setting is
+    set or not respectively.
+    """
+    if not settings.configured:
+        settings.configure()
+    # Example: `settings.clients`
+    if getattr(settings, option).validate():
+        return False
+    return True
+
+
 def skip_if_not_set(*options):
     """Skips test if expected configuration is not set.
 
@@ -104,12 +116,10 @@ def skip_if_not_set(*options):
     def decorator(func):
         @wraps(func)
         def wrapper(*args, **kwargs):
-            if not settings.configured:
-                settings.configure()
             missing = []
             for option in options:
                 # Example: `settings.clients`
-                if getattr(settings, option).validate():
+                if not setting_is_set(option):
                     # List of all sections that are not fully configured
                     missing.append(option)
             if not missing:

--- a/tests/foreman/endtoend/utils.py
+++ b/tests/foreman/endtoend/utils.py
@@ -1,4 +1,5 @@
 """Module that aggregates common bits of the end to end tests."""
+from robottelo.decorators import setting_is_set
 from robottelo.vm import VirtualMachine
 
 AK_CONTENT_LABEL = u'rhel-6-server-rhev-agent-rpms'
@@ -21,6 +22,8 @@ class ClientProvisioningMixin(object):
             is available.
         :param package_name: Name of the package to be installed on the client.
         """
+        if not setting_is_set('clients'):
+            return
         with VirtualMachine(distro='rhel66') as vm:
             # Pull rpm from Foreman server and install on client
             vm.install_katello_ca()


### PR DESCRIPTION
If the clients support is not available on the configuration, skip the end to
end client provisioning.