### PR TITLE
[master] add BZ1398392 decorator for cli.test_domain

### DIFF
--- a/tests/foreman/cli/test_domain.py
+++ b/tests/foreman/cli/test_domain.py
@@ -23,7 +23,7 @@ from robottelo.cli.factory import make_domain, make_location, make_org
 from robottelo.datafactory import (
     filtered_datapoint, invalid_id_list, valid_data_list
 )
-from robottelo.decorators import run_only_on, tier1
+from robottelo.decorators import run_only_on, tier1, bz_bug_is_open
 from robottelo.test import CLITestCase
 
 
@@ -45,10 +45,12 @@ def valid_create_params():
 @filtered_datapoint
 def invalid_create_params():
     """Returns a list of invalid domain create parameters"""
-    return [
-        {u'dns-id': '-1'},
+    params = [
         {u'name': gen_string(str_type='utf8', length=256)},
     ]
+    if not bz_bug_is_open(1398392):
+        params.append({u'dns-id': '-1'})
+    return params
 
 
 @filtered_datapoint
@@ -69,11 +71,13 @@ def valid_update_params():
 @filtered_datapoint
 def invalid_update_params():
     """Returns a list of invalid domain update parameters"""
-    return [
+    params = [
         {u'name': ''},
         {u'name': gen_string(str_type='utf8', length=256)},
-        {u'dns-id': '-1'},
     ]
+    if not bz_bug_is_open(1398392):
+        params.append({u'dns-id': '-1'})
+    return params
 
 
 @filtered_datapoint


### PR DESCRIPTION
Fixes https://github.com/SatelliteQE/robottelo/issues/4032

```bash
$ nosetests -s -m test_negative_create test_domain.py 
2016-11-24 17:51:01 - robottelo - DEBUG - Started setUpClass: tests.foreman.cli.test_domain/DomainTestCase
2016-11-24 17:51:01 - robottelo - DEBUG - Started Test: DomainTestCase/test_negative_create
2016-11-24 17:51:01 - robottelo.decorators - INFO - Bugzilla bug 1398392 not in cache. Fetching.
2016-11-24 17:51:04 - robottelo.ssh - INFO - Instantiated Paramiko client 0x7fcc1ef19c10
2016-11-24 17:51:04 - robottelo.ssh - DEBUG - Connected to [sat63.com]
2016-11-24 17:51:04 - robottelo.ssh - DEBUG - >>> LANG=en_US.UTF-8  hammer -v -u admin -p changeme --output=csv domain create --name="𩾅𦅗膢䝉僚쓶𒀋魞𩧊텲𩘭𢡉鯕憣𪡿𠐀𥳛𧲊ꈖ볼𤁻𠉼𩺅𢂏𪄫𧋃𒃓诞鸼躬𠼼𪁒ꗸ䕥𡢣𧽺𦀹𡷇𨘿𥝶胘𤂗逞陮륈琴𡥆ᗻ𦌂𥀅峒知𡺸聧𤂘癓𩮚𧣵𫂛헠𨿺𥪓ꌽ𩆄벙졾𒇫䢺𐒌𨣻𐭥𠂯꽃㛹𩷈䑸쿬𠇨鰐𦷪𥐯𧺉𨿙𠲱𠤦渐荀𦖢哨ዶ𤜿𦚭𩽬𨨀제䒏엷㕔塷ﴴ𩉉𫑁𩇙𦙷𥎆䱳𥀧揥ꋚ斥𨽸𣧥𦀲𣈸凿禲튝𤢖ⶻ鄒𦵐箯𢢫ණ놇𧇯ĩ𪫔𥴬Ἀ𢎧㳜읹𥟗穅羢왼뛛콣ᒾ愕𨘭偭𥳎Ƽ䈳𧻎Ⴄ𩅐剢𨰚𠜺蔞𐱂敍퍠𩋾䣟𢼕ⵘ𪉲ㅱ𡫵뚨𪆐찐㬻𦄏𣎜趏𣡩襧𣙄ᑅ탢玓𢑤𠹱𢀗삗𪭜𢒑鲵짆梌𧯙𠨿𥞜爜𠎢𤰃𡛪𧶷擜ṷ饕斦𢜾𢉭ﮞ칂𩆸𥆪𨟎𥖔𥄩𩔺Ꮇ𪫰𠆨𝜚䢿𥚦𢊽쀆윅𫜤悕ⱱ𤝮𣃝㰎𩿨㚐𨓮𪥚𤎴쪚𨝿𐤩𣈾𤌫𨅥𢙳𡠪𪀶𢥎盪𣤇𣏡𦔜𧇎𪵁좱𢂾𡪷𦒪眇𢆝𠨋𪕲ꄔ뾹𤙸톦𢯷"
2016-11-24 17:51:05 - robottelo.ssh - DEBUG - <<< stderr
[ERROR 2016-11-24 11:51:05 API] 422 Unprocessable Entity
[ERROR 2016-11-24 11:51:05 Exception] DNS domain is too long (maximum is 255 characters)
Could not create the domain:
  DNS domain is too long (maximum is 255 characters)

2016-11-24 17:51:05 - robottelo.ssh - INFO - Destroying Paramiko client 0x7fcc1ef19c10
2016-11-24 17:51:05 - robottelo.ssh - INFO - Destroyed Paramiko client 0x7fcc1ef19c10
2016-11-24 17:51:05 - robottelo - DEBUG - Finished Test: DomainTestCase/test_negative_create
.2016-11-24 17:51:05 - robottelo - DEBUG - Started tearDownClass: tests.foreman.cli.test_domain/DomainTestCase

----------------------------------------------------------------------
Ran 1 test in 4.251s

OK
```