### PR TITLE
Replace tearDown with cleanup func for VirtualMachine tests

### DIFF
--- a/robottelo/cleanup.py
+++ b/robottelo/cleanup.py
@@ -34,6 +34,14 @@ def org_cleanup(org_id=None):
     entities.Organization(id=org_id).delete()
 
 
+def vm_cleanup(vm):
+    """Destroys virtual machine
+
+    :param robottelo.vm.VirtualMachine vm: virtual machine to destroy
+    """
+    vm.destroy()
+
+
 class EntitiesCleaner(object):
     """Register and clean entities for cleanup using signals"""
 

--- a/tests/foreman/cli/test_host.py
+++ b/tests/foreman/cli/test_host.py
@@ -17,6 +17,7 @@
 from fauxfactory import gen_mac, gen_string
 from nailgun import entities
 from robottelo import ssh
+from robottelo.cleanup import vm_cleanup
 from robottelo.cli.base import CLIReturnCodeError
 from robottelo.cli.contentview import ContentView
 from robottelo.cli.factory import (
@@ -1394,6 +1395,7 @@ class KatelloAgentTestCase(CLITestCase):
         super(KatelloAgentTestCase, self).setUp()
         # Create VM and register content host
         self.client = VirtualMachine(distro=DISTRO_RHEL7)
+        self.addCleanup(vm_cleanup, self.client)
         self.client.create()
         self.client.install_katello_ca()
         # Register content host, install katello-agent
@@ -1404,11 +1406,6 @@ class KatelloAgentTestCase(CLITestCase):
         self.host = Host.info({'name': self.client.hostname})
         self.client.enable_repo(REPOS['rhst7']['id'])
         self.client.install_katello_agent()
-
-    def tearDown(self):
-        """Destroy the VM"""
-        self.client.destroy()
-        super(KatelloAgentTestCase, self).tearDown()
 
     @tier3
     @run_only_on('sat')

--- a/tests/foreman/cli/test_remoteexecution.py
+++ b/tests/foreman/cli/test_remoteexecution.py
@@ -18,6 +18,7 @@
 from datetime import datetime, timedelta
 from fauxfactory import gen_string
 from robottelo import ssh
+from robottelo.cleanup import vm_cleanup
 from robottelo.cli.base import CLIReturnCodeError
 from robottelo.cli.factory import (
     CLIFactoryError,
@@ -183,6 +184,7 @@ class RemoteExecutionTestCase(CLITestCase):
             '''echo 'getenforce' > {0}'''.format(TEMPLATE_FILE)
         )
         cls.client = VirtualMachine(distro=DISTRO_RHEL7)
+        cls.addCleanup(vm_cleanup, cls.client)
         cls.client.create()
         cls.client.install_katello_ca()
         cls.client.register_contenthost(
@@ -192,12 +194,6 @@ class RemoteExecutionTestCase(CLITestCase):
         cls.client.enable_repo(REPOS['rhst7']['id'])
         cls.client.install_katello_agent()
         add_remote_execution_ssh_key(cls.client.hostname)
-
-    @classmethod
-    def tearDownClass(cls):
-        """Remove the VM used for testing remote execution"""
-        cls.client.destroy()
-        super(RemoteExecutionTestCase, cls).tearDownClass()
 
     @tier2
     def test_positive_run_default_job_template(self):

--- a/tests/foreman/longrun/test_inc_updates.py
+++ b/tests/foreman/longrun/test_inc_updates.py
@@ -36,6 +36,7 @@ from robottelo import manifests
 from robottelo.api.utils import (
     enable_rhrepo_and_fetchid, promote, upload_manifest
 )
+from robottelo.cleanup import vm_cleanup
 from robottelo.cli.contentview import ContentView as ContentViewCLI
 from robottelo.constants import (
     DEFAULT_ARCHITECTURE,
@@ -194,6 +195,7 @@ class IncrementalUpdateTestCase(TestCase):
         # Create client machine and register it to satellite with
         # rhel_6_partial_ak
         self.vm = VirtualMachine(distro=DISTRO_RHEL6, tag='incupdate')
+        self.addCleanup(vm_cleanup, self.vm)
         self.setup_vm(self.vm, rhel_6_partial_ak.name, self.org.label)
         self.vm.enable_repo(REPOS['rhva6']['id'])
         self.vm.run('yum install -y {0}'.format(REAL_0_RH_PACKAGE))
@@ -203,11 +205,6 @@ class IncrementalUpdateTestCase(TestCase):
         self.partial_hosts = []
         for host in hosts:
             self.partial_hosts.append(host)
-
-    def tearDown(self):
-        """Destroys provisioned vm"""
-        self.vm.destroy()
-        super(IncrementalUpdateTestCase, self).tearDown()
 
     @staticmethod
     def setup_vm(client, act_key, org_name):

--- a/tests/foreman/ui/test_contenthost.py
+++ b/tests/foreman/ui/test_contenthost.py
@@ -16,6 +16,7 @@
 @Upstream: No
 """
 from nailgun import entities
+from robottelo.cleanup import vm_cleanup
 from robottelo.cli.factory import (
     setup_org_for_a_custom_repo,
     setup_org_for_a_rh_repo,
@@ -87,6 +88,7 @@ class ContentHostTestCase(UITestCase):
         katello-ca and katello-agent packages"""
         super(ContentHostTestCase, self).setUp()
         self.client = VirtualMachine(distro=DISTRO_RHEL7)
+        self.addCleanup(vm_cleanup, self.client)
         self.client.create()
         self.client.install_katello_ca()
         result = self.client.register_contenthost(
@@ -94,11 +96,6 @@ class ContentHostTestCase(UITestCase):
         self.assertEqual(result.return_code, 0)
         self.client.enable_repo(REPOS['rhst7']['id'])
         self.client.install_katello_agent()
-
-    def tearDown(self):
-        """Destroy the VM"""
-        self.client.destroy()
-        super(ContentHostTestCase, self).tearDown()
 
     @tier3
     def test_positive_install_package(self):

--- a/tests/foreman/ui/test_hostcollection.py
+++ b/tests/foreman/ui/test_hostcollection.py
@@ -19,6 +19,7 @@
 from fauxfactory import gen_string
 from nailgun import entities
 from robottelo.api.utils import promote
+from robottelo.cleanup import vm_cleanup
 from robottelo.cli.factory import (
     make_fake_host,
     setup_org_for_a_custom_repo,
@@ -460,6 +461,7 @@ class HostCollectionPackageManagementTest(UITestCase):
         self.hosts = []
         for _ in range(self.hosts_number):
             client = VirtualMachine(distro=DISTRO_RHEL7)
+            self.addCleanup(vm_cleanup, client)
             self.hosts.append(client)
             client.create()
             client.install_katello_ca()
@@ -477,12 +479,6 @@ class HostCollectionPackageManagementTest(UITestCase):
             host=host_ids,
             organization=self.session_org,
         ).create()
-
-    def tearDown(self):
-        """Destroy all the VMs"""
-        for client in self.hosts:
-            client.destroy()
-        super(HostCollectionPackageManagementTest, self).tearDown()
 
     def _validate_package_installed(self, hosts, package_name,
                                     expected_installed=True, timeout=120):


### PR DESCRIPTION
Closes #4105 (and all other places not mentioned in original issue)
tearDown has one serious drawback - it's executed only in case of failure inside the test and is not executed in case of exception inside setUp or setUpClass.
@ldjebran discovered we have issues with installing katello-agent in 6.3, which was installed inside of setUp/setUpClass, so the tests are failing in setUp/setUpClass correspondingly and tearDown is not being executed which leads to lots of vms not being destroyed.
Cleanup functions are being executed regardless of root place of failure, i.e. no matter if the failure happened in test or in setUp/setUpClass, that's why it works for us and resolves the issue.