### PR TITLE
[6.2.z] Implemented UI CV package filter tests

### DIFF
--- a/robottelo/ui/base.py
+++ b/robottelo/ui/base.py
@@ -460,13 +460,19 @@ class Base(object):
         txt_field.send_keys(newtext)
         self.wait_for_ajax()
 
-    def text_field_update(self, locator, newtext):
+    def text_field_update(self, target, newtext):
+        """Function to replace text from textbox using a common locator or
+        WebElement
+
+        :param tuple || WebElement target: Either locator that
+            describes the element or element itself.
         """
-        Function to replace text from textbox using a common locator
-        """
-        txt_field = self.wait_until_element(locator)
+        if isinstance(target, tuple):
+            txt_field = self.wait_until_element(target)
+        else:
+            txt_field = target
         txt_field.clear()
-        self.logger.debug(u'Updating text field:%s with:%s', locator, newtext)
+        self.logger.debug(u'Updating text field:%s with:%s', target, newtext)
         txt_field.send_keys(newtext)
         self.wait_for_ajax()
 
@@ -592,21 +598,31 @@ class Base(object):
         self.wait_for_ajax()
         return element.is_displayed()
 
-    def element_type(self, locator):
-        """Determine UI element type using locator tag
+    def element_type(self, target):
+        """Determine UI element type using locator/element tag
 
-        :param locator: The locator of the element
+        :param tuple || WebElement target: Either locator that
+            describes the element or element itself.
         :return: Returns element type value
         :rtype: str
 
         """
         element_type = None
-        element = self.wait_until_element(locator)
+        if isinstance(target, tuple):
+            element = self.wait_until_element(target)
+        else:
+            element = target
         if element is not None:
             element_type = element.tag_name.lower()
             if (element_type == 'input' and
                     element.get_attribute('type') == 'checkbox'):
                 element_type = 'checkbox'
+            elif (element_type == 'input' and
+                    element.get_attribute('type') == 'radio'):
+                element_type = 'radio'
+            elif (element_type == 'div' and
+                    'ace_editor' in element.get_attribute('class')):
+                element_type = 'ace_editor'
         return element_type
 
     def click(self, target, wait_for_ajax=True,
@@ -634,7 +650,7 @@ class Base(object):
         if element is None:
             raise UINoSuchElementError(
                 u'{0}: element {1} was not found while trying to click'
-                .format(type(self).__name__, str(target))
+                .format(type(self).__name__, target)
             )
         # Required since from selenium 2.48.0. which makes Selenium more
         # closely resemble a user when interacting with elements.
@@ -648,12 +664,13 @@ class Base(object):
         if wait_for_ajax:
             self.wait_for_ajax(ajax_timeout)
 
-    def select(self, locator, list_value, wait_for_ajax=True, timeout=30,
+    def select(self, target, list_value, wait_for_ajax=True, timeout=30,
                scroll=True, select_by='visible_text'):
-        """Select the element described by the ``locator``. Current method
-        supports both classical <select> tags and newer jquery-select elements
+        """Select the element. Current method supports both classical <select>
+        tags and newer jquery-select elements
 
-        :param locator: The locator that describes the select list element.
+        :param tuple || WebElement target: Either locator that
+            describes the element or element itself.
         :param list_value: The value to select from the dropdown
         :param wait_for_ajax: Flag that indicates if should wait for AJAX after
             clicking on the element
@@ -662,12 +679,15 @@ class Base(object):
         :param scroll: Decide whether scroll to element in case it is located
             out of the page
         :param select_by: method for select element in the list of options
-             visible_text, index, value
+            visible_text, index, value
 
         """
         # Check whether our select list element has <select> tag
-        if self.element_type(locator) == 'select':
-            element = self.wait_until_element(locator)
+        if self.element_type(target) == 'select':
+            if isinstance(target, tuple):
+                element = self.wait_until_element(target)
+            else:
+                element = target
             if scroll:
                 self.scroll_into_view(element)
             select_element = Select(element)
@@ -677,7 +697,7 @@ class Base(object):
         # If no - treat it like jquery select list
         else:
             self.click(
-                locator,
+                target,
                 wait_for_ajax=wait_for_ajax,
                 ajax_timeout=timeout,
                 scroll=scroll,
@@ -691,7 +711,7 @@ class Base(object):
                 ajax_timeout=timeout,
                 scroll=scroll,
             )
-        self.logger.debug(u'Selected value %s on %s', list_value, locator)
+        self.logger.debug(u'Selected value %s on %s', list_value, target)
 
     def perform_action_chain_move(self, locator):
         """Moving the mouse to the middle of an element specified by locator
@@ -721,30 +741,34 @@ class Base(object):
         ActionChains(self.browser).move_by_offset(x, y).perform()
         self.wait_for_ajax()
 
-    def assign_value(self, locator, value):
+    def assign_value(self, target, value):
         """Assign provided value to page element depending on the type of that
         element
 
-        :param locator: The locator that describes the element.
+        :param tuple || WebElement target: Either locator that
+            describes the element or element itself.
         :param value: Value that needs to be assigned to the element
         :raise: ValueError if the element type is unknown to our code.
 
         """
-        element_type = self.element_type(locator)
+        element_type = self.element_type(target)
         if element_type == 'input' or element_type == 'textarea':
-            self.text_field_update(locator, value)
+            self.text_field_update(target, value)
         elif element_type == 'select' or element_type == 'span':
-            self.select(locator, value)
-        elif element_type == 'checkbox':
-            state = self.wait_until_element(locator).is_selected()
+            self.select(target, value)
+        elif element_type == 'checkbox' or element_type == 'radio':
+            if isinstance(target, tuple):
+                state = self.wait_until_element(target).is_selected()
+            else:
+                state = target.is_selected()
             if value != state:
-                self.click(locator)
-        elif element_type == 'div' and 'ace' in locator[1]:
+                self.click(target)
+        elif element_type == 'ace_editor':
             self.browser.execute_script(
                 "Editor.setValue('{0}');".format(value))
         else:
             raise ValueError(
-                u'Provided locator {0} is not supported by framework'
-                .format(locator)
+                u'Provided target {0} is not supported by framework'
+                .format(target)
             )
-        self.logger.debug(u'Assigned value %s to %s', value, locator)
+        self.logger.debug(u'Assigned value %s to %s', value, target)

--- a/robottelo/ui/contentviews.py
+++ b/robottelo/ui/contentviews.py
@@ -3,7 +3,8 @@
 
 import time
 
-from robottelo.constants import FILTER_ERRATA_TYPE, FILTER_ERRATA_DATE
+from robottelo.constants import FILTER_ERRATA_DATE, FILTER_ERRATA_TYPE
+from robottelo.decorators import bz_bug_is_open
 from robottelo.ui.base import Base, UIError, UINoSuchElementError
 from robottelo.ui.locators import common_locators, locators, tab_locators
 from robottelo.ui.navigator import Navigator
@@ -429,10 +430,106 @@ class ContentViews(Base):
     def remove_packages_from_filter(self, cv_name, filter_name, package_names):
         """Removes selected packages from selected package type filter."""
         self.go_to_filter_page(cv_name, filter_name)
-        strategy, value = locators['contentviews.select_pkg_checkbox']
-        for package in package_names:
-            self.click((strategy, value % package))
-            self.click(locators['contentviews.remove_packages'])
+        # On UI there's no attribute or text containing package name, just
+        # disabled input with value set to package name after page loading (so
+        # there's no @value attribute). This makes impossible to form xpath for
+        # specific package and the only remaining option is to locate all the
+        # packages and select only the one whose input contains desired value
+        packages = self.find_elements(locators['contentviews.packages'])
+        checkboxes = [
+            package.find_element(*locators['contentviews.package_checkbox'])
+            for package in packages
+            if package.get_attribute('value') in package_names
+        ]
+        for checkbox in checkboxes:
+            self.click(checkbox)
+        self.click(locators['contentviews.remove_packages'])
+
+    def update_package_filter(self, cv_name, filter_name, package_name,
+                              version_type=None, version_value=None,
+                              new_package_name=None, new_version_type=None,
+                              new_version_value=None):
+        """Update package in a filter"""
+        version_types = {
+            'Equal To': 'equal',
+            'Greater Than': 'greater',
+            'Less Than': 'less',
+            'Range': 'range',
+            'All Versions': 'all',
+        }
+        self.go_to_filter_page(cv_name, filter_name)
+        # As it's impossible to obtain specific filter directly,
+        # getting all the package filters first
+        packages = self.find_elements(locators['contentviews.packages'])
+        # Then selecting the filters with the same package as passed
+        packages = [
+            package for package in packages
+            if package.get_attribute('value') == package_name
+        ]
+        # As there can be multiple filters for the same package, user may want
+        # to specify version type and version of package filter
+        # If version type was passed - filter package list by version type
+        if version_type:
+            packages = [
+                package for package in packages
+                if package.find_element(
+                    *locators['contentviews.package_version_type']
+                ).get_attribute('value') == version_types[version_type]
+            ]
+        # If version was passed - filter package list by version
+        if version_value:
+            packages = [
+                package for package in packages
+                if package.find_element(
+                    *locators['contentviews.package_version_value']
+                ).get_attribute('value') == version_value
+            ]
+        # What's left in package list is probably our package, let's work with
+        # it
+        if packages:
+            package = packages[0]
+        # But if package list is empty - notify user he specified something
+        # wrong
+        else:
+            raise UINoSuchElementError('Package filter not found')
+        # Now just usual stuff - clicking 'edit' button, updating corresponding
+        # fields and clicking 'save' button
+        self.click(
+            package.find_element(*locators['contentviews.package_edit']))
+        if new_package_name:
+            self.assign_value(package, new_package_name)
+        if new_version_type:
+            self.assign_value(
+                package.find_element(
+                    *locators['contentviews.package_version_type']),
+                new_version_type
+            )
+        if new_version_value:
+            self.assign_value(
+                package.find_element(
+                    *locators['contentviews.package_version_value']),
+                new_version_value
+            )
+        self.click(
+            package.find_element(*locators['contentviews.package_save']))
+
+    def update_filter_affected_repos(self, cv_name, filter_name,
+                                     new_affected_repos):
+        """Update affected repos of content view filter"""
+        self.go_to_filter_page(cv_name, filter_name)
+        self.click(tab_locators['contentviews.tab_filter_affected_repos'])
+        self.assign_value(
+            locators['contentviews.affected_repos_radio'], True)
+        all_repo_checkboxes = self.find_elements(
+            locators['contentviews.affected_repos_checkboxes'])
+        # Uncheck all the repos first
+        for checkbox in all_repo_checkboxes:
+            self.assign_value(checkbox, False)
+        # Check off passed repos
+        for repo_name in new_affected_repos:
+            strategy, value = locators['contentviews.affected_repo_checkbox']
+            self.assign_value((strategy, value % repo_name), True)
+        self.click(locators['contentviews.filter_update_repos'])
 
     def add_remove_package_groups_to_filter(self, cv_name, filter_name,
                                             package_groups, is_add=True):
@@ -596,3 +693,33 @@ class ContentViews(Base):
             raise UIError(
                 '"Next" button is enabled when it should not'
             )
+
+    def version_search(self, name, version_name):
+        """Search for version in content view"""
+        self.click(self.search(name))
+        self.click(tab_locators['contentviews.tab_versions'])
+        if not bz_bug_is_open(1400535):
+            self.assign_value(
+                common_locators['kt_table_search'], version_name)
+            self.click(common_locators['kt_table_search_button'])
+        strategy, value = locators['contentviews.version_name']
+        return self.wait_until_element((strategy, value % version_name))
+
+    def package_search(self, name, version_name, package_name,
+                       package_version=None):
+        """Search for package in content view version"""
+        self.click(self.version_search(name, version_name))
+        self.click(tab_locators['contentviews.tab_version_packages'])
+        # type package version alongside with package name into search field if
+        # it was passed
+        self.assign_value(
+            common_locators['kt_table_search'],
+            package_name if not package_version else
+            'name = "{}" and version = "{}"'.format(
+                package_name,
+                package_version,
+            )
+        )
+        self.click(common_locators['kt_table_search_button'])
+        strategy, value = locators['contentviews.version.package_name']
+        return self.wait_until_element((strategy, value % package_name))

--- a/robottelo/ui/locators.py
+++ b/robottelo/ui/locators.py
@@ -557,6 +557,14 @@ tab_locators = LocatorDict({
         By.XPATH, "//a[contains(@ui-sref, 'available')]"),
     "contentviews.tab_remove": (
         By.XPATH, "//a[contains(@ui-sref, 'list')]"),
+    # Fourth level UI
+    "contentviews.tab_filter_affected_repos": (
+        By.XPATH,
+        ("//a[contains(@ui-sref, 'content-views.details.filters.details.rpm."
+         "repositories')]")),
+    "contentviews.tab_version_packages": (
+        By.XPATH,
+        "//a[contains(@ui-sref, 'content-views.details.version.packages')]"),
 
     # Content Hosts
     # Third level UI
@@ -804,6 +812,11 @@ common_locators = LocatorDict({
     "kt_search_button": (
         By.XPATH,
         "//button[@ng-click='table.search(table.searchTerm)']"),
+    "kt_table_search": (
+        By.XPATH, "//input[@ng-model='detailsTable.searchTerm']"),
+    "kt_table_search_button": (
+        By.XPATH,
+        "//button[@ng-click='detailsTable.search(detailsTable.searchTerm)']"),
     # Katello common Product and Repo locators
     "gpg_key": (By.ID, "gpg_key_id"),
     "all_values": (By.XPATH,
@@ -2387,17 +2400,42 @@ locators = LocatorDict({
         By.XPATH, "//input[@ng-model='rule.min_version']"),
     "contentviews.less_max_value": (
         By.XPATH, "//input[@ng-model='rule.max_version']"),
-    "contentviews.select_pkg_checkbox": (
+    "contentviews.packages": (
         By.XPATH,
-        ("//tr[@row-select='rule']"
-         "//td[contains(normalize-space(.), '%s')]"
-         "/preceding-sibling::td[@class='row-select']"
+        "//tr[@row-select='rule']/td/input[@ng-model='rule.name']"),
+    "contentviews.package_checkbox": (
+        By.XPATH,
+        ("../preceding-sibling::td[@class='row-select']"
          "/input[@type='checkbox']")),
+    "contentviews.package_edit": (
+        By.XPATH,
+        ("../following-sibling::td/button[contains(@class, 'btn') and "
+         "contains(@ng-click, 'rule.editMode = true')]")),
+    "contentviews.package_version_type": (
+        By.XPATH,
+        "../following-sibling::td/span/select[@ng-model='rule.type']"),
+    "contentviews.package_version_value": (
+        By.XPATH,
+        "../following-sibling::td/span/span/input[@ng-model='rule.version']"),
+    "contentviews.package_save": (
+        By.XPATH,
+        ("../following-sibling::td/div/"
+         "button[contains(@ng-click, 'handleSave')]")),
     "contentviews.remove_packages": (
         By.XPATH, "//button[@ng-click='removeRules(filter)']"),
-    "contentviews.affected_repos": (
+    "contentviews.affected_repos_radio": (
         By.XPATH,
-        "//a[contains(@ui-sref, 'filters.details.rpm.repositories')]"),
+        ("//input[@type='radio' and @ng-model='showRepos' and "
+         "@ng-value='true']")),
+    "contentviews.affected_repos_checkboxes": (
+        By.XPATH,
+        "//input[@type='checkbox' and @ng-model='repository.selected']"),
+    "contentviews.affected_repo_checkbox": (
+        By.XPATH,
+        ("//input[@type='checkbox' and @ng-model='repository.selected']"
+         "[../following-sibling::td/a[contains(normalize-space(.), '%s')]]")),
+    "contentviews.filter_update_repos": (
+        By.XPATH, "//button[@ng-click='updateRepositories()']"),
     "contentviews.show_repos": (
         By.XPATH, "//input[@ng-model='showRepos']"),
     "contentviews.select_pkg_group_checkbox": (
@@ -2449,6 +2487,14 @@ locators = LocatorDict({
         By.XPATH, "//button[@ng-click='copy(copyName)']"),
     "contentviews.yum_repositories": (
         By.XPATH, "//a[@class='ng-scope' and contains(@ui-sref,'yum.list')]"),
+    "contentviews.version.package_name": (
+        By.XPATH,
+        ("//div[@bst-table='detailsTable']//tr[contains(@class, 'ng-scope')]"
+         "/td[1][contains(., '%s')]")),
+    "contentviews.version.package_version": (
+        By.XPATH,
+        ("//div[@bst-table='detailsTable']//tr[contains(@class, 'ng-scope')]"
+         "/td[2][contains(., '%s')]")),
 
     # Packages
     "package.rpm_name": (By.XPATH, "//a[contains(., '%s')]"),


### PR DESCRIPTION
Backporting support of webelements as alternative to locators in basic UI helpers and implementation of ui cv package filter tests to 6.2.z branch.
Basically, both commits are similar to 6.3, just with some fixes to make them work in 6.2.z

```python
[gw0] linux2 Python 2.7.10 cwd: /home/andrii/workspace/robottelo
[gw1] linux2 Python 2.7.10 cwd: /home/andrii/workspace/robottelo
[gw0] Python 2.7.10 (default, Sep  8 2015, 17:20:17)  -- [GCC 5.1.1 20150618 (Red Hat 5.1.1-4)]
[gw1] Python 2.7.10 (default, Sep  8 2015, 17:20:17)  -- [GCC 5.1.1 20150618 (Red Hat 5.1.1-4)]
gw0 [7] / gw1 [7]

scheduling tests via LoadScheduling

tests/foreman/ui/test_contentview.py::ContentViewTestCase::test_positive_add_package_exclusion_filter_and_publish <- robottelo/decorators/__init__.py 
tests/foreman/ui/test_contentview.py::ContentViewTestCase::test_negative_add_same_package_filter_twice <- robottelo/decorators/__init__.py 
[gw0] SKIPPED tests/foreman/ui/test_contentview.py::ContentViewTestCase::test_negative_add_same_package_filter_twice <- robottelo/decorators/__init__.py 
tests/foreman/ui/test_contentview.py::ContentViewTestCase::test_positive_add_package_inclusion_filter_and_publish <- robottelo/decorators/__init__.py 
[gw1] PASSED tests/foreman/ui/test_contentview.py::ContentViewTestCase::test_positive_add_package_exclusion_filter_and_publish <- robottelo/decorators/__init__.py 
tests/foreman/ui/test_contentview.py::ContentViewTestCase::test_positive_remove_package_from_exclusion_filter <- robottelo/decorators/__init__.py 
[gw0] PASSED tests/foreman/ui/test_contentview.py::ContentViewTestCase::test_positive_add_package_inclusion_filter_and_publish <- robottelo/decorators/__init__.py 
tests/foreman/ui/test_contentview.py::ContentViewTestCase::test_positive_update_exclusive_filter_package_version <- robottelo/decorators/__init__.py 
[gw1] PASSED tests/foreman/ui/test_contentview.py::ContentViewTestCase::test_positive_remove_package_from_exclusion_filter <- robottelo/decorators/__init__.py 
[gw0] PASSED tests/foreman/ui/test_contentview.py::ContentViewTestCase::test_positive_update_exclusive_filter_package_version <- robottelo/decorators/__init__.py 
tests/foreman/ui/test_contentview.py::ContentViewTestCase::test_positive_update_inclusive_filter_package_version <- robottelo/decorators/__init__.py 
tests/foreman/ui/test_contentview.py::ContentViewTestCase::test_positive_update_filter_affected_repos <- robottelo/decorators/__init__.py 
[gw1] PASSED tests/foreman/ui/test_contentview.py::ContentViewTestCase::test_positive_update_filter_affected_repos <- robottelo/decorators/__init__.py 
[gw0] PASSED tests/foreman/ui/test_contentview.py::ContentViewTestCase::test_positive_update_inclusive_filter_package_version <- robottelo/decorators/__init__.py 

==================== 6 passed, 1 skipped in 673.14 seconds =====================
```