### PR TITLE
Commented out view_params permission from API permissions.

### DIFF
--- a/robottelo/constants.py
+++ b/robottelo/constants.py
@@ -517,7 +517,9 @@ PERMISSIONS = {
         'create_params',
         'edit_params',
         'destroy_params',
-        'view_params',
+        # This permission was removed for downstream version 6.2.
+        # However this change is temporary and the plan is to add it back
+        # 'view_params',
     ],
     'Hostgroup': [
         'view_hostgroups',


### PR DESCRIPTION
`view_params` permission was removed for downstream version 6.2. However this change is temporary and the plan is to add it back, so parameter was commented out instead of removing.
Fixes #3656

```python
 py.test -v tests/foreman/api/test_permission.py -k PermissionTestCase 
===================================================================== test session starts =====================================================================
platform linux2 -- Python 2.7.11, pytest-2.9.2, py-1.4.31, pluggy-0.3.1 -- /home/qui/code/robottelo/venv2/bin/python2.7
cachedir: .cache
rootdir: /home/qui/code/robottelo, inifile: 
collected 7 items 

tests/foreman/api/test_permission.py::PermissionTestCase::test_positive_search <- robottelo/decorators/__init__.py PASSED
tests/foreman/api/test_permission.py::PermissionTestCase::test_positive_search_by_name <- robottelo/decorators/__init__.py PASSED
tests/foreman/api/test_permission.py::PermissionTestCase::test_positive_search_by_resource_type <- robottelo/decorators/__init__.py PASSED

======================================================== 4 tests deselected by '-kPermissionTestCase' =========================================================
========================================================== 3 passed, 4 deselected in 459.12 seconds ===========================================================
```