### PR TITLE
[6.2.z] add-bugzilla-coverage-1420511

### DIFF
--- a/robottelo/api/utils.py
+++ b/robottelo/api/utils.py
@@ -213,3 +213,83 @@ def get_role_by_bz(bz_id):
                 ]
             entities.Filter(permission=permissions, role=role).create()
     return role.read()
+
+
+def create_role_permissions(role, permissions_types_names):  # pragma: no cover
+    """Create role permissions found in dict permissions_types_names.
+
+    :param role: nailgun.entities.Role
+    :param permissions_types_names: a dict containing resource types
+        and permission names to add to the role, example usage.
+
+          ::
+
+           permissions_types_names = {
+               None: ['access_dashboard'],
+               'Organization': ['view_organizations'],
+               'Location': ['view_locations'],
+               'Katello::KTEnvironment': [
+                   'view_lifecycle_environments',
+                   'edit_lifecycle_environments',
+                   'promote_or_remove_content_views_to_environments'
+               ]
+           }
+           role = entities.Role(name='example_role_name').create()
+           create_role_permissions(role, permissions_types_names)
+    """
+    for resource_type, permissions_name in permissions_types_names.items():
+        if resource_type is None:
+            permissions_entities = []
+            for name in permissions_name:
+                result = entities.Permission(name=name).search()
+                if not result:
+                    raise entities.APIResponseError(
+                        'permission "{}" not found'.format(name))
+                if len(result) > 1:
+                    raise entities.APIResponseError(
+                        'found more than one entity for permission'
+                        ' "{}"'.format(name)
+                    )
+                entity_permission = result[0]
+                if entity_permission.name != name:
+                    raise entities.APIResponseError(
+                        'the returned permission is different from the'
+                        ' requested one "{0} != {1}"'.format(
+                            entity_permission.name, name)
+                    )
+                permissions_entities.append(entity_permission)
+        else:
+            if not permissions_name:
+                raise ValueError('resource type "{}" empty. You must select at'
+                                 ' least one permission'.format(resource_type))
+
+            resource_type_permissions_entities = entities.Permission(
+                resource_type=resource_type).search()
+            if not resource_type_permissions_entities:
+                raise entities.APIResponseError(
+                    'resource type "{}" permissions not found'.format(
+                        resource_type)
+                )
+
+            permissions_entities = [
+                entity
+                for entity in resource_type_permissions_entities
+                if entity.name in permissions_name
+            ]
+            # ensure that all the requested permissions entities where
+            # retrieved
+            permissions_entities_names = {
+                entity.name for entity in permissions_entities
+            }
+            not_found_names = set(permissions_name).difference(
+                permissions_entities_names)
+            if not_found_names:
+                raise entities.APIResponseError(
+                    'permissions names entities not found'
+                    ' "{}"'.format(not_found_names)
+                )
+        entities.Filter(
+            permission=permissions_entities,
+            role=role,
+            search=None
+        ).create()

--- a/tests/foreman/ui/test_lifecycleenvironment.py
+++ b/tests/foreman/ui/test_lifecycleenvironment.py
@@ -18,10 +18,19 @@
 
 from fauxfactory import gen_string
 from nailgun import entities
+from robottelo.api.utils import create_role_permissions
 from robottelo.datafactory import generate_strings_list
-from robottelo.decorators import run_only_on, stubbed, tier1, tier2
+from robottelo.decorators import (
+    run_only_on,
+    skip_if_bug_open,
+    stubbed,
+    tier1,
+    tier2,
+)
 from robottelo.test import UITestCase
+from robottelo.ui.base import UINoSuchElementError
 from robottelo.ui.factory import make_lifecycle_environment
+from robottelo.ui.locators import menu_locators
 from robottelo.ui.session import Session
 
 
@@ -154,3 +163,90 @@ class LifeCycleEnvironmentTestCase(UITestCase):
 
         @caseautomation: notautomated
         """
+
+    @skip_if_bug_open('bugzilla', 1420511)
+    @run_only_on('sat')
+    @tier2
+    def test_positive_custom_user_view_lce(self):
+        """As a custom user attempt to view a lifecycle environment created
+        by admin user
+
+        @id: 768b647b-c530-4eca-9caa-38cf8622f36d
+
+        @BZ: 1420511
+
+        @Steps:
+
+        As an admin user:
+
+        1. Create an additional lifecycle environments other than Library
+        2. Create a user without administrator privileges
+        3. Create a role with the the following permissions:
+
+        * (Miscellaneous): access_dashboard
+        * Lifecycle Environment:
+
+          * edit_lifecycle_environments
+          * promote_or_remove_content_views_to_environment
+          * view_lifecycle_environments
+
+        * Location: view_locations
+        * Organization: view_organizations
+
+        4. Assign the created role to the custom user
+
+        As a custom user:
+
+        1. Log in
+        2. Navigate to Content -> Lifecycle Environments
+
+        @Assert: The additional lifecycle environment is viewable
+        and accessible by the custom user.
+
+        @CaseLevel: Integration
+        """
+        role_name = gen_string('alpha')
+        env_name = gen_string('alpha')
+        user_login = gen_string('alpha')
+        user_password = gen_string('alpha')
+        org = entities.Organization().create()
+        role = entities.Role(name=role_name).create()
+        permissions_types_names = {
+            None: ['access_dashboard'],
+            'Organization': ['view_organizations'],
+            'Location': ['view_locations'],
+            'Katello::KTEnvironment': [
+                'view_lifecycle_environments',
+                'edit_lifecycle_environments',
+                'promote_or_remove_content_views_to_environments'
+            ]
+        }
+        create_role_permissions(role, permissions_types_names)
+        entities.User(
+            default_organization=org,
+            organization=[org],
+            role=[role],
+            login=user_login,
+            password=user_password
+        ).create()
+        # create a life cycle environment as admin user and ensure it's visible
+        with Session(self.browser) as session:
+            make_lifecycle_environment(
+                session, org=org.name, name=env_name)
+            self.assertIsNotNone(self.lifecycleenvironment.search(env_name))
+
+        # ensure the created user also can find the created life cycle
+        # environment link
+        with Session(self.browser, user=user_login, password=user_password):
+            # to ensure that the created user has only the assigned
+            # permissions, check that hosts menu tab does not exist
+            self.assertIsNone(
+                self.content_views.wait_until_element(
+                    menu_locators['menu.hosts'], timeout=1)
+            )
+            # assert that the created user is not a global admin user
+            # check administer->users page
+            with self.assertRaises(UINoSuchElementError):
+                session.nav.go_to_users()
+            # assert that the user can view the lvce created by admin user
+            self.assertIsNotNone(self.lifecycleenvironment.search(env_name))


### PR DESCRIPTION
```console
2017-02-13 15:37:26 - robottelo.ui.locators - DEBUG - Accessing locator "content_env.select_name" by xpath: "//a[contains(@ui-sref, 'environment.details') and contains(.,'%s')]"
2017-02-13 15:37:38 - robottelo.ui.base - DEBUG - TimeoutException: Waiting for element '//a[contains(@ui-sref, 'environment.details') and contains(.,'xTgxCgeBbi')]' to display. Message: element //a[contains(@ui-sref, 'environment.details') and contains(.,'xTgxCgeBbi')] is not visible

2017-02-13 15:37:38 - robottelo - DEBUG - Finished Test: LifeCycleEnvironmentTestCase/test_positive_lvce_user_access
2017-02-13 15:37:38 - robottelo.test - DEBUG - Saving screenshot /tmp/robottelo/screenshots/2017-02-13/LifeCycleEnvironmentTestCase-test_positive_lvce_user_access-screenshot-2017-02-13_15_37_38.png

Failure
Traceback (most recent call last):
  File "/home/dlezz/projects/robottelo-fork/robottelo/decorators/__init__.py", line 254, in wrapper
    return func(*args, **kwargs)
  File "/home/dlezz/projects/robottelo-fork/tests/foreman/ui/test_lifecycleenvironment.py", line 273, in test_positive_lvce_user_access
    self.assertIsNotNone(self.lifecycleenvironment.search(env_name))
AssertionError: unexpectedly None

2017-02-13 15:37:38 - robottelo - DEBUG - Started tearDownClass: tests.foreman.ui.test_lifecycleenvironment/LifeCycleEnvironmentTestCase
2017-02-13 15:37:38 - nailgun.client - DEBUG - Making HTTP DELETE request to https://ibm-x3650m4-02-vm-01.lab.eng.bos.redhat.com/api/v2/users/36 with options {'verify': False, 'auth': ('admin', 'changeme'), 'headers': {'content-type': 'application/json'}} and no data.
2017-02-13 15:37:39 - nailgun.client - DEBUG - Received HTTP 200 response: {"id":36,"login":"TpUlLLMGII","firstname":"Robottelo User TpUlLLMGII","lastname":null,"mail":"jhaDdegz@test.gov","admin":true,"last_login_on":"2017-02-13T13:37:13.248Z","auth_source_id":1,"created_at":"2017-02-13T13:36:43.283Z","updated_at":"2017-02-13T13:37:13.249Z","password_hash":"f567e81a08fd7649c40494913dcd8ba4f419cc24","password_salt":"cc089a9691b8bc1c362ea8ec3003342c6ead2a3f","locale":null,"avatar_hash":null,"default_organization_id":1,"default_location_id":null,"lower_login":"tpulllmgii","mail_enabled":true,"timezone":null}
2017-02-13 15:37:39 - robottelo - INFO - Session user is being deleted: nailgun.entities.User(nailgun.config.ServerConfig(url='https://ibm-x3650m4-02-vm-01.lab.eng.bos.redhat.com', verify=False, auth=('admin', 'changeme')), organization=[], firstname=u'Robottelo User TpUlLLMGII', default_organization=nailgun.entities.Organization(nailgun.config.ServerConfig(url='https://ibm-x3650m4-02-vm-01.lab.eng.bos.redhat.com', verify=False, auth=('admin', 'changeme')), id=1), admin=True, lastname=None, role=[nailgun.entities.Role(nailgun.config.ServerConfig(url='https://ibm-x3650m4-02-vm-01.lab.eng.bos.redhat.com', verify=False, auth=('admin', 'changeme')), id=14)], location=[], auth_source=nailgun.entities.AuthSourceLDAP(nailgun.config.ServerConfig(url='https://ibm-x3650m4-02-vm-01.lab.eng.bos.redhat.com', verify=False, auth=('admin', 'changeme')), id=1), mail=u'jhaDdegz@test.gov', login=u'TpUlLLMGII', id=36, default_location=None)

Process finished with exit code 0
```
https://bugzilla.redhat.com/show_bug.cgi?id=1420511
issue : https://github.com/SatelliteQE/robottelo/issues/4329

for the moment the created user, cannot view the lifecycle environment , but it should by the given permissions 
**test to be cherry-picked to 6.3**
