### PR TITLE
Update BZ id for UI bookmark discovery-rule subtest

### DIFF
--- a/robottelo/constants.py
+++ b/robottelo/constants.py
@@ -1038,7 +1038,7 @@ BOOKMARK_ENTITIES = [
     },
     {
         'name': 'DiscoveryRules', 'controller': 'discovery_rules',
-        'skip_for_ui': 1324508, 'setup': entities.DiscoveryRule
+        'skip_for_ui': 1387569, 'setup': entities.DiscoveryRule
     },
     {
         'name': 'GlobalParameter', 'controller': 'common_parameters',


### PR DESCRIPTION
Previous BZ is already resolved, however there's another bug, updating constant accordingly.

Some random test result (should be enough as `BOOKMARK_ENTITIES` constant is used in test suite setup):
```
py.test tests/foreman/ui/test_bookmark.py -v -k 'test_positive_create_bookmark_populate_auto'
================================================ test session starts ================================================
platform linux2 -- Python 2.7.10, pytest-3.0.3, py-1.4.31, pluggy-0.4.0 -- /home/andrii/env/bin/python
cachedir: .cache
rootdir: /home/andrii/workspace/robottelo, inifile: 
plugins: xdist-1.13.1, repeat-0.2
collected 14 items 

tests/foreman/ui/test_bookmark.py::BookmarkTestCase::test_positive_create_bookmark_populate_auto PASSED

================================================ 13 tests deselected ================================================
===================================== 1 passed, 13 deselected in 61.77 seconds ======================================
```