### PR TITLE
Fixed API paths on 6.2.z

### DIFF
--- a/tests/foreman/endtoend/test_api_endtoend.py
+++ b/tests/foreman/endtoend/test_api_endtoend.py
@@ -415,7 +415,11 @@ API_PATHS = {
         u'/katello/api/hosts/bulk/install_content',
         u'/katello/api/hosts/bulk/remove_content',
         u'/katello/api/hosts/bulk/remove_host_collections',
+        u'/katello/api/hosts/bulk/subscriptions/add_subscriptions',
+        u'/katello/api/hosts/bulk/subscriptions/auto_attach',
+        u'/katello/api/hosts/bulk/subscriptions/remove_subscriptions'
         u'/katello/api/hosts/bulk/update_content',
+
     ),
     u'host_errata': (
         u'/api/hosts/:host_id/errata',


### PR DESCRIPTION
 close #3782 

## Test Result
```console
/home/renzo/PycharmProjects/venvs/robottelo/bin/python /home/renzo/bin/pycharm-2016.2/helpers/pycharm/pytestrunner.py -p pytest_teamcity /home/renzo/PycharmProjects/robottelo/tests/foreman/endtoend/test_api_endtoend.py "-k AvailableURLsTestCase and test_positive_get_status_code"
Testing started at 11:03 AM ...
============================= test session starts ==============================
platform linux2 -- Python 2.7.12, pytest-2.9.2, py-1.4.31, pluggy-0.3.1
rootdir: /home/renzo/PycharmProjects/robottelo, inifile: 
plugins: cov-2.3.0, xdist-1.14
collected 7 items

test_api_endtoend.py 2016-09-08 11:03:51 - robottelo - DEBUG - Started setUpClass: tests.foreman.endtoend.test_api_endtoend/AvailableURLsTestCase
2016-09-08 11:03:51 - nailgun.client - DEBUG - Making HTTP GET request to https://sat-r220-08.lab.eng.rdu2.redhat.com:50120/api/v2 with options {'verify': False, 'auth': ('admin', 'changeme'), 'headers': {'content-type': 'application/json'}} and no data.
2016-09-08 11:03:52 - nailgun.client - DEBUG - Received HTTP 200 response: {"links":{"base":{},"api":{},"host_subscriptions":{"List a host's subscriptions":"/api/hosts/:host_id/subscriptions","Trigger an auto-attach of subscriptions":"/api/hosts/:host_id/subscriptions/auto_attach","List subscription events for the host":"/api/hosts/:host_id/subscriptions/events","Unregister the host as a subscription consumer":"/api/hosts/:host_id/subscriptions","Register a host with subscription and information":"/api/hosts/subscriptions","Add a subscription to a host":"/api/hosts/:host_id/subscriptions/add_subscriptions","Set content overrides for the host":"/api/hosts/:host_id/subscriptions/content_override","Get content and overrides for the host":"/api/hosts/:host_id/subscriptions/product_content"},"hosts":{"List all hosts":"/api/hosts","Show a host":"/api/hosts/:id","Create a host":"/api/hosts","Update a host":"/api/hosts/:id","Delete a host":"/api/hosts/:id","Get configuration status of host":"/api/hosts/:id/status","Get status of host":"/api/hosts/:id/status/:type","Get vm attributes of host":"/api/hosts/:id/vm_compute_attributes","Force a Puppet agent run on the host":"/api/hosts/:id/puppetrun","Disassociate the host from a VM":"/api/hosts/:id/disassociate","Run a power operation on host":"/api/hosts/:id/power","Boot host from specified device":"/api/hosts/:id/boot","Upload facts for a host, creating the host if required":"/api/hosts/facts","Rebuild orchestration config":"/api/hosts/:id/rebuild_config","Preview rendered provisioning template content":"/api/hosts/:id/template/:kind","Alter a hosts host collections":"/api/hosts/:host_id/host_collections"},"interfaces":{"List all interfaces for host":"/api/hosts/:host_id/interfaces","Show an interface for host":"/api/hosts/:host_id/interfaces/:id","Create an interface on a host":"/api/hosts/:host_id/interfaces","Update a host's interface":"/api/hosts/:host_id/interfaces/:id","Delete a host's interface":"/api/hosts/:host_id/interfaces/:id"},"hostgroups":{"List all host groups":"/api/hostgroups","Show a host group":"/api/hostgroups/:id","Create a host group":"/api/hostgroups","Update a host group":"/api/hostgroups/:id","Delete a host group":"/api/hostgroups/:id","Clone a host group":"/api/hostgroups/:id/clone"},"containers":{"List all containers":"/docker/api/v2/containers","Show a container":"/docker/api/v2/containers/:id","Create a container":"/docker/api/v2/containers","Delete a container":"/docker/api/v2/containers/:id","Show container logs":"/docker/api/v2/containers/:id/logs","Run power operation on a container":"/docker/api/v2/containers/:id/power"},"registries":{"List all docker registries":"/docker/api/v2/registries","Show a docker registry":"/docker/api/v2/registries/:id","Create a docker registry":"/docker/api/v2/registries","Update a docker registry":"/docker/api/v2/registries/:id","Delete a docker registry":"/docker/api/v2/registries/:id"},"disks":{"Boot disks":"/bootdisk/api","Download generic image":"/bootdisk/api/generic","Download host image":"/bootdisk/api/hosts/:host_id"},"subnet_disks":{"Subnet boot disks":"/bootdisk/api","Download subnet generic image":"/bootdisk/api/subnets/:subnet_id"},"recurring_logics":{"List recurring logics":"/foreman_tasks/api/recurring_logics","Show recurring logic details":"/foreman_tasks/api/recurring_logics/:id","Cancel recurring logic":"/foreman_tasks/api/recurring_logics/:id/cancel"},"foreman_tasks":{"Show task summary":"/foreman_tasks/api/tasks/summary","Show task details":"/foreman_tasks/api/tasks/:id","List dynflow tasks for uuids":"/foreman_tasks/api/tasks/bulk_search","Resume all paused error tasks":"/foreman_tasks/api/tasks/bulk_resume","List tasks":"/foreman_tasks/api/tasks","Send data to the task from external executor (such as smart_Capsule_dynflow)":"/foreman_tasks/api/tasks/callback"},"candlepin_proxies":{"Update the information about enabled repositories":"/katello/api/systems/:id/enabled_repos"},"activation_keys":{"List activation keys":"/katello/api/activation_keys","Create an activation key":"/katello/api/activation_keys","Update an activation key":"/katello/api/activation_keys/:id","Destroy an activation key":"/katello/api/activation_keys/:id","Show an activation key":"/katello/api/activation_keys/:id","Copy an activation key":"/katello/api/activation_keys/:id/copy","List host collections the system does not belong to":"/katello/api/activation_keys/:id/host_collections/available","Show release versions available for an activation key":"/katello/api/activation_keys/:id/releases","Show content available for an activation key":"/katello/api/activation_keys/:id/product_content","Attach a subscription":"/katello/api/activation_keys/:id/add_subscriptions","Unattach a subscription":"/katello/api/activation_keys/:id/remove_subscriptions","Override content for activation_key":"/katello/api/activation_keys/:id/content_override"},"capsule_content":{"List the lifecycle environments attached to the capsule":"/katello/api/capsules/:id/content/lifecycle_environments","List the lifecycle environments not attached to the capsule":"/katello/api/capsules/:id/content/available_lifecycle_environments","Add lifecycle environments to the capsule":"/katello/api/capsules/:id/content/lifecycle_environments","Remove lifecycle environments from the capsule":"/katello/api/capsules/:id/content/lifecycle_environments/:environment_id","Synchronize the content to the capsule":"/katello/api/capsules/:id/content/sync","Get current capsule synchronization status":"/katello/api/capsules/:id/content/sync","Cancel running capsule synchronization":"/katello/api/capsules/:id/content/sync"},"smart_proxies":{"Import puppet classes from puppet Capsule":"/api/smart_proxies/:id/import_puppetclasses","List all capsules":"/api/smart_proxies","Show a capsule":"/api/smart_proxies/:id","Create a capsule":"/api/smart_proxies","Update a capsule":"/api/smart_proxies/:id","Delete a capsule":"/api/smart_proxies/:id","Refresh capsule features":"/api/smart_proxies/:id/refresh"},"capsules":{"List all capsules":"/katello/api/capsules","Show the capsule details":"/katello/api/capsules/:id"},"content_uploads":{"Create an upload request":"/katello/api/repositories/:repository_id/content_uploads","Upload a chunk of the file's content":"/katello/api/repositories/:repository_id/content_uploads/:id","Delete an upload request":"/katello/api/repositories/:repository_id/content_uploads/:id"},"content_view_filter_rules":{"List filter rules":"/katello/api/content_view_filters/:content_view_filter_id/rules","Create a filter rule. The parameters included should be based upon the filter type":"/katello/api/content_view_filters/:content_view_filter_id/rules","Show filter rule info":"/katello/api/content_view_filters/:content_view_filter_id/rules/:id","Update a filter rule. The parameters included should be based upon the filter type":"/katello/api/content_view_filters/:content_view_filter_id/rules/:id","Delete a filter rule":"/katello/api/content_view_filters/:content_view_filter_id/rules/:id"},"content_view_filters":{"list filters":"/katello/api/content_views/:content_view_id/filters","create a filter for a content view":"/katello/api/content_views/:content_view_id/filters","show filter info":"/katello/api/content_views/:content_view_id/filters/:id","update a filter":"/katello/api/content_views/:content_view_id/filters/:id","delete a filter":"/katello/api/content_views/:content_view_id/filters/:id"},"content_view_histories":{"Show a content view's history":"/katello/api/content_views/:id/history"},"content_view_puppet_modules":{"List content view puppet modules":"/katello/api/content_views/:content_view_id/content_view_puppet_modules","Add a puppet module to the content view":"/katello/api/content_views/:content_view_id/content_view_puppet_modules","Show a content view puppet module":"/katello/api/content_views/:content_view_id/content_view_puppet_modules/:id","Update a puppet module associated with the content view":"/katello/api/content_views/:content_view_id/content_view_puppet_modules/:id","Remove a puppet module from the content view":"/katello/api/content_views/:content_view_id/content_view_puppet_modules/:id"},"content_view_versions":{"List content view versions":"/katello/api/content_view_versions","Show content view version":"/katello/api/content_view_versions/:id","Promote a content view version":"/katello/api/content_view_versions/:id/promote","Export a content view version":"/katello/api/content_view_versions/:id/export","Remove content view version":"/katello/api/content_view_versions/:id","Perform an Incremental Update on one or more Content View Versions":"/katello/api/content_view_versions/incremental_update"},"content_views":{"List content views":"/katello/api/organizations/:organization_id/content_views","Create a content view":"/katello/api/organizations/:organization_id/content_views","Update a content view":"/katello/api/content_views/:id","Publish a content view":"/katello/api/content_views/:id/publish","Show a content view":"/katello/api/content_views/:id","Get puppet modules that are available to be added to the content view":"/katello/api/content_views/:id/available_puppet_modules","Get puppet modules names that are available to be added to the content view":"/katello/api/content_views/:id/available_puppet_module_names","Remove a content view from an environment":"/katello/api/content_views/:id/environments/:environment_id","Remove versions and/or environments from a content view and reassign systems and keys":"/katello/api/content_views/:id/remove","Delete a content view":"/katello/api/content_views/:id","Make copy of a content view":"/katello/api/content_views/:id/copy"},"docker_manifests":{"List docker_manifests":"/katello/api/compare","Show a docker manifest":"/katello/api/docker_manifests/:id"},"docker_tags":{"List docker_tags":"/katello/api/compare","Show a docker tag":"/katello/api/docker_tags/:id"},"lifecycle_environments":{"List environments in an organization":"/katello/api/environments","Show an environment":"/katello/api/environments/:id","Create an environment":"/katello/api/environments","Update an environment":"/katello/api/environments/:id","Destroy an environment":"/katello/api/environments/:id","List environment paths":"/katello/api/organizations/:organization_id/environments/paths","List repositories available in the environment":"/katello/api/organizations/:organization_id/environments/:id/repositories"},"errata":{"List errata":"/katello/api/compare","Show an erratum":"/katello/api/errata/:id"},"gpg_keys":{"List gpg keys":"/katello/api/gpg_keys","Create a gpg key":"/katello/api/gpg_keys","Show a gpg key":"/katello/api/gpg_keys/:id","Update a repository":"/katello/api/gpg_keys/:id","Destroy a gpg key":"/katello/api/gpg_keys/:id","Upload gpg key contents":"/katello/api/gpg_keys/:id/content"},"host_autocomplete":{},"host_collections":{"Show a host collection":"/katello/api/host_collections/:id","List host collections":"/katello/api/host_collections","Create a host collection":"/katello/api/host_collections","Update a host collection":"/katello/api/host_collections/:id","Add host to the host collection":"/katello/api/host_collections/:id/add_hosts","Remove hosts from the host collection":"/katello/api/host_collections/:id/remove_hosts","Destroy a host collection":"/katello/api/host_collections/:id","Make copy of a host collection":"/katello/api/host_collections/:id/copy"},"host_errata":{"List errata available for the content host":"/api/hosts/:host_id/errata","Schedule errata for installation":"/api/hosts/:host_id/errata/apply","Retrieve a single errata for a host":"/api/hosts/:host_id/errata/:id"},"host_packages":{"List packages installed on the host":"/api/hosts/:host_id/packages","Install packages remotely":"/api/hosts/:host_id/packages/install","Update packages remotely":"/api/hosts/:host_id/packages/upgrade_all","Uninstall packages remotely":"/api/hosts/:host_id/packages/remove"},"hosts_bulk_actions":{"Add one or more host collections to one or more hosts":"/katello/api/hosts/bulk/add_host_collections","Remove one or more host collections from one or more hosts":"/katello/api/hosts/bulk/remove_host_collections","Fetch applicable errata for a system":"/katello/api/hosts/bulk/applicable_errata","Install content on one or more hosts":"/katello/api/hosts/bulk/install_content","Update content on one or more hosts":"/katello/api/hosts/bulk/update_content","Remove content on one or more hosts":"/katello/api/hosts/bulk/remove_content","Destroy one or more hosts":"/katello/api/hosts/bulk/destroy","Remove subscriptions from one or more hosts":"/katello/api/hosts/bulk/subscriptions/remove_subscriptions","Add subscriptions to one or more hosts":"/katello/api/hosts/bulk/subscriptions/add_subscriptions","Trigger an auto-attach of subscriptions on one or more hosts":"/katello/api/hosts/bulk/subscriptions/auto_attach","Assign the environment and content view to one or more hosts":"/katello/api/hosts/bulk/environment_content_view","Given a set of hosts and errata, lists the content view versions and environments that need updating":"/katello/api/hosts/bulk/available_incremental_updates"},"organizations":{"List all organizations":"/katello/api/organizations","Show organization":"/katello/api/organizations/:id","Create organization":"/katello/api/organizations","Update organization":"/katello/api/organizations/:id","Delete an organization":"/katello/api/organizations/:id","Discover Repositories":"/katello/api/organizations/:id/repo_discover","Cancel repository discovery":"/katello/api/organizations/:label/cancel_repo_discover","Download a debug certificate":"/katello/api/organizations/:label/download_debug_certificate","Auto-attach available subscriptions to all hosts within an organization. Asynchronous operation":"/katello/api/organizations/:id/autoattach_subscriptions","List all :resource_id":"/katello/api/organizations/:id/redhat_provider"},"ostree_branches":{"List ostree_branches":"/katello/api/compare","Show an ostree branch":"/katello/api/ostree_branches/:id"},"package_groups":{"List package_groups":"/katello/api/compare","Show a package group":"/katello/api/package_groups/:id"},"packages":{"List packages":"/katello/api/compare","Show a package":"/katello/api/packages/:id"},"ping":{"Shows status of system and it's subcomponents":"/katello/api/ping","Shows version information":"/katello/api/status"},"products_bulk_actions":{"Destroy one or more products":"/katello/api/products/bulk/destroy","Sync one or more products":"/katello/api/products/bulk/sync_plan"},"products":{"List products":"/katello/api/products","Create a product":"/katello/api/products","Show a product":"/katello/api/products/:id","Updates a product":"/katello/api/products/:id","Destroy a product":"/katello/api/products/:id","Sync all repositories for a product":"/katello/api/products/:id/sync"},"puppet_modules":{"List puppet_modules":"/katello/api/compare","Show a puppet module":"/katello/api/puppet_modules/:id"},"repositories_bulk_actions":{"Destroy one or more repositories":"/katello/api/repositories/bulk/destroy","Synchronize repository":"/katello/api/repositories/bulk/sync"},"repositories":{"List of enabled repositories":"/katello/api/repositories","Create a custom repository":"/katello/api/repositories","Show the available repository types":"/katello/api/repositories/repository_types","Show a repository":"/katello/api/repositories/:id","Sync a repository":"/katello/api/repositories/:id/sync","Export a repository":"/katello/api/repositories/:id/export","Update a repository":"/katello/api/repositories/:id","Destroy a custom repository":"/katello/api/repositories/:id","Upload content into the repository":"/katello/api/repositories/:id/upload_content","Import uploads into a repository":"/katello/api/repositories/:id/import_uploads","Return the content of a repo gpg key, used directly by yum":"/katello/api/repositories/:id/gpg_key_content"},"repository_sets":{"List repository sets for a product":"/katello/api/products/:product_id/repository_sets","Get info about a repository set":"/katello/api/products/:product_id/repository_sets/:id","Get list or available repositories for the repository set":"/katello/api/products/:product_id/repository_sets/:id/available_repositories","Enable a repository from the set":"/katello/api/products/:product_id/repository_sets/:id/enable","Disable a repository form the set":"/katello/api/products/:product_id/repository_sets/:id/disable"},"root":{},"subscriptions":{"List organization subscriptions":"/katello/api/organizations/:organization_id/subscriptions","Show a subscription":"/katello/api/organizations/:organization_id/subscriptions/:id","Add a subscription to an activation key":"/katello/api/activation_keys/:activation_key_id/subscriptions","Unattach a subscription":"/katello/api/activation_keys/:activation_key_id/subscriptions/:id","Upload a subscription manifest":"/katello/api/organizations/:organization_id/subscriptions/upload","Refresh previously imported manifest for Red Hat provider":"/katello/api/organizations/:organization_id/subscriptions/refresh_manifest","Delete manifest from Red Hat provider":"/katello/api/organizations/:organization_id/subscriptions/delete_manifest","obtain manifest history for subscriptions":"/katello/api/organizations/:organization_id/subscriptions/manifest_history"},"sync":{"Get status of repo synchronisation for given product":"/katello/api/organizations/:organization_id/products/:product_id/sync"},"sync_plans":{"List sync plans":"/katello/api/sync_plans","Show a sync plan":"/katello/api/organizations/:organization_id/sync_plans/:id","Create a sync plan":"/katello/api/organizations/:organization_id/sync_plans","Update a sync plan":"/katello/api/organizations/:organization_id/sync_plans/:id","Destroy a sync plan":"/katello/api/organizations/:organization_id/sync_plans/:id","Add products to sync plan":"/katello/api/organizations/:organization_id/sync_plans/:id/add_products","Remove products from sync plan":"/katello/api/organizations/:organization_id/sync_plans/:id/remove_products","Initiate a sync of the products attached to the sync plan":"/katello/api/sync_plans/:id/sync"},"systems":{"List content hosts":"/katello/api/systems","Update content host information":"/katello/api/systems/:id","Show a content host":"/katello/api/systems/:id","Show releases available for the content host":"/katello/api/systems/:id/releases"},"uebercerts":{"Show an ueber certificate for an organization":"/katello/api/organizations/:organization_id/uebercert"},"discovered_hosts":{"List all discovered hosts":"/api/v2/discovered_hosts","Show a discovered host":"/api/v2/discovered_hosts/:id","Create a discovered host for testing (use /facts to create new hosts)":"/api/v2/discovered_hosts","Provision a discovered host":"/api/v2/discovered_hosts/:id","Delete a discovered host":"/api/v2/discovered_hosts/:id","Upload facts for a host, creating the host if required":"/api/v2/discovered_hosts/facts","Execute rules against a discovered host":"/api/v2/discovered_hosts/:id/auto_provision","Execute rules against all currently discovered hosts":"/api/v2/discovered_hosts/auto_provision_all","Refreshing the facts of a discovered host":"/api/v2/discovered_hosts/:id/refresh_facts","Rebooting a discovered host":"/api/v2/discovered_hosts/:id/reboot","Rebooting all discovered hosts":"/api/v2/discovered_hosts/reboot_all"},"discovery_rules":{"List all discovery rules":"/api/v2/discovery_rules","Show a discovery rule":"/api/v2/discovery_rules/:id","Create a discovery rule":"/api/v2/discovery_rules","Update a rule":"/api/v2/discovery_rules/:id","Delete a rule":"/api/v2/discovery_rules/:id"},"foreman_openscap_arf_reports":{"List Arf reports":"/api/v2/compliance/arf_reports","Show an Arf report":"/api/v2/compliance/arf_reports/:id","Deletes an Arf Report":"/api/v2/compliance/arf_reports/:id","Upload an ARF report":"/api/v2/compliance/arf/:cname/:policy_id/:date"},"foreman_openscap_policies":{"List SCAP contents":"/api/v2/compliance/policies","Show an SCAP content":"/api/v2/compliance/policies/:id","Create a policy":"/api/v2/compliance/policies","Update a policy":"/api/v2/compliance/policies/:id","Deletes a policy":"/api/v2/compliance/policies/:id","Show a policy's SCAP content":"/api/v2/compliance/policies/:id/content"},"foreman_openscap_scap_contents":{"List SCAP contents":"/api/v2/compliance/scap_contents","Show an SCAP content":"/api/v2/compliance/scap_contents/:id","Create SCAP content":"/api/v2/compliance/scap_contents","Update an SCAP content":"/api/v2/compliance/scap_contents/:id","Deletes an SCAP content":"/api/v2/compliance/scap_contents/:id"},"foreign_input_sets":{"List foreign input sets":"/api/templates/:template_id/foreign_input_sets","Show foreign input set details":"/api/templates/:template_id/foreign_input_sets/:id","Create a foreign input set":"/api/templates/:template_id/foreign_input_sets","Delete a foreign input set":"/api/templates/:template_id/foreign_input_sets/:id","Update a foreign input set":"/api/templates/:template_id/foreign_input_sets/:id"},"job_invocations":{"List job invocations":"/api/job_invocations","Show job invocation":"/api/job_invocations/:id","Create a job invocation":"/api/job_invocations","Get output for a host":"/api/job_invocations/:id/hosts/:host_id"},"job_templates":{"List job templates":"/api/job_templates","Import a job template from ERB":"/api/job_templates/import","Export a job template to ERB":"/api/job_templates/:id/export","Show job template details":"/api/job_templates/:id","Create a job template":"/api/job_templates","Update a job template":"/api/job_templates/:id","Delete a job template":"/api/job_templates/:id","Clone a provision template":"/api/job_templates/:id/clone"},"remote_execution_features":{"List remote execution features":"/api/remote_execution_features","Show remote execution feature":"/api/remote_execution_features/:id","Update a job template":"/api/remote_execution_features/:id"},"template_inputs":{"List template inputs":"/api/templates/:template_id/template_inputs","Show template input details":"/api/templates/:template_id/template_inputs/:id","Create a template input":"/api/templates/:template_id/template_inputs","Delete a template input":"/api/templates/:template_id/template_inputs/:id","Update a template input":"/api/templates/:template_id/template_inputs/:id"},"architectures":{"List all architectures":"/api/architectures","Show an architecture":"/api/architectures/:id","Create an architecture":"/api/architectures","Update an architecture":"/api/architectures/:id","Delete an architecture":"/api/architectures/:id"},"audits":{"List all audits":"/api/audits","Show an audit":"/api/audits/:id"},"auth_source_ldaps":{"List all LDAP authentication sources":"/api/auth_source_ldaps","Show an LDAP authentication source":"/api/auth_source_ldaps/:id","Create an LDAP authentication source":"/api/auth_source_ldaps","Update an LDAP authentication source":"/api/auth_source_ldaps/:id","Test LDAP connection":"/api/auth_source_ldaps/:id/test","Delete an LDAP authentication source":"/api/auth_source_ldaps/:id"},"autosign":{"List all autosign entries":"/api/smart_proxies/smart_proxy_id/autosign"},"bookmarks":{"List all bookmarks":"/api/bookmarks","Show a bookmark":"/api/bookmarks/:id","Create a bookmark":"/api/bookmarks","Update a bookmark":"/api/bookmarks/:id","Delete a bookmark":"/api/bookmarks/:id"},"common_parameters":{"List all global parameters":"/api/common_parameters","Show a global parameter":"/api/common_parameters/:id","Create a global parameter":"/api/common_parameters","Update a global parameter":"/api/common_parameters/:id","Delete a global parameter":"/api/common_parameters/:id"},"compute_attributes":{"Create a compute attributes set":"/api/compute_resources/:compute_resource_id/compute_profiles/:compute_profile_id/compute_attributes","Update a compute attributes set":"/api/compute_resources/:compute_resource_id/compute_profiles/:compute_profile_id/compute_attributes/:id"},"compute_profiles":{"List of compute profiles":"/api/compute_profiles","Show a compute profile":"/api/compute_profiles/:id","Create a compute profile":"/api/compute_profiles","Update a compute profile":"/api/compute_profiles/:id","Delete a compute profile":"/api/compute_profiles/:id"},"compute_resources":{"List all compute resources":"/api/compute_resources","Show a compute resource":"/api/compute_resources/:id","Create a compute resource":"/api/compute_resources","Update a compute resource":"/api/compute_resources/:id","Delete a compute resource":"/api/compute_resources/:id","List available images for a compute resource":"/api/compute_resources/:id/available_images","List available clusters for a compute resource":"/api/compute_resources/:id/available_clusters","List available flavors for a compute resource":"/api/compute_resources/:id/available_flavors","List available folders for a compute resource":"/api/compute_resources/:id/available_folders","List available zone for a compute resource":"/api/compute_resources/:id/available_zones","List available networks for a compute resource":"/api/compute_resources/:id/available_networks","List resource pools for a compute resource cluster":"/api/compute_resources/:id/available_clusters/:cluster_id/available_resource_pools","List storage domains for a compute resource":"/api/compute_resources/:id/available_storage_domains","List storage pods for a compute resource":"/api/compute_resources/:id/available_storage_pods","List available security groups for a compute resource":"/api/compute_resources/:id/available_security_groups","Associate VMs to Hosts":"/api/compute_resources/:id/associate"},"config_groups":{"List of config groups":"/api/config_groups","Show a config group":"/api/config_groups/:id","Create a config group":"/api/config_groups","Update a config group":"/api/config_groups/:id","Delete a config group":"/api/config_groups/:id"},"config_reports":{"List all reports":"/api/config_reports","Show a report":"/api/config_reports/:id","Create a report":"/api/config_reports","Delete a report":"/api/config_reports/:id","Show the last report for a host":"/api/hosts/:host_id/config_reports/last"},"config_templates":{"List provisioning templates":"/api/config_templates","Show provisioning template details":"/api/config_templates/:id","Create a provisioning template":"/api/config_templates","Update a provisioning template":"/api/config_templates/:id","Delete a provisioning template":"/api/config_templates/:id","Update the default PXE menu on all configured TFTP servers":"/api/config_templates/build_pxe_default","Clone a provision template":"/api/config_templates/:id/clone"},"dashboard":{"Get dashboard details":"/api/dashboard"},"domains":{"List of domains":"/api/domains","Show a domain":"/api/domains/:id","Create a domain":"/api/domains","Update a domain":"/api/domains/:id","Delete a domain":"/api/domains/:id"},"environments":{"Import puppet classes from puppet Capsule":"/api/smart_proxies/:id/import_puppetclasses","List all environments":"/api/environments","Show an environment":"/api/environments/:id","Create an environment":"/api/environments","Update an environment":"/api/environments/:id","Delete an environment":"/api/environments/:id"},"external_usergroups":{"List all external user groups for user group":"/api/usergroups/:usergroup_id/external_usergroups","Show an external user group for user group":"/api/usergroups/:usergroup_id/external_usergroups/:id","Create an external user group linked to a user group":"/api/usergroups/:usergroup_id/external_usergroups","Update external user group":"/api/usergroups/:usergroup_id/external_usergroups/:id","Refresh external user group":"/api/usergroups/:usergroup_id/external_usergroups/:id/refresh","Delete an external user group":"/api/usergroups/:usergroup_id/external_usergroups/:id"},"fact_values":{"List all fact values":"/api/fact_values"},"filters":{"List all filters":"/api/filters","Show a filter":"/api/filters/:id","Create a filter":"/api/filters","Update a filter":"/api/filters/:id","Delete a filter":"/api/filters/:id"},"home":{"Show available API links":"/api","Show status":"/api/status"},"host_classes":{"List all Puppet class IDs for host":"/api/hosts/:host_id/puppetclass_ids","Add a Puppet class to host":"/api/hosts/:host_id/puppetclass_ids","Remove a Puppet class from host":"/api/hosts/:host_id/puppetclass_ids/:id"},"hostgroup_classes":{"List all Puppet class IDs for host group":"/api/hostgroups/:hostgroup_id/puppetclass_ids","Add a Puppet class to host group":"/api/hostgroups/:hostgroup_id/puppetclass_ids","Remove a Puppet class from host group":"/api/hostgroups/:hostgroup_id/puppetclass_ids/:id"},"images":{"List all images for a compute resource":"/api/compute_resources/:compute_resource_id/images","Show an image":"/api/compute_resources/:compute_resource_id/images/:id","Create an image":"/api/compute_resources/:compute_resource_id/images","Update an image":"/api/compute_resources/:compute_resource_id/images/:id","Delete an image":"/api/compute_resources/:compute_resource_id/images/:id"},"locations":{"List all locations":"/api/locations","Show a location":"/api/locations/:id","Create a location":"/api/locations","Update a location":"/api/locations/:id","Delete a location":"/api/locations/:id"},"mail_notifications":{"List of email notifications":"/api/mail_notifications","Show an email notification":"/api/mail_notifications/:id"},"media":{"List all installation media":"/api/media","Show a medium":"/api/media/:id","Create a medium":"/api/media","Update a medium":"/api/media/:id","Delete a medium":"/api/media/:id"},"models":{"List all hardware models":"/api/models","Show a hardware model":"/api/models/:id","Create a hardware model":"/api/models","Update a hardware model":"/api/models/:id","Delete a hardware model":"/api/models/:id"},"operatingsystems":{"List all operating systems":"/api/operatingsystems","Show an operating system":"/api/operatingsystems/:id","Create an operating system":"/api/operatingsystems","Update an operating system":"/api/operatingsystems/:id","Delete an operating system":"/api/operatingsystems/:id","List boot files for an operating system":"/api/operatingsystems/:id/bootfiles"},"os_default_templates":{"List default templates combinations for an operating system":"/api/operatingsystems/:operatingsystem_id/os_default_templates","Show a default template combination for an operating system":"/api/operatingsystems/:operatingsystem_id/os_default_templates/:id","Create a default template combination for an operating system":"/api/operatingsystems/:operatingsystem_id/os_default_templates","Update a default template combination for an operating system":"/api/operatingsystems/:operatingsystem_id/os_default_templates/:id","Delete a default template combination for an operating system":"/api/operatingsystems/:operatingsystem_id/os_default_templates/:id"},"override_values":{"List of override values for a specific smart variable":"/api/smart_variables/:smart_variable_id/override_values","Show an override value for a specific smart variable":"/api/smart_variables/:smart_variable_id/override_values/:id","Create an override value for a specific smart variable":"/api/smart_variables/:smart_variable_id/override_values","Update an override value for a specific smart variable":"/api/smart_variables/:smart_variable_id/override_values/:id","Delete an override value for a specific smart variable":"/api/smart_variables/:smart_variable_id/override_values/:id"},"parameters":{"List all parameters for a host":"/api/hosts/:host_id/parameters","Show a nested parameter for a host":"/api/hosts/:host_id/parameters/:id","Create a nested parameter for a host":"/api/hosts/:host_id/parameters","Update a nested parameter for a host":"/api/hosts/:host_id/parameters/:id","Delete a nested parameter for a host":"/api/hosts/:host_id/parameters/:id","Delete all nested parameters for a host":"/api/hosts/:host_id/parameters"},"permissions":{"List all permissions":"/api/permissions","Show a permission":"/api/permissions/:id","List available resource types":"/api/permissions/resource_types"},"plugins":{"List installed plugins":"/api/plugins"},"provisioning_templates":{"List provisioning templates":"/api/provisioning_templates","Show provisioning template details":"/api/provisioning_templates/:id","Create a provisioning template":"/api/provisioning_templates","Update a provisioning template":"/api/provisioning_templates/:id","Delete a provisioning template":"/api/provisioning_templates/:id","Update the default PXE menu on all configured TFTP servers":"/api/provisioning_templates/build_pxe_default","Clone a provision template":"/api/provisioning_templates/:id/clone"},"ptables":{"List all partition tables":"/api/ptables","Show a partition table":"/api/ptables/:id","Create a partition table":"/api/ptables","Update a partition table":"/api/ptables/:id","Delete a partition table":"/api/ptables/:id","Clone a template":"/api/ptables/:id/clone"},"puppetclasses":{"List all Puppet classes":"/api/puppetclasses","Show a Puppet class":"/api/puppetclasses/:id","Create a Puppet class":"/api/puppetclasses","Update a Puppet class":"/api/puppetclasses/:id","Delete a Puppet class":"/api/puppetclasses/:id"},"realms":{"List of realms":"/api/realms","Show a realm":"/api/realms/:id","Create a realm":"/api/realms","Update a realm":"/api/realms/:id","Delete a realm":"/api/realms/:id"},"reports":{"List all reports":"/api/reports","Show a report":"/api/reports/:id","Create a report":"/api/reports","Delete a report":"/api/reports/:id","Show the last report for a host":"/api/hosts/:host_id/reports/last"},"roles":{"List all roles":"/api/roles","Show a role":"/api/roles/:id","Create a role":"/api/roles","Update a role":"/api/roles/:id","Delete a role":"/api/roles/:id"},"settings":{"List all settings":"/api/settings","Show a setting":"/api/settings/:id","Update a setting":"/api/settings/:id"},"smart_class_parameters":{"List all smart class parameters":"/api/smart_class_parameters","Show a smart class parameter":"/api/smart_class_parameters/:id","Update a smart class parameter":"/api/smart_class_parameters/:id"},"smart_variables":{"List all smart variables":"/api/smart_variables","Show a smart variable":"/api/smart_variables/:id","Create a smart variable":"/api/smart_variables","Update a smart variable":"/api/smart_variables/:id","Delete a smart variable":"/api/smart_variables/:id"},"statistics":{"Get statistics":"/api/statistics"},"subnets":{"List of subnets":"/api/subnets","Show a subnet":"/api/subnets/:id","Create a subnet":"/api/subnets","Update a subnet":"/api/subnets/:id","Delete a subnet":"/api/subnets/:id"},"tasks":{"List all tasks for a given orchestration event":"/api/orchestration/:id/tasks"},"template_combinations":{"List template combination":"/api/config_templates/:config_template_id/template_combinations","Add a template combination":"/api/config_templates/:config_template_id/template_combinations","Show template combination":"/api/template_combinations/:id","Update template combination":"/api/provisioning_templates/:provisioning_template_id/template_combinations/:id","Delete a template combination":"/api/template_combinations/:id"},"template_kinds":{"List all template kinds":"/api/template_kinds"},"usergroups":{"List all user groups":"/api/usergroups","Show a user group":"/api/usergroups/:id","Create a user group":"/api/usergroups","Update a user group":"/api/usergroups/:id","Delete a user group":"/api/usergroups/:id"},"users":{"List all users":"/api/users","Show a user":"/api/users/:id","Create a user":"/api/users","Update a user":"/api/users/:id","Delete a user":"/api/users/:id"}}}
2016-09-08 11:03:52 - robottelo - DEBUG - Finished Test: AvailableURLsTestCase/test_positive_get_status_code
.2016-09-08 11:03:52 - robottelo - DEBUG - Started tearDownClass: tests.foreman.endtoend.test_api_endtoend/AvailableURLsTestCase


 6 tests deselected by '-k AvailableURLsTestCase and test_positive_get_status_code' 
==================== 1 passed, 6 deselected in 2.17 seconds ====================

Process finished with exit code 0
```