### PR TITLE
Fix lru_cache import path; fix travis failure

### DIFF
--- a/robottelo/helpers.py
+++ b/robottelo/helpers.py
@@ -18,7 +18,7 @@ from robottelo.config import settings
 if six.PY3:  # pragma: no cover
     from functools import lru_cache  # noqa
 else:  # pragma: no cover
-    from cachetools import lru_cache  # noqa
+    from cachetools.func import lru_cache  # noqa
 
 LOGGER = logging.getLogger(__name__)
 

--- a/robottelo/host_info.py
+++ b/robottelo/host_info.py
@@ -2,7 +2,7 @@
 import logging
 
 import re
-from cachetools import lru_cache
+from robottelo.helpers import lru_cache
 
 from robottelo import ssh
 LOGGER = logging.getLogger(__name__)


### PR DESCRIPTION
Latest sphinx release 1.4.8 (altogether with new cachetools release 2.0.0, both released 1-3 days ago) uncovered issue with wrong import path - `lru_cache` from `cachetools` is located under `cachetools.func` path, not just `cachetools`. Fixing this to make green travis builds