### PR TITLE
Fixes Issue #3821

### DIFF
--- a/robottelo/constants.py
+++ b/robottelo/constants.py
@@ -16,6 +16,9 @@ BZ_CLOSED_STATUSES = [
     'CLOSED'
 ]
 
+DISTRO_RHEL6 = "rhel68"
+DISTRO_RHEL7 = "rhel72"
+
 FOREMAN_PROVIDERS = {
     'libvirt': 'Libvirt',
     'rhev': 'RHEV',

--- a/robottelo/vm.py
+++ b/robottelo/vm.py
@@ -15,14 +15,12 @@ import time
 
 from robottelo import ssh
 from robottelo.config import settings
+from robottelo.constants import DISTRO_RHEL6, DISTRO_RHEL7
 from robottelo.helpers import install_katello_ca, remove_katello_ca
 
 BASE_IMAGES = (
-    'rhel65',
-    'rhel66',
-    'rhel67',
-    'rhel70',
-    'rhel71',
+    DISTRO_RHEL6,
+    DISTRO_RHEL7,
 )
 
 logger = logging.getLogger(__name__)
@@ -416,10 +414,10 @@ class VirtualMachine(object):
 
         # Red Hat Access Insights requires RHEL 6/7 repo and it is not
         # possible to sync the repo during the tests, Adding repo file.
-        if rhel_distro == 'rhel67':
+        if rhel_distro == DISTRO_RHEL6:
             rhel_repo = settings.rhel6_repo
             insights_repo = settings.rhai.insights_client_el6repo
-        if rhel_distro == 'rhel71':
+        if rhel_distro == DISTRO_RHEL7:
             rhel_repo = settings.rhel7_repo
             insights_repo = settings.rhai.insights_client_el7repo
 

--- a/tests/foreman/api/test_errata.py
+++ b/tests/foreman/api/test_errata.py
@@ -25,6 +25,8 @@ from robottelo.cli.factory import (
 from robottelo.constants import (
     DEFAULT_ARCHITECTURE,
     DEFAULT_RELEASE_VERSION,
+    DISTRO_RHEL6,
+    DISTRO_RHEL7,
     FAKE_1_CUSTOM_PACKAGE,
     FAKE_2_CUSTOM_PACKAGE,
     FAKE_2_ERRATA_ID,
@@ -184,8 +186,8 @@ class ErrataTestCase(APITestCase):
 
         @CaseLevel: System
         """
-        with VirtualMachine(distro='rhel71') as client1, VirtualMachine(
-                distro='rhel71') as client2:
+        with VirtualMachine(distro=DISTRO_RHEL7) as client1, VirtualMachine(
+                distro=DISTRO_RHEL7) as client2:
             clients = [client1, client2]
             for client in clients:
                 client.install_katello_ca()
@@ -224,7 +226,7 @@ class ErrataTestCase(APITestCase):
 
         @CaseLevel: System
         """
-        with VirtualMachine(distro='rhel71') as client:
+        with VirtualMachine(distro=DISTRO_RHEL7) as client:
             client.install_katello_ca()
             result = client.register_contenthost(
                 self.org.label, self.activation_key.name)
@@ -514,7 +516,7 @@ class ErrataTestCase(APITestCase):
         content_view.publish()
         cvv = content_view.read().version[-1].read()
         promote(cvv, env.id)
-        with VirtualMachine(distro='rhel67') as client:
+        with VirtualMachine(distro=DISTRO_RHEL6) as client:
             client.install_katello_ca()
             result = client.register_contenthost(
                 org.label,
@@ -595,7 +597,7 @@ class ErrataTestCase(APITestCase):
         content_view.publish()
         cvv = content_view.read().version[-1].read()
         promote(cvv, env.id)
-        with VirtualMachine(distro='rhel67') as client:
+        with VirtualMachine(distro=DISTRO_RHEL6) as client:
             client.install_katello_ca()
             result = client.register_contenthost(
                 org.label,

--- a/tests/foreman/cli/test_activationkey.py
+++ b/tests/foreman/cli/test_activationkey.py
@@ -37,6 +37,7 @@ from robottelo.cli.lifecycleenvironment import LifecycleEnvironment
 from robottelo.cli.repository import Repository
 from robottelo.cli.subscription import Subscription
 from robottelo.constants import FAKE_0_YUM_REPO, PRDS, REPOS, REPOSET
+from robottelo.constants import DISTRO_RHEL6
 from robottelo.datafactory import valid_data_list, invalid_values_list
 from robottelo.decorators import (
     run_in_one_thread,
@@ -593,8 +594,8 @@ class ActivationKeyTestCase(CLITestCase):
             u'organization-id': self.org['id'],
             u'max-hosts': '1',
         })
-        with VirtualMachine(distro='rhel65') as vm1:
-            with VirtualMachine(distro='rhel65') as vm2:
+        with VirtualMachine(distro=DISTRO_RHEL6) as vm1:
+            with VirtualMachine(distro=DISTRO_RHEL6) as vm2:
                 vm1.install_katello_ca()
                 result = vm1.register_contenthost(
                     self.org['label'], new_ak['name'])
@@ -820,7 +821,7 @@ class ActivationKeyTestCase(CLITestCase):
             })
             for _ in range(2)
         ]
-        with VirtualMachine(distro='rhel65') as vm:
+        with VirtualMachine(distro=DISTRO_RHEL6) as vm:
             vm.install_katello_ca()
             for i in range(2):
                 result = vm.register_contenthost(

--- a/tests/foreman/cli/test_contenthost.py
+++ b/tests/foreman/cli/test_contenthost.py
@@ -27,6 +27,7 @@ from robottelo.cli.factory import (
 )
 from robottelo.cli.contenthost import ContentHost
 from robottelo.cli.contentview import ContentView
+from robottelo.constants import DISTRO_RHEL7
 from robottelo.cli.lifecycleenvironment import LifecycleEnvironment
 from robottelo.datafactory import (
     invalid_values_list,
@@ -381,7 +382,7 @@ class ContentHostTestCase(CLITestCase):
 
         @CaseLevel: System
         """
-        with VirtualMachine(distro='rhel71') as client:
+        with VirtualMachine(distro=DISTRO_RHEL7) as client:
             client.install_katello_ca()
             result = client.run(
                 u'subscription-manager register --org {0} '
@@ -411,7 +412,7 @@ class ContentHostTestCase(CLITestCase):
             'lifecycle-environment-id': self.NEW_LIFECYCLE['id'],
             'organization-id': self.NEW_ORG['id'],
         })
-        with VirtualMachine(distro='rhel71') as client:
+        with VirtualMachine(distro=DISTRO_RHEL7) as client:
             client.install_katello_ca()
             client.register_contenthost(
                 self.NEW_ORG['label'],
@@ -443,7 +444,7 @@ class ContentHostTestCase(CLITestCase):
             'lifecycle-environment-id': self.NEW_LIFECYCLE['id'],
             'organization-id': self.NEW_ORG['id'],
         })
-        with VirtualMachine(distro='rhel71') as client:
+        with VirtualMachine(distro=DISTRO_RHEL7) as client:
             client.install_katello_ca()
             client.register_contenthost(
                 self.NEW_ORG['label'],
@@ -472,7 +473,7 @@ class ContentHostTestCase(CLITestCase):
             'lifecycle-environment-id': self.NEW_LIFECYCLE['id'],
             'organization-id': self.NEW_ORG['id'],
         })
-        with VirtualMachine(distro='rhel71') as client:
+        with VirtualMachine(distro=DISTRO_RHEL7) as client:
             client.install_katello_ca()
             client.register_contenthost(
                 self.NEW_ORG['label'],

--- a/tests/foreman/cli/test_host.py
+++ b/tests/foreman/cli/test_host.py
@@ -36,6 +36,7 @@ from robottelo.cli.operatingsys import OperatingSys
 from robottelo.cli.proxy import Proxy
 from robottelo.config import settings
 from robottelo.constants import (
+    DISTRO_RHEL7,
     FAKE_0_CUSTOM_PACKAGE,
     FAKE_0_CUSTOM_PACKAGE_GROUP,
     FAKE_0_CUSTOM_PACKAGE_GROUP_NAME,
@@ -940,7 +941,7 @@ class KatelloAgentTestCase(CLITestCase):
         """
         super(KatelloAgentTestCase, self).setUp()
         # Create VM and register content host
-        self.client = VirtualMachine(distro='rhel71')
+        self.client = VirtualMachine(distro=DISTRO_RHEL7)
         self.client.create()
         self.client.install_katello_ca()
         # Register content host, install katello-agent

--- a/tests/foreman/endtoend/test_ui_endtoend.py
+++ b/tests/foreman/endtoend/test_ui_endtoend.py
@@ -24,6 +24,7 @@ from robottelo.constants import (
     DEFAULT_LOC,
     DEFAULT_ORG,
     DEFAULT_SUBSCRIPTION_NAME,
+    DISTRO_RHEL6,
     DOMAIN,
     FAKE_0_PUPPET_REPO,
     FOREMAN_PROVIDERS,
@@ -435,7 +436,7 @@ class EndToEndTestCase(UITestCase, ClientProvisioningMixin):
                     common_locators['alert.success']
                 ))
             # Create VM
-            with VirtualMachine(distro='rhel67') as vm:
+            with VirtualMachine(distro=DISTRO_RHEL6) as vm:
                 vm.install_katello_ca()
                 vm.register_contenthost(org_name, activation_key_name)
                 vm.configure_puppet(rhel6_repo)

--- a/tests/foreman/endtoend/utils.py
+++ b/tests/foreman/endtoend/utils.py
@@ -1,5 +1,6 @@
 # coding=utf-8
 """Module that aggregates common bits of the end to end tests."""
+from robottelo.constants import DISTRO_RHEL6
 from robottelo.decorators import setting_is_set
 from robottelo.vm import VirtualMachine
 
@@ -25,7 +26,7 @@ class ClientProvisioningMixin(object):
         """
         if not setting_is_set('clients'):
             return
-        with VirtualMachine(distro='rhel66') as vm:
+        with VirtualMachine(distro=DISTRO_RHEL6) as vm:
             # Pull rpm from Foreman server and install on client
             vm.install_katello_ca()
             # Register client with foreman server using act keys

--- a/tests/foreman/longrun/test_inc_updates.py
+++ b/tests/foreman/longrun/test_inc_updates.py
@@ -41,6 +41,7 @@ from robottelo.constants import (
     DEFAULT_ARCHITECTURE,
     DEFAULT_RELEASE_VERSION,
     DEFAULT_SUBSCRIPTION_NAME,
+    DISTRO_RHEL6,
     PRDS,
     REAL_0_RH_PACKAGE,
     REPOS,
@@ -192,7 +193,7 @@ class IncrementalUpdateTestCase(TestCase):
 
         # Create client machine and register it to satellite with
         # rhel_6_partial_ak
-        self.vm = VirtualMachine(distro='rhel67', tag='incupdate')
+        self.vm = VirtualMachine(distro=DISTRO_RHEL6, tag='incupdate')
         self.setup_vm(self.vm, rhel_6_partial_ak.name, self.org.label)
         self.vm.enable_repo(REPOS['rhva6']['id'])
         self.vm.run('yum install -y {0}'.format(REAL_0_RH_PACKAGE))

--- a/tests/foreman/longrun/test_oscap.py
+++ b/tests/foreman/longrun/test_oscap.py
@@ -28,6 +28,8 @@ from robottelo.constants import (
     ANY_CONTEXT,
     DEFAULT_LOC,
     DEFAULT_SUBSCRIPTION_NAME,
+    DISTRO_RHEL6,
+    DISTRO_RHEL7,
     OSCAP_DEFAULT_CONTENT,
     OSCAP_PERIOD,
     OSCAP_PROFILE,
@@ -191,12 +193,12 @@ class OpenScapTestCase(UITestCase):
         ]
         vm_values = [
             {
-                'distro': 'rhel67',
+                'distro': DISTRO_RHEL6,
                 'hgrp': hgrp6_name,
                 'rhel_repo': rhel6_repo,
             },
             {
-                'distro': 'rhel71',
+                'distro': DISTRO_RHEL7,
                 'hgrp': hgrp7_name,
                 'rhel_repo': rhel7_repo,
             },

--- a/tests/foreman/rhai/test_rhai.py
+++ b/tests/foreman/rhai/test_rhai.py
@@ -16,12 +16,12 @@
 """
 
 import time
-
 from fauxfactory import gen_string
 from nailgun import entities
 from robottelo import manifests
 from robottelo.api.utils import upload_manifest
 from robottelo.constants import DEFAULT_SUBSCRIPTION_NAME
+from robottelo.constants import DISTRO_RHEL6, DISTRO_RHEL7
 from robottelo.decorators import run_in_one_thread, skip_if_not_set
 from robottelo.test import UITestCase
 from robottelo.ui.locators import locators
@@ -83,10 +83,10 @@ class RHAITestCase(UITestCase):
 
         """
         # Register a VM to Access Insights Service
-        with VirtualMachine(distro='rhel67') as vm:
+        with VirtualMachine(distro=DISTRO_RHEL6) as vm:
             try:
                 vm.configure_rhai_client(self.ak_name, self.org_label,
-                                         'rhel67')
+                                         DISTRO_RHEL6)
 
                 with Session(self.browser) as session:
                     # view clients registered to Red Hat Access Insights
@@ -134,10 +134,10 @@ class RHAITestCase(UITestCase):
 
         """
         # Register a VM to Access Insights Service
-        with VirtualMachine(distro='rhel71') as vm:
+        with VirtualMachine(distro=DISTRO_RHEL7) as vm:
             try:
                 vm.configure_rhai_client(self.ak_name, self.org_label,
-                                         'rhel71')
+                                         DISTRO_RHEL7)
 
                 with Session(self.browser) as session:
                     session.nav.go_to_select_org(self.org_name)

--- a/tests/foreman/rhai/test_rhai_client.py
+++ b/tests/foreman/rhai/test_rhai_client.py
@@ -19,7 +19,7 @@ from fauxfactory import gen_string
 from nailgun import entities
 from robottelo import manifests
 from robottelo.api.utils import upload_manifest
-from robottelo.constants import DEFAULT_SUBSCRIPTION_NAME
+from robottelo.constants import DEFAULT_SUBSCRIPTION_NAME, DISTRO_RHEL6
 from robottelo.decorators import run_in_one_thread, skip_if_not_set
 from robottelo.test import TestCase
 from robottelo.vm import VirtualMachine
@@ -78,8 +78,9 @@ class RHAIClientTestCase(TestCase):
         @Assert: 'redhat-access-insights --test-connection' should return
         zero on a successfully registered machine to RHAI service
         """
-        with VirtualMachine(distro='rhel67') as vm:
-            vm.configure_rhai_client(self.ak_name, self.org_label, 'rhel67')
+        with VirtualMachine(distro=DISTRO_RHEL6) as vm:
+            vm.configure_rhai_client(self.ak_name, self.org_label,
+                                     DISTRO_RHEL6)
             test_connection = vm.run(
                 'redhat-access-insights --test-connection')
             self.logger.info('Return code for --test-connection {0}'.format(

--- a/tests/foreman/ui/test_activationkey.py
+++ b/tests/foreman/ui/test_activationkey.py
@@ -28,6 +28,7 @@ from robottelo.api.utils import (
 from robottelo.constants import (
     DEFAULT_CV,
     DEFAULT_SUBSCRIPTION_NAME,
+    DISTRO_RHEL6,
     ENVIRONMENT,
     FAKE_1_YUM_REPO,
     FAKE_2_YUM_REPO,
@@ -61,7 +62,7 @@ class ActivationKeyTestCase(UITestCase):
         cls.base_key_name = entities.ActivationKey(
             organization=cls.organization
         ).create().name
-        cls.vm_distro = 'rhel65'
+        cls.vm_distro = DISTRO_RHEL6
 
     # pylint: disable=too-many-arguments
     def create_sync_custom_repo(self, product_name=None, repo_name=None,

--- a/tests/foreman/ui/test_contenthost.py
+++ b/tests/foreman/ui/test_contenthost.py
@@ -21,6 +21,7 @@ from robottelo.cli.factory import (
     setup_org_for_a_rh_repo,
 )
 from robottelo.constants import (
+    DISTRO_RHEL7,
     FAKE_0_CUSTOM_PACKAGE,
     FAKE_0_CUSTOM_PACKAGE_GROUP,
     FAKE_0_CUSTOM_PACKAGE_GROUP_NAME,
@@ -85,7 +86,7 @@ class ContentHostTestCase(UITestCase):
         """Create a VM, subscribe it to satellite-tools repo, install
         katello-ca and katello-agent packages"""
         super(ContentHostTestCase, self).setUp()
-        self.client = VirtualMachine(distro='rhel71')
+        self.client = VirtualMachine(distro=DISTRO_RHEL7)
         self.client.create()
         self.client.install_katello_ca()
         result = self.client.register_contenthost(

--- a/tests/foreman/ui/test_errata.py
+++ b/tests/foreman/ui/test_errata.py
@@ -30,6 +30,8 @@ from robottelo.cli.repository_set import RepositorySet
 from robottelo.constants import (
     DEFAULT_ARCHITECTURE,
     DEFAULT_RELEASE_VERSION,
+    DISTRO_RHEL6,
+    DISTRO_RHEL7,
     FAKE_1_CUSTOM_PACKAGE,
     FAKE_2_CUSTOM_PACKAGE,
     FAKE_2_ERRATA_ID,
@@ -224,7 +226,7 @@ class ErrataTestCase(UITestCase):
 
         @CaseLevel: System
         """
-        with VirtualMachine(distro='rhel71') as client:
+        with VirtualMachine(distro=DISTRO_RHEL7) as client:
             client.install_katello_ca()
             result = client.register_contenthost(
                 self.session_org.label,
@@ -259,8 +261,8 @@ class ErrataTestCase(UITestCase):
         @CaseLevel: System
         """
         with nested(
-                VirtualMachine(distro='rhel71'),
-                VirtualMachine(distro='rhel71')
+                VirtualMachine(distro=DISTRO_RHEL7),
+                VirtualMachine(distro=DISTRO_RHEL7)
         ) as (client1, client2):
             clients = [client1, client2]
             for client in clients:
@@ -500,7 +502,7 @@ class ErrataTestCase(UITestCase):
 
         @CaseLevel: System
         """
-        with VirtualMachine(distro='rhel71') as client:
+        with VirtualMachine(distro=DISTRO_RHEL7) as client:
                 client.install_katello_ca()
                 result = client.register_contenthost(
                     self.session_org.label,
@@ -563,7 +565,7 @@ class ErrataTestCase(UITestCase):
 
         @CaseLevel: System
         """
-        with VirtualMachine(distro='rhel71') as client:
+        with VirtualMachine(distro=DISTRO_RHEL7) as client:
             client.install_katello_ca()
             result = client.register_contenthost(
                 self.session_org.label,
@@ -663,7 +665,7 @@ class ErrataTestCase(UITestCase):
             'organization-id': org.id,
             'to-lifecycle-environment-id': env.id,
         })
-        with VirtualMachine(distro='rhel67') as client:
+        with VirtualMachine(distro=DISTRO_RHEL6) as client:
             client.install_katello_ca()
             result = client.register_contenthost(
                 org.label,
@@ -768,7 +770,7 @@ class ErrataTestCase(UITestCase):
             'organization-id': org.id,
             'to-lifecycle-environment-id': env.id,
         })
-        with VirtualMachine(distro='rhel67') as client:
+        with VirtualMachine(distro=DISTRO_RHEL6) as client:
             client.install_katello_ca()
             result = client.register_contenthost(
                 org.label,

--- a/tests/foreman/ui/test_gpgkey.py
+++ b/tests/foreman/ui/test_gpgkey.py
@@ -21,6 +21,7 @@ from fauxfactory import gen_string
 from nailgun import entities
 from robottelo.config import settings
 from robottelo.constants import (
+    DISTRO_RHEL6,
     FAKE_1_YUM_REPO,
     FAKE_2_YUM_REPO,
     REPO_DISCOVERY_URL,
@@ -473,7 +474,7 @@ class GPGKey(UITestCase):
                 break
         # Create VM
         package_name = 'cow'
-        with VirtualMachine(distro='rhel66') as vm:
+        with VirtualMachine(distro=DISTRO_RHEL6) as vm:
             # Download and Install rpm
             result = vm.run(
                 "wget -nd -r -l1 --no-parent -A '*.noarch.rpm' http://{0}/pub/"

--- a/tests/foreman/ui/test_hostcollection.py
+++ b/tests/foreman/ui/test_hostcollection.py
@@ -25,6 +25,7 @@ from robottelo.cli.factory import (
     setup_org_for_a_rh_repo,
 )
 from robottelo.constants import (
+    DISTRO_RHEL7,
     FAKE_0_CUSTOM_PACKAGE,
     FAKE_0_CUSTOM_PACKAGE_GROUP,
     FAKE_0_CUSTOM_PACKAGE_GROUP_NAME,
@@ -458,7 +459,7 @@ class HostCollectionPackageManagementTest(UITestCase):
         super(HostCollectionPackageManagementTest, self).setUp()
         self.hosts = []
         for _ in range(self.hosts_number):
-            client = VirtualMachine(distro='rhel71')
+            client = VirtualMachine(distro=DISTRO_RHEL7)
             self.hosts.append(client)
             client.create()
             client.install_katello_ca()

--- a/tests/foreman/ui/test_hostunification.py
+++ b/tests/foreman/ui/test_hostunification.py
@@ -22,6 +22,7 @@ from robottelo.cli.factory import setup_org_for_a_rh_repo
 from robottelo.constants import (
     DEFAULT_CV,
     DEFAULT_SUBSCRIPTION_NAME,
+    DISTRO_RHEL7,
     ENVIRONMENT,
     PRDS,
     REPOS,
@@ -75,7 +76,7 @@ class HostContentHostUnificationTestCase(UITestCase):
 
         @CaseLevel: System
         """
-        with VirtualMachine(distro='rhel71') as vm:
+        with VirtualMachine(distro=DISTRO_RHEL7) as vm:
             vm.install_katello_ca()
             result = vm.register_contenthost(self.org_.label, lce='Library')
             self.assertEqual(result.return_code, 0)
@@ -118,7 +119,7 @@ class HostContentHostUnificationTestCase(UITestCase):
             'lifecycle-environment-id': env.id,
             'activationkey-id': activation_key.id,
         })
-        with VirtualMachine(distro='rhel71') as vm:
+        with VirtualMachine(distro=DISTRO_RHEL7) as vm:
             vm.install_katello_ca()
             result = vm.register_contenthost(org.label, activation_key.name)
             self.assertEqual(result.return_code, 0)
@@ -197,7 +198,7 @@ class HostContentHostUnificationTestCase(UITestCase):
 
         @CaseLevel: System
         """
-        with VirtualMachine(distro='rhel71') as vm:
+        with VirtualMachine(distro=DISTRO_RHEL7) as vm:
             vm.install_katello_ca()
             result = vm.register_contenthost(self.org_.label, lce='Library')
             self.assertEqual(result.return_code, 0)
@@ -237,7 +238,7 @@ class HostContentHostUnificationTestCase(UITestCase):
 
         @CaseLevel: System
         """
-        with VirtualMachine(distro='rhel71') as vm:
+        with VirtualMachine(distro=DISTRO_RHEL7) as vm:
             vm.install_katello_ca()
             result = vm.register_contenthost(self.org_.label, lce='Library')
             self.assertEqual(result.return_code, 0)
@@ -270,7 +271,7 @@ class HostContentHostUnificationTestCase(UITestCase):
 
         @CaseLevel: System
         """
-        with VirtualMachine(distro='rhel71') as vm:
+        with VirtualMachine(distro=DISTRO_RHEL7) as vm:
             vm.install_katello_ca()
             result = vm.register_contenthost(self.org_.label, lce='Library')
             self.assertEqual(result.return_code, 0)
@@ -313,7 +314,7 @@ class HostContentHostUnificationTestCase(UITestCase):
             'lifecycle-environment-id': env.id,
             'activationkey-id': activation_key.id,
         })
-        with VirtualMachine(distro='rhel71') as vm:
+        with VirtualMachine(distro=DISTRO_RHEL7) as vm:
             vm.install_katello_ca()
             result = vm.register_contenthost(org.label, activation_key.name)
             self.assertEqual(result.return_code, 0)
@@ -359,7 +360,7 @@ class HostContentHostUnificationTestCase(UITestCase):
             'lifecycle-environment-id': env.id,
             'activationkey-id': activation_key.id,
         })
-        with VirtualMachine(distro='rhel71') as vm:
+        with VirtualMachine(distro=DISTRO_RHEL7) as vm:
             vm.install_katello_ca()
             result = vm.register_contenthost(org.label, activation_key.name)
             self.assertEqual(result.return_code, 0)
@@ -402,7 +403,7 @@ class HostContentHostUnificationTestCase(UITestCase):
             'lifecycle-environment-id': env.id,
             'activationkey-id': activation_key.id,
         })
-        with VirtualMachine(distro='rhel71') as vm:
+        with VirtualMachine(distro=DISTRO_RHEL7) as vm:
             vm.install_katello_ca()
             result = vm.register_contenthost(org.label, activation_key.name)
             self.assertEqual(result.return_code, 0)

--- a/tests/foreman/ui/test_remoteexecution.py
+++ b/tests/foreman/ui/test_remoteexecution.py
@@ -16,7 +16,7 @@
 """
 from datetime import datetime, timedelta
 from nailgun import entities
-from robottelo.constants import OS_TEMPLATE_DATA_FILE
+from robottelo.constants import OS_TEMPLATE_DATA_FILE, DISTRO_RHEL7
 from robottelo.datafactory import (
     gen_string,
     generate_strings_list,
@@ -392,7 +392,7 @@ class RemoteExecutionTestCase(UITestCase):
 
         @CaseLevel: Integration
         """
-        with VirtualMachine(distro='rhel71') as client:
+        with VirtualMachine(distro=DISTRO_RHEL7) as client:
             client.install_katello_ca()
             client.register_contenthost(self.organization.label, lce='Library')
             add_remote_execution_ssh_key(client.ip_addr)
@@ -425,7 +425,7 @@ class RemoteExecutionTestCase(UITestCase):
         @CaseLevel: System
         """
         jobs_template_name = gen_string('alpha')
-        with VirtualMachine(distro='rhel71') as client:
+        with VirtualMachine(distro=DISTRO_RHEL7) as client:
             client.install_katello_ca()
             client.register_contenthost(self.organization.label, lce='Library')
             add_remote_execution_ssh_key(client.ip_addr)
@@ -469,8 +469,8 @@ class RemoteExecutionTestCase(UITestCase):
 
         @CaseLevel: System
         """
-        with VirtualMachine(distro='rhel71') as client:
-            with VirtualMachine(distro='rhel71') as client2:
+        with VirtualMachine(distro=DISTRO_RHEL7) as client:
+            with VirtualMachine(distro=DISTRO_RHEL7) as client2:
                 for vm in client, client2:
                     vm.install_katello_ca()
                     vm.register_contenthost(
@@ -511,7 +511,7 @@ class RemoteExecutionTestCase(UITestCase):
 
         @CaseLevel: System
         """
-        with VirtualMachine(distro='rhel71') as client:
+        with VirtualMachine(distro=DISTRO_RHEL7) as client:
             client.install_katello_ca()
             client.register_contenthost(self.organization.label, lce='Library')
             add_remote_execution_ssh_key(client.ip_addr)


### PR DESCRIPTION
Declared the constants in constants.py for the base images
Currently supports rhel68 and rhel72
Updates all instances , with the new constants DISTRO_RHEL6, DISTRO_RHEL7 respectively.
