### PR TITLE
#3774 cli erratum list

### DIFF
--- a/robottelo/cli/erratum.py
+++ b/robottelo/cli/erratum.py
@@ -1,0 +1,25 @@
+# -*- encoding: utf-8 -*-
+"""
+Usage::
+
+    hammer erratum [OPTIONS] SUBCOMMAND [ARG] ...
+
+Parameters::
+
+ SUBCOMMAND                    subcommand
+ [ARG] ...                     subcommand arguments
+
+Subcommands::
+
+ info                          Show an erratum
+ list                          List errata
+"""
+
+
+from robottelo.cli.base import Base
+
+
+class Erratum(Base):
+    """Manipulates Foreman's erratum."""
+
+    command_base = 'erratum'

--- a/tests/foreman/cli/test_errata.py
+++ b/tests/foreman/cli/test_errata.py
@@ -33,7 +33,6 @@ from robottelo.constants import (
     FAKE_6_YUM_REPO,
 )
 from robottelo.decorators import (
-    run_only_on,
     stubbed,
     tier3,
 )
@@ -546,7 +545,6 @@ class ErrataTestCase(CLITestCase):
                 ]
                 self.assertEquals(errata_ids, sorted_errata_ids)
 
-    @run_only_on('sat')
     @tier3
     def test_positive_list_filter_by_org_id_and_sort_by_issued_date(self):
         """Filter errata by org id and sort by issued date

--- a/tests/foreman/cli/test_errata.py
+++ b/tests/foreman/cli/test_errata.py
@@ -262,12 +262,12 @@ class ErrataTestCase(CLITestCase):
     def setUpClass(cls):
         """Create 3 organizations
 
-           1- one organization with one product and one repository
+           1- Create an org with one custom product & repository
 
-           2- one organization with one product and one repository
+           2- Create an org2 with an other custom product & repository
 
-           3- one organization with 2 products and one repository for each
-              product
+           3- Create an org3 with two other products, each containing one
+              custom repository
 
            note: all products repositories contain erratum
            """
@@ -358,32 +358,48 @@ class ErrataTestCase(CLITestCase):
             with self.subTest(sort_text):
                 erratum_list = Erratum.list({'order': sort_text,
                                              'per-page': ERRATUM_MAX_IDS_INFO})
+                # note: the erratum_list, contain a list of restraint info
+                # (id, errata-id, type, title) about each errata
                 self.assertGreater(len(erratum_list), 0)
+                # build a list of erratum id received from Erratum.list
                 erratum_ids = [
                     errata['id']
                     for errata in erratum_list
                 ]
+                # build a list of errata-id field value in the same order as
+                # received from Erratum.list
                 errata_ids = [
                     errata['errata-id']
                     for errata in erratum_list
                 ]
-                sorted_errata_list = self._get_sorted_erratum_ids_info(
+                # build a sorted more detailed erratum info list, that also
+                # contain the sort field
+                sorted_errata_info_list = self._get_sorted_erratum_ids_info(
                     erratum_ids,
                     sort_by=sort_field,
                     sort_reversed=sort_reversed
                 )
-                sorted_fields = [
+                # build a list of sort field (issued/updated) values in the
+                # same order as received from the detailed sorted erratum info
+                # list
+                sort_field_values = [
                     errata[sort_field]
-                    for errata in sorted_errata_list
+                    for errata in sorted_errata_info_list
                 ]
+                # ensure that the sort field (issued/updated) values are sorted
+                # as needed
                 self.assertEquals(
-                    sorted_fields,
-                    sorted(sorted_fields, reverse=sort_reversed)
+                    sort_field_values,
+                    sorted(sort_field_values, reverse=sort_reversed)
                 )
+                # build a list of errata-id field value in the same order as
+                # received from the detailed sorted errata info list
                 sorted_errata_ids = [
                     errata['errata-id']
-                    for errata in sorted_errata_list
+                    for errata in sorted_errata_info_list
                 ]
+                # ensure that the errata ids received by Erratum.list is sorted
+                # as needed
                 self.assertEquals(errata_ids, sorted_errata_ids)
 
     @tier3
@@ -411,32 +427,48 @@ class ErrataTestCase(CLITestCase):
                     'order': sort_text,
                     'per-page': ERRATUM_MAX_IDS_INFO
                 })
+                # note: the erratum_list, contain a list of restraint info
+                # (id, errata-id, type, title) about each errata
                 self.assertGreater(len(erratum_list), 0)
+                # build a list of erratum id received from Erratum.list
                 erratum_ids = [
                     errata['id']
                     for errata in erratum_list
                 ]
+                # build a list of errata-id field value in the same order as
+                # received from Erratum.list
                 errata_ids = [
                     errata['errata-id']
                     for errata in erratum_list
                 ]
-                sorted_errata_list = self._get_sorted_erratum_ids_info(
+                # build a sorted more detailed erratum info list, that also
+                # contain the sort field
+                sorted_errata_info_list = self._get_sorted_erratum_ids_info(
                     erratum_ids,
                     sort_by=sort_field,
                     sort_reversed=sort_reversed
                 )
-                sorted_fields = [
+                # build a list of sort field (issued/updated) values in the
+                # same order as received from the detailed sorted erratum info
+                # list
+                sort_field_values = [
                     errata[sort_field]
-                    for errata in sorted_errata_list
+                    for errata in sorted_errata_info_list
                 ]
+                # ensure that the sort field (issued/updated) values are sorted
+                # as needed
                 self.assertEquals(
-                    sorted_fields,
-                    sorted(sorted_fields, reverse=sort_reversed)
+                    sort_field_values,
+                    sorted(sort_field_values, reverse=sort_reversed)
                 )
+                # build a list of errata-id field value in the same order as
+                # received from the detailed sorted errata info list
                 sorted_errata_ids = [
                     errata['errata-id']
-                    for errata in sorted_errata_list
+                    for errata in sorted_errata_info_list
                 ]
+                # ensure that the errata ids received by Erratum.list is sorted
+                # as needed
                 self.assertEquals(errata_ids, sorted_errata_ids)
 
     @tier3
@@ -464,32 +496,48 @@ class ErrataTestCase(CLITestCase):
                     'order': sort_text,
                     'per-page': ERRATUM_MAX_IDS_INFO
                 })
+                # note: the erratum_list, contain a list of restraint info
+                # (id, errata-id, type, title) about each errata
                 self.assertGreater(len(erratum_list), 0)
+                # build a list of erratum id received from Erratum.list
                 erratum_ids = [
                     errata['id']
                     for errata in erratum_list
                 ]
+                # build a list of errata-id field value in the same order as
+                # received from Erratum.list
                 errata_ids = [
                     errata['errata-id']
                     for errata in erratum_list
                 ]
-                sorted_errata_list = self._get_sorted_erratum_ids_info(
+                # build a sorted more detailed erratum info list, that also
+                # contain the sort field
+                sorted_errata_info_list = self._get_sorted_erratum_ids_info(
                     erratum_ids,
                     sort_by=sort_field,
                     sort_reversed=sort_reversed
                 )
-                sorted_fields = [
+                # build a list of sort field (issued/updated) values in the
+                # same order as received from the detailed sorted erratum info
+                # list
+                sort_field_values = [
                     errata[sort_field]
-                    for errata in sorted_errata_list
+                    for errata in sorted_errata_info_list
                 ]
+                # ensure that the sort field (issued/updated) values are sorted
+                # as needed
                 self.assertEquals(
-                    sorted_fields,
-                    sorted(sorted_fields, reverse=sort_reversed)
+                    sort_field_values,
+                    sorted(sort_field_values, reverse=sort_reversed)
                 )
+                # build a list of errata-id field value in the same order as
+                # received from the detailed sorted errata info list
                 sorted_errata_ids = [
                     errata['errata-id']
-                    for errata in sorted_errata_list
+                    for errata in sorted_errata_info_list
                 ]
+                # ensure that the errata ids received by Erratum.list is sorted
+                # as needed
                 self.assertEquals(errata_ids, sorted_errata_ids)
 
     @tier3
@@ -517,32 +565,48 @@ class ErrataTestCase(CLITestCase):
                     'order': sort_text,
                     'per-page': ERRATUM_MAX_IDS_INFO
                 })
+                # note: the erratum_list, contain a list of restraint info
+                # (id, errata-id, type, title) about each errata
                 self.assertGreater(len(erratum_list), 0)
+                # build a list of erratum id received from Erratum.list
                 erratum_ids = [
                     errata['id']
                     for errata in erratum_list
                 ]
+                # build a list of errata-id field value in the same order as
+                # received from Erratum.list
                 errata_ids = [
                     errata['errata-id']
                     for errata in erratum_list
                 ]
-                sorted_errata_list = self._get_sorted_erratum_ids_info(
+                # build a sorted more detailed erratum info list, that also
+                # contain the sort field
+                sorted_errata_info_list = self._get_sorted_erratum_ids_info(
                     erratum_ids,
                     sort_by=sort_field,
                     sort_reversed=sort_reversed
                 )
-                sorted_fields = [
+                # build a list of sort field (issued/updated) values in the
+                # same order as received from the detailed sorted erratum info
+                # list
+                sort_field_values = [
                     errata[sort_field]
-                    for errata in sorted_errata_list
+                    for errata in sorted_errata_info_list
                 ]
+                # ensure that the sort field (issued/updated) values are sorted
+                # as needed
                 self.assertEquals(
-                    sorted_fields,
-                    sorted(sorted_fields, reverse=sort_reversed)
+                    sort_field_values,
+                    sorted(sort_field_values, reverse=sort_reversed)
                 )
+                # build a list of errata-id field value in the same order as
+                # received from the detailed sorted errata info list
                 sorted_errata_ids = [
                     errata['errata-id']
-                    for errata in sorted_errata_list
+                    for errata in sorted_errata_info_list
                 ]
+                # ensure that the errata ids received by Erratum.list is sorted
+                # as needed
                 self.assertEquals(errata_ids, sorted_errata_ids)
 
     @tier3
@@ -570,32 +634,48 @@ class ErrataTestCase(CLITestCase):
                     'order': sort_text,
                     'per-page': ERRATUM_MAX_IDS_INFO
                 })
+                # note: the erratum_list, contain a list of restraint info
+                # (id, errata-id, type, title) about each errata
                 self.assertGreater(len(erratum_list), 0)
+                # build a list of erratum id received from Erratum.list
                 erratum_ids = [
                     errata['id']
                     for errata in erratum_list
                 ]
+                # build a list of errata-id field value in the same order as
+                # received from Erratum.list
                 errata_ids = [
                     errata['errata-id']
                     for errata in erratum_list
                 ]
-                sorted_errata_list = self._get_sorted_erratum_ids_info(
+                # build a sorted more detailed erratum info list, that also
+                # contain the sort field
+                sorted_errata_info_list = self._get_sorted_erratum_ids_info(
                     erratum_ids,
                     sort_by=sort_field,
                     sort_reversed=sort_reversed
                 )
-                sorted_fields = [
+                # build a list of sort field (issued/updated) values in the
+                # same order as received from the detailed sorted erratum info
+                # list
+                sort_field_values = [
                     errata[sort_field]
-                    for errata in sorted_errata_list
+                    for errata in sorted_errata_info_list
                 ]
+                # ensure that the sort field (issued/updated) values are sorted
+                # as needed
                 self.assertEquals(
-                    sorted_fields,
-                    sorted(sorted_fields, reverse=sort_reversed)
+                    sort_field_values,
+                    sorted(sort_field_values, reverse=sort_reversed)
                 )
+                # build a list of errata-id field value in the same order as
+                # received from the detailed sorted errata info list
                 sorted_errata_ids = [
                     errata['errata-id']
-                    for errata in sorted_errata_list
+                    for errata in sorted_errata_info_list
                 ]
+                # ensure that the errata ids received by Erratum.list is sorted
+                # as needed
                 self.assertEquals(errata_ids, sorted_errata_ids)
 
     @tier3
@@ -623,32 +703,48 @@ class ErrataTestCase(CLITestCase):
                     'order': sort_text,
                     'per-page': ERRATUM_MAX_IDS_INFO
                 })
+                # note: the erratum_list, contain a list of restraint info
+                # (id, errata-id, type, title) about each errata
                 self.assertGreater(len(erratum_list), 0)
+                # build a list of erratum id received from Erratum.list
                 erratum_ids = [
                     errata['id']
                     for errata in erratum_list
                 ]
+                # build a list of errata-id field value in the same order as
+                # received from Erratum.list
                 errata_ids = [
                     errata['errata-id']
                     for errata in erratum_list
                 ]
-                sorted_errata_list = self._get_sorted_erratum_ids_info(
+                # build a sorted more detailed erratum info list, that also
+                # contain the sort field
+                sorted_errata_info_list = self._get_sorted_erratum_ids_info(
                     erratum_ids,
                     sort_by=sort_field,
                     sort_reversed=sort_reversed
                 )
-                sorted_fields = [
+                # build a list of sort field (issued/updated) values in the
+                # same order as received from the detailed sorted erratum info
+                # list
+                sort_field_values = [
                     errata[sort_field]
-                    for errata in sorted_errata_list
+                    for errata in sorted_errata_info_list
                 ]
+                # ensure that the sort field (issued/updated) values are sorted
+                # as needed
                 self.assertEquals(
-                    sorted_fields,
-                    sorted(sorted_fields, reverse=sort_reversed)
+                    sort_field_values,
+                    sorted(sort_field_values, reverse=sort_reversed)
                 )
+                # build a list of errata-id field value in the same order as
+                # received from the detailed sorted errata info list
                 sorted_errata_ids = [
                     errata['errata-id']
-                    for errata in sorted_errata_list
+                    for errata in sorted_errata_info_list
                 ]
+                # ensure that the errata ids received by Erratum.list is sorted
+                # as needed
                 self.assertEquals(errata_ids, sorted_errata_ids)
 
     @tier3
@@ -676,32 +772,48 @@ class ErrataTestCase(CLITestCase):
                     'order': sort_text,
                     'per-page': ERRATUM_MAX_IDS_INFO
                 })
+                # note: the erratum_list, contain a list of restraint info
+                # (id, errata-id, type, title) about each errata
                 self.assertGreater(len(erratum_list), 0)
+                # build a list of erratum id received from Erratum.list
                 erratum_ids = [
                     errata['id']
                     for errata in erratum_list
                 ]
+                # build a list of errata-id field in the same order as received
+                # from Erratum.list
                 errata_ids = [
                     errata['errata-id']
                     for errata in erratum_list
                 ]
-                sorted_errata_list = self._get_sorted_erratum_ids_info(
+                # build a sorted more detailed erratum info list, that also
+                # contain the sort field
+                sorted_errata_info_list = self._get_sorted_erratum_ids_info(
                     erratum_ids,
                     sort_by=sort_field,
                     sort_reversed=sort_reversed
                 )
-                sorted_fields = [
+                # build a list of sort field (issued/updated) values in the
+                # same order as received from the detailed sorted erratum info
+                # list
+                sort_field_values = [
                     errata[sort_field]
-                    for errata in sorted_errata_list
+                    for errata in sorted_errata_info_list
                 ]
+                # ensure that the sort field (issued/updated) values are sorted
+                # as needed
                 self.assertEquals(
-                    sorted_fields,
-                    sorted(sorted_fields, reverse=sort_reversed)
+                    sort_field_values,
+                    sorted(sort_field_values, reverse=sort_reversed)
                 )
+                # build a list of errata-id field value in the same order as
+                # received from the detailed sorted errata info list
                 sorted_errata_ids = [
                     errata['errata-id']
-                    for errata in sorted_errata_list
+                    for errata in sorted_errata_info_list
                 ]
+                # ensure that the errata ids received by Erratum.list is sorted
+                # as needed
                 self.assertEquals(errata_ids, sorted_errata_ids)
 
     @tier3


### PR DESCRIPTION
```bash
dlezz@elysion:~/projects/robottelo-fork$ py.test tests/foreman/cli/test_errata.py -v -k "ErrataTestCase"
=========================================================== test session starts ===========================================================
platform linux2 -- Python 2.7.12, pytest-3.0.3, py-1.4.31, pluggy-0.4.0 -- /home/dlezz/bin/redhat/python/2.7/bin/python
cachedir: .cache
rootdir: /home/dlezz/projects/robottelo-fork, inifile: 
plugins: cov-2.4.0, xdist-1.15.0
collected 34 items 

tests/foreman/cli/test_errata.py::ErrataTestCase::test_positive_list_affected_chosts <- ../../bin/redhat/python/2.7/lib/python2.7/site-packages/unittest2/case.py SKIPPED
tests/foreman/cli/test_errata.py::ErrataTestCase::test_positive_list_affected_chosts_by_erratum_restrict_flag <- ../../bin/redhat/python/2.7/lib/python2.7/site-packages/unittest2/case.py SKIPPED
tests/foreman/cli/test_errata.py::ErrataTestCase::test_positive_list_filter_by_cve <- ../../bin/redhat/python/2.7/lib/python2.7/site-packages/unittest2/case.py SKIPPED
tests/foreman/cli/test_errata.py::ErrataTestCase::test_positive_list_filter_by_org_id PASSED
tests/foreman/cli/test_errata.py::ErrataTestCase::test_positive_list_filter_by_org_id_and_sort_by_issued_date <- robottelo/decorators/__init__.py PASSED
tests/foreman/cli/test_errata.py::ErrataTestCase::test_positive_list_filter_by_org_id_and_sort_by_updated_date PASSED
tests/foreman/cli/test_errata.py::ErrataTestCase::test_positive_list_filter_by_org_label PASSED
tests/foreman/cli/test_errata.py::ErrataTestCase::test_positive_list_filter_by_org_label_and_sort_by_issued_date PASSED
tests/foreman/cli/test_errata.py::ErrataTestCase::test_positive_list_filter_by_org_label_and_sort_by_updated_date PASSED
tests/foreman/cli/test_errata.py::ErrataTestCase::test_positive_list_filter_by_org_name PASSED
tests/foreman/cli/test_errata.py::ErrataTestCase::test_positive_list_filter_by_org_name_and_sort_by_issued_date PASSED
tests/foreman/cli/test_errata.py::ErrataTestCase::test_positive_list_filter_by_org_name_and_sort_by_updated_date PASSED
tests/foreman/cli/test_errata.py::ErrataTestCase::test_positive_list_filter_by_product_id PASSED
tests/foreman/cli/test_errata.py::ErrataTestCase::test_positive_list_filter_by_product_id_and_org_id PASSED
tests/foreman/cli/test_errata.py::ErrataTestCase::test_positive_list_filter_by_product_id_and_org_label PASSED
tests/foreman/cli/test_errata.py::ErrataTestCase::test_positive_list_filter_by_product_id_and_org_name PASSED
tests/foreman/cli/test_errata.py::ErrataTestCase::test_positive_list_filter_by_product_name <- ../../bin/redhat/python/2.7/lib/python2.7/site-packages/unittest2/case.py SKIPPED
tests/foreman/cli/test_errata.py::ErrataTestCase::test_positive_list_filter_by_product_name_and_org_id PASSED
tests/foreman/cli/test_errata.py::ErrataTestCase::test_positive_list_filter_by_product_name_and_org_label PASSED
tests/foreman/cli/test_errata.py::ErrataTestCase::test_positive_list_filter_by_product_name_and_org_name PASSED
tests/foreman/cli/test_errata.py::ErrataTestCase::test_positive_list_sort_by_issued_date PASSED
tests/foreman/cli/test_errata.py::ErrataTestCase::test_positive_user_permission <- ../../bin/redhat/python/2.7/lib/python2.7/site-packages/unittest2/case.py SKIPPED
tests/foreman/cli/test_errata.py::ErrataTestCase::test_positive_view_available_count_in_affected_chosts <- ../../bin/redhat/python/2.7/lib/python2.7/site-packages/unittest2/case.py SKIPPED

=========================================================== 11 tests deselected ===========================================================
========================================= 17 passed, 6 skipped, 11 deselected in 1018.55 seconds ==========================================
```