### PR TITLE
#3586-test_positive_publish-promote_composite_with_custom_content

### DIFF
--- a/tests/foreman/ui/test_contentview.py
+++ b/tests/foreman/ui/test_contentview.py
@@ -1461,7 +1461,12 @@ class ContentViewTestCase(UITestCase):
                 filter_term='Latest'
             )
             # publish the first content
-            self.content_views.publish(cv1_name)
+            cv1_version = self.content_views.publish(cv1_name)
+            self.assertIsNotNone(self.content_views.wait_until_element(
+                common_locators['alert.success_sub_form']))
+            # promote the first content view to environment
+            self.content_views.promote(
+                cv1_name, cv1_version, env_name)
             self.assertIsNotNone(self.content_views.wait_until_element(
                 common_locators['alert.success_sub_form']))
             # create the second content view

--- a/tests/foreman/ui/test_contentview.py
+++ b/tests/foreman/ui/test_contentview.py
@@ -34,6 +34,8 @@ from robottelo.constants import (
     DOCKER_REGISTRY_HUB,
     ENVIRONMENT,
     FAKE_0_PUPPET_REPO,
+    FAKE_1_PUPPET_REPO,
+    FAKE_0_YUM_REPO,
     FAKE_1_YUM_REPO,
     FEDORA23_OSTREE_REPO,
     FILTER_CONTENT_TYPE,
@@ -1127,8 +1129,9 @@ class ContentViewTestCase(UITestCase):
             self.assertIsNotNone(self.content_views.wait_until_element(
                 common_locators['alert.success_sub_form']))
 
-    @stubbed()
+    @run_in_one_thread
     @run_only_on('sat')
+    @skip_if_not_set('fake_manifest')
     @tier2
     def test_positive_promote_composite_with_custom_content(self):
         # Variations:
@@ -1144,13 +1147,103 @@ class ContentViewTestCase(UITestCase):
 
         @steps: create a composite view containing multiple content types
 
-        @assert: Content view can be promoted
-
-        @caseautomation: notautomated
-
+        @assert: Composite content view can be promoted
 
         @CaseLevel: Integration
         """
+        env_name = gen_string('alpha')
+        cv1_name = gen_string('alpha')
+        cv2_name = gen_string('alpha')
+        cv_composite_name = gen_string('alpha')
+        custom_repo1_name = gen_string('alpha')
+        custom_repo2_name = gen_string('alpha')
+        custom_repo1_url = FAKE_0_YUM_REPO
+        custom_repo2_url = FAKE_1_YUM_REPO
+        puppet_repo1_url = FAKE_0_PUPPET_REPO
+        puppet_repo2_url = FAKE_1_PUPPET_REPO
+        puppet_module1 = 'httpd'
+        puppet_module2 = 'ntp'
+        rh7_repo = {
+            'name': REPOS['rhst7']['name'],
+            'product': PRDS['rhel'],
+            'reposet': REPOSET['rhst7'],
+            'basearch': 'x86_64',
+            'releasever': None,
+        }
+        org = entities.Organization().create()
+        with Session(self.browser) as session:
+            # create a life cycle environment
+            make_lifecycle_environment(
+                session, org=org.name, name=env_name)
+            # create repositories
+            self.setup_to_create_cv(rh_repo=rh7_repo, org_id=org.id)
+            self.setup_to_create_cv(
+                repo_name=custom_repo1_name,
+                repo_url=custom_repo1_url,
+                org_id=org.id
+            )
+            self.setup_to_create_cv(
+                repo_name=custom_repo2_name,
+                repo_url=custom_repo2_url,
+                org_id=org.id
+            )
+            self.setup_to_create_cv(
+                repo_url=puppet_repo1_url,
+                repo_type=REPO_TYPE['puppet'],
+                org_id=org.id
+            )
+            self.setup_to_create_cv(
+                repo_url=puppet_repo2_url,
+                repo_type=REPO_TYPE['puppet'],
+                org_id=org.id
+            )
+            # create the first content view
+            make_contentview(session, org=org.name, name=cv1_name)
+            self.assertIsNotNone(self.content_views.search(cv1_name))
+            # add repositories to first content view
+            self.content_views.add_remove_repos(
+                cv1_name, [rh7_repo['name'], custom_repo1_name])
+            # add the first puppet module to first content view
+            self.content_views.add_puppet_module(
+                cv1_name,
+                puppet_module1,
+                filter_term='Latest'
+            )
+            # publish the first content
+            self.content_views.publish(cv1_name)
+            self.assertIsNotNone(self.content_views.wait_until_element(
+                common_locators['alert.success_sub_form']))
+            # create the second content view
+            make_contentview(session, org=org.name, name=cv2_name)
+            self.assertIsNotNone(self.content_views.search(cv2_name))
+            # add repositories to the second content view
+            self.content_views.add_remove_repos(
+                cv2_name, [custom_repo2_name])
+            # add the second puppet module to the second content view
+            self.content_views.add_puppet_module(
+                cv2_name,
+                puppet_module2,
+                filter_term='Latest'
+            )
+            # publish the second content
+            self.content_views.publish(cv2_name)
+            self.assertIsNotNone(self.content_views.wait_until_element(
+                common_locators['alert.success_sub_form']))
+            # create a composite content view
+            self.content_views.create(cv_composite_name, is_composite=True)
+            self.assertIsNotNone(self.content_views.search(cv_composite_name))
+            # add the first and second content views to the composite one
+            self.content_views.add_remove_cv(
+                cv_composite_name, [cv1_name, cv2_name])
+            # publish the composite content view
+            version_name = self.content_views.publish(cv_composite_name)
+            self.assertIsNotNone(self.content_views.wait_until_element(
+                common_locators['alert.success_sub_form']))
+            # promote the composite content view
+            self.content_views.promote(
+                cv_composite_name, version_name, env_name)
+            self.assertIsNotNone(self.content_views.wait_until_element(
+                common_locators['alert.success_sub_form']))
 
     @run_in_one_thread
     @run_only_on('sat')
@@ -1289,8 +1382,9 @@ class ContentViewTestCase(UITestCase):
             self.assertIsNotNone(self.content_views.wait_until_element(
                 common_locators['alert.success_sub_form']))
 
-    @stubbed()
+    @run_in_one_thread
     @run_only_on('sat')
+    @skip_if_not_set('fake_manifest')
     @tier2
     def test_positive_publish_composite_with_custom_content(self):
         # Variations:
@@ -1304,13 +1398,98 @@ class ContentViewTestCase(UITestCase):
 
         @setup: Multiple environments for an org; custom content synced
 
-        @assert: Content view can be published
-
-        @caseautomation: notautomated
-
+        @assert: Composite content view can be published
 
         @CaseLevel: Integration
         """
+        env_name = gen_string('alpha')
+        cv1_name = gen_string('alpha')
+        cv2_name = gen_string('alpha')
+        cv_composite_name = gen_string('alpha')
+        custom_repo1_name = gen_string('alpha')
+        custom_repo2_name = gen_string('alpha')
+        custom_repo1_url = FAKE_0_YUM_REPO
+        custom_repo2_url = FAKE_1_YUM_REPO
+        puppet_repo1_url = FAKE_0_PUPPET_REPO
+        puppet_repo2_url = FAKE_1_PUPPET_REPO
+        puppet_module1 = 'httpd'
+        puppet_module2 = 'ntp'
+        rh7_repo = {
+            'name': REPOS['rhst7']['name'],
+            'product': PRDS['rhel'],
+            'reposet': REPOSET['rhst7'],
+            'basearch': 'x86_64',
+            'releasever': None,
+        }
+        org = entities.Organization().create()
+        with Session(self.browser) as session:
+            # create a life cycle environment
+            make_lifecycle_environment(
+                session, org=org.name, name=env_name)
+            # create repositories
+            self.setup_to_create_cv(rh_repo=rh7_repo, org_id=org.id)
+            self.setup_to_create_cv(
+                repo_name=custom_repo1_name,
+                repo_url=custom_repo1_url,
+                org_id=org.id
+            )
+            self.setup_to_create_cv(
+                repo_name=custom_repo2_name,
+                repo_url=custom_repo2_url,
+                org_id=org.id
+            )
+            self.setup_to_create_cv(
+                repo_url=puppet_repo1_url,
+                repo_type=REPO_TYPE['puppet'],
+                org_id=org.id
+            )
+            self.setup_to_create_cv(
+                repo_url=puppet_repo2_url,
+                repo_type=REPO_TYPE['puppet'],
+                org_id=org.id
+            )
+            # create the first content view
+            make_contentview(session, org=org.name, name=cv1_name)
+            self.assertIsNotNone(self.content_views.search(cv1_name))
+            # add repositories to first content view
+            self.content_views.add_remove_repos(
+                cv1_name, [rh7_repo['name'], custom_repo1_name])
+            # add the first puppet module to first content view
+            self.content_views.add_puppet_module(
+                cv1_name,
+                puppet_module1,
+                filter_term='Latest'
+            )
+            # publish the first content
+            self.content_views.publish(cv1_name)
+            self.assertIsNotNone(self.content_views.wait_until_element(
+                common_locators['alert.success_sub_form']))
+            # create the second content view
+            make_contentview(session, org=org.name, name=cv2_name)
+            self.assertIsNotNone(self.content_views.search(cv2_name))
+            # add repositories to the second content view
+            self.content_views.add_remove_repos(
+                cv2_name, [custom_repo2_name])
+            # add the second puppet module to the second content view
+            self.content_views.add_puppet_module(
+                cv2_name,
+                puppet_module2,
+                filter_term='Latest'
+            )
+            # publish the second content
+            self.content_views.publish(cv2_name)
+            self.assertIsNotNone(self.content_views.wait_until_element(
+                common_locators['alert.success_sub_form']))
+            # create a composite content view
+            self.content_views.create(cv_composite_name, is_composite=True)
+            self.assertIsNotNone(self.content_views.search(cv_composite_name))
+            # add the first and second content views to the composite one
+            self.content_views.add_remove_cv(
+                cv_composite_name, [cv1_name, cv2_name])
+            # publish the composite content view
+            self.content_views.publish(cv_composite_name)
+            self.assertIsNotNone(self.content_views.wait_until_element(
+                common_locators['alert.success_sub_form']))
 
     @run_only_on('sat')
     @tier2


### PR DESCRIPTION
```bash
"!!! Congratulations your changes are good to fly, make a great PR! dlezz++ !!!"
```
```bash
(2.7) dlezz@elysion:~/projects/robottelo-fork$ py.test tests/foreman/ui/test_contentview.py -v -k 'test_positive_promote_composite_with_custom_content'
================================================= test session starts ==================================================
platform linux2 -- Python 2.7.12, pytest-3.0.3, py-1.4.31, pluggy-0.4.0 -- /home/dlezz/bin/redhat/python/2.7/bin/python
cachedir: .cache
rootdir: /home/dlezz/projects/robottelo-fork, inifile: 
plugins: cov-2.4.0, xdist-1.15.0
collected 64 items 

tests/foreman/ui/test_contentview.py::ContentViewTestCase::test_positive_promote_composite_with_custom_content <- robottelo/decorators/__init__.py PASSED

================================================= 63 tests deselected ==================================================
====================================== 1 passed, 63 deselected in 494.23 seconds =======================================
```
```bash
(2.7) dlezz@elysion:~/projects/robottelo-fork$ py.test tests/foreman/ui/test_contentview.py -v -k 'test_positive_publish_composite_with_custom_content'
================================================= test session starts ==================================================
platform linux2 -- Python 2.7.12, pytest-3.0.3, py-1.4.31, pluggy-0.4.0 -- /home/dlezz/bin/redhat/python/2.7/bin/python
cachedir: .cache
rootdir: /home/dlezz/projects/robottelo-fork, inifile: 
plugins: cov-2.4.0, xdist-1.15.0
collected 64 items 

tests/foreman/ui/test_contentview.py::ContentViewTestCase::test_positive_publish_composite_with_custom_content <- robottelo/decorators/__init__.py PASSED

================================================= 63 tests deselected ==================================================
====================================== 1 passed, 63 deselected in 489.09 seconds =======================================
```