### PR TITLE
Automate BZ 1240491 / CLI content-view puppet module tests

### DIFF
--- a/robottelo/cli/contentview.py
+++ b/robottelo/cli/contentview.py
@@ -161,6 +161,20 @@ class ContentView(Base):
         return hammer.parse_info(cls.execute(cls._construct_command(options)))
 
     @classmethod
+    def puppet_module_list(cls, options):
+        """List content view puppet modules"""
+        cls.command_sub = 'puppet-module list'
+        return cls.execute(
+            cls._construct_command(options), output_format='csv')
+
+    @classmethod
+    def puppet_module_remove(cls, options):
+        """Remove a puppet module from the content view"""
+        cls.command_sub = 'puppet-module remove'
+        return cls.execute(
+            cls._construct_command(options), output_format='csv')
+
+    @classmethod
     def version_list(cls, options):
         """Lists content-view's versions."""
         cls.command_sub = 'version list'

--- a/robottelo/cli/contentview.py
+++ b/robottelo/cli/contentview.py
@@ -151,16 +151,6 @@ class ContentView(Base):
             cls._construct_command(options), output_format='csv')
 
     @classmethod
-    def puppet_module_info(cls, options):
-        """Provides puppet-module info related to content-view's version."""
-        cls.command_sub = 'puppet-module info'
-
-        if options is None:
-            options = {}
-
-        return hammer.parse_info(cls.execute(cls._construct_command(options)))
-
-    @classmethod
     def puppet_module_list(cls, options):
         """List content view puppet modules"""
         cls.command_sub = 'puppet-module list'

--- a/tests/foreman/cli/test_contentview.py
+++ b/tests/foreman/cli/test_contentview.py
@@ -1029,9 +1029,7 @@ class ContentViewTestCase(CLITestCase):
             u'url': CUSTOM_PUPPET_REPO,
         })
         puppet_module = PuppetModule.list({
-            'search': 'name={0} and version={1}'.format(
-                module['name'], module['version'])
-        })[0]
+            'search': 'name={name} and version={version}'.format(**module)})[0]
         Repository.synchronize({'id': puppet_repository['id']})
         content_view = make_content_view({u'organization-id': self.org['id']})
         ContentView.puppet_module_add({
@@ -1039,6 +1037,12 @@ class ContentViewTestCase(CLITestCase):
             u'name': puppet_module['name'],
             u'author': puppet_module['author'],
         })
+        # Check output of `content-view info` subcommand
+        content_view = ContentView.info({'id': content_view['id']})
+        self.assertGreater(content_view['puppet-modules'], 0)
+        self.assertEqual(
+            puppet_module['name'], content_view['puppet-modules'][0]['name'])
+        # Check output of `content-view puppet module list` subcommand
         cv_module = ContentView.puppet_module_list(
             {'content-view-id': content_view['id']})
         self.assertGreater(len(cv_module), 0)
@@ -1071,28 +1075,140 @@ class ContentViewTestCase(CLITestCase):
         })
         Repository.synchronize({'id': puppet_repository['id']})
         puppet_module = PuppetModule.list({
-            'search': 'name={0} and version={1}'.format(
-                module['name'], module['version'])
-        })[0]
-        for by in ('uuid', 'id'):
-            with self.subTest(by=by):
+            'search': 'name={name} and version={version}'.format(**module)})[0]
+        for identifier_type in ('uuid', 'id'):
+            with self.subTest(add_by=identifier_type):
                 content_view = make_content_view(
                     {u'organization-id': self.org['id']})
                 ContentView.puppet_module_add({
                     u'content-view-id': content_view['id'],
-                    by: puppet_module[by],
+                    identifier_type: puppet_module[identifier_type],
                 })
+                # Check output of `content-view info` subcommand
+                content_view = ContentView.info({'id': content_view['id']})
+                self.assertGreater(len(content_view['puppet-modules']), 0)
+                self.assertEqual(
+                    puppet_module['name'],
+                    content_view['puppet-modules'][0]['name']
+                )
+                # Check output of `content-view puppet module list` subcommand
                 cv_module = ContentView.puppet_module_list(
                     {'content-view-id': content_view['id']})
                 self.assertGreater(len(cv_module), 0)
                 self.assertEqual(cv_module[0]['version'], module['version'])
-                # Remove puppet module before next iteration
-                ContentView.puppet_module_remove({
-                    'content-view-id': content_view['id'],
-                    'uuid': puppet_module['uuid']
-                })
-                self.assertEqual(len(ContentView.puppet_module_list(
-                    {'content-view-id': content_view['id']})), 0)
+
+    @tier2
+    @run_only_on('sat')
+    def test_positive_remove_puppet_module_by_name(self):
+        """Remove puppet module from Content View by name
+
+        @id: b9d161de-d2a1-46e1-922d-5e22826a41e4
+
+        @Assert: Module successfully removed and no modules are listed
+
+        @CaseLevel: Integration
+        """
+        puppet_repository = make_repository({
+            u'content-type': u'puppet',
+            u'product-id': self.product['id'],
+            u'url': CUSTOM_PUPPET_REPO,
+        })
+        Repository.synchronize({'id': puppet_repository['id']})
+        puppet_modules = PuppetModule.list(
+            {u'repository-id': puppet_repository['id']})
+        puppet_module = random.choice(puppet_modules)
+        content_view = make_content_view({u'organization-id': self.org['id']})
+        # Add puppet module
+        ContentView.puppet_module_add({
+            u'content-view-id': content_view['id'],
+            u'name': puppet_module['name'],
+            u'author': puppet_module['author'],
+        })
+        content_view = ContentView.info({'id': content_view['id']})
+        self.assertGreater(len(content_view['puppet-modules']), 0)
+        # Remove puppet module
+        ContentView.puppet_module_remove({
+            u'content-view-id': content_view['id'],
+            u'name': puppet_module['name'],
+            u'author': puppet_module['author'],
+        })
+        content_view = ContentView.info({'id': content_view['id']})
+        self.assertEqual(len(content_view['puppet-modules']), 0)
+
+    @tier2
+    @skip_if_bug_open('bugzilla', 1427260)
+    @run_only_on('sat')
+    def test_positive_remove_puppet_module_by_id(self):
+        """Remove puppet module from Content View by id
+
+        @id: 972a484c-6f38-4015-b20b-6a83d15b6c97
+
+        @Assert: Module successfully removed and no modules are listed
+
+        @CaseLevel: Integration
+
+        @BZ: 1427260
+        """
+        puppet_repository = make_repository({
+            u'content-type': u'puppet',
+            u'product-id': self.product['id'],
+            u'url': CUSTOM_PUPPET_REPO,
+        })
+        Repository.synchronize({'id': puppet_repository['id']})
+        puppet_modules = PuppetModule.list(
+            {u'repository-id': puppet_repository['id']})
+        puppet_module = random.choice(puppet_modules)
+        content_view = make_content_view({u'organization-id': self.org['id']})
+        # Add puppet module
+        ContentView.puppet_module_add({
+            u'content-view-id': content_view['id'],
+            u'id': puppet_module['id']
+        })
+        content_view = ContentView.info({'id': content_view['id']})
+        self.assertGreater(len(content_view['puppet-modules']), 0)
+        # Remove puppet module
+        ContentView.puppet_module_remove({
+            'content-view-id': content_view['id'],
+            'id': content_view['puppet-modules'][0]['id']
+        })
+        content_view = ContentView.info({'id': content_view['id']})
+        self.assertEqual(len(content_view['puppet-modules']), 0)
+
+    @tier2
+    @run_only_on('sat')
+    def test_positive_remove_puppet_module_by_uuid(self):
+        """Remove puppet module from Content View by uuid
+
+        @id: c63339aa-3d74-4a37-aaef-6777e0f6cb35
+
+        @Assert: Module successfully removed and no modules are listed
+
+        @CaseLevel: Integration
+        """
+        puppet_repository = make_repository({
+            u'content-type': u'puppet',
+            u'product-id': self.product['id'],
+            u'url': CUSTOM_PUPPET_REPO,
+        })
+        Repository.synchronize({'id': puppet_repository['id']})
+        puppet_modules = PuppetModule.list(
+            {u'repository-id': puppet_repository['id']})
+        puppet_module = random.choice(puppet_modules)
+        content_view = make_content_view({u'organization-id': self.org['id']})
+        # Add puppet module
+        ContentView.puppet_module_add({
+            'content-view-id': content_view['id'],
+            'uuid': puppet_module['uuid'],
+        })
+        content_view = ContentView.info({'id': content_view['id']})
+        self.assertGreater(len(content_view['puppet-modules']), 0)
+        # Remove puppet module
+        ContentView.puppet_module_remove({
+            'content-view-id': content_view['id'],
+            'uuid': puppet_module['uuid'],
+        })
+        content_view = ContentView.info({'id': content_view['id']})
+        self.assertEqual(len(content_view['puppet-modules']), 0)
 
     @tier2
     @run_only_on('sat')

--- a/tests/foreman/cli/test_contentview.py
+++ b/tests/foreman/cli/test_contentview.py
@@ -41,6 +41,7 @@ from robottelo.cli.puppetmodule import PuppetModule
 from robottelo.cli.subscription import Subscription
 from robottelo.cli.user import User
 from robottelo.constants import (
+    CUSTOM_PUPPET_REPO,
     DEFAULT_CV,
     DEFAULT_ROLE,
     DOCKER_REGISTRY_HUB,
@@ -1009,6 +1010,89 @@ class ContentViewTestCase(CLITestCase):
             new_repo['name'],
             'Repo was not associated to CV',
         )
+
+    @tier2
+    @run_only_on('sat')
+    def test_positive_add_puppet_module(self):
+        """Add puppet module to Content View by name
+
+        @id: 81d3305e-c0c2-487b-9fd8-828b3250fe6e
+
+        @Assert: Module was added and has latest version.
+
+        @CaseLevel: Integration
+        """
+        module = {'name': 'versioned', 'version': '3.3.3'}
+        puppet_repository = make_repository({
+            u'content-type': u'puppet',
+            u'product-id': self.product['id'],
+            u'url': CUSTOM_PUPPET_REPO,
+        })
+        puppet_module = PuppetModule.list({
+            'search': 'name={0} and version={1}'.format(
+                module['name'], module['version'])
+        })[0]
+        Repository.synchronize({'id': puppet_repository['id']})
+        content_view = make_content_view({u'organization-id': self.org['id']})
+        ContentView.puppet_module_add({
+            u'content-view-id': content_view['id'],
+            u'name': puppet_module['name'],
+            u'author': puppet_module['author'],
+        })
+        cv_module = ContentView.puppet_module_list(
+            {'content-view-id': content_view['id']})
+        self.assertGreater(len(cv_module), 0)
+        self.assertIn(puppet_module['version'], cv_module[0]['version'])
+        self.assertIn('Latest', cv_module[0]['version'])
+
+    @tier2
+    @run_only_on('sat')
+    def test_positive_add_puppet_module_older_version(self):
+        """Add older version of puppet module to Content View by id/uuid
+
+        @id: 39654b3e-963f-4859-81f2-9992b60433c2
+
+        @Steps:
+
+        1. Upload/sync puppet repo with several versions of the same module
+        2. Add older version by id/uuid to CV
+
+        @Assert: Exact version (and not latest) was added.
+
+        @CaseLevel: Integration
+
+        @BZ: 1240491
+        """
+        module = {'name': 'versioned', 'version': '2.2.2'}
+        puppet_repository = make_repository({
+            u'content-type': u'puppet',
+            u'product-id': self.product['id'],
+            u'url': CUSTOM_PUPPET_REPO,
+        })
+        Repository.synchronize({'id': puppet_repository['id']})
+        puppet_module = PuppetModule.list({
+            'search': 'name={0} and version={1}'.format(
+                module['name'], module['version'])
+        })[0]
+        for by in ('uuid', 'id'):
+            with self.subTest(by=by):
+                content_view = make_content_view(
+                    {u'organization-id': self.org['id']})
+                ContentView.puppet_module_add({
+                    u'content-view-id': content_view['id'],
+                    by: puppet_module[by],
+                })
+                cv_module = ContentView.puppet_module_list(
+                    {'content-view-id': content_view['id']})
+                self.assertGreater(len(cv_module), 0)
+                self.assertEqual(cv_module[0]['version'], module['version'])
+                # Remove puppet module before next iteration
+                ContentView.puppet_module_remove({
+                    'content-view-id': content_view['id'],
+                    'uuid': puppet_module['uuid']
+                })
+                self.assertEqual(len(ContentView.puppet_module_list(
+                    {'content-view-id': content_view['id']})), 0)
 
     @tier2
     @run_only_on('sat')


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1240491

```python
py.test tests/foreman/cli/test_contentview.py "-k ContentViewTestCase and test_positive_add_puppet_module"
============================= test session starts ==============================
platform linux2 -- Python 2.7.12, pytest-2.9.2, py-1.4.31, pluggy-0.3.1
rootdir: /home/qui/code/robottelo, inifile: 
plugins: xdist-1.14, cov-2.3.1
collected 76 items

 74 tests deselected by '-k ContentViewTestCase and test_positive_add_puppet_module' 
================== 2 passed, 74 deselected in 147.48 seconds ===================
```