### PR TITLE
Experimental support of Microsoft Edge with Microsoft WebDriver

### DIFF
--- a/robottelo.properties.sample
+++ b/robottelo.properties.sample
@@ -55,12 +55,13 @@ ssh_key=
 #   other valid webdriver values are going to be translated to firefox.
 # browser=selenium
 
-# Webdriver to use. Valid values are chrome, firefox, ie, phantomjs
+# Webdriver to use. Valid values are chrome, firefox, ie, edge, phantomjs
 # webdriver=firefox
 
 # Binary location for selected wedriver
 # webdriver_binary=/usr/bin/firefox
 # webdriver_binary=/usr/bin/chromedriver
+# webdriver_binary=C:\\Program Files (x86)\\Microsoft Web Driver\\MicrosoftWebDriver.exe
 
 # webdriver_desired_capabilities accepts extra configuration to be passed to
 # saucelabs in order to configure the test options. You can use the platform

--- a/robottelo/config/base.py
+++ b/robottelo/config/base.py
@@ -879,7 +879,7 @@ class Settings(object):
         """Validate Robottelo's general settings."""
         validation_errors = []
         browsers = ('selenium', 'docker', 'saucelabs')
-        webdrivers = ('chrome', 'firefox', 'ie', 'phantomjs', 'remote')
+        webdrivers = ('chrome', 'edge', 'firefox', 'ie', 'phantomjs', 'remote')
         if self.browser not in browsers:
             validation_errors.append(
                 '[robottelo] browser should be one of {0}.'

--- a/robottelo/test.py
+++ b/robottelo/test.py
@@ -1,3 +1,4 @@
+# -*- encoding: utf-8 -*-
 """Test utilities for writing foreman tests
 
 All test cases for foreman tests are defined in this module and have utilities
@@ -279,6 +280,14 @@ class UITestCase(TestCase):
             self.addCleanup(self.browser.quit)
         self.browser.maximize_window()
         self.browser.get(settings.server.get_url())
+        # Workaround 'Certificate Error' screen on Microsoft Edge
+        if (self.driver_name == 'edge' and
+                'Certificate Error' in self.browser.title or
+                'Login' not in self.browser.title):
+            self.browser.get(
+                "javascript:document.getElementById('invalidcert_continue')"
+                ".click()"
+            )
 
         self.browser.foreman_user = self.foreman_user
         self.browser.foreman_password = self.foreman_password

--- a/robottelo/ui/browser.py
+++ b/robottelo/ui/browser.py
@@ -77,6 +77,10 @@ class Chrome(DriverLoggerMixin, webdriver.Chrome):
     """Custom Chrome for custom logging"""
 
 
+class Edge(DriverLoggerMixin, webdriver.Edge):
+    """Custom Edge for custom logging"""
+
+
 class Ie(DriverLoggerMixin, webdriver.Ie):
     """Custom Ie for custom logging"""
 
@@ -108,6 +112,18 @@ def browser():
             return (
                 Ie() if settings.webdriver_binary is None
                 else Ie(executable_path=settings.webdriver_binary)
+            )
+        elif webdriver_name == 'edge':
+            capabilities = webdriver.DesiredCapabilities.EDGE.copy()
+            capabilities['acceptSslCerts'] = True
+            capabilities['javascriptEnabled'] = True
+            return (
+                Edge(capabilities=capabilities)
+                if settings.webdriver_binary is None
+                else Edge(
+                    capabilities=capabilities,
+                    executable_path=settings.webdriver_binary,
+                )
             )
         elif webdriver_name == 'phantomjs':
             return PhantomJS(


### PR DESCRIPTION
Small patch i've used to be able to execute our tests under Microsoft Edge browser.

Note that this change alone in not enough, you'll have to use Microsoft WebDriver version 3.14393 or later and Microsoft Edge 14.14393 or later (part after the dot should match), as previous Edge  13.10586 version seems to have issues with Certificate Error screen rendering.


You'll also have to replace
```python
url_request.urlopen("http://127.0.0.1:%d/shutdown" % self.port)
```
with 
```python
url_request.urlopen("http://localhost:%d/shutdown" % self.port)
```
in `C:\Python27\Lib\site-packages\selenium\webdriver\edge\services.py` if you're using `selenium-2.48.0` (from our requirements file) as otherwise selenium won't be able to stop the service and will mark your tests with `FAIL` OR you can update selenium to newer version (i've tested the latest one available, `selenium-3.3.0`) which is not affected by this issue.