### PR TITLE
BASE_IMAGE values are now picked up from robottelo.properties file.

### DIFF
--- a/robottelo.properties.sample
+++ b/robottelo.properties.sample
@@ -142,6 +142,12 @@ ssh_key=
 # image_dir=/opt/robottelo/images
 
 
+# For tests that uses the images for content-host testcases.
+# [distro]
+# image_el6=rhel68
+# image_el7=rhel73
+
+
 # For tests that uses the docker feature
 # [docker]
 # If you have docker deamon running on the server and it is published under a

--- a/robottelo/config/base.py
+++ b/robottelo/config/base.py
@@ -277,6 +277,28 @@ class ClientsSettings(FeatureSettings):
         return validation_errors
 
 
+class DistroSettings(FeatureSettings):
+    """Distro settings definitions."""
+    def __init__(self, *args, **kwargs):
+        super(DistroSettings, self).__init__(*args, **kwargs)
+        self.image_el6 = None
+        self.image_el7 = None
+
+    def read(self, reader):
+        """Read distro settings."""
+        self.image_el6 = reader.get('distro', 'image_el6')
+        self.image_el7 = reader.get('distro', 'image_el7')
+
+    def validate(self):
+        """Validate distro settings."""
+        validation_errors = []
+        if not all((self.image_el6, self.image_el7)):
+            validation_errors.append(
+                'Both [distro] image_el6 and image_el7 '
+                'options must be provided.')
+        return validation_errors
+
+
 class DockerSettings(FeatureSettings):
     """Docker settings definitions."""
     def __init__(self, *args, **kwargs):
@@ -742,6 +764,7 @@ class Settings(object):
         self.clients = ClientsSettings()
         self.compute_resources = LibvirtHostSettings()
         self.discovery = DiscoveryISOSettings()
+        self.distro = DistroSettings()
         self.docker = DockerSettings()
         self.fake_capsules = FakeCapsuleSettings()
         self.fake_manifest = FakeManifestSettings()

--- a/robottelo/constants.py
+++ b/robottelo/constants.py
@@ -24,8 +24,8 @@ BZ_CLOSED_STATUSES = [
     'CLOSED'
 ]
 
-DISTRO_RHEL6 = "rhel68"
-DISTRO_RHEL7 = "rhel73"
+DISTRO_RHEL6 = "rhel6"
+DISTRO_RHEL7 = "rhel7"
 
 FOREMAN_PROVIDERS = {
     'libvirt': 'Libvirt',

--- a/robottelo/vm.py
+++ b/robottelo/vm.py
@@ -18,11 +18,6 @@ from robottelo.config import settings
 from robottelo.constants import DISTRO_RHEL6, DISTRO_RHEL7
 from robottelo.helpers import install_katello_ca, remove_katello_ca
 
-BASE_IMAGES = (
-    DISTRO_RHEL6,
-    DISTRO_RHEL7,
-)
-
 logger = logging.getLogger(__name__)
 
 
@@ -33,8 +28,8 @@ class VirtualMachineError(Exception):
 class VirtualMachine(object):
     """Manages a virtual machine to allow client provisioning for robottelo
 
-    It expects that base images listed on ``BASE_IMAGES`` are created and
-    snap-guest is setup on the provisioning server.
+    It expects that base images are created and snap-guest is setup on the
+    provisioning server.
 
     This also can be used as a context manager::
 
@@ -56,13 +51,21 @@ class VirtualMachine(object):
             self, cpu=1, ram=512, distro=None, provisioning_server=None,
             image_dir=None, tag=None, hostname=None, domain=None,
             target_image=None):
+        distro_el6 = settings.distro.image_el6
+        distro_el7 = settings.distro.image_el7
         self.cpu = cpu
         self.ram = ram
-        self.distro = BASE_IMAGES[-1] if distro is None else distro
-        if self.distro not in BASE_IMAGES:
+        if distro == 'rhel6':
+            distro = distro_el6
+        if distro == 'rhel7':
+            distro = distro_el7
+        if distro is None:
+            distro = distro_el7
+        self.distro = distro
+        if self.distro not in (distro_el6, distro_el7):
             raise VirtualMachineError(
-                u'{0} is not a supported distro. Choose one of {1}'
-                .format(self.distro, ', '.join(BASE_IMAGES))
+                u'{0} is not a supported distro. Choose one of {1}, {2}'
+                .format(self.distro, distro_el6, distro_el7)
             )
         if provisioning_server is None:
             self.provisioning_server = settings.clients.provisioning_server


### PR DESCRIPTION
a) The DISTRO_RHEL6 and DISTRO_RHEL7 constants are retained but now
   they only specify the RHEL major version.
b) Now depending upon the settings.distro.image_rhel6 or
   settings.distro.image_rhel7 the `distro` value in VirtualMachine
   is assigned.