### PR TITLE
[6.2.z] Added missing /api/hosts/:id/enc path on end-to-end tests

### DIFF
--- a/tests/foreman/endtoend/test_api_endtoend.py
+++ b/tests/foreman/endtoend/test_api_endtoend.py
@@ -395,6 +395,7 @@ API_PATHS = {
         u'/api/hosts/:id',
         u'/api/hosts/:id',
         u'/api/hosts/:id',
+        u'/api/hosts/:id/enc',
         u'/api/hosts/:id/boot',
         u'/api/hosts/:id/disassociate',
         u'/api/hosts/:id/power',


### PR DESCRIPTION
This is blocking 6.2.7 release