### PR TITLE
[needs cherrypick to 6.2.2] updated hammer command tree

### DIFF
--- a/tests/foreman/data/hammer_commands.json
+++ b/tests/foreman/data/hammer_commands.json
@@ -6278,6 +6278,139 @@
       ],
       "subcommands": [
         {
+          "description": "import or export activation keys",
+          "name": "activation-keys",
+          "options": [
+            {
+              "help": "Continue processing even if individual resource error",
+              "name": "continue-on-error",
+              "value": null
+            },
+            {
+              "help": "Export one subscription per row, only process update subscriptions on import",
+              "name": "itemized-subscriptions",
+              "value": null
+            },
+            {
+              "help": "Only process organization matching this name",
+              "name": "organization",
+              "shortname": null,
+              "value": "ORGANIZATION"
+            },
+            {
+              "help": "Export current data instead of importing",
+              "name": "export",
+              "value": null
+            },
+            {
+              "help": "CSV file (default to /dev/stdout with --export, otherwise required)",
+              "name": "file",
+              "value": "FILE_NAME"
+            },
+            {
+              "help": "print help",
+              "name": "help",
+              "shortname": "h",
+              "value": null
+            },
+            {
+              "help": "be verbose",
+              "name": "verbose",
+              "shortname": "v",
+              "value": null
+            }
+          ],
+          "subcommands": []
+        },
+        {
+          "description": "import or export content hosts",
+          "name": "content-hosts",
+          "options": [
+            {
+              "help": "Continue processing even if individual resource error",
+              "name": "continue-on-error",
+              "value": null
+            },
+            {
+              "help": "Export one subscription per row, only process update subscriptions on import",
+              "name": "itemized-subscriptions",
+              "value": null
+            },
+            {
+              "help": "Only process organization matching this name",
+              "name": "organization",
+              "shortname": null,
+              "value": "ORGANIZATION"
+            },
+            {
+              "help": "Export current data instead of importing",
+              "name": "export",
+              "value": null
+            },
+            {
+              "help": "CSV file (default to /dev/stdout with --export, otherwise required)",
+              "name": "file",
+              "value": "FILE_NAME"
+            },
+            {
+              "help": "print help",
+              "name": "help",
+              "shortname": "h",
+              "value": null
+            },
+            {
+              "help": "be verbose",
+              "name": "verbose",
+              "shortname": "v",
+              "value": null
+            }
+          ],
+          "subcommands": []
+        },
+        {
+          "description": "import or export subscriptions",
+          "name": "subscriptions",
+          "options": [
+              {
+                "help": "Continue processing even if individual resource error",
+                "name": "continue-on-error",
+                "shortname": null,
+                "value": null
+              },
+              {
+                "help": "Export current data instead of importing",
+                "name": "export",
+                "shortname": null,
+                "value": null
+              },
+              {
+                "help": "CSV file (default to /dev/stdout with --export, otherwise required)",
+                "name": "file",
+                "shortname": null,
+                "value": "FILE_NAME"
+              },
+              {
+                "help": "Only process organization matching this name",
+                "name": "organization",
+                "shortname": null,
+                "value": "ORGANIZATION"
+              },
+              {
+                "help": "print help",
+                "name": "help",
+                "shortname": "h",
+                "value": null
+              },
+              {
+                "help": "be verbose",
+                "name": "verbose",
+                "shortname": "v",
+                "value": null
+              }
+            ],
+            "subcommands": []
+        },
+        {
           "description": "export into directory",
           "name": "export",
           "options": [
@@ -6355,6 +6488,11 @@
           "description": "import or export settings",
           "name": "settings",
           "options": [
+            {
+              "help": "Continue processing even if individual resource error",
+              "name": "continue-on-error",
+              "value": null
+            },
             {
               "help": "Export current data instead of importing",
               "name": "export",
@@ -11997,6 +12135,95 @@
             }
           ],
           "subcommands": [
+            {
+              "description": "Add a subscription to a host",
+              "name": "attach",
+              "options": [
+                {
+                  "help": "Name to search by",
+                  "name": "host",
+                  "value": "HOST_NAME"
+                },
+                {
+                  "help": null,
+                  "name": "host-id",
+                  "value": "HOST_ID"
+                },
+                {
+                  "help": "Quantity of this subscriptions to add. Defaults to 1",
+                  "name": "quantity",
+                  "value": "Quantity"
+                },
+                {
+                  "help": "ID of subscription",
+                  "name": "subscription-id",
+                  "value": "SUBSCRIPTION_ID"
+                },
+                {
+                  "help": "print help",
+                  "name": "help",
+                  "shortname": "h",
+                  "value": null
+                }
+              ],
+              "subcommands": []
+            },
+            {
+              "description": "Trigger an auto-attach of subscriptions",
+              "name": "auto-attach",
+              "options": [
+                {
+                  "help": "Name to search by",
+                  "name": "host",
+                  "value": "HOST_NAME"
+                },
+                {
+                  "help": null,
+                  "name": "host-id",
+                  "value": "HOST_ID"
+                },
+                {
+                  "help": "print help",
+                  "name": "help",
+                  "shortname": "h",
+                  "value": null
+                }
+              ],
+              "subcommands": []
+            },
+            {
+              "description": null,
+              "name": "remove",
+              "options": [
+                {
+                  "help": "Name to search by",
+                  "name": "host",
+                  "value": "HOST_NAME"
+                },
+                {
+                  "help": null,
+                  "name": "host-id",
+                  "value": "HOST_ID"
+                },
+                {
+                  "help": "Quantity of this subscriptions to add. Defaults to 1",
+                  "name": "quantity",
+                  "value": "Quantity"
+                },
+                {
+                  "help": "ID of subscription",
+                  "name": "subscription-id",
+                  "value": "SUBSCRIPTION_ID"
+                },
+                {
+                  "help": "print help",
+                  "name": "help",
+                  "shortname": "h",
+                  "value": null
+                }
+              ],
+              "subcommands": []
+            },
             {
               "description": "Register a host with subscription and information.",
               "name": "register",
@@ -27554,6 +27781,12 @@
           "name": "create",
           "options": [
             {
+              "help": "is an admin user group\nOne of true/false, yes/no, 1/0.",
+              "name": "admin",
+              "shortname": null,
+              "value": "ADMIN"
+            },
+            {
               "help": "",
               "name": "name",
               "shortname": null,
@@ -28042,6 +28275,12 @@
           "description": "Update a user group",
           "name": "update",
           "options": [
+            {
+              "help": "is an admin user group\nOne of true/false, yes/no, 1/0.",
+              "name": "admin",
+              "shortname": null,
+              "value": "ADMIN"
+            },
             {
               "help": "",
               "name": "id",


### PR DESCRIPTION
tested on `6.2.2`
```
+ /home/jenkins/shiningpanda/jobs/ad0ef6b5/virtualenvs/d41d8cd9/bin/py.test -v --junit-xml=foreman-results.xml -m 'not stubbed' tests/foreman/cli/test_hammer.py -k test_positive_all_options
============================= test session starts ==============================
platform linux2 -- Python 2.7.10, pytest-3.0.2, py-1.4.31, pluggy-0.3.1 -- /home/jenkins/shiningpanda/jobs/ad0ef6b5/virtualenvs/d41d8cd9/bin/python2.7
cachedir: .cache
rootdir: /home/jenkins/workspace/satellite6-standalone-automation, inifile: 
plugins: xdist-1.15.0
collecting ... collected 1 items

tests/foreman/cli/test_hammer.py::HammerCommandsTestCase::test_positive_all_options PASSED

 generated xml file: /home/jenkins/workspace/satellite6-standalone-automation/foreman-results.xml 
========================= 1 passed in 1341.64 seconds ==========================
+ exit 0
Deleting 2 temporary files
Recording test results

Started calculate disk usage of build
Finished Calculation of disk usage of build in 0 seconds
Started calculate disk usage of workspace
Finished Calculation of disk usage of workspace in 0 seconds
Finished: SUCCESS

```