### PR TITLE
Use sat server hostname as external compute resource url

### DIFF
--- a/tests/foreman/api/test_docker.py
+++ b/tests/foreman/api/test_docker.py
@@ -1132,7 +1132,7 @@ class DockerContainerTestCase(APITestCase):
         cls.cr_external = entities.DockerComputeResource(
             name=gen_string('alpha'),
             organization=[cls.org],
-            url=settings.docker.external_url,
+            url='http://{0}:2375'.format(settings.server.hostname),
         ).create()
         install_katello_ca()
 

--- a/tests/foreman/cli/test_docker.py
+++ b/tests/foreman/cli/test_docker.py
@@ -1302,7 +1302,7 @@ class DockerContainersTestCase(CLITestCase):
         cls.cr_external = make_compute_resource({
             'organization-ids': [cls.org['id']],
             'provider': DOCKER_PROVIDER,
-            'url': settings.docker.external_url,
+            'url': 'http://{0}:2375'.format(settings.server.hostname),
         })
         install_katello_ca()
 

--- a/tests/foreman/ui/test_docker.py
+++ b/tests/foreman/ui/test_docker.py
@@ -1178,7 +1178,7 @@ class DockerContainerTestCase(UITestCase):
         cls.cr_external = entities.DockerComputeResource(
             name=gen_string('alpha'),
             organization=[cls.organization],
-            url=settings.docker.external_url,
+            url='http://{0}:2375'.format(settings.server.hostname),
         ).create()
         cls.parameter_list = [
             {'main_tab_name': 'Image', 'sub_tab_name': 'Content View',


### PR DESCRIPTION
As per #3508 discussion, we can't use our `sesame` machine as a external compute resource and should use satellite machine hostnames instead.
Should resolve at least following test failures:
```
tests.foreman.api.test_docker.DockerContainerTestCase.test_positive_read_container_log
tests.foreman.api.test_docker.DockerContainerTestCase.test_positive_create_using_cv
tests.foreman.cli.test_docker.DockerContainersTestCase.test_positive_create_using_cv
tests.foreman.ui.test_docker.DockerContainerTestCase.test_positive_create_with_compresource
tests.foreman.ui.test_docker.DockerContainerTestCase.test_positive_power_on_off
tests.foreman.ui.test_docker.DockerContainerTestCase.test_positive_delete
```
Test results:
```python
py.test tests/foreman/cli/test_docker.py tests/foreman/api/test_docker.py tests/foreman/ui/test_docker.py -k 'test_positive_read_container_log or test_positive_create_using_cv or test_positive_create_with_compresource or test_positive_power_on_off or test_positive_delete'
================================ test session starts =================================
platform linux2 -- Python 2.7.10, pytest-2.9.2, py-1.4.31, pluggy-0.3.1
rootdir: /home/andrii/workspace/robottelo, inifile: 
plugins: xdist-1.13.1, repeat-0.2
collected 141 items 

tests/foreman/cli/test_docker.py ......ss..
tests/foreman/api/test_docker.py .........
tests/foreman/ui/test_docker.py ........

 114 tests deselected by '-ktest_positive_read_container_log or test_positive_create_using_cv or test_positive_create_with_compresource or test_positive_power_on_off or test_positive_delete' 
============== 25 passed, 2 skipped, 114 deselected in 1770.55 seconds ===============
```