### PR TITLE
[6.2.z] Cherry-pick - Skip tests if required properties section is not set

### DIFF
--- a/tests/foreman/api/test_computeresource.py
+++ b/tests/foreman/api/test_computeresource.py
@@ -19,14 +19,16 @@ http://www.katello.org/docs/api/apidoc/compute_resources.html
 
 @Upstream: No
 """
+from random import randint
+
 from fauxfactory import gen_string
 from nailgun import entities
-from random import randint
 from requests.exceptions import HTTPError
+
 from robottelo.config import settings
 from robottelo.constants import LIBVIRT_RESOURCE_URL
 from robottelo.datafactory import invalid_values_list, valid_data_list
-from robottelo.decorators import tier1, tier2
+from robottelo.decorators import skip_if_not_set, tier1, tier2
 from robottelo.test import APITestCase
 
 
@@ -34,6 +36,7 @@ class ComputeResourceTestCase(APITestCase):
     """Tests for ``katello/api/v2/compute_resources``."""
 
     @classmethod
+    @skip_if_not_set('compute_resources')
     def setUpClass(cls):
         """Set up organization and location for tests."""
         super(ComputeResourceTestCase, cls).setUpClass()

--- a/tests/foreman/cli/test_computeresource.py
+++ b/tests/foreman/cli/test_computeresource.py
@@ -35,12 +35,18 @@ Subcommands::
 import random
 
 from fauxfactory import gen_string, gen_url
+
 from robottelo.cli.base import CLIReturnCodeError
 from robottelo.cli.computeresource import ComputeResource
 from robottelo.cli.factory import make_location, make_compute_resource
 from robottelo.config import settings
 from robottelo.constants import FOREMAN_PROVIDERS, LIBVIRT_RESOURCE_URL
-from robottelo.decorators import run_only_on, skip_if_bug_open, tier1
+from robottelo.decorators import (
+    run_only_on,
+    skip_if_bug_open,
+    skip_if_not_set,
+    tier1,
+)
 from robottelo.test import CLITestCase
 
 
@@ -104,6 +110,7 @@ class ComputeResourceTestCase(CLITestCase):
     """ComputeResource CLI tests."""
 
     @classmethod
+    @skip_if_not_set('compute_resources')
     def setUpClass(cls):
         super(ComputeResourceTestCase, cls).setUpClass()
         cls.current_libvirt_url = (

--- a/tests/foreman/cli/test_docker.py
+++ b/tests/foreman/cli/test_docker.py
@@ -1191,6 +1191,7 @@ class DockerClientTestCase(CLITestCase):
             ssh.command('docker rmi {0}'.format(repo['published-at']))
 
     @run_only_on('sat')
+    @skip_if_not_set('docker')
     @tier3
     def test_positive_upload_image(self):
         """A Docker-enabled client can create a new ``Dockerfile``

--- a/tests/foreman/cli/test_import.py
+++ b/tests/foreman/cli/test_import.py
@@ -41,6 +41,7 @@ from robottelo.decorators import (
     bz_bug_is_open,
     run_in_one_thread,
     skip_if_bug_open,
+    skip_if_not_set,
     tier1,
     tier3,
 )
@@ -513,6 +514,7 @@ class TestImport(CLITestCase):
 
     """
     @classmethod
+    @skip_if_not_set('transition')
     def setUpClass(cls):
         super(TestImport, cls).setUpClass()
         # prepare the default dataset

--- a/tests/foreman/cli/test_organization.py
+++ b/tests/foreman/cli/test_organization.py
@@ -46,6 +46,7 @@ from robottelo.datafactory import (
 )
 from robottelo.decorators import (
     run_only_on,
+    skip_if_not_set,
     tier1,
     tier2,
 )
@@ -559,6 +560,7 @@ class OrganizationTestCase(CLITestCase):
         self.assertNotIn(hostgroup['name'], org['hostgroups'])
 
     @run_only_on('sat')
+    @skip_if_not_set('compute_resources')
     @tier2
     def test_positive_add_compresource_by_name(self):
         """Add a compute resource to organization by its name
@@ -619,6 +621,7 @@ class OrganizationTestCase(CLITestCase):
             self.assertIn(resource['name'], org['compute-resources'])
 
     @run_only_on('sat')
+    @skip_if_not_set('compute_resources')
     @tier2
     def test_positive_remove_compresource_by_id(self):
         """Remove a compute resource from organization by its ID
@@ -648,6 +651,7 @@ class OrganizationTestCase(CLITestCase):
         self.assertNotIn(compute_res['name'], org['compute-resources'])
 
     @run_only_on('sat')
+    @skip_if_not_set('compute_resources')
     @tier2
     def test_positive_remove_compresource_by_name(self):
         """Remove a compute resource from organization by its name

--- a/tests/foreman/endtoend/test_api_endtoend.py
+++ b/tests/foreman/endtoend/test_api_endtoend.py
@@ -39,6 +39,7 @@ from robottelo.constants import (
 from robottelo.decorators import (
     bz_bug_is_open,
     setting_is_set,
+    skip_if_not_set,
 )
 from robottelo.helpers import get_nailgun_config
 from robottelo.test import TestCase
@@ -930,6 +931,7 @@ class EndToEndTestCase(TestCase, ClientProvisioningMixin):
             u'Not all services seem to be up and running!'
         )
 
+    @skip_if_not_set('compute_resources')
     def test_positive_end_to_end(self):
         """Perform end to end smoke tests using RH and custom repos.
 

--- a/tests/foreman/endtoend/test_cli_endtoend.py
+++ b/tests/foreman/endtoend/test_cli_endtoend.py
@@ -48,7 +48,11 @@ from robottelo.constants import (
     REPOSET,
 )
 from robottelo.config import settings
-from robottelo.decorators import bz_bug_is_open, setting_is_set
+from robottelo.decorators import (
+    bz_bug_is_open,
+    setting_is_set,
+    skip_if_not_set,
+)
 from robottelo.test import CLITestCase
 
 from .utils import AK_CONTENT_LABEL, ClientProvisioningMixin
@@ -94,6 +98,7 @@ class EndToEndTestCase(CLITestCase, ClientProvisioningMixin):
         self.assertEqual(result['login'], 'admin')
         self.assertEqual(result['admin'], 'yes')
 
+    @skip_if_not_set('compute_resources')
     def test_positive_end_to_end(self):
         """Perform end to end smoke tests using RH and custom repos.
 

--- a/tests/foreman/endtoend/test_ui_endtoend.py
+++ b/tests/foreman/endtoend/test_ui_endtoend.py
@@ -108,6 +108,7 @@ class EndToEndTestCase(UITestCase, ClientProvisioningMixin):
         with Session(self.browser):
             self.assertTrue(self.user.user_admin_role_toggle('admin'))
 
+    @skip_if_not_set('compute_resources')
     def test_positive_end_to_end(self):
         """Perform end to end smoke tests using RH and custom repos.
 
@@ -341,6 +342,8 @@ class EndToEndTestCase(UITestCase, ClientProvisioningMixin):
         puppet_repository_name = gen_string('alpha')
         repos = self.sync.create_repos_tree(SAT6_TOOLS_TREE)
         rhel_prd = DEFAULT_SUBSCRIPTION_NAME
+        if settings.rhel6_repo is None:
+            self.skipTest('Missing configuration for rhel6_repo')
         rhel6_repo = settings.rhel6_repo
         with Session(self.browser) as session:
             # Create New organization

--- a/tests/foreman/longrun/test_oscap.py
+++ b/tests/foreman/longrun/test_oscap.py
@@ -160,7 +160,11 @@ class OpenScapTestCase(UITestCase):
 
         @CaseLevel: System
         """
+        if settings.rhel6_repo is None:
+            self.skipTest('Missing configuration for rhel6_repo')
         rhel6_repo = settings.rhel6_repo
+        if settings.rhel7_repo is None:
+            self.skipTest('Missing configuration for rhel7_repo')
         rhel7_repo = settings.rhel7_repo
         rhel6_content = OSCAP_DEFAULT_CONTENT['rhel6_content']
         rhel7_content = OSCAP_DEFAULT_CONTENT['rhel7_content']

--- a/tests/foreman/performance/test_pulp_sync.py
+++ b/tests/foreman/performance/test_pulp_sync.py
@@ -19,6 +19,7 @@
 import csv
 
 from robottelo.config import settings
+from robottelo.decorators import skip_if_not_set
 from robottelo.performance.constants import (
     RAW_SYNC_FILE_NAME,
     STAT_SYNC_FILE_NAME
@@ -57,6 +58,7 @@ class ConcurrentSyncTestCase(ConcurrentTestCase):
 
     """
     @classmethod
+    @skip_if_not_set('performance')
     def setUpClass(cls):
         super(ConcurrentSyncTestCase, cls).setUpClass()
 

--- a/tests/foreman/performance/test_standard_prep.py
+++ b/tests/foreman/performance/test_standard_prep.py
@@ -22,6 +22,7 @@ from robottelo.cli.repository import Repository
 from robottelo.cli.repository_set import RepositorySet
 from robottelo.cli.subscription import Subscription
 from robottelo.config import settings
+from robottelo.decorators import skip_if_not_set
 from robottelo.performance.constants import MANIFEST_FILE_NAME
 from robottelo.test import TestCase
 
@@ -39,6 +40,7 @@ class StandardPrepTestCase(TestCase):
     """
 
     @classmethod
+    @skip_if_not_set('performance')
     def setUpClass(cls):
         super(StandardPrepTestCase, cls).setUpClass()
 

--- a/tests/foreman/ui/test_computeresource.py
+++ b/tests/foreman/ui/test_computeresource.py
@@ -20,7 +20,7 @@ from nailgun import entities
 from robottelo.config import settings
 from robottelo.constants import FOREMAN_PROVIDERS, LIBVIRT_RESOURCE_URL
 from robottelo.datafactory import invalid_names_list, valid_data_list
-from robottelo.decorators import run_only_on, tier1
+from robottelo.decorators import run_only_on, skip_if_not_set, tier1
 from robottelo.test import UITestCase
 from robottelo.ui.factory import make_resource
 from robottelo.ui.locators import common_locators
@@ -31,6 +31,7 @@ class ComputeResourceTestCase(UITestCase):
     """Implements Compute Resource tests in UI"""
 
     @classmethod
+    @skip_if_not_set('compute_resources')
     def setUpClass(cls):
         super(ComputeResourceTestCase, cls).setUpClass()
         cls.current_libvirt_url = (

--- a/tests/foreman/ui/test_computeresource_rhev.py
+++ b/tests/foreman/ui/test_computeresource_rhev.py
@@ -13,7 +13,7 @@
 @Upstream: No
 """
 
-from robottelo.decorators import run_only_on, tier1, tier2, tier3, stubbed
+from robottelo.decorators import run_only_on, stubbed, tier1, tier2, tier3
 from robottelo.test import UITestCase
 
 

--- a/tests/foreman/ui/test_location.py
+++ b/tests/foreman/ui/test_location.py
@@ -24,7 +24,7 @@ from robottelo.datafactory import (
     generate_strings_list,
     invalid_values_list,
 )
-from robottelo.decorators import run_only_on, tier1, tier2
+from robottelo.decorators import run_only_on, skip_if_not_set, tier1, tier2
 from robottelo.constants import (
     DEFAULT_ORG,
     INSTALL_MEDIUM_URL,
@@ -439,6 +439,7 @@ class LocationTestCase(UITestCase):
                     self.assertIsNotNone(element)
 
     @run_only_on('sat')
+    @skip_if_not_set('compute_resources')
     @tier2
     def test_positive_add_compresource(self):
         """Add compute resource using the location name and compute resource
@@ -780,6 +781,7 @@ class LocationTestCase(UITestCase):
                     self.assertIsNone(element)
 
     @run_only_on('sat')
+    @skip_if_not_set('compute_resources')
     @tier2
     def test_positive_remove_compresource(self):
         """Remove compute resource by using the location name and compute

--- a/tests/foreman/ui/test_organization.py
+++ b/tests/foreman/ui/test_organization.py
@@ -640,6 +640,7 @@ class OrganizationTestCase(UITestCase):
                     self.assertIsNotNone(element)
 
     @run_only_on('sat')
+    @skip_if_not_set('compute_resources')
     @tier2
     def test_positive_remove_compresource(self):
         """Remove compute resource using the organization name and
@@ -848,6 +849,7 @@ class OrganizationTestCase(UITestCase):
         """
 
     @run_only_on('sat')
+    @skip_if_not_set('compute_resources')
     @tier2
     def test_positive_add_compresource(self):
         """Add compute resource using the organization

--- a/tests/foreman/ui/test_oscapcontent.py
+++ b/tests/foreman/ui/test_oscapcontent.py
@@ -21,7 +21,12 @@ from nailgun import entities
 from robottelo.config import settings
 from robottelo.constants import OSCAP_DEFAULT_CONTENT
 from robottelo.datafactory import invalid_values_list, valid_data_list
-from robottelo.decorators import skip_if_bug_open, tier1, tier2
+from robottelo.decorators import (
+    skip_if_bug_open,
+    skip_if_not_set,
+    tier1,
+    tier2,
+)
 from robottelo.helpers import get_data_file
 from robottelo.test import UITestCase
 from robottelo.ui.factory import make_oscapcontent
@@ -33,6 +38,7 @@ class OpenScapContentTestCase(UITestCase):
     """Implements Oscap Content tests in UI."""
 
     @classmethod
+    @skip_if_not_set('oscap')
     def setUpClass(cls):
         super(OpenScapContentTestCase, cls).setUpClass()
         path = settings.oscap.content_path

--- a/tests/foreman/ui/test_oscappolicy.py
+++ b/tests/foreman/ui/test_oscappolicy.py
@@ -22,7 +22,7 @@ from robottelo.constants import (
     OSCAP_WEEKDAY,
 )
 from robottelo.datafactory import invalid_values_list, valid_data_list
-from robottelo.decorators import skip_if_bug_open, tier1
+from robottelo.decorators import skip_if_bug_open, skip_if_not_set, tier1
 from robottelo.helpers import get_data_file
 from robottelo.test import UITestCase
 from robottelo.ui.factory import make_oscapcontent, make_oscappolicy
@@ -33,6 +33,7 @@ class OpenScapPolicy(UITestCase):
     """Implements Oscap Policy tests in UI."""
 
     @classmethod
+    @skip_if_not_set('oscap')
     def setUpClass(cls):
         super(OpenScapPolicy, cls).setUpClass()
         cls.content_path = get_data_file(


### PR DESCRIPTION
Cherry-pick of #4128 and #4134. Closes #3006 

```python
% py.test tests/foreman/api/test_computeresource.py tests/foreman/cli/test_{organization.py,computeresource.py} tests/foreman/ui/test_{organization.py,location.py,computeresource.py} tests/foreman/endtoend/test* -k 'test_positive_end_to_end or ComputeResourceTestCase or test_positive_add_compresource or test_positive_remove_compresource or test_positive_add_compresource_by_name or test_positive_remove_compresource_by_id or test_positive_remove_compresource_by_name or test_positive_puppet_install'                                                                                        
===================================================================== test session starts =====================================================================
platform linux2 -- Python 2.7.12, pytest-2.9.2, py-1.4.31, pluggy-0.3.1
rootdir: /home/qui/code/robottelo, inifile: 
plugins: xdist-1.14, cov-2.3.1
collected 180 items 

tests/foreman/api/test_computeresource.py sssssssssssssssssssss
tests/foreman/cli/test_organization.py .s.ss
tests/foreman/cli/test_computeresource.py ssssssssssssss
tests/foreman/ui/test_organization.py ss
tests/foreman/ui/test_location.py ss
tests/foreman/ui/test_computeresource.py sssssssss
tests/foreman/endtoend/test_api_endtoend.py s
tests/foreman/endtoend/test_cli_endtoend.py s
tests/foreman/endtoend/test_ui_endtoend.py ss

 123 tests deselected by '-ktest_positive_end_to_end or ComputeResourceTestCase or test_positive_add_compresource or test_positive_remove_compresource or test_positive_add_compresource_by_name or test_positive_remove_compresource_by_id or test_positive_remove_compresource_by_name or test_positive_puppet_install' 
=================================================== 2 passed, 55 skipped, 123 deselected in 173.53 seconds ====================================================
```
```python
% py.test tests/foreman/cli/test_docker.py tests/foreman/cli/test_import.py  tests/foreman/longrun/test_oscap.py tests/foreman/performance/test_pulp_sync.py tests/foreman/performance/test_standard_prep.py  tests/foreman/ui/test_computeresource_rhev.py tests/foreman/ui/test_host.py tests/foreman/ui/test_oscapcontent.py  tests/foreman/ui/test_oscappolicy.py -k 'OpenScapPolicy or test_positive_upload_image or TestImport or OpenScapContentTestCase or AtomicHostTestCase or RhevComputeResourceTestCase or StandardPrepTestCase or ConcurrentSyncTestCase or test_positive_upload_to_satellite'
===================================================================== test session starts =====================================================================
platform linux2 -- Python 2.7.12, pytest-2.9.2, py-1.4.31, pluggy-0.3.1
rootdir: /home/qui/code/robottelo, inifile: 
plugins: xdist-1.14, cov-2.3.1
collected 126 items 

tests/foreman/cli/test_docker.py s
tests/foreman/cli/test_import.py ssssssssssssssssssssssssssss
tests/foreman/longrun/test_oscap.py s
tests/foreman/performance/test_pulp_sync.py ss
tests/foreman/performance/test_standard_prep.py s
tests/foreman/ui/test_computeresource_rhev.py sssssssssssssss
tests/foreman/ui/test_oscapcontent.py sssss
tests/foreman/ui/test_oscappolicy.py ssss

 69 tests deselected by '-kOpenScapPolicy or test_positive_upload_image or TestImport or OpenScapContentTestCase or AtomicHostTestCase or RhevComputeResourceTestCase or StandardPrepTestCase or ConcurrentSyncTestCase or test_positive_upload_to_satellite' 
========================================================= 57 skipped, 69 deselected in 24.83 seconds ==========================================================
```