### PR TITLE
Mark all repository export tests as sequential ones

### DIFF
--- a/tests/foreman/cli/test_satellitesync.py
+++ b/tests/foreman/cli/test_satellitesync.py
@@ -28,6 +28,7 @@ from robottelo.decorators import (
 from robottelo.test import CLITestCase
 
 
+@run_in_one_thread
 class RepositoryExportTestCase(CLITestCase):
     """Tests for exporting a repository via CLI"""
 
@@ -136,7 +137,6 @@ class RepositoryExportTestCase(CLITestCase):
         self.assertEqual(result.return_code, 0)
         self.assertGreaterEqual(len(result.stdout), 1)
 
-    @run_in_one_thread
     @skip_if_not_set('fake_manifest')
     @tier3
     def test_positive_export_rh_product(self):


### PR DESCRIPTION
As #3541 which was merged yesterday marked one of two repo export tests with `run_in_one_thread`, they probably shouldn't interfere anymore, but

* as both tests are sharing the same setup, where they update `pulp_export_destination` dir, none of them shouldn't even potentially be considered as parallel test - if that setting gets updated when another repo export test is in progress, nothing will be exported into expected directory
* currently there're only two of them which are executed in different suites so we can't see the issue, but if another test is added - it will start failing on jenkins without obvious reason (as it will pass locally in 1 thread and will fail on jenkins with 'dir not found' error which is not descriptive at all)
* (bonus) right now setup (which is basically more like setupClass) is being executed for each test (once for 'parallel' test and once for sequential one), marking them both as sequential ones will make setup execute only once, so it's a small performance boost :)