### PR TITLE
[6.2.z] Fix UI content view clone test

### DIFF
--- a/robottelo/ui/locators.py
+++ b/robottelo/ui/locators.py
@@ -2406,7 +2406,7 @@ locators = LocatorDict({
     "contentviews.filter_name": (
         By.XPATH, "//tr[@row-select='filter']/td[2]/a[contains(., '%s')]"),
     "contentviews.copy": (
-        By.XPATH, "//a[@ng-click='showCopy = true']"),
+        By.XPATH, "//button[@ng-click='showCopy = true']"),
     "contentviews.copy_name": (
         By.XPATH, "//input[@ng-model='copyName']"),
     "contentviews.copy_create": (


### PR DESCRIPTION
Similar to #3972 
```python
py.test tests/foreman/ui/test_contentview.py -k test_positive_clone_within_same_env
================================================ test session starts ================================================
platform linux2 -- Python 2.7.10, pytest-2.9.2, py-1.4.31, pluggy-0.3.1
rootdir: /home/andrii/workspace/robottelo, inifile: 
plugins: xdist-1.14, cov-2.3.1
collected 62 items 

tests/foreman/ui/test_contentview.py .

========================== 61 tests deselected by '-ktest_positive_clone_within_same_env' ===========================
===================================== 1 passed, 61 deselected in 141.17 seconds =====================================
```