### PR TITLE
Automate BZ 1321511 -- validate autocomplete content

### DIFF
--- a/robottelo/ui/hostgroup.py
+++ b/robottelo/ui/hostgroup.py
@@ -1,7 +1,7 @@
 # -*- encoding: utf-8 -*-
 """Implements Host Group UI."""
 from robottelo.ui.base import Base
-from robottelo.ui.locators import common_locators, locators
+from robottelo.ui.locators import common_locators, locators, tab_locators
 from robottelo.ui.navigator import Navigator
 
 
@@ -9,7 +9,8 @@ class Hostgroup(Base):
     """Manipulates hostgroup from UI."""
 
     def create(self, name, parent=None, environment=None, content_source=None,
-               puppet_ca=None, puppet_master=None, oscap_capsule=None):
+               content_view=None, puppet_ca=None, puppet_master=None,
+               oscap_capsule=None, activation_keys=None):
         """Creates a new hostgroup from UI."""
         self.click(locators['hostgroups.new'])
         self.assign_value(locators['hostgroups.name'], name)
@@ -20,12 +21,19 @@ class Hostgroup(Base):
         if content_source:
             self.assign_value(
                 locators['hostgroups.content_source'], content_source)
+        if content_view:
+            self.assign_value(
+                locators['hostgroups.content_view'], content_view)
         if puppet_ca:
             self.assign_value(locators['hostgroups.puppet_ca'], puppet_ca)
         if puppet_master:
             self.assign_value(
                 locators['hostgroups.puppet_master'], puppet_master)
         if oscap_capsule:
+            self.assign_value(
+                locators['hostgroups.oscap_capsule'], oscap_capsule)
+        if activation_keys:
+            self.click(tab_locators['hostgroup.activation_keys'])
             self.assign_value(
                 locators['hostgroups.oscap_capsule'], oscap_capsule)
         self.click(common_locators['submit'])

--- a/robottelo/ui/locators/base.py
+++ b/robottelo/ui/locators/base.py
@@ -826,6 +826,10 @@ locators = LocatorDict({
         By.XPATH,
         ("//div[contains(@id, 'hostgroup_content_source')]/a"
          "/span[contains(@class, 'arrow')]")),
+    "hostgroups.content_view": (
+        By.XPATH,
+        ("//div[contains(@id, 'hostgroup_content_view')]/a"
+         "/span[contains(@class, 'arrow')]")),
     "hostgroups.puppet_ca": (
         By.XPATH,
         ("//div[contains(@id, 'hostgroup_puppet_ca_proxy_id')]/a"
@@ -838,7 +842,10 @@ locators = LocatorDict({
         By.XPATH,
         ("//div[contains(@id, 'hostgroup_openscap_proxy_id')]/a"
          "/span[contains(@class, 'arrow')]")),
-
+    "hostgroups.activation_keys": (
+        By.XPATH, "//input[contains(@id, 'activation_keys')]"),
+    "hostgroups.ak_autocomplete": (
+        By.XPATH, "//ul[contains(@class, 'ui-autocomplete')]/li/a"),
     # Users
 
     # Users.primary

--- a/robottelo/ui/locators/tab.py
+++ b/robottelo/ui/locators/tab.py
@@ -36,6 +36,20 @@ tab_locators = LocatorDict({
     "host.tab_params": (By.XPATH, "//a[@href='#params']"),
     "host.tab_additional_information": (By.XPATH, "//a[@href='#info']"),
 
+    # Hostgroup
+    # Third level UI
+
+    "hostgroup.tab_hostgroup": (By.XPATH, "//a[@href='#primary']"),
+    "hostgroup.tab_ansible_roles": (By.XPATH, "//a[@href='#ansible_roles']"),
+    "hostgroup.tab_puppet_classes": (By.XPATH, "//a[@href='#puppet_klasses']"),
+    "hostgroup.tab_network": (By.XPATH, "//a[@href='#network']"),
+    "hostgroup.tab_operating_system": (By.XPATH, ("//a[@href='#os']")),
+    "hostgroup.tab_params": (By.XPATH, "//a[@href='#params']"),
+    "hostgroup.tab_locations": (By.XPATH, "//a[@href='#locations']"),
+    "hostgroup.tab_organizations": (By.XPATH, "//a[@href='#organizations']"),
+    "hostgroup.tab_activation_keys": (
+        By.XPATH, "//a[@href='#activation_keys']"),
+
     # Provisioning Templates
     # Third level UI
 

--- a/tests/foreman/ui/test_hostgroup.py
+++ b/tests/foreman/ui/test_hostgroup.py
@@ -17,11 +17,13 @@
 """
 
 from fauxfactory import gen_string
+from nailgun import entities
+
 from robottelo.datafactory import generate_strings_list, invalid_values_list
 from robottelo.decorators import run_only_on, tier1
 from robottelo.test import UITestCase
 from robottelo.ui.factory import make_hostgroup
-from robottelo.ui.locators import common_locators
+from robottelo.ui.locators import common_locators, locators, tab_locators
 from robottelo.ui.session import Session
 from robottelo.config import settings
 
@@ -34,6 +36,16 @@ class HostgroupTestCase(UITestCase):
         """Set up class for hostgroup UI test cases"""
         super(HostgroupTestCase, cls).setUpClass()
         cls.sat6_hostname = settings.server.hostname
+        cls.organization = entities.Organization().create()
+        cls.env = entities.LifecycleEnvironment(
+            organization=cls.organization, name='Library').search()[0]
+        cls.cv = entities.ContentView(organization=cls.organization).create()
+        cls.cv.publish()
+        cls.ak = entities.ActivationKey(
+            organization=cls.organization,
+            environment=cls.env,
+            content_view=cls.cv,
+        ).create()
 
     @run_only_on('sat')
     @tier1
@@ -141,3 +153,73 @@ class HostgroupTestCase(UITestCase):
                     oscap_capsule=self.sat6_hostname,
                 )
             self.assertIsNotNone(self.hostgroup.search(name))
+
+    @run_only_on('sat')
+    @tier1
+    def test_positive_create_with_activation_keys(self):
+        """Create new hostgroup with activation keys
+
+        @id: cfda3c1b-37fd-42c1-a74c-841efb83b2f5
+
+        @Assert: Hostgroup is created with activation keys
+        """
+        name = gen_string('alpha')
+        with Session(self.browser) as session:
+            make_hostgroup(
+                session,
+                name=name,
+                environment=self.env.name,
+                content_view=self.cv.name,
+                activation_key=self.ak.name,
+            )
+            self.assertIsNotNone(self.hostgroup.search(name))
+
+    @run_only_on('sat')
+    @tier1
+    def test_positive_check_activation_keys_autocomplete(self):
+        """Open Hostgroup New/Edit modal and verify that Activation Keys
+        autocomplete respects selected Content View
+
+        @id: 07906caf-871d-4d1f-8914-38027e71c16b
+
+        @Steps:
+
+        1. Create two content views A & B
+        2. Publish both content views
+        3. Create an activation key pointed to view A in Library
+        4. Create an activation key pointed to view B in Library
+        5. Go to the new Hostgroup page, select content view B & Library,
+            click on the activation key tab and click in the input box
+
+        @Assert: Only the activation key for view B is listed
+
+        @BZ: 1321511
+        """
+        # Use setup entities as A and create another set for B.
+        cv_b = entities.ContentView(organization=self.organization).create()
+        cv_b.publish()
+        ak_b = entities.ActivationKey(
+            organization=self.organization,
+            environment=self.env,
+            content_view=cv_b,
+        ).create()
+        with Session(self.browser) as session:
+            session.nav.go_to_select_org(self.organization.name)
+            session.nav.go_to_host_groups()
+            self.hostgroup.click(locators['hostgroups.new'])
+            self.hostgroup.assign_value(
+                locators['hostgroups.environment'], self.env.name)
+            self.hostgroup.assign_value(
+                locators['hostgroups.content_view'], cv_b.name)
+            # Switch to Activation Keys tab and click on input
+            # to load autocomplete
+            self.hostgroup.click(tab_locators['hostgroup.tab_activation_keys'])
+            self.hostgroup.click(locators['hostgroups.activation_keys'])
+            autocompletes = self.hostgroup.find_elements(
+                locators['hostgroups.ak_autocomplete'])
+            # Ensure that autocomplete list is not empty
+            self.assertGreaterEqual(len(autocompletes), 1)
+            # Check for AK names in list
+            autocompletes = [item.text for item in autocompletes]
+            self.assertIn(ak_b.name, autocompletes)
+            self.assertNotIn(self.ak.name, autocompletes)


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1321511
```python
% pytest -v tests/foreman/ui/test_hostgroup.py -k 'activation'
===================================================================== test session starts =====================================================================
platform linux2 -- Python 2.7.12, pytest-3.0.4, py-1.4.31, pluggy-0.4.0 -- /home/qui/code/venv/2/bin/python2
cachedir: .cache
rootdir: /home/qui/code/robottelo, inifile: 
plugins: xdist-1.15.0, html-1.12.0, cov-2.4.0
collected 8 items 

tests/foreman/ui/test_hostgroup.py::HostgroupTestCase::test_positive_check_activation_keys_autocomplete <- robottelo/decorators/__init__.py PASSED
tests/foreman/ui/test_hostgroup.py::HostgroupTestCase::test_positive_create_with_activation_keys <- robottelo/decorators/__init__.py PASSED

===================================================================== 6 tests deselected ======================================================================
=========================================================== 2 passed, 6 deselected in 85.65 seconds ===========================================================
```
