### PR TITLE
Update API & UI sync plan start date tests according to Sat6.2 changes

### DIFF
--- a/tests/foreman/api/test_syncplan.py
+++ b/tests/foreman/api/test_syncplan.py
@@ -163,6 +163,7 @@ class SyncPlanCreateTestCase(APITestCase):
                 self.assertEqual(sync_plan.interval, interval)
 
     @run_only_on('sat')
+    @skip_if_bug_open('bugzilla', 1335133)
     @tier1
     def test_positive_create_with_sync_date(self):
         """Create a sync plan and update its sync date.
@@ -178,7 +179,7 @@ class SyncPlanCreateTestCase(APITestCase):
                     sync_date=syncdate,
                 ).create()
                 self.assertEqual(
-                    syncdate.strftime('%Y-%m-%d %H:%M:%S UTC'),
+                    syncdate.strftime('%m/%d/%Y %I:%M:%p'),
                     sync_plan.sync_date
                 )
 
@@ -325,8 +326,9 @@ class SyncPlanUpdateTestCase(APITestCase):
                     interval
                 )
 
-    @tier1
     @run_only_on('sat')
+    @skip_if_bug_open('bugzilla', 1335133)
+    @tier1
     def test_positive_update_sync_date(self):
         """Updated sync plan's sync date.
 
@@ -342,7 +344,7 @@ class SyncPlanUpdateTestCase(APITestCase):
             with self.subTest(syncdate):
                 sync_plan.sync_date = syncdate
                 self.assertEqual(
-                    syncdate.strftime('%Y-%m-%d %H:%M:%S UTC'),
+                    syncdate.strftime('%m/%d/%Y %I:%M:%p'),
                     sync_plan.update(['sync_date']).sync_date
                 )
 


### PR DESCRIPTION
1) Server now returns date and time in US style (`%m/%d/%Y %I:%M:%p` instead of `%Y-%m-%d %H:%M:%S`)
2) As per [BZ1335133](https://bugzilla.redhat.com/show_bug.cgi?id=1335133), server returns start date in its own time zone, not in user's (that's especially wrong for UI tests), skipping the tests