### PR TITLE
Fix negative UI host unification test

### DIFF
--- a/tests/foreman/ui/test_hostunification.py
+++ b/tests/foreman/ui/test_hostunification.py
@@ -523,11 +523,13 @@ class HostContentHostUnificationTestCase(UITestCase):
                 ],
             )
             hostname = u'{0}.{1}'.format(host.name, host.domain.name)
-            self.contenthost.execute_package_action(
-                hostname,
-                'Package Install',
-                'busybox',
-            )
+            with self.assertRaises(UIError):
+                self.contenthost.execute_package_action(
+                    hostname,
+                    'Package Install',
+                    'busybox',
+                    timeout=5,
+                )
             self.assertIsNotNone(
                 self.contenthost.wait_until_element(
                     common_locators['alert.error'])


### PR DESCRIPTION
Closes #3653 
As it's negative test it should expect operation to fail.
Also setting custom timeout not to wait 2 minutes with no specific reason.
Test results:
```python
py.test tests/foreman/ui/test_hostunification.py -v -k 'test_negative_add_contents_to_unregistered_host'
============================== test session starts ==============================
platform linux2 -- Python 2.7.10, pytest-2.9.2, py-1.4.31, pluggy-0.3.1 -- /home/andrii/env/bin/python
cachedir: .cache
rootdir: /home/andrii/workspace/robottelo, inifile: 
plugins: xdist-1.13.1, repeat-0.2
collected 11 items 

tests/foreman/ui/test_hostunification.py::HostContentHostUnificationTestCase::test_negative_add_contents_to_unregistered_host <- robottelo/decorators/__init__.py PASSED

== 10 tests deselected by '-ktest_negative_add_contents_to_unregistered_host' ===
=================== 1 passed, 10 deselected in 65.52 seconds ====================
```