### PR TITLE
[6.2.z] Cherry-pick of #3708 - Update list of hammer commands.

### DIFF
--- a/tests/foreman/data/hammer_commands.json
+++ b/tests/foreman/data/hammer_commands.json
@@ -1033,6 +1033,81 @@
       ]
     },
     {
+      "description": "Administrative server-side tasks",
+      "name": "admin",
+      "options": [
+        {
+          "help": "print help",
+          "name": "help",
+          "shortname": "h",
+          "value": null
+        }
+      ],
+      "subcommands": [
+        {
+          "description": "Logging verbosity level setup",
+          "name": "logging",
+          "options": [
+            {
+              "help": "Skip configuration backups creation",
+              "name": "no-backup",
+              "shortname": null,
+              "value": null
+            },
+            {
+              "help": "Operate on prefixed environment (e.g. chroot).",
+              "name": "prefix",
+              "shortname": null,
+              "value": "PATH"
+            },
+            {
+              "help": "Apply to all components.",
+              "name": "all",
+              "shortname": "a",
+              "value": null
+            },
+            {
+              "help": "Components to apply, use --list to get them. Comma separated list of values.",
+              "name": "components",
+              "shortname": "c",
+              "value": "COMPONENTS"
+            },
+            {
+              "help": "Increase verbosity level to debug.",
+              "name": "level-debug",
+              "shortname": "d",
+              "value": null
+            },
+            {
+              "help": "print help",
+              "name": "help",
+              "shortname": "h",
+              "value": null
+            },
+            {
+              "help": "List available components.",
+              "name": "list",
+              "shortname": "l",
+              "value": null
+            },
+            {
+              "help": "Do not apply specified changes.",
+              "name": "dry-run",
+              "shortname": "n",
+              "value": null
+            },
+            {
+              "help": "Decrease verbosity level to standard.",
+              "name": "level-production",
+              "shortname": "p",
+              "value": null
+            }
+          ],
+          "subcommands": []
+        }
+      ]
+    },
+    {
       "description": "Manipulate architectures.",
       "name": "architecture",
       "options": [


### PR DESCRIPTION
Test results for 6.2.z/6.2.4
```python
% py.test -v tests/foreman/cli/test_hammer.py
===================================================================== test session starts =====================================================================
platform linux2 -- Python 2.7.12, pytest-2.9.2, py-1.4.31, pluggy-0.3.1 -- /home/qui/code/venv/6.2.z/bin/python2
cachedir: .cache
rootdir: /home/qui/code/robottelo, inifile: 
plugins: xdist-1.14, cov-2.3.1
collected 1 items 

tests/foreman/cli/test_hammer.py::HammerCommandsTestCase::test_positive_all_options PASSED

================================================================= 1 passed in 3675.37 seconds =================================================================
```