### PR TITLE
[6.2.z] cherrypick -- added hostgroup clone api test, fixed lru_cache path

### DIFF
--- a/robottelo/helpers.py
+++ b/robottelo/helpers.py
@@ -18,7 +18,7 @@ from robottelo.config import settings
 if six.PY3:  # pragma: no cover
     from functools import lru_cache  # noqa
 else:  # pragma: no cover
-    from cachetools import lru_cache  # noqa
+    from cachetools.func import lru_cache  # noqa
 
 LOGGER = logging.getLogger(__name__)
 

--- a/tests/foreman/api/test_hostgroup.py
+++ b/tests/foreman/api/test_hostgroup.py
@@ -198,6 +198,24 @@ class HostGroupTestCase(APITestCase):
                 ).create()
                 self.assertEqual(name, hostgroup.name)
 
+    @tier1
+    def test_positive_clone(self):
+        """Create a hostgroup by cloning an existing one
+
+        @id: 44ac8b3b-9cb0-4a9e-ad9b-2c67b2411922
+
+        @assert: A hostgroup is cloned with new name
+        """
+        hostgroup = entities.HostGroup(
+            location=[self.loc],
+            organization=[self.org],
+        ).create()
+        hostgroup_cloned_name = gen_string('alpha', 6)
+        hostgroup_cloned = entities.HostGroup(
+                id=hostgroup.id
+                ).clone(data={u'name': hostgroup_cloned_name})
+        self.assertEqual(hostgroup_cloned[u'name'], hostgroup_cloned_name)
+
     @tier2
     def test_positive_create_with_parent(self):
         """Create a hostgroup with parent hostgroup specified

--- a/tests/foreman/api/test_hostgroup.py
+++ b/tests/foreman/api/test_hostgroup.py
@@ -210,11 +210,11 @@ class HostGroupTestCase(APITestCase):
             location=[self.loc],
             organization=[self.org],
         ).create()
-        hostgroup_cloned_name = gen_string('alpha', 6)
+        hostgroup_cloned_name = gen_string('alpha')
         hostgroup_cloned = entities.HostGroup(
-                id=hostgroup.id
-                ).clone(data={u'name': hostgroup_cloned_name})
-        self.assertEqual(hostgroup_cloned[u'name'], hostgroup_cloned_name)
+            id=hostgroup.id
+        ).clone(data={'name': hostgroup_cloned_name})
+        self.assertEqual(hostgroup_cloned['name'], hostgroup_cloned_name)
 
     @tier2
     def test_positive_create_with_parent(self):


### PR DESCRIPTION
Cherry picked 2 commits adding a test for hostgroup clone API call. Test result:

``` 
nosetests tests/foreman/api/test_hostgroup.py:HostGroupTestCase.test_positive_clone
.
----------------------------------------------------------------------
Ran 1 test in 7.942s

OK
```

Also fixed the lru_cache path in a separate commit, this was fixed in master a while ago in https://github.com/SatelliteQE/robottelo/pull/3883

