### PR TITLE
[6.2.z] Cherry-pick - Added repository/puppet tests. (#4157)

### DIFF
--- a/tests/foreman/api/test_repository.py
+++ b/tests/foreman/api/test_repository.py
@@ -391,6 +391,30 @@ class RepositoryTestCase(APITestCase):
         repo2 = entities.Repository(name=repo1.name).create()
         self.assertEqual(repo1.name, repo2.name)
 
+    @tier2
+    def test_positive_create_puppet_repo_same_url_different_orgs(self):
+        """Create two repos with the same URL in two different organizations.
+
+        @id: 7c74c2b8-732a-4c47-8ad9-697121db05be
+
+        @Assert: Repositories are created and puppet modules are visible from
+        different organizations.
+
+        @CaseLevel: Integration
+        """
+        url = 'https://omaciel.fedorapeople.org/7c74c2b8/'
+        # Use setup product for the first repo and create new org/product
+        # for the second one
+        org = entities.Organization().create()
+        products = (self.product, entities.Product(organization=org).create())
+        # Create repositories within different organizations/products
+        for product in products:
+            repo = entities.Repository(
+                url=url, product=product, content_type='puppet').create()
+            repo.sync()
+            self.assertGreaterEqual(
+                repo.read().content_counts['puppet_module'], 1)
+
     @tier1
     @run_only_on('sat')
     def test_negative_create_name(self):

--- a/tests/foreman/cli/test_repository.py
+++ b/tests/foreman/cli/test_repository.py
@@ -517,6 +517,38 @@ class RepositoryTestCase(CLITestCase):
                 self.assertEqual(new_repo['content-type'], content_type)
                 self.assertEqual(new_repo['name'], name)
 
+    @tier2
+    def test_positive_create_puppet_repo_same_url_different_orgs(self):
+        """Create two repos with the same URL in two different organizations.
+
+        @id: b3502064-f400-4e60-a11f-b3772bd23a98
+
+        @Assert: Repositories are created and puppet modules are visible from
+        different organizations.
+
+        @CaseLevel: Integration
+        """
+        url = 'https://omaciel.fedorapeople.org/b3502064/'
+        # Create first repo
+        repo = self._make_repository({
+            u'content-type': u'puppet',
+            u'url': url,
+        })
+        Repository.synchronize({'id': repo['id']})
+        repo = Repository.info({'id': repo['id']})
+        self.assertEqual(repo['content-counts']['puppet-modules'], '1')
+        # Create another org and repo
+        org = make_org()
+        product = make_product({'organization-id': org['id']})
+        new_repo = self._make_repository({
+            u'url': url,
+            u'product': product,
+            u'content-type': u'puppet',
+        })
+        Repository.synchronize({'id': new_repo['id']})
+        new_repo = Repository.info({'id': new_repo['id']})
+        self.assertEqual(new_repo['content-counts']['puppet-modules'], '1')
+
     @tier1
     def test_negative_create_with_name(self):
         """Repository name cannot be 300-characters long

--- a/tests/foreman/ui/test_repository.py
+++ b/tests/foreman/ui/test_repository.py
@@ -183,6 +183,51 @@ class RepositoryTestCase(UITestCase):
                     )
                     self.assertIsNotNone(self.repository.search(repo_name))
 
+    @tier2
+    def test_positive_create_puppet_repo_same_url_different_orgs(self):
+        """Create two repos with the same URL in two different organizations.
+
+        @id: f4cb00ed-6faf-4c79-9f66-76cd333299cb
+
+        @Assert: Repositories are created and puppet modules are visible from
+        different organizations.
+
+        @CaseLevel: Integration
+        """
+        url = 'https://omaciel.fedorapeople.org/f4cb00ed/'
+        # Create first repository
+        repo = entities.Repository(
+            url=url,
+            product=self.session_prod,
+            content_type=REPO_TYPE['puppet'],
+        ).create()
+        repo.sync()
+        # Create second repository
+        org = entities.Organization().create()
+        product = entities.Product(organization=org).create()
+        new_repo = entities.Repository(
+            url=url,
+            product=product,
+            content_type=REPO_TYPE['puppet'],
+        ).create()
+        new_repo.sync()
+        with Session(self.browser) as session:
+            # Check packages number in first repository
+            self.products.search_and_click(self.session_prod.name)
+            self.assertIsNotNone(self.repository.search(repo.name))
+            self.repository.search_and_click(repo.name)
+            number = self.repository.find_element(
+                locators['repo.fetch_puppet_modules'])
+            self.assertEqual(int(number.text), 1)
+            # Check packages number in first repository
+            session.nav.go_to_select_org(org.name)
+            self.products.search_and_click(product.name)
+            self.assertIsNotNone(self.repository.search(new_repo.name))
+            self.repository.search_and_click(new_repo.name)
+            number = self.repository.find_element(
+                locators['repo.fetch_puppet_modules'])
+            self.assertEqual(int(number.text), 1)
+
     @run_only_on('sat')
     @tier1
     def test_positive_create_repo_with_checksum(self):


### PR DESCRIPTION
Cherry-picked from #4157. Closes #3219 
```python
]% py.test -v tests/foreman/{api,cli,ui}/test_repository.py -k 'test_positive_create_puppet_repo_same_url_different_orgs'
===================================================================== test session starts =====================================================================
platform linux2 -- Python 2.7.12, pytest-3.0.4, py-1.4.31, pluggy-0.4.0 -- /home/qui/code/venv/2/bin/python2
cachedir: .cache
rootdir: /home/qui/code/robottelo, inifile: 
plugins: xdist-1.15.0, html-1.12.0, cov-2.4.0
collected 169 items 

tests/foreman/api/test_repository.py::RepositoryTestCase::test_positive_create_puppet_repo_same_url_different_orgs PASSED
tests/foreman/cli/test_repository.py::RepositoryTestCase::test_positive_create_puppet_repo_same_url_different_orgs PASSED
tests/foreman/ui/test_repository.py::RepositoryTestCase::test_positive_create_puppet_repo_same_url_different_orgs PASSED

==================================================================== 166 tests deselected =====================================================================
========================================================= 3 passed, 166 deselected in 199.97 seconds ==========================================================
```