### PR TITLE
[6.2.z] Cherry-pick - Automate BZ 1291271

### DIFF
--- a/tests/foreman/ui/test_activationkey.py
+++ b/tests/foreman/ui/test_activationkey.py
@@ -1284,3 +1284,38 @@ class ActivationKeyTestCase(UITestCase):
                         self.activationkey.search(self.base_key_name))
                     self.activationkey.copy(self.base_key_name, new_name)
                     self.assertIsNone(self.activationkey.search(new_name))
+
+    @tier2
+    def test_positive_remove_user(self):
+        """Delete any user who has previously created an activation key
+        and check that activation key still exists
+
+        @id: f0504bd8-52d2-40cd-91c6-64d71b14c876
+
+        @Assert: Activation Key can be read
+
+        @BZ: 1291271
+        """
+        ak_name = gen_string('alpha')
+        # Create user
+        password = gen_string('alpha')
+        user = entities.User(
+            password=password, login=gen_string('alpha'), admin=True).create()
+        # Create Activation Key with new user credentials
+        with Session(
+                self.browser,
+                user=user.login,
+                password=password,
+        ) as session:
+            make_activationkey(
+                session,
+                org=self.organization.name,
+                name=ak_name,
+                env=ENVIRONMENT,
+            )
+            self.assertIsNotNone(self.activationkey.search(ak_name))
+        # Remove user and check that AK still exists
+        user.delete()
+        with Session(self.browser) as session:
+            set_context(session, org=self.organization.name)
+            self.assertIsNotNone(self.activationkey.search(ak_name))


### PR DESCRIPTION
Cherry-picked from #4304
https://bugzilla.redhat.com/show_bug.cgi?id=1291271

```python
% py.test  -v tests/foreman/{api,cli,ui}/test_activationkey.py -k 'remove_user' 
===================================================================== test session starts =====================================================================
platform linux2 -- Python 2.7.12, pytest-2.9.2, py-1.4.31, pluggy-0.3.1 -- /home/qui/code/venv/6.2.z/bin/python2
cachedir: .cache
rootdir: /home/qui/code/robottelo, inifile: 
plugins: xdist-1.14, cov-2.3.1
collected 104 items 
2017-02-14 13:55:47 - conftest - DEBUG - Found WONTFIX in decorated tests ['1269196', '1210180', '1103157', '1156555', '1230902', '1245334', '1204686', '1267224', '1226425', '1217635', '1079482', '1214312']

2017-02-14 13:55:47 - conftest - DEBUG - Collected 104 test cases

2017-02-14 13:55:47 - conftest - DEBUG - Deselected test tests.foreman.api.test_activationkey.test_negative_create_with_no_host_limit_set_max due to WONTFIX


tests/foreman/api/test_activationkey.py::ActivationKeyTestCase::test_positive_remove_user PASSED
tests/foreman/cli/test_activationkey.py::ActivationKeyTestCase::test_positive_remove_user PASSED
tests/foreman/ui/test_activationkey.py::ActivationKeyTestCase::test_positive_remove_user PASSED

=========================================================== 101 tests deselected by '-kremove_user' ===========================================================
========================================================= 3 passed, 101 deselected in 153.41 seconds ==========================================================
```