### PR TITLE
Added missing /api/hosts/:id/enc path on end-to-end tests

### DIFF
--- a/tests/foreman/endtoend/test_api_endtoend.py
+++ b/tests/foreman/endtoend/test_api_endtoend.py
@@ -396,6 +396,7 @@ API_PATHS = {
         u'/api/hosts/:id',
         u'/api/hosts/:id',
         u'/api/hosts/:id',
+        u'/api/hosts/:id/enc',
         u'/api/hosts/:id/boot',
         u'/api/hosts/:id/disassociate',
         u'/api/hosts/:id/power',


### PR DESCRIPTION
close #4146