### PR TITLE
Add tests for role clone / automate BZ 1353788

### DIFF
--- a/robottelo/ui/locators/base.py
+++ b/robottelo/ui/locators/base.py
@@ -947,6 +947,7 @@ locators = LocatorDict({
          "a[contains(@data-id, 'refresh')]")),
     # Roles
     "roles.new": (By.XPATH, "//a[contains(@href, '/roles/new')]"),
+    "roles.clone": (By.XPATH, "//a[contains(@data-id, 'clone')]"),
     "roles.name": (By.ID, "role_name"),
     "roles.dropdown": (
         By.XPATH,
@@ -967,6 +968,10 @@ locators = LocatorDict({
                           "//input[@placeholder='Filter permissions']"),
     "roles.perm_type": (By.XPATH, "//label[contains(., '%s')]"),
     "roles.permission": (By.XPATH, "//input[@value='%s']"),
+    "roles.resources": (
+        By.XPATH, "//table[contains(@id, 'DataTables_Table')]/tbody/tr/td[1]"),
+    "roles.permissions": (
+        By.XPATH, "//td[contains(text(), '%s')]/following-sibling::td[1]"),
 
     # Architecture
     "arch.new": (By.XPATH, "//a[contains(@href, '/architectures/new')]"),

--- a/robottelo/ui/locators/base.py
+++ b/robottelo/ui/locators/base.py
@@ -972,6 +972,12 @@ locators = LocatorDict({
         By.XPATH, "//table[contains(@id, 'DataTables_Table')]/tbody/tr/td[1]"),
     "roles.permissions": (
         By.XPATH, "//td[contains(text(), '%s')]/following-sibling::td[1]"),
+    "roles.filters.pagination_next": (
+        By.XPATH,
+        "//li[contains(@class, 'next') and "
+        "not(contains(@class, 'disabled'))]/a"
+    ),
+    "roles.filters.search": (By.XPATH, "//input[@type='search']"),
 
     # Architecture
     "arch.new": (By.XPATH, "//a[contains(@href, '/architectures/new')]"),

--- a/robottelo/ui/locators/tab.py
+++ b/robottelo/ui/locators/tab.py
@@ -126,6 +126,9 @@ tab_locators = LocatorDict({
         "//a[@data-toggle='tab' and contains(@href,'params')]"),
 
     # Roles
+    # Second level UI
+    "roles.tab_role": (By.XPATH, "//a[@href='#primary']"),
+    "roles.tab_filters": (By.XPATH, "//a[@href='#filters']"),
     # Third level UI
     "roles.tab_filter": (
         By.XPATH, "//a[@href='#primary']"),

--- a/robottelo/ui/role.py
+++ b/robottelo/ui/role.py
@@ -85,3 +85,29 @@ class Role(Base):
             self.click(tab_locators['roles.tab_location'])
             self.configure_entity(location, FILTER['filter_loc'])
         self.click(common_locators['submit'])
+
+    def get_resources(self, role_name):
+        self.search_and_click(role_name)
+        self.click(tab_locators['roles.tab_filters'])
+        resources = self.find_elements(locators['roles.resources'])
+        return [item.text for item in resources]
+
+    def get_permissions(self, role_name, resource_type):
+        self.search_and_click(role_name)
+        self.click(tab_locators['roles.tab_filters'])
+        permissions = self.wait_until_element(
+            locators['roles.permissions'] % resource_type)
+        if permissions:
+            return permissions.text.split(', ')
+        else:
+            return None
+
+    def clone(self, name, new_name=None, locations=None, organizations=None):
+        """Clone role with name/location/organization."""
+        self.search(name)
+        self.click(locators['roles.dropdown'] % name)
+        self.click(locators['roles.clone'])
+        self.assign_value(locators['roles.name'], new_name)
+        if locations or organizations:
+            self._configure_taxonomies(locations, organizations)
+        self.click(common_locators['submit'])

--- a/robottelo/ui/role.py
+++ b/robottelo/ui/role.py
@@ -87,22 +87,47 @@ class Role(Base):
         self.click(common_locators['submit'])
 
     def get_resources(self, role_name):
+        """Fetch resources from role filters.
+
+        :param role_name: String with role name.
+        :return: List of strings with resource names.
+        """
         self.search_and_click(role_name)
         self.click(tab_locators['roles.tab_filters'])
-        resources = self.find_elements(locators['roles.resources'])
-        return [item.text for item in resources]
+        resources = [
+            resource.text for resource in
+            self.find_elements(locators['roles.resources'])
+        ]
+        next_ = self.find_element(locators["roles.filters.pagination_next"])
+        while next_:
+            self.click(next_)
+            next_ = self.find_element(
+                locators["roles.filters.pagination_next"])
+            resources.extend(
+                [resource.text for resource in
+                    self.find_elements(locators['roles.resources'])])
+        return resources
 
-    def get_permissions(self, role_name, resource_type):
+    def get_permissions(self, role_name, resource_types):
+        """Fetch permissions for provided resource types from role filters.
+
+        :param role_name: String with role name.
+        :param resource_types: List with resource types names.
+        :return: Dict with resource name as a key and list of strings with
+            permissions names as a values.
+        """
         self.search_and_click(role_name)
         self.click(tab_locators['roles.tab_filters'])
-        permissions = self.wait_until_element(
-            locators['roles.permissions'] % resource_type)
-        if permissions:
-            return permissions.text.split(', ')
-        else:
-            return None
+        dict_permissions = {}
+        for res_type in resource_types:
+            self.assign_value(locators["roles.filters.search"], res_type)
+            permissions = self.wait_until_element(
+                locators['roles.permissions'] % res_type)
+            if permissions:
+                dict_permissions[res_type] = permissions.text.split(', ')
+        return dict_permissions
 
-    def clone(self, name, new_name=None, locations=None, organizations=None):
+    def clone(self, name, new_name, locations=None, organizations=None):
         """Clone role with name/location/organization."""
         self.search(name)
         self.click(locators['roles.dropdown'] % name)

--- a/tests/foreman/ui/test_role.py
+++ b/tests/foreman/ui/test_role.py
@@ -15,14 +15,17 @@
 
 @Upstream: No
 """
+from random import choice
 
 from fauxfactory import gen_string
 from nailgun import entities
+from robottelo.constants import ROLES
 from robottelo.datafactory import generate_strings_list, invalid_values_list
 from robottelo.decorators import stubbed, tier1, tier2
 from robottelo.test import UITestCase
 from robottelo.ui.factory import make_domain, make_role, make_user, set_context
 from robottelo.ui.locators import common_locators, menu_locators
+from robottelo.ui.locators import tab_locators
 from robottelo.ui.session import Session
 
 
@@ -99,14 +102,127 @@ class RoleTestCase(UITestCase):
         @Assert: Role is updated
         """
         name = gen_string('alpha')
+        resource_type = 'Architecture'
+        permissions = ['view_architectures', 'edit_architectures']
         with Session(self.browser) as session:
             make_role(session, name=name)
             self.assertIsNotNone(self.role.search(name))
             self.role.add_permission(
                 name,
-                resource_type='Architecture',
-                permission_list=['view_architectures', 'create_architectures'],
+                resource_type=resource_type,
+                permission_list=permissions,
             )
+            self.assertIsNotNone(
+                self.role.wait_until_element(common_locators['alert.success']))
+            new_permissions = self.role.get_permissions(name, resource_type)
+            self.assertIsNotNone(new_permissions)
+            self.assertEqual(set(permissions), set(new_permissions))
+
+    @tier1
+    def test_positive_clone_builtin(self):
+        """Clone one of the builtin roles
+
+        @id: e3e6af90-fb31-4de9-8f36-f50550d7f00e
+
+        @Assert: New role is created.
+        """
+        builtin_name = choice(ROLES)
+        new_name = gen_string('alpha')
+        with Session(self.browser):
+            self.role.clone(builtin_name, new_name)
+            self.assertIsNotNone(
+                self.role.wait_until_element(common_locators['alert.success']))
+            self.assertIsNotNone(self.role.search(new_name))
+            # Ensure that cloned role contains correct resource type
+            builtin_resources = self.role.get_resources(builtin_name)
+            cloned_resources = self.role.get_resources(new_name)
+            self.assertGreater(len(cloned_resources), 0)
+            self.assertEqual(set(builtin_resources), set(cloned_resources))
+            # And correct permissions for every resource type
+            for resource in cloned_resources:
+                self.assertEqual(
+                    set(self.role.get_permissions(builtin_name, resource)),
+                    set(self.role.get_permissions(new_name, resource))
+                )
+
+    @tier1
+    def test_positive_clone_custom(self):
+        """Create custom role with permissions and clone it
+
+        @id: a4367968-eae5-4b8a-9b5c-61824b261320
+
+        @Assert: New role is created and contains all permissions
+        """
+        name = gen_string('alpha')
+        new_name = gen_string('alpha')
+        # Pick up custom permissions
+        resource_type = 'Architecture'
+        permissions = ['view_architectures', 'edit_architectures']
+        with Session(self.browser) as session:
+            # Create custom role with permissions
+            make_role(session, name=name)
+            self.role.add_permission(
+                name, resource_type=resource_type, permission_list=permissions,
+            )
+            self.assertIsNotNone(self.role.search(name))
+            # Clone role
+            self.role.clone(name, new_name)
+            self.assertIsNotNone(
+                self.role.wait_until_element(common_locators['alert.success']))
+            self.assertIsNotNone(self.role.search(new_name))
+            # Ensure that cloned role contains correct resource type
+            cloned_resources = self.role.get_resources(new_name)
+            self.assertGreater(len(cloned_resources), 0)
+            self.assertEqual(resource_type, cloned_resources[0])
+            # and all permissions
+            cloned_permissions = self.role.get_permissions(
+                new_name, resource_type)
+            self.assertIsNotNone(cloned_permissions)
+            self.assertEqual(set(permissions), set(cloned_permissions))
+
+    @tier1
+    def test_positive_assign_cloned_role(self):
+        """Clone role and assign it to user
+
+        @id: cbb17f37-9039-4875-981b-1f427b095ed1
+
+        @Assert: User is created successfully
+
+        @BZ: 1353788
+        """
+        user_name = gen_string('alpha')
+        role_name = gen_string('alpha')
+        with Session(self.browser) as session:
+            # Clone one of the builtin roles
+            self.role.navigate_to_entity()
+            self.role.clone(choice(ROLES), role_name)
+            # Create user wit this role
+            self.user.navigate_to_entity()
+            make_user(
+                session, username=user_name, roles=[role_name], edit=True)
+            self.user.search_and_click(user_name)
+            self.user.click(tab_locators['users.tab_roles'])
+            element = self.user.wait_until_element(
+                common_locators['entity_deselect'] % role_name)
+            self.assertIsNotNone(element)
+
+    @tier1
+    def test_positive_delete_cloned(self):
+        """Delete cloned role
+
+        @id: 7f0a595b-2b27-4dca-b15a-02cd2519b2f7
+
+        @Assert: Role is deleted
+
+        @BZ: 1353788
+        """
+        new_name = gen_string('alpha')
+        with Session(self.browser):
+            self.role.clone(choice(ROLES), new_name)
+            self.assertIsNotNone(
+                self.role.wait_until_element(common_locators['alert.success']))
+            self.assertIsNotNone(self.role.search(new_name))
+            self.role.delete(new_name)
 
 
 class CannedRoleTestCases(UITestCase):


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1353788

```python
% pytest -n 2 -v tests/foreman/ui/test_role.py -k 'RoleTestCase and (clone or update_permission) and not Canned'
===================================================================== test session starts =====================================================================
platform linux2 -- Python 2.7.12, pytest-3.0.4, py-1.4.31, pluggy-0.4.0 -- /home/qui/code/venv/2/bin/python2
cachedir: .cache
rootdir: /home/qui/code/robottelo, inifile: 
plugins: xdist-1.15.0, html-1.12.0, cov-2.4.0
[gw0] linux2 Python 2.7.12 cwd: /home/qui/code/robottelo
[gw1] linux2 Python 2.7.12 cwd: /home/qui/code/robottelo
[gw0] Python 2.7.12 (default, Nov  7 2016, 11:55:55)  -- [GCC 6.2.1 20160830]
[gw1] Python 2.7.12 (default, Nov  7 2016, 11:55:55)  -- [GCC 6.2.1 20160830]
gw0 [5] / gw1 [5]
scheduling tests via LoadScheduling

tests/foreman/ui/test_role.py::RoleTestCase::test_positive_assign_cloned_role 
tests/foreman/ui/test_role.py::RoleTestCase::test_positive_clone_builtin 
[gw1] PASSED tests/foreman/ui/test_role.py::RoleTestCase::test_positive_assign_cloned_role 
tests/foreman/ui/test_role.py::RoleTestCase::test_positive_clone_custom 
[gw0] PASSED tests/foreman/ui/test_role.py::RoleTestCase::test_positive_clone_builtin 
[gw1] PASSED tests/foreman/ui/test_role.py::RoleTestCase::test_positive_clone_custom 
tests/foreman/ui/test_role.py::RoleTestCase::test_positive_delete_cloned 
tests/foreman/ui/test_role.py::RoleTestCase::test_positive_update_permission 
[gw1] PASSED tests/foreman/ui/test_role.py::RoleTestCase::test_positive_update_permission 
[gw0] PASSED tests/foreman/ui/test_role.py::RoleTestCase::test_positive_delete_cloned 

================================================================= 5 passed in 141.94 seconds =================================================================
```