### PR TITLE
Fix api test test_verify_bugzilla_1107708

### DIFF
--- a/tests/foreman/api/test_hostgroup.py
+++ b/tests/foreman/api/test_hostgroup.py
@@ -109,7 +109,7 @@ class HostGroupTestCase(APITestCase):
         # We have two environments (one created after publishing and one more
         # was created after promotion), so we need to select promoted one
         environments = entities.Environment().search(
-            query={'organization_id': org.id}
+            query={'search': 'organization_id={0}'.format(org.id)}
         )
         self.assertEqual(len(environments), 2)
         environments = [


### PR DESCRIPTION
Closes #3654 
Test was failing due to incorrect environment search query.
Test results:
```python
py.test tests/foreman/api/test_hostgroup.py -k 'test_verify_bugzilla_1107708' -v
============================== test session starts ==============================
platform linux2 -- Python 2.7.10, pytest-2.9.2, py-1.4.31, pluggy-0.3.1 -- /home/andrii/env/bin/python
cachedir: .cache
rootdir: /home/andrii/workspace/robottelo, inifile: 
plugins: xdist-1.13.1, repeat-0.2
collected 40 items 

tests/foreman/api/test_hostgroup.py::HostGroupTestCase::test_verify_bugzilla_1107708 <- robottelo/decorators/__init__.py PASSED

============ 39 tests deselected by '-ktest_verify_bugzilla_1107708' ============
=================== 1 passed, 39 deselected in 60.45 seconds ====================
```