### PR TITLE
Added tests for Smart Class Parameters

### DIFF
--- a/tests/foreman/cli/test_classparameters.py
+++ b/tests/foreman/cli/test_classparameters.py
@@ -912,7 +912,7 @@ class SmartClassParametersTestCase(CLITestCase):
         with self.assertRaises(CLIReturnCodeError):
             SmartClassParameter.add_override_value({
                 'smart-class-parameter-id': sc_param_id,
-                'match': 'non_existing_attribute',
+                'match': 'hostgroup=nonexistingHG',
                 'value': gen_string('alpha')
             })
 
@@ -1499,3 +1499,16 @@ class SmartClassParametersTestCase(CLITestCase):
         })
         self.assertFalse(sc_param['default-value'])
         self.assertEqual(sc_param['hidden-value?'], True)
+
+    @classmethod
+    def tearDownClass(cls):
+        """Removes entire module from the system and re-imports classes into
+        proxy. This is required as other types of tests (API/UI) use the same
+        module.
+        """
+        super(SmartClassParametersTestCase, cls).tearDownClass()
+        ssh.command('puppet module uninstall --force puppetlabs/ntp')
+        Proxy.importclasses({
+            u'environment': cls.env['name'],
+            u'name': cls.host_name,
+        })


### PR DESCRIPTION
Depends on SatelliteQE/nailgun#313. Closes #3751
Mostly adoptation of CLI tests from #3576. Dataset should be updated after #3620
```python
py.test -v -k "SmartClassParametersTestCase" tests/foreman/api/test_classparameters.py
===================================================================== test session starts =====================================================================
platform linux2 -- Python 2.7.12, pytest-3.0.1, py-1.4.31, pluggy-0.3.1 -- /home/qui/code/robottelo/venv2/bin/python2.7
cachedir: .cache
rootdir: /home/qui/code/robottelo, inifile: 
plugins: cov-2.3.1, xdist-1.15.0
collected 46 items 
=========================================================== 35 passed, 12 skipped in 160.11 seconds ===========================================================
```

Upstream:
```python
=========================================================== 35 passed, 12 skipped in 111.04 seconds ===========================================================
```