### PR TITLE
Fix all 'context.exception.message' test verifications

### DIFF
--- a/robottelo/ui/contentviews.py
+++ b/robottelo/ui/contentviews.py
@@ -295,7 +295,14 @@ class ContentViews(Base):
         otherwise remove_contentView
         """
         self.click(self.search(composite_cv))
-        self.click(tab_locators['contentviews.tab_content_views'])
+        if self.wait_until_element(
+                tab_locators['contentviews.tab_content_views']):
+            self.click(tab_locators['contentviews.tab_content_views'])
+        else:
+            raise UINoSuchElementError(
+                'Could not find ContentView tab, please make sure '
+                'selected view is composite'
+            )
         for cv_name in cv_names:
             if is_add:
                 self.click(tab_locators['contentviews.tab_cv_add'])

--- a/robottelo/ui/settings.py
+++ b/robottelo/ui/settings.py
@@ -41,17 +41,21 @@ class Settings(Base):
         self.click(tab_locator)
 
         strategy, value = locators['settings.edit_param']
-        self.click((strategy, value % param_name))
-
-        if value_type == 'dropdown':
-            self.select(locators['settings.select_value'], param_value)
-        elif value_type == 'input':
-            self.wait_until_element(locators['settings.input_value'])
-            self.field_update('settings.input_value', param_value)
+        if self.wait_until_element((strategy, value % param_name)) is None:
+            raise UINoSuchElementError(
+                'Could not find edit button to update selected param'
+            )
         else:
-            raise OptionError('Please input appropriate value type')
-        self.wait_for_ajax()
-        self.click(locators['settings.save'])
+            self.click((strategy, value % param_name))
+            if value_type == 'dropdown':
+                self.select(locators['settings.select_value'], param_value)
+            elif value_type == 'input':
+                self.wait_until_element(locators['settings.input_value'])
+                self.field_update('settings.input_value', param_value)
+            else:
+                raise OptionError('Please input appropriate value type')
+            self.wait_for_ajax()
+            self.click(locators['settings.save'])
 
     def get_saved_value(self, tab_locator, param_name):
         """Fetch the updated value to assert"""

--- a/tests/foreman/ui/test_contentview.py
+++ b/tests/foreman/ui/test_contentview.py
@@ -53,7 +53,7 @@ from robottelo.decorators import (
 )
 from robottelo.decorators.host import skip_if_os
 from robottelo.helpers import read_data_file
-from robottelo.ui.base import UIError
+from robottelo.ui.base import UIError, UINoSuchElementError
 from robottelo.ui.factory import make_contentview, make_lifecycle_environment
 from robottelo.ui.locators import common_locators, locators
 from robottelo.ui.session import Session
@@ -684,13 +684,13 @@ class ContentViewTestCase(UITestCase):
             make_contentview(
                 session, org=self.organization.name, name=cv2_name)
             self.assertIsNotNone(self.content_views.search(cv2_name))
-            with self.assertRaises(UIError) as context:
+            with self.assertRaises(UINoSuchElementError) as context:
                 self.content_views.add_remove_cv(cv1_name, [cv2_name])
-                self.assertEqual(
-                    context.exception.message,
-                    'Could not find ContentView tab, please make sure '
-                    'selected view is composite'
-                )
+            self.assertEqual(
+                context.exception.message,
+                'Could not find ContentView tab, please make sure '
+                'selected view is composite'
+            )
 
     @run_only_on('sat')
     @tier2
@@ -716,11 +716,11 @@ class ContentViewTestCase(UITestCase):
                 common_locators['alert.success_sub_form']))
             with self.assertRaises(UIError) as context:
                 self.content_views.add_remove_repos(cv_name, [repo_name])
-                self.assertEqual(
-                    context.exception.message,
-                    'Could not find repo "{0}" to add into CV'
-                    .format(repo_name)
-                )
+            self.assertEqual(
+                context.exception.message,
+                u'Could not find repo "{0}" to add into CV'
+                .format(repo_name)
+            )
 
     @stubbed()
     @run_only_on('sat')

--- a/tests/foreman/ui/test_setting.py
+++ b/tests/foreman/ui/test_setting.py
@@ -27,7 +27,7 @@ from robottelo.decorators import (
     tier1,
 )
 from robottelo.test import UITestCase
-from robottelo.ui.base import UIError
+from robottelo.ui.base import UINoSuchElementError
 from robottelo.ui.factory import edit_param
 from robottelo.ui.locators import common_locators, tab_locators
 from robottelo.ui.session import Session
@@ -698,16 +698,16 @@ class SettingTestCase(UITestCase):
         with Session(self.browser) as session:
             for param_name in invalid_oauth_active_values():
                 with self.subTest(param_name):
-                    with self.assertRaises(UIError) as context:
+                    with self.assertRaises(UINoSuchElementError) as context:
                         edit_param(
                             session,
                             tab_locator=self.tab_locator,
                             param_name=param_name,
                         )
-                        self.assertEqual(
-                            context.exception.message,
-                            'Could not find edit button to update param'
-                        )
+                    self.assertEqual(
+                        context.exception.message,
+                        'Could not find edit button to update selected param'
+                    )
 
     @tier1
     def test_positive_update_require_ssl_smart_proxies_param(self):

--- a/tests/foreman/ui/test_template.py
+++ b/tests/foreman/ui/test_template.py
@@ -131,10 +131,10 @@ class TemplateTestCase(UITestCase):
                     custom_really=True,
                     template_type='',
                 )
-                self.assertEqual(
-                    context.exception.message,
-                    'Could not create template "{0}" without type'.format(name)
-                )
+            self.assertEqual(
+                context.exception.message,
+                u'Could not create template "{0}" without type'.format(name)
+            )
 
     @run_only_on('sat')
     @tier1
@@ -155,10 +155,10 @@ class TemplateTestCase(UITestCase):
                     custom_really=True,
                     template_type='PXELinux template',
                 )
-                self.assertEqual(
-                    context.exception.message,
-                    'Could not create blank template "{0}"'.format(name)
-                )
+            self.assertEqual(
+                context.exception.message,
+                u'Could not create blank template "{0}"'.format(name)
+            )
 
     @run_only_on('sat')
     @tier1


### PR DESCRIPTION
Fixes #3644

Test results:
```python
py.test -v -k "(ContentViewTestCase and (test_negative_add_components_to_non_composite or test_negative_add_dupe_repos)) or (SettingTestCase and test_negative_update_oauth_active_param) or (TemplateTestCase and (test_negative_create_without_type or test_negative_create_without_upload))" tests/foreman/ui
===================================================================== test session starts =====================================================================
platform linux2 -- Python 2.7.12, pytest-2.9.2, py-1.4.31, pluggy-0.3.1 -- /home/qui/code/robottelo/venv2/bin/python2.7
cachedir: .cache
rootdir: /home/qui/code/robottelo, inifile: 
plugins: cov-2.3.1, xdist-1.14
collected 969 items 

tests/foreman/ui/test_contentview.py::ContentViewTestCase::test_negative_add_components_to_non_composite <- robottelo/decorators/__init__.py PASSED
tests/foreman/ui/test_contentview.py::ContentViewTestCase::test_negative_add_dupe_repos <- robottelo/decorators/__init__.py PASSED
tests/foreman/ui/test_setting.py::SettingTestCase::test_negative_update_oauth_active_param PASSED
tests/foreman/ui/test_template.py::TemplateTestCase::test_negative_create_without_type <- robottelo/decorators/__init__.py PASSED
tests/foreman/ui/test_template.py::TemplateTestCase::test_negative_create_without_upload <- robottelo/decorators/__init__.py PASSED

 964 tests deselected by '-k(ContentViewTestCase and (test_negative_add_components_to_non_composite or test_negative_add_dupe_repos)) or (SettingTestCase and test_negative_update_oauth_active_param) or (TemplateTestCase and (test_negative_create_without_type or test_negative_create_without_upload))' 
========================================================= 5 passed, 964 deselected in 231.37 seconds ==========================================================
```