### PR TITLE
[6.2.z Cherry-pick] Fix adding ssh keys to clients; fixes UI remote execution test

### DIFF
--- a/robottelo/helpers.py
+++ b/robottelo/helpers.py
@@ -270,6 +270,9 @@ def add_remote_execution_ssh_key(hostname, key_path=None, **kwargs):
     key_path = key_path or '~foreman-proxy/.ssh/id_rsa_foreman_proxy.pub'
     # This connection defaults to settings.server
     server_key = ssh.command('cat %s' % key_path).stdout
+    # Sometimes stdout contains extra empty string. Skipping it
+    if isinstance(server_key, list):
+        server_key = server_key[0]
 
     # add that key to the client using hostname and kwargs for connection
     ssh.add_authorized_key(server_key, hostname=hostname, **kwargs)


### PR DESCRIPTION
```python
py.test tests/foreman/ui/test_remoteexecution.py -k test_positive_run_default_job_template
================================================ test session starts ================================================
platform linux2 -- Python 2.7.10, pytest-2.9.2, py-1.4.31, pluggy-0.3.1
rootdir: /home/andrii/workspace/robottelo, inifile: 
plugins: xdist-1.14, cov-2.3.1
collected 17 items 

tests/foreman/ui/test_remoteexecution.py .

========================= 16 tests deselected by '-ktest_positive_run_default_job_template' =========================
===================================== 1 passed, 16 deselected in 185.74 seconds =====================================
```