### PR TITLE
Use custom puppet repo for puppet related tests

### DIFF
--- a/robottelo/cli/factory.py
+++ b/robottelo/cli/factory.py
@@ -2949,3 +2949,41 @@ def configure_env_for_provision(org=None, loc=None):
         'ptable': ptable,
         'os': os
     }
+
+
+def publish_puppet_module(puppet_modules, repo_url, organization_id=None):
+    """Creates puppet repo, sync it via provided url and publish using
+    Content View publishing mechanism. It makes puppet class available
+    via Puppet Environment created by Content View and returns Content
+    View entity.
+
+    :param puppet_modules: List of dictionaries with module 'author'
+        and module 'name' fields.
+    :param str repo_url: Url of the repo that can be synced using pulp:
+        pulp repo or puppet forge.
+    :param organization_id: Organization id that is shared between created
+        entities.
+    :return: Content View entity.
+    """
+    if not organization_id:
+        organization_id = make_org()['id']
+    product = make_product({u'organization-id': organization_id})
+    repo = make_repository({
+        u'product-id': product['id'],
+        u'content-type': 'puppet',
+        u'url': repo_url,
+    })
+    # Synchronize repo via provided URL
+    Repository.synchronize({'id': repo['id']})
+    # Add selected module to Content View
+    cv = make_content_view({u'organization-id': organization_id})
+    for module in puppet_modules:
+        ContentView.puppet_module_add({
+            u'author': module['author'],
+            u'name': module['name'],
+            u'content-view-id': cv['id'],
+        })
+    # CV publishing will automatically create Environment and
+    # Puppet Class entities
+    ContentView.publish({u'id': cv['id']})
+    return ContentView.info({u'id': cv['id']})

--- a/robottelo/constants.py
+++ b/robottelo/constants.py
@@ -470,6 +470,7 @@ FAKE_YUM_DRPM_REPO = (
 FAKE_YUM_SRPM_REPO = (
     u'https://repos.fedorapeople.org/repos/pulp/pulp/fixtures/srpm/'
 )
+CUSTOM_PUPPET_REPO = u'http://omaciel.fedorapeople.org/bagoftricks'
 FAKE_0_PUPPET_REPO = u'http://davidd.fedorapeople.org/repos/random_puppet/'
 FAKE_1_PUPPET_REPO = u'http://omaciel.fedorapeople.org/fakepuppet01'
 FAKE_2_PUPPET_REPO = u'http://omaciel.fedorapeople.org/fakepuppet02'

--- a/tests/foreman/api/test_classparameters.py
+++ b/tests/foreman/api/test_classparameters.py
@@ -19,12 +19,12 @@ import json
 from random import choice
 
 from fauxfactory import gen_boolean, gen_integer, gen_string
+from robottelo.constants import CUSTOM_PUPPET_REPO
+
 from nailgun import entities
 from requests import HTTPError
 
-from robottelo import ssh
 from robottelo.api.utils import delete_puppet_class
-from robottelo.config import settings
 from robottelo.datafactory import filtered_datapoint
 from robottelo.decorators import (
     run_in_one_thread,
@@ -119,38 +119,58 @@ class SmartClassParametersTestCase(APITestCase):
 
     @classmethod
     def setUpClass(cls):
+        """Import some parametrized puppet classes. This is required to make
+        sure that we have smart class variable available.
+        Read all available smart class parameters for imported puppet class to
+        be able to work with unique entity for each specific test.
+        """
         super(SmartClassParametersTestCase, cls).setUpClass()
-        cls.puppet_module = "puppetlabs/ntp"
-        cls.host_name = settings.server.hostname
-        ssh.command(
-            'puppet module install --force {0}'.format(cls.puppet_module))
+        cls.puppet_module = "robottelo/api_test_classparameters"
+        cls.org = entities.Organization().create()
+        # Create product and puppet modules repository
+        product = entities.Product(organization=cls.org).create()
+        repo = entities.Repository(
+            product=product,
+            content_type='puppet',
+            url=CUSTOM_PUPPET_REPO
+        ).create()
+        # Synchronize repo via provided URL
+        repo.sync()
+        # Add selected module to Content View
+        cv = entities.ContentView(organization=cls.org).create()
+        entities.ContentViewPuppetModule(
+            author=cls.puppet_module.split('/')[0],
+            name=cls.puppet_module.split('/')[1],
+            content_view=cv,
+        ).create()
+        # CV publishing will automatically create Environment and
+        # Puppet Class entities
+        cv.publish()
         cls.env = entities.Environment().search(
-            query={'search': 'name="production"'}
-        )
-        if len(cls.env) == 0:
-            raise Exception("Environment not found")
-        cls.env = cls.env[0]
-        cls.proxy = entities.SmartProxy(name=cls.host_name).search()[0]
-        cls.proxy.import_puppetclasses(environment=cls.env)
-        cls.puppet = entities.PuppetClass().search(
-            query={'search': 'name="ntp"'}
+            query={'search': 'content_view="{0}"'.format(cv.name)}
         )[0]
+        cls.puppet = entities.PuppetClass().search(query={
+            'search': 'name="{0}"'.format(cls.puppet_module.split('/')[1])
+        })[0]
         cls.sc_params_list = entities.SmartClassParameters().search(
-            query={'search': 'puppetclass="ntp"', 'per_page': 100}
-        )
-        if len(cls.sc_params_list) < 45:
-            raise RuntimeError('There are not enough smart class parameters to'
-                               ' work with in provided puppet class')
+            query={
+                'search': 'puppetclass="{0}"'.format(cls.puppet.name),
+                'per_page': 900
+            })
 
     @classmethod
     def tearDownClass(cls):
-        """Removes entire module from the system and re-imports classes into
-        proxy. This is required as other types of tests (CLI/UI) use the same
-        module.
-        """
+        """Removes puppet class."""
         super(SmartClassParametersTestCase, cls).tearDownClass()
-        delete_puppet_class(cls.puppet.name, cls.puppet_module,
-                            cls.host_name, cls.env.name)
+        delete_puppet_class(cls.puppet.name)
+
+    def setUp(self):
+        """Checks that there is at least one not overridden
+        smart class parameter before executing test.
+        """
+        if len(self.sc_params_list) == 0:
+            raise Exception("Not enough smart class parameters. Please"
+                            "update puppet module.")
 
     @run_only_on('sat')
     @tier2
@@ -167,9 +187,7 @@ class SmartClassParametersTestCase(APITestCase):
         sc_param.override = True
         sc_param.update(['override'])
         self.assertEqual(sc_param.read().override, True)
-        host = entities.Host().search(
-            query={'search': 'name=' + self.host_name}
-        )[0]
+        host = entities.Host(organization=self.org).create()
         host.puppet_class = [self.puppet]
         host.update(['puppet_class'])
         self.assertGreater(len(host.list_scparams()), 0)

--- a/tests/foreman/cli/test_puppetclass.py
+++ b/tests/foreman/cli/test_puppetclass.py
@@ -16,17 +16,12 @@
 @Upstream: No
 """
 
-from robottelo.cli.contentview import ContentView
 from robottelo.cli.environment import Environment
 from robottelo.cli.factory import (
-    make_content_view,
     make_org,
-    make_product,
-    make_repository,
     make_smart_variable,
-)
+    publish_puppet_module)
 from robottelo.cli.puppet import Puppet
-from robottelo.cli.repository import Repository
 from robottelo.constants import CUSTOM_PUPPET_REPO
 from robottelo.decorators import (
     tier2,
@@ -43,27 +38,18 @@ class PuppetClassTestCase(CLITestCase):
         """Import a parametrized puppet class.
         """
         super(PuppetClassTestCase, cls).setUpClass()
-        puppet_module = "robottelo/generic_2"
-        org = make_org()
-        product = make_product({u'organization-id': org['id']})
-        repo = make_repository({
-            u'product-id': product['id'],
-            u'content-type': 'puppet',
-            u'url': CUSTOM_PUPPET_REPO,
-        })
-        Repository.synchronize({'id': repo['id']})
-        cv = make_content_view({u'organization-id': org['id']})
-        ContentView.puppet_module_add({
-            u'author': puppet_module.split('/')[0],
-            u'name': puppet_module.split('/')[1],
-            u'content-view-id': cv['id'],
-        })
-        ContentView.publish({u'id': cv['id']})
+        cls.puppet_modules = [
+            {'author': 'robottelo', 'name': 'generic_1'},
+        ]
+        cls.org = make_org()
+        cv = publish_puppet_module(
+            cls.puppet_modules, CUSTOM_PUPPET_REPO, cls.org['id'])
         cls.env = Environment.list({
-            u'search': 'content_view="{0}"'.format(cv['name'])
+            'search': u'content_view="{0}"'.format(cv['name'])
         })[0]
         cls.puppet = Puppet.info({
-            u'name': puppet_module.split('/')[1]
+            'name': cls.puppet_modules[0]['name'],
+            'environment': cls.env['name'],
         })
 
     @run_only_on('sat')


### PR DESCRIPTION
Use custom puppet repo for puppet related tests instead of puppet forge.
Should fix random failures of smart class parameters / smart variables tests as now every testsuite uses its own custom puppet module and separate puppet environment.
```python
% nosetests tests/foreman/api/test_{classparameters,variables}.py
SSSS.............SSSSSS............................S..S....SSSS........S............SSSSS
----------------------------------------------------------------------
Ran 89 tests in 425.293s
OK (SKIP=22)
```
```python
% nosetests tests/foreman/cli/test_{classparameters,variables,puppetclass}.py
.SSSS..........SSSSSS........................SSSS....S..S......SSSSS.....S............
----------------------------------------------------------------------
Ran 94 tests in 2050.927s
OK (SKIP=23)
```