### PR TITLE
[6.3][Cherry-Pick]Add sanity test for navigation functionality and cover BZ1394974

### DIFF
--- a/docs/api/tests.foreman.ui.rst
+++ b/docs/api/tests.foreman.ui.rst
@@ -183,6 +183,12 @@
 
 .. automodule:: tests.foreman.ui.test_myaccount
 
+:mod:`tests.foreman.ui.test_navigation`
+---------------------------------------
+
+.. automodule:: tests.foreman.ui.test_navigation
+
+
 :mod:`tests.foreman.ui.test_openscap`
 -------------------------------------
 

--- a/robottelo/ui/locators/common.py
+++ b/robottelo/ui/locators/common.py
@@ -103,6 +103,9 @@ common_locators = LocatorDict({
     "parameter_remove": (
         By.XPATH, "//tr/td/input[@value='%s']/following::td/a"),
 
+    "application_logo": (
+        By.XPATH, "//img[contains(@alt, 'Header logo')]"),
+
     # Katello Common Locators
     "confirm_remove": (
         By.XPATH, "//button[@ng-click='ok()' or @ng-click='delete()']"),

--- a/robottelo/ui/locators/menu.py
+++ b/robottelo/ui/locators/menu.py
@@ -43,7 +43,7 @@ menu_locators = LocatorDict({
 
     "menu.jobs": (
         By.XPATH,
-        (MENU_CONTAINER_PATH + "//a[@id='menu_item_jobs']")),
+        (MENU_CONTAINER_PATH + "//a[@id='menu_item_job_invocations']")),
 
     # Content Menu
     "menu.content": (

--- a/tests/foreman/ui/test_login.py
+++ b/tests/foreman/ui/test_login.py
@@ -36,7 +36,7 @@ def invalid_credentials():
 
 
 class LoginTestCase(UITestCase):
-    """Implements the login tests rom UI"""
+    """Implements the login tests from UI"""
 
     @tier1
     def test_positive_login(self):

--- a/tests/foreman/ui/test_navigation.py
+++ b/tests/foreman/ui/test_navigation.py
@@ -1,0 +1,116 @@
+# -*- encoding: utf-8 -*-
+"""Test class for Navigation UI
+
+@Requirement: Navigation
+
+@CaseAutomation: Automated
+
+@CaseLevel: Acceptance
+
+@CaseComponent: UI
+
+@TestType: Functional
+
+@CaseImportance: High
+
+@Upstream: No
+"""
+
+from robottelo.decorators import skip_if_bug_open, tier1
+from robottelo.test import UITestCase
+from robottelo.ui.locators import common_locators, menu_locators
+from robottelo.ui.session import Session
+
+
+class NavigationTestCase(UITestCase):
+    """Implements the navigation tests from UI"""
+
+    def page_objects(self):
+        return {
+            'Activation Key': self.activationkey,
+            'Architecture': self.architecture,
+            'Bookmark': self.bookmark,
+            'Container': self.container,
+            'Compute Profile': self.compute_profile,
+            'Compute Resource': self.compute_resource,
+            'Content Hosts': self.contenthost,
+            'Config Groups': self.configgroups,
+            'Content Views': self.content_views,
+            'Docker Tag': self.dockertag,
+            'Domain': self.domain,
+            'Discovered Hosts': self.discoveredhosts,
+            'Discovery Rules': self.discoveryrules,
+            'Environment': self.environment,
+            'Gpgkey': self.gpgkey,
+            'Hardware Model': self.hardwaremodel,
+            'Host Collection': self.hostcollection,
+            'Host Group': self.hostgroup,
+            'Hosts': self.hosts,
+            'Jobs': self.job,
+            'Job Template': self.jobtemplate,
+            'LDAP Authsource': self.ldapauthsource,
+            'LifecycleEnvironment': self.lifecycleenvironment,
+            'Location': self.location,
+            'Medium': self.medium,
+            'Operating Systems': self.operatingsys,
+            'Organization': self.org,
+            'SCAP Contents': self.oscapcontent,
+            'Policies': self.oscappolicy,
+            'Reports': self.oscapreports,
+            'Packages': self.package,
+            'Partition Table': self.partitiontable,
+            'Puppet Classes': self.puppetclasses,
+            'Product': self.products,
+            'Registry': self.registry,
+            'Role': self.role,
+            'Settings': self.settings,
+            'Subnet': self.subnet,
+            'Subscriptions': self.subscriptions,
+            'Sync Plan': self.syncplan,
+            'Template': self.template,
+            'Trend': self.trend,
+            'User': self.user,
+            'User Group': self.usergroup,
+        }
+
+    @skip_if_bug_open('bugzilla', 1418695)
+    @tier1
+    def test_positive_navigate(self):
+        """Navigate through application pages
+
+        @id: da8b1242-364e-44ec-8a17-dd5d8047a386
+
+        @Assert: Page is opened without errors
+        """
+        with Session(self.browser) as session:
+            for page in self.page_objects().values():
+                    page.navigate_to_entity()
+                    self.assertIsNotNone(session.nav.wait_until_element(
+                        menu_locators['menu.current_text']))
+                    self.assertIsNone(session.nav.wait_until_element(
+                        common_locators['alert.error'], timeout=1))
+                    self.assertIsNone(session.nav.wait_until_element(
+                        common_locators['notif.error'], timeout=1))
+
+    @tier1
+    def test_positive_sat_logo_redirection(self):
+        """Check that we can be redirected from current page using application
+        logo in the top left section of the screen
+
+        @id: 9f05ac85-3b0f-4220-b2b4-a9fd050f3dc0
+
+        @BZ: 1394974
+
+        @Assert: No error is raised after redirection and logo is still present
+        on the page
+        """
+        with Session(self.browser) as session:
+            pages = self.page_objects()
+            for page_name in (
+                    'Activation Key', 'Product', 'Domain', 'Location'):
+                pages[page_name].navigate_to_entity()
+                session.nav.click(common_locators['application_logo'])
+                self.assertIsNotNone(session.nav.wait_until_element(
+                    common_locators['application_logo']))
+                self.assertIsNone(session.nav.wait_until_element(
+                    common_locators['alert.error'], timeout=1))


### PR DESCRIPTION
Same as https://github.com/SatelliteQE/robottelo/pull/4283
Situation with defects is completely different here as issue in 6.2 is resolved in 6.3, but introduced a new one
```
nosetests tests/foreman/ui/test_navigation.py
S.
----------------------------------------------------------------------
Ran 2 tests in 50.469s

OK (SKIP=1)
```