### PR TITLE
[6.2.z]remove if bz_bug_is_open 1219610 - hammer discovery_rule

### DIFF
--- a/tests/foreman/cli/test_hammer.py
+++ b/tests/foreman/cli/test_hammer.py
@@ -18,7 +18,7 @@ import json
 
 from robottelo import ssh
 from robottelo.cli import hammer
-from robottelo.decorators import bz_bug_is_open, tier1
+from robottelo.decorators import tier1
 from robottelo.helpers import read_data_file
 from robottelo.test import CLITestCase
 from six import StringIO
@@ -96,13 +96,16 @@ class HammerCommandsTestCase(CLITestCase):
         command_subcommands = set(
             [subcommand['name'] for subcommand in output['subcommands']]
         )
-        if 'discovery_rule' in command and bz_bug_is_open(1219610):
-            # Adjust the discovery_rule subcommand name. The expected data is
-            # already with the naming convetion name
-            expected = _fetch_command_info(
-                command.replace('discovery_rule', 'discovery-rule'))
-        else:
-            expected = _fetch_command_info(command)
+        # the bug was closed with status "CLOSED WONTFIX"
+        # keep the code commented in case of a reopen
+        # if 'discovery_rule' in command and bz_bug_is_open(1219610):
+        #     # Adjust the discovery_rule subcommand name. The expected data is
+        #     # already with the naming convention name
+        #     expected = _fetch_command_info(
+        #         command.replace('discovery_rule', 'discovery-rule'))
+        # else:
+        #     expected = _fetch_command_info(command)
+        expected = _fetch_command_info(command)
         expected_options = set()
         expected_subcommands = set()
 
@@ -114,11 +117,12 @@ class HammerCommandsTestCase(CLITestCase):
                 [subcommand['name'] for subcommand in expected['subcommands']]
             )
 
-        if command == 'hammer' and bz_bug_is_open(1219610):
-            # Adjust the discovery_rule subcommand name
-            command_subcommands.discard('discovery_rule')
-            command_subcommands.add('discovery-rule')
-
+        # the bug was closed with status "CLOSED WONTFIX"
+        # keep the code commented in case of a reopen
+        # if command == 'hammer' and bz_bug_is_open(1219610):
+        #     # Adjust the discovery_rule subcommand name
+        #     command_subcommands.discard('discovery_rule')
+        #     command_subcommands.add('discovery-rule')
         added_options = tuple(command_options - expected_options)
         removed_options = tuple(expected_options - command_options)
         added_subcommands = tuple(command_subcommands - expected_subcommands)

--- a/tests/foreman/data/hammer_commands.json
+++ b/tests/foreman/data/hammer_commands.json
@@ -7188,7 +7188,8 @@
     },
     {
       "description": "Manipulate discovered rules.",
-      "name": "discovery-rule",
+      "name": "discovery_rule",
+      "__comment_name": "The names uses _ because of BZ 1219610",
       "options": [
         {
           "help": "print help",


### PR DESCRIPTION
```console
(2.7) dlezz@elysion:~/projects/robottelo-fork$ py.test tests/foreman/cli/test_hammer.py -v -k "test_positive_all_options"
================================================= test session starts ==================================================
platform linux2 -- Python 2.7.12, pytest-3.0.5, py-1.4.32, pluggy-0.4.0 -- /home/dlezz/bin/redhat/6.2.z/python/2.7/bin/python2.7
cachedir: .cache
rootdir: /home/dlezz/projects/robottelo-fork, inifile: 
plugins: xdist-1.14, cov-2.3.1
collected 1 items 

tests/foreman/cli/test_hammer.py::HammerCommandsTestCase::test_positive_all_options PASSED

============================================= 1 passed in 3661.19 seconds ==============================================
(2.7) dlezz@elysion:~/projects/robottelo-fork$ 
```
issue: https://github.com/SatelliteQE/robottelo/issues/4180 