### PR TITLE
[6.2.z] Fix #4347 exclude DEFERRED resolution from test collection

### DIFF
--- a/robottelo/bz_helpers.py
+++ b/robottelo/bz_helpers.py
@@ -42,8 +42,8 @@ def get_decorated_bugs():  # pragma: no cover
     return bugs
 
 
-def get_wontfix_bugs(bugs=None, log=None):
-    """returns the ID of bugs CLOSED as WONTFIX"""
+def get_deselect_bug_ids(bugs=None, log=None):
+    """returns the IDs of bugs to be deselected from test collection"""
     if log is None:
         log = log_debug
     bugs = bugs or get_decorated_bugs()
@@ -52,7 +52,7 @@ def get_wontfix_bugs(bugs=None, log=None):
         bug_data = data.get('bug_data')
         # when not authenticated, private bugs will have no bug data
         if bug_data:
-            if bug_data['resolution'] in ('WONTFIX', 'CANTFIX'):
+            if bug_data['resolution'] in ('WONTFIX', 'CANTFIX', 'DEFERRED'):
                 wontfixes.append(bug_id)
         else:
             log('bug data for bug id "{}" was not retrieved,'

--- a/tests/foreman/conftest.py
+++ b/tests/foreman/conftest.py
@@ -2,7 +2,7 @@
 """Configurations for py.test runner"""
 import datetime
 import pytest
-from robottelo.bz_helpers import get_wontfix_bugs, group_by_key
+from robottelo.bz_helpers import get_deselect_bug_ids, group_by_key
 from robottelo.helpers import get_func_name
 
 
@@ -44,7 +44,7 @@ def pytest_namespace():
     log("Registering custom pytest_namespace")
     return {
         'bugzilla': {
-            'wontfix_ids': get_wontfix_bugs(log=log),
+            'wontfix_ids': get_deselect_bug_ids(log=log),
             'decorated_functions': []
         }
     }

--- a/tests/robottelo/test_bz_helpers.py
+++ b/tests/robottelo/test_bz_helpers.py
@@ -1,7 +1,7 @@
 # coding: utf-8
 
 from unittest2 import TestCase
-from robottelo.bz_helpers import get_wontfix_bugs, group_by_key
+from robottelo.bz_helpers import get_deselect_bug_ids, group_by_key
 from robottelo.helpers import get_func_name
 
 
@@ -34,7 +34,7 @@ class BZHelperTestCase(TestCase):
 
     def test_get_wontfix_bugs(self):
         """Test if wontfixes are filtered"""
-        self.assertNotIn('1236', get_wontfix_bugs(self.bz_data))
+        self.assertNotIn('1236', get_deselect_bug_ids(self.bz_data))
 
     def test_group_by_key(self):
         """Test if decorated functions are grouped"""


### PR DESCRIPTION
renamed helper
added proper docstring
added DEFERRED as resolution to be removed 