### PR TITLE
Refactored port tunneling for make_proxy - fixes #3453

### DIFF
--- a/robottelo.properties.sample
+++ b/robottelo.properties.sample
@@ -257,3 +257,11 @@ ssh_key=
 # [upgrade]
 # Option for providing a preUpgrade yaml data file location on server
 # upgrade_data=
+
+# section for fake capsule setup.
+[fake_capsules]
+# a range of ports configured for capsule port mapping represented by a tuple:
+#<int>, <int> (no brackets)
+# for RHEL7 - the ports needs to have a correct selinux context set:
+# 'semanage port -a -t websm_port_t -p tcp <port-range>'
+port_range=9091, 14999

--- a/robottelo/cli/factory.py
+++ b/robottelo/cli/factory.py
@@ -40,7 +40,7 @@ from robottelo.cli.operatingsys import OperatingSys
 from robottelo.cli.org import Org
 from robottelo.cli.partitiontable import PartitionTable
 from robottelo.cli.product import Product
-from robottelo.cli.proxy import Proxy, SSHTunnelError, default_url_on_new_port
+from robottelo.cli.proxy import CapsuleTunnelError, Proxy
 from robottelo.cli.repository import Repository
 from robottelo.cli.repository_set import RepositorySet
 from robottelo.cli.role import Role
@@ -60,7 +60,9 @@ from robottelo.constants import (
     TEMPLATE_TYPES,
 )
 from robottelo.decorators import bz_bug_is_open, cacheable
-from robottelo.helpers import update_dictionary
+from robottelo.helpers import (
+    update_dictionary, default_url_on_new_port, get_available_capsule_port
+)
 from robottelo.ssh import upload_file
 from tempfile import mkstemp
 from time import sleep
@@ -616,15 +618,15 @@ def make_proxy(options=None):
     }
 
     if options is None or 'url' not in options:
-        newport = random.randint(9191, 49090)
+        newport = get_available_capsule_port()
         try:
             with default_url_on_new_port(9090, newport) as url:
                 args['url'] = url
                 return create_object(Proxy, args, options)
-        except SSHTunnelError as err:
+        except CapsuleTunnelError as err:
             raise CLIFactoryError(
                 'Failed to create ssh tunnel: {0}'.format(err))
-
+    args['url'] = options['url']
     return create_object(Proxy, args, options)
 
 

--- a/robottelo/cli/proxy.py
+++ b/robottelo/cli/proxy.py
@@ -19,62 +19,11 @@ Subcommands::
     refresh-features              Refresh smart proxy features
     update                        Update a smart proxy.
 """
-import contextlib
-import logging
-
-from robottelo import ssh
 from robottelo.cli.base import Base
-from robottelo.config import settings
-from time import sleep
 
 
-class SSHTunnelError(Exception):
-    """Raised when ssh tunnel creation fails."""
-
-
-@contextlib.contextmanager
-def default_url_on_new_port(oldport, newport):
-    """Creates context where the default smart-proxy is forwarded on a new port
-    REQUIRES GatewayPorts yes in sshd_config
-
-    :param int oldport: Port to be forwarded.
-    :param int newport: New port to be used to forward `oldport`.
-
-    :return: A string containing the new capsule URL with port.
-    :rtype: str
-
-    """
-    logger = logging.getLogger('robottelo')
-    command_timeout = 2
-    domain = settings.server.hostname
-    user = settings.server.ssh_username
-    key = settings.server.ssh_key
-    ssh.upload_file(key, '/tmp/dsa_{0}'.format(newport))
-    ssh.command('chmod 700 /tmp/dsa_{0}'.format(newport))
-
-    with ssh._get_connection() as connection:
-        command = (
-            u'ssh -i {0} -o StrictHostKeyChecking=no -R {1}:{2}:{3} {4}@{5}'
-        ).format(
-            '/tmp/dsa_{0}'.format(newport),
-            newport, domain, oldport, user, domain)
-        logger.debug('Creating tunnel {0}'.format(command))
-        transport = connection.get_transport()
-        channel = transport.open_session()
-        channel.exec_command(command)
-        # if exit_status appears until command_timeout, throw error
-        for _ in range(command_timeout):
-            if channel.exit_status_ready():
-                if channel.recv_exit_status() != 0:
-                    stderr = u''
-                    while channel.recv_stderr_ready():
-                        stderr += channel.recv_stderr(1)
-                    logger.debug('Tunnel failed: {0}'.format(stderr))
-                    # Something failed, so raise an exception.
-                    raise SSHTunnelError(stderr)
-            sleep(1)
-        yield 'https://{0}:{1}'.format(domain, newport)
-        ssh.command('rm -f /tmp/dsa_{0}'.format(newport))
+class CapsuleTunnelError(Exception):
+    """Raised when tunnel creation fails."""
 
 
 class Proxy(Base):

--- a/robottelo/config/settings.py
+++ b/robottelo/config/settings.py
@@ -372,6 +372,28 @@ class LibvirtHostSettings(FeatureSettings):
         return validation_errors
 
 
+class FakeCapsuleSettings(FeatureSettings):
+    """Fake Capsule settings definitions."""
+    def __init__(self, *args, **kwargs):
+        super(FakeCapsuleSettings, self).__init__(*args, **kwargs)
+        self.port_range = None
+
+    def read(self, reader):
+        """Read fake capsule settings"""
+        self.port_range = reader.get(
+            'fake_capsules', 'port_range', cast=tuple
+        )
+
+    def validate(self):
+        """Validate fake capsule settings."""
+        validation_errors = []
+        if self.port_range is None:
+            validation_errors.append(
+                '[fake_capsules] port_range option must be provided.'
+            )
+        return validation_errors
+
+
 class DiscoveryISOSettings(FeatureSettings):
     """Discovery ISO name settings definition."""
     def __init__(self, *args, **kwargs):
@@ -575,6 +597,7 @@ class Settings(object):
         self.compute_resources = LibvirtHostSettings()
         self.discovery = DiscoveryISOSettings()
         self.docker = DockerSettings()
+        self.fake_capsules = FakeCapsuleSettings()
         self.fake_manifest = FakeManifestSettings()
         self.ldap = LDAPSettings()
         self.oscap = OscapSettings()
@@ -618,6 +641,9 @@ class Settings(object):
         if self.reader.has_section('docker'):
             self.docker.read(self.reader)
             self._validation_errors.extend(self.docker.validate())
+        if self.reader.has_section('fake_capsules'):
+            self.fake_capsules.read(self.reader)
+            self._validation_errors.extend(self.fake_capsules.validate())
         if self.reader.has_section('fake_manifest'):
             self.fake_manifest.read(self.reader)
             self._validation_errors.extend(self.fake_manifest.validate())


### PR DESCRIPTION
Will work only after https://github.com/SatelliteQE/automation-tools/issues/381 is merged.

- using ~~`socat`~~`netcat`, we no longer need ssh port forwarding magic (sshd config, cloning the private keys, private key cleanup, etc.)
- The port pool for tunneling is now hardcoded and uses `fuser` command to determine available ports.
- with selinux context correctly set for the hardcoded pool (using a task in automation-tools: https://github.com/SatelliteQE/automation-tools/issues/381) we are able to use the mock capsule with RHEL7 too

```
$ nosetests -m test_positive_create_with_name test_capsule.py
.
----------------------------------------------------------------------
Ran 1 test in 16.671s

OK
```
