### PR TITLE
Fix UI sync plan tests

### DIFF
--- a/tests/foreman/ui/test_syncplan.py
+++ b/tests/foreman/ui/test_syncplan.py
@@ -3,7 +3,7 @@
 from datetime import datetime, timedelta
 from fauxfactory import gen_string
 from nailgun import entities
-from random import randint
+from random import choice, randint
 from robottelo import manifests
 from robottelo.api.utils import enable_rhrepo_and_fetchid
 from robottelo.constants import PRDS, REPOS, REPOSET, SYNC_INTERVAL
@@ -96,7 +96,7 @@ class SyncPlanTestCase(UITestCase):
                         org=self.organization.name,
                         name=name,
                         description=gen_string('utf8'),
-                        sync_interval=valid_sync_intervals()[randint(0, 2)],
+                        sync_interval=choice(valid_sync_intervals()),
                     )
                     self.assertIsNotNone(self.syncplan.search(name))
 
@@ -117,7 +117,7 @@ class SyncPlanTestCase(UITestCase):
                         org=self.organization.name,
                         name=name,
                         description=desc,
-                        sync_interval=valid_sync_intervals()[randint(0, 2)],
+                        sync_interval=choice(valid_sync_intervals()),
                     )
                     self.assertIsNotNone(self.syncplan.search(name))
 


### PR DESCRIPTION
With `run_one_datapoint=true` `valid_sync_intervals()` returns only one element, updating tests to pick random sync interval regardless of of returned list length.
```python
py.test tests/foreman/ui/test_syncplan.py -k 'test_positive_create_with_name or test_positive_create_with_description'
================================ test session starts =================================
platform linux2 -- Python 2.7.10, pytest-2.9.1, py-1.4.31, pluggy-0.3.1
rootdir: /home/andrii/workspace/robottelo, inifile: 
plugins: xdist-1.13.1, repeat-0.2
collected 19 items 

tests/foreman/ui/test_syncplan.py ..

 17 tests deselected by '-ktest_positive_create_with_name or test_positive_create_with_description' 
===================== 2 passed, 17 deselected in 583.98 seconds ======================
```