### PR TITLE
Fixes sync plans tests according to latest build

### DIFF
--- a/tests/foreman/api/test_syncplan.py
+++ b/tests/foreman/api/test_syncplan.py
@@ -170,7 +170,6 @@ class SyncPlanCreateTestCase(APITestCase):
                 self.assertEqual(sync_plan.interval, interval)
 
     @run_only_on('sat')
-    @skip_if_bug_open('bugzilla', 1335133)
     @tier1
     def test_positive_create_with_sync_date(self):
         """Create a sync plan and update its sync date.
@@ -186,7 +185,7 @@ class SyncPlanCreateTestCase(APITestCase):
                     sync_date=syncdate,
                 ).create()
                 self.assertEqual(
-                    syncdate.strftime('%m/%d/%Y %I:%M:%p'),
+                    syncdate.strftime('%Y/%m/%d %H:%M:%S UTC'),
                     sync_plan.sync_date
                 )
 
@@ -334,7 +333,6 @@ class SyncPlanUpdateTestCase(APITestCase):
                 )
 
     @run_only_on('sat')
-    @skip_if_bug_open('bugzilla', 1335133)
     @tier1
     def test_positive_update_sync_date(self):
         """Updated sync plan's sync date.
@@ -351,7 +349,7 @@ class SyncPlanUpdateTestCase(APITestCase):
             with self.subTest(syncdate):
                 sync_plan.sync_date = syncdate
                 self.assertEqual(
-                    syncdate.strftime('%m/%d/%Y %I:%M:%p'),
+                    syncdate.strftime('%Y/%m/%d %H:%M:%S UTC'),
                     sync_plan.update(['sync_date']).sync_date
                 )
 

--- a/tests/foreman/ui/test_syncplan.py
+++ b/tests/foreman/ui/test_syncplan.py
@@ -15,7 +15,6 @@ from robottelo.datafactory import (
 from robottelo.decorators import (
     run_in_one_thread,
     run_only_on,
-    skip_if_bug_open,
     stubbed,
     tier1,
     tier2,
@@ -142,7 +141,6 @@ class SyncPlanTestCase(UITestCase):
                     )
                     self.assertIsNotNone(self.syncplan.search(name))
 
-    @skip_if_bug_open('bugzilla', 1335133)
     @tier2
     def test_positive_create_with_start_time(self):
         """Create Sync plan with specified start time
@@ -170,10 +168,9 @@ class SyncPlanTestCase(UITestCase):
             # to validate via UI.
             self.assertEqual(
                 str(starttime_text).rpartition(':')[0],
-                startdate.strftime("%m/%d/%Y %I:%M")
+                startdate.strftime("%Y/%m/%d %H:%M")
             )
 
-    @skip_if_bug_open('bugzilla', 1335133)
     @tier2
     def test_positive_create_with_start_date(self):
         """Create Sync plan with specified start date
@@ -198,7 +195,7 @@ class SyncPlanTestCase(UITestCase):
                 locators['sp.fetch_startdate']).text
             self.assertEqual(
                 str(startdate_text).partition(' ')[0],
-                startdate.strftime("%m/%d/%Y")
+                startdate.strftime("%Y/%m/%d")
             )
 
     @tier1


### PR DESCRIPTION
```
nosetests tests/foreman/api/test_syncplan.py -m test_positive_update_sync_date
.
----------------------------------------------------------------------
Ran 1 test in 14.127s

OK
nosetests tests/foreman/api/test_syncplan.py -m test_positive_create_with_sync_date
.
----------------------------------------------------------------------
Ran 1 test in 12.263s

OK
nosetests tests/foreman/ui/test_syncplan.py -m start_
..
----------------------------------------------------------------------
Ran 2 tests in 84.750s

OK
```