### PR TITLE
Created ssh.add_authorized_key function - Closes #3665

### DIFF
--- a/robottelo/helpers.py
+++ b/robottelo/helpers.py
@@ -253,3 +253,20 @@ def remove_katello_ca(hostname=None):
             )
             if result.return_code != 0:
                 raise AssertionError('Failed to reset the rhsm.conf')
+
+
+def add_remote_execution_ssh_key(hostname, key_path=None, **kwargs):
+    """Add remote execution keys to the client
+
+    :param str hostname: The client hostname
+    :param str key: Path to a key on the satellite server
+    :param dict kwargs: directly passed to `ssh.add_authorized_key`
+    """
+
+    # get satellite box ssh-key or defaults to foreman-proxy
+    key_path = key_path or '~foreman-proxy/.ssh/id_rsa_foreman_proxy.pub'
+    # This connection defaults to settings.server
+    server_key = ssh.command('cat %s' % key_path).stdout
+
+    # add that key to the client using hostname and kwargs for connection
+    ssh.add_authorized_key(server_key, hostname=hostname, **kwargs)

--- a/tests/robottelo/test_ssh.py
+++ b/tests/robottelo/test_ssh.py
@@ -1,6 +1,7 @@
 """Tests for module ``robottelo.ssh``."""
 # (too-many-public-methods) pylint: disable=R0904
 import os
+import paramiko
 import six
 
 from robottelo import ssh
@@ -10,6 +11,23 @@ if six.PY2:
     import mock
 else:
     from unittest import mock
+
+
+class MockChannel(object):
+    def __init__(self, ret):
+        self.ret = ret
+
+    def recv_exit_status(self):
+        return self.ret
+
+
+class MockStdout(object):
+    def __init__(self, cmd, ret):
+        self.cmd = cmd
+        self.channel = MockChannel(ret=ret)
+
+    def read(self):
+        return self.cmd
 
 
 class MockSSHClient(object):
@@ -30,6 +48,7 @@ class MockSSHClient(object):
         self.username = None
         self.key_filename = None
         self.password = None
+        self.ret_code = 0
 
     def set_missing_host_key_policy(self, policy):  # pylint:disable=W0613
         """A no-op stub method."""
@@ -58,6 +77,13 @@ class MockSSHClient(object):
     def close(self):
         """A no-op stub method."""
         self.close_ += 1
+
+    def exec_command(self, cmd, *args, **kwargs):
+        return (
+            self.ret_code,
+            MockStdout(cmd, self.ret_code),
+            MockStdout('', self.ret_code)
+        )
 
 
 class SSHTestCase(TestCase):
@@ -118,3 +144,110 @@ class SSHTestCase(TestCase):
         self.assertEqual(connection.set_missing_host_key_policy_, 1)
         self.assertEqual(connection.connect_, 1)
         self.assertEqual(connection.close_, 1)
+
+    def test_valid_ssh_pub_keys(self):
+        valid_keys = (
+            ("ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDuMCPmX7iBXAxH5oLznswA5cc"
+             "fV/FABwIWnYl0OYRkDhv3mu9Eogk4H6sCguq4deJtRkwg2C3yEmsNYfBWYu4y5Rk"
+             "I4TH/k3N161wn91nBxs/+wqoN3g9tUuWrf98PG4NnYvmZU67RuiSUNXpgLEPfo8j"
+             "MKkJ5veKu++DmHdpfqFB9ljWEfWz+kAAKgwo251VRDaKwFsb91LbLFpqn9rfMJUB"
+             "hOn+Uebfd0TrHzw08gbVmvfAn61isvFVhvIJBTjNSWsBIm8SuCvhH+inYOwttfE8"
+             "FGeR1KSp9Xl0PCYDK0BwvQO3qwD+nehsEUR/FJUXm1IZPc8fi17ieGgPOnrgf"
+             " user@new-host"),
+            ("ssh-dss AAAAB3NzaC1kc3MAAACBAMzXU0Jl0fRCKy5B7R8KVKMLJYuhVPagBSi7"
+             "UxRAiVHOHzscQzt5wrgRqknuQ9/xIAVAMUVy3ND5zBLkqKwGm9DKGeYEv7xxDi6Z"
+             "z5QjsI9oSSqFSMauDxgl+foC4QPrIlUvb9ez5bVg6aJHKJEngDo+lvfVROgQOvTx"
+             "I9IXn7oLAAAAFQCz4jDBOnTjkWXgw8sT46HM1jK4SwAAAIAS2BvUlEevY+2YOiqD"
+             "SRy9Dhr+/bWLuLl7oUTEnxPhCyo8paaU0fJO1w3BUsbO3Rg4sBgXChRNyg7iKriB"
+             "WbPH6EK1e6IcYv8wUdobB3wg+RJlYU2cq7V8HcPJh+hfAGfMD6UnTDLg+P5SCEW7"
+             "Ag+knZNwfKv9IAtd0W86EFdVWwAAAIEAkj5boIRqLiUGbRipEzWzZbWMis2S8Ji2"
+             "oR6fUD/h6bZ5ta8nEWApri5OQExK7upelTjSR+MHEDRmeepchkTX0LOjBkZgsPyb"
+             "6nEpQUQUJAuns8yAnhsKuEuZmlAGwXOSKiD/KRyJu4KjbbV4oyKXU1fF70zPLmOT"
+             "fyvserP5qyo= user@new-host"),
+            ("ecdsa-sha2-nistp256 AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAy"
+             "NTYAAABBBPWuLEsYvplkL6XR5wbxzXyzw8tLE/JjLXlzUgxv4LhJN4iufXLPSOvj"
+             "sk0ek1TE059poyy5ps+GU2DkisSUVYA= user@new-host")
+        )
+        for key in valid_keys:
+            self.assertTrue(ssh.is_ssh_pub_key(key))
+
+    def test_invalid_ssh_pub_keys(self):
+        invalid_keys = (
+            "ssh-rsa1 xxxxxx user@host",  # rsa1 is unsafe
+            "foo bar blaz",  # not a valid type
+            "ssh-rsa /gfdgdf/fsdfsdfsdf/@ user@host",  # not valid base64 data
+            "sdhsfbghjsbgjhbg user@host",  # not a valid format
+        )
+        for key in invalid_keys:
+            self.assertFalse(ssh.is_ssh_pub_key(key))
+
+    def test_add_authorized_key_raises_invalid_key(self):
+        with self.assertRaises(AttributeError):
+            ssh.add_authorized_key('sfsdfsdfsdf')
+        with self.assertRaises(AttributeError):
+            ssh.add_authorized_key('sdhsfbghjsbgjhbg user@host')
+        with self.assertRaises(AttributeError):
+            ssh.add_authorized_key('ssh-rsa /gfdgdf/fsdfsdfsdf/@ user@host')
+
+    @mock.patch('robottelo.ssh.settings')
+    def test_add_authorized_key(self, settings):
+        ssh._call_paramiko_sshclient = MockSSHClient  # pylint:disable=W0212
+        settings.server.hostname = 'example.com'
+        settings.server.ssh_username = 'nobody'
+        settings.server.ssh_key = None
+        settings.server.ssh_password = 'test_password'
+        ssh.add_authorized_key('ssh-rsa xxxx user@host')
+
+    @mock.patch('robottelo.ssh.settings')
+    def test_execute_command(self, settings):
+        ssh._call_paramiko_sshclient = MockSSHClient  # pylint:disable=W0212
+        settings.server.hostname = 'example.com'
+        settings.server.ssh_username = 'nobody'
+        settings.server.ssh_key = None
+        settings.server.ssh_password = 'test_password'
+        with ssh._get_connection() as connection:  # pylint:disable=W0212
+            ret = ssh.execute_command('ls -la', connection)
+            self.assertEquals(ret.stdout, u'ls -la')
+            self.assertIsInstance(ret, ssh.SSHCommandResult)
+
+    @mock.patch('robottelo.ssh.settings')
+    def test_command(self, settings):
+        ssh._call_paramiko_sshclient = MockSSHClient  # pylint:disable=W0212
+        settings.server.hostname = 'example.com'
+        settings.server.ssh_username = 'nobody'
+        settings.server.ssh_key = None
+        settings.server.ssh_password = 'test_password'
+
+        ret = ssh.command('ls -la')
+        self.assertEquals(ret.stdout, u'ls -la')
+        self.assertIsInstance(ret, ssh.SSHCommandResult)
+
+    @mock.patch('robottelo.ssh.settings')
+    def test_parse_csv(self, settings):
+        ssh._call_paramiko_sshclient = MockSSHClient  # pylint:disable=W0212
+        settings.server.hostname = 'example.com'
+        settings.server.ssh_username = 'nobody'
+        settings.server.ssh_key = None
+        settings.server.ssh_password = 'test_password'
+
+        ret = ssh.command('a,b,c\n1,2,3', output_format='csv')
+        self.assertEquals(ret.stdout, [{u'a': u'1', u'b': u'2', u'c': u'3'}])
+        self.assertIsInstance(ret, ssh.SSHCommandResult)
+
+    @mock.patch('robottelo.ssh.settings')
+    def test_parse_json(self, settings):
+        ssh._call_paramiko_sshclient = MockSSHClient  # pylint:disable=W0212
+        settings.server.hostname = 'example.com'
+        settings.server.ssh_username = 'nobody'
+        settings.server.ssh_key = None
+        settings.server.ssh_password = 'test_password'
+
+        ret = ssh.command('{"a": 1, "b": true}', output_format='json')
+        self.assertEquals(ret.stdout, {u'a': u'1', u'b': True})
+        self.assertIsInstance(ret, ssh.SSHCommandResult)
+
+    def test_call_paramiko_client(self):
+        self.assertIsInstance(
+            ssh._call_paramiko_sshclient(),
+            (paramiko.SSHClient, MockSSHClient)
+        )


### PR DESCRIPTION
Closes #3665

```console
$ cd robottelo
$ python manage.py shell
In [1]: from robottelo.ssh  import add_authorized_key
In [2]: add_authorized_key('/tmp/test_rsa.pub')  # path, file-like or string-key

2016-07-28 20:06:12 - robottelo.ssh - INFO - Instantiated Paramiko client 0x7fd1f97fb690
2016-07-28 20:06:12 - robottelo.ssh - DEBUG - Connected to [FQDN.redhat.com]
2016-07-28 20:06:12 - robottelo.ssh - DEBUG - >>> mkdir -p ~/.ssh
2016-07-28 20:06:13 - robottelo.ssh - DEBUG - >>> grep -q 'ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDuMCPmX7iBXAxH5oLznswA5ccfV/FABwIWnYl0OYRkDhv3mu9Eogk4H6sCguq4deJtRkwg2C3yEmsNYfBWYu4y5RkI4TH/k3N161wn91nBxs/+wqoN3g9tUuWrf98PG4NnYvmZU67RuiSUNXpgLEPfo8jMKkJ5veKu++DmHdpfqFB9ljWEfWz+kAAKgwo251VRDaKwFsb91LbLFpqn9rfMJUBhOn+Uebfd0TrHzw08gbVmvfAn61isvFVhvIJBTjNSWsBIm8SuCvhH+inYOwttfE8FGeR1KSp9Xl0PCYDK0BwvQO3qwD+nehsEUR/FJUXm1IZPc8fi17ieGgPOnrgf user@new-host' ~/.ssh/authorized_keys || echo 'ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDuMCPmX7iBXAxH5oLznswA5ccfV/FABwIWnYl0OYRkDhv3mu9Eogk4H6sCguq4deJtRkwg2C3yEmsNYfBWYu4y5RkI4TH/k3N161wn91nBxs/+wqoN3g9tUuWrf98PG4NnYvmZU67RuiSUNXpgLEPfo8jMKkJ5veKu++DmHdpfqFB9ljWEfWz+kAAKgwo251VRDaKwFsb91LbLFpqn9rfMJUBhOn+Uebfd0TrHzw08gbVmvfAn61isvFVhvIJBTjNSWsBIm8SuCvhH+inYOwttfE8FGeR1KSp9Xl0PCYDK0BwvQO3qwD+nehsEUR/FJUXm1IZPc8fi17ieGgPOnrgf user@new-host' >> ~/.ssh/authorized_keys
2016-07-28 20:06:13 - robottelo.ssh - DEBUG - >>> chmod 700 ~/.ssh
2016-07-28 20:06:14 - robottelo.ssh - DEBUG - >>> chmod 600 ~/.ssh/authorized_keys
2016-07-28 20:06:15 - robottelo.ssh - DEBUG - >>> chown -R root ~/.ssh
2016-07-28 20:06:16 - robottelo.ssh - DEBUG - >>> command -v restorecon && restorecon -RvF ~/.ssh || true
2016-07-28 20:06:16 - robottelo.ssh - DEBUG - <<< stdout /usr/sbin/restorecon
2016-07-28 20:06:16 - robottelo.ssh - INFO - Destroying Paramiko client 0x7fd1f97fb690
2016-07-28 20:06:17 - robottelo.ssh - INFO - Destroyed Paramiko client 0x7fd1f97fb690
```