### PR TITLE
[backport to 6.2.z] endtoend tests - bulk host actions added

### DIFF
--- a/tests/foreman/endtoend/test_api_endtoend.py
+++ b/tests/foreman/endtoend/test_api_endtoend.py
@@ -416,6 +416,9 @@ API_PATHS = {
         u'/katello/api/hosts/bulk/remove_content',
         u'/katello/api/hosts/bulk/remove_host_collections',
         u'/katello/api/hosts/bulk/update_content',
+        u'/katello/api/hosts/bulk/subscriptions/add_subscriptions',
+        u'/katello/api/hosts/bulk/subscriptions/auto_attach',
+        u'/katello/api/hosts/bulk/subscriptions/remove_subscriptions',
     ),
     u'host_errata': (
         u'/api/hosts/:host_id/errata',


### PR DESCRIPTION
We need to backport (cherry pick) this one to `6.2.z` branch too

```bash
$ py.test -n4 -k test_positive_get_links test_api_endtoend.py -s
======================================== test session starts ========================================
platform linux2 -- Python 2.7.11, pytest-2.9.2, py-1.4.31, pluggy-0.3.1
rootdir: /home/rplevka/work/rplevka/robottelo, inifile: 
plugins: xdist-1.14
gw0 [1] / gw1 [1] / gw2 [1] / gw3 [1]
scheduling tests via LoadScheduling
.
===================================== 1 passed in 3.95 seconds ======================================
```