### PR TITLE
Automated BZ 1379372 and host-collection list

### DIFF
--- a/tests/foreman/cli/test_host_collection.py
+++ b/tests/foreman/cli/test_host_collection.py
@@ -366,6 +366,147 @@ class HostCollectionTestCase(CLITestCase):
         self.assertEqual(new_system['name'].lower(), result[0]['name'])
 
     @tier2
+    def test_positive_list_by_name(self):
+        """Check if host collection list can be filtered by name
+
+        @id: 2d611a48-1e51-49b5-8f20-81b09f96c542
+
+        @Assert: Only host-collection with specific name is listed
+
+        @CaseLevel: Integration
+        """
+        # Create two host collections within the same org
+        host_col = self._new_host_collection()
+        self._new_host_collection()
+        # List all host collections
+        self.assertGreaterEqual(len(HostCollection.list()), 2)
+        # Filter list by name
+        result = HostCollection.list({'name': host_col['name']})
+        self.assertEqual(len(result), 1)
+        self.assertEqual(result[0]['id'], host_col['id'])
+
+    @tier2
+    def test_positive_list_by_org_id(self):
+        """Check if host collection list can be filtered by organization id
+
+        @id: afbe077a-0de1-432c-a0c4-082129aab92e
+
+        @Assert: Only host-collection within specific org is listed
+
+        @CaseLevel: Integration
+        """
+        # Create two host collections within different organizations
+        self._new_host_collection()
+        new_org = make_org()
+        host_col = self._new_host_collection(
+            {'organization-id': new_org['id']})
+        # List all host collections
+        self.assertGreaterEqual(len(HostCollection.list()), 2)
+        # Filter list by org id
+        result = HostCollection.list({'organization-id': new_org['id']})
+        self.assertEqual(len(result), 1)
+        self.assertEqual(result[0]['id'], host_col['id'])
+
+    @tier2
+    def test_positive_list_by_org_name(self):
+        """Check if host collection list can be filtered by organization name
+
+        @id: 0102094f-f5af-4067-8a07-541ba9d94f61
+
+        @Assert: Only host-collection within specific org is listed
+
+        @CaseLevel: Integration
+        """
+        # Create two host collections within different organizations
+        self._new_host_collection()
+        new_org = make_org()
+        host_col = self._new_host_collection(
+            {'organization-id': new_org['id']})
+        # List all host collections
+        self.assertGreaterEqual(len(HostCollection.list()), 2)
+        # Filter list by org id
+        result = HostCollection.list({'organization': new_org['name']})
+        self.assertEqual(len(result), 1)
+        self.assertEqual(result[0]['name'], host_col['name'])
+
+    @tier2
+    def test_positive_list_by_host_id(self):
+        """Check if host collection list can be filtered by associated host id
+
+        @id: de272461-9804-4524-83c8-23e47abfc8e3
+
+        @Assert: Only host-collection with specific host is listed
+
+        @CaseLevel: Integration
+
+        @BZ: 1379372
+        """
+        # Create two host collections within the same org but only one with
+        # associated host that will be used for filtering
+        host_col = self._new_host_collection()
+        self._new_host_collection()
+        host = self._make_fake_host_helper()
+        HostCollection.add_host({
+            'host-ids': host['id'],
+            'id': host_col['id'],
+            'organization-id': self.org['id'],
+        })
+        host_col = HostCollection.info({
+            'id': host_col['id'],
+            'organization-id': self.org['id']
+        })
+        self.assertEqual(host_col['total-hosts'], '1')
+        # List all host collections within organization
+        result = HostCollection.list({'organization-id': self.org['id']})
+        self.assertGreaterEqual(len(result), 2)
+        # Filter list by associated host name
+        result = HostCollection.list({
+            'organization-id': self.org['id'],
+            'host-id': host['id']
+        })
+        self.assertEqual(len(result), 1)
+        self.assertEqual(result[0]['id'], host_col['id'])
+
+    @tier2
+    def test_positive_list_by_host_name(self):
+        """Check if host collection list can be filtered by
+        associated host name
+
+        @id: 2a99e11f-50b8-48b4-8dce-e6ad8ff9c051
+
+        @Assert: Only host-collection with specific host is listed
+
+        @CaseLevel: Integration
+
+        @BZ: 1379372
+        """
+        # Create two host collections within the same org but only one with
+        # associated host that will be used for filtering
+        host_col = self._new_host_collection()
+        self._new_host_collection()
+        host = self._make_fake_host_helper()
+        HostCollection.add_host({
+            'hosts': host['name'],
+            'name': host_col['name'],
+            'organization': self.org['name'],
+        })
+        host_col = HostCollection.info({
+            'name': host_col['name'],
+            'organization': self.org['name']
+        })
+        self.assertEqual(host_col['total-hosts'], '1')
+        # List all host collections within organization
+        result = HostCollection.list({'organization': self.org['name']})
+        self.assertGreaterEqual(len(result), 2)
+        # Filter list by associated host name
+        result = HostCollection.list({
+            'organization': self.org['name'],
+            'host': host['name']
+        })
+        self.assertEqual(len(result), 1)
+        self.assertEqual(result[0]['name'], host_col['name'])
+
+    @tier2
     def test_positive_host_collection_host_pagination(self):
         """Check if pagination configured on per-page param defined in hammer
         host-collection hosts command overrides global configuration defined


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1379372
```python
% py.test -v -n 2 tests/foreman/cli/test_host_collection.py -k 'list_by'[bz_1379372]
===================================================================== test session starts =====================================================================
platform linux2 -- Python 2.7.12, pytest-3.0.4, py-1.4.31, pluggy-0.4.0 -- /home/qui/code/venv/2/bin/python2
cachedir: .cache
rootdir: /home/qui/code/run_robottelo, inifile: 
plugins: xdist-1.15.0, html-1.12.0, cov-2.4.0
[gw0] linux2 Python 2.7.12 cwd: /home/qui/code/run_robottelo
[gw1] linux2 Python 2.7.12 cwd: /home/qui/code/run_robottelo
[gw0] Python 2.7.12 (default, Nov  7 2016, 11:55:55)  -- [GCC 6.2.1 20160830]
[gw1] Python 2.7.12 (default, Nov  7 2016, 11:55:55)  -- [GCC 6.2.1 20160830]
gw0 [5] / gw1 [5]
scheduling tests via LoadScheduling

[gw0] PASSED tests/foreman/cli/test_host_collection.py::HostCollectionTestCase::test_positive_list_by_host_id 
[gw1] PASSED tests/foreman/cli/test_host_collection.py::HostCollectionTestCase::test_positive_list_by_host_name 
[gw0] PASSED tests/foreman/cli/test_host_collection.py::HostCollectionTestCase::test_positive_list_by_name 
[gw0] PASSED tests/foreman/cli/test_host_collection.py::HostCollectionTestCase::test_positive_list_by_org_name 
[gw1] PASSED tests/foreman/cli/test_host_collection.py::HostCollectionTestCase::test_positive_list_by_org_id 

================================================================= 5 passed in 185.63 seconds ==================================================================
```