### PR TITLE
6.2.z-add-bug-coverage-1420503

### DIFF
--- a/tests/foreman/cli/test_lifecycleenvironment.py
+++ b/tests/foreman/cli/test_lifecycleenvironment.py
@@ -22,7 +22,12 @@ from robottelo.cli.factory import make_lifecycle_environment, make_org
 from robottelo.cli.lifecycleenvironment import LifecycleEnvironment
 from robottelo.constants import ENVIRONMENT
 from robottelo.datafactory import valid_data_list
-from robottelo.decorators import run_only_on, tier1
+from robottelo.decorators import (
+    run_only_on,
+    skip_if_bug_open,
+    tier1,
+    tier2
+)
 from robottelo.test import CLITestCase
 
 
@@ -282,3 +287,42 @@ class LifeCycleEnvironmentTestCase(CLITestCase):
             u'Library >> {0}'.format(lc_env['name']),
             u''.join(result)
         )
+
+    @skip_if_bug_open('bugzilla', 1420503)
+    @run_only_on('sat')
+    @tier2
+    def test_positive_list_all_with_per_page(self):
+        """Attempt to list more than 20 lifecycle environment with per-page
+        option.
+
+        @id: 6e10fb0e-5e2c-45e6-85a8-0c853450257b
+
+        @BZ: 1420503
+
+        @assert: all the Lifecycle environments are listed
+        """
+        org = make_org()
+        lifecycle_environments_count = 25
+        per_page_count = lifecycle_environments_count + 5
+        env_base_name = gen_string('alpha')
+        last_env_name = ENVIRONMENT
+        env_names = [last_env_name]
+        for env_index in range(lifecycle_environments_count):
+            env_name = '{0}-{1}'.format(env_base_name, env_index)
+            make_lifecycle_environment({
+                'name': env_name,
+                'organization-id': org['id'],
+                'prior': last_env_name
+            })
+            last_env_name = env_name
+            env_names.append(env_name)
+
+        lifecycle_environments = LifecycleEnvironment.list({
+            'organization-id': org['id'],
+            'per_page': per_page_count
+        })
+
+        self.assertEqual(len(lifecycle_environments),
+                         lifecycle_environments_count + 1)
+        env_name_set = {env['name'] for env in lifecycle_environments}
+        self.assertEqual(env_name_set, set(env_names))


### PR DESCRIPTION
with lifecycle_environments_count = 19 and without per-page
```console
(2.7) dlezz@elysion:~/projects/robottelo-fork$ py.test tests/foreman/cli/test_lifecycleenvironment.py -v -k "test_positive_list_all_with_per_page"
================================================= test session starts ==================================================
platform linux2 -- Python 2.7.12, pytest-2.9.2, py-1.4.32, pluggy-0.3.1 -- /home/dlezz/bin/redhat/6.2.z/python/2.7/bin/python2.7
cachedir: .cache
rootdir: /home/dlezz/projects/robottelo-fork, inifile: 
plugins: xdist-1.14, cov-2.3.1
collected 12 items 

tests/foreman/cli/test_lifecycleenvironment.py::LifeCycleEnvironmentTestCase::test_positive_list_all_with_per_page <- robottelo/decorators/__init__.py PASSED

=========================== 11 tests deselected by '-ktest_positive_list_all_with_per_page' ============================
====================================== 1 passed, 11 deselected in 216.27 seconds =======================================
(2.7) dlezz@elysion:~/projects/robottelo-fork$ 
```

with lifecycle_environments_count = 25 and with per-page="30"
```console
bottelo.ssh - DEBUG - Connected to [ibm-x3650m4-02-vm-01.lab.eng.bos.redhat.com]
2017-02-13 18:02:18 - robottelo.ssh - DEBUG - >>> LANG=en_US.UTF-8  hammer -v -u admin -p changeme --output=csv lifecycle-environment list --per_page="30" --organization-id="64"
2017-02-13 18:02:21 - robottelo.ssh - DEBUG - <<< stderr
[ERROR 2017-02-13 11:02:22 Exception] Error: Unrecognised option '--per_page'

See: 'hammer lifecycle-environment list --help'
Error: Unrecognised option '--per_page'

See: 'hammer lifecycle-environment list --help'
[ERROR 2017-02-13 11:02:22 Exception] 

Clamp::UsageError (Unrecognised option '--per_page'):
    /opt/theforeman/tfm/root/usr/share/gems/gems/clamp-1.0.0/lib/clamp/option/parsing.rb:62:in `find_option'
    /opt/theforeman/tfm/root/usr/share/gems/gems/clamp-1.0.0/lib/clamp/option/parsing.rb:28:in `parse_options'
    /opt/theforeman/tfm/root/usr/share/gems/gems/clamp-1.0.0/lib/clamp/command.rb:53:in `parse'
    /opt/theforeman/tfm/root/usr/share/gems/gems/hammer_cli-0.5.1.12/lib/hammer_cli/abstract.rb:32:in `parse'
    /opt/theforeman/tfm/root/usr/share/gems/gems/clamp-1.0.0/lib/clamp/command.rb:67:in `run'
    /opt/theforeman/tfm/root/usr/share/gems/gems/hammer_cli-0.5.1.12/lib/hammer_cli/abstract.rb:24:in `run'
    /opt/theforeman/tfm/root/usr/share/gems/gems/clamp-1.0.0/lib/clamp/subcommand/execution.rb:11:in `execute'
    /opt/theforeman/tfm/root/usr/share/gems/gems/clamp-1.0.0/lib/clamp/command.rb:68:in `run'
    /opt/theforeman/tfm/root/usr/share/gems/gems/hammer_cli-0.5.1.12/lib/hammer_cli/abstract.rb:24:in `run'
    /opt/theforeman/tfm/root/usr/share/gems/gems/clamp-1.0.0/lib/clamp/subcommand/execution.rb:11:in `execute'
    /opt/theforeman/tfm/root/usr/share/gems/gems/clamp-1.0.0/lib/clamp/command.rb:68:in `run'
    /opt/theforeman/tfm/root/usr/share/gems/gems/hammer_cli-0.5.1.12/lib/hammer_cli/abstract.rb:24:in `run'
    /opt/theforeman/tfm/root/usr/share/gems/gems/clamp-1.0.0/lib/clamp/command.rb:133:in `run'
    /opt/theforeman/tfm/root/usr/share/gems/gems/hammer_cli-0.5.1.12/bin/hammer:125:in `<top (required)>'
    /usr/bin/hammer:23:in `load'
    /usr/bin/hammer:23:in `<main>'

```
bug: https://bugzilla.redhat.com/show_bug.cgi?id=1420503
issue: https://github.com/SatelliteQE/robottelo/issues/4328

to be cherry-picked to 6.3