### PR TITLE
[6.2.z] refactored vm.py

### DIFF
--- a/tests/foreman/cli/test_activationkey.py
+++ b/tests/foreman/cli/test_activationkey.py
@@ -558,11 +558,12 @@ class ActivationKeyTestCase(CLITestCase):
                 vm1.install_katello_ca()
                 result = vm1.register_contenthost(
                     self.org['label'], new_ak['name'])
-                self.assertEqual(result.return_code, 0)
+                self.assertTrue(vm1.subscribed())
                 vm2.install_katello_ca()
                 result = vm2.register_contenthost(
                     self.org['label'], new_ak['name'])
-                self.assertEqual(result.return_code, 255)
+                self.assertFalse(vm2.subscribed())
+                self.assertEqual(result.return_code, 70)
                 self.assertGreater(len(result.stderr), 0)
 
     @skip_if_bug_open('bugzilla', 1110476)
@@ -783,9 +784,9 @@ class ActivationKeyTestCase(CLITestCase):
         with VirtualMachine(distro=DISTRO_RHEL6) as vm:
             vm.install_katello_ca()
             for i in range(2):
-                result = vm.register_contenthost(
+                vm.register_contenthost(
                     self.org['label'], new_aks[i]['name'])
-                self.assertEqual(result.return_code, 0)
+                self.assertTrue(vm.subscribed())
 
     @skip_if_not_set('clients')
     @stubbed()

--- a/tests/robottelo/test_vm.py
+++ b/tests/robottelo/test_vm.py
@@ -35,10 +35,11 @@ class VirtualMachineTestCase(unittest2.TestCase):
     @patch('robottelo.ssh.command', side_effect=[
         ssh.SSHCommandResult(),
         ssh.SSHCommandResult(stdout=['(192.168.0.1)']),
+        ssh.SSHCommandResult()
     ])
     def test_dont_create_if_already_created(
             self, ssh_command, sleep):
-        """Check if the creation steps does run more than one"""
+        """Check if the creation steps are run more than once"""
         self.configure_provisoning_server()
         vm = VirtualMachine()
 
@@ -50,8 +51,7 @@ class VirtualMachineTestCase(unittest2.TestCase):
             vm.create()
             vm.create()
         self.assertEqual(vm.ip_addr, '192.168.0.1')
-        self.assertEqual(ssh_command.call_count, 2)
-        self.assertEqual(sleep.call_count, 1)
+        self.assertEqual(ssh_command.call_count, 3)
 
     def test_invalid_distro(self):
         """Check if an exception is raised if an invalid distro is passed"""


### PR DESCRIPTION
- moved sleep logic to the hypervisor
- fixed cli.activation_key test cases - updated the assertions


```
 generated xml file: /home/jenkins/workspace/satellite6-standalone-automation/foreman-results.xml 
=================== 2 tests deselected by "-m 'not stubbed'" ===================
============ 42 passed, 4 skipped, 2 deselected in 2388.99 seconds =============
+ exit 0
Deleting 1 temporary files
Recording test results

Archiving artifacts
Started calculate disk usage of build
Finished Calculation of disk usage of build in 0 seconds
Started calculate disk usage of workspace
Finished Calculation of disk usage of workspace in 0 seconds
Finished: SUCCESS
```

partly addresses https://github.com/SatelliteQE/robottelo/issues/4153