### PR TITLE
6.2.z #3586 ui cv add edit rh custom spin

### DIFF
--- a/robottelo/constants.py
+++ b/robottelo/constants.py
@@ -314,6 +314,17 @@ FILTER_TYPE = {
     'exclude': "Exclude"
 }
 
+FILTER_ERRATA_TYPE = {
+    'security': "security",
+    'enhancement': "enhancement",
+    'bugfix': "bugfix"
+}
+
+FILTER_ERRATA_DATE = {
+    'updated': "updated",
+    'issued': "issued"
+}
+
 DOCKER_REGISTRY_HUB = u'https://registry-1.docker.io'
 CUSTOM_RPM_REPO = (
     u'http://repos.fedorapeople.org/repos/pulp/pulp/fixtures/rpm/'

--- a/robottelo/ui/contentviews.py
+++ b/robottelo/ui/contentviews.py
@@ -34,14 +34,18 @@ class ContentViews(Base):
     def set_calendar_date_value(self, name, value):
         """Set the input value of a date field and press the button to hide
          the calendar popup panel"""
+        strategy, calendar_date_input_locator = locators[
+            'contentviews.calendar_date_input']
         self.assign_value(
-            locators.contentviews.calendar_date_input % name,
+            (strategy, calendar_date_input_locator % name),
             value
         )
         # the calendar panel popup and hide other form elements that became
         # unreachable.
         # close the popup calendar panel
-        self.click(locators.contentviews.calendar_date_button % name)
+        strategy, calendar_date_button_locator = locators[
+            'contentviews.calendar_date_button']
+        self.click((strategy, calendar_date_button_locator % name))
 
     def create(self, name, label=None, description=None, is_composite=False):
         """Creates a content view"""
@@ -484,9 +488,11 @@ class ContentViews(Base):
             # will check all selected errata types first, after then uncheck
             # the not selected ones.
             # 1 - check first the types that are in the errata_types
+            strategy, erratum_type_checkbox_locator = locators[
+                'contentviews.erratum_type_checkbox']
             for errata_type in errata_types:
                 self.assign_value(
-                    locators.contentviews.erratum_type_checkbox % errata_type,
+                    (strategy, erratum_type_checkbox_locator % errata_type),
                     True
                 )
             # we are sure now that any check box not in the errata_types
@@ -495,18 +501,20 @@ class ContentViews(Base):
             for errata_type in set(allowed_errata_types).difference(
                     errata_types):
                 self.assign_value(
-                    locators.contentviews.erratum_type_checkbox % errata_type,
+                    (strategy, erratum_type_checkbox_locator % errata_type),
                     False
                 )
         if date_type is not None:
             if date_type not in allowed_date_types:
                 raise UIError('date type "{0}" not allowed'.format(date_type))
-            self.click(locators.contentviews.erratum_date_type % date_type)
+            strategy, erratum_date_type_locator = locators[
+                'contentviews.erratum_date_type']
+            self.click((strategy, erratum_date_type_locator % date_type))
         if start_date is not None:
             self.set_calendar_date_value('start_date', start_date)
         if end_date is not None:
             self.set_calendar_date_value('end_date', end_date)
-        self.click(locators.contentviews.save_erratum)
+        self.click(locators['contentviews.save_erratum'])
 
     def fetch_puppet_module(self, cv_name, module_name):
         """Get added puppet module name from selected content-view"""

--- a/robottelo/ui/locators.py
+++ b/robottelo/ui/locators.py
@@ -2416,6 +2416,17 @@ locators = LocatorDict({
          "//td[contains(normalize-space(.), '%s')]"
          "/preceding-sibling::td[@class='row-select']"
          "/input[@type='checkbox']")),
+    "contentviews.erratum_type_checkbox": (
+        By.XPATH, "//input[@ng-model='types.%s']"),
+    "contentviews.erratum_date_type": (
+        By.XPATH, "//input[@type='radio' and @value='%s']"),
+    "contentviews.calendar_date_input": (
+        By.XPATH, "//input[@ng-model='rule.%s']"),
+    "contentviews.calendar_date_button": (
+        By.XPATH, "//input[@ng-model='rule.%s']/.."
+                  "//li/button[@ng-click='isOpen = false']"),
+    "contentviews.save_erratum": (
+        By.XPATH, "//button[contains(@ng-click, 'handleSave()')]"),
     "contentviews.add_errata": (
         By.XPATH, "//button[@ng-click='addErrata(filter)']"),
     "contentviews.remove_errata": (

--- a/robottelo/ui/locators.py
+++ b/robottelo/ui/locators.py
@@ -2423,7 +2423,7 @@ locators = LocatorDict({
     "contentviews.calendar_date_input": (
         By.XPATH, "//input[@ng-model='rule.%s']"),
     "contentviews.calendar_date_button": (
-        By.XPATH, "//input[@ng-model='rule.%s']/.."
+        By.XPATH, "//input[@ng-model='rule.%s']/../ul"
                   "//li/button[@ng-click='isOpen = false']"),
     "contentviews.save_erratum": (
         By.XPATH, "//button[contains(@ng-click, 'handleSave()')]"),

--- a/tests/foreman/ui/test_contentview.py
+++ b/tests/foreman/ui/test_contentview.py
@@ -486,7 +486,7 @@ class ContentViewTestCase(UITestCase):
             self.assertIsNotNone(self.content_views.search(cv_name))
             self.content_views.add_remove_repos(cv_name, [rh_repo['name']])
             self.assertIsNotNone(self.content_views.wait_until_element(
-                common_locators.alert.success_sub_form))
+                common_locators['alert.success_sub_form']))
             self.content_views.add_filter(
                 cv_name,
                 filter_name,
@@ -508,7 +508,7 @@ class ContentViewTestCase(UITestCase):
                 open_filter=True
             )
             self.assertIsNotNone(self.content_views.wait_until_element(
-                common_locators.alert.success_sub_form))
+                common_locators['alert.success_sub_form']))
 
     @run_only_on('sat')
     @tier1
@@ -671,7 +671,7 @@ class ContentViewTestCase(UITestCase):
             self.assertIsNotNone(self.content_views.search(cv_name))
             self.content_views.add_remove_repos(cv_name, [rh_repo['name']])
             self.assertIsNotNone(self.content_views.wait_until_element(
-                common_locators.alert.success_sub_form))
+                common_locators['alert.success_sub_form']))
             self.content_views.add_filter(
                 cv_name,
                 filter_name,
@@ -694,7 +694,7 @@ class ContentViewTestCase(UITestCase):
                 open_filter=False
             )
             self.assertIsNotNone(self.content_views.wait_until_element(
-                common_locators.alert.success_sub_form))
+                common_locators['alert.success_sub_form']))
             # this assertion should find/open the cv and search for our filter
             self.assertIsNotNone(
                  self.content_views.search_filter(cv_name, filter_name))


### PR DESCRIPTION
```bash
(2.7) dlezz@elysion:~/projects/robottelo-fork$ py.test tests/foreman/ui/test_contentview.py -v -k "test_positive_add_rh_custom_spin or test_positive_edit_rh_custom_spin"
================================================= test session starts ==================================================
platform linux2 -- Python 2.7.12, pytest-2.9.2, py-1.4.31, pluggy-0.3.1 -- /home/dlezz/bin/redhat/6.2.z/python/2.7/bin/python
cachedir: .cache
rootdir: /home/dlezz/projects/robottelo-fork, inifile: 
plugins: xdist-1.14, cov-2.3.1
collected 62 items 

tests/foreman/ui/test_contentview.py::ContentViewTestCase::test_positive_add_rh_custom_spin <- robottelo/decorators/__init__.py PASSED
tests/foreman/ui/test_contentview.py::ContentViewTestCase::test_positive_edit_rh_custom_spin <- robottelo/decorators/__init__.py PASSED

=========== 60 tests deselected by '-ktest_positive_add_rh_custom_spin or test_positive_edit_rh_custom_spin' ===========
====================================== 2 passed, 60 deselected 
```
**cherry-pick from 6.3 + changes to adapt to 6.2.z**