### PR TITLE
converted locked template tests to positive tests

### DIFF
--- a/tests/foreman/cli/test_template.py
+++ b/tests/foreman/cli/test_template.py
@@ -4,14 +4,13 @@
 from fauxfactory import gen_string
 from robottelo.cli.base import CLIReturnCodeError
 from robottelo.cli.factory import (
-    CLIFactoryError,
     make_location,
     make_org,
     make_os,
     make_template,
 )
 from robottelo.cli.template import Template
-from robottelo.decorators import run_only_on, skip_if_bug_open, tier1, tier2
+from robottelo.decorators import run_only_on, tier1, tier2
 from robottelo.test import CLITestCase
 
 
@@ -64,21 +63,19 @@ class TemplateTestCase(CLITestCase):
 
     @run_only_on('sat')
     @tier1
-    @skip_if_bug_open('bugzilla', 1328976)
-    def test_negative_create_locked(self):
-        """Check that locked Template cannot be created
+    def test_positive_create_locked(self):
+        """Check that locked Template can be created
 
         @Feature: Template - Create
 
-        @Assert: It is not allowed to create locked Template
+        @Assert: The locked template is created successfully
 
-        @BZ: 1328976
         """
-        with self.assertRaises(CLIFactoryError):
-            make_template({
+        new_template = make_template({
                 'locked': 'true',
                 'name': gen_string('alpha'),
             })
+        self.assertEqual(new_template['locked'], 'yes')
 
     @run_only_on('sat')
     @tier1


### PR DESCRIPTION
```
 py.test tests/foreman/cli/test_template.py -k test_positive_create_locked
======================================================================== test session starts ========================================================================
platform linux2 -- Python 2.7.11, pytest-2.9.1, py-1.4.31, pluggy-0.3.1
rootdir: /home/suresh/hacking/robottelo, inifile: 
plugins: cov-2.2.1, xdist-1.14
collected 9 items 

tests/foreman/cli/test_template.py .

======================================================= 8 tests deselected by '-ktest_positive_create_locked' =======================================================
============================================================== 1 passed, 8 deselected in 6.60 seconds ===============================================================
```