### PR TITLE
Skip tests because of BZ 1395229

### DIFF
--- a/tests/foreman/api/test_organization.py
+++ b/tests/foreman/api/test_organization.py
@@ -319,6 +319,7 @@ class OrganizationUpdateTestCase(APITestCase):
         self.assertEqual(len(org.hostgroup), 1)
         self.assertEqual(org.hostgroup[0].id, hostgroup.id)
 
+    @skip_if_bug_open('bugzilla', 1395229)
     @tier2
     def test_positive_remove_hostgroup(self):
         """Add a hostgroup to an organization and then remove it
@@ -370,6 +371,7 @@ class OrganizationUpdateTestCase(APITestCase):
         self.assertEqual(len(org.smart_proxy), 1)
         self.assertEqual(org.smart_proxy[0].id, smart_proxy.id)
 
+    @skip_if_bug_open('bugzilla', 1395229)
     @tier2
     def test_positive_remove_smart_proxy(self):
         """Remove a smart proxy from an organization

--- a/tests/foreman/api/test_template.py
+++ b/tests/foreman/api/test_template.py
@@ -48,6 +48,7 @@ class ConfigTemplateTestCase(APITestCase):
         response.raise_for_status()
         self.assertIsInstance(response.json(), dict)
 
+    @skip_if_bug_open('bugzilla', 1395229)
     @tier2
     def test_positive_add_orgs(self):
         """Associate a config template with organizations.

--- a/tests/foreman/cli/test_organization.py
+++ b/tests/foreman/cli/test_organization.py
@@ -46,6 +46,7 @@ from robottelo.datafactory import (
 )
 from robottelo.decorators import (
     run_only_on,
+    skip_if_bug_open,
     skip_if_not_set,
     tier1,
     tier2,
@@ -243,6 +244,7 @@ class OrganizationTestCase(CLITestCase):
         self.assertIn(new_subnet['name'], org['subnets'][0])
 
     @run_only_on('sat')
+    @skip_if_bug_open('bugzilla', 1395229)
     @tier2
     def test_positive_remove_subnet_by_name(self):
         """Remove a subnet from organization by its name
@@ -270,6 +272,7 @@ class OrganizationTestCase(CLITestCase):
         self.assertEqual(len(org['subnets']), 0)
 
     @run_only_on('sat')
+    @skip_if_bug_open('bugzilla', 1395229)
     @tier2
     def test_positive_remove_subnet_by_id(self):
         """Remove a subnet from organization by its ID
@@ -334,6 +337,7 @@ class OrganizationTestCase(CLITestCase):
         org = Org.info({'id': org['id']})
         self.assertIn(user['login'], org['users'])
 
+    @skip_if_bug_open('bugzilla', 1395229)
     @tier2
     def test_positive_remove_user_by_id(self):
         """Remove an user from organization by its ID
@@ -357,6 +361,7 @@ class OrganizationTestCase(CLITestCase):
         org = Org.info({'id': org['id']})
         self.assertNotIn(user['login'], org['users'])
 
+    @skip_if_bug_open('bugzilla', 1395229)
     @tier2
     def test_positive_remove_user_by_name(self):
         """Remove an user from organization by its login and organization name
@@ -422,6 +427,7 @@ class OrganizationTestCase(CLITestCase):
         org = Org.info({'name': org['name']})
         self.assertIn(user['login'], org['users'])
 
+    @skip_if_bug_open('bugzilla', 1395229)
     @tier2
     def test_positive_remove_admin_user_by_id(self):
         """Remove an admin user from organization by user ID and the
@@ -447,6 +453,7 @@ class OrganizationTestCase(CLITestCase):
         org = Org.info({'id': org['id']})
         self.assertNotIn(user['login'], org['users'])
 
+    @skip_if_bug_open('bugzilla', 1395229)
     @tier2
     def test_positive_remove_admin_user_by_name(self):
         """Remove an admin user from organization by user login and the
@@ -512,6 +519,7 @@ class OrganizationTestCase(CLITestCase):
         self.assertIn(hostgroup['name'], org['hostgroups'])
 
     @run_only_on('sat')
+    @skip_if_bug_open('bugzilla', 1395229)
     @tier2
     def test_positive_remove_hostgroup_by_name(self):
         """Remove a hostgroup from an organization by its name
@@ -536,6 +544,7 @@ class OrganizationTestCase(CLITestCase):
         self.assertNotIn(hostgroup['name'], org['hostgroups'])
 
     @run_only_on('sat')
+    @skip_if_bug_open('bugzilla', 1395229)
     @tier2
     def test_positive_remove_hostgroup_by_id(self):
         """Remove a hostgroup from an organization by its ID
@@ -622,6 +631,7 @@ class OrganizationTestCase(CLITestCase):
 
     @run_only_on('sat')
     @skip_if_not_set('compute_resources')
+    @skip_if_bug_open('bugzilla', 1395229)
     @tier2
     def test_positive_remove_compresource_by_id(self):
         """Remove a compute resource from organization by its ID
@@ -652,6 +662,7 @@ class OrganizationTestCase(CLITestCase):
 
     @run_only_on('sat')
     @skip_if_not_set('compute_resources')
+    @skip_if_bug_open('bugzilla', 1395229)
     @tier2
     def test_positive_remove_compresource_by_name(self):
         """Remove a compute resource from organization by its name
@@ -721,6 +732,7 @@ class OrganizationTestCase(CLITestCase):
         self.assertIn(medium['name'], org['installation-media'])
 
     @run_only_on('sat')
+    @skip_if_bug_open('bugzilla', 1395229)
     @tier2
     def test_positive_remove_medium_by_id(self):
         """Remove a medium from organization by its ID
@@ -745,6 +757,7 @@ class OrganizationTestCase(CLITestCase):
         self.assertNotIn(medium['name'], org['installation-media'])
 
     @run_only_on('sat')
+    @skip_if_bug_open('bugzilla', 1395229)
     @tier2
     def test_positive_remove_medium_by_name(self):
         """Remove a medium from organization by its name
@@ -957,6 +970,7 @@ class OrganizationTestCase(CLITestCase):
         self.assertIn(domain['name'], result['domains'])
 
     @run_only_on('sat')
+    @skip_if_bug_open('bugzilla', 1395229)
     @tier2
     def test_positive_remove_domain_by_name(self):
         """Remove a domain from organization by its name
@@ -984,6 +998,7 @@ class OrganizationTestCase(CLITestCase):
         self.assertEqual(len(result['domains']), 0)
 
     @run_only_on('sat')
+    @skip_if_bug_open('bugzilla', 1395229)
     @tier2
     def test_positive_remove_domain_by_id(self):
         """Remove a domain from organization by its ID

--- a/tests/foreman/cli/test_template.py
+++ b/tests/foreman/cli/test_template.py
@@ -25,7 +25,7 @@ from robottelo.cli.factory import (
     make_template,
 )
 from robottelo.cli.template import Template
-from robottelo.decorators import run_only_on, tier1, tier2
+from robottelo.decorators import run_only_on, skip_if_bug_open, tier1, tier2
 from robottelo.test import CLITestCase
 
 
@@ -131,6 +131,7 @@ class TemplateTestCase(CLITestCase):
         self.assertIn(os_string, new_template['operating-systems'])
 
     @run_only_on('sat')
+    @skip_if_bug_open('bugzilla', 1395229)
     @tier2
     def test_positive_remove_os_by_id(self):
         """Check if operating system can be removed from a template

--- a/tests/foreman/cli/test_usergroup.py
+++ b/tests/foreman/cli/test_usergroup.py
@@ -30,7 +30,7 @@ from robottelo.datafactory import (
     valid_data_list,
     valid_usernames_list,
 )
-from robottelo.decorators import tier1, tier2
+from robottelo.decorators import skip_if_bug_open, tier1, tier2
 from robottelo.test import CLITestCase
 
 
@@ -466,6 +466,7 @@ class UserGroupTestCase(CLITestCase):
         user_group = UserGroup.info({'id': user_group['id']})
         self.assertEqual(user_group['user-groups'][0], sub_user_group['name'])
 
+    @skip_if_bug_open('bugzilla', 1395229)
     @tier2
     def test_positive_remove_role_by_id(self):
         """Create new user group using valid role attached to that group. Then
@@ -487,6 +488,7 @@ class UserGroupTestCase(CLITestCase):
         user_group = UserGroup.info({'id': user_group['id']})
         self.assertEqual(len(user_group['roles']), 0)
 
+    @skip_if_bug_open('bugzilla', 1395229)
     @tier2
     def test_positive_remove_role_by_name(self):
         """Create new user group using valid role attached to that group. Then
@@ -508,6 +510,7 @@ class UserGroupTestCase(CLITestCase):
         user_group = UserGroup.info({'id': user_group['id']})
         self.assertEqual(len(user_group['roles']), 0)
 
+    @skip_if_bug_open('bugzilla', 1395229)
     @tier2
     def test_positive_remove_user_by_id(self):
         """Create new user group using valid user attached to that group. Then
@@ -529,6 +532,7 @@ class UserGroupTestCase(CLITestCase):
         user_group = UserGroup.info({'id': user_group['id']})
         self.assertEqual(len(user_group['users']), 0)
 
+    @skip_if_bug_open('bugzilla', 1395229)
     @tier2
     def test_positive_remove_user_by_name(self):
         """Create new user group using valid user attached to that group. Then
@@ -550,6 +554,7 @@ class UserGroupTestCase(CLITestCase):
         user_group = UserGroup.info({'id': user_group['id']})
         self.assertEqual(len(user_group['users']), 0)
 
+    @skip_if_bug_open('bugzilla', 1395229)
     @tier2
     def test_positive_remove_usergroup_by_id(self):
         """Create new user group using another user group attached to the
@@ -571,6 +576,7 @@ class UserGroupTestCase(CLITestCase):
         user_group = UserGroup.info({'id': user_group['id']})
         self.assertEqual(len(user_group['user-groups']), 0)
 
+    @skip_if_bug_open('bugzilla', 1395229)
     @tier2
     def test_positive_remove_usergroup_by_name(self):
         """Create new user group using another user group attached to the


### PR DESCRIPTION
A lot of tests failing because of https://bugzilla.redhat.com/show_bug.cgi?id=1395229
Including CLI tests though BZ desribes API problem. As in most cases hammer sends `[]` as value for `remove` commands.

```
# hammer --debug -v -u admin -p changeme  organization remove-domain --domain="oikseyik8f" --name="YtRJH8"

[ INFO 2017-01-05 11:54:39 API] PUT /katello/api/organizations/61
[DEBUG 2017-01-05 11:54:39 API] Params: {
    "organization" => {
        "domain_ids" => []
    }
}
```

@oshtaier Though you suggested to open more relevant BZs, devs close them as duplicates because `1395229` describes the root cause. 