### PR TITLE
Optimize and fix UI content host tests

### DIFF
--- a/tests/foreman/ui/test_contenthost.py
+++ b/tests/foreman/ui/test_contenthost.py
@@ -45,39 +45,45 @@ class ContentHostTestCase(UITestCase):
 
     @classmethod
     def set_session_org(cls):
-        """Create separate organization for each test"""
+        """Create an organization for tests, which will be selected
+        automatically"""
         cls.session_org = entities.Organization().create()
 
+    @classmethod
     @skip_if_not_set('clients', 'fake_manifest')
-    def setUp(self):
-        """Create Lifecycle Environment, Content View, Activation key,
-        then create a VM, subscribe it to satellite-tools repo, install
-        katello-ca and katello-agent packages"""
-        super(ContentHostTestCase, self).setUp()
-        self.env = entities.LifecycleEnvironment(
-            organization=self.session_org).create()
-        self.content_view = entities.ContentView(
-            organization=self.session_org).create()
-        self.activation_key = entities.ActivationKey(
-            environment=self.env,
-            organization=self.session_org,
+    def setUpClass(cls):
+        """Create Lifecycle Environment, Content View and Activation key
+        """
+        super(ContentHostTestCase, cls).setUpClass()
+        cls.env = entities.LifecycleEnvironment(
+            organization=cls.session_org).create()
+        cls.content_view = entities.ContentView(
+            organization=cls.session_org).create()
+        cls.activation_key = entities.ActivationKey(
+            environment=cls.env,
+            organization=cls.session_org,
         ).create()
         setup_org_for_a_rh_repo({
             'product': PRDS['rhel'],
             'repository-set': REPOSET['rhst7'],
             'repository': REPOS['rhst7']['name'],
-            'organization-id': self.session_org.id,
-            'content-view-id': self.content_view.id,
-            'lifecycle-environment-id': self.env.id,
-            'activationkey-id': self.activation_key.id,
+            'organization-id': cls.session_org.id,
+            'content-view-id': cls.content_view.id,
+            'lifecycle-environment-id': cls.env.id,
+            'activationkey-id': cls.activation_key.id,
         })
         setup_org_for_a_custom_repo({
             'url': FAKE_0_YUM_REPO,
-            'organization-id': self.session_org.id,
-            'content-view-id': self.content_view.id,
-            'lifecycle-environment-id': self.env.id,
-            'activationkey-id': self.activation_key.id,
+            'organization-id': cls.session_org.id,
+            'content-view-id': cls.content_view.id,
+            'lifecycle-environment-id': cls.env.id,
+            'activationkey-id': cls.activation_key.id,
         })
+
+    def setUp(self):
+        """Create a VM, subscribe it to satellite-tools repo, install
+        katello-ca and katello-agent packages"""
+        super(ContentHostTestCase, self).setUp()
         self.client = VirtualMachine(distro='rhel71')
         self.client.create()
         self.client.install_katello_ca()


### PR DESCRIPTION
Tests were failing on CI as `session_org` is a single org per test class, and each test setup contained manifest upload, i.e. manifest was uploading to the same organization multiple times.
Instead of creating separate org per test, moving all the dependencies creation (org, lce, cv, repo, etc) to setUpClass, leaving only unique host (vm) per each test. This will also reduce time needed for tests execution for around 50% (22 minutes less in comparison with #3595 results)
Test results:
```python
============================= test session starts ==============================
platform linux2 -- Python 2.7.10, pytest-2.9.2, py-1.4.31, pluggy-0.3.1 -- /home/andrii/env/bin/python
cachedir: .cache
rootdir: /home/andrii/workspace/robottelo, inifile: 
plugins: xdist-1.13.1, repeat-0.2
collecting ... collected 5 items

tests/foreman/ui/test_contenthost.py::ContentHostTestCase::test_positive_install_package PASSED
tests/foreman/ui/test_contenthost.py::ContentHostTestCase::test_positive_install_package_group PASSED
tests/foreman/ui/test_contenthost.py::ContentHostTestCase::test_positive_remove_package PASSED
tests/foreman/ui/test_contenthost.py::ContentHostTestCase::test_positive_remove_package_group PASSED
tests/foreman/ui/test_contenthost.py::ContentHostTestCase::test_positive_upgrade_package PASSED

========================= 5 passed in 1136.85 seconds ==========================

```