### PR TITLE
Added error msg asserts to negative subnet and syncplan CLI tests

### DIFF
--- a/tests/foreman/cli/test_subnet.py
+++ b/tests/foreman/cli/test_subnet.py
@@ -180,8 +180,12 @@ class SubnetTestCase(CLITestCase):
         """
         for options in invalid_missing_attributes():
             with self.subTest(options):
-                with self.assertRaises(CLIFactoryError):
+                with self.assertRaises(CLIFactoryError) as raise_ctx:
                     make_subnet(options)
+                self.assert_error_msg(
+                    raise_ctx,
+                    u'Could not create the subnet:'
+                )
 
     @run_only_on('sat')
     @tier1
@@ -200,8 +204,12 @@ class SubnetTestCase(CLITestCase):
                 # generate pool range from network address
                 for key, val in pool.iteritems():
                     opts[key] = re.sub(r'\d+$', str(val), network)
-                with self.assertRaises(CLIFactoryError):
+                with self.assertRaises(CLIFactoryError) as raise_ctx:
                     make_subnet(opts)
+                self.assert_error_msg(
+                    raise_ctx,
+                    u'Could not create the subnet:'
+                )
 
     @run_only_on('sat')
     @tier1
@@ -301,12 +309,16 @@ class SubnetTestCase(CLITestCase):
         for options in invalid_missing_attributes():
             with self.subTest(options):
                 options['id'] = subnet['id']
-                with self.assertRaises(CLIReturnCodeError):
+                with self.assertRaises(CLIReturnCodeError) as raise_ctx:
                     Subnet.update(options)
                     # check - subnet is not updated
                     result = Subnet.info({u'id': subnet['id']})
                     for key in options.keys():
                         self.assertEqual(subnet[key], result[key])
+                self.assert_error_msg(
+                    raise_ctx,
+                    u'Could not update the subnet:'
+                )
 
     @run_only_on('sat')
     @tier1
@@ -324,8 +336,12 @@ class SubnetTestCase(CLITestCase):
                 # generate pool range from network address
                 for key, val in options.iteritems():
                     opts[key] = re.sub(r'\d+$', str(val), subnet['network'])
-                with self.assertRaises(CLIReturnCodeError):
+                with self.assertRaises(CLIReturnCodeError) as raise_ctx:
                     Subnet.update(opts)
+                self.assert_error_msg(
+                    raise_ctx,
+                    u'Could not update the subnet:'
+                )
                 # check - subnet is not updated
                 result = Subnet.info({u'id': subnet['id']})
                 for key in options.keys():

--- a/tests/foreman/cli/test_syncplan.py
+++ b/tests/foreman/cli/test_syncplan.py
@@ -231,8 +231,12 @@ class SyncPlanTestCase(CLITestCase):
         """
         for name in invalid_values_list():
             with self.subTest(name):
-                with self.assertRaises(CLIFactoryError):
+                with self.assertRaises(CLIFactoryError) as raise_ctx:
                     self._make_sync_plan({u'name': name})
+                self.assert_error_msg(
+                    raise_ctx,
+                    u'Could not create the sync plan:'
+                )
 
     @tier1
     def test_positive_update_description(self):
@@ -377,6 +381,7 @@ class SyncPlanTestCase(CLITestCase):
                 ['errata', 'package-groups', 'packages'],
                 max_attempts=5,
             )
+            # validate the error message once unstubbed (#3611)
 
     # This Bugzilla bug is private. It is impossible to fetch info about it.
     @stubbed('Unstub when BZ1279539 is fixed')


### PR DESCRIPTION
Fixes #3752

Results for affected tests:
```
py.test tests/foreman/cli/test_subnet.py -v -k negative
======================= test session starts ========================
platform linux2 -- Python 2.7.11, pytest-2.9.2, py-1.4.31, pluggy-0.3.1 -- /usr/bin/python
cachedir: .cache
rootdir: /home/pondrejk/Documents/robottelo, inifile: 
plugins: cov-2.3.1, xdist-1.15.0
collected 15 items 

tests/foreman/cli/test_subnet.py::SubnetTestCase::test_negative_create_with_address_pool <- robottelo/decorators/__init__.py PASSED
tests/foreman/cli/test_subnet.py::SubnetTestCase::test_negative_create_with_attributes <- robottelo/decorators/__init__.py PASSED
tests/foreman/cli/test_subnet.py::SubnetTestCase::test_negative_update_address_pool <- robottelo/decorators/__init__.py PASSED
tests/foreman/cli/test_subnet.py::SubnetTestCase::test_negative_update_attributes <- robottelo/decorators/__init__.py PASSED

=============== 11 tests deselected by '-knegative' ================
============ 4 passed, 11 deselected in 158.61 seconds =============
 ```
```
py.test tests/foreman/cli/test_syncplan.py -v -k negative
======================= test session starts ========================
platform linux2 -- Python 2.7.11, pytest-2.9.2, py-1.4.31, pluggy-0.3.1 -- /usr/bin/python
cachedir: .cache
rootdir: /home/pondrejk/Documents/robottelo, inifile: 
plugins: cov-2.3.1, xdist-1.15.0
collected 15 items 

tests/foreman/cli/test_syncplan.py::SyncPlanTestCase::test_negative_create_with_name PASSED
tests/foreman/cli/test_syncplan.py::SyncPlanTestCase::test_negative_synchronize_custom_product_current_sync_date <- ../../../../usr/lib/python2.7/site-packages/unittest2/case.py SKIPPED

=============== 13 tests deselected by '-knegative' ================
======= 1 passed, 1 skipped, 13 deselected in 71.87 seconds ========
```