### PR TITLE
Add capsule API tests

### DIFF
--- a/tests/foreman/api/test_smartproxy.py
+++ b/tests/foreman/api/test_smartproxy.py
@@ -14,14 +14,224 @@
 
 @Upstream: No
 """
+from fauxfactory import gen_string
 from nailgun import entities
+from requests import HTTPError
+
+from robottelo.api.utils import one_to_many_names
+from robottelo.cleanup import capsule_cleanup
 from robottelo.config import settings
+from robottelo.datafactory import valid_data_list
 from robottelo.decorators import (
+    bz_bug_is_open,
+    run_only_on,
     skip_if_bug_open,
+    skip_if_not_set,
     tier1,
+    tier2,
+)
+from robottelo.helpers import (
+    default_url_on_new_port,
+    get_available_capsule_port,
 )
 from robottelo.test import APITestCase
-from robottelo.api.utils import one_to_many_names
+
+
+class CapsuleTestCase(APITestCase):
+    """Tests for Smart Proxy (Capsule) entity."""
+
+    @skip_if_not_set('fake_capsules')
+    @run_only_on('sat')
+    @tier1
+    def test_negative_create_with_url(self):
+        """Proxy creation with random URL
+
+        @id: e48a6260-97e0-4234-a69c-77bbbcde85d6
+
+        @Assert: Proxy is not created
+        """
+        # Create a random proxy
+        with self.assertRaises(HTTPError) as context:
+            entities.SmartProxy(
+                url='http://{0}:{1}'.format(
+                    gen_string('alpha', 6),
+                    gen_string('numeric', 4)
+                )).create()
+        self.assertRegexpMatches(
+            context.exception.response.text, u'Unable to communicate')
+
+    @skip_if_not_set('fake_capsules')
+    @run_only_on('sat')
+    @tier1
+    def test_positive_create_with_name(self):
+        """Proxy creation with valid name
+
+        @id: 0ffe0dc5-675e-45f4-b7e1-a14d3dd81f6e
+
+        @Assert: Proxy is created
+        """
+        for name in valid_data_list():
+            with self.subTest(name):
+                with default_url_on_new_port(
+                        9090, get_available_capsule_port()) as url:
+                    proxy = entities.SmartProxy(name=name, url=url).create()
+                    self.assertEquals(proxy.read().name, name)
+                # Add capsule id to cleanup list
+                self.addCleanup(capsule_cleanup, proxy.id)
+
+    @skip_if_not_set('fake_capsules')
+    @run_only_on('sat')
+    @tier1
+    def test_positive_delete(self):
+        """Proxy deletion
+
+        @id: 872bf12e-736d-43d1-87cf-2923966b59d0
+
+        @Assert: Proxy is deleted
+        """
+        with default_url_on_new_port(
+                9090, get_available_capsule_port()) as url:
+            proxy = entities.SmartProxy(url=url).create()
+        if bz_bug_is_open(1398695):
+            try:
+                proxy.delete()
+            except HTTPError as err:
+                if "Can't modify frozen hash" not in err.response.text:
+                    raise err
+        else:
+            proxy.delete()
+        with self.assertRaises(HTTPError):
+            proxy.read()
+
+    @skip_if_not_set('fake_capsules')
+    @run_only_on('sat')
+    @tier1
+    def test_positive_update_name(self):
+        """Proxy name update
+
+        @id: f279640e-d7e9-48a3-aed8-7bf406e9d6f2
+
+        @Assert: Proxy has the name updated
+        """
+        with default_url_on_new_port(
+                9090, get_available_capsule_port()) as url:
+            proxy = entities.SmartProxy(url=url).create()
+            for new_name in valid_data_list():
+                with self.subTest(new_name):
+                    proxy.name = new_name
+                    proxy.update(['name'])
+                    self.assertEqual(proxy.read().name, new_name)
+        # Add capsule id to cleanup list
+        self.addCleanup(capsule_cleanup, proxy.id)
+
+    @skip_if_not_set('fake_capsules')
+    @run_only_on('sat')
+    @tier1
+    def test_positive_update_url(self):
+        """Proxy url update
+
+        @id: 0305fd54-4e0c-4dd9-a537-d342c3dc867e
+
+        @Assert: Proxy has the url updated
+        """
+        with default_url_on_new_port(
+                9090, get_available_capsule_port()) as url:
+            proxy = entities.SmartProxy(url=url).create()
+        with default_url_on_new_port(
+                9090, get_available_capsule_port()) as url:
+            proxy.url = url
+            proxy.update(['url'])
+            self.assertEqual(proxy.read().url, url)
+        # Add capsule id to cleanup list
+        self.addCleanup(capsule_cleanup, proxy.id)
+
+    @skip_if_not_set('fake_capsules')
+    @run_only_on('sat')
+    @tier1
+    def test_positive_update_organization(self):
+        """Proxy name update with the home proxy
+
+        @id: 62631275-7a92-4d34-a949-c56e0c4063f1
+
+        @Assert: Proxy has the name updated
+        """
+        organizations = [
+            entities.Organization().create().read() for _ in range(2)]
+        newport = get_available_capsule_port()
+        with default_url_on_new_port(9090, newport) as url:
+            proxy = entities.SmartProxy(url=url).create()
+            proxy.organization = organizations
+            proxy.update(['organization'])
+            self.assertEqual(
+                {org.id for org in proxy.read().organization},
+                {org.id for org in organizations}
+            )
+        # Add capsule id to cleanup list
+        self.addCleanup(capsule_cleanup, proxy.id)
+
+    @skip_if_not_set('fake_capsules')
+    @run_only_on('sat')
+    @tier1
+    def test_positive_update_location(self):
+        """Proxy name update with the home proxy
+
+        @id: e08eaaa9-7c11-4cda-bbe7-6d1f7c732569
+
+        @Assert: Proxy has the name updated
+        """
+        locations = [entities.Location().create().read() for _ in range(2)]
+        with default_url_on_new_port(
+                9090, get_available_capsule_port()) as url:
+            proxy = entities.SmartProxy(url=url).create()
+            proxy.location = locations
+            proxy.update(['location'])
+            self.assertEqual(
+                {loc.id for loc in proxy.read().location},
+                {loc.id for loc in locations}
+            )
+        # Add capsule id to cleanup list
+        self.addCleanup(capsule_cleanup, proxy.id)
+
+    @skip_if_not_set('fake_capsules')
+    @run_only_on('sat')
+    @tier2
+    def test_positive_refresh_features(self):
+        """Refresh smart proxy features, search for proxy by id
+
+        @id: d0237546-702e-4d1a-9212-8391295174da
+
+        @Assert: Proxy features are refreshed
+
+        @CaseLevel: Integration
+        """
+        # Since we want to run multiple commands against our fake capsule, we
+        # need the tunnel kept open in order not to allow different concurrent
+        # test to claim it. Thus we want to manage the tunnel manually.
+
+        # get an available port for our fake capsule
+        with default_url_on_new_port(
+                9090, get_available_capsule_port()) as url:
+            proxy = entities.SmartProxy(url=url).create()
+            proxy.refresh()
+        # Add capsule id to cleanup list
+        self.addCleanup(capsule_cleanup, proxy.id)
+
+    @skip_if_not_set('fake_capsules')
+    @run_only_on('sat')
+    @tier1
+    def test_positive_import_puppet_classes(self):
+        """Import puppet classes from proxy
+
+        @id: 385efd1b-6146-47bf-babf-0127ce5955ed
+
+        @Assert: Puppet classes are imported from proxy
+        """
+        with default_url_on_new_port(
+                9090, get_available_capsule_port()) as url:
+            proxy = entities.SmartProxy(url=url).create()
+            proxy.import_puppetclasses()
+        # Add capsule id to cleanup list
+        self.addCleanup(capsule_cleanup, proxy.id)
 
 
 class SmartProxyMissingAttrTestCase(APITestCase):

--- a/tests/foreman/cli/test_capsule.py
+++ b/tests/foreman/cli/test_capsule.py
@@ -23,8 +23,8 @@ from robottelo.cli.factory import CLIFactoryError, make_proxy
 from robottelo.cli.proxy import Proxy
 from robottelo.datafactory import valid_data_list
 from robottelo.decorators import (
-    bz_bug_is_open,
     run_only_on,
+    skip_if_bug_open,
     skip_if_not_set,
     stubbed,
     tier1,
@@ -81,6 +81,7 @@ class CapsuleTestCase(CLITestCase):
 
     @skip_if_not_set('fake_capsules')
     @run_only_on('sat')
+    @skip_if_bug_open('bugzilla', 1398695)
     @tier1
     def test_positive_delete_by_id(self):
         """Proxy deletion with the home proxy
@@ -92,14 +93,7 @@ class CapsuleTestCase(CLITestCase):
         for name in valid_data_list():
             with self.subTest(name):
                 proxy = make_proxy({u'name': name})
-                if bz_bug_is_open(1398695):
-                    try:
-                        Proxy.delete({'id': proxy['id']})
-                    except CLIReturnCodeError as err:
-                        if err.return_code != 70:
-                            raise err
-                else:
-                    Proxy.delete({'id': proxy['id']})
+                Proxy.delete({'id': proxy['id']})
                 with self.assertRaises(CLIReturnCodeError):
                     Proxy.info({u'id': proxy['id']})
 


### PR DESCRIPTION
Added CRUD API tests for Smart Proxy. Part of #4091.
Depends on SatelliteQE/nailgun#343

```python
% nosetests tests/foreman/api/test_smartproxy.py:CapsuleTestCase
.........
----------------------------------------------------------------------
Ran 9 tests in 257.669s
OK
```