### PR TITLE
Implement content host remote package management tests

### DIFF
--- a/docs/api/tests.foreman.ui.rst
+++ b/docs/api/tests.foreman.ui.rst
@@ -43,6 +43,11 @@
 
 .. automodule:: tests.foreman.ui.test_config_group
 
+:mod:`tests.foreman.ui.test_contenthost`
+----------------------------------------
+
+.. automodule:: tests.foreman.ui.test_contenthost
+
 :mod:`tests.foreman.ui.test_contentview`
 ----------------------------------------
 

--- a/robottelo/ui/locators.py
+++ b/robottelo/ui/locators.py
@@ -1065,6 +1065,10 @@ locators = LocatorDict({
         "//form[@bst-edit-text='host.name']//button[@ng-click='save()']"),
     "contenthost.unregister": (
         By.XPATH, "//button[@ng-disabled='host.deleting']"),
+    "contenthost.confirm_deletion": (
+        By.XPATH,
+        ("//input[@type='radio' and @ng-model='host.unregisterDelete' and "
+         "@ng-value='true']")),
     "contenthost.subscription_active": (
         By.XPATH,
         ("//td[a[contains(@href, 'content_hosts') and contains(.,'%s')]]"
@@ -1092,6 +1096,19 @@ locators = LocatorDict({
         By.XPATH,
         ("//form[@ng-submit='performPackageAction()']"
          "//button[contains(@class, 'ng-scope')]")),
+    "contenthost.remote_action_finished": (
+        By.XPATH,
+        ("//div[contains(@class, 'progress') and "
+         "@value='task.progressbar.value' and "
+         "div[contains(@style, '100%')]]")),
+    "contenthost.package_search_box": (
+        By.XPATH, "//input[@ng-model='detailsTable.searchTerm']"),
+    "contenthost.package_search_button": (
+        By.XPATH, "//button[contains(@ng-click, 'detailsTable.search')]"),
+    "contenthost.package_search_name": (
+        By.XPATH,
+        ("//tr[@class='ng-scope' and @row-select='package']"
+         "/td[contains(@class, 'ng-scope') and contains(., '%s')]")),
 
     # Hosts
 

--- a/tests/foreman/cli/test_host.py
+++ b/tests/foreman/cli/test_host.py
@@ -953,6 +953,7 @@ class KatelloAgentTestCase(CLITestCase):
         self.client.install_katello_agent()
 
     def tearDown(self):
+        """Destroy the VM"""
         self.client.destroy()
         super(KatelloAgentTestCase, self).tearDown()
 

--- a/tests/foreman/ui/test_contenthost.py
+++ b/tests/foreman/ui/test_contenthost.py
@@ -1,0 +1,206 @@
+# -*- encoding: utf-8 -*-
+"""Test class for Content Hosts UI
+
+@Requirement: Content Host
+
+@CaseAutomation: Automated
+
+@CaseLevel: Acceptance
+
+@CaseComponent: UI
+
+@TestType: Functional
+
+@CaseImportance: High
+
+@Upstream: No
+"""
+from nailgun import entities
+from robottelo.cli.factory import (
+    setup_org_for_a_custom_repo,
+    setup_org_for_a_rh_repo,
+)
+from robottelo.constants import (
+    FAKE_0_CUSTOM_PACKAGE,
+    FAKE_0_CUSTOM_PACKAGE_NAME,
+    FAKE_1_CUSTOM_PACKAGE,
+    FAKE_1_CUSTOM_PACKAGE_NAME,
+    FAKE_2_CUSTOM_PACKAGE,
+    FAKE_0_CUSTOM_PACKAGE_GROUP,
+    FAKE_0_CUSTOM_PACKAGE_GROUP_NAME,
+    FAKE_0_YUM_REPO,
+    PRDS,
+    REPOS,
+    REPOSET,
+)
+from robottelo.decorators import run_in_one_thread, skip_if_not_set, tier3
+from robottelo.test import UITestCase
+from robottelo.ui.session import Session
+from robottelo.vm import VirtualMachine
+
+
+@run_in_one_thread
+class ContentHostTestCase(UITestCase):
+    """Implements Content Host tests in UI"""
+
+    @classmethod
+    def set_session_org(cls):
+        """Create separate organization for each test"""
+        cls.session_org = entities.Organization().create()
+
+    @skip_if_not_set('clients', 'fake_manifest')
+    def setUp(self):
+        """Create Lifecycle Environment, Content View, Activation key,
+        then create a VM, subscribe it to satellite-tools repo, install
+        katello-ca and katello-agent packages"""
+        super(ContentHostTestCase, self).setUp()
+        self.env = entities.LifecycleEnvironment(
+            organization=self.session_org).create()
+        self.content_view = entities.ContentView(
+            organization=self.session_org).create()
+        self.activation_key = entities.ActivationKey(
+            environment=self.env,
+            organization=self.session_org,
+        ).create()
+        setup_org_for_a_rh_repo({
+            'product': PRDS['rhel'],
+            'repository-set': REPOSET['rhst7'],
+            'repository': REPOS['rhst7']['name'],
+            'organization-id': self.session_org.id,
+            'content-view-id': self.content_view.id,
+            'lifecycle-environment-id': self.env.id,
+            'activationkey-id': self.activation_key.id,
+        })
+        setup_org_for_a_custom_repo({
+            'url': FAKE_0_YUM_REPO,
+            'organization-id': self.session_org.id,
+            'content-view-id': self.content_view.id,
+            'lifecycle-environment-id': self.env.id,
+            'activationkey-id': self.activation_key.id,
+        })
+        self.client = VirtualMachine(distro='rhel71')
+        self.client.create()
+        self.client.install_katello_ca()
+        result = self.client.register_contenthost(
+            self.session_org.label, self.activation_key.name)
+        self.assertEqual(result.return_code, 0)
+        self.client.enable_repo(REPOS['rhst7']['id'])
+        self.client.install_katello_agent()
+
+    def tearDown(self):
+        """Destroy the VM"""
+        self.client.destroy()
+        super(ContentHostTestCase, self).tearDown()
+
+    @tier3
+    def test_positive_install_package(self):
+        """Install a package to a host remotely
+
+        @id: 13b9422d-4b7a-4068-9a57-a94602cd6410
+
+        @assert: Package was successfully installed
+
+        @CaseLevel: System
+        """
+        with Session(self.browser):
+            result = self.contenthost.execute_package_action(
+                self.client.hostname,
+                'Package Install',
+                FAKE_0_CUSTOM_PACKAGE_NAME,
+            )
+            self.assertEqual(result, 'success')
+            self.assertIsNotNone(self.contenthost.package_search(
+                self.client.hostname, FAKE_0_CUSTOM_PACKAGE_NAME))
+
+    @tier3
+    def test_positive_remove_package(self):
+        """Remove a package from a host remotely
+
+        @id: 86d8896b-06d9-4c99-937e-f3aa07b4eb69
+
+        @Assert: Package was successfully removed
+
+        @CaseLevel: System
+        """
+        self.client.download_install_rpm(
+            FAKE_0_YUM_REPO,
+            FAKE_0_CUSTOM_PACKAGE
+        )
+        with Session(self.browser):
+            result = self.contenthost.execute_package_action(
+                self.client.hostname,
+                'Package Remove',
+                FAKE_0_CUSTOM_PACKAGE_NAME,
+            )
+            self.assertEqual(result, 'success')
+            self.assertIsNone(self.contenthost.package_search(
+                self.client.hostname, FAKE_0_CUSTOM_PACKAGE_NAME))
+
+    @tier3
+    def test_positive_upgrade_package(self):
+        """Upgrade a host package remotely
+
+        @id: 1969db93-e7af-4f5f-973d-23c222224db6
+
+        @Assert: Package was successfully upgraded
+
+        @CaseLevel: System
+        """
+        self.client.run('yum install -y {0}'.format(FAKE_1_CUSTOM_PACKAGE))
+        with Session(self.browser):
+            result = self.contenthost.execute_package_action(
+                self.client.hostname,
+                'Package Update',
+                FAKE_1_CUSTOM_PACKAGE_NAME,
+            )
+            self.assertEqual(result, 'success')
+            self.assertIsNotNone(self.contenthost.package_search(
+                self.client.hostname, FAKE_2_CUSTOM_PACKAGE))
+
+    @tier3
+    def test_positive_install_package_group(self):
+        """Install a package group to a host remotely
+
+        @id: a43fb21b-5f6a-4f14-8cd6-114ec287540c
+
+        @Assert: Package group was successfully installed
+
+        @CaseLevel: System
+        """
+        with Session(self.browser):
+            result = self.contenthost.execute_package_action(
+                self.client.hostname,
+                'Group Install',
+                FAKE_0_CUSTOM_PACKAGE_GROUP_NAME,
+            )
+            self.assertEqual(result, 'success')
+            for package in FAKE_0_CUSTOM_PACKAGE_GROUP:
+                self.assertIsNotNone(self.contenthost.package_search(
+                    self.client.hostname, package))
+
+    @tier3
+    def test_positive_remove_package_group(self):
+        """Remove a package group from a host remotely
+
+        @id: dbeea1f2-adf4-4ad8-a989-efad8ce21b98
+
+        @Assert: Package group was successfully removed
+
+        @CaseLevel: System
+        """
+        with Session(self.browser):
+            result = self.contenthost.execute_package_action(
+                self.client.hostname,
+                'Group Install',
+                FAKE_0_CUSTOM_PACKAGE_GROUP_NAME,
+            )
+            self.assertEqual(result, 'success')
+            result = self.contenthost.execute_package_action(
+                self.client.hostname,
+                'Group Remove',
+                FAKE_0_CUSTOM_PACKAGE_GROUP_NAME,
+            )
+            self.assertEqual(result, 'success')
+            for package in FAKE_0_CUSTOM_PACKAGE_GROUP:
+                self.assertIsNone(self.contenthost.package_search(
+                    self.client.hostname, package))


### PR DESCRIPTION
Closes #3585 
```python
py.test tests/foreman/ui/test_contenthost.py -v     
================================ test session starts =================================
platform linux2 -- Python 2.7.10, pytest-2.9.2, py-1.4.31, pluggy-0.3.1 -- /home/andrii/env/bin/python
cachedir: .cache
rootdir: /home/andrii/workspace/robottelo, inifile: 
plugins: xdist-1.13.1, repeat-0.2
collected 5 items 

tests/foreman/ui/test_contenthost.py::ContentHostTestCase::test_positive_install_package PASSED
tests/foreman/ui/test_contenthost.py::ContentHostTestCase::test_positive_install_package_group PASSED
tests/foreman/ui/test_contenthost.py::ContentHostTestCase::test_positive_remove_package PASSED
tests/foreman/ui/test_contenthost.py::ContentHostTestCase::test_positive_remove_package_group PASSED
tests/foreman/ui/test_contenthost.py::ContentHostTestCase::test_positive_upgrade_package PASSED

============================ 5 passed in 2485.63 seconds =============================
```
```python
py.test tests/foreman/ui/test_hostunification.py -v -k test_positive_delete_content_host
================================ test session starts =================================
platform linux2 -- Python 2.7.10, pytest-2.9.2, py-1.4.31, pluggy-0.3.1 -- /home/andrii/env/bin/python
cachedir: .cache
rootdir: /home/andrii/workspace/robottelo, inifile: 
plugins: xdist-1.13.1, repeat-0.2
collected 11 items 

tests/foreman/ui/test_hostunification.py::HostContentHostUnificationTestCase::test_positive_delete_content_host <- robottelo/decorators.py PASSED

============ 10 tests deselected by '-ktest_positive_delete_content_host' ============
===================== 1 passed, 10 deselected in 371.44 seconds ======================
```