### PR TITLE
Update UI/repository/test_upload to include BZ 1154384

### DIFF
--- a/tests/foreman/ui/test_repository.py
+++ b/tests/foreman/ui/test_repository.py
@@ -1459,6 +1459,8 @@ class RepositoryTestCase(UITestCase):
         @id: 201d5742-cb1a-4534-ac02-91b5a4669d22
 
         @Assert: Upload is successful and package is listed
+
+        @BZ: 1394390, 1154384
         """
         repo_name = gen_string('alpha')
         with Session(self.browser) as session:
@@ -1468,9 +1470,11 @@ class RepositoryTestCase(UITestCase):
             self.assertIsNotNone(self.repository.search(repo_name))
             self.repository.upload_content(
                 repo_name, get_data_file(RPM_TO_UPLOAD))
-            # Check alert
-            self.assertIsNotNone(self.activationkey.wait_until_element(
-                common_locators['alert.success_sub_form']))
+            # Check alert, its message should contain file name
+            alert = self.activationkey.wait_until_element(
+                common_locators['alert.success_sub_form'])
+            self.assertIsNotNone(alert)
+            self.assertIn(RPM_TO_UPLOAD, alert.text)
             # Check packages count
             count = self.repository.fetch_content_count(repo_name, 'packages')
             self.assertGreaterEqual(count, 1)
@@ -1513,6 +1517,8 @@ class RepositoryTestCase(UITestCase):
         @id: 2da4ddeb-3d6a-4b77-b44a-190a0c20a4f6
 
         @Assert: Upload is successful and module is listed
+
+        @BZ: 1154384
         """
         repo_name = gen_string('alpha')
         with Session(self.browser) as session:
@@ -1523,9 +1529,11 @@ class RepositoryTestCase(UITestCase):
             self.assertIsNotNone(self.repository.search(repo_name))
             self.repository.upload_content(
                 repo_name, get_data_file(PUPPET_MODULE_NTP_PUPPETLABS))
-            # Check alert
-            self.assertIsNotNone(self.activationkey.wait_until_element(
-                common_locators['alert.success_sub_form']))
+            # Check alert, its message should contain file name
+            alert = self.activationkey.wait_until_element(
+                common_locators['alert.success_sub_form'])
+            self.assertIsNotNone(alert)
+            self.assertIn(PUPPET_MODULE_NTP_PUPPETLABS, alert.text)
             # Check packages count
             count = self.repository.fetch_content_count(repo_name, 'puppet')
             self.assertGreaterEqual(count, 1)


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1154384

```python
% pytest -v tests/foreman/ui/test_repository.py -k 'positive_upload'
===================================================================== test session starts =====================================================================
platform linux2 -- Python 2.7.12, pytest-3.0.4, py-1.4.31, pluggy-0.4.0 -- /home/qui/code/venv/2/bin/python2
cachedir: .cache
rootdir: /home/qui/code/robottelo, inifile: 
plugins: xdist-1.15.0, html-1.12.0, cov-2.4.0
collected 58 items 

tests/foreman/ui/test_repository.py::RepositoryTestCase::test_positive_upload_puppet PASSED
tests/foreman/ui/test_repository.py::RepositoryTestCase::test_positive_upload_rpm <- robottelo/decorators/__init__.py SKIPPED

===================================================================== 56 tests deselected =====================================================================
==================================================== 1 passed, 1 skipped, 56 deselected in 112.98 seconds =====================================================
```