### PR TITLE
[6.2.z] Added upload tests for UI/repository.

### DIFF
--- a/robottelo/ui/locators.py
+++ b/robottelo/ui/locators.py
@@ -1973,23 +1973,15 @@ locators = LocatorDict({
     "repo.result_spinner": (
         By.XPATH,
         "//i[@ng-show='task.pending' and contains(@class, 'icon-spinner')]"),
-    "repo.manage_content.packages": (
+    "repo.manage_content": (
         By.XPATH,
         "//button[contains(@ui-sref,"
-        " 'products.details.repositories.manage-content.packages')]"),
-    "repo.manage_content.puppet_modules": (
-        By.XPATH,
-        "//button[contains(@ui-sref,"
-        " 'products.details.repositories.manage-content.puppet-modules')]"),
-    "repo.manage_content.docker_manifests": (
-        By.XPATH,
-        "//button[contains(@ui-sref,"
-        " 'products.details.repositories.manage-content.docker-manifests')]"),
-    "repo.manage_content.ostree_branches": (
-        By.XPATH,
-        "//button[contains(@ui-sref,"
-        " 'products.details.repositories.manage-content.ostree-branches)]"),
-    "repo.content_items": (By.XPATH, "//tr[@row-select='item']"),
+        " 'products.details.repositories.manage-content')"
+        " and not(contains(@class, 'ng-hide'))]"),
+    "repo.content.packages": (By.XPATH, "//tr[@row-select='package']"),
+    "repo.content.puppet_modules": (By.XPATH, "//tr[@row-select='item']"),
+    "repo.upload.file_path": (By.XPATH, ("//input[@name='content[]']")),
+    "repo.upload": (By.XPATH, ("//button[@upload-submit]")),
     # Activation Keys
 
     "ak.new": (By.XPATH, "//button[@ui-sref='activation-keys.new']"),

--- a/robottelo/ui/repository.py
+++ b/robottelo/ui/repository.py
@@ -158,10 +158,10 @@ class Repos(Base):
                 'repo.fetch_' + field_name]).text == expected_field_value)
         return False
 
-    def upload(self, repo_name, filename):
-        """"""
+    def upload_content(self, repo_name, file_path):
+        """Upload content to a repository."""
         self.search_and_click(repo_name)
         browse_element = self.wait_until_element(
             locators['repo.upload.file_path'])
-        browse_element.send_keys(filename)
+        browse_element.send_keys(file_path)
         self.click(locators['repo.upload'])

--- a/robottelo/ui/repository.py
+++ b/robottelo/ui/repository.py
@@ -157,3 +157,11 @@ class Repos(Base):
             return (self.wait_until_element(locators[
                 'repo.fetch_' + field_name]).text == expected_field_value)
         return False
+
+    def upload(self, repo_name, filename):
+        """"""
+        self.search_and_click(repo_name)
+        browse_element = self.wait_until_element(
+            locators['repo.upload.file_path'])
+        browse_element.send_keys(filename)
+        self.click(locators['repo.upload'])

--- a/tests/foreman/ui/test_repository.py
+++ b/tests/foreman/ui/test_repository.py
@@ -27,18 +27,21 @@ from robottelo.constants import (
     DOCKER_REGISTRY_HUB,
     DOWNLOAD_POLICIES,
     FAKE_0_PUPPET_REPO,
+    FAKE_1_PUPPET_REPO,
     FAKE_1_YUM_REPO,
     FAKE_2_YUM_REPO,
     FEDORA22_OSTREE_REPO,
     FEDORA23_OSTREE_REPO,
     PRDS,
+    PUPPET_MODULE_NTP_PUPPETLABS,
     REPO_DISCOVERY_URL,
     REPO_TYPE,
     REPOS,
+    RPM_TO_UPLOAD,
     SAT6_TOOLS_TREE,
     VALID_GPG_KEY_BETA_FILE,
     VALID_GPG_KEY_FILE,
-    FAKE_1_PUPPET_REPO)
+)
 from robottelo.datafactory import (
     filtered_datapoint,
     generate_strings_list,
@@ -52,7 +55,7 @@ from robottelo.decorators import (
     tier2,
 )
 from robottelo.decorators.host import skip_if_os
-from robottelo.helpers import read_data_file
+from robottelo.helpers import get_data_file, read_data_file
 from robottelo.test import UITestCase
 from robottelo.ui.factory import make_repository, set_context
 from robottelo.ui.locators import common_locators, locators, tab_locators
@@ -1014,6 +1017,119 @@ class RepositoryTestCase(UITestCase):
                     strategy, value % SAT6_TOOLS_TREE[0][-1]
                 )).is_selected()
             )
+
+    @tier1
+    def test_positive_upload_yum(self):
+        """Create yum repository and upload rpm package
+
+        @id: 201d5742-cb1a-4534-ac02-91b5a4669d22
+
+        @Assert: Upload is successful and package is listed
+        """
+        repo_name = gen_string('alpha')
+        with Session(self.browser) as session:
+            set_context(session, org=self.session_org.name)
+            self.products.search(self.session_prod.name).click()
+            make_repository(session, name=repo_name)
+            self.assertIsNotNone(self.repository.search(repo_name))
+            self.repository.upload(repo_name, get_data_file(RPM_TO_UPLOAD))
+            # Check alert
+            self.assertIsNotNone(self.activationkey.wait_until_element(
+                common_locators['alert.success_sub_form']))
+            # Check packages number
+            number = self.repository.find_element(
+                locators['repo.fetch_packages'])
+            self.assertGreater(int(number.text), 0)
+            # Check packages list
+            self.repository.click(locators['repo.manage_content'])
+            packages = [
+                package.text for package in
+                self.repository.find_elements(
+                    locators['repo.content.packages'])
+            ]
+            self.assertIn(RPM_TO_UPLOAD.rstrip('.rpm'), packages)
+
+    @tier1
+    def test_negative_upload_yum(self):
+        """Create yum repository but upload any content except rpm
+
+        @id: 77a098c2-3f63-4e9f-88b9-f0657b721611
+
+        @Assert: Error is raised during upload and file is not listed
+        """
+        repo_name = gen_string('alpha')
+        with Session(self.browser) as session:
+            set_context(session, org=self.session_org.name)
+            self.products.search(self.session_prod.name).click()
+            make_repository(session, name=repo_name)
+            self.assertIsNotNone(self.repository.search(repo_name))
+            self.repository.upload(
+                repo_name, get_data_file(PUPPET_MODULE_NTP_PUPPETLABS))
+            # Check alert
+            self.assertIsNotNone(self.activationkey.wait_until_element(
+                common_locators['alert.error_sub_form']))
+            # Check packages number
+            number = self.repository.find_element(
+                locators['repo.fetch_packages'])
+            self.assertEqual(int(number.text), 0)
+
+    @tier1
+    def test_positive_upload_puppet(self):
+        """Create puppet repository and upload puppet module
+
+        @id: 2da4ddeb-3d6a-4b77-b44a-190a0c20a4f6
+
+        @Assert: Upload is successful and module is listed
+        """
+        repo_name = gen_string('alpha')
+        with Session(self.browser) as session:
+            set_context(session, org=self.session_org.name)
+            self.products.search(self.session_prod.name).click()
+            make_repository(
+                session, name=repo_name, repo_type=REPO_TYPE['puppet'])
+            self.assertIsNotNone(self.repository.search(repo_name))
+            self.repository.upload(
+                repo_name, get_data_file(PUPPET_MODULE_NTP_PUPPETLABS))
+            # Check alert
+            self.assertIsNotNone(self.activationkey.wait_until_element(
+                common_locators['alert.success_sub_form']))
+            # Check packages number
+            number = self.repository.find_element(
+                locators['repo.fetch_puppet_modules'])
+            self.assertGreater(int(number.text), 0)
+            # Check packages list
+            self.repository.click(locators['repo.manage_content'])
+            # Select all modules names from modules table
+            packages = [
+                package.text.split()[0] for package in
+                self.repository.find_elements(
+                    locators['repo.content.puppet_modules'])
+            ]
+            self.assertIn('ntp', packages)
+
+    @tier1
+    def test_negative_upload_puppet(self):
+        """Create puppet repository but upload any content except puppet module
+
+        @id: 79ebea29-2c5c-476d-8d1a-54e6b9d49e17
+
+        @Assert: Error is raised during upload and file is not listed
+        """
+        repo_name = gen_string('alpha')
+        with Session(self.browser) as session:
+            set_context(session, org=self.session_org.name)
+            self.products.search(self.session_prod.name).click()
+            make_repository(
+                session, name=repo_name, repo_type=REPO_TYPE['puppet'])
+            self.assertIsNotNone(self.repository.search(repo_name))
+            self.repository.upload(repo_name, get_data_file(RPM_TO_UPLOAD))
+            # Check alert
+            self.assertIsNotNone(self.activationkey.wait_until_element(
+                common_locators['alert.error_sub_form']))
+            # Check packages number
+            number = self.repository.find_element(
+                locators['repo.fetch_puppet_modules'])
+            self.assertEqual(int(number.text), 0)
 
 
 class GitPuppetMirrorTestCase(UITestCase):

--- a/tests/foreman/ui/test_repository.py
+++ b/tests/foreman/ui/test_repository.py
@@ -1019,7 +1019,7 @@ class RepositoryTestCase(UITestCase):
             )
 
     @tier1
-    def test_positive_upload_yum(self):
+    def test_positive_upload_rpm(self):
         """Create yum repository and upload rpm package
 
         @id: 201d5742-cb1a-4534-ac02-91b5a4669d22
@@ -1050,7 +1050,7 @@ class RepositoryTestCase(UITestCase):
             self.assertIn(RPM_TO_UPLOAD.rstrip('.rpm'), packages)
 
     @tier1
-    def test_negative_upload_yum(self):
+    def test_negative_upload_rpm(self):
         """Create yum repository but upload any content except rpm
 
         @id: 77a098c2-3f63-4e9f-88b9-f0657b721611

--- a/tests/foreman/ui/test_repository.py
+++ b/tests/foreman/ui/test_repository.py
@@ -951,7 +951,7 @@ class RepositoryTestCase(UITestCase):
             # Create and sync first repo
             repo1 = entities.Repository(
                 product=self.session_prod,
-                content_type='puppet',
+                content_type=REPO_TYPE['puppet'],
                 url=FAKE_0_PUPPET_REPO,
             ).create()
             repo1.sync()
@@ -960,27 +960,25 @@ class RepositoryTestCase(UITestCase):
             self.repository.search_and_click(repo1.name)
             content_count = self.repository.find_element(
                 locators['repo.fetch_puppet_modules']).text
-            self.repository.click(
-                locators['repo.manage_content.puppet_modules'])
+            self.repository.click(locators['repo.manage_content'])
             modules_num = len(self.repository.find_elements(
-                locators['repo.content_items']))
+                locators['repo.content.puppet_modules']))
             self.assertEqual(content_count, str(modules_num))
             # Create and sync second repo
             repo2 = entities.Repository(
                 product=self.session_prod,
-                content_type='puppet',
+                content_type=REPO_TYPE['puppet'],
                 url=FAKE_1_PUPPET_REPO,
             ).create()
             repo2.sync()
             # Verify that number of modules from the first repo has not changed
             self.products.search_and_click(self.session_prod.name)
             self.repository.search_and_click(repo1.name)
-            self.repository.click(
-                locators['repo.manage_content.puppet_modules'])
+            self.repository.click(locators['repo.manage_content'])
             self.assertEqual(
                 modules_num,
                 len(self.repository.find_elements(
-                    locators['repo.content_items']))
+                    locators['repo.content.puppet_modules']))
             )
 
     @run_in_one_thread


### PR DESCRIPTION
As mentioned in #3930 upload testscases were missing for UI testsuits.
I've added these tests to 6.2.z first as unfortunately there is now no way to test them on 6.3. I think they can be cherry-picked later to master branch without significant problems.
```python
% py.test -n 3 -v tests/foreman/ui/test_repository.py -k 'test_positive_list_puppet_modules_with_multiple_repos or test_positive_upload_yum or test_positive_upload_puppet or test_negative_upload_yum or test_negative_upload_puppet'                                         
===================================================================== test session starts =====================================================================

tests/foreman/ui/test_repository.py::RepositoryTestCase::test_positive_list_puppet_modules_with_multiple_repos 
tests/foreman/ui/test_repository.py::RepositoryTestCase::test_negative_upload_puppet 
tests/foreman/ui/test_repository.py::RepositoryTestCase::test_negative_upload_yum 
[gw0] PASSED tests/foreman/ui/test_repository.py::RepositoryTestCase::test_negative_upload_puppet 
tests/foreman/ui/test_repository.py::RepositoryTestCase::test_positive_upload_puppet 
[gw2] PASSED tests/foreman/ui/test_repository.py::RepositoryTestCase::test_negative_upload_yum 
tests/foreman/ui/test_repository.py::RepositoryTestCase::test_positive_upload_yum 
[gw1] PASSED tests/foreman/ui/test_repository.py::RepositoryTestCase::test_positive_list_puppet_modules_with_multiple_repos 
[gw0] PASSED tests/foreman/ui/test_repository.py::RepositoryTestCase::test_positive_upload_puppet 
[gw2] PASSED tests/foreman/ui/test_repository.py::RepositoryTestCase::test_positive_upload_yum 

================================================================= 5 passed in 106.82 seconds ==================================================================
````