### PR TITLE
Added tests for  hammer organization subcommands

### DIFF
--- a/robottelo/cli/org.py
+++ b/robottelo/cli/org.py
@@ -50,54 +50,6 @@ class Org(Base):
     command_base = 'organization'
 
     @classmethod
-    def add_subnet(cls, options=None):
-        """Adds existing subnet to an org"""
-        cls.command_sub = 'add-subnet'
-        return cls.execute(cls._construct_command(options))
-
-    @classmethod
-    def remove_subnet(cls, options=None):
-        """Removes a subnet from an org"""
-        cls.command_sub = 'remove-subnet'
-        return cls.execute(cls._construct_command(options))
-
-    @classmethod
-    def add_domain(cls, options=None):
-        """Adds a domain to an org"""
-        cls.command_sub = 'add-domain'
-        return cls.execute(cls._construct_command(options))
-
-    @classmethod
-    def remove_domain(cls, options=None):
-        """Removes a domain from an org"""
-        cls.command_sub = 'remove-domain'
-        return cls.execute(cls._construct_command(options))
-
-    @classmethod
-    def add_user(cls, options=None):
-        """Adds an user to an org"""
-        cls.command_sub = 'add-user'
-        return cls.execute(cls._construct_command(options))
-
-    @classmethod
-    def remove_user(cls, options=None):
-        """Removes an user from an org"""
-        cls.command_sub = 'remove-user'
-        return cls.execute(cls._construct_command(options))
-
-    @classmethod
-    def add_hostgroup(cls, options=None):
-        """Adds a hostgroup to an org"""
-        cls.command_sub = 'add-hostgroup'
-        return cls.execute(cls._construct_command(options))
-
-    @classmethod
-    def remove_hostgroup(cls, options=None):
-        """Removes a hostgroup from an org"""
-        cls.command_sub = 'remove-hostgroup'
-        return cls.execute(cls._construct_command(options))
-
-    @classmethod
     def add_compute_resource(cls, options=None):
         """Adds a computeresource to an org"""
         cls.command_sub = 'add-compute-resource'
@@ -107,18 +59,6 @@ class Org(Base):
     def remove_compute_resource(cls, options=None):
         """Removes a computeresource from an org"""
         cls.command_sub = 'remove-compute-resource'
-        return cls.execute(cls._construct_command(options))
-
-    @classmethod
-    def add_medium(cls, options=None):
-        """Adds a medium to an org"""
-        cls.command_sub = 'add-medium'
-        return cls.execute(cls._construct_command(options))
-
-    @classmethod
-    def remove_medium(cls, options=None):
-        """Removes a medium from an org"""
-        cls.command_sub = 'remove-medium'
         return cls.execute(cls._construct_command(options))
 
     @classmethod
@@ -134,6 +74,18 @@ class Org(Base):
         return cls.execute(cls._construct_command(options))
 
     @classmethod
+    def add_domain(cls, options=None):
+        """Adds a domain to an org"""
+        cls.command_sub = 'add-domain'
+        return cls.execute(cls._construct_command(options))
+
+    @classmethod
+    def remove_domain(cls, options=None):
+        """Removes a domain from an org"""
+        cls.command_sub = 'remove-domain'
+        return cls.execute(cls._construct_command(options))
+
+    @classmethod
     def add_environment(cls, options=None):
         """Adds an environment to an org"""
         cls.command_sub = 'add-environment'
@@ -146,15 +98,15 @@ class Org(Base):
         return cls.execute(cls._construct_command(options))
 
     @classmethod
-    def add_smart_proxy(cls, options=None):
-        """Adds a smartproxy to an org"""
-        cls.command_sub = 'add-smart-proxy'
+    def add_hostgroup(cls, options=None):
+        """Adds a hostgroup to an org"""
+        cls.command_sub = 'add-hostgroup'
         return cls.execute(cls._construct_command(options))
 
     @classmethod
-    def remove_smart_proxy(cls, options=None):
-        """Removes a smartproxy from an org"""
-        cls.command_sub = 'remove-smart-proxy'
+    def remove_hostgroup(cls, options=None):
+        """Removes a hostgroup from an org"""
+        cls.command_sub = 'remove-hostgroup'
         return cls.execute(cls._construct_command(options))
 
     @classmethod
@@ -170,11 +122,58 @@ class Org(Base):
         return cls.execute(cls._construct_command(options))
 
     @classmethod
+    def add_medium(cls, options=None):
+        """Adds a medium to an org"""
+        cls.command_sub = 'add-medium'
+        return cls.execute(cls._construct_command(options))
+
+    @classmethod
+    def remove_medium(cls, options=None):
+        """Removes a medium from an org"""
+        cls.command_sub = 'remove-medium'
+        return cls.execute(cls._construct_command(options))
+
+    @classmethod
+    def add_smart_proxy(cls, options=None):
+        """Adds a smartproxy to an org"""
+        cls.command_sub = 'add-smart-proxy'
+        return cls.execute(cls._construct_command(options))
+
+    @classmethod
+    def remove_smart_proxy(cls, options=None):
+        """Removes a smartproxy from an org"""
+        cls.command_sub = 'remove-smart-proxy'
+        return cls.execute(cls._construct_command(options))
+
+    @classmethod
+    def add_subnet(cls, options=None):
+        """Adds existing subnet to an org"""
+        cls.command_sub = 'add-subnet'
+        return cls.execute(cls._construct_command(options))
+
+    @classmethod
+    def remove_subnet(cls, options=None):
+        """Removes a subnet from an org"""
+        cls.command_sub = 'remove-subnet'
+        return cls.execute(cls._construct_command(options))
+
+    @classmethod
+    def add_user(cls, options=None):
+        """Adds an user to an org"""
+        cls.command_sub = 'add-user'
+        return cls.execute(cls._construct_command(options))
+
+    @classmethod
+    def remove_user(cls, options=None):
+        """Removes an user from an org"""
+        cls.command_sub = 'remove-user'
+        return cls.execute(cls._construct_command(options))
+
+    @classmethod
     def set_parameter(cls, options=None):
         """Create or update parameter for an organization."""
         cls.command_sub = 'set-parameter'
         return cls.execute(cls._construct_command(options))
-
 
     @classmethod
     def delete_parameter(cls, options=None):

--- a/robottelo/cli/org.py
+++ b/robottelo/cli/org.py
@@ -16,12 +16,14 @@ Subcommands::
     add-domain                    Associate a resource
     add-environment               Associate a resource
     add-hostgroup                 Associate a resource
+    add-location                  Associate a location
     add-medium                    Associate a resource
     add-smartproxy                Associate a resource
     add-subnet                    Associate a resource
     add-user                      Associate a resource
     create                        Create an organization
     delete                        Delete an organization
+    delete-parameter              Delete parameter for an organization.
     info                          Show an organization
     list                          List all organizations
     remove_computeresource        Disassociate a resource
@@ -29,10 +31,13 @@ Subcommands::
     remove_domain                 Disassociate a resource
     remove_environment            Disassociate a resource
     remove_hostgroup              Disassociate a resource
+    remove-location               Disassociate a location
     remove_medium                 Disassociate a resource
     remove_smartproxy             Disassociate a resource
     remove_subnet                 Disassociate a resource
     remove_user                   Disassociate a resource
+    set-parameter                 Create or update parameter for an
+                                    organization.
     update                        Update an organization
 """
 
@@ -40,188 +45,139 @@ from robottelo.cli.base import Base
 
 
 class Org(Base):
-    """
-    Manipulates Foreman's Organizations
-    """
+    """Manipulates Foreman's Organizations"""
 
     command_base = 'organization'
 
     @classmethod
     def add_subnet(cls, options=None):
-        """
-        Adds existing subnet to an org
-        """
-
+        """Adds existing subnet to an org"""
         cls.command_sub = 'add-subnet'
-
         return cls.execute(cls._construct_command(options))
 
     @classmethod
     def remove_subnet(cls, options=None):
-        """
-        Removes a subnet from an org
-        """
-
+        """Removes a subnet from an org"""
         cls.command_sub = 'remove-subnet'
-
         return cls.execute(cls._construct_command(options))
 
     @classmethod
     def add_domain(cls, options=None):
-        """
-        Adds a domain to an org
-        """
-
+        """Adds a domain to an org"""
         cls.command_sub = 'add-domain'
-
         return cls.execute(cls._construct_command(options))
 
     @classmethod
     def remove_domain(cls, options=None):
-        """
-        Removes a domain from an org
-        """
-
+        """Removes a domain from an org"""
         cls.command_sub = 'remove-domain'
-
         return cls.execute(cls._construct_command(options))
 
     @classmethod
     def add_user(cls, options=None):
-        """
-        Adds an user to an org
-        """
-
+        """Adds an user to an org"""
         cls.command_sub = 'add-user'
-
         return cls.execute(cls._construct_command(options))
 
     @classmethod
     def remove_user(cls, options=None):
-        """
-        Removes an user from an org
-        """
-
+        """Removes an user from an org"""
         cls.command_sub = 'remove-user'
-
         return cls.execute(cls._construct_command(options))
 
     @classmethod
     def add_hostgroup(cls, options=None):
-        """
-        Adds a hostgroup to an org
-        """
-
+        """Adds a hostgroup to an org"""
         cls.command_sub = 'add-hostgroup'
-
         return cls.execute(cls._construct_command(options))
 
     @classmethod
     def remove_hostgroup(cls, options=None):
-        """
-        Removes a hostgroup from an org
-        """
-
+        """Removes a hostgroup from an org"""
         cls.command_sub = 'remove-hostgroup'
-
         return cls.execute(cls._construct_command(options))
 
     @classmethod
     def add_compute_resource(cls, options=None):
-        """
-        Adds a computeresource to an org
-        """
-
+        """Adds a computeresource to an org"""
         cls.command_sub = 'add-compute-resource'
-
         return cls.execute(cls._construct_command(options))
 
     @classmethod
     def remove_compute_resource(cls, options=None):
-        """
-        Removes a computeresource from an org
-        """
-
+        """Removes a computeresource from an org"""
         cls.command_sub = 'remove-compute-resource'
-
         return cls.execute(cls._construct_command(options))
 
     @classmethod
     def add_medium(cls, options=None):
-        """
-        Adds a medium to an org
-        """
-
+        """Adds a medium to an org"""
         cls.command_sub = 'add-medium'
-
         return cls.execute(cls._construct_command(options))
 
     @classmethod
     def remove_medium(cls, options=None):
-        """
-        Removes a medium from an org
-        """
-
+        """Removes a medium from an org"""
         cls.command_sub = 'remove-medium'
-
         return cls.execute(cls._construct_command(options))
 
     @classmethod
     def add_config_template(cls, options=None):
-        """
-        Adds a configtemplate to an org
-        """
-
+        """Adds a configtemplate to an org"""
         cls.command_sub = 'add-config-template'
-
         return cls.execute(cls._construct_command(options))
 
     @classmethod
     def remove_config_template(cls, options=None):
-        """
-        Removes a configtemplate from an org
-        """
-
+        """Removes a configtemplate from an org"""
         cls.command_sub = 'remove-config-template'
-
         return cls.execute(cls._construct_command(options))
 
     @classmethod
     def add_environment(cls, options=None):
-        """
-        Adds an environment to an org
-        """
-
+        """Adds an environment to an org"""
         cls.command_sub = 'add-environment'
-
         return cls.execute(cls._construct_command(options))
 
     @classmethod
     def remove_environment(cls, options=None):
-        """
-        Removes an environment from an org
-        """
-
+        """Removes an environment from an org"""
         cls.command_sub = 'remove-environment'
-
         return cls.execute(cls._construct_command(options))
 
     @classmethod
     def add_smart_proxy(cls, options=None):
-        """
-        Adds a smartproxy to an org
-        """
-
+        """Adds a smartproxy to an org"""
         cls.command_sub = 'add-smart-proxy'
-
         return cls.execute(cls._construct_command(options))
 
     @classmethod
     def remove_smart_proxy(cls, options=None):
-        """
-        Removes a smartproxy from an org
-        """
-
+        """Removes a smartproxy from an org"""
         cls.command_sub = 'remove-smart-proxy'
+        return cls.execute(cls._construct_command(options))
 
+    @classmethod
+    def add_location(cls, options=None):
+        """Adds a location to an org"""
+        cls.command_sub = 'add-location'
+        return cls.execute(cls._construct_command(options))
+
+    @classmethod
+    def remove_location(cls, options=None):
+        """Removes a location from an org"""
+        cls.command_sub = 'remove-location'
+        return cls.execute(cls._construct_command(options))
+
+    @classmethod
+    def set_parameter(cls, options=None):
+        """Create or update parameter for an organization."""
+        cls.command_sub = 'set-parameter'
+        return cls.execute(cls._construct_command(options))
+
+
+    @classmethod
+    def delete_parameter(cls, options=None):
+        """Delete parameter for an organization."""
+        cls.command_sub = 'delete-parameter'
         return cls.execute(cls._construct_command(options))

--- a/tests/foreman/cli/test_organization.py
+++ b/tests/foreman/cli/test_organization.py
@@ -1335,6 +1335,11 @@ class OrganizationTestCase(CLITestCase):
             'organization': org['name'],
         })
         result = Org.info({'id': org['id']})
+        self.assertEqual(len(result['parameters']), 1)
+        Org.delete_parameter({
+            'name': param_name,
+            'organization': org['name'],
+        })
         self.assertEqual(len(result['parameters']), 0)
         self.assertNotIn(param_name.lower(), result['parameters'])
 

--- a/tests/foreman/cli/test_organization.py
+++ b/tests/foreman/cli/test_organization.py
@@ -27,6 +27,7 @@ from robottelo.cli.factory import (
     make_domain,
     make_hostgroup,
     make_lifecycle_environment,
+    make_location,
     make_medium,
     make_org,
     make_proxy,
@@ -46,6 +47,7 @@ from robottelo.datafactory import (
 )
 from robottelo.decorators import (
     run_only_on,
+    skip_if_bug_open,
     skip_if_not_set,
     tier1,
     tier2,
@@ -1165,6 +1167,176 @@ class OrganizationTestCase(CLITestCase):
         })
         org = Org.info({'name': org['name']})
         self.assertNotIn(proxy['name'], org['smart-proxies'])
+
+    @run_only_on('sat')
+    @tier2
+    def test_positive_add_location_by_id(self):
+        """Add a location to organization by its id
+
+        @id: 83848f18-2cca-457c-af57-e6249386c81c
+
+        @Assert: Location is added to the org
+
+        @CaseLevel: Integration
+        """
+        org = make_org()
+        loc = make_location()
+        Org.add_location({
+            'location-id': loc['id'],
+            'name': org['name'],
+        })
+        result = Org.info({'id': org['id']})
+        self.assertEqual(len(result['locations']), 1)
+        self.assertIn(loc['name'], result['locations'])
+
+    @run_only_on('sat')
+    @tier2
+    def test_positive_add_location_by_name(self):
+        """Add a location to organization by its name
+
+        @id: f39522e8-5280-429e-b954-79153c2c73c2
+
+        @Assert: Location is added to the org
+
+        @CaseLevel: Integration
+        """
+        org = make_org()
+        loc = make_location()
+        Org.add_location({
+            'location': loc['name'],
+            'name': org['name'],
+        })
+        result = Org.info({'id': org['id']})
+        self.assertEqual(len(result['locations']), 1)
+        self.assertIn(loc['name'], result['locations'])
+
+    @run_only_on('sat')
+    @skip_if_bug_open('bugzilla', 1395229)
+    @tier2
+    def test_positive_remove_location_by_id(self):
+        """Remove a location from organization by its id
+
+        @id: 37b63e5c-8fd5-439c-9540-972b597b590a
+
+        @Assert: Location is removed from the org
+
+        @CaseLevel: Integration
+        """
+        org = make_org()
+        loc = make_location()
+        Org.add_location({
+            'location-id': loc['id'],
+            'name': org['name'],
+        })
+        result = Org.info({'id': org['id']})
+        self.assertEqual(len(result['locations']), 1)
+        self.assertIn(loc['name'], result['locations'])
+        Org.remove_location({
+            'location-id': loc['id'],
+            'id': org['id'],
+        })
+        result = Org.info({'id': org['id']})
+        self.assertEqual(len(result['locations']), 0)
+
+    @run_only_on('sat')
+    @skip_if_bug_open('bugzilla', 1395229)
+    @tier2
+    def test_positive_remove_location_by_name(self):
+        """Remove a location from organization by its name
+
+        @id: 35770afa-1623-448c-af4f-a702851063db
+
+        @Assert: Location is removed from the org
+
+        @CaseLevel: Integration
+        """
+        org = make_org()
+        loc = make_location()
+        Org.add_location({
+            'location': loc['name'],
+            'name': org['name'],
+        })
+        result = Org.info({'id': org['id']})
+        self.assertEqual(len(result['locations']), 1)
+        self.assertIn(loc['name'], result['locations'])
+        Org.remove_location({
+            'location': loc['name'],
+            'id': org['id'],
+        })
+        result = Org.info({'id': org['id']})
+        self.assertEqual(len(result['locations']), 0)
+
+    @run_only_on('sat')
+    @tier1
+    def test_positive_add_parameter(self):
+        """Add a parameter to organization
+
+        @id: b0b59650-5718-45e2-8724-151dc52b1486
+
+        @Assert: Parameter is added to the org
+        """
+        param_name = gen_string('alpha')
+        param_value = gen_string('alpha')
+        org = make_org()
+        Org.set_parameter({
+            'name': param_name,
+            'value': param_value,
+            'organization': org['name'],
+        })
+        result = Org.info({'id': org['id']})
+        self.assertEqual(len(result['parameters']), 1)
+        self.assertEqual(param_value, result['parameters'][param_name.lower()])
+
+    @run_only_on('sat')
+    @tier1
+    def test_positive_update_parameter(self):
+        """Update a parameter associated with organization
+
+        @id: 4a7ed165-a0c5-4ba6-833a-5a1b3ee47ace
+
+        @Assert: Parameter is updated
+        """
+        param_name = gen_string('alpha')
+        param_new_value = gen_string('alpha')
+        org = make_org()
+        # Create parameter
+        Org.set_parameter({
+            'name': param_name,
+            'value': gen_string('alpha'),
+            'organization': org['name'],
+        })
+        result = Org.info({'id': org['id']})
+        self.assertEqual(len(result['parameters']), 1)
+        Org.set_parameter({
+            'name': param_name,
+            'value': param_new_value,
+            'organization': org['name'],
+        })
+        result = Org.info({'id': org['id']})
+        self.assertEqual(len(result['parameters']), 1)
+        self.assertEqual(
+            param_new_value, result['parameters'][param_name.lower()])
+
+    @run_only_on('sat')
+    @skip_if_bug_open('bugzilla', 1395229)
+    @tier1
+    def test_positive_remove_parameter(self):
+        """Remove a parameter from organization
+
+        @id: e4099279-4e73-4c14-9e7c-912b3787b99f
+
+        @Assert: Parameter is removed from the org
+        """
+        param_name = gen_string('alpha')
+        org = make_org()
+        Org.set_parameter({
+            'name': param_name,
+            'value': gen_string('alpha'),
+            'organization': org['name'],
+        })
+        result = Org.info({'id': org['id']})
+        self.assertEqual(len(result['parameters']), 0)
+        self.assertNotIn(param_name.lower(), result['parameters'])
 
     # Negative Create
 


### PR DESCRIPTION
Added coverage for hammer `organization` subcommands. Also covers #4082.

```python
% pytest -v tests/foreman/cli/test_organization.py -k 'parameter or location'
===================================================================== test session starts =====================================================================
platform linux2 -- Python 2.7.12, pytest-3.0.4, py-1.4.31, pluggy-0.4.0 -- /home/qui/code/venv/2/bin/python2
cachedir: .cache
rootdir: /home/qui/code/robottelo, inifile: 
plugins: xdist-1.15.0, html-1.12.0, cov-2.4.0
collected 67 items 

tests/foreman/cli/test_organization.py::OrganizationTestCase::test_positive_add_location_by_id <- robottelo/decorators/__init__.py PASSED
tests/foreman/cli/test_organization.py::OrganizationTestCase::test_positive_add_location_by_name <- robottelo/decorators/__init__.py PASSED
tests/foreman/cli/test_organization.py::OrganizationTestCase::test_positive_add_parameter <- robottelo/decorators/__init__.py PASSED
tests/foreman/cli/test_organization.py::OrganizationTestCase::test_positive_remove_location_by_id <- robottelo/decorators/__init__.py SKIPPED
tests/foreman/cli/test_organization.py::OrganizationTestCase::test_positive_remove_location_by_name <- robottelo/decorators/__init__.py SKIPPED
tests/foreman/cli/test_organization.py::OrganizationTestCase::test_positive_remove_parameter <- robottelo/decorators/__init__.py SKIPPED
tests/foreman/cli/test_organization.py::OrganizationTestCase::test_positive_update_parameter <- robottelo/decorators/__init__.py PASSED

===================================================================== 60 tests deselected =====================================================================
===================================================== 4 passed, 3 skipped, 60 deselected in 79.54 seconds =====================================================
```