### PR TITLE
[6.2.z] fixes #4022 and #4023 in api/test_multiple_paths.py

### DIFF
--- a/tests/foreman/api/test_multiple_paths.py
+++ b/tests/foreman/api/test_multiple_paths.py
@@ -36,8 +36,9 @@ BZ_1118015_ENTITIES = (
     entities.ContentView, entities.DockerComputeResource, entities.Environment,
     entities.GPGKey, entities.Host, entities.HostCollection,
     entities.HostGroup, entities.LibvirtComputeResource,
-    entities.LifecycleEnvironment, entities.OperatingSystem, entities.Product,
-    entities.Repository, entities.Role, entities.Subnet, entities.User,
+    entities.LifecycleEnvironment, entities.OperatingSystem,
+    entities.Organization, entities.Product, entities.Repository,
+    entities.Role, entities.Subnet, entities.User,
 )
 BZ_1154156_ENTITIES = (entities.ConfigTemplate, entities.Host, entities.User)
 BZ_1187366_ENTITIES = (entities.LifecycleEnvironment, entities.Organization)
@@ -172,7 +173,7 @@ class EntityTestCase(APITestCase):
         )
         for entity_cls in set(valid_entities()) - set(exclude_list):
             with self.subTest(entity_cls):
-                logger.debug('test_get_status_code arg: %s', entity_cls)
+                self.logger.info('test_get_status_code arg: %s', entity_cls)
                 skip_if_sam(self, entity_cls)
                 response = client.get(
                     entity_cls().path(),
@@ -199,7 +200,7 @@ class EntityTestCase(APITestCase):
         )
         for entity_cls in set(valid_entities()) - set(exclude_list):
             with self.subTest(entity_cls):
-                logger.debug('test_get_unauthorized arg: %s', entity_cls)
+                self.logger.info('test_get_unauthorized arg: %s', entity_cls)
                 skip_if_sam(self, entity_cls)
                 response = client.get(
                     entity_cls().path(),
@@ -222,7 +223,7 @@ class EntityTestCase(APITestCase):
         )
         for entity_cls in set(valid_entities()) - set(exclude_list):
             with self.subTest(entity_cls):
-                logger.debug('test_post_status_code arg: %s', entity_cls)
+                self.logger.info('test_post_status_code arg: %s', entity_cls)
                 skip_if_sam(self, entity_cls)
 
                 # Libvirt compute resources suffer from BZ 1118015. However,
@@ -254,7 +255,7 @@ class EntityTestCase(APITestCase):
         )
         for entity_cls in set(valid_entities()) - set(exclude_list):
             with self.subTest(entity_cls):
-                logger.debug('test_post_unauthorized arg: %s', entity_cls)
+                self.logger.info('test_post_unauthorized arg: %s', entity_cls)
                 skip_if_sam(self, entity_cls)
                 server_cfg = get_nailgun_config()
                 server_cfg.auth = ()
@@ -280,7 +281,7 @@ class EntityIdTestCase(APITestCase):
         )
         for entity_cls in set(valid_entities()) - set(exclude_list):
             with self.subTest(entity_cls):
-                logger.debug('test_get_status_code arg: %s', entity_cls)
+                self.logger.info('test_get_status_code arg: %s', entity_cls)
                 skip_if_sam(self, entity_cls)
                 try:
                     entity = entity_cls(id=entity_cls().create_json()['id'])
@@ -306,7 +307,7 @@ class EntityIdTestCase(APITestCase):
         )
         for entity_cls in set(valid_entities()) - set(exclude_list):
             with self.subTest(entity_cls):
-                logger.debug('test_put_status_code arg: %s', entity_cls)
+                self.logger.info('test_put_status_code arg: %s', entity_cls)
                 skip_if_sam(self, entity_cls)
                 if (entity_cls in BZ_1154156_ENTITIES and
                         bz_bug_is_open(1154156)):
@@ -346,7 +347,7 @@ class EntityIdTestCase(APITestCase):
         )
         for entity_cls in set(valid_entities()) - set(exclude_list):
             with self.subTest(entity_cls):
-                logger.debug('test_delete_status_code arg: %s', entity_cls)
+                self.logger.info('test_delete_status_code arg: %s', entity_cls)
                 skip_if_sam(self, entity_cls)
                 if (entity_cls == entities.ConfigTemplate and
                         bz_bug_is_open(1096333)):
@@ -400,7 +401,7 @@ class DoubleCheckTestCase(APITestCase):
         )
         for entity_cls in set(valid_entities()) - set(exclude_list):
             with self.subTest(entity_cls):
-                logger.debug('test_put_and_get arg: %s', entity_cls)
+                self.logger.info('test_put_and_get arg: %s', entity_cls)
                 skip_if_sam(self, entity_cls)
                 if (entity_cls in BZ_1154156_ENTITIES and
                         bz_bug_is_open(1154156)):
@@ -442,7 +443,7 @@ class DoubleCheckTestCase(APITestCase):
         )
         for entity_cls in set(valid_entities()) - set(exclude_list):
             with self.subTest(entity_cls):
-                logger.debug('test_post_and_get arg: %s', entity_cls)
+                self.logger.info('test_post_and_get arg: %s', entity_cls)
                 skip_if_sam(self, entity_cls)
                 if (entity_cls in BZ_1154156_ENTITIES and
                         bz_bug_is_open(1154156)):
@@ -472,7 +473,7 @@ class DoubleCheckTestCase(APITestCase):
         )
         for entity_cls in set(valid_entities()) - set(exclude_list):
             with self.subTest(entity_cls):
-                logger.debug('test_delete_and_get arg: %s', entity_cls)
+                self.logger.info('test_delete_and_get arg: %s', entity_cls)
                 skip_if_sam(self, entity_cls)
                 if (entity_cls is entities.ConfigTemplate and
                         bz_bug_is_open(1096333)):
@@ -514,7 +515,7 @@ class EntityReadTestCase(APITestCase):
         )
         for entity_cls in set(valid_entities()) - set(exclude_list):
             with self.subTest(entity_cls):
-                logger.debug('test_entity_read arg: %s', entity_cls)
+                self.logger.info('test_entity_read arg: %s', entity_cls)
                 skip_if_sam(self, entity_cls)
                 entity_id = entity_cls().create_json()['id']
                 self.assertIsInstance(


### PR DESCRIPTION
fixes https://github.com/SatelliteQE/robottelo/issues/4022
- fix logging
- fix logging level

fixes #4023 
- add entities.Organization to the BZ_1118015_ENTITIES

```bash
$ nosetests -m test_positive_post_status_code test_multiple_paths.py -s
2016-11-24 12:07:34 - robottelo - DEBUG - Started setUpClass: tests.foreman.api.test_multiple_paths/EntityTestCase
2016-11-24 12:07:34 - robottelo - DEBUG - Started Test: EntityTestCase/test_positive_post_status_code
2016-11-24 12:07:34 - robottelo - INFO - test_post_status_code arg: <class 'nailgun.entities.Organization'>
2016-11-24 12:07:34 - robottelo.decorators - INFO - Bugzilla bug 1118015 not in cache. Fetching.
2016-11-24 12:07:35 - robottelo - DEBUG - Finished Test: EntityTestCase/test_positive_post_status_code
S2016-11-24 12:07:35 - robottelo - DEBUG - Started tearDownClass: tests.foreman.api.test_multiple_paths/EntityTestCase

----------------------------------------------------------------------
Ran 1 test in 1.023s

OK (SKIP=1)

```