### PR TITLE
[6.2.z] Fix for PR #4085

### DIFF
--- a/tests/foreman/ui/test_repository.py
+++ b/tests/foreman/ui/test_repository.py
@@ -1032,7 +1032,8 @@ class RepositoryTestCase(UITestCase):
             self.products.search(self.session_prod.name).click()
             make_repository(session, name=repo_name)
             self.assertIsNotNone(self.repository.search(repo_name))
-            self.repository.upload(repo_name, get_data_file(RPM_TO_UPLOAD))
+            self.repository.upload_content(
+                repo_name, get_data_file(RPM_TO_UPLOAD))
             # Check alert
             self.assertIsNotNone(self.activationkey.wait_until_element(
                 common_locators['alert.success_sub_form']))
@@ -1063,7 +1064,7 @@ class RepositoryTestCase(UITestCase):
             self.products.search(self.session_prod.name).click()
             make_repository(session, name=repo_name)
             self.assertIsNotNone(self.repository.search(repo_name))
-            self.repository.upload(
+            self.repository.upload_content(
                 repo_name, get_data_file(PUPPET_MODULE_NTP_PUPPETLABS))
             # Check alert
             self.assertIsNotNone(self.activationkey.wait_until_element(
@@ -1088,7 +1089,7 @@ class RepositoryTestCase(UITestCase):
             make_repository(
                 session, name=repo_name, repo_type=REPO_TYPE['puppet'])
             self.assertIsNotNone(self.repository.search(repo_name))
-            self.repository.upload(
+            self.repository.upload_content(
                 repo_name, get_data_file(PUPPET_MODULE_NTP_PUPPETLABS))
             # Check alert
             self.assertIsNotNone(self.activationkey.wait_until_element(
@@ -1122,7 +1123,8 @@ class RepositoryTestCase(UITestCase):
             make_repository(
                 session, name=repo_name, repo_type=REPO_TYPE['puppet'])
             self.assertIsNotNone(self.repository.search(repo_name))
-            self.repository.upload(repo_name, get_data_file(RPM_TO_UPLOAD))
+            self.repository.upload_content(
+                repo_name, get_data_file(RPM_TO_UPLOAD))
             # Check alert
             self.assertIsNotNone(self.activationkey.wait_until_element(
                 common_locators['alert.error_sub_form']))


### PR DESCRIPTION
Fix for PR #4085.
```python
% py.test -n 3 -v tests/foreman/ui/test_repository.py -k 'test_positive_upload_rpm or test_positive_upload_puppet or test_negative_upload_rpm or test_negative_upload_puppet'
=============================================== test session starts ================================================
tests/foreman/ui/test_repository.py::RepositoryTestCase::test_positive_upload_puppet 
tests/foreman/ui/test_repository.py::RepositoryTestCase::test_negative_upload_puppet 
tests/foreman/ui/test_repository.py::RepositoryTestCase::test_negative_upload_rpm 
[gw1] PASSED tests/foreman/ui/test_repository.py::RepositoryTestCase::test_negative_upload_rpm 
[gw0] PASSED tests/foreman/ui/test_repository.py::RepositoryTestCase::test_negative_upload_puppet 
tests/foreman/ui/test_repository.py::RepositoryTestCase::test_positive_upload_rpm 
[gw2] PASSED tests/foreman/ui/test_repository.py::RepositoryTestCase::test_positive_upload_puppet 
[gw0] PASSED tests/foreman/ui/test_repository.py::RepositoryTestCase::test_positive_upload_rpm 

============================================ 4 passed in 89.10 seconds =============================================
```