### PR TITLE
Fix discovery rules functionality for 6.3

### DIFF
--- a/robottelo/ui/discoveryrules.py
+++ b/robottelo/ui/discoveryrules.py
@@ -69,6 +69,7 @@ class DiscoveryRules(Base):
             name,
             really,
             locators['discoveryrules.rule_delete'],
+            drop_locator=locators['discoveryrules.dropdown'],
         )
 
     def update(self, name, new_name=None, search_rule=None, hostgroup=None,

--- a/robottelo/ui/locators/base.py
+++ b/robottelo/ui/locators/base.py
@@ -1851,6 +1851,10 @@ locators = LocatorDict({
                    " and contains(., '%s')]")),
     "discoveryrules.rule_delete": (
         By.XPATH, "//a[contains(@data-confirm, '%s') and @class='delete']"),
+    "discoveryrules.dropdown": (
+        By.XPATH,
+        ("//td/a[normalize-space(.)='%s']"
+         "/following::td/div/a[@data-toggle='dropdown']")),
 
     # Discovered Hosts
     "discoveredhosts.hostname": (


### PR DESCRIPTION
Closes #3843 
```
nosetests tests/foreman/ui/test_discoveryrule.py
.S...SS..S..S......SSS.......S
----------------------------------------------------------------------
Ran 30 tests in 924.624s

OK (SKIP=9)
```