### PR TITLE
CLIReturnError expose return_code, stderr and msg to assertRaisesRegex

### DIFF
--- a/robottelo/cli/base.py
+++ b/robottelo/cli/base.py
@@ -29,7 +29,16 @@ class CLIReturnCodeError(Exception):
         self.message = msg
 
     def __str__(self):
-        return self.message
+        """Include return_code, stderr and msg to string repr so
+        assertRaisesRegexp can be used to assert error present on any
+        attribute
+        """
+        return repr(self)
+
+    def __repr__(self):
+        """Include return_code, stderr and msg to improve logging"""
+        tmpl = u'CLIReturnCodeError(return_code={!r}, stderr={!r}, msg={!r}'
+        return tmpl.format(self.return_code, self.stderr, self.msg)
 
 
 class Base(object):

--- a/tests/robottelo/test_cli.py
+++ b/tests/robottelo/test_cli.py
@@ -237,6 +237,16 @@ class BaseCliTestCase(unittest2.TestCase):
         self.assert_cmd_execution(construct, execute, Base.dump, 'dump')
 
 
+class CLIErrorTests(unittest2.TestCase):
+    """Tests for the CLIError cli class"""
+
+    def test_error_msg_is_exposed(self):
+        """Check if message error is exposed to assertRaisesRegexp"""
+        msg = u'organization-id option is required for Foo.create'
+        with self.assertRaisesRegexp(CLIError, msg):
+            raise CLIError(msg)
+
+
 class CLIReturnCodeErrorTestCase(unittest2.TestCase):
     """Tests for the CLIReturnCodeError cli class"""
 
@@ -248,7 +258,17 @@ class CLIReturnCodeErrorTestCase(unittest2.TestCase):
         self.assertEqual(error.msg, u'msg')
         self.assertEqual(error.message, error.msg)
 
-    def test_str(self):
-        """Check __str__ returns message attribute"""
-        error = CLIReturnCodeError(1, u'stderr', u'msg')
-        self.assertEqual(error.message, str(error))
+    def test_return_code_is_exposed(self):
+        """Check if return_code is exposed to assertRaisesRegexp"""
+        with self.assertRaisesRegexp(CLIReturnCodeError, u'1'):
+            raise CLIReturnCodeError(1, u'stderr', u'msg')
+
+    def test_stderr_is_exposed(self):
+        """Check if stderr is exposed to assertRaisesRegexp"""
+        with self.assertRaisesRegexp(CLIReturnCodeError, u'stderr'):
+            raise CLIReturnCodeError(1, u'stderr', u'msg')
+
+    def test_message_is_exposed(self):
+        """Check if message is exposed to assertRaisesRegexp"""
+        with self.assertRaisesRegexp(CLIReturnCodeError, u'msg'):
+            raise CLIReturnCodeError(1, u'stderr', u'msg')


### PR DESCRIPTION
 close #3782 

Test results

```console
============================= test session starts ==============================
platform linux2 -- Python 2.7.12, pytest-2.9.2, py-1.4.31, pluggy-0.3.1
rootdir: /home/renzo/PycharmProjects/robottelo, inifile: 
plugins: cov-2.3.0, xdist-1.14
collected 185 items

test_api_utils.py ..
test_cli.py ......................
test_config_casts.py ..............
test_config_settings.py .....
test_datafactory.py .....
test_decorators.py ...........................................
test_hammer.py .........
test_helpers.py ...........
test_host_info.py ................
test_ssh.py ..............
test_ui.py .....
test_ui_locators.py ........................
test_vm.py ......
decorators/test_host.py .........

========================== 185 passed in 1.72 seconds ==========================

Process finished with exit code 0
```