### PR TITLE
Automated chained lifecycle environments table fits screen

### DIFF
--- a/robottelo/ui/locators/base.py
+++ b/robottelo/ui/locators/base.py
@@ -1461,6 +1461,9 @@ locators = LocatorDict({
     "content_env.edit_description_textarea.save": (
         By.XPATH,
         "//form[@bst-edit-textarea='environment.description']//button"),
+    "content_env.table": (
+        By.XPATH,
+        "//table[contains(@class,'environment-table')]"),
 
     # GPG Key
     "gpgkey.new": (By.XPATH, "//button[@ui-sref='gpg-keys.new']"),

--- a/robottelo/ui/locators/common.py
+++ b/robottelo/ui/locators/common.py
@@ -9,6 +9,8 @@ common_locators = LocatorDict({
 
     # common locators
 
+    "body": (By.CSS_SELECTOR, "body"),
+
     # Notifications
     "notif.error": (
         By.XPATH, "//div[contains(@class, 'jnotify-notification-error')]"),

--- a/tests/foreman/ui/test_lifecycleenvironment.py
+++ b/tests/foreman/ui/test_lifecycleenvironment.py
@@ -15,13 +15,16 @@
 
 @Upstream: No
 """
+from itertools import chain
 
-from fauxfactory import gen_string
+from fauxfactory import gen_string, gen_alpha
 from nailgun import entities
+
 from robottelo.datafactory import generate_strings_list
 from robottelo.decorators import run_only_on, stubbed, tier1, tier2
 from robottelo.test import UITestCase
 from robottelo.ui.factory import make_lifecycle_environment
+from robottelo.ui.locators.base import locators
 from robottelo.ui.session import Session
 
 
@@ -154,3 +157,22 @@ class LifeCycleEnvironmentTestCase(UITestCase):
 
         @caseautomation: notautomated
         """
+
+    def test_positive_env_list_fits_screen(self):
+        """Check if long list of lifecycle environments fits into screen
+
+        @BZ: 1295922
+
+        """
+        with Session(self.browser) as session:
+            env_names = [gen_alpha() for _ in range(11)]
+            for name, prior in zip(env_names, chain([None], env_names)):
+                make_lifecycle_environment(
+                    session,
+                    org=self.org_name,
+                    name=name,
+                    prior=prior
+                )
+                envs_table=session.nav.wait_until_element(locator=locators[
+                    'content_env.table'])
+                print(envs_table)

--- a/tests/foreman/ui/test_lifecycleenvironment.py
+++ b/tests/foreman/ui/test_lifecycleenvironment.py
@@ -17,14 +17,14 @@
 """
 from itertools import chain
 
-from fauxfactory import gen_string, gen_alpha
+from fauxfactory import gen_string
 from nailgun import entities
 
 from robottelo.datafactory import generate_strings_list
 from robottelo.decorators import run_only_on, stubbed, tier1, tier2
 from robottelo.test import UITestCase
 from robottelo.ui.factory import make_lifecycle_environment
-from robottelo.ui.locators.base import locators
+from robottelo.ui.locators import common_locators, locators
 from robottelo.ui.session import Session
 
 
@@ -158,14 +158,20 @@ class LifeCycleEnvironmentTestCase(UITestCase):
         @caseautomation: notautomated
         """
 
-    def test_positive_env_list_fits_screen(self):
+    @tier1
+    def test_positive_env_list_fits_browser_screen(self):
         """Check if long list of lifecycle environments fits into screen
+
+        @id: 63b985b0-c847-11e6-92ad-68f72889dc7f
+
+        @Setup: save 8+ chained lifecycles environments
 
         @BZ: 1295922
 
+        @Assert: lifecycle environments table fits screen
         """
         with Session(self.browser) as session:
-            env_names = [gen_alpha() for _ in range(11)]
+            env_names = [gen_string('alpha') for _ in range(11)]
             for name, prior in zip(env_names, chain([None], env_names)):
                 make_lifecycle_environment(
                     session,
@@ -173,6 +179,10 @@ class LifeCycleEnvironmentTestCase(UITestCase):
                     name=name,
                     prior=prior
                 )
-                envs_table=session.nav.wait_until_element(locator=locators[
-                    'content_env.table'])
-                print(envs_table)
+            envs_table = session.nav.wait_until_element(
+                locator=locators['content_env.table']
+            )
+            table_width = envs_table.size['width']
+            body = session.nav.find_element(common_locators['body'])
+            body_width = body.size['width']
+            self.assertGreaterEqual(body_width - table_width, 0)


### PR DESCRIPTION
close #3215

Test result:

```console
/home/renzo/PycharmProjects/venvs/robottelo/bin/python /home/renzo/bin/pycharm-2016.3/helpers/pycharm/pytestrunner.py -p pytest_teamcity /home/renzo/PycharmProjects/robottelo/tests/foreman/ui/test_lifecycleenvironment.py "-k LifeCycleEnvironmentTestCase and test_positive_env_list_fits_screen"
============================== 5 tests deselected ==============================
========= 1 passed, 5 deselected, 1 pytest-warnings in 241.74 seconds ==========
```