### PR TITLE
[6.2.z][Chery-pick]-CLI-API contentview version removal (stubed + imlementation) + conflict resolution

### DIFF
--- a/tests/foreman/api/test_contentviewversion.py
+++ b/tests/foreman/api/test_contentviewversion.py
@@ -484,11 +484,8 @@ class ContentViewVersionDeleteTestCase(APITestCase):
         5. Create an Activation key with the QE environment
         6. Register a content-host using the Activation key
         7. Remove the content view cv1 version from QE environment.
-           The remove environment wizard should propose to replace the current
-           QE environment of cv1 by an other (as QE environment of cv1
-           is attached to a content-host),
-           choose DEV and content view cv1 as a replacement for Content-host
-           and for Activation key.
+           Note - prior removing replace the current QE environment of cv1 by
+           DEV and content view cv1 for Content-host and for Activation key.
         8. Refresh content-host subscription
 
         @Assert:
@@ -526,10 +523,8 @@ class ContentViewVersionDeleteTestCase(APITestCase):
         5. Create an Activation key with the QE environment and cv1
         6. Register a content-host using the Activation key
         7. Delete the content view cv1.
-           The delete content view wizard should propose to replace the current
-           QE environment of cv1 by an other (as QE environment of cv1
-           is attached to a content-host), choose DEV and content view cv2
-           as a replacement for Content-host and for Activation key.
+           Note - prior deleting replace the current QE environment of cv1 by
+           DEV and content view cv2 for Content-host and for Activation key.
         8. Refresh content-host subscription
 
         @Assert:

--- a/tests/foreman/api/test_contentviewversion.py
+++ b/tests/foreman/api/test_contentviewversion.py
@@ -23,7 +23,12 @@ from robottelo.constants import (
     PUPPET_MODULE_NTP_PUPPETLABS,
     ZOO_CUSTOM_GPG_KEY,
 )
-from robottelo.decorators import tier2
+from robottelo.decorators import (
+    run_only_on,
+    stubbed,
+    tier2,
+    tier3,
+)
 from robottelo.helpers import get_data_file, read_data_file
 from robottelo.test import APITestCase
 
@@ -309,6 +314,277 @@ class ContentViewVersionDeleteTestCase(APITestCase):
             content_view.version[0].delete()
         # Make sure that content view version is still present
         self.assertEqual(len(content_view.read().version), 1)
+
+    @stubbed()
+    @run_only_on('sat')
+    @tier2
+    def test_positive_remove_renamed_cv_version_from_default_env(self):
+        """Remove version of renamed content view from Library environment
+
+        @id: 7d5961d0-6a9a-4610-979e-cbc4ddbc50ca
+
+        @Steps:
+
+        1. Create a content view
+        2. Add a yum repo to the content view
+        3. Publish the content view
+        4. Rename the content view
+        5. remove the published version from Library environment
+
+        @Assert: content view version is removed from Library environment
+
+        @caseautomation: notautomated
+
+        @CaseLevel: Integration
+        """
+
+    @stubbed()
+    @run_only_on('sat')
+    @tier2
+    def test_positive_remove_qe_promoted_cv_version_from_default_env(self):
+        """Remove QE promoted content view version from Library environment
+
+        @id: c7795762-93bd-419c-ac49-d10dc26b842b
+
+        @Steps:
+
+        1. Create a content view
+        2. Add docker repo(s) to it
+        3. Publish content view
+        4. Promote the content view version to multiple environments
+           Library -> DEV -> QE
+        5. remove the content view version from Library environment
+
+        @Assert: Content view version exist only in DEV, QE
+        and not in Library
+
+        @caseautomation: notautomated
+
+        @CaseLevel: Integration
+        """
+
+    @stubbed()
+    @run_only_on('sat')
+    @tier2
+    def test_positive_remove_prod_promoted_cv_version_from_default_env(self):
+        """Remove PROD promoted content view version from Library environment
+
+        @id: 24911876-7c2a-4a12-a3aa-98051dfda29d
+
+        @Steps:
+
+        1. Create a content view
+        2. Add yum repositories, puppet modules, docker repositories to CV
+        3. Publish content view
+        4. Promote the content view version to multiple environments
+           Library -> DEV -> QE -> PROD
+        5. remove the content view version from Library environment
+
+        @Assert: Content view version exist only in DEV, QE, PROD
+        and not in Library
+
+        @caseautomation: notautomated
+
+        @CaseLevel: Integration
+        """
+
+    @stubbed()
+    @run_only_on('sat')
+    @tier2
+    def test_positive_remove_cv_version_from_env(self):
+        """Remove promoted content view version from environment
+
+        @id: 17cf18bf-09d5-4641-b0e0-c50e628fa6c8
+
+        @Steps:
+
+        1. Create a content view
+        2. Add a yum repo and a puppet module to the content view
+        3. Publish the content view
+        4. Promote the content view version to multiple environments
+           Library -> DEV -> QE -> STAGE -> PROD
+        5. remove the content view version from PROD environment
+        6. Assert: content view version exists only in Library, DEV, QE, STAGE
+           and not in PROD
+        7. Promote again from STAGE -> PROD
+
+        @Assert: Content view version exist in Library, DEV, QE, STAGE, PROD
+
+        @caseautomation: notautomated
+
+        @CaseLevel: Integration
+        """
+
+    @stubbed()
+    @run_only_on('sat')
+    @tier2
+    def test_positive_remove_cv_version_from_multi_env(self):
+        """Remove promoted content view version from multiple environment
+
+        @id: 18b86a68-8e6a-43ea-b95e-188fba125a26
+
+        @Steps:
+
+        1. Create a content view
+        2. Add a yum repo and a puppet module to the content view
+        3. Publish the content view
+        4. Promote the content view version to multiple environments
+           Library -> DEV -> QE -> STAGE -> PROD
+        5. Remove content view version from QE, STAGE and PROD
+
+        @Assert: Content view version exists only in Library, DEV
+
+        @caseautomation: notautomated
+
+        @CaseLevel: Integration
+        """
+
+    @stubbed()
+    @run_only_on('sat')
+    @tier2
+    def test_positive_delete_cv_promoted_to_multi_env(self):
+        """Delete published content view with version promoted to multiple
+         environments
+
+        @id: c164bd97-e710-4a5a-9c9f-657e6bed804b
+
+        @Steps:
+
+        1. Create a content view
+        2. Add a yum repo and a puppet module to the content view
+        3. Publish the content view
+        4. Promote the content view to multiple environment
+           Library -> DEV -> QE -> STAGE -> PROD
+        5. Delete the content view, this should delete the content with all
+           it's published/promoted versions from all environments
+
+        @Assert: The content view doesn't exists
+
+        @caseautomation: notautomated
+
+        @CaseLevel: Integration
+        """
+
+    @stubbed()
+    @run_only_on('sat')
+    @tier3
+    def test_positive_remove_cv_version_from_env_with_host_registered(self):
+        """Remove promoted content view version from environment that is used
+        in association of an Activation key and content-host registration.
+
+        @id: a5b9ba8b-80e6-4435-bc0a-041b3fda227c
+
+        @Steps:
+
+        1. Create a content view cv1
+        2. Add a yum repo and a puppet module to the content view
+        3. Publish the content view
+        4. Promote the content view to multiple environment
+           Library -> DEV -> QE
+        5. Create an Activation key with the QE environment
+        6. Register a content-host using the Activation key
+        7. Remove the content view cv1 version from QE environment.
+           The remove environment wizard should propose to replace the current
+           QE environment of cv1 by an other (as QE environment of cv1
+           is attached to a content-host),
+           choose DEV and content view cv1 as a replacement for Content-host
+           and for Activation key.
+        8. Refresh content-host subscription
+
+        @Assert:
+
+        1. Activation key exists
+        2. Content-host exists
+        3. QE environment of cv1 was replaced by DEV environment of cv1
+           in activation key
+        4. QE environment of cv1 was replaced by DEV environment of cv1
+           in content-host
+        5. At content-host some package from cv1 is installable
+
+        @caseautomation: notautomated
+
+        @CaseLevel: System
+        """
+
+    @stubbed()
+    @run_only_on('sat')
+    @tier3
+    def test_positive_delete_cv_multi_env_promoted_with_host_registered(self):
+        """Delete published content view with version promoted to multiple
+         environments, with one of the environments used in association of an
+         Activation key and content-host registration.
+
+        @id: 10699af9-617e-4930-9c80-2827a0ba52eb
+
+        @Steps:
+
+        1. Create two content view cv1 and cv2
+        2. Add a yum repo and a puppet module to both content views
+        3. Publish the content views
+        4. Promote the content views to multiple environment
+           Library -> DEV -> QE
+        5. Create an Activation key with the QE environment and cv1
+        6. Register a content-host using the Activation key
+        7. Delete the content view cv1.
+           The delete content view wizard should propose to replace the current
+           QE environment of cv1 by an other (as QE environment of cv1
+           is attached to a content-host), choose DEV and content view cv2
+           as a replacement for Content-host and for Activation key.
+        8. Refresh content-host subscription
+
+        @Assert:
+
+        1. The content view cv1 doesn't exist
+        2. Activation key exists
+        3. Content-host exists
+        4. QE environment of cv1 was replaced by DEV environment of cv2
+           in activation key
+        5. QE environment of cv1 was replaced by DEV environment of cv2
+           in content-host
+        6. At content-host some package from cv2 is installable
+
+        @caseautomation: notautomated
+
+        @CaseLevel: System
+        """
+
+    @stubbed()
+    @run_only_on('sat')
+    @tier3
+    def test_positive_remove_cv_version_from_multi_env_capsule_scenario(self):
+        """Remove promoted content view version from multiple environment,
+        with satellite setup to use capsule
+
+        @id: 1e8a8e64-eec8-49e0-b121-919c53f416d2
+
+        @Steps:
+
+        1. Create a content view
+        2. Setup satellite to use a capsule and to sync all lifecycle
+           environments
+        3. Add a yum repo, puppet module and a docker repo to the content view
+        4. Publish the content view
+        5. Promote the content view to multiple environment
+           Library -> DEV -> QE -> PROD
+        6. Make sure the capsule is updated (content synchronization may be
+           applied)
+        7. Disconnect the capsule
+        8. Remove the content view version from Library and DEV environments
+           and assert successful completion
+        9. Bring the capsule back online and assert that the task is completed
+           in capsule
+        10. Make sure the capsule is updated (content synchronization may be
+            applied)
+
+        @Assert: content view version in capsule is removed from Library
+        and DEV and exists only in QE and PROD
+
+        @caseautomation: notautomated
+
+        @CaseLevel: System
+        """
+        # Note: This test case requires complete external capsule
+        #  configuration.
 
 
 class ContentViewVersionIncrementalTestCase(APITestCase):

--- a/tests/foreman/cli/test_contentview.py
+++ b/tests/foreman/cli/test_contentview.py
@@ -1938,28 +1938,6 @@ class ContentViewTestCase(CLITestCase):
     @stubbed()
     @run_only_on('sat')
     @tier2
-    def test_positive_remove_cv_version_from_default_env(self):
-        """Remove content view version from Library environment
-
-        @id: 308e75df-f872-4a87-a5af-5f3b5b076822
-
-        @Steps:
-
-        1. Create a content view
-        2. Add a yum repo to it
-        3. Publish content view
-        4. remove the published version from Library environment
-
-        @Assert: content view version is removed from Library environment
-
-        @caseautomation: notautomated
-
-        @CaseLevel: Integration
-        """
-
-    @stubbed()
-    @run_only_on('sat')
-    @tier2
     def test_positive_remove_renamed_cv_version_from_default_env(self):
         """Remove version of renamed content view from Library environment
 
@@ -2123,8 +2101,8 @@ class ContentViewTestCase(CLITestCase):
         3. Publish the content view
         4. Promote the content view to multiple environment
            Library -> DEV -> QE -> STAGE -> PROD
-        5. Delete the content view, this should delete the content with all
-           it's published/promoted versions from all environments
+        5. Delete the content view
+           (may delete the published versions environments prior this step)
 
         @Assert: The content view doesn't exists
 
@@ -2152,11 +2130,8 @@ class ContentViewTestCase(CLITestCase):
         5. Create an Activation key with the QE environment
         6. Register a content-host using the Activation key
         7. Remove the content view cv1 version from QE environment.
-           The remove environment wizard should propose to replace the current
-           QE environment of cv1 by an other (as QE environment of cv1
-           is attached to a content-host),
-           choose DEV and content view cv1 as a replacement for Content-host
-           and for Activation key.
+           Note - prior removing replace the current QE environment of cv1 by
+           DEV and content view cv1 for Content-host and for Activation key.
         8. Refresh content-host subscription
 
         @Assert:
@@ -2194,10 +2169,8 @@ class ContentViewTestCase(CLITestCase):
         5. Create an Activation key with the QE environment and cv1
         6. Register a content-host using the Activation key
         7. Delete the content view cv1.
-           The delete content view wizard should propose to replace the current
-           QE environment of cv1 by an other (as QE environment of cv1
-           is attached to a content-host), choose DEV and content view cv2
-           as a replacement for Content-host and for Activation key.
+           Note - prior deleting replace the current QE environment of cv1 by
+           DEV and content view cv2 for Content-host and for Activation key.
         8. Refresh content-host subscription
 
         @Assert:

--- a/tests/foreman/cli/test_contentview.py
+++ b/tests/foreman/cli/test_contentview.py
@@ -1935,6 +1935,325 @@ class ContentViewTestCase(CLITestCase):
 
         """
 
+    @stubbed()
+    @run_only_on('sat')
+    @tier2
+    def test_positive_remove_cv_version_from_default_env(self):
+        """Remove content view version from Library environment
+
+        @id: 308e75df-f872-4a87-a5af-5f3b5b076822
+
+        @Steps:
+
+        1. Create a content view
+        2. Add a yum repo to it
+        3. Publish content view
+        4. remove the published version from Library environment
+
+        @Assert: content view version is removed from Library environment
+
+        @caseautomation: notautomated
+
+        @CaseLevel: Integration
+        """
+
+    @stubbed()
+    @run_only_on('sat')
+    @tier2
+    def test_positive_remove_renamed_cv_version_from_default_env(self):
+        """Remove version of renamed content view from Library environment
+
+        @id: aa9bbfda-72e8-45ec-b26d-fdf2691980cf
+
+        @Steps:
+
+        1. Create a content view
+        2. Add a yum repo to the content view
+        3. Publish the content view
+        4. Rename the content view
+        5. remove the published version from Library environment
+
+        @Assert: content view version is removed from Library environment
+
+        @caseautomation: notautomated
+
+        @CaseLevel: Integration
+        """
+
+    @stubbed()
+    @run_only_on('sat')
+    @tier2
+    def test_positive_remove_promoted_cv_version_from_default_env(self):
+        """Remove promoted content view version from Library environment
+
+        @id: 6643837a-560a-47de-aa4d-90778914dcfa
+
+        @Steps:
+
+        1. Create a content view
+        2. Add a puppet module(s) to the content view
+        3. Publish the content view
+        4. Promote the content view version from Library -> DEV
+        5. remove the content view version from Library environment
+
+        @Assert:
+
+        1. Content view version exist only in DEV and not in Library
+        2. The puppet module(s) exists in content view version
+
+        @caseautomation: notautomated
+
+        @CaseLevel: Integration
+        """
+
+    @stubbed()
+    @run_only_on('sat')
+    @tier2
+    def test_positive_remove_qe_promoted_cv_version_from_default_env(self):
+        """Remove QE promoted content view version from Library environment
+
+        @id: e286697f-4113-40a3-b8e8-9ca50647e6d5
+
+        @Steps:
+
+        1. Create a content view
+        2. Add docker repo(s) to it
+        3. Publish content view
+        4. Promote the content view version to multiple environments
+           Library -> DEV -> QE
+        5. remove the content view version from Library environment
+
+        @Assert: Content view version exist only in DEV, QE
+        and not in Library
+
+        @caseautomation: notautomated
+
+        @CaseLevel: Integration
+        """
+
+    @stubbed()
+    @run_only_on('sat')
+    @tier2
+    def test_positive_remove_prod_promoted_cv_version_from_default_env(self):
+        """Remove PROD promoted content view version from Library environment
+
+        @id: ffe3d64e-c3d2-4889-9454-ccc6b10f4db7
+
+        @Steps:
+
+        1. Create a content view
+        2. Add yum repositories, puppet modules, docker repositories to CV
+        3. Publish content view
+        4. Promote the content view version to multiple environments
+           Library -> DEV -> QE -> PROD
+        5. remove the content view version from Library environment
+
+        @Assert: Content view version exist only in DEV, QE, PROD
+        and not in Library
+
+        @caseautomation: notautomated
+
+        @CaseLevel: Integration
+        """
+
+    @stubbed()
+    @run_only_on('sat')
+    @tier2
+    def test_positive_remove_cv_version_from_env(self):
+        """Remove promoted content view version from environment
+
+        @id: 577757ac-b184-4ece-9310-182dd5ceb718
+
+        @Steps:
+
+        1. Create a content view
+        2. Add a yum repo and a puppet module to the content view
+        3. Publish the content view
+        4. Promote the content view version to multiple environments
+           Library -> DEV -> QE -> STAGE -> PROD
+        5. remove the content view version from PROD environment
+        6. Assert: content view version exists only in Library, DEV, QE, STAGE
+           and not in PROD
+        7. Promote again from STAGE -> PROD
+
+        @Assert: Content view version exist in Library, DEV, QE, STAGE, PROD
+
+        @caseautomation: notautomated
+
+        @CaseLevel: Integration
+        """
+
+    @stubbed()
+    @run_only_on('sat')
+    @tier2
+    def test_positive_remove_cv_version_from_multi_env(self):
+        """Remove promoted content view version from multiple environment
+
+        @id: 997cfd7d-9029-47e2-a41e-84f4370b5ce5
+
+        @Steps:
+
+        1. Create a content view
+        2. Add a yum repo and a puppet module to the content view
+        3. Publish the content view
+        4. Promote the content view version to multiple environments
+           Library -> DEV -> QE -> STAGE -> PROD
+        5. Remove content view version from QE, STAGE and PROD
+
+        @Assert: Content view version exists only in Library, DEV
+
+        @caseautomation: notautomated
+
+        @CaseLevel: Integration
+        """
+
+    @stubbed()
+    @run_only_on('sat')
+    @tier2
+    def test_positive_delete_cv_promoted_to_multi_env(self):
+        """Delete published content view with version promoted to multiple
+         environments
+
+        @id: 93dd7518-5901-4a71-a4c3-0f1215238b26
+
+        @Steps:
+
+        1. Create a content view
+        2. Add a yum repo and a puppet module to the content view
+        3. Publish the content view
+        4. Promote the content view to multiple environment
+           Library -> DEV -> QE -> STAGE -> PROD
+        5. Delete the content view, this should delete the content with all
+           it's published/promoted versions from all environments
+
+        @Assert: The content view doesn't exists
+
+        @caseautomation: notautomated
+
+        @CaseLevel: Integration
+        """
+
+    @stubbed()
+    @run_only_on('sat')
+    @tier3
+    def test_positive_remove_cv_version_from_env_with_host_registered(self):
+        """Remove promoted content view version from environment that is used
+        in association of an Activation key and content-host registration.
+
+        @id: 001a2b76-a87b-4c11-8837-f5fe3c04a075
+
+        @Steps:
+
+        1. Create a content view cv1
+        2. Add a yum repo and a puppet module to the content view
+        3. Publish the content view
+        4. Promote the content view to multiple environment
+           Library -> DEV -> QE
+        5. Create an Activation key with the QE environment
+        6. Register a content-host using the Activation key
+        7. Remove the content view cv1 version from QE environment.
+           The remove environment wizard should propose to replace the current
+           QE environment of cv1 by an other (as QE environment of cv1
+           is attached to a content-host),
+           choose DEV and content view cv1 as a replacement for Content-host
+           and for Activation key.
+        8. Refresh content-host subscription
+
+        @Assert:
+
+        1. Activation key exists
+        2. Content-host exists
+        3. QE environment of cv1 was replaced by DEV environment of cv1
+           in activation key
+        4. QE environment of cv1 was replaced by DEV environment of cv1
+           in content-host
+        5. At content-host some package from cv1 is installable
+
+        @caseautomation: notautomated
+
+        @CaseLevel: System
+        """
+
+    @stubbed()
+    @run_only_on('sat')
+    @tier3
+    def test_positive_delete_cv_multi_env_promoted_with_host_registered(self):
+        """Delete published content view with version promoted to multiple
+         environments, with one of the environments used in association of an
+         Activation key and content-host registration.
+
+        @id: 82442d23-45b5-4d39-b867-c5d46bbcbbf9
+
+        @Steps:
+
+        1. Create two content view cv1 and cv2
+        2. Add a yum repo and a puppet module to both content views
+        3. Publish the content views
+        4. Promote the content views to multiple environment
+           Library -> DEV -> QE
+        5. Create an Activation key with the QE environment and cv1
+        6. Register a content-host using the Activation key
+        7. Delete the content view cv1.
+           The delete content view wizard should propose to replace the current
+           QE environment of cv1 by an other (as QE environment of cv1
+           is attached to a content-host), choose DEV and content view cv2
+           as a replacement for Content-host and for Activation key.
+        8. Refresh content-host subscription
+
+        @Assert:
+
+        1. The content view cv1 doesn't exist
+        2. Activation key exists
+        3. Content-host exists
+        4. QE environment of cv1 was replaced by DEV environment of cv2
+           in activation key
+        5. QE environment of cv1 was replaced by DEV environment of cv2
+           in content-host
+        6. At content-host some package from cv2 is installable
+
+        @caseautomation: notautomated
+
+        @CaseLevel: System
+        """
+
+    @stubbed()
+    @run_only_on('sat')
+    @tier3
+    def test_positive_remove_cv_version_from_multi_env_capsule_scenario(self):
+        """Remove promoted content view version from multiple environment,
+        with satellite setup to use capsule
+
+        @id: 3725fef6-73a4-4dcb-a306-70e6ba826a3d
+
+        @Steps:
+
+        1. Create a content view
+        2. Setup satellite to use a capsule and to sync all lifecycle
+           environments
+        3. Add a yum repo, puppet module and a docker repo to the content view
+        4. Publish the content view
+        5. Promote the content view to multiple environment
+           Library -> DEV -> QE -> PROD
+        6. Make sure the capsule is updated (content synchronization may be
+           applied)
+        7. Disconnect the capsule
+        8. Remove the content view version from Library and DEV environments
+           and assert successful completion
+        9. Bring the capsule back online and assert that the task is completed
+           in capsule
+        10. Make sure the capsule is updated (content synchronization may be
+            applied)
+
+        @Assert: content view version in capsule is removed from Library
+        and DEV and exists only in QE and PROD
+
+        @caseautomation: notautomated
+
+        @CaseLevel: System
+        """
+        # Note: This test case requires complete external capsule
+        #  configuration.
+
     # ROLES TESTING
 
     # pylint: disable=unexpected-keyword-arg

--- a/tests/foreman/cli/test_contentview.py
+++ b/tests/foreman/cli/test_contentview.py
@@ -37,8 +37,11 @@ from robottelo.cli.puppetmodule import PuppetModule
 from robottelo.cli.subscription import Subscription
 from robottelo.constants import (
     DEFAULT_CV,
+    DOCKER_REGISTRY_HUB,
+    DOCKER_UPSTREAM_NAME,
     ENVIRONMENT,
     FAKE_0_PUPPET_REPO,
+    FAKE_1_YUM_REPO,
     PRDS,
     REPOS,
     REPOSET,
@@ -107,6 +110,18 @@ class ContentViewTestCase(CLITestCase):
             # propagate.
             ContentViewTestCase.rhel_content_org = None
             raise
+
+    @staticmethod
+    def _get_content_view_version_lce_names_set(content_view_id, version_id):
+        """returns a set of content view version lifecycle environment names
+
+        :rtype: set
+        """
+        lifecycle_environments = ContentView.version_info({
+            'content-view-id': content_view_id,
+            'id': version_id
+        })['lifecycle-environments']
+        return {lce['name'] for lce in lifecycle_environments}
 
     # pylint: disable=unexpected-keyword-arg
     def setUp(self):
@@ -1935,7 +1950,6 @@ class ContentViewTestCase(CLITestCase):
 
         """
 
-    @stubbed()
     @run_only_on('sat')
     @tier2
     def test_positive_remove_renamed_cv_version_from_default_env(self):
@@ -1953,12 +1967,60 @@ class ContentViewTestCase(CLITestCase):
 
         @Assert: content view version is removed from Library environment
 
-        @caseautomation: notautomated
-
         @CaseLevel: Integration
         """
+        new_name = gen_string('alpha')
+        org = make_org()
+        custom_yum_product = make_product({u'organization-id': org['id']})
+        custom_yum_repo = make_repository({
+            u'content-type': 'yum',
+            u'product-id': custom_yum_product['id'],
+            u'url': FAKE_1_YUM_REPO,
+        })
+        Repository.synchronize({'id': custom_yum_repo['id']})
+        content_view = make_content_view({u'organization-id': org['id']})
+        ContentView.add_repository({
+            'id': content_view['id'],
+            'organization-id': org['id'],
+            'repository-id': custom_yum_repo['id'],
+        })
+        ContentView.publish({u'id': content_view['id']})
+        # ensure that the published content version is in Library environment
+        content_view_versions = ContentView.info({
+            u'id': content_view['id']
+        })['versions']
+        self.assertGreater(len(content_view_versions), 0)
+        content_view_version = content_view_versions[-1]
+        self.assertIn(
+            ENVIRONMENT,
+            self._get_content_view_version_lce_names_set(
+                content_view['id'],
+                content_view_version['id']
+            )
+        )
+        # rename the content view
+        ContentView.update({
+            'id': content_view['id'],
+            'new-name': new_name
+        })
+        content_view = ContentView.info({'id': content_view['id']})
+        self.assertEqual(new_name, content_view['name'])
+        # remove content view version from Library lifecycle environment
+        ContentView.remove_from_environment({
+            'id': content_view['id'],
+            'organization-id': org['id'],
+            'lifecycle-environment': ENVIRONMENT
+        })
+        # ensure that the published content version is not in Library
+        # environment
+        self.assertNotIn(
+            ENVIRONMENT,
+            self._get_content_view_version_lce_names_set(
+                content_view['id'],
+                content_view_version['id']
+            )
+        )
 
-    @stubbed()
     @run_only_on('sat')
     @tier2
     def test_positive_remove_promoted_cv_version_from_default_env(self):
@@ -1979,12 +2041,84 @@ class ContentViewTestCase(CLITestCase):
         1. Content view version exist only in DEV and not in Library
         2. The puppet module(s) exists in content view version
 
-        @caseautomation: notautomated
-
         @CaseLevel: Integration
         """
+        org = make_org()
+        lce_dev = make_lifecycle_environment({'organization-id': org['id']})
+        puppet_product = make_product({u'organization-id': org['id']})
+        puppet_repository = make_repository({
+            u'content-type': u'puppet',
+            u'product-id': puppet_product['id'],
+            u'url': FAKE_0_PUPPET_REPO,
+        })
+        Repository.synchronize({'id': puppet_repository['id']})
+        puppet_modules = PuppetModule.list({
+            u'repository-id': puppet_repository['id'],
+            u'per-page': False,
+        })
+        self.assertGreater(len(puppet_modules), 0)
+        puppet_module = random.choice(puppet_modules)
+        content_view = make_content_view({u'organization-id': org['id']})
+        ContentView.puppet_module_add({
+            u'content-view-id': content_view['id'],
+            u'uuid': puppet_module['uuid'],
+        })
+        ContentView.publish({u'id': content_view['id']})
+        content_view_versions = ContentView.info({
+            u'id': content_view['id']
+        })['versions']
+        self.assertGreater(len(content_view_versions), 0)
+        content_view_version = content_view_versions[-1]
+        ContentView.version_promote({
+            'id': content_view_version['id'],
+            'to-lifecycle-environment-id': lce_dev['id']
+        })
+        # ensure that the published content version is in Library and DEV
+        # environments
+        content_view_version_info = ContentView.version_info({
+            'organization-id': org['id'],
+            'content-view-id': content_view['id'],
+            'id': content_view_version['id']
+        })
+        content_view_version_lce_names = {
+            lce['name']
+            for lce in content_view_version_info['lifecycle-environments']
+        }
+        self.assertEqual(
+            {ENVIRONMENT, lce_dev['name']},
+            content_view_version_lce_names
+        )
+        initial_puppet_modules_ids = {
+            puppet_module['id']
+            for puppet_module in content_view_version_info.get(
+                'puppet-modules', [])
+        }
+        self.assertGreater(len(initial_puppet_modules_ids), 0)
+        # remove content view version from Library lifecycle environment
+        ContentView.remove_from_environment({
+            'id': content_view['id'],
+            'organization-id': org['id'],
+            'lifecycle-environment': ENVIRONMENT
+        })
+        # ensure content view version not in Library and only in DEV
+        # environment and that puppet module still exist
+        content_view_version_info = ContentView.version_info({
+            'organization-id': org['id'],
+            'content-view-id': content_view['id'],
+            'id': content_view_version['id']
+        })
+        content_view_version_lce_names = {
+            lce['name']
+            for lce in content_view_version_info['lifecycle-environments']
+        }
+        self.assertEqual({lce_dev['name']}, content_view_version_lce_names)
+        puppet_modules_ids = {
+                puppet_module['id']
+                for puppet_module in content_view_version_info.get(
+                    'puppet-modules', [])
+        }
+        self.assertEqual(initial_puppet_modules_ids, puppet_modules_ids)
 
-    @stubbed()
     @run_only_on('sat')
     @tier2
     def test_positive_remove_qe_promoted_cv_version_from_default_env(self):
@@ -2004,12 +2138,65 @@ class ContentViewTestCase(CLITestCase):
         @Assert: Content view version exist only in DEV, QE
         and not in Library
 
-        @caseautomation: notautomated
-
         @CaseLevel: Integration
         """
+        org = make_org()
+        lce_dev = make_lifecycle_environment({'organization-id': org['id']})
+        lce_qe = make_lifecycle_environment({
+            'organization-id': org['id'],
+            'prior': lce_dev['name']
+        })
+        docker_product = make_product({u'organization-id': org['id']})
+        docker_repository = make_repository({
+            'content-type': 'docker',
+            'docker-upstream-name': DOCKER_UPSTREAM_NAME,
+            'name': gen_string('alpha', 20),
+            'product-id': docker_product['id'],
+            'url': DOCKER_REGISTRY_HUB,
+        })
+        Repository.synchronize({'id': docker_repository['id']})
+        content_view = make_content_view({u'organization-id': org['id']})
+        ContentView.add_repository({
+            'id': content_view['id'],
+            'organization-id': org['id'],
+            'repository-id': docker_repository['id'],
+        })
+        ContentView.publish({u'id': content_view['id']})
+        content_view_versions = ContentView.info({
+            u'id': content_view['id']
+        })['versions']
+        self.assertGreater(len(content_view_versions), 0)
+        content_view_version = content_view_versions[-1]
+        for lce in [lce_dev, lce_qe]:
+            ContentView.version_promote({
+                'id': content_view_version['id'],
+                'to-lifecycle-environment-id': lce['id']
+            })
+        # ensure that the published content version is in Library, DEV and QE
+        # environments
+        self.assertEqual(
+            {ENVIRONMENT, lce_dev['name'], lce_qe['name']},
+            self._get_content_view_version_lce_names_set(
+                content_view['id'],
+                content_view_version['id']
+            )
+        )
+        # remove content view version from Library lifecycle environment
+        ContentView.remove_from_environment({
+            'id': content_view['id'],
+            'organization-id': org['id'],
+            'lifecycle-environment': ENVIRONMENT
+        })
+        # ensure content view version is not in Library and only in DEV and QE
+        # environments
+        self.assertEqual(
+            {lce_dev['name'], lce_qe['name']},
+            self._get_content_view_version_lce_names_set(
+                content_view['id'],
+                content_view_version['id']
+            )
+        )
 
-    @stubbed()
     @run_only_on('sat')
     @tier2
     def test_positive_remove_prod_promoted_cv_version_from_default_env(self):
@@ -2029,12 +2216,94 @@ class ContentViewTestCase(CLITestCase):
         @Assert: Content view version exist only in DEV, QE, PROD
         and not in Library
 
-        @caseautomation: notautomated
-
         @CaseLevel: Integration
         """
+        org = make_org()
+        lce_dev = make_lifecycle_environment({'organization-id': org['id']})
+        lce_qe = make_lifecycle_environment({
+            'organization-id': org['id'],
+            'prior': lce_dev['name']
+        })
+        lce_prod = make_lifecycle_environment({
+            'organization-id': org['id'],
+            'prior': lce_qe['name']
+        })
+        custom_yum_product = make_product({u'organization-id': org['id']})
+        custom_yum_repo = make_repository({
+            u'content-type': 'yum',
+            u'product-id': custom_yum_product['id'],
+            u'url': FAKE_1_YUM_REPO,
+        })
+        Repository.synchronize({'id': custom_yum_repo['id']})
+        puppet_product = make_product({u'organization-id': org['id']})
+        puppet_repository = make_repository({
+            u'content-type': u'puppet',
+            u'product-id': puppet_product['id'],
+            u'url': FAKE_0_PUPPET_REPO,
+        })
+        Repository.synchronize({'id': puppet_repository['id']})
+        puppet_modules = PuppetModule.list({
+            u'repository-id': puppet_repository['id'],
+            u'per-page': False,
+        })
+        self.assertGreater(len(puppet_modules), 0)
+        puppet_module = random.choice(puppet_modules)
+        docker_product = make_product({u'organization-id': org['id']})
+        docker_repository = make_repository({
+            'content-type': 'docker',
+            'docker-upstream-name': DOCKER_UPSTREAM_NAME,
+            'name': gen_string('alpha', 20),
+            'product-id': docker_product['id'],
+            'url': DOCKER_REGISTRY_HUB,
+        })
+        Repository.synchronize({'id': docker_repository['id']})
+        content_view = make_content_view({u'organization-id': org['id']})
+        for repo in [custom_yum_repo, docker_repository]:
+            ContentView.add_repository({
+                'id': content_view['id'],
+                'organization-id': org['id'],
+                'repository-id': repo['id'],
+            })
+        ContentView.puppet_module_add({
+            u'content-view-id': content_view['id'],
+            u'uuid': puppet_module['uuid'],
+        })
+        ContentView.publish({u'id': content_view['id']})
+        content_view_versions = ContentView.info({
+            u'id': content_view['id']
+        })['versions']
+        self.assertGreater(len(content_view_versions), 0)
+        content_view_version = content_view_versions[-1]
+        for lce in [lce_dev, lce_qe, lce_prod]:
+            ContentView.version_promote({
+                'id': content_view_version['id'],
+                'to-lifecycle-environment-id': lce['id']
+            })
+        # ensure that the published content version is in Library, DEV, QE and
+        # PROD environments
+        self.assertEqual(
+            {ENVIRONMENT, lce_dev['name'], lce_qe['name'], lce_prod['name']},
+            self._get_content_view_version_lce_names_set(
+                content_view['id'],
+                content_view_version['id']
+            )
+        )
+        # remove content view version from Library lifecycle environment
+        ContentView.remove_from_environment({
+            'id': content_view['id'],
+            'organization-id': org['id'],
+            'lifecycle-environment': ENVIRONMENT
+        })
+        # ensure content view version is not in Library and only in DEV, QE
+        # and PROD environments
+        self.assertEqual(
+            {lce_dev['name'], lce_qe['name'], lce_prod['name']},
+            self._get_content_view_version_lce_names_set(
+                content_view['id'],
+                content_view_version['id']
+            )
+        )
 
-    @stubbed()
     @run_only_on('sat')
     @tier2
     def test_positive_remove_cv_version_from_env(self):
@@ -2056,12 +2325,102 @@ class ContentViewTestCase(CLITestCase):
 
         @Assert: Content view version exist in Library, DEV, QE, STAGE, PROD
 
-        @caseautomation: notautomated
-
         @CaseLevel: Integration
         """
+        org = make_org()
+        lce_dev = make_lifecycle_environment({'organization-id': org['id']})
+        lce_qe = make_lifecycle_environment({
+            'organization-id': org['id'],
+            'prior': lce_dev['name']
+        })
+        lce_stage = make_lifecycle_environment({
+            'organization-id': org['id'],
+            'prior': lce_qe['name']
+        })
+        lce_prod = make_lifecycle_environment({
+            'organization-id': org['id'],
+            'prior': lce_stage['name']
+        })
+        custom_yum_product = make_product({u'organization-id': org['id']})
+        custom_yum_repo = make_repository({
+            u'content-type': 'yum',
+            u'product-id': custom_yum_product['id'],
+            u'url': FAKE_1_YUM_REPO,
+        })
+        Repository.synchronize({'id': custom_yum_repo['id']})
+        puppet_product = make_product({u'organization-id': org['id']})
+        puppet_repository = make_repository({
+            u'content-type': u'puppet',
+            u'product-id': puppet_product['id'],
+            u'url': FAKE_0_PUPPET_REPO,
+        })
+        Repository.synchronize({'id': puppet_repository['id']})
+        puppet_modules = PuppetModule.list({
+            u'repository-id': puppet_repository['id'],
+            u'per-page': False,
+        })
+        self.assertGreater(len(puppet_modules), 0)
+        puppet_module = random.choice(puppet_modules)
+        content_view = make_content_view({u'organization-id': org['id']})
+        ContentView.add_repository({
+            'id': content_view['id'],
+            'organization-id': org['id'],
+            'repository-id': custom_yum_repo['id'],
+        })
+        ContentView.puppet_module_add({
+            u'content-view-id': content_view['id'],
+            u'uuid': puppet_module['uuid'],
+        })
+        ContentView.publish({u'id': content_view['id']})
+        content_view_versions = ContentView.info({
+            u'id': content_view['id']
+        })['versions']
+        self.assertGreater(len(content_view_versions), 0)
+        content_view_version = content_view_versions[-1]
+        for lce in [lce_dev, lce_qe, lce_stage, lce_prod]:
+            ContentView.version_promote({
+                'id': content_view_version['id'],
+                'to-lifecycle-environment-id': lce['id']
+            })
+        # ensure that the published content version is in Library, DEV, QE,
+        # STAGE and PROD environments
+        self.assertEqual(
+            {ENVIRONMENT, lce_dev['name'], lce_qe['name'], lce_stage['name'],
+             lce_prod['name']},
+            self._get_content_view_version_lce_names_set(
+                content_view['id'],
+                content_view_version['id']
+            )
+        )
+        # remove content view version from PROD lifecycle environment
+        ContentView.remove_from_environment({
+            'id': content_view['id'],
+            'organization-id': org['id'],
+            'lifecycle-environment': lce_prod['name']
+        })
+        # ensure content view version is not in PROD and only in Library, DEV,
+        # QE and STAGE environments
+        self.assertEqual(
+            {ENVIRONMENT, lce_dev['name'], lce_qe['name'], lce_stage['name']},
+            self._get_content_view_version_lce_names_set(
+                content_view['id'],
+                content_view_version['id']
+            )
+        )
+        # promote content view version to PROD environment again
+        ContentView.version_promote({
+            'id': content_view_version['id'],
+            'to-lifecycle-environment-id': lce_prod['id']
+        })
+        self.assertEqual(
+            {ENVIRONMENT, lce_dev['name'], lce_qe['name'], lce_stage['name'],
+             lce_prod['name']},
+            self._get_content_view_version_lce_names_set(
+                content_view['id'],
+                content_view_version['id']
+            )
+        )
 
-    @stubbed()
     @run_only_on('sat')
     @tier2
     def test_positive_remove_cv_version_from_multi_env(self):
@@ -2080,12 +2439,91 @@ class ContentViewTestCase(CLITestCase):
 
         @Assert: Content view version exists only in Library, DEV
 
-        @caseautomation: notautomated
-
         @CaseLevel: Integration
         """
+        org = make_org()
+        lce_dev = make_lifecycle_environment({'organization-id': org['id']})
+        lce_qe = make_lifecycle_environment({
+            'organization-id': org['id'],
+            'prior': lce_dev['name']
+        })
+        lce_stage = make_lifecycle_environment({
+            'organization-id': org['id'],
+            'prior': lce_qe['name']
+        })
+        lce_prod = make_lifecycle_environment({
+            'organization-id': org['id'],
+            'prior': lce_stage['name']
+        })
+        custom_yum_product = make_product({u'organization-id': org['id']})
+        custom_yum_repo = make_repository({
+            u'content-type': 'yum',
+            u'product-id': custom_yum_product['id'],
+            u'url': FAKE_1_YUM_REPO,
+        })
+        Repository.synchronize({'id': custom_yum_repo['id']})
+        puppet_product = make_product({u'organization-id': org['id']})
+        puppet_repository = make_repository({
+            u'content-type': u'puppet',
+            u'product-id': puppet_product['id'],
+            u'url': FAKE_0_PUPPET_REPO,
+        })
+        Repository.synchronize({'id': puppet_repository['id']})
+        puppet_modules = PuppetModule.list({
+            u'repository-id': puppet_repository['id'],
+            u'per-page': False,
+        })
+        self.assertGreater(len(puppet_modules), 0)
+        puppet_module = random.choice(puppet_modules)
+        content_view = make_content_view({u'organization-id': org['id']})
+        ContentView.add_repository({
+            'id': content_view['id'],
+            'organization-id': org['id'],
+            'repository-id': custom_yum_repo['id'],
+        })
+        ContentView.puppet_module_add({
+            u'content-view-id': content_view['id'],
+            u'uuid': puppet_module['uuid'],
+        })
+        ContentView.publish({u'id': content_view['id']})
+        content_view_versions = ContentView.info({
+            u'id': content_view['id']
+        })['versions']
+        self.assertGreater(len(content_view_versions), 0)
+        content_view_version = content_view_versions[-1]
+        for lce in [lce_dev, lce_qe, lce_stage, lce_prod]:
+            ContentView.version_promote({
+                'id': content_view_version['id'],
+                'to-lifecycle-environment-id': lce['id']
+            })
+        # ensure that the published content version is in Library, DEV, QE,
+        # STAGE and PROD environments
+        self.assertEqual(
+            {ENVIRONMENT, lce_dev['name'], lce_qe['name'], lce_stage['name'],
+             lce_prod['name']},
+            self._get_content_view_version_lce_names_set(
+                content_view['id'],
+                content_view_version['id']
+            )
+        )
+        # remove content view version from QE, STAGE, PROD lifecycle
+        # environments
+        for lce in [lce_qe, lce_stage, lce_prod]:
+            ContentView.remove_from_environment({
+                'id': content_view['id'],
+                'organization-id': org['id'],
+                'lifecycle-environment': lce['name']
+            })
+        # ensure content view version is not in PROD and only in Library, DEV,
+        # QE and STAGE environments
+        self.assertEqual(
+            {ENVIRONMENT, lce_dev['name']},
+            self._get_content_view_version_lce_names_set(
+                content_view['id'],
+                content_view_version['id']
+            )
+        )
 
-    @stubbed()
     @run_only_on('sat')
     @tier2
     def test_positive_delete_cv_promoted_to_multi_env(self):
@@ -2106,10 +2544,95 @@ class ContentViewTestCase(CLITestCase):
 
         @Assert: The content view doesn't exists
 
-        @caseautomation: notautomated
-
         @CaseLevel: Integration
         """
+        org = make_org()
+        lce_dev = make_lifecycle_environment({'organization-id': org['id']})
+        lce_qe = make_lifecycle_environment({
+            'organization-id': org['id'],
+            'prior': lce_dev['name']
+        })
+        lce_stage = make_lifecycle_environment({
+            'organization-id': org['id'],
+            'prior': lce_qe['name']
+        })
+        lce_prod = make_lifecycle_environment({
+            'organization-id': org['id'],
+            'prior': lce_stage['name']
+        })
+        custom_yum_product = make_product({u'organization-id': org['id']})
+        custom_yum_repo = make_repository({
+            u'content-type': 'yum',
+            u'product-id': custom_yum_product['id'],
+            u'url': FAKE_1_YUM_REPO,
+        })
+        Repository.synchronize({'id': custom_yum_repo['id']})
+        puppet_product = make_product({u'organization-id': org['id']})
+        puppet_repository = make_repository({
+            u'content-type': u'puppet',
+            u'product-id': puppet_product['id'],
+            u'url': FAKE_0_PUPPET_REPO,
+        })
+        Repository.synchronize({'id': puppet_repository['id']})
+        puppet_modules = PuppetModule.list({
+            u'repository-id': puppet_repository['id'],
+            u'per-page': False,
+        })
+        self.assertGreater(len(puppet_modules), 0)
+        puppet_module = random.choice(puppet_modules)
+        content_view = make_content_view({u'organization-id': org['id']})
+        ContentView.add_repository({
+            'id': content_view['id'],
+            'organization-id': org['id'],
+            'repository-id': custom_yum_repo['id'],
+        })
+        ContentView.puppet_module_add({
+            u'content-view-id': content_view['id'],
+            u'uuid': puppet_module['uuid'],
+        })
+        ContentView.publish({u'id': content_view['id']})
+        content_view_versions = ContentView.info({
+            u'id': content_view['id']
+        })['versions']
+        self.assertGreater(len(content_view_versions), 0)
+        content_view_version = content_view_versions[-1]
+        for lce in [lce_dev, lce_qe, lce_stage, lce_prod]:
+            ContentView.version_promote({
+                'id': content_view_version['id'],
+                'to-lifecycle-environment-id': lce['id']
+            })
+        # ensure that the published content version is in Library, DEV, QE,
+        # STAGE and PROD environments
+        promoted_lce_names_set = self._get_content_view_version_lce_names_set(
+                content_view['id'],
+                content_view_version['id']
+            )
+        self.assertEqual(
+            {ENVIRONMENT, lce_dev['name'], lce_qe['name'], lce_stage['name'],
+             lce_prod['name']},
+            promoted_lce_names_set
+        )
+        # remove from all promoted lifecycle environments
+        for lce_name in promoted_lce_names_set:
+            ContentView.remove_from_environment({
+                'id': content_view['id'],
+                'organization-id': org['id'],
+                'lifecycle-environment': lce_name
+            })
+        # ensure content view in content views list
+        content_views = ContentView.list({'organization-id': org['id']})
+        self.assertIn(
+            content_view['name'],
+            [cv['name'] for cv in content_views]
+        )
+        # delete the content view
+        ContentView.delete({'id': content_view['id']})
+        # ensure the content view is not in content views list
+        content_views = ContentView.list({'organization-id': org['id']})
+        self.assertNotIn(
+            content_view['name'],
+            [cv['name'] for cv in content_views]
+        )
 
     @stubbed()
     @run_only_on('sat')


### PR DESCRIPTION
```console
dlezz@elysion:~/projects/robottelo-fork$ py.test tests/foreman/cli/test_contentview.py -v -k "test_positive_delete_cv_promoted_to_multi_env or test_positive_remove_cv_version_from_env or test_positive_remove_cv_version_from_multi_env or test_positive_remove_prod_promoted_cv_version_from_default_env or test_positive_remove_promoted_cv_version_from_default_env or test_positive_remove_qe_promoted_cv_version_from_default_env or test_positive_remove_renamed_cv_version_from_default_env"
================================================= test session starts ==================================================
platform linux2 -- Python 2.7.12, pytest-2.9.2, py-1.4.32, pluggy-0.3.1 -- /home/dlezz/bin/redhat/6.2.z/python/2.7/bin/python2.7
cachedir: .cache
rootdir: /home/dlezz/projects/robottelo-fork, inifile: 
plugins: xdist-1.14, cov-2.3.1
collected 59 items 

tests/foreman/cli/test_contentview.py::ContentViewTestCase::test_positive_delete_cv_promoted_to_multi_env <- robottelo/decorators/__init__.py PASSED
tests/foreman/cli/test_contentview.py::ContentViewTestCase::test_positive_remove_cv_version_from_env <- robottelo/decorators/__init__.py PASSED
tests/foreman/cli/test_contentview.py::ContentViewTestCase::test_positive_remove_cv_version_from_env_with_host_registered <- ../../bin/redhat/6.2.z/python/2.7/lib/python2.7/site-packages/unittest2/case.py SKIPPED
tests/foreman/cli/test_contentview.py::ContentViewTestCase::test_positive_remove_cv_version_from_multi_env <- robottelo/decorators/__init__.py PASSED
tests/foreman/cli/test_contentview.py::ContentViewTestCase::test_positive_remove_cv_version_from_multi_env_capsule_scenario <- ../../bin/redhat/6.2.z/python/2.7/lib/python2.7/site-packages/unittest2/case.py SKIPPED
tests/foreman/cli/test_contentview.py::ContentViewTestCase::test_positive_remove_prod_promoted_cv_version_from_default_env <- robottelo/decorators/__init__.py PASSED
tests/foreman/cli/test_contentview.py::ContentViewTestCase::test_positive_remove_promoted_cv_version_from_default_env <- robottelo/decorators/__init__.py PASSED
tests/foreman/cli/test_contentview.py::ContentViewTestCase::test_positive_remove_qe_promoted_cv_version_from_default_env <- robottelo/decorators/__init__.py PASSED
tests/foreman/cli/test_contentview.py::ContentViewTestCase::test_positive_remove_renamed_cv_version_from_default_env <- robottelo/decorators/__init__.py PASSED

 50 tests deselected by '-ktest_positive_delete_cv_promoted_to_multi_env or test_positive_remove_cv_version_from_env or test_positive_remove_cv_version_from_multi_env or test_positive_remove_prod_promoted_cv_version_from_default_env or test_positive_remove_promoted_cv_version_from_default_env or test_positive_remove_qe_promoted_cv_version_from_default_env or test_positive_remove_renamed_cv_version_from_default_env' 
================================ 7 passed, 2 skipped, 50 deselected in 2040.63 seconds =================================


dlezz@elysion:~/projects/robottelo-fork$ py.test tests/foreman/api/test_contentviewversion.py -v -k "test_positive_remove_cv_version_from_multi_env or test_positive_remove_cv_version_from_env or test_positive_remove_prod_promoted_cv_version_from_default_env or test_positive_remove_qe_promoted_cv_version_from_default_env or test_positive_remove_renamed_cv_version_from_default_env or test_positive_delete_cv_promoted_to_multi_env"
================================================= test session starts ==================================================
platform linux2 -- Python 2.7.12, pytest-2.9.2, py-1.4.32, pluggy-0.3.1 -- /home/dlezz/bin/redhat/6.2.z/python/2.7/bin/python2.7
cachedir: .cache
rootdir: /home/dlezz/projects/robottelo-fork, inifile: 
plugins: xdist-1.14, cov-2.3.1
collected 19 items 

tests/foreman/api/test_contentviewversion.py::ContentViewVersionDeleteTestCase::test_positive_delete_cv_promoted_to_multi_env <- robottelo/decorators/__init__.py PASSED
tests/foreman/api/test_contentviewversion.py::ContentViewVersionDeleteTestCase::test_positive_remove_cv_version_from_env <- robottelo/decorators/__init__.py PASSED
tests/foreman/api/test_contentviewversion.py::ContentViewVersionDeleteTestCase::test_positive_remove_cv_version_from_env_with_host_registered <- ../../bin/redhat/6.2.z/python/2.7/lib/python2.7/site-packages/unittest2/case.py SKIPPED
tests/foreman/api/test_contentviewversion.py::ContentViewVersionDeleteTestCase::test_positive_remove_cv_version_from_multi_env <- robottelo/decorators/__init__.py PASSED
tests/foreman/api/test_contentviewversion.py::ContentViewVersionDeleteTestCase::test_positive_remove_cv_version_from_multi_env_capsule_scenario <- ../../bin/redhat/6.2.z/python/2.7/lib/python2.7/site-packages/unittest2/case.py SKIPPED
tests/foreman/api/test_contentviewversion.py::ContentViewVersionDeleteTestCase::test_positive_remove_prod_promoted_cv_version_from_default_env <- robottelo/decorators/__init__.py PASSED
tests/foreman/api/test_contentviewversion.py::ContentViewVersionDeleteTestCase::test_positive_remove_qe_promoted_cv_version_from_default_env <- robottelo/decorators/__init__.py PASSED
tests/foreman/api/test_contentviewversion.py::ContentViewVersionDeleteTestCase::test_positive_remove_renamed_cv_version_from_default_env <- robottelo/decorators/__init__.py PASSED

 11 tests deselected by '-ktest_positive_remove_cv_version_from_multi_env or test_positive_remove_cv_version_from_env or test_positive_remove_prod_promoted_cv_version_from_default_env or test_positive_remove_qe_promoted_cv_version_from_default_env or test_positive_remove_renamed_cv_version_from_default_env or test_positive_delete_cv_promoted_to_multi_env' 
================================ 6 passed, 2 skipped, 11 deselected in 1023.40 seconds =================================
```