### PR TITLE
[6.2.z][Cherry-pick] Added UI Content View test to automate BZ1317828

### DIFF
--- a/tests/foreman/ui/test_contentview.py
+++ b/tests/foreman/ui/test_contentview.py
@@ -20,7 +20,7 @@ Feature details: https://fedorahosted.org/katello/wiki/ContentViews
 """
 
 from fauxfactory import gen_string
-from nailgun import entities
+from nailgun import entities, entity_mixins
 from robottelo.api.utils import enable_rhrepo_and_fetchid, upload_manifest
 from robottelo import manifests
 from robottelo.api.utils import get_role_by_bz
@@ -59,7 +59,7 @@ from robottelo.decorators import (
 from robottelo.helpers import read_data_file
 from robottelo.ui.base import UIError
 from robottelo.ui.factory import make_contentview, make_lifecycle_environment
-from robottelo.ui.locators import common_locators, locators
+from robottelo.ui.locators import common_locators, locators, tab_locators
 from robottelo.ui.session import Session
 from robottelo.test import UITestCase
 
@@ -106,8 +106,13 @@ class ContentViewTestCase(UITestCase):
                 reposet=rh_repo['reposet'],
                 releasever=rh_repo['releasever'],
             )
+        old_task_timeout = entity_mixins.TASK_TIMEOUT
+        # Update timeout to 10 minutes to finish sync
+        entity_mixins.TASK_TIMEOUT = 600
         # Sync repository
         entities.Repository(id=repo_id).sync()
+        entity_mixins.TASK_TIMEOUT = old_task_timeout
+        return repo_id
 
     def _get_cv_version_environments(self, cv_version):
         """Return the list of environments promoted to the version of content
@@ -2176,8 +2181,8 @@ class ContentViewTestCase(UITestCase):
         @CaseLevel: Integration
         """
 
-    @stubbed()
     @run_only_on('sat')
+    @skip_if_bug_open('bugzilla', 1426687)
     @tier2
     def test_negative_readonly_user_add_remove_repo(self):
         """Attempt to add and remove content view's yum and docker repositories
@@ -2197,7 +2202,7 @@ class ContentViewTestCase(UITestCase):
 
         @CaseLevel: Integration
 
-        @BZ: 1317828
+        @BZ: 1426687
         """
         user_login = gen_string('alpha')
         user_password = gen_string('alphanumeric')
@@ -2276,6 +2281,7 @@ class ContentViewTestCase(UITestCase):
                             )
                         )
 
+    @stubbed
     @run_only_on('sat')
     @tier2
     def test_negative_non_admin_user_actions(self):

--- a/tests/foreman/ui/test_contentview.py
+++ b/tests/foreman/ui/test_contentview.py
@@ -2245,9 +2245,8 @@ class ContentViewTestCase(UITestCase):
             repository=[docker_repo, yum_repo],
         ).create()
         # Log in as readonly user
-        with Session(self.browser, user_login, user_password) as session:
+        with Session(self.browser, user_login, user_password):
             # Open the content view
-            session.nav.go_to_content_views()
             cv = self.content_views.search(content_view.name)
             self.assertIsNotNone(cv)
             self.content_views.click(cv)

--- a/tests/foreman/ui/test_contentview.py
+++ b/tests/foreman/ui/test_contentview.py
@@ -2179,6 +2179,106 @@ class ContentViewTestCase(UITestCase):
     @stubbed()
     @run_only_on('sat')
     @tier2
+    def test_negative_readonly_user_add_remove_repo(self):
+        """Attempt to add and remove content view's yum and docker repositories
+        as a readonly user
+
+        @id: 907bf51f-8ebc-420e-b594-af0dc823e5b4
+
+        @Setup:
+
+        1. Create a user with the Content View read-only role
+        2. Create a content view
+        3. Add custom yum and docker repositories to content view
+
+        @Assert: User with read-only role for content view can not see 'Add'/
+        'Remove' repositories tabs as well as 'Add repository' and 'Remove
+        repository' buttons
+
+        @CaseLevel: Integration
+
+        @BZ: 1317828
+        """
+        user_login = gen_string('alpha')
+        user_password = gen_string('alphanumeric')
+        # Create a role with content views read only permissions
+        role = entities.Role().create()
+        for resource_type, perm_name in (
+                ('Host', 'view_hosts'),
+                ('Katello::ContentView', 'promote_or_remove_content_views'),
+                ('Katello::ContentView', 'publish_content_views'),
+                ('Katello::ContentView', 'view_content_views'),
+                ('Katello::Product', 'view_products'),
+        ):
+            # Permission search doesn't filter permissions by name. Filtering
+            # them by resource type and looking for one with specific name
+            # instead
+            perms_list = entities.Permission(
+                resource_type=resource_type).search(query={'per_page': 100000})
+            desired_perm = next(
+                perm for perm in perms_list if perm.name == perm_name)
+            entities.Filter(
+                organization=[self.organization],
+                permission=[desired_perm],
+                role=role,
+            ).create()
+        # Create a user and assign the above created role
+        entities.User(
+            default_organization=self.organization,
+            organization=[self.organization],
+            role=[role],
+            login=user_login,
+            password=user_password,
+        ).create()
+        # Create yum and docker repositories
+        repo_id = self.setup_to_create_cv()
+        yum_repo = entities.Repository(id=repo_id).read()
+        docker_repo = entities.Repository(
+            content_type=REPO_TYPE['docker'],
+            docker_upstream_name=DOCKER_UPSTREAM_NAME,
+            product=entities.Product(organization=self.organization).create(),
+            url=DOCKER_REGISTRY_HUB,
+        ).create()
+        # Create a content view
+        content_view = entities.ContentView(
+            organization=self.organization,
+            repository=[docker_repo, yum_repo],
+        ).create()
+        # Log in as readonly user
+        with Session(self.browser, user_login, user_password) as session:
+            # Open the content view
+            session.nav.go_to_content_views()
+            cv = self.content_views.search(content_view.name)
+            self.assertIsNotNone(cv)
+            self.content_views.click(cv)
+            # Ensure 'Add'/'Remove' tabs and buttons are absent for both docker
+            # and yum repos
+            for tab in 'docker', 'yum':
+                with self.subTest(tab):
+                    if tab == 'docker':
+                        self.content_views.click(
+                            tab_locators['contentviews.tab_docker_content'])
+                    elif tab == 'yum':
+                        self.content_views.click(
+                            tab_locators['contentviews.tab_content'])
+                        self.content_views.click(
+                            locators['contentviews.content_repo'])
+
+                    for element_locator in (
+                        tab_locators['contentviews.tab_repo_add'],
+                        tab_locators['contentviews.tab_repo_remove'],
+                        locators['contentviews.add_repo'],
+                        locators['contentviews.remove_repo'],
+                    ):
+                        self.assertIsNone(
+                            self.content_views.wait_until_element(
+                                element_locator,
+                                timeout=1,
+                            )
+                        )
+
+    @run_only_on('sat')
+    @tier2
     def test_negative_non_admin_user_actions(self):
         # Note:
         # Obviously all of this stuff should work with 'admin' user


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1426687
```python
py.test tests/foreman/ui/test_contentview.py -k test_negative_readonly_user_add_remove_repo
============================= test session starts ==============================
platform darwin -- Python 2.7.13, pytest-2.9.2, py-1.4.32, pluggy-0.3.1
rootdir: /Users/andrii/workspace/robottelo, inifile:
plugins: xdist-1.15.0, cov-2.3.1
collected 82 items
2017-02-24 17:35:21 - conftest - DEBUG - Found WONTFIX in decorated tests ['1269


6.2.z specific changes to backport the test
196', '1103157', '1156555', '1230902', '1245334', '1204686', '1267224', '1226425', '1217635', '1079482', '1214312']

2017-02-24 17:35:21 - conftest - DEBUG - Collected 82 test cases


tests/foreman/ui/test_contentview.py s

==== 81 tests deselected by '-ktest_negative_readonly_user_add_remove_repo' ====
================== 1 skipped, 81 deselected in 14.97 seconds ===================
```