### PR TITLE
Discovery rules permissions tests from UI and org/location association tests via api

### DIFF
--- a/robottelo/ui/locators/base.py
+++ b/robottelo/ui/locators/base.py
@@ -1825,6 +1825,8 @@ locators = LocatorDict({
     # Discovery Rules
     "discoveryrules.new": (
         By.XPATH, "//a[@data-id='aid_discovery_rules_new']"),
+    "discoveryrules.disabled_name": (
+        By.XPATH, "//a[@disabled='disabled']/span[contains(., '%s')]"),
     "discoveryrules.name": (
         By.XPATH, "//input[@id='discovery_rule_name']"),
     "discoveryrules.search": (

--- a/tests/foreman/api/test_discoveryrule.py
+++ b/tests/foreman/api/test_discoveryrule.py
@@ -19,7 +19,7 @@ from fauxfactory import gen_choice, gen_integer, gen_string
 from nailgun import entities
 from requests.exceptions import HTTPError
 from robottelo.datafactory import valid_data_list
-from robottelo.decorators import run_only_on, stubbed, tier1, tier2
+from robottelo.decorators import run_only_on, tier1, tier2
 from robottelo.test import APITestCase
 
 
@@ -78,7 +78,6 @@ class DiscoveryRuleTestCase(APITestCase):
                 )
 
     @run_only_on('sat')
-    @stubbed()
     @tier1
     def test_positive_create_with_org_loc(self):
         """Create discovery rule by associating org and location
@@ -86,9 +85,18 @@ class DiscoveryRuleTestCase(APITestCase):
         @id: 121e0a30-8a24-47d7-974d-998886ed1ea7
 
         @Assert: Rule was created and with given org & location.
-
-        @caseautomation: notautomated
         """
+        org = entities.Organization().create()
+        loc = entities.Location().create()
+        hostgroup = entities.HostGroup(organization=[org]).create()
+        discovery_rule = entities.DiscoveryRule(
+            hostgroup=hostgroup,
+            search_='cpu_count = 1',
+            organization=[org],
+            location=[loc],
+        ).create()
+        self.assertEqual(org.name, discovery_rule.organization[0].read().name)
+        self.assertEqual(loc.name, discovery_rule.location[0].read().name)
 
     @tier1
     @run_only_on('sat')
@@ -164,7 +172,6 @@ class DiscoveryRuleTestCase(APITestCase):
                 self.assertEqual(discovery_rule.name, name)
 
     @run_only_on('sat')
-    @stubbed()
     @tier1
     def test_positive_update_org_loc(self):
         """Update org and location of selected discovery rule
@@ -172,9 +179,21 @@ class DiscoveryRuleTestCase(APITestCase):
         @id: 0f8ec302-f9de-4713-87b7-0f1aca515149
 
         @Assert: Rule was updated and with given org & location.
-
-        @caseautomation: notautomated
         """
+        org = entities.Organization().create()
+        loc = entities.Location().create()
+        hostgroup = entities.HostGroup(organization=[org]).create()
+        discovery_rule = self.discovery_rule.create()
+        discovery_rule.organization = [org]
+        discovery_rule.location = [loc]
+        discovery_rule.hostgroup = hostgroup
+        discovery_rule = discovery_rule.update([
+            'organization',
+            'location',
+            'hostgroup',
+        ])
+        self.assertEqual(org.name, discovery_rule.organization[0].read().name)
+        self.assertEqual(loc.name, discovery_rule.location[0].read().name)
 
     @tier1
     def test_positive_update_search_rule(self):


### PR DESCRIPTION
Test Results:
**Org Tests**

```console
]# py.test -v tests/foreman/api/test_discoveryrule.py::DiscoveryRuleTestCase -k test_positive_create_with_org_loc================================================================ test session starts =================================================================
platform linux2 -- Python 2.7.12, pytest-3.0.2, py-1.4.31, pluggy-0.3.1 -- /usr/bin/python
cachedir: .cache
rootdir: /home/sghai/QE/robottelo, inifile: 
collected 12 items 

tests/foreman/api/test_discoveryrule.py::DiscoveryRuleTestCase::test_positive_create_with_org_loc <- robottelo/decorators/__init__.py PASSED

================================================================ 11 tests deselected =================================================================
====================================================== 1 passed, 11 deselected in 20.51 seconds ======================================================
```
```console
[ robottelo]# py.test -v tests/foreman/api/test_discoveryrule.py::DiscoveryRuleTestCase -k test_positive_update_org_loc================================================================ test session starts =================================================================
platform linux2 -- Python 2.7.12, pytest-3.0.2, py-1.4.31, pluggy-0.3.1 -- /usr/bin/python
cachedir: .cache
rootdir: /home/sghai/QE/robottelo, inifile: 
collected 12 items 

tests/foreman/api/test_discoveryrule.py::DiscoveryRuleTestCase::test_positive_update_org_loc <- robottelo/decorators/__init__.py PASSED

================================================================ 11 tests deselected =================================================================
====================================================== 1 passed, 11 deselected in 23.75 seconds ======================================================
```

**Roles Tests**
```console
robottelo]$ py.test -v tests/foreman/ui/test_discoveryrule.py::DiscoveryRuleReaderRoleTestCase
================================================================ test session starts =================================================================
platform linux2 -- Python 2.7.12, pytest-3.0.2, py-1.4.31, pluggy-0.3.1 -- /usr/bin/python
cachedir: .cache
rootdir: /home/sghai/QE/robottelo, inifile: 
collected 3 items 

tests/foreman/ui/test_discoveryrule.py::DiscoveryRuleReaderRoleTestCase::test_negative_delete_rule_with_non_admin_user <- robottelo/decorators/__init__.py PASSED
tests/foreman/ui/test_discoveryrule.py::DiscoveryRuleReaderRoleTestCase::test_positive_list_host_based_on_rule_search_query <- robottelo/decorators/__init__.py SKIPPED
tests/foreman/ui/test_discoveryrule.py::DiscoveryRuleReaderRoleTestCase::test_positive_view_existing_rule_with_non_admin_user <- robottelo/decorators/__init__.py PASSED

======================================================== 2 passed, 1 skipped in 68.74 seconds ========================================================
```
```console
robottelo]$ py.test -v tests/foreman/ui/test_discoveryrule.py::DiscoveryRuleManagerRoleTestCase
================================================================ test session starts =================================================================
platform linux2 -- Python 2.7.12, pytest-3.0.2, py-1.4.31, pluggy-0.3.1 -- /usr/bin/python
cachedir: .cache
rootdir: /home/sghai/QE/robottelo, inifile: 
collected 2 items 

tests/foreman/ui/test_discoveryrule.py::DiscoveryRuleManagerRoleTestCase::test_positive_create_rule_with_non_admin_user <- robottelo/decorators/__init__.py PASSED
tests/foreman/ui/test_discoveryrule.py::DiscoveryRuleManagerRoleTestCase::test_positive_delete_rule_with_non_admin_user <- robottelo/decorators/__init__.py PASSED

============================================================= 2 passed in 76.72 seconds ==============================================================
```