### PR TITLE
Fix CLI activation key product content tests

### DIFF
--- a/tests/foreman/cli/test_activationkey.py
+++ b/tests/foreman/cli/test_activationkey.py
@@ -608,19 +608,21 @@ class ActivationKeyTestCase(CLITestCase):
 
         @CaseLevel: System
         """
+        org = make_org()
         result = setup_org_for_a_rh_repo({
             u'product': PRDS['rhel'],
             u'repository-set': REPOSET['rhst7'],
             u'repository': REPOS['rhst7']['name'],
-            u'organization-id': self.org['id'],
+            u'organization-id': org['id'],
         })
         content = ActivationKey.product_content({
             u'id': result['activationkey-id'],
-            u'organization-id': self.org['id'],
+            u'organization-id': org['id'],
         })
         self.assertEqual(content[0]['name'], REPOSET['rhst7'])
 
     @run_only_on('sat')
+    @skip_if_bug_open('bugzilla', 1360239)
     @tier3
     def test_positive_add_custom_product(self):
         """Test that custom product can be associated to Activation Keys
@@ -644,6 +646,7 @@ class ActivationKeyTestCase(CLITestCase):
 
     @run_in_one_thread
     @run_only_on('sat')
+    @skip_if_bug_open('bugzilla', 1360239)
     @skip_if_not_set('fake_manifest')
     @tier3
     def test_positive_add_redhat_and_custom_products(self):
@@ -661,15 +664,16 @@ class ActivationKeyTestCase(CLITestCase):
 
         @CaseLevel: System
         """
+        org = make_org()
         result = setup_org_for_a_rh_repo({
             u'product': PRDS['rhel'],
             u'repository-set': REPOSET['rhst7'],
             u'repository': REPOS['rhst7']['name'],
-            u'organization-id': self.org['id'],
+            u'organization-id': org['id'],
         })
         result = setup_org_for_a_custom_repo({
             u'url': FAKE_0_YUM_REPO,
-            u'organization-id': self.org['id'],
+            u'organization-id': org['id'],
             u'activationkey-id': result['activationkey-id'],
             u'content-view-id': result['content-view-id'],
             u'lifecycle-environment-id': result['lifecycle-environment-id'],
@@ -677,7 +681,7 @@ class ActivationKeyTestCase(CLITestCase):
         repo = Repository.info({u'id': result['repository-id']})
         content = ActivationKey.product_content({
             u'id': result['activationkey-id'],
-            u'organization-id': self.org['id'],
+            u'organization-id': org['id'],
         })
         self.assertEqual(len(content), 2)
         self.assertEqual(
@@ -1164,6 +1168,7 @@ class ActivationKeyTestCase(CLITestCase):
         self.assertIn(
             u"'--auto-attach': value must be one of", exe.exception.stderr)
 
+    @skip_if_bug_open('bugzilla', 1360239)
     @tier3
     def test_positive_content_override(self):
         """Positive content override


### PR DESCRIPTION
Due to [BZ1360239](https://bugzilla.redhat.com/show_bug.cgi?id=1360239) custom products are not returned by `activation-key product-content` command, skipping affected tests.
Also  `test_positive_add_redhat_product` and `test_positive_add_redhat_and_custom_products` were sharing the same org and both were trying to upload a manifest, so one test was failing, fixing that too.
Closes #3652

Test results:
```python
py.test tests/foreman/cli/test_activationkey.py -v -k 'test_positive_add_redhat_product'                      
============================== test session starts ==============================
platform linux2 -- Python 2.7.10, pytest-2.9.2, py-1.4.31, pluggy-0.3.1 -- /home/andrii/env/bin/python
cachedir: .cache
rootdir: /home/andrii/workspace/robottelo, inifile: 
plugins: xdist-1.13.1, repeat-0.2
collected 47 items 

tests/foreman/cli/test_activationkey.py::ActivationKeyTestCase::test_positive_add_redhat_product <- robottelo/decorators/__init__.py PASSED

========== 46 tests deselected by '-ktest_positive_add_redhat_product' ==========
=================== 1 passed, 46 deselected in 134.42 seconds ===================
```