### PR TITLE
Workaround ISE on smart proxy deletion

### DIFF
--- a/robottelo/cleanup.py
+++ b/robottelo/cleanup.py
@@ -3,8 +3,10 @@
 import logging
 from collections import deque, defaultdict
 from nailgun import entities, signals
+from robottelo.cli.base import CLIReturnCodeError
 from robottelo.cli.proxy import Proxy
 from robottelo.constants import DEFAULT_ORG_ID
+from robottelo.decorators import bz_bug_is_open
 
 
 LOGGER = logging.getLogger(__name__)
@@ -12,7 +14,14 @@ LOGGER = logging.getLogger(__name__)
 
 def capsule_cleanup(proxy_id=None):
     """Deletes the capsule with the given id"""
-    Proxy.delete({'id': proxy_id})
+    if bz_bug_is_open(1398695):
+        try:
+            Proxy.delete({'id': proxy_id})
+        except CLIReturnCodeError as err:
+            if err.return_code != 70:
+                raise err
+    else:
+        Proxy.delete({'id': proxy_id})
 
 
 def location_cleanup(loc_id=None):

--- a/tests/foreman/cli/test_capsule.py
+++ b/tests/foreman/cli/test_capsule.py
@@ -23,8 +23,13 @@ from robottelo.cli.factory import CLIFactoryError, make_proxy
 from robottelo.cli.proxy import Proxy
 from robottelo.datafactory import valid_data_list
 from robottelo.decorators import (
-    run_only_on, stubbed, tier1, tier2, skip_if_not_set
-    )
+    bz_bug_is_open,
+    run_only_on,
+    skip_if_not_set,
+    stubbed,
+    tier1,
+    tier2,
+)
 from robottelo.helpers import (
     default_url_on_new_port,
     get_available_capsule_port
@@ -87,7 +92,14 @@ class CapsuleTestCase(CLITestCase):
         for name in valid_data_list():
             with self.subTest(name):
                 proxy = make_proxy({u'name': name})
-                Proxy.delete({u'id': proxy['id']})
+                if bz_bug_is_open(1398695):
+                    try:
+                        Proxy.delete({'id': proxy['id']})
+                    except CLIReturnCodeError as err:
+                        if err.return_code != 70:
+                            raise err
+                else:
+                    Proxy.delete({'id': proxy['id']})
                 with self.assertRaises(CLIReturnCodeError):
                     Proxy.info({u'id': proxy['id']})
 


### PR DESCRIPTION
Closes #4029 
Smart proxy deletion causes internal server error as per https://bugzilla.redhat.com/show_bug.cgi?id=1398695 . However smart proxy is being deleted successfully so instead of skipping all the tests related to smart proxies (especially those ones which are exercising different things and deleting proxies just as part of tierdown) i'm proposing to ignore this ISE while BZ is open