### PR TITLE
[6.1.z] fix nonexistent rhel65 image

### DIFF
--- a/robottelo/constants.py
+++ b/robottelo/constants.py
@@ -16,6 +16,9 @@ BZ_CLOSED_STATUSES = [
     'CLOSED'
 ]
 
+DISTRO_RHEL6 = "rhel68"
+DISTRO_RHEL7 = "rhel72"
+
 FOREMAN_PROVIDERS = {
     'libvirt': 'Libvirt',
     'rhev': 'RHEV',

--- a/robottelo/vm.py
+++ b/robottelo/vm.py
@@ -15,14 +15,12 @@ import time
 
 from robottelo import ssh
 from robottelo.config import settings
+from robottelo.constants import DISTRO_RHEL6, DISTRO_RHEL7
 from robottelo.helpers import install_katello_ca, remove_katello_ca
 
 BASE_IMAGES = (
-    'rhel65',
-    'rhel66',
-    'rhel67',
-    'rhel70',
-    'rhel71',
+    DISTRO_RHEL6,
+    DISTRO_RHEL7,
 )
 
 logger = logging.getLogger(__name__)
@@ -402,10 +400,10 @@ class VirtualMachine(object):
 
         # Red Hat Access Insights requires RHEL 6/7 repo and it is not
         # possible to sync the repo during the tests, Adding repo file.
-        if rhel_distro == 'rhel67':
+        if rhel_distro == DISTRO_RHEL6:
             rhel_repo = settings.rhel6_repo
             insights_repo = settings.rhai.insights_client_el6repo
-        if rhel_distro == 'rhel71':
+        if rhel_distro == DISTRO_RHEL7:
             rhel_repo = settings.rhel7_repo
             insights_repo = settings.rhai.insights_client_el7repo
 

--- a/tests/foreman/cli/test_activationkey.py
+++ b/tests/foreman/cli/test_activationkey.py
@@ -21,6 +21,7 @@ from robottelo.cli.lifecycleenvironment import LifecycleEnvironment
 from robottelo.cli.repository import Repository
 from robottelo.cli.subscription import Subscription
 from robottelo.constants import FAKE_0_YUM_REPO, PRDS, REPOS, REPOSET
+from robottelo.constants import DISTRO_RHEL6
 from robottelo.datafactory import valid_data_list, invalid_values_list
 from robottelo.decorators import (
     run_only_on,
@@ -575,8 +576,8 @@ class ActivationKeyTestCase(CLITestCase):
             u'unlimited-content-hosts': '0',
             u'max-content-hosts': '1',
         })
-        with VirtualMachine(distro='rhel65') as vm1:
-            with VirtualMachine(distro='rhel65') as vm2:
+        with VirtualMachine(distro=DISTRO_RHEL6) as vm1:
+            with VirtualMachine(distro=DISTRO_RHEL6) as vm2:
                 vm1.install_katello_ca()
                 result = vm1.register_contenthost(
                     new_ak['name'], self.org['label'])
@@ -788,7 +789,7 @@ class ActivationKeyTestCase(CLITestCase):
             })
             for _ in range(2)
         ]
-        with VirtualMachine(distro='rhel65') as vm:
+        with VirtualMachine(distro=DISTRO_RHEL6) as vm:
             vm.install_katello_ca()
             for i in range(2):
                 result = vm.register_contenthost(

--- a/tests/foreman/cli/test_contenthost.py
+++ b/tests/foreman/cli/test_contenthost.py
@@ -14,6 +14,7 @@ from robottelo.cli.factory import (
 )
 from robottelo.cli.contenthost import ContentHost
 from robottelo.cli.contentview import ContentView
+from robottelo.constants import DISTRO_RHEL7
 from robottelo.cli.lifecycleenvironment import LifecycleEnvironment
 from robottelo.constants import (
     FAKE_0_CUSTOM_PACKAGE,
@@ -406,7 +407,7 @@ class ContentHostTestCase(CLITestCase):
 
         @assert: Content host successfully registered to appropriate org
         """
-        with VirtualMachine(distro='rhel71') as client:
+        with VirtualMachine(distro=DISTRO_RHEL7) as client:
             client.install_katello_ca()
             result = client.run(
                 u'subscription-manager register --org {0} '
@@ -434,7 +435,7 @@ class ContentHostTestCase(CLITestCase):
             'lifecycle-environment-id': self.NEW_LIFECYCLE['id'],
             'organization-id': self.NEW_ORG['id'],
         })
-        with VirtualMachine(distro='rhel71') as client:
+        with VirtualMachine(distro=DISTRO_RHEL7) as client:
             client.install_katello_ca()
             client.register_contenthost(
                 activation_key['name'],
@@ -464,7 +465,7 @@ class ContentHostTestCase(CLITestCase):
             'lifecycle-environment-id': self.NEW_LIFECYCLE['id'],
             'organization-id': self.NEW_ORG['id'],
         })
-        with VirtualMachine(distro='rhel71') as client:
+        with VirtualMachine(distro=DISTRO_RHEL7) as client:
             client.install_katello_ca()
             client.register_contenthost(
                 activation_key['name'],
@@ -488,7 +489,7 @@ class ContentHostTestCase(CLITestCase):
             'lifecycle-environment-id': self.NEW_LIFECYCLE['id'],
             'organization-id': self.NEW_ORG['id'],
         })
-        with VirtualMachine(distro='rhel71') as client:
+        with VirtualMachine(distro=DISTRO_RHEL7) as client:
             client.install_katello_ca()
             client.register_contenthost(
                 activation_key['name'],

--- a/tests/foreman/longrun/test_inc_updates.py
+++ b/tests/foreman/longrun/test_inc_updates.py
@@ -13,7 +13,7 @@ from robottelo.api.utils import (
     enable_rhrepo_and_fetchid, promote, upload_manifest
 )
 from robottelo.cli.contentview import ContentView as ContentViewCLI
-from robottelo.constants import PRD_SETS
+from robottelo.constants import PRD_SETS, DISTRO_RHEL6
 from robottelo.decorators import (
     run_only_on,
     skip_if_bug_open,
@@ -179,7 +179,7 @@ class IncrementalUpdateTestCase(TestCase):
         # Register the first vm with rhel_6_ak and the other two vms with
         # rhel_6_partial_ak
         cls.vm = [
-            VirtualMachine(distro='rhel67', tag='incupdate')
+            VirtualMachine(distro=DISTRO_RHEL6, tag='incupdate')
             for _ in range(3)
         ]
         cls.setup_vm(cls.vm[0], rhel_6_ak.name, cls.org.label)

--- a/tests/foreman/longrun/test_oscap.py
+++ b/tests/foreman/longrun/test_oscap.py
@@ -11,6 +11,8 @@ from robottelo.config import settings
 from robottelo.constants import (
     ANY_CONTEXT,
     DEFAULT_SUBSCRIPTION_NAME,
+    DISTRO_RHEL6,
+    DISTRO_RHEL7,
     OSCAP_DEFAULT_CONTENT,
     OSCAP_PERIOD,
     OSCAP_PROFILE,
@@ -156,12 +158,12 @@ class OpenScapTestCase(UITestCase):
         ]
         vm_values = [
             {
-                'distro': 'rhel67',
+                'distro': DISTRO_RHEL6,
                 'hgrp': hgrp6_name,
                 'rhel_repo': rhel6_repo,
             },
             {
-                'distro': 'rhel71',
+                'distro': DISTRO_RHEL7,
                 'hgrp': hgrp7_name,
                 'rhel_repo': rhel7_repo,
             },

--- a/tests/foreman/rhai/test_rhai.py
+++ b/tests/foreman/rhai/test_rhai.py
@@ -1,13 +1,13 @@
 """Tests for Red Hat Access Insights"""
 
 import time
-
 from fauxfactory import gen_string
 from nailgun import entities
 from robottelo import manifests
 from robottelo.api.utils import upload_manifest
 from robottelo.constants import DEFAULT_SUBSCRIPTION_NAME
 from robottelo.decorators import skip_if_not_set
+from robottelo.constants import DISTRO_RHEL6, DISTRO_RHEL7
 from robottelo.test import UITestCase
 from robottelo.ui.locators import locators
 from robottelo.ui.navigator import Navigator
@@ -67,10 +67,10 @@ class RHAITestCase(UITestCase):
 
         """
         # Register a VM to Access Insights Service
-        with VirtualMachine(distro='rhel67') as vm:
+        with VirtualMachine(distro=DISTRO_RHEL6) as vm:
             try:
                 vm.configure_rhai_client(self.ak_name, self.org_label,
-                                         'rhel67')
+                                         DISTRO_RHEL6)
 
                 with Session(self.browser) as session:
                     # view clients registered to Red Hat Access Insights
@@ -119,10 +119,10 @@ class RHAITestCase(UITestCase):
 
         """
         # Register a VM to Access Insights Service
-        with VirtualMachine(distro='rhel71') as vm:
+        with VirtualMachine(distro=DISTRO_RHEL7) as vm:
             try:
                 vm.configure_rhai_client(self.ak_name, self.org_label,
-                                         'rhel71')
+                                         DISTRO_RHEL7)
 
                 with Session(self.browser) as session:
                     session.nav.go_to_select_org(self.org_name)

--- a/tests/foreman/rhai/test_rhai_client.py
+++ b/tests/foreman/rhai/test_rhai_client.py
@@ -4,7 +4,7 @@ from fauxfactory import gen_string
 from nailgun import entities
 from robottelo import manifests
 from robottelo.api.utils import upload_manifest
-from robottelo.constants import DEFAULT_SUBSCRIPTION_NAME
+from robottelo.constants import DEFAULT_SUBSCRIPTION_NAME, DISTRO_RHEL6
 from robottelo.decorators import skip_if_not_set
 from robottelo.test import TestCase
 from robottelo.vm import VirtualMachine
@@ -63,8 +63,9 @@ class RHAIClientTestCase(TestCase):
         @Assert: 'redhat-access-insights --test-connection' should return
         zero on a successfully registered machine to RHAI service
         """
-        with VirtualMachine(distro='rhel67') as vm:
-            vm.configure_rhai_client(self.ak_name, self.org_label, 'rhel67')
+        with VirtualMachine(distro=DISTRO_RHEL6) as vm:
+            vm.configure_rhai_client(self.ak_name, self.org_label,
+                                     DISTRO_RHEL6)
             test_connection = vm.run(
                 'redhat-access-insights --test-connection')
             self.logger.info('Return code for --test-connection {0}'.format(

--- a/tests/foreman/smoke/test_ui_smoke.py
+++ b/tests/foreman/smoke/test_ui_smoke.py
@@ -8,6 +8,7 @@ from robottelo.constants import (
     DEFAULT_LOC,
     DEFAULT_ORG,
     DEFAULT_SUBSCRIPTION_NAME,
+    DISTRO_RHEL6,
     DOMAIN,
     FAKE_0_PUPPET_REPO,
     FOREMAN_PROVIDERS,
@@ -467,7 +468,7 @@ class SmokeTestCase(UITestCase):
                     common_locators['alert.success']
                 ))
             # Create VM
-            with VirtualMachine(distro='rhel67') as vm:
+            with VirtualMachine(distro=DISTRO_RHEL6) as vm:
                 vm.install_katello_ca()
                 vm.register_contenthost(activation_key_name, org_name)
                 vm.configure_puppet(rhel6_repo)

--- a/tests/foreman/ui/test_activationkey.py
+++ b/tests/foreman/ui/test_activationkey.py
@@ -13,6 +13,7 @@ from robottelo.api.utils import (
 from robottelo.constants import (
     DEFAULT_CV,
     DEFAULT_SUBSCRIPTION_NAME,
+    DISTRO_RHEL6,
     ENVIRONMENT,
     FAKE_1_YUM_REPO,
     FAKE_2_YUM_REPO,
@@ -45,7 +46,7 @@ class ActivationKeyTestCase(UITestCase):
         cls.base_key_name = entities.ActivationKey(
             organization=cls.organization
         ).create().name
-        cls.vm_distro = 'rhel65'
+        cls.vm_distro = DISTRO_RHEL6
 
     # pylint: disable=too-many-arguments
     def create_sync_custom_repo(self, product_name=None, repo_name=None,

--- a/tests/foreman/ui/test_gpgkey.py
+++ b/tests/foreman/ui/test_gpgkey.py
@@ -6,6 +6,7 @@ from fauxfactory import gen_string
 from nailgun import entities
 from robottelo.config import settings
 from robottelo.constants import (
+    DISTRO_RHEL6,
     FAKE_1_YUM_REPO,
     FAKE_2_YUM_REPO,
     REPO_DISCOVERY_URL,
@@ -465,7 +466,7 @@ class GPGKey(UITestCase):
                 break
         # Create VM
         package_name = 'cow'
-        with VirtualMachine(distro='rhel66') as vm:
+        with VirtualMachine(distro=DISTRO_RHEL6) as vm:
             # Download and Install rpm
             result = vm.run(
                 "wget -nd -r -l1 --no-parent -A '*.noarch.rpm' http://{0}/pub/"


### PR DESCRIPTION
- fix nonexisting rhel65 image
- update rhel6{6,7} to rhel68 image where applicable

(Fixes #3899)