### PR TITLE
Automated stubs on cli.myaccount.py

### DIFF
--- a/robottelo/constants.py
+++ b/robottelo/constants.py
@@ -2,6 +2,11 @@
 """Defines various constants"""
 from nailgun import entities
 
+LOCALES = (
+    'ca', 'de', 'en', 'en_GB', 'es', 'fr', 'gl', 'it', 'ja', 'ko',
+    'pt_BR', 'ru', 'sv_SE', 'zh_CN', 'zh_TW'
+)
+
 # Bugzilla
 BZ_OPEN_STATUSES = [
     'NEW',
@@ -965,7 +970,6 @@ STRING_TYPES = [
     u'alpha', u'numeric', u'alphanumeric',
     u'latin1', u'utf8', u'cjk', u'html'
 ]
-
 
 # All UI crud classes listed here to allow dynamical import
 # import import_string; import_string('robottelo.ui.{0}'.format(item))


### PR DESCRIPTION
 close #3742

Removed stub for invalid password since it not make sense on cli.

Example:
hammer -u ksm7UG -p 1 user update --id 5 --password 2
User [ksm7UG] updated

hammer -u ksm7UG -p 2 user update --id 5 --password 3
User [ksm7UG] updated

Test Results:

```console
(robottelo) [renzo@note robottelo]$ py.test tests/foreman/cli/test_myaccount.py
========================================================== test session starts ==========================================================
platform linux2 -- Python 2.7.12, pytest-2.9.2, py-1.4.31, pluggy-0.3.1
rootdir: /home/renzo/PycharmProjects/robottelo, inifile: 
plugins: cov-2.3.0, xdist-1.14
collected 8 items 

tests/foreman/cli/test_myaccount.py ........

====================================================== 8 passed in 313.70 seconds =======================================================
(robottelo) [renzo@note robottelo]$ 

```