### PR TITLE
Decorated UI bookmark tests with run_in_one_thread decorator

### DIFF
--- a/tests/foreman/ui/test_bookmark.py
+++ b/tests/foreman/ui/test_bookmark.py
@@ -22,6 +22,7 @@ from nailgun import entities
 from robottelo.constants import BOOKMARK_ENTITIES, STRING_TYPES
 from robottelo.decorators import (
     bz_bug_is_open,
+    run_in_one_thread,
     skip_if_bug_open,
     tier1,
     tier2,
@@ -32,6 +33,7 @@ from robottelo.ui.locators import common_locators, locators
 from robottelo.ui.session import Session
 
 
+@run_in_one_thread
 class BookmarkTestCase(UITestCase):
     """Test for common Bookmark operations in UI"""
 


### PR DESCRIPTION
There's no searchbar on bookmarks page and in order to find specific bookmark the only thing we can do is set `items_per_page` to some huge value before tests execution and revert the value afterwards. The problem here is the fact that with multithreading each thread is playing with global `items_per_page` separately and as soon as one of threads finished execution it reverts value back to 20. That leads to failures as some other thread which is still executing the test suddenly can see only first 20 bookmarks from the list.

Made some investigation and couldn't find any better solution rather than mark the tests as sequential ones. `items_per_page` is a global variable which should not be accessed by multiple threads at the same time.
There's no way to fix the issue on unittests side - with parallel execution all of its methods like setUp/setUpClass/setUpModule are duplicated for each thread.
No way to fix it on py.test side too - found multiple open issues in their repo where people ask to add the ability to execute some actions in 1 thread before executing tests simultaneously and there's no resolution as for now.

So the only way to deal with issue in timely manner i can see is to mark the tests as sequential ones. Bookmark tests are pretty fast as they do not use manifests/hosts provisioning etc, so we shouldn't affect performance much. And imo it's worth it to wait for another minute or two but receive correct results instead of 1-2 mins faster but with 3-5 random failures.
And btw, current UI bookmark search implementation contains check whether RFE BZ for searchbar is closed, so we don't even need to introduce some kind of `if bz_bug_is_open` checks for `@run_in_one_thread` decorator as we will know for sure when the searchbar is finally there.

Part of #4211 