### PR TITLE
fixes nc compatibility issues for RHEL6 - using ncat instead

### DIFF
--- a/robottelo/helpers.py
+++ b/robottelo/helpers.py
@@ -311,7 +311,13 @@ def get_available_capsule_port(port_pool=None):
         )
     # converts a List of strings to a List of integers
     try:
-        used_ports = (map(int, fuser_cmd.stdout[:-1]))
+        print(fuser_cmd)
+        used_ports = map(
+            int,
+            [val for val in fuser_cmd.stdout[:-1]
+                if val != 'Cannot stat file ']
+        )
+
     except ValueError:
         raise CapsuleTunnelError(
             'Failed parsing the port numbers from stdout: {0}'
@@ -344,7 +350,7 @@ def default_url_on_new_port(oldport, newport):
 
     with ssh._get_connection() as connection:
         command = (
-            u'nc -kl -p {0} -c "nc {1} {2}"'
+            u'ncat -kl -p {0} -c "ncat {1} {2}"'
         ).format(newport, domain, oldport)
         logger.debug('Creating tunnel: {0}'.format(command))
         transport = connection.get_transport()


### PR DESCRIPTION
There was an incompatibility error with `RHEL6` this time, where `nc` does not support `-c` option.
We replaced the original `nc` by `ncat`:

```
# cat /etc/*release
LSB_VERSION=base-4.0-amd64:base-4.0-noarch:core-4.0-amd64:core-4.0-noarch:graphics-4.0-amd64:graphics-4.0-noarch:printing-4.0-amd64:printing-4.0-noarch
Red Hat Enterprise Linux Server release 6.8 (Santiago)
Red Hat Enterprise Linux Server release 6.8 (Santiago)

# ncat -kl -p 12345 -c "nc localhost 9090" &
[1] 30808

# curl -k https://my-host-1.domain.com:12345
<!DOCTYPE html>
<html>
<head>
  <style type="text/css">
  body { text-align:center;font-family:helvetica,arial;font-size:22px;
    color:#888;margin:20px}
  #c {margin:0 auto;width:500px;text-align:left}
  </style>
</head>
<body>
  <h2>Sinatra doesn&rsquo;t know this ditty.</h2>
  <img src='https://my-host-1.domain.com:12345/__sinatra__/404.png'>
  <div id="c">
    Try this:
    <pre>get '/' do
  "Hello World"
end</pre>
  </div>
</body>
</html>
```

Also, a minor fix for `fuser` call has been introduced, where we remove occasional `Cannot stat file ` string from `stdout` - This happens to `fuser` sometimes as the process might die during `fuser` is listing its file descriptor - this actually means the port is no longer owned by the process, so we want to keep it in the pool of available ports.

```
$ py.test test_capsule.py -n6
===================================== test session starts =====================================
platform linux2 -- Python 2.7.11, pytest-2.9.2, py-1.4.31, pluggy-0.3.1
rootdir: /home/rplevka/work/rplevka/robottelo, inifile: 
plugins: xdist-1.14
gw0 [15] / gw1 [15] / gw2 [15] / gw3 [15] / gw4 [15] / gw5 [15]
scheduling tests via LoadScheduling
.sss.....ssssss
============================ 6 passed, 9 skipped in 25.91 seconds =============================
```