### PR TITLE
Mark some missing subscription upload tests with run_in_one_thread decorator

### DIFF
--- a/tests/foreman/api/test_contentview.py
+++ b/tests/foreman/api/test_contentview.py
@@ -28,7 +28,6 @@ from robottelo.decorators import (
 )
 from robottelo.helpers import get_data_file
 from robottelo.test import APITestCase
-from unittest import skipIf
 
 
 # Some tests repeatedly publish content views or promote content view versions.
@@ -308,7 +307,6 @@ class ContentViewCreateTestCase(APITestCase):
                     entities.ContentView(name=name).create()
 
 
-@skipIf(bz_bug_is_open(1329292), 'Skipping due to open Bugzilla bug #1329292')
 class ContentViewPublishPromoteTestCase(APITestCase):
     """Tests for publishing and promoting content views."""
 

--- a/tests/foreman/api/test_contentviewversion.py
+++ b/tests/foreman/api/test_contentviewversion.py
@@ -8,7 +8,7 @@ from robottelo.constants import (
     PUPPET_MODULE_NTP_PUPPETLABS,
     ZOO_CUSTOM_GPG_KEY,
 )
-from robottelo.decorators import skip_if_bug_open, tier2
+from robottelo.decorators import tier2
 from robottelo.helpers import get_data_file, read_data_file
 from robottelo.test import APITestCase
 
@@ -281,7 +281,6 @@ class ContentViewVersionDeleteTestCase(APITestCase):
 class ContentViewVersionIncrementalTestCase(APITestCase):
     """Tests for content view version promotion."""
 
-    @skip_if_bug_open('bugzilla', 1329292)
     @tier2
     def test_positive_incremental_update_puppet(self):
         """Incrementally update a CVV with a puppet module.

--- a/tests/foreman/api/test_hostgroup.py
+++ b/tests/foreman/api/test_hostgroup.py
@@ -30,7 +30,6 @@ class HostGroupTestCase(APITestCase):
         cls.loc = entities.Location(organization=[cls.org]).create()
 
     @skip_if_bug_open('bugzilla', 1222118)
-    @skip_if_bug_open('bugzilla', 1329292)
     @tier3
     def test_verify_bugzilla_1107708(self):
         """Host that created from HostGroup entity with PuppetClass

--- a/tests/foreman/api/test_repository.py
+++ b/tests/foreman/api/test_repository.py
@@ -27,6 +27,7 @@ from robottelo.datafactory import (
     valid_labels_list,
 )
 from robottelo.decorators import (
+    run_in_one_thread,
     run_only_on,
     skip_if_bug_open,
     skip_if_not_set,
@@ -405,7 +406,6 @@ class RepositoryTestCase(APITestCase):
         self.assertEqual(repo.gpg_key.id, gpg_key_2.id)
 
     @run_only_on('sat')
-    @skip_if_bug_open('bugzilla', 1329292)
     @tier2
     def test_positive_update_contents(self):
         """Create a repository and upload RPM contents.
@@ -607,6 +607,7 @@ class RepositoryTestCase(APITestCase):
                     repo.read()
 
 
+@run_in_one_thread
 class RepositorySyncTestCase(APITestCase):
     """Tests for ``/katello/api/repositories/:id/sync``."""
 

--- a/tests/foreman/api/test_subscription.py
+++ b/tests/foreman/api/test_subscription.py
@@ -8,10 +8,11 @@ from nailgun import entities
 from nailgun.entity_mixins import TaskFailedError
 from robottelo.api.utils import upload_manifest
 from robottelo import manifests
-from robottelo.decorators import skip_if_not_set, tier1
+from robottelo.decorators import run_in_one_thread, skip_if_not_set, tier1
 from robottelo.test import APITestCase
 
 
+@run_in_one_thread
 class SubscriptionsTestCase(APITestCase):
     """Tests for the ``subscriptions`` path."""
 

--- a/tests/foreman/cli/test_satellitesync.py
+++ b/tests/foreman/cli/test_satellitesync.py
@@ -18,7 +18,13 @@ from robottelo.cli.repository import Repository
 from robottelo.cli.repository_set import RepositorySet
 from robottelo.cli.settings import Settings
 from robottelo.cli.subscription import Subscription
-from robottelo.decorators import run_only_on, skip_if_not_set, stubbed, tier3
+from robottelo.decorators import (
+    run_in_one_thread,
+    run_only_on,
+    skip_if_not_set,
+    stubbed,
+    tier3,
+)
 from robottelo.test import CLITestCase
 
 
@@ -130,6 +136,7 @@ class RepositoryExportTestCase(CLITestCase):
         self.assertEqual(result.return_code, 0)
         self.assertGreaterEqual(len(result.stdout), 1)
 
+    @run_in_one_thread
     @skip_if_not_set('fake_manifest')
     @tier3
     def test_positive_export_rh_product(self):

--- a/tests/foreman/longrun/test_oscap.py
+++ b/tests/foreman/longrun/test_oscap.py
@@ -19,13 +19,20 @@ from robottelo.constants import (
     REPOS,
     REPOSET,
 )
-from robottelo.decorators import run_only_on, skip_if_not_set, stubbed, tier4
+from robottelo.decorators import (
+    run_in_one_thread,
+    run_only_on,
+    skip_if_not_set,
+    stubbed,
+    tier4,
+)
 from robottelo.test import UITestCase
 from robottelo.ui.factory import set_context, make_hostgroup, make_oscappolicy
 from robottelo.ui.session import Session
 from robottelo.vm import VirtualMachine
 
 
+@run_in_one_thread
 class OpenScapTestCase(UITestCase):
     """Implements Product tests in UI"""
 

--- a/tests/foreman/rhai/test_rhai.py
+++ b/tests/foreman/rhai/test_rhai.py
@@ -7,7 +7,7 @@ from nailgun import entities
 from robottelo import manifests
 from robottelo.api.utils import upload_manifest
 from robottelo.constants import DEFAULT_SUBSCRIPTION_NAME
-from robottelo.decorators import skip_if_not_set
+from robottelo.decorators import run_in_one_thread, skip_if_not_set
 from robottelo.test import UITestCase
 from robottelo.ui.locators import locators
 from robottelo.ui.navigator import Navigator
@@ -15,6 +15,7 @@ from robottelo.ui.session import Session
 from robottelo.vm import VirtualMachine
 
 
+@run_in_one_thread
 class RHAITestCase(UITestCase):
 
     @classmethod

--- a/tests/foreman/rhai/test_rhai_client.py
+++ b/tests/foreman/rhai/test_rhai_client.py
@@ -5,11 +5,12 @@ from nailgun import entities
 from robottelo import manifests
 from robottelo.api.utils import upload_manifest
 from robottelo.constants import DEFAULT_SUBSCRIPTION_NAME
-from robottelo.decorators import skip_if_not_set
+from robottelo.decorators import run_in_one_thread, skip_if_not_set
 from robottelo.test import TestCase
 from robottelo.vm import VirtualMachine
 
 
+@run_in_one_thread
 class RHAIClientTestCase(TestCase):
 
     @classmethod

--- a/tests/foreman/ui/test_contentview.py
+++ b/tests/foreman/ui/test_contentview.py
@@ -128,7 +128,6 @@ class ContentViewTestCase(UITestCase):
                             name, self.organization.name))
                     self.assertIsNone(self.content_views.search(name))
 
-    @run_in_one_thread
     @run_only_on('sat')
     @tier2
     def test_positive_end_to_end(self):
@@ -175,7 +174,6 @@ class ContentViewTestCase(UITestCase):
             self.assertIsNotNone(self.content_views.wait_until_element
                                  (common_locators['alert.success_sub_form']))
 
-    @run_in_one_thread
     @run_only_on('sat')
     @tier2
     def test_positive_add_puppet_module(self):
@@ -238,7 +236,6 @@ class ContentViewTestCase(UITestCase):
             self.assertIsNone(self.content_views.search_filter(
                 cv_name, filter_name))
 
-    @run_in_one_thread
     @run_only_on('sat')
     @tier2
     def test_positive_add_package_filter(self):
@@ -273,7 +270,6 @@ class ContentViewTestCase(UITestCase):
                 [None, None, None, '4.6'],
             )
 
-    @run_in_one_thread
     @run_only_on('sat')
     @tier2
     def test_positive_add_package_group_filter(self):
@@ -307,7 +303,6 @@ class ContentViewTestCase(UITestCase):
             self.assertIsNotNone(self.content_views.wait_until_element(
                 common_locators['alert.success_sub_form']))
 
-    @run_in_one_thread
     @run_only_on('sat')
     @tier2
     def test_positive_add_errata_filter(self):
@@ -577,7 +572,6 @@ class ContentViewTestCase(UITestCase):
 
         """
 
-    @run_in_one_thread
     @run_only_on('sat')
     @tier2
     def test_positive_add_custom_content(self):
@@ -658,7 +652,6 @@ class ContentViewTestCase(UITestCase):
                     'selected view is composite'
                 )
 
-    @run_in_one_thread
     @run_only_on('sat')
     @tier2
     def test_negative_add_dupe_repos(self):
@@ -764,7 +757,6 @@ class ContentViewTestCase(UITestCase):
 
         """
 
-    @run_in_one_thread
     @run_only_on('sat')
     @tier2
     def test_positive_promote_with_custom_content(self):
@@ -889,7 +881,6 @@ class ContentViewTestCase(UITestCase):
 
         """
 
-    @run_in_one_thread
     @run_only_on('sat')
     @tier2
     def test_positive_publish_with_custom_content(self):
@@ -993,7 +984,6 @@ class ContentViewTestCase(UITestCase):
 
         """
 
-    @run_in_one_thread
     @run_only_on('sat')
     @tier2
     def test_positive_clone_within_same_env(self):

--- a/tests/foreman/ui/test_subscription.py
+++ b/tests/foreman/ui/test_subscription.py
@@ -2,12 +2,13 @@
 from nailgun import entities
 from robottelo import manifests
 from robottelo.constants import DEFAULT_SUBSCRIPTION_NAME
-from robottelo.decorators import skip_if_not_set, tier1
+from robottelo.decorators import run_in_one_thread, skip_if_not_set, tier1
 from robottelo.test import UITestCase
 from robottelo.ui.locators import common_locators
 from robottelo.ui.session import Session
 
 
+@run_in_one_thread
 class SubscriptionTestCase(UITestCase):
     """Implements subscriptions/manifests tests in UI"""
 


### PR DESCRIPTION
Latest automation results uncovered we're still facing some race condition issues when uploading manifests. As few of failed tests were already marked with `run_in_one_thread` decorator, that could only mean some of our subscription upload tests haven't been  marked yet and they're interfering with already marked ones.
Ran through the list of tests containing `upload(` or `manifests.clone()` and found few more tests which required update.
As a bonus - removed `run_in_one_thread` mark from some accidentally marked content view tests, which are working with custom repos, not RH ones so they don't use subscription upload.