### PR TITLE
Decorate custom generator helpers with @datacheck

### DIFF
--- a/tests/foreman/api/test_activationkey.py
+++ b/tests/foreman/api/test_activationkey.py
@@ -3,20 +3,26 @@ from fauxfactory import gen_integer, gen_string
 from nailgun import client, entities
 from requests.exceptions import HTTPError
 from robottelo.config import settings
-from robottelo.datafactory import invalid_names_list, valid_data_list
+from robottelo.datafactory import (
+    datacheck,
+    invalid_names_list,
+    valid_data_list,
+)
 from robottelo.decorators import rm_bug_is_open, skip_if_bug_open, tier1, tier2
 from robottelo.test import APITestCase
 from six.moves import http_client
 
 
+@datacheck
 def _good_max_hosts():
-    """Return a generator yielding valid ``max_hosts`` values."""
-    return (gen_integer(*limits) for limits in ((1, 20), (10000, 20000)))
+    """Return a list of valid ``max_hosts`` values."""
+    return [gen_integer(*limits) for limits in ((1, 20), (10000, 20000))]
 
 
+@datacheck
 def _bad_max_hosts():
-    """Return a generator yielding invalid ``max_hosts`` values."""
-    return (gen_integer(-100, -1), 0, gen_string('alpha'))
+    """Return a list of invalid ``max_hosts`` values."""
+    return [gen_integer(-100, -1), 0, gen_string('alpha')]
 
 
 class ActivationKeyTestCase(APITestCase):

--- a/tests/foreman/api/test_docker.py
+++ b/tests/foreman/api/test_docker.py
@@ -1,6 +1,6 @@
 # -*- encoding: utf-8 -*-
 """Unit tests for the Docker feature."""
-from fauxfactory import gen_choice, gen_string, gen_url
+from fauxfactory import gen_string, gen_url
 from nailgun import entities
 from random import randint, shuffle
 from requests.exceptions import HTTPError
@@ -11,7 +11,11 @@ from robottelo.constants import (
     DOCKER_0_EXTERNAL_REGISTRY,
     DOCKER_1_EXTERNAL_REGISTRY,
 )
-from robottelo.datafactory import valid_data_list
+from robottelo.datafactory import (
+    datacheck,
+    generate_strings_list,
+    valid_data_list,
+)
 from robottelo.decorators import (
     run_only_on,
     skip_if_bug_open,
@@ -24,15 +28,15 @@ from robottelo.helpers import install_katello_ca, remove_katello_ca
 from robottelo.test import APITestCase
 
 DOCKER_PROVIDER = 'Docker'
-STRING_TYPES = ['alpha', 'alphanumeric', 'cjk', 'utf8', 'latin1']
 
 
+@datacheck
 def _invalid_names():
-    """Return a generator yielding various kinds of invalid strings for
-    Docker repositories.
+    """Return a list of various kinds of invalid strings for Docker
+    repositories.
 
     """
-    return (
+    return [
         # boundaries
         gen_string('alphanumeric', 2),
         gen_string('alphanumeric', 31),
@@ -65,15 +69,15 @@ def _invalid_names():
             gen_string('alphanumeric', randint(3, 6)),
             gen_string('alphanumeric', randint(3, 6)),
         ),
-    )
+    ]
 
 
+@datacheck
 def _valid_names():
-    """Return a generator yielding various kinds of valid strings for
-    Docker repositories.
+    """Return a list of various kinds of valid strings for Docker repositories.
 
     """
-    return (
+    return [
         # boundaries
         gen_string('alphanumeric', 3).lower(),
         gen_string('alphanumeric', 30).lower(),
@@ -93,7 +97,7 @@ def _valid_names():
             gen_string('alphanumeric', randint(3, 6)).lower(),
         ),
         u'-_-_/-_.',
-    )
+    ]
 
 
 def _create_repository(product, name=None, upstream_name=None):
@@ -108,7 +112,7 @@ def _create_repository(product, name=None, upstream_name=None):
 
     """
     if name is None:
-        name = gen_string(gen_choice(STRING_TYPES), 15)
+        name = generate_strings_list(15, ['numeric', 'html'])
     if upstream_name is None:
         upstream_name = u'busybox'
     return entities.Repository(

--- a/tests/foreman/api/test_environment.py
+++ b/tests/foreman/api/test_environment.py
@@ -8,20 +8,20 @@ from fauxfactory import gen_string
 from nailgun import entities
 from requests.exceptions import HTTPError
 from robottelo.api.utils import one_to_many_names
-from robottelo.datafactory import invalid_names_list
+from robottelo.datafactory import datacheck, invalid_names_list
 from robottelo.decorators import run_only_on, skip_if_bug_open, tier1, tier2
 from robottelo.test import APITestCase
 
 
+@datacheck
 def valid_data_list():
-    """Return a generator yielding various kinds of valid strings for
-    Environment entity
+    """Return a list of various kinds of valid strings for Environment entity
     """
-    return(
+    return [
         gen_string('alpha'),
         gen_string('numeric'),
         gen_string('alphanumeric'),
-    )
+    ]
 
 
 class EnvironmentTestCase(APITestCase):

--- a/tests/foreman/api/test_location.py
+++ b/tests/foreman/api/test_location.py
@@ -11,10 +11,11 @@ from requests.exceptions import HTTPError
 from robottelo.cleanup import capsule_cleanup, location_cleanup
 from robottelo.cli.factory import make_proxy
 from robottelo.decorators import tier1, tier2
-from robottelo.datafactory import invalid_values_list
+from robottelo.datafactory import datacheck, invalid_values_list
 from robottelo.test import APITestCase
 
 
+@datacheck
 def valid_loc_data_list():
     """List of valid data for input testing.
 

--- a/tests/foreman/api/test_organization.py
+++ b/tests/foreman/api/test_organization.py
@@ -10,13 +10,14 @@ from nailgun import client, entities
 from random import randint
 from requests.exceptions import HTTPError
 from robottelo.config import settings
-from robottelo.datafactory import invalid_values_list
+from robottelo.datafactory import datacheck, invalid_values_list
 from robottelo.decorators import skip_if_bug_open, tier1, tier2
 from robottelo.helpers import get_nailgun_config
 from robottelo.test import APITestCase
 from six.moves import http_client
 
 
+@datacheck
 def valid_org_data_list():
     """List of valid data for input testing.
 

--- a/tests/foreman/api/test_role.py
+++ b/tests/foreman/api/test_role.py
@@ -5,30 +5,11 @@ http://theforeman.org/api/apidoc/v2/roles.html
 
 """
 
-from fauxfactory import (
-    gen_alpha,
-    gen_alphanumeric,
-    gen_cjk,
-    gen_latin1,
-    gen_numeric_string,
-    gen_utf8,
-)
 from nailgun import entities
 from requests.exceptions import HTTPError
+from robottelo.datafactory import generate_strings_list
 from robottelo.decorators import bz_bug_is_open, tier1
 from robottelo.test import APITestCase
-
-
-def data_generator():
-    """Returns a tuple of data for role names"""
-    return (
-        gen_alpha,
-        gen_alphanumeric,
-        gen_cjk,
-        gen_latin1,
-        gen_numeric_string,
-        gen_utf8,
-    )
 
 
 class RoleTestCase(APITestCase):
@@ -43,14 +24,11 @@ class RoleTestCase(APITestCase):
         @Assert: An entity can be created without receiving any errors, the
         entity can be fetched, and the fetched entity has the specified name.
         """
-        for name_generator in data_generator():
-            with self.subTest(name_generator):
-                if bz_bug_is_open(1112657) and (
-                        name_generator is gen_cjk or
-                        name_generator is gen_latin1 or
-                        name_generator is gen_utf8):
+        for name in generate_strings_list(exclude_types=['html']):
+            with self.subTest(name):
+                if bz_bug_is_open(1112657) and name in [
+                        'cjk', 'latin1', 'utf8']:
                     self.skipTest('Bugzilla bug 1112657 is open.')
-                name = name_generator()
                 self.assertEqual(entities.Role(name=name).create().name, name)
 
     @tier1
@@ -61,14 +39,11 @@ class RoleTestCase(APITestCase):
 
         @Assert: The role cannot be fetched after it is deleted.
         """
-        for name_generator in data_generator():
-            with self.subTest(name_generator):
-                if bz_bug_is_open(1112657) and (
-                        name_generator is gen_cjk or
-                        name_generator is gen_latin1 or
-                        name_generator is gen_utf8):
+        for name in generate_strings_list(exclude_types=['html']):
+            with self.subTest(name):
+                if bz_bug_is_open(1112657) and name in [
+                        'cjk', 'latin1', 'utf8']:
                     self.skipTest('Bugzilla bug 1112657 is open.')
-                name = name_generator()
                 role = entities.Role(name=name).create()
                 self.assertEqual(role.name, name)
                 role.delete()
@@ -83,14 +58,11 @@ class RoleTestCase(APITestCase):
 
         @Assert: The role is updated with the given name.
         """
-        for name_generator in data_generator():
-            with self.subTest(name_generator):
-                if bz_bug_is_open(1112657) and (
-                        name_generator is gen_cjk or
-                        name_generator is gen_latin1 or
-                        name_generator is gen_utf8):
+        for name in generate_strings_list(exclude_types=['html']):
+            with self.subTest(name):
+                if bz_bug_is_open(1112657) and name in [
+                        'cjk', 'latin1', 'utf8']:
                     self.skipTest('Bugzilla bug 1112657 is open.')
                 role = entities.Role().create()
-                name = name_generator()
                 role.name = name
                 self.assertEqual(role.update(['name']).name, name)

--- a/tests/foreman/api/test_syncplan.py
+++ b/tests/foreman/api/test_syncplan.py
@@ -13,7 +13,11 @@ from robottelo import manifests
 from robottelo.api.utils import enable_rhrepo_and_fetchid
 from robottelo.config import settings
 from robottelo.constants import PRDS, REPOS, REPOSET
-from robottelo.datafactory import invalid_values_list, valid_data_list
+from robottelo.datafactory import (
+    datacheck,
+    invalid_values_list,
+    valid_data_list,
+)
 from requests.exceptions import HTTPError
 from robottelo.decorators import (
     run_in_one_thread,
@@ -28,9 +32,10 @@ from robottelo.test import APITestCase
 from time import sleep
 
 
+@datacheck
 def valid_sync_dates():
-    """Returns a tuple of valid sync dates."""
-    return(
+    """Returns a list of valid sync dates."""
+    return [
         # Today
         datetime.now(),
         # 5 minutes from now
@@ -41,12 +46,13 @@ def valid_sync_dates():
         datetime.now() - timedelta(days=1),
         # 5 minutes ago
         datetime.now() - timedelta(seconds=300),
-    )
+    ]
 
 
+@datacheck
 def valid_sync_interval():
-    """Returns a tuple of valid sync intervals."""
-    return (u'hourly', u'daily', u'weekly')
+    """Returns a list of valid sync intervals."""
+    return [u'hourly', u'daily', u'weekly']
 
 
 class SyncPlanTestCase(APITestCase):

--- a/tests/foreman/cli/test_docker.py
+++ b/tests/foreman/cli/test_docker.py
@@ -1,6 +1,6 @@
 # pylint: attribute-defined-outside-init
 """Unit tests for the Docker feature."""
-from fauxfactory import gen_alpha, gen_choice, gen_string, gen_url
+from fauxfactory import gen_alpha, gen_string, gen_url
 from random import choice, randint
 from robottelo.cli.base import CLIReturnCodeError
 from robottelo.cli.docker import Docker
@@ -26,7 +26,7 @@ from robottelo.constants import (
     DOCKER_1_EXTERNAL_REGISTRY,
     DOCKER_REGISTRY_HUB,
 )
-from robottelo.datafactory import valid_data_list
+from robottelo.datafactory import generate_strings_list, valid_data_list
 from robottelo.decorators import (
     run_only_on,
     skip_if_bug_open,
@@ -38,8 +38,6 @@ from robottelo.decorators import (
 )
 from robottelo.helpers import install_katello_ca, remove_katello_ca
 from robottelo.test import CLITestCase
-
-STRING_TYPES = ['alpha', 'alphanumeric', 'cjk', 'utf8', 'latin1']
 
 DOCKER_PROVIDER = 'Docker'
 REPO_CONTENT_TYPE = 'docker'
@@ -60,7 +58,7 @@ def _make_docker_repo(product_id, name=None, upstream_name=None):
     return make_repository({
         'content-type': REPO_CONTENT_TYPE,
         'docker-upstream-name': upstream_name or REPO_UPSTREAM_NAME,
-        'name': name or gen_string(gen_choice(STRING_TYPES), 15),
+        'name': name or generate_strings_list(15, ['numeric', 'html']),
         'product-id': product_id,
         'url': DOCKER_REGISTRY_HUB,
     })

--- a/tests/foreman/cli/test_domain.py
+++ b/tests/foreman/cli/test_domain.py
@@ -5,11 +5,12 @@ from robottelo.cli.base import CLIReturnCodeError
 from robottelo.cli.domain import Domain
 from robottelo.cli.factory import CLIFactoryError
 from robottelo.cli.factory import make_domain, make_location, make_org
-from robottelo.datafactory import invalid_id_list, valid_data_list
+from robottelo.datafactory import datacheck, invalid_id_list, valid_data_list
 from robottelo.decorators import run_only_on, tier1
 from robottelo.test import CLITestCase
 
 
+@datacheck
 def valid_create_params():
     """Returns a list of valid domain create parameters"""
     return [
@@ -24,6 +25,7 @@ def valid_create_params():
     ]
 
 
+@datacheck
 def invalid_create_params():
     """Returns a list of invalid domain create parameters"""
     return [
@@ -32,6 +34,7 @@ def invalid_create_params():
     ]
 
 
+@datacheck
 def valid_update_params():
     """Returns a list of valid domain update parameters"""
     return [
@@ -46,6 +49,7 @@ def valid_update_params():
     ]
 
 
+@datacheck
 def invalid_update_params():
     """Returns a list of invalid domain update parameters"""
     return [
@@ -55,6 +59,7 @@ def invalid_update_params():
     ]
 
 
+@datacheck
 def valid_set_params():
     """Returns a list of valid domain set parameters"""
     return [
@@ -69,6 +74,7 @@ def valid_set_params():
     ]
 
 
+@datacheck
 def invalid_set_params():
     """Returns a list of invalid domain set parameters"""
     return [
@@ -81,6 +87,7 @@ def invalid_set_params():
     ]
 
 
+@datacheck
 def valid_delete_params():
     """Returns a list of valid domain delete parameters"""
     return [

--- a/tests/foreman/cli/test_location.py
+++ b/tests/foreman/cli/test_location.py
@@ -19,11 +19,12 @@ from robottelo.cli.factory import (
     make_user,
 )
 from robottelo.cli.location import Location
-from robottelo.datafactory import invalid_values_list
+from robottelo.datafactory import datacheck, invalid_values_list
 from robottelo.decorators import skip_if_bug_open, run_only_on, tier1, tier2
 from robottelo.test import CLITestCase
 
 
+@datacheck
 def valid_loc_data_list():
     """List of valid data for input testing.
 

--- a/tests/foreman/cli/test_organization.py
+++ b/tests/foreman/cli/test_organization.py
@@ -24,6 +24,7 @@ from robottelo.cli.org import Org
 from robottelo.config import settings
 from robottelo.constants import FOREMAN_PROVIDERS
 from robottelo.datafactory import (
+    datacheck,
     invalid_values_list,
     valid_data_list,
     valid_org_names_list,
@@ -36,6 +37,7 @@ from robottelo.decorators import (
 from robottelo.test import CLITestCase
 
 
+@datacheck
 def valid_labels_list():
     """Random simpler data for positive creation
 

--- a/tests/foreman/cli/test_subnet.py
+++ b/tests/foreman/cli/test_subnet.py
@@ -9,42 +9,45 @@ from robottelo.cli.base import CLIReturnCodeError
 from robottelo.cli.factory import make_domain, make_subnet, CLIFactoryError
 from robottelo.cli.subnet import Subnet
 from robottelo.constants import SUBNET_IPAM_TYPES
-from robottelo.datafactory import valid_data_list
+from robottelo.datafactory import datacheck, valid_data_list
 from robottelo.decorators import run_only_on, tier1
 from robottelo.test import CLITestCase
 
 
+@datacheck
 def valid_addr_pools():
-    """Returns a tuple of valid address pools"""
-    return(
+    """Returns a list of valid address pools"""
+    return [
         [gen_integer(min_value=1, max_value=255),
          gen_integer(min_value=1, max_value=255)],
         [gen_integer(min_value=1, max_value=255)] * 2,
         [1, 255],
-    )
+    ]
 
 
+@datacheck
 def invalid_addr_pools():
-    """Returns a tuple of invalid address pools"""
-    return(
+    """Returns a list of invalid address pools"""
+    return [
         {u'from': gen_integer(min_value=1, max_value=255)},
         {u'to': gen_integer(min_value=1, max_value=255)},
         {u'from': gen_integer(min_value=128, max_value=255),
          u'to': gen_integer(min_value=1, max_value=127)},
         {u'from': 256, u'to': 257},
-    )
+    ]
 
 
+@datacheck
 def invalid_missing_attributes():
-    """Returns a tuple of invalid missing attributes"""
-    return(
+    """Returns a list of invalid missing attributes"""
+    return [
         {u'name': ''},
         {u'network': '256.0.0.0'},
         {u'network': ''},
         {u'mask': '256.0.0.0'},
         {u'mask': ''},
         {u'mask': '255.0.255.0'}
-    )
+    ]
 
 
 class SubnetTestCase(CLITestCase):

--- a/tests/foreman/cli/test_syncplan.py
+++ b/tests/foreman/cli/test_syncplan.py
@@ -19,7 +19,11 @@ from robottelo.cli.repository_set import RepositorySet
 from robottelo.cli.subscription import Subscription
 from robottelo.cli.syncplan import SyncPlan
 from robottelo.constants import PRDS, REPOS, REPOSET
-from robottelo.datafactory import valid_data_list, invalid_values_list
+from robottelo.datafactory import (
+    datacheck,
+    valid_data_list,
+    invalid_values_list,
+)
 from robottelo.decorators import (
     run_in_one_thread,
     skip_if_bug_open,
@@ -32,9 +36,10 @@ from robottelo.test import CLITestCase
 from time import sleep
 
 
+@datacheck
 def valid_name_interval_create_tests():
-    """Returns a tuple of valid data for interval create tests."""
-    return(
+    """Returns a list of valid data for interval create tests."""
+    return [
         {u'name': gen_string('alpha', 15), u'interval': u'hourly'},
         {u'name': gen_string('alphanumeric', 15), u'interval': u'hourly'},
         {u'name': gen_string('numeric', 15), u'interval': u'hourly'},
@@ -53,12 +58,13 @@ def valid_name_interval_create_tests():
         {u'name': gen_string('latin1', 15), u'interval': u'weekly'},
         {u'name': gen_string('utf8', 15), u'interval': u'weekly'},
         {u'name': gen_string('html', 15), u'interval': u'weekly'},
-    )
+    ]
 
 
+@datacheck
 def valid_name_interval_update_tests():
-    """Returns a tuple of valid data for interval update tests."""
-    return(
+    """Returns a list of valid data for interval update tests."""
+    return[
         {u'name': gen_string('alpha', 15),
          u'interval': u'daily', u'new-interval': u'hourly'},
         {u'name': gen_string('alphanumeric', 15),
@@ -95,7 +101,7 @@ def valid_name_interval_update_tests():
          u'interval': u'hourly', u'new-interval': u'weekly'},
         {u'name': gen_string('html', 15),
          u'interval': u'hourly', u'new-interval': u'weekly'},
-    )
+    ]
 
 
 class SyncPlanTestCase(CLITestCase):

--- a/tests/foreman/ui/test_architecture.py
+++ b/tests/foreman/ui/test_architecture.py
@@ -2,7 +2,11 @@
 """Test class for Architecture UI"""
 from fauxfactory import gen_string
 from nailgun import entities
-from robottelo.datafactory import generate_strings_list, invalid_values_list
+from robottelo.datafactory import (
+    datacheck,
+    generate_strings_list,
+    invalid_values_list,
+)
 from robottelo.decorators import run_only_on, tier1
 from robottelo.test import UITestCase
 from robottelo.ui.factory import make_arch
@@ -10,15 +14,16 @@ from robottelo.ui.locators import common_locators
 from robottelo.ui.session import Session
 
 
+@datacheck
 def valid_arch_os_names():
-    """Returns a tuple of arch/os names for creation tests"""
-    return(
+    """Returns a list of arch/os names for creation tests"""
+    return [
         {u'name': gen_string('alpha'), u'os_name': gen_string('alpha')},
         {u'name': gen_string('html'), u'os_name': gen_string('html')},
         {u'name': gen_string('utf8'), u'os_name': gen_string('utf8')},
         {u'name': gen_string('alphanumeric'),
          u'os_name': gen_string('alphanumeric')}
-    )
+    ]
 
 
 class ArchitectureTestCase(UITestCase):

--- a/tests/foreman/ui/test_discoveryrule.py
+++ b/tests/foreman/ui/test_discoveryrule.py
@@ -2,7 +2,11 @@
 """Test class for Foreman Discovery Rules"""
 from fauxfactory import gen_integer, gen_ipaddr, gen_string
 from nailgun import entities
-from robottelo.datafactory import invalid_values_list, valid_data_list
+from robottelo.datafactory import (
+    datacheck,
+    invalid_values_list,
+    valid_data_list,
+)
 from robottelo.decorators import run_only_on, skip_if_bug_open, tier1
 from robottelo.test import UITestCase
 from robottelo.ui.factory import make_discoveryrule
@@ -10,6 +14,7 @@ from robottelo.ui.locators import common_locators
 from robottelo.ui.session import Session
 
 
+@datacheck
 def valid_search_queries():
     """Generates a list of all the input strings, (excluding html)"""
     return [

--- a/tests/foreman/ui/test_docker.py
+++ b/tests/foreman/ui/test_docker.py
@@ -12,7 +12,7 @@ from robottelo.constants import (
     FOREMAN_PROVIDERS,
     REPO_TYPE,
 )
-from robottelo.datafactory import valid_data_list
+from robottelo.datafactory import datacheck, valid_data_list
 from robottelo.decorators import (
     run_only_on,
     skip_if_bug_open,
@@ -35,27 +35,31 @@ from robottelo.ui.locators import common_locators, locators
 from robottelo.ui.products import Products
 from robottelo.ui.session import Session
 
-VALID_DOCKER_UPSTREAM_NAMES = (
-    # boundaries
-    gen_string('alphanumeric', 3).lower(),
-    gen_string('alphanumeric', 30).lower(),
-    u'{0}/{1}'.format(
-        gen_string('alphanumeric', 4).lower(),
+
+@datacheck
+def valid_docker_upstream_names():
+    """Generates a list of valid docker upstream names"""
+    return [
+        # boundaries
         gen_string('alphanumeric', 3).lower(),
-    ),
-    u'{0}/{1}'.format(
         gen_string('alphanumeric', 30).lower(),
-        gen_string('alphanumeric', 30).lower(),
-    ),
-    # allowed non alphanumeric character
-    u'{0}-{1}_{2}/{2}-{1}_{0}.{3}'.format(
-        gen_string('alphanumeric', randint(3, 6)).lower(),
-        gen_string('alphanumeric', randint(3, 6)).lower(),
-        gen_string('alphanumeric', randint(3, 6)).lower(),
-        gen_string('alphanumeric', randint(3, 6)).lower(),
-    ),
-    u'-_-_/-_.',
-)
+        u'{0}/{1}'.format(
+            gen_string('alphanumeric', 4).lower(),
+            gen_string('alphanumeric', 3).lower(),
+        ),
+        u'{0}/{1}'.format(
+            gen_string('alphanumeric', 30).lower(),
+            gen_string('alphanumeric', 30).lower(),
+        ),
+        # allowed non alphanumeric character
+        u'{0}-{1}_{2}/{2}-{1}_{0}.{3}'.format(
+            gen_string('alphanumeric', randint(3, 6)).lower(),
+            gen_string('alphanumeric', randint(3, 6)).lower(),
+            gen_string('alphanumeric', randint(3, 6)).lower(),
+            gen_string('alphanumeric', randint(3, 6)).lower(),
+        ),
+        u'-_-_/-_.',
+    ]
 
 
 def _create_repository(session, org, name, product, upstream_name=None):
@@ -256,7 +260,7 @@ class DockerRepositoryTestCase(UITestCase):
             self.assertIsNotNone(self.repository.search(repo_name))
             self.assertTrue(self.repository.validate_field(
                 repo_name, 'upstream', 'busybox'))
-            for new_upstream_name in VALID_DOCKER_UPSTREAM_NAMES:
+            for new_upstream_name in valid_docker_upstream_names():
                 with self.subTest(new_upstream_name):
                     self.products.search(product.name).click()
                     self.repository.update(

--- a/tests/foreman/ui/test_domain.py
+++ b/tests/foreman/ui/test_domain.py
@@ -2,7 +2,11 @@
 """Test class for Domain UI"""
 from fauxfactory import gen_string
 from robottelo.constants import DOMAIN
-from robottelo.datafactory import generate_strings_list, invalid_values_list
+from robottelo.datafactory import (
+    datacheck,
+    generate_strings_list,
+    invalid_values_list,
+)
 from robottelo.decorators import (
     bz_bug_is_open,
     run_only_on,
@@ -17,6 +21,7 @@ from robottelo.ui.locators import common_locators
 from robottelo.ui.session import Session
 
 
+@datacheck
 def valid_long_domain_names():
     """Returns a list of valid long domain names
 
@@ -32,6 +37,7 @@ def valid_long_domain_names():
     ]
 
 
+@datacheck
 def valid_domain_update_data():
     """Returns a list of valid test data for domain update tests"""
     return [

--- a/tests/foreman/ui/test_hw_model.py
+++ b/tests/foreman/ui/test_hw_model.py
@@ -1,7 +1,11 @@
 """Test class for Config Groups UI"""
 
 from fauxfactory import gen_string
-from robottelo.datafactory import invalid_values_list, valid_data_list
+from robottelo.datafactory import (
+    datacheck,
+    invalid_values_list,
+    valid_data_list,
+)
 from robottelo.decorators import bz_bug_is_open, run_only_on, tier1
 from robottelo.test import UITestCase
 from robottelo.ui.factory import make_hw_model
@@ -9,6 +13,7 @@ from robottelo.ui.locators import common_locators
 from robottelo.ui.session import Session
 
 
+@datacheck
 def valid_hw_model_names():
     """Returns a list of valid hw model names"""
     return [

--- a/tests/foreman/ui/test_location.py
+++ b/tests/foreman/ui/test_location.py
@@ -4,7 +4,11 @@
 from fauxfactory import gen_ipaddr, gen_string
 from nailgun import entities
 from robottelo.config import settings
-from robottelo.datafactory import generate_strings_list, invalid_values_list
+from robottelo.datafactory import (
+    datacheck,
+    generate_strings_list,
+    invalid_values_list,
+)
 from robottelo.decorators import run_only_on, tier1, tier2
 from robottelo.constants import (
     ANY_CONTEXT,
@@ -19,6 +23,7 @@ from robottelo.ui.locators import common_locators, locators, tab_locators
 from robottelo.ui.session import Session
 
 
+@datacheck
 def valid_org_loc_data():
     """Returns a list of valid org/location data"""
     return [
@@ -37,6 +42,7 @@ def valid_org_loc_data():
     ]
 
 
+@datacheck
 def valid_env_names():
     """Returns a list of valid environment names"""
     return [

--- a/tests/foreman/ui/test_login.py
+++ b/tests/foreman/ui/test_login.py
@@ -2,10 +2,12 @@
 """Test class for Login UI"""
 
 from fauxfactory import gen_string
+from robottelo.datafactory import datacheck
 from robottelo.decorators import tier1
 from robottelo.test import UITestCase
 
 
+@datacheck
 def invalid_credentials():
     """Returns a list of invalid credentials"""
     return [

--- a/tests/foreman/ui/test_operatingsystem.py
+++ b/tests/foreman/ui/test_operatingsystem.py
@@ -5,7 +5,11 @@ from fauxfactory import gen_string
 from nailgun import entities
 from robottelo.constants import (
     INSTALL_MEDIUM_URL, PARTITION_SCRIPT_DATA_FILE)
-from robottelo.datafactory import invalid_values_list, valid_data_list
+from robottelo.datafactory import (
+    datacheck,
+    invalid_values_list,
+    valid_data_list,
+)
 from robottelo.decorators import run_only_on, skip_if_bug_open, tier1, tier2
 from robottelo.helpers import get_data_file
 from robottelo.test import UITestCase
@@ -15,6 +19,7 @@ from robottelo.ui.locators import common_locators
 from robottelo.ui.session import Session
 
 
+@datacheck
 def valid_os_parameters():
     """Returns a list of valid os parameters"""
     return [

--- a/tests/foreman/ui/test_organization.py
+++ b/tests/foreman/ui/test_organization.py
@@ -8,6 +8,7 @@ from robottelo.api.utils import upload_manifest
 from robottelo.config import settings
 from robottelo.constants import INSTALL_MEDIUM_URL, LIBVIRT_RESOURCE_URL
 from robottelo.datafactory import (
+    datacheck,
     generate_strings_list,
     invalid_names_list,
     invalid_values_list,
@@ -27,6 +28,7 @@ from robottelo.ui.locators import common_locators, locators, tab_locators
 from robottelo.ui.session import Session
 
 
+@datacheck
 def valid_labels():
     """Returns a list of valid labels"""
     return [
@@ -36,6 +38,7 @@ def valid_labels():
     ]
 
 
+@datacheck
 def valid_users():
     """Returns a list of valid users"""
     return[
@@ -48,6 +51,7 @@ def valid_users():
     ]
 
 
+@datacheck
 def valid_env_names():
     """Returns a list of valid environment names"""
     return [

--- a/tests/foreman/ui/test_partitiontable.py
+++ b/tests/foreman/ui/test_partitiontable.py
@@ -2,7 +2,11 @@
 """Test class for Partition Table UI"""
 from fauxfactory import gen_string
 from robottelo.constants import PARTITION_SCRIPT_DATA_FILE
-from robottelo.datafactory import generate_strings_list, invalid_values_list
+from robottelo.datafactory import (
+    datacheck,
+    generate_strings_list,
+    invalid_values_list,
+)
 from robottelo.decorators import (
     bz_bug_is_open,
     run_only_on,
@@ -18,6 +22,7 @@ from robottelo.ui.session import Session
 PARTITION_SCRIPT_DATA_FILE = get_data_file(PARTITION_SCRIPT_DATA_FILE)
 
 
+@datacheck
 def valid_partition_table_names():
     """Returns a list of valid partition table names"""
     return [
@@ -30,6 +35,7 @@ def valid_partition_table_names():
     ]
 
 
+@datacheck
 def valid_partition_table_update_names():
     """Returns a list of valid partition table names for update tests"""
     return [

--- a/tests/foreman/ui/test_repository.py
+++ b/tests/foreman/ui/test_repository.py
@@ -16,7 +16,11 @@ from robottelo.constants import (
     VALID_GPG_KEY_BETA_FILE,
     VALID_GPG_KEY_FILE,
 )
-from robottelo.datafactory import generate_strings_list, invalid_values_list
+from robottelo.datafactory import (
+    datacheck,
+    generate_strings_list,
+    invalid_values_list,
+)
 from robottelo.decorators import run_only_on, stubbed, tier1, tier2
 from robottelo.helpers import read_data_file
 from robottelo.test import UITestCase
@@ -25,6 +29,7 @@ from robottelo.ui.locators import common_locators, locators, tab_locators
 from robottelo.ui.session import Session
 
 
+@datacheck
 def valid_repo_names_docker_sync():
     """Returns a list of valid repo names for docker sync test"""
     return [

--- a/tests/foreman/ui/test_setting.py
+++ b/tests/foreman/ui/test_setting.py
@@ -4,6 +4,7 @@
 from fauxfactory import gen_email, gen_string, gen_url
 from functools import wraps
 from random import choice, randint
+from robottelo.datafactory import datacheck
 from robottelo.decorators import (
     bz_bug_is_open,
     run_only_on,
@@ -31,6 +32,7 @@ def pick_one_if_bz_open(func):
     return func_wrapper
 
 
+@datacheck
 def valid_boolean_values():
     """Returns a list of valid boolean values"""
     return [
@@ -39,6 +41,7 @@ def valid_boolean_values():
     ]
 
 
+@datacheck
 def valid_settings_values():
     """Returns a list of valid settings values"""
     return [
@@ -52,6 +55,7 @@ def valid_settings_values():
     ]
 
 
+@datacheck
 @pick_one_if_bz_open
 def invalid_foreman_urls():
     """Returns a list of invalid foreman urls"""
@@ -64,12 +68,14 @@ def invalid_foreman_urls():
     ]
 
 
+@datacheck
 @pick_one_if_bz_open
 def invalid_settings_values():
     """Returns a list of invalid settings values"""
     return [' ', '-1', 'text', '0']
 
 
+@datacheck
 def valid_maxtrend_timeout_values():
     """Returns a list of valid maxtrend, timeout values"""
     return [
@@ -78,6 +84,7 @@ def valid_maxtrend_timeout_values():
     ]
 
 
+@datacheck
 def valid_urls():
     """Returns a list of valid urls"""
     return [
@@ -96,6 +103,7 @@ def valid_urls():
     ]
 
 
+@datacheck
 def valid_login_delegation_values():
     """Returns a list of valid delegation values"""
     return [
@@ -107,6 +115,7 @@ def valid_login_delegation_values():
     ]
 
 
+@datacheck
 @pick_one_if_bz_open
 def invalid_oauth_active_values():
     """Returns a list of invalid oauth_active values"""
@@ -118,6 +127,7 @@ def invalid_oauth_active_values():
     ]
 
 
+@datacheck
 def valid_trusted_puppetmaster_hosts():
     """Returns a list of valid trusted puppetmaster hosts"""
     return [
@@ -127,11 +137,13 @@ def valid_trusted_puppetmaster_hosts():
     ]
 
 
+@datacheck
 def valid_token_duration():
     """Returns a list of valid token durations"""
     return ['90', '0']
 
 
+@datacheck
 @pick_one_if_bz_open
 def invalid_token_duration():
     """Returns a list of invalid token durations"""

--- a/tests/foreman/ui/test_subnet.py
+++ b/tests/foreman/ui/test_subnet.py
@@ -3,7 +3,11 @@
 
 from fauxfactory import gen_ipaddr, gen_netmask, gen_string
 from nailgun import entities
-from robottelo.datafactory import generate_strings_list, invalid_values_list
+from robottelo.datafactory import (
+    datacheck,
+    generate_strings_list,
+    invalid_values_list,
+)
 from robottelo.decorators import bz_bug_is_open, run_only_on, tier1, tier2
 from robottelo.test import UITestCase
 from robottelo.ui.base import UIError
@@ -12,6 +16,7 @@ from robottelo.ui.locators import common_locators, locators, tab_locators
 from robottelo.ui.session import Session
 
 
+@datacheck
 def valid_long_names():
     """Returns a list of valid long subnet names"""
     return [

--- a/tests/foreman/ui/test_syncplan.py
+++ b/tests/foreman/ui/test_syncplan.py
@@ -7,7 +7,11 @@ from random import randint
 from robottelo import manifests
 from robottelo.api.utils import enable_rhrepo_and_fetchid
 from robottelo.constants import PRDS, REPOS, REPOSET, SYNC_INTERVAL
-from robottelo.datafactory import generate_strings_list, invalid_values_list
+from robottelo.datafactory import (
+    datacheck,
+    generate_strings_list,
+    invalid_values_list,
+)
 from robottelo.decorators import (
     run_in_one_thread,
     run_only_on,
@@ -24,6 +28,7 @@ from robottelo.ui.session import Session
 from time import sleep
 
 
+@datacheck
 def valid_sync_intervals():
     """Returns a list of valid sync intervals"""
     return [

--- a/tests/foreman/ui/test_user.py
+++ b/tests/foreman/ui/test_user.py
@@ -6,6 +6,7 @@ from fauxfactory import gen_string
 from nailgun import entities
 from robottelo.constants import DEFAULT_ORG, LANGUAGES, ROLES
 from robottelo.datafactory import (
+    datacheck,
     invalid_emails_list,
     invalid_names_list,
     invalid_values_list,
@@ -18,6 +19,7 @@ from robottelo.ui.locators import common_locators, locators, tab_locators
 from robottelo.ui.session import Session
 
 
+@datacheck
 def valid_strings(len1=10):
     """Generates a list of all the input strings, (excluding html)"""
     return [


### PR DESCRIPTION
To speed up tests execution on jenkins, we use `run_one_datapoint=true` setting in `robottelo.properties` file, which decorates datafactory helpers to return only 1 random name instead of a list with all possible combinations. This leads to 1 subtest per each test instead of 5-7 of them, i.e we are not testing the same things with all possible combination of names but reducing execution time in 5-7 times.
The thing is only generic datafactory helpers were decorated, but a lot of modules have their custom ones which we forgot to update. Fixing that flaw as it should lead to noticeable performance improvements.
Example of test executed before this change:
```python
py.test tests/foreman/cli/test_syncplan.py -k 'test_positive_create_with_interval'
================================ test session starts =================================
platform linux2 -- Python 2.7.10, pytest-2.9.1, py-1.4.31, pluggy-0.3.1
rootdir: /home/andrii/workspace/robottelo, inifile: 
plugins: xdist-1.13.1, repeat-0.2
collected 15 items 

tests/foreman/cli/test_syncplan.py .

=========== 14 tests deselected by '-ktest_positive_create_with_interval' ============
====================== 1 passed, 14 deselected in 99.80 seconds ======================
```
And after:
```python
py.test tests/foreman/cli/test_syncplan.py -k 'test_positive_create_with_interval'
================================ test session starts =================================
platform linux2 -- Python 2.7.10, pytest-2.9.1, py-1.4.31, pluggy-0.3.1
rootdir: /home/andrii/workspace/robottelo, inifile: 
plugins: xdist-1.13.1, repeat-0.2
collected 15 items 

tests/foreman/cli/test_syncplan.py .

=========== 14 tests deselected by '-ktest_positive_create_with_interval' ============
====================== 1 passed, 14 deselected in 12.90 seconds ======================
```
In relative values it leads up to 7-8x performance boost for some tests (3-4x times faster in average, i guess).
P.S.: please note that only _some_ of the tests were affected, we won't receive 3-4 times faster jenkins runs :) but even 10% performance boost will actually mean reducing runs duration for another hour which is cool.