### PR TITLE
[DNM] fixes 4185 - excluding fe:* MAC addresses on creating libvirt host

### DIFF
--- a/robottelo/libvirt_discovery.py
+++ b/robottelo/libvirt_discovery.py
@@ -56,7 +56,16 @@ class LibvirtGuest(object):
         else:
             self.image_dir = image_dir
         if mac is None:
-            self.mac = gen_mac(multicast=False, locally=True)
+            # fe:* MAC range is considered reserved in libvirt
+            for _ in range(0, 10):
+                mac = gen_mac(multicast=False, locally=True)
+                if not mac.startswith(u'fe'):
+                    self.mac = mac
+                    break
+                mac = None
+            if not mac:
+                raise ValueError('Unable to generate a valid MAC address')
+
         else:
             self.mac = mac
         if bridge is None:


### PR DESCRIPTION
Addresses: https://github.com/SatelliteQE/robottelo/issues/4185

requires cherry-pick

this could be considered a proof of the concept (note that 'not' is being used in the actual code, so the 'fe:*' address is __not__ going to be returned)
```python
In [103]: while True:
   .....:     mac = gen_mac(multicast=False, locally=True)
   .....:     if mac.startswith(u'fe'):
   .....:         break
   .....:     

In [104]: mac
Out[104]: u'fe:05:35:d1:9b:41'

In [105]: while True:
    mac = gen_mac(multicast=False, locally=True)
    if mac.startswith(u'fe'):
        break
   .....:     

In [106]: mac
Out[106]: u'fe:4b:12:fb:7f:dc'

In [107]: while True:
    mac = gen_mac(multicast=False, locally=True)
    if mac.startswith(u'fe'):
        break
   .....:     

In [108]: mac
Out[108]: u'fe:c2:cc:6a:ab:2a'
```