### PR TITLE
Deselect all tests skipped due to WONTFIX BZs

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -1,13 +1,2 @@
 # coding: utf-8
-"""Configurations for py.test runner"""
-import pytest
-
-
-@pytest.fixture(scope="session")
-def worker_id(request):
-    """Gets the worker ID when running in multi-threading with xdist"""
-    if hasattr(request.config, 'slaveinput'):
-        # return gw+(0..n)
-        return request.config.slaveinput['slaveid']
-    else:
-        return 'master'
+"""Global Configurations for py.test runner"""

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -34,7 +34,7 @@ release = version
 extensions = ['sphinx.ext.autodoc', 'sphinx.ext.viewcode']
 source_suffix = '.rst'
 master_doc = 'index'
-exclude_patterns = ['_build']
+exclude_patterns = ['_build', 'pytest/*']
 nitpicky = True
 nitpick_ignore = [
     ('py:obj', 'bool'),

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,6 +15,7 @@ six==1.10.0
 unittest2==1.1.0
 python_bugzilla==1.2.2
 PyYAML==3.12
+robozilla==0.1.6
 
 # Get nailgun from master
 git+https://github.com/SatelliteQE/nailgun.git#egg=nailgun

--- a/robottelo/bz_helpers.py
+++ b/robottelo/bz_helpers.py
@@ -1,0 +1,43 @@
+# coding: utf-8
+import os
+from collections import defaultdict
+from robottelo.config.base import get_project_root
+from robozilla.filters import BZDecorator
+from robozilla.parser import Parser
+
+BASE_PATH = os.path.join(get_project_root(), 'tests', 'foreman')
+
+
+def get_decorated_bugs():  # pragma: no cover
+    """Using Robozilla parser, get all IDs from skip_if_bug_open decorator
+    and return the dictionary containing fetched data.
+
+    Important information is stored on `bug_data` key::
+        bugs[BUG_ID]['bug_data']['resolution|status|flags|whiteboard']
+    """
+    parser = Parser(BASE_PATH, filters=[BZDecorator])
+    bugs = parser.parse()
+    return bugs
+
+
+def get_wontfix_bugs(bugs=None):
+    """returns the ID of bugs CLOSED as WONTFIX"""
+    bugs = bugs or get_decorated_bugs()
+    wontfixes = []
+    for bug_id, data in bugs.items():
+        if data['bug_data']['resolution'] in ('WONTFIX', 'CANTFIX'):
+            wontfixes.append(bug_id)
+    return wontfixes
+
+
+def group_by_key(data):
+    """Gets a lsit of tuples and groups by item[0] - the key"""
+    res = defaultdict(list)
+    for k, v in data:
+        res[k].append(v)
+    return dict(res)
+
+
+def get_func_name(func):
+    """Given a func object return standardized name to use across project"""
+    return '{0}.{1}'.format(func.__module__, func.__name__)

--- a/robottelo/decorators/__init__.py
+++ b/robottelo/decorators/__init__.py
@@ -8,6 +8,7 @@ import re
 import requests
 import unittest2
 from functools import wraps
+from robottelo.bz_helpers import get_func_name
 from robottelo.config import settings
 from robottelo.constants import BZ_OPEN_STATUSES, NOT_IMPLEMENTED
 from robottelo.host_info import get_host_sat_version
@@ -527,6 +528,8 @@ class skip_if_bug_open(object):  # noqa pylint:disable=C0103,R0903
         :param func: The function being decorated.
 
         """
+        self.register_bug_id(func)
+
         if self.bug_type not in ('bugzilla', 'redmine'):
             raise BugTypeError(
                 '"{0}" is not a recognized bug type. Did you mean '
@@ -572,3 +575,14 @@ class skip_if_bug_open(object):  # noqa pylint:disable=C0103,R0903
 
         # This function replaces what is being decorated.
         return wrapper_func
+
+    def register_bug_id(self, func):  # pragma: no cover
+        """Every time the test is decorated, takes the BZ number and
+        register it in pytest global namespace variable to be accessible in
+        conftest in order to perform the filtering of test collection
+        """
+        bz_namespace = getattr(pytest, 'bugzilla', None)
+        if bz_namespace:
+            bz_namespace.decorated_functions.append(
+                (get_func_name(func), str(self.bug_id))
+            )

--- a/tests/foreman/conftest.py
+++ b/tests/foreman/conftest.py
@@ -1,0 +1,77 @@
+# coding: utf-8
+"""Configurations for py.test runner"""
+import datetime
+import pytest
+
+from robottelo.bz_helpers import get_wontfix_bugs, group_by_key, get_func_name
+
+
+def log(message, level="DEBUG"):
+    """Pytest has a limitation to use logging.logger from conftest.py
+    so we need to emulate the logger by stdouting the output
+    """
+    now = datetime.datetime.now()
+    full_message = "{date} - conftest - {level} - {message}\n".format(
+        date=now.strftime("%Y-%m-%d %H:%M:%S"),
+        level=level,
+        message=message
+    )
+    print(full_message)  # noqa
+    with open('robottelo.log', 'a') as log_file:
+        log_file.write(full_message)
+
+
+@pytest.fixture(scope="session")
+def worker_id(request):
+    """Gets the worker ID when running in multi-threading with xdist
+    """
+    if hasattr(request.config, 'slaveinput'):
+        # return gw+(0..n)
+        return request.config.slaveinput['slaveid']
+    else:
+        return 'master'
+
+
+def pytest_namespace():
+    """return dict of name->object to be made globally available in
+    the pytest namespace.  This hook is called at plugin registration
+    time.
+    Object is accessible only via dotted notation `item.key.nested_key`
+
+    Exposes the list of all WONTFIX bugs and a mapping between decorated
+    functions and Bug IDS (populated by decorator).
+    """
+    log("Registering custom pytest_namespace")
+    return {
+        'bugzilla': {
+            'wontfix_ids': get_wontfix_bugs(),
+            'decorated_functions': []
+        }
+    }
+
+
+def pytest_collection_modifyitems(items, config):
+    """ called after collection has been performed, may filter or re-order
+    the items in-place.
+
+    Deselecting all tests skipped due to WONTFIX BZ.
+    """
+    deselected_items = []
+    wontfix_ids = pytest.bugzilla.wontfix_ids
+    decorated_functions = group_by_key(pytest.bugzilla.decorated_functions)
+
+    log("Found WONTFIX in decorated tests %s" % wontfix_ids)
+    log("Collected %s test cases" % len(items))
+
+    for item in items:
+        name = get_func_name(item.function)
+        bug_ids = decorated_functions.get(name)
+        if bug_ids:
+            for bug_id in bug_ids:
+                if bug_id in wontfix_ids:
+                    deselected_items.append(item)
+                    log("Deselected test %s due to WONTFIX" % name)
+                    break
+
+    config.hook.pytest_deselected(items=deselected_items)
+    items[:] = [item for item in items if item not in deselected_items]

--- a/tests/robottelo/test_bz_helpers.py
+++ b/tests/robottelo/test_bz_helpers.py
@@ -1,0 +1,58 @@
+# coding: utf-8
+
+from unittest2 import TestCase
+from robottelo.bz_helpers import get_wontfix_bugs, group_by_key, get_func_name
+
+
+class BZHelperTestCase(TestCase):
+
+    def setUp(self):
+        self.bz_data = {
+            '1234': {
+                'bug_data': {
+                    'resolution': 'WONTFIX'
+                }
+            },
+            '1235': {
+                'bug_data': {
+                    'resolution': 'CANTFIX'
+                }
+            },
+            '1236': {
+                'bug_data': {
+                    'resolution': ''
+                }
+            }
+        }
+
+        self.decorated_functions = [
+            ('function1', '1234'),
+            ('function1', '1235'),
+            ('function2', '1236')
+        ]
+
+    def test_get_wontfix_bugs(self):
+        """Test if wontfixes are filtered"""
+        self.assertNotIn('1236', get_wontfix_bugs(self.bz_data))
+
+    def test_group_by_key(self):
+        """Test if decorated functions are grouped"""
+        grouped = group_by_key(self.decorated_functions)
+        self.assertEqual(
+            set(['function1', 'function2']),
+            set(list(grouped.keys()))
+        )
+        self.assertEqual(set(grouped['function1']), set(['1234', '1235']))
+        self.assertEqual(set(grouped['function2']), set(['1236']))
+
+    def test_get_func_name(self):
+        """Test if name is proper generated for function"""
+
+        self.assertEqual(
+            get_func_name(test_function),
+            'tests.robottelo.test_bz_helpers.test_function'
+        )
+
+
+def test_function():
+    """Does nothing, only used to test get_func_name"""


### PR DESCRIPTION
Fixes #4261 
Connected to #4260 

- Added `robozilla` as dependency to parse all bugzilla ids
- Moved `conftest.py` to `tests/foreman` directory
- Implemented `bz_helpers` using robozilla parser
- Added `hook` to add variables to `pytest namespace`
- Added `hook` to **deselect** all tests decorated with WONTFIX Bz.