### PR TITLE
Skip tests if required properties section is not set.

### DIFF
--- a/tests/foreman/cli/test_docker.py
+++ b/tests/foreman/cli/test_docker.py
@@ -1191,6 +1191,7 @@ class DockerClientTestCase(CLITestCase):
             ssh.command('docker rmi {0}'.format(repo['published-at']))
 
     @run_only_on('sat')
+    @skip_if_not_set('docker')
     @tier3
     def test_positive_upload_image(self):
         """A Docker-enabled client can create a new ``Dockerfile``

--- a/tests/foreman/cli/test_import.py
+++ b/tests/foreman/cli/test_import.py
@@ -41,6 +41,7 @@ from robottelo.decorators import (
     bz_bug_is_open,
     run_in_one_thread,
     skip_if_bug_open,
+    skip_if_not_set,
     tier1,
     tier3,
 )
@@ -513,6 +514,7 @@ class TestImport(CLITestCase):
 
     """
     @classmethod
+    @skip_if_not_set('transition')
     def setUpClass(cls):
         super(TestImport, cls).setUpClass()
         # prepare the default dataset

--- a/tests/foreman/longrun/test_oscap.py
+++ b/tests/foreman/longrun/test_oscap.py
@@ -173,7 +173,11 @@ class OpenScapTestCase(UITestCase):
 
         @CaseLevel: System
         """
+        if settings.rhel6_repo is None:
+            self.skipTest('Missing configuration for rhel6_repo')
         rhel6_repo = settings.rhel6_repo
+        if settings.rhel7_repo is None:
+            self.skipTest('Missing configuration for rhel7_repo')
         rhel7_repo = settings.rhel7_repo
         rhel6_content = OSCAP_DEFAULT_CONTENT['rhel6_content']
         rhel7_content = OSCAP_DEFAULT_CONTENT['rhel7_content']

--- a/tests/foreman/performance/test_pulp_sync.py
+++ b/tests/foreman/performance/test_pulp_sync.py
@@ -19,6 +19,7 @@
 import csv
 
 from robottelo.config import settings
+from robottelo.decorators import skip_if_not_set
 from robottelo.performance.constants import (
     RAW_SYNC_FILE_NAME,
     STAT_SYNC_FILE_NAME
@@ -57,6 +58,7 @@ class ConcurrentSyncTestCase(ConcurrentTestCase):
 
     """
     @classmethod
+    @skip_if_not_set('performance')
     def setUpClass(cls):
         super(ConcurrentSyncTestCase, cls).setUpClass()
 

--- a/tests/foreman/performance/test_standard_prep.py
+++ b/tests/foreman/performance/test_standard_prep.py
@@ -22,6 +22,7 @@ from robottelo.cli.repository import Repository
 from robottelo.cli.repository_set import RepositorySet
 from robottelo.cli.subscription import Subscription
 from robottelo.config import settings
+from robottelo.decorators import skip_if_not_set
 from robottelo.performance.constants import MANIFEST_FILE_NAME
 from robottelo.test import TestCase
 
@@ -39,6 +40,7 @@ class StandardPrepTestCase(TestCase):
     """
 
     @classmethod
+    @skip_if_not_set('performance')
     def setUpClass(cls):
         super(StandardPrepTestCase, cls).setUpClass()
 

--- a/tests/foreman/ui/test_computeresource_rhev.py
+++ b/tests/foreman/ui/test_computeresource_rhev.py
@@ -15,10 +15,18 @@
 
 from fauxfactory import gen_string
 from nailgun import entities
+
 from robottelo.config import settings
 from robottelo.constants import FOREMAN_PROVIDERS
 from robottelo.datafactory import invalid_names_list, valid_data_list
-from robottelo.decorators import run_only_on, tier1, tier2, tier3, stubbed
+from robottelo.decorators import (
+    run_only_on,
+    skip_if_not_set,
+    stubbed,
+    tier1,
+    tier2,
+    tier3,
+)
 from robottelo.test import UITestCase
 from robottelo.ui.factory import make_resource
 from robottelo.ui.locators import common_locators
@@ -29,6 +37,7 @@ class RhevComputeResourceTestCase(UITestCase):
     """Implements Compute Resource tests in UI"""
 
     @classmethod
+    @skip_if_not_set('rhev')
     def setUpClass(cls):
         super(RhevComputeResourceTestCase, cls).setUpClass()
         cls.rhev_url = settings.rhev.hostname

--- a/tests/foreman/ui/test_host.py
+++ b/tests/foreman/ui/test_host.py
@@ -724,7 +724,7 @@ class AtomicHostTestCase(UITestCase):
 
     @classmethod
     @skip_if_os('RHEL6')
-    @skip_if_not_set('vlan_networking', 'compute_resources')
+    @skip_if_not_set('vlan_networking', 'compute_resources', 'ostree')
     def setUpClass(cls):
         """Steps required to create a Atomic host on libvirt
 

--- a/tests/foreman/ui/test_oscapcontent.py
+++ b/tests/foreman/ui/test_oscapcontent.py
@@ -21,7 +21,12 @@ from nailgun import entities
 from robottelo.config import settings
 from robottelo.constants import OSCAP_DEFAULT_CONTENT
 from robottelo.datafactory import invalid_values_list, valid_data_list
-from robottelo.decorators import skip_if_bug_open, tier1, tier2
+from robottelo.decorators import (
+    skip_if_bug_open,
+    skip_if_not_set,
+    tier1,
+    tier2,
+)
 from robottelo.helpers import get_data_file
 from robottelo.test import UITestCase
 from robottelo.ui.factory import make_oscapcontent
@@ -33,6 +38,7 @@ class OpenScapContentTestCase(UITestCase):
     """Implements Oscap Content tests in UI."""
 
     @classmethod
+    @skip_if_not_set('oscap')
     def setUpClass(cls):
         super(OpenScapContentTestCase, cls).setUpClass()
         path = settings.oscap.content_path

--- a/tests/foreman/ui/test_oscappolicy.py
+++ b/tests/foreman/ui/test_oscappolicy.py
@@ -22,7 +22,7 @@ from robottelo.constants import (
     OSCAP_WEEKDAY,
 )
 from robottelo.datafactory import invalid_values_list, valid_data_list
-from robottelo.decorators import skip_if_bug_open, tier1
+from robottelo.decorators import skip_if_bug_open, skip_if_not_set, tier1
 from robottelo.helpers import get_data_file
 from robottelo.test import UITestCase
 from robottelo.ui.factory import make_oscapcontent, make_oscappolicy
@@ -33,6 +33,7 @@ class OpenScapPolicy(UITestCase):
     """Implements Oscap Policy tests in UI."""
 
     @classmethod
+    @skip_if_not_set('oscap')
     def setUpClass(cls):
         super(OpenScapPolicy, cls).setUpClass()
         cls.content_path = get_data_file(


### PR DESCRIPTION
Part of #3006.
```python
% pytest tests/foreman/cli/test_docker.py tests/foreman/cli/test_import.py  tests/foreman/longrun/test_oscap.py tests/foreman/performance/test_pulp_sync.py tests/foreman/performance/test_standard_prep.py  tests/foreman/ui/test_computeresource_rhev.py tests/foreman/ui/test_host.py tests/foreman/ui/test_oscapcontent.py  tests/foreman/ui/test_oscappolicy.py -k 'OpenScapPolicy or test_positive_upload_image or TestImport or OpenScapContentTestCase or AtomicHostTestCase or RhevComputeResourceTestCase or StandardPrepTestCase or ConcurrentSyncTestCase or test_positive_upload_to_satellite'  
===================================================================== test session starts =====================================================================
platform linux2 -- Python 2.7.12, pytest-3.0.4, py-1.4.31, pluggy-0.4.0
rootdir: /home/qui/code/robottelo, inifile: 
plugins: xdist-1.15.0, html-1.12.0, cov-2.4.0
collected 134 items 

tests/foreman/cli/test_docker.py s
tests/foreman/cli/test_import.py ssssssssssssssssssssssssssss
tests/foreman/longrun/test_oscap.py s
tests/foreman/performance/test_pulp_sync.py ss
tests/foreman/performance/test_standard_prep.py s
tests/foreman/ui/test_computeresource_rhev.py sssssssssssssssss
tests/foreman/ui/test_host.py sssssss
tests/foreman/ui/test_oscapcontent.py sssss
tests/foreman/ui/test_oscappolicy.py ssss

===================================================================== 68 tests deselected =====================================================================
========================================================= 66 skipped, 68 deselected in 12.26 seconds ==========================================================
```