### PR TITLE
added api test for hostgroup clone, related to #2476

### DIFF
--- a/tests/foreman/api/test_hostgroup.py
+++ b/tests/foreman/api/test_hostgroup.py
@@ -198,6 +198,24 @@ class HostGroupTestCase(APITestCase):
                 ).create()
                 self.assertEqual(name, hostgroup.name)
 
+    @tier1
+    def test_positive_clone(self):
+        """Create a hostgroup by cloning an existing one
+
+        @id: 44ac8b3b-9cb0-4a9e-ad9b-2c67b2411922
+
+        @assert: A hostgroup is cloned with new name
+        """
+        hostgroup = entities.HostGroup(
+            location=[self.loc],
+            organization=[self.org],
+        ).create()
+        hostgroup_cloned_name = gen_string('alpha', 6)
+        hostgroup_cloned = entities.HostGroup(
+                id=hostgroup.id
+                ).clone(data={u'name': hostgroup_cloned_name})
+        self.assertEqual(hostgroup_cloned[u'name'], hostgroup_cloned_name)
+
     @tier2
     def test_positive_create_with_parent(self):
         """Create a hostgroup with parent hostgroup specified

--- a/tests/foreman/api/test_hostgroup.py
+++ b/tests/foreman/api/test_hostgroup.py
@@ -210,11 +210,11 @@ class HostGroupTestCase(APITestCase):
             location=[self.loc],
             organization=[self.org],
         ).create()
-        hostgroup_cloned_name = gen_string('alpha', 6)
+        hostgroup_cloned_name = gen_string('alpha')
         hostgroup_cloned = entities.HostGroup(
-                id=hostgroup.id
-                ).clone(data={u'name': hostgroup_cloned_name})
-        self.assertEqual(hostgroup_cloned[u'name'], hostgroup_cloned_name)
+            id=hostgroup.id
+        ).clone(data={'name': hostgroup_cloned_name})
+        self.assertEqual(hostgroup_cloned['name'], hostgroup_cloned_name)
 
     @tier2
     def test_positive_create_with_parent(self):


### PR DESCRIPTION
test result:
```
nosetests tests/foreman/api/test_hostgroup.py:HostGroupTestCase.test_positive_clone -v
Create a hostgroup by cloning an existing one ... ok

----------------------------------------------------------------------
Ran 1 test in 14.172s

OK
 ```