### PR TITLE
Update paths for API end to end tests

### DIFF
--- a/tests/foreman/endtoend/test_api_endtoend.py
+++ b/tests/foreman/endtoend/test_api_endtoend.py
@@ -445,6 +445,8 @@ API_PATHS = {
         u'/api/job_templates/:id',
         u'/api/job_templates/:id',
         u'/api/job_templates/:id/clone',
+        u'/api/job_templates/:id/export',
+        u'/api/job_templates/import',
     ),
     u'lifecycle_environments': (
         u'/katello/api/environments',


### PR DESCRIPTION
Depends on https://github.com/SatelliteQE/nailgun/pull/296 in order to pass 100% of the API end to end tests.