### PR TITLE
Fix typo in hostgroup create helper.

### DIFF
--- a/robottelo/ui/hostgroup.py
+++ b/robottelo/ui/hostgroup.py
@@ -35,7 +35,7 @@ class Hostgroup(Base):
         if activation_keys:
             self.click(tab_locators['hostgroup.activation_keys'])
             self.assign_value(
-                locators['hostgroups.oscap_capsule'], oscap_capsule)
+                locators['hostgroups.activation_keys'], activation_keys)
         self.click(common_locators['submit'])
 
     def navigate_to_entity(self):


### PR DESCRIPTION
Test results for affected tests:
```python
% pytest -v tests/foreman/ui/test_hostgroup.py -k 'activation'
===================================================================== test session starts =====================================================================
platform linux2 -- Python 2.7.12, pytest-3.0.4, py-1.4.31, pluggy-0.4.0 -- /home/qui/code/venv/2/bin/python2
cachedir: .cache
rootdir: /home/qui/code/robottelo, inifile: 
plugins: xdist-1.15.0, html-1.12.0, cov-2.4.0
collected 8 items 

tests/foreman/ui/test_hostgroup.py::HostgroupTestCase::test_positive_check_activation_keys_autocomplete <- robottelo/decorators/__init__.py PASSED
tests/foreman/ui/test_hostgroup.py::HostgroupTestCase::test_positive_create_with_activation_keys <- robottelo/decorators/__init__.py PASSED

===================================================================== 6 tests deselected ======================================================================
========================================================== 2 passed, 6 deselected in 105.11 seconds ===========================================================
```