### PR TITLE
[6.2.z] getting job invocation output before asserts

### DIFF
--- a/robottelo/cli/job_invocation.py
+++ b/robottelo/cli/job_invocation.py
@@ -24,3 +24,10 @@ class JobInvocation(Base):
     """
 
     command_base = 'job-invocation'
+
+    @classmethod
+    def get_output(cls, options):
+        """Get output of the job invocation"""
+        cls.command_sub = 'output'
+        return cls.execute(
+            cls._construct_command(options))

--- a/tests/foreman/cli/test_remoteexecution.py
+++ b/tests/foreman/cli/test_remoteexecution.py
@@ -252,6 +252,10 @@ class RemoteExecutionTestCase(CLITestCase):
             'inputs': 'command="ls"',
             'search-query': "name ~ {0}".format(self.client.hostname),
         })
+        JobInvocation.get_output({
+             'id': invocation_command[u'id'],
+             'host': self.client.hostname
+        })
         self.assertEqual(invocation_command['success'], u'1')
 
     @tier2
@@ -271,6 +275,10 @@ class RemoteExecutionTestCase(CLITestCase):
         invocation_command = make_job_invocation({
             'job-template': template_name,
             'search-query': "name ~ {0}".format(self.client.hostname),
+        })
+        JobInvocation.get_output({
+             'id': invocation_command[u'id'],
+             'host': self.client.hostname
         })
         self.assertEqual(invocation_command[u'success'], u'1')
 
@@ -301,6 +309,10 @@ class RemoteExecutionTestCase(CLITestCase):
             pending_state = invocation_info[u'pending']
             sleep(30)
         # Check the job status
+        JobInvocation.get_output({
+             'id': invocation_command[u'id'],
+             'host': self.client.hostname
+        })
         invocation_info = JobInvocation.info({
             'id': invocation_command[u'id']})
         self.assertEqual(invocation_info[u'success'], u'1')


### PR DESCRIPTION
Requested in #4402 CLI part
Results:

```
nosetests -v tests/foreman/cli/test_remoteexecution.py:RemoteExecutionTestCase 
Run custom job template against a single host ... ok
Run default job template against a single host ... ok
Schedule a job to be ran against a host ... ok

----------------------------------------------------------------------
Ran 3 tests in 135.671s

OK
```