### PR TITLE
Fixed command to get 6.2 version

### DIFF
--- a/robottelo/host_info.py
+++ b/robottelo/host_info.py
@@ -29,11 +29,7 @@ def get_host_os_version():
     return 'Not Available'
 
 
-_SAT_6_2_VERSION_COMMAND = (
-    u'grep "SATELLITE_SHORT_VERSION" '
-    u'/opt/theforeman/tfm/root/usr/share/gems/gems/foreman_theme_satellite-0'
-    u'.1.25/lib/foreman_theme_satellite/version.rb'
-)
+_SAT_6_2_VERSION_COMMAND = u'rpm -q satellite'
 
 _SAT_6_1_VERSION_COMMAND = (
     u'grep "VERSION" /usr/share/foreman/lib/satellite/version.rb'

--- a/tests/robottelo/test_host_info.py
+++ b/tests/robottelo/test_host_info.py
@@ -156,7 +156,7 @@ class GetHostSatVersionTestCase(TestCase):
     def test_sat_6_dot_2(self):
         """Check if can parse major 6.2.x versions"""
         self.assert_sat_version(
-            u'  SATELLITE_SHORT_VERSION = "6.2.7"',
+            u'satellite-6.2.0-21.1.el7sat.noarch',
             u'6.2'
         )
 


### PR DESCRIPTION
close #3725 
## Test Results for API
```console
1 tests deselected by '-k RepositorySetTestCase and test_positive_reposet_disable' 
=================== 1 passed, 1 deselected in 367.17 seconds ===================

Process finished with exit code 0
```
## Robottelo unit tests
```console
============================= test session starts ==============================
platform linux2 -- Python 2.7.12, pytest-2.9.2, py-1.4.31, pluggy-0.3.1
rootdir: /home/renzo/PycharmProjects/robottelo, inifile: 
plugins: cov-2.3.0, xdist-1.14
collected 168 items

test_api_utils.py ..
test_cli.py .....
test_config_casts.py ..............
test_config_settings.py .....
test_datafactory.py .....
test_decorators.py ...........................................
test_hammer.py .........
test_helpers.py ...........
test_host_info.py ................
test_ssh.py ..............
test_ui.py .....
test_ui_locators.py ........................
test_vm.py ......
decorators/test_host.py .........

========================== 168 passed in 2.11 seconds ==========================

Process finished with exit code 0

```