### PR TITLE
[needs cherrypick] logging - added py.test worker information to the log

### DIFF
--- a/robottelo/test.py
+++ b/robottelo/test.py
@@ -110,7 +110,8 @@ class TestCase(unittest2.TestCase):
         self.worker_id = worker_id
         if worker_id != 'master':
             formatter = logging.Formatter(
-                fmt='%(asctime)s - %(name)s - %(levelname)s - %(message)s',
+                fmt='%(asctime)s - {0} - %(name)s - %(levelname)s -'
+                ' %(message)s'.format(worker_id),
                 datefmt='%Y-%m-%d %H:%M:%S'
             )
             handler = logging.FileHandler(


### PR DESCRIPTION
We lost the worker information while joining the individual worker logs into one.
This will add a new field just after the timestamp:
```
2016-10-04 14:51:06 - gw2 - robottelo - DEBUG - Started Test: UserTestCase/test_negative_create_with_blank_authorized_by_full
```

before:
```
2016-10-04 14:49:53 - robottelo - DEBUG - Started Test: UserTestCase/test_negative_create_with_empty_email
```

I plan to use this piece of information for visualizing the logs in a form of a timeline per worker in order to better debug parallel tasks (race condition, etc.)