### PR TITLE
[Cherry-pick] Added UI host test to automate BZ1391656

### DIFF
--- a/robottelo/ui/hosts.py
+++ b/robottelo/ui/hosts.py
@@ -256,3 +256,38 @@ class Hosts(Base):
         self.assign_value(
             locators['host.smart_variable_value'] % sv_name, sv_value)
         self.click(common_locators['submit'])
+
+    def fetch_host_parameters(self, name, domain_name, parameters_list):
+        """Fetches parameter values of specified host
+
+        :param name: host's name (without domain part)
+        :param domain_name: host's domain name
+        :param parameters_list: A list of parameters to be fetched. Each
+            parameter should be a separate list containing tab name and
+            parameter name in absolute correspondence to UI (Similar to
+            parameters list passed to create a host). Example::
+
+                [
+                    ['Host', 'Lifecycle Environment'],
+                    ['Host', 'Content View'],
+                ]
+
+        :return: Dictionary of parameter name - parameter value pairs
+        :rtype: dict
+        """
+        host = self.search(u'{0}.{1}'.format(name, domain_name))
+        self.click(host)
+        self.click(locators['host.edit'])
+        result = {}
+        for tab_name, param_name in parameters_list:
+            tab_locator = tab_locators['.tab_'.join((
+                'host',
+                (tab_name.lower()).replace(' ', '_')
+            ))]
+            param_locator = locators['.fetch_'.join((
+                'host',
+                (param_name.lower()).replace(' ', '_')
+            ))]
+            self.click(tab_locator)
+            result[param_name] = self.wait_until_element(param_locator).text
+        return result

--- a/robottelo/ui/locators/base.py
+++ b/robottelo/ui/locators/base.py
@@ -514,10 +514,18 @@ locators = LocatorDict({
         By.XPATH,
         ("//div[contains(@id, 'host_lifecycle_environment_id')]/a"
          "/span[contains(@class, 'arrow')]")),
+    "host.fetch_lifecycle_environment": (
+        By.XPATH,
+        ("//div[contains(@id, 'host_lifecycle_environment_id')]/a"
+         "/span[contains(@class, 'chosen')]")),
     "host.content_view": (
         By.XPATH,
         ("//div[contains(@id, 'host_content_view_id')]/a"
          "/span[contains(@class, 'arrow')]")),
+    "host.fetch_content_view": (
+        By.XPATH,
+        ("//div[contains(@id, 'host_content_view_id')]/a"
+         "/span[contains(@class, 'chosen')]")),
     "host.puppet_environment": (
         By.XPATH,
         ("//div[contains(@id, 'host_environment_id')]/a"

--- a/tests/foreman/ui/test_host.py
+++ b/tests/foreman/ui/test_host.py
@@ -23,6 +23,8 @@ from robottelo.api.utils import (
     upload_manifest,
 )
 from robottelo import manifests
+from robottelo.cli.contentview import ContentView as cli_ContentView
+from robottelo.cli.proxy import Proxy as cli_Proxy
 from robottelo.config import settings
 from robottelo.constants import (
     DEFAULT_CV,
@@ -39,12 +41,15 @@ from robottelo.decorators import (
     skip_if_bug_open,
     skip_if_not_set,
     stubbed,
+    tier2,
     tier3,
 )
 from robottelo.decorators.host import skip_if_os
 from robottelo.test import UITestCase
-from robottelo.ui.factory import make_host
+from robottelo.ui.factory import make_host, set_context
 from robottelo.ui.session import Session
+
+import robottelo.cli.factory as cli_factory
 
 
 class HostTestCase(UITestCase):
@@ -691,6 +696,71 @@ class HostTestCase(UITestCase):
             # Delete host
             self.hosts.delete(
                 u'{0}.{1}'.format(host.name, host.domain.name))
+
+    @tier2
+    def test_positive_validate_inherited_cv_lce(self):
+        """Create a host with hostgroup specified via CLI. Make sure host
+        inherited hostgroup's lifecycle environment, content view and both
+        fields are properly reflected via WebUI
+
+        @id: c83f6819-2649-4a8b-bb1d-ce93b2243765
+
+        @Assert: Host's lifecycle environment and content view match the ones
+        specified in hostgroup
+
+        @CaseLevel: Integration
+
+        @BZ: 1391656
+        """
+        host = entities.Host()
+        host.create_missing()
+
+        new_lce = cli_factory.make_lifecycle_environment({
+            'organization-id': host.organization.id})
+        new_cv = cli_factory.make_content_view({
+            'organization-id': host.organization.id})
+        cli_ContentView.publish({'id': new_cv['id']})
+        version_id = cli_ContentView.version_list({
+            'content-view-id': new_cv['id'],
+        })[0]['id']
+        cli_ContentView.version_promote({
+            'id': version_id,
+            'to-lifecycle-environment-id': new_lce['id'],
+            'organization-id': host.organization.id,
+        })
+        hostgroup = cli_factory.make_hostgroup({
+            'content-view-id': new_cv['id'],
+            'lifecycle-environment-id': new_lce['id'],
+            'organization-ids': host.organization.id,
+        })
+        puppet_proxy = cli_Proxy.list({
+            'search': 'url = https://{0}:9090'.format(settings.server.hostname)
+        })[0]
+
+        cli_factory.make_host({
+            'architecture-id': host.architecture.id,
+            'domain-id': host.domain.id,
+            'environment-id': host.environment.id,
+            'hostgroup-id': hostgroup['id'],
+            'location-id': host.location.id,
+            'medium-id': host.medium.id,
+            'name': host.name,
+            'operatingsystem-id': host.operatingsystem.id,
+            'organization-id': host.organization.id,
+            'partition-table-id': host.ptable.id,
+            'puppet-proxy-id': puppet_proxy['id'],
+        })
+
+        with Session(self.browser) as session:
+            set_context(session, host.organization.name, host.location.name)
+            result = self.hosts.fetch_host_parameters(
+                host.name,
+                host.domain.name,
+                [['Host', 'Lifecycle Environment'],
+                 ['Host', 'Content View']],
+            )
+            self.assertEqual(result['Lifecycle Environment'], new_lce['name'])
+            self.assertEqual(result['Content View'], new_cv['name'])
 
     @stubbed()
     @tier3


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1391656

Basically a cherry-pick from #4313 of UI test (CLI part is already merged)

Test results:
```python
py.test tests/foreman/ui/test_host.py -k test_positive_validate_inherited_cv_lce
============================= test session starts ==============================
platform darwin -- Python 2.7.13, pytest-3.0.6, py-1.4.32, pluggy-0.4.0
rootdir: /Users/andrii/workspace/robottelo, inifile:
collected 20 items


[Cherry-pick] Added UI host test to automate BZ1391656
2017-02-14 16:03:26 - conftest - DEBUG - Found WONTFIX in decorated tests ['1269196', '1245334', '1217635', '1226425', '1156555', '1204686', '1267224', '1103157', '1230902', '1214312', '1079482']

2017-02-14 16:03:26 - conftest - DEBUG - Collected 20 test cases


tests/foreman/ui/test_host.py .

============================= 19 tests deselected ==============================
================== 1 passed, 19 deselected in 244.30 seconds ===================
```