### PR TITLE
[6.3][cherry-pick]-implement-bz-coverage-1387892-1429468

### DIFF
--- a/robottelo/ui/locators/tab.py
+++ b/robottelo/ui/locators/tab.py
@@ -212,6 +212,12 @@ tab_locators = LocatorDict({
     # Third level UI
     "contenthost.tab_details": (
         By.XPATH, "//a[@class='ng-scope' and contains(@href,'info')]"),
+    "contenthost.tab_provisioning_details": (
+        By.XPATH,
+        "//a[@class='ng-scope' and contains(@href,'provisioning')]"),
+    "contenthost.tab_provisioning_details_host_link": (
+        By.XPATH,
+        "//span[@class='info-value']/a[contains(@href,'hosts')]"),
     "contenthost.tab_subscriptions": (
         By.XPATH,
         ("//li[@class='dropdown' and contains(@ng-class, "

--- a/tests/foreman/ui/test_contenthost.py
+++ b/tests/foreman/ui/test_contenthost.py
@@ -15,12 +15,15 @@
 
 :Upstream: No
 """
+from six.moves.urllib.parse import urljoin
+
 from nailgun import entities
 from robottelo.cleanup import vm_cleanup
 from robottelo.cli.factory import (
     setup_org_for_a_custom_repo,
     setup_org_for_a_rh_repo,
 )
+from robottelo.config import settings
 from robottelo.constants import (
     DISTRO_RHEL7,
     FAKE_0_CUSTOM_PACKAGE,
@@ -36,8 +39,14 @@ from robottelo.constants import (
     REPOS,
     REPOSET,
 )
-from robottelo.decorators import run_in_one_thread, skip_if_not_set, tier3
+from robottelo.decorators import (
+    run_in_one_thread,
+    skip_if_bug_open,
+    skip_if_not_set,
+    tier3,
+)
 from robottelo.test import UITestCase
+from robottelo.ui.locators import tab_locators
 from robottelo.ui.session import Session
 from robottelo.vm import VirtualMachine
 
@@ -251,3 +260,34 @@ class ContentHostTestCase(UITestCase):
             )
             self.assertEqual(
                 result['Registered By'], self.activation_key.name)
+
+    @skip_if_bug_open('bugzilla', 1387892)
+    @tier3
+    def test_positive_provisioning_host_link(self):
+        """Check that the host link in provisioning tab of content host page
+         point to the host details page.
+
+        @id: 28f5fb0e-007b-4ee6-876e-9693fb7f5841
+
+        @assert: The Provisioning host details name link at
+        content_hosts/provisioning point to host detail page eg: hosts/hostname
+
+        @BZ: 1387892
+
+        @CaseLevel: System
+        """
+        with Session(self.browser):
+            # open the content host
+            self.contenthost.search_and_click(self.client.hostname)
+            # open the provisioning tab of the content host
+            self.contenthost.click(
+                tab_locators['contenthost.tab_provisioning_details'])
+            # click the name field value that contain the hostname
+            self.contenthost.click(
+                tab_locators['contenthost.tab_provisioning_details_host_link'])
+            # assert that the current url is equal to:
+            # server_host_url/hosts/hostname
+
+            host_url = urljoin(settings.server.get_url(),
+                               'hosts/{0}'.format(self.client.hostname))
+            self.assertEqual(self.browser.current_url, host_url)

--- a/tests/foreman/ui/test_contenthost.py
+++ b/tests/foreman/ui/test_contenthost.py
@@ -268,14 +268,15 @@ class ContentHostTestCase(UITestCase):
         """Check that the host link in provisioning tab of content host page
         point to the host details page.
 
-        @id: 28f5fb0e-007b-4ee6-876e-9693fb7f5841
+        :id: 28f5fb0e-007b-4ee6-876e-9693fb7f5841
 
-        @assert: The Provisioning host details name link at
-        content_hosts/provisioning point to host detail page eg: hosts/hostname
+        :assert: The Provisioning host details name link at
+            content_hosts/provisioning point to host detail page
+            eg: hosts/hostname
 
-        @BZ: 1387892
+        :BZ: 1387892
 
-        @CaseLevel: System
+        :CaseLevel: System
         """
         with Session(self.browser):
             # open the content host

--- a/tests/foreman/ui/test_contenthost.py
+++ b/tests/foreman/ui/test_contenthost.py
@@ -261,11 +261,12 @@ class ContentHostTestCase(UITestCase):
             self.assertEqual(
                 result['Registered By'], self.activation_key.name)
 
+    @skip_if_bug_open('bugzilla', 1377676)
     @skip_if_bug_open('bugzilla', 1387892)
     @tier3
     def test_positive_provisioning_host_link(self):
         """Check that the host link in provisioning tab of content host page
-         point to the host details page.
+        point to the host details page.
 
         @id: 28f5fb0e-007b-4ee6-876e-9693fb7f5841
 
@@ -287,7 +288,6 @@ class ContentHostTestCase(UITestCase):
                 tab_locators['contenthost.tab_provisioning_details_host_link'])
             # assert that the current url is equal to:
             # server_host_url/hosts/hostname
-
             host_url = urljoin(settings.server.get_url(),
                                'hosts/{0}'.format(self.client.hostname))
             self.assertEqual(self.browser.current_url, host_url)


### PR DESCRIPTION
**Settings content default_download_policy immediate** to skip the bug 1406315
issue: https://github.com/SatelliteQE/robottelo/issues/4404 
coverage of bug for 6.3: https://bugzilla.redhat.com/show_bug.cgi?id=1387892

when run without the decorator:
http://pastebin.test.redhat.com/463194

original PR : https://github.com/SatelliteQE/robottelo/pull/4403 for the coverage of cloned with flag 6.2.z https://bugzilla.redhat.com/show_bug.cgi?id=1429468
