### PR TITLE
add interactive shell to robottelo

### DIFF
--- a/manage.py
+++ b/manage.py
@@ -1,0 +1,78 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+"""
+This is a command management for Robottelo including shell command
+
+    $ python manage.py shell
+    Welcome to Robottelo Interactive shell
+        Auto imported: [settings, entities, rt, ng]
+    In [1]: org = entities.Organization().create()
+    ... DEBUG: ... making POST resquest to...
+
+Depends on click:
+    pip install click
+"""
+import click
+import nailgun
+import code
+import readline
+import rlcompleter
+import importlib
+from robottelo.config import settings
+
+
+@click.group()
+def core_cmd():
+    """ Core commands wrapper """
+    pass
+
+
+class RobotteloLoader(object):
+    def __getattr__(self, item):
+        return importlib.import_module('robottelo.{0}'.format(item))
+
+
+@core_cmd.command()
+@click.option('--ipython/--no-ipython', default=True)
+def shell(ipython):
+    """Runs a Python shell with Robottelo context"""
+    _vars = globals()
+    _vars.update(locals())
+    auto_imported = {
+        'settings': settings,
+        'entities': nailgun.entities,
+        'ng': nailgun,
+        'rt': RobotteloLoader()
+    }
+    _vars.update(auto_imported)
+    banner_msg = (
+        'Welcome to Robottelo interactive shell\n'
+        '\tAuto imported: {0}\n'
+        '\tng is nailgun e.g: ng.client\n'
+        '\trt is robottelo e.g: rt.datafactory\n'
+    ).format(auto_imported.keys())
+    readline.set_completer(rlcompleter.Completer(_vars).complete)
+    readline.parse_and_bind('tab: complete')
+    try:
+        if ipython is True:
+            from IPython import start_ipython
+            from traitlets.config import Config
+            c = Config()
+            c.TerminalInteractiveShell.banner2 = banner_msg
+            start_ipython(argv=[], user_ns=_vars, config=c)
+        else:
+            raise ImportError
+    except ImportError:
+        shell = code.InteractiveConsole(_vars)
+        shell.interact(banner=banner_msg)
+
+
+help_text = """
+    Robottelo Interactive shell!
+    """
+manager = click.CommandCollection(help=help_text)
+manager.add_source(core_cmd)
+
+if __name__ == '__main__':
+    settings.configure()
+    manager()

--- a/requirements-optional.txt
+++ b/requirements-optional.txt
@@ -18,3 +18,6 @@ docker-py
 
 # For reporting test results on SauceLabs
 sauceclient
+
+# For interactive shell
+click


### PR DESCRIPTION
Add interactive shell to robottelo it is useful for debugging specially entities and factories

```bash
$ pip install -r requirements-optional.txt   # to install click

$ cd robottelo
$ python manage.py 
Usage: manage.py [OPTIONS] COMMAND [ARGS]...

      Robottelo Interactive shell!

Options:
  --help  Show this message and exit.

Commands:
  shell  Runs a Python shell with Robottelo context
```

then shell (if ipython installed it opens in ipython, otherwise in normal python shell)

```bash
$ python manage.py shell
Python 2.7.11 (default, Mar 31 2016, 20:46:51) 
Welcome to Robottelo interactive shell
	Auto imported: ['rt', 'entities', 'ng', 'settings']
	ng is nailgun e.g: ng.client
    rt is robottelo e.g: rt.datafactory

In [1]: entities.Organization
Out[1]: nailgun.entities.Organization
In [2]: ng.client
Out[2]: <module 'nailgun.client' from '/nailgun/nailgun/client.pyc'>
In [3]: settings.cleanup
Out[3]: True
In [4]: rt.datafactory.gen_string
Out[4]: <function fauxfactory.gen_string>
```