### PR TITLE
Do not merge [6.2.z] update broken test ,  to align with API messages changes.

### DIFF
--- a/tests/foreman/api/test_discoveredhost.py
+++ b/tests/foreman/api/test_discoveredhost.py
@@ -21,6 +21,7 @@ from robottelo.datafactory import valid_data_list
 from robottelo.decorators import (
     run_only_on,
     skip_if_bug_open,
+    bz_bug_is_open,
     stubbed,
     tier2,
     tier3,
@@ -145,7 +146,10 @@ class DiscoveryTestCase(APITestCase):
             with self.subTest(name):
                 mac_address = gen_mac()
                 host = _create_discovered_host(name, macaddress=mac_address)
-                host_name = 'mac{0}'.format(mac_address.replace(':', ''))
+                if bz_bug_is_open(1392919):
+                    host_name = 'mac{0}'.format(mac_address.replace(':', ''))
+                else:
+                    host_name = 'mac{0}'.format(host['mac'].replace(':', ''))
                 self.assertEqual(host['name'], host_name)
 
     @stubbed()

--- a/tests/foreman/api/test_discoveredhost.py
+++ b/tests/foreman/api/test_discoveredhost.py
@@ -143,8 +143,9 @@ class DiscoveryTestCase(APITestCase):
         """
         for name in valid_data_list():
             with self.subTest(name):
-                host = _create_discovered_host(name)
-                host_name = 'mac{0}'.format(host['mac'].replace(':', ''))
+                mac_address = gen_mac()
+                host = _create_discovered_host(name, macaddress=mac_address)
+                host_name = 'mac{0}'.format(mac_address.replace(':', ''))
                 self.assertEqual(host['name'], host_name)
 
     @stubbed()


### PR DESCRIPTION
```bash
(2.7) dlezz@elysion:~/projects/robottelo-fork$ py.test tests/foreman/api/test_discoveredhost.py -v -k 'test_positive_upload_facts'
================================================= test session starts ==================================================
platform linux2 -- Python 2.7.12, pytest-2.9.2, py-1.4.31, pluggy-0.3.1 -- /home/dlezz/bin/redhat/6.2.z/python/2.7/bin/python
cachedir: .cache
rootdir: /home/dlezz/projects/robottelo-fork, inifile: 
plugins: xdist-1.14, cov-2.3.1
collected 21 items 

tests/foreman/api/test_discoveredhost.py::DiscoveryTestCase::test_positive_upload_facts <- robottelo/decorators/__init__.py PASSED

================================ 20 tests deselected by '-ktest_positive_upload_facts' =================================
======================================= 1 passed, 20 deselected in 10.19 seconds =======================================
```