### PR TITLE
Implement UI host unification tests

### DIFF
--- a/docs/api/robottelo.ui.rst
+++ b/docs/api/robottelo.ui.rst
@@ -38,6 +38,11 @@
 
 .. automodule:: robottelo.ui.container
 
+:mod:`robottelo.ui.contenthost`
+-------------------------------
+
+.. automodule:: robottelo.ui.contenthost
+
 :mod:`robottelo.ui.contentviews`
 --------------------------------
 

--- a/docs/api/tests.foreman.ui.rst
+++ b/docs/api/tests.foreman.ui.rst
@@ -94,7 +94,7 @@
 .. automodule:: tests.foreman.ui.test_host
 
 :mod:`tests.foreman.ui.test_hostunification`
-----------------------------------------------------
+--------------------------------------------
 
 .. automodule:: tests.foreman.ui.test_hostunification
 

--- a/robottelo/test.py
+++ b/robottelo/test.py
@@ -48,6 +48,7 @@ from robottelo.ui.computeprofile import ComputeProfile
 from robottelo.ui.computeresource import ComputeResource
 from robottelo.ui.configgroups import ConfigGroups
 from robottelo.ui.container import Container
+from robottelo.ui.contenthost import ContentHost
 from robottelo.ui.contentviews import ContentViews
 from robottelo.ui.discoveredhosts import DiscoveredHosts
 from robottelo.ui.discoveryrules import DiscoveryRules
@@ -267,6 +268,7 @@ class UITestCase(TestCase):
         self.container = Container(self.browser)
         self.compute_profile = ComputeProfile(self.browser)
         self.compute_resource = ComputeResource(self.browser)
+        self.contenthost = ContentHost(self.browser)
         self.configgroups = ConfigGroups(self.browser)
         self.content_views = ContentViews(self.browser)
         self.dockertag = DockerTag(self.browser)

--- a/robottelo/ui/contenthost.py
+++ b/robottelo/ui/contenthost.py
@@ -1,0 +1,91 @@
+"""Utilities to manipulate content hosts via UI."""
+from robottelo.ui.base import Base, UIError
+from robottelo.ui.locators import common_locators, locators, tab_locators
+from robottelo.ui.navigator import Navigator
+
+
+class ContentHost(Base):
+    """Manipulates Content Hosts from UI"""
+    is_katello = True
+
+    def navigate_to_entity(self):
+        """Navigate to Content Hosts entity page"""
+        Navigator(self.browser).go_to_content_hosts()
+
+    def _search_locator(self):
+        """Specify locator for Content Hosts entity search procedure"""
+        return locators['contenthost.select_name']
+
+    def add_subscriptions(self, subscriptions=None, tab_locator=None,
+                          select_locator=None):
+        """Add or remove subscription association for content host."""
+        strategy, value = locators['contenthost.subscription_select']
+        self.click(tab_locators['contenthost.tab_subscriptions'])
+        self.click(tab_locators['contenthost.tab_subscriptions_subscriptions'])
+        if not self.wait_until_element(tab_locator):
+            raise UIError('Can not manage subscriptions for content host.'
+                          'Make sure content host is registered')
+        self.click(tab_locators['contenthost.add_subscription'])
+        for subscription in subscriptions:
+            self.click(strategy, value % subscription)
+        self.click(select_locator)
+
+    def update(self, name, new_name=None, add_subscriptions=None,
+               rm_subscriptions=None):
+        """Updates an existing content host"""
+        self.click(self.search(name))
+        self.click(tab_locators['contenthost.tab_details'])
+
+        if new_name:
+            self.edit_entity(
+                locators['contenthost.edit_name'],
+                locators['contenthost.edit_name_text'],
+                new_name,
+                locators['contenthost.save_name'],
+            )
+        if add_subscriptions:
+            self.add_subscriptions(
+                subscriptions=add_subscriptions,
+                tab_locator=tab_locators['contenthost.add_subscription'],
+                select_locator=locators['contenthost.add_selected'],
+            )
+        if rm_subscriptions:
+            self.add_subscriptions(
+                subscriptions=add_subscriptions,
+                tab_locator=tab_locators['contenthost.list_subscriptions'],
+                select_locator=locators['contenthost.remove_selected'],
+            )
+
+    def unregister(self, name, really=True):
+        """Unregisters a content host."""
+        self.click(self.search(name))
+        self.click(locators['contenthost.unregister'])
+        if really:
+            self.click(common_locators['confirm_remove'])
+        else:
+            self.click(common_locators['cancel'])
+
+    def validate_subscription_status(self, name, expected_value=True,
+                                     timeout=120):
+        """Check whether a content host has active subscription or not"""
+        for _ in range(timeout / 5):
+            self.search(name)
+            strategy, value = (
+                locators['contenthost.subscription_active'] if expected_value
+                else locators['contenthost.subscription_not_active']
+            )
+            result = self.wait_until_element(
+                (strategy, value % name), timeout=5)
+            if result:
+                return True
+        return False
+
+    def install_package(self, name, package_name):
+        """Remotely install package to content host"""
+        self.click(self.search(name))
+        self.click(tab_locators['contenthost.tab_packages'])
+        self.assign_value(
+            locators['contenthost.remote_actions'], 'Package Install')
+        self.assign_value(
+            locators['contenthost.package_name_input'], package_name)
+        self.click(locators['contenthost.perform_remote_action'])

--- a/robottelo/ui/locators.py
+++ b/robottelo/ui/locators.py
@@ -546,6 +546,30 @@ tab_locators = LocatorDict({
     "contentviews.tab_remove": (
         By.XPATH, "//a[contains(@ui-sref, 'list')]"),
 
+    # Content Hosts
+    # Third level UI
+    "contenthost.tab_details": (
+        By.XPATH, "//a[@class='ng-scope' and contains(@href,'info')]"),
+    "contenthost.tab_subscriptions": (
+        By.XPATH,
+        ("//li[@class='dropdown' and contains(@ng-class, "
+         "'content-hosts.details.subscriptions.list')]/a")),
+    "contenthost.tab_subscriptions_subscriptions": (
+        By.XPATH,
+        "//a[@class='ng-scope' and contains(@href,'subscriptions')]"),
+    "contenthost.tab_packages": (
+        By.XPATH,
+        "//a[@class='ng-scope' and contains(@href,'packages')]"),
+    # Fourth level UI
+    "contenthost.list_subscriptions": (
+        By.XPATH,
+        ("//a[contains(@ui-sref,'subscriptions.list')]"
+         "/span[@class='ng-scope']")),
+    "contenthost.add_subscription": (
+        By.XPATH,
+        ("//a[contains(@ui-sref,'subscriptions.add')]"
+         "/span[@class='ng-scope']")),
+
     # Sync Plans
     # Third level UI
     "sp.tab_details": (
@@ -1027,6 +1051,47 @@ locators = LocatorDict({
         By.XPATH,
         ("//a[contains(@href, 'compute_resources/') and "
          "contains(@href, 'vms/') and contains(., '%s')]")),
+
+    # Content Hosts
+    "contenthost.select_name": (
+       By.XPATH, "//a[contains(@href, 'content_hosts') and contains(.,'%s')]"),
+    "contenthost.edit_name": (
+        By.XPATH, "//form[@bst-edit-text='host.name']//div/span/i"),
+    "contenthost.edit_name_text": (
+        By.XPATH,
+        "//form[@bst-edit-text='host.name']/div/input"),
+    "contenthost.save_name": (
+        By.XPATH,
+        "//form[@bst-edit-text='host.name']//button[@ng-click='save()']"),
+    "contenthost.unregister": (
+        By.XPATH, "//button[@ng-disabled='host.deleting']"),
+    "contenthost.subscription_active": (
+        By.XPATH,
+        ("//td[a[contains(@href, 'content_hosts') and contains(.,'%s')]]"
+         "/following-sibling::td/span[contains(@ng-class, "
+         "'host.subscription_status') and  contains(@class, 'green')]")),
+    "contenthost.subscription_not_active": (
+        By.XPATH,
+        ("//td[a[contains(@href, 'content_hosts') and contains(.,'%s')]]"
+         "/following-sibling::td/span[contains(@ng-class, "
+         "'host.subscription_status') and  contains(@class, 'red')]")),
+    "contenthost.subscription_select": (
+        By.XPATH,
+        ("//tr[//a[contains(@href,'info') and contains(.,'%s')]]"
+         "/following-sibling::tr[1]/td/input[@type='checkbox']")),
+    "contenthost.add_selected": (
+        By.XPATH, "//button[contains(@ng-click, 'addSelected()')]"),
+    "contenthost.remove_selected": (
+        By.XPATH, "//button[contains(@ng-click, 'removeSelected()')]"),
+    "contenthost.remote_actions": (
+        By.XPATH, "//select[@name='remote_action']"),
+    "contenthost.package_name_input": (
+        By.XPATH,
+        "//input[@type='text' and contains(@ng-model, 'packageAction')]"),
+    "contenthost.perform_remote_action": (
+        By.XPATH,
+        ("//form[@ng-submit='performPackageAction()']"
+         "//button[contains(@class, 'ng-scope')]")),
 
     # Hosts
 

--- a/tests/foreman/cli/test_activationkey.py
+++ b/tests/foreman/cli/test_activationkey.py
@@ -554,11 +554,11 @@ class ActivationKeyTestCase(CLITestCase):
             with VirtualMachine(distro='rhel65') as vm2:
                 vm1.install_katello_ca()
                 result = vm1.register_contenthost(
-                    new_ak['name'], self.org['label'])
+                    self.org['label'], new_ak['name'])
                 self.assertEqual(result.return_code, 0)
                 vm2.install_katello_ca()
                 result = vm2.register_contenthost(
-                    new_ak['name'], self.org['label'])
+                    self.org['label'], new_ak['name'])
                 self.assertEqual(result.return_code, 255)
                 self.assertGreater(len(result.stderr), 0)
 
@@ -777,7 +777,7 @@ class ActivationKeyTestCase(CLITestCase):
             vm.install_katello_ca()
             for i in range(2):
                 result = vm.register_contenthost(
-                    new_aks[i]['name'], self.org['label'])
+                    self.org['label'], new_aks[i]['name'])
                 self.assertEqual(result.return_code, 0)
 
     @skip_if_not_set('clients')

--- a/tests/foreman/cli/test_contenthost.py
+++ b/tests/foreman/cli/test_contenthost.py
@@ -414,12 +414,12 @@ class ContentHostTestCase(CLITestCase):
         with VirtualMachine(distro='rhel71') as client:
             client.install_katello_ca()
             client.register_contenthost(
-                activation_key['name'],
                 self.NEW_ORG['label'],
+                activation_key['name'],
             )
             result = client.register_contenthost(
-                activation_key['name'],
                 self.NEW_ORG['label'],
+                activation_key['name'],
                 force=False,
             )
             # Depending on distro version, successful return_code may be 0 or
@@ -446,8 +446,8 @@ class ContentHostTestCase(CLITestCase):
         with VirtualMachine(distro='rhel71') as client:
             client.install_katello_ca()
             client.register_contenthost(
-                activation_key['name'],
                 self.NEW_ORG['label'],
+                activation_key['name'],
             )
             result = ContentHost.list({
                 'organization-id': self.NEW_ORG['id'],
@@ -475,8 +475,8 @@ class ContentHostTestCase(CLITestCase):
         with VirtualMachine(distro='rhel71') as client:
             client.install_katello_ca()
             client.register_contenthost(
-                activation_key['name'],
                 self.NEW_ORG['label'],
+                activation_key['name'],
             )
             result = ContentHost.list({
                 'organization-id': self.NEW_ORG['id'],

--- a/tests/foreman/cli/test_host.py
+++ b/tests/foreman/cli/test_host.py
@@ -945,8 +945,8 @@ class KatelloAgentTestCase(CLITestCase):
         self.client.install_katello_ca()
         # Register content host, install katello-agent
         self.client.register_contenthost(
+            KatelloAgentTestCase.org['label'],
             KatelloAgentTestCase.activation_key['name'],
-            KatelloAgentTestCase.org['label']
         )
         self.host = Host.info({'name': self.client.hostname})
         self.client.enable_repo(REPOS['rhst7']['id'])

--- a/tests/foreman/endtoend/test_ui_endtoend.py
+++ b/tests/foreman/endtoend/test_ui_endtoend.py
@@ -436,7 +436,7 @@ class EndToEndTestCase(UITestCase, ClientProvisioningMixin):
             # Create VM
             with VirtualMachine(distro='rhel67') as vm:
                 vm.install_katello_ca()
-                vm.register_contenthost(activation_key_name, org_name)
+                vm.register_contenthost(org_name, activation_key_name)
                 vm.configure_puppet(rhel6_repo)
                 host = vm.hostname
                 set_context(session, org=ANY_CONTEXT['org'])

--- a/tests/foreman/endtoend/utils.py
+++ b/tests/foreman/endtoend/utils.py
@@ -30,7 +30,7 @@ class ClientProvisioningMixin(object):
             vm.install_katello_ca()
             # Register client with foreman server using act keys
             result = vm.register_contenthost(
-                activation_key_name, organization_label)
+                organization_label, activation_key_name)
             self.assertEqual(result.return_code, 0)
             # Install rpm on client
             result = vm.run('yum install -y {0}'.format(package_name))

--- a/tests/foreman/longrun/test_inc_updates.py
+++ b/tests/foreman/longrun/test_inc_updates.py
@@ -231,8 +231,8 @@ class IncrementalUpdateTestCase(TestCase):
 
         # Register content host, install katello-agent
         result = client.register_contenthost(
-            act_key,
             org_name,
+            act_key,
             releasever='6.7'
         )
         assert result.return_code == 0

--- a/tests/foreman/longrun/test_oscap.py
+++ b/tests/foreman/longrun/test_oscap.py
@@ -223,7 +223,7 @@ class OpenScapTestCase(UITestCase):
                 with VirtualMachine(distro=value['distro']) as vm:
                     host = vm.hostname
                     vm.install_katello_ca()
-                    vm.register_contenthost(self.ak_name, self.org_name)
+                    vm.register_contenthost(self.org_name, self.ak_name)
                     vm.configure_puppet(value['rhel_repo'])
                     session.nav.go_to_hosts()
                     set_context(session, org=ANY_CONTEXT['org'])
@@ -252,7 +252,7 @@ class OpenScapTestCase(UITestCase):
                     self.assertEqual(result.return_code, 0)
                     # BZ 1259188 , required till CH and Hosts unification.
                     # We need to re-register because of above bug and FE
-                    vm.register_contenthost(self.ak_name, self.org_name)
+                    vm.register_contenthost(self.org_name, self.ak_name)
                     # Runs the actual oscap scan on the vm/clients and
                     # uploads report to Internal Capsule.
                     vm.execute_foreman_scap_client()

--- a/tests/foreman/ui/test_activationkey.py
+++ b/tests/foreman/ui/test_activationkey.py
@@ -439,7 +439,7 @@ class ActivationKeyTestCase(UITestCase):
                 common_locators['alert.success_sub_form']))
             with VirtualMachine(distro=self.vm_distro) as vm:
                 vm.install_katello_ca()
-                result = vm.register_contenthost(name, self.organization.label)
+                result = vm.register_contenthost(self.organization.label, name)
                 self.assertEqual(result.return_code, 0)
                 self.activationkey.delete(name)
 
@@ -797,11 +797,11 @@ class ActivationKeyTestCase(UITestCase):
                 with VirtualMachine(distro=self.vm_distro) as vm2:
                     vm1.install_katello_ca()
                     result = vm1.register_contenthost(
-                        name, self.organization.label)
+                        self.organization.label, name)
                     self.assertEqual(result.return_code, 0)
                     vm2.install_katello_ca()
                     result = vm2.register_contenthost(
-                        name, self.organization.label)
+                        self.organization.label, name)
                     self.assertNotEqual(result.return_code, 0)
                     self.assertGreater(len(result.stderr), 0)
                     self.assertIn(
@@ -838,7 +838,7 @@ class ActivationKeyTestCase(UITestCase):
             # Creating VM
             with VirtualMachine(distro=self.vm_distro) as vm:
                 vm.install_katello_ca()
-                vm.register_contenthost(key_name, self.organization.label)
+                vm.register_contenthost(self.organization.label, key_name)
                 name = self.activationkey.fetch_associated_content_host(
                     key_name)
                 self.assertEqual(vm.hostname, name)
@@ -1107,8 +1107,8 @@ class ActivationKeyTestCase(UITestCase):
             with VirtualMachine(distro=self.vm_distro) as vm:
                 vm.install_katello_ca()
                 result = vm.register_contenthost(
+                    self.organization.label,
                     '{0},{1}'.format(key_1_name, key_2_name),
-                    self.organization.label
                 )
                 self.assertEqual(result.return_code, 0)
                 # Assert the content-host association with activation-key


### PR DESCRIPTION
This PR:
* Implements all the host unification stubs we have
* Adds Content Host UI entity (as it's required for host unification tests)
* updates `VM.register_contenthost()` method to register content host not only by organization name + activation key, but also by credentials+organization+environment name

Tests results:
```python
py.test tests/foreman/ui/test_hostunification.py -n 2 -v
============================= test session starts ==============================
platform linux2 -- Python 2.7.10, pytest-2.9.2, py-1.4.31, pluggy-0.3.1 -- /home/andrii/env/bin/python
cachedir: .cache
rootdir: /home/andrii/workspace/robottelo, inifile: 
plugins: xdist-1.13.1, repeat-0.2
gw0 I / gw1 I
[gw0] linux2 Python 2.7.10 cwd: /home/andrii/workspace/robottelo
[gw1] linux2 Python 2.7.10 cwd: /home/andrii/workspace/robottelo
[gw0] Python 2.7.10 (default, Sep  8 2015, 17:20:17)  -- [GCC 5.1.1 20150618 (Red Hat 5.1.1-4)]
[gw1] Python 2.7.10 (default, Sep  8 2015, 17:20:17)  -- [GCC 5.1.1 20150618 (Red Hat 5.1.1-4)]
gw0 [10] / gw1 [10]

scheduling tests via LoadScheduling

tests/foreman/ui/test_hostunification.py::HostContentHostUnificationTestCase::test_positive_delete_from_allhosts <- robottelo/decorators.py 
tests/foreman/ui/test_hostunification.py::HostContentHostUnificationTestCase::test_negative_add_contents_to_unregistered_host <- robottelo/decorators.py 
[gw0] PASSED tests/foreman/ui/test_hostunification.py::HostContentHostUnificationTestCase::test_negative_add_contents_to_unregistered_host <- robottelo/decorators.py 
tests/foreman/ui/test_hostunification.py::HostContentHostUnificationTestCase::test_negative_add_subs_to_unregistered_host <- robottelo/decorators.py 
[gw0] PASSED tests/foreman/ui/test_hostunification.py::HostContentHostUnificationTestCase::test_negative_add_subs_to_unregistered_host <- robottelo/decorators.py 
tests/foreman/ui/test_hostunification.py::HostContentHostUnificationTestCase::test_positive_re_register_host <- robottelo/decorators.py 
[gw1] PASSED tests/foreman/ui/test_hostunification.py::HostContentHostUnificationTestCase::test_positive_delete_from_allhosts <- robottelo/decorators.py 
tests/foreman/ui/test_hostunification.py::HostContentHostUnificationTestCase::test_positive_provision_foreman_host <- robottelo/decorators.py 
[gw1] PASSED tests/foreman/ui/test_hostunification.py::HostContentHostUnificationTestCase::test_positive_provision_foreman_host <- robottelo/decorators.py 
tests/foreman/ui/test_hostunification.py::HostContentHostUnificationTestCase::test_positive_register_host_via_rhsm <- robottelo/decorators.py 
[gw1] PASSED tests/foreman/ui/test_hostunification.py::HostContentHostUnificationTestCase::test_positive_register_host_via_rhsm <- robottelo/decorators.py 
tests/foreman/ui/test_hostunification.py::HostContentHostUnificationTestCase::test_positive_rename_content_host <- robottelo/decorators.py 
[gw0] PASSED tests/foreman/ui/test_hostunification.py::HostContentHostUnificationTestCase::test_positive_re_register_host <- robottelo/decorators.py 
tests/foreman/ui/test_hostunification.py::HostContentHostUnificationTestCase::test_positive_register_host_via_ak <- robottelo/decorators.py 
[gw1] PASSED tests/foreman/ui/test_hostunification.py::HostContentHostUnificationTestCase::test_positive_rename_content_host <- robottelo/decorators.py 
[gw0] PASSED tests/foreman/ui/test_hostunification.py::HostContentHostUnificationTestCase::test_positive_register_host_via_ak <- robottelo/decorators.py 
tests/foreman/ui/test_hostunification.py::HostContentHostUnificationTestCase::test_positive_rename_foreman_host <- robottelo/decorators.py 
tests/foreman/ui/test_hostunification.py::HostContentHostUnificationTestCase::test_positive_unregister_content_host <- robottelo/decorators.py 
[gw1] PASSED tests/foreman/ui/test_hostunification.py::HostContentHostUnificationTestCase::test_positive_rename_foreman_host <- robottelo/decorators.py 
[gw0] PASSED tests/foreman/ui/test_hostunification.py::HostContentHostUnificationTestCase::test_positive_unregister_content_host <- robottelo/decorators.py 

========================= 10 passed in 747.54 seconds ==========================
```