### PR TITLE
[6.2.z] Fix UI Content View Version functionality

### DIFF
--- a/robottelo/ui/locators.py
+++ b/robottelo/ui/locators.py
@@ -2239,12 +2239,11 @@ locators = LocatorDict({
         By.XPATH, "//div[contains(@class, 'has-error') and "
                   "contains(@class, 'form-group')]"),
     "contentviews.remove": (
-        By.XPATH, "//button[@ui-sref='content-views.details.deletion']"),
+        By.XPATH,
+        "//button[contains(@ng-click, 'content-views.details.deletion')]"),
     "contentviews.remove_ver": (
         By.XPATH, ("//td/a[contains(., '%s')]/following::td/"
-                   "button[contains(@ui-sref, 'version-deletion')]")),
-    "contentviews.remove_cv_version": (
-        By.XPATH, "//a[contains(@ui-sref, 'version-deletion')]/button"),
+                   "button[contains(@ng-click, 'version-deletion')]")),
     "contentviews.completely_remove_checkbox": (
         By.XPATH, "//span/input[contains(@ng-model, 'deleteArchive')]"),
     "contentviews.next_button": (


### PR DESCRIPTION
Can't cherry pick PR #3860 as we have different locator models for 6.2 & 6.3 and the fix is partially cherry picked already.
But basically this PR + PR #3949 == #3860 for 6.2.z

Test results:
```python
py.test tests/foreman/ui/test_contentview.py -k positive_delete_
============================= test session starts ==============================
platform linux2 -- Python 2.7.10, pytest-2.9.2, py-1.4.31, pluggy-0.3.1
rootdir: /home/andrii/workspace/robottelo, inifile: 
plugins: xdist-1.14, cov-2.3.1
collected 62 items 

tests/foreman/ui/test_contentview.py ...

================= 59 tests deselected by '-kpositive_delete_' ==================
================== 3 passed, 59 deselected in 288.53 seconds ===================

```