### PR TITLE
Added API & CLI host test to automate BZ1391656

### DIFF
--- a/tests/foreman/api/test_host.py
+++ b/tests/foreman/api/test_host.py
@@ -205,6 +205,39 @@ class HostTestCase(APITestCase):
         self.assertEqual(host.hostgroup.read().name, hostgroup.name)
 
     @run_only_on('sat')
+    @tier2
+    def test_positive_create_inherit_lce_cv(self):
+        """Create a host with hostgroup specified. Make sure host inherited
+        hostgroup's lifecycle environment and content-view
+
+        @id: 229cbdbc-838b-456c-bc6f-4ac895badfbc
+
+        @Assert: Host's lifecycle environment and content view match the ones
+        specified in hostgroup
+
+        @CaseLevel: Integration
+
+        @BZ: 1391656
+        """
+        hostgroup = entities.HostGroup(
+            content_view=self.cv,
+            lifecycle_environment=self.lce,
+            organization=[self.org],
+        ).create()
+        host = entities.Host(
+            hostgroup=hostgroup,
+            organization=self.org,
+        ).create()
+        self.assertEqual(
+            host.content_facet_attributes['lifecycle_environment_id'],
+            hostgroup.lifecycle_environment.id
+        )
+        self.assertEqual(
+            host.content_facet_attributes['content_view_id'],
+            hostgroup.content_view.id
+        )
+
+    @run_only_on('sat')
     @tier1
     def test_positive_create_with_puppet_proxy(self):
         """Create a host with puppet proxy specified

--- a/tests/foreman/cli/test_host.py
+++ b/tests/foreman/cli/test_host.py
@@ -28,6 +28,7 @@ from robottelo.cli.factory import (
     make_domain,
     make_environment,
     make_fake_host,
+    make_hostgroup,
     make_lifecycle_environment,
     make_medium,
     make_org,
@@ -430,6 +431,38 @@ class HostCreateTestCase(CLITestCase):
         })
         self.assertEqual(result['name'], host.name + '.' + host.domain.name)
         Host.delete({'id': result['id']})
+
+    @tier2
+    def test_positive_create_inherit_lce_cv(self):
+        """Create a host with hostgroup specified. Make sure host inherited
+        hostgroup's lifecycle environment and content-view
+
+        @id: ba73b8c8-3ce1-4fa8-a33b-89ded9ffef47
+
+        @Assert: Host's lifecycle environment and content view match the ones
+        specified in hostgroup
+
+        @CaseLevel: Integration
+
+        @BZ: 1391656
+        """
+        hostgroup = make_hostgroup({
+            'content-view-id': self.new_cv['id'],
+            'lifecycle-environment-id': self.new_lce['id'],
+            'organization-ids': self.new_org['id'],
+        })
+        host = make_fake_host({
+            'hostgroup-id': hostgroup['id'],
+            'organization-id': self.new_org['id'],
+        })
+        self.assertEqual(
+            host['content-information']['lifecycle-environment'],
+            hostgroup['lifecycle-environment'],
+        )
+        self.assertEqual(
+            host['content-information']['content-view'],
+            hostgroup['content-view'],
+        )
 
     @run_only_on('sat')
     @stubbed


### PR DESCRIPTION
Covers [BZ1391656](https://bugzilla.redhat.com/show_bug.cgi?id=1391656)
```python
py.test tests/foreman/{api,cli}/test_host.py -k test_positive_create_inherit_lce_cv
============================= test session starts ==============================
platform darwin -- Python 2.7.13, pytest-3.0.6, py-1.4.32, pluggy-0.4.0
rootdir: /Users/andrii/workspace/robottelo, inifile:
collected 119 items

tests/foreman/api/test_host.py .
tests/foreman/cli/test_host.py .

============================= 117 tests deselected =============================
```