### PR TITLE
Issue #4044, use new rhel73 base images

### DIFF
--- a/robottelo/constants.py
+++ b/robottelo/constants.py
@@ -129,7 +129,7 @@ CUST_PERMS_LIST = [
 ]
 
 DISTRO_RHEL6 = "rhel68"
-DISTRO_RHEL7 = "rhel72"
+DISTRO_RHEL7 = "rhel73"
 
 FOREMAN_PROVIDERS = {
     'libvirt': 'Libvirt',


### PR DESCRIPTION
Small Change to update the constant variable to use new , rhel73 baseOS image