### PR TITLE
Implemented UI repository-set disable test

### DIFF
--- a/robottelo/ui/sync.py
+++ b/robottelo/ui/sync.py
@@ -9,6 +9,7 @@ from functools import partial
 from robottelo.constants import PRDS, REPOSET
 from robottelo.ui.base import Base
 from robottelo.ui.locators import locators, tab_locators
+from robottelo.ui.navigator import Navigator
 
 
 class Sync(Base):
@@ -130,6 +131,7 @@ class Sync(Base):
         :return: None.
 
         """
+        Navigator(self.browser).go_to_red_hat_repositories()
         # Locator to select content tabs from Red Hat repositories page
         # e.g. 'RPMs', 'KIckstarts', 'ISOs', 'OSTree'
         repo_tab_locator = 'manifest.{0}_tab'.format(repo_tab.lower())

--- a/tests/foreman/endtoend/test_ui_endtoend.py
+++ b/tests/foreman/endtoend/test_ui_endtoend.py
@@ -213,7 +213,6 @@ class EndToEndTestCase(UITestCase, ClientProvisioningMixin):
 
             # step 2.7: Enable a Red Hat repository
             if self.fake_manifest_is_set:
-                session.nav.go_to_red_hat_repositories()
                 self.sync.enable_rh_repos(repos, REPO_TAB['rpms'])
 
             # step 2.8: Synchronize the three repositories
@@ -358,7 +357,6 @@ class EndToEndTestCase(UITestCase, ClientProvisioningMixin):
             self.assertTrue(session.nav.wait_until_element(
                 common_locators['alert.success']
             ))
-            session.nav.go_to_red_hat_repositories()
             # List of dictionary passed to enable the redhat repos
             # It selects Product->Reposet-> Repo
             self.sync.enable_rh_repos(repos, REPO_TAB['rpms'])

--- a/tests/foreman/ui/test_repository.py
+++ b/tests/foreman/ui/test_repository.py
@@ -20,10 +20,12 @@ import time
 
 from fauxfactory import gen_string
 from nailgun import entities
-from robottelo import ssh
+from robottelo import manifests, ssh
+from robottelo.api.utils import upload_manifest
 from robottelo.constants import (
     CHECKSUM_TYPE,
     DOCKER_REGISTRY_HUB,
+    DOWNLOAD_POLICIES,
     FAKE_0_PUPPET_REPO,
     FAKE_1_YUM_REPO,
     FAKE_2_YUM_REPO,
@@ -31,18 +33,27 @@ from robottelo.constants import (
     FAKE_YUM_SRPM_REPO,
     FEDORA22_OSTREE_REPO,
     FEDORA23_OSTREE_REPO,
+    PRDS,
     REPO_DISCOVERY_URL,
+    REPO_TAB,
     REPO_TYPE,
+    REPOS,
+    SAT6_TOOLS_TREE,
     VALID_GPG_KEY_BETA_FILE,
     VALID_GPG_KEY_FILE,
-    DOWNLOAD_POLICIES
 )
 from robottelo.datafactory import (
     filtered_datapoint,
     generate_strings_list,
     invalid_values_list,
 )
-from robottelo.decorators import run_only_on, stubbed, tier1, tier2
+from robottelo.decorators import (
+    run_in_one_thread,
+    run_only_on,
+    stubbed,
+    tier1,
+    tier2,
+)
 from robottelo.decorators.host import skip_if_os
 from robottelo.helpers import read_data_file
 from robottelo.test import UITestCase
@@ -929,6 +940,8 @@ class RepositoryTestCase(UITestCase):
         @id: 1967a540-a265-4046-b87b-627524b63688
 
         @Assert: srpms can be listed in repository
+
+        @CaseLevel: Integration
         """
         product = entities.Product(organization=self.session_org).create()
         repo_name = gen_string('alphanumeric')
@@ -966,6 +979,8 @@ class RepositoryTestCase(UITestCase):
         @id: 2a57cbde-c616-440d-8bcb-6e18bd2d5c5f
 
         @Assert: srpms can be listed in content view
+
+        @CaseLevel: Integration
         """
         product = entities.Product(organization=self.session_org).create()
         repo_name = gen_string('alphanumeric')
@@ -1015,6 +1030,8 @@ class RepositoryTestCase(UITestCase):
 
         @Assert: srpms can be listed in content view in proper lifecycle
         environment
+
+        @CaseLevel: Integration
         """
         lce = entities.LifecycleEnvironment(
             organization=self.session_org).create()
@@ -1068,6 +1085,8 @@ class RepositoryTestCase(UITestCase):
         @id: 5e703d9a-ea26-4062-9d5c-d31bfbe87417
 
         @Assert: drpms can be listed in repository
+
+        @CaseLevel: Integration
         """
         product = entities.Product(organization=self.session_org).create()
         repo_name = gen_string('alphanumeric')
@@ -1105,6 +1124,8 @@ class RepositoryTestCase(UITestCase):
         @id: cffa862c-f972-4aa4-96b2-5a4513cb3eef
 
         @Assert: drpms can be listed in content view
+
+        @CaseLevel: Integration
         """
         product = entities.Product(organization=self.session_org).create()
         repo_name = gen_string('alphanumeric')
@@ -1154,6 +1175,8 @@ class RepositoryTestCase(UITestCase):
 
         @Assert: drpms can be listed in content view in proper lifecycle
         environment
+
+        @CaseLevel: Integration
         """
         lce = entities.LifecycleEnvironment(
             organization=self.session_org).create()
@@ -1199,3 +1222,38 @@ class RepositoryTestCase(UITestCase):
         )
         self.assertEqual(result.return_code, 0)
         self.assertGreaterEqual(len(result.stdout), 1)
+
+    @run_in_one_thread
+    @tier2
+    def test_positive_reposet_disable(self):
+        """Enable RH repo, sync it and then disable
+
+        @id: de596c56-1327-49e8-86d5-a1ab907f26aa
+
+        @Assert: RH repo was disabled
+
+        @CaseLevel: Integration
+        """
+        org = entities.Organization().create()
+        with manifests.clone() as manifest:
+            upload_manifest(org.id, manifest.content)
+        repos = self.sync.create_repos_tree(SAT6_TOOLS_TREE)
+        with Session(self.browser) as session:
+            session.nav.go_to_select_org(org.name)
+            session.nav.go_to_red_hat_repositories()
+            # Enable RH repository
+            self.sync.enable_rh_repos(repos, REPO_TAB['rpms'])
+            session.nav.go_to_sync_status()
+            # Sync the repo and verify sync was successful
+            self.assertTrue(self.sync.sync_noversion_rh_repos(
+                PRDS['rhel'], [REPOS['rhst6']['name']]
+            ))
+            session.nav.go_to_red_hat_repositories()
+            # Click the checkbox once more to disable the repo
+            self.sync.enable_rh_repos(repos, REPO_TAB['rpms'])
+            # Verify the repo is disabled
+            self.assertFalse(
+                self.sync.wait_until_element(
+                    locators['rh.repo_checkbox'] % repos[0][0][0]['repo_name']
+                ).is_selected()
+            )

--- a/tests/foreman/ui/test_repository.py
+++ b/tests/foreman/ui/test_repository.py
@@ -1240,7 +1240,6 @@ class RepositoryTestCase(UITestCase):
         repos = self.sync.create_repos_tree(SAT6_TOOLS_TREE)
         with Session(self.browser) as session:
             session.nav.go_to_select_org(org.name)
-            session.nav.go_to_red_hat_repositories()
             # Enable RH repository
             self.sync.enable_rh_repos(repos, REPO_TAB['rpms'])
             session.nav.go_to_sync_status()
@@ -1248,7 +1247,6 @@ class RepositoryTestCase(UITestCase):
             self.assertTrue(self.sync.sync_noversion_rh_repos(
                 PRDS['rhel'], [REPOS['rhst6']['name']]
             ))
-            session.nav.go_to_red_hat_repositories()
             # Click the checkbox once more to disable the repo
             self.sync.enable_rh_repos(repos, REPO_TAB['rpms'])
             # Verify the repo is disabled

--- a/tests/foreman/ui/test_sync.py
+++ b/tests/foreman/ui/test_sync.py
@@ -103,7 +103,6 @@ class SyncTestCase(UITestCase):
             upload_manifest(self.organization.id, manifest.content)
         with Session(self.browser) as session:
             session.nav.go_to_select_org(self.organization.name)
-            session.nav.go_to_red_hat_repositories()
             self.sync.enable_rh_repos(repos, REPO_TAB['rpms'])
             session.nav.go_to_sync_status()
             sync = self.sync.sync_rh_repos(repos)
@@ -191,7 +190,6 @@ class SyncTestCase(UITestCase):
             upload_manifest(org.id, manifest.content)
         with Session(self.browser) as session:
             session.nav.go_to_select_org(org.name)
-            session.nav.go_to_red_hat_repositories()
             self.sync.enable_rh_repos(repos, repo_tab=REPO_TAB['ostree'])
             session.nav.go_to_sync_status()
             self.assertTrue(self.sync.sync_noversion_rh_repos(


### PR DESCRIPTION
Part of #2439
Test results:
```python
py.test tests/foreman/ui/test_repository.py -k test_positive_reposet_disable -v
================================================ test session starts ================================================
platform linux2 -- Python 2.7.10, pytest-3.0.3, py-1.4.31, pluggy-0.4.0 -- /home/andrii/env/bin/python
cachedir: .cache
rootdir: /home/andrii/workspace/robottelo, inifile: 
plugins: xdist-1.13.1, repeat-0.2
collected 38 items 

tests/foreman/ui/test_repository.py::RepositoryTestCase::test_positive_reposet_disable PASSED

================================================ 37 tests deselected ================================================
===================================== 1 passed, 37 deselected in 285.25 seconds =====================================
```