### PR TITLE
Fixing typo in UI host tests

### DIFF
--- a/tests/foreman/ui/test_host.py
+++ b/tests/foreman/ui/test_host.py
@@ -148,7 +148,7 @@ class HostTestCase(UITestCase):
             cls.domain = entities.Domain(
                 dns=cls.proxy,
                 location=[cls.loc],
-                organization=[cls.org],
+                organization=[cls.org_],
             ).create()
         cls.domain_name = cls.domain.name
 


### PR DESCRIPTION
```
nosetests tests/foreman/ui/test_host.py
S.FS.SSSSSS.S
======================================================================
FAIL: Create a new Host on libvirt compute resource
----------------------------------------------------------------------
Ran 13 tests in 475.834s

FAILED (SKIP=9, failures=1)
```
One failure is not related to the mentioned fix