### PR TITLE
Added verification if passed to hammer options supported by CLI factory

### DIFF
--- a/robottelo/cli/factory.py
+++ b/robottelo/cli/factory.py
@@ -92,6 +92,13 @@ def create_object(cli_object, options, values):
     :return: A dictionary representing the newly created resource.
 
     """
+    if values:
+        diff = set(values.keys()).difference(set(options.keys()))
+        if diff:
+            logger.debug(
+                "Option(s) {0} not supported by CLI factory. Please check for "
+                "a typo or update default options".format(diff)
+            )
     update_dictionary(options, values)
     try:
         result = cli_object.create(options)


### PR DESCRIPTION
Personally I found it very frustrating to spend time playing around with `hammer` and `make_${entity_name}` methods just to find that passed to method options weren't declared in its body and as result were silently dropped.

Added quick check and logging to `create_object` method that is called by every `make_$entity` method.

Not supported option added:
```
make_architecture({'name': "testme", 'missingopt': "missing"})
2016-08-09 15:41:20 - robottelo.cli.factory - DEBUG - Option(s) set(['missingopt']) not supported by CLI factory. Please check for a typo or update default options
2016-08-09 15:41:22 - robottelo.ssh - INFO - Instantiated Paramiko client 0x7f3a98a58950
2016-08-09 15:41:22 - robottelo.ssh - DEBUG - Connected to [example.com]
2016-08-09 15:41:22 - robottelo.ssh - DEBUG - >>> LANG=en_US.UTF-8  hammer -v -u admin -p changeme --output=csv architecture create --name="testme"
2016-08-09 15:41:24 - robottelo.ssh - DEBUG - <<< stdout
Message,Id,Name
Architecture created,20,testme
```

Only supported options
```
make_architecture({'name': "test"})
2016-08-09 15:38:23 - robottelo.ssh - INFO - Instantiated Paramiko client 0x7f180f13add0
2016-08-09 15:38:23 - robottelo.ssh - DEBUG - Connected to [example.com]
2016-08-09 15:38:23 - robottelo.ssh - DEBUG - >>> LANG=en_US.UTF-8  hammer -v -u admin -p changeme --output=csv architecture create --name="test"
2016-08-09 15:38:25 - robottelo.ssh - DEBUG - <<< stdout
Message,Id,Name
Architecture created,19,test
```