### PR TITLE
Fix UI location tests

### DIFF
--- a/robottelo/ui/location.py
+++ b/robottelo/ui/location.py
@@ -93,20 +93,16 @@ class Location(Base):
         if parent:
             self.select(locators['location.parent'], parent)
         self.click(common_locators['submit'])
-        edit_locator = self.wait_until_element(
-            locators['location.proceed_to_edit'])
-        if edit_locator:
-            edit_locator.click()
-            self._configure_location(
-                users=users, proxies=proxies,
-                subnets=subnets, resources=resources,
-                medias=medias, templates=templates,
-                domains=domains, envs=envs,
-                hostgroups=hostgroups,
-                organizations=organizations,
-                select=select,
-            )
-            self.click(common_locators['submit'])
+        self._configure_location(
+            users=users, proxies=proxies,
+            subnets=subnets, resources=resources,
+            medias=medias, templates=templates,
+            domains=domains, envs=envs,
+            hostgroups=hostgroups,
+            organizations=organizations,
+            select=select,
+        )
+        self.click(common_locators['submit'])
 
     def update(self, loc_name, new_name=None, users=None,
                proxies=None, subnets=None, resources=None, medias=None,

--- a/tests/foreman/ui/test_location.py
+++ b/tests/foreman/ui/test_location.py
@@ -11,14 +11,14 @@ from robottelo.datafactory import (
 )
 from robottelo.decorators import run_only_on, tier1, tier2
 from robottelo.constants import (
-    ANY_CONTEXT,
+    DEFAULT_ORG,
     INSTALL_MEDIUM_URL,
     LIBVIRT_RESOURCE_URL,
     OS_TEMPLATE_DATA_FILE,
 )
 from robottelo.helpers import get_data_file
 from robottelo.test import UITestCase
-from robottelo.ui.factory import make_loc, make_templates, set_context
+from robottelo.ui.factory import make_loc, make_templates
 from robottelo.ui.locators import common_locators, locators, tab_locators
 from robottelo.ui.session import Session
 
@@ -55,6 +55,14 @@ def valid_env_names():
 class LocationTestCase(UITestCase):
     """Implements Location tests in UI"""
     location = None
+
+    @classmethod
+    def setUpClass(cls):
+        """Set up an organization for tests."""
+        super(LocationTestCase, cls).setUpClass()
+        cls.org_ = entities.Organization().search(query={
+            'search': 'name="{0}"'.format(DEFAULT_ORG)
+        })[0]
 
     # Auto Search
 
@@ -117,8 +125,8 @@ class LocationTestCase(UITestCase):
     @run_only_on('sat')
     @tier1
     def test_negative_create_with_same_name(self):
-        """Create location with valid values, then create a new one
-        with same values.
+        """Create location with valid values, then create a new one with same
+        values.
 
         @feature: Locations
 
@@ -403,9 +411,9 @@ class LocationTestCase(UITestCase):
 
     @run_only_on('sat')
     @tier2
-    def test_add_compresource(self):
-        """Add compute resource using the location name and
-        compute resource name
+    def test_positive_add_compresource(self):
+        """Add compute resource using the location name and compute resource
+        name
 
         @feature: Locations
 
@@ -481,8 +489,7 @@ class LocationTestCase(UITestCase):
     @run_only_on('sat')
     @tier2
     def test_positive_add_template(self):
-        """Add config template by using location name and config
-        template name.
+        """Add config template by using location name and config template name.
 
         @feature: Locations
 
@@ -524,10 +531,17 @@ class LocationTestCase(UITestCase):
             for env_name in valid_env_names():
                 with self.subTest(env_name):
                     loc_name = gen_string('alpha')
-                    env = entities.Environment(name=env_name).create()
+                    env = entities.Environment(
+                        name=env_name,
+                        organization=[self.org_],
+                    ).create()
                     self.assertEqual(env.name, env_name)
-                    set_context(session, org=ANY_CONTEXT['org'])
-                    make_loc(session, name=loc_name, envs=[env_name])
+                    make_loc(
+                        session,
+                        envs=[env_name],
+                        name=loc_name,
+                        organizations=[self.org_.name],
+                    )
                     self.location.search(loc_name).click()
                     session.nav.click(tab_locators['context.tab_env'])
                     element = session.nav.wait_until_element(
@@ -565,8 +579,12 @@ class LocationTestCase(UITestCase):
                         mask='255.255.255.0',
                     ).create()
                     self.assertEqual(subnet.name, subnet_name)
-                    set_context(session, org=ANY_CONTEXT['org'])
-                    make_loc(session, name=loc_name, subnets=[subnet_name])
+                    make_loc(
+                        session,
+                        name=loc_name,
+                        organizations=[self.org_.name],
+                        subnets=[subnet_name],
+                    )
                     self.location.search(loc_name).click()
                     session.nav.click(tab_locators['context.tab_subnets'])
                     element = session.nav.wait_until_element(
@@ -586,8 +604,8 @@ class LocationTestCase(UITestCase):
     @run_only_on('sat')
     @tier2
     def test_positive_remove_domain(self):
-        """Add a domain to an location and remove it by location name
-        and domain name
+        """Add a domain to an location and remove it by location name and
+        domain name
 
         @feature: Locations
 
@@ -599,10 +617,17 @@ class LocationTestCase(UITestCase):
             for domain_name in generate_strings_list():
                 with self.subTest(domain_name):
                     loc_name = gen_string('alpha')
-                    domain = entities.Domain(name=domain_name).create()
+                    domain = entities.Domain(
+                        name=domain_name,
+                        organization=[self.org_],
+                    ).create()
                     self.assertEqual(domain.name, domain_name)
-                    set_context(session, org=ANY_CONTEXT['org'])
-                    make_loc(session, name=loc_name, domains=[domain_name])
+                    make_loc(
+                        session,
+                        domains=[domain_name],
+                        name=loc_name,
+                        organizations=[self.org_.name],
+                    )
                     self.location.search(loc_name).click()
                     session.nav.click(tab_locators['context.tab_domains'])
                     element = session.nav.wait_until_element(
@@ -622,8 +647,8 @@ class LocationTestCase(UITestCase):
     @run_only_on('sat')
     @tier2
     def test_positive_remove_user(self):
-        """Create admin users then add user and remove it by using the
-        location name
+        """Create admin users then add user and remove it by using the location
+        name
 
         @feature: Locations
 
@@ -645,8 +670,12 @@ class LocationTestCase(UITestCase):
                         password=gen_string('alpha'),
                     ).create()
                     self.assertEqual(user.login, user_name)
-                    set_context(session, org=ANY_CONTEXT['org'])
-                    make_loc(session, name=loc_name, users=[user_name])
+                    make_loc(
+                        session,
+                        name=loc_name,
+                        organizations=[self.org_.name],
+                        users=[user_name],
+                    )
                     self.location.search(loc_name).click()
                     session.nav.click(tab_locators['context.tab_users'])
                     element = session.nav.wait_until_element(
@@ -678,10 +707,16 @@ class LocationTestCase(UITestCase):
             for host_grp_name in generate_strings_list():
                 with self.subTest(host_grp_name):
                     loc_name = gen_string('alpha')
-                    host_grp = entities.HostGroup(name=host_grp_name).create()
+                    host_grp = entities.HostGroup(
+                        name=host_grp_name,
+                        organization=[self.org_],
+                    ).create()
                     self.assertEqual(host_grp.name, host_grp_name)
-                    set_context(session, org=ANY_CONTEXT['org'])
-                    make_loc(session, name=loc_name)
+                    make_loc(
+                        session,
+                        name=loc_name,
+                        organizations=[self.org_.name],
+                    )
                     self.location.search(loc_name).click()
                     session.nav.click(tab_locators['context.tab_hostgrps'])
                     element = session.nav.wait_until_element(
@@ -701,8 +736,8 @@ class LocationTestCase(UITestCase):
     @run_only_on('sat')
     @tier2
     def test_positive_remove_compresource(self):
-        """Remove compute resource by using the location name and
-        compute resource name
+        """Remove compute resource by using the location name and compute
+        resource name
 
         @feature: Locations
 
@@ -716,11 +751,17 @@ class LocationTestCase(UITestCase):
                     loc_name = gen_string('alpha')
                     url = LIBVIRT_RESOURCE_URL % settings.server.hostname
                     resource = entities.LibvirtComputeResource(
-                        name=resource_name, url=url
+                        name=resource_name,
+                        organization=[self.org_],
+                        url=url,
                     ).create()
                     self.assertEqual(resource.name, resource_name)
-                    set_context(session, org=ANY_CONTEXT['org'])
-                    make_loc(session, name=loc_name, resources=[resource_name])
+                    make_loc(
+                        session,
+                        name=loc_name,
+                        organizations=[self.org_.name],
+                        resources=[resource_name],
+                    )
                     self.location.search(loc_name).click()
                     session.nav.click(tab_locators['context.tab_resources'])
                     element = self.location.wait_until_element(
@@ -754,12 +795,17 @@ class LocationTestCase(UITestCase):
                     loc_name = gen_string('alpha')
                     medium = entities.Media(
                         name=medium_name,
-                        path_=INSTALL_MEDIUM_URL % gen_string('alpha', 6),
+                        organization=[self.org_],
                         os_family='Redhat',
+                        path_=INSTALL_MEDIUM_URL % gen_string('alpha', 6),
                     ).create()
                     self.assertEqual(medium.name, medium_name)
-                    set_context(session, org=ANY_CONTEXT['org'])
-                    make_loc(session, name=loc_name, medias=[medium_name])
+                    make_loc(
+                        session,
+                        medias=[medium_name],
+                        organizations=[self.org_.name],
+                        name=loc_name,
+                    )
                     self.location.search(loc_name).click()
                     session.nav.click(tab_locators['context.tab_media'])
                     element = session.nav.wait_until_element(
@@ -779,8 +825,7 @@ class LocationTestCase(UITestCase):
     @run_only_on('sat')
     @tier2
     def test_positive_remove_template(self):
-        """
-        Remove config template
+        """Remove config template
 
         @feature: Locations
 
@@ -791,7 +836,6 @@ class LocationTestCase(UITestCase):
             for template_name in generate_strings_list(length=8):
                 with self.subTest(template_name):
                     loc_name = gen_string('alpha')
-                    set_context(session, org=ANY_CONTEXT['org'])
                     make_templates(
                         session,
                         name=template_name,
@@ -800,7 +844,11 @@ class LocationTestCase(UITestCase):
                         custom_really=True,
                     )
                     self.assertIsNotNone(self.template.search(template_name))
-                    make_loc(session, name=loc_name)
+                    make_loc(
+                        session,
+                        name=loc_name,
+                        organizations=[self.org_.name],
+                    )
                     self.location.search(loc_name).click()
                     session.nav.click(tab_locators['context.tab_template'])
                     element = session.nav.wait_until_element(


### PR DESCRIPTION
Should resolve 11 failures. 2 main reason of failures are
- small infra change (no more need to click 'edit' button after creating a loc)
- tests were not using any organization, just 'any context'. Changing organization to 'Any context' on dashboard requires a lot of time (especially when lots of entities are created) so tests were failing by timeout

Test results:
```python
============================= test session starts ==============================
platform linux2 -- Python 2.7.10, pytest-2.9.2, py-1.4.31, pluggy-0.3.1 -- /home/andrii/env/bin/python
cachedir: .cache
rootdir: /home/andrii/workspace/robottelo, inifile: 
plugins: xdist-1.13.1, repeat-0.2
gw0 I / gw1 I
[gw0] linux2 Python 2.7.10 cwd: /home/andrii/workspace/robottelo
[gw1] linux2 Python 2.7.10 cwd: /home/andrii/workspace/robottelo
[gw0] Python 2.7.10 (default, Sep  8 2015, 17:20:17)  -- [GCC 5.1.1 20150618 (Red Hat 5.1.1-4)]
[gw1] Python 2.7.10 (default, Sep  8 2015, 17:20:17)  -- [GCC 5.1.1 20150618 (Red Hat 5.1.1-4)]
gw0 [18] / gw1 [18]

scheduling tests via LoadScheduling

tests/foreman/ui/test_location.py::LocationTestCase::test_positive_add_domain <- robottelo/decorators.py 
tests/foreman/ui/test_location.py::LocationTestCase::test_add_environment <- robottelo/decorators.py 
[gw0] PASSED tests/foreman/ui/test_location.py::LocationTestCase::test_add_environment <- robottelo/decorators.py 
tests/foreman/ui/test_location.py::LocationTestCase::test_positive_add_compresource <- robottelo/decorators.py 
[gw1] PASSED tests/foreman/ui/test_location.py::LocationTestCase::test_positive_add_domain <- robottelo/decorators.py 
tests/foreman/ui/test_location.py::LocationTestCase::test_positive_add_hostgroup <- robottelo/decorators.py 
[gw1] PASSED tests/foreman/ui/test_location.py::LocationTestCase::test_positive_add_hostgroup <- robottelo/decorators.py 
tests/foreman/ui/test_location.py::LocationTestCase::test_positive_add_subnet <- robottelo/decorators.py 
[gw0] PASSED tests/foreman/ui/test_location.py::LocationTestCase::test_positive_add_compresource <- robottelo/decorators.py 
tests/foreman/ui/test_location.py::LocationTestCase::test_positive_add_medium <- robottelo/decorators.py 
[gw1] PASSED tests/foreman/ui/test_location.py::LocationTestCase::test_positive_add_subnet <- robottelo/decorators.py 
tests/foreman/ui/test_location.py::LocationTestCase::test_positive_add_template <- robottelo/decorators.py 
[gw0] PASSED tests/foreman/ui/test_location.py::LocationTestCase::test_positive_add_medium <- robottelo/decorators.py 
tests/foreman/ui/test_location.py::LocationTestCase::test_positive_add_org <- robottelo/decorators.py 
[gw1] PASSED tests/foreman/ui/test_location.py::LocationTestCase::test_positive_add_template <- robottelo/decorators.py 
tests/foreman/ui/test_location.py::LocationTestCase::test_positive_add_user <- robottelo/decorators.py 
[gw0] PASSED tests/foreman/ui/test_location.py::LocationTestCase::test_positive_add_org <- robottelo/decorators.py 
tests/foreman/ui/test_location.py::LocationTestCase::test_positive_create_with_location_and_org <- robottelo/decorators.py 
[gw1] PASSED tests/foreman/ui/test_location.py::LocationTestCase::test_positive_add_user <- robottelo/decorators.py 
tests/foreman/ui/test_location.py::LocationTestCase::test_positive_remove_compresource <- robottelo/decorators.py 
[gw0] PASSED tests/foreman/ui/test_location.py::LocationTestCase::test_positive_create_with_location_and_org <- robottelo/decorators.py 
tests/foreman/ui/test_location.py::LocationTestCase::test_positive_remove_domain <- robottelo/decorators.py 
[gw1] PASSED tests/foreman/ui/test_location.py::LocationTestCase::test_positive_remove_compresource <- robottelo/decorators.py 
tests/foreman/ui/test_location.py::LocationTestCase::test_positive_remove_environment <- robottelo/decorators.py 
[gw0] PASSED tests/foreman/ui/test_location.py::LocationTestCase::test_positive_remove_domain <- robottelo/decorators.py 
tests/foreman/ui/test_location.py::LocationTestCase::test_positive_remove_hostgroup <- robottelo/decorators.py 
[gw1] PASSED tests/foreman/ui/test_location.py::LocationTestCase::test_positive_remove_environment <- robottelo/decorators.py 
tests/foreman/ui/test_location.py::LocationTestCase::test_positive_remove_medium <- robottelo/decorators.py 
[gw0] PASSED tests/foreman/ui/test_location.py::LocationTestCase::test_positive_remove_hostgroup <- robottelo/decorators.py 
tests/foreman/ui/test_location.py::LocationTestCase::test_positive_remove_subnet <- robottelo/decorators.py 
[gw1] PASSED tests/foreman/ui/test_location.py::LocationTestCase::test_positive_remove_medium <- robottelo/decorators.py 
[gw0] PASSED tests/foreman/ui/test_location.py::LocationTestCase::test_positive_remove_subnet <- robottelo/decorators.py 
tests/foreman/ui/test_location.py::LocationTestCase::test_positive_remove_user <- robottelo/decorators.py 
tests/foreman/ui/test_location.py::LocationTestCase::test_positive_remove_template <- robottelo/decorators.py 
[gw0] PASSED tests/foreman/ui/test_location.py::LocationTestCase::test_positive_remove_user <- robottelo/decorators.py 
[gw1] PASSED tests/foreman/ui/test_location.py::LocationTestCase::test_positive_remove_template <- robottelo/decorators.py 

========================= 18 passed in 461.63 seconds ==========================
```