### PR TITLE
[6.2.z] Support custom search queries & fix template test

### DIFF
--- a/robottelo/ui/base.py
+++ b/robottelo/ui/base.py
@@ -117,12 +117,17 @@ class Base(object):
         """Helper method to perform the commonly used search then click"""
         return self.click(self.search(element))
 
-    def search(self, element):
+    def search(self, element, _raw_query=None):
         """Uses the search box to locate an element from a list of elements.
 
         :param element: either element name or a tuple, containing element name
             as a first element and all the rest variables required for element
             locator.
+        :param _raw_query: (optional) custom search query. Can be used to find
+            entity by some of its fields (e.g. 'hostgroup = foo' for entity
+            named 'bar') or to combine complex queries (e.g.
+            'name = foo and os = bar'). Note that this will ignore entity's
+            default ``search_key``.
         """
         element_name = element[0] if isinstance(element, tuple) else element
         # Navigate to the page
@@ -154,7 +159,7 @@ class Base(object):
         # Pass the data into search field and push the search button if
         # applicable
         searchbox.clear()
-        searchbox.send_keys(u'{0} = {1}'.format(
+        searchbox.send_keys(_raw_query or u'{0} = {1}'.format(
             search_key, escape_search(element_name)))
         # ensure mouse points at search button and no tooltips are covering it
         # before clicking

--- a/tests/foreman/ui/test_template.py
+++ b/tests/foreman/ui/test_template.py
@@ -341,8 +341,9 @@ class TemplateTestCase(UITestCase):
                 hostgroup=hostgroup.name,
             )
             self.assertIsNotNone(self.template.search(template_name))
-            try:
-                self.template.search_key = 'hostgroup'
-                self.assertIsNotNone(self.template.search(hostgroup.name))
-            finally:
-                self.template.search_key = 'name'
+            self.assertIsNotNone(
+                self.template.search(
+                    template_name,
+                    _raw_query='hostgroup = {}'.format(hostgroup.name)
+                )
+            )


### PR DESCRIPTION
Our searching design with search_key has one serious flaw.
Assume we have template `foo` which is associated with hostgroup `bar`. To find template by hostname we have to change `search_key` to 'hostgroup' and perform `self.template_search('bar')` But, as searching returns element by specified name, this way we do not only change the search query to `hostgroup = 'bar'`, but also are expecting to find the template with name `bar`, not `foo`.

For this case, instead of introducing some optional `expected_name=None` optional arg, i'd like to add a support of custom queries which is very old request (#3066) that satisfies our needs in this case too - it can be used to combine some complex queries like  `name = foo and os = bar` AND adds ability to pass the query different from expected name. Even more - no more ugly workarounds with `try: .. finally: ..` are needed for changing the `search_key`.

As a bonus fixed 1 affected test which would definitely fail as soon as BZ is closed.