### PR TITLE
Add coverage for BZ 1318004 and repo remove-content.

### DIFF
--- a/robottelo/cli/package.py
+++ b/robottelo/cli/package.py
@@ -1,0 +1,25 @@
+# -*- encoding: utf-8 -*-
+"""
+Usage::
+
+    hammer package [OPTIONS] SUBCOMMAND [ARG] ...
+
+Parameters::
+
+    SUBCOMMAND                    subcommand
+    [ARG] ...                     subcommand arguments
+
+Subcommands::
+
+    info                          Show a package
+    list                          List packages
+"""
+from robottelo.cli.base import Base
+
+
+class Package(Base):
+    """
+    Manipulates packages command.
+    """
+
+    command_base = 'package'

--- a/robottelo/cli/repository.py
+++ b/robottelo/cli/repository.py
@@ -78,6 +78,16 @@ class Repository(Base):
         )
 
     @classmethod
+    def remove_content(cls, options):
+        """Remove content from a repository"""
+        cls.command_sub = 'remove-content'
+        return cls.execute(
+            cls._construct_command(options),
+            output_format='csv',
+            ignore_stderr=True,
+        )
+
+    @classmethod
     def upload_content(cls, options):
         """Upload content to repository."""
         cls.command_sub = 'upload-content'

--- a/robottelo/ui/locators/base.py
+++ b/robottelo/ui/locators/base.py
@@ -1223,6 +1223,17 @@ locators = LocatorDict({
         " and not(contains(@class, 'ng-hide'))]"),
     "repo.content.packages": (By.XPATH, "//tr[@row-select='package']"),
     "repo.content.puppet_modules": (By.XPATH, "//tr[@row-select='item']"),
+    "repo.content.select_all": (
+        By.XPATH,
+        "//div[@bst-table='detailsTable']"
+        "//input[@type='checkbox'and @ng-model='selection.allSelected']"
+    ),
+    "repo.content.remove": (
+        By.XPATH,
+        "//div[@bst-modal='removeContent()']/following-sibling::"
+        "button[@ng-click='openModal()']"
+    ),
+    "repo.content.confirm_remove": (By.XPATH, "//button[@ng-click='ok()']"),
     "repo.upload.file_path": (By.XPATH, ("//input[@name='content[]']")),
     "repo.upload": (By.XPATH, ("//button[@upload-submit]")),
     # Activation Keys

--- a/robottelo/ui/repository.py
+++ b/robottelo/ui/repository.py
@@ -1,6 +1,6 @@
 """Implements Repos UI."""
 from robottelo.constants import CHECKSUM_TYPE, REPO_TYPE
-from robottelo.ui.base import Base
+from robottelo.ui.base import Base, UINoSuchElementError
 from robottelo.ui.locators import common_locators, locators, tab_locators
 
 
@@ -137,6 +137,40 @@ class Repos(Base):
             return (self.wait_until_element(locators[
                 'repo.fetch_' + field_name]).text == expected_field_value)
         return False
+
+    def fetch_content_count(self, repo_name, content_type):
+        """Fetch content count for specific repo and content type.
+
+        :param repo_name: Name of repository that should be fetched.
+        :param content_type: Type of repository content. Supported values are:
+
+            * packages
+            * errata
+            * package_groups
+            * puppet
+
+        :returns: Content count.
+        :rtype: int
+        :raises: ``ValueError`` if passed ``content_type`` is not supported.
+        :raises robottelo.ui.base.UINoSuchElementError: If content is not
+            found.
+        """
+        self.search_and_click(repo_name)
+        if content_type == 'packages':
+            locator = locators['repo.fetch_packages']
+        elif content_type == 'errata':
+            locator = locators['repo.fetch_errata']
+        elif content_type == 'package_groups':
+            locator = locators['repo.fetch_package_groups']
+        elif content_type == 'puppet':
+            locator = locators['repo.fetch_puppet_modules']
+        else:
+            raise ValueError("Please provide supported content_type value")
+        number = self.find_element(locator)
+        if number:
+            return int(number.text)
+        else:
+            raise UINoSuchElementError("Content count not found")
 
     def remove_content(self, repo_name):
         """Remove content from a repository."""

--- a/robottelo/ui/repository.py
+++ b/robottelo/ui/repository.py
@@ -138,6 +138,14 @@ class Repos(Base):
                 'repo.fetch_' + field_name]).text == expected_field_value)
         return False
 
+    def remove_content(self, repo_name):
+        """Remove content from a repository."""
+        self.search_and_click(repo_name)
+        self.click(locators['repo.manage_content'])
+        self.click(locators['repo.content.select_all'])
+        self.click(locators['repo.content.remove'])
+        self.click(locators['repo.content.confirm_remove'])
+
     def upload_content(self, repo_name, file_path):
         """Upload content to a repository."""
         self.search_and_click(repo_name)

--- a/tests/foreman/api/test_repository.py
+++ b/tests/foreman/api/test_repository.py
@@ -705,7 +705,7 @@ class RepositoryTestCase(APITestCase):
 
         @id: f686b74b-7ee9-4806-b999-bc05ffe61a9d
 
-        @Assert: The repository's content is removed and content counts shows
+        @Assert: The repository's content is removed and content count shows
         zero packages
         """
         # Create repository and synchronize it
@@ -904,12 +904,12 @@ class RepositoryTestCase(APITestCase):
     @run_only_on('sat')
     @tier2
     def test_positive_resynchronize_rpm_repo(self):
-        """Check that that repository content is resynced after packages were
+        """Check that repository content is resynced after packages were
         removed from repository
 
         @id: e3a62529-edbd-4062-9246-bef5f33bdcf0
 
-        @Assert: Repository have updated non-zero packages counts
+        @Assert: Repository has updated non-zero packages count
 
         @CaseLevel: Integration
 
@@ -935,12 +935,12 @@ class RepositoryTestCase(APITestCase):
     @run_only_on('sat')
     @tier2
     def test_positive_resynchronize_puppet_repo(self):
-        """Check that that repository content is resynced after puppet modules
+        """Check that repository content is resynced after puppet modules
         were removed from repository
 
         @id: db50beb0-de73-4783-abc8-57e61188b6c7
 
-        @Assert: Repository have updated non-zero puppet modules counts
+        @Assert: Repository has updated non-zero puppet modules count
 
         @CaseLevel: Integration
 

--- a/tests/foreman/cli/test_repository.py
+++ b/tests/foreman/cli/test_repository.py
@@ -804,12 +804,12 @@ class RepositoryTestCase(CLITestCase):
     @run_only_on('sat')
     @tier2
     def test_positive_resynchronize_rpm_repo(self):
-        """Check that that repository content is resynced after packages were
+        """Check that repository content is resynced after packages were
         removed from repository
 
         @id: dc415563-c9b8-4e3c-9d2a-f4ac251c7d35
 
-        @Assert: Repository have updated non-zero packages counts
+        @Assert: Repository has updated non-zero packages count
 
         @CaseLevel: Integration
 
@@ -841,12 +841,12 @@ class RepositoryTestCase(CLITestCase):
     @run_only_on('sat')
     @tier2
     def test_positive_resynchronize_puppet_repo(self):
-        """Check that that repository content is resynced after puppet modules
+        """Check that repository content is resynced after puppet modules
         were removed from repository
 
         @id: 9e28f0ae-3875-4c1e-ad8b-d068f4409fe3
 
-        @Assert: Repository have updated non-zero puppet modules counts
+        @Assert: Repository has updated non-zero puppet modules count
 
         @CaseLevel: Integration
 

--- a/tests/foreman/ui/test_repository.py
+++ b/tests/foreman/ui/test_repository.py
@@ -595,6 +595,106 @@ class RepositoryTestCase(UITestCase):
                     self.assertTrue(self.prd_sync_is_ok(repo_name))
 
     @run_only_on('sat')
+    @tier2
+    def test_positive_resynchronize_rpm_repo(self):
+        """Check that that repository content is resynced after packages were
+        removed from repository
+
+        @id: dc415563-c9b8-4e3c-9d2a-f4ac251c7d35
+
+        @Assert: Repository have updated non-zero package counts
+
+        @CaseLevel: Integration
+
+        @BZ: 1318004
+        """
+        with Session(self.browser) as session:
+            repo = entities.Repository(
+                url=FAKE_1_YUM_REPO,
+                content_type='yum',
+                product=self.session_prod,
+            ).create()
+            self.setup_navigate_syncnow(
+                session,
+                self.session_prod.name,
+                repo.name,
+            )
+            self.assertTrue(self.prd_sync_is_ok(repo.name))
+            # Check packages number
+            self.repository.search_and_click(repo.name)
+            number = self.repository.find_element(
+                locators['repo.fetch_packages'])
+            self.assertGreaterEqual(int(number.text), 1)
+            # Remove packages
+            self.repository.remove_content(repo.name)
+            self.repository.search_and_click(repo.name)
+            number = self.repository.find_element(
+                locators['repo.fetch_packages'])
+            self.assertEqual(int(number.text), 0)
+            # Sync it again
+            self.setup_navigate_syncnow(
+                session,
+                self.session_prod.name,
+                repo.name,
+            )
+            self.assertTrue(self.prd_sync_is_ok(repo.name))
+            # Check packages number
+            self.repository.search_and_click(repo.name)
+            number = self.repository.find_element(
+                locators['repo.fetch_packages'])
+            self.assertGreaterEqual(int(number.text), 1)
+
+    @run_only_on('sat')
+    @tier2
+    def test_positive_resynchronize_puppet_repo(self):
+        """Check that that repository content is resynced after packages were
+        removed from repository
+
+        @id: c82dfe9d-aa1c-4922-ab3f-5d66ba8375c5
+
+        @Assert: Repository have updated non-zero package counts
+
+        @CaseLevel: Integration
+
+        @BZ: 1318004
+        """
+        with Session(self.browser) as session:
+            repo = entities.Repository(
+                url=FAKE_1_PUPPET_REPO,
+                content_type='puppet',
+                product=self.session_prod,
+            ).create()
+            self.setup_navigate_syncnow(
+                session,
+                self.session_prod.name,
+                repo.name,
+            )
+            self.assertTrue(self.prd_sync_is_ok(repo.name))
+            # Check packages number
+            self.repository.search_and_click(repo.name)
+            number = self.repository.find_element(
+                locators['repo.fetch_puppet_modules'])
+            self.assertGreaterEqual(int(number.text), 1)
+            # Remove packages
+            self.repository.remove_content(repo.name)
+            self.repository.search_and_click(repo.name)
+            number = self.repository.find_element(
+                locators['repo.fetch_puppet_modules'])
+            self.assertEqual(int(number.text), 0)
+            # Sync repo again
+            self.setup_navigate_syncnow(
+                session,
+                self.session_prod.name,
+                repo.name,
+            )
+            self.assertTrue(self.prd_sync_is_ok(repo.name))
+            # Check packages number
+            self.repository.search_and_click(repo.name)
+            number = self.repository.find_element(
+                locators['repo.fetch_puppet_modules'])
+            self.assertGreaterEqual(int(number.text), 1)
+
+    @run_only_on('sat')
     @skip_if_os('RHEL6')
     @tier1
     def test_positive_create_custom_ostree_repo(self):
@@ -1474,6 +1574,72 @@ class RepositoryTestCase(UITestCase):
             self.assertIsNotNone(self.activationkey.wait_until_element(
                 common_locators['alert.error_sub_form']))
             # Check packages number
+            number = self.repository.find_element(
+                locators['repo.fetch_puppet_modules'])
+            self.assertEqual(int(number.text), 0)
+
+    @run_only_on('sat')
+    @tier1
+    def test_positive_remove_content_rpm(self):
+        """Synchronize repository and remove content from it
+
+        @id: 054763e5-b6a8-4f06-a9f7-6819fbc7aba8
+
+        @Assert: Content Counts shows zero rpm packages
+        """
+        with Session(self.browser) as session:
+            repo = entities.Repository(
+                url=FAKE_1_YUM_REPO,
+                content_type='yum',
+                product=self.session_prod,
+            ).create()
+            self.setup_navigate_syncnow(
+                session,
+                self.session_prod.name,
+                repo.name,
+            )
+            self.assertTrue(self.prd_sync_is_ok(repo.name))
+            # Check packages number
+            self.repository.search_and_click(repo.name)
+            number = self.repository.find_element(
+                locators['repo.fetch_packages'])
+            self.assertGreaterEqual(int(number.text), 1)
+            # Remove packages
+            self.repository.remove_content(repo.name)
+            self.repository.search_and_click(repo.name)
+            number = self.repository.find_element(
+                locators['repo.fetch_packages'])
+            self.assertEqual(int(number.text), 0)
+
+    @run_only_on('sat')
+    @tier2
+    def test_positive_remove_content_puppet(self):
+        """Synchronize repository and remove content from it
+
+        @id: be178e21-5d64-46d4-8a41-c3f0f62dabe0
+
+        @Assert: Content Counts shows zero puppet modules
+        """
+        with Session(self.browser) as session:
+            repo = entities.Repository(
+                url=FAKE_1_PUPPET_REPO,
+                content_type='puppet',
+                product=self.session_prod,
+            ).create()
+            self.setup_navigate_syncnow(
+                session,
+                self.session_prod.name,
+                repo.name,
+            )
+            self.assertTrue(self.prd_sync_is_ok(repo.name))
+            # Check packages number
+            self.repository.search_and_click(repo.name)
+            number = self.repository.find_element(
+                locators['repo.fetch_puppet_modules'])
+            self.assertGreaterEqual(int(number.text), 1)
+            # Remove packages
+            self.repository.remove_content(repo.name)
+            self.repository.search_and_click(repo.name)
             number = self.repository.find_element(
                 locators['repo.fetch_puppet_modules'])
             self.assertEqual(int(number.text), 0)

--- a/tests/foreman/ui/test_repository.py
+++ b/tests/foreman/ui/test_repository.py
@@ -597,12 +597,12 @@ class RepositoryTestCase(UITestCase):
     @run_only_on('sat')
     @tier2
     def test_positive_resynchronize_rpm_repo(self):
-        """Check that that repository content is resynced after packages were
+        """Check that repository content is resynced after packages were
         removed from repository
 
         @id: dc415563-c9b8-4e3c-9d2a-f4ac251c7d35
 
-        @Assert: Repository have updated non-zero package counts
+        @Assert: Repository has updated non-zero package count
 
         @CaseLevel: Integration
 
@@ -620,17 +620,13 @@ class RepositoryTestCase(UITestCase):
                 repo.name,
             )
             self.assertTrue(self.prd_sync_is_ok(repo.name))
-            # Check packages number
-            self.repository.search_and_click(repo.name)
-            number = self.repository.find_element(
-                locators['repo.fetch_packages'])
-            self.assertGreaterEqual(int(number.text), 1)
+            # Check packages count
+            count = self.repository.fetch_content_count(repo.name, 'packages')
+            self.assertGreaterEqual(count, 1)
             # Remove packages
             self.repository.remove_content(repo.name)
-            self.repository.search_and_click(repo.name)
-            number = self.repository.find_element(
-                locators['repo.fetch_packages'])
-            self.assertEqual(int(number.text), 0)
+            count = self.repository.fetch_content_count(repo.name, 'packages')
+            self.assertEqual(count, 0)
             # Sync it again
             self.setup_navigate_syncnow(
                 session,
@@ -639,20 +635,18 @@ class RepositoryTestCase(UITestCase):
             )
             self.assertTrue(self.prd_sync_is_ok(repo.name))
             # Check packages number
-            self.repository.search_and_click(repo.name)
-            number = self.repository.find_element(
-                locators['repo.fetch_packages'])
-            self.assertGreaterEqual(int(number.text), 1)
+            count = self.repository.fetch_content_count(repo.name, 'packages')
+            self.assertGreaterEqual(count, 1)
 
     @run_only_on('sat')
     @tier2
     def test_positive_resynchronize_puppet_repo(self):
-        """Check that that repository content is resynced after packages were
+        """Check that repository content is resynced after packages were
         removed from repository
 
         @id: c82dfe9d-aa1c-4922-ab3f-5d66ba8375c5
 
-        @Assert: Repository have updated non-zero package counts
+        @Assert: Repository has updated non-zero package count
 
         @CaseLevel: Integration
 
@@ -670,17 +664,14 @@ class RepositoryTestCase(UITestCase):
                 repo.name,
             )
             self.assertTrue(self.prd_sync_is_ok(repo.name))
-            # Check packages number
-            self.repository.search_and_click(repo.name)
-            number = self.repository.find_element(
-                locators['repo.fetch_puppet_modules'])
-            self.assertGreaterEqual(int(number.text), 1)
+            # Check packages count
+            count = self.repository.fetch_content_count(repo.name, 'puppet')
+            self.assertGreaterEqual(count, 1)
             # Remove packages
             self.repository.remove_content(repo.name)
             self.repository.search_and_click(repo.name)
-            number = self.repository.find_element(
-                locators['repo.fetch_puppet_modules'])
-            self.assertEqual(int(number.text), 0)
+            count = self.repository.fetch_content_count(repo.name, 'puppet')
+            self.assertEqual(count, 0)
             # Sync repo again
             self.setup_navigate_syncnow(
                 session,
@@ -688,11 +679,9 @@ class RepositoryTestCase(UITestCase):
                 repo.name,
             )
             self.assertTrue(self.prd_sync_is_ok(repo.name))
-            # Check packages number
-            self.repository.search_and_click(repo.name)
-            number = self.repository.find_element(
-                locators['repo.fetch_puppet_modules'])
-            self.assertGreaterEqual(int(number.text), 1)
+            # Check packages count
+            count = self.repository.fetch_content_count(repo.name, 'puppet')
+            self.assertGreaterEqual(count, 1)
 
     @run_only_on('sat')
     @skip_if_os('RHEL6')
@@ -1482,10 +1471,9 @@ class RepositoryTestCase(UITestCase):
             # Check alert
             self.assertIsNotNone(self.activationkey.wait_until_element(
                 common_locators['alert.success_sub_form']))
-            # Check packages number
-            number = self.repository.find_element(
-                locators['repo.fetch_packages'])
-            self.assertGreater(int(number.text), 0)
+            # Check packages count
+            count = self.repository.fetch_content_count(repo_name, 'packages')
+            self.assertGreaterEqual(count, 1)
             # Check packages list
             self.repository.click(locators['repo.manage_content'])
             packages = [
@@ -1514,10 +1502,9 @@ class RepositoryTestCase(UITestCase):
             # Check alert
             self.assertIsNotNone(self.activationkey.wait_until_element(
                 common_locators['alert.error_sub_form']))
-            # Check packages number
-            number = self.repository.find_element(
-                locators['repo.fetch_packages'])
-            self.assertEqual(int(number.text), 0)
+            # Check packages count
+            count = self.repository.fetch_content_count(repo_name, 'packages')
+            self.assertEqual(count, 0)
 
     @tier1
     def test_positive_upload_puppet(self):
@@ -1539,10 +1526,9 @@ class RepositoryTestCase(UITestCase):
             # Check alert
             self.assertIsNotNone(self.activationkey.wait_until_element(
                 common_locators['alert.success_sub_form']))
-            # Check packages number
-            number = self.repository.find_element(
-                locators['repo.fetch_puppet_modules'])
-            self.assertGreater(int(number.text), 0)
+            # Check packages count
+            count = self.repository.fetch_content_count(repo_name, 'puppet')
+            self.assertGreaterEqual(count, 1)
             # Check packages list
             self.repository.click(locators['repo.manage_content'])
             # Select all modules names from modules table
@@ -1574,9 +1560,8 @@ class RepositoryTestCase(UITestCase):
             self.assertIsNotNone(self.activationkey.wait_until_element(
                 common_locators['alert.error_sub_form']))
             # Check packages number
-            number = self.repository.find_element(
-                locators['repo.fetch_puppet_modules'])
-            self.assertEqual(int(number.text), 0)
+            count = self.repository.fetch_content_count(repo_name, 'puppet')
+            self.assertEqual(count, 0)
 
     @run_only_on('sat')
     @tier1
@@ -1599,17 +1584,15 @@ class RepositoryTestCase(UITestCase):
                 repo.name,
             )
             self.assertTrue(self.prd_sync_is_ok(repo.name))
-            # Check packages number
+            # Check packages count
             self.repository.search_and_click(repo.name)
-            number = self.repository.find_element(
-                locators['repo.fetch_packages'])
-            self.assertGreaterEqual(int(number.text), 1)
+            count = self.repository.fetch_content_count(repo.name, 'packages')
+            self.assertGreaterEqual(count, 1)
             # Remove packages
             self.repository.remove_content(repo.name)
             self.repository.search_and_click(repo.name)
-            number = self.repository.find_element(
-                locators['repo.fetch_packages'])
-            self.assertEqual(int(number.text), 0)
+            count = self.repository.fetch_content_count(repo.name, 'packages')
+            self.assertEqual(count, 0)
 
     @run_only_on('sat')
     @tier2
@@ -1632,17 +1615,14 @@ class RepositoryTestCase(UITestCase):
                 repo.name,
             )
             self.assertTrue(self.prd_sync_is_ok(repo.name))
-            # Check packages number
-            self.repository.search_and_click(repo.name)
-            number = self.repository.find_element(
-                locators['repo.fetch_puppet_modules'])
-            self.assertGreaterEqual(int(number.text), 1)
+            # Check packages count
+            count = self.repository.fetch_content_count(repo.name, 'puppet')
+            self.assertGreaterEqual(count, 1)
             # Remove packages
             self.repository.remove_content(repo.name)
             self.repository.search_and_click(repo.name)
-            number = self.repository.find_element(
-                locators['repo.fetch_puppet_modules'])
-            self.assertEqual(int(number.text), 0)
+            count = self.repository.fetch_content_count(repo.name, 'puppet')
+            self.assertEqual(count, 0)
 
 
 class GitPuppetMirrorTestCase(UITestCase):


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1318004
https://bugzilla.redhat.com/show_bug.cgi?id=1349646
https://bugzilla.redhat.com/show_bug.cgi?id=1413145

```python
% py.test -v tests/foreman/{api,cli,ui}/test_repository.py -k 'resync or remove_content' 
===================================================================== test session starts =====================================================================
platform linux2 -- Python 2.7.12, pytest-3.0.4, py-1.4.31, pluggy-0.4.0 -- /home/qui/code/venv/2/bin/python2
cachedir: .cache
rootdir: /home/qui/code/robottelo, inifile: 
plugins: xdist-1.15.0, html-1.12.0, cov-2.4.0
collected 188 items 

tests/foreman/api/test_repository.py::RepositoryTestCase::test_positive_remove_contents <- robottelo/decorators/__init__.py PASSED
tests/foreman/api/test_repository.py::RepositoryTestCase::test_positive_resynchronize_puppet_repo <- robottelo/decorators/__init__.py PASSED
tests/foreman/api/test_repository.py::RepositoryTestCase::test_positive_resynchronize_rpm_repo <- robottelo/decorators/__init__.py PASSED
tests/foreman/cli/test_repository.py::RepositoryTestCase::test_positive_remove_content_puppet <- robottelo/decorators/__init__.py PASSED
tests/foreman/cli/test_repository.py::RepositoryTestCase::test_positive_remove_content_rpm <- robottelo/decorators/__init__.py PASSED
tests/foreman/cli/test_repository.py::RepositoryTestCase::test_positive_resynchronize_puppet_repo <- robottelo/decorators/__init__.py PASSED
tests/foreman/cli/test_repository.py::RepositoryTestCase::test_positive_resynchronize_rpm_repo <- robottelo/decorators/__init__.py PASSED
tests/foreman/ui/test_repository.py::RepositoryTestCase::test_positive_remove_content_puppet <- robottelo/decorators/__init__.py PASSED
tests/foreman/ui/test_repository.py::RepositoryTestCase::test_positive_remove_content_rpm <- robottelo/decorators/__init__.py PASSED
tests/foreman/ui/test_repository.py::RepositoryTestCase::test_positive_resynchronize_puppet_repo <- robottelo/decorators/__init__.py PASSED
tests/foreman/ui/test_repository.py::RepositoryTestCase::test_positive_resynchronize_rpm_repo <- robottelo/decorators/__init__.py PASSED

==================================================================== 177 tests deselected =====================================================================
========================================================= 11 passed, 177 deselected in 669.02 seconds =========================================================
```