### PR TITLE
Related to #4213 - yum content-type corrected to puppet in puupet test

### DIFF
--- a/tests/foreman/cli/test_repository.py
+++ b/tests/foreman/cli/test_repository.py
@@ -763,7 +763,7 @@ class RepositoryTestCase(CLITestCase):
             url_encoded = url.format(creds['login'], creds['pass'])
             with self.subTest(url):
                 new_repo = self._make_repository({
-                    u'content-type': u'yum',
+                    u'content-type': u'puppet',
                     u'url': url_encoded,
                 })
                 # Assertion that repo is not yet synced


### PR DESCRIPTION
the test is blocked by a BZ for 6.3, however, we can see from stdout that it uses the correct content-type now:
```
2017-01-24 10:27:07 - robottelo.ssh - DEBUG - >>> LANG=en_US.UTF-8  hammer -v -u admin -p changeme --output=csv repository create --product-id="2" --name="kUSysVzVqXjcLtU" --publish-via-http="true" --url="http://admin:changeme@rplevka.fedorapeople.org/fakepuppet01/" --content-type="puppet"
2017-01-24 10:27:10 - robottelo.ssh - DEBUG - <<< stdout
Message,Id,Name
Repository created,10,kUSysVzVqXjcLtU

2017-01-24 10:27:11 - robottelo.ssh - DEBUG - >>> LANG=en_US.UTF-8  hammer -v -u admin -p changeme  repository info --id="10"
2017-01-24 10:27:13 - robottelo.ssh - DEBUG - <<< stdout
ID:                 10
Name:               kUSysVzVqXjcLtU
Label:              kUSysVzVqXjcLtU
Organization:       TvRSKn
Red Hat Repository: no
Content Type:       puppet
URL:                http://admin:changeme@rplevka.fedorapeople.org/fakepuppet01/
Publish Via HTTP:   yes
Published At:       http://sat6.com/pulp/puppet/TvRSKn-hHgKqmVSNvpdidqeUisl-kUSysVzVqXjcLtU/
Relative Path:      TvRSKn/Library/custom/hHgKqmVSNvpdidqeUisl/kUSysVzVqXjcLtU
Product:            
    ID:   2
    Name: LnmJNBKABE
GPG Key:            

Sync:               
    Status: Not Synced
Created:            2017/01/24 09:27:09
Updated:            2017/01/24 09:27:09
Content Counts:     
    Puppet Modules: 0
...
2017-01-24 10:15:56 - robottelo.ssh - DEBUG - >>> LANG=en_US.UTF-8  hammer -v -u admin -p changeme --output=csv repository synchronize --id="1"
2017-01-24 10:16:04 - robottelo.ssh - DEBUG - <<< stderr
Task 66e31e1e-c3a7-4a2d-9344-0bff91bee75e planned: 0.0/1, 0%, elapsed: 00:00:00
Task 66e31e1e-c3a7-4a2d-9344-0bff91bee75e running: 0.0/1, 0%, 0.0/s, elapsed: 00:00:02
Task 66e31e1e-c3a7-4a2d-9344-0bff91bee75e running: 0.0/1, 0%, 0.0/s, elapsed: 00:00:04
Task 66e31e1e-c3a7-4a2d-9344-0bff91bee75e warning: 1.0/1, 100%, 0.2/s, elapsed: 00:00:06
Task 66e31e1e-c3a7-4a2d-9344-0bff91bee75e warning: 1.0/1, 100%, 0.2/s, elapsed: 00:00:06
PLP0000: Importer indicated a failed response

```

Test passed for 6.2.7 where the BZ patch has landed:
```
$ pytest -k test_positive_synchronize_auth_puppet_repo test_repository.py
=== test session starts ===
platform linux2 -- Python 2.7.12, pytest-3.0.5, py-1.4.32, pluggy-0.4.0
rootdir: /home/rplevka/work/rplevka/robottelo, inifile: 
plugins: xdist-1.14
collected 65 items 

test_repository.py .

=== 64 tests deselected ===
=== 1 passed, 64 deselected in 232.05 seconds ===
```