### PR TITLE
[6.2.z] #4162 UI - Add Exception handling when None element passed to selenium browser.execute_script

### DIFF
--- a/robottelo/ui/base.py
+++ b/robottelo/ui/base.py
@@ -686,6 +686,12 @@ class Base(object):
         if self.element_type(target) == 'select':
             if isinstance(target, tuple):
                 element = self.wait_until_element(target)
+                if element is None:
+                    # restore the Timeout exception
+                    raise TimeoutException(
+                        u'{0}: Timeout waiting for element {1} to display.'
+                        .format(type(self).__name__, target)
+                    )
             else:
                 element = target
             if scroll:

--- a/robottelo/ui/navigator.py
+++ b/robottelo/ui/navigator.py
@@ -1,7 +1,7 @@
 # -*- encoding: utf-8 -*-
 """Implements Navigator UI."""
 from robottelo.decorators import bz_bug_is_open
-from robottelo.ui.base import Base, UIError
+from robottelo.ui.base import Base, TimeoutException, UIError
 from robottelo.ui.locators import menu_locators
 
 
@@ -17,6 +17,12 @@ class Navigator(Base):
             self.perform_action_chain_move(sub_menu_locator)
             tertiary_element = self.wait_until_element(
                 tertiary_menu_locator)
+            if tertiary_element is None:
+                # restore the Timeout exception
+                raise TimeoutException(
+                    u'{0}: Timeout waiting for element {1} to display.'
+                    .format(type(self).__name__, tertiary_menu_locator)
+                )
             self.browser.execute_script(
                 "arguments[0].click();",
                 tertiary_element,


### PR DESCRIPTION
wait_until_element return a None element if TimeoutException occur.
The purpose of this PR is a step to resolve some missing checking on the selenium element, that is passed directly to execute_script and that prevent us from sending a None element to execute_script in two cases here:
 - menu_click , that via self.scroll_into_view(element) execute: self.browser.execute_script( 'arguments[0].scrollIntoView(false);', element)
- select execute: self.browser.execute_script("arguments[0].click();", "arguments[0].click();", tertiary_element, tertiary_element)

```console
(2.7) dlezz@elysion:~/projects/robottelo-fork$ py.test -v tests/foreman/ui/test_contentview.py -k "test_positive_delete"
================================================= test session starts ==================================================
platform linux2 -- Python 2.7.12, pytest-2.9.2, py-1.4.32, pluggy-0.3.1 -- /home/dlezz/bin/redhat/6.2.z/python/2.7/bin/python2.7
cachedir: .cache
rootdir: /home/dlezz/projects/robottelo-fork, inifile: 
plugins: xdist-1.14, cov-2.3.1
collected 69 items 

tests/foreman/ui/test_contentview.py::ContentViewTestCase::test_positive_delete <- robottelo/decorators/__init__.py PASSED
tests/foreman/ui/test_contentview.py::ContentViewTestCase::test_positive_delete_default_version <- robottelo/decorators/__init__.py PASSED
tests/foreman/ui/test_contentview.py::ContentViewTestCase::test_positive_delete_non_default_version <- robottelo/decorators/__init__.py PASSED
tests/foreman/ui/test_contentview.py::ContentViewTestCase::test_positive_delete_version_with_ak <- robottelo/decorators/__init__.py PASSED

=================================== 65 tests deselected by '-ktest_positive_delete' ====================================
====================================== 4 passed, 65 deselected in 584.66 seconds =======================================
```
issue https://github.com/SatelliteQE/robottelo/issues/4162
The actual error in tests looks like: http://pastebin.test.redhat.com/450301 