### PR TITLE
#3600 Issue related - create a composite content view 

### DIFF
--- a/tests/foreman/cli/test_contentview.py
+++ b/tests/foreman/cli/test_contentview.py
@@ -645,6 +645,43 @@ class ContentViewTestCase(CLITestCase):
             'version was not associated to composite CV',
         )
 
+    @tier2
+    @run_only_on('sat')
+    def test_positive_create_composite_with_component_ids(self):
+        """create a composite content view with a component_ids option
+
+        @id: 6d4b94da-258d-4690-a5b6-bacaf6b1671a
+
+        @assert: Composite content view component ids are similar to the
+        nested content view versions ids
+
+        @CaseLevel: Integration
+        """
+        # Create CV
+        new_cv = make_content_view({u'organization-id': self.org['id']})
+        # Publish a new version of CV twice
+        for _ in range(2):
+            ContentView.publish({u'id': new_cv['id']})
+        new_cv = ContentView.info({u'id': new_cv['id']})
+        # Let us now store the version ids
+        component_ids = [new_cv['versions'][0]['id'],
+                         new_cv['versions'][1]['id']]
+        # Create CV
+        comp_cv = make_content_view({
+            'composite': True,
+            'organization-id': self.org['id'],
+            'component-ids': component_ids
+        })
+        # Assert whether the composite content view components IDs are equal
+        # to the component_ids input values
+        comp_cv = ContentView.info({u'id': comp_cv['id']})
+        self.assertEqual(
+            [comp['id'] for comp in comp_cv['components']],
+            component_ids,
+            'IDs of the composite content view components differ from '
+            'the input values',
+        )
+
     # Content Views: Adding products/repos
 
     @run_in_one_thread


### PR DESCRIPTION
#3600 Issue related. 

Test for creating composite content-view with --component-ids option

Test-reasult: 

test_positive_create_composite_with_component_ids added

$ py.test tests/foreman/cli/test_contentview.py -k test_positive_create_composite_with_component_ids 
============= test session starts =======platform darwin -- Python 2.7.10, pytest-2.9.2, py-1.4.31, pluggy-0.3.1
rootdir: /Users/helgie/robottelo, inifile: 
plugins: cov-2.3.0, xdist-1.14
collected 50 items 

tests/foreman/cli/test_contentview.py .
============ 49 tests deselected by '-ktest_positive_create_composite_with_component_ids' =============
==================== 1 passed, 49 deselected in 76.95 seconds ==============