### PR TITLE
Pin testimony version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ python:
     - "3.5"
     - "3.6"
 install:
-    - pip install -r requirements.txt coveralls flake8 sphinx testimony tox-travis manage
+    - pip install -r requirements.txt coveralls flake8 sphinx tox-travis manage
 script:
     - flake8 .
     - make test-docstrings

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,12 @@
 sudo: false
 language: python
-env:
-    - TOXENV=py27
-    - TOXENV=py34
+python:
+    - "2.7"
+    - "3.4"
+    - "3.5"
+    - "3.6"
 install:
-    - pip install -r requirements.txt coveralls flake8 sphinx testimony tox manage
+    - pip install -r requirements.txt coveralls flake8 sphinx testimony tox-travis manage
 script:
     - flake8 .
     - make test-docstrings

--- a/requirements-optional.txt
+++ b/requirements-optional.txt
@@ -4,7 +4,6 @@ flake8
 mock
 pytest-cov
 pytest-xdist
-testimony
 tox
 
 # Voluntary (recommended!) tool for checking code quality.

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,6 +12,7 @@ pytest==3.0.6
 requests==2.13.0
 selenium==2.48.0  # pyup: ignore
 six==1.10.0
+testimony==1.2.0  # pyup: ignore
 unittest2==1.1.0
 python_bugzilla==1.2.2
 PyYAML==3.12

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27,py34
+envlist = py27,py34,py35,py36
 [testenv]
 deps=
     -rrequirements.txt


### PR DESCRIPTION
I have added two **separate** commits (please do not squash) to accomplish the following:

1) Make sure robottelo is being tested on Python 3.5 and 3.6 (this will avoid issues like #4318)
2) Pin testimony version to avoid breaking robottelo when the new version gets released.