### PR TITLE
[Cherrypick to 6.1.z] Bugzilla credentials moved to config

### DIFF
--- a/robottelo.properties.sample
+++ b/robottelo.properties.sample
@@ -25,7 +25,6 @@ ssh_key=
 # Admin password when accessing API and UI
 # admin_password=changeme
 
-
 # Override robottelo configuration
 # [robottelo]
 # The directory where screenshots will be saved.
@@ -78,6 +77,13 @@ ssh_key=
 # capsule_repo=http://capsule/repo
 # sattools_repo=http://sattools/repo
 
+# Bugzilla data to authenticate API calls
+[bugzilla]
+# username used when accessing Bugzilla's API
+# bz_username=admin
+
+# password used when accessing Bugzilla's API
+# bz_password=changeme
 
 # For LDAP Authentication.
 # [ldap]

--- a/robottelo/config/settings.py
+++ b/robottelo/config/settings.py
@@ -3,6 +3,7 @@ import logging
 import os
 import sys
 
+from functools import partial
 from logging import config
 from nailgun import entities, entity_mixins
 from nailgun.config import ServerConfig
@@ -213,6 +214,32 @@ class ServerSettings(FeatureSettings):
         """
         return urljoin(
             self.get_pub_url(), 'katello-ca-consumer-latest.noarch.rpm')
+
+
+class BugzillaSettings(FeatureSettings):
+    """Bugzilla server settings definitions."""
+    def __init__(self, *args, **kwargs):
+        super(BugzillaSettings, self).__init__(*args, **kwargs)
+        self.password = None
+        self.username = None
+
+    def read(self, reader):
+        """Read and validate Bugzilla server settings."""
+        get_bz = partial(reader.get, 'bugzilla')
+        self.password = get_bz('bz_password', 'changeme')
+        self.username = get_bz('bz_username', 'admin')
+
+    def get_credentials(self):
+        """Return credentials for interacting with a Bugzilla API.
+
+        :return: A username-password dict.
+        :rtype: dict
+
+        """
+        return {'user': self.username, 'password': self.password}
+
+    def validate(self):
+        return []
 
 
 class ClientsSettings(FeatureSettings):
@@ -540,6 +567,7 @@ class Settings(object):
         self.webdriver = None
         self.webdriver_binary = None
 
+        self.bugzilla = BugzillaSettings()
         # Features
         self.clients = ClientsSettings()
         self.compute_resources = LibvirtHostSettings()
@@ -573,41 +601,19 @@ class Settings(object):
         self._read_robottelo_settings()
         self._validation_errors.extend(
             self._validate_robottelo_settings())
-        self.server.read(self.reader)
-        self._validation_errors.extend(self.server.validate())
-        if self.reader.has_section('clients'):
-            self.clients.read(self.reader)
-            self._validation_errors.extend(self.clients.validate())
-        if self.reader.has_section('compute_resources'):
-            self.compute_resources.read(self.reader)
-            self._validation_errors.extend(self.compute_resources.validate())
-        if self.reader.has_section('discovery'):
-            self.discovery.read(self.reader)
-            self._validation_errors.extend(self.discovery.validate())
-        if self.reader.has_section('docker'):
-            self.docker.read(self.reader)
-            self._validation_errors.extend(self.docker.validate())
-        if self.reader.has_section('fake_manifest'):
-            self.fake_manifest.read(self.reader)
-            self._validation_errors.extend(self.fake_manifest.validate())
-        if self.reader.has_section('ldap'):
-            self.ldap.read(self.reader)
-            self._validation_errors.extend(self.ldap.validate())
-        if self.reader.has_section('oscap'):
-            self.oscap.read(self.reader)
-            self._validation_errors.extend(self.oscap.validate())
-        if self.reader.has_section('performance'):
-            self.performance.read(self.reader)
-            self._validation_errors.extend(self.performance.validate())
-        if self.reader.has_section('rhai'):
-            self.rhai.read(self.reader)
-            self._validation_errors.extend(self.rhai.validate())
-        if self.reader.has_section('transition'):
-            self.transition.read(self.reader)
-            self._validation_errors.extend(self.transition.validate())
-        if self.reader.has_section('vlan_networking'):
-            self.vlan_networking.read(self.reader)
-            self._validation_errors.extend(self.vlan_networking.validate())
+
+        attrs = map(
+            lambda attr_name: (attr_name, getattr(self, attr_name)),
+            dir(self)
+        )
+        feature_settings = filter(
+            lambda tpl: isinstance(tpl[1], FeatureSettings),
+            attrs
+        )
+        for name, settings in feature_settings:
+            if self.reader.has_section(name) or name == 'server':
+                settings.read(self.reader)
+                self._validation_errors.extend(settings.validate())
 
         if self._validation_errors:
             raise ImproperlyConfigured(

--- a/robottelo/decorators/__init__.py
+++ b/robottelo/decorators/__init__.py
@@ -255,7 +255,8 @@ def _get_bugzilla_bug(bug_id):
         LOGGER.info('Bugzilla bug {0} not in cache. Fetching.'.format(bug_id))
         # Make a network connection to the Bugzilla server.
         try:
-            bz_conn = bugzilla.RHBugzilla()
+            bz_conn = bugzilla.RHBugzilla(
+                **settings.bugzilla.get_credentials())
             bz_conn.connect(BUGZILLA_URL)
         except (TypeError, ValueError):
             raise BugFetchError(
@@ -263,7 +264,10 @@ def _get_bugzilla_bug(bug_id):
             )
         # Fetch the bug and place it in the cache.
         try:
-            _bugzilla[bug_id] = bz_conn.getbugsimple(bug_id)
+            _bugzilla[bug_id] = bz_conn.getbug(
+                bug_id,
+                include_fields=['id', 'status', 'whiteboard', 'flags']
+            )
         except Fault as err:
             raise BugFetchError(
                 'Could not fetch bug. Error: {0}'.format(err.faultString)


### PR DESCRIPTION
#close 4045

(cherry picked from commit 330e0dd)

Test results:

```console

============================= test session starts ==============================
platform linux2 -- Python 2.7.12, pytest-3.0.3, py-1.4.31, pluggy-0.4.0
rootdir: /home/renzo/PycharmProjects/robottelo, inifile: 
plugins: xdist-1.15.0, cov-2.3.1
collected 85 items

test_api_utils.py ..
test_cli.py .....
test_datafactory.py .....
test_decorators.py ....WARNING:robottelo.decorators:
.......WARNING:robottelo.decorators:
................................
test_hammer.py .......
test_helpers.py ...........
test_ssh.py .
test_ui.py .....
test_vm.py ......

========================== 85 passed in 1.20 seconds ===========================
```