### PR TITLE
#4101-UI-Implement CV version removal

### DIFF
--- a/robottelo/constants.py
+++ b/robottelo/constants.py
@@ -514,6 +514,8 @@ FAKE_0_CUSTOM_PACKAGE_GROUP = [
     'stork-0.12-2.noarch',
 ]
 
+FAKE_0_PUPPET_MODULE = 'httpd'
+
 #: All permissions exposed by the server.
 #: :mod:`tests.foreman.api.test_permission` makes use of this.
 PERMISSIONS = {

--- a/robottelo/ui/contentviews.py
+++ b/robottelo/ui/contentviews.py
@@ -614,3 +614,45 @@ class ContentViews(Base):
         self.click(common_locators['kt_table_search_button'])
         return self.wait_until_element(
             locators['contentviews.version.package_name'] % package_name)
+
+    def puppet_module_search(self, name, version, module_name):
+        """Search for puppet module element in content view version"""
+        self.click(self.version_search(name, version))
+        self.click(tab_locators.contentviews.tab_version_puppet_modules)
+        self.assign_value(
+            common_locators.kt_table_search,
+            module_name
+        )
+        self.click(common_locators.kt_table_search_button)
+        return self.wait_until_element(
+            locators.contentviews.version.puppet_module_name % module_name)
+
+    def remove_version_from_environments(self, name, version, environments):
+        """Remove a content view version from lifecycle environments"""
+        # find and open the content view
+        self.search_and_click(name)
+        # click on the version remove button
+        self.click(locators.contentviews.remove_ver % version)
+        # ensure, that remove Completely remove version check box is unchecked
+        self.assign_value(
+            locators.contentviews.completely_remove_checkbox,
+            False
+        )
+        # get all the available lifecycle environments
+        all_environments_elements = self.find_elements(
+            locators.contentviews.delete_version_environments)
+        all_environments = [
+            env_element.text
+            for env_element in all_environments_elements
+        ]
+        # select the needed ones that are in the environments arg
+        # and unselected the ones not in environments arg
+        for environment in all_environments:
+            self.assign_value(
+                (locators.contentviews.delete_version_environment_checkbox
+                 % environment),
+                environment in environments
+            )
+        self.click(locators.contentviews.next_button)
+        self.click(locators.contentviews.confirm_remove_ver)
+        self.check_progress_bar_status(version)

--- a/robottelo/ui/locators/base.py
+++ b/robottelo/ui/locators/base.py
@@ -1550,6 +1550,15 @@ locators = LocatorDict({
         "//table[@bst-table='table']//tr/td[contains(., '%s')]/"
         "following-sibling::td/ul/li[@ng-repeat='environment in"
         " version.environments']"),
+    "contentviews.delete_version_environments": (
+        By.XPATH,
+        "//table[@bst-table='environmentsTable']//"
+        "tr[@row-select='environment']/"
+        "td/input[@ng-model='environment.selected']/../../td[2]"),
+    "contentviews.delete_version_environment_checkbox": (
+        By.XPATH,
+        "//table[@bst-table='environmentsTable']//tr/td[contains(., '%s')]/"
+        "preceding-sibling::td/input[@ng-model='environment.selected']"),
     "contentviews.success_rm_alert": (
         By.XPATH,
         ("//div[contains(@class, 'alert-success')]"
@@ -1749,6 +1758,11 @@ locators = LocatorDict({
         By.XPATH,
         ("//div[@bst-table='detailsTable']//tr[contains(@class, 'ng-scope')]"
          "/td[2][contains(., '%s')]")),
+    "contentviews.version.puppet_module_name": (
+        By.XPATH,
+        ("//table[@data-block='table']"
+         "//tr[contains(@ng-repeat, 'puppetModule in detailsTable.rows')]"
+         "/td/a[contains(., '%s')]")),
 
     # Packages
     "package.rpm_name": (By.XPATH, "//a[contains(., '%s')]"),

--- a/robottelo/ui/locators/tab.py
+++ b/robottelo/ui/locators/tab.py
@@ -182,6 +182,10 @@ tab_locators = LocatorDict({
     "contentviews.tab_version_packages": (
         By.XPATH,
         "//a[contains(@ui-sref, 'content-views.details.version.packages')]"),
+    "contentviews.tab_version_puppet_modules": (
+        By.XPATH,
+        "//a[contains(@ui-sref, "
+        "'content-views.details.version.puppet-modules')]"),
 
     # Content Hosts
     # Third level UI


### PR DESCRIPTION
```console
(2.7) dlezz@elysion:~/projects/robottelo-fork$ py.test tests/foreman/ui/test_contentview.py -k "test_positive_remove_cv_version_from_default_env or test_positive_remove_renamed_cv_version_from_default_env or test_positive_remove_promoted_cv_version_from_default_env or test_positive_remove_qe_promoted_cv_version_from_default_env or test_positive_remove_prod_promoted_cv_version_from_default_env or test_positive_remove_cv_version_from_env or test_positive_remove_cv_version_from_multi_env or test_positive_delete_cv_promoted_to_multi_env"
================================================= test session starts ==================================================
platform linux2 -- Python 2.7.12, pytest-3.0.3, py-1.4.31, pluggy-0.4.0
rootdir: /home/dlezz/projects/robottelo-fork, inifile: 
plugins: cov-2.4.0, xdist-1.15.0
collected 81 items 

tests/foreman/ui/test_contentview.py ...s.s....

================================================= 71 tests deselected ==================================================
================================ 8 passed, 2 skipped, 71 deselected in 2459.14 seconds =================================
(2.7) dlezz@elysion:~/projects/robottelo-fork$ 
```
issue: ##4101