### PR TITLE
[6.2.z] Cherry-pick - Add stubbed decorator for stubs. (#4144)

### DIFF
--- a/tests/foreman/cli/test_repository.py
+++ b/tests/foreman/cli/test_repository.py
@@ -57,6 +57,7 @@ from robottelo.constants import (
 from robottelo.decorators import (
     run_only_on,
     skip_if_bug_open,
+    stubbed,
     tier1,
     tier2,
 )
@@ -1200,6 +1201,7 @@ class GitPuppetMirrorTestCase(CLITestCase):
     # create a sync schedule against the mirror to make sure it is periodically
     # update to contain the latest and greatest.
 
+    @stubbed()
     @tier2
     def test_positive_git_local_create(self):
         """Create repository with local git puppet mirror.
@@ -1220,6 +1222,7 @@ class GitPuppetMirrorTestCase(CLITestCase):
         @CaseAutomation: notautomated
         """
 
+    @stubbed()
     @tier2
     def test_positive_git_local_update(self):
         """Update repository with local git puppet mirror.
@@ -1240,6 +1243,7 @@ class GitPuppetMirrorTestCase(CLITestCase):
         @CaseAutomation: notautomated
         """
 
+    @stubbed()
     @tier2
     def test_positive_git_local_delete(self):
         """Delete repository with local git puppet mirror.
@@ -1260,6 +1264,7 @@ class GitPuppetMirrorTestCase(CLITestCase):
         @CaseAutomation: notautomated
         """
 
+    @stubbed()
     @tier2
     def test_positive_git_remote_create(self):
         """Create repository with remote git puppet mirror.
@@ -1280,6 +1285,7 @@ class GitPuppetMirrorTestCase(CLITestCase):
         @CaseAutomation: notautomated
         """
 
+    @stubbed()
     @tier2
     def test_positive_git_remote_update(self):
         """Update repository with remote git puppet mirror.
@@ -1300,6 +1306,7 @@ class GitPuppetMirrorTestCase(CLITestCase):
         @CaseAutomation: notautomated
         """
 
+    @stubbed()
     @tier2
     def test_positive_git_remote_delete(self):
         """Delete repository with remote git puppet mirror.
@@ -1320,6 +1327,7 @@ class GitPuppetMirrorTestCase(CLITestCase):
         @CaseAutomation: notautomated
         """
 
+    @stubbed()
     @tier2
     def test_positive_git_sync(self):
         """Sync repository with git puppet mirror.
@@ -1341,6 +1349,7 @@ class GitPuppetMirrorTestCase(CLITestCase):
         @CaseAutomation: notautomated
         """
 
+    @stubbed()
     @tier2
     def test_positive_git_sync_with_content_change(self):
         """Sync repository with changes in git puppet mirror.
@@ -1368,6 +1377,7 @@ class GitPuppetMirrorTestCase(CLITestCase):
         @CaseAutomation: notautomated
         """
 
+    @stubbed()
     @tier2
     def test_positive_git_sync_schedule(self):
         """Scheduled sync of git puppet mirror.
@@ -1387,6 +1397,7 @@ class GitPuppetMirrorTestCase(CLITestCase):
         @CaseAutomation: notautomated
         """
 
+    @stubbed()
     @tier2
     def test_positive_git_view_content(self):
         """View content in synced git puppet mirror

--- a/tests/foreman/ui/test_repository.py
+++ b/tests/foreman/ui/test_repository.py
@@ -1428,6 +1428,7 @@ class GitPuppetMirrorTestCase(UITestCase):
     # create a sync schedule against the mirror to make sure it is periodically
     # update to contain the latest and greatest.
 
+    @stubbed()
     @tier2
     def test_positive_git_local_create(self):
         """Create repository with local git puppet mirror.
@@ -1448,6 +1449,7 @@ class GitPuppetMirrorTestCase(UITestCase):
         @CaseAutomation: notautomated
         """
 
+    @stubbed()
     @tier2
     def test_positive_git_local_update(self):
         """Update repository with local git puppet mirror.
@@ -1468,6 +1470,7 @@ class GitPuppetMirrorTestCase(UITestCase):
         @CaseAutomation: notautomated
         """
 
+    @stubbed()
     @tier2
     def test_positive_git_local_delete(self):
         """Delete repository with local git puppet mirror.
@@ -1488,6 +1491,7 @@ class GitPuppetMirrorTestCase(UITestCase):
         @CaseAutomation: notautomated
         """
 
+    @stubbed()
     @tier2
     def test_positive_git_remote_create(self):
         """Create repository with remote git puppet mirror.
@@ -1508,6 +1512,7 @@ class GitPuppetMirrorTestCase(UITestCase):
         @CaseAutomation: notautomated
         """
 
+    @stubbed()
     @tier2
     def test_positive_git_remote_update(self):
         """Update repository with remote git puppet mirror.
@@ -1528,6 +1533,7 @@ class GitPuppetMirrorTestCase(UITestCase):
         @CaseAutomation: notautomated
         """
 
+    @stubbed()
     @tier2
     def test_positive_git_remote_delete(self):
         """Delete repository with remote git puppet mirror.
@@ -1548,6 +1554,7 @@ class GitPuppetMirrorTestCase(UITestCase):
         @CaseAutomation: notautomated
         """
 
+    @stubbed()
     @tier2
     def test_positive_git_sync(self):
         """Sync repository with git puppet mirror.
@@ -1569,6 +1576,7 @@ class GitPuppetMirrorTestCase(UITestCase):
         @CaseAutomation: notautomated
         """
 
+    @stubbed()
     @tier2
     def test_positive_git_sync_with_content_change(self):
         """Sync repository with changes in git puppet mirror.
@@ -1596,6 +1604,7 @@ class GitPuppetMirrorTestCase(UITestCase):
         @CaseAutomation: notautomated
         """
 
+    @stubbed()
     @tier2
     def test_positive_git_sync_schedule(self):
         """Scheduled sync of git puppet mirror.
@@ -1615,6 +1624,7 @@ class GitPuppetMirrorTestCase(UITestCase):
         @CaseAutomation: notautomated
         """
 
+    @stubbed()
     @tier2
     def test_positive_git_view_content(self):
         """View content in synced git puppet mirror


### PR DESCRIPTION
Cherrypicked from #4144 
```python
% py.test tests/foreman/{cli,ui}/test_repository.py -k 'Git'
===================================================================== test session starts =====================================================================
platform linux2 -- Python 2.7.12, pytest-3.0.4, py-1.4.31, pluggy-0.4.0
rootdir: /home/qui/code/robottelo, inifile: 
plugins: xdist-1.15.0, html-1.12.0, cov-2.4.0
collected 111 items 

tests/foreman/cli/test_repository.py ssssssssss
tests/foreman/ui/test_repository.py ssssssssss

===================================================================== 91 tests deselected =====================================================================
========================================================== 20 skipped, 91 deselected in 2.91 seconds ==========================================================
```