### PR TITLE
Ignore Pycharm .idea in version control

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,6 @@
 /.project
 /.pydevproject
 /.settings/
+
+# For Pycharm
+/.idea


### PR DESCRIPTION
Once Eclipse metadata is already ignored, this does the same i.e. prevent Pycharm users from committing unwanted files
This is simple PR so I can see the process for the first time since I just joined the team