### PR TITLE
[6.2.z] Improve bz_bug_is_open() logic

### DIFF
--- a/robottelo/decorators/__init__.py
+++ b/robottelo/decorators/__init__.py
@@ -368,13 +368,15 @@ def bz_bug_is_open(bug_id):
     except BugFetchError as err:
         LOGGER.warning(err)
         return False
+    # NOT_FOUND, ON_QA, VERIFIED, RELEASE_PENDING, CLOSED
     if bug is None or bug.status not in BZ_OPEN_STATUSES:
-        # if not upstream mode, verify whiteboard field for the presence of
-        # 'verified in upstream' text
-        if (not settings.upstream and bug.whiteboard and
-                'verified in upstream' in bug.whiteboard.lower()):
+        # do not test bugs with whiteboard 'verified in upstream' in downstream
+        # until they are in 'CLOSED' state
+        if (not settings.upstream and bug.status != 'CLOSED' and bug.whiteboard
+                and 'verified in upstream' in bug.whiteboard.lower()):
             return True
         return False
+    # NEW, ASSIGNED, MODIFIED, POST
     return True
 
 

--- a/tests/robottelo/test_decorators.py
+++ b/tests/robottelo/test_decorators.py
@@ -108,7 +108,11 @@ class BzBugIsOpenTestCase(TestCase):
         decorators._get_bugzilla_bug = lambda bug_id: MockBug()
         for MockBug.status in BZ_OPEN_STATUSES + BZ_CLOSED_STATUSES:
             for MockBug.whiteboard in self.valid_whiteboard_data:
-                self.assertTrue(decorators.bz_bug_is_open(self.bug_id))
+                # 'CLOSED' state overides whiteboard 'verified in upstream'
+                if MockBug.status == 'CLOSED':
+                    self.assertFalse(decorators.bz_bug_is_open(self.bug_id))
+                else:
+                    self.assertTrue(decorators.bz_bug_is_open(self.bug_id))
 
     @mock.patch('robottelo.decorators.settings')
     def test_downstream_closedbug_invalid_whiteboard(self, dec_settings):


### PR DESCRIPTION
Improve bz_bug_is_open() logic
- improve logic for downstream when dealing with bugs 'verified in upstream'
- adapt robottelo tests to handle this logic

(Implements #3896)