### PR TITLE
[6.1.z] Cherry-pick - Fix cli.test_contentview.py weak assertions.

### DIFF
--- a/tests/foreman/cli/test_contentview.py
+++ b/tests/foreman/cli/test_contentview.py
@@ -659,6 +659,122 @@ class ContentViewTestCase(CLITestCase):
             'version was not associated to composite CV',
         )
 
+    @tier2
+    @run_only_on('sat')
+    def test_positive_remove_version_by_id_from_composite(self):
+        """Create a composite content view and remove its content version by id
+
+        @Feature: Content Views
+
+        @assert: Composite content view info output does not contain any values
+        """
+        # Create new repository
+        new_repo = make_repository({u'product-id': self.product['id']})
+        # Sync REPO
+        Repository.synchronize({'id': new_repo['id']})
+        # Create new content-view and add repository to view
+        new_cv = make_content_view({u'organization-id': self.org['id']})
+        ContentView.add_repository({
+            u'id': new_cv['id'],
+            u'organization-id': self.org['id'],
+            u'repository-id': new_repo['id'],
+        })
+        # Publish a new version of CV
+        ContentView.publish({u'id': new_cv['id']})
+        # Get the CV info
+        new_cv = ContentView.info({u'id': new_cv['id']})
+        # Create a composite CV
+        comp_cv = make_content_view({
+            'composite': True,
+            'organization-id': self.org['id'],
+            'component-ids': new_cv['versions'][0]['id']
+        })
+        ContentView.publish({u'id': comp_cv['id']})
+        new_cv = ContentView.info({u'id': comp_cv['id']})
+        env = new_cv['lifecycle-environments'][0]
+        cvv = new_cv['versions'][0]
+        ContentView.remove_from_environment({
+            u'id': new_cv['id'],
+            u'lifecycle-environment-id': env['id'],
+        })
+        ContentView.remove({
+            u'content-view-version-ids': cvv['id'],
+            u'id': new_cv['id'],
+        })
+        new_cv = ContentView.info({u'id': new_cv['id']})
+        self.assertEqual(len(new_cv['versions']), 0)
+
+    @tier2
+    @run_only_on('sat')
+    def test_positive_create_composite_with_component_ids(self):
+        """create a composite content view with a component_ids option
+
+        @Feature: Content Views
+
+        @assert: Composite content view component ids are similar to the
+        nested content view versions ids
+        """
+        # Create CV
+        new_cv = make_content_view({u'organization-id': self.org['id']})
+        # Publish a new version of CV twice
+        for _ in range(2):
+            ContentView.publish({u'id': new_cv['id']})
+        new_cv = ContentView.info({u'id': new_cv['id']})
+        # Let us now store the version ids
+        component_ids = [version['id'] for version in new_cv['versions']]
+        # Create CV
+        comp_cv = make_content_view({
+            'composite': True,
+            'organization-id': self.org['id'],
+            'component-ids': component_ids
+        })
+        # Assert whether the composite content view components IDs are equal
+        # to the component_ids input values
+        comp_cv = ContentView.info({u'id': comp_cv['id']})
+        self.assertEqual(
+            {comp['id'] for comp in comp_cv['components']},
+            set(component_ids),
+            'IDs of the composite content view components differ from '
+            'the input values',
+        )
+
+    @tier2
+    @run_only_on('sat')
+    def test_positive_update_composite_with_component_ids(self):
+        """Update a composite content view with a component_ids option
+
+        @Feature: Content Views
+
+        @assert: Composite content view component ids are similar to the
+        nested content view versions ids
+        """
+        # Create a CV to add to the composite one
+        cv = make_content_view({u'organization-id': self.org['id']})
+        # Publish a new version of the CV
+        ContentView.publish({u'id': cv['id']})
+        new_cv = ContentView.info({u'id': cv['id']})
+        # Let us now store the version ids
+        component_ids = new_cv['versions'][0]['id']
+        # Create a composite CV
+        comp_cv = make_content_view({
+            'composite': True,
+            'organization-id': self.org['id']
+        })
+        # Update a composite content view with a component id version
+        ContentView.update({
+            'id': comp_cv['id'],
+            'component-ids': component_ids,
+        })
+        # Assert whether the composite content view components IDs are equal
+        # to the component_ids input values
+        comp_cv = ContentView.info({u'id': comp_cv['id']})
+        self.assertEqual(
+            comp_cv['components'][0]['id'],
+            component_ids,
+            'IDs of the composite content view components differ from '
+            'the input values',
+        )
+
     # Content Views: Adding products/repos
 
     @tier2
@@ -1354,9 +1470,9 @@ class ContentViewTestCase(CLITestCase):
         # Actual assert for this test happens HERE
         # Test whether the version1 now belongs to Library
         version1 = ContentView.version_info({u'id': version1_id})
-        self.assertEqual(
-            version1['lifecycle-environments'][0]['label'],
+        self.assertIn(
             ENVIRONMENT,
+            [env['label'] for env in version1['lifecycle-environments']],
             'Version 1 is not in Library',
         )
         # Promotion of version1 to Dev env
@@ -1367,9 +1483,9 @@ class ContentViewTestCase(CLITestCase):
         # The only way to validate whether env has the version is to
         # validate that version has the env.
         version1 = ContentView.version_info({u'id': version1_id})
-        self.assertEqual(
-            version1['lifecycle-environments'][1]['id'],
+        self.assertIn(
             self.env1['id'],
+            [env['id'] for env in version1['lifecycle-environments']],
             'Promotion of version1 not successful to the env',
         )
         # Now Publish version2 of CV
@@ -1380,9 +1496,9 @@ class ContentViewTestCase(CLITestCase):
         version2_id = new_cv['versions'][1]['id']
         # Test whether the version2 now belongs to Library
         version2 = ContentView.version_info({u'id': version2_id})
-        self.assertEqual(
-            version2['lifecycle-environments'][0]['label'],
+        self.assertIn(
             ENVIRONMENT,
+            [env['label'] for env in version2['lifecycle-environments']],
             'Version 2 not in Library'
         )
         # Promotion of version2 to Dev env
@@ -1393,9 +1509,9 @@ class ContentViewTestCase(CLITestCase):
         # Actual assert for this test happens here.
         # Test whether the version2 now belongs to next env
         version2 = ContentView.version_info({u'id': version2_id})
-        self.assertEqual(
-            version2['lifecycle-environments'][1]['id'],
+        self.assertIn(
             self.env1['id'],
+            [env['id'] for env in version2['lifecycle-environments']],
             'Promotion of version2 not successful to the env',
         )
 
@@ -1438,9 +1554,9 @@ class ContentViewTestCase(CLITestCase):
         version1_id = new_cv['versions'][0]['id']
         # Test whether the version1 now belongs to Library
         version = ContentView.version_info({u'id': version1_id})
-        self.assertEqual(
-            version['lifecycle-environments'][0]['label'],
+        self.assertIn(
             ENVIRONMENT,
+            [env['label'] for env in version['lifecycle-environments']],
             'Version 1 is not in Library',
         )
         # Promotion of version1 to Dev env
@@ -1452,9 +1568,9 @@ class ContentViewTestCase(CLITestCase):
         # validate that version has the env.
         # Test whether the version1 now belongs to next env
         version1 = ContentView.version_info({u'id': version1_id})
-        self.assertEqual(
-            version1['lifecycle-environments'][1]['id'],
+        self.assertIn(
             self.env1['id'],
+            [env['id'] for env in version1['lifecycle-environments']],
             'Promotion of version1 not successful to the env',
         )
         # Now Publish version2 of CV
@@ -1469,9 +1585,9 @@ class ContentViewTestCase(CLITestCase):
             1,
             'Version1 may still exist in Library',
         )
-        self.assertNotEqual(
-            version1['lifecycle-environments'][0]['label'],
+        self.assertNotIn(
             ENVIRONMENT,
+            [env['label'] for env in version1['lifecycle-environments']],
             'Version1 still exists in Library',
         )
         # Only after we publish version2 the info is populated.


### PR DESCRIPTION
Cherry-pick of #3985. Part of #3903 
Some tests that were affected by cherry-picked commit were not present in `6.1.z` branch, however these tests are valid for `6.1` and passed on `6.1.8`.

Test-results for 6.1.z branch on 6.1.8.
```python
% py.test -v tests/foreman/cli/test_contentview.py -k 'test_positive_remove_version_by_id_from_composite or test_positive_create_composite_with_component_ids or test_positive_update_composite_with_component_ids or test_positive_update_version_once or test_positive_update_version_multiple'                               
===================================================================== test session starts =====================================================================
platform linux2 -- Python 2.7.12, pytest-3.0.4, py-1.4.31, pluggy-0.4.0 -- /home/qui/code/venv/6.1.z/bin/python2
cachedir: .cache
rootdir: /home/qui/code/robottelo, inifile: 
plugins: xdist-1.15.0, cov-2.4.0
collected 51 items 

tests/foreman/cli/test_contentview.py::ContentViewTestCase::test_positive_create_composite_with_component_ids <- /home/qui/code/robottelo/robottelo/decorators/__init__.py PASSED
tests/foreman/cli/test_contentview.py::ContentViewTestCase::test_positive_remove_version_by_id_from_composite <- /home/qui/code/robottelo/robottelo/decorators/__init__.py PASSED
tests/foreman/cli/test_contentview.py::ContentViewTestCase::test_positive_update_composite_with_component_ids <- /home/qui/code/robottelo/robottelo/decorators/__init__.py PASSED
tests/foreman/cli/test_contentview.py::ContentViewTestCase::test_positive_update_version_multiple <- /home/qui/code/robottelo/robottelo/decorators/__init__.py PASSED
tests/foreman/cli/test_contentview.py::ContentViewTestCase::test_positive_update_version_once <- /home/qui/code/robottelo/robottelo/decorators/__init__.py PASSED

===================================================================== 46 tests deselected =====================================================================
========================================================== 5 passed, 46 deselected in 492.02 seconds =========================================================
```