### PR TITLE
Removed 2 duplicate permissions from constants.py

### DIFF
--- a/robottelo/constants.py
+++ b/robottelo/constants.py
@@ -334,8 +334,6 @@ PERMISSIONS = {
         'destroy_registries',
         'download_bootdisk',
         'edit_recurring_logics',
-        'execute_template_invocation',
-        'filter_autocompletion_for_template_invocation',
         'logs',
         'my_organizations',
         'rh_telemetry_api',


### PR DESCRIPTION
this PR removes 2 more duplicates from the root of the permissions list, fixing the rest 2 failing `api.test_permission` tests on RHEL6