### PR TITLE
Replace duplicated BZs with original IDs and removed one test

### DIFF
--- a/tests/foreman/cli/test_errata.py
+++ b/tests/foreman/cli/test_errata.py
@@ -81,7 +81,7 @@ from robottelo.vm import VirtualMachine
 ERRATUM_MAX_IDS_INFO = 10
 
 
-@skip_if_bug_open('bugzilla', 1405428)
+@skip_if_bug_open('bugzilla', 1372372)
 @run_in_one_thread
 class HostCollectionErrataInstallTestCase(CLITestCase):
     """CLI Tests for the errata management feature"""
@@ -1041,7 +1041,7 @@ class ErrataTestCase(CLITestCase):
                 # as needed
                 self.assertEqual(errata_ids, sorted_errata_ids)
 
-    @skip_if_bug_open('bugzilla', 1402767)
+    @skip_if_bug_open('bugzilla', 1283173)
     @tier3
     def test_positive_list_filter_by_product_id(self):
         """Filter errata by product id

--- a/tests/foreman/ui/test_contentview.py
+++ b/tests/foreman/ui/test_contentview.py
@@ -49,7 +49,6 @@ from robottelo.datafactory import invalid_names_list, valid_data_list
 from robottelo.decorators import (
     run_in_one_thread,
     run_only_on,
-    skip_if_bug_open,
     skip_if_not_set,
     stubbed,
     tier1,
@@ -756,57 +755,6 @@ class ContentViewTestCase(UITestCase):
                     '5.6.6'
                 )
             )
-
-    @run_only_on('sat')
-    @skip_if_bug_open('bugzilla', 1402826)
-    @tier2
-    def test_negative_add_same_package_filter_twice(self):
-        """Update version of package inside exclusive cv package filter
-
-        @id: 5a97de5a-679e-4150-adf7-b4a28290b834
-
-        @assert: Same package filter can not be added again
-
-        @CaseLevel: Integration
-        """
-        cv_name = gen_string('alpha')
-        repo_name = gen_string('alpha')
-        package_name = 'walrus'
-        with Session(self.browser) as session:
-            self.setup_to_create_cv(repo_name=repo_name)
-            # Create content-view
-            make_contentview(session, org=self.organization.name, name=cv_name)
-            self.assertIsNotNone(self.content_views.search(cv_name))
-            self.content_views.add_remove_repos(cv_name, [repo_name])
-            for filter_type in FILTER_TYPE['exclude'], FILTER_TYPE['include']:
-                with self.subTest(filter_type):
-                    filter_name = gen_string('alpha')
-                    self.content_views.add_filter(
-                        cv_name,
-                        filter_name,
-                        FILTER_CONTENT_TYPE['package'],
-                        filter_type,
-                    )
-                    self.content_views.add_packages_to_filter(
-                        cv_name,
-                        filter_name,
-                        [package_name],
-                        ['Equal To'],
-                        ['0.71-1'],
-                        [None],
-                    )
-                    self.assertIsNotNone(self.content_views.wait_until_element(
-                        common_locators['alert.success_sub_form']))
-                    self.content_views.add_packages_to_filter(
-                        cv_name,
-                        filter_name,
-                        [package_name],
-                        ['Equal To'],
-                        ['0.71-1'],
-                        [None],
-                    )
-                    self.assertIsNotNone(self.content_views.wait_until_element(
-                        common_locators['alert.error_sub_form']))
 
     @run_only_on('sat')
     @tier2


### PR DESCRIPTION
in #4349 there is a list of all BZ status (taken from decorator)

- I replaced the DUPLICATED with original ID
1405428 is a dupe of 1372372
1402767 is a dupe of 1283173
Both have the proper flag for sat6.2.z and I flipped the qe_test_coverage to +



- and removed one specific test (explained in #4348) which is
present and fixed in 6.3 but will not be included in 6.2.z

Closes #4349
Closes #4348