### PR TITLE
[6.2.z] Cherry-pick - Automate BZ 1321511 -- validate autocomplete content 

### DIFF
--- a/robottelo/ui/hostgroup.py
+++ b/robottelo/ui/hostgroup.py
@@ -31,7 +31,7 @@ class Hostgroup(Base):
         if activation_keys:
             self.click(tab_locators['hostgroup.activation_keys'])
             self.assign_value(
-                locators['hostgroups.oscap_capsule'], oscap_capsule)
+                locators['hostgroups.activation_keys'], activation_keys)
         self.click(common_locators['submit'])
 
     def navigate_to_entity(self):

--- a/robottelo/ui/hostgroup.py
+++ b/robottelo/ui/hostgroup.py
@@ -1,7 +1,7 @@
 # -*- encoding: utf-8 -*-
 """Implements Host Group UI."""
 from robottelo.ui.base import Base, UIError
-from robottelo.ui.locators import common_locators, locators
+from robottelo.ui.locators import common_locators, locators, tab_locators
 from robottelo.ui.navigator import Navigator
 
 
@@ -9,7 +9,8 @@ class Hostgroup(Base):
     """Manipulates hostgroup from UI."""
 
     def create(self, name, parent=None, environment=None, content_source=None,
-               puppet_ca=None, puppet_master=None):
+               content_view=None, puppet_ca=None, puppet_master=None,
+               activation_keys=None):
         """Creates a new hostgroup from UI."""
         self.click(locators['hostgroups.new'])
         if not self.wait_until_element(locators['hostgroups.name']):
@@ -21,10 +22,16 @@ class Hostgroup(Base):
             self.select(locators['hostgroups.environment'], environment)
         if content_source:
             self.select(locators['hostgroups.content_source'], content_source)
+        if content_view:
+            self.select(locators['hostgroups.content_view'], content_view)
         if puppet_ca:
             self.select(locators['hostgroups.puppet_ca'], puppet_ca)
         if puppet_master:
             self.select(locators['hostgroups.puppet_master'], puppet_master)
+        if activation_keys:
+            self.click(tab_locators['hostgroup.activation_keys'])
+            self.assign_value(
+                locators['hostgroups.oscap_capsule'], oscap_capsule)
         self.click(common_locators['submit'])
 
     def navigate_to_entity(self):

--- a/robottelo/ui/locators.py
+++ b/robottelo/ui/locators.py
@@ -425,6 +425,20 @@ tab_locators = LocatorDict({
     "host.tab_params": (By.XPATH, "//a[@href='#params']"),
     "host.tab_additional_information": (By.XPATH, "//a[@href='#info']"),
 
+    # Hostgroup
+    # Third level UI
+
+    "hostgroup.tab_hostgroup": (By.XPATH, "//a[@href='#primary']"),
+    "hostgroup.tab_ansible_roles": (By.XPATH, "//a[@href='#ansible_roles']"),
+    "hostgroup.tab_puppet_classes": (By.XPATH, "//a[@href='#puppet_klasses']"),
+    "hostgroup.tab_network": (By.XPATH, "//a[@href='#network']"),
+    "hostgroup.tab_operating_system": (By.XPATH, "//a[@href='#os']"),
+    "hostgroup.tab_params": (By.XPATH, "//a[@href='#params']"),
+    "hostgroup.tab_locations": (By.XPATH, "//a[@href='#locations']"),
+    "hostgroup.tab_organizations": (By.XPATH, "//a[@href='#organizations']"),
+    "hostgroup.tab_activation_keys": (
+        By.XPATH, "//a[@href='#activation_keys']"),
+
     # Provisioning Templates
     # Third level UI
 
@@ -1611,6 +1625,10 @@ locators = LocatorDict({
         By.XPATH,
         ("//div[contains(@id, 'hostgroup_content_source')]/a"
          "/span[contains(@class, 'arrow')]")),
+    "hostgroups.content_view": (
+        By.XPATH,
+        ("//div[contains(@id, 'hostgroup_content_view')]/a"
+         "/span[contains(@class, 'arrow')]")),
     "hostgroups.puppet_ca": (
         By.XPATH,
         ("//div[contains(@id, 'hostgroup_puppet_ca_proxy_id')]/a"
@@ -1619,6 +1637,10 @@ locators = LocatorDict({
         By.XPATH,
         ("//div[contains(@id, 'hostgroup_puppet_proxy')]/a"
          "/span[contains(@class, 'arrow')]")),
+    "hostgroups.activation_keys": (
+        By.XPATH, "//input[contains(@id, 'activation_keys')]"),
+    "hostgroups.ak_autocomplete": (
+        By.XPATH, "//ul[contains(@class, 'ui-autocomplete')]/li/a"),
 
     # Users
 

--- a/robottelo/ui/locators.py
+++ b/robottelo/ui/locators.py
@@ -1611,7 +1611,10 @@ locators = LocatorDict({
     "hostgroups.new": (By.XPATH, "//a[contains(@href, '/hostgroups/new')]"),
     "hostgroups.name": (By.ID, "hostgroup_name"),
     "hostgroups.parent": (By.ID, "hostgroup_parent_id"),
-    "hostgroups.environment": (By.ID, "hostgroup_environment_id"),
+    "hostgroups.environment": (
+        By.XPATH,
+        ("//div[contains(@id, 'hostgroup_lifecycle_environment')]/a"
+         "/span[contains(@class, 'arrow')]")),
     "hostgroups.hostgroup": (By.XPATH, "//a[contains(.,'%s')]"),
     "hostgroups.dropdown": (
         By.XPATH,


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1321511

```python
% py.test -v tests/foreman/ui/test_hostgroup.py -k 'activation' 
===================================================================== test session starts =====================================================================
platform linux2 -- Python 2.7.12, pytest-2.9.2, py-1.4.31, pluggy-0.3.1 -- /home/qui/code/venv/6.2.z/bin/python2
cachedir: .cache
rootdir: /home/qui/code/robottelo, inifile: 
plugins: xdist-1.14, cov-2.3.1
collected 8 items 
2017-02-21 12:30:06 - conftest - DEBUG - Found WONTFIX in decorated tests ['1269196', '1103157', '1156555', '1230902', '1245334', '1204686', '1267224', '1226425', '1217635', '1079482', '1214312']

2017-02-21 12:30:06 - conftest - DEBUG - Collected 8 test cases


tests/foreman/ui/test_hostgroup.py::HostgroupTestCase::test_positive_check_activation_keys_autocomplete <- robottelo/decorators/__init__.py PASSED
tests/foreman/ui/test_hostgroup.py::HostgroupTestCase::test_positive_create_with_activation_keys <- robottelo/decorators/__init__.py PASSED

============================================================ 6 tests deselected by '-kactivation' =============================================================
========================================================== 2 passed, 6 deselected in 100.84 seconds ===========================================================
```