### PR TITLE
Change libvirt URL to use external source

### DIFF
--- a/robottelo/constants.py
+++ b/robottelo/constants.py
@@ -27,7 +27,7 @@ FOREMAN_PROVIDERS = {
     'docker': 'Docker',
 }
 
-LIBVIRT_RESOURCE_URL = 'qemu+tcp://%s:16509/system'
+LIBVIRT_RESOURCE_URL = 'qemu+ssh://root@%s/system'
 
 
 HTML_TAGS = [

--- a/tests/foreman/api/test_computeresource.py
+++ b/tests/foreman/api/test_computeresource.py
@@ -26,7 +26,7 @@ class ComputeResourceTestCase(APITestCase):
         cls.org = entities.Organization().create()
         cls.loc = entities.Location(organization=[cls.org]).create()
         cls.current_libvirt_url = (
-            LIBVIRT_RESOURCE_URL % settings.server.hostname
+            LIBVIRT_RESOURCE_URL % settings.compute_resources.libvirt_hostname
         )
 
     @tier1

--- a/tests/foreman/cli/test_computeresource.py
+++ b/tests/foreman/cli/test_computeresource.py
@@ -93,7 +93,7 @@ class ComputeResourceTestCase(CLITestCase):
     def setUpClass(cls):
         super(ComputeResourceTestCase, cls).setUpClass()
         cls.current_libvirt_url = (
-            LIBVIRT_RESOURCE_URL % settings.server.hostname
+            LIBVIRT_RESOURCE_URL % settings.compute_resources.libvirt_hostname
         )
 
     # pylint: disable=no-self-use

--- a/tests/foreman/cli/test_organization.py
+++ b/tests/foreman/cli/test_organization.py
@@ -523,7 +523,9 @@ class OrganizationTestCase(CLITestCase):
         org = make_org()
         compute_res = make_compute_resource({
             'provider': FOREMAN_PROVIDERS['libvirt'],
-            'url': "qemu+tcp://%s:16509/system" % settings.server.hostname
+            'url': u'qemu+ssh://root@{0}/system'.format(
+                settings.compute_resources.libvirt_hostname
+            )
         })
         Org.add_compute_resource({
             'compute-resource': compute_res['name'],
@@ -575,7 +577,9 @@ class OrganizationTestCase(CLITestCase):
         org = make_org()
         compute_res = make_compute_resource({
             'provider': FOREMAN_PROVIDERS['libvirt'],
-            'url': "qemu+tcp://%s:16509/system" % settings.server.hostname
+            'url': u'qemu+ssh://root@{0}/system'.format(
+                settings.compute_resources.libvirt_hostname
+            )
         })
         Org.add_compute_resource({
             'compute-resource-id': compute_res['id'],
@@ -600,7 +604,9 @@ class OrganizationTestCase(CLITestCase):
         org = make_org()
         compute_res = make_compute_resource({
             'provider': FOREMAN_PROVIDERS['libvirt'],
-            'url': "qemu+tcp://%s:16509/system" % settings.server.hostname
+            'url': u'qemu+ssh://root@{0}/system'.format(
+                settings.compute_resources.libvirt_hostname
+            )
         })
         Org.add_compute_resource({
             'compute-resource': compute_res['name'],

--- a/tests/foreman/endtoend/test_api_endtoend.py
+++ b/tests/foreman/endtoend/test_api_endtoend.py
@@ -1096,8 +1096,9 @@ class EndToEndTestCase(TestCase, ClientProvisioningMixin):
         # step 2.16: Create a new libvirt compute resource
         entities.LibvirtComputeResource(
             server_config,
-            url=u'qemu+tcp://{0}:16509/system'.format(
-                settings.server.hostname),
+            url=u'qemu+ssh://root@{0}/system'.format(
+                settings.compute_resources.libvirt_hostname
+            ),
         ).create()
 
         # step 2.17: Create a new subnet

--- a/tests/foreman/endtoend/test_cli_endtoend.py
+++ b/tests/foreman/endtoend/test_cli_endtoend.py
@@ -370,8 +370,9 @@ class EndToEndTestCase(CLITestCase, ClientProvisioningMixin):
             {
                 u'name': gen_alphanumeric(),
                 u'provider': u'Libvirt',
-                u'url': u'qemu+tcp://{0}:16509/system'.format(
-                    settings.server.hostname),
+                u'url': u'qemu+ssh://root@{0}/system'.format(
+                    settings.compute_resources.libvirt_hostname
+                ),
             }
         )
 

--- a/tests/foreman/endtoend/test_ui_endtoend.py
+++ b/tests/foreman/endtoend/test_ui_endtoend.py
@@ -274,7 +274,8 @@ class EndToEndTestCase(UITestCase, ClientProvisioningMixin):
                 provider_type=FOREMAN_PROVIDERS['libvirt'],
                 parameter_list=[[
                     'URL',
-                    LIBVIRT_RESOURCE_URL % settings.server.hostname,
+                    (LIBVIRT_RESOURCE_URL %
+                     settings.compute_resources.libvirt_hostname),
                     'field'
                 ]],
             )

--- a/tests/foreman/ui/test_computeresource.py
+++ b/tests/foreman/ui/test_computeresource.py
@@ -19,7 +19,7 @@ class ComputeResourceTestCase(UITestCase):
     def setUpClass(cls):
         super(ComputeResourceTestCase, cls).setUpClass()
         cls.current_libvirt_url = (
-            LIBVIRT_RESOURCE_URL % settings.server.hostname
+            LIBVIRT_RESOURCE_URL % settings.compute_resources.libvirt_hostname
         )
 
     @run_only_on('sat')

--- a/tests/foreman/ui/test_location.py
+++ b/tests/foreman/ui/test_location.py
@@ -424,7 +424,8 @@ class LocationTestCase(UITestCase):
             for resource_name in generate_strings_list():
                 with self.subTest(resource_name):
                     loc_name = gen_string('alpha')
-                    url = LIBVIRT_RESOURCE_URL % settings.server.hostname
+                    url = (LIBVIRT_RESOURCE_URL %
+                           settings.compute_resources.libvirt_hostname)
                     resource = entities.LibvirtComputeResource(
                         name=resource_name, url=url).create()
                     self.assertEqual(resource.name, resource_name)
@@ -749,7 +750,8 @@ class LocationTestCase(UITestCase):
             for resource_name in generate_strings_list():
                 with self.subTest(resource_name):
                     loc_name = gen_string('alpha')
-                    url = LIBVIRT_RESOURCE_URL % settings.server.hostname
+                    url = (LIBVIRT_RESOURCE_URL %
+                           settings.compute_resources.libvirt_hostname)
                     resource = entities.LibvirtComputeResource(
                         name=resource_name,
                         organization=[self.org_],

--- a/tests/foreman/ui/test_organization.py
+++ b/tests/foreman/ui/test_organization.py
@@ -616,7 +616,8 @@ class OrganizationTestCase(UITestCase):
             for resource_name in generate_strings_list():
                 with self.subTest(resource_name):
                     org_name = gen_string('alpha')
-                    url = LIBVIRT_RESOURCE_URL % settings.server.hostname
+                    url = (LIBVIRT_RESOURCE_URL %
+                           settings.compute_resources.libvirt_hostname)
                     # Create compute resource using nailgun
                     resource = entities.LibvirtComputeResource(
                         name=resource_name,
@@ -775,7 +776,8 @@ class OrganizationTestCase(UITestCase):
             for resource_name in generate_strings_list():
                 with self.subTest(resource_name):
                     org_name = gen_string('alpha')
-                    url = LIBVIRT_RESOURCE_URL % settings.server.hostname
+                    url = (LIBVIRT_RESOURCE_URL %
+                           settings.compute_resources.libvirt_hostname)
                     # Create compute resource using nailgun
                     resource = entities.LibvirtComputeResource(
                         name=resource_name,


### PR DESCRIPTION
```
nosetests tests/foreman/api/test_computeresource.py
.....................
----------------------------------------------------------------------
Ran 21 tests in 230.435s

OK
```
```
nosetests tests/foreman/ui/test_computeresource.py
.........
----------------------------------------------------------------------
Ran 9 tests in 811.813s

OK
```
```
nosetests tests/foreman/ui/test_location.py -m compresource
..
----------------------------------------------------------------------
Ran 2 tests in 617.639s

OK
nosetests tests/foreman/ui/test_organization.py -m compresource
..
----------------------------------------------------------------------
Ran 2 tests in 666.406s

OK
```
```
nosetests tests/foreman/cli/test_computeresource.py
...S..........
----------------------------------------------------------------------
Ran 14 tests in 366.400s

OK (SKIP=1)
```
```
nosetests tests/foreman/cli/test_organization.py -m compresource
.....
----------------------------------------------------------------------
Ran 5 tests in 152.185s

OK
```