### PR TITLE
ostree sync and content-view related tests with custom repo

### DIFF
--- a/robottelo/constants.py
+++ b/robottelo/constants.py
@@ -155,6 +155,13 @@ CHECKSUM_TYPE = {
     'sha1': "sha1",
 }
 
+REPO_TAB = {
+    'rpms': "RPMs",
+    'kickstarts': "Kickstarts",
+    'isos': "ISOs",
+    'ostree': "OSTree",
+}
+
 # On importing manifests, Red Hat repositories are listed like this:
 # Product -> RepositorySet -> Repository
 # We need to first select the Product, then the reposet and then the repos
@@ -162,6 +169,7 @@ CHECKSUM_TYPE = {
 PRDS = {
     'rhcf': 'Red Hat CloudForms',
     'rhel': 'Red Hat Enterprise Linux Server',
+    'rhah': 'Red Hat Enterprise Linux Atomic Host',
 }
 
 REPOSET = {
@@ -172,6 +180,7 @@ REPOSET = {
     ),
     'rhst7': 'Red Hat Satellite Tools 6.1 (for RHEL 7 Server) (RPMs)',
     'rhst6': 'Red Hat Satellite Tools 6.1 (for RHEL 6 Server) (RPMs)',
+    'rhaht': 'Red Hat Enterprise Linux Atomic Host (Trees)'
 }
 
 REPOS = {
@@ -199,6 +208,9 @@ REPOS = {
             'Red Hat Enterprise Virtualization Agents for RHEL 6 Server RPMs '
             'x86_64 6.5'
         ),
+    },
+    'rhaht': {
+        'name': ('Red Hat Enterprise Linux Atomic Host Trees'),
     },
 }
 
@@ -231,6 +243,13 @@ SAT6_TOOLS_TREE = [
      'Red Hat Satellite Tools 6.1 for RHEL 6 Server RPMs x86_64'),
     ('rhel', 'rhst6', 'rhst6', 'repo_arch', 'x86_64'),
     ('rhel', 'rhst6', 'rhst6', 'repo_ver', '6.1'),
+]
+
+ATOMIC_HOST_TREE = [
+    ('rhah', 'rhaht', 'rhaht', 'repo_name',
+     'Red Hat Enterprise Linux Atomic Host Trees'),
+    ('rhah', 'rhaht', 'rhaht', 'repo_arch', None),
+    ('rhah', 'rhaht', 'rhaht', 'repo_ver', None),
 ]
 
 DEFAULT_ORG_ID = 1

--- a/robottelo/ui/contentviews.py
+++ b/robottelo/ui/contentviews.py
@@ -164,6 +164,8 @@ class ContentViews(Base):
             self.click(locators['contentviews.content_repo'])
         elif repo_type == 'docker':
             self.click(tab_locators['contentviews.tab_docker_content'])
+        elif repo_type == 'ostree':
+            self.click(tab_locators['contentviews.tab_ostree_content'])
         strategy, value = locators['contentviews.select_repo']
         for repo_name in repo_names:
             if add_repo:

--- a/robottelo/ui/locators/base.py
+++ b/robottelo/ui/locators/base.py
@@ -1276,8 +1276,17 @@ locators = LocatorDict({
          "div/form/div[2]/div/span[contains(@class,'editable')]")),
 
     # Enable RH Repos expander
-    "rh.prd_expander": (
+    "rh.rpms_prd_expander": (
         By.XPATH, ("//div[@id='ui-tabs-1']//td[contains(.,'%s')]"
+                   "/span[@class='expander']")),
+    "rh.kickstarts_prd_expander": (
+        By.XPATH, ("//div[@id='ui-tabs-2']//td[contains(.,'%s')]"
+                   "/span[@class='expander']")),
+    "rh.isos_prd_expander": (
+        By.XPATH, ("//div[@id='ui-tabs-6']//td[contains(.,'%s')]"
+                   "/span[@class='expander']")),
+    "rh.ostree_prd_expander": (
+        By.XPATH, ("//div[@id='ui-tabs-7']//td[contains(.,'%s')]"
                    "/span[@class='expander']")),
     "rh.reposet_expander": (
         By.XPATH, ("//span[contains(@class, 'expander_area') and "

--- a/robottelo/ui/locators/tab.py
+++ b/robottelo/ui/locators/tab.py
@@ -141,6 +141,9 @@ tab_locators = LocatorDict({
     "contentviews.tab_docker_content": (
         By.XPATH,
         "//a[@class='ng-scope' and contains(@href, 'docker')]"),
+    "contentviews.tab_ostree_content": (
+        By.XPATH,
+        "//a[@class='ng-scope' and contains(@href, 'ostree')]"),
     "contentviews.tab_history": (
         By.XPATH, "//a[@class='ng-scope' and contains(@href, 'history')]"),
     "contentviews.tab_tasks": (
@@ -235,6 +238,18 @@ tab_locators = LocatorDict({
         By.XPATH, "//a[contains(@ui-sref, 'details.products')]/span/span"),
 
     # Manifest / subscriptions
+    "manifest.rpms_tab": (
+        By.XPATH,
+        "//div[@id='content_tabs']/ul/li/a[contains(@href, 'rpms')]"),
+    "manifest.kickstarts_tab": (
+        By.XPATH,
+        "//div[@id='content_tabs']/ul/li/a[contains(@href, 'kickstarts')]"),
+    "manifest.isos_tab": (
+        By.XPATH,
+        "//div[@id='content_tabs']/ul/li/a[contains(@href, 'isos')]"),
+    "manifest.ostree_tab": (
+        By.XPATH,
+        "//div[@id='content_tabs']/ul/li/a[contains(@href, 'ostree')]"),
     "subs.tab_details": (
         By.XPATH, "//a[contains(@ui-sref,'manifest.details')]"),
     "subs.import_history": (

--- a/robottelo/ui/sync.py
+++ b/robottelo/ui/sync.py
@@ -8,7 +8,7 @@ from collections import defaultdict
 from functools import partial
 from robottelo.constants import PRDS, REPOSET
 from robottelo.ui.base import Base
-from robottelo.ui.locators import locators
+from robottelo.ui.locators import locators, tab_locators
 
 
 class Sync(Base):
@@ -118,7 +118,7 @@ class Sync(Base):
             repos_tree[p][rs][r][ra] = value
         return repos_tree
 
-    def enable_rh_repos(self, repos_tree):
+    def enable_rh_repos(self, repos_tree, repo_tab):
         """Enables Red Hat Repos, after importing a RedHat Manifest.
 
         We need to first select the PRD to enable, then the reposet
@@ -126,10 +126,18 @@ class Sync(Base):
         each reposet could have multiple repos.
 
         :param repos_tree: Repositories to enable which is a List of dictionary
+        :param str repo_tab: To select Repository tab from RH repositories page
         :return: None.
 
         """
-        strategy, value = locators['rh.prd_expander']
+        # Locator to select content tabs from Red Hat repositories page
+        # e.g. 'RPMs', 'KIckstarts', 'ISOs', 'OSTree'
+        repo_tab_locator = 'manifest.{0}_tab'.format(repo_tab.lower())
+        self.click(tab_locators[repo_tab_locator])
+        # Locator to select product expander from Red Hat repositories page,
+        # its based on content tabs
+        product_expander_loc = 'rh.{0}_prd_expander'.format(repo_tab.lower())
+        strategy, value = locators[product_expander_loc]
         strategy1, value1 = locators['rh.reposet_expander']
         strategy2, value2 = locators['rh.reposet_checkbox']
         strategy3, value3 = locators['rh.repo_checkbox']

--- a/tests/foreman/endtoend/test_ui_endtoend.py
+++ b/tests/foreman/endtoend/test_ui_endtoend.py
@@ -33,6 +33,7 @@ from robottelo.constants import (
     REPOS,
     REPOSET,
     REPO_TYPE,
+    REPO_TAB,
     RHVA_REPO_TREE,
     SAT6_TOOLS_TREE,
     FAKE_6_PUPPET_REPO,
@@ -212,7 +213,7 @@ class EndToEndTestCase(UITestCase, ClientProvisioningMixin):
             # step 2.7: Enable a Red Hat repository
             if self.fake_manifest_is_set:
                 session.nav.go_to_red_hat_repositories()
-                self.sync.enable_rh_repos(repos)
+                self.sync.enable_rh_repos(repos, REPO_TAB['rpms'])
 
             # step 2.8: Synchronize the three repositories
             self.navigator.go_to_sync_status()
@@ -359,7 +360,7 @@ class EndToEndTestCase(UITestCase, ClientProvisioningMixin):
             session.nav.go_to_red_hat_repositories()
             # List of dictionary passed to enable the redhat repos
             # It selects Product->Reposet-> Repo
-            self.sync.enable_rh_repos(repos)
+            self.sync.enable_rh_repos(repos, REPO_TAB['rpms'])
             session.nav.go_to_sync_status()
             # Sync the repos
             # syn.sync_rh_repos returns boolean values and not objects


### PR DESCRIPTION
- since we don't have atomic tree subscription in automation manifest so most of the tests are around custom ostree repo.
- However I added support for RH atomic host Tree too (but its untested)