### PR TITLE
[Cherry-pick] Fixing subscription issue from UI/CLI side (#4207)

### DIFF
--- a/robottelo/cli/subscription.py
+++ b/robottelo/cli/subscription.py
@@ -35,7 +35,7 @@ class Subscription(Base):
     def upload(cls, options=None):
         """Upload a subscription manifest."""
         cls.command_sub = 'upload'
-        timeout = 900 if bz_bug_is_open(1340229) else 300
+        timeout = 900 if bz_bug_is_open(1339696) else 300
         return cls.execute(
             cls._construct_command(options),
             ignore_stderr=True,

--- a/robottelo/ui/locators/base.py
+++ b/robottelo/ui/locators/base.py
@@ -1865,6 +1865,7 @@ locators = LocatorDict({
     # Manifests / subscriptions
     "subs.select": (
         By.XPATH, ("//tr[contains(@ng-repeat-start, 'groupedSubscriptions') "
+                   "and contains(., '%s')]/following-sibling::tr[1]/td/"
                    "a[contains(@href, '/info')]")),
     "subs.delete_manifest": (
         By.XPATH, "//button[contains(@ng-click,'deleteManifest')]"),

--- a/robottelo/ui/subscription.py
+++ b/robottelo/ui/subscription.py
@@ -38,7 +38,7 @@ class Subscriptions(Base):
             handler.write(manifest.content.read())
         browse_element.send_keys(manifest.filename)
         self.click(locators['subs.upload'])
-        timeout = 900 if bz_bug_is_open(1340229) else 300
+        timeout = 900 if bz_bug_is_open(1339696) else 300
         self.wait_until_element(locators['subs.manifest_exists'], timeout)
         os.remove(manifest.filename)
 
@@ -46,8 +46,9 @@ class Subscriptions(Base):
         """Deletes Manifest/subscriptions via UI."""
         self.click(locators['subs.manage_manifest'])
         self.click(locators['subs.delete_manifest'])
+        timeout = 900 if bz_bug_is_open(1339696) else 300
         self.wait_until_element_is_not_visible(
-            locators['subs.manifest_exists'], 300)
+            locators['subs.manifest_exists'], timeout)
 
     def refresh(self):
         """Refreshes Manifest/subscriptions via UI."""


### PR DESCRIPTION
Closes #4206
Cherry-pick of #4207 to master as it's affected too.

Test results:
```python
py.test tests/foreman/ui/test_subscription.py                
================================================ test session starts ================================================
platform linux2 -- Python 2.7.10, pytest-3.0.3, py-1.4.31, pluggy-0.4.0
rootdir: /home/andrii/workspace/robottelo, inifile: 
plugins: xdist-1.13.1, repeat-0.2
collected 1 items 

tests/foreman/ui/test_subscription.py .

============================================= 1 passed in 76.34 seconds =============================================

py.test tests/foreman/cli/test_subscription.py -k test_positive_manifest_upload
================================================ test session starts ================================================
platform linux2 -- Python 2.7.10, pytest-3.0.3, py-1.4.31, pluggy-0.4.0
rootdir: /home/andrii/workspace/robottelo, inifile: 
plugins: xdist-1.13.1, repeat-0.2
collected 6 items 

tests/foreman/cli/test_subscription.py .

================================================ 5 tests deselected =================================================
====================================== 1 passed, 5 deselected in 34.41 seconds ======================================
```