### PR TITLE
Automated tests around discoveredhost provisioning/auto-provisioning

### DIFF
--- a/robottelo/api/utils.py
+++ b/robottelo/api/utils.py
@@ -243,8 +243,8 @@ def configure_provisioning(org=None, loc=None):
         entity_mixins.TASK_TIMEOUT = old_task_timeout
     # Search for puppet environment and associate location
     environment = entities.Environment(
-        organization=[org.id]).search()[0]
-    environment.location = [loc]
+        organization=[org.id]).search()[0].read()
+    environment.location.append(loc)
     environment = environment.update(['location'])
 
     # Search for SmartProxy, and associate location
@@ -253,10 +253,11 @@ def configure_provisioning(org=None, loc=None):
             u'search': u'name={0}'.format(
                 settings.server.hostname)
         }
-    )[0]
-    proxy.location = [loc]
+    )
+    proxy = proxy[0].read()
+    proxy.location.append(loc)
     proxy = proxy.update(['location'])
-    proxy.organization = [org]
+    proxy.organization.append(org)
     proxy = proxy.update(['organization'])
 
     # Search for existing domain or create new otherwise. Associate org,
@@ -288,14 +289,14 @@ def configure_provisioning(org=None, loc=None):
         query={u'search': u'network={0}'.format(network)}
     )
     if len(subnet) == 1:
-        subnet = subnet[0]
+        subnet = subnet[0].read()
         subnet.domain = [domain]
-        subnet.location = [loc]
-        subnet.organization = [org]
-        subnet.dns = proxy
-        subnet.dhcp = proxy
-        subnet.tftp = proxy
-        subnet.discovery = proxy
+        subnet.location.append(loc)
+        subnet.organization.append(org)
+        subnet.dns = [proxy]
+        subnet.dhcp = [proxy]
+        subnet.tftp = [proxy]
+        subnet.discovery = [proxy]
         subnet = subnet.update([
             'domain',
             'discovery',
@@ -352,23 +353,24 @@ def configure_provisioning(org=None, loc=None):
         query={
             u'search': u'name="{0}"'.format(DEFAULT_PTABLE)
         }
-    )[0]
+    )[0].read()
 
     # Get the OS ID
     os = entities.OperatingSystem().search(query={
         u'search': u'name="RedHat" AND (major="{0}" OR major="{1}")'
         .format(RHEL_6_MAJOR_VERSION, RHEL_7_MAJOR_VERSION)
-        })[0]
+        })[0].read()
 
     # Get the Provisioning template_ID and update with OS, Org, Location
     provisioning_template = entities.ConfigTemplate().search(
         query={
             u'search': u'name="{0}"'.format(DEFAULT_TEMPLATE)
         }
-    )[0]
-    provisioning_template.operatingsystem = [os]
-    provisioning_template.organization = [org]
-    provisioning_template.location = [loc]
+    )
+    provisioning_template = provisioning_template[0].read()
+    provisioning_template.operatingsystem.append(os)
+    provisioning_template.organization.append(org)
+    provisioning_template.location.append(loc)
     provisioning_template = provisioning_template.update([
         'location',
         'operatingsystem',
@@ -380,10 +382,11 @@ def configure_provisioning(org=None, loc=None):
         query={
             u'search': u'name="{0}"'.format(DEFAULT_PXE_TEMPLATE)
         }
-    )[0]
-    pxe_template.operatingsystem = [os]
-    pxe_template.organization = [org]
-    pxe_template.location = [loc]
+    )
+    pxe_template = pxe_template[0].read()
+    pxe_template.operatingsystem.append(os)
+    pxe_template.organization.append(org)
+    pxe_template.location.append(loc)
     pxe_template = pxe_template.update(
         ['location', 'operatingsystem', 'organization']
     )
@@ -391,7 +394,7 @@ def configure_provisioning(org=None, loc=None):
     # Get the arch ID
     arch = entities.Architecture().search(
         query={u'search': u'name="x86_64"'}
-    )[0]
+    )[0].read()
 
     # Get the media and update its location
     media = entities.Media(organization=[org]).search()[0].read()
@@ -399,11 +402,11 @@ def configure_provisioning(org=None, loc=None):
     media.organization.append(org)
     media = media.update(['location', 'organization'])
     # Update the OS to associate arch, ptable, templates
-    os.architecture = [arch]
-    os.ptable = [ptable]
-    os.config_template = [provisioning_template]
-    os.config_template = [pxe_template]
-    os.medium = [media]
+    os.architecture.append(arch)
+    os.ptable.append(ptable)
+    os.config_template.append(provisioning_template)
+    os.config_template.append(pxe_template)
+    os.medium.append(media)
     os = os.update([
         'architecture',
         'config_template',

--- a/robottelo/constants.py
+++ b/robottelo/constants.py
@@ -180,6 +180,8 @@ FILTER = {
     'container_org': 'docker_container_wizard_states_preliminary_organization',
     'cr_loc': 'compute_resource_location',
     'cr_org': 'compute_resource_organization',
+    'discovery_rule_loc': 'discovery_rule_location',
+    'discovery_rule_org': 'discovery_rule_organization',
     'env_org': 'environment_organization',
     'filter_org': 'filter_organization',
     'filter_loc': 'filter_location',

--- a/robottelo/libvirt_discovery.py
+++ b/robottelo/libvirt_discovery.py
@@ -178,6 +178,7 @@ class LibvirtGuest(object):
             '--model=virtio',
             '--mac={vm_mac}',
             '--config',
+            '--live',
         ]
         command = u' '.join(command_args).format(
             vm_name=self.hostname,

--- a/robottelo/ui/discoveredhosts.py
+++ b/robottelo/ui/discoveredhosts.py
@@ -75,20 +75,19 @@ class DiscoveredHosts(Base):
         self.click(locators['discoveredhosts.dropdown'] % hostname)
         self.click(locators['discoveredhosts.refresh_facts'] % hostname)
 
-    def assertdiscoveredhost(self, hostname):
-        """
-        Check if host is visible under 'Discovered Hosts' on UI
+    def waitfordiscoveredhost(self, hostname):
+        """Check if host is visible under 'Discovered Hosts' on UI
 
         Introduced a delay of 300secs by polling every 10 secs to see if
         unknown host gets discovered and become visible on UI
         """
-        discovered_host = self.search(hostname)
         for _ in range(30):
-            if discovered_host is None:
-                sleep(10)
-                discovered_host = self.search(hostname)
+            discovered_host = self.search(hostname)
+            if discovered_host:
+                return True
             else:
-                break
+                sleep(10)
+        return False
 
     def fetch_fact_value(self, hostname, element):
         """Fetch the value of selected fact from discovered hosts page"""
@@ -132,8 +131,16 @@ class DiscoveredHosts(Base):
         self.click(locators['discoveredhosts.dropdown'] % hostname)
         self.click(locators['discoveredhosts.auto_provision'] % hostname)
 
+    def auto_provision_all(self):
+        """Auto provision all the discovered hosts"""
+        self.navigate_to_entity()
+        self.discoveredhosts.click(
+            locators["discoveredhosts.auto_provision_all"]
+        )
+
     def update_org_loc(self, hostnames, new_org=None, new_loc=None):
         """Update the default org or location for bulk of discovered hosts"""
+        self.navigate_to_entity()
         for host in hostnames:
             self.click(locators['discoveredhosts.select_host'] % host)
         self.click(locators['discoveredhosts.select_action'])
@@ -158,12 +165,12 @@ class DiscoveredHosts(Base):
             self.click(locators['discoveredhosts.provision_from_facts'])
         else:
             self.click(locators['discoveredhosts.provision'] % hostname)
-        self.select(
+        self.assign_value(
             locators['discoveredhosts.select_modal_hostgroup'],
             hostgroup
         )
-        self.select(locators['discoveredhosts.select_modal_org'], org)
-        self.select(locators['discoveredhosts.select_modal_loc'], loc)
+        self.assign_value(locators['discoveredhosts.select_modal_org'], org)
+        self.assign_value(locators['discoveredhosts.select_modal_loc'], loc)
         if not quick_create:
             self.click(locators['discoveredhosts.create_host_button'])
             if new_name is not None:

--- a/robottelo/ui/discoveredhosts.py
+++ b/robottelo/ui/discoveredhosts.py
@@ -134,9 +134,7 @@ class DiscoveredHosts(Base):
     def auto_provision_all(self):
         """Auto provision all the discovered hosts"""
         self.navigate_to_entity()
-        self.discoveredhosts.click(
-            locators["discoveredhosts.auto_provision_all"]
-        )
+        self.click(locators["discoveredhosts.auto_provision_all"])
 
     def update_org_loc(self, hostnames, new_org=None, new_loc=None):
         """Update the default org or location for bulk of discovered hosts"""
@@ -165,16 +163,16 @@ class DiscoveredHosts(Base):
             self.click(locators['discoveredhosts.provision_from_facts'])
         else:
             self.click(locators['discoveredhosts.provision'] % hostname)
-        self.assign_value(
+        self.select(
             locators['discoveredhosts.select_modal_hostgroup'],
             hostgroup
         )
-        self.assign_value(locators['discoveredhosts.select_modal_org'], org)
-        self.assign_value(locators['discoveredhosts.select_modal_loc'], loc)
+        self.select(locators['discoveredhosts.select_modal_org'], org)
+        self.select(locators['discoveredhosts.select_modal_loc'], loc)
         if not quick_create:
             self.click(locators['discoveredhosts.create_host_button'])
             if new_name is not None:
-                self.text_field_update(locators['host.name'], new_name)
+                self.assign_value(locators['host.name'], new_name)
             if parameters_list is not None:
                 self.hosts._configure_hosts_parameters(parameters_list)
             self.wait_until_element_is_not_visible(

--- a/robottelo/ui/discoveredhosts.py
+++ b/robottelo/ui/discoveredhosts.py
@@ -1,8 +1,9 @@
 # -*- encoding: utf-8 -*-
 """Implements Discovered Hosts from UI."""
 from robottelo.ui.base import Base, UIError
-from robottelo.ui.locators import locators
+from robottelo.ui.locators import common_locators, locators
 from robottelo.ui.navigator import Navigator
+from time import sleep
 
 
 class DiscoveredHosts(Base):
@@ -74,6 +75,21 @@ class DiscoveredHosts(Base):
         self.click(locators['discoveredhosts.dropdown'] % hostname)
         self.click(locators['discoveredhosts.refresh_facts'] % hostname)
 
+    def assertdiscoveredhost(self, hostname):
+        """
+        Check if host is visible under 'Discovered Hosts' on UI
+
+        Introduced a delay of 300secs by polling every 10 secs to see if
+        unknown host gets discovered and become visible on UI
+        """
+        discovered_host = self.search(hostname)
+        for _ in range(30):
+            if discovered_host is None:
+                sleep(10)
+                discovered_host = self.search(hostname)
+            else:
+                break
+
     def fetch_fact_value(self, hostname, element):
         """Fetch the value of selected fact from discovered hosts page"""
         host = self.search(hostname)
@@ -104,11 +120,58 @@ class DiscoveredHosts(Base):
             wait_for_ajax=False
         )
 
-    def update_org(self, hostnames, new_org):
+    def auto_provision(self, hostname):
+        """Auto provision the discovered host from dropdown"""
+        host = self.search(hostname)
+        if not host:
+            raise UIError(
+                'Could not find the selected discovered host "{0}"'
+                .format(hostname)
+            )
+        # Manually provision the host by selecting 'auto_provision' option
+        self.click(locators['discoveredhosts.dropdown'] % hostname)
+        self.click(locators['discoveredhosts.auto_provision'] % hostname)
+
+    def update_org_loc(self, hostnames, new_org=None, new_loc=None):
         """Update the default org or location for bulk of discovered hosts"""
         for host in hostnames:
             self.click(locators['discoveredhosts.select_host'] % host)
         self.click(locators['discoveredhosts.select_action'])
-        self.click(locators['discoveredhosts.assign_org'])
-        self.select(locators['discoveredhosts.select_org'], new_org)
+        if new_org:
+            self.click(locators['discoveredhosts.assign_org'])
+            self.select(locators['discoveredhosts.select_org'], new_org)
+        if new_loc:
+            self.click(locators['discoveredhosts.assign_loc'])
+            self.select(locators['discoveredhosts.select_loc'], new_loc)
         self.click(locators['discoveredhosts.bulk_submit_button'])
+
+    def provision_discoveredhost(self, hostgroup, org, loc, hostname,
+                                 new_name=None, parameters_list=None,
+                                 puppet_classes=None,
+                                 interface_parameters=None,
+                                 host_parameters=None, quick_create=False,
+                                 facts_page=False):
+        """Creates a host."""
+        if facts_page:
+            self.search_and_click(hostname)
+            self.click(locators['discoveredhosts.select_action_facts'])
+            self.click(locators['discoveredhosts.provision_from_facts'])
+        else:
+            self.click(locators['discoveredhosts.provision'] % hostname)
+        self.select(
+            locators['discoveredhosts.select_modal_hostgroup'],
+            hostgroup
+        )
+        self.select(locators['discoveredhosts.select_modal_org'], org)
+        self.select(locators['discoveredhosts.select_modal_loc'], loc)
+        if not quick_create:
+            self.click(locators['discoveredhosts.create_host_button'])
+            if new_name is not None:
+                self.text_field_update(locators['host.name'], new_name)
+            if parameters_list is not None:
+                self.hosts._configure_hosts_parameters(parameters_list)
+            self.wait_until_element_is_not_visible(
+                common_locators['modal_background'])
+            self.click(common_locators['submit'])
+        else:
+            self.click(locators['discoveredhosts.quick_create_button'])

--- a/robottelo/ui/discoveryrules.py
+++ b/robottelo/ui/discoveryrules.py
@@ -53,7 +53,7 @@ class DiscoveryRules(Base):
         self.assign_value(
             locators['discoveryrules.hostgroup_dropdown'], hostgroup)
         self._configure_discovery(
-            hostname, host_limit, priority, enabled, locations, organizations)
+            hostname, host_limit, priority, locations, organizations)
         self.click(common_locators['submit'])
 
     def navigate_to_entity(self):

--- a/robottelo/ui/discoveryrules.py
+++ b/robottelo/ui/discoveryrules.py
@@ -3,7 +3,7 @@
 from robottelo.constants import FILTER
 from robottelo.decorators import bz_bug_is_open
 from robottelo.ui.base import Base
-from robottelo.ui.locators import common_locators, locators
+from robottelo.ui.locators import common_locators, locators, tab_locators
 from robottelo.ui.navigator import Navigator
 
 
@@ -52,7 +52,8 @@ class DiscoveryRules(Base):
         self.assign_value(locators['discoveryrules.search'], search_rule)
         self.assign_value(
             locators['discoveryrules.hostgroup_dropdown'], hostgroup)
-        self._configure_discovery(hostname, host_limit, priority, enabled)
+        self._configure_discovery(
+            hostname, host_limit, priority, enabled, locations, organizations)
         self.click(common_locators['submit'])
 
     def navigate_to_entity(self):

--- a/robottelo/ui/discoveryrules.py
+++ b/robottelo/ui/discoveryrules.py
@@ -1,5 +1,6 @@
 # -*- encoding: utf-8 -*-
 """Implements Discovery Rules from UI."""
+from robottelo.constants import FILTER
 from robottelo.decorators import bz_bug_is_open
 from robottelo.ui.base import Base
 from robottelo.ui.locators import common_locators, locators
@@ -10,7 +11,8 @@ class DiscoveryRules(Base):
     """Manipulates Discovery Rules from UI"""
 
     def _configure_discovery(self, hostname=None, host_limit=None,
-                             priority=None, enabled=True):
+                             priority=None, locations=None, organizations=None,
+                             enabled=True):
         """Configures various parameters for discovery rule."""
         if hostname:
             self.assign_value(
@@ -28,9 +30,22 @@ class DiscoveryRules(Base):
                 priority
             )
         self.assign_value(locators['discoveryrules.enabled'], enabled)
+        if locations:
+            self.configure_entity(
+                locations,
+                FILTER['discovery_rule_loc'],
+                tab_locator=tab_locators['tab_loc'],
+            )
+        if organizations:
+            self.configure_entity(
+                organizations,
+                FILTER['discovery_rule_org'],
+                tab_locator=tab_locators['tab_org'],
+            )
 
     def create(self, name, search_rule, hostgroup, hostname=None,
-               host_limit=None, priority=None, enabled=True):
+               host_limit=None, priority=None, locations=None,
+               organizations=None, select=True, enabled=True):
         """Creates new discovery rule from UI"""
         self.click(locators['discoveryrules.new'])
         self.assign_value(locators['discoveryrules.name'], name)

--- a/robottelo/ui/factory.py
+++ b/robottelo/ui/factory.py
@@ -1,6 +1,9 @@
 # -*- encoding: utf-8 -*-
 from fauxfactory import gen_string, gen_email
-from robottelo.constants import REPO_TYPE, CHECKSUM_TYPE
+from robottelo.constants import (
+    REPO_TYPE,
+    CHECKSUM_TYPE,
+)
 from robottelo.helpers import update_dictionary
 from robottelo.ui.activationkey import ActivationKey
 from robottelo.ui.architecture import Architecture
@@ -397,6 +400,8 @@ def make_discoveryrule(session, org=None, loc=None, force_context=True,
         u'host_limit': None,
         u'priority': None,
         u'enabled': True,
+        u'locations': None,
+        u'organizations': None,
     }
     page = session.nav.go_to_discovery_rules
     core_factory(create_args, kwargs, session, page,

--- a/robottelo/ui/factory.py
+++ b/robottelo/ui/factory.py
@@ -1,9 +1,6 @@
 # -*- encoding: utf-8 -*-
 from fauxfactory import gen_string, gen_email
-from robottelo.constants import (
-    REPO_TYPE,
-    CHECKSUM_TYPE,
-)
+from robottelo.constants import CHECKSUM_TYPE, REPO_TYPE
 from robottelo.helpers import update_dictionary
 from robottelo.ui.activationkey import ActivationKey
 from robottelo.ui.architecture import Architecture

--- a/robottelo/ui/locators/base.py
+++ b/robottelo/ui/locators/base.py
@@ -2011,8 +2011,9 @@ locators = LocatorDict({
     "discoveredhosts.assign_loc": (
         By.XPATH, ("//a[contains(@onclick, "
                    "'/discovered_hosts/select_multiple_location')]")),
-    "discoveredhosts.select_org": (By.ID, "organization_id"),
-    "discoveredhosts.select_loc": (By.ID, "location_id"),
+    "discoveredhosts.select_org": (
+        By.XPATH, ("//select[@id='organization_id']")),
+    "discoveredhosts.select_loc": (By.XPATH, "//select[@id='location_id']"),
     "discoveredhosts.fetch_interfaces": (
         By.XPATH, ("//div[@id='content']/table/tbody/tr[2]/"
                    "td[contains(.,'eth')]")),
@@ -2032,18 +2033,14 @@ locators = LocatorDict({
         By.XPATH, ("//td/span/a[contains(@href, '%s')]/following::td/div[2]"
                    "/span/a[contains(.,'Provision')]")),
     "discoveredhosts.select_modal_hostgroup": (
-        By.ID, "s2id_host_hostgroup_id"),
-    "discoveredhosts.select_modal_org": (By.ID, "s2id_host_organization_id"),
-    "discoveredhosts.select_modal_loc": (By.ID, "s2id_host_location_id"),
-    "discoveredhosts.hostgroup_selector": (
-        By.XPATH, ("//div[@id='s2id_host_hostgroup_id']/a")),
+        By.XPATH, ("//div[@id='s2id_host_hostgroup_id']/a/span")),
+    "discoveredhosts.select_modal_org": (
+        By.XPATH, ("//div[@id='s2id_host_organization_id']/a/span")),
+    "discoveredhosts.select_modal_loc": (
+        By.XPATH, ("//div[@id='s2id_host_location_id']/a/span")),
     "discoverehosts.select_choices": (
         By.XPATH, ("/li[contains(@class, 'select2-result')]"
                    "/div[contains(., '%s')]")),
-    "discoveredhosts.org_selector": (
-        By.XPATH, ("//div[@id='s2id_host_organization_id']/a/span")),
-    "discoveredhosts.loc_selector": (
-        By.XPATH, ("//div[@id='s2id_host_location_id']/a/span")),
     "discoveredhosts.quick_create_button": (
         By.XPATH, ("//input[@value='Quick create']")),
     "discoveredhosts.create_host_button": (

--- a/robottelo/ui/locators/base.py
+++ b/robottelo/ui/locators/base.py
@@ -1979,6 +1979,9 @@ locators = LocatorDict({
     "discoveredhosts.reboot": (
         By.XPATH, ("//a[contains(@href,'%s') and "
                    "contains(@data-id,'reboot')]")),
+    "discoveredhosts.auto_provision": (
+        By.XPATH, ("//a[contains(@href,'%s') and "
+                   "contains(@data-id,'auto_provision')]")),
     "discoveredhosts.delete": (
         By.XPATH, ("//a[@class='delete' and contains(@data-confirm, '%s')]")),
     "discoveredhosts.delete_from_facts": (
@@ -1991,9 +1994,17 @@ locators = LocatorDict({
                    "input[@type='checkbox']")),
     "discoveredhosts.select_action": (
         By.XPATH, ("//div[@id='submit_multiple']/a[@data-toggle='dropdown']")),
+    "discoveredhosts.select_action_facts": (
+        By.XPATH, ("//div[@id='title_action']//a[@data-toggle='dropdown']")),
+    "discoveredhosts.provision_from_facts": (
+        By.XPATH, ("//div[@id='title_action']//ul/li"
+                   "/a[contains(., 'Provision')]")),
     "discoveredhosts.multi_delete": (
         By.XPATH, ("//a[contains(@onclick, "
                    "'/discovered_hosts/multiple_destroy')]")),
+    "discoveredhosts.auto_provision_all": (
+        By.XPATH, ("//div[@id='submit_multiple']"
+                   "/following::a[contains(@href, 'auto_provision_all')]")),
     "discoveredhosts.assign_org": (
         By.XPATH, ("//a[contains(@onclick, "
                    "'/discovered_hosts/select_multiple_organization')]")),
@@ -2005,6 +2016,9 @@ locators = LocatorDict({
     "discoveredhosts.fetch_interfaces": (
         By.XPATH, ("//div[@id='content']/table/tbody/tr[2]/"
                    "td[contains(.,'eth')]")),
+    "discoveredhosts.fetch_fact": (
+        By.XPATH, ("//div[@id='content']/table/tbody/tr[2]"
+                   "/td[contains(.,'%s')]")),
     "discoveredhosts.fetch_bios": (
         By.XPATH, ("//div[@id='content']/table/tbody/tr[2]"
                    "/td[contains(.,'bios')]")),
@@ -2014,6 +2028,26 @@ locators = LocatorDict({
     "discoveredhosts.bulk_submit_button": (
         By.XPATH, ("//div[@id='confirmation-modal']"
                    "//div[@class='modal-footer']/button[2]")),
+    "discoveredhosts.provision": (
+        By.XPATH, ("//td/span/a[contains(@href, '%s')]/following::td/div[2]"
+                   "/span/a[contains(.,'Provision')]")),
+    "discoveredhosts.select_modal_hostgroup": (
+        By.ID, "s2id_host_hostgroup_id"),
+    "discoveredhosts.select_modal_org": (By.ID, "s2id_host_organization_id"),
+    "discoveredhosts.select_modal_loc": (By.ID, "s2id_host_location_id"),
+    "discoveredhosts.hostgroup_selector": (
+        By.XPATH, ("//div[@id='s2id_host_hostgroup_id']/a")),
+    "discoverehosts.select_choices": (
+        By.XPATH, ("/li[contains(@class, 'select2-result')]"
+                   "/div[contains(., '%s')]")),
+    "discoveredhosts.org_selector": (
+        By.XPATH, ("//div[@id='s2id_host_organization_id']/a/span")),
+    "discoveredhosts.loc_selector": (
+        By.XPATH, ("//div[@id='s2id_host_location_id']/a/span")),
+    "discoveredhosts.quick_create_button": (
+        By.XPATH, ("//input[@value='Quick create']")),
+    "discoveredhosts.create_host_button": (
+        By.XPATH, ("//input[@value='Create host']")),
 
     # LDAP Authentication
     "ldapsource.new": (

--- a/robottelo/ui/locators/base.py
+++ b/robottelo/ui/locators/base.py
@@ -2033,11 +2033,11 @@ locators = LocatorDict({
         By.XPATH, ("//td/span/a[contains(@href, '%s')]/following::td/div[2]"
                    "/span/a[contains(.,'Provision')]")),
     "discoveredhosts.select_modal_hostgroup": (
-        By.XPATH, ("//div[@id='s2id_host_hostgroup_id']/a/span")),
+        By.ID, "s2id_host_hostgroup_id"),
     "discoveredhosts.select_modal_org": (
-        By.XPATH, ("//div[@id='s2id_host_organization_id']/a/span")),
+        By.ID, "s2id_host_organization_id"),
     "discoveredhosts.select_modal_loc": (
-        By.XPATH, ("//div[@id='s2id_host_location_id']/a/span")),
+        By.ID, "s2id_host_location_id"),
     "discoverehosts.select_choices": (
         By.XPATH, ("/li[contains(@class, 'select2-result')]"
                    "/div[contains(., '%s')]")),

--- a/robottelo/ui/locators/tab.py
+++ b/robottelo/ui/locators/tab.py
@@ -28,9 +28,11 @@ tab_locators = LocatorDict({
     "host.tab_puppet_classes": (By.XPATH, "//a[@href='#puppet_klasses']"),
     "host.tab_interfaces": (By.XPATH, "//a[@href='#network']"),
     "host.tab_operating_system": (
-        By.XPATH, "//form[@id='new_host']//a[@href='#os']"),
+        By.XPATH, ("//form[@id='new_host' or contains(@id,'edit_host')]"
+                   "//a[@href='#os']")),
     "host.tab_virtual_machine": (
-        By.XPATH, "//form[@id='new_host']//a[@href='#compute_resource']"),
+        By.XPATH, ("//form[@id='new_host' or contains(@id,'edit_host')]"
+                   "//a[@href='#compute_resource']")),
     "host.tab_params": (By.XPATH, "//a[@href='#params']"),
     "host.tab_additional_information": (By.XPATH, "//a[@href='#info']"),
 

--- a/tests/foreman/ui/test_discoveredhost.py
+++ b/tests/foreman/ui/test_discoveredhost.py
@@ -112,8 +112,6 @@ class DiscoveryTestCase(UITestCase):
             name=gen_string('alpha'),
             organization=[cls.org],
         ).create()
-        cls.loc_name = cls.loc.name
-
         # Update default org and location params to place discovered host
         cls.discovery_loc = entities.Setting().search(
             query={'search': 'name="discovery_location"'})[0]
@@ -162,7 +160,9 @@ class DiscoveryTestCase(UITestCase):
             session.nav.go_to_select_org(self.org_name)
             with LibvirtGuest() as pxe_host:
                 hostname = pxe_host.guest_name
-                self.discoveredhosts.assertdiscoveredhost(hostname)
+                self.assertTrue(
+                    self.discoveredhosts.waitfordiscoveredhost(hostname)
+                )
                 self.assertIsNotNone(self.discoveredhosts.search(hostname))
 
     @run_only_on('sat')
@@ -186,7 +186,9 @@ class DiscoveryTestCase(UITestCase):
             session.nav.go_to_select_org(self.org_name)
             with LibvirtGuest(boot_iso=True) as pxe_less_host:
                 hostname = pxe_less_host.guest_name
-                self.discoveredhosts.assertdiscoveredhost(hostname)
+                self.assertTrue(
+                    self.discoveredhosts.waitfordiscoveredhost(hostname)
+                )
                 self.assertIsNotNone(self.discoveredhosts.search(hostname))
 
     @run_only_on('sat')
@@ -327,7 +329,9 @@ class DiscoveryTestCase(UITestCase):
             self._edit_discovery_fact_column_param(session, "interfaces")
             with LibvirtGuest(boot_iso=True, extra_nic=True) as pxe_less_host:
                 hostname = pxe_less_host.guest_name
-                self.discoveredhosts.assertdiscoveredhost(hostname)
+                self.assertTrue(
+                    self.discoveredhosts.waitfordiscoveredhost(hostname)
+                )
                 self.assertIsNotNone(self.discoveredhosts.search(hostname))
                 element = locators['discoveredhosts.fetch_interfaces']
                 host_interfaces = self.discoveredhosts.fetch_fact_value(
@@ -400,7 +404,9 @@ class DiscoveryTestCase(UITestCase):
             self._edit_discovery_fact_column_param(session, "interfaces")
             with LibvirtGuest(extra_nic=True) as pxe_host:
                 hostname = pxe_host.guest_name
-                self.discoveredhosts.assertdiscoveredhost(hostname)
+                self.assertTrue(
+                    self.discoveredhosts.waitfordiscoveredhost(hostname)
+                )
                 self.assertIsNotNone(self.discoveredhosts.search(hostname))
                 element = locators['discoveredhosts.fetch_interfaces']
                 host_interfaces = self.discoveredhosts.fetch_fact_value(
@@ -430,7 +436,9 @@ class DiscoveryTestCase(UITestCase):
             self._edit_discovery_fact_column_param(session, param_value)
             with LibvirtGuest(boot_iso=True) as pxe_less_host:
                 hostname = pxe_less_host.guest_name
-                self.discoveredhosts.assertdiscoveredhost(hostname)
+                self.assertTrue(
+                    self.discoveredhosts.waitfordiscoveredhost(hostname)
+                )
                 element = locators['discoveredhosts.fetch_custom_fact']
                 custom_fact = self.discoveredhosts.fetch_fact_value(
                     hostname, element)
@@ -455,12 +463,14 @@ class DiscoveryTestCase(UITestCase):
             session.nav.go_to_select_org(self.org_name)
             with LibvirtGuest() as pxe_host:
                 host_name = pxe_host.guest_name
-                self.discoveredhosts.assertdiscoveredhost(host_name)
+                self.assertTrue(
+                    self.discoveredhosts.waitfordiscoveredhost(host_name)
+                )
                 self.discoveredhosts.provision_discoveredhost(
                     hostname=host_name,
                     hostgroup=self.config_env['host_group'],
                     org=self.org_name,
-                    loc=self.loc_name,
+                    loc=self.loc.name,
                     facts_page=True,
                     quick_create=True)
                 self.assertIsNotNone(self.discoveredhosts.wait_until_element(
@@ -475,7 +485,7 @@ class DiscoveryTestCase(UITestCase):
 
     @run_only_on('sat')
     @tier3
-    def test_positive_delete(self):
+    def test_positive_delete_1(self):
         """Delete the selected discovered host
 
         @id: 25a2a3ea-9659-4bdb-8631-c4dd19766014
@@ -484,14 +494,15 @@ class DiscoveryTestCase(UITestCase):
 
         @Assert: Selected host should be removed successfully
 
-
         @CaseLevel: System
         """
         with Session(self.browser) as session:
             session.nav.go_to_select_org(self.org_name)
             with LibvirtGuest() as pxe_host:
                 hostname = pxe_host.guest_name
-                self.discoveredhosts.assertdiscoveredhost(hostname)
+                self.assertTrue(
+                    self.discoveredhosts.waitfordiscoveredhost(hostname)
+                )
                 self.discoveredhosts.delete(hostname)
 
     @run_only_on('sat')
@@ -505,14 +516,15 @@ class DiscoveryTestCase(UITestCase):
 
         @Assert: Selected host should be removed successfully
 
-
         @CaseLevel: System
         """
         with Session(self.browser) as session:
             session.nav.go_to_select_org(self.org_name)
             with LibvirtGuest() as pxe_host:
                 hostname = pxe_host.guest_name
-                self.discoveredhosts.assertdiscoveredhost(hostname)
+                self.assertTrue(
+                    self.discoveredhosts.waitfordiscoveredhost(hostname)
+                )
                 self.discoveredhosts.delete_from_facts(hostname)
                 self.assertIsNone(self.discoveredhosts.search(hostname))
 
@@ -535,10 +547,14 @@ class DiscoveryTestCase(UITestCase):
             session.nav.go_to_select_org(self.org_name)
             with LibvirtGuest() as pxe_1_host:
                 host_1_name = pxe_1_host.guest_name
-                self.discoveredhosts.assertdiscoveredhost(host_1_name)
+                self.assertTrue(
+                    self.discoveredhosts.waitfordiscoveredhost(host_1_name)
+                )
                 with LibvirtGuest() as pxe_2_host:
                     host_2_name = pxe_2_host.guest_name
-                    self.discoveredhosts.assertdiscoveredhost(host_2_name)
+                    self.assertTrue(
+                        self.discoveredhosts.waitfordiscoveredhost(host_2_name)
+                    )
                     hostnames = [host_1_name, host_2_name]
                     for hostname in hostnames:
                         host = self.discoveredhosts.search(hostname)
@@ -576,7 +592,9 @@ class DiscoveryTestCase(UITestCase):
             self._edit_discovery_fact_column_param(session, param_value)
             with LibvirtGuest() as pxe_host:
                 hostname = pxe_host.guest_name
-                self.discoveredhosts.assertdiscoveredhost(hostname)
+                self.assertTrue(
+                    self.discoveredhosts.waitfordiscoveredhost(hostname)
+                )
                 self.assertIsNotNone(self.discoveredhosts.search(hostname))
                 # To add a new network interface on discovered host
                 pxe_host.attach_nic()
@@ -607,7 +625,9 @@ class DiscoveryTestCase(UITestCase):
             self._edit_discovery_fact_column_param(session, 'interfaces')
             with LibvirtGuest(boot_iso=True) as pxe_less_host:
                 hostname = pxe_less_host.guest_name
-                self.discoveredhosts.assertdiscoveredhost(hostname)
+                self.assertTrue(
+                    self.discoveredhosts.waitfordiscoveredhost(hostname)
+                )
                 self.assertIsNotNone(self.discoveredhosts.search(hostname))
                 # To add a new network interface on discovered host
                 pxe_less_host.attach_nic()
@@ -636,7 +656,9 @@ class DiscoveryTestCase(UITestCase):
             session.nav.go_to_select_org(self.org_name)
             with LibvirtGuest() as pxe_host:
                 hostname = pxe_host.guest_name
-                self.discoveredhosts.assertdiscoveredhost(hostname)
+                self.assertTrue(
+                    self.discoveredhosts.waitfordiscoveredhost(hostname)
+                )
                 element = (locators['discoveredhosts.fetch_ip'] % hostname)
                 # Get the IP of discovered host
                 host_ip = self.discoveredhosts.fetch_fact_value(
@@ -668,19 +690,18 @@ class DiscoveryTestCase(UITestCase):
             session.nav.go_to_select_org(self.org_name)
             with LibvirtGuest() as pxe_1_host:
                 host_1_name = pxe_1_host.guest_name
-                self.discoveredhosts.assertdiscoveredhost(host_1_name)
+                self.assertTrue(
+                    self.discoveredhosts.waitfordiscoveredhost(host_1_name)
+                )
                 with LibvirtGuest() as pxe_2_host:
                     host_2_name = pxe_2_host.guest_name
-                    self.discoveredhosts.assertdiscoveredhost(host_2_name)
+                    self.assertTrue(
+                        self.discoveredhosts.waitfordiscoveredhost(host_2_name)
+                    )
                     hostnames = [host_1_name, host_2_name]
                     for hostname in hostnames:
-                        host = self.discoveredhosts.search(hostname)
-                        if not host:
-                            raise UIError(
-                                'Could not find the selected discovered host '
-                                '"{0}"'.format(hostname)
-                            )
-                    self.discoveredhosts.navigate_to_entity()
+                        self.assertIsNotNone(
+                            self.discoveredhosts.search(hostname))
                     self.discoveredhosts.update_org_loc(hostnames, new_org)
 
     @run_only_on('sat')
@@ -698,26 +719,25 @@ class DiscoveryTestCase(UITestCase):
 
         @CaseLevel: System
         """
-        loc = gen_string('alpha')
-        entities.Location(name=loc).create()
+        loc = entities.Location().create()
         with Session(self.browser) as session:
             session.nav.go_to_select_org(self.org_name)
             with LibvirtGuest() as pxe_1_host:
                 host_1_name = pxe_1_host.guest_name
-                self.discoveredhosts.assertdiscoveredhost(host_1_name)
+                self.assertTrue(
+                    self.discoveredhosts.waitfordiscoveredhost(host_1_name)
+                )
                 with LibvirtGuest() as pxe_2_host:
                     host_2_name = pxe_2_host.guest_name
-                    self.discoveredhosts.assertdiscoveredhost(host_2_name)
+                    self.assertTrue(
+                        self.discoveredhosts.waitfordiscoveredhost(host_2_name)
+                    )
                     hostnames = [host_1_name, host_2_name]
                     for hostname in hostnames:
-                        host = self.discoveredhosts.search(hostname)
-                        if not host:
-                            raise UIError(
-                                'Could not find the selected discovered host '
-                                '"{0}"'.format(hostname)
-                            )
-                    self.discoveredhosts.navigate_to_entity()
-                    self.discoveredhosts.update_org_loc(hostnames, new_loc=loc)
+                        self.assertIsNotNone(
+                            self.discoveredhosts.search(hostname))
+                    self.discoveredhosts.update_org_loc(
+                        hostnames, new_loc=loc.name)
 
     @run_only_on('sat')
     @tier3
@@ -739,7 +759,6 @@ class DiscoveryTestCase(UITestCase):
         """
 
     @run_only_on('sat')
-    @stubbed()
     @tier3
     def test_positive_manual_provision_host_with_rule(self):
         """Create a new discovery rule and manually provision a discovered host using
@@ -761,7 +780,9 @@ class DiscoveryTestCase(UITestCase):
             with LibvirtGuest() as pxe_host:
                 host_name = pxe_host.guest_name
                 self.discoveredhosts.assertdiscoveredhost(host_name)
-                self.assertIsNotNone(self.discoveredhosts.search(host_name))
+                self.assertTrue(
+                    self.discoveredhosts.waitfordiscoveredhost(host_name)
+                )
                 element = (locators['discoveredhosts.fetch_ip'] % host_name)
                 # Get the IP of discovered host
                 host_ip = self.discoveredhosts.fetch_fact_value(
@@ -773,16 +794,14 @@ class DiscoveryTestCase(UITestCase):
                         host_limit=1,
                         hostgroup=self.config_env['host_group'],
                         search_rule=host_ip,
-                        locations=[self.loc_name],
+                        locations=[self.loc.name],
                 )
                 self.assertIsNotNone(self.discoveryrules.search(rule_name))
                 self.discoveredhosts.auto_provision(host_name)
                 self.assertIsNotNone(self.discoveredhosts.wait_until_element(
                     common_locators['notif.success']))
-                search = self.hosts.search(
-                    u'{0}.{1}'.format(host_name, self.config_env['domain'])
-                )
-                self.assertIsNotNone(search)
+                self.assertIsNotNone(self.hosts.search(
+                    u'{0}.{1}'.format(host_name, self.config_env['domain'])))
                 # Check that provisioned host is not in the list of discovered
                 # hosts anymore
                 self.assertIsNone(self.discoveredhosts.search(host_name))
@@ -842,8 +861,9 @@ class DiscoveryTestCase(UITestCase):
         # Disable flag to auto provision discovered hosts via discovery rules
         discovery_auto = entities.Setting().search(
             query={'search': 'name="discovery_auto"'})[0]
+        default_discovery_auto = discovery_auto.value
         discovery_auto.value = 'False'
-        discovery_auto.update({'value'})
+        discovery_auto.update(['value'])
         rule_name = gen_string('alpha')
         with Session(self.browser) as session:
             session.nav.go_to_select_org(self.org_name)
@@ -854,22 +874,26 @@ class DiscoveryTestCase(UITestCase):
                 host_limit=1,
                 hostgroup=self.config_env['host_group'],
                 search_rule='cpu_count = 1',
-                locations=[self.loc_name],
+                locations=[self.loc.name],
             )
             self.assertIsNotNone(self.discoveryrules.search(rule_name))
             with LibvirtGuest() as pxe_host:
                 host_name = pxe_host.guest_name
-                self.discoveredhosts.assertdiscoveredhost(host_name)
+                self.assertTrue(
+                    self.discoveredhosts.waitfordiscoveredhost(host_name)
+                )
                 self.assertIsNotNone(self.discoveredhosts.search(host_name))
                 # Check that host shouldn't list under all hosts
-                search = self.hosts.search(
-                    u'{0}.{1}'.format(host_name, self.config_env['domain'])
-                )
-                self.assertIsNone(search)
+                self.assertIsNone(self.hosts.search(
+                    u'{0}.{1}'.format(host_name, self.config_env['domain'])))
                 # Check that host still listed under discovered hosts
                 self.assertIsNotNone(self.discoveredhosts.search(host_name))
+                # Revert the discovery_auto flag to default value
+                discovery_auto.value = default_discovery_auto
+                discovery_auto.update(['value'])
 
     @run_only_on('sat')
+    @stubbed()
     @tier3
     def test_negative_create_discovery_rule(self):
         """Create a discovery rule with invalid query
@@ -941,17 +965,17 @@ class DiscoveryTestCase(UITestCase):
             with LibvirtGuest() as pxe_host:
                 host_name = pxe_host.guest_name
                 self.discoveredhosts.assertdiscoveredhost(host_name)
-                self.assertIsNotNone(self.discoveredhosts.search(host_name))
+                self.assertTrue(
+                    self.discoveredhosts.waitfordiscoveredhost(host_name)
+                )
                 self.discoveredhosts.provision_discoveredhost(
                     hostname=host_name,
                     hostgroup=self.config_env['host_group'],
                     org=self.org_name,
-                    loc=self.loc_name,
+                    loc=self.loc.name,
                     new_name=name)
-                search = self.hosts.search(
-                    u'{0}.{1}'.format(name, self.config_env['domain'])
-                )
-                self.assertIsNotNone(search)
+                self.assertIsNotNone(self.hosts.search(
+                    u'{0}.{1}'.format(name, self.config_env['domain'])))
                 # Check that provisioned host is not in the list of discovered
                 # hosts anymore
                 self.assertIsNone(self.discoveredhosts.search(host_name))
@@ -972,10 +996,14 @@ class DiscoveryTestCase(UITestCase):
             session.nav.go_to_select_org(self.org_name)
             with LibvirtGuest() as pxe_1_host:
                 host_1_name = pxe_1_host.guest_name
-                self.discoveredhosts.assertdiscoveredhost(host_1_name)
+                self.assertTrue(
+                    self.discoveredhosts.waitfordiscoveredhost(host_1_name)
+                )
                 with LibvirtGuest() as pxe_2_host:
                     host_2_name = pxe_2_host.guest_name
-                    self.discoveredhosts.assertdiscoveredhost(host_2_name)
+                    self.assertTrue(
+                        self.discoveredhosts.waitfordiscoveredhost(host_2_name)
+                    )
                     # Define a discovery rule
                     make_discoveryrule(
                         session,
@@ -983,19 +1011,15 @@ class DiscoveryTestCase(UITestCase):
                         host_limit=2,
                         hostgroup=self.config_env['host_group'],
                         search_rule='cpu_count = 1',
-                        locations=[self.loc_name],
+                        locations=[self.loc.name],
                     )
                     self.assertIsNotNone(self.discoveryrules.search(rule_name))
-                    session.nav.go_to_discovered_hosts()
-                    self.discoveredhosts.click(
-                        locators["discoveredhosts.auto_provision_all"])
+                    self.discoveredhosts.auto_provision_all()
                     hostnames = [host_1_name, host_2_name]
                     for hostname in hostnames:
-                        search = self.hosts.search(
+                        self.assertIsNotNone(self.hosts.search(
                             u'{0}.{1}'.format(
-                                hostname, self.config_env['domain'])
-                        )
-                        self.assertIsNotNone(search)
+                                hostname, self.config_env['domain'])))
                         # Check that provisioned host is not in the list of
                         # discovered hosts anymore
                         self.assertIsNone(
@@ -1029,7 +1053,9 @@ class DiscoveryTestCase(UITestCase):
             self._edit_discovery_fact_column_param(session, param_value)
             with LibvirtGuest() as pxe_host:
                 hostname = pxe_host.guest_name
-                self.discoveredhosts.assertdiscoveredhost(hostname)
+                self.assertTrue(
+                    self.discoveredhosts.waitfordiscoveredhost(hostname)
+                )
                 element = locators['discoveredhosts.fetch_bios']
                 host_bios = self.discoveredhosts.fetch_fact_value(
                     hostname, element)
@@ -1062,7 +1088,9 @@ class DiscoveryTestCase(UITestCase):
             self._edit_discovery_fact_column_param(session, param_value)
             with LibvirtGuest() as pxe_host:
                 hostname = pxe_host.guest_name
-                self.discoveredhosts.assertdiscoveredhost(hostname)
+                self.assertTrue(
+                    self.discoveredhosts.waitfordiscoveredhost(hostname)
+                )
                 element = (
                     locators['discoveredhosts.fetch_fact'] % expected_value
                 )
@@ -1185,17 +1213,17 @@ class DiscoveryTestCase(UITestCase):
             session.nav.go_to_select_org(self.org_name)
             with LibvirtGuest() as pxe_host:
                 host_name = pxe_host.guest_name
-                self.discoveredhosts.assertdiscoveredhost(host_name)
+                self.assertTrue(
+                    self.discoveredhosts.waitfordiscoveredhost(host_name)
+                )
                 self.assertIsNotNone(self.discoveredhosts.search(host_name))
                 self.discoveredhosts.provision_discoveredhost(
                     hostname=host_name,
                     hostgroup=self.config_env['host_group'],
                     org=self.org_name,
-                    loc=self.loc_name)
-                search = self.hosts.search(
-                    u'{0}.{1}'.format(host_name, self.config_env['domain'])
-                )
-                self.assertIsNotNone(search)
+                    loc=self.loc.name)
+                self.assertIsNotNone(self.hosts.search(
+                    u'{0}.{1}'.format(host_name, self.config_env['domain'])))
                 # Check that provisioned host is not in the list of discovered
                 # hosts anymore
                 self.assertIsNone(self.discoveredhosts.search(host_name))
@@ -1222,18 +1250,18 @@ class DiscoveryTestCase(UITestCase):
             session.nav.go_to_select_org(self.org_name)
             with LibvirtGuest() as pxe_host:
                 host_name = pxe_host.guest_name
-                self.discoveredhosts.assertdiscoveredhost(host_name)
+                self.assertTrue(
+                    self.discoveredhosts.waitfordiscoveredhost(host_name)
+                )
                 self.assertIsNotNone(self.discoveredhosts.search(host_name))
                 self.discoveredhosts.provision_discoveredhost(
                     hostname=host_name,
                     hostgroup=self.config_env['host_group'],
                     org=self.org_name,
-                    loc=self.loc_name,
+                    loc=self.loc.name,
                     quick_create=True)
-                search = self.hosts.search(
-                    u'{0}.{1}'.format(host_name, self.config_env['domain'])
-                )
-                self.assertIsNotNone(search)
+                self.assertIsNotNone(self.hosts.search(
+                    u'{0}.{1}'.format(host_name, self.config_env['domain'])))
                 # Check that provisioned host is not in the list of discovered
                 # hosts anymore
                 self.assertIsNone(self.discoveredhosts.search(host_name))
@@ -1412,6 +1440,7 @@ class DiscoveryPrefixTestCase(UITestCase):
 
     @classmethod
     def setUpClass(cls):
+        """Update discovery prefix with some string than default 'mac'"""
         super(DiscoveryPrefixTestCase, cls).setUpClass()
         cls.org = entities.Organization(name=gen_string('alpha')).create()
         cls.org_name = cls.org.name
@@ -1421,17 +1450,17 @@ class DiscoveryPrefixTestCase(UITestCase):
             query={'search': 'name="discovery_prefix"'})[0]
         cls.default_prefix = str(cls.discovery_prefix.value)
         cls.discovery_prefix.value = cls.prefix
-        cls.discovery_prefix.update({'value'})
+        cls.discovery_prefix.update(['value'])
         cls.discovery_org = entities.Setting().search(
             query={'search': 'name="discovery_organization"'})[0]
         cls.discovery_org.value = cls.org.name
-        cls.discovery_org.update({'value'})
+        cls.discovery_org.update(['value'])
 
     @classmethod
     def tearDownClass(cls):
         """Restore default 'hostname_prefix' global setting's value"""
         cls.discovery_prefix.value = cls.default_prefix
-        cls.discovery_prefix.update({'value'})
+        cls.discovery_prefix.update(['value'])
 
         super(DiscoveryPrefixTestCase, cls).tearDownClass()
 
@@ -1460,5 +1489,7 @@ class DiscoveryPrefixTestCase(UITestCase):
                 host_name = '{0}{1}'.format(
                     self.prefix, host_mac.replace(':', "")
                 )
-                self.discoveredhosts.assertdiscoveredhost(host_name)
+                self.assertTrue(
+                    self.discoveredhosts.waitfordiscoveredhost(host_name)
+                )
                 self.assertIsNotNone(self.discoveredhosts.search(host_name))

--- a/tests/foreman/ui/test_discoveredhost.py
+++ b/tests/foreman/ui/test_discoveredhost.py
@@ -27,11 +27,15 @@ from robottelo.decorators import (
     stubbed,
     tier3
 )
+from robottelo.api.utils import configure_provisioning
 from robottelo.libvirt_discovery import LibvirtGuest
 from robottelo.test import UITestCase
 from robottelo.ui.base import UIError
-from robottelo.ui.factory import edit_param
-from robottelo.ui.locators import locators, tab_locators
+from robottelo.ui.factory import (
+    edit_param,
+    make_discoveryrule,
+)
+from robottelo.ui.locators import common_locators, locators, tab_locators
 from robottelo.ui.session import Session
 from time import sleep
 
@@ -39,21 +43,6 @@ from time import sleep
 @run_in_one_thread
 class DiscoveryTestCase(UITestCase):
     """Implements Foreman discovery tests in UI."""
-
-    def _assertdiscoveredhost(self, hostname):
-        """
-        Check if host is visible under 'Discovered Hosts' on UI
-
-        Introduced a delay of 300secs by polling every 10 secs to see if
-        unknown host gets discovered and become visible on UI
-        """
-        discovered_host = self.discoveredhosts.search(hostname)
-        for _ in range(30):
-            if discovered_host is None:
-                sleep(10)
-                discovered_host = self.discoveredhosts.search(hostname)
-            else:
-                break
 
     def _edit_discovery_fact_column_param(self, session, param_value):
         """
@@ -123,6 +112,7 @@ class DiscoveryTestCase(UITestCase):
             name=gen_string('alpha'),
             organization=[cls.org],
         ).create()
+        cls.loc_name = cls.loc.name
 
         # Update default org and location params to place discovered host
         cls.discovery_loc = entities.Setting().search(
@@ -140,6 +130,8 @@ class DiscoveryTestCase(UITestCase):
         cls.default_discovery_auto = str(cls.discovery_auto.value)
         cls.discovery_auto.value = 'True'
         cls.discovery_auto.update({'value'})
+
+        cls.config_env = configure_provisioning(org=cls.org, loc=cls.loc)
 
     @classmethod
     def tearDownClass(cls):
@@ -170,7 +162,7 @@ class DiscoveryTestCase(UITestCase):
             session.nav.go_to_select_org(self.org_name)
             with LibvirtGuest() as pxe_host:
                 hostname = pxe_host.guest_name
-                self._assertdiscoveredhost(hostname)
+                self.discoveredhosts.assertdiscoveredhost(hostname)
                 self.assertIsNotNone(self.discoveredhosts.search(hostname))
 
     @run_only_on('sat')
@@ -194,7 +186,7 @@ class DiscoveryTestCase(UITestCase):
             session.nav.go_to_select_org(self.org_name)
             with LibvirtGuest(boot_iso=True) as pxe_less_host:
                 hostname = pxe_less_host.guest_name
-                self._assertdiscoveredhost(hostname)
+                self.discoveredhosts.assertdiscoveredhost(hostname)
                 self.assertIsNotNone(self.discoveredhosts.search(hostname))
 
     @run_only_on('sat')
@@ -335,7 +327,7 @@ class DiscoveryTestCase(UITestCase):
             self._edit_discovery_fact_column_param(session, "interfaces")
             with LibvirtGuest(boot_iso=True, extra_nic=True) as pxe_less_host:
                 hostname = pxe_less_host.guest_name
-                self._assertdiscoveredhost(hostname)
+                self.discoveredhosts.assertdiscoveredhost(hostname)
                 self.assertIsNotNone(self.discoveredhosts.search(hostname))
                 element = locators['discoveredhosts.fetch_interfaces']
                 host_interfaces = self.discoveredhosts.fetch_fact_value(
@@ -408,7 +400,7 @@ class DiscoveryTestCase(UITestCase):
             self._edit_discovery_fact_column_param(session, "interfaces")
             with LibvirtGuest(extra_nic=True) as pxe_host:
                 hostname = pxe_host.guest_name
-                self._assertdiscoveredhost(hostname)
+                self.discoveredhosts.assertdiscoveredhost(hostname)
                 self.assertIsNotNone(self.discoveredhosts.search(hostname))
                 element = locators['discoveredhosts.fetch_interfaces']
                 host_interfaces = self.discoveredhosts.fetch_fact_value(
@@ -438,33 +430,13 @@ class DiscoveryTestCase(UITestCase):
             self._edit_discovery_fact_column_param(session, param_value)
             with LibvirtGuest(boot_iso=True) as pxe_less_host:
                 hostname = pxe_less_host.guest_name
-                self._assertdiscoveredhost(hostname)
+                self.discoveredhosts.assertdiscoveredhost(hostname)
                 element = locators['discoveredhosts.fetch_custom_fact']
                 custom_fact = self.discoveredhosts.fetch_fact_value(
                     hostname, element)
                 self.assertEqual(u'somevalue', custom_fact)
 
     @run_only_on('sat')
-    @stubbed()
-    @tier3
-    def test_positive_provision(self):
-        """Provision the selected discovered host by selecting
-        'provision' button from 'Discovered Host' page.
-
-        @id: 81df99e3-6d24-4bbf-9121-cffb927efe39
-
-        @Setup: Host should already be discovered
-
-        @Assert: Host should be provisioned successfully and entry from
-        discovered host should be auto removed
-
-        @caseautomation: notautomated
-
-        @CaseLevel: System
-        """
-
-    @run_only_on('sat')
-    @stubbed()
     @tier3
     def test_positive_provision_from_facts(self):
         """Provision the selected discovered host from facts page by
@@ -477,10 +449,29 @@ class DiscoveryTestCase(UITestCase):
         @Assert: Host should be provisioned successfully and entry from
         discovered host should be auto removed
 
-        @caseautomation: notautomated
-
         @CaseLevel: System
         """
+        with Session(self.browser) as session:
+            session.nav.go_to_select_org(self.org_name)
+            with LibvirtGuest() as pxe_host:
+                host_name = pxe_host.guest_name
+                self.discoveredhosts.assertdiscoveredhost(host_name)
+                self.discoveredhosts.provision_discoveredhost(
+                    hostname=host_name,
+                    hostgroup=self.config_env['host_group'],
+                    org=self.org_name,
+                    loc=self.loc_name,
+                    facts_page=True,
+                    quick_create=True)
+                self.assertIsNotNone(self.discoveredhosts.wait_until_element(
+                    common_locators['notif.success']))
+                search = self.hosts.search(
+                    u'{0}.{1}'.format(host_name, self.config_env['domain'])
+                )
+                self.assertIsNotNone(search)
+                # Check that provisioned host is not in the list of discovered
+                # hosts anymore
+                self.assertIsNone(self.discoveredhosts.search(host_name))
 
     @run_only_on('sat')
     @tier3
@@ -500,7 +491,7 @@ class DiscoveryTestCase(UITestCase):
             session.nav.go_to_select_org(self.org_name)
             with LibvirtGuest() as pxe_host:
                 hostname = pxe_host.guest_name
-                self._assertdiscoveredhost(hostname)
+                self.discoveredhosts.assertdiscoveredhost(hostname)
                 self.discoveredhosts.delete(hostname)
 
     @run_only_on('sat')
@@ -521,7 +512,7 @@ class DiscoveryTestCase(UITestCase):
             session.nav.go_to_select_org(self.org_name)
             with LibvirtGuest() as pxe_host:
                 hostname = pxe_host.guest_name
-                self._assertdiscoveredhost(hostname)
+                self.discoveredhosts.assertdiscoveredhost(hostname)
                 self.discoveredhosts.delete_from_facts(hostname)
                 self.assertIsNone(self.discoveredhosts.search(hostname))
 
@@ -544,10 +535,10 @@ class DiscoveryTestCase(UITestCase):
             session.nav.go_to_select_org(self.org_name)
             with LibvirtGuest() as pxe_1_host:
                 host_1_name = pxe_1_host.guest_name
-                self._assertdiscoveredhost(host_1_name)
+                self.discoveredhosts.assertdiscoveredhost(host_1_name)
                 with LibvirtGuest() as pxe_2_host:
                     host_2_name = pxe_2_host.guest_name
-                    self._assertdiscoveredhost(host_2_name)
+                    self.discoveredhosts.assertdiscoveredhost(host_2_name)
                     hostnames = [host_1_name, host_2_name]
                     for hostname in hostnames:
                         host = self.discoveredhosts.search(hostname)
@@ -585,7 +576,7 @@ class DiscoveryTestCase(UITestCase):
             self._edit_discovery_fact_column_param(session, param_value)
             with LibvirtGuest() as pxe_host:
                 hostname = pxe_host.guest_name
-                self._assertdiscoveredhost(hostname)
+                self.discoveredhosts.assertdiscoveredhost(hostname)
                 self.assertIsNotNone(self.discoveredhosts.search(hostname))
                 # To add a new network interface on discovered host
                 pxe_host.attach_nic()
@@ -616,7 +607,7 @@ class DiscoveryTestCase(UITestCase):
             self._edit_discovery_fact_column_param(session, 'interfaces')
             with LibvirtGuest(boot_iso=True) as pxe_less_host:
                 hostname = pxe_less_host.guest_name
-                self._assertdiscoveredhost(hostname)
+                self.discoveredhosts.assertdiscoveredhost(hostname)
                 self.assertIsNotNone(self.discoveredhosts.search(hostname))
                 # To add a new network interface on discovered host
                 pxe_less_host.attach_nic()
@@ -645,7 +636,7 @@ class DiscoveryTestCase(UITestCase):
             session.nav.go_to_select_org(self.org_name)
             with LibvirtGuest() as pxe_host:
                 hostname = pxe_host.guest_name
-                self._assertdiscoveredhost(hostname)
+                self.discoveredhosts.assertdiscoveredhost(hostname)
                 element = (locators['discoveredhosts.fetch_ip'] % hostname)
                 # Get the IP of discovered host
                 host_ip = self.discoveredhosts.fetch_fact_value(
@@ -677,10 +668,10 @@ class DiscoveryTestCase(UITestCase):
             session.nav.go_to_select_org(self.org_name)
             with LibvirtGuest() as pxe_1_host:
                 host_1_name = pxe_1_host.guest_name
-                self._assertdiscoveredhost(host_1_name)
+                self.discoveredhosts.assertdiscoveredhost(host_1_name)
                 with LibvirtGuest() as pxe_2_host:
                     host_2_name = pxe_2_host.guest_name
-                    self._assertdiscoveredhost(host_2_name)
+                    self.discoveredhosts.assertdiscoveredhost(host_2_name)
                     hostnames = [host_1_name, host_2_name]
                     for hostname in hostnames:
                         host = self.discoveredhosts.search(hostname)
@@ -689,11 +680,10 @@ class DiscoveryTestCase(UITestCase):
                                 'Could not find the selected discovered host '
                                 '"{0}"'.format(hostname)
                             )
-                        self.discoveredhosts.navigate_to_entity()
-                    self.discoveredhosts.update_org(hostnames, new_org)
+                    self.discoveredhosts.navigate_to_entity()
+                    self.discoveredhosts.update_org_loc(hostnames, new_org)
 
     @run_only_on('sat')
-    @stubbed()
     @tier3
     def test_positive_update_default_location(self):
         """Change the default location of more than one discovered hosts
@@ -706,15 +696,32 @@ class DiscoveryTestCase(UITestCase):
         @Assert: Default Location should be successfully changed for multiple
         hosts
 
-        @caseautomation: notautomated
-
         @CaseLevel: System
         """
+        loc = gen_string('alpha')
+        entities.Location(name=loc).create()
+        with Session(self.browser) as session:
+            session.nav.go_to_select_org(self.org_name)
+            with LibvirtGuest() as pxe_1_host:
+                host_1_name = pxe_1_host.guest_name
+                self.discoveredhosts.assertdiscoveredhost(host_1_name)
+                with LibvirtGuest() as pxe_2_host:
+                    host_2_name = pxe_2_host.guest_name
+                    self.discoveredhosts.assertdiscoveredhost(host_2_name)
+                    hostnames = [host_1_name, host_2_name]
+                    for hostname in hostnames:
+                        host = self.discoveredhosts.search(hostname)
+                        if not host:
+                            raise UIError(
+                                'Could not find the selected discovered host '
+                                '"{0}"'.format(hostname)
+                            )
+                    self.discoveredhosts.navigate_to_entity()
+                    self.discoveredhosts.update_org_loc(hostnames, new_loc=loc)
 
     @run_only_on('sat')
-    @stubbed()
     @tier3
-    def test_positive_provision_host_with_rule(self):
+    def test_positive_auto_provision_host_with_rule(self):
         """Create a new discovery rule and provision a discovered host using
         that discovery rule.
 
@@ -726,10 +733,59 @@ class DiscoveryTestCase(UITestCase):
 
         @Assert: Host should reboot and provision
 
+        @CaseLevel: System
+
         @caseautomation: notautomated
+        """
+
+    @run_only_on('sat')
+    @stubbed()
+    @tier3
+    def test_positive_manual_provision_host_with_rule(self):
+        """Create a new discovery rule and manually provision a discovered host using
+        that discovery rule.
+
+        Set query as (e.g IP=IP_of_discovered_host)
+
+        @id: 4488ab9a-d462-4a62-a1a1-e5656c8a8b99
+
+        @Setup: Host should already be discovered
+
+        @Assert: Host should reboot and provision
 
         @CaseLevel: System
         """
+        rule_name = gen_string('alpha')
+        with Session(self.browser) as session:
+            session.nav.go_to_select_org(self.org_name)
+            with LibvirtGuest() as pxe_host:
+                host_name = pxe_host.guest_name
+                self.discoveredhosts.assertdiscoveredhost(host_name)
+                self.assertIsNotNone(self.discoveredhosts.search(host_name))
+                element = (locators['discoveredhosts.fetch_ip'] % host_name)
+                # Get the IP of discovered host
+                host_ip = self.discoveredhosts.fetch_fact_value(
+                    host_name, element)
+                # Define a discovery rule with IP_address
+                make_discoveryrule(
+                        session,
+                        name=rule_name,
+                        host_limit=1,
+                        hostgroup=self.config_env['host_group'],
+                        search_rule=host_ip,
+                        locations=[self.loc_name],
+                )
+                self.assertIsNotNone(self.discoveryrules.search(rule_name))
+                self.discoveredhosts.auto_provision(host_name)
+                self.assertIsNotNone(self.discoveredhosts.wait_until_element(
+                    common_locators['notif.success']))
+                search = self.hosts.search(
+                    u'{0}.{1}'.format(host_name, self.config_env['domain'])
+                )
+                self.assertIsNotNone(search)
+                # Check that provisioned host is not in the list of discovered
+                # hosts anymore
+                self.assertIsNone(self.discoveredhosts.search(host_name))
 
     @run_only_on('sat')
     @stubbed()
@@ -770,7 +826,6 @@ class DiscoveryTestCase(UITestCase):
         """
 
     @run_only_on('sat')
-    @stubbed()
     @tier3
     def test_positive_provision_without_auto_provision(self):
         """Create a discovery rule and execute it when
@@ -782,13 +837,39 @@ class DiscoveryTestCase(UITestCase):
 
         @Assert: Host should not be rebooted automatically
 
-        @caseautomation: notautomated
-
         @CaseLevel: System
         """
+        # Disable flag to auto provision discovered hosts via discovery rules
+        discovery_auto = entities.Setting().search(
+            query={'search': 'name="discovery_auto"'})[0]
+        discovery_auto.value = 'False'
+        discovery_auto.update({'value'})
+        rule_name = gen_string('alpha')
+        with Session(self.browser) as session:
+            session.nav.go_to_select_org(self.org_name)
+            # Define a discovery rule
+            make_discoveryrule(
+                session,
+                name=rule_name,
+                host_limit=1,
+                hostgroup=self.config_env['host_group'],
+                search_rule='cpu_count = 1',
+                locations=[self.loc_name],
+            )
+            self.assertIsNotNone(self.discoveryrules.search(rule_name))
+            with LibvirtGuest() as pxe_host:
+                host_name = pxe_host.guest_name
+                self.discoveredhosts.assertdiscoveredhost(host_name)
+                self.assertIsNotNone(self.discoveredhosts.search(host_name))
+                # Check that host shouldn't list under all hosts
+                search = self.hosts.search(
+                    u'{0}.{1}'.format(host_name, self.config_env['domain'])
+                )
+                self.assertIsNone(search)
+                # Check that host still listed under discovered hosts
+                self.assertIsNotNone(self.discoveredhosts.search(host_name))
 
     @run_only_on('sat')
-    @stubbed()
     @tier3
     def test_negative_create_discovery_rule(self):
         """Create a discovery rule with invalid query
@@ -800,8 +881,6 @@ class DiscoveryTestCase(UITestCase):
 
         @Assert: Rule should automatically be skipped on clicking
         'Auto provision'. UI Should raise 'No matching rule found'
-
-        @caseautomation: notautomated
 
         @CaseLevel: System
         """
@@ -844,7 +923,6 @@ class DiscoveryTestCase(UITestCase):
         """
 
     @run_only_on('sat')
-    @stubbed()
     @tier3
     def test_positive_update_name(self):
         """Update the discovered host name and provision it
@@ -855,37 +933,30 @@ class DiscoveryTestCase(UITestCase):
 
         @Assert: The hostname should be updated and host should be provisioned
 
-        @caseautomation: notautomated
-
         @CaseLevel: System
         """
+        name = gen_string('alpha')
+        with Session(self.browser) as session:
+            session.nav.go_to_select_org(self.org_name)
+            with LibvirtGuest() as pxe_host:
+                host_name = pxe_host.guest_name
+                self.discoveredhosts.assertdiscoveredhost(host_name)
+                self.assertIsNotNone(self.discoveredhosts.search(host_name))
+                self.discoveredhosts.provision_discoveredhost(
+                    hostname=host_name,
+                    hostgroup=self.config_env['host_group'],
+                    org=self.org_name,
+                    loc=self.loc_name,
+                    new_name=name)
+                search = self.hosts.search(
+                    u'{0}.{1}'.format(name, self.config_env['domain'])
+                )
+                self.assertIsNotNone(search)
+                # Check that provisioned host is not in the list of discovered
+                # hosts anymore
+                self.assertIsNone(self.discoveredhosts.search(host_name))
 
     @run_only_on('sat')
-    @stubbed()
-    @tier3
-    def test_positive_update_discovery_prefix(self):
-        """Update the discovery_prefix parameter other than mac
-
-        @id: 08f1d852-e9a0-430e-b73a-e2a7a144ac10
-
-        @Steps:
-
-        1. Goto settings &#8592; Discovered tab -> discovery_prefix
-
-        2. Edit discovery_prefix using any text that must start with a letter
-
-        @Setup: Host should already be discovered
-
-        @Assert: discovery_prefix is updated and provisioned host has same
-        prefix in its hostname
-
-        @caseautomation: notautomated
-
-        @CaseLevel: System
-        """
-
-    @run_only_on('sat')
-    @stubbed()
     @tier3
     def test_positive_auto_provision_all(self):
         """Discover a bunch of hosts and auto-provision all
@@ -894,10 +965,41 @@ class DiscoveryTestCase(UITestCase):
 
         @Assert: All host should be successfully rebooted and provisioned
 
-        @caseautomation: notautomated
-
         @CaseLevel: System
         """
+        rule_name = gen_string('alpha')
+        with Session(self.browser) as session:
+            session.nav.go_to_select_org(self.org_name)
+            with LibvirtGuest() as pxe_1_host:
+                host_1_name = pxe_1_host.guest_name
+                self.discoveredhosts.assertdiscoveredhost(host_1_name)
+                with LibvirtGuest() as pxe_2_host:
+                    host_2_name = pxe_2_host.guest_name
+                    self.discoveredhosts.assertdiscoveredhost(host_2_name)
+                    # Define a discovery rule
+                    make_discoveryrule(
+                        session,
+                        name=rule_name,
+                        host_limit=2,
+                        hostgroup=self.config_env['host_group'],
+                        search_rule='cpu_count = 1',
+                        locations=[self.loc_name],
+                    )
+                    self.assertIsNotNone(self.discoveryrules.search(rule_name))
+                    session.nav.go_to_discovered_hosts()
+                    self.discoveredhosts.click(
+                        locators["discoveredhosts.auto_provision_all"])
+                    hostnames = [host_1_name, host_2_name]
+                    for hostname in hostnames:
+                        search = self.hosts.search(
+                            u'{0}.{1}'.format(
+                                hostname, self.config_env['domain'])
+                        )
+                        self.assertIsNotNone(search)
+                        # Check that provisioned host is not in the list of
+                        # discovered hosts anymore
+                        self.assertIsNone(
+                            self.discoveredhosts.search(hostname))
 
     @run_only_on('sat')
     @tier3
@@ -927,14 +1029,13 @@ class DiscoveryTestCase(UITestCase):
             self._edit_discovery_fact_column_param(session, param_value)
             with LibvirtGuest() as pxe_host:
                 hostname = pxe_host.guest_name
-                self._assertdiscoveredhost(hostname)
+                self.discoveredhosts.assertdiscoveredhost(hostname)
                 element = locators['discoveredhosts.fetch_bios']
                 host_bios = self.discoveredhosts.fetch_fact_value(
                     hostname, element)
                 self.assertEqual(u'Seabios', host_bios)
 
     @run_only_on('sat')
-    @stubbed()
     @tier3
     def test_negative_add_fact(self):
         """Add a new fact column with invalid fact to display on
@@ -945,18 +1046,29 @@ class DiscoveryTestCase(UITestCase):
         @Steps:
 
         1. Goto settings -> Discovered tab -> discovery_fact_coloumn
-
         2. Edit discovery_fact_coloumn
-
         3. Add 'test'
 
         @Assert: The added fact should be displayed on 'discovered_host' page
         after successful discovery and shows 'N/A'
 
-        @caseautomation: notautomated
-
         @CaseLevel: System
         """
+        param_value = 'test'
+        expected_value = u'N/A'
+        with Session(self.browser) as session:
+            session.nav.go_to_select_org(self.org_name)
+            # To show new fact column 'Interfaces' on Discovered Hosts page
+            self._edit_discovery_fact_column_param(session, param_value)
+            with LibvirtGuest() as pxe_host:
+                hostname = pxe_host.guest_name
+                self.discoveredhosts.assertdiscoveredhost(hostname)
+                element = (
+                    locators['discoveredhosts.fetch_fact'] % expected_value
+                )
+                fact_value = self.discoveredhosts.fetch_fact_value(
+                    hostname, element)
+                self.assertEqual(expected_value, fact_value)
 
     @run_only_on('sat')
     @stubbed()
@@ -1057,7 +1169,6 @@ class DiscoveryTestCase(UITestCase):
         """
 
     @run_only_on('sat')
-    @stubbed()
     @tier3
     def test_positive_provision_with_hostgroup_from_new_model_window(self):
         """Provision a discovered host manually by associating hostgroup from
@@ -1065,15 +1176,31 @@ class DiscoveryTestCase(UITestCase):
 
         @id: f17fb8c9-f9cb-4547-80bc-3b40c6691bb1
 
-        @Assert: Provisioned host is created with selected host-group
-
-        @caseautomation: notautomated
+        @Assert: Provisioned host is created with selected host-group and entry
+        from discovered host should be auto removed.
 
         @CaseLevel: System
         """
+        with Session(self.browser) as session:
+            session.nav.go_to_select_org(self.org_name)
+            with LibvirtGuest() as pxe_host:
+                host_name = pxe_host.guest_name
+                self.discoveredhosts.assertdiscoveredhost(host_name)
+                self.assertIsNotNone(self.discoveredhosts.search(host_name))
+                self.discoveredhosts.provision_discoveredhost(
+                    hostname=host_name,
+                    hostgroup=self.config_env['host_group'],
+                    org=self.org_name,
+                    loc=self.loc_name)
+                search = self.hosts.search(
+                    u'{0}.{1}'.format(host_name, self.config_env['domain'])
+                )
+                self.assertIsNotNone(search)
+                # Check that provisioned host is not in the list of discovered
+                # hosts anymore
+                self.assertIsNone(self.discoveredhosts.search(host_name))
 
     @run_only_on('sat')
-    @stubbed()
     @tier3
     def test_positive_provision_using_quick_host_button(self):
         """Associate hostgroup while provisioning a discovered host from
@@ -1086,12 +1213,30 @@ class DiscoveryTestCase(UITestCase):
         1. Host should already be discovered
         2. Hostgroup should already be created with all required entities.
 
-        @Assert: Host should be quickly provisionioned.
-
-        @caseautomation: notautomated
+        @Assert: Host should be quickly provisioned and entry from
+        discovered host should be auto removed.
 
         @CaseLevel: System
         """
+        with Session(self.browser) as session:
+            session.nav.go_to_select_org(self.org_name)
+            with LibvirtGuest() as pxe_host:
+                host_name = pxe_host.guest_name
+                self.discoveredhosts.assertdiscoveredhost(host_name)
+                self.assertIsNotNone(self.discoveredhosts.search(host_name))
+                self.discoveredhosts.provision_discoveredhost(
+                    hostname=host_name,
+                    hostgroup=self.config_env['host_group'],
+                    org=self.org_name,
+                    loc=self.loc_name,
+                    quick_create=True)
+                search = self.hosts.search(
+                    u'{0}.{1}'.format(host_name, self.config_env['domain'])
+                )
+                self.assertIsNotNone(search)
+                # Check that provisioned host is not in the list of discovered
+                # hosts anymore
+                self.assertIsNone(self.discoveredhosts.search(host_name))
 
     @run_only_on('sat')
     @stubbed()
@@ -1260,3 +1405,60 @@ class DiscoveryTestCase(UITestCase):
 
         @CaseLevel: System
         """
+
+
+class DiscoveryPrefixTestCase(UITestCase):
+    """Test around updating Discovery Prefix"""
+
+    @classmethod
+    def setUpClass(cls):
+        super(DiscoveryPrefixTestCase, cls).setUpClass()
+        cls.org = entities.Organization(name=gen_string('alpha')).create()
+        cls.org_name = cls.org.name
+        # Update hostname_prefix with some string other than default 'mac'
+        cls.prefix = 'dhost'
+        cls.discovery_prefix = entities.Setting().search(
+            query={'search': 'name="discovery_prefix"'})[0]
+        cls.default_prefix = str(cls.discovery_prefix.value)
+        cls.discovery_prefix.value = cls.prefix
+        cls.discovery_prefix.update({'value'})
+        cls.discovery_org = entities.Setting().search(
+            query={'search': 'name="discovery_organization"'})[0]
+        cls.discovery_org.value = cls.org.name
+        cls.discovery_org.update({'value'})
+
+    @classmethod
+    def tearDownClass(cls):
+        """Restore default 'hostname_prefix' global setting's value"""
+        cls.discovery_prefix.value = cls.default_prefix
+        cls.discovery_prefix.update({'value'})
+
+        super(DiscoveryPrefixTestCase, cls).tearDownClass()
+
+    @run_only_on('sat')
+    @tier3
+    def test_positive_update_discovery_prefix(self):
+        """Update the discovery_prefix parameter other than mac
+
+        @id: 08f1d852-e9a0-430e-b73a-e2a7a144ac10
+
+        @Steps:
+
+        1. Goto settings -> Discovered tab -> discovery_prefix
+        2. Edit discovery_prefix using any text that must start with a letter
+
+        @Setup: Host should already be discovered
+
+        @Assert: Host should be discovered with updated prefix.
+
+        @CaseLevel: System
+        """
+        with Session(self.browser) as session:
+            session.nav.go_to_select_org(self.org_name)
+            with LibvirtGuest() as pxe_host:
+                host_mac = pxe_host.mac
+                host_name = '{0}{1}'.format(
+                    self.prefix, host_mac.replace(':', "")
+                )
+                self.discoveredhosts.assertdiscoveredhost(host_name)
+                self.assertIsNotNone(self.discoveredhosts.search(host_name))

--- a/tests/foreman/ui/test_discoveryrule.py
+++ b/tests/foreman/ui/test_discoveryrule.py
@@ -57,6 +57,9 @@ class DiscoveryRuleTestCase(UITestCase):
     @classmethod
     def set_session_org(cls):
         cls.session_org = entities.Organization().create()
+        cls.session_loc = entities.Location(
+            organization=[cls.session_org]
+        ).create()
 
     @classmethod
     def setUpClass(cls):
@@ -68,7 +71,9 @@ class DiscoveryRuleTestCase(UITestCase):
         cls.per_page.value = '100000'
         cls.per_page.update({'value'})
         cls.host_group = entities.HostGroup(
-            organization=[cls.session_org]).create()
+            organization=[cls.session_org],
+            location=[cls.session_loc],
+        ).create()
 
     @classmethod
     def tearDownClass(cls):
@@ -137,6 +142,7 @@ class DiscoveryRuleTestCase(UITestCase):
             make_discoveryrule(
                 session,
                 name=name,
+                locations=[self.session_loc.name],
                 hostgroup=self.host_group.name,
                 hostname=hostname,
             )


### PR DESCRIPTION
Connected to #4053

- Updated `create` discovery_rule method to support org/location association
- Added 10 new tests around discoveredhost provisioning/auto-provisioning