### PR TITLE
replace raise_ctx with assertRaisesRegex in negative cli tests

### DIFF
--- a/tests/foreman/cli/test_subnet.py
+++ b/tests/foreman/cli/test_subnet.py
@@ -180,12 +180,11 @@ class SubnetTestCase(CLITestCase):
         """
         for options in invalid_missing_attributes():
             with self.subTest(options):
-                with self.assertRaises(CLIFactoryError) as raise_ctx:
-                    make_subnet(options)
-                self.assert_error_msg(
-                    raise_ctx,
+                with self.assertRaisesRegex(
+                    CLIFactoryError,
                     u'Could not create the subnet:'
-                )
+                ):
+                    make_subnet(options)
 
     @run_only_on('sat')
     @tier1
@@ -309,16 +308,15 @@ class SubnetTestCase(CLITestCase):
         for options in invalid_missing_attributes():
             with self.subTest(options):
                 options['id'] = subnet['id']
-                with self.assertRaises(CLIReturnCodeError) as raise_ctx:
+                with self.assertRaisesRegex(
+                    CLIReturnCodeError,
+                    u'Could not update the subnet:'
+                ):
                     Subnet.update(options)
                     # check - subnet is not updated
                     result = Subnet.info({u'id': subnet['id']})
                     for key in options.keys():
                         self.assertEqual(subnet[key], result[key])
-                self.assert_error_msg(
-                    raise_ctx,
-                    u'Could not update the subnet:'
-                )
 
     @run_only_on('sat')
     @tier1
@@ -336,12 +334,11 @@ class SubnetTestCase(CLITestCase):
                 # generate pool range from network address
                 for key, val in options.iteritems():
                     opts[key] = re.sub(r'\d+$', str(val), subnet['network'])
-                with self.assertRaises(CLIReturnCodeError) as raise_ctx:
-                    Subnet.update(opts)
-                self.assert_error_msg(
-                    raise_ctx,
+                with self.assertRaisesRegex(
+                    CLIReturnCodeError,
                     u'Could not update the subnet:'
-                )
+                ):
+                    Subnet.update(opts)
                 # check - subnet is not updated
                 result = Subnet.info({u'id': subnet['id']})
                 for key in options.keys():

--- a/tests/foreman/cli/test_syncplan.py
+++ b/tests/foreman/cli/test_syncplan.py
@@ -231,12 +231,11 @@ class SyncPlanTestCase(CLITestCase):
         """
         for name in invalid_values_list():
             with self.subTest(name):
-                with self.assertRaises(CLIFactoryError) as raise_ctx:
+                with self.assertRaisesRegex(
+                   CLIFactoryError,
+                   u'Could not create the sync plan:'
+                ):
                     self._make_sync_plan({u'name': name})
-                self.assert_error_msg(
-                    raise_ctx,
-                    u'Could not create the sync plan:'
-                )
 
     @tier1
     def test_positive_update_description(self):

--- a/tests/foreman/cli/test_user.py
+++ b/tests/foreman/cli/test_user.py
@@ -228,12 +228,11 @@ class UserTestCase(CLITestCase):
                     'password': gen_string('alpha'),
                 }
                 self.logger.debug(str(options))
-                with self.assertRaises(CLIReturnCodeError) as raise_ctx:
-                    User.create(options)
-                self.assert_error_msg(
-                    raise_ctx,
+                with self.assertRaisesRegex(
+                    CLIReturnCodeError,
                     u'Could not create the user:'
-                )
+                ):
+                    User.create(options)
 
     @tier1
     def test_negative_create_with_invalid_firstname(self):
@@ -253,12 +252,11 @@ class UserTestCase(CLITestCase):
                     'mail': 'root@localhost',
                     'password': gen_string('alpha'),
                 }
-                with self.assertRaises(CLIReturnCodeError) as raise_ctx:
-                    User.create(options)
-                self.assert_error_msg(
-                    raise_ctx,
+                with self.assertRaisesRegex(
+                    CLIReturnCodeError,
                     u'Could not create the user'
-                )
+                ):
+                    User.create(options)
 
     @tier1
     def test_negative_create_with_invalid_lastname(self):
@@ -278,12 +276,11 @@ class UserTestCase(CLITestCase):
                     'mail': 'root@localhost',
                     'password': gen_string('alpha'),
                 }
-                with self.assertRaises(CLIReturnCodeError) as raise_ctx:
-                    User.create(options)
-                self.assert_error_msg(
-                    raise_ctx,
+                with self.assertRaisesRegex(
+                    CLIReturnCodeError,
                     u'Could not create the user'
-                )
+                ):
+                    User.create(options)
 
     @tier1
     def test_negative_create_with_invalid_email(self):
@@ -303,12 +300,11 @@ class UserTestCase(CLITestCase):
                     'mail': email,
                     'password': gen_string('alpha'),
                 }
-                with self.assertRaises(CLIReturnCodeError) as raise_ctx:
-                    User.create(options)
-                self.assert_error_msg(
-                    raise_ctx,
+                with self.assertRaisesRegex(
+                    CLIReturnCodeError,
                     u'Could not create the user'
-                )
+                ):
+                    User.create(options)
 
     @skip_if_bug_open('bugzilla', 1204686)
     @tier1
@@ -321,7 +317,10 @@ class UserTestCase(CLITestCase):
 
         @BZ: 1204686
         """
-        with self.assertRaises(CLIReturnCodeError) as raise_ctx:
+        with self.assertRaisesRegex(
+            CLIReturnCodeError,
+            u'Could not create the user:'
+        ):
             User.create({
                 'auth-source-id': 1,
                 'firstname': gen_string('alpha'),
@@ -330,10 +329,6 @@ class UserTestCase(CLITestCase):
                 'mail': '',
                 'password': gen_string('alpha'),
             })
-        self.assert_error_msg(
-            raise_ctx,
-            u'Could not create the user:'
-        )
 
     @tier1
     def test_negative_create_with_blank_authorized_by(self):
@@ -343,16 +338,15 @@ class UserTestCase(CLITestCase):
 
         @Assert: User is not created. Appropriate error shown.
         """
-        with self.assertRaises(CLIReturnCodeError) as raise_ctx:
+        with self.assertRaisesRegex(
+            CLIReturnCodeError,
+            u'Could not create the user:'
+        ):
             User.create({
                 'auth-source-id': '',
                 'login': gen_string('alpha'),
                 'mail': 'root@localhost',
             })
-        self.assert_error_msg(
-            raise_ctx,
-            u'Could not create the user:'
-        )
 
     @tier1
     def test_negative_create_with_blank_authorized_by_full(self):
@@ -364,17 +358,16 @@ class UserTestCase(CLITestCase):
 
         @Assert: User is not created. Appropriate error shown.
         """
-        with self.assertRaises(CLIReturnCodeError) as raise_ctx:
+        with self.assertRaisesRegex(
+            CLIReturnCodeError,
+            u'Could not create the user:'
+        ):
             User.create({
                 'auth-source-id': '',
                 'login': gen_string('alpha'),
                 'mail': 'root@localhost',
                 'password': gen_string('alpha'),
             })
-        self.assert_error_msg(
-            raise_ctx,
-            u'Could not create the user:'
-        )
 
     @tier1
     def test_positive_update_to_non_admin(self):
@@ -446,12 +439,11 @@ class UserTestCase(CLITestCase):
 
         @Assert: User is not deleted
         """
-        with self.assertRaises(CLIReturnCodeError) as raise_ctx:
-            User.delete({'login': self.foreman_user})
-        self.assert_error_msg(
-            raise_ctx,
+        with self.assertRaisesRegex(
+            CLIReturnCodeError,
             u'Could not delete the user:'
-        )
+        ):
+            User.delete({'login': self.foreman_user})
         self.assertTrue(User.info({'login': self.foreman_user}))
 
     @tier1
@@ -846,12 +838,11 @@ class UserWithCleanUpTestCase(CLITestCase):
         for new_user_name in invalid_names_list():
             with self.subTest(new_user_name):
                 options = {'id': user['id'], 'login': new_user_name}
-                with self.assertRaises(CLIReturnCodeError) as raise_ctx:
-                    User.update(options)
-                self.assert_error_msg(
-                    raise_ctx,
+                with self.assertRaisesRegex(
+                    CLIReturnCodeError,
                     u'Could not update the user:'
-                )
+                ):
+                    User.update(options)
 
     @tier1
     def test_negative_update_firstname(self):
@@ -867,12 +858,11 @@ class UserWithCleanUpTestCase(CLITestCase):
                 options = {
                     'firstname': invalid_firstname, 'login': user['login'],
                 }
-                with self.assertRaises(CLIReturnCodeError) as raise_ctx:
-                    User.update(options)
-                self.assert_error_msg(
-                    raise_ctx,
+                with self.assertRaisesRegex(
+                    CLIReturnCodeError,
                     u'Could not update the user:'
-                )
+                ):
+                    User.update(options)
                 updated_user = User.info({'id': user['id']})
                 self.assertEqual(updated_user['name'], user['name'])
 
@@ -887,15 +877,14 @@ class UserWithCleanUpTestCase(CLITestCase):
         user = self.user
         for invalid_lastname in (gen_string('alpha', 51), gen_string('html')):
             with self.subTest(invalid_lastname):
-                with self.assertRaises(CLIReturnCodeError) as raise_ctx:
+                with self.assertRaisesRegex(
+                    CLIReturnCodeError,
+                    u'Could not update the user:'
+                ):
                     User.update({
                         'lastname': invalid_lastname,
                         'login': user['login']
                     })
-                self.assert_error_msg(
-                    raise_ctx,
-                    u'Could not update the user:'
-                )
 
     @tier1
     def test_negative_update_email(self):
@@ -908,15 +897,14 @@ class UserWithCleanUpTestCase(CLITestCase):
         user = self.user
         for email in invalid_emails_list():
             with self.subTest(email):
-                with self.assertRaises(CLIReturnCodeError) as raise_ctx:
+                with self.assertRaisesRegex(
+                    CLIReturnCodeError,
+                    u'Could not update the user:'
+                ):
                     User.update({
                         'login': user['login'],
                         'mail': email
                     })
-                self.assert_error_msg(
-                    raise_ctx,
-                    u'Could not update the user:'
-                )
 
     @skip_if_bug_open('bugzilla', 1138553)
     @tier2


### PR DESCRIPTION
Related to #3789
Test results for affected files:

```
py.test tests/foreman/cli/test_syncplan.py -k test_negative
======================================================== test session starts ========================================================
platform linux2 -- Python 2.7.11, pytest-3.0.1, py-1.4.31, pluggy-0.3.1
rootdir: /home/pondrejk/Documents/robottelo, inifile: 
plugins: cov-2.3.1, xdist-1.15.0
collected 15 items 

tests/foreman/cli/test_syncplan.py .s

======================================================== 13 tests deselected ========================================================
======================================== 1 passed, 1 skipped, 13 deselected in 62.29 seconds ========================================
```

```
py.test tests/foreman/cli/test_subnet.py -k test_negative
======================================================== test session starts ========================================================
platform linux2 -- Python 2.7.11, pytest-3.0.1, py-1.4.31, pluggy-0.3.1
rootdir: /home/pondrejk/Documents/robottelo, inifile: 
plugins: cov-2.3.1, xdist-1.15.0
collected 15 items 

tests/foreman/cli/test_subnet.py ....

======================================================== 11 tests deselected ========================================================
============================================= 4 passed, 11 deselected in 134.68 seconds =============================================
```

```
py.test tests/foreman/cli/test_user.py -k test_negative
======================================================= test session starts =======================================================
platform linux2 -- Python 2.7.11, pytest-3.0.1, py-1.4.31, pluggy-0.3.1
rootdir: /home/pondrejk/Documents/robottelo, inifile: 
plugins: cov-2.3.1, xdist-1.15.0
collected 49 items 

tests/foreman/cli/test_user.py ..s.........

======================================================= 37 tests deselected =======================================================
====================================== 11 passed, 1 skipped, 37 deselected in 427.56 seconds ======================================
```