### PR TITLE
Automated BZ 1385351

### DIFF
--- a/tests/foreman/api/test_classparameters.py
+++ b/tests/foreman/api/test_classparameters.py
@@ -133,7 +133,7 @@ class SmartClassParametersTestCase(APITestCase):
             cls.puppet_modules, CUSTOM_PUPPET_REPO, cls.org)
         cls.env = entities.Environment().search(
             query={'search': u'content_view="{0}"'.format(cv.name)}
-        )[0]
+        )[0].read()
         cls.puppet_class = entities.PuppetClass().search(query={
             'search': u'name = "{0}" and environment = "{1}"'.format(
                 cls.puppet_modules[0]['name'], cls.env.name)
@@ -174,13 +174,18 @@ class SmartClassParametersTestCase(APITestCase):
         sc_param.override = True
         sc_param.update(['override'])
         self.assertEqual(sc_param.read().override, True)
-        host = entities.Host(organization=self.org).create()
-        host.puppet_class = [self.puppet_class]
-        host.update(['puppet_class'])
-        self.assertGreater(len(host.list_scparams()), 0)
+        host = entities.Host(
+            organization=self.org,
+            environment=self.env
+        ).create()
+        host.add_puppetclass(
+            data={'puppetclass_id': self.puppet_class.id})
+        result = host.list_scparams()['results']
+        self.assertGreater(len(result), 0)
+        # Check that only unique results are returned
+        self.assertEqual(len(result), len({scp['id'] for scp in result}))
 
     @run_only_on('sat')
-    @skip_if_bug_open('bugzilla', 1374253)
     @tier2
     def test_positive_list_parameters_by_hostgroup_id(self):
         """List all the parameters included in specific HostGroup by id.
@@ -194,10 +199,13 @@ class SmartClassParametersTestCase(APITestCase):
         sc_param = self.sc_params_list.pop()
         sc_param.override = True
         sc_param.update(['override'])
-        hostgroup = entities.HostGroup().create()
+        hostgroup = entities.HostGroup(environment=self.env).create()
         hostgroup.add_puppetclass(
             data={'puppetclass_id': self.puppet_class.id})
-        self.assertGreater(len(hostgroup.list_scparams()), 0)
+        result = hostgroup.list_scparams()['results']
+        self.assertGreater(len(result), 0)
+        # Check that only unique results are returned
+        self.assertEqual(len(result), len({scp['id'] for scp in result}))
 
     @run_only_on('sat')
     @tier1
@@ -208,7 +216,37 @@ class SmartClassParametersTestCase(APITestCase):
 
         @assert: Parameters listed for specific Puppet class.
         """
-        self.assertGreater(len(self.puppet_class.list_scparams()), 0)
+        result = self.puppet_class.list_scparams()['results']
+        self.assertGreater(len(result), 0)
+        # Check that only unique results are returned
+        self.assertEqual(len(result), len({scp['id'] for scp in result}))
+
+    @run_only_on('sat')
+    @tier1
+    def test_positive_import_twice_list_parameters_by_puppetclass_id(self):
+        """Import same puppet class twice (e.g. into different Content Views)
+        but list class parameters only for specific puppet class.
+
+        @id: c20a56fd-a328-44ce-81ce-52e315c95a81
+
+        @assert: Parameters listed for specific Puppet class.
+
+        BZ: 1385351
+        """
+        cv = publish_puppet_module(
+            self.puppet_modules, CUSTOM_PUPPET_REPO, self.org)
+        env = entities.Environment().search(
+            query={'search': u'content_view="{0}"'.format(cv.name)}
+        )[0].read()
+        puppet_class = entities.PuppetClass().search(query={
+            'search': u'name = "{0}" and environment = "{1}"'.format(
+                self.puppet_modules[0]['name'], env.name)
+        })[0]
+        result = puppet_class.list_scparams(
+            data={'per_page': 1000})['results']
+        self.assertGreater(len(result), 0)
+        # Check that only unique results are returned
+        self.assertEqual(len(result), len({scp['id'] for scp in result}))
 
     @run_only_on('sat')
     @tier2
@@ -225,7 +263,10 @@ class SmartClassParametersTestCase(APITestCase):
         sc_param.override = True
         sc_param.update(['override'])
         self.assertEqual(sc_param.read().override, True)
-        self.assertGreater(len(self.env.list_scparams()), 0)
+        result = self.env.list_scparams()['results']
+        self.assertGreater(len(result), 0)
+        # Check that only unique results are returned
+        self.assertEqual(len(result), len({scp['id'] for scp in result}))
 
     @run_only_on('sat')
     @tier1

--- a/tests/foreman/cli/test_classparameters.py
+++ b/tests/foreman/cli/test_classparameters.py
@@ -192,8 +192,13 @@ class SmartClassParametersTestCase(CLITestCase):
             u'environment': self.env['name'],
             u'puppet-classes': self.puppet_class['name'],
         })
-        host_sc_params_list = Host.sc_params({u'host': host.name})
-        self.assertGreater(len(host_sc_params_list), 0)
+        host_sc_params = Host.sc_params({u'host': host.name})
+        self.assertGreater(len(host_sc_params), 0)
+        # Check that only unique results are returned
+        self.assertEqual(
+            len(host_sc_params),
+            len({scp['id'] for scp in host_sc_params})
+        )
 
     @run_only_on('sat')
     @tier2
@@ -222,8 +227,13 @@ class SmartClassParametersTestCase(CLITestCase):
             u'environment': self.env['name'],
             u'puppet-classes': self.puppet_class['name'],
         })
-        host_sc_params_list = Host.sc_params({u'host-id': host.id})
-        self.assertGreater(len(host_sc_params_list), 0)
+        host_sc_params = Host.sc_params({u'host-id': host.id})
+        self.assertGreater(len(host_sc_params), 0)
+        # Check that only unique results are returned
+        self.assertEqual(
+            len(host_sc_params),
+            len({scp['id'] for scp in host_sc_params})
+        )
 
     @run_only_on('sat')
     @tier2
@@ -253,6 +263,11 @@ class SmartClassParametersTestCase(CLITestCase):
         hostgroup_sc_params = HostGroup.sc_params({
             u'hostgroup': hostgroup['name']})
         self.assertGreater(len(hostgroup_sc_params), 0)
+        # Check that only unique results are returned
+        self.assertEqual(
+            len(hostgroup_sc_params),
+            len({scp['id'] for scp in hostgroup_sc_params})
+        )
 
     @run_only_on('sat')
     @tier2
@@ -282,6 +297,11 @@ class SmartClassParametersTestCase(CLITestCase):
         hostgroup_sc_params = HostGroup.sc_params({
             u'hostgroup-id': hostgroup['id']})
         self.assertGreater(len(hostgroup_sc_params), 0)
+        # Check that only unique results are returned
+        self.assertEqual(
+            len(hostgroup_sc_params),
+            len({scp['id'] for scp in hostgroup_sc_params})
+        )
 
     @run_only_on('sat')
     @tier1
@@ -292,11 +312,13 @@ class SmartClassParametersTestCase(CLITestCase):
 
         @assert: Parameters listed for specific Puppet class.
         """
-        sc_params_list = SmartClassParameter.list({
+        sc_params = SmartClassParameter.list({
             'environment': self.env['name'],
             'puppet-class': self.puppet_class['name']
         })
-        self.assertGreater(len(sc_params_list), 0)
+        self.assertGreater(len(sc_params), 0)
+        # Check that only unique results are returned
+        self.assertEqual(len(sc_params), len({scp['id'] for scp in sc_params}))
 
     @run_only_on('sat')
     @tier1
@@ -307,11 +329,43 @@ class SmartClassParametersTestCase(CLITestCase):
 
         @assert: Parameters listed for specific Puppet class.
         """
-        sc_params_list = SmartClassParameter.list({
+        sc_params = SmartClassParameter.list({
             'environment': self.env['name'],
             'puppet-class-id': self.puppet_class['id']
         })
-        self.assertGreater(len(sc_params_list), 0)
+        self.assertGreater(len(sc_params), 0)
+        # Check that only unique results are returned
+        self.assertEqual(len(sc_params), len({scp['id'] for scp in sc_params}))
+
+    @run_only_on('sat')
+    @tier1
+    def test_positive_import_twice_list_parameters_by_puppetclass_id(self):
+        """Import same puppet class twice (e.g. into different Content Views)
+        but list class parameters only for specific puppet class.
+
+        @id: 79a33641-54af-4e04-89ff-3b7f9a4e3ec2
+
+        @assert: Parameters listed for specific Puppet class.
+
+        BZ: 1385351
+        """
+        cv = publish_puppet_module(
+            self.puppet_modules, CUSTOM_PUPPET_REPO, self.org['id'])
+        env = Environment.list({
+            'search': u'content_view="{0}"'.format(cv['name'])
+        })[0]
+        puppet_class = Puppet.info({
+            'name': self.puppet_modules[0]['name'],
+            'environment': env['name'],
+        })
+        sc_params = SmartClassParameter.list({
+            'environment': env['name'],
+            'puppet-class-id': puppet_class['id'],
+            'per-page': 1000,
+        })
+        self.assertGreater(len(sc_params), 0)
+        # Check that only unique results are returned
+        self.assertEqual(len(sc_params), len({scp['id'] for scp in sc_params}))
 
     @run_only_on('sat')
     @tier1


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1385351
```python
% py.test tests/foreman/{api,cli}/test_classparameters.py -k 'list_parameters'            [git][robottelo/.][bz_1385351U]
===================================================================== test session starts =====================================================================
platform linux2 -- Python 2.7.12, pytest-3.0.4, py-1.4.31, pluggy-0.4.0
rootdir: /home/qui/code/robottelo, inifile: 
plugins: xdist-1.15.0, html-1.12.0, cov-2.4.0
collected 90 items 

tests/foreman/api/test_classparameters.py ....
tests/foreman/cli/test_classparameters.py ......

===================================================================== 80 tests deselected =====================================================================
========================================================= 10 passed, 80 deselected in 340.56 seconds ==========================================================
```
Also as some changes were made in setup for API, results for entire class:
```python
% py.test tests/foreman/api/test_classparameters.py                                       [git][robottelo/.][bz_1385351U]
===================================================================== test session starts =====================================================================
platform linux2 -- Python 2.7.12, pytest-3.0.4, py-1.4.31, pluggy-0.4.0
rootdir: /home/qui/code/robottelo, inifile: 
plugins: xdist-1.15.0, html-1.12.0, cov-2.4.0
collected 47 items 

tests/foreman/api/test_classparameters.py ssss..............ssssss.......................

=========================================================== 37 passed, 10 skipped in 203.88 seconds ===========================================================
```