### PR TITLE
Fixing user test to work for any organization that was chosen by default

### DIFF
--- a/tests/foreman/ui/test_user.py
+++ b/tests/foreman/ui/test_user.py
@@ -13,7 +13,7 @@ from robottelo.datafactory import (
 )
 from robottelo.decorators import skip_if_bug_open, stubbed, tier1, tier2, tier3
 from robottelo.test import UITestCase
-from robottelo.ui.factory import make_user
+from robottelo.ui.factory import make_user, set_context
 from robottelo.ui.locators import common_locators, locators, tab_locators
 from robottelo.ui.session import Session
 
@@ -251,6 +251,7 @@ class UserTestCase(UITestCase):
         for org_name in [org_name1, org_name2]:
             entities.Organization(name=org_name).create()
         with Session(self.browser) as session:
+            set_context(session, org=DEFAULT_ORG)
             make_user(
                 session,
                 username=name,


### PR DESCRIPTION
We can pretend that 'Any Context' will be always chosen by default and remove `DEFAULT_ORG` from verification loop at all, but I decided that it will be more reliable to support all possible default organizations and always switch to it, no matter what was selected when you log-in to application

```
nosetests tests/foreman/ui/test_user.py -m test_positive_create_with_multiple_orgs
.
----------------------------------------------------------------------
Ran 1 test in 50.581s

OK
```