### PR TITLE
flake8 version bump (to the same version as 6.2.z has)

### DIFF
--- a/requirements-freeze.txt
+++ b/requirements-freeze.txt
@@ -11,7 +11,7 @@ docutils==0.12
 ecdsa==0.13
 execnet==1.4.1
 fauxfactory==2.0.9
-flake8==2.5.4
+flake8==3.0.4
 funcsigs==0.4
 inflection==0.3.1
 Inflector==2.0.11
@@ -19,7 +19,7 @@ Jinja2==2.8
 lazy-object-proxy==1.2.1
 linecache2==1.0.0
 MarkupSafe==0.23
-mccabe==0.4.0
+mccabe==0.5.2
 mock==1.3.0
 nailgun==0.25.0
 numpy==1.10.4


### PR DESCRIPTION
We need similar (or the same) version of linter across branches and compared to version what you have locally.

Otherwise builds are failing for some branches while they are green at your machine.