### PR TITLE
Skip CLI activation key subscription remove test due to open BZ

### DIFF
--- a/tests/foreman/cli/test_activationkey.py
+++ b/tests/foreman/cli/test_activationkey.py
@@ -666,6 +666,7 @@ class ActivationKeyTestCase(CLITestCase):
         """
 
     @run_in_one_thread
+    @skip_if_bug_open('bugzilla', 1339211)
     @skip_if_not_set('fake_manifest')
     @tier2
     def test_positive_delete_subscription(self):


### PR DESCRIPTION
[BZ1339211](https://bugzilla.redhat.com/show_bug.cgi?id=1339211) - 'hammer activation-key subscriptions' shows already removed subscriptions