### PR TITLE
#3586-UI-CV- add-edit_rh_custom_spin

### DIFF
--- a/robottelo/constants.py
+++ b/robottelo/constants.py
@@ -428,6 +428,17 @@ FILTER_TYPE = {
     'exclude': "Exclude"
 }
 
+FILTER_ERRATA_TYPE = {
+    'security': "security",
+    'enhancement': "enhancement",
+    'bugfix': "bugfix"
+}
+
+FILTER_ERRATA_DATE = {
+    'updated': "updated",
+    'issued': "issued"
+}
+
 DOCKER_REGISTRY_HUB = u'https://registry-1.docker.io'
 CUSTOM_RPM_REPO = (
     u'http://repos.fedorapeople.org/repos/pulp/pulp/fixtures/rpm/'

--- a/robottelo/ui/contentviews.py
+++ b/robottelo/ui/contentviews.py
@@ -35,12 +35,12 @@ class ContentViews(Base):
         """Set the input value of a date field and press the button to hide
          the calendar popup panel"""
         self.assign_value(
-            locators['contentviews.calendar_date_input'] % name, value)
+            locators.contentviews.calendar_date_input % name, value
+        )
         # the calendar panel popup and hide other form elements that became
         # unreachable.
         # close the popup calendar panel
-        self.click(
-            locators["contentviews.calendar_date_button"] % name)
+        self.click(locators.contentviews.calendar_date_button % name)
 
     def create(self, name, label=None, description=None, is_composite=False):
         """Creates a content view"""
@@ -468,38 +468,43 @@ class ContentViews(Base):
         """Edit Erratum Date Range Filter"""
         allowed_errata_types = FILTER_ERRATA_TYPE.values()
         allowed_date_types = FILTER_ERRATA_DATE.values()
-        erratum_type_locator = locators['contentviews.erratum_type_checkbox']
-        date_type_locator = locators['contentviews.erratum_date_type']
         if open_filter:
             self.go_to_filter_page(cv_name, filter_name)
         if errata_types is not None:
-            if errata_types:
-                # because of the behaviour of the UI to check and disable
-                # the last element if the others are unchecked,
-                # will check all the elements first,
-                # after then uncheck the not selected ones
-                for errata_type in allowed_errata_types:
-                    self.assign_value(erratum_type_locator % errata_type, True)
-                for errata_type in allowed_errata_types:
-                    if errata_type not in errata_types:
-                        self.assign_value(
-                            erratum_type_locator % errata_type, False)
-            else:
-                # minimum one errata type is mandatory
+            if not errata_types:
                 raise UIError(
-                    'errata types is empty, minimum required: one errata type')
+                    'errata types is empty, minimum required: one errata type'
+                )
+            if not set(errata_types).issubset(allowed_errata_types):
+                raise UIError('some types in errata_types are not allowed')
+            # because of the behaviour of the UI to disable the last checked
+            # element.
+            # will check all selected errata types first, after then uncheck
+            # the not selected ones.
+            # 1 - check first the types that are in the errata_types
+            for errata_type in errata_types:
+                self.assign_value(
+                    locators.contentviews.erratum_type_checkbox % errata_type,
+                    True
+                )
+            # we are sure now that any check box not in the errata_types
+            # is enabled and clickable
+            # 2 - uncheck the types that are not in the selection
+            for errata_type in set(allowed_errata_types).difference(
+                    errata_types):
+                self.assign_value(
+                    locators.contentviews.erratum_type_checkbox % errata_type,
+                    False
+                )
         if date_type is not None:
-            if date_type in allowed_date_types:
-                self.click(date_type_locator % date_type)
-            else:
-                raise UIError(
-                    'date type "{0}" not allowed'.format(date_type))
+            if date_type not in allowed_date_types:
+                raise UIError('date type "{0}" not allowed'.format(date_type))
+            self.click(locators.contentviews.erratum_date_type % date_type)
         if start_date is not None:
             self.set_calendar_date_value('start_date', start_date)
         if end_date is not None:
             self.set_calendar_date_value('end_date', end_date)
-
-        self.click(locators['contentviews.save_erratum'])
+        self.click(locators.contentviews.save_erratum)
 
     def fetch_puppet_module(self, cv_name, module_name):
         """Get added puppet module name from selected content-view"""

--- a/robottelo/ui/contentviews.py
+++ b/robottelo/ui/contentviews.py
@@ -35,7 +35,8 @@ class ContentViews(Base):
         """Set the input value of a date field and press the button to hide
          the calendar popup panel"""
         self.assign_value(
-            locators.contentviews.calendar_date_input % name, value
+            locators.contentviews.calendar_date_input % name,
+            value
         )
         # the calendar panel popup and hide other form elements that became
         # unreachable.

--- a/robottelo/ui/locators/base.py
+++ b/robottelo/ui/locators/base.py
@@ -1656,6 +1656,17 @@ locators = LocatorDict({
          "//td[contains(normalize-space(.), '%s')]"
          "/preceding-sibling::td[@class='row-select']"
          "/input[@type='checkbox']")),
+    "contentviews.erratum_type_checkbox": (
+        By.XPATH, "//input[@ng-model='types.%s']"),
+    "contentviews.erratum_date_type": (
+        By.XPATH, "//input[@type='radio' and @value='%s']"),
+    "contentviews.calendar_date_input": (
+        By.XPATH, "//input[@ng-model='rule.%s']"),
+    "contentviews.calendar_date_button": (
+        By.XPATH, "//input[@ng-model='rule.%s']/.."
+                  "//li/button[@ng-click='isOpen = false']"),
+    "contentviews.save_erratum": (
+        By.XPATH, "//button[contains(@ng-click, 'handleSave()')]"),
     "contentviews.add_errata": (
         By.XPATH, "//button[@ng-click='addErrata(filter)']"),
     "contentviews.remove_errata": (

--- a/tests/foreman/ui/test_contentview.py
+++ b/tests/foreman/ui/test_contentview.py
@@ -38,6 +38,8 @@ from robottelo.constants import (
     FEDORA23_OSTREE_REPO,
     FILTER_CONTENT_TYPE,
     FILTER_TYPE,
+    FILTER_ERRATA_TYPE,
+    FILTER_ERRATA_DATE,
     PRDS,
     REPOS,
     REPOSET,
@@ -447,8 +449,9 @@ class ContentViewTestCase(UITestCase):
                     self.assertIsNotNone(self.content_views.wait_until_element(
                         common_locators['alert.success_sub_form']))
 
-    @stubbed()
+    @run_in_one_thread
     @run_only_on('sat')
+    @skip_if_not_set('fake_manifest')
     @tier3
     def test_positive_edit_rh_custom_spin(self):
         # Variations might be:
@@ -464,11 +467,49 @@ class ContentViewTestCase(UITestCase):
         @assert: edited content view save is successful and info is
         updated
 
-        @caseautomation: notautomated
-
-
         @CaseLevel: System
         """
+        cv_name = gen_string('alpha')
+        filter_name = gen_string('alpha')
+        rh_repo = {
+            'name': REPOS['rhst7']['name'],
+            'product': PRDS['rhel'],
+            'reposet': REPOSET['rhst7'],
+            'basearch': 'x86_64',
+            'releasever': None
+        }
+        # Create new org to import manifest
+        org = entities.Organization().create()
+        with Session(self.browser) as session:
+            self.setup_to_create_cv(rh_repo=rh_repo, org_id=org.id)
+            # Create content view
+            make_contentview(session, org=org.name, name=cv_name)
+            self.assertIsNotNone(self.content_views.search(cv_name))
+            self.content_views.add_remove_repos(cv_name, [rh_repo['name']])
+            self.assertIsNotNone(self.content_views.wait_until_element(
+                common_locators['alert.success_sub_form']))
+            self.content_views.add_filter(
+                cv_name,
+                filter_name,
+                FILTER_CONTENT_TYPE['erratum by date and type'],
+                FILTER_TYPE['exclude']
+            )
+            # this assertion should find/open the cv and search for our filter
+            self.assertIsNotNone(
+                self.content_views.search_filter(cv_name, filter_name))
+            # go to the filter open it, edit it and save
+            self.content_views.edit_erratum_date_range_filter(
+                cv_name,
+                filter_name,
+                errata_types=[FILTER_ERRATA_TYPE['enhancement'],
+                              FILTER_ERRATA_TYPE['bugfix']],
+                date_type=FILTER_ERRATA_DATE['issued'],
+                start_date='2016-01-01',
+                end_date='2016-06-01',
+                open_filter=True
+            )
+            self.assertIsNotNone(self.content_views.wait_until_element(
+                common_locators['alert.success_sub_form']))
 
     @run_only_on('sat')
     @tier1
@@ -591,7 +632,7 @@ class ContentViewTestCase(UITestCase):
             self.assertIsNotNone(self.content_views.wait_until_element(
                 common_locators['alert.success_sub_form']))
 
-    @stubbed()
+    @run_in_one_thread
     @run_only_on('sat')
     @skip_if_not_set('fake_manifest')
     @tier2
@@ -611,11 +652,53 @@ class ContentViewTestCase(UITestCase):
 
         @assert: Filtered RH content only is available/can be seen in a view
 
-        @caseautomation: notautomated
-
-
         @CaseLevel: Integration
         """
+        cv_name = gen_string('alpha')
+        filter_name = gen_string('alpha')
+        rh_repo = {
+            'name': REPOS['rhst7']['name'],
+            'product': PRDS['rhel'],
+            'reposet': REPOSET['rhst7'],
+            'basearch': 'x86_64',
+            'releasever': None
+        }
+        # Create new org to import manifest
+        org = entities.Organization().create()
+        with Session(self.browser) as session:
+            self.setup_to_create_cv(rh_repo=rh_repo, org_id=org.id)
+            # Create content view
+            make_contentview(session, org=org.name, name=cv_name)
+            self.assertIsNotNone(self.content_views.search(cv_name))
+            self.content_views.add_remove_repos(cv_name, [rh_repo['name']])
+            self.assertIsNotNone(self.content_views.wait_until_element(
+                common_locators['alert.success_sub_form']))
+            self.content_views.add_filter(
+                cv_name,
+                filter_name,
+                FILTER_CONTENT_TYPE['erratum by date and type'],
+                FILTER_TYPE['exclude']
+            )
+            # edit the filter fields immediately after creation and without
+            # opening, as after creation the filter form should be opened
+            # and ready to be be edited
+            # should not assert the filter existence to not exist from
+            # the window at this time
+            self.content_views.edit_erratum_date_range_filter(
+                cv_name,
+                filter_name,
+                errata_types=[FILTER_ERRATA_TYPE['enhancement'],
+                              FILTER_ERRATA_TYPE['bugfix']],
+                date_type=FILTER_ERRATA_DATE['issued'],
+                start_date='2016-01-01',
+                end_date='2016-06-01',
+                open_filter=False
+            )
+            self.assertIsNotNone(self.content_views.wait_until_element(
+                common_locators['alert.success_sub_form']))
+            # this assertion should find/open the cv and search for our filter
+            self.assertIsNotNone(
+                 self.content_views.search_filter(cv_name, filter_name))
 
     @run_only_on('sat')
     @tier2

--- a/tests/foreman/ui/test_contentview.py
+++ b/tests/foreman/ui/test_contentview.py
@@ -679,11 +679,11 @@ class ContentViewTestCase(UITestCase):
                 FILTER_CONTENT_TYPE['erratum by date and type'],
                 FILTER_TYPE['exclude']
             )
-            # edit the filter fields immediately after creation and without
-            # opening, as after creation the filter form should be opened
-            # and ready to be be edited
-            # should not assert the filter existence to not exist from
-            # the window at this time
+            # The last executed function will create the filter and open the
+            # edit filter form.
+            # will not assert the filter existence here to not exist from the
+            # filter edit form.
+            # will edit the filter fields immediately with open_filter=False
             self.content_views.edit_erratum_date_range_filter(
                 cv_name,
                 filter_name,

--- a/tests/foreman/ui/test_contentview.py
+++ b/tests/foreman/ui/test_contentview.py
@@ -487,7 +487,7 @@ class ContentViewTestCase(UITestCase):
             self.assertIsNotNone(self.content_views.search(cv_name))
             self.content_views.add_remove_repos(cv_name, [rh_repo['name']])
             self.assertIsNotNone(self.content_views.wait_until_element(
-                common_locators['alert.success_sub_form']))
+                common_locators.alert.success_sub_form))
             self.content_views.add_filter(
                 cv_name,
                 filter_name,
@@ -509,7 +509,7 @@ class ContentViewTestCase(UITestCase):
                 open_filter=True
             )
             self.assertIsNotNone(self.content_views.wait_until_element(
-                common_locators['alert.success_sub_form']))
+                common_locators.alert.success_sub_form))
 
     @run_only_on('sat')
     @tier1
@@ -672,7 +672,7 @@ class ContentViewTestCase(UITestCase):
             self.assertIsNotNone(self.content_views.search(cv_name))
             self.content_views.add_remove_repos(cv_name, [rh_repo['name']])
             self.assertIsNotNone(self.content_views.wait_until_element(
-                common_locators['alert.success_sub_form']))
+                common_locators.alert.success_sub_form))
             self.content_views.add_filter(
                 cv_name,
                 filter_name,
@@ -681,7 +681,7 @@ class ContentViewTestCase(UITestCase):
             )
             # The last executed function will create the filter and open the
             # edit filter form.
-            # will not assert the filter existence here to not exist from the
+            # will not assert the filter existence here to not exit from the
             # filter edit form.
             # will edit the filter fields immediately with open_filter=False
             self.content_views.edit_erratum_date_range_filter(
@@ -695,7 +695,7 @@ class ContentViewTestCase(UITestCase):
                 open_filter=False
             )
             self.assertIsNotNone(self.content_views.wait_until_element(
-                common_locators['alert.success_sub_form']))
+                common_locators.alert.success_sub_form))
             # this assertion should find/open the cv and search for our filter
             self.assertIsNotNone(
                  self.content_views.search_filter(cv_name, filter_name))


### PR DESCRIPTION
``` bash
dlezz@elysion:~/projects/robottelo-fork$ py.test tests/foreman/ui/test_contentview.py -v -k 'test_positive_edit_rh_custom_spin'
================================================= test session starts ==================================================
platform linux2 -- Python 2.7.12, pytest-3.0.3, py-1.4.31, pluggy-0.4.0 -- /home/dlezz/bin/redhat/python/2.7/bin/python
cachedir: .cache
rootdir: /home/dlezz/projects/robottelo-fork, inifile: 
plugins: cov-2.4.0, xdist-1.15.0
collected 65 items 

tests/foreman/ui/test_contentview.py::ContentViewTestCase::test_positive_edit_rh_custom_spin <- robottelo/decorators/__init__.py PASSED

================================================= 64 tests deselected ==================================================
====================================== 1 passed, 64 deselected in 306.83 seconds =======================================
```

``` bash
dlezz@elysion:~/projects/robottelo-fork$ py.test tests/foreman/ui/test_contentview.py -v -k 'test_positive_add_rh_custom_spin'
================================================= test session starts ==================================================
platform linux2 -- Python 2.7.12, pytest-3.0.3, py-1.4.31, pluggy-0.4.0 -- /home/dlezz/bin/redhat/python/2.7/bin/python
cachedir: .cache
rootdir: /home/dlezz/projects/robottelo-fork, inifile: 
plugins: cov-2.4.0, xdist-1.15.0
collected 65 items 

tests/foreman/ui/test_contentview.py::ContentViewTestCase::test_positive_add_rh_custom_spin <- robottelo/decorators/__init__.py PASSED

================================================= 64 tests deselected ==================================================
====================================== 1 passed, 64 deselected in 304.04 seconds =======================================
```
