### PR TITLE
[6.2.z] Cherry-pick - Add tests for role clone / automate BZ 1353788

### DIFF
--- a/robottelo/ui/locators.py
+++ b/robottelo/ui/locators.py
@@ -1704,6 +1704,7 @@ locators = LocatorDict({
          "a[contains(@data-id, 'refresh')]")),
     # Roles
     "roles.new": (By.XPATH, "//a[contains(@href, '/roles/new')]"),
+    "roles.clone": (By.XPATH, "//a[contains(@data-id, 'clone')]"),
     "roles.name": (By.ID, "role_name"),
     "roles.dropdown": (
         By.XPATH,
@@ -1722,6 +1723,16 @@ locators = LocatorDict({
                           "//input[@placeholder='Filter permissions']"),
     "roles.perm_type": (By.XPATH, "//label[contains(., '%s')]"),
     "roles.permission": (By.XPATH, "//input[@value='%s']"),
+    "roles.resources": (
+        By.XPATH, "//table[contains(@id, 'DataTables_Table')]/tbody/tr/td[1]"),
+    "roles.permissions": (
+        By.XPATH, "//td[contains(text(), '%s')]/following-sibling::td[1]"),
+    "roles.filters.pagination_next": (
+        By.XPATH,
+        "//li[contains(@class, 'next') and "
+        "not(contains(@class, 'disabled'))]/a"
+    ),
+    "roles.filters.search": (By.XPATH, "//input[@type='search']"),
 
     # Architecture
     "arch.new": (By.XPATH, "//a[contains(@href, '/architectures/new')]"),

--- a/robottelo/ui/locators.py
+++ b/robottelo/ui/locators.py
@@ -501,6 +501,9 @@ tab_locators = LocatorDict({
         "//a[@data-toggle='tab' and contains(@href,'params')]"),
 
     # Roles
+    # Second level UI
+    "roles.tab_role": (By.XPATH, "//a[@href='#primary']"),
+    "roles.tab_filters": (By.XPATH, "//a[@href='#filters']"),
     # Third level UI
     "roles.tab_filter": (
         By.XPATH, "//a[@href='#primary']"),
@@ -1732,7 +1735,9 @@ locators = LocatorDict({
         "//li[contains(@class, 'next') and "
         "not(contains(@class, 'disabled'))]/a"
     ),
-    "roles.filters.search": (By.XPATH, "//input[@type='search']"),
+    "roles.filters.search": (
+        By.XPATH,
+        "//input[contains(@aria-controls, 'DataTables') and @type='text']"),
 
     # Architecture
     "arch.new": (By.XPATH, "//a[contains(@href, '/architectures/new')]"),

--- a/robottelo/ui/role.py
+++ b/robottelo/ui/role.py
@@ -99,8 +99,8 @@ class Role(Base):
         dict_permissions = {}
         for res_type in resource_types:
             self.assign_value(locators["roles.filters.search"], res_type)
-            permissions = self.wait_until_element(
-                locators['roles.permissions'] % res_type)
+            strategy, value = locators['roles.permissions']
+            permissions = self.wait_until_element((strategy, value % res_type))
             if permissions:
                 dict_permissions[res_type] = permissions.text.split(', ')
         return dict_permissions
@@ -108,7 +108,8 @@ class Role(Base):
     def clone(self, name, new_name, locations=None, organizations=None):
         """Clone role with name/location/organization."""
         self.search(name)
-        self.click(locators['roles.dropdown'] % name)
+        strategy, value = locators['roles.dropdown']
+        self.click((strategy, value % name))
         self.click(locators['roles.clone'])
         self.assign_value(locators['roles.name'], new_name)
         if locations or organizations:

--- a/tests/foreman/ui/test_role.py
+++ b/tests/foreman/ui/test_role.py
@@ -21,10 +21,10 @@ from fauxfactory import gen_string
 from nailgun import entities
 from robottelo.constants import ROLES
 from robottelo.datafactory import generate_strings_list, invalid_values_list
-from robottelo.decorators import tier1
+from robottelo.decorators import tier1, skip_if_bug_open
 from robottelo.test import UITestCase
-from robottelo.ui.factory import make_domain, make_role, make_user, set_context
-from robottelo.ui.locators import common_locators, menu_locators, tab_locators
+from robottelo.ui.factory import make_role, make_user
+from robottelo.ui.locators import common_locators, tab_locators
 from robottelo.ui.session import Session
 
 
@@ -120,6 +120,7 @@ class RoleTestCase(UITestCase):
             self.assertEqual(
                 set(permissions), set(assigned_permissions[resource_type]))
 
+    @skip_if_bug_open('bugzilla', 1353788)
     @tier1
     def test_positive_clone_builtin(self):
         """Clone one of the builtin roles
@@ -153,6 +154,7 @@ class RoleTestCase(UITestCase):
                     "Permissions differs for {0} resource type".format(key)
                 )
 
+    @skip_if_bug_open('bugzilla', 1353788)
     @tier1
     def test_positive_clone_custom(self):
         """Create custom role with permissions and clone it
@@ -169,8 +171,11 @@ class RoleTestCase(UITestCase):
         with Session(self.browser) as session:
             # Create custom role with permissions
             make_role(session, name=name)
-            self.role.add_permission(
-                name, resource_type=resource_type, permission_list=permissions,
+            self.role.update(
+                name,
+                add_permission=True,
+                resource_type=resource_type,
+                permission_list=permissions,
             )
             self.assertIsNotNone(self.role.search(name))
             # Clone role
@@ -189,6 +194,7 @@ class RoleTestCase(UITestCase):
             self.assertEqual(
                 set(permissions), set(cloned_permissions[resource_type]))
 
+    @skip_if_bug_open('bugzilla', 1353788)
     @tier1
     def test_positive_assign_cloned_role(self):
         """Clone role and assign it to user
@@ -213,6 +219,7 @@ class RoleTestCase(UITestCase):
                 common_locators['entity_deselect'] % role_name)
             self.assertIsNotNone(element)
 
+    @skip_if_bug_open('bugzilla', 1353788)
     @tier1
     def test_positive_delete_cloned(self):
         """Delete cloned role


### PR DESCRIPTION
Cherry-pick of #4293 with some changes specific for 6.2

https://bugzilla.redhat.com/show_bug.cgi?id=1353788
Bug still in POST for 6.2, so tests are skipped with decorator.

```python
% py.test -n 2 -v tests/foreman/ui/test_role.py -k 'RoleTestCase and (clone or update_permission) and not Canned'
===================================================================== test session starts =====================================================================
platform linux2 -- Python 2.7.12, pytest-2.9.2, py-1.4.31, pluggy-0.3.1 -- /home/qui/code/venv/6.2.z/bin/python2

tests/foreman/ui/test_role.py::RoleTestCase::test_positive_clone_builtin <- robottelo/decorators/__init__.py 
tests/foreman/ui/test_role.py::RoleTestCase::test_positive_assign_cloned_role <- robottelo/decorators/__init__.py 
[gw1] SKIPPED tests/foreman/ui/test_role.py::RoleTestCase::test_positive_assign_cloned_role <- robottelo/decorators/__init__.py 
tests/foreman/ui/test_role.py::RoleTestCase::test_positive_clone_custom <- robottelo/decorators/__init__.py 
[gw0] SKIPPED tests/foreman/ui/test_role.py::RoleTestCase::test_positive_clone_builtin <- robottelo/decorators/__init__.py 
[gw1] SKIPPED tests/foreman/ui/test_role.py::RoleTestCase::test_positive_clone_custom <- robottelo/decorators/__init__.py 
tests/foreman/ui/test_role.py::RoleTestCase::test_positive_update_permission 
tests/foreman/ui/test_role.py::RoleTestCase::test_positive_delete_cloned <- robottelo/decorators/__init__.py 
[gw0] SKIPPED tests/foreman/ui/test_role.py::RoleTestCase::test_positive_delete_cloned <- robottelo/decorators/__init__.py 
[gw1] PASSED tests/foreman/ui/test_role.py::RoleTestCase::test_positive_update_permission 

============================================================ 1 passed, 4 skipped in 76.12 seconds =============================================================
```