### PR TITLE
Added tests for puppet modules list from the repo

### DIFF
--- a/robottelo/ui/locators/base.py
+++ b/robottelo/ui/locators/base.py
@@ -1211,9 +1211,29 @@ locators = LocatorDict({
     "repo.fetch_package_groups": (
         By.XPATH, "//td[span[text()='Package Groups']]/following-sibling::td",
     ),
+    "repo.fetch_puppet_modules": (
+        By.XPATH, "//td[span[text()='Puppet Modules']]/following-sibling::td",
+    ),
     "repo.result_spinner": (
         By.XPATH,
         "//i[@ng-show='task.pending' and contains(@class, 'icon-spinner')]"),
+    "repo.manage_content.packages": (
+        By.XPATH,
+        "//button[contains(@ui-sref,"
+        " 'products.details.repositories.manage-content.packages')]"),
+    "repo.manage_content.puppet_modules": (
+        By.XPATH,
+        "//button[contains(@ui-sref,"
+        " 'products.details.repositories.manage-content.puppet-modules')]"),
+    "repo.manage_content.docker_manifests": (
+        By.XPATH,
+        "//button[contains(@ui-sref,"
+        " 'products.details.repositories.manage-content.docker-manifests')]"),
+    "repo.manage_content.ostree_branches": (
+        By.XPATH,
+        "//button[contains(@ui-sref,"
+        " 'products.details.repositories.manage-content.ostree-branches)]"),
+    "repo.content_items": (By.XPATH, "//tr[@row-select='item']"),
     # Activation Keys
 
     "ak.new": (By.XPATH, "//button[@ui-sref='activation-keys.new']"),


### PR DESCRIPTION
Added tests for puppet modules list from the repo. Part of #2246
```python
% py.test -v tests/foreman/{api,ui}/test_repository.py tests/foreman/cli/test_puppetmodule.py -k 'test_positive_list_puppet_modules_with_multiple_repos or test_positive_list_multiple_repos'
===================================================================== test session starts =====================================================================
platform linux2 -- Python 2.7.12, pytest-3.0.4, py-1.4.31, pluggy-0.4.0 -- /home/qui/code/venv/2/bin/python2
cachedir: .cache
rootdir: /home/qui/code/robottelo, inifile: 
plugins: xdist-1.15.0, cov-2.4.0
collected 102 items 

tests/foreman/api/test_repository.py::RepositoryTestCase::test_positive_list_puppet_modules_with_multiple_repos <- robottelo/decorators/__init__.py PASSED
tests/foreman/ui/test_repository.py::RepositoryTestCase::test_positive_list_puppet_modules_with_multiple_repos PASSED
tests/foreman/cli/test_puppetmodule.py::PuppetModuleTestCase::test_positive_list_multiple_repos <- robottelo/decorators/__init__.py PASSED

===================================================================== 99 tests deselected =====================================================================
========================================================== 3 passed, 99 deselected in 285.81 seconds ==========================================================
```