### PR TITLE
Fix location/organization CLI tests that were skipped

### DIFF
--- a/tests/foreman/cli/test_location.py
+++ b/tests/foreman/cli/test_location.py
@@ -759,9 +759,10 @@ class LocationTestCase(CLITestCase):
             'value': param_value,
             'location': location['name'],
         })
-        result = Location.info({'id': location['id']})
-        self.assertEqual(len(result['parameters']), 1)
-        self.assertEqual(param_value, result['parameters'][param_name.lower()])
+        location = Location.info({'id': location['id']})
+        self.assertEqual(len(location['parameters']), 1)
+        self.assertEqual(
+            param_value, location['parameters'][param_name.lower()])
 
     @tier1
     def test_positive_add_parameter_by_loc_id(self):
@@ -779,9 +780,10 @@ class LocationTestCase(CLITestCase):
             'value': param_value,
             'location-id': location['id'],
         })
-        result = Location.info({'id': location['id']})
-        self.assertEqual(len(result['parameters']), 1)
-        self.assertEqual(param_value, result['parameters'][param_name.lower()])
+        location = Location.info({'id': location['id']})
+        self.assertEqual(len(location['parameters']), 1)
+        self.assertEqual(
+            param_value, location['parameters'][param_name.lower()])
 
     @tier1
     def test_positive_update_parameter(self):
@@ -800,19 +802,18 @@ class LocationTestCase(CLITestCase):
             'value': gen_string('alpha'),
             'location': location['name'],
         })
-        result = Location.info({'id': location['id']})
-        self.assertEqual(len(result['parameters']), 1)
+        location = Location.info({'id': location['id']})
+        self.assertEqual(len(location['parameters']), 1)
         Location.set_parameter({
             'name': param_name,
             'value': param_new_value,
             'location': location['name'],
         })
-        result = Location.info({'id': location['id']})
-        self.assertEqual(len(result['parameters']), 1)
+        location = Location.info({'id': location['id']})
+        self.assertEqual(len(location['parameters']), 1)
         self.assertEqual(
-            param_new_value, result['parameters'][param_name.lower()])
+            param_new_value, location['parameters'][param_name.lower()])
 
-    @skip_if_bug_open('bugzilla', 1395229)
     @tier1
     def test_positive_remove_parameter_by_loc_name(self):
         """Remove a parameter from location
@@ -828,16 +829,16 @@ class LocationTestCase(CLITestCase):
             'value': gen_string('alpha'),
             'location': location['name'],
         })
-        result = Location.info({'id': location['id']})
-        self.assertEqual(len(result['parameters']), 1)
+        location = Location.info({'id': location['id']})
+        self.assertEqual(len(location['parameters']), 1)
         Location.delete_parameter({
             'name': param_name,
             'location': location['name'],
         })
-        self.assertEqual(len(result['parameters']), 0)
-        self.assertNotIn(param_name.lower(), result['parameters'])
+        location = Location.info({'id': location['id']})
+        self.assertEqual(len(location['parameters']), 0)
+        self.assertNotIn(param_name.lower(), location['parameters'])
 
-    @skip_if_bug_open('bugzilla', 1395229)
     @tier1
     def test_positive_remove_parameter_by_loc_id(self):
         """Remove a parameter from location
@@ -853,11 +854,12 @@ class LocationTestCase(CLITestCase):
             'value': gen_string('alpha'),
             'location-id': location['id'],
         })
-        result = Location.info({'id': location['id']})
-        self.assertEqual(len(result['parameters']), 1)
+        location = Location.info({'id': location['id']})
+        self.assertEqual(len(location['parameters']), 1)
         Location.delete_parameter({
             'name': param_name,
             'location-id': location['id'],
         })
-        self.assertEqual(len(result['parameters']), 0)
-        self.assertNotIn(param_name.lower(), result['parameters'])
+        location = Location.info({'id': location['id']})
+        self.assertEqual(len(location['parameters']), 0)
+        self.assertNotIn(param_name.lower(), location['parameters'])

--- a/tests/foreman/cli/test_organization.py
+++ b/tests/foreman/cli/test_organization.py
@@ -1199,9 +1199,9 @@ class OrganizationTestCase(CLITestCase):
             'location-id': loc['id'],
             'name': org['name'],
         })
-        result = Org.info({'id': org['id']})
-        self.assertEqual(len(result['locations']), 1)
-        self.assertIn(loc['name'], result['locations'])
+        org = Org.info({'id': org['id']})
+        self.assertEqual(len(org['locations']), 1)
+        self.assertIn(loc['name'], org['locations'])
 
     @run_only_on('sat')
     @tier2
@@ -1220,9 +1220,9 @@ class OrganizationTestCase(CLITestCase):
             'location': loc['name'],
             'name': org['name'],
         })
-        result = Org.info({'id': org['id']})
-        self.assertEqual(len(result['locations']), 1)
-        self.assertIn(loc['name'], result['locations'])
+        org = Org.info({'id': org['id']})
+        self.assertEqual(len(org['locations']), 1)
+        self.assertIn(loc['name'], org['locations'])
 
     @run_only_on('sat')
     @skip_if_bug_open('bugzilla', 1395229)
@@ -1242,15 +1242,15 @@ class OrganizationTestCase(CLITestCase):
             'location-id': loc['id'],
             'name': org['name'],
         })
-        result = Org.info({'id': org['id']})
-        self.assertEqual(len(result['locations']), 1)
-        self.assertIn(loc['name'], result['locations'])
+        org = Org.info({'id': org['id']})
+        self.assertEqual(len(org['locations']), 1)
+        self.assertIn(loc['name'], org['locations'])
         Org.remove_location({
             'location-id': loc['id'],
             'id': org['id'],
         })
-        result = Org.info({'id': org['id']})
-        self.assertEqual(len(result['locations']), 0)
+        org = Org.info({'id': org['id']})
+        self.assertEqual(len(org['locations']), 0)
 
     @run_only_on('sat')
     @skip_if_bug_open('bugzilla', 1395229)
@@ -1270,15 +1270,15 @@ class OrganizationTestCase(CLITestCase):
             'location': loc['name'],
             'name': org['name'],
         })
-        result = Org.info({'id': org['id']})
-        self.assertEqual(len(result['locations']), 1)
-        self.assertIn(loc['name'], result['locations'])
+        org = Org.info({'id': org['id']})
+        self.assertEqual(len(org['locations']), 1)
+        self.assertIn(loc['name'], org['locations'])
         Org.remove_location({
             'location': loc['name'],
             'id': org['id'],
         })
-        result = Org.info({'id': org['id']})
-        self.assertEqual(len(result['locations']), 0)
+        org = Org.info({'id': org['id']})
+        self.assertEqual(len(org['locations']), 0)
 
     @run_only_on('sat')
     @tier1
@@ -1297,9 +1297,9 @@ class OrganizationTestCase(CLITestCase):
             'value': param_value,
             'organization': org['name'],
         })
-        result = Org.info({'id': org['id']})
-        self.assertEqual(len(result['parameters']), 1)
-        self.assertEqual(param_value, result['parameters'][param_name.lower()])
+        org = Org.info({'id': org['id']})
+        self.assertEqual(len(org['parameters']), 1)
+        self.assertEqual(param_value, org['parameters'][param_name.lower()])
 
     @run_only_on('sat')
     @tier1
@@ -1318,9 +1318,9 @@ class OrganizationTestCase(CLITestCase):
             'value': param_value,
             'organization-id': org['id'],
         })
-        result = Org.info({'id': org['id']})
-        self.assertEqual(len(result['parameters']), 1)
-        self.assertEqual(param_value, result['parameters'][param_name.lower()])
+        org = Org.info({'id': org['id']})
+        self.assertEqual(len(org['parameters']), 1)
+        self.assertEqual(param_value, org['parameters'][param_name.lower()])
 
     @run_only_on('sat')
     @tier1
@@ -1340,20 +1340,19 @@ class OrganizationTestCase(CLITestCase):
             'value': gen_string('alpha'),
             'organization': org['name'],
         })
-        result = Org.info({'id': org['id']})
-        self.assertEqual(len(result['parameters']), 1)
+        org = Org.info({'id': org['id']})
+        self.assertEqual(len(org['parameters']), 1)
         Org.set_parameter({
             'name': param_name,
             'value': param_new_value,
             'organization': org['name'],
         })
-        result = Org.info({'id': org['id']})
-        self.assertEqual(len(result['parameters']), 1)
+        org = Org.info({'id': org['id']})
+        self.assertEqual(len(org['parameters']), 1)
         self.assertEqual(
-            param_new_value, result['parameters'][param_name.lower()])
+            param_new_value, org['parameters'][param_name.lower()])
 
     @run_only_on('sat')
-    @skip_if_bug_open('bugzilla', 1395229)
     @tier1
     def test_positive_remove_parameter_by_org_name(self):
         """Remove a parameter from organization
@@ -1369,17 +1368,17 @@ class OrganizationTestCase(CLITestCase):
             'value': gen_string('alpha'),
             'organization': org['name'],
         })
-        result = Org.info({'id': org['id']})
-        self.assertEqual(len(result['parameters']), 1)
+        org = Org.info({'id': org['id']})
+        self.assertEqual(len(org['parameters']), 1)
         Org.delete_parameter({
             'name': param_name,
             'organization': org['name'],
         })
-        self.assertEqual(len(result['parameters']), 0)
-        self.assertNotIn(param_name.lower(), result['parameters'])
+        org = Org.info({'id': org['id']})
+        self.assertEqual(len(org['parameters']), 0)
+        self.assertNotIn(param_name.lower(), org['parameters'])
 
     @run_only_on('sat')
-    @skip_if_bug_open('bugzilla', 1395229)
     @tier1
     def test_positive_remove_parameter_by_org_id(self):
         """Remove a parameter from organization
@@ -1395,14 +1394,15 @@ class OrganizationTestCase(CLITestCase):
             'value': gen_string('alpha'),
             'organization-id': org['id'],
         })
-        result = Org.info({'id': org['id']})
-        self.assertEqual(len(result['parameters']), 1)
+        org = Org.info({'id': org['id']})
+        self.assertEqual(len(org['parameters']), 1)
         Org.delete_parameter({
             'name': param_name,
             'organization-id': org['id'],
         })
-        self.assertEqual(len(result['parameters']), 0)
-        self.assertNotIn(param_name.lower(), result['parameters'])
+        org = Org.info({'id': org['id']})
+        self.assertEqual(len(org['parameters']), 0)
+        self.assertNotIn(param_name.lower(), org['parameters'])
 
     # Negative Create
 


### PR DESCRIPTION
Some tests added in #4378 were not affected by BZ like other `remove` tests but rather had missing step.
Also added cosmetic changes -- general `result` was renamed to specific `org` or `location` when fetching organization or location info.

```python
% py.test -v tests/foreman/cli/test_{location,organization}.py -k 'parameter'
===================================================================== test session starts =====================================================================
platform linux2 -- Python 2.7.12, pytest-2.9.2, py-1.4.32, pluggy-0.3.1 -- /home/qui/code/venv/2/bin/python2
cachedir: .cache
rootdir: /home/qui/code/robottelo, inifile: 
plugins: xdist-1.15.0, html-1.12.0, cov-2.3.1
collected 111 items 
2017-03-10 11:32:00 - conftest - DEBUG - Found WONTFIX in decorated tests ['1269196', '1245334', '1217635', '1226425', '1156555', '1204686', '1267224', '1103157', '1230902', '1214312', '1079482']

2017-03-10 11:32:00 - conftest - DEBUG - Collected 111 test cases


tests/foreman/cli/test_location.py::LocationTestCase::test_positive_add_parameter_by_loc_id PASSED
tests/foreman/cli/test_location.py::LocationTestCase::test_positive_add_parameter_by_loc_name PASSED
tests/foreman/cli/test_location.py::LocationTestCase::test_positive_remove_parameter_by_loc_id PASSED
tests/foreman/cli/test_location.py::LocationTestCase::test_positive_remove_parameter_by_loc_name PASSED
tests/foreman/cli/test_location.py::LocationTestCase::test_positive_update_parameter PASSED
tests/foreman/cli/test_organization.py::OrganizationTestCase::test_positive_add_parameter_by_org_id <- robottelo/decorators/__init__.py PASSED
tests/foreman/cli/test_organization.py::OrganizationTestCase::test_positive_add_parameter_by_org_name <- robottelo/decorators/__init__.py PASSED
tests/foreman/cli/test_organization.py::OrganizationTestCase::test_positive_remove_parameter_by_org_id <- robottelo/decorators/__init__.py PASSED
tests/foreman/cli/test_organization.py::OrganizationTestCase::test_positive_remove_parameter_by_org_name <- robottelo/decorators/__init__.py PASSED
tests/foreman/cli/test_organization.py::OrganizationTestCase::test_positive_update_parameter <- robottelo/decorators/__init__.py PASSED

============================================================ 101 tests deselected by '-kparameter' ============================================================
========================================================= 10 passed, 101 deselected in 288.61 seconds =========================================================
```