### PR TITLE
[master] fix #4022 and #4023 in api/test_multiple_paths.py

### DIFF
--- a/tests/foreman/api/test_multiple_paths.py
+++ b/tests/foreman/api/test_multiple_paths.py
@@ -36,8 +36,9 @@ BZ_1118015_ENTITIES = (
     entities.ContentView, entities.DockerComputeResource, entities.Environment,
     entities.GPGKey, entities.Host, entities.HostCollection,
     entities.HostGroup, entities.LibvirtComputeResource,
-    entities.LifecycleEnvironment, entities.OperatingSystem, entities.Product,
-    entities.Repository, entities.Role, entities.Subnet, entities.User,
+    entities.LifecycleEnvironment, entities.OperatingSystem,
+    entities.Organization, entities.Product, entities.Repository,
+    entities.Role, entities.Subnet, entities.User,
 )
 
 
@@ -170,7 +171,7 @@ class EntityTestCase(APITestCase):
         )
         for entity_cls in set(valid_entities()) - set(exclude_list):
             with self.subTest(entity_cls):
-                logger.debug('test_get_status_code arg: %s', entity_cls)
+                self.logger.info('test_get_status_code arg: %s', entity_cls)
                 skip_if_sam(self, entity_cls)
                 response = client.get(
                     entity_cls().path(),
@@ -197,7 +198,7 @@ class EntityTestCase(APITestCase):
         )
         for entity_cls in set(valid_entities()) - set(exclude_list):
             with self.subTest(entity_cls):
-                logger.debug('test_get_unauthorized arg: %s', entity_cls)
+                self.logger.info('test_get_unauthorized arg: %s', entity_cls)
                 skip_if_sam(self, entity_cls)
                 response = client.get(
                     entity_cls().path(),
@@ -220,7 +221,7 @@ class EntityTestCase(APITestCase):
         )
         for entity_cls in set(valid_entities()) - set(exclude_list):
             with self.subTest(entity_cls):
-                logger.debug('test_post_status_code arg: %s', entity_cls)
+                self.logger.info('test_post_status_code arg: %s', entity_cls)
                 skip_if_sam(self, entity_cls)
 
                 # Libvirt compute resources suffer from BZ 1118015. However,
@@ -252,7 +253,7 @@ class EntityTestCase(APITestCase):
         )
         for entity_cls in set(valid_entities()) - set(exclude_list):
             with self.subTest(entity_cls):
-                logger.debug('test_post_unauthorized arg: %s', entity_cls)
+                self.logger.info('test_post_unauthorized arg: %s', entity_cls)
                 skip_if_sam(self, entity_cls)
                 server_cfg = get_nailgun_config()
                 server_cfg.auth = ()
@@ -278,7 +279,7 @@ class EntityIdTestCase(APITestCase):
         )
         for entity_cls in set(valid_entities()) - set(exclude_list):
             with self.subTest(entity_cls):
-                logger.debug('test_get_status_code arg: %s', entity_cls)
+                self.logger.info('test_get_status_code arg: %s', entity_cls)
                 skip_if_sam(self, entity_cls)
                 try:
                     entity = entity_cls(id=entity_cls().create_json()['id'])
@@ -306,7 +307,7 @@ class EntityIdTestCase(APITestCase):
             exclude_list += (entities.HostGroup,)
         for entity_cls in set(valid_entities()) - set(exclude_list):
             with self.subTest(entity_cls):
-                logger.debug('test_put_status_code arg: %s', entity_cls)
+                self.logger.info('test_put_status_code arg: %s', entity_cls)
                 skip_if_sam(self, entity_cls)
 
                 # Create an entity
@@ -343,7 +344,7 @@ class EntityIdTestCase(APITestCase):
         )
         for entity_cls in set(valid_entities()) - set(exclude_list):
             with self.subTest(entity_cls):
-                logger.debug('test_delete_status_code arg: %s', entity_cls)
+                self.logger.info('test_delete_status_code arg: %s', entity_cls)
                 skip_if_sam(self, entity_cls)
                 try:
                     entity = entity_cls(id=entity_cls().create_json()['id'])
@@ -393,7 +394,7 @@ class DoubleCheckTestCase(APITestCase):
             exclude_list += (entities.HostGroup, )
         for entity_cls in set(valid_entities()) - set(exclude_list):
             with self.subTest(entity_cls):
-                logger.debug('test_put_and_get arg: %s', entity_cls)
+                self.logger.info('test_put_and_get arg: %s', entity_cls)
                 skip_if_sam(self, entity_cls)
 
                 # Create an entity.
@@ -432,7 +433,7 @@ class DoubleCheckTestCase(APITestCase):
         )
         for entity_cls in set(valid_entities()) - set(exclude_list):
             with self.subTest(entity_cls):
-                logger.debug('test_post_and_get arg: %s', entity_cls)
+                self.logger.info('test_post_and_get arg: %s', entity_cls)
                 skip_if_sam(self, entity_cls)
 
                 entity = entity_cls()
@@ -459,7 +460,7 @@ class DoubleCheckTestCase(APITestCase):
         )
         for entity_cls in set(valid_entities()) - set(exclude_list):
             with self.subTest(entity_cls):
-                logger.debug('test_delete_and_get arg: %s', entity_cls)
+                self.logger.info('test_delete_and_get arg: %s', entity_cls)
                 skip_if_sam(self, entity_cls)
 
                 # Create an entity, delete it and get it.
@@ -495,7 +496,7 @@ class EntityReadTestCase(APITestCase):
         )
         for entity_cls in set(valid_entities()) - set(exclude_list):
             with self.subTest(entity_cls):
-                logger.debug('test_entity_read arg: %s', entity_cls)
+                self.logger.info('test_entity_read arg: %s', entity_cls)
                 skip_if_sam(self, entity_cls)
                 entity_id = entity_cls().create_json()['id']
                 self.assertIsInstance(


### PR DESCRIPTION
fixes #4022 
- fix logging in api/test_multiple_paths.py
- fix logging level

fixes #4023 
- add entities.Organization to the BZ_1118015_ENTITIES

```bash
$ nosetests -m test_positive_post_status_code test_multiple_paths.py -s
2016-11-24 11:56:07 - robottelo - DEBUG - Started setUpClass: tests.foreman.api.test_multiple_paths/EntityTestCase
2016-11-24 11:56:07 - robottelo - DEBUG - Started Test: EntityTestCase/test_positive_post_status_code
2016-11-24 11:56:07 - robottelo - INFO - test_post_status_code arg: <class 'nailgun.entities.Organization'>
2016-11-24 11:56:07 - robottelo.decorators - INFO - Bugzilla bug 1118015 not in cache. Fetching.
2016-11-24 11:56:08 - robottelo - DEBUG - Finished Test: EntityTestCase/test_positive_post_status_code
S2016-11-24 11:56:08 - robottelo - DEBUG - Started tearDownClass: tests.foreman.api.test_multiple_paths/EntityTestCase

----------------------------------------------------------------------
Ran 1 test in 1.034s

OK (SKIP=1)
```