### PR TITLE
[6.2.z] Cherry-pick - Fix naive proxy retrieval 

### DIFF
--- a/tests/foreman/api/test_host.py
+++ b/tests/foreman/api/test_host.py
@@ -172,7 +172,7 @@ class HostTestCase(APITestCase):
 
         @assert: A host is created with expected puppet proxy assigned
         """
-        proxy = entities.SmartProxy().search()[0]
+        proxy = entities.SmartProxy(id=1).read()
         host = entities.Host(puppet_proxy=proxy).create()
         self.assertEqual(host.puppet_proxy.read().name, proxy.name)
 
@@ -185,7 +185,7 @@ class HostTestCase(APITestCase):
 
         @assert: A host is created with expected puppet CA proxy assigned
         """
-        proxy = entities.SmartProxy().search()[0]
+        proxy = entities.SmartProxy(id=1).read()
         host = entities.Host(puppet_ca_proxy=proxy).create()
         self.assertEqual(host.puppet_ca_proxy.read().name, proxy.name)
 
@@ -580,7 +580,7 @@ class HostTestCase(APITestCase):
         @assert: A host is updated with a new puppet proxy
         """
         host = entities.Host().create()
-        new_proxy = entities.SmartProxy().search()[0]
+        new_proxy = entities.SmartProxy(id=1).read()
         host.puppet_proxy = new_proxy
         host = host.update(['puppet_proxy'])
         self.assertEqual(host.puppet_proxy.read().name, new_proxy.name)
@@ -595,7 +595,7 @@ class HostTestCase(APITestCase):
         @assert: A host is updated with a new puppet CA proxy
         """
         host = entities.Host().create()
-        new_proxy = entities.SmartProxy().search()[0]
+        new_proxy = entities.SmartProxy(id=1).read()
         host.puppet_ca_proxy = new_proxy
         host = host.update(['puppet_ca_proxy'])
         self.assertEqual(host.puppet_ca_proxy.read().name, new_proxy.name)

--- a/tests/foreman/api/test_host.py
+++ b/tests/foreman/api/test_host.py
@@ -172,7 +172,9 @@ class HostTestCase(APITestCase):
 
         @assert: A host is created with expected puppet proxy assigned
         """
-        proxy = entities.SmartProxy(id=1).read()
+        proxy = entities.SmartProxy().search(query={
+            'search': 'url = https://{0}:9090'.format(settings.server.hostname)
+        })[0]
         host = entities.Host(puppet_proxy=proxy).create()
         self.assertEqual(host.puppet_proxy.read().name, proxy.name)
 
@@ -185,7 +187,9 @@ class HostTestCase(APITestCase):
 
         @assert: A host is created with expected puppet CA proxy assigned
         """
-        proxy = entities.SmartProxy(id=1).read()
+        proxy = entities.SmartProxy().search(query={
+            'search': 'url = https://{0}:9090'.format(settings.server.hostname)
+        })[0]
         host = entities.Host(puppet_ca_proxy=proxy).create()
         self.assertEqual(host.puppet_ca_proxy.read().name, proxy.name)
 
@@ -580,7 +584,9 @@ class HostTestCase(APITestCase):
         @assert: A host is updated with a new puppet proxy
         """
         host = entities.Host().create()
-        new_proxy = entities.SmartProxy(id=1).read()
+        new_proxy = entities.SmartProxy().search(query={
+            'search': 'url = https://{0}:9090'.format(settings.server.hostname)
+        })[0]
         host.puppet_proxy = new_proxy
         host = host.update(['puppet_proxy'])
         self.assertEqual(host.puppet_proxy.read().name, new_proxy.name)
@@ -595,7 +601,9 @@ class HostTestCase(APITestCase):
         @assert: A host is updated with a new puppet CA proxy
         """
         host = entities.Host().create()
-        new_proxy = entities.SmartProxy(id=1).read()
+        new_proxy = entities.SmartProxy().search(query={
+            'search': 'url = https://{0}:9090'.format(settings.server.hostname)
+        })[0]
         host.puppet_ca_proxy = new_proxy
         host = host.update(['puppet_ca_proxy'])
         self.assertEqual(host.puppet_ca_proxy.read().name, new_proxy.name)

--- a/tests/foreman/api/test_hostgroup.py
+++ b/tests/foreman/api/test_hostgroup.py
@@ -365,7 +365,9 @@ class HostGroupTestCase(APITestCase):
 
         @assert: A hostgroup is created with expected puppet CA proxy assigned
         """
-        proxy = entities.SmartProxy(id=1).read()
+        proxy = entities.SmartProxy().search(query={
+            'search': 'url = https://{0}:9090'.format(settings.server.hostname)
+        })[0]
         hostgroup = entities.HostGroup(
             location=[self.loc],
             organization=[self.org],
@@ -429,7 +431,10 @@ class HostGroupTestCase(APITestCase):
         realm = entities.Realm(
             location=[self.loc],
             organization=[self.org],
-            realm_proxy=entities.SmartProxy(id=1).read()
+            realm_proxy=entities.SmartProxy().search(
+                query={'search': 'url = https://{0}:9090'.format(
+                    settings.server.hostname)}
+            )[0]
         ).create()
         hostgroup = entities.HostGroup(
             location=[self.loc],
@@ -446,7 +451,9 @@ class HostGroupTestCase(APITestCase):
 
         @assert: A hostgroup is created with expected puppet proxy assigned
         """
-        proxy = entities.SmartProxy(id=1).read()
+        proxy = entities.SmartProxy().search(query={
+            'search': 'url = https://{0}:9090'.format(settings.server.hostname)
+        })[0]
         hostgroup = entities.HostGroup(
             location=[self.loc],
             organization=[self.org],
@@ -462,7 +469,9 @@ class HostGroupTestCase(APITestCase):
 
         @assert: A hostgroup is created with expected content source assigned
         """
-        content_source = entities.SmartProxy(id=1).read()
+        content_source = entities.SmartProxy().search(query={
+            'search': 'url = https://{0}:9090'.format(settings.server.hostname)
+        })[0]
         hostgroup = entities.HostGroup(
             content_source=content_source,
             location=[self.loc],
@@ -761,7 +770,9 @@ class HostGroupTestCase(APITestCase):
             location=[self.loc],
             organization=[self.org],
         ).create()
-        new_proxy = entities.SmartProxy(id=1).read()
+        new_proxy = entities.SmartProxy().search(query={
+            'search': 'url = https://{0}:9090'.format(settings.server.hostname)
+        })[0]
         hostgroup.puppet_ca_proxy = new_proxy
         hostgroup = hostgroup.update(['puppet_ca_proxy'])
         self.assertEqual(hostgroup.puppet_ca_proxy.read().name, new_proxy.name)
@@ -834,7 +845,10 @@ class HostGroupTestCase(APITestCase):
         realm = entities.Realm(
             location=[self.loc],
             organization=[self.org],
-            realm_proxy=entities.SmartProxy(id=1).read(),
+            realm_proxy=entities.SmartProxy().search(
+                query={'search': 'url = https://{0}:9090'.format(
+                    settings.server.hostname)}
+            )[0]
         ).create()
         hostgroup = entities.HostGroup(
             location=[self.loc],
@@ -844,7 +858,10 @@ class HostGroupTestCase(APITestCase):
         new_realm = entities.Realm(
             location=[self.loc],
             organization=[self.org],
-            realm_proxy=entities.SmartProxy(id=1).read(),
+            realm_proxy=entities.SmartProxy().search(
+                query={'search': 'url = https://{0}:9090'.format(
+                    settings.server.hostname)}
+            )[0]
         ).create()
         hostgroup.realm = new_realm
         hostgroup = hostgroup.update(['realm'])
@@ -862,7 +879,9 @@ class HostGroupTestCase(APITestCase):
             location=[self.loc],
             organization=[self.org],
         ).create()
-        new_proxy = entities.SmartProxy(id=1).read()
+        new_proxy = entities.SmartProxy().search(query={
+            'search': 'url = https://{0}:9090'.format(settings.server.hostname)
+        })[0]
         hostgroup.puppet_proxy = new_proxy
         hostgroup = hostgroup.update(['puppet_proxy'])
         self.assertEqual(hostgroup.puppet_proxy.read().name, new_proxy.name)
@@ -879,7 +898,9 @@ class HostGroupTestCase(APITestCase):
             location=[self.loc],
             organization=[self.org],
         ).create()
-        new_content_source = entities.SmartProxy(id=1).read()
+        new_content_source = entities.SmartProxy().search(query={
+            'search': 'url = https://{0}:9090'.format(settings.server.hostname)
+        })[0]
         hostgroup.content_source = new_content_source
         hostgroup = hostgroup.update(['content_source'])
         self.assertEqual(

--- a/tests/foreman/api/test_hostgroup.py
+++ b/tests/foreman/api/test_hostgroup.py
@@ -365,7 +365,7 @@ class HostGroupTestCase(APITestCase):
 
         @assert: A hostgroup is created with expected puppet CA proxy assigned
         """
-        proxy = entities.SmartProxy().search()[0]
+        proxy = entities.SmartProxy(id=1).read()
         hostgroup = entities.HostGroup(
             location=[self.loc],
             organization=[self.org],
@@ -429,7 +429,7 @@ class HostGroupTestCase(APITestCase):
         realm = entities.Realm(
             location=[self.loc],
             organization=[self.org],
-            realm_proxy=entities.SmartProxy().search()[0],
+            realm_proxy=entities.SmartProxy(id=1).read()
         ).create()
         hostgroup = entities.HostGroup(
             location=[self.loc],
@@ -446,7 +446,7 @@ class HostGroupTestCase(APITestCase):
 
         @assert: A hostgroup is created with expected puppet proxy assigned
         """
-        proxy = entities.SmartProxy().search()[0]
+        proxy = entities.SmartProxy(id=1).read()
         hostgroup = entities.HostGroup(
             location=[self.loc],
             organization=[self.org],
@@ -462,7 +462,7 @@ class HostGroupTestCase(APITestCase):
 
         @assert: A hostgroup is created with expected content source assigned
         """
-        content_source = entities.SmartProxy().search()[0]
+        content_source = entities.SmartProxy(id=1).read()
         hostgroup = entities.HostGroup(
             content_source=content_source,
             location=[self.loc],
@@ -761,7 +761,7 @@ class HostGroupTestCase(APITestCase):
             location=[self.loc],
             organization=[self.org],
         ).create()
-        new_proxy = entities.SmartProxy().search()[0]
+        new_proxy = entities.SmartProxy(id=1).read()
         hostgroup.puppet_ca_proxy = new_proxy
         hostgroup = hostgroup.update(['puppet_ca_proxy'])
         self.assertEqual(hostgroup.puppet_ca_proxy.read().name, new_proxy.name)
@@ -834,7 +834,7 @@ class HostGroupTestCase(APITestCase):
         realm = entities.Realm(
             location=[self.loc],
             organization=[self.org],
-            realm_proxy=entities.SmartProxy().search()[0],
+            realm_proxy=entities.SmartProxy(id=1).read(),
         ).create()
         hostgroup = entities.HostGroup(
             location=[self.loc],
@@ -844,7 +844,7 @@ class HostGroupTestCase(APITestCase):
         new_realm = entities.Realm(
             location=[self.loc],
             organization=[self.org],
-            realm_proxy=entities.SmartProxy().search()[0],
+            realm_proxy=entities.SmartProxy(id=1).read(),
         ).create()
         hostgroup.realm = new_realm
         hostgroup = hostgroup.update(['realm'])
@@ -862,7 +862,7 @@ class HostGroupTestCase(APITestCase):
             location=[self.loc],
             organization=[self.org],
         ).create()
-        new_proxy = entities.SmartProxy().search()[0]
+        new_proxy = entities.SmartProxy(id=1).read()
         hostgroup.puppet_proxy = new_proxy
         hostgroup = hostgroup.update(['puppet_proxy'])
         self.assertEqual(hostgroup.puppet_proxy.read().name, new_proxy.name)
@@ -879,7 +879,7 @@ class HostGroupTestCase(APITestCase):
             location=[self.loc],
             organization=[self.org],
         ).create()
-        new_content_source = entities.SmartProxy().search()[0]
+        new_content_source = entities.SmartProxy(id=1).read()
         hostgroup.content_source = new_content_source
         hostgroup = hostgroup.update(['content_source'])
         self.assertEqual(

--- a/tests/foreman/api/test_location.py
+++ b/tests/foreman/api/test_location.py
@@ -265,7 +265,7 @@ class LocationTestCase(APITestCase):
         # Add capsule to cleanup list
         self.addCleanup(capsule_cleanup, proxy_id)
 
-        proxy = entities.SmartProxy(id=proxy_id).search()[0]
+        proxy = entities.SmartProxy(id=proxy_id).read()
         location = entities.Location(smart_proxy=[proxy]).create()
         # Add location to cleanup list
         self.addCleanup(location_cleanup, location.id)
@@ -575,12 +575,12 @@ class LocationTestCase(APITestCase):
         self.addCleanup(capsule_cleanup, proxy_id_1)
         self.addCleanup(capsule_cleanup, proxy_id_2)
 
-        proxy = entities.SmartProxy(id=proxy_id_1).search()[0]
+        proxy = entities.SmartProxy(id=proxy_id_1).read()
         location = entities.Location(smart_proxy=[proxy]).create()
         # Add location to cleanup list
         self.addCleanup(location_cleanup, location.id)
 
-        new_proxy = entities.SmartProxy(id=proxy_id_2).search()[0]
+        new_proxy = entities.SmartProxy(id=proxy_id_2).read()
         location.smart_proxy = [new_proxy]
         location = location.update(['smart_proxy'])
         self.assertEqual(location.smart_proxy[0].id, new_proxy.id)
@@ -640,7 +640,7 @@ class LocationTestCase(APITestCase):
         # Add capsule to cleanup list
         self.addCleanup(capsule_cleanup, proxy_id)
 
-        proxy = entities.SmartProxy(id=proxy_id).search()[0]
+        proxy = entities.SmartProxy(id=proxy_id).read()
         location = entities.Location(smart_proxy=[proxy]).create()
         # Add location to cleanup list
         self.addCleanup(location_cleanup, location.id)

--- a/tests/foreman/api/test_organization.py
+++ b/tests/foreman/api/test_organization.py
@@ -351,7 +351,10 @@ class OrganizationUpdateTestCase(APITestCase):
         # Every Satellite has a built-in smart proxy, so let's find it
         smart_proxy = entities.SmartProxy().search(query={
             'search': 'url = https://{0}:9090'.format(settings.server.hostname)
-        })[0]
+        })
+        # Check that proxy is found and unpack it from the list
+        self.assertGreater(len(smart_proxy), 0)
+        smart_proxy = smart_proxy[0]
         # By default, newly created organization uses built-in smart proxy,
         # so we need to remove it first
         org = entities.Organization().create()

--- a/tests/foreman/api/test_organization.py
+++ b/tests/foreman/api/test_organization.py
@@ -349,7 +349,9 @@ class OrganizationUpdateTestCase(APITestCase):
         @CaseLevel: Integration
         """
         # Every Satellite has a built-in smart proxy, so let's find it
-        smart_proxy = entities.SmartProxy(id=1).read()
+        smart_proxy = entities.SmartProxy().search(query={
+            'search': 'url = https://{0}:9090'.format(settings.server.hostname)
+        })[0]
         # By default, newly created organization uses built-in smart proxy,
         # so we need to remove it first
         org = entities.Organization().create()

--- a/tests/foreman/api/test_organization.py
+++ b/tests/foreman/api/test_organization.py
@@ -349,9 +349,7 @@ class OrganizationUpdateTestCase(APITestCase):
         @CaseLevel: Integration
         """
         # Every Satellite has a built-in smart proxy, so let's find it
-        smart_proxies = entities.SmartProxy().search()
-        self.assertGreater(len(smart_proxies), 0)
-        smart_proxy = smart_proxies[0]
+        smart_proxy = entities.SmartProxy(id=1).read()
         # By default, newly created organization uses built-in smart proxy,
         # so we need to remove it first
         org = entities.Organization().create()

--- a/tests/foreman/api/test_smartproxy.py
+++ b/tests/foreman/api/test_smartproxy.py
@@ -41,9 +41,8 @@ class SmartProxyMissingAttrTestCase(APITestCase):
         existing smart proxy should always succeed.
         """
         super(SmartProxyMissingAttrTestCase, cls).setUpClass()
-        smart_proxies = entities.SmartProxy().search()
-        assert len(smart_proxies) > 0
-        cls.smart_proxy_attrs = set(smart_proxies[0].update_json([]).keys())
+        smart_proxy = entities.SmartProxy(id=1).read()
+        cls.smart_proxy_attrs = set(smart_proxy.update_json([]).keys())
 
     @tier1
     def test_positive_update_loc(self):

--- a/tests/foreman/api/test_smartproxy.py
+++ b/tests/foreman/api/test_smartproxy.py
@@ -15,6 +15,7 @@
 @Upstream: No
 """
 from nailgun import entities
+from robottelo.config import settings
 from robottelo.decorators import (
     skip_if_bug_open,
     tier1,
@@ -41,7 +42,9 @@ class SmartProxyMissingAttrTestCase(APITestCase):
         existing smart proxy should always succeed.
         """
         super(SmartProxyMissingAttrTestCase, cls).setUpClass()
-        smart_proxy = entities.SmartProxy(id=1).read()
+        smart_proxy = entities.SmartProxy().search(query={
+            'search': 'url = https://{0}:9090'.format(settings.server.hostname)
+        })[0]
         cls.smart_proxy_attrs = set(smart_proxy.update_json([]).keys())
 
     @tier1

--- a/tests/foreman/api/test_smartproxy.py
+++ b/tests/foreman/api/test_smartproxy.py
@@ -44,7 +44,10 @@ class SmartProxyMissingAttrTestCase(APITestCase):
         super(SmartProxyMissingAttrTestCase, cls).setUpClass()
         smart_proxy = entities.SmartProxy().search(query={
             'search': 'url = https://{0}:9090'.format(settings.server.hostname)
-        })[0]
+        })
+        # Check that proxy is found and unpack it from the list
+        assert len(smart_proxy) > 0, "No smart proxy is found"
+        smart_proxy = smart_proxy[0]
         cls.smart_proxy_attrs = set(smart_proxy.update_json([]).keys())
 
     @tier1

--- a/tests/foreman/cli/test_gpgkey.py
+++ b/tests/foreman/cli/test_gpgkey.py
@@ -35,7 +35,7 @@ from robottelo.cli.gpgkey import GPGKey
 from robottelo.cli.org import Org
 from robottelo.cli.product import Product
 from robottelo.cli.repository import Repository
-from robottelo.constants import VALID_GPG_KEY_FILE
+from robottelo.constants import DEFAULT_ORG, VALID_GPG_KEY_FILE
 from robottelo.datafactory import invalid_values_list, valid_data_list
 from robottelo.decorators import (
     run_only_on,
@@ -135,9 +135,7 @@ class TestGPGKey(CLITestCase):
 
         @assert: gpg key is created
         """
-        result = Org.list()
-        self.assertGreater(len(result), 0, 'No organization found')
-        org = result[0]
+        org = Org.info({'name': DEFAULT_ORG})
         for name in valid_data_list():
             with self.subTest(name):
                 gpg_key = make_gpg_key({

--- a/tests/foreman/cli/test_host.py
+++ b/tests/foreman/cli/test_host.py
@@ -78,9 +78,7 @@ class HostCreateTestCase(CLITestCase):
         """
         super(HostCreateTestCase, self).setUp()
         # Use the default installation smart proxy
-        result = Proxy.list()
-        self.assertGreater(len(result), 0)
-        self.puppet_proxy = result[0]
+        self.puppet_proxy = Proxy.info({'id': 1})
 
     @tier1
     def test_positive_create_with_name(self):
@@ -157,9 +155,7 @@ class HostDeleteTestCase(CLITestCase):
         """Create a host to use in tests"""
         super(HostDeleteTestCase, self).setUp()
         # Use the default installation smart proxy
-        result = Proxy.list()
-        self.assertGreater(len(result), 0)
-        self.puppet_proxy = result[0]
+        self.puppet_proxy = Proxy.info({'id': 1})
         self.host = entities.Host()
         self.host.create_missing()
         self.host = Host.create({
@@ -210,9 +206,7 @@ class HostUpdateTestCase(CLITestCase):
     def setUp(self):
         """Create a host to reuse later"""
         super(HostUpdateTestCase, self).setUp()
-        self.proxies = Proxy.list()
-        self.assertGreater(len(self.proxies), 0)
-        self.puppet_proxy = self.proxies[0]
+        self.puppet_proxy = Proxy.info({'id': 1})
         # using nailgun to create dependencies
         self.host_args = entities.Host()
         self.host_args.create_missing()
@@ -678,9 +672,7 @@ class HostParameterTestCase(CLITestCase):
     def setUpClass(cls):
         """Create host to tests parameters for"""
         super(HostParameterTestCase, cls).setUpClass()
-        cls.proxies = Proxy.list()
-        assert len(cls.proxies) > 0
-        cls.puppet_proxy = cls.proxies[0]
+        cls.puppet_proxy = Proxy.info({'id': 1})
         # using nailgun to create dependencies
         cls.host = entities.Host()
         cls.host.create_missing()

--- a/tests/foreman/cli/test_host.py
+++ b/tests/foreman/cli/test_host.py
@@ -78,7 +78,9 @@ class HostCreateTestCase(CLITestCase):
         """
         super(HostCreateTestCase, self).setUp()
         # Use the default installation smart proxy
-        self.puppet_proxy = Proxy.info({'id': 1})
+        self.puppet_proxy = Proxy.list({
+            'search': 'url = https://{0}:9090'.format(settings.server.hostname)
+        })[0]
 
     @tier1
     def test_positive_create_with_name(self):
@@ -155,7 +157,9 @@ class HostDeleteTestCase(CLITestCase):
         """Create a host to use in tests"""
         super(HostDeleteTestCase, self).setUp()
         # Use the default installation smart proxy
-        self.puppet_proxy = Proxy.info({'id': 1})
+        self.puppet_proxy = Proxy.list({
+            'search': 'url = https://{0}:9090'.format(settings.server.hostname)
+        })[0]
         self.host = entities.Host()
         self.host.create_missing()
         self.host = Host.create({
@@ -206,7 +210,9 @@ class HostUpdateTestCase(CLITestCase):
     def setUp(self):
         """Create a host to reuse later"""
         super(HostUpdateTestCase, self).setUp()
-        self.puppet_proxy = Proxy.info({'id': 1})
+        self.puppet_proxy = Proxy.list({
+            'search': 'url = https://{0}:9090'.format(settings.server.hostname)
+        })[0]
         # using nailgun to create dependencies
         self.host_args = entities.Host()
         self.host_args.create_missing()
@@ -672,7 +678,9 @@ class HostParameterTestCase(CLITestCase):
     def setUpClass(cls):
         """Create host to tests parameters for"""
         super(HostParameterTestCase, cls).setUpClass()
-        cls.puppet_proxy = Proxy.info({'id': 1})
+        cls.puppet_proxy = Proxy.list({
+            'search': 'url = https://{0}:9090'.format(settings.server.hostname)
+        })[0]
         # using nailgun to create dependencies
         cls.host = entities.Host()
         cls.host.create_missing()

--- a/tests/foreman/cli/test_hostgroup.py
+++ b/tests/foreman/cli/test_hostgroup.py
@@ -162,7 +162,7 @@ class HostGroupTestCase(CLITestCase):
         @Assert: Hostgroup is created and has puppet CA proxy server assigned
 
         """
-        puppet_proxy = Proxy.list()[0]
+        puppet_proxy = Proxy.info({'id': 1})
         hostgroup = make_hostgroup({'puppet-ca-proxy': puppet_proxy['name']})
         self.assertEqual(puppet_proxy['id'], hostgroup['puppet-ca-proxy-id'])
 
@@ -276,7 +276,7 @@ class HostGroupTestCase(CLITestCase):
             'organization-ids': org['id'],
         })
         lce = make_lifecycle_environment({'organization-id': org['id']})
-        puppet_proxy = Proxy.list()[0]
+        puppet_proxy = Proxy.info({'id': 1})
         # Content View should be promoted to be used with LC Env
         cv = make_content_view({'organization-id': org['id']})
         ContentView.publish({'id': cv['id']})

--- a/tests/foreman/cli/test_hostgroup.py
+++ b/tests/foreman/cli/test_hostgroup.py
@@ -35,6 +35,7 @@ from robottelo.cli.factory import (
     make_partition_table,
     make_subnet,
 )
+from robottelo.config import settings
 from robottelo.datafactory import (
     invalid_id_list,
     invalid_values_list,
@@ -162,7 +163,9 @@ class HostGroupTestCase(CLITestCase):
         @Assert: Hostgroup is created and has puppet CA proxy server assigned
 
         """
-        puppet_proxy = Proxy.info({'id': 1})
+        puppet_proxy = Proxy.list({
+            'search': 'url = https://{0}:9090'.format(settings.server.hostname)
+        })[0]
         hostgroup = make_hostgroup({'puppet-ca-proxy': puppet_proxy['name']})
         self.assertEqual(puppet_proxy['id'], hostgroup['puppet-ca-proxy-id'])
 
@@ -175,7 +178,9 @@ class HostGroupTestCase(CLITestCase):
 
         @Assert: Hostgroup is created and has puppet proxy server assigned
         """
-        puppet_proxy = Proxy.list()[0]
+        puppet_proxy = Proxy.list({
+            'search': 'url = https://{0}:9090'.format(settings.server.hostname)
+        })[0]
         hostgroup = make_hostgroup({'puppet-proxy': puppet_proxy['name']})
         self.assertEqual(
             puppet_proxy['id'],
@@ -276,7 +281,9 @@ class HostGroupTestCase(CLITestCase):
             'organization-ids': org['id'],
         })
         lce = make_lifecycle_environment({'organization-id': org['id']})
-        puppet_proxy = Proxy.info({'id': 1})
+        puppet_proxy = Proxy.list({
+            'search': 'url = https://{0}:9090'.format(settings.server.hostname)
+        })[0]
         # Content View should be promoted to be used with LC Env
         cv = make_content_view({'organization-id': org['id']})
         ContentView.publish({'id': cv['id']})

--- a/tests/foreman/cli/test_hostgroup.py
+++ b/tests/foreman/cli/test_hostgroup.py
@@ -317,7 +317,7 @@ class HostGroupTestCase(CLITestCase):
             'organization-ids': org['id'],
         })
 
-        hostgroup = make_hostgroup({
+        make_hostgroup_params = {
             'location-ids': loc['id'],
             'environment-id': env['id'],
             'lifecycle-environment': lce['name'],
@@ -331,7 +331,9 @@ class HostGroupTestCase(CLITestCase):
             'partition-table-id': ptable['id'],
             'medium-id': media['id'],
             'operatingsystem-id': os['id'],
-        })
+        }
+
+        hostgroup = make_hostgroup(make_hostgroup_params)
         self.assertIn(org['name'], hostgroup['organizations'])
         self.assertIn(loc['name'], hostgroup['locations'])
         self.assertEqual(env['name'], hostgroup['environment'])

--- a/tests/foreman/cli/test_subnet.py
+++ b/tests/foreman/cli/test_subnet.py
@@ -212,13 +212,11 @@ class SubnetTestCase(CLITestCase):
 
         @Assert: Subnet is listed
         """
-        # Fetch current total
-        subnets_before = Subnet.list()
         # Make a new subnet
-        make_subnet()
-        # Fetch total again
-        subnets_after = Subnet.list()
-        self.assertGreater(len(subnets_after), len(subnets_before))
+        subnet = make_subnet()
+        # Fetch ids from subnets list
+        subnets_ids = [subnet_['id'] for subnet_ in Subnet.list()]
+        self.assertIn(subnet['id'], subnets_ids)
 
     @run_only_on('sat')
     @tier1


### PR DESCRIPTION
Cherry-pick of #3991. Part of #3942
Test-results for 6.2.z branch on 6.2.4.
2 failures because of bug fixed in 6.3 only
```python
% nosetests tests/foreman/cli/test_host.py:HostUpdateTestCase
..............EE..
----------------------------------------------------------------------
Ran 18 tests in 1455.659s
FAILED (errors=2)
```
```python
% nosetests tests/foreman/cli/test_host.py:HostDeleteTestCase
..
----------------------------------------------------------------------
Ran 2 tests in 133.575s
OK
```
```python
]% nosetests tests/foreman/cli/test_host.py:HostCreateTestCase
..
----------------------------------------------------------------------
Ran 2 tests in 193.292s
OK
```
```python
% nosetests tests/foreman/cli/test_host.py:HostParameterTestCase
........
----------------------------------------------------------------------
Ran 8 tests in 928.892s
OK
```
```python
% nosetests tests/foreman/cli/test_hostgroup.py:HostGroupTestCase.test_positive_create_with_puppet_ca_proxy 
.
----------------------------------------------------------------------
Ran 1 test in 21.269s
OK
```
```python
% nosetests tests/foreman/api/test_host.py:HostTestCase.{test_positive_create_with_puppet_proxy,test_positive_create_with_puppet_ca_proxy,test_positive_update_puppet_proxy,test_positive_update_puppet_ca_proxy}
....
----------------------------------------------------------------------
Ran 4 tests in 114.663s
OK
```
```python
% nosetests tests/foreman/api/test_hostgroup.py:HostGroupTestCase.{test_positive_create_with_puppet_ca_proxy,test_positive_create_with_realm,test_positive_create_with_puppet_proxy,test_positive_create_with_content_source,test_positive_update_puppet_ca_proxy,test_positive_update_realm,test_positive_update_puppet_proxy,test_positive_update_content_source}  
.S...S..
----------------------------------------------------------------------
Ran 8 tests in 65.017s
OK (SKIP=2)
```python
% nosetests tests/foreman/api/test_organization.py:OrganizationUpdateTestCase.test_positive_add_smart_proxy tests/foreman/cli/test_hostgroup.py:HostGroupTestCase.test_positive_create_with_multiple_entities
..
----------------------------------------------------------------------
Ran 2 tests in 248.216s
OK
```
```python
% nosetests tests/foreman/api/test_location.py:LocationTestCase
.................................                                                                       
----------------------------------------------------------------------
Ran 33 tests in 623.746s
OK
```