### PR TITLE
[6.2.z] Cherrey-pick - Automate BZ 1213097 / Added tests for CV create with repo

### DIFF
--- a/robottelo/cli/factory.py
+++ b/robottelo/cli/factory.py
@@ -287,8 +287,11 @@ def make_content_view(options=None):
         --organization ORGANIZATION_NAME  Organization name to search by
         --organization-id ORGANIZATION_ID Organization identifier
         --organization-label ORGANIZATION_LABEL Organization label to search by
+        --product PRODUCT_NAME          Product name to search by
+        --product-id PRODUCT_ID         product numeric identifier
+        --repositories REPOSITORY_NAMES Comma separated list of values.
         --repository-ids REPOSITORY_IDS List of repository ids
-                                      Comma separated list of values.
+                                        Comma separated list of values.
         -h, --help                    print help
 
     """
@@ -305,6 +308,9 @@ def make_content_view(options=None):
         u'organization': None,
         u'organization-id': None,
         u'organization-label': None,
+        u'product': None,
+        u'product-id': None,
+        u'repositories': None,
         u'repository-ids': None
     }
 

--- a/tests/foreman/cli/test_contentview.py
+++ b/tests/foreman/cli/test_contentview.py
@@ -183,6 +183,43 @@ class ContentViewTestCase(CLITestCase):
         with self.assertRaises(CLIReturnCodeError):
             ContentView.create({'organization-id': gen_string('alpha')})
 
+    @tier2
+    @run_only_on('sat')
+    def test_positive_create_with_repo_id(self):
+        """Create content view providing repository id
+
+        @id: bb91affe-f8d4-4724-8b61-41f3cb898fd3
+
+        @assert: Content view is created and repository is associated with CV
+
+        @BZ: 1213097
+        """
+        repo = make_repository({'product-id': self.product['id']})
+        cv = make_content_view({
+            'organization-id': self.org['id'],
+            'repository-ids': [repo['id']],
+        })
+        self.assertEqual(cv['yum-repositories'][0]['id'], repo['id'])
+
+    @tier2
+    @run_only_on('sat')
+    def test_positive_create_with_repo_name(self):
+        """Create content view providing repository name
+
+        @id: 80992a94-4c8e-4dbe-bc62-25af0bd2301d
+
+        @assert: Content view is created and repository is associated with CV
+
+        @BZ: 1213097
+        """
+        repo = make_repository({'product-id': self.product['id']})
+        cv = make_content_view({
+            'organization-id': self.org['id'],
+            'product': self.product['name'],
+            'repositories': [repo['name']],
+        })
+        self.assertEqual(cv['yum-repositories'][0]['name'], repo['name'])
+
     @tier1
     def test_positive_create_empty_and_verify_files(self):
         """Create an empty content view and make sure no files are created at


### PR DESCRIPTION
Cherrt-picked from #4303.
https://bugzilla.redhat.com/show_bug.cgi?id=1213097

Test results for 6.2:
```python
% py.test  -v tests/foreman/cli/test_contentview.py -k 'create_with_repo'
===================================================================== test session starts =====================================================================
platform linux2 -- Python 2.7.12, pytest-2.9.2, py-1.4.31, pluggy-0.3.1 -- /home/qui/code/venv/6.2.z/bin/python2
cachedir: .cache
rootdir: /home/qui/code/robottelo, inifile: 
plugins: xdist-1.14, cov-2.3.1
collected 51 items 
2017-02-14 13:34:35 - conftest - DEBUG - Found WONTFIX in decorated tests ['1269196', '1210180', '1103157', '1156555', '1230902', '1245334', '1204686', '1267224', '1226425', '1217635', '1079482', '1214312']

2017-02-14 13:34:35 - conftest - DEBUG - Collected 51 test cases


tests/foreman/cli/test_contentview.py::ContentViewTestCase::test_positive_create_with_repo_id <- robottelo/decorators/__init__.py PASSED
tests/foreman/cli/test_contentview.py::ContentViewTestCase::test_positive_create_with_repo_name <- robottelo/decorators/__init__.py PASSED

========================================================= 49 tests deselected by '-kcreate_with_repo' =========================================================
========================================================== 2 passed, 49 deselected in 141.23 seconds ==========================================================
```