### PR TITLE
Added testcase to cover bugzilla 1292622

### DIFF
--- a/tests/foreman/ui/test_oscappolicy.py
+++ b/tests/foreman/ui/test_oscappolicy.py
@@ -200,3 +200,43 @@ class OpenScapPolicy(UITestCase):
                     self.assertIsNotNone(
                         self.oscappolicy.search(new_policy_name))
                     policy_name = new_policy_name
+
+    @skip_if_bug_open('bugzilla', 1292622)
+    @tier1
+    def test_positive_create_with_space_policy_name(self):
+        """Create OpenScap Policy with a space in its name.
+
+        @id: a45ec231-0ca9-4719-9239-eef0355822dc
+
+        @Steps:
+
+        1. Create an openscap content.
+        2. Create an openscap Policy.
+        3. Provide openscap policy name with space in it.
+        4. Provide all other the appropriate parameters.
+
+        @Assert: Creation of Policy with a space in its name is successful.
+
+        @BZ: 1292622
+        """
+        content_name = gen_string('alpha')
+        with Session(self.browser) as session:
+            make_oscapcontent(
+                session,
+                name=content_name,
+                content_path=self.content_path,
+            )
+            self.assertIsNotNone(
+                self.oscapcontent.search(content_name))
+            policy_name = "Test policy"
+            with self.subTest(policy_name):
+                make_oscappolicy(
+                    session,
+                    content=content_name,
+                    name=policy_name,
+                    period=OSCAP_PERIOD['weekly'],
+                    profile=OSCAP_PROFILE['c2s_rhel6'],
+                    period_value=OSCAP_WEEKDAY['friday'],
+                )
+                self.assertIsNotNone(
+                    self.oscappolicy.search(policy_name))


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1292622 (A SCAP Compliance Policy cannot be created with a space in its name)
```
###  pytest tests/foreman/ui/test_oscappolicy.py -k test_positive_create_with_space
===================================================================================== test session starts =====================================================================================
platform linux2 -- Python 2.7.12, pytest-3.0.6, py-1.4.31, pluggy-0.4.0
rootdir: /home/sjagtap/PycharmProjects/robottelo, inifile:
plugins: cov-2.3.1, xdist-1.15.0
collected 5 items

tests/foreman/ui/test_oscappolicy.py .

===================================================================================== 4 tests deselected ======================================================================================
========================================================================== 1 passed, 4 deselected in 111.91 seconds
```