### PR TITLE
Introduce run_in_one_thread decorator to execute specific tests in 1 thread

### DIFF
--- a/robottelo/decorators.py
+++ b/robottelo/decorators.py
@@ -27,6 +27,9 @@ tier3 = pytest.mark.tier3
 # Long running tests
 tier4 = pytest.mark.tier4
 
+# Tests to be executed in 1 thread
+run_in_one_thread = pytest.mark.run_in_one_thread
+
 # A dict mapping bug IDs to python-bugzilla bug objects.
 _bugzilla = {}
 

--- a/tests/foreman/api/test_contentview.py
+++ b/tests/foreman/api/test_contentview.py
@@ -17,6 +17,7 @@ from robottelo.constants import (
 from robottelo.datafactory import invalid_names_list, valid_data_list
 from robottelo.decorators import (
     bz_bug_is_open,
+    run_in_one_thread,
     run_only_on,
     skip_if_bug_open,
     skip_if_not_set,
@@ -933,6 +934,7 @@ class ContentViewDeleteTestCase(APITestCase):
                     entities.ContentView(id=cv.id).read()
 
 
+@run_in_one_thread
 class ContentViewRedHatContent(APITestCase):
     """Tests for publishing and promoting content views."""
 

--- a/tests/foreman/cli/test_activationkey.py
+++ b/tests/foreman/cli/test_activationkey.py
@@ -23,6 +23,7 @@ from robottelo.cli.subscription import Subscription
 from robottelo.constants import FAKE_0_YUM_REPO, PRDS, REPOS, REPOSET
 from robottelo.datafactory import valid_data_list, invalid_values_list
 from robottelo.decorators import (
+    run_in_one_thread,
     run_only_on,
     skip_if_bug_open,
     skip_if_not_set,
@@ -565,6 +566,7 @@ class ActivationKeyTestCase(CLITestCase):
                 self.assertEqual(
                     activation_key['host-collection'], host_col_name)
 
+    @run_in_one_thread
     @run_only_on('sat')
     @skip_if_not_set('fake_manifest')
     @tier3
@@ -607,6 +609,7 @@ class ActivationKeyTestCase(CLITestCase):
         })
         self.assertEqual(content[0]['name'], repo['name'])
 
+    @run_in_one_thread
     @run_only_on('sat')
     @skip_if_not_set('fake_manifest')
     @tier3
@@ -662,6 +665,7 @@ class ActivationKeyTestCase(CLITestCase):
         @Status: Manual
         """
 
+    @run_in_one_thread
     @skip_if_not_set('fake_manifest')
     @tier2
     def test_positive_delete_subscription(self):
@@ -908,6 +912,7 @@ class ActivationKeyTestCase(CLITestCase):
                 })
                 self.assertEqual(len(activation_key['host-collections']), 0)
 
+    @run_in_one_thread
     @skip_if_not_set('fake_manifest')
     @tier2
     def test_positive_add_subscription_by_id(self):
@@ -993,6 +998,7 @@ class ActivationKeyTestCase(CLITestCase):
             })
         self.assertEqual(exception.exception.return_code, 65)
 
+    @run_in_one_thread
     @skip_if_not_set('fake_manifest')
     @tier2
     def test_positive_copy_subscription(self):

--- a/tests/foreman/cli/test_contentview.py
+++ b/tests/foreman/cli/test_contentview.py
@@ -29,6 +29,7 @@ from robottelo.constants import (
     REPOSET,
 )
 from robottelo.decorators import (
+    run_in_one_thread,
     run_only_on,
     skip_if_bug_open,
     stubbed,
@@ -641,8 +642,9 @@ class ContentViewTestCase(CLITestCase):
 
     # Content Views: Adding products/repos
 
-    @tier2
+    @run_in_one_thread
     @run_only_on('sat')
+    @tier2
     def test_positive_add_rh_repo_by_id(self):
         """Associate Red Hat content to a content view
 
@@ -671,8 +673,9 @@ class ContentViewTestCase(CLITestCase):
             'Repo was not associated to CV',
         )
 
-    @tier2
+    @run_in_one_thread
     @run_only_on('sat')
+    @tier2
     def test_positive_add_rh_repo_by_id_and_create_filter(self):
         """Associate Red Hat content to a content view and create filter
 
@@ -924,8 +927,9 @@ class ContentViewTestCase(CLITestCase):
     # katello content view promote --label=MyView --env=Dev --org=ACME
     # katello content view promote --view=MyView --env=Staging --org=ACME
 
-    @tier2
+    @run_in_one_thread
     @run_only_on('sat')
+    @tier2
     def test_positive_promote_rh_content(self):
         """attempt to promote a content view containing RH content
 
@@ -1138,8 +1142,9 @@ class ContentViewTestCase(CLITestCase):
     # Content Views: publish
     # katello content definition publish --label=MyView
 
-    @tier2
+    @run_in_one_thread
     @run_only_on('sat')
+    @tier2
     def test_positive_publish_rh_content(self):
         """attempt to publish a content view containing RH content
 
@@ -1503,8 +1508,9 @@ class ContentViewTestCase(CLITestCase):
         content_view = ContentView.info({u'id': content_view['id']})
         self.assertEqual(content_view['content-host-count'], '1')
 
-    @tier3
+    @run_in_one_thread
     @run_only_on('sat')
+    @tier3
     def test_positive_subscribe_chost_by_id_using_rh_content(self):
         """Attempt to subscribe content host to content view that has
         Red Hat repository assigned to it
@@ -1550,8 +1556,9 @@ class ContentViewTestCase(CLITestCase):
         content_view = ContentView.info({u'id': content_view['id']})
         self.assertEqual(content_view['content-host-count'], '1')
 
-    @tier3
+    @run_in_one_thread
     @run_only_on('sat')
+    @tier3
     def test_positive_subscribe_chost_by_id_using_rh_content_and_filters(self):
         """Attempt to subscribe content host to filtered content view
         that has Red Hat repository assigned to it

--- a/tests/foreman/cli/test_host.py
+++ b/tests/foreman/cli/test_host.py
@@ -40,6 +40,7 @@ from robottelo.datafactory import (
     valid_hosts_list,
 )
 from robottelo.decorators import (
+    run_in_one_thread,
     run_only_on,
     skip_if_not_set,
     tier1,
@@ -843,6 +844,7 @@ class HostParameterTestCase(CLITestCase):
                 self.assertNotIn(name, self.host['parameters'].keys())
 
 
+@run_in_one_thread
 class KatelloAgentTestCase(CLITestCase):
     """Host tests, which require VM with installed katello-agent."""
 

--- a/tests/foreman/cli/test_import.py
+++ b/tests/foreman/cli/test_import.py
@@ -22,7 +22,13 @@ from robottelo.cli.subscription import Subscription
 from robottelo.cli.template import Template
 from robottelo.cli.user import User
 from robottelo.config import settings
-from robottelo.decorators import bz_bug_is_open, skip_if_bug_open
+from robottelo.decorators import (
+    bz_bug_is_open,
+    run_in_one_thread,
+    skip_if_bug_open,
+    tier1,
+    tier3,
+)
 from robottelo.test import CLITestCase
 
 
@@ -482,6 +488,7 @@ def gen_import_ak_data():
     },)
 
 
+@run_in_one_thread
 class TestImport(CLITestCase):
     """Import CLI tests.
 
@@ -501,6 +508,7 @@ class TestImport(CLITestCase):
         ssh.command(u'rm -r {0}'.format(cls.default_dataset[0]))
         super(TestImport, cls).tearDownClass()
 
+    @tier1
     def test_positive_import_orgs_default(self):
         """Import all organizations from the default data set
         (predefined source).
@@ -521,6 +529,7 @@ class TestImport(CLITestCase):
                     Org.info({'name': org['organization']})
                 clean_transdata()
 
+    @tier3
     def test_positive_import_orgs_manifests(self):
         """Import all organizations from the default data set
         (predefined source) and upload manifests for each of them
@@ -552,6 +561,7 @@ class TestImport(CLITestCase):
                     self.assertIn('SUCCESS', manifest_history)
                 clean_transdata()
 
+    @tier1
     def test_negative_reimport_orgs_default(self):
         """Try to Import all organizations from the predefined source
         and try to import them again
@@ -572,6 +582,7 @@ class TestImport(CLITestCase):
                 self.assertEqual(orgs_before, Org.list())
                 clean_transdata()
 
+    @tier1
     def test_positive_import_orgs_recovery(self):
         """Try to Import organizations with the same name to invoke
         usage of a recovery strategy (rename, map, none)
@@ -621,6 +632,7 @@ class TestImport(CLITestCase):
                 })
                 clean_transdata()
 
+    @tier1
     def test_positive_merge_orgs(self):
         """Try to Import all organizations and their users from CSV
         to a mapped organization.
@@ -658,6 +670,7 @@ class TestImport(CLITestCase):
                 self.assertTrue(all((user in logins for user in imp_users)))
                 clean_transdata()
 
+    @tier1
     def test_positive_import_users_default(self):
         """Import all 3 users from the default data set (predefined
         source).
@@ -687,6 +700,7 @@ class TestImport(CLITestCase):
                 self.assertTrue(imp_users.issubset(logins))
                 clean_transdata()
 
+    @tier1
     def test_negative_reimport_users_default(self):
         """Try to Import all users from the
         predefined source and try to import them again
@@ -716,6 +730,7 @@ class TestImport(CLITestCase):
                 self.assertTrue(users_after.issubset(users_before))
                 clean_transdata()
 
+    @tier1
     def test_positive_import_users_merge(self):
         """Try to Merge users with the same name using 'merge-users'
         option.
@@ -754,6 +769,7 @@ class TestImport(CLITestCase):
                     self.assertNotEqual(User.info({'id': record['sat6']}), '')
                 clean_transdata()
 
+    @tier1
     def test_positive_import_users_recovery(self):
         """Try to Import users with the same name to invoke
         usage of a recovery strategy (rename, map, none)
@@ -815,6 +831,7 @@ class TestImport(CLITestCase):
                 ssh.command(u'rm -rf {0}'.format(' '.join(pwdfiles)))
                 clean_transdata()
 
+    @tier1
     def test_positive_import_host_collections_default(self):
         """Import all System Groups from the default data set
         (predefined source) as the Host Collections.
@@ -850,6 +867,7 @@ class TestImport(CLITestCase):
                     )
                 clean_transdata()
 
+    @tier1
     def test_negative_reimport_host_collections_default(self):
         """Try to re-import all System Groups from the default data set
         (predefined source) as the Host Collections.
@@ -882,6 +900,7 @@ class TestImport(CLITestCase):
                 self.assertEqual(hcollections_before, hcollections_after)
                 clean_transdata()
 
+    @tier1
     def test_positive_import_host_collections_recovery(self):
         """Try to Import Collections with the same name to invoke
         usage of a recovery strategy (rename, map, none)
@@ -944,6 +963,7 @@ class TestImport(CLITestCase):
                     HostCollection.info({'id': record['sat6']})
                 clean_transdata()
 
+    @tier1
     def test_positive_import_repo_default(self):
         """Import and enable all Repositories from the default data set
         (predefined source)
@@ -982,6 +1002,7 @@ class TestImport(CLITestCase):
                     )
                 clean_transdata()
 
+    @tier1
     def test_negative_reimport_repo(self):
         """Import and enable all Repositories from the default data set
         (predefined source), then try to Import Repositories from the same CSV
@@ -1032,6 +1053,7 @@ class TestImport(CLITestCase):
                 )
                 clean_transdata()
 
+    @tier1
     def test_positive_import_repo_recovery(self):
         """Try to Import Repos with the same name to invoke
         usage of a recovery strategy (rename, map, none)
@@ -1094,6 +1116,7 @@ class TestImport(CLITestCase):
                     Repository.info({'id': record['sat6']})
                 clean_transdata()
 
+    @tier1
     def test_positive_import_cv_default(self):
         """Import and enable all Content Views from the default data set
         (predefined source)
@@ -1137,6 +1160,7 @@ class TestImport(CLITestCase):
                     )
                 clean_transdata()
 
+    @tier1
     def test_negative_reimport_cv(self):
         """Import and enable all Content Views from the default data set
         (predefined source), then try to Import them from the same CSV
@@ -1190,6 +1214,7 @@ class TestImport(CLITestCase):
                 )
                 clean_transdata()
 
+    @tier1
     def test_positive_import_cv_recovery(self):
         """Try to Import Content Views with the same name to invoke
         usage of a recovery strategy (rename, map, none)
@@ -1263,6 +1288,7 @@ class TestImport(CLITestCase):
                 clean_transdata()
 
     @skip_if_bug_open('bugzilla', 1325880)
+    @tier1
     def test_positive_translate_macros(self):
         """Check whether all supported Sat5 macros are being properly
         converted to the Puppet facts.
@@ -1377,6 +1403,7 @@ class TestImport(CLITestCase):
         )
         clean_transdata()
 
+    @tier3
     def test_positive_import_enable_rh_repos(self):
         """Import and enable all red hat repositories from predefined
         dataset
@@ -1425,6 +1452,7 @@ class TestImport(CLITestCase):
                     )
                 clean_transdata()
 
+    @tier3
     def test_negative_reimport_enable_rh_repos(self):
         """Repetitive Import and enable of all red hat repositories from
         the predefined dataset
@@ -1470,6 +1498,7 @@ class TestImport(CLITestCase):
                 clean_transdata()
 
     @skip_if_bug_open('bugzilla', 1325497)
+    @tier1
     def test_positive_import_chosts_default(self):
         """Import all content hosts from
         the predefined dataset
@@ -1499,6 +1528,7 @@ class TestImport(CLITestCase):
                     )
                 clean_transdata()
 
+    @tier1
     def test_negative_reimport_chosts(self):
         """Repetitive Import of all content hosts from
         the predefined dataset
@@ -1539,6 +1569,7 @@ class TestImport(CLITestCase):
                 clean_transdata()
 
     @skip_if_bug_open('bugzilla', 1267224)
+    @tier1
     def test_negative_import_chosts_recovery(self):
         """Try to invoke usage of a recovery strategy
 
@@ -1569,6 +1600,7 @@ class TestImport(CLITestCase):
                     })
                 clean_transdata()
 
+    @tier1
     def test_positive_import_snippets_default(self):
         """Import template snippets from the default data set
         (predefined source)
@@ -1607,6 +1639,7 @@ class TestImport(CLITestCase):
                 clean_transdata()
 
     @skip_if_bug_open('bugzilla', 1325880)
+    @tier1
     def test_positive_import_config_files_default(self):
         """Import all Config Files from the default data set
         (predefined source)
@@ -1646,6 +1679,7 @@ class TestImport(CLITestCase):
                 clean_transdata()
 
     @skip_if_bug_open('bugzilla', 1325880)
+    @tier1
     def test_negative_reimport_config_files(self):
         """Repetitive Import of all Config Files from the default
         data set (predefined source)
@@ -1701,6 +1735,7 @@ class TestImport(CLITestCase):
                 clean_transdata()
 
     @skip_if_bug_open('bugzilla', 1325124)
+    @tier1
     def test_positive_import_ak_default(self):
         """Import AKs from the default data set
         (predefined source)

--- a/tests/foreman/cli/test_subscription.py
+++ b/tests/foreman/cli/test_subscription.py
@@ -6,11 +6,17 @@ from robottelo.cli.repository import Repository
 from robottelo.cli.repository_set import RepositorySet
 from robottelo.cli.subscription import Subscription
 from robottelo.constants import PRDS, REPOS, REPOSET
-from robottelo.decorators import skip_if_bug_open, tier1, tier2
+from robottelo.decorators import (
+    run_in_one_thread,
+    skip_if_bug_open,
+    tier1,
+    tier2,
+)
 from robottelo.ssh import upload_file
 from robottelo.test import CLITestCase
 
 
+@run_in_one_thread
 class SubscriptionTestCase(CLITestCase):
     """Manifest CLI tests"""
 

--- a/tests/foreman/longrun/test_inc_updates.py
+++ b/tests/foreman/longrun/test_inc_updates.py
@@ -15,6 +15,7 @@ from robottelo.api.utils import (
 from robottelo.cli.contentview import ContentView as ContentViewCLI
 from robottelo.constants import PRD_SETS
 from robottelo.decorators import (
+    run_in_one_thread,
     run_only_on,
     skip_if_bug_open,
     skip_if_not_set,
@@ -24,6 +25,7 @@ from robottelo.test import TestCase
 from robottelo.vm import VirtualMachine
 
 
+@run_in_one_thread
 class IncrementalUpdateTestCase(TestCase):
     """Tests for the Incremental Update feature"""
 

--- a/tests/foreman/ui/test_activationkey.py
+++ b/tests/foreman/ui/test_activationkey.py
@@ -20,6 +20,7 @@ from robottelo.constants import (
 )
 from robottelo.datafactory import invalid_names_list, valid_data_list
 from robottelo.decorators import (
+    run_in_one_thread,
     run_only_on,
     skip_if_not_set,
     stubbed,
@@ -560,6 +561,7 @@ class ActivationKeyTestCase(UITestCase):
             selected_cv = self.activationkey.get_attribute(name, cv_locator)
             self.assertEqual(cv2_name, selected_cv)
 
+    @run_in_one_thread
     @run_only_on('sat')
     @skip_if_not_set('fake_manifest')
     @tier2
@@ -799,8 +801,9 @@ class ActivationKeyTestCase(UITestCase):
                     key_name)
                 self.assertEqual(vm.hostname, name)
 
-    @skip_if_not_set('fake_manifest')
+    @run_in_one_thread
     @run_only_on('sat')
+    @skip_if_not_set('fake_manifest')
     @tier2
     def test_positive_add_rh_product(self):
         """Test that RH product can be associated to Activation Keys
@@ -872,8 +875,9 @@ class ActivationKeyTestCase(UITestCase):
             self.assertIsNotNone(self.activationkey.wait_until_element(
                 common_locators['alert.success_sub_form']))
 
-    @skip_if_not_set('fake_manifest')
+    @run_in_one_thread
     @run_only_on('sat')
+    @skip_if_not_set('fake_manifest')
     @tier2
     def test_positive_add_rh_and_custom_products(self):
         """Test that RH/Custom product can be associated to Activation
@@ -943,6 +947,7 @@ class ActivationKeyTestCase(UITestCase):
             self.assertIsNotNone(self.activationkey.wait_until_element(
                 common_locators['alert.success_sub_form']))
 
+    @run_in_one_thread
     @skip_if_not_set('fake_manifest')
     @tier2
     def test_positive_delete_manifest(self):

--- a/tests/foreman/ui/test_adusergroup.py
+++ b/tests/foreman/ui/test_adusergroup.py
@@ -5,6 +5,7 @@ from robottelo.config import settings
 from robottelo.constants import (
     LDAP_SERVER_TYPE, LDAP_ATTR, PERMISSIONS, ANY_CONTEXT)
 from robottelo.decorators import (
+    run_in_one_thread,
     stubbed,
     skip_if_bug_open,
     skip_if_not_set,
@@ -19,6 +20,7 @@ from robottelo.ui.session import Session
 from selenium.webdriver.common.action_chains import ActionChains
 
 
+@run_in_one_thread
 class ActiveDirectoryUserGroupTestCase(UITestCase):
     """Implements Active Directory feature tests in UI."""
 

--- a/tests/foreman/ui/test_contentview.py
+++ b/tests/foreman/ui/test_contentview.py
@@ -24,6 +24,7 @@ from robottelo.constants import (
 )
 from robottelo.datafactory import invalid_names_list, valid_data_list
 from robottelo.decorators import (
+    run_in_one_thread,
     run_only_on,
     skip_if_bug_open,
     skip_if_not_set,
@@ -515,6 +516,7 @@ class ContentViewTestCase(UITestCase):
             self.assertIsNotNone(self.content_views.wait_until_element(
                 common_locators['alert.success_sub_form']))
 
+    @run_in_one_thread
     @run_only_on('sat')
     @skip_if_not_set('fake_manifest')
     @tier2
@@ -694,6 +696,7 @@ class ContentViewTestCase(UITestCase):
 
         """
 
+    @run_in_one_thread
     @run_only_on('sat')
     @skip_if_not_set('fake_manifest')
     @tier3
@@ -826,6 +829,7 @@ class ContentViewTestCase(UITestCase):
 
         """
 
+    @run_in_one_thread
     @run_only_on('sat')
     @skip_if_not_set('fake_manifest')
     @tier3

--- a/tests/foreman/ui/test_organization.py
+++ b/tests/foreman/ui/test_organization.py
@@ -13,6 +13,7 @@ from robottelo.datafactory import (
     invalid_values_list,
 )
 from robottelo.decorators import (
+    run_in_one_thread,
     run_only_on,
     skip_if_bug_open,
     skip_if_not_set,
@@ -229,6 +230,7 @@ class OrganizationTestCase(UITestCase):
                     entities.Organization(name=org_name).create()
                     self.org.delete(org_name)
 
+    @run_in_one_thread
     @skip_if_not_set('fake_manifest')
     @tier2
     def test_verify_bugzilla_1225588(self):
@@ -258,6 +260,7 @@ class OrganizationTestCase(UITestCase):
                     break
             self.assertIsNone(status)
 
+    @run_in_one_thread
     @skip_if_not_set('fake_manifest')
     @tier2
     def test_verify_bugzilla_1259248(self):

--- a/tests/foreman/ui/test_sync.py
+++ b/tests/foreman/ui/test_sync.py
@@ -6,6 +6,7 @@ from robottelo.api.utils import upload_manifest
 from robottelo.constants import FAKE_1_YUM_REPO
 from robottelo.datafactory import generate_strings_list
 from robottelo.decorators import (
+    run_in_one_thread,
     run_only_on,
     skip_if_not_set,
     stubbed,
@@ -61,6 +62,7 @@ class SyncTestCase(UITestCase):
                     # sync.sync_custom_repos returns boolean value
                     self.assertTrue(sync)
 
+    @run_in_one_thread
     @skip_if_not_set('fake_manifest')
     @tier2
     def test_positive_sync_rh_repos(self):


### PR DESCRIPTION
A little bit of backstory:
> Some of robottelo tests are required to be executed sequentally. Good examples are CLI import tests or UI AD Usergroup tests. As we run our automation in 4 threads, to execute such tests in 1 thread a workaround was introduced - jenkins job executed 2 commands, the first one is py.test in 4 threads running everything except mentioned tests, and the second one - only CLI import tests in 1 thread.
This approach is not flexible as it requires changes on jenkins each time new 'exceptions' are introduced. But it was ok for us as there were only few of such tests.
Recently a new Satellite race condition issue was discovered, making us upload only 1 manifest at the same time, otherwise tasks will fail ([BZ1336738](https://bugzilla.redhat.com/show_bug.cgi?id=1336738)). As the tests with manifests are numerous and corresponding bugzilla was moved out of current release, we were forced to find a better way to identify tests that should be run sequentially.

`run_in_one_thread` is an optional decorator which doesn't conflict with tier decorators (both can and basically should be applied at the same time). It doesn't contain any logic on robottelo side but is used as a tag describing that specific test (or even class with tests) should be executed in 1 thread and can't be executed while some others tests are running in the background.
Together with this PR, jenkins jobs should be updated to execute 2 commands 1 by 1 - tests not decorated with run_in_one_thread in 4 threads first, and only after that tests decorated with run_in_one_thread in 1 thread. The idea is simple as that:
```bash
py.test tests/foreman -n 4 -m 'tier1 and not run_in_one_thread'
py.test tests/foreman -m 'tier1 and run_in_one_thread'
```
for each tier job accordingly.
This will allow us to easily decorate the tests which have to be executed sequentially in 1 line of code with no changes to any of jenkins jobs.