### PR TITLE
#4038 Bug 1401469 - hammer filter info does not return organizations and locations

### DIFF
--- a/tests/foreman/cli/test_filter.py
+++ b/tests/foreman/cli/test_filter.py
@@ -25,7 +25,7 @@ from robottelo.cli.factory import (
 )
 from robottelo.cli.filter import Filter
 from robottelo.cli.role import Role
-from robottelo.decorators import tier1
+from robottelo.decorators import skip_if_bug_open, tier1
 from robottelo.test import APITestCase
 
 
@@ -64,6 +64,7 @@ class FilterTestCase(APITestCase):
             set(self.perms)
         )
 
+    @skip_if_bug_open('bugzilla', 1401469)
     @tier1
     def test_positive_create_with_org(self):
         """Create a filter and assign it some permissions.
@@ -82,6 +83,7 @@ class FilterTestCase(APITestCase):
         # we expect here only only one organization, i.e. first element
         self.assertEqual(filter_['organizations'][0], org['name'])
 
+    @skip_if_bug_open('bugzilla', 1401469)
     @tier1
     def test_positive_create_with_loc(self):
         """Create a filter and assign it some permissions.
@@ -185,6 +187,7 @@ class FilterTestCase(APITestCase):
         filter_ = Filter.info({'id': filter_['id']})
         self.assertEqual(filter_['role'], new_role['name'])
 
+    @skip_if_bug_open('bugzilla', 1401469)
     @tier1
     def test_positive_update_org_loc(self):
         """Create a filter and assign it to another organization and location.


### PR DESCRIPTION
```bash
(2.7) dlezz@elysion:~/projects/robottelo-fork$ py.test tests/foreman/cli/test_filter.py -v -k "FilterTestCase"
================================================= test session starts ==================================================
platform linux2 -- Python 2.7.12, pytest-3.0.3, py-1.4.31, pluggy-0.4.0 -- /home/dlezz/bin/redhat/python/2.7/bin/python
cachedir: .cache
rootdir: /home/dlezz/projects/robottelo-fork, inifile: 
plugins: cov-2.4.0, xdist-1.15.0
collected 8 items 

tests/foreman/cli/test_filter.py::FilterTestCase::test_positive_create_with_loc <- robottelo/decorators/__init__.py SKIPPED
tests/foreman/cli/test_filter.py::FilterTestCase::test_positive_create_with_org <- robottelo/decorators/__init__.py SKIPPED
tests/foreman/cli/test_filter.py::FilterTestCase::test_positive_create_with_permission PASSED
tests/foreman/cli/test_filter.py::FilterTestCase::test_positive_delete PASSED
tests/foreman/cli/test_filter.py::FilterTestCase::test_positive_delete_role PASSED
tests/foreman/cli/test_filter.py::FilterTestCase::test_positive_update_org_loc <- robottelo/decorators/__init__.py SKIPPED
tests/foreman/cli/test_filter.py::FilterTestCase::test_positive_update_permissions PASSED
tests/foreman/cli/test_filter.py::FilterTestCase::test_positive_update_role PASSED

======================================== 5 passed, 3 skipped in 225.52 seconds =========================================
```