### PR TITLE
Added error msg asserts to negative CLI user tests, fixes #3745

### DIFF
--- a/tests/foreman/cli/test_user.py
+++ b/tests/foreman/cli/test_user.py
@@ -228,7 +228,12 @@ class UserTestCase(CLITestCase):
                     'password': gen_string('alpha'),
                 }
                 self.logger.debug(str(options))
-                self.assertRaises(CLIReturnCodeError, User.create, options)
+                with self.assertRaises(CLIReturnCodeError) as raise_ctx:
+                    User.create(options)
+                self.assert_error_msg(
+                    raise_ctx,
+                    u'Could not create the user:'
+                )
 
     @tier1
     def test_negative_create_with_invalid_firstname(self):
@@ -248,7 +253,12 @@ class UserTestCase(CLITestCase):
                     'mail': 'root@localhost',
                     'password': gen_string('alpha'),
                 }
-                self.assertRaises(CLIReturnCodeError, User.create, options)
+                with self.assertRaises(CLIReturnCodeError) as raise_ctx:
+                    User.create(options)
+                self.assert_error_msg(
+                    raise_ctx,
+                    u'Could not create the user'
+                )
 
     @tier1
     def test_negative_create_with_invalid_lastname(self):
@@ -268,7 +278,12 @@ class UserTestCase(CLITestCase):
                     'mail': 'root@localhost',
                     'password': gen_string('alpha'),
                 }
-                self.assertRaises(CLIReturnCodeError, User.create, options)
+                with self.assertRaises(CLIReturnCodeError) as raise_ctx:
+                    User.create(options)
+                self.assert_error_msg(
+                    raise_ctx,
+                    u'Could not create the user'
+                )
 
     @tier1
     def test_negative_create_with_invalid_email(self):
@@ -288,7 +303,12 @@ class UserTestCase(CLITestCase):
                     'mail': email,
                     'password': gen_string('alpha'),
                 }
-                self.assertRaises(CLIReturnCodeError, User.create, options)
+                with self.assertRaises(CLIReturnCodeError) as raise_ctx:
+                    User.create(options)
+                self.assert_error_msg(
+                    raise_ctx,
+                    u'Could not create the user'
+                )
 
     @skip_if_bug_open('bugzilla', 1204686)
     @tier1
@@ -301,7 +321,7 @@ class UserTestCase(CLITestCase):
 
         @BZ: 1204686
         """
-        with self.assertRaises(CLIReturnCodeError):
+        with self.assertRaises(CLIReturnCodeError) as raise_ctx:
             User.create({
                 'auth-source-id': 1,
                 'firstname': gen_string('alpha'),
@@ -310,6 +330,10 @@ class UserTestCase(CLITestCase):
                 'mail': '',
                 'password': gen_string('alpha'),
             })
+        self.assert_error_msg(
+            raise_ctx,
+            u'Could not create the user:'
+        )
 
     @tier1
     def test_negative_create_with_blank_authorized_by(self):
@@ -319,12 +343,16 @@ class UserTestCase(CLITestCase):
 
         @Assert: User is not created. Appropriate error shown.
         """
-        with self.assertRaises(CLIReturnCodeError):
+        with self.assertRaises(CLIReturnCodeError) as raise_ctx:
             User.create({
                 'auth-source-id': '',
                 'login': gen_string('alpha'),
                 'mail': 'root@localhost',
             })
+        self.assert_error_msg(
+            raise_ctx,
+            u'Could not create the user:'
+        )
 
     @tier1
     def test_negative_create_with_blank_authorized_by_full(self):
@@ -336,13 +364,17 @@ class UserTestCase(CLITestCase):
 
         @Assert: User is not created. Appropriate error shown.
         """
-        with self.assertRaises(CLIReturnCodeError):
+        with self.assertRaises(CLIReturnCodeError) as raise_ctx:
             User.create({
                 'auth-source-id': '',
                 'login': gen_string('alpha'),
                 'mail': 'root@localhost',
                 'password': gen_string('alpha'),
             })
+        self.assert_error_msg(
+            raise_ctx,
+            u'Could not create the user:'
+        )
 
     @tier1
     def test_positive_update_to_non_admin(self):
@@ -414,8 +446,12 @@ class UserTestCase(CLITestCase):
 
         @Assert: User is not deleted
         """
-        with self.assertRaises(CLIReturnCodeError):
+        with self.assertRaises(CLIReturnCodeError) as raise_ctx:
             User.delete({'login': self.foreman_user})
+        self.assert_error_msg(
+            raise_ctx,
+            u'Could not delete the user:'
+        )
         self.assertTrue(User.info({'login': self.foreman_user}))
 
     @tier1
@@ -806,7 +842,12 @@ class UserWithCleanUpTestCase(CLITestCase):
         for new_user_name in invalid_names_list():
             with self.subTest(new_user_name):
                 options = {'id': user['id'], 'login': new_user_name}
-                self.assertRaises(CLIReturnCodeError, User.update, options)
+                with self.assertRaises(CLIReturnCodeError) as raise_ctx:
+                    User.update(options)
+                self.assert_error_msg(
+                    raise_ctx,
+                    u'Could not update the user:'
+                )
 
     @tier1
     def test_negative_update_firstname(self):
@@ -822,7 +863,12 @@ class UserWithCleanUpTestCase(CLITestCase):
                 options = {
                     'firstname': invalid_firstname, 'login': user['login'],
                 }
-                self.assertRaises(CLIReturnCodeError, User.update, options)
+                with self.assertRaises(CLIReturnCodeError) as raise_ctx:
+                    User.update(options)
+                self.assert_error_msg(
+                    raise_ctx,
+                    u'Could not update the user:'
+                )
                 updated_user = User.info({'id': user['id']})
                 self.assertEqual(updated_user['name'], user['name'])
 
@@ -837,10 +883,14 @@ class UserWithCleanUpTestCase(CLITestCase):
         user = self.user
         for invalid_lastname in (gen_string('alpha', 51), gen_string('html')):
             with self.subTest(invalid_lastname):
-                self.assertRaises(
-                    CLIReturnCodeError,
-                    User.update,
-                    {'lastname': invalid_lastname, 'login': user['login']}
+                with self.assertRaises(CLIReturnCodeError) as raise_ctx:
+                    User.update({
+                        'lastname': invalid_lastname,
+                        'login': user['login']
+                    })
+                self.assert_error_msg(
+                    raise_ctx,
+                    u'Could not update the user:'
                 )
 
     @tier1
@@ -854,10 +904,14 @@ class UserWithCleanUpTestCase(CLITestCase):
         user = self.user
         for email in invalid_emails_list():
             with self.subTest(email):
-                self.assertRaises(
-                    CLIReturnCodeError,
-                    User.update,
-                    {'login': user['login'], 'mail': email}
+                with self.assertRaises(CLIReturnCodeError) as raise_ctx:
+                    User.update({
+                        'login': user['login'],
+                        'mail': email
+                    })
+                self.assert_error_msg(
+                    raise_ctx,
+                    u'Could not update the user:'
                 )
 
     @skip_if_bug_open('bugzilla', 1138553)


### PR DESCRIPTION
Based on yesterday's talk with @renzon and his work on #3716 
Results for affected tests:

```
py.test tests/foreman/cli/test_user.py -v -k negative
============================================= test session starts =============================================
platform linux2 -- Python 2.7.11, pytest-2.9.2, py-1.4.31, pluggy-0.3.1 -- /usr/bin/python
cachedir: .cache
rootdir: /home/pondrejk/Documents/robottelo, inifile: 
plugins: cov-2.3.1, xdist-1.15.0
collected 49 items 

tests/foreman/cli/test_user.py::UserTestCase::test_negative_create_with_blank_authorized_by PASSED
tests/foreman/cli/test_user.py::UserTestCase::test_negative_create_with_blank_authorized_by_full PASSED
tests/foreman/cli/test_user.py::UserTestCase::test_negative_create_with_empty_email <- robottelo/decorators/__init__.py SKIPPED
tests/foreman/cli/test_user.py::UserTestCase::test_negative_create_with_invalid_email PASSED
tests/foreman/cli/test_user.py::UserTestCase::test_negative_create_with_invalid_firstname PASSED
tests/foreman/cli/test_user.py::UserTestCase::test_negative_create_with_invalid_lastname PASSED
tests/foreman/cli/test_user.py::UserTestCase::test_negative_create_with_invalid_username PASSED
tests/foreman/cli/test_user.py::UserTestCase::test_negative_delete_internal_admin PASSED
tests/foreman/cli/test_user.py::UserWithCleanUpTestCase::test_negative_update_email PASSED
tests/foreman/cli/test_user.py::UserWithCleanUpTestCase::test_negative_update_firstname PASSED
tests/foreman/cli/test_user.py::UserWithCleanUpTestCase::test_negative_update_surname PASSED
tests/foreman/cli/test_user.py::UserWithCleanUpTestCase::test_negative_update_username PASSED

===================================== 37 tests deselected by '-knegative' =====================================
============================ 11 passed, 1 skipped, 37 deselected in 357.57 seconds ============================
```