### PR TITLE
Numpy should not be a requirement Fix #4247

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,6 +1,7 @@
 [run]
 omit =
     robottelo/commands/*.py
+    robottelo/performance/*.py
 include =
     robottelo/*.py
     robottelo/api

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,6 @@ cryptography==1.7.2
 fauxfactory==2.0.9
 Inflector==2.0.11
 mock==2.0.0
-numpy==1.12.0
 paramiko==2.1.1
 pygal==2.3.1
 pytest==3.0.6

--- a/robottelo/performance/stat.py
+++ b/robottelo/performance/stat.py
@@ -1,6 +1,10 @@
 """Test utilities for writing csv files"""
 import csv
-import numpy
+
+try:
+    import numpy
+except ImportError:
+    numpy = None
 
 
 def generate_stat_for_concurrent_thread(
@@ -11,6 +15,14 @@ def generate_stat_for_concurrent_thread(
         num_buckets):
     """statistics computing utility for Candlepin tests"""
     # check empty case: empty bucket has no need to compute stat
+
+    if numpy is None:
+        # numpy was removed from requirements to save build time
+        raise RuntimeError(
+            "Dependency `numpy` is not installed!"
+            " run `pip install numpy` in CI script"
+        )
+
     if bucket_size == 0:
         return
     else:


### PR DESCRIPTION
Closes #4247 

We do not need `numpy` as requirements unless someday we run performance tests, which in that case can be added in the CI script not on requirements.