### PR TITLE
[Cherry pick to 6.2.z] Automated host listing its own errata

### DIFF
--- a/tests/foreman/cli/test_host.py
+++ b/tests/foreman/cli/test_host.py
@@ -16,6 +16,7 @@
 """
 from fauxfactory import gen_mac, gen_string
 from nailgun import entities
+from robottelo import ssh
 from robottelo.cli.base import CLIReturnCodeError
 from robottelo.cli.factory import (
     make_activation_key,
@@ -1144,3 +1145,21 @@ class KatelloAgentTestCase(CLITestCase):
         result = self.client.run(
             'yum install -y {0}'.format(FAKE_1_CUSTOM_PACKAGE))
         self.assertNotEqual(result.return_code, 0)
+
+
+class HostErrataTestCase(CLITestCase):
+    """Tests for errata's host sub command"""
+
+    @tier1
+    def test_positive_errata_list_of_sat_server(self):
+        """Check if errata list doesn't raise exception. Check BZ for details.
+
+        @id: 6b22f0c0-9c4b-11e6-ab93-68f72889dc7f
+
+        @assert: Satellite host errata list not failing
+
+        @BZ: 1351040
+        """
+        hostname = ssh.command('hostname').stdout[0]
+        host = Host.info({'name': hostname})
+        self.assertIsInstance(Host.errata_list({'host-id': host['id']}), list)


### PR DESCRIPTION
close #3950

(cherry picked from commit 3cf7617)

[Bz](https://bugzilla.redhat.com/show_bug.cgi?id=1351040) is verified only on 6.3, still not working on 6.2.4, besides target milestone is 6.2:

```console
E           CLIReturnCodeError: Command "host errata list" finished with return_code 70
E           stderr contains following message:
E           [ERROR 2016-11-17 11:00:10 Exception] undefined method `installable_errata' for nil:NilClass
```
On 6.3:

```console

============================= 39 tests deselected ==============================
=================== 1 passed, 39 deselected in 16.51 seconds ===================
```