### PR TITLE
[6.2.z] Cherry-pick - Add Activation Key tests for non-admin user. (#4069)

### DIFF
--- a/robottelo/ui/activationkey.py
+++ b/robottelo/ui/activationkey.py
@@ -165,6 +165,19 @@ class ActivationKey(Base):
             raise UINoSuchElementError(
                 "Couldn't find activation key '{0}'".format(name))
 
+    def remove_host_collection(self, name, host_collection_name):
+        """Remove an existing Host Collection from Activation Key."""
+        # find activation key
+        self.search_and_click(name)
+        self.click(tab_locators['ak.host_collections'])
+        self.click(tab_locators['ak.host_collections.list'])
+        # select host collection
+        strategy, value = tab_locators['ak.host_collections.add.select']
+        self.click((strategy, value % host_collection_name))
+        # add host collection
+        self.click(
+            tab_locators['ak.host_collections.list.remove_selected'])
+
     def fetch_associated_content_host(self, name):
         """Fetch associated content host from selected activation key."""
         self.click(self.search(name))

--- a/robottelo/ui/locators.py
+++ b/robottelo/ui/locators.py
@@ -628,6 +628,8 @@ tab_locators = LocatorDict({
         By.XPATH, "//button[@ng-click='addHostCollections()']"),
     "ak.host_collections.list": (
         By.XPATH, "//a[contains(@ui-sref, 'host-collections.list')]"),
+    "ak.host_collections.list.remove_selected": (
+        By.XPATH, "//button[@ng-click='removeHostCollections()']"),
     "ak.associations": (
         By.XPATH, "//ul/li[@class='dropdown']/a"),
     "ak.tab_prd_content": (

--- a/tests/foreman/ui/test_activationkey.py
+++ b/tests/foreman/ui/test_activationkey.py
@@ -257,6 +257,111 @@ class ActivationKeyTestCase(UITestCase):
                 (strategy, value % host_col.name))
             self.assertIsNotNone(host_collection)
 
+    @tier2
+    def test_positive_add_host_collection_non_admin(self):
+        """Test that host collection can be associated to Activation Keys
+        by non-admin user.
+
+        @id: 417f0b36-fd49-4414-87ab-6f72a09696f2
+
+        @Assert: Activation key is created, added host collection is listed
+
+        @CaseLevel: Integration
+        """
+        ak_name = gen_string('alpha')
+        # create Host Collection using API
+        hc = entities.HostCollection(
+            organization=self.organization,
+            name=gen_string('alpha'),
+        ).create()
+        # Create non-admin user with specified permissions
+        role = entities.Role().create()
+        for res_type in ['Katello::ActivationKey', 'Katello::HostCollection']:
+            permission = entities.Permission(resource_type=res_type).search()
+            entities.Filter(permission=permission, role=role).create()
+        # Add 'Viewer' role to be able to read default environment and
+        # content view while creating AK
+        role2 = entities.Role().search(query={'search': 'name="Viewer"'})[0]
+        password = gen_string('alphanumeric')
+        user = entities.User(
+            admin=False,
+            role=[role, role2],
+            password=password,
+            organization=[self.organization],
+        ).create()
+        with Session(
+                self.browser, user=user.login, password=password) as session:
+            make_activationkey(session, name=ak_name, env=ENVIRONMENT)
+            self.assertIsNotNone(self.activationkey.search(ak_name))
+            # add Host Collection
+            self.activationkey.add_host_collection(ak_name, hc.name)
+            self.assertIsNotNone(self.activationkey.find_element(
+                common_locators['alert.success_sub_form']))
+            # check added host collection is listed
+            self.activationkey.click(tab_locators['ak.host_collections.list'])
+            strategy, value = tab_locators['ak.host_collections.add.select']
+            host_collection = self.activationkey.wait_until_element(
+                (strategy, value % hc.name))
+            self.assertIsNotNone(host_collection)
+
+    @tier2
+    def test_positive_remove_host_collection_non_admin(self):
+        """Test that host collection can be removed from Activation Keys
+        by non-admin user.
+
+        @id: 187456ec-5690-4524-9701-8bdb74c7912a
+
+        @Assert: Activation key is created, removed host collection
+        is not listed
+
+        @CaseLevel: Integration
+        """
+        ak_name = gen_string('alpha')
+        # create Host Collection using API
+        hc = entities.HostCollection(
+            organization=self.organization,
+            name=gen_string('alpha'),
+        ).create()
+        # Create non-admin user with specified permissions
+        role = entities.Role().create()
+        for res_type in ['Katello::ActivationKey', 'Katello::HostCollection']:
+            permission = entities.Permission(resource_type=res_type).search()
+            entities.Filter(permission=permission, role=role).create()
+        # Add 'Viewer' role to be able to read default environment and
+        # content view while creating AK
+        role2 = entities.Role().search(query={'search': 'name="Viewer"'})[0]
+        password = gen_string('alphanumeric')
+        user = entities.User(
+            admin=False,
+            role=[role, role2],
+            password=password,
+            organization=[self.organization],
+        ).create()
+        with Session(
+                self.browser, user=user.login, password=password) as session:
+            make_activationkey(session, name=ak_name, env=ENVIRONMENT)
+            self.assertIsNotNone(self.activationkey.search(ak_name))
+            # add Host Collection
+            self.activationkey.add_host_collection(ak_name, hc.name)
+            self.assertIsNotNone(self.activationkey.find_element(
+                common_locators['alert.success_sub_form']))
+            # check added host collection is listed
+            self.activationkey.click(tab_locators['ak.host_collections.list'])
+            strategy, value = tab_locators['ak.host_collections.add.select']
+            host_collection = self.activationkey.wait_until_element(
+                (strategy, value % hc.name))
+            self.assertIsNotNone(host_collection)
+            # remove Host Collection
+            self.activationkey.remove_host_collection(ak_name, hc.name)
+            self.assertIsNotNone(self.activationkey.find_element(
+                common_locators['alert.success_sub_form']))
+            # check added host collection is not listed
+            self.activationkey.click(tab_locators['ak.host_collections.list'])
+            strategy, value = tab_locators['ak.host_collections.add.select']
+            host_collection = self.activationkey.wait_until_element(
+                (strategy, value % hc.name))
+            self.assertIsNone(host_collection)
+
     @tier1
     def test_positive_create_with_usage_limit(self):
         """Create Activation key with finite Usage limit


### PR DESCRIPTION
Cherry-pick of #4069. Bug described in #3920 was fixed in 6.2.5 so it also applicable for 6.2.z.
Closes #3920.
```python
% py.test -v -n 2 tests/foreman/ui/test_activationkey.py -k ' test_positive_remove_host_collection_non_admin or  test_positive_add_host_collection_non_admin'    
===================================================================== test session starts =====================================================================

tests/foreman/ui/test_activationkey.py::ActivationKeyTestCase::test_positive_remove_host_collection_non_admin 
tests/foreman/ui/test_activationkey.py::ActivationKeyTestCase::test_positive_add_host_collection_non_admin     
[gw1] PASSED tests/foreman/ui/test_activationkey.py::ActivationKeyTestCase::test_positive_add_host_collection_non_admin 
[gw0] PASSED tests/foreman/ui/test_activationkey.py::ActivationKeyTestCase::test_positive_remove_host_collection_non_admin 

================================================================= 2 passed in 111.12 seconds ==================================================================
```