### PR TITLE
Writes a log file for each worker if running in multi threads closes #3536

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,8 @@
 /docs/robottelo.log
 /foreman-results.xml
 /robottelo.log
+/robottelo_gw*.log
+/robottelo_master.log
 /test-*.pstats
 /.tox
 /.coverage

--- a/Makefile
+++ b/Makefile
@@ -44,6 +44,9 @@ help:
 	@echo "  test-foreman-smoke         to perform a generic smoke test"
 	@echo "  graph-entities             to graph entity relationships"
 	@echo "  lint                       to run pylint on the entire codebase"
+	@echo "  logs-join                  to join xdist log files into one"
+	@echo "  logs-clean                 to delete all xdist log files in the root"
+	@echo "  pyc-clean                  to delete all temporary artifacts"
 
 docs:
 	@cd docs; $(MAKE) html
@@ -109,6 +112,18 @@ graph-entities:
 lint:
 	scripts/lint.py
 
+pyc-clean: ## remove Python file artifacts
+	find . -name '*.pyc' -exec rm -f {} +
+	find . -name '*.pyo' -exec rm -f {} +
+	find . -name '*~' -exec rm -f {} +
+	find . -name '__pycache__' -exec rm -fr {} +
+
+logs-join:
+	-cat robottelo_gw*.log > robottelo_master.log
+
+logs-clean:
+	-rm -f robottelo_gw*.log
+
 # Special Targets -------------------------------------------------------------
 
 .PHONY: help docs docs-clean test-docstrings test-robottelo \
@@ -116,4 +131,4 @@ lint:
         test-foreman-rhai test-foreman-rhci test-foreman-tier1 \
         test-foreman-tier2 test-foreman-tier3 test-foreman-tier4 \
         test-foreman-ui test-foreman-ui-xvfb test-foreman-smoke \
-        graph-entities lint
+        graph-entities lint logs-join logs-clean pyc-clean

--- a/conftest.py
+++ b/conftest.py
@@ -1,0 +1,13 @@
+# coding: utf-8
+"""Configurations for py.test runner"""
+import pytest
+
+
+@pytest.fixture(scope="session")
+def worker_id(request):
+    """Gets the worker ID when running in multi-threading with xdist"""
+    if hasattr(request.config, 'slaveinput'):
+        # return gw+(0..n)
+        return request.config.slaveinput['slaveid']
+    else:
+        return 'master'


### PR DESCRIPTION
When **py.test** runs in multithreading **-n** option we need to store a separate log file for each worker.

Also included a **make** helper to join all logs in to one at the end of the build.

```console
$ ls *.log
robottelo.log
robottelo_gw0.log
robottelo_gw1.log
robottelo_gw2.log
robottelo_gw3.log

$ make logs-join 
cat robottelo_gw*.log > robottelo_master.log

$ ls *.log
robottelo.log
robottelo_gw0.log
robottelo_gw1.log
robottelo_gw2.log
robottelo_gw3.log
robottelo_master.log

$ make logs-clean
rm robottelo_gw*.log

$ ls *.log
robottelo.log
robotello_master.log
```
The default **robottelo.log** is still being recorded and we should keep it because the **threaded** logs cannot get messages from **setUpClass** or another **pre-init** classmethods.

It closes #3536 