### PR TITLE
6.3 cherry-pick -- CLI getting job invocation output before asserts

### DIFF
--- a/robottelo/cli/job_invocation.py
+++ b/robottelo/cli/job_invocation.py
@@ -24,3 +24,10 @@ class JobInvocation(Base):
     """
 
     command_base = 'job-invocation'
+
+    @classmethod
+    def get_output(cls, options):
+        """Get output of the job invocation"""
+        cls.command_sub = 'output'
+        return cls.execute(
+            cls._construct_command(options))

--- a/tests/foreman/cli/test_remoteexecution.py
+++ b/tests/foreman/cli/test_remoteexecution.py
@@ -252,7 +252,16 @@ class RemoteExecutionTestCase(CLITestCase):
             'inputs': 'command="ls"',
             'search-query': "name ~ {0}".format(self.client.hostname),
         })
-        self.assertEqual(invocation_command['success'], u'1')
+        self.assertEqual(
+                invocation_command['success'],
+                u'1',
+                'host output: {0}'.format(
+                    ' '.join(JobInvocation.get_output({
+                        'id': invocation_command[u'id'],
+                        'host': self.client.hostname})
+                    )
+                )
+            )
 
     @tier2
     def test_positive_run_custom_job_template(self):
@@ -272,7 +281,16 @@ class RemoteExecutionTestCase(CLITestCase):
             'job-template': template_name,
             'search-query': "name ~ {0}".format(self.client.hostname),
         })
-        self.assertEqual(invocation_command[u'success'], u'1')
+        self.assertEqual(
+                invocation_command['success'],
+                u'1',
+                'host output: {0}'.format(
+                    ' '.join(JobInvocation.get_output({
+                        'id': invocation_command[u'id'],
+                        'host': self.client.hostname})
+                    )
+                )
+            )
 
     @tier3
     def test_positive_run_scheduled_job_template(self):
@@ -300,7 +318,15 @@ class RemoteExecutionTestCase(CLITestCase):
                 'id': invocation_command[u'id']})
             pending_state = invocation_info[u'pending']
             sleep(30)
-        # Check the job status
         invocation_info = JobInvocation.info({
             'id': invocation_command[u'id']})
-        self.assertEqual(invocation_info[u'success'], u'1')
+        self.assertEqual(
+                invocation_info['success'],
+                u'1',
+                'host output: {0}'.format(
+                    ' '.join(JobInvocation.get_output({
+                        'id': invocation_command[u'id'],
+                        'host': self.client.hostname})
+                    )
+                )
+            )


### PR DESCRIPTION
Cherry picking from PR #4408 so that it is not forgotten
Requested in issue #4402 
Testing is currently prevented by https://bugzilla.redhat.com/show_bug.cgi?id=1406315
Also this is dependent on PR #4236 that is currently on hold