### PR TITLE
[6.2.z] [cherry-pick] ui contentview version removal + conflict resolution

### DIFF
--- a/robottelo/constants.py
+++ b/robottelo/constants.py
@@ -385,6 +385,8 @@ FAKE_0_CUSTOM_PACKAGE_GROUP = [
     'stork-0.12-2.noarch',
 ]
 
+FAKE_0_PUPPET_MODULE = 'httpd'
+
 #: All permissions exposed by the server.
 #: :mod:`tests.foreman.api.test_permission` makes use of this.
 PERMISSIONS = {

--- a/robottelo/constants.py
+++ b/robottelo/constants.py
@@ -327,6 +327,7 @@ FILTER_ERRATA_DATE = {
 }
 
 DOCKER_REGISTRY_HUB = u'https://registry-1.docker.io'
+DOCKER_UPSTREAM_NAME = u'busybox'
 CUSTOM_RPM_REPO = (
     u'http://repos.fedorapeople.org/repos/pulp/pulp/fixtures/rpm/'
 )

--- a/robottelo/ui/contentviews.py
+++ b/robottelo/ui/contentviews.py
@@ -723,3 +723,45 @@ class ContentViews(Base):
         self.click(common_locators['kt_table_search_button'])
         strategy, value = locators['contentviews.version.package_name']
         return self.wait_until_element((strategy, value % package_name))
+
+    def puppet_module_search(self, name, version, module_name):
+        """Search for puppet module element in content view version"""
+        self.click(self.version_search(name, version))
+        self.click(tab_locators['contentviews.tab_version_puppet_modules'])
+        self.assign_value(
+            common_locators['kt_table_search'],
+            module_name
+        )
+        self.click(common_locators.kt_table_search_button)
+        strategy, value = locators['contentviews.version.puppet_module_name']
+        return self.wait_until_element( strategy, value % module_name)
+
+    def remove_version_from_environments(self, name, version, environments):
+        """Remove a content view version from lifecycle environments"""
+        # find and open the content view
+        self.search_and_click(name)
+        # click on the version remove button
+        self.click(locators.contentviews.remove_ver % version)
+        # ensure, that remove Completely remove version check box is unchecked
+        self.assign_value(
+            locators.contentviews.completely_remove_checkbox,
+            False
+        )
+        # get all the available lifecycle environments
+        all_environments_elements = self.find_elements(
+            locators.contentviews.delete_version_environments)
+        all_environments = [
+            env_element.text
+            for env_element in all_environments_elements
+        ]
+        # select the needed ones that are in the environments arg
+        # and unselected the ones not in environments arg
+        for environment in all_environments:
+            self.assign_value(
+                (locators.contentviews.delete_version_environment_checkbox
+                 % environment),
+                environment in environments
+            )
+        self.click(locators.contentviews.next_button)
+        self.click(locators.contentviews.confirm_remove_ver)
+        self.check_progress_bar_status(version)

--- a/robottelo/ui/contentviews.py
+++ b/robottelo/ui/contentviews.py
@@ -732,24 +732,25 @@ class ContentViews(Base):
             common_locators['kt_table_search'],
             module_name
         )
-        self.click(common_locators.kt_table_search_button)
+        self.click(common_locators['kt_table_search_button'])
         strategy, value = locators['contentviews.version.puppet_module_name']
-        return self.wait_until_element( strategy, value % module_name)
+        return self.wait_until_element((strategy, value % module_name))
 
     def remove_version_from_environments(self, name, version, environments):
         """Remove a content view version from lifecycle environments"""
         # find and open the content view
         self.search_and_click(name)
         # click on the version remove button
-        self.click(locators.contentviews.remove_ver % version)
+        strategy, value = locators['contentviews.remove_ver']
+        self.click((strategy, value % version))
         # ensure, that remove Completely remove version check box is unchecked
         self.assign_value(
-            locators.contentviews.completely_remove_checkbox,
+            locators['contentviews.completely_remove_checkbox'],
             False
         )
         # get all the available lifecycle environments
         all_environments_elements = self.find_elements(
-            locators.contentviews.delete_version_environments)
+            locators['contentviews.delete_version_environments'])
         all_environments = [
             env_element.text
             for env_element in all_environments_elements
@@ -757,11 +758,12 @@ class ContentViews(Base):
         # select the needed ones that are in the environments arg
         # and unselected the ones not in environments arg
         for environment in all_environments:
+            strategy, value = locators[
+                'contentviews.delete_version_environment_checkbox']
             self.assign_value(
-                (locators.contentviews.delete_version_environment_checkbox
-                 % environment),
+                (strategy, value % environment),
                 environment in environments
             )
-        self.click(locators.contentviews.next_button)
-        self.click(locators.contentviews.confirm_remove_ver)
+        self.click(locators['contentviews.next_button'])
+        self.click(locators['contentviews.confirm_remove_ver'])
         self.check_progress_bar_status(version)

--- a/robottelo/ui/locators.py
+++ b/robottelo/ui/locators.py
@@ -566,6 +566,11 @@ tab_locators = LocatorDict({
         By.XPATH,
         "//a[contains(@ui-sref, 'content-views.details.version.packages')]"),
 
+    "contentviews.tab_version_puppet_modules": (
+        By.XPATH,
+        "//a[contains(@ui-sref, "
+        "'content-views.details.version.puppet-modules')]"),
+
     # Content Hosts
     # Third level UI
     "contenthost.tab_details": (

--- a/robottelo/ui/locators.py
+++ b/robottelo/ui/locators.py
@@ -2291,6 +2291,15 @@ locators = LocatorDict({
         "//table[@bst-table='table']//tr/td[contains(., '%s')]/"
         "following-sibling::td/ul/li[@ng-repeat='environment in"
         " version.environments']"),
+    "contentviews.delete_version_environments": (
+        By.XPATH,
+        "//table[@bst-table='environmentsTable']//"
+        "tr[@row-select='environment']/"
+        "td/input[@ng-model='environment.selected']/../../td[2]"),
+    "contentviews.delete_version_environment_checkbox": (
+        By.XPATH,
+        "//table[@bst-table='environmentsTable']//tr/td[contains(., '%s')]/"
+        "preceding-sibling::td/input[@ng-model='environment.selected']"),
     "contentviews.success_rm_alert": (
         By.XPATH,
         ("//div[contains(@class, 'alert-success')]"
@@ -2489,6 +2498,11 @@ locators = LocatorDict({
         By.XPATH,
         ("//div[@bst-table='detailsTable']//tr[contains(@class, 'ng-scope')]"
          "/td[2][contains(., '%s')]")),
+    "contentviews.version.puppet_module_name": (
+        By.XPATH,
+        ("//table[@data-block='table']"
+         "//tr[contains(@ng-repeat, 'puppetModule in detailsTable.rows')]"
+         "/td/a[contains(., '%s')]")),
 
     # Packages
     "package.rpm_name": (By.XPATH, "//a[contains(., '%s')]"),

--- a/tests/foreman/ui/test_contentview.py
+++ b/tests/foreman/ui/test_contentview.py
@@ -25,8 +25,11 @@ from robottelo.api.utils import enable_rhrepo_and_fetchid, upload_manifest
 from robottelo import manifests
 from robottelo.constants import (
     DEFAULT_CV,
+    DOCKER_REGISTRY_HUB,
+    DOCKER_UPSTREAM_NAME,
     ENVIRONMENT,
     FAKE_0_PUPPET_REPO,
+    FAKE_0_PUPPET_MODULE,
     FAKE_0_YUM_REPO,
     FAKE_1_PUPPET_REPO,
     FAKE_1_YUM_REPO,
@@ -70,7 +73,8 @@ class ContentViewTestCase(UITestCase):
 
     # pylint: disable=too-many-arguments
     def setup_to_create_cv(self, repo_name=None, repo_url=None, repo_type=None,
-                           rh_repo=None, org_id=None):
+                           rh_repo=None, org_id=None,
+                           docker_upstream_name=None):
         """Create product/repo and sync it"""
 
         if not rh_repo:
@@ -86,6 +90,7 @@ class ContentViewTestCase(UITestCase):
                 url=(repo_url or FAKE_1_YUM_REPO),
                 content_type=(repo_type or REPO_TYPE['yum']),
                 product=product,
+                docker_upstream_name=docker_upstream_name,
             ).create().id
         elif rh_repo:
             # Uploads the manifest and returns the result.
@@ -2616,7 +2621,6 @@ class ContentViewTestCase(UITestCase):
         @CaseLevel: Integration
         """
 
-    @stubbed()
     @run_only_on('sat')
     @tier2
     def test_positive_remove_cv_version_from_default_env(self):
@@ -2636,12 +2640,40 @@ class ContentViewTestCase(UITestCase):
 
         @Assert: content view version is removed from Library environment
 
-        @caseautomation: notautomated
-
         @CaseLevel: Integration
         """
+        cv_name = gen_string('alpha')
+        repo_name = gen_string('alpha')
+        # create a new organization
+        org = entities.Organization().create()
+        with Session(self.browser) as session:
+            # create a yum repository
+            self.setup_to_create_cv(
+                repo_name=repo_name,
+                repo_url=FAKE_0_YUM_REPO,
+                org_id=org.id
+            )
+            # create a content view
+            make_contentview(
+                session, org=org.name, name=cv_name)
+            self.assertIsNotNone(self.content_views.search(cv_name))
+            # add the repository to the created content view
+            self.content_views.add_remove_repos(cv_name, [repo_name])
+            self.assertIsNotNone(self.content_views.wait_until_element(
+                common_locators['alert.success_sub_form']))
+            # publish the content view
+            version = self.content_views.publish(cv_name)
+            self.assertIsNotNone(
+                self.content_views.wait_until_element(
+                    common_locators['alert.success_sub_form'])
+            )
+            self.assertEqual(
+                self._get_cv_version_environments(version), [ENVIRONMENT])
+            # remove the content view version from Library environment
+            self.content_views.remove_version_from_environments(
+                cv_name, version, [ENVIRONMENT])
+            self.assertEqual(self._get_cv_version_environments(version), [])
 
-    @stubbed()
     @run_only_on('sat')
     @tier2
     def test_positive_remove_renamed_cv_version_from_default_env(self):
@@ -2663,12 +2695,49 @@ class ContentViewTestCase(UITestCase):
 
         @Assert: content view version is removed from Library environment
 
-        @caseautomation: notautomated
-
         @CaseLevel: Integration
         """
+        cv_name = gen_string('alpha')
+        new_cv_name = gen_string('alpha')
+        repo_name = gen_string('alpha')
+        # create a new organization
+        org = entities.Organization().create()
+        with Session(self.browser) as session:
+            # create a yum repository
+            self.setup_to_create_cv(
+                repo_name=repo_name,
+                repo_url=FAKE_0_YUM_REPO,
+                org_id=org.id
+            )
+            # create a content view
+            make_contentview(
+                session, org=org.name, name=cv_name)
+            self.assertIsNotNone(self.content_views.search(cv_name))
+            # add the repository to the created content view
+            self.content_views.add_remove_repos(cv_name, [repo_name])
+            self.assertIsNotNone(self.content_views.wait_until_element(
+                common_locators['alert.success_sub_form']))
+            # publish the content view
+            version = self.content_views.publish(cv_name)
+            self.assertIsNotNone(
+                self.content_views.wait_until_element(
+                    common_locators['alert.success_sub_form'])
+            )
+            # rename the content view
+            self.content_views.update(cv_name, new_cv_name)
+            self.assertIsNone(self.content_views.search(cv_name))
+            # ensure the cv exits with the new name
+            cv_element = self.content_views.search(new_cv_name)
+            self.assertIsNotNone(cv_element)
+            # open the content view
+            self.content_views.click(cv_element)
+            self.assertEqual(
+                self._get_cv_version_environments(version), [ENVIRONMENT])
+            # remove the content view version from Library environment
+            self.content_views.remove_version_from_environments(
+                new_cv_name, version, [ENVIRONMENT])
+            self.assertEqual(self._get_cv_version_environments(version), [])
 
-    @stubbed()
     @run_only_on('sat')
     @tier2
     def test_positive_remove_promoted_cv_version_from_default_env(self):
@@ -2694,12 +2763,68 @@ class ContentViewTestCase(UITestCase):
 
         2. The puppet module(s) exists in content view version
 
-        @caseautomation: notautomated
-
         @CaseLevel: Integration
         """
+        cv_name = gen_string('alpha')
+        env_dev_name = gen_string('alpha')
+        puppet_repo_url = FAKE_0_PUPPET_REPO
+        puppet_module_name = FAKE_0_PUPPET_MODULE
+        # create a new organization
+        org = entities.Organization().create()
+        with Session(self.browser) as session:
+            # create the DEV lifecycle environment
+            make_lifecycle_environment(
+                session, org=org.name, name=env_dev_name)
+            # create a puppet repository
+            self.setup_to_create_cv(
+                repo_url=puppet_repo_url,
+                repo_type=REPO_TYPE['puppet'],
+                org_id=org.id
+            )
+            # create a content view
+            make_contentview(
+                session, org=org.name, name=cv_name)
+            self.assertIsNotNone(self.content_views.search(cv_name))
+            # add the puppet module to the created content view
+            self.content_views.add_puppet_module(
+                cv_name,
+                puppet_module_name,
+                filter_term='Latest',
+            )
+            self.assertIsNotNone(
+                self.content_views.fetch_puppet_module(
+                    cv_name, puppet_module_name)
+            )
+            # publish the content view
+            version = self.content_views.publish(cv_name)
+            self.assertIsNotNone(
+                self.content_views.wait_until_element(
+                    common_locators['alert.success_sub_form'])
+            )
+            # promote the content view to DEV lifecycle environment
+            self.content_views.promote(cv_name, version, env_dev_name)
+            self.assertEqual(
+                set(self._get_cv_version_environments(version)),
+                {ENVIRONMENT, env_dev_name}
+            )
+            # ensure that puppet module is in content view version
+            self.assertIsNotNone(
+                self.content_views.puppet_module_search(cv_name, version,
+                                                        puppet_module_name)
+            )
+            # remove the content view version from Library environment
+            self.content_views.remove_version_from_environments(
+                cv_name, version, [ENVIRONMENT])
+            self.assertEqual(
+                set(self._get_cv_version_environments(version)),
+                {env_dev_name}
+            )
+            # ensure that puppet module still in content view version
+            self.assertIsNotNone(
+                self.content_views.puppet_module_search(cv_name, version,
+                                                        puppet_module_name)
+            )
 
-    @stubbed()
     @run_only_on('sat')
     @tier2
     def test_positive_remove_qe_promoted_cv_version_from_default_env(self):
@@ -2723,12 +2848,61 @@ class ContentViewTestCase(UITestCase):
         @Assert: Content view version exist only in DEV, QE
                  and not in Library
 
-        @caseautomation: notautomated
-
         @CaseLevel: Integration
         """
+        cv_name = gen_string('alpha')
+        env_dev_name = gen_string('alpha')
+        env_qe_name = gen_string('alpha')
+        docker_repo_name = gen_string('alpha')
+        docker_repo_url = DOCKER_REGISTRY_HUB
+        docker_upstream_name = DOCKER_UPSTREAM_NAME
+        # create a new organization
+        org = entities.Organization().create()
+        with Session(self.browser) as session:
+            # create the DEV, QE lifecycle environments
+            env_prior = None
+            for env_name in [env_dev_name, env_qe_name]:
+                make_lifecycle_environment(
+                    session, org=org.name, name=env_name, prior=env_prior)
+                env_prior = env_name
+            # create a docker repository
+            self.setup_to_create_cv(
+                repo_name=docker_repo_name,
+                repo_url=docker_repo_url,
+                repo_type=REPO_TYPE['docker'],
+                org_id=org.id,
+                docker_upstream_name=docker_upstream_name
+            )
+            # create a content view
+            make_contentview(
+                session, org=org.name, name=cv_name)
+            self.assertIsNotNone(self.content_views.search(cv_name))
+            # add the docker repo to the created content view
+            self.content_views.add_remove_repos(
+                cv_name, [docker_repo_name], repo_type='docker')
+            self.assertIsNotNone(self.content_views.wait_until_element(
+                common_locators['alert.success_sub_form']))
+            # publish the content view
+            version = self.content_views.publish(cv_name)
+            self.assertIsNotNone(
+                self.content_views.wait_until_element(
+                    common_locators['alert.success_sub_form'])
+            )
+            # promote the content view to DEV, QE lifecycle environments
+            for env_name in [env_dev_name, env_qe_name]:
+                self.content_views.promote(cv_name, version, env_name)
+            self.assertEqual(
+                set(self._get_cv_version_environments(version)),
+                {ENVIRONMENT, env_dev_name, env_qe_name}
+            )
+            # remove the content view version from Library environment
+            self.content_views.remove_version_from_environments(
+                cv_name, version, [ENVIRONMENT])
+            self.assertEqual(
+                set(self._get_cv_version_environments(version)),
+                {env_dev_name, env_qe_name}
+            )
 
-    @stubbed()
     @run_only_on('sat')
     @tier2
     def test_positive_remove_prod_promoted_cv_version_from_default_env(self):
@@ -2752,12 +2926,92 @@ class ContentViewTestCase(UITestCase):
         @Assert: Content view version exist only in DEV, QE, PROD
                  and not in Library
 
-        @caseautomation: notautomated
-
         @CaseLevel: Integration
         """
+        cv_name = gen_string('alpha')
+        # create env names [DEV, QE, PROD]
+        env_names = [gen_string('alpha') for _ in range(3)]
+        all_env_names_set = set(env_names)
+        all_env_names_set.add(ENVIRONMENT)
+        puppet_repo_url = FAKE_0_PUPPET_REPO
+        puppet_module_name = FAKE_0_PUPPET_MODULE
+        repos = [
+            dict(
+                repo_name=gen_string('alpha'),
+                repo_url=FAKE_0_YUM_REPO,
+                repo_type=REPO_TYPE['yum'],
+            ),
+            dict(
+                repo_name=gen_string('alpha'),
+                repo_url=DOCKER_REGISTRY_HUB,
+                repo_type=REPO_TYPE['docker'],
+                docker_upstream_name=DOCKER_UPSTREAM_NAME
+            ),
+            dict(
+                repo_name=gen_string('alpha'),
+                repo_url=puppet_repo_url,
+                repo_type=REPO_TYPE['puppet'],
+            ),
+        ]
+        # create a new organization
+        org = entities.Organization().create()
+        with Session(self.browser) as session:
+            # create the DEV, QE, PROD lifecycle environments
+            env_prior = None
+            for env_name in env_names:
+                make_lifecycle_environment(
+                    session, org=org.name, name=env_name, prior=env_prior)
+                env_prior = env_name
+            # create the repositories
+            for repo in repos:
+                self.setup_to_create_cv(
+                    org_id=org.id,
+                    **repo
+                )
+            # create a content view
+            make_contentview(
+                session, org=org.name, name=cv_name)
+            self.assertIsNotNone(self.content_views.search(cv_name))
+            # add the repos to content view
+            for repo in repos:
+                repo_name = repo['repo_name']
+                repo_type = repo['repo_type']
+                if repo_type == 'puppet':
+                    self.content_views.add_puppet_module(
+                        cv_name,
+                        puppet_module_name,
+                        filter_term='Latest',
+                    )
+                    self.assertIsNotNone(
+                        self.content_views.fetch_puppet_module(
+                            cv_name, puppet_module_name)
+                    )
+                else:
+                    self.content_views.add_remove_repos(
+                        cv_name, [repo_name], repo_type=repo_type)
+                    self.assertIsNotNone(self.content_views.wait_until_element(
+                        common_locators['alert.success_sub_form']))
+            # publish the content view
+            version = self.content_views.publish(cv_name)
+            self.assertIsNotNone(
+                self.content_views.wait_until_element(
+                    common_locators['alert.success_sub_form'])
+            )
+            # promote the content view to DEV, QE, PROD lifecycle environments
+            for env_name in env_names:
+                self.content_views.promote(cv_name, version, env_name)
+            self.assertEqual(
+                set(self._get_cv_version_environments(version)),
+                all_env_names_set
+            )
+            # remove the content view version from Library environment
+            self.content_views.remove_version_from_environments(
+                cv_name, version, [ENVIRONMENT])
+            self.assertEqual(
+                set(self._get_cv_version_environments(version)),
+                set(env_names)
+            )
 
-    @stubbed()
     @run_only_on('sat')
     @tier2
     def test_positive_remove_cv_version_from_env(self):
@@ -2785,13 +3039,93 @@ class ContentViewTestCase(UITestCase):
 
         @Assert: Content view version exist in Library, DEV, QE, STAGE, PROD
 
-
-        @caseautomation: notautomated
-
         @CaseLevel: Integration
         """
+        cv_name = gen_string('alpha')
+        # create env names [DEV, QE, STAGE, PROD]
+        env_names = [gen_string('alpha') for _ in range(4)]
+        env_dev_name, env_qe_name, env_stage_name, env_prod_name = env_names
+        all_env_names_set = set(env_names)
+        all_env_names_set.add(ENVIRONMENT)
+        puppet_repo_url = FAKE_0_PUPPET_REPO
+        puppet_module_name = FAKE_0_PUPPET_MODULE
+        repos = [
+            dict(
+                repo_name=gen_string('alpha'),
+                repo_url=FAKE_0_YUM_REPO,
+                repo_type=REPO_TYPE['yum'],
+            ),
+            dict(
+                repo_name=gen_string('alpha'),
+                repo_url=puppet_repo_url,
+                repo_type=REPO_TYPE['puppet'],
+            ),
+        ]
+        # create a new organization
+        org = entities.Organization().create()
+        with Session(self.browser) as session:
+            # create the DEV, QE, STAGE, PROD lifecycle environments
+            env_prior = None
+            for env_name in env_names:
+                make_lifecycle_environment(
+                    session, org=org.name, name=env_name, prior=env_prior)
+                env_prior = env_name
+            # create the repositories
+            for repo in repos:
+                self.setup_to_create_cv(
+                    org_id=org.id,
+                    **repo
+                )
+            # create a content view
+            make_contentview(
+                session, org=org.name, name=cv_name)
+            self.assertIsNotNone(self.content_views.search(cv_name))
+            # add the repos to content view
+            for repo in repos:
+                repo_name = repo['repo_name']
+                repo_type = repo['repo_type']
+                if repo_type == 'puppet':
+                    self.content_views.add_puppet_module(
+                        cv_name,
+                        puppet_module_name,
+                        filter_term='Latest',
+                    )
+                    self.assertIsNotNone(
+                        self.content_views.fetch_puppet_module(
+                            cv_name, puppet_module_name)
+                    )
+                else:
+                    self.content_views.add_remove_repos(
+                        cv_name, [repo_name], repo_type=repo_type)
+                    self.assertIsNotNone(self.content_views.wait_until_element(
+                        common_locators['alert.success_sub_form']))
+            # publish the content view
+            version = self.content_views.publish(cv_name)
+            self.assertIsNotNone(
+                self.content_views.wait_until_element(
+                    common_locators['alert.success_sub_form'])
+            )
+            # promote the content view to all lifecycle environments
+            for env_name in env_names:
+                self.content_views.promote(cv_name, version, env_name)
+            self.assertEqual(
+                set(self._get_cv_version_environments(version)),
+                all_env_names_set
+            )
+            # remove the content view version from PROD environment
+            self.content_views.remove_version_from_environments(
+                cv_name, version, [env_prod_name])
+            self.assertEqual(
+                set(self._get_cv_version_environments(version)),
+                {ENVIRONMENT, env_dev_name, env_qe_name, env_stage_name}
+            )
+            # promote again to PROD
+            self.content_views.promote(cv_name, version, env_prod_name)
+            self.assertEqual(
+                set(self._get_cv_version_environments(version)),
+                all_env_names_set
+            )
 
-    @stubbed()
     @run_only_on('sat')
     @tier2
     def test_positive_remove_cv_version_from_multi_env(self):
@@ -2814,12 +3148,87 @@ class ContentViewTestCase(UITestCase):
 
         @Assert: Content view version exists only in Library, DEV
 
-        @caseautomation: notautomated
-
         @CaseLevel: Integration
         """
+        cv_name = gen_string('alpha')
+        # create env names [DEV, QE, STAGE, PROD]
+        env_names = [gen_string('alpha') for _ in range(4)]
+        env_dev_name, env_qe_name, env_stage_name, env_prod_name = env_names
+        all_env_names_set = set(env_names)
+        all_env_names_set.add(ENVIRONMENT)
+        puppet_repo_url = FAKE_0_PUPPET_REPO
+        puppet_module_name = FAKE_0_PUPPET_MODULE
+        repos = [
+            dict(
+                repo_name=gen_string('alpha'),
+                repo_url=FAKE_0_YUM_REPO,
+                repo_type=REPO_TYPE['yum'],
+            ),
+            dict(
+                repo_name=gen_string('alpha'),
+                repo_url=puppet_repo_url,
+                repo_type=REPO_TYPE['puppet'],
+            ),
+        ]
+        # create a new organization
+        org = entities.Organization().create()
+        with Session(self.browser) as session:
+            # create the DEV, QE, STAGE, PROD lifecycle environments
+            env_prior = None
+            for env_name in env_names:
+                make_lifecycle_environment(
+                    session, org=org.name, name=env_name, prior=env_prior)
+                env_prior = env_name
+            # create the repositories
+            for repo in repos:
+                self.setup_to_create_cv(
+                    org_id=org.id,
+                    **repo
+                )
+            # create a content view
+            make_contentview(
+                session, org=org.name, name=cv_name)
+            self.assertIsNotNone(self.content_views.search(cv_name))
+            # add the repos to content view
+            for repo in repos:
+                repo_name = repo['repo_name']
+                repo_type = repo['repo_type']
+                if repo_type == 'puppet':
+                    self.content_views.add_puppet_module(
+                        cv_name,
+                        puppet_module_name,
+                        filter_term='Latest',
+                    )
+                    self.assertIsNotNone(
+                        self.content_views.fetch_puppet_module(
+                            cv_name, puppet_module_name)
+                    )
+                else:
+                    self.content_views.add_remove_repos(
+                        cv_name, [repo_name], repo_type=repo_type)
+                    self.assertIsNotNone(self.content_views.wait_until_element(
+                        common_locators['alert.success_sub_form']))
+            # publish the content view
+            version = self.content_views.publish(cv_name)
+            self.assertIsNotNone(
+                self.content_views.wait_until_element(
+                    common_locators['alert.success_sub_form'])
+            )
+            # promote the content view to all lifecycle environments
+            for env_name in env_names:
+                self.content_views.promote(cv_name, version, env_name)
+            self.assertEqual(
+                set(self._get_cv_version_environments(version)),
+                all_env_names_set
+            )
+            # remove the content view version from QE, STAGE, PROD environments
+            self.content_views.remove_version_from_environments(
+                cv_name, version, [env_qe_name, env_stage_name, env_prod_name])
+            self.assertEqual(
+                set(self._get_cv_version_environments(version)),
+                {ENVIRONMENT, env_dev_name}
+            )
 
-    @stubbed()
     @run_only_on('sat')
     @tier2
     def test_positive_delete_cv_promoted_to_multi_env(self):
@@ -2844,10 +3253,84 @@ class ContentViewTestCase(UITestCase):
 
         @Assert: The content view doesn't exists
 
-        @caseautomation: notautomated
-
         @CaseLevel: Integration
         """
+        cv_name = gen_string('alpha')
+        # create env names [DEV, QE, STAGE, PROD]
+        env_names = [gen_string('alpha') for _ in range(4)]
+        all_env_names_set = set(env_names)
+        all_env_names_set.add(ENVIRONMENT)
+        puppet_repo_url = FAKE_0_PUPPET_REPO
+        puppet_module_name = FAKE_0_PUPPET_MODULE
+        repos = [
+            dict(
+                repo_name=gen_string('alpha'),
+                repo_url=FAKE_0_YUM_REPO,
+                repo_type=REPO_TYPE['yum'],
+            ),
+            dict(
+                repo_name=gen_string('alpha'),
+                repo_url=puppet_repo_url,
+                repo_type=REPO_TYPE['puppet'],
+            ),
+        ]
+        # create a new organization
+        org = entities.Organization().create()
+        with Session(self.browser) as session:
+            # create the DEV, QE, STAGE, PROD lifecycle environments
+            env_prior = None
+            for env_name in env_names:
+                make_lifecycle_environment(
+                    session, org=org.name, name=env_name, prior=env_prior)
+                env_prior = env_name
+            # create the repositories
+            for repo in repos:
+                self.setup_to_create_cv(
+                    org_id=org.id,
+                    **repo
+                )
+            # create a content view
+            make_contentview(
+                session, org=org.name, name=cv_name)
+            self.assertIsNotNone(self.content_views.search(cv_name))
+            # add the repos to content view
+            for repo in repos:
+                repo_name = repo['repo_name']
+                repo_type = repo['repo_type']
+                if repo_type == 'puppet':
+                    self.content_views.add_puppet_module(
+                        cv_name,
+                        puppet_module_name,
+                        filter_term='Latest',
+                    )
+                    self.assertIsNotNone(
+                        self.content_views.fetch_puppet_module(
+                            cv_name, puppet_module_name)
+                    )
+                else:
+                    self.content_views.add_remove_repos(
+                        cv_name, [repo_name], repo_type=repo_type)
+                    self.assertIsNotNone(self.content_views.wait_until_element(
+                        common_locators['alert.success_sub_form']))
+            # publish the content view
+            version = self.content_views.publish(cv_name)
+            self.assertIsNotNone(
+                self.content_views.wait_until_element(
+                    common_locators['alert.success_sub_form'])
+            )
+            # promote the content view to all lifecycle environments
+            for env_name in env_names:
+                self.content_views.promote(cv_name, version, env_name)
+            self.assertEqual(
+                set(self._get_cv_version_environments(version)),
+                all_env_names_set
+            )
+            # remove all the environments from version
+            self.content_views.remove_version_from_environments(
+                cv_name, version, list(all_env_names_set))
+            # delete content view
+            self.content_views.delete(cv_name)
+            self.assertIsNone(self.content_views.search(cv_name))
 
     @stubbed()
     @run_only_on('sat')

--- a/tests/foreman/ui/test_contentview.py
+++ b/tests/foreman/ui/test_contentview.py
@@ -2615,3 +2615,367 @@ class ContentViewTestCase(UITestCase):
 
         @CaseLevel: Integration
         """
+
+    @stubbed()
+    @run_only_on('sat')
+    @tier2
+    def test_positive_remove_cv_version_from_default_env(self):
+        """Remove content view version from Library environment
+
+        @id: 43c83c15-c883-45a7-be05-d9b26da99e3c
+
+        @Steps:
+
+        1. Create a content view
+
+        2. Add a yum repo to it
+
+        3. Publish content view
+
+        4. remove the published version from Library environment
+
+        @Assert: content view version is removed from Library environment
+
+        @caseautomation: notautomated
+
+        @CaseLevel: Integration
+        """
+
+    @stubbed()
+    @run_only_on('sat')
+    @tier2
+    def test_positive_remove_renamed_cv_version_from_default_env(self):
+        """Remove version of renamed content view from Library environment
+
+        @id: bd5ca409-f3ab-43b5-bb63-3b747aa75506
+
+        @Steps:
+
+        1. Create a content view
+
+        2. Add a yum repo to the content view
+
+        3. Publish the content view
+
+        4. Rename the content view
+
+        5. remove the published version from Library environment
+
+        @Assert: content view version is removed from Library environment
+
+        @caseautomation: notautomated
+
+        @CaseLevel: Integration
+        """
+
+    @stubbed()
+    @run_only_on('sat')
+    @tier2
+    def test_positive_remove_promoted_cv_version_from_default_env(self):
+        """Remove promoted content view version from Library environment
+
+        @id: a8649444-b063-4fb4-b932-a3fae7d4021d
+
+        @Steps:
+
+        1. Create a content view
+
+        2. Add a puppet module(s) to the content view
+
+        3. Publish the content view
+
+        4. Promote the content view version from Library -> DEV
+
+        5. remove the content view version from Library environment
+
+        @Assert:
+
+        1. Content view version exist only in DEV and not in Library
+
+        2. The puppet module(s) exists in content view version
+
+        @caseautomation: notautomated
+
+        @CaseLevel: Integration
+        """
+
+    @stubbed()
+    @run_only_on('sat')
+    @tier2
+    def test_positive_remove_qe_promoted_cv_version_from_default_env(self):
+        """Remove QE promoted content view version from Library environment
+
+        @id: 71ad8b72-68c4-4c98-9387-077f54ef0184
+
+        @Steps:
+
+        1. Create a content view
+
+        2. Add docker repo(s) to it
+
+        3. Publish content view
+
+        4. Promote the content view version to multiple environments
+           Library -> DEV -> QE
+
+        5. remove the content view version from Library environment
+
+        @Assert: Content view version exist only in DEV, QE
+                 and not in Library
+
+        @caseautomation: notautomated
+
+        @CaseLevel: Integration
+        """
+
+    @stubbed()
+    @run_only_on('sat')
+    @tier2
+    def test_positive_remove_prod_promoted_cv_version_from_default_env(self):
+        """Remove PROD promoted content view version from Library environment
+
+        @id: 6a874041-43c7-4682-ba06-571e49d5bbea
+
+        @Steps:
+
+        1. Create a content view
+
+        2. Add yum repositories, puppet modules, docker repositories to CV
+
+        3. Publish content view
+
+        4. Promote the content view version to multiple environments
+           Library -> DEV -> QE -> PROD
+
+        5. remove the content view version from Library environment
+
+        @Assert: Content view version exist only in DEV, QE, PROD
+                 and not in Library
+
+        @caseautomation: notautomated
+
+        @CaseLevel: Integration
+        """
+
+    @stubbed()
+    @run_only_on('sat')
+    @tier2
+    def test_positive_remove_cv_version_from_env(self):
+        """Remove promoted content view version from environment
+
+        @id: d1da23ee-a5db-4990-9572-1a0919a9fe1c
+
+        @Steps:
+
+        1. Create a content view
+
+        2. Add a yum repo and a puppet module to the content view
+
+        3. Publish the content view
+
+        4. Promote the content view version to multiple environments
+           Library -> DEV -> QE -> STAGE -> PROD
+
+        5. remove the content view version from PROD environment
+
+        @Assert: content view version exists only in Library, DEV, QE, STAGE
+                   and not in PROD
+
+        7. Promote again from STAGE -> PROD
+
+        @Assert: Content view version exist in Library, DEV, QE, STAGE, PROD
+
+
+        @caseautomation: notautomated
+
+        @CaseLevel: Integration
+        """
+
+    @stubbed()
+    @run_only_on('sat')
+    @tier2
+    def test_positive_remove_cv_version_from_multi_env(self):
+        """Remove promoted content view version from multiple environment
+
+        @id: 0d54c256-ac6d-4487-ab09-4e8dd257358e
+
+        @Steps:
+
+        1. Create a content view
+
+        2. Add a yum repo and a puppet module to the content view
+
+        3. Publish the content view
+
+        4. Promote the content view version to multiple environments
+           Library -> DEV -> QE -> STAGE -> PROD
+
+        5. Remove content view version from QE, STAGE and PROD
+
+        @Assert: Content view version exists only in Library, DEV
+
+        @caseautomation: notautomated
+
+        @CaseLevel: Integration
+        """
+
+    @stubbed()
+    @run_only_on('sat')
+    @tier2
+    def test_positive_delete_cv_promoted_to_multi_env(self):
+        """Delete published content view with version promoted to multiple
+         environments
+
+        @id: f16f2db5-7f5b-4ebb-863e-6c18ff745ce4
+
+        @Steps:
+
+        1. Create a content view
+
+        2. Add a yum repo and a puppet module to the content view
+
+        3. Publish the content view
+
+        4. Promote the content view to multiple environment
+           Library -> DEV -> QE -> STAGE -> PROD
+
+        5. Delete the content view, this should delete the content with all
+           it's published/promoted versions from all environments
+
+        @Assert: The content view doesn't exists
+
+        @caseautomation: notautomated
+
+        @CaseLevel: Integration
+        """
+
+    @stubbed()
+    @run_only_on('sat')
+    @tier3
+    def test_positive_remove_cv_version_from_env_with_host_registered(self):
+        """Remove promoted content view version from environment that is used
+        in association of an Activation key and content-host registration.
+
+        @id: a8ca3de1-3f79-4029-8033-00315b6b854f
+
+        @Steps:
+
+        1. Create a content view
+
+        2. Add a yum repo and a puppet module to the content view
+
+        3. Publish the content view
+
+        4. Promote the content view to multiple environment
+           Library -> DEV -> QE
+
+        5. Create an Activation key with the QE environment
+
+        6. Register a content-host using the Activation key
+
+        7. Remove the content view version from QE environment
+
+        8. Verify if the affected Activation key and content-host are
+           functioning properly
+
+        @Assert:
+
+        1. Activation key exists
+
+        2. Content-host exists
+
+        3. Content view does not exist in activation key and content-host
+           association
+
+        @caseautomation: notautomated
+
+        @CaseLevel: Integration
+        """
+
+    @stubbed()
+    @run_only_on('sat')
+    @tier3
+    def test_positive_delete_cv_multi_env_promoted_with_host_registered(self):
+        """Delete published content view with version promoted to multiple
+         environments, with one of the environments used in association of an
+         Activation key and content-host registration.
+
+        @id: 73453c99-8f34-413d-8f95-e4a2f4c58a00
+
+        @Steps:
+
+        1. Create a content view
+
+        2. Add a yum repo and a puppet module to the content view
+
+        3. Publish the content view
+
+        4. Promote the content view to multiple environment
+           Library -> DEV -> QE
+
+        5. Create an Activation key with the QE environment
+
+        6. Register a content-host using the Activation key
+
+        7. Delete the content view
+
+        8. Verify if the affected Activation key and content-host are
+           functioning properly
+
+
+        @Assert:
+
+        1. The content view doesn't exist
+
+        2. Activation key exists
+
+        3. Content-host exists
+
+        4. Content view does not exist in activation key and content-host
+           association
+
+        @caseautomation: notautomated
+
+        @CaseLevel: Integration
+        """
+
+    @stubbed()
+    @run_only_on('sat')
+    @tier3
+    def test_positive_remove_cv_version_from_multi_env_capsule_scenario(self):
+        """Remove promoted content view version from multiple environment,
+        with satellite setup to use capsule
+
+        @id: ba731272-66e6-461e-8e9d-564b4092a92d
+
+        @Steps:
+
+        1. Create a content view
+
+        2. Setup satellite to use a capsule and to sync all lifecycle
+           environments
+
+        3. Add a yum repo, puppet module and a docker repo to the content view
+
+        4. Publish the content view
+
+        5. Promote the content view to multiple environment
+           Library -> DEV -> QE -> PROD
+
+        6. Disconnect the capsule
+
+        7. Remove the content view version from Library and DEV environments
+           and assert successful completion
+
+        8. Bring the capsule back online and assert that the task is completed
+           in capsule
+
+        9. Make sure the capsule is updated
+
+        @Assert: content view version in capsule is removed from Library
+                 and DEV and exists only in QE and PROD
+
+        @caseautomation: notautomated
+
+        @CaseLevel: Integration
+        """


### PR DESCRIPTION
**stubbed  + major implementation**
```console
(2.7) dlezz@elysion:~/projects/robottelo-fork$ py.test tests/foreman/ui/test_contentview.py -k "test_positive_remove_cv_version_from_default_env or test_positive_remove_renamed_cv_version_from_default_env or test_positive_remove_promoted_cv_version_from_default_env or test_positive_remove_qe_promoted_cv_version_from_default_env or test_positive_remove_prod_promoted_cv_version_from_default_env or test_positive_remove_cv_version_from_env or test_positive_remove_cv_version_from_multi_env or test_positive_delete_cv_promoted_to_multi_env"
================================================= test session starts ==================================================
platform linux2 -- Python 2.7.12, pytest-2.9.2, py-1.4.32, pluggy-0.3.1
rootdir: /home/dlezz/projects/robottelo-fork, inifile: 
plugins: xdist-1.14, cov-2.3.1
collected 80 items 

tests/foreman/ui/test_contentview.py ...s.s....

 70 tests deselected by '-ktest_positive_remove_cv_version_from_default_env or test_positive_remove_renamed_cv_version_from_default_env or test_positive_remove_promoted_cv_version_from_default_env or test_positive_remove_qe_promoted_cv_version_from_default_env or test_positive_remove_prod_promoted_cv_version_from_default_env or test_positive_remove_cv_version_from_env or test_positive_remove_cv_version_from_multi_env or test_positive_delete_cv_promoted_to_multi_env' 
================================ 8 passed, 2 skipped, 70 deselected in 2344.82 seconds =================================
(2.7) dlezz@elysion:~/projects/robottelo-fork$ 
```
original PRs:
https://github.com/SatelliteQE/robottelo/pull/4071
https://github.com/SatelliteQE/robottelo/pull/4184