### PR TITLE
#3586 ui cv publish/promote with rh custom spin

### DIFF
--- a/tests/foreman/ui/test_contentview.py
+++ b/tests/foreman/ui/test_contentview.py
@@ -924,16 +924,13 @@ class ContentViewTestCase(UITestCase):
             'releasever': None,
         }
         env_name = gen_string('alpha')
-        strategy, value = locators['content_env.select_name']
         # Create new org to import manifest
         org = entities.Organization().create()
         with Session(self.browser) as session:
             make_lifecycle_environment(
                 session, org=org.name, name=env_name)
-
             self.assertIsNotNone(session.nav.wait_until_element(
-                (strategy, value % env_name)))
-
+                locators['content_env.select_name'] % env_name))
             self.setup_to_create_cv(rh_repo=rh_repo, org_id=org.id)
             # Create content-view
             make_contentview(session, org=org.name, name=cv_name)
@@ -942,7 +939,6 @@ class ContentViewTestCase(UITestCase):
             self.content_views.add_remove_repos(cv_name, [rh_repo['name']])
             self.assertIsNotNone(self.content_views.wait_until_element(
                 common_locators['alert.success_sub_form']))
-
             # add a filter
             self.content_views.add_filter(
                 cv_name,
@@ -951,14 +947,20 @@ class ContentViewTestCase(UITestCase):
                 FILTER_TYPE['exclude'],
             )
             # assert the added filter visible
-            self.assertIsNotNone(self.content_views.search_filter(cv_name, filter_name))
+            self.assertIsNotNone(
+                self.content_views.search_filter(cv_name, filter_name))
             # exclude some package in the created filter
-            self.content_views.add_packages_to_filter(cv_name, filter_name, ['gofer'], ['All Versions'], [None], [None])
-
+            self.content_views.add_packages_to_filter(
+                cv_name,
+                filter_name,
+                ['gofer'],
+                ['All Versions'],
+                [None],
+                [None]
+            )
             self.content_views.publish(cv_name)
             self.assertIsNotNone(self.content_views.wait_until_element(
                 common_locators['alert.success_sub_form']))
-
             self.content_views.promote(cv_name, 'Version 1', env_name)
             self.assertIsNotNone(self.content_views.wait_until_element(
                 common_locators['alert.success_sub_form']))
@@ -1093,7 +1095,6 @@ class ContentViewTestCase(UITestCase):
 
         @CaseLevel: System
         """
-
         cv_name = gen_string('alpha')
         filter_name = gen_string('alpha')
         rh_repo = {
@@ -1104,17 +1105,14 @@ class ContentViewTestCase(UITestCase):
             'releasever': None,
         }
         env_name = gen_string('alpha')
-        strategy, value = locators['content_env.select_name']
         # Create new org to import manifest
         org = entities.Organization().create()
         with Session(self.browser) as session:
             # create a lifecycle environment
             make_lifecycle_environment(
                 session, org=org.name, name=env_name)
-
             self.assertIsNotNone(session.nav.wait_until_element(
-                (strategy, value % env_name)))
-
+                locators['content_env.select_name'] % env_name))
             self.setup_to_create_cv(rh_repo=rh_repo, org_id=org.id)
             # Create content view
             make_contentview(session, org=org.name, name=cv_name)
@@ -1123,7 +1121,6 @@ class ContentViewTestCase(UITestCase):
             self.content_views.add_remove_repos(cv_name, [rh_repo['name']])
             self.assertIsNotNone(self.content_views.wait_until_element(
                 common_locators['alert.success_sub_form']))
-
             # Add a package exclude filter
             self.content_views.add_filter(
                 cv_name,
@@ -1132,9 +1129,17 @@ class ContentViewTestCase(UITestCase):
                 FILTER_TYPE['exclude'],
             )
             # assert the added filter visible
-            self.assertIsNotNone(self.content_views.search_filter(cv_name, filter_name))
+            self.assertIsNotNone(
+                self.content_views.search_filter(cv_name, filter_name))
             # exclude some package in the created filter
-            self.content_views.add_packages_to_filter(cv_name, filter_name, ['gofer'], ['All Versions'], [None], [None])
+            self.content_views.add_packages_to_filter(
+                cv_name,
+                filter_name,
+                ['gofer'],
+                ['All Versions'],
+                [None],
+                [None]
+            )
             # Publish the content view
             self.content_views.publish(cv_name)
             # Assert the content view successfully published

--- a/tests/foreman/ui/test_contentview.py
+++ b/tests/foreman/ui/test_contentview.py
@@ -898,7 +898,7 @@ class ContentViewTestCase(UITestCase):
             self.assertIsNotNone(self.content_views.wait_until_element(
                 common_locators['alert.success_sub_form']))
 
-    @stubbed()
+    @run_in_one_thread
     @run_only_on('sat')
     @skip_if_not_set('fake_manifest')
     @tier3
@@ -912,11 +912,56 @@ class ContentViewTestCase(UITestCase):
 
         @assert: Content view can be promoted
 
-        @caseautomation: notautomated
-
-
         @CaseLevel: System
         """
+        cv_name = gen_string('alpha')
+        filter_name = gen_string('alpha')
+        rh_repo = {
+            'name': REPOS['rhst7']['name'],
+            'product': PRDS['rhel'],
+            'reposet': REPOSET['rhst7'],
+            'basearch': 'x86_64',
+            'releasever': None,
+        }
+        env_name = gen_string('alpha')
+        strategy, value = locators['content_env.select_name']
+        # Create new org to import manifest
+        org = entities.Organization().create()
+        with Session(self.browser) as session:
+            make_lifecycle_environment(
+                session, org=org.name, name=env_name)
+
+            self.assertIsNotNone(session.nav.wait_until_element(
+                (strategy, value % env_name)))
+
+            self.setup_to_create_cv(rh_repo=rh_repo, org_id=org.id)
+            # Create content-view
+            make_contentview(session, org=org.name, name=cv_name)
+            self.assertIsNotNone(self.content_views.search(cv_name))
+            # Add rh repo
+            self.content_views.add_remove_repos(cv_name, [rh_repo['name']])
+            self.assertIsNotNone(self.content_views.wait_until_element(
+                common_locators['alert.success_sub_form']))
+
+            # add a filter
+            self.content_views.add_filter(
+                cv_name,
+                filter_name,
+                FILTER_CONTENT_TYPE['package'],
+                FILTER_TYPE['exclude'],
+            )
+            # assert the added filter visible
+            self.assertIsNotNone(self.content_views.search_filter(cv_name, filter_name))
+            # exclude some package in the created filter
+            self.content_views.add_packages_to_filter(cv_name, filter_name, ['gofer'], ['All Versions'], [None], [None])
+
+            self.content_views.publish(cv_name)
+            self.assertIsNotNone(self.content_views.wait_until_element(
+                common_locators['alert.success_sub_form']))
+
+            self.content_views.promote(cv_name, 'Version 1', env_name)
+            self.assertIsNotNone(self.content_views.wait_until_element(
+                common_locators['alert.success_sub_form']))
 
     @run_only_on('sat')
     @tier2


### PR DESCRIPTION
```bash
(2.7) dlezz@elysion:~/projects/robottelo-fork$ py.test tests/foreman/ui/test_contentview.py -v -k 'test_positive_publish_with_rh_custom_spin'
================================================= test session starts ==================================================
platform linux2 -- Python 2.7.12, pytest-3.0.3, py-1.4.31, pluggy-0.4.0 -- /home/dlezz/bin/redhat/python/2.7/bin/python
cachedir: .cache
rootdir: /home/dlezz/projects/robottelo-fork, inifile: 
plugins: cov-2.4.0, xdist-1.15.0
collected 64 items 

tests/foreman/ui/test_contentview.py::ContentViewTestCase::test_positive_publish_with_rh_custom_spin <- robottelo/decorators/__init__.py PASSED

================================================= 63 tests deselected ==================================================
====================================== 1 passed, 63 deselected in 186.71 seconds =======================================
```
```bash
(2.7) dlezz@elysion:~/projects/robottelo-fork$ py.test tests/foreman/ui/test_contentview.py -v -k 'test_positive_promote_with_rh_custom_spin'
================================================= test session starts ==================================================
platform linux2 -- Python 2.7.12, pytest-3.0.3, py-1.4.31, pluggy-0.4.0 -- /home/dlezz/bin/redhat/python/2.7/bin/python
cachedir: .cache
rootdir: /home/dlezz/projects/robottelo-fork, inifile: 
plugins: cov-2.4.0, xdist-1.15.0
collected 64 items 

tests/foreman/ui/test_contentview.py::ContentViewTestCase::test_positive_promote_with_rh_custom_spin <- robottelo/decorators/__init__.py PASSED

================================================= 63 tests deselected ==================================================
====================================== 1 passed, 63 deselected in 233.86 seconds =======================================
```