### PR TITLE
[6.1.z] add BZ1398392 decorator for cli.test_domain

### DIFF
--- a/tests/foreman/cli/test_domain.py
+++ b/tests/foreman/cli/test_domain.py
@@ -6,7 +6,7 @@ from robottelo.cli.domain import Domain
 from robottelo.cli.factory import CLIFactoryError
 from robottelo.cli.factory import make_domain, make_location, make_org
 from robottelo.datafactory import invalid_id_list, valid_data_list
-from robottelo.decorators import run_only_on, tier1
+from robottelo.decorators import run_only_on, tier1, bz_bug_is_open
 from robottelo.test import CLITestCase
 
 
@@ -26,11 +26,12 @@ def valid_create_params():
 
 def invalid_create_params():
     """Returns a list of invalid domain create parameters"""
-    return [
-        {u'description': gen_string(str_type='utf8', length=256)},
-        {u'dns-id': '-1'},
+    params = [
         {u'name': gen_string(str_type='utf8', length=256)},
     ]
+    if not bz_bug_is_open(1398392):
+        params.append({u'dns-id': '-1'})
+    return params
 
 
 def valid_update_params():
@@ -49,12 +50,14 @@ def valid_update_params():
 
 def invalid_update_params():
     """Returns a list of invalid domain update parameters"""
-    return [
+    params = [
         {u'name': ''},
         {u'name': gen_string(str_type='utf8', length=256)},
         {u'description': gen_string(str_type='utf8', length=256)},
-        {u'dns-id': '-1'},
     ]
+    if not bz_bug_is_open(1398392):
+        params.append({u'dns-id': '-1'})
+    return params
 
 
 def valid_set_params():


### PR DESCRIPTION
Fixes https://github.com/SatelliteQE/robottelo/issues/4032

```bash
$ nosetests -s -m test_negative_create test_domain.py 
2016-11-24 17:55:55 - robottelo - DEBUG - Running test DomainTestCase/test_negative_create
2016-11-24 17:55:55 - robottelo.decorators - INFO - Bugzilla bug 1398392 not in cache. Fetching.
2016-11-24 17:55:56 - robottelo.ssh - DEBUG - >>> [sat61.com] LANG=en_US.UTF-8  hammer -v -u admin -p changeme --output=csv domain create --name="𪔞쒆평䭪㧸꿂ꔌ𩒜𓊅𤚺ᡪ𪜮𢗐齙쟸𧫢𩬨ꠊ𢭘𨎵돁你𫕗𦬜瓀𒆜𧃴ퟩ늄𣱚𧆨ᔥ豤ഭ蜨䞴𓁌㟬ġ𐑬𐀈𡽹𧘴𦛷浴菧ꑙ𤌙숪𨱙𒅅ⷑᇆ뭱𧧤𥪉䣯𧆊믺蒕뚹𡷝𦼫냾𩂜𥽋袘𨫢큇㽴壁䫼𠎵㔿𫒘𡣨㯎𡪮徺뒊𫐋𣒐𣐄縳촕𥤨죷䢆癬𤀌𧹽𪭙鰑𠊏쎥𧄚𥻕𩮃Ы穐𦄣𨳉켘䦘赶𢱰𤷺蒅攠쪀𧫼𠗑蚹쾱𩧞𪆭浸턆𤁶𫓍瞥孔𣉔늵𦼟椮夼Ñ꼽骘焫ᖿ𣊕茾𢬢𫗵㲜爧𡝗𢐆𥦼崡뮭棘强𡒺識𦞰𣻡䠙𧲋ݞ艍𢜚𡎙𥁵䔌줮ἱꌣ私𡨭ꈐ𨷂𡅤㾙ᖦ𣯫𠽑𩉟𤮿𤄥𡁥𣡠駳膏햚笒뵞𝛞𦻋𦫢喫𡁞𩻣𥞘껑嫰𪖊췓榸㓧ꅮ闳뜫Ⳏ犤脏뙒𨌺𩛈צ𡔻ᾒ漭ᵶ𪰔𠃇𐒅𪰊𠓚𥩺𢋞𠃆ᇏ𤜆𫆐𧻗𫙰澒𪣛긦𢌮㒠𡥌𤰕솬䉗ᖬ靋𣷗鏐𠁥𦞕摨훆𫕕𡢆뺫𩇀駝𨩖𨄣𨅺뗑釔ᮠꄵ𥄥𠔫𠎚鴺𐰚𪝌𤇛姵"
2016-11-24 17:55:58 - robottelo.ssh - INFO - Instantiated Paramiko client 0x7f14e62322d0
2016-11-24 17:55:59 - robottelo.ssh - INFO - Destroying Paramiko client 0x7f14e62322d0
2016-11-24 17:55:59 - robottelo.ssh - INFO - Destroyed Paramiko client 0x7f14e62322d0
2016-11-24 17:55:59 - robottelo.ssh - DEBUG - <<< stderr
[ERROR 2016-11-24 11:55:59 API] 422 Unprocessable Entity
[ERROR 2016-11-24 11:55:59 Exception] DNS domain is too long (maximum is 255 characters)
Could not create the domain:
  DNS domain is too long (maximum is 255 characters)

.
----------------------------------------------------------------------
Ran 1 test in 4.121s

OK

```