### PR TITLE
Add coverage for BZ 1337947

### DIFF
--- a/robottelo/cli/factory.py
+++ b/robottelo/cli/factory.py
@@ -2125,20 +2125,23 @@ def make_environment(options=None):
 
     Options::
 
-        --location-ids LOCATION_IDS   REPLACE locations with given ids
-                                      Comma separated list of values.
-        --name NAME
-        --organization-ids ORGANIZATION_IDS   REPLACE organizations with
-                                              given ids.
-                                              Comma separated list of values.
-        -h, --help                            print help
+         --location-ids LOCATION_IDS         REPLACE locations with given ids
+                                             Comma separated list of values.
+         --locations LOCATION_NAMES          Comma separated list of values.
+         --name NAME
+         --organization-ids ORGANIZATION_IDS REPLACE organizations with given
+                                             ids.
+                                             Comma separated list of values.
+         --organizations ORGANIZATION_NAMES  Comma separated list of values.
 
     """
     # Assigning default values for attributes
     args = {
         u'location-ids': None,
+        u'locations': None,
         u'name': gen_alphanumeric(6),
         u'organization-ids': None,
+        u'organizations': None,
     }
 
     return create_object(Environment, args, options)


### PR DESCRIPTION
Add coverage for https://bugzilla.redhat.com/show_bug.cgi?id=1337947
```python
% py.test -v tests/foreman/cli/test_environment.py -k 'list_ and org_and_loc'
===================================================================== test session starts =====================================================================
platform linux2 -- Python 2.7.12, pytest-3.0.4, py-1.4.31, pluggy-0.4.0 -- /home/qui/code/venv/2/bin/python2
cachedir: .cache
rootdir: /home/qui/code/robottelo, inifile: 
plugins: xdist-1.15.0, html-1.12.0, cov-2.4.0
collected 17 items 

tests/foreman/cli/test_environment.py::EnvironmentTestCase::test_negative_list_with_non_existing_org_and_loc <- robottelo/decorators/__init__.py PASSED
tests/foreman/cli/test_environment.py::EnvironmentTestCase::test_negative_list_with_org_and_loc <- robottelo/decorators/__init__.py PASSED
tests/foreman/cli/test_environment.py::EnvironmentTestCase::test_positive_list_with_org_and_loc <- robottelo/decorators/__init__.py PASSED

===================================================================== 14 tests deselected =====================================================================
========================================================== 3 passed, 14 deselected in 118.86 seconds ==========================================================
```