### PR TITLE
Automate BZ 11315267/1256461

### DIFF
--- a/robottelo/cli/org.py
+++ b/robottelo/cli/org.py
@@ -168,15 +168,3 @@ class Org(Base):
         """Removes an user from an org"""
         cls.command_sub = 'remove-user'
         return cls.execute(cls._construct_command(options))
-
-    @classmethod
-    def set_parameter(cls, options=None):
-        """Create or update parameter for an organization."""
-        cls.command_sub = 'set-parameter'
-        return cls.execute(cls._construct_command(options))
-
-    @classmethod
-    def delete_parameter(cls, options=None):
-        """Delete parameter for an organization."""
-        cls.command_sub = 'delete-parameter'
-        return cls.execute(cls._construct_command(options))

--- a/tests/foreman/cli/test_location.py
+++ b/tests/foreman/cli/test_location.py
@@ -742,3 +742,122 @@ class LocationTestCase(CLITestCase):
         Location.delete({'id': loc['id']})
         with self.assertRaises(CLIReturnCodeError):
             Location.info({'id': loc['id']})
+
+    @tier1
+    def test_positive_add_parameter_by_loc_name(self):
+        """Add a parameter to location
+
+        @id: d4c2f27d-7c16-4296-9da6-2e7135bfb6ad
+
+        @Assert: Parameter is added to the location
+        """
+        param_name = gen_string('alpha')
+        param_value = gen_string('alpha')
+        location = make_location()
+        Location.set_parameter({
+            'name': param_name,
+            'value': param_value,
+            'location': location['name'],
+        })
+        result = Location.info({'id': location['id']})
+        self.assertEqual(len(result['parameters']), 1)
+        self.assertEqual(param_value, result['parameters'][param_name.lower()])
+
+    @tier1
+    def test_positive_add_parameter_by_loc_id(self):
+        """Add a parameter to location
+
+        @id: 61b564f2-a42a-48de-833d-bec3a127d0f5
+
+        @Assert: Parameter is added to the location
+        """
+        param_name = gen_string('alpha')
+        param_value = gen_string('alpha')
+        location = make_location()
+        Location.set_parameter({
+            'name': param_name,
+            'value': param_value,
+            'location-id': location['id'],
+        })
+        result = Location.info({'id': location['id']})
+        self.assertEqual(len(result['parameters']), 1)
+        self.assertEqual(param_value, result['parameters'][param_name.lower()])
+
+    @tier1
+    def test_positive_update_parameter(self):
+        """Update a parameter associated with location
+
+        @id: 7b61fa71-0203-4709-9abd-9bb51ce6c19f
+
+        @Assert: Parameter is updated
+        """
+        param_name = gen_string('alpha')
+        param_new_value = gen_string('alpha')
+        location = make_location()
+        # Create parameter
+        Location.set_parameter({
+            'name': param_name,
+            'value': gen_string('alpha'),
+            'location': location['name'],
+        })
+        result = Location.info({'id': location['id']})
+        self.assertEqual(len(result['parameters']), 1)
+        Location.set_parameter({
+            'name': param_name,
+            'value': param_new_value,
+            'location': location['name'],
+        })
+        result = Location.info({'id': location['id']})
+        self.assertEqual(len(result['parameters']), 1)
+        self.assertEqual(
+            param_new_value, result['parameters'][param_name.lower()])
+
+    @skip_if_bug_open('bugzilla', 1395229)
+    @tier1
+    def test_positive_remove_parameter_by_loc_name(self):
+        """Remove a parameter from location
+
+        @id: 97fda466-1894-431e-bc76-3b1c7643522f
+
+        @Assert: Parameter is removed from the location
+        """
+        param_name = gen_string('alpha')
+        location = make_location()
+        Location.set_parameter({
+            'name': param_name,
+            'value': gen_string('alpha'),
+            'location': location['name'],
+        })
+        result = Location.info({'id': location['id']})
+        self.assertEqual(len(result['parameters']), 1)
+        Location.delete_parameter({
+            'name': param_name,
+            'location': location['name'],
+        })
+        self.assertEqual(len(result['parameters']), 0)
+        self.assertNotIn(param_name.lower(), result['parameters'])
+
+    @skip_if_bug_open('bugzilla', 1395229)
+    @tier1
+    def test_positive_remove_parameter_by_loc_id(self):
+        """Remove a parameter from location
+
+        @id: 13836073-3e39-4d3e-b4b4-e87619c28bae
+
+        @Assert: Parameter is removed from the location
+        """
+        param_name = gen_string('alpha')
+        location = make_location()
+        Location.set_parameter({
+            'name': param_name,
+            'value': gen_string('alpha'),
+            'location-id': location['id'],
+        })
+        result = Location.info({'id': location['id']})
+        self.assertEqual(len(result['parameters']), 1)
+        Location.delete_parameter({
+            'name': param_name,
+            'location-id': location['id'],
+        })
+        self.assertEqual(len(result['parameters']), 0)
+        self.assertNotIn(param_name.lower(), result['parameters'])

--- a/tests/foreman/cli/test_organization.py
+++ b/tests/foreman/cli/test_organization.py
@@ -1282,7 +1282,7 @@ class OrganizationTestCase(CLITestCase):
 
     @run_only_on('sat')
     @tier1
-    def test_positive_add_parameter(self):
+    def test_positive_add_parameter_by_org_name(self):
         """Add a parameter to organization
 
         @id: b0b59650-5718-45e2-8724-151dc52b1486
@@ -1296,6 +1296,27 @@ class OrganizationTestCase(CLITestCase):
             'name': param_name,
             'value': param_value,
             'organization': org['name'],
+        })
+        result = Org.info({'id': org['id']})
+        self.assertEqual(len(result['parameters']), 1)
+        self.assertEqual(param_value, result['parameters'][param_name.lower()])
+
+    @run_only_on('sat')
+    @tier1
+    def test_positive_add_parameter_by_org_id(self):
+        """Add a parameter to organization
+
+        @id: bb76f67e-5329-4777-b563-3fe4ebffc9ce
+
+        @Assert: Parameter is added to the org
+        """
+        param_name = gen_string('alpha')
+        param_value = gen_string('alpha')
+        org = make_org()
+        Org.set_parameter({
+            'name': param_name,
+            'value': param_value,
+            'organization-id': org['id'],
         })
         result = Org.info({'id': org['id']})
         self.assertEqual(len(result['parameters']), 1)
@@ -1334,7 +1355,7 @@ class OrganizationTestCase(CLITestCase):
     @run_only_on('sat')
     @skip_if_bug_open('bugzilla', 1395229)
     @tier1
-    def test_positive_remove_parameter(self):
+    def test_positive_remove_parameter_by_org_name(self):
         """Remove a parameter from organization
 
         @id: e4099279-4e73-4c14-9e7c-912b3787b99f
@@ -1353,6 +1374,32 @@ class OrganizationTestCase(CLITestCase):
         Org.delete_parameter({
             'name': param_name,
             'organization': org['name'],
+        })
+        self.assertEqual(len(result['parameters']), 0)
+        self.assertNotIn(param_name.lower(), result['parameters'])
+
+    @run_only_on('sat')
+    @skip_if_bug_open('bugzilla', 1395229)
+    @tier1
+    def test_positive_remove_parameter_by_org_id(self):
+        """Remove a parameter from organization
+
+        @id: 9b0e7c5c-32cd-4428-8798-3469599c9b05
+
+        @Assert: Parameter is removed from the org
+        """
+        param_name = gen_string('alpha')
+        org = make_org()
+        Org.set_parameter({
+            'name': param_name,
+            'value': gen_string('alpha'),
+            'organization-id': org['id'],
+        })
+        result = Org.info({'id': org['id']})
+        self.assertEqual(len(result['parameters']), 1)
+        Org.delete_parameter({
+            'name': param_name,
+            'organization-id': org['id'],
         })
         self.assertEqual(len(result['parameters']), 0)
         self.assertNotIn(param_name.lower(), result['parameters'])


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1315267
https://bugzilla.redhat.com/show_bug.cgi?id=1256461

Added missing coverage for Location's set-parameter/delete-parameter, covers BZ ^.
Also updated Organization's parameter tests. Helpers were removed from organization class as they are already implemented in base class.

```python
% py.test -v tests/foreman/cli/test_{location,organization}.py -k 'parameter'
===================================================================== test session starts =====================================================================
platform linux2 -- Python 2.7.12, pytest-2.9.2, py-1.4.32, pluggy-0.3.1 -- /home/qui/code/venv/2/bin/python2
2017-02-23 18:03:44 - conftest - DEBUG - Collected 111 test cases
tests/foreman/cli/test_location.py::LocationTestCase::test_positive_add_parameter_by_loc_id PASSED
tests/foreman/cli/test_location.py::LocationTestCase::test_positive_add_parameter_by_loc_name PASSED
tests/foreman/cli/test_location.py::LocationTestCase::test_positive_remove_parameter_by_loc_id <- robottelo/decorators/__init__.py SKIPPED
tests/foreman/cli/test_location.py::LocationTestCase::test_positive_remove_parameter_by_loc_name <- robottelo/decorators/__init__.py SKIPPED
tests/foreman/cli/test_location.py::LocationTestCase::test_positive_update_parameter PASSED
tests/foreman/cli/test_organization.py::OrganizationTestCase::test_positive_add_parameter_by_org_id <- robottelo/decorators/__init__.py PASSED
tests/foreman/cli/test_organization.py::OrganizationTestCase::test_positive_add_parameter_by_org_name <- robottelo/decorators/__init__.py PASSED
tests/foreman/cli/test_organization.py::OrganizationTestCase::test_positive_remove_parameter_by_org_id <- robottelo/decorators/__init__.py SKIPPED
tests/foreman/cli/test_organization.py::OrganizationTestCase::test_positive_remove_parameter_by_org_name <- robottelo/decorators/__init__.py SKIPPED
tests/foreman/cli/test_organization.py::OrganizationTestCase::test_positive_update_parameter <- robottelo/decorators/__init__.py PASSED

============================================================ 101 tests deselected by '-kparameter' ============================================================
==================================================== 6 passed, 4 skipped, 101 deselected in 113.73 seconds ====================================================
```