### PR TITLE
Added config for mention_bot to skip some people

### DIFF
--- a/.mention-bot
+++ b/.mention-bot
@@ -1,0 +1,22 @@
+{
+    "userBlacklist": [
+        "elyezer",
+        "omaciel",
+        "cswiii",
+        "Ichimonji10",
+        "AdamSaleh",
+        "tkolhar",
+        "alda519",
+        "anarang",
+        "jhutar",
+        "danuzclaudes",
+        "helgie",
+        "lhellebr",
+        "ares",
+        "eanxgeek",
+        "apagac"
+    ],
+    "createReviewRequest": true,
+    "delayed": true,
+    "delayedUntil": "5 minutes"
+}


### PR DESCRIPTION
We are going to test the use of mention bot https://github.com/facebook/mention-bot

This config file specifies people who should never be mentioned or assigned as reviewer.