### PR TITLE
Cherry-pick - Added upload tests for UI/repository. (#4085)

### DIFF
--- a/robottelo/ui/locators/base.py
+++ b/robottelo/ui/locators/base.py
@@ -1217,23 +1217,15 @@ locators = LocatorDict({
     "repo.result_spinner": (
         By.XPATH,
         "//i[@ng-show='task.pending' and contains(@class, 'icon-spinner')]"),
-    "repo.manage_content.packages": (
+    "repo.manage_content": (
         By.XPATH,
         "//button[contains(@ui-sref,"
-        " 'products.details.repositories.manage-content.packages')]"),
-    "repo.manage_content.puppet_modules": (
-        By.XPATH,
-        "//button[contains(@ui-sref,"
-        " 'products.details.repositories.manage-content.puppet-modules')]"),
-    "repo.manage_content.docker_manifests": (
-        By.XPATH,
-        "//button[contains(@ui-sref,"
-        " 'products.details.repositories.manage-content.docker-manifests')]"),
-    "repo.manage_content.ostree_branches": (
-        By.XPATH,
-        "//button[contains(@ui-sref,"
-        " 'products.details.repositories.manage-content.ostree-branches)]"),
-    "repo.content_items": (By.XPATH, "//tr[@row-select='item']"),
+        " 'products.details.repositories.manage-content')"
+        " and not(contains(@class, 'ng-hide'))]"),
+    "repo.content.packages": (By.XPATH, "//tr[@row-select='package']"),
+    "repo.content.puppet_modules": (By.XPATH, "//tr[@row-select='item']"),
+    "repo.upload.file_path": (By.XPATH, ("//input[@name='content[]']")),
+    "repo.upload": (By.XPATH, ("//button[@upload-submit]")),
     # Activation Keys
 
     "ak.new": (By.XPATH, "//button[@ui-sref='activation-keys.new']"),

--- a/robottelo/ui/repository.py
+++ b/robottelo/ui/repository.py
@@ -157,3 +157,11 @@ class Repos(Base):
             return (self.wait_until_element(locators[
                 'repo.fetch_' + field_name]).text == expected_field_value)
         return False
+
+    def upload_content(self, repo_name, file_path):
+        """Upload content to a repository."""
+        self.search_and_click(repo_name)
+        browse_element = self.wait_until_element(
+            locators['repo.upload.file_path'])
+        browse_element.send_keys(file_path)
+        self.click(locators['repo.upload'])


### PR DESCRIPTION
Cherry-pick of #4085 that was firstly added to `6.2.z` because of broken UI in Snap 8.
Closes #3930 
```python
% py.test -n 3 -v tests/foreman/ui/test_repository.py -k 'test_positive_list_puppet_modules_with_multiple_repos or test_positive_upload_rpm or test_positive_upload_puppet or test_negative_upload_rpm or test_negative_upload_puppet'    
=============================================== test session starts ================================================

tests/foreman/ui/test_repository.py::RepositoryTestCase::test_negative_upload_puppet 
tests/foreman/ui/test_repository.py::RepositoryTestCase::test_positive_list_puppet_modules_with_multiple_repos 
tests/foreman/ui/test_repository.py::RepositoryTestCase::test_negative_upload_rpm 
[gw0] PASSED tests/foreman/ui/test_repository.py::RepositoryTestCase::test_negative_upload_rpm 
tests/foreman/ui/test_repository.py::RepositoryTestCase::test_positive_upload_rpm <- robottelo/decorators/__init__.py 
[gw2] PASSED tests/foreman/ui/test_repository.py::RepositoryTestCase::test_negative_upload_puppet 
tests/foreman/ui/test_repository.py::RepositoryTestCase::test_positive_upload_puppet 
[gw0] SKIPPED tests/foreman/ui/test_repository.py::RepositoryTestCase::test_positive_upload_rpm <- robottelo/decorators/__init__.py 
[gw2] PASSED tests/foreman/ui/test_repository.py::RepositoryTestCase::test_positive_upload_puppet 
[gw1] PASSED tests/foreman/ui/test_repository.py::RepositoryTestCase::test_positive_list_puppet_modules_with_multiple_repos 

====================================== 4 passed, 1 skipped in 102.01 seconds =======================================
```