### PR TITLE
Fixes #3873 - unescape + encode the unicode literals in the error messages

### DIFF
--- a/robottelo/test.py
+++ b/robottelo/test.py
@@ -180,7 +180,9 @@ class CLITestCase(TestCase):
         :param contents: contents which must be present on message
         """
         exception = raise_ctx.exception
-        error_msg = getattr(exception, 'stderr', exception.message)
+        error_msg = getattr(exception, 'stderr', exception.message).decode(
+            'unicode-escape'
+        )
         for content in contents:
             self.assertIn(content, error_msg)
 


### PR DESCRIPTION
Fixes https://github.com/SatelliteQE/robottelo/issues/3873

```bash
$ py.test -k test_negative_create_with_invalid_name test_activationkey.py
============================================================================================================================ test session starts =============================================================================================================================
platform linux2 -- Python 2.7.11, pytest-2.9.2, py-1.4.31, pluggy-0.3.1
rootdir: /home/rplevka/work/rplevka/robottelo, inifile: 
plugins: xdist-1.14
collected 48 items 

test_activationkey.py .

===================================================================================================== 47 tests deselected by '-ktest_negative_create_with_invalid_name' ======================================================================================================
================================================================================================================== 1 passed, 47 deselecte
```

Since asserting on error messages has been backported to `6.2.z`, cherry-picking this commit does not apply