### PR TITLE
Fix travis mock error and added .pyup.yml config specifing reqs file as requirements.txt

### DIFF
--- a/.pyup.yml
+++ b/.pyup.yml
@@ -1,0 +1,3 @@
+pin: False
+requirements:
+  - requirements.txt

--- a/tox.ini
+++ b/tox.ini
@@ -4,5 +4,4 @@ envlist = py27,py34
 deps=
     -rrequirements.txt
     pytest-cov
-    py27: mock
 commands=py.test --cov --cov-config=.coveragerc tests/robottelo


### PR DESCRIPTION
- pin: False = If we add a requirement without version, bot should not automatically pin it.
- requirements: Specify the bot to check only requirements.txt and never other req files.


plus: mock is already on requirements, new setuptools complains if installed again.