### PR TITLE
[6.2.z] Backport SCP/SV tests.

### DIFF
--- a/docs/api/robottelo.cli.rst
+++ b/docs/api/robottelo.cli.rst
@@ -185,6 +185,11 @@ Submodules:
 
 .. automodule:: robottelo.cli.scparams
 
+:mod:`robottelo.cli.smart_variable`
+-----------------------------------
+
+.. automodule:: robottelo.cli.smart_variable
+
 :mod:`robottelo.cli.subnet`
 ---------------------------
 

--- a/docs/api/robottelo.ui.rst
+++ b/docs/api/robottelo.ui.rst
@@ -198,6 +198,11 @@
 
 .. automodule:: robottelo.ui.settings
 
+:mod:`robottelo.ui.smart_variable`
+----------------------------------
+
+.. automodule:: robottelo.ui.smart_variable
+
 :mod:`robottelo.ui.subnet`
 --------------------------
 

--- a/docs/api/tests.foreman.api.rst
+++ b/docs/api/tests.foreman.api.rst
@@ -187,3 +187,7 @@
 ---------------------------------------
 
 .. automodule:: tests.foreman.api.test_usergroup
+
+:mod:`tests.foreman.api.test_variables`
+---------------------------------------
+.. automodule:: tests.foreman.api.test_variables

--- a/docs/api/tests.foreman.cli.rst
+++ b/docs/api/tests.foreman.cli.rst
@@ -173,6 +173,11 @@
 
 .. automodule:: tests.foreman.cli.test_product
 
+:mod:`tests.foreman.cli.test_puppetclass`
+------------------------------------------
+
+.. automodule:: tests.foreman.cli.test_puppetclass
+
 :mod:`tests.foreman.cli.test_puppetmodule`
 ------------------------------------------
 

--- a/robottelo/cli/factory.py
+++ b/robottelo/cli/factory.py
@@ -53,6 +53,7 @@ from robottelo.cli.syncplan import SyncPlan
 from robottelo.cli.template import Template
 from robottelo.cli.user import User
 from robottelo.cli.usergroup import UserGroup, UserGroupExternal
+from robottelo.cli.smart_variable import SmartVariable
 from robottelo.config import settings
 from robottelo.constants import (
     DEFAULT_SUBSCRIPTION_NAME,
@@ -1914,6 +1915,79 @@ def make_template(options=None):
     # End - Special handling for template factory
 
     return create_object(Template, args, options)
+
+
+@cacheable
+def make_smart_variable(options=None):
+    """
+    Usage::
+
+        hammer smart-variable create [OPTIONS]
+
+    Options::
+
+        --avoid-duplicates AVOID_DUPLICATES         Remove duplicate values (
+                                                    only array type)
+                                                    One of true/false, yes/no,
+                                                    1/0.
+        --default-value DEFAULT_VALUE               Default value of variable
+        --description DESCRIPTION                   Description of variable
+        --hidden-value HIDDEN_VALUE                 When enabled the parameter
+                                                    is hidden in the UI
+                                                    One of true/false, yes/no,
+                                                    1/0.
+        --merge-default MERGE_DEFAULT               Include default value when
+                                                    merging all matching values
+                                                    One of true/false, yes/no,
+                                                    1/0.
+        --merge-overrides MERGE_OVERRIDES           Merge all matching values(
+                                                    only array/hash type)
+                                                    One of true/false, yes/no,
+                                                    1/0.
+        --override-value-order OVERRIDE_VALUE_ORDER The order in which values
+                                                    are resolved
+        --puppet-class PUPPET_CLASS_NAME            Puppet class name
+        --puppet-class-id PUPPET_CLASS_ID           ID of Puppet class
+        --validator-rule VALIDATOR_RULE             Used to enforce certain
+                                                    values for the parameter
+                                                    values
+        --validator-type VALIDATOR_TYPE             Type of the validator.
+                                                    Possible value(s):
+                                                    'regexp', 'list', ''
+        --variable VARIABLE                         Name of variable
+        --variable-type VARIABLE_TYPE               Type of the variable.
+                                                    Possible value(s):
+                                                    'string', 'boolean',
+                                                    'integer', 'real', 'array',
+                                                    'hash', 'yaml', 'json'
+         -h, --help                                 print help
+
+    """
+    # Puppet class name or ID is a required field.
+    if (
+            not options or
+            'puppet-class' not in options and
+            'puppet-class-id' not in options):
+        raise CLIFactoryError('Please provide a valid Puppet class')
+
+    # Assigning default values for attributes
+    args = {
+        u'avoid-duplicates': None,
+        u'default-value': None,
+        u'description': None,
+        u'hidden-value': None,
+        u'merge-default': None,
+        u'merge-overrides': None,
+        u'override-value-order': None,
+        u'puppet-class': None,
+        u'puppet-class-id': None,
+        u'validator-rule': None,
+        u'validator-type': None,
+        u'variable': gen_alphanumeric(),
+        u'variable-type': None,
+    }
+
+    return create_object(SmartVariable, args, options)
 
 
 def activationkey_add_subscription_to_repo(options=None):

--- a/robottelo/cli/factory.py
+++ b/robottelo/cli/factory.py
@@ -2339,39 +2339,6 @@ def setup_org_for_a_rh_repo(options=None):
         u'repository-id': rhel_repo['id'],
     }
 
-def publish_puppet_module(puppet_modules, repo_url, organization_id=None):
-    """Creates puppet repo, sync it via provided url and publish using
-    Content View publishing mechanism. It makes puppet class available
-    via Puppet Environment created by Content View and returns Content
-    View entity.
-
-    :param puppet_modules: List of dictionaries with module 'author'
-        and module 'name' fields.
-    :param str repo_url: Url of the repo that can be synced using pulp:
-        pulp repo or puppet forge.
-    :param organization_id: Organization id that is shared between created
-        entities.
-    :return: Content View entity.
-    """
-    if not organization_id:
-        organization_id = make_org()['id']
-    product = make_product({u'organization-id': organization_id})
-    repo = make_repository({
-        u'product-id': product['id'],
-        u'content-type': 'puppet',
-        u'url': repo_url,
-    })
-    # Synchronize repo via provided URL
-    Repository.synchronize({'id': repo['id']})
-    # Add selected module to Content View
-    cv = make_content_view({u'organization-id': organization_id})
-    for module in puppet_modules:
-        ContentView.puppet_module_add({
-            u'author': module['author'],
-            u'name': module['name'],
-            u'content-view-id': cv['id'],
-        })
-
 
 def publish_puppet_module(puppet_modules, repo_url, organization_id=None):
     """Creates puppet repo, sync it via provided url and publish using
@@ -2405,7 +2372,3 @@ def publish_puppet_module(puppet_modules, repo_url, organization_id=None):
             u'name': module['name'],
             u'content-view-id': cv['id'],
         })
-    # CV publishing will automatically create Environment and
-    # Puppet Class entities
-    ContentView.publish({u'id': cv['id']})
-    return ContentView.info({u'id': cv['id']})

--- a/robottelo/cli/factory.py
+++ b/robottelo/cli/factory.py
@@ -2338,3 +2338,40 @@ def setup_org_for_a_rh_repo(options=None):
         u'organization-id': org_id,
         u'repository-id': rhel_repo['id'],
     }
+
+def publish_puppet_module(puppet_modules, repo_url, organization_id=None):
+    """Creates puppet repo, sync it via provided url and publish using
+    Content View publishing mechanism. It makes puppet class available
+    via Puppet Environment created by Content View and returns Content
+    View entity.
+
+    :param puppet_modules: List of dictionaries with module 'author'
+        and module 'name' fields.
+    :param str repo_url: Url of the repo that can be synced using pulp:
+        pulp repo or puppet forge.
+    :param organization_id: Organization id that is shared between created
+        entities.
+    :return: Content View entity.
+    """
+    if not organization_id:
+        organization_id = make_org()['id']
+    product = make_product({u'organization-id': organization_id})
+    repo = make_repository({
+        u'product-id': product['id'],
+        u'content-type': 'puppet',
+        u'url': repo_url,
+    })
+    # Synchronize repo via provided URL
+    Repository.synchronize({'id': repo['id']})
+    # Add selected module to Content View
+    cv = make_content_view({u'organization-id': organization_id})
+    for module in puppet_modules:
+        ContentView.puppet_module_add({
+            u'author': module['author'],
+            u'name': module['name'],
+            u'content-view-id': cv['id'],
+        })
+    # CV publishing will automatically create Environment and
+    # Puppet Class entities
+    ContentView.publish({u'id': cv['id']})
+    return ContentView.info({u'id': cv['id']})

--- a/robottelo/cli/factory.py
+++ b/robottelo/cli/factory.py
@@ -2371,6 +2371,40 @@ def publish_puppet_module(puppet_modules, repo_url, organization_id=None):
             u'name': module['name'],
             u'content-view-id': cv['id'],
         })
+
+
+def publish_puppet_module(puppet_modules, repo_url, organization_id=None):
+    """Creates puppet repo, sync it via provided url and publish using
+    Content View publishing mechanism. It makes puppet class available
+    via Puppet Environment created by Content View and returns Content
+    View entity.
+
+    :param puppet_modules: List of dictionaries with module 'author'
+        and module 'name' fields.
+    :param str repo_url: Url of the repo that can be synced using pulp:
+        pulp repo or puppet forge.
+    :param organization_id: Organization id that is shared between created
+        entities.
+    :return: Content View entity.
+    """
+    if not organization_id:
+        organization_id = make_org()['id']
+    product = make_product({u'organization-id': organization_id})
+    repo = make_repository({
+        u'product-id': product['id'],
+        u'content-type': 'puppet',
+        u'url': repo_url,
+    })
+    # Synchronize repo via provided URL
+    Repository.synchronize({'id': repo['id']})
+    # Add selected module to Content View
+    cv = make_content_view({u'organization-id': organization_id})
+    for module in puppet_modules:
+        ContentView.puppet_module_add({
+            u'author': module['author'],
+            u'name': module['name'],
+            u'content-view-id': cv['id'],
+        })
     # CV publishing will automatically create Environment and
     # Puppet Class entities
     ContentView.publish({u'id': cv['id']})

--- a/robottelo/cli/host.py
+++ b/robottelo/cli/host.py
@@ -375,3 +375,24 @@ class Host(Base):
         cls.command_sub = 'sc-params'
         return cls.execute(
             cls._construct_command(options), output_format='csv')
+
+    @classmethod
+    def smart_variables(cls, options=None):
+        """List all smart variables
+
+        Usage::
+
+            hammer host smart-variables [OPTIONS]
+
+        Options::
+
+            --host HOST_NAME              Host name
+            --host-id HOST_ID
+            --order ORDER                 sort results
+            --page PAGE                   paginate results
+            --per-page PER_PAGE           number of entries per request
+            --search SEARCH               filter results
+        """
+        cls.command_sub = 'smart-variables'
+        return cls.execute(
+            cls._construct_command(options), output_format='csv')

--- a/robottelo/cli/hostgroup.py
+++ b/robottelo/cli/hostgroup.py
@@ -52,3 +52,25 @@ class HostGroup(Base):
         cls.command_sub = 'sc-params'
         return cls.execute(
             cls._construct_command(options), output_format='csv')
+
+    @classmethod
+    def smart_variables(cls, options=None):
+        """List all smart variables
+
+        Usage::
+
+            hammer hostgroup smart-variables [OPTIONS]
+
+        Options::
+
+            --hostgroup HOSTGROUP_NAME        Hostgroup name
+            --hostgroup-id HOSTGROUP_ID
+            --hostgroup-title HOSTGROUP_TITLE Hostgroup title
+            --order ORDER                     sort results
+            --page PAGE                       paginate results
+            --per-page PER_PAGE               number of entries per request
+            --search SEARCH                   filter results
+        """
+        cls.command_sub = 'smart-variables'
+        return cls.execute(
+            cls._construct_command(options), output_format='csv')

--- a/robottelo/cli/puppet.py
+++ b/robottelo/cli/puppet.py
@@ -13,7 +13,8 @@ Subcommands::
 
     info                          Show a puppetclass
     list                          List all puppetclasses.
-    sc_params                     List all smart class parameters
+    sc-params                     List all smart class parameters
+    smart-variables               List all smart variables
 """
 
 from robottelo.cli.base import Base
@@ -25,3 +26,37 @@ class Puppet(Base):
     """
 
     command_base = 'puppet-class'
+
+    @classmethod
+    def sc_params(cls, options=None):
+        """
+        Usage:
+            hammer puppet-class sc-params [OPTIONS]
+
+        Options:
+             --order ORDER                      sort results
+             --page PAGE                        paginate results
+             --per-page PER_PAGE                number of entries per request
+             --puppet-class PUPPET_CLASS_NAME   Puppet class name
+             --puppet-class-id PUPPET_CLASS_ID  ID of Puppet class
+             --search SEARCH                    filter results
+        """
+        cls.command_sub = 'sc-params'
+        return cls.execute(cls._construct_command(options))
+
+    @classmethod
+    def smart_variables(cls, options=None):
+        """
+        Usage:
+            hammer puppet-class smart-variables [OPTIONS]
+
+        Options:
+             --order ORDER                      sort results
+             --page PAGE                        paginate results
+             --per-page PER_PAGE                number of entries per request
+             --puppet-class PUPPET_CLASS_NAME   Puppet class name
+             --puppet-class-id PUPPET_CLASS_ID  ID of Puppet class
+             --search SEARCH                    filter results
+         """
+        cls.command_sub = 'smart-variables'
+        return cls.execute(cls._construct_command(options))

--- a/robottelo/cli/smart_variable.py
+++ b/robottelo/cli/smart_variable.py
@@ -1,0 +1,81 @@
+# -*- encoding: utf-8 -*-
+"""
+Usage::
+
+    hammer smart-variable [OPTIONS] SUBCOMMAND [ARG] ...
+
+Parameters::
+
+    SUBCOMMAND                    subcommand
+    [ARG] ...                     subcommand arguments
+
+Subcommands::
+
+    add-override-value            Create an override value for a specific smart
+                                  variable
+    create                        Create a smart variable
+    delete                        Delete a smart variable
+    info                          Show a smart variable
+    list                          List all smart variables
+    remove-override-value         Delete an override value for a specific smart
+                                  variable
+    update                        Update a smart variable
+"""
+
+from robottelo.cli.base import Base
+
+
+class SmartVariable(Base):
+    """Manipulates smart variables"""
+
+    command_base = 'smart-variable'
+
+    @classmethod
+    def info(cls, options=None):
+        """Gets information for smart variables"""
+        cls.command_sub = 'info'
+        return cls.execute(
+            cls._construct_command(options), output_format='json')
+
+    @classmethod
+    def add_override_value(cls, options=None):
+        """Create an override value for a specific smart variable
+
+        Usage::
+
+            hammer smart-variable add-override-value [OPTIONS]
+
+        Options::
+
+            --match MATCH                                       Override match
+            --smart-variable SMART_VARIABLE_NAME                Smart variable
+                                                                name
+            --smart-variable-id SMART_VARIABLE_ID               ID of smart
+                                                                variable
+            --use-puppet-default USE_PUPPET_DEFAULT             One of
+                                                                true/false,
+                                                                yes/no, 1/0.
+            --value VALUE                                       Override value
+        """
+        cls.command_sub = 'add-override-value'
+        return cls.execute(
+            cls._construct_command(options), output_format='csv')
+
+    @classmethod
+    def remove_override_value(cls, options=None):
+        """Delete an override value for a specific smart variable
+
+        Usage::
+
+            hammer smart-variable remove-override-value [OPTIONS]
+
+        Options::
+
+            --id ID
+            --smart-variable SMART_VARIABLE_NAME                Smart variable
+                                                                name
+            --smart-variable-id SMART_VARIABLE_ID
+        """
+        cls.command_sub = 'remove-override-value'
+        return cls.execute(
+            cls._construct_command(options), output_format='csv')

--- a/robottelo/test.py
+++ b/robottelo/test.py
@@ -83,6 +83,7 @@ from robottelo.ui.repository import Repos
 from robottelo.ui.rhai import RHAI
 from robottelo.ui.role import Role
 from robottelo.ui.settings import Settings
+from robottelo.ui.smart_variable import SmartVariable
 from robottelo.ui.subnet import Subnet
 from robottelo.ui.subscription import Subscriptions
 from robottelo.ui.sync import Sync
@@ -312,6 +313,7 @@ class UITestCase(TestCase):
         self.rhai = RHAI(self.browser)
         self.role = Role(self.browser)
         self.settings = Settings(self.browser)
+        self.smart_variable = SmartVariable(self.browser)
         self.subnet = Subnet(self.browser)
         self.subscriptions = Subscriptions(self.browser)
         self.sync = Sync(self.browser)

--- a/robottelo/ui/factory.py
+++ b/robottelo/ui/factory.py
@@ -34,6 +34,7 @@ from robottelo.ui.registry import Registry
 from robottelo.ui.repository import Repos
 from robottelo.ui.role import Role
 from robottelo.ui.settings import Settings
+from robottelo.ui.smart_variable import SmartVariable
 from robottelo.ui.subnet import Subnet
 from robottelo.ui.syncplan import Syncplan
 from robottelo.ui.template import Template
@@ -744,3 +745,29 @@ def make_host_collection(
     core_factory(create_args, kwargs, session, page,
                  org=org, loc=loc, force_context=force_context)
     HostCollection(session.browser).create(**create_args)
+
+
+def make_smart_variable(
+        session, org=None, loc=None, force_context=True, **kwargs):
+    """Creates Smart Variable"""
+    create_args = {
+        u'name': gen_string('alpha'),
+        u'puppet_class': None,
+        u'description': None,
+        u'key_type': None,
+        u'default_value': None,
+        u'hidden_value': False,
+        u'validator_type': None,
+        u'validator_rule': None,
+        u'matcher': None,
+        u'matcher_priority': None,
+        u'matcher_merge_overrides': None,
+        u'matcher_merge_default': None,
+        u'matcher_merge_avoid': None,
+    }
+    page = session.nav.go_to_puppet_classes
+    core_factory(create_args, kwargs, session, page,
+                 org=org, loc=loc, force_context=force_context)
+    PuppetClasses(session.browser).click(
+        PuppetClasses(session.browser).search(kwargs['puppet_class']))
+    SmartVariable(session.browser).create(**create_args)

--- a/robottelo/ui/hosts.py
+++ b/robottelo/ui/hosts.py
@@ -229,3 +229,57 @@ class Hosts(Base):
             self.click(tab_locator)
             result[param_name] = self.wait_until_element(param_locator).text
         return result
+
+    def get_yaml_output(self, name):
+        """Return YAML output for specific host
+
+        :param str name: Name of Host to read information from
+        """
+        self.click(self.search(name))
+        self.click(locators['host.yaml_button'])
+        output = self.wait_until_element(locators['host.yaml_output']).text
+        self.browser.back()
+        self.wait_for_ajax()
+        return output
+
+    def get_smart_variable_value(self, host_name, sv_name, hidden=False):
+        """Return smart variable value element for specific host
+
+        :param str host_name: Name of Host to get smart variable information
+            from
+        :param str sv_name: Name of Smart Variable to be read
+        :param bool hidden: Specify whether it is expected that read value is
+            hidden on UI or not
+        """
+        self.click(self.search(host_name))
+        self.click(locators['host.edit'])
+        self.click(tab_locators['host.tab_params'])
+        if hidden:
+            locator = locators['host.smart_variable_value_hidden'] % sv_name
+        else:
+            locator = locators['host.smart_variable_value'] % sv_name
+        return self.wait_until_element(locator)
+
+    def set_smart_variable_value(self, host_name, sv_name, sv_value,
+                                 override=True, hidden=False):
+        """Set smart variable value for specific host
+
+        :param str host_name: Name of Host where smart variable value should be
+            modified
+        :param str sv_name: Name of Smart Variable to be modified
+        :param bool override: Specify whether it is expected to override smart
+            value or just edit its value
+        :param bool hidden: Specify whether it is expected that smart variable
+            value is hidden on UI or not
+        """
+        self.click(self.search(host_name))
+        self.click(locators['host.edit'])
+        self.click(tab_locators['host.tab_params'])
+        if override:
+            self.click(locators['host.smart_variable_override'] % sv_name)
+        if hidden:
+            locator = locators['host.smart_variable_value_hidden'] % sv_name
+        else:
+            locator = locators['host.smart_variable_value'] % sv_name
+        self.assign_value(locator, sv_value)
+        self.click(common_locators['submit'])

--- a/robottelo/ui/hosts.py
+++ b/robottelo/ui/hosts.py
@@ -242,21 +242,26 @@ class Hosts(Base):
         self.wait_for_ajax()
         return output
 
-    def get_smart_variable_value(self, host_name, sv_name):
+    def get_smart_variable_value(self, host_name, sv_name, hidden=False):
         """Return smart variable value element for specific host
 
         :param str host_name: Name of Host to get smart variable information
             from
         :param str sv_name: Name of Smart Variable to be read
+        :param bool hidden: Specify whether it is expected that read value is
+            hidden on UI or not
         """
         self.click(self.search(host_name))
         self.click(locators['host.edit'])
         self.click(tab_locators['host.tab_params'])
-        return self.wait_until_element(
-            locators['host.smart_variable_value'] % sv_name)
+        if hidden:
+            strategy, value = locators['host.smart_variable_value_hidden']
+        else:
+            strategy, value = locators['host.smart_variable_value']
+        return self.wait_until_element((strategy, value % sv_name))
 
     def set_smart_variable_value(self, host_name, sv_name, sv_value,
-                                 override=True):
+                                 override=True, hidden=False):
         """Set smart variable value for specific host
 
         :param str host_name: Name of Host where smart variable value should be
@@ -265,12 +270,18 @@ class Hosts(Base):
         :param str sv_value: Value of Smart Variable that should be set
         :param bool override: Specify whether it is expected to override smart
             value or just edit its value
+        :param bool hidden: Specify whether it is expected that smart variable
+            value is hidden on UI or not
         """
         self.click(self.search(host_name))
         self.click(locators['host.edit'])
         self.click(tab_locators['host.tab_params'])
         if override:
-            self.click(locators['host.smart_variable_override'] % sv_name)
-        self.assign_value(
-            locators['host.smart_variable_value'] % sv_name, sv_value)
+            strategy, value = locators['host.smart_variable_override']
+            self.click((strategy, value % sv_name))
+        if hidden:
+            strategy, value = locators['host.smart_variable_value_hidden']
+        else:
+            strategy, value = locators['host.smart_variable_value']
+        self.assign_value((strategy, value % sv_name), sv_value)
         self.click(common_locators['submit'])

--- a/robottelo/ui/hosts.py
+++ b/robottelo/ui/hosts.py
@@ -242,44 +242,35 @@ class Hosts(Base):
         self.wait_for_ajax()
         return output
 
-    def get_smart_variable_value(self, host_name, sv_name, hidden=False):
+    def get_smart_variable_value(self, host_name, sv_name):
         """Return smart variable value element for specific host
 
         :param str host_name: Name of Host to get smart variable information
             from
         :param str sv_name: Name of Smart Variable to be read
-        :param bool hidden: Specify whether it is expected that read value is
-            hidden on UI or not
         """
         self.click(self.search(host_name))
         self.click(locators['host.edit'])
         self.click(tab_locators['host.tab_params'])
-        if hidden:
-            locator = locators['host.smart_variable_value_hidden'] % sv_name
-        else:
-            locator = locators['host.smart_variable_value'] % sv_name
-        return self.wait_until_element(locator)
+        return self.wait_until_element(
+            locators['host.smart_variable_value'] % sv_name)
 
     def set_smart_variable_value(self, host_name, sv_name, sv_value,
-                                 override=True, hidden=False):
+                                 override=True):
         """Set smart variable value for specific host
 
         :param str host_name: Name of Host where smart variable value should be
             modified
         :param str sv_name: Name of Smart Variable to be modified
+        :param str sv_value: Value of Smart Variable that should be set
         :param bool override: Specify whether it is expected to override smart
             value or just edit its value
-        :param bool hidden: Specify whether it is expected that smart variable
-            value is hidden on UI or not
         """
         self.click(self.search(host_name))
         self.click(locators['host.edit'])
         self.click(tab_locators['host.tab_params'])
         if override:
             self.click(locators['host.smart_variable_override'] % sv_name)
-        if hidden:
-            locator = locators['host.smart_variable_value_hidden'] % sv_name
-        else:
-            locator = locators['host.smart_variable_value'] % sv_name
-        self.assign_value(locator, sv_value)
+        self.assign_value(
+            locators['host.smart_variable_value'] % sv_name, sv_value)
         self.click(common_locators['submit'])

--- a/robottelo/ui/locators.py
+++ b/robottelo/ui/locators.py
@@ -1454,8 +1454,9 @@ locators = LocatorDict({
         "(//textarea[contains(@id, '_value') "
         "and contains(@name, 'parameters')])[%i]"),
     "host.smart_variable_value": (
-        By.XPATH,
-        "//*[ancestor::tr//td[contains(., '%s')] and @data-property='value']"),
+        By.XPATH, "//textarea[ancestor::tr//td[contains(., '%s')]]"),
+    "host.smart_variable_value_hidden": (
+        By.XPATH, "//input[ancestor::tr//td[contains(., '%s')]]"),
     "host.smart_variable_override": (
         By.XPATH,
         "//a[ancestor::tr//td[contains(., '%s')] and @data-tag='override']"
@@ -1472,7 +1473,7 @@ locators = LocatorDict({
     ),
     "host.smart_variable_puppet_class": (
         By.XPATH, "//td[contains(., '%s')]//ancestor::tbody/tr[1]/td[1]"),
-    "host.override_error": (By.CSS_SELECTOR, "input:invalid[value='%s']"),
+    "host.override_error": (By.XPATH, "//td[@class='has-error']"),
 
     # host.vm (NOTE:- visible only when selecting a compute resource)
     "host.cpus": (
@@ -3155,6 +3156,10 @@ locators = LocatorDict({
         By.XPATH,
         "//textarea[(ancestor::div[@class='tab-pane fields active'] or "
         "contains(@id, 'variable_')) and contains(@name, '[default_value]')]"),
+    "smart_variable.default_value_hidden": (
+        By.XPATH,
+        "//input[(ancestor::div[@class='tab-pane fields active'] or "
+        "contains(@id, 'variable_')) and contains(@name, '[default_value]')]"),
     "smart_variable.hidden_value": (
         By.XPATH,
         "//input[(ancestor::div[@class='tab-pane fields active'] or "
@@ -3212,6 +3217,11 @@ locators = LocatorDict({
     "smart_variable.matcher_value": (
         By.XPATH,
         "(//textarea[(ancestor::div[@class='tab-pane fields active'] or "
+        "contains(@id, 'variable_')) and contains(@name, '[value]')])[%i]"
+    ),
+    "smart_variable.matcher_value_hidden": (
+        By.XPATH,
+        "(//input[(ancestor::div[@class='tab-pane fields active'] or "
         "contains(@id, 'variable_')) and contains(@name, '[value]')])[%i]"
     ),
     "smart_variable.matcher_error": (By.XPATH, "//tr[@class='has-error']"),

--- a/robottelo/ui/locators.py
+++ b/robottelo/ui/locators.py
@@ -1454,9 +1454,8 @@ locators = LocatorDict({
         "(//textarea[contains(@id, '_value') "
         "and contains(@name, 'parameters')])[%i]"),
     "host.smart_variable_value": (
-        By.XPATH, "//textarea[ancestor::tr//td[contains(., '%s')]]"),
-    "host.smart_variable_value_hidden": (
-        By.XPATH, "//input[ancestor::tr//td[contains(., '%s')]]"),
+        By.XPATH,
+        "//*[ancestor::tr//td[contains(., '%s')] and @data-property='value']"),
     "host.smart_variable_override": (
         By.XPATH,
         "//a[ancestor::tr//td[contains(., '%s')] and @data-tag='override']"
@@ -1473,7 +1472,7 @@ locators = LocatorDict({
     ),
     "host.smart_variable_puppet_class": (
         By.XPATH, "//td[contains(., '%s')]//ancestor::tbody/tr[1]/td[1]"),
-    "host.override_error": (By.XPATH, "//td[@class='has-error']"),
+    "host.override_error": (By.CSS_SELECTOR, "input:invalid[value='%s']"),
 
     # host.vm (NOTE:- visible only when selecting a compute resource)
     "host.cpus": (
@@ -3156,10 +3155,6 @@ locators = LocatorDict({
         By.XPATH,
         "//textarea[(ancestor::div[@class='tab-pane fields active'] or "
         "contains(@id, 'variable_')) and contains(@name, '[default_value]')]"),
-    "smart_variable.default_value_hidden": (
-        By.XPATH,
-        "//input[(ancestor::div[@class='tab-pane fields active'] or "
-        "contains(@id, 'variable_')) and contains(@name, '[default_value]')]"),
     "smart_variable.hidden_value": (
         By.XPATH,
         "//input[(ancestor::div[@class='tab-pane fields active'] or "
@@ -3217,11 +3212,6 @@ locators = LocatorDict({
     "smart_variable.matcher_value": (
         By.XPATH,
         "(//textarea[(ancestor::div[@class='tab-pane fields active'] or "
-        "contains(@id, 'variable_')) and contains(@name, '[value]')])[%i]"
-    ),
-    "smart_variable.matcher_value_hidden": (
-        By.XPATH,
-        "(//input[(ancestor::div[@class='tab-pane fields active'] or "
         "contains(@id, 'variable_')) and contains(@name, '[value]')])[%i]"
     ),
     "smart_variable.matcher_error": (By.XPATH, "//tr[@class='has-error']"),

--- a/robottelo/ui/locators.py
+++ b/robottelo/ui/locators.py
@@ -246,7 +246,7 @@ menu_locators = LocatorDict({
     "menu.smart_variables": (
         By.XPATH,
         ("//div[contains(@style,'static') or contains(@style, 'fixed')]"
-         "//a[@id='menu_item_lookup_keys']")),
+         "//a[@id='menu_item_variable_lookup_keys']")),
     "menu.configure_groups": (
         By.XPATH,
         ("//div[contains(@style,'static') or contains(@style, 'fixed')]"
@@ -713,6 +713,14 @@ tab_locators = LocatorDict({
     # Compute resources
     "resource.tab_containers": (
         By.XPATH, "//a[@data-toggle='tab' and contains(@href, 'vms')]"),
+
+    # Puppet Class
+    "puppet_class.tab_smart_parameter": (
+        By.XPATH,
+        "//a[@data-toggle='tab' and contains(@href, 'smart_class_param')]"),
+    "puppet_class.tab_smart_variable": (
+        By.XPATH,
+        "//a[@data-toggle='tab' and contains(@href, 'smart_vars')]"),
 })
 
 common_locators = LocatorDict({
@@ -1287,6 +1295,9 @@ locators = LocatorDict({
         By.XPATH,
         ("//input[contains(@id,'host_ids')]"
          "/../../td[@class='ellipsis']/a[contains(@href,'%s')]")),
+    "host.yaml_button": (By.XPATH, "//a[text()='YAML' and "
+                                   "contains(@class, 'btn')]"),
+    "host.yaml_output": (By.XPATH, "//pre"),
     "host.name": (By.ID, "host_name"),
     "host.organization": (
         By.XPATH,
@@ -1442,6 +1453,27 @@ locators = LocatorDict({
         By.XPATH,
         "(//textarea[contains(@id, '_value') "
         "and contains(@name, 'parameters')])[%i]"),
+    "host.smart_variable_value": (
+        By.XPATH, "//textarea[ancestor::tr//td[contains(., '%s')]]"),
+    "host.smart_variable_value_hidden": (
+        By.XPATH, "//input[ancestor::tr//td[contains(., '%s')]]"),
+    "host.smart_variable_override": (
+        By.XPATH,
+        "//a[ancestor::tr//td[contains(., '%s')] and @data-tag='override']"
+    ),
+    "host.smart_variable_unhide": (
+        By.XPATH,
+        "//a[ancestor::tr//td[contains(., '%s')] and "
+        "@data-original-title='Unhide this value']"
+    ),
+    "host.smart_variable_hide": (
+        By.XPATH,
+        "//a[ancestor::tr//td[contains(., '%s')] and "
+        "@data-original-title='Hide this value']"
+    ),
+    "host.smart_variable_puppet_class": (
+        By.XPATH, "//td[contains(., '%s')]//ancestor::tbody/tr[1]/td[1]"),
+    "host.override_error": (By.XPATH, "//td[@class='has-error']"),
 
     # host.vm (NOTE:- visible only when selecting a compute resource)
     "host.cpus": (
@@ -3099,4 +3131,101 @@ locators = LocatorDict({
     "hostcollection.errata.cancel_installation": (
         By.XPATH,
         "//button[contains(@ng-click, 'detailsTable.working = false')]"),
+
+    # Smart Variable
+    "smart_variable.new": (By.XPATH, "//a[contains(., '+ Add Variable')]"),
+    "smart_variable.select_name": (By.XPATH, "//a[contains(., '%s')]"),
+    "smart_variable.key": (
+        By.XPATH,
+        "//input[(ancestor::div[@class='tab-pane fields active'] or "
+        "contains(@id, 'variable_')) and contains(@name, '[key]')]"),
+    "smart_variable.description": (
+        By.XPATH,
+        "//textarea[(ancestor::div[@class='tab-pane fields active'] or "
+        "contains(@id, 'variable_')) and contains(@name, '[description]')]"),
+    "smart_variable.puppet_class": (
+        By.XPATH,
+        "//div[(ancestor::div[@class='tab-pane fields active'] or "
+        "contains(@id, 'variable_')) and contains(@id, 'puppetclass')]/a"
+        "/span[contains(@class, 'arrow')]"),
+    "smart_variable.key_type": (
+        By.XPATH,
+        "//select[(ancestor::div[@class='tab-pane fields active'] or "
+        "contains(@id, 'variable_')) and contains(@name, '[key_type]')]"),
+    "smart_variable.default_value": (
+        By.XPATH,
+        "//textarea[(ancestor::div[@class='tab-pane fields active'] or "
+        "contains(@id, 'variable_')) and contains(@name, '[default_value]')]"),
+    "smart_variable.default_value_hidden": (
+        By.XPATH,
+        "//input[(ancestor::div[@class='tab-pane fields active'] or "
+        "contains(@id, 'variable_')) and contains(@name, '[default_value]')]"),
+    "smart_variable.hidden_value": (
+        By.XPATH,
+        "//input[(ancestor::div[@class='tab-pane fields active'] or "
+        "contains(@id, 'variable_')) and contains(@id, 'hidden_value')]"),
+    "smart_variable.optional_expander": (
+        By.XPATH,
+        "//h2[(ancestor::div[@class='tab-pane fields active'] or "
+        "ancestor::form[contains(@id, 'edit_variable')]) and "
+        "contains(@data-target, 'input_validators')]"),
+    "smart_variable.validator_type": (
+        By.XPATH,
+        "//select[(ancestor::div[@class='tab-pane fields active'] or "
+        "contains(@id, 'variable_')) and contains(@name, '[validator_type]')]"
+    ),
+    "smart_variable.validator_rule": (
+        By.XPATH,
+        "//input[(ancestor::div[@class='tab-pane fields active'] or "
+        "contains(@id, 'variable_')) and contains(@name, '[validator_rule]')]"
+    ),
+    "smart_variable.matcher_priority": (
+        By.XPATH,
+        "//textarea[(ancestor::div[@class='tab-pane fields active'] or "
+        "contains(@name, 'variable_')) and contains(@name, '[path]')]"
+    ),
+    "smart_variable.merge_overrides": (
+        By.XPATH,
+        "//input[(ancestor::div[@class='tab-pane fields active'] or "
+        "contains(@id, 'variable_')) and contains(@id, 'merge_override')]"),
+    "smart_variable.merge_default": (
+        By.XPATH,
+        "//input[(ancestor::div[@class='tab-pane fields active'] or "
+        "contains(@id, 'variable_')) and contains(@id, 'merge_default')]"),
+    "smart_variable.avoid_duplicates": (
+        By.XPATH,
+        "//input[(ancestor::div[@class='tab-pane fields active'] or "
+        "contains(@id, 'variable_')) and contains(@id, 'avoid_duplicates')]"),
+    "smart_variable.add_matcher": (
+        By.XPATH,
+        "//a[(ancestor::div[@class='tab-pane fields active'] or "
+        "ancestor::form[contains(@id, 'edit_variable')]) and "
+        "contains(@data-original-title, 'new matcher')]"
+    ),
+    "smart_variable.matcher_attribute_type": (
+        By.XPATH,
+        "(//select[(ancestor::div[@class='tab-pane fields active'] or "
+        "ancestor::form[contains(@id, 'edit_variable')]) and "
+        "contains(@class, 'matcher_key')])[%i]"
+    ),
+    "smart_variable.matcher_attribute_value": (
+        By.XPATH,
+        "(//input[(ancestor::div[@class='tab-pane fields active'] or "
+        "ancestor::form[contains(@id, 'edit_variable')]) and "
+        "contains(@class, 'matcher_value')])[%i]"
+    ),
+    "smart_variable.matcher_value": (
+        By.XPATH,
+        "(//textarea[(ancestor::div[@class='tab-pane fields active'] or "
+        "contains(@id, 'variable_')) and contains(@name, '[value]')])[%i]"
+    ),
+    "smart_variable.matcher_value_hidden": (
+        By.XPATH,
+        "(//input[(ancestor::div[@class='tab-pane fields active'] or "
+        "contains(@id, 'variable_')) and contains(@name, '[value]')])[%i]"
+    ),
+    "smart_variable.matcher_error": (By.XPATH, "//tr[@class='has-error']"),
+    "smart_variable.delete": (
+        By.XPATH, "//a[@class='delete' and contains(@data-confirm, '%s')]"),
+    "smart_variable.table_value": (By.XPATH, "//td[contains(., '%s')]"),
 })

--- a/robottelo/ui/smart_variable.py
+++ b/robottelo/ui/smart_variable.py
@@ -1,0 +1,183 @@
+# -*- encoding: utf-8 -*-
+"""Implements Smart Variables UI"""
+
+from robottelo.ui.base import Base, UIError
+from robottelo.ui.locators import common_locators, locators, tab_locators
+from robottelo.ui.navigator import Navigator
+
+
+class SmartVariable(Base):
+    """Manipulates Smart Variables from UI"""
+
+    search_key = 'key'
+
+    def navigate_to_entity(self):
+        """Navigate to Smart Variable entity page"""
+        Navigator(self.browser).go_to_smart_variables()
+
+    def _search_locator(self):
+        """Specify locator for Smart Variable entity search procedure"""
+        return locators['smart_variable.select_name']
+
+    def _configure_variable(self, puppet_class=None, description=None,
+                            key_type=None, default_value=None,
+                            hidden_value=False, validator_type=None,
+                            validator_rule=None, matcher=None,
+                            matcher_priority=None,
+                            matcher_merge_overrides=None,
+                            matcher_merge_default=None,
+                            matcher_merge_avoid=None):
+        """Configuring Smart Variable parameters"""
+        if puppet_class:
+            self.assign_value(
+                locators['smart_variable.puppet_class'], puppet_class)
+        if description:
+            self.assign_value(
+                locators['smart_variable.description'], description)
+        if key_type:
+            self.assign_value(
+                locators['smart_variable.key_type'], key_type)
+        if default_value:
+            self.assign_value(
+                locators['smart_variable.default_value'], default_value)
+        if validator_type or validator_rule:
+            self.click(locators['smart_variable.optional_expander'])
+            if validator_type:
+                self.assign_value(
+                    locators['smart_variable.validator_type'], validator_type)
+            if validator_rule:
+                self.assign_value(
+                    locators['smart_variable.validator_rule'], validator_rule)
+        if matcher_priority:
+            self.assign_value(
+                locators['smart_variable.matcher_priority'], matcher_priority)
+        if matcher_merge_overrides is not None:
+            self.assign_value(
+                locators['smart_variable.merge_overrides'],
+                matcher_merge_overrides
+            )
+        if matcher_merge_default is not None:
+            self.assign_value(
+                locators['smart_variable.merge_default'],
+                matcher_merge_default
+            )
+        if matcher_merge_avoid is not None:
+            self.assign_value(
+                locators['smart_variable.avoid_duplicates'],
+                matcher_merge_avoid
+            )
+        if matcher:
+            self.add_matcher(matcher)
+        if hidden_value is not None:
+            self.assign_value(
+                locators['smart_variable.hidden_value'], hidden_value)
+
+    def create(self, name, puppet_class=None, description=None, key_type=None,
+               default_value=None, hidden_value=False, validator_type=None,
+               validator_rule=None, matcher=None, matcher_priority=None,
+               matcher_merge_overrides=None, matcher_merge_default=None,
+               matcher_merge_avoid=None):
+        """Creates new Smart Variable from UI"""
+        self.click(tab_locators['puppet_class.tab_smart_variable'])
+        self.click(locators['smart_variable.new'])
+        self.assign_value(locators['smart_variable.key'], name)
+        self._configure_variable(
+            description=description, key_type=key_type,
+            default_value=default_value, hidden_value=hidden_value,
+            validator_type=validator_type, validator_rule=validator_rule,
+            matcher=matcher, matcher_priority=matcher_priority,
+            matcher_merge_overrides=matcher_merge_overrides,
+            matcher_merge_default=matcher_merge_default,
+            matcher_merge_avoid=matcher_merge_avoid,
+        )
+        self.click(common_locators['submit'])
+
+    def update(self, name, new_name=None, puppet_class=None, description=None,
+               key_type=None, default_value=None, hidden_value=False,
+               validator_type=None, validator_rule=None, matcher=None,
+               matcher_priority=None, matcher_merge_overrides=None,
+               matcher_merge_default=None, matcher_merge_avoid=None):
+        """Updates existing Smart Variable from UI"""
+        self.click(self.search(name))
+        if new_name:
+            self.assign_value(locators['smart_variable.key'], new_name)
+        self._configure_variable(
+            description=description, key_type=key_type,
+            puppet_class=puppet_class, default_value=default_value,
+            hidden_value=hidden_value, validator_type=validator_type,
+            validator_rule=validator_rule, matcher_priority=matcher_priority,
+            matcher=matcher, matcher_merge_overrides=matcher_merge_overrides,
+            matcher_merge_default=matcher_merge_default,
+            matcher_merge_avoid=matcher_merge_avoid,
+        )
+        self.click(common_locators['submit'])
+
+    def delete(self, name, really=True):
+        """Deletes smart variable from UI"""
+        self.delete_entity(
+            name,
+            really,
+            locators['smart_variable.delete'],
+        )
+
+    def validate_smart_variable(self, name, field_name, field_value):
+        """Checks if selected smart variable has necessary field value on the
+        index pages
+
+        :param str name: Name of Smart Variable to be validated
+        :param str field_name: Smart Variable field that should be validated
+            (e.g. 'puppet_class' or 'overrides_number')
+        :param str field_value: Expected value for specified field
+        """
+        self.search(name)
+        searched = self.wait_until_element(
+            locators['smart_variable.table_value'] % field_value)
+        if searched is None:
+            raise UIError(
+                'Smart Variable "{0}" field in the table has not "{1}" value.'
+                .format(field_name, field_value)
+            )
+        else:
+            return True
+
+    def add_matcher(self, matcher_list):
+        """Adding new matcher to Smart Variable
+
+        :param matcher_list: List of matchers to be added to smart
+            variable. Each element is a dictionary of next format:
+            {
+            'matcher_attribute': 'attr_type=attr_value',
+            'matcher_value': 'value'
+            }
+
+        """
+        for i, matcher in enumerate(matcher_list, start=1):
+            self.click(locators['smart_variable.add_matcher'])
+            matcher_attribute = matcher['matcher_attribute'].split('=')
+            self.assign_value(
+                locators['smart_variable.matcher_attribute_type'] % i,
+                matcher_attribute[0]
+            )
+            self.assign_value(
+                locators['smart_variable.matcher_attribute_value'] % i,
+                matcher_attribute[1]
+            )
+            self.assign_value(
+                locators['smart_variable.matcher_value'] % i,
+                matcher['matcher_value']
+            )
+
+    def validate_checkbox(self, sv_name, checkbox_name):
+        """Checks if specific smart variable checkbox is enabled or not
+
+        :param str sv_name: Name of Smart Variable to be validated
+        :param str checkbox_name: Name of Smart Variable check box that will be
+            validated whether it is enabled or not (e.g. 'Merge overrides',
+            'Merge default' or 'Avoid duplicates')
+        :return bool: Return True if checkbox can be clicked and False
+            otherwise
+        """
+        self.click(self.search(sv_name))
+        locator_name = '.'.join((
+            'smart_variable', (checkbox_name.lower()).replace(' ', '_')))
+        return self.is_element_enabled(locators[locator_name])

--- a/robottelo/ui/smart_variable.py
+++ b/robottelo/ui/smart_variable.py
@@ -130,8 +130,8 @@ class SmartVariable(Base):
         :param str field_value: Expected value for specified field
         """
         self.search(name)
-        searched = self.wait_until_element(
-            locators['smart_variable.table_value'] % field_value)
+        strategy, value = locators['smart_variable.table_value']
+        searched = self.wait_until_element((strategy, value % field_value))
         if searched is None:
             raise UIError(
                 'Smart Variable "{0}" field in the table has not "{1}" value.'
@@ -154,18 +154,13 @@ class SmartVariable(Base):
         for i, matcher in enumerate(matcher_list, start=1):
             self.click(locators['smart_variable.add_matcher'])
             matcher_attribute = matcher['matcher_attribute'].split('=')
-            self.assign_value(
-                locators['smart_variable.matcher_attribute_type'] % i,
-                matcher_attribute[0]
-            )
-            self.assign_value(
-                locators['smart_variable.matcher_attribute_value'] % i,
-                matcher_attribute[1]
-            )
-            self.assign_value(
-                locators['smart_variable.matcher_value'] % i,
-                matcher['matcher_value']
-            )
+            strategy, value = locators['smart_variable.matcher_attribute_type']
+            self.assign_value((strategy, value % i), matcher_attribute[0])
+            strategy, value = locators[
+                'smart_variable.matcher_attribute_value']
+            self.assign_value((strategy, value % i), matcher_attribute[1])
+            strategy, value = locators['smart_variable.matcher_value']
+            self.assign_value((strategy, value % i), matcher['matcher_value'])
 
     def validate_checkbox(self, sv_name, checkbox_name):
         """Checks if specific smart variable checkbox is enabled or not

--- a/tests/foreman/api/test_classparameters.py
+++ b/tests/foreman/api/test_classparameters.py
@@ -138,6 +138,12 @@ class SmartClassParametersTestCase(APITestCase):
             raise RuntimeError('There are not enough smart class parameters to'
                                ' work with in provided puppet class')
 
+    @classmethod
+    def tearDownClass(cls):
+        super(SmartClassParametersTestCase, cls).tearDownClass()
+        ssh.command('puppet module uninstall --force puppetlabs/ntp')
+        cls.proxy.import_puppetclasses(environment=cls.env)
+
     @run_only_on('sat')
     @tier2
     def test_positive_list_parameters_by_host_id(self):
@@ -1554,9 +1560,3 @@ class SmartClassParametersTestCase(APITestCase):
         sc_param = sc_param.read()
         self.assertEqual(getattr(sc_param, 'hidden_value?'), True)
         self.assertFalse(sc_param.default_value)
-
-    @classmethod
-    def tearDownClass(cls):
-        super(SmartClassParametersTestCase, cls).tearDownClass()
-        ssh.command('puppet module uninstall --force puppetlabs/ntp')
-        cls.proxy.import_puppetclasses(environment=cls.env)

--- a/tests/foreman/api/test_classparameters.py
+++ b/tests/foreman/api/test_classparameters.py
@@ -133,7 +133,7 @@ class SmartClassParametersTestCase(APITestCase):
             cls.puppet_modules, CUSTOM_PUPPET_REPO, cls.org)
         cls.env = entities.Environment().search(
             query={'search': u'content_view="{0}"'.format(cv.name)}
-        )[0]
+        )[0].read()
         cls.puppet_class = entities.PuppetClass().search(query={
             'search': u'name = "{0}" and environment = "{1}"'.format(
                 cls.puppet_modules[0]['name'], cls.env.name)
@@ -174,13 +174,18 @@ class SmartClassParametersTestCase(APITestCase):
         sc_param.override = True
         sc_param.update(['override'])
         self.assertEqual(sc_param.read().override, True)
-        host = entities.Host(organization=self.org).create()
-        host.puppet_class = [self.puppet_class]
-        host.update(['puppet_class'])
-        self.assertGreater(len(host.list_scparams()), 0)
+        host = entities.Host(
+            organization=self.org,
+            environment=self.env
+        ).create()
+        host.add_puppetclass(
+            data={'puppetclass_id': self.puppet_class.id})
+        result = host.list_scparams()['results']
+        self.assertGreater(len(result), 0)
+        # Check that only unique results are returned
+        self.assertEqual(len(result), len({scp['id'] for scp in result}))
 
     @run_only_on('sat')
-    @skip_if_bug_open('bugzilla', 1374253)
     @tier2
     def test_positive_list_parameters_by_hostgroup_id(self):
         """List all the parameters included in specific HostGroup by id.
@@ -194,10 +199,13 @@ class SmartClassParametersTestCase(APITestCase):
         sc_param = self.sc_params_list.pop()
         sc_param.override = True
         sc_param.update(['override'])
-        hostgroup = entities.HostGroup().create()
+        hostgroup = entities.HostGroup(environment=self.env).create()
         hostgroup.add_puppetclass(
             data={'puppetclass_id': self.puppet_class.id})
-        self.assertGreater(len(hostgroup.list_scparams()), 0)
+        result = hostgroup.list_scparams()['results']
+        self.assertGreater(len(result), 0)
+        # Check that only unique results are returned
+        self.assertEqual(len(result), len({scp['id'] for scp in result}))
 
     @run_only_on('sat')
     @tier1
@@ -208,7 +216,37 @@ class SmartClassParametersTestCase(APITestCase):
 
         @assert: Parameters listed for specific Puppet class.
         """
-        self.assertGreater(len(self.puppet_class.list_scparams()), 0)
+        result = self.puppet_class.list_scparams()['results']
+        self.assertGreater(len(result), 0)
+        # Check that only unique results are returned
+        self.assertEqual(len(result), len({scp['id'] for scp in result}))
+
+    @run_only_on('sat')
+    @tier1
+    def test_positive_import_twice_list_parameters_by_puppetclass_id(self):
+        """Import same puppet class twice (e.g. into different Content Views)
+        but list class parameters only for specific puppet class.
+
+        @id: c20a56fd-a328-44ce-81ce-52e315c95a81
+
+        @assert: Parameters listed for specific Puppet class.
+
+        BZ: 1385351
+        """
+        cv = publish_puppet_module(
+            self.puppet_modules, CUSTOM_PUPPET_REPO, self.org)
+        env = entities.Environment().search(
+            query={'search': u'content_view="{0}"'.format(cv.name)}
+        )[0].read()
+        puppet_class = entities.PuppetClass().search(query={
+            'search': u'name = "{0}" and environment = "{1}"'.format(
+                self.puppet_modules[0]['name'], env.name)
+        })[0]
+        result = puppet_class.list_scparams(
+            data={'per_page': 1000})['results']
+        self.assertGreater(len(result), 0)
+        # Check that only unique results are returned
+        self.assertEqual(len(result), len({scp['id'] for scp in result}))
 
     @run_only_on('sat')
     @tier2
@@ -225,7 +263,10 @@ class SmartClassParametersTestCase(APITestCase):
         sc_param.override = True
         sc_param.update(['override'])
         self.assertEqual(sc_param.read().override, True)
-        self.assertGreater(len(self.env.list_scparams()), 0)
+        result = self.env.list_scparams()['results']
+        self.assertGreater(len(result), 0)
+        # Check that only unique results are returned
+        self.assertEqual(len(result), len({scp['id'] for scp in result}))
 
     @run_only_on('sat')
     @tier1

--- a/tests/foreman/api/test_classparameters.py
+++ b/tests/foreman/api/test_classparameters.py
@@ -26,6 +26,7 @@ from robottelo import ssh
 from robottelo.config import settings
 from robottelo.datafactory import filtered_datapoint
 from robottelo.decorators import (
+    run_in_one_thread,
     run_only_on,
     skip_if_bug_open,
     stubbed,
@@ -111,6 +112,7 @@ def invalid_sc_parameters_data():
     ]
 
 
+@run_in_one_thread
 class SmartClassParametersTestCase(APITestCase):
     """Implements Smart Class Parameter tests in API"""
 
@@ -124,8 +126,7 @@ class SmartClassParametersTestCase(APITestCase):
         )
         if len(cls.env) == 0:
             raise Exception("Environment not found")
-        else:
-            cls.env = cls.env[0]
+        cls.env = cls.env[0]
         cls.proxy = entities.SmartProxy(name=cls.host_name).search()[0]
         cls.proxy.import_puppetclasses(environment=cls.env)
         cls.puppet = entities.PuppetClass().search(

--- a/tests/foreman/api/test_classparameters.py
+++ b/tests/foreman/api/test_classparameters.py
@@ -180,10 +180,7 @@ class SmartClassParametersTestCase(APITestCase):
         ).create()
         host.add_puppetclass(
             data={'puppetclass_id': self.puppet_class.id})
-        result = host.list_scparams()['results']
-        self.assertGreater(len(result), 0)
-        # Check that only unique results are returned
-        self.assertEqual(len(result), len({scp['id'] for scp in result}))
+        self.assertGreater(len(host.list_scparams()['results']), 0)
 
     @run_only_on('sat')
     @tier2
@@ -202,10 +199,7 @@ class SmartClassParametersTestCase(APITestCase):
         hostgroup = entities.HostGroup(environment=self.env).create()
         hostgroup.add_puppetclass(
             data={'puppetclass_id': self.puppet_class.id})
-        result = hostgroup.list_scparams()['results']
-        self.assertGreater(len(result), 0)
-        # Check that only unique results are returned
-        self.assertEqual(len(result), len({scp['id'] for scp in result}))
+        self.assertGreater(len(hostgroup.list_scparams()['results']), 0)
 
     @run_only_on('sat')
     @tier1
@@ -218,35 +212,6 @@ class SmartClassParametersTestCase(APITestCase):
         """
         result = self.puppet_class.list_scparams()['results']
         self.assertGreater(len(result), 0)
-        # Check that only unique results are returned
-        self.assertEqual(len(result), len({scp['id'] for scp in result}))
-
-    @run_only_on('sat')
-    @tier1
-    def test_positive_import_twice_list_parameters_by_puppetclass_id(self):
-        """Import same puppet class twice (e.g. into different Content Views)
-        but list class parameters only for specific puppet class.
-
-        @id: c20a56fd-a328-44ce-81ce-52e315c95a81
-
-        @assert: Parameters listed for specific Puppet class.
-
-        BZ: 1385351
-        """
-        cv = publish_puppet_module(
-            self.puppet_modules, CUSTOM_PUPPET_REPO, self.org)
-        env = entities.Environment().search(
-            query={'search': u'content_view="{0}"'.format(cv.name)}
-        )[0].read()
-        puppet_class = entities.PuppetClass().search(query={
-            'search': u'name = "{0}" and environment = "{1}"'.format(
-                self.puppet_modules[0]['name'], env.name)
-        })[0]
-        result = puppet_class.list_scparams(
-            data={'per_page': 1000})['results']
-        self.assertGreater(len(result), 0)
-        # Check that only unique results are returned
-        self.assertEqual(len(result), len({scp['id'] for scp in result}))
 
     @run_only_on('sat')
     @tier2
@@ -263,10 +228,7 @@ class SmartClassParametersTestCase(APITestCase):
         sc_param.override = True
         sc_param.update(['override'])
         self.assertEqual(sc_param.read().override, True)
-        result = self.env.list_scparams()['results']
-        self.assertGreater(len(result), 0)
-        # Check that only unique results are returned
-        self.assertEqual(len(result), len({scp['id'] for scp in result}))
+        self.assertGreater(len(self.env.list_scparams()['results']), 0)
 
     @run_only_on('sat')
     @tier1

--- a/tests/foreman/api/test_variables.py
+++ b/tests/foreman/api/test_variables.py
@@ -23,7 +23,7 @@ from fauxfactory import gen_integer, gen_string
 from nailgun import entities
 from requests import HTTPError
 
-from robottelo.api.utils import delete_puppet_class, publish_puppet_module
+from robottelo.api.utils import publish_puppet_module
 from robottelo.constants import CUSTOM_PUPPET_REPO
 from robottelo.datafactory import (
     filtered_datapoint,
@@ -379,7 +379,8 @@ class SmartVariablesTestCase(APITestCase):
                     variable_type=data['sc_type'],
                     default_value=data['value'],
                 ).create()
-                self.assertEqual(smart_variable.variable_type, data['sc_type'])
+                self.assertEqual(
+                    smart_variable.parameter_type, data['sc_type'])
                 if data['sc_type'] in ('json', 'hash', 'array'):
                     self.assertEqual(
                         smart_variable.default_value, json.loads(data['value'])
@@ -451,7 +452,7 @@ class SmartVariablesTestCase(APITestCase):
     def test_negative_create_matcher_empty_value(self):
         """Create matcher with empty value with type other than string
 
-        @id: a90b5bcd-f76c-4663-bf41-2f96e7e15c0f
+        @id: ad24999f-1bed-4abb-a01f-3cb485d67968
 
         @steps:
 
@@ -1154,6 +1155,7 @@ class SmartVariablesTestCase(APITestCase):
         self.assertEqual(smart_variable.merge_default, True)
 
     @run_only_on('sat')
+    @skip_if_bug_open('bugzilla', 1375652)
     @tier1
     def test_negative_enable_merge_overrides_default_flags(self):
         """Disable Merge Overrides, Merge Default flags for non supported types
@@ -1216,6 +1218,7 @@ class SmartVariablesTestCase(APITestCase):
         self.assertEqual(smart_variable.avoid_duplicates, True)
 
     @run_only_on('sat')
+    @skip_if_bug_open('bugzilla', 1375652)
     @tier1
     def test_negative_enable_avoid_duplicates_flag(self):
         """Disable Avoid duplicates flag for non supported types

--- a/tests/foreman/api/test_variables.py
+++ b/tests/foreman/api/test_variables.py
@@ -21,9 +21,8 @@ from fauxfactory import gen_integer, gen_string
 from nailgun import entities
 from requests import HTTPError
 
-from robottelo import ssh
-from robottelo.api.utils import delete_puppet_class
-from robottelo.config import settings
+from robottelo.api.utils import delete_puppet_class, publish_puppet_module
+from robottelo.constants import CUSTOM_PUPPET_REPO
 from robottelo.datafactory import invalid_values_list, valid_data_list
 from robottelo.decorators import (
     run_only_on,
@@ -45,31 +44,31 @@ class SmartVariablesTestCase(APITestCase):
         class variables.
         """
         super(SmartVariablesTestCase, cls).setUpClass()
-        cls.puppet_module = "puppetlabs/ntp"
-        cls.host_name = settings.server.hostname
-        ssh.command(
-            'puppet module install --force {0}'.format(cls.puppet_module))
+        cls.puppet_modules = [
+            {'author': 'robottelo', 'name': 'api_test_variables'},
+        ]
+        cls.org = entities.Organization().create()
+        cv = publish_puppet_module(
+            cls.puppet_modules, CUSTOM_PUPPET_REPO, cls.org)
         cls.env = entities.Environment().search(
-            query={'search': 'name="production"'}
-        )
-        if len(cls.env) == 0:
-            raise Exception("Environment not found")
-        cls.env = cls.env[0]
-        cls.proxy = entities.SmartProxy(name=cls.host_name).search()[0]
-        cls.proxy.import_puppetclasses(environment=cls.env)
-        cls.puppet = entities.PuppetClass().search(
-            query={'search': 'name="ntp"'}
+            query={'search': u'content_view="{0}"'.format(cv.name)}
         )[0]
+        # Find imported puppet class
+        cls.puppet_class = entities.PuppetClass().search(query={
+            'search': u'name = "{0}" and environment = "{1}"'.format(
+                cls.puppet_modules[0]['name'], cls.env.name)
+        })[0]
+        # And all its subclasses
+        cls.puppet_subclasses = entities.PuppetClass().search(query={
+            'search': u'name = "{0}::" and environment = "{1}"'.format(
+                cls.puppet_modules[0]['name'], cls.env.name)
+        })
 
     @classmethod
     def tearDownClass(cls):
-        """Removes entire module from the system and re-imports classes into
-        proxy. This is required as other types of tests (CLI/UI) use the same
-        module.
-        """
+        """Removes puppet class."""
         super(SmartVariablesTestCase, cls).tearDownClass()
-        delete_puppet_class(cls.puppet.name, cls.puppet_module,
-                            cls.host_name, cls.env.name)
+        delete_puppet_class(cls.puppet_class.name)
 
     @run_only_on('sat')
     @tier1
@@ -85,7 +84,7 @@ class SmartVariablesTestCase(APITestCase):
         for name in valid_data_list():
             with self.subTest(name):
                 smart_variable = entities.SmartVariable(
-                    puppetclass=self.puppet,
+                    puppetclass=self.puppet_class,
                     variable=name,
                 ).create()
                 self.assertEqual(smart_variable.variable, name)
@@ -105,7 +104,7 @@ class SmartVariablesTestCase(APITestCase):
         for name in invalid_values_list():
             with self.subTest(name), self.assertRaises(HTTPError):
                 entities.SmartVariable(
-                    puppetclass=self.puppet,
+                    puppetclass=self.puppet_class,
                     variable=name,
                 ).create()
 
@@ -121,7 +120,7 @@ class SmartVariablesTestCase(APITestCase):
         @assert: The smart Variable is deleted successfully
         """
         smart_variable = entities.SmartVariable(
-            puppetclass=self.puppet
+            puppetclass=self.puppet_class
         ).create()
         smart_variable.delete()
         with self.assertRaises(HTTPError) as context:
@@ -148,12 +147,12 @@ class SmartVariablesTestCase(APITestCase):
         @assert: The variable is updated with new puppet class.
         """
         smart_variable = entities.SmartVariable(
-            puppetclass=self.puppet,
+            puppetclass=self.puppet_class,
         ).create()
-        self.assertEqual(smart_variable.puppetclass.id, self.puppet.id)
-        new_puppet = entities.PuppetClass().search(
-            query={'search': 'name="ntp::config"'}
-        )[0]
+        self.assertEqual(smart_variable.puppetclass.id, self.puppet_class.id)
+        new_puppet = entities.PuppetClass().search(query={
+            'search': 'name="{0}"'.format(choice(self.puppet_subclasses).name)
+        })[0]
         smart_variable.puppetclass = new_puppet
         updated_sv = smart_variable.update(['puppetclass'])
         self.assertEqual(updated_sv.puppetclass.id, new_puppet.id)
@@ -173,7 +172,7 @@ class SmartVariablesTestCase(APITestCase):
         @assert: The variable is updated with new name.
         """
         smart_variable = entities.SmartVariable(
-            puppetclass=self.puppet,
+            puppetclass=self.puppet_class,
         ).create()
         for new_name in valid_data_list():
             with self.subTest(new_name):
@@ -199,12 +198,12 @@ class SmartVariablesTestCase(APITestCase):
         name = gen_string('alpha')
         entities.SmartVariable(
             variable=name,
-            puppetclass=self.puppet,
+            puppetclass=self.puppet_class,
         ).create()
         with self.assertRaises(HTTPError) as context:
             entities.SmartVariable(
                 variable=name,
-                puppetclass=self.puppet,
+                puppetclass=self.puppet_class,
             ).create()
         self.assertRegexpMatches(
             context.exception.response.text,
@@ -222,11 +221,11 @@ class SmartVariablesTestCase(APITestCase):
 
         @CaseLevel: Integration
         """
-        entities.SmartVariable(puppetclass=self.puppet).create()
-        host = entities.Host().search(
-            query={'search': 'name={0}'.format(self.host_name)}
-        )[0]
-        host.add_puppetclass(data={'puppetclass_id': self.puppet.id})
+        entities.SmartVariable(puppetclass=self.puppet_class).create()
+        host = entities.Host(organization=self.org).create()
+        host.environment = self.env
+        host.update(['environment'])
+        host.add_puppetclass(data={'puppetclass_id': self.puppet_class.id})
         self.assertGreater(len(host.list_smart_variables()['results']), 0)
 
     @run_only_on('sat')
@@ -240,9 +239,10 @@ class SmartVariablesTestCase(APITestCase):
 
         @CaseLevel: Integration
         """
-        entities.SmartVariable(puppetclass=self.puppet).create()
+        entities.SmartVariable(puppetclass=self.puppet_class).create()
         hostgroup = entities.HostGroup().create()
-        hostgroup.add_puppetclass(data={'puppetclass_id': self.puppet.id})
+        hostgroup.add_puppetclass(
+            data={'puppetclass_id': self.puppet_class.id})
         self.assertGreater(len(hostgroup.list_smart_variables()['results']), 0)
 
     @run_only_on('sat')
@@ -254,7 +254,7 @@ class SmartVariablesTestCase(APITestCase):
 
         @assert: All variables listed for puppet class
         """
-        self.assertGreater(len(self.puppet.list_smart_variables()), 0)
+        self.assertGreater(len(self.puppet_class.list_smart_variables()), 0)
 
     @run_only_on('sat')
     @stubbed()
@@ -305,7 +305,7 @@ class SmartVariablesTestCase(APITestCase):
         @assert: Matcher is created with empty value
         """
         smart_variable = entities.SmartVariable(
-            puppetclass=self.puppet,
+            puppetclass=self.puppet_class,
             variable_type='string',
         ).create()
         entities.OverrideValue(
@@ -334,7 +334,7 @@ class SmartVariablesTestCase(APITestCase):
         @assert: Matcher is not created for empty value
         """
         smart_variable = entities.SmartVariable(
-            puppetclass=self.puppet,
+            puppetclass=self.puppet_class,
             default_value=gen_integer(),
             variable_type='integer',
         ).create()
@@ -362,7 +362,7 @@ class SmartVariablesTestCase(APITestCase):
         @assert: Matcher is not created
         """
         smart_variable = entities.SmartVariable(
-            puppetclass=self.puppet,
+            puppetclass=self.puppet_class,
         ).create()
         with self.assertRaises(HTTPError) as context:
             entities.OverrideValue(
@@ -392,7 +392,7 @@ class SmartVariablesTestCase(APITestCase):
         """
         value = gen_string('alpha')
         smart_variable = entities.SmartVariable(
-            puppetclass=self.puppet,
+            puppetclass=self.puppet_class,
             default_value=value,
         ).create()
         smart_variable.default_value = gen_string('alpha')
@@ -425,7 +425,7 @@ class SmartVariablesTestCase(APITestCase):
         """
         value = gen_string('numeric')
         smart_variable = entities.SmartVariable(
-            puppetclass=self.puppet,
+            puppetclass=self.puppet_class,
             default_value=gen_string('alpha'),
         ).create()
         smart_variable.default_value = value
@@ -454,7 +454,7 @@ class SmartVariablesTestCase(APITestCase):
         @assert: Matcher is not created for non matching value with regexp
         """
         smart_variable = entities.SmartVariable(
-            puppetclass=self.puppet,
+            puppetclass=self.puppet_class,
             default_value=gen_string('numeric'),
             validator_type='regexp',
             validator_rule='[0-9]',
@@ -487,7 +487,7 @@ class SmartVariablesTestCase(APITestCase):
         """
         value = gen_string('numeric')
         smart_variable = entities.SmartVariable(
-            puppetclass=self.puppet,
+            puppetclass=self.puppet_class,
             default_value=gen_string('numeric'),
             validator_type='regexp',
             validator_rule='[0-9]',
@@ -523,7 +523,7 @@ class SmartVariablesTestCase(APITestCase):
         """
         with self.assertRaises(HTTPError) as context:
             entities.SmartVariable(
-                puppetclass=self.puppet,
+                puppetclass=self.puppet_class,
                 default_value=gen_string('alphanumeric'),
                 validator_type='list',
                 validator_rule='5, test',
@@ -559,7 +559,7 @@ class SmartVariablesTestCase(APITestCase):
         values_list_str = ", ".join(str(x) for x in values_list)
         value = choice(values_list)
         smart_variable = entities.SmartVariable(
-            puppetclass=self.puppet,
+            puppetclass=self.puppet_class,
             default_value=value,
             validator_type='list',
             validator_rule=values_list_str,
@@ -585,7 +585,7 @@ class SmartVariablesTestCase(APITestCase):
         validator
         """
         smart_variable = entities.SmartVariable(
-            puppetclass=self.puppet,
+            puppetclass=self.puppet_class,
             default_value='example',
             validator_type='list',
             validator_rule='test, example, 30',
@@ -618,7 +618,7 @@ class SmartVariablesTestCase(APITestCase):
         @assert: Matcher is created for matching value with list validator
         """
         smart_variable = entities.SmartVariable(
-            puppetclass=self.puppet,
+            puppetclass=self.puppet_class,
             default_value='example',
             validator_type='list',
             validator_rule='test, example, 30',
@@ -653,7 +653,7 @@ class SmartVariablesTestCase(APITestCase):
         value
         """
         smart_variable = entities.SmartVariable(
-            puppetclass=self.puppet,
+            puppetclass=self.puppet_class,
             default_value=True,
             variable_type='boolean',
         ).create()
@@ -684,7 +684,7 @@ class SmartVariablesTestCase(APITestCase):
         @assert: Matcher is created for matching the type of default value
         """
         smart_variable = entities.SmartVariable(
-            puppetclass=self.puppet,
+            puppetclass=self.puppet_class,
             default_value=True,
             variable_type='boolean',
         ).create()
@@ -711,7 +711,7 @@ class SmartVariablesTestCase(APITestCase):
         @assert: Matcher is not created for non existing attribute
         """
         smart_variable = entities.SmartVariable(
-            puppetclass=self.puppet,
+            puppetclass=self.puppet_class,
         ).create()
         with self.assertRaises(HTTPError) as context:
             entities.OverrideValue(
@@ -739,7 +739,7 @@ class SmartVariablesTestCase(APITestCase):
         """
         value = gen_string('alpha')
         smart_variable = entities.SmartVariable(
-            puppetclass=self.puppet,
+            puppetclass=self.puppet_class,
         ).create()
         entities.OverrideValue(
             smart_variable=smart_variable,
@@ -780,7 +780,8 @@ class SmartVariablesTestCase(APITestCase):
     @stubbed()
     @tier1
     def test_negative_update_variable_attribute_priority(self):
-        """Matcher Value set on Attribute Priority for Host - alternate priority
+        """Matcher Value set on Attribute Priority
+        for Host - alternate priority
 
         @id: f6ef2193-5d63-43f1-8d91-e30984b2c0c5
 
@@ -1014,7 +1015,7 @@ class SmartVariablesTestCase(APITestCase):
         @assert: The Merge Overrides, Merge Default flags are enabled to set
         """
         smart_variable = entities.SmartVariable(
-            puppetclass=self.puppet,
+            puppetclass=self.puppet_class,
             default_value=[gen_integer()],
             variable_type='array',
         ).create()
@@ -1026,7 +1027,6 @@ class SmartVariablesTestCase(APITestCase):
         self.assertEqual(smart_variable.merge_default, True)
 
     @run_only_on('sat')
-    @skip_if_bug_open('bugzilla', 1375652)
     @tier1
     def test_negative_enable_merge_overrides_default_flags(self):
         """Disable Merge Overrides, Merge Default flags for non supported types
@@ -1039,7 +1039,7 @@ class SmartVariablesTestCase(APITestCase):
         set
         """
         smart_variable = entities.SmartVariable(
-            puppetclass=self.puppet,
+            puppetclass=self.puppet_class,
             default_value='50',
             variable_type='string',
         ).create()
@@ -1052,9 +1052,8 @@ class SmartVariablesTestCase(APITestCase):
             "array or hash"
         )
         with self.assertRaises(HTTPError) as context:
-            smart_variable.merge_overrides = True
             smart_variable.merge_default = True
-            smart_variable.update(['merge_overrides', 'merge_default'])
+            smart_variable.update(['merge_default'])
         self.assertRegexpMatches(
             context.exception.response.text,
             "Validation failed: Merge default can only be set when merge "
@@ -1079,7 +1078,7 @@ class SmartVariablesTestCase(APITestCase):
         @assert: The Avoid Duplicates is enabled to set to True
         """
         smart_variable = entities.SmartVariable(
-            puppetclass=self.puppet,
+            puppetclass=self.puppet_class,
             default_value=[gen_integer()],
             variable_type='array',
         ).create()
@@ -1090,7 +1089,6 @@ class SmartVariablesTestCase(APITestCase):
         self.assertEqual(smart_variable.avoid_duplicates, True)
 
     @run_only_on('sat')
-    @skip_if_bug_open('bugzilla', 1375652)
     @tier1
     def test_negative_enable_avoid_duplicates_flag(self):
         """Disable Avoid duplicates flag for non supported types
@@ -1107,7 +1105,7 @@ class SmartVariablesTestCase(APITestCase):
            array
         """
         smart_variable = entities.SmartVariable(
-            puppetclass=self.puppet,
+            puppetclass=self.puppet_class,
             default_value=True,
             variable_type='boolean',
         ).create()
@@ -1120,14 +1118,14 @@ class SmartVariablesTestCase(APITestCase):
             "array or hash"
         )
         with self.assertRaises(HTTPError) as context:
-            smart_variable.merge_overrides = True
             smart_variable.avoid_duplicates = True
-            smart_variable.update(['merge_overrides', 'avoid_duplicates'])
+            smart_variable.update(['avoid_duplicates'])
         self.assertRegexpMatches(
             context.exception.response.text,
-            "Validation failed: Merge default can only be set when merge "
-            "overrides is set"
+            "Validation failed: Avoid duplicates can only be set for arrays "
+            "that have merge_overrides set to true"
         )
+        smart_variable = smart_variable.read()
         self.assertEqual(smart_variable.merge_overrides, False)
         self.assertEqual(smart_variable.avoid_duplicates, False)
 
@@ -1147,7 +1145,7 @@ class SmartVariablesTestCase(APITestCase):
         """
         value = gen_string('alpha')
         smart_variable = entities.SmartVariable(
-            puppetclass=self.puppet,
+            puppetclass=self.puppet_class,
         ).create()
         matcher = entities.OverrideValue(
             smart_variable=smart_variable,
@@ -1186,14 +1184,15 @@ class SmartVariablesTestCase(APITestCase):
         matcher_value = gen_string('alpha')
         # Create variable
         smart_variable = entities.SmartVariable(
-            puppetclass=self.puppet,
+            puppetclass=self.puppet_class,
         ).create()
         # Create hostgroup and add puppet class to it
         hostgroup = entities.HostGroup(
             name=hostgroup_name,
             environment=self.env,
         ).create()
-        hostgroup.add_puppetclass(data={'puppetclass_id': self.puppet.id})
+        hostgroup.add_puppetclass(
+            data={'puppetclass_id': self.puppet_class.id})
         # Create matcher
         entities.OverrideValue(
             smart_variable=smart_variable,
@@ -1215,7 +1214,8 @@ class SmartVariablesTestCase(APITestCase):
             name=hostgroup_name,
             environment=self.env,
         ).create()
-        hostgroup.add_puppetclass(data={'puppetclass_id': self.puppet.id})
+        hostgroup.add_puppetclass(
+            data={'puppetclass_id': self.puppet_class.id})
         self.assertEqual(len(smart_variable.read().override_values), 0)
 
     @run_only_on('sat')
@@ -1233,7 +1233,7 @@ class SmartVariablesTestCase(APITestCase):
         @assert: The 'hidden value' flag is set
         """
         smart_variable = entities.SmartVariable(
-            puppetclass=self.puppet,
+            puppetclass=self.puppet_class,
             hidden_value=True,
         ).create()
         self.assertEqual(getattr(smart_variable, 'hidden_value?'), True)
@@ -1255,7 +1255,7 @@ class SmartVariablesTestCase(APITestCase):
         @assert: The 'hidden value' flag set to false
         """
         smart_variable = entities.SmartVariable(
-            puppetclass=self.puppet,
+            puppetclass=self.puppet_class,
             hidden_value=True,
         ).create()
         self.assertEqual(getattr(smart_variable, 'hidden_value?'), True)
@@ -1284,7 +1284,7 @@ class SmartVariablesTestCase(APITestCase):
         """
         value = gen_string('alpha')
         smart_variable = entities.SmartVariable(
-            puppetclass=self.puppet,
+            puppetclass=self.puppet_class,
             default_value=gen_string('alpha'),
             hidden_value=True,
         ).create()

--- a/tests/foreman/api/test_variables.py
+++ b/tests/foreman/api/test_variables.py
@@ -21,7 +21,7 @@ from fauxfactory import gen_integer, gen_string
 from nailgun import entities
 from requests import HTTPError
 
-from robottelo.api.utils import delete_puppet_class, publish_puppet_module
+from robottelo.api.utils import publish_puppet_module
 from robottelo.constants import CUSTOM_PUPPET_REPO
 from robottelo.datafactory import invalid_values_list, valid_data_list
 from robottelo.decorators import (
@@ -60,15 +60,20 @@ class SmartVariablesTestCase(APITestCase):
         })[0]
         # And all its subclasses
         cls.puppet_subclasses = entities.PuppetClass().search(query={
-            'search': u'name = "{0}::" and environment = "{1}"'.format(
+            'search': u'name ~ "{0}::" and environment = "{1}"'.format(
                 cls.puppet_modules[0]['name'], cls.env.name)
         })
 
-    @classmethod
-    def tearDownClass(cls):
-        """Removes puppet class."""
-        super(SmartVariablesTestCase, cls).tearDownClass()
-        delete_puppet_class(cls.puppet_class.name)
+    # TearDown brakes parallel tests run as every test depends on the same
+    # puppet class that will be removed during TearDown.
+    # Uncomment for developing or debugging and do not forget to import
+    # `robottelo.api.utils.delete_puppet_class`.
+    #
+    # @classmethod
+    # def tearDownClass(cls):
+    #     """Removes puppet class."""
+    #     super(SmartVariablesTestCase, cls).tearDownClass()
+    #     delete_puppet_class(cls.puppet_class.name)
 
     @run_only_on('sat')
     @tier1

--- a/tests/foreman/api/test_variables.py
+++ b/tests/foreman/api/test_variables.py
@@ -21,7 +21,7 @@ from fauxfactory import gen_integer, gen_string
 from nailgun import entities
 from requests import HTTPError
 
-from robottelo.api.utils import publish_puppet_module
+from robottelo.api.utils import delete_puppet_class, publish_puppet_module
 from robottelo.constants import CUSTOM_PUPPET_REPO
 from robottelo.datafactory import invalid_values_list, valid_data_list
 from robottelo.decorators import (

--- a/tests/foreman/api/test_variables.py
+++ b/tests/foreman/api/test_variables.py
@@ -1,0 +1,879 @@
+# -*- encoding: utf-8 -*-
+"""Test class for Smart/Puppet Variables
+
+@Requirement: Smart_Variables
+
+@CaseAutomation: Automated
+
+@CaseLevel: Acceptance
+
+@CaseComponent: API
+
+@TestType: Functional
+
+@CaseImportance: High
+
+@Upstream: No
+"""
+
+from robottelo.decorators import run_only_on, stubbed, tier1, tier2, tier3
+from robottelo.test import APITestCase
+
+
+class SmartVariablesTestCase(APITestCase):
+    """Implements Smart Variables tests in API"""
+
+    @run_only_on('sat')
+    @stubbed()
+    @tier1
+    def test_positive_create(self):
+        """Create a Smart Variable with valid name
+
+        @id: 4cd20cca-d419-43f5-9734-e9ae1caae4cb
+
+        @steps: Create a smart Variable with Valid name and valid default value
+
+        @assert: The smart Variable is created successfully
+
+        @caseautomation: notautomated
+        """
+
+    @run_only_on('sat')
+    @stubbed()
+    @tier1
+    def test_negative_create(self):
+        """Create a Smart Variable with invalid name
+
+        @id: d92f8bdd-93de-49ba-85a3-685aac9eda0a
+
+        @steps: Create a smart Variable with invalid name and valid default
+        value
+
+        @assert: The smart Variable is not created
+
+        @caseautomation: notautomated
+        """
+
+    @run_only_on('sat')
+    @stubbed()
+    @tier1
+    def test_positive_delete_smart_variable_by_id(self):
+        """Delete a Smart Variable by id
+
+        @id: 6d8354db-a028-4ae0-bcb6-87aa1cb9ec5d
+
+        @steps: Delete a smart Variable by id
+
+        @assert: The smart Variable is deleted successfully
+
+        @caseautomation: notautomated
+        """
+
+    @run_only_on('sat')
+    @stubbed()
+    @tier1
+    def test_positive_delete_smart_variable_by_name(self):
+        """Delete a Smart Variable by name
+
+        @id: 5ee2e72f-4224-4505-bf2e-2a29a16d55c1
+
+        @steps: Delete a smart Variable by name
+
+        @assert: The smart Variable is deleted successfully
+
+        @caseautomation: notautomated
+        """
+
+    @run_only_on('sat')
+    @stubbed()
+    @tier3
+    def test_positive_list_variables_by_host_id(self):
+        """List all the variables associated to Host by host id
+
+        @id: 4fc1f249-5da7-493b-a1d3-4ce7b625ad96
+
+        @assert: All variables listed for Host
+
+        @caseautomation: notautomated
+
+        @CaseLevel: System
+        """
+
+    @run_only_on('sat')
+    @stubbed()
+    @tier3
+    def test_positive_list_variables_by_hostgroup_id(self):
+        """List all the variables associated to HostGroup by hostgroup id
+
+        @id: db6861cc-b390-45bc-8c7d-cf10f46aecb3
+
+        @assert: All variables listed for HostGroup
+
+        @caseautomation: notautomated
+
+        @CaseLevel: System
+        """
+
+    @run_only_on('sat')
+    @stubbed()
+    @tier3
+    def test_positive_list_variables_by_puppetclass_id(self):
+        """List all the variables associated to puppet class by puppet class id
+
+        @id: cd743329-b354-4ddc-ada0-3ddd774e2701
+
+        @assert: All variables listed for puppet class
+
+        @caseautomation: notautomated
+
+        @CaseLevel: System
+        """
+
+    @run_only_on('sat')
+    @stubbed()
+    @tier1
+    def test_positive_create_variable_type(self):
+        """Create variable for variable types - Valid Value
+
+        Types - string, boolean, integer, real, array, hash, yaml, json
+
+        @id: 4c8b4134-33c1-4f7f-83f9-a751c49ae2da
+
+        @steps: Create a variable with all valid key types and default values
+
+        @assert: Variable created with all given types successfully
+
+        @caseautomation: notautomated
+        """
+
+    @run_only_on('sat')
+    @stubbed()
+    @tier1
+    def test_negative_create_variable_type(self):
+        """Negative variable Update for variable types - Invalid Value
+
+        Types - string, boolean, integer, real, array, hash, yaml, json
+
+        @id: 9709d67c-682f-4e6c-8b8b-f02f6c2d3b71
+
+        @steps: Create a variable with all valid key types and invalid default
+        values
+
+        @assert: Variable is not created for invalid value
+
+        @caseautomation: notautomated
+        """
+
+    @run_only_on('sat')
+    @stubbed()
+    @tier1
+    def test_positive_create_matcher_empty_value(self):
+        """Create matcher with empty value with string type
+
+        @id: a90b5bcd-f76c-4663-bf41-2f96e7e15c0f
+
+        @steps:
+
+        1. Create a matcher for variable with empty value and type string
+
+        @assert: Matcher is created with empty value
+
+        @caseautomation: notautomated
+        """
+
+    @run_only_on('sat')
+    @stubbed()
+    @tier1
+    def test_negative_create_matcher_empty_value(self):
+        """Create matcher with empty value with type other than string
+
+        @id: a90b5bcd-f76c-4663-bf41-2f96e7e15c0f
+
+        @steps:
+
+        1. Create a matcher for variable with empty value and type any other
+           than string
+
+        @assert: Matcher is not created for empty value
+
+        @caseautomation: notautomated
+        """
+
+    @run_only_on('sat')
+    @stubbed()
+    @tier1
+    def test_negative_create_default_value_with_regex(self):
+        """Create variable with non matching regex validator
+
+        @id: 0c80bd58-26aa-4c2a-a087-ed3b88b226a7
+
+        @steps:
+
+        1. Create variable with default value that doesn't matches the regex
+           of step 2
+        2. Validate this value with regexp validator type and rule
+
+        @assert: Variable is not created for non matching value with regex
+
+        @caseautomation: notautomated
+        """
+
+    @run_only_on('sat')
+    @stubbed()
+    @tier1
+    def test_positive_create_default_value_with_regex(self):
+        """Create variable with matching regex validator
+
+        @id: aa9803b9-9a45-4ad8-b502-e0e32fc4b7d8
+
+        @steps:
+
+        1. Create variable with default value that matches the regex of
+           step 2
+        2. Validate this value with regex validator type and rule
+
+        @assert: Variable is created for matching value with regex
+
+        @caseautomation: notautomated
+        """
+
+    @run_only_on('sat')
+    @stubbed()
+    @tier1
+    def test_negative_create_matcher_value_with_regex(self):
+        """Create matcher with non matching regexp validator
+
+        @id: 8a0f9251-7992-4d1e-bace-7e32637bf56f
+
+        @steps:
+
+        1. Create a matcher with value that doesn't matches the regex of step 2
+        2. Validate this value with regex validator type and rule
+
+        @assert: Matcher is not created for non matching value with regexp
+
+        @caseautomation: notautomated
+        """
+
+    @run_only_on('sat')
+    @stubbed()
+    @tier1
+    def test_positive_create_matcher_value_with_regex(self):
+        """Create matcher with matching regex validator
+
+        @id: 3ad09261-eb55-4758-b915-84006c9e527c
+
+        @steps:
+
+        1. Create a matcher with value that matches the regex of step 2
+        2. Validate this value with regex validator type and rule
+
+        @assert: Matcher is created for matching value with regex
+
+        @caseautomation: notautomated
+        """
+
+    @run_only_on('sat')
+    @stubbed()
+    @tier1
+    def test_negative_create_default_value_with_list(self):
+        """Create variable with non matching list validator
+
+        @id: cacb83a5-3e50-490b-b94f-a5d27f44ae12
+
+        @steps:
+
+        1. Create variable with default value that doesn't matches the list
+           validator of step 2
+        2. Validate this value with list validator type and rule
+
+        @assert: Variable is not created for non matching value with list
+        validator
+
+        @caseautomation: notautomated
+        """
+
+    @run_only_on('sat')
+    @stubbed()
+    @tier1
+    def test_positive_create_default_value_with_list(self):
+        """Create variable with matching list validator
+
+        @id: 6bc2caa0-1300-4751-8239-34b96517465b
+
+        @steps:
+
+        1. Create variable with default value that matches the list validator
+           of step 2
+        2. Validate this value with list validator type and rule
+
+        @assert: Variable is created for matching value with list
+
+        @caseautomation: notautomated
+        """
+
+    @run_only_on('sat')
+    @stubbed()
+    @tier1
+    def test_negative_create_matcher_value_with_list(self):
+        """Create matcher with non matching list validator
+
+        @id: 0aff0fdf-5a62-49dc-abe1-b727459d030a
+
+        @steps:
+
+        1. Create a matcher with value that doesn't matches the list validator
+           of step 2
+        2. Validate this value with list validator type and rule
+
+        @assert: Matcher is not created for non matching value with list
+        validator
+
+        @caseautomation: notautomated
+        """
+
+    @run_only_on('sat')
+    @stubbed()
+    @tier1
+    def test_positive_create_matcher_value_with_list(self):
+        """Create matcher with matching list validator
+
+        @id: f5eda535-6623-4130-bea0-97faf350a6a6
+
+        @steps:
+
+        1. Create a matcher with value that matches the list validator
+           of step 2
+        2. Validate this value with list validator type and rule
+
+        @assert: Matcher is created for matching value with list validator
+
+        @caseautomation: notautomated
+        """
+
+    @run_only_on('sat')
+    @stubbed()
+    @tier1
+    def test_negative_create_matcher_value_with_default_type(self):
+        """Create matcher with non matching type of default value
+
+        @id: 790c63d7-4e8a-4187-8566-3d85d57f9a4f
+
+        @steps:
+
+        1. Create variable with valid type and value
+        2. Create a matcher with value that doesn't matches the default type
+
+        @assert: Matcher is not created for non matching the type of default
+        value
+
+        @caseautomation: notautomated
+        """
+
+    @run_only_on('sat')
+    @stubbed()
+    @tier1
+    def test_positive_create_matcher_value_with_default_type(self):
+        """Create matcher with matching type of default value
+
+        @id: 99057f05-62cb-4230-b16c-d96ca6a5ae91
+
+        @steps:
+
+
+        1. Create variable with valid type and value
+        2. Create a matcher with value that matches the default type
+
+        @assert: Matcher is created for matching the type of default value
+
+        @caseautomation: notautomated
+        """
+
+    @run_only_on('sat')
+    @stubbed()
+    @tier1
+    def test_negative_create_matcher_non_existing_attribute(self):
+        """Create matcher for non existing attribute
+
+        @id: 23b16e7f-0626-467e-b53b-35e1634cc30d
+
+        @steps: Create matcher for non existing attribute
+
+        @assert: Matcher is not created for non existing attribute
+
+        @caseautomation: notautomated
+        """
+
+    @run_only_on('sat')
+    @stubbed()
+    @tier1
+    def test_positive_create_matcher(self):
+        """Create matcher for attribute in variable
+
+        @id: f0b3d51a-cf9a-4b43-9567-eb12cd973299
+
+        @steps: Create a matcher with all valid values
+
+        @assert: The matcher has been created successfully
+
+        @caseautomation: notautomated
+        """
+
+    @run_only_on('sat')
+    @stubbed()
+    @tier1
+    def test_positive_update_variable_attribute_priority(self):
+        """Variable value set on Attribute Priority for Host
+
+        @id: 78474b5e-7a50-4de0-b22c-3413ac06d067
+
+        @bz: 1362372
+
+        @steps:
+
+        1. Create variable with some valid value and type
+        2. Set fqdn as top priority attribute
+        3. Create first matcher for fqdn with valid details
+        4. Create second matcher for some attribute with valid details
+           Note - The FQDN/host should have this attribute
+        5. Check ENC output of associated host.
+
+        @assert: The ENC output shows variable value of fqdn matcher only
+
+        @caseautomation: notautomated
+        """
+
+    @run_only_on('sat')
+    @stubbed()
+    @tier1
+    def test_negative_update_variable_attribute_priority(self):
+        """Matcher Value set on Attribute Priority for Host - alternate priority
+
+        @id: f6ef2193-5d63-43f1-8d91-e30984b2c0c5
+
+        @bz: 1362372
+
+        @steps:
+
+        1. Create variable with valid value and type
+        2. Set some attribute(other than fqdn) as top priority attribute
+           Note - The fqdn/host should have this attribute
+        3. Create first matcher for fqdn with valid details
+        4. Create second matcher for attribute of step 3 with valid details
+        5. Check ENC output of associated host.
+
+        @assert: The ENC output shows variable value of step 4 matcher only
+
+        @caseautomation: notautomated
+        """
+
+    @run_only_on('sat')
+    @stubbed()
+    @tier1
+    def test_positive_update_variable_merge_override(self):
+        """Merge the values of all the associated matchers
+
+        Note - This TC is only for array and hash key types
+
+        @id: bb37995e-71f9-441c-b4d5-79e5b5ff3973
+
+        @bz: 1362372
+
+        @steps:
+
+        1. Create variable with valid value and type
+        2. Create first matcher for attribute fqdn with valid details
+        3. Create second matcher for other attribute with valid details.
+           Note - The fqdn/host should have this attribute
+        4. Create more matchers for some more attributes if any
+           Note - The fqdn/host should have this attributes
+        5. Set 'merge overrides' to True
+        6. Check ENC output of associated host
+
+        @assert:
+
+        1. The ENC output shows variable values merged from all the
+           associated matchers
+        2. The variable doesn't show the default value of variable.
+        3. Duplicate values in any are displayed
+
+        @caseautomation: notautomated
+        """
+
+    @run_only_on('sat')
+    @stubbed()
+    @tier1
+    def test_negative_update_variable_merge_override(self):
+        """Merge the override values from non associated matchers
+
+        Note - This TC is only for array and hash key types
+
+        @id: afcb7ef4-38dd-484b-8a02-bc4e3d027204
+
+        @bz: 1362372
+
+        @steps:
+
+        1. Create variable with valid value and type
+        2. Create first matcher for attribute fqdn with valid details
+        3. Create second matcher for other attribute with valid details
+           Note - The fqdn/host should not have this attribute
+        4. Create more matchers for some more attributes if any
+           Note - The fqdn/host should not have this attributes
+        5. Set 'merge overrides' to True
+        6. Check ENC output of associated host
+
+        @assert:
+
+        1. The ENC output shows variable values only for fqdn
+        2. The variable doesn't have the values for attribute
+           which are not associated to host
+        3. The variable doesn't have the default value of variable
+        4. Duplicate values if any are displayed
+
+        @caseautomation: notautomated
+        """
+
+    @run_only_on('sat')
+    @stubbed()
+    @tier1
+    def test_positive_update_variable_merge_default(self):
+        """Merge the values of all the associated matchers + default value
+
+        Note - This TC is only for array and hash key types
+
+        @id: 9607c52c-f4c7-468b-a741-d179de144646
+
+        @bz: 1362372
+
+        @steps:
+
+        1. Create variable with valid value and type
+        2. Create first matcher for attribute fqdn with valid details
+        3. Create second matcher for other attribute with valid details
+           Note - The fqdn/host should have this attribute
+        4. Create more matchers for some more attributes if any
+           Note - The fqdn/host should have this attributes
+        5. Set 'merge overrides' to True
+        6. Set 'merge default' to True
+        7. Check ENC output of associated host
+
+        @assert:
+
+        1. The ENC output shows the variable values merged from all the
+           associated matchers
+        2. The variable values has the default value of variable
+        3. Duplicate values if any are displayed
+
+        @caseautomation: notautomated
+        """
+
+    @run_only_on('sat')
+    @stubbed()
+    @tier1
+    def test_negative_update_variable_merge_default(self):
+        """Empty default value is not shown in merged values
+
+        Note - This TC is only for array and hash key types
+
+        @id: 9033de15-f7e8-42be-b2be-c04c13aa039b
+
+        @bz: 1362372
+
+        @steps:
+
+        1. Create variable with empty value and type
+        2. Create first matcher for attribute fqdn with valid details
+        3. Create second matcher for other attribute with valid details
+           Note - The fqdn/host should have this attribute
+        4. Create more matchers for some more attributes if any
+           Note - The fqdn/host should have this attributes
+        5. Set 'merge overrides' to True
+        6. Set 'merge default' to True
+        7. Check ENC output of associated host
+
+        @assert:
+
+        1. The ENC output shows variable values merged from all the associated
+           matchers
+        2. The variable doesn't have the empty default value of variable
+        3. Duplicate values if any are displayed
+
+        @caseautomation: notautomated
+        """
+
+    @run_only_on('sat')
+    @stubbed()
+    @tier1
+    def test_positive_update_variable_avoid_duplicate(self):
+        """Merge the values of all the associated matchers, remove duplicates
+
+        Note - This TC is only for array and hash key types
+
+        @id: fcb2dfb9-64d6-4647-bbcc-3e5c900aca1b
+
+        @bz: 1362372
+
+        @steps:
+
+        1. Create variable with valid value and type
+        2. Create first matcher for attribute fqdn with some value
+        3. Create second matcher for other attribute with same value as fqdn
+           matcher.
+           Note - The fqdn/host should have this attribute
+        4. Set 'merge overrides' to True
+        5. Set 'merge default' to True
+        6. Set 'avoid duplicate' to True
+        7. Check ENC output of associated host
+
+        @assert:
+
+        1. The ENC output shows the variable values merged from all the
+           associated matchers
+        2. The variable shows the default value of variable
+        3. Duplicate values are removed / not displayed
+
+        @caseautomation: notautomated
+        """
+
+    @run_only_on('sat')
+    @stubbed()
+    @tier1
+    def test_negative_update_variable_avoid_duplicate(self):
+        """Duplicates are not removed as they were not really present
+
+        Note - This TC is only for array and hash key types
+
+        @id: 1f8a06de-0c53-424e-b2c9-b48a580d6298
+
+        @bz: 1362372
+
+        @steps:
+
+        1. Create variable with valid value and type
+        2. Create first matcher for attribute fqdn with some value
+        3. Create second matcher for other attribute with other value than fqdn
+           matcher and default value.
+           Note - The fqdn/host should have this attribute
+        4. Set 'merge overrides' to True
+        5. Set 'merge default' to True
+        6. Set 'avoid duplicates' to True
+        7. Check ENC output of associated host
+
+        @assert:
+
+        1. The ENC output shows the variable values merged from all matchers
+        2. The variable shows default value of variable
+        3. No value removed as duplicate value
+
+        @caseautomation: notautomated
+        """
+
+    @run_only_on('sat')
+    @stubbed()
+    @tier3
+    def test_positive_enable_merge_overrides_and_default_flags(self):
+        """Enable Merge Overrides, Merge Default flags for supported types
+
+        @id: af2c16e1-9a78-4615-9bc3-34fadca6a179
+
+        @steps: Set variable type to array/hash
+
+        @assert: The Merge Overrides, Merge Default flags are enabled to set
+
+        @caseautomation: notautomated
+
+        @CaseLevel: System
+        """
+
+    @run_only_on('sat')
+    @stubbed()
+    @tier3
+    def test_negative_enable_merge_overrides_default_flags(self):
+        """Disable Merge Overrides, Merge Default flags for non supported types
+
+        @id: f62a7e23-6fb4-469a-8589-4c987ff589ef
+
+        @steps: Set variable type other than array/hash
+
+        @assert: The Merge Overrides, Merge Default flags are not enabled to
+        set
+
+        @caseautomation: notautomated
+
+        @CaseLevel: System
+        """
+
+    @run_only_on('sat')
+    @stubbed()
+    @tier3
+    def test_positive_enable_avaoid_duplicates_flag(self):
+        """Enable Avoid duplicates flag for supported type
+
+        @id: 98fb1884-ad2b-45a0-b376-66bbc5ef6f72
+
+        @steps:
+
+        1. Set variable type to array
+        2. Set 'merge overrides' to True
+
+        @assert: The Avoid Duplicates is enabled to set to True
+
+        @caseautomation: notautomated
+
+        @CaseLevel: System
+        """
+
+    @run_only_on('sat')
+    @stubbed()
+    @tier3
+    def test_negative_enable_avoid_duplicates_flag(self):
+        """Disable Avoid duplicates flag for non supported types
+
+        @id: c7a2f718-6346-4851-b5f1-ab36c2fa8c6a
+
+        @steps: Set variable type other than array
+
+        @assert:
+
+        1. The Merge Overrides flag is only enabled to set for type hash
+           other than array
+        2. The Avoid duplicates flag not enabled to set for any type than
+           array
+
+        @caseautomation: notautomated
+
+        @CaseLevel: System
+        """
+
+    @run_only_on('sat')
+    @stubbed()
+    @tier1
+    def test_positive_remove_matcher(self):
+        """Removal of matcher from variable
+
+        @id: 7a932a99-2bd9-43ee-bcda-2b01a389787c
+
+        @steps:
+
+        1. Override the variable and create a matcher for some attribute
+        2. Remove the matcher created in step 1
+
+        @assert: The matcher removed from variable
+
+        @caseautomation: notautomated
+
+        @CaseLevel: Integration
+        """
+
+    @run_only_on('sat')
+    @stubbed()
+    @tier3
+    def test_positive_impact_variable_delete_attribute(self):
+        """Impact on variable after deleting associated attribute
+
+        @id: d4faec04-be29-48e6-8585-10ff1c361a9e
+
+        @steps:
+
+        1. Create a variable and matcher for some attribute
+        2. Delete the attribute
+        3. Recreate the attribute with same name as earlier
+
+        @assert:
+
+        1. The matcher for deleted attribute removed from variable
+        2. On recreating attribute, the matcher should not reappear in variable
+
+        @caseautomation: notautomated
+
+        @CaseLevel: System
+        """
+
+    @run_only_on('sat')
+    @stubbed()
+    @tier2
+    def test_positive_hide_variable_default_value(self):
+        """Hide the default value of variable
+
+        @id: 04bed7fa8-a5be-4fc0-8e9b-d68da00f8de0
+
+        @steps:
+
+        1. Create variable with valid type and value
+        2. Set 'Hidden Value' flag to true
+
+        @assert: The 'hidden value' flag is set
+
+        @caseautomation: notautomated
+
+        @CaseLevel: System
+        """
+
+    @run_only_on('sat')
+    @stubbed()
+    @tier2
+    def test_positive_unhide_variable_default_value(self):
+        """Unhide the default value of variable
+
+        @id: e8b3ec03-1abb-48d8-9409-17178bb887cb
+
+        @steps:
+
+        1. Create variable with valid type and value
+        2. Set 'Hidden Value' flag to True
+        3. After hiding, set the 'Hidden Value' flag to False
+
+        @assert: The 'hidden value' flag set to false
+
+        @caseautomation: notautomated
+
+        @CaseLevel: System
+        """
+
+    @run_only_on('sat')
+    @stubbed()
+    @tier3
+    def test_positive_update_hidden_value_in_variable(self):
+        """Update the hidden default value of variable
+
+        @id: 21b5586e-9434-45ea-ae85-12e24c549412
+
+        @steps:
+
+        1. Create variable with valid type and value
+        2. Set 'Hidden Value' flag to true
+        3. Now in hidden state, update the default value
+
+        @assert:
+
+        1. The variable default value is updated
+        2. The 'hidden value' flag set to True
+
+        @caseautomation: notautomated
+
+        @CaseLevel: System
+        """
+
+    @run_only_on('sat')
+    @stubbed()
+    @tier3
+    def test_positive_hide_empty_default_value(self):
+        """Hiding the empty default value
+
+        @id: 010253f4-5f33-42b8-a40b-796a373670a6
+
+        @steps:
+
+        1. Create variable with valid type and empty value
+        2. Set 'Hidden Value' to true
+
+        @assert:
+
+        1. The 'hidden value' flag set to True
+        2. The default value is empty after hide
+
+        @caseautomation: notautomated
+
+        @CaseLevel: System
+        """

--- a/tests/foreman/cli/test_classparameters.py
+++ b/tests/foreman/cli/test_classparameters.py
@@ -21,6 +21,8 @@ from random import choice
 
 from nailgun import entities
 
+from robottelo import ssh
+from robottelo.api.utils import delete_puppet_class
 from robottelo.cli.base import CLIReturnCodeError
 from robottelo.cli.contentview import ContentView
 from robottelo.cli.environment import Environment
@@ -178,6 +180,16 @@ class SmartClassParametersTestCase(CLITestCase):
         if len(self.sc_params_list) == 0:
             raise Exception("Not enough smart class parameters. Please "
                             "update puppet module.")
+
+    @classmethod
+    def tearDownClass(cls):
+        """Removes entire module from the system and re-imports classes into
+        proxy. This is required as other types of tests (API/UI) use the same
+        module.
+        """
+        super(SmartClassParametersTestCase, cls).tearDownClass()
+        delete_puppet_class(cls.puppet['name'], cls.puppet_module,
+                            cls.host_name, cls.env['name'])
 
     @run_only_on('sat')
     @tier2
@@ -1029,7 +1041,6 @@ class SmartClassParametersTestCase(CLITestCase):
         @assert: The matcher has been created successfully.
         """
         sc_param_id = self.sc_params_ids_list.pop()
-        value = gen_string('alpha')
         SmartClassParameter.update({
             'id': sc_param_id,
             'override': 1,
@@ -1038,7 +1049,6 @@ class SmartClassParametersTestCase(CLITestCase):
         SmartClassParameter.add_override_value({
             'smart-class-parameter-id': sc_param_id,
             'match': 'domain=test.com',
-            'value': value,
             'use-puppet-default': 1
         })
         sc_param = SmartClassParameter.info({
@@ -1049,8 +1059,6 @@ class SmartClassParametersTestCase(CLITestCase):
             sc_param['override-values']['values']['1']['match'],
             'domain=test.com'
         )
-        self.assertEqual(
-            sc_param['override-values']['values']['1']['value'], value)
 
     @run_only_on('sat')
     @stubbed()
@@ -1536,16 +1544,3 @@ class SmartClassParametersTestCase(CLITestCase):
         })
         self.assertFalse(sc_param['default-value'])
         self.assertEqual(sc_param['hidden-value?'], True)
-
-    @classmethod
-    def tearDownClass(cls):
-        """Removes entire module from the system and re-imports classes into
-        proxy. This is required as other types of tests (API/UI) use the same
-        module.
-        """
-        super(SmartClassParametersTestCase, cls).tearDownClass()
-        ssh.command('puppet module uninstall --force puppetlabs/ntp')
-        Proxy.importclasses({
-            u'environment': cls.env['name'],
-            u'name': cls.host_name,
-        })

--- a/tests/foreman/cli/test_classparameters.py
+++ b/tests/foreman/cli/test_classparameters.py
@@ -23,7 +23,6 @@ from nailgun import entities
 
 from robottelo.api.utils import delete_puppet_class
 from robottelo.cli.base import CLIReturnCodeError
-from robottelo.cli.contentview import ContentView
 from robottelo.cli.environment import Environment
 from robottelo.cli.factory import (
     make_content_view,

--- a/tests/foreman/cli/test_classparameters.py
+++ b/tests/foreman/cli/test_classparameters.py
@@ -949,7 +949,7 @@ class SmartClassParametersTestCase(CLITestCase):
         with self.assertRaises(CLIReturnCodeError):
             SmartClassParameter.add_override_value({
                 'smart-class-parameter-id': sc_param_id,
-                'match': 'non_existing_attribute',
+                'match': 'hostgroup=nonexistingHG',
                 'value': gen_string('alpha')
             })
 
@@ -1536,3 +1536,16 @@ class SmartClassParametersTestCase(CLITestCase):
         })
         self.assertFalse(sc_param['default-value'])
         self.assertEqual(sc_param['hidden-value?'], True)
+
+    @classmethod
+    def tearDownClass(cls):
+        """Removes entire module from the system and re-imports classes into
+        proxy. This is required as other types of tests (API/UI) use the same
+        module.
+        """
+        super(SmartClassParametersTestCase, cls).tearDownClass()
+        ssh.command('puppet module uninstall --force puppetlabs/ntp')
+        Proxy.importclasses({
+            u'environment': cls.env['name'],
+            u'name': cls.host_name,
+        })

--- a/tests/foreman/cli/test_classparameters.py
+++ b/tests/foreman/cli/test_classparameters.py
@@ -21,7 +21,6 @@ from random import choice
 
 from nailgun import entities
 
-from robottelo import ssh
 from robottelo.api.utils import delete_puppet_class
 from robottelo.cli.base import CLIReturnCodeError
 from robottelo.cli.contentview import ContentView
@@ -180,6 +179,16 @@ class SmartClassParametersTestCase(CLITestCase):
         if len(self.sc_params_list) == 0:
             raise Exception("Not enough smart class parameters. Please "
                             "update puppet module.")
+
+    @classmethod
+    def tearDownClass(cls):
+        """Removes entire module from the system and re-imports classes into
+        proxy. This is required as other types of tests (API/UI) use the same
+        module.
+        """
+        super(SmartClassParametersTestCase, cls).tearDownClass()
+        delete_puppet_class(cls.puppet['name'], cls.puppet_module,
+                            cls.host_name, cls.env['name'])
 
     @classmethod
     def tearDownClass(cls):

--- a/tests/foreman/cli/test_classparameters.py
+++ b/tests/foreman/cli/test_classparameters.py
@@ -25,28 +25,24 @@ from robottelo.api.utils import delete_puppet_class
 from robottelo.cli.base import CLIReturnCodeError
 from robottelo.cli.environment import Environment
 from robottelo.cli.factory import (
-    make_content_view,
     make_hostgroup,
     make_org,
-    make_product,
-    make_repository,
     publish_puppet_module,
 )
 from robottelo.cli.host import Host
 from robottelo.cli.hostgroup import HostGroup
 from robottelo.cli.puppet import Puppet
-from robottelo.cli.repository import Repository
 from robottelo.cli.scparams import SmartClassParameter
-from robottelo.constants import FAKE_8_PUPPET_REPO
 from robottelo.constants import CUSTOM_PUPPET_REPO
 from robottelo.datafactory import filtered_datapoint, gen_string
 from robottelo.decorators import (
     run_in_one_thread,
     run_only_on,
+    skip_if_bug_open,
     stubbed,
     tier1,
     tier2,
-    skip_if_bug_open)
+)
 from robottelo.test import CLITestCase
 
 
@@ -1075,6 +1071,7 @@ class SmartClassParametersTestCase(CLITestCase):
         @assert: The matcher has been created successfully.
         """
         sc_param_id = self.sc_params_ids_list.pop()
+        value = gen_string('alpha')
         SmartClassParameter.update({
             'id': sc_param_id,
             'override': 1,
@@ -1083,7 +1080,8 @@ class SmartClassParametersTestCase(CLITestCase):
         SmartClassParameter.add_override_value({
             'smart-class-parameter-id': sc_param_id,
             'match': 'domain=test.com',
-            'use-puppet-default': 1
+            'use-puppet-default': 1,
+            'value': value,
         })
         sc_param = SmartClassParameter.info({
             'puppet-class': self.puppet_class['name'],

--- a/tests/foreman/cli/test_puppetclass.py
+++ b/tests/foreman/cli/test_puppetclass.py
@@ -1,0 +1,74 @@
+# -*- encoding: utf-8 -*-
+"""Test class for Puppet Classes CLI
+
+@Requirement: Puppetclass
+
+@CaseAutomation: Automated
+
+@CaseLevel: Acceptance
+
+@CaseComponent: CLI
+
+@TestType: Functional
+
+@CaseImportance: High
+
+@Upstream: No
+"""
+
+from robottelo import ssh
+from robottelo.cli.environment import Environment
+from robottelo.cli.factory import make_smart_variable
+from robottelo.cli.proxy import Proxy
+from robottelo.cli.puppet import Puppet
+from robottelo.config import settings
+from robottelo.decorators import (
+    tier2,
+    run_only_on
+)
+from robottelo.test import CLITestCase
+
+
+class PuppetClassTestCase(CLITestCase):
+    """Implements puppet class tests in CLI."""
+
+    @classmethod
+    def setUpClass(cls):
+        """Import a parametrized puppet class.
+        """
+        super(PuppetClassTestCase, cls).setUpClass()
+        cls.host_name = settings.server.hostname
+        ssh.command('puppet module install --force puppetlabs/ntp')
+        cls.env = Environment.info({u'name': 'production'})
+        Proxy.importclasses({
+            u'environment': cls.env['name'],
+            u'name': cls.host_name,
+        })
+        cls.puppet = Puppet.info({u'name': 'ntp'})
+
+    @run_only_on('sat')
+    @tier2
+    def test_positive_list_smart_class_parameters(self):
+        """List smart class parameters associated with the puppet class.
+
+        @id: 56b370c2-8fc6-49be-9676-242178cc709a
+
+        @assert: Smart class parameters listed for the class.
+        """
+        class_sc_parameters = Puppet.sc_params({
+            u'puppet-class': self.puppet['name']})
+        self.assertGreater(len(class_sc_parameters), 0)
+
+    @run_only_on('sat')
+    @tier2
+    def test_positive_list_smart_variables(self):
+        """List smart variables associated with the puppet class.
+
+        @id: cb2b41c0-29cc-4c0b-a7c8-38403d6dda5b
+
+        @assert: Smart variables listed for the class.
+        """
+        make_smart_variable({'puppet-class': self.puppet['name']})
+        class_smart_variables = Puppet.smart_variables({
+            u'puppet-class': self.puppet['name']})
+        self.assertGreater(len(class_smart_variables), 0)

--- a/tests/foreman/cli/test_variables.py
+++ b/tests/foreman/cli/test_variables.py
@@ -19,8 +19,6 @@ from random import choice
 
 from nailgun import entities
 
-
-from robottelo.api.utils import delete_puppet_class
 from robottelo.cli.base import CLIReturnCodeError
 from robottelo.cli.environment import Environment
 from robottelo.cli.factory import (
@@ -227,7 +225,7 @@ class SmartVariablesTestCase(CLITestCase):
                     'variable': name,
                     'puppet-class': self.puppet_class['name']
                 })
-                self.assertEqual(smart_variable['variable'], name)
+                self.assertEqual(smart_variable['name'], name)
 
     @run_only_on('sat')
     @tier1
@@ -246,7 +244,7 @@ class SmartVariablesTestCase(CLITestCase):
             with self.subTest(name):
                 with self.assertRaises(CLIReturnCodeError):
                     SmartVariable.create({
-                        'variable': name,
+                        'name': name,
                         'puppet-class': self.puppet_class['name']
                     })
 
@@ -284,9 +282,9 @@ class SmartVariablesTestCase(CLITestCase):
         """
         smart_variable = make_smart_variable({
             'puppet-class': self.puppet_class['name']})
-        SmartVariable.delete({'variable': smart_variable['variable']})
+        SmartVariable.delete({'name': smart_variable['name']})
         with self.assertRaises(CLIReturnCodeError):
-            SmartVariable.info({'variable': smart_variable['variable']})
+            SmartVariable.info({'name': smart_variable['name']})
 
     @run_only_on('sat')
     @tier1
@@ -310,15 +308,15 @@ class SmartVariablesTestCase(CLITestCase):
         new_puppet = Puppet.info(
             {u'name': choice(self.puppet_subclasses)['name']})
         SmartVariable.update({
-            'variable': smart_variable['variable'],
+            'name': smart_variable['name'],
             'puppet-class': new_puppet['name']
         })
         updated_sv = SmartVariable.info(
-            {'variable': smart_variable['variable']})
+            {'name': smart_variable['name']})
         self.assertEqual(updated_sv['puppet-class'], new_puppet['name'])
 
     @run_only_on('sat')
-    @skip_if_bug_open('bugzilla', 1367032)
+    @skip_if_bug_open('bugzilla', 1412124)
     @tier1
     def test_positive_update_name(self):
         """Update Smart Variable's name
@@ -338,11 +336,11 @@ class SmartVariablesTestCase(CLITestCase):
             with self.subTest(new_name):
                 SmartVariable.update({
                     'id': smart_variable['id'],
-                    'new-variable': new_name,
+                    'new-name': new_name,
                     'puppet-class': self.puppet_class['name']
                 })
                 updated_sv = SmartVariable.info({'id': smart_variable['id']})
-                self.assertEqual(updated_sv['variable'], new_name)
+                self.assertEqual(updated_sv['name'], new_name)
 
     @run_only_on('sat')
     @tier1
@@ -364,7 +362,7 @@ class SmartVariablesTestCase(CLITestCase):
             {'variable': name, 'puppet-class': self.puppet_class['name']})
         with self.assertRaises(CLIReturnCodeError):
             SmartVariable.create({
-                'variable': name, 'puppet-class': self.puppet_class['name']})
+                'name': name, 'puppet-class': self.puppet_class['name']})
 
     @run_only_on('sat')
     @tier1
@@ -979,7 +977,7 @@ class SmartVariablesTestCase(CLITestCase):
             'value': '[23, 44, 66]',
         })
         SmartVariable.update({
-            'variable': smart_variable['variable'],
+            'name': smart_variable['name'],
             'merge-overrides': 1,
             'merge-default': 1,
         })
@@ -1165,7 +1163,7 @@ class SmartVariablesTestCase(CLITestCase):
             'variable-type': 'array'
         })
         SmartVariable.update({
-            'variable': smart_variable['variable'],
+            'name': smart_variable['name'],
             'merge-overrides': 1,
             'merge-default': 1,
         })
@@ -1176,6 +1174,7 @@ class SmartVariablesTestCase(CLITestCase):
             smart_variable['override-values']['merge-default-value'], True)
 
     @run_only_on('sat')
+    @skip_if_bug_open('bugzilla', 1375652)
     @tier1
     def test_negative_enable_merge_overrides_default_flags(self):
         """Attempt to enable Merge Overrides, Merge Default flags for non
@@ -1199,7 +1198,7 @@ class SmartVariablesTestCase(CLITestCase):
         })
         with self.assertRaises(CLIReturnCodeError):
             SmartVariable.update({
-                'variable': smart_variable['variable'],
+                'name': smart_variable['name'],
                 'merge-overrides': 1,
                 'merge-default': 1,
             })
@@ -1229,11 +1228,11 @@ class SmartVariablesTestCase(CLITestCase):
             'variable-type': 'array'
         })
         SmartVariable.update({
-            'variable': smart_variable['variable'],
+            'name': smart_variable['name'],
             'merge-overrides': 1,
         })
         SmartVariable.update({
-            'variable': smart_variable['variable'],
+            'name': smart_variable['name'],
             'avoid-duplicates': 1,
         })
         smart_variable = SmartVariable.info({'id': smart_variable['id']})
@@ -1241,6 +1240,7 @@ class SmartVariablesTestCase(CLITestCase):
             smart_variable['override-values']['avoid-duplicates'], True)
 
     @run_only_on('sat')
+    @skip_if_bug_open('bugzilla', 1375652)
     @tier1
     def test_negative_enable_avoid_duplicates_flag(self):
         """Attempt to enable Avoid duplicates flag for non supported types.
@@ -1267,7 +1267,7 @@ class SmartVariablesTestCase(CLITestCase):
         })
         with self.assertRaises(CLIReturnCodeError):
             SmartVariable.update({
-                'variable': smart_variable['variable'],
+                'name': smart_variable['name'],
                 'merge-overrides': 1,
                 'avoid-duplicates': 1,
             })
@@ -1378,11 +1378,11 @@ class SmartVariablesTestCase(CLITestCase):
         })
         self.assertEqual(smart_variable['hidden-value?'], True)
         SmartVariable.update({
-            'variable': smart_variable['variable'],
+            'name': smart_variable['name'],
             'hidden-value': 0
         })
         updated_sv = SmartVariable.info(
-            {'variable': smart_variable['variable']})
+            {'name': smart_variable['name']})
         self.assertEqual(updated_sv['hidden-value?'], False)
 
     @run_only_on('sat')
@@ -1411,11 +1411,11 @@ class SmartVariablesTestCase(CLITestCase):
         })
         self.assertEqual(smart_variable['hidden-value?'], True)
         SmartVariable.update({
-            'variable': smart_variable['variable'],
+            'name': smart_variable['name'],
             'default-value': value,
         })
         updated_sv = SmartVariable.info(
-            {'variable': smart_variable['variable']})
+            {'name': smart_variable['name']})
         self.assertEqual(updated_sv['default-value'], value)
 
     @run_only_on('sat')

--- a/tests/foreman/cli/test_variables.py
+++ b/tests/foreman/cli/test_variables.py
@@ -19,6 +19,8 @@ from random import choice
 
 from nailgun import entities
 
+
+from robottelo.api.utils import delete_puppet_class
 from robottelo.cli.base import CLIReturnCodeError
 from robottelo.cli.environment import Environment
 from robottelo.cli.factory import (

--- a/tests/foreman/cli/test_variables.py
+++ b/tests/foreman/cli/test_variables.py
@@ -1,0 +1,1066 @@
+# -*- encoding: utf-8 -*-
+"""Test class for Puppet Smart Variables
+
+@Requirement: Variables
+
+@CaseAutomation: Automated
+
+@CaseLevel: Acceptance
+
+@CaseComponent: CLI
+
+@TestType: Functional
+
+@CaseImportance: High
+
+@Upstream: No
+"""
+
+from robottelo.decorators import (
+    run_only_on,
+    stubbed,
+    tier1,
+    tier2,
+    tier3
+)
+from robottelo.test import CLITestCase
+
+
+class SmartVariablesTestCase(CLITestCase):
+    """Implements Smart Variables tests in CLI"""
+
+    @run_only_on('sat')
+    @stubbed()
+    @tier2
+    def test_positive_list_variables_by_host_name(self):
+        """List all smart variables associated to host by hostname.
+
+        @id: ee0da54c-ab60-4dde-8e1f-d548b52bac73
+
+        @steps: List all the smart variables associated to specific host by
+        hostname.
+
+        @assert: Smart Variables listed for specific Host by hostname.
+
+        @CaseLevel: Integration
+        """
+
+    @run_only_on('sat')
+    @stubbed()
+    @tier2
+    def test_positive_list_variables_by_host_id(self):
+        """List all smart variables associated to host by host id.
+
+        @id: ee2e994b-2a6d-4069-a2f7-e244a3134772
+
+        @steps: List all the smart variables associated to specific host by
+        host id.
+
+        @assert: Smart Variables listed for specific Host by host id.
+
+        @CaseLevel: Integration
+        """
+
+    @run_only_on('sat')
+    @stubbed()
+    @tier2
+    def test_positive_list_variables_by_hostgroup_name(self):
+        """List all smart variables associated to hostgroup by hostgroup name
+
+        @id: cb69abe0-2349-4114-91e9-ef93f261dc50
+
+        @steps: List all smart variables associated to hostgroup by hostgroup
+        name.
+
+        @assert: Smart Variables listed for specific HostGroup by hostgroup
+        name.
+
+        @CaseLevel: Integration
+        """
+
+    @run_only_on('sat')
+    @stubbed()
+    @tier2
+    def test_positive_list_variables_by_hostgroup_id(self):
+        """List all smart variables associated to hostgroup by hostgroup id
+
+        @id: 0f167c4c-e4de-4b66-841f-d5a9e410391e
+
+        @steps: List all smart variables associated to hostgroup by hostgroup
+        id.
+
+        @assert: Smart Variables listed for specific HostGroup by hostgroup id.
+
+        @CaseLevel: Integration
+        """
+
+    @run_only_on('sat')
+    @stubbed()
+    @tier1
+    def test_positive_list_variables_by_puppetclass_name(self):
+        """List all smart variables associated to puppet class by puppet class
+        name.
+
+        @id: 43b795c2-a64d-4a84-bb35-1e8fd0e1a0c9
+
+        @steps: List all smart variables associated to puppet class by puppet
+        class name.
+
+        @assert: Smart Variables listed for specific puppet class by puppet
+        class name.
+
+        @CaseLevel: Integration
+        """
+
+    @run_only_on('sat')
+    @stubbed()
+    @tier1
+    def test_positive_list_variables_by_puppetclass_id(self):
+        """List all smart variables associated to puppet class by puppet class
+        id.
+
+        @id: 57d290e8-2ae2-4c09-ab1e-7c7914bc4ba8
+
+        @steps: List all smart variables associated to puppet class by puppet
+        class id.
+
+        @assert: Smart Variables listed for specific puppet class by puppet
+        class id.
+
+        @CaseLevel: Integration
+        """
+
+    @run_only_on('sat')
+    @stubbed()
+    @tier1
+    def test_positive_create(self):
+        """Create a Smart Variable.
+
+        @id: 8be9ed26-9a27-42a8-8edd-b255637f205e
+
+        @steps:
+
+        1. Create a smart Variable with Valid name and default value.
+
+        @assert: The smart Variable is created successfully.
+
+        @caseautomation: notautomated
+        """
+
+    @run_only_on('sat')
+    @stubbed()
+    @tier1
+    def test_negative_create(self):
+        """Create Smart Variable with invalid name.
+
+        @id: 3f71f39f-4178-42e7-be40-2a3538361466
+
+        @steps:
+
+        1. Create a smart Variable with Invalid name and valid default value.
+
+        @assert: The smart Variable is not created.
+
+        @caseautomation: notautomated
+        """
+
+    @run_only_on('sat')
+    @stubbed()
+    @tier1
+    def test_positive_delete_smart_variable_by_id(self):
+        """Delete a Smart Variable by id.
+
+        @id: b0c4f7f0-d568-411f-94c2-fa525f36a8fd
+
+        @steps:
+
+        1. Delete a smart Variable by id.
+
+        @assert: The smart Variable is deleted successfully.
+
+        @caseautomation: notautomated
+        """
+
+    @run_only_on('sat')
+    @stubbed()
+    @tier1
+    def test_positive_delete_smart_variable_by_name(self):
+        """Delete a Smart Variable by name.
+
+        @id: 52900000-d7e1-4f0c-b67e-a2a1d25fc76e
+
+        @steps:
+
+        1. Delete a smart Variable by name.
+
+        @assert: The smart Variable is deleted successfully.
+
+        @caseautomation: notautomated
+        """
+
+    @run_only_on('sat')
+    @stubbed()
+    @tier1
+    def test_positive_update_variable_puppet_class(self):
+        """Update Smart Variable's puppet class.
+
+        @id: 0f2d617b-c9ec-46e9-ac84-7a0d59a84811
+
+        @steps:
+
+        1. Create a smart variable with valid name and default value.
+        2. Add this variable to some host/hostgroup.
+        3. Update the puppet class associated to the smart variable created in
+        step1.
+
+        @assert: The variable is updated with new puppet class.
+
+        @caseautomation: notautomated
+        """
+
+    @run_only_on('sat')
+    @stubbed()
+    @tier3
+    def test_negative_duplicate_name_variable(self):
+        """Create Smart Variable with an existing name.
+
+        @id: cc219111-1d2a-47ae-9b22-0b399f2d586d
+
+        @steps:
+
+        1. Create a smart Variable with Valid name and default value.
+        2. Attempt to create a variable with same name from same/other class.
+
+        @assert: The variable with same name are not allowed to create from
+        any class.
+
+        @caseautomation: notautomated
+
+        @CaseLevel: System
+        """
+
+    @run_only_on('sat')
+    @stubbed()
+    @tier1
+    def test_positive_create_type(self):
+        """Create smart variable with all valid key types and values.
+
+        Types - string, boolean, integer, real, array, hash, yaml, json
+
+        @id: 63d9c79a-5d54-44f8-b36d-45eb183cb148
+
+        @steps:
+
+        1.  Create a variable with valid key type and default value.
+
+        @assert: Variable is created with a new type successfully.
+
+        @caseautomation: notautomated
+        """
+
+    @run_only_on('sat')
+    @stubbed()
+    @tier1
+    def test_negative_update_type(self):
+        """Create smart variable with all valid key types but invalid values.
+
+        Types - string, boolean, integer, real, array, hash, yaml, json
+
+        @id: aab8423e-3857-4ac9-9f18-aec64f95a90d
+
+        @steps:
+
+        1.  Create a variable with valid key type and invalid default value.
+
+        @assert: Variable is not created with new type for invalid value.
+
+        @caseautomation: notautomated
+        """
+
+    @run_only_on('sat')
+    @stubbed()
+    @tier1
+    def test_positive_create_empty_matcher_value(self):
+        """Create matcher with empty value for string type.
+
+        @id: 00fe9a2b-a4c0-4f3e-9bc3-db22f8625005
+
+        @steps: Create a matcher for variable with type string and empty value
+
+        @assert: Matcher is created with empty value
+
+        @caseautomation: notautomated
+        """
+
+    @run_only_on('sat')
+    @stubbed()
+    @tier1
+    def test_negative_create_empty_matcher_value(self):
+        """Create matcher with empty value for non string type.
+
+        @id: 677a0881-c42a-4063-ac7b-7e7d9b5bc307
+
+        @steps: Create a matcher for variable with type other than string and
+        empty value
+
+        @assert: Matcher is not created with empty value
+
+        @caseautomation: notautomated
+        """
+
+    @run_only_on('sat')
+    @stubbed()
+    @tier1
+    def test_negative_validate_default_value_with_regex(self):
+        """Test variable is not created for unmatched validator type regex.
+
+        @id: f728ea2c-f7f4-4d9b-8c92-9681e0b21769
+
+        @steps:
+
+        1.  Create a variable with value that doesn't match the regex of step 2
+        2.  Validate this value with regex validator type and valid rule.
+
+        @assert: Variable is not created for unmatched validator rule.
+
+        @caseautomation: notautomated
+        """
+
+    @run_only_on('sat')
+    @stubbed()
+    @tier1
+    def test_positive_validate_default_value_with_regex(self):
+        """Test variable is created for matched validator type regex.
+
+        @id: f720c888-0ed0-4d32-bf72-8f5db5c1b5ed
+
+        @steps:
+
+        1.  Create a variable with some default value that matches the regex of
+        step 2
+        2.  Validate this value with regex validator type and rule.
+
+        @assert: Variable is created for matched validator rule.
+
+        @caseautomation: notautomated
+        """
+
+    @run_only_on('sat')
+    @stubbed()
+    @tier1
+    def test_negative_validate_matcher_value_with_regex(self):
+        """Test matcher is not created for unmatched validator type regex.
+
+        @id: 6542a847-7627-4bc2-828f-33b06d30d4e4
+
+        @steps:
+
+        1.  Create a matcher with value that doesn't match the regex of step 2.
+        2.  Validate this value with regex validator type and rule.
+
+        @assert: Matcher is not created for unmatched validator rule.
+
+        @caseautomation: notautomated
+        """
+
+    @run_only_on('sat')
+    @stubbed()
+    @tier1
+    def test_positive_validate_matcher_value_with_regex(self):
+        """Test matcher is created for matched validator type regex.
+
+        @id: 67e20b4b-cf39-4dbc-b553-80c5d54b7ad2
+
+        @steps:
+
+        1.  Create a matcher with value that matches the regex of step 2.
+        2.  Validate this value with regex validator type and rule.
+
+        @assert: Matcher is created for matched validator rule.
+
+        @caseautomation: notautomated
+        """
+
+    @run_only_on('sat')
+    @stubbed()
+    @tier1
+    def test_negative_validate_default_value_with_list(self):
+        """Test variable is not created for unmatched validator type list.
+
+        @id: dc2b6471-99d7-448b-b90a-9675baacbebe
+
+        @steps:
+
+        1.  Create variable with some default value that doesn't match the list
+        of step 2.
+        2.  Validate this value with list validator type and rule.
+
+        @assert: Variable is not created for unmatched validator rule.
+
+        @caseautomation: notautomated
+        """
+
+    @run_only_on('sat')
+    @stubbed()
+    @tier1
+    def test_positive_validate_default_value_with_list(self):
+        """Test variable is created for matched validator type list.
+
+        @id: e3cbb3a6-5ac0-43b4-a566-6da758ae4cf6
+
+        @steps:
+
+        1.  Create a variable with some default value that matches the list of
+        step 2.
+        2.  Validate this value with list validator type and rule.
+
+        @assert: Variable is created for matched validator rule.
+
+        @caseautomation: notautomated
+        """
+
+    @run_only_on('sat')
+    @stubbed()
+    @tier1
+    def test_negative_validate_matcher_value_with_list(self):
+        """Test matcher is not created for unmatched validator type list.
+
+        @id: b6523714-8d6f-4b23-8ecf-6972a584bfee
+
+        @steps:
+
+        1.  Create a matcher with value that doesn't match the list of step 2.
+        2.  Validate this value with list validator type and rule.
+
+        @assert: Matcher is not created for unmatched validator rule.
+
+        @caseautomation: notautomated
+        """
+
+    @run_only_on('sat')
+    @stubbed()
+    @tier1
+    def test_positive_validate_matcher_value_with_list(self):
+        """Test matcher is created for matched validator type list.
+
+        @id: 751e70ba-f1a4-4b73-878f-b2ab260a8a78
+
+        @steps:
+
+        1.  Create a matcher with value that matches the list of step 2.
+        2.  Validate this value with list validator type and rule.
+
+        @assert: Matcher is created for matched validator rule.
+
+        @caseautomation: notautomated
+        """
+
+    @run_only_on('sat')
+    @stubbed()
+    @tier1
+    def test_negative_validate_matcher_value_with_default_type(self):
+        """Matcher is not created for value not of default type.
+
+        @id: 84463d56-839f-4d5b-8646-cb6772fe5875
+
+        @steps:
+
+        1.  Create variable with valid default value.
+        2.  Create matcher with value that doesn't match the default type.
+
+        @assert: Matcher is not created for unmatched type.
+
+        @caseautomation: notautomated
+        """
+
+    @run_only_on('sat')
+    @stubbed()
+    @tier1
+    def test_positive_validate_matcher_value_with_default_type(self):
+        """Matcher is created for default type value.
+
+        @id: fc29aeb4-ead9-48ff-92de-3db659e8b0d1
+
+        @steps:
+
+        1.  Create variable default type with valid value.
+        2.  Create a matcher with value that matches the default type.
+
+        @assert: Matcher is created for matched type.
+
+        @caseautomation: notautomated
+        """
+
+    @run_only_on('sat')
+    @stubbed()
+    @tier1
+    def test_negative_validate_matcher_non_existing_attribute(self):
+        """Test matcher creation for non-existing attribute.
+
+        @id: bde1edf6-12b8-457e-ac8f-a909666abfb5
+
+        @steps:
+
+        1.  Attempt to create a matcher with non existing attribute.
+
+        @assert: Matcher is not created for non-existing attribute.
+
+        @caseautomation: notautomated
+        """
+
+    @run_only_on('sat')
+    @stubbed()
+    @tier1
+    def test_positive_create_matcher(self):
+        """Create a Smart Variable with matcher.
+
+        @id: 9ab8ae74-ee58-4738-8d8b-0e465eee8696
+
+        @steps:
+
+        1. Create a smart variable with valid name and default value.
+        2. Create a matcher for Host with valid value.
+
+        @assert:
+
+        1. The smart Variable with matcher is created successfully.
+        2. The variable is associated with host with match.
+
+        @caseautomation: notautomated
+        """
+
+    @run_only_on('sat')
+    @stubbed()
+    @tier1
+    def test_positive_create_matcher_attribute_priority(self):
+        """Matcher Value set on Attribute Priority for Host.
+
+        @id: 1a774df6-d704-4e89-b951-bc6740c233cd
+
+        @steps:
+
+        1.  Create variable with some default value.
+        2.  Set fqdn as top priority attribute.
+        3.  Create first matcher for fqdn with valid details.
+        4.  Create second matcher for some attribute with valid details.
+        Note - The fqdn/host should have this attribute.
+        5.  Go to YAML output of associated host.
+
+        @assert: The YAML output has the value only for fqdn matcher.
+
+        @caseautomation: notautomated
+        """
+
+    @run_only_on('sat')
+    @stubbed()
+    @tier1
+    def test_negative_create_matcher_attribute_priority(self):
+        """Matcher Value set on Attribute Priority for Host - alternate priority.
+
+        @id: e4e8da4d-f37c-44c8-8cbb-17171cc0648b
+
+        @steps:
+
+        1.  Create variable with some default value.
+        2.  Set some attribute(other than fqdn) as top priority attribute.
+        Note - The fqdn/host should have this attribute.
+        3.  Create first matcher for fqdn with valid details.
+        4.  Create second matcher for attribute of step 3 with valid details.
+        5.  Go to YAML output of associated host.
+
+        @assert:
+
+        1.  The YAML output has the value only for step 5 matcher.
+        2.  The YAML output doesn't have value for fqdn/host matcher.
+
+        @caseautomation: notautomated
+        """
+
+    @run_only_on('sat')
+    @stubbed()
+    @tier1
+    def test_positive_create_matcher_merge_override(self):
+        """Merge the values of all the associated matchers.
+
+        @id: 2f8e80ff-612f-461e-9498-90ebab2352c5
+
+        @steps:
+
+        1.  Create variable with some default value.
+        2.  Create first matcher for attribute fqdn with valid details.
+        3.  Create second matcher for other attribute with valid details.
+        Note - The fqdn/host should have this attribute.
+        4.  Create more matchers for some more attributes if any.
+        Note - The fqdn/host should have this attributes.
+        5.  Set --merge-overrides to true.
+        6.  Go to YAML output of associated host.
+
+        @assert:
+
+        1.  The YAML output has the values merged from all the associated
+        matchers.
+        2.  The YAML output doesn't have the default value of variable.
+        3.  Duplicate values in YAML output if any are displayed.
+
+        @caseautomation: notautomated
+        """
+
+    @run_only_on('sat')
+    @stubbed()
+    @tier1
+    def test_negative_create_matcher_merge_override(self):
+        """Test merge the values from non associated matchers.
+
+        @id: 97831f91-c55a-4861-8730-4857c92f8829
+
+        @steps:
+
+        1.  Create variable with some default value.
+        3.  Create first matcher for attribute fqdn with valid details.
+        4.  Create second matcher for other attribute with valid details.
+        Note - The fqdn/host should not have this attribute.
+        5.  Create more matchers for some more attributes if any.
+        Note - The fqdn/host should not have this attributes.
+        6.  Set --merge-overrides to true.
+        7.  Go to YAML output of associated host.
+
+        @assert:
+
+        1.  The YAML output has the values only for fqdn.
+        2.  The YAML output doesn't have the values for attribute
+        which are not associated to host.
+        3.  The YAML output doesn't have the default value of variable.
+        4.  Duplicate values in YAML output if any are displayed.
+
+        @caseautomation: notautomated
+        """
+
+    @run_only_on('sat')
+    @stubbed()
+    @tier1
+    def test_positive_create_matcher_merge_default(self):
+        """Merge the values of all the associated matchers + default value.
+
+        @id: 3ff6bddd-c384-41bf-9209-d554b9859da0
+
+        @steps:
+
+        1. Create variable with some default value.
+        2. Create first matcher for attribute fqdn with valid details.
+        3. Create second matcher for other attribute with valid details.
+        Note - The fqdn/host should have this attribute.
+        4. Create more matchers for some more attributes if any.
+        Note - The fqdn/host should have this attributes.
+        5. Set --merge-overrides to true.
+        6. Set --merge-default to true.
+        7. Go to YAML output of associated host.
+
+        @assert:
+
+        1. The YAML output has the values merged from all
+        the associated matchers.
+        2. The YAML output has the default value of variable.
+        3. Duplicate values in YAML output if any are displayed.
+
+        @caseautomation: notautomated
+        """
+
+    @run_only_on('sat')
+    @stubbed()
+    @tier1
+    def test_negative_create_matcher_merge_default(self):
+        """Test empty default value in merged values.
+
+        @id: 7a7211f2-be81-4d5b-9a9b-755ba064fc76
+
+        @steps:
+
+        1. Create variable with some default value.
+        2. Create first matcher for attribute fqdn with valid details.
+        3. Create second matcher for other attribute with valid details.
+        Note - The fqdn/host should have this attribute.
+        4. Create more matchers for some more attributes if any.
+        Note - The fqdn/host should have this attributes.
+        5. Set --merge-overrides to true.
+        6. Set --merge-default to true.
+        7. Go to YAML output of associated host.
+
+        @assert:
+
+        1.  The YAML output has the values merged from all
+        the associated matchers.
+        2.  The YAML output doesn't have the empty default value of variable.
+        3.  Duplicate values in YAML output if any are displayed.
+
+        @caseautomation: notautomated
+        """
+
+    @run_only_on('sat')
+    @stubbed()
+    @tier1
+    def test_positive_create_matcher_avoid_duplicate(self):
+        """Merge the values of all the associated matchers, remove duplicates.
+
+        @id: d37bb265-796b-485f-8305-85c84f830fe5
+
+        @steps:
+
+        1.  Create variable with type array and value.
+        2.  Create first matcher for attribute fqdn with some value.
+        3.  Create second matcher for other attribute with
+        same value as fqdn matcher.
+        Note - The fqdn/host should have this attribute.
+        4.  Set --merge-overrides to true.
+        5.  Set --merge-default to true.
+        6.  Set --avoid -duplicates' to true.
+        7.  Go to YAML output of associated host.
+
+        @assert:
+
+        1.  The YAML output has the values merged from all
+        the associated matchers.
+        2.  The YAML output has the default value of variable.
+        3.  Duplicate values in YAML output are removed / not displayed.
+
+        @caseautomation: notautomated
+        """
+
+    @run_only_on('sat')
+    @stubbed()
+    @tier1
+    def test_negative_create_matcher_avoid_duplicate(self):
+        """Duplicates not removed as they were not really present.
+
+        @id: 972cf68b-fd3d-4731-97bf-119e03c61b33
+
+        @steps:
+
+        1.  Create variable with type array and value.
+        2.  Create first matcher for attribute fqdn with some value.
+        3.  Create second matcher for other attribute with other value
+        than fqdn matcher and default value.
+        Note - The fqdn/host should have this attribute.
+        4.  Set --merge-overrides to true.
+        5.  Set --merge-default to true.
+        6.  Set --avoid -duplicates' to true.
+        7.  Go to YAML output of associated host.
+
+        @assert:
+
+        1.  The YAML output has the values merged from all matchers.
+        2.  The YAML output has the default value of variable.
+        3.  No value removed as duplicate value.
+
+        @caseautomation: notautomated
+        """
+
+    @run_only_on('sat')
+    @stubbed()
+    @tier3
+    def test_positive_enable_merge_overrides_default_flags(self):
+        """Enable Merge Overrides, Merge Default flags for supported types.
+
+        @id: c000f408-c293-4915-9432-6b597a2e6ad0
+
+        @steps:
+
+        1.  Set variable type to array/hash.
+
+        @assert: The Merge Overrides, Merge Default flags are allowed to set
+        true.
+
+        @caseautomation: notautomated
+
+        @CaseLevel: System
+        """
+
+    @run_only_on('sat')
+    @stubbed()
+    @tier3
+    def test_negative_enable_merge_overrides_default_flags(self):
+        """Disable Merge Overrides, Merge Default flags for non supported types.
+
+        @id: 306400df-e823-48d6-b541-ef3b20181c78
+
+        @steps:
+
+        1.  Set variable type other than array/hash.
+
+        @assert: The Merge Overrides, Merge Default flags are not allowed
+        to set to true.
+
+        @caseautomation: notautomated
+
+        @CaseLevel: System
+        """
+
+    @run_only_on('sat')
+    @stubbed()
+    @tier3
+    def test_positive_enable_avoid_duplicates_flag(self):
+        """Enable Avoid duplicates flag for supported type- array.
+
+        @id: 0c7063e0-8e85-44b7-abae-4def7f68833a
+
+        @steps:
+
+        1. Set variable type to array.
+        2. Set '--merge-overrides' to true.
+
+        @assert: The '--avoid-duplicates' flag is allowed to set true.
+
+        @caseautomation: notautomated
+
+        @CaseLevel: System
+        """
+
+    @run_only_on('sat')
+    @stubbed()
+    @tier3
+    def test_negative_enable_avoid_duplicates_flag(self):
+        """Disable Avoid duplicates flag for non supported types.
+
+        @id: ea1e8e31-4374-4172-82fd-538d29d70c03
+
+        @steps:
+
+        1.  Set variable type other than array.
+
+        @assert:
+
+        1.  The '--merge-overrides' is only allowed to set to true for type
+        hash.
+        2.  The '--avoid-duplicates' is not allowed to set to true for type
+        other than array.
+
+        @caseautomation: notautomated
+
+        @CaseLevel: System
+        """
+
+    @run_only_on('sat')
+    @stubbed()
+    @tier3
+    def test_positive_impact_delete_attribute(self):
+        """Impact on variable after deleting associated attribute.
+
+        @id: ac6f3a65-ed39-4e97-bdee-349f08bd878e
+
+        @steps:
+
+        1.  Create a variable with matcher for some attribute.
+        2.  Delete the attribute.
+        3.  Recreate the attribute with same name as earlier.
+
+        @assert:
+
+        1.  The matcher for deleted attribute removed from variable.
+        2.  On recreating attribute, the matcher should not reappear in
+        variable.
+
+        @caseautomation: notautomated
+
+        @CaseLevel: System
+        """
+
+    @run_only_on('sat')
+    @stubbed()
+    @tier1
+    def test_positive_create_override_from_attribute(self):
+        """Impact on variable on overriding the variable value from attribute.
+
+        @id: 07622cab-26f9-4826-a61b-64748e4866a1
+
+        @steps:
+
+        1.  Create a variable.
+        2.  Associate variable with fqdn/hostgroup.
+        3.  From host/hostgroup, override the variable value.
+
+        @assert:
+
+        1.  The host/hostgroup is saved with changes.
+        2.  New matcher for fqdn/hostgroup created inside variable.
+
+        @caseautomation: notautomated
+        """
+
+    @run_only_on('sat')
+    @stubbed()
+    @tier1
+    def test_negative_create_override_from_attribute(self):
+        """No impact on variable on overriding the variable
+        with invalid value from attribute.
+
+        @id: 471fd4b3-c88a-4d3d-a142-343c75803c36
+
+        @steps:
+
+        1.  Create a variable.
+        2.  Associate variable with fqdn/hostgroup.
+        3.  From host/hostgroup, Attempt to override the variable with invalid
+        key type of value.
+
+        @assert:
+
+        1.  No matcher for fqdn/hostgroup is created inside variable.
+
+        @caseautomation: notautomated
+        """
+
+    @run_only_on('sat')
+    @stubbed()
+    @tier1
+    def test_negative_create_empty_value_matcher_from_attribute(self):
+        """Override variable value with empty value from attribute.
+
+        @id: 49dab842-b310-4149-b187-bd7ccf5464a6
+
+        @steps:
+
+        1.  Create a variable.
+        2.  Associate variable with fqdn/hostgroup.
+        3.  From host/hostgroup, Attempt to override the variable with empty
+        value.
+
+        @assert:
+
+        1.  Matcher for fqdn/hostgroup created for blank value.
+
+        @caseautomation: notautomated
+        """
+
+    @run_only_on('sat')
+    @stubbed()
+    @tier1
+    def test_positive_update_matcher_from_attribute(self):
+        """Impact on variable on editing the variable value from attribute.
+
+        @id: aa28f59f-0327-486b-8b16-64a2fe025e38
+
+        @steps:
+
+        1.  Create a variable.
+        2.  Associate variable with fqdn/hostgroup.
+        3.  Create a matcher for fqdn/hostgroup with valid details.
+        4.  From host/hostgroup, edit the variable value.
+
+        @assert:
+
+        1.  The host/hostgroup is saved with changes.
+        2.  Matcher value in variable is updated from fqdn/hostgroup.
+
+        @caseautomation: notautomated
+        """
+
+    @run_only_on('sat')
+    @stubbed()
+    @tier1
+    def test_negative_update_matcher_from_attribute(self):
+        """No Impact on variable on editing the variable with
+        invalid value from attribute.
+
+        @id: 083dc374-9cc1-447c-98f0-54fa800d4ea7
+
+        @steps:
+
+        1.  Create a variable.
+        2.  Associate variable with fqdn/hostgroup.
+        3.  Create a matcher for fqdn/hostgroup with valid details.
+        4.  From host/hostgroup, attempt to edit the variable
+        with invalid value.
+
+        @assert:
+
+        1.  Matcher value in variable is not updated from fqdn/hostgroup for
+        invalid value.
+
+        @caseautomation: notautomated
+        """
+
+    @run_only_on('sat')
+    @stubbed()
+    @tier3
+    def test_positive_hide_default_value(self):
+        """Test hiding of the default value of variable.
+
+        @id: 00dd5627-5d7c-4fb2-9bbc-bf812205459e
+
+        @steps:
+
+        1. Create a variable.
+        2. Enter some valid default value.
+        3. Set '--hidden-value' to true.
+
+        @assert: The default value is set to true.
+
+        @caseautomation: notautomated
+
+        @CaseLevel: System
+        """
+
+    @run_only_on('sat')
+    @stubbed()
+    @tier3
+    def test_positive_unhide_default_value(self):
+        """Test unhiding of the default value of variable.
+
+        @id: e1928ebf-32dd-4fb6-a40b-4c84507c1e2f
+
+        @steps:
+
+        1. Create a variable with some default value.
+        2. Set '--hidden-value' to true.
+        3. After hiding, set '--hidden-value' to false.
+
+        @assert: The default value is set to false.
+
+        @caseautomation: notautomated
+
+        @CaseLevel: System
+        """
+
+    @run_only_on('sat')
+    @stubbed()
+    @tier1
+    def test_positive_update_hidden_value(self):
+        """Update the hidden default value of variable.
+
+        @id: 944d3fb9-ce90-47d8-bc54-fdf505bd5317
+
+        @steps:
+
+        1. Create a variable with some valid default value.
+        2. Set '--hidden-value' to true.
+        3. Again update the default value.
+
+        @assert:
+
+        1. The variable default value is updated.
+        2. The variable '--hidden-value' is set true.
+
+        @caseautomation: notautomated
+        """
+
+    @run_only_on('sat')
+    @stubbed()
+    @tier3
+    def test_positive_hide_empty_default_value(self):
+        """Hiding the empty default value.
+
+        @id: dc4f7200-dd20-4b63-a27a-e6dc4d5607a5
+
+        @steps:
+
+        1.  Create a variable with empty value.
+        2.  Set '--hidden-value' to true.
+
+        @assert:
+
+        1.  The '--hidden-value' is set to true.
+        2.  The default value is empty.
+
+        @caseautomation: notautomated
+
+        @CaseLevel: System
+        """

--- a/tests/foreman/cli/test_variables.py
+++ b/tests/foreman/cli/test_variables.py
@@ -19,7 +19,6 @@ from random import choice
 
 from nailgun import entities
 
-from robottelo.api.utils import delete_puppet_class
 from robottelo.cli.base import CLIReturnCodeError
 from robottelo.cli.environment import Environment
 from robottelo.cli.factory import (
@@ -77,11 +76,16 @@ class SmartVariablesTestCase(CLITestCase):
                 cls.puppet_class['name'], cls.env['name'])
         })
 
-    @classmethod
-    def tearDownClass(cls):
-        """Removes puppet class."""
-        super(SmartVariablesTestCase, cls).tearDownClass()
-        delete_puppet_class(cls.puppet_class['name'])
+    # TearDown brakes parallel tests run as every test depends on the same
+    # puppet class that will be removed during TearDown
+    # Uncomment for developing or debugging and do not forget to import
+    # `robottelo.api.utils.delete_puppet_class`.
+    #
+    # @classmethod
+    # def tearDownClass(cls):
+    #     """Removes puppet class."""
+    #     super(SmartVariablesTestCase, cls).tearDownClass()
+    #     delete_puppet_class(cls.puppet_class['name'])
 
     @run_only_on('sat')
     @tier2
@@ -332,11 +336,11 @@ class SmartVariablesTestCase(CLITestCase):
             with self.subTest(new_name):
                 SmartVariable.update({
                     'id': smart_variable['id'],
-                    'new-name': new_name,
+                    'new-variable': new_name,
                     'puppet-class': self.puppet_class['name']
                 })
                 updated_sv = SmartVariable.info({'id': smart_variable['id']})
-                self.assertEqual(updated_sv['name'], new_name)
+                self.assertEqual(updated_sv['variable'], new_name)
 
     @run_only_on('sat')
     @tier1
@@ -536,7 +540,7 @@ class SmartVariablesTestCase(CLITestCase):
 
         @assert: Variable is created for matched validator rule.
         """
-        value = gen_string('numeric')
+        value = gen_string('numeric').lstrip('0')
         smart_variable = make_smart_variable({
             'puppet-class': self.puppet_class['name'],
             'default-value': gen_string('alpha')
@@ -593,7 +597,7 @@ class SmartVariablesTestCase(CLITestCase):
 
         @assert: Matcher is created for matched validator rule.
         """
-        value = gen_string('numeric')
+        value = gen_string('numeric').lstrip('0')
         smart_variable = make_smart_variable({
             'puppet-class': self.puppet_class['name'],
             'default-value': gen_string('numeric'),

--- a/tests/foreman/cli/test_variables.py
+++ b/tests/foreman/cli/test_variables.py
@@ -15,18 +15,23 @@
 
 @Upstream: No
 """
+from random import choice
 
-from robottelo import ssh
+from nailgun import entities
+
 from robottelo.api.utils import delete_puppet_class
 from robottelo.cli.base import CLIReturnCodeError
 from robottelo.cli.environment import Environment
-from robottelo.cli.factory import make_hostgroup, make_smart_variable
+from robottelo.cli.factory import (
+    make_hostgroup,
+    make_org,
+    make_smart_variable,
+    publish_puppet_module)
 from robottelo.cli.host import Host
 from robottelo.cli.hostgroup import HostGroup
-from robottelo.cli.proxy import Proxy
 from robottelo.cli.puppet import Puppet
 from robottelo.cli.smart_variable import SmartVariable
-from robottelo.config import settings
+from robottelo.constants import CUSTOM_PUPPET_REPO
 from robottelo.datafactory import (
     gen_string,
     invalid_values_list,
@@ -52,26 +57,31 @@ class SmartVariablesTestCase(CLITestCase):
         class variables.
         """
         super(SmartVariablesTestCase, cls).setUpClass()
-        cls.puppet_module = "puppetlabs/ntp"
-        cls.host_name = settings.server.hostname
-        ssh.command(
-            'puppet module install --force {0}'.format(cls.puppet_module))
-        cls.env = Environment.info({u'name': 'production'})
-        Proxy.importclasses({
-            u'environment': cls.env['name'],
-            u'name': cls.host_name,
+        cls.puppet_modules = [
+            {'author': 'robottelo', 'name': 'cli_test_variables'},
+        ]
+        cls.org = make_org()
+        cv = publish_puppet_module(
+            cls.puppet_modules, CUSTOM_PUPPET_REPO, cls.org['id'])
+        cls.env = Environment.list({
+            'search': u'content_view="{0}"'.format(cv['name'])
+        })[0]
+        # Find imported puppet class
+        cls.puppet_class = Puppet.info({
+            'name': cls.puppet_modules[0]['name'],
+            'environment': cls.env['name'],
         })
-        cls.puppet = Puppet.info({u'name': 'ntp'})
+        # And all its subclasses
+        cls.puppet_subclasses = Puppet.list({
+            'search': "name ~ {0}:: and environment = {1}".format(
+                cls.puppet_class['name'], cls.env['name'])
+        })
 
     @classmethod
     def tearDownClass(cls):
-        """Removes entire module from the system and re-imports classes into
-        proxy. This is required as other types of tests (API/UI) use the same
-        module.
-        """
+        """Removes puppet class."""
         super(SmartVariablesTestCase, cls).tearDownClass()
-        delete_puppet_class(cls.puppet['name'], cls.puppet_module,
-                            cls.host_name, cls.env['name'])
+        delete_puppet_class(cls.puppet_class['name'])
 
     @run_only_on('sat')
     @tier2
@@ -84,13 +94,15 @@ class SmartVariablesTestCase(CLITestCase):
 
         @CaseLevel: Integration
         """
-        make_smart_variable({'puppet-class': self.puppet['name']})
+        make_smart_variable({'puppet-class': self.puppet_class['name']})
+        host = entities.Host(organization=self.org['id']).create()
         Host.update({
-            u'name': self.host_name,
-            u'puppet-classes': self.puppet['name']
+            u'name': host.name,
+            u'environment': self.env['name'],
+            u'puppet-classes': self.puppet_class['name'],
         })
         host_smart_variables_list = Host.smart_variables({
-            u'host': self.host_name})
+            u'host': host.name})
         self.assertGreater(len(host_smart_variables_list), 0)
 
     @run_only_on('sat')
@@ -104,14 +116,15 @@ class SmartVariablesTestCase(CLITestCase):
 
         @CaseLevel: Integration
         """
-        make_smart_variable({'puppet-class': self.puppet['name']})
+        make_smart_variable({'puppet-class': self.puppet_class['name']})
+        host = entities.Host(organization=self.org['id']).create()
         Host.update({
-            u'name': self.host_name,
-            u'puppet-classes': self.puppet['name']
+            u'name': host.name,
+            u'environment': self.env['name'],
+            u'puppet-classes': self.puppet_class['name'],
         })
-        host_id = Host.info({u'name': self.host_name})['id']
         host_smart_variables_list = Host.smart_variables({
-            u'host-id': host_id})
+            u'host-id': host.id})
         self.assertGreater(len(host_smart_variables_list), 0)
 
     @run_only_on('sat')
@@ -126,10 +139,10 @@ class SmartVariablesTestCase(CLITestCase):
 
         @CaseLevel: Integration
         """
-        make_smart_variable({'puppet-class': self.puppet['name']})
+        make_smart_variable({'puppet-class': self.puppet_class['name']})
         hostgroup = make_hostgroup({
             'environment-id': self.env['id'],
-            'puppet-class-ids': self.puppet['id']
+            'puppet-class-ids': self.puppet_class['id']
         })
         hostgroup_smart_variables = HostGroup.smart_variables({
             u'hostgroup': hostgroup['name']})
@@ -146,10 +159,10 @@ class SmartVariablesTestCase(CLITestCase):
 
         @CaseLevel: Integration
         """
-        make_smart_variable({'puppet-class': self.puppet['name']})
+        make_smart_variable({'puppet-class': self.puppet_class['name']})
         hostgroup = make_hostgroup({
             'environment-id': self.env['id'],
-            'puppet-class-ids': self.puppet['id']
+            'puppet-class-ids': self.puppet_class['id']
         })
         hostgroup_smart_variables = HostGroup.smart_variables({
             u'hostgroup-id': hostgroup['id']})
@@ -166,9 +179,9 @@ class SmartVariablesTestCase(CLITestCase):
         @assert: Smart Variables listed for specific puppet class by puppet
         class name.
         """
-        make_smart_variable({'puppet-class': self.puppet['name']})
+        make_smart_variable({'puppet-class': self.puppet_class['name']})
         sc_params_list = SmartVariable.list({
-            'puppet-class': self.puppet['name']
+            'puppet-class': self.puppet_class['name']
         })
         self.assertGreater(len(sc_params_list), 0)
 
@@ -183,9 +196,9 @@ class SmartVariablesTestCase(CLITestCase):
         @assert: Smart Variables listed for specific puppet class by puppet
         class id.
         """
-        make_smart_variable({'puppet-class-id': self.puppet['id']})
+        make_smart_variable({'puppet-class-id': self.puppet_class['id']})
         sc_params_list = SmartVariable.list({
-            'puppet-class-id': self.puppet['id']
+            'puppet-class-id': self.puppet_class['id']
         })
         self.assertGreater(len(sc_params_list), 0)
 
@@ -205,7 +218,9 @@ class SmartVariablesTestCase(CLITestCase):
         for name in valid_data_list():
             with self.subTest(name):
                 smart_variable = make_smart_variable({
-                    'variable': name, 'puppet-class': self.puppet['name']})
+                    'variable': name,
+                    'puppet-class': self.puppet_class['name']
+                })
                 self.assertEqual(smart_variable['variable'], name)
 
     @run_only_on('sat')
@@ -225,7 +240,9 @@ class SmartVariablesTestCase(CLITestCase):
             with self.subTest(name):
                 with self.assertRaises(CLIReturnCodeError):
                     SmartVariable.create({
-                        'variable': name, 'puppet-class': self.puppet['name']})
+                        'variable': name,
+                        'puppet-class': self.puppet_class['name']
+                    })
 
     @run_only_on('sat')
     @tier1
@@ -241,7 +258,7 @@ class SmartVariablesTestCase(CLITestCase):
         @assert: The smart Variable is deleted successfully.
         """
         smart_variable = make_smart_variable({
-            'puppet-class': self.puppet['name']})
+            'puppet-class': self.puppet_class['name']})
         SmartVariable.delete({'id': smart_variable['id']})
         with self.assertRaises(CLIReturnCodeError):
             SmartVariable.info({'id': smart_variable['id']})
@@ -260,7 +277,7 @@ class SmartVariablesTestCase(CLITestCase):
         @assert: The smart Variable is deleted successfully.
         """
         smart_variable = make_smart_variable({
-            'puppet-class': self.puppet['name']})
+            'puppet-class': self.puppet_class['name']})
         SmartVariable.delete({'variable': smart_variable['variable']})
         with self.assertRaises(CLIReturnCodeError):
             SmartVariable.info({'variable': smart_variable['variable']})
@@ -281,9 +298,11 @@ class SmartVariablesTestCase(CLITestCase):
         @assert: The variable is updated with new puppet class.
         """
         smart_variable = make_smart_variable({
-            'puppet-class': self.puppet['name']})
-        self.assertEqual(smart_variable['puppet-class'], self.puppet['name'])
-        new_puppet = Puppet.info({u'name': 'ntp::config'})
+            'puppet-class': self.puppet_class['name']})
+        self.assertEqual(
+            smart_variable['puppet-class'], self.puppet_class['name'])
+        new_puppet = Puppet.info(
+            {u'name': choice(self.puppet_subclasses)['name']})
         SmartVariable.update({
             'variable': smart_variable['variable'],
             'puppet-class': new_puppet['name']
@@ -308,13 +327,13 @@ class SmartVariablesTestCase(CLITestCase):
         @assert: The variable is updated with new name.
         """
         smart_variable = make_smart_variable({
-            'puppet-class': self.puppet['name']})
+            'puppet-class': self.puppet_class['name']})
         for new_name in valid_data_list():
             with self.subTest(new_name):
                 SmartVariable.update({
                     'id': smart_variable['id'],
                     'new-name': new_name,
-                    'puppet-class': self.puppet['name']
+                    'puppet-class': self.puppet_class['name']
                 })
                 updated_sv = SmartVariable.info({'id': smart_variable['id']})
                 self.assertEqual(updated_sv['name'], new_name)
@@ -336,10 +355,10 @@ class SmartVariablesTestCase(CLITestCase):
         """
         name = gen_string('alpha')
         make_smart_variable(
-            {'variable': name, 'puppet-class': self.puppet['name']})
+            {'variable': name, 'puppet-class': self.puppet_class['name']})
         with self.assertRaises(CLIReturnCodeError):
             SmartVariable.create({
-                'variable': name, 'puppet-class': self.puppet['name']})
+                'variable': name, 'puppet-class': self.puppet_class['name']})
 
     @run_only_on('sat')
     @tier1
@@ -357,7 +376,7 @@ class SmartVariablesTestCase(CLITestCase):
         for value in valid_data_list():
             with self.subTest(value):
                 smart_variable = make_smart_variable({
-                    'puppet-class': self.puppet['name'],
+                    'puppet-class': self.puppet_class['name'],
                     'default-value': value,
                 })
                 self.assertEqual(smart_variable['default-value'], value)
@@ -412,7 +431,7 @@ class SmartVariablesTestCase(CLITestCase):
         @assert: Matcher is created with empty value
         """
         smart_variable = make_smart_variable({
-            'puppet-class': self.puppet['name'],
+            'puppet-class': self.puppet_class['name'],
             'default-value': gen_string('alpha'),
         })
         SmartVariable.add_override_value({
@@ -441,7 +460,7 @@ class SmartVariablesTestCase(CLITestCase):
         @assert: Matcher is not created with empty value
         """
         smart_variable = make_smart_variable({
-            'puppet-class': self.puppet['name'],
+            'puppet-class': self.puppet_class['name'],
             'default-value': '20',
             'variable-type': 'integer'
         })
@@ -464,7 +483,7 @@ class SmartVariablesTestCase(CLITestCase):
         @assert: Matcher is not created
         """
         smart_variable = make_smart_variable({
-            'puppet-class': self.puppet['name'],
+            'puppet-class': self.puppet_class['name'],
         })
         with self.assertRaises(CLIReturnCodeError):
             SmartVariable.add_override_value({
@@ -489,7 +508,7 @@ class SmartVariablesTestCase(CLITestCase):
         """
         value = gen_string('alpha')
         smart_variable = make_smart_variable({
-            'puppet-class': self.puppet['name'],
+            'puppet-class': self.puppet_class['name'],
             'default-value': value
         })
         with self.assertRaises(CLIReturnCodeError):
@@ -519,7 +538,7 @@ class SmartVariablesTestCase(CLITestCase):
         """
         value = gen_string('numeric')
         smart_variable = make_smart_variable({
-            'puppet-class': self.puppet['name'],
+            'puppet-class': self.puppet_class['name'],
             'default-value': gen_string('alpha')
         })
         SmartVariable.update({
@@ -548,7 +567,7 @@ class SmartVariablesTestCase(CLITestCase):
         @assert: Matcher is not created for unmatched validator rule.
         """
         smart_variable = make_smart_variable({
-            'puppet-class': self.puppet['name'],
+            'puppet-class': self.puppet_class['name'],
             'default-value': gen_string('numeric'),
             'validator-type': 'regexp',
             'validator-rule': '[0-9]',
@@ -576,7 +595,7 @@ class SmartVariablesTestCase(CLITestCase):
         """
         value = gen_string('numeric')
         smart_variable = make_smart_variable({
-            'puppet-class': self.puppet['name'],
+            'puppet-class': self.puppet_class['name'],
             'default-value': gen_string('numeric'),
             'validator-type': 'regexp',
             'validator-rule': '[0-9]',
@@ -612,7 +631,7 @@ class SmartVariablesTestCase(CLITestCase):
         """
         with self.assertRaises(CLIReturnCodeError):
             SmartVariable.create({
-                'puppet-class': self.puppet['name'],
+                'puppet-class': self.puppet_class['name'],
                 'default-value': gen_string('alphanumeric'),
                 'validator-type': 'list',
                 'validator-rule': '5, test',
@@ -633,7 +652,7 @@ class SmartVariablesTestCase(CLITestCase):
         @assert: Variable is created for matched validator rule.
         """
         smart_variable = make_smart_variable({
-            'puppet-class': self.puppet['name'],
+            'puppet-class': self.puppet_class['name'],
             'default-value': 'test',
             'validator-type': 'list',
             'validator-rule': '5, test',
@@ -658,7 +677,7 @@ class SmartVariablesTestCase(CLITestCase):
         @assert: Matcher is not created for unmatched validator rule.
         """
         smart_variable = make_smart_variable({
-            'puppet-class': self.puppet['name'],
+            'puppet-class': self.puppet_class['name'],
             'default-value': '50',
             'validator-type': 'list',
             'validator-rule': '25, example, 50',
@@ -686,7 +705,7 @@ class SmartVariablesTestCase(CLITestCase):
         @assert: Matcher is created for matched validator rule.
         """
         smart_variable = make_smart_variable({
-            'puppet-class': self.puppet['name'],
+            'puppet-class': self.puppet_class['name'],
             'default-value': 'example',
             'validator-type': 'list',
             'validator-rule': 'test, example, 30',
@@ -722,7 +741,7 @@ class SmartVariablesTestCase(CLITestCase):
         @assert: Matcher is not created for unmatched type.
         """
         smart_variable = make_smart_variable({
-            'puppet-class': self.puppet['name'],
+            'puppet-class': self.puppet_class['name'],
             'default-value': 'true',
             'variable-type': 'boolean'
         })
@@ -748,7 +767,7 @@ class SmartVariablesTestCase(CLITestCase):
         @assert: Matcher is created for matched type.
         """
         smart_variable = make_smart_variable({
-            'puppet-class': self.puppet['name'],
+            'puppet-class': self.puppet_class['name'],
             'default-value': 'true',
             'variable-type': 'boolean'
         })
@@ -801,7 +820,7 @@ class SmartVariablesTestCase(CLITestCase):
         """
         value = gen_string('alpha')
         smart_variable = make_smart_variable({
-            'puppet-class': self.puppet['name']})
+            'puppet-class': self.puppet_class['name']})
         SmartVariable.add_override_value({
             'smart-variable-id': smart_variable['id'],
             'match': 'is_virtual=true',
@@ -837,7 +856,7 @@ class SmartVariablesTestCase(CLITestCase):
         """
         value = gen_string('alpha')
         smart_variable = make_smart_variable({
-            'puppet-class': self.puppet['name']})
+            'puppet-class': self.puppet_class['name']})
         SmartVariable.add_override_value({
             'smart-variable-id': smart_variable['id'],
             'match': 'is_virtual=true',
@@ -939,7 +958,7 @@ class SmartVariablesTestCase(CLITestCase):
         @CaseLevel: Integration
         """
         smart_variable = make_smart_variable({
-            'puppet-class': self.puppet['name'],
+            'puppet-class': self.puppet_class['name'],
             'default-value': '[56]',
             'variable-type': 'array'
         })
@@ -1135,7 +1154,7 @@ class SmartVariablesTestCase(CLITestCase):
         True.
         """
         smart_variable = make_smart_variable({
-            'puppet-class': self.puppet['name'],
+            'puppet-class': self.puppet_class['name'],
             'default-value': '[56]',
             'variable-type': 'array'
         })
@@ -1151,7 +1170,6 @@ class SmartVariablesTestCase(CLITestCase):
             smart_variable['override-values']['merge-default-value'], True)
 
     @run_only_on('sat')
-    @skip_if_bug_open('bugzilla', 1375652)
     @tier1
     def test_negative_enable_merge_overrides_default_flags(self):
         """Attempt to enable Merge Overrides, Merge Default flags for non
@@ -1169,7 +1187,7 @@ class SmartVariablesTestCase(CLITestCase):
         to set to True.
         """
         smart_variable = make_smart_variable({
-            'puppet-class': self.puppet['name'],
+            'puppet-class': self.puppet_class['name'],
             'default-value': gen_string('numeric'),
             'variable-type': 'integer'
         })
@@ -1179,6 +1197,11 @@ class SmartVariablesTestCase(CLITestCase):
                 'merge-overrides': 1,
                 'merge-default': 1,
             })
+        smart_variable = SmartVariable.info({'id': smart_variable['id']})
+        self.assertEqual(
+            smart_variable['override-values']['merge-overrides'], False)
+        self.assertEqual(
+            smart_variable['override-values']['merge-default-value'], False)
 
     @run_only_on('sat')
     @tier1
@@ -1195,7 +1218,7 @@ class SmartVariablesTestCase(CLITestCase):
         @assert: The '--avoid-duplicates' flag is allowed to set true.
         """
         smart_variable = make_smart_variable({
-            'puppet-class': self.puppet['name'],
+            'puppet-class': self.puppet_class['name'],
             'default-value': '[test]',
             'variable-type': 'array'
         })
@@ -1212,7 +1235,6 @@ class SmartVariablesTestCase(CLITestCase):
             smart_variable['override-values']['avoid-duplicates'], True)
 
     @run_only_on('sat')
-    @skip_if_bug_open('bugzilla', 1375652)
     @tier1
     def test_negative_enable_avoid_duplicates_flag(self):
         """Attempt to enable Avoid duplicates flag for non supported types.
@@ -1233,7 +1255,7 @@ class SmartVariablesTestCase(CLITestCase):
         other than array.
         """
         smart_variable = make_smart_variable({
-            'puppet-class': self.puppet['name'],
+            'puppet-class': self.puppet_class['name'],
             'default-value': gen_string('numeric'),
             'variable-type': 'integer'
         })
@@ -1243,6 +1265,11 @@ class SmartVariablesTestCase(CLITestCase):
                 'merge-overrides': 1,
                 'avoid-duplicates': 1,
             })
+        smart_variable = SmartVariable.info({'id': smart_variable['id']})
+        self.assertEqual(
+            smart_variable['override-values']['merge-overrides'], False)
+        self.assertEqual(
+            smart_variable['override-values']['avoid-duplicates'], False)
 
     @tier2
     def test_positive_impact_delete_attribute(self):
@@ -1267,11 +1294,11 @@ class SmartVariablesTestCase(CLITestCase):
         hostgroup_name = gen_string('alpha')
         matcher_value = gen_string('alpha')
         smart_variable = make_smart_variable(
-            {'puppet-class': self.puppet['name']})
+            {'puppet-class': self.puppet_class['name']})
         hostgroup = make_hostgroup({
             'name': hostgroup_name,
             'environment-id': self.env['id'],
-            'puppet-class-ids': self.puppet['id']
+            'puppet-class-ids': self.puppet_class['id']
         })
         SmartVariable.add_override_value({
             'smart-variable-id': smart_variable['id'],
@@ -1293,7 +1320,7 @@ class SmartVariablesTestCase(CLITestCase):
         make_hostgroup({
             'name': hostgroup_name,
             'environment-id': self.env['id'],
-            'puppet-class-ids': self.puppet['id']
+            'puppet-class-ids': self.puppet_class['id']
         })
         smart_variable = SmartVariable.info({'id': smart_variable['id']})
         self.assertEqual(len(smart_variable['override-values']['values']), 0)
@@ -1316,7 +1343,7 @@ class SmartVariablesTestCase(CLITestCase):
         value is hidden
         """
         smart_variable = make_smart_variable({
-            'puppet-class': self.puppet['name'],
+            'puppet-class': self.puppet_class['name'],
             'default-value': gen_string('alpha'),
             'hidden-value': 1,
         })
@@ -1339,7 +1366,7 @@ class SmartVariablesTestCase(CLITestCase):
         @assert: The hidden value is set to false.
         """
         smart_variable = make_smart_variable({
-            'puppet-class': self.puppet['name'],
+            'puppet-class': self.puppet_class['name'],
             'default-value': gen_string('alpha'),
             'hidden-value': 1,
         })
@@ -1372,7 +1399,7 @@ class SmartVariablesTestCase(CLITestCase):
         """
         value = gen_string('alpha')
         smart_variable = make_smart_variable({
-            'puppet-class': self.puppet['name'],
+            'puppet-class': self.puppet_class['name'],
             'default-value': gen_string('alpha'),
             'hidden-value': 1,
         })
@@ -1403,7 +1430,7 @@ class SmartVariablesTestCase(CLITestCase):
         2.  The default value is empty.
         """
         smart_variable = make_smart_variable({
-            'puppet-class': self.puppet['name'],
+            'puppet-class': self.puppet_class['name'],
             'default-value': '',
             'hidden-value': 1,
         })

--- a/tests/foreman/cli/test_variables.py
+++ b/tests/foreman/cli/test_variables.py
@@ -1137,6 +1137,7 @@ class SmartVariablesTestCase(CLITestCase):
             smart_variable['override-values']['merge-default-value'], True)
 
     @run_only_on('sat')
+    @skip_if_bug_open('bugzilla', 1375652)
     @tier1
     def test_negative_enable_merge_overrides_default_flags(self):
         """Attempt to enable Merge Overrides, Merge Default flags for non
@@ -1197,6 +1198,7 @@ class SmartVariablesTestCase(CLITestCase):
             smart_variable['override-values']['avoid-duplicates'], True)
 
     @run_only_on('sat')
+    @skip_if_bug_open('bugzilla', 1375652)
     @tier1
     def test_negative_enable_avoid_duplicates_flag(self):
         """Attempt to enable Avoid duplicates flag for non supported types.


### PR DESCRIPTION
SmartVariables/SmartClassParameters were ready for a long time on master branch but weren'y baclported for 6.2.
Unfortunately, most of the PRs affected several tests-suites so it was really hard  to cherry-pick them separately, however most of the changes should be cherry-picks and manual changes, specific for 6.2, added only in last commit.

111 (new for 6.2) tests were backported. Depends on SatelliteQE/nailgun/#374
```python
% py.test tests/foreman/{api,cli}/test_{classparameters,variables}.py
===================================================================== test session starts =====================================================================
platform linux2 -- Python 2.7.12, pytest-2.9.2, py-1.4.31, pluggy-0.3.1
rootdir: /home/qui/code/robottelo, inifile: 
plugins: xdist-1.14, cov-2.3.1
collected 183 items 
2017-02-20 17:13:00 - conftest - DEBUG - Found WONTFIX in decorated tests ['1156555', '1269196', '1210180', '1245334', '1217635', '1226425', '1204686', '1267224', '1103157', '1230902', '1214312', '1079482']

2017-02-20 17:13:00 - conftest - DEBUG - Collected 183 test cases


tests/foreman/api/test_classparameters.py ssss..............ssssss.....s.................
tests/foreman/api/test_variables.py .....s.....ssssss.....................sssss
tests/foreman/cli/test_classparameters.py .ssss..........ssssss...........s...........
tests/foreman/cli/test_variables.py ..ssss..sss..s......sssss.....s...........s......

========================================================== 134 passed, 49 skipped in 2892.95 seconds ==========================================================
```
```python
% py.test tests/foreman/ui/test_variables.py
===================================================================== test session starts =====================================================================
platform linux2 -- Python 2.7.12, pytest-2.9.2, py-1.4.31, pluggy-0.3.1
rootdir: /home/qui/code/robottelo, inifile: 
plugins: xdist-1.14, cov-2.3.1
collected 44 items 
2017-02-20 16:15:57 - conftest - DEBUG - Found WONTFIX in decorated tests ['1156555', '1269196', '1210180', '1245334', '1217635', '1226425', '1204686', '1267224', '1103157', '1230902', '1214312', '1079482']

2017-02-20 16:15:57 - conftest - DEBUG - Collected 44 test cases

tests/foreman/ui/test_variables.py ............................................

================================================================ 44 passed in 2664.19 seconds =================================================================
```