### PR TITLE
[6.3][cherry-pick] FIX logging without data, but data was retrieved with resolution not in ('WONTFIX', 'CANFIX')

### DIFF
--- a/robottelo/bz_helpers.py
+++ b/robottelo/bz_helpers.py
@@ -51,7 +51,8 @@ def get_wontfix_bugs(bugs=None, log=None):
     for bug_id, data in bugs.items():
         bug_data = data.get('bug_data')
         # when not authenticated, private bugs will have no bug data
-        if bug_data and bug_data['resolution'] in ('WONTFIX', 'CANTFIX'):
+        if bug_data:
+            if bug_data['resolution'] in ('WONTFIX', 'CANTFIX'):
                 wontfixes.append(bug_id)
         else:
             log('bug data for bug id "{}" was not retrieved,'


### PR DESCRIPTION
```console
platform linux2 -- Python 2.7.12, pytest-3.0.6, py-1.4.31, pluggy-0.4.0 -- /home/dlezz/bin/redhat/python/2.7/bin/python2.7
cachedir: .cache
rootdir: /home/dlezz/projects/robottelo-fork, inifile: 
plugins: xdist-1.15.0, cov-2.3.1
collected 21 items 
2017-02-16 14:28:47 - conftest - DEBUG - Found WONTFIX in decorated tests ['1269196', '1245334', '1217635', '1226425', '1156555', '1204686', '1267224', '1103157', '1230902', '1214312', '1079482']

2017-02-16 14:28:47 - conftest - DEBUG - Collected 21 test cases

2017-02-16 14:28:47 - conftest - DEBUG - Deselected test tests.foreman.api.test_organization.test_verify_bugzilla_1103157 due to WONTFIX


tests/foreman/api/test_organization.py::OrganizationTestCase::test_negative_create_with_invalid_name PASSED
tests/foreman/api/test_organization.py::OrganizationTestCase::test_negative_create_with_same_name PASSED
tests/foreman/api/test_organization.py::OrganizationTestCase::test_positive_create_text_plain PASSED
tests/foreman/api/test_organization.py::OrganizationTestCase::test_positive_create_with_auto_label PASSED
tests/foreman/api/test_organization.py::OrganizationTestCase::test_positive_create_with_custom_label PASSED
tests/foreman/api/test_organization.py::OrganizationTestCase::test_positive_create_with_name_and_description PASSED
tests/foreman/api/test_organization.py::OrganizationTestCase::test_positive_create_with_name_and_label PASSED
tests/foreman/api/test_organization.py::OrganizationTestCase::test_positive_create_with_name_label_description PASSED
tests/foreman/api/test_organization.py::OrganizationTestCase::test_positive_search PASSED
tests/foreman/api/test_organization.py::OrganizationUpdateTestCase::test_negative_update PASSED
tests/foreman/api/test_organization.py::OrganizationUpdateTestCase::test_positive_add_hostgroup PASSED
tests/foreman/api/test_organization.py::OrganizationUpdateTestCase::test_positive_add_media <- robottelo/decorators/__init__.py SKIPPED
tests/foreman/api/test_organization.py::OrganizationUpdateTestCase::test_positive_add_smart_proxy <- robottelo/decorators/__init__.py SKIPPED
tests/foreman/api/test_organization.py::OrganizationUpdateTestCase::test_positive_remove_hostgroup <- robottelo/decorators/__init__.py SKIPPED
tests/foreman/api/test_organization.py::OrganizationUpdateTestCase::test_positive_remove_smart_proxy <- robottelo/decorators/__init__.py SKIPPED
tests/foreman/api/test_organization.py::OrganizationUpdateTestCase::test_positive_update_description PASSED
tests/foreman/api/test_organization.py::OrganizationUpdateTestCase::test_positive_update_name PASSED
tests/foreman/api/test_organization.py::OrganizationUpdateTestCase::test_positive_update_name_and_description PASSED
tests/foreman/api/test_organization.py::OrganizationUpdateTestCase::test_positive_update_subnet PASSED
tests/foreman/api/test_organization.py::OrganizationUpdateTestCase::test_positive_update_user PASSED

======================================================= 1 tests deselected =======================================================
====================================== 16 passed, 4 skipped, 1 deselected in 216.56 seconds ======================================
```
logs head with authenticated Bugzilla user:
```text
2017-02-16 14:28:30 - conftest - DEBUG - Registering custom pytest_namespace
2017-02-16 14:28:47 - conftest - DEBUG - Found WONTFIX in decorated tests ['1269196', '1245334', '1217635', '1226425', '1156555', '1204686', '1267224', '1103157', '1230902', '1214312', '1079482']
2017-02-16 14:28:47 - conftest - DEBUG - Collected 21 test cases
2017-02-16 14:28:47 - conftest - DEBUG - Deselected test tests.foreman.api.test_organization.test_verify_bugzilla_1103157 due to WONTFIX
2017-02-16 14:28:47 - robottelo - DEBUG - Started setUpClass: tests.foreman.api.test_organization/OrganizationTestCase
2017-02-16 14:28:47 - robottelo - DEBUG - Started Test: OrganizationTestCase/test_negative_create_with_invalid_name
```
logs head with unauthenticated Bugzilla user:
```text
2017-02-16 14:42:21 - conftest - DEBUG - Registering custom pytest_namespace
2017-02-16 14:42:30 - conftest - DEBUG - bug data for bug id "1317057" was not retrieved, please review bugzilla credentials
2017-02-16 14:42:30 - conftest - DEBUG - Found WONTFIX in decorated tests ['1269196', '1245334', '1217635', '1226425', '1156555', '1204686', '1267224', '1103157', '1230902', '1214312', '1079482']
2017-02-16 14:42:30 - conftest - DEBUG - Collected 21 test cases
2017-02-16 14:42:30 - conftest - DEBUG - Deselected test tests.foreman.api.test_organization.test_verify_bugzilla_1103157 due to WONTFIX
2017-02-16 14:42:30 - robottelo - DEBUG - Started setUpClass: tests.foreman.api.test_organization/OrganizationTestCase
2017-02-16 14:42:30 - robottelo - DEBUG - Started Test: OrganizationTestCase/test_negative_create_with_invalid_name
```
**note: 2017-02-16 14:42:30 - conftest - DEBUG - bug data for bug id "1317057" was not retrieved, please review bugzilla credentials**
 
1317057 - is a private bug