### PR TITLE
#4101-CLI-Implement CV version removal

### DIFF
--- a/robottelo/constants.py
+++ b/robottelo/constants.py
@@ -452,6 +452,7 @@ FILTER_ERRATA_DATE = {
 }
 
 DOCKER_REGISTRY_HUB = u'https://registry-1.docker.io'
+DOCKER_UPSTREAM_NAME = u'busybox'
 CUSTOM_RPM_REPO = (
     u'http://repos.fedorapeople.org/repos/pulp/pulp/fixtures/rpm/'
 )


### PR DESCRIPTION
```bash
"!!! Congratulations your changes are good to fly, make a great PR! dlezz++ !!!"
platform linux2 -- Python 2.7.12, pytest-3.0.3, py-1.4.31, pluggy-0.4.0 -- /home/dlezz/bin/redhat/python/2.7/bin/python
cachedir: .cache
rootdir: /home/dlezz/projects/robottelo-fork, inifile: 
plugins: cov-2.4.0, xdist-1.15.0
collected 72 items 

tests/foreman/cli/test_contentview.py::ContentViewTestCase::test_positive_delete_cv_promoted_to_multi_env <- robottelo/decorators/__init__.py PASSED
tests/foreman/cli/test_contentview.py::ContentViewTestCase::test_positive_remove_cv_version_from_env <- robottelo/decorators/__init__.py PASSED
tests/foreman/cli/test_contentview.py::ContentViewTestCase::test_positive_remove_cv_version_from_env_with_host_registered <- ../../bin/redhat/python/2.7/lib/python2.7/site-packages/unittest2/case.py SKIPPED
tests/foreman/cli/test_contentview.py::ContentViewTestCase::test_positive_remove_cv_version_from_multi_env <- robottelo/decorators/__init__.py PASSED
tests/foreman/cli/test_contentview.py::ContentViewTestCase::test_positive_remove_cv_version_from_multi_env_capsule_scenario <- ../../bin/redhat/python/2.7/lib/python2.7/site-packages/unittest2/case.py SKIPPED
tests/foreman/cli/test_contentview.py::ContentViewTestCase::test_positive_remove_prod_promoted_cv_version_from_default_env <- robottelo/decorators/__init__.py PASSED
tests/foreman/cli/test_contentview.py::ContentViewTestCase::test_positive_remove_promoted_cv_version_from_default_env <- robottelo/decorators/__init__.py PASSED
tests/foreman/cli/test_contentview.py::ContentViewTestCase::test_positive_remove_qe_promoted_cv_version_from_default_env <- robottelo/decorators/__init__.py PASSED
tests/foreman/cli/test_contentview.py::ContentViewTestCase::test_positive_remove_renamed_cv_version_from_default_env <- robottelo/decorators/__init__.py PASSED

================================================= 63 tests deselected ==================================================
================================ 7 passed, 2 skipped, 63 deselected in 1712.03 seconds =================================
```
issue https://github.com/SatelliteQE/robottelo/issues/4101