### PR TITLE
Add hostcolletion.execute_bulk_package_action closes #3598

### DIFF
--- a/robottelo/ui/locators.py
+++ b/robottelo/ui/locators.py
@@ -1110,6 +1110,35 @@ locators = LocatorDict({
         ("//tr[@class='ng-scope' and @row-select='package']"
          "/td[contains(@class, 'ng-scope') and contains(., '%s')]")),
 
+    # Content Host - Bulk Actions
+
+    # %s action names: 'update all', 'install', 'update', 'remove'
+    "contenthost.bulk_actions.via_katello_agent": (
+        By.XPATH,
+        ("//a[contains(@ng-click, \"performViaKatelloAgent"
+         "('%s', content)\")]")),
+    "contenthost.bulk_actions.via_remote_execution": (
+        By.XPATH,
+        ("//a[contains(@ng-click, \"performViaRemoteExecution"
+         "('%s', false)\")]")),
+    "contenthost.bulk_actions.via_remote_execution_custom": (
+        By.XPATH,
+        ("//a[contains(@ng-click, \"performViaRemoteExecution"
+         "('%s', true)\")]")),
+
+    "contenthost.bulk_actions.package_type": (By.ID, "package"),
+    "contenthost.bulk_actions.package_group_type": (By.ID, "package_group"),
+    "contenthost.bulk_actions.package_name_input": (
+        By.XPATH,
+        "//input[@type='text' and contains(@ng-model, 'content.content')]"),
+
+    "contenthost.bulk_actions.action_dropdown": (
+        By.XPATH,
+        "%s/../../../button[contains(@data-toggle,'dropdown')]"),
+
+    "contenthost.bulk_actions.remote_action_scheduled": (
+        By.XPATH, '//div[@bst-alert="success"]'),
+
     # Hosts
 
     # Default tab (Host)
@@ -2740,4 +2769,8 @@ locators = LocatorDict({
     "hostcollection.add_host": (
         By.XPATH,
         "//button[contains(@ng-click, 'addSelected')]"),
+    "hostcollection.collection_actions.packages": (
+        By.XPATH,
+        ("//li[@bst-feature-flag='remote_actions']"
+         "//a[contains(@href, 'packages')]")),
 })

--- a/robottelo/ui/navigator.py
+++ b/robottelo/ui/navigator.py
@@ -397,14 +397,23 @@ class Navigator(Base):
             menu_locators['menu.oscap_reports'],
         )
 
-    def go_to_select_org(self, org):
+    def go_to_select_org(self, org, force=True):
         """Selects the specified organization.
 
         :param str org: The organization to select.
+        :param force: Force navigation to org even if org is already selected
         :return: Returns the organization.
         :rtype: str
 
         """
+
+        # if force=False and org is already the current selected, do nothing.
+        if not force and self.find_element(
+                menu_locators['menu.current_text']).text == org:
+            self.logger.debug(u'%s is already the org in the context', org)
+            return
+
+        self.logger.debug(u'Changing context to %s organization', org)
         strategy, value = menu_locators['org.select_org']
         self.menu_click(
             menu_locators['menu.any_context'],


### PR DESCRIPTION
closes #3598

Added `hostcollection.execute_bulk_package_action` tested using the @abalakh  approach and worked locally with selenium + firefox for each one of the cases:

- update all
- install a package
- update a package
- remove a package

All **action_names** tested for **package** and **package_group** using **action_via=katello_agent** because **remote_execution** cannot be tested locally (or I missed something about it)

 