### PR TITLE
[6.2.z] productize _gen_mac_for_libvirt()

### DIFF
--- a/robottelo/libvirt_discovery.py
+++ b/robottelo/libvirt_discovery.py
@@ -18,6 +18,17 @@ from robottelo.config import settings
 logger = logging.getLogger(__name__)
 
 
+def _gen_mac_for_libvirt():
+    # fe:* MAC range is considered reserved in libvirt
+    for _ in range(0, 10):
+        mac = gen_mac(multicast=False, locally=True)
+        if not mac.startswith(u'fe'):
+            return mac
+        mac = None
+    if not mac:
+        raise ValueError('Unable to generate a valid MAC address')
+
+
 class LibvirtGuestError(Exception):
     """Exception raised for failed virtual guests on external libvirt"""
 
@@ -56,18 +67,7 @@ class LibvirtGuest(object):
         else:
             self.image_dir = image_dir
         if mac is None:
-            # fe:* MAC range is considered reserved in libvirt
-            for _ in range(0, 10):
-                mac = gen_mac(multicast=False, locally=True)
-                if not mac.startswith(u'fe'):
-                    self.mac = mac
-                    break
-                mac = None
-            if not mac:
-                raise ValueError('Unable to generate a valid MAC address')
-
-        else:
-            self.mac = mac
+            self.mac = _gen_mac_for_libvirt()
         if bridge is None:
             self.bridge = settings.vlan_networking.bridge
         else:
@@ -123,7 +123,7 @@ class LibvirtGuest(object):
             command_args.append('--cdrom={0}'.format(boot_iso_dir))
 
         if self.extra_nic:
-            nic_mac = gen_mac(multicast=False, locally=True)
+            nic_mac = _gen_mac_for_libvirt()
             command_args.append('--network=bridge:{vm_bridge}')
             command_args.append('--mac={0}'.format(nic_mac))
 
@@ -178,7 +178,7 @@ class LibvirtGuest(object):
             raise LibvirtGuestError(
                 'The virtual guest should be created before updating it'
             )
-        nic_mac = gen_mac(multicast=False, locally=True)
+        nic_mac = _gen_mac_for_libvirt()
         command_args = [
             'virsh attach-interface',
             '--domain={vm_name}',


### PR DESCRIPTION
cherry-pick of https://github.com/SatelliteQE/robottelo/pull/4194

```
In [4]: g = LibvirtGuest(extra_nic=True)

In [5]: g.create()
2017-01-18 11:01:49 - robottelo.ssh - INFO - Instantiated Paramiko client 0x7fe8bdd6b650
2017-01-18 11:01:49 - robottelo.ssh - DEBUG - Connected to [libvirt1.satellite.com]
2017-01-18 11:01:49 - robottelo.ssh - DEBUG - >>> virt-install --hvm --network=bridge:downstream_el6 --mac=c6:d7:f1:b5:40:1f --name=macc6d7f1b5401f.satellite.com --ram=1024 --vcpus=1 --os-type=linux --os-variant=rhel7 --disk pat
2017-01-18 11:01:52 - robottelo.ssh - DEBUG - <<< stdout

Starting install...
Allocating 'macc6d7f1b5401f.satellite.c | 8.0 GB  00:00·····
Creating domain...                                          |    0 B  00:00·····
Domain installation still in progress. You can reconnect to·
the console to complete the installation process.

2017-01-18 11:01:52 - robottelo.ssh - INFO - Destroying Paramiko client 0x7fe8bdd6b650
2017-01-18 11:01:52 - robottelo.ssh - INFO - Destroyed Paramiko client 0x7fe8bdd6b650

In [6]: g.attach_nic()
2017-01-18 11:01:57 - robottelo.ssh - INFO - Instantiated Paramiko client 0x7fe8bdd6be50
2017-01-18 11:01:57 - robottelo.ssh - DEBUG - Connected to [libvirt1.satellite.com]
2017-01-18 11:01:57 - robottelo.ssh - DEBUG - >>> virsh attach-interface --domain=macc6d7f1b5401f.satellite.com --type=bridge --source=downstream_el6 --model=virtio --mac=ee:0c:95:2e:e0:5b --config
2017-01-18 11:01:58 - robottelo.ssh - DEBUG - <<< stdout
Interface attached successfully


2017-01-18 11:01:58 - robottelo.ssh - INFO - Destroying Paramiko client 0x7fe8bdd6be50
2017-01-18 11:01:58 - robottelo.ssh - INFO - Destroyed Paramiko client 0x7fe8bdd6be50
```