### PR TITLE
Fixes issue #4107 Oscap tests to be run in different Organization

### DIFF
--- a/robottelo/ui/factory.py
+++ b/robottelo/ui/factory.py
@@ -661,14 +661,16 @@ def make_ldapauth(session, **kwargs):
     LdapAuthSource(session.browser).create(**create_args)
 
 
-def make_oscapcontent(session, **kwargs):
+def make_oscapcontent(session, org=None, loc=None, **kwargs):
     """Creates an OSCAP Content"""
     create_args = {
         u'name': None,
         u'content_path': None,
+        u'content_org': None,
+        u'content_loc': None,
     }
     page = session.nav.go_to_oscap_content
-    core_factory(create_args, kwargs, session, page)
+    core_factory(create_args, kwargs, session, page, org=org, loc=loc)
     OpenScapContent(session.browser).create(**create_args)
 
 

--- a/robottelo/ui/oscapcontent.py
+++ b/robottelo/ui/oscapcontent.py
@@ -18,13 +18,20 @@ class OpenScapContent(Base):
         """Specify locator for OpenScap content entity search procedure"""
         return locators['oscap.content_select']
 
-    def create(self, name, content_path=None):
+    def create(self, name, content_path=None,
+               content_org=None, content_loc=None):
         """Creates new oscap Content from UI"""
         self.click(locators['oscap.upload_content'])
         self.text_field_update(locators['oscap.content_title'], name)
         self.wait_until_element(
             locators['oscap.content_path']
         ).send_keys(content_path)
+        if content_org:
+            self.click(tab_locators['tab_org'])
+            self.configure_entity([content_org], FILTER['oscap_org'])
+        if content_loc:
+            self.click(tab_locators['tab_loc'])
+            self.configure_entity([content_org], FILTER['oscap_loc'])
         self.click(common_locators['submit'])
 
     def delete(self, name, really=True):

--- a/tests/foreman/ui/test_oscapcontent.py
+++ b/tests/foreman/ui/test_oscapcontent.py
@@ -37,6 +37,15 @@ class OpenScapContentTestCase(UITestCase):
         super(OpenScapContentTestCase, cls).setUpClass()
         path = settings.oscap.content_path
         cls.content_path = get_data_file(path)
+        org = entities.Organization(name=gen_string('alpha')).create()
+        cls.org_name = org.name
+        proxy = entities.SmartProxy().search(
+            query={
+                u'search': u'name={0}'.format(
+                    settings.server.hostname)
+            }
+        )[0]
+        proxy.organization = [org]
 
     @tier1
     def test_positive_create(self):
@@ -58,6 +67,7 @@ class OpenScapContentTestCase(UITestCase):
                         session,
                         name=content_name,
                         content_path=self.content_path,
+                        content_org=self.org_name,
                     )
                     self.assertIsNotNone(
                         self.oscapcontent.search(content_name))
@@ -85,6 +95,7 @@ class OpenScapContentTestCase(UITestCase):
                         session,
                         name=content_name,
                         content_path=self.content_path,
+                        content_org=self.org_name,
                     )
                     self.assertIsNotNone(session.nav.wait_until_element(
                         common_locators['haserror']))
@@ -134,6 +145,7 @@ class OpenScapContentTestCase(UITestCase):
                 session,
                 name=content_name,
                 content_path=self.content_path,
+                content_org=self.org_name,
             )
             self.oscapcontent.update(content_name, content_org=org.name)
             session.nav.go_to_select_org(org.name)
@@ -161,6 +173,7 @@ class OpenScapContentTestCase(UITestCase):
                         session,
                         name=content_name,
                         content_path=self.content_path,
+                        content_org=self.org_name,
                     )
                     self.assertIsNotNone(
                         self.oscapcontent.search(content_name))


### PR DESCRIPTION
Oscap tests to be run in different Organization, to avoid oscap capsule org mismatch
If the content created is in the OrgA , the Oscap capsule should also be present in OrgA