### PR TITLE
Add more coverage to Errate UI Page

### DIFF
--- a/robottelo/constants.py
+++ b/robottelo/constants.py
@@ -1207,3 +1207,11 @@ TOOLS_ERRATA_DETAILS = [
         'Before applying this update, make sure all previously released errata'
     ],
 ]
+
+TOOLS_ERRATA_TABLE_DETAILS = [
+    'RHBA-2016:1503',
+    'Satellite 6.2 Tools Release',
+    'Bug Fix Advisory',
+    'Installable',
+    '7/27/16'
+]

--- a/robottelo/constants.py
+++ b/robottelo/constants.py
@@ -1187,3 +1187,23 @@ BACKUP_FILES = [
     u'pulp_data.tar',
     u'pulp.snar',
 ]
+
+TOOLS_ERRATA_DETAILS = [
+    ['Advisory', 'RHBA-2016:1503'],
+    ['CVEs', 'N/A'],
+    ['Type', 'Bug Fix Advisory'],
+    ['Severity', 'None'],
+    ['Issued', '7/27/16'],
+    ['Last Updated On', '7/27/16'],
+    ['Reboot Suggested', 'No'],
+    [
+        'Topic',
+        'Red Hat Satellite 6.2 now available for Red Hat Enterprise Linux 6 '
+        'and 7'
+    ],
+    ['Description', 'This update provides Satellite 6.2 client tooling'],
+    [
+        'Solution',
+        'Before applying this update, make sure all previously released errata'
+    ],
+]

--- a/robottelo/ui/errata.py
+++ b/robottelo/ui/errata.py
@@ -139,6 +139,16 @@ class Errata(Base):
                         parameter_name, actual_text, parameter_value)
                 )
 
+    def validate_table_fields(
+            self, errata_id, only_applicable=None, values_list=None):
+        """Check that errata table fields has appropriate values"""
+        if only_applicable is not None:
+            self.navigate_to_entity()
+            self.show_only_applicable(only_applicable)
+        self.search(errata_id)
+        for value in values_list:
+            self.wait_until_element(locators['errata.table_value'] % value)
+
     def auto_complete_search(self, errata_id, partial_id=None,
                              only_applicable=None):
         """Auto complete search by giving partial ID of errata."""

--- a/robottelo/ui/errata.py
+++ b/robottelo/ui/errata.py
@@ -132,7 +132,7 @@ class Errata(Base):
                 (parameter_name.lower()).replace(' ', '_')
             ))
             actual_text = self.wait_until_element(locators[param_locator]).text
-            if actual_text != parameter_value:
+            if parameter_value not in actual_text:
                 raise UIError(
                     'Actual text for "{0}" parameter is "{1}", but it is'
                     ' expected to have "{2}"'.format(

--- a/robottelo/ui/locators/base.py
+++ b/robottelo/ui/locators/base.py
@@ -2419,6 +2419,8 @@ locators = LocatorDict({
         "//span[text()='Affected Packages']/.."
         "/following-sibling::ul[1]/li/a[contains(., '%s')]"
     ),
+    "errata.table_value": (
+        By.XPATH, "//td[contains(normalize-space(.), '%s')]"),
 
 
     # Smart Variable

--- a/robottelo/ui/locators/base.py
+++ b/robottelo/ui/locators/base.py
@@ -2352,9 +2352,6 @@ locators = LocatorDict({
     "errata.filter_applicable": (
         By.XPATH, "//input[@ng-model='showApplicable']"),
     "errata.select_name": (By.XPATH, "//a[contains(., '%s')]"),
-    "errata.cves": (
-        By.XPATH,
-        "//span[text()='CVEs']/../../span[contains(@class, 'info-value')]"),
     "errata.content_hosts.installable": (
         By.XPATH, "//input[@ng-model='restrictInstallable']"),
     "errata.content_hosts.env_filter": (
@@ -2375,6 +2372,54 @@ locators = LocatorDict({
         ("//a[contains(@href, 'repositories') and contains(., '%s')]"
          "[../following-sibling::td/a[contains(@ui-sref, 'products.details') "
          "and contains(., '%s')]]")),
+    "errata.advisory": (
+        By.XPATH,
+        "//span[text()='Advisory']/../../span[contains(@class, 'info-value')]"
+    ),
+    "errata.cves": (
+        By.XPATH,
+        "//span[text()='CVEs']/../../span[contains(@class, 'info-value')]"),
+    "errata.type": (
+        By.XPATH,
+        "//span[text()='Type']/../../span[contains(@class, 'info-value')]"
+    ),
+    "errata.severity": (
+        By.XPATH,
+        "//span[text()='Severity']/../../span[contains(@class, 'info-value')]"
+    ),
+    "errata.issued": (
+        By.XPATH,
+        "//span[text()='Issued']/../../span[contains(@class, 'info-value')]"
+    ),
+    "errata.last_updated_on": (
+        By.XPATH,
+        "//span[text()='Last Updated On']/../.."
+        "/span[contains(@class, 'info-value')]"),
+    "errata.reboot_suggested": (
+        By.XPATH,
+        "//span[text()='Reboot Suggested?']/../.."
+        "/span[contains(@class, 'info-value')]"),
+    "errata.topic": (
+        By.XPATH,
+        "//span[text()='Topic']/.."
+        "/following-sibling::p[contains(@class, 'info-paragraph')][1]"
+    ),
+    "errata.description": (
+        By.XPATH,
+        "//span[text()='Description']/.."
+        "/following-sibling::p[contains(@class, 'info-paragraph')][1]"
+    ),
+    "errata.solution": (
+        By.XPATH,
+        "//span[text()='Solution']/.."
+        "/following-sibling::p[contains(@class, 'info-paragraph')][1]"
+    ),
+    "errata.affected_packages": (
+        By.XPATH,
+        "//span[text()='Affected Packages']/.."
+        "/following-sibling::ul[1]/li/a[contains(., '%s')]"
+    ),
+
 
     # Smart Variable
     "smart_variable.new": (By.XPATH, "//a[contains(., '+ Add Variable')]"),

--- a/tests/foreman/ui/test_errata.py
+++ b/tests/foreman/ui/test_errata.py
@@ -42,6 +42,7 @@ from robottelo.constants import (
     REAL_0_RH_PACKAGE,
     REPOS,
     REPOSET,
+    TOOLS_ERRATA_DETAILS,
 )
 from robottelo.decorators import (
     run_in_one_thread,
@@ -284,29 +285,6 @@ class ErrataTestCase(UITestCase):
                     self.assertIsNotNone(self.contenthost.package_search(
                         client.hostname, FAKE_2_CUSTOM_PACKAGE))
 
-    @stubbed()
-    @tier2
-    def test_positive_view(self):
-        """View erratum similar to RH Customer portal
-
-        @id: 7d0814fd-70e8-4451-ac96-c632cae55731
-
-        @Setup: Errata synced on satellite server.
-
-        @Steps:
-
-        1. Go to Content -> Errata. Review the Errata page.
-
-        @Assert: The following fields are displayed: Errata Id, Title, Type,
-        Affected Content Hosts, Updated.
-
-        @caseautomation: notautomated
-
-
-        @CaseLevel: Integration
-        """
-
-    @stubbed()
     @tier2
     def test_positive_view_details(self):
         """View erratum details similar to RH Customer portal
@@ -323,11 +301,14 @@ class ErrataTestCase(UITestCase):
         Severity, Issued, Last Update on, Reboot Suggested, Topic, Description,
         Solution, Affected Packages.
 
-        @caseautomation: notautomated
-
-
         @CaseLevel: Integration
         """
+        with Session(self.browser):
+            self.errata.check_errata_details(
+                REAL_0_ERRATA_ID,
+                TOOLS_ERRATA_DETAILS,
+                only_applicable=False,
+            )
 
     @tier2
     def test_positive_view_products_and_repos(self):

--- a/tests/foreman/ui/test_errata.py
+++ b/tests/foreman/ui/test_errata.py
@@ -43,6 +43,7 @@ from robottelo.constants import (
     REPOS,
     REPOSET,
     TOOLS_ERRATA_DETAILS,
+    TOOLS_ERRATA_TABLE_DETAILS,
 )
 from robottelo.decorators import (
     run_in_one_thread,
@@ -284,6 +285,30 @@ class ErrataTestCase(UITestCase):
                 for client in clients:
                     self.assertIsNotNone(self.contenthost.package_search(
                         client.hostname, FAKE_2_CUSTOM_PACKAGE))
+
+    @tier2
+    def test_positive_view(self):
+        """View erratum similar to RH Customer portal
+
+        @id: 7d0814fd-70e8-4451-ac96-c632cae55731
+
+        @Setup: Errata synced on satellite server.
+
+        @Steps:
+
+        1. Go to Content -> Errata. Review the Errata page.
+
+        @Assert: The following fields: Errata Id, Title, Type, Affected Content
+        Hosts, Updated has expected values for errata table.
+
+        @CaseLevel: Integration
+        """
+        with Session(self.browser):
+            self.errata.validate_table_fields(
+                REAL_0_ERRATA_ID,
+                only_applicable=False,
+                values_list=TOOLS_ERRATA_TABLE_DETAILS
+            )
 
     @tier2
     def test_positive_view_details(self):


### PR DESCRIPTION
Closes #3494 

That issue actually was covered and we can close it anyway, but I decided to implement one more stub before closing it. Also, removed one stub that is really hard to cover from selenium perspective and its value is almost equal to none

```
nosetests tests/foreman/ui/test_errata.py -m test_positive_view_details
.
----------------------------------------------------------------------
Ran 1 test in 555.844s

OK
```