### PR TITLE
[6.1.z] productize _gen_mac_for_libvirt()

### DIFF
--- a/robottelo/libvirt_discovery.py
+++ b/robottelo/libvirt_discovery.py
@@ -36,8 +36,8 @@ class LibvirtGuest(object):
     """
 
     def __init__(
-            self, cpu=1, ram=1024, boot_iso=False, libvirt_server=None,
-            image_dir=None, mac=None, bridge=None):
+            self, cpu=1, ram=1024, boot_iso=False, extra_nic=False,
+            libvirt_server=None, image_dir=None, mac=None, bridge=None):
         self.cpu = cpu
         self.ram = ram
         if libvirt_server is None:
@@ -80,6 +80,7 @@ class LibvirtGuest(object):
                 'argument.'
             )
         self.boot_iso = boot_iso
+        self.extra_nic = extra_nic
         self.hostname = None
         self.ip_addr = None
         self._domain = None
@@ -120,6 +121,11 @@ class LibvirtGuest(object):
             boot_iso_dir = u'{0}/{1}'.format(
                 self.image_dir, self.boot_iso_name)
             command_args.append('--cdrom={0}'.format(boot_iso_dir))
+
+        if self.extra_nic:
+            nic_mac = gen_mac(multicast=False, locally=True)
+            command_args.append('--network=bridge:{vm_bridge}')
+            command_args.append('--mac={0}'.format(nic_mac))
 
         if self._domain is None:
             try:
@@ -172,7 +178,7 @@ class LibvirtGuest(object):
             raise LibvirtGuestError(
                 'The virtual guest should be created before updating it'
             )
-
+        nic_mac = gen_mac(multicast=False, locally=True)
         command_args = [
             'virsh attach-interface',
             '--domain={vm_name}',
@@ -185,7 +191,7 @@ class LibvirtGuest(object):
         command = u' '.join(command_args).format(
             vm_name=self.hostname,
             vm_bridge=self.bridge,
-            vm_mac=self.mac,
+            vm_mac=nic_mac,
         )
 
         result = ssh.command(command, self.libvirt_server)

--- a/robottelo/libvirt_discovery.py
+++ b/robottelo/libvirt_discovery.py
@@ -18,6 +18,17 @@ from robottelo.config import settings
 logger = logging.getLogger(__name__)
 
 
+def _gen_mac_for_libvirt():
+    # fe:* MAC range is considered reserved in libvirt
+    for _ in range(0, 10):
+        mac = gen_mac(multicast=False, locally=True)
+        if not mac.startswith(u'fe'):
+            return mac
+        mac = None
+    if not mac:
+        raise ValueError('Unable to generate a valid MAC address')
+
+
 class LibvirtGuestError(Exception):
     """Exception raised for failed virtual guests on external libvirt"""
 
@@ -56,18 +67,7 @@ class LibvirtGuest(object):
         else:
             self.image_dir = image_dir
         if mac is None:
-            # fe:* MAC range is considered reserved in libvirt
-            for _ in range(0, 10):
-                mac = gen_mac(multicast=False, locally=True)
-                if not mac.startswith(u'fe'):
-                    self.mac = mac
-                    break
-                mac = None
-            if not mac:
-                raise ValueError('Unable to generate a valid MAC address')
-
-        else:
-            self.mac = mac
+            self.mac = _gen_mac_for_libvirt()
         if bridge is None:
             self.bridge = settings.vlan_networking.bridge
         else:
@@ -123,7 +123,7 @@ class LibvirtGuest(object):
             command_args.append('--cdrom={0}'.format(boot_iso_dir))
 
         if self.extra_nic:
-            nic_mac = gen_mac(multicast=False, locally=True)
+            nic_mac = _gen_mac_for_libvirt()
             command_args.append('--network=bridge:{vm_bridge}')
             command_args.append('--mac={0}'.format(nic_mac))
 
@@ -178,7 +178,7 @@ class LibvirtGuest(object):
             raise LibvirtGuestError(
                 'The virtual guest should be created before updating it'
             )
-        nic_mac = gen_mac(multicast=False, locally=True)
+        nic_mac = _gen_mac_for_libvirt()
         command_args = [
             'virsh attach-interface',
             '--domain={vm_name}',


### PR DESCRIPTION
There are 2 separate commits in this PR:
- cherry-picked `extra_nic` feature
- cherry-pick of https://github.com/SatelliteQE/robottelo/pull/4194
```python
In [4]: g = LibvirtGuest(extra_nic=True)

In [5]: g.create()
2017-01-18 11:43:54 - robottelo.ssh - DEBUG - >>> [libvirt1.satellite.com] virt-install --hvm --network=bridge:downstream_el6 --mac=42:7f:a2:26:92:a1 --name=mac427fa22692a1.satellite.com --ram=1024 --vcpus=1 --os-type=linux --os
2017-01-18 11:43:55 - robottelo.ssh - INFO - Instantiated Paramiko client 0x7fddb6cea2d0
2017-01-18 11:43:58 - robottelo.ssh - INFO - Destroying Paramiko client 0x7fddb6cea2d0
2017-01-18 11:43:58 - robottelo.ssh - INFO - Destroyed Paramiko client 0x7fddb6cea2d0
2017-01-18 11:43:58 - robottelo.ssh - DEBUG - <<< stdout

Starting install...
Allocating 'mac427fa22692a1.satellite.c | 8.0 GB  00:00·····
Creating domain...                                          |    0 B  00:00·····
Domain installation still in progress. You can reconnect to· 
the console to complete the installation process.


In [6]: g.attach_nic()
2017-01-18 11:44:04 - robottelo.ssh - DEBUG - >>> [libvirt1.satellite.com] virsh attach-interface --domain=mac427fa22692a1.satellite.com --type=bridge --source=downstream_el6 --model=virtio --mac=36:c1:48:08:bf:9d --config
2017-01-18 11:44:05 - robottelo.ssh - INFO - Instantiated Paramiko client 0x7fddb6cfe110
2017-01-18 11:44:06 - robottelo.ssh - INFO - Destroying Paramiko client 0x7fddb6cfe110
2017-01-18 11:44:06 - robottelo.ssh - INFO - Destroyed Paramiko client 0x7fddb6cfe110
2017-01-18 11:44:06 - robottelo.ssh - DEBUG - <<< stdout
Interface attached successfully
```