### PR TITLE
[6.2.z] cherry-pick enable test for hammer fact list

### DIFF
--- a/tests/foreman/cli/test_fact.py
+++ b/tests/foreman/cli/test_fact.py
@@ -17,14 +17,13 @@
 
 from fauxfactory import gen_string
 from robottelo.cli.fact import Fact
-from robottelo.decorators import run_only_on, stubbed, tier1
+from robottelo.decorators import run_only_on, tier1
 from robottelo.test import CLITestCase
 
 
 class FactTestCase(CLITestCase):
     """Fact related tests."""
 
-    @stubbed('Need to create facts before we can check them.')
     @run_only_on('sat')
     @tier1
     def test_positive_list_by_name(self):
@@ -35,10 +34,14 @@ class FactTestCase(CLITestCase):
         @Assert: Fact List is displayed
 
         """
-        for fact in ('uptime', 'uptime_days', 'uptime_seconds', 'memoryfree',
-                     'ipaddress'):
+        for fact in (
+                u'uptime',
+                u'uptime_days',
+                u'uptime_seconds',
+                u'memoryfree',
+                u'ipaddress'):
             with self.subTest(fact):
-                args = {'search': "fact='%s'" % fact}
+                args = {u'search': "fact={0}".format(fact)}
                 facts = Fact().list(args)
                 self.assertEqual(facts[0]['fact'], fact)
 
@@ -53,6 +56,6 @@ class FactTestCase(CLITestCase):
 
         """
         fact = gen_string('alpha')
-        args = {'search': "fact='%s'" % fact}
+        args = {'search': "fact={0}".format(fact)}
         self.assertEqual(
             Fact().list(args), [], 'No records should be returned')


### PR DESCRIPTION
Unstubbed because there always is at least one host (server itself) with facts to list. Test results:

```
nosetests tests/foreman/cli/test_fact.py:FactTestCase
..
----------------------------------------------------------------------
Ran 2 tests in 17.700s

OK
```