### PR TITLE
Fix config group delete test case for UI

### DIFF
--- a/robottelo/ui/configgroups.py
+++ b/robottelo/ui/configgroups.py
@@ -42,5 +42,4 @@ class ConfigGroups(Base):
             name,
             really,
             locators['config_groups.delete'],
-            drop_locator=locators['config_groups.dropdown'],
         )

--- a/tests/foreman/ui/test_config_group.py
+++ b/tests/foreman/ui/test_config_group.py
@@ -92,10 +92,9 @@ class ConfigGroupTestCase(UITestCase):
         @id: 50879d3c-7c38-4294-aae4-0f3f146c9613
 
         @Assert: Config-Groups is deleted
-
         """
         with Session(self.browser) as session:
-            for name in generate_strings_list(length=8):
+            for name in valid_data_list():
                 with self.subTest(name):
                     make_config_groups(session, name=name)
                     self.configgroups.delete(name)


### PR DESCRIPTION
Delete button is not located in dropdown anymore

```
nosetests tests/foreman/ui/test_config_group.py
....
----------------------------------------------------------------------
Ran 4 tests in 467.121s

OK
```