### PR TITLE
Added tier1 ostree repository tests from CLI

### DIFF
--- a/robottelo/cli/factory.py
+++ b/robottelo/cli/factory.py
@@ -680,8 +680,8 @@ def make_repository(options=None):
                                                 currently 'sha1' &amp; 'sha256'
                                                 are supported.'
         --content-type CONTENT_TYPE             type of repo (either 'yum',
-                                                'puppet' or 'docker', defaults
-                                                to 'yum')
+                                                'puppet', 'docker' or 'ostree',
+                                                defaults to 'yum')
         --docker-upstream-name DOCKER_UPSTREAM_NAME name of the upstream docker
                                                 repository
         --download-policy DOWNLOAD_POLICY       download policy for yum repos


### PR DESCRIPTION
- Added few tier1 OSTree repository tests from CLI
- Using `assertRaisesRegex` though a discussion is still on-going but I'm open to make any change around this.

Test Results:
```console
robottelo]$ py.test -v tests/foreman/cli/test_repository.py::RepositoryTestCase -k ostree
================================================================ test session starts =================================================================
platform linux2 -- Python 2.7.5, pytest-2.9.2, py-1.4.31, pluggy-0.3.1 -- /usr/bin/python
cachedir: .cache
rootdir: /home/sghai/QE/robottelo, inifile: 
plugins: cov-2.3.1, xdist-1.15.0
collected 47 items 

tests/foreman/cli/test_repository.py::RepositoryTestCase::test_negative_create_ostree_repo_with_checksum <- robottelo/decorators/__init__.py SKIPPED
tests/foreman/cli/test_repository.py::RepositoryTestCase::test_negative_create_unprotected_ostree_repo <- robottelo/decorators/host.py PASSED
tests/foreman/cli/test_repository.py::RepositoryTestCase::test_positive_create_ostree_repo <- robottelo/decorators/host.py PASSED
tests/foreman/cli/test_repository.py::RepositoryTestCase::test_positive_delete_ostree_by_id <- robottelo/decorators/host.py PASSED
tests/foreman/cli/test_repository.py::RepositoryTestCase::test_positive_delete_ostree_by_name <- robottelo/decorators/host.py PASSED
tests/foreman/cli/test_repository.py::RepositoryTestCase::test_positive_synchronize_ostree_repo <- robottelo/decorators/host.py PASSED

========================================================= 41 tests deselected by '-kostree' ==========================================================
================================================ 5 passed, 1 skipped, 41 deselected in 519.77 seconds ==============================================
```