### PR TITLE
Making the attach_nic work on a running domain

### DIFF
--- a/robottelo/libvirt_discovery.py
+++ b/robottelo/libvirt_discovery.py
@@ -177,7 +177,6 @@ class LibvirtGuest(object):
             '--source={vm_bridge}',
             '--model=virtio',
             '--mac={vm_mac}',
-            '--config',
             '--live',
         ]
         command = u' '.join(command_args).format(


### PR DESCRIPTION
Closes #4155

a simple command modification allows us to attach the NIC to the domain without a need of restarting it.
