### PR TITLE
[6.2.z] Quickfix for SCP tests

### DIFF
--- a/tests/foreman/cli/test_classparameters.py
+++ b/tests/foreman/cli/test_classparameters.py
@@ -174,7 +174,7 @@ class SmartClassParametersTestCase(CLITestCase):
         """Checks that there is at least one not overridden
         smart class parameter before executing test.
         """
-        super(SmartClassParameter, self).setUp()
+        super(SmartClassParametersTestCase, self).setUp()
         if len(self.sc_params_list) == 0:
             raise Exception("Not enough smart class parameters. Please "
                             "update puppet module.")


### PR DESCRIPTION
Run results for 6.2.z/6.2.4. One test failed as fixed in 6.3 only.
```
% nosetests tests/foreman/cli/test_classparameters.py                                      [git][robottelo/.][qf_scp]
.SSSS..........SSSSSS..........E...........
======================================================================
----------------------------------------------------------------------
Ran 43 tests in 928.709s
FAILED (SKIP=10, errors=1)
```