### PR TITLE
Move DISTRO_RHEL6 and DISTRO_RHEL7 to robottelo.properties file.

### DIFF
--- a/robottelo.properties.sample
+++ b/robottelo.properties.sample
@@ -142,6 +142,12 @@ ssh_key=
 # image_dir=/opt/robottelo/images
 
 
+# For tests that uses the images for content-host testcases.
+# [distro]
+# image_el6=rhel68
+# image_el7=rhel73
+
+
 # For tests that uses the docker feature
 # [docker]
 # If you have docker deamon running on the server and it is published under a

--- a/robottelo/config/base.py
+++ b/robottelo/config/base.py
@@ -277,6 +277,28 @@ class ClientsSettings(FeatureSettings):
         return validation_errors
 
 
+class DistroSettings(FeatureSettings):
+    """Distro settings definitions."""
+    def __init__(self, *args, **kwargs):
+        super(DistroSettings, self).__init__(*args, **kwargs)
+        self.image_el6 = None
+        self.image_el7 = None
+
+    def read(self, reader):
+        """Read distro settings."""
+        self.image_el6 = reader.get('distro', 'image_el6')
+        self.image_el7 = reader.get('distro', 'image_el7')
+
+    def validate(self):
+        """Validate distro settings."""
+        validation_errors = []
+        if not all((self.image_el6, self.image_el7)):
+            validation_errors.append(
+                'Both [distro] image_el6 and image_el7 '
+                'options must be provided.')
+        return validation_errors
+
+
 class DockerSettings(FeatureSettings):
     """Docker settings definitions."""
     def __init__(self, *args, **kwargs):
@@ -742,6 +764,7 @@ class Settings(object):
         self.clients = ClientsSettings()
         self.compute_resources = LibvirtHostSettings()
         self.discovery = DiscoveryISOSettings()
+        self.distro = DistroSettings()
         self.docker = DockerSettings()
         self.fake_capsules = FakeCapsuleSettings()
         self.fake_manifest = FakeManifestSettings()

--- a/robottelo/constants.py
+++ b/robottelo/constants.py
@@ -24,9 +24,6 @@ BZ_CLOSED_STATUSES = [
     'CLOSED'
 ]
 
-DISTRO_RHEL6 = "rhel68"
-DISTRO_RHEL7 = "rhel73"
-
 FOREMAN_PROVIDERS = {
     'libvirt': 'Libvirt',
     'rhev': 'RHEV',

--- a/robottelo/vm.py
+++ b/robottelo/vm.py
@@ -15,8 +15,10 @@ import time
 
 from robottelo import ssh
 from robottelo.config import settings
-from robottelo.constants import DISTRO_RHEL6, DISTRO_RHEL7
 from robottelo.helpers import install_katello_ca, remove_katello_ca
+
+DISTRO_RHEL6 = settings.distro.image_el6
+DISTRO_RHEL7 = settings.distro.image_el7
 
 BASE_IMAGES = (
     DISTRO_RHEL6,

--- a/tests/foreman/api/test_errata.py
+++ b/tests/foreman/api/test_errata.py
@@ -22,11 +22,10 @@ from robottelo.cli.factory import (
     setup_org_for_a_custom_repo,
     setup_org_for_a_rh_repo,
 )
+from robottelo.config import settings
 from robottelo.constants import (
     DEFAULT_ARCHITECTURE,
     DEFAULT_RELEASE_VERSION,
-    DISTRO_RHEL6,
-    DISTRO_RHEL7,
     FAKE_1_CUSTOM_PACKAGE,
     FAKE_2_CUSTOM_PACKAGE,
     FAKE_2_ERRATA_ID,
@@ -55,6 +54,8 @@ from time import sleep
 
 CUSTOM_REPO_URL = FAKE_6_YUM_REPO
 CUSTOM_REPO_ERRATA_ID = FAKE_2_ERRATA_ID
+DISTRO_RHEL6 = settings.distro.image_el6
+DISTRO_RHEL7 = settings.distro.image_el7
 
 
 @run_in_one_thread

--- a/tests/foreman/cli/test_activationkey.py
+++ b/tests/foreman/cli/test_activationkey.py
@@ -38,8 +38,8 @@ from robottelo.cli.lifecycleenvironment import LifecycleEnvironment
 from robottelo.cli.repository import Repository
 from robottelo.cli.subscription import Subscription
 from robottelo.cli.user import User
+from robottelo.config import settings
 from robottelo.constants import FAKE_0_YUM_REPO, PRDS, REPOS, REPOSET
-from robottelo.constants import DISTRO_RHEL6
 from robottelo.datafactory import valid_data_list, invalid_values_list
 from robottelo.decorators import (
     run_in_one_thread,
@@ -54,6 +54,9 @@ from robottelo.decorators import (
 from robottelo.ssh import upload_file
 from robottelo.test import CLITestCase
 from robottelo.vm import VirtualMachine
+
+
+DISTRO_RHEL6 = settings.distro.image_el6
 
 
 class ActivationKeyTestCase(CLITestCase):

--- a/tests/foreman/cli/test_host.py
+++ b/tests/foreman/cli/test_host.py
@@ -44,7 +44,6 @@ from robottelo.cli.proxy import Proxy
 from robottelo.config import settings
 from robottelo.constants import (
     DEFAULT_CV,
-    DISTRO_RHEL7,
     ENVIRONMENT,
     FAKE_0_CUSTOM_PACKAGE,
     FAKE_0_CUSTOM_PACKAGE_GROUP,
@@ -76,6 +75,9 @@ from robottelo.decorators import (
 )
 from robottelo.test import CLITestCase
 from robottelo.vm import VirtualMachine
+
+
+DISTRO_RHEL7 = settings.distro.image_el7
 
 
 class HostCreateTestCase(CLITestCase):

--- a/tests/foreman/cli/test_remoteexecution.py
+++ b/tests/foreman/cli/test_remoteexecution.py
@@ -28,7 +28,8 @@ from robottelo.cli.factory import (
 )
 from robottelo.cli.job_invocation import JobInvocation
 from robottelo.cli.job_template import JobTemplate
-from robottelo.constants import DISTRO_RHEL7, REPOS
+from robottelo.config import settings
+from robottelo.constants import REPOS
 from robottelo.datafactory import invalid_values_list
 from robottelo.decorators import tier1, tier2, tier3
 from robottelo.helpers import add_remote_execution_ssh_key
@@ -38,6 +39,7 @@ from time import sleep
 
 TEMPLATE_FILE = u'template_file.txt'
 TEMPLATE_FILE_EMPTY = u'template_file_empty.txt'
+DISTRO_RHEL7 = settings.distro.image_el7
 
 
 class JobTemplateTestCase(CLITestCase):

--- a/tests/foreman/endtoend/test_ui_endtoend.py
+++ b/tests/foreman/endtoend/test_ui_endtoend.py
@@ -24,7 +24,6 @@ from robottelo.constants import (
     DEFAULT_LOC,
     DEFAULT_ORG,
     DEFAULT_SUBSCRIPTION_NAME,
-    DISTRO_RHEL6,
     DOMAIN,
     FAKE_0_PUPPET_REPO,
     FOREMAN_PROVIDERS,
@@ -63,6 +62,9 @@ from robottelo.ui.locators import common_locators
 from robottelo.ui.session import Session
 from robottelo.vm import VirtualMachine
 from .utils import ClientProvisioningMixin
+
+
+DISTRO_RHEL6 = settings.distro.image_el6
 
 
 class EndToEndTestCase(UITestCase, ClientProvisioningMixin):

--- a/tests/foreman/endtoend/utils.py
+++ b/tests/foreman/endtoend/utils.py
@@ -1,10 +1,11 @@
 # coding=utf-8
 """Module that aggregates common bits of the end to end tests."""
-from robottelo.constants import DISTRO_RHEL6
+from robottelo.config import settings
 from robottelo.decorators import setting_is_set
 from robottelo.vm import VirtualMachine
 
 AK_CONTENT_LABEL = u'rhel-6-server-rhev-agent-rpms'
+DISTRO_RHEL6 = settings.distro.image_el6
 
 
 class ClientProvisioningMixin(object):

--- a/tests/foreman/longrun/test_inc_updates.py
+++ b/tests/foreman/longrun/test_inc_updates.py
@@ -38,11 +38,11 @@ from robottelo.api.utils import (
 )
 from robottelo.cleanup import vm_cleanup
 from robottelo.cli.contentview import ContentView as ContentViewCLI
+from robottelo.config import settings
 from robottelo.constants import (
     DEFAULT_ARCHITECTURE,
     DEFAULT_RELEASE_VERSION,
     DEFAULT_SUBSCRIPTION_NAME,
-    DISTRO_RHEL6,
     PRDS,
     REAL_0_RH_PACKAGE,
     REPOS,
@@ -56,6 +56,9 @@ from robottelo.decorators import (
 )
 from robottelo.test import TestCase
 from robottelo.vm import VirtualMachine
+
+
+DISTRO_RHEL6 = settings.distro.image_el6
 
 
 @run_in_one_thread

--- a/tests/foreman/longrun/test_oscap.py
+++ b/tests/foreman/longrun/test_oscap.py
@@ -28,8 +28,6 @@ from robottelo.constants import (
     ANY_CONTEXT,
     DEFAULT_LOC,
     DEFAULT_SUBSCRIPTION_NAME,
-    DISTRO_RHEL6,
-    DISTRO_RHEL7,
     OSCAP_DEFAULT_CONTENT,
     OSCAP_PERIOD,
     OSCAP_PROFILE,
@@ -49,6 +47,10 @@ from robottelo.test import UITestCase
 from robottelo.ui.factory import set_context, make_hostgroup, make_oscappolicy
 from robottelo.ui.session import Session
 from robottelo.vm import VirtualMachine
+
+
+DISTRO_RHEL6 = settings.distro.image_el6
+DISTRO_RHEL7 = settings.distro.image_el7
 
 
 @run_in_one_thread

--- a/tests/foreman/rhai/test_rhai.py
+++ b/tests/foreman/rhai/test_rhai.py
@@ -20,14 +20,18 @@ from fauxfactory import gen_string
 from nailgun import entities
 from robottelo import manifests
 from robottelo.api.utils import upload_manifest
+from robottelo.config import settings
 from robottelo.constants import DEFAULT_SUBSCRIPTION_NAME
-from robottelo.constants import DISTRO_RHEL6, DISTRO_RHEL7
 from robottelo.decorators import run_in_one_thread, skip_if_not_set
 from robottelo.test import UITestCase
 from robottelo.ui.locators import locators
 from robottelo.ui.navigator import Navigator
 from robottelo.ui.session import Session
 from robottelo.vm import VirtualMachine
+
+
+DISTRO_RHEL6 = settings.distro.image_el6
+DISTRO_RHEL7 = settings.distro.image_el7
 
 
 @run_in_one_thread

--- a/tests/foreman/ui/test_activationkey.py
+++ b/tests/foreman/ui/test_activationkey.py
@@ -33,11 +33,10 @@ from robottelo.cli.factory import (
     make_org,
     setup_org_for_a_rh_repo,
 )
+from robottelo.config import settings
 from robottelo.constants import (
     DEFAULT_CV,
     DEFAULT_SUBSCRIPTION_NAME,
-    DISTRO_RHEL6,
-    DISTRO_RHEL7,
     ENVIRONMENT,
     FAKE_1_YUM_REPO,
     FAKE_2_YUM_REPO,
@@ -61,6 +60,10 @@ from robottelo.ui.factory import make_activationkey, set_context
 from robottelo.ui.locators import common_locators, locators, tab_locators
 from robottelo.ui.session import Session
 from robottelo.vm import VirtualMachine
+
+
+DISTRO_RHEL6 = settings.distro.image_el6
+DISTRO_RHEL7 = settings.distro.image_el7
 
 
 class ActivationKeyTestCase(UITestCase):

--- a/tests/foreman/ui/test_contenthost.py
+++ b/tests/foreman/ui/test_contenthost.py
@@ -21,8 +21,8 @@ from robottelo.cli.factory import (
     setup_org_for_a_custom_repo,
     setup_org_for_a_rh_repo,
 )
+from robottelo.config import settings
 from robottelo.constants import (
-    DISTRO_RHEL7,
     FAKE_0_CUSTOM_PACKAGE,
     FAKE_0_CUSTOM_PACKAGE_GROUP,
     FAKE_0_CUSTOM_PACKAGE_GROUP_NAME,
@@ -40,6 +40,9 @@ from robottelo.decorators import run_in_one_thread, skip_if_not_set, tier3
 from robottelo.test import UITestCase
 from robottelo.ui.session import Session
 from robottelo.vm import VirtualMachine
+
+
+DISTRO_RHEL7 = settings.distro.image_el7
 
 
 @run_in_one_thread

--- a/tests/foreman/ui/test_contentview.py
+++ b/tests/foreman/ui/test_contentview.py
@@ -33,7 +33,6 @@ from robottelo.config import settings
 from robottelo.constants import (
     DEFAULT_CV,
     DEFAULT_SUBSCRIPTION_NAME,
-    DISTRO_RHEL7,
     DOCKER_REGISTRY_HUB,
     DOCKER_UPSTREAM_NAME,
     ENVIRONMENT,
@@ -75,6 +74,9 @@ from robottelo.ui.locators.menu import menu_locators
 from robottelo.ui.locators.tab import tab_locators
 from robottelo.ui.session import Session
 from robottelo.vm import VirtualMachine
+
+
+DISTRO_RHEL7 = settings.distro.image_el7
 
 
 class ContentViewTestCase(UITestCase):

--- a/tests/foreman/ui/test_errata.py
+++ b/tests/foreman/ui/test_errata.py
@@ -26,11 +26,10 @@ from robottelo.cli.contentview import ContentView
 from robottelo.cli.host import Host
 from robottelo.cli.repository import Repository
 from robottelo.cli.repository_set import RepositorySet
+from robottelo.config import settings
 from robottelo.constants import (
     DEFAULT_ARCHITECTURE,
     DEFAULT_RELEASE_VERSION,
-    DISTRO_RHEL6,
-    DISTRO_RHEL7,
     FAKE_1_CUSTOM_PACKAGE,
     FAKE_2_CUSTOM_PACKAGE,
     FAKE_2_ERRATA_ID,
@@ -60,6 +59,8 @@ from robottelo.vm import VirtualMachine
 
 CUSTOM_REPO_URL = FAKE_6_YUM_REPO
 CUSTOM_REPO_ERRATA_ID = FAKE_2_ERRATA_ID
+DISTRO_RHEL6 = settings.distro.image_el6
+DISTRO_RHEL7 = settings.distro.image_el7
 
 
 @run_in_one_thread

--- a/tests/foreman/ui/test_gpgkey.py
+++ b/tests/foreman/ui/test_gpgkey.py
@@ -21,7 +21,6 @@ from fauxfactory import gen_string
 from nailgun import entities
 from robottelo.config import settings
 from robottelo.constants import (
-    DISTRO_RHEL6,
     FAKE_1_YUM_REPO,
     FAKE_2_YUM_REPO,
     REPO_DISCOVERY_URL,
@@ -45,6 +44,9 @@ from robottelo.ui.factory import make_gpgkey
 from robottelo.ui.locators import common_locators, locators
 from robottelo.ui.session import Session
 from robottelo.vm import VirtualMachine
+
+
+DISTRO_RHEL6 = settings.distro.image_el6
 
 
 def get_random_gpgkey_name():

--- a/tests/foreman/ui/test_hostcollection.py
+++ b/tests/foreman/ui/test_hostcollection.py
@@ -25,8 +25,8 @@ from robottelo.cli.factory import (
     setup_org_for_a_custom_repo,
     setup_org_for_a_rh_repo,
 )
+from robottelo.config import settings
 from robottelo.constants import (
-    DISTRO_RHEL7,
     FAKE_0_CUSTOM_PACKAGE,
     FAKE_0_CUSTOM_PACKAGE_GROUP,
     FAKE_0_CUSTOM_PACKAGE_GROUP_NAME,
@@ -59,6 +59,9 @@ from robottelo.ui.locators import common_locators
 from robottelo.ui.session import Session
 from robottelo.vm import VirtualMachine
 from time import sleep
+
+
+DISTRO_RHEL7 = settings.distro.image_el7
 
 
 class HostCollectionTestCase(UITestCase):

--- a/tests/foreman/ui/test_hostunification.py
+++ b/tests/foreman/ui/test_hostunification.py
@@ -19,10 +19,10 @@
 from fauxfactory import gen_string
 from nailgun import entities
 from robottelo.cli.factory import setup_org_for_a_rh_repo
+from robottelo.config import settings
 from robottelo.constants import (
     DEFAULT_CV,
     DEFAULT_SUBSCRIPTION_NAME,
-    DISTRO_RHEL7,
     ENVIRONMENT,
     PRDS,
     REPOS,
@@ -40,6 +40,9 @@ from robottelo.ui.factory import make_host
 from robottelo.ui.locators import common_locators
 from robottelo.ui.session import Session
 from robottelo.vm import VirtualMachine
+
+
+DISTRO_RHEL7 = settings.distro.image_el7
 
 
 class HostContentHostUnificationTestCase(UITestCase):

--- a/tests/foreman/ui/test_remoteexecution.py
+++ b/tests/foreman/ui/test_remoteexecution.py
@@ -16,7 +16,8 @@
 """
 from datetime import datetime, timedelta
 from nailgun import entities
-from robottelo.constants import OS_TEMPLATE_DATA_FILE, DISTRO_RHEL7
+from robottelo.config import settings
+from robottelo.constants import OS_TEMPLATE_DATA_FILE
 from robottelo.datafactory import (
     gen_string,
     generate_strings_list,
@@ -31,6 +32,7 @@ from robottelo.ui.session import Session
 from robottelo.vm import VirtualMachine
 
 OS_TEMPLATE_DATA_FILE = get_data_file(OS_TEMPLATE_DATA_FILE)
+DISTRO_RHEL7 = settings.distro.image_el7
 
 
 class JobsTemplateTestCase(UITestCase):


### PR DESCRIPTION
a) This PR should be merged against 6.1 and 6.2 branches as well. For now this is for the master branch.

b) Also this PR requires another patch at the robottelo-ci end to dynamically update the `image_el6` and `image_el7` values under the [distro] section in the robottelo.properties file.

Will raise one PR soon to address the b) part as mentioned above.