### PR TITLE
Fix UI content view clone test

### DIFF
--- a/robottelo/ui/locators/base.py
+++ b/robottelo/ui/locators/base.py
@@ -1678,7 +1678,7 @@ locators = LocatorDict({
     "contentviews.filter_name": (
         By.XPATH, "//tr[@row-select='filter']/td[2]/a[contains(., '%s')]"),
     "contentviews.copy": (
-        By.XPATH, "//a[@ng-click='showCopy = true']"),
+        By.XPATH, "//button[@ng-click='showCopy = true']"),
     "contentviews.copy_name": (
         By.XPATH, "//input[@ng-model='copyName']"),
     "contentviews.copy_create": (


### PR DESCRIPTION
```python
py.test tests/foreman/ui/test_contentview.py -k test_positive_clone_within_same_env
================================================ test session starts ================================================
platform linux2 -- Python 2.7.10, pytest-3.0.3, py-1.4.31, pluggy-0.4.0
rootdir: /home/andrii/workspace/robottelo, inifile: 
plugins: xdist-1.13.1, repeat-0.2
collected 64 items 

tests/foreman/ui/test_contentview.py .

================================================ 63 tests deselected ================================================
===================================== 1 passed, 63 deselected in 170.22 seconds =====================================
```