### PR TITLE
compare objects after cloning via api

### DIFF
--- a/tests/foreman/api/test_contentview.py
+++ b/tests/foreman/api/test_contentview.py
@@ -366,6 +366,30 @@ class ContentViewCreateTestCase(APITestCase):
                 )
 
     @tier1
+    def test_positive_clone(self):
+        """Create a content view by copying an existing one
+
+        @id: ee03dc63-e2b0-4a89-a828-2910405279ff
+
+        @assert: A content view is cloned with relevant parameters
+        """
+        org = entities.Organization().create()
+        content_view = entities.ContentView(organization=org).create()
+
+        cloned_cv = entities.ContentView(id=content_view.copy(
+            data={u'name': gen_string('alpha', gen_integer(3, 30))}
+        )['id']).read_json()
+
+        # remove unique values before comparison
+        cv_origin = content_view.read_json()
+        uniqe_keys = (u'label', u'id', u'name', u'updated_at', u'created_at')
+        for key in uniqe_keys:
+            del cv_origin[key]
+            del cloned_cv[key]
+
+        self.assertEqual(cv_origin, cloned_cv)
+
+    @tier1
     def test_negative_create_with_invalid_name(self):
         """Create content view providing an invalid name.
 

--- a/tests/foreman/api/test_hostgroup.py
+++ b/tests/foreman/api/test_hostgroup.py
@@ -204,7 +204,7 @@ class HostGroupTestCase(APITestCase):
 
         @id: 44ac8b3b-9cb0-4a9e-ad9b-2c67b2411922
 
-        @assert: A hostgroup is cloned with new name
+        @assert: A hostgroup is cloned with same parameters
         """
         hostgroup = entities.HostGroup(
             location=[self.loc],
@@ -214,7 +214,20 @@ class HostGroupTestCase(APITestCase):
         hostgroup_cloned = entities.HostGroup(
             id=hostgroup.id
         ).clone(data={'name': hostgroup_cloned_name})
-        self.assertEqual(hostgroup_cloned['name'], hostgroup_cloned_name)
+        hostgroup_origin = hostgroup.read_json()
+
+        # remove unset values before comparison
+        unset_keys = set(hostgroup_cloned) - set(hostgroup_origin)
+        for key in unset_keys:
+            del hostgroup_cloned[key]
+
+        # remove unique values before comparison
+        uniqe_keys = (u'updated_at', u'created_at', u'title', u'id', u'name')
+        for key in uniqe_keys:
+            del hostgroup_cloned[key]
+
+        self.assertDictContainsSubset(hostgroup_cloned, hostgroup_origin)
+        self.assertEqual(hostgroup_cloned, hostgroup_cloned)
 
     @tier2
     def test_positive_create_with_parent(self):

--- a/tests/foreman/api/test_template.py
+++ b/tests/foreman/api/test_template.py
@@ -169,13 +169,22 @@ class ConfigTemplateTestCase(APITestCase):
 
         @id: 8dfbb234-7a52-4873-be72-4de086472669
 
-        @Assert: The template is cloned successfully
+        @Assert: The template is cloned successfully with all values
 
         @CaseLevel: Integration
         """
         template = entities.ConfigTemplate().create()
+        template_origin = template.read_json()
+
+        # remove unique keys
+        uniqe_keys = (u'updated_at', u'created_at', u'id', u'name')
+        for key in uniqe_keys:
+            del template_origin[key]
+
         for name in valid_data_list():
             with self.subTest(name):
                 new_template = entities.ConfigTemplate(
-                    id=template.clone(data={u'name': name})['id']).read()
-                self.assertEqual(name, new_template.name)
+                    id=template.clone(data={u'name': name})['id']).read_json()
+                for key in uniqe_keys:
+                    del new_template[key]
+                self.assertEqual(template_origin, new_template)


### PR DESCRIPTION
related to #3984 
test results:
```
nosetests tests/foreman/api/test_contentview.py:ContentViewCreateTestCase.test_positive_clone 
.
----------------------------------------------------------------------
Ran 1 test in 7.680s
```
```
nosetests tests/foreman/api/test_hostgroup.py:HostGroupTestCase.test_positive_clone
.
----------------------------------------------------------------------
Ran 1 test in 8.493s
```
```
nosetests tests/foreman/api/test_template.py:ConfigTemplateTestCase.test_positive_clone
.
----------------------------------------------------------------------
Ran 1 test in 10.533s
```