### PR TITLE
Update api endtoend

### DIFF
--- a/robottelo/constants.py
+++ b/robottelo/constants.py
@@ -283,7 +283,7 @@ DEFAULT_LOC = "Default Location"
 DEFAULT_CV = "Default Organization View"
 DEFAULT_PTABLE = "Kickstart default"
 DEFAULT_SUBSCRIPTION_NAME = (
-    'Red Hat Enterprise Linux Server Entry Level, Self-support')
+    'Red Hat Enterprise Linux Server, Premium (Physical or Virtual Nodes)')
 
 LANGUAGES = [
     u'zh_TW',

--- a/tests/foreman/endtoend/test_api_endtoend.py
+++ b/tests/foreman/endtoend/test_api_endtoend.py
@@ -1072,13 +1072,20 @@ class EndToEndTestCase(TestCase, ClientProvisioningMixin):
         ).create()
 
         # step 2.15: Add the products to the activation key
+        subscription_added = False
         for sub in entities.Subscription(organization=org).search():
             if sub.read_json()['product_name'] == DEFAULT_SUBSCRIPTION_NAME:
                 activation_key.add_subscriptions(data={
                     'quantity': 1,
                     'subscription_id': sub.id,
                 })
+                subscription_added = True
                 break
+        self.assertTrue(
+            subscription_added,
+            'Not able to find subscription "{0}"'
+            .format(DEFAULT_SUBSCRIPTION_NAME)
+        )
         # step 2.15.1: Enable product content
         if self.fake_manifest_is_set:
             activation_key.content_override(data={'content_override': {


### PR DESCRIPTION
I have added two commits to accomplish the following:

* Update the default subscription name constant
* Update API end to end test to make sure a subscription is added to the activation key before proceeding (this same improvement can be done on the master branch)

I am targeting the 6.2.z branch on this PR.