### PR TITLE
Fixes oscap long-run test for 6.2.z, fixes issue #4286

### DIFF
--- a/robottelo/constants.py
+++ b/robottelo/constants.py
@@ -865,6 +865,7 @@ OSCAP_PROFILE = {
     'rhccp': ('Red Hat Corporate Profile for '
               'Certified Cloud Providers (RH CCP)'),
     'usgcb': 'United States Government Configuration Baseline (USGCB)',
+    'common': 'Common Profile for General-Purpose Systems',
 }
 
 ROLES = [

--- a/robottelo/ui/hosts.py
+++ b/robottelo/ui/hosts.py
@@ -124,8 +124,7 @@ class Hosts(Base):
                puppet_classes=None, interface_parameters=None,
                host_parameters=None):
         """Updates a Host."""
-        element = self.search(u'{0}.{1}'.format(name, domain_name))
-        self.click(element)
+        self.search_and_click(u'{0}.{1}'.format(name, domain_name))
         self.click(locators['host.edit'])
         if new_name:
             self.wait_until_element(locators['host.name'])

--- a/robottelo/ui/locators.py
+++ b/robottelo/ui/locators.py
@@ -1581,11 +1581,17 @@ locators = LocatorDict({
         ("//td/a/span[contains(., '%s')]"
          "/following::td/div/ul/li[2]/a[@class='delete']")),
     "hostgroups.content_source": (
-        By.ID, "hostgroup_content_source_id"),
+        By.XPATH,
+        ("//div[contains(@id, 'hostgroup_content_source')]/a"
+         "/span[contains(@class, 'arrow')]")),
     "hostgroups.puppet_ca": (
-        By.ID, "hostgroup_puppet_ca_proxy_id"),
+        By.XPATH,
+        ("//div[contains(@id, 'hostgroup_puppet_ca_proxy_id')]/a"
+         "/span[contains(@class, 'arrow')]")),
     "hostgroups.puppet_master": (
-        By.ID, "hostgroup_puppet_proxy_id"),
+        By.XPATH,
+        ("//div[contains(@id, 'hostgroup_puppet_proxy')]/a"
+         "/span[contains(@class, 'arrow')]")),
 
     # Users
 
@@ -2859,8 +2865,7 @@ locators = LocatorDict({
     "oscap.custom_policy": (By.ID, "policy_cron_line"),
 
     # oscap reports
-    "oscap.report_select": (
-        By.XPATH, "//span[contains(@data-original-title, '%s')]"),
+    "oscap.report_select": (By.XPATH, "//a[normalize-space(.)='%s']"),
 
     # Registries
     "registry.new": (By.XPATH, "//a[contains(@href, '/registries/new')]"),


### PR DESCRIPTION
Fixed locators , and other nitpicks test is able to run again.

```
 nosetests tests.foreman.longrun.test_oscap:OpenScapTestCase.test_positive_upload_to_satellite
.
----------------------------------------------------------------------
Ran 1 test in 1045.552s

OK

```





Signed-off-by: san7ket <san7ketjagtap@gmail.com>