### PR TITLE
Add UI tests for repo download policy and fixes other UI issues

### DIFF
--- a/robottelo/constants.py
+++ b/robottelo/constants.py
@@ -150,9 +150,11 @@ REPO_TYPE = {
     'ostree': "ostree",
 }
 
-DOWNLOAD_POLICIES = [
-    'on_demand', 'background', 'immediate'
-]
+DOWNLOAD_POLICIES = {
+    'on_demand': "On Demand",
+    'background': "Background",
+    'immediate': "Immediate"
+}
 
 CHECKSUM_TYPE = {
     'default': "Default",

--- a/robottelo/ui/factory.py
+++ b/robottelo/ui/factory.py
@@ -224,6 +224,7 @@ def make_repository(session, org=None, loc=None,
         u'repo_type': REPO_TYPE['yum'],
         u'repo_checksum': CHECKSUM_TYPE['default'],
         u'upstream_repo_name': None,
+        u'download_policy': None,
     }
     page = Repos(session.browser).navigate_to_entity
     core_factory(create_args, kwargs, session, page,

--- a/robottelo/ui/locators/base.py
+++ b/robottelo/ui/locators/base.py
@@ -1130,6 +1130,11 @@ locators = LocatorDict({
     "repo.gpg_key": (
         By.XPATH, ("//form[@selector='repository.gpg_key_id']"
                    "//div/span")),
+    "repo.download_policy_edit": (
+        By.XPATH, "//form[@selector='repository.download_policy']//i"),
+    "repo.download_policy_update": (
+        By.XPATH, "//form[@selector='repository.download_policy']/div/select"),
+    "repo.download_policy": (By.ID, "download_policy"),
     "repo.checksum_edit": (
         By.XPATH, ("//form[@selector='repository.checksum_type']"
                    "/div/div/span/i[contains(@class,'fa-edit')]")),
@@ -1147,6 +1152,9 @@ locators = LocatorDict({
                    "/div/span[contains(@class,'editable-value')]")),
     "repo.fetch_gpgkey": (
         By.XPATH, ("//form[@selector='repository.gpg_key_id']"
+                   "/div[@class='bst-edit']/div/span[2]")),
+    "repo.fetch_download_policy": (
+        By.XPATH, ("//form[@selector='repository.download_policy']"
                    "/div[@class='bst-edit']/div/span[2]")),
     "repo.fetch_checksum": (
         By.XPATH, ("//form[@selector='repository.checksum_type']"

--- a/robottelo/ui/locators/menu.py
+++ b/robottelo/ui/locators/menu.py
@@ -4,6 +4,16 @@
 from selenium.webdriver.common.by import By
 from .model import LocatorDict
 
+NAVBAR_PATH = (
+    '//div[contains(@class,"navbar") '
+    'and contains(@class,"persist-header") and '
+    'not(contains(@style, "display: none")) and '
+    'not(contains(@style, "display:none"))]'
+)
+
+MENU_CONTAINER_PATH = NAVBAR_PATH + '//ul[@id="menu"]'
+ADM_MENU_CONTAINER_PATH = NAVBAR_PATH + '//ul[@id="menu2"]'
+
 
 menu_locators = LocatorDict({
     # Menus
@@ -13,293 +23,231 @@ menu_locators = LocatorDict({
     # Monitor Menu
     "menu.monitor": (
         By.XPATH,
-        ("//div[contains(@style,'static') or contains(@style,'fixed')]"
-         "//a[@id='monitor_menu']")),
+        (MENU_CONTAINER_PATH + "//a[@id='monitor_menu']")),
     "menu.dashboard": (
         By.XPATH,
-        ("//div[contains(@style,'static') or contains(@style,'fixed')]"
-         "//a[@id='menu_item_dashboard']")),
+        (MENU_CONTAINER_PATH + "//a[@id='menu_item_dashboard']")),
     "menu.reports": (
         By.XPATH,
-        ("//div[contains(@style,'static') or contains(@style,'fixed')]"
-         "//a[@id='menu_item_reports']")),
+        (MENU_CONTAINER_PATH + "//a[@id='menu_item_reports']")),
     "menu.facts": (
         By.XPATH,
-        ("//div[contains(@style,'static') or contains(@style,'fixed')]"
-         "//a[@id='menu_item_fact_values']")),
+        (MENU_CONTAINER_PATH + "//a[@id='menu_item_fact_values']")),
     "menu.statistics": (
         By.XPATH,
-        ("//div[contains(@style,'static') or contains(@style,'fixed')]"
-         "//a[@id='menu_item_statistics']")),
+        (MENU_CONTAINER_PATH + "//a[@id='menu_item_statistics']")),
     "menu.trends": (
         By.XPATH,
-        ("//div[contains(@style,'static') or contains(@style,'fixed')]"
-         "//a[@id='menu_item_trends']")),
+        (MENU_CONTAINER_PATH + "//a[@id='menu_item_trends']")),
     "menu.audits": (
         By.XPATH,
-        ("//div[contains(@style,'static') or contains(@style,'fixed')]"
-         "//a[@id='menu_item_audits']")),
+        (MENU_CONTAINER_PATH + "//a[@id='menu_item_audits']")),
 
     "menu.jobs": (
         By.XPATH,
-        ("//div[contains(@style,'static') or contains(@style,'fixed')]"
-         "//a[@id='menu_item_jobs']")),
+        (MENU_CONTAINER_PATH + "//a[@id='menu_item_jobs']")),
 
     # Content Menu
     "menu.content": (
         By.XPATH,
-        ("//div[contains(@style,'static') or contains(@style, 'fixed')]"
-         "//a[@id='content_menu']")),
+        (MENU_CONTAINER_PATH + "//a[@id='content_menu']")),
     "menu.life_cycle_environments": (
         By.XPATH,
-        ("//div[contains(@style,'static') or contains(@style, 'fixed')]"
-         "//a[@id='menu_item_environments']")),
+        (MENU_CONTAINER_PATH + "//a[@id='menu_item_environments']")),
     "menu.red_hat_subscriptions": (
         By.XPATH,
-        ("//div[contains(@style,'static') or contains(@style, 'fixed')]"
-         "//a[@id='menu_item_red_hat_subscriptions']")),
+        (MENU_CONTAINER_PATH + "//a[@id='menu_item_red_hat_subscriptions']")),
     "menu.activation_keys": (
         By.XPATH,
-        ("//div[contains(@style,'static') or contains(@style, 'fixed')]"
-         "//a[@id='menu_item_activation_keys']")),
+        (MENU_CONTAINER_PATH + "//a[@id='menu_item_activation_keys']")),
     "menu.red_hat_repositories": (
         By.XPATH,
-        ("//div[contains(@style,'static') or contains(@style, 'fixed')]"
-         "//a[@id='menu_item_redhat_provider']")),
+        (MENU_CONTAINER_PATH + "//a[@id='menu_item_redhat_provider']")),
     "menu.products": (
         By.XPATH,
-        ("//div[contains(@style,'static') or contains(@style, 'fixed')]"
-         "//a[@id='menu_item_products']")),
+        (MENU_CONTAINER_PATH + "//a[@id='menu_item_products']")),
     "menu.gpg_keys": (
         By.XPATH,
-        ("//div[contains(@style,'static') or contains(@style, 'fixed')]"
-         "//a[@id='menu_item_gpg_keys']")),
+        (MENU_CONTAINER_PATH + "//a[@id='menu_item_gpg_keys']")),
     "menu.sync_status": (
         By.XPATH,
-        ("//div[contains(@style,'static') or contains(@style, 'fixed')]"
-         "//a[@id='menu_item_sync_status']")),
+        (MENU_CONTAINER_PATH + "//a[@id='menu_item_sync_status']")),
     "menu.sync_plans": (
         By.XPATH,
-        ("//div[contains(@style,'static') or contains(@style, 'fixed')]"
-         "//a[@id='menu_item_sync_plans']")),
+        (MENU_CONTAINER_PATH + "//a[@id='menu_item_sync_plans']")),
     "menu.content_views": (
         By.XPATH,
-        ("//div[contains(@style,'static') or contains(@style, 'fixed')]"
-         "//a[@id='menu_item_content_views']")),
+        (MENU_CONTAINER_PATH + "//a[@id='menu_item_content_views']")),
     "menu.errata": (
         By.XPATH,
-        ("//div[contains(@style,'static') or contains(@style, 'fixed')]"
-         "//a[@id='menu_item_errata']")),
+        (MENU_CONTAINER_PATH + "//a[@id='menu_item_errata']")),
     "menu.packages": (
         By.XPATH,
-        ("//div[contains(@style,'static') or contains(@style, 'fixed')]"
-         "//a[@id='menu_item_packages']")),
+        (MENU_CONTAINER_PATH + "//a[@id='menu_item_packages']")),
     "menu.puppet_modules": (
         By.XPATH,
-        ("//div[contains(@style,'static') or contains(@style, 'fixed')]"
-         "//a[@id='menu_item_puppet_modules']")),
+        (MENU_CONTAINER_PATH + "//a[@id='menu_item_puppet_modules']")),
     "menu.docker_tags": (
         By.XPATH,
-        ("//div[contains(@style,'static') or contains(@style, 'fixed')]"
-         "//a[@id='menu_item_docker_tags']")),
+        (MENU_CONTAINER_PATH + "//a[@id='menu_item_docker_tags']")),
 
     # Containers Menu
     "menu.containers": (
         By.XPATH,
-        ("//div[contains(@style,'static') or contains(@style,'fixed')]"
-         "//a[@id='containers_menu']")),
+        (MENU_CONTAINER_PATH + "//a[@id='containers_menu']")),
     "menu.all_containers": (
         By.XPATH,
-        ("//div[contains(@style,'static') or contains(@style,'fixed')]"
-         "//a[@id='menu_item_containers']")),
+        (MENU_CONTAINER_PATH + "//a[@id='menu_item_containers']")),
     "menu.new_container": (
         By.XPATH,
-        ("//div[contains(@style,'static') or contains(@style,'fixed')]"
-         "//a[@id='menu_item_new_container']")),
+        (MENU_CONTAINER_PATH + "//a[@id='menu_item_new_container']")),
     "menu.registries": (
         By.XPATH,
-        ("//div[contains(@style,'static') or contains(@style,'fixed')]"
-         "//a[@id='menu_item_registries']")),
+        (MENU_CONTAINER_PATH + "//a[@id='menu_item_registries']")),
 
     # Hosts Menu
     "menu.hosts": (
         By.XPATH,
-        ("//div[contains(@style,'static') or contains(@style,'fixed')]"
-         "//a[@id='hosts_menu']")),
+        (MENU_CONTAINER_PATH + "//a[@id='hosts_menu']")),
     "menu.all_hosts": (
         By.XPATH,
-        ("//div[contains(@style,'static') or contains(@style,'fixed')]"
-         "//a[@id='menu_item_hosts']")),
+        (MENU_CONTAINER_PATH + "//a[@id='menu_item_hosts']")),
     "menu.discovered_hosts": (
         By.XPATH,
-        ("//div[contains(@style,'static') or contains(@style,'fixed')]"
-         "//a[@id='menu_item_discovered_hosts']")),
+        (MENU_CONTAINER_PATH + "//a[@id='menu_item_discovered_hosts']")),
     "menu.content_hosts": (
         By.XPATH,
-        ("//div[contains(@style,'static') or contains(@style, 'fixed')]"
-         "//a[@id='menu_item_content_hosts']")),
+        (MENU_CONTAINER_PATH + "//a[@id='menu_item_content_hosts']")),
     "menu.host_collections": (
         By.XPATH,
-        ("//div[contains(@style,'static') or contains(@style, 'fixed')]"
+        (MENU_CONTAINER_PATH +
          "//a[@id='menu_item_host_collections']")),
     "menu.operating_systems": (
         By.XPATH,
-        ("//div[contains(@style,'static') or contains(@style,'fixed')]"
-         "//a[@id='menu_item_operatingsystems']")),
+        (MENU_CONTAINER_PATH + "//a[@id='menu_item_operatingsystems']")),
     "menu.provisioning_templates": (
         By.XPATH,
-        ("//div[contains(@style,'static') or contains(@style, 'fixed')]"
+        (MENU_CONTAINER_PATH +
          "//a[@id='menu_item_provisioning_templates']")),
     "menu.partition_tables": (
         By.XPATH,
-        ("//div[contains(@style,'static') or contains(@style, 'fixed')]"
-         "//a[@id='menu_item_partition_tables']")),
+        (MENU_CONTAINER_PATH + "//a[@id='menu_item_partition_tables']")),
     "menu.job_templates": (
         By.XPATH,
-        ("//div[contains(@style,'static') or contains(@style, 'fixed')]"
-         "//a[@id='menu_item_job_templates']")),
+        (MENU_CONTAINER_PATH + "//a[@id='menu_item_job_templates']")),
     "menu.installation_media": (
         By.XPATH,
-        ("//div[contains(@style,'static') or contains(@style, 'fixed')]"
-         "//a[@id='menu_item_media']")),
+        (MENU_CONTAINER_PATH + "//a[@id='menu_item_media']")),
     "menu.hardware_models": (
         By.XPATH,
-        ("//div[contains(@style,'static') or contains(@style, 'fixed')]"
-         "//a[@id='menu_item_models']")),
+        (MENU_CONTAINER_PATH + "//a[@id='menu_item_models']")),
     "menu.architectures": (
         By.XPATH,
-        ("//div[contains(@style,'static') or contains(@style, 'fixed')]"
-         "//a[@id='menu_item_architectures']")),
+        (MENU_CONTAINER_PATH + "//a[@id='menu_item_architectures']")),
     "menu.oscap_policy": (
         By.XPATH,
-        ("//div[contains(@style,'static') or contains(@style, 'fixed')]"
-         "//a[@id='menu_item_compliance_policies']")),
+        (MENU_CONTAINER_PATH + "//a[@id='menu_item_compliance_policies']")),
     "menu.oscap_content": (
         By.XPATH,
-        ("//div[contains(@style,'static') or contains(@style, 'fixed')]"
-         "//a[@id='menu_item_compliance_contents']")),
+        (MENU_CONTAINER_PATH + "//a[@id='menu_item_compliance_contents']")),
     "menu.oscap_reports": (
         By.XPATH,
-        ("//div[contains(@style,'static') or contains(@style, 'fixed')]"
-         "//a[@id='menu_item_compliance_reports']")),
+        (MENU_CONTAINER_PATH + "//a[@id='menu_item_compliance_reports']")),
 
     # Configure Menu
     "menu.configure": (
         By.XPATH,
-        ("//div[contains(@style,'static') or contains(@style, 'fixed')]"
-         "//a[@id='configure_menu']")),
+        (MENU_CONTAINER_PATH + "//a[@id='configure_menu']")),
     "menu.host_groups": (
         By.XPATH,
-        ("//div[contains(@style,'static') or contains(@style, 'fixed')]"
-         "//a[@id='menu_item_hostgroups']")),
+        (MENU_CONTAINER_PATH + "//a[@id='menu_item_hostgroups']")),
     "menu.discovery_rules": (
         By.XPATH,
-        ("//div[contains(@style,'static') or contains(@style, 'fixed')]"
-         "//a[@id='menu_item_discovery_rules']")),
+        (MENU_CONTAINER_PATH + "//a[@id='menu_item_discovery_rules']")),
     "menu.global_parameters": (
         By.XPATH,
-        ("//div[contains(@style,'static') or contains(@style, 'fixed')]"
-         "//a[@id='menu_item_common_parameters']")),
+        (MENU_CONTAINER_PATH + "//a[@id='menu_item_common_parameters']")),
     "menu.environments": (
         By.XPATH,
-        ("//div[contains(@style,'static') or contains(@style, 'fixed')]"
+        (MENU_CONTAINER_PATH +
          "//li[contains(@class,'menu_tab_environments')]"
          "/a[@id='menu_item_environments']")),
     "menu.puppet_classes": (
         By.XPATH,
-        ("//div[contains(@style,'static') or contains(@style, 'fixed')]"
-         "//a[@id='menu_item_puppetclasses']")),
+        (MENU_CONTAINER_PATH + "//a[@id='menu_item_puppetclasses']")),
     "menu.smart_variables": (
         By.XPATH,
-        ("//div[contains(@style,'static') or contains(@style, 'fixed')]"
-         "//a[@id='menu_item_lookup_keys']")),
+        (MENU_CONTAINER_PATH + "//a[@id='menu_item_lookup_keys']")),
     "menu.configure_groups": (
         By.XPATH,
-        ("//div[contains(@style,'static') or contains(@style, 'fixed')]"
-         "//a[@id='menu_item_config_groups']")),
+        (MENU_CONTAINER_PATH + "//a[@id='menu_item_config_groups']")),
 
     # Infrastructure Menu
     "menu.infrastructure": (
         By.XPATH,
-        ("//div[contains(@style,'static') or contains(@style,'fixed')]"
-         "//a[@id='infrastructure_menu']")),
+        (MENU_CONTAINER_PATH + "//a[@id='infrastructure_menu']")),
     "menu.smart_proxies": (
         By.XPATH,
-        ("//div[contains(@style,'static') or contains(@style, 'fixed')]"
-         "//a[@id='menu_item_smart_proxies']")),
+        (MENU_CONTAINER_PATH + "//a[@id='menu_item_smart_proxies']")),
     "menu.compute_resources": (
         By.XPATH,
-        ("//div[contains(@style,'static') or contains(@style, 'fixed')]"
-         "//a[@id='menu_item_compute_resources']")),
+        (MENU_CONTAINER_PATH + "//a[@id='menu_item_compute_resources']")),
     "menu.compute_profiles": (
         By.XPATH,
-        ("//div[contains(@style,'static') or contains(@style, 'fixed')]"
-         "//a[@id='menu_item_compute_profiles']")),
+        (MENU_CONTAINER_PATH + "//a[@id='menu_item_compute_profiles']")),
     "menu.subnets": (
         By.XPATH,
-        ("//div[contains(@style,'static') or contains(@style, 'fixed')]"
-         "//a[@id='menu_item_subnets']")),
+        (MENU_CONTAINER_PATH + "//a[@id='menu_item_subnets']")),
     "menu.domains": (
         By.XPATH,
-        ("//div[contains(@style,'static') or contains(@style, 'fixed')]"
-         "//a[@id='menu_item_domains']")),
+        (MENU_CONTAINER_PATH + "//a[@id='menu_item_domains']")),
 
     # Access Insights menu
     "menu.insights": (
         By.XPATH,
-        ("//div[contains(@style,'static') or contains(@style,'fixed')]"
-         "//a[@id='redhat_access_top_menu']")),
+        (MENU_CONTAINER_PATH + "//a[@id='redhat_access_top_menu']")),
     "insights.overview": (
         By.XPATH,
-        ("//div[contains(@style,'static') or contains(@style,'fixed')]"
-         "//a[@href='/redhat_access/insights']")),
+        (MENU_CONTAINER_PATH + "//a[@href='/redhat_access/insights']")),
     "insights.rules": (
         By.XPATH,
-        ("//div[contains(@style,'static') or contains(@style,'fixed')]"
+        (MENU_CONTAINER_PATH +
          "//a[@href='/redhat_access/insights/rules/']")),
     "insights.systems": (
         By.XPATH,
-        ("//div[contains(@style,'static') or contains(@style,'fixed')]"
+        (MENU_CONTAINER_PATH +
          "//a[@href='/redhat_access/insights/systems/']")),
     "insights.manage": (
         By.XPATH,
-        ("//div[contains(@style,'static') or contains(@style,'fixed')]"
+        (MENU_CONTAINER_PATH +
          "//a[@href='/redhat_access/insights/manage']")),
 
 
     # Administer Menu
     "menu.administer": (
         By.XPATH,
-        ("//div[contains(@style,'static') or contains(@style, 'fixed')]"
-         "//a[@id='administer_menu']")),
+        (ADM_MENU_CONTAINER_PATH + "//a[@id='administer_menu']")),
     "menu.ldap_auth": (
         By.XPATH,
-        ("//div[contains(@style,'static') or contains(@style, 'fixed')]"
-         "//a[@id='menu_item_auth_source_ldaps']")),
+        (ADM_MENU_CONTAINER_PATH + "//a[@id='menu_item_auth_source_ldaps']")),
     "menu.users": (
         By.XPATH,
-        ("//div[contains(@style,'static') or contains(@style, 'fixed')]"
-         "//a[@id='menu_item_users']")),
+        (ADM_MENU_CONTAINER_PATH + "//a[@id='menu_item_users']")),
     "menu.user_groups": (
         By.XPATH,
-        ("//div[contains(@style,'static') or contains(@style, 'fixed')]"
-         "//a[@id='menu_item_usergroups']")),
+        (ADM_MENU_CONTAINER_PATH + "//a[@id='menu_item_usergroups']")),
     "menu.roles": (
         By.XPATH,
-        ("//div[contains(@style,'static') or contains(@style, 'fixed')]"
-         "//a[@id='menu_item_roles']")),
+        (ADM_MENU_CONTAINER_PATH + "//a[@id='menu_item_roles']")),
     "menu.bookmarks": (
         By.XPATH,
-        ("//div[contains(@style,'static') or contains(@style, 'fixed')]"
-         "//a[@id='menu_item_bookmarks']")),
+        (ADM_MENU_CONTAINER_PATH + "//a[@id='menu_item_bookmarks']")),
     "menu.settings": (
         By.XPATH,
-        ("//div[contains(@style,'static') or contains(@style, 'fixed')]"
-         "//a[@id='menu_item_settings']")),
+        (ADM_MENU_CONTAINER_PATH + "//a[@id='menu_item_settings']")),
     "menu.about": (
         By.XPATH,
-        ("//div[contains(@style,'static') or contains(@style, 'fixed')]"
-         "//a[@id='menu_item_about_index']")),
+        (ADM_MENU_CONTAINER_PATH + "//a[@id='menu_item_about_index']")),
 
     # Account Menu
     "menu.account": (By.XPATH, "//a[@id='account_menu']"),
@@ -309,35 +257,31 @@ menu_locators = LocatorDict({
     # Common Locators for Orgs and Locations
     "menu.any_context": (
         By.XPATH,
-        ("//div[contains(@style,'static') or contains(@style,'fixed')]"
-         "//li[contains(@class,'org-switcher')]/a")),
+        (MENU_CONTAINER_PATH + "//li[contains(@class,'org-switcher')]/a")),
     # Updated to current_text as the fetched text can also be org+loc
     "menu.current_text": (
         By.XPATH,
-        ("//div[contains(@style,'static') or contains(@style,'fixed')]"
-         "//li[contains(@class,'org-switcher')]/a")),
+        (MENU_CONTAINER_PATH + "//li[contains(@class,'org-switcher')]/a")),
     "menu.fetch_org": (
         By.XPATH,
-        ("//div[contains(@style,'static') or contains(@style, 'fixed')]"
-         "//li[contains(@class, 'org-menu')]/a")),
+        (MENU_CONTAINER_PATH + "//li[contains(@class, 'org-menu')]/a")),
     "menu.fetch_loc": (
         By.XPATH,
-        ("//div[contains(@style,'static') or contains(@style, 'fixed')]"
-         "//li[contains(@class, 'loc-menu')]/a")),
+        (MENU_CONTAINER_PATH + "//li[contains(@class, 'loc-menu')]/a")),
 
     # Orgs
     "org.manage_org": (
         By.XPATH,
-        ("//div[contains(@style,'static') or contains(@style,'fixed')]"
+        (MENU_CONTAINER_PATH +
          "//a[@class='manage-menu' and contains(@href, 'organizations')]")),
     "org.nav_current_org": (
         By.XPATH,
-        ("(//div[contains(@style,'static') or contains(@style,'fixed')]"
+        ("(" + MENU_CONTAINER_PATH +
          "//li[contains(@class,'org-switcher')]"
          "//li/a[@data-toggle='dropdown'])[1]")),
     "org.select_org": (
         By.XPATH,
-        ("//div[contains(@style,'static') or contains(@style,'fixed')]"
+        (MENU_CONTAINER_PATH +
          "//a[@href='/organizations/clear']/../../li/a[contains(.,'%s')]|"
          "//div[contains(@style,'static') or contains(@style,'fixed')]"
          "//a[@href='/organizations/clear']/../../li/a"
@@ -346,16 +290,16 @@ menu_locators = LocatorDict({
     # Locations
     "loc.manage_loc": (
         By.XPATH,
-        ("//div[contains(@style,'static') or contains(@style,'fixed')]"
+        (MENU_CONTAINER_PATH +
          "//a[@class='manage-menu' and contains(@href, 'locations')]")),
     "loc.nav_current_loc": (
         By.XPATH,
-        ("(//div[contains(@style,'static') or contains(@style,'fixed')]"
+        ("(" + MENU_CONTAINER_PATH +
          "//li[contains(@class,'org-switcher')]"
          "//li/a[@data-toggle='dropdown'])[2]")),
     "loc.select_loc": (
         By.XPATH,
-        ("//div[contains(@style,'static') or contains(@style,'fixed')]"
+        (MENU_CONTAINER_PATH +
          "//a[@href='/locations/clear']/../../li/a[contains(.,'%s')]|"
          "//div[contains(@style,'static') or contains(@style,'fixed')]"
          "//a[@href='/locations/clear']/../../li/a"

--- a/robottelo/ui/repository.py
+++ b/robottelo/ui/repository.py
@@ -18,7 +18,7 @@ class Repos(Base):
 
     def create(self, name, gpg_key=None, http=False, url=None,
                upstream_repo_name=None, repo_type=REPO_TYPE['yum'],
-               repo_checksum=CHECKSUM_TYPE['default']):
+               repo_checksum=CHECKSUM_TYPE['default'], download_policy=None):
         """Creates new repository from UI."""
         self.click(locators['repo.new'])
         self.text_field_update(common_locators['name'], name)
@@ -33,6 +33,11 @@ class Repos(Base):
             self.select(common_locators['gpg_key'], gpg_key)
         if url:
             self.text_field_update(locators['repo.url'], url)
+        if download_policy:
+            self.select(
+                locators['repo.download_policy'],
+                download_policy
+            )
         if upstream_repo_name:
             self.text_field_update(
                 locators['repo.upstream_name'], upstream_repo_name)
@@ -40,8 +45,9 @@ class Repos(Base):
             self.click(locators['repo.via_http'])
         self.click(common_locators['create'])
 
-    def update(self, name, new_name=None, new_url=None, new_repo_checksum=None,
-               new_gpg_key=None, http=False, new_upstream_name=None):
+    def update(self, name, new_name=None, new_url=None,
+               new_repo_checksum=None, new_gpg_key=None, http=False,
+               new_upstream_name=None, download_policy=None):
         """Updates repositories from UI."""
         repo_element = self.search(name)
         if repo_element is None:
@@ -74,6 +80,13 @@ class Repos(Base):
             self.click(locators['repo.upstream_edit'])
             self.text_field_update(
                 locators['repo.upstream_update'], new_upstream_name)
+            self.click(common_locators['save'])
+        if download_policy:
+            self.click(locators['repo.download_policy_edit'])
+            self.select(
+                locators['repo.download_policy_update'],
+                download_policy
+            )
             self.click(common_locators['save'])
 
     def delete(self, name, really=True):
@@ -139,7 +152,7 @@ class Repos(Base):
         self.wait_for_ajax()
         if field_name in [
             'checksum', 'errata', 'gpgkey', 'package_groups', 'packages',
-            'upstream', 'url',
+            'upstream', 'url', 'download_policy'
         ]:
             return (self.wait_until_element(locators[
                 'repo.fetch_' + field_name]).text == expected_field_value)


### PR DESCRIPTION
Closes #3730 
Closes #3744 

1) Added automation for download_policy (13 new tests) on UI.repository and related changes on repo factory
2) Added better log error messages on UI wait_element, find_element etc... (related to #3744)
3) Added `self.object.search_and_click("string_here")` helper method to be used in place of the common `self.object.click(self.object.search("string_here"))`
4) Added support for `select_by_{text|value|index}` on selenium `select` element wrapper
5) Do not forced change org context if org already selected (saves time)
6) Used `session_org` related to #3519 
7) Fix locators.menu.MENU_CONTAINER_XPATH to work in upstream
8) Fix error messages to use u"" (unicode prefix)

Downstream Test Results:

```console
$ py.test -v tests/foreman/ui/test_repository.py
======== test session starts =======
platform linux2 -- Python 2.7.11, pytest-2.9.2, py-1.4.31, pluggy-0.3.1 -- /home/brocha/.virtualenvs/rob/bin/python2
collected 31 items 

RepositoryTestCase::test_negative_create_with_invalid_download_policy PASSED
RepositoryTestCase::test_negative_create_with_invalid_name PASSED
RepositoryTestCase::test_negative_create_with_same_names PASSED
RepositoryTestCase::test_negative_delete_puppet_repo_associated_with_cv PASSED
RepositoryTestCase::test_negative_download_policy_displayed_for_non_yum_repo PASSED
RepositoryTestCase::test_negative_update_to_invalid_download_policy PASSED
RepositoryTestCase::test_positive_create_background_update_to_immediate PASSED
RepositoryTestCase::test_positive_create_background_update_to_on_demand PASSED
RepositoryTestCase::test_positive_create_custom_ostree_repo PASSED
RepositoryTestCase::test_positive_create_immediate_update_to_background PASSED
RepositoryTestCase::test_positive_create_immediate_update_to_on_demand PASSED
RepositoryTestCase::test_positive_create_in_different_orgs PASSED
RepositoryTestCase::test_positive_create_on_demand_update_to_background PASSED
RepositoryTestCase::test_positive_create_on_demand_update_to_immediate PASSED
RepositoryTestCase::test_positive_create_repo_with_checksum PASSED
RepositoryTestCase::test_positive_create_with_default_download_policy PASSED
RepositoryTestCase::test_positive_create_with_download_policy PASSED
RepositoryTestCase::test_positive_create_with_name PASSED
RepositoryTestCase::test_positive_delete PASSED
RepositoryTestCase::test_positive_delete_custom_ostree_repo PASSED
RepositoryTestCase::test_positive_discover_repo_via_existing_product PASSED
RepositoryTestCase::test_positive_discover_repo_via_new_product FAILED
RepositoryTestCase::test_positive_download_policy_displayed_for_yum_repos PASSED
RepositoryTestCase::test_positive_sync_custom_repo_docker PASSED
RepositoryTestCase::test_positive_sync_custom_repo_puppet PASSED
RepositoryTestCase::test_positive_sync_custom_repo_yum PASSED
RepositoryTestCase::test_positive_update_checksum_type PASSED
RepositoryTestCase::test_positive_update_custom_ostree_repo_name PASSED
RepositoryTestCase::test_positive_update_custom_ostree_repo_url PASSED
RepositoryTestCase::test_positive_update_gpg PASSED
RepositoryTestCase::test_positive_update_url PASSED
====== 1 failed, 30 passed in 1712.21 seconds ======
```

The Failing test is related to `discover_repo` 
```
2016-08-31 01:26:51 - robottelo.ui.browser - DEBUG - findElement: id: 16 {'using': 'xpath', 'value': "//table[@bst-table='discoveryTable']//td[contains(., 'fakerepo01/')]/../td/input[@type='checkbox']"}
StaleElementReferenceException: Message: Element is no longer attached to the DOM
E       For documentation on this error, please visit: http://seleniumhq.org/exceptions/stale_element_reference.html
```
