### PR TITLE
Automate BZ 1316681

### DIFF
--- a/tests/foreman/api/test_repository.py
+++ b/tests/foreman/api/test_repository.py
@@ -980,6 +980,54 @@ class RepositoryTestCase(APITestCase):
                 with self.assertRaises(HTTPError):
                     repo.read()
 
+    @tier2
+    @run_only_on('sat')
+    def test_positive_delete_rpm(self):
+        """Check if rpm repository with packages can be deleted.
+
+        @id: d61c8c8b-2b77-4bff-b215-fa2b7c05aa78
+
+        @Assert: The repository deleted successfully.
+
+        @CaseLevel: Integration
+        """
+        repo = entities.Repository(
+            url=FAKE_2_YUM_REPO,
+            content_type='yum',
+            product=self.product,
+        ).create()
+        repo.sync()
+        # Check that there is at least one package
+        self.assertGreaterEqual(repo.read().content_counts['rpm'], 1)
+        repo.delete()
+        with self.assertRaises(HTTPError):
+            repo.read()
+
+    @tier2
+    @run_only_on('sat')
+    def test_positive_delete_puppet(self):
+        """Check if puppet repository with puppet modules can be deleted.
+
+        @id: 5c60b0ab-ef50-41a3-8578-bfdb5cb228ea
+
+        @Assert: The repository deleted successfully.
+
+        @CaseLevel: Integration
+
+        @BZ: 1316681
+        """
+        repo = entities.Repository(
+            url=FAKE_1_PUPPET_REPO,
+            content_type='puppet',
+            product=self.product,
+        ).create()
+        repo.sync()
+        # Check that there is at least one puppet module
+        self.assertGreaterEqual(repo.read().content_counts['puppet_module'], 1)
+        repo.delete()
+        with self.assertRaises(HTTPError):
+            repo.read()
+
     @tier1
     @run_only_on('sat')
     def test_positive_list_puppet_modules_with_multiple_repos(self):

--- a/tests/foreman/cli/test_repository.py
+++ b/tests/foreman/cli/test_repository.py
@@ -1045,6 +1045,68 @@ class RepositoryTestCase(CLITestCase):
 
     @run_only_on('sat')
     @tier1
+    def test_positive_delete_by_name(self):
+        """Check if repository can be created and deleted
+
+        @id: 463980a4-dbcf-4178-83a6-1863cf59909a
+
+        @Assert: Repository is created and then deleted
+        """
+        for name in valid_data_list():
+            with self.subTest(name):
+                new_repo = self._make_repository({u'name': name})
+                Repository.delete({
+                    'name': new_repo['name'],
+                    'product-id': self.product['id']
+                })
+                with self.assertRaises(CLIReturnCodeError):
+                    Repository.info({u'id': new_repo['id']})
+
+    @run_only_on('sat')
+    @tier1
+    def test_positive_delete_rpm(self):
+        """Check if rpm repository with packages can be deleted.
+
+        @id: 1172492f-d595-4c8e-89c1-fabb21eb04ac
+
+        @Assert: Repository is deleted.
+        """
+        new_repo = self._make_repository({
+            u'content-type': u'yum', u'url': FAKE_1_YUM_REPO})
+        Repository.synchronize({'id': new_repo['id']})
+        new_repo = Repository.info({'id': new_repo['id']})
+        self.assertEqual(new_repo['sync']['status'], 'Success')
+        # Check that there is at least one package
+        self.assertGreater(int(new_repo['content-counts']['packages']), 0)
+        Repository.delete({u'id': new_repo['id']})
+        with self.assertRaises(CLIReturnCodeError):
+            Repository.info({u'id': new_repo['id']})
+
+    @run_only_on('sat')
+    @tier1
+    def test_positive_delete_puppet(self):
+        """Check if puppet repository with puppet modules can be deleted.
+
+        @id: 83d92454-11b7-4f9a-952d-650ffe5135e4
+
+        @Assert: Repository is deleted.
+
+        @BZ: 1316681
+        """
+        new_repo = self._make_repository({
+            u'content-type': u'puppet', u'url': FAKE_1_PUPPET_REPO})
+        Repository.synchronize({'id': new_repo['id']})
+        new_repo = Repository.info({'id': new_repo['id']})
+        self.assertEqual(new_repo['sync']['status'], 'Success')
+        # Check that there is at least one puppet module
+        self.assertGreater(
+            int(new_repo['content-counts']['puppet-modules']), 0)
+        Repository.delete({u'id': new_repo['id']})
+        with self.assertRaises(CLIReturnCodeError):
+            Repository.info({u'id': new_repo['id']})
+
+    @run_only_on('sat')
+    @tier1
     def test_positive_remove_content_by_repo_name(self):
         """Synchronize repository and remove rpm content from using repo name
 


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1316681

```python
% py.test -v tests/foreman/{api,cli}/test_repository.py -k 'positive_delete and not OstreeRepositoryTestCase' 
===================================================================== test session starts =====================================================================
platform linux2 -- Python 2.7.12, pytest-2.9.2, py-1.4.32, pluggy-0.3.1 -- /home/qui/code/venv/2/bin/python2
cachedir: .cache
rootdir: /home/qui/code/robottelo, inifile: 
plugins: xdist-1.15.0, html-1.12.0, cov-2.3.1
collected 139 items 

tests/foreman/api/test_repository.py::RepositoryTestCase::test_positive_delete <- robottelo/decorators/__init__.py PASSED
tests/foreman/api/test_repository.py::RepositoryTestCase::test_positive_delete_puppet <- robottelo/decorators/__init__.py PASSED
tests/foreman/api/test_repository.py::RepositoryTestCase::test_positive_delete_rpm <- robottelo/decorators/__init__.py PASSED
tests/foreman/cli/test_repository.py::RepositoryTestCase::test_positive_delete_by_id <- robottelo/decorators/__init__.py PASSED
tests/foreman/cli/test_repository.py::RepositoryTestCase::test_positive_delete_by_name <- robottelo/decorators/__init__.py PASSED
tests/foreman/cli/test_repository.py::RepositoryTestCase::test_positive_delete_puppet <- robottelo/decorators/__init__.py PASSED
tests/foreman/cli/test_repository.py::RepositoryTestCase::test_positive_delete_rpm <- robottelo/decorators/__init__.py PASSED

======================================== 132 tests deselected by '-kpositive_delete and not OstreeRepositoryTestCase' =========================================
========================================================= 7 passed, 132 deselected in 432.45 seconds ==========================================================
```