### PR TITLE
Replaced make_content_host calls with make_fake_host in CLI tests

### DIFF
--- a/tests/foreman/cli/test_contentview.py
+++ b/tests/foreman/cli/test_contentview.py
@@ -23,11 +23,11 @@ from robottelo.cli.contentview import ContentView
 from robottelo.cli.factory import (
     CLIFactoryError,
     make_activation_key,
-    make_content_host,
     make_content_view,
     make_content_view_filter,
     make_content_view_filter_rule,
     make_filter,
+    make_fake_host,
     make_lifecycle_environment,
     make_org,
     make_product,
@@ -589,7 +589,7 @@ class ContentViewTestCase(CLITestCase):
         source_cv = ContentView.info({u'id': source_cv['id']})
         self.assertEqual(source_cv['content-host-count'], '0')
 
-        make_content_host({
+        make_fake_host({
             u'content-view-id': source_cv['id'],
             u'lifecycle-environment-id': env[0]['id'],
             u'name': gen_alphanumeric(),
@@ -1904,7 +1904,7 @@ class ContentViewTestCase(CLITestCase):
         })
         content_view = ContentView.info({u'id': content_view['id']})
         self.assertEqual(content_view['content-host-count'], '0')
-        make_content_host({
+        make_fake_host({
             u'content-view-id': content_view['id'],
             u'lifecycle-environment-id': env['id'],
             u'name': gen_alphanumeric(),
@@ -1954,7 +1954,7 @@ class ContentViewTestCase(CLITestCase):
         })
         content_view = ContentView.info({u'id': content_view['id']})
         self.assertEqual(content_view['content-host-count'], '0')
-        make_content_host({
+        make_fake_host({
             u'content-view-id': content_view['id'],
             u'lifecycle-environment-id': env['id'],
             u'name': gen_alphanumeric(),
@@ -2024,7 +2024,7 @@ class ContentViewTestCase(CLITestCase):
         content_view = ContentView.info({u'id': content_view['id']})
         self.assertEqual(content_view['content-host-count'], '0')
 
-        make_content_host({
+        make_fake_host({
             u'content-view-id': content_view['id'],
             u'lifecycle-environment-id': env['id'],
             u'name': gen_alphanumeric(),
@@ -2070,7 +2070,7 @@ class ContentViewTestCase(CLITestCase):
         content_view = ContentView.info({u'id': content_view['id']})
         self.assertEqual(content_view['content-host-count'], '0')
 
-        make_content_host({
+        make_fake_host({
             u'content-view-id': content_view['id'],
             u'lifecycle-environment-id': env['id'],
             u'name': gen_alphanumeric(),
@@ -2108,7 +2108,7 @@ class ContentViewTestCase(CLITestCase):
         content_view = ContentView.info({u'id': content_view['id']})
         self.assertEqual(content_view['content-host-count'], '0')
 
-        make_content_host({
+        make_fake_host({
             u'content-view-id': content_view['id'],
             u'lifecycle-environment-id': env['id'],
             u'name': gen_alphanumeric(),
@@ -2168,7 +2168,7 @@ class ContentViewTestCase(CLITestCase):
         content_view = ContentView.info({u'id': content_view['id']})
         self.assertEqual(content_view['content-host-count'], '0')
 
-        make_content_host({
+        make_fake_host({
             u'content-view-id': content_view['id'],
             u'lifecycle-environment-id': env['id'],
             u'name': gen_alphanumeric(),

--- a/tests/foreman/cli/test_host_collection.py
+++ b/tests/foreman/cli/test_host_collection.py
@@ -20,8 +20,13 @@ from fauxfactory import gen_string
 from robottelo.cli.base import CLIReturnCodeError
 from robottelo.cli.contentview import ContentView
 from robottelo.cli.factory import (
-    CLIFactoryError, make_org, make_host_collection, make_content_view,
-    make_lifecycle_environment, make_content_host)
+    CLIFactoryError,
+    make_content_view,
+    make_fake_host,
+    make_host_collection,
+    make_lifecycle_environment,
+    make_org,
+)
 from robottelo.cli.hostcollection import HostCollection
 from robottelo.cli.lifecycleenvironment import LifecycleEnvironment
 from robottelo.constants import DEFAULT_CV, ENVIRONMENT
@@ -88,9 +93,9 @@ class HostCollectionTestCase(CLITestCase):
 
         return make_host_collection(options)
 
-    def _make_content_host_helper(self):
-        """Make a new content host"""
-        return make_content_host({
+    def _make_fake_host_helper(self):
+        """Make a new fake host"""
+        return make_fake_host({
             u'content-view-id': self.default_cv['id'],
             u'lifecycle-environment-id': self.library['id'],
             u'name': gen_string('alpha', 15),
@@ -283,7 +288,7 @@ class HostCollectionTestCase(CLITestCase):
         new_host_col = self._new_host_collection({
             'name': gen_string('alpha', 15)
         })
-        new_system = self._make_content_host_helper()
+        new_system = self._make_fake_host_helper()
         no_of_content_host = new_host_col['total-hosts']
         HostCollection.add_host({
             u'host-ids': new_system['id'],
@@ -309,7 +314,7 @@ class HostCollectionTestCase(CLITestCase):
         new_host_col = self._new_host_collection({
             'name': gen_string('alpha', 15)
         })
-        new_system = self._make_content_host_helper()
+        new_system = self._make_fake_host_helper()
         HostCollection.add_host({
             u'host-ids': new_system['id'],
             u'id': new_host_col['id'],
@@ -342,7 +347,7 @@ class HostCollectionTestCase(CLITestCase):
         """
         host_col_name = gen_string('alpha', 15)
         new_host_col = self._new_host_collection({'name': host_col_name})
-        new_system = self._make_content_host_helper()
+        new_system = self._make_fake_host_helper()
         no_of_content_host = new_host_col['total-hosts']
         HostCollection.add_host({
             u'host-ids': new_system['id'],
@@ -379,7 +384,7 @@ class HostCollectionTestCase(CLITestCase):
             'name': gen_string('alpha', 15)
         })
         host_ids = ','.join(
-            self._make_content_host_helper()['id'] for i in range(2)
+            self._make_fake_host_helper()['id'] for _ in range(2)
         )
         HostCollection.add_host({
             u'host-ids': host_ids,

--- a/tests/foreman/ui/test_hostcollection.py
+++ b/tests/foreman/ui/test_hostcollection.py
@@ -20,7 +20,7 @@ from fauxfactory import gen_string
 from nailgun import entities
 from robottelo.api.utils import promote
 from robottelo.cli.factory import (
-    make_content_host,
+    make_fake_host,
     setup_org_for_a_custom_repo,
     setup_org_for_a_rh_repo,
 )
@@ -353,7 +353,7 @@ class HostCollectionTestCase(UITestCase):
             organization=self.organization).create()
         cv.publish()
         promote(cv.read().version[0], lce.id)
-        new_system = make_content_host({
+        new_system = make_fake_host({
             u'content-view-id': cv.id,
             u'lifecycle-environment-id': lce.id,
             u'name': gen_string('alpha'),
@@ -390,7 +390,7 @@ class HostCollectionTestCase(UITestCase):
         cv.publish()
         promote(cv.read().version[0], lce.id)
         new_systems = [
-            make_content_host({
+            make_fake_host({
                 u'content-view-id': cv.id,
                 u'lifecycle-environment-id': lce.id,
                 u'name': gen_string('alpha'),


### PR DESCRIPTION
As `hammer content-host` subcommand was completely dropped in favor of `hammer host` command, tests should create a host in favor of content-host accordingly.
Depends on #3946
Part of #3939
