### PR TITLE
Fixes regression for location and org switcher. Fixes two more cases for location entity

### DIFF
--- a/robottelo/ui/locators.py
+++ b/robottelo/ui/locators.py
@@ -363,8 +363,10 @@ menu_locators = LocatorDict({
     "org.select_org": (
         By.XPATH,
         ("//div[contains(@style,'static') or contains(@style,'fixed')]"
+         "//a[@href='/organizations/clear']/../../li/a[contains(.,'%s')]|"
+         "//div[contains(@style,'static') or contains(@style,'fixed')]"
          "//a[@href='/organizations/clear']/../../li/a"
-         "/span[contains(.,'%s') or contains(@data-original-title, '%s')]")),
+         "/span[contains(@data-original-title, '%s')]")),
 
     # Locations
     "loc.manage_loc": (
@@ -379,8 +381,10 @@ menu_locators = LocatorDict({
     "loc.select_loc": (
         By.XPATH,
         ("//div[contains(@style,'static') or contains(@style,'fixed')]"
+         "//a[@href='/locations/clear']/../../li/a[contains(.,'%s')]|"
+         "//div[contains(@style,'static') or contains(@style,'fixed')]"
          "//a[@href='/locations/clear']/../../li/a"
-         "/span[contains(.,'%s') or contains(@data-original-title, '%s')]"))
+         "/span[contains(@data-original-title, '%s')]"))
 })
 
 tab_locators = LocatorDict({

--- a/tests/foreman/ui/test_location.py
+++ b/tests/foreman/ui/test_location.py
@@ -500,7 +500,7 @@ class LocationTestCase(UITestCase):
                         name=template,
                         template_path=get_data_file(OS_TEMPLATE_DATA_FILE),
                         custom_really=True,
-                        template_type='provision',
+                        template_type='Provisioning template',
                     )
                     self.assertIsNotNone(self.template.search(template))
                     self.location.search(loc_name).click()
@@ -796,7 +796,7 @@ class LocationTestCase(UITestCase):
                         session,
                         name=template_name,
                         template_path=get_data_file(OS_TEMPLATE_DATA_FILE),
-                        template_type='provision',
+                        template_type='Provisioning template',
                         custom_really=True,
                     )
                     self.assertIsNotNone(self.template.search(template_name))


### PR DESCRIPTION
```
nosetests tests/foreman/ui/test_location.py -m test_positive_create_with_location_and_org
.
----------------------------------------------------------------------
Ran 1 test in 240.360s

OK
```

```
nosetests tests/foreman/ui/test_location.py -m test_positive_remove_template
.
----------------------------------------------------------------------
Ran 1 test in 412.798s

OK
nosetests tests/foreman/ui/test_location.py -m test_positive_add_template
.
----------------------------------------------------------------------
Ran 1 test in 291.434s

OK
```

```
nosetests tests/foreman/ui/test_location.py -m test_positive_create_with_location_and_org
.
----------------------------------------------------------------------
Ran 1 test in 192.237s

OK

nosetests tests/foreman/ui/test_contentview.py -m test_positive_update_name
.
----------------------------------------------------------------------
Ran 1 test in 143.812s

OK
nosetests tests/foreman/ui/test_location.py -m test_positive_remove_template
.
----------------------------------------------------------------------
Ran 1 test in 403.419s

OK
```