### PR TITLE
added crud tests for hammer job-template

### DIFF
--- a/docs/api/tests.foreman.cli.rst
+++ b/docs/api/tests.foreman.cli.rst
@@ -178,6 +178,11 @@
 
 .. automodule:: tests.foreman.cli.test_puppetmodule
 
+:mod:`tests.foreman.cli.test_remoteexecution`
+---------------------------------------------
+
+.. automodule:: tests.foreman.cli.test_remoteexecution
+
 :mod:`tests.foreman.cli.test_report`
 ------------------------------------
 

--- a/robottelo/cli/factory.py
+++ b/robottelo/cli/factory.py
@@ -33,6 +33,7 @@ from robottelo.cli.gpgkey import GPGKey
 from robottelo.cli.host import Host
 from robottelo.cli.hostcollection import HostCollection
 from robottelo.cli.hostgroup import HostGroup
+from robottelo.cli.job_template import JobTemplate
 from robottelo.cli.lifecycleenvironment import LifecycleEnvironment
 from robottelo.cli.location import Location
 from robottelo.cli.medium import Medium
@@ -1144,6 +1145,61 @@ def make_host_collection(options=None):
     }
 
     return create_object(HostCollection, args, options)
+
+
+@cacheable
+def make_job_template(options=None):
+    """
+    Usage::
+
+        hammer job-template create
+
+    Options::
+
+       --audit-comment AUDIT_COMMENT
+       --current-user CURRENT_USER              Whether the current user login
+                                                should be used as the effective
+                                                user.
+       --description-format DESCRIPTION_FORMAT  This template is used to
+                                                generate the description.
+       --file TEMPLATE                          Path to a file that contains
+                                                the template.
+       --job-category JOB_CATEGORY              Job category.
+       --location-ids LOCATION_IDS              Comma separated list of values.
+       --locations LOCATION_NAMES               Comma separated list of values.
+       --locked LOCKED                          Whether or not the template is
+                                                locked for editing.
+       --name NAME                              Template name
+       --organization-ids ORGANIZATION_IDS      Comma separated list of values.
+       --organizations ORGANIZATION_NAMES       Comma separated list of values.
+       --overridable OVERRIDABLE                Whether it should be allowed to
+                                                override the effective user
+                                                from the invocation form.
+       --provider-type PROVIDER_TYPE            Possible value(s): 'SSH'
+       --snippet SNIPPET                        One of true/false, yes/no, 1/0.
+       --value VALUE                            What user should be used to run
+                                                the script (using sudo-like
+                                                mechanisms).
+
+    """
+    args = {
+        u'audit-comment': None,
+        u'current-user': None,
+        u'description-format': None,
+        u'file': None,
+        u'job-category': u'Miscellaneous',
+        u'location-ids': None,
+        u'locations': None,
+        u'name': None,
+        u'organization-ids': None,
+        u'organizations': None,
+        u'overridable': None,
+        u'provider-type': u'SSH',
+        u'snippet': None,
+        u'value': None,
+    }
+
+    return create_object(JobTemplate, args, options)
 
 
 @cacheable

--- a/robottelo/cli/job_invocation.py
+++ b/robottelo/cli/job_invocation.py
@@ -1,0 +1,26 @@
+# -*- encoding: utf-8 -*-
+"""
+Usage:
+    hammer job-invocation [OPTIONS] SUBCOMMAND [ARG] ...
+
+Parameters:
+    SUBCOMMAND      subcommand
+    [ARG] ...       subcommand arguments
+
+Subcommands:
+
+    create          Create a job invocation
+    info            Show job invocation
+    list            List job invocations
+    output          View the output for a host
+"""
+
+from robottelo.cli.base import Base
+
+
+class JobInvocation(Base):
+    """
+    Run remote jobs.
+    """
+
+    command_base = 'job-invocation'

--- a/robottelo/cli/job_template.py
+++ b/robottelo/cli/job_template.py
@@ -1,0 +1,29 @@
+# -*- encoding: utf-8 -*-
+"""
+Usage:
+    hammer job-template [OPTIONS] SUBCOMMAND [ARG] ...
+
+Parameters:
+
+    SUBCOMMAND      subcommand
+    [ARG] ...       subcommand arguments
+
+Subcommands:
+
+     create         Create a job template
+     delete         Delete a job template
+     dump           View job template content
+     info           Show job template details
+     list           List job templates
+     update         Update a job template
+"""
+
+from robottelo.cli.base import Base
+
+
+class JobTemplate(Base):
+    """
+    Manipulate job templates.
+    """
+
+    command_base = 'job-template'

--- a/tests/foreman/cli/test_remoteexecution.py
+++ b/tests/foreman/cli/test_remoteexecution.py
@@ -1,0 +1,199 @@
+# -*- encoding: utf-8 -*-
+"""Test class for Remote Execution Management UI
+
+@Requirement: Remoteexecution
+
+@CaseAutomation: Automated
+
+@CaseLevel: Acceptance
+
+@CaseComponent: CLI
+
+@TestType: Functional
+
+@CaseImportance: High
+
+@Upstream: No
+"""
+
+from fauxfactory import gen_string
+from robottelo import ssh
+from robottelo.cli.base import CLIReturnCodeError
+from robottelo.cli.factory import (
+    CLIFactoryError,
+    make_job_template,
+    make_org
+)
+from robottelo.cli.job_template import JobTemplate
+from robottelo.datafactory import invalid_values_list
+from robottelo.decorators import tier1, tier2, tier3, stubbed
+from robottelo.test import CLITestCase
+
+TEMPLATE_FILE = u'template_file.txt'
+TEMPLATE_FILE_EMPTY = u'template_file_empty.txt'
+
+
+class JobTemplateTestCase(CLITestCase):
+    """Implements job template tests in CLI."""
+
+    @classmethod
+    def setUpClass(cls):
+        """Create an organization and host which can be re-used in tests."""
+        super(JobTemplateTestCase, cls).setUpClass()
+        cls.organization = make_org()
+        ssh.command(
+            '''echo '<%= input("command") %>' > {0}'''.format(TEMPLATE_FILE)
+        )
+        ssh.command('touch {0}'.format(TEMPLATE_FILE_EMPTY))
+
+    @tier1
+    def test_positive_create_job_template(self):
+        """Create a simple Job Template
+
+        @id: a5a67b10-61b0-4362-b671-9d9f095c452c
+
+        @Assert: The job template was successfully created
+        """
+        template_name = gen_string('alpha', 7)
+        make_job_template({
+            u'organizations': self.organization['name'],
+            u'name': template_name,
+            u'file': TEMPLATE_FILE
+        })
+        self.assertIsNotNone(
+            JobTemplate.info({u'name': template_name})
+        )
+
+    @tier1
+    def test_negative_create_job_template_with_invalid_name(self):
+        """Create Job Template with invalid name
+
+        @id: eb51afd4-e7b3-42c3-81c3-6e18ef3d7efe
+
+        @Assert: Job Template with invalid name cannot be created and error is
+        raised
+        """
+        for name in invalid_values_list():
+            with self.subTest(name):
+                with self.assertRaisesRegex(
+                    CLIFactoryError,
+                    u'Could not create the job template:'
+                ):
+                    for name in invalid_values_list():
+                        make_job_template({
+                            u'organizations': self.organization['name'],
+                            u'name': name,
+                            u'file': TEMPLATE_FILE
+                        })
+
+    @tier1
+    def test_negative_create_job_template_with_same_name(self):
+        """Create Job Template with duplicate name
+
+        @id: 66100c82-97f5-4300-a0c9-8cf041f7789f
+
+        @Assert: The name duplication is caught and error is raised
+        """
+        template_name = gen_string('alpha', 7)
+        make_job_template({
+            u'organizations': self.organization['name'],
+            u'name': template_name,
+            u'file': TEMPLATE_FILE
+        })
+        with self.assertRaisesRegex(
+            CLIFactoryError,
+            u'Could not create the job template:'
+        ):
+            make_job_template({
+                u'organizations': self.organization['name'],
+                u'name': template_name,
+                u'file': TEMPLATE_FILE
+            })
+
+    @tier1
+    def test_negative_create_empty_job_template(self):
+        """Create Job Template with empty template file
+
+        @id: 749be863-94ae-4008-a242-c23f353ca404
+
+        @Assert: The empty file is detected and error is raised
+        """
+        template_name = gen_string('alpha', 7)
+        with self.assertRaisesRegex(
+            CLIFactoryError,
+            u'Could not create the job template:'
+        ):
+            make_job_template({
+                u'organizations': self.organization['name'],
+                u'name': template_name,
+                u'file': TEMPLATE_FILE_EMPTY
+            })
+
+    @tier1
+    def test_positive_delete_job_template(self):
+        """Delete a job template
+
+        @id: 33104c04-20e9-47aa-99da-4bf3414ea31a
+
+        @Assert: The Job Template has been deleted
+        """
+        template_name = gen_string('alpha', 7)
+        make_job_template({
+            u'organizations': self.organization['name'],
+            u'name': template_name,
+            u'file': TEMPLATE_FILE
+        })
+        JobTemplate.delete({u'name': template_name})
+        with self.assertRaises(CLIReturnCodeError):
+            JobTemplate.info({u'name': template_name})
+
+    @tier1
+    def test_positive_view_dump(self):
+        """Export contents of a job template
+
+        @id: 25fcfcaa-fc4c-425e-919e-330e36195c4a
+
+        @Assert: Verify no errors are thrown
+        """
+        template_name = gen_string('alpha', 7)
+        make_job_template({
+            u'organizations': self.organization['name'],
+            u'name': template_name,
+            u'file': TEMPLATE_FILE
+        })
+        dumped_content = JobTemplate.dump({u'name': template_name})
+        self.assertGreater(len(dumped_content), 0)
+
+
+class RemoteExecutionTestCase(CLITestCase):
+    """Implements job execution tests in CLI."""
+
+    @stubbed
+    @tier2
+    def test_positive_run_default_job_template(self):
+        """Run default job template against a single host
+
+        @id: f4470ed4-f971-4a3c-a2f1-150d45755e48
+
+        @Assert: Verify the job was successfully ran against the host
+        """
+
+    @stubbed
+    @tier2
+    def test_positive_run_custom_job_template(self):
+        """Run custom job template against a single host
+
+        @id: 71928f36-61b4-46e6-842c-a051cfd9a68e
+
+        @Assert: Verify the job was successfully ran against the host
+        """
+
+    @stubbed
+    @tier3
+    def test_positive_run_scheduled_job_template(self):
+        """Schedule a job to be ran against a host
+
+        @id: 1953517b-6908-40aa-858b-747629d2f374
+
+        @Assert: Verify the job was successfully ran after the designated time
+        """


### PR DESCRIPTION
Related issue is #3822 
Test results:
```
nosetests -v tests/foreman/cli/test_remoteexecution.py

Create Job Template with empty template file ... ok
Create Job Template with invalid name ... ok
Create Job Template with duplicate name ... ok
Create a simple Job Template ... ok
Delete a job template ... ok
Export contents of a job template ... ok

----------------------------------------------------------------------
Ran 6 tests in 106.737s

OK
```
job-invocation tests are TBD
