### PR TITLE
Removed duplicated key in ui.locators dict lines 1936x2026

### DIFF
--- a/robottelo/ui/locators.py
+++ b/robottelo/ui/locators.py
@@ -1933,8 +1933,6 @@ locators = LocatorDict({
     "contentviews.remove_ver": (
         By.XPATH, ("//td/a[contains(., '%s')]/following::td/"
                    "button[contains(@ui-sref, 'version-deletion')]")),
-    "contentviews.remove_cv": (
-        By.XPATH, "//button[@ng-click='removeContentViews()']"),
     "contentviews.remove_cv_version": (
         By.XPATH, "//a[contains(@ui-sref, 'version-deletion')]/button"),
     "contentviews.completely_remove_checkbox": (


### PR DESCRIPTION
This is a pycodestyle small fix, this key is duplicated on lines:

https://github.com/SatelliteQE/robottelo/blob/master/robottelo/ui/locators.py#L1936

and

https://github.com/SatelliteQE/robottelo/blob/master/robottelo/ui/locators.py#L2026