### PR TITLE
Gpg fixes and coverage for BZ1411800

### DIFF
--- a/robottelo/ui/gpgkey.py
+++ b/robottelo/ui/gpgkey.py
@@ -29,11 +29,6 @@ class GPGKey(Base):
         elif key_content:
             self.click(locators['gpgkey.content'])
             self.assign_value(locators['gpgkey.content'], key_content)
-        else:
-            raise UIError(
-                u'Could not create new gpgkey "{0}" without contents'
-                .format(name)
-            )
         self.click(common_locators['create'])
         self.wait_until_element_is_not_visible(locators['gpgkey.new_form'])
 
@@ -59,21 +54,24 @@ class GPGKey(Base):
             self.assign_value(locators['gpgkey.file_path'], new_key)
             self.click(locators['gpgkey.upload_button'])
 
-    def assert_product_repo(self, key_name, product):
-        """To validate product and repo association with gpg keys.
+    def get_product_repo(self, key_name, entity_name, entity_type='Product'):
+        """To validate whether product and repo associated with gpg keys.
 
-        Here product is a boolean variable when product = True; validation
-        assert product tab otherwise assert repo tab.
+        :param str key_name: Name of gpg key to be validated
+        :param str entity_name: Product or repository name to be validated
+        :param str entity_type: Specify type of entity to be validated (e.g.
+            'Product' or 'Repository')
+        :return: Return found entity or None otherwise
         """
         self.search_and_click(key_name)
-        if product:
+        if entity_type == 'Product':
             self.click(tab_locators['gpgkey.tab_products'])
-        else:
+            self.assign_value(locators['gpgkey.product_search'], entity_name)
+        elif entity_type == 'Repository':
             self.click(tab_locators['gpgkey.tab_repos'])
-        if self.wait_until_element(locators['gpgkey.product_repo']):
-            element = self.find_element(
-                locators['gpgkey.product_repo']).get_attribute('innerHTML')
-            return element.strip(' \t\n\r')
+            self.assign_value(locators['gpgkey.repo_search'], entity_name)
+        return self.wait_until_element(
+            locators['gpgkey.product_repo'] % entity_name)
 
     def assert_key_from_product(self, name, prd_element, repo=None):
         """Assert the key association after deletion from product tab."""

--- a/robottelo/ui/locators/base.py
+++ b/robottelo/ui/locators/base.py
@@ -1517,11 +1517,13 @@ locators = LocatorDict({
          "//button[@ng-click='save()']")),
     "gpgkey.upload_button": (
         By.XPATH, "//button[@ng-click='progress.uploading = true']"),
-    "gpgkey.product_repo_search": (
-        By.XPATH,
-        ("//input[@placeholder='Filter' and contains(@ng-model, 'Search']")),
+    "gpgkey.product_search": (
+        By.XPATH, "//input[@ng-model='productSearch']"),
+    "gpgkey.repo_search": (
+        By.XPATH, "//input[@ng-model='repositorySearch']"),
     "gpgkey.product_repo": (
-        By.XPATH, "//td/a[contains(@href, 'repositories')]"),
+        By.XPATH,
+        "//td/a[contains(@href, 'repositories') and contains(., '%s')]"),
 
     # Content views
     "contentviews.new": (By.XPATH, "//a[@ui-sref='content-views.new']"),

--- a/robottelo/ui/locators/base.py
+++ b/robottelo/ui/locators/base.py
@@ -1047,6 +1047,7 @@ locators = LocatorDict({
 
     # Products
     "prd.new": (By.XPATH, "//button[contains(@ui-sref,'products.new')]"),
+    "prd.title": (By.XPATH, "//h2/span[contains(.,'Product %s')]"),
     "prd.bulk_actions": (
         By.XPATH, "//button[contains(@ui-sref,'products.bulk-actions')]"),
     "prd.repo_discovery": (

--- a/robottelo/ui/repository.py
+++ b/robottelo/ui/repository.py
@@ -114,6 +114,7 @@ class Repos(Base):
         while discover_cancel:
             discover_cancel = self.wait_until_element(
                 locators['repo.cancel_discover'])
+        self.wait_for_ajax()
         for url in discovered_urls:
             self.click(locators['repo.discovered_url_checkbox'] % url)
         self.click(locators['repo.create_selected'])

--- a/tests/foreman/ui/test_gpgkey.py
+++ b/tests/foreman/ui/test_gpgkey.py
@@ -555,6 +555,20 @@ class GPGKey(UITestCase):
         @CaseLevel: System
         """
 
+    @stubbed()
+    @run_only_on('sat')
+    @tier1
+    def test_positive_info(self):
+        """Create single gpg key and get its info
+
+        @id: c8b75db1-9394-4a99-9d91-0d388aacfd1a
+
+        @assert: specific information for gpg key matches the creation values
+
+        @caseautomation: notautomated
+
+        """
+
 
 class GPGKeyProductAssociateTestCase(UITestCase):
     """Implements Product Association tests for GPG Keys via UI"""

--- a/tests/foreman/ui/test_gpgkey.py
+++ b/tests/foreman/ui/test_gpgkey.py
@@ -32,7 +32,6 @@ from robottelo.constants import (
 from robottelo.datafactory import invalid_names_list, valid_data_list
 from robottelo.decorators import (
     run_only_on,
-    skip_if_bug_open,
     skip_if_not_set,
     stubbed,
     tier1,
@@ -41,7 +40,6 @@ from robottelo.decorators import (
 )
 from robottelo.helpers import get_data_file, read_data_file
 from robottelo.test import UITestCase
-from robottelo.ui.base import UIError
 from robottelo.ui.factory import make_gpgkey
 from robottelo.ui.locators import common_locators
 from robottelo.ui.session import Session
@@ -113,8 +111,8 @@ class GPGKey(UITestCase):
     @run_only_on('sat')
     @tier1
     def test_negative_create_via_import_and_same_name(self):
-        """Create gpg key with valid name and valid gpg key via
-        file import then try to create new one with same name
+        """Create gpg key with valid name and valid gpg key via file import
+        then try to create new one with same name and same content
 
         @id: d5e28e8a-e0ef-4c74-a18b-e2646a2cdba5
 
@@ -138,8 +136,9 @@ class GPGKey(UITestCase):
     @run_only_on('sat')
     @tier1
     def test_negative_create_via_paste_and_same_name(self):
-        """Create gpg key with valid name and valid gpg key text via
-        cut and paste/string import then try to create new one with same name
+        """Create gpg key with valid name and valid gpg key text via cut and
+        paste/string import then try to create new one with same name and same
+        content
 
         @id: c6b256a5-6b9b-4927-a6c6-048ba36d2834
 
@@ -170,15 +169,16 @@ class GPGKey(UITestCase):
         """
         name = gen_string('alphanumeric')
         with Session(self.browser) as session:
-            with self.assertRaises(UIError):
-                make_gpgkey(session, name=name, org=self.organization.name)
+            make_gpgkey(session, name=name, org=self.organization.name)
+            self.assertIsNotNone(
+                self.gpgkey.wait_until_element(common_locators['alert.error'])
+            )
             self.assertIsNone(self.gpgkey.search(name))
 
     @run_only_on('sat')
     @tier1
     def test_negative_create_via_import_and_invalid_name(self):
-        """Create gpg key with invalid name and valid gpg key via
-        file import
+        """Create gpg key with invalid name and valid gpg key via file import
 
         @id: bc5f96e6-e997-4995-ad04-614e66480b7f
 
@@ -203,8 +203,8 @@ class GPGKey(UITestCase):
     @run_only_on('sat')
     @tier1
     def test_negative_create_via_paste_and_invalid_name(self):
-        """Create gpg key with invalid name and valid gpg key text via
-        cut and paste/string
+        """Create gpg key with invalid name and valid gpg key text via cut and
+        paste/string
 
         @id: 652857de-c522-4c68-a758-13d0b37cc62a
 
@@ -230,8 +230,8 @@ class GPGKey(UITestCase):
     @run_only_on('sat')
     @tier1
     def test_positive_delete_for_imported_content(self):
-        """Create gpg key with valid name and valid gpg key via file
-        import then delete it
+        """Create gpg key with valid name and valid gpg key via file import
+        then delete it
 
         @id: 495547c0-8e38-49cc-9be4-3f24a20d3af7
 
@@ -253,8 +253,8 @@ class GPGKey(UITestCase):
     @run_only_on('sat')
     @tier1
     def test_positive_delete_for_pasted_content(self):
-        """Create gpg key with valid name and valid gpg key text via
-        cut and paste/string then delete it
+        """Create gpg key with valid name and valid gpg key text via cut and
+        paste/string then delete it
 
         @id: 77c97202-a877-4647-b7e2-3a9b68945fc4
 
@@ -297,8 +297,8 @@ class GPGKey(UITestCase):
             self.assertIsNotNone(self.gpgkey.search(name))
             self.gpgkey.update(name, new_name)
             self.assertIsNotNone(self.gpgkey.wait_until_element(
-                common_locators['alert.success_sub_form']
-            ))
+                common_locators['alert.success_sub_form']))
+            self.assertIsNotNone(self.gpgkey.search(new_name))
 
     @run_only_on('sat')
     @tier1
@@ -323,8 +323,7 @@ class GPGKey(UITestCase):
             self.assertIsNotNone(self.gpgkey.search(name))
             self.gpgkey.update(name, new_key=new_key_path)
             self.assertIsNotNone(self.gpgkey.wait_until_element(
-                common_locators['alert.success_sub_form']
-            ))
+                common_locators['alert.success_sub_form']))
 
     @run_only_on('sat')
     @tier1
@@ -348,8 +347,8 @@ class GPGKey(UITestCase):
             self.assertIsNotNone(self.gpgkey.search(name))
             self.gpgkey.update(name, new_name)
             self.assertIsNotNone(self.gpgkey.wait_until_element(
-                common_locators['alert.success_sub_form']
-            ))
+                common_locators['alert.success_sub_form']))
+            self.assertIsNotNone(self.gpgkey.search(new_name))
 
     @run_only_on('sat')
     @tier1
@@ -373,8 +372,7 @@ class GPGKey(UITestCase):
             self.assertIsNotNone(self.gpgkey.search(name))
             self.gpgkey.update(name, new_key=new_key_path)
             self.assertIsNotNone(self.gpgkey.wait_until_element(
-                common_locators['alert.success_sub_form']
-            ))
+                common_locators['alert.success_sub_form']))
 
     # Negative Update
 
@@ -410,8 +408,8 @@ class GPGKey(UITestCase):
     @tier3
     @skip_if_not_set('clients')
     def test_positive_consume_content_using_repo(self):
-        """Hosts can install packages using gpg key associated with
-        single custom repository
+        """Hosts can install packages using gpg key associated with single
+        custom repository
 
         @id: c6b78312-91d3-47a2-a6c6-f906a4522fe4
 
@@ -556,48 +554,6 @@ class GPGKey(UITestCase):
         @CaseLevel: System
         """
 
-    @stubbed()
-    @run_only_on('sat')
-    @tier1
-    def test_positive_list(self):
-        """Create gpg key and list it
-
-        @id: 9963f533-47aa-49a9-b251-3d81fc07e732
-
-        @assert: gpg key is displayed/listed
-
-        @caseautomation: notautomated
-
-        """
-
-    @stubbed()
-    @run_only_on('sat')
-    @tier1
-    def test_positive_search(self):
-        """Create gpg key and search/find it
-
-        @id: d55b8034-7f55-45cc-8ee0-43db0534e586
-
-        @assert: gpg key can be found
-
-        @caseautomation: notautomated
-
-        """
-
-    @stubbed()
-    @run_only_on('sat')
-    @tier1
-    def test_positive_info(self):
-        """Create single gpg key and get its info
-
-        @id: c8b75db1-9394-4a99-9d91-0d388aacfd1a
-
-        @assert: specific information for gpg key matches the creation values
-
-        @caseautomation: notautomated
-
-        """
-
 
 class GPGKeyProductAssociateTestCase(UITestCase):
     """Implements Product Association tests for GPG Keys via UI"""
@@ -612,8 +568,8 @@ class GPGKeyProductAssociateTestCase(UITestCase):
     @run_only_on('sat')
     @tier2
     def test_positive_add_empty_product(self):
-        """Create gpg key with valid name and valid gpg key
-        then associate it with empty (no repos) custom product
+        """Create gpg key with valid name and valid gpg key then associate
+        it with empty (no repos) custom product
 
         @id: e18ae9f5-43d9-4049-92ca-1eafaca05096
 
@@ -628,7 +584,7 @@ class GPGKeyProductAssociateTestCase(UITestCase):
             organization=self.organization,
         ).create()
         # Creates new product and associate GPGKey with it
-        entities.Product(
+        product = entities.Product(
             gpg_key=gpg_key,
             name=gen_string('alpha'),
             organization=self.organization,
@@ -637,19 +593,19 @@ class GPGKeyProductAssociateTestCase(UITestCase):
             session.nav.go_to_select_org(self.organization.name)
             # Assert that GPGKey is associated with product
             self.assertIsNotNone(
-                self.gpgkey.assert_product_repo(name, product=True)
+                self.gpgkey.get_product_repo(name, product.name)
             )
 
     @run_only_on('sat')
     @tier2
     def test_positive_add_product_with_repo(self):
-        """Create gpg key with valid name and valid gpg key
-        then associate it with custom product that has one repository
+        """Create gpg key with valid name and valid gpg key then associate it
+        with custom product that has one repository
 
         @id: 7514b33a-da75-43bd-a84b-5a805c84511d
 
-        @assert: gpg key is associated with product as well as
-        with the repository
+        @assert: gpg key is associated with product as well as with the
+        repository
 
         @CaseLevel: Integration
         """
@@ -666,7 +622,7 @@ class GPGKeyProductAssociateTestCase(UITestCase):
             organization=self.organization,
         ).create()
         # Creates new repository without GPGKey
-        entities.Repository(
+        repo = entities.Repository(
             name=gen_string('alpha'),
             url=FAKE_1_YUM_REPO,
             product=product,
@@ -674,21 +630,24 @@ class GPGKeyProductAssociateTestCase(UITestCase):
         with Session(self.browser) as session:
             session.nav.go_to_select_org(self.organization.name)
             # Assert that GPGKey is associated with product and repository
-            for product_ in (True, False):
-                self.assertIsNotNone(
-                    self.gpgkey.assert_product_repo(name, product=product_)
+            self.assertIsNotNone(
+                self.gpgkey.get_product_repo(name, product.name)
+            )
+            self.assertIsNotNone(
+                self.gpgkey.get_product_repo(
+                    name, repo.name, entity_type='Repository'
                 )
+            )
 
     @run_only_on('sat')
     @tier2
     def test_positive_add_product_with_repos(self):
-        """Create gpg key with valid name and valid gpg key
-        then associate it with custom product that has more than one repository
+        """Create gpg key with valid name and valid gpg key then associate it
+        with custom product that has more than one repository
 
         @id: 0edffad7-0ab4-4bef-b16b-f6c8de55b0dc
 
-        @assert: gpg key is associated with product as well as with
-        the repositories
+        @assert: gpg key is properly associated with repositories
 
         @CaseLevel: Integration
         """
@@ -705,13 +664,13 @@ class GPGKeyProductAssociateTestCase(UITestCase):
             organization=self.organization,
         ).create()
         # Creates new repository_1 without GPGKey
-        entities.Repository(
+        repo1 = entities.Repository(
             name=gen_string('alpha'),
             product=product,
             url=FAKE_1_YUM_REPO,
         ).create()
         # Creates new repository_2 without GPGKey
-        entities.Repository(
+        repo2 = entities.Repository(
             name=gen_string('alpha'),
             product=product,
             url=FAKE_2_YUM_REPO,
@@ -719,12 +678,16 @@ class GPGKeyProductAssociateTestCase(UITestCase):
         with Session(self.browser) as session:
             session.nav.go_to_select_org(self.organization.name)
             # Assert that GPGKey is associated with product and repository
-            for product_ in (True, False):
+            self.assertIsNotNone(
+                self.gpgkey.get_product_repo(name, product.name)
+            )
+            for repo in [repo1, repo2]:
                 self.assertIsNotNone(
-                    self.gpgkey.assert_product_repo(name, product=product_)
+                    self.gpgkey.get_product_repo(
+                        name, repo.name, entity_type='Repository'
+                    )
                 )
 
-    @skip_if_bug_open('bugzilla', 1210180)
     @run_only_on('sat')
     @tier2
     def test_positive_add_product_using_repo_discovery(self):
@@ -741,6 +704,7 @@ class GPGKeyProductAssociateTestCase(UITestCase):
         @CaseLevel: Integration
         """
         name = get_random_gpgkey_name()
+        product_name = gen_string('alpha')
         with Session(self.browser) as session:
             make_gpgkey(
                 session,
@@ -757,16 +721,20 @@ class GPGKeyProductAssociateTestCase(UITestCase):
                 new_product=True,
                 product=gen_string('alpha'),
             )
-            for product in (True, False):
-                self.assertIsNotNone(
-                    self.gpgkey.assert_product_repo(name, product=product)
+            self.assertIsNotNone(
+                self.gpgkey.get_product_repo(name, product_name)
+            )
+            self.assertIsNotNone(
+                self.gpgkey.get_product_repo(
+                    name, 'fakerepo01', entity_type='Repository'
                 )
+            )
 
     @run_only_on('sat')
     @tier2
     def test_positive_add_repo_from_product_with_repo(self):
-        """Create gpg key with valid name and valid gpg key then
-        associate it to repository from custom product that has one repository
+        """Create gpg key with valid name and valid gpg key then associate it
+        to repository from custom product that has one repository
 
         @id: 5d78890f-4130-4dc3-9cfe-48999149422f
 
@@ -787,7 +755,7 @@ class GPGKeyProductAssociateTestCase(UITestCase):
             organization=self.organization,
         ).create()
         # Creates new repository with GPGKey
-        entities.Repository(
+        repo = entities.Repository(
             name=gen_string('alpha'),
             url=FAKE_1_YUM_REPO,
             product=product,
@@ -797,19 +765,19 @@ class GPGKeyProductAssociateTestCase(UITestCase):
             session.nav.go_to_select_org(self.organization.name)
             # Assert that GPGKey is not associated with product
             self.assertIsNone(
-                self.gpgkey.assert_product_repo(name, product=True)
+                self.gpgkey.get_product_repo(name, product.name)
             )
             # Assert that GPGKey is associated with repository
             self.assertIsNotNone(
-                self.gpgkey.assert_product_repo(name, product=False)
+                self.gpgkey.get_product_repo(
+                    name, repo.name, entity_type='Repository')
             )
 
     @run_only_on('sat')
     @tier2
     def test_positive_add_repo_from_product_with_repos(self):
-        """Create gpg key with valid name and valid gpg key then
-        associate it to repository from custom product that has more than
-        one repository
+        """Create gpg key with valid name and valid gpg key then associate it
+        to repository from custom product that has more than one repository
 
         @id: 1fb38e01-4c04-4609-842d-069f96157317
 
@@ -830,14 +798,14 @@ class GPGKeyProductAssociateTestCase(UITestCase):
             organization=self.organization,
         ).create()
         # Creates new repository with GPGKey
-        entities.Repository(
+        repo1 = entities.Repository(
             name=gen_string('alpha'),
             url=FAKE_1_YUM_REPO,
             product=product,
             gpg_key=gpg_key,
         ).create()
         # Creates new repository without GPGKey
-        entities.Repository(
+        repo2 = entities.Repository(
             name=gen_string('alpha'),
             url=FAKE_2_YUM_REPO,
             product=product,
@@ -846,11 +814,19 @@ class GPGKeyProductAssociateTestCase(UITestCase):
             session.nav.go_to_select_org(self.organization.name)
             # Assert that GPGKey is not associated with product
             self.assertIsNone(
-                self.gpgkey.assert_product_repo(name, product=True)
+                self.gpgkey.get_product_repo(name, product.name)
             )
-            # Assert that GPGKey is not associated with product
+            # Assert that GPGKey is associated with first repository
             self.assertIsNotNone(
-                self.gpgkey.assert_product_repo(name, product=False)
+                self.gpgkey.get_product_repo(
+                    name, repo1.name, entity_type='Repository'
+                )
+            )
+            # Assert that GPGKey is not associated with second repository
+            self.assertIsNone(
+                self.gpgkey.get_product_repo(
+                    name, repo2.name, entity_type='Repository'
+                )
             )
 
     @stubbed()
@@ -872,8 +848,8 @@ class GPGKeyProductAssociateTestCase(UITestCase):
     @run_only_on('sat')
     @tier2
     def test_positive_update_key_for_empty_product(self):
-        """Create gpg key with valid name and valid gpg key then
-        associate it with empty (no repos) custom product then update the key
+        """Create gpg key with valid name and valid gpg key then associate it
+        with empty (no repos) custom product then update the key
 
         @id: 519817c3-9b67-4859-8069-95987ebf9453
 
@@ -898,27 +874,25 @@ class GPGKeyProductAssociateTestCase(UITestCase):
             session.nav.go_to_select_org(self.organization.name)
             # Assert that GPGKey is associated with product
             self.assertIsNotNone(
-                self.gpgkey.assert_product_repo(name, product=True)
+                self.gpgkey.get_product_repo(name, product.name)
             )
             # Update the Key name
             self.gpgkey.update(name, new_name)
             # Again assert that GPGKey is associated with product
-            self.assertEqual(
-                product.name,
-                self.gpgkey.assert_product_repo(new_name, product=True)
+            self.assertIsNotNone(
+                self.gpgkey.get_product_repo(new_name, product.name)
             )
 
     @run_only_on('sat')
     @tier2
     def test_positive_update_key_for_product_with_repo(self):
-        """Create gpg key with valid name and valid gpg key
-        then associate it with custom product that has one repository
-        then update the key
+        """Create gpg key with valid name and valid gpg key then associate it
+        with custom product that has one repository then update the key
 
         @id: 02cb0601-6aa2-4589-b61e-3d3785a7e100
 
-        @assert: gpg key is associated with product as well as with
-        repository before/after update
+        @assert: gpg key is associated with product as well as with repository
+        before/after update
 
         @CaseLevel: Integration
         """
@@ -935,7 +909,7 @@ class GPGKeyProductAssociateTestCase(UITestCase):
             organization=self.organization,
         ).create()
         # Creates new repository without GPGKey
-        entities.Repository(
+        repo = entities.Repository(
             name=gen_string('alpha'),
             product=product,
             url=FAKE_1_YUM_REPO,
@@ -945,23 +919,31 @@ class GPGKeyProductAssociateTestCase(UITestCase):
         with Session(self.browser) as session:
             session.nav.go_to_select_org(self.organization.name)
             # Assert that before update GPGKey is associated with product, repo
-            for product_ in (True, False):
-                self.assertIsNotNone(
-                    self.gpgkey.assert_product_repo(name, product=product_)
+            self.assertIsNotNone(
+                self.gpgkey.get_product_repo(name, product.name)
+            )
+            self.assertIsNotNone(
+                self.gpgkey.get_product_repo(
+                    name, repo.name, entity_type='Repository'
                 )
+            )
             self.gpgkey.update(name, new_name)
             # Assert that after update GPGKey is associated with product, repo
-            for product_ in (True, False):
-                self.assertIsNotNone(
-                    self.gpgkey.assert_product_repo(new_name, product=product_)
+            self.assertIsNotNone(
+                self.gpgkey.get_product_repo(new_name, product.name)
+            )
+            self.assertIsNotNone(
+                self.gpgkey.get_product_repo(
+                    new_name, repo.name, entity_type='Repository'
                 )
+            )
 
     @run_only_on('sat')
     @tier2
     def test_positive_update_key_for_product_with_repos(self):
-        """Create gpg key with valid name and valid gpg key
-        then associate it with custom product that has more than one
-        repository then update the key
+        """Create gpg key with valid name and valid gpg key then associate it
+        with custom product that has more than one repository then update the
+        key
 
         @id: 3ca4d9ff-8032-4c2a-aed9-00ac2d1352d1
 
@@ -983,13 +965,13 @@ class GPGKeyProductAssociateTestCase(UITestCase):
             organization=self.organization,
         ).create()
         # Creates new repository_1 without GPGKey
-        entities.Repository(
+        repo1 = entities.Repository(
             name=gen_string('alpha'),
             product=product,
             url=FAKE_1_YUM_REPO,
         ).create()
         # Creates new repository_2 without GPGKey
-        entities.Repository(
+        repo2 = entities.Repository(
             name=gen_string('alpha'),
             product=product,
             url=FAKE_2_YUM_REPO,
@@ -999,18 +981,27 @@ class GPGKeyProductAssociateTestCase(UITestCase):
         with Session(self.browser) as session:
             session.nav.go_to_select_org(self.organization.name)
             # Assert that before update GPGKey is associated with product, repo
-            for product_ in (True, False):
+            self.assertIsNotNone(
+                self.gpgkey.get_product_repo(name, product.name)
+            )
+            for repo in [repo1, repo2]:
                 self.assertIsNotNone(
-                    self.gpgkey.assert_product_repo(name, product=product_)
+                    self.gpgkey.get_product_repo(
+                        name, repo.name, entity_type='Repository'
+                    )
                 )
             self.gpgkey.update(name, new_name)
             # Assert that after update GPGKey is associated with product, repo
-            for product_ in (True, False):
+            self.assertIsNotNone(
+                self.gpgkey.get_product_repo(new_name, product.name)
+            )
+            for repo in [repo1, repo2]:
                 self.assertIsNotNone(
-                    self.gpgkey.assert_product_repo(new_name, product=product_)
+                    self.gpgkey.get_product_repo(
+                        new_name, repo.name, entity_type='Repository'
+                    )
                 )
 
-    @skip_if_bug_open('bugzilla', 1210180)
     @run_only_on('sat')
     @tier2
     def test_positive_update_key_for_product_using_repo_discovery(self):
@@ -1029,6 +1020,7 @@ class GPGKeyProductAssociateTestCase(UITestCase):
         """
         name = get_random_gpgkey_name()
         new_name = gen_string('alpha')
+        product_name = gen_string('alpha')
         entities.GPGKey(
             content=self.key_content,
             name=name,
@@ -1045,22 +1037,30 @@ class GPGKeyProductAssociateTestCase(UITestCase):
                 new_product=True,
                 product=gen_string('alpha'),
             )
-            for product in (True, False):
-                self.assertIsNotNone(
-                    self.gpgkey.assert_product_repo(name, product=product)
+            self.assertIsNotNone(
+                self.gpgkey.get_product_repo(name, product_name)
+            )
+            self.assertIsNotNone(
+                self.gpgkey.get_product_repo(
+                    name, 'fakerepo01', entity_type='Repository'
                 )
+            )
             self.gpgkey.update(name, new_name)
-            for product in (True, False):
-                self.assertIsNotNone(
-                    self.gpgkey.assert_product_repo(new_name, product=product)
+            self.assertIsNotNone(
+                self.gpgkey.get_product_repo(new_name, product_name)
+            )
+            self.assertIsNotNone(
+                self.gpgkey.get_product_repo(
+                    new_name, 'fakerepo01', entity_type='Repository'
                 )
+            )
 
     @run_only_on('sat')
     @tier2
     def test_positive_update_key_for_repo_from_product_with_repo(self):
-        """Create gpg key with valid name and valid gpg key then
-        associate it to repository from custom product that has one repository
-        then update the key
+        """Create gpg key with valid name and valid gpg key then associate it
+        to repository from custom product that has one repository then update
+        the key
 
         @id: 9827306e-76d7-4aef-8074-e97fc39d3bbb
 
@@ -1081,7 +1081,7 @@ class GPGKeyProductAssociateTestCase(UITestCase):
             organization=self.organization,
         ).create()
         # Creates new repository with GPGKey
-        entities.Repository(
+        repo = entities.Repository(
             gpg_key=gpg_key,
             name=gen_string('alpha'),
             product=product,
@@ -1093,34 +1093,38 @@ class GPGKeyProductAssociateTestCase(UITestCase):
             session.nav.go_to_select_org(self.organization.name)
             # Assert that GPGKey is not associated with product
             self.assertIsNone(
-                self.gpgkey.assert_product_repo(name, product=True)
+                self.gpgkey.get_product_repo(name, product.name)
             )
             # Assert that GPGKey is associated with repository
             self.assertIsNotNone(
-                self.gpgkey.assert_product_repo(name, product=False)
+                self.gpgkey.get_product_repo(
+                    name, repo.name, entity_type='Repository'
+                )
             )
             self.gpgkey.update(name, new_name)
             # Assert that after update GPGKey is not associated with product
             self.assertIsNone(
-                self.gpgkey.assert_product_repo(new_name, product=True)
+                self.gpgkey.get_product_repo(new_name, product.name)
             )
             # Assert that after update GPGKey is still associated
             # with repository
             self.assertIsNotNone(
-                self.gpgkey.assert_product_repo(new_name, product=False)
+                self.gpgkey.get_product_repo(
+                    new_name, repo.name, entity_type='Repository'
+                )
             )
 
     @run_only_on('sat')
     @tier2
     def test_positive_update_key_for_repo_from_product_with_repos(self):
-        """Create gpg key with valid name and valid gpg key then
-        associate it to repository from custom product that has more than
-        one repository then update the key
+        """Create gpg key with valid name and valid gpg key then associate it
+        to repository from custom product that has more than one repository
+        then update the key
 
         @id: d4f2fa16-860c-4ad5-b04f-8ce24b5618e9
 
-        @assert: gpg key is associated with single repository
-        before/after update but not with product
+        @assert: gpg key is associated with single repository before/after
+        update but not with product
 
         @CaseLevel: Integration
         """
@@ -1136,14 +1140,14 @@ class GPGKeyProductAssociateTestCase(UITestCase):
             organization=self.organization,
         ).create()
         # Creates new repository_1 with GPGKey
-        entities.Repository(
+        repo1 = entities.Repository(
             name=gen_string('alpha'),
             url=FAKE_1_YUM_REPO,
             product=product,
             gpg_key=gpg_key,
         ).create()
         # Creates new repository_2 without GPGKey
-        entities.Repository(
+        repo2 = entities.Repository(
             name=gen_string('alpha'),
             product=product,
             url=FAKE_2_YUM_REPO,
@@ -1154,20 +1158,38 @@ class GPGKeyProductAssociateTestCase(UITestCase):
             session.nav.go_to_select_org(self.organization.name)
             # Assert that GPGKey is not associated with product
             self.assertIsNone(
-                self.gpgkey.assert_product_repo(name, product=True)
+                self.gpgkey.get_product_repo(name, product.name)
             )
-            # Assert that GPGKey is associated with repository
+            # Assert that GPGKey is associated with first repository
             self.assertIsNotNone(
-                self.gpgkey.assert_product_repo(name, product=False)
+                self.gpgkey.get_product_repo(
+                    name, repo1.name, entity_type='Repository'
+                )
+            )
+            # Assert that GPGKey is not associated with second repository
+            self.assertIsNone(
+                self.gpgkey.get_product_repo(
+                    name, repo2.name, entity_type='Repository'
+                )
             )
             self.gpgkey.update(name, new_name)
             # Assert that after update GPGKey is not associated with product
             self.assertIsNone(
-                self.gpgkey.assert_product_repo(new_name, product=True)
+                self.gpgkey.get_product_repo(new_name, product.name)
             )
-            # Assert that after update GPGKey is not associated with repository
+            # Assert that after update GPGKey is associated with first
+            # repository
             self.assertIsNotNone(
-                self.gpgkey.assert_product_repo(new_name, product=False)
+                self.gpgkey.get_product_repo(
+                    new_name, repo1.name, entity_type='Repository'
+                )
+            )
+            # Assert that after update GPGKey is not associated with second
+            # repository
+            self.assertIsNone(
+                self.gpgkey.get_product_repo(
+                    new_name, repo2.name, entity_type='Repository'
+                )
             )
 
     @stubbed
@@ -1218,7 +1240,7 @@ class GPGKeyProductAssociateTestCase(UITestCase):
             session.nav.go_to_select_org(self.organization.name)
             # Assert that GPGKey is associated with product
             self.assertIsNotNone(
-                self.gpgkey.assert_product_repo(name, product=True)
+                self.gpgkey.get_product_repo(name, product.name)
             )
             self.gpgkey.delete(name)
             # Assert GPGKey isn't associated with product
@@ -1252,23 +1274,30 @@ class GPGKeyProductAssociateTestCase(UITestCase):
             organization=self.organization,
         ).create()
         # Creates new repository without GPGKey
-        entities.Repository(
+        repo = entities.Repository(
             name=gen_string('alpha'),
             url=FAKE_1_YUM_REPO,
             product=product,
         ).create()
         with Session(self.browser) as session:
             session.nav.go_to_select_org(self.organization.name)
-            # Assert that GPGKey is associated with product, repository
-            for product_ in (True, False):
-                self.assertIsNotNone(
-                    self.gpgkey.assert_product_repo(name, product=product_)
+            self.assertIsNotNone(
+                self.gpgkey.get_product_repo(name, product.name)
+            )
+            self.assertIsNotNone(
+                self.gpgkey.get_product_repo(
+                    name, repo.name, entity_type='Repository'
                 )
+            )
             self.gpgkey.delete(name)
             # Assert GPGKey isn't associated with product
             prd_element = self.products.search(product.name)
             self.assertIsNone(
                 self.gpgkey.assert_key_from_product(name, prd_element))
+            self.assertIsNone(
+                self.gpgkey.assert_key_from_product(
+                    name, prd_element, repo.name)
+            )
 
     @run_only_on('sat')
     @tier2
@@ -1310,18 +1339,12 @@ class GPGKeyProductAssociateTestCase(UITestCase):
         ).create()
         with Session(self.browser) as session:
             session.nav.go_to_select_org(self.organization.name)
-            # Assert that GPGKey is associated with product, repository
-            for product_ in (True, False):
-                self.assertIsNotNone(
-                    self.gpgkey.assert_product_repo(name, product=product_)
-                )
             self.gpgkey.delete(name)
             # Assert GPGKey isn't associated with product
             prd_element = self.products.search(product.name)
             self.assertIsNone(
                 self.gpgkey.assert_key_from_product(name, prd_element))
 
-    @skip_if_bug_open('bugzilla', 1210180)
     @run_only_on('sat')
     @tier2
     def test_positive_delete_key_for_product_using_repo_discovery(self):
@@ -1356,10 +1379,6 @@ class GPGKeyProductAssociateTestCase(UITestCase):
                 new_product=True,
                 product=product_name,
             )
-            for product_ in (True, False):
-                self.assertIsNotNone(
-                    self.gpgkey.assert_product_repo(name, product=product_)
-                )
             self.gpgkey.delete(name)
             prd_element = self.products.search(product_name)
             self.assertIsNone(
@@ -1399,15 +1418,6 @@ class GPGKeyProductAssociateTestCase(UITestCase):
         ).create()
         with Session(self.browser) as session:
             session.nav.go_to_select_org(self.organization.name)
-            session.nav.go_to_gpg_keys()
-            # Assert that GPGKey is not associated with product
-            self.assertIsNone(
-                self.gpgkey.assert_product_repo(name, product=True)
-            )
-            # Assert that GPGKey is associated with repository
-            self.assertIsNotNone(
-                self.gpgkey.assert_product_repo(name, product=False)
-            )
             self.gpgkey.delete(name)
             # Assert that after deletion GPGKey is not associated with product
             prd_element = self.products.search(product.name)
@@ -1441,7 +1451,7 @@ class GPGKeyProductAssociateTestCase(UITestCase):
             organization=self.organization,
         ).create()
         # Creates new repository_1 with GPGKey association
-        repo1 = entities.Repository(
+        repo = entities.Repository(
             gpg_key=gpg_key,
             name=gen_string('alpha'),
             product=product,
@@ -1455,21 +1465,14 @@ class GPGKeyProductAssociateTestCase(UITestCase):
         ).create()
         with Session(self.browser) as session:
             session.nav.go_to_select_org(self.organization.name)
-            session.nav.go_to_gpg_keys()
-            # Assert that GPGKey is not associated with product
-            self.assertIsNone(
-                self.gpgkey.assert_product_repo(name, product=True)
-            )
-            # Assert that GPGKey is associated with repository
-            self.assertIsNotNone(
-                self.gpgkey.assert_product_repo(name, product=False)
-            )
             self.gpgkey.delete(name)
             # Assert key shouldn't be associated with product or repository
             # after deletion
             prd_element = self.products.search(product.name)
             self.assertIsNone(self.gpgkey.assert_key_from_product(
-                name, prd_element, repo1.name))
+                name, prd_element))
+            self.assertIsNone(self.gpgkey.assert_key_from_product(
+                name, prd_element, repo.name))
 
     @stubbed()
     @run_only_on('sat')


### PR DESCRIPTION
```
nosetests tests/foreman/ui/test_gpgkey.py
......FSS.........FE....S.EE..ES.E....
----------------------------------------------------------------------
Ran 38 tests in 5365.934s

FAILED (SKIP=4, errors=5, failures=2)
```

3 errors happened due BZ1210180 which has WONTFIX resolution
few errors happened because I run tests on not proper infrastructure

1 failure stands for BZ1411800 which is ON_QA state for 6.2.z. Gonna verify the defect once I able to cherry-pick current code to 6.2.z branch
