### PR TITLE
Before CV reimport wait for publish

### DIFF
--- a/tests/foreman/cli/test_import.py
+++ b/tests/foreman/cli/test_import.py
@@ -125,8 +125,8 @@ def import_content_hosts(files, tmp_dir):
         u'dir': os.path.join(tmp_dir, 'exports/CHANNELS'),
         u'verbose': True
     })
-    if bz_bug_is_open('1263650'):
-        wait_for_publish()
+    # WONTFIX if bz_bug_is_open('1263650'):
+    wait_for_publish()
     # proceed with importing the content hosts
     import_chosts = Import.content_host_with_tr_data({
         u'csv-file': files['system-profiles'],
@@ -1210,6 +1210,8 @@ class TestImport(CLITestCase):
                     'csv-file': files['custom-channels'],
                     'dir': os.path.join(tmp_dir, 'exports/CHANNELS'),
                 })
+                # WONTFIX if bz_bug_is_open('1263650'):
+                wait_for_publish()
                 # get the sat6 mapping of the imported organizations
                 imp_orgs = get_sat6_id(
                     Import.csv_to_dataset([files['users']]),


### PR DESCRIPTION
We have this change already in place when importing content-host.
For CV reimport it is missing and so CV publishing fails with 500 ISE

```
2017-01-06 12:29:27 - robottelo.ssh - DEBUG - >>> LANG=en_US.UTF-8  hammer -v -u admin -p changeme  import content-view --csv-file="/tmp/tmp.l01tY5rwmT/tmpZxxtMa" --dir="/tmp/tmp.l01tY5rwmT/exports/CHANNELS"
2017-01-06 12:29:37 - robottelo.ssh - DEBUG - <<< stdout
No such {redhat_,}content_view: 106
No such {redhat_,}content_view: 105
No such {redhat_,}content_view: 104
Publishing of content view [458] failed with RestClient::InternalServerError: 500 Internal Server Error
Summary
  No action taken.
```
