### PR TITLE
[6.2.z] Cherry-pick of SRPM/DRPM tests

### DIFF
--- a/robottelo/constants.py
+++ b/robottelo/constants.py
@@ -335,6 +335,9 @@ FAKE_2_YUM_REPO = u'http://inecas.fedorapeople.org/fakerepos/zoo2/'
 FAKE_3_YUM_REPO = u'http://omaciel.fedorapeople.org/fakerepo01'
 FAKE_4_YUM_REPO = u'http://omaciel.fedorapeople.org/fakerepo02'
 FAKE_5_YUM_REPO = u'http://{0}:{1}@rplevka.fedorapeople.org/fakerepo01/'
+FAKE_YUM_DRPM_REPO = (
+    u'https://repos.fedorapeople.org/repos/pulp/pulp/fixtures/drpm/'
+)
 FAKE_YUM_SRPM_REPO = (
     u'https://repos.fedorapeople.org/repos/pulp/pulp/fixtures/srpm/'
 )

--- a/robottelo/constants.py
+++ b/robottelo/constants.py
@@ -335,6 +335,9 @@ FAKE_2_YUM_REPO = u'http://inecas.fedorapeople.org/fakerepos/zoo2/'
 FAKE_3_YUM_REPO = u'http://omaciel.fedorapeople.org/fakerepo01'
 FAKE_4_YUM_REPO = u'http://omaciel.fedorapeople.org/fakerepo02'
 FAKE_5_YUM_REPO = u'http://{0}:{1}@rplevka.fedorapeople.org/fakerepo01/'
+FAKE_YUM_SRPM_REPO = (
+    u'https://repos.fedorapeople.org/repos/pulp/pulp/fixtures/srpm/'
+)
 FAKE_0_PUPPET_REPO = u'http://davidd.fedorapeople.org/repos/random_puppet/'
 FAKE_1_PUPPET_REPO = u'http://omaciel.fedorapeople.org/fakepuppet01'
 FAKE_2_PUPPET_REPO = u'http://omaciel.fedorapeople.org/fakepuppet02'

--- a/tests/foreman/api/test_repository.py
+++ b/tests/foreman/api/test_repository.py
@@ -654,23 +654,6 @@ class RepositoryTestCase(APITestCase):
         # Verify the repository's contents.
         self.assertEqual(repo.read().content_counts['rpm'], 1)
 
-    @skip_if_bug_open('bugzilla', 1378442)
-    @run_only_on('sat')
-    @tier1
-    def test_positive_upload_contents_srpm(self):
-        """Create a repository and upload SRPM contents.
-
-        @id: e091a725-048f-44ca-90cc-c016c450ced9
-
-        @Assert: The repository's contents include one SRPM.
-        """
-        # Create a repository and upload source RPM content.
-        repo = entities.Repository(product=self.product).create()
-        with open(get_data_file(SRPM_TO_UPLOAD), 'rb') as handle:
-            repo.upload_content(files={'content': handle})
-        # Verify the repository's contents.
-        self.assertEqual(repo.read().content_counts['rpm'], 1)
-
     @run_only_on('sat')
     @tier1
     def test_negative_update_name(self):
@@ -1016,6 +999,23 @@ class SRPMRepositoryTestCase(APITestCase):
         super(SRPMRepositoryTestCase, cls).setUpClass()
         cls.org = entities.Organization().create()
         cls.product = entities.Product(organization=cls.org).create()
+
+    @skip_if_bug_open('bugzilla', 1378442)
+    @run_only_on('sat')
+    @tier1
+    def test_positive_upload_contents_srpm(self):
+        """Create a repository and upload SRPM contents.
+
+        @id: e091a725-048f-44ca-90cc-c016c450ced9
+
+        @Assert: The repository's contents include one SRPM.
+        """
+        # Create a repository and upload source RPM content.
+        repo = entities.Repository(product=self.product).create()
+        with open(get_data_file(SRPM_TO_UPLOAD), 'rb') as handle:
+            repo.upload_content(files={'content': handle})
+        # Verify the repository's contents.
+        self.assertEqual(repo.read().content_counts['rpm'], 1)
 
     @tier2
     def test_positive_sync(self):

--- a/tests/foreman/api/test_repository.py
+++ b/tests/foreman/api/test_repository.py
@@ -30,6 +30,7 @@ from robottelo.constants import (
     FAKE_7_PUPPET_REPO,
     FAKE_2_YUM_REPO,
     FAKE_5_YUM_REPO,
+    FAKE_YUM_DRPM_REPO,
     FAKE_YUM_SRPM_REPO,
     PRDS,
     REPOS,
@@ -1097,6 +1098,109 @@ class SRPMRepositoryTestCase(APITestCase):
         result = ssh.command(
             'ls /var/lib/pulp/published/yum/https/repos/{}/{}/{}/custom/{}/{}/'
             ' | grep .src.rpm'
+            .format(
+                self.org.label,
+                lce.name,
+                cv.label,
+                self.product.label,
+                repo.label,
+            )
+        )
+        self.assertEqual(result.return_code, 0)
+        self.assertGreaterEqual(len(result.stdout), 1)
+
+
+class DRPMRepositoryTestCase(APITestCase):
+    """Tests specific to using repositories containing delta RPMs."""
+
+    @classmethod
+    def setUpClass(cls):
+        """Create a product and an org which can be re-used in tests."""
+        super(DRPMRepositoryTestCase, cls).setUpClass()
+        cls.org = entities.Organization().create()
+        cls.product = entities.Product(organization=cls.org).create()
+
+    @tier2
+    def test_positive_sync(self):
+        """Synchronize repository with DRPMs
+
+        @id: 7816031c-b7df-49e0-bf42-7f6e2d9b0233
+
+        @Assert: drpms can be listed in repository
+        """
+        repo = entities.Repository(
+            product=self.product,
+            url=FAKE_YUM_DRPM_REPO,
+        ).create()
+        repo.sync()
+        result = ssh.command(
+            'ls /var/lib/pulp/published/yum/https/repos/{}/Library'
+            '/custom/{}/{}/drpms/ | grep .drpm'
+            .format(
+                self.org.label,
+                self.product.label,
+                repo.label,
+            )
+        )
+        self.assertEqual(result.return_code, 0)
+        self.assertGreaterEqual(len(result.stdout), 1)
+
+    @tier2
+    def test_positive_sync_publish_cv(self):
+        """Synchronize repository with DRPMs, add repository to content view
+        and publish content view
+
+        @id: dac4bd82-1433-4e5d-b82f-856056ca3924
+
+        @Assert: drpms can be listed in content view
+        """
+        repo = entities.Repository(
+            product=self.product,
+            url=FAKE_YUM_DRPM_REPO,
+        ).create()
+        repo.sync()
+        cv = entities.ContentView(organization=self.org).create()
+        cv.repository = [repo]
+        cv.update(['repository'])
+        cv.publish()
+        result = ssh.command(
+            'ls /var/lib/pulp/published/yum/https/repos/{}/content_views/{}'
+            '/1.0/custom/{}/{}/drpms/ | grep .drpm'
+            .format(
+                self.org.label,
+                cv.label,
+                self.product.label,
+                repo.label,
+            )
+        )
+        self.assertEqual(result.return_code, 0)
+        self.assertGreaterEqual(len(result.stdout), 1)
+
+    @tier2
+    def test_positive_sync_publish_promote_cv(self):
+        """Synchronize repository with DRPMs, add repository to content view,
+        publish and promote content view to lifecycle environment
+
+        @id: 44296354-8ca2-4ce0-aa16-398effc80d9c
+
+        @Assert: drpms can be listed in content view in proper lifecycle
+        environment
+        """
+        lce = entities.LifecycleEnvironment(organization=self.org).create()
+        repo = entities.Repository(
+            product=self.product,
+            url=FAKE_YUM_DRPM_REPO,
+        ).create()
+        repo.sync()
+        cv = entities.ContentView(organization=self.org).create()
+        cv.repository = [repo]
+        cv.update(['repository'])
+        cv.publish()
+        cv = cv.read()
+        promote(cv.version[0], lce.id)
+        result = ssh.command(
+            'ls /var/lib/pulp/published/yum/https/repos/{}/{}/{}/custom/{}/{}'
+            '/drpms/ | grep .drpm'
             .format(
                 self.org.label,
                 lce.name,

--- a/tests/foreman/api/test_repository.py
+++ b/tests/foreman/api/test_repository.py
@@ -18,14 +18,19 @@ from fauxfactory import gen_string
 from nailgun import entities
 from nailgun.entity_mixins import TaskFailedError
 from requests.exceptions import HTTPError
-from robottelo import manifests
-from robottelo.api.utils import enable_rhrepo_and_fetchid, upload_manifest
+from robottelo import manifests, ssh
+from robottelo.api.utils import (
+    enable_rhrepo_and_fetchid,
+    promote,
+    upload_manifest,
+)
 from robottelo.constants import (
     DOCKER_REGISTRY_HUB,
     FAKE_0_PUPPET_REPO,
     FAKE_7_PUPPET_REPO,
     FAKE_2_YUM_REPO,
     FAKE_5_YUM_REPO,
+    FAKE_YUM_SRPM_REPO,
     PRDS,
     REPOS,
     REPOSET,
@@ -60,7 +65,7 @@ class RepositoryTestCase(APITestCase):
     """Tests for ``katello/api/v2/repositories``."""
 
     @classmethod
-    def setUpClass(cls):  # noqa
+    def setUpClass(cls):
         """Create an organization and product which can be re-used in tests."""
         super(RepositoryTestCase, cls).setUpClass()
         cls.org = entities.Organization().create()
@@ -928,7 +933,7 @@ class DockerRepositoryTestCase(APITestCase):
     """Tests specific to using ``Docker`` repositories."""
 
     @classmethod
-    def setUpClass(cls):  # noqa
+    def setUpClass(cls):
         """Create an organization and product which can be re-used in tests."""
         super(DockerRepositoryTestCase, cls).setUpClass()
         cls.org = entities.Organization().create()
@@ -999,3 +1004,106 @@ class DockerRepositoryTestCase(APITestCase):
         repository.name = new_name
         repository = repository.update(['name'])
         self.assertEqual(new_name, repository.name)
+
+
+class SRPMRepositoryTestCase(APITestCase):
+    """Tests specific to using repositories containing source RPMs."""
+
+    @classmethod
+    def setUpClass(cls):
+        """Create a product and an org which can be re-used in tests."""
+        super(SRPMRepositoryTestCase, cls).setUpClass()
+        cls.org = entities.Organization().create()
+        cls.product = entities.Product(organization=cls.org).create()
+
+    @tier2
+    def test_positive_sync(self):
+        """Synchronize repository with SRPMs
+
+        @id: f87391c6-c18a-4c4f-81db-decbba7f1856
+
+        @Assert: srpms can be listed in repository
+        """
+        repo = entities.Repository(
+            product=self.product,
+            url=FAKE_YUM_SRPM_REPO,
+        ).create()
+        repo.sync()
+        result = ssh.command(
+            'ls /var/lib/pulp/published/yum/https/repos/{}/Library'
+            '/custom/{}/{}/ | grep .src.rpm'
+            .format(
+                self.org.label,
+                self.product.label,
+                repo.label,
+            )
+        )
+        self.assertEqual(result.return_code, 0)
+        self.assertGreaterEqual(len(result.stdout), 1)
+
+    @tier2
+    def test_positive_sync_publish_cv(self):
+        """Synchronize repository with SRPMs, add repository to content view
+        and publish content view
+
+        @id: a0868429-584c-4e36-b93f-c85e8e94a60b
+
+        @Assert: srpms can be listed in content view
+        """
+        repo = entities.Repository(
+            product=self.product,
+            url=FAKE_YUM_SRPM_REPO,
+        ).create()
+        repo.sync()
+        cv = entities.ContentView(organization=self.org).create()
+        cv.repository = [repo]
+        cv.update(['repository'])
+        cv.publish()
+        result = ssh.command(
+            'ls /var/lib/pulp/published/yum/https/repos/{}/content_views/{}'
+            '/1.0/custom/{}/{}/ | grep .src.rpm'
+            .format(
+                self.org.label,
+                cv.label,
+                self.product.label,
+                repo.label,
+            )
+        )
+        self.assertEqual(result.return_code, 0)
+        self.assertGreaterEqual(len(result.stdout), 1)
+
+    @tier2
+    def test_positive_sync_publish_promote_cv(self):
+        """Synchronize repository with SRPMs, add repository to content view,
+        publish and promote content view to lifecycle environment
+
+        @id: 811b524f-2b19-4408-ad7f-d7251625e35c
+
+        @Assert: srpms can be listed in content view in proper lifecycle
+        environment
+        """
+        lce = entities.LifecycleEnvironment(organization=self.org).create()
+        repo = entities.Repository(
+            product=self.product,
+            url=FAKE_YUM_SRPM_REPO,
+        ).create()
+        repo.sync()
+        cv = entities.ContentView(organization=self.org).create()
+        cv.repository = [repo]
+        cv.update(['repository'])
+        cv.publish()
+        cv = cv.read()
+        promote(cv.version[0], lce.id)
+        result = ssh.command(
+            'ls /var/lib/pulp/published/yum/https/repos/{}/{}/{}/custom/{}/{}/'
+            ' | grep .src.rpm'
+            .format(
+                self.org.label,
+                lce.name,
+                cv.label,
+                self.product.label,
+                repo.label,
+            )
+        )
+        self.assertEqual(result.return_code, 0)
+        self.assertGreaterEqual(len(result.stdout), 1)

--- a/tests/foreman/cli/test_repository.py
+++ b/tests/foreman/cli/test_repository.py
@@ -926,6 +926,17 @@ class RepositoryTestCase(CLITestCase):
             result[0]['message'],
         )
 
+
+class SRPMRepositoryTestCase(CLITestCase):
+    """Tests specific to using repositories containing source RPMs."""
+
+    @classmethod
+    def setUpClass(cls):
+        """Create a product and an org which can be re-used in tests."""
+        super(SRPMRepositoryTestCase, cls).setUpClass()
+        cls.org = make_org()
+        cls.product = make_product({'organization-id': cls.org['id']})
+
     @skip_if_bug_open('bugzilla', 1378442)
     @tier1
     def test_positive_upload_content_srpm(self):
@@ -948,17 +959,6 @@ class RepositoryTestCase(CLITestCase):
             "Successfully uploaded file '{0}'".format(SRPM_TO_UPLOAD),
             result[0]['message'],
         )
-
-
-class SRPMRepositoryTestCase(CLITestCase):
-    """Tests specific to using repositories containing source RPMs."""
-
-    @classmethod
-    def setUpClass(cls):
-        """Create a product and an org which can be re-used in tests."""
-        super(SRPMRepositoryTestCase, cls).setUpClass()
-        cls.org = make_org()
-        cls.product = make_product({'organization-id': cls.org['id']})
 
     @tier2
     def test_positive_sync(self):

--- a/tests/foreman/cli/test_repository.py
+++ b/tests/foreman/cli/test_repository.py
@@ -19,13 +19,17 @@
 from fauxfactory import gen_string
 from robottelo import ssh
 from robottelo.cli.base import CLIReturnCodeError
+from robottelo.cli.contentview import ContentView
 from robottelo.cli.task import Task
 from robottelo.cli.factory import (
+    make_content_view,
     make_gpg_key,
+    make_lifecycle_environment,
     make_org,
+    make_product,
     make_product_wait,
     make_repository,
-    CLIFactoryError
+    CLIFactoryError,
 )
 from robottelo.cli.repository import Repository
 from robottelo.cli.settings import Settings
@@ -43,6 +47,7 @@ from robottelo.constants import (
     FAKE_5_PUPPET_REPO,
     FAKE_5_YUM_REPO,
     FAKE_7_PUPPET_REPO,
+    FAKE_YUM_SRPM_REPO,
     RPM_TO_UPLOAD,
     SRPM_TO_UPLOAD,
     DOWNLOAD_POLICIES,
@@ -942,6 +947,117 @@ class RepositoryTestCase(CLITestCase):
             "Successfully uploaded file '{0}'".format(SRPM_TO_UPLOAD),
             result[0]['message'],
         )
+
+
+class SRPMRepositoryTestCase(CLITestCase):
+    """Tests specific to using repositories containing source RPMs."""
+
+    @classmethod
+    def setUpClass(cls):
+        """Create a product and an org which can be re-used in tests."""
+        super(SRPMRepositoryTestCase, cls).setUpClass()
+        cls.org = make_org()
+        cls.product = make_product({'organization-id': cls.org['id']})
+
+    @tier2
+    def test_positive_sync(self):
+        """Synchronize repository with SRPMs
+
+        @id: eb69f840-122d-4180-b869-1bd37518480c
+
+        @Assert: srpms can be listed in repository
+        """
+        repo = make_repository({
+            'product-id': self.product['id'],
+            'url': FAKE_YUM_SRPM_REPO,
+        })
+        Repository.synchronize({'id': repo['id']})
+        result = ssh.command(
+            'ls /var/lib/pulp/published/yum/https/repos/{}/Library'
+            '/custom/{}/{}/ | grep .src.rpm'
+            .format(
+                self.org['label'],
+                self.product['label'],
+                repo['label'],
+            )
+        )
+        self.assertEqual(result.return_code, 0)
+        self.assertGreaterEqual(len(result.stdout), 1)
+
+    @tier2
+    def test_positive_sync_publish_cv(self):
+        """Synchronize repository with SRPMs, add repository to content view
+        and publish content view
+
+        @id: 78cd6345-9c6c-490a-a44d-2ad64b7e959b
+
+        @Assert: srpms can be listed in content view
+        """
+        repo = make_repository({
+            'product-id': self.product['id'],
+            'url': FAKE_YUM_SRPM_REPO,
+        })
+        Repository.synchronize({'id': repo['id']})
+        cv = make_content_view({'organization-id': self.org['id']})
+        ContentView.add_repository({
+            'id': cv['id'],
+            'repository-id': repo['id'],
+        })
+        ContentView.publish({'id': cv['id']})
+        result = ssh.command(
+            'ls /var/lib/pulp/published/yum/https/repos/{}/content_views/{}'
+            '/1.0/custom/{}/{}/ | grep .src.rpm'
+            .format(
+                self.org['label'],
+                cv['label'],
+                self.product['label'],
+                repo['label'],
+            )
+        )
+        self.assertEqual(result.return_code, 0)
+        self.assertGreaterEqual(len(result.stdout), 1)
+
+    @tier2
+    def test_positive_sync_publish_promote_cv(self):
+        """Synchronize repository with SRPMs, add repository to content view,
+        publish and promote content view to lifecycle environment
+
+        @id: 3d197118-b1fa-456f-980e-ad1a517bc769
+
+        @Assert: srpms can be listed in content view in proper lifecycle
+        environment
+        """
+        lce = make_lifecycle_environment({'organization-id': self.org['id']})
+        repo = make_repository({
+            'product-id': self.product['id'],
+            'url': FAKE_YUM_SRPM_REPO,
+        })
+        Repository.synchronize({'id': repo['id']})
+        cv = make_content_view({'organization-id': self.org['id']})
+        ContentView.add_repository({
+            'id': cv['id'],
+            'repository-id': repo['id'],
+        })
+        ContentView.publish({'id': cv['id']})
+        content_view = ContentView.info({'id': cv['id']})
+        cvv = content_view['versions'][0]
+        ContentView.version_promote({
+            'id': cvv['id'],
+            'to-lifecycle-environment-id': lce['id'],
+        })
+        result = ssh.command(
+            'ls /var/lib/pulp/published/yum/https/repos/{}/{}/{}/custom/{}/{}/'
+            ' | grep .src.rpm'
+            .format(
+                self.org['label'],
+                lce['label'],
+                cv['label'],
+                self.product['label'],
+                repo['label'],
+            )
+        )
+        self.assertEqual(result.return_code, 0)
+        self.assertGreaterEqual(len(result.stdout), 1)
 
 
 class GitPuppetMirrorTestCase(CLITestCase):

--- a/tests/foreman/cli/test_repository.py
+++ b/tests/foreman/cli/test_repository.py
@@ -47,6 +47,7 @@ from robottelo.constants import (
     FAKE_5_PUPPET_REPO,
     FAKE_5_YUM_REPO,
     FAKE_7_PUPPET_REPO,
+    FAKE_YUM_DRPM_REPO,
     FAKE_YUM_SRPM_REPO,
     RPM_TO_UPLOAD,
     SRPM_TO_UPLOAD,
@@ -1048,6 +1049,117 @@ class SRPMRepositoryTestCase(CLITestCase):
         result = ssh.command(
             'ls /var/lib/pulp/published/yum/https/repos/{}/{}/{}/custom/{}/{}/'
             ' | grep .src.rpm'
+            .format(
+                self.org['label'],
+                lce['label'],
+                cv['label'],
+                self.product['label'],
+                repo['label'],
+            )
+        )
+        self.assertEqual(result.return_code, 0)
+        self.assertGreaterEqual(len(result.stdout), 1)
+
+
+class DRPMRepositoryTestCase(CLITestCase):
+    """Tests specific to using repositories containing delta RPMs."""
+
+    @classmethod
+    def setUpClass(cls):
+        """Create a product and an org which can be re-used in tests."""
+        super(DRPMRepositoryTestCase, cls).setUpClass()
+        cls.org = make_org()
+        cls.product = make_product({'organization-id': cls.org['id']})
+
+    @tier2
+    def test_positive_sync(self):
+        """Synchronize repository with DRPMs
+
+        @id: a645966c-750b-40ef-a264-dc3bb632b9fd
+
+        @Assert: drpms can be listed in repository
+        """
+        repo = make_repository({
+            'product-id': self.product['id'],
+            'url': FAKE_YUM_DRPM_REPO,
+        })
+        Repository.synchronize({'id': repo['id']})
+        result = ssh.command(
+            'ls /var/lib/pulp/published/yum/https/repos/{}/Library'
+            '/custom/{}/{}/drpms/ | grep .drpm'
+            .format(
+                self.org['label'],
+                self.product['label'],
+                repo['label'],
+            )
+        )
+        self.assertEqual(result.return_code, 0)
+        self.assertGreaterEqual(len(result.stdout), 1)
+
+    @tier2
+    def test_positive_sync_publish_cv(self):
+        """Synchronize repository with DRPMs, add repository to content view
+        and publish content view
+
+        @id: 014bfc80-4622-422e-a0ec-755b1d9f845e
+
+        @Assert: drpms can be listed in content view
+        """
+        repo = make_repository({
+            'product-id': self.product['id'],
+            'url': FAKE_YUM_DRPM_REPO,
+        })
+        Repository.synchronize({'id': repo['id']})
+        cv = make_content_view({'organization-id': self.org['id']})
+        ContentView.add_repository({
+            'id': cv['id'],
+            'repository-id': repo['id'],
+        })
+        ContentView.publish({'id': cv['id']})
+        result = ssh.command(
+            'ls /var/lib/pulp/published/yum/https/repos/{}/content_views/{}'
+            '/1.0/custom/{}/{}/drpms/ | grep .drpm'
+            .format(
+                self.org['label'],
+                cv['label'],
+                self.product['label'],
+                repo['label'],
+            )
+        )
+        self.assertEqual(result.return_code, 0)
+        self.assertGreaterEqual(len(result.stdout), 1)
+
+    @tier2
+    def test_positive_sync_publish_promote_cv(self):
+        """Synchronize repository with DRPMs, add repository to content view,
+        publish and promote content view to lifecycle environment
+
+        @id: a01cb12b-d388-4902-8532-714f4e28ec56
+
+        @Assert: drpms can be listed in content view in proper lifecycle
+        environment
+        """
+        lce = make_lifecycle_environment({'organization-id': self.org['id']})
+        repo = make_repository({
+            'product-id': self.product['id'],
+            'url': FAKE_YUM_DRPM_REPO,
+        })
+        Repository.synchronize({'id': repo['id']})
+        cv = make_content_view({'organization-id': self.org['id']})
+        ContentView.add_repository({
+            'id': cv['id'],
+            'repository-id': repo['id'],
+        })
+        ContentView.publish({'id': cv['id']})
+        content_view = ContentView.info({'id': cv['id']})
+        cvv = content_view['versions'][0]
+        ContentView.version_promote({
+            'id': cvv['id'],
+            'to-lifecycle-environment-id': lce['id'],
+        })
+        result = ssh.command(
+            'ls /var/lib/pulp/published/yum/https/repos/{}/{}/{}/custom/{}/{}'
+            '/drpms/ | grep .drpm'
             .format(
                 self.org['label'],
                 lce['label'],

--- a/tests/foreman/ui/test_repository.py
+++ b/tests/foreman/ui/test_repository.py
@@ -20,7 +20,8 @@ import time
 
 from fauxfactory import gen_string
 from nailgun import entities
-from robottelo import manifests
+
+from robottelo import manifests, ssh
 from robottelo.api.utils import upload_manifest
 from robottelo.constants import (
     CHECKSUM_TYPE,
@@ -30,6 +31,7 @@ from robottelo.constants import (
     FAKE_1_PUPPET_REPO,
     FAKE_1_YUM_REPO,
     FAKE_2_YUM_REPO,
+    FAKE_YUM_SRPM_REPO,
     FEDORA22_OSTREE_REPO,
     FEDORA23_OSTREE_REPO,
     PRDS,
@@ -57,7 +59,7 @@ from robottelo.decorators import (
 from robottelo.decorators.host import skip_if_os
 from robottelo.helpers import get_data_file, read_data_file
 from robottelo.test import UITestCase
-from robottelo.ui.factory import make_repository, set_context
+from robottelo.ui.factory import make_contentview, make_repository, set_context
 from robottelo.ui.locators import common_locators, locators, tab_locators
 from robottelo.ui.session import Session
 from selenium.common.exceptions import NoSuchElementException
@@ -79,7 +81,7 @@ class RepositoryTestCase(UITestCase):
     """Implements Repos tests in UI"""
 
     @classmethod
-    def setUpClass(cls):  # noqa
+    def setUpClass(cls):
         super(RepositoryTestCase, cls).setUpClass()
         # create instances to be shared across the sessions
         cls.session_loc = entities.Location().create()
@@ -938,6 +940,145 @@ class RepositoryTestCase(UITestCase):
                             locators['repo.download_policy']
                         )
                     )
+
+    @tier2
+    def test_positive_sync(self):
+        """Synchronize repository with SRPMs
+
+        @id: 1967a540-a265-4046-b87b-627524b63688
+
+        @Assert: srpms can be listed in repository
+        """
+        product = entities.Product(organization=self.session_org).create()
+        repo_name = gen_string('alphanumeric')
+        with Session(self.browser) as session:
+            self.products.search(product.name).click()
+            make_repository(
+                session,
+                name=repo_name,
+                url=FAKE_YUM_SRPM_REPO,
+            )
+            self.assertIsNotNone(self.repository.search(repo_name))
+            self.setup_navigate_syncnow(
+                session,
+                product.name,
+                repo_name,
+            )
+            self.assertTrue(self.prd_sync_is_ok(repo_name))
+        result = ssh.command(
+            'ls /var/lib/pulp/published/yum/https/repos/{}/Library'
+            '/custom/{}/{}/ | grep .src.rpm'
+            .format(
+                self.session_org.label,
+                product.label,
+                repo_name,
+            )
+        )
+        self.assertEqual(result.return_code, 0)
+        self.assertGreaterEqual(len(result.stdout), 1)
+
+    @tier2
+    def test_positive_sync_publish_cv(self):
+        """Synchronize repository with SRPMs, add repository to content view
+        and publish content view
+
+        @id: 2a57cbde-c616-440d-8bcb-6e18bd2d5c5f
+
+        @Assert: srpms can be listed in content view
+        """
+        product = entities.Product(organization=self.session_org).create()
+        repo_name = gen_string('alphanumeric')
+        cv_name = gen_string('alphanumeric')
+        with Session(self.browser) as session:
+            self.products.search(product.name).click()
+            make_repository(
+                session,
+                name=repo_name,
+                url=FAKE_YUM_SRPM_REPO,
+            )
+            self.assertIsNotNone(self.repository.search(repo_name))
+            self.setup_navigate_syncnow(
+                session,
+                product.name,
+                repo_name,
+            )
+            self.assertTrue(self.prd_sync_is_ok(repo_name))
+
+            make_contentview(session, org=self.session_org.name, name=cv_name)
+            self.assertIsNotNone(self.content_views.search(cv_name))
+            self.content_views.add_remove_repos(cv_name, [repo_name])
+            self.assertIsNotNone(self.content_views.wait_until_element(
+                common_locators['alert.success_sub_form']))
+            self.content_views.publish(cv_name)
+            self.assertIsNotNone(self.content_views.wait_until_element
+                                 (common_locators['alert.success_sub_form']))
+        result = ssh.command(
+            'ls /var/lib/pulp/published/yum/https/repos/{}/content_views/{}'
+            '/1.0/custom/{}/{}/ | grep .src.rpm'
+            .format(
+                self.session_org.label,
+                cv_name,
+                product.label,
+                repo_name,
+            )
+        )
+        self.assertEqual(result.return_code, 0)
+        self.assertGreaterEqual(len(result.stdout), 1)
+
+    @tier2
+    def test_positive_sync_publish_promote_cv(self):
+        """Synchronize repository with SRPMs, add repository to content view,
+        publish and promote content view to lifecycle environment
+
+        @id: 4563d1c1-cdce-4838-a67f-c0a5d4e996a6
+
+        @Assert: srpms can be listed in content view in proper lifecycle
+        environment
+        """
+        lce = entities.LifecycleEnvironment(
+            organization=self.session_org).create()
+        product = entities.Product(organization=self.session_org).create()
+        repo_name = gen_string('alphanumeric')
+        cv_name = gen_string('alphanumeric')
+        with Session(self.browser) as session:
+            self.products.search(product.name).click()
+            make_repository(
+                session,
+                name=repo_name,
+                url=FAKE_YUM_SRPM_REPO,
+            )
+            self.assertIsNotNone(self.repository.search(repo_name))
+            self.setup_navigate_syncnow(
+                session,
+                product.name,
+                repo_name,
+            )
+            self.assertTrue(self.prd_sync_is_ok(repo_name))
+
+            make_contentview(session, org=self.session_org.name, name=cv_name)
+            self.assertIsNotNone(self.content_views.search(cv_name))
+            self.content_views.add_remove_repos(cv_name, [repo_name])
+            self.assertIsNotNone(self.content_views.wait_until_element(
+                common_locators['alert.success_sub_form']))
+            self.content_views.publish(cv_name)
+            self.assertIsNotNone(self.content_views.wait_until_element
+                                 (common_locators['alert.success_sub_form']))
+            self.content_views.promote(cv_name, 'Version 1', lce.name)
+            self.assertIsNotNone(self.content_views.wait_until_element
+                                 (common_locators['alert.success_sub_form']))
+        result = ssh.command(
+            'ls /var/lib/pulp/published/yum/https/repos/{}/{}/{}/custom/{}/{}/'
+            ' | grep .src.rpm'
+            .format(
+                self.session_org.label,
+                lce.name,
+                cv_name,
+                product.label,
+                repo_name,
+            )
+        )
+        self.assertEqual(result.return_code, 0)
+        self.assertGreaterEqual(len(result.stdout), 1)
 
     @tier1
     def test_positive_list_puppet_modules_with_multiple_repos(self):


### PR DESCRIPTION
Cherry-pick of #3871 and #3865
Test results for 6.2.5:
```python
% nosetests tests/foreman/{api,cli}/test_repository.py:{SRPMRepositoryTestCase,DRPMRepositoryTestCase}
...S......S...
----------------------------------------------------------------------
Ran 14 tests in 648.386s
OK (SKIP=2)
```
```python
% py.test -v tests/foreman/ui/test_repository.py -k 'test_positive_srpm_sync or test_positive_srpm_sync_publish_cv or test_positive_srpm_sync_publish_promote_cv or test_positive_drpm_sync or test_positive_drpm_sync_publish_cv or test_positive_drpm_sync_publish_promote_cv'
===================================================================== test session starts =====================================================================
platform linux2 -- Python 2.7.12, pytest-2.9.2, py-1.4.31, pluggy-0.3.1 -- /home/qui/code/venv/6.2.z/bin/python2
cachedir: .cache
rootdir: /home/qui/code/robottelo, inifile: 
plugins: xdist-1.14, cov-2.3.1
collected 53 items 

tests/foreman/ui/test_repository.py::RepositoryTestCase::test_positive_drpm_sync PASSED
tests/foreman/ui/test_repository.py::RepositoryTestCase::test_positive_drpm_sync_publish_cv PASSED
tests/foreman/ui/test_repository.py::RepositoryTestCase::test_positive_drpm_sync_publish_promote_cv PASSED
tests/foreman/ui/test_repository.py::RepositoryTestCase::test_positive_srpm_sync PASSED
tests/foreman/ui/test_repository.py::RepositoryTestCase::test_positive_srpm_sync_publish_cv PASSED
tests/foreman/ui/test_repository.py::RepositoryTestCase::test_positive_srpm_sync_publish_promote_cv PASSED

 47 tests deselected by '-ktest_positive_srpm_sync or test_positive_srpm_sync_publish_cv or test_positive_srpm_sync_publish_promote_cv or test_positive_drpm_sync or test_positive_drpm_sync_publish_cv or test_positive_drpm_sync_publish_promote_cv' 
========================================================== 6 passed, 47 deselected in 556.48 seconds ==========================================================
```