### PR TITLE
Assertion elements replaced for test_positive_upload_and_delete

### DIFF
--- a/robottelo/ui/base.py
+++ b/robottelo/ui/base.py
@@ -261,8 +261,8 @@ class Base(object):
             self.button_timeout = 15
             self.result_timeout = 15
 
-    def wait_until_element_exists(
-            self, locator, timeout=12, poll_frequency=0.5):
+    def wait_until_element_exists(self, locator, timeout=12,
+                                  poll_frequency=0.5):
         """Wrapper around Selenium's WebDriver that allows you to pause your
         test until an element in the web page is present.
 

--- a/robottelo/ui/locators.py
+++ b/robottelo/ui/locators.py
@@ -615,6 +615,10 @@ tab_locators = LocatorDict({
         By.XPATH, "//a[contains(@ui-sref,'manifest.details')]"),
     "subs.import_history": (
         By.XPATH, "//a[contains(@ui-sref,'manifest.history')]"),
+    "subs.import_history.imported.success": (
+        By.XPATH, "//td[text()[contains(.,'imported successfully')]]"),
+    "subs.import_history.deleted": (
+        By.XPATH, "//td[text()[contains(., 'deleted')]]"),
 
     # Oscap Policy
     "oscap.content": (

--- a/robottelo/ui/subscription.py
+++ b/robottelo/ui/subscription.py
@@ -46,6 +46,8 @@ class Subscriptions(Base):
         """Deletes Manifest/subscriptions via UI."""
         self.click(locators['subs.manage_manifest'])
         self.click(locators['subs.delete_manifest'])
+        self.wait_until_element_is_not_visible(
+            locators['subs.manifest_exists'], 300)
 
     def refresh(self):
         """Refreshes Manifest/subscriptions via UI."""

--- a/tests/foreman/ui/test_subscription.py
+++ b/tests/foreman/ui/test_subscription.py
@@ -19,7 +19,7 @@ from robottelo import manifests
 from robottelo.constants import DEFAULT_SUBSCRIPTION_NAME
 from robottelo.decorators import run_in_one_thread, skip_if_not_set, tier1
 from robottelo.test import UITestCase
-from robottelo.ui.locators import common_locators
+from robottelo.ui.locators import tab_locators
 from robottelo.ui.session import Session
 
 
@@ -45,11 +45,11 @@ class SubscriptionTestCase(UITestCase):
             # Step 1: Attempt to upload a manifest
             with manifests.clone() as manifest:
                 self.subscriptions.upload(manifest)
-            self.assertTrue(self.subscriptions.wait_until_element(
-                common_locators['alert.success']))
+            self.assertTrue(self.subscriptions.wait_until_element_exists(
+                tab_locators['subs.import_history.imported.success']))
             # Step 2: Attempt to delete the manifest
             self.subscriptions.delete()
-            self.assertTrue(self.subscriptions.wait_until_element(
-                common_locators['alert.success']))
+            self.assertTrue(self.subscriptions.wait_until_element_exists(
+                tab_locators['subs.import_history.deleted']))
             self.assertIsNone(
                 self.subscriptions.search(DEFAULT_SUBSCRIPTION_NAME))


### PR DESCRIPTION
New locators added: 'deleted' and 'imported' records on the manifest import history table.

Assertions criteria changed to these locators.
wait_until_element_go method added to the base.py file. It waits until the element is gone from the page.
delete method from the subscription.py file is updated: now it waits until the subscription note is gone.

Test results:

 py.test tests/foreman/ui/test_subscription.py -v -k 'test_positive_upload_and_delete'
========= test session starts =============================
platform darwin -- Python 2.7.10, pytest-2.9.2, py-1.4.31, pluggy-0.3.1 -- /Users/helgie/robottelo/venv/bin/python
cachedir: .cache
rootdir: /Users/helgie/robottelo, inifile: 
plugins: cov-2.3.0, xdist-1.14
collected 1 items 

tests/foreman/ui/test_subscription.py::SubscriptionTestCase::test_positive_upload_and_delete <- robottelo/decorators/__init__.py PASSED

======= 1 passed in 173.70 seconds ===========