### PR TITLE
Fix cli.test_contentview.py weak assertions.

### DIFF
--- a/tests/foreman/cli/test_contentview.py
+++ b/tests/foreman/cli/test_contentview.py
@@ -758,8 +758,7 @@ class ContentViewTestCase(CLITestCase):
             ContentView.publish({u'id': new_cv['id']})
         new_cv = ContentView.info({u'id': new_cv['id']})
         # Let us now store the version ids
-        component_ids = [new_cv['versions'][0]['id'],
-                         new_cv['versions'][1]['id']]
+        component_ids = [version['id'] for version in new_cv['versions']]
         # Create CV
         comp_cv = make_content_view({
             'composite': True,
@@ -770,8 +769,8 @@ class ContentViewTestCase(CLITestCase):
         # to the component_ids input values
         comp_cv = ContentView.info({u'id': comp_cv['id']})
         self.assertEqual(
-            [comp['id'] for comp in comp_cv['components']],
-            component_ids,
+            {comp['id'] for comp in comp_cv['components']},
+            set(component_ids),
             'IDs of the composite content view components differ from '
             'the input values',
         )
@@ -1739,9 +1738,9 @@ class ContentViewTestCase(CLITestCase):
         # Actual assert for this test happens HERE
         # Test whether the version1 now belongs to Library
         version1 = ContentView.version_info({u'id': version1_id})
-        self.assertEqual(
-            version1['lifecycle-environments'][0]['label'],
+        self.assertIn(
             ENVIRONMENT,
+            [env['label'] for env in version1['lifecycle-environments']],
             'Version 1 is not in Library',
         )
         # Promotion of version1 to Dev env
@@ -1752,9 +1751,9 @@ class ContentViewTestCase(CLITestCase):
         # The only way to validate whether env has the version is to
         # validate that version has the env.
         version1 = ContentView.version_info({u'id': version1_id})
-        self.assertEqual(
-            version1['lifecycle-environments'][1]['id'],
+        self.assertIn(
             self.env1['id'],
+            [env['id'] for env in version1['lifecycle-environments']],
             'Promotion of version1 not successful to the env',
         )
         # Now Publish version2 of CV
@@ -1765,9 +1764,9 @@ class ContentViewTestCase(CLITestCase):
         version2_id = new_cv['versions'][1]['id']
         # Test whether the version2 now belongs to Library
         version2 = ContentView.version_info({u'id': version2_id})
-        self.assertEqual(
-            version2['lifecycle-environments'][0]['label'],
+        self.assertIn(
             ENVIRONMENT,
+            [env['label'] for env in version2['lifecycle-environments']],
             'Version 2 not in Library'
         )
         # Promotion of version2 to Dev env
@@ -1778,9 +1777,9 @@ class ContentViewTestCase(CLITestCase):
         # Actual assert for this test happens here.
         # Test whether the version2 now belongs to next env
         version2 = ContentView.version_info({u'id': version2_id})
-        self.assertEqual(
-            version2['lifecycle-environments'][1]['id'],
+        self.assertIn(
             self.env1['id'],
+            [env['id'] for env in version2['lifecycle-environments']],
             'Promotion of version2 not successful to the env',
         )
 
@@ -1825,9 +1824,9 @@ class ContentViewTestCase(CLITestCase):
         version1_id = new_cv['versions'][0]['id']
         # Test whether the version1 now belongs to Library
         version = ContentView.version_info({u'id': version1_id})
-        self.assertEqual(
-            version['lifecycle-environments'][0]['label'],
+        self.assertIn(
             ENVIRONMENT,
+            [env['label'] for env in version['lifecycle-environments']],
             'Version 1 is not in Library',
         )
         # Promotion of version1 to Dev env
@@ -1839,9 +1838,9 @@ class ContentViewTestCase(CLITestCase):
         # validate that version has the env.
         # Test whether the version1 now belongs to next env
         version1 = ContentView.version_info({u'id': version1_id})
-        self.assertEqual(
-            version1['lifecycle-environments'][1]['id'],
+        self.assertIn(
             self.env1['id'],
+            [env['id'] for env in version1['lifecycle-environments']],
             'Promotion of version1 not successful to the env',
         )
         # Now Publish version2 of CV
@@ -1856,9 +1855,9 @@ class ContentViewTestCase(CLITestCase):
             1,
             'Version1 may still exist in Library',
         )
-        self.assertNotEqual(
-            version1['lifecycle-environments'][0]['label'],
+        self.assertNotIn(
             ENVIRONMENT,
+            [env['label'] for env in version1['lifecycle-environments']],
             'Version1 still exists in Library',
         )
         # Only after we publish version2 the info is populated.


### PR DESCRIPTION
Fixes #3903.
I hope that I found all the affected tests.
```python
% py.test -v tests/foreman/cli/test_contentview.py -k 'test_positive_create_composite_with_component_ids or test_positive_update_version_once or test_positive_update_version_multiple'
===================================================================== test session starts =====================================================================
platform linux2 -- Python 2.7.12, pytest-3.0.3, py-1.4.31, pluggy-0.4.0 -- /home/qui/code/venv/2/bin/python2
cachedir: .cache
rootdir: /home/qui/code/robottelo, inifile: 
plugins: xdist-1.15.0, cov-2.3.1
collected 62 items 

tests/foreman/cli/test_contentview.py::ContentViewTestCase::test_positive_create_composite_with_component_ids <- robottelo/decorators/__init__.py PASSED
tests/foreman/cli/test_contentview.py::ContentViewTestCase::test_positive_update_version_multiple <- robottelo/decorators/__init__.py PASSED
tests/foreman/cli/test_contentview.py::ContentViewTestCase::test_positive_update_version_once <- robottelo/decorators/__init__.py PASSED

===================================================================== 59 tests deselected =====================================================================
========================================================== 3 passed, 59 deselected in 398.59 seconds ==========================================================
```