### PR TITLE
[6.1.z] - fix #4022 and #4023 in api/test_multiple_paths.py

### DIFF
--- a/tests/foreman/api/test_multiple_paths.py
+++ b/tests/foreman/api/test_multiple_paths.py
@@ -21,9 +21,9 @@ BZ_1118015_ENTITIES = (
     entities.ContentView, entities.DockerComputeResource, entities.Environment,
     entities.GPGKey, entities.Host, entities.HostCollection,
     entities.HostGroup, entities.LibvirtComputeResource,
-    entities.LifecycleEnvironment, entities.OperatingSystem, entities.Product,
-    entities.Repository, entities.Role, entities.Subnet, entities.System,
-    entities.User,
+    entities.LifecycleEnvironment, entities.OperatingSystem,
+    entities.Organization, entities.Product, entities.Repository,
+    entities.Role, entities.Subnet, entities.User,
 )
 BZ_1154156_ENTITIES = (entities.ConfigTemplate, entities.Host, entities.User)
 BZ_1187366_ENTITIES = (entities.LifecycleEnvironment, entities.Organization)
@@ -163,7 +163,7 @@ class EntityTestCase(APITestCase):
         )
         for entity_cls in set(valid_entities()) - set(exclude_list):
             with self.subTest(entity_cls):
-                logger.debug('test_get_status_code arg: %s', entity_cls)
+                self.logger.info('test_get_status_code arg: %s', entity_cls)
                 skip_if_sam(self, entity_cls)
                 response = client.get(
                     entity_cls().path(),
@@ -190,7 +190,7 @@ class EntityTestCase(APITestCase):
         )
         for entity_cls in set(valid_entities()) - set(exclude_list):
             with self.subTest(entity_cls):
-                logger.debug('test_get_unauthorized arg: %s', entity_cls)
+                self.logger.info('test_get_unauthorized arg: %s', entity_cls)
                 skip_if_sam(self, entity_cls)
                 response = client.get(
                     entity_cls().path(),
@@ -213,7 +213,7 @@ class EntityTestCase(APITestCase):
         )
         for entity_cls in set(valid_entities()) - set(exclude_list):
             with self.subTest(entity_cls):
-                logger.debug('test_post_status_code arg: %s', entity_cls)
+                self.logger.info('test_post_status_code arg: %s', entity_cls)
                 skip_if_sam(self, entity_cls)
 
                 # Libvirt compute resources suffer from BZ 1118015. However,
@@ -245,7 +245,7 @@ class EntityTestCase(APITestCase):
         )
         for entity_cls in set(valid_entities()) - set(exclude_list):
             with self.subTest(entity_cls):
-                logger.debug('test_post_unauthorized arg: %s', entity_cls)
+                self.logger.info('test_post_unauthorized arg: %s', entity_cls)
                 skip_if_sam(self, entity_cls)
                 server_cfg = get_nailgun_config()
                 server_cfg.auth = ()
@@ -271,7 +271,7 @@ class EntityIdTestCase(APITestCase):
         )
         for entity_cls in set(valid_entities()) - set(exclude_list):
             with self.subTest(entity_cls):
-                logger.debug('test_get_status_code arg: %s', entity_cls)
+                self.logger.info('test_get_status_code arg: %s', entity_cls)
                 skip_if_sam(self, entity_cls)
                 try:
                     entity = entity_cls(id=entity_cls().create_json()['id'])
@@ -297,7 +297,7 @@ class EntityIdTestCase(APITestCase):
         )
         for entity_cls in set(valid_entities()) - set(exclude_list):
             with self.subTest(entity_cls):
-                logger.debug('test_put_status_code arg: %s', entity_cls)
+                self.logger.info('test_put_status_code arg: %s', entity_cls)
                 skip_if_sam(self, entity_cls)
                 if (entity_cls in BZ_1154156_ENTITIES and
                         bz_bug_is_open(1154156)):
@@ -337,7 +337,7 @@ class EntityIdTestCase(APITestCase):
         )
         for entity_cls in set(valid_entities()) - set(exclude_list):
             with self.subTest(entity_cls):
-                logger.debug('test_delete_status_code arg: %s', entity_cls)
+                self.logger.info('test_delete_status_code arg: %s', entity_cls)
                 skip_if_sam(self, entity_cls)
                 if (entity_cls == entities.ConfigTemplate and
                         bz_bug_is_open(1096333)):
@@ -391,7 +391,7 @@ class DoubleCheckTestCase(APITestCase):
         )
         for entity_cls in set(valid_entities()) - set(exclude_list):
             with self.subTest(entity_cls):
-                logger.debug('test_put_and_get arg: %s', entity_cls)
+                self.logger.info('test_put_and_get arg: %s', entity_cls)
                 skip_if_sam(self, entity_cls)
                 if (entity_cls in BZ_1154156_ENTITIES and
                         bz_bug_is_open(1154156)):
@@ -433,7 +433,7 @@ class DoubleCheckTestCase(APITestCase):
         )
         for entity_cls in set(valid_entities()) - set(exclude_list):
             with self.subTest(entity_cls):
-                logger.debug('test_post_and_get arg: %s', entity_cls)
+                self.logger.info('test_post_and_get arg: %s', entity_cls)
                 skip_if_sam(self, entity_cls)
                 if (entity_cls in BZ_1154156_ENTITIES and
                         bz_bug_is_open(1154156)):
@@ -463,7 +463,7 @@ class DoubleCheckTestCase(APITestCase):
         )
         for entity_cls in set(valid_entities()) - set(exclude_list):
             with self.subTest(entity_cls):
-                logger.debug('test_delete_and_get arg: %s', entity_cls)
+                self.logger.info('test_delete_and_get arg: %s', entity_cls)
                 skip_if_sam(self, entity_cls)
                 if (entity_cls is entities.ConfigTemplate and
                         bz_bug_is_open(1096333)):
@@ -509,7 +509,7 @@ class EntityReadTestCase(APITestCase):
         )
         for entity_cls in set(valid_entities()) - set(exclude_list):
             with self.subTest(entity_cls):
-                logger.debug('test_entity_read arg: %s', entity_cls)
+                self.logger.info('test_entity_read arg: %s', entity_cls)
                 skip_if_sam(self, entity_cls)
                 if entity_cls == entities.System and bz_bug_is_open(1223494):
                     self.skipTest('Cannot read all system attributes.')


### PR DESCRIPTION
fixes #4022
- fix logging in api/test_multiple_paths.py
- fix logging level

fixes #4023
- add entities.Organization to the BZ_1118015_ENTITIES

```bash
 nosetests -m test_positive_post_status_code test_multiple_paths.py -s
2016-11-24 12:01:07 - robottelo - INFO - test_post_status_code arg: <class 'nailgun.entities.Organization'>
2016-11-24 12:01:07 - robottelo.decorators - INFO - Bugzilla bug 1118015 not in cache. Fetching.
S
----------------------------------------------------------------------
Ran 1 test in 0.991s

OK (SKIP=1)

```