### PR TITLE
Implemented CRUDs for API Host interface and covered BZ1285669

### DIFF
--- a/robottelo/datafactory.py
+++ b/robottelo/datafactory.py
@@ -297,6 +297,31 @@ def valid_usernames_list():
     )
 
 
+@filtered_datapoint
+def valid_interfaces_list():
+    """Generates a list of valid host interface names."""
+    return [
+        gen_string('alpha', random.randint(1, 255)).lower(),
+        gen_string('alphanumeric', random.randint(1, 255)).lower(),
+        gen_string('numeric', random.randint(1, 255)),
+    ]
+
+
+@filtered_datapoint
+def invalid_interfaces_list():
+    """Generates a list of invalid host interface names."""
+    return [
+        gen_string('alpha', 300).lower(),
+        gen_string('alphanumeric', 300).lower(),
+        gen_string('numeric', 300),
+        gen_string('cjk'),
+        gen_string('cyrillic'),
+        gen_string('html'),
+        gen_string('latin1'),
+        gen_string('utf8'),
+    ]
+
+
 def valid_http_credentials(url_encoded=False):
     """Returns a list of valid credentials for HTTP authentication
     The credentials dictionary contains the following keys:

--- a/tests/foreman/api/test_host.py
+++ b/tests/foreman/api/test_host.py
@@ -1374,9 +1374,7 @@ class HostInterfaceTestCase(APITestCase):
         for name in valid_interfaces_list():
             with self.subTest(name):
                 interface = entities.Interface(
-                    host=self.host,
-                    name=name,
-                ).create()
+                    host=self.host, name=name).create()
                 self.assertEqual(interface.name, name)
 
     @tier1
@@ -1390,11 +1388,9 @@ class HostInterfaceTestCase(APITestCase):
         """
         for name in invalid_interfaces_list():
             with self.subTest(name):
-                with self.assertRaises(HTTPError):
-                    entities.Interface(
-                        host=self.host,
-                        name=name,
-                    ).create()
+                with self.assertRaises(HTTPError) as error:
+                    entities.Interface(host=self.host, name=name).create()
+                self.assertEqual(error.exception.response.status_code, 422)
 
     @tier1
     def test_positive_update_name(self):
@@ -1424,9 +1420,10 @@ class HostInterfaceTestCase(APITestCase):
         for new_name in invalid_interfaces_list():
             with self.subTest(new_name):
                 interface.name = new_name
-                with self.assertRaises(HTTPError):
+                with self.assertRaises(HTTPError) as error:
                     interface.update(['name'])
                 self.assertNotEqual(interface.read().name, new_name)
+                self.assertEqual(error.exception.response.status_code, 422)
 
     @tier1
     def test_positive_delete(self):
@@ -1478,10 +1475,7 @@ class HostInterfaceTestCase(APITestCase):
         @Assert: An interface was successfully deleted, host was not deleted
         """
         host = entities.Host().create()
-        interface = entities.Interface(
-            host=host,
-            primary=False,
-        ).create()
+        interface = entities.Interface(host=host, primary=False).create()
         interface.delete()
         with self.assertRaises(HTTPError):
             interface.read()

--- a/tests/robottelo/test_datafactory.py
+++ b/tests/robottelo/test_datafactory.py
@@ -10,6 +10,7 @@ from robottelo.datafactory import (
     generate_strings_list,
     invalid_emails_list,
     invalid_id_list,
+    invalid_interfaces_list,
     invalid_names_list,
     invalid_values_list,
     invalid_usernames_list,
@@ -19,6 +20,7 @@ from robottelo.datafactory import (
     valid_environments_list,
     valid_hosts_list,
     valid_hostgroups_list,
+    valid_interfaces_list,
     valid_labels_list,
     valid_names_list,
     valid_org_names_list,
@@ -42,8 +44,9 @@ class FilteredDataPointTestCase(unittest2.TestCase):
         """Tests if run_one_datapoint=false returns all data points"""
         settings.run_one_datapoint = False
         self.assertEqual(len(generate_strings_list()), 7)
-        self.assertEqual(len(invalid_id_list()), 4)
         self.assertEqual(len(invalid_emails_list()), 10)
+        self.assertEqual(len(invalid_id_list()), 4)
+        self.assertEqual(len(invalid_interfaces_list()), 8)
         self.assertEqual(len(invalid_names_list()), 7)
         self.assertEqual(len(invalid_values_list()), 10)
         self.assertEqual(len(invalid_usernames_list()), 4)
@@ -53,6 +56,7 @@ class FilteredDataPointTestCase(unittest2.TestCase):
         self.assertEqual(len(valid_environments_list()), 3)
         self.assertEqual(len(valid_hosts_list()), 3)
         self.assertEqual(len(valid_hostgroups_list()), 7)
+        self.assertEqual(len(valid_interfaces_list()), 3)
         self.assertEqual(len(valid_names_list()), 15)
         self.assertEqual(len(valid_org_names_list()), 7)
         self.assertEqual(len(valid_usernames_list()), 6)
@@ -63,6 +67,7 @@ class FilteredDataPointTestCase(unittest2.TestCase):
         self.assertEqual(len(generate_strings_list()), 1)
         self.assertEqual(len(invalid_emails_list()), 1)
         self.assertEqual(len(invalid_id_list()), 1)
+        self.assertEqual(len(invalid_interfaces_list()), 1)
         self.assertEqual(len(invalid_names_list()), 1)
         self.assertEqual(len(invalid_values_list()), 1)
         self.assertEqual(len(valid_data_list()), 1)
@@ -70,6 +75,7 @@ class FilteredDataPointTestCase(unittest2.TestCase):
         self.assertEqual(len(valid_environments_list()), 1)
         self.assertEqual(len(valid_hosts_list()), 1)
         self.assertEqual(len(valid_hostgroups_list()), 1)
+        self.assertEqual(len(valid_interfaces_list()), 1)
         self.assertEqual(len(valid_labels_list()), 1)
         self.assertEqual(len(valid_names_list()), 1)
         self.assertEqual(len(valid_org_names_list()), 1)
@@ -112,17 +118,21 @@ class TestReturnTypes(unittest2.TestCase):
         11. :meth:`robottelo.datafactory.valid_org_names_list`
         12. :meth:`robottelo.datafactory.valid_usernames_list`
         13. :meth:`robottelo.datafactory.invalid_id_list`
+        14. :meth:`robottelo.datafactory.invalid_interfaces_list`
+        15. :meth:`robottelo.datafactory.valid_interfaces_list`
 
         """
         for item in itertools.chain(
                 generate_strings_list(),
                 invalid_emails_list(),
+                invalid_interfaces_list(),
                 invalid_names_list(),
                 valid_data_list(),
                 valid_emails_list(),
                 valid_environments_list(),
                 valid_hosts_list(),
                 valid_hostgroups_list(),
+                valid_interfaces_list(),
                 valid_labels_list(),
                 valid_names_list(),
                 valid_org_names_list(),


### PR DESCRIPTION
http://bugzilla.redhat.com/show_bug.cgi?id=1285669

```python
py.test tests/foreman/api/test_host.py::HostInterfaceTestCase
============================= test session starts ==============================
platform darwin -- Python 2.7.13, pytest-3.0.6, py-1.4.32, pluggy-0.4.0
rootdir: /Users/andrii/workspace/robottelo, inifile:
collected 7 items

tests/foreman/api/test_host.py .......

========================== 7 passed in 100.81 seconds ==========================
```

Depends on SatelliteQE/nailgun#373