### PR TITLE
Move external registry urls to properties file

### DIFF
--- a/robottelo.properties.sample
+++ b/robottelo.properties.sample
@@ -141,6 +141,12 @@ ssh_key=
 # in other words, the daemon is initialized with `--host tcp://0.0.0.0:<port>`.
 # This will be used by tests that test external docker daemon.
 # external_url=http://localhost:2375
+# These will be used by tests that exercise external docker registries. Second
+# one will be used by tests that validate updating from one docker registry url
+# to another
+# External docker registries urls in the format http[s]://<server>[:<port>].
+# external_registry_1=
+# external_registry_2=
 
 
 # For testing Red Hat Access Insights

--- a/robottelo/cli/factory.py
+++ b/robottelo/cli/factory.py
@@ -50,9 +50,9 @@ from robottelo.cli.syncplan import SyncPlan
 from robottelo.cli.template import Template
 from robottelo.cli.user import User
 from robottelo.cli.usergroup import UserGroup, UserGroupExternal
+from robottelo.config import settings
 from robottelo.constants import (
     DEFAULT_SUBSCRIPTION_NAME,
-    DOCKER_0_EXTERNAL_REGISTRY,
     FAKE_1_YUM_REPO,
     FOREMAN_PROVIDERS,
     OPERATING_SYSTEMS,
@@ -648,7 +648,7 @@ def make_registry(options=None):
         u'description': None,
         u'name': gen_string('alphanumeric'),
         u'password': None,
-        u'url': DOCKER_0_EXTERNAL_REGISTRY,
+        u'url': settings.docker.external_registry_1,
         u'username': None,
     }
 

--- a/robottelo/config/settings.py
+++ b/robottelo/config/settings.py
@@ -248,20 +248,28 @@ class DockerSettings(FeatureSettings):
         super(DockerSettings, self).__init__(*args, **kwargs)
         self.unix_socket = None
         self.external_url = None
+        self.external_registry_1 = None
+        self.external_registry_2 = None
 
     def read(self, reader):
         """Read docker settings."""
         self.unix_socket = reader.get(
             'docker', 'unix_socket', False, bool)
         self.external_url = reader.get('docker', 'external_url')
+        self.external_registry_1 = reader.get('docker', 'external_registry_1')
+        self.external_registry_2 = reader.get('docker', 'external_registry_2')
 
     def validate(self):
         """Validate docker settings."""
         validation_errors = []
-        if not any(vars(self).values()):
+        if not any((self.unix_socket, self.external_url)):
             validation_errors.append(
                 'Either [docker] unix_socket or external_url options must '
                 'be provided or enabled.')
+        if not all((self.external_registry_1, self.external_registry_2)):
+            validation_errors.append(
+                'Both [docker] external_registry_1 and external_registry_2 '
+                'options must be provided.')
         return validation_errors
 
     def get_unix_socket_url(self):

--- a/robottelo/constants.py
+++ b/robottelo/constants.py
@@ -289,8 +289,6 @@ FILTER_TYPE = {'include': "Include",
                'exclude': "Exclude"}
 
 DOCKER_REGISTRY_HUB = u'https://registry-1.docker.io'
-DOCKER_0_EXTERNAL_REGISTRY = u'https://registry.access.redhat.com'
-DOCKER_1_EXTERNAL_REGISTRY = u'http://satqe-docker-registry.usersys.redhat.com:5000/'  # noqa
 GOOGLE_CHROME_REPO = u'http://dl.google.com/linux/chrome/rpm/stable/x86_64'
 FAKE_0_YUM_REPO = u'http://inecas.fedorapeople.org/fakerepos/zoo/'
 FAKE_1_YUM_REPO = u'http://inecas.fedorapeople.org/fakerepos/zoo3/'

--- a/tests/foreman/api/test_docker.py
+++ b/tests/foreman/api/test_docker.py
@@ -21,11 +21,7 @@ from random import choice, randint, shuffle
 from requests.exceptions import HTTPError
 from robottelo.api.utils import promote
 from robottelo.config import settings
-from robottelo.constants import (
-    DOCKER_REGISTRY_HUB,
-    DOCKER_0_EXTERNAL_REGISTRY,
-    DOCKER_1_EXTERNAL_REGISTRY,
-)
+from robottelo.constants import DOCKER_REGISTRY_HUB
 from robottelo.datafactory import (
     datacheck,
     generate_strings_list,
@@ -1346,7 +1342,8 @@ class DockerContainerTestCase(APITestCase):
         @CaseLevel: Integration
         """
         repo_name = 'rhel'
-        registry = entities.Registry(url=DOCKER_0_EXTERNAL_REGISTRY).create()
+        registry = entities.Registry(
+            url=settings.docker.external_registry_1).create()
         try:
             compute_resource = entities.DockerComputeResource(
                 organization=[self.org],
@@ -1390,7 +1387,15 @@ class DockerRegistryTestCase(APITestCase):
     """Tests specific to performing CRUD methods against ``Registries``
     repositories.
     """
-    url = DOCKER_0_EXTERNAL_REGISTRY
+
+    @classmethod
+    @skip_if_not_set('docker')
+    def setUpClass(cls):
+        """Skip the tests if docker section is not set in properties file and
+        set external docker registry url which can be re-used in tests.
+        """
+        super(DockerRegistryTestCase, cls).setUpClass()
+        cls.url = settings.docker.external_registry_1
 
     @tier1
     @run_only_on('sat')
@@ -1447,7 +1452,7 @@ class DockerRegistryTestCase(APITestCase):
 
         @CaseLevel: Integration
         """
-        new_url = DOCKER_1_EXTERNAL_REGISTRY
+        new_url = settings.docker.external_registry_2
         registry = entities.Registry(url=self.url).create()
         try:
             self.assertEqual(registry.url, self.url)

--- a/tests/foreman/cli/test_docker.py
+++ b/tests/foreman/cli/test_docker.py
@@ -37,11 +37,7 @@ from robottelo.cli.contentview import ContentView
 from robottelo.cli.product import Product
 from robottelo.cli.repository import Repository
 from robottelo.config import settings
-from robottelo.constants import (
-    DOCKER_0_EXTERNAL_REGISTRY,
-    DOCKER_1_EXTERNAL_REGISTRY,
-    DOCKER_REGISTRY_HUB,
-)
+from robottelo.constants import DOCKER_REGISTRY_HUB
 from robottelo.datafactory import generate_strings_list, valid_data_list
 from robottelo.decorators import (
     run_in_one_thread,
@@ -1601,7 +1597,7 @@ class DockerContainersTestCase(CLITestCase):
         @CaseLevel: Integration
         """
         repo_name = 'rhel'
-        registry = make_registry({'url': DOCKER_0_EXTERNAL_REGISTRY})
+        registry = make_registry({'url': settings.docker.external_registry_1})
         try:
             compute_resource = make_compute_resource({
                 'organization-ids': [self.org['id']],
@@ -1652,6 +1648,15 @@ class DockerRegistryTestCase(CLITestCase):
     repositories.
     """
 
+    @classmethod
+    @skip_if_not_set('docker')
+    def setUpClass(cls):
+        """Skip the tests if docker section is not set in properties file and
+        set external docker registry url which can be re-used in tests.
+        """
+        super(DockerRegistryTestCase, cls).setUpClass()
+        cls.url = settings.docker.external_registry_1
+
     @tier1
     @run_only_on('sat')
     def test_positive_create_with_name(self):
@@ -1667,13 +1672,12 @@ class DockerRegistryTestCase(CLITestCase):
                 registry = make_registry({
                     'description': description,
                     'name': name,
-                    'url': DOCKER_0_EXTERNAL_REGISTRY,
+                    'url': self.url,
                 })
                 try:
                     self.assertEqual(registry['name'], name)
                     self.assertEqual(registry['description'], description)
-                    self.assertEqual(
-                        registry['url'], DOCKER_0_EXTERNAL_REGISTRY)
+                    self.assertEqual(registry['url'], self.url)
                 finally:
                     Docker.registry.delete({'id': registry['id']})
 
@@ -1735,7 +1739,7 @@ class DockerRegistryTestCase(CLITestCase):
         """
         registry = make_registry()
         try:
-            new_url = DOCKER_1_EXTERNAL_REGISTRY
+            new_url = settings.docker.external_registry_2
             Docker.registry.update({
                 'id': registry['id'],
                 'url': new_url,
@@ -1757,7 +1761,7 @@ class DockerRegistryTestCase(CLITestCase):
         """
         registry = make_registry()
         try:
-            new_url = DOCKER_1_EXTERNAL_REGISTRY
+            new_url = settings.docker.external_registry_2
             Docker.registry.update({
                 'name': registry['name'],
                 'url': new_url,

--- a/tests/foreman/ui/test_docker.py
+++ b/tests/foreman/ui/test_docker.py
@@ -21,8 +21,6 @@ from random import randint, shuffle
 from robottelo.api.utils import promote
 from robottelo.config import settings
 from robottelo.constants import (
-    DOCKER_0_EXTERNAL_REGISTRY,
-    DOCKER_1_EXTERNAL_REGISTRY,
     DOCKER_REGISTRY_HUB,
     FOREMAN_PROVIDERS,
     REPO_TYPE,
@@ -1335,7 +1333,8 @@ class DockerContainerTestCase(UITestCase):
         """
         repo_name = 'rhel'
         container_name = gen_string('alphanumeric')
-        registry = entities.Registry(url=DOCKER_0_EXTERNAL_REGISTRY).create()
+        registry = entities.Registry(
+            url=settings.docker.external_registry_1).create()
         try:
             with Session(self.browser) as session:
                 session.nav.go_to_select_org(self.organization.name)
@@ -1425,6 +1424,15 @@ class DockerRegistryTestCase(UITestCase):
     repositories.
     """
 
+    @classmethod
+    @skip_if_not_set('docker')
+    def setUpClass(cls):
+        """Skip the tests if docker section is not set in properties file and
+        set external docker registry url which can be re-used in tests.
+        """
+        super(DockerRegistryTestCase, cls).setUpClass()
+        cls.url = settings.docker.external_registry_1
+
     @run_only_on('sat')
     @tier1
     @skip_if_bug_open('bugzilla', 1333805)
@@ -1441,7 +1449,7 @@ class DockerRegistryTestCase(UITestCase):
                     make_registry(
                         session,
                         name=name,
-                        url=DOCKER_0_EXTERNAL_REGISTRY,
+                        url=self.url,
                         description=gen_string('utf8'),
                     )
                     try:
@@ -1464,7 +1472,7 @@ class DockerRegistryTestCase(UITestCase):
             make_registry(
                 session,
                 name=name,
-                url=DOCKER_0_EXTERNAL_REGISTRY,
+                url=self.url,
                 description=gen_string('utf8'),
             )
             try:
@@ -1493,12 +1501,12 @@ class DockerRegistryTestCase(UITestCase):
             make_registry(
                 session,
                 name=name,
-                url=DOCKER_0_EXTERNAL_REGISTRY,
+                url=self.url,
             )
             try:
                 registry_entity = entities.Registry(name=name).search()[0]
                 self.assertIsNotNone(self.registry.search(name))
-                new_url = DOCKER_1_EXTERNAL_REGISTRY
+                new_url = settings.docker.external_registry_2
                 self.registry.update(name, new_url=new_url)
                 self.registry.search(name).click()
                 self.assertIsNotNone(self.registry.wait_until_element(
@@ -1521,7 +1529,7 @@ class DockerRegistryTestCase(UITestCase):
             make_registry(
                 session,
                 name=name,
-                url=DOCKER_0_EXTERNAL_REGISTRY,
+                url=self.url,
                 description=gen_string('alphanumeric'),
             )
             try:
@@ -1550,7 +1558,7 @@ class DockerRegistryTestCase(UITestCase):
             make_registry(
                 session,
                 name=name,
-                url=DOCKER_0_EXTERNAL_REGISTRY,
+                url=self.url,
                 username=gen_string('alphanumeric'),
             )
             try:
@@ -1580,7 +1588,7 @@ class DockerRegistryTestCase(UITestCase):
                     make_registry(
                         session,
                         name=name,
-                        url=DOCKER_0_EXTERNAL_REGISTRY,
+                        url=self.url,
                         description=gen_string('utf8'),
                     )
                     self.registry.delete(name)


### PR DESCRIPTION
Moved external registry urls to robottelo.properties file as those urls are internal.
Closes #3403 

Test results (with properties set to valid values):
```python
py.test tests/foreman/{api,cli,ui}/test_docker.py::DockerRegistryTestCase -k 'test_positive_update_url' 
================================ test session starts =================================
platform linux2 -- Python 2.7.10, pytest-2.9.2, py-1.4.31, pluggy-0.3.1
rootdir: /home/andrii/workspace/robottelo, inifile: 
plugins: xdist-1.13.1, repeat-0.2
collected 23 items 

tests/foreman/api/test_docker.py .
tests/foreman/cli/test_docker.py ..
tests/foreman/ui/test_docker.py .

================ 19 tests deselected by '-ktest_positive_update_url' =================
====================== 4 passed, 19 deselected in 67.21 seconds ======================
```