### PR TITLE
Add initial coverage for discovered hosts in CLI

### DIFF
--- a/docs/api/robottelo.cli.rst
+++ b/docs/api/robottelo.cli.rst
@@ -35,6 +35,16 @@ Submodules:
 
 .. automodule:: robottelo.cli.contentview
 
+:mod:`robottelo.cli.discoveredhost`
+-----------------------------------
+
+.. automodule:: robottelo.cli.discoveredhost
+
+:mod:`robottelo.cli.discoveryrule`
+----------------------------------
+
+.. automodule:: robottelo.cli.discoveryrule
+
 :mod:`robottelo.cli.docker`
 ---------------------------
 

--- a/robottelo/cli/discoveredhost.py
+++ b/robottelo/cli/discoveredhost.py
@@ -1,0 +1,31 @@
+# -*- encoding: utf-8 -*-
+"""
+Usage::
+
+    hammer discovery [OPTIONS] SUBCOMMAND [ARG] ...
+
+Parameters::
+
+    SUBCOMMAND                    subcommand
+    [ARG] ...                     subcommand arguments
+
+Subcommands::
+
+    auto-provision                Auto provision a host
+    delete                        Delete a discovered host
+    facts                         Show a discovered host
+    info                          Show a discovered host
+    list                          List all discovered hosts
+    provision                     Provision a discovered host
+    reboot                        Reboot a host
+    refresh-facts                 Refresh the facts of a host
+"""
+
+
+from robottelo.cli.base import Base
+
+
+class DiscoveredHost(Base):
+    """Manipulates Discovery Hosts"""
+
+    command_base = 'discovery'

--- a/robottelo/cli/settings.py
+++ b/robottelo/cli/settings.py
@@ -13,7 +13,6 @@ Subcommands::
 
     list                          List all settings
     set                           Update a setting
-
 """
 
 from robottelo.cli.base import Base

--- a/robottelo/cli/template.py
+++ b/robottelo/cli/template.py
@@ -74,3 +74,10 @@ class Template(Base):
         cls.command_sub = 'clone'
         return cls.execute(
             cls._construct_command(options), output_format='csv')
+
+    @classmethod
+    def build_pxe_default(cls, options=None):
+        """Build PXE default template"""
+        cls.command_sub = 'build-pxe-default'
+        return cls.execute(
+            cls._construct_command(options), output_format='csv')


### PR DESCRIPTION
All functionality implemented through CLI and testes against 6.2.x only as 6.3 infrastructure is not ready:

```
nosetests tests/foreman/cli/test_discoveredhost.py
SSSSSSSSSSS..SSSS
----------------------------------------------------------------------
Ran 17 tests in 238.576s

OK (SKIP=15)
```
