### PR TITLE
Implemented custom assertNotRaises and assertNotRaisesRegex assertions

### DIFF
--- a/tests/foreman/api/test_host.py
+++ b/tests/foreman/api/test_host.py
@@ -1501,14 +1501,8 @@ class HostInterfaceTestCase(APITestCase):
         )
         with self.assertRaises(HTTPError):
             primary_interface.delete()
-        # mark the test as failed instead of errored in case of 404 error
-        try:
+        with self.assertNotRaises(HTTPError, http_status_code=404):
             primary_interface.read()
-        except HTTPError as error:
-            if error.response.status_code == 404:
-                self.fail('Primary interface was removed')
-            else:
-                raise
 
     @tier1
     def test_positive_delete_and_check_host(self):
@@ -1526,11 +1520,5 @@ class HostInterfaceTestCase(APITestCase):
         interface.delete()
         with self.assertRaises(HTTPError):
             interface.read()
-        # mark the test as failed instead of errored in case of 404 error
-        try:
+        with self.assertNotRaises(HTTPError, http_status_code=404):
             host.read()
-        except HTTPError as error:
-            if error.response.status_code == 404:
-                self.fail('Interface deletion removed the host itself')
-            else:
-                raise

--- a/tests/foreman/api/test_host.py
+++ b/tests/foreman/api/test_host.py
@@ -1501,7 +1501,7 @@ class HostInterfaceTestCase(APITestCase):
         )
         with self.assertRaises(HTTPError):
             primary_interface.delete()
-        with self.assertNotRaises(HTTPError, http_status_code=404):
+        with self.assertNotRaises(HTTPError, expected_value=404):
             primary_interface.read()
 
     @tier1
@@ -1520,5 +1520,5 @@ class HostInterfaceTestCase(APITestCase):
         interface.delete()
         with self.assertRaises(HTTPError):
             interface.read()
-        with self.assertNotRaises(HTTPError, http_status_code=404):
+        with self.assertNotRaises(HTTPError, expected_value=404):
             host.read()

--- a/tests/robottelo/test_assertions.py
+++ b/tests/robottelo/test_assertions.py
@@ -3,7 +3,7 @@
 from collections import namedtuple
 from requests import HTTPError
 from robottelo.cli.base import CLIReturnCodeError
-from robottelo.test import TestCase
+from robottelo.test import APITestCase, CLITestCase
 
 
 def fake_128_return_code():
@@ -46,8 +46,10 @@ def fake_200_response():
     return response
 
 
-class AssertNotRaisesTestCase(TestCase):
-    """Tests for :meth:`robottelo.test.TestCase.assertNotRaises`."""
+class APIAssertNotRaisesTestCase(APITestCase):
+    """Generic and API specific tests for
+    :meth:`robottelo.test.TestCase.assertNotRaises`.
+    """
 
     @classmethod
     def setUpClass(cls):
@@ -90,41 +92,23 @@ class AssertNotRaisesTestCase(TestCase):
             with self.assertNotRaises(HTTPError):
                 fake_404_response()
 
-    def test_positive_api_raised_callable_with_status_code(self):
+    def test_positive_raised_callable_with_status_code(self):
         """Assert that the test will fail (not marked as errored) in case
         expected exception with expected http_status_code was risen inside
         :meth:`robottelo.test.TestCase.assertNotRaises` call.
         """
         with self.assertRaises(AssertionError):
             self.assertNotRaises(
-                HTTPError, fake_404_response, http_status_code=404)
+                HTTPError, fake_404_response, expected_value=404)
 
-    def test_positive_api_raised_context_manager_with_status_code(self):
+    def test_positive_raised_context_manager_with_status_code(self):
         """Assert that the test will fail (not marked as errored) in case
         expected exception with expected http_status_code was risen inside
         :meth:`robottelo.test.TestCase.assertNotRaises` block.
         """
         with self.assertRaises(AssertionError):
-            with self.assertNotRaises(HTTPError, http_status_code=404):
+            with self.assertNotRaises(HTTPError, expected_value=404):
                 fake_404_response()
-
-    def test_positive_cli_raised_callable_with_status_code(self):
-        """Assert that the test will fail (not marked as errored) in case
-        expected exception with expected cli_return_code code was risen inside
-        :meth:`robottelo.test.TestCase.assertNotRaises` call.
-        """
-        with self.assertRaises(AssertionError):
-            self.assertNotRaises(
-                CLIReturnCodeError, fake_128_return_code, cli_return_code=128)
-
-    def test_positive_cli_raised_context_manager_with_status_code(self):
-        """Assert that the test will fail (not marked as errored) in case
-        expected exception with expected cli_return_code was risen inside
-        :meth:`robottelo.test.TestCase.assertNotRaises` block.
-        """
-        with self.assertRaises(AssertionError):
-            with self.assertNotRaises(CLIReturnCodeError, cli_return_code=128):
-                fake_128_return_code()
 
     def test_positive_not_raised_callable(self):
         """Assert that the test won't fail in case exception was not risen
@@ -154,41 +138,23 @@ class AssertNotRaisesTestCase(TestCase):
             with self.assertNotRaises(HTTPError):
                 raise ValueError
 
-    def test_negative_api_wrong_status_code_callable(self):
+    def test_negative_wrong_status_code_callable(self):
         """Assert that expected exception with unexpected http_status_code
         won't be handled and passed through to the test from
         :meth:`robottelo.test.TestCase.assertNotRaises` call.
         """
         with self.assertRaises(HTTPError):
             self.assertNotRaises(
-                HTTPError, fake_404_response, http_status_code=405)
+                HTTPError, fake_404_response, expected_value=405)
 
-    def test_negative_api_wrong_status_code_context_manager(self):
+    def test_negative_wrong_status_code_context_manager(self):
         """Assert that expected exception with unexpected http_status_code
         won't be handled and passed through to the test from
         :meth:`robottelo.test.TestCase.assertNotRaises` block.
         """
         with self.assertRaises(HTTPError):
-            with self.assertNotRaises(HTTPError, http_status_code=405):
+            with self.assertNotRaises(HTTPError, expected_value=405):
                 fake_404_response()
-
-    def test_negative_cli_wrong_status_code_callable(self):
-        """Assert that expected exception with unexpected cli_return_code
-        won't be handled and passed through to the test from
-        :meth:`robottelo.test.TestCase.assertNotRaises` call.
-        """
-        with self.assertRaises(CLIReturnCodeError):
-            self.assertNotRaises(
-                CLIReturnCodeError, fake_128_return_code, cli_return_code=129)
-
-    def test_negative_cli_wrong_status_code_context_manager(self):
-        """Assert that expected exception with unexpected cli_return_code
-        status code won't be handled and passed through to the test from
-        :meth:`robottelo.test.TestCase.assertNotRaises` block.
-        """
-        with self.assertRaises(CLIReturnCodeError):
-            with self.assertNotRaises(CLIReturnCodeError, cli_return_code=129):
-                fake_128_return_code()
 
     def test_negative_wrong_exception_and_status_code_callable(self):
         """Assert that unexpected exception with unexpected status code won't
@@ -199,7 +165,7 @@ class AssertNotRaisesTestCase(TestCase):
             self.assertNotRaises(
                 ZeroDivisionError,
                 fake_404_response,
-                http_status_code=405,
+                expected_value=405,
             )
 
     def test_negative_wrong_exception_and_status_code_context_manager(self):
@@ -208,7 +174,7 @@ class AssertNotRaisesTestCase(TestCase):
         :meth:`robottelo.test.TestCase.assertNotRaises` block.
         """
         with self.assertRaises(HTTPError):
-            with self.assertNotRaises(ZeroDivisionError, http_status_code=405):
+            with self.assertNotRaises(ZeroDivisionError, expected_value=405):
                 fake_404_response()
 
     def test_negative_wrong_exception_correct_status_code_callable(self):
@@ -220,7 +186,7 @@ class AssertNotRaisesTestCase(TestCase):
             self.assertNotRaises(
                 ZeroDivisionError,
                 fake_404_response,
-                http_status_code=404,
+                expected_value=404,
             )
 
     def test_negative_wrong_exc_correct_status_code_context_manager(self):
@@ -229,12 +195,13 @@ class AssertNotRaisesTestCase(TestCase):
         :meth:`robottelo.test.TestCase.assertNotRaises` block.
         """
         with self.assertRaises(HTTPError):
-            with self.assertNotRaises(ZeroDivisionError, http_status_code=404):
+            with self.assertNotRaises(ZeroDivisionError, expected_value=404):
                 fake_404_response()
 
 
-class AssertNotRaisesRegexTestCase(TestCase):
-    """Tests for :meth:`robottelo.test.TestCase.assertNotRaisesRegex`."""
+class CLIAssertNotRaisesTestCase(CLITestCase):
+    """CLI specific tests for :meth:`robottelo.test.TestCase.assertNotRaises`.
+    """
 
     @classmethod
     def setUpClass(cls):
@@ -260,8 +227,73 @@ class AssertNotRaisesRegexTestCase(TestCase):
         """
         pass
 
-    api_pattern = '404 Client Error'
-    cli_pattern = '404 Resource Not Found'
+    def test_positive_raised_callable_with_status_code(self):
+        """Assert that the test will fail (not marked as errored) in case
+        expected exception with expected cli_return_code code was risen inside
+        :meth:`robottelo.test.TestCase.assertNotRaises` call.
+        """
+        with self.assertRaises(AssertionError):
+            self.assertNotRaises(
+                CLIReturnCodeError, fake_128_return_code, expected_value=128)
+
+    def test_positive_raised_context_manager_with_status_code(self):
+        """Assert that the test will fail (not marked as errored) in case
+        expected exception with expected cli_return_code was risen inside
+        :meth:`robottelo.test.TestCase.assertNotRaises` block.
+        """
+        with self.assertRaises(AssertionError):
+            with self.assertNotRaises(CLIReturnCodeError, expected_value=128):
+                fake_128_return_code()
+
+    def test_negative_wrong_status_code_callable(self):
+        """Assert that expected exception with unexpected cli_return_code
+        won't be handled and passed through to the test from
+        :meth:`robottelo.test.TestCase.assertNotRaises` call.
+        """
+        with self.assertRaises(CLIReturnCodeError):
+            self.assertNotRaises(
+                CLIReturnCodeError, fake_128_return_code, expected_value=129)
+
+    def test_negative_wrong_status_code_context_manager(self):
+        """Assert that expected exception with unexpected cli_return_code
+        status code won't be handled and passed through to the test from
+        :meth:`robottelo.test.TestCase.assertNotRaises` block.
+        """
+        with self.assertRaises(CLIReturnCodeError):
+            with self.assertNotRaises(CLIReturnCodeError, expected_value=129):
+                fake_128_return_code()
+
+
+class APIAssertNotRaisesRegexTestCase(APITestCase):
+    """Generic and API specific tests for
+    :meth:`robottelo.test.TestCase.assertNotRaisesRegex`.
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        """Do not inherit and stub :meth:`setUpClass`."""
+        pass
+
+    @classmethod
+    def tearDownClass(cls):
+        """Do not inherit and stub :meth:`tearDownClass`."""
+        pass
+
+    def setUp(self):
+        """Do not inherit and stub :meth:`setUp`."""
+        pass
+
+    def tearDown(self):
+        """Do not inherit and stub :meth:`tearDown`."""
+        pass
+
+    def _set_worker_logger(self, worker_id):
+        """Do not inherit and stub ``_get_worker_logger`` not to have to deal
+        with worker ids and logger.
+        """
+        pass
+
+    pattern = '404 Client Error'
 
     def test_positive_raised_callable(self):
         """Assert that the test will fail (not marked as errored) in case
@@ -272,7 +304,7 @@ class AssertNotRaisesRegexTestCase(TestCase):
         with self.assertRaises(AssertionError):
             self.assertNotRaisesRegex(
                 HTTPError,
-                self.api_pattern,
+                self.pattern,
                 fake_404_response,
             )
 
@@ -283,10 +315,10 @@ class AssertNotRaisesRegexTestCase(TestCase):
         pattern was found in exception message.
         """
         with self.assertRaises(AssertionError):
-            with self.assertNotRaisesRegex(HTTPError, self.api_pattern):
+            with self.assertNotRaisesRegex(HTTPError, self.pattern):
                 fake_404_response()
 
-    def test_positive_api_raised_callable_with_status_code(self):
+    def test_positive_raised_callable_with_status_code(self):
         """Assert that the test will fail (not marked as errored) in case
         expected exception was risen inside
         :meth:`robottelo.test.TestCase.assertNotRaisesRegex` call and
@@ -295,11 +327,11 @@ class AssertNotRaisesRegexTestCase(TestCase):
         with self.assertRaises(AssertionError):
             self.assertNotRaisesRegex(
                 HTTPError,
-                self.api_pattern,
+                self.pattern,
                 fake_404_response,
-                http_status_code=404)
+                expected_value=404)
 
-    def test_positive_api_raised_context_manager_with_status_code(self):
+    def test_positive_raised_context_manager_with_status_code(self):
         """Assert that the test will fail (not marked as errored) in case
         expected exception was risen inside
         :meth:`robottelo.test.TestCase.assertNotRaisesRegex` block and
@@ -307,45 +339,20 @@ class AssertNotRaisesRegexTestCase(TestCase):
         """
         with self.assertRaises(AssertionError):
             with self.assertNotRaisesRegex(
-                    HTTPError, self.api_pattern, http_status_code=404):
+                    HTTPError, self.pattern, expected_value=404):
                 fake_404_response()
-
-    def test_positive_cli_raised_callable_with_status_code(self):
-        """Assert that the test will fail (not marked as errored) in case
-        expected exception was risen inside
-        :meth:`robottelo.test.TestCase.assertNotRaisesRegex` call and
-        cli_return_code altogether with regex pattern match expected ones.
-        """
-        with self.assertRaises(AssertionError):
-            self.assertNotRaisesRegex(
-                CLIReturnCodeError,
-                self.cli_pattern,
-                fake_128_return_code,
-                cli_return_code=128)
-
-    def test_positive_cli_raised_context_manager_with_status_code(self):
-        """Assert that the test will fail (not marked as errored) in case
-        expected exception was risen inside
-        :meth:`robottelo.test.TestCase.assertNotRaisesRegex` block and
-        cli_return_code altogether with regex pattern match expected ones.
-        """
-        with self.assertRaises(AssertionError):
-            with self.assertNotRaisesRegex(
-                    CLIReturnCodeError, self.cli_pattern, cli_return_code=128):
-                fake_128_return_code()
 
     def test_positive_not_raised_callable(self):
         """Assert that the test won't fail in case exception was not risen
         inside :meth:`robottelo.test.TestCase.assertNotRaisesRegex` call.
         """
-        self.assertNotRaisesRegex(
-            HTTPError, self.api_pattern, fake_200_response)
+        self.assertNotRaisesRegex(HTTPError, self.pattern, fake_200_response)
 
     def test_positive_not_raised_context_manager(self):
         """Assert that the test won't fail in case exception was not risen
         inside :meth:`robottelo.test.TestCase.assertNotRaisesRegex` block.
         """
-        with self.assertNotRaisesRegex(HTTPError, self.api_pattern):
+        with self.assertNotRaisesRegex(HTTPError, self.pattern):
             fake_200_response()
 
     def test_negative_wrong_exception_raised_callable(self):
@@ -354,7 +361,7 @@ class AssertNotRaisesRegexTestCase(TestCase):
         :meth:`robottelo.test.TestCase.assertNotRaisesRegex` call.
         """
         with self.assertRaises(ZeroDivisionError):
-            self.assertNotRaisesRegex(HTTPError, self.api_pattern, 1/0)
+            self.assertNotRaisesRegex(HTTPError, self.pattern, 1/0)
 
     def test_negative_wrong_exception_raised_context_manager(self):
         """Assert that unexpected exception with expected pattern won't be
@@ -362,10 +369,10 @@ class AssertNotRaisesRegexTestCase(TestCase):
         :meth:`robottelo.test.TestCase.assertNotRaisesRegex` block.
         """
         with self.assertRaises(ValueError):
-            with self.assertNotRaisesRegex(HTTPError, self.api_pattern):
+            with self.assertNotRaisesRegex(HTTPError, self.pattern):
                 raise ValueError
 
-    def test_negative_api_wrong_status_code_callable(self):
+    def test_negative_wrong_status_code_callable(self):
         """Assert that expected exception with valid pattern but unexpected
         http_status_code won't be handled and passed through to the test from
         :meth:`robottelo.test.TestCase.assertNotRaisesRegex` call.
@@ -373,12 +380,12 @@ class AssertNotRaisesRegexTestCase(TestCase):
         with self.assertRaises(HTTPError):
             self.assertNotRaisesRegex(
                 HTTPError,
-                self.api_pattern,
+                self.pattern,
                 fake_404_response,
-                http_status_code=405,
+                expected_value=405,
             )
 
-    def test_negative_api_wrong_status_code_context_manager(self):
+    def test_negative_wrong_status_code_context_manager(self):
         """Assert that expected exception with valid pattern but unexpected
         http_status_code won't be handled and passed through to the test from
         :meth:`robottelo.test.TestCase.assertNotRaisesRegex` block.
@@ -386,36 +393,10 @@ class AssertNotRaisesRegexTestCase(TestCase):
         with self.assertRaises(HTTPError):
             with self.assertNotRaisesRegex(
                 HTTPError,
-                self.api_pattern,
-                http_status_code=405,
+                self.pattern,
+                expected_value=405,
             ):
                 fake_404_response()
-
-    def test_negative_cli_wrong_status_code_callable(self):
-        """Assert that expected exception with valid pattern but unexpected
-        cli_return_code won't be handled and passed through to the test from
-        :meth:`robottelo.test.TestCase.assertNotRaisesRegex` call.
-        """
-        with self.assertRaises(CLIReturnCodeError):
-            self.assertNotRaisesRegex(
-                CLIReturnCodeError,
-                self.cli_pattern,
-                fake_128_return_code,
-                cli_return_code=129,
-            )
-
-    def test_negative_cli_wrong_status_code_context_manager(self):
-        """Assert that expected exception with valid pattern but unexpected
-        cli_return_code won't be handled and passed through to the test from
-        :meth:`robottelo.test.TestCase.assertNotRaisesRegex` block.
-        """
-        with self.assertRaises(CLIReturnCodeError):
-            with self.assertNotRaisesRegex(
-                CLIReturnCodeError,
-                self.cli_pattern,
-                cli_return_code=129,
-            ):
-                fake_128_return_code()
 
     def test_negative_wrong_exception_and_status_code_callable(self):
         """Assert that unexpected exception with unexpected status code but
@@ -425,9 +406,9 @@ class AssertNotRaisesRegexTestCase(TestCase):
         with self.assertRaises(HTTPError):
             self.assertNotRaisesRegex(
                 ZeroDivisionError,
-                self.api_pattern,
+                self.pattern,
                 fake_404_response,
-                http_status_code=405,
+                expected_value=405,
             )
 
     def test_negative_wrong_exception_and_status_code_context_manager(self):
@@ -437,7 +418,7 @@ class AssertNotRaisesRegexTestCase(TestCase):
         """
         with self.assertRaises(HTTPError):
             with self.assertNotRaisesRegex(
-                    ZeroDivisionError, self.api_pattern, http_status_code=405):
+                    ZeroDivisionError, self.pattern, expected_value=405):
                 fake_404_response()
 
     def test_negative_wrong_exception_correct_status_code_callable(self):
@@ -448,9 +429,9 @@ class AssertNotRaisesRegexTestCase(TestCase):
         with self.assertRaises(HTTPError):
             self.assertNotRaisesRegex(
                 ZeroDivisionError,
-                self.api_pattern,
+                self.pattern,
                 fake_404_response,
-                http_status_code=404,
+                expected_value=404,
             )
 
     def test_negative_wrong_exc_correct_status_code_context_manager(self):
@@ -461,8 +442,8 @@ class AssertNotRaisesRegexTestCase(TestCase):
         with self.assertRaises(HTTPError):
             with self.assertNotRaisesRegex(
                 ZeroDivisionError,
-                self.api_pattern,
-                http_status_code=404,
+                self.pattern,
+                expected_value=404,
             ):
                 fake_404_response()
 
@@ -476,7 +457,7 @@ class AssertNotRaisesRegexTestCase(TestCase):
                 HTTPError,
                 'foo',
                 fake_404_response,
-                http_status_code=404,
+                expected_value=404,
             )
 
     def test_negative_wrong_pattern_correct_exc_status_context_manager(self):
@@ -486,10 +467,7 @@ class AssertNotRaisesRegexTestCase(TestCase):
         """
         with self.assertRaises(HTTPError):
             with self.assertNotRaisesRegex(
-                HTTPError,
-                'foo',
-                http_status_code=404,
-            ):
+                    HTTPError, 'foo', expected_value=404):
                 fake_404_response()
 
     def test_negative_wrong_pattern_status_code_correct_exc_callable(self):
@@ -502,7 +480,7 @@ class AssertNotRaisesRegexTestCase(TestCase):
                 HTTPError,
                 'foo',
                 fake_404_response,
-                http_status_code=405,
+                expected_value=405,
             )
 
     def test_negative_wrong_pattern_status_code_correct_exc_manager(self):
@@ -512,10 +490,7 @@ class AssertNotRaisesRegexTestCase(TestCase):
         """
         with self.assertRaises(HTTPError):
             with self.assertNotRaisesRegex(
-                HTTPError,
-                'foo',
-                http_status_code=405,
-            ):
+                    HTTPError, 'foo', expected_value=405):
                 fake_404_response()
 
     def test_negative_wrong_pattern_exc_correct_status_code_callable(self):
@@ -528,7 +503,7 @@ class AssertNotRaisesRegexTestCase(TestCase):
                 ZeroDivisionError,
                 'foo',
                 fake_404_response,
-                http_status_code=404,
+                expected_value=404,
             )
 
     def test_negative_wrong_pattern_exc_correct_status_code_manager(self):
@@ -540,6 +515,89 @@ class AssertNotRaisesRegexTestCase(TestCase):
             with self.assertNotRaisesRegex(
                 ZeroDivisionError,
                 'foo',
-                http_status_code=404,
+                expected_value=404,
             ):
                 fake_404_response()
+
+
+class CLIAssertNotRaisesRegexTestCase(CLITestCase):
+    """CLI specific tests for
+    :meth:`robottelo.test.TestCase.assertNotRaisesRegex`.
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        """Do not inherit and stub :meth:`setUpClass`."""
+        pass
+
+    @classmethod
+    def tearDownClass(cls):
+        """Do not inherit and stub :meth:`tearDownClass`."""
+        pass
+
+    def setUp(self):
+        """Do not inherit and stub :meth:`setUp`."""
+        pass
+
+    def tearDown(self):
+        """Do not inherit and stub :meth:`tearDown`."""
+        pass
+
+    def _set_worker_logger(self, worker_id):
+        """Do not inherit and stub ``_get_worker_logger`` not to have to deal
+        with worker ids and logger.
+        """
+        pass
+
+    pattern = '404 Resource Not Found'
+
+    def test_positive_raised_callable_with_status_code(self):
+        """Assert that the test will fail (not marked as errored) in case
+        expected exception was risen inside
+        :meth:`robottelo.test.TestCase.assertNotRaisesRegex` call and
+        cli_return_code altogether with regex pattern match expected ones.
+        """
+        with self.assertRaises(AssertionError):
+            self.assertNotRaisesRegex(
+                CLIReturnCodeError,
+                self.pattern,
+                fake_128_return_code,
+                expected_value=128,
+            )
+
+    def test_positive_raised_context_manager_with_status_code(self):
+        """Assert that the test will fail (not marked as errored) in case
+        expected exception was risen inside
+        :meth:`robottelo.test.TestCase.assertNotRaisesRegex` block and
+        cli_return_code altogether with regex pattern match expected ones.
+        """
+        with self.assertRaises(AssertionError):
+            with self.assertNotRaisesRegex(
+                    CLIReturnCodeError, self.pattern, expected_value=128):
+                fake_128_return_code()
+
+    def test_negative_wrong_status_code_callable(self):
+        """Assert that expected exception with valid pattern but unexpected
+        cli_return_code won't be handled and passed through to the test from
+        :meth:`robottelo.test.TestCase.assertNotRaisesRegex` call.
+        """
+        with self.assertRaises(CLIReturnCodeError):
+            self.assertNotRaisesRegex(
+                CLIReturnCodeError,
+                self.pattern,
+                fake_128_return_code,
+                expected_value=129,
+            )
+
+    def test_negative_wrong_status_code_context_manager(self):
+        """Assert that expected exception with valid pattern but unexpected
+        cli_return_code won't be handled and passed through to the test from
+        :meth:`robottelo.test.TestCase.assertNotRaisesRegex` block.
+        """
+        with self.assertRaises(CLIReturnCodeError):
+            with self.assertNotRaisesRegex(
+                CLIReturnCodeError,
+                self.pattern,
+                expected_value=129,
+            ):
+                fake_128_return_code()

--- a/tests/robottelo/test_assertions.py
+++ b/tests/robottelo/test_assertions.py
@@ -1,0 +1,545 @@
+# -*- encoding: utf-8 -*-
+"""Tests for custom assertions in ``robottelo.test.TestCase``."""
+from collections import namedtuple
+from requests import HTTPError
+from robottelo.cli.base import CLIReturnCodeError
+from robottelo.test import TestCase
+
+
+def fake_128_return_code():
+    """Fake CLI response with 128 return_code"""
+    # flake8:noqa (line-too-long) pylint:disable=C0301
+    raise CLIReturnCodeError(
+        128,
+        u"""[ERROR 2017-03-01 05:58:50 API] 404 Resource Not Found
+        [ERROR 2017-03-01 05:58:50 Exception] Resource medium not found by id \\'1\\'
+        Resource medium not found by id \\'1\\'
+        [ERROR 2017-03-01 05:58:50 Exception]
+
+        RestClient::ResourceNotFound (404 Resource Not Found):""",
+        u"""Command "medium info" finished with return_code 128
+        stderr contains following message:
+        [ERROR 2017-03-01 05:58:50 API] 404 Resource Not Found
+        [ERROR 2017-03-01 05:58:50 Exception] Resource medium not found by id \\'1\\'
+        Resource medium not found by id \\'1\\'
+        [ERROR 2017-03-01 05:58:50 Exception]
+
+        RestClient::ResourceNotFound (404 Resource Not Found):"""
+    )
+
+
+def fake_404_response():
+    """Fake HTTP response with 404 status code"""
+    response = namedtuple('response', 'ok raw reason request status_code')
+    response.status_code = 404
+    raise HTTPError(
+        u'404 Client Error: Not Found for url: '
+        u'https://example.com/api/v2/hosts/1',
+        response=response,
+    )
+
+
+def fake_200_response():
+    """Fake HTTP response with 200 status code"""
+    response = namedtuple('response', 'ok raw reason request status_code')
+    response.status_code = 200
+    return response
+
+
+class AssertNotRaisesTestCase(TestCase):
+    """Tests for :meth:`robottelo.test.TestCase.assertNotRaises`."""
+
+    @classmethod
+    def setUpClass(cls):
+        """Do not inherit and stub :meth:`setUpClass`."""
+        pass
+
+    @classmethod
+    def tearDownClass(cls):
+        """Do not inherit and stub :meth:`tearDownClass`."""
+        pass
+
+    def setUp(self):
+        """Do not inherit and stub :meth:`setUp`."""
+        pass
+
+    def tearDown(self):
+        """Do not inherit and stub :meth:`tearDown`."""
+        pass
+
+    def _set_worker_logger(self, worker_id):
+        """Do not inherit and stub ``_get_worker_logger`` not to have to deal
+        with worker ids and logger.
+        """
+        pass
+
+    def test_positive_raised_callable(self):
+        """Assert that the test will fail (not marked as errored) in case
+        expected exception was risen inside
+        :meth:`robottelo.test.TestCase.assertNotRaises` call.
+        """
+        with self.assertRaises(AssertionError):
+            self.assertNotRaises(HTTPError, fake_404_response)
+
+    def test_positive_raised_context_manager(self):
+        """Assert that the test will fail (not marked as errored) in case
+        expected exception was risen inside
+        :meth:`robottelo.test.TestCase.assertNotRaises` block.
+        """
+        with self.assertRaises(AssertionError):
+            with self.assertNotRaises(HTTPError):
+                fake_404_response()
+
+    def test_positive_api_raised_callable_with_status_code(self):
+        """Assert that the test will fail (not marked as errored) in case
+        expected exception with expected http_status_code was risen inside
+        :meth:`robottelo.test.TestCase.assertNotRaises` call.
+        """
+        with self.assertRaises(AssertionError):
+            self.assertNotRaises(
+                HTTPError, fake_404_response, http_status_code=404)
+
+    def test_positive_api_raised_context_manager_with_status_code(self):
+        """Assert that the test will fail (not marked as errored) in case
+        expected exception with expected http_status_code was risen inside
+        :meth:`robottelo.test.TestCase.assertNotRaises` block.
+        """
+        with self.assertRaises(AssertionError):
+            with self.assertNotRaises(HTTPError, http_status_code=404):
+                fake_404_response()
+
+    def test_positive_cli_raised_callable_with_status_code(self):
+        """Assert that the test will fail (not marked as errored) in case
+        expected exception with expected cli_return_code code was risen inside
+        :meth:`robottelo.test.TestCase.assertNotRaises` call.
+        """
+        with self.assertRaises(AssertionError):
+            self.assertNotRaises(
+                CLIReturnCodeError, fake_128_return_code, cli_return_code=128)
+
+    def test_positive_cli_raised_context_manager_with_status_code(self):
+        """Assert that the test will fail (not marked as errored) in case
+        expected exception with expected cli_return_code was risen inside
+        :meth:`robottelo.test.TestCase.assertNotRaises` block.
+        """
+        with self.assertRaises(AssertionError):
+            with self.assertNotRaises(CLIReturnCodeError, cli_return_code=128):
+                fake_128_return_code()
+
+    def test_positive_not_raised_callable(self):
+        """Assert that the test won't fail in case exception was not risen
+        inside :meth:`robottelo.test.TestCase.assertNotRaises` call.
+        """
+        self.assertNotRaises(HTTPError, fake_200_response)
+
+    def test_positive_not_raised_context_manager(self):
+        """Assert that the test won't fail in case exception was not risen
+        inside :meth:`robottelo.test.TestCase.assertNotRaises` block.
+        """
+        with self.assertNotRaises(HTTPError):
+            fake_200_response()
+
+    def test_negative_wrong_exception_raised_callable(self):
+        """Assert that unexpected exception won't be handled and passed through
+        to the test from :meth:`robottelo.test.TestCase.assertNotRaises` call.
+        """
+        with self.assertRaises(ZeroDivisionError):
+            self.assertNotRaises(HTTPError, 1/0)
+
+    def test_negative_wrong_exception_raised_context_manager(self):
+        """Assert that unexpected exception won't be handled and passed through
+        to the test from :meth:`robottelo.test.TestCase.assertNotRaises` block.
+        """
+        with self.assertRaises(ValueError):
+            with self.assertNotRaises(HTTPError):
+                raise ValueError
+
+    def test_negative_api_wrong_status_code_callable(self):
+        """Assert that expected exception with unexpected http_status_code
+        won't be handled and passed through to the test from
+        :meth:`robottelo.test.TestCase.assertNotRaises` call.
+        """
+        with self.assertRaises(HTTPError):
+            self.assertNotRaises(
+                HTTPError, fake_404_response, http_status_code=405)
+
+    def test_negative_api_wrong_status_code_context_manager(self):
+        """Assert that expected exception with unexpected http_status_code
+        won't be handled and passed through to the test from
+        :meth:`robottelo.test.TestCase.assertNotRaises` block.
+        """
+        with self.assertRaises(HTTPError):
+            with self.assertNotRaises(HTTPError, http_status_code=405):
+                fake_404_response()
+
+    def test_negative_cli_wrong_status_code_callable(self):
+        """Assert that expected exception with unexpected cli_return_code
+        won't be handled and passed through to the test from
+        :meth:`robottelo.test.TestCase.assertNotRaises` call.
+        """
+        with self.assertRaises(CLIReturnCodeError):
+            self.assertNotRaises(
+                CLIReturnCodeError, fake_128_return_code, cli_return_code=129)
+
+    def test_negative_cli_wrong_status_code_context_manager(self):
+        """Assert that expected exception with unexpected cli_return_code
+        status code won't be handled and passed through to the test from
+        :meth:`robottelo.test.TestCase.assertNotRaises` block.
+        """
+        with self.assertRaises(CLIReturnCodeError):
+            with self.assertNotRaises(CLIReturnCodeError, cli_return_code=129):
+                fake_128_return_code()
+
+    def test_negative_wrong_exception_and_status_code_callable(self):
+        """Assert that unexpected exception with unexpected status code won't
+        be handled and passed through to the test from
+        :meth:`robottelo.test.TestCase.assertNotRaises` call.
+        """
+        with self.assertRaises(HTTPError):
+            self.assertNotRaises(
+                ZeroDivisionError,
+                fake_404_response,
+                http_status_code=405,
+            )
+
+    def test_negative_wrong_exception_and_status_code_context_manager(self):
+        """Assert that unexpected exception with unexpected status code won't
+        be handled and passed through to the test from
+        :meth:`robottelo.test.TestCase.assertNotRaises` block.
+        """
+        with self.assertRaises(HTTPError):
+            with self.assertNotRaises(ZeroDivisionError, http_status_code=405):
+                fake_404_response()
+
+    def test_negative_wrong_exception_correct_status_code_callable(self):
+        """Assert that unexpected exception with expected status code won't be
+        handled and passed through to the test from
+        :meth:`robottelo.test.TestCase.assertNotRaises` call.
+        """
+        with self.assertRaises(HTTPError):
+            self.assertNotRaises(
+                ZeroDivisionError,
+                fake_404_response,
+                http_status_code=404,
+            )
+
+    def test_negative_wrong_exc_correct_status_code_context_manager(self):
+        """Assert that unexpected exception with expected status code won't be
+        handled and passed through to the test from
+        :meth:`robottelo.test.TestCase.assertNotRaises` block.
+        """
+        with self.assertRaises(HTTPError):
+            with self.assertNotRaises(ZeroDivisionError, http_status_code=404):
+                fake_404_response()
+
+
+class AssertNotRaisesRegexTestCase(TestCase):
+    """Tests for :meth:`robottelo.test.TestCase.assertNotRaisesRegex`."""
+
+    @classmethod
+    def setUpClass(cls):
+        """Do not inherit and stub :meth:`setUpClass`."""
+        pass
+
+    @classmethod
+    def tearDownClass(cls):
+        """Do not inherit and stub :meth:`tearDownClass`."""
+        pass
+
+    def setUp(self):
+        """Do not inherit and stub :meth:`setUp`."""
+        pass
+
+    def tearDown(self):
+        """Do not inherit and stub :meth:`tearDown`."""
+        pass
+
+    def _set_worker_logger(self, worker_id):
+        """Do not inherit and stub ``_get_worker_logger`` not to have to deal
+        with worker ids and logger.
+        """
+        pass
+
+    api_pattern = '404 Client Error'
+    cli_pattern = '404 Resource Not Found'
+
+    def test_positive_raised_callable(self):
+        """Assert that the test will fail (not marked as errored) in case
+        expected exception was risen inside
+        :meth:`robottelo.test.TestCase.assertNotRaisesRegex` call and expected
+        pattern was found in exception message.
+        """
+        with self.assertRaises(AssertionError):
+            self.assertNotRaisesRegex(
+                HTTPError,
+                self.api_pattern,
+                fake_404_response,
+            )
+
+    def test_positive_raised_context_manager(self):
+        """Assert that the test will fail (not marked as errored) in case
+        expected exception was risen inside
+        :meth:`robottelo.test.TestCase.assertNotRaisesRegex` block and expected
+        pattern was found in exception message.
+        """
+        with self.assertRaises(AssertionError):
+            with self.assertNotRaisesRegex(HTTPError, self.api_pattern):
+                fake_404_response()
+
+    def test_positive_api_raised_callable_with_status_code(self):
+        """Assert that the test will fail (not marked as errored) in case
+        expected exception was risen inside
+        :meth:`robottelo.test.TestCase.assertNotRaisesRegex` call and
+        http_status_code altogether with regex pattern match expected ones.
+        """
+        with self.assertRaises(AssertionError):
+            self.assertNotRaisesRegex(
+                HTTPError,
+                self.api_pattern,
+                fake_404_response,
+                http_status_code=404)
+
+    def test_positive_api_raised_context_manager_with_status_code(self):
+        """Assert that the test will fail (not marked as errored) in case
+        expected exception was risen inside
+        :meth:`robottelo.test.TestCase.assertNotRaisesRegex` block and
+        http_status_code altogether with regex pattern match expected ones.
+        """
+        with self.assertRaises(AssertionError):
+            with self.assertNotRaisesRegex(
+                    HTTPError, self.api_pattern, http_status_code=404):
+                fake_404_response()
+
+    def test_positive_cli_raised_callable_with_status_code(self):
+        """Assert that the test will fail (not marked as errored) in case
+        expected exception was risen inside
+        :meth:`robottelo.test.TestCase.assertNotRaisesRegex` call and
+        cli_return_code altogether with regex pattern match expected ones.
+        """
+        with self.assertRaises(AssertionError):
+            self.assertNotRaisesRegex(
+                CLIReturnCodeError,
+                self.cli_pattern,
+                fake_128_return_code,
+                cli_return_code=128)
+
+    def test_positive_cli_raised_context_manager_with_status_code(self):
+        """Assert that the test will fail (not marked as errored) in case
+        expected exception was risen inside
+        :meth:`robottelo.test.TestCase.assertNotRaisesRegex` block and
+        cli_return_code altogether with regex pattern match expected ones.
+        """
+        with self.assertRaises(AssertionError):
+            with self.assertNotRaisesRegex(
+                    CLIReturnCodeError, self.cli_pattern, cli_return_code=128):
+                fake_128_return_code()
+
+    def test_positive_not_raised_callable(self):
+        """Assert that the test won't fail in case exception was not risen
+        inside :meth:`robottelo.test.TestCase.assertNotRaisesRegex` call.
+        """
+        self.assertNotRaisesRegex(
+            HTTPError, self.api_pattern, fake_200_response)
+
+    def test_positive_not_raised_context_manager(self):
+        """Assert that the test won't fail in case exception was not risen
+        inside :meth:`robottelo.test.TestCase.assertNotRaisesRegex` block.
+        """
+        with self.assertNotRaisesRegex(HTTPError, self.api_pattern):
+            fake_200_response()
+
+    def test_negative_wrong_exception_raised_callable(self):
+        """Assert that unexpected exception with expected pattern won't be
+        handled and passed through to the test from
+        :meth:`robottelo.test.TestCase.assertNotRaisesRegex` call.
+        """
+        with self.assertRaises(ZeroDivisionError):
+            self.assertNotRaisesRegex(HTTPError, self.api_pattern, 1/0)
+
+    def test_negative_wrong_exception_raised_context_manager(self):
+        """Assert that unexpected exception with expected pattern won't be
+        handled and passed through to the test from
+        :meth:`robottelo.test.TestCase.assertNotRaisesRegex` block.
+        """
+        with self.assertRaises(ValueError):
+            with self.assertNotRaisesRegex(HTTPError, self.api_pattern):
+                raise ValueError
+
+    def test_negative_api_wrong_status_code_callable(self):
+        """Assert that expected exception with valid pattern but unexpected
+        http_status_code won't be handled and passed through to the test from
+        :meth:`robottelo.test.TestCase.assertNotRaisesRegex` call.
+        """
+        with self.assertRaises(HTTPError):
+            self.assertNotRaisesRegex(
+                HTTPError,
+                self.api_pattern,
+                fake_404_response,
+                http_status_code=405,
+            )
+
+    def test_negative_api_wrong_status_code_context_manager(self):
+        """Assert that expected exception with valid pattern but unexpected
+        http_status_code won't be handled and passed through to the test from
+        :meth:`robottelo.test.TestCase.assertNotRaisesRegex` block.
+        """
+        with self.assertRaises(HTTPError):
+            with self.assertNotRaisesRegex(
+                HTTPError,
+                self.api_pattern,
+                http_status_code=405,
+            ):
+                fake_404_response()
+
+    def test_negative_cli_wrong_status_code_callable(self):
+        """Assert that expected exception with valid pattern but unexpected
+        cli_return_code won't be handled and passed through to the test from
+        :meth:`robottelo.test.TestCase.assertNotRaisesRegex` call.
+        """
+        with self.assertRaises(CLIReturnCodeError):
+            self.assertNotRaisesRegex(
+                CLIReturnCodeError,
+                self.cli_pattern,
+                fake_128_return_code,
+                cli_return_code=129,
+            )
+
+    def test_negative_cli_wrong_status_code_context_manager(self):
+        """Assert that expected exception with valid pattern but unexpected
+        cli_return_code won't be handled and passed through to the test from
+        :meth:`robottelo.test.TestCase.assertNotRaisesRegex` block.
+        """
+        with self.assertRaises(CLIReturnCodeError):
+            with self.assertNotRaisesRegex(
+                CLIReturnCodeError,
+                self.cli_pattern,
+                cli_return_code=129,
+            ):
+                fake_128_return_code()
+
+    def test_negative_wrong_exception_and_status_code_callable(self):
+        """Assert that unexpected exception with unexpected status code but
+        expected pattern won't be handled and passed through to the test from
+        :meth:`robottelo.test.TestCase.assertNotRaisesRegex` call.
+        """
+        with self.assertRaises(HTTPError):
+            self.assertNotRaisesRegex(
+                ZeroDivisionError,
+                self.api_pattern,
+                fake_404_response,
+                http_status_code=405,
+            )
+
+    def test_negative_wrong_exception_and_status_code_context_manager(self):
+        """Assert that unexpected exception with unexpected status code but
+        expected pattern won't be handled and passed through to the test from
+        :meth:`robottelo.test.TestCase.assertNotRaisesRegex` block.
+        """
+        with self.assertRaises(HTTPError):
+            with self.assertNotRaisesRegex(
+                    ZeroDivisionError, self.api_pattern, http_status_code=405):
+                fake_404_response()
+
+    def test_negative_wrong_exception_correct_status_code_callable(self):
+        """Assert that unexpected exception with expected status code and
+        pattern won't be handled and passed through to the test from
+        :meth:`robottelo.test.TestCase.assertNotRaisesRegex` call.
+        """
+        with self.assertRaises(HTTPError):
+            self.assertNotRaisesRegex(
+                ZeroDivisionError,
+                self.api_pattern,
+                fake_404_response,
+                http_status_code=404,
+            )
+
+    def test_negative_wrong_exc_correct_status_code_context_manager(self):
+        """Assert that unexpected exception with expected status code and
+        pattern won't be handled and passed through to the test from
+        :meth:`robottelo.test.TestCase.assertNotRaisesRegex` block.
+        """
+        with self.assertRaises(HTTPError):
+            with self.assertNotRaisesRegex(
+                ZeroDivisionError,
+                self.api_pattern,
+                http_status_code=404,
+            ):
+                fake_404_response()
+
+    def test_negative_wrong_pattern_correct_exc_status_code_callable(self):
+        """Assert that expected exception with expected status code but invalid
+        pattern won't be handled and passed through to the test from
+        :meth:`robottelo.test.TestCase.assertNotRaisesRegex` call.
+        """
+        with self.assertRaises(HTTPError):
+            self.assertNotRaisesRegex(
+                HTTPError,
+                'foo',
+                fake_404_response,
+                http_status_code=404,
+            )
+
+    def test_negative_wrong_pattern_correct_exc_status_context_manager(self):
+        """Assert that expected exception with expected status code but invalid
+        pattern won't be handled and passed through to the test from
+        :meth:`robottelo.test.TestCase.assertNotRaisesRegex` block.
+        """
+        with self.assertRaises(HTTPError):
+            with self.assertNotRaisesRegex(
+                HTTPError,
+                'foo',
+                http_status_code=404,
+            ):
+                fake_404_response()
+
+    def test_negative_wrong_pattern_status_code_correct_exc_callable(self):
+        """Assert that expected exception with unexpected status code and
+        pattern won't be handled and passed through to the test from
+        :meth:`robottelo.test.TestCase.assertNotRaisesRegex` call.
+        """
+        with self.assertRaises(HTTPError):
+            self.assertNotRaisesRegex(
+                HTTPError,
+                'foo',
+                fake_404_response,
+                http_status_code=405,
+            )
+
+    def test_negative_wrong_pattern_status_code_correct_exc_manager(self):
+        """Assert that expected exception with unexpected status code and
+        pattern won't be handled and passed through to the test from
+        :meth:`robottelo.test.TestCase.assertNotRaisesRegex` block.
+        """
+        with self.assertRaises(HTTPError):
+            with self.assertNotRaisesRegex(
+                HTTPError,
+                'foo',
+                http_status_code=405,
+            ):
+                fake_404_response()
+
+    def test_negative_wrong_pattern_exc_correct_status_code_callable(self):
+        """Assert that unexpected exception with invalid patter but expected
+        status code won't be handled and passed through to the test from
+        :meth:`robottelo.test.TestCase.assertNotRaisesRegex` call.
+        """
+        with self.assertRaises(HTTPError):
+            self.assertNotRaisesRegex(
+                ZeroDivisionError,
+                'foo',
+                fake_404_response,
+                http_status_code=404,
+            )
+
+    def test_negative_wrong_pattern_exc_correct_status_code_manager(self):
+        """Assert that unexpected exception with invalid patter but expected
+        status code won't be handled and passed through to the test from
+        :meth:`robottelo.test.TestCase.assertNotRaisesRegex` call.
+        """
+        with self.assertRaises(HTTPError):
+            with self.assertNotRaisesRegex(
+                ZeroDivisionError,
+                'foo',
+                http_status_code=404,
+            ):
+                fake_404_response()


### PR DESCRIPTION
### Background

Some of our tests, especially those ones which target negative cases, are validating whether command will succeed and don't raise any exceptions.
As there are no built-in or unittest assertions like `assertNotRaises`, in most cases we were validating such commands by simply executing them and hoping they will pass, and if they won't - failure will tell us about regression. The thing is, `unittest` marks all the tests, which were not failed inside assertions, as 'error', not 'failure', which is confusing causing everyone to think we have an error in our automation code, when the code itself is completely ok.

To workaround this, sometimes we were using something like this:
```python
try:
    do_thing()
except ExpectedException:
    self.fail()
```
which doesn't look great but works for us.

Then #4267 was submitted, pointing to the fact that expecting exception is not enough for api/cli tests. For example when we're expecting 404 error telling us the resource is not found, in case we just catch HTTPError we can hide different failures like server's 500 error.
To workaround this issue, a bit more tricky workaround was introduced:
```python
try:
    entity.read()
except HTTPError as error:
    if error.response.status_code == 404:
        self.fail()
    else:
        raise
```
This workaround is definitely too complicated to use it every time and some user-friendly helper had to be introduced instead.

### What's this PR about

This pull request introduces following 2 helpers:

* assertNotRaises()
* assertNotRaisesRegex()

the purpose of which is to execute some code and in case expected Exception occurred - mark the test as 'failure', not 'error' with no tricky workarounds.

### Usage

The usage is pretty much similar to `assertRaises` assertion.
Let's assume we want to ensure some host exists in satellite. Before, in API test, we had to do something like this:
```python
try:
    host.read()
except HTTPError:
    self.fail()
```

Now we can simply pass the instruction to `self.assertNotRaises()` method:
```python
self.assertNotRaises(HTTPError, host.read)
```

OR use `assertNotRaises` as a context manager:
```python
with self.assertNotRaises(HTTPError):
    host.read()
```
which allows us to execute a block of code and looks better in general.

Both forms are equal and in case no exceptions were risen - the test will proceed, if expected exception was risen - `AssertionError` will be risen and the test will be marked as 'FAIL', if any other exception occurred - exception won't be caught which will lead to test being marked as 'ERROR'.

But what if just checking Exception presence is not enough and we want to specify the exact HTTP status code (or return code for CLI) which we are expecting to happen? For example, in previous example, we're expecting that in case host is not present - 404 error will be shown, but definitely not 500 error or something else.
For such case, `assertRaises` accepts 2 optional arguments - `http_status_code` and `cli_return_code` for API and CLI accordingly.

So instead of
```python
try:
    host.read()
except HTTPError as error:
    if error.response.status_code == 404:
        self.fail()
    else:
        raise
```

We can now use
```python
self.assertNotRaises(HTTPError, host.read, http_status_code=404)
```
for callable object or we can use assertion as a context manager:
```python
with self.assertNotRaises(HTTPError, http_status_code=404):
    host.read()
```

For CLI, syntax is similar:
```python
with self.assertNotRaises(CLIReturnCodeError, cli_return_code=128):
    Host.info({'id': 1})
```

This way, only expected exception will be caught and only in case response code matches the expected one.

And what if that's still not enough and we want to check the exception message to ensure some pattern is there? The answer is `assertNotRaisesRegex` assertion, which is basically extended `assertNotRaises` assertion which should be used similar to `assertRaisesRegex`.

Example usage with exception and pattern:
```python
# with callable:
self.assertNotRaisesRegex(HTTPError, '404 Client Error', host.read)

# as a context manager:
with self.assertNotRaisesRegex(HTTPError, '404 Client Error'):
    host.read()
```
Example usage with exception, response code and pattern:
```python
# with callable:
self.assertNotRaisesRegex(
    HTTPError, '404 Client Error', host.read, http_status_code=404)

# as a context manager:
with self.assertNotRaisesRegex(
        HTTPError, '404 Client Error', http_status_code=404):
    host.read()
```

And, of course, valid regular expression patterns are supported.

Similar to previous examples, if the exception is risen - only in case exception, pattern and response code (if specified) match the expected ones - test will be marked with 'FAIL', all others exceptions won't be handled and will mark the test with 'ERROR' as usual.