### PR TITLE
Implement some Docker UI stubs

### DIFF
--- a/robottelo/ui/computeresource.py
+++ b/robottelo/ui/computeresource.py
@@ -144,3 +144,14 @@ class ComputeResource(Base):
             locators['resource.delete'],
             drop_locator=locators['resource.dropdown'],
         )
+
+    def search_container(self, cr_name, container_name):
+        """Searches for specific container located in compute resource under
+        'Containers' tab
+        """
+        self.click(self.search(cr_name))
+        self.click(tab_locators['resource.tab_containers'])
+        self.text_field_update(
+            locators['resource.filter_containers'], container_name)
+        strategy, value = locators['resource.select_container']
+        return self.wait_until_element((strategy, value % container_name))

--- a/robottelo/ui/container.py
+++ b/robottelo/ui/container.py
@@ -101,6 +101,11 @@ class Container(Base):
                     parameter['sub_tab_name'] + ' Tab')
                 self.click(locators[current_tab])
                 self.assign_value(
+                    locators[
+                        self._form_locator_name(
+                            'registry.' + parameter['name'])
+                    ]
+                    if parameter['sub_tab_name'] == 'External registry' else
                     locators[self._form_locator_name(parameter['name'])],
                     parameter['value']
                 )

--- a/robottelo/ui/locators.py
+++ b/robottelo/ui/locators.py
@@ -645,6 +645,10 @@ tab_locators = LocatorDict({
         "contains(@ui-sref, 'host-collections.details.hosts.list')]"),
     "hostcollection.collection_actions": (
         By.XPATH, "//a[contains(@href, 'actions')]/span"),
+
+    # Compute resources
+    "resource.tab_containers": (
+        By.XPATH, "//a[@data-toggle='tab' and contains(@href, 'vms')]"),
 })
 
 common_locators = LocatorDict({
@@ -1013,6 +1017,12 @@ locators = LocatorDict({
          "/following::td/div/ul/li/a[@class='delete']")),
     "resource.edit": (
         By.XPATH, "//a[contains(@data-id,'edit') and contains(@href,'%s')]"),
+    "resource.filter_containers": (
+        By.XPATH, "//div[contains(@id, 'filter')]//input[@type='text']"),
+    "resource.select_container": (
+        By.XPATH,
+        ("//a[contains(@href, 'compute_resources/') and "
+         "contains(@href, 'vms/') and contains(., '%s')]")),
 
     # Hosts
 
@@ -2517,6 +2527,15 @@ locators = LocatorDict({
          "/span[contains(@class, 'arrow')]")),
     "container.docker_hub_tag": (
         By.ID, "hub_docker_container_wizard_states_image_tag"),
+    "container.registry.registry": (
+        By.XPATH,
+        ("//div[contains(@id, 'image_registry_id')]/a"
+         "/span[contains(@class, 'arrow')]")),
+    "container.registry.search": (
+        By.ID,
+        "registry_docker_container_wizard_states_image_repository_name"),
+    "container.registry.tag": (
+        By.ID, "registry_docker_container_wizard_states_image_tag"),
     "container.name": (
         By.ID, "docker_container_wizard_states_configuration_name"),
     "container.command": (


### PR DESCRIPTION
Depends on #3568 
```
py.test tests/foreman/ui/test_docker.py -k 'test_positive_search_docker_image or test_positive_list_containers or test_positive_create_with_external_registry' -v
================================ test session starts =================================
platform linux2 -- Python 2.7.10, pytest-2.9.2, py-1.4.31, pluggy-0.3.1 -- /home/andrii/env/bin/python
cachedir: .cache
rootdir: /home/andrii/workspace/robottelo, inifile: 
plugins: xdist-1.13.1, repeat-0.2
collected 44 items 

tests/foreman/ui/test_docker.py::DockerTagTestCase::test_positive_search_docker_image <- robottelo/decorators.py PASSED
tests/foreman/ui/test_docker.py::DockerComputeResourceTestCase::test_positive_list_containers PASSED
tests/foreman/ui/test_docker.py::DockerContainerTestCase::test_positive_create_with_external_registry <- robottelo/decorators.py PASSED

 41 tests deselected by '-ktest_positive_search_docker_image or test_positive_list_containers or test_positive_create_with_external_registry' 
===================== 3 passed, 41 deselected in 297.05 seconds ======================
```