### PR TITLE
Fix naive proxy retrieval

### DIFF
--- a/tests/foreman/api/test_host.py
+++ b/tests/foreman/api/test_host.py
@@ -179,7 +179,7 @@ class HostTestCase(APITestCase):
 
         @assert: A host is created with expected puppet proxy assigned
         """
-        proxy = entities.SmartProxy().search()[0]
+        proxy = entities.SmartProxy(id=1).read()
         host = entities.Host(puppet_proxy=proxy).create()
         self.assertEqual(host.puppet_proxy.read().name, proxy.name)
 
@@ -192,7 +192,7 @@ class HostTestCase(APITestCase):
 
         @assert: A host is created with expected puppet CA proxy assigned
         """
-        proxy = entities.SmartProxy().search()[0]
+        proxy = entities.SmartProxy(id=1).read()
         host = entities.Host(puppet_ca_proxy=proxy).create()
         self.assertEqual(host.puppet_ca_proxy.read().name, proxy.name)
 
@@ -587,7 +587,7 @@ class HostTestCase(APITestCase):
         @assert: A host is updated with a new puppet proxy
         """
         host = entities.Host().create()
-        new_proxy = entities.SmartProxy().search()[0]
+        new_proxy = entities.SmartProxy(id=1).read()
         host.puppet_proxy = new_proxy
         host = host.update(['puppet_proxy'])
         self.assertEqual(host.puppet_proxy.read().name, new_proxy.name)
@@ -602,7 +602,7 @@ class HostTestCase(APITestCase):
         @assert: A host is updated with a new puppet CA proxy
         """
         host = entities.Host().create()
-        new_proxy = entities.SmartProxy().search()[0]
+        new_proxy = entities.SmartProxy(id=1).read()
         host.puppet_ca_proxy = new_proxy
         host = host.update(['puppet_ca_proxy'])
         self.assertEqual(host.puppet_ca_proxy.read().name, new_proxy.name)

--- a/tests/foreman/api/test_host.py
+++ b/tests/foreman/api/test_host.py
@@ -179,7 +179,9 @@ class HostTestCase(APITestCase):
 
         @assert: A host is created with expected puppet proxy assigned
         """
-        proxy = entities.SmartProxy(id=1).read()
+        proxy = entities.SmartProxy().search(query={
+            'search': 'url = https://{0}:9090'.format(settings.server.hostname)
+        })[0]
         host = entities.Host(puppet_proxy=proxy).create()
         self.assertEqual(host.puppet_proxy.read().name, proxy.name)
 
@@ -192,7 +194,9 @@ class HostTestCase(APITestCase):
 
         @assert: A host is created with expected puppet CA proxy assigned
         """
-        proxy = entities.SmartProxy(id=1).read()
+        proxy = entities.SmartProxy().search(query={
+            'search': 'url = https://{0}:9090'.format(settings.server.hostname)
+        })[0]
         host = entities.Host(puppet_ca_proxy=proxy).create()
         self.assertEqual(host.puppet_ca_proxy.read().name, proxy.name)
 
@@ -587,7 +591,9 @@ class HostTestCase(APITestCase):
         @assert: A host is updated with a new puppet proxy
         """
         host = entities.Host().create()
-        new_proxy = entities.SmartProxy(id=1).read()
+        new_proxy = entities.SmartProxy().search(query={
+            'search': 'url = https://{0}:9090'.format(settings.server.hostname)
+        })[0]
         host.puppet_proxy = new_proxy
         host = host.update(['puppet_proxy'])
         self.assertEqual(host.puppet_proxy.read().name, new_proxy.name)
@@ -602,7 +608,9 @@ class HostTestCase(APITestCase):
         @assert: A host is updated with a new puppet CA proxy
         """
         host = entities.Host().create()
-        new_proxy = entities.SmartProxy(id=1).read()
+        new_proxy = entities.SmartProxy().search(query={
+            'search': 'url = https://{0}:9090'.format(settings.server.hostname)
+        })[0]
         host.puppet_ca_proxy = new_proxy
         host = host.update(['puppet_ca_proxy'])
         self.assertEqual(host.puppet_ca_proxy.read().name, new_proxy.name)

--- a/tests/foreman/api/test_hostgroup.py
+++ b/tests/foreman/api/test_hostgroup.py
@@ -365,7 +365,9 @@ class HostGroupTestCase(APITestCase):
 
         @assert: A hostgroup is created with expected puppet CA proxy assigned
         """
-        proxy = entities.SmartProxy(id=1).read()
+        proxy = entities.SmartProxy().search(query={
+            'search': 'url = https://{0}:9090'.format(settings.server.hostname)
+        })[0]
         hostgroup = entities.HostGroup(
             location=[self.loc],
             organization=[self.org],
@@ -429,7 +431,10 @@ class HostGroupTestCase(APITestCase):
         realm = entities.Realm(
             location=[self.loc],
             organization=[self.org],
-            realm_proxy=entities.SmartProxy(id=1).read()
+            realm_proxy=entities.SmartProxy().search(
+                query={'search': 'url = https://{0}:9090'.format(
+                    settings.server.hostname)}
+            )[0]
         ).create()
         hostgroup = entities.HostGroup(
             location=[self.loc],
@@ -446,7 +451,9 @@ class HostGroupTestCase(APITestCase):
 
         @assert: A hostgroup is created with expected puppet proxy assigned
         """
-        proxy = entities.SmartProxy(id=1).read()
+        proxy = entities.SmartProxy().search(query={
+            'search': 'url = https://{0}:9090'.format(settings.server.hostname)
+        })[0]
         hostgroup = entities.HostGroup(
             location=[self.loc],
             organization=[self.org],
@@ -462,7 +469,9 @@ class HostGroupTestCase(APITestCase):
 
         @assert: A hostgroup is created with expected content source assigned
         """
-        content_source = entities.SmartProxy(id=1).read()
+        content_source = entities.SmartProxy().search(query={
+            'search': 'url = https://{0}:9090'.format(settings.server.hostname)
+        })[0]
         hostgroup = entities.HostGroup(
             content_source=content_source,
             location=[self.loc],
@@ -769,7 +778,9 @@ class HostGroupTestCase(APITestCase):
             location=[self.loc],
             organization=[self.org],
         ).create()
-        new_proxy = entities.SmartProxy(id=1).read()
+        new_proxy = entities.SmartProxy().search(query={
+            'search': 'url = https://{0}:9090'.format(settings.server.hostname)
+        })[0]
         hostgroup.puppet_ca_proxy = new_proxy
         hostgroup = hostgroup.update(['puppet_ca_proxy'])
         self.assertEqual(hostgroup.puppet_ca_proxy.read().name, new_proxy.name)
@@ -844,7 +855,10 @@ class HostGroupTestCase(APITestCase):
         realm = entities.Realm(
             location=[self.loc],
             organization=[self.org],
-            realm_proxy=entities.SmartProxy(id=1).read(),
+            realm_proxy=entities.SmartProxy().search(
+                query={'search': 'url = https://{0}:9090'.format(
+                    settings.server.hostname)}
+            )[0]
         ).create()
         hostgroup = entities.HostGroup(
             location=[self.loc],
@@ -854,7 +868,10 @@ class HostGroupTestCase(APITestCase):
         new_realm = entities.Realm(
             location=[self.loc],
             organization=[self.org],
-            realm_proxy=entities.SmartProxy(id=1).read(),
+            realm_proxy=entities.SmartProxy().search(
+                query={'search': 'url = https://{0}:9090'.format(
+                    settings.server.hostname)}
+            )[0]
         ).create()
         hostgroup.realm = new_realm
         hostgroup = hostgroup.update(['realm'])
@@ -873,7 +890,9 @@ class HostGroupTestCase(APITestCase):
             location=[self.loc],
             organization=[self.org],
         ).create()
-        new_proxy = entities.SmartProxy(id=1).read()
+        new_proxy = entities.SmartProxy().search(query={
+            'search': 'url = https://{0}:9090'.format(settings.server.hostname)
+        })[0]
         hostgroup.puppet_proxy = new_proxy
         hostgroup = hostgroup.update(['puppet_proxy'])
         self.assertEqual(hostgroup.puppet_proxy.read().name, new_proxy.name)
@@ -891,7 +910,9 @@ class HostGroupTestCase(APITestCase):
             location=[self.loc],
             organization=[self.org],
         ).create()
-        new_content_source = entities.SmartProxy(id=1).read()
+        new_content_source = entities.SmartProxy().search(query={
+            'search': 'url = https://{0}:9090'.format(settings.server.hostname)
+        })[0]
         hostgroup.content_source = new_content_source
         hostgroup = hostgroup.update(['content_source'])
         self.assertEqual(

--- a/tests/foreman/api/test_hostgroup.py
+++ b/tests/foreman/api/test_hostgroup.py
@@ -365,7 +365,7 @@ class HostGroupTestCase(APITestCase):
 
         @assert: A hostgroup is created with expected puppet CA proxy assigned
         """
-        proxy = entities.SmartProxy().search()[0]
+        proxy = entities.SmartProxy(id=1).read()
         hostgroup = entities.HostGroup(
             location=[self.loc],
             organization=[self.org],
@@ -429,7 +429,7 @@ class HostGroupTestCase(APITestCase):
         realm = entities.Realm(
             location=[self.loc],
             organization=[self.org],
-            realm_proxy=entities.SmartProxy().search()[0],
+            realm_proxy=entities.SmartProxy(id=1).read()
         ).create()
         hostgroup = entities.HostGroup(
             location=[self.loc],
@@ -446,7 +446,7 @@ class HostGroupTestCase(APITestCase):
 
         @assert: A hostgroup is created with expected puppet proxy assigned
         """
-        proxy = entities.SmartProxy().search()[0]
+        proxy = entities.SmartProxy(id=1).read()
         hostgroup = entities.HostGroup(
             location=[self.loc],
             organization=[self.org],
@@ -462,7 +462,7 @@ class HostGroupTestCase(APITestCase):
 
         @assert: A hostgroup is created with expected content source assigned
         """
-        content_source = entities.SmartProxy().search()[0]
+        content_source = entities.SmartProxy(id=1).read()
         hostgroup = entities.HostGroup(
             content_source=content_source,
             location=[self.loc],
@@ -769,7 +769,7 @@ class HostGroupTestCase(APITestCase):
             location=[self.loc],
             organization=[self.org],
         ).create()
-        new_proxy = entities.SmartProxy().search()[0]
+        new_proxy = entities.SmartProxy(id=1).read()
         hostgroup.puppet_ca_proxy = new_proxy
         hostgroup = hostgroup.update(['puppet_ca_proxy'])
         self.assertEqual(hostgroup.puppet_ca_proxy.read().name, new_proxy.name)
@@ -844,7 +844,7 @@ class HostGroupTestCase(APITestCase):
         realm = entities.Realm(
             location=[self.loc],
             organization=[self.org],
-            realm_proxy=entities.SmartProxy().search()[0],
+            realm_proxy=entities.SmartProxy(id=1).read(),
         ).create()
         hostgroup = entities.HostGroup(
             location=[self.loc],
@@ -854,7 +854,7 @@ class HostGroupTestCase(APITestCase):
         new_realm = entities.Realm(
             location=[self.loc],
             organization=[self.org],
-            realm_proxy=entities.SmartProxy().search()[0],
+            realm_proxy=entities.SmartProxy(id=1).read(),
         ).create()
         hostgroup.realm = new_realm
         hostgroup = hostgroup.update(['realm'])
@@ -873,7 +873,7 @@ class HostGroupTestCase(APITestCase):
             location=[self.loc],
             organization=[self.org],
         ).create()
-        new_proxy = entities.SmartProxy().search()[0]
+        new_proxy = entities.SmartProxy(id=1).read()
         hostgroup.puppet_proxy = new_proxy
         hostgroup = hostgroup.update(['puppet_proxy'])
         self.assertEqual(hostgroup.puppet_proxy.read().name, new_proxy.name)
@@ -891,7 +891,7 @@ class HostGroupTestCase(APITestCase):
             location=[self.loc],
             organization=[self.org],
         ).create()
-        new_content_source = entities.SmartProxy().search()[0]
+        new_content_source = entities.SmartProxy(id=1).read()
         hostgroup.content_source = new_content_source
         hostgroup = hostgroup.update(['content_source'])
         self.assertEqual(

--- a/tests/foreman/api/test_location.py
+++ b/tests/foreman/api/test_location.py
@@ -265,7 +265,7 @@ class LocationTestCase(APITestCase):
         # Add capsule to cleanup list
         self.addCleanup(capsule_cleanup, proxy_id)
 
-        proxy = entities.SmartProxy(id=proxy_id).search()[0]
+        proxy = entities.SmartProxy(id=proxy_id).read()
         location = entities.Location(smart_proxy=[proxy]).create()
         # Add location to cleanup list
         self.addCleanup(location_cleanup, location.id)
@@ -575,12 +575,12 @@ class LocationTestCase(APITestCase):
         self.addCleanup(capsule_cleanup, proxy_id_1)
         self.addCleanup(capsule_cleanup, proxy_id_2)
 
-        proxy = entities.SmartProxy(id=proxy_id_1).search()[0]
+        proxy = entities.SmartProxy(id=proxy_id_1).read()
         location = entities.Location(smart_proxy=[proxy]).create()
         # Add location to cleanup list
         self.addCleanup(location_cleanup, location.id)
 
-        new_proxy = entities.SmartProxy(id=proxy_id_2).search()[0]
+        new_proxy = entities.SmartProxy(id=proxy_id_2).read()
         location.smart_proxy = [new_proxy]
         location = location.update(['smart_proxy'])
         self.assertEqual(location.smart_proxy[0].id, new_proxy.id)
@@ -640,7 +640,7 @@ class LocationTestCase(APITestCase):
         # Add capsule to cleanup list
         self.addCleanup(capsule_cleanup, proxy_id)
 
-        proxy = entities.SmartProxy(id=proxy_id).search()[0]
+        proxy = entities.SmartProxy(id=proxy_id).read()
         location = entities.Location(smart_proxy=[proxy]).create()
         # Add location to cleanup list
         self.addCleanup(location_cleanup, location.id)

--- a/tests/foreman/api/test_organization.py
+++ b/tests/foreman/api/test_organization.py
@@ -349,7 +349,9 @@ class OrganizationUpdateTestCase(APITestCase):
         @CaseLevel: Integration
         """
         # Every Satellite has a built-in smart proxy, so let's find it
-        smart_proxy = entities.SmartProxy(id=1).read()
+        smart_proxy = entities.SmartProxy().search(query={
+            'search': 'url = https://{0}:9090'.format(settings.server.hostname)
+        })[0]
         # By default, newly created organization uses built-in smart proxy,
         # so we need to remove it first
         org = entities.Organization().create()

--- a/tests/foreman/api/test_organization.py
+++ b/tests/foreman/api/test_organization.py
@@ -349,9 +349,7 @@ class OrganizationUpdateTestCase(APITestCase):
         @CaseLevel: Integration
         """
         # Every Satellite has a built-in smart proxy, so let's find it
-        smart_proxies = entities.SmartProxy().search()
-        self.assertGreater(len(smart_proxies), 0)
-        smart_proxy = smart_proxies[0]
+        smart_proxy = entities.SmartProxy(id=1).read()
         # By default, newly created organization uses built-in smart proxy,
         # so we need to remove it first
         org = entities.Organization().create()

--- a/tests/foreman/api/test_organization.py
+++ b/tests/foreman/api/test_organization.py
@@ -339,6 +339,7 @@ class OrganizationUpdateTestCase(APITestCase):
         self.assertEqual(len(org.hostgroup), 0)
 
     @tier2
+    @skip_if_bug_open('bugzilla', 1395229)
     def test_positive_add_smart_proxy(self):
         """Add a smart proxy to an organization
 
@@ -351,7 +352,10 @@ class OrganizationUpdateTestCase(APITestCase):
         # Every Satellite has a built-in smart proxy, so let's find it
         smart_proxy = entities.SmartProxy().search(query={
             'search': 'url = https://{0}:9090'.format(settings.server.hostname)
-        })[0]
+        })
+        # Check that proxy is found and unpack it from the list
+        self.assertGreater(len(smart_proxy), 0)
+        smart_proxy = smart_proxy[0]
         # By default, newly created organization uses built-in smart proxy,
         # so we need to remove it first
         org = entities.Organization().create()

--- a/tests/foreman/api/test_smartproxy.py
+++ b/tests/foreman/api/test_smartproxy.py
@@ -41,9 +41,8 @@ class SmartProxyMissingAttrTestCase(APITestCase):
         existing smart proxy should always succeed.
         """
         super(SmartProxyMissingAttrTestCase, cls).setUpClass()
-        smart_proxies = entities.SmartProxy().search()
-        assert len(smart_proxies) > 0
-        cls.smart_proxy_attrs = set(smart_proxies[0].update_json([]).keys())
+        smart_proxy = entities.SmartProxy(id=1).read()
+        cls.smart_proxy_attrs = set(smart_proxy.update_json([]).keys())
 
     @tier1
     def test_positive_update_loc(self):

--- a/tests/foreman/api/test_smartproxy.py
+++ b/tests/foreman/api/test_smartproxy.py
@@ -15,6 +15,7 @@
 @Upstream: No
 """
 from nailgun import entities
+from robottelo.config import settings
 from robottelo.decorators import (
     skip_if_bug_open,
     tier1,
@@ -41,7 +42,9 @@ class SmartProxyMissingAttrTestCase(APITestCase):
         existing smart proxy should always succeed.
         """
         super(SmartProxyMissingAttrTestCase, cls).setUpClass()
-        smart_proxy = entities.SmartProxy(id=1).read()
+        smart_proxy = entities.SmartProxy().search(query={
+            'search': 'url = https://{0}:9090'.format(settings.server.hostname)
+        })[0]
         cls.smart_proxy_attrs = set(smart_proxy.update_json([]).keys())
 
     @tier1

--- a/tests/foreman/api/test_smartproxy.py
+++ b/tests/foreman/api/test_smartproxy.py
@@ -44,7 +44,10 @@ class SmartProxyMissingAttrTestCase(APITestCase):
         super(SmartProxyMissingAttrTestCase, cls).setUpClass()
         smart_proxy = entities.SmartProxy().search(query={
             'search': 'url = https://{0}:9090'.format(settings.server.hostname)
-        })[0]
+        })
+        # Check that proxy is found and unpack it from the list
+        assert len(smart_proxy) > 0, "No smart proxy is found"
+        smart_proxy = smart_proxy[0]
         cls.smart_proxy_attrs = set(smart_proxy.update_json([]).keys())
 
     @tier1

--- a/tests/foreman/cli/test_gpgkey.py
+++ b/tests/foreman/cli/test_gpgkey.py
@@ -35,7 +35,7 @@ from robottelo.cli.gpgkey import GPGKey
 from robottelo.cli.org import Org
 from robottelo.cli.product import Product
 from robottelo.cli.repository import Repository
-from robottelo.constants import VALID_GPG_KEY_FILE
+from robottelo.constants import DEFAULT_ORG, VALID_GPG_KEY_FILE
 from robottelo.datafactory import invalid_values_list, valid_data_list
 from robottelo.decorators import (
     run_only_on,
@@ -135,9 +135,7 @@ class TestGPGKey(CLITestCase):
 
         @assert: gpg key is created
         """
-        result = Org.list()
-        self.assertGreater(len(result), 0, 'No organization found')
-        org = result[0]
+        org = Org.info({'name': DEFAULT_ORG})
         for name in valid_data_list():
             with self.subTest(name):
                 gpg_key = make_gpg_key({

--- a/tests/foreman/cli/test_host.py
+++ b/tests/foreman/cli/test_host.py
@@ -80,7 +80,9 @@ class HostCreateTestCase(CLITestCase):
         """
         super(HostCreateTestCase, self).setUp()
         # Use the default installation smart proxy
-        self.puppet_proxy = Proxy.info({'id': 1})
+        self.puppet_proxy = Proxy.list({
+            'search': 'url = https://{0}:9090'.format(settings.server.hostname)
+        })[0]
 
     @tier1
     def test_positive_create_with_name(self):
@@ -328,7 +330,9 @@ class HostDeleteTestCase(CLITestCase):
         """Create a host to use in tests"""
         super(HostDeleteTestCase, self).setUp()
         # Use the default installation smart proxy
-        self.puppet_proxy = Proxy.info({'id': 1})
+        self.puppet_proxy = Proxy.list({
+            'search': 'url = https://{0}:9090'.format(settings.server.hostname)
+        })[0]
         self.host = entities.Host()
         self.host.create_missing()
         self.host = Host.create({
@@ -379,7 +383,9 @@ class HostUpdateTestCase(CLITestCase):
     def setUp(self):
         """Create a host to reuse later"""
         super(HostUpdateTestCase, self).setUp()
-        self.puppet_proxy = Proxy.info({'id': 1})
+        self.puppet_proxy = Proxy.list({
+            'search': 'url = https://{0}:9090'.format(settings.server.hostname)
+        })[0]
         # using nailgun to create dependencies
         self.host_args = entities.Host()
         self.host_args.create_missing()
@@ -845,7 +851,9 @@ class HostParameterTestCase(CLITestCase):
     def setUpClass(cls):
         """Create host to tests parameters for"""
         super(HostParameterTestCase, cls).setUpClass()
-        cls.puppet_proxy = Proxy.info({'id': 1})
+        cls.puppet_proxy = Proxy.list({
+            'search': 'url = https://{0}:9090'.format(settings.server.hostname)
+        })[0]
         # using nailgun to create dependencies
         cls.host = entities.Host()
         cls.host.create_missing()

--- a/tests/foreman/cli/test_host.py
+++ b/tests/foreman/cli/test_host.py
@@ -80,9 +80,7 @@ class HostCreateTestCase(CLITestCase):
         """
         super(HostCreateTestCase, self).setUp()
         # Use the default installation smart proxy
-        result = Proxy.list()
-        self.assertGreater(len(result), 0)
-        self.puppet_proxy = result[0]
+        self.puppet_proxy = Proxy.info({'id': 1})
 
     @tier1
     def test_positive_create_with_name(self):
@@ -330,9 +328,7 @@ class HostDeleteTestCase(CLITestCase):
         """Create a host to use in tests"""
         super(HostDeleteTestCase, self).setUp()
         # Use the default installation smart proxy
-        result = Proxy.list()
-        self.assertGreater(len(result), 0)
-        self.puppet_proxy = result[0]
+        self.puppet_proxy = Proxy.info({'id': 1})
         self.host = entities.Host()
         self.host.create_missing()
         self.host = Host.create({
@@ -383,9 +379,7 @@ class HostUpdateTestCase(CLITestCase):
     def setUp(self):
         """Create a host to reuse later"""
         super(HostUpdateTestCase, self).setUp()
-        self.proxies = Proxy.list()
-        self.assertGreater(len(self.proxies), 0)
-        self.puppet_proxy = self.proxies[0]
+        self.puppet_proxy = Proxy.info({'id': 1})
         # using nailgun to create dependencies
         self.host_args = entities.Host()
         self.host_args.create_missing()
@@ -851,9 +845,7 @@ class HostParameterTestCase(CLITestCase):
     def setUpClass(cls):
         """Create host to tests parameters for"""
         super(HostParameterTestCase, cls).setUpClass()
-        cls.proxies = Proxy.list()
-        assert len(cls.proxies) > 0
-        cls.puppet_proxy = cls.proxies[0]
+        cls.puppet_proxy = Proxy.info({'id': 1})
         # using nailgun to create dependencies
         cls.host = entities.Host()
         cls.host.create_missing()

--- a/tests/foreman/cli/test_hostgroup.py
+++ b/tests/foreman/cli/test_hostgroup.py
@@ -35,6 +35,7 @@ from robottelo.cli.factory import (
     make_partition_table,
     make_subnet,
 )
+from robottelo.config import settings
 from robottelo.datafactory import (
     invalid_id_list,
     invalid_values_list,
@@ -162,7 +163,9 @@ class HostGroupTestCase(CLITestCase):
         @Assert: Hostgroup is created and has puppet CA proxy server assigned
 
         """
-        puppet_proxy = Proxy.info({'id': 1})
+        puppet_proxy = Proxy.list({
+            'search': 'url = https://{0}:9090'.format(settings.server.hostname)
+        })[0]
         hostgroup = make_hostgroup({'puppet-ca-proxy': puppet_proxy['name']})
         self.assertEqual(puppet_proxy['id'], hostgroup['puppet-ca-proxy-id'])
 
@@ -175,7 +178,9 @@ class HostGroupTestCase(CLITestCase):
 
         @Assert: Hostgroup is created and has puppet proxy server assigned
         """
-        puppet_proxy = Proxy.list()[0]
+        puppet_proxy = Proxy.list({
+            'search': 'url = https://{0}:9090'.format(settings.server.hostname)
+        })[0]
         hostgroup = make_hostgroup({'puppet-proxy': puppet_proxy['name']})
         self.assertEqual(
             puppet_proxy['id'],
@@ -275,7 +280,9 @@ class HostGroupTestCase(CLITestCase):
             'organization-ids': org['id'],
         })
         lce = make_lifecycle_environment({'organization-id': org['id']})
-        puppet_proxy = Proxy.info({'id': 1})
+        puppet_proxy = Proxy.list({
+            'search': 'url = https://{0}:9090'.format(settings.server.hostname)
+        })[0]
         # Content View should be promoted to be used with LC Env
         cv = make_content_view({'organization-id': org['id']})
         ContentView.publish({'id': cv['id']})

--- a/tests/foreman/cli/test_hostgroup.py
+++ b/tests/foreman/cli/test_hostgroup.py
@@ -162,7 +162,7 @@ class HostGroupTestCase(CLITestCase):
         @Assert: Hostgroup is created and has puppet CA proxy server assigned
 
         """
-        puppet_proxy = Proxy.list()[0]
+        puppet_proxy = Proxy.info({'id': 1})
         hostgroup = make_hostgroup({'puppet-ca-proxy': puppet_proxy['name']})
         self.assertEqual(puppet_proxy['id'], hostgroup['puppet-ca-proxy-id'])
 
@@ -275,7 +275,7 @@ class HostGroupTestCase(CLITestCase):
             'organization-ids': org['id'],
         })
         lce = make_lifecycle_environment({'organization-id': org['id']})
-        puppet_proxy = Proxy.list()[0]
+        puppet_proxy = Proxy.info({'id': 1})
         # Content View should be promoted to be used with LC Env
         cv = make_content_view({'organization-id': org['id']})
         ContentView.publish({'id': cv['id']})

--- a/tests/foreman/cli/test_hostgroup.py
+++ b/tests/foreman/cli/test_hostgroup.py
@@ -316,7 +316,7 @@ class HostGroupTestCase(CLITestCase):
             'organization-ids': org['id'],
         })
 
-        hostgroup = make_hostgroup({
+        make_hostgroup_params = {
             'location-ids': loc['id'],
             'environment-id': env['id'],
             'lifecycle-environment': lce['name'],
@@ -325,12 +325,19 @@ class HostGroupTestCase(CLITestCase):
             'content-view-id': cv['id'],
             'domain-id': domain['id'],
             'subnet-id': subnet['id'],
-            'organization-id': org['id'],
+            'organization-ids': org['id'],
             'architecture-id': arch['id'],
             'partition-table-id': ptable['id'],
             'medium-id': media['id'],
             'operatingsystem-id': os['id'],
-        })
+        }
+        # If bug is open provide LCE id as parameter
+        # because LCE name cause errors
+        if bz_bug_is_open(1395254):
+            make_hostgroup_params.pop('lifecycle-environment')
+            make_hostgroup_params['lifecycle-environment-id'] = lce['id']
+
+        hostgroup = make_hostgroup(make_hostgroup_params)
         self.assertIn(org['name'], hostgroup['organizations'])
         self.assertIn(loc['name'], hostgroup['locations'])
         self.assertEqual(env['name'], hostgroup['environment'])

--- a/tests/foreman/cli/test_location.py
+++ b/tests/foreman/cli/test_location.py
@@ -603,6 +603,7 @@ class LocationTestCase(CLITestCase):
             })
 
     @run_only_on('sat')
+    @skip_if_bug_open('bugzilla', 1395110)
     @tier2
     def test_positive_add_capsule_by_name(self):
         """Add a capsule to location by its name
@@ -628,6 +629,7 @@ class LocationTestCase(CLITestCase):
 
     @run_only_on('sat')
     @tier2
+    @skip_if_bug_open('bugzilla', 1395110)
     def test_positive_add_capsule_by_id(self):
         """Add a capsule to location by its ID
 
@@ -652,6 +654,7 @@ class LocationTestCase(CLITestCase):
 
     @run_only_on('sat')
     @tier2
+    @skip_if_bug_open('bugzilla', 1395110)
     def test_positive_remove_capsule_by_id(self):
         """Remove a capsule from organization by its id
 
@@ -680,6 +683,7 @@ class LocationTestCase(CLITestCase):
 
     @run_only_on('sat')
     @tier2
+    @skip_if_bug_open('bugzilla', 1395110)
     def test_positive_remove_capsule_by_name(self):
         """Remove a capsule from organization by its name
 

--- a/tests/foreman/cli/test_subnet.py
+++ b/tests/foreman/cli/test_subnet.py
@@ -219,13 +219,11 @@ class SubnetTestCase(CLITestCase):
 
         @Assert: Subnet is listed
         """
-        # Fetch current total
-        subnets_before = Subnet.list()
         # Make a new subnet
-        make_subnet()
-        # Fetch total again
-        subnets_after = Subnet.list()
-        self.assertGreater(len(subnets_after), len(subnets_before))
+        subnet = make_subnet()
+        # Fetch ids from subnets list
+        subnets_ids = [subnet_['id'] for subnet_ in Subnet.list()]
+        self.assertIn(subnet['id'], subnets_ids)
 
     @run_only_on('sat')
     @tier1


### PR DESCRIPTION
Fixes #3942
Test run results for 6.3
```python
% nosetests tests/foreman/cli/test_host.py:{HostCreateTestCase,HostDeleteTestCase,HostUpdateTestCase,HostParameterTestCase}           
..............................
----------------------------------------------------------------------
Ran 30 tests in 1684.901s
OK
```
```python
% nosetests tests/foreman/cli/test_hostgroup.py:HostGroupTestCase.test_positive_create_with_puppet_ca_proxy 
.                                                                                                      
----------------------------------------------------------------------
Ran 1 test in 12.701s
OK
```
```python
% nosetests tests/foreman/api/test_host.py:HostTestCase.{test_positive_create_with_puppet_proxy,test_positive_create_with_puppet_ca_proxy,test_positive_update_puppet_proxy,test_positive_update_puppet_ca_proxy}
....python
----------------------------------------------------------------------
Ran 4 tests in 75.776s
OK
```
```python
% nosetests tests/foreman/api/test_hostgroup.py:HostGroupTestCase.{test_positive_create_with_puppet_ca_proxy,test_positive_create_with_realm,test_positive_create_with_puppet_proxy,test_positive_create_with_content_source,test_positive_update_puppet_ca_proxy,test_positive_update_realm,test_positive_update_puppet_proxy,test_positive_update_content_source}      
.S..SSSS
----------------------------------------------------------------------
Ran 8 tests in 20.023s
OK (SKIP=5)
```
`tests/foreman/api/test_smartproxy.py:SmartProxyMissingAttrTestCase` skipped becaus of bug.
`tests/foreman/api/test_organization.py:OrganizationUpdateTestCase.test_positive_add_smart_proxy` fails because of bug in 6.3. However, test passed with the change on 6.2.
`tests/foreman/cli/test_hostgroup.py:HostGroupTestCase.test_positive_create_with_multiple_entities` fails because of bug in 6.3. However, test passed with the change on 6.2.
`tests/foreman/api/test_location.py:LocationTestCase` tests are failing because of bug in 6.3. However, tests passed with the change on 6.2.