### PR TITLE
Fix random location failure with tooltip overlapping search button

### DIFF
--- a/robottelo/ui/base.py
+++ b/robottelo/ui/base.py
@@ -115,6 +115,10 @@ class Base(object):
         searchbox.clear()
         searchbox.send_keys(u'{0} = {1}'.format(
             search_key, escape_search(element_name)))
+        # ensure mouse points at search button and no tooltips are covering it
+        # before clicking
+        self.perform_action_chain_move(search_button_locator)
+
         self.click(search_button_locator)
         # Make sure that found element is returned no matter it described by
         # its own locator or common one (locator can transform depending on


### PR DESCRIPTION
When you click 'Manage locations' link and leave cursor at that level - it will appear on the first item of the locations list. If the first item of the list has a long name and is shortened, tooltip with full
name will appear as cursor is pointing on it. And if your browser resolution is 1424px (+-100px) - tooltip will overlap search button, making it impossible to click on it, just like that:
![2016-06-06 17_33_29-fedora 23 xfce light ssd - vmware workstation](https://cloud.githubusercontent.com/assets/11719030/15825649/4ea96f86-2c0d-11e6-950e-1c19d61d56e8.png)

Moving the cursor to the search button explicitly, making the tooltip disappear before actual clicking.