### PR TITLE
Automate BZ 1371900

### DIFF
--- a/tests/foreman/api/test_host.py
+++ b/tests/foreman/api/test_host.py
@@ -1352,6 +1352,42 @@ class HostTestCase(APITestCase):
         @caselevel: System
         """
 
+    @tier1
+    def test_positive_read_puppet_proxy_name(self):
+        """Read a hostgroup created with puppet proxy and inspect server's
+        response
+
+        @id: 8825462e-f1dc-4054-b7fb-69c2b10722a2
+
+        @Assert: Field 'puppet_proxy_name' is returned
+
+        @BZ: 1371900
+        """
+        proxy = entities.SmartProxy().search(query={
+            'search': 'url = https://{0}:9090'.format(settings.server.hostname)
+        })[0]
+        host = entities.Host(puppet_proxy=proxy).create().read_json()
+        self.assertIn('puppet_proxy_name', host)
+        self.assertEqual(proxy.name, host['puppet_proxy_name'])
+
+    @tier1
+    def test_positive_read_puppet_ca_proxy_name(self):
+        """Read a hostgroup created with puppet ca proxy and inspect server's
+        response
+
+        @id: 8941395f-8040-4705-a981-5da21c47efd1
+
+        @Assert: Field 'puppet_ca_proxy_name' is returned
+
+        @BZ: 1371900
+        """
+        proxy = entities.SmartProxy().search(query={
+            'search': 'url = https://{0}:9090'.format(settings.server.hostname)
+        })[0]
+        host = entities.Host(puppet_ca_proxy=proxy).create().read_json()
+        self.assertIn('puppet_ca_proxy_name', host)
+        self.assertEqual(proxy.name, host['puppet_ca_proxy_name'])
+
 
 class HostInterfaceTestCase(APITestCase):
     """Tests for Host Interfaces"""

--- a/tests/foreman/api/test_hostgroup.py
+++ b/tests/foreman/api/test_hostgroup.py
@@ -1199,3 +1199,39 @@ class HostGroupMissingAttrTestCase(APITestCase):
                 self.host_group_attrs
             )
         )
+
+    @tier1
+    def test_positive_read_puppet_proxy_name(self):
+        """Read a hostgroup created with puppet proxy and inspect server's
+        response
+
+        @id: f93d0866-0073-4577-8777-6d645b63264f
+
+        @Assert: Field 'puppet_proxy_name' is returned
+
+        @BZ: 1371900
+        """
+        proxy = entities.SmartProxy().search(query={
+            'search': 'url = https://{0}:9090'.format(settings.server.hostname)
+        })[0]
+        hg = entities.HostGroup(puppet_proxy=proxy).create().read_json()
+        self.assertIn('puppet_proxy_name', hg)
+        self.assertEqual(proxy.name, hg['puppet_proxy_name'])
+
+    @tier1
+    def test_positive_read_puppet_ca_proxy_name(self):
+        """Read a hostgroup created with puppet ca proxy and inspect server's
+        response
+
+        @id: ab151e09-8e64-4377-95e8-584629750659
+
+        @Assert: Field 'puppet_ca_proxy_name' is returned
+
+        @BZ: 1371900
+        """
+        proxy = entities.SmartProxy().search(query={
+            'search': 'url = https://{0}:9090'.format(settings.server.hostname)
+        })[0]
+        hg = entities.HostGroup(puppet_ca_proxy=proxy).create().read_json()
+        self.assertIn('puppet_ca_proxy_name', hg)
+        self.assertEqual(proxy.name, hg['puppet_ca_proxy_name'])


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1371900

```python
% py.test -v tests/foreman/api/test_host{,group}.py -k 'read'                                [git][robottelo/.][1371900U]
===================================================================== test session starts =====================================================================
platform linux2 -- Python 2.7.12, pytest-2.9.2, py-1.4.32, pluggy-0.3.1 -- /home/qui/code/venv/2/bin/python2

2017-02-23 19:43:15 - conftest - DEBUG - Collected 109 test cases

tests/foreman/api/test_host.py::HostTestCase::test_positive_read_puppet_ca_proxy_name PASSED
tests/foreman/api/test_host.py::HostTestCase::test_positive_read_puppet_proxy_name PASSED
tests/foreman/api/test_hostgroup.py::HostGroupMissingAttrTestCase::test_positive_read_puppet_ca_proxy_name PASSED
tests/foreman/api/test_hostgroup.py::HostGroupMissingAttrTestCase::test_positive_read_puppet_proxy_name PASSED

============================================================== 105 tests deselected by '-kread' ===============================================================
========================================================= 4 passed, 105 deselected in 108.29 seconds ==========================================================
```