### PR TITLE
Tell pyup bot to ignore selenium version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -11,7 +11,7 @@ paramiko==2.1.1
 pygal==2.3.1
 pytest==3.0.6
 requests==2.13.0
-selenium==2.48.0
+selenium==2.48.0  # pyup: ignore
 six==1.10.0
 unittest2==1.1.0
 python_bugzilla==1.2.2


### PR DESCRIPTION
as explained by @oshtaier and @abalakh in #4241
we cannot upgrade selenium yet, so lets make pyup bot to ignore that lib.