### PR TITLE
Skip tests due to BZ #1378009

### DIFF
--- a/tests/foreman/api/test_hostgroup.py
+++ b/tests/foreman/api/test_hostgroup.py
@@ -541,6 +541,7 @@ class HostGroupTestCase(APITestCase):
         )
 
     @tier1
+    @skip_if_bug_open('bugzilla', 1378009)
     def test_positive_update_name(self):
         """Update a hostgroup with a new name
 
@@ -559,6 +560,7 @@ class HostGroupTestCase(APITestCase):
                 self.assertEqual(name, hostgroup.name)
 
     @tier2
+    @skip_if_bug_open('bugzilla', 1378009)
     def test_positive_update_parent(self):
         """Update a hostgroup with a new parent hostgroup
 
@@ -586,6 +588,7 @@ class HostGroupTestCase(APITestCase):
         self.assertEqual(hostgroup.parent.read().name, new_parent.name)
 
     @tier2
+    @skip_if_bug_open('bugzilla', 1378009)
     def test_positive_update_env(self):
         """Update a hostgroup with a new environment
 
@@ -613,6 +616,7 @@ class HostGroupTestCase(APITestCase):
         self.assertEqual(hostgroup.environment.read().name, new_env.name)
 
     @tier2
+    @skip_if_bug_open('bugzilla', 1378009)
     def test_positive_update_os(self):
         """Update a hostgroup with a new operating system
 
@@ -644,6 +648,7 @@ class HostGroupTestCase(APITestCase):
         self.assertEqual(hostgroup.operatingsystem.read().name, new_os.name)
 
     @tier2
+    @skip_if_bug_open('bugzilla', 1378009)
     def test_positive_update_arch(self):
         """Update a hostgroup with a new architecture
 
@@ -664,6 +669,7 @@ class HostGroupTestCase(APITestCase):
         self.assertEqual(hostgroup.architecture.read().name, new_arch.name)
 
     @tier2
+    @skip_if_bug_open('bugzilla', 1378009)
     def test_positive_update_media(self):
         """Update a hostgroup with a new media
 
@@ -702,6 +708,7 @@ class HostGroupTestCase(APITestCase):
         self.assertEqual(hostgroup.medium.read().name, new_media.name)
 
     @tier2
+    @skip_if_bug_open('bugzilla', 1378009)
     def test_positive_update_ptable(self):
         """Update a hostgroup with a new partition table
 
@@ -732,6 +739,7 @@ class HostGroupTestCase(APITestCase):
         self.assertEqual(hostgroup.ptable.read().name, new_ptable.name)
 
     @tier1
+    @skip_if_bug_open('bugzilla', 1378009)
     def test_positive_update_puppet_ca_proxy(self):
         """Update a hostgroup with a new puppet CA proxy
 
@@ -749,6 +757,7 @@ class HostGroupTestCase(APITestCase):
         self.assertEqual(hostgroup.puppet_ca_proxy.read().name, new_proxy.name)
 
     @tier2
+    @skip_if_bug_open('bugzilla', 1378009)
     def test_positive_update_subnet(self):
         """Update a hostgroup with a new subnet
 
@@ -776,6 +785,7 @@ class HostGroupTestCase(APITestCase):
         self.assertEqual(hostgroup.subnet.read().name, new_subnet.name)
 
     @tier2
+    @skip_if_bug_open('bugzilla', 1378009)
     def test_positive_update_domain(self):
         """Update a hostgroup with a new domain
 
@@ -833,6 +843,7 @@ class HostGroupTestCase(APITestCase):
         self.assertEqual(hostgroup.realm.read().name, new_realm.name)
 
     @tier1
+    @skip_if_bug_open('bugzilla', 1378009)
     def test_positive_update_puppet_proxy(self):
         """Update a hostgroup with a new puppet proxy
 
@@ -850,6 +861,7 @@ class HostGroupTestCase(APITestCase):
         self.assertEqual(hostgroup.puppet_proxy.read().name, new_proxy.name)
 
     @tier1
+    @skip_if_bug_open('bugzilla', 1378009)
     def test_positive_update_content_source(self):
         """Update a hostgroup with a new puppet proxy
 
@@ -868,6 +880,7 @@ class HostGroupTestCase(APITestCase):
             hostgroup.content_source.read().name, new_content_source.name)
 
     @tier2
+    @skip_if_bug_open('bugzilla', 1378009)
     def test_positive_update_cv(self):
         """Update a hostgroup with a new content view
 
@@ -897,6 +910,7 @@ class HostGroupTestCase(APITestCase):
         self.assertEqual(hostgroup.content_view.read().name, new_cv.name)
 
     @tier2
+    @skip_if_bug_open('bugzilla', 1378009)
     def test_positive_update_lce(self):
         """Update a hostgroup with a new lifecycle environment
 
@@ -919,6 +933,7 @@ class HostGroupTestCase(APITestCase):
             hostgroup.lifecycle_environment.read().name, new_lce.name)
 
     @tier2
+    @skip_if_bug_open('bugzilla', 1378009)
     def test_positive_update_loc(self):
         """Update a hostgroup with a new location
 
@@ -938,6 +953,7 @@ class HostGroupTestCase(APITestCase):
         self.assertEqual(hostgroup.location[0].read().name, new_loc.name)
 
     @tier2
+    @skip_if_bug_open('bugzilla', 1378009)
     def test_positive_update_org(self):
         """Update a hostgroup with a new organization
 
@@ -957,6 +973,7 @@ class HostGroupTestCase(APITestCase):
         self.assertEqual(hostgroup.organization[0].read().name, new_org.name)
 
     @tier2
+    @skip_if_bug_open('bugzilla', 1378009)
     def test_positive_update_locs(self):
         """Update a hostgroup with new multiple locations
 
@@ -982,6 +999,7 @@ class HostGroupTestCase(APITestCase):
         )
 
     @tier2
+    @skip_if_bug_open('bugzilla', 1378009)
     def test_positive_update_orgs(self):
         """Update a hostgroup with new multiple organizations
 

--- a/tests/foreman/api/test_multiple_paths.py
+++ b/tests/foreman/api/test_multiple_paths.py
@@ -39,8 +39,6 @@ BZ_1118015_ENTITIES = (
     entities.LifecycleEnvironment, entities.OperatingSystem, entities.Product,
     entities.Repository, entities.Role, entities.Subnet, entities.User,
 )
-BZ_1154156_ENTITIES = (entities.ConfigTemplate, entities.Host, entities.User)
-BZ_1187366_ENTITIES = (entities.LifecycleEnvironment, entities.Organization)
 
 
 def valid_entities():
@@ -304,13 +302,12 @@ class EntityIdTestCase(APITestCase):
         exclude_list = (
             entities.TemplateKind,  # see comments in class definition
         )
+        if bz_bug_is_open(1378009):
+            exclude_list += (entities.HostGroup,)
         for entity_cls in set(valid_entities()) - set(exclude_list):
             with self.subTest(entity_cls):
                 logger.debug('test_put_status_code arg: %s', entity_cls)
                 skip_if_sam(self, entity_cls)
-                if (entity_cls in BZ_1154156_ENTITIES and
-                        bz_bug_is_open(1154156)):
-                    self.skipTest("Bugzilla bug 1154156 is open.")
 
                 # Create an entity
                 entity_id = entity_cls().create_json()['id']
@@ -348,17 +345,11 @@ class EntityIdTestCase(APITestCase):
             with self.subTest(entity_cls):
                 logger.debug('test_delete_status_code arg: %s', entity_cls)
                 skip_if_sam(self, entity_cls)
-                if (entity_cls == entities.ConfigTemplate and
-                        bz_bug_is_open(1096333)):
-                    self.skipTest('Cannot delete config templates.')
                 try:
                     entity = entity_cls(id=entity_cls().create_json()['id'])
                 except HTTPError as err:
                     self.fail(err)
                 response = entity.delete_raw()
-                if (entity_cls in BZ_1187366_ENTITIES and
-                        bz_bug_is_open(1187366)):
-                    self.skipTest('BZ 1187366 is open.')
                 self.assertIn(
                     response.status_code,
                     (
@@ -398,13 +389,12 @@ class DoubleCheckTestCase(APITestCase):
         exclude_list = (
             entities.TemplateKind,  # see comments in class definition
         )
+        if bz_bug_is_open(1378009):
+            exclude_list += (entities.HostGroup, )
         for entity_cls in set(valid_entities()) - set(exclude_list):
             with self.subTest(entity_cls):
                 logger.debug('test_put_and_get arg: %s', entity_cls)
                 skip_if_sam(self, entity_cls)
-                if (entity_cls in BZ_1154156_ENTITIES and
-                        bz_bug_is_open(1154156)):
-                    self.skipTest("Bugzilla bug 1154156 is open.")
 
                 # Create an entity.
                 entity_id = entity_cls().create_json()['id']
@@ -444,9 +434,6 @@ class DoubleCheckTestCase(APITestCase):
             with self.subTest(entity_cls):
                 logger.debug('test_post_and_get arg: %s', entity_cls)
                 skip_if_sam(self, entity_cls)
-                if (entity_cls in BZ_1154156_ENTITIES and
-                        bz_bug_is_open(1154156)):
-                    self.skipTest('Bugzilla bug 1154156 is open.')
 
                 entity = entity_cls()
                 entity_id = entity.create_json()['id']
@@ -474,12 +461,6 @@ class DoubleCheckTestCase(APITestCase):
             with self.subTest(entity_cls):
                 logger.debug('test_delete_and_get arg: %s', entity_cls)
                 skip_if_sam(self, entity_cls)
-                if (entity_cls is entities.ConfigTemplate and
-                        bz_bug_is_open(1096333)):
-                    self.skipTest('BZ 1096333: Cannot delete config templates')
-                if (entity_cls in BZ_1187366_ENTITIES and
-                        bz_bug_is_open(1187366)):
-                    self.skipTest('BZ 1187366: Cannot delete orgs or envs.')
 
                 # Create an entity, delete it and get it.
                 try:


### PR DESCRIPTION
20 API tests are failing because of bug in hostgroup update ([BZ #1378009](https://bugzilla.redhat.com/show_bug.cgi?id=1378009)).
Most of them are from `HostGroupTestCase` and related to hostgroup update.  However, I'm not sure is it good idea to skip 
`api.test_multiple_paths.DoubleCheckTestCase.test_positive_put_and_get_requests` and
`api.test_multiple_paths.EntityIdTestCase.test_positive_put_status_code`
They're testing a lot of stuff besides hostgroup update.
```
% nosetests tests/foreman/api/test_{hostgroup.py,multiple_paths.py}
....................S..SSSSSSSSSSSSSSSSSSS...S..S.........S
----------------------------------------------------------------------
Ran 59 tests in 1308.621s
OK (SKIP=23)
```
