### PR TITLE
Add support for long names for org and location switcher

### DIFF
--- a/robottelo/ui/locators.py
+++ b/robottelo/ui/locators.py
@@ -363,7 +363,8 @@ menu_locators = LocatorDict({
     "org.select_org": (
         By.XPATH,
         ("//div[contains(@style,'static') or contains(@style,'fixed')]"
-         "//a[@href='/organizations/clear']/../../li/a[contains(.,'%s')]")),
+         "//a[@href='/organizations/clear']/../../li/a"
+         "/span[contains(.,'%s') or contains(@data-original-title, '%s')]")),
 
     # Locations
     "loc.manage_loc": (
@@ -378,7 +379,8 @@ menu_locators = LocatorDict({
     "loc.select_loc": (
         By.XPATH,
         ("//div[contains(@style,'static') or contains(@style,'fixed')]"
-         "//a[@href='/locations/clear']/../../li/a[contains(.,'%s')]"))
+         "//a[@href='/locations/clear']/../../li/a"
+         "/span[contains(.,'%s') or contains(@data-original-title, '%s')]"))
 })
 
 tab_locators = LocatorDict({
@@ -668,7 +670,7 @@ common_locators = LocatorDict({
         ("//div[@class='ms-selection']/ul[@class='ms-list']"
          "/li[@class='ms-elem-selection ms-selected']")),
     "select_filtered_entity": (
-        By.XPATH, "//a/span[contains(@data-original-title, '%s')]"),
+        By.XPATH, "//table//a/span[contains(@data-original-title, '%s')]"),
     "checked_entity": (
         By.XPATH, "//input[@checked='checked']/parent::label"),
     "entity_select": (

--- a/robottelo/ui/navigator.py
+++ b/robottelo/ui/navigator.py
@@ -403,11 +403,14 @@ class Navigator(Base):
         self.menu_click(
             menu_locators['menu.any_context'],
             menu_locators['org.nav_current_org'],
-            (strategy, value % org),
+            (strategy, value % (org, org)),
         )
         self.perform_action_chain_move(menu_locators['menu.current_text'])
+        org_dropdown = org
+        if len(org) > 30:
+            org_dropdown = org[:27] + '...'
         if self.wait_until_element(
-                menu_locators['menu.fetch_org']).text != org:
+                menu_locators['menu.fetch_org']).text != org_dropdown:
             raise UIError(
                 u'Could not select the organization: {0}'.format(org)
             )
@@ -430,11 +433,14 @@ class Navigator(Base):
         self.menu_click(
             menu_locators['menu.any_context'],
             menu_locators['loc.nav_current_loc'],
-            (strategy, value % loc),
+            (strategy, value % (loc, loc)),
         )
         self.perform_action_chain_move(menu_locators['menu.current_text'])
+        loc_dropdown = loc
+        if len(loc) > 30:
+            loc_dropdown = loc[:27] + '...'
         if self.wait_until_element(
-                menu_locators['menu.fetch_loc']).text != loc:
+                menu_locators['menu.fetch_loc']).text != loc_dropdown:
             raise UIError(
                 u'Could not select the location: {0}'.format(loc)
             )

--- a/tests/foreman/ui/test_location.py
+++ b/tests/foreman/ui/test_location.py
@@ -27,18 +27,18 @@ from robottelo.ui.session import Session
 def valid_org_loc_data():
     """Returns a list of valid org/location data"""
     return [
-        {'org_name': gen_string('alpha', 10),
-         'loc_name': gen_string('alpha', 10)},
-        {'org_name': gen_string('numeric', 10),
-         'loc_name': gen_string('numeric', 10)},
-        {'org_name': gen_string('alphanumeric', 10),
-         'loc_name': gen_string('alphanumeric', 10)},
-        {'org_name': gen_string('utf8', 10),
-         'loc_name': gen_string('utf8', 10)},
-        {'org_name': gen_string('latin1', 20),
-         'loc_name': gen_string('latin1', 10)},
-        {'org_name': gen_string('html', 20),
-         'loc_name': gen_string('html', 10)}
+        {'org_name': gen_string('alpha', 242),
+         'loc_name': gen_string('alpha', 242)},
+        {'org_name': gen_string('numeric', 242),
+         'loc_name': gen_string('numeric', 242)},
+        {'org_name': gen_string('alphanumeric', 242),
+         'loc_name': gen_string('alphanumeric', 242)},
+        {'org_name': gen_string('utf8', 80),
+         'loc_name': gen_string('utf8', 80)},
+        {'org_name': gen_string('latin1', 242),
+         'loc_name': gen_string('latin1', 242)},
+        {'org_name': gen_string('html', 217),
+         'loc_name': gen_string('html', 217)}
     ]
 
 


### PR DESCRIPTION
When we have long html tag that used as a name of location or organization, it will be transformed in another format that can be seen when we try to select it from switcher dropdown (e.g. `<area>aPHorxWqmfHYtGiZXdXUly</area>` -> `<area>aPHorxWqmfHYtGiZXdXUly<...`)
I was thinking about alternative solution for a long time, but all of them require some refactoring of fundamental parts of the code that I don't like to do only for sake of one test case, and not even test case but part of one data point. Anyway, all data types will be verified, so we cannot even say that we will have any decrease of coverage at all. If anyone has another laconic solution, I will be more than happy to hear it
```
nosetests tests/foreman/ui/test_location.py -m test_positive_create_with_location_and_org
.
----------------------------------------------------------------------
Ran 1 test in 290.800s

OK
```