### PR TITLE
[6.2.z]Implement host-collection erratum

### DIFF
--- a/robottelo/cleanup.py
+++ b/robottelo/cleanup.py
@@ -25,6 +25,14 @@ def org_cleanup(org_id=None):
     entities.Organization(id=org_id).delete()
 
 
+def vm_cleanup(vm):
+    """Destroys virtual machine
+
+    :param robottelo.vm.VirtualMachine vm: virtual machine to destroy
+    """
+    vm.destroy()
+
+
 class EntitiesCleaner(object):
     """Register and clean entities for cleanup using signals"""
 

--- a/robottelo/cli/hostcollection.py
+++ b/robottelo/cli/hostcollection.py
@@ -99,3 +99,17 @@ class HostCollection(Base):
         cls.command_sub = 'hosts'
         return cls.execute(
             cls._construct_command(options), output_format='csv')
+
+    @classmethod
+    def erratum_install(cls, options):
+        """Schedule errata for installation"""
+        cls.command_sub = 'erratum install'
+        return cls.execute(
+            cls._construct_command(options), output_format='csv')
+
+    @classmethod
+    def package_install(cls, options):
+        """Schedule package for installation"""
+        cls.command_sub = 'package install'
+        return cls.execute(
+            cls._construct_command(options), output_format='csv')


### PR DESCRIPTION
Issue https://github.com/SatelliteQE/robottelo/issues/3774
```bash
(2.7) dlezz@elysion:~/projects/robottelo-fork$ py.test tests/foreman/cli/test_errata.py -v -k "test_negative_install_by_hc_id_without_errata_info or test_negative_install_by_hc_name_without_errata_info or test_negative_install_without_hc_info or test_negative_install_by_hc_id_without_org_info or test_negative_install_by_hc_name_without_org_info"
================================================= test session starts ==================================================
platform linux2 -- Python 2.7.12, pytest-2.9.2, py-1.4.31, pluggy-0.3.1 -- /home/dlezz/bin/redhat/6.2.z/python/2.7/bin/python
cachedir: .cache
rootdir: /home/dlezz/projects/robottelo-fork, inifile: 
plugins: xdist-1.14, cov-2.3.1
collected 34 items 

tests/foreman/cli/test_errata.py::HostCollectionErrataInstallTestCase::test_negative_install_by_hc_id_without_errata_info <- robottelo/decorators/__init__.py PASSED
tests/foreman/cli/test_errata.py::HostCollectionErrataInstallTestCase::test_negative_install_by_hc_id_without_org_info <- robottelo/decorators/__init__.py PASSED
tests/foreman/cli/test_errata.py::HostCollectionErrataInstallTestCase::test_negative_install_by_hc_name_without_errata_info <- robottelo/decorators/__init__.py PASSED
tests/foreman/cli/test_errata.py::HostCollectionErrataInstallTestCase::test_negative_install_by_hc_name_without_org_info <- robottelo/decorators/__init__.py PASSED
tests/foreman/cli/test_errata.py::HostCollectionErrataInstallTestCase::test_negative_install_without_hc_info <- robottelo/decorators/__init__.py PASSED

 29 tests deselected by '-ktest_negative_install_by_hc_id_without_errata_info or test_negative_install_by_hc_name_without_errata_info or test_negative_install_without_hc_info or test_negative_install_by_hc_id_without_org_info or test_negative_install_by_hc_name_without_org_info' 
====================================== 5 passed, 29 deselected in 2593.74 seconds ======================================
(2.7) dlezz@elysion:~/projects/robottelo-fork$ 
```
 - Because of the bug I made only the negative tests to show that the virtual machines are setup correctly
 - This tests are here to be cherry-picked in the future when the bug will be fixed on 6.3