### PR TITLE
Increase timeout for UI & CLI manifest upload

### DIFF
--- a/robottelo/cli/subscription.py
+++ b/robottelo/cli/subscription.py
@@ -21,6 +21,7 @@ Subcommands::
 """
 
 from robottelo.cli.base import Base
+from robottelo.decorators import bz_bug_is_open
 
 
 class Subscription(Base):
@@ -34,9 +35,11 @@ class Subscription(Base):
     def upload(cls, options=None):
         """Upload a subscription manifest."""
         cls.command_sub = 'upload'
+        timeout = 900 if bz_bug_is_open(1339696) else 300
         return cls.execute(
             cls._construct_command(options),
             ignore_stderr=True,
+            timeout=timeout,
         )
 
     @classmethod

--- a/robottelo/ui/subscription.py
+++ b/robottelo/ui/subscription.py
@@ -1,6 +1,7 @@
 """Implements Subscriptions/Manifest handling for the UI"""
 import os
 
+from robottelo.decorators import bz_bug_is_open
 from robottelo.ui.base import Base
 from robottelo.ui.locators import common_locators, locators
 from robottelo.ui.navigator import Navigator
@@ -37,7 +38,8 @@ class Subscriptions(Base):
             handler.write(manifest.content.read())
         browse_element.send_keys(manifest.filename)
         self.click(locators['subs.upload'])
-        self.wait_until_element(locators['subs.manifest_exists'], 300)
+        timeout = 900 if bz_bug_is_open(1339696) else 300
+        self.wait_until_element(locators['subs.manifest_exists'], timeout)
         os.remove(manifest.filename)
 
     def delete(self):


### PR DESCRIPTION
Similar to SatelliteQE/nailgun#294, but for CLI & UI:
> As per [this discussion](https://github.com/SatelliteQE/robottelo/pull/3483#issuecomment-221566076) and [BZ1339696](https://bugzilla.redhat.com/show_bug.cgi?id=1339696), manifest upload duration increases depending on number of organizations and activation keys present in system. And in the end of automation run, according to @rplevka's investigation, it takes up to 11 minutes to upload a manifest.
Updating timeout for manifest upload operation to 15 mins so we can successfully receive the results.
