### PR TITLE
Fixed custom product subscription related tests

### DIFF
--- a/robottelo/cli/factory.py
+++ b/robottelo/cli/factory.py
@@ -2028,7 +2028,9 @@ def activationkey_add_subscription_to_repo(options=None):
         )
     for subscription in subscriptions:
         if subscription['name'] == options['subscription']:
-            if int(subscription['quantity']) == 0:
+            if (
+                    subscription['quantity'] != 'Unlimited' and
+                    int(subscription['quantity']) == 0):
                 raise CLIFactoryError(
                     'All the subscriptions are already consumed')
             try:

--- a/tests/foreman/ui/test_errata.py
+++ b/tests/foreman/ui/test_errata.py
@@ -31,9 +31,9 @@ from robottelo.constants import (
     DEFAULT_ARCHITECTURE,
     DEFAULT_RELEASE_VERSION,
     FAKE_1_CUSTOM_PACKAGE,
-    FAKE_1_ERRATA_ID,
     FAKE_2_CUSTOM_PACKAGE,
     FAKE_2_ERRATA_ID,
+    FAKE_3_ERRATA_ID,
     FAKE_3_YUM_REPO,
     FAKE_6_YUM_REPO,
     PRDS,
@@ -156,13 +156,13 @@ class ErrataTestCase(UITestCase):
         with Session(self.browser) as session:
             session.nav.go_to_errata()
             self.errata.show_only_applicable(False)
-            self.assertIsNone(self.errata.search(CUSTOM_REPO_ERRATA_ID))
-            self.assertIsNotNone(self.errata.search(FAKE_1_ERRATA_ID))
+            self.assertIsNone(self.errata.search(FAKE_3_ERRATA_ID))
+            self.assertIsNotNone(self.errata.search(CUSTOM_REPO_ERRATA_ID))
             session.nav.go_to_select_org(org.name)
             session.nav.go_to_errata()
             self.errata.show_only_applicable(False)
-            self.assertIsNone(self.errata.search(FAKE_1_ERRATA_ID))
-            self.assertIsNotNone(self.errata.search(CUSTOM_REPO_ERRATA_ID))
+            self.assertIsNone(self.errata.search(CUSTOM_REPO_ERRATA_ID))
+            self.assertIsNotNone(self.errata.search(FAKE_3_ERRATA_ID))
 
     @tier2
     def test_positive_list_permission(self):


### PR DESCRIPTION
Closes #3857
The root cause is custom products subscriptions in 6.3 may contain
string value 'Unlimited' for its 'quantity' field, and robottelo
was expecting only string containing integer and was converting it
with `int()` func, which leads to failure.

List of affected tests (not complete):
```
tests.foreman.cli.test_host.KatelloAgentTestCase.test_positive_install_package
tests.foreman.cli.test_host.KatelloAgentTestCase.test_negative_unregister_and_pull_content
tests.foreman.cli.test_host.KatelloAgentTestCase.test_positive_apply_errata
tests.foreman.cli.test_host.KatelloAgentTestCase.test_positive_get_errata_info
tests.foreman.cli.test_host.KatelloAgentTestCase.test_positive_install_package_group
tests.foreman.cli.test_host.KatelloAgentTestCase.test_positive_remove_package
tests.foreman.cli.test_host.KatelloAgentTestCase.test_positive_remove_package_group
tests.foreman.cli.test_host.KatelloAgentTestCase.test_positive_upgrade_package
tests.foreman.cli.test_host.KatelloAgentTestCase.test_positive_upgrade_packages_all
tests.foreman.api.test_errata.ErrataTestCase.test_positive_filter_by_cve
tests.foreman.api.test_errata.ErrataTestCase.test_positive_filter_by_envs
tests.foreman.api.test_errata.ErrataTestCase.test_positive_get_applicable_for_host
tests.foreman.api.test_errata.ErrataTestCase.test_positive_get_count_for_host
tests.foreman.api.test_errata.ErrataTestCase.test_positive_get_diff_for_cv_envs
tests.foreman.api.test_errata.ErrataTestCase.test_positive_install_in_hc
tests.foreman.api.test_errata.ErrataTestCase.test_positive_install_in_host
tests.foreman.api.test_errata.ErrataTestCase.test_positive_list
tests.foreman.api.test_errata.ErrataTestCase.test_positive_list_updated
tests.foreman.api.test_errata.ErrataTestCase.test_positive_sort_by_issued_date
tests.foreman.ui.test_errata.ErrataTestCase.test_positive_view_cve
tests.foreman.ui.test_errata.ErrataTestCase.test_positive_search_autocomplete
tests.foreman.ui.test_errata.ErrataTestCase.test_positive_view_products_and_repos
tests.foreman.ui.test_errata.ErrataTestCase.test_positive_list_permission
tests.foreman.ui.test_errata.ErrataTestCase.test_positive_list
tests.foreman.ui.test_errata.ErrataTestCase.test_positive_chost_library
tests.foreman.ui.test_errata.ErrataTestCase.test_positive_apply_for_all_hosts
tests.foreman.ui.test_errata.ErrataTestCase.test_positive_apply_for_host
tests.foreman.ui.test_errata.ErrataTestCase.test_positive_chost_previous_env
tests.foreman.ui.test_errata.ErrataTestCase.test_positive_show_count_on_chost_details_page
tests.foreman.ui.test_errata.ErrataTestCase.test_positive_show_count_on_chost_page
tests.foreman.ui.test_contenthost.ContentHostTestCase.test_positive_install_errata
tests.foreman.ui.test_contenthost.ContentHostTestCase.test_positive_install_package
tests.foreman.ui.test_contenthost.ContentHostTestCase.test_positive_install_package_group
tests.foreman.ui.test_contenthost.ContentHostTestCase.test_positive_remove_package
tests.foreman.ui.test_contenthost.ContentHostTestCase.test_positive_remove_package_group
tests.foreman.ui.test_contenthost.ContentHostTestCase.test_positive_upgrade_package
```

Ran 2 random tests from the list:
```python
/home/andrii/env/bin/python /home/andrii/workspace/pycharm-2016.1.3/helpers/pydev/pydevd.py --multiproc --qt-support --client 127.0.0.1 --port 33839 --file /home/andrii/workspace/pycharm-2016.1.3/helpers/pycharm/pytestrunner.py -p pytest_teamcity /home/andrii/workspace/robottelo/tests/foreman/ui/test_errata.py "-k ErrataTestCase and test_positive_list"
Testing started at 4:42 PM ...
pydev debugger: process 7666 is connecting

Connected to pydev debugger (build 145.1504)
============================= test session starts ==============================
platform linux2 -- Python 2.7.10, pytest-2.9.2, py-1.4.31, pluggy-0.3.1
rootdir: /home/andrii/workspace/robottelo, inifile: 
plugins: xdist-1.13.1, repeat-0.2
collected 17 items

..


====== 15 tests deselected by '-k ErrataTestCase and test_positive_list' =======
================== 2 passed, 15 deselected in 1619.40 seconds ==================

Process finished with exit code 0
```