### PR TITLE
fixes #4213 - yum content-type corrected to puppet in puppet test

### DIFF
--- a/tests/foreman/cli/test_repository.py
+++ b/tests/foreman/cli/test_repository.py
@@ -757,7 +757,7 @@ class RepositoryTestCase(CLITestCase):
             url_encoded = url.format(creds['login'], creds['pass'])
             with self.subTest(url):
                 new_repo = self._make_repository({
-                    u'content-type': u'yum',
+                    u'content-type': u'puppet',
                     u'url': url_encoded,
                 })
                 # Assertion that repo is not yet synced


### PR DESCRIPTION
cherry-pick of https://github.com/SatelliteQE/robottelo/pull/4222
fixes #4213 

```bash
$ pytest -k test_positive_synchronize_auth_puppet_repo test_repository.py
=== test session starts ===
platform linux2 -- Python 2.7.12, pytest-3.0.5, py-1.4.32, pluggy-0.4.0
rootdir: /home/rplevka/work/rplevka/robottelo, inifile: 
plugins: xdist-1.14
collected 65 items 

test_repository.py .

=== 64 tests deselected ===
=== 1 passed, 64 deselected in 232.05 seconds ===
```