### PR TITLE
[6.1.z] Requirements-freeze misses pytest-cov

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,6 +13,9 @@ PYTEST_OPTS=-v --junit-xml=foreman-results.xml -m 'not stubbed'
 PYTEST_XDIST_NUMPROCESSES=auto
 PYTEST_XDIST_OPTS=$(PYTEST_OPTS) -n $(PYTEST_XDIST_NUMPROCESSES) --boxed
 ROBOTTELO_TESTS_PATH=tests/robottelo/
+TESTIMONY_TOKENS="test, feature, status, assert, bz, caseautomation, casecomponent, caseimportance, caselevel, caseposneg, id, requirement, setup, subtype1, steps, testtype, upstream"
+TESTIMONY_MINIMUM_TOKENS="test"
+TESTIMONY_OPTIONS=--tokens=$(TESTIMONY_TOKENS) --token-prefix "@" --minimum-tokens=$(TESTIMONY_MINIMUM_TOKENS)
 
 # Commands --------------------------------------------------------------------
 
@@ -51,11 +54,11 @@ docs-clean:
 	@cd docs; $(MAKE) clean
 
 test-docstrings:
-	testimony validate_docstring tests/foreman/api
-	testimony validate_docstring tests/foreman/cli
-	testimony validate_docstring tests/foreman/rhci
-	testimony validate_docstring tests/foreman/ui
-	testimony validate_docstring tests/foreman/rhai
+	testimony $(TESTIMONY_OPTIONS) validate tests/foreman/api
+	testimony $(TESTIMONY_OPTIONS) validate tests/foreman/cli
+	testimony $(TESTIMONY_OPTIONS) validate tests/foreman/rhci
+	testimony $(TESTIMONY_OPTIONS) validate tests/foreman/ui
+	testimony $(TESTIMONY_OPTIONS) validate tests/foreman/rhai
 
 test-robottelo:
 	$$(which py.test) -s  $(ROBOTTELO_TESTS_PATH)

--- a/requirements-freeze.txt
+++ b/requirements-freeze.txt
@@ -18,6 +18,13 @@ unittest2==1.1.0
 pycrypto==2.6.1
 python_bugzilla==1.2.2
 
+# Manually added
+flake8==3.0.4
+pytest-cov==2.2.1
+tox==2.3.1
+Sphinx==1.3.6
+testimony==1.2.0
+coveralls==1.1
 
 # Install robottelo itself to the path
 --editable .

--- a/robottelo/log.py
+++ b/robottelo/log.py
@@ -3,7 +3,7 @@ import os
 import re
 
 from robottelo import ssh
-from robottelo.config.settings import get_project_root
+from robottelo.config.base import get_project_root
 
 LOGS_DATA_DIR = os.path.join(get_project_root(), 'data', 'logs')
 


### PR DESCRIPTION
Nit pick I found for travis-ci, pytest-cov is not referred in code so was not added in requirements-freeze

plus:
-  Fix issue with wrong import path on robottelo.config
-  Fix testimony docstring (@elyezer ++ )

