### PR TITLE
Fix tests for add puppet module to content view functionality

### DIFF
--- a/robottelo/ui/contentviews.py
+++ b/robottelo/ui/contentviews.py
@@ -271,13 +271,19 @@ class ContentViews(Base):
         or by 'version'.
         """
         self.click(self.search(cv_name))
-        self.click(tab_locators['contentviews.tab_puppet_modules'])
+        if self.wait_until_element(
+                tab_locators['contentviews.tab_puppet_modules']):
+            self.click(tab_locators['contentviews.tab_puppet_modules'])
+        else:
+            raise UIError('Could not find tab to add puppet_modules')
         self.click(locators['contentviews.add_module'])
-        self.text_field_update(common_locators['cv_filter'], module_name)
+        self.text_field_update(
+            locators['contentviews.search_filters'], module_name)
+        self.click(locators['contentviews.search_button'])
         strategy, value = locators['contentviews.select_module']
         self.click((strategy, value % module_name))
         self.text_field_update(
-            common_locators['cv_filter'], filter_term)
+            locators['contentview.version_filter'], filter_term)
         strategy, value = locators['contentviews.select_module_ver']
         self.click((strategy, value % filter_term))
 
@@ -286,15 +292,7 @@ class ContentViews(Base):
         When 'is_add' Flag is set then add_contentView will be performed,
         otherwise remove_contentView
         """
-        element = self.search(composite_cv)
-
-        if not element:
-            raise UIError(
-                'Could not find the selected CV "{0}"'.format(composite_cv)
-            )
-
-        element.click()
-        self.wait_for_ajax()
+        self.click(self.search(composite_cv))
         self.click(tab_locators['contentviews.tab_content_views'])
         for cv_name in cv_names:
             if is_add:

--- a/robottelo/ui/locators.py
+++ b/robottelo/ui/locators.py
@@ -747,8 +747,6 @@ common_locators = LocatorDict({
         ("//div[@id='parameters']/span[@class='help-block'"
          "and string-length(text()) > 10]")),
 
-    "cv_filter": (
-        By.XPATH, "//input[@ng-model='filterTerm']"),
     "search": (By.ID, "search"),
     "auto_search": (
         By.XPATH, "//ul[contains(@id, 'ui-id')]/li/a[contains(., '%s')]"),
@@ -2231,6 +2229,8 @@ locators = LocatorDict({
          "//input[@ng-model='detailsTable.searchTerm']")),
     "contentviews.search_button": (
         By.XPATH, "//button[contains(@ng-click, 'detailsTable.search')]"),
+    "contentviews.table_filter": (
+        By.XPATH, "//input[@ng-model='filterTerm']"),
     "contentviews.filter_name": (
         By.XPATH, "//tr[@row-select='filter']/td[2]/a[contains(., '%s')]"),
     "contentviews.copy": (

--- a/tests/foreman/ui/test_contentview.py
+++ b/tests/foreman/ui/test_contentview.py
@@ -40,7 +40,6 @@ from robottelo.datafactory import invalid_names_list, valid_data_list
 from robottelo.decorators import (
     run_in_one_thread,
     run_only_on,
-    skip_if_bug_open,
     skip_if_not_set,
     stubbed,
     tier1,
@@ -531,7 +530,6 @@ class ContentViewTestCase(UITestCase):
         # until we logout and navigate again to puppet-module tab
         with Session(self.browser) as session:
             session.nav.go_to_select_org(org.name)
-            session.nav.go_to_content_views()
             module = self.content_views.fetch_puppet_module(
                 cv_name1, puppet_module)
             self.assertIsNotNone(module)
@@ -540,11 +538,8 @@ class ContentViewTestCase(UITestCase):
             self.content_views.publish(cv_name2)
             self.content_views.create(composite_name, is_composite=True)
             session.nav.go_to_select_org(org.name)
-            session.nav.go_to_content_views()
             self.content_views.add_remove_cv(
                 composite_name, [cv_name1, cv_name2])
-            self.assertIsNotNone(self.content_views.wait_until_element(
-                common_locators['alert.success_sub_form']))
 
     @run_in_one_thread
     @run_only_on('sat')
@@ -630,7 +625,6 @@ class ContentViewTestCase(UITestCase):
             self.assertIsNotNone(self.content_views.wait_until_element(
                 common_locators['alert.success_sub_form']))
 
-    @skip_if_bug_open('bugzilla', 1297308)
     @run_only_on('sat')
     @tier2
     def test_negative_add_puppet_repo_to_composite(self):
@@ -642,7 +636,6 @@ class ContentViewTestCase(UITestCase):
 
         @assert: User cannot create a composite content view
         that contains direct puppet repos.
-
 
         @CaseLevel: Integration
         """
@@ -658,10 +651,10 @@ class ContentViewTestCase(UITestCase):
             with self.assertRaises(UIError) as context:
                 self.content_views.add_puppet_module(
                     composite_name, 'httpd', filter_term='Latest')
-                self.assertEqual(
-                    context.exception.message,
-                    'Could not find tab to add puppet_modules'
-                )
+            self.assertEqual(
+                context.exception.message,
+                'Could not find tab to add puppet_modules'
+            )
 
     @run_only_on('sat')
     @tier2


### PR DESCRIPTION
Closes #3639 
```
nosetests tests/foreman/ui/test_contentview.py -m test_positive_create_composite
.
----------------------------------------------------------------------
Ran 1 test in 585.155s

OK
```
```
nosetests tests/foreman/ui/test_contentview.py -m test_negative_add_puppet_repo_to_composite
.
----------------------------------------------------------------------
Ran 1 test in 50.143s

OK
```
```
nosetests tests/foreman/ui/test_contentview.py -m test_positive_add_puppet_module
.
----------------------------------------------------------------------
Ran 1 test in 86.272s

OK
```