### PR TITLE
[6.1.z] Cherry-pick - Fix naive proxy retrieval 

### DIFF
--- a/tests/foreman/api/test_host.py
+++ b/tests/foreman/api/test_host.py
@@ -156,7 +156,7 @@ class HostTestCase(APITestCase):
 
         @assert: A host is created with expected puppet proxy assigned
         """
-        proxy = entities.SmartProxy().search()[0]
+        proxy = entities.SmartProxy(id=1).read()
         host = entities.Host(puppet_proxy=proxy).create()
         self.assertEqual(host.puppet_proxy.read().name, proxy.name)
 
@@ -169,7 +169,7 @@ class HostTestCase(APITestCase):
 
         @assert: A host is created with expected puppet CA proxy assigned
         """
-        proxy = entities.SmartProxy().search()[0]
+        proxy = entities.SmartProxy(id=1).read()
         host = entities.Host(puppet_ca_proxy=proxy).create()
         self.assertEqual(host.puppet_ca_proxy.read().name, proxy.name)
 
@@ -502,7 +502,7 @@ class HostTestCase(APITestCase):
         @assert: A host is updated with a new puppet proxy
         """
         host = entities.Host().create()
-        new_proxy = entities.SmartProxy().search()[0]
+        new_proxy = entities.SmartProxy(id=1).read()
         host.puppet_proxy = new_proxy
         host = host.update(['puppet_proxy'])
         self.assertEqual(host.puppet_proxy.read().name, new_proxy.name)
@@ -517,7 +517,7 @@ class HostTestCase(APITestCase):
         @assert: A host is updated with a new puppet CA proxy
         """
         host = entities.Host().create()
-        new_proxy = entities.SmartProxy().search()[0]
+        new_proxy = entities.SmartProxy(id=1).read()
         host.puppet_ca_proxy = new_proxy
         host = host.update(['puppet_ca_proxy'])
         self.assertEqual(host.puppet_ca_proxy.read().name, new_proxy.name)

--- a/tests/foreman/api/test_host.py
+++ b/tests/foreman/api/test_host.py
@@ -156,7 +156,9 @@ class HostTestCase(APITestCase):
 
         @assert: A host is created with expected puppet proxy assigned
         """
-        proxy = entities.SmartProxy(id=1).read()
+        proxy = entities.SmartProxy().search(query={
+            'search': 'url = https://{0}:9090'.format(settings.server.hostname)
+        })[0]
         host = entities.Host(puppet_proxy=proxy).create()
         self.assertEqual(host.puppet_proxy.read().name, proxy.name)
 
@@ -169,7 +171,9 @@ class HostTestCase(APITestCase):
 
         @assert: A host is created with expected puppet CA proxy assigned
         """
-        proxy = entities.SmartProxy(id=1).read()
+        proxy = entities.SmartProxy().search(query={
+            'search': 'url = https://{0}:9090'.format(settings.server.hostname)
+        })[0]
         host = entities.Host(puppet_ca_proxy=proxy).create()
         self.assertEqual(host.puppet_ca_proxy.read().name, proxy.name)
 
@@ -502,7 +506,9 @@ class HostTestCase(APITestCase):
         @assert: A host is updated with a new puppet proxy
         """
         host = entities.Host().create()
-        new_proxy = entities.SmartProxy(id=1).read()
+        new_proxy = entities.SmartProxy().search(query={
+            'search': 'url = https://{0}:9090'.format(settings.server.hostname)
+        })[0]
         host.puppet_proxy = new_proxy
         host = host.update(['puppet_proxy'])
         self.assertEqual(host.puppet_proxy.read().name, new_proxy.name)
@@ -517,7 +523,9 @@ class HostTestCase(APITestCase):
         @assert: A host is updated with a new puppet CA proxy
         """
         host = entities.Host().create()
-        new_proxy = entities.SmartProxy(id=1).read()
+        new_proxy = entities.SmartProxy().search(query={
+            'search': 'url = https://{0}:9090'.format(settings.server.hostname)
+        })[0]
         host.puppet_ca_proxy = new_proxy
         host = host.update(['puppet_ca_proxy'])
         self.assertEqual(host.puppet_ca_proxy.read().name, new_proxy.name)

--- a/tests/foreman/api/test_hostgroup.py
+++ b/tests/foreman/api/test_hostgroup.py
@@ -317,7 +317,7 @@ class HostGroupTestCase(APITestCase):
 
         @assert: A hostgroup is created with expected puppet CA proxy assigned
         """
-        proxy = entities.SmartProxy().search()[0]
+        proxy = entities.SmartProxy(id=1).read()
         hostgroup = entities.HostGroup(
             location=[self.loc],
             organization=[self.org],
@@ -374,7 +374,7 @@ class HostGroupTestCase(APITestCase):
         realm = entities.Realm(
             location=[self.loc],
             organization=[self.org],
-            realm_proxy=entities.SmartProxy().search()[0],
+            realm_proxy=entities.SmartProxy(id=1).read()
         ).create()
         hostgroup = entities.HostGroup(
             location=[self.loc],
@@ -391,7 +391,7 @@ class HostGroupTestCase(APITestCase):
 
         @assert: A hostgroup is created with expected puppet proxy assigned
         """
-        proxy = entities.SmartProxy().search()[0]
+        proxy = entities.SmartProxy(id=1).read()
         hostgroup = entities.HostGroup(
             location=[self.loc],
             organization=[self.org],
@@ -407,7 +407,7 @@ class HostGroupTestCase(APITestCase):
 
         @assert: A hostgroup is created with expected content source assigned
         """
-        content_source = entities.SmartProxy().search()[0]
+        content_source = entities.SmartProxy(id=1).read()
         hostgroup = entities.HostGroup(
             content_source=content_source,
             location=[self.loc],
@@ -686,7 +686,7 @@ class HostGroupTestCase(APITestCase):
             location=[self.loc],
             organization=[self.org],
         ).create()
-        new_proxy = entities.SmartProxy().search()[0]
+        new_proxy = entities.SmartProxy(id=1).read()
         hostgroup.puppet_ca_proxy = new_proxy
         hostgroup = hostgroup.update(['puppet_ca_proxy'])
         self.assertEqual(hostgroup.puppet_ca_proxy.read().name, new_proxy.name)
@@ -752,7 +752,7 @@ class HostGroupTestCase(APITestCase):
         realm = entities.Realm(
             location=[self.loc],
             organization=[self.org],
-            realm_proxy=entities.SmartProxy().search()[0],
+            realm_proxy=entities.SmartProxy(id=1).read(),
         ).create()
         hostgroup = entities.HostGroup(
             location=[self.loc],
@@ -762,7 +762,7 @@ class HostGroupTestCase(APITestCase):
         new_realm = entities.Realm(
             location=[self.loc],
             organization=[self.org],
-            realm_proxy=entities.SmartProxy().search()[0],
+            realm_proxy=entities.SmartProxy(id=1).read(),
         ).create()
         hostgroup.realm = new_realm
         hostgroup = hostgroup.update(['realm'])
@@ -780,7 +780,7 @@ class HostGroupTestCase(APITestCase):
             location=[self.loc],
             organization=[self.org],
         ).create()
-        new_proxy = entities.SmartProxy().search()[0]
+        new_proxy = entities.SmartProxy(id=1).read()
         hostgroup.puppet_proxy = new_proxy
         hostgroup = hostgroup.update(['puppet_proxy'])
         self.assertEqual(hostgroup.puppet_proxy.read().name, new_proxy.name)
@@ -797,7 +797,7 @@ class HostGroupTestCase(APITestCase):
             location=[self.loc],
             organization=[self.org],
         ).create()
-        new_content_source = entities.SmartProxy().search()[0]
+        new_content_source = entities.SmartProxy(id=1).read()
         hostgroup.content_source = new_content_source
         hostgroup = hostgroup.update(['content_source'])
         self.assertEqual(

--- a/tests/foreman/api/test_hostgroup.py
+++ b/tests/foreman/api/test_hostgroup.py
@@ -317,7 +317,9 @@ class HostGroupTestCase(APITestCase):
 
         @assert: A hostgroup is created with expected puppet CA proxy assigned
         """
-        proxy = entities.SmartProxy(id=1).read()
+        proxy = entities.SmartProxy().search(query={
+            'search': 'url = https://{0}:9090'.format(settings.server.hostname)
+        })[0]
         hostgroup = entities.HostGroup(
             location=[self.loc],
             organization=[self.org],
@@ -374,7 +376,10 @@ class HostGroupTestCase(APITestCase):
         realm = entities.Realm(
             location=[self.loc],
             organization=[self.org],
-            realm_proxy=entities.SmartProxy(id=1).read()
+            realm_proxy=entities.SmartProxy().search(
+                query={'search': 'url = https://{0}:9090'.format(
+                    settings.server.hostname)}
+            )[0]
         ).create()
         hostgroup = entities.HostGroup(
             location=[self.loc],
@@ -391,7 +396,9 @@ class HostGroupTestCase(APITestCase):
 
         @assert: A hostgroup is created with expected puppet proxy assigned
         """
-        proxy = entities.SmartProxy(id=1).read()
+        proxy = entities.SmartProxy().search(query={
+            'search': 'url = https://{0}:9090'.format(settings.server.hostname)
+        })[0]
         hostgroup = entities.HostGroup(
             location=[self.loc],
             organization=[self.org],
@@ -407,7 +414,9 @@ class HostGroupTestCase(APITestCase):
 
         @assert: A hostgroup is created with expected content source assigned
         """
-        content_source = entities.SmartProxy(id=1).read()
+        content_source = entities.SmartProxy().search(query={
+            'search': 'url = https://{0}:9090'.format(settings.server.hostname)
+        })[0]
         hostgroup = entities.HostGroup(
             content_source=content_source,
             location=[self.loc],
@@ -686,7 +695,9 @@ class HostGroupTestCase(APITestCase):
             location=[self.loc],
             organization=[self.org],
         ).create()
-        new_proxy = entities.SmartProxy(id=1).read()
+        new_proxy = entities.SmartProxy().search(query={
+            'search': 'url = https://{0}:9090'.format(settings.server.hostname)
+        })[0]
         hostgroup.puppet_ca_proxy = new_proxy
         hostgroup = hostgroup.update(['puppet_ca_proxy'])
         self.assertEqual(hostgroup.puppet_ca_proxy.read().name, new_proxy.name)
@@ -752,7 +763,10 @@ class HostGroupTestCase(APITestCase):
         realm = entities.Realm(
             location=[self.loc],
             organization=[self.org],
-            realm_proxy=entities.SmartProxy(id=1).read(),
+            realm_proxy=entities.SmartProxy().search(
+                query={'search': 'url = https://{0}:9090'.format(
+                    settings.server.hostname)}
+            )[0]
         ).create()
         hostgroup = entities.HostGroup(
             location=[self.loc],
@@ -762,7 +776,10 @@ class HostGroupTestCase(APITestCase):
         new_realm = entities.Realm(
             location=[self.loc],
             organization=[self.org],
-            realm_proxy=entities.SmartProxy(id=1).read(),
+            realm_proxy=entities.SmartProxy().search(
+                query={'search': 'url = https://{0}:9090'.format(
+                    settings.server.hostname)}
+            )[0]
         ).create()
         hostgroup.realm = new_realm
         hostgroup = hostgroup.update(['realm'])
@@ -780,7 +797,9 @@ class HostGroupTestCase(APITestCase):
             location=[self.loc],
             organization=[self.org],
         ).create()
-        new_proxy = entities.SmartProxy(id=1).read()
+        new_proxy = entities.SmartProxy().search(query={
+            'search': 'url = https://{0}:9090'.format(settings.server.hostname)
+        })[0]
         hostgroup.puppet_proxy = new_proxy
         hostgroup = hostgroup.update(['puppet_proxy'])
         self.assertEqual(hostgroup.puppet_proxy.read().name, new_proxy.name)
@@ -797,7 +816,9 @@ class HostGroupTestCase(APITestCase):
             location=[self.loc],
             organization=[self.org],
         ).create()
-        new_content_source = entities.SmartProxy(id=1).read()
+        new_content_source = entities.SmartProxy().search(query={
+            'search': 'url = https://{0}:9090'.format(settings.server.hostname)
+        })[0]
         hostgroup.content_source = new_content_source
         hostgroup = hostgroup.update(['content_source'])
         self.assertEqual(

--- a/tests/foreman/api/test_organization.py
+++ b/tests/foreman/api/test_organization.py
@@ -322,7 +322,9 @@ class OrganizationUpdateTestCase(APITestCase):
         @Assert: Smart proxy is successfully added to organization
         """
         # Every Satellite has a built-in smart proxy, so let's find it
-        smart_proxy = entities.SmartProxy(id=1).read()
+        smart_proxy = entities.SmartProxy().search(query={
+            'search': 'url = https://{0}:9090'.format(settings.server.hostname)
+        })[0]
         # By default, newly created organization uses built-in smart proxy,
         # so we need to remove it first
         org = entities.Organization().create()

--- a/tests/foreman/api/test_organization.py
+++ b/tests/foreman/api/test_organization.py
@@ -324,7 +324,10 @@ class OrganizationUpdateTestCase(APITestCase):
         # Every Satellite has a built-in smart proxy, so let's find it
         smart_proxy = entities.SmartProxy().search(query={
             'search': 'url = https://{0}:9090'.format(settings.server.hostname)
-        })[0]
+        })
+        # Check that proxy is found and unpack it from the list
+        self.assertGreater(len(smart_proxy), 0)
+        smart_proxy = smart_proxy[0]
         # By default, newly created organization uses built-in smart proxy,
         # so we need to remove it first
         org = entities.Organization().create()

--- a/tests/foreman/api/test_organization.py
+++ b/tests/foreman/api/test_organization.py
@@ -322,9 +322,7 @@ class OrganizationUpdateTestCase(APITestCase):
         @Assert: Smart proxy is successfully added to organization
         """
         # Every Satellite has a built-in smart proxy, so let's find it
-        smart_proxies = entities.SmartProxy().search()
-        self.assertGreater(len(smart_proxies), 0)
-        smart_proxy = smart_proxies[0]
+        smart_proxy = entities.SmartProxy(id=1).read()
         # By default, newly created organization uses built-in smart proxy,
         # so we need to remove it first
         org = entities.Organization().create()

--- a/tests/foreman/api/test_smartproxy.py
+++ b/tests/foreman/api/test_smartproxy.py
@@ -1,5 +1,6 @@
 """Tests for the ``smart_proxies`` paths."""
 from nailgun import entities
+from robottelo.config import settings
 from robottelo.decorators import (
     skip_if_bug_open,
     tier1,
@@ -26,7 +27,9 @@ class SmartProxyMissingAttrTestCase(APITestCase):
         existing smart proxy should always succeed.
         """
         super(SmartProxyMissingAttrTestCase, cls).setUpClass()
-        smart_proxy = entities.SmartProxy(id=1).read()
+        smart_proxy = entities.SmartProxy().search(query={
+            'search': 'url = https://{0}:9090'.format(settings.server.hostname)
+        })[0]
         cls.smart_proxy_attrs = set(smart_proxy.update_json([]).keys())
 
     @tier1

--- a/tests/foreman/api/test_smartproxy.py
+++ b/tests/foreman/api/test_smartproxy.py
@@ -29,7 +29,10 @@ class SmartProxyMissingAttrTestCase(APITestCase):
         super(SmartProxyMissingAttrTestCase, cls).setUpClass()
         smart_proxy = entities.SmartProxy().search(query={
             'search': 'url = https://{0}:9090'.format(settings.server.hostname)
-        })[0]
+        })
+        # Check that proxy is found and unpack it from the list
+        assert len(smart_proxy) > 0, "No smart proxy is found"
+        smart_proxy = smart_proxy[0]
         cls.smart_proxy_attrs = set(smart_proxy.update_json([]).keys())
 
     @tier1

--- a/tests/foreman/api/test_smartproxy.py
+++ b/tests/foreman/api/test_smartproxy.py
@@ -26,9 +26,8 @@ class SmartProxyMissingAttrTestCase(APITestCase):
         existing smart proxy should always succeed.
         """
         super(SmartProxyMissingAttrTestCase, cls).setUpClass()
-        smart_proxies = entities.SmartProxy().search()
-        assert len(smart_proxies) > 0
-        cls.smart_proxy_attrs = set(smart_proxies[0].update_json([]).keys())
+        smart_proxy = entities.SmartProxy(id=1).read()
+        cls.smart_proxy_attrs = set(smart_proxy.update_json([]).keys())
 
     @tier1
     def test_positive_update_loc(self):

--- a/tests/foreman/cli/test_gpgkey.py
+++ b/tests/foreman/cli/test_gpgkey.py
@@ -20,7 +20,7 @@ from robottelo.cli.gpgkey import GPGKey
 from robottelo.cli.org import Org
 from robottelo.cli.product import Product
 from robottelo.cli.repository import Repository
-from robottelo.constants import VALID_GPG_KEY_FILE
+from robottelo.constants import DEFAULT_ORG, VALID_GPG_KEY_FILE
 from robottelo.datafactory import invalid_values_list, valid_data_list
 from robottelo.decorators import (
     run_only_on,
@@ -124,9 +124,7 @@ class TestGPGKey(CLITestCase):
 
         @BZ: 1172009
         """
-        result = Org.list()
-        self.assertGreater(len(result), 0, 'No organization found')
-        org = result[0]
+        org = Org.info({'name': DEFAULT_ORG})
         for name in valid_data_list():
             with self.subTest(name):
                 gpg_key = make_gpg_key({

--- a/tests/foreman/cli/test_host.py
+++ b/tests/foreman/cli/test_host.py
@@ -33,7 +33,9 @@ class HostCreateTestCase(CLITestCase):
         """
         super(HostCreateTestCase, self).setUp()
         # Use the default installation smart proxy
-        self.puppet_proxy = Proxy.info({'id': 1})
+        self.puppet_proxy = Proxy.list({
+            'search': 'url = https://{0}:9090'.format(settings.server.hostname)
+        })[0]
 
     @tier1
     def test_positive_create_with_name(self):
@@ -111,7 +113,9 @@ class HostDeleteTestCase(CLITestCase):
         """Create a host to use in tests"""
         super(HostDeleteTestCase, self).setUp()
         # Use the default installation smart proxy
-        self.puppet_proxy = Proxy.info({'id': 1})
+        self.puppet_proxy = Proxy.list({
+            'search': 'url = https://{0}:9090'.format(settings.server.hostname)
+        })[0]
         self.host = entities.Host()
         self.host.create_missing()
         self.host = Host.create({
@@ -162,7 +166,9 @@ class HostUpdateTestCase(CLITestCase):
     def setUp(self):
         """Create a host to reuse later"""
         super(HostUpdateTestCase, self).setUp()
-        self.puppet_proxy = Proxy.info({'id': 1})
+        self.puppet_proxy = Proxy.list({
+            'search': 'url = https://{0}:9090'.format(settings.server.hostname)
+        })[0]
         # using nailgun to create dependencies
         self.host_args = entities.Host()
         self.host_args.create_missing()
@@ -597,7 +603,9 @@ class HostParameterTestCase(CLITestCase):
     def setUpClass(cls):
         """Create host to tests parameters for"""
         super(HostParameterTestCase, cls).setUpClass()
-        cls.puppet_proxy = Proxy.info({'id': 1})
+        cls.puppet_proxy = Proxy.list({
+            'search': 'url = https://{0}:9090'.format(settings.server.hostname)
+        })[0]
         # using nailgun to create dependencies
         cls.host = entities.Host()
         cls.host.create_missing()

--- a/tests/foreman/cli/test_host.py
+++ b/tests/foreman/cli/test_host.py
@@ -33,9 +33,7 @@ class HostCreateTestCase(CLITestCase):
         """
         super(HostCreateTestCase, self).setUp()
         # Use the default installation smart proxy
-        result = Proxy.list()
-        self.assertGreater(len(result), 0)
-        self.puppet_proxy = result[0]
+        self.puppet_proxy = Proxy.info({'id': 1})
 
     @tier1
     def test_positive_create_with_name(self):
@@ -113,9 +111,7 @@ class HostDeleteTestCase(CLITestCase):
         """Create a host to use in tests"""
         super(HostDeleteTestCase, self).setUp()
         # Use the default installation smart proxy
-        result = Proxy.list()
-        self.assertGreater(len(result), 0)
-        self.puppet_proxy = result[0]
+        self.puppet_proxy = Proxy.info({'id': 1})
         self.host = entities.Host()
         self.host.create_missing()
         self.host = Host.create({
@@ -166,9 +162,7 @@ class HostUpdateTestCase(CLITestCase):
     def setUp(self):
         """Create a host to reuse later"""
         super(HostUpdateTestCase, self).setUp()
-        self.proxies = Proxy.list()
-        self.assertGreater(len(self.proxies), 0)
-        self.puppet_proxy = self.proxies[0]
+        self.puppet_proxy = Proxy.info({'id': 1})
         # using nailgun to create dependencies
         self.host_args = entities.Host()
         self.host_args.create_missing()
@@ -603,9 +597,7 @@ class HostParameterTestCase(CLITestCase):
     def setUpClass(cls):
         """Create host to tests parameters for"""
         super(HostParameterTestCase, cls).setUpClass()
-        cls.proxies = Proxy.list()
-        assert len(cls.proxies) > 0
-        cls.puppet_proxy = cls.proxies[0]
+        cls.puppet_proxy = Proxy.info({'id': 1})
         # using nailgun to create dependencies
         cls.host = entities.Host()
         cls.host.create_missing()

--- a/tests/foreman/cli/test_hostgroup.py
+++ b/tests/foreman/cli/test_hostgroup.py
@@ -1,8 +1,6 @@
 # -*- encoding: utf-8 -*-
 """Test class for :class:`robottelo.cli.hostgroup.HostGroup` CLI."""
-from fauxfactory import gen_string
 from robottelo.cli.base import CLIReturnCodeError
-from robottelo.cli.contentview import ContentView
 from robottelo.cli.hostgroup import HostGroup
 from robottelo.cli.proxy import Proxy
 from robottelo.cli.factory import (
@@ -11,15 +9,15 @@ from robottelo.cli.factory import (
     make_location,
     make_org,
     make_os,
-    make_domain, make_lifecycle_environment, make_content_view, make_subnet,
-    make_architecture, make_partition_table)
+    make_domain,
+)
 from robottelo.config import settings
 from robottelo.datafactory import (
     invalid_id_list,
     invalid_values_list,
     valid_hostgroups_list,
 )
-from robottelo.decorators import run_only_on, tier1, skip_if_bug_open, tier2
+from robottelo.decorators import run_only_on, tier1
 from robottelo.test import CLITestCase
 
 
@@ -176,7 +174,7 @@ class HostGroupTestCase(CLITestCase):
         """Successfully update an HostGroup.
 
         @Feature: HostGroup
-g
+
         @Assert: HostGroup is updated.
         """
         hostgroup = make_hostgroup()

--- a/tests/foreman/cli/test_hostgroup.py
+++ b/tests/foreman/cli/test_hostgroup.py
@@ -4,12 +4,12 @@ from robottelo.cli.base import CLIReturnCodeError
 from robottelo.cli.hostgroup import HostGroup
 from robottelo.cli.proxy import Proxy
 from robottelo.cli.factory import (
+    make_domain,
     make_environment,
     make_hostgroup,
     make_location,
     make_org,
     make_os,
-    make_domain,
 )
 from robottelo.config import settings
 from robottelo.datafactory import (
@@ -149,8 +149,6 @@ class HostGroupTestCase(CLITestCase):
         @Feature: Hostgroup - Positive create
 
         @Assert: Hostgroup should be created and has architecture assigned
-
-        @BZ: 1354544
         """
         arch = 'x86_64'
         hostgroup = make_hostgroup({'architecture': arch})

--- a/tests/foreman/cli/test_hostgroup.py
+++ b/tests/foreman/cli/test_hostgroup.py
@@ -146,7 +146,7 @@ class HostGroupTestCase(CLITestCase):
     def test_positive_create_with_architecture(self):
         """Check if hostgroup with architecture can be created
 
-        @id: 21c619f4-7339-4fb0-9e29-e12dae65f943
+        @Feature: Hostgroup - Positive create
 
         @Assert: Hostgroup should be created and has architecture assigned
 
@@ -161,7 +161,7 @@ class HostGroupTestCase(CLITestCase):
     def test_positive_create_with_domain(self):
         """Check if hostgroup with domain can be created
 
-        @id: c468fcac-9e42-4ee6-a431-abe29b6848ce
+        @Feature: Hostgroup - Positive create
 
         @Assert: Hostgroup should be created and has domain assigned
         """

--- a/tests/foreman/cli/test_subnet.py
+++ b/tests/foreman/cli/test_subnet.py
@@ -197,13 +197,11 @@ class SubnetTestCase(CLITestCase):
 
         @Assert: Subnet is listed
         """
-        # Fetch current total
-        subnets_before = Subnet.list()
         # Make a new subnet
-        make_subnet()
-        # Fetch total again
-        subnets_after = Subnet.list()
-        self.assertGreater(len(subnets_after), len(subnets_before))
+        subnet = make_subnet()
+        # Fetch ids from subnets list
+        subnets_ids = [subnet_['id'] for subnet_ in Subnet.list()]
+        self.assertIn(subnet['id'], subnets_ids)
 
     @run_only_on('sat')
     @tier1


### PR DESCRIPTION
Cherry-pick of #3991. Closes #3942
Test results for 6.1.z on 6.1.8:
```python
% nosetests tests/foreman/cli/test_host.py:{HostCreateTestCase,HostDeleteTestCase,HostUpdateTestCase,HostParameterTestCase}
..............................
----------------------------------------------------------------------
Ran 30 tests in 1912.495s
OK
```
```python
% nosetests tests/foreman/cli/test_hostgroup.py:HostGroupTestCase.test_positive_create_with_puppet_ca_proxy
.
----------------------------------------------------------------------
Ran 1 test in 11.908s
OK
```
```python
% nosetests tests/foreman/api/test_host.py:HostTestCase.{test_positive_create_with_puppet_proxy,test_positive_create_with_puppet_ca_proxy,test_positive_update_puppet_proxy,test_positive_update_puppet_ca_proxy}
....
----------------------------------------------------------------------
Ran 4 tests in 105.064s
OK
```python
% nosetests tests/foreman/api/test_hostgroup.py:HostGroupTestCase.{test_positive_create_with_puppet_ca_proxy,test_positive_create_with_realm,test_positive_create_with_puppet_proxy,test_positive_create_with_content_source,test_positive_update_puppet_ca_proxy,test_positive_update_realm,test_positive_update_puppet_proxy,test_positive_update_content_source}
........
----------------------------------------------------------------------
Ran 8 tests in 85.275s
OK
```
