### PR TITLE
[6.2.z] implement CLI capsule + test cv version remove

### DIFF
--- a/robottelo.properties.sample
+++ b/robottelo.properties.sample
@@ -271,3 +271,23 @@ ssh_key=
 # for RHEL7 - the ports needs to have a correct selinux context set:
 # 'semanage port -a -t websm_port_t -p tcp <port-range>'
 port_range=9091, 14999
+
+# section for real capsule
+# [capsule]
+# to setup a real capsule we need the capsule virtual machine hostname
+# resolvable.
+# we should register a hostname and get a hash value as described in
+# https://mojo.redhat.com/docs/DOC-13143, that we should use on the stage of
+# ddns setup
+# domain is the base ddns domain, the virtual machine hostname will be a sub
+# domain of this domain.
+# domain=
+# the instance_name is the key used in the registration above, and used to name
+# the instance of the virtual machine
+# the real finale hostname should be instance_name.domain
+# instance_name=
+# the hash is the hash value returned in ddns registration
+# hash=
+# ddns rpm package to install on the virtual machine to setup ddns hostname
+# resolution
+# ddns_package_url=

--- a/robottelo/cli/capsule.py
+++ b/robottelo/cli/capsule.py
@@ -1,0 +1,131 @@
+# -*- encoding: utf-8 -*-
+"""
+Usage::
+
+    hammer capsule [OPTIONS] SUBCOMMAND [ARG] ...
+
+Parameters::
+
+    SUBCOMMAND                    subcommand
+    [ARG] ...                     subcommand arguments
+
+Subcommands::
+
+    content                       Manage the capsule content
+    create                        Create a capsule
+    delete                        Delete a capsule
+    import-classes                Import puppet classes from puppet Capsule.
+    info                          Show a capsule
+    list                          List all capsules
+    refresh-features              Refresh capsule features
+    update                        Update a capsule
+"""
+
+from robottelo.cli.base import Base
+
+
+class Capsule(Base):
+    """
+    Manipulates Foreman's capsule.
+    """
+
+    command_base = 'capsule'
+
+    @classmethod
+    def content_add_lifecycle_environment(cls, options):
+        """Add lifecycle environments to the capsule."""
+
+        cls.command_sub = 'content add-lifecycle-environment'
+
+        result = cls.execute(
+            cls._construct_command(options), output_format='csv')
+
+        return result
+
+    @classmethod
+    def content_available_lifecycle_environments(cls, options):
+        """List the lifecycle environments not attached to the capsule."""
+
+        cls.command_sub = 'content available-lifecycle-environments'
+
+        result = cls.execute(
+            cls._construct_command(options), output_format='csv')
+
+        return result
+
+    @classmethod
+    def content_info(cls, options):
+        """Get current capsule synchronization status."""
+
+        cls.command_sub = 'content info'
+
+        result = cls.execute(
+            cls._construct_command(options), output_format='json')
+
+        return result
+
+    @classmethod
+    def content_lifecycle_environments(cls, options):
+        """List the lifecycle environments attached to the capsule."""
+
+        cls.command_sub = 'content lifecycle-environments'
+
+        result = cls.execute(
+            cls._construct_command(options), output_format='csv')
+
+        return result
+
+    @classmethod
+    def content_remove_lifecycle_environment(cls, options):
+        """Remove lifecycle environments from the capsule."""
+
+        cls.command_sub = 'content remove-lifecycle-environment'
+
+        result = cls.execute(
+            cls._construct_command(options), output_format='csv')
+
+        return result
+
+    @classmethod
+    def content_synchronization_status(cls, options):
+        """Get current capsule synchronization status."""
+
+        cls.command_sub = 'content synchronization-status'
+
+        result = cls.execute(
+            cls._construct_command(options), output_format='csv')
+
+        return result
+
+    @classmethod
+    def content_synchronize(cls, options):
+        """Synchronize the content to the capsule."""
+
+        cls.command_sub = 'content synchronize'
+
+        result = cls.execute(
+            cls._construct_command(options), output_format='csv')
+
+        return result
+
+    @classmethod
+    def import_classes(cls, options):
+        """Import puppet classes from puppet Capsule."""
+
+        cls.command_sub = 'import-classes'
+
+        result = cls.execute(
+            cls._construct_command(options), output_format='csv')
+
+        return result
+
+    @classmethod
+    def refresh_features(cls, options):
+        """Refresh capsule features."""
+
+        cls.command_sub = 'refresh-features'
+
+        result = cls.execute(
+            cls._construct_command(options), output_format='csv')
+
+        return result

--- a/robottelo/cli/factory.py
+++ b/robottelo/cli/factory.py
@@ -23,6 +23,7 @@ from robottelo.cli.activationkey import ActivationKey
 from robottelo.cli.architecture import Architecture
 from robottelo.cli.base import CLIReturnCodeError
 from robottelo.cli.computeresource import ComputeResource
+from robottelo.cli.capsule import Capsule
 from robottelo.cli.contenthost import ContentHost
 from robottelo.cli.contentview import ContentView
 from robottelo.cli.docker import DockerContainer, DockerRegistry
@@ -56,18 +57,28 @@ from robottelo.cli.usergroup import UserGroup, UserGroupExternal
 from robottelo.cli.smart_variable import SmartVariable
 from robottelo.config import settings
 from robottelo.constants import (
+    DEFAULT_LOC,
     DEFAULT_SUBSCRIPTION_NAME,
     FAKE_1_YUM_REPO,
     FOREMAN_PROVIDERS,
     OPERATING_SYSTEMS,
     SYNC_INTERVAL,
+    DISTRO_RHEL6,
+    DISTRO_RHEL7,
+    REPOS,
+    REPOSET,
+    PRDS,
+    PRD_SETS,
     TEMPLATE_TYPES,
 )
 from robottelo.decorators import bz_bug_is_open, cacheable
 from robottelo.helpers import (
     update_dictionary, default_url_on_new_port, get_available_capsule_port
 )
-from robottelo.ssh import upload_file
+from robottelo.ssh import (
+    download_file,
+    upload_file,
+)
 from tempfile import mkstemp
 from time import sleep
 
@@ -2376,3 +2387,334 @@ def publish_puppet_module(puppet_modules, repo_url, organization_id=None):
     # Puppet Class entities
     ContentView.publish({u'id': cv['id']})
     return ContentView.info({u'id': cv['id']})
+
+
+def _extract_capsule_satellite_installer_command(text):
+    cmd_start_with = 'satellite-installer'
+    cmd_lines = []
+    if text:
+        if isinstance(text, (list, tuple)):
+            lines = text
+        else:
+            lines = text.split('\n')
+        cmd_start_found = False
+        cmd_end_found = False
+        for line in lines:
+            if line.lstrip().startswith(cmd_start_with):
+                cmd_start_found = True
+            if cmd_start_found and not cmd_end_found:
+                cmd_lines.append(line.strip('\\'))
+                if not line.endswith('\\'):
+                    cmd_end_found = True
+    if cmd_lines:
+        # remove empty spaces
+        cmd = ' '.join(cmd_lines)
+        while '  ' in cmd:
+            cmd = cmd.replace('  ', ' ')
+
+        return cmd
+    return None
+
+
+def _get_capsule_vm_distro_repos(distro):
+    """Return the right RH repos info for the capsule setup"""
+    rh_repos = []
+    if distro == DISTRO_RHEL7:
+        # Red Hat Enterprise Linux 7 Server
+        rh_product_arch = PRD_SETS['rhel_72']['arch']
+        rh_product_releasever = PRD_SETS['rhel_72']['releasever']
+        rh_repos.append({
+            'product': PRD_SETS['rhel_72']['product'],
+            'repository-set': PRD_SETS['rhel_72']['reposet'],
+            'repository': PRD_SETS['rhel_72']['reponame'],
+            'repository-id': PRD_SETS['rhel_72']['label'],
+            'releasever': rh_product_releasever,
+            'arch': rh_product_arch
+        })
+        # Red Hat Satellite Capsule 6.2 (for RHEL 7 Server)
+        rh_repos.append({
+            'product': PRDS['rhsc'],
+            'repository-set': REPOSET['rhsc7'],
+            'repository': REPOS['rhsc7']['name'],
+            'repository-id': REPOS['rhsc7']['id'],
+        })
+    elif distro == DISTRO_RHEL6:
+        # Red Hat Enterprise Linux 6 Server
+        rh_product_arch = PRD_SETS['rhel_68']['arch']
+        rh_product_releasever = PRD_SETS['rhel_68']['releasever']
+        rh_repos.append({
+            'product': PRD_SETS['rhel_68']['product'],
+            'repository-set': PRD_SETS['rhel_68']['reposet'],
+            'repository': PRD_SETS['rhel_68']['reponame'],
+            'repository-id': PRD_SETS['rhel_68']['label'],
+            'releasever': rh_product_releasever,
+            'arch': rh_product_arch
+        })
+        # Red Hat Satellite Capsule 6.2 (for RHEL 6 Server)
+        rh_repos.append({
+            'product': PRDS['rhsc'],
+            'repository-set': REPOSET['rhsc6'],
+            'repository': REPOS['rhsc6']['name'],
+            'repository-id': REPOS['rhsc6']['id'],
+        })
+    else:
+        raise CLIFactoryError('distro "{}" not supported'.format(distro))
+
+    return rh_product_arch, rh_product_releasever, rh_repos
+
+
+def setup_capsule_virtual_machine(capsule_vm, org_id=None, lce_id=None,
+                                  organization_ids=None, location_ids=None):
+    """Setup a Virtual Machine to host a capsule node
+
+    :param capsule_vm: the virtual machine to
+     setup as a capsule node
+    :param org_id: The organization that setup the capsule content
+    :param lce_id: The lifecycle environment  the capsule content was
+     promoted.
+    :param organization_ids: the organization ids of
+     organizations that will use the capsule.
+    :param location_ids: the location ids for which the content
+     will be synchronized.
+    :return tuple: capsule, org, lce  objects
+
+    Notes:
+
+    1. as this setup need the default manifest to be consumed, please ensure
+       that this function is called from one thread.
+
+    2. The org will consume the default manifest, it probable that it cannot
+       be installed for other organizations, if the tests need a manifest to be
+       uploaded, use the same org that setup the capsule by providing the
+       org_id and lce_id to be able to create and promote the capsule
+       content view and to create the capsule subscription key.
+    """
+    if capsule_vm.distro not in (DISTRO_RHEL6, DISTRO_RHEL7):
+        raise CLIFactoryError(
+            u'virtual machine distro "{}" not supported'.format(
+                capsule_vm.distro)
+        )
+
+    # Get the necessary repositories info to setup a capsule host
+    capsule_vm_distro_repos = _get_capsule_vm_distro_repos(capsule_vm.distro)
+    rh_product_arch, rh_product_releasever, rh_repos = capsule_vm_distro_repos
+
+    if organization_ids is None:
+        organization_ids = []
+
+    if location_ids is None:
+        location_ids = []
+
+    if org_id is None:
+        # create a new org
+        capsule_org = make_org({
+            'name': 'capsule-{0}'.format(gen_string('alpha', 10))})
+        org_id = capsule_org['id']
+    else:
+        capsule_org = Org.info({'id': org_id})
+
+    if lce_id is None:
+        # Create a new lifecycle environment for capsule only
+        capsule_lce = make_lifecycle_environment({
+            'name': 'capsule-{0}'.format(gen_string('alpha', 10)),
+            'organization-id': org_id
+        })
+        lce_id = capsule_lce['id']
+    else:
+        capsule_lce = LifecycleEnvironment.info({
+            'id': lce_id, 'organization-id': org_id})
+
+    # Clone manifest and upload it
+    with manifests.clone() as manifest:
+        upload_file(manifest.content, manifest.filename)
+    try:
+        Subscription.upload({
+            u'file': manifest.filename,
+            u'organization-id': org_id,
+        })
+    except CLIReturnCodeError as err:
+        raise CLIFactoryError(
+            u'Failed to upload manifest\n{0}'.format(err.msg))
+
+    # Enable the RH capsule products
+    for rh_repo in rh_repos:
+        try:
+            RepositorySet.enable({
+                u'basearch': rh_product_arch,
+                u'name': rh_repo['repository-set'],
+                u'organization-id': org_id,
+                u'product': rh_repo['product'],
+                u'releasever': rh_repo.get('releasever'),
+            })
+        except CLIReturnCodeError as err:
+            raise CLIFactoryError(
+                u'Failed to enable repository set\n{0}'.format(err.msg))
+    # Retrieve the repositories info
+    rh_repos_info = []
+    for rh_repo in rh_repos:
+        try:
+            rh_repo_info = Repository.info({
+                u'name': rh_repo['repository'],
+                u'organization-id': org_id,
+                u'product': rh_repo['product'],
+            })
+            rh_repos_info.append(rh_repo_info)
+        except CLIReturnCodeError as err:
+            raise CLIFactoryError(
+                u'Failed to fetch repository info\n{0}'.format(err.msg))
+    # Synchronize the RH repositories
+    for rh_repo in rh_repos:
+        try:
+            Repository.synchronize({
+                u'name': rh_repo['repository'],
+                u'organization-id': org_id,
+                u'product': rh_repo['product'],
+            })
+        except CLIReturnCodeError as err:
+            raise CLIFactoryError(
+                u'Failed to synchronize repository\n{0}'.format(err.msg))
+    # Create a content view
+    content_view_id = make_content_view({
+        u'organization-id': org_id,
+        u'name': 'capsule-{0}'.format(gen_string('alpha', 10))
+    })['id']
+    for rh_repo_info in rh_repos_info:
+        try:
+            ContentView.add_repository({
+                u'id': content_view_id,
+                u'organization-id': org_id,
+                u'repository-id': rh_repo_info['id'],
+            })
+        except CLIReturnCodeError as err:
+            raise CLIFactoryError(
+                u'Failed to add repository to content view\n{0}'
+                .format(err.msg)
+            )
+    # Publish the content view
+    try:
+        ContentView.publish({u'id': content_view_id})
+    except CLIReturnCodeError as err:
+        raise CLIFactoryError(
+            u'Failed to publish new version of content view\n{0}'
+            .format(err.msg)
+        )
+    # Get the latest content view version id
+    try:
+        content_view_version = ContentView.info(
+            {u'id': content_view_id}
+        )['versions'][-1]
+    except CLIReturnCodeError as err:
+        raise CLIFactoryError(
+            u'Failed to fetch content view info\n{0}'.format(err.msg))
+    # Promote content view version to lifecycle environment
+    try:
+        ContentView.version_promote({
+            u'id': content_view_version['id'],
+            u'organization-id': org_id,
+            u'to-lifecycle-environment-id': lce_id,
+        })
+    except CLIReturnCodeError as err:
+        raise CLIFactoryError(
+            u'Failed to promote version to next environment\n{0}'
+            .format(err.msg)
+        )
+    activation_key = make_activation_key({
+        u'organization-id': org_id,
+        u'lifecycle-environment-id': lce_id,
+        u'content-view-id': content_view_id,
+        u'name': 'capsule-{0}'.format(gen_alphanumeric())
+    })
+    # Add subscriptions to activation-key
+    subscriptions = Subscription.list({'organization-id': org_id})
+    for subscription in subscriptions:
+        activationkey_add_subscription_to_repo({
+            'organization-id': org_id,
+            'activationkey-id': activation_key['id'],
+            'subscription': subscription['name']
+        })
+    # Install katello ca on capsule virtual machine
+    capsule_vm.install_katello_ca()
+    # Register the capsule host to satellite
+    capsule_vm.register_contenthost(
+        capsule_org['name'],
+        activation_key=activation_key['name']
+    )
+    # Patch the os release version
+    capsule_vm.run(
+        "touch /etc/yum/vars/releasever "
+        "&& echo '{0}' > /etc/yum/vars/releasever"
+        .format(rh_product_releasever)
+    )
+    # Enable the repositories
+    for repo in rh_repos:
+        repo_id = repo['repository-id']
+        capsule_vm.enable_repo(repo_id)
+
+    # Refresh the subscription
+    capsule_vm.run('subscription-manager refresh')
+    capsule_vm.run('yum clean all && yum repolist')
+    # Install katello agent
+    capsule_vm.install_katello_agent()
+
+    cert_file_path = '/tmp/{0}-certs.tar'.format(capsule_vm.hostname)
+    result = ssh.command(
+        'capsule-certs-generate '
+        '--capsule-fqdn {0} '
+        '--certs-tar {1}'
+        .format(capsule_vm.hostname, cert_file_path)
+    )
+    if result.return_code != 0:
+        raise CLIFactoryError(
+            u'was unable to generate certificate\n{}'.format(result.stderr))
+
+    # retrieve the installer command from the result output
+    satellite_installer_cmd = _extract_capsule_satellite_installer_command(
+        result.stdout
+    )
+    # copy the certificate to capsule vm
+    _, temporary_local_cert_file_path = mkstemp(suffix='-certs.tar')
+    download_file(
+        remote_file=cert_file_path,
+        local_file=temporary_local_cert_file_path,
+        hostname=settings.server.hostname
+    )
+    upload_file(
+        local_file=temporary_local_cert_file_path,
+        remote_file=cert_file_path,
+        hostname=capsule_vm.hostname
+    )
+    # delete the temporary file
+    os.remove(temporary_local_cert_file_path)
+    # Install Satellite Capsule product
+    capsule_vm.run('yum install -y satellite-capsule')
+    result = capsule_vm.run('rpm -q satellite-capsule')
+    if result.return_code != 0:
+        raise CLIFactoryError(
+            u'Failed to install satellite-capsule package\n{}'.format(
+                result.stderr)
+        )
+    result = capsule_vm.run(satellite_installer_cmd)
+    if result.return_code != 0:
+        # # before exit down load the capsule log file
+        download_file(
+            '/var/log/foreman-installer/capsule.log',
+            '/tmp/capsule.log',
+            capsule_vm.ip_addr
+        )
+        raise CLIFactoryError(result.return_code, result.stderr,
+                              u'foreman installer failed at capsule host')
+
+    capsule = Capsule.info({'name': capsule_vm.hostname})
+
+    if organization_ids:
+        # update the capsule with organization_ids and location_ids
+        if not location_ids:
+            location_ids.append(Location.info({'name': DEFAULT_LOC})['id'])
+
+        Capsule.update({
+            'id': capsule['id'],
+            'organization-ids': organization_ids,
+            'location-ids': location_ids
+        })
+
+    return capsule, capsule_org, capsule_lce

--- a/robottelo/config/settings.py
+++ b/robottelo/config/settings.py
@@ -253,6 +253,47 @@ class BugzillaSettings(FeatureSettings):
         return validation_errors
 
 
+class CapsuleSettings(FeatureSettings):
+    """Clients settings definitions."""
+
+    def __init__(self, *args, **kwargs):
+        super(CapsuleSettings, self).__init__(*args, **kwargs)
+        self.domain = None
+        self.instance_name = None
+        self.hash = None
+        self.ddns_package_url = None
+
+    def read(self, reader):
+        """Read clients settings."""
+        self.domain = reader.get('capsule', 'domain')
+        self.instance_name = reader.get('capsule', 'instance_name')
+        self.hash = reader.get('capsule', 'hash')
+        self.ddns_package_url = reader.get('capsule', 'ddns_package_url')
+
+    @property
+    def hostname(self):
+        if self.instance_name and self.domain:
+            return '{0}.{1}'.format(self.instance_name, self.domain)
+
+        return None
+
+    def validate(self):
+        """Validate capsule settings."""
+        validation_errors = []
+        if self.domain is None:
+            validation_errors.append(
+                '[capsule] domain option must be provided.')
+        if self.instance_name is None:
+            validation_errors.append(
+                '[capsule] instance_name option must be provided.')
+        if self.hash is None:
+            validation_errors.append('[capsule] hash option must be provided.')
+        if self.ddns_package_url is None:
+            validation_errors.append(
+                '[capsule] ddns_package_url option must be provided.')
+        return validation_errors
+
+
 class ClientsSettings(FeatureSettings):
     """Clients settings definitions."""
     def __init__(self, *args, **kwargs):
@@ -628,6 +669,7 @@ class Settings(object):
 
         self.bugzilla = BugzillaSettings()
         # Features
+        self.capsule = CapsuleSettings()
         self.clients = ClientsSettings()
         self.compute_resources = LibvirtHostSettings()
         self.discovery = DiscoveryISOSettings()

--- a/robottelo/constants.py
+++ b/robottelo/constants.py
@@ -175,6 +175,7 @@ CHECKSUM_TYPE = {
 PRDS = {
     'rhcf': 'Red Hat CloudForms',
     'rhel': 'Red Hat Enterprise Linux Server',
+    'rhsc': 'Red Hat Satellite Capsule',
 }
 
 REPOSET = {
@@ -183,12 +184,26 @@ REPOSET = {
     'rhva6': (
         'Red Hat Enterprise Virtualization Agents for RHEL 6 Server (RPMs)'
     ),
+    'rhsc7': 'Red Hat Satellite Capsule 6.2 (for RHEL 7 Server) (RPMs)',
+    'rhsc6': 'Red Hat Satellite Capsule 6.2 (for RHEL 6 Server) (RPMs)',
     'rhst7': 'Red Hat Satellite Tools 6.2 (for RHEL 7 Server) (RPMs)',
     'rhst6': 'Red Hat Satellite Tools 6.2 (for RHEL 6 Server) (RPMs)',
     'rhaht': 'Red Hat Enterprise Linux Atomic Host (Trees)'
 }
 
 REPOS = {
+    'rhsc7': {
+        'id': 'rhel-7-server-satellite-capsule-6.2-rpms',
+        'name': (
+            'Red Hat Satellite Capsule 6.2 for RHEL 7 Server RPMs x86_64'
+        ),
+    },
+    'rhsc6': {
+        'id': 'rhel-6-server-satellite-capsule-6.2-rpms',
+        'name': (
+            'Red Hat Satellite Capsule 6.2 for RHEL 6 Server RPMs x86_64'
+        ),
+    },
     'rhst7': {
         'id': 'rhel-7-server-satellite-tools-6.2-rpms',
         'name': (
@@ -228,6 +243,14 @@ PRD_SETS = {
         'releasever': u'6.7',
         'label': u'rhel-6-server-rpms'
     },
+    'rhel_68': {
+        'product': u'Red Hat Enterprise Linux Server',
+        'reposet': u'Red Hat Enterprise Linux 6 Server (RPMs)',
+        'reponame': u'Red Hat Enterprise Linux 6 Server RPMs x86_64 6.8',
+        'arch': u'x86_64',
+        'releasever': u'6.8',
+        'label': u'rhel-6-server-rpms'
+    },
     'rhel6_sat6tools': {
         'product': u'Red Hat Enterprise Linux Server',
         'reposet': u'Red Hat Satellite Tools 6.2 (for RHEL 6 Server) '
@@ -237,7 +260,15 @@ PRD_SETS = {
         'arch': u'x86_64',
         'releasever': None,
         'label': u'rhel-6-server-satellite-tools-6.2-rpms'
-    }
+    },
+    'rhel_72': {
+        'product': u'Red Hat Enterprise Linux Server',
+        'reposet': u'Red Hat Enterprise Linux 7 Server (RPMs)',
+        'reponame': u'Red Hat Enterprise Linux 7 Server RPMs x86_64 7.2',
+        'arch': u'x86_64',
+        'releasever': u'7.2',
+        'label': u'rhel-7-server-rpms'
+    },
 }
 
 RHEL_6_MAJOR_VERSION = 6
@@ -276,6 +307,8 @@ SAT6_TOOLS_TREE = [
     ('rhel', 'rhst6', 'rhst6', 'repo_arch', 'x86_64'),
     ('rhel', 'rhst6', 'rhst6', 'repo_ver', '6.2'),
 ]
+
+SATELLITE_FIREWALL_SERVICE_NAME = 'RH-Satellite-6'
 
 DEFAULT_ORG_ID = 1
 #: Name (not label!) of the default organization.

--- a/robottelo/vm_capsule.py
+++ b/robottelo/vm_capsule.py
@@ -1,0 +1,289 @@
+"""Virtual machine client provisioning with satellite capsule product setup"""
+import logging
+import time
+
+from robottelo import ssh
+from robottelo.config import settings
+from robottelo.constants import (
+    DISTRO_RHEL6,
+    DISTRO_RHEL7,
+    SATELLITE_FIREWALL_SERVICE_NAME,
+)
+from robottelo.cli.capsule import Capsule
+from robottelo.cli.factory import (
+    setup_capsule_virtual_machine,
+)
+from robottelo.cli.host import Host
+from robottelo.decorators import setting_is_set
+from robottelo.host_info import get_host_os_version
+from robottelo.vm import VirtualMachine
+
+logger = logging.getLogger(__name__)
+
+
+class CapsuleVirtualMachineError(Exception):
+    """Exception raised for failed capsule virtual machine operations"""
+
+
+class CapsuleVirtualMachine(VirtualMachine):
+    """Virtual machine client provisioning with satellite capsule product
+    setup
+    """
+
+    def __init__(
+            self, cpu=4, ram=16384, distro=None, provisioning_server=None,
+            image_dir=None, org_id=None, lce_id=None,
+            organization_ids=None, location_ids=None):
+        """Manage a virtual machine with satellite capsule product setup for
+        client provisioning.
+
+        :param int cpu: The number of CPUs usage.
+        :param int ram: the number of RAM usage in mega bytes.
+        :param str distro: The OS distro to use to provision the virtual
+         machine, it's also used in capsule setup to prepare the satellite
+         products content.
+        :param str provisioning_server: the provisioning server url
+        :param str image_dir: the images location path on the provisioning
+         server.
+        :param int org_id: The organization id used to subscribe the
+         virtual machine and to create the products contents that the virtual
+         machine will use to setup the capsule.
+        :param int lce_id: the lifecycle environment used for the subscription
+         of virtual machine
+        :param List[int] organization_ids: the organization ids of
+         organizations that will use the capsule.
+        :param List[int] location_ids: the location ids for which the content
+         will be synchronized.
+        """
+        # ensure that capsule configuration exist and validate
+        if not setting_is_set('capsule'):
+            raise CapsuleVirtualMachineError('capsule configuration not set')
+
+        if distro is None:
+            # use the same distro as satellite host server os
+            server_host_os_version = get_host_os_version()
+            if server_host_os_version.startswith('RHEL6'):
+                distro = DISTRO_RHEL6
+            elif server_host_os_version.startswith('RHEL7'):
+                distro = DISTRO_RHEL7
+            else:
+                raise CapsuleVirtualMachineError(
+                    'cannot find a default compatible distro to create'
+                    ' the virtual machine')
+
+        self._capsule_domain = settings.capsule.domain
+        self._capsule_instance_name = settings.capsule.instance_name
+        self._capsule_hostname_hash = settings.capsule.hash
+        self._capsule_hostname = settings.capsule.hostname
+        self._ddns_package_url = settings.capsule.ddns_package_url
+
+        super(CapsuleVirtualMachine, self).__init__(
+            cpu=cpu, ram=ram, distro=distro,
+            provisioning_server=provisioning_server, image_dir=image_dir,
+            hostname=self._capsule_hostname,
+            domain=self._capsule_domain,
+            target_image=self._capsule_instance_name
+        )
+
+        self._capsule_org_id = org_id
+        self._capsule_lce_id = lce_id
+        if organization_ids is None:
+            organization_ids = []
+        self._capsule_organization_ids = organization_ids
+        if location_ids is None:
+            location_ids = []
+        self._capsule_location_ids = location_ids
+        self._capsule = None
+        self._capsule_org = None
+        self._capsule_lce = None
+
+    @property
+    def hostname_local(self):
+        """The virtual machine local hostname from provisioning server"""
+        return '{0}.local'.format(self._target_image)
+
+    @property
+    def capsule_org(self):
+        return self._capsule_org
+
+    @property
+    def capsule(self):
+        return self._capsule
+
+    @property
+    def capsule_lce(self):
+        return self._capsule_lce
+
+    @property
+    def capsule_location_ids(self):
+        return self._capsule_location_ids
+
+    @property
+    def capsule_organization_ids(self):
+        return self._capsule_organization_ids
+
+    def _capsule_setup_ddns(self):
+        """Setup and configure ddns client and ensure it's functionality"""
+        self.run('yum localinstall -y {}'.format(self._ddns_package_url))
+        self.run(
+            'echo "{0} {1} {2}" >> /etc/redhat-internal-ddns/hosts'.format(
+                self._capsule_instance_name,
+                self._capsule_domain,
+                self._capsule_hostname_hash
+            )
+        )
+        self.run('echo "127.0.0.1 {} localhost" > /etc/hosts'.format(
+            self._capsule_hostname))
+        self.run('echo "{0} {1} {2}" >> /etc/hosts'.format(
+            self.ip_addr, self._capsule_hostname, self._capsule_instance_name))
+
+        if self.distro == DISTRO_RHEL7:
+            self.run('hostnamectl set-hostname {}'.format(
+                self._capsule_hostname))
+
+        self.run('redhat-internal-ddns-client.sh enable')
+        self.run('redhat-internal-ddns-client.sh update')
+
+        def ensure_host_resolved(
+                ssh_func, host_to_ping, ip_addr, time_sleep=60, retries=10):
+            resolved = False
+            retry_max_index = retries - 1
+            for retry_index in range(retries):
+                ssh_func_result = ssh_func('ping -c 1 {}'.format(host_to_ping))
+                ssh_func_output = ''.join(ssh_func_result.stdout)
+                if ssh_func_result.return_code == 0 and (
+                            '({})'.format(ip_addr) in ssh_func_output):
+                    resolved = True
+                    break
+
+                if retry_index != retry_max_index:
+                    # do not sleep at last index
+                    time.sleep(time_sleep)
+
+            return resolved
+
+        # Ensure capsule hostname is resolvable from the server host
+        hostname_resolved = ensure_host_resolved(
+            ssh.command, self._capsule_hostname, self.ip_addr)
+        if not hostname_resolved:
+            raise CapsuleVirtualMachineError(
+                'Failed to resolver the capsule hostname from the server')
+
+        # Ensure capsule hostname is resolvable at capsule host
+        hostname_resolved = ensure_host_resolved(
+            self.run, self._capsule_hostname, '127.0.0.1', retries=1)
+        if not hostname_resolved:
+            raise CapsuleVirtualMachineError(
+                'Failed to resolver the capsule hostname from capsule')
+
+        if self.distro == DISTRO_RHEL7:
+            # Add RH-Satellite-6 service to firewall public zone
+            self.run('firewall-cmd --zone=public --add-service={}'.format(
+                SATELLITE_FIREWALL_SERVICE_NAME))
+
+    def _capsule_cleanup(self):
+        """make the necessary cleanup in case of a crash"""
+        if self._subscribed:
+            self.unregister()
+
+        if self._capsule_hostname:
+            # do cleanup as using a static hostname that can be reused by
+            # other tests and organizations
+            try:
+                # try to delete the hostname first
+                Host.delete({'name': self._capsule_hostname})
+                # try delete the capsule
+                # note: if the host was not registered the capsule does not
+                # exist yet
+                Capsule.delete({'name': self._capsule_hostname})
+            except Exception as exp:
+                # do nothing, only log the exception
+                # as maybe that the host was not registered or setup does not
+                # reach that stage
+                # or maybe that the capsule was not registered or setup does
+                # not reach that stage
+                logger.error('Failed to cleanup the host: {0}\n{1}'.format(
+                    self.hostname, exp.message))
+
+    def _setup_capsule(self):
+        """Prepare the virtual machine to host a capsule node"""
+        # setup the ddns client to have a resolvable capsule hostname
+        self._capsule_setup_ddns()
+
+        setup_result = setup_capsule_virtual_machine(
+            self,
+            org_id=self._capsule_org_id,
+            lce_id=self._capsule_lce_id,
+            organization_ids=self._capsule_organization_ids,
+            location_ids=self._capsule_location_ids
+        )
+
+        self._capsule, self._capsule_org, self._capsule_lce = setup_result
+
+        self._capsule_org_id = self._capsule_org['id']
+        self._capsule_lce_id = self._capsule_lce['id']
+
+    def create(self):
+        super(CapsuleVirtualMachine, self).create()
+        try:
+            self._setup_capsule()
+        except:
+            # handle exception as VirtualMachine has no exception handling
+            # in __enter__ function
+            self._capsule_cleanup()
+            raise
+
+    def suspend(self, ensure=False):
+        """Suspend the virtual machine.
+
+        :param bool ensure: ensure that the virtual machine is unreachable
+
+        Notes:
+
+        1. The virtual machine will consume system RAM but not processor
+           resources. Disk and network I/O does not occur while the guest is
+           suspended.
+        2. This operation is immediate and the guest can be restarted with
+           resume.
+        """
+        result = ssh.command(
+            u'virsh suspend {0}'.format(self._target_image),
+            hostname=self.provisioning_server
+        )
+        suspended = True if result.return_code == 0 else False
+        if suspended and ensure:
+            # ping one time the virtual machine to ensure that it's unreachable
+            result = ssh.command(
+                'ping -c 1 {}'.format(self.hostname),
+                hostname=self.provisioning_server
+            )
+            suspended = True if result.return_code != 0 else False
+
+        return suspended
+
+    def resume(self, ensure=False):
+        """Restore from a suspended state
+
+        :param bool ensure: ensure that the virtual machine is reachable
+
+        Note: This operation is immediate
+        """
+        result = ssh.command(
+            u'virsh resume {0}'.format(self._target_image),
+            hostname=self.provisioning_server
+        )
+        resumed = True if result.return_code == 0 else False
+        if resumed and ensure:
+            # ping one time the virtual machine to ensure that it's reachable
+            result = ssh.command(
+                'ping -c 1 {}'.format(self.hostname),
+                hostname=self.provisioning_server
+            )
+            resumed = True if result.return_code == 0 else False
+
+        return resumed
+
+    def destroy(self):
+        """Destroys the virtual machine on the provisioning server"""
+        self._capsule_cleanup()
+        super(CapsuleVirtualMachine, self).destroy()

--- a/tests/foreman/cli/test_contentview.py
+++ b/tests/foreman/cli/test_contentview.py
@@ -17,8 +17,10 @@
 import random
 
 from fauxfactory import gen_alphanumeric, gen_string
+
 from robottelo import manifests, ssh
 from robottelo.cli.base import CLIReturnCodeError
+from robottelo.cli.capsule import Capsule
 from robottelo.cli.contentview import ContentView
 from robottelo.cli.factory import (
     CLIFactoryError,
@@ -31,9 +33,9 @@ from robottelo.cli.factory import (
     make_repository,
     make_user,
 )
+from robottelo.cli.puppetmodule import PuppetModule
 from robottelo.cli.repository import Repository
 from robottelo.cli.repository_set import RepositorySet
-from robottelo.cli.puppetmodule import PuppetModule
 from robottelo.cli.subscription import Subscription
 from robottelo.constants import (
     CUSTOM_PUPPET_REPO,
@@ -59,6 +61,7 @@ from robottelo.decorators import (
 )
 from robottelo.ssh import upload_file
 from robottelo.test import CLITestCase
+from robottelo.vm_capsule import CapsuleVirtualMachine
 
 
 class ContentViewTestCase(CLITestCase):
@@ -2949,7 +2952,7 @@ class ContentViewTestCase(CLITestCase):
         @CaseLevel: System
         """
 
-    @stubbed()
+    @run_in_one_thread
     @run_only_on('sat')
     @tier3
     def test_positive_remove_cv_version_from_multi_env_capsule_scenario(self):
@@ -2986,6 +2989,174 @@ class ContentViewTestCase(CLITestCase):
         """
         # Note: This test case requires complete external capsule
         #  configuration.
+        org = make_org()
+        dev_env = make_lifecycle_environment({
+            'organization-id': org['id']
+        })
+        qe_env = make_lifecycle_environment({
+            'organization-id': org['id'],
+            'prior': dev_env['name'],
+        })
+        prod_env = make_lifecycle_environment({
+            'organization-id': org['id'],
+            'prior': qe_env['name'],
+        })
+        with CapsuleVirtualMachine(organization_ids=[org['id']]) as capsule_vm:
+            capsule = capsule_vm.capsule
+            # Add all environments to capsule
+            environments = {ENVIRONMENT, dev_env['name'], qe_env['name'],
+                            prod_env['name']}
+            for env_name in environments:
+                Capsule.content_add_lifecycle_environment({
+                    'id': capsule['id'],
+                    'organization-id': org['id'],
+                    'environment': env_name
+                })
+            capsule_environments = Capsule.content_lifecycle_environments({
+                'id': capsule['id'],
+                'organization-id': org['id']
+            })
+            capsule_environments_names = {
+                env['name'] for env in capsule_environments}
+            self.assertEqual(environments, capsule_environments_names)
+            # Setup a yum repo
+            custom_yum_product = make_product({'organization-id': org['id']})
+            custom_yum_repo = make_repository({
+                'content-type': 'yum',
+                'product-id': custom_yum_product['id'],
+                'url': FAKE_1_YUM_REPO,
+            })
+            Repository.synchronize({'id': custom_yum_repo['id']})
+            # Setup a puppet repo
+            puppet_product = make_product({'organization-id': org['id']})
+            puppet_repository = make_repository({
+                'content-type': 'puppet',
+                'product-id': puppet_product['id'],
+                'url': FAKE_0_PUPPET_REPO,
+            })
+            Repository.synchronize({'id': puppet_repository['id']})
+            puppet_modules = PuppetModule.list({
+                'repository-id': puppet_repository['id'],
+                'per-page': False,
+            })
+            self.assertGreater(len(puppet_modules), 0)
+            puppet_module = puppet_modules[0]
+            # Setup a docker repo
+            docker_product = make_product({'organization-id': org['id']})
+            docker_repository = make_repository({
+                'content-type': 'docker',
+                'docker-upstream-name': 'busybox',
+                'name': gen_string('alpha', 20),
+                'product-id': docker_product['id'],
+                'url': DOCKER_REGISTRY_HUB,
+            })
+            content_view = make_content_view({'organization-id': org['id']})
+            # Associate the yum repository to content view
+            ContentView.add_repository({
+                'id': content_view['id'],
+                'organization-id': org['id'],
+                'repository-id': custom_yum_repo['id'],
+            })
+            # Associate the puppet module to content view
+            ContentView.puppet_module_add({
+                'content-view-id': content_view['id'],
+                'uuid': puppet_module['uuid'],
+            })
+            # Associate the docker repository to content view
+            ContentView.add_repository({
+                'id': content_view['id'],
+                'repository-id': docker_repository['id'],
+            })
+            # Publish the content view
+            ContentView.publish({'id': content_view['id']})
+            content_view_version = ContentView.info(
+                {'id': content_view['id']}
+            )['versions'][-1]
+            # Promote the content view to DEV, QE, PROD
+            for env in [dev_env, qe_env, prod_env]:
+                ContentView.version_promote({
+                    'id': content_view_version['id'],
+                    'organization-id': org['id'],
+                    'to-lifecycle-environment-id': env['id'],
+                })
+            # Synchronize the capsule content
+            Capsule.content_synchronize({
+                'id': capsule['id'],
+                'organization-id': org['id'],
+            })
+            capsule_content_info = Capsule.content_info({
+                'id': capsule['id'],
+                'organization-id': org['id']
+            })
+            # Ensure that all environments exists in capsule content
+            capsule_content_info_lces = capsule_content_info[
+                'lifecycle-environments']
+            capsule_content_lce_names = {
+                lce['name']
+                for lce in capsule_content_info_lces.values()
+                }
+            self.assertEqual(environments, capsule_content_lce_names)
+            # Ensure first that the content view exit in all capsule
+            # environments
+            for capsule_content_info_lce in capsule_content_info_lces.values():
+                self.assertIn('content-views', capsule_content_info_lce)
+                # Retrieve the content views info of this lce
+                capsule_content_info_lce_cvs = list(capsule_content_info_lce[
+                    'content-views'].values())
+                # Get the content views names of this lce
+                capsule_content_info_lce_cvs_names = [
+                    cv['name']['name'] for cv in capsule_content_info_lce_cvs]
+                cv_count = 1
+                if capsule_content_info_lce['name'] == ENVIRONMENT:
+                    # There is a Default Organization View in addition
+                    cv_count = 2
+                self.assertEqual(len(capsule_content_info_lce_cvs), cv_count)
+                self.assertIn(content_view['name'],
+                              capsule_content_info_lce_cvs_names)
+            # Suspend the capsule with ensure True to ping the virtual machine
+            suspended = capsule_vm.suspend(ensure=True)
+            self.assertTrue(suspended)
+            # Remove the content view version from Library and DEV environments
+            for lce_name in [ENVIRONMENT, dev_env['name']]:
+                ContentView.remove_from_environment({
+                    'id': content_view['id'],
+                    'organization-id': org['id'],
+                    'lifecycle-environment': lce_name
+                })
+            # Assert that the content view version does not exit in Library and
+            # DEV and exist only in QE and PROD
+            environments_with_cv = {qe_env['name'], prod_env['name']}
+            self.assertEqual(
+                environments_with_cv,
+                self._get_content_view_version_lce_names_set(
+                    content_view['id'],
+                    content_view_version['id']
+                )
+            )
+            # Resume the capsule with ensure True to ping the virtual machine
+            resumed = capsule_vm.resume(ensure=True)
+            self.assertTrue(resumed)
+            # Assert that in capsule content the content view version
+            # does not exit in Library and DEV and exist only in QE and PROD
+            capsule_content_info = Capsule.content_info({
+                'id': capsule['id'],
+                'organization-id': org['id']
+            })
+            capsule_content_info_lces = capsule_content_info[
+                'lifecycle-environments']
+            for capsule_content_info_lce in capsule_content_info_lces.values():
+                # retrieve the content views info of this lce
+                capsule_content_info_lce_cvs = capsule_content_info_lce.get(
+                    'content-views', {}).values()
+                # get the content views names of this lce
+                capsule_content_info_lce_cvs_names = [
+                    cv['name']['name'] for cv in capsule_content_info_lce_cvs]
+                if capsule_content_info_lce['name'] in environments_with_cv:
+                    self.assertIn(content_view['name'],
+                                  capsule_content_info_lce_cvs_names)
+                else:
+                    self.assertNotIn(content_view['name'],
+                                     capsule_content_info_lce_cvs_names)
 
     # ROLES TESTING
 


### PR DESCRIPTION
issue : https://github.com/SatelliteQE/robottelo/issues/4101
https://github.com/SatelliteQE/robottelo-ci/pull/513

capsule: config data: http://pastebin.test.redhat.com/458978 

test implemented :  **cli/test_contentview.test_positive_remove_cv_version_from_multi_env_capsule_scenario**

**SAT running on rhel7, VM distro DISTRO_RHEL7:**
full test log :  http://pastebin.test.redhat.com/459338
```console
(sat-6.2.z) dlezz@elysion:~/projects/robottelo-fork$ py.test tests/foreman/cli/test_contentview.py -v -k "test_positive_remove_cv_version_from_multi_env_capsule_scenario"
================================================= test session starts ==================================================
platform linux2 -- Python 2.7.13, pytest-2.9.2, py-1.4.32, pluggy-0.3.1 -- /home/dlezz/.pyenv/versions/sat-6.2.z/bin/python
cachedir: .cache
rootdir: /home/dlezz/projects/robottelo-fork, inifile: 
plugins: cov-2.3.1
collected 61 items 
2017-02-27 10:19:43 - conftest - DEBUG - Found WONTFIX in decorated tests ['1269196', '1103157', '1156555', '1230902', '1245334', '1204686', '1267224', '1226425', '1217635', '1079482', '1214312']

2017-02-27 10:19:43 - conftest - DEBUG - Collected 61 test cases


tests/foreman/cli/test_contentview.py::ContentViewTestCase::test_positive_remove_cv_version_from_multi_env_capsule_scenario <- robottelo/decorators/__init__.py PASSED

============== 60 tests deselected by '-ktest_positive_remove_cv_version_from_multi_env_capsule_scenario' ==============
====================================== 1 passed, 60 deselected in 1828.63 seconds ======================================
(sat-6.2.z) dlezz@elysion:~/projects/robottelo-fork$ 
```
**SAT running on rhel7, VM distro DISTRO_RHEL6**
full test log : http://pastebin.test.redhat.com/459385
```console
(sat-6.2.z) dlezz@elysion:~/projects/robottelo-fork$ py.test tests/foreman/cli/test_contentview.py -v -k "test_positive_remove_cv_version_from_multi_env_capsule_scenario"
================================================= test session starts ==================================================
platform linux2 -- Python 2.7.13, pytest-2.9.2, py-1.4.32, pluggy-0.3.1 -- /home/dlezz/.pyenv/versions/sat-6.2.z/bin/python
cachedir: .cache
rootdir: /home/dlezz/projects/robottelo-fork, inifile: 
plugins: cov-2.3.1
collected 61 items 
2017-02-27 11:42:37 - conftest - DEBUG - Found WONTFIX in decorated tests ['1269196', '1103157', '1156555', '1230902', '1245334', '1204686', '1267224', '1226425', '1217635', '1079482', '1214312']

2017-02-27 11:42:37 - conftest - DEBUG - Collected 61 test cases


tests/foreman/cli/test_contentview.py::ContentViewTestCase::test_positive_remove_cv_version_from_multi_env_capsule_scenario <- robottelo/decorators/__init__.py PASSED

============== 60 tests deselected by '-ktest_positive_remove_cv_version_from_multi_env_capsule_scenario' ==============
====================================== 1 passed, 60 deselected in 4498.65 seconds ======================================
(sat-6.2.z) dlezz@elysion:~/projects/robottelo-fork$ 
```
**SAT running on rhel6, VM distro DISTRO_RHEL6**
full test log : http://pastebin.test.redhat.com/459593
```console
(sat-6.2.z) dlezz@elysion:~/projects/robottelo-fork$ py.test tests/foreman/cli/test_contentview.py -v -k "test_positive_remove_cv_version_from_multi_env_capsule_scenario"
================================================= test session starts ==================================================
platform linux2 -- Python 2.7.13, pytest-2.9.2, py-1.4.32, pluggy-0.3.1 -- /home/dlezz/.pyenv/versions/sat-6.2.z/bin/python
cachedir: .cache
rootdir: /home/dlezz/projects/robottelo-fork, inifile: 
plugins: cov-2.3.1
collected 61 items 
2017-02-27 18:53:04 - conftest - DEBUG - Found WONTFIX in decorated tests ['1269196', '1103157', '1156555', '1230902', '1245334', '1204686', '1267224', '1226425', '1217635', '1079482', '1214312']

2017-02-27 18:53:04 - conftest - DEBUG - Collected 61 test cases


tests/foreman/cli/test_contentview.py::ContentViewTestCase::test_positive_remove_cv_version_from_multi_env_capsule_scenario <- robottelo/decorators/__init__.py PASSED

============== 60 tests deselected by '-ktest_positive_remove_cv_version_from_multi_env_capsule_scenario' ==============
====================================== 1 passed, 60 deselected in 6486.58 seconds ======================================
```

**SAT running on rhel6, VM distro DISTRO_RHEL7**
full test log : http://pastebin.test.redhat.com/459765
```console
(sat-6.2.z) dlezz@elysion:~/projects/robottelo-fork$ py.test tests/foreman/cli/test_contentview.py -v -k "test_positive_remove_cv_version_from_multi_env_capsule_scenario"
================================================= test session starts ==================================================
platform linux2 -- Python 2.7.13, pytest-2.9.2, py-1.4.32, pluggy-0.3.1 -- /home/dlezz/.pyenv/versions/sat-6.2.z/bin/python
cachedir: .cache
rootdir: /home/dlezz/projects/robottelo-fork, inifile: 
plugins: cov-2.3.1
collected 61 items 
2017-02-27 20:44:28 - conftest - DEBUG - Found WONTFIX in decorated tests ['1269196', '1103157', '1156555', '1230902', '1245334', '1204686', '1267224', '1226425', '1217635', '1079482', '1214312']

2017-02-27 20:44:28 - conftest - DEBUG - Collected 61 test cases


tests/foreman/cli/test_contentview.py::ContentViewTestCase::test_positive_remove_cv_version_from_multi_env_capsule_scenario <- robottelo/decorators/__init__.py PASSED

============== 60 tests deselected by '-ktest_positive_remove_cv_version_from_multi_env_capsule_scenario' ==============
====================================== 1 passed, 60 deselected in 3593.69 seconds ======================================
```