### PR TITLE
Fix locator for AD usergroup functionality

### DIFF
--- a/robottelo/ui/locators/base.py
+++ b/robottelo/ui/locators/base.py
@@ -905,7 +905,7 @@ locators = LocatorDict({
         By.XPATH,
         ("//input[not(contains(@id, 'new_external_usergroups')) and "
          "contains(@name, 'name') and contains(@id, "
-         "'external_usergroups_attributes_new')]")),
+         "'external_usergroups_attributes')]")),
     "usergroups.ext_authsource_id": (
         By.XPATH,
         ("//div[contains(@id, 'auth_source_id')]/a"


### PR DESCRIPTION
Reviewed coverage for both 6.2 and 6.3. Reopened corresponding defect and provide all failing scenarios:
https://bugzilla.redhat.com/show_bug.cgi?id=1221971
```
nosetests tests/foreman/ui/test_adusergroup.py
...S...S.S.
----------------------------------------------------------------------
Ran 11 tests in 832.367s

OK (SKIP=3)
```