### PR TITLE
[6.2.z] Requirements-freeze misses pytest-cov

### DIFF
--- a/requirements-freeze.txt
+++ b/requirements-freeze.txt
@@ -19,6 +19,14 @@ unittest2==1.1.0
 python_bugzilla==1.2.2
 PyYAML==3.12
 
+# Manually added
+flake8==3.0.4
+pytest-cov==2.3.1
+tox==2.3.1
+Sphinx==1.4.5
+testimony==1.2.0
+coveralls==1.1
+
 # Install nailgun specific branch
 git+https://github.com/SatelliteQE/nailgun.git@6.2.z#egg=nailgun
 


### PR DESCRIPTION
Nit pick I found for travis-ci, pytest-cov and other testing libs is not referred in code so was not added in requirements-freeze

Currently it is inconsistent, z-branches uses only reqs file while master install explicit in travis.yaml