### PR TITLE
Drop invalid <U+FEFF> character

### DIFF
--- a/tests/foreman/cli/test_satellitesync.py
+++ b/tests/foreman/cli/test_satellitesync.py
@@ -1,4 +1,4 @@
-﻿# -*- encoding: utf-8 -*-
+# -*- encoding: utf-8 -*-
 """Test class for InterSatellite Sync
 
 @Requirement: Satellitesync


### PR DESCRIPTION
For more info check http://www.fileformat.info/info/unicode/char/feff/index.htm.

The character is shown on git grep: `tests/foreman/cli/test_satellitesync.py:<U+FEFF># -*- encoding: utf-8 -*-`
