### PR TITLE
Fix end_to_end tests - GOOGLE_CHROME_REPO doesn't exists anymore.

### DIFF
--- a/robottelo/constants.py
+++ b/robottelo/constants.py
@@ -318,7 +318,9 @@ FILTER_TYPE = {
 }
 
 DOCKER_REGISTRY_HUB = u'https://registry-1.docker.io'
-GOOGLE_CHROME_REPO = u'http://dl.google.com/linux/chrome/rpm/stable/x86_64'
+CUSTOM_RPM_REPO = (
+    u'http://repos.fedorapeople.org/repos/pulp/pulp/fixtures/rpm/'
+)
 FAKE_0_YUM_REPO = u'http://inecas.fedorapeople.org/fakerepos/zoo/'
 FAKE_1_YUM_REPO = u'http://inecas.fedorapeople.org/fakerepos/zoo3/'
 FAKE_2_YUM_REPO = u'http://inecas.fedorapeople.org/fakerepos/zoo2/'

--- a/tests/foreman/endtoend/test_api_endtoend.py
+++ b/tests/foreman/endtoend/test_api_endtoend.py
@@ -31,7 +31,7 @@ from robottelo.constants import (
     DEFAULT_ORG,
     DEFAULT_SUBSCRIPTION_NAME,
     FAKE_0_PUPPET_REPO,
-    GOOGLE_CHROME_REPO,
+    CUSTOM_RPM_REPO,
     PRDS,
     REPOS,
     REPOSET,
@@ -992,7 +992,7 @@ class EndToEndTestCase(TestCase, ClientProvisioningMixin):
             server_config,
             product=prod,
             content_type=u'yum',
-            url=GOOGLE_CHROME_REPO
+            url=CUSTOM_RPM_REPO
         ).create()
         repositories.append(repo1)
 

--- a/tests/foreman/endtoend/test_cli_endtoend.py
+++ b/tests/foreman/endtoend/test_cli_endtoend.py
@@ -42,7 +42,7 @@ from robottelo.constants import (
     DEFAULT_ORG,
     DEFAULT_SUBSCRIPTION_NAME,
     FAKE_0_PUPPET_REPO,
-    GOOGLE_CHROME_REPO,
+    CUSTOM_RPM_REPO,
     PRDS,
     REPOS,
     REPOSET,
@@ -173,7 +173,7 @@ class EndToEndTestCase(CLITestCase, ClientProvisioningMixin):
                 u'name': gen_alphanumeric(),
                 u'product-id': product['id'],
                 u'publish-via-http': u'true',
-                u'url': GOOGLE_CHROME_REPO,
+                u'url': CUSTOM_RPM_REPO,
             }
         )
         repositories.append(yum_repo)

--- a/tests/foreman/endtoend/test_ui_endtoend.py
+++ b/tests/foreman/endtoend/test_ui_endtoend.py
@@ -28,7 +28,7 @@ from robottelo.constants import (
     DOMAIN,
     FAKE_0_PUPPET_REPO,
     FOREMAN_PROVIDERS,
-    GOOGLE_CHROME_REPO,
+    CUSTOM_RPM_REPO,
     LIBVIRT_RESOURCE_URL,
     PRDS,
     REPOS,
@@ -196,7 +196,7 @@ class EndToEndTestCase(UITestCase, ClientProvisioningMixin):
             make_repository(
                 session,
                 name=yum_repository_name,
-                url=GOOGLE_CHROME_REPO
+                url=CUSTOM_RPM_REPO
             )
             self.assertIsNotNone(self.repository.search(yum_repository_name))
 


### PR DESCRIPTION
Google Chrome RPM repo is returning 404, Google may shutdown the or changed the URL.

Replacing with Pulp/fixture/rpm/ repo as CUSTOM_RPM_REPO for endtoend tests