### PR TITLE
Fix UI subscription failures

### DIFF
--- a/tests/foreman/ui/test_subscription.py
+++ b/tests/foreman/ui/test_subscription.py
@@ -4,7 +4,7 @@ from robottelo import manifests
 from robottelo.constants import DEFAULT_SUBSCRIPTION_NAME
 from robottelo.decorators import skip_if_not_set, tier1
 from robottelo.test import UITestCase
-from robottelo.ui.locators import common_locators, locators
+from robottelo.ui.locators import common_locators
 from robottelo.ui.session import Session
 
 
@@ -18,58 +18,24 @@ class SubscriptionTestCase(UITestCase):
 
     @skip_if_not_set('fake_manifest')
     @tier1
-    def test_positive_upload_basic(self):
-        """Upload a manifest with minimal input parameters
+    def test_positive_upload_and_delete(self):
+        """Upload a manifest with minimal input parameters and delete it
 
-        @Feature: Manifest/Subscription - Positive Create
+        @Feature: Manifest/Subscription
 
-        @Assert: Manifest is uploaded successfully
+        @Assert: Manifest is uploaded and deleted successfully
         """
         with Session(self.browser) as session:
             session.nav.go_to_select_org(self.organization.name)
             session.nav.go_to_red_hat_subscriptions()
+            # Step 1: Attempt to upload a manifest
             with manifests.clone() as manifest:
                 self.subscriptions.upload(manifest)
             self.assertTrue(self.subscriptions.wait_until_element(
                 common_locators['alert.success']))
-
-    @skip_if_not_set('fake_manifest')
-    @tier1
-    def test_positive_delete(self):
-        """Upload a manifest and then delete it
-
-        @Feature: Manifest/Subscription - Positive Delete
-
-        @Assert: Manifest is deleted successfully
-        """
-        with Session(self.browser) as session:
-            session.nav.go_to_select_org(self.organization.name)
-            session.nav.go_to_red_hat_subscriptions()
-            with manifests.clone() as manifest:
-                self.subscriptions.upload(manifest)
+            # Step 2: Attempt to delete the manifest
             self.subscriptions.delete()
             self.assertTrue(self.subscriptions.wait_until_element(
                 common_locators['alert.success']))
-
-    @skip_if_not_set('fake_manifest')
-    @tier1
-    def test_positive_assert_delete_button(self):
-        """Upload and delete a manifest
-
-        @Feature: Manifest/Subscription - Positive Delete
-
-        @Assert: Manifest is Deleted. Delete button is asserted. Subscriptions
-        is asserted
-        """
-        with Session(self.browser) as session:
-            session.nav.go_to_select_org(self.organization.name)
-            session.nav.go_to_red_hat_subscriptions()
-            with manifests.clone() as manifest:
-                self.subscriptions.upload(manifest)
-            self.subscriptions.delete()
-            self.assertTrue(self.subscriptions.wait_until_element(
-                common_locators['alert.success']))
-            self.assertTrue(self.subscriptions.wait_until_element(
-                locators['subs.delete_manifest']))
             self.assertIsNone(
                 self.subscriptions.search(DEFAULT_SUBSCRIPTION_NAME))


### PR DESCRIPTION
Note:
1. Before this fix, the UI subscription tests fail if the delete tests are called
first.  It is not reproducible locally.
2. I understand that this fix breaks the atomicity of tests by combining few
tests but without these changes, none of the subscription tests run in tier1 and
this reduces test coverage for subscriptions.
3. Also note that this test removes the invalid
test_positive_assert_delete_button test as it tries to assert the delete button
during the manifest delete process and this is error prone and invalid.