### PR TITLE
Implement remaining UI bookmark stubs

### DIFF
--- a/robottelo/ui/locators.py
+++ b/robottelo/ui/locators.py
@@ -785,7 +785,7 @@ locators = LocatorDict({
     "bookmark.select_name": (
         By.XPATH,
         ("//td[following-sibling::td[text()='%s']]"
-         "/a[contains(@href,'bookmarks')][span[contains(.,'%s')]]")),
+         "/a[span[contains(.,'%s')]]")),
     "bookmark.new": (
         By.XPATH,
         ("//ul[contains(@class, 'dropdown-menu')]"
@@ -806,7 +806,7 @@ locators = LocatorDict({
     "bookmark.select_long_name": (
         By.XPATH,
         ("//td[following-sibling::td[text()='%s']]"
-         "/a[contains(@href,'bookmarks')][span[@data-original-title='%s']]")),
+         "/a[span[@data-original-title='%s']]")),
     "bookmark.delete": (
         By.XPATH,
         "//a[@class='delete' and contains(@data-confirm, '%s')]"),


### PR DESCRIPTION
```python
py.test tests/foreman/ui/test_bookmark.py -k 'test_positive_create_bookmark_public or test_positive_update_bookmark_public or test_negative_delete_bookmark'
================================ test session starts =================================
platform linux2 -- Python 2.7.10, pytest-2.9.2, py-1.4.31, pluggy-0.3.1
rootdir: /home/andrii/workspace/robottelo, inifile: 
plugins: xdist-1.13.1, repeat-0.2
collected 14 items 

tests/foreman/ui/test_bookmark.py ...

 11 tests deselected by '-ktest_positive_create_bookmark_public or test_positive_update_bookmark_public or test_negative_delete_bookmark' 
===================== 3 passed, 11 deselected in 190.90 seconds ======================
```