### PR TITLE
Using session_org in ui/test_subscription to address #3519

### DIFF
--- a/tests/foreman/ui/test_subscription.py
+++ b/tests/foreman/ui/test_subscription.py
@@ -12,9 +12,8 @@ class SubscriptionTestCase(UITestCase):
     """Implements subscriptions/manifests tests in UI"""
 
     @classmethod
-    def setUpClass(cls):  # noqa
-        super(SubscriptionTestCase, cls).setUpClass()
-        cls.organization = entities.Organization().create()
+    def set_session_org(cls):
+        cls.session_org = entities.Organization().create()
 
     @skip_if_not_set('fake_manifest')
     @tier1
@@ -26,7 +25,6 @@ class SubscriptionTestCase(UITestCase):
         @Assert: Manifest is uploaded and deleted successfully
         """
         with Session(self.browser) as session:
-            session.nav.go_to_select_org(self.organization.name)
             session.nav.go_to_red_hat_subscriptions()
             # Step 1: Attempt to upload a manifest
             with manifests.clone() as manifest:


### PR DESCRIPTION
Created organization in **set_session_org** makes the user to login with that organization context and avoids 1 call to **go_to_select_org**

```bash
Session set with:
	User: 8:odGMQDoocW
	Organization: 6:IEeJMD
.....
2016-06-07 10:44:00 - robottelo - DEBUG - Cleanup deleted 1 entities
2016-06-07 10:44:00 - robottelo - DEBUG - Deleting session_user
....
=== 1 passed in 84.11 seconds ===
```