### PR TITLE
Added scripts to validate and fix duplicated and empty @ids

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,3 +44,6 @@
 
 # For Pycharm
 /.idea
+
+# For backup files.
+*~

--- a/Makefile
+++ b/Makefile
@@ -47,6 +47,9 @@ help:
 	@echo "  logs-join                  to join xdist log files into one"
 	@echo "  logs-clean                 to delete all xdist log files in the root"
 	@echo "  pyc-clean                  to delete all temporary artifacts"
+	@echo "  uuid-check                 to check for duplicated @id: in testimony docstring tags"
+	@echo "  uuid-replace-empty         to replace empty @id: with new generated uuid"
+	@echo "  uuid-replace-duplicate     to replace duplicated @id: with new generated uuid"
 
 docs:
 	@cd docs; $(MAKE) html
@@ -54,7 +57,7 @@ docs:
 docs-clean:
 	@cd docs; $(MAKE) clean
 
-test-docstrings:
+test-docstrings: uuid-check
 	testimony $(TESTIMONY_OPTIONS) validate tests/foreman/api
 	testimony $(TESTIMONY_OPTIONS) validate tests/foreman/cli
 	testimony $(TESTIMONY_OPTIONS) validate tests/foreman/rhci
@@ -124,6 +127,15 @@ logs-join:
 logs-clean:
 	-rm -f robottelo_gw*.log
 
+uuid-check:  ## list duplicated uuids
+	scripts/check_duplicate_uuids.sh
+
+uuid-replace-duplicate:  ## list duplicated uuids
+	scripts/replace_dup_uuids.sh
+
+uuid-replace-empty:  ## list duplicated uuids
+	scripts/replace_empty_uuids.sh
+
 # Special Targets -------------------------------------------------------------
 
 .PHONY: help docs docs-clean test-docstrings test-robottelo \
@@ -131,4 +143,5 @@ logs-clean:
         test-foreman-rhai test-foreman-rhci test-foreman-tier1 \
         test-foreman-tier2 test-foreman-tier3 test-foreman-tier4 \
         test-foreman-ui test-foreman-ui-xvfb test-foreman-endtoend \
-        graph-entities lint logs-join logs-clean pyc-clean
+        graph-entities lint logs-join logs-clean pyc-clean \
+        uuid-check uuid-replace-duplicate uuid-replace-empty

--- a/scripts/check_duplicate_uuids.sh
+++ b/scripts/check_duplicate_uuids.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+
+# This script checks duplicated or empty uuids and exit with 1 if found
+
+# finds occurrences of empty @id: testimony tags
+grep -E -i -r -n "@id:(.+[[:blank:]]|$)" tests/foreman/
+EMPTY=$?
+
+if [ $EMPTY = 0 ]; then
+    echo "Empty @id found in testimony tags"
+    exit 1
+fi
+
+# Finds occurrences of @id: in testimony tags then
+# sort the output and filters only the duplicated
+# then looks for existence of "@id:" in final output
+# NOTE: can't print the line number -n here because of uniq -d
+grep -r -i "@id:" tests/foreman/ | sort | uniq -d | grep "@id:"
+DUPLICATE=$?
+
+# grep exits with status code 0 if text is found
+# but we need to invert the logic here
+# if duplicate found return with error 1
+if [ $DUPLICATE = 0 ]; then
+    echo "Duplicate @id found in testimony tags"
+    exit 1
+fi

--- a/scripts/replace_dup_uuids.sh
+++ b/scripts/replace_dup_uuids.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+
+# This script finds duplicated @id and replaces with new uuids
+
+grep -r -i "@id:" tests/foreman/ | sort | uniq -d | grep "@id:" | while read -r line ; do
+    OLDIFS=$IFS
+    IFS=':' read -r dup_file dup_id <<< $line
+    echo "filename: $dup_file"
+    echo "Id to replace: $dup_id"
+    NEW_ID=$(uuidgen)
+    echo "Replacing with the new id: $NEW_ID"
+    LAST_LINE=$(grep -i -n "$dup_id" $dup_file | tail -1)
+
+    IFS=':' read -r linenumber linecontent <<< $LAST_LINE
+    echo $linenumber
+    trimmed_linecontent=$(echo $linecontent)
+    sed -i~ "${linenumber}s/${trimmed_linecontent}/@id: ${NEW_ID}/g" $dup_file
+    echo "----------------------------------------------------------------"
+    IFS=$OLDIFS
+done

--- a/scripts/replace_empty_uuids.sh
+++ b/scripts/replace_empty_uuids.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+
+# this script finds empty @id: and replace with new uuids
+
+# finds occurrences of empty @id: testimony tags
+EMPTY_IDS=$(grep -E -i -r -n "@id:(.+[[:blank:]]|$)" tests/foreman/)
+
+if [ -n "$EMPTY_IDS" ]; then
+   echo "Generating new UUIDS for empty @id tags..."
+else
+   echo "No empty @id was found"
+fi
+
+# iterate if any empty @id found
+for output_line in $EMPTY_IDS
+do
+    if (echo "$output_line" | grep "tests/foreman"); then
+        OLDIFS=$IFS
+        # splits the grep output to get filename and occurrence line number
+        IFS=':' read -r filename line <<< $output_line
+        # generate uuid and place in specific line number
+        sed -r -i~ "${line}s/@id:(.+[[:blank:]]|$)/@id: $(uuidgen)/g" $filename
+        IFS=$OLDIFS
+    fi
+done

--- a/tests/foreman/api/test_repository.py
+++ b/tests/foreman/api/test_repository.py
@@ -981,7 +981,7 @@ class OstreeRepositoryTestCase(APITestCase):
     def test_positive_update_name(self):
         """Update ostree repository name.
 
-        @id: 6dff0c90-170f-40b9-9347-8ec97d89f2fd
+        @id: 4d9f1418-cc08-4c3c-a5dd-1d20fb9052a2
 
         @Assert: The repository name is updated.
         """

--- a/tests/foreman/api/test_variables.py
+++ b/tests/foreman/api/test_variables.py
@@ -312,7 +312,7 @@ class SmartVariablesTestCase(APITestCase):
     def test_negative_create_matcher_empty_value(self):
         """Create matcher with empty value with type other than string
 
-        @id: a90b5bcd-f76c-4663-bf41-2f96e7e15c0f
+        @id: ad24999f-1bed-4abb-a01f-3cb485d67968
 
         @steps:
 

--- a/tests/foreman/cli/test_hostgroup.py
+++ b/tests/foreman/cli/test_hostgroup.py
@@ -217,7 +217,7 @@ class HostGroupTestCase(CLITestCase):
     def test_positive_create_with_lifecycle_environment(self):
         """Check if hostgroup with lifecyle environment can be created
 
-        @id: c468fcac-9e42-4ee6-a431-abe29b6848ce
+        @id: 24bc3010-4e61-47d8-b8ae-0d66e1055aea
 
         @Assert: Hostgroup should be created and has lifecycle env assigned
 
@@ -239,7 +239,7 @@ class HostGroupTestCase(CLITestCase):
         """Check if hostgroup with multiple organizations can be created
         if one of them is associated with lifecycle environment
 
-        @id: 32be4630-0032-4f5f-89d4-44f8d05fe585
+        @id: ca110a74-401d-48f9-9700-6c57f1c10f11
 
         @Assert: Hostgroup is created, has both new organizations assigned
         and has lifecycle env assigned

--- a/tests/foreman/ui/test_contenthost.py
+++ b/tests/foreman/ui/test_contenthost.py
@@ -216,7 +216,7 @@ class ContentHostTestCase(UITestCase):
     def test_positive_install_errata(self):
         """Install a errata to a host remotely
 
-        @id: 13b9422d-4b7a-4068-9a57-a94602cd6410
+        @id: b69b9797-3c0c-42cd-94ed-3f751bb9b24c
 
         @assert: Errata was successfully installed
 

--- a/tests/foreman/ui/test_hostcollection.py
+++ b/tests/foreman/ui/test_hostcollection.py
@@ -632,7 +632,7 @@ class HostCollectionPackageManagementTest(UITestCase):
     def test_positive_install_errata(self):
         """Install an errata to the hosts inside host collection remotely
 
-        @id: 5a6fff0a-686f-419b-a773-4d03713e47e9
+        @id: 69c83000-0b46-4735-8c03-e9e0b48af0fb
 
         @Assert: Errata was successfully installed in all the hosts in host
         collection

--- a/tests/foreman/ui/test_remoteexecution.py
+++ b/tests/foreman/ui/test_remoteexecution.py
@@ -410,7 +410,7 @@ class RemoteExecutionTestCase(UITestCase):
     def test_positive_run_custom_job_template(self):
         """Run a job template against a single host
 
-        @id: 7f0cdd1a-c87c-4324-ae9c-dbc30abad217
+        @id: 89b75feb-afff-44f2-a2bd-2ffe74b63ec7
 
         @Setup: Create a working job template.
 

--- a/tests/foreman/ui/test_repository.py
+++ b/tests/foreman/ui/test_repository.py
@@ -678,7 +678,7 @@ class RepositoryTestCase(UITestCase):
     def test_positive_create_with_download_policy(self):
         """Create YUM repositories with available download policies
 
-        @id: 8037a68b-66b8-4b42-a80b-fb08495f948d
+        @id: 8099fb98-963d-4370-bf51-6807f5efd6d3
 
         @Assert: YUM repository with a download policy is created
         """


### PR DESCRIPTION
closes #3834
closes #3735 

I fixed the duplications found by @rplevka  in #3834 

Added `make uuid-check` (based in @rplevka snippet and using @elyezer help)  which exits with status code `1` if any duplicated or empty `@id:` testimony tag is found in our code base. (added that script call to `make test-docstring` which is called by travis.

Added make commands to help contributor to check invalid `@id` before commiting.
(optionally can be added as a commit hook)

# Before commiting please do:

```
make test-docstring
make test-robottelo
make uuid-check
``` 

We can create a target to group all `make test-commit` what about?


# if duplicates found 

you will see the filename and duplicated `@id` in output so you can fix it.

If want to fix automatically use:

`make uuid-replace-duplicate` 

All duplicated (last-occurrence) will be replaced with new generated uuid)

# Writing new stubs

If writing new test-stubs you can leave the `@id:` empty as in

```
def test_something(self):
    """
    @id:
    @Assert: Test something 
    """
```

Then run

```make uuid-replace-empty```

A new uuid will be generated and placed in that empty tag.

Backup~ files will be created in same folder for each changed file.

This script uses the command `uuidgen` ensure you have it installed.

Not forget to mention that [similar idea](https://github.com/san7ket/uuid) has been implemented by @san7ket, so thanks for the script you emailed, it helped. 
