### PR TITLE
[6.2.z] Cherry-pick - Added tests for puppet modules list from the repo.

### DIFF
--- a/robottelo/ui/locators.py
+++ b/robottelo/ui/locators.py
@@ -1952,9 +1952,29 @@ locators = LocatorDict({
     "repo.fetch_package_groups": (
         By.XPATH, "//td[span[text()='Package Groups']]/following-sibling::td",
     ),
+    "repo.fetch_puppet_modules": (
+        By.XPATH, "//td[span[text()='Puppet Modules']]/following-sibling::td",
+    ),
     "repo.result_spinner": (
         By.XPATH,
         "//i[@ng-show='task.pending' and contains(@class, 'icon-spinner')]"),
+    "repo.manage_content.packages": (
+        By.XPATH,
+        "//button[contains(@ui-sref,"
+        " 'products.details.repositories.manage-content.packages')]"),
+    "repo.manage_content.puppet_modules": (
+        By.XPATH,
+        "//button[contains(@ui-sref,"
+        " 'products.details.repositories.manage-content.puppet-modules')]"),
+    "repo.manage_content.docker_manifests": (
+        By.XPATH,
+        "//button[contains(@ui-sref,"
+        " 'products.details.repositories.manage-content.docker-manifests')]"),
+    "repo.manage_content.ostree_branches": (
+        By.XPATH,
+        "//button[contains(@ui-sref,"
+        " 'products.details.repositories.manage-content.ostree-branches)]"),
+    "repo.content_items": (By.XPATH, "//tr[@row-select='item']"),
     # Activation Keys
 
     "ak.new": (By.XPATH, "//button[@ui-sref='activation-keys.new']"),

--- a/tests/foreman/api/test_repository.py
+++ b/tests/foreman/api/test_repository.py
@@ -34,8 +34,8 @@ from robottelo.constants import (
     VALID_GPG_KEY_BETA_FILE,
     VALID_GPG_KEY_FILE,
     DOWNLOAD_POLICIES,
-    REPO_TYPE
-)
+    REPO_TYPE,
+    FAKE_1_PUPPET_REPO)
 from robottelo.datafactory import (
     invalid_http_credentials,
     invalid_names_list,
@@ -860,6 +860,38 @@ class RepositoryTestCase(APITestCase):
                 repo.delete()
                 with self.assertRaises(HTTPError):
                     repo.read()
+
+    @tier1
+    @run_only_on('sat')
+    def test_positive_list_puppet_modules_with_multiple_repos(self):
+        """Verify that puppet modules list for specific repo is correct
+        and does not affected by other repositories.
+
+        @id: e9e16ac2-a58d-4d49-b378-59e4f5b3a3ec
+
+        @Assert: Number of modules has no changed after a second repo
+        was synced.
+        """
+        # Create and sync first repo
+        repo1 = entities.Repository(
+            product=self.product,
+            content_type='puppet',
+            url=FAKE_0_PUPPET_REPO,
+        ).create()
+        repo1.sync()
+        # Verify that number of synced modules is correct
+        content_count = repo1.read().content_counts['puppet_module']
+        modules_num = len(repo1.puppet_modules()['results'])
+        self.assertEqual(content_count, modules_num)
+        # Create and sync second repo
+        repo2 = entities.Repository(
+            product=self.product,
+            content_type='puppet',
+            url=FAKE_1_PUPPET_REPO,
+        ).create()
+        repo2.sync()
+        # Verify that number of modules from the first repo has not changed
+        self.assertEqual(modules_num, len(repo1.puppet_modules()['results']))
 
 
 @run_in_one_thread

--- a/tests/foreman/ui/test_repository.py
+++ b/tests/foreman/ui/test_repository.py
@@ -38,7 +38,7 @@ from robottelo.constants import (
     SAT6_TOOLS_TREE,
     VALID_GPG_KEY_BETA_FILE,
     VALID_GPG_KEY_FILE,
-)
+    FAKE_1_PUPPET_REPO)
 from robottelo.datafactory import (
     filtered_datapoint,
     generate_strings_list,
@@ -935,6 +935,53 @@ class RepositoryTestCase(UITestCase):
                             locators['repo.download_policy']
                         )
                     )
+
+    @tier1
+    def test_positive_list_puppet_modules_with_multiple_repos(self):
+        """
+        Verify that puppet modules list for specific repo is correct
+        and does not affected by other repositories.
+
+        @id: 82ef2987-cb71-4164-aee5-4496b974d1bd
+
+        @Assert: Number of modules has no changed after a second repo
+        was synced.
+        """
+        with Session(self.browser):
+            # Create and sync first repo
+            repo1 = entities.Repository(
+                product=self.session_prod,
+                content_type='puppet',
+                url=FAKE_0_PUPPET_REPO,
+            ).create()
+            repo1.sync()
+            # Find modules count
+            self.products.search_and_click(self.session_prod.name)
+            self.repository.search_and_click(repo1.name)
+            content_count = self.repository.find_element(
+                locators['repo.fetch_puppet_modules']).text
+            self.repository.click(
+                locators['repo.manage_content.puppet_modules'])
+            modules_num = len(self.repository.find_elements(
+                locators['repo.content_items']))
+            self.assertEqual(content_count, str(modules_num))
+            # Create and sync second repo
+            repo2 = entities.Repository(
+                product=self.session_prod,
+                content_type='puppet',
+                url=FAKE_1_PUPPET_REPO,
+            ).create()
+            repo2.sync()
+            # Verify that number of modules from the first repo has not changed
+            self.products.search_and_click(self.session_prod.name)
+            self.repository.search_and_click(repo1.name)
+            self.repository.click(
+                locators['repo.manage_content.puppet_modules'])
+            self.assertEqual(
+                modules_num,
+                len(self.repository.find_elements(
+                    locators['repo.content_items']))
+            )
 
     @run_in_one_thread
     @tier2


### PR DESCRIPTION
Depends on SatelliteQE/nailgun#337
Cherry-pick of #4047. Closes #2246 

```python
% py.test -n 3 -v tests/foreman/{api,ui}/test_repository.py tests/foreman/cli/test_puppetmodule.py -k 'test_positive_list_puppet_modules_with_multiple_repos or test_positive_list_multiple_repos'
===================================================================== test session starts =====================================================================
[gw1] PASSED tests/foreman/api/test_repository.py::RepositoryTestCase::test_positive_list_puppet_modules_with_multiple_repos <- robottelo/decorators/__init__.py 
[gw0] PASSED tests/foreman/ui/test_repository.py::RepositoryTestCase::test_positive_list_puppet_modules_with_multiple_repos 
[gw2] PASSED tests/foreman/cli/test_puppetmodule.py::PuppetModuleTestCase::test_positive_list_multiple_repos <- robottelo/decorators/__init__.py 

================================================================= 3 passed in 137.03 seconds ==================================================================
```