### PR TITLE
Support WebElement as alternative to locators in basic UI helpers

### DIFF
--- a/robottelo/ui/base.py
+++ b/robottelo/ui/base.py
@@ -613,7 +613,10 @@ class Base(object):
             if (element_type == 'input' and
                     element.get_attribute('type') == 'checkbox'):
                 element_type = 'checkbox'
-            if (element_type == 'div' and
+            elif (element_type == 'input' and
+                    element.get_attribute('type') == 'radio'):
+                element_type = 'radio'
+            elif (element_type == 'div' and
                     'ace_editor' in element.get_attribute('class')):
                 element_type = 'ace_editor'
         return element_type
@@ -749,7 +752,7 @@ class Base(object):
             self.text_field_update(target, value)
         elif element_type == 'select' or element_type == 'span':
             self.select(target, value)
-        elif element_type == 'checkbox':
+        elif element_type == 'checkbox' or element_type == 'radio':
             if isinstance(target, (tuple, Locator)):
                 state = self.wait_until_element(target).is_selected()
             else:


### PR DESCRIPTION
`Base.click` is already supporting both locators and WebElement, updating following methods accordingly:
* text_field_update
* element_type
* select
* assign_value

This change is required for upcoming PR covering #778 as i play with WebElements directly there.

Some test results for existing tests using these helpers (just to prove no regressions were added):
* Ace editor:
```python
py.test tests/foreman/ui/test_remoteexecution.py -k test_positive_view_diff
============================= test session starts ==============================
platform linux2 -- Python 2.7.10, pytest-3.0.3, py-1.4.31, pluggy-0.4.0
rootdir: /home/andrii/workspace/robottelo, inifile: 
plugins: xdist-1.13.1, repeat-0.2
collected 17 items 

tests/foreman/ui/test_remoteexecution.py .

============================= 16 tests deselected ==============================
=================== 1 passed, 16 deselected in 78.80 seconds ===================
```
* Select:
```python
py.test tests/foreman/ui/test_activationkey.py -k test_positive_create_with_envs
========================= test session starts ==========================
platform linux2 -- Python 2.7.10, pytest-3.0.3, py-1.4.31, pluggy-0.4.0
rootdir: /home/andrii/workspace/robottelo, inifile: 
plugins: xdist-1.13.1, repeat-0.2
collected 33 items 

tests/foreman/ui/test_activationkey.py .

========================= 32 tests deselected ==========================
============== 1 passed, 32 deselected in 131.24 seconds ===============
```
* Checkbox:
```python
py.test tests/foreman/ui/test_sync.py -k test_positive_sync_custom_repo
========================= test session starts ==========================
platform linux2 -- Python 2.7.10, pytest-3.0.3, py-1.4.31, pluggy-0.4.0
rootdir: /home/andrii/workspace/robottelo, inifile: 
plugins: xdist-1.13.1, repeat-0.2
collected 5 items 

tests/foreman/ui/test_sync.py .

========================== 4 tests deselected ==========================
=============== 1 passed, 4 deselected in 74.61 seconds ================
```