### PR TITLE
[6.2.z] Skip UI Discovery Rule Bookmark subtest

### DIFF
--- a/robottelo/constants.py
+++ b/robottelo/constants.py
@@ -908,7 +908,7 @@ BOOKMARK_ENTITIES = [
     },
     {
         'name': 'DiscoveryRules', 'controller': 'discovery_rules',
-        'skip_for_ui': 1324508, 'setup': entities.DiscoveryRule
+        'skip_for_ui': True, 'setup': entities.DiscoveryRule
     },
     {
         'name': 'GlobalParameter', 'controller': 'common_parameters',


### PR DESCRIPTION
BZ1324508 has been fixed for 6.3, subtest was unblocked for both 6.3 and 6.2, as a result 6.2.z received 11 new failures. Skipping the subtest for 6.2.z completely (without BZ id) as BZ seems to never gonna make it to 6.2.z branch.