### PR TITLE
ostree repo type shouldn't be checked for rhel6

### DIFF
--- a/tests/foreman/cli/test_repository.py
+++ b/tests/foreman/cli/test_repository.py
@@ -70,6 +70,7 @@ from robottelo.datafactory import (
 )
 from robottelo.decorators.host import skip_if_os
 from robottelo.helpers import get_data_file
+from robottelo.host_info import get_host_os_version
 from robottelo.test import CLITestCase
 
 
@@ -600,9 +601,17 @@ class RepositoryTestCase(CLITestCase):
 
         @Assert: Non-YUM repository is not created with a download policy
         """
-        non_yum_repo_types = [
-            item for item in REPO_TYPE.keys() if item != 'yum'
-        ]
+        os_version = get_host_os_version()
+        # ostree is not supported for rhel6 so the following check
+        if os_version.startswith('RHEL6'):
+            non_yum_repo_types = [
+                item for item in REPO_TYPE.keys()
+                if item != 'yum' and item != 'ostree'
+            ]
+        else:
+            non_yum_repo_types = [
+                 item for item in REPO_TYPE.keys() if item != 'yum'
+            ]
         for content_type in non_yum_repo_types:
             with self.subTest(content_type):
                 with self.assertRaisesRegex(

--- a/tests/foreman/ui/test_repository.py
+++ b/tests/foreman/ui/test_repository.py
@@ -60,6 +60,7 @@ from robottelo.decorators import (
 )
 from robottelo.decorators.host import skip_if_os
 from robottelo.helpers import get_data_file, read_data_file
+from robottelo.host_info import get_host_os_version
 from robottelo.test import UITestCase
 from robottelo.ui.factory import make_contentview, make_repository, set_context
 from robottelo.ui.locators import common_locators, locators, tab_locators
@@ -920,10 +921,18 @@ class RepositoryTestCase(UITestCase):
 
         @Assert: Dropdown for download policy is not displayed for non-yum repo
         """
-        non_yum_repo_types = [
-            repo_type for repo_type in REPO_TYPE.values()
-            if repo_type != 'yum'
-        ]
+        os_version = get_host_os_version()
+        # ostree is not supported for rhel6 so the following check
+        if os_version.startswith('RHEL6'):
+            non_yum_repo_types = [
+                repo_type for repo_type in REPO_TYPE.values()
+                if repo_type != 'yum' and repo_type != 'ostree'
+            ]
+        else:
+            non_yum_repo_types = [
+                repo_type for repo_type in REPO_TYPE.values()
+                if repo_type != 'yum'
+            ]
         with Session(self.browser):
             for content_type in non_yum_repo_types:
                 self.products.search_and_click(self.session_prod.name)


### PR DESCRIPTION
Test results:

rhel6:
```console
robottelo]$ py.test -v tests/foreman/ui/test_repository.py::RepositoryTestCase -k test_negative_download_policy_displayed_for_non_yum_repo
================================================================ test session starts =================================================================
platform linux2 -- Python 2.7.12, pytest-3.0.2, py-1.4.31, pluggy-0.3.1 -- /usr/bin/python
cachedir: .cache
rootdir: /home/sghai/QE/robottelo, inifile: 
collected 43 items 

tests/foreman/ui/test_repository.py::RepositoryTestCase::test_negative_download_policy_displayed_for_non_yum_repo PASSED

================================================================ 42 tests deselected =================================================================
====================================================== 1 passed, 42 deselected in 62.51 seconds ======================================================
```

```console
robottelo]$ py.test -v tests/foreman/cli/test_repository.py::RepositoryTestCase -k test_negative_create_non_yum_with_download_policy
================================================================ test session starts =================================================================
platform linux2 -- Python 2.7.12, pytest-3.0.2, py-1.4.31, pluggy-0.3.1 -- /usr/bin/python
cachedir: .cache
rootdir: /home/sghai/QE/robottelo, inifile: 
collected 42 items 

tests/foreman/cli/test_repository.py::RepositoryTestCase::test_negative_create_non_yum_with_download_policy PASSED

================================================================ 41 tests deselected =================================================================
====================================================== 1 passed, 41 deselected in 50.16 seconds =====================================================
```

rhel7:
```console
robottelo]$ py.test -v tests/foreman/cli/test_repository.py::RepositoryTestCase -k test_negative_create_non_yum_with_download_policy
================================================================ test session starts =================================================================
platform linux2 -- Python 2.7.12, pytest-3.0.2, py-1.4.31, pluggy-0.3.1 -- /usr/bin/python
cachedir: .cache
rootdir: /home/sghai/QE/robottelo, inifile: 
collected 42 items 

tests/foreman/cli/test_repository.py::RepositoryTestCase::test_negative_create_non_yum_with_download_policy PASSED

================================================================ 41 tests deselected =================================================================
====================================================== 1 passed, 41 deselected in 42.19 
seconds ======================================================
```

```console
robottelo]$ py.test -v tests/foreman/ui/test_repository.py::RepositoryTestCase -k test_negative_download_policy_displayed_for_non_yum_repo
================================================================ test session starts =================================================================
platform linux2 -- Python 2.7.12, pytest-3.0.2, py-1.4.31, pluggy-0.3.1 -- /usr/bin/python
cachedir: .cache
rootdir: /home/sghai/QE/robottelo, inifile: 
collected 43 items 

tests/foreman/ui/test_repository.py::RepositoryTestCase::test_negative_download_policy_displayed_for_non_yum_repo PASSED

================================================================ 42 tests deselected =================================================================
====================================================== 1 passed, 42 deselected in 88.16 seconds ======================================================
```