### PR TITLE
fixes #4011 - Modify default_download_policy test to fetch value from settings

### DIFF
--- a/tests/foreman/api/test_repository.py
+++ b/tests/foreman/api/test_repository.py
@@ -186,12 +186,16 @@ class RepositoryTestCase(APITestCase):
 
         @Assert: YUM repository with a default download policy
         """
+
+        default_dl_policy = entities.Setting().search(
+            query={'search': 'name=default_download_policy'}
+        )
+        self.assertTrue(default_dl_policy)
         repo = entities.Repository(
             product=self.product,
             content_type='yum'
         ).create()
-        # this default value can change to 'on_demand' in future
-        self.assertEqual(repo.download_policy, 'immediate')
+        self.assertEqual(repo.download_policy, default_dl_policy[0].value)
 
     @tier1
     def test_positive_create_immediate_update_to_on_demand(self):

--- a/tests/foreman/cli/test_repository.py
+++ b/tests/foreman/cli/test_repository.py
@@ -32,6 +32,7 @@ from robottelo.cli.factory import (
     CLIFactoryError
 )
 from robottelo.cli.repository import Repository
+from robottelo.cli.settings import Settings
 from robottelo.constants import (
     FEDORA23_OSTREE_REPO,
     DOCKER_REGISTRY_HUB,
@@ -235,8 +236,14 @@ class RepositoryTestCase(CLITestCase):
 
         @Assert: YUM repository with a default download policy
         """
+        default_dl_policy = Settings.list(
+            {'search': 'name=default_download_policy'}
+        )
+        self.assertTrue(default_dl_policy)
         new_repo = self._make_repository({u'content-type': u'yum'})
-        self.assertEqual(new_repo['download-policy'], 'immediate')
+        self.assertEqual(
+            new_repo['download-policy'], default_dl_policy[0]['value']
+        )
 
     @tier1
     def test_positive_create_immediate_update_to_on_demand(self):

--- a/tests/foreman/ui/test_repository.py
+++ b/tests/foreman/ui/test_repository.py
@@ -719,13 +719,19 @@ class RepositoryTestCase(UITestCase):
         @Assert: YUM repository with a default download policy
         """
         repo_name = gen_string('alphanumeric')
+        default_dl_policy = entities.Setting().search(
+            query={'search': 'name=default_download_policy'}
+        )
+        self.assertTrue(default_dl_policy and
+                        DOWNLOAD_POLICIES.get(default_dl_policy[0].value))
+        default_dl_policy = DOWNLOAD_POLICIES.get(default_dl_policy[0].value)
         with Session(self.browser) as session:
             session.nav.go_to_select_org(self.session_org.name, force=False)
             self.products.search_and_click(self.session_prod.name)
             make_repository(session, name=repo_name, repo_type='yum')
             self.assertTrue(
                 self.repository.validate_field(
-                    repo_name, 'download_policy', 'Immediate'
+                    repo_name, 'download_policy', default_dl_policy
                 )
             )
 


### PR DESCRIPTION
partially [1/2] addresses: https://github.com/SatelliteQE/robottelo/issues/4011
This should not only fix the recent failure due to the change in default dl policy value, but it should link the test to the actual value in the settings, making the test dynamic and prone to future default value changes.