### PR TITLE
[6.2.z] add BZ1398392 decorator for cli.test_domain

### DIFF
--- a/tests/foreman/cli/test_domain.py
+++ b/tests/foreman/cli/test_domain.py
@@ -23,7 +23,7 @@ from robottelo.cli.factory import make_domain, make_location, make_org
 from robottelo.datafactory import (
     filtered_datapoint, invalid_id_list, valid_data_list
 )
-from robottelo.decorators import run_only_on, tier1
+from robottelo.decorators import run_only_on, tier1, bz_bug_is_open
 from robottelo.test import CLITestCase
 
 
@@ -45,10 +45,12 @@ def valid_create_params():
 @filtered_datapoint
 def invalid_create_params():
     """Returns a list of invalid domain create parameters"""
-    return [
-        {u'dns-id': '-1'},
+    params = [
         {u'name': gen_string(str_type='utf8', length=256)},
     ]
+    if not bz_bug_is_open(1398392):
+        params.append({u'dns-id': '-1'})
+    return params
 
 
 @filtered_datapoint
@@ -69,11 +71,13 @@ def valid_update_params():
 @filtered_datapoint
 def invalid_update_params():
     """Returns a list of invalid domain update parameters"""
-    return [
+    params = [
         {u'name': ''},
         {u'name': gen_string(str_type='utf8', length=256)},
-        {u'dns-id': '-1'},
     ]
+    if not bz_bug_is_open(1398392):
+        params.append({u'dns-id': '-1'})
+    return params
 
 
 @filtered_datapoint


### PR DESCRIPTION
Fixes https://github.com/SatelliteQE/robottelo/issues/4032

```bash
$ nosetests -s -m test_negative_create test_domain.py 
2016-11-24 17:52:24 - robottelo - DEBUG - Started setUpClass: tests.foreman.cli.test_domain/DomainTestCase
2016-11-24 17:52:24 - robottelo - DEBUG - Started Test: DomainTestCase/test_negative_create
2016-11-24 17:52:24 - robottelo.decorators - INFO - Bugzilla bug 1398392 not in cache. Fetching.
2016-11-24 17:52:27 - robottelo.ssh - INFO - Instantiated Paramiko client 0x7f397d9abe50
2016-11-24 17:52:27 - robottelo.ssh - DEBUG - Connected to [sat62.redhat.com]
2016-11-24 17:52:27 - robottelo.ssh - DEBUG - >>> LANG=en_US.UTF-8  hammer -v -u admin -p changeme --output=csv domain create --name="𢢻𥊖𡉶𢧈㘿𩘕ᇩ𤭿𪫷𪻋ꪖ羄𣥁𢚥𤠵蠥妜𥲞煐𥙘蔅𡀔ԝ𦦅𡵤ᬘ揞𐎰詒𩍮𪔢䭦ᣬ莐㣌義𢈬㔕骿ဟ𩨟𦝣뾰숛𨉒𤋗㠆𫃍𝕆ꇫ𫀼𪄇𓏋崴𩣪ਗ忕𦣶𓏮䕙𣯢ඈ슆𣄴𪌐𧺸𤾌㻟𠬾ꕯ𦾦ꏵ矶𠃀㰄𤳆𓅠𩡌𧲿𣘜솃𥣇𫊣𪳓Ệ𠬿𢾸𥱖𦣙ᠺ옚ꄸ𦁱𦚲𝕋𣗴𠜪𠋸뭁𫌼띘䪈𪠂铚𦕃𣦺𡜡𐑸𧵘𢆂𧤐쀑诹𓌟呉𥅺𫚅Ꮼ뎳퀴𠎉羒턞𢏾䖞𢴋𢚆𦘙䪇𧧢𓎈𣪃퐇ᶧ𨫖ᇿᳩ𢵷㨙亪ભ틨𡟼𡵿墩𡒄倠毩청땂𣌰𣾀𤸛𫀡𫏇𠼺瑔Ḅ섾걿瘝𡴸𩌎𧭉塵嗑𡘯𩧧𡇷賠ベ뿎𢻴𝝧𤠶㰜𢼒𥌟𨖫맸䱨㹳ጐ膸𩵋𠚪푗𨍨䑻𦺻𦆔煒觳준飑띷뱨𠱓ఊ붞𫉴鵪𡲬𦰩𡀋𧵉𠦳𢚚ꜳ凗錕짼𧢠錨𫗷𠴨𢡤ւ鷉𩓬묂𡭴Ӄ𦱤𧒼利𨧄맣𩀰㧏擀𝖁𥝟䩎𢙐常誧耄𥑅蹎쭜虚抹𪢛덑ꅁ𩑮𨡳㠸𤐴𥼠鍟𦹬馊𦌄𠧳"
2016-11-24 17:52:28 - robottelo.ssh - DEBUG - <<< stderr
[ERROR 2016-11-24 11:52:28 API] 422 Unprocessable Entity
[ERROR 2016-11-24 11:52:28 Exception] DNS domain is too long (maximum is 255 characters)
Could not create the domain:
  DNS domain is too long (maximum is 255 characters)

2016-11-24 17:52:28 - robottelo.ssh - INFO - Destroying Paramiko client 0x7f397d9abe50
2016-11-24 17:52:28 - robottelo.ssh - INFO - Destroyed Paramiko client 0x7f397d9abe50
2016-11-24 17:52:28 - robottelo - DEBUG - Finished Test: DomainTestCase/test_negative_create
.2016-11-24 17:52:28 - robottelo - DEBUG - Started tearDownClass: tests.foreman.cli.test_domain/DomainTestCase

----------------------------------------------------------------------
Ran 1 test in 4.015s

OK

```