### PR TITLE
[6.2.z] refactor test as no exception raised when manifest not loaded

### DIFF
--- a/tests/foreman/cli/test_subscription.py
+++ b/tests/foreman/cli/test_subscription.py
@@ -150,16 +150,22 @@ class SubscriptionTestCase(CLITestCase):
         """
         self._upload_manifest(
             self.org['id'], manifests.original_manifest())
-        Subscription.list(
+        subscription_list = Subscription.list(
             {'organization-id': self.org['id']},
             per_page=False,
         )
+        self.assertGreater(len(subscription_list), 0)
         Subscription.refresh_manifest({
             'organization-id': self.org['id'],
         })
+        subscription_list = Subscription.list(
+            {'organization-id': self.org['id']},
+            per_page=False,
+        )
         Subscription.delete_manifest({
             'organization-id': self.org['id'],
         })
+        self.assertGreater(len(subscription_list), 0)
 
     @skip_if_bug_open('bugzilla', 1226425)
     @tier1


### PR DESCRIPTION
```console
(2.7) dlezz@elysion:~/projects/robottelo-fork$ py.test tests/foreman/cli/test_subscription.py -v -k "test_positive_manifest_refresh"
================================================= test session starts ==================================================
platform linux2 -- Python 2.7.12, pytest-3.0.5, py-1.4.32, pluggy-0.4.0 -- /home/dlezz/bin/redhat/6.2.z/python/2.7/bin/python2.7
cachedir: .cache
rootdir: /home/dlezz/projects/robottelo-fork, inifile: 
plugins: xdist-1.14, cov-2.3.1
collected 6 items 

tests/foreman/cli/test_subscription.py::SubscriptionTestCase::test_positive_manifest_refresh PASSED

================================================== 5 tests deselected ==================================================
======================================= 1 passed, 5 deselected in 103.93 seconds =======================================
```
issue https://github.com/SatelliteQE/robottelo/issues/4214