### PR TITLE
[Cherry-pick] Fixing locator for CV publish

### DIFF
--- a/robottelo/ui/contentviews.py
+++ b/robottelo/ui/contentviews.py
@@ -220,14 +220,7 @@ class ContentViews(Base):
         """Publishes to create new version of CV and promotes the contents to
         'Library' environment
         """
-        element = self.search(cv_name)
-        if not element:
-            raise UIError(
-                'Could not find the selected CV "{0}"'.format(cv_name)
-            )
-
-        element.click()
-        self.wait_for_ajax()
+        self.click(self.search(cv_name))
         self.click(locators['contentviews.publish'])
         version_label = self.wait_until_element(
             locators['contentviews.ver_label'])
@@ -245,16 +238,8 @@ class ContentViews(Base):
 
     def promote(self, cv_name, version, env):
         """Promotes the selected version of content-view to given environment.
-
         """
-        element = self.search(cv_name)
-        if not element:
-            raise UIError(
-                'Could not find the selected CV "{0}"'.format(cv_name)
-            )
-
-        element.click()
-        self.wait_for_ajax()
+        self.click(self.search(cv_name))
         self.click(tab_locators['contentviews.tab_versions'])
         strategy, value = locators['contentviews.promote_button']
         self.click((strategy, value % version))

--- a/robottelo/ui/locators.py
+++ b/robottelo/ui/locators.py
@@ -2265,7 +2265,7 @@ locators = LocatorDict({
         ("//div[contains(@class, 'alert-success')]"
          "/div/span[contains(., 'Successfully removed')]")),
     "contentviews.publish": (
-        By.XPATH, "//a[contains(@href, 'publish')]/span"),
+        By.XPATH, "//button[contains(@ng-click, 'details.publish')]"),
     "contentviews.publish_comment": (By.ID, "comment"),
     "contentviews.publish_progress": (
         By.XPATH,


### PR DESCRIPTION
Running against last 6.2.x SNAP with 6.2.z branch. Take one random test as it is cherry-pick procedure
```
nosetests tests/foreman/ui/test_docker.py -m test_positive_add_docker_repos_to_ccv
.
----------------------------------------------------------------------
Ran 1 test in 228.425s

OK
```