### PR TITLE
[6.2.z] Implemented UI repository-set disable test (#4008)

### DIFF
--- a/robottelo/ui/sync.py
+++ b/robottelo/ui/sync.py
@@ -9,6 +9,7 @@ from functools import partial
 from robottelo.constants import PRDS, REPOSET
 from robottelo.ui.base import Base
 from robottelo.ui.locators import locators
+from robottelo.ui.navigator import Navigator
 
 
 class Sync(Base):
@@ -129,6 +130,7 @@ class Sync(Base):
         :return: None.
 
         """
+        Navigator(self.browser).go_to_red_hat_repositories()
         strategy, value = locators['rh.prd_expander']
         strategy1, value1 = locators['rh.reposet_expander']
         strategy2, value2 = locators['rh.reposet_checkbox']

--- a/tests/foreman/endtoend/test_ui_endtoend.py
+++ b/tests/foreman/endtoend/test_ui_endtoend.py
@@ -212,7 +212,6 @@ class EndToEndTestCase(UITestCase, ClientProvisioningMixin):
 
             # step 2.7: Enable a Red Hat repository
             if self.fake_manifest_is_set:
-                session.nav.go_to_red_hat_repositories()
                 self.sync.enable_rh_repos(repos)
 
             # step 2.8: Synchronize the three repositories
@@ -357,7 +356,6 @@ class EndToEndTestCase(UITestCase, ClientProvisioningMixin):
             self.assertTrue(session.nav.wait_until_element(
                 common_locators['alert.success']
             ))
-            session.nav.go_to_red_hat_repositories()
             # List of dictionary passed to enable the redhat repos
             # It selects Product->Reposet-> Repo
             self.sync.enable_rh_repos(repos)

--- a/tests/foreman/ui/test_sync.py
+++ b/tests/foreman/ui/test_sync.py
@@ -94,7 +94,6 @@ class SyncTestCase(UITestCase):
             upload_manifest(self.organization.id, manifest.content)
         with Session(self.browser) as session:
             session.nav.go_to_select_org(self.organization.name)
-            session.nav.go_to_red_hat_repositories()
             self.sync.enable_rh_repos(repos)
             session.nav.go_to_sync_status()
             sync = self.sync.sync_rh_repos(repos)


### PR DESCRIPTION
* Implemented UI repository-set disable test

Part of #2439

* Moved navigation to entity inside enable_rh_repos() method

```python
py.test tests/foreman/ui/test_repository.py -k test_positive_reposet_disable -v
=============================== test session starts ===============================
platform linux2 -- Python 2.7.10, pytest-2.9.2, py-1.4.31, pluggy-0.3.1 -- /home/andrii/env62z/bin/python
cachedir: .cache
rootdir: /home/andrii/workspace/robottelo, inifile: 
plugins: xdist-1.14, cov-2.3.1
collected 32 items 

tests/foreman/ui/test_repository.py::RepositoryTestCase::test_positive_reposet_disable PASSED

============ 31 tests deselected by '-ktest_positive_reposet_disable' =============
==================== 1 passed, 31 deselected in 150.38 seconds ====================
```