### PR TITLE
[6.2.z] Added API & UI host test to automate BZ1391656

### DIFF
--- a/robottelo/ui/hosts.py
+++ b/robottelo/ui/hosts.py
@@ -194,3 +194,38 @@ class Hosts(Base):
                         parameter['command']
                     )
                     self.click(common_locators['submit'])
+
+    def fetch_host_parameters(self, name, domain_name, parameters_list):
+        """Fetches parameter values of specified host
+
+        :param name: host's name (without domain part)
+        :param domain_name: host's domain name
+        :param parameters_list: A list of parameters to be fetched. Each
+            parameter should be a separate list containing tab name and
+            parameter name in absolute correspondence to UI (Similar to
+            parameters list passed to create a host). Example::
+
+                [
+                    ['Host', 'Lifecycle Environment'],
+                    ['Host', 'Content View'],
+                ]
+
+        :return: Dictionary of parameter name - parameter value pairs
+        :rtype: dict
+        """
+        host = self.search(u'{0}.{1}'.format(name, domain_name))
+        self.click(host)
+        self.click(locators['host.edit'])
+        result = {}
+        for tab_name, param_name in parameters_list:
+            tab_locator = tab_locators['.tab_'.join((
+                'host',
+                (tab_name.lower()).replace(' ', '_')
+            ))]
+            param_locator = locators['.fetch_'.join((
+                'host',
+                (param_name.lower()).replace(' ', '_')
+            ))]
+            self.click(tab_locator)
+            result[param_name] = self.wait_until_element(param_locator).text
+        return result

--- a/robottelo/ui/locators.py
+++ b/robottelo/ui/locators.py
@@ -1308,10 +1308,18 @@ locators = LocatorDict({
         By.XPATH,
         ("//div[contains(@id, 'host_lifecycle_environment_id')]/a"
          "/span[contains(@class, 'arrow')]")),
+    "host.fetch_lifecycle_environment": (
+        By.XPATH,
+        ("//div[contains(@id, 'host_lifecycle_environment_id')]/a"
+         "/span[contains(@class, 'chosen')]")),
     "host.content_view": (
         By.XPATH,
         ("//div[contains(@id, 'host_content_view_id')]/a"
          "/span[contains(@class, 'arrow')]")),
+    "host.fetch_content_view": (
+        By.XPATH,
+        ("//div[contains(@id, 'host_content_view_id')]/a"
+         "/span[contains(@class, 'chosen')]")),
     "host.puppet_environment": (
         By.XPATH,
         ("//div[contains(@id, 'host_environment_id')]/a"

--- a/tests/foreman/api/test_host.py
+++ b/tests/foreman/api/test_host.py
@@ -200,6 +200,39 @@ class HostTestCase(APITestCase):
         self.assertEqual(host.hostgroup.read().name, hostgroup.name)
 
     @run_only_on('sat')
+    @tier2
+    def test_positive_create_inherit_lce_cv(self):
+        """Create a host with hostgroup specified. Make sure host inherited
+        hostgroup's lifecycle environment and content-view
+
+        @id: 229cbdbc-838b-456c-bc6f-4ac895badfbc
+
+        @Assert: Host's lifecycle environment and content view match the ones
+        specified in hostgroup
+
+        @CaseLevel: Integration
+
+        @BZ: 1391656
+        """
+        hostgroup = entities.HostGroup(
+            content_view=self.cv,
+            lifecycle_environment=self.lce,
+            organization=[self.org],
+        ).create()
+        host = entities.Host(
+            hostgroup=hostgroup,
+            organization=self.org,
+        ).create()
+        self.assertEqual(
+            host.content_facet_attributes['lifecycle_environment_id'],
+            hostgroup.lifecycle_environment.id
+        )
+        self.assertEqual(
+            host.content_facet_attributes['content_view_id'],
+            hostgroup.content_view.id
+        )
+
+    @run_only_on('sat')
     @tier1
     def test_positive_create_with_puppet_proxy(self):
         """Create a host with puppet proxy specified


### PR DESCRIPTION
Covers [BZ1391656](https://bugzilla.redhat.com/show_bug.cgi?id=1391656) for 6.2.z
```python
py.test tests/foreman/{api,ui}/test_host.py -k inherit
============================= test session starts ==============================
platform darwin -- Python 2.7.13, pytest-2.9.2, py-1.4.32, pluggy-0.3.1
rootdir: /Users/andrii/workspace/robottelo, inifile:
plugins: xdist-1.15.0, cov-2.3.1
collected 69 items

tests/foreman/api/test_host.py .
tests/foreman/ui/test_host.py .

====================== 67 tests deselected by '-kinherit' ======================
================== 2 passed, 67 deselected in 380.46 seconds ===================
```