### PR TITLE
Add full coverage for smart variables in UI

### DIFF
--- a/docs/api/robottelo.ui.rst
+++ b/docs/api/robottelo.ui.rst
@@ -198,6 +198,11 @@
 
 .. automodule:: robottelo.ui.settings
 
+:mod:`robottelo.ui.smart_variable`
+----------------------------------
+
+.. automodule:: robottelo.ui.smart_variable
+
 :mod:`robottelo.ui.subnet`
 --------------------------
 

--- a/robottelo/test.py
+++ b/robottelo/test.py
@@ -83,6 +83,7 @@ from robottelo.ui.repository import Repos
 from robottelo.ui.rhai import RHAI
 from robottelo.ui.role import Role
 from robottelo.ui.settings import Settings
+from robottelo.ui.smart_variable import SmartVariable
 from robottelo.ui.subnet import Subnet
 from robottelo.ui.subscription import Subscriptions
 from robottelo.ui.sync import Sync
@@ -320,6 +321,7 @@ class UITestCase(TestCase):
         self.rhai = RHAI(self.browser)
         self.role = Role(self.browser)
         self.settings = Settings(self.browser)
+        self.smart_variable = SmartVariable(self.browser)
         self.subnet = Subnet(self.browser)
         self.subscriptions = Subscriptions(self.browser)
         self.sync = Sync(self.browser)

--- a/robottelo/ui/factory.py
+++ b/robottelo/ui/factory.py
@@ -34,6 +34,7 @@ from robottelo.ui.registry import Registry
 from robottelo.ui.repository import Repos
 from robottelo.ui.role import Role
 from robottelo.ui.settings import Settings
+from robottelo.ui.smart_variable import SmartVariable
 from robottelo.ui.subnet import Subnet
 from robottelo.ui.syncplan import Syncplan
 from robottelo.ui.template import Template
@@ -740,3 +741,29 @@ def make_host_collection(
     core_factory(create_args, kwargs, session, page,
                  org=org, loc=loc, force_context=force_context)
     HostCollection(session.browser).create(**create_args)
+
+
+def make_smart_variable(
+        session, org=None, loc=None, force_context=True, **kwargs):
+    """Creates Smart Variable"""
+    create_args = {
+        u'name': gen_string('alpha'),
+        u'puppet_class': None,
+        u'description': None,
+        u'key_type': None,
+        u'default_value': None,
+        u'hidden_value': False,
+        u'validator_type': None,
+        u'validator_rule': None,
+        u'matcher': None,
+        u'matcher_priority': None,
+        u'matcher_merge_overrides': None,
+        u'matcher_merge_default': None,
+        u'matcher_merge_avoid': None,
+    }
+    page = session.nav.go_to_puppet_classes
+    core_factory(create_args, kwargs, session, page,
+                 org=org, loc=loc, force_context=force_context)
+    PuppetClasses(session.browser).click(
+        PuppetClasses(session.browser).search(kwargs['puppet_class']))
+    SmartVariable(session.browser).create(**create_args)

--- a/robottelo/ui/hosts.py
+++ b/robottelo/ui/hosts.py
@@ -195,3 +195,57 @@ class Hosts(Base):
                         parameter['command']
                     )
                     self.click(common_locators['submit'])
+
+    def get_yaml_output(self, name):
+        """Return YAML output for specific host
+
+        :param str name: Name of Host to read information from
+        """
+        self.click(self.search(name))
+        self.click(locators['host.yaml_button'])
+        output = self.wait_until_element(locators['host.yaml_output']).text
+        self.browser.back()
+        self.wait_for_ajax()
+        return output
+
+    def get_smart_variable_value(self, host_name, sv_name, hidden=False):
+        """Return smart variable value element for specific host
+
+        :param str host_name: Name of Host to get smart variable information
+            from
+        :param str sv_name: Name of Smart Variable to be read
+        :param bool hidden: Specify whether it is expected that read value is
+            hidden on UI or not
+        """
+        self.click(self.search(host_name))
+        self.click(locators['host.edit'])
+        self.click(tab_locators['host.tab_params'])
+        if hidden:
+            locator = locators['host.smart_variable_value_hidden'] % sv_name
+        else:
+            locator = locators['host.smart_variable_value'] % sv_name
+        return self.wait_until_element(locator)
+
+    def set_smart_variable_value(self, host_name, sv_name, sv_value,
+                                 override=True, hidden=False):
+        """Set smart variable value for specific host
+
+        :param str host_name: Name of Host where smart variable value should be
+            modified
+        :param str sv_name: Name of Smart Variable to be modified
+        :param bool override: Specify whether it is expected to override smart
+            value or just edit its value
+        :param bool hidden: Specify whether it is expected that smart variable
+            value is hidden on UI or not
+        """
+        self.click(self.search(host_name))
+        self.click(locators['host.edit'])
+        self.click(tab_locators['host.tab_params'])
+        if override:
+            self.click(locators['host.smart_variable_override'] % sv_name)
+        if hidden:
+            locator = locators['host.smart_variable_value_hidden'] % sv_name
+        else:
+            locator = locators['host.smart_variable_value'] % sv_name
+        self.assign_value(locator, sv_value)
+        self.click(common_locators['submit'])

--- a/robottelo/ui/locators/base.py
+++ b/robottelo/ui/locators/base.py
@@ -480,6 +480,9 @@ locators = LocatorDict({
         By.XPATH,
         ("//input[contains(@id,'host_ids')]"
          "/../../td[@class='ellipsis']/a[contains(@href,'%s')]")),
+    "host.yaml_button": (By.XPATH, "//a[text()='YAML' and "
+                                   "contains(@class, 'btn')]"),
+    "host.yaml_output": (By.XPATH, "//pre"),
     "host.name": (By.ID, "host_name"),
     "host.organization": (
         By.XPATH,
@@ -627,6 +630,27 @@ locators = LocatorDict({
         By.XPATH,
         "(//textarea[contains(@id, '_value') "
         "and contains(@name, 'parameters')])[%i]"),
+    "host.smart_variable_value": (
+        By.XPATH, "//textarea[ancestor::tr//td[contains(., '%s')]]"),
+    "host.smart_variable_value_hidden": (
+        By.XPATH, "//input[ancestor::tr//td[contains(., '%s')]]"),
+    "host.smart_variable_override": (
+        By.XPATH,
+        "//a[ancestor::tr//td[contains(., '%s')] and @data-tag='override']"
+    ),
+    "host.smart_variable_unhide": (
+        By.XPATH,
+        "//a[ancestor::tr//td[contains(., '%s')] and "
+        "@data-original-title='Unhide this value']"
+    ),
+    "host.smart_variable_hide": (
+        By.XPATH,
+        "//a[ancestor::tr//td[contains(., '%s')] and "
+        "@data-original-title='Hide this value']"
+    ),
+    "host.smart_variable_puppet_class": (
+        By.XPATH, "//td[contains(., '%s')]//ancestor::tbody/tr[1]/td[1]"),
+    "host.override_error": (By.XPATH, "//td[@class='has-error']"),
 
     # host.vm (NOTE:- visible only when selecting a compute resource)
     "host.cpus": (
@@ -2223,4 +2247,101 @@ locators = LocatorDict({
         ("//a[contains(@href, 'repositories') and contains(., '%s')]"
          "[../following-sibling::td/a[contains(@ui-sref, 'products.details') "
          "and contains(., '%s')]]")),
+
+    # Smart Variable
+    "smart_variable.new": (By.XPATH, "//a[contains(., '+ Add Variable')]"),
+    "smart_variable.select_name": (By.XPATH, "//a[contains(., '%s')]"),
+    "smart_variable.key": (
+        By.XPATH,
+        "//input[(ancestor::div[@class='tab-pane fields active'] or "
+        "contains(@id, 'variable_')) and contains(@name, '[key]')]"),
+    "smart_variable.description": (
+        By.XPATH,
+        "//textarea[(ancestor::div[@class='tab-pane fields active'] or "
+        "contains(@id, 'variable_')) and contains(@name, '[description]')]"),
+    "smart_variable.puppet_class": (
+        By.XPATH,
+        "//div[(ancestor::div[@class='tab-pane fields active'] or "
+        "contains(@id, 'variable_')) and contains(@id, 'puppetclass')]/a"
+        "/span[contains(@class, 'arrow')]"),
+    "smart_variable.key_type": (
+        By.XPATH,
+        "//select[(ancestor::div[@class='tab-pane fields active'] or "
+        "contains(@id, 'variable_')) and contains(@name, '[key_type]')]"),
+    "smart_variable.default_value": (
+        By.XPATH,
+        "//textarea[(ancestor::div[@class='tab-pane fields active'] or "
+        "contains(@id, 'variable_')) and contains(@name, '[default_value]')]"),
+    "smart_variable.default_value_hidden": (
+        By.XPATH,
+        "//input[(ancestor::div[@class='tab-pane fields active'] or "
+        "contains(@id, 'variable_')) and contains(@name, '[default_value]')]"),
+    "smart_variable.hidden_value": (
+        By.XPATH,
+        "//input[(ancestor::div[@class='tab-pane fields active'] or "
+        "contains(@id, 'variable_')) and contains(@id, 'hidden_value')]"),
+    "smart_variable.optional_expander": (
+        By.XPATH,
+        "//h2[(ancestor::div[@class='tab-pane fields active'] or "
+        "ancestor::form[contains(@id, 'edit_variable')]) and "
+        "contains(@data-target, 'input_validators')]"),
+    "smart_variable.validator_type": (
+        By.XPATH,
+        "//select[(ancestor::div[@class='tab-pane fields active'] or "
+        "contains(@id, 'variable_')) and contains(@name, '[validator_type]')]"
+    ),
+    "smart_variable.validator_rule": (
+        By.XPATH,
+        "//input[(ancestor::div[@class='tab-pane fields active'] or "
+        "contains(@id, 'variable_')) and contains(@name, '[validator_rule]')]"
+    ),
+    "smart_variable.matcher_priority": (
+        By.XPATH,
+        "//textarea[(ancestor::div[@class='tab-pane fields active'] or "
+        "contains(@name, 'variable_')) and contains(@name, '[path]')]"
+    ),
+    "smart_variable.merge_overrides": (
+        By.XPATH,
+        "//input[(ancestor::div[@class='tab-pane fields active'] or "
+        "contains(@id, 'variable_')) and contains(@id, 'merge_override')]"),
+    "smart_variable.merge_default": (
+        By.XPATH,
+        "//input[(ancestor::div[@class='tab-pane fields active'] or "
+        "contains(@id, 'variable_')) and contains(@id, 'merge_default')]"),
+    "smart_variable.avoid_duplicates": (
+        By.XPATH,
+        "//input[(ancestor::div[@class='tab-pane fields active'] or "
+        "contains(@id, 'variable_')) and contains(@id, 'avoid_duplicates')]"),
+    "smart_variable.add_matcher": (
+        By.XPATH,
+        "//a[(ancestor::div[@class='tab-pane fields active'] or "
+        "ancestor::form[contains(@id, 'edit_variable')]) and "
+        "contains(@data-original-title, 'new matcher')]"
+    ),
+    "smart_variable.matcher_attribute_type": (
+        By.XPATH,
+        "(//select[(ancestor::div[@class='tab-pane fields active'] or "
+        "ancestor::form[contains(@id, 'edit_variable')]) and "
+        "contains(@class, 'matcher_key')])[%i]"
+    ),
+    "smart_variable.matcher_attribute_value": (
+        By.XPATH,
+        "(//input[(ancestor::div[@class='tab-pane fields active'] or "
+        "ancestor::form[contains(@id, 'edit_variable')]) and "
+        "contains(@class, 'matcher_value')])[%i]"
+    ),
+    "smart_variable.matcher_value": (
+        By.XPATH,
+        "(//textarea[(ancestor::div[@class='tab-pane fields active'] or "
+        "contains(@id, 'variable_')) and contains(@name, '[value]')])[%i]"
+    ),
+    "smart_variable.matcher_value_hidden": (
+        By.XPATH,
+        "(//input[(ancestor::div[@class='tab-pane fields active'] or "
+        "contains(@id, 'variable_')) and contains(@name, '[value]')])[%i]"
+    ),
+    "smart_variable.matcher_error": (By.XPATH, "//tr[@class='has-error']"),
+    "smart_variable.delete": (
+        By.XPATH, "//a[@class='delete' and contains(@data-confirm, '%s')]"),
+    "smart_variable.table_value": (By.XPATH, "//td[contains(., '%s')]"),
 })

--- a/robottelo/ui/locators/menu.py
+++ b/robottelo/ui/locators/menu.py
@@ -5,10 +5,8 @@ from selenium.webdriver.common.by import By
 from .model import LocatorDict
 
 NAVBAR_PATH = (
-    '//div[contains(@class,"navbar") '
-    'and contains(@class,"persist-header") and '
-    'not(contains(@style, "display: none")) and '
-    'not(contains(@style, "display:none"))]'
+    '//div[contains(@class,"navbar-inner") and '
+    'not(contains(@style, "display"))]'
 )
 
 MENU_CONTAINER_PATH = NAVBAR_PATH + '//ul[@id="menu"]'
@@ -177,7 +175,7 @@ menu_locators = LocatorDict({
         (MENU_CONTAINER_PATH + "//a[@id='menu_item_puppetclasses']")),
     "menu.smart_variables": (
         By.XPATH,
-        (MENU_CONTAINER_PATH + "//a[@id='menu_item_lookup_keys']")),
+        (MENU_CONTAINER_PATH + "//a[@id='menu_item_variable_lookup_keys']")),
     "menu.configure_groups": (
         By.XPATH,
         (MENU_CONTAINER_PATH + "//a[@id='menu_item_config_groups']")),

--- a/robottelo/ui/locators/tab.py
+++ b/robottelo/ui/locators/tab.py
@@ -328,4 +328,12 @@ tab_locators = LocatorDict({
         By.XPATH, "//a[@data-toggle='tab' and contains(@href, 'vms')]"),
     "resource.tab_virtual_machines": (By.XPATH, "//a[contains(@href, 'vms')]"),
     "resource.tab_images": (By.XPATH, "//a[.='Images']"),
+
+    # Puppet Class
+    "puppet_class.tab_smart_parameter": (
+        By.XPATH,
+        "//a[@data-toggle='tab' and contains(@href, 'smart_class_param')]"),
+    "puppet_class.tab_smart_variable": (
+        By.XPATH,
+        "//a[@data-toggle='tab' and contains(@href, 'smart_vars')]"),
 })

--- a/robottelo/ui/smart_variable.py
+++ b/robottelo/ui/smart_variable.py
@@ -1,0 +1,183 @@
+# -*- encoding: utf-8 -*-
+"""Implements Smart Variables UI"""
+
+from robottelo.ui.base import Base, UIError
+from robottelo.ui.locators import common_locators, locators, tab_locators
+from robottelo.ui.navigator import Navigator
+
+
+class SmartVariable(Base):
+    """Manipulates Smart Variables from UI"""
+
+    search_key = 'key'
+
+    def navigate_to_entity(self):
+        """Navigate to Smart Variable entity page"""
+        Navigator(self.browser).go_to_smart_variables()
+
+    def _search_locator(self):
+        """Specify locator for Smart Variable entity search procedure"""
+        return locators['smart_variable.select_name']
+
+    def _configure_variable(self, puppet_class=None, description=None,
+                            key_type=None, default_value=None,
+                            hidden_value=False, validator_type=None,
+                            validator_rule=None, matcher=None,
+                            matcher_priority=None,
+                            matcher_merge_overrides=None,
+                            matcher_merge_default=None,
+                            matcher_merge_avoid=None):
+        """Configuring Smart Variable parameters"""
+        if puppet_class:
+            self.assign_value(
+                locators['smart_variable.puppet_class'], puppet_class)
+        if description:
+            self.assign_value(
+                locators['smart_variable.description'], description)
+        if key_type:
+            self.assign_value(
+                locators['smart_variable.key_type'], key_type)
+        if default_value:
+            self.assign_value(
+                locators['smart_variable.default_value'], default_value)
+        if validator_type or validator_rule:
+            self.click(locators['smart_variable.optional_expander'])
+            if validator_type:
+                self.assign_value(
+                    locators['smart_variable.validator_type'], validator_type)
+            if validator_rule:
+                self.assign_value(
+                    locators['smart_variable.validator_rule'], validator_rule)
+        if matcher_priority:
+            self.assign_value(
+                locators['smart_variable.matcher_priority'], matcher_priority)
+        if matcher_merge_overrides is not None:
+            self.assign_value(
+                locators['smart_variable.merge_overrides'],
+                matcher_merge_overrides
+            )
+        if matcher_merge_default is not None:
+            self.assign_value(
+                locators['smart_variable.merge_default'],
+                matcher_merge_default
+            )
+        if matcher_merge_avoid is not None:
+            self.assign_value(
+                locators['smart_variable.avoid_duplicates'],
+                matcher_merge_avoid
+            )
+        if matcher:
+            self.add_matcher(matcher)
+        if hidden_value is not None:
+            self.assign_value(
+                locators['smart_variable.hidden_value'], hidden_value)
+
+    def create(self, name, puppet_class=None, description=None, key_type=None,
+               default_value=None, hidden_value=False, validator_type=None,
+               validator_rule=None, matcher=None, matcher_priority=None,
+               matcher_merge_overrides=None, matcher_merge_default=None,
+               matcher_merge_avoid=None):
+        """Creates new Smart Variable from UI"""
+        self.click(tab_locators['puppet_class.tab_smart_variable'])
+        self.click(locators['smart_variable.new'])
+        self.assign_value(locators['smart_variable.key'], name)
+        self._configure_variable(
+            description=description, key_type=key_type,
+            default_value=default_value, hidden_value=hidden_value,
+            validator_type=validator_type, validator_rule=validator_rule,
+            matcher=matcher, matcher_priority=matcher_priority,
+            matcher_merge_overrides=matcher_merge_overrides,
+            matcher_merge_default=matcher_merge_default,
+            matcher_merge_avoid=matcher_merge_avoid,
+        )
+        self.click(common_locators['submit'])
+
+    def update(self, name, new_name=None, puppet_class=None, description=None,
+               key_type=None, default_value=None, hidden_value=False,
+               validator_type=None, validator_rule=None, matcher=None,
+               matcher_priority=None, matcher_merge_overrides=None,
+               matcher_merge_default=None, matcher_merge_avoid=None):
+        """Updates existing Smart Variable from UI"""
+        self.click(self.search(name))
+        if new_name:
+            self.assign_value(locators['smart_variable.key'], new_name)
+        self._configure_variable(
+            description=description, key_type=key_type,
+            puppet_class=puppet_class, default_value=default_value,
+            hidden_value=hidden_value, validator_type=validator_type,
+            validator_rule=validator_rule, matcher_priority=matcher_priority,
+            matcher=matcher, matcher_merge_overrides=matcher_merge_overrides,
+            matcher_merge_default=matcher_merge_default,
+            matcher_merge_avoid=matcher_merge_avoid,
+        )
+        self.click(common_locators['submit'])
+
+    def delete(self, name, really=True):
+        """Deletes smart variable from UI"""
+        self.delete_entity(
+            name,
+            really,
+            locators['smart_variable.delete'],
+        )
+
+    def validate_smart_variable(self, name, field_name, field_value):
+        """Checks if selected smart variable has necessary field value on the
+        index pages
+
+        :param str name: Name of Smart Variable to be validated
+        :param str field_name: Smart Variable field that should be validated
+            (e.g. 'puppet_class' or 'overrides_number')
+        :param str field_value: Expected value for specified field
+        """
+        self.search(name)
+        searched = self.wait_until_element(
+            locators['smart_variable.table_value'] % field_value)
+        if searched is None:
+            raise UIError(
+                'Smart Variable "{0}" field in the table has not "{1}" value.'
+                .format(field_name, field_value)
+            )
+        else:
+            return True
+
+    def add_matcher(self, matcher_list):
+        """Adding new matcher to Smart Variable
+
+        :param matcher_list: List of matchers to be added to smart
+            variable. Each element is a dictionary of next format:
+            {
+            'matcher_attribute': 'attr_type=attr_value',
+            'matcher_value': 'value'
+            }
+
+        """
+        for i, matcher in enumerate(matcher_list, start=1):
+            self.click(locators['smart_variable.add_matcher'])
+            matcher_attribute = matcher['matcher_attribute'].split('=')
+            self.assign_value(
+                locators['smart_variable.matcher_attribute_type'] % i,
+                matcher_attribute[0]
+            )
+            self.assign_value(
+                locators['smart_variable.matcher_attribute_value'] % i,
+                matcher_attribute[1]
+            )
+            self.assign_value(
+                locators['smart_variable.matcher_value'] % i,
+                matcher['matcher_value']
+            )
+
+    def validate_checkbox(self, sv_name, checkbox_name):
+        """Checks if specific smart variable checkbox is enabled or not
+
+        :param str sv_name: Name of Smart Variable to be validated
+        :param str checkbox_name: Name of Smart Variable check box that will be
+            validated whether it is enabled or not (e.g. 'Merge overrides',
+            'Merge default' or 'Avoid duplicates')
+        :return bool: Return True if checkbox can be clicked and False
+            otherwise
+        """
+        self.click(self.search(sv_name))
+        locator_name = '.'.join((
+            'smart_variable', (checkbox_name.lower()).replace(' ', '_')))
+        return self.is_element_enabled(locators[locator_name])

--- a/tests/foreman/api/test_classparameters.py
+++ b/tests/foreman/api/test_classparameters.py
@@ -138,6 +138,12 @@ class SmartClassParametersTestCase(APITestCase):
             raise RuntimeError('There are not enough smart class parameters to'
                                ' work with in provided puppet class')
 
+    @classmethod
+    def tearDownClass(cls):
+        super(SmartClassParametersTestCase, cls).tearDownClass()
+        ssh.command('puppet module uninstall --force puppetlabs/ntp')
+        cls.proxy.import_puppetclasses(environment=cls.env)
+
     @run_only_on('sat')
     @tier2
     def test_positive_list_parameters_by_host_id(self):
@@ -1554,9 +1560,3 @@ class SmartClassParametersTestCase(APITestCase):
         sc_param = sc_param.read()
         self.assertEqual(getattr(sc_param, 'hidden_value?'), True)
         self.assertFalse(sc_param.default_value)
-
-    @classmethod
-    def tearDownClass(cls):
-        super(SmartClassParametersTestCase, cls).tearDownClass()
-        ssh.command('puppet module uninstall --force puppetlabs/ntp')
-        cls.proxy.import_puppetclasses(environment=cls.env)


### PR DESCRIPTION
Behold the might of <del>Stormwind</del> <del>Orgrimmar</del>ughm... of smart variables for UI :)

Latest Downstream(6.2.x):
```
nosetests tests/foreman/ui/test_variables.py
............................................
----------------------------------------------------------------------
Ran 44 tests in 2576.700s

OK
```
Latest Upstream:
65% of pass rate. It is really hard to determine whether style used in the application is the one that will be used for 'black' edition or it is specific of 'blue' edition. + It is really hard to work further with such huge bunch of code. Let's merge it and I will work on fixing right away. Functionality will be the same, some changes to elements will be required only.

