### PR TITLE
[6.2.z] Cherry-pick - Added tests for role and filter hammer commands

### DIFF
--- a/docs/api/robottelo.cli.rst
+++ b/docs/api/robottelo.cli.rst
@@ -60,6 +60,11 @@ Submodules:
 
 .. automodule:: robottelo.cli.factory
 
+:mod:`robottelo.cli.filter`
+---------------------------
+
+.. automodule:: robottelo.cli.filter
+
 :mod:`robottelo.cli.globalparam`
 --------------------------------
 

--- a/docs/api/tests.foreman.cli.rst
+++ b/docs/api/tests.foreman.cli.rst
@@ -78,6 +78,11 @@
 
 .. automodule:: tests.foreman.cli.test_fact
 
+:mod:`tests.foreman.cli.test_filter`
+------------------------------------
+
+.. automodule:: tests.foreman.cli.test_filter
+
 :mod:`tests.foreman.cli.test_globalparam`
 -----------------------------------------
 

--- a/robottelo/cli/factory.py
+++ b/robottelo/cli/factory.py
@@ -28,6 +28,7 @@ from robottelo.cli.contentview import ContentView
 from robottelo.cli.docker import DockerContainer, DockerRegistry
 from robottelo.cli.domain import Domain
 from robottelo.cli.environment import Environment
+from robottelo.cli.filter import Filter
 from robottelo.cli.gpgkey import GPGKey
 from robottelo.cli.host import Host
 from robottelo.cli.hostcollection import HostCollection
@@ -733,6 +734,53 @@ def make_role(options=None):
     args = {u'name': gen_alphanumeric(6)}
 
     return create_object(Role, args, options)
+
+
+@cacheable
+def make_filter(options=None):
+    """
+    Usage::
+
+        hammer filter create [OPTIONS]
+
+    Options::
+
+        --location-ids LOCATION_IDS         Comma separated list of values.
+        --locations LOCATION_NAMES          Comma separated list of values.
+        --organization-ids ORGANIZATION_IDS Comma separated list of values.
+        --organizations ORGANIZATION_NAMES  Comma separated list of values.
+        --permission-ids PERMISSION_IDS     Comma separated list of values.
+        --permissions PERMISSION_NAMES      Comma separated list of values.
+        --role ROLE_NAME                    User role name
+        --role-id ROLE_ID
+        --search SEARCH
+        -h, --help                          print help
+    """
+    args = {
+        u'location-ids': None,
+        u'locations': None,
+        u'organization-ids': None,
+        u'organizations': None,
+        u'permission-ids': None,
+        u'permissions': None,
+        u'role': None,
+        u'role-id': None,
+        u'search': None,
+    }
+
+    # Role and permissions are required fields.
+    if not options:
+        raise CLIFactoryError('Please provide required parameters')
+
+    # Do we have at least one role field?
+    if not any(options.get(key) for key in ['role', 'role-id']):
+        raise CLIFactoryError('Please provide a valid role field.')
+
+    # Do we have at least one permissions field?
+    if not any(options.get(key) for key in ['permissions', 'permission-ids']):
+        raise CLIFactoryError('Please provide a valid permissions field.')
+
+    return create_object(Filter, args, options)
 
 
 @cacheable

--- a/robottelo/cli/filter.py
+++ b/robottelo/cli/filter.py
@@ -1,0 +1,33 @@
+# -*- encoding: utf-8 -*-
+"""
+Usage::
+     hammer filter [OPTIONS] SUBCOMMAND [ARG] ...
+
+Parameters::
+
+ SUBCOMMAND                    subcommand
+ [ARG] ...                     subcommand arguments
+
+Subcommands::
+
+ available-permissions         List all permissions
+ available-resources           List available resource types.
+ create                        Create a filter
+ delete                        Delete a filter
+ info                          Show a filter
+ list                          List all filters
+ update                        Update a filter
+"""
+
+from robottelo.cli.base import Base
+
+
+class Filter(Base):
+    """Manipulates Katello's filter command."""
+    command_base = 'filter'
+
+    @classmethod
+    def available_permissions(cls, options=None):
+        cls.command_sub = 'available-permissions'
+        return cls.execute(
+            cls._construct_command(options), output_format='csv')

--- a/robottelo/cli/role.py
+++ b/robottelo/cli/role.py
@@ -22,5 +22,10 @@ from robottelo.cli.base import Base
 
 class Role(Base):
     """Manipulates Katello engine's role command."""
-
     command_base = 'role'
+
+    @classmethod
+    def filters(cls, options=None):
+        cls.command_sub = 'filters'
+        return cls.execute(
+            cls._construct_command(options), output_format='json')

--- a/tests/foreman/cli/test_filter.py
+++ b/tests/foreman/cli/test_filter.py
@@ -1,0 +1,216 @@
+# -*- encoding: utf-8 -*-
+"""Test for Roles CLI
+
+@Requirement: Filter
+
+@CaseAutomation: Automated
+
+@CaseLevel: Acceptance
+
+@CaseComponent: CLI
+
+@TestType: Functional
+
+@CaseImportance: High
+
+@Upstream: No
+"""
+
+from robottelo.cli.base import CLIReturnCodeError
+from robottelo.cli.factory import (
+    make_filter,
+    make_location,
+    make_org,
+    make_role,
+)
+from robottelo.cli.filter import Filter
+from robottelo.cli.role import Role
+from robottelo.decorators import tier1
+from robottelo.test import APITestCase
+
+
+class FilterTestCase(APITestCase):
+
+    @classmethod
+    def setUpClass(cls):
+        """Search for Organization permissions. Set ``cls.perms``."""
+        super(FilterTestCase, cls).setUpClass()
+        cls.perms = [
+            permission['name']
+            for permission in Filter.available_permissions(
+                {'resource-type': 'User'})
+            ]
+
+    def setUp(self):
+        """Create a role that a filter would be assigned """
+        super(FilterTestCase, self).setUp()
+        self.role = make_role()
+
+    @tier1
+    def test_positive_create_with_permission(self):
+        """Create a filter and assign it some permissions.
+
+        @id: 6da6c5d3-2727-4eb7-aa15-9f7b6f91d3b2
+
+        @Assert: The created filter has the assigned permissions.
+        """
+        # Assign filter to created role
+        filter_ = make_filter({
+            'role-id': self.role['id'],
+            'permissions': self.perms,
+        })
+        self.assertEqual(
+            set(filter_['permissions'].split(", ")),
+            set(self.perms)
+        )
+
+    @tier1
+    def test_positive_create_with_org(self):
+        """Create a filter and assign it some permissions.
+
+        @id: f6308192-0e1f-427b-a296-b285f6684691
+
+        @Assert: The created filter has the assigned permissions.
+        """
+        org = make_org()
+        # Assign filter to created role
+        filter_ = make_filter({
+            'role-id': self.role['id'],
+            'permissions': self.perms,
+            'organization-ids': org['id'],
+        })
+        # we expect here only only one organization, i.e. first element
+        self.assertEqual(filter_['organizations'][0], org['name'])
+
+    @tier1
+    def test_positive_create_with_loc(self):
+        """Create a filter and assign it some permissions.
+
+        @id: d7d1969a-cb30-4e97-a9a3-3a4aaf608795
+
+        @Assert: The created filter has the assigned permissions.
+        """
+        loc = make_location()
+        # Assign filter to created role
+        filter_ = make_filter({
+            'role-id': self.role['id'],
+            'permissions': self.perms,
+            'location-ids': loc['id'],
+        })
+        # we expect here only only one location, i.e. first element
+        self.assertEqual(filter_['locations'][0], loc['name'])
+
+    @tier1
+    def test_positive_delete(self):
+        """Create a filter and delete it afterwards.
+
+        @id: 97d1093c-0d49-454b-86f6-f5be87b32775
+
+        @Assert: The deleted filter cannot be fetched.
+        """
+        filter_ = make_filter({
+            'role-id': self.role['id'],
+            'permissions': self.perms,
+        })
+        Filter.delete({'id': filter_['id']})
+        with self.assertRaises(CLIReturnCodeError):
+            Filter.info({'id': filter_['id']})
+
+    @tier1
+    def test_positive_delete_role(self):
+        """Create a filter and delete the role it points at.
+
+        @id: e2adb6a4-e408-4912-a32d-2bf2c43187d9
+
+        @Assert: The filter cannot be fetched.
+        """
+        filter_ = make_filter({
+            'role-id': self.role['id'],
+            'permissions': self.perms,
+        })
+
+        # A filter depends on a role. Deleting a role implicitly deletes the
+        # filter pointing at it.
+        Role.delete({'id': self.role['id']})
+        with self.assertRaises(CLIReturnCodeError):
+            Role.info({'id': self.role['id']})
+        with self.assertRaises(CLIReturnCodeError):
+            Filter.info({'id': filter_['id']})
+
+    @tier1
+    def test_positive_update_permissions(self):
+        """Create a filter and update its permissions.
+
+        @id: 3d6a52d8-2f8f-4f97-a155-9b52888af16e
+
+        @Assert: Permissions updated.
+        """
+        filter_ = make_filter({
+            'role-id': self.role['id'],
+            'permissions': self.perms,
+        })
+        new_perms = [
+            permission['name']
+            for permission in Filter.available_permissions(
+                {'resource-type': 'User'})
+            ]
+        Filter.update({
+            'id': filter_['id'],
+            'permissions': new_perms
+        })
+        filter_ = Filter.info({'id': filter_['id']})
+        self.assertEqual(
+            set(filter_['permissions'].split(", ")),
+            set(new_perms)
+        )
+
+    @tier1
+    def test_positive_update_role(self):
+        """Create a filter and assign it to another role.
+
+        @id: 2950b3a1-2bce-447f-9df2-869b1d10eaf5
+
+        @Assert: Filter is created and assigned to new role.
+        """
+        filter_ = make_filter({
+            'role-id': self.role['id'],
+            'permissions': self.perms,
+        })
+        # Update with another role
+        new_role = make_role()
+        Filter.update({
+            'id': filter_['id'],
+            'role-id': new_role['id'],
+        })
+        filter_ = Filter.info({'id': filter_['id']})
+        self.assertEqual(filter_['role'], new_role['name'])
+
+    @tier1
+    def test_positive_update_org_loc(self):
+        """Create a filter and assign it to another organization and location.
+
+         @id: 9bb59109-9701-4ef3-95c6-81f387d372da
+
+         @Assert: Filter is created and assigned to new org and loc.
+         """
+        org = make_org()
+        loc = make_location()
+        filter_ = make_filter({
+            'role-id': self.role['id'],
+            'permissions': self.perms,
+            'organization-ids': org['id'],
+            'location-ids': loc['id']
+        })
+        # Update org and loc
+        new_org = make_org()
+        new_loc = make_location()
+        Filter.update({
+            'id': filter_['id'],
+            'permissions': self.perms,
+            'organization-ids': new_org['id'],
+            'location-ids': new_loc['id']
+        })
+        filter_ = Filter.info({'id': filter_['id']})
+        # We expect here only one organization and location
+        self.assertEqual(filter_['organizations'][0], new_org['name'])
+        self.assertEqual(filter_['locations'][0], new_loc['name'])


### PR DESCRIPTION
Cherry-pick of #3704. Closes #4037
Test-results for 6.2.z branch on 6.2.4.
```python
% py.test -v -k "FilterTestCase or RoleTestCase" tests/foreman/cli/test_{role.py,filter.py}
===================================================================== test session starts =====================================================================
platform linux2 -- Python 2.7.12, pytest-2.9.2, py-1.4.31, pluggy-0.3.1 -- /home/qui/code/venv/6.2.z/bin/python2
cachedir: .cache
rootdir: /home/qui/code/robottelo, inifile: 
plugins: xdist-1.14, cov-2.3.1
collected 13 items 

tests/foreman/cli/test_role.py::RoleTestCase::test_positive_create_with_filter PASSED
tests/foreman/cli/test_role.py::RoleTestCase::test_positive_create_with_name PASSED
tests/foreman/cli/test_role.py::RoleTestCase::test_positive_create_with_permission PASSED
tests/foreman/cli/test_role.py::RoleTestCase::test_positive_delete_by_id PASSED
tests/foreman/cli/test_role.py::RoleTestCase::test_positive_update_name PASSED
tests/foreman/cli/test_filter.py::FilterTestCase::test_positive_create_with_loc PASSED
tests/foreman/cli/test_filter.py::FilterTestCase::test_positive_create_with_org PASSED
tests/foreman/cli/test_filter.py::FilterTestCase::test_positive_create_with_permission PASSED
tests/foreman/cli/test_filter.py::FilterTestCase::test_positive_delete PASSED
tests/foreman/cli/test_filter.py::FilterTestCase::test_positive_delete_role PASSED
tests/foreman/cli/test_filter.py::FilterTestCase::test_positive_update_org_loc PASSED
tests/foreman/cli/test_filter.py::FilterTestCase::test_positive_update_permissions PASSED
tests/foreman/cli/test_filter.py::FilterTestCase::test_positive_update_role PASSED

================================================================= 13 passed in 913.27 seconds =================================================================
```