### PR TITLE
Skip tests if required properties section is not set, part 2.

### DIFF
--- a/tests/foreman/api/test_computeresource.py
+++ b/tests/foreman/api/test_computeresource.py
@@ -19,14 +19,16 @@ http://www.katello.org/docs/api/apidoc/compute_resources.html
 
 @Upstream: No
 """
+from random import randint
+
 from fauxfactory import gen_string
 from nailgun import entities
-from random import randint
 from requests.exceptions import HTTPError
+
 from robottelo.config import settings
 from robottelo.constants import LIBVIRT_RESOURCE_URL
 from robottelo.datafactory import invalid_values_list, valid_data_list
-from robottelo.decorators import tier1, tier2
+from robottelo.decorators import skip_if_not_set, tier1, tier2
 from robottelo.test import APITestCase
 
 
@@ -34,6 +36,7 @@ class ComputeResourceTestCase(APITestCase):
     """Tests for ``katello/api/v2/compute_resources``."""
 
     @classmethod
+    @skip_if_not_set('compute_resources')
     def setUpClass(cls):
         """Set up organization and location for tests."""
         super(ComputeResourceTestCase, cls).setUpClass()

--- a/tests/foreman/cli/test_computeresource.py
+++ b/tests/foreman/cli/test_computeresource.py
@@ -35,12 +35,18 @@ Subcommands::
 import random
 
 from fauxfactory import gen_string, gen_url
+
 from robottelo.cli.base import CLIReturnCodeError
 from robottelo.cli.computeresource import ComputeResource
 from robottelo.cli.factory import make_location, make_compute_resource
 from robottelo.config import settings
 from robottelo.constants import FOREMAN_PROVIDERS, LIBVIRT_RESOURCE_URL
-from robottelo.decorators import run_only_on, skip_if_bug_open, tier1
+from robottelo.decorators import (
+    run_only_on,
+    skip_if_bug_open,
+    skip_if_not_set,
+    tier1,
+)
 from robottelo.test import CLITestCase
 
 
@@ -104,6 +110,7 @@ class ComputeResourceTestCase(CLITestCase):
     """ComputeResource CLI tests."""
 
     @classmethod
+    @skip_if_not_set('compute_resources')
     def setUpClass(cls):
         super(ComputeResourceTestCase, cls).setUpClass()
         cls.current_libvirt_url = (

--- a/tests/foreman/cli/test_organization.py
+++ b/tests/foreman/cli/test_organization.py
@@ -46,6 +46,7 @@ from robottelo.datafactory import (
 )
 from robottelo.decorators import (
     run_only_on,
+    skip_if_not_set,
     tier1,
     tier2,
 )
@@ -559,6 +560,7 @@ class OrganizationTestCase(CLITestCase):
         self.assertNotIn(hostgroup['name'], org['hostgroups'])
 
     @run_only_on('sat')
+    @skip_if_not_set('compute_resources')
     @tier2
     def test_positive_add_compresource_by_name(self):
         """Add a compute resource to organization by its name
@@ -619,6 +621,7 @@ class OrganizationTestCase(CLITestCase):
             self.assertIn(resource['name'], org['compute-resources'])
 
     @run_only_on('sat')
+    @skip_if_not_set('compute_resources')
     @tier2
     def test_positive_remove_compresource_by_id(self):
         """Remove a compute resource from organization by its ID
@@ -648,6 +651,7 @@ class OrganizationTestCase(CLITestCase):
         self.assertNotIn(compute_res['name'], org['compute-resources'])
 
     @run_only_on('sat')
+    @skip_if_not_set('compute_resources')
     @tier2
     def test_positive_remove_compresource_by_name(self):
         """Remove a compute resource from organization by its name

--- a/tests/foreman/endtoend/test_api_endtoend.py
+++ b/tests/foreman/endtoend/test_api_endtoend.py
@@ -39,6 +39,7 @@ from robottelo.constants import (
 from robottelo.decorators import (
     bz_bug_is_open,
     setting_is_set,
+    skip_if_not_set,
 )
 from robottelo.helpers import get_nailgun_config
 from robottelo.test import TestCase
@@ -930,6 +931,7 @@ class EndToEndTestCase(TestCase, ClientProvisioningMixin):
             u'Not all services seem to be up and running!'
         )
 
+    @skip_if_not_set('compute_resources')
     def test_positive_end_to_end(self):
         """Perform end to end smoke tests using RH and custom repos.
 

--- a/tests/foreman/endtoend/test_cli_endtoend.py
+++ b/tests/foreman/endtoend/test_cli_endtoend.py
@@ -47,7 +47,11 @@ from robottelo.constants import (
     REPOSET,
 )
 from robottelo.config import settings
-from robottelo.decorators import bz_bug_is_open, setting_is_set
+from robottelo.decorators import (
+    bz_bug_is_open,
+    setting_is_set,
+    skip_if_not_set,
+)
 from robottelo.test import CLITestCase
 
 from .utils import AK_CONTENT_LABEL, ClientProvisioningMixin
@@ -93,6 +97,7 @@ class EndToEndTestCase(CLITestCase, ClientProvisioningMixin):
         self.assertEqual(result['login'], 'admin')
         self.assertEqual(result['admin'], 'yes')
 
+    @skip_if_not_set('compute_resources')
     def test_positive_end_to_end(self):
         """Perform end to end smoke tests using RH and custom repos.
 

--- a/tests/foreman/endtoend/test_ui_endtoend.py
+++ b/tests/foreman/endtoend/test_ui_endtoend.py
@@ -109,6 +109,7 @@ class EndToEndTestCase(UITestCase, ClientProvisioningMixin):
         with Session(self.browser):
             self.assertTrue(self.user.user_admin_role_toggle('admin'))
 
+    @skip_if_not_set('compute_resources')
     def test_positive_end_to_end(self):
         """Perform end to end smoke tests using RH and custom repos.
 
@@ -342,6 +343,8 @@ class EndToEndTestCase(UITestCase, ClientProvisioningMixin):
         puppet_repository_name = gen_string('alpha')
         repos = self.sync.create_repos_tree(SAT6_TOOLS_TREE)
         rhel_prd = DEFAULT_SUBSCRIPTION_NAME
+        if settings.rhel6_repo is None:
+            self.skipTest('Missing configuration for rhel6_repo')
         rhel6_repo = settings.rhel6_repo
         with Session(self.browser) as session:
             # Create New organization

--- a/tests/foreman/ui/test_computeresource.py
+++ b/tests/foreman/ui/test_computeresource.py
@@ -20,7 +20,7 @@ from nailgun import entities
 from robottelo.config import settings
 from robottelo.constants import FOREMAN_PROVIDERS, LIBVIRT_RESOURCE_URL
 from robottelo.datafactory import invalid_names_list, valid_data_list
-from robottelo.decorators import run_only_on, tier1
+from robottelo.decorators import run_only_on, skip_if_not_set, tier1
 from robottelo.test import UITestCase
 from robottelo.ui.factory import make_resource
 from robottelo.ui.locators import common_locators
@@ -31,6 +31,7 @@ class ComputeResourceTestCase(UITestCase):
     """Implements Compute Resource tests in UI"""
 
     @classmethod
+    @skip_if_not_set('compute_resources')
     def setUpClass(cls):
         super(ComputeResourceTestCase, cls).setUpClass()
         cls.current_libvirt_url = (

--- a/tests/foreman/ui/test_location.py
+++ b/tests/foreman/ui/test_location.py
@@ -24,7 +24,7 @@ from robottelo.datafactory import (
     generate_strings_list,
     invalid_values_list,
 )
-from robottelo.decorators import run_only_on, tier1, tier2
+from robottelo.decorators import run_only_on, skip_if_not_set, tier1, tier2
 from robottelo.constants import (
     DEFAULT_ORG,
     INSTALL_MEDIUM_URL,
@@ -439,6 +439,7 @@ class LocationTestCase(UITestCase):
                     self.assertIsNotNone(element)
 
     @run_only_on('sat')
+    @skip_if_not_set('compute_resources')
     @tier2
     def test_positive_add_compresource(self):
         """Add compute resource using the location name and compute resource
@@ -780,6 +781,7 @@ class LocationTestCase(UITestCase):
                     self.assertIsNone(element)
 
     @run_only_on('sat')
+    @skip_if_not_set('compute_resources')
     @tier2
     def test_positive_remove_compresource(self):
         """Remove compute resource by using the location name and compute

--- a/tests/foreman/ui/test_organization.py
+++ b/tests/foreman/ui/test_organization.py
@@ -640,6 +640,7 @@ class OrganizationTestCase(UITestCase):
                     self.assertIsNotNone(element)
 
     @run_only_on('sat')
+    @skip_if_not_set('compute_resources')
     @tier2
     def test_positive_remove_compresource(self):
         """Remove compute resource using the organization name and
@@ -848,6 +849,7 @@ class OrganizationTestCase(UITestCase):
         """
 
     @run_only_on('sat')
+    @skip_if_not_set('compute_resources')
     @tier2
     def test_positive_add_compresource(self):
         """Add compute resource using the organization


### PR DESCRIPTION
Part of #3006.

2 passed tests were not modified and were collected by pytest because their names match expression.
```python
% pytest tests/foreman/api/test_computeresource.py tests/foreman/cli/test_{organization.py,computeresource.py} tests/foreman/ui/test_{organization.py,location.py,computeresource.py} tests/foreman/endtoend/test* -k 'test_positive_end_to_end or ComputeResourceTestCase or test_positive_add_compresource or test_positive_remove_compresource or test_positive_add_compresource_by_name or test_positive_remove_compresource_by_id or test_positive_remove_compresource_by_name or test_positive_puppet_install'
===================================================================== test session starts =====================================================================
platform linux2 -- Python 2.7.12, pytest-3.0.4, py-1.4.31, pluggy-0.4.0
rootdir: /home/qui/code/robottelo, inifile: 
plugins: xdist-1.15.0, html-1.12.0, cov-2.4.0
collected 180 items 

tests/foreman/api/test_computeresource.py sssssssssssssssssssss
tests/foreman/cli/test_organization.py .s.ss
tests/foreman/cli/test_computeresource.py ssssssssssssss
tests/foreman/ui/test_organization.py ss
tests/foreman/ui/test_location.py ss
tests/foreman/ui/test_computeresource.py sssssssss
tests/foreman/endtoend/test_api_endtoend.py s
tests/foreman/endtoend/test_cli_endtoend.py s
tests/foreman/endtoend/test_ui_endtoend.py ss

==================================================================== 123 tests deselected =====================================================================
=================================================== 2 passed, 55 skipped, 123 deselected in 101.46 seconds ====================================================
```