### PR TITLE
[6.2.z] add run_in_one_thread and minor refactoring to allow proxy cleanup ven after a test failure

### DIFF
--- a/tests/foreman/api/test_smartproxy.py
+++ b/tests/foreman/api/test_smartproxy.py
@@ -23,6 +23,7 @@ from robottelo.cleanup import capsule_cleanup
 from robottelo.config import settings
 from robottelo.datafactory import valid_data_list
 from robottelo.decorators import (
+    run_in_one_thread,
     run_only_on,
     skip_if_bug_open,
     skip_if_not_set,
@@ -36,8 +37,16 @@ from robottelo.helpers import (
 from robottelo.test import APITestCase
 
 
+@run_in_one_thread
 class CapsuleTestCase(APITestCase):
     """Tests for Smart Proxy (Capsule) entity."""
+
+    def _create_smart_proxy(self, **kwargs):
+        """Create a Smart Proxy and register the cleanup function"""
+        proxy = entities.SmartProxy(**kwargs).create()
+        # Add proxy id to cleanup list
+        self.addCleanup(capsule_cleanup, proxy.id)
+        return proxy
 
     @skip_if_not_set('fake_capsules')
     @run_only_on('sat')
@@ -69,10 +78,8 @@ class CapsuleTestCase(APITestCase):
             with self.subTest(name):
                 new_port = get_available_capsule_port()
                 with default_url_on_new_port(9090, new_port) as url:
-                    proxy = entities.SmartProxy(name=name, url=url).create()
+                    proxy = self._create_smart_proxy(name=name, url=url)
                     self.assertEquals(proxy.name, name)
-                # Add capsule id to cleanup list
-                self.addCleanup(capsule_cleanup, proxy.id)
 
     @skip_if_not_set('fake_capsules')
     @run_only_on('sat')
@@ -104,14 +111,12 @@ class CapsuleTestCase(APITestCase):
         """
         new_port = get_available_capsule_port()
         with default_url_on_new_port(9090, new_port) as url:
-            proxy = entities.SmartProxy(url=url).create()
+            proxy = self._create_smart_proxy(url=url)
             for new_name in valid_data_list():
                 with self.subTest(new_name):
                     proxy.name = new_name
                     proxy = proxy.update(['name'])
                     self.assertEqual(proxy.name, new_name)
-        # Add capsule id to cleanup list
-        self.addCleanup(capsule_cleanup, proxy.id)
 
     @skip_if_not_set('fake_capsules')
     @run_only_on('sat')
@@ -126,15 +131,13 @@ class CapsuleTestCase(APITestCase):
         # Create fake capsule
         port = get_available_capsule_port()
         with default_url_on_new_port(9090, port) as url:
-            proxy = entities.SmartProxy(url=url).create()
+            proxy = self._create_smart_proxy(url=url)
         # Open another tunnel to update url
         new_port = get_available_capsule_port()
         with default_url_on_new_port(9090, new_port) as url:
             proxy.url = url
             proxy = proxy.update(['url'])
             self.assertEqual(proxy.url, url)
-        # Add capsule id to cleanup list
-        self.addCleanup(capsule_cleanup, proxy.id)
 
     @skip_if_not_set('fake_capsules')
     @run_only_on('sat')
@@ -150,15 +153,13 @@ class CapsuleTestCase(APITestCase):
             entities.Organization().create() for _ in range(2)]
         newport = get_available_capsule_port()
         with default_url_on_new_port(9090, newport) as url:
-            proxy = entities.SmartProxy(url=url).create()
+            proxy = self._create_smart_proxy(url=url)
             proxy.organization = organizations
             proxy = proxy.update(['organization'])
             self.assertEqual(
                 {org.id for org in proxy.organization},
                 {org.id for org in organizations}
             )
-        # Add capsule id to cleanup list
-        self.addCleanup(capsule_cleanup, proxy.id)
 
     @skip_if_not_set('fake_capsules')
     @run_only_on('sat')
@@ -173,15 +174,13 @@ class CapsuleTestCase(APITestCase):
         locations = [entities.Location().create() for _ in range(2)]
         new_port = get_available_capsule_port()
         with default_url_on_new_port(9090, new_port) as url:
-            proxy = entities.SmartProxy(url=url).create()
+            proxy = self._create_smart_proxy(url=url)
             proxy.location = locations
             proxy = proxy.update(['location'])
             self.assertEqual(
                 {loc.id for loc in proxy.location},
                 {loc.id for loc in locations}
             )
-        # Add capsule id to cleanup list
-        self.addCleanup(capsule_cleanup, proxy.id)
 
     @skip_if_not_set('fake_capsules')
     @run_only_on('sat')
@@ -202,10 +201,8 @@ class CapsuleTestCase(APITestCase):
         # get an available port for our fake capsule
         new_port = get_available_capsule_port()
         with default_url_on_new_port(9090, new_port) as url:
-            proxy = entities.SmartProxy(url=url).create()
+            proxy = self._create_smart_proxy(url=url)
             proxy.refresh()
-        # Add capsule id to cleanup list
-        self.addCleanup(capsule_cleanup, proxy.id)
 
     @skip_if_not_set('fake_capsules')
     @run_only_on('sat')
@@ -219,15 +216,13 @@ class CapsuleTestCase(APITestCase):
         """
         new_port = get_available_capsule_port()
         with default_url_on_new_port(9090, new_port) as url:
-            proxy = entities.SmartProxy(url=url).create()
+            proxy = self._create_smart_proxy(url=url)
             result = proxy.import_puppetclasses()
             self.assertEqual(
                 result['message'],
                 "Successfully updated environment and puppetclasses from "
                 "the on-disk puppet installation"
             )
-        # Add capsule id to cleanup list
-        self.addCleanup(capsule_cleanup, proxy.id)
 
 
 class SmartProxyMissingAttrTestCase(APITestCase):


### PR DESCRIPTION
When the tests are running alone in different processes, randomly some of the tests may fail 1 time of 6  attempt (log example of a success test pass http://pastebin.test.redhat.com/449135).
But if the tests are launched in parallel with other tests, randomly some of the tests may fail see the log http://pastebin.test.redhat.com/449131) 

The main reason of this:
in function: https://github.com/SatelliteQE/robottelo/blob/6.2.z/robottelo/helpers.py#L373 
under system load  ncat open the port (the url is yielded to test) and than the port is closed.

Sequential log test: 
```console
(2.7) dlezz@elysion:~/projects/robottelo-fork$ py.test tests/foreman/api/test_smartproxy.py -v -k "CapsuleTestCase"================================================= test session starts ==================================================
platform linux2 -- Python 2.7.12, pytest-3.0.5, py-1.4.32, pluggy-0.4.0 -- /home/dlezz/bin/redhat/6.2.z/python/2.7/bin/python2.7
cachedir: .cache
rootdir: /home/dlezz/projects/robottelo-fork, inifile: 
plugins: xdist-1.14, cov-2.3.1
collected 11 items 

tests/foreman/api/test_smartproxy.py::CapsuleTestCase::test_negative_create_with_url <- robottelo/decorators/__init__.py PASSED
tests/foreman/api/test_smartproxy.py::CapsuleTestCase::test_positive_create_with_name <- robottelo/decorators/__init__.py PASSED
tests/foreman/api/test_smartproxy.py::CapsuleTestCase::test_positive_delete <- robottelo/decorators/__init__.py SKIPPED
tests/foreman/api/test_smartproxy.py::CapsuleTestCase::test_positive_import_puppet_classes <- robottelo/decorators/__init__.py PASSED
tests/foreman/api/test_smartproxy.py::CapsuleTestCase::test_positive_refresh_features <- robottelo/decorators/__init__.py PASSED
tests/foreman/api/test_smartproxy.py::CapsuleTestCase::test_positive_update_location <- robottelo/decorators/__init__.py PASSED
tests/foreman/api/test_smartproxy.py::CapsuleTestCase::test_positive_update_name <- robottelo/decorators/__init__.py PASSED
tests/foreman/api/test_smartproxy.py::CapsuleTestCase::test_positive_update_organization <- robottelo/decorators/__init__.py PASSED
tests/foreman/api/test_smartproxy.py::CapsuleTestCase::test_positive_update_url <- robottelo/decorators/__init__.py PASSED

================================================== 2 tests deselected ==================================================
================================= 8 passed, 1 skipped, 2 deselected in 245.57 seconds ==================================
(2.7) dlezz@elysion:~/projects/robottelo-fork$ 
```
related tests that may be affected:
but here there is only 3 tests in tier1 and they always succeed:
https://github.com/SatelliteQE/robottelo/blob/6.2.z/tests/foreman/cli/test_capsule.py#L41
but any way need a refactoring of the cleanup