### PR TITLE
Automated synchronizing SRPM package via API/CLI/UI

### DIFF
--- a/robottelo/constants.py
+++ b/robottelo/constants.py
@@ -320,6 +320,9 @@ FAKE_5_YUM_REPO = u'http://{0}:{1}@rplevka.fedorapeople.org/fakerepo01/'
 FAKE_6_YUM_REPO = (
     u'https://jlsherrill.fedorapeople.org/fake-repos/needed-errata/'
 )
+FAKE_YUM_SRPM_REPO = (
+    u'https://repos.fedorapeople.org/repos/pulp/pulp/fixtures/srpm/'
+)
 FAKE_0_PUPPET_REPO = u'http://davidd.fedorapeople.org/repos/random_puppet/'
 FAKE_1_PUPPET_REPO = u'http://omaciel.fedorapeople.org/fakepuppet01'
 FAKE_2_PUPPET_REPO = u'http://omaciel.fedorapeople.org/fakepuppet02'

--- a/tests/foreman/api/test_repository.py
+++ b/tests/foreman/api/test_repository.py
@@ -18,14 +18,19 @@ from fauxfactory import gen_string
 from nailgun import entities
 from nailgun.entity_mixins import TaskFailedError
 from requests.exceptions import HTTPError
-from robottelo import manifests
-from robottelo.api.utils import enable_rhrepo_and_fetchid, upload_manifest
+from robottelo import manifests, ssh
+from robottelo.api.utils import (
+    enable_rhrepo_and_fetchid,
+    promote,
+    upload_manifest,
+)
 from robottelo.constants import (
     DOCKER_REGISTRY_HUB,
     FAKE_0_PUPPET_REPO,
     FAKE_7_PUPPET_REPO,
     FAKE_2_YUM_REPO,
     FAKE_5_YUM_REPO,
+    FAKE_YUM_SRPM_REPO,
     FEDORA22_OSTREE_REPO,
     FEDORA23_OSTREE_REPO,
     PRDS,
@@ -63,7 +68,7 @@ class RepositoryTestCase(APITestCase):
     """Tests for ``katello/api/v2/repositories``."""
 
     @classmethod
-    def setUpClass(cls):  # noqa
+    def setUpClass(cls):
         """Create an organization and product which can be re-used in tests."""
         super(RepositoryTestCase, cls).setUpClass()
         cls.org = entities.Organization().create()
@@ -895,7 +900,7 @@ class DockerRepositoryTestCase(APITestCase):
     """Tests specific to using ``Docker`` repositories."""
 
     @classmethod
-    def setUpClass(cls):  # noqa
+    def setUpClass(cls):
         """Create an organization and product which can be re-used in tests."""
         super(DockerRepositoryTestCase, cls).setUpClass()
         cls.org = entities.Organization().create()
@@ -973,7 +978,7 @@ class OstreeRepositoryTestCase(APITestCase):
 
     @classmethod
     @skip_if_os('RHEL6')
-    def setUpClass(cls):  # noqa
+    def setUpClass(cls):
         """Create a product and an org which can be re-used in tests."""
         super(OstreeRepositoryTestCase, cls).setUpClass()
         cls.org = entities.Organization().create()
@@ -1075,3 +1080,106 @@ class OstreeRepositoryTestCase(APITestCase):
             basearch=None,
         )
         entities.Repository(id=repo_id).sync()
+
+
+class SRPMRepositoryTestCase(APITestCase):
+    """Tests specific to using repositories containing source RPMs."""
+
+    @classmethod
+    def setUpClass(cls):
+        """Create a product and an org which can be re-used in tests."""
+        super(SRPMRepositoryTestCase, cls).setUpClass()
+        cls.org = entities.Organization().create()
+        cls.product = entities.Product(organization=cls.org).create()
+
+    @tier2
+    def test_positive_sync(self):
+        """Synchronize repository with SRPMs
+
+        @id: f87391c6-c18a-4c4f-81db-decbba7f1856
+
+        @Assert: srpms can be listed in repository
+        """
+        repo = entities.Repository(
+            product=self.product,
+            url=FAKE_YUM_SRPM_REPO,
+        ).create()
+        repo.sync()
+        result = ssh.command(
+            'ls /var/lib/pulp/published/yum/https/repos/{}/Library'
+            '/custom/{}/{}/ | grep .src.rpm'
+            .format(
+                self.org.label,
+                self.product.label,
+                repo.label,
+            )
+        )
+        self.assertEqual(result.return_code, 0)
+        self.assertGreaterEqual(len(result.stdout), 1)
+
+    @tier2
+    def test_positive_sync_publish_cv(self):
+        """Synchronize repository with SRPMs, add repository to content view
+        and publish content view
+
+        @id: a0868429-584c-4e36-b93f-c85e8e94a60b
+
+        @Assert: srpms can be listed in content view
+        """
+        repo = entities.Repository(
+            product=self.product,
+            url=FAKE_YUM_SRPM_REPO,
+        ).create()
+        repo.sync()
+        cv = entities.ContentView(organization=self.org).create()
+        cv.repository = [repo]
+        cv.update(['repository'])
+        cv.publish()
+        result = ssh.command(
+            'ls /var/lib/pulp/published/yum/https/repos/{}/content_views/{}'
+            '/1.0/custom/{}/{}/ | grep .src.rpm'
+            .format(
+                self.org.label,
+                cv.label,
+                self.product.label,
+                repo.label,
+            )
+        )
+        self.assertEqual(result.return_code, 0)
+        self.assertGreaterEqual(len(result.stdout), 1)
+
+    @tier2
+    def test_positive_sync_publish_promote_cv(self):
+        """Synchronize repository with SRPMs, add repository to content view,
+        publish and promote content view to lifecycle environment
+
+        @id: 811b524f-2b19-4408-ad7f-d7251625e35c
+
+        @Assert: srpms can be listed in content view in proper lifecycle
+        environment
+        """
+        lce = entities.LifecycleEnvironment(organization=self.org).create()
+        repo = entities.Repository(
+            product=self.product,
+            url=FAKE_YUM_SRPM_REPO,
+        ).create()
+        repo.sync()
+        cv = entities.ContentView(organization=self.org).create()
+        cv.repository = [repo]
+        cv.update(['repository'])
+        cv.publish()
+        cv = cv.read()
+        promote(cv.version[0], lce.id)
+        result = ssh.command(
+            'ls /var/lib/pulp/published/yum/https/repos/{}/{}/{}/custom/{}/{}/'
+            ' | grep .src.rpm'
+            .format(
+                self.org.label,
+                lce.name,
+                cv.label,
+                self.product.label,
+                repo.label,
+            )
+        )
+        self.assertEqual(result.return_code, 0)
+        self.assertGreaterEqual(len(result.stdout), 1)

--- a/tests/foreman/ui/test_repository.py
+++ b/tests/foreman/ui/test_repository.py
@@ -20,12 +20,14 @@ import time
 
 from fauxfactory import gen_string
 from nailgun import entities
+from robottelo import ssh
 from robottelo.constants import (
     CHECKSUM_TYPE,
     DOCKER_REGISTRY_HUB,
     FAKE_0_PUPPET_REPO,
     FAKE_1_YUM_REPO,
     FAKE_2_YUM_REPO,
+    FAKE_YUM_SRPM_REPO,
     FEDORA22_OSTREE_REPO,
     FEDORA23_OSTREE_REPO,
     REPO_DISCOVERY_URL,
@@ -43,7 +45,7 @@ from robottelo.decorators import run_only_on, stubbed, tier1, tier2
 from robottelo.decorators.host import skip_if_os
 from robottelo.helpers import read_data_file
 from robottelo.test import UITestCase
-from robottelo.ui.factory import make_repository, set_context
+from robottelo.ui.factory import make_contentview, make_repository, set_context
 from robottelo.ui.locators import common_locators, locators, tab_locators
 from robottelo.ui.session import Session
 from selenium.common.exceptions import NoSuchElementException
@@ -65,7 +67,7 @@ class RepositoryTestCase(UITestCase):
     """Implements Repos tests in UI"""
 
     @classmethod
-    def setUpClass(cls):  # noqa
+    def setUpClass(cls):
         super(RepositoryTestCase, cls).setUpClass()
         # create instances to be shared across the sessions
         cls.session_loc = entities.Location().create()
@@ -918,3 +920,142 @@ class RepositoryTestCase(UITestCase):
                             locators['repo.download_policy']
                         )
                     )
+
+    @tier2
+    def test_positive_sync(self):
+        """Synchronize repository with SRPMs
+
+        @id: 1967a540-a265-4046-b87b-627524b63688
+
+        @Assert: srpms can be listed in repository
+        """
+        product = entities.Product(organization=self.session_org).create()
+        repo_name = gen_string('alphanumeric')
+        with Session(self.browser) as session:
+            self.products.search(product.name).click()
+            make_repository(
+                session,
+                name=repo_name,
+                url=FAKE_YUM_SRPM_REPO,
+            )
+            self.assertIsNotNone(self.repository.search(repo_name))
+            self.setup_navigate_syncnow(
+                session,
+                product.name,
+                repo_name,
+            )
+            self.assertTrue(self.prd_sync_is_ok(repo_name))
+        result = ssh.command(
+            'ls /var/lib/pulp/published/yum/https/repos/{}/Library'
+            '/custom/{}/{}/ | grep .src.rpm'
+            .format(
+                self.session_org.label,
+                product.label,
+                repo_name,
+            )
+        )
+        self.assertEqual(result.return_code, 0)
+        self.assertGreaterEqual(len(result.stdout), 1)
+
+    @tier2
+    def test_positive_sync_publish_cv(self):
+        """Synchronize repository with SRPMs, add repository to content view
+        and publish content view
+
+        @id: 2a57cbde-c616-440d-8bcb-6e18bd2d5c5f
+
+        @Assert: srpms can be listed in content view
+        """
+        product = entities.Product(organization=self.session_org).create()
+        repo_name = gen_string('alphanumeric')
+        cv_name = gen_string('alphanumeric')
+        with Session(self.browser) as session:
+            self.products.search(product.name).click()
+            make_repository(
+                session,
+                name=repo_name,
+                url=FAKE_YUM_SRPM_REPO,
+            )
+            self.assertIsNotNone(self.repository.search(repo_name))
+            self.setup_navigate_syncnow(
+                session,
+                product.name,
+                repo_name,
+            )
+            self.assertTrue(self.prd_sync_is_ok(repo_name))
+
+            make_contentview(session, org=self.session_org.name, name=cv_name)
+            self.assertIsNotNone(self.content_views.search(cv_name))
+            self.content_views.add_remove_repos(cv_name, [repo_name])
+            self.assertIsNotNone(self.content_views.wait_until_element(
+                common_locators['alert.success_sub_form']))
+            self.content_views.publish(cv_name)
+            self.assertIsNotNone(self.content_views.wait_until_element
+                                 (common_locators['alert.success_sub_form']))
+        result = ssh.command(
+            'ls /var/lib/pulp/published/yum/https/repos/{}/content_views/{}'
+            '/1.0/custom/{}/{}/ | grep .src.rpm'
+            .format(
+                self.session_org.label,
+                cv_name,
+                product.label,
+                repo_name,
+            )
+        )
+        self.assertEqual(result.return_code, 0)
+        self.assertGreaterEqual(len(result.stdout), 1)
+
+    @tier2
+    def test_positive_sync_publish_promote_cv(self):
+        """Synchronize repository with SRPMs, add repository to content view,
+        publish and promote content view to lifecycle environment
+
+        @id: 4563d1c1-cdce-4838-a67f-c0a5d4e996a6
+
+        @Assert: srpms can be listed in content view in proper lifecycle
+        environment
+        """
+        lce = entities.LifecycleEnvironment(
+            organization=self.session_org).create()
+        product = entities.Product(organization=self.session_org).create()
+        repo_name = gen_string('alphanumeric')
+        cv_name = gen_string('alphanumeric')
+        with Session(self.browser) as session:
+            self.products.search(product.name).click()
+            make_repository(
+                session,
+                name=repo_name,
+                url=FAKE_YUM_SRPM_REPO,
+            )
+            self.assertIsNotNone(self.repository.search(repo_name))
+            self.setup_navigate_syncnow(
+                session,
+                product.name,
+                repo_name,
+            )
+            self.assertTrue(self.prd_sync_is_ok(repo_name))
+
+            make_contentview(session, org=self.session_org.name, name=cv_name)
+            self.assertIsNotNone(self.content_views.search(cv_name))
+            self.content_views.add_remove_repos(cv_name, [repo_name])
+            self.assertIsNotNone(self.content_views.wait_until_element(
+                common_locators['alert.success_sub_form']))
+            self.content_views.publish(cv_name)
+            self.assertIsNotNone(self.content_views.wait_until_element
+                                 (common_locators['alert.success_sub_form']))
+            self.content_views.promote(cv_name, 'Version 1', lce.name)
+            self.assertIsNotNone(self.content_views.wait_until_element
+                                 (common_locators['alert.success_sub_form']))
+        result = ssh.command(
+            'ls /var/lib/pulp/published/yum/https/repos/{}/{}/{}/custom/{}/{}/'
+            ' | grep .src.rpm'
+            .format(
+                self.session_org.label,
+                lce.name,
+                cv_name,
+                product.label,
+                repo_name,
+            )
+        )
+        self.assertEqual(result.return_code, 0)
+        self.assertGreaterEqual(len(result.stdout), 1)


### PR DESCRIPTION
Closes #3854

Test results:
```python
py.test tests/foreman/{api,cli,ui}/test_repository.py -k 'test_sync' -v -n 2
================================================ test session starts ================================================
platform linux2 -- Python 2.7.10, pytest-2.9.2, py-1.4.31, pluggy-0.3.1 -- /home/andrii/env/bin/python
cachedir: .cache
rootdir: /home/andrii/workspace/robottelo, inifile: 
plugins: xdist-1.13.1, repeat-0.2
[gw0] linux2 Python 2.7.10 cwd: /home/andrii/workspace/robottelo
[gw1] linux2 Python 2.7.10 cwd: /home/andrii/workspace/robottelo
[gw0] Python 2.7.10 (default, Sep  8 2015, 17:20:17)  -- [GCC 5.1.1 20150618 (Red Hat 5.1.1-4)]
[gw1] Python 2.7.10 (default, Sep  8 2015, 17:20:17)  -- [GCC 5.1.1 20150618 (Red Hat 5.1.1-4)]
gw0 [9] / gw1 [9]
scheduling tests via LoadScheduling

tests/foreman/api/test_repository.py::SRPMRepositoryTestCase::test_sync 
tests/foreman/api/test_repository.py::SRPMRepositoryTestCase::test_sync_publish_promote_cv 
[gw0] PASSED tests/foreman/api/test_repository.py::SRPMRepositoryTestCase::test_sync 
tests/foreman/api/test_repository.py::SRPMRepositoryTestCase::test_sync_publish_cv 
[gw1] PASSED tests/foreman/api/test_repository.py::SRPMRepositoryTestCase::test_sync_publish_promote_cv 
tests/foreman/cli/test_repository.py::SRPMRepositoryTestCase::test_sync 
[gw0] PASSED tests/foreman/api/test_repository.py::SRPMRepositoryTestCase::test_sync_publish_cv 
tests/foreman/cli/test_repository.py::SRPMRepositoryTestCase::test_sync_publish_cv 
[gw1] PASSED tests/foreman/cli/test_repository.py::SRPMRepositoryTestCase::test_sync 
tests/foreman/cli/test_repository.py::SRPMRepositoryTestCase::test_sync_publish_promote_cv 
[gw0] PASSED tests/foreman/cli/test_repository.py::SRPMRepositoryTestCase::test_sync_publish_cv 
tests/foreman/ui/test_repository.py::RepositoryTestCase::test_sync 
[gw1] PASSED tests/foreman/cli/test_repository.py::SRPMRepositoryTestCase::test_sync_publish_promote_cv 
[gw0] PASSED tests/foreman/ui/test_repository.py::RepositoryTestCase::test_sync 
tests/foreman/ui/test_repository.py::RepositoryTestCase::test_sync_publish_promote_cv 
tests/foreman/ui/test_repository.py::RepositoryTestCase::test_sync_publish_cv 
[gw0] PASSED tests/foreman/ui/test_repository.py::RepositoryTestCase::test_sync_publish_promote_cv 
[gw1] PASSED tests/foreman/ui/test_repository.py::RepositoryTestCase::test_sync_publish_cv 

============================================ 9 passed in 517.84 seconds =============================================
```