### PR TITLE
Automated synchronizing DRPM package via API/CLI/UI

### DIFF
--- a/robottelo/constants.py
+++ b/robottelo/constants.py
@@ -323,6 +323,9 @@ FAKE_5_YUM_REPO = u'http://{0}:{1}@rplevka.fedorapeople.org/fakerepo01/'
 FAKE_6_YUM_REPO = (
     u'https://jlsherrill.fedorapeople.org/fake-repos/needed-errata/'
 )
+FAKE_YUM_DRPM_REPO = (
+    u'https://repos.fedorapeople.org/repos/pulp/pulp/fixtures/drpm/'
+)
 FAKE_YUM_SRPM_REPO = (
     u'https://repos.fedorapeople.org/repos/pulp/pulp/fixtures/srpm/'
 )

--- a/tests/foreman/ui/test_repository.py
+++ b/tests/foreman/ui/test_repository.py
@@ -27,6 +27,7 @@ from robottelo.constants import (
     FAKE_0_PUPPET_REPO,
     FAKE_1_YUM_REPO,
     FAKE_2_YUM_REPO,
+    FAKE_YUM_DRPM_REPO,
     FAKE_YUM_SRPM_REPO,
     FEDORA22_OSTREE_REPO,
     FEDORA23_OSTREE_REPO,
@@ -922,7 +923,7 @@ class RepositoryTestCase(UITestCase):
                     )
 
     @tier2
-    def test_positive_sync(self):
+    def test_positive_srpm_sync(self):
         """Synchronize repository with SRPMs
 
         @id: 1967a540-a265-4046-b87b-627524b63688
@@ -958,7 +959,7 @@ class RepositoryTestCase(UITestCase):
         self.assertGreaterEqual(len(result.stdout), 1)
 
     @tier2
-    def test_positive_sync_publish_cv(self):
+    def test_positive_srpm_sync_publish_cv(self):
         """Synchronize repository with SRPMs, add repository to content view
         and publish content view
 
@@ -1006,7 +1007,7 @@ class RepositoryTestCase(UITestCase):
         self.assertGreaterEqual(len(result.stdout), 1)
 
     @tier2
-    def test_positive_sync_publish_promote_cv(self):
+    def test_positive_srpm_sync_publish_promote_cv(self):
         """Synchronize repository with SRPMs, add repository to content view,
         publish and promote content view to lifecycle environment
 
@@ -1049,6 +1050,145 @@ class RepositoryTestCase(UITestCase):
         result = ssh.command(
             'ls /var/lib/pulp/published/yum/https/repos/{}/{}/{}/custom/{}/{}/'
             ' | grep .src.rpm'
+            .format(
+                self.session_org.label,
+                lce.name,
+                cv_name,
+                product.label,
+                repo_name,
+            )
+        )
+        self.assertEqual(result.return_code, 0)
+        self.assertGreaterEqual(len(result.stdout), 1)
+
+    @tier2
+    def test_positive_drpm_sync(self):
+        """Synchronize repository with DRPMs
+
+        @id: 5e703d9a-ea26-4062-9d5c-d31bfbe87417
+
+        @Assert: drpms can be listed in repository
+        """
+        product = entities.Product(organization=self.session_org).create()
+        repo_name = gen_string('alphanumeric')
+        with Session(self.browser) as session:
+            self.products.search(product.name).click()
+            make_repository(
+                session,
+                name=repo_name,
+                url=FAKE_YUM_DRPM_REPO,
+            )
+            self.assertIsNotNone(self.repository.search(repo_name))
+            self.setup_navigate_syncnow(
+                session,
+                product.name,
+                repo_name,
+            )
+            self.assertTrue(self.prd_sync_is_ok(repo_name))
+        result = ssh.command(
+            'ls /var/lib/pulp/published/yum/https/repos/{}/Library'
+            '/custom/{}/{}/drpms/ | grep .drpm'
+            .format(
+                self.session_org.label,
+                product.label,
+                repo_name,
+            )
+        )
+        self.assertEqual(result.return_code, 0)
+        self.assertGreaterEqual(len(result.stdout), 1)
+
+    @tier2
+    def test_positive_drpm_sync_publish_cv(self):
+        """Synchronize repository with DRPMs, add repository to content view
+        and publish content view
+
+        @id: cffa862c-f972-4aa4-96b2-5a4513cb3eef
+
+        @Assert: drpms can be listed in content view
+        """
+        product = entities.Product(organization=self.session_org).create()
+        repo_name = gen_string('alphanumeric')
+        cv_name = gen_string('alphanumeric')
+        with Session(self.browser) as session:
+            self.products.search(product.name).click()
+            make_repository(
+                session,
+                name=repo_name,
+                url=FAKE_YUM_DRPM_REPO,
+            )
+            self.assertIsNotNone(self.repository.search(repo_name))
+            self.setup_navigate_syncnow(
+                session,
+                product.name,
+                repo_name,
+            )
+            self.assertTrue(self.prd_sync_is_ok(repo_name))
+
+            make_contentview(session, org=self.session_org.name, name=cv_name)
+            self.assertIsNotNone(self.content_views.search(cv_name))
+            self.content_views.add_remove_repos(cv_name, [repo_name])
+            self.assertIsNotNone(self.content_views.wait_until_element(
+                common_locators['alert.success_sub_form']))
+            self.content_views.publish(cv_name)
+            self.assertIsNotNone(self.content_views.wait_until_element
+                                 (common_locators['alert.success_sub_form']))
+        result = ssh.command(
+            'ls /var/lib/pulp/published/yum/https/repos/{}/content_views/{}'
+            '/1.0/custom/{}/{}/drpms/ | grep .drpm'
+            .format(
+                self.session_org.label,
+                cv_name,
+                product.label,
+                repo_name,
+            )
+        )
+        self.assertEqual(result.return_code, 0)
+        self.assertGreaterEqual(len(result.stdout), 1)
+
+    @tier2
+    def test_positive_drpm_sync_publish_promote_cv(self):
+        """Synchronize repository with DRPMs, add repository to content view,
+        publish and promote content view to lifecycle environment
+
+        @id: e33ee07c-4677-4be8-bd53-73689edfda34
+
+        @Assert: drpms can be listed in content view in proper lifecycle
+        environment
+        """
+        lce = entities.LifecycleEnvironment(
+            organization=self.session_org).create()
+        product = entities.Product(organization=self.session_org).create()
+        repo_name = gen_string('alphanumeric')
+        cv_name = gen_string('alphanumeric')
+        with Session(self.browser) as session:
+            self.products.search(product.name).click()
+            make_repository(
+                session,
+                name=repo_name,
+                url=FAKE_YUM_DRPM_REPO,
+            )
+            self.assertIsNotNone(self.repository.search(repo_name))
+            self.setup_navigate_syncnow(
+                session,
+                product.name,
+                repo_name,
+            )
+            self.assertTrue(self.prd_sync_is_ok(repo_name))
+
+            make_contentview(session, org=self.session_org.name, name=cv_name)
+            self.assertIsNotNone(self.content_views.search(cv_name))
+            self.content_views.add_remove_repos(cv_name, [repo_name])
+            self.assertIsNotNone(self.content_views.wait_until_element(
+                common_locators['alert.success_sub_form']))
+            self.content_views.publish(cv_name)
+            self.assertIsNotNone(self.content_views.wait_until_element
+                                 (common_locators['alert.success_sub_form']))
+            self.content_views.promote(cv_name, 'Version 1', lce.name)
+            self.assertIsNotNone(self.content_views.wait_until_element
+                                 (common_locators['alert.success_sub_form']))
+        result = ssh.command(
+            'ls /var/lib/pulp/published/yum/https/repos/{}/{}/{}/custom/{}/{}'
+            '/drpms/ | grep .drpm'
             .format(
                 self.session_org.label,
                 lce.name,


### PR DESCRIPTION
Closes #3852 

Test results:
```python
py.test tests/foreman/{api,cli}/test_repository.py::DRPMRepositoryTestCase -v -n 2
================================================ test session starts ================================================
platform linux2 -- Python 2.7.10, pytest-2.9.2, py-1.4.31, pluggy-0.3.1 -- /home/andrii/env/bin/python
cachedir: .cache
rootdir: /home/andrii/workspace/robottelo, inifile: 
plugins: xdist-1.13.1, repeat-0.2
[gw0] linux2 Python 2.7.10 cwd: /home/andrii/workspace/robottelo
[gw1] linux2 Python 2.7.10 cwd: /home/andrii/workspace/robottelo
[gw0] Python 2.7.10 (default, Sep  8 2015, 17:20:17)  -- [GCC 5.1.1 20150618 (Red Hat 5.1.1-4)]
[gw1] Python 2.7.10 (default, Sep  8 2015, 17:20:17)  -- [GCC 5.1.1 20150618 (Red Hat 5.1.1-4)]
gw0 [6] / gw1 [6]
scheduling tests via LoadScheduling

tests/foreman/api/test_repository.py::DRPMRepositoryTestCase::test_positive_sync_publish_promote_cv 
tests/foreman/api/test_repository.py::DRPMRepositoryTestCase::test_positive_sync 
[gw0] PASSED tests/foreman/api/test_repository.py::DRPMRepositoryTestCase::test_positive_sync 
tests/foreman/api/test_repository.py::DRPMRepositoryTestCase::test_positive_sync_publish_cv 
[gw0] PASSED tests/foreman/api/test_repository.py::DRPMRepositoryTestCase::test_positive_sync_publish_cv 
tests/foreman/cli/test_repository.py::DRPMRepositoryTestCase::test_positive_sync_publish_cv 
[gw1] PASSED tests/foreman/api/test_repository.py::DRPMRepositoryTestCase::test_positive_sync_publish_promote_cv 
[gw0] PASSED tests/foreman/cli/test_repository.py::DRPMRepositoryTestCase::test_positive_sync_publish_cv 
tests/foreman/cli/test_repository.py::DRPMRepositoryTestCase::test_positive_sync_publish_promote_cv 
tests/foreman/cli/test_repository.py::DRPMRepositoryTestCase::test_positive_sync 
[gw1] PASSED tests/foreman/cli/test_repository.py::DRPMRepositoryTestCase::test_positive_sync 
[gw0] PASSED tests/foreman/cli/test_repository.py::DRPMRepositoryTestCase::test_positive_sync_publish_promote_cv 

============================================ 6 passed in 244.08 seconds =============================================
py.test tests/foreman/ui/test_repository.py -v -n 2 -k 'test_positive_drpm'
================================================ test session starts ================================================
platform linux2 -- Python 2.7.10, pytest-2.9.2, py-1.4.31, pluggy-0.3.1 -- /home/andrii/env/bin/python
cachedir: .cache
rootdir: /home/andrii/workspace/robottelo, inifile: 
plugins: xdist-1.13.1, repeat-0.2
[gw0] linux2 Python 2.7.10 cwd: /home/andrii/workspace/robottelo
[gw1] linux2 Python 2.7.10 cwd: /home/andrii/workspace/robottelo
[gw0] Python 2.7.10 (default, Sep  8 2015, 17:20:17)  -- [GCC 5.1.1 20150618 (Red Hat 5.1.1-4)]
[gw1] Python 2.7.10 (default, Sep  8 2015, 17:20:17)  -- [GCC 5.1.1 20150618 (Red Hat 5.1.1-4)]
gw0 [3] / gw1 [3]
scheduling tests via LoadScheduling

tests/foreman/ui/test_repository.py::RepositoryTestCase::test_positive_drpm_sync 
[gw0] PASSED tests/foreman/ui/test_repository.py::RepositoryTestCase::test_positive_drpm_sync 
tests/foreman/ui/test_repository.py::RepositoryTestCase::test_positive_drpm_sync_publish_cv 
tests/foreman/ui/test_repository.py::RepositoryTestCase::test_positive_drpm_sync_publish_promote_cv 
[gw0] PASSED tests/foreman/ui/test_repository.py::RepositoryTestCase::test_positive_drpm_sync_publish_cv 
[gw1] PASSED tests/foreman/ui/test_repository.py::RepositoryTestCase::test_positive_drpm_sync_publish_promote_cv 

============================================ 3 passed in 236.30 seconds =============================================
```