### PR TITLE
Changing compute resource type according to correct app behaviour

### DIFF
--- a/tests/foreman/ui/test_computeresource.py
+++ b/tests/foreman/ui/test_computeresource.py
@@ -5,7 +5,7 @@ from nailgun import entities
 from robottelo.config import settings
 from robottelo.constants import FOREMAN_PROVIDERS, LIBVIRT_RESOURCE_URL
 from robottelo.datafactory import invalid_names_list, valid_data_list
-from robottelo.decorators import skip_if_bug_open, run_only_on, tier1
+from robottelo.decorators import run_only_on, tier1
 from robottelo.test import UITestCase
 from robottelo.ui.factory import make_resource
 from robottelo.ui.locators import common_locators
@@ -228,11 +228,10 @@ class ComputeResourceTestCase(UITestCase):
                     self.assertIsNotNone(self.compute_resource.search(name))
                     self.compute_resource.delete(name)
 
-    @skip_if_bug_open('bugzilla', 1336727)
     @run_only_on('sat')
     @tier1
-    def test_positive_access_docker_via_profile(self):
-        """Try to access docker compute resource via compute profile
+    def test_positive_access_libvirt_via_profile(self):
+        """Try to access libvirt compute resource via compute profile
         (1-Small) screen
 
         @Feature: Compute Resource
@@ -244,11 +243,10 @@ class ComputeResourceTestCase(UITestCase):
             make_resource(
                 session,
                 name=name,
-                provider_type=FOREMAN_PROVIDERS['docker'],
+                provider_type=FOREMAN_PROVIDERS['libvirt'],
                 parameter_list=[[
-                    'URL', settings.docker.external_url, 'field'
+                    'URL', self.current_libvirt_url, 'field'
                 ]],
             )
-            self.assertIsNotNone(
-                self.compute_profile.select_resource('1-Small', name, 'Docker')
-            )
+            self.assertIsNotNone(self.compute_profile.select_resource(
+                '1-Small', name, 'Libvirt'))

--- a/tests/foreman/ui/test_docker.py
+++ b/tests/foreman/ui/test_docker.py
@@ -972,7 +972,6 @@ class DockerComputeResourceTestCase(UITestCase):
         super(DockerComputeResourceTestCase, cls).setUpClass()
         cls.organization = entities.Organization().create()
 
-    @skip_if_bug_open('bugzilla', 1336727)
     @run_only_on('sat')
     @tier1
     def test_positive_create_internal(self):
@@ -999,7 +998,6 @@ class DockerComputeResourceTestCase(UITestCase):
                     self.assertIsNotNone(
                         self.compute_resource.search(comp_name))
 
-    @skip_if_bug_open('bugzilla', 1336727)
     @run_only_on('sat')
     @tier1
     def test_positive_update_internal(self):
@@ -1045,7 +1043,6 @@ class DockerComputeResourceTestCase(UITestCase):
 
         """
 
-    @skip_if_bug_open('bugzilla', 1336727)
     @run_only_on('sat')
     @tier1
     def test_positive_create_external(self):
@@ -1072,7 +1069,6 @@ class DockerComputeResourceTestCase(UITestCase):
                     self.assertIsNotNone(
                         self.compute_resource.search(comp_name))
 
-    @skip_if_bug_open('bugzilla', 1336727)
     @run_only_on('sat')
     @tier1
     def test_positive_update_external(self):
@@ -1119,7 +1115,6 @@ class DockerComputeResourceTestCase(UITestCase):
         @Status: Manual
         """
 
-    @skip_if_bug_open('bugzilla', 1336727)
     @run_only_on('sat')
     @tier1
     def test_positive_delete(self):


### PR DESCRIPTION
Refer to https://bugzilla.redhat.com/show_bug.cgi?id=1319791 for more details
Also https://bugzilla.redhat.com/show_bug.cgi?id=1336727 was fixed and unblocked the functionality.

```
nosetests tests/foreman/ui/test_computeresource.py -m test_positive_access_libvirt_via_profile
.
----------------------------------------------------------------------
Ran 1 test in 30.747s

OK

nosetests tests/foreman/ui/test_docker.py:DockerComputeResourceTestCase
...SS..
----------------------------------------------------------------------
Ran 7 tests in 263.862s

OK (SKIP=2)
```