### PR TITLE
[6.3.0] add bugzilla configuration and validation and add bugzilla credentials settings to robozilla bugzilla reader

### DIFF
--- a/robottelo.properties.sample
+++ b/robottelo.properties.sample
@@ -104,7 +104,7 @@ ssh_key=
 # sattools_repo=http://sattools/repo
 
 # Bugzilla data to authenticate API calls
-[bugzilla]
+# [bugzilla]
 # username used when accessing Bugzilla's API
 # bz_username=admin
 

--- a/robottelo/bz_helpers.py
+++ b/robottelo/bz_helpers.py
@@ -1,11 +1,22 @@
 # coding: utf-8
+import logging
 import os
 from collections import defaultdict
+
+from robottelo.config import settings
 from robottelo.config.base import get_project_root
+from robottelo.decorators import setting_is_set
 from robozilla.filters import BZDecorator
 from robozilla.parser import Parser
 
 BASE_PATH = os.path.join(get_project_root(), 'tests', 'foreman')
+
+
+LOGGER = logging.getLogger(__name__)
+
+
+def log_debug(message):
+    LOGGER.debug(message)
 
 
 def get_decorated_bugs():  # pragma: no cover
@@ -15,18 +26,36 @@ def get_decorated_bugs():  # pragma: no cover
     Important information is stored on `bug_data` key::
         bugs[BUG_ID]['bug_data']['resolution|status|flags|whiteboard']
     """
-    parser = Parser(BASE_PATH, filters=[BZDecorator])
+    # look for settings bugzilla credentials
+    # any way Parser bugzilla reader will check for exported environment names
+    # BUGZILLA_USER_NAME and BUGZILLA_USER_PASSWORD if no credentials was
+    # supplied
+    bz_reader_options = {}
+    bz_credentials = {}
+    if setting_is_set('bugzilla'):
+        bz_credentials = settings.bugzilla.get_credentials()
+
+    bz_reader_options['credentials'] = bz_credentials
+    parser = Parser(BASE_PATH, filters=[BZDecorator],
+                    reader_options=bz_reader_options)
     bugs = parser.parse()
     return bugs
 
 
-def get_wontfix_bugs(bugs=None):
+def get_wontfix_bugs(bugs=None, log=None):
     """returns the ID of bugs CLOSED as WONTFIX"""
+    if log is None:
+        log = log_debug
     bugs = bugs or get_decorated_bugs()
     wontfixes = []
     for bug_id, data in bugs.items():
-        if data['bug_data']['resolution'] in ('WONTFIX', 'CANTFIX'):
-            wontfixes.append(bug_id)
+        bug_data = data.get('bug_data')
+        # when not authenticated, private bugs will have no bug data
+        if bug_data and bug_data['resolution'] in ('WONTFIX', 'CANTFIX'):
+                wontfixes.append(bug_id)
+        else:
+            log('bug data for bug id "{}" was not retrieved,'
+                ' please review bugzilla credentials'.format(bug_id))
     return wontfixes
 
 
@@ -36,8 +65,3 @@ def group_by_key(data):
     for k, v in data:
         res[k].append(v)
     return dict(res)
-
-
-def get_func_name(func):
-    """Given a func object return standardized name to use across project"""
-    return '{0}.{1}'.format(func.__module__, func.__name__)

--- a/robottelo/config/base.py
+++ b/robottelo/config/base.py
@@ -244,7 +244,14 @@ class BugzillaSettings(FeatureSettings):
         return {'user': self.username, 'password': self.password}
 
     def validate(self):
-        return []
+        validation_errors = []
+        if self.username is None:
+            validation_errors.append(
+                '[bugzilla] bz_username must be provided.')
+        if self.password is None:
+            validation_errors.append(
+                '[bugzilla] bz_password must be provided.')
+        return validation_errors
 
 
 class ClientsSettings(FeatureSettings):

--- a/robottelo/decorators/__init__.py
+++ b/robottelo/decorators/__init__.py
@@ -8,7 +8,7 @@ import re
 import requests
 import unittest2
 from functools import wraps
-from robottelo.bz_helpers import get_func_name
+from robottelo.helpers import get_func_name
 from robottelo.config import settings
 from robottelo.constants import (
     BUGZILLA_URL,
@@ -299,9 +299,9 @@ def _get_bugzilla_bug(bug_id):
     else:
         LOGGER.info('Bugzilla bug {0} not in cache. Fetching.'.format(bug_id))
         # Make a network connection to the Bugzilla server.
-        bz_credentials = settings.bugzilla.get_credentials()
-        if any(value is None for value in bz_credentials.values()):
-            bz_credentials = {}
+        bz_credentials = {}
+        if setting_is_set('bugzilla'):
+            bz_credentials = settings.bugzilla.get_credentials()
         try:
             bz_conn = bugzilla.RHBugzilla(url=BUGZILLA_URL, **bz_credentials)
         except (TypeError, ValueError):  # pragma: no cover

--- a/robottelo/helpers.py
+++ b/robottelo/helpers.py
@@ -390,3 +390,8 @@ class Storage(object):
             kwargs.update(item)
         for key, value in kwargs.items():
             setattr(self, key, value)
+
+
+def get_func_name(func):
+    """Given a func object return standardized name to use across project"""
+    return '{0}.{1}'.format(func.__module__, func.__name__)

--- a/tests/foreman/conftest.py
+++ b/tests/foreman/conftest.py
@@ -2,8 +2,8 @@
 """Configurations for py.test runner"""
 import datetime
 import pytest
-
-from robottelo.bz_helpers import get_wontfix_bugs, group_by_key, get_func_name
+from robottelo.bz_helpers import get_wontfix_bugs, group_by_key
+from robottelo.helpers import get_func_name
 
 
 def log(message, level="DEBUG"):
@@ -44,7 +44,7 @@ def pytest_namespace():
     log("Registering custom pytest_namespace")
     return {
         'bugzilla': {
-            'wontfix_ids': get_wontfix_bugs(),
+            'wontfix_ids': get_wontfix_bugs(log=log),
             'decorated_functions': []
         }
     }

--- a/tests/robottelo/test_bz_helpers.py
+++ b/tests/robottelo/test_bz_helpers.py
@@ -1,7 +1,8 @@
 # coding: utf-8
 
 from unittest2 import TestCase
-from robottelo.bz_helpers import get_wontfix_bugs, group_by_key, get_func_name
+from robottelo.bz_helpers import get_wontfix_bugs, group_by_key
+from robottelo.helpers import get_func_name
 
 
 class BZHelperTestCase(TestCase):


### PR DESCRIPTION
for unauthenticated bz calls private bugs are not returned and bug_data does not exist, which result to exception.
also when bugzilla is first launched will create a cache, for some users launching the tests locally  the bz settings does not work and no cache exists.

```console
(2.7) dlezz@elysion:~/projects/robottelo-fork$  py.test -v  -m 'not stubbed' tests/foreman/api/test_organization.py
================================================= test session starts ==================================================
platform linux2 -- Python 2.7.12, pytest-3.0.6, py-1.4.31, pluggy-0.4.0 -- /home/dlezz/bin/redhat/python/2.7/bin/python2.7
cachedir: .cache
rootdir: /home/dlezz/projects/robottelo-fork, inifile: 
plugins: xdist-1.15.0, cov-2.3.1
collected 21 items 
2017-02-14 18:18:15 - conftest - DEBUG - Found WONTFIX in decorated tests ['1269196', '1245334', '1217635', '1226425', '1156555', '1204686', '1267224', '1103157', '1230902', '1214312', '1079482']

2017-02-14 18:18:15 - conftest - DEBUG - Collected 21 test cases

2017-02-14 18:18:15 - conftest - DEBUG - Deselected test tests.foreman.api.test_organization.test_verify_bugzilla_1103157 due to WONTFIX


tests/foreman/api/test_organization.py::OrganizationTestCase::test_negative_create_with_invalid_name PASSED
tests/foreman/api/test_organization.py::OrganizationTestCase::test_negative_create_with_same_name PASSED
tests/foreman/api/test_organization.py::OrganizationTestCase::test_positive_create_text_plain PASSED
tests/foreman/api/test_organization.py::OrganizationTestCase::test_positive_create_with_auto_label PASSED
tests/foreman/api/test_organization.py::OrganizationTestCase::test_positive_create_with_custom_label PASSED
tests/foreman/api/test_organization.py::OrganizationTestCase::test_positive_create_with_name_and_description PASSED
tests/foreman/api/test_organization.py::OrganizationTestCase::test_positive_create_with_name_and_label PASSED
tests/foreman/api/test_organization.py::OrganizationTestCase::test_positive_create_with_name_label_description PASSED
tests/foreman/api/test_organization.py::OrganizationTestCase::test_positive_search PASSED
tests/foreman/api/test_organization.py::OrganizationUpdateTestCase::test_negative_update PASSED
tests/foreman/api/test_organization.py::OrganizationUpdateTestCase::test_positive_add_hostgroup PASSED
tests/foreman/api/test_organization.py::OrganizationUpdateTestCase::test_positive_add_media <- robottelo/decorators/__init__.py SKIPPED
tests/foreman/api/test_organization.py::OrganizationUpdateTestCase::test_positive_add_smart_proxy <- robottelo/decorators/__init__.py SKIPPED
tests/foreman/api/test_organization.py::OrganizationUpdateTestCase::test_positive_remove_hostgroup <- robottelo/decorators/__init__.py SKIPPED
tests/foreman/api/test_organization.py::OrganizationUpdateTestCase::test_positive_remove_smart_proxy <- robottelo/decorators/__init__.py SKIPPED
tests/foreman/api/test_organization.py::OrganizationUpdateTestCase::test_positive_update_description PASSED
tests/foreman/api/test_organization.py::OrganizationUpdateTestCase::test_positive_update_name PASSED
tests/foreman/api/test_organization.py::OrganizationUpdateTestCase::test_positive_update_name_and_description PASSED
tests/foreman/api/test_organization.py::OrganizationUpdateTestCase::test_positive_update_subnet PASSED
tests/foreman/api/test_organization.py::OrganizationUpdateTestCase::test_positive_update_user PASSED

================================================== 1 tests deselected ==================================================
================================= 16 passed, 4 skipped, 1 deselected in 197.51 seconds =================================
(2.7) dlezz@elysion:~/projects/robottelo-fork$ 
```
**to be cherry-picked to 6.2.z**

**important**
please note that the location of python-bugzilla cache has changed 
see https://github.com/python-bugzilla/python-bugzilla/blob/master/bugzilla.1#L219
from ~/.<filename> to ~/.cache/python-bugzilla/.<filename>
that can influence the automation that probably must have the cached files in the two places for jenkins user.
for the moment it seems bugzilla is looking to both location.

in recap of bugzilla config
if config:
```text
[bugzilla]
# bz_username=
# bz_password=
```
py.test result 
```console
robottelo.config.base.ImproperlyConfigured: Failed to validate the configuration, check the message(s):
[bugzilla] bz_username must be provided.
[bugzilla] bz_password must be provided.
```
___________________________________________________
if config:
```text
# [bugzilla]
# bz_username=
# bz_password=
```
py.test result 
if bugzilla was invoked earlier with credentials and there is a cache bugzilla will detect that and will authenticate from the cache
if not bugzilla will work as anonymous

if config:
```text
[bugzilla]
bz_username=
bz_password=
```
py.test result 
if bugzilla was invoked earlier with credentials and there is a cache 
bugzilla will detect that and will authenticate from the cache
bugzilla will work as anonymous if failed authentication or authenticated if the user and password are correct

