### PR TITLE
Add missing stubbed decorator for stubs.

### DIFF
--- a/tests/foreman/cli/test_repository.py
+++ b/tests/foreman/cli/test_repository.py
@@ -58,6 +58,7 @@ from robottelo.constants import (
 from robottelo.decorators import (
     run_only_on,
     skip_if_bug_open,
+    stubbed,
     tier1,
     tier2,
 )
@@ -1350,6 +1351,7 @@ class GitPuppetMirrorTestCase(CLITestCase):
     # create a sync schedule against the mirror to make sure it is periodically
     # update to contain the latest and greatest.
 
+    @stubbed()
     @tier2
     def test_positive_git_local_create(self):
         """Create repository with local git puppet mirror.
@@ -1370,6 +1372,7 @@ class GitPuppetMirrorTestCase(CLITestCase):
         @CaseAutomation: notautomated
         """
 
+    @stubbed()
     @tier2
     def test_positive_git_local_update(self):
         """Update repository with local git puppet mirror.
@@ -1390,6 +1393,7 @@ class GitPuppetMirrorTestCase(CLITestCase):
         @CaseAutomation: notautomated
         """
 
+    @stubbed()
     @tier2
     def test_positive_git_local_delete(self):
         """Delete repository with local git puppet mirror.
@@ -1410,6 +1414,7 @@ class GitPuppetMirrorTestCase(CLITestCase):
         @CaseAutomation: notautomated
         """
 
+    @stubbed()
     @tier2
     def test_positive_git_remote_create(self):
         """Create repository with remote git puppet mirror.
@@ -1430,6 +1435,7 @@ class GitPuppetMirrorTestCase(CLITestCase):
         @CaseAutomation: notautomated
         """
 
+    @stubbed()
     @tier2
     def test_positive_git_remote_update(self):
         """Update repository with remote git puppet mirror.
@@ -1450,6 +1456,7 @@ class GitPuppetMirrorTestCase(CLITestCase):
         @CaseAutomation: notautomated
         """
 
+    @stubbed()
     @tier2
     def test_positive_git_remote_delete(self):
         """Delete repository with remote git puppet mirror.
@@ -1470,6 +1477,7 @@ class GitPuppetMirrorTestCase(CLITestCase):
         @CaseAutomation: notautomated
         """
 
+    @stubbed()
     @tier2
     def test_positive_git_sync(self):
         """Sync repository with git puppet mirror.
@@ -1491,6 +1499,7 @@ class GitPuppetMirrorTestCase(CLITestCase):
         @CaseAutomation: notautomated
         """
 
+    @stubbed()
     @tier2
     def test_positive_git_sync_with_content_change(self):
         """Sync repository with changes in git puppet mirror.
@@ -1518,6 +1527,7 @@ class GitPuppetMirrorTestCase(CLITestCase):
         @CaseAutomation: notautomated
         """
 
+    @stubbed()
     @tier2
     def test_positive_git_sync_schedule(self):
         """Scheduled sync of git puppet mirror.
@@ -1537,6 +1547,7 @@ class GitPuppetMirrorTestCase(CLITestCase):
         @CaseAutomation: notautomated
         """
 
+    @stubbed()
     @tier2
     def test_positive_git_view_content(self):
         """View content in synced git puppet mirror

--- a/tests/foreman/ui/test_repository.py
+++ b/tests/foreman/ui/test_repository.py
@@ -1441,6 +1441,7 @@ class GitPuppetMirrorTestCase(UITestCase):
     # create a sync schedule against the mirror to make sure it is periodically
     # update to contain the latest and greatest.
 
+    @stubbed()
     @tier2
     def test_positive_git_local_create(self):
         """Create repository with local git puppet mirror.
@@ -1461,6 +1462,7 @@ class GitPuppetMirrorTestCase(UITestCase):
         @CaseAutomation: notautomated
         """
 
+    @stubbed()
     @tier2
     def test_positive_git_local_update(self):
         """Update repository with local git puppet mirror.
@@ -1481,6 +1483,7 @@ class GitPuppetMirrorTestCase(UITestCase):
         @CaseAutomation: notautomated
         """
 
+    @stubbed()
     @tier2
     def test_positive_git_local_delete(self):
         """Delete repository with local git puppet mirror.
@@ -1501,6 +1504,7 @@ class GitPuppetMirrorTestCase(UITestCase):
         @CaseAutomation: notautomated
         """
 
+    @stubbed()
     @tier2
     def test_positive_git_remote_create(self):
         """Create repository with remote git puppet mirror.
@@ -1521,6 +1525,7 @@ class GitPuppetMirrorTestCase(UITestCase):
         @CaseAutomation: notautomated
         """
 
+    @stubbed()
     @tier2
     def test_positive_git_remote_update(self):
         """Update repository with remote git puppet mirror.
@@ -1541,6 +1546,7 @@ class GitPuppetMirrorTestCase(UITestCase):
         @CaseAutomation: notautomated
         """
 
+    @stubbed()
     @tier2
     def test_positive_git_remote_delete(self):
         """Delete repository with remote git puppet mirror.
@@ -1561,6 +1567,7 @@ class GitPuppetMirrorTestCase(UITestCase):
         @CaseAutomation: notautomated
         """
 
+    @stubbed()
     @tier2
     def test_positive_git_sync(self):
         """Sync repository with git puppet mirror.
@@ -1582,6 +1589,7 @@ class GitPuppetMirrorTestCase(UITestCase):
         @CaseAutomation: notautomated
         """
 
+    @stubbed()
     @tier2
     def test_positive_git_sync_with_content_change(self):
         """Sync repository with changes in git puppet mirror.
@@ -1609,6 +1617,7 @@ class GitPuppetMirrorTestCase(UITestCase):
         @CaseAutomation: notautomated
         """
 
+    @stubbed()
     @tier2
     def test_positive_git_sync_schedule(self):
         """Scheduled sync of git puppet mirror.
@@ -1628,6 +1637,7 @@ class GitPuppetMirrorTestCase(UITestCase):
         @CaseAutomation: notautomated
         """
 
+    @stubbed()
     @tier2
     def test_positive_git_view_content(self):
         """View content in synced git puppet mirror


### PR DESCRIPTION
```python
% py.test tests/foreman/{cli,ui}/test_repository.py -k 'Git'
===================================================================== test session starts =====================================================================
platform linux2 -- Python 2.7.12, pytest-3.0.4, py-1.4.31, pluggy-0.4.0
rootdir: /home/qui/code/robottelo, inifile: 
plugins: xdist-1.15.0, html-1.12.0, cov-2.4.0
collected 117 items 

tests/foreman/cli/test_repository.py ssssssssss
tests/foreman/ui/test_repository.py ssssssssss

===================================================================== 97 tests deselected =====================================================================
========================================================== 20 skipped, 97 deselected in 5.22 seconds ==========================================================
```