### PR TITLE
[6.2.z] #3586-UI-CV-est_positive_clone_within_diff_env cherry-pick (#3996)

### DIFF
--- a/tests/foreman/ui/test_contentview.py
+++ b/tests/foreman/ui/test_contentview.py
@@ -1083,11 +1083,9 @@ class ContentViewTestCase(UITestCase):
                 self.content_views.fetch_yum_content_repo_name(copy_cv_name)
             )
 
-    @stubbed()
     @run_only_on('sat')
     @tier2
     def test_positive_clone_within_diff_env(self):
-        # Dev note: "not implemented yet"
         """attempt to create new content view based on existing
         view, inside a different environment
 
@@ -1095,11 +1093,63 @@ class ContentViewTestCase(UITestCase):
 
         @assert: Content view can be published
 
-        @caseautomation: notautomated
-
-
         @CaseLevel: Integration
         """
+        repo_name = gen_string('alpha')
+        cv_name = gen_string('alpha')
+        env_name = gen_string('alpha')
+        copy_cv_name = gen_string('alpha')
+        copy_env_name = gen_string('alpha')
+        with Session(self.browser) as session:
+            # create a repository
+            self.setup_to_create_cv(repo_name=repo_name)
+            # create a lifecycle environment
+            make_lifecycle_environment(
+                session, org=self.organization.name, name=env_name)
+            # create a content view
+            make_contentview(session, org=self.organization.name, name=cv_name)
+            self.assertIsNotNone(self.content_views.search(cv_name))
+            # add repository to the created content view
+            self.content_views.add_remove_repos(cv_name, [repo_name])
+            self.assertIsNotNone(
+                self.content_views.wait_until_element(
+                    common_locators['alert.success_sub_form'])
+            )
+            # publish the content view
+            version = self.content_views.publish(cv_name)
+            self.assertIsNotNone(
+                self.content_views.wait_until_element(
+                    common_locators['alert.success_sub_form'])
+            )
+            # promote env_name to the content view version
+            self.content_views.promote(cv_name, version, env_name)
+            # assert env_name successfully promoted
+            self.assertIsNotNone(self.content_views.wait_until_element(
+                common_locators['alert.success_sub_form']))
+            # create a new lifecycle environment that we should promote to
+            #  the published version of the copy of content view
+            make_lifecycle_environment(
+                session, org=self.organization.name, name=copy_env_name)
+            # create a copy of content view with a new name
+            self.content_views.copy_view(cv_name, copy_cv_name)
+            # ensure that the copy of the content view exist
+            self.assertIsNotNone(self.content_views.search(copy_cv_name))
+            # ensure that the repository is in the copy of content view
+            self.assertEqual(
+                repo_name,
+                self.content_views.fetch_yum_content_repo_name(copy_cv_name)
+            )
+            # publish the content view copy
+            copy_version = self.content_views.publish(copy_cv_name)
+            self.assertIsNotNone(
+                self.content_views.wait_until_element(
+                    common_locators['alert.success_sub_form'])
+            )
+            # promote the other environment to the copy of content view version
+            self.content_views.promote(
+                copy_cv_name, copy_version, copy_env_name)
+            self.assertIsNotNone(self.content_views.wait_until_element(
+                common_locators['alert.success_sub_form']))
 
     @stubbed()
     @run_only_on('sat')


### PR DESCRIPTION
```bash
(2.7) dlezz@elysion:~/projects/robottelo-fork$ py.test tests/foreman/ui/test_contentview.py -v -k 'test_positive_clone_within_diff_env'
================================================= test session starts ==================================================
platform linux2 -- Python 2.7.12, pytest-2.9.2, py-1.4.31, pluggy-0.3.1 -- /home/dlezz/bin/redhat/6.2.z/python/2.7/bin/python
cachedir: .cache
rootdir: /home/dlezz/projects/robottelo-fork, inifile: 
plugins: xdist-1.14, cov-2.3.1
collected 62 items 

tests/foreman/ui/test_contentview.py::ContentViewTestCase::test_positive_clone_within_diff_env <- robottelo/decorators/__init__.py PASSED

============================ 61 tests deselected by '-ktest_positive_clone_within_diff_env' ============================
====================================== 1 passed, 61 deselected in 230.28 seconds =======================================
```
