### PR TITLE
[6.2.z] Cherrypick of #3690 - Update hostgroup tests according to changes in hammer options

### DIFF
--- a/robottelo/cli/factory.py
+++ b/robottelo/cli/factory.py
@@ -509,7 +509,9 @@ def make_partition_table(options=None):
     args = {
         u'file': '/tmp/{0}'.format(gen_alphanumeric()),
         u'name': gen_alphanumeric(),
-        u'os-family': random.choice(OPERATING_SYSTEMS)
+        u'os-family': random.choice(OPERATING_SYSTEMS),
+        u'organization-ids': None,
+        u'location-ids': None
     }
 
     # Upload file to server
@@ -1527,10 +1529,11 @@ def make_hostgroup(options=None):
         u'name': gen_alphanumeric(6),
         u'operatingsystem': None,
         u'operatingsystem-id': None,
+        u'organization-id': None,
         u'organization-ids': None,
         u'parent-id': None,
-        u'ptable': None,
-        u'ptable-id': None,
+        u'partition-table': None,
+        u'partition-table-id': None,
         u'puppet-ca-proxy': None,
         u'puppet-ca-proxy-id': None,
         u'puppet-class-ids': None,


### PR DESCRIPTION
```python
% py.test -v tests/foreman/cli/test_hostgroup.py -k 'test_positive_create_with_lifecycle_environment or test_positive_create_with_orgs_and_lce or test_positive_create_with_multiple_entities' 
===================================================================== test session starts =====================================================================
platform linux2 -- Python 2.7.12, pytest-2.9.2, py-1.4.31, pluggy-0.3.1 -- /home/qui/code/venv/6.2.z/bin/python2
cachedir: .cache
rootdir: /home/qui/code/robottelo, inifile: 
plugins: xdist-1.14, cov-2.3.1
collected 21 items 

tests/foreman/cli/test_hostgroup.py::HostGroupTestCase::test_positive_create_with_lifecycle_environment <- robottelo/decorators/__init__.py SKIPPED
tests/foreman/cli/test_hostgroup.py::HostGroupTestCase::test_positive_create_with_multiple_entities <- robottelo/decorators/__init__.py PASSED
tests/foreman/cli/test_hostgroup.py::HostGroupTestCase::test_positive_create_with_orgs_and_lce PASSED

 18 tests deselected by '-ktest_positive_create_with_lifecycle_environment or test_positive_create_with_orgs_and_lce or test_positive_create_with_multiple_entities' 
==================================================== 2 passed, 1 skipped, 18 deselected in 270.36 seconds =====================================================
```