### PR TITLE
[6.2.z][Cherry-pick] Fix API environment and smartproxy missing attributes tests (#4282)

### DIFF
--- a/tests/foreman/api/test_environment.py
+++ b/tests/foreman/api/test_environment.py
@@ -23,7 +23,7 @@ from nailgun import entities
 from requests.exceptions import HTTPError
 from robottelo.api.utils import one_to_many_names
 from robottelo.datafactory import filtered_datapoint, invalid_names_list
-from robottelo.decorators import run_only_on, skip_if_bug_open, tier1, tier2
+from robottelo.decorators import run_only_on, tier1, tier2
 from robottelo.test import APITestCase
 
 
@@ -220,7 +220,6 @@ class MissingAttrEnvironmentTestCase(APITestCase):
     """
 
     @classmethod
-    @skip_if_bug_open('bugzilla', 1262029)
     def setUpClass(cls):
         """Create an ``Environment``."""
         super(MissingAttrEnvironmentTestCase, cls).setUpClass()
@@ -228,24 +227,26 @@ class MissingAttrEnvironmentTestCase(APITestCase):
         cls.env_attrs = set(env.update_json([]).keys())
 
     @tier2
-    def test_location(self):
+    def test_positive_update_loc(self):
         """Update an environment. Inspect the server's response.
 
         @id: a4c1bc22-d586-4150-92fc-7797f0f5bfb0
 
         @Assert: The response contains some value for the ``location`` field.
 
+        @BZ: 1262029
+
         @CaseLevel: Integration
         """
         names = one_to_many_names('location')
-        self.assertGreater(
+        self.assertGreaterEqual(
             len(names & self.env_attrs),
             1,
             'None of {0} are in {1}'.format(names, self.env_attrs),
         )
 
     @tier2
-    def test_organization(self):
+    def test_positive_update_org(self):
         """Update an environment. Inspect the server's response.
 
         @id: ac46bcac-5db0-4899-b2fc-d48d2116287e
@@ -253,10 +254,12 @@ class MissingAttrEnvironmentTestCase(APITestCase):
         @Assert: The response contains some value for the ``organization``
         field.
 
+        @BZ: 1262029
+
         @CaseLevel: Integration
         """
         names = one_to_many_names('organization')
-        self.assertGreater(
+        self.assertGreaterEqual(
             len(names & self.env_attrs),
             1,
             'None of {0} are in {1}'.format(names, self.env_attrs),

--- a/tests/foreman/api/test_smartproxy.py
+++ b/tests/foreman/api/test_smartproxy.py
@@ -235,7 +235,6 @@ class SmartProxyMissingAttrTestCase(APITestCase):
     """
 
     @classmethod
-    @skip_if_bug_open('bugzilla', 1262037)
     def setUpClass(cls):
         """Find a ``SmartProxy``.
 
@@ -258,9 +257,11 @@ class SmartProxyMissingAttrTestCase(APITestCase):
         @id: 42d6b749-c047-4fd2-90ee-ffab7be558f9
 
         @Assert: The response contains some value for the ``location`` field.
+
+        @BZ: 1262037
         """
         names = one_to_many_names('location')
-        self.assertGreater(
+        self.assertGreaterEqual(
             len(names & self.smart_proxy_attrs),
             1,
             'None of {0} are in {1}'.format(names, self.smart_proxy_attrs),
@@ -274,9 +275,11 @@ class SmartProxyMissingAttrTestCase(APITestCase):
 
         @Assert: The response contains some value for the ``organization``
         field.
+
+        @BZ: 1262037
         """
         names = one_to_many_names('organization')
-        self.assertGreater(
+        self.assertGreaterEqual(
             len(names & self.smart_proxy_attrs),
             1,
             'None of {0} are in {1}'.format(names, self.smart_proxy_attrs),


### PR DESCRIPTION
Cherry pick of #4282 

Test results:
```python
py.test tests/foreman/api/test_smartproxy.py::SmartProxyMissingAttrTestCase tests/foreman/api/test_environment.py::MissingAttrEnvironmentTestCase
============================= test session starts ==============================
platform darwin -- Python 2.7.13, pytest-2.9.2, py-1.4.32, pluggy-0.3.1
rootdir: /Users/andrii/workspace/robottelo, inifile:
plugins: xdist-1.15.0, cov-2.3.1
collected 4 items

tests/foreman/api/test_smartproxy.py ..
tests/foreman/api/test_environment.py ..

=========================== 4 passed in 4.53 seconds ===========================
```
Closes #4281