### PR TITLE
Fix compute profile issue with dropdown

### DIFF
--- a/robottelo/ui/computeprofile.py
+++ b/robottelo/ui/computeprofile.py
@@ -18,8 +18,7 @@ class ComputeProfile(Base):
     def create(self, name):
         """Creates new compute profile entity"""
         self.click(locators['profile.new'])
-        self.wait_until_element(locators['profile.name']).send_keys(name)
-        self.wait_for_ajax()
+        self.assign_value(locators['profile.name'], name)
         self.click(common_locators['submit'])
 
     def update(self, old_name, new_name):
@@ -29,11 +28,8 @@ class ComputeProfile(Base):
             raise UINoSuchElementError(
                 'Could not find compute profile {0}'.format(old_name))
         if element:
-            strategy, value = locators['profile.dropdown']
-            self.click((strategy, value % old_name))
-            strategy, value = locators['profile.rename']
-            self.click((strategy, value % old_name))
-            self.field_update('profile.name', new_name)
+            self.click(locators['profile.rename'] % old_name)
+            self.assign_value(locators['profile.name'], new_name)
             self.click(common_locators['submit'])
 
     def delete(self, name, really=True):
@@ -52,14 +48,8 @@ class ComputeProfile(Base):
         resource (e.g. '2-Medium' or '1-Small')
         :param res_name: Name of compute resource to select from the list
         :param res_type: Type of compute resource (e.g. 'Libvirt' or 'Docker')
-
         """
-        profile = self.search(profile_name)
-        if profile is None:
-            raise UINoSuchElementError(
-                u'Could not find the profile {0}'.format(profile_name))
-        profile.click()
+        self.search_and_click(profile_name)
         resource = u'{0} ({1})'.format(res_name, res_type)
-        strategy, value = locators['profile.resource_name']
-        self.click((strategy, value % resource))
+        self.click(locators['profile.resource_name'] % resource)
         return self.wait_until_element(locators['profile.resource_form'])

--- a/robottelo/ui/locators/base.py
+++ b/robottelo/ui/locators/base.py
@@ -219,7 +219,7 @@ locators = LocatorDict({
     "profile.rename": (
         By.XPATH,
         ("//td/a[contains(., '%s')]"
-         "/following::td/div/ul/li/a[text()='Rename']")),
+         "/following::td/div/span/a[text()='Rename']")),
     "profile.delete": (
         By.XPATH,
         ("//td/a[contains(., '%s')]"


### PR DESCRIPTION
Rename button is now located outside dropdown. Refactored code a bit.

```
nosetests tests/foreman/ui/test_computeprofile.py
.....
----------------------------------------------------------------------
Ran 5 tests in 307.256s

OK
```

```
nosetests tests/foreman/ui/test_computeresource.py -m test_positive_access_libvirt_via_profile
.
----------------------------------------------------------------------
Ran 1 test in 58.267s

OK
```