### PR TITLE
Fix smart varialbes tests.

### DIFF
--- a/robottelo/ui/hosts.py
+++ b/robottelo/ui/hosts.py
@@ -208,7 +208,7 @@ class Hosts(Base):
         self.wait_for_ajax()
         return output
 
-    def get_smart_variable_value(self, host_name, sv_name, hidden=False):
+    def get_smart_variable_value(self, host_name, sv_name):
         """Return smart variable value element for specific host
 
         :param str host_name: Name of Host to get smart variable information
@@ -220,14 +220,11 @@ class Hosts(Base):
         self.click(self.search(host_name))
         self.click(locators['host.edit'])
         self.click(tab_locators['host.tab_params'])
-        if hidden:
-            locator = locators['host.smart_variable_value_hidden'] % sv_name
-        else:
-            locator = locators['host.smart_variable_value'] % sv_name
-        return self.wait_until_element(locator)
+        return self.wait_until_element(
+            locators['host.smart_variable_value'] % sv_name)
 
     def set_smart_variable_value(self, host_name, sv_name, sv_value,
-                                 override=True, hidden=False):
+                                 override=True):
         """Set smart variable value for specific host
 
         :param str host_name: Name of Host where smart variable value should be
@@ -243,9 +240,6 @@ class Hosts(Base):
         self.click(tab_locators['host.tab_params'])
         if override:
             self.click(locators['host.smart_variable_override'] % sv_name)
-        if hidden:
-            locator = locators['host.smart_variable_value_hidden'] % sv_name
-        else:
-            locator = locators['host.smart_variable_value'] % sv_name
-        self.assign_value(locator, sv_value)
+        self.assign_value(
+            locators['host.smart_variable_value'] % sv_name, sv_value)
         self.click(common_locators['submit'])

--- a/robottelo/ui/hosts.py
+++ b/robottelo/ui/hosts.py
@@ -214,8 +214,6 @@ class Hosts(Base):
         :param str host_name: Name of Host to get smart variable information
             from
         :param str sv_name: Name of Smart Variable to be read
-        :param bool hidden: Specify whether it is expected that read value is
-            hidden on UI or not
         """
         self.click(self.search(host_name))
         self.click(locators['host.edit'])
@@ -230,10 +228,9 @@ class Hosts(Base):
         :param str host_name: Name of Host where smart variable value should be
             modified
         :param str sv_name: Name of Smart Variable to be modified
+        :param str sv_value: Value of Smart Variable that should be set
         :param bool override: Specify whether it is expected to override smart
             value or just edit its value
-        :param bool hidden: Specify whether it is expected that smart variable
-            value is hidden on UI or not
         """
         self.click(self.search(host_name))
         self.click(locators['host.edit'])

--- a/robottelo/ui/locators/base.py
+++ b/robottelo/ui/locators/base.py
@@ -638,9 +638,8 @@ locators = LocatorDict({
         "(//textarea[contains(@id, '_value') "
         "and contains(@name, 'parameters')])[%i]"),
     "host.smart_variable_value": (
-        By.XPATH, "//textarea[ancestor::tr//td[contains(., '%s')]]"),
-    "host.smart_variable_value_hidden": (
-        By.XPATH, "//input[ancestor::tr//td[contains(., '%s')]]"),
+        By.XPATH,
+        "//*[ancestor::tr//td[contains(., '%s')] and @data-property='value']"),
     "host.smart_variable_override": (
         By.XPATH,
         "//a[ancestor::tr//td[contains(., '%s')] and @data-tag='override']"
@@ -657,7 +656,7 @@ locators = LocatorDict({
     ),
     "host.smart_variable_puppet_class": (
         By.XPATH, "//td[contains(., '%s')]//ancestor::tbody/tr[1]/td[1]"),
-    "host.override_error": (By.XPATH, "//td[@class='has-error']"),
+    "host.override_error": (By.CSS_SELECTOR, "input:invalid[value='%s']"),
 
     # host.vm (NOTE:- visible only when selecting a compute resource)
     "host.cpus": (
@@ -2373,10 +2372,6 @@ locators = LocatorDict({
         By.XPATH,
         "//textarea[(ancestor::div[@class='tab-pane fields active'] or "
         "contains(@id, 'variable_')) and contains(@name, '[default_value]')]"),
-    "smart_variable.default_value_hidden": (
-        By.XPATH,
-        "//input[(ancestor::div[@class='tab-pane fields active'] or "
-        "contains(@id, 'variable_')) and contains(@name, '[default_value]')]"),
     "smart_variable.hidden_value": (
         By.XPATH,
         "//input[(ancestor::div[@class='tab-pane fields active'] or "
@@ -2434,11 +2429,6 @@ locators = LocatorDict({
     "smart_variable.matcher_value": (
         By.XPATH,
         "(//textarea[(ancestor::div[@class='tab-pane fields active'] or "
-        "contains(@id, 'variable_')) and contains(@name, '[value]')])[%i]"
-    ),
-    "smart_variable.matcher_value_hidden": (
-        By.XPATH,
-        "(//input[(ancestor::div[@class='tab-pane fields active'] or "
         "contains(@id, 'variable_')) and contains(@name, '[value]')])[%i]"
     ),
     "smart_variable.matcher_error": (By.XPATH, "//tr[@class='has-error']"),

--- a/tests/foreman/api/test_variables.py
+++ b/tests/foreman/api/test_variables.py
@@ -21,7 +21,7 @@ from fauxfactory import gen_integer, gen_string
 from nailgun import entities
 from requests import HTTPError
 
-from robottelo.api.utils import delete_puppet_class, publish_puppet_module
+from robottelo.api.utils import publish_puppet_module
 from robottelo.constants import CUSTOM_PUPPET_REPO
 from robottelo.datafactory import invalid_values_list, valid_data_list
 from robottelo.decorators import (
@@ -60,15 +60,20 @@ class SmartVariablesTestCase(APITestCase):
         })[0]
         # And all its subclasses
         cls.puppet_subclasses = entities.PuppetClass().search(query={
-            'search': u'name = "{0}::" and environment = "{1}"'.format(
+            'search': u'name ~ "{0}::" and environment = "{1}"'.format(
                 cls.puppet_modules[0]['name'], cls.env.name)
         })
 
-    @classmethod
-    def tearDownClass(cls):
-        """Removes puppet class."""
-        super(SmartVariablesTestCase, cls).tearDownClass()
-        delete_puppet_class(cls.puppet_class.name)
+    # TearDown brakes parallel tests run as every test depends on the same
+    # puppet class that will be removed during TearDown.
+    # Uncomment for developing or debugging and do not forget to import
+    # `robottelo.api.utils.delete_puppet_class`.
+    #
+    # @classmethod
+    # def tearDownClass(cls):
+    #     """Removes puppet class."""
+    #     super(SmartVariablesTestCase, cls).tearDownClass()
+    #     delete_puppet_class(cls.puppet_class.name)
 
     @run_only_on('sat')
     @tier1

--- a/tests/foreman/cli/test_variables.py
+++ b/tests/foreman/cli/test_variables.py
@@ -19,7 +19,6 @@ from random import choice
 
 from nailgun import entities
 
-from robottelo.api.utils import delete_puppet_class
 from robottelo.cli.base import CLIReturnCodeError
 from robottelo.cli.environment import Environment
 from robottelo.cli.factory import (
@@ -77,11 +76,16 @@ class SmartVariablesTestCase(CLITestCase):
                 cls.puppet_class['name'], cls.env['name'])
         })
 
-    @classmethod
-    def tearDownClass(cls):
-        """Removes puppet class."""
-        super(SmartVariablesTestCase, cls).tearDownClass()
-        delete_puppet_class(cls.puppet_class['name'])
+    # TearDown brakes parallel tests run as every test depends on the same
+    # puppet class that will be removed during TearDown
+    # Uncomment for developing or debugging and do not forget to import
+    # `robottelo.api.utils.delete_puppet_class`.
+    #
+    # @classmethod
+    # def tearDownClass(cls):
+    #     """Removes puppet class."""
+    #     super(SmartVariablesTestCase, cls).tearDownClass()
+    #     delete_puppet_class(cls.puppet_class['name'])
 
     @run_only_on('sat')
     @tier2

--- a/tests/foreman/cli/test_variables.py
+++ b/tests/foreman/cli/test_variables.py
@@ -336,11 +336,11 @@ class SmartVariablesTestCase(CLITestCase):
             with self.subTest(new_name):
                 SmartVariable.update({
                     'id': smart_variable['id'],
-                    'new-name': new_name,
+                    'new-variable': new_name,
                     'puppet-class': self.puppet_class['name']
                 })
                 updated_sv = SmartVariable.info({'id': smart_variable['id']})
-                self.assertEqual(updated_sv['name'], new_name)
+                self.assertEqual(updated_sv['variable'], new_name)
 
     @run_only_on('sat')
     @tier1
@@ -540,7 +540,7 @@ class SmartVariablesTestCase(CLITestCase):
 
         @assert: Variable is created for matched validator rule.
         """
-        value = gen_string('numeric')
+        value = gen_string('numeric').lstrip('0')
         smart_variable = make_smart_variable({
             'puppet-class': self.puppet_class['name'],
             'default-value': gen_string('alpha')
@@ -597,7 +597,7 @@ class SmartVariablesTestCase(CLITestCase):
 
         @assert: Matcher is created for matched validator rule.
         """
-        value = gen_string('numeric')
+        value = gen_string('numeric').lstrip('0')
         smart_variable = make_smart_variable({
             'puppet-class': self.puppet_class['name'],
             'default-value': gen_string('numeric'),


### PR DESCRIPTION
This change should fix 44 failures for `ui/test_variables` and 15 failures for `cli/test_variables`. Closes #3938 and also #3931.

```python
 py.test -n 2 -v tests/foreman/ui/test_variables.py
=========================================================== 1 failed, 43 passed in 2848.72 seconds ============================================================
```
1 failure looks more like a problem with my local infrastructure, after re-run it passed.
```python
py.test -v tests/foreman/ui/test_variables.py -k 'test_positive_update_name'
===================================================================== test session starts =====================================================================
platform linux2 -- Python 2.7.12, pytest-3.0.4, py-1.4.31, pluggy-0.4.0 -- /home/qui/code/venv/2/bin/python2
tests/foreman/ui/test_variables.py::SmartVariablesTestCase::test_positive_update_name <- robottelo/decorators/__init__.py PASSED
===================================================================== 43 tests deselected =====================================================================
========================================================== 1 passed, 43 deselected in 237.46 seconds ==========================================================
```
