### PR TITLE
Fixes UserWithCleanUpTestCase setUp methods

### DIFF
--- a/tests/foreman/cli/test_user.py
+++ b/tests/foreman/cli/test_user.py
@@ -601,6 +601,7 @@ class UserWithCleanUpTestCase(CLITestCase):
         the role itself
         """
 
+        super(UserWithCleanUpTestCase, cls).setUpClass()
         settings.configure()
         include_list = [gen_string("alphanumeric", 100)]
 
@@ -617,15 +618,18 @@ class UserWithCleanUpTestCase(CLITestCase):
     @classmethod
     def tearDownClass(cls):
         """Remove all roles created during tests"""
+        super(UserWithCleanUpTestCase, cls).tearDownClass()
         for role_id in cls.stubbed_roles:
             Role.delete({'id': role_id})
 
     def setUp(self):
         """Setting up user to be used on tests"""
+        super(UserWithCleanUpTestCase, self).setUp()
         self.user = make_user()
 
     def tearDown(self):
         """Cleaning up user used on tests"""
+        super(UserWithCleanUpTestCase, self).tearDown()
         User.delete({'id': self.user['id']})
 
     def assert_user_roles(self, roles_dct):


### PR DESCRIPTION
https://github.com/SatelliteQE/robottelo/pull/3738 introduced `UserWithCleanUpTestCase` but its `setUp*()` and `tearDown*()` methods override those from the parent `TestCase` class. Thus there's no `logger` attribute, etc. resulting in test failures:

```bash
$ py.test -n4 -k test_positive_update_firstname test_user.py
=========================================== test session starts ============================================
platform linux2 -- Python 2.7.11 -- py-1.4.30 -- pytest-2.7.3
rootdir: /home/w1pko/work/robottelo, inifile: 
plugins: xdist, xdist, xdist, cov
gw0 [1] / gw1 [1] / gw2 [1] / gw3 [1]
scheduling tests via LoadScheduling
E^C
================================================== ERRORS ==================================================
_________________ ERROR at setup of UserWithCleanUpTestCase.test_positive_update_firstname _________________
[gw3] linux2 -- Python 2.7.11 /usr/bin/python2
self = <tests.foreman.cli.test_user.UserWithCleanUpTestCase testMethod=test_positive_update_firstname>
worker_id = 'gw3'

    @pytest.fixture(autouse=True)
    def _set_worker_logger(self, worker_id):
        """Set up a separate logger for each pytest-xdist worker
            if worker_id != 'master' then xdist is running in multi-threading so
            a logfile named 'robottelo_gw{worker_id}.log' will be created.
            """
        self.worker_id = worker_id
        if worker_id != 'master':
            formatter = logging.Formatter(
                fmt='%(asctime)s - %(name)s - %(levelname)s - %(message)s',
                datefmt='%Y-%m-%d %H:%M:%S'
            )
            handler = logging.FileHandler(
                'robottelo_{0}.log'.format(worker_id))
            handler.setFormatter(formatter)
>           self.logger.addHandler(handler)
E           AttributeError: 'UserWithCleanUpTestCase' object has no attribute 'logger'

../../../robottelo/test.py:118: AttributeError
```
After I added calls to `super(...).setUp*()`:
```bash
$ py.test -n4 -k test_positive_update_firstname test_user.py
=========================================== test session starts ============================================
platform linux2 -- Python 2.7.11 -- py-1.4.30 -- pytest-2.7.3
rootdir: /home/w1pko/work/robottelo, inifile: 
plugins: xdist, xdist, xdist, cov
gw0 [1] / gw1 [1] / gw2 [1] / gw3 [1]
scheduling tests via LoadScheduling
.
======================================== 1 passed in 122.82 seconds ========================================
✔ ~/work/robottelo/tests/foreman/cli [UserWithCleanUpTestCase_setup_fix L|✚ 1…2⚑ 11]
```