### PR TITLE
[6.1.z] fixes 4185 - excluding fe:* MAC addresses on creating libvirt host

### DIFF
--- a/robottelo/libvirt_discovery.py
+++ b/robottelo/libvirt_discovery.py
@@ -56,7 +56,16 @@ class LibvirtGuest(object):
         else:
             self.image_dir = image_dir
         if mac is None:
-            self.mac = gen_mac(multicast=False, locally=True)
+            # fe:* MAC range is considered reserved in libvirt
+            for _ in range(0, 10):
+                mac = gen_mac(multicast=False, locally=True)
+                if not mac.startswith(u'fe'):
+                    self.mac = mac
+                    break
+                mac = None
+            if not mac:
+                raise ValueError('Unable to generate a valid MAC address')
+
         else:
             self.mac = mac
         if bridge is None:


### PR DESCRIPTION
Connected to #4185 
cherry-pick of https://github.com/SatelliteQE/robottelo/pull/4189