### PR TITLE
Quick fix for UI bookmarks tests

### DIFF
--- a/tests/foreman/ui/test_bookmark.py
+++ b/tests/foreman/ui/test_bookmark.py
@@ -60,7 +60,9 @@ class BookmarkTestCase(UITestCase):
                     entity['setup'](organization=cls.org_).create()
                 # entities with no organizations
                 elif entity['name'] in (
+                        'Compute_Profile',
                         'ConfigGroups',
+                        'HardwareModel',
                         'PuppetClasses',
                         'UserGroup'):
                     entity['setup']().create()


### PR DESCRIPTION
Completely forgot that we need to specify HardwareModel and ComputeProfile as exclusions which don't have organizations assigned. 
Test results with everything but HardwareModel and ComputeProfile commented:
```python
py.test tests/foreman/ui/test_bookmark.py
================================ test session starts =================================
platform linux2 -- Python 2.7.10, pytest-2.9.1, py-1.4.31, pluggy-0.3.1
rootdir: /home/andrii/workspace/robottelo, inifile: 
plugins: xdist-1.13.1, repeat-0.2
collected 14 items 

tests/foreman/ui/test_bookmark.py s..s.....s..s.

======================= 10 passed, 4 skipped in 328.56 seconds =======================
```