### PR TITLE
Updated one_to_one_names to correspond changes in API.

### DIFF
--- a/robottelo/api/utils.py
+++ b/robottelo/api/utils.py
@@ -79,14 +79,14 @@ def one_to_one_names(name):
 
     Example of usage::
 
-        >>> one_to_many_names('person') == {'person', 'person_id'}
+        >>> one_to_many_names('person') == {'person_name', 'person_id'}
         True
 
     :param name: A field name.
     :returns: A set including both ``name`` and variations on ``name``.
 
     """
-    return set((name, name + '_id'))
+    return set((name + '_name', name + '_id'))
 
 
 def one_to_many_names(name):

--- a/tests/foreman/api/test_hostgroup.py
+++ b/tests/foreman/api/test_hostgroup.py
@@ -1082,14 +1082,16 @@ class HostGroupMissingAttrTestCase(APITestCase):
 
         @id: 9d42f47a-2f08-45ad-97d0-de94f0f1de2f
 
-        @Assert: The response contains some value for the ``content_source``
+        @Assert: The response contains both values for the ``content_source``
         field.
         """
         names = one_to_one_names('content_source')
-        self.assertGreater(
-            len(names & self.host_group_attrs),
-            1,
-            'None of {0} are in {1}'.format(names, self.host_group_attrs)
+        self.assertTrue(
+            names.issubset(self.host_group_attrs),
+            '{0} not found in {1}'.format(
+                names.difference(self.host_group_attrs),
+                self.host_group_attrs
+            )
         )
 
     @tier1
@@ -1098,14 +1100,16 @@ class HostGroupMissingAttrTestCase(APITestCase):
 
         @id: 7d36f33e-f161-4d2a-9ee4-8eb949ed4cbf
 
-        @Assert: The response contains some value for the ``content_view``
+        @Assert: The response contains both values for the ``content_view``
         field.
         """
         names = one_to_one_names('content_view')
-        self.assertGreater(
-            len(names & self.host_group_attrs),
-            1,
-            'None of {0} are in {1}'.format(names, self.host_group_attrs)
+        self.assertTrue(
+            names.issubset(self.host_group_attrs),
+            '{0} not found in {1}'.format(
+                names.difference(self.host_group_attrs),
+                self.host_group_attrs
+            )
         )
 
     @tier1
@@ -1114,12 +1118,14 @@ class HostGroupMissingAttrTestCase(APITestCase):
 
         @id: efa17f59-47f9-40c6-821d-c348c4d852ff
 
-        @Assert: The response contains some value for the
+        @Assert: The response contains both values for the
         ``lifecycle_environment`` field.
         """
         names = one_to_one_names('lifecycle_environment')
-        self.assertGreater(
-            len(names & self.host_group_attrs),
-            1,
-            'None of {0} are in {1}'.format(names, self.host_group_attrs)
+        self.assertTrue(
+            names.issubset(self.host_group_attrs),
+            '{0} not found in {1}'.format(
+                names.difference(self.host_group_attrs),
+                self.host_group_attrs
+            )
         )

--- a/tests/robottelo/test_api_utils.py
+++ b/tests/robottelo/test_api_utils.py
@@ -10,7 +10,7 @@ class UtilsTestCase(TestCase):
         """Test :func:`robottelo.api.utils.one_to_one_names`."""
         self.assertEqual(
             utils.one_to_one_names('person'),
-            {'person', 'person_id'},
+            {'person_name', 'person_id'},
         )
 
     def test_one_to_many_names(self):


### PR DESCRIPTION
Updated tests in `HostGroupMissingAttrTestCase`. Now both fields, `*_id` and `*_name`, are required.
Fixes #3671

```python
py.test -v -k 'HostGroupMissingAttrTestCase' tests/foreman/api/test_hostgroup.py 
============================================== test session starts ==============================================
platform linux2 -- Python 2.7.12, pytest-2.9.2, py-1.4.31, pluggy-0.3.1 -- /home/qui/code/robottelo/venv2/bin/python2.7
cachedir: .cache
rootdir: /home/qui/code/robottelo, inifile: 
plugins: cov-2.3.0, xdist-1.14
collected 43 items 

tests/foreman/api/test_hostgroup.py::HostGroupMissingAttrTestCase::test_positive_get_content_source PASSED
tests/foreman/api/test_hostgroup.py::HostGroupMissingAttrTestCase::test_positive_get_cv PASSED
tests/foreman/api/test_hostgroup.py::HostGroupMissingAttrTestCase::test_positive_get_lce PASSED

============================ 40 tests deselected by '-kHostGroupMissingAttrTestCase' ============================
==================================== 3 passed, 40 deselected in 3.32 seconds ====================================
```