### PR TITLE
Added repository/puppet tests.

### DIFF
--- a/tests/foreman/api/test_repository.py
+++ b/tests/foreman/api/test_repository.py
@@ -406,24 +406,17 @@ class RepositoryTestCase(APITestCase):
         @CaseLevel: Integration
         """
         url = 'https://omaciel.fedorapeople.org/7c74c2b8/'
-        # Create first repo
-        repo = entities.Repository(
-            url=url,
-            product=self.product,
-            content_type='puppet',
-        ).create()
-        repo.sync()
-        self.assertGreaterEqual(repo.read().content_counts['puppet_module'], 1)
-        # Create another org and repo
+        # Use setup product for the first repo and create new org/product
+        # for the second one
         org = entities.Organization().create()
-        product = entities.Product(organization=org).create()
-        repo = entities.Repository(
-            url=url,
-            product=product,
-            content_type='puppet',
-        ).create()
-        repo.sync()
-        self.assertGreaterEqual(repo.read().content_counts['puppet_module'], 1)
+        products = (self.product, entities.Product(organization=org).create())
+        # Create repositories within different organizations/products
+        for product in products:
+            repo = entities.Repository(
+                url=url, product=product, content_type='puppet').create()
+            repo.sync()
+            self.assertGreaterEqual(
+                repo.read().content_counts['puppet_module'], 1)
 
     @tier1
     @run_only_on('sat')

--- a/tests/foreman/api/test_repository.py
+++ b/tests/foreman/api/test_repository.py
@@ -394,6 +394,37 @@ class RepositoryTestCase(APITestCase):
         repo2 = entities.Repository(name=repo1.name).create()
         self.assertEqual(repo1.name, repo2.name)
 
+    @tier2
+    def test_positive_create_puppet_repo_same_url_different_orgs(self):
+        """Create two repos with the same URL in two different organizations.
+
+        @id: 7c74c2b8-732a-4c47-8ad9-697121db05be
+
+        @Assert: Repositories are created and puppet modules are visible from
+        different organizations.
+
+        @CaseLevel: Integration
+        """
+        url = 'https://omaciel.fedorapeople.org/7c74c2b8/'
+        # Create first repo
+        repo = entities.Repository(
+            url=url,
+            product=self.product,
+            content_type='puppet',
+        ).create()
+        repo.sync()
+        self.assertGreaterEqual(repo.read().content_counts['puppet_module'], 1)
+        # Create another org and repo
+        org = entities.Organization().create()
+        product = entities.Product(organization=org).create()
+        repo = entities.Repository(
+            url=url,
+            product=product,
+            content_type='puppet',
+        ).create()
+        repo.sync()
+        self.assertGreaterEqual(repo.read().content_counts['puppet_module'], 1)
+
     @tier1
     @run_only_on('sat')
     def test_negative_create_name(self):

--- a/tests/foreman/cli/test_repository.py
+++ b/tests/foreman/cli/test_repository.py
@@ -520,6 +520,38 @@ class RepositoryTestCase(CLITestCase):
                 self.assertEqual(new_repo['content-type'], content_type)
                 self.assertEqual(new_repo['name'], name)
 
+    @tier2
+    def test_positive_create_puppet_repo_same_url_different_orgs(self):
+        """Create two repos with the same URL in two different organizations.
+
+        @id: b3502064-f400-4e60-a11f-b3772bd23a98
+
+        @Assert: Repositories are created and puppet modules are visible from
+        different organizations.
+
+        @CaseLevel: Integration
+        """
+        url = 'https://omaciel.fedorapeople.org/b3502064/'
+        # Create first repo
+        repo = self._make_repository({
+            u'content-type': u'puppet',
+            u'url': url,
+        })
+        Repository.synchronize({'id': repo['id']})
+        repo = Repository.info({'id': repo['id']})
+        self.assertEqual(repo['content-counts']['puppet-modules'], '1')
+        # Create another org and repo
+        org = make_org()
+        product = make_product({'organization-id': org['id']})
+        new_repo = self._make_repository({
+            u'url': url,
+            u'product': product,
+            u'content-type': u'puppet',
+        })
+        Repository.synchronize({'id': new_repo['id']})
+        new_repo = Repository.info({'id': new_repo['id']})
+        self.assertEqual(new_repo['content-counts']['puppet-modules'], '1')
+
     @tier1
     def test_negative_create_with_name(self):
         """Repository name cannot be 300-characters long


### PR DESCRIPTION
Part of #3219. Though original issues speaks about adding puppet modules to content view, it was inspired by BZ https://bugzilla.redhat.com/show_bug.cgi?id=1297308. Further discussion in that BZ showed that it is general problem with puppet repositories and not with UI or content views.
These tests covers original problem with same puppet url and different organizations. Adding puppet repos to content view seems to be covered in content view tests.

Also as for me tests names are too complicated. If you have better ides how to name them please suggest.

```python
% py.test tests/foreman/{api,cli,ui}/test_repository.py -k 'test_positive_create_puppet_repo_same_url_different_orgs'    
===================================================================== test session starts =====================================================================
platform linux2 -- Python 2.7.12, pytest-3.0.4, py-1.4.31, pluggy-0.4.0
rootdir: /home/qui/code/robottelo, inifile: 
plugins: xdist-1.15.0, html-1.12.0, cov-2.4.0
collected 180 items 

tests/foreman/api/test_repository.py .
tests/foreman/cli/test_repository.py .
tests/foreman/ui/test_repository.py .

==================================================================== 177 tests deselected =====================================================================
========================================================= 3 passed, 177 deselected in 240.11 seconds ==========================================================
```
