### PR TITLE
Implemented UI contenthost test for BZ1380117

### DIFF
--- a/robottelo/ui/contenthost.py
+++ b/robottelo/ui/contenthost.py
@@ -215,3 +215,35 @@ class ContentHost(Base):
             result[name]['color'] = color
             result[name]['value'] = int(value)
         return result
+
+    def fetch_parameters(self, name, parameters_list):
+        """Fetches parameter values of specified host
+
+        :param name: content host's name (with domain)
+        :param parameters_list: A list of parameters to be fetched. Each
+            parameter should be a separate list containing tab name and
+            parameter name in absolute correspondence to UI (Similar to
+            parameters list passed to create a host). Example::
+
+                [
+                    ['Details', 'Registered By'],
+                    ['Provisioning Details', 'Status'],
+                ]
+
+        :return: Dictionary of parameter name - parameter value pairs
+        :rtype: dict
+        """
+        self.search_and_click(name)
+        result = {}
+        for tab_name, param_name in parameters_list:
+            tab_locator = tab_locators['.tab_'.join((
+                'contenthost',
+                (tab_name.lower()).replace(' ', '_')
+            ))]
+            param_locator = locators['.fetch_'.join((
+                'contenthost',
+                (param_name.lower()).replace(' ', '_')
+            ))]
+            self.click(tab_locator)
+            result[param_name] = self.wait_until_element(param_locator).text
+        return result

--- a/robottelo/ui/locators/base.py
+++ b/robottelo/ui/locators/base.py
@@ -430,6 +430,11 @@ locators = LocatorDict({
         By.XPATH,
         ("//tr[@class='ng-scope' and @row-select='package']"
          "/td[contains(@class, 'ng-scope') and contains(., '%s')]")),
+    "contenthost.fetch_registered_by": (
+        By.XPATH,
+        ("//div[@class='detail']/span[contains(@translate-plural, 'Activation "
+         "Keys')]/following-sibling::span"
+         "//a[contains(@href, 'activation_keys')]")),
 
     # Content Host - Bulk Actions
 

--- a/tests/foreman/ui/test_contenthost.py
+++ b/tests/foreman/ui/test_contenthost.py
@@ -229,3 +229,25 @@ class ContentHostTestCase(UITestCase):
             self.assertEqual(result, 'success')
             self.assertIsNotNone(self.contenthost.package_search(
                 self.client.hostname, FAKE_2_CUSTOM_PACKAGE))
+
+    @tier3
+    def test_positive_fetch_registered_by(self):
+        """Register a host with activation key and fetch host's 'Registered by'
+        field value.
+
+        @id: 5c6dbb5d-bd26-4439-ab04-536a6ad012b9
+
+        @assert: 'Registered By' field on content host page points to
+        activation key which was used to register the host
+
+        @BZ: 1380117
+
+        @CaseLevel: System
+        """
+        with Session(self.browser):
+            result = self.contenthost.fetch_parameters(
+                self.client.hostname,
+                [['Details', 'Registered By']],
+            )
+            self.assertEqual(
+                result['Registered By'], self.activation_key.name)


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1380117

Currently katello-agent installation is broken for 6.3, but as it's not needed for this specific test, i've commented out corresponding line in setUp to receive test results:
```python
py.test tests/foreman/ui/test_contenthost.py -k test_positive_fetch_registered_by
============================= test session starts ==============================
platform darwin -- Python 2.7.13, pytest-3.0.6, py-1.4.32, pluggy-0.4.0
rootdir: /Users/andrii/workspace/robottelo, inifile:
collected 7 items
2017-02-21 15:42:59 - conftest - DEBUG - Found WONTFIX in decorated tests ['1269196', '1245334', '1217635', '1226425', '1156555', '1204686', '1267224', '1103157', '1230902', '1214312', '1079482']

2017-02-21 15:42:59 - conftest - DEBUG - Collected 7 test cases


tests/foreman/ui/test_contenthost.py .

============================== 6 tests deselected ==============================
=================== 1 passed, 6 deselected in 802.10 seconds ===================
```