### PR TITLE
[6.2.z] decorate docker bugs for internal  interface

### DIFF
--- a/tests/foreman/api/test_docker.py
+++ b/tests/foreman/api/test_docker.py
@@ -28,6 +28,7 @@ from robottelo.datafactory import (
     valid_data_list,
 )
 from robottelo.decorators import (
+    bz_bug_is_open,
     run_in_one_thread,
     run_only_on,
     skip_if_bug_open,
@@ -36,6 +37,7 @@ from robottelo.decorators import (
     tier2,
 )
 from robottelo.helpers import install_katello_ca, remove_katello_ca
+from robottelo.host_info import get_host_os_version
 from robottelo.test import APITestCase
 
 DOCKER_PROVIDER = 'Docker'
@@ -1370,7 +1372,12 @@ class DockerContainerTestCase(APITestCase):
         @Assert: The docker containers are deleted in local and external
         compute resources
         """
-        for compute_resource in (self.cr_internal, self.cr_external):
+        cr_interfaces = [self.cr_external, self.cr_internal]
+        # there is some bugs affecting docker internal interface on RHEL7
+        if get_host_os_version().startswith('RHEL7'):
+            if bz_bug_is_open(1366573) or bz_bug_is_open(1414797):
+                cr_interfaces.pop()
+        for compute_resource in cr_interfaces:
             with self.subTest(compute_resource.url):
                 container = entities.DockerHubContainer(
                     command='top',


### PR DESCRIPTION
for RHEL6
```console
(2.7) dlezz@elysion:~/projects/robottelo-fork$ py.test -v tests/foreman/api/test_docker.py::DockerContainerTestCase::test_positive_delete
================================================= test session starts ==================================================
platform linux2 -- Python 2.7.12, pytest-2.9.2, py-1.4.32, pluggy-0.3.1 -- /home/dlezz/bin/redhat/6.2.z/python/2.7/bin/python2.7
cachedir: .cache
rootdir: /home/dlezz/projects/robottelo-fork, inifile: 
plugins: xdist-1.14, cov-2.3.1
collected 7 items 

tests/foreman/api/test_docker.py::DockerContainerTestCase::test_positive_delete <- robottelo/decorators/__init__.py PASSED

============================================== 1 passed in 50.99 seconds ===============================================
```
for RHEL7
```console
(2.7) dlezz@elysion:~/projects/robottelo-fork$ py.test -v tests/foreman/api/test_docker.py::DockerContainerTestCase::test_positive_delete
================================================= test session starts ==================================================
platform linux2 -- Python 2.7.12, pytest-2.9.2, py-1.4.32, pluggy-0.3.1 -- /home/dlezz/bin/redhat/6.2.z/python/2.7/bin/python2.7
cachedir: .cache
rootdir: /home/dlezz/projects/robottelo-fork, inifile: 
plugins: xdist-1.14, cov-2.3.1
collected 7 items 

tests/foreman/api/test_docker.py::DockerContainerTestCase::test_positive_delete <- robottelo/decorators/__init__.py PASSED

============================================== 1 passed in 64.60 seconds ===============================================
```
https://bugzilla.redhat.com/show_bug.cgi?id=1366573
https://bugzilla.redhat.com/show_bug.cgi?id=1414797
decorate only for tier1 test to allow the external interface on rh7 to be basically tested
