### PR TITLE
PostUpgrade Verification APIs and Tests for Organization

### DIFF
--- a/robottelo.properties.sample
+++ b/robottelo.properties.sample
@@ -252,3 +252,8 @@ ssh_key=
 # The default libvirt image dir will be used
 # "/var/lib/libvirt/images/".
 # libvirt_image_dir=/var/lib/libvirt/images
+
+# Section for PostUpgrade Verification Tests
+# [upgrade]
+# Option for providing a preUpgrade yaml data file location on server
+# upgrade_data=

--- a/robottelo/config/settings.py
+++ b/robottelo/config/settings.py
@@ -529,6 +529,23 @@ class VlanNetworkSettings(FeatureSettings):
         return validation_errors
 
 
+class UpgradeSettings(FeatureSettings):
+    """Satellite upgrade settings definitions."""
+    def __init__(self, *args, **kwargs):
+        super(UpgradeSettings, self).__init__(*args, **kwargs)
+        self.upgrade_data = None
+
+    def read(self, reader):
+        """Read and validate Satellite server settings."""
+        self.upgrade_data = reader.get('upgrade', 'upgrade_data')
+
+    def validate(self):
+        validation_errors = []
+        if self.upgrade_data is None:
+            validation_errors.append('[upgrade] data must be provided.')
+        return validation_errors
+
+
 class Settings(object):
     """Robottelo's settings representation."""
 
@@ -565,6 +582,7 @@ class Settings(object):
         self.rhai = RHAISettings()
         self.transition = TransitionSettings()
         self.vlan_networking = VlanNetworkSettings()
+        self.upgrade = UpgradeSettings()
 
     def configure(self):
         """Read the settings file and parse the configuration.
@@ -621,6 +639,9 @@ class Settings(object):
         if self.reader.has_section('vlan_networking'):
             self.vlan_networking.read(self.reader)
             self._validation_errors.extend(self.vlan_networking.validate())
+        if self.reader.has_section('upgrade'):
+            self.upgrade.read(self.reader)
+            self._validation_errors.extend(self.upgrade.validate())
 
         if self._validation_errors:
             raise ImproperlyConfigured(

--- a/robottelo/datafactory.py
+++ b/robottelo/datafactory.py
@@ -4,10 +4,10 @@ import random
 
 from functools import wraps
 from fauxfactory import gen_string, gen_integer
-
 from robottelo.config import settings
 from robottelo.constants import STRING_TYPES
 from robottelo.decorators import bz_bug_is_open
+from robottelo.upgrade import get_all_yaml_data, get_yaml_field_value
 from six.moves.urllib.parse import quote_plus
 
 
@@ -428,3 +428,35 @@ def invalid_http_credentials(url_encoded=False):
                 for cred in credentials]
     else:
         return credentials
+
+
+@filtered_datapoint
+def get_valid_preupgrade_data(test_entity, field):
+    """Returns valid list of tuples for given test_entity and field from
+    preUpgrade YAML file
+
+    :param str test_entity: The test_entity name in YAML file
+        e.g. Organization-Tests to check it exists and its associations
+    :param str field: Field name in YAML for which the test created
+        e.g. name to check if the test_entity exists by name
+        e.g. smart-proxy to check association with test_entity
+    :return: List of tuples. Tuple containing pair of SubEntity, field_value
+        e.g. [('Default Organization',2),('another_org',5)], where 2 and 5 are
+        ids(field) of two mentioned orgs(subEntity)
+    """
+    datalist = []
+    test_entity = test_entity.lower()
+    field = field.lower()
+    for entity in get_all_yaml_data()[test_entity].keys():
+        field_data = get_yaml_field_value(test_entity, entity, field)
+        if field_data is None:
+            continue
+        elif type(field_data) == list:
+            for value in field_data:
+                datalist.append((entity, value))
+        else:
+            datalist.append((entity, field_data))
+    if not datalist:
+        raise InvalidArgumentError('No such field/test \'{0}\' exists in YAML'
+                                   'file under {1}'.format(field, test_entity))
+    return datalist

--- a/robottelo/upgrade/__init__.py
+++ b/robottelo/upgrade/__init__.py
@@ -1,0 +1,37 @@
+# -*- encoding: utf-8 -*-
+"""Implements Upgrade functions."""
+import yaml
+
+from robottelo.config import settings
+from robottelo.helpers import download_server_file
+
+
+def get_all_yaml_data():
+    """Downloads and fetches all data from YAML file.
+
+    :return: Dict type contains data fetched from yaml in the form of
+        {node:{subnode:{fields:data}}}
+    """
+    yaml_path = download_server_file('yml', settings.upgrade.upgrade_data)
+    with open(yaml_path) as handler:
+        yamldata = yaml.load(handler)
+    return yamldata
+
+
+def get_yaml_field_value(section, subsection, field, default=None):
+    """Fetches field value from dict format of yaml file
+
+    :param str section: Topmost section of yaml file
+    :param str subsection: Second most section under top of yaml file
+    :param str field: Field under second most section of yaml file of which
+        value will be fetched
+    :return: String/List for given field e.g id of org
+    """
+    try:
+        yamldata = get_all_yaml_data()
+        if field not in yamldata[section][subsection]:
+            return
+        result = yamldata[section][subsection][field]
+    except KeyError:
+        result = default
+    return result

--- a/setup.py
+++ b/setup.py
@@ -26,6 +26,7 @@ setup(
         'pygal',
         'pytest',
         'python-bugzilla',
+        'PyYAML',
         'requests',
         'selenium<2.49',
         'six',

--- a/tests/foreman/upgrade/test_organization.py
+++ b/tests/foreman/upgrade/test_organization.py
@@ -1,0 +1,96 @@
+# -*- encoding: utf-8 -*-
+
+"""Test class for Organization PostUpgrade
+
+@Requirement: Organization
+
+@CaseAutomation: Automated
+
+@CaseLevel: Acceptance
+
+@CaseComponent: CLI
+
+@TestType: Upgrade
+
+@CaseImportance: High
+
+@Upstream: No
+"""
+from robottelo.cli.org import Org
+from robottelo.datafactory import get_valid_preupgrade_data
+from robottelo.decorators import tier1
+from robottelo.test import CLITestCase
+
+
+class OrganizationTestCase(CLITestCase):
+    """Tests for Post Upgrade Organizations verification via Hammer CLI"""
+
+    @tier1
+    def test_positive_exits_org_by_id(self):
+        """Test whether the Organization exists on Post Upgrade - id
+
+        @id: da2821d0-1ea2-423d-8172-7372c98d8858
+
+        @assert: Organization by id exists post Upgrade
+        """
+        for org, org_id in get_valid_preupgrade_data(
+                'organization-tests', 'id'):
+            with self.subTest(org_id):
+                result = Org.exists(search=('name', org))
+                self.assertEqual(str(org_id), result['id'])
+
+    @tier1
+    def test_positive_exists_org_by_name(self):
+        """Test whether the Organization exists on Post Upgrade - name
+
+        @id: 639c3fec-ed5d-4c05-a301-801e3b47efb8
+
+        @assert: Organization by name exists post Upgrade
+        """
+        for org, org_name in get_valid_preupgrade_data(
+                'organization-tests', 'name'):
+            with self.subTest(org_name):
+                result = Org.exists(search=('name', org))
+                self.assertEqual(org_name, result['name'])
+
+    @tier1
+    def test_positive_association_org_smart_proxy(self):
+        """Test Smart Proxy is associated with Organization
+
+        @id: 9986ec9d-b37c-482c-9bb1-7c25f6bfd34c
+
+        @assert: Smart Proxy is associated with Organization
+        """
+        for org, sp in get_valid_preupgrade_data(
+                'organization-tests', 'smart-proxy'):
+            with self.subTest(sp):
+                result = Org.info({'name': org})
+                self.assertIn(sp, result['smart-proxies'])
+
+    @tier1
+    def test_positive_association_org_template(self):
+        """Test Template is associated with Organization
+
+        @id: 2c8a6362-f95f-4aec-bc63-57242a639167
+
+        @assert: Template is associated with Organization
+        """
+        for org, template in get_valid_preupgrade_data(
+                'organization-tests', 'template'):
+            with self.subTest(template):
+                result = Org.info({'name': org})
+                self.assertIn(template, result['templates'])
+
+    @tier1
+    def test_positive_association_org_puppet_environment(self):
+        """Test Puppet Environment is associated with Organization
+
+        @id: 12c6d711-c6d6-4bcb-9e24-01cadb205f7b
+
+        @assert: Puppet Environment is associated with Organization
+        """
+        for org, penv in get_valid_preupgrade_data(
+                'organization-tests', 'Puppet-Environments'):
+            with self.subTest(penv):
+                result = Org.info({'name': org})
+                self.assertIn(penv, result['environments'])


### PR DESCRIPTION
This PR contains:
1. API, Settings_module updates related to PostUpgrade Verification
2. Basic tests for PostUpgrade verification of Organization entity. Later will be added more.

Also, more tests and modules will be added under tests/foreman/upgrade/ for all other entities.