### PR TITLE
hammer sc-params and smart-variables ouput format changed to csv

### DIFF
--- a/robottelo/cli/puppet.py
+++ b/robottelo/cli/puppet.py
@@ -42,7 +42,10 @@ class Puppet(Base):
              --search SEARCH                    filter results
         """
         cls.command_sub = 'sc-params'
-        return cls.execute(cls._construct_command(options))
+        return cls.execute(
+                cls._construct_command(options),
+                output_format='csv'
+        )
 
     @classmethod
     def smart_variables(cls, options=None):
@@ -59,4 +62,7 @@ class Puppet(Base):
              --search SEARCH                    filter results
          """
         cls.command_sub = 'smart-variables'
-        return cls.execute(cls._construct_command(options))
+        return cls.execute(
+                cls._construct_command(options),
+                output_format='csv'
+        )


### PR DESCRIPTION
With default output format, asserts in `test_positive_list_smart_class_parameters` and `test_positive_list_smart_variables` (in https://github.com/SatelliteQE/robottelo/blob/master/tests/foreman/cli/test_puppetclass.py) were always true, i.e. greater than 0 even with empty output.

Test results:
```
nosetests -v tests/foreman/cli/test_puppetclass.py:PuppetClassTestCase 
List smart class parameters associated with the puppet class. ... ok
List smart variables associated with the puppet class. ... ok

----------------------------------------------------------------------
Ran 2 tests in 122.307s

OK

```