### PR TITLE
Add more coverage for package content search functionality

### DIFF
--- a/robottelo/ui/locators/base.py
+++ b/robottelo/ui/locators/base.py
@@ -1778,6 +1778,7 @@ locators = LocatorDict({
     "package.build_time": (
         By.XPATH, "//span[text()='Build Time']/../.."
                   "/span[contains(@class, 'info-value')]"),
+    "package.content_file": (By.XPATH, "//div[contains(., '%s')]"),
 
     # System Groups
     "system-groups.new": (

--- a/robottelo/ui/locators/tab.py
+++ b/robottelo/ui/locators/tab.py
@@ -351,4 +351,12 @@ tab_locators = LocatorDict({
     "puppet_class.tab_smart_variable": (
         By.XPATH,
         "//a[@data-toggle='tab' and contains(@href, 'smart_vars')]"),
+
+    # Packages
+    "package.tab_details": (
+        By.XPATH, "//a[contains(@href, 'info')]/span"),
+    "package.tab_files": (
+        By.XPATH, "//a[contains(@href, 'files')]/span"),
+    "package.tab_dependencies": (
+        By.XPATH, "//a[contains(@href, 'dependencies')]/span"),
 })

--- a/robottelo/ui/packages.py
+++ b/robottelo/ui/packages.py
@@ -2,7 +2,7 @@
 """Implements Packages UI"""
 
 from robottelo.ui.base import Base, UIError
-from robottelo.ui.locators import locators
+from robottelo.ui.locators import locators, tab_locators
 from robottelo.ui.navigator import Navigator
 
 
@@ -45,3 +45,11 @@ class Package(Base):
                     ' expected to have "{2}"'.format(
                         parameter_name, actual_text, parameter_value)
                 )
+
+    def check_file_list(self, name, file_list):
+        """Check whether necessary file(s) are present in the package"""
+        self.click(self.search(name))
+        self.click(tab_locators['package.tab_files'])
+        for package_file in file_list:
+            self.wait_until_element(
+                locators['package.content_file'] % package_file)


### PR DESCRIPTION
Closes #3495
Seems as good enough coverage for that area. Of course, we can think about adding something more, but it will be a little bit advanced scenarios
```
nosetests tests/foreman/ui/test_packages.py
.....
----------------------------------------------------------------------
Ran 5 tests in 365.900s

OK
```