### PR TITLE
Fix API host collection test_positive_update_host test

### DIFF
--- a/tests/foreman/api/test_hostcollection.py
+++ b/tests/foreman/api/test_hostcollection.py
@@ -267,7 +267,6 @@ class HostCollectionTestCase(APITestCase):
                 self.assertEqual(
                     host_collection.unlimited_hosts, unlimited)
 
-    @skip_if_bug_open('bugzilla', 1325989)
     @tier1
     def test_positive_update_host(self):
         """Update host collection's host.
@@ -280,11 +279,10 @@ class HostCollectionTestCase(APITestCase):
             host=[self.hosts[0]],
             organization=self.org,
         ).create()
-        host_collection.host = self.hosts[1]
+        host_collection.host = [self.hosts[1]]
         host_collection = host_collection.update(['host'])
         self.assertEqual(host_collection.host[0].id, self.hosts[1].id)
 
-    @skip_if_bug_open('bugzilla', 1325989)
     @tier1
     def test_positive_update_hosts(self):
         """Update host collection's hosts.


### PR DESCRIPTION
```python
py.test tests/foreman/api/test_hostcollection.py -k test_positive_update_host
================================================ test session starts ================================================
platform linux2 -- Python 2.7.10, pytest-3.0.3, py-1.4.31, pluggy-0.4.0
rootdir: /home/andrii/workspace/robottelo, inifile: 
plugins: xdist-1.13.1, repeat-0.2
collected 17 items 

tests/foreman/api/test_hostcollection.py ..

================================================ 15 tests deselected ================================================
===================================== 2 passed, 15 deselected in 80.15 seconds ======================================
```