### PR TITLE
Update host/with_image tests.

### DIFF
--- a/tests/foreman/api/test_host.py
+++ b/tests/foreman/api/test_host.py
@@ -534,6 +534,7 @@ class HostTestCase(APITestCase):
         host = entities.Host(
             organization=self.org,
             location=self.loc,
+            compute_resource=self.compresource_libvirt,
             image=self.image,
         ).create()
         self.assertEqual(host.image.id, self.image.id)
@@ -1094,6 +1095,11 @@ class HostTestCase(APITestCase):
         @CaseLevel: Integration
         """
         host = entities.Host(organization=self.org, location=self.loc).create()
+        host = entities.Host(
+            organization=self.org,
+            location=self.loc,
+            compute_resource=self.compresource_libvirt,
+        ).create()
         self.assertIsNone(host.image)
         host.image = self.image
         host = host.update(['image'])


### PR DESCRIPTION
Depends on SatelliteQE/nailgun#383

```python
% py.test tests/foreman/api/test_host.py -k 'image'
===================================================================== test session starts =====================================================================
platform linux2 -- Python 2.7.12, pytest-2.9.2, py-1.4.32, pluggy-0.3.1
2017-02-27 15:28:31 - conftest - DEBUG - Collected 61 test cases

tests/foreman/api/test_host.py ..

============================================================== 59 tests deselected by '-kimage' ===============================================================
========================================================== 2 passed, 59 deselected in 91.30 seconds ===========================================================
```