### PR TITLE
Add tests for hammer puppet-class, fixes #1028

### DIFF
--- a/docs/api/tests.foreman.cli.rst
+++ b/docs/api/tests.foreman.cli.rst
@@ -173,6 +173,11 @@
 
 .. automodule:: tests.foreman.cli.test_product
 
+:mod:`tests.foreman.cli.test_puppetclass`
+------------------------------------------
+
+.. automodule:: tests.foreman.cli.test_puppetclass
+
 :mod:`tests.foreman.cli.test_puppetmodule`
 ------------------------------------------
 

--- a/robottelo/cli/puppet.py
+++ b/robottelo/cli/puppet.py
@@ -13,7 +13,8 @@ Subcommands::
 
     info                          Show a puppetclass
     list                          List all puppetclasses.
-    sc_params                     List all smart class parameters
+    sc-params                     List all smart class parameters
+    smart-variables               List all smart variables
 """
 
 from robottelo.cli.base import Base
@@ -25,3 +26,37 @@ class Puppet(Base):
     """
 
     command_base = 'puppet-class'
+
+    @classmethod
+    def sc_params(cls, options=None):
+        """
+        Usage:
+            hammer puppet-class sc-params [OPTIONS]
+
+        Options:
+             --order ORDER                      sort results
+             --page PAGE                        paginate results
+             --per-page PER_PAGE                number of entries per request
+             --puppet-class PUPPET_CLASS_NAME   Puppet class name
+             --puppet-class-id PUPPET_CLASS_ID  ID of Puppet class
+             --search SEARCH                    filter results
+        """
+        cls.command_sub = 'sc-params'
+        return cls.execute(cls._construct_command(options))
+
+    @classmethod
+    def smart_variables(cls, options=None):
+        """
+        Usage:
+            hammer puppet-class smart-variables [OPTIONS]
+
+        Options:
+             --order ORDER                      sort results
+             --page PAGE                        paginate results
+             --per-page PER_PAGE                number of entries per request
+             --puppet-class PUPPET_CLASS_NAME   Puppet class name
+             --puppet-class-id PUPPET_CLASS_ID  ID of Puppet class
+             --search SEARCH                    filter results
+         """
+        cls.command_sub = 'smart-variables'
+        return cls.execute(cls._construct_command(options))

--- a/tests/foreman/cli/test_puppetclass.py
+++ b/tests/foreman/cli/test_puppetclass.py
@@ -1,0 +1,74 @@
+# -*- encoding: utf-8 -*-
+"""Test class for Puppet Classes CLI
+
+@Requirement: Puppetclass
+
+@CaseAutomation: Automated
+
+@CaseLevel: Acceptance
+
+@CaseComponent: CLI
+
+@TestType: Functional
+
+@CaseImportance: High
+
+@Upstream: No
+"""
+
+from robottelo import ssh
+from robottelo.cli.environment import Environment
+from robottelo.cli.factory import make_smart_variable
+from robottelo.cli.proxy import Proxy
+from robottelo.cli.puppet import Puppet
+from robottelo.config import settings
+from robottelo.decorators import (
+    tier2,
+    run_only_on
+)
+from robottelo.test import CLITestCase
+
+
+class PuppetClassTestCase(CLITestCase):
+    """Implements puppet class tests in CLI."""
+
+    @classmethod
+    def setUpClass(cls):
+        """Import a parametrized puppet class.
+        """
+        super(PuppetClassTestCase, cls).setUpClass()
+        cls.host_name = settings.server.hostname
+        ssh.command('puppet module install --force puppetlabs/ntp')
+        cls.env = Environment.info({u'name': 'production'})
+        Proxy.importclasses({
+            u'environment': cls.env['name'],
+            u'name': cls.host_name,
+        })
+        cls.puppet = Puppet.info({u'name': 'ntp'})
+
+    @run_only_on('sat')
+    @tier2
+    def test_positive_list_smart_class_parameters(self):
+        """List smart class parameters associated with the puppet class.
+
+        @id: 56b370c2-8fc6-49be-9676-242178cc709a
+
+        @assert: Smart class parameters listed for the class.
+        """
+        class_sc_parameters = Puppet.sc_params({
+            u'puppet-class': self.puppet['name']})
+        self.assertGreater(len(class_sc_parameters), 0)
+
+    @run_only_on('sat')
+    @tier2
+    def test_positive_list_smart_variables(self):
+        """List smart variables associated with the puppet class.
+
+        @id: cb2b41c0-29cc-4c0b-a7c8-38403d6dda5b
+
+        @assert: Smart variables listed for the class.
+        """
+        make_smart_variable({'puppet-class': self.puppet['name']})
+        class_smart_variables = Puppet.smart_variables({
+            u'puppet-class': self.puppet['name']})
+        self.assertGreater(len(class_smart_variables), 0)


### PR DESCRIPTION
Adding tests for `hammer puppet-class sc-params` and `hammer puppet-class smart-variables`. Test results:

```
nosetests -v tests/foreman/cli/test_puppetclass.py:PuppetClassTestCase
List smart class parameters associated with the puppet class. ... ok
List smart variables associated with the puppet class. ... ok

----------------------------------------------------------------------
Ran 2 tests in 31.175s

OK
```