### PR TITLE
Fix 6.3 bookmark test failures for UI and API

### DIFF
--- a/robottelo/constants.py
+++ b/robottelo/constants.py
@@ -888,7 +888,7 @@ BOOKMARK_ENTITIES = [
     },
     {'name': 'Hosts', 'controller': 'hosts', 'setup': entities.Host},
     {
-        'name': 'ContentHost', 'controller': 'katello_systems',
+        'name': 'ContentHost', 'controller': 'hosts',
         'skip_for_ui': True
     },
     {'name': 'HostCollection', 'controller': 'katello_host_collections'},
@@ -918,7 +918,7 @@ BOOKMARK_ENTITIES = [
     },
     {
         'name': 'ConfigGroups', 'controller': 'config_groups',
-        'setup': entities.ConfigGroup
+        'setup': entities.ConfigGroup, 'skip_for_ui': 1378084
     },
     {
         'name': 'PuppetEnv', 'controller': 'environments',


### PR DESCRIPTION
PR fixes 21 test failures.
Closes #3844 
Root cause for API tests is controller for ContentHost has changed from `katello_systems` to `hosts` as part of host unification (and AFAIK systems controller and paths have been deprecated for a long time and now are completely removed).
For UI tests as a pre-condition we need to create a config group to be able to create a bookmark, and config group creation via API is broken (BZ1378084). Skipping config group subtest while bug is open.
Test results:
API:
```python
============================= test session starts ==============================
platform linux2 -- Python 2.7.10, pytest-2.9.2, py-1.4.31, pluggy-0.3.1 -- /home/andrii/env/bin/python
cachedir: .cache
rootdir: /home/andrii/workspace/robottelo, inifile: 
plugins: xdist-1.13.1, repeat-0.2
collecting ... collected 13 items

tests/foreman/api/test_bookmarks.py::BookmarkTestCase::test_negative_create_empty_query PASSED
tests/foreman/api/test_bookmarks.py::BookmarkTestCase::test_negative_create_null_public <- robottelo/decorators/__init__.py SKIPPED
tests/foreman/api/test_bookmarks.py::BookmarkTestCase::test_negative_create_same_name PASSED
tests/foreman/api/test_bookmarks.py::BookmarkTestCase::test_negative_create_with_invalid_name PASSED
tests/foreman/api/test_bookmarks.py::BookmarkTestCase::test_negative_update_empty_query PASSED
tests/foreman/api/test_bookmarks.py::BookmarkTestCase::test_negative_update_invalid_name PASSED
tests/foreman/api/test_bookmarks.py::BookmarkTestCase::test_negative_update_same_name PASSED
tests/foreman/api/test_bookmarks.py::BookmarkTestCase::test_positive_create_public PASSED
tests/foreman/api/test_bookmarks.py::BookmarkTestCase::test_positive_create_with_name PASSED
tests/foreman/api/test_bookmarks.py::BookmarkTestCase::test_positive_create_with_query PASSED
tests/foreman/api/test_bookmarks.py::BookmarkTestCase::test_positive_update_name PASSED
tests/foreman/api/test_bookmarks.py::BookmarkTestCase::test_positive_update_public PASSED
tests/foreman/api/test_bookmarks.py::BookmarkTestCase::test_positive_update_query PASSED

==================== 12 passed, 1 skipped in 805.96 seconds ====================
```
UI:
```python
============================= test session starts ==============================
platform linux2 -- Python 2.7.10, pytest-2.9.2, py-1.4.31, pluggy-0.3.1 -- /home/andrii/env/bin/python
cachedir: .cache
rootdir: /home/andrii/workspace/robottelo, inifile: 
plugins: xdist-1.13.1, repeat-0.2
collecting ... collected 14 items

tests/foreman/ui/test_bookmark.py::BookmarkTestCase::test_negative_create_bookmark_no_name <- robottelo/decorators/__init__.py SKIPPED
tests/foreman/ui/test_bookmark.py::BookmarkTestCase::test_negative_create_bookmark_no_query PASSED
tests/foreman/ui/test_bookmark.py::BookmarkTestCase::test_negative_create_bookmark_same_name PASSED
tests/foreman/ui/test_bookmark.py::BookmarkTestCase::test_negative_delete_bookmark PASSED
tests/foreman/ui/test_bookmark.py::BookmarkTestCase::test_negative_update_bookmark_name PASSED
tests/foreman/ui/test_bookmark.py::BookmarkTestCase::test_negative_update_bookmark_name_empty FAILED
tests/foreman/ui/test_bookmark.py::BookmarkTestCase::test_negative_update_bookmark_name_empty ERROR
tests/foreman/ui/test_bookmark.py::BookmarkTestCase::test_negative_update_bookmark_query_empty <- robottelo/decorators/__init__.py PASSED
tests/foreman/ui/test_bookmark.py::BookmarkTestCase::test_positive_create_bookmark_populate_auto PASSED
tests/foreman/ui/test_bookmark.py::BookmarkTestCase::test_positive_create_bookmark_populate_manual PASSED
tests/foreman/ui/test_bookmark.py::BookmarkTestCase::test_positive_create_bookmark_public PASSED
tests/foreman/ui/test_bookmark.py::BookmarkTestCase::test_positive_delete_bookmark PASSED
tests/foreman/ui/test_bookmark.py::BookmarkTestCase::test_positive_update_bookmark_name PASSED
tests/foreman/ui/test_bookmark.py::BookmarkTestCase::test_positive_update_bookmark_public FAILED
tests/foreman/ui/test_bookmark.py::BookmarkTestCase::test_positive_update_bookmark_public ERROR
tests/foreman/ui/test_bookmark.py::BookmarkTestCase::test_positive_update_bookmark_query <- robottelo/decorators/__init__.py PASSED

========== 2 failed, 11 passed, 1 skipped, 2 error in 1165.15 seconds ==========
```
2 tests failed with webdriver exception as i was working in the background and accidentally interfered a bit. Another run:
```python
============================= test session starts ==============================
platform linux2 -- Python 2.7.10, pytest-2.9.2, py-1.4.31, pluggy-0.3.1 -- /home/andrii/env/bin/python
cachedir: .cache
rootdir: /home/andrii/workspace/robottelo, inifile: 
plugins: xdist-1.13.1, repeat-0.2
collecting ... collected 14 items

tests/foreman/ui/test_bookmark.py::BookmarkTestCase::test_negative_update_bookmark_name_empty PASSED
tests/foreman/ui/test_bookmark.py::BookmarkTestCase::test_positive_update_bookmark_public PASSED

 12 tests deselected by '-ktest_negative_update_bookmark_name_empty or test_positive_update_bookmark_public' 
================== 2 passed, 12 deselected in 137.49 seconds ===================
```
