### PR TITLE
#3586-UI-CV-test_negative_add_dupe_modules

### DIFF
--- a/tests/foreman/ui/test_contentview.py
+++ b/tests/foreman/ui/test_contentview.py
@@ -867,14 +867,11 @@ class ContentViewTestCase(UITestCase):
                 filter_term='Latest'
             )
             # ensure that the puppet module is added to content view
-            session.nav.go_to_select_org(self.organization.name)
             self.assertIsNotNone(
                 self.content_views.fetch_puppet_module(
                     cv_name, module_name)
             )
-            # ensure that the module that we already added cannot be found
-            # in the list of modules to add when try to add it a second time.
-            session.nav.go_to_select_org(self.organization.name)
+            # ensure that cannot add the same module a second time.
             with self.assertRaises(UINoSuchElementError) as context:
                 self.content_views.add_puppet_module(
                     cv_name,

--- a/tests/foreman/ui/test_contentview.py
+++ b/tests/foreman/ui/test_contentview.py
@@ -836,7 +836,6 @@ class ContentViewTestCase(UITestCase):
                 .format(repo_name)
             )
 
-    @stubbed()
     @run_only_on('sat')
     @tier2
     def test_negative_add_dupe_modules(self):
@@ -847,11 +846,45 @@ class ContentViewTestCase(UITestCase):
 
         @assert: User cannot add modules multiple times to the view
 
-        @caseautomation: notautomated
-
-
         @CaseLevel: Integration
         """
+        cv_name = gen_string('alpha')
+        module_name = 'samba'
+        product = entities.Product(organization=self.organization).create()
+        puppet_repository = entities.Repository(
+            url=FAKE_0_PUPPET_REPO,
+            content_type='puppet',
+            product=product
+        ).create()
+        puppet_repository.sync()
+        with Session(self.browser) as session:
+            # Create content-view
+            make_contentview(session, org=self.organization.name, name=cv_name)
+            self.assertIsNotNone(self.content_views.search(cv_name))
+            self.content_views.add_puppet_module(
+                cv_name,
+                module_name,
+                filter_term='Latest'
+            )
+            # ensure that the puppet module is added to content view
+            session.nav.go_to_select_org(self.organization.name)
+            self.assertIsNotNone(
+                self.content_views.fetch_puppet_module(
+                    cv_name, module_name)
+            )
+            # ensure that the module that we already added cannot be found
+            # in the list of modules to add when try to add it a second time.
+            session.nav.go_to_select_org(self.organization.name)
+            with self.assertRaises(UINoSuchElementError) as context:
+                self.content_views.add_puppet_module(
+                    cv_name,
+                    module_name,
+                    filter_term='Latest'
+                )
+                # ensure that the select location of our module is in the
+                # exception message
+                _, location = locators.contentviews.select_module % module_name
+                self.assertIn(location, context.exception.message)
 
     @run_in_one_thread
     @run_only_on('sat')

--- a/tests/foreman/ui/test_contentview.py
+++ b/tests/foreman/ui/test_contentview.py
@@ -878,10 +878,10 @@ class ContentViewTestCase(UITestCase):
                     module_name,
                     filter_term='Latest'
                 )
-                # ensure that the select location of our module is in the
-                # exception message
-                _, location = locators.contentviews.select_module % module_name
-                self.assertIn(location, context.exception.message)
+            # ensure that the select location of our module is in the
+            # exception message
+            _, location = locators.contentviews.select_module % module_name
+            self.assertIn(location, context.exception.message)
 
     @run_in_one_thread
     @run_only_on('sat')


### PR DESCRIPTION
``` bash
============================================== 203 passed in 0.75 seconds ==============================================
"!!! Congratulations your changes are good to fly, make a great PR! dlezz++ !!!"
dlezz@elysion:~/projects/robottelo-fork$ py.test tests/foreman/ui/test_contentview.py -v -k 'test_negative_add_dupe_modules'
================================================= test session starts ==================================================
platform linux2 -- Python 2.7.12, pytest-3.0.3, py-1.4.31, pluggy-0.4.0 -- /home/dlezz/bin/redhat/python/2.7/bin/python
cachedir: .cache
rootdir: /home/dlezz/projects/robottelo-fork, inifile: 
plugins: cov-2.4.0, xdist-1.15.0
collected 65 items 

tests/foreman/ui/test_contentview.py::ContentViewTestCase::test_negative_add_dupe_modules <- robottelo/decorators/__init__.py PASSED

================================================= 64 tests deselected ==================================================
====================================== 1 passed, 64 deselected in 126.42 seconds =======================================
```
