### PR TITLE
[6.3][cherry-pick] add bugzilla coverage 1420511 + conflict resolution + remove decorator

### DIFF
--- a/tests/foreman/ui/test_lifecycleenvironment.py
+++ b/tests/foreman/ui/test_lifecycleenvironment.py
@@ -24,7 +24,6 @@ from robottelo.api.utils import create_role_permissions
 from robottelo.datafactory import generate_strings_list
 from robottelo.decorators import (
     run_only_on,
-    skip_if_bug_open,
     stubbed,
     tier1,
     tier2,
@@ -195,7 +194,6 @@ class LifeCycleEnvironmentTestCase(UITestCase):
             body_width = body.size['width']
             self.assertGreaterEqual(body_width - table_width, 0)
 
-    @skip_if_bug_open('bugzilla', 1420511)
     @run_only_on('sat')
     @tier2
     def test_positive_custom_user_view_lce(self):

--- a/tests/foreman/ui/test_lifecycleenvironment.py
+++ b/tests/foreman/ui/test_lifecycleenvironment.py
@@ -20,11 +20,19 @@ from itertools import chain
 from fauxfactory import gen_string
 from nailgun import entities
 
+from robottelo.api.utils import create_role_permissions
 from robottelo.datafactory import generate_strings_list
-from robottelo.decorators import run_only_on, stubbed, tier1, tier2
+from robottelo.decorators import (
+    run_only_on,
+    skip_if_bug_open,
+    stubbed,
+    tier1,
+    tier2,
+)
 from robottelo.test import UITestCase
+from robottelo.ui.base import UINoSuchElementError
 from robottelo.ui.factory import make_lifecycle_environment
-from robottelo.ui.locators import common_locators, locators
+from robottelo.ui.locators import common_locators, locators, menu_locators
 from robottelo.ui.session import Session
 
 
@@ -186,3 +194,90 @@ class LifeCycleEnvironmentTestCase(UITestCase):
             body = session.nav.find_element(common_locators['body'])
             body_width = body.size['width']
             self.assertGreaterEqual(body_width - table_width, 0)
+
+    @skip_if_bug_open('bugzilla', 1420511)
+    @run_only_on('sat')
+    @tier2
+    def test_positive_custom_user_view_lce(self):
+        """As a custom user attempt to view a lifecycle environment created
+        by admin user
+
+        @id: 768b647b-c530-4eca-9caa-38cf8622f36d
+
+        @BZ: 1420511
+
+        @Steps:
+
+        As an admin user:
+
+        1. Create an additional lifecycle environments other than Library
+        2. Create a user without administrator privileges
+        3. Create a role with the the following permissions:
+
+        * (Miscellaneous): access_dashboard
+        * Lifecycle Environment:
+
+          * edit_lifecycle_environments
+          * promote_or_remove_content_views_to_environment
+          * view_lifecycle_environments
+
+        * Location: view_locations
+        * Organization: view_organizations
+
+        4. Assign the created role to the custom user
+
+        As a custom user:
+
+        1. Log in
+        2. Navigate to Content -> Lifecycle Environments
+
+        @Assert: The additional lifecycle environment is viewable
+        and accessible by the custom user.
+
+        @CaseLevel: Integration
+        """
+        role_name = gen_string('alpha')
+        env_name = gen_string('alpha')
+        user_login = gen_string('alpha')
+        user_password = gen_string('alpha')
+        org = entities.Organization().create()
+        role = entities.Role(name=role_name).create()
+        permissions_types_names = {
+            None: ['access_dashboard'],
+            'Organization': ['view_organizations'],
+            'Location': ['view_locations'],
+            'Katello::KTEnvironment': [
+                'view_lifecycle_environments',
+                'edit_lifecycle_environments',
+                'promote_or_remove_content_views_to_environments'
+            ]
+        }
+        create_role_permissions(role, permissions_types_names)
+        entities.User(
+            default_organization=org,
+            organization=[org],
+            role=[role],
+            login=user_login,
+            password=user_password
+        ).create()
+        # create a life cycle environment as admin user and ensure it's visible
+        with Session(self.browser) as session:
+            make_lifecycle_environment(
+                session, org=org.name, name=env_name)
+            self.assertIsNotNone(self.lifecycleenvironment.search(env_name))
+
+        # ensure the created user also can find the created life cycle
+        # environment link
+        with Session(self.browser, user=user_login, password=user_password):
+            # to ensure that the created user has only the assigned
+            # permissions, check that hosts menu tab does not exist
+            self.assertIsNone(
+                self.content_views.wait_until_element(
+                    menu_locators['menu.hosts'], timeout=1)
+            )
+            # assert that the created user is not a global admin user
+            # check administer->users page
+            with self.assertRaises(UINoSuchElementError):
+                session.nav.go_to_users()
+            # assert that the user can view the lvce created by admin user
+            self.assertIsNotNone(self.lifecycleenvironment.search(env_name))


### PR DESCRIPTION
removed the decorator as not affected by the bug in 6.3
```console
(2.7) dlezz@elysion:~/projects/robottelo-fork$ py.test tests/foreman/ui/test_lifecycleenvironment.py -v -k "test_positive_custom_user_view_lce"
================================================= test session starts ==================================================
platform linux2 -- Python 2.7.12, pytest-3.0.6, py-1.4.31, pluggy-0.4.0 -- /home/dlezz/bin/redhat/python/2.7/bin/python2.7
cachedir: .cache
rootdir: /home/dlezz/projects/robottelo-fork, inifile: 
plugins: xdist-1.15.0, cov-2.3.1
collected 7 items 
2017-02-21 16:40:41 - conftest - DEBUG - Found WONTFIX in decorated tests ['1269196', '1245334', '1217635', '1226425', '1156555', '1204686', '1267224', '1103157', '1230902', '1214312', '1079482']

2017-02-21 16:40:41 - conftest - DEBUG - Collected 7 test cases


tests/foreman/ui/test_lifecycleenvironment.py::LifeCycleEnvironmentTestCase::test_positive_custom_user_view_lce <- robottelo/decorators/__init__.py PASSED

================================================== 6 tests deselected ==================================================
======================================= 1 passed, 6 deselected in 76.30 seconds ========================================
(2.7) dlezz@elysion:~/projects/robottelo-fork$ 
```
original PR: https://github.com/SatelliteQE/robottelo/pull/4333
issue: https://github.com/SatelliteQE/robottelo/issues/4329 