### PR TITLE
Added UI AK list associated hosts test

### DIFF
--- a/robottelo/ui/activationkey.py
+++ b/robottelo/ui/activationkey.py
@@ -59,6 +59,16 @@ class ActivationKey(Base):
             (strategy, value % subscription_name))
         return element
 
+    def search_host(self, ak_name, host_name):
+        """Search for host activated by selected activation key."""
+        self.click(self.search(ak_name))
+        self.click(tab_locators['ak.associations'])
+        self.click(locators['ak.content_hosts'])
+        self.assign_value(common_locators['kt_table_search'], host_name)
+        self.click(common_locators['kt_table_search_button'])
+        return self.wait_until_element(
+            locators['ak.content_host_select'] % host_name)
+
     def update(self, name, new_name=None, description=None,
                limit=None, content_view=None, env=None):
         """Updates an existing activation key."""

--- a/robottelo/ui/locators/base.py
+++ b/robottelo/ui/locators/base.py
@@ -1293,9 +1293,13 @@ locators = LocatorDict({
     "ak.content_host_name": (
         By.XPATH,
         "//tr[@ng-controller='ContentHostStatusController']/td/a"),
+    "ak.content_host_select": (
+        By.XPATH,
+        ("//tr[@ng-controller='ContentHostStatusController']/td"
+         "/a[contains(., '%s')]")),
     "ak.prd_content.edit_repo": (
         By.XPATH,
-        ("//u[contains(.,'%s')]/../..//i[contains(@class,'fa-edit')]")),
+        "//u[contains(.,'%s')]/../..//i[contains(@class,'fa-edit')]"),
     "ak.prd_content.select_repo": (
         By.XPATH,
         "//u[contains(.,'%s')]/../../div/form/div/select"),

--- a/tests/foreman/ui/test_activationkey.py
+++ b/tests/foreman/ui/test_activationkey.py
@@ -25,13 +25,25 @@ from robottelo.api.utils import (
     promote,
     upload_manifest,
 )
+from robottelo.cli.factory import (
+    activationkey_add_subscription_to_repo,
+    make_activation_key,
+    make_content_view,
+    make_lifecycle_environment,
+    make_org,
+    setup_org_for_a_rh_repo,
+)
 from robottelo.constants import (
     DEFAULT_CV,
     DEFAULT_SUBSCRIPTION_NAME,
     DISTRO_RHEL6,
+    DISTRO_RHEL7,
     ENVIRONMENT,
     FAKE_1_YUM_REPO,
     FAKE_2_YUM_REPO,
+    PRDS,
+    REPOSET,
+    REPOS,
     REPO_TYPE,
 )
 from robottelo.datafactory import invalid_names_list, valid_data_list
@@ -1179,3 +1191,75 @@ class ActivationKeyTestCase(UITestCase):
                         self.activationkey.search(self.base_key_name))
                     self.activationkey.copy(self.base_key_name, new_name)
                     self.assertIsNone(self.activationkey.search(new_name))
+
+    @run_in_one_thread
+    @tier3
+    def test_positive_list_hosts(self):
+        """Verify only hosts registered by specific activation key are listed
+        on Activation Key -> Associations -> Content Hosts page
+
+        @id: 9364bfcc-ef69-4183-9ca8-e2904b3f4068
+
+        @Steps:
+        1. Create 2 activation keys
+        2. Register 2 hosts, one for each activation key
+
+        @Assert: Activation Key -> Associations -> Content Hosts page should
+        show only hosts registered via the key
+
+        @BZ: 1372826
+        """
+        org = make_org()
+        env = make_lifecycle_environment({'organization-id': org['id']})
+        content_view = make_content_view({'organization-id': org['id']})
+        activation_key = make_activation_key({
+            'lifecycle-environment-id': env['id'],
+            'organization-id': org['id'],
+        })
+        setup_org_for_a_rh_repo({
+            'product': PRDS['rhel'],
+            'repository-set': REPOSET['rhst7'],
+            'repository': REPOS['rhst7']['name'],
+            'organization-id': org['id'],
+            'content-view-id': content_view['id'],
+            'lifecycle-environment-id': env['id'],
+            'activationkey-id': activation_key['id'],
+        })
+        another_ak = make_activation_key({
+            'content-view-id': content_view['id'],
+            'lifecycle-environment-id': env['id'],
+            'organization-id': org['id'],
+        })
+        activationkey_add_subscription_to_repo({
+            'activationkey-id': another_ak['id'],
+            'organization-id': org['id'],
+            'subscription': DEFAULT_SUBSCRIPTION_NAME,
+        })
+        with VirtualMachine(distro=DISTRO_RHEL7) as client1, VirtualMachine(
+                distro=DISTRO_RHEL7) as client2:
+            client1.install_katello_ca()
+            client2.install_katello_ca()
+            result = client1.register_contenthost(
+                org['label'], activation_key['name'])
+            self.assertEqual(result.return_code, 0)
+            result = client2.register_contenthost(
+                org['label'], another_ak['name'])
+            self.assertEqual(result.return_code, 0)
+            with Session(self.browser) as session:
+                set_context(session, org=org['name'])
+                self.assertIsNotNone(
+                    self.activationkey.search_host(
+                        activation_key['name'], client1.hostname)
+                )
+                self.assertIsNone(
+                    self.activationkey.search_host(
+                        activation_key['name'], client2.hostname)
+                )
+                self.assertIsNotNone(
+                    self.activationkey.search_host(
+                        another_ak['name'], client2.hostname)
+                )
+                self.assertIsNone(
+                    self.activationkey.search_host(
+                        another_ak['name'], client1.hostname)
+                )


### PR DESCRIPTION
Closes #3919

Test results:
```python
py.test tests/foreman/ui/test_activationkey.py -v -k 'test_positive_list_hosts'
================================================ test session starts ================================================
platform linux2 -- Python 2.7.10, pytest-3.0.3, py-1.4.31, pluggy-0.4.0 -- /home/andrii/env/bin/python
cachedir: .cache
rootdir: /home/andrii/workspace/robottelo, inifile: 
plugins: xdist-1.13.1, repeat-0.2
collected 33 items 

tests/foreman/ui/test_activationkey.py::ActivationKeyTestCase::test_positive_list_hosts PASSED

================================================ 32 tests deselected ================================================
===================================== 1 passed, 32 deselected in 416.58 seconds =====================================
```