### PR TITLE
Decorate auth repo sync test cases

### DIFF
--- a/tests/foreman/api/test_repository.py
+++ b/tests/foreman/api/test_repository.py
@@ -512,6 +512,7 @@ class RepositoryTestCase(APITestCase):
         self.assertGreaterEqual(repo.read().content_counts['rpm'], 1)
 
     @run_only_on('sat')
+    @skip_if_bug_open('bugzilla', 1328092)
     @tier2
     def test_positive_synchronize_auth_yum_repo(self):
         """Check if secured repository can be created and synced
@@ -538,6 +539,7 @@ class RepositoryTestCase(APITestCase):
                 self.assertGreaterEqual(repo.read().content_counts['rpm'], 1)
 
     @run_only_on('sat')
+    @skip_if_bug_open('bugzilla', 1328092)
     @tier2
     def test_negative_synchronize_auth_yum_repo(self):
         """Check if secured repo fails to synchronize with invalid credentials
@@ -563,6 +565,7 @@ class RepositoryTestCase(APITestCase):
                     repo.sync()
 
     @run_only_on('sat')
+    @skip_if_bug_open('bugzilla', 1328092)
     @tier2
     def test_positive_synchronize_auth_puppet_repo(self):
         """Check if secured puppet repository can be created and synced


### PR DESCRIPTION
It seems that defect will be fixed not so fast as we thought, so needs to decorate corresponding test cases