### PR TITLE
Run repository set tests in one thread

### DIFF
--- a/tests/foreman/api/test_repository_set.py
+++ b/tests/foreman/api/test_repository_set.py
@@ -9,10 +9,11 @@ from nailgun import entities
 from robottelo import manifests
 from robottelo.api.utils import upload_manifest
 from robottelo.constants import PRDS, REPOSET
-from robottelo.decorators import run_only_on, tier1
+from robottelo.decorators import run_in_one_thread, run_only_on, tier1
 from robottelo.test import APITestCase
 
 
+@run_in_one_thread
 class RepositorySetTestCase(APITestCase):
     """Tests for ``katello/api/v2/products/<product_id>/repository_sets``."""
 

--- a/tests/foreman/cli/test_repository_set.py
+++ b/tests/foreman/cli/test_repository_set.py
@@ -5,11 +5,12 @@ from robottelo.cli.repository_set import RepositorySet
 from robottelo.cli.subscription import Subscription
 from robottelo import manifests
 from robottelo.constants import PRDS, REPOSET
-from robottelo.decorators import tier1
+from robottelo.decorators import run_in_one_thread, tier1
 from robottelo.ssh import upload_file
 from robottelo.test import CLITestCase
 
 
+@run_in_one_thread
 class RepositorySetTestCase(CLITestCase):
     """Repository Set CLI tests."""
 


### PR DESCRIPTION
Locally tests are failing because of race condition with subscription upload:

```python
py.test tests/foreman/cli/test_repository_set.py -n 4 -v
============================= test session starts ==============================
platform linux2 -- Python 2.7.10, pytest-2.9.2, py-1.4.31, pluggy-0.3.1 -- /home/andrii/env/bin/python
cachedir: .cache
rootdir: /home/andrii/workspace/robottelo, inifile: 
plugins: xdist-1.13.1, repeat-0.2
gw0 I / gw1 I / gw2 I / gw3 I
[gw0] linux2 Python 2.7.10 cwd: /home/andrii/workspace/robottelo
[gw1] linux2 Python 2.7.10 cwd: /home/andrii/workspace/robottelo
[gw2] linux2 Python 2.7.10 cwd: /home/andrii/workspace/robottelo
[gw3] linux2 Python 2.7.10 cwd: /home/andrii/workspace/robottelo
[gw1] Python 2.7.10 (default, Sep  8 2015, 17:20:17)  -- [GCC 5.1.1 20150618 (Red Hat 5.1.1-4)]
[gw0] Python 2.7.10 (default, Sep  8 2015, 17:20:17)  -- [GCC 5.1.1 20150618 (Red Hat 5.1.1-4)]
[gw2] Python 2.7.10 (default, Sep  8 2015, 17:20:17)  -- [GCC 5.1.1 20150618 (Red Hat 5.1.1-4)]
[gw3] Python 2.7.10 (default, Sep  8 2015, 17:20:17)  -- [GCC 5.1.1 20150618 (Red Hat 5.1.1-4)]
gw0 [7] / gw1 [7] / gw2 [7] / gw3 [7]

scheduling tests via LoadScheduling

tests/foreman/cli/test_repository_set.py::RepositorySetTestCase::test_positive_disable_by_name 
tests/foreman/cli/test_repository_set.py::RepositorySetTestCase::test_positive_enable_by_label 
tests/foreman/cli/test_repository_set.py::RepositorySetTestCase::test_positive_disable_by_id 
[gw1] FAILED tests/foreman/cli/test_repository_set.py::RepositorySetTestCase::test_positive_enable_by_label 
[gw3] PASSED tests/foreman/cli/test_repository_set.py::RepositorySetTestCase::test_positive_disable_by_name 
[gw2] PASSED tests/foreman/cli/test_repository_set.py::RepositorySetTestCase::test_positive_disable_by_id 
tests/foreman/cli/test_repository_set.py::RepositorySetTestCase::test_positive_enable_by_name 
tests/foreman/cli/test_repository_set.py::RepositorySetTestCase::test_positive_disable_by_label 
tests/foreman/cli/test_repository_set.py::RepositorySetTestCase::test_positive_list_available_repositories 
tests/foreman/cli/test_repository_set.py::RepositorySetTestCase::test_positive_enable_by_id 
[gw3] FAILED tests/foreman/cli/test_repository_set.py::RepositorySetTestCase::test_positive_enable_by_id 
[gw0] FAILED tests/foreman/cli/test_repository_set.py::RepositorySetTestCase::test_positive_list_available_repositories 
[gw1] PASSED tests/foreman/cli/test_repository_set.py::RepositorySetTestCase::test_positive_enable_by_name 
[gw2] PASSED tests/foreman/cli/test_repository_set.py::RepositorySetTestCase::test_positive_disable_by_label 

=================================== FAILURES ===================================
[...]
----------------------------- Captured stdout call -----------------------------
[...]
2016-06-06 12:09:01 - robottelo.ssh - DEBUG - >>> [example.com] LANG=en_US.UTF-8  hammer -v -u admin -p changeme  subscription upload --organization-id="7" --file="/tmp/manifest-1465204137.zip"
2016-06-06 12:09:02 - robottelo.ssh - INFO - Instantiated Paramiko client 0x7f95c4036cd0
2016-06-06 12:09:08 - robottelo.ssh - INFO - Destroying Paramiko client 0x7f95c4036cd0
2016-06-06 12:09:08 - robottelo.ssh - INFO - Destroyed Paramiko client 0x7f95c4036cd0
2016-06-06 12:09:08 - robottelo.ssh - DEBUG - <<< stderr
Task 096fc0b3-7bb7-4c31-82bb-f94c70a58f61 running: 0.0/1, 0%, elapsed: 00:00:00
Task 096fc0b3-7bb7-4c31-82bb-f94c70a58f61 running: 0.0/1, 0%, 0.0/s, elapsed: 00:00:02
Task 096fc0b3-7bb7-4c31-82bb-f94c70a58f61 warning: 1.0/1, 100%, 0.2/s, elapsed: 00:00:04
Task 096fc0b3-7bb7-4c31-82bb-f94c70a58f61 warning: 1.0/1, 100%, 0.2/s, elapsed: 00:00:04
PG::Error: ERROR:  duplicate key value violates unique constraint "index_katello_subscriptions_on_cp_id"
: INSERT INTO "katello_subscriptions" ("cp_id", "created_at", "updated_at") VALUES ($1, $2, $3) RETURNING "id"
[...]
===================== 3 failed, 4 passed in 93.29 seconds ======================
```
Results when executed in 1 thread:
```python
py.test tests/foreman/cli/test_repository_set.py -n 1 -v
============================= test session starts ==============================
platform linux2 -- Python 2.7.10, pytest-2.9.2, py-1.4.31, pluggy-0.3.1 -- /home/andrii/env/bin/python
cachedir: .cache
rootdir: /home/andrii/workspace/robottelo, inifile: 
plugins: xdist-1.13.1, repeat-0.2
gw0 I
[gw0] linux2 Python 2.7.10 cwd: /home/andrii/workspace/robottelo
[gw0] Python 2.7.10 (default, Sep  8 2015, 17:20:17)  -- [GCC 5.1.1 20150618 (Red Hat 5.1.1-4)]
gw0 [7]

scheduling tests via LoadScheduling

tests/foreman/cli/test_repository_set.py::RepositorySetTestCase::test_positive_disable_by_id 
[gw0] PASSED tests/foreman/cli/test_repository_set.py::RepositorySetTestCase::test_positive_disable_by_id 
tests/foreman/cli/test_repository_set.py::RepositorySetTestCase::test_positive_disable_by_label 
[gw0] PASSED tests/foreman/cli/test_repository_set.py::RepositorySetTestCase::test_positive_disable_by_label 
tests/foreman/cli/test_repository_set.py::RepositorySetTestCase::test_positive_disable_by_name 
[gw0] PASSED tests/foreman/cli/test_repository_set.py::RepositorySetTestCase::test_positive_disable_by_name 
tests/foreman/cli/test_repository_set.py::RepositorySetTestCase::test_positive_enable_by_id 
[gw0] PASSED tests/foreman/cli/test_repository_set.py::RepositorySetTestCase::test_positive_enable_by_id 
tests/foreman/cli/test_repository_set.py::RepositorySetTestCase::test_positive_enable_by_label 
[gw0] PASSED tests/foreman/cli/test_repository_set.py::RepositorySetTestCase::test_positive_enable_by_label 
tests/foreman/cli/test_repository_set.py::RepositorySetTestCase::test_positive_enable_by_name 
[gw0] PASSED tests/foreman/cli/test_repository_set.py::RepositorySetTestCase::test_positive_enable_by_name 
tests/foreman/cli/test_repository_set.py::RepositorySetTestCase::test_positive_list_available_repositories 
[gw0] PASSED tests/foreman/cli/test_repository_set.py::RepositorySetTestCase::test_positive_list_available_repositories 

========================== 7 passed in 278.12 seconds ==========================
```