### PR TITLE
Ignored RHEL6.x for ostree tests

### DIFF
--- a/tests/foreman/ui/test_repository.py
+++ b/tests/foreman/ui/test_repository.py
@@ -517,7 +517,8 @@ class RepositoryTestCase(UITestCase):
                         content_type=REPO_TYPE['docker'],
                     ).create()
                     self.setup_navigate_syncnow(
-                        session, product.name, repo_name,)
+                        session, product.name, repo_name
+                    )
                     # prd_sync_is_ok returns boolean values and not objects
                     self.assertTrue(self.prd_sync_is_ok(repo_name))
 
@@ -635,5 +636,8 @@ class RepositoryTestCase(UITestCase):
             )
             self.products.click(self.products.search(prod.name))
             # Validate the new repo URL
-            self.assertTrue(self.repository.validate_field(
-                            repo_name, 'url', FEDORA23_OSTREE_REPO))
+            self.assertTrue(
+                self.repository.validate_field(
+                    repo_name, 'url', FEDORA23_OSTREE_REPO
+                )
+            )


### PR DESCRIPTION
close #3638
Improved skip_if_os decorator logging to easier debug
Improved test_host tests to fail instead of skipping
when unittest2.SkipTest is raised