### PR TITLE
Fix test_remoteexecution failure due to ssh.command wrong output format

### DIFF
--- a/robottelo/helpers.py
+++ b/robottelo/helpers.py
@@ -57,7 +57,7 @@ class ServerFileDownloader(object):
             file will be downloaded.
         :returns: Returns complete file path with name of downloaded file.
         """
-        if not self.file_downloaded:
+        if not self.file_downloaded:  # pragma: no cover
             self.fd, self.file_path = mkstemp(suffix='.{}'.format(extention))
             fileobj = os.fdopen(self.fd, 'w')
             fileobj.write(requests.get(fileurl).content)
@@ -269,7 +269,7 @@ def add_remote_execution_ssh_key(hostname, key_path=None, **kwargs):
     # get satellite box ssh-key or defaults to foreman-proxy
     key_path = key_path or '~foreman-proxy/.ssh/id_rsa_foreman_proxy.pub'
     # This connection defaults to settings.server
-    server_key = ssh.command('cat %s' % key_path).stdout
+    server_key = ssh.command('cat %s' % key_path, output_format='plain').stdout
 
     # add that key to the client using hostname and kwargs for connection
     ssh.add_authorized_key(server_key, hostname=hostname, **kwargs)

--- a/robottelo/ssh.py
+++ b/robottelo/ssh.py
@@ -42,7 +42,7 @@ class SSHCommandResult(object):
         return tmpl.format(**self.__dict__)
 
 
-def _call_paramiko_sshclient():
+def _call_paramiko_sshclient():  # pragma: no cover
     """Call ``paramiko.SSHClient``.
 
     This function does not alter the behaviour of ``paramiko.SSHClient``. It
@@ -136,11 +136,11 @@ def add_authorized_key(key, hostname=None, username=None, password=None,
     """
 
     if getattr(key, 'read', None):  # key is a file-like object
-        key_content = key.read()
+        key_content = key.read()  # pragma: no cover
     elif is_ssh_pub_key(key):  # key is a valid key-string
         key_content = key
     elif os.path.exists(key):  # key is a path to a pub key-file
-        with open(key, 'r') as key_file:
+        with open(key, 'r') as key_file:  # pragma: no cover
             key_content = key_file.read()
     else:
         raise AttributeError('Invalid key')
@@ -181,7 +181,7 @@ def upload_file(local_file, remote_file, hostname=None):
     :param hostname: target machine hostname. If not provided will be used the
         ``server.hostname`` from the configuration.
     """
-    with get_connection(hostname=hostname) as connection:
+    with get_connection(hostname=hostname) as connection:  # pragma: no cover
         try:
             sftp = connection.open_sftp()
             # Check if local_file is a file-like object and use the proper
@@ -199,9 +199,9 @@ def download_file(remote_file, local_file=None, hostname=None):
     provided will be used the server.
 
     """
-    if local_file is None:
+    if local_file is None:  # pragma: no cover
         local_file = remote_file
-    with get_connection(hostname=hostname) as connection:
+    with get_connection(hostname=hostname) as connection:  # pragma: no cover
         try:
             sftp = connection.open_sftp()
             sftp.get(remote_file, local_file)
@@ -240,7 +240,7 @@ def execute_command(cmd, connection, output_format=None, timeout=120):
 
     :param cmd: a command to be executed via ssh
     :param connection: SSH Paramiko client connection
-    :param output_format: json|csv valid only for hammer commands
+    :param output_format: plain|json|csv valid only for hammer commands
     :param timeout: defaults to 120
     :return: SSHCommandResult
     """
@@ -261,8 +261,9 @@ def execute_command(cmd, connection, output_format=None, timeout=120):
         # Convert to unicode string and remove all color codes characters
         stderr = regex.sub('', decode_to_utf8(stderr))
         logger.debug('<<< stderr\n%s', stderr)
-    if stdout and output_format != 'json':
-        # Only for hammer commands
+    # we don't want a list as output of 'plain' just pure text
+    if stdout and output_format not in ('json', 'plain'):
+        # Mostly only for hammer commands
         # for output we don't really want to see all of Rails traffic
         # information, so strip it out.
         # Empty fields are returned as "" which gives us u'""'
@@ -283,6 +284,10 @@ def is_ssh_pub_key(key):
     :param key: A string containing a ssh public key encoded in base64
     :return: Boolean
     """
+
+    if not isinstance(key, six.string_types):
+        raise ValueError(
+            "Key should be a string type, received: %s" % type(key))
 
     # 1) a valid pub key has 3 parts separated by space
     try:


### PR DESCRIPTION
The following failure in automation:

```console
Test Result : tests.foreman.ui.test_remoteexecution
@tier2
    def test_positive_run_default_job_template(self):
        """Run a job template against a single host
...
>           key_type, key_string, comment = key.split()
E           AttributeError: 'list' object has no attribute 'split'
```

happening because a change introduced in https://github.com/SatelliteQE/robottelo/commit/5b91121dcc38f218fcc977469a009e38db6c98b4

Rational:

Our SSHCommandResult tries to transform **csv** outputs into a **list** striping out **rails** specific messages, but that should be done only for hammer commands with **csv** output defined, currently most tests pass None as output format but expects to be hammer **csv**.

So I added a new out_format **plain** which skips the transformation of the command output in to a list returning only the pure plain text stdout.

Now ssh key upload works again using the plain text output.

Added some `# pragma: no cover` on places where we are not going to unit-test (mostly related to file uploads)