### PR TITLE
Mention bot is buggy, going to keep only the blacklist to make it to work again.

### DIFF
--- a/.mention-bot
+++ b/.mention-bot
@@ -15,8 +15,5 @@
         "ares",
         "eanxgeek",
         "apagac"
-    ],
-    "delayed": true,
-    "delayedUntil": "5m",
-    "findPotentialReviewers": true
+    ]
 }


### PR DESCRIPTION
When we fix mention-bot in master we should cherry-pick to other branches