### PR TITLE
[6.2.z] default_url_on_new_port() updated - wait some time for a return code …

### DIFF
--- a/robottelo/cli/factory.py
+++ b/robottelo/cli/factory.py
@@ -623,7 +623,7 @@ def make_proxy(options=None):
     if options is None or 'url' not in options:
         newport = get_available_capsule_port()
         try:
-            with default_url_on_new_port(9090, newport) as url:
+            with default_url_on_new_port(9090, newport) as (url, _):
                 args['url'] = url
                 return create_object(Proxy, args, options)
         except CapsuleTunnelError as err:

--- a/tests/foreman/api/test_smartproxy.py
+++ b/tests/foreman/api/test_smartproxy.py
@@ -77,7 +77,7 @@ class CapsuleTestCase(APITestCase):
         for name in valid_data_list():
             with self.subTest(name):
                 new_port = get_available_capsule_port()
-                with default_url_on_new_port(9090, new_port) as url:
+                with default_url_on_new_port(9090, new_port) as (url, _):
                     proxy = self._create_smart_proxy(name=name, url=url)
                     self.assertEquals(proxy.name, name)
 
@@ -93,7 +93,7 @@ class CapsuleTestCase(APITestCase):
         @Assert: Proxy is deleted
         """
         new_port = get_available_capsule_port()
-        with default_url_on_new_port(9090, new_port) as url:
+        with default_url_on_new_port(9090, new_port) as (url, _):
             proxy = entities.SmartProxy(url=url).create()
             proxy.delete()
         with self.assertRaises(HTTPError):
@@ -110,7 +110,7 @@ class CapsuleTestCase(APITestCase):
         @Assert: Proxy has the name updated
         """
         new_port = get_available_capsule_port()
-        with default_url_on_new_port(9090, new_port) as url:
+        with default_url_on_new_port(9090, new_port) as (url, _):
             proxy = self._create_smart_proxy(url=url)
             for new_name in valid_data_list():
                 with self.subTest(new_name):
@@ -130,11 +130,11 @@ class CapsuleTestCase(APITestCase):
         """
         # Create fake capsule
         port = get_available_capsule_port()
-        with default_url_on_new_port(9090, port) as url:
+        with default_url_on_new_port(9090, port) as (url, _):
             proxy = self._create_smart_proxy(url=url)
         # Open another tunnel to update url
         new_port = get_available_capsule_port()
-        with default_url_on_new_port(9090, new_port) as url:
+        with default_url_on_new_port(9090, new_port) as (url, _):
             proxy.url = url
             proxy = proxy.update(['url'])
             self.assertEqual(proxy.url, url)
@@ -152,7 +152,7 @@ class CapsuleTestCase(APITestCase):
         organizations = [
             entities.Organization().create() for _ in range(2)]
         newport = get_available_capsule_port()
-        with default_url_on_new_port(9090, newport) as url:
+        with default_url_on_new_port(9090, newport) as (url, _):
             proxy = self._create_smart_proxy(url=url)
             proxy.organization = organizations
             proxy = proxy.update(['organization'])
@@ -173,7 +173,7 @@ class CapsuleTestCase(APITestCase):
         """
         locations = [entities.Location().create() for _ in range(2)]
         new_port = get_available_capsule_port()
-        with default_url_on_new_port(9090, new_port) as url:
+        with default_url_on_new_port(9090, new_port) as (url, _):
             proxy = self._create_smart_proxy(url=url)
             proxy.location = locations
             proxy = proxy.update(['location'])
@@ -200,7 +200,7 @@ class CapsuleTestCase(APITestCase):
 
         # get an available port for our fake capsule
         new_port = get_available_capsule_port()
-        with default_url_on_new_port(9090, new_port) as url:
+        with default_url_on_new_port(9090, new_port) as (url, _):
             proxy = self._create_smart_proxy(url=url)
             proxy.refresh()
 
@@ -215,7 +215,7 @@ class CapsuleTestCase(APITestCase):
         @Assert: Puppet classes are imported from proxy
         """
         new_port = get_available_capsule_port()
-        with default_url_on_new_port(9090, new_port) as url:
+        with default_url_on_new_port(9090, new_port) as (url, _):
             proxy = self._create_smart_proxy(url=url)
             result = proxy.import_puppetclasses()
             self.assertEqual(

--- a/tests/foreman/cli/test_capsule.py
+++ b/tests/foreman/cli/test_capsule.py
@@ -34,7 +34,6 @@ from robottelo.helpers import (
     default_url_on_new_port,
     get_available_capsule_port
 )
-from robottelo.config import settings
 from robottelo.test import CLITestCase
 
 
@@ -108,7 +107,7 @@ class CapsuleTestCase(CLITestCase):
         for new_name in valid_data_list():
             with self.subTest(new_name):
                 newport = get_available_capsule_port()
-                with default_url_on_new_port(9090, newport) as url:
+                with default_url_on_new_port(9090, newport) as (url, _):
                     Proxy.update({
                         u'id': proxy['id'],
                         u'name': new_name,
@@ -137,8 +136,7 @@ class CapsuleTestCase(CLITestCase):
 
         # get an available port for our fake capsule
         port = get_available_capsule_port()
-        with default_url_on_new_port(9090, port):
-            url = u'https://{0}:{1}'.format(settings.server.hostname, port)
+        with default_url_on_new_port(9090, port) as (url, _):
             proxy = make_proxy({u'url': url})
             Proxy.refresh_features({u'id': proxy['id']})
         # Add capsule id to cleanup list
@@ -162,8 +160,7 @@ class CapsuleTestCase(CLITestCase):
 
         # get an available port for our fake capsule
         port = get_available_capsule_port()
-        with default_url_on_new_port(9090, port):
-            url = u'https://{0}:{1}'.format(settings.server.hostname, port)
+        with default_url_on_new_port(9090, port) as (url, _):
             proxy = make_proxy({u'url': url})
             Proxy.refresh_features({u'id': proxy['name']})
         # Add capsule id to cleanup list


### PR DESCRIPTION
- default_url_on_new_port() updated - wait some time for a return code to appear
- default_url_on_new_port() updated - now returns the channel object to give some control to user

Here's the example of trying to open a tunnel on an already used port (invoking the error):
forward the port on a host manually (assure it will be used):
```
[root@bkr-hv01-guest02 ~]# ncat -kl -p 12456 -c "ncat bkr-hv01-guest02.com 9090"
```
use our function to try to open up the tunnel on the same port:
```
In [9]: with default_url_on_new_port(9090, 12456) as con:
    sleep(5)
   ...:     
2017-01-31 15:03:17 - robottelo.ssh - INFO - Instantiated Paramiko client 0x7f42a55f4510
2017-01-31 15:03:17 - robottelo.ssh - DEBUG - Connected to [bkr-hv01-guest02.com]
2017-01-31 15:03:17 - robottelo - DEBUG - Creating tunnel: ncat -kl -p 12456 -c "ncat bkr-hv01.com 9090"
2017-01-31 15:03:18 - robottelo - DEBUG - exit status ready: 2
2017-01-31 15:03:18 - robottelo - DEBUG - Tunnel failed: Ncat: bind to 0.0.0.0:12456: Address already in use. QUITTING.

2017-01-31 15:03:18 - robottelo.ssh - INFO - Destroying Paramiko client 0x7f42a55f4510
2017-01-31 15:03:18 - robottelo.ssh - INFO - Destroyed Paramiko client 0x7f42a55f4510
---------------------------------------------------------------------------
CapsuleTunnelError                        Traceback (most recent call last)
<ipython-input-9-f08bdaedc27d> in <module>()
----> 1 with default_url_on_new_port(9090, 12456) as con:
      2     sleep(5)
      3     print(con.is_active())
      4 

/usr/lib64/python2.7/contextlib.pyc in __enter__(self)
     15     def __enter__(self):
     16         try:
---> 17             return self.gen.next()
     18         except StopIteration:
     19             raise RuntimeError("generator didn't yield")

/home/rplevka/work/rplevka/robottelo/robottelo/helpers.py in default_url_on_new_port(oldport, newport)
    377                     logger.debug('Tunnel failed: {0}'.format(stderr))
    378                     # Something failed, so raise an exception.
--> 379                     raise CapsuleTunnelError(stderr)
    380                 break
    381             else:

CapsuleTunnelError: Ncat: bind to 0.0.0.0:12456: Address already in use. QUITTING.
```
before,  this commit, no timeout has been implemented so we didn't wait for any possible error to be returned (the `execute_command` is async).

also, the function now yields the `Channel` object itself, giving us some control over it during the test.
e.g. we might want to send some test data to it in order to find out, whether it's still opened:

```
In [11]: with default_url_on_new_port(9090, 12457) as con:
    sleep(5)
    con.send('ping')
   ....:     
2017-01-31 15:12:14 - robottelo.ssh - INFO - Instantiated Paramiko client 0x7f42a55f4790
2017-01-31 15:12:14 - robottelo.ssh - DEBUG - Connected to [bkr-hv01-guest02.com]
2017-01-31 15:12:14 - robottelo - DEBUG - Creating tunnel: ncat -kl -p 12457 -c "ncat bkr-hv01-guest02.com 9090"
2017-01-31 15:12:24 - robottelo - DEBUG - Tunnel created for 12457
2017-01-31 15:12:29 - robottelo.ssh - INFO - Destroying Paramiko client 0x7f42a55f4790
2017-01-31 15:12:29 - robottelo.ssh - INFO - Destroyed Paramiko client 0x7f42a55f4790
```
this comes handy in case the `ncat` process on the server gets killed for whatever reason. Before, we lost info and control over the process. now, we get an Exception, e.g.:

```
In [12]: with default_url_on_new_port(9090, 12457) as con:
    sleep(5)
    con.send('ping')
   ....:     
2017-01-31 15:15:33 - robottelo.ssh - INFO - Instantiated Paramiko client 0x7f42a56008d0
2017-01-31 15:15:33 - robottelo.ssh - DEBUG - Connected to [bkr-hv01-guest02.com]
2017-01-31 15:15:33 - robottelo - DEBUG - Creating tunnel: ncat -kl -p 12457 -c "ncat bkr-hv01-guest02.com 9090"
2017-01-31 15:15:43 - robottelo - DEBUG - Tunnel created for 12457
```
...i have 5 seconds from this point to go to the host and kill the `ncat` process i've just created...
```
[root@bkr-hv01-guest02 ~]# ps aux | grep ncat
root     14932  1.0  0.0  37432  1008 pts/4    Ss+  09:15   0:00 ncat -kl -p 12457 -c ncat bkr-hv01-guest02.com 9090
root     14944  0.0  0.0 103320   852 pts/3    S+   09:15   0:00 grep ncat
[root@bkr-hv01-guest02 ~]# kill 14932
[root@bkr-hv01-guest02 ~]#
```
..aand back to the python shell after the 5-second sleep expires:
```
2017-01-31 15:15:48 - robottelo.ssh - INFO - Destroying Paramiko client 0x7f42a56008d0
2017-01-31 15:15:48 - robottelo.ssh - INFO - Destroyed Paramiko client 0x7f42a56008d0
---------------------------------------------------------------------------
error                                     Traceback (most recent call last)
<ipython-input-12-9f12c169b32f> in <module>()
      1 with default_url_on_new_port(9090, 12457) as con:
      2     sleep(5)
----> 3     con.send('ping')
      4 

/usr/lib/python2.7/site-packages/paramiko/channel.pyc in send(self, s)
    765         m.add_byte(cMSG_CHANNEL_DATA)
    766         m.add_int(self.remote_chanid)
--> 767         return self._send(s, m)
    768 
    769     def send_stderr(self, s):

/usr/lib/python2.7/site-packages/paramiko/channel.pyc in _send(self, s, m)
   1131             if self.closed:
   1132                 # this doesn't seem useful, but it is the documented behavior of Socket
-> 1133                 raise socket.error('Socket is closed')
   1134             size = self._wait_for_send_window(size)
   1135             if size == 0:

error: Socket is closed
```
so, by catching the `socket.error` we can exit the test wit a proper error message even before passing such non-functional port to `make_proxy` and failing it there.