### PR TITLE
Automated BZ1360239

### DIFF
--- a/robottelo/api/utils.py
+++ b/robottelo/api/utils.py
@@ -27,7 +27,7 @@ def enable_rhrepo_and_fetchid(basearch, org_id, product, repo,
     :param str reposet: The reposet name in which repository exists.
     :param str repo: The repository name who's Id is to be fetched.
     :param str basearch: The architecture of the repository.
-    :param str releasever: The releasever of the repository.
+    :param str optional releasever: The releasever of the repository.
     :return: Returns the repository Id.
     :rtype: str
 

--- a/robottelo/ui/activationkey.py
+++ b/robottelo/ui/activationkey.py
@@ -178,6 +178,15 @@ class ActivationKey(Base):
         self.click(locators['ak.content_hosts'])
         return self.wait_until_element(locators['ak.content_host_name']).text
 
+    def fetch_product_contents(self, name):
+        """Fetch associated product content from selected activation key."""
+        self.search_and_click(name)
+        self.click(tab_locators['ak.tab_prd_content'])
+        return [
+            el.text for el
+            in self.find_elements(locators['ak.product_contents'])
+        ]
+
     def copy(self, name, new_name=None):
         """Copies an existing activation key"""
         self.search_and_click(name)

--- a/robottelo/ui/locators/base.py
+++ b/robottelo/ui/locators/base.py
@@ -1464,6 +1464,12 @@ locators = LocatorDict({
     "ak.subscriptions.search": (
         By.XPATH,
         "//input[@ng-model='subscriptionSearch']"),
+    "ak.product_contents": (
+        By.XPATH,
+        ("//div[contains(@ng-controller, "
+         "'ActivationKeyProductDetailsController')]/div[@class='row']"
+         "/div[@ng-repeat='content in product.available_content']/h4/u"),
+    ),
 
     # Sync Status
     "sync.prd_expander": (

--- a/tests/foreman/cli/test_activationkey.py
+++ b/tests/foreman/cli/test_activationkey.py
@@ -668,7 +668,6 @@ class ActivationKeyTestCase(CLITestCase):
         self.assertEqual(content[0]['name'], REPOSET['rhst7'])
 
     @run_only_on('sat')
-    @skip_if_bug_open('bugzilla', 1360239)
     @tier3
     def test_positive_add_custom_product(self):
         """Test that custom product can be associated to Activation Keys
@@ -678,6 +677,8 @@ class ActivationKeyTestCase(CLITestCase):
         @Assert: Custom products are successfully associated to Activation key
 
         @CaseLevel: System
+
+        @BZ: 1360239
         """
         result = setup_org_for_a_custom_repo({
             u'url': FAKE_0_YUM_REPO,
@@ -692,7 +693,6 @@ class ActivationKeyTestCase(CLITestCase):
 
     @run_in_one_thread
     @run_only_on('sat')
-    @skip_if_bug_open('bugzilla', 1360239)
     @skip_if_not_set('fake_manifest')
     @tier3
     def test_positive_add_redhat_and_custom_products(self):
@@ -709,6 +709,8 @@ class ActivationKeyTestCase(CLITestCase):
         @Assert: RH/Custom product is successfully associated to Activation key
 
         @CaseLevel: System
+
+        @BZ: 1360239
         """
         org = make_org()
         result = setup_org_for_a_rh_repo({

--- a/tests/foreman/ui/test_activationkey.py
+++ b/tests/foreman/ui/test_activationkey.py
@@ -1394,3 +1394,53 @@ class ActivationKeyTestCase(UITestCase):
         with Session(self.browser) as session:
             set_context(session, org=self.organization.name)
             self.assertIsNotNone(self.activationkey.search(ak_name))
+
+    @run_in_one_thread
+    @skip_if_not_set('fake_manifest')
+    @tier2
+    def test_positive_fetch_product_content(self):
+        """Associate RH & custom product with AK and fetch AK's product content
+
+        @id: 4c37fb12-ea2a-404e-b7cc-a2735e8dedb6
+
+        @Assert: Both Red Hat and custom product subscriptions are assigned as
+        Activation Key's product content
+
+        @BZ: 1360239
+
+        @CaseLevel: Integration
+        """
+        org = entities.Organization().create()
+        with manifests.clone() as manifest:
+            upload_manifest(org.id, manifest.content)
+        rh_repo_id = enable_rhrepo_and_fetchid(
+            basearch='x86_64',
+            org_id=org.id,
+            product=PRDS['rhel'],
+            repo=REPOS['rhst7']['name'],
+            reposet=REPOSET['rhst7'],
+            releasever=None,
+        )
+        rh_repo = entities.Repository(id=rh_repo_id).read()
+        rh_repo.sync()
+        custom_product = entities.Product(organization=org).create()
+        custom_repo = entities.Repository(
+            name=gen_string('alphanumeric').upper(),  # first letter is always
+            # uppercase on product content page, workarounding it for
+            # successful checks
+            product=custom_product).create()
+        custom_repo.sync()
+        cv = entities.ContentView(
+            organization=org,
+            repository=[rh_repo_id, custom_repo.id],
+        ).create()
+        cv.publish()
+        ak = entities.ActivationKey(content_view=cv, organization=org).create()
+        with Session(self.browser) as session:
+            set_context(session, org=org.name)
+            self.activationkey.associate_product(
+                ak.name, [custom_product.name, DEFAULT_SUBSCRIPTION_NAME])
+            self.assertEqual(
+                set(self.activationkey.fetch_product_contents(ak.name)),
+                {custom_repo.name, REPOSET['rhst7']}
+            )


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1360239
```python
py.test tests/foreman/{api,cli,ui}/test_activationkey.py -k 'test_positive_add_custom_product or test_positive_add_redhat_and_custom_products or test_positive_fetch_product_content'
============================= test session starts ==============================
platform darwin -- Python 2.7.13, pytest-3.0.6, py-1.4.32, pluggy-0.4.0
rootdir: /Users/andrii/workspace/robottelo, inifile:
collected 108 items
2017-03-09 17:28:06 - conftest - DEBUG - Found WONTFIX in decorated tests ['1269196', '1245334', '1217635', '1226425', '1156555', '1204686', '1267224', '1103157', '1230902', '1214312', '1079482']

2017-03-09 17:28:06 - conftest - DEBUG - Collected 108 test cases

2017-03-09 17:28:06 - conftest - DEBUG - Deselected test tests.foreman.api.test_activationkey.test_negative_create_with_no_host_limit_set_max due to WONTFIX


tests/foreman/api/test_activationkey.py .
tests/foreman/cli/test_activationkey.py ..
tests/foreman/ui/test_activationkey.py ..

============================= 103 tests deselected =============================
================= 5 passed, 103 deselected in 2926.19 seconds ==================
```