### PR TITLE
Fix lru_cache import path

### DIFF
--- a/robottelo/helpers.py
+++ b/robottelo/helpers.py
@@ -18,7 +18,7 @@ from robottelo.config import settings
 if six.PY3:  # pragma: no cover
     from functools import lru_cache  # noqa
 else:  # pragma: no cover
-    from cachetools import lru_cache  # noqa
+    from cachetools.func import lru_cache  # noqa
 
 LOGGER = logging.getLogger(__name__)
 


### PR DESCRIPTION
Newer version of `cachetools` requires this change for the `6.2.z` branch.