### PR TITLE
[6.2.z] implement bz_coverage for 1387892-1429468

### DIFF
--- a/robottelo/ui/locators.py
+++ b/robottelo/ui/locators.py
@@ -597,6 +597,10 @@ tab_locators = LocatorDict({
     # Third level UI
     "contenthost.tab_details": (
         By.XPATH, "//a[@class='ng-scope' and contains(@href,'info')]"),
+    "contenthost.tab_provisioning_details": (
+        By.XPATH, "//a[@class='ng-scope' and contains(@href,'provisioning')]"),
+    "contenthost.tab_provisioning_details_host_link": (
+        By.XPATH, "//span[@class='info-value']/a[contains(@href,'hosts')]"),
     "contenthost.tab_subscriptions": (
         By.XPATH,
         ("//li[@class='dropdown' and contains(@ng-class, "


### PR DESCRIPTION
coverage of cloned to with flag 6.2.z  https://bugzilla.redhat.com/show_bug.cgi?id=1429468
of bug for 6.3: https://bugzilla.redhat.com/show_bug.cgi?id=1387892

when run without the decorator:
last test fragments: http://pastebin.test.redhat.com/461757