### PR TITLE
Fix regression for CLI tests

### DIFF
--- a/robottelo/ssh.py
+++ b/robottelo/ssh.py
@@ -261,7 +261,7 @@ def execute_command(cmd, connection, output_format=None, timeout=120):
         # Convert to unicode string and remove all color codes characters
         stderr = regex.sub('', decode_to_utf8(stderr))
         logger.debug('<<< stderr\n%s', stderr)
-    if stdout and output_format == 'csv':
+    if stdout and output_format != 'json':
         # Only for hammer commands
         # for output we don't really want to see all of Rails traffic
         # information, so strip it out.

--- a/tests/robottelo/test_ssh.py
+++ b/tests/robottelo/test_ssh.py
@@ -207,7 +207,7 @@ class SSHTestCase(TestCase):
         settings.server.ssh_password = 'test_password'
         with ssh._get_connection() as connection:  # pylint:disable=W0212
             ret = ssh.execute_command('ls -la', connection)
-            self.assertEquals(ret.stdout, u'ls -la')
+            self.assertEquals(ret.stdout, [u'ls -la'])
             self.assertIsInstance(ret, ssh.SSHCommandResult)
 
     @mock.patch('robottelo.ssh.settings')
@@ -219,7 +219,7 @@ class SSHTestCase(TestCase):
         settings.server.ssh_password = 'test_password'
 
         ret = ssh.command('ls -la')
-        self.assertEquals(ret.stdout, u'ls -la')
+        self.assertEquals(ret.stdout, [u'ls -la'])
         self.assertIsInstance(ret, ssh.SSHCommandResult)
 
     @mock.patch('robottelo.ssh.settings')


### PR DESCRIPTION
Partially reverts #3670 
Huge part of our CLI commands don't have any `output_format` specified, so it's set to `None` instead of `csv`, following check is skipped and basically that's why all the CLI tests failed in the latest run on Jenkins.
Quick PR to revert it back to make everything workable. Some random cli test result:
```python
py.test tests/foreman/cli/test_contentview.py -v -k 'test_positive_delete_by_id'
============================== test session starts ==============================
platform linux2 -- Python 2.7.10, pytest-2.9.2, py-1.4.31, pluggy-0.3.1 -- /home/andrii/env/bin/python
cachedir: .cache
rootdir: /home/andrii/workspace/robottelo, inifile: 
plugins: xdist-1.13.1, repeat-0.2
collected 49 items 

tests/foreman/cli/test_contentview.py::ContentViewTestCase::test_positive_delete_by_id <- robottelo/decorators/__init__.py PASSED

============= 48 tests deselected by '-ktest_positive_delete_by_id' =============
=================== 1 passed, 48 deselected in 53.29 seconds ====================
```