### PR TITLE
Fix UI Host tests

### DIFF
--- a/robottelo/ui/hosts.py
+++ b/robottelo/ui/hosts.py
@@ -57,6 +57,14 @@ class Hosts(Base):
                 self.click(
                     common_locators['entity_select_list'] % parameter_value)
                 continue
+            elif parameter_name == 'Puppet Environment':
+                # Make sure 'inherit' button is not pressed before selecting
+                # puppet environment, as otherwise 'Puppet Environment'
+                # dropdown will be disabled
+                inherit = self.wait_until_element(
+                    locators.host.inherit_puppet_environment)
+                if 'active' in inherit.get_attribute('class'):
+                    self.click(inherit)
             self.assign_value(param_locator, parameter_value)
 
     def _configure_interface_parameters(self, parameters_list):
@@ -77,6 +85,21 @@ class Hosts(Base):
                 'host',
                 (parameter_name.lower()).replace(' ', '_')
             ))]
+            # send_keys() can't send left parenthesis (see
+            # SeleniumHQ/selenium#674), which is a part of network type name
+            # (e.g. 'Physical (Bridge)')
+            if parameter_name == 'Network type' and ' (' in parameter_value:
+                self.click(param_locator)
+                # typing network type name without parenthesis part
+                self.assign_value(
+                    common_locators['select_list_search_box'],
+                    parameter_value.split(' (')[0]
+                )
+                # selecting network type by its full name (with parenthesis
+                # part)
+                self.click(
+                    common_locators['entity_select_list'] % parameter_value)
+                continue
             self.assign_value(param_locator, parameter_value)
         self.click(locators['host.save_interface'])
 

--- a/robottelo/ui/locators/base.py
+++ b/robottelo/ui/locators/base.py
@@ -519,6 +519,10 @@ locators = LocatorDict({
         By.XPATH,
         ("//div[contains(@id, 'host_environment_id')]/a"
          "/span[contains(@class, 'arrow')]")),
+    "host.inherit_puppet_environment": (
+        By.XPATH,
+        ("//div[contains(@id, 'host_environment_id')]/following-sibling::"
+         "span/button[contains(@class, 'btn-can-disable')]")),
     "host.reset_puppet_environment": (By.ID, "reset_puppet_environment"),
     "host.content_source": (
         By.XPATH,
@@ -552,7 +556,8 @@ locators = LocatorDict({
         "/button[contains(@class, 'showModal')]"),
     "host.interface_type": (
         By.XPATH,
-        "//div[@id='interfaceModal']//select[contains(@id, '_type')]"),
+        ("//div[@id='interfaceModal']//div[contains(@id, '_type')]/a/"
+         "span[contains(@class, 'arrow')]")),
     "host.interface_mac_address": (
         By.XPATH,
         "//div[@id='interfaceModal']//input[contains(@id, '_mac')]"),
@@ -564,7 +569,8 @@ locators = LocatorDict({
         "//div[@id='interfaceModal']//input[contains(@id, '_name')]"),
     "host.interface_domain": (
         By.XPATH,
-        "//div[@id='interfaceModal']//select[contains(@id, '_domain_id')]"),
+        ("//div[@id='interfaceModal']//div[contains(@id, '_domain_id')]/a/"
+         "span[contains(@class, 'arrow')]")),
     "host.interface_subnet": (
         By.XPATH,
         "//div[@id='interfaceModal']//select[contains(@id, '_subnet_id')]"),
@@ -588,12 +594,12 @@ locators = LocatorDict({
         "//div[@id='interfaceModal']//input[contains(@id, '_virtual')]"),
     "host.interface_network_type": (
         By.XPATH,
-        ("//div[@id='interfaceModal']"
-         "//select[contains(@id, '_compute_attributes_type')]")),
+        ("//div[@id='interfaceModal']//div[contains(@id, "
+         "'_compute_attributes_type')]/a/span[contains(@class, 'arrow')]")),
     "host.interface_network": (
         By.XPATH,
-        ("//div[@id='interfaceModal']"
-         "//*[contains(@id, '_compute_attributes_bridge')]")),
+        ("//div[@id='interfaceModal']//div[contains(@id, "
+         "'_compute_attributes_bridge')]/a/span[contains(@class, 'arrow')]")),
     "host.nic_type": (
         By.XPATH,
         ("//div[@id='interfaceModal']"
@@ -664,9 +670,7 @@ locators = LocatorDict({
         ("//div[contains(@id, 'host_compute_attributes_cpus')]/a"
          "/span[contains(@class, 'arrow')]")),
     "host.memory": (
-        By.XPATH,
-        ("//div[contains(@id, 'host_compute_attributes_memory')]/a"
-         "/span[contains(@class, 'arrow')]")),
+        By.XPATH, "//input[contains(@id, 'host_compute_attributes_memory')]"),
     "host.vm_start": (By.ID, "host_compute_attributes_start"),
     "host.vm_addstorage": (
         By.XPATH, "//fieldset[@id='storage_volumes']/a"),

--- a/tests/foreman/ui/test_host.py
+++ b/tests/foreman/ui/test_host.py
@@ -36,6 +36,7 @@ from robottelo.constants import (
 )
 from robottelo.decorators import (
     run_only_on,
+    skip_if_bug_open,
     skip_if_not_set,
     stubbed,
     tier3,
@@ -175,6 +176,7 @@ class HostTestCase(UITestCase):
             cls.subnet.organization = [cls.org_]
             cls.subnet.dns = cls.proxy
             cls.subnet.dhcp = cls.proxy
+            cls.subnet.ipam = 'DHCP'
             cls.subnet.tftp = cls.proxy
             cls.subnet.discovery = cls.proxy
             cls.subnet = cls.subnet.update([
@@ -182,6 +184,7 @@ class HostTestCase(UITestCase):
                 'discovery',
                 'dhcp',
                 'dns',
+                'ipam',
                 'location',
                 'organization',
                 'tftp',
@@ -193,6 +196,7 @@ class HostTestCase(UITestCase):
                 network=network,
                 mask=settings.vlan_networking.netmask,
                 domain=[cls.domain],
+                ipam='DHCP',
                 location=[cls.loc],
                 organization=[cls.org_],
                 dns=cls.proxy,
@@ -723,6 +727,7 @@ class AtomicHostTestCase(UITestCase):
     hostname = gen_string('numeric')
 
     @classmethod
+    @skip_if_bug_open('bugzilla', 1414134)
     @skip_if_os('RHEL6')
     @skip_if_not_set('vlan_networking', 'compute_resources', 'ostree')
     def setUpClass(cls):


### PR DESCRIPTION
Summary of changes:
* Fixed outdated locators
* 'Inherit' button for puppet env in some cases may be switched on by default, making it impossible to select desired Puppet Environment. Added workaround to switch off that toggle button
* 'Network type' dropdown now contains values with left parenthesis, which can't be typed due to old selenium issue. Added workaround to select appropriate value without typing in parenthesis part
* IP address for host interface now is automatically populated only in case subnet's IPAM is set to 'DHCP'. Updated setup section to update existing subnet's IPAM or create subnet with 'DHCP' specified.
* Atomic host tests are blocked by BZ. Decorated them with `@skip_if_bug_open` decorator

Closes #4198 

Test results:
```python
py.test tests/foreman/ui/test_host.py          
============================= test session starts =============================
platform linux2 -- Python 2.7.10, pytest-3.0.3, py-1.4.31, pluggy-0.4.0
rootdir: /home/andrii/workspace/robottelo, inifile: 
plugins: xdist-1.13.1, repeat-0.2
collected 19 items 

tests/foreman/ui/test_host.py ....s..s....sssssss

=================== 10 passed, 9 skipped in 710.37 seconds ====================
```