### PR TITLE
Change token prefix

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ PYTEST_XDIST_OPTS=$(PYTEST_OPTS) -n $(PYTEST_XDIST_NUMPROCESSES) --boxed
 ROBOTTELO_TESTS_PATH=tests/robottelo/
 TESTIMONY_TOKENS="assert, bz, caseautomation, casecomponent, caseimportance, caselevel, caseposneg, id, requirement, setup, subtype1, steps, testtype, upstream"
 TESTIMONY_MINIMUM_TOKENS="id, requirement, caseautomation, caselevel, casecomponent, testtype, caseimportance, upstream"
-TESTIMONY_OPTIONS=--tokens=$(TESTIMONY_TOKENS) --token-prefix "@" --minimum-tokens=$(TESTIMONY_MINIMUM_TOKENS)
+TESTIMONY_OPTIONS=--tokens=$(TESTIMONY_TOKENS) --minimum-tokens=$(TESTIMONY_MINIMUM_TOKENS)
 
 # Commands --------------------------------------------------------------------
 
@@ -66,10 +66,15 @@ test-docstrings: uuid-check
 	$(info "Checking for errors in docstrings and testimony tags...")
 	testimony $(TESTIMONY_OPTIONS) validate tests/foreman/api
 	testimony $(TESTIMONY_OPTIONS) validate tests/foreman/cli
-	testimony $(TESTIMONY_OPTIONS) validate tests/foreman/rhci
-	testimony $(TESTIMONY_OPTIONS) validate tests/foreman/ui
+	testimony $(TESTIMONY_OPTIONS) validate tests/foreman/endtoend
+	testimony $(TESTIMONY_OPTIONS) validate tests/foreman/installer
+	testimony $(TESTIMONY_OPTIONS) validate tests/foreman/longrun
+	testimony $(TESTIMONY_OPTIONS) validate tests/foreman/performance
 	testimony $(TESTIMONY_OPTIONS) validate tests/foreman/rhai
+	testimony $(TESTIMONY_OPTIONS) validate tests/foreman/rhci
 	testimony $(TESTIMONY_OPTIONS) validate tests/foreman/sys
+	testimony $(TESTIMONY_OPTIONS) validate tests/foreman/ui
+	testimony $(TESTIMONY_OPTIONS) validate tests/foreman/upgrade
 
 test-robottelo:
 	$(info "Running robottelo framework unit tests...")

--- a/docs/api/tests.foreman.performance.rst
+++ b/docs/api/tests.foreman.performance.rst
@@ -18,6 +18,11 @@
 
 .. automodule:: tests.foreman.performance.test_candlepin_concurrent_subscription_attach
 
+:mod:`tests.foreman.performance.test_pulp_sync`
+-----------------------------------------------
+
+.. automodule:: tests.foreman.performance.test_pulp_sync
+
 :mod:`tests.foreman.performance.test_standard_prep`
 ---------------------------------------------------
 

--- a/docs/api/tests.foreman.rst
+++ b/docs/api/tests.foreman.rst
@@ -7,10 +7,14 @@ Submodules:
 
     tests.foreman.api
     tests.foreman.cli
-    tests.foreman.performance
     tests.foreman.endtoend
+    tests.foreman.installer
+    tests.foreman.longrun
+    tests.foreman.performance
+    tests.foreman.rhai
     tests.foreman.rhci
-    tests.foreman.ui
     tests.foreman.sys
+    tests.foreman.ui
+    tests.foreman.upgrade
 
 .. automodule:: tests.foreman

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,7 +12,7 @@ pytest==3.0.6
 requests==2.13.0
 selenium==2.48.0  # pyup: ignore
 six==1.10.0
-testimony==1.2.0  # pyup: ignore
+testimony==1.3.1
 unittest2==1.1.0
 python-bugzilla==2.0.0
 PyYAML==3.12

--- a/scripts/fix_uuids.sh
+++ b/scripts/fix_uuids.sh
@@ -1,10 +1,10 @@
 #!/usr/bin/env bash
 
-# This script finds empty @id: and replace with new uuids
+# This script finds empty :id: and replace with new uuids
 # Then it finds for duplicates and replaces last occurrence with new uuids
-# finally it fixes '@id:xyz' to '@id: xyz' (missing space after :)
+# finally it fixes ':id:xyz' to ':id: xyz' (missing space after :)
 
-ID_TOKEN="@id:"
+ID_TOKEN=":id:"
 
 if [ "$1" = "--check" ]; then
     CHECK_ONLY=true
@@ -29,7 +29,7 @@ else
    echo "No empty $ID_TOKEN was found"
 fi
 
-# iterate if any empty @id found
+# iterate if any empty :id found
 for output_line in $EMPTY_IDS
 do
     if (echo "$output_line" | grep "tests/foreman"); then
@@ -43,11 +43,11 @@ do
     fi
 done
 
-# This script finds duplicated @id and replaces with new uuids
+# This script finds duplicated :id and replaces with new uuids
 
-# Finds occurrences of @id: in testimony tags then
+# Finds occurrences of :id: in testimony tags then
 # sort the output and filters only the duplicated
-# then looks for existence of "@id:" in final output
+# then looks for existence of ":id:" in final output
 # NOTE: can't print the line number -n here because of uniq -d
 DUP_EXISTS=$(grep -r -i $ID_TOKEN tests/foreman/ --include=*.py | sort | uniq -d | grep $ID_TOKEN)
 

--- a/scripts/gen_api_docs.sh
+++ b/scripts/gen_api_docs.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-for test_suite in api cli endtoend sys ui; do
+for test_suite in api cli endtoend installer longrun performance rhai rhci sys ui upgrade; do
     cat >"docs/api/tests.foreman.${test_suite}.rst" <<EOF
 :mod:\`tests.foreman.${test_suite}\`
 $(printf %$(( 21 + ${#test_suite} ))s | tr ' ' =)

--- a/tests/foreman/api/test_activationkey.py
+++ b/tests/foreman/api/test_activationkey.py
@@ -1,18 +1,18 @@
 """Unit tests for the ``activation_keys`` paths.
 
-@Requirement: Activationkey
+:Requirement: Activationkey
 
-@CaseAutomation: Automated
+:CaseAutomation: Automated
 
-@CaseLevel: Acceptance
+:CaseLevel: Acceptance
 
-@CaseComponent: API
+:CaseComponent: API
 
-@TestType: Functional
+:TestType: Functional
 
-@CaseImportance: High
+:CaseImportance: High
 
-@Upstream: No
+:Upstream: No
 """
 from fauxfactory import gen_integer, gen_string
 from nailgun import client, entities
@@ -58,10 +58,10 @@ class ActivationKeyTestCase(APITestCase):
     def test_positive_create_unlimited_hosts(self):
         """Create a plain vanilla activation key.
 
-        @id: 1d73b8cc-a754-4637-8bae-d9d2aaf89003
+        :id: 1d73b8cc-a754-4637-8bae-d9d2aaf89003
 
-        @Assert: Check that activation key is created and its "unlimited_hosts"
-        attribute defaults to true.
+        :Assert: Check that activation key is created and its "unlimited_hosts"
+            attribute defaults to true.
         """
         self.assertTrue(
             entities.ActivationKey().create().unlimited_hosts
@@ -71,10 +71,10 @@ class ActivationKeyTestCase(APITestCase):
     def test_positive_create_limited_hosts(self):
         """Create an activation key with limited hosts.
 
-        @id: 9bbba620-fd98-4139-a44b-af8ce330c7a4
+        :id: 9bbba620-fd98-4139-a44b-af8ce330c7a4
 
-        @Assert: Check that activation key is created and that hosts number
-        is limited
+        :Assert: Check that activation key is created and that hosts number is
+            limited
         """
         for max_host in _good_max_hosts():
             with self.subTest(max_host):
@@ -87,9 +87,9 @@ class ActivationKeyTestCase(APITestCase):
     def test_positive_create_with_name(self):
         """Create an activation key providing the initial name.
 
-        @id: 749e0d28-640e-41e5-89d6-b92411ce73a3
+        :id: 749e0d28-640e-41e5-89d6-b92411ce73a3
 
-        @Assert: Activation key is created and contains provided name.
+        :Assert: Activation key is created and contains provided name.
         """
         for name in valid_data_list():
             with self.subTest(name):
@@ -100,9 +100,9 @@ class ActivationKeyTestCase(APITestCase):
     def test_positive_create_with_description(self):
         """Create an activation key and provide a description.
 
-        @id: 64d93726-6f96-4a2e-ab29-eb5bfa2ff8ff
+        :id: 64d93726-6f96-4a2e-ab29-eb5bfa2ff8ff
 
-        @Assert: Created entity contains the provided description.
+        :Assert: Created entity contains the provided description.
         """
         for desc in valid_data_list():
             with self.subTest(desc):
@@ -113,9 +113,9 @@ class ActivationKeyTestCase(APITestCase):
     def test_negative_create_with_no_host_limit(self):
         """Create activation key without providing limitation for hosts number
 
-        @id: a9e756e1-886d-4f0d-b685-36ce4247517d
+        :id: a9e756e1-886d-4f0d-b685-36ce4247517d
 
-        @Assert: Activation key is not created
+        :Assert: Activation key is not created
         """
         with self.assertRaises(HTTPError):
             entities.ActivationKey(unlimited_hosts=False).create()
@@ -124,9 +124,9 @@ class ActivationKeyTestCase(APITestCase):
     def test_negative_create_with_invalid_host_limit(self):
         """Create activation key with invalid limit values for hosts number.
 
-        @id: c018b177-2074-4f1a-a7e0-9f38d6c9a1a6
+        :id: c018b177-2074-4f1a-a7e0-9f38d6c9a1a6
 
-        @Assert: Activation key is not created
+        :Assert: Activation key is not created
         """
         for max_host in _bad_max_hosts():
             with self.subTest(max_host):
@@ -140,9 +140,9 @@ class ActivationKeyTestCase(APITestCase):
         """Create activation key with unlimited hosts and set max hosts of
         varied values.
 
-        @id: 71b9b000-b978-4a95-b6f8-83c09ed39c01
+        :id: 71b9b000-b978-4a95-b6f8-83c09ed39c01
 
-        @Assert: Activation key is not created
+        :Assert: Activation key is not created
         """
         for max_host in _bad_max_hosts():
             with self.subTest(max_host):
@@ -154,9 +154,9 @@ class ActivationKeyTestCase(APITestCase):
     def test_negative_create_with_invalid_name(self):
         """Create activation key providing an invalid name.
 
-        @id: 5f7051be-0320-4d37-9085-6904025ad909
+        :id: 5f7051be-0320-4d37-9085-6904025ad909
 
-        @Assert: Activation key is not created
+        :Assert: Activation key is not created
         """
         for name in invalid_names_list():
             with self.subTest(name):
@@ -167,9 +167,9 @@ class ActivationKeyTestCase(APITestCase):
     def test_positive_update_limited_host(self):
         """Create activation key then update it to limited hosts.
 
-        @id: 34ca8303-8135-4694-9cf7-b20f8b4b0a1e
+        :id: 34ca8303-8135-4694-9cf7-b20f8b4b0a1e
 
-        @Assert: Activation key is created, updated to limited host
+        :Assert: Activation key is created, updated to limited host
         """
         # unlimited_hosts defaults to True.
         act_key = entities.ActivationKey().create()
@@ -187,9 +187,9 @@ class ActivationKeyTestCase(APITestCase):
         """Create activation key providing the initial name, then update
         its name to another valid name.
 
-        @id: f219f2dc-8759-43ab-a277-fbabede6795e
+        :id: f219f2dc-8759-43ab-a277-fbabede6795e
 
-        @Assert: Activation key is created, and its name can be updated.
+        :Assert: Activation key is created, and its name can be updated.
         """
         act_key = entities.ActivationKey().create()
         for new_name in valid_data_list():
@@ -202,13 +202,13 @@ class ActivationKeyTestCase(APITestCase):
     def test_negative_update_limit(self):
         """Create activation key then update its limit to invalid value.
 
-        @id: 0f857d2f-81ed-4b8b-b26e-34b4f294edbc
+        :id: 0f857d2f-81ed-4b8b-b26e-34b4f294edbc
 
-        @Assert:
+        :Assert:
 
-        1. Activation key is created
-        2. Update fails
-        3. Record is not changed
+            1. Activation key is created
+            2. Update fails
+            3. Record is not changed
         """
         act_key = entities.ActivationKey().create()
         want = {
@@ -229,9 +229,9 @@ class ActivationKeyTestCase(APITestCase):
     def test_negative_update_name(self):
         """Create activation key then update its name to an invalid name.
 
-        @id: da85a32c-942b-4ab8-a133-36b028208c4d
+        :id: da85a32c-942b-4ab8-a133-36b028208c4d
 
-        @Assert: Activation key is created, and its name is not updated.
+        :Assert: Activation key is created, and its name is not updated.
         """
         act_key = entities.ActivationKey().create()
         for new_name in invalid_names_list():
@@ -248,9 +248,9 @@ class ActivationKeyTestCase(APITestCase):
         """Create an activation key with ``max_hosts == 1``, then update that
         field with a string value.
 
-        @id: 3bcff792-105a-4577-b7c2-5b0de4f79c77
+        :id: 3bcff792-105a-4577-b7c2-5b0de4f79c77
 
-        @Assert: The update fails with an HTTP 422 return code.
+        :Assert: The update fails with an HTTP 422 return code.
         """
         act_key = entities.ActivationKey(max_hosts=1).create()
         with self.assertRaises(HTTPError):
@@ -262,11 +262,11 @@ class ActivationKeyTestCase(APITestCase):
     def test_positive_get_releases_status_code(self):
         """Get an activation key's releases. Check response format.
 
-        @id: e1ea4797-8d92-4bec-ae6b-7a26599825ab
+        :id: e1ea4797-8d92-4bec-ae6b-7a26599825ab
 
-        @Assert: HTTP 200 is returned with an ``application/json`` content-type
+        :Assert: HTTP 200 is returned with an ``application/json`` content-type
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         act_key = entities.ActivationKey().create()
         path = act_key.path('releases')
@@ -283,11 +283,11 @@ class ActivationKeyTestCase(APITestCase):
     def test_positive_get_releases_content(self):
         """Get an activation key's releases. Check response contents.
 
-        @id: 2fec3d71-33e9-40e5-b934-90b03afc26a1
+        :id: 2fec3d71-33e9-40e5-b934-90b03afc26a1
 
-        @Assert: A list of results is returned.
+        :Assert: A list of results is returned.
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         act_key = entities.ActivationKey().create()
         response = client.get(
@@ -302,17 +302,17 @@ class ActivationKeyTestCase(APITestCase):
     def test_positive_add_host_collections(self):
         """Associate an activation key with several host collections.
 
-        @id: 1538808c-621e-4cf9-9b9b-840c5dd54644
+        :id: 1538808c-621e-4cf9-9b9b-840c5dd54644
 
-        @Assert:
+        :Assert:
 
-        1. By default, an activation key is associated with no host
-           collections.
-        2. After associating an activation key with some set of host
-           collections and reading that activation key, the correct host
-           collections are listed.
+            1. By default, an activation key is associated with no host
+               collections.
+            2. After associating an activation key with some set of host
+               collections and reading that activation key, the correct host
+               collections are listed.
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         org = entities.Organization().create()  # re-use this to speed up test
 
@@ -338,17 +338,18 @@ class ActivationKeyTestCase(APITestCase):
     def test_positive_remove_host_collection(self):
         """Disassociate host collection from the activation key
 
-        @id: 31992ac4-fe55-45bb-bd17-a191928ec2ab
+        :id: 31992ac4-fe55-45bb-bd17-a191928ec2ab
 
-        @Assert:
+        :Assert:
 
-        1. By default, an activation key is associated with no host
-           collections.
-        2. Associating host collection with activation key add it to the list.
-        3. Disassociating host collection from the activation key actually
-           removes it from the list
+            1. By default, an activation key is associated with no host
+               collections.
+            2. Associating host collection with activation key add it to the
+               list.
+            3. Disassociating host collection from the activation key actually
+               removes it from the list
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         org = entities.Organization().create()
 
@@ -375,9 +376,9 @@ class ActivationKeyTestCase(APITestCase):
         """Create an activation key, then update the auto_attach
         field with the inverse boolean value.
 
-        @id: ec225dad-2d27-4b37-989d-1ba2c7f74ac4
+        :id: ec225dad-2d27-4b37-989d-1ba2c7f74ac4
 
-        @Assert: The value is changed.
+        :Assert: The value is changed.
         """
         act_key = entities.ActivationKey().create()
         act_key_2 = entities.ActivationKey(
@@ -390,9 +391,9 @@ class ActivationKeyTestCase(APITestCase):
     def test_positive_delete(self):
         """Create activation key and then delete it.
 
-        @id: aa28d8fb-e07d-45fa-b43a-fc90c706d633
+        :id: aa28d8fb-e07d-45fa-b43a-fc90c706d633
 
-        @Assert: Activation key is successfully deleted.
+        :Assert: Activation key is successfully deleted.
         """
         for name in valid_data_list():
             with self.subTest(name):
@@ -406,11 +407,11 @@ class ActivationKeyTestCase(APITestCase):
         """Delete any user who has previously created an activation key
         and check that activation key still exists
 
-        @id: 02ce92d4-8f49-48a0-bf9e-5d401f84cf46
+        :id: 02ce92d4-8f49-48a0-bf9e-5d401f84cf46
 
-        @Assert: Activation Key can be read
+        :Assert: Activation Key can be read
 
-        @BZ: 1291271
+        :BZ: 1291271
         """
         password = gen_string('alpha')
         user = entities.User(
@@ -433,14 +434,14 @@ class ActivationKeyTestCase(APITestCase):
     def test_positive_fetch_product_content(self):
         """Associate RH & custom product with AK and fetch AK's product content
 
-        @id: 424f3dfb-0112-464b-b633-e8c9bce6e0f1
+        :id: 424f3dfb-0112-464b-b633-e8c9bce6e0f1
 
-        @Assert: Both Red Hat and custom product subscriptions are assigned as
-        Activation Key's product content
+        :Assert: Both Red Hat and custom product subscriptions are assigned as
+            Activation Key's product content
 
-        @BZ: 1360239
+        :BZ: 1360239
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         org = entities.Organization().create()
         with manifests.clone() as manifest:
@@ -498,9 +499,9 @@ class ActivationKeySearchTestCase(APITestCase):
     def test_positive_search_by_org(self):
         """Search for all activation keys in an organization.
 
-        @id: aedba598-2e47-44a8-826c-4dc304ba00be
+        :id: aedba598-2e47-44a8-826c-4dc304ba00be
 
-        @Assert: Only activation keys in the organization are returned.
+        :Assert: Only activation keys in the organization are returned.
         """
         act_keys = entities.ActivationKey(organization=self.org).search()
         self.assertEqual(len(act_keys), 1)

--- a/tests/foreman/api/test_architecture.py
+++ b/tests/foreman/api/test_architecture.py
@@ -1,18 +1,18 @@
 """Unit tests for the ``architectures`` paths.
 
-@Requirement: Architecture
+:Requirement: Architecture
 
-@CaseAutomation: Automated
+:CaseAutomation: Automated
 
-@CaseLevel: Acceptance
+:CaseLevel: Acceptance
 
-@CaseComponent: API
+:CaseComponent: API
 
-@TestType: Functional
+:TestType: Functional
 
-@CaseImportance: High
+:CaseImportance: High
 
-@Upstream: No
+:Upstream: No
 """
 from nailgun import entities
 from requests.exceptions import HTTPError
@@ -28,12 +28,12 @@ class ArchitectureTestCase(APITestCase):
     def test_positive_add_os(self):
         """Create an architecture and associate it with an OS.
 
-        @id: 9943063d-34f3-4dbc-a341-474ec781e4d9
+        :id: 9943063d-34f3-4dbc-a341-474ec781e4d9
 
-        @Assert: The architecture can be created, and the association can be
-        read back from the server.
+        :Assert: The architecture can be created, and the association can be
+            read back from the server.
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         operating_sys = entities.OperatingSystem().create()
         arch = entities.Architecture(operatingsystem=[operating_sys]).create()
@@ -46,9 +46,9 @@ class ArchitectureTestCase(APITestCase):
     def test_positive_create_with_name(self):
         """Create an architecture providing the initial name.
 
-        @id: acbadcda-3410-45cb-a3aa-932a0facadc1
+        :id: acbadcda-3410-45cb-a3aa-932a0facadc1
 
-        @Assert: Architecture is created and contains provided name.
+        :Assert: Architecture is created and contains provided name.
         """
         for name in valid_data_list():
             with self.subTest(name):
@@ -61,9 +61,9 @@ class ArchitectureTestCase(APITestCase):
         """Create architecture providing an invalid initial name.
         set.
 
-        @id: c740b8c4-8ee3-4481-b041-4eff2faf9055
+        :id: c740b8c4-8ee3-4481-b041-4eff2faf9055
 
-        @Assert: Architecture is not created
+        :Assert: Architecture is not created
         """
         for name in invalid_names_list():
             with self.subTest(name):
@@ -75,9 +75,9 @@ class ArchitectureTestCase(APITestCase):
         """Create architecture then update its name to another
         valid name.
 
-        @id: 8dbbf4f8-188e-406a-9099-a707f553d6bb
+        :id: 8dbbf4f8-188e-406a-9099-a707f553d6bb
 
-        @Assert: Architecture is created, and its name can be updated.
+        :Assert: Architecture is created, and its name can be updated.
         """
         arch = entities.Architecture().create()
 
@@ -92,9 +92,9 @@ class ArchitectureTestCase(APITestCase):
     def test_negative_update_name(self):
         """Create architecture then update its name to an invalid name.
 
-        @id: 301b335e-9bc1-47d9-8bef-a8ca2e9ea18e
+        :id: 301b335e-9bc1-47d9-8bef-a8ca2e9ea18e
 
-        @Assert: Architecture is created, and its name is not updated.
+        :Assert: Architecture is created, and its name is not updated.
         """
         arch = entities.Architecture().create()
         for new_name in invalid_names_list():
@@ -109,9 +109,9 @@ class ArchitectureTestCase(APITestCase):
     def test_positive_delete(self):
         """Create architecture and then delete it.
 
-        @id: 114a2973-a889-4a5e-bfac-de4406826258
+        :id: 114a2973-a889-4a5e-bfac-de4406826258
 
-        @Assert: architecture is successfully deleted.
+        :Assert: architecture is successfully deleted.
         """
         for name in valid_data_list():
             with self.subTest(name):

--- a/tests/foreman/api/test_bookmarks.py
+++ b/tests/foreman/api/test_bookmarks.py
@@ -1,19 +1,19 @@
 # -*- encoding: utf-8 -*-
 """Test classes for Bookmark tests
 
-@Requirement: Bookmarks
+:Requirement: Bookmarks
 
-@CaseAutomation: Automated
+:CaseAutomation: Automated
 
-@CaseLevel: Acceptance
+:CaseLevel: Acceptance
 
-@CaseComponent: API
+:CaseComponent: API
 
-@TestType: Functional
+:TestType: Functional
 
-@CaseImportance: High
+:CaseImportance: High
 
-@Upstream: No
+:Upstream: No
 """
 from fauxfactory import gen_string
 from nailgun import entities
@@ -32,16 +32,16 @@ class BookmarkTestCase(APITestCase):
     def test_positive_create_with_name(self):
         """Create a bookmark
 
-        @id: aeef0944-379a-4a27-902d-aa5969dbd441
+        :id: aeef0944-379a-4a27-902d-aa5969dbd441
 
-        @Steps:
+        :Steps:
 
-        1. Create a bookmark with a random name, query and random valid
-           controller
-        2. List the bookmarks
+            1. Create a bookmark with a random name, query and random valid
+               controller
+            2. List the bookmarks
 
-        @Assert: No errors, Bookmark is listed, controller matches the
-        controller the bookmark was created for
+        :Assert: No errors, Bookmark is listed, controller matches the
+            controller the bookmark was created for
         """
         for entity in BOOKMARK_ENTITIES:
             with self.subTest(entity['controller']):
@@ -59,16 +59,16 @@ class BookmarkTestCase(APITestCase):
     def test_positive_create_with_query(self):
         """Create a bookmark
 
-        @id: 9fb6d485-92b5-43ea-b776-012c13734100
+        :id: 9fb6d485-92b5-43ea-b776-012c13734100
 
-        @Steps:
+        :Steps:
 
-        1. Create a bookmark with a random query, name and random valid
-           controller
-        2. List the bookmarks
+            1. Create a bookmark with a random query, name and random valid
+               controller
+            2. List the bookmarks
 
-        @Assert: No errors, Bookmark is listed, controller matches the
-        controller the bookmark was created for
+        :Assert: No errors, Bookmark is listed, controller matches the
+            controller the bookmark was created for
         """
         for entity in BOOKMARK_ENTITIES:
             with self.subTest(entity['controller']):
@@ -85,15 +85,15 @@ class BookmarkTestCase(APITestCase):
     def test_positive_create_public(self):
         """Create a public bookmark
 
-        @id: 511b9bcf-0661-4e44-b1bc-475a1c207aa9
+        :id: 511b9bcf-0661-4e44-b1bc-475a1c207aa9
 
-        @Steps:
+        :Steps:
 
-        1. Create a bookmark with a random name and public = true
-        2. List the bookmarks
+            1. Create a bookmark with a random name and public = true
+            2. List the bookmarks
 
-        @Assert: No errors, Bookmark is listed, controller matches the entity
-        the bookmark was created for and is displayed as public
+        :Assert: No errors, Bookmark is listed, controller matches the entity
+            the bookmark was created for and is displayed as public
         """
         for entity in BOOKMARK_ENTITIES:
             with self.subTest(entity['controller']):
@@ -110,14 +110,14 @@ class BookmarkTestCase(APITestCase):
     def test_negative_create_with_invalid_name(self):
         """Create a bookmark with invalid name
 
-        @id: 9a79c561-8225-43fc-8ec7-b6858e9665e2
+        :id: 9a79c561-8225-43fc-8ec7-b6858e9665e2
 
-        @Steps:
+        :Steps:
 
-        1. Attempt to create a bookmark with providing an invalid name
-        2. List the bookmarks
+            1. Attempt to create a bookmark with providing an invalid name
+            2. List the bookmarks
 
-        @Assert: Error returned, Bookmark is not created (not listed)
+        :Assert: Error returned, Bookmark is not created (not listed)
         """
         for entity in BOOKMARK_ENTITIES:
             with self.subTest(entity['controller']):
@@ -137,15 +137,15 @@ class BookmarkTestCase(APITestCase):
     def test_negative_create_empty_query(self):
         """Create a bookmark with empty query
 
-        @id: 674d569f-6f86-43ba-b9cc-f43e05e8ab1c
+        :id: 674d569f-6f86-43ba-b9cc-f43e05e8ab1c
 
-        @Steps:
+        :Steps:
 
-        1. Create a bookmark with providing an empty query
-        2. List the bookmarks
+            1. Create a bookmark with providing an empty query
+            2. List the bookmarks
 
-        @Assert: Error notification - search query cannot be empty, Bookmark is
-        not created (not listed)
+        :Assert: Error notification - search query cannot be empty, Bookmark is
+            not created (not listed)
         """
         for entity in BOOKMARK_ENTITIES:
             with self.subTest(entity['controller']):
@@ -164,22 +164,20 @@ class BookmarkTestCase(APITestCase):
     def test_negative_create_same_name(self):
         """Create bookmarks with the same names
 
-        @id: f78f6e97-da77-4a61-95c2-622c439d325d
+        :id: f78f6e97-da77-4a61-95c2-622c439d325d
 
-        @Setup:
+        :Setup: Create a bookmark with a random name
 
-        1. Create a bookmark with a random name
+        :Steps:
 
-        @Steps:
+            1. Create a new bookmark using a random name
+            2. Create a second bookmark, using the same name as the previous
+               Bookmark. Assert that an error is raised.
+            3. List the bookmarks. Assert that the Bookmark created is present
+               and there's only one listed
 
-        1. Create a new bookmark using a random name
-        2. Create a second bookmark, using the same name as
-           the previous Bookmark. Assert that an error is raised.
-        3. List the bookmarks. Assert that the Bookmark created is present and
-           there's only one listed
-
-        @Assert: Error notification - name already taken, Bookmark is not
-        created (not listed)
+        :Assert: Error notification - name already taken, Bookmark is not
+            created (not listed)
         """
         for entity in BOOKMARK_ENTITIES:
             with self.subTest(entity['controller']):
@@ -202,18 +200,18 @@ class BookmarkTestCase(APITestCase):
     def test_negative_create_null_public(self):
         """Create a bookmark omitting the public parameter
 
-        @id: 0a4cb5ea-912b-445e-a874-b345e43d3eac
+        :id: 0a4cb5ea-912b-445e-a874-b345e43d3eac
 
-        @Steps:
+        :Steps:
 
-        1. Create a new bookmark using a random name, random query and omit the
-           'public' parameter
-        2. List the bookmarks
+            1. Create a new bookmark using a random name, random query and omit
+               the 'public' parameter
+            2. List the bookmarks
 
-        @Assert: Error notification - public is required, Bookmark is not
-        created (not listed)
+        :Assert: Error notification - public is required, Bookmark is not
+            created (not listed)
 
-        @BZ: 1302725
+        :BZ: 1302725
         """
         for entity in BOOKMARK_ENTITIES:
             with self.subTest(entity['controller']):
@@ -233,17 +231,13 @@ class BookmarkTestCase(APITestCase):
     def test_positive_update_name(self):
         """Update a bookmark
 
-        @id: 1cde270a-26fb-4cff-bdff-89fef17a7624
+        :id: 1cde270a-26fb-4cff-bdff-89fef17a7624
 
-        @Setup:
+        :Setup: Create a new bookmark with a random name and random query
 
-        1. Create a new bookmark with a random name and random query
+        :Steps: Update the previously created bookmark with another random name
 
-        @Steps:
-
-        1. Update the previously created bookmark with another random name
-
-        @Assert: The new bookmark name is listed
+        :Assert: The new bookmark name is listed
         """
         for entity in BOOKMARK_ENTITIES:
             with self.subTest(entity['controller']):
@@ -261,18 +255,15 @@ class BookmarkTestCase(APITestCase):
     def test_negative_update_same_name(self):
         """Update a bookmark with name already taken
 
-        @id: 6becf121-2bea-4f7e-98f4-338bd88b8f4b
+        :id: 6becf121-2bea-4f7e-98f4-338bd88b8f4b
 
-        @Setup:
+        :Setup: Create 2 bookmarks with a random names with random query
 
-        1. Create 2 bookmarks with a random names with random query
+        :Steps: Try to update the name of the first (or second) Bookmark
+            created in the Setup with the name of the second (or first)
+            Bookmark
 
-        @Steps:
-
-        1. Try to update the name of the first (or second) Bookmark created in
-           the Setup with the name of the second (or first) Bookmark
-
-        @Assert: Error - name already taken, bookmark not updated
+        :Assert: Error - name already taken, bookmark not updated
         """
         for entity in BOOKMARK_ENTITIES:
             with self.subTest(entity['controller']):
@@ -294,18 +285,14 @@ class BookmarkTestCase(APITestCase):
     def test_negative_update_invalid_name(self):
         """Update a bookmark with an invalid name
 
-        @id: 479795bb-aeed-45b3-a7e3-d3449c808087
+        :id: 479795bb-aeed-45b3-a7e3-d3449c808087
 
-        @Setup:
+        :Setup: Create a bookmark with a random name and random query
 
-        1. Create a bookmark with a random name and random query
+        :Steps: Update the name of the previously created bookmarks to an
+            invalid value
 
-        @Steps:
-
-        1. Update the name of the previously created bookmarks to an invalid
-           value
-
-        @Assert: Error - bookmark not updated
+        :Assert: Error - bookmark not updated
         """
         for entity in BOOKMARK_ENTITIES:
             with self.subTest(entity['controller']):
@@ -325,17 +312,13 @@ class BookmarkTestCase(APITestCase):
     def test_positive_update_query(self):
         """Update a bookmark query
 
-        @id: 92a31de2-bebf-4396-94f5-adf59f8d66a5
+        :id: 92a31de2-bebf-4396-94f5-adf59f8d66a5
 
-        @Setup:
+        :Setup: Create a bookmark with a random name and random query
 
-        1. Create a bookmark with a random name and random query
+        :Steps: Update the query of the previously created bookmark
 
-        @Steps:
-
-        1. Update the query of the previously created bookmark
-
-        @Assert: The updated query submitted
+        :Assert: The updated query submitted
         """
         for entity in BOOKMARK_ENTITIES:
             with self.subTest(entity['controller']):
@@ -352,17 +335,14 @@ class BookmarkTestCase(APITestCase):
     def test_negative_update_empty_query(self):
         """Update a bookmark with an empty query
 
-        @id: 948602d3-532a-47fe-b313-91e3fab809bf
+        :id: 948602d3-532a-47fe-b313-91e3fab809bf
 
-        @Setup:
+        :Setup: Create a bookmark with a random name and random query
 
-        1. Create a bookmark with a random name and random query
+        :Steps: Update the query of the pre-created bookmark with an empty
+            value
 
-        @Steps:
-
-        1. Update the query of the pre-created bookmark with an empty value
-
-        @Assert: Error - search query cannot be empty, bookmark not updated
+        :Assert: Error - search query cannot be empty, bookmark not updated
         """
         for entity in BOOKMARK_ENTITIES:
             with self.subTest(entity['controller']):
@@ -379,19 +359,17 @@ class BookmarkTestCase(APITestCase):
     def test_positive_update_public(self):
         """Update a bookmark public state to private and vice versa
 
-        @id: 2717360d-37c4-4bb9-bce1-b1edabdf11b3
+        :id: 2717360d-37c4-4bb9-bce1-b1edabdf11b3
 
-        @Setup:
+        :Setup: Create a bookmark with a random name and random query with
+            public attribute set to True/False
 
-        1. Create a bookmark with a random name and random query with public
-           attribute set to True/False
+        :Steps:
 
-        @Steps:
+            1. Update the bookmarks 'public' attribute
+            2. List the bookmarks
 
-        1. Update the bookmarks 'public' attribute
-        2. List the bookmarks
-
-        @Assert: Bookmark is updated with new public state
+        :Assert: Bookmark is updated with new public state
         """
         for entity in BOOKMARK_ENTITIES:
             with self.subTest(entity['controller']):

--- a/tests/foreman/api/test_classparameters.py
+++ b/tests/foreman/api/test_classparameters.py
@@ -1,19 +1,19 @@
 # -*- encoding: utf-8 -*-
 """Test class for Smart/Puppet Class Parameter
 
-@Requirement: Classparameters
+:Requirement: Classparameters
 
-@CaseAutomation: Automated
+:CaseAutomation: Automated
 
-@CaseLevel: Acceptance
+:CaseLevel: Acceptance
 
-@CaseComponent: API
+:CaseComponent: API
 
-@TestType: Functional
+:TestType: Functional
 
-@CaseImportance: High
+:CaseImportance: High
 
-@Upstream: No
+:Upstream: No
 """
 import json
 from random import choice
@@ -164,11 +164,11 @@ class SmartClassParametersTestCase(APITestCase):
     def test_positive_list_parameters_by_host_id(self):
         """List all the parameters included in specific Host by its id.
 
-        @id: a9e551f9-261b-40e6-b7f6-35621fc46285
+        :id: a9e551f9-261b-40e6-b7f6-35621fc46285
 
-        @assert: Parameters listed for specific Host.
+        :assert: Parameters listed for specific Host.
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         sc_param = self.sc_params_list.pop()
         sc_param.override = True
@@ -190,11 +190,11 @@ class SmartClassParametersTestCase(APITestCase):
     def test_positive_list_parameters_by_hostgroup_id(self):
         """List all the parameters included in specific HostGroup by id.
 
-        @id: 88ceea89-b8b5-4ca2-9d59-3b2614c7f9a7
+        :id: 88ceea89-b8b5-4ca2-9d59-3b2614c7f9a7
 
-        @assert: Parameters listed for specific HostGroup.
+        :assert: Parameters listed for specific HostGroup.
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         sc_param = self.sc_params_list.pop()
         sc_param.override = True
@@ -212,9 +212,9 @@ class SmartClassParametersTestCase(APITestCase):
     def test_positive_list_parameters_by_puppetclass_id(self):
         """List all the parameters for specific puppet class by id.
 
-        @id: c0378f1e-c215-4f85-892c-d21a8b5a7060
+        :id: c0378f1e-c215-4f85-892c-d21a8b5a7060
 
-        @assert: Parameters listed for specific Puppet class.
+        :assert: Parameters listed for specific Puppet class.
         """
         result = self.puppet_class.list_scparams()['results']
         self.assertGreater(len(result), 0)
@@ -227,9 +227,9 @@ class SmartClassParametersTestCase(APITestCase):
         """Import same puppet class twice (e.g. into different Content Views)
         but list class parameters only for specific puppet class.
 
-        @id: c20a56fd-a328-44ce-81ce-52e315c95a81
+        :id: c20a56fd-a328-44ce-81ce-52e315c95a81
 
-        @assert: Parameters listed for specific Puppet class.
+        :assert: Parameters listed for specific Puppet class.
 
         BZ: 1385351
         """
@@ -253,11 +253,11 @@ class SmartClassParametersTestCase(APITestCase):
     def test_positive_list_parameters_by_environment_id(self):
         """List all the parameters for specific environment by id.
 
-        @id: d4a06038-7405-4d75-b8ac-c43f48a3bc59
+        :id: d4a06038-7405-4d75-b8ac-c43f48a3bc59
 
-        @assert: Parameters listed for specific environment.
+        :assert: Parameters listed for specific environment.
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         sc_param = self.sc_params_list.pop()
         sc_param.override = True
@@ -273,14 +273,14 @@ class SmartClassParametersTestCase(APITestCase):
     def test_positive_override(self):
         """Override the Default Parameter value.
 
-        @id: eaa11546-79df-452e-9552-5b2507a27b48
+        :id: eaa11546-79df-452e-9552-5b2507a27b48
 
-        @steps:
+        :steps:
 
-        1. Set override to True.
-        2. Set the new valid Default Value.
+            1. Set override to True.
+            2. Set the new valid Default Value.
 
-        @assert: Parameter Value overridden with new value.
+        :assert: Parameter Value overridden with new value.
         """
         sc_param = self.sc_params_list.pop()
         value = gen_string('alpha')
@@ -296,14 +296,14 @@ class SmartClassParametersTestCase(APITestCase):
     def test_negative_override(self):
         """Override the Default Parameter value - override Unchecked.
 
-        @id: f4d56d31-ac48-495f-9e56-545f274a060f
+        :id: f4d56d31-ac48-495f-9e56-545f274a060f
 
-        @steps:
+        :steps:
 
-        1. Set override to False.
-        2. Set the new valid Default Value.
+            1. Set override to False.
+            2. Set the new valid Default Value.
 
-        @assert: Parameter value not allowed/disabled to override.
+        :assert: Parameter value not allowed/disabled to override.
         """
         sc_param = self.sc_params_list.pop()
         self.assertEqual(sc_param.read().override, False)
@@ -320,14 +320,14 @@ class SmartClassParametersTestCase(APITestCase):
     def test_positive_puppet_default(self):
         """On Override, Set Puppet Default Value.
 
-        @id: 7261b409-b482-41ba-934d-4b724e8113ac
+        :id: 7261b409-b482-41ba-934d-4b724e8113ac
 
-        @steps:
+        :steps:
 
-        1. Set override to True.
-        2. Set 'Use Puppet Default' to True.
+            1. Set override to True.
+            2. Set 'Use Puppet Default' to True.
 
-        @assert: Puppet Default Value applied on parameter.
+        :assert: Puppet Default Value applied on parameter.
         """
         sc_param = self.sc_params_list.pop()
         sc_param.override = True
@@ -342,15 +342,15 @@ class SmartClassParametersTestCase(APITestCase):
 
         Types - string, boolean, integer, real, array, hash, yaml, json
 
-        @id: 1140c3bf-ab3b-4da6-99fb-9c508cefbbd1
+        :id: 1140c3bf-ab3b-4da6-99fb-9c508cefbbd1
 
-        @steps:
+        :steps:
 
-        1. Set override to True.
-        2. Update the Key Type to any of available.
-        3. Set a 'valid' default Value.
+            1. Set override to True.
+            2. Update the Key Type to any of available.
+            3. Set a 'valid' default Value.
 
-        @assert: Parameter Updated with a new type successfully.
+        :assert: Parameter Updated with a new type successfully.
         """
         sc_param = self.sc_params_list.pop()
         for data in valid_sc_parameters_data():
@@ -387,18 +387,18 @@ class SmartClassParametersTestCase(APITestCase):
 
         Types - string, boolean, integer, real, array, hash, yaml, json
 
-        @id: 7f0ab885-5520-4431-a916-f739c0498a5b
+        :id: 7f0ab885-5520-4431-a916-f739c0498a5b
 
-        @steps:
+        :steps:
 
-        1. Set override to True.
-        2. Update the Key Type.
-        3. Attempt to set an 'Invalid' default Value.
+            1. Set override to True.
+            2. Update the Key Type.
+            3. Attempt to set an 'Invalid' default Value.
 
-        @assert:
+        :assert:
 
-        1. Parameter not updated with string type for invalid value.
-        2. Error raised for invalid default value.
+            1. Parameter not updated with string type for invalid value.
+            2. Error raised for invalid default value.
         """
         sc_param = self.sc_params_list.pop()
         for test_data in invalid_sc_parameters_data():
@@ -422,15 +422,15 @@ class SmartClassParametersTestCase(APITestCase):
     def test_negative_validate_puppet_default_value(self):
         """Validation doesn't work on puppet default value.
 
-        @id: 7d934091-e642-45df-b296-397865c0fe8e
+        :id: 7d934091-e642-45df-b296-397865c0fe8e
 
-        @steps:
+        :steps:
 
-        1. Set override to True.
-        2. Set puppet default value to 'Use Puppet Default'.
-        3. Set Validator Type and Rule to validate this value.
+            1. Set override to True.
+            2. Set puppet default value to 'Use Puppet Default'.
+            3. Set Validator Type and Rule to validate this value.
 
-        @assert: Validation shouldn't work with puppet default value.
+        :assert: Validation shouldn't work with puppet default value.
         """
 
     @run_only_on('sat')
@@ -438,15 +438,15 @@ class SmartClassParametersTestCase(APITestCase):
     def test_positive_validate_default_value_required_check(self):
         """No error raised for non-empty default Value - Required check.
 
-        @id: 92977eb0-92c2-4734-84d9-6fda8ff9d2d8
+        :id: 92977eb0-92c2-4734-84d9-6fda8ff9d2d8
 
-        @steps:
+        :steps:
 
-        1. Set override to True.
-        2. Set some default value, Not empty.
-        3. Set 'required' to true.
+            1. Set override to True.
+            2. Set some default value, Not empty.
+            3. Set 'required' to true.
 
-        @assert: No error raised for non-empty default value
+        :assert: No error raised for non-empty default value
         """
         sc_param = self.sc_params_list.pop()
         sc_param.parameter_type = 'boolean'
@@ -465,16 +465,15 @@ class SmartClassParametersTestCase(APITestCase):
     def test_negative_validate_matcher_value_required_check(self):
         """Error is raised for blank matcher Value - Required check.
 
-        @id: 49de2c9b-40f1-4837-8ebb-dfa40d8fcb89
+        :id: 49de2c9b-40f1-4837-8ebb-dfa40d8fcb89
 
-        @steps:
+        :steps:
+            1. Set override to True.
+            2. Create a matcher for Parameter for some attribute.
+            3. Set no value for matcher. Keep blank.
+            4. Set 'required' to true.
 
-        1. Set override to True.
-        2. Create a matcher for Parameter for some attribute.
-        3. Set no value for matcher. Keep blank.
-        4. Set 'required' to true.
-
-        @assert: Error raised for blank matcher value.
+        :assert: Error raised for blank matcher value.
         """
         sc_param = self.sc_params_list.pop()
         sc_param.override = True
@@ -496,16 +495,16 @@ class SmartClassParametersTestCase(APITestCase):
     def test_positive_validate_matcher_value_required_check(self):
         """Error is not raised for matcher Value - Required checkbox.
 
-        @id: bf620cef-c7ab-4a32-9050-bd06040dc8d1
+        :id: bf620cef-c7ab-4a32-9050-bd06040dc8d1
 
-        @steps:
+        :steps:
 
-        1. Set override to True.
-        2. Create a matcher for Parameter for some attribute.
-        3. Set some Value for matcher.
-        4. Set 'required' to true.
+            1. Set override to True.
+            2. Create a matcher for Parameter for some attribute.
+            3. Set some Value for matcher.
+            4. Set 'required' to true.
 
-        @assert: Error not raised for matcher value.
+        :assert: Error not raised for matcher value.
         """
         sc_param = self.sc_params_list.pop()
         value = gen_string('alpha')
@@ -526,15 +525,15 @@ class SmartClassParametersTestCase(APITestCase):
     def test_negative_validate_default_value_with_regex(self):
         """Error is raised for default value not matching with regex.
 
-        @id: 99628b78-3037-4c20-95f0-7ce5455093ac
+        :id: 99628b78-3037-4c20-95f0-7ce5455093ac
 
-        @steps:
+        :steps:
 
-        1. Set override to True.
-        2. Set default value that doesn't matches the regex of step 3.
-        3. Validate this value with regex validator type and rule.
+            1. Set override to True.
+            2. Set default value that doesn't matches the regex of step 3.
+            3. Validate this value with regex validator type and rule.
 
-        @assert: Error raised for default value not matching with regex.
+        :assert: Error raised for default value not matching with regex.
         """
         value = gen_string('alpha')
         sc_param = self.sc_params_list.pop()
@@ -558,15 +557,15 @@ class SmartClassParametersTestCase(APITestCase):
     def test_positive_validate_default_value_with_regex(self):
         """Error is not raised for default value matching with regex.
 
-        @id: d5df7804-9633-4ef8-a065-10807351d230
+        :id: d5df7804-9633-4ef8-a065-10807351d230
 
-        @steps:
+        :steps:
 
-        1. Set override to True.
-        2. Set default value that matches the regex of step 3.
-        3. Validate this value with regex validator type and rule.
+            1. Set override to True.
+            2. Set default value that matches the regex of step 3.
+            3. Validate this value with regex validator type and rule.
 
-        @assert: Error not raised for default value matching with regex.
+        :assert: Error not raised for default value matching with regex.
         """
         value = gen_string('numeric')
         sc_param = self.sc_params_list.pop()
@@ -587,16 +586,16 @@ class SmartClassParametersTestCase(APITestCase):
     def test_negative_validate_matcher_value_with_regex(self):
         """Error is raised for matcher value not matching with regex.
 
-        @id: 08820c89-2b93-40f1-be17-0bd38c519e90
+        :id: 08820c89-2b93-40f1-be17-0bd38c519e90
 
-        @steps:
+        :steps:
 
-        1. Set override to True.
-        2. Create a matcher with value that doesn't match
-           the regex of step 3.
-        3. Validate this value with regex validator type and rule.
+            1. Set override to True.
+            2. Create a matcher with value that doesn't match the regex of step
+               3.
+            3. Validate this value with regex validator type and rule.
 
-        @assert: Error raised for matcher value not matching with regex.
+        :assert: Error raised for matcher value not matching with regex.
         """
         sc_param = self.sc_params_list.pop()
         value = gen_string('numeric')
@@ -627,15 +626,15 @@ class SmartClassParametersTestCase(APITestCase):
     def test_positive_validate_matcher_value_with_regex(self):
         """Error is not raised for matcher value matching with regex.
 
-        @id: 74164406-885b-4f5b-8ea0-06738314310f
+        :id: 74164406-885b-4f5b-8ea0-06738314310f
 
-        @steps:
+        :steps:
 
-        1. Set override to True.
-        2. Create a matcher with value that matches the regex of step 3.
-        3. Validate this value with regex validator type and rule.
+            1. Set override to True.
+            2. Create a matcher with value that matches the regex of step 3.
+            3. Validate this value with regex validator type and rule.
 
-        @assert: Error not raised for matcher value matching with regex.
+        :assert: Error not raised for matcher value matching with regex.
         """
         sc_param = self.sc_params_list.pop()
         value = gen_string('numeric')
@@ -658,15 +657,15 @@ class SmartClassParametersTestCase(APITestCase):
     def test_negative_validate_default_value_with_list(self):
         """Error is raised for default value not in list.
 
-        @id: 75b1dc0b-2287-4b99-b8dc-e50b83355819
+        :id: 75b1dc0b-2287-4b99-b8dc-e50b83355819
 
-        @steps:
+        :steps:
 
-        1. Set override to True.
-        2. Set default value that doesn't matches the list of step 3.
-        3. Validate this value with list validator type and rule.
+            1. Set override to True.
+            2. Set default value that doesn't matches the list of step 3.
+            3. Validate this value with list validator type and rule.
 
-        @assert: Error is raised for default value that is not in list.
+        :assert: Error is raised for default value that is not in list.
         """
         value = gen_string('alphanumeric')
         sc_param = self.sc_params_list.pop()
@@ -692,15 +691,15 @@ class SmartClassParametersTestCase(APITestCase):
     def test_positive_validate_default_value_with_list(self):
         """Error is not raised for default value in list.
 
-        @id: d5d5f084-fa62-4ec3-90ea-9fcabd7bda4f
+        :id: d5d5f084-fa62-4ec3-90ea-9fcabd7bda4f
 
-        @steps:
+        :steps:
 
-        1. Set override to True.
-        2. Set default value that matches the list of step 3.
-        3. Validate this value with list validator type and rule.
+            1. Set override to True.
+            2. Set default value that matches the list of step 3.
+            3. Validate this value with list validator type and rule.
 
-        @assert: Error not raised for default value in list.
+        :assert: Error not raised for default value in list.
         """
         # Generate list of values
         values_list = [
@@ -733,16 +732,16 @@ class SmartClassParametersTestCase(APITestCase):
     def test_negative_validate_matcher_value_with_list(self):
         """Error is raised for matcher value not in list.
 
-        @id: a5e89e86-253f-4254-9ebb-eefb3dc2c2ab
+        :id: a5e89e86-253f-4254-9ebb-eefb3dc2c2ab
 
-        @steps:
+        :steps:
 
-        1. Set override to True.
-        2. Create a matcher with value that doesn't match
-           the list of step 3.
-        3. Validate this value with list validator type and rule.
+            1. Set override to True.
+            2. Create a matcher with value that doesn't match the list of step
+               3.
+            3. Validate this value with list validator type and rule.
 
-        @assert: Error raised for matcher value not in list.
+        :assert: Error raised for matcher value not in list.
         """
         sc_param = self.sc_params_list.pop()
         entities.OverrideValue(
@@ -772,15 +771,15 @@ class SmartClassParametersTestCase(APITestCase):
     def test_positive_validate_matcher_value_with_list(self):
         """Error is not raised for matcher value in list.
 
-        @id: 05c1a0bb-ba27-4842-bb6a-8420114cffe7
+        :id: 05c1a0bb-ba27-4842-bb6a-8420114cffe7
 
-        @steps:
+        :steps:
 
-        1. Set override to True.
-        2. Create a matcher with value that matches the list of step 3.
-        3. Validate this value with list validator type and rule.
+            1. Set override to True.
+            2. Create a matcher with value that matches the list of step 3.
+            3. Validate this value with list validator type and rule.
 
-        @assert: Error not raised for matcher value in list.
+        :assert: Error not raised for matcher value in list.
         """
         sc_param = self.sc_params_list.pop()
         entities.OverrideValue(
@@ -802,15 +801,16 @@ class SmartClassParametersTestCase(APITestCase):
     def test_negative_validate_matcher_value_with_default_type(self):
         """Error is raised for matcher value not of default type.
 
-        @id: 21668ef4-1a7a-41cb-98e3-dc4c664db351
+        :id: 21668ef4-1a7a-41cb-98e3-dc4c664db351
 
-        @steps:
+        :steps:
 
-        1. Set override to True.
-        2. Update parameter default type with valid value.
-        3. Create a matcher with value that doesn't matches the default type.
+            1. Set override to True.
+            2. Update parameter default type with valid value.
+            3. Create a matcher with value that doesn't matches the default
+               type.
 
-        @assert: Error raised for matcher value not of default type.
+        :assert: Error raised for matcher value not of default type.
         """
         sc_param = self.sc_params_list.pop()
         sc_param.override = True
@@ -833,15 +833,15 @@ class SmartClassParametersTestCase(APITestCase):
     def test_positive_validate_matcher_value_with_default_type(self):
         """No error for matcher value of default type.
 
-        @id: 77b6e90d-e38a-4973-98e3-c698eae5c534
+        :id: 77b6e90d-e38a-4973-98e3-c698eae5c534
 
-        @steps:
+        :steps:
 
-        1. Set override to True.
-        2. Update parameter default type with valid value.
-        3. Create a matcher with value that matches the default type.
+            1. Set override to True.
+            2. Update parameter default type with valid value.
+            3. Create a matcher with value that matches the default type.
 
-        @assert: Error not raised for matcher value of default type.
+        :assert: Error not raised for matcher value of default type.
         """
         sc_param = self.sc_params_list.pop()
         sc_param.override = True
@@ -863,15 +863,16 @@ class SmartClassParametersTestCase(APITestCase):
     def test_negative_validate_matcher_and_default_value(self):
         """Error for invalid default and matcher value is raised both at a time.
 
-        @id: e46a12cb-b3ea-42eb-b1bb-b750655b6a4a
+        :id: e46a12cb-b3ea-42eb-b1bb-b750655b6a4a
 
-        @steps:
+        :steps:
 
-        1. Set override to True.
-        2. Update parameter default type with Invalid value.
-        3. Create a matcher with value that doesn't matches the default type.
+            1. Set override to True.
+            2. Update parameter default type with Invalid value.
+            3. Create a matcher with value that doesn't matches the default
+               type.
 
-        @assert: Error raised for invalid default and matcher value both.
+        :assert: Error raised for invalid default and matcher value both.
         """
         sc_param = self.sc_params_list.pop()
         entities.OverrideValue(
@@ -894,14 +895,14 @@ class SmartClassParametersTestCase(APITestCase):
     def test_negative_validate_matcher_non_existing_attribute(self):
         """Error while creating matcher for Non Existing Attribute.
 
-        @id: bef0e457-16be-4ca6-bc56-fa32dff55a01
+        :id: bef0e457-16be-4ca6-bc56-fa32dff55a01
 
-        @steps:
+        :steps:
 
-        1. Set override to True.
-        2. Create a matcher with non existing attribute in org.
+            1. Set override to True.
+            2. Create a matcher with non existing attribute in org.
 
-        @assert: Error raised for non existing attribute.
+        :assert: Error raised for non existing attribute.
         """
         sc_param = self.sc_params_list.pop()
         with self.assertRaises(HTTPError) as context:
@@ -921,15 +922,15 @@ class SmartClassParametersTestCase(APITestCase):
     def test_positive_create_matcher(self):
         """Create matcher for attribute in parameter.
 
-        @id: 19d319e6-9b12-485e-a680-c84d18742c40
+        :id: 19d319e6-9b12-485e-a680-c84d18742c40
 
-        @steps:
+        :steps:
 
-        1. Set override to True.
-        2. Set some default Value.
-        3. Create a matcher with all valid values.
+            1. Set override to True.
+            2. Set some default Value.
+            3. Create a matcher with all valid values.
 
-        @assert: The matcher has been created successfully.
+        :assert: The matcher has been created successfully.
         """
         sc_param = self.sc_params_list.pop()
         value = gen_string('alpha')
@@ -949,16 +950,16 @@ class SmartClassParametersTestCase(APITestCase):
         """Create matcher for attribute in parameter where
         value is puppet default value.
 
-        @id: 2b205e9c-e50c-48cd-8ebb-3b6bea09be77
+        :id: 2b205e9c-e50c-48cd-8ebb-3b6bea09be77
 
-        @steps:
+        :steps:
 
-        1. Set override to True.
-        2. Set some default Value.
-        3. Create matcher with valid attribute type, name and
-           puppet default value.
+            1. Set override to True.
+            2. Set some default Value.
+            3. Create matcher with valid attribute type, name and puppet
+               default value.
 
-        @assert: The matcher has been created successfully.
+        :assert: The matcher has been created successfully.
         """
         sc_param = self.sc_params_list.pop()
         value = gen_string('alpha')
@@ -983,22 +984,22 @@ class SmartClassParametersTestCase(APITestCase):
     def test_positive_create_matcher_attribute_priority(self):
         """Matcher Value set on Attribute Priority for Host.
 
-        @id: f951bdaa-eb3e-40a7-9314-8b67514dabe8
+        :id: f951bdaa-eb3e-40a7-9314-8b67514dabe8
 
-        @steps:
+        :steps:
 
-        1. Set override to True.
-        2. Set some default Value.
-        3. Set fqdn as top priority attribute.
-        4. Create first matcher for fqdn with valid details.
-        5. Create second matcher for some attribute with valid details.
-           Note - The fqdn/host should have this attribute.
-        6. Update the parameter with above steps.
-        7. Go to YAML output of associated host.
+            1. Set override to True.
+            2. Set some default Value.
+            3. Set fqdn as top priority attribute.
+            4. Create first matcher for fqdn with valid details.
+            5. Create second matcher for some attribute with valid details.
+               Note - The fqdn/host should have this attribute.
+            6. Update the parameter with above steps.
+            7. Go to YAML output of associated host.
 
-        @assert: The YAML output has the value only for fqdn matcher.
+        :assert: The YAML output has the value only for fqdn matcher.
 
-        @caseautomation: notautomated
+        :caseautomation: notautomated
         """
 
     @run_only_on('sat')
@@ -1007,25 +1008,26 @@ class SmartClassParametersTestCase(APITestCase):
     def test_negative_create_matcher_attribute_priority(self):
         """Matcher Value set on Attribute Priority for Host - alternate priority.
 
-        @id: 99c66726-83eb-40cb-949f-8d70e74beb09
+        :id: 99c66726-83eb-40cb-949f-8d70e74beb09
 
-        @steps:
+        :steps:
 
-        1. Set override to True.
-        2. Set some default Value.
-        3. Set some attribute(other than fqdn) as top priority attribute.
-           Note - The fqdn/host should have this attribute.
-        4. Create first matcher for fqdn with valid details.
-        5. Create second matcher for attribute of step 3 with valid details.
-        6. Update the parameter with above steps.
-        7. Go to YAML output of associated host.
+            1. Set override to True.
+            2. Set some default Value.
+            3. Set some attribute(other than fqdn) as top priority attribute.
+               Note - The fqdn/host should have this attribute.
+            4. Create first matcher for fqdn with valid details.
+            5. Create second matcher for attribute of step 3 with valid
+               details.
+            6. Update the parameter with above steps.
+            7. Go to YAML output of associated host.
 
-        @assert:
+        :assert:
 
-        1. The YAML output has the value only for step 5 matcher.
-        2. The YAML output doesn't have value for fqdn/host matcher.
+            1. The YAML output has the value only for step 5 matcher.
+            2. The YAML output doesn't have value for fqdn/host matcher.
 
-        @caseautomation: notautomated
+        :caseautomation: notautomated
         """
 
     @run_only_on('sat')
@@ -1034,29 +1036,29 @@ class SmartClassParametersTestCase(APITestCase):
     def test_positive_create_matcher_merge_override(self):
         """Merge the values of all the associated matchers.
 
-        @id: ebbb3aa4-2a86-4f1a-b633-eb7bd91c9d3c
+        :id: ebbb3aa4-2a86-4f1a-b633-eb7bd91c9d3c
 
-        @steps:
+        :steps:
 
-        1. Set override to True.
-        2. Set some default Value.
-        3. Create first matcher for attribute fqdn with valid details.
-        4. Create second matcher for other attribute with valid details.
-           Note - The fqdn/host should have this attribute.
-        5. Create more matchers for some more attributes if any.
-           Note - The fqdn/host should have this attributes.
-        6. Set 'merge overrides' to True.
-        7. Update the parameter with above steps.
-        8. Go to YAML output of associated host.
+            1. Set override to True.
+            2. Set some default Value.
+            3. Create first matcher for attribute fqdn with valid details.
+            4. Create second matcher for other attribute with valid details.
+               Note - The fqdn/host should have this attribute.
+            5. Create more matchers for some more attributes if any.
+               Note - The fqdn/host should have this attributes.
+            6. Set 'merge overrides' to True.
+            7. Update the parameter with above steps.
+            8. Go to YAML output of associated host.
 
-        @assert:
+        :assert:
 
-        1. The YAML output has the values merged from all the associated
-           matchers.
-        2. The YAML output doesn't have the default value of parameter.
-        3. Duplicate values in YAML output if any are displayed.
+            1. The YAML output has the values merged from all the associated
+               matchers.
+            2. The YAML output doesn't have the default value of parameter.
+            3. Duplicate values in YAML output if any are displayed.
 
-        @caseautomation: notautomated
+        :caseautomation: notautomated
         """
 
     @run_only_on('sat')
@@ -1065,30 +1067,30 @@ class SmartClassParametersTestCase(APITestCase):
     def test_negative_create_matcher_merge_override(self):
         """Attempt to merge the values from non associated matchers.
 
-        @id: 2a37310d-1dc3-489d-8674-08d3b244c61e
+        :id: 2a37310d-1dc3-489d-8674-08d3b244c61e
 
-        @steps:
+        :steps:
 
-        1. Set override to True.
-        2. Set some default Value.
-        3. Create first matcher for attribute fqdn with valid details.
-        4. Create second matcher for other attribute with valid details.
-           Note - The fqdn/host should not have this attribute.
-        5. Create more matchers for some more attributes if any.
-           Note - The fqdn/host should not have this attributes.
-        6. Set 'merge overrides' to True.
-        7. Update the parameter with above steps.
-        8. Go to YAML output of associated host.
+            1. Set override to True.
+            2. Set some default Value.
+            3. Create first matcher for attribute fqdn with valid details.
+            4. Create second matcher for other attribute with valid details.
+               Note - The fqdn/host should not have this attribute.
+            5. Create more matchers for some more attributes if any.
+               Note - The fqdn/host should not have this attributes.
+            6. Set 'merge overrides' to True.
+            7. Update the parameter with above steps.
+            8. Go to YAML output of associated host.
 
-        @assert:
+        :assert:
 
-        1. The YAML output has the values only for fqdn.
-        2. The YAML output doesn't have the values for attribute
-           which are not associated to host.
-        3. The YAML output doesn't have the default value of parameter.
-        4. Duplicate values in YAML output if any are displayed.
+            1. The YAML output has the values only for fqdn.
+            2. The YAML output doesn't have the values for attribute
+               which are not associated to host.
+            3. The YAML output doesn't have the default value of parameter.
+            4. Duplicate values in YAML output if any are displayed.
 
-        @caseautomation: notautomated
+        :caseautomation: notautomated
         """
 
     @run_only_on('sat')
@@ -1097,31 +1099,32 @@ class SmartClassParametersTestCase(APITestCase):
     def test_positive_create_matcher_merge_override_puppet_value(self):
         """Merge the values of all the associated matchers + puppet default value.
 
-        @id: 0d829b65-a7cf-49d7-a907-6ab170a2004d
+        :id: 0d829b65-a7cf-49d7-a907-6ab170a2004d
 
-        @steps:
+        :steps:
 
-        1. Set override to True.
-        2. Set some default Value.
-        3. Create first matcher for attribute fqdn with valid details.
-        4. Create second matcher for other attribute with value
-           as puppet default.
-           Note - The fqdn/host should have this attribute.
-        5. Create more matchers for some more attributes with value
-           as puppet default.
-           Note - The fqdn/host should have this attributes.
-        6. Set 'merge overrides' to True.
-        7. Set 'merge default' to True.
-        8. Update the parameter with above steps.
-        9. Go to YAML output of associated host.
+            1. Set override to True.
+            2. Set some default Value.
+            3. Create first matcher for attribute fqdn with valid details.
+            4. Create second matcher for other attribute with value as puppet
+               default.
+               Note - The fqdn/host should have this attribute.
+            5. Create more matchers for some more attributes with value as
+               puppet default.
+               Note - The fqdn/host should have this attributes.
+            6. Set 'merge overrides' to True.
+            7. Set 'merge default' to True.
+            8. Update the parameter with above steps.
+            9. Go to YAML output of associated host.
 
-        @assert:
+        :assert:
 
-        1. The YAML output has the value only for fqdn.
-        2. The YAML output doesn't have the puppet default values of matchers.
-        3. Duplicate values in YAML output if any are displayed.
+            1. The YAML output has the value only for fqdn.
+            2. The YAML output doesn't have the puppet default values of
+               matchers.
+            3. Duplicate values in YAML output if any are displayed.
 
-        @caseautomation: notautomated
+        :caseautomation: notautomated
         """
 
     @run_only_on('sat')
@@ -1130,30 +1133,30 @@ class SmartClassParametersTestCase(APITestCase):
     def test_positive_create_matcher_merge_default(self):
         """Merge the values of all the associated matchers + default value.
 
-        @id: b338f637-449c-44a3-89e2-51e7278a6957
+        :id: b338f637-449c-44a3-89e2-51e7278a6957
 
-        @steps:
+        :steps:
 
-        1. Set override to True.
-        2. Set some default Value.
-        3. Create first matcher for attribute fqdn with valid details.
-        4. Create second matcher for other attribute with valid details.
-           Note - The fqdn/host should have this attribute.
-        5. Create more matchers for some more attributes if any.
-           Note - The fqdn/host should have this attributes.
-        6. Set 'merge overrides' to True.
-        7. Set 'merge default' to True.
-        8. Update the parameter with above steps.
-        9. Go to YAML output of associated host.
+            1. Set override to True.
+            2. Set some default Value.
+            3. Create first matcher for attribute fqdn with valid details.
+            4. Create second matcher for other attribute with valid details.
+               Note - The fqdn/host should have this attribute.
+            5. Create more matchers for some more attributes if any.
+               Note - The fqdn/host should have this attributes.
+            6. Set 'merge overrides' to True.
+            7. Set 'merge default' to True.
+            8. Update the parameter with above steps.
+            9. Go to YAML output of associated host.
 
-        @assert:
+        :assert:
 
-        1. The YAML output has the values merged from all
-           the associated matchers.
-        2. The YAML output has the default value of parameter.
-        3. Duplicate values in YAML output if any are displayed.
+            1. The YAML output has the values merged from all the associated
+               matchers.
+            2. The YAML output has the default value of parameter.
+            3. Duplicate values in YAML output if any are displayed.
 
-        @caseautomation: notautomated
+        :caseautomation: notautomated
         """
 
     @run_only_on('sat')
@@ -1162,30 +1165,31 @@ class SmartClassParametersTestCase(APITestCase):
     def test_negative_create_matcher_merge_default(self):
         """Empty default value is not shown in merged values.
 
-        @id: 757b3e32-8789-4124-9ed8-e0d7e7735b0e
+        :id: 757b3e32-8789-4124-9ed8-e0d7e7735b0e
 
-        @steps:
+        :steps:
 
-        1. Set override to True.
-        2. Set empty default Value.
-        3. Create first matcher for attribute fqdn with valid details.
-        4. Create second matcher for other attribute with valid details.
-           Note - The fqdn/host should have this attribute.
-        5. Create more matchers for some more attributes if any.
-           Note - The fqdn/host should have this attributes.
-        6. Set 'merge overrides' to True.
-        7. Set 'merge default' to True.
-        8. Update the parameter with above steps.
-        9. Go to YAML output of associated host.
+            1. Set override to True.
+            2. Set empty default Value.
+            3. Create first matcher for attribute fqdn with valid details.
+            4. Create second matcher for other attribute with valid details.
+               Note - The fqdn/host should have this attribute.
+            5. Create more matchers for some more attributes if any.
+               Note - The fqdn/host should have this attributes.
+            6. Set 'merge overrides' to True.
+            7. Set 'merge default' to True.
+            8. Update the parameter with above steps.
+            9. Go to YAML output of associated host.
 
-        @assert:
+        :assert:
 
-        1. The YAML output has the values merged from all
-           the associated matchers.
-        2. The YAML output doesn't have the empty default value of parameter.
-        3. Duplicate values in YAML output if any are displayed.
+            1. The YAML output has the values merged from all the associated
+               matchers.
+            2. The YAML output doesn't have the empty default value of
+               parameter.
+            3. Duplicate values in YAML output if any are displayed.
 
-        @caseautomation: notautomated
+        :caseautomation: notautomated
         """
 
     @run_only_on('sat')
@@ -1194,30 +1198,30 @@ class SmartClassParametersTestCase(APITestCase):
     def test_positive_create_matcher_merge_puppet_default(self):
         """Merge the values of all the associated matchers + puppet default value.
 
-        @id: de18fbfd-1a71-4651-b3f8-fab6b22ccbc0
+        :id: de18fbfd-1a71-4651-b3f8-fab6b22ccbc0
 
-        @steps:
+        :steps:
 
-        1. Set override to True.
-        2. Set default Value as puppet default value.
-        3. Create first matcher for attribute fqdn with valid details.
-        4. Create second matcher for other attribute with valid details.
-           Note - The fqdn/host should have this attribute.
-        5. Create more matchers for some more attributes if any.
-           Note - The fqdn/host should have this attributes.
-        6. Set 'merge overrides' to True.
-        7. Set 'merge default' to True.
-        8. Update the parameter with above steps.
-        9. Go to YAML output of associated host.
+            1. Set override to True.
+            2. Set default Value as puppet default value.
+            3. Create first matcher for attribute fqdn with valid details.
+            4. Create second matcher for other attribute with valid details.
+               Note - The fqdn/host should have this attribute.
+            5. Create more matchers for some more attributes if any.
+               Note - The fqdn/host should have this attributes.
+            6. Set 'merge overrides' to True.
+            7. Set 'merge default' to True.
+            8. Update the parameter with above steps.
+            9. Go to YAML output of associated host.
 
-        @assert:
+        :assert:
 
-        1. The YAML output has the values merged from all
-           the associated matchers.
-        2. The YAML output doesn't have the puppet default value.
-        3. Duplicate values in YAML output if any are displayed.
+            1. The YAML output has the values merged from all the associated
+               matchers.
+            2. The YAML output doesn't have the puppet default value.
+            3. Duplicate values in YAML output if any are displayed.
 
-        @caseautomation: notautomated
+        :caseautomation: notautomated
         """
 
     @run_only_on('sat')
@@ -1226,30 +1230,30 @@ class SmartClassParametersTestCase(APITestCase):
     def test_positive_create_matcher_avoid_duplicate(self):
         """Merge the values of all the associated matchers, remove duplicates.
 
-        @id: 4c150b7d-3a1f-47c3-a2bd-be91435c4dfb
+        :id: 4c150b7d-3a1f-47c3-a2bd-be91435c4dfb
 
-        @steps:
+        :steps:
 
-        1. Set override to True.
-        2. Set some default Value of array type.
-        3. Create first matcher for attribute fqdn with some value.
-        4. Create second matcher for other attribute with
-           same value as fqdn matcher.
-           Note - The fqdn/host should have this attribute.
-        5. Set 'merge overrides' to True.
-        6. Set 'merge default' to True.
-        7. Set 'avoid duplicate' to True.
-        8. Update the parameter with above steps.
-        9. Go to YAML output of associated host.
+            1. Set override to True.
+            2. Set some default Value of array type.
+            3. Create first matcher for attribute fqdn with some value.
+            4. Create second matcher for other attribute with same value as
+               fqdn matcher.
+               Note - The fqdn/host should have this attribute.
+            5. Set 'merge overrides' to True.
+            6. Set 'merge default' to True.
+            7. Set 'avoid duplicate' to True.
+            8. Update the parameter with above steps.
+            9. Go to YAML output of associated host.
 
-        @assert:
+        :assert:
 
-        1. The YAML output has the values merged from all
-           the associated matchers.
-        2. The YAML output has the default value of parameter.
-        3. Duplicate values in YAML output are removed / not displayed.
+            1. The YAML output has the values merged from all the associated
+               matchers.
+            2. The YAML output has the default value of parameter.
+            3. Duplicate values in YAML output are removed / not displayed.
 
-        @caseautomation: notautomated
+        :caseautomation: notautomated
         """
 
     @run_only_on('sat')
@@ -1258,29 +1262,29 @@ class SmartClassParametersTestCase(APITestCase):
     def test_negative_create_matcher_avoid_duplicate(self):
         """Duplicates are not removed as they were not really present.
 
-        @id: 71cc1f74-5acb-4516-8d30-213b5657dfd4
+        :id: 71cc1f74-5acb-4516-8d30-213b5657dfd4
 
-        @steps:
+        :steps:
 
-        1. Set override to True.
-        2. Set some default Value of array type.
-        3. Create first matcher for attribute fqdn with some value.
-        4. Create second matcher for other attribute with other value
-           than fqdn matcher and default value.
-           Note - The fqdn/host should have this attribute.
-        5. Set 'merge overrides' to True.
-        6. Set 'merge default' to True.
-        7. Set 'merge avoid duplicates' to True.
-        8. Update the parameter with above steps.
-        9. Go to YAML output of associated host.
+            1. Set override to True.
+            2. Set some default Value of array type.
+            3. Create first matcher for attribute fqdn with some value.
+            4. Create second matcher for other attribute with other value than
+               fqdn matcher and default value.
+               Note - The fqdn/host should have this attribute.
+            5. Set 'merge overrides' to True.
+            6. Set 'merge default' to True.
+            7. Set 'merge avoid duplicates' to True.
+            8. Update the parameter with above steps.
+            9. Go to YAML output of associated host.
 
-        @assert:
+        :assert:
 
-        1. The YAML output has the values merged from all matchers.
-        2. The YAML output has the default value of parameter.
-        3. No value removed as duplicate value.
+            1. The YAML output has the values merged from all matchers.
+            2. The YAML output has the default value of parameter.
+            3. No value removed as duplicate value.
 
-        @caseautomation: notautomated
+        :caseautomation: notautomated
         """
 
     @run_only_on('sat')
@@ -1288,14 +1292,12 @@ class SmartClassParametersTestCase(APITestCase):
     def test_positive_enable_merge_overrides_default_checkboxes(self):
         """Enable Merge Overrides, Merge Default checkbox for supported types.
 
-        @id: ae1c8e2d-c15d-4325-9aa6-cc6b091fb95a
+        :id: ae1c8e2d-c15d-4325-9aa6-cc6b091fb95a
 
-        @steps:
+        :steps: Set parameter type to array/hash.
 
-        1. Set parameter type to array/hash.
-
-        @assert: The Merge Overrides, Merge Default checks are enabled to
-        check.
+        :assert: The Merge Overrides, Merge Default checks are enabled to
+            check.
         """
         sc_param = self.sc_params_list.pop()
         sc_param.override = True
@@ -1320,14 +1322,12 @@ class SmartClassParametersTestCase(APITestCase):
     def test_negative_enable_merge_overrides_default_checkboxes(self):
         """Disable Merge Overrides, Merge Default checkboxes for non supported types.
 
-        @id: d7b1c336-bd9f-40a3-a573-939f2a021cdc
+        :id: d7b1c336-bd9f-40a3-a573-939f2a021cdc
 
-        @steps:
+        :steps: Set parameter type other than array/hash.
 
-        1. Set parameter type other than array/hash.
-
-        @assert: The Merge Overrides, Merge Default checks are not enabled to
-        check.
+        :assert: The Merge Overrides, Merge Default checks are not enabled to
+            check.
         """
         sc_param = self.sc_params_list.pop()
         sc_param.override = True
@@ -1368,14 +1368,14 @@ class SmartClassParametersTestCase(APITestCase):
     def test_positive_enable_avoid_duplicates_checkbox(self):
         """Enable Avoid duplicates checkbox for supported type- array.
 
-        @id: 80bf52df-e678-4384-a4d5-7a88928620ce
+        :id: 80bf52df-e678-4384-a4d5-7a88928620ce
 
-        @steps:
+        :steps:
 
-        1. Set parameter type to array.
-        2. Set 'merge overrides' to True.
+            1. Set parameter type to array.
+            2. Set 'merge overrides' to True.
 
-        @assert: The Avoid Duplicates is enabled to set to True.
+        :assert: The Avoid Duplicates is enabled to set to True.
         """
         sc_param = self.sc_params_list.pop()
         sc_param.override = True
@@ -1398,18 +1398,16 @@ class SmartClassParametersTestCase(APITestCase):
     def test_negative_enable_avoid_duplicates_checkbox(self):
         """Disable Avoid duplicates checkbox for non supported types.
 
-        @id: 11d75f6d-7105-4ee8-b147-b8329cae4156
+        :id: 11d75f6d-7105-4ee8-b147-b8329cae4156
 
-        @steps:
+        :steps: Set parameter type other than array.
 
-        1. Set parameter type other than array.
+        :assert:
 
-        @assert:
-
-        1. The Merge Overrides checkbox is only enabled to check
-           for type hash other than array.
-        2. The Avoid duplicates checkbox not enabled to check
-           for any type than array.
+            1. The Merge Overrides checkbox is only enabled to check for type
+               hash other than array.
+            2. The Avoid duplicates checkbox not enabled to check for any type
+               than array.
         """
         sc_param = self.sc_params_list.pop()
         sc_param.override = True
@@ -1435,14 +1433,14 @@ class SmartClassParametersTestCase(APITestCase):
     def test_positive_remove_matcher(self):
         """Removal of matcher from parameter.
 
-        @id: 9018d624-07f2-4fb2-b421-8888c7d324a7
+        :id: 9018d624-07f2-4fb2-b421-8888c7d324a7
 
-        @steps:
+        :steps:
 
-        1. Override the parameter and create a matcher for some attribute.
-        2. Remove the matcher created in step 1.
+            1. Override the parameter and create a matcher for some attribute.
+            2. Remove the matcher created in step 1.
 
-        @assert: The matcher removed from parameter.
+        :assert: The matcher removed from parameter.
         """
         sc_param = self.sc_params_list.pop()
         value = gen_string('alpha')
@@ -1461,20 +1459,20 @@ class SmartClassParametersTestCase(APITestCase):
     def test_positive_impact_parameter_delete_attribute(self):
         """Impact on parameter after deleting associated attribute.
 
-        @id: 3ffbf403-dac9-4172-a586-82267765abd8
+        :id: 3ffbf403-dac9-4172-a586-82267765abd8
 
-        @steps:
+        :steps:
 
-        1. Set the parameter to True and create a matcher
-           for some attribute.
-        2. Delete the attribute.
-        3. Recreate the attribute with same name as earlier.
+            1. Set the parameter to True and create a matcher for some
+               attribute.
+            2. Delete the attribute.
+            3. Recreate the attribute with same name as earlier.
 
-        @assert:
+        :assert:
 
-        1. The matcher for deleted attribute removed from parameter.
-        2. On recreating attribute, the matcher should not
-           reappear in parameter.
+            1. The matcher for deleted attribute removed from parameter.
+            2. On recreating attribute, the matcher should not reappear in
+               parameter.
         """
         sc_param = self.sc_params_list.pop()
         hostgroup_name = gen_string('alpha')
@@ -1509,15 +1507,15 @@ class SmartClassParametersTestCase(APITestCase):
     def test_positive_hide_parameter_default_value(self):
         """Hide the default value of parameter.
 
-        @id: 0cb8ab59-7910-4573-9dea-2e489d1578d4
+        :id: 0cb8ab59-7910-4573-9dea-2e489d1578d4
 
-        @steps:
+        :steps:
 
-        1. Set the override flag to True.
-        2. Set some valid default value.
-        3. Set 'Hidden Value' to true.
+            1. Set the override flag to True.
+            2. Set some valid default value.
+            3. Set 'Hidden Value' to true.
 
-        @assert: The 'hidden value' set to True for that parameter.
+        :assert: The 'hidden value' set to True for that parameter.
         """
         sc_param = self.sc_params_list.pop()
         sc_param.override = True
@@ -1533,16 +1531,16 @@ class SmartClassParametersTestCase(APITestCase):
     def test_positive_unhide_parameter_default_value(self):
         """Unhide the default value of parameter.
 
-        @id: 73151830-e902-4b9e-888e-149570869530
+        :id: 73151830-e902-4b9e-888e-149570869530
 
-        @steps:
+        :steps:
 
-        1. Set the override flag to True.
-        2. Set some valid default value.
-        3. Set 'Hidden Value' to True and update parameter.
-        4. After hiding, set the 'Hidden Value' to False.
+            1. Set the override flag to True.
+            2. Set some valid default value.
+            3. Set 'Hidden Value' to True and update parameter.
+            4. After hiding, set the 'Hidden Value' to False.
 
-        @assert: The 'hidden value' set to false for that parameter.
+        :assert: The 'hidden value' set to false for that parameter.
         """
         sc_param = self.sc_params_list.pop()
         sc_param.override = True
@@ -1561,19 +1559,19 @@ class SmartClassParametersTestCase(APITestCase):
     def test_positive_update_hidden_value_in_parameter(self):
         """Update the hidden default value of parameter.
 
-        @id: 6f7ad3c4-7745-45bf-a9f9-697f049556da
+        :id: 6f7ad3c4-7745-45bf-a9f9-697f049556da
 
-        @steps:
+        :steps:
 
-        1. Set the override flag for the parameter.
-        2. Set some valid default value.
-        3. Set 'Hidden Value' to true and update the parameter.
-        4. Now in hidden state, update the default value.
+            1. Set the override flag for the parameter.
+            2. Set some valid default value.
+            3. Set 'Hidden Value' to true and update the parameter.
+            4. Now in hidden state, update the default value.
 
-        @assert:
+        :assert:
 
-        1. The parameter default value is updated.
-        2. The 'hidden value' set/displayed as True for that parameter.
+            1. The parameter default value is updated.
+            2. The 'hidden value' set/displayed as True for that parameter.
         """
         old_value = gen_string('alpha')
         new_value = gen_string('alpha')
@@ -1596,18 +1594,18 @@ class SmartClassParametersTestCase(APITestCase):
     def test_positive_hide_empty_default_value(self):
         """Hiding the empty default value.
 
-        @id: b6882658-9201-4e87-978a-0195a99ec07d
+        :id: b6882658-9201-4e87-978a-0195a99ec07d
 
-        @steps:
+        :steps:
 
-        1. Set the override flag to True.
-        2. Don't set any default value/Set empty value.
-        3. Set 'Hidden Value' to true and update the parameter.
+            1. Set the override flag to True.
+            2. Don't set any default value/Set empty value.
+            3. Set 'Hidden Value' to true and update the parameter.
 
-        @assert:
+        :assert:
 
-        1. The 'hidden value' set to True for that parameter.
-        2. The default value is empty even after hide.
+            1. The 'hidden value' set to True for that parameter.
+            2. The default value is empty even after hide.
         """
         sc_param = self.sc_params_list.pop()
         sc_param.override = True

--- a/tests/foreman/api/test_computeprofile.py
+++ b/tests/foreman/api/test_computeprofile.py
@@ -1,19 +1,19 @@
 # -*- encoding: utf-8 -*-
 """Unit tests for the Compute Profile feature.
 
-@Requirement: Computeprofile
+:Requirement: Computeprofile
 
-@CaseAutomation: Automated
+:CaseAutomation: Automated
 
-@CaseLevel: Acceptance
+:CaseLevel: Acceptance
 
-@CaseComponent: API
+:CaseComponent: API
 
-@TestType: Functional
+:TestType: Functional
 
-@CaseImportance: High
+:CaseImportance: High
 
-@Upstream: No
+:Upstream: No
 """
 from nailgun import entities
 from requests.exceptions import HTTPError
@@ -30,9 +30,9 @@ class ComputeProfileTestCase(APITestCase):
     def test_positive_create_with_name(self):
         """Create new Compute Profile using different names
 
-        @id: 97d04911-9368-4674-92c7-1e3ff114bc18
+        :id: 97d04911-9368-4674-92c7-1e3ff114bc18
 
-        @Assert: Compute Profile is created
+        :Assert: Compute Profile is created
         """
         for name in valid_data_list():
             with self.subTest(name):
@@ -44,9 +44,9 @@ class ComputeProfileTestCase(APITestCase):
     def test_negative_create(self):
         """Attempt to create Compute Profile using invalid names only
 
-        @id: 2d34a1fd-70a5-4e59-b2e2-86fbfe8e31ab
+        :id: 2d34a1fd-70a5-4e59-b2e2-86fbfe8e31ab
 
-        @Assert: Compute Profile is not created
+        :Assert: Compute Profile is not created
         """
         for name in invalid_values_list():
             with self.subTest(name):
@@ -58,9 +58,9 @@ class ComputeProfileTestCase(APITestCase):
     def test_positive_update_name(self):
         """Update selected Compute Profile entity using proper names
 
-        @id: c79193d7-2e0f-4ed9-b947-05feeddabfda
+        :id: c79193d7-2e0f-4ed9-b947-05feeddabfda
 
-        @Assert: Compute Profile is updated.
+        :Assert: Compute Profile is updated.
         """
         profile = entities.ComputeProfile().create()
         for new_name in valid_data_list():
@@ -74,9 +74,9 @@ class ComputeProfileTestCase(APITestCase):
     def test_negative_update_name(self):
         """Attempt to update Compute Profile entity using invalid names only
 
-        @id: 042b40d5-a78b-4e65-b5cb-5b270b800b37
+        :id: 042b40d5-a78b-4e65-b5cb-5b270b800b37
 
-        @Assert: Compute Profile is not updated.
+        :Assert: Compute Profile is not updated.
         """
         profile = entities.ComputeProfile().create()
         for new_name in invalid_values_list():
@@ -92,9 +92,9 @@ class ComputeProfileTestCase(APITestCase):
     def test_positive_delete(self):
         """Delete Compute Profile entity
 
-        @id: 0a620e23-7ba6-4178-af7a-fd1e332f478f
+        :id: 0a620e23-7ba6-4178-af7a-fd1e332f478f
 
-        @Assert: Compute Profile is deleted successfully.
+        :Assert: Compute Profile is deleted successfully.
         """
         for name in valid_data_list():
             with self.subTest(name):

--- a/tests/foreman/api/test_computeresource.py
+++ b/tests/foreman/api/test_computeresource.py
@@ -5,19 +5,19 @@ A full API reference for compute resources can be found here:
 http://www.katello.org/docs/api/apidoc/compute_resources.html
 
 
-@Requirement: Computeresource
+:Requirement: Computeresource
 
-@CaseAutomation: Automated
+:CaseAutomation: Automated
 
-@CaseLevel: Acceptance
+:CaseLevel: Acceptance
 
-@CaseComponent: API
+:CaseComponent: API
 
-@TestType: Functional
+:TestType: Functional
 
-@CaseImportance: High
+:CaseImportance: High
 
-@Upstream: No
+:Upstream: No
 """
 from random import randint
 
@@ -50,9 +50,9 @@ class ComputeResourceTestCase(APITestCase):
     def test_positive_create_with_name(self):
         """Create compute resources with different names
 
-        @id: 1e545c56-2f53-44c1-a17e-38c83f8fe0c1
+        :id: 1e545c56-2f53-44c1-a17e-38c83f8fe0c1
 
-        @Assert: Compute resources are created with expected names
+        :Assert: Compute resources are created with expected names
         """
         for name in valid_data_list():
             with self.subTest(name):
@@ -68,9 +68,9 @@ class ComputeResourceTestCase(APITestCase):
     def test_positive_create_with_description(self):
         """Create compute resources with different descriptions
 
-        @id: 1fa5b35d-ee47-452b-bb5f-4a4ca321f992
+        :id: 1fa5b35d-ee47-452b-bb5f-4a4ca321f992
 
-        @Assert: Compute resources are created with expected descriptions
+        :Assert: Compute resources are created with expected descriptions
         """
         for description in valid_data_list():
             with self.subTest(description):
@@ -87,9 +87,9 @@ class ComputeResourceTestCase(APITestCase):
         """Create a libvirt compute resources with different values of
         'display_type' parameter
 
-        @id: 76380f31-e217-4ff1-ac6b-20f41e59f133
+        :id: 76380f31-e217-4ff1-ac6b-20f41e59f133
 
-        @Assert: Compute resources are created with expected display_type value
+        :Assert: Compute resources are created with expected display_type value
         """
         for display_type in ('spice', 'vnc'):
             with self.subTest(display_type):
@@ -106,9 +106,9 @@ class ComputeResourceTestCase(APITestCase):
         """Create compute resources with different providers. Testing only
         Libvirt and Docker as other providers require valid credentials
 
-        @id: f61c66c9-15f8-4b00-9e53-7ebfb09397cc
+        :id: f61c66c9-15f8-4b00-9e53-7ebfb09397cc
 
-        @Assert: Compute resources are created with expected providers
+        :Assert: Compute resources are created with expected providers
         """
         for entity in (entities.DockerComputeResource(),
                        entities.LibvirtComputeResource()):
@@ -122,12 +122,12 @@ class ComputeResourceTestCase(APITestCase):
     def test_positive_create_with_locs(self):
         """Create a compute resource with multiple locations
 
-        @id: c6c6c6f7-50ca-4f38-8126-eb95359d7cbb
+        :id: c6c6c6f7-50ca-4f38-8126-eb95359d7cbb
 
-        @Assert: A compute resource is created with expected multiple locations
-        assigned
+        :Assert: A compute resource is created with expected multiple locations
+            assigned
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         locs = [
             entities.Location(organization=[self.org]).create()
@@ -147,12 +147,12 @@ class ComputeResourceTestCase(APITestCase):
     def test_positive_create_with_orgs(self):
         """Create a compute resource with multiple organizations
 
-        @id: 2f6e5019-6353-477e-a81f-2a551afc7556
+        :id: 2f6e5019-6353-477e-a81f-2a551afc7556
 
-        @Assert: A compute resource is created with expected multiple
-        organizations assigned
+        :Assert: A compute resource is created with expected multiple
+            organizations assigned
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         orgs = [
             entities.Organization().create()
@@ -171,9 +171,9 @@ class ComputeResourceTestCase(APITestCase):
     def test_positive_update_name(self):
         """Update a compute resource with different names
 
-        @id: 60f08418-b1a2-445e-9cd6-dbc92a33b57a
+        :id: 60f08418-b1a2-445e-9cd6-dbc92a33b57a
 
-        @Assert: Compute resource is updated with expected names
+        :Assert: Compute resource is updated with expected names
         """
         compresource = entities.LibvirtComputeResource(
             location=[self.loc],
@@ -190,9 +190,9 @@ class ComputeResourceTestCase(APITestCase):
     def test_positive_update_description(self):
         """Update a compute resource with different descriptions
 
-        @id: aac5dc53-8709-441b-b360-28b8efd3f63f
+        :id: aac5dc53-8709-441b-b360-28b8efd3f63f
 
-        @Assert: Compute resource is updated with expected descriptions
+        :Assert: Compute resource is updated with expected descriptions
         """
         compresource = entities.LibvirtComputeResource(
             description=gen_string('alpha'),
@@ -211,9 +211,9 @@ class ComputeResourceTestCase(APITestCase):
         """Update a libvirt compute resource with different values of
         'display_type' parameter
 
-        @id: 0cbf08ac-acc4-476a-b389-271cea2b6cda
+        :id: 0cbf08ac-acc4-476a-b389-271cea2b6cda
 
-        @Assert: Compute resource is updated with expected display_type value
+        :Assert: Compute resource is updated with expected display_type value
         """
         compresource = entities.LibvirtComputeResource(
             display_type='VNC',
@@ -231,9 +231,9 @@ class ComputeResourceTestCase(APITestCase):
     def test_positive_update_url(self):
         """Update a compute resource's url field
 
-        @id: 259aa060-ed9e-4ed5-91e1-7fb0a3592879
+        :id: 259aa060-ed9e-4ed5-91e1-7fb0a3592879
 
-        @Assert: Compute resource is updated with expected url
+        :Assert: Compute resource is updated with expected url
         """
         new_url = 'qemu+tcp://localhost:16509/system'
 
@@ -250,11 +250,11 @@ class ComputeResourceTestCase(APITestCase):
     def test_positive_update_loc(self):
         """Update a compute resource's location
 
-        @id: 57e96c7c-da9e-4400-af80-c374cd6b3d4a
+        :id: 57e96c7c-da9e-4400-af80-c374cd6b3d4a
 
-        @Assert: Compute resource is updated with expected location
+        :Assert: Compute resource is updated with expected location
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         compresource = entities.LibvirtComputeResource(
             location=[self.loc],
@@ -271,11 +271,11 @@ class ComputeResourceTestCase(APITestCase):
     def test_positive_update_locs(self):
         """Update a compute resource with new multiple locations
 
-        @id: cda9f501-2879-4cb0-a017-51ee795232f1
+        :id: cda9f501-2879-4cb0-a017-51ee795232f1
 
-        @Assert: Compute resource is updated with expected locations
+        :Assert: Compute resource is updated with expected locations
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         compresource = entities.LibvirtComputeResource(
             location=[self.loc],
@@ -297,11 +297,11 @@ class ComputeResourceTestCase(APITestCase):
     def test_positive_update_org(self):
         """Update a compute resource's organization
 
-        @id: 430b64a2-7f64-4344-a73b-1b47d8dfa6cb
+        :id: 430b64a2-7f64-4344-a73b-1b47d8dfa6cb
 
-        @Assert: Compute resource is updated with expected organization
+        :Assert: Compute resource is updated with expected organization
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         compresource = entities.LibvirtComputeResource(
             organization=[self.org],
@@ -317,11 +317,11 @@ class ComputeResourceTestCase(APITestCase):
     def test_positive_update_orgs(self):
         """Update a compute resource with new multiple organizations
 
-        @id: 2c759ad5-d115-46d9-8365-712c0bb39a1d
+        :id: 2c759ad5-d115-46d9-8365-712c0bb39a1d
 
-        @Assert: Compute resource is updated with expected organizations
+        :Assert: Compute resource is updated with expected organizations
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         compresource = entities.LibvirtComputeResource(
             organization=[self.org],
@@ -342,9 +342,9 @@ class ComputeResourceTestCase(APITestCase):
     def test_positive_delete(self):
         """Delete a compute resource
 
-        @id: 0117a4f1-e2c2-44aa-8919-453166aeebbc
+        :id: 0117a4f1-e2c2-44aa-8919-453166aeebbc
 
-        @Assert: Compute resources is successfully deleted
+        :Assert: Compute resources is successfully deleted
         """
         compresource = entities.LibvirtComputeResource(
             location=[self.loc],
@@ -359,9 +359,9 @@ class ComputeResourceTestCase(APITestCase):
     def test_negative_create_with_invalid_name(self):
         """Attempt to create compute resources with invalid names
 
-        @id: f73bf838-3ffd-46d3-869c-81b334b47b13
+        :id: f73bf838-3ffd-46d3-869c-81b334b47b13
 
-        @Assert: Compute resources are not created
+        :Assert: Compute resources are not created
         """
         for name in invalid_values_list():
             with self.subTest(name):
@@ -377,9 +377,9 @@ class ComputeResourceTestCase(APITestCase):
     def test_negative_create_with_same_name(self):
         """Attempt to create a compute resource with already existing name
 
-        @id: 9376e25c-2aa8-4d99-83aa-2eec160c030e
+        :id: 9376e25c-2aa8-4d99-83aa-2eec160c030e
 
-        @Assert: Compute resources is not created
+        :Assert: Compute resources is not created
         """
         name = gen_string('alphanumeric')
         entities.LibvirtComputeResource(
@@ -400,9 +400,9 @@ class ComputeResourceTestCase(APITestCase):
     def test_negative_create_with_url(self):
         """Attempt to create compute resources with invalid url
 
-        @id: 37e9bf39-382e-4f02-af54-d3a17e285c2a
+        :id: 37e9bf39-382e-4f02-af54-d3a17e285c2a
 
-        @Assert: Compute resources are not created
+        :Assert: Compute resources are not created
         """
         for url in ('', gen_string('alpha')):
             with self.subTest(url):
@@ -417,9 +417,9 @@ class ComputeResourceTestCase(APITestCase):
     def test_negative_update_invalid_name(self):
         """Attempt to update compute resource with invalid names
 
-        @id: a6554c1f-e52f-4614-9fc3-2127ced31470
+        :id: a6554c1f-e52f-4614-9fc3-2127ced31470
 
-        @Assert: Compute resource is not updated
+        :Assert: Compute resource is not updated
         """
         name = gen_string('alphanumeric')
         compresource = entities.LibvirtComputeResource(
@@ -439,9 +439,9 @@ class ComputeResourceTestCase(APITestCase):
     def test_negative_update_same_name(self):
         """Attempt to update a compute resource with already existing name
 
-        @id: 4d7c5eb0-b8cb-414f-aa10-fe464a164ab4
+        :id: 4d7c5eb0-b8cb-414f-aa10-fe464a164ab4
 
-        @Assert: Compute resources is not updated
+        :Assert: Compute resources is not updated
         """
         name = gen_string('alphanumeric')
         entities.LibvirtComputeResource(
@@ -464,9 +464,9 @@ class ComputeResourceTestCase(APITestCase):
     def test_negative_update_url(self):
         """Attempt to update a compute resource with invalid url
 
-        @id: b5256090-2ceb-4976-b54e-60d60419fe50
+        :id: b5256090-2ceb-4976-b54e-60d60419fe50
 
-        @Assert: Compute resources is not updated
+        :Assert: Compute resources is not updated
         """
         compresource = entities.LibvirtComputeResource(
             location=[self.loc],

--- a/tests/foreman/api/test_contentview.py
+++ b/tests/foreman/api/test_contentview.py
@@ -1,19 +1,19 @@
 # -*- encoding: utf-8 -*-
 """Unit tests for the ``content_views`` paths.
 
-@Requirement: Contentview
+:Requirement: Contentview
 
-@CaseAutomation: Automated
+:CaseAutomation: Automated
 
-@CaseLevel: Acceptance
+:CaseLevel: Acceptance
 
-@CaseComponent: API
+:CaseComponent: API
 
-@TestType: Functional
+:TestType: Functional
 
-@CaseImportance: High
+:CaseImportance: High
 
-@Upstream: No
+:Upstream: No
 """
 import random
 
@@ -64,12 +64,12 @@ class ContentViewTestCase(APITestCase):
     def test_positive_subscribe_host(self):
         """Subscribe a host to a content view
 
-        @id: b5a08369-bf92-48ab-b9aa-10f5b9774b79
+        :id: b5a08369-bf92-48ab-b9aa-10f5b9774b79
 
-        @Assert: It is possible to create a host and set its 'content_view_id'
-        facet attribute
+        :Assert: It is possible to create a host and set its 'content_view_id'
+            facet attribute
 
-        @CaseLevel: System
+        :CaseLevel: System
         """
         # organization
         # ├── lifecycle environment
@@ -113,12 +113,12 @@ class ContentViewTestCase(APITestCase):
         based on existing view within the same environment as the
         original content view
 
-        @id: a7be5dc1-26c1-4354-99a1-1cbc90c89c64
+        :id: a7be5dc1-26c1-4354-99a1-1cbc90c89c64
 
-        @Assert: Cloned content view can be published and promoted
-        to the same environment as the original content view
+        :Assert: Cloned content view can be published and promoted to the same
+            environment as the original content view
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         org = entities.Organization().create()
         lc_env = entities.LifecycleEnvironment(organization=org).create()
@@ -139,12 +139,12 @@ class ContentViewTestCase(APITestCase):
         view based on existing view but promoted to a
         different environment
 
-        @id: a4d21c85-a77c-4664-95ba-3d32c3ad1663
+        :id: a4d21c85-a77c-4664-95ba-3d32c3ad1663
 
-        @Assert: Cloned content view can be published and promoted
-        to a different environment as the original content view
+        :Assert: Cloned content view can be published and promoted to a
+            different environment as the original content view
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         org = entities.Organization().create()
         lc_env = entities.LifecycleEnvironment(organization=org).create()
@@ -163,11 +163,11 @@ class ContentViewTestCase(APITestCase):
     def test_positive_add_custom_content(self):
         """Associate custom content in a view
 
-        @id: db452e0c-0c17-40f2-bab4-8467e7a875f1
+        :id: db452e0c-0c17-40f2-bab4-8467e7a875f1
 
-        @Assert: Custom content assigned and present in content view
+        :Assert: Custom content assigned and present in content view
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         org = entities.Organization().create()
         product = entities.Product(organization=org).create()
@@ -186,12 +186,12 @@ class ContentViewTestCase(APITestCase):
         """Attempt to associate puppet repos within a custom content
         view directly
 
-        @id: 659e0b7a-9886-43aa-a489-dbd509c29ef8
+        :id: 659e0b7a-9886-43aa-a489-dbd509c29ef8
 
-        @Assert: User cannot create a non-composite content view that contains
-        direct puppet repos reference.
+        :Assert: User cannot create a non-composite content view that contains
+            direct puppet repos reference.
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         org = entities.Organization().create()
         product = entities.Product(organization=org).create()
@@ -213,11 +213,11 @@ class ContentViewTestCase(APITestCase):
         """Attempt to associate the same repo multiple times within a
         content view
 
-        @id: 9e3dff38-fdcc-4483-9844-0619797cf1d5
+        :id: 9e3dff38-fdcc-4483-9844-0619797cf1d5
 
-        @Assert: User cannot add repos multiple times to the view
+        :Assert: User cannot add repos multiple times to the view
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         org = entities.Organization().create()
         product = entities.Product(organization=org).create()
@@ -237,11 +237,11 @@ class ContentViewTestCase(APITestCase):
         """Attempt to associate duplicate puppet modules within a
         content view
 
-        @id: 79036b3b-18dd-489e-9725-15f052371512
+        :id: 79036b3b-18dd-489e-9725-15f052371512
 
-        @Assert: User cannot add same modules multiple times to the view
+        :Assert: User cannot add same modules multiple times to the view
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         org = entities.Organization().create()
         product = entities.Product(organization=org).create()
@@ -278,18 +278,19 @@ class ContentViewTestCase(APITestCase):
     def test_positive_restart_promote_via_dynflow(self):
         """Attempt to restart a promotion
 
-        @id: 99fc4562-0230-40a5-aef1-f65f02feae65
+        :id: 99fc4562-0230-40a5-aef1-f65f02feae65
 
-        @steps:
+        :steps:
 
-        1. (Somehow) cause a CV promotion to fail.  Not exactly sure how yet.
-        2. Via Dynflow, restart promotion
+            1. (Somehow) cause a CV promotion to fail.  Not exactly sure how
+               yet.
+            2. Via Dynflow, restart promotion
 
-        @assert: Promotion is restarted.
+        :assert: Promotion is restarted.
 
-        @caseautomation: notautomated
+        :caseautomation: notautomated
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
 
     @tier2
@@ -297,18 +298,19 @@ class ContentViewTestCase(APITestCase):
     def test_positive_restart_publish_via_dynflow(self):
         """Attempt to restart a publish
 
-        @id: 8612959e-cd52-404e-88ec-7351c2d282d0
+        :id: 8612959e-cd52-404e-88ec-7351c2d282d0
 
-        @steps:
+        :steps:
 
-        1. (Somehow) cause a CV publish  to fail.  Not exactly sure how yet.
-        2. Via Dynflow, restart publish
+            1. (Somehow) cause a CV publish  to fail.  Not exactly sure how
+               yet.
+            2. Via Dynflow, restart publish
 
-        @assert: Publish is restarted.
+        :assert: Publish is restarted.
 
-        @caseautomation: notautomated
+        :caseautomation: notautomated
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
 
 
@@ -319,10 +321,10 @@ class ContentViewCreateTestCase(APITestCase):
     def test_positive_create_composite(self):
         """Create composite and non-composite content views.
 
-        @id: 4a3b616d-53ab-4396-9a50-916d6c42a401
+        :id: 4a3b616d-53ab-4396-9a50-916d6c42a401
 
-        @Assert: Creation succeeds and content-view is composite or
-        non-composite, respectively.
+        :Assert: Creation succeeds and content-view is composite or
+            non-composite, respectively.
         """
         for composite in (True, False):
             with self.subTest(composite):
@@ -337,9 +339,9 @@ class ContentViewCreateTestCase(APITestCase):
     def test_positive_create_with_name(self):
         """Create empty content-view with random names.
 
-        @id: 80d36498-2e71-4aa9-b696-f0a45e86267f
+        :id: 80d36498-2e71-4aa9-b696-f0a45e86267f
 
-        @Assert: Content-view is created and had random name.
+        :Assert: Content-view is created and had random name.
         """
         for name in valid_data_list():
             with self.subTest(name):
@@ -352,9 +354,9 @@ class ContentViewCreateTestCase(APITestCase):
     def test_positive_create_with_description(self):
         """Create empty content view with random description.
 
-        @id: 068e3e7c-34ac-47cb-a1bb-904d12c74cc7
+        :id: 068e3e7c-34ac-47cb-a1bb-904d12c74cc7
 
-        @Assert: Content-view is created and has random description.
+        :Assert: Content-view is created and has random description.
         """
         for desc in valid_data_list():
             with self.subTest(desc):
@@ -369,9 +371,9 @@ class ContentViewCreateTestCase(APITestCase):
     def test_positive_clone(self):
         """Create a content view by copying an existing one
 
-        @id: ee03dc63-e2b0-4a89-a828-2910405279ff
+        :id: ee03dc63-e2b0-4a89-a828-2910405279ff
 
-        @assert: A content view is cloned with relevant parameters
+        :assert: A content view is cloned with relevant parameters
         """
         org = entities.Organization().create()
         content_view = entities.ContentView(organization=org).create()
@@ -393,9 +395,9 @@ class ContentViewCreateTestCase(APITestCase):
     def test_negative_create_with_invalid_name(self):
         """Create content view providing an invalid name.
 
-        @id: 261376ca-7d12-41b6-9c36-5f284865243e
+        :id: 261376ca-7d12-41b6-9c36-5f284865243e
 
-        @Assert: Content View is not created
+        :Assert: Content View is not created
         """
         for name in invalid_names_list():
             with self.subTest(name):
@@ -443,12 +445,12 @@ class ContentViewPublishPromoteTestCase(APITestCase):
     def test_positive_publish_multiple(self):
         """Publish a content view several times.
 
-        @id: 54072676-cb59-43d4-82d6-432d8aa103e7
+        :id: 54072676-cb59-43d4-82d6-432d8aa103e7
 
-        @Assert: Content view has the correct number of versions after each
-        publishing operation.
+        :Assert: Content view has the correct number of versions after each
+            publishing operation.
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         content_view = entities.ContentView().create()
         for _ in range(REPEAT):
@@ -459,13 +461,13 @@ class ContentViewPublishPromoteTestCase(APITestCase):
     def test_positive_publish_with_content_multiple(self):
         """Give a content view yum packages and publish it repeatedly.
 
-        @id: 7db81c1f-c69e-453f-bea4-ecad47f27c69
+        :id: 7db81c1f-c69e-453f-bea4-ecad47f27c69
 
-        @Assert: The yum repo is referenced from the content view, the content
-        view can be published several times, and each content view version has
-        at least one package.
+        :Assert: The yum repo is referenced from the content view, the content
+            view can be published several times, and each content view version
+            has at least one package.
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         content_view = entities.ContentView(organization=self.org).create()
         content_view.repository = [self.yum_repo]
@@ -486,12 +488,12 @@ class ContentViewPublishPromoteTestCase(APITestCase):
         """Create empty composite view and assign one normal content
         view to it. After that publish that composite content view once.
 
-        @id: da7cff4a-fa89-4ca5-8289-18794eb66b92
+        :id: da7cff4a-fa89-4ca5-8289-18794eb66b92
 
-        @Assert: Composite content view is published and corresponding
-        version is assigned to it.
+        :Assert: Composite content view is published and corresponding version
+            is assigned to it.
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         composite_cv = entities.ContentView(
             composite=True,
@@ -507,12 +509,12 @@ class ContentViewPublishPromoteTestCase(APITestCase):
         normal content views to it. After that publish that composite content
         view once.
 
-        @id: 0d56d318-46a4-4da5-871b-72a3926055dd
+        :id: 0d56d318-46a4-4da5-871b-72a3926055dd
 
-        @Assert: Composite content view is published and corresponding
-        version is assigned to it.
+        :Assert: Composite content view is published and corresponding version
+            is assigned to it.
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         composite_cv = entities.ContentView(
             composite=True,
@@ -528,12 +530,12 @@ class ContentViewPublishPromoteTestCase(APITestCase):
         view to it. After that publish that composite content view several
         times.
 
-        @id: c0163c56-97c3-4296-aeff-c35a894572d7
+        :id: c0163c56-97c3-4296-aeff-c35a894572d7
 
-        @Assert: Composite content view is published several times
-        and corresponding versions are assigned to it.
+        :Assert: Composite content view is published several times and
+            corresponding versions are assigned to it.
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         composite_cv = entities.ContentView(
             composite=True,
@@ -551,12 +553,12 @@ class ContentViewPublishPromoteTestCase(APITestCase):
         normal content views to it. After that publish that composite content
         view several times.
 
-        @id: da8ad491-02f2-4b84-b850-0dea7259739c
+        :id: da8ad491-02f2-4b84-b850-0dea7259739c
 
-        @Assert: Composite content view is published several times
-        and corresponding versions are assigned to it.
+        :Assert: Composite content view is published several times and
+            corresponding versions are assigned to it.
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         composite_cv = entities.ContentView(
             composite=True,
@@ -572,13 +574,13 @@ class ContentViewPublishPromoteTestCase(APITestCase):
     def test_positive_publish_with_puppet_once(self):
         """Publish a content view that has puppet module once.
 
-        @id: 42083b8e-1cf0-4ee6-9dd5-7de8f06ae028
+        :id: 42083b8e-1cf0-4ee6-9dd5-7de8f06ae028
 
-        @Assert: The puppet module is referenced from the content view, the
-        content view can be published once and corresponding version refer to
-        puppet module
+        :Assert: The puppet module is referenced from the content view, the
+            content view can be published once and corresponding version refer
+            to puppet module
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         content_view = entities.ContentView(organization=self.org).create()
         puppet_module = random.choice(
@@ -599,13 +601,13 @@ class ContentViewPublishPromoteTestCase(APITestCase):
         """Publish a content view that has puppet module
         several times.
 
-        @id: 7096abc9-e761-40cc-8e5b-acc16c7e9c27
+        :id: 7096abc9-e761-40cc-8e5b-acc16c7e9c27
 
-        @Assert: The puppet module is referenced from the content view, the
-        content view can be published several times, and each version
-        references the puppet module.
+        :Assert: The puppet module is referenced from the content view, the
+            content view can be published several times, and each version
+            references the puppet module.
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         content_view = entities.ContentView(organization=self.org).create()
         puppet_module = random.choice(
@@ -632,12 +634,12 @@ class ContentViewPublishPromoteTestCase(APITestCase):
     def test_positive_promote_empty_multiple(self):
         """Promote a content view version ``REPEAT`` times.
 
-        @id: 06453880-49fd-4ed1-8ee2-cdc530eaa31a
+        :id: 06453880-49fd-4ed1-8ee2-cdc530eaa31a
 
-        @Assert: The content view version points to ``REPEAT + 1`` lifecycle
-        environments after the promotions.
+        :Assert: The content view version points to ``REPEAT + 1`` lifecycle
+            environments after the promotions.
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         content_view = entities.ContentView(organization=self.org).create()
         content_view.publish()
@@ -659,13 +661,13 @@ class ContentViewPublishPromoteTestCase(APITestCase):
         """Give a content view a yum repo, publish it once and promote
         the content view version ``REPEAT + 1`` times.
 
-        @id: 58783790-2839-4e91-94d3-008dc3fe3219
+        :id: 58783790-2839-4e91-94d3-008dc3fe3219
 
-        @Assert: The content view has one repository, the content view version
-        is in ``REPEAT + 1`` lifecycle environments and it has at least one
-        package.
+        :Assert: The content view has one repository, the content view version
+            is in ``REPEAT + 1`` lifecycle environments and it has at least one
+            package.
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         content_view = entities.ContentView(organization=self.org).create()
         content_view.repository = [self.yum_repo]
@@ -693,13 +695,13 @@ class ContentViewPublishPromoteTestCase(APITestCase):
         """Give content view a puppet module. Publish
         and promote it once
 
-        @id: 1d56d5c7-aeb7-4d50-a1fd-43f462cae19c
+        :id: 1d56d5c7-aeb7-4d50-a1fd-43f462cae19c
 
-        @Assert: The content view has one puppet module, the content view
-        version is in ``Library + 1`` lifecycle environments and it has one
-        puppet module assigned too.
+        :Assert: The content view has one puppet module, the content view
+            version is in ``Library + 1`` lifecycle environments and it has one
+            puppet module assigned too.
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         content_view = entities.ContentView(organization=self.org).create()
         puppet_module = random.choice(
@@ -728,13 +730,13 @@ class ContentViewPublishPromoteTestCase(APITestCase):
         """Give a content view a puppet module, publish it once and
         promote the content view version ``Library + random`` times.
 
-        @id: a01465b6-00e9-4a96-9ab5-269a270313cc
+        :id: a01465b6-00e9-4a96-9ab5-269a270313cc
 
-        @Assert: The content view has one puppet module, the content view
-        version is in ``Library + random`` lifecycle environments and it has
-        one puppet module.
+        :Assert: The content view has one puppet module, the content view
+            version is in ``Library + random`` lifecycle environments and it
+            has one puppet module.
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         content_view = entities.ContentView(organization=self.org).create()
         puppet_module = random.choice(
@@ -769,12 +771,12 @@ class ContentViewPublishPromoteTestCase(APITestCase):
         """Create normal content view, publish and add it to a new
         composite content view
 
-        @id: 36894150-5321-4ffd-ab5a-a7ad01401cf4
+        :id: 36894150-5321-4ffd-ab5a-a7ad01401cf4
 
-        @Assert: Content view can be created and assigned to composite one
-        through content view versions mechanism
+        :Assert: Content view can be created and assigned to composite one
+            through content view versions mechanism
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         content_view = entities.ContentView(organization=self.org).create()
         content_view.repository = [self.yum_repo]
@@ -805,11 +807,11 @@ class ContentViewPublishPromoteTestCase(APITestCase):
         """Attempt to associate components in a non-composite content
         view
 
-        @id: 60aa7a4e-df6e-407e-86c7-a4c540bda8b5
+        :id: 60aa7a4e-df6e-407e-86c7-a4c540bda8b5
 
-        @Assert: User cannot add components to the view
+        :Assert: User cannot add components to the view
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         content_view = entities.ContentView(organization=self.org).create()
         content_view.repository = [self.yum_repo]
@@ -831,12 +833,12 @@ class ContentViewPublishPromoteTestCase(APITestCase):
         """Create empty composite view and assign one normal content
         view to it. After that promote that composite content view once.
 
-        @id: f25d2f64-8b42-42d2-b713-8827fa3a6a1b
+        :id: f25d2f64-8b42-42d2-b713-8827fa3a6a1b
 
-        @Assert: Composite content view version points to
-        ``Library + 1`` lifecycle environments after the promotions.
+        :Assert: Composite content view version points to ``Library + 1``
+            lifecycle environments after the promotions.
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         composite_cv = entities.ContentView(
             composite=True,
@@ -856,12 +858,12 @@ class ContentViewPublishPromoteTestCase(APITestCase):
         normal content views to it. After that promote that composite
         content view once.
 
-        @id: 20389383-7510-421c-803a-e73de9db941a
+        :id: 20389383-7510-421c-803a-e73de9db941a
 
-        @Assert: Composite content view version points to ``Library + 1``
-        lifecycle environments after the promotions.
+        :Assert: Composite content view version points to ``Library + 1``
+            lifecycle environments after the promotions.
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         composite_cv = entities.ContentView(
             composite=True,
@@ -881,12 +883,12 @@ class ContentViewPublishPromoteTestCase(APITestCase):
         view to it. After that promote that composite content view
         ``Library + random`` times.
 
-        @id: ba3b737c-365a-4a7b-9109-e6d52fd1c31f
+        :id: ba3b737c-365a-4a7b-9109-e6d52fd1c31f
 
-        @Assert: Composite content view version points to ``Library + random``
-        lifecycle environments after the promotions.
+        :Assert: Composite content view version points to ``Library + random``
+            lifecycle environments after the promotions.
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         composite_cv = entities.ContentView(
             composite=True,
@@ -913,12 +915,12 @@ class ContentViewPublishPromoteTestCase(APITestCase):
         normal content views to it. After that promote that composite content
         view ``Library + random`` times.
 
-        @id: 368811fe-f24a-48a5-b883-9c1d08a03d6b
+        :id: 368811fe-f24a-48a5-b883-9c1d08a03d6b
 
-        @Assert: Composite content view version points to
-        ``Library + random`` lifecycle environments after the promotions.
+        :Assert: Composite content view version points to ``Library + random``
+            lifecycle environments after the promotions.
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         composite_cv = entities.ContentView(
             composite=True,
@@ -944,11 +946,11 @@ class ContentViewPublishPromoteTestCase(APITestCase):
         """Try to publish content view few times in a row and then re-promote
         first version to default environment
 
-        @id: 40d20aba-726f-48e3-93b7-fb1ab1851ac7
+        :id: 40d20aba-726f-48e3-93b7-fb1ab1851ac7
 
-        @Assert: Content view promoted out of sequence properly
+        :Assert: Content view promoted out of sequence properly
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         content_view = entities.ContentView(organization=self.org).create()
         for _ in range(REPEAT):
@@ -986,9 +988,9 @@ class ContentViewUpdateTestCase(APITestCase):
     def test_positive_update_attributes(self):
         """Update a content view and provide valid attributes.
 
-        @id: 3f1457f2-586b-472c-8053-99017c4a4909
+        :id: 3f1457f2-586b-472c-8053-99017c4a4909
 
-        @Assert: The update succeeds.
+        :Assert: The update succeeds.
         """
         attrs = {'description': gen_utf8(), 'name': gen_utf8()}
         for key, value in attrs.items():
@@ -1002,10 +1004,9 @@ class ContentViewUpdateTestCase(APITestCase):
         """Create content view providing the initial name, then update
         its name to another valid name.
 
-        @id: 15e6fa3a-1a65-4e7d-8d32-3a81227ac1c8
+        :id: 15e6fa3a-1a65-4e7d-8d32-3a81227ac1c8
 
-        @Assert: Content View is created, and its name can be
-        updated.
+        :Assert: Content View is created, and its name can be updated.
         """
         for new_name in valid_data_list():
             with self.subTest(new_name):
@@ -1018,10 +1019,9 @@ class ContentViewUpdateTestCase(APITestCase):
         """Create content view then update its name to an
         invalid name.
 
-        @id: 69a2ce8d-19b2-49a3-97db-a1fdebbb16be
+        :id: 69a2ce8d-19b2-49a3-97db-a1fdebbb16be
 
-        @Assert: Content View is created, and its name is not
-        updated.
+        :Assert: Content View is created, and its name is not updated.
         """
         for new_name in invalid_names_list():
             with self.subTest(new_name):
@@ -1037,9 +1037,9 @@ class ContentViewUpdateTestCase(APITestCase):
     def test_negative_update_label(self):
         """Try to update a content view label with any value
 
-        @id: 77883887-800f-412f-91a3-b2f7ed999c70
+        :id: 77883887-800f-412f-91a3-b2f7ed999c70
 
-        @Assert: The content view label is immutable and cannot be modified
+        :Assert: The content view label is immutable and cannot be modified
         """
         with self.assertRaises(HTTPError):
             entities.ContentView(
@@ -1054,9 +1054,9 @@ class ContentViewDeleteTestCase(APITestCase):
     def test_positive_delete(self):
         """Create content view and then delete it.
 
-        @id: d582f1b3-8118-4e78-a639-237c6f9d27c6
+        :id: d582f1b3-8118-4e78-a639-237c6f9d27c6
 
-        @Assert: Content View is successfully deleted.
+        :Assert: Content View is successfully deleted.
         """
         for name in valid_data_list():
             with self.subTest(name):
@@ -1097,11 +1097,11 @@ class ContentViewRedHatContent(APITestCase):
     def test_positive_add_rh(self):
         """associate Red Hat content in a view
 
-        @id: f011a269-813d-4e82-afe8-f106b23cb03e
+        :id: f011a269-813d-4e82-afe8-f106b23cb03e
 
-        @Assert: RH Content assigned and present in a view
+        :Assert: RH Content assigned and present in a view
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         content_view = entities.ContentView(organization=self.org).create()
         self.assertEqual(len(content_view.repository), 0)
@@ -1117,12 +1117,11 @@ class ContentViewRedHatContent(APITestCase):
     def test_positive_add_rh_custom_spin(self):
         """Associate Red Hat content in a view and filter it using rule
 
-        @id: 30c3103d-9503-4501-8117-1f2d25353215
+        :id: 30c3103d-9503-4501-8117-1f2d25353215
 
-        @Assert: Filtered RH content is available and can be seen in a
-        view
+        :Assert: Filtered RH content is available and can be seen in a view
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         content_view = entities.ContentView(organization=self.org).create()
         content_view.repository = [self.repo]
@@ -1150,12 +1149,11 @@ class ContentViewRedHatContent(APITestCase):
         """Edit content views for a custom rh spin.  For example,
         modify a filter
 
-        @id: 81d77ecd-8bac-44c6-8bc2-b6e38ad77a0b
+        :id: 81d77ecd-8bac-44c6-8bc2-b6e38ad77a0b
 
-        @assert: edited content view save is successful and info is
-        updated
+        :assert: edited content view save is successful and info is updated
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         content_view = entities.ContentView(organization=self.org).create()
         content_view.repository = [self.repo]
@@ -1182,11 +1180,11 @@ class ContentViewRedHatContent(APITestCase):
     def test_positive_publish_rh(self):
         """Attempt to publish a content view containing Red Hat content
 
-        @id: 4f1698ef-a23b-48d6-be25-dbbf2d76c95c
+        :id: 4f1698ef-a23b-48d6-be25-dbbf2d76c95c
 
-        @Assert: Content view can be published
+        :Assert: Content view can be published
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         content_view = entities.ContentView(organization=self.org).create()
         content_view.repository = [self.repo]
@@ -1199,11 +1197,11 @@ class ContentViewRedHatContent(APITestCase):
         """Attempt to publish a content view containing Red Hat spin - i.e.,
         contains filters.
 
-        @id: 094a8c46-935b-4dbc-830e-19bec935276c
+        :id: 094a8c46-935b-4dbc-830e-19bec935276c
 
-        @Assert: Content view can be published
+        :Assert: Content view can be published
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         content_view = entities.ContentView(organization=self.org).create()
         content_view.repository = [self.repo]
@@ -1220,11 +1218,11 @@ class ContentViewRedHatContent(APITestCase):
     def test_positive_promote_rh(self):
         """Attempt to promote a content view containing Red Hat content
 
-        @id: 991dd9cc-5818-42dc-9098-66b312adfd97
+        :id: 991dd9cc-5818-42dc-9098-66b312adfd97
 
-        @Assert: Content view can be promoted
+        :Assert: Content view can be promoted
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         content_view = entities.ContentView(organization=self.org).create()
         content_view.repository = [self.repo]
@@ -1241,11 +1239,11 @@ class ContentViewRedHatContent(APITestCase):
         """Attempt to promote a content view containing Red Hat spin - i.e.,
         contains filters.
 
-        @id: 8331ba11-1742-425f-83b1-6b06c5785572
+        :id: 8331ba11-1742-425f-83b1-6b06c5785572
 
-        @Assert: Content view can be promoted
+        :Assert: Content view can be promoted
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         content_view = entities.ContentView(organization=self.org).create()
         content_view.repository = [self.repo]
@@ -1275,21 +1273,20 @@ class ContentViewRolesTestCase(APITestCase):
     def test_positive_admin_user_actions(self):
         """Attempt to manage content views
 
-        @id: 75b638af-d132-4b5e-b034-a373565c72b4
+        :id: 75b638af-d132-4b5e-b034-a373565c72b4
 
-        @steps:
-        with global admin account:
+        :steps: with global admin account:
 
-        1. create a user with all content views permissions
-        2. create lifecycle environment
-        3. create 2 content views (one to delete, the other to manage)
+            1. create a user with all content views permissions
+            2. create lifecycle environment
+            3. create 2 content views (one to delete, the other to manage)
 
-        @setup: create a user with all content views permissions
+        :setup: create a user with all content views permissions
 
-        @assert: The user can Read, Modify, Delete, Publish, Promote the
-        content views
+        :assert: The user can Read, Modify, Delete, Publish, Promote the
+            content views
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         user_login = gen_string('alpha')
         user_password = gen_string('alphanumeric')
@@ -1338,18 +1335,18 @@ class ContentViewRolesTestCase(APITestCase):
     def test_positive_readonly_user_actions(self):
         """Attempt to view content views
 
-        @id: cdfd6e51-cd46-4afa-807c-98b2195fcf0e
+        :id: cdfd6e51-cd46-4afa-807c-98b2195fcf0e
 
-        @setup:
+        :setup:
 
-        1. create a user with the Content View read-only role
-        2. create content view
-        3. add a custom repository to content view
+            1. create a user with the Content View read-only role
+            2. create content view
+            3. add a custom repository to content view
 
-        @assert: User with read-only role for content view can view the
-        repository in the content view
+        :assert: User with read-only role for content view can view the
+            repository in the content view
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         user_login = gen_string('alpha')
         user_password = gen_string('alphanumeric')
@@ -1398,18 +1395,18 @@ class ContentViewRolesTestCase(APITestCase):
     def test_negative_readonly_user_actions(self):
         """Attempt to manage content views
 
-        @id: aae6eede-b40e-4e06-a5f7-59d9251aa35d
+        :id: aae6eede-b40e-4e06-a5f7-59d9251aa35d
 
-        @setup:
+        :setup:
 
-        1. create a user with the Content View read-only role
-        2. create content view
-        3. add a custom repository to content view
+            1. create a user with the Content View read-only role
+            2. create content view
+            3. add a custom repository to content view
 
-        @assert: User with read only role for content view cannot Modify,
-        Delete, Publish, Promote the content views
+        :assert: User with read only role for content view cannot Modify,
+            Delete, Publish, Promote the content views
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         user_login = gen_string('alpha')
         user_password = gen_string('alphanumeric')
@@ -1469,15 +1466,15 @@ class ContentViewRolesTestCase(APITestCase):
     def test_negative_non_readonly_user_actions(self):
         """Attempt to view content views
 
-        @id: 9cbc661a-dbe3-4b88-af27-4cf7b9544074
+        :id: 9cbc661a-dbe3-4b88-af27-4cf7b9544074
 
-        @setup: create a user with all Content View permissions except 'view'
-        role
+        :setup: create a user with all Content View permissions except 'view'
+            role
 
-        @assert: the user can perform different operations against content
-        view, but not read it
+        :assert: the user can perform different operations against content
+            view, but not read it
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         user_login = gen_string('alpha')
         user_password = gen_string('alphanumeric')
@@ -1562,11 +1559,11 @@ class OstreeContentViewTestCase(APITestCase):
     def test_positive_add_custom_ostree_content(self):
         """Associate custom ostree content in a view
 
-        @id: 209e59b0-c73d-4a5f-a1dc-0d74dff9a084
+        :id: 209e59b0-c73d-4a5f-a1dc-0d74dff9a084
 
-        @Assert: Custom ostree content assigned and present in content view
+        :Assert: Custom ostree content assigned and present in content view
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         content_view = entities.ContentView(organization=self.org).create()
         self.assertEqual(len(content_view.repository), 0)
@@ -1583,11 +1580,11 @@ class OstreeContentViewTestCase(APITestCase):
     def test_positive_publish_custom_ostree(self):
         """Publish a content view with custom ostree contents
 
-        @id: e5f5c940-20e5-406f-9d27-a703195a3b88
+        :id: e5f5c940-20e5-406f-9d27-a703195a3b88
 
-        @Assert: Content-view with Custom ostree published successfully
+        :Assert: Content-view with Custom ostree published successfully
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         content_view = entities.ContentView(organization=self.org).create()
         content_view.repository = [self.ostree_repo]
@@ -1599,11 +1596,11 @@ class OstreeContentViewTestCase(APITestCase):
     def test_positive_promote_custom_ostree(self):
         """Promote a content view with custom ostree contents
 
-        @id: 3d9f3641-0776-45f7-bf1e-7d5779346b93
+        :id: 3d9f3641-0776-45f7-bf1e-7d5779346b93
 
-        @Assert: Content-view with custom ostree contents promoted successfully
+        :Assert: Content-view with custom ostree contents promoted successfully
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         content_view = entities.ContentView(organization=self.org).create()
         content_view.repository = [self.ostree_repo]
@@ -1618,12 +1615,12 @@ class OstreeContentViewTestCase(APITestCase):
     def test_positive_publish_promote_with_custom_ostree_and_other(self):
         """Publish & Promote a content view with custom ostree and other contents
 
-        @id: 690ec30a-56ac-4478-afb2-be34a85a614a
+        :id: 690ec30a-56ac-4478-afb2-be34a85a614a
 
-        @Assert: Content-view with custom ostree and other contents promoted
-        successfully
+        :Assert: Content-view with custom ostree and other contents promoted
+            successfully
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         content_view = entities.ContentView(organization=self.org).create()
         content_view.repository = [
@@ -1682,11 +1679,11 @@ class ContentViewRedHatOstreeContent(APITestCase):
     def test_positive_add_rh_ostree_content(self):
         """Associate RH atomic ostree content in a view
 
-        @id: 81883f05-e47f-45fa-bea4-c733da9cf30c
+        :id: 81883f05-e47f-45fa-bea4-c733da9cf30c
 
-        @Assert: RH atomic ostree content assigned and present in content view
+        :Assert: RH atomic ostree content assigned and present in content view
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         content_view = entities.ContentView(organization=self.org).create()
         self.assertEqual(len(content_view.repository), 0)
@@ -1702,11 +1699,11 @@ class ContentViewRedHatOstreeContent(APITestCase):
     def test_positive_publish_RH_ostree(self):
         """Publish a content view with RH ostree contents
 
-        @id: 067ebb6e-2dad-4932-ae84-64c4373c9cb8
+        :id: 067ebb6e-2dad-4932-ae84-64c4373c9cb8
 
-        @Assert: Content-view with RH ostree contents published successfully
+        :Assert: Content-view with RH ostree contents published successfully
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         content_view = entities.ContentView(organization=self.org).create()
         content_view.repository = [self.repo]
@@ -1718,11 +1715,11 @@ class ContentViewRedHatOstreeContent(APITestCase):
     def test_positive_promote_RH_ostree(self):
         """Promote a content view with RH ostree contents
 
-        @id: 447a96e0-331b-447c-9a8d-423d1b22ef6a
+        :id: 447a96e0-331b-447c-9a8d-423d1b22ef6a
 
-        @Assert: Content-view with RH ostree contents promoted successfully
+        :Assert: Content-view with RH ostree contents promoted successfully
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         content_view = entities.ContentView(organization=self.org).create()
         content_view.repository = [self.repo]
@@ -1737,12 +1734,12 @@ class ContentViewRedHatOstreeContent(APITestCase):
     def test_positive_publish_promote_with_RH_ostree_and_other(self):
         """Publish & Promote a content view with RH ostree and other contents
 
-        @id: def6caa3-ac31-42fa-9579-39a18b8244bd
+        :id: def6caa3-ac31-42fa-9579-39a18b8244bd
 
-        @Assert: Content-view with RH ostree and other contents promoted
-        successfully
+        :Assert: Content-view with RH ostree and other contents promoted
+            successfully
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         repo_id = enable_rhrepo_and_fetchid(
             basearch='x86_64',

--- a/tests/foreman/api/test_contentviewfilter.py
+++ b/tests/foreman/api/test_contentviewfilter.py
@@ -4,19 +4,19 @@ A full API reference for content views can be found here:
 http://www.katello.org/docs/api/apidoc/content_view_filters.html
 
 
-@Requirement: Contentviewfilter
+:Requirement: Contentviewfilter
 
-@CaseAutomation: Automated
+:CaseAutomation: Automated
 
-@CaseLevel: Acceptance
+:CaseLevel: Acceptance
 
-@CaseComponent: API
+:CaseComponent: API
 
-@TestType: Functional
+:TestType: Functional
 
-@CaseImportance: High
+:CaseImportance: High
 
-@Upstream: No
+:Upstream: No
 """
 from fauxfactory import gen_integer, gen_string
 from nailgun import client, entities
@@ -56,12 +56,12 @@ class ContentViewFilterTestCase(APITestCase):
     def test_negative_get_with_no_args(self):
         """Issue an HTTP GET to the base content view filters path.
 
-        @id: da29fd90-cd96-49f9-b94e-71d4e3a35a57
+        :id: da29fd90-cd96-49f9-b94e-71d4e3a35a57
 
-        @Assert: An HTTP 200 response is received if a GET request is issued
-        with no arguments specified.
+        :Assert: An HTTP 200 response is received if a GET request is issued
+            with no arguments specified.
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         response = client.get(
             entities.AbstractContentViewFilter().path(),
@@ -75,12 +75,12 @@ class ContentViewFilterTestCase(APITestCase):
     def test_negative_get_with_bad_args(self):
         """Issue an HTTP GET to the base content view filters path.
 
-        @id: e6fea726-930b-4b74-b784-41528811994f
+        :id: e6fea726-930b-4b74-b784-41528811994f
 
-        @Assert: An HTTP 200 response is received if a GET request is issued
-        with bad arguments specified.
+        :Assert: An HTTP 200 response is received if a GET request is issued
+            with bad arguments specified.
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         response = client.get(
             entities.AbstractContentViewFilter().path(),
@@ -95,12 +95,12 @@ class ContentViewFilterTestCase(APITestCase):
     def test_positive_create_erratum_with_name(self):
         """Create new erratum content filter using different inputs as a name
 
-        @id: f78a133f-441f-4fcc-b292-b9eed228d755
+        :id: f78a133f-441f-4fcc-b292-b9eed228d755
 
-        @Assert: Content view filter created successfully and has correct name
-        and type
+        :Assert: Content view filter created successfully and has correct name
+            and type
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         for name in valid_data_list():
             with self.subTest(name):
@@ -116,12 +116,12 @@ class ContentViewFilterTestCase(APITestCase):
     def test_positive_create_pkg_group_with_name(self):
         """Create new package group content filter using different inputs as a name
 
-        @id: f9bfb6bf-a879-4f1a-970d-8f4df533cd59
+        :id: f9bfb6bf-a879-4f1a-970d-8f4df533cd59
 
-        @Assert: Content view filter created successfully and has correct name
-        and type
+        :Assert: Content view filter created successfully and has correct name
+            and type
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         for name in valid_data_list():
             with self.subTest(name):
@@ -137,12 +137,12 @@ class ContentViewFilterTestCase(APITestCase):
     def test_positive_create_rpm_with_name(self):
         """Create new RPM content filter using different inputs as a name
 
-        @id: f1c88e72-7993-47ac-8fbc-c749d32bc768
+        :id: f1c88e72-7993-47ac-8fbc-c749d32bc768
 
-        @Assert: Content view filter created successfully and has correct name
-        and type
+        :Assert: Content view filter created successfully and has correct name
+            and type
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         for name in valid_data_list():
             with self.subTest(name):
@@ -158,12 +158,12 @@ class ContentViewFilterTestCase(APITestCase):
     def test_positive_create_with_inclusion(self):
         """Create new content view filter with different inclusion values
 
-        @id: 81130dc9-ae33-48bc-96a7-d54d3e99448e
+        :id: 81130dc9-ae33-48bc-96a7-d54d3e99448e
 
-        @Assert: Content view filter created successfully and has correct
-        inclusion value
+        :Assert: Content view filter created successfully and has correct
+            inclusion value
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         for inclusion in (True, False):
             with self.subTest(inclusion):
@@ -178,12 +178,12 @@ class ContentViewFilterTestCase(APITestCase):
     def test_positive_create_with_description(self):
         """Create new content filter using different inputs as a description
 
-        @id: e057083f-e69d-46e7-b336-45faaf67fa52
+        :id: e057083f-e69d-46e7-b336-45faaf67fa52
 
-        @Assert: Content view filter created successfully and has correct
-        description
+        :Assert: Content view filter created successfully and has correct
+            description
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         for description in valid_data_list():
             with self.subTest(description):
@@ -198,12 +198,12 @@ class ContentViewFilterTestCase(APITestCase):
     def test_positive_create_with_repo(self):
         """Create new content filter with repository assigned
 
-        @id: 7207d4cf-3ccf-4d63-a50a-1373b16062e2
+        :id: 7207d4cf-3ccf-4d63-a50a-1373b16062e2
 
-        @Assert: Content view filter created successfully and has repository
-        assigned
+        :Assert: Content view filter created successfully and has repository
+            assigned
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         cvf = entities.RPMContentViewFilter(
             content_view=self.content_view,
@@ -218,12 +218,12 @@ class ContentViewFilterTestCase(APITestCase):
         """Create new content view filter with different 'original packages'
         option values
 
-        @id: 789abd8a-9e9f-4c7c-b1ac-6b69f23f77dd
+        :id: 789abd8a-9e9f-4c7c-b1ac-6b69f23f77dd
 
-        @Assert: Content view filter created successfully and has 'original
-        packages' value
+        :Assert: Content view filter created successfully and has 'original
+            packages' value
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         for original_packages in (True, False):
             with self.subTest(original_packages):
@@ -242,12 +242,12 @@ class ContentViewFilterTestCase(APITestCase):
         repo already assigned to it. Create new content view filter and assign
         it to the content view.
 
-        @id: 2cd28bf3-cd8a-4943-8e63-806d3676ada1
+        :id: 2cd28bf3-cd8a-4943-8e63-806d3676ada1
 
-        @Assert: Content view filter created successfully and has both
-        repositories assigned (yum and docker)
+        :Assert: Content view filter created successfully and has both
+            repositories assigned (yum and docker)
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         docker_repository = entities.Repository(
             content_type='docker',
@@ -271,11 +271,11 @@ class ContentViewFilterTestCase(APITestCase):
     def test_negative_create_with_invalid_name(self):
         """Try to create content view filter using invalid names only
 
-        @id: 8cf4227b-75c4-4d6f-b94f-88e4eb586435
+        :id: 8cf4227b-75c4-4d6f-b94f-88e4eb586435
 
-        @Assert: Content view filter was not created
+        :Assert: Content view filter was not created
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         for name in invalid_names_list():
             with self.subTest(name):
@@ -290,11 +290,11 @@ class ContentViewFilterTestCase(APITestCase):
     def test_negative_create_with_same_name(self):
         """Try to create content view filter using same name twice
 
-        @id: 73a64ca7-07a3-49ee-8921-0474a16a23ff
+        :id: 73a64ca7-07a3-49ee-8921-0474a16a23ff
 
-        @Assert: Second content view filter was not created
+        :Assert: Second content view filter was not created
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         kwargs = {
             'content_view': self.content_view,
@@ -310,11 +310,11 @@ class ContentViewFilterTestCase(APITestCase):
         """Try to create content view filter without providing content
         view
 
-        @id: 3b5af53f-9533-482f-9ec9-b313cbb91dd7
+        :id: 3b5af53f-9533-482f-9ec9-b313cbb91dd7
 
-        @Assert: Content view filter is not created
+        :Assert: Content view filter is not created
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         with self.assertRaises(HTTPError):
             entities.RPMContentViewFilter(content_view=None).create()
@@ -325,11 +325,11 @@ class ContentViewFilterTestCase(APITestCase):
         """Try to create content view filter using incorrect repository
         id
 
-        @id: aa427770-c327-4ca1-b67f-a9a94edca784
+        :id: aa427770-c327-4ca1-b67f-a9a94edca784
 
-        @Assert: Content view filter is not created
+        :Assert: Content view filter is not created
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         with self.assertRaises(HTTPError):
             entities.RPMContentViewFilter(
@@ -342,11 +342,11 @@ class ContentViewFilterTestCase(APITestCase):
     def test_positive_delete_by_id(self):
         """Delete content view filter
 
-        @id: 07caeb9d-419d-43f8-996b-456b0cc0f70d
+        :id: 07caeb9d-419d-43f8-996b-456b0cc0f70d
 
-        @Assert: Content view filter was deleted
+        :Assert: Content view filter was deleted
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         cvf = entities.RPMContentViewFilter(
             content_view=self.content_view,
@@ -360,11 +360,11 @@ class ContentViewFilterTestCase(APITestCase):
     def test_positive_update_name(self):
         """Update content view filter with new name
 
-        @id: f310c161-00d2-4281-9721-6e45cbc5e4ec
+        :id: f310c161-00d2-4281-9721-6e45cbc5e4ec
 
-        @Assert: Content view filter updated successfully and name was changed
+        :Assert: Content view filter updated successfully and name was changed
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         cvf = entities.RPMContentViewFilter(
             content_view=self.content_view,
@@ -379,12 +379,12 @@ class ContentViewFilterTestCase(APITestCase):
     def test_positive_update_description(self):
         """Update content view filter with new description
 
-        @id: f2c5db28-0163-4cf3-929a-16ba1cb98c34
+        :id: f2c5db28-0163-4cf3-929a-16ba1cb98c34
 
-        @Assert: Content view filter updated successfully and description was
-        changed
+        :Assert: Content view filter updated successfully and description was
+            changed
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         cvf = entities.RPMContentViewFilter(
             content_view=self.content_view,
@@ -399,12 +399,12 @@ class ContentViewFilterTestCase(APITestCase):
     def test_positive_update_inclusion(self):
         """Update content view filter with new inclusion value
 
-        @id: 0aedd2d6-d020-4a90-adcd-01694b47c0b0
+        :id: 0aedd2d6-d020-4a90-adcd-01694b47c0b0
 
-        @Assert: Content view filter updated successfully and inclusion value
-        was changed
+        :Assert: Content view filter updated successfully and inclusion value
+            was changed
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         cvf = entities.RPMContentViewFilter(
             content_view=self.content_view,
@@ -420,12 +420,12 @@ class ContentViewFilterTestCase(APITestCase):
     def test_positive_update_repo(self):
         """Update content view filter with new repository
 
-        @id: 329ef155-c2d0-4aa2-bac3-79087ae49bdf
+        :id: 329ef155-c2d0-4aa2-bac3-79087ae49bdf
 
-        @Assert: Content view filter updated successfully and has new
-        repository assigned
+        :Assert: Content view filter updated successfully and has new
+            repository assigned
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         cvf = entities.RPMContentViewFilter(
             content_view=self.content_view,
@@ -446,12 +446,12 @@ class ContentViewFilterTestCase(APITestCase):
     def test_positive_update_repos(self):
         """Update content view filter with multiple repositories
 
-        @id: 478fbb1c-fa1d-4fcd-93d6-3a7f47092ed3
+        :id: 478fbb1c-fa1d-4fcd-93d6-3a7f47092ed3
 
-        @Assert: Content view filter updated successfully and has new
-        repositories assigned
+        :Assert: Content view filter updated successfully and has new
+            repositories assigned
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         cvf = entities.RPMContentViewFilter(
             content_view=self.content_view,
@@ -479,12 +479,12 @@ class ContentViewFilterTestCase(APITestCase):
     def test_positive_update_original_packages(self):
         """Update content view filter with new 'original packages' option value
 
-        @id: 0c41e57a-afa3-479e-83ba-01f09f0fd2b6
+        :id: 0c41e57a-afa3-479e-83ba-01f09f0fd2b6
 
-        @Assert: Content view filter updated successfully and 'original
-        packages' value was changed
+        :Assert: Content view filter updated successfully and 'original
+            packages' value was changed
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         cvf = entities.RPMContentViewFilter(
             content_view=self.content_view,
@@ -503,12 +503,12 @@ class ContentViewFilterTestCase(APITestCase):
         """Update existing content view filter which has yum repository
         assigned with new docker repository
 
-        @id: 909db0c9-764a-4ca8-9b56-cd8fedd543eb
+        :id: 909db0c9-764a-4ca8-9b56-cd8fedd543eb
 
-        @Assert: Content view filter was updated successfully and has both
-        repositories assigned (yum and docker)
+        :Assert: Content view filter was updated successfully and has both
+            repositories assigned (yum and docker)
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         cvf = entities.RPMContentViewFilter(
             content_view=self.content_view,
@@ -534,11 +534,11 @@ class ContentViewFilterTestCase(APITestCase):
     def test_negative_update_name(self):
         """Try to update content view filter using invalid names only
 
-        @id: 9799648a-3900-4186-8271-6b2dedb547ab
+        :id: 9799648a-3900-4186-8271-6b2dedb547ab
 
-        @Assert: Content view filter was not updated
+        :Assert: Content view filter was not updated
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         cvf = entities.RPMContentViewFilter(
             content_view=self.content_view,
@@ -554,11 +554,11 @@ class ContentViewFilterTestCase(APITestCase):
     def test_negative_update_same_name(self):
         """Try to update content view filter's name to already used one
 
-        @id: b68569f1-9f7b-4a95-9e2a-a5da348abff7
+        :id: b68569f1-9f7b-4a95-9e2a-a5da348abff7
 
-        @Assert: Content view filter was not updated
+        :Assert: Content view filter was not updated
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         name = gen_string('alpha', 8)
         entities.RPMContentViewFilter(
@@ -578,11 +578,11 @@ class ContentViewFilterTestCase(APITestCase):
         """Try to update content view filter using incorrect content
         view ID
 
-        @id: a6477d5f-e4d2-44ba-84f5-8f9004b52eb2
+        :id: a6477d5f-e4d2-44ba-84f5-8f9004b52eb2
 
-        @Assert: Content view filter was not updated
+        :Assert: Content view filter was not updated
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         cvf = entities.RPMContentViewFilter(
             content_view=self.content_view,
@@ -597,11 +597,11 @@ class ContentViewFilterTestCase(APITestCase):
         """Try to update content view filter using incorrect repository
         ID
 
-        @id: 43ded66a-331c-4160-820d-261f973a7be2
+        :id: 43ded66a-331c-4160-820d-261f973a7be2
 
-        @Assert: Content view filter was not updated
+        :Assert: Content view filter was not updated
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         cvf = entities.RPMContentViewFilter(
             content_view=self.content_view,
@@ -617,11 +617,11 @@ class ContentViewFilterTestCase(APITestCase):
         """Try to update content view filter with new repository which doesn't
         belong to filter's content view
 
-        @id: e11ba045-da8a-4f26-a0b9-3b1149358717
+        :id: e11ba045-da8a-4f26-a0b9-3b1149358717
 
-        @Assert: Content view filter was not updated
+        :Assert: Content view filter was not updated
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         cvf = entities.RPMContentViewFilter(
             content_view=self.content_view,
@@ -649,9 +649,9 @@ class ContentViewFilterSearchTestCase(APITestCase):
     def test_positive_search_erratum(self):
         """Search for an erratum content view filter's rules.
 
-        @id: 6a86060f-6b4f-4688-8ea9-c198e0aeb3f6
+        :id: 6a86060f-6b4f-4688-8ea9-c198e0aeb3f6
 
-        @Assert: The search completes with no errors.
+        :Assert: The search completes with no errors.
         """
         cv_filter = entities.ErratumContentViewFilter(
             content_view=self.content_view
@@ -662,9 +662,9 @@ class ContentViewFilterSearchTestCase(APITestCase):
     def test_positive_search_package_group(self):
         """Search for an package group content view filter's rules.
 
-        @id: 832c50cc-c2c8-48c9-9a23-80956baf5f3c
+        :id: 832c50cc-c2c8-48c9-9a23-80956baf5f3c
 
-        @Assert: The search completes with no errors.
+        :Assert: The search completes with no errors.
         """
         cv_filter = entities.PackageGroupContentViewFilter(
             content_view=self.content_view
@@ -675,9 +675,9 @@ class ContentViewFilterSearchTestCase(APITestCase):
     def test_positive_search_rpm(self):
         """Search for an rpm content view filter's rules.
 
-        @id: 1c9058f1-35c4-46f2-9b21-155ef988564a
+        :id: 1c9058f1-35c4-46f2-9b21-155ef988564a
 
-        @Assert: The search completes with no errors.
+        :Assert: The search completes with no errors.
         """
         cv_filter = entities.RPMContentViewFilter(
             content_view=self.content_view

--- a/tests/foreman/api/test_contentviewversion.py
+++ b/tests/foreman/api/test_contentviewversion.py
@@ -1,18 +1,18 @@
 """Unit tests for the ``content_view_versions`` paths.
 
-@Requirement: Contentviewversion
+:Requirement: Contentviewversion
 
-@CaseAutomation: Automated
+:CaseAutomation: Automated
 
-@CaseLevel: Acceptance
+:CaseLevel: Acceptance
 
-@CaseComponent: API
+:CaseComponent: API
 
-@TestType: Functional
+:TestType: Functional
 
-@CaseImportance: High
+:CaseImportance: High
 
-@Upstream: No
+:Upstream: No
 """
 import random
 from fauxfactory import gen_string
@@ -58,11 +58,11 @@ class ContentViewVersionCreateTestCase(APITestCase):
     def test_positive_create(self):
         """Create a content view version.
 
-        @id: 627c84b3-e3f1-416c-a09b-5d2200d6429f
+        :id: 627c84b3-e3f1-416c-a09b-5d2200d6429f
 
-        @Assert: Content View Version is created.
+        :Assert: Content View Version is created.
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         # Fetch content view for latest information
         cv = self.content_view.read()
@@ -79,11 +79,11 @@ class ContentViewVersionCreateTestCase(APITestCase):
     def test_negative_create(self):
         """Create content view version using the 'Default Content View'.
 
-        @id: 0afd49c6-f3a4-403e-9929-849f51ffa922
+        :id: 0afd49c6-f3a4-403e-9929-849f51ffa922
 
-        @Assert: Content View Version is not created
+        :Assert: Content View Version is not created
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         # The default content view cannot be published
         cv = entities.ContentView(
@@ -124,11 +124,11 @@ class ContentViewVersionPromoteTestCase(APITestCase):
         """Promote a content view version to 'next in sequence'
         lifecycle environment.
 
-        @id: f205ca06-8ab5-4546-83bd-deac4363d487
+        :id: f205ca06-8ab5-4546-83bd-deac4363d487
 
-        @Assert: Promotion succeeds.
+        :Assert: Promotion succeeds.
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         # Create a new content view...
         cv = entities.ContentView(organization=self.org).create()
@@ -154,11 +154,11 @@ class ContentViewVersionPromoteTestCase(APITestCase):
         """Promote a content view version to a lifecycle environment
         that is 'out of sequence'.
 
-        @id: e88405de-843d-4279-9d81-cedaab7c23cf
+        :id: e88405de-843d-4279-9d81-cedaab7c23cf
 
-        @Assert: The promotion succeeds.
+        :Assert: The promotion succeeds.
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         # Create a new content view...
         cv = entities.ContentView(organization=self.org).create()
@@ -180,11 +180,11 @@ class ContentViewVersionPromoteTestCase(APITestCase):
     def test_negative_promote_valid_environment(self):
         """Promote the default content view version.
 
-        @id: cd4f3c3d-93c5-425f-bc3b-d1ac17696a4a
+        :id: cd4f3c3d-93c5-425f-bc3b-d1ac17696a4a
 
-        @Assert: The promotion fails.
+        :Assert: The promotion fails.
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         with self.assertRaises(HTTPError):
             promote(self.default_cv, self.lce1.id)
@@ -194,11 +194,11 @@ class ContentViewVersionPromoteTestCase(APITestCase):
         """Promote a content view version to a lifecycle environment
         that is 'out of sequence'.
 
-        @id: 621d1bb6-92c6-4209-8369-6ea14a4c8a01
+        :id: 621d1bb6-92c6-4209-8369-6ea14a4c8a01
 
-        @Assert: The promotion fails.
+        :Assert: The promotion fails.
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         # Create a new content view...
         cv = entities.ContentView(organization=self.org).create()
@@ -225,11 +225,11 @@ class ContentViewVersionDeleteTestCase(APITestCase):
         that content view. Add repository and gpg key to initial content view
         for better coverage
 
-        @id: 066dec47-c942-4c01-8956-359c8b23a6d4
+        :id: 066dec47-c942-4c01-8956-359c8b23a6d4
 
-        @Assert: Content version deleted successfully
+        :Assert: Content version deleted successfully
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         key_content = read_data_file(ZOO_CUSTOM_GPG_KEY)
         org = entities.Organization().create()
@@ -273,11 +273,11 @@ class ContentViewVersionDeleteTestCase(APITestCase):
         and one more non-default environments through 'delete_from_environment'
         command and delete content view version from that content view.
 
-        @id: 95bb973c-ebec-4a72-a1b6-ad28b66bd11b
+        :id: 95bb973c-ebec-4a72-a1b6-ad28b66bd11b
 
-        @Assert: Content view version deleted successfully
+        :Assert: Content view version deleted successfully
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         org = entities.Organization().create()
         content_view = entities.ContentView(organization=org).create()
@@ -303,11 +303,11 @@ class ContentViewVersionDeleteTestCase(APITestCase):
         view version while content view is still associated with lifecycle
         environment
 
-        @id: 21c35aae-2f9c-4679-b3ba-7cd9182bd880
+        :id: 21c35aae-2f9c-4679-b3ba-7cd9182bd880
 
-        @Assert: Content view version is not deleted
+        :Assert: Content view version is not deleted
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         org = entities.Organization().create()
         content_view = entities.ContentView(organization=org).create()
@@ -325,19 +325,19 @@ class ContentViewVersionDeleteTestCase(APITestCase):
     def test_positive_remove_renamed_cv_version_from_default_env(self):
         """Remove version of renamed content view from Library environment
 
-        @id: 7d5961d0-6a9a-4610-979e-cbc4ddbc50ca
+        :id: 7d5961d0-6a9a-4610-979e-cbc4ddbc50ca
 
-        @Steps:
+        :Steps:
 
-        1. Create a content view
-        2. Add a yum repo to the content view
-        3. Publish the content view
-        4. Rename the content view
-        5. remove the published version from Library environment
+            1. Create a content view
+            2. Add a yum repo to the content view
+            3. Publish the content view
+            4. Rename the content view
+            5. remove the published version from Library environment
 
-        @Assert: content view version is removed from Library environment
+        :Assert: content view version is removed from Library environment
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         new_name = gen_string('alpha')
         org = entities.Organization().create()
@@ -379,21 +379,20 @@ class ContentViewVersionDeleteTestCase(APITestCase):
     def test_positive_remove_qe_promoted_cv_version_from_default_env(self):
         """Remove QE promoted content view version from Library environment
 
-        @id: c7795762-93bd-419c-ac49-d10dc26b842b
+        :id: c7795762-93bd-419c-ac49-d10dc26b842b
 
-        @Steps:
+        :Steps:
 
-        1. Create a content view
-        2. Add docker repo(s) to it
-        3. Publish content view
-        4. Promote the content view version to multiple environments
-           Library -> DEV -> QE
-        5. remove the content view version from Library environment
+            1. Create a content view
+            2. Add docker repo(s) to it
+            3. Publish content view
+            4. Promote the content view version to multiple environments
+                Library -> DEV -> QE
+            5. remove the content view version from Library environment
 
-        @Assert: Content view version exist only in DEV, QE
-        and not in Library
+        :Assert: Content view version exist only in DEV, QE and not in Library
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         org = entities.Organization().create()
         lce_dev = entities.LifecycleEnvironment(organization=org).create()
@@ -443,21 +442,21 @@ class ContentViewVersionDeleteTestCase(APITestCase):
     def test_positive_remove_prod_promoted_cv_version_from_default_env(self):
         """Remove PROD promoted content view version from Library environment
 
-        @id: 24911876-7c2a-4a12-a3aa-98051dfda29d
+        :id: 24911876-7c2a-4a12-a3aa-98051dfda29d
 
-        @Steps:
+        :Steps:
 
-        1. Create a content view
-        2. Add yum repositories, puppet modules, docker repositories to CV
-        3. Publish content view
-        4. Promote the content view version to multiple environments
-           Library -> DEV -> QE -> PROD
-        5. remove the content view version from Library environment
+            1. Create a content view
+            2. Add yum repositories, puppet modules, docker repositories to CV
+            3. Publish content view
+            4. Promote the content view version to multiple environments
+                Library -> DEV -> QE -> PROD
+            5. remove the content view version from Library environment
 
-        @Assert: Content view version exist only in DEV, QE, PROD
-        and not in Library
+        :Assert: Content view version exist only in DEV, QE, PROD and not in
+            Library
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         org = entities.Organization().create()
         lce_dev = entities.LifecycleEnvironment(organization=org).create()
@@ -531,23 +530,23 @@ class ContentViewVersionDeleteTestCase(APITestCase):
     def test_positive_remove_cv_version_from_env(self):
         """Remove promoted content view version from environment
 
-        @id: 17cf18bf-09d5-4641-b0e0-c50e628fa6c8
+        :id: 17cf18bf-09d5-4641-b0e0-c50e628fa6c8
 
-        @Steps:
+        :Steps:
 
-        1. Create a content view
-        2. Add a yum repo and a puppet module to the content view
-        3. Publish the content view
-        4. Promote the content view version to multiple environments
-           Library -> DEV -> QE -> STAGE -> PROD
-        5. remove the content view version from PROD environment
-        6. Assert: content view version exists only in Library, DEV, QE, STAGE
-           and not in PROD
-        7. Promote again from STAGE -> PROD
+            1. Create a content view
+            2. Add a yum repo and a puppet module to the content view
+            3. Publish the content view
+            4. Promote the content view version to multiple environments
+               Library -> DEV -> QE -> STAGE -> PROD
+            5. remove the content view version from PROD environment
+            6. Assert: content view version exists only in Library, DEV, QE,
+               STAGE and not in PROD
+            7. Promote again from STAGE -> PROD
 
-        @Assert: Content view version exist in Library, DEV, QE, STAGE, PROD
+        :Assert: Content view version exist in Library, DEV, QE, STAGE, PROD
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         org = entities.Organization().create()
         lce_dev = entities.LifecycleEnvironment(organization=org).create()
@@ -625,20 +624,20 @@ class ContentViewVersionDeleteTestCase(APITestCase):
     def test_positive_remove_cv_version_from_multi_env(self):
         """Remove promoted content view version from multiple environment
 
-        @id: 18b86a68-8e6a-43ea-b95e-188fba125a26
+        :id: 18b86a68-8e6a-43ea-b95e-188fba125a26
 
-        @Steps:
+        :Steps:
 
-        1. Create a content view
-        2. Add a yum repo and a puppet module to the content view
-        3. Publish the content view
-        4. Promote the content view version to multiple environments
-           Library -> DEV -> QE -> STAGE -> PROD
-        5. Remove content view version from QE, STAGE and PROD
+            1. Create a content view
+            2. Add a yum repo and a puppet module to the content view
+            3. Publish the content view
+            4. Promote the content view version to multiple environments
+               Library -> DEV -> QE -> STAGE -> PROD
+            5. Remove content view version from QE, STAGE and PROD
 
-        @Assert: Content view version exists only in Library, DEV
+        :Assert: Content view version exists only in Library, DEV
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         org = entities.Organization().create()
         lce_dev = entities.LifecycleEnvironment(organization=org).create()
@@ -712,21 +711,21 @@ class ContentViewVersionDeleteTestCase(APITestCase):
         """Delete published content view with version promoted to multiple
          environments
 
-        @id: c164bd97-e710-4a5a-9c9f-657e6bed804b
+        :id: c164bd97-e710-4a5a-9c9f-657e6bed804b
 
-        @Steps:
+        :Steps:
 
-        1. Create a content view
-        2. Add a yum repo and a puppet module to the content view
-        3. Publish the content view
-        4. Promote the content view to multiple environment
-           Library -> DEV -> QE -> STAGE -> PROD
-        5. Delete the content view, this should delete the content with all
-           it's published/promoted versions from all environments
+            1. Create a content view
+            2. Add a yum repo and a puppet module to the content view
+            3. Publish the content view
+            4. Promote the content view to multiple environment
+               Library -> DEV -> QE -> STAGE -> PROD
+            5. Delete the content view, this should delete the content with all
+               it's published/promoted versions from all environments
 
-        @Assert: The content view doesn't exists
+        :Assert: The content view doesn't exists
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         org = entities.Organization().create()
         lce_dev = entities.LifecycleEnvironment(organization=org).create()
@@ -800,35 +799,35 @@ class ContentViewVersionDeleteTestCase(APITestCase):
         """Remove promoted content view version from environment that is used
         in association of an Activation key and content-host registration.
 
-        @id: a5b9ba8b-80e6-4435-bc0a-041b3fda227c
+        :id: a5b9ba8b-80e6-4435-bc0a-041b3fda227c
 
-        @Steps:
+        :Steps:
 
-        1. Create a content view cv1
-        2. Add a yum repo and a puppet module to the content view
-        3. Publish the content view
-        4. Promote the content view to multiple environment
-           Library -> DEV -> QE
-        5. Create an Activation key with the QE environment
-        6. Register a content-host using the Activation key
-        7. Remove the content view cv1 version from QE environment.
-           Note - prior removing replace the current QE environment of cv1 by
-           DEV and content view cv1 for Content-host and for Activation key.
-        8. Refresh content-host subscription
+            1. Create a content view cv1
+            2. Add a yum repo and a puppet module to the content view
+            3. Publish the content view
+            4. Promote the content view to multiple environment Library -> DEV
+               -> QE
+            5. Create an Activation key with the QE environment
+            6. Register a content-host using the Activation key
+            7. Remove the content view cv1 version from QE environment.  Note -
+               prior removing replace the current QE environment of cv1 by DEV
+               and content view cv1 for Content-host and for Activation key.
+            8. Refresh content-host subscription
 
-        @Assert:
+        :Assert:
 
-        1. Activation key exists
-        2. Content-host exists
-        3. QE environment of cv1 was replaced by DEV environment of cv1
-           in activation key
-        4. QE environment of cv1 was replaced by DEV environment of cv1
-           in content-host
-        5. At content-host some package from cv1 is installable
+            1. Activation key exists
+            2. Content-host exists
+            3. QE environment of cv1 was replaced by DEV environment of cv1 in
+               activation key
+            4. QE environment of cv1 was replaced by DEV environment of cv1 in
+               content-host
+            5. At content-host some package from cv1 is installable
 
-        @caseautomation: notautomated
+        :caseautomation: notautomated
 
-        @CaseLevel: System
+        :CaseLevel: System
         """
 
     @stubbed()
@@ -839,36 +838,37 @@ class ContentViewVersionDeleteTestCase(APITestCase):
          environments, with one of the environments used in association of an
          Activation key and content-host registration.
 
-        @id: 10699af9-617e-4930-9c80-2827a0ba52eb
+        :id: 10699af9-617e-4930-9c80-2827a0ba52eb
 
-        @Steps:
+        :Steps:
 
-        1. Create two content view cv1 and cv2
-        2. Add a yum repo and a puppet module to both content views
-        3. Publish the content views
-        4. Promote the content views to multiple environment
-           Library -> DEV -> QE
-        5. Create an Activation key with the QE environment and cv1
-        6. Register a content-host using the Activation key
-        7. Delete the content view cv1.
-           Note - prior deleting replace the current QE environment of cv1 by
-           DEV and content view cv2 for Content-host and for Activation key.
-        8. Refresh content-host subscription
+            1. Create two content view cv1 and cv2
+            2. Add a yum repo and a puppet module to both content views
+            3. Publish the content views
+            4. Promote the content views to multiple environment Library -> DEV
+               -> QE
+            5. Create an Activation key with the QE environment and cv1
+            6. Register a content-host using the Activation key
+            7. Delete the content view cv1.
+               Note - prior deleting replace the current QE environment of cv1
+               by DEV and content view cv2 for Content-host and for Activation
+               key.
+            8. Refresh content-host subscription
 
-        @Assert:
+        :Assert:
 
-        1. The content view cv1 doesn't exist
-        2. Activation key exists
-        3. Content-host exists
-        4. QE environment of cv1 was replaced by DEV environment of cv2
-           in activation key
-        5. QE environment of cv1 was replaced by DEV environment of cv2
-           in content-host
-        6. At content-host some package from cv2 is installable
+            1. The content view cv1 doesn't exist
+            2. Activation key exists
+            3. Content-host exists
+            4. QE environment of cv1 was replaced by DEV environment of cv2 in
+               activation key
+            5. QE environment of cv1 was replaced by DEV environment of cv2 in
+               content-host
+            6. At content-host some package from cv2 is installable
 
-        @caseautomation: notautomated
+        :caseautomation: notautomated
 
-        @CaseLevel: System
+        :CaseLevel: System
         """
 
     @stubbed()
@@ -878,33 +878,34 @@ class ContentViewVersionDeleteTestCase(APITestCase):
         """Remove promoted content view version from multiple environment,
         with satellite setup to use capsule
 
-        @id: 1e8a8e64-eec8-49e0-b121-919c53f416d2
+        :id: 1e8a8e64-eec8-49e0-b121-919c53f416d2
 
-        @Steps:
+        :Steps:
 
-        1. Create a content view
-        2. Setup satellite to use a capsule and to sync all lifecycle
-           environments
-        3. Add a yum repo, puppet module and a docker repo to the content view
-        4. Publish the content view
-        5. Promote the content view to multiple environment
-           Library -> DEV -> QE -> PROD
-        6. Make sure the capsule is updated (content synchronization may be
-           applied)
-        7. Disconnect the capsule
-        8. Remove the content view version from Library and DEV environments
-           and assert successful completion
-        9. Bring the capsule back online and assert that the task is completed
-           in capsule
-        10. Make sure the capsule is updated (content synchronization may be
-            applied)
+            1. Create a content view
+            2. Setup satellite to use a capsule and to sync all lifecycle
+               environments
+            3. Add a yum repo, puppet module and a docker repo to the content
+               view
+            4. Publish the content view
+            5. Promote the content view to multiple environment Library -> DEV
+               -> QE -> PROD
+            6. Make sure the capsule is updated (content synchronization may be
+               applied)
+            7. Disconnect the capsule
+            8. Remove the content view version from Library and DEV
+               environments and assert successful completion
+            9. Bring the capsule back online and assert that the task is
+               completed in capsule
+            10. Make sure the capsule is updated (content synchronization may
+                be applied)
 
-        @Assert: content view version in capsule is removed from Library
-        and DEV and exists only in QE and PROD
+        :Assert: content view version in capsule is removed from Library and
+            DEV and exists only in QE and PROD
 
-        @caseautomation: notautomated
+        :caseautomation: notautomated
 
-        @CaseLevel: System
+        :CaseLevel: System
         """
         # Note: This test case requires complete external capsule
         #  configuration.
@@ -917,12 +918,12 @@ class ContentViewVersionIncrementalTestCase(APITestCase):
     def test_positive_incremental_update_puppet(self):
         """Incrementally update a CVV with a puppet module.
 
-        @id: 19b2fe3b-6c91-4713-9910-17517fba661f
+        :id: 19b2fe3b-6c91-4713-9910-17517fba661f
 
-        @Assert: The incremental update succeeds with no errors, and the
-        content view is given an additional version.
+        :Assert: The incremental update succeeds with no errors, and the
+            content view is given an additional version.
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         # Create a content view and add a yum repository to it. Publish the CV.
         product = entities.Product().create()

--- a/tests/foreman/api/test_discoveredhost.py
+++ b/tests/foreman/api/test_discoveredhost.py
@@ -1,19 +1,19 @@
 # -*- encoding: utf-8 -*-
 """API Tests for foreman discovery feature
 
-@Requirement: Discoveredhost
+:Requirement: Discoveredhost
 
-@CaseAutomation: Automated
+:CaseAutomation: Automated
 
-@CaseLevel: Acceptance
+:CaseLevel: Acceptance
 
-@CaseComponent: API
+:CaseComponent: API
 
-@TestType: Functional
+:TestType: Functional
 
-@CaseImportance: High
+:CaseImportance: High
 
-@Upstream: No
+:Upstream: No
 """
 from fauxfactory import gen_string, gen_ipaddr, gen_mac
 from nailgun import entities
@@ -68,20 +68,18 @@ class DiscoveryTestCase(APITestCase):
     def test_positive_list_all(self):
         """List all discovered hosts
 
-        @id: ac3b49d6-87a2-4d36-8085-72113b14ffb5
+        :id: ac3b49d6-87a2-4d36-8085-72113b14ffb5
 
-        @Setup: Provisioning should be configured and a host should be
-        discovered
+        :Setup: Provisioning should be configured and a host should be
+            discovered
 
-        @Steps:
+        :Steps: GET /api/v2/discovered_hosts
 
-        1. GET /api/v2/discovered_hosts
+        :Assert: List of all discovered hosts are retrieved
 
-        @Assert: List of all discovered hosts are retrieved
+        :caseautomation: notautomated
 
-        @caseautomation: notautomated
-
-        @CaseLevel: System
+        :CaseLevel: System
         """
 
     @stubbed()
@@ -89,20 +87,18 @@ class DiscoveryTestCase(APITestCase):
     def test_positive_show(self):
         """Show a specific discovered hosts
 
-        @id: f607838d-bbbb-40d6-b58e-e8eea6ef3d1d
+        :id: f607838d-bbbb-40d6-b58e-e8eea6ef3d1d
 
-        @Setup: Provisioning should be configured and a host should be
-        discovered
+        :Setup: Provisioning should be configured and a host should be
+            discovered
 
-        @Steps:
+        :Steps: GET /api/v2/discovered_hosts/:id
 
-        1. GET /api/v2/discovered_hosts/:id
+        :Assert: Selected host is retrieved
 
-        @Assert: Selected host is retrieved
+        :caseautomation: notautomated
 
-        @caseautomation: notautomated
-
-        @CaseLevel: System
+        :CaseLevel: System
         """
 
     @stubbed()
@@ -110,20 +106,18 @@ class DiscoveryTestCase(APITestCase):
     def test_positive_create(self):
         """Create a discovered hosts
 
-        @id: b8f68ff0-6fda-46a0-aaea-ca2e714e3bec
+        :id: b8f68ff0-6fda-46a0-aaea-ca2e714e3bec
 
-        @Setup: Provisioning should be configured and a host should be
-        discovered
+        :Setup: Provisioning should be configured and a host should be
+            discovered
 
-        @Steps:
+        :Steps: POST /api/v2/discovered_hosts
 
-        1. POST /api/v2/discovered_hosts
+        :Assert: Host should be created successfully
 
-        @Assert: Host should be created successfully
+        :caseautomation: notautomated
 
-        @caseautomation: notautomated
-
-        @CaseLevel: System
+        :CaseLevel: System
         """
 
     @run_only_on('sat')
@@ -132,15 +126,13 @@ class DiscoveryTestCase(APITestCase):
     def test_positive_upload_facts(self):
         """Upload fake facts to create a discovered host
 
-        @id: c1f40204-bbb0-46d0-9b60-e42f00ad1649
+        :id: c1f40204-bbb0-46d0-9b60-e42f00ad1649
 
-        @Steps:
+        :Steps: POST /api/v2/discovered_hosts/facts
 
-        1. POST /api/v2/discovered_hosts/facts
+        :Assert: Host should be created successfully
 
-        @Assert: Host should be created successfully
-
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         for name in valid_data_list():
             with self.subTest(name):
@@ -157,20 +149,18 @@ class DiscoveryTestCase(APITestCase):
     def test_positive_provision_pxe_less_host(self):
         """Provision a pxe-less discovered hosts
 
-        @id: 91bb254b-3c30-4608-b1ba-e18bcc22efb5
+        :id: 91bb254b-3c30-4608-b1ba-e18bcc22efb5
 
-        @Setup: Provisioning should be configured and a host should be
-        discovered
+        :Setup: Provisioning should be configured and a host should be
+            discovered
 
-        @Steps:
+        :Steps: PUT /api/v2/discovered_hosts/:id
 
-        1. PUT /api/v2/discovered_hosts/:id
+        :Assert: Host should be provisioned successfully
 
-        @Assert: Host should be provisioned successfully
+        :caseautomation: notautomated
 
-        @caseautomation: notautomated
-
-        @CaseLevel: System
+        :CaseLevel: System
         """
 
     @stubbed()
@@ -178,19 +168,18 @@ class DiscoveryTestCase(APITestCase):
     def test_positive_provision_pxe_host(self):
         """Provision a pxe-based discovered hosts
 
-        @id: e805b9c5-e8f6-4129-a0e6-ab54e5671ddb
+        :id: e805b9c5-e8f6-4129-a0e6-ab54e5671ddb
 
-        @Setup: Provisioning should be configured and a host should be
-        discovered
+        :Setup: Provisioning should be configured and a host should be
+            discovered
 
-        @Steps:
-        1. PUT /api/v2/discovered_hosts/:id
+        :Steps: PUT /api/v2/discovered_hosts/:id
 
-        @Assert: Host should be provisioned successfully
+        :Assert: Host should be provisioned successfully
 
-        @caseautomation: notautomated
+        :caseautomation: notautomated
 
-        @CaseLevel: System
+        :CaseLevel: System
         """
 
     @stubbed()
@@ -198,20 +187,18 @@ class DiscoveryTestCase(APITestCase):
     def test_positive_delete_pxe_less_host(self):
         """Delete a pxe-less discovered hosts
 
-        @id: e8604ee4-04e9-4bb5-9487-18ab37ea271d
+        :id: e8604ee4-04e9-4bb5-9487-18ab37ea271d
 
-        @Setup: Provisioning should be configured and a host should be
-        discovered
+        :Setup: Provisioning should be configured and a host should be
+            discovered
 
-        @Steps:
+        :Steps: DELETE /api/v2/discovered_hosts/:id
 
-        1. DELETE /api/v2/discovered_hosts/:id
+        :Assert: Discovered Host should be deleted successfully
 
-        @Assert: Discovered Host should be deleted successfully
+        :caseautomation: notautomated
 
-        @caseautomation: notautomated
-
-        @CaseLevel: System
+        :CaseLevel: System
         """
 
     @stubbed()
@@ -219,19 +206,18 @@ class DiscoveryTestCase(APITestCase):
     def test_positive_delete_pxe_host(self):
         """Delete a pxe-based discovered hosts
 
-        @id: 2ab2ad88-4470-4d4c-8e0b-5892ad8d675e
+        :id: 2ab2ad88-4470-4d4c-8e0b-5892ad8d675e
 
-        @Setup: Provisioning should be configured and a host should be
-        discovered
+        :Setup: Provisioning should be configured and a host should be
+            discovered
 
-        @Steps:
-        1. DELETE /api/v2/discovered_hosts/:id
+        :Steps: DELETE /api/v2/discovered_hosts/:id
 
-        @Assert: Discovered Host should be deleted successfully
+        :Assert: Discovered Host should be deleted successfully
 
-        @caseautomation: notautomated
+        :caseautomation: notautomated
 
-        @CaseLevel: System
+        :CaseLevel: System
         """
 
     @stubbed()
@@ -239,20 +225,18 @@ class DiscoveryTestCase(APITestCase):
     def test_positive_auto_provision_pxe_less_host(self):
         """Auto provision a pxe-less host by executing discovery rules
 
-        @id: 80a4be02-517a-4d41-bacc-a3f9dce47bdf
+        :id: 80a4be02-517a-4d41-bacc-a3f9dce47bdf
 
-        @Setup: Provisioning should be configured and a host should be
-        discovered
+        :Setup: Provisioning should be configured and a host should be
+            discovered
 
-        @Steps:
+        :Steps: POST /api/v2/discovered_hosts/:id/auto_provision
 
-        1. POST /api/v2/discovered_hosts/:id/auto_provision
+        :Assert: Selected Host should be auto-provisioned successfully
 
-        @Assert: Selected Host should be auto-provisioned successfully
+        :caseautomation: notautomated
 
-        @caseautomation: notautomated
-
-        @CaseLevel: System
+        :CaseLevel: System
         """
 
     @stubbed()
@@ -260,19 +244,18 @@ class DiscoveryTestCase(APITestCase):
     def test_positive_auto_provision_pxe_host(self):
         """Auto provision a pxe-based host by executing discovery rules
 
-        @id: c93fd7c9-41ef-4eb5-8042-f72e87e67e10
+        :id: c93fd7c9-41ef-4eb5-8042-f72e87e67e10
 
-        @Setup: Provisioning should be configured and a host should be
-        discovered
+        :Setup: Provisioning should be configured and a host should be
+            discovered
 
-        @Steps:
-        1. POST /api/v2/discovered_hosts/:id/auto_provision
+        :Steps: POST /api/v2/discovered_hosts/:id/auto_provision
 
-        @Assert: Selected Host should be auto-provisioned successfully
+        :Assert: Selected Host should be auto-provisioned successfully
 
-        @caseautomation: notautomated
+        :caseautomation: notautomated
 
-        @CaseLevel: System
+        :CaseLevel: System
         """
 
     @stubbed()
@@ -280,20 +263,18 @@ class DiscoveryTestCase(APITestCase):
     def test_positive_auto_provision_all(self):
         """Auto provision all host by executing discovery rules
 
-        @id: 954d3688-62d9-47f7-9106-a4fff8825ffa
+        :id: 954d3688-62d9-47f7-9106-a4fff8825ffa
 
-        @Setup: Provisioning should be configured and more than one host should
-        be discovered
+        :Setup: Provisioning should be configured and more than one host should
+            be discovered
 
-        @Steps:
+        :Steps: POST /api/v2/discovered_hosts/auto_provision_all
 
-        1. POST /api/v2/discovered_hosts/auto_provision_all
+        :Assert: All discovered hosts should be auto-provisioned successfully
 
-        @Assert: All discovered hosts should be auto-provisioned successfully
+        :caseautomation: notautomated
 
-        @caseautomation: notautomated
-
-        @CaseLevel: System
+        :CaseLevel: System
         """
 
     @stubbed()
@@ -301,24 +282,21 @@ class DiscoveryTestCase(APITestCase):
     def test_positive_refresh_facts_pxe_less_host(self):
         """Refreshing the facts of pxe-less discovered host by adding a new NIC.
 
-        @id: c6ef642e-5eb1-4297-bad1-48f88a1660c6
+        :id: c6ef642e-5eb1-4297-bad1-48f88a1660c6
 
-        @Setup:
+        :Setup:
 
-        1. Provisioning should be configured and more than one host should
-        be discovered via discovery ISO
+            1. Provisioning should be configured and more than one host should
+               be discovered via discovery ISO
+            2. Add a NIC on discovered host
 
-        2. Add a NIC on discovered host
+        :Steps: PUT /api/v2/discovered_hosts/:id/refresh_facts
 
-        @Steps:
+        :Assert: Added Fact should be displayed on refreshing the facts
 
-        1. PUT /api/v2/discovered_hosts/:id/refresh_facts
+        :caseautomation: notautomated
 
-        @Assert: Added Fact should be displayed on refreshing the facts
-
-        @caseautomation: notautomated
-
-        @CaseLevel: System
+        :CaseLevel: System
         """
 
     @stubbed()
@@ -326,22 +304,20 @@ class DiscoveryTestCase(APITestCase):
     def test_positive_refresh_facts_pxe_host(self):
         """Refresh the facts of pxe based discovered hosts by adding a new NIC
 
-        @id: 413fb608-cd5c-441d-af86-fd2d40346d96
+        :id: 413fb608-cd5c-441d-af86-fd2d40346d96
 
-        @Setup:
-        1. Provisioning should be configured and more than one host should
-        be discovered
+        :Setup:
+            1. Provisioning should be configured and more than one host should
+            be discovered
+            2. Add a NIC on discovered host
 
-        2. Add a NIC on discovered host
+        :Steps: PUT /api/v2/discovered_hosts/:id/refresh_facts
 
-        @Steps:
-        1. PUT /api/v2/discovered_hosts/:id/refresh_facts
+        :Assert: Added Fact should be displayed on refreshing the facts
 
-        @Assert: Added Fact should be displayed on refreshing the facts
+        :caseautomation: notautomated
 
-        @caseautomation: notautomated
-
-        @CaseLevel: System
+        :CaseLevel: System
         """
 
     @stubbed()
@@ -349,20 +325,18 @@ class DiscoveryTestCase(APITestCase):
     def test_positive_reboot_pxe_host(self):
         """Rebooting a pxe based discovered host
 
-        @id: 69c807f8-5646-4aa6-8b3c-5ecab69560fc
+        :id: 69c807f8-5646-4aa6-8b3c-5ecab69560fc
 
-        @Setup: Provisioning should be configured and more than one host should
-        be discovered via PXE boot.
+        :Setup: Provisioning should be configured and more than one host should
+            be discovered via PXE boot.
 
-        @Steps:
+        :Steps: PUT /api/v2/discovered_hosts/:id/reboot
 
-        1. PUT /api/v2/discovered_hosts/:id/reboot
+        :Assert: Selected host should be rebooted successfully
 
-        @Assert: Selected host should be rebooted successfully
+        :caseautomation: notautomated
 
-        @caseautomation: notautomated
-
-        @CaseLevel: System
+        :CaseLevel: System
         """
 
     @stubbed()
@@ -370,19 +344,18 @@ class DiscoveryTestCase(APITestCase):
     def test_positive_reboot_pxe_less_host(self):
         """Rebooting a pxe-less discovered host
 
-        @id: 2e7bdf3c-fb5d-44da-981d-d4ba9ffaba60
+        :id: 2e7bdf3c-fb5d-44da-981d-d4ba9ffaba60
 
-        @Setup: Provisioning should be configured and more than one host should
-        be discovered using discovery ISO.
+        :Setup: Provisioning should be configured and more than one host should
+            be discovered using discovery ISO.
 
-        @Steps:
-        1. PUT /api/v2/discovered_hosts/:id/reboot
+        :Steps: PUT /api/v2/discovered_hosts/:id/reboot
 
-        @Assert: Selected host should be rebooted successfully
+        :Assert: Selected host should be rebooted successfully
 
-        @caseautomation: notautomated
+        :caseautomation: notautomated
 
-        @CaseLevel: System
+        :CaseLevel: System
         """
 
     @stubbed()
@@ -392,15 +365,15 @@ class DiscoveryTestCase(APITestCase):
 
         Set query as (e.g IP=IP_of_discovered_host)
 
-        @id: a5531225-0b5f-4999-925f-4f40f77e20f8
+        :id: a5531225-0b5f-4999-925f-4f40f77e20f8
 
-        @Setup: Host should already be discovered
+        :Setup: Host should already be discovered
 
-        @Assert: Host should reboot and provision
+        :Assert: Host should reboot and provision
 
-        @caseautomation: notautomated
+        :caseautomation: notautomated
 
-        @CaseLevel: System
+        :CaseLevel: System
         """
 
     @stubbed()
@@ -410,15 +383,15 @@ class DiscoveryTestCase(APITestCase):
         that applies to multi hosts.
         Set query as cpu_count = 1 OR mem > 500
 
-        @id: 19ce9ac0-e915-41b3-8c2d-2b17e5fbe42a
+        :id: 19ce9ac0-e915-41b3-8c2d-2b17e5fbe42a
 
-        @Setup: Multiple hosts should already be discovered in same subnet
+        :Setup: Multiple hosts should already be discovered in same subnet
 
-        @Assert: All Hosts of same subnet should reboot and provision
+        :Assert: All Hosts of same subnet should reboot and provision
 
-        @caseautomation: notautomated
+        :caseautomation: notautomated
 
-        @CaseLevel: System
+        :CaseLevel: System
         """
 
     @stubbed()
@@ -427,16 +400,16 @@ class DiscoveryTestCase(APITestCase):
         """Create multiple discovery rules with different priority and check
         rule with highest priority executed first
 
-        @id: b91c4979-f8ce-4f6e-9474-9ccd4c3bc793
+        :id: b91c4979-f8ce-4f6e-9474-9ccd4c3bc793
 
-        @Setup: Multiple hosts should already be discovered
+        :Setup: Multiple hosts should already be discovered
 
-        @Assert: Host with lower count have higher priority
-        and that rule should be executed first
+        :Assert: Host with lower count have higher priority and that rule
+            should be executed first
 
-        @caseautomation: notautomated
+        :caseautomation: notautomated
 
-        @CaseLevel: System
+        :CaseLevel: System
         """
 
     @stubbed()
@@ -445,16 +418,16 @@ class DiscoveryTestCase(APITestCase):
         """Create a discovery rule (CPU_COUNT = 2) with host limit 1 and
         provision more than one host with same rule
 
-        @id: 553c8ebf-d1c1-4ac2-9948-d3664a5b450b
+        :id: 553c8ebf-d1c1-4ac2-9948-d3664a5b450b
 
-        @Setup: Host with two CPUs should already be discovered
+        :Setup: Host with two CPUs should already be discovered
 
-        @Assert: Rule should only be applied to one discovered host and for
-        other rule should already be skipped.
+        :Assert: Rule should only be applied to one discovered host and for
+            other rule should already be skipped.
 
-        @caseautomation: notautomated
+        :caseautomation: notautomated
 
-        @CaseLevel: System
+        :CaseLevel: System
         """
 
     @stubbed()
@@ -462,16 +435,16 @@ class DiscoveryTestCase(APITestCase):
     def test_positive_provision_with_updated_discovery_rule(self):
         """Update an existing rule and provision a host with it.
 
-        @id: 3fb20e0f-02e9-4158-9744-f583308c4e89
+        :id: 3fb20e0f-02e9-4158-9744-f583308c4e89
 
-        @Setup: Host should already be discovered
+        :Setup: Host should already be discovered
 
-        @Assert: User should be able to update the rule and it should be
-        applied on discovered host
+        :Assert: User should be able to update the rule and it should be
+            applied on discovered host
 
-        @caseautomation: notautomated
+        :caseautomation: notautomated
 
-        @CaseLevel: System
+        :CaseLevel: System
         """
 
     @stubbed()
@@ -480,15 +453,15 @@ class DiscoveryTestCase(APITestCase):
         """Update the discovered hostname in existing rule and provision a host
         with it
 
-        @id: aaa1d6ac-0f52-4b1f-9bfe-853169985621
+        :id: aaa1d6ac-0f52-4b1f-9bfe-853169985621
 
-        @Setup: Host should already be discovered
+        :Setup: Host should already be discovered
 
-        @Assert: The host name should be updated and host should be provisioned
+        :Assert: The host name should be updated and host should be provisioned
 
-        @caseautomation: notautomated
+        :caseautomation: notautomated
 
-        @CaseLevel: System
+        :CaseLevel: System
         """
 
     @stubbed()
@@ -496,13 +469,13 @@ class DiscoveryTestCase(APITestCase):
     def test_positive_list_facts(self):
         """List facts of a discovered host
 
-        @id: 7c40da85-f06a-4e86-80a8-d18d1b2abd32
+        :id: 7c40da85-f06a-4e86-80a8-d18d1b2abd32
 
-        @Setup: Host should already be discovered
+        :Setup: Host should already be discovered
 
-        @Assert: facts of selected discovered host should be listed
+        :Assert: facts of selected discovered host should be listed
 
-        @caseautomation: notautomated
+        :caseautomation: notautomated
 
-        @CaseLevel: System
+        :CaseLevel: System
         """

--- a/tests/foreman/api/test_discoveryrule.py
+++ b/tests/foreman/api/test_discoveryrule.py
@@ -1,19 +1,19 @@
 # -*- encoding: utf-8 -*-
 """API Tests for foreman discovery feature
 
-@Requirement: Discoveryrule
+:Requirement: Discoveryrule
 
-@CaseAutomation: Automated
+:CaseAutomation: Automated
 
-@CaseLevel: Acceptance
+:CaseLevel: Acceptance
 
-@CaseComponent: API
+:CaseComponent: API
 
-@TestType: Functional
+:TestType: Functional
 
-@CaseImportance: High
+:CaseImportance: High
 
-@Upstream: No
+:Upstream: No
 """
 from fauxfactory import gen_choice, gen_integer, gen_string
 from nailgun import entities
@@ -63,9 +63,9 @@ class DiscoveryRuleTestCase(APITestCase):
 
         Set query as (e.g CPU_Count = 1)
 
-        @id: b8ae7a80-b9a8-4924-808c-482a2b4102c4
+        :id: b8ae7a80-b9a8-4924-808c-482a2b4102c4
 
-        @Assert: Rule should be created with given name and query
+        :Assert: Rule should be created with given name and query
         """
         for name in valid_data_list():
             with self.subTest(name):
@@ -82,9 +82,9 @@ class DiscoveryRuleTestCase(APITestCase):
     def test_positive_create_with_org_loc(self):
         """Create discovery rule by associating org and location
 
-        @id: 121e0a30-8a24-47d7-974d-998886ed1ea7
+        :id: 121e0a30-8a24-47d7-974d-998886ed1ea7
 
-        @Assert: Rule was created and with given org & location.
+        :Assert: Rule was created and with given org & location.
         """
         org = entities.Organization().create()
         loc = entities.Location().create()
@@ -103,9 +103,9 @@ class DiscoveryRuleTestCase(APITestCase):
     def test_positive_delete(self):
         """Delete a discovery rule
 
-        @id: 9fdba953-dcc7-4532-9204-17a45b0d9e05
+        :id: 9fdba953-dcc7-4532-9204-17a45b0d9e05
 
-        @Assert: Rule should be deleted successfully
+        :Assert: Rule should be deleted successfully
         """
         for name in valid_data_list():
             with self.subTest(name):
@@ -119,9 +119,9 @@ class DiscoveryRuleTestCase(APITestCase):
     def test_negative_create_with_too_long_name(self):
         """Create a discovery rule with more than 255 char in name
 
-        @id: 415379b7-0134-40b9-adb1-2fe0adb1ac36
+        :id: 415379b7-0134-40b9-adb1-2fe0adb1ac36
 
-        @Assert: Validation error should be raised
+        :Assert: Validation error should be raised
         """
         for name in (
                 gen_string(str_type, 256)
@@ -135,9 +135,9 @@ class DiscoveryRuleTestCase(APITestCase):
     def test_negative_create_with_invalid_host_limit(self):
         """Create a discovery rule with invalid host limit
 
-        @id: 84503d8d-86f6-49bf-ab97-eff418d3e3d0
+        :id: 84503d8d-86f6-49bf-ab97-eff418d3e3d0
 
-        @Assert: Validation error should be raised
+        :Assert: Validation error should be raised
         """
         self.discovery_rule.max_count = gen_string('alpha')
         with self.assertRaises(HTTPError):
@@ -147,9 +147,9 @@ class DiscoveryRuleTestCase(APITestCase):
     def test_negative_create_with_invalid_priority(self):
         """Create a discovery rule with invalid priority
 
-        @id: 4ec7d76a-22ba-4c3e-952c-667a6f0a5728
+        :id: 4ec7d76a-22ba-4c3e-952c-667a6f0a5728
 
-        @Assert: Validation error should be raised
+        :Assert: Validation error should be raised
         """
         self.discovery_rule.priority = gen_string('alpha')
         with self.assertRaises(HTTPError):
@@ -160,9 +160,9 @@ class DiscoveryRuleTestCase(APITestCase):
     def test_positive_update_name(self):
         """Update an existing discovery rule name
 
-        @id: 769c0739-538b-4451-af7b-deb2ecd3dc0d
+        :id: 769c0739-538b-4451-af7b-deb2ecd3dc0d
 
-        @Assert: User should be able to update the rule
+        :Assert: User should be able to update the rule
         """
         discovery_rule = self.discovery_rule.create()
         for name in valid_data_list():
@@ -176,9 +176,9 @@ class DiscoveryRuleTestCase(APITestCase):
     def test_positive_update_org_loc(self):
         """Update org and location of selected discovery rule
 
-        @id: 0f8ec302-f9de-4713-87b7-0f1aca515149
+        :id: 0f8ec302-f9de-4713-87b7-0f1aca515149
 
-        @Assert: Rule was updated and with given org & location.
+        :Assert: Rule was updated and with given org & location.
         """
         org = entities.Organization().create()
         loc = entities.Location().create()
@@ -199,9 +199,9 @@ class DiscoveryRuleTestCase(APITestCase):
     def test_positive_update_search_rule(self):
         """Update an existing discovery search rule
 
-        @id: 2c5ecb7e-87bc-4980-9620-7ae00e3f360e
+        :id: 2c5ecb7e-87bc-4980-9620-7ae00e3f360e
 
-        @Assert: User should be able to update the rule
+        :Assert: User should be able to update the rule
         """
         discovery_rule = self.discovery_rule.create()
         discovery_rule.search_ = 'Location = Default_Location'
@@ -214,9 +214,9 @@ class DiscoveryRuleTestCase(APITestCase):
     def test_positive_update_host_limit(self):
         """Update an existing rule with valid host limit.
 
-        @id: 33084060-2866-46b9-bfab-23d91aea73d8
+        :id: 33084060-2866-46b9-bfab-23d91aea73d8
 
-        @Assert: User should be able to update the rule
+        :Assert: User should be able to update the rule
         """
         discovery_rule = self.discovery_rule.create()
         discovery_rule.max_count = gen_integer(1, 100)
@@ -229,9 +229,9 @@ class DiscoveryRuleTestCase(APITestCase):
     def test_positive_disable(self):
         """Disable an existing enabled discovery rule.
 
-        @id: 330aa943-167b-46dd-b434-1a6e5fe8f283
+        :id: 330aa943-167b-46dd-b434-1a6e5fe8f283
 
-        @Assert: User should be able to update the rule
+        :Assert: User should be able to update the rule
         """
         discovery_rule = self.discovery_rule.create()
         self.assertEqual(discovery_rule.enabled, True)
@@ -245,11 +245,11 @@ class DiscoveryRuleTestCase(APITestCase):
     def test_positive_update_rule_hostgroup(self):
         """Update host group of an existing rule.
 
-        @id: dcf15e83-c529-462a-b5da-fd45bb457fde
+        :id: dcf15e83-c529-462a-b5da-fd45bb457fde
 
-        @Assert: User should be able to update the rule
+        :Assert: User should be able to update the rule
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         discovery_rule = self.discovery_rule.create()
         discovery_rule.hostgroup = entities.HostGroup().create()

--- a/tests/foreman/api/test_docker.py
+++ b/tests/foreman/api/test_docker.py
@@ -1,19 +1,19 @@
 # -*- encoding: utf-8 -*-
 """Unit tests for the Docker feature.
 
-@Requirement: Docker
+:Requirement: Docker
 
-@CaseAutomation: Automated
+:CaseAutomation: Automated
 
-@CaseLevel: Acceptance
+:CaseLevel: Acceptance
 
-@CaseComponent: API
+:CaseComponent: API
 
-@TestType: Functional
+:TestType: Functional
 
-@CaseImportance: High
+:CaseImportance: High
 
-@Upstream: No
+:Upstream: No
 """
 from fauxfactory import gen_string, gen_url
 from nailgun import entities
@@ -152,9 +152,9 @@ class DockerRepositoryTestCase(APITestCase):
     def test_positive_create_with_name(self):
         """Create one Docker-type repository
 
-        @id: 3360aab2-74f3-4f6e-a083-46498ceacad2
+        :id: 3360aab2-74f3-4f6e-a083-46498ceacad2
 
-        @Assert: A repository is created with a Docker upstream repository.
+        :Assert: A repository is created with a Docker upstream repository.
         """
         for name in valid_data_list():
             with self.subTest(name):
@@ -172,9 +172,9 @@ class DockerRepositoryTestCase(APITestCase):
         """Create a Docker-type repository with a valid docker upstream
         name
 
-        @id: 742a2118-0ab2-4e63-b978-88fe9f52c034
+        :id: 742a2118-0ab2-4e63-b978-88fe9f52c034
 
-        @Assert: A repository is created with the specified upstream name.
+        :Assert: A repository is created with the specified upstream name.
         """
         for upstream_name in _valid_names():
             with self.subTest(upstream_name):
@@ -191,9 +191,9 @@ class DockerRepositoryTestCase(APITestCase):
         """Create a Docker-type repository with a invalid docker
         upstream name.
 
-        @id: 2c5abb4a-e50b-427a-81d2-57eaf8f57a0f
+        :id: 2c5abb4a-e50b-427a-81d2-57eaf8f57a0f
 
-        @Assert: A repository is not created and a proper error is raised.
+        :Assert: A repository is not created and a proper error is raised.
         """
         product = entities.Product(organization=self.org).create()
         for upstream_name in _invalid_names():
@@ -206,12 +206,12 @@ class DockerRepositoryTestCase(APITestCase):
     def test_positive_create_repos_using_same_product(self):
         """Create multiple Docker-type repositories
 
-        @id: 4a6929fc-5111-43ff-940c-07a754828630
+        :id: 4a6929fc-5111-43ff-940c-07a754828630
 
-        @Assert: Multiple docker repositories are created with a Docker
-        usptream repository and they all belong to the same product.
+        :Assert: Multiple docker repositories are created with a Docker
+            usptream repository and they all belong to the same product.
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         product = entities.Product(organization=self.org).create()
         for _ in range(randint(2, 5)):
@@ -224,12 +224,13 @@ class DockerRepositoryTestCase(APITestCase):
     def test_positive_create_repos_using_multiple_products(self):
         """Create multiple Docker-type repositories on multiple products
 
-        @id: 5a65d20b-d3b5-4bd7-9c8f-19c8af190558
+        :id: 5a65d20b-d3b5-4bd7-9c8f-19c8af190558
 
-        @Assert: Multiple docker repositories are created with a Docker
-        upstream repository and they all belong to their respective products.
+        :Assert: Multiple docker repositories are created with a Docker
+            upstream repository and they all belong to their respective
+            products.
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         for _ in range(randint(2, 5)):
             product = entities.Product(organization=self.org).create()
@@ -246,12 +247,12 @@ class DockerRepositoryTestCase(APITestCase):
     def test_positive_sync(self):
         """Create and sync a Docker-type repository
 
-        @id: 80fbcd84-1c6f-444f-a44e-7d2738a0cba2
+        :id: 80fbcd84-1c6f-444f-a44e-7d2738a0cba2
 
-        @Assert: A repository is created with a Docker repository
-        and it is synchronized.
+        :Assert: A repository is created with a Docker repository and it is
+            synchronized.
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         repo = _create_repository(
             entities.Product(organization=self.org).create()
@@ -265,10 +266,10 @@ class DockerRepositoryTestCase(APITestCase):
     def test_positive_update_name(self):
         """Create a Docker-type repository and update its name.
 
-        @id: 7967e6b5-c206-4ad0-bcf5-64a7ce85233b
+        :id: 7967e6b5-c206-4ad0-bcf5-64a7ce85233b
 
-        @Assert: A repository is created with a Docker upstream repository and
-        that its name can be updated.
+        :Assert: A repository is created with a Docker upstream repository and
+            that its name can be updated.
         """
         repo = _create_repository(
             entities.Product(organization=self.org).create())
@@ -285,10 +286,10 @@ class DockerRepositoryTestCase(APITestCase):
     def test_positive_update_upstream_name(self):
         """Create a Docker-type repository and update its upstream name.
 
-        @id: 4e2fb78d-0b6a-4455-8869-8eaf9d4a61b0
+        :id: 4e2fb78d-0b6a-4455-8869-8eaf9d4a61b0
 
-        @Assert: A repository is created with a Docker upstream repository and
-        that its upstream name can be updated.
+        :Assert: A repository is created with a Docker upstream repository and
+            that its upstream name can be updated.
         """
         new_upstream_name = u'fedora/ssh'
         repo = _create_repository(
@@ -305,12 +306,12 @@ class DockerRepositoryTestCase(APITestCase):
     def test_positive_update_url(self):
         """Create a Docker-type repository and update its URL.
 
-        @id: 6a588e65-bf1d-4ca9-82ce-591f9070215f
+        :id: 6a588e65-bf1d-4ca9-82ce-591f9070215f
 
-        @Assert: A repository is created with a Docker upstream repository and
-        that its URL can be updated.
+        :Assert: A repository is created with a Docker upstream repository and
+            that its URL can be updated.
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         new_url = gen_url()
         repo = _create_repository(
@@ -328,10 +329,10 @@ class DockerRepositoryTestCase(APITestCase):
     def test_positive_delete(self):
         """Create and delete a Docker-type repository
 
-        @id: 92df93cb-9de2-40fa-8451-b8c1ba8f45be
+        :id: 92df93cb-9de2-40fa-8451-b8c1ba8f45be
 
-        @Assert: A repository is created with a Docker upstream repository and
-        then deleted.
+        :Assert: A repository is created with a Docker upstream repository and
+            then deleted.
         """
         repo = _create_repository(
             entities.Product(organization=self.org).create())
@@ -346,12 +347,12 @@ class DockerRepositoryTestCase(APITestCase):
         """Create Docker-type repositories on multiple products and
         delete a random repository from a random product.
 
-        @id: cbc2792d-cf81-41f7-8889-001a27e4dd66
+        :id: cbc2792d-cf81-41f7-8889-001a27e4dd66
 
-        @Assert: Random repository can be deleted from random product without
-        altering the other products.
+        :Assert: Random repository can be deleted from random product without
+            altering the other products.
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         repos = []
         products = [
@@ -391,12 +392,12 @@ class DockerContentViewTestCase(APITestCase):
     def test_positive_add_docker_repo(self):
         """Add one Docker-type repository to a non-composite content view
 
-        @id: a065822f-bb41-4fc9-bf5c-65814ca11b2d
+        :id: a065822f-bb41-4fc9-bf5c-65814ca11b2d
 
-        @Assert: A repository is created with a Docker repository and the
-        product is added to a non-composite content view
+        :Assert: A repository is created with a Docker repository and the
+            product is added to a non-composite content view
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         repo = _create_repository(
             entities.Product(organization=self.org).create())
@@ -415,12 +416,12 @@ class DockerContentViewTestCase(APITestCase):
         """Add multiple Docker-type repositories to a
         non-composite content view.
 
-        @id: 08eed081-2003-4475-95ac-553a56b83997
+        :id: 08eed081-2003-4475-95ac-553a56b83997
 
-        @Assert: Repositories are created with Docker upstream repos and the
-        product is added to a non-composite content view.
+        :Assert: Repositories are created with Docker upstream repos and the
+            product is added to a non-composite content view.
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         product = entities.Product(organization=self.org).create()
         repos = [
@@ -457,12 +458,12 @@ class DockerContentViewTestCase(APITestCase):
     def test_positive_add_synced_docker_repo(self):
         """Create and sync a Docker-type repository
 
-        @id: 3c7d6f17-266e-43d3-99f8-13bf0251eca6
+        :id: 3c7d6f17-266e-43d3-99f8-13bf0251eca6
 
-        @Assert: A repository is created with a Docker repository
-        and it is synchronized.
+        :Assert: A repository is created with a Docker repository and it is
+            synchronized.
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         repo = _create_repository(
             entities.Product(organization=self.org).create())
@@ -484,13 +485,13 @@ class DockerContentViewTestCase(APITestCase):
     def test_positive_add_docker_repo_to_ccv(self):
         """Add one Docker-type repository to a composite content view
 
-        @id: fe278275-2bb2-4d68-8624-f0cfd63ecb57
+        :id: fe278275-2bb2-4d68-8624-f0cfd63ecb57
 
-        @Assert: A repository is created with a Docker repository and the
-        product is added to a content view which is then added to a composite
-        content view.
+        :Assert: A repository is created with a Docker repository and the
+            product is added to a content view which is then added to a
+            composite content view.
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         repo = _create_repository(
             entities.Product(organization=self.org).create())
@@ -527,13 +528,13 @@ class DockerContentViewTestCase(APITestCase):
         """Add multiple Docker-type repositories to a composite
         content view.
 
-        @id: 3824ccae-fb59-4f63-a1ab-a4f2419fcadd
+        :id: 3824ccae-fb59-4f63-a1ab-a4f2419fcadd
 
-        @Assert: One repository is created with a Docker upstream repository
-        and the product is added to a random number of content views which are
-        then added to a composite content view.
+        :Assert: One repository is created with a Docker upstream repository
+            and the product is added to a random number of content views which
+            are then added to a composite content view.
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         cv_versions = []
         product = entities.Product(organization=self.org).create()
@@ -574,13 +575,13 @@ class DockerContentViewTestCase(APITestCase):
     def test_positive_publish_with_docker_repo(self):
         """Add Docker-type repository to content view and publish it once.
 
-        @id: 86a73e96-ead6-41fb-8095-154a0b83e344
+        :id: 86a73e96-ead6-41fb-8095-154a0b83e344
 
-        @Assert: One repository is created with a Docker upstream repository
-        and the product is added to a content view which is then published
-        only once.
+        :Assert: One repository is created with a Docker upstream repository
+            and the product is added to a content view which is then published
+            only once.
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         repo = _create_repository(
             entities.Product(organization=self.org).create())
@@ -611,14 +612,14 @@ class DockerContentViewTestCase(APITestCase):
         """Add Docker-type repository to composite content view and
         publish it once.
 
-        @id: 103ebee0-1978-4fc5-a11e-4dcdbf704185
+        :id: 103ebee0-1978-4fc5-a11e-4dcdbf704185
 
-        @Assert: One repository is created with an upstream repository and the
-        product is added to a content view which is then published only once
-        and then added to a composite content view which is also published only
-        once.
+        :Assert: One repository is created with an upstream repository and the
+            product is added to a content view which is then published only
+            once and then added to a composite content view which is also
+            published only once.
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         repo = _create_repository(
             entities.Product(organization=self.org).create())
@@ -665,13 +666,13 @@ class DockerContentViewTestCase(APITestCase):
         """Add Docker-type repository to content view and publish it
         multiple times.
 
-        @id: e2caad64-e9f4-422d-a1ab-f64c286d82ff
+        :id: e2caad64-e9f4-422d-a1ab-f64c286d82ff
 
-        @Assert: One repository is created with a Docker upstream repository
-        and the product is added to a content view which is then published
-        multiple times.
+        :Assert: One repository is created with a Docker upstream repository
+            and the product is added to a content view which is then published
+            multiple times.
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         repo = _create_repository(
             entities.Product(organization=self.org).create())
@@ -698,13 +699,13 @@ class DockerContentViewTestCase(APITestCase):
         """Add Docker-type repository to content view and publish it
         multiple times.
 
-        @id: 77a5957a-7415-41c3-be68-fa706fee7c98
+        :id: 77a5957a-7415-41c3-be68-fa706fee7c98
 
-        @Assert: One repository is created with a Docker upstream repository
-        and the product is added to a content view which is then added to a
-        composite content view which is then published multiple times.
+        :Assert: One repository is created with a Docker upstream repository
+            and the product is added to a content view which is then added to a
+            composite content view which is then published multiple times.
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         repo = _create_repository(
             entities.Product(organization=self.org).create())
@@ -747,12 +748,12 @@ class DockerContentViewTestCase(APITestCase):
         """Add Docker-type repository to content view and publish it.
         Then promote it to the next available lifecycle-environment.
 
-        @id: 5ab7d7f1-fb13-4b83-b228-a6293be36195
+        :id: 5ab7d7f1-fb13-4b83-b228-a6293be36195
 
-        @Assert: Docker-type repository is promoted to content view found in
-        the specific lifecycle-environment.
+        :Assert: Docker-type repository is promoted to content view found in
+            the specific lifecycle-environment.
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         lce = entities.LifecycleEnvironment(organization=self.org).create()
         repo = _create_repository(
@@ -781,12 +782,12 @@ class DockerContentViewTestCase(APITestCase):
         """Add Docker-type repository to content view and publish it.
         Then promote it to multiple available lifecycle-environments.
 
-        @id: 7b0cbc95-5f63-47f3-9048-e6917078be73
+        :id: 7b0cbc95-5f63-47f3-9048-e6917078be73
 
-        @Assert: Docker-type repository is promoted to content view found in
-        the specific lifecycle-environments.
+        :Assert: Docker-type repository is promoted to content view found in
+            the specific lifecycle-environments.
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         repo = _create_repository(
             entities.Product(organization=self.org).create())
@@ -816,12 +817,12 @@ class DockerContentViewTestCase(APITestCase):
         Then add that content view to composite one. Publish and promote that
         composite content view to the next available lifecycle-environment.
 
-        @id: e903c7b2-7722-4a9e-bb69-99bbd3c23946
+        :id: e903c7b2-7722-4a9e-bb69-99bbd3c23946
 
-        @Assert: Docker-type repository is promoted to content view found in
-        the specific lifecycle-environment.
+        :Assert: Docker-type repository is promoted to content view found in
+            the specific lifecycle-environment.
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         lce = entities.LifecycleEnvironment(organization=self.org).create()
         repo = _create_repository(
@@ -860,12 +861,12 @@ class DockerContentViewTestCase(APITestCase):
         Then add that content view to composite one. Publish and promote that
         composite content view to the multiple available lifecycle-environments
 
-        @id: 91ac0f4a-8974-47e2-a1d6-7d734aa4ad46
+        :id: 91ac0f4a-8974-47e2-a1d6-7d734aa4ad46
 
-        @Assert: Docker-type repository is promoted to content view found in
-        the specific lifecycle-environments.
+        :Assert: Docker-type repository is promoted to content view found in
+            the specific lifecycle-environments.
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         repo = _create_repository(
             entities.Product(organization=self.org).create())
@@ -927,11 +928,11 @@ class DockerActivationKeyTestCase(APITestCase):
         and publish it. Then create an activation key and associate it with the
         Docker content view.
 
-        @id: ce4ae928-49c7-4782-a032-08885050dd83
+        :id: ce4ae928-49c7-4782-a032-08885050dd83
 
-        @Assert: Docker-based content view can be added to activation key
+        :Assert: Docker-based content view can be added to activation key
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         ak = entities.ActivationKey(
             content_view=self.content_view,
@@ -949,12 +950,12 @@ class DockerActivationKeyTestCase(APITestCase):
         Docker content view. Then remove this content view from the activation
         key.
 
-        @id: 6a887a67-6700-47ac-9230-deaa0e382f22
+        :id: 6a887a67-6700-47ac-9230-deaa0e382f22
 
-        @Assert: Docker-based content view can be added and then removed from
-        the activation key.
+        :Assert: Docker-based content view can be added and then removed from
+            the activation key.
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         ak = entities.ActivationKey(
             content_view=self.content_view,
@@ -973,11 +974,11 @@ class DockerActivationKeyTestCase(APITestCase):
         publish it. Create an activation key and associate it with the
         composite Docker content view.
 
-        @id: 2fc8a462-9d91-48bc-8e32-7ff8f769b9e4
+        :id: 2fc8a462-9d91-48bc-8e32-7ff8f769b9e4
 
-        @Assert: Docker-based content view can be added to activation key
+        :Assert: Docker-based content view can be added to activation key
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         comp_content_view = entities.ContentView(
             composite=True,
@@ -1007,12 +1008,12 @@ class DockerActivationKeyTestCase(APITestCase):
         composite Docker content view. Then, remove the composite content view
         from the activation key.
 
-        @id: f3542272-13db-4a49-bc27-d1137172df41
+        :id: f3542272-13db-4a49-bc27-d1137172df41
 
-        @Assert: Docker-based composite content view can be added and then
-        removed from the activation key.
+        :Assert: Docker-based composite content view can be added and then
+            removed from the activation key.
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         comp_content_view = entities.ContentView(
             composite=True,
@@ -1052,11 +1053,11 @@ class DockerComputeResourceTestCase(APITestCase):
         """Create a Docker-based Compute Resource in the Satellite 6
         instance.
 
-        @id: 146dd836-83c7-4f9c-937e-791162ea106e
+        :id: 146dd836-83c7-4f9c-937e-791162ea106e
 
-        @Assert: Compute Resource can be created and listed.
+        :Assert: Compute Resource can be created and listed.
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         for name in valid_data_list():
             with self.subTest(name):
@@ -1077,12 +1078,12 @@ class DockerComputeResourceTestCase(APITestCase):
         """Create a Docker-based Compute Resource in the Satellite 6
         instance then edit its attributes.
 
-        @id: 5590621f-063c-4e32-80cb-ebe634dbadaa
+        :id: 5590621f-063c-4e32-80cb-ebe634dbadaa
 
-        @Assert: Compute Resource can be created, listed and its attributes can
-        be updated.
+        :Assert: Compute Resource can be created, listed and its attributes can
+            be updated.
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         for url in (settings.docker.external_url,
                     settings.docker.get_unix_socket_url()):
@@ -1104,12 +1105,12 @@ class DockerComputeResourceTestCase(APITestCase):
         """Create a Docker-based Compute Resource in the Satellite 6
         instance then list its running containers.
 
-        @id: 96bfba71-03e5-4d80-bd27-fc5db8e00b50
+        :id: 96bfba71-03e5-4d80-bd27-fc5db8e00b50
 
-        @Assert: Compute Resource can be created and existing instances can be
-        listed.
+        :Assert: Compute Resource can be created and existing instances can be
+            listed.
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         for url in (settings.docker.external_url,
                     settings.docker.get_unix_socket_url()):
@@ -1137,11 +1138,11 @@ class DockerComputeResourceTestCase(APITestCase):
         """Create a Docker-based Compute Resource using an external
         Docker-enabled system.
 
-        @id: 91ae6374-82de-424e-aa4c-e19209acd5b5
+        :id: 91ae6374-82de-424e-aa4c-e19209acd5b5
 
-        @Assert: Compute Resource can be created and listed.
+        :Assert: Compute Resource can be created and listed.
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         for name in valid_data_list():
             with self.subTest(name):
@@ -1159,9 +1160,9 @@ class DockerComputeResourceTestCase(APITestCase):
     def test_positive_delete(self):
         """Create a Docker-based Compute Resource then delete it.
 
-        @id: f1f23c1e-6481-46b5-9485-787ae18d9ed5
+        :id: f1f23c1e-6481-46b5-9485-787ae18d9ed5
 
-        @Assert: Compute Resource can be created, listed and deleted.
+        :Assert: Compute Resource can be created, listed and deleted.
         """
         for url in (settings.docker.external_url,
                     settings.docker.get_unix_socket_url()):
@@ -1209,11 +1210,11 @@ class DockerContainerTestCase(APITestCase):
     def test_positive_create_with_compresource(self):
         """Create containers for local and external compute resources
 
-        @id: c57c261c-39cf-4a71-93a4-e01e3ec368a7
+        :id: c57c261c-39cf-4a71-93a4-e01e3ec368a7
 
-        @Assert: The docker container is created for each compute resource
+        :Assert: The docker container is created for each compute resource
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         for compute_resource in (self.cr_internal, self.cr_external):
             with self.subTest(compute_resource.url):
@@ -1235,11 +1236,11 @@ class DockerContainerTestCase(APITestCase):
         environment and docker repository for local and external compute
         resources
 
-        @id: 69f29cc8-45e0-4b3a-b001-2842c45617e0
+        :id: 69f29cc8-45e0-4b3a-b001-2842c45617e0
 
-        @Assert: The docker container is created for each compute resource
+        :Assert: The docker container is created for each compute resource
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         lce = entities.LifecycleEnvironment(organization=self.org).create()
         repo = _create_repository(
@@ -1281,12 +1282,12 @@ class DockerContainerTestCase(APITestCase):
         """Create containers for local and external compute resource,
         then power them on and finally power them off
 
-        @id: 6271afcf-698b-47e2-af80-1ce38c111742
+        :id: 6271afcf-698b-47e2-af80-1ce38c111742
 
-        @Assert: The docker container is created for each compute resource
-        and the power status is showing properly
+        :Assert: The docker container is created for each compute resource and
+            the power status is showing properly
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         for compute_resource in (self.cr_internal, self.cr_external):
             with self.subTest(compute_resource):
@@ -1311,12 +1312,12 @@ class DockerContainerTestCase(APITestCase):
         """Create containers for local and external compute resource and
         read their logs
 
-        @id: ffeb3c57-c7dc-4cee-a087-b52daedd4485
+        :id: ffeb3c57-c7dc-4cee-a087-b52daedd4485
 
-        @Assert: The docker container is created for each compute resource and
-        its log can be read
+        :Assert: The docker container is created for each compute resource and
+            its log can be read
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         for compute_resource in (self.cr_internal, self.cr_external):
             with self.subTest(compute_resource):
@@ -1334,12 +1335,12 @@ class DockerContainerTestCase(APITestCase):
         """Create a container pulling an image from a custom external
         registry
 
-        @id: 04506604-637f-473b-a764-825c61067b1b
+        :id: 04506604-637f-473b-a764-825c61067b1b
 
-        @Assert: The docker container is created and the image is pulled from
-        the external registry
+        :Assert: The docker container is created and the image is pulled from
+            the external registry
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         repo_name = 'rhel'
         registry = entities.Registry(
@@ -1365,10 +1366,10 @@ class DockerContainerTestCase(APITestCase):
     def test_positive_delete(self):
         """Delete containers in local and external compute resources
 
-        @id: 12efdf50-9494-48c3-a181-01c495b48c19
+        :id: 12efdf50-9494-48c3-a181-01c495b48c19
 
-        @Assert: The docker containers are deleted in local and external
-        compute resources
+        :Assert: The docker containers are deleted in local and external
+            compute resources
         """
         for compute_resource in (self.cr_internal, self.cr_external):
             with self.subTest(compute_resource.url):
@@ -1402,9 +1403,9 @@ class DockerRegistryTestCase(APITestCase):
     def test_positive_create_with_name(self):
         """Create an external docker registry
 
-        @id: 8212ab15-8298-4a46-88ba-eaf71069e068
+        :id: 8212ab15-8298-4a46-88ba-eaf71069e068
 
-        @Assert: External registry is created successfully
+        :Assert: External registry is created successfully
         """
         for name in valid_data_list():
             with self.subTest(name):
@@ -1426,9 +1427,9 @@ class DockerRegistryTestCase(APITestCase):
     def test_positive_update_name(self):
         """Create an external docker registry and update its name
 
-        @id: fdd9c76b-43a7-4ece-8975-3b08241134c8
+        :id: fdd9c76b-43a7-4ece-8975-3b08241134c8
 
-        @Assert: the external registry is updated with the new name
+        :Assert: the external registry is updated with the new name
         """
         registry = entities.Registry(
             name=gen_string('alpha'), url=self.url).create()
@@ -1446,11 +1447,11 @@ class DockerRegistryTestCase(APITestCase):
     def test_positive_update_url(self):
         """Create an external docker registry and update its URL
 
-        @id: a3701f92-0846-4d1b-b691-48cdc85c1341
+        :id: a3701f92-0846-4d1b-b691-48cdc85c1341
 
-        @Assert: the external registry is updated with the new URL
+        :Assert: the external registry is updated with the new URL
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         new_url = settings.docker.external_registry_2
         registry = entities.Registry(url=self.url).create()
@@ -1467,11 +1468,11 @@ class DockerRegistryTestCase(APITestCase):
     def test_positive_update_description(self):
         """Create an external docker registry and update its description
 
-        @id: 7eb08208-8b45-444f-b365-2d6f6e417533
+        :id: 7eb08208-8b45-444f-b365-2d6f6e417533
 
-        @Assert: the external registry is updated with the new description
+        :Assert: the external registry is updated with the new description
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         registry = entities.Registry(url=self.url).create()
         try:
@@ -1488,11 +1489,11 @@ class DockerRegistryTestCase(APITestCase):
     def test_positive_update_username(self):
         """Create an external docker registry and update its username
 
-        @id: 7da17c30-4582-4e27-a080-e446e6eec176
+        :id: 7da17c30-4582-4e27-a080-e446e6eec176
 
-        @Assert: the external registry is updated with the new username
+        :Assert: the external registry is updated with the new username
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         username = gen_string('alpha')
         new_username = gen_string('alpha')
@@ -1514,9 +1515,9 @@ class DockerRegistryTestCase(APITestCase):
     def test_positive_delete(self):
         """Create an external docker registry and then delete it
 
-        @id: 1a215237-91b5-4fcc-8c18-a9944068ac88
+        :id: 1a215237-91b5-4fcc-8c18-a9944068ac88
 
-        @Assert: The external registry is deleted successfully
+        :Assert: The external registry is deleted successfully
         """
         registry = entities.Registry(url=self.url).create()
         registry.delete()

--- a/tests/foreman/api/test_email.py
+++ b/tests/foreman/api/test_email.py
@@ -1,18 +1,18 @@
 """API Tests for the email notification feature
 
-@Requirement: Email
+:Requirement: Email
 
-@CaseAutomation: Automated
+:CaseAutomation: Automated
 
-@CaseLevel: Acceptance
+:CaseLevel: Acceptance
 
-@CaseComponent: API
+:CaseComponent: API
 
-@TestType: Functional
+:TestType: Functional
 
-@CaseImportance: High
+:CaseImportance: High
 
-@Upstream: No
+:Upstream: No
 """
 from robottelo.decorators import stubbed, tier1
 from robottelo.test import APITestCase
@@ -26,14 +26,13 @@ class EmailTestCase(APITestCase):
     def test_positive_enable_and_disable_notification(self):
         """Manage user email notification preferences.
 
-        @id: 60928133-7bdc-4934-9804-f52b10d9ac95
+        :id: 60928133-7bdc-4934-9804-f52b10d9ac95
 
-        @Steps:
+        :Steps: Enable and disable email notifications using
+            /api/mail_notifications
 
-        1. Enable and disable email notifications using /api/mail_notifications
+        :Assert: Enabling and disabling email notification preferences saved
+            accordingly.
 
-        @Assert: Enabling and disabling email notification preferences saved
-        accordingly.
-
-        @caseautomation: notautomated
+        :caseautomation: notautomated
         """

--- a/tests/foreman/api/test_environment.py
+++ b/tests/foreman/api/test_environment.py
@@ -4,19 +4,19 @@ A full API reference for environments can be found here:
 http://theforeman.org/api/apidoc/v2/environments.html
 
 
-@Requirement: Environment
+:Requirement: Environment
 
-@CaseAutomation: Automated
+:CaseAutomation: Automated
 
-@CaseLevel: Acceptance
+:CaseLevel: Acceptance
 
-@CaseComponent: API
+:CaseComponent: API
 
-@TestType: Functional
+:TestType: Functional
 
-@CaseImportance: High
+:CaseImportance: High
 
-@Upstream: No
+:Upstream: No
 """
 from fauxfactory import gen_string
 from nailgun import entities
@@ -46,9 +46,9 @@ class EnvironmentTestCase(APITestCase):
     def test_positive_create_with_name(self):
         """Create an environment and provide a valid name.
 
-        @id: 8869ccf8-a511-4fa7-ac36-11494e85f532
+        :id: 8869ccf8-a511-4fa7-ac36-11494e85f532
 
-        @Assert: The environment created successfully and has expected name.
+        :Assert: The environment created successfully and has expected name.
         """
         for name in valid_data_list():
             with self.subTest(name):
@@ -60,10 +60,10 @@ class EnvironmentTestCase(APITestCase):
     def test_positive_create_with_org(self):
         """Create an environment and assign it to new organization.
 
-        @id: de7e4132-5ca7-4b41-9af3-df075d31f8f4
+        :id: de7e4132-5ca7-4b41-9af3-df075d31f8f4
 
-        @Assert: The environment created successfully and has expected
-        attributes.
+        :Assert: The environment created successfully and has expected
+            attributes.
         """
         org = entities.Organization().create()
         env = entities.Environment(
@@ -78,10 +78,10 @@ class EnvironmentTestCase(APITestCase):
     def test_positive_create_with_loc(self):
         """Create an environment and assign it to new location.
 
-        @id: 34d4bf4a-f36e-4433-999c-beda6916e781
+        :id: 34d4bf4a-f36e-4433-999c-beda6916e781
 
-        @Assert: The environment created successfully and has expected
-        attributes.
+        :Assert: The environment created successfully and has expected
+            attributes.
         """
         location = entities.Location().create()
         env = entities.Environment(
@@ -96,9 +96,9 @@ class EnvironmentTestCase(APITestCase):
     def test_negative_create_with_too_long_name(self):
         """Create an environment and provide an invalid name.
 
-        @id: e2654954-b3a1-4594-a487-bcd0cc8195ad
+        :id: e2654954-b3a1-4594-a487-bcd0cc8195ad
 
-        @Assert: The server returns an error.
+        :Assert: The server returns an error.
         """
         for name in invalid_names_list():
             with self.subTest(name):
@@ -110,11 +110,11 @@ class EnvironmentTestCase(APITestCase):
     def test_negative_create_with_invalid_characters(self):
         """Create an environment and provide an illegal name.
 
-        @id: 8ec57d04-4ce6-48b4-b7f9-79025019ad0f
+        :id: 8ec57d04-4ce6-48b4-b7f9-79025019ad0f
 
-        @Assert: The server returns an error.
+        :Assert: The server returns an error.
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         str_types = ('cjk', 'latin1', 'utf8')
         for name in (gen_string(str_type) for str_type in str_types):
@@ -128,9 +128,9 @@ class EnvironmentTestCase(APITestCase):
         """Create environment entity providing the initial name, then
         update its name to another valid name.
 
-        @id: ef48e79a-6b6a-4811-b49b-09f2effdd18f
+        :id: ef48e79a-6b6a-4811-b49b-09f2effdd18f
 
-        @Assert: Environment entity is created and updated properly
+        :Assert: Environment entity is created and updated properly
         """
         env = entities.Environment().create()
         for new_name in valid_data_list():
@@ -144,11 +144,11 @@ class EnvironmentTestCase(APITestCase):
     def test_positive_update_org(self):
         """Update environment and assign it to a new organization
 
-        @id: 31e43faa-65ee-4757-ac3d-3825eba37ae5
+        :id: 31e43faa-65ee-4757-ac3d-3825eba37ae5
 
-        @Assert: Environment entity is updated properly
+        :Assert: Environment entity is updated properly
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         env = entities.Environment().create()
         org = entities.Organization().create()
@@ -162,11 +162,11 @@ class EnvironmentTestCase(APITestCase):
     def test_positive_update_loc(self):
         """Update environment and assign it to a new location
 
-        @id: da56b040-69e3-4d4f-8ab3-3bfe923eaffe
+        :id: da56b040-69e3-4d4f-8ab3-3bfe923eaffe
 
-        @Assert: Environment entity is updated properly
+        :Assert: Environment entity is updated properly
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         env = entities.Environment().create()
         location = entities.Location().create()
@@ -181,9 +181,9 @@ class EnvironmentTestCase(APITestCase):
         """Create environment entity providing the initial name, then
         try to update its name to invalid one.
 
-        @id: 9cd024ab-db3d-4b15-b6da-dd2089321df3
+        :id: 9cd024ab-db3d-4b15-b6da-dd2089321df3
 
-        @Assert: Environment entity is not updated
+        :Assert: Environment entity is not updated
         """
         env = entities.Environment().create()
         for new_name in invalid_names_list():
@@ -197,9 +197,9 @@ class EnvironmentTestCase(APITestCase):
     def test_positive_delete(self):
         """Create new environment entity and then delete it.
 
-        @id: 500539c0-f839-4c6b-838f-a3a256962d65
+        :id: 500539c0-f839-4c6b-838f-a3a256962d65
 
-        @Assert: Environment entity is deleted successfully
+        :Assert: Environment entity is deleted successfully
         """
         for name in valid_data_list():
             with self.subTest(name):
@@ -230,13 +230,13 @@ class MissingAttrEnvironmentTestCase(APITestCase):
     def test_positive_update_loc(self):
         """Update an environment. Inspect the server's response.
 
-        @id: a4c1bc22-d586-4150-92fc-7797f0f5bfb0
+        :id: a4c1bc22-d586-4150-92fc-7797f0f5bfb0
 
-        @Assert: The response contains some value for the ``location`` field.
+        :Assert: The response contains some value for the ``location`` field.
 
-        @BZ: 1262029
+        :BZ: 1262029
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         names = one_to_many_names('location')
         self.assertGreaterEqual(
@@ -249,14 +249,14 @@ class MissingAttrEnvironmentTestCase(APITestCase):
     def test_positive_update_org(self):
         """Update an environment. Inspect the server's response.
 
-        @id: ac46bcac-5db0-4899-b2fc-d48d2116287e
+        :id: ac46bcac-5db0-4899-b2fc-d48d2116287e
 
-        @Assert: The response contains some value for the ``organization``
-        field.
+        :Assert: The response contains some value for the ``organization``
+            field.
 
-        @BZ: 1262029
+        :BZ: 1262029
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         names = one_to_many_names('organization')
         self.assertGreaterEqual(

--- a/tests/foreman/api/test_errata.py
+++ b/tests/foreman/api/test_errata.py
@@ -1,18 +1,18 @@
 """API Tests for the errata management feature
 
-@Requirement: Errata
+:Requirement: Errata
 
-@CaseAutomation: Automated
+:CaseAutomation: Automated
 
-@CaseLevel: Acceptance
+:CaseLevel: Acceptance
 
-@CaseComponent: API
+:CaseComponent: API
 
-@TestType: Functional
+:TestType: Functional
 
-@CaseImportance: High
+:CaseImportance: High
 
-@Upstream: No
+:Upstream: No
 """
 
 # For ease of use hc refers to host-collection throughout this document
@@ -174,17 +174,15 @@ class ErrataTestCase(APITestCase):
     def test_positive_install_in_hc(self):
         """Install errata in a host-collection
 
-        @id: 6f0242df-6511-4c0f-95fc-3fa32c63a064
+        :id: 6f0242df-6511-4c0f-95fc-3fa32c63a064
 
-        @Setup: Errata synced on satellite server.
+        :Setup: Errata synced on satellite server.
 
-        @Steps:
+        :Steps: PUT /api/v2/hosts/bulk/update_content
 
-        1. PUT /api/v2/hosts/bulk/update_content
+        :Assert: errata is installed in the host-collection.
 
-        @Assert: errata is installed in the host-collection.
-
-        @CaseLevel: System
+        :CaseLevel: System
         """
         with VirtualMachine(distro=DISTRO_RHEL7) as client1, VirtualMachine(
                 distro=DISTRO_RHEL7) as client2:
@@ -214,17 +212,15 @@ class ErrataTestCase(APITestCase):
     def test_positive_install_in_host(self):
         """Install errata in a host
 
-        @id: 1e6fc159-b0d6-436f-b945-2a5731c46df5
+        :id: 1e6fc159-b0d6-436f-b945-2a5731c46df5
 
-        @Setup: Errata synced on satellite server.
+        :Setup: Errata synced on satellite server.
 
-        @Steps:
+        :Steps: PUT /api/v2/hosts/:id/errata/apply
 
-        1. PUT /api/v2/hosts/:id/errata/apply
+        :Assert: errata is installed in the host.
 
-        @Assert: errata is installed in the host.
-
-        @CaseLevel: System
+        :CaseLevel: System
         """
         with VirtualMachine(distro=DISTRO_RHEL7) as client:
             client.install_katello_ca()
@@ -244,16 +240,16 @@ class ErrataTestCase(APITestCase):
     def test_positive_list(self):
         """View all errata specific to repository
 
-        @id: 1efceabf-9821-4804-bacf-2213ac0c7550
+        :id: 1efceabf-9821-4804-bacf-2213ac0c7550
 
-        @Setup: Errata synced on satellite server.
+        :Setup: Errata synced on satellite server.
 
-        @Steps: Create two repositories each synced and containing errata
+        :Steps: Create two repositories each synced and containing errata
 
-        @Assert: Check that the errata belonging to one repo is not showing in
-        the other.
+        :Assert: Check that the errata belonging to one repo is not showing in
+            the other.
 
-        @CaseLevel: System
+        :CaseLevel: System
         """
         repo1 = entities.Repository(
             id=self.custom_entities['repository-id']).read()
@@ -283,17 +279,15 @@ class ErrataTestCase(APITestCase):
     def test_positive_list_updated(self):
         """View all errata in an Org sorted by Updated
 
-        @id: 560d6584-70bd-4d1b-993a-cc7665a9e600
+        :id: 560d6584-70bd-4d1b-993a-cc7665a9e600
 
-        @Setup: Errata synced on satellite server.
+        :Setup: Errata synced on satellite server.
 
-        @Steps:
+        :Steps: GET /katello/api/errata
 
-        1. GET /katello/api/errata
+        :Assert: Errata is filtered by Org and sorted by Updated date.
 
-        @Assert: Errata is filtered by Org and sorted by Updated date.
-
-        @CaseLevel: System
+        :CaseLevel: System
         """
         repo = entities.Repository(name=REPOS['rhva6']['name']).search(
                 query={'organization_id': self.org.id})
@@ -321,17 +315,15 @@ class ErrataTestCase(APITestCase):
     def test_positive_filter_by_cve(self):
         """Filter errata by CVE
 
-        @id: a921d4c2-8d3d-4462-ba6c-fbd4b898a3f2
+        :id: a921d4c2-8d3d-4462-ba6c-fbd4b898a3f2
 
-        @Setup: Errata synced on satellite server.
+        :Setup: Errata synced on satellite server.
 
-        @Steps:
+        :Steps: GET /katello/api/errata
 
-        1. GET /katello/api/errata
+        :Assert: Errata is filtered by CVE.
 
-        @Assert: Errata is filtered by CVE.
-
-        @CaseLevel: System
+        :CaseLevel: System
         """
         repo = entities.Repository(name=REPOS['rhva6']['name']).search(
             query={'organization_id': self.org.id})
@@ -365,17 +357,15 @@ class ErrataTestCase(APITestCase):
     def test_positive_sort_by_issued_date(self):
         """Filter errata by issued date
 
-        @id: 6b4a783a-a7b4-4af4-b9e6-eb2928b7f7c1
+        :id: 6b4a783a-a7b4-4af4-b9e6-eb2928b7f7c1
 
-        @Setup: Errata synced on satellite server.
+        :Setup: Errata synced on satellite server.
 
-        @Steps:
+        :Steps: GET /katello/api/errata
 
-        1. GET /katello/api/errata
+        :Assert: Errata is sorted by issued date.
 
-        @Assert: Errata is sorted by issued date.
-
-        @CaseLevel: System
+        :CaseLevel: System
         """
         repo = entities.Repository(name=REPOS['rhva6']['name']).search(
             query={'organization_id': self.org.id})
@@ -404,21 +394,20 @@ class ErrataTestCase(APITestCase):
         """Filter applicable errata for a content host by current and
         Library environments
 
-        @id: f41bfcc2-39ee-4ae1-a71f-d2c9288875be
+        :id: f41bfcc2-39ee-4ae1-a71f-d2c9288875be
 
-        @Setup:
+        :Setup:
 
-        1. Make sure multiple environments are present.
-        2. One of Content host's previous environment has additional errata.
+            1. Make sure multiple environments are present.
+            2. One of Content host's previous environment has additional
+               errata.
 
-        @Steps:
+        :Steps: GET /katello/api/errata
 
-        1. GET /katello/api/errata
+        :Assert: The errata for the content host is filtered by current and
+            Library environments.
 
-        @Assert: The errata for the content host is filtered by current and
-        Library environments.
-
-        @CaseLevel: System
+        :CaseLevel: System
         """
         org = entities.Organization().create()
         env = entities.LifecycleEnvironment(
@@ -460,20 +449,18 @@ class ErrataTestCase(APITestCase):
     def test_positive_get_count_for_host(self):
         """Available errata count when retrieving Host
 
-        @id: 2f35933f-8026-414e-8f75-7f4ec048faae
+        :id: 2f35933f-8026-414e-8f75-7f4ec048faae
 
-        @Setup:
+        :Setup:
 
-        1. Errata synced on satellite server.
-        2. Some Content hosts present.
+            1. Errata synced on satellite server.
+            2. Some Content hosts present.
 
-        @Steps:
+        :Steps: GET /api/v2/hosts
 
-        1. GET /api/v2/hosts
+        :Assert: The available errata count is retrieved.
 
-        @Assert: The available errata count is retrieved.
-
-        @CaseLevel: System
+        :CaseLevel: System
         """
         org = entities.Organization().create()
         env = entities.LifecycleEnvironment(
@@ -541,20 +528,17 @@ class ErrataTestCase(APITestCase):
     def test_positive_get_applicable_for_host(self):
         """Get applicable errata ids for a host
 
-        @id: 51d44d51-eb3f-4ee4-a1df-869629d427ac
+        :id: 51d44d51-eb3f-4ee4-a1df-869629d427ac
 
-        @Setup:
+        :Setup:
+            1. Errata synced on satellite server.
+            2. Some Content hosts present.
 
-        1. Errata synced on satellite server.
-        2. Some Content hosts present.
+        :Steps: GET /api/v2/hosts/:id/errata
 
-        @Steps:
+        :Assert: The available errata is retrieved.
 
-        1. GET /api/v2/hosts/:id/errata
-
-        @Assert: The available errata is retrieved.
-
-        @CaseLevel: System
+        :CaseLevel: System
         """
         org = entities.Organization().create()
         env = entities.LifecycleEnvironment(
@@ -632,21 +616,19 @@ class ErrataTestCase(APITestCase):
         """Generate a difference in errata between a set of environments
         for a content view
 
-        @id: 96732506-4a89-408c-8d7e-f30c8d469769
+        :id: 96732506-4a89-408c-8d7e-f30c8d469769
 
-        @Setup:
+        :Setup:
 
-        1. Errata synced on satellite server.
-        2. Multiple environments present.
+            1. Errata synced on satellite server.
+            2. Multiple environments present.
 
-        @Steps:
+        :Steps: GET /katello/api/compare
 
-        1. GET /katello/api/compare
+        :Assert: Difference in errata between a set of environments for a
+            content view is retrieved.
 
-        @Assert: Difference in errata between a set of environments for a
-        content view is retrieved.
-
-        @CaseLevel: System
+        :CaseLevel: System
         """
         org = entities.Organization().create()
         env = entities.LifecycleEnvironment(
@@ -700,23 +682,20 @@ class ErrataTestCase(APITestCase):
         """Select multiple errata and apply them to multiple content
         views in multiple environments
 
-        @id: 5d8f6aee-baac-4217-ba34-13adccdf1ca8
+        :id: 5d8f6aee-baac-4217-ba34-13adccdf1ca8
 
-        @Setup:
+        :Setup:
+            1. Errata synced on satellite server.
+            2. Multiple environments/content views present.
 
-        1. Errata synced on satellite server.
-        2. Multiple environments/content views present.
+        :Steps: POST /katello/api/hosts/bulk/available_incremental_updates
 
-        @Steps:
+        :Assert: Selected errata are applied to multiple content views in
+            multiple environments.
 
-        1. POST /katello/api/hosts/bulk/available_incremental_updates
+        :caseautomation: notautomated
 
-        @Assert: Selected errata are applied to multiple content views in
-        multiple environments.
-
-        @caseautomation: notautomated
-
-        @CaseLevel: System
+        :CaseLevel: System
         """
 
     @stubbed()
@@ -725,22 +704,19 @@ class ErrataTestCase(APITestCase):
         """Query a subset of environments or content views to push new
         errata
 
-        @id: f6ec8066-36cc-42a8-9a1a-156721e733c3
+        :id: f6ec8066-36cc-42a8-9a1a-156721e733c3
 
-        @Setup:
+        :Setup:
+            1. Errata synced on satellite server.
+            2. Multiple environments/content views present.
 
-        1. Errata synced on satellite server.
-        2. Multiple environments/content views present.
+        :Steps: POST /katello/api/content_view_versions/incremental_update
 
-        @Steps:
+        :Assert: Subset of environments/content views retrieved.
 
-        1. POST /katello/api/content_view_versions/incremental_update
+        :caseautomation: notautomated
 
-        @Assert: Subset of environments/content views retrieved.
-
-        @caseautomation: notautomated
-
-        @CaseLevel: System
+        :CaseLevel: System
         """
 
     @stubbed()
@@ -749,20 +725,17 @@ class ErrataTestCase(APITestCase):
         """Select multiple packages and apply them to multiple content
         views in multiple environments
 
-        @id: 61549360-ce99-42a3-8d6b-2cd713f8b556
+        :id: 61549360-ce99-42a3-8d6b-2cd713f8b556
 
-        @Setup:
+        :Setup:
+            1. Errata synced on satellite server.
+            2. Multiple environments/content views present.
 
-        1. Errata synced on satellite server.
-        2. Multiple environments/content views present.
+        :Steps: POST /katello/api/content_view_versions/incremental_update
 
-        @Steps:
+        :Assert: Packages are applied to multiple environments/content views.
 
-        1. POST /katello/api/content_view_versions/incremental_update
+        :caseautomation: notautomated
 
-        @Assert: Packages are applied to multiple environments/content views.
-
-        @caseautomation: notautomated
-
-        @CaseLevel: System
+        :CaseLevel: System
         """

--- a/tests/foreman/api/test_filter.py
+++ b/tests/foreman/api/test_filter.py
@@ -4,19 +4,19 @@ An API reference is available here:
 http://theforeman.org/api/apidoc/v2/filters.html
 
 
-@Requirement: Filter
+:Requirement: Filter
 
-@CaseAutomation: Automated
+:CaseAutomation: Automated
 
-@CaseLevel: Acceptance
+:CaseLevel: Acceptance
 
-@CaseComponent: API
+:CaseComponent: API
 
-@TestType: Functional
+:TestType: Functional
 
-@CaseImportance: High
+:CaseImportance: High
 
-@Upstream: No
+:Upstream: No
 """
 from nailgun import entities
 from requests.exceptions import HTTPError
@@ -40,9 +40,9 @@ class FilterTestCase(APITestCase):
     def test_positive_create_with_permission(self):
         """Create a filter and assign it some permissions.
 
-        @id: b8631d0a-a71a-41aa-9f9a-d12d62adc496
+        :id: b8631d0a-a71a-41aa-9f9a-d12d62adc496
 
-        @Assert: The created filter has the assigned permissions.
+        :Assert: The created filter has the assigned permissions.
         """
         # Create a filter and assign all ProvisioningTemplate permissions to it
         filter_ = entities.Filter(permission=self.ct_perms).create()
@@ -55,9 +55,9 @@ class FilterTestCase(APITestCase):
     def test_positive_delete(self):
         """Create a filter and delete it afterwards.
 
-        @id: f0c56fd8-c91d-48c3-ad21-f538313b17eb
+        :id: f0c56fd8-c91d-48c3-ad21-f538313b17eb
 
-        @Assert: The deleted filter cannot be fetched.
+        :Assert: The deleted filter cannot be fetched.
         """
         filter_ = entities.Filter(permission=self.ct_perms).create()
         filter_.delete()
@@ -68,9 +68,9 @@ class FilterTestCase(APITestCase):
     def test_positive_delete_role(self):
         """Create a filter and delete the role it points at.
 
-        @id: b129642d-926d-486a-84d9-5952b44ac446
+        :id: b129642d-926d-486a-84d9-5952b44ac446
 
-        @Assert: The filter cannot be fetched.
+        :Assert: The filter cannot be fetched.
         """
         role = entities.Role().create()
         filter_ = entities.Filter(permission=self.ct_perms, role=role).create()

--- a/tests/foreman/api/test_foremantask.py
+++ b/tests/foreman/api/test_foremantask.py
@@ -1,18 +1,18 @@
 """Unit tests for the ``foreman_tasks/api/v2/tasks`` paths.
 
-@Requirement: Foremantask
+:Requirement: Foremantask
 
-@CaseAutomation: Automated
+:CaseAutomation: Automated
 
-@CaseLevel: Acceptance
+:CaseLevel: Acceptance
 
-@CaseComponent: API
+:CaseComponent: API
 
-@TestType: Functional
+:TestType: Functional
 
-@CaseImportance: High
+:CaseImportance: High
 
-@Upstream: No
+:Upstream: No
 """
 from nailgun import entities
 from requests.exceptions import HTTPError
@@ -28,9 +28,9 @@ class ForemanTaskTestCase(APITestCase):
     def test_negative_fetch_non_existent_task(self):
         """Fetch a non-existent task.
 
-        @id: a2a81ca2-63c4-47f5-9314-5852f5e2617f
+        :id: a2a81ca2-63c4-47f5-9314-5852f5e2617f
 
-        @Assert: An HTTP 4XX or 5XX message is returned.
+        :Assert: An HTTP 4XX or 5XX message is returned.
         """
         with self.assertRaises(HTTPError):
             entities.ForemanTask(id='abc123').read()
@@ -40,9 +40,9 @@ class ForemanTaskTestCase(APITestCase):
     def test_positive_get_summary(self):
         """Get a summary of foreman tasks.
 
-        @id: bdcab413-a25d-4fe1-9db4-b50b5c31ebce
+        :id: bdcab413-a25d-4fe1-9db4-b50b5c31ebce
 
-        @Assert: A list of dicts is returned.
+        :Assert: A list of dicts is returned.
         """
         summary = entities.ForemanTask().summary()
         self.assertIsInstance(summary, list)

--- a/tests/foreman/api/test_gpgkey.py
+++ b/tests/foreman/api/test_gpgkey.py
@@ -1,18 +1,18 @@
 """Unit tests for the ``gpgkeys`` paths.
 
-@Requirement: Gpgkey
+:Requirement: Gpgkey
 
-@CaseAutomation: Automated
+:CaseAutomation: Automated
 
-@CaseLevel: Acceptance
+:CaseLevel: Acceptance
 
-@CaseComponent: API
+:CaseComponent: API
 
-@TestType: Functional
+:TestType: Functional
 
-@CaseImportance: High
+:CaseImportance: High
 
-@Upstream: No
+:Upstream: No
 """
 from fauxfactory import gen_string
 from nailgun import entities
@@ -39,16 +39,16 @@ class GPGKeyTestCase(APITestCase):
     def test_positive_search_in_org(self):
         """Search for a GPG key and specify just ``organization_id``.
 
-        @id: ff5e047c-404b-4379-8d28-3ad8cb39b6a9
+        :id: ff5e047c-404b-4379-8d28-3ad8cb39b6a9
 
-        @Steps:
+        :Steps:
 
-        1. Create an organization.
-        1. Create a GPG key belonging to the organization.
-        2. Search for GPG keys in the organization.
+            1. Create an organization.
+            2. Create a GPG key belonging to the organization.
+            3. Search for GPG keys in the organization.
 
-        @Assert: Only one GPG key is in the search results: the created GPG
-        key.
+        :Assert: Only one GPG key is in the search results: the created GPG
+            key.
         """
         org = entities.Organization().create()
         gpg_key = entities.GPGKey(organization=org).create()
@@ -61,9 +61,9 @@ class GPGKeyTestCase(APITestCase):
     def test_positive_create_with_name(self):
         """Create a GPG key with valid name.
 
-        @id: 741d969b-28ef-481f-bcf7-ed4cd920b030
+        :id: 741d969b-28ef-481f-bcf7-ed4cd920b030
 
-        @Assert: A GPG key is created with the given name.
+        :Assert: A GPG key is created with the given name.
         """
         for name in valid_data_list():
             with self.subTest(name):
@@ -76,9 +76,9 @@ class GPGKeyTestCase(APITestCase):
     def test_positive_create_with_content(self):
         """Create a GPG key with valid name and valid gpg key text.
 
-        @id: cfa6690e-fed7-49cf-94f9-fd2deed941c0
+        :id: cfa6690e-fed7-49cf-94f9-fd2deed941c0
 
-        @Assert: A GPG key is created with the expected content.
+        :Assert: A GPG key is created with the expected content.
         """
         gpg_key = entities.GPGKey(
             organization=self.org, content=self.key_content).create()
@@ -89,9 +89,9 @@ class GPGKeyTestCase(APITestCase):
     def test_negative_create_name(self):
         """Attempt to create GPG key with invalid names only.
 
-        @id: 904a3ed0-7d50-495e-a700-b4f1ae913599
+        :id: 904a3ed0-7d50-495e-a700-b4f1ae913599
 
-        @Assert: A GPG key is not created and error is raised.
+        :Assert: A GPG key is not created and error is raised.
         """
         for name in invalid_values_list():
             with self.subTest(name):
@@ -104,9 +104,9 @@ class GPGKeyTestCase(APITestCase):
         """Attempt to create a GPG key providing a name of already existent
         entity
 
-        @id: 78299f13-5977-4409-9bc7-844e54349926
+        :id: 78299f13-5977-4409-9bc7-844e54349926
 
-        @Assert: A GPG key is not created and error is raised.
+        :Assert: A GPG key is not created and error is raised.
         """
         name = gen_string('alphanumeric')
         entities.GPGKey(organization=self.org, name=name).create()
@@ -118,9 +118,9 @@ class GPGKeyTestCase(APITestCase):
     def test_negative_create_with_content(self):
         """Attempt to create GPG key with empty content.
 
-        @id: fc79c840-6bcb-4d97-9145-c0008d5b028d
+        :id: fc79c840-6bcb-4d97-9145-c0008d5b028d
 
-        @Assert: A GPG key is not created and error is raised.
+        :Assert: A GPG key is not created and error is raised.
         """
         with self.assertRaises(HTTPError):
             entities.GPGKey(content='').create()
@@ -130,9 +130,9 @@ class GPGKeyTestCase(APITestCase):
     def test_positive_update_name(self):
         """Update GPG key name to another valid name.
 
-        @id: 9868025d-5346-42c9-b850-916ce37a9541
+        :id: 9868025d-5346-42c9-b850-916ce37a9541
 
-        @Assert: The GPG key name can be updated.
+        :Assert: The GPG key name can be updated.
         """
         gpg_key = entities.GPGKey(organization=self.org).create()
         for new_name in valid_data_list():
@@ -146,9 +146,9 @@ class GPGKeyTestCase(APITestCase):
     def test_positive_update_content(self):
         """Update GPG key content text to another valid one.
 
-        @id: 62fdaf55-c931-4be6-9857-68cc816046ad
+        :id: 62fdaf55-c931-4be6-9857-68cc816046ad
 
-        @Assert: The GPG key content text can be updated.
+        :Assert: The GPG key content text can be updated.
         """
         gpg_key = entities.GPGKey(
             organization=self.org,
@@ -163,9 +163,9 @@ class GPGKeyTestCase(APITestCase):
     def test_negative_update_name(self):
         """Attempt to update GPG key name to invalid one
 
-        @id: 1a43f610-8969-4f08-967f-fb6af0fca31b
+        :id: 1a43f610-8969-4f08-967f-fb6af0fca31b
 
-        @Assert: GPG key is not updated
+        :Assert: GPG key is not updated
         """
         gpg_key = entities.GPGKey(organization=self.org).create()
         for new_name in invalid_values_list():
@@ -180,9 +180,9 @@ class GPGKeyTestCase(APITestCase):
         """Attempt to update GPG key name to the name of existing GPG key
         entity
 
-        @id: e294e3b2-1125-4ad9-969a-eb3f1966419e
+        :id: e294e3b2-1125-4ad9-969a-eb3f1966419e
 
-        @Assert: GPG key is not updated
+        :Assert: GPG key is not updated
         """
         name = gen_string('alpha')
         entities.GPGKey(organization=self.org, name=name).create()
@@ -196,9 +196,9 @@ class GPGKeyTestCase(APITestCase):
     def test_negative_update_content(self):
         """Attempt to update GPG key content to invalid one
 
-        @id: fee30ef8-370a-4fdd-9e45-e7ab95dade8b
+        :id: fee30ef8-370a-4fdd-9e45-e7ab95dade8b
 
-        @Assert: GPG key is not updated
+        :Assert: GPG key is not updated
         """
         gpg_key = entities.GPGKey(
             organization=self.org, content=self.key_content).create()
@@ -212,9 +212,9 @@ class GPGKeyTestCase(APITestCase):
     def test_positive_delete(self):
         """Create a GPG key with different names and then delete it.
 
-        @id: b06d211f-2827-40f7-b627-8b1fbaee2eb4
+        :id: b06d211f-2827-40f7-b627-8b1fbaee2eb4
 
-        @Assert: The GPG key deleted successfully.
+        :Assert: The GPG key deleted successfully.
         """
         gpg_key = entities.GPGKey(organization=self.org).create()
         gpg_key.delete()

--- a/tests/foreman/api/test_host.py
+++ b/tests/foreman/api/test_host.py
@@ -5,19 +5,19 @@ An API reference can be found here:
 http://theforeman.org/api/apidoc/v2/hosts.html
 
 
-@Requirement: Host
+:Requirement: Host
 
-@CaseAutomation: Automated
+:CaseAutomation: Automated
 
-@CaseLevel: Acceptance
+:CaseLevel: Acceptance
 
-@CaseComponent: API
+:CaseComponent: API
 
-@TestType: Functional
+:TestType: Functional
 
-@CaseImportance: High
+:CaseImportance: High
 
-@Upstream: No
+:Upstream: No
 """
 from fauxfactory import gen_integer, gen_ipaddr, gen_mac, gen_string
 from nailgun import client, entities
@@ -84,9 +84,9 @@ class HostTestCase(APITestCase):
     def test_positive_get_search(self):
         """GET ``api/v2/hosts`` and specify the ``search`` parameter.
 
-        @id: d63f87e5-66e6-4886-8b44-4129259493a6
+        :id: d63f87e5-66e6-4886-8b44-4129259493a6
 
-        @Assert: HTTP 200 is returned, along with ``search`` term.
+        :Assert: HTTP 200 is returned, along with ``search`` term.
         """
         query = gen_string('utf8', gen_integer(1, 100))
         response = client.get(
@@ -103,9 +103,9 @@ class HostTestCase(APITestCase):
     def test_positive_get_per_page(self):
         """GET ``api/v2/hosts`` and specify the ``per_page`` parameter.
 
-        @id: 9086f41c-b3b9-4af2-b6c4-46b80b4d1cfd
+        :id: 9086f41c-b3b9-4af2-b6c4-46b80b4d1cfd
 
-        @Assert: HTTP 200 is returned, along with per ``per_page`` value.
+        :Assert: HTTP 200 is returned, along with per ``per_page`` value.
         """
         per_page = gen_integer(1, 1000)
         response = client.get(
@@ -122,10 +122,10 @@ class HostTestCase(APITestCase):
     def test_positive_create_with_owner_type(self):
         """Create a host and specify an ``owner_type``.
 
-        @id: 9f486875-1f30-4dcb-b7ce-b2cf515c413b
+        :id: 9f486875-1f30-4dcb-b7ce-b2cf515c413b
 
-        @Assert: The host can be read back, and the ``owner_type`` attribute is
-        correct.
+        :Assert: The host can be read back, and the ``owner_type`` attribute is
+            correct.
         """
         for owner_type in ('User', 'Usergroup'):
             with self.subTest(owner_type):
@@ -139,9 +139,9 @@ class HostTestCase(APITestCase):
     def test_positive_update_owner_type(self):
         """Update a host's ``owner_type``.
 
-        @id: b72cd8ef-3a0b-4d2d-94f9-9b64908d699a
+        :id: b72cd8ef-3a0b-4d2d-94f9-9b64908d699a
 
-        @Assert: The host's ``owner_type`` attribute is updated as requested.
+        :Assert: The host's ``owner_type`` attribute is updated as requested.
         """
         host = entities.Host().create()
         for owner_type in ('User', 'Usergroup'):
@@ -157,9 +157,9 @@ class HostTestCase(APITestCase):
     def test_positive_create_with_name(self):
         """Create a host with different names and minimal input parameters
 
-        @id: a7c0e8ec-3816-4092-88b1-0324cb271752
+        :id: a7c0e8ec-3816-4092-88b1-0324cb271752
 
-        @assert: A host is created with expected name
+        :assert: A host is created with expected name
         """
         for name in valid_hosts_list():
             with self.subTest(name):
@@ -174,9 +174,9 @@ class HostTestCase(APITestCase):
     def test_positive_create_with_ip(self):
         """Create a host with IP address specified
 
-        @id: 3f266906-c509-42ce-9b20-def448bf8d86
+        :id: 3f266906-c509-42ce-9b20-def448bf8d86
 
-        @assert: A host is created with expected IP address
+        :assert: A host is created with expected IP address
         """
         ip_addr = gen_ipaddr()
         host = entities.Host(ip=ip_addr).create()
@@ -187,11 +187,11 @@ class HostTestCase(APITestCase):
     def test_positive_create_with_hostgroup(self):
         """Create a host with hostgroup specified
 
-        @id: 8f9601f9-afd8-4a88-8f28-a5cbc996e805
+        :id: 8f9601f9-afd8-4a88-8f28-a5cbc996e805
 
-        @assert: A host is created with expected hostgroup assigned
+        :assert: A host is created with expected hostgroup assigned
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         org = entities.Organization().create()
         loc = entities.Location(organization=[org]).create()
@@ -212,14 +212,14 @@ class HostTestCase(APITestCase):
         """Create a host with hostgroup specified. Make sure host inherited
         hostgroup's lifecycle environment and content-view
 
-        @id: 229cbdbc-838b-456c-bc6f-4ac895badfbc
+        :id: 229cbdbc-838b-456c-bc6f-4ac895badfbc
 
-        @Assert: Host's lifecycle environment and content view match the ones
-        specified in hostgroup
+        :Assert: Host's lifecycle environment and content view match the ones
+            specified in hostgroup
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
 
-        @BZ: 1391656
+        :BZ: 1391656
         """
         hostgroup = entities.HostGroup(
             content_view=self.cv,
@@ -244,9 +244,9 @@ class HostTestCase(APITestCase):
     def test_positive_create_with_puppet_proxy(self):
         """Create a host with puppet proxy specified
 
-        @id: 9269d87b-abb9-48e0-b0d1-9b8e258e1ae3
+        :id: 9269d87b-abb9-48e0-b0d1-9b8e258e1ae3
 
-        @assert: A host is created with expected puppet proxy assigned
+        :assert: A host is created with expected puppet proxy assigned
         """
         proxy = entities.SmartProxy().search(query={
             'search': 'url = https://{0}:9090'.format(settings.server.hostname)
@@ -259,9 +259,9 @@ class HostTestCase(APITestCase):
     def test_positive_create_with_puppet_ca_proxy(self):
         """Create a host with puppet CA proxy specified
 
-        @id: 1b73dd35-c2e8-44bd-b8f8-9e51428a6239
+        :id: 1b73dd35-c2e8-44bd-b8f8-9e51428a6239
 
-        @assert: A host is created with expected puppet CA proxy assigned
+        :assert: A host is created with expected puppet CA proxy assigned
         """
         proxy = entities.SmartProxy().search(query={
             'search': 'url = https://{0}:9090'.format(settings.server.hostname)
@@ -274,9 +274,9 @@ class HostTestCase(APITestCase):
     def test_positive_create_with_puppet_class(self):
         """Create a host with associated puppet classes
 
-        @id: 2690d6b0-441b-44c5-b7d2-4093616e037e
+        :id: 2690d6b0-441b-44c5-b7d2-4093616e037e
 
-        @assert: A host is created with expected puppet classes
+        :assert: A host is created with expected puppet classes
         """
         host = entities.Host(
             organization=self.org,
@@ -294,11 +294,11 @@ class HostTestCase(APITestCase):
     def test_positive_create_with_subnet(self):
         """Create a host with subnet specified
 
-        @id: 9aa97aff-8439-4027-89ee-01c643fbf7d1
+        :id: 9aa97aff-8439-4027-89ee-01c643fbf7d1
 
-        @assert: A host is created with expected subnet assigned
+        :assert: A host is created with expected subnet assigned
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         org = entities.Organization().create()
         loc = entities.Location(organization=[org]).create()
@@ -318,11 +318,11 @@ class HostTestCase(APITestCase):
     def test_positive_create_with_compresource(self):
         """Create a host with compute resource specified
 
-        @id: 53069f2e-67a7-4d57-9846-acf6d8ce03cb
+        :id: 53069f2e-67a7-4d57-9846-acf6d8ce03cb
 
-        @assert: A host is created with expected compute resource assigned
+        :assert: A host is created with expected compute resource assigned
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         org = entities.Organization().create()
         loc = entities.Location(organization=[org]).create()
@@ -342,11 +342,11 @@ class HostTestCase(APITestCase):
     def test_positive_create_with_model(self):
         """Create a host with model specified
 
-        @id: 7a912a19-71e4-4843-87fd-bab98c156f4a
+        :id: 7a912a19-71e4-4843-87fd-bab98c156f4a
 
-        @assert: A host is created with expected model assigned
+        :assert: A host is created with expected model assigned
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         model = entities.Model().create()
         host = entities.Host(model=model).create()
@@ -357,11 +357,11 @@ class HostTestCase(APITestCase):
     def test_positive_create_with_user(self):
         """Create a host with user specified
 
-        @id: 72e20f8f-17dc-4e38-8ac1-d08df8758f56
+        :id: 72e20f8f-17dc-4e38-8ac1-d08df8758f56
 
-        @assert: A host is created with expected user assigned
+        :assert: A host is created with expected user assigned
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         user = entities.User().create()
         host = entities.Host(
@@ -375,11 +375,11 @@ class HostTestCase(APITestCase):
     def test_positive_create_with_usergroup(self):
         """Create a host with user group specified
 
-        @id: 706e860c-8c05-4ddc-be20-0ecd9f0da813
+        :id: 706e860c-8c05-4ddc-be20-0ecd9f0da813
 
-        @assert: A host is created with expected user group assigned
+        :assert: A host is created with expected user group assigned
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         org = entities.Organization().create()
         loc = entities.Location(organization=[org]).create()
@@ -407,9 +407,9 @@ class HostTestCase(APITestCase):
         """Create a host with 'build' parameter specified.
         Build parameter determines whether to enable the host for provisioning
 
-        @id: de30cf62-5036-4247-a5f0-37dd2b4aae23
+        :id: de30cf62-5036-4247-a5f0-37dd2b4aae23
 
-        @assert: A host is created with expected 'build' parameter value
+        :assert: A host is created with expected 'build' parameter value
         """
         host = entities.Host(build=True).create()
         self.assertEqual(host.build, True)
@@ -421,9 +421,9 @@ class HostTestCase(APITestCase):
         Enabled parameter determines whether to include the host within
         Satellite 6 reporting
 
-        @id: bd8d33f9-37de-4b8d-863e-9f73cd8dcec1
+        :id: bd8d33f9-37de-4b8d-863e-9f73cd8dcec1
 
-        @assert: A host is created with expected 'enabled' parameter value
+        :assert: A host is created with expected 'enabled' parameter value
         """
         host = entities.Host(enabled=False).create()
         self.assertEqual(host.enabled, False)
@@ -435,9 +435,9 @@ class HostTestCase(APITestCase):
         Managed flag shows whether the host is managed or unmanaged and
         determines whether some extra parameters are required
 
-        @id: 00dcfaed-6f54-4b6a-a022-9c97fb992324
+        :id: 00dcfaed-6f54-4b6a-a022-9c97fb992324
 
-        @assert: A host is created with expected managed parameter value
+        :assert: A host is created with expected managed parameter value
         """
         host = entities.Host(managed=True).create()
         self.assertEqual(host.managed, True)
@@ -447,9 +447,9 @@ class HostTestCase(APITestCase):
     def test_positive_create_with_comment(self):
         """Create a host with a comment
 
-        @id: 9b78663f-139c-4d0b-9115-180624b0d41b
+        :id: 9b78663f-139c-4d0b-9115-180624b0d41b
 
-        @assert: A host is created with expected comment
+        :assert: A host is created with expected comment
         """
         for comment in valid_data_list():
             with self.subTest(comment):
@@ -461,11 +461,11 @@ class HostTestCase(APITestCase):
     def test_positive_create_with_compute_profile(self):
         """Create a host with a compute profile specified
 
-        @id: 94be25e8-035d-42c5-b1f3-3aa20030410d
+        :id: 94be25e8-035d-42c5-b1f3-3aa20030410d
 
-        @assert: A host is created with expected compute profile assigned
+        :assert: A host is created with expected compute profile assigned
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         profile = entities.ComputeProfile().create()
         host = entities.Host(compute_profile=profile).create()
@@ -476,11 +476,11 @@ class HostTestCase(APITestCase):
     def test_positive_create_with_content_view(self):
         """Create a host with a content view specified
 
-        @id: 10f69c7a-088e-474c-b869-1ad12deda2ad
+        :id: 10f69c7a-088e-474c-b869-1ad12deda2ad
 
-        @Assert: A host is created with expected content view assigned
+        :Assert: A host is created with expected content view assigned
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         host = entities.Host(
             organization=self.org,
@@ -502,9 +502,9 @@ class HostTestCase(APITestCase):
     def test_positive_create_with_host_parameters(self):
         """Create a host with a host parameters specified
 
-        @id: e3af6718-4016-4756-bbb0-e3c24ac1e340
+        :id: e3af6718-4016-4756-bbb0-e3c24ac1e340
 
-        @Assert: A host is created with expected host parameters
+        :Assert: A host is created with expected host parameters
         """
         parameters = [{
             'name': gen_string('alpha'), 'value': gen_string('alpha')
@@ -527,11 +527,11 @@ class HostTestCase(APITestCase):
     def test_positive_create_with_image(self):
         """Create a host with an image specified
 
-        @id: 38b17b4d-d9d8-4ea1-aa0f-558496b990fc
+        :id: 38b17b4d-d9d8-4ea1-aa0f-558496b990fc
 
-        @Assert: A host is created with expected image
+        :Assert: A host is created with expected image
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         host = entities.Host(
             organization=self.org,
@@ -546,9 +546,9 @@ class HostTestCase(APITestCase):
     def test_positive_create_with_provision_method(self):
         """Create a host with provision method specified
 
-        @id: c2243c30-f70a-4063-a4a4-f67b598a892b
+        :id: c2243c30-f70a-4063-a4a4-f67b598a892b
 
-        @Assert: A host is created with expected provision method
+        :Assert: A host is created with expected provision method
         """
         for method in ['build', 'image']:
             with self.subTest(method):
@@ -566,9 +566,9 @@ class HostTestCase(APITestCase):
     def test_positive_delete(self):
         """Delete a host
 
-        @id: ec725359-a75e-498c-9da8-f5abd2343dd3
+        :id: ec725359-a75e-498c-9da8-f5abd2343dd3
 
-        @assert: Host is deleted
+        :assert: Host is deleted
         """
         host = entities.Host().create()
         host.delete()
@@ -580,9 +580,9 @@ class HostTestCase(APITestCase):
     def test_positive_update_name(self):
         """Update a host with a new name
 
-        @id: a82b606c-d683-44ba-9086-684396ef1c10
+        :id: a82b606c-d683-44ba-9086-684396ef1c10
 
-        @assert: A host is updated with expected name
+        :assert: A host is updated with expected name
         """
         host = entities.Host().create()
         for new_name in valid_hosts_list():
@@ -599,9 +599,9 @@ class HostTestCase(APITestCase):
     def test_positive_update_mac(self):
         """Update a host with a new MAC address
 
-        @id: 72e3b020-7347-4500-8669-c6ddf6dfd0b6
+        :id: 72e3b020-7347-4500-8669-c6ddf6dfd0b6
 
-        @assert: A host is updated with a new MAC address
+        :assert: A host is updated with a new MAC address
         """
         host = entities.Host().create()
         new_mac = gen_mac()
@@ -614,11 +614,11 @@ class HostTestCase(APITestCase):
     def test_positive_update_domain(self):
         """Update a host with a new domain
 
-        @id: 8ca9f67c-4c11-40f9-b434-4f200bad000f
+        :id: 8ca9f67c-4c11-40f9-b434-4f200bad000f
 
-        @assert: A host is updated with a new domain
+        :assert: A host is updated with a new domain
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         host = entities.Host().create()
         new_domain = entities.Domain(
@@ -634,11 +634,11 @@ class HostTestCase(APITestCase):
     def test_positive_update_env(self):
         """Update a host with a new environment
 
-        @id: 87a08dbf-fd4c-4b6c-bf73-98ab70756fc6
+        :id: 87a08dbf-fd4c-4b6c-bf73-98ab70756fc6
 
-        @assert: A host is updated with a new environment
+        :assert: A host is updated with a new environment
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         host = entities.Host().create()
         new_env = entities.Environment(
@@ -654,11 +654,11 @@ class HostTestCase(APITestCase):
     def test_positive_update_arch(self):
         """Update a host with a new architecture
 
-        @id: 5f190b14-e6db-46e1-8cd1-e94e048e6a77
+        :id: 5f190b14-e6db-46e1-8cd1-e94e048e6a77
 
-        @assert: A host is updated with a new architecture
+        :assert: A host is updated with a new architecture
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         host = entities.Host().create()
         new_arch = entities.Architecture(
@@ -673,11 +673,11 @@ class HostTestCase(APITestCase):
     def test_positive_update_os(self):
         """Update a host with a new operating system
 
-        @id: 46edced1-8909-4066-b196-b8e22512341f
+        :id: 46edced1-8909-4066-b196-b8e22512341f
 
-        @assert: A host is updated with a new operating system
+        :assert: A host is updated with a new operating system
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         host = entities.Host().create()
         new_os = entities.OperatingSystem(
@@ -696,11 +696,11 @@ class HostTestCase(APITestCase):
     def test_positive_update_medium(self):
         """Update a host with a new medium
 
-        @id: d81cb65c-48b3-4ce3-971e-51b9dd123697
+        :id: d81cb65c-48b3-4ce3-971e-51b9dd123697
 
-        @assert: A host is updated with a new medium
+        :assert: A host is updated with a new medium
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         host = entities.Host().create()
         new_medium = entities.Media(
@@ -720,9 +720,9 @@ class HostTestCase(APITestCase):
     def test_positive_update_ip(self):
         """Update a host with a new IP address
 
-        @id: 4c009db9-d720-429e-8150-bebf246d3a43
+        :id: 4c009db9-d720-429e-8150-bebf246d3a43
 
-        @assert: A host is updated with a new IP address
+        :assert: A host is updated with a new IP address
         """
         host = entities.Host(ip=gen_ipaddr()).create()
         new_ip = gen_ipaddr()
@@ -735,11 +735,11 @@ class HostTestCase(APITestCase):
     def test_positive_update_hostgroup(self):
         """Update a host with a new hostgroup
 
-        @id: dbe15f9a-242e-40f1-be90-d4f135596790
+        :id: dbe15f9a-242e-40f1-be90-d4f135596790
 
-        @assert: A host is updated with a new hostgroup
+        :assert: A host is updated with a new hostgroup
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         org = entities.Organization().create()
         loc = entities.Location(organization=[org]).create()
@@ -765,9 +765,9 @@ class HostTestCase(APITestCase):
     def test_positive_update_puppet_proxy(self):
         """Update a host with a new puppet proxy
 
-        @id: 98c11e9b-54b0-4f1f-819c-4ff1863457ff
+        :id: 98c11e9b-54b0-4f1f-819c-4ff1863457ff
 
-        @assert: A host is updated with a new puppet proxy
+        :assert: A host is updated with a new puppet proxy
         """
         host = entities.Host().create()
         new_proxy = entities.SmartProxy().search(query={
@@ -782,9 +782,9 @@ class HostTestCase(APITestCase):
     def test_positive_update_puppet_ca_proxy(self):
         """Update a host with a new puppet CA proxy
 
-        @id: 82eacf60-cf89-4035-ad9a-3f78ceb41d39
+        :id: 82eacf60-cf89-4035-ad9a-3f78ceb41d39
 
-        @assert: A host is updated with a new puppet CA proxy
+        :assert: A host is updated with a new puppet CA proxy
         """
         host = entities.Host().create()
         new_proxy = entities.SmartProxy().search(query={
@@ -799,9 +799,9 @@ class HostTestCase(APITestCase):
     def test_positive_update_puppet_class(self):
         """Update a host with a new puppet classes
 
-        @id: 73f9efce-3807-4196-b4e3-a6bfbfe95c99
+        :id: 73f9efce-3807-4196-b4e3-a6bfbfe95c99
 
-        @assert: A host is update with a new puppet classes
+        :assert: A host is update with a new puppet classes
         """
         host = entities.Host(organization=self.org, location=self.loc).create()
         self.assertEqual(len(host.puppetclass), 0)
@@ -818,11 +818,11 @@ class HostTestCase(APITestCase):
     def test_positive_update_subnet(self):
         """Update a host with a new subnet
 
-        @id: c938e6b2-dbc0-4cd2-894a-8f2cc0e31063
+        :id: c938e6b2-dbc0-4cd2-894a-8f2cc0e31063
 
-        @assert: A host is updated with a new subnet
+        :assert: A host is updated with a new subnet
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         org = entities.Organization().create()
         loc = entities.Location(organization=[org]).create()
@@ -848,11 +848,11 @@ class HostTestCase(APITestCase):
     def test_positive_update_compresource(self):
         """Update a host with a new compute resource
 
-        @id: 422f5db1-4eb6-43c2-a908-af9f8b5358f0
+        :id: 422f5db1-4eb6-43c2-a908-af9f8b5358f0
 
-        @assert: A host is updated with a new compute resource
+        :assert: A host is updated with a new compute resource
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         org = entities.Organization().create()
         loc = entities.Location(organization=[org]).create()
@@ -879,11 +879,11 @@ class HostTestCase(APITestCase):
     def test_positive_update_model(self):
         """Update a host with a new model
 
-        @id: da584445-ec24-4bed-82d0-d964bafa49bf
+        :id: da584445-ec24-4bed-82d0-d964bafa49bf
 
-        @assert: A host is updated with a new model
+        :assert: A host is updated with a new model
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         host = entities.Host(model=entities.Model().create()).create()
         new_model = entities.Model().create()
@@ -896,11 +896,11 @@ class HostTestCase(APITestCase):
     def test_positive_update_user(self):
         """Update a host with a new user
 
-        @id: afb3a9d1-61ba-43c4-a00f-a1887441b8d0
+        :id: afb3a9d1-61ba-43c4-a00f-a1887441b8d0
 
-        @assert: A host is updated with a new user
+        :assert: A host is updated with a new user
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         host = entities.Host(
             owner=entities.User().create(),
@@ -916,11 +916,11 @@ class HostTestCase(APITestCase):
     def test_positive_update_usergroup(self):
         """Update a host with a new user group
 
-        @id: a8d702ee-592a-4b5d-9fec-2fa07d3fda1b
+        :id: a8d702ee-592a-4b5d-9fec-2fa07d3fda1b
 
-        @assert: A host is updated with a new user group
+        :assert: A host is updated with a new user group
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         org = entities.Organization().create()
         loc = entities.Location(organization=[org]).create()
@@ -954,9 +954,9 @@ class HostTestCase(APITestCase):
         """Update a host with a new 'build' parameter value.
         Build parameter determines whether to enable the host for provisioning
 
-        @id: f176ebc9-0406-4a7e-8e20-5325808d33db
+        :id: f176ebc9-0406-4a7e-8e20-5325808d33db
 
-        @assert: A host is updated with a new 'build' parameter value
+        :assert: A host is updated with a new 'build' parameter value
         """
         for build in (True, False):
             with self.subTest(build):
@@ -972,9 +972,9 @@ class HostTestCase(APITestCase):
         Enabled parameter determines whether to include the host within
         Satellite 6 reporting
 
-        @id: 8a84e842-3537-46d5-8275-1c593c2171b3
+        :id: 8a84e842-3537-46d5-8275-1c593c2171b3
 
-        @assert: A host is updated with a new 'enabled' parameter value
+        :assert: A host is updated with a new 'enabled' parameter value
         """
         for enabled in (True, False):
             with self.subTest(enabled):
@@ -990,9 +990,9 @@ class HostTestCase(APITestCase):
         Managed flag shows whether the host is managed or unmanaged and
         determines whether some extra parameters are required
 
-        @id: 623064aa-db84-4470-ac13-63f32d9f81b6
+        :id: 623064aa-db84-4470-ac13-63f32d9f81b6
 
-        @assert: A host is updated with a new 'managed' parameter value
+        :assert: A host is updated with a new 'managed' parameter value
         """
         for managed in (True, False):
             with self.subTest(managed):
@@ -1006,9 +1006,9 @@ class HostTestCase(APITestCase):
     def test_positive_update_comment(self):
         """Update a host with a new comment
 
-        @id: ceca20ce-5ecc-4f7f-b920-28b7bd74d351
+        :id: ceca20ce-5ecc-4f7f-b920-28b7bd74d351
 
-        @assert: A host is updated with a new comment
+        :assert: A host is updated with a new comment
         """
         for new_comment in valid_data_list():
             with self.subTest(new_comment):
@@ -1022,11 +1022,11 @@ class HostTestCase(APITestCase):
     def test_positive_update_compute_profile(self):
         """Update a host with a new compute profile
 
-        @id: a634c8a5-11ef-4d92-9df1-1f7e065f162e
+        :id: a634c8a5-11ef-4d92-9df1-1f7e065f162e
 
-        @assert: A host is updated with a new compute profile
+        :assert: A host is updated with a new compute profile
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         host = entities.Host(
             compute_profile=entities.ComputeProfile().create(),
@@ -1041,11 +1041,11 @@ class HostTestCase(APITestCase):
     def test_positive_update_content_view(self):
         """Update a host with a new content view
 
-        @id: f51612fd-cbbc-4f9f-b85b-a4104a0501e5
+        :id: f51612fd-cbbc-4f9f-b85b-a4104a0501e5
 
-        @assert: A host is updated with a new content view
+        :assert: A host is updated with a new content view
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         host = entities.Host(organization=self.org, location=self.loc).create()
         self.assertFalse(hasattr(host, 'content_facet_attributes'))
@@ -1066,9 +1066,9 @@ class HostTestCase(APITestCase):
     def test_positive_update_host_parameters(self):
         """Update a host with a new host parameters
 
-        @id: db0f5731-b0cc-4429-85fb-4032cb43ce4a
+        :id: db0f5731-b0cc-4429-85fb-4032cb43ce4a
 
-        @assert: A host is updated with a new host parameters
+        :assert: A host is updated with a new host parameters
         """
         parameters = [{
             'name': gen_string('alpha'), 'value': gen_string('alpha')
@@ -1090,11 +1090,11 @@ class HostTestCase(APITestCase):
     def test_positive_update_image(self):
         """Update a host with a new image
 
-        @id: e5d8a5b0-7834-4099-9047-8290c7008931
+        :id: e5d8a5b0-7834-4099-9047-8290c7008931
 
-        @assert: A host is updated with a new image
+        :assert: A host is updated with a new image
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         host = entities.Host(organization=self.org, location=self.loc).create()
         host = entities.Host(
@@ -1112,9 +1112,9 @@ class HostTestCase(APITestCase):
     def test_negative_update_name(self):
         """Attempt to update a host with invalid or empty name
 
-        @id: 1c46b44c-a2ea-43a6-b4d9-244101b081e8
+        :id: 1c46b44c-a2ea-43a6-b4d9-244101b081e8
 
-        @assert: A host is not updated
+        :assert: A host is not updated
         """
         host = entities.Host().create()
         for new_name in invalid_values_list():
@@ -1133,9 +1133,9 @@ class HostTestCase(APITestCase):
     def test_negative_update_mac(self):
         """Attempt to update a host with invalid or empty MAC address
 
-        @id: 1954ea4e-e0c2-475f-af67-557e91ebc1e2
+        :id: 1954ea4e-e0c2-475f-af67-557e91ebc1e2
 
-        @assert: A host is not updated
+        :assert: A host is not updated
         """
         host = entities.Host().create()
         for new_mac in invalid_values_list():
@@ -1151,11 +1151,11 @@ class HostTestCase(APITestCase):
         """Attempt to update a host with an architecture, which does not belong
         to host's operating system
 
-        @id: 07b9c0e7-f02b-4aff-99ae-5c203255aba1
+        :id: 07b9c0e7-f02b-4aff-99ae-5c203255aba1
 
-        @assert: A host is not updated
+        :assert: A host is not updated
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         host = entities.Host().create()
         new_arch = entities.Architecture().create()
@@ -1171,11 +1171,11 @@ class HostTestCase(APITestCase):
         """Attempt to update a host with an operating system, which is not
         associated with host's medium
 
-        @id: 40e79f73-6356-4d61-9806-7ade2f4f8829
+        :id: 40e79f73-6356-4d61-9806-7ade2f4f8829
 
-        @assert: A host is not updated
+        :assert: A host is not updated
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         host = entities.Host().create()
         new_os = entities.OperatingSystem(
@@ -1194,22 +1194,19 @@ class HostTestCase(APITestCase):
     def test_positive_create_baremetal_with_bios(self):
         """Create a new Host from provided MAC address
 
-        @id: 9d74ed70-3197-4825-bf96-21eeb4a765f9
+        :id: 9d74ed70-3197-4825-bf96-21eeb4a765f9
 
-        @setup:
+        :setup: Create a PXE-based VM with BIOS boot mode (outside of
+            Satellite).
 
-        1. Create a PXE-based VM with BIOS boot mode (outside of Satellite).
+        :steps: Create a new host using 'BareMetal' option and MAC address of
+            the pre-created VM
 
-        @steps:
+        :assert: Host is created
 
-        1. Create a new host using 'BareMetal' option and MAC address of the
-        pre-created VM
+        :caseautomation: notautomated
 
-        @assert: Host is created
-
-        @caseautomation: notautomated
-
-        @caselevel: System
+        :caselevel: System
         """
 
     @run_only_on('sat')
@@ -1218,22 +1215,19 @@ class HostTestCase(APITestCase):
     def test_positive_create_baremetal_with_uefi(self):
         """Create a new Host from provided MAC address
 
-        @id: 9b852c4d-a94f-4ba9-b666-ea4718320a42
+        :id: 9b852c4d-a94f-4ba9-b666-ea4718320a42
 
-        @setup:
+        :setup: Create a PXE-based VM with UEFI boot mode (outside of
+            Satellite).
 
-        1. Create a PXE-based VM with UEFI boot mode (outside of Satellite).
+        :steps: Create a new host using 'BareMetal' option and MAC address of
+            the pre-created VM
 
-        @steps:
+        :assert: Host is created
 
-        1. Create a new host using 'BareMetal' option and MAC address of the
-        pre-created VM
+        :caseautomation: notautomated
 
-        @assert: Host is created
-
-        @caseautomation: notautomated
-
-        @caselevel: System
+        :caselevel: System
         """
 
     @run_only_on('sat')
@@ -1243,27 +1237,28 @@ class HostTestCase(APITestCase):
         """Provision a new Host and verify the tftp and dhcpd file
         structure is correct
 
-        @id: 0c51c8ad-858c-44e1-8b14-8e0c52c29da1
+        :id: 0c51c8ad-858c-44e1-8b14-8e0c52c29da1
 
-        @steps:
+        :steps:
 
-        1. Associate a pxegrub-type provisioning template with the os
-        2. Create new host (can be fictive bare metal) with the above OS and
-        PXE loader set to Grub UEFI
-        3. Build the host
+            1. Associate a pxegrub-type provisioning template with the os
+            2. Create new host (can be fictive bare metal) with the above OS
+               and PXE loader set to Grub UEFI
+            3. Build the host
 
-        @assert:
-        Verify [/var/lib/tftpboot/] contains the following dir/file structure:
-            grub/bootia32.efi
-            grub/bootx64.efi
-            grub/01-AA-BB-CC-DD-EE-FF
-            grub/efidefault
-            grub/shim.efi
-        and record in /var/lib/dhcpd/dhcpd.leases points to the bootloader
+        :assert:
+            Verify [/var/lib/tftpboot/] contains the following dir/file
+            structure:
+                grub/bootia32.efi
+                grub/bootx64.efi
+                grub/01-AA-BB-CC-DD-EE-FF
+                grub/efidefault
+                grub/shim.efi
+            and record in /var/lib/dhcpd/dhcpd.leases points to the bootloader
 
-        @caseautomation: notautomated
+        :caseautomation: notautomated
 
-        @caselevel: System
+        :caselevel: System
         """
 
     @run_only_on('sat')
@@ -1273,27 +1268,27 @@ class HostTestCase(APITestCase):
         """Provision a new Host and verify the tftp and dhcpd file structure is
         correct
 
-        @id: ac4d535f-09bb-49db-b38b-90f9bad5fa19
+        :id: ac4d535f-09bb-49db-b38b-90f9bad5fa19
 
-        @steps:
+        :steps:
 
-        1. Associate a pxegrub-type provisioning template with the os
-        2. Create new host (can be fictive bare metal) with the above OS and
-        PXE loader set to Grub UEFI SecureBoot
-        3. Build the host
+            1. Associate a pxegrub-type provisioning template with the os
+            2. Create new host (can be fictive bare metal) with the above OS
+               and PXE loader set to Grub UEFI SecureBoot
+            3. Build the host
 
-        @assert:
-        Verify [/var/lib/tftpboot/] contains the following dir/file structure:
-            grub/bootia32.efi
-            grub/bootx64.efi
-            grub/01-AA-BB-CC-DD-EE-FF
-            grub/efidefault
-            grub/shim.efi
-        and record in /var/lib/dhcpd/dhcpd.leases points to the bootloader
+        :assert: Verify [/var/lib/tftpboot/] contains the following dir/file
+            structure:
+                grub/bootia32.efi
+                grub/bootx64.efi
+                grub/01-AA-BB-CC-DD-EE-FF
+                grub/efidefault
+                grub/shim.efi
+            and record in /var/lib/dhcpd/dhcpd.leases points to the bootloader
 
-        @caseautomation: notautomated
+        :caseautomation: notautomated
 
-        @caselevel: System
+        :caselevel: System
         """
 
     @run_only_on('sat')
@@ -1303,28 +1298,28 @@ class HostTestCase(APITestCase):
         """Provision a new UEFI Host and verify the tftp and dhcpd file
         structure is correct
 
-        @id: fb951256-e173-4c2a-a812-92db80443cec
+        :id: fb951256-e173-4c2a-a812-92db80443cec
 
-        @steps:
+        :steps:
+            1. Associate a pxegrub-type provisioning template with the os
+            2. Create new host (can be fictive bare metal) with the above OS
+               and PXE loader set to Grub2 UEFI
+            3. Build the host
 
-        1. Associate a pxegrub-type provisioning template with the os
-        2. Create new host (can be fictive bare metal) with the above OS and
-        PXE loader set to Grub2 UEFI
-        3. Build the host
+        :assert:
+            Verify [/var/lib/tftpboot/] contains the following dir/file
+            structure:
+                pxegrub2
+                grub2/grub.cfg-01-aa-bb-cc-dd-ee-ff
+                grub2/grub.cfg
+                grub2/grubx32.efi
+                grub2/grubx64.efi
+                grub/shim.efi
+            and record in /var/lib/dhcpd/dhcpd.leases points to the bootloader
 
-        @assert:
-        Verify [/var/lib/tftpboot/] contains the following dir/file structure:
-            pxegrub2
-            grub2/grub.cfg-01-aa-bb-cc-dd-ee-ff
-            grub2/grub.cfg
-            grub2/grubx32.efi
-            grub2/grubx64.efi
-            grub/shim.efi
-        and record in /var/lib/dhcpd/dhcpd.leases points to the bootloader
+        :caseautomation: notautomated
 
-        @caseautomation: notautomated
-
-        @caselevel: System
+        :caselevel: System
         """
 
     @run_only_on('sat')
@@ -1334,28 +1329,28 @@ class HostTestCase(APITestCase):
         """Provision a new UEFI Host and verify the tftp and dhcpd file
         structure is correct
 
-        @id: c0ea18df-d8c0-403a-b053-f5e500f8e3a3
+        :id: c0ea18df-d8c0-403a-b053-f5e500f8e3a3
 
-        @steps:
+        :steps:
+            1. Associate a pxegrub-type provisioning template with the os
+            2. Create new host (can be fictive bare metal) with the above OS
+               and PXE loader set to Grub2 UEFI SecureBoot
+            3. Build the host
 
-        1. Associate a pxegrub-type provisioning template with the os
-        2. Create new host (can be fictive bare metal) with the above OS and
-        PXE loader set to Grub2 UEFI SecureBoot
-        3. Build the host
+        :assert:
+            Verify [/var/lib/tftpboot/] contains the following dir/file
+            structure:
+                pxegrub2
+                grub2/grub.cfg-01-aa-bb-cc-dd-ee-ff
+                grub2/grub.cfg
+                grub2/grubx32.efi
+                grub2/grubx64.efi
+                grub/shim.efi
+            and record in /var/lib/dhcpd/dhcpd.leases points to the bootloader
 
-        @assert:
-        Verify [/var/lib/tftpboot/] contains the following dir/file structure:
-            pxegrub2
-            grub2/grub.cfg-01-aa-bb-cc-dd-ee-ff
-            grub2/grub.cfg
-            grub2/grubx32.efi
-            grub2/grubx64.efi
-            grub/shim.efi
-        and record in /var/lib/dhcpd/dhcpd.leases points to the bootloader
+        :caseautomation: notautomated
 
-        @caseautomation: notautomated
-
-        @caselevel: System
+        :caselevel: System
         """
 
     @tier1
@@ -1363,11 +1358,11 @@ class HostTestCase(APITestCase):
         """Read a hostgroup created with puppet proxy and inspect server's
         response
 
-        @id: 8825462e-f1dc-4054-b7fb-69c2b10722a2
+        :id: 8825462e-f1dc-4054-b7fb-69c2b10722a2
 
-        @Assert: Field 'puppet_proxy_name' is returned
+        :Assert: Field 'puppet_proxy_name' is returned
 
-        @BZ: 1371900
+        :BZ: 1371900
         """
         proxy = entities.SmartProxy().search(query={
             'search': 'url = https://{0}:9090'.format(settings.server.hostname)
@@ -1381,11 +1376,11 @@ class HostTestCase(APITestCase):
         """Read a hostgroup created with puppet ca proxy and inspect server's
         response
 
-        @id: 8941395f-8040-4705-a981-5da21c47efd1
+        :id: 8941395f-8040-4705-a981-5da21c47efd1
 
-        @Assert: Field 'puppet_ca_proxy_name' is returned
+        :Assert: Field 'puppet_ca_proxy_name' is returned
 
-        @BZ: 1371900
+        :BZ: 1371900
         """
         proxy = entities.SmartProxy().search(query={
             'search': 'url = https://{0}:9090'.format(settings.server.hostname)
@@ -1409,9 +1404,9 @@ class HostInterfaceTestCase(APITestCase):
         """Create an interface with different names and minimal input
         parameters
 
-        @id: a45ee576-bec6-47a6-a018-a00e555eb2ad
+        :id: a45ee576-bec6-47a6-a018-a00e555eb2ad
 
-        @Assert: An interface is created with expected name
+        :Assert: An interface is created with expected name
         """
         for name in valid_interfaces_list():
             with self.subTest(name):
@@ -1424,9 +1419,9 @@ class HostInterfaceTestCase(APITestCase):
         """Attempt to create an interface with different invalid entries as
         names (>255 chars, unsupported string types)
 
-        @id: 6fae26d8-8f62-41ba-a1cc-0185137ef70f
+        :id: 6fae26d8-8f62-41ba-a1cc-0185137ef70f
 
-        @Assert: An interface is not created
+        :Assert: An interface is not created
         """
         for name in invalid_interfaces_list():
             with self.subTest(name):
@@ -1438,9 +1433,9 @@ class HostInterfaceTestCase(APITestCase):
     def test_positive_update_name(self):
         """Update interface name with different valid inputs
 
-        @id: c5034b04-097e-47a4-908b-ee78de1699a4
+        :id: c5034b04-097e-47a4-908b-ee78de1699a4
 
-        @Assert: Interface name is successfully updated
+        :Assert: Interface name is successfully updated
         """
         interface = entities.Interface(host=self.host).create()
         for new_name in valid_interfaces_list():
@@ -1454,9 +1449,9 @@ class HostInterfaceTestCase(APITestCase):
         """Attempt to update interface name with different invalid entries
         (>255 chars, unsupported string types)
 
-        @id: 6a1fb718-adfb-47cb-b28c-fb3cd01f99b0
+        :id: 6a1fb718-adfb-47cb-b28c-fb3cd01f99b0
 
-        @Assert: An interface is not updated
+        :Assert: An interface is not updated
         """
         interface = entities.Interface(host=self.host).create()
         for new_name in invalid_interfaces_list():
@@ -1471,9 +1466,9 @@ class HostInterfaceTestCase(APITestCase):
     def test_positive_delete(self):
         """Delete host's interface (not primary)
 
-        @id: 9bf83c3a-a4dc-420e-8d47-8572e5ae1dd6
+        :id: 9bf83c3a-a4dc-420e-8d47-8572e5ae1dd6
 
-        @Assert: An interface is successfully deleted
+        :Assert: An interface is successfully deleted
         """
         host = entities.Host().create()
         interface = entities.Interface(host=host).create()
@@ -1485,9 +1480,9 @@ class HostInterfaceTestCase(APITestCase):
     def test_negative_delete(self):
         """Attempt to delete host's primary interface
 
-        @id: 716a9dfd-0f31-45aa-a6d1-42add032a15c
+        :id: 716a9dfd-0f31-45aa-a6d1-42add032a15c
 
-        @Assert: An interface is not deleted
+        :Assert: An interface is not deleted
         """
         host = entities.Host().create()
         primary_interface = next(
@@ -1510,11 +1505,11 @@ class HostInterfaceTestCase(APITestCase):
         """Delete host's interface (not primary) and make sure the host was not
         accidentally removed altogether with the interface
 
-        @BZ: 1285669
+        :BZ: 1285669
 
-        @id: 3b3e9b3f-cfb2-433f-bd1f-0a8e1d9f0b34
+        :id: 3b3e9b3f-cfb2-433f-bd1f-0a8e1d9f0b34
 
-        @Assert: An interface was successfully deleted, host was not deleted
+        :Assert: An interface was successfully deleted, host was not deleted
         """
         host = entities.Host().create()
         interface = entities.Interface(host=host, primary=False).create()

--- a/tests/foreman/api/test_hostcollection.py
+++ b/tests/foreman/api/test_hostcollection.py
@@ -1,18 +1,18 @@
 """Unit tests for host collections.
 
-@Requirement: Hostcollection
+:Requirement: Hostcollection
 
-@CaseAutomation: Automated
+:CaseAutomation: Automated
 
-@CaseLevel: Acceptance
+:CaseLevel: Acceptance
 
-@CaseComponent: API
+:CaseComponent: API
 
-@TestType: Functional
+:TestType: Functional
 
-@CaseImportance: High
+:CaseImportance: High
 
-@Upstream: No
+:Upstream: No
 """
 from nailgun import entities
 from random import choice
@@ -40,10 +40,10 @@ class HostCollectionTestCase(APITestCase):
     def test_positive_create_with_name(self):
         """Create host collections with different names.
 
-        @id: 8f2b9223-f5be-4cb1-8316-01ea747cae14
+        :id: 8f2b9223-f5be-4cb1-8316-01ea747cae14
 
-        @Assert: The host collection was successfully created and has
-        appropriate name.
+        :Assert: The host collection was successfully created and has
+            appropriate name.
         """
         for name in valid_data_list():
             with self.subTest(name):
@@ -58,12 +58,12 @@ class HostCollectionTestCase(APITestCase):
         """Create new host collection and then retrieve list of all existing
         host collections
 
-        @id: 6ae32df2-b917-4830-8709-15fb272b76c1
+        :id: 6ae32df2-b917-4830-8709-15fb272b76c1
 
-        @BZ: 1331875
+        :BZ: 1331875
 
-        @Assert: Returned list of host collections for the system contains at
-        least one collection
+        :Assert: Returned list of host collections for the system contains at
+            least one collection
         """
         entities.HostCollection(organization=self.org).create()
         hc_list = entities.HostCollection().search()
@@ -74,10 +74,10 @@ class HostCollectionTestCase(APITestCase):
         """Create host collection for specific organization. Retrieve list of
         host collections for that organization
 
-        @id: 5f9de8ab-2c53-401b-add3-57d86c97563a
+        :id: 5f9de8ab-2c53-401b-add3-57d86c97563a
 
-        @Assert: The host collection was successfully created and present in
-        the list of collections for specific organization
+        :Assert: The host collection was successfully created and present in
+            the list of collections for specific organization
         """
         org = entities.Organization().create()
         hc = entities.HostCollection(organization=org).create()
@@ -89,10 +89,10 @@ class HostCollectionTestCase(APITestCase):
     def test_positive_create_with_description(self):
         """Create host collections with different descriptions.
 
-        @id: 9d13392f-8d9d-4ff1-8909-4233e4691055
+        :id: 9d13392f-8d9d-4ff1-8909-4233e4691055
 
-        @Assert: The host collection was successfully created and has
-        appropriate description.
+        :Assert: The host collection was successfully created and has
+            appropriate description.
         """
         for desc in valid_data_list():
             with self.subTest(desc):
@@ -106,10 +106,10 @@ class HostCollectionTestCase(APITestCase):
     def test_positive_create_with_limit(self):
         """Create host collections with different limits.
 
-        @id: 86d9387b-7036-4794-96fd-5a3472dd9160
+        :id: 86d9387b-7036-4794-96fd-5a3472dd9160
 
-        @Assert: The host collection was successfully created and has
-        appropriate limit.
+        :Assert: The host collection was successfully created and has
+            appropriate limit.
         """
         for limit in (1, 3, 5, 10, 20):
             with self.subTest(limit):
@@ -124,10 +124,10 @@ class HostCollectionTestCase(APITestCase):
         """Create host collection with different values of 'unlimited hosts'
         parameter.
 
-        @id: d385574e-5794-4442-b6cd-e5ded001d877
+        :id: d385574e-5794-4442-b6cd-e5ded001d877
 
-        @Assert: The host collection was successfully created and has
-        appropriate 'unlimited hosts' parameter value.
+        :Assert: The host collection was successfully created and has
+            appropriate 'unlimited hosts' parameter value.
         """
         for unlimited in (True, False):
             with self.subTest(unlimited):
@@ -144,10 +144,10 @@ class HostCollectionTestCase(APITestCase):
     def test_positive_create_with_host(self):
         """Create a host collection that contains a host.
 
-        @id: 9dc0ad72-58c2-4079-b1ca-2c4373472f0f
+        :id: 9dc0ad72-58c2-4079-b1ca-2c4373472f0f
 
-        @Assert: The host collection can be read back, and it includes one
-        host.
+        :Assert: The host collection can be read back, and it includes one
+            host.
         """
         host_collection = entities.HostCollection(
             host=[self.hosts[0]],
@@ -160,10 +160,10 @@ class HostCollectionTestCase(APITestCase):
     def test_positive_create_with_hosts(self):
         """Create a host collection that contains hosts.
 
-        @id: bb8d2b42-9a8b-4c4f-ba0c-c56ae5a7eb1d
+        :id: bb8d2b42-9a8b-4c4f-ba0c-c56ae5a7eb1d
 
-        @Assert: The host collection can be read back, and it references two
-        hosts.
+        :Assert: The host collection can be read back, and it references two
+            hosts.
         """
         host_collection = entities.HostCollection(
             host=self.hosts,
@@ -176,11 +176,11 @@ class HostCollectionTestCase(APITestCase):
     def test_positive_add_host(self):
         """Add a host to host collection.
 
-        @id: da8bc901-7ac8-4029-bb62-af21aa4d3a88
+        :id: da8bc901-7ac8-4029-bb62-af21aa4d3a88
 
-        @Assert: Host was added to the host collection.
+        :Assert: Host was added to the host collection.
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         host_collection = entities.HostCollection(
             organization=self.org,
@@ -194,11 +194,11 @@ class HostCollectionTestCase(APITestCase):
     def test_positive_add_hosts(self):
         """Add hosts to host collection.
 
-        @id: f76b4db1-ccd5-47ab-be15-8c7d91d03b22
+        :id: f76b4db1-ccd5-47ab-be15-8c7d91d03b22
 
-        @Assert: Hosts were added to the host collection.
+        :Assert: Hosts were added to the host collection.
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         host_collection = entities.HostCollection(
             organization=self.org,
@@ -212,10 +212,10 @@ class HostCollectionTestCase(APITestCase):
     def test_positive_read_host_ids(self):
         """Read a host collection and look at the ``host_ids`` field.
 
-        @id: 444a1528-64c8-41b6-ba2b-6c49799d5980
+        :id: 444a1528-64c8-41b6-ba2b-6c49799d5980
 
-        @Assert: The ``host_ids`` field matches the host IDs passed in when
-        creating the host collection.
+        :Assert: The ``host_ids`` field matches the host IDs passed in when
+            creating the host collection.
         """
         host_collection = entities.HostCollection(
             host=self.hosts,
@@ -230,9 +230,9 @@ class HostCollectionTestCase(APITestCase):
     def test_positive_update_name(self):
         """Check if host collection name can be updated
 
-        @id: b2dedb99-6dd7-41be-8aaa-74065c820ac6
+        :id: b2dedb99-6dd7-41be-8aaa-74065c820ac6
 
-        @Assert: Host collection name was successfully updated
+        :Assert: Host collection name was successfully updated
         """
         host_collection = entities.HostCollection(
             organization=self.org).create()
@@ -245,9 +245,9 @@ class HostCollectionTestCase(APITestCase):
     def test_positive_update_description(self):
         """Check if host collection description can be updated
 
-        @id: f8e9bd1c-1525-4b5f-a07c-eb6b6e7aa628
+        :id: f8e9bd1c-1525-4b5f-a07c-eb6b6e7aa628
 
-        @Assert: Host collection description was updated
+        :Assert: Host collection description was updated
         """
         host_collection = entities.HostCollection(
             organization=self.org).create()
@@ -261,9 +261,9 @@ class HostCollectionTestCase(APITestCase):
     def test_positive_update_limit(self):
         """Check if host collection limit can be updated
 
-        @id: 4eda7796-cd81-453b-9b72-4ef84b2c1d8c
+        :id: 4eda7796-cd81-453b-9b72-4ef84b2c1d8c
 
-        @Assert: Host collection limit was updated
+        :Assert: Host collection limit was updated
         """
         host_collection = entities.HostCollection(
             max_hosts=1,
@@ -280,9 +280,9 @@ class HostCollectionTestCase(APITestCase):
     def test_positive_update_unlimited_hosts(self):
         """Check if host collection 'unlimited hosts' parameter can be updated
 
-        @id: 09a3973d-9832-4255-87bf-f9eaeab4aee8
+        :id: 09a3973d-9832-4255-87bf-f9eaeab4aee8
 
-        @Assert: Host collection 'unlimited hosts' parameter was updated
+        :Assert: Host collection 'unlimited hosts' parameter was updated
         """
         random_unlimited = choice([True, False])
         host_collection = entities.HostCollection(
@@ -303,9 +303,9 @@ class HostCollectionTestCase(APITestCase):
     def test_positive_update_host(self):
         """Update host collection's host.
 
-        @id: 23082854-abcf-4085-be9c-a5d155446acb
+        :id: 23082854-abcf-4085-be9c-a5d155446acb
 
-        @Assert: The host collection was updated with a new host.
+        :Assert: The host collection was updated with a new host.
         """
         host_collection = entities.HostCollection(
             host=[self.hosts[0]],
@@ -319,9 +319,9 @@ class HostCollectionTestCase(APITestCase):
     def test_positive_update_hosts(self):
         """Update host collection's hosts.
 
-        @id: 0433b37d-ae16-456f-a51d-c7b800334861
+        :id: 0433b37d-ae16-456f-a51d-c7b800334861
 
-        @Assert: The host collection was updated with new hosts.
+        :Assert: The host collection was updated with new hosts.
         """
         host_collection = entities.HostCollection(
             host=self.hosts,
@@ -343,9 +343,9 @@ class HostCollectionTestCase(APITestCase):
     def test_positive_delete(self):
         """Check if host collection can be deleted
 
-        @id: 13a16cd2-16ce-4966-8c03-5d821edf963b
+        :id: 13a16cd2-16ce-4966-8c03-5d821edf963b
 
-        @Assert: Host collection was successfully deleted
+        :Assert: Host collection was successfully deleted
         """
         host_collection = entities.HostCollection(
             organization=self.org).create()
@@ -357,9 +357,9 @@ class HostCollectionTestCase(APITestCase):
     def test_negative_create_with_invalid_name(self):
         """Try to create host collections with different invalid names
 
-        @id: 38f67d04-a19d-4eab-a577-21b8d62c7389
+        :id: 38f67d04-a19d-4eab-a577-21b8d62c7389
 
-        @Assert: The host collection was not created
+        :Assert: The host collection was not created
         """
         for name in invalid_values_list():
             with self.subTest(name):

--- a/tests/foreman/api/test_hostgroup.py
+++ b/tests/foreman/api/test_hostgroup.py
@@ -1,19 +1,19 @@
 # -*- encoding: utf-8 -*-
 """Tests for the ``hostgroups`` paths.
 
-@Requirement: Hostgroup
+:Requirement: Hostgroup
 
-@CaseAutomation: Automated
+:CaseAutomation: Automated
 
-@CaseLevel: Acceptance
+:CaseLevel: Acceptance
 
-@CaseComponent: API
+:CaseComponent: API
 
-@TestType: Functional
+:TestType: Functional
 
-@CaseImportance: High
+:CaseImportance: High
 
-@Upstream: No
+:Upstream: No
 """
 from fauxfactory import gen_string
 from nailgun import client, entities, entity_fields
@@ -51,12 +51,12 @@ class HostGroupTestCase(APITestCase):
         assigned to it should inherit such puppet class information under
         'all_puppetclasses' field
 
-        @id: 7b840f3d-413c-40bb-9a7d-cd9dad3c0737
+        :id: 7b840f3d-413c-40bb-9a7d-cd9dad3c0737
 
-        @Assert: Host inherited 'all_puppetclasses' details from HostGroup that
-        was used for such Host create procedure
+        :Assert: Host inherited 'all_puppetclasses' details from HostGroup that
+            was used for such Host create procedure
 
-        @CaseLevel: System
+        :CaseLevel: System
         """
         # Creating entities like organization, content view and lifecycle_env
         # with not utf-8 names for easier interaction with puppet environment
@@ -185,9 +185,9 @@ class HostGroupTestCase(APITestCase):
     def test_positive_create_with_name(self):
         """Create a hostgroup with different names
 
-        @id: fd5d353c-fd0c-4752-8a83-8f399b4c3416
+        :id: fd5d353c-fd0c-4752-8a83-8f399b4c3416
 
-        @assert: A hostgroup is created with expected name
+        :assert: A hostgroup is created with expected name
         """
         for name in valid_hostgroups_list():
             with self.subTest(name):
@@ -202,9 +202,9 @@ class HostGroupTestCase(APITestCase):
     def test_positive_clone(self):
         """Create a hostgroup by cloning an existing one
 
-        @id: 44ac8b3b-9cb0-4a9e-ad9b-2c67b2411922
+        :id: 44ac8b3b-9cb0-4a9e-ad9b-2c67b2411922
 
-        @assert: A hostgroup is cloned with same parameters
+        :assert: A hostgroup is cloned with same parameters
         """
         hostgroup = entities.HostGroup(
             location=[self.loc],
@@ -233,11 +233,11 @@ class HostGroupTestCase(APITestCase):
     def test_positive_create_with_parent(self):
         """Create a hostgroup with parent hostgroup specified
 
-        @id: 308d6921-0bf1-4fae-8bcf-7b312208e27c
+        :id: 308d6921-0bf1-4fae-8bcf-7b312208e27c
 
-        @assert: A hostgroup is created with expected parent hostgroup assigned
+        :assert: A hostgroup is created with expected parent hostgroup assigned
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         parent_hostgroup = entities.HostGroup(
             location=[self.loc],
@@ -254,11 +254,11 @@ class HostGroupTestCase(APITestCase):
     def test_positive_create_with_env(self):
         """Create a hostgroup with environment specified
 
-        @id: 528afd01-356a-4082-9e88-a5b2a715a792
+        :id: 528afd01-356a-4082-9e88-a5b2a715a792
 
-        @assert: A hostgroup is created with expected environment assigned
+        :assert: A hostgroup is created with expected environment assigned
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         env = entities.Environment(
             location=[self.loc],
@@ -275,11 +275,11 @@ class HostGroupTestCase(APITestCase):
     def test_positive_create_with_os(self):
         """Create a hostgroup with operating system specified
 
-        @id: ca443d3f-2b99-4f0e-b92e-37c3e9fcc460
+        :id: ca443d3f-2b99-4f0e-b92e-37c3e9fcc460
 
-        @assert: A hostgroup is created with expected operating system assigned
+        :assert: A hostgroup is created with expected operating system assigned
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         arch = entities.Architecture().create()
         ptable = entities.PartitionTable().create()
@@ -300,11 +300,11 @@ class HostGroupTestCase(APITestCase):
     def test_positive_create_with_arch(self):
         """Create a hostgroup with architecture specified
 
-        @id: c2f50b94-fa80-49c9-8279-76cfe458bc74
+        :id: c2f50b94-fa80-49c9-8279-76cfe458bc74
 
-        @assert: A hostgroup is created with expected architecture assigned
+        :assert: A hostgroup is created with expected architecture assigned
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         arch = entities.Architecture().create()
         hostgroup = entities.HostGroup(
@@ -318,11 +318,11 @@ class HostGroupTestCase(APITestCase):
     def test_positive_create_with_media(self):
         """Create a hostgroup with media specified
 
-        @id: b0b93207-a8bc-4af7-8ccd-d0bbf46dc0b0
+        :id: b0b93207-a8bc-4af7-8ccd-d0bbf46dc0b0
 
-        @assert: A hostgroup is created with expected media assigned
+        :assert: A hostgroup is created with expected media assigned
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         arch = entities.Architecture().create()
         ptable = entities.PartitionTable().create()
@@ -349,11 +349,11 @@ class HostGroupTestCase(APITestCase):
     def test_positive_create_with_ptable(self):
         """Create a hostgroup with partition table specified
 
-        @id: f161fd59-fa38-4c4e-a641-489f754d5977
+        :id: f161fd59-fa38-4c4e-a641-489f754d5977
 
-        @assert: A hostgroup is created with expected partition table assigned
+        :assert: A hostgroup is created with expected partition table assigned
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         arch = entities.Architecture().create()
         ptable = entities.PartitionTable().create()
@@ -374,9 +374,9 @@ class HostGroupTestCase(APITestCase):
     def test_positive_create_with_puppet_ca_proxy(self):
         """Create a hostgroup with puppet CA proxy specified
 
-        @id: 5c715ee8-2fd6-42c6-aece-037733f67454
+        :id: 5c715ee8-2fd6-42c6-aece-037733f67454
 
-        @assert: A hostgroup is created with expected puppet CA proxy assigned
+        :assert: A hostgroup is created with expected puppet CA proxy assigned
         """
         proxy = entities.SmartProxy().search(query={
             'search': 'url = https://{0}:9090'.format(settings.server.hostname)
@@ -392,11 +392,11 @@ class HostGroupTestCase(APITestCase):
     def test_positive_create_with_subnet(self):
         """Create a hostgroup with subnet specified
 
-        @id: affcaa2e-e22f-4601-97b2-4ca516f6ad2b
+        :id: affcaa2e-e22f-4601-97b2-4ca516f6ad2b
 
-        @assert: A hostgroup is created with expected subnet assigned
+        :assert: A hostgroup is created with expected subnet assigned
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         subnet = entities.Subnet(
             location=[self.loc],
@@ -413,11 +413,11 @@ class HostGroupTestCase(APITestCase):
     def test_positive_create_with_domain(self):
         """Create a hostgroup with domain specified
 
-        @id: 4f4aee5d-1f43-45e6-ac60-0573083dbcee
+        :id: 4f4aee5d-1f43-45e6-ac60-0573083dbcee
 
-        @assert: A hostgroup is created with expected domain assigned
+        :assert: A hostgroup is created with expected domain assigned
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         domain = entities.Domain(
             location=[self.loc],
@@ -435,11 +435,11 @@ class HostGroupTestCase(APITestCase):
     def test_positive_create_with_realm(self):
         """Create a hostgroup with realm specified
 
-        @id: 4f07ff8d-746f-4ab5-ae0b-03d629f6296c
+        :id: 4f07ff8d-746f-4ab5-ae0b-03d629f6296c
 
-        @assert: A hostgroup is created with expected realm assigned
+        :assert: A hostgroup is created with expected realm assigned
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         realm = entities.Realm(
             location=[self.loc],
@@ -460,9 +460,9 @@ class HostGroupTestCase(APITestCase):
     def test_positive_create_with_puppet_proxy(self):
         """Create a hostgroup with puppet proxy specified
 
-        @id: 4f39f246-d12f-468c-a33b-66486c3806fe
+        :id: 4f39f246-d12f-468c-a33b-66486c3806fe
 
-        @assert: A hostgroup is created with expected puppet proxy assigned
+        :assert: A hostgroup is created with expected puppet proxy assigned
         """
         proxy = entities.SmartProxy().search(query={
             'search': 'url = https://{0}:9090'.format(settings.server.hostname)
@@ -478,9 +478,9 @@ class HostGroupTestCase(APITestCase):
     def test_positive_create_with_content_source(self):
         """Create a hostgroup with content source specified
 
-        @id: 39a6273e-8301-449a-a9d3-e3b61cda1e81
+        :id: 39a6273e-8301-449a-a9d3-e3b61cda1e81
 
-        @assert: A hostgroup is created with expected content source assigned
+        :assert: A hostgroup is created with expected content source assigned
         """
         content_source = entities.SmartProxy().search(query={
             'search': 'url = https://{0}:9090'.format(settings.server.hostname)
@@ -497,11 +497,11 @@ class HostGroupTestCase(APITestCase):
     def test_positive_create_with_cv(self):
         """Create a hostgroup with content view specified
 
-        @id: 43dfd2e9-68fe-4682-9cac-61c622c11126
+        :id: 43dfd2e9-68fe-4682-9cac-61c622c11126
 
-        @assert: A hostgroup is created with expected content view assigned
+        :assert: A hostgroup is created with expected content view assigned
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         content_view = entities.ContentView(organization=self.org).create()
         content_view.publish()
@@ -520,12 +520,12 @@ class HostGroupTestCase(APITestCase):
     def test_positive_create_with_lce(self):
         """Create a hostgroup with lifecycle environment specified
 
-        @id: 92215990-0754-429a-8fa2-c47806ece8a6
+        :id: 92215990-0754-429a-8fa2-c47806ece8a6
 
-        @assert: A hostgroup is created with expected lifecycle environment
-        assigned
+        :assert: A hostgroup is created with expected lifecycle environment
+            assigned
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         lce = entities.LifecycleEnvironment(organization=self.org).create()
         hostgroup = entities.HostGroup(
@@ -539,12 +539,12 @@ class HostGroupTestCase(APITestCase):
     def test_positive_create_with_locs(self):
         """Create a hostgroup with multiple locations specified
 
-        @id: 0c2ee2ff-9e7a-4931-8cea-f4eecbd8c4c0
+        :id: 0c2ee2ff-9e7a-4931-8cea-f4eecbd8c4c0
 
-        @assert: A hostgroup is created with expected multiple locations
-        assigned
+        :assert: A hostgroup is created with expected multiple locations
+            assigned
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         locs = [
             entities.Location(organization=[self.org]).create()
@@ -563,12 +563,12 @@ class HostGroupTestCase(APITestCase):
     def test_positive_create_with_orgs(self):
         """Create a hostgroup with multiple organizations specified
 
-        @id: 09642238-cf0d-469a-a0b5-c167b1b8edf5
+        :id: 09642238-cf0d-469a-a0b5-c167b1b8edf5
 
-        @assert: A hostgroup is created with expected multiple organizations
-        assigned
+        :assert: A hostgroup is created with expected multiple organizations
+            assigned
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         orgs = [
             entities.Organization().create()
@@ -585,9 +585,9 @@ class HostGroupTestCase(APITestCase):
     def test_positive_update_name(self):
         """Update a hostgroup with a new name
 
-        @id: 8abb151f-a058-4f47-a1c1-f60a32cd7572
+        :id: 8abb151f-a058-4f47-a1c1-f60a32cd7572
 
-        @assert: A hostgroup is updated with expected name
+        :assert: A hostgroup is updated with expected name
         """
         hostgroup = entities.HostGroup(
             location=[self.loc],
@@ -604,11 +604,11 @@ class HostGroupTestCase(APITestCase):
     def test_positive_update_parent(self):
         """Update a hostgroup with a new parent hostgroup
 
-        @id: 6766d2e6-2305-49db-8db5-8417cf00b0a8
+        :id: 6766d2e6-2305-49db-8db5-8417cf00b0a8
 
-        @assert: A hostgroup is updated with expected parent hostgroup
+        :assert: A hostgroup is updated with expected parent hostgroup
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         parent = entities.HostGroup(
             location=[self.loc],
@@ -632,11 +632,11 @@ class HostGroupTestCase(APITestCase):
     def test_positive_update_env(self):
         """Update a hostgroup with a new environment
 
-        @id: 24f3852d-a94a-4d85-ab7b-afe845832d94
+        :id: 24f3852d-a94a-4d85-ab7b-afe845832d94
 
-        @assert: A hostgroup is updated with expected environment
+        :assert: A hostgroup is updated with expected environment
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         env = entities.Environment(
             location=[self.loc],
@@ -660,11 +660,11 @@ class HostGroupTestCase(APITestCase):
     def test_positive_update_os(self):
         """Update a hostgroup with a new operating system
 
-        @id: c52cdc4f-499b-4a5e-ab7b-a172db42b038
+        :id: c52cdc4f-499b-4a5e-ab7b-a172db42b038
 
-        @assert: A hostgroup is updated with expected operating system
+        :assert: A hostgroup is updated with expected operating system
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         arch = entities.Architecture().create()
         ptable = entities.PartitionTable().create()
@@ -692,11 +692,11 @@ class HostGroupTestCase(APITestCase):
     def test_positive_update_arch(self):
         """Update a hostgroup with a new architecture
 
-        @id: 57890ca6-dec7-43fe-ae4b-336cc2268d01
+        :id: 57890ca6-dec7-43fe-ae4b-336cc2268d01
 
-        @assert: A hostgroup is updated with expected architecture
+        :assert: A hostgroup is updated with expected architecture
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         hostgroup = entities.HostGroup(
             architecture=entities.Architecture().create(),
@@ -713,11 +713,11 @@ class HostGroupTestCase(APITestCase):
     def test_positive_update_media(self):
         """Update a hostgroup with a new media
 
-        @id: 9b6ffbb8-0518-4900-95fd-49fc1d90a4be
+        :id: 9b6ffbb8-0518-4900-95fd-49fc1d90a4be
 
-        @assert: A hostgroup is updated with expected media
+        :assert: A hostgroup is updated with expected media
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         arch = entities.Architecture().create()
         ptable = entities.PartitionTable().create()
@@ -752,11 +752,11 @@ class HostGroupTestCase(APITestCase):
     def test_positive_update_ptable(self):
         """Update a hostgroup with a new partition table
 
-        @id: 95fccc76-33c6-45a3-842e-61917cce40fc
+        :id: 95fccc76-33c6-45a3-842e-61917cce40fc
 
-        @assert: A hostgroup is updated with expected partition table
+        :assert: A hostgroup is updated with expected partition table
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         arch = entities.Architecture().create()
         ptable = entities.PartitionTable().create()
@@ -783,9 +783,9 @@ class HostGroupTestCase(APITestCase):
     def test_positive_update_puppet_ca_proxy(self):
         """Update a hostgroup with a new puppet CA proxy
 
-        @id: fd13ab0e-1a5b-48a0-a852-3fff8306271f
+        :id: fd13ab0e-1a5b-48a0-a852-3fff8306271f
 
-        @assert: A hostgroup is updated with expected puppet CA proxy
+        :assert: A hostgroup is updated with expected puppet CA proxy
         """
         hostgroup = entities.HostGroup(
             location=[self.loc],
@@ -803,11 +803,11 @@ class HostGroupTestCase(APITestCase):
     def test_positive_update_subnet(self):
         """Update a hostgroup with a new subnet
 
-        @id: 2b539fd9-5fcf-4d74-9cd8-3b3997bac992
+        :id: 2b539fd9-5fcf-4d74-9cd8-3b3997bac992
 
-        @assert: A hostgroup is updated with expected subnet
+        :assert: A hostgroup is updated with expected subnet
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         subnet = entities.Subnet(
             location=[self.loc],
@@ -831,11 +831,11 @@ class HostGroupTestCase(APITestCase):
     def test_positive_update_domain(self):
         """Update a hostgroup with a new domain
 
-        @id: db7b79e9-a833-4d93-96e2-d9adc9f35c21
+        :id: db7b79e9-a833-4d93-96e2-d9adc9f35c21
 
-        @assert: A hostgroup is updated with expected domain
+        :assert: A hostgroup is updated with expected domain
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         domain = entities.Domain(
             location=[self.loc],
@@ -859,11 +859,11 @@ class HostGroupTestCase(APITestCase):
     def test_positive_update_realm(self):
         """Update a hostgroup with a new realm
 
-        @id: fd9d141f-7a71-4439-92c7-1dbc1eea4772
+        :id: fd9d141f-7a71-4439-92c7-1dbc1eea4772
 
-        @assert: A hostgroup is updated with expected realm
+        :assert: A hostgroup is updated with expected realm
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         realm = entities.Realm(
             location=[self.loc],
@@ -895,9 +895,9 @@ class HostGroupTestCase(APITestCase):
     def test_positive_update_puppet_proxy(self):
         """Update a hostgroup with a new puppet proxy
 
-        @id: 86eca603-2cdd-4563-b6f6-aaa5cea1a723
+        :id: 86eca603-2cdd-4563-b6f6-aaa5cea1a723
 
-        @assert: A hostgroup is updated with expected puppet proxy
+        :assert: A hostgroup is updated with expected puppet proxy
         """
         hostgroup = entities.HostGroup(
             location=[self.loc],
@@ -915,9 +915,9 @@ class HostGroupTestCase(APITestCase):
     def test_positive_update_content_source(self):
         """Update a hostgroup with a new puppet proxy
 
-        @id: 02ef1340-a21e-41b7-8aa7-d6fdea196c16
+        :id: 02ef1340-a21e-41b7-8aa7-d6fdea196c16
 
-        @assert: A hostgroup is updated with expected puppet proxy
+        :assert: A hostgroup is updated with expected puppet proxy
         """
         hostgroup = entities.HostGroup(
             location=[self.loc],
@@ -936,11 +936,11 @@ class HostGroupTestCase(APITestCase):
     def test_positive_update_cv(self):
         """Update a hostgroup with a new content view
 
-        @id: 5fa39bc9-c780-49c5-b580-b973e2d25226
+        :id: 5fa39bc9-c780-49c5-b580-b973e2d25226
 
-        @assert: A hostgroup is updated with expected content view
+        :assert: A hostgroup is updated with expected content view
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         content_view = entities.ContentView(organization=self.org).create()
         content_view.publish()
@@ -966,11 +966,11 @@ class HostGroupTestCase(APITestCase):
     def test_positive_update_lce(self):
         """Update a hostgroup with a new lifecycle environment
 
-        @id: df89d8e3-bd36-4ad9-bde8-1872ae3dd918
+        :id: df89d8e3-bd36-4ad9-bde8-1872ae3dd918
 
-        @assert: A hostgroup is updated with expected lifecycle environment
+        :assert: A hostgroup is updated with expected lifecycle environment
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         lce = entities.LifecycleEnvironment(organization=self.org).create()
         hostgroup = entities.HostGroup(
@@ -989,11 +989,11 @@ class HostGroupTestCase(APITestCase):
     def test_positive_update_loc(self):
         """Update a hostgroup with a new location
 
-        @id: 62d88bb0-34d1-447f-ae69-b2122d8142b4
+        :id: 62d88bb0-34d1-447f-ae69-b2122d8142b4
 
-        @assert: A hostgroup is updated with expected location
+        :assert: A hostgroup is updated with expected location
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         hostgroup = entities.HostGroup(
             location=[self.loc],
@@ -1009,11 +1009,11 @@ class HostGroupTestCase(APITestCase):
     def test_positive_update_org(self):
         """Update a hostgroup with a new organization
 
-        @id: 8f83983b-398f-40e4-8917-47b3205137d7
+        :id: 8f83983b-398f-40e4-8917-47b3205137d7
 
-        @assert: A hostgroup is updated with expected organization
+        :assert: A hostgroup is updated with expected organization
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         hostgroup = entities.HostGroup(
             location=[self.loc],
@@ -1029,11 +1029,11 @@ class HostGroupTestCase(APITestCase):
     def test_positive_update_locs(self):
         """Update a hostgroup with new multiple locations
 
-        @id: b045f7e8-d7c0-428b-a29c-8d54e53742e2
+        :id: b045f7e8-d7c0-428b-a29c-8d54e53742e2
 
-        @assert: A hostgroup is updated with expected locations
+        :assert: A hostgroup is updated with expected locations
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         hostgroup = entities.HostGroup(
             location=[self.loc],
@@ -1055,11 +1055,11 @@ class HostGroupTestCase(APITestCase):
     def test_positive_update_orgs(self):
         """Update a hostgroup with new multiple organizations
 
-        @id: 5f6bd4f9-4bd6-4d7e-9a91-de824299020e
+        :id: 5f6bd4f9-4bd6-4d7e-9a91-de824299020e
 
-        @assert: A hostgroup is updated with expected organizations
+        :assert: A hostgroup is updated with expected organizations
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         hostgroup = entities.HostGroup(
             location=[self.loc],
@@ -1080,9 +1080,9 @@ class HostGroupTestCase(APITestCase):
     def test_positive_delete(self):
         """Delete a hostgroup
 
-        @id: bef6841b-5077-4b84-842e-a286bfbb92d2
+        :id: bef6841b-5077-4b84-842e-a286bfbb92d2
 
-        @assert: A hostgroup is deleted
+        :assert: A hostgroup is deleted
         """
         hostgroup = entities.HostGroup(
             location=[self.loc],
@@ -1096,9 +1096,9 @@ class HostGroupTestCase(APITestCase):
     def test_negative_create_with_name(self):
         """Attempt to create a hostgroup with invalid names
 
-        @id: 3f5aa17a-8db9-4fe9-b309-b8ec5e739da1
+        :id: 3f5aa17a-8db9-4fe9-b309-b8ec5e739da1
 
-        @assert: A hostgroup is not created
+        :assert: A hostgroup is not created
         """
         for name in invalid_values_list():
             with self.subTest(name):
@@ -1113,9 +1113,9 @@ class HostGroupTestCase(APITestCase):
     def test_negative_update_name(self):
         """Attempt to update a hostgroup with invalid names
 
-        @id: 6d8c4738-a0c4-472b-9a71-27c8a3832335
+        :id: 6d8c4738-a0c4-472b-9a71-27c8a3832335
 
-        @assert: A hostgroup is not updated
+        :assert: A hostgroup is not updated
         """
         hostgroup = entities.HostGroup(
             location=[self.loc],
@@ -1150,10 +1150,10 @@ class HostGroupMissingAttrTestCase(APITestCase):
     def test_positive_get_content_source(self):
         """Read a host group. Inspect the server's response.
 
-        @id: 9d42f47a-2f08-45ad-97d0-de94f0f1de2f
+        :id: 9d42f47a-2f08-45ad-97d0-de94f0f1de2f
 
-        @Assert: The response contains both values for the ``content_source``
-        field.
+        :Assert: The response contains both values for the ``content_source``
+            field.
         """
         names = one_to_one_names('content_source')
         self.assertTrue(
@@ -1168,10 +1168,10 @@ class HostGroupMissingAttrTestCase(APITestCase):
     def test_positive_get_cv(self):
         """Read a host group. Inspect the server's response.
 
-        @id: 7d36f33e-f161-4d2a-9ee4-8eb949ed4cbf
+        :id: 7d36f33e-f161-4d2a-9ee4-8eb949ed4cbf
 
-        @Assert: The response contains both values for the ``content_view``
-        field.
+        :Assert: The response contains both values for the ``content_view``
+            field.
         """
         names = one_to_one_names('content_view')
         self.assertTrue(
@@ -1186,10 +1186,10 @@ class HostGroupMissingAttrTestCase(APITestCase):
     def test_positive_get_lce(self):
         """Read a host group. Inspect the server's response.
 
-        @id: efa17f59-47f9-40c6-821d-c348c4d852ff
+        :id: efa17f59-47f9-40c6-821d-c348c4d852ff
 
-        @Assert: The response contains both values for the
-        ``lifecycle_environment`` field.
+        :Assert: The response contains both values for the
+            ``lifecycle_environment`` field.
         """
         names = one_to_one_names('lifecycle_environment')
         self.assertTrue(
@@ -1205,11 +1205,11 @@ class HostGroupMissingAttrTestCase(APITestCase):
         """Read a hostgroup created with puppet proxy and inspect server's
         response
 
-        @id: f93d0866-0073-4577-8777-6d645b63264f
+        :id: f93d0866-0073-4577-8777-6d645b63264f
 
-        @Assert: Field 'puppet_proxy_name' is returned
+        :Assert: Field 'puppet_proxy_name' is returned
 
-        @BZ: 1371900
+        :BZ: 1371900
         """
         proxy = entities.SmartProxy().search(query={
             'search': 'url = https://{0}:9090'.format(settings.server.hostname)
@@ -1223,11 +1223,11 @@ class HostGroupMissingAttrTestCase(APITestCase):
         """Read a hostgroup created with puppet ca proxy and inspect server's
         response
 
-        @id: ab151e09-8e64-4377-95e8-584629750659
+        :id: ab151e09-8e64-4377-95e8-584629750659
 
-        @Assert: Field 'puppet_ca_proxy_name' is returned
+        :Assert: Field 'puppet_ca_proxy_name' is returned
 
-        @BZ: 1371900
+        :BZ: 1371900
         """
         proxy = entities.SmartProxy().search(query={
             'search': 'url = https://{0}:9090'.format(settings.server.hostname)

--- a/tests/foreman/api/test_lifecycleenvironment.py
+++ b/tests/foreman/api/test_lifecycleenvironment.py
@@ -4,19 +4,19 @@ Documentation for these paths is available here:
 http://www.katello.org/docs/api/apidoc/lifecycle_environments.html
 
 
-@Requirement: Lifecycleenvironment
+:Requirement: Lifecycleenvironment
 
-@CaseAutomation: Automated
+:CaseAutomation: Automated
 
-@CaseLevel: Acceptance
+:CaseLevel: Acceptance
 
-@CaseComponent: API
+:CaseComponent: API
 
-@TestType: Functional
+:TestType: Functional
 
-@CaseImportance: High
+:CaseImportance: High
 
-@Upstream: No
+:Upstream: No
 """
 from fauxfactory import gen_string
 from nailgun import entities
@@ -41,9 +41,9 @@ class LifecycleEnvironmentTestCase(APITestCase):
     def test_positive_create_with_name(self):
         """Create lifecycle environment with valid name only
 
-        @id: ec1d985a-6a39-4de6-b635-c803ecedd832
+        :id: ec1d985a-6a39-4de6-b635-c803ecedd832
 
-        @Assert: Lifecycle environment is created and has proper name
+        :Assert: Lifecycle environment is created and has proper name
         """
         for name in valid_data_list():
             with self.subTest(name):
@@ -58,9 +58,9 @@ class LifecycleEnvironmentTestCase(APITestCase):
     def test_positive_create_with_description(self):
         """Create lifecycle environment with valid description
 
-        @id: 0bc05510-afc7-4087-ab75-1065ab5ba1d3
+        :id: 0bc05510-afc7-4087-ab75-1065ab5ba1d3
 
-        @Assert: Lifecycle environment is created and has proper description
+        :Assert: Lifecycle environment is created and has proper description
         """
         description = gen_string('utf8')
         lc_env = entities.LifecycleEnvironment(
@@ -75,9 +75,9 @@ class LifecycleEnvironmentTestCase(APITestCase):
         """Create lifecycle environment with valid name, prior to
         Library
 
-        @id: 66d34781-8210-4282-8b5e-4be811d5c756
+        :id: 66d34781-8210-4282-8b5e-4be811d5c756
 
-        @Assert: Lifecycle environment is created with Library as prior
+        :Assert: Lifecycle environment is created with Library as prior
         """
         lc_env = entities.LifecycleEnvironment(
             organization=self.org,
@@ -89,9 +89,9 @@ class LifecycleEnvironmentTestCase(APITestCase):
     def test_negative_create_with_invalid_name(self):
         """Create lifecycle environment providing an invalid name
 
-        @id: 7e8ea2e6-5927-4e86-8ea8-04c3feb524a6
+        :id: 7e8ea2e6-5927-4e86-8ea8-04c3feb524a6
 
-        @Assert: Lifecycle environment is not created
+        :Assert: Lifecycle environment is not created
         """
         for name in invalid_values_list():
             with self.subTest(name):
@@ -104,9 +104,9 @@ class LifecycleEnvironmentTestCase(APITestCase):
         """Create lifecycle environment providing the initial name, then
         update its name to another valid name.
 
-        @id: b6715e02-f15e-4ab8-8b13-18a3619fee9e
+        :id: b6715e02-f15e-4ab8-8b13-18a3619fee9e
 
-        @Assert: Lifecycle environment is created and updated properly
+        :Assert: Lifecycle environment is created and updated properly
         """
         lc_env = entities.LifecycleEnvironment(organization=self.org).create()
         for new_name in valid_data_list():
@@ -121,11 +121,11 @@ class LifecycleEnvironmentTestCase(APITestCase):
         """Create lifecycle environment providing the initial
         description, then update its description to another one.
 
-        @id: e946b1fc-f79f-4e57-9d4a-3181a276222b
+        :id: e946b1fc-f79f-4e57-9d4a-3181a276222b
 
-        @Assert: Lifecycle environment is created and updated properly
+        :Assert: Lifecycle environment is created and updated properly
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         lc_env = entities.LifecycleEnvironment(
             organization=self.org,
@@ -141,10 +141,10 @@ class LifecycleEnvironmentTestCase(APITestCase):
     def test_negative_update_name(self):
         """Update lifecycle environment providing an invalid name
 
-        @id: 55723382-9d98-43c8-85fb-df4702ca7478
+        :id: 55723382-9d98-43c8-85fb-df4702ca7478
 
-        @Assert: Lifecycle environment is not updated and corresponding error
-        is raised
+        :Assert: Lifecycle environment is not updated and corresponding error
+            is raised
         """
         name = gen_string('alpha')
         lc_env = entities.LifecycleEnvironment(
@@ -163,9 +163,9 @@ class LifecycleEnvironmentTestCase(APITestCase):
     def test_positive_delete(self):
         """Create lifecycle environment and then delete it.
 
-        @id: cd5a97ca-c1e8-41c7-8d6b-f908916b24e1
+        :id: cd5a97ca-c1e8-41c7-8d6b-f908916b24e1
 
-        @Assert: Lifecycle environment is deleted successfully
+        :Assert: Lifecycle environment is deleted successfully
         """
         lc_env = entities.LifecycleEnvironment(organization=self.org).create()
         lc_env.delete()
@@ -177,18 +177,18 @@ class LifecycleEnvironmentTestCase(APITestCase):
     def test_positive_search_in_org(self):
         """Search for a lifecycle environment and specify an org ID.
 
-        @id: 110e4777-c374-4365-b676-b1db4552fe51
+        :id: 110e4777-c374-4365-b676-b1db4552fe51
 
-        @Steps:
+        :Steps:
 
-        1. Create an organization.
-        2. Create a lifecycle environment belonging to the organization.
-        3. Search for lifecycle environments in the organization.
+            1. Create an organization.
+            2. Create a lifecycle environment belonging to the organization.
+            3. Search for lifecycle environments in the organization.
 
-        @Assert: Only "Library" and the lifecycle environment just created are
-        in the search results.
+        :Assert: Only "Library" and the lifecycle environment just created are
+            in the search results.
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         org = entities.Organization().create()
         lc_env = entities.LifecycleEnvironment(organization=org).create()
@@ -205,23 +205,20 @@ class LifecycleEnvironmentTestCase(APITestCase):
         """Verify that no error is thrown when creating an evironment after
         registering a host to Library.
 
-        @id: ceedf88d-1ad1-47ff-aab1-04587a8121ee
+        :id: ceedf88d-1ad1-47ff-aab1-04587a8121ee
 
-        @BZ: 1348727
+        :BZ: 1348727
 
-        @Setup:
+        :Setup:
+            1. Create an organization.
+            2. Create a new content host.
+            3. Register the content host to the Library environment.
 
-        1. Create an organization.
-        2. Create a new content host.
-        3. Register the content host to the Library environment.
+        :Steps: Create a new environment.
 
-        @Steps:
+        :Assert: The environment is created without any errors.
 
-        1. Create a new environment.
+        :CaseLevel: Integration
 
-        @Assert: The environment is created without any errors.
-
-        @CaseLevel: Integration
-
-        @caseautomation: notautomated
+        :caseautomation: notautomated
         """

--- a/tests/foreman/api/test_location.py
+++ b/tests/foreman/api/test_location.py
@@ -4,19 +4,19 @@ A full API reference for locations can be found here:
 http://theforeman.org/api/apidoc/v2/locations.html
 
 
-@Requirement: Location
+:Requirement: Location
 
-@CaseAutomation: Automated
+:CaseAutomation: Automated
 
-@CaseLevel: Acceptance
+:CaseLevel: Acceptance
 
-@CaseComponent: API
+:CaseComponent: API
 
-@TestType: Functional
+:TestType: Functional
 
-@CaseImportance: High
+:CaseImportance: High
 
-@Upstream: No
+:Upstream: No
 """
 from fauxfactory import gen_integer, gen_string
 from nailgun import entities
@@ -57,10 +57,10 @@ class LocationTestCase(APITestCase):
     def test_positive_create_with_name(self):
         """Create new locations using different inputs as a name
 
-        @id: 90bb90a3-120f-4ea6-89a9-62757be42486
+        :id: 90bb90a3-120f-4ea6-89a9-62757be42486
 
-        @Assert: Location created successfully and has expected and correct
-        name
+        :Assert: Location created successfully and has expected and correct
+            name
         """
         for name in valid_loc_data_list():
             with self.subTest(name):
@@ -71,10 +71,10 @@ class LocationTestCase(APITestCase):
     def test_positive_create_with_description(self):
         """Create new location with custom description
 
-        @id: 8d82fe06-895d-4c99-87c0-354124e013fd
+        :id: 8d82fe06-895d-4c99-87c0-354124e013fd
 
-        @Assert: Location created successfully and has expected and correct
-        description
+        :Assert: Location created successfully and has expected and correct
+            description
         """
         description = gen_string('utf8')
         location = entities.Location(description=description).create()
@@ -84,12 +84,12 @@ class LocationTestCase(APITestCase):
     def test_positive_create_with_user(self):
         """Create new location with assigned user to it
 
-        @id: d3798742-c05d-4864-8eca-44872b4afdbf
+        :id: d3798742-c05d-4864-8eca-44872b4afdbf
 
-        @Assert: Location created successfully and has correct user assigned to
-        it with expected login name
+        :Assert: Location created successfully and has correct user assigned to
+            it with expected login name
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         user = entities.User().create()
         location = entities.Location(user=[user]).create()
@@ -101,12 +101,12 @@ class LocationTestCase(APITestCase):
         """Create new location with Libvirt compute resource assigned to
         it
 
-        @id: 292033fd-9a13-4537-ad10-095ba621d66b
+        :id: 292033fd-9a13-4537-ad10-095ba621d66b
 
-        @Assert: Location created successfully and has correct Libvirt compute
-        resource assigned to it
+        :Assert: Location created successfully and has correct Libvirt compute
+            resource assigned to it
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         test_cr = entities.LibvirtComputeResource().create()
         location = entities.Location(compute_resource=[test_cr]).create()
@@ -119,12 +119,12 @@ class LocationTestCase(APITestCase):
         """Create new location with Docker compute resource assigned to
         it
 
-        @id: 0c55292b-d6ff-45e3-a065-d6a2c8ba2469
+        :id: 0c55292b-d6ff-45e3-a065-d6a2c8ba2469
 
-        @Assert: Location created successfully and has correct Docker compute
-        resource assigned to it
+        :Assert: Location created successfully and has correct Docker compute
+            resource assigned to it
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         test_cr = entities.DockerComputeResource().create()
         location = entities.Location(compute_resource=[test_cr]).create()
@@ -136,12 +136,12 @@ class LocationTestCase(APITestCase):
     def test_positive_create_with_template(self):
         """Create new location with config template assigned to it
 
-        @id: bf2daa6b-6478-472d-89f1-bfa74a75c349
+        :id: bf2daa6b-6478-472d-89f1-bfa74a75c349
 
-        @Assert: Location created successfully and list of config templates
-        assigned to that location should contain expected one
+        :Assert: Location created successfully and list of config templates
+            assigned to that location should contain expected one
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         template = entities.ConfigTemplate().create()
         location = entities.Location(config_template=[template]).create()
@@ -155,12 +155,12 @@ class LocationTestCase(APITestCase):
     def test_positive_create_with_domain(self):
         """Create new location with assigned domain to it
 
-        @id: 3f79a584-e195-4f1d-a978-777bae200251
+        :id: 3f79a584-e195-4f1d-a978-777bae200251
 
-        @Assert: Location created successfully and has correct and expected
-        domain assigned to it
+        :Assert: Location created successfully and has correct and expected
+            domain assigned to it
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         domain = entities.Domain().create()
         location = entities.Location(domain=[domain]).create()
@@ -170,12 +170,12 @@ class LocationTestCase(APITestCase):
     def test_positive_create_with_subnet(self):
         """Create new location with assigned subnet to it
 
-        @id: d6104c39-02d8-4051-a35b-334d9f260a33
+        :id: d6104c39-02d8-4051-a35b-334d9f260a33
 
-        @Assert: Location created successfully and has correct subnet with
-        expected network address assigned to it
+        :Assert: Location created successfully and has correct subnet with
+            expected network address assigned to it
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         subnet = entities.Subnet().create()
         location = entities.Location(subnet=[subnet]).create()
@@ -186,12 +186,12 @@ class LocationTestCase(APITestCase):
     def test_positive_create_with_env(self):
         """Create new location with assigned environment to it
 
-        @id: ac9cd08d-2033-4758-b4d1-c59a41198e92
+        :id: ac9cd08d-2033-4758-b4d1-c59a41198e92
 
-        @Assert: Location created successfully and has correct and expected
-        environment assigned to it
+        :Assert: Location created successfully and has correct and expected
+            environment assigned to it
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         env = entities.Environment().create()
         location = entities.Location(environment=[env]).create()
@@ -201,12 +201,12 @@ class LocationTestCase(APITestCase):
     def test_positive_create_with_hostgroup(self):
         """Create new location with assigned host group to it
 
-        @id: 154d55f8-41d7-411d-9a35-a2e8c639f144
+        :id: 154d55f8-41d7-411d-9a35-a2e8c639f144
 
-        @Assert: Location created successfully and has correct and expected
-        host group assigned to it
+        :Assert: Location created successfully and has correct and expected
+            host group assigned to it
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         host_group = entities.HostGroup().create()
         location = entities.Location(hostgroup=[host_group]).create()
@@ -216,12 +216,12 @@ class LocationTestCase(APITestCase):
     def test_positive_create_with_org(self):
         """Create new location with assigned organization to it
 
-        @id: 5032a93f-4b37-4c19-b6d3-26e3a868d0f1
+        :id: 5032a93f-4b37-4c19-b6d3-26e3a868d0f1
 
-        @Assert: Location created successfully and has correct organization
-        assigned to it with expected title
+        :Assert: Location created successfully and has correct organization
+            assigned to it with expected title
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         org = entities.Organization().create()
         location = entities.Location(organization=[org]).create()
@@ -234,12 +234,12 @@ class LocationTestCase(APITestCase):
         assigned to it can be created in the system. Organizations were chosen
         for that purpose
 
-        @id: f55ab63f-9c10-4f43-be69-d1f90e26fd51
+        :id: f55ab63f-9c10-4f43-be69-d1f90e26fd51
 
-        @Assert: Location created successfully and has correct organizations
-        assigned to it
+        :Assert: Location created successfully and has correct organizations
+            assigned to it
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         orgs_amount = randint(3, 5)
         org_ids = [
@@ -254,12 +254,12 @@ class LocationTestCase(APITestCase):
     def test_positive_create_with_capsule(self):
         """Create new location with assigned capsule to it
 
-        @id: 73f07e4b-b180-4906-8189-e9c0345abc5c
+        :id: 73f07e4b-b180-4906-8189-e9c0345abc5c
 
-        @Assert: Location created successfully and has correct capsule assigned
-        to it
+        :Assert: Location created successfully and has correct capsule assigned
+            to it
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         proxy_id = make_proxy()['id']
         # Add capsule to cleanup list
@@ -277,9 +277,9 @@ class LocationTestCase(APITestCase):
     def test_positive_delete(self):
         """Delete location
 
-        @id: 63691139-45de-4e15-9abb-66c90808cbbb
+        :id: 63691139-45de-4e15-9abb-66c90808cbbb
 
-        @Assert: Location was deleted
+        :Assert: Location was deleted
         """
         location = entities.Location().create()
         location.delete()
@@ -290,9 +290,9 @@ class LocationTestCase(APITestCase):
     def test_negative_create_with_name(self):
         """Attempt to create new location using invalid names only
 
-        @id: 320e6bca-5645-423b-b86a-2b6f35c8dae3
+        :id: 320e6bca-5645-423b-b86a-2b6f35c8dae3
 
-        @Assert: Location is not created and expected error is raised
+        :Assert: Location is not created and expected error is raised
         """
         for name in invalid_values_list():
             with self.subTest(name):
@@ -303,9 +303,9 @@ class LocationTestCase(APITestCase):
     def test_negative_create_with_same_name(self):
         """Attempt to create new location using name of existing entity
 
-        @id: bc09acb3-9ecf-4d23-b3ef-94f24e16e6db
+        :id: bc09acb3-9ecf-4d23-b3ef-94f24e16e6db
 
-        @Assert: Location is not created and expected error is raised
+        :Assert: Location is not created and expected error is raised
         """
         name = gen_string('alphanumeric')
         location = entities.Location(name=name).create()
@@ -317,9 +317,9 @@ class LocationTestCase(APITestCase):
     def test_negative_create_with_domain(self):
         """Attempt to create new location using non-existent domain identifier
 
-        @id: 5449532d-7959-4547-ba05-9e194eea495d
+        :id: 5449532d-7959-4547-ba05-9e194eea495d
 
-        @Assert: Location is not created and expected error is raised
+        :Assert: Location is not created and expected error is raised
         """
         with self.assertRaises(HTTPError):
             entities.Location(domain=[gen_integer(10000, 99999)]).create()
@@ -328,9 +328,9 @@ class LocationTestCase(APITestCase):
     def test_positive_update_name(self):
         """Update location with new name
 
-        @id: 73ff6dab-e12a-4f7d-9c1f-6984fc076329
+        :id: 73ff6dab-e12a-4f7d-9c1f-6984fc076329
 
-        @Assert: Location updated successfully and name was changed
+        :Assert: Location updated successfully and name was changed
         """
         for new_name in valid_loc_data_list():
             with self.subTest(new_name):
@@ -342,9 +342,9 @@ class LocationTestCase(APITestCase):
     def test_positive_update_description(self):
         """Update location with new description
 
-        @id: 1340811a-43db-4aab-93b4-c36e438281a6
+        :id: 1340811a-43db-4aab-93b4-c36e438281a6
 
-        @Assert: Location updated successfully and description was changed
+        :Assert: Location updated successfully and description was changed
         """
         for new_description in valid_loc_data_list():
             with self.subTest(new_description):
@@ -359,11 +359,11 @@ class LocationTestCase(APITestCase):
     def test_positive_update_user(self):
         """Update location with new user
 
-        @id: 83ddb92d-f25d-44c0-87e7-631bdfc1f792
+        :id: 83ddb92d-f25d-44c0-87e7-631bdfc1f792
 
-        @Assert: Location updated successfully and has correct user assigned
+        :Assert: Location updated successfully and has correct user assigned
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         location = entities.Location(user=[entities.User().create()]).create()
         new_user = entities.User().create()
@@ -374,12 +374,12 @@ class LocationTestCase(APITestCase):
     def test_positive_update_libvirt_compresource(self):
         """Update location with new Libvirt compute resource
 
-        @id: 9d0aef06-25dd-4352-8045-00b24b79b514
+        :id: 9d0aef06-25dd-4352-8045-00b24b79b514
 
-        @Assert: Location updated successfully and has correct Libvirt compute
-        resource assigned
+        :Assert: Location updated successfully and has correct Libvirt compute
+            resource assigned
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         location = entities.Location(
             compute_resource=[entities.LibvirtComputeResource().create()],
@@ -397,12 +397,12 @@ class LocationTestCase(APITestCase):
     def test_positive_update_docker_compresource(self):
         """Update location with new Docker compute resource
 
-        @id: 01ee537e-1629-44ab-b8f1-bb9a304050d6
+        :id: 01ee537e-1629-44ab-b8f1-bb9a304050d6
 
-        @Assert: Location updated successfully and has correct Docker compute
-        resource assigned
+        :Assert: Location updated successfully and has correct Docker compute
+            resource assigned
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         location = entities.Location(
             compute_resource=[entities.DockerComputeResource().create()],
@@ -420,12 +420,12 @@ class LocationTestCase(APITestCase):
     def test_positive_update_template(self):
         """Update location with new config template
 
-        @id: 9c8a1306-b0c7-4f72-8a31-4ff441bf5c75
+        :id: 9c8a1306-b0c7-4f72-8a31-4ff441bf5c75
 
-        @Assert: Location updated successfully and has correct config template
-        assigned
+        :Assert: Location updated successfully and has correct config template
+            assigned
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         location = entities.Location(
             config_template=[entities.ConfigTemplate().create()],
@@ -444,11 +444,11 @@ class LocationTestCase(APITestCase):
     def test_positive_update_domain(self):
         """Update location with new domain
 
-        @id: 1016dfb9-8103-45f1-8738-0579fa9754c1
+        :id: 1016dfb9-8103-45f1-8738-0579fa9754c1
 
-        @Assert: Location updated successfully and has correct domain assigned
+        :Assert: Location updated successfully and has correct domain assigned
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         location = entities.Location(
             domain=[entities.Domain().create()],
@@ -461,11 +461,11 @@ class LocationTestCase(APITestCase):
     def test_positive_update_subnet(self):
         """Update location with new subnet
 
-        @id: 67e5516a-26e2-4d44-9c62-5bb35486cfa7
+        :id: 67e5516a-26e2-4d44-9c62-5bb35486cfa7
 
-        @Assert: Location updated successfully and has correct subnet assigned
+        :Assert: Location updated successfully and has correct subnet assigned
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         location = entities.Location(
             subnet=[entities.Subnet().create()],
@@ -478,12 +478,12 @@ class LocationTestCase(APITestCase):
     def test_positive_update_env(self):
         """Update location with new environment
 
-        @id: 900a2441-4897-4e44-b8e4-bf7a956292ac
+        :id: 900a2441-4897-4e44-b8e4-bf7a956292ac
 
-        @Assert: Location updated successfully and has correct environment
-        assigned
+        :Assert: Location updated successfully and has correct environment
+            assigned
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         location = entities.Location(
             environment=[entities.Environment().create()],
@@ -499,12 +499,12 @@ class LocationTestCase(APITestCase):
     def test_positive_update_hostgroup(self):
         """Update location with new host group
 
-        @id: 8f3f4569-8f96-46e2-bd01-7712bb9fa4f6
+        :id: 8f3f4569-8f96-46e2-bd01-7712bb9fa4f6
 
-        @Assert: Location updated successfully and has correct host group
-        assigned
+        :Assert: Location updated successfully and has correct host group
+            assigned
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         location = entities.Location(
             hostgroup=[entities.HostGroup().create()],
@@ -520,12 +520,12 @@ class LocationTestCase(APITestCase):
     def test_positive_update_org(self):
         """Update location with new organization
 
-        @id: 4791027f-f236-4152-ba20-b8f9624316c5
+        :id: 4791027f-f236-4152-ba20-b8f9624316c5
 
-        @Assert: Location updated successfully and has correct organization
-        assigned
+        :Assert: Location updated successfully and has correct organization
+            assigned
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         location = entities.Location(
             organization=[entities.Organization().create()],
@@ -541,12 +541,12 @@ class LocationTestCase(APITestCase):
     def test_positive_update_orgs(self):
         """Update location with with multiple organizations
 
-        @id: e53a0a93-5c7b-4e5b-99cb-decc123deeb6
+        :id: e53a0a93-5c7b-4e5b-99cb-decc123deeb6
 
-        @Assert: Location created successfully and has correct organizations
-        assigned
+        :Assert: Location created successfully and has correct organizations
+            assigned
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         location = entities.Location(
             organization=[entities.Organization().create()],
@@ -563,11 +563,11 @@ class LocationTestCase(APITestCase):
     def test_positive_update_capsule(self):
         """Update location with new capsule
 
-        @id: 2786146f-f466-4ed8-918a-5f46806558e2
+        :id: 2786146f-f466-4ed8-918a-5f46806558e2
 
-        @Assert: Location updated successfully and has correct capsule assigned
+        :Assert: Location updated successfully and has correct capsule assigned
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         proxy_id_1 = make_proxy()['id']
         proxy_id_2 = make_proxy()['id']
@@ -590,9 +590,9 @@ class LocationTestCase(APITestCase):
     def test_negative_update_name(self):
         """Try to update location using invalid names only
 
-        @id: dd1e2bf5-44a8-4d15-ac4d-ae1dcc84b7fc
+        :id: dd1e2bf5-44a8-4d15-ac4d-ae1dcc84b7fc
 
-        @Assert: Location is not updated
+        :Assert: Location is not updated
         """
         for new_name in invalid_values_list():
             with self.subTest(new_name):
@@ -609,11 +609,11 @@ class LocationTestCase(APITestCase):
         """Try to update existing location with incorrect domain. Use
         domain id
 
-        @id: e26c92f2-42cb-4706-9e03-3e00a134cb9f
+        :id: e26c92f2-42cb-4706-9e03-3e00a134cb9f
 
-        @Assert: Location is not updated
+        :Assert: Location is not updated
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         location = entities.Location(
             domain=[entities.Domain().create()],
@@ -630,11 +630,11 @@ class LocationTestCase(APITestCase):
     def test_positive_remove_capsule(self):
         """Remove a capsule from location
 
-        @id: 43221ef8-054b-4311-8be0-e02f32e30d98
+        :id: 43221ef8-054b-4311-8be0-e02f32e30d98
 
-        @Assert: Capsule was removed successfully
+        :Assert: Capsule was removed successfully
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         proxy_id = make_proxy()['id']
         # Add capsule to cleanup list

--- a/tests/foreman/api/test_media.py
+++ b/tests/foreman/api/test_media.py
@@ -1,18 +1,18 @@
 """Tests for the ``media`` paths.
 
-@Requirement: Media
+:Requirement: Media
 
-@CaseAutomation: Automated
+:CaseAutomation: Automated
 
-@CaseLevel: Acceptance
+:CaseLevel: Acceptance
 
-@CaseComponent: API
+:CaseComponent: API
 
-@TestType: Functional
+:TestType: Functional
 
-@CaseImportance: High
+:CaseImportance: High
 
-@Upstream: No
+:Upstream: No
 """
 import random
 from fauxfactory import gen_string, gen_url
@@ -38,9 +38,9 @@ class MediaTestCase(APITestCase):
     def test_positive_create_with_name(self):
         """Create media with valid name only
 
-        @id: 892b44d5-0f11-4e9d-8ee9-fd5abe0b0a9b
+        :id: 892b44d5-0f11-4e9d-8ee9-fd5abe0b0a9b
 
-        @Assert: Media entity is created and has proper name
+        :Assert: Media entity is created and has proper name
         """
         for name in valid_data_list():
             with self.subTest(name):
@@ -55,9 +55,9 @@ class MediaTestCase(APITestCase):
     def test_positive_create_with_os_family(self):
         """Create media with every OS family possible
 
-        @id: 7885e205-6189-4e71-a6ee-e5ddb077ecee
+        :id: 7885e205-6189-4e71-a6ee-e5ddb077ecee
 
-        @Assert: Media entity is created and has proper OS family assigned
+        :Assert: Media entity is created and has proper OS family assigned
         """
         for os_family in OPERATING_SYSTEMS:
             with self.subTest(os_family):
@@ -72,11 +72,11 @@ class MediaTestCase(APITestCase):
     def test_positive_create_with_location(self):
         """Create media entity assigned to non-default location
 
-        @id: 1c4fa736-c145-46ca-9feb-c4046fc778c6
+        :id: 1c4fa736-c145-46ca-9feb-c4046fc778c6
 
-        @Assert: Media entity is created and has proper location
+        :Assert: Media entity is created and has proper location
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         location = entities.Location().create()
         media = entities.Media(
@@ -90,11 +90,11 @@ class MediaTestCase(APITestCase):
     def test_positive_create_with_os(self):
         """Create media entity assigned to operation system entity
 
-        @id: dec22198-ed07-480c-9306-fa5458baec0b
+        :id: dec22198-ed07-480c-9306-fa5458baec0b
 
-        @Assert: Media entity is created and assigned to expected OS
+        :Assert: Media entity is created and assigned to expected OS
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         os = entities.OperatingSystem().create()
         media = entities.Media(
@@ -108,9 +108,9 @@ class MediaTestCase(APITestCase):
     def test_negative_create_with_invalid_name(self):
         """Try to create media entity providing an invalid name
 
-        @id: 0934f4dc-f674-40fe-a639-035761139c83
+        :id: 0934f4dc-f674-40fe-a639-035761139c83
 
-        @Assert: Media entity is not created
+        :Assert: Media entity is not created
         """
         for name in invalid_values_list():
             with self.subTest(name):
@@ -122,9 +122,9 @@ class MediaTestCase(APITestCase):
     def test_negative_create_with_invalid_url(self):
         """Try to create media entity providing an invalid URL
 
-        @id: ae00b6bb-37ed-459e-b9f7-acc92ed0b262
+        :id: ae00b6bb-37ed-459e-b9f7-acc92ed0b262
 
-        @Assert: Media entity is not created
+        :Assert: Media entity is not created
         """
         with self.assertRaises(HTTPError):
             entities.Media(path_='NON_EXISTENT_URL').create()
@@ -134,9 +134,9 @@ class MediaTestCase(APITestCase):
     def test_negative_create_with_invalid_os_family(self):
         """Try to create media entity providing an invalid OS family
 
-        @id: 368b7eac-8c52-4071-89c0-1946d7101291
+        :id: 368b7eac-8c52-4071-89c0-1946d7101291
 
-        @Assert: Media entity is not created
+        :Assert: Media entity is not created
         """
         with self.assertRaises(HTTPError):
             entities.Media(os_family='NON_EXISTENT_OS').create()
@@ -147,9 +147,9 @@ class MediaTestCase(APITestCase):
         """Create media entity providing the initial name, then update
         its name to another valid name.
 
-        @id: a99c3c27-ad0a-474f-ad80-cb61022618a9
+        :id: a99c3c27-ad0a-474f-ad80-cb61022618a9
 
-        @Assert: Media entity is created and updated properly
+        :Assert: Media entity is created and updated properly
         """
         media = entities.Media(organization=[self.org]).create()
         for new_name in valid_data_list():
@@ -164,11 +164,11 @@ class MediaTestCase(APITestCase):
         """Create media entity providing the initial url path, then
         update that url to another valid one.
 
-        @id: 997fd9f6-4809-4de8-869d-7a4a0bf4c958
+        :id: 997fd9f6-4809-4de8-869d-7a4a0bf4c958
 
-        @Assert: Media entity is created and updated properly
+        :Assert: Media entity is created and updated properly
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         media = entities.Media(organization=[self.org]).create()
         new_url = gen_url(subdomain=gen_string('alpha'))
@@ -181,9 +181,9 @@ class MediaTestCase(APITestCase):
         """Create media entity providing the initial os family, then
         update that operation system to another valid one from the list.
 
-        @id: 4daca3f4-39c9-43ec-92f2-a1e506147d71
+        :id: 4daca3f4-39c9-43ec-92f2-a1e506147d71
 
-        @Assert: Media entity is created and updated properly
+        :Assert: Media entity is created and updated properly
         """
         media = entities.Media(
             organization=[self.org],
@@ -200,9 +200,9 @@ class MediaTestCase(APITestCase):
         """Create media entity providing the initial name, then try to
         update its name to invalid one.
 
-        @id: 1c7d3af1-8cef-454e-80b6-a8e95b5dfa8b
+        :id: 1c7d3af1-8cef-454e-80b6-a8e95b5dfa8b
 
-        @Assert: Media entity is not updated
+        :Assert: Media entity is not updated
         """
         media = entities.Media(organization=[self.org]).create()
         for new_name in invalid_values_list():
@@ -215,9 +215,9 @@ class MediaTestCase(APITestCase):
     def test_negative_update_url(self):
         """Try to update media with invalid url.
 
-        @id: 6832f178-4adc-4bb1-957d-0d8d4fd8d9cd
+        :id: 6832f178-4adc-4bb1-957d-0d8d4fd8d9cd
 
-        @Assert: Media entity is not updated
+        :Assert: Media entity is not updated
         """
         media = entities.Media(organization=[self.org]).create()
         with self.assertRaises(HTTPError):
@@ -229,9 +229,9 @@ class MediaTestCase(APITestCase):
     def test_negative_update_os_family(self):
         """Try to update media with invalid operation system.
 
-        @id: f4c5438d-5f98-40b1-9bc7-c0741e81303a
+        :id: f4c5438d-5f98-40b1-9bc7-c0741e81303a
 
-        @Assert: Media entity is not updated
+        :Assert: Media entity is not updated
         """
         media = entities.Media(organization=[self.org]).create()
         with self.assertRaises(HTTPError):
@@ -243,9 +243,9 @@ class MediaTestCase(APITestCase):
     def test_positive_delete(self):
         """Create new media entity and then delete it.
 
-        @id: 178c8ee2-2f69-41df-a604-e8a9e6c396ab
+        :id: 178c8ee2-2f69-41df-a604-e8a9e6c396ab
 
-        @Assert: Media entity is deleted successfully
+        :Assert: Media entity is deleted successfully
         """
         for name in valid_data_list():
             with self.subTest(name):

--- a/tests/foreman/api/test_multiple_paths.py
+++ b/tests/foreman/api/test_multiple_paths.py
@@ -1,18 +1,18 @@
 """Data-driven unit tests for multiple paths.
 
-@Requirement: Multiple paths
+:Requirement: Multiple paths
 
-@CaseAutomation: Automated
+:CaseAutomation: Automated
 
-@CaseLevel: Acceptance
+:CaseLevel: Acceptance
 
-@CaseComponent: API
+:CaseComponent: API
 
-@TestType: Functional
+:TestType: Functional
 
-@CaseImportance: High
+:CaseImportance: High
 
-@Upstream: No
+:Upstream: No
 """
 import logging
 
@@ -156,9 +156,9 @@ class EntityTestCase(APITestCase):
     def test_positive_get_status_code(self):
         """GET an entity-dependent path.
 
-        @id: 89e4fafe-7780-4be4-acc1-90f7c02a8530
+        :id: 89e4fafe-7780-4be4-acc1-90f7c02a8530
 
-        @Assert: HTTP 200 is returned with an ``application/json`` content-type
+        :Assert: HTTP 200 is returned with an ``application/json`` content-type
         """
         exclude_list = (
             entities.ActivationKey,  # need organization_id or environment_id
@@ -189,9 +189,9 @@ class EntityTestCase(APITestCase):
     def test_negative_get_unauthorized(self):
         """GET an entity-dependent path without credentials.
 
-        @id: 49127c71-55a2-42d1-b418-59229e9bad00
+        :id: 49127c71-55a2-42d1-b418-59229e9bad00
 
-        @Assert: HTTP 401 is returned
+        :Assert: HTTP 401 is returned
         """
         exclude_list = (
             entities.ActivationKey,  # need organization_id or environment_id
@@ -212,9 +212,9 @@ class EntityTestCase(APITestCase):
     def test_positive_post_status_code(self):
         """Issue a POST request and check the returned status code.
 
-        @id: 40247cdd-ad72-4b7b-97c6-583addb1b25a
+        :id: 40247cdd-ad72-4b7b-97c6-583addb1b25a
 
-        @Assert: HTTP 201 is returned with an ``application/json`` content-type
+        :Assert: HTTP 201 is returned with an ``application/json`` content-type
         """
         exclude_list = (
             entities.TemplateKind,  # see comments in class definition
@@ -244,9 +244,9 @@ class EntityTestCase(APITestCase):
     def test_negative_post_unauthorized(self):
         """POST to an entity-dependent path without credentials.
 
-        @id: 2ec82336-5bcc-451a-90ed-9abcecc5a0a8
+        :id: 2ec82336-5bcc-451a-90ed-9abcecc5a0a8
 
-        @Assert: HTTP 401 is returned
+        :Assert: HTTP 401 is returned
         """
         exclude_list = (
             entities.TemplateKind,  # see comments in class definition
@@ -270,9 +270,9 @@ class EntityIdTestCase(APITestCase):
     def test_positive_get_status_code(self):
         """Create an entity and GET it.
 
-        @id: 4fb6cca6-c63f-4d4f-811e-53bf4e6b9752
+        :id: 4fb6cca6-c63f-4d4f-811e-53bf4e6b9752
 
-        @Assert: HTTP 200 is returned with an ``application/json`` content-type
+        :Assert: HTTP 200 is returned with an ``application/json`` content-type
         """
         exclude_list = (
             entities.TemplateKind,  # see comments in class definition
@@ -296,9 +296,9 @@ class EntityIdTestCase(APITestCase):
     def test_positive_put_status_code(self):
         """Issue a PUT request and check the returned status code.
 
-        @id: 1a2186b1-0709-4a73-8199-71114e10afce
+        :id: 1a2186b1-0709-4a73-8199-71114e10afce
 
-        @Assert: HTTP 200 is returned with an ``application/json`` content-type
+        :Assert: HTTP 200 is returned with an ``application/json`` content-type
         """
         exclude_list = (
             entities.TemplateKind,  # see comments in class definition
@@ -334,10 +334,10 @@ class EntityIdTestCase(APITestCase):
         """Issue an HTTP DELETE request and check the returned status
         code.
 
-        @id: bacf4bf2-eb2b-4201-a21c-8d15f5b06e7a
+        :id: bacf4bf2-eb2b-4201-a21c-8d15f5b06e7a
 
-        @Assert: HTTP 200, 202 or 204 is returned with an ``application/json``
-        content-type.
+        :Assert: HTTP 200, 202 or 204 is returned with an ``application/json``
+            content-type.
         """
         exclude_list = (
             entities.TemplateKind,  # see comments in class definition
@@ -383,9 +383,9 @@ class DoubleCheckTestCase(APITestCase):
     def test_positive_put_and_get_requests(self):
         """Update an entity, then read it back.
 
-        @id: f5d3039f-5468-4dd2-8ac9-6e948ef39866
+        :id: f5d3039f-5468-4dd2-8ac9-6e948ef39866
 
-        @Assert: The entity is updated with the given attributes.
+        :Assert: The entity is updated with the given attributes.
         """
         exclude_list = (
             entities.TemplateKind,  # see comments in class definition
@@ -424,9 +424,9 @@ class DoubleCheckTestCase(APITestCase):
     def test_positive_post_and_get_requests(self):
         """Create an entity, then read it back.
 
-        @id: c658095b-2bf9-4c3e-8ddf-c1792e743a10
+        :id: c658095b-2bf9-4c3e-8ddf-c1792e743a10
 
-        @Assert: The entity is created with the given attributes.
+        :Assert: The entity is created with the given attributes.
         """
         exclude_list = (
             entities.TemplateKind,  # see comments in class definition
@@ -451,9 +451,9 @@ class DoubleCheckTestCase(APITestCase):
     def test_positive_delete_and_get_requests(self):
         """Issue an HTTP DELETE request and GET the deleted entity.
 
-        @id: 04a37ba7-c553-40e1-bc4c-ec2ebf567647
+        :id: 04a37ba7-c553-40e1-bc4c-ec2ebf567647
 
-        @Assert: An HTTP 404 is returned when fetching the missing entity.
+        :Assert: An HTTP 404 is returned when fetching the missing entity.
         """
         exclude_list = (
             entities.TemplateKind,  # see comments in class definition
@@ -485,9 +485,9 @@ class EntityReadTestCase(APITestCase):
         """Create an entity and get it using
         ``nailgun.entity_mixins.EntityReadMixin.read``.
 
-        @id: 78bddedd-bbcf-4e26-a9f7-746874f58529
+        :id: 78bddedd-bbcf-4e26-a9f7-746874f58529
 
-        @Assert: The just-read entity is an instance of the correct class.
+        :Assert: The just-read entity is an instance of the correct class.
         """
         exclude_list = (
             entities.Architecture,  # see test_architecture_read
@@ -508,10 +508,10 @@ class EntityReadTestCase(APITestCase):
     def test_positive_architecture_read(self):
         """Create an arch that points to an OS, and read the arch.
 
-        @id: e4c7babe-11d8-4f85-8382-5267a49046e9
+        :id: e4c7babe-11d8-4f85-8382-5267a49046e9
 
-        @Assert: The call to ``Architecture.read`` succeeds, and the response
-        contains the correct operating system ID.
+        :Assert: The call to ``Architecture.read`` succeeds, and the response
+            contains the correct operating system ID.
         """
         os_id = entities.OperatingSystem().create_json()['id']
         arch_id = entities.Architecture(
@@ -526,9 +526,9 @@ class EntityReadTestCase(APITestCase):
         """Create a SyncPlan and read it back using
         ``nailgun.entity_mixins.EntityReadMixin.read``.
 
-        @id: 2a5f53c7-262a-44a6-b7bf-d57fbaef3dc7
+        :id: 2a5f53c7-262a-44a6-b7bf-d57fbaef3dc7
 
-        @Assert: The just-read entity is an instance of the correct class.
+        :Assert: The just-read entity is an instance of the correct class.
         """
         org_id = entities.Organization().create_json()['id']
         syncplan_id = entities.SyncPlan(
@@ -545,9 +545,9 @@ class EntityReadTestCase(APITestCase):
         """Create an OperatingSystemParameter and get it using
         ``nailgun.entity_mixins.EntityReadMixin.read``.
 
-        @id: 1de63937-5ca1-4101-b4ee-4b398c66b630
+        :id: 1de63937-5ca1-4101-b4ee-4b398c66b630
 
-        @Assert: The just-read entity is an instance of the correct class.
+        :Assert: The just-read entity is an instance of the correct class.
         """
         os_id = entities.OperatingSystem().create_json()['id']
         osp_id = entities.OperatingSystemParameter(
@@ -567,10 +567,10 @@ class EntityReadTestCase(APITestCase):
         """Create an Permission entity and get it using
         ``nailgun.entity_mixins.EntityReadMixin.read``.
 
-        @id: 5631a1eb-33ff-4abe-bf01-6c8d98c47a96
+        :id: 5631a1eb-33ff-4abe-bf01-6c8d98c47a96
 
-        @Assert: The just-read entity is an instance of the correct class and
-        name and resource_type fields are populated
+        :Assert: The just-read entity is an instance of the correct class and
+            name and resource_type fields are populated
         """
         perm = entities.Permission().search(query={'per_page': 1})[0]
         self.assertGreater(len(perm.name), 0)
@@ -580,9 +580,9 @@ class EntityReadTestCase(APITestCase):
     def test_positive_media_read(self):
         """Create a media pointing at an OS and read the media.
 
-        @id: 67b656fe-9302-457a-b544-3addb11c85e0
+        :id: 67b656fe-9302-457a-b544-3addb11c85e0
 
-        @Assert: The media points at the correct operating system.
+        :Assert: The media points at the correct operating system.
         """
         os_id = entities.OperatingSystem().create_json()['id']
         media_id = entities.Media(operatingsystem=[os_id]).create_json()['id']

--- a/tests/foreman/api/test_operatingsystem.py
+++ b/tests/foreman/api/test_operatingsystem.py
@@ -6,19 +6,19 @@ References for the relevant paths can be found here:
 * http://theforeman.org/api/apidoc/v2/parameters.html
 
 
-@Requirement: Operatingsystem
+:Requirement: Operatingsystem
 
-@CaseAutomation: Automated
+:CaseAutomation: Automated
 
-@CaseLevel: Acceptance
+:CaseLevel: Acceptance
 
-@CaseComponent: API
+:CaseComponent: API
 
-@TestType: Functional
+:TestType: Functional
 
-@CaseImportance: High
+:CaseImportance: High
 
-@Upstream: No
+:Upstream: No
 """
 import random
 from fauxfactory import gen_string
@@ -39,9 +39,9 @@ class OperatingSystemParameterTestCase(APITestCase):
     def test_verify_bugzilla_1114640(self):
         """Create a parameter for operating system 1.
 
-        @id: e817ae43-226c-44e3-b559-62b8d394047b
+        :id: e817ae43-226c-44e3-b559-62b8d394047b
 
-        @Assert: A parameter is created and can be read afterwards.
+        :Assert: A parameter is created and can be read afterwards.
         """
         # Check whether OS 1 exists.
         os1 = entities.OperatingSystem(id=1).read_raw()
@@ -80,9 +80,9 @@ class OperatingSystemTestCase(APITestCase):
     def test_positive_create_with_name(self):
         """Create operating system with valid name only
 
-        @id: e95707bf-3344-4d85-866f-4642a8f66cff
+        :id: e95707bf-3344-4d85-866f-4642a8f66cff
 
-        @Assert: Operating system entity is created and has proper name
+        :Assert: Operating system entity is created and has proper name
         """
         for name in valid_data_list():
             with self.subTest(name):
@@ -94,10 +94,10 @@ class OperatingSystemTestCase(APITestCase):
     def test_positive_create_with_os_family(self):
         """Create operating system with every OS family possible
 
-        @id: 6ad32d22-53cc-4bab-ac10-f466f75d7cc6
+        :id: 6ad32d22-53cc-4bab-ac10-f466f75d7cc6
 
-        @Assert: Operating system entity is created and has proper OS family
-        assigned
+        :Assert: Operating system entity is created and has proper OS family
+            assigned
         """
         for os_family in OPERATING_SYSTEMS:
             with self.subTest(os_family):
@@ -109,10 +109,10 @@ class OperatingSystemTestCase(APITestCase):
     def test_positive_create_with_minor_version(self):
         """Create operating system with minor version
 
-        @id: fc2e36ca-eb5c-440b-957e-390cd9820945
+        :id: fc2e36ca-eb5c-440b-957e-390cd9820945
 
-        @Assert: Operating system entity is created and has proper minor
-        version
+        :Assert: Operating system entity is created and has proper minor
+            version
         """
         minor_version = gen_string('numeric')
         os = entities.OperatingSystem(minor=minor_version).create()
@@ -124,9 +124,9 @@ class OperatingSystemTestCase(APITestCase):
     def test_verify_bugzilla_1230902(self):
         """Create an operating system with an integer minor version.
 
-        @id: b45e0b94-62f7-45ff-a19e-83c7a0f51339
+        :id: b45e0b94-62f7-45ff-a19e-83c7a0f51339
 
-        @Assert: The minor version can be read back as a string.
+        :Assert: The minor version can be read back as a string.
         """
         minor = int(gen_string('numeric', random.randint(1, 16)))
         operating_sys = entities.OperatingSystem(minor=minor).create()
@@ -137,9 +137,9 @@ class OperatingSystemTestCase(APITestCase):
     def test_positive_create_with_description(self):
         """Create operating system with description
 
-        @id: 980e6411-da11-4fec-ae46-47722367ae40
+        :id: 980e6411-da11-4fec-ae46-47722367ae40
 
-        @Assert: Operating system entity is created and has proper description
+        :Assert: Operating system entity is created and has proper description
         """
         name = gen_string('utf8')
         for desc in valid_data_list():
@@ -154,10 +154,10 @@ class OperatingSystemTestCase(APITestCase):
     def test_positive_create_with_password_hash(self):
         """Create operating system with valid password hash option
 
-        @id: 00830e71-b414-41ab-bc8f-03fd2fbd5a84
+        :id: 00830e71-b414-41ab-bc8f-03fd2fbd5a84
 
-        @Assert: Operating system entity is created and has proper password
-        hash type
+        :Assert: Operating system entity is created and has proper password
+            hash type
         """
         for pass_hash in ['MD5', 'SHA256', 'SHA512']:
             with self.subTest(pass_hash):
@@ -169,12 +169,12 @@ class OperatingSystemTestCase(APITestCase):
     def test_positive_create_with_arch(self):
         """Create an operating system that points at an architecture.
 
-        @id: 6a3f7183-b0bf-4834-8c69-a49fe8d7ee5a
+        :id: 6a3f7183-b0bf-4834-8c69-a49fe8d7ee5a
 
-        @Assert: The operating system is created and points at the given
-        architecture.
+        :Assert: The operating system is created and points at the given
+            architecture.
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         arch = entities.Architecture().create()
         operating_sys = entities.OperatingSystem(architecture=[arch]).create()
@@ -187,12 +187,12 @@ class OperatingSystemTestCase(APITestCase):
         """Create an operating system that points at multiple different
         architectures.
 
-        @id: afd26c6a-bf54-4883-baa5-95f263e6fb36
+        :id: afd26c6a-bf54-4883-baa5-95f263e6fb36
 
-        @Assert: The operating system is created and points at the expected
-        architectures.
+        :Assert: The operating system is created and points at the expected
+            architectures.
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         amount = range(random.randint(3, 5))
         archs = [entities.Architecture().create() for _ in amount]
@@ -208,12 +208,12 @@ class OperatingSystemTestCase(APITestCase):
     def test_positive_create_with_ptable(self):
         """Create an operating system that points at a partition table.
 
-        @id: bef37ff9-d8fa-4518-9073-0518aa9f9a42
+        :id: bef37ff9-d8fa-4518-9073-0518aa9f9a42
 
-        @Assert: The operating system is created and points at the given
-        partition table.
+        :Assert: The operating system is created and points at the given
+            partition table.
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         ptable = entities.PartitionTable().create()
         operating_sys = entities.OperatingSystem(ptable=[ptable]).create()
@@ -226,12 +226,12 @@ class OperatingSystemTestCase(APITestCase):
         """Create an operating system that points at multiple different
         partition tables.
 
-        @id: ed48a279-a222-45ce-81e4-72ae9422482a
+        :id: ed48a279-a222-45ce-81e4-72ae9422482a
 
-        @Assert: The operating system is created and points at the expected
-        partition tables.
+        :Assert: The operating system is created and points at the expected
+            partition tables.
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         amount = range(random.randint(3, 5))
         ptables = [entities.PartitionTable().create() for _ in amount]
@@ -247,11 +247,11 @@ class OperatingSystemTestCase(APITestCase):
     def test_positive_create_with_media(self):
         """Create an operating system that points at a media.
 
-        @id: 56fadee4-c676-48b6-a2db-e6fef9d2a575
+        :id: 56fadee4-c676-48b6-a2db-e6fef9d2a575
 
-        @Assert: The operating system is created and points at the given media.
+        :Assert: The operating system is created and points at the given media.
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         medium = entities.Media(organization=[self.org]).create()
         operating_sys = entities.OperatingSystem(medium=[medium]).create()
@@ -263,12 +263,12 @@ class OperatingSystemTestCase(APITestCase):
     def test_positive_create_with_template(self):
         """Create an operating system that points at a config template.
 
-        @id: df73ecba-5a1c-4201-9c2f-b2e03e8fec25
+        :id: df73ecba-5a1c-4201-9c2f-b2e03e8fec25
 
-        @Assert: The operating system is created and points at the expected
-        config template.
+        :Assert: The operating system is created and points at the expected
+            config template.
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         template = entities.ConfigTemplate(organization=[self.org]).create()
         operating_sys = entities.OperatingSystem(
@@ -282,9 +282,9 @@ class OperatingSystemTestCase(APITestCase):
         """Try to create operating system entity providing an invalid
         name
 
-        @id: cd4286fd-7128-4385-9c8d-ef979c22ee38
+        :id: cd4286fd-7128-4385-9c8d-ef979c22ee38
 
-        @Assert: Operating system entity is not created
+        :Assert: Operating system entity is not created
         """
         for name in invalid_values_list():
             with self.subTest(name):
@@ -297,9 +297,9 @@ class OperatingSystemTestCase(APITestCase):
         """Try to create operating system entity providing an invalid
         operating system family
 
-        @id: 205a433d-750b-4b06-9fd4-274303780d6d
+        :id: 205a433d-750b-4b06-9fd4-274303780d6d
 
-        @Assert: Operating system entity is not created
+        :Assert: Operating system entity is not created
         """
         with self.assertRaises(HTTPError):
             entities.OperatingSystem(family='NON_EXISTENT_OS').create()
@@ -311,11 +311,11 @@ class OperatingSystemTestCase(APITestCase):
         """Try to create operating system entity providing too long
         description value
 
-        @id: fe5fc36a-5994-4d8a-91f6-0425765b8c39
+        :id: fe5fc36a-5994-4d8a-91f6-0425765b8c39
 
-        @Assert: Operating system entity is not created
+        :Assert: Operating system entity is not created
 
-        @BZ: 1328935
+        :BZ: 1328935
         """
         with self.assertRaises(HTTPError):
             entities.OperatingSystem(
@@ -328,9 +328,9 @@ class OperatingSystemTestCase(APITestCase):
         major version value (More than 5 characters, empty value, negative
         number)
 
-        @id: f2646bc2-d639-4079-bdcb-ff76679f1457
+        :id: f2646bc2-d639-4079-bdcb-ff76679f1457
 
-        @Assert: Operating system entity is not created
+        :Assert: Operating system entity is not created
         """
         for major_version in gen_string('numeric', 6), '', '-6':
             with self.subTest(major_version):
@@ -343,9 +343,9 @@ class OperatingSystemTestCase(APITestCase):
         """Try to create operating system entity providing incorrect
         minor version value (More than 16 characters and negative number)
 
-        @id: dec4b456-153c-4a66-8b8e-b12ac7800e51
+        :id: dec4b456-153c-4a66-8b8e-b12ac7800e51
 
-        @Assert: Operating system entity is not created
+        :Assert: Operating system entity is not created
         """
         for minor_version in gen_string('numeric', 17), '-5':
             with self.subTest(minor_version):
@@ -358,9 +358,9 @@ class OperatingSystemTestCase(APITestCase):
         """Try to create operating system entity providing invalid
         password hash value
 
-        @id: 9cfcb6d4-0601-4fc7-bd1e-8b8327129a69
+        :id: 9cfcb6d4-0601-4fc7-bd1e-8b8327129a69
 
-        @Assert: Operating system entity is not created
+        :Assert: Operating system entity is not created
         """
         with self.assertRaises(HTTPError):
             entities.OperatingSystem(password_hash='INVALID_HASH').create()
@@ -372,9 +372,9 @@ class OperatingSystemTestCase(APITestCase):
         version. Then try to create operating system using the same name and
         version
 
-        @id: 3f2ca323-7789-4d2b-bf21-2454317147ff
+        :id: 3f2ca323-7789-4d2b-bf21-2454317147ff
 
-        @Assert: Second operating system entity is not created
+        :Assert: Second operating system entity is not created
         """
         os = entities.OperatingSystem().create()
         with self.assertRaises(HTTPError):
@@ -386,9 +386,9 @@ class OperatingSystemTestCase(APITestCase):
         """Create operating system entity providing the initial name,
         then update its name to another valid name.
 
-        @id: 2898e16a-865a-4de6-b2a5-bb0934fc2b76
+        :id: 2898e16a-865a-4de6-b2a5-bb0934fc2b76
 
-        @Assert: Operating system entity is created and updated properly
+        :Assert: Operating system entity is created and updated properly
         """
         os = entities.OperatingSystem().create()
         for new_name in valid_data_list():
@@ -403,9 +403,9 @@ class OperatingSystemTestCase(APITestCase):
         """Create operating entity providing the initial description,
         then update that description to another valid one.
 
-        @id: c809700a-b6ab-4651-9bd0-d0d9bd6a47dd
+        :id: c809700a-b6ab-4651-9bd0-d0d9bd6a47dd
 
-        @Assert: Operating system entity is created and updated properly
+        :Assert: Operating system entity is created and updated properly
         """
         os = entities.OperatingSystem(description=gen_string('utf8')).create()
         for new_desc in valid_data_list():
@@ -420,9 +420,9 @@ class OperatingSystemTestCase(APITestCase):
         """Create operating entity providing the initial major version,
         then update that version to another valid one.
 
-        @id: e57fd4a3-f0ae-49fb-bd84-9a6ec606a2a2
+        :id: e57fd4a3-f0ae-49fb-bd84-9a6ec606a2a2
 
-        @Assert: Operating system entity is created and updated properly
+        :Assert: Operating system entity is created and updated properly
         """
         os = entities.OperatingSystem().create()
         new_major_version = gen_string('numeric', 5)
@@ -436,9 +436,9 @@ class OperatingSystemTestCase(APITestCase):
         """Create operating entity providing the initial minor version,
         then update that version to another valid one.
 
-        @id: ca36f7cf-4487-4743-be06-52c5f47ffe71
+        :id: ca36f7cf-4487-4743-be06-52c5f47ffe71
 
-        @Assert: Operating system entity is created and updated properly
+        :Assert: Operating system entity is created and updated properly
         """
         os = entities.OperatingSystem(minor=gen_string('numeric')).create()
         new_minor_version = gen_string('numeric')
@@ -452,9 +452,9 @@ class OperatingSystemTestCase(APITestCase):
         """Create operating entity providing the initial os family, then
         update that family to another valid one from the list.
 
-        @id: 3d1f8fdc-d2de-4277-a0ba-07228a2fae82
+        :id: 3d1f8fdc-d2de-4277-a0ba-07228a2fae82
 
-        @Assert: Operating system entity is created and updated properly
+        :Assert: Operating system entity is created and updated properly
         """
         os = entities.OperatingSystem(family=OPERATING_SYSTEMS[0]).create()
         new_os_family = OPERATING_SYSTEMS[
@@ -469,12 +469,12 @@ class OperatingSystemTestCase(APITestCase):
         """Create an operating system that points at an architecture and
         then update it to point to another architecture
 
-        @id: ad69b4a3-6371-4516-b5ce-f6298edf35b3
+        :id: ad69b4a3-6371-4516-b5ce-f6298edf35b3
 
-        @Assert: The operating system is updated and points at the expected
-        architecture.
+        :Assert: The operating system is updated and points at the expected
+            architecture.
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         arch_1 = entities.Architecture().create()
         arch_2 = entities.Architecture().create()
@@ -492,12 +492,12 @@ class OperatingSystemTestCase(APITestCase):
         """Create an operating system that points at partition table and
         then update it to point to another partition table
 
-        @id: 0dde5372-4b90-4c83-b497-31e94065adab
+        :id: 0dde5372-4b90-4c83-b497-31e94065adab
 
-        @Assert: The operating system is updated and points at the expected
-        partition table.
+        :Assert: The operating system is updated and points at the expected
+            partition table.
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         ptable_1 = entities.PartitionTable().create()
         ptable_2 = entities.PartitionTable().create()
@@ -515,12 +515,12 @@ class OperatingSystemTestCase(APITestCase):
         """Create an operating system that points at media entity and
         then update it to point to another media
 
-        @id: 18b5f6b5-52ab-4722-8412-f0de85ad20fe
+        :id: 18b5f6b5-52ab-4722-8412-f0de85ad20fe
 
-        @Assert: The operating system is updated and points at the expected
-        media.
+        :Assert: The operating system is updated and points at the expected
+            media.
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         media_1 = entities.Media(organization=[self.org]).create()
         media_2 = entities.Media(organization=[self.org]).create()
@@ -538,12 +538,12 @@ class OperatingSystemTestCase(APITestCase):
         """Create an operating system that points at media entity and
         then update it to point to another multiple different medias.
 
-        @id: 756c4aa8-278d-488e-b48f-a8d2ace4526e
+        :id: 756c4aa8-278d-488e-b48f-a8d2ace4526e
 
-        @Assert: The operating system is updated and points at the expected
-        medias.
+        :Assert: The operating system is updated and points at the expected
+            medias.
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         initial_media = entities.Media(organization=[self.org]).create()
         os = entities.OperatingSystem(medium=[initial_media]).create()
@@ -565,12 +565,12 @@ class OperatingSystemTestCase(APITestCase):
         """Create an operating system that points at config template and
         then update it to point to another template
 
-        @id: 02125a7a-905a-492a-a49b-768adf4ac00c
+        :id: 02125a7a-905a-492a-a49b-768adf4ac00c
 
-        @Assert: The operating system is updated and points at the expected
-        config template.
+        :Assert: The operating system is updated and points at the expected
+            config template.
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         template_1 = entities.ConfigTemplate(organization=[self.org]).create()
         template_2 = entities.ConfigTemplate(organization=[self.org]).create()
@@ -588,9 +588,9 @@ class OperatingSystemTestCase(APITestCase):
         """Create operating system entity providing the initial name,
         then update its name to invalid one.
 
-        @id: 3ba55d6e-99cb-4878-b41b-a59476d1db58
+        :id: 3ba55d6e-99cb-4878-b41b-a59476d1db58
 
-        @Assert: Operating system entity is not updated
+        :Assert: Operating system entity is not updated
         """
         os = entities.OperatingSystem().create()
         for new_name in invalid_values_list():
@@ -605,9 +605,9 @@ class OperatingSystemTestCase(APITestCase):
         """Create operating entity providing the initial major version,
         then update that version to invalid one.
 
-        @id: de07c2f7-0896-493d-976c-e9f3a8a57025
+        :id: de07c2f7-0896-493d-976c-e9f3a8a57025
 
-        @Assert: Operating system entity is not updated
+        :Assert: Operating system entity is not updated
         """
         os = entities.OperatingSystem().create()
         with self.assertRaises(HTTPError):
@@ -619,9 +619,9 @@ class OperatingSystemTestCase(APITestCase):
         """Create operating entity providing the initial minor version,
         then update that version to invalid one.
 
-        @id: 130d028f-302d-4c20-b35c-c7f024f3897b
+        :id: 130d028f-302d-4c20-b35c-c7f024f3897b
 
-        @Assert: Operating system entity is not updated
+        :Assert: Operating system entity is not updated
         """
         os = entities.OperatingSystem(minor=gen_string('numeric')).create()
         with self.assertRaises(HTTPError):
@@ -634,9 +634,9 @@ class OperatingSystemTestCase(APITestCase):
         """Create operating entity providing the initial os family, then
         update that family to invalid one.
 
-        @id: fc11506e-8a46-470b-bde0-6fc5db98463f
+        :id: fc11506e-8a46-470b-bde0-6fc5db98463f
 
-        @Assert: Operating system entity is not updated
+        :Assert: Operating system entity is not updated
         """
         os = entities.OperatingSystem(family=OPERATING_SYSTEMS[0]).create()
         with self.assertRaises(HTTPError):
@@ -648,9 +648,9 @@ class OperatingSystemTestCase(APITestCase):
     def test_positive_delete(self):
         """Create new operating system entity and then delete it.
 
-        @id: 3dbffb56-ad99-441d-921c-0fad6504d257
+        :id: 3dbffb56-ad99-441d-921c-0fad6504d257
 
-        @Assert: Operating System entity is deleted successfully
+        :Assert: Operating System entity is deleted successfully
         """
         for name in valid_data_list():
             with self.subTest(name):

--- a/tests/foreman/api/test_organization.py
+++ b/tests/foreman/api/test_organization.py
@@ -5,19 +5,19 @@ tested can be found here:
 http://theforeman.org/api/apidoc/v2/organizations.html
 
 
-@Requirement: Organization
+:Requirement: Organization
 
-@CaseAutomation: Automated
+:CaseAutomation: Automated
 
-@CaseLevel: Acceptance
+:CaseLevel: Acceptance
 
-@CaseComponent: API
+:CaseComponent: API
 
-@TestType: Functional
+:TestType: Functional
 
-@CaseImportance: High
+:CaseImportance: High
 
-@Upstream: No
+:Upstream: No
 """
 from fauxfactory import gen_alphanumeric, gen_string
 from nailgun import client, entities
@@ -57,9 +57,9 @@ class OrganizationTestCase(APITestCase):
     def test_positive_create_text_plain(self):
         """Create an organization using a 'text/plain' content-type.
 
-        @id: 6f67a3f0-0c1d-498c-9a35-28207b0faec2
+        :id: 6f67a3f0-0c1d-498c-9a35-28207b0faec2
 
-        @Assert: HTTP 415 is returned.
+        :Assert: HTTP 415 is returned.
         """
         organization = entities.Organization()
         organization.create_missing()
@@ -77,10 +77,10 @@ class OrganizationTestCase(APITestCase):
     def test_positive_create_with_auto_label(self):
         """Create an organization and provide a name.
 
-        @id: c9f69ee5-c6dd-4821-bb05-0d93ffa22460
+        :id: c9f69ee5-c6dd-4821-bb05-0d93ffa22460
 
-        @Assert: The organization has the provided attributes and an
-        auto-generated label.
+        :Assert: The organization has the provided attributes and an
+            auto-generated label.
         """
         org = entities.Organization().create()
         self.assertTrue(hasattr(org, 'label'))
@@ -90,9 +90,9 @@ class OrganizationTestCase(APITestCase):
     def test_positive_create_with_custom_label(self):
         """Create an org and provide a name and identical label.
 
-        @id: f0deab6a-b09b-4110-8575-d4bea945a545
+        :id: f0deab6a-b09b-4110-8575-d4bea945a545
 
-        @Assert: The organization has the provided attributes.
+        :Assert: The organization has the provided attributes.
         """
         # A label has a more restrictive allowable charset than a name, so we
         # use it for populating both name and label.
@@ -107,9 +107,9 @@ class OrganizationTestCase(APITestCase):
     def test_positive_create_with_name_and_label(self):
         """Create an organization and provide a name and label.
 
-        @id: 2bdd9aa8-a36a-4009-ac29-5c3d6416a2b7
+        :id: 2bdd9aa8-a36a-4009-ac29-5c3d6416a2b7
 
-        @Assert: The organization has the provided attributes.
+        :Assert: The organization has the provided attributes.
         """
         org = entities.Organization()
         org.name = name = org.get_fields()['name'].gen_value()
@@ -122,10 +122,10 @@ class OrganizationTestCase(APITestCase):
     def test_positive_create_with_name_and_description(self):
         """Create an organization and provide a name and description.
 
-        @id: afeea84b-61ca-40bf-bb16-476432919115
+        :id: afeea84b-61ca-40bf-bb16-476432919115
 
-        @Assert: The organization has the provided attributes and an
-        auto-generated label.
+        :Assert: The organization has the provided attributes and an
+            auto-generated label.
         """
         for name in valid_org_data_list():
             with self.subTest(name):
@@ -145,9 +145,9 @@ class OrganizationTestCase(APITestCase):
     def test_positive_create_with_name_label_description(self):
         """Create an org and provide a name, label and description.
 
-        @id: f7d92392-751e-45de-91da-5ed2a47afc3f
+        :id: f7d92392-751e-45de-91da-5ed2a47afc3f
 
-        @Assert: The organization has the provided name, label and description.
+        :Assert: The organization has the provided name, label and description.
         """
         org = entities.Organization()
         org.name = name = org.get_fields()['name'].gen_value()
@@ -162,9 +162,9 @@ class OrganizationTestCase(APITestCase):
     def test_negative_create_with_invalid_name(self):
         """Create an org with an incorrect name.
 
-        @id: 9c6a4b45-a98a-4d76-9865-92d992fa1a22
+        :id: 9c6a4b45-a98a-4d76-9865-92d992fa1a22
 
-        @Assert: The organization cannot be created.
+        :Assert: The organization cannot be created.
         """
         for name in invalid_values_list():
             with self.subTest(name):
@@ -175,9 +175,9 @@ class OrganizationTestCase(APITestCase):
     def test_negative_create_with_same_name(self):
         """Create two organizations with identical names.
 
-        @id: a0f5333c-cc83-403c-9bf7-08fb372909dc
+        :id: a0f5333c-cc83-403c-9bf7-08fb372909dc
 
-        @Assert: The second organization cannot be created.
+        :Assert: The second organization cannot be created.
         """
         name = entities.Organization().create().name
         with self.assertRaises(HTTPError):
@@ -187,9 +187,9 @@ class OrganizationTestCase(APITestCase):
     def test_positive_search(self):
         """Create an organization, then search for it by name.
 
-        @id: f6f1d839-21f2-4676-8683-9f899cbdec4c
+        :id: f6f1d839-21f2-4676-8683-9f899cbdec4c
 
-        @Assert: Searching returns at least one result.
+        :Assert: Searching returns at least one result.
         """
         org = entities.Organization().create()
         orgs = entities.Organization().search(
@@ -213,9 +213,9 @@ class OrganizationUpdateTestCase(APITestCase):
     def test_positive_update_name(self):
         """Update an organization's name with valid values.
 
-        @id: 68f2ba13-2538-407c-9f33-2447fca28cd5
+        :id: 68f2ba13-2538-407c-9f33-2447fca28cd5
 
-        @Assert: The organization's name is updated.
+        :Assert: The organization's name is updated.
         """
         for name in valid_org_data_list():
             with self.subTest(name):
@@ -227,9 +227,9 @@ class OrganizationUpdateTestCase(APITestCase):
     def test_positive_update_description(self):
         """Update an organization's description with valid values.
 
-        @id: bd223197-1021-467e-8714-c1a767ae89af
+        :id: bd223197-1021-467e-8714-c1a767ae89af
 
-        @Assert: The organization's description is updated.
+        :Assert: The organization's description is updated.
         """
         for desc in valid_org_data_list():
             with self.subTest(desc):
@@ -241,9 +241,9 @@ class OrganizationUpdateTestCase(APITestCase):
     def test_positive_update_name_and_description(self):
         """Update an organization with new name and description.
 
-        @id: 30036e70-b8fc-4c24-9494-b201bbd1c28d
+        :id: 30036e70-b8fc-4c24-9494-b201bbd1c28d
 
-        @Assert: The organization's name and description are updated.
+        :Assert: The organization's name and description are updated.
         """
         name = gen_string('alpha')
         desc = gen_string('alpha')
@@ -257,11 +257,11 @@ class OrganizationUpdateTestCase(APITestCase):
     def test_positive_update_user(self):
         """Update an organization, associate user with it.
 
-        @id: 2c0c0061-5b4e-4007-9f54-b61d6e65ef58
+        :id: 2c0c0061-5b4e-4007-9f54-b61d6e65ef58
 
-        @Assert: User is associated with organization.
+        :Assert: User is associated with organization.
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         user = entities.User().create()
         self.organization.user = [user]
@@ -273,11 +273,11 @@ class OrganizationUpdateTestCase(APITestCase):
     def test_positive_update_subnet(self):
         """Update an organization, associate subnet with it.
 
-        @id: 3aa0b9cb-37f7-4e7e-a6ec-c1b407225e54
+        :id: 3aa0b9cb-37f7-4e7e-a6ec-c1b407225e54
 
-        @Assert: Subnet is associated with organization.
+        :Assert: Subnet is associated with organization.
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         subnet = entities.Subnet().create()
         self.organization.subnet = [subnet]
@@ -290,11 +290,11 @@ class OrganizationUpdateTestCase(APITestCase):
     def test_positive_add_media(self):
         """Update an organization and associate it with a media.
 
-        @id: 83f085d9-94c0-4462-9780-d29ea4cb5aac
+        :id: 83f085d9-94c0-4462-9780-d29ea4cb5aac
 
-        @Assert: An organization is associated with a media.
+        :Assert: An organization is associated with a media.
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         media = entities.Media().create()
         self.organization.media = [media]
@@ -306,11 +306,11 @@ class OrganizationUpdateTestCase(APITestCase):
     def test_positive_add_hostgroup(self):
         """Add a hostgroup to an organization
 
-        @id: e8c2ccfd-9ae8-4a39-b459-bc5818f54e63
+        :id: e8c2ccfd-9ae8-4a39-b459-bc5818f54e63
 
-        @Assert: Hostgroup is added to organization
+        :Assert: Hostgroup is added to organization
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         org = entities.Organization().create()
         hostgroup = entities.HostGroup().create()
@@ -324,11 +324,11 @@ class OrganizationUpdateTestCase(APITestCase):
     def test_positive_remove_hostgroup(self):
         """Add a hostgroup to an organization and then remove it
 
-        @id: 7eb1aca7-fd7b-404f-ab18-21be5052a11f
+        :id: 7eb1aca7-fd7b-404f-ab18-21be5052a11f
 
-        @Assert: Hostgroup is added to organization and then removed
+        :Assert: Hostgroup is added to organization and then removed
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         org = entities.Organization().create()
         hostgroup = entities.HostGroup().create()
@@ -344,11 +344,11 @@ class OrganizationUpdateTestCase(APITestCase):
     def test_positive_add_smart_proxy(self):
         """Add a smart proxy to an organization
 
-        @id: e21de720-3fa2-429b-bd8e-b6a48a13146d
+        :id: e21de720-3fa2-429b-bd8e-b6a48a13146d
 
-        @Assert: Smart proxy is successfully added to organization
+        :Assert: Smart proxy is successfully added to organization
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         # Every Satellite has a built-in smart proxy, so let's find it
         smart_proxy = entities.SmartProxy().search(query={
@@ -376,11 +376,11 @@ class OrganizationUpdateTestCase(APITestCase):
     def test_positive_remove_smart_proxy(self):
         """Remove a smart proxy from an organization
 
-        @id: 8045910e-d85c-47ee-9aed-ac0a6bbb646b
+        :id: 8045910e-d85c-47ee-9aed-ac0a6bbb646b
 
-        @Assert: Smart proxy is removed from organization
+        :Assert: Smart proxy is removed from organization
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         # By default, newly created organization uses built-in smart proxy,
         # so we can remove it instead of adding and removing some another one
@@ -395,9 +395,9 @@ class OrganizationUpdateTestCase(APITestCase):
     def test_negative_update(self):
         """Update an organization's attributes with invalid values.
 
-        @id: b7152d0b-5ab0-4d68-bfdf-f3eabcb5fbc6
+        :id: b7152d0b-5ab0-4d68-bfdf-f3eabcb5fbc6
 
-        @Assert: The organization's attributes are not updated.
+        :Assert: The organization's attributes are not updated.
         """
         dataset = (
             {'name': gen_string(str_type='utf8', length=256)},
@@ -419,23 +419,23 @@ class OrganizationUpdateTestCase(APITestCase):
         using different transactions and different users to see that they
         actually added, but not overwrite each other
 
-        @id: 5f4fd2b7-d998-4980-b5e7-9822bd54156b
+        :id: 5f4fd2b7-d998-4980-b5e7-9822bd54156b
 
-        @Steps:
+        :Steps:
 
-        1. Use the admin user to create an organization and two compute
-           resources. Make one compute resource point at / belong to the
-           organization.
-        2. Create a user and give them the ability to update compute resources
-           and organizations. Have this user make the second compute resource
-           point at / belong to the organization.
-        3. Use the admin user to read information about the organization.
-           Verify that both compute resources are pointing at / belong to the
-           organization.
+            1. Use the admin user to create an organization and two compute
+               resources. Make one compute resource point at / belong to the
+               organization.
+            2. Create a user and give them the ability to update compute
+               resources and organizations. Have this user make the second
+               compute resource point at / belong to the organization.
+            3. Use the admin user to read information about the organization.
+               Verify that both compute resources are pointing at / belong to
+               the organization.
 
-        @Assert: Organization contains both compute resources
+        :Assert: Organization contains both compute resources
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         # setUpClass() creates an organization w/admin user. Here, we use admin
         # to make two compute resources and make first belong to organization.

--- a/tests/foreman/api/test_partitiontable.py
+++ b/tests/foreman/api/test_partitiontable.py
@@ -4,19 +4,19 @@ A full API reference for patition tables can be found here:
 http://theforeman.org/api/apidoc/v2/ptables.html
 
 
-@Requirement: Partitiontable
+:Requirement: Partitiontable
 
-@CaseAutomation: Automated
+:CaseAutomation: Automated
 
-@CaseLevel: Acceptance
+:CaseLevel: Acceptance
 
-@CaseComponent: API
+:CaseComponent: API
 
-@TestType: Functional
+:TestType: Functional
 
-@CaseImportance: High
+:CaseImportance: High
 
-@Upstream: No
+:Upstream: No
 """
 from fauxfactory import gen_integer
 from nailgun import entities
@@ -40,11 +40,11 @@ class PartitionTableTestCase(APITestCase):
     def test_positive_create_with_one_character_name(self):
         """Create Partition table with 1 character in name
 
-        @id: 71601d96-8ce8-4ecb-b053-af6f26a246ea
+        :id: 71601d96-8ce8-4ecb-b053-af6f26a246ea
 
-        @Assert: Partition table was created
+        :Assert: Partition table was created
 
-        @BZ: 1229384
+        :BZ: 1229384
         """
         for name in generate_strings_list(length=1):
             with self.subTest(name):
@@ -55,9 +55,9 @@ class PartitionTableTestCase(APITestCase):
     def test_positive_create_with_name(self):
         """Create new partition tables using different inputs as a name
 
-        @id: f774051a-8ad4-48dc-b652-0e3c382b6043
+        :id: f774051a-8ad4-48dc-b652-0e3c382b6043
 
-        @Assert: Partition table created successfully and has correct name
+        :Assert: Partition table created successfully and has correct name
         """
         for name in generate_strings_list(length=gen_integer(4, 30)):
             with self.subTest(name):
@@ -69,9 +69,9 @@ class PartitionTableTestCase(APITestCase):
         """Create new partition tables using different inputs as a
         layout
 
-        @id: 12e9d821-415e-4e8b-b4c6-9921c74c1fc5
+        :id: 12e9d821-415e-4e8b-b4c6-9921c74c1fc5
 
-        @Assert: Partition table created successfully and has correct layout
+        :Assert: Partition table created successfully and has correct layout
         """
         for layout in valid_data_list():
             with self.subTest(layout):
@@ -82,10 +82,10 @@ class PartitionTableTestCase(APITestCase):
     def test_positive_create_with_os(self):
         """Create new partition table with random operating system
 
-        @id: ebd55ed6-5fb2-4f17-ac73-b56661ee5254
+        :id: ebd55ed6-5fb2-4f17-ac73-b56661ee5254
 
-        @Assert: Partition table created successfully and has correct operating
-        system
+        :Assert: Partition table created successfully and has correct operating
+            system
         """
         os_family = OPERATING_SYSTEMS[randint(0, 8)]
         ptable = entities.PartitionTable(os_family=os_family).create()
@@ -95,9 +95,9 @@ class PartitionTableTestCase(APITestCase):
     def test_negative_create_with_invalid_name(self):
         """Try to create partition table using invalid names only
 
-        @id: 02631917-2f7a-4cf7-bb2a-783349a04758
+        :id: 02631917-2f7a-4cf7-bb2a-783349a04758
 
-        @Assert: Partition table was not created
+        :Assert: Partition table was not created
         """
         for name in invalid_values_list():
             with self.subTest(name):
@@ -108,9 +108,9 @@ class PartitionTableTestCase(APITestCase):
     def test_negative_create_with_empty_layout(self):
         """Try to create partition table with empty layout
 
-        @id: 03cb7a35-e4c3-4874-841b-0760c3b8d6af
+        :id: 03cb7a35-e4c3-4874-841b-0760c3b8d6af
 
-        @Assert: Partition table was not created
+        :Assert: Partition table was not created
         """
         for layout in ('', ' ', None):
             with self.subTest(layout):
@@ -121,9 +121,9 @@ class PartitionTableTestCase(APITestCase):
     def test_positive_delete(self):
         """Delete partition table
 
-        @id: 36133202-8849-432e-838b-3d13d088ef28
+        :id: 36133202-8849-432e-838b-3d13d088ef28
 
-        @Assert: Partition table was deleted
+        :Assert: Partition table was deleted
         """
         ptable = entities.PartitionTable().create()
         ptable.delete()
@@ -134,9 +134,9 @@ class PartitionTableTestCase(APITestCase):
     def test_positive_update_name(self):
         """Update partition tables with new name
 
-        @id: 8bde5a54-21a8-420e-b6cb-1d81c381d0b2
+        :id: 8bde5a54-21a8-420e-b6cb-1d81c381d0b2
 
-        @Assert: Partition table updated successfully and name was changed
+        :Assert: Partition table updated successfully and name was changed
         """
         ptable = entities.PartitionTable().create()
         for new_name in generate_strings_list(length=gen_integer(4, 30)):
@@ -148,9 +148,9 @@ class PartitionTableTestCase(APITestCase):
     def test_positive_update_layout(self):
         """Update partition table with new layout
 
-        @id: 329eea6e-3474-4cc1-87d4-15e765e0a255
+        :id: 329eea6e-3474-4cc1-87d4-15e765e0a255
 
-        @Assert: Partition table updated successfully and layout was changed
+        :Assert: Partition table updated successfully and layout was changed
         """
         ptable = entities.PartitionTable().create()
         for new_layout in valid_data_list():
@@ -162,10 +162,10 @@ class PartitionTableTestCase(APITestCase):
     def test_positive_update_os(self):
         """Update partition table with new random operating system
 
-        @id: bf03d80c-3527-4b0a-b6c7-4629a8eaefb2
+        :id: bf03d80c-3527-4b0a-b6c7-4629a8eaefb2
 
-        @Assert: Partition table updated successfully and operating system was
-        changed
+        :Assert: Partition table updated successfully and operating system was
+            changed
         """
         ptable = entities.PartitionTable(
             os_family=OPERATING_SYSTEMS[0],
@@ -178,9 +178,9 @@ class PartitionTableTestCase(APITestCase):
     def test_negative_update_name(self):
         """Try to update partition table using invalid names only
 
-        @id: 7e9face8-2c20-450e-890c-6def6de570ca
+        :id: 7e9face8-2c20-450e-890c-6def6de570ca
 
-        @Assert: Partition table was not updated
+        :Assert: Partition table was not updated
         """
         ptable = entities.PartitionTable().create()
         for new_name in invalid_values_list():
@@ -193,9 +193,9 @@ class PartitionTableTestCase(APITestCase):
     def test_negative_update_layout(self):
         """Try to update partition table with empty layout
 
-        @id: 35c84c8f-b802-4076-89f2-4ec04cf43a31
+        :id: 35c84c8f-b802-4076-89f2-4ec04cf43a31
 
-        @Assert: Partition table was not updated
+        :Assert: Partition table was not updated
         """
         ptable = entities.PartitionTable().create()
         for new_layout in ('', ' ', None):

--- a/tests/foreman/api/test_permission.py
+++ b/tests/foreman/api/test_permission.py
@@ -5,19 +5,19 @@ Each ``APITestCase`` subclass tests a single URL. A full list of URLs to be
 tested can be found here: http://theforeman.org/api/apidoc/v2/permissions.html
 
 
-@Requirement: Permission
+:Requirement: Permission
 
-@CaseAutomation: Automated
+:CaseAutomation: Automated
 
-@CaseLevel: Acceptance
+:CaseLevel: Acceptance
 
-@CaseComponent: API
+:CaseComponent: API
 
-@TestType: Functional
+:TestType: Functional
 
-@CaseImportance: High
+:CaseImportance: High
 
-@Upstream: No
+:Upstream: No
 """
 import json
 import re
@@ -76,10 +76,10 @@ class PermissionTestCase(APITestCase):
     def test_positive_search_by_name(self):
         """Search for a permission by name.
 
-        @id: 1b6117f6-599d-4b2d-80a8-1e0764bdc04d
+        :id: 1b6117f6-599d-4b2d-80a8-1e0764bdc04d
 
-        @assert: Only one permission is returned, and the permission returned
-        is the one searched for.
+        :assert: Only one permission is returned, and the permission returned
+            is the one searched for.
         """
         failures = {}
         for permission_name in self.permission_names:
@@ -99,10 +99,10 @@ class PermissionTestCase(APITestCase):
     def test_positive_search_by_resource_type(self):
         """Search for permissions by resource type.
 
-        @id: 29d9362b-1bf3-4722-b40f-a5e8b4d0d9ba
+        :id: 29d9362b-1bf3-4722-b40f-a5e8b4d0d9ba
 
-        @assert: The permissions returned are equal to what is listed for that
-        resource type in :data:`robottelo.constants.PERMISSIONS`.
+        :assert: The permissions returned are equal to what is listed for that
+            resource type in :data:`robottelo.constants.PERMISSIONS`.
         """
         failures = {}
         for resource_type in self.permission_resource_types:
@@ -130,9 +130,9 @@ class PermissionTestCase(APITestCase):
     def test_positive_search(self):
         """search with no parameters return all permissions
 
-        @id: e58308df-19ec-415d-8fa1-63ebf3cd0ad6
+        :id: e58308df-19ec-415d-8fa1-63ebf3cd0ad6
 
-        @assert: Search returns a list of all expected permissions
+        :assert: Search returns a list of all expected permissions
         """
         permissions = entities.Permission().search(query={'per_page': 1000})
         names = {perm.name for perm in permissions}
@@ -235,10 +235,10 @@ class UserRoleTestCase(APITestCase):
     def test_positive_check_create(self):
         """Check whether the "create_*" role has an effect.
 
-        @id: e4c92365-58b7-4538-9d1b-93f3cf51fbef
+        :id: e4c92365-58b7-4538-9d1b-93f3cf51fbef
 
-        @Assert: A user cannot create an entity when missing the "create_*"
-        role, and they can create an entity when given the "create_*" role.
+        :Assert: A user cannot create an entity when missing the "create_*"
+            role, and they can create an entity when given the "create_*" role.
         """
         for entity_cls in (entities.Architecture, entities.Domain):
             with self.subTest(entity_cls):
@@ -254,10 +254,10 @@ class UserRoleTestCase(APITestCase):
     def test_positive_check_read(self):
         """Check whether the "view_*" role has an effect.
 
-        @id: 55689121-2646-414f-beb1-dbba5973c523
+        :id: 55689121-2646-414f-beb1-dbba5973c523
 
-        @Assert: A user cannot read an entity when missing the "view_*" role,
-        and they can read an entity when given the "view_*" role.
+        :Assert: A user cannot read an entity when missing the "view_*" role,
+            and they can read an entity when given the "view_*" role.
 
         """
         for entity_cls in (entities.Architecture, entities.Domain):
@@ -272,10 +272,10 @@ class UserRoleTestCase(APITestCase):
     def test_positive_check_delete(self):
         """Check whether the "destroy_*" role has an effect.
 
-        @id: 71365147-51ef-4602-948f-78a5e78e32b4
+        :id: 71365147-51ef-4602-948f-78a5e78e32b4
 
-        @Assert: A user cannot read an entity with missing the "destroy_*"
-        role, and they can read an entity when given the "destroy_*" role.
+        :Assert: A user cannot read an entity with missing the "destroy_*"
+            role, and they can read an entity when given the "destroy_*" role.
 
         """
         for entity_cls in (entities.Architecture, entities.Domain):
@@ -294,10 +294,10 @@ class UserRoleTestCase(APITestCase):
     def test_positive_check_update(self):
         """Check whether the "edit_*" role has an effect.
 
-        @id: b5de2115-b031-413e-8e5b-eac8cb714174
+        :id: b5de2115-b031-413e-8e5b-eac8cb714174
 
-        @Assert: A user cannot update an entity when missing the "edit_*" role,
-        and they can update an entity when given the "edit_*" role.
+        :Assert: A user cannot update an entity when missing the "edit_*" role,
+            and they can update an entity when given the "edit_*" role.
 
         NOTE: This method will only work if ``entity`` has a name.
 

--- a/tests/foreman/api/test_product.py
+++ b/tests/foreman/api/test_product.py
@@ -4,19 +4,19 @@
 A full API reference for products can be found here:
 http://theforeman.org/api/apidoc/v2/products.html
 
-@Requirement: Product
+:Requirement: Product
 
-@CaseAutomation: Automated
+:CaseAutomation: Automated
 
-@CaseLevel: Acceptance
+:CaseLevel: Acceptance
 
-@CaseComponent: API
+:CaseComponent: API
 
-@TestType: Functional
+:TestType: Functional
 
-@CaseImportance: High
+:CaseImportance: High
 
-@Upstream: No
+:Upstream: No
 """
 from fauxfactory import gen_string
 from nailgun import entities
@@ -47,9 +47,9 @@ class ProductTestCase(APITestCase):
     def test_positive_create_with_name(self):
         """Create a product providing different valid names
 
-        @id: 3d873b73-6919-4fda-84df-0e26bdf0c1dc
+        :id: 3d873b73-6919-4fda-84df-0e26bdf0c1dc
 
-        @Assert: A product is created with expected name.
+        :Assert: A product is created with expected name.
         """
         for name in valid_data_list():
             with self.subTest(name):
@@ -62,9 +62,9 @@ class ProductTestCase(APITestCase):
     def test_positive_create_with_label(self):
         """Create a product providing label which is different from its name
 
-        @id: 95cf8e05-fd09-422e-bf6f-8b1dde762976
+        :id: 95cf8e05-fd09-422e-bf6f-8b1dde762976
 
-        @Assert: A product is created with expected label.
+        :Assert: A product is created with expected label.
         """
         label = gen_string('alphanumeric')
         product = entities.Product(label=label, organization=self.org).create()
@@ -76,9 +76,9 @@ class ProductTestCase(APITestCase):
     def test_positive_create_with_description(self):
         """Create a product providing different descriptions
 
-        @id: f3e2df77-6711-440b-800a-9cebbbec36c5
+        :id: f3e2df77-6711-440b-800a-9cebbbec36c5
 
-        @Assert: A product is created with expected description.
+        :Assert: A product is created with expected description.
         """
         for desc in valid_data_list():
             with self.subTest(desc):
@@ -91,11 +91,11 @@ class ProductTestCase(APITestCase):
     def test_positive_create_with_gpg(self):
         """Create a product and provide a GPG key.
 
-        @id: 57331c1f-15dd-4c9f-b8fc-3010847b2975
+        :id: 57331c1f-15dd-4c9f-b8fc-3010847b2975
 
-        @Assert: A product is created with the specified GPG key.
+        :Assert: A product is created with the specified GPG key.
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         # Create an organization, GPG key and product.
         #
@@ -114,9 +114,9 @@ class ProductTestCase(APITestCase):
     def test_negative_create_with_name(self):
         """Create a product providing invalid names only
 
-        @id: 76531f53-09ff-4ee9-89b9-09a697526fb1
+        :id: 76531f53-09ff-4ee9-89b9-09a697526fb1
 
-        @Assert: A product is not created
+        :Assert: A product is not created
         """
         for name in invalid_values_list():
             with self.subTest(name):
@@ -128,9 +128,9 @@ class ProductTestCase(APITestCase):
     def test_negative_create_with_same_name(self):
         """Create a product providing a name of already existent entity
 
-        @id: 039269c5-607a-4b70-91dd-b8fed8e50cc6
+        :id: 039269c5-607a-4b70-91dd-b8fed8e50cc6
 
-        @Assert: A product is not created
+        :Assert: A product is not created
         """
         name = gen_string('alphanumeric')
         entities.Product(name=name, organization=self.org).create()
@@ -142,9 +142,9 @@ class ProductTestCase(APITestCase):
     def test_negative_create_with_label(self):
         """Create a product providing invalid label
 
-        @id: 30b1a737-07f1-4786-b68a-734e57c33a62
+        :id: 30b1a737-07f1-4786-b68a-734e57c33a62
 
-        @Assert: A product is not created
+        :Assert: A product is not created
         """
         with self.assertRaises(HTTPError):
             entities.Product(label=gen_string('utf8')).create()
@@ -154,9 +154,9 @@ class ProductTestCase(APITestCase):
     def test_positive_update_name(self):
         """Update product name to another valid name.
 
-        @id: 1a9f6e0d-43fb-42e2-9dbd-e880f03b0297
+        :id: 1a9f6e0d-43fb-42e2-9dbd-e880f03b0297
 
-        @Assert: Product name can be updated.
+        :Assert: Product name can be updated.
         """
         product = entities.Product(organization=self.org).create()
         for new_name in valid_data_list():
@@ -170,9 +170,9 @@ class ProductTestCase(APITestCase):
     def test_positive_update_description(self):
         """Update product description to another valid one.
 
-        @id: c960c326-2e9f-4ee7-bdec-35a705305067
+        :id: c960c326-2e9f-4ee7-bdec-35a705305067
 
-        @Assert: Product description can be updated.
+        :Assert: Product description can be updated.
         """
         product = entities.Product(organization=self.org).create()
         for new_desc in valid_data_list():
@@ -186,9 +186,9 @@ class ProductTestCase(APITestCase):
     def test_positive_update_name_to_original(self):
         """Rename Product back to original name
 
-        @id: 3075f17f-4475-4b64-9fbd-1e41ced9142d
+        :id: 3075f17f-4475-4b64-9fbd-1e41ced9142d
 
-        @Assert: Product Renamed to original
+        :Assert: Product Renamed to original
         """
         product = entities.Product(organization=self.org).create()
         new_name = gen_string('alpha')
@@ -211,11 +211,11 @@ class ProductTestCase(APITestCase):
     def test_positive_update_gpg(self):
         """Create a product and update its GPGKey
 
-        @id: 3b08f155-a0d6-4987-b281-dc02e8d5a03e
+        :id: 3b08f155-a0d6-4987-b281-dc02e8d5a03e
 
-        @Assert: The updated product points to a new GPG key.
+        :Assert: The updated product points to a new GPG key.
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         # Create a product and make it point to a GPG key.
         gpg_key_1 = entities.GPGKey(
@@ -240,11 +240,11 @@ class ProductTestCase(APITestCase):
     def test_positive_update_organization(self):
         """Create a product and update its organization
 
-        @id: b298957a-2cdb-4f17-a934-098612f3b659
+        :id: b298957a-2cdb-4f17-a934-098612f3b659
 
-        @Assert: The updated product points to a new organization
+        :Assert: The updated product points to a new organization
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         product = entities.Product(organization=self.org).create()
         # Update the product and make it point to a new organization.
@@ -258,9 +258,9 @@ class ProductTestCase(APITestCase):
     def test_negative_update_name(self):
         """Attempt to update product name to invalid one
 
-        @id: 3eb61fa8-3524-4872-8f1b-4e88004f66f5
+        :id: 3eb61fa8-3524-4872-8f1b-4e88004f66f5
 
-        @Assert: Product is not updated
+        :Assert: Product is not updated
         """
         product = entities.Product(organization=self.org).create()
         for new_name in invalid_values_list():
@@ -276,9 +276,9 @@ class ProductTestCase(APITestCase):
     def test_negative_update_label(self):
         """Attempt to update product label to another one.
 
-        @id: 065cd673-8d10-46c7-800c-b731b06a5359
+        :id: 065cd673-8d10-46c7-800c-b731b06a5359
 
-        @Assert: Product is not updated and error is raised
+        :Assert: Product is not updated and error is raised
         """
         product = entities.Product(organization=self.org).create()
         product.label = gen_string('alpha')
@@ -290,9 +290,9 @@ class ProductTestCase(APITestCase):
     def test_positive_delete(self):
         """Create product and then delete it.
 
-        @id: 30df95f5-0a4e-41ee-a99f-b418c5c5f2f3
+        :id: 30df95f5-0a4e-41ee-a99f-b418c5c5f2f3
 
-        @Assert: Product is successfully deleted.
+        :Assert: Product is successfully deleted.
         """
         for name in valid_data_list():
             with self.subTest(name):
@@ -305,9 +305,9 @@ class ProductTestCase(APITestCase):
     def test_positive_sync(self):
         """Sync product (repository within a product)
 
-        @id: 860e00a1-c370-4bd0-8987-449338071d56
+        :id: 860e00a1-c370-4bd0-8987-449338071d56
 
-        @Assert: Repository within a product is successfully synced.
+        :Assert: Repository within a product is successfully synced.
         """
         product = entities.Product().create()
         rpm_repo = entities.Repository(
@@ -323,13 +323,13 @@ class ProductTestCase(APITestCase):
     def test_positive_sync_several_repos(self):
         """Sync product (all repositories within a product)
 
-        @id: 07918442-b72f-4db5-96b6-975564f3663a
+        :id: 07918442-b72f-4db5-96b6-975564f3663a
 
-        @Assert: All repositories within a product are successfully synced.
+        :Assert: All repositories within a product are successfully synced.
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
 
-        @BZ: 1389543
+        :BZ: 1389543
         """
         product = entities.Product().create()
         rpm_repo = entities.Repository(

--- a/tests/foreman/api/test_puppet.py
+++ b/tests/foreman/api/test_puppet.py
@@ -1,18 +1,18 @@
 """End to end test for Puppet funcionality
 
-@Requirement: Puppet
+:Requirement: Puppet
 
-@CaseAutomation: Automated
+:CaseAutomation: Automated
 
-@CaseLevel: Acceptance
+:CaseLevel: Acceptance
 
-@CaseComponent: API
+:CaseComponent: API
 
-@TestType: Functional
+:TestType: Functional
 
-@CaseImportance: High
+:CaseImportance: High
 
-@Upstream: No
+:Upstream: No
 """
 
 from robottelo.config import settings
@@ -42,33 +42,34 @@ class PuppetTestCase(APITestCase):
     def test_positive_puppet_scenario(self):
         """Tests extensive all-in-one puppet scenario
 
-        @id: 29635f43-e701-4539-844c-275545cdf9c4
+        :id: 29635f43-e701-4539-844c-275545cdf9c4
 
-        @Steps:
+        :Steps:
 
-        1. Create an organization and upload a cloned manifest for it.
-        2. Enable respective Satellite Tools repos and sync them.
-        3. Create a product and a LFE
-        4. Create a puppet repos within the product
-        5. Upload motd puppet module into the repo
-        6. Upload parameterizable puppet module and create smart params for it
-        7. Create a CV and add Tools repo and puppet module(s)
-        8. Publish and promote CV to the LFE
-        9. Create AK with the product and enable Satellite Tools in it
-        10. Create a libvirt compute resource
-        11. Create a sane subnet and sane domain to be used by libvirt
-        12. Create a hostgroup associated with all created entities
-            (especially Puppet Classes has added puppet modules)
-        13. Provision a host using the hostgroup on libvirt resource
-        14. Assert that puppet agent can run on the host
-        15. Assert that the puppet modules get installed by provisioning
-        16. Run facter on host and assert that was successful
+            1. Create an organization and upload a cloned manifest for it.
+            2. Enable respective Satellite Tools repos and sync them.
+            3. Create a product and a LFE
+            4. Create a puppet repos within the product
+            5. Upload motd puppet module into the repo
+            6. Upload parameterizable puppet module and create smart params for
+               it
+            7. Create a CV and add Tools repo and puppet module(s)
+            8. Publish and promote CV to the LFE
+            9. Create AK with the product and enable Satellite Tools in it
+            10. Create a libvirt compute resource
+            11. Create a sane subnet and sane domain to be used by libvirt
+            12. Create a hostgroup associated with all created entities
+                (especially Puppet Classes has added puppet modules)
+            13. Provision a host using the hostgroup on libvirt resource
+            14. Assert that puppet agent can run on the host
+            15. Assert that the puppet modules get installed by provisioning
+            16. Run facter on host and assert that was successful
 
-        @Assert: multiple asserts along the code
+        :Assert: multiple asserts along the code
 
-        @caseautomation: notautomated
+        :caseautomation: notautomated
 
-        @CaseLevel: System
+        :CaseLevel: System
         """
 
 
@@ -88,31 +89,31 @@ class PuppetCapsuleTestCase(APITestCase):
     def test_positive_puppet_capsule_scenario(self):
         """Tests extensive all-in-one puppet scenario via Capsule
 
-        @id: faffb182-93dc-4406-805c-3b2f10891854
+        :id: faffb182-93dc-4406-805c-3b2f10891854
 
-        @Steps:
+        :Steps:
+            1. Create an organization and upload a cloned manifest for it.
+            2. Enable respective Satellite Tools repos and sync them.
+            3. Create a product and a LFE
+            4. Create a puppet repos within the product
+            5. Upload motd puppet module into the repo
+            6. Upload parameterizable puppet module and create smart params for
+               it
+            7. Create a CV and add Tools repo and puppet module(s)
+            8. Publish and promote CV to the LFE
+            9. Create AK with the product and enable Satellite Tools in it
+            10. Create a libvirt compute resource
+            11. Create a sane subnet and sane domain to be used by libvirt
+            12. Create a hostgroup associated with all created entities
+                (especially Puppet Classes has added puppet modules)
+            13. Provision a host using the hostgroup on libvirt resource
+            14. Assert that puppet agent can run on the host
+            15. Assert that the puppet modules get installed by provisioning
+            16. Run facter on host and assert that was successful
 
-        1. Create an organization and upload a cloned manifest for it.
-        2. Enable respective Satellite Tools repos and sync them.
-        3. Create a product and a LFE
-        4. Create a puppet repos within the product
-        5. Upload motd puppet module into the repo
-        6. Upload parameterizable puppet module and create smart params for it
-        7. Create a CV and add Tools repo and puppet module(s)
-        8. Publish and promote CV to the LFE
-        9. Create AK with the product and enable Satellite Tools in it
-        10. Create a libvirt compute resource
-        11. Create a sane subnet and sane domain to be used by libvirt
-        12. Create a hostgroup associated with all created entities
-            (especially Puppet Classes has added puppet modules)
-        13. Provision a host using the hostgroup on libvirt resource
-        14. Assert that puppet agent can run on the host
-        15. Assert that the puppet modules get installed by provisioning
-        16. Run facter on host and assert that was successful
+        :Assert: multiple asserts along the code
 
-        @Assert: multiple asserts along the code
+        :caseautomation: notautomated
 
-        @caseautomation: notautomated
-
-        @CaseLevel: System
+        :CaseLevel: System
         """

--- a/tests/foreman/api/test_puppetmodule.py
+++ b/tests/foreman/api/test_puppetmodule.py
@@ -1,18 +1,18 @@
 """Unit tests for the ``katello/api/v2/puppet_modules`` paths.
 
-@Requirement: Puppetmodule
+:Requirement: Puppetmodule
 
-@CaseAutomation: Automated
+:CaseAutomation: Automated
 
-@CaseLevel: Acceptance
+:CaseLevel: Acceptance
 
-@CaseComponent: API
+:CaseComponent: API
 
-@TestType: Functional
+:TestType: Functional
 
-@CaseImportance: High
+:CaseImportance: High
 
-@Upstream: No
+:Upstream: No
 """
 from nailgun import entities
 from robottelo.constants import PUPPET_MODULE_NTP_PUPPETLABS
@@ -45,9 +45,9 @@ class RepositorySearchTestCase(APITestCase):
     def test_positive_search_no_results(self):
         """Search for puppet modules in an empty repository.
 
-        @id: eafc7a71-d550-4983-9941-b87aa57b83e9
+        :id: eafc7a71-d550-4983-9941-b87aa57b83e9
 
-        @Assert: No puppet modules are returned.
+        :Assert: No puppet modules are returned.
         """
         query = {'repository_id': self.repository.id}
         self.assertEqual(len(entities.PuppetModule().search(query=query)), 0)
@@ -56,9 +56,9 @@ class RepositorySearchTestCase(APITestCase):
     def test_positive_search_single_result(self):
         """Search for puppet modules in a non-empty repository.
 
-        @id: 5337b2be-e207-4580-8407-19b88cb40403
+        :id: 5337b2be-e207-4580-8407-19b88cb40403
 
-        @Assert: Only the modules in that repository are returned.
+        :Assert: Only the modules in that repository are returned.
         """
         with open(get_data_file(PUPPET_MODULE_NTP_PUPPETLABS), 'rb') as handle:
             self.repository.upload_content(files={'content': handle})
@@ -95,9 +95,9 @@ class ContentViewVersionSearchTestCase(APITestCase):
     def test_positive_search_no_results(self):
         """Search for puppet modules in an emtpy content view version.
 
-        @id: 3a59e2fc-5c95-405e-bf4a-f1fe78e73300
+        :id: 3a59e2fc-5c95-405e-bf4a-f1fe78e73300
 
-        @Assert: No puppet modules are found.
+        :Assert: No puppet modules are found.
         """
         self.content_view.publish()
         self.content_view = self.content_view.read()
@@ -108,9 +108,9 @@ class ContentViewVersionSearchTestCase(APITestCase):
     def test_positive_search_single_result(self):
         """Search for puppet modules in a CVV with one puppet module.
 
-        @id: cc358a91-8640-48e3-851d-383e55ba42c3
+        :id: cc358a91-8640-48e3-851d-383e55ba42c3
 
-        @Assert: One puppet module is found.
+        :Assert: One puppet module is found.
         """
         # Find the puppet module in `self.repository` and assign it to
         # `self.content_view`. Publish the content view.

--- a/tests/foreman/api/test_repository.py
+++ b/tests/foreman/api/test_repository.py
@@ -1,18 +1,18 @@
 """Unit tests for the ``repositories`` paths.
 
-@Requirement: Repository
+:Requirement: Repository
 
-@CaseAutomation: Automated
+:CaseAutomation: Automated
 
-@CaseLevel: Acceptance
+:CaseLevel: Acceptance
 
-@CaseComponent: API
+:CaseComponent: API
 
-@TestType: Functional
+:TestType: Functional
 
-@CaseImportance: High
+:CaseImportance: High
 
-@Upstream: No
+:Upstream: No
 """
 from fauxfactory import gen_string
 from nailgun import entities
@@ -80,9 +80,9 @@ class RepositoryTestCase(APITestCase):
     def test_positive_create_with_name(self):
         """Create a repository with valid name.
 
-        @id: 159f7296-55d2-4360-948f-c24e7d75b962
+        :id: 159f7296-55d2-4360-948f-c24e7d75b962
 
-        @Assert: A repository is created with the given name.
+        :Assert: A repository is created with the given name.
         """
         for name in valid_data_list():
             with self.subTest(name):
@@ -95,9 +95,9 @@ class RepositoryTestCase(APITestCase):
     def test_positive_create_with_label(self):
         """Create a repository providing label which is different from its name
 
-        @id: 3be1b3fa-0e17-416f-97f0-858709e6b1da
+        :id: 3be1b3fa-0e17-416f-97f0-858709e6b1da
 
-        @Assert: A repository is created with expected label.
+        :Assert: A repository is created with expected label.
         """
         for label in valid_labels_list():
             with self.subTest(label):
@@ -111,9 +111,9 @@ class RepositoryTestCase(APITestCase):
     def test_positive_create_yum(self):
         """Create yum repository.
 
-        @id: 7bac7f45-0fb3-4443-bb3b-cee72248ca5d
+        :id: 7bac7f45-0fb3-4443-bb3b-cee72248ca5d
 
-        @Assert: A repository is created and has yum type.
+        :Assert: A repository is created and has yum type.
         """
         repo = entities.Repository(
             product=self.product,
@@ -128,9 +128,9 @@ class RepositoryTestCase(APITestCase):
     def test_positive_create_puppet(self):
         """Create puppet repository.
 
-        @id: daa10ded-6de3-44b3-9707-9f0ac983d2ea
+        :id: daa10ded-6de3-44b3-9707-9f0ac983d2ea
 
-        @Assert: A repository is created and has puppet type.
+        :Assert: A repository is created and has puppet type.
         """
         repo = entities.Repository(
             product=self.product,
@@ -144,9 +144,9 @@ class RepositoryTestCase(APITestCase):
     def test_positive_create_with_auth_yum_repo(self):
         """Create yum repository with basic HTTP authentication
 
-        @id: 1b17fe37-cdbf-4a79-9b0d-6813ea502754
+        :id: 1b17fe37-cdbf-4a79-9b0d-6813ea502754
 
-        @Assert: yum repository is created
+        :Assert: yum repository is created
         """
         url = FAKE_5_YUM_REPO
         for creds in valid_http_credentials(url_encoded=True):
@@ -164,9 +164,9 @@ class RepositoryTestCase(APITestCase):
     def test_positive_create_with_download_policy(self):
         """Create YUM repositories with available download policies
 
-        @id: 5e5479c4-904d-4892-bc43-6f81fa3813f8
+        :id: 5e5479c4-904d-4892-bc43-6f81fa3813f8
 
-        @Assert: YUM repository with a download policy is created
+        :Assert: YUM repository with a download policy is created
         """
         for policy in DOWNLOAD_POLICIES:
             with self.subTest(policy):
@@ -182,9 +182,9 @@ class RepositoryTestCase(APITestCase):
         """Verify if the default download policy is assigned
         when creating a YUM repo without `download_policy` field
 
-        @id: 54108f30-d73e-46d3-ae56-cda28678e7e9
+        :id: 54108f30-d73e-46d3-ae56-cda28678e7e9
 
-        @Assert: YUM repository with a default download policy
+        :Assert: YUM repository with a default download policy
         """
 
         default_dl_policy = entities.Setting().search(
@@ -202,9 +202,9 @@ class RepositoryTestCase(APITestCase):
         """Update `immediate` download policy to `on_demand`
         for a newly created YUM repository
 
-        @id: 8a70de9b-4663-4251-b91e-d3618ee7ef84
+        :id: 8a70de9b-4663-4251-b91e-d3618ee7ef84
 
-        @Assert: immediate download policy is updated to on_demand
+        :Assert: immediate download policy is updated to on_demand
         """
         repo = entities.Repository(
             product=self.product,
@@ -220,9 +220,9 @@ class RepositoryTestCase(APITestCase):
         """Update `immediate` download policy to `background`
         for a newly created YUM repository
 
-        @id: 9aaf53be-1127-4559-9faf-899888a52846
+        :id: 9aaf53be-1127-4559-9faf-899888a52846
 
-        @Assert: immediate download policy is updated to background
+        :Assert: immediate download policy is updated to background
         """
         repo = entities.Repository(
             product=self.product,
@@ -238,9 +238,9 @@ class RepositoryTestCase(APITestCase):
         """Update `on_demand` download policy to `immediate`
         for a newly created YUM repository
 
-        @id: 589ff7bb-4251-4218-bb90-4e63c9baf702
+        :id: 589ff7bb-4251-4218-bb90-4e63c9baf702
 
-        @Assert: on_demand download policy is updated to immediate
+        :Assert: on_demand download policy is updated to immediate
         """
         repo = entities.Repository(
             product=self.product,
@@ -256,9 +256,9 @@ class RepositoryTestCase(APITestCase):
         """Update `on_demand` download policy to `background`
         for a newly created YUM repository
 
-        @id: 1d9888a0-c5b5-41a7-815d-47e936022a60
+        :id: 1d9888a0-c5b5-41a7-815d-47e936022a60
 
-        @Assert: on_demand download policy is updated to background
+        :Assert: on_demand download policy is updated to background
         """
         repo = entities.Repository(
             product=self.product,
@@ -274,9 +274,9 @@ class RepositoryTestCase(APITestCase):
         """Update `background` download policy to `immediate`
         for a newly created YUM repository
 
-        @id: 169530a7-c5ce-4ca5-8cdd-15398e13e2af
+        :id: 169530a7-c5ce-4ca5-8cdd-15398e13e2af
 
-        @Assert: background download policy is updated to immediate
+        :Assert: background download policy is updated to immediate
         """
         repo = entities.Repository(
             product=self.product,
@@ -292,9 +292,9 @@ class RepositoryTestCase(APITestCase):
         """Update `background` download policy to `on_demand`
         for a newly created YUM repository
 
-        @id: 40a3e963-61ff-41c4-aa6c-d9a4a638af4a
+        :id: 40a3e963-61ff-41c4-aa6c-d9a4a638af4a
 
-        @Assert: background download policy is updated to on_demand
+        :Assert: background download policy is updated to on_demand
         """
         repo = entities.Repository(
             product=self.product,
@@ -310,9 +310,9 @@ class RepositoryTestCase(APITestCase):
     def test_positive_create_with_auth_puppet_repo(self):
         """Create Puppet repository with basic HTTP authentication
 
-        @id: af9e4f0f-d128-43d2-a680-0a62c7dab266
+        :id: af9e4f0f-d128-43d2-a680-0a62c7dab266
 
-        @Assert: Puppet repository is created
+        :Assert: Puppet repository is created
         """
         url = FAKE_7_PUPPET_REPO
         for creds in valid_http_credentials(url_encoded=True):
@@ -331,9 +331,9 @@ class RepositoryTestCase(APITestCase):
     def test_positive_create_checksum(self):
         """Create a repository with valid checksum type.
 
-        @id: c3678878-758a-4501-a038-a59503fee453
+        :id: c3678878-758a-4501-a038-a59503fee453
 
-        @Assert: A repository is created and has expected checksum type.
+        :Assert: A repository is created and has expected checksum type.
         """
         for checksum_type in 'sha1', 'sha256':
             with self.subTest(checksum_type):
@@ -346,10 +346,10 @@ class RepositoryTestCase(APITestCase):
     def test_positive_create_unprotected(self):
         """Create a repository with valid unprotected flag values.
 
-        @id: 38f78733-6a72-4bf5-912a-cfc51658f80c
+        :id: 38f78733-6a72-4bf5-912a-cfc51658f80c
 
-        @Assert: A repository is created and has expected unprotected flag
-        state.
+        :Assert: A repository is created and has expected unprotected flag
+            state.
         """
         for unprotected in True, False:
             repo = entities.Repository(
@@ -361,11 +361,11 @@ class RepositoryTestCase(APITestCase):
     def test_positive_create_with_gpg(self):
         """Create a repository and provide a GPG key ID.
 
-        @id: 023cf84b-74f3-4e63-a9d7-10afee6c1990
+        :id: 023cf84b-74f3-4e63-a9d7-10afee6c1990
 
-        @Assert: A repository is created with the given GPG key ID.
+        :Assert: A repository is created with the given GPG key ID.
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         gpg_key = entities.GPGKey(
             content=read_data_file(VALID_GPG_KEY_FILE),
@@ -383,12 +383,12 @@ class RepositoryTestCase(APITestCase):
     def test_positive_create_same_name_different_orgs(self):
         """Create two repos with the same name in two different organizations.
 
-        @id: bd1bd7e3-e393-44c8-a6d0-42edade40f60
+        :id: bd1bd7e3-e393-44c8-a6d0-42edade40f60
 
-        @Assert: The two repositories are successfully created and have given
-        name.
+        :Assert: The two repositories are successfully created and have given
+            name.
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         repo1 = entities.Repository(product=self.product).create()
         repo2 = entities.Repository(name=repo1.name).create()
@@ -398,12 +398,12 @@ class RepositoryTestCase(APITestCase):
     def test_positive_create_puppet_repo_same_url_different_orgs(self):
         """Create two repos with the same URL in two different organizations.
 
-        @id: 7c74c2b8-732a-4c47-8ad9-697121db05be
+        :id: 7c74c2b8-732a-4c47-8ad9-697121db05be
 
-        @Assert: Repositories are created and puppet modules are visible from
-        different organizations.
+        :Assert: Repositories are created and puppet modules are visible from
+            different organizations.
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         url = 'https://omaciel.fedorapeople.org/7c74c2b8/'
         # Use setup product for the first repo and create new org/product
@@ -423,9 +423,9 @@ class RepositoryTestCase(APITestCase):
     def test_negative_create_name(self):
         """Attempt to create repository with invalid names only.
 
-        @id: 24947c92-3415-43df-add6-d6eb38afd8a3
+        :id: 24947c92-3415-43df-add6-d6eb38afd8a3
 
-        @Assert: A repository is not created and error is raised.
+        :Assert: A repository is not created and error is raised.
         """
         for name in invalid_values_list():
             with self.subTest(name):
@@ -438,9 +438,9 @@ class RepositoryTestCase(APITestCase):
         """Attempt to create a repository providing a name of already existent
         entity
 
-        @id: 0493dfc4-0043-4682-b339-ce61da7d48ae
+        :id: 0493dfc4-0043-4682-b339-ce61da7d48ae
 
-        @Assert: Second repository is not created
+        :Assert: Second repository is not created
         """
         name = gen_string('alphanumeric')
         entities.Repository(product=self.product, name=name).create()
@@ -452,9 +452,9 @@ class RepositoryTestCase(APITestCase):
     def test_negative_create_label(self):
         """Attempt to create repository with invalid label.
 
-        @id: f646ae84-2660-41bd-9883-331285fa1c9a
+        :id: f646ae84-2660-41bd-9883-331285fa1c9a
 
-        @Assert: A repository is not created and error is raised.
+        :Assert: A repository is not created and error is raised.
         """
         with self.assertRaises(HTTPError):
             entities.Repository(label=gen_string('utf8')).create()
@@ -464,9 +464,9 @@ class RepositoryTestCase(APITestCase):
     def test_negative_create_url(self):
         """Attempt to create repository with invalid url.
 
-        @id: 0bb9fc3f-d442-4437-b5d8-83024bc7ceab
+        :id: 0bb9fc3f-d442-4437-b5d8-83024bc7ceab
 
-        @Assert: A repository is not created and error is raised.
+        :Assert: A repository is not created and error is raised.
         """
         for url in invalid_names_list():
             with self.subTest(url):
@@ -478,9 +478,9 @@ class RepositoryTestCase(APITestCase):
     def test_negative_create_with_auth_url_with_special_characters(self):
         """Verify that repository URL cannot contain unquoted special characters
 
-        @id: 2ffaa412-e5e5-4bec-afaa-9ea54315df49
+        :id: 2ffaa412-e5e5-4bec-afaa-9ea54315df49
 
-        @Assert: A repository is not created and error is raised.
+        :Assert: A repository is not created and error is raised.
         """
         # get a list of valid credentials without quoting them
         for cred in [creds for creds in valid_http_credentials()
@@ -495,9 +495,9 @@ class RepositoryTestCase(APITestCase):
     def test_negative_create_with_auth_url_too_long(self):
         """Verify that repository URL length is limited
 
-        @id: 5aad4e9f-f7e1-497c-8e1f-55e07e38ee80
+        :id: 5aad4e9f-f7e1-497c-8e1f-55e07e38ee80
 
-        @Assert: A repository is not created and error is raised.
+        :Assert: A repository is not created and error is raised.
         """
         for cred in invalid_http_credentials():
             with self.subTest(cred):
@@ -510,9 +510,9 @@ class RepositoryTestCase(APITestCase):
         """Verify that YUM repository cannot be created with invalid
         download policy
 
-        @id: 3b143bf8-7056-4c94-910d-69a451071f26
+        :id: 3b143bf8-7056-4c94-910d-69a451071f26
 
-        @Assert: YUM repository is not created with invalid download policy
+        :Assert: YUM repository is not created with invalid download policy
         """
         with self.assertRaises(HTTPError):
             entities.Repository(
@@ -526,9 +526,9 @@ class RepositoryTestCase(APITestCase):
         """Verify that YUM repository cannot be updated to invalid
         download policy
 
-        @id: 5bd6a2e4-7ff0-42ac-825a-6b2a2f687c89
+        :id: 5bd6a2e4-7ff0-42ac-825a-6b2a2f687c89
 
-        @Assert: YUM repository is not updated to invalid download policy
+        :Assert: YUM repository is not updated to invalid download policy
         """
         with self.assertRaises(HTTPError):
             repo = entities.Repository(
@@ -543,10 +543,9 @@ class RepositoryTestCase(APITestCase):
         """Verify that non-YUM repositories cannot be created with
         download policy
 
-        @id: 71388973-50ea-4a20-9406-0aca142014ca
+        :id: 71388973-50ea-4a20-9406-0aca142014ca
 
-        @Assert: Non-YUM repository is not created with a
-        download policy
+        :Assert: Non-YUM repository is not created with a download policy
         """
         non_yum_repo_types = [
             repo_type for repo_type in REPO_TYPE.keys()
@@ -566,9 +565,9 @@ class RepositoryTestCase(APITestCase):
     def test_negative_create_checksum(self):
         """Attempt to create repository with invalid checksum type.
 
-        @id: c49a3c49-110d-4b74-ae14-5c9494a4541c
+        :id: c49a3c49-110d-4b74-ae14-5c9494a4541c
 
-        @Assert: A repository is not created and error is raised.
+        :Assert: A repository is not created and error is raised.
         """
         with self.assertRaises(HTTPError):
             entities.Repository(checksum_type=gen_string('alpha')).create()
@@ -578,9 +577,9 @@ class RepositoryTestCase(APITestCase):
     def test_positive_update_name(self):
         """Update repository name to another valid name.
 
-        @id: 1b428129-7cf9-449b-9e3b-74360c5f9eca
+        :id: 1b428129-7cf9-449b-9e3b-74360c5f9eca
 
-        @Assert: The repository name can be updated.
+        :Assert: The repository name can be updated.
         """
         repo = entities.Repository(product=self.product).create()
         for new_name in valid_data_list():
@@ -594,9 +593,9 @@ class RepositoryTestCase(APITestCase):
     def test_positive_update_checksum(self):
         """Update repository checksum type to another valid one.
 
-        @id: 205e6e59-33c6-4a58-9245-1cac3a4f550a
+        :id: 205e6e59-33c6-4a58-9245-1cac3a4f550a
 
-        @Assert: The repository checksum type can be updated.
+        :Assert: The repository checksum type can be updated.
         """
         repo = entities.Repository(
             product=self.product, checksum_type='sha1').create()
@@ -609,9 +608,9 @@ class RepositoryTestCase(APITestCase):
     def test_positive_update_url(self):
         """Update repository url to another valid one.
 
-        @id: 8fbc11f0-a5c5-498e-a314-87958dcd7832
+        :id: 8fbc11f0-a5c5-498e-a314-87958dcd7832
 
-        @Assert: The repository url can be updated.
+        :Assert: The repository url can be updated.
         """
         repo = entities.Repository(product=self.product).create()
         repo.url = FAKE_2_YUM_REPO
@@ -623,9 +622,9 @@ class RepositoryTestCase(APITestCase):
     def test_positive_update_unprotected(self):
         """Update repository unprotected flag to another valid one.
 
-        @id: c55d169a-8f11-4bf8-9913-b3d39fee75f0
+        :id: c55d169a-8f11-4bf8-9913-b3d39fee75f0
 
-        @Assert: The repository unprotected flag can be updated.
+        :Assert: The repository unprotected flag can be updated.
         """
         repo = entities.Repository(
             product=self.product, unprotected=False).create()
@@ -638,11 +637,11 @@ class RepositoryTestCase(APITestCase):
     def test_positive_update_gpg(self):
         """Create a repository and update its GPGKey
 
-        @id: 0e9319dc-c922-4ecf-9f83-d221cfdf54c2
+        :id: 0e9319dc-c922-4ecf-9f83-d221cfdf54c2
 
-        @Assert: The updated repository points to a new GPG key.
+        :Assert: The updated repository points to a new GPG key.
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         # Create a repo and make it point to a GPG key.
         gpg_key_1 = entities.GPGKey(
@@ -668,11 +667,11 @@ class RepositoryTestCase(APITestCase):
     def test_positive_update_contents(self):
         """Create a repository and upload RPM contents.
 
-        @id: 8faa64f9-b620-4c0a-8c80-801e8e6436f1
+        :id: 8faa64f9-b620-4c0a-8c80-801e8e6436f1
 
-        @Assert: The repository's contents include one RPM.
+        :Assert: The repository's contents include one RPM.
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         # Create a repository and upload RPM content.
         repo = entities.Repository(product=self.product).create()
@@ -687,9 +686,9 @@ class RepositoryTestCase(APITestCase):
     def test_positive_upload_contents_srpm(self):
         """Create a repository and upload SRPM contents.
 
-        @id: e091a725-048f-44ca-90cc-c016c450ced9
+        :id: e091a725-048f-44ca-90cc-c016c450ced9
 
-        @Assert: The repository's contents include one SRPM.
+        :Assert: The repository's contents include one SRPM.
         """
         # Create a repository and upload source RPM content.
         repo = entities.Repository(product=self.product).create()
@@ -703,10 +702,10 @@ class RepositoryTestCase(APITestCase):
     def test_positive_remove_contents(self):
         """Synchronize a repository and remove rpm content.
 
-        @id: f686b74b-7ee9-4806-b999-bc05ffe61a9d
+        :id: f686b74b-7ee9-4806-b999-bc05ffe61a9d
 
-        @Assert: The repository's content is removed and content count shows
-        zero packages
+        :Assert: The repository's content is removed and content count shows
+            zero packages
         """
         # Create repository and synchronize it
         repo = entities.Repository(
@@ -727,9 +726,9 @@ class RepositoryTestCase(APITestCase):
     def test_negative_update_name(self):
         """Attempt to update repository name to invalid one
 
-        @id: 6f2f41a4-d871-4b91-87b1-a5a401c4aa69
+        :id: 6f2f41a4-d871-4b91-87b1-a5a401c4aa69
 
-        @Assert: Repository is not updated
+        :Assert: Repository is not updated
         """
         repo = entities.Repository(product=self.product).create()
         for new_name in invalid_values_list():
@@ -744,9 +743,9 @@ class RepositoryTestCase(APITestCase):
     def test_negative_update_label(self):
         """Attempt to update repository label to another one.
 
-        @id: 828d85df-3c25-4a69-b6a2-401c6b82e4f3
+        :id: 828d85df-3c25-4a69-b6a2-401c6b82e4f3
 
-        @Assert: Repository is not updated and error is raised
+        :Assert: Repository is not updated and error is raised
         """
         repo = entities.Repository(product=self.product).create()
         repo.label = gen_string('alpha')
@@ -759,9 +758,9 @@ class RepositoryTestCase(APITestCase):
         """Verify that repository URL credentials cannot be updated to contain
         the forbidden characters
 
-        @id: 47530b1c-e964-402a-a633-c81583fb5b98
+        :id: 47530b1c-e964-402a-a633-c81583fb5b98
 
-        @Assert: Repository url not updated
+        :Assert: Repository url not updated
         """
         new_repo = entities.Repository(product=self.product).create()
         # get auth repos with credentials containing unquoted special chars
@@ -782,9 +781,9 @@ class RepositoryTestCase(APITestCase):
     def test_negative_update_auth_url_too_long(self):
         """Update the original url for a repository to value which is too long
 
-        @id: cc00fbf4-d284-4404-88d9-ea0c0f03abe1
+        :id: cc00fbf4-d284-4404-88d9-ea0c0f03abe1
 
-        @Assert: Repository url not updated
+        :Assert: Repository url not updated
         """
         new_repo = entities.Repository(product=self.product).create()
         # get auth repos with credentials containing unquoted special chars
@@ -804,11 +803,11 @@ class RepositoryTestCase(APITestCase):
     def test_positive_synchronize(self):
         """Create a repo and sync it.
 
-        @id: 03beb469-570d-4109-b447-9c4c0b849266
+        :id: 03beb469-570d-4109-b447-9c4c0b849266
 
-        @Assert: The repo has at least one RPM.
+        :Assert: The repo has at least one RPM.
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         repo = entities.Repository(product=self.product).create()
         repo.sync()
@@ -820,11 +819,11 @@ class RepositoryTestCase(APITestCase):
     def test_positive_synchronize_auth_yum_repo(self):
         """Check if secured repository can be created and synced
 
-        @id: bc44881c-e13f-45a9-90c2-5b18c7b25454
+        :id: bc44881c-e13f-45a9-90c2-5b18c7b25454
 
-        @Assert: Repository is created and synced
+        :Assert: Repository is created and synced
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         url = FAKE_5_YUM_REPO
         for creds in [cred for cred in valid_http_credentials(url_encoded=True)
@@ -849,11 +848,11 @@ class RepositoryTestCase(APITestCase):
     def test_negative_synchronize_auth_yum_repo(self):
         """Check if secured repo fails to synchronize with invalid credentials
 
-        @id: 88361168-69b5-4239-819a-889e316e28dc
+        :id: 88361168-69b5-4239-819a-889e316e28dc
 
-        @Assert: Repository is created but synchronization fails
+        :Assert: Repository is created but synchronization fails
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         url = FAKE_5_YUM_REPO
         for creds in [cred for cred in valid_http_credentials(url_encoded=True)
@@ -877,11 +876,11 @@ class RepositoryTestCase(APITestCase):
     def test_positive_synchronize_auth_puppet_repo(self):
         """Check if secured puppet repository can be created and synced
 
-        @id: a1e25d36-baae-46cb-aa3b-5cb9fca4f059
+        :id: a1e25d36-baae-46cb-aa3b-5cb9fca4f059
 
-        @Assert: Repository is created and synced
+        :Assert: Repository is created and synced
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         url = FAKE_7_PUPPET_REPO
         for creds in [cred for cred in valid_http_credentials(url_encoded=True)
@@ -907,13 +906,13 @@ class RepositoryTestCase(APITestCase):
         """Check that repository content is resynced after packages were
         removed from repository
 
-        @id: e3a62529-edbd-4062-9246-bef5f33bdcf0
+        :id: e3a62529-edbd-4062-9246-bef5f33bdcf0
 
-        @Assert: Repository has updated non-zero packages count
+        :Assert: Repository has updated non-zero packages count
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
 
-        @BZ: 1318004
+        :BZ: 1318004
         """
         # Create repository and synchronize it
         repo = entities.Repository(
@@ -938,13 +937,13 @@ class RepositoryTestCase(APITestCase):
         """Check that repository content is resynced after puppet modules
         were removed from repository
 
-        @id: db50beb0-de73-4783-abc8-57e61188b6c7
+        :id: db50beb0-de73-4783-abc8-57e61188b6c7
 
-        @Assert: Repository has updated non-zero puppet modules count
+        :Assert: Repository has updated non-zero puppet modules count
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
 
-        @BZ: 1318004
+        :BZ: 1318004
         """
         # Create repository and synchronize it
         repo = entities.Repository(
@@ -968,9 +967,9 @@ class RepositoryTestCase(APITestCase):
     def test_positive_delete(self):
         """Create a repository with different names and then delete it.
 
-        @id: 29c2571a-b7fb-4ec7-b433-a1840758bcb0
+        :id: 29c2571a-b7fb-4ec7-b433-a1840758bcb0
 
-        @Assert: The repository deleted successfully.
+        :Assert: The repository deleted successfully.
         """
         for name in valid_data_list():
             with self.subTest(name):
@@ -985,11 +984,11 @@ class RepositoryTestCase(APITestCase):
     def test_positive_delete_rpm(self):
         """Check if rpm repository with packages can be deleted.
 
-        @id: d61c8c8b-2b77-4bff-b215-fa2b7c05aa78
+        :id: d61c8c8b-2b77-4bff-b215-fa2b7c05aa78
 
-        @Assert: The repository deleted successfully.
+        :Assert: The repository deleted successfully.
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         repo = entities.Repository(
             url=FAKE_2_YUM_REPO,
@@ -1008,13 +1007,13 @@ class RepositoryTestCase(APITestCase):
     def test_positive_delete_puppet(self):
         """Check if puppet repository with puppet modules can be deleted.
 
-        @id: 5c60b0ab-ef50-41a3-8578-bfdb5cb228ea
+        :id: 5c60b0ab-ef50-41a3-8578-bfdb5cb228ea
 
-        @Assert: The repository deleted successfully.
+        :Assert: The repository deleted successfully.
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
 
-        @BZ: 1316681
+        :BZ: 1316681
         """
         repo = entities.Repository(
             url=FAKE_1_PUPPET_REPO,
@@ -1034,10 +1033,10 @@ class RepositoryTestCase(APITestCase):
         """Verify that puppet modules list for specific repo is correct
         and does not affected by other repositories.
 
-        @id: e9e16ac2-a58d-4d49-b378-59e4f5b3a3ec
+        :id: e9e16ac2-a58d-4d49-b378-59e4f5b3a3ec
 
-        @Assert: Number of modules has no changed after a second repo
-        was synced.
+        :Assert: Number of modules has no changed after a second repo was
+            synced.
         """
         # Create and sync first repo
         repo1 = entities.Repository(
@@ -1071,11 +1070,11 @@ class RepositorySyncTestCase(APITestCase):
     def test_positive_sync_rh(self):
         """Sync RedHat Repository.
 
-        @id: d69c44cd-753c-4a75-9fd5-a8ed963b5e04
+        :id: d69c44cd-753c-4a75-9fd5-a8ed963b5e04
 
-        @Assert: Synced repo should fetch the data successfully.
+        :Assert: Synced repo should fetch the data successfully.
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         org = entities.Organization().create()
         with manifests.clone() as manifest:
@@ -1105,9 +1104,9 @@ class DockerRepositoryTestCase(APITestCase):
     def test_positive_create(self):
         """Create a Docker-type repository
 
-        @id: 2ce5b52d-8470-4c33-aeeb-9aee1af1cd74
+        :id: 2ce5b52d-8470-4c33-aeeb-9aee1af1cd74
 
-        @Assert: A repository is created with a Docker repository.
+        :Assert: A repository is created with a Docker repository.
         """
         product = entities.Product(organization=self.org).create()
         for name in valid_data_list():
@@ -1129,12 +1128,12 @@ class DockerRepositoryTestCase(APITestCase):
     def test_positive_synchronize(self):
         """Create and sync a Docker-type repository
 
-        @id: 27653663-e5a7-4700-a3c1-f6eab6468adf
+        :id: 27653663-e5a7-4700-a3c1-f6eab6468adf
 
-        @Assert: A repository is created with a Docker repository and it is
-        synchronized.
+        :Assert: A repository is created with a Docker repository and it is
+            synchronized.
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         product = entities.Product(organization=self.org).create()
         repo = entities.Repository(
@@ -1153,9 +1152,9 @@ class DockerRepositoryTestCase(APITestCase):
     def test_positive_update_name(self):
         """Update a repository's name.
 
-        @id: 6dff0c90-170f-40b9-9347-8ec97d89f2fd
+        :id: 6dff0c90-170f-40b9-9347-8ec97d89f2fd
 
-        @Assert: The repository's name is updated.
+        :Assert: The repository's name is updated.
         """
         repository = entities.Repository(
             content_type='docker'
@@ -1183,9 +1182,9 @@ class OstreeRepositoryTestCase(APITestCase):
     def test_positive_create_ostree(self):
         """Create ostree repository.
 
-        @id: f3332dd3-1e6d-44e2-8f24-fae6fba2de8d
+        :id: f3332dd3-1e6d-44e2-8f24-fae6fba2de8d
 
-        @Assert: A repository is created and has ostree type.
+        :Assert: A repository is created and has ostree type.
         """
         repo = entities.Repository(
             product=self.product,
@@ -1199,9 +1198,9 @@ class OstreeRepositoryTestCase(APITestCase):
     def test_positive_update_name(self):
         """Update ostree repository name.
 
-        @id: 4d9f1418-cc08-4c3c-a5dd-1d20fb9052a2
+        :id: 4d9f1418-cc08-4c3c-a5dd-1d20fb9052a2
 
-        @Assert: The repository name is updated.
+        :Assert: The repository name is updated.
         """
         repo = entities.Repository(
             product=self.product,
@@ -1218,9 +1217,9 @@ class OstreeRepositoryTestCase(APITestCase):
     def test_positive_update_url(self):
         """Update ostree repository url.
 
-        @id: 6ba45475-a060-42a7-bc9e-ea2824a5476b
+        :id: 6ba45475-a060-42a7-bc9e-ea2824a5476b
 
-        @Assert: The repository url is updated.
+        :Assert: The repository url is updated.
         """
         repo = entities.Repository(
             product=self.product,
@@ -1237,9 +1236,9 @@ class OstreeRepositoryTestCase(APITestCase):
     def test_positive_delete_ostree(self):
         """Delete an ostree repository.
 
-        @id: 05db79ed-28c7-47fc-85f5-194a805d71ca
+        :id: 05db79ed-28c7-47fc-85f5-194a805d71ca
 
-        @Assert: The ostree repository deleted successfully.
+        :Assert: The ostree repository deleted successfully.
         """
         repo = entities.Repository(
             product=self.product,
@@ -1257,11 +1256,11 @@ class OstreeRepositoryTestCase(APITestCase):
     def test_positive_sync_rh_atomic(self):
         """Sync RH Atomic Ostree Repository.
 
-        @id: 38c8aeaa-5ad2-40cb-b1d2-f0ac604f9fdd
+        :id: 38c8aeaa-5ad2-40cb-b1d2-f0ac604f9fdd
 
-        @Assert: Synced repo should fetch the data successfully.
+        :Assert: Synced repo should fetch the data successfully.
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         org = entities.Organization().create()
         with manifests.clone() as manifest:
@@ -1291,9 +1290,9 @@ class SRPMRepositoryTestCase(APITestCase):
     def test_positive_sync(self):
         """Synchronize repository with SRPMs
 
-        @id: f87391c6-c18a-4c4f-81db-decbba7f1856
+        :id: f87391c6-c18a-4c4f-81db-decbba7f1856
 
-        @Assert: srpms can be listed in repository
+        :Assert: srpms can be listed in repository
         """
         repo = entities.Repository(
             product=self.product,
@@ -1317,9 +1316,9 @@ class SRPMRepositoryTestCase(APITestCase):
         """Synchronize repository with SRPMs, add repository to content view
         and publish content view
 
-        @id: a0868429-584c-4e36-b93f-c85e8e94a60b
+        :id: a0868429-584c-4e36-b93f-c85e8e94a60b
 
-        @Assert: srpms can be listed in content view
+        :Assert: srpms can be listed in content view
         """
         repo = entities.Repository(
             product=self.product,
@@ -1348,10 +1347,10 @@ class SRPMRepositoryTestCase(APITestCase):
         """Synchronize repository with SRPMs, add repository to content view,
         publish and promote content view to lifecycle environment
 
-        @id: 811b524f-2b19-4408-ad7f-d7251625e35c
+        :id: 811b524f-2b19-4408-ad7f-d7251625e35c
 
-        @Assert: srpms can be listed in content view in proper lifecycle
-        environment
+        :Assert: srpms can be listed in content view in proper lifecycle
+            environment
         """
         lce = entities.LifecycleEnvironment(organization=self.org).create()
         repo = entities.Repository(
@@ -1394,9 +1393,9 @@ class DRPMRepositoryTestCase(APITestCase):
     def test_positive_sync(self):
         """Synchronize repository with DRPMs
 
-        @id: 7816031c-b7df-49e0-bf42-7f6e2d9b0233
+        :id: 7816031c-b7df-49e0-bf42-7f6e2d9b0233
 
-        @Assert: drpms can be listed in repository
+        :Assert: drpms can be listed in repository
         """
         repo = entities.Repository(
             product=self.product,
@@ -1420,9 +1419,9 @@ class DRPMRepositoryTestCase(APITestCase):
         """Synchronize repository with DRPMs, add repository to content view
         and publish content view
 
-        @id: dac4bd82-1433-4e5d-b82f-856056ca3924
+        :id: dac4bd82-1433-4e5d-b82f-856056ca3924
 
-        @Assert: drpms can be listed in content view
+        :Assert: drpms can be listed in content view
         """
         repo = entities.Repository(
             product=self.product,
@@ -1451,10 +1450,10 @@ class DRPMRepositoryTestCase(APITestCase):
         """Synchronize repository with DRPMs, add repository to content view,
         publish and promote content view to lifecycle environment
 
-        @id: 44296354-8ca2-4ce0-aa16-398effc80d9c
+        :id: 44296354-8ca2-4ce0-aa16-398effc80d9c
 
-        @Assert: drpms can be listed in content view in proper lifecycle
-        environment
+        :Assert: drpms can be listed in content view in proper lifecycle
+            environment
         """
         lce = entities.LifecycleEnvironment(organization=self.org).create()
         repo = entities.Repository(

--- a/tests/foreman/api/test_repository_set.py
+++ b/tests/foreman/api/test_repository_set.py
@@ -5,19 +5,19 @@ A full API reference for products can be found here:
 http://www.katello.org/docs/api/apidoc/repository_sets.html
 
 
-@Requirement: Repository set
+:Requirement: Repository set
 
-@CaseAutomation: Automated
+:CaseAutomation: Automated
 
-@CaseLevel: Acceptance
+:CaseLevel: Acceptance
 
-@CaseComponent: API
+:CaseComponent: API
 
-@TestType: Functional
+:TestType: Functional
 
-@CaseImportance: High
+:CaseImportance: High
 
-@Upstream: No
+:Upstream: No
 """
 from nailgun import entities
 from robottelo import manifests
@@ -36,9 +36,9 @@ class RepositorySetTestCase(APITestCase):
     def test_positive_reposet_enable(self):
         """Enable repo from reposet
 
-        @id: dedcecf7-613a-4e85-a3af-92fb57e2b0a1
+        :id: dedcecf7-613a-4e85-a3af-92fb57e2b0a1
 
-        @Assert: Repository was enabled
+        :Assert: Repository was enabled
         """
         org = entities.Organization().create()
         with manifests.clone() as manifest:
@@ -66,9 +66,9 @@ class RepositorySetTestCase(APITestCase):
     def test_positive_reposet_disable(self):
         """Disable repo from reposet
 
-        @id: 60a102df-099e-4325-8924-2a31e5f738ba
+        :id: 60a102df-099e-4325-8924-2a31e5f738ba
 
-        @Assert: Repository was disabled
+        :Assert: Repository was disabled
         """
         org = entities.Organization().create()
         with manifests.clone() as manifest:

--- a/tests/foreman/api/test_rhsm.py
+++ b/tests/foreman/api/test_rhsm.py
@@ -4,19 +4,19 @@ No API doc exists for the subscription manager path(s). However, bugzilla bug
 1112802 provides some relevant information.
 
 
-@Requirement: Rhsm
+:Requirement: Rhsm
 
-@CaseAutomation: Automated
+:CaseAutomation: Automated
 
-@CaseLevel: Acceptance
+:CaseLevel: Acceptance
 
-@CaseComponent: API
+:CaseComponent: API
 
-@TestType: Functional
+:TestType: Functional
 
-@CaseImportance: High
+:CaseImportance: High
 
-@Upstream: No
+:Upstream: No
 """
 from nailgun import client
 from robottelo.config import settings
@@ -32,10 +32,10 @@ class RedHatSubscriptionManagerTestCase(APITestCase):
     def test_positive_path(self):
         """Check whether the path exists.
 
-        @id: a8706cb7-549b-4426-9bd9-4beecc33c797
+        :id: a8706cb7-549b-4426-9bd9-4beecc33c797
 
-        @Assert: Issuing an HTTP GET produces an HTTP 200 response with an
-        ``application/json`` content-type, and the response is a list.
+        :Assert: Issuing an HTTP GET produces an HTTP 200 response with an
+            ``application/json`` content-type, and the response is a list.
 
         This test targets bugzilla bug 1112802.
         """

--- a/tests/foreman/api/test_role.py
+++ b/tests/foreman/api/test_role.py
@@ -4,19 +4,19 @@ An API reference is available here:
 http://theforeman.org/api/apidoc/v2/roles.html
 
 
-@Requirement: Role
+:Requirement: Role
 
-@CaseAutomation: Automated
+:CaseAutomation: Automated
 
-@CaseLevel: Acceptance
+:CaseLevel: Acceptance
 
-@CaseComponent: API
+:CaseComponent: API
 
-@TestType: Functional
+:TestType: Functional
 
-@CaseImportance: High
+:CaseImportance: High
 
-@Upstream: No
+:Upstream: No
 """
 
 from nailgun import entities
@@ -33,10 +33,11 @@ class RoleTestCase(APITestCase):
     def test_positive_create(self):
         """Create a role with name ``name_generator()``.
 
-        @id: 488a0970-f844-4286-b1eb-dd93005b4580
+        :id: 488a0970-f844-4286-b1eb-dd93005b4580
 
-        @Assert: An entity can be created without receiving any errors, the
-        entity can be fetched, and the fetched entity has the specified name.
+        :Assert: An entity can be created without receiving any errors, the
+            entity can be fetched, and the fetched entity has the specified
+            name.
         """
         for name in generate_strings_list(exclude_types=['html']):
             with self.subTest(name):
@@ -49,9 +50,9 @@ class RoleTestCase(APITestCase):
     def test_positive_delete(self):
         """Delete a role with name ``name_generator()``.
 
-        @id: 6e1d9f9c-3cbb-460b-8ef8-4a156e6552a0
+        :id: 6e1d9f9c-3cbb-460b-8ef8-4a156e6552a0
 
-        @Assert: The role cannot be fetched after it is deleted.
+        :Assert: The role cannot be fetched after it is deleted.
         """
         for name in generate_strings_list(exclude_types=['html']):
             with self.subTest(name):
@@ -68,9 +69,9 @@ class RoleTestCase(APITestCase):
     def test_positive_update(self):
         """Update a role with and give a name of ``name_generator()``.
 
-        @id: 30cb4b42-24cd-48a0-a3c5-7ca44c060e2e
+        :id: 30cb4b42-24cd-48a0-a3c5-7ca44c060e2e
 
-        @Assert: The role is updated with the given name.
+        :Assert: The role is updated with the given name.
         """
         for name in generate_strings_list(exclude_types=['html']):
             with self.subTest(name):
@@ -90,13 +91,13 @@ class CannedRoleTestCases(APITestCase):
     def test_positive_create_role_with_taxonomies(self):
         """create role with taxonomies
 
-        @id: fa449217-889c-429b-89b5-0b6c018ffd9e
+        :id: fa449217-889c-429b-89b5-0b6c018ffd9e
 
-        @steps: Create new role with taxonomies
+        :steps: Create new role with taxonomies
 
-        @assert: New role is created with taxonomies
+        :assert: New role is created with taxonomies
 
-        @caseautomation: notautomated
+        :caseautomation: notautomated
         """
 
     @stubbed
@@ -104,13 +105,13 @@ class CannedRoleTestCases(APITestCase):
     def test_positive_create_role_without_taxonomies(self):
         """Create role without taxonomies
 
-        @id: fe65a691-1b04-4bfe-a24b-adb48feb31d1
+        :id: fe65a691-1b04-4bfe-a24b-adb48feb31d1
 
-        @steps: Create new role without any taxonomies
+        :steps: Create new role without any taxonomies
 
-        @assert: New role is created without taxonomies
+        :assert: New role is created without taxonomies
 
-        @caseautomation: notautomated
+        :caseautomation: notautomated
         """
 
     @stubbed
@@ -118,20 +119,20 @@ class CannedRoleTestCases(APITestCase):
     def test_positive_create_filter_without_override(self):
         """Create filter in role w/o overriding it
 
-        @id: 1aadb7ea-ff76-4171-850f-188ba6f87021
+        :id: 1aadb7ea-ff76-4171-850f-188ba6f87021
 
-        @steps:
+        :steps:
 
-        1. Create a role with taxonomies assigned
-        2. Create filter in role without overriding it
+            1. Create a role with taxonomies assigned
+            2. Create filter in role without overriding it
 
-        @assert:
+        :assert:
 
-        1. Filter w/o override is created in role
-        2. The taxonomies of role are inherited to filter
-        3. Override check is not marked by default in filters table
+            1. Filter w/o override is created in role
+            2. The taxonomies of role are inherited to filter
+            3. Override check is not marked by default in filters table
 
-        @caseautomation: notautomated
+        :caseautomation: notautomated
         """
 
     @stubbed
@@ -139,20 +140,17 @@ class CannedRoleTestCases(APITestCase):
     def test_positive_create_non_overridable_filter(self):
         """Create non overridable filter in role
 
-        @id: f891e2e1-76f8-4edf-8c96-b41d05483298
+        :id: f891e2e1-76f8-4edf-8c96-b41d05483298
 
-        @steps:
+        :steps: Create a filter to which taxonomies cannot be associated.  e.g
+            Architecture filter
 
-        1. Create a filter to which taxonomies cannot be associated.
-        e.g Architecture filter
+        :assert:
+            1. Filter is created without taxonomies.
+            2. Override check is set to false
+            3. Filter doesnt inherit taxonomies from role
 
-        @assert:
-
-        1. Filter is created without taxonomies.
-        2. Override check is set to false
-        3. Filter doesnt inherit taxonomies from role
-
-        @caseautomation: notautomated
+        :caseautomation: notautomated
         """
 
     @stubbed
@@ -160,18 +158,15 @@ class CannedRoleTestCases(APITestCase):
     def test_negative_override_non_overridable_filter(self):
         """Override non overridable filter
 
-        @id: 7793be96-e8eb-451b-a986-51a46a1ab4f9
+        :id: 7793be96-e8eb-451b-a986-51a46a1ab4f9
 
-        @steps:
+        :steps: Attempt to override a filter to which taxonomies cannot be
+            associated.  e.g Architecture filter
 
-        1. Attempt to override a filter to which taxonomies cannot be
-        associated.
-        e.g Architecture filter
+        :assert: Filter is not overrided as taxonomies cannot be applied to
+            that filter
 
-        @assert: Filter is not overrided as taxonomies cannot be applied to
-        that filter
-
-        @caseautomation: notautomated
+        :caseautomation: notautomated
         """
 
     @stubbed
@@ -179,21 +174,21 @@ class CannedRoleTestCases(APITestCase):
     def test_positive_create_overridable_filter(self):
         """Create overridable filter in role
 
-        @id: c7ea9377-9b9e-495e-accd-3576166d504e
+        :id: c7ea9377-9b9e-495e-accd-3576166d504e
 
-        @steps:
+        :steps:
 
-        1. Create a filter to which taxonomies can be associated.
-        e.g Domain filter
-        2. Override a filter with some taxonomies
+            1. Create a filter to which taxonomies can be associated.
+            e.g Domain filter
+            2. Override a filter with some taxonomies
 
-        @assert:
+        :assert:
 
-        1. Filter is created with taxonomies
-        2. Override check is set to true
-        3. Filter doesnt inherits taxonomies from role
+            1. Filter is created with taxonomies
+            2. Override check is set to true
+            3. Filter doesnt inherits taxonomies from role
 
-        @caseautomation: notautomated
+        :caseautomation: notautomated
         """
 
     @stubbed
@@ -201,15 +196,13 @@ class CannedRoleTestCases(APITestCase):
     def test_positive_update_role_taxonomies(self):
         """Update role taxonomies which applies to its non-overrided filters
 
-        @id: 902dcb32-2126-4ff4-b733-3e86749ccd1e
+        :id: 902dcb32-2126-4ff4-b733-3e86749ccd1e
 
-        @steps:
+        :steps: Update existing role with different taxonomies
 
-        1. Update existing role with different taxonomies
+        :assert: The taxonomies are applied only to non-overrided role filters
 
-        @assert: The taxonomies are applied only to non-overrided role filters
-
-        @caseautomation: notautomated
+        :caseautomation: notautomated
         """
 
     @stubbed
@@ -217,15 +210,15 @@ class CannedRoleTestCases(APITestCase):
     def test_negative_update_role_taxonomies(self):
         """Update role taxonomies which doesnt applies to its overrided filters
 
-        @id: 9f3bf95a-f71a-4063-b51c-12610bc655f2
+        :id: 9f3bf95a-f71a-4063-b51c-12610bc655f2
 
-        @steps:
+        :steps:
 
-        1. Update existing role with different taxonomies
+            1. Update existing role with different taxonomies
 
-        @assert: The overridden role filters are not updated
+        :assert: The overridden role filters are not updated
 
-        @caseautomation: notautomated
+        :caseautomation: notautomated
         """
 
     @stubbed
@@ -233,17 +226,17 @@ class CannedRoleTestCases(APITestCase):
     def test_positive_disable_filter_override(self):
         """Unset override resets filter taxonomies
 
-        @id: eaa7b921-7c12-45c5-989b-d82aa2b6e3a6
+        :id: eaa7b921-7c12-45c5-989b-d82aa2b6e3a6
 
-        @steps:
+        :steps:
 
-        1. Create role with overridden filter having different taxonomies than
-        its role.
-        2. Unset the override flag in above role filter
+            1. Create role with overridden filter having different taxonomies
+               than its role.
+            2. Unset the override flag in above role filter
 
-        @assert: The taxonomies of filters resets/synced to role taxonomies
+        :assert: The taxonomies of filters resets/synced to role taxonomies
 
-        @caseautomation: notautomated
+        :caseautomation: notautomated
         """
 
     @stubbed
@@ -251,21 +244,21 @@ class CannedRoleTestCases(APITestCase):
     def test_positive_access_resources_from_role_taxonomies(self):
         """Test user access resources from taxonomies of assigned role
 
-        @id: 706a8cea-5f65-4736-81ae-eb6fa4ea8c7a
+        :id: 706a8cea-5f65-4736-81ae-eb6fa4ea8c7a
 
-        @steps:
+        :steps:
 
-        1. Create role with taxonomies
-        2. Create resource(s) filter(s) without overriding them
-        3. Create user with taxonomies same as role taxonomies
-        4. Assign step 1 role to user
+            1. Create role with taxonomies
+            2. Create resource(s) filter(s) without overriding them
+            3. Create user with taxonomies same as role taxonomies
+            4. Assign step 1 role to user
 
-        @assert: User should be able to access the resource(s) of the assigned
-        role
+        :assert: User should be able to access the resource(s) of the assigned
+            role
 
-        @caseautomation: notautomated
+        :caseautomation: notautomated
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
 
     @stubbed
@@ -274,19 +267,19 @@ class CannedRoleTestCases(APITestCase):
         """Test user cannot access resources from non associated taxonomies to
         role
 
-        @id: 87317ca9-b47b-4a6f-a80f-e2bbd1d9cf4e
+        :id: 87317ca9-b47b-4a6f-a80f-e2bbd1d9cf4e
 
-        @steps:
+        :steps:
 
-        1. Create role with taxonomies
-        2. Create resource(s) filter(s) without overriding them
-        3. Create user with taxonomies not matching role taxonomies
-        4. Assign step 1 role to user
+            1. Create role with taxonomies
+            2. Create resource(s) filter(s) without overriding them
+            3. Create user with taxonomies not matching role taxonomies
+            4. Assign step 1 role to user
 
-        @assert: User should not be able to access the resource(s) that are not
-        associated to assigned role
+        :assert: User should not be able to access the resource(s) that are not
+            associated to assigned role
 
-        @caseautomation: notautomated
+        :caseautomation: notautomated
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """

--- a/tests/foreman/api/test_smartproxy.py
+++ b/tests/foreman/api/test_smartproxy.py
@@ -1,18 +1,18 @@
 """Tests for the ``smart_proxies`` paths.
 
-@Requirement: Smartproxy
+:Requirement: Smartproxy
 
-@CaseAutomation: Automated
+:CaseAutomation: Automated
 
-@CaseLevel: Acceptance
+:CaseLevel: Acceptance
 
-@CaseComponent: API
+:CaseComponent: API
 
-@TestType: Functional
+:TestType: Functional
 
-@CaseImportance: High
+:CaseImportance: High
 
-@Upstream: No
+:Upstream: No
 """
 from fauxfactory import gen_url
 from nailgun import entities
@@ -45,9 +45,9 @@ class CapsuleTestCase(APITestCase):
     def test_negative_create_with_url(self):
         """Proxy creation with random URL
 
-        @id: e48a6260-97e0-4234-a69c-77bbbcde85d6
+        :id: e48a6260-97e0-4234-a69c-77bbbcde85d6
 
-        @Assert: Proxy is not created
+        :Assert: Proxy is not created
         """
         # Create a random proxy
         with self.assertRaises(HTTPError) as context:
@@ -61,9 +61,9 @@ class CapsuleTestCase(APITestCase):
     def test_positive_create_with_name(self):
         """Proxy creation with valid name
 
-        @id: 0ffe0dc5-675e-45f4-b7e1-a14d3dd81f6e
+        :id: 0ffe0dc5-675e-45f4-b7e1-a14d3dd81f6e
 
-        @Assert: Proxy is created
+        :Assert: Proxy is created
         """
         for name in valid_data_list():
             with self.subTest(name):
@@ -81,9 +81,9 @@ class CapsuleTestCase(APITestCase):
     def test_positive_delete(self):
         """Proxy deletion
 
-        @id: 872bf12e-736d-43d1-87cf-2923966b59d0
+        :id: 872bf12e-736d-43d1-87cf-2923966b59d0
 
-        @Assert: Proxy is deleted
+        :Assert: Proxy is deleted
         """
         new_port = get_available_capsule_port()
         with default_url_on_new_port(9090, new_port) as url:
@@ -98,9 +98,9 @@ class CapsuleTestCase(APITestCase):
     def test_positive_update_name(self):
         """Proxy name update
 
-        @id: f279640e-d7e9-48a3-aed8-7bf406e9d6f2
+        :id: f279640e-d7e9-48a3-aed8-7bf406e9d6f2
 
-        @Assert: Proxy has the name updated
+        :Assert: Proxy has the name updated
         """
         new_port = get_available_capsule_port()
         with default_url_on_new_port(9090, new_port) as url:
@@ -119,9 +119,9 @@ class CapsuleTestCase(APITestCase):
     def test_positive_update_url(self):
         """Proxy url update
 
-        @id: 0305fd54-4e0c-4dd9-a537-d342c3dc867e
+        :id: 0305fd54-4e0c-4dd9-a537-d342c3dc867e
 
-        @Assert: Proxy has the url updated
+        :Assert: Proxy has the url updated
         """
         # Create fake capsule
         port = get_available_capsule_port()
@@ -142,9 +142,9 @@ class CapsuleTestCase(APITestCase):
     def test_positive_update_organization(self):
         """Proxy name update with the home proxy
 
-        @id: 62631275-7a92-4d34-a949-c56e0c4063f1
+        :id: 62631275-7a92-4d34-a949-c56e0c4063f1
 
-        @Assert: Proxy has the name updated
+        :Assert: Proxy has the name updated
         """
         organizations = [
             entities.Organization().create() for _ in range(2)]
@@ -166,9 +166,9 @@ class CapsuleTestCase(APITestCase):
     def test_positive_update_location(self):
         """Proxy name update with the home proxy
 
-        @id: e08eaaa9-7c11-4cda-bbe7-6d1f7c732569
+        :id: e08eaaa9-7c11-4cda-bbe7-6d1f7c732569
 
-        @Assert: Proxy has the name updated
+        :Assert: Proxy has the name updated
         """
         locations = [entities.Location().create() for _ in range(2)]
         new_port = get_available_capsule_port()
@@ -189,11 +189,11 @@ class CapsuleTestCase(APITestCase):
     def test_positive_refresh_features(self):
         """Refresh smart proxy features, search for proxy by id
 
-        @id: d0237546-702e-4d1a-9212-8391295174da
+        :id: d0237546-702e-4d1a-9212-8391295174da
 
-        @Assert: Proxy features are refreshed
+        :Assert: Proxy features are refreshed
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         # Since we want to run multiple commands against our fake capsule, we
         # need the tunnel kept open in order not to allow different concurrent
@@ -213,9 +213,9 @@ class CapsuleTestCase(APITestCase):
     def test_positive_import_puppet_classes(self):
         """Import puppet classes from proxy
 
-        @id: 385efd1b-6146-47bf-babf-0127ce5955ed
+        :id: 385efd1b-6146-47bf-babf-0127ce5955ed
 
-        @Assert: Puppet classes are imported from proxy
+        :Assert: Puppet classes are imported from proxy
         """
         new_port = get_available_capsule_port()
         with default_url_on_new_port(9090, new_port) as url:
@@ -259,11 +259,11 @@ class SmartProxyMissingAttrTestCase(APITestCase):
     def test_positive_update_loc(self):
         """Update a smart proxy. Inspect the server's response.
 
-        @id: 42d6b749-c047-4fd2-90ee-ffab7be558f9
+        :id: 42d6b749-c047-4fd2-90ee-ffab7be558f9
 
-        @Assert: The response contains some value for the ``location`` field.
+        :Assert: The response contains some value for the ``location`` field.
 
-        @BZ: 1262037
+        :BZ: 1262037
         """
         names = one_to_many_names('location')
         self.assertGreaterEqual(
@@ -276,12 +276,12 @@ class SmartProxyMissingAttrTestCase(APITestCase):
     def test_positive_update_org(self):
         """Update a smart proxy. Inspect the server's response.
 
-        @id: fbde9f87-33db-4b95-a5f7-71a618460c84
+        :id: fbde9f87-33db-4b95-a5f7-71a618460c84
 
-        @Assert: The response contains some value for the ``organization``
-        field.
+        :Assert: The response contains some value for the ``organization``
+            field.
 
-        @BZ: 1262037
+        :BZ: 1262037
         """
         names = one_to_many_names('organization')
         self.assertGreaterEqual(

--- a/tests/foreman/api/test_subscription.py
+++ b/tests/foreman/api/test_subscription.py
@@ -4,19 +4,19 @@ A full API reference for subscriptions can be found here:
 https://<sat6.com>/apidoc/v2/subscriptions.html
 
 
-@Requirement: Subscription
+:Requirement: Subscription
 
-@CaseAutomation: Automated
+:CaseAutomation: Automated
 
-@CaseLevel: Acceptance
+:CaseLevel: Acceptance
 
-@CaseComponent: API
+:CaseComponent: API
 
-@TestType: Functional
+:TestType: Functional
 
-@CaseImportance: High
+:CaseImportance: High
 
-@Upstream: No
+:Upstream: No
 """
 from nailgun import entities
 from nailgun.entity_mixins import TaskFailedError
@@ -35,9 +35,9 @@ class SubscriptionsTestCase(APITestCase):
     def test_positive_create(self):
         """Upload a manifest.
 
-        @id: 6faf9d96-9b45-4bdc-afa9-ec3fbae83d41
+        :id: 6faf9d96-9b45-4bdc-afa9-ec3fbae83d41
 
-        @Assert: Manifest is uploaded successfully
+        :Assert: Manifest is uploaded successfully
         """
         org = entities.Organization().create()
         with manifests.clone() as manifest:
@@ -48,9 +48,9 @@ class SubscriptionsTestCase(APITestCase):
     def test_positive_refresh(self):
         """Upload a manifest and refresh it afterwards.
 
-        @id: cd195db6-e81b-42cb-a28d-ec0eb8a53341
+        :id: cd195db6-e81b-42cb-a28d-ec0eb8a53341
 
-        @Assert: Manifest is refreshed successfully
+        :Assert: Manifest is refreshed successfully
         """
         org = entities.Organization().create()
         sub = entities.Subscription(organization=org)
@@ -67,9 +67,9 @@ class SubscriptionsTestCase(APITestCase):
     def test_positive_delete(self):
         """Delete an Uploaded manifest.
 
-        @id: 4c21c7c9-2b26-4a65-a304-b978d5ba34fc
+        :id: 4c21c7c9-2b26-4a65-a304-b978d5ba34fc
 
-        @Assert: Manifest is Deleted successfully
+        :Assert: Manifest is Deleted successfully
         """
         org = entities.Organization().create()
         sub = entities.Subscription(organization=org)
@@ -84,9 +84,9 @@ class SubscriptionsTestCase(APITestCase):
     def test_negative_upload(self):
         """Upload the same manifest to two organizations.
 
-        @id: 60ca078d-cfaf-402e-b0db-34d8901449fe
+        :id: 60ca078d-cfaf-402e-b0db-34d8901449fe
 
-        @Assert: The manifest is not uploaded to the second organization.
+        :Assert: The manifest is not uploaded to the second organization.
         """
         orgs = [entities.Organization().create() for _ in range(2)]
         with manifests.clone() as manifest:

--- a/tests/foreman/api/test_syncplan.py
+++ b/tests/foreman/api/test_syncplan.py
@@ -4,19 +4,19 @@ A full API reference for sync plans can be found here:
 http://www.katello.org/docs/api/apidoc/sync_plans.html
 
 
-@Requirement: Syncplan
+:Requirement: Syncplan
 
-@CaseAutomation: Automated
+:CaseAutomation: Automated
 
-@CaseLevel: Acceptance
+:CaseLevel: Acceptance
 
-@CaseComponent: API
+:CaseComponent: API
 
-@TestType: Functional
+:TestType: Functional
 
-@CaseImportance: High
+:CaseImportance: High
 
-@Upstream: No
+:Upstream: No
 """
 import random
 from datetime import datetime, timedelta
@@ -76,9 +76,9 @@ class SyncPlanTestCase(APITestCase):
     def test_positive_get_routes(self):
         """Issue an HTTP GET response to both available routes.
 
-        @id: 9e40ea7f-71ea-4ced-94ba-cde03620c654
+        :id: 9e40ea7f-71ea-4ced-94ba-cde03620c654
 
-        @Assert: The same response is returned.
+        :Assert: The same response is returned.
 
         Targets BZ 1132817.
         """
@@ -120,9 +120,9 @@ class SyncPlanCreateTestCase(APITestCase):
     def test_positive_create_enabled_disabled(self):
         """Create sync plan with different 'enabled' field values.
 
-        @id: df5837e7-3d0f-464a-bd67-86b423c16eb4
+        :id: df5837e7-3d0f-464a-bd67-86b423c16eb4
 
-        @Assert: A sync plan is created, 'enabled' field has correct value.
+        :Assert: A sync plan is created, 'enabled' field has correct value.
         """
         for enabled in (False, True):
             with self.subTest(enabled):
@@ -137,9 +137,9 @@ class SyncPlanCreateTestCase(APITestCase):
     def test_positive_create_with_name(self):
         """Create a sync plan with a random name.
 
-        @id: c1263134-0d7c-425a-82fd-df5274e1f9ba
+        :id: c1263134-0d7c-425a-82fd-df5274e1f9ba
 
-        @Assert: A sync plan is created with the specified name.
+        :Assert: A sync plan is created with the specified name.
         """
         for name in valid_data_list():
             with self.subTest(name):
@@ -154,9 +154,9 @@ class SyncPlanCreateTestCase(APITestCase):
     def test_positive_create_with_description(self):
         """Create a sync plan with a random description.
 
-        @id: 3e5745e8-838d-44a5-ad61-7e56829ad47c
+        :id: 3e5745e8-838d-44a5-ad61-7e56829ad47c
 
-        @Assert: A sync plan is created with the specified description.
+        :Assert: A sync plan is created with the specified description.
         """
         for description in valid_data_list():
             with self.subTest(description):
@@ -171,9 +171,9 @@ class SyncPlanCreateTestCase(APITestCase):
     def test_positive_create_with_interval(self):
         """Create a sync plan with a random interval.
 
-        @id: d160ed1c-b698-42dc-be0b-67ac693c7840
+        :id: d160ed1c-b698-42dc-be0b-67ac693c7840
 
-        @Assert: A sync plan is created with the specified interval.
+        :Assert: A sync plan is created with the specified interval.
         """
         for interval in valid_sync_interval():
             with self.subTest(interval):
@@ -188,9 +188,9 @@ class SyncPlanCreateTestCase(APITestCase):
     def test_positive_create_with_sync_date(self):
         """Create a sync plan and update its sync date.
 
-        @id: bdb6e0a9-0d3b-4811-83e2-2140b7bb62e3
+        :id: bdb6e0a9-0d3b-4811-83e2-2140b7bb62e3
 
-        @Assert: A sync plan can be created with a random sync date.
+        :Assert: A sync plan can be created with a random sync date.
         """
         for syncdate in valid_sync_dates():
             with self.subTest(syncdate):
@@ -208,9 +208,9 @@ class SyncPlanCreateTestCase(APITestCase):
     def test_negative_create_with_invalid_name(self):
         """Create a sync plan with an invalid name.
 
-        @id: a3a0f844-2f81-4f87-9f68-c25506c29ce2
+        :id: a3a0f844-2f81-4f87-9f68-c25506c29ce2
 
-        @Assert: A sync plan can not be created with the specified name.
+        :Assert: A sync plan can not be created with the specified name.
         """
         for name in invalid_values_list():
             with self.subTest(name):
@@ -225,9 +225,9 @@ class SyncPlanCreateTestCase(APITestCase):
     def test_negative_create_with_invalid_interval(self):
         """Create a sync plan with invalid interval specified.
 
-        @id: f5844526-9f58-4be3-8a96-3849a465fc02
+        :id: f5844526-9f58-4be3-8a96-3849a465fc02
 
-        @Assert: A sync plan can not be created with invalid interval specified
+        :Assert: A sync plan can not be created with invalid interval specified
         """
         for interval in invalid_values_list():
             with self.subTest(interval):
@@ -242,9 +242,9 @@ class SyncPlanCreateTestCase(APITestCase):
     def test_negative_create_with_empty_interval(self):
         """Create a sync plan with no interval specified.
 
-        @id: b4686463-69c8-4538-b040-6fb5246a7b00
+        :id: b4686463-69c8-4538-b040-6fb5246a7b00
 
-        @Assert: A sync plan can not be created with no interval specified.
+        :Assert: A sync plan can not be created with no interval specified.
         """
         sync_plan = entities.SyncPlan(organization=self.org)
         sync_plan.create_missing()
@@ -267,9 +267,9 @@ class SyncPlanUpdateTestCase(APITestCase):
     def test_positive_update_enabled(self):
         """Create sync plan and update it with opposite 'enabled' value.
 
-        @id: 325c0ef5-c0e8-4cb9-b85e-87eb7f42c2f8
+        :id: 325c0ef5-c0e8-4cb9-b85e-87eb7f42c2f8
 
-        @Assert: Sync plan is updated with different 'enabled' value.
+        :Assert: Sync plan is updated with different 'enabled' value.
         """
         for enabled in (False, True):
             with self.subTest(enabled):
@@ -288,10 +288,10 @@ class SyncPlanUpdateTestCase(APITestCase):
     def test_positive_update_name(self):
         """Create a sync plan and update its name.
 
-        @id: dbfadf4f-50af-4aa8-8d7d-43988dc4528f
+        :id: dbfadf4f-50af-4aa8-8d7d-43988dc4528f
 
-        @Assert: A sync plan is created and its name can be updated with the
-        specified name.
+        :Assert: A sync plan is created and its name can be updated with the
+            specified name.
         """
         sync_plan = entities.SyncPlan(organization=self.org).create()
         for name in valid_data_list():
@@ -304,10 +304,10 @@ class SyncPlanUpdateTestCase(APITestCase):
     def test_positive_update_description(self):
         """Create a sync plan and update its description.
 
-        @id: 4769fe9c-9eec-40c8-b015-1e3d7e570bec
+        :id: 4769fe9c-9eec-40c8-b015-1e3d7e570bec
 
-        @Assert: A sync plan is created and its description can be updated with
-        the specified description.
+        :Assert: A sync plan is created and its description can be updated with
+            the specified description.
         """
         sync_plan = entities.SyncPlan(
             description=gen_string('alpha'),
@@ -326,10 +326,10 @@ class SyncPlanUpdateTestCase(APITestCase):
     def test_positive_update_interval(self):
         """Create a sync plan and update its interval.
 
-        @id: cf2eddf8-b4db-430e-a9b0-83c626b45068
+        :id: cf2eddf8-b4db-430e-a9b0-83c626b45068
 
-        @Assert: A sync plan is created and its interval can be updated with
-        the specified interval.
+        :Assert: A sync plan is created and its interval can be updated with
+            the specified interval.
         """
         for interval in valid_sync_interval():
             with self.subTest(interval):
@@ -351,9 +351,9 @@ class SyncPlanUpdateTestCase(APITestCase):
     def test_positive_update_sync_date(self):
         """Updated sync plan's sync date.
 
-        @id: fad472c7-01b4-453b-ae33-0845c9e0dfd4
+        :id: fad472c7-01b4-453b-ae33-0845c9e0dfd4
 
-        @Assert: Sync date is updated with the specified sync date.
+        :Assert: Sync date is updated with the specified sync date.
         """
         sync_plan = entities.SyncPlan(
             organization=self.org,
@@ -372,9 +372,9 @@ class SyncPlanUpdateTestCase(APITestCase):
     def test_negative_update_name(self):
         """Try to update a sync plan with an invalid name.
 
-        @id: ae502053-9d3c-4cad-aee4-821f846ceae5
+        :id: ae502053-9d3c-4cad-aee4-821f846ceae5
 
-        @Assert: A sync plan can not be updated with the specified name.
+        :Assert: A sync plan can not be updated with the specified name.
         """
         sync_plan = entities.SyncPlan(organization=self.org).create()
         for name in invalid_values_list():
@@ -388,9 +388,9 @@ class SyncPlanUpdateTestCase(APITestCase):
     def test_negative_update_interval(self):
         """Try to update a sync plan with invalid interval.
 
-        @id: 8c981174-6f55-49c0-8baa-40e5c3fc598c
+        :id: 8c981174-6f55-49c0-8baa-40e5c3fc598c
 
-        @Assert: A sync plan can not be updated with empty interval specified.
+        :Assert: A sync plan can not be updated with empty interval specified.
         """
         sync_plan = entities.SyncPlan(organization=self.org).create()
         for interval in invalid_values_list():
@@ -416,11 +416,11 @@ class SyncPlanProductTestCase(APITestCase):
     def test_positive_add_product(self):
         """Create a sync plan and add one product to it.
 
-        @id: 036dea02-f73d-4fc1-9c41-5515b6659c79
+        :id: 036dea02-f73d-4fc1-9c41-5515b6659c79
 
-        @Assert: A sync plan can be created and one product can be added to it.
+        :Assert: A sync plan can be created and one product can be added to it.
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         syncplan = entities.SyncPlan(organization=self.org).create()
         product = entities.Product(organization=self.org).create()
@@ -434,12 +434,12 @@ class SyncPlanProductTestCase(APITestCase):
     def test_positive_add_products(self):
         """Create a sync plan and add two products to it.
 
-        @id: 2a80ecad-2245-46d8-bbc6-0b802e68d50c
+        :id: 2a80ecad-2245-46d8-bbc6-0b802e68d50c
 
-        @Assert: A sync plan can be created and two products can be added to
-        it.
+        :Assert: A sync plan can be created and two products can be added to
+            it.
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         syncplan = entities.SyncPlan(organization=self.org).create()
         products = [
@@ -462,12 +462,12 @@ class SyncPlanProductTestCase(APITestCase):
         """Create a sync plan with two products and then remove one
         product from it.
 
-        @id: 987a0d94-ceb7-4115-9770-2297e60a63fa
+        :id: 987a0d94-ceb7-4115-9770-2297e60a63fa
 
-        @Assert: A sync plan can be created and one product can be removed from
-        it.
+        :Assert: A sync plan can be created and one product can be removed from
+            it.
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         syncplan = entities.SyncPlan(organization=self.org).create()
         products = [
@@ -488,12 +488,12 @@ class SyncPlanProductTestCase(APITestCase):
         """Create a sync plan with two products and then remove both
         products from it.
 
-        @id: eed8c239-8ba3-4dbd-aa6b-c289cd4efd47
+        :id: eed8c239-8ba3-4dbd-aa6b-c289cd4efd47
 
-        @Assert: A sync plan can be created and both products can be removed
-        from it.
+        :Assert: A sync plan can be created and both products can be removed
+            from it.
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         syncplan = entities.SyncPlan(organization=self.org).create()
         products = [
@@ -514,12 +514,12 @@ class SyncPlanProductTestCase(APITestCase):
     def test_positive_repeatedly_add_remove(self):
         """Repeatedly add and remove a product from a sync plan.
 
-        @id: b67536ba-3a36-4bb7-a405-0e12081d5a7e
+        :id: b67536ba-3a36-4bb7-a405-0e12081d5a7e
 
-        @Assert: A task is returned which can be used to monitor the additions
-        and removals.
+        :Assert: A task is returned which can be used to monitor the additions
+            and removals.
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         syncplan = entities.SyncPlan(organization=self.org).create()
         product = entities.Product(organization=self.org).create()
@@ -577,13 +577,13 @@ class SyncPlanSynchronizeTestCase(APITestCase):
         """Verify product won't get synced immediately after adding association
         with a sync plan which has already been started
 
-        @id: 263a6a79-8236-4757-bf9e-8d9091ba2a11
+        :id: 263a6a79-8236-4757-bf9e-8d9091ba2a11
 
-        @Assert: Product was not synchronized
+        :Assert: Product was not synchronized
 
-        @BZ: 1279539
+        :BZ: 1279539
 
-        @CaseLevel: System
+        :CaseLevel: System
         """
         sync_plan = entities.SyncPlan(
             organization=self.org,
@@ -612,13 +612,13 @@ class SyncPlanSynchronizeTestCase(APITestCase):
         custom product and verify the product gets synchronized on the next
         sync occurrence
 
-        @id: 0495cb39-2f15-4b6e-9828-1e9517c5c826
+        :id: 0495cb39-2f15-4b6e-9828-1e9517c5c826
 
-        @Assert: Product is synchronized successfully.
+        :Assert: Product is synchronized successfully.
 
-        @BZ: 1279539
+        :BZ: 1279539
 
-        @CaseLevel: System
+        :CaseLevel: System
         """
         interval = 60 * 60  # 'hourly' sync interval in seconds
         sync_plan = entities.SyncPlan(
@@ -647,11 +647,11 @@ class SyncPlanSynchronizeTestCase(APITestCase):
         """Create a sync plan with sync date in a future and sync one custom
         product with it automatically.
 
-        @id: b70a0c50-7335-4285-b24c-edfc1187f034
+        :id: b70a0c50-7335-4285-b24c-edfc1187f034
 
-        @Assert: Product is synchronized successfully.
+        :Assert: Product is synchronized successfully.
 
-        @CaseLevel: System
+        :CaseLevel: System
         """
         delay = 10 * 60  # delay for sync date in seconds
         sync_plan = entities.SyncPlan(
@@ -682,11 +682,11 @@ class SyncPlanSynchronizeTestCase(APITestCase):
         """Create a sync plan with sync date in a future and sync multiple
         custom products with multiple repos automatically.
 
-        @id: e646196e-3951-4297-8c3c-1494d9895347
+        :id: e646196e-3951-4297-8c3c-1494d9895347
 
-        @Assert: Products are synchronized successfully.
+        :Assert: Products are synchronized successfully.
 
-        @CaseLevel: System
+        :CaseLevel: System
         """
         delay = 10 * 60  # delay for sync date in seconds
         sync_plan = entities.SyncPlan(
@@ -737,13 +737,13 @@ class SyncPlanSynchronizeTestCase(APITestCase):
         RH product and verify the product gets synchronized on the next sync
         occurrence
 
-        @id: 080c316d-4a06-4ee9-b5f6-1b210d8d0593
+        :id: 080c316d-4a06-4ee9-b5f6-1b210d8d0593
 
-        @Assert: Product is synchronized successfully.
+        :Assert: Product is synchronized successfully.
 
-        @BZ: 1279539
+        :BZ: 1279539
 
-        @CaseLevel: System
+        :CaseLevel: System
         """
         interval = 60 * 60  # 'hourly' sync interval in seconds
         org = entities.Organization().create()
@@ -790,11 +790,11 @@ class SyncPlanSynchronizeTestCase(APITestCase):
         """Create a sync plan with sync date in a future and sync one RH
         product with it automatically.
 
-        @id: 6697a00f-2181-4c2b-88eb-2333268d780b
+        :id: 6697a00f-2181-4c2b-88eb-2333268d780b
 
-        @Assert: Product is synchronized successfully.
+        :Assert: Product is synchronized successfully.
 
-        @CaseLevel: System
+        :CaseLevel: System
         """
         delay = 10 * 60  # delay for sync date in seconds
         org = entities.Organization().create()
@@ -853,12 +853,12 @@ class SyncPlanDeleteTestCase(APITestCase):
     def test_positive_delete_one_product(self):
         """Create a sync plan with one product and delete it.
 
-        @id: e565c464-33e2-4bca-8eca-15d5a7d4b155
+        :id: e565c464-33e2-4bca-8eca-15d5a7d4b155
 
-        @Assert: A sync plan is created with one product and sync plan can be
-        deleted.
+        :Assert: A sync plan is created with one product and sync plan can be
+            deleted.
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         sync_plan = entities.SyncPlan(organization=self.org).create()
         product = entities.Product(organization=self.org).create()
@@ -872,12 +872,12 @@ class SyncPlanDeleteTestCase(APITestCase):
     def test_positive_delete_products(self):
         """Create a sync plan with two products and delete them.
 
-        @id: f21bd57f-369e-4acd-a492-5532349a3804
+        :id: f21bd57f-369e-4acd-a492-5532349a3804
 
-        @Assert: A sync plan is created with one product and sync plan can be
-        deleted.
+        :Assert: A sync plan is created with one product and sync plan can be
+            deleted.
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         sync_plan = entities.SyncPlan(organization=self.org).create()
         products = [
@@ -895,12 +895,12 @@ class SyncPlanDeleteTestCase(APITestCase):
     def test_positive_delete_synced_product(self):
         """Create a sync plan with one synced product and delete it.
 
-        @id: 195d8fec-1fa0-42ab-84a5-32dd81a285ca
+        :id: 195d8fec-1fa0-42ab-84a5-32dd81a285ca
 
-        @Assert: A sync plan is created with one synced product and sync plan
-        can be deleted.
+        :Assert: A sync plan is created with one synced product and sync plan
+            can be deleted.
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         sync_plan = entities.SyncPlan(organization=self.org).create()
         product = entities.Product(organization=self.org).create()

--- a/tests/foreman/api/test_template.py
+++ b/tests/foreman/api/test_template.py
@@ -4,19 +4,19 @@ A full API reference is available here:
 http://theforeman.org/api/apidoc/v2/config_templates.html
 
 
-@Requirement: Template
+:Requirement: Template
 
-@CaseAutomation: Automated
+:CaseAutomation: Automated
 
-@CaseLevel: Acceptance
+:CaseLevel: Acceptance
 
-@CaseComponent: API
+:CaseComponent: API
 
-@TestType: Functional
+:TestType: Functional
 
-@CaseImportance: High
+:CaseImportance: High
 
-@Upstream: No
+:Upstream: No
 """
 from random import choice
 
@@ -38,11 +38,11 @@ class ConfigTemplateTestCase(APITestCase):
     def test_positive_build_pxe_default(self):
         """Call the "build_pxe_default" path.
 
-        @id: ca19d9da-1049-4b39-823b-933fc1a0cebd
+        :id: ca19d9da-1049-4b39-823b-933fc1a0cebd
 
-        @Assert: The response is a JSON payload.
+        :Assert: The response is a JSON payload.
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         response = client.get(
             entities.ConfigTemplate().path('build_pxe_default'),
@@ -57,11 +57,11 @@ class ConfigTemplateTestCase(APITestCase):
     def test_positive_add_orgs(self):
         """Associate a config template with organizations.
 
-        @id: b60907c3-47b9-4bc7-99d6-08615ebe9d68
+        :id: b60907c3-47b9-4bc7-99d6-08615ebe9d68
 
-        @Assert: Config template is associated with organization
+        :Assert: Config template is associated with organization
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         orgs = [entities.Organization().create() for _ in range(2)]
 
@@ -93,9 +93,9 @@ class ConfigTemplateTestCase(APITestCase):
     def test_positive_create_with_name(self):
         """Create a configuration template providing the initial name.
 
-        @id: 20ccd5c8-98c3-4f22-af50-9760940e5d39
+        :id: 20ccd5c8-98c3-4f22-af50-9760940e5d39
 
-        @Assert: Configuration Template is created and contains provided name.
+        :Assert: Configuration Template is created and contains provided name.
         """
         for name in valid_data_list():
             with self.subTest(name):
@@ -106,9 +106,9 @@ class ConfigTemplateTestCase(APITestCase):
     def test_negative_create_with_invalid_name(self):
         """Create configuration template providing an invalid name.
 
-        @id: 2ec7023f-db4d-49ed-b783-6a4fce79064a
+        :id: 2ec7023f-db4d-49ed-b783-6a4fce79064a
 
-        @Assert: Configuration Template is not created
+        :Assert: Configuration Template is not created
         """
         for name in invalid_names_list():
             with self.subTest(name):
@@ -119,10 +119,10 @@ class ConfigTemplateTestCase(APITestCase):
     def test_positive_create_with_template_kind(self):
         """Create a provisioning template providing the template_kind.
 
-        @id: d7309be8-b5c9-4f77-8c4e-e9f2b8982076
+        :id: d7309be8-b5c9-4f77-8c4e-e9f2b8982076
 
-        @Assert: Provisioning Template is created and contains provided
-        template kind.
+        :Assert: Provisioning Template is created and contains provided
+            template kind.
         """
         template_kind = choice(entities.TemplateKind().search())
         template = entities.ProvisioningTemplate(
@@ -135,11 +135,11 @@ class ConfigTemplateTestCase(APITestCase):
         """Create a provisioning template providing existing
         template_kind name.
 
-        @id: 4a1410e4-aa3c-4d27-b062-089e34722bd9
+        :id: 4a1410e4-aa3c-4d27-b062-089e34722bd9
 
-        @Assert: Provisioning Template is created
+        :Assert: Provisioning Template is created
 
-        @BZ: 1379006
+        :BZ: 1379006
         """
         template_kind = choice(entities.TemplateKind().search())
         template = entities.ProvisioningTemplate(snippet=False)
@@ -154,11 +154,11 @@ class ConfigTemplateTestCase(APITestCase):
         """Create a provisioning template providing non-existing
         template_kind name.
 
-        @id: e6de9ceb-fe4b-43ce-b7e3-5453ca4bd164
+        :id: e6de9ceb-fe4b-43ce-b7e3-5453ca4bd164
 
-        @Assert: 404 error and expected message is returned
+        :Assert: 404 error and expected message is returned
 
-        @BZ: 1379006
+        :BZ: 1379006
         """
         template = entities.ProvisioningTemplate(snippet=False)
         template.create_missing()
@@ -177,10 +177,10 @@ class ConfigTemplateTestCase(APITestCase):
         """Create configuration template providing the initial name,
         then update its name to another valid name.
 
-        @id: 58ccc4ee-5faa-4fb2-bfd0-e19412e230dd
+        :id: 58ccc4ee-5faa-4fb2-bfd0-e19412e230dd
 
-        @Assert: Configuration Template is created, and its name can be
-        updated.
+        :Assert: Configuration Template is created, and its name can be
+            updated.
         """
         c_temp = entities.ConfigTemplate().create()
 
@@ -195,10 +195,10 @@ class ConfigTemplateTestCase(APITestCase):
         """Create configuration template then update its name to an
         invalid name.
 
-        @id: f6167dc5-26ba-46d7-b61f-14c290d6a8fa
+        :id: f6167dc5-26ba-46d7-b61f-14c290d6a8fa
 
-        @Assert: Configuration Template is created, and its name is not
-        updated.
+        :Assert: Configuration Template is created, and its name is not
+            updated.
         """
         c_temp = entities.ConfigTemplate().create()
         for new_name in invalid_names_list():
@@ -213,9 +213,9 @@ class ConfigTemplateTestCase(APITestCase):
     def test_positive_delete(self):
         """Create configuration template and then delete it.
 
-        @id: 1471f17c-4412-4717-a6c4-b57a8d2f8cfd
+        :id: 1471f17c-4412-4717-a6c4-b57a8d2f8cfd
 
-        @Assert: Configuration Template is successfully deleted.
+        :Assert: Configuration Template is successfully deleted.
         """
         for name in valid_data_list():
             with self.subTest(name):
@@ -228,11 +228,11 @@ class ConfigTemplateTestCase(APITestCase):
     def test_positive_clone(self):
         """Assure ability to clone a provisioning template
 
-        @id: 8dfbb234-7a52-4873-be72-4de086472669
+        :id: 8dfbb234-7a52-4873-be72-4de086472669
 
-        @Assert: The template is cloned successfully with all values
+        :Assert: The template is cloned successfully with all values
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         template = entities.ConfigTemplate().create()
         template_origin = template.read_json()

--- a/tests/foreman/api/test_template_combination.py
+++ b/tests/foreman/api/test_template_combination.py
@@ -1,19 +1,19 @@
 # -*- coding: utf-8 -*-
 """Tests for template combination
 
-@Requirement: TemplateCombination
+:Requirement: TemplateCombination
 
-@CaseAutomation: Automated
+:CaseAutomation: Automated
 
-@CaseLevel: Acceptance
+:CaseLevel: Acceptance
 
-@CaseComponent: API
+:CaseComponent: API
 
-@TestType: Functional
+:TestType: Functional
 
-@CaseImportance: Medium
+:CaseImportance: Medium
 
-@Upstream: No
+:Upstream: No
 """
 from nailgun import entities
 from requests.exceptions import HTTPError
@@ -75,11 +75,11 @@ class TemplateCombinationTestCase(APITestCase):
     def test_positive_get_combination(self):
         """Assert API template combination get method works.
 
-        @id: 2447674e-c37e-11e6-93cb-68f72889dc7f
+        :id: 2447674e-c37e-11e6-93cb-68f72889dc7f
 
-        @Setup: save a template combination
+        :Setup: save a template combination
 
-        @Assert: TemplateCombination can be retrieved through API
+        :Assert: TemplateCombination can be retrieved through API
         """
         combination = self.template_combination.read()
         self.assertIsInstance(combination, entities.TemplateCombination)
@@ -92,11 +92,11 @@ class TemplateCombinationTestCase(APITestCase):
     def test_positive_delete_combination(self):
         """Assert API template combination delete method works.
 
-        @id: 3a5cb370-c5f6-11e6-bb2f-68f72889dc7f
+        :id: 3a5cb370-c5f6-11e6-bb2f-68f72889dc7f
 
-        @Setup: save a template combination
+        :Setup: save a template combination
 
-        @Assert: TemplateCombination can be deleted through API
+        :Assert: TemplateCombination can be deleted through API
         """
         combination = self.template_combination.read()
         self.assertIsInstance(combination, entities.TemplateCombination)

--- a/tests/foreman/api/test_user.py
+++ b/tests/foreman/api/test_user.py
@@ -4,19 +4,19 @@ Each ``APITestCase`` subclass tests a single URL. A full list of URLs to be
 tested can be found here: http://theforeman.org/api/apidoc/v2/users.html
 
 
-@Requirement: User
+:Requirement: User
 
-@CaseAutomation: Automated
+:CaseAutomation: Automated
 
-@CaseLevel: Acceptance
+:CaseLevel: Acceptance
 
-@CaseComponent: API
+:CaseComponent: API
 
-@TestType: Functional
+:TestType: Functional
 
-@CaseImportance: High
+:CaseImportance: High
 
-@Upstream: No
+:Upstream: No
 """
 from nailgun import entities
 from requests.exceptions import HTTPError
@@ -39,9 +39,9 @@ class UserTestCase(APITestCase):
     def test_positive_create_with_username(self):
         """Create User for all variations of Username
 
-        @id: a9827cda-7f6d-4785-86ff-3b6969c9c00a
+        :id: a9827cda-7f6d-4785-86ff-3b6969c9c00a
 
-        @Assert: User is created
+        :Assert: User is created
         """
         for username in valid_usernames_list():
             with self.subTest(username):
@@ -52,9 +52,9 @@ class UserTestCase(APITestCase):
     def test_positive_create_with_firstname(self):
         """Create User for all variations of First Name
 
-        @id: 036bb958-227c-420c-8f2b-c607136f12e0
+        :id: 036bb958-227c-420c-8f2b-c607136f12e0
 
-        @Assert: User is created
+        :Assert: User is created
         """
         for firstname in generate_strings_list(
                 exclude_types=['html'], max_length=50):
@@ -66,9 +66,9 @@ class UserTestCase(APITestCase):
     def test_positive_create_with_lastname(self):
         """Create User for all variations of Last Name
 
-        @id: 95d3b571-77e7-42a1-9c48-21f242e8cdc2
+        :id: 95d3b571-77e7-42a1-9c48-21f242e8cdc2
 
-        @Assert: User is created
+        :Assert: User is created
         """
         for lastname in generate_strings_list(
                 exclude_types=['html'], max_length=50):
@@ -80,9 +80,9 @@ class UserTestCase(APITestCase):
     def test_positive_create_with_email(self):
         """Create User for all variations of Email
 
-        @id: e68caf51-44ba-4d32-b79b-9ab9b67b9590
+        :id: e68caf51-44ba-4d32-b79b-9ab9b67b9590
 
-        @Assert: User is created
+        :Assert: User is created
         """
         for mail in valid_emails_list():
             with self.subTest(mail):
@@ -93,9 +93,9 @@ class UserTestCase(APITestCase):
     def test_positive_create_with_password(self):
         """Create User for all variations of Password
 
-        @id: 53d0a419-0730-4f7d-9170-d855adfc5070
+        :id: 53d0a419-0730-4f7d-9170-d855adfc5070
 
-        @Assert: User is created
+        :Assert: User is created
         """
         for password in generate_strings_list(
                 exclude_types=['html'], max_length=50):
@@ -107,9 +107,9 @@ class UserTestCase(APITestCase):
     def test_positive_delete(self):
         """Create random users and then delete it.
 
-        @id: df6059e7-85c5-42fa-99b5-b7f1ef809f52
+        :id: df6059e7-85c5-42fa-99b5-b7f1ef809f52
 
-        @Assert: The user cannot be fetched after deletion.
+        :Assert: The user cannot be fetched after deletion.
         """
         for mail in valid_emails_list():
             with self.subTest(mail):
@@ -122,9 +122,9 @@ class UserTestCase(APITestCase):
     def test_positive_update_admin(self):
         """Update a user and provide the ``admin`` attribute.
 
-        @id: b5fedf65-37f5-43ca-806a-ac9a7979b19d
+        :id: b5fedf65-37f5-43ca-806a-ac9a7979b19d
 
-        @Assert: The user's ``admin`` attribute is updated.
+        :Assert: The user's ``admin`` attribute is updated.
         """
         for admin_enable in (True, False):
             with self.subTest(admin_enable):
@@ -136,9 +136,9 @@ class UserTestCase(APITestCase):
     def test_negative_create_with_invalid_email(self):
         """Create User with invalid Email Address
 
-        @id: ebbd1f5f-e71f-41f4-a956-ce0071b0a21c
+        :id: ebbd1f5f-e71f-41f4-a956-ce0071b0a21c
 
-        @Assert: User is not created. Appropriate error shown.
+        :Assert: User is not created. Appropriate error shown.
         """
         for mail in invalid_emails_list():
             with self.subTest(mail):
@@ -149,9 +149,9 @@ class UserTestCase(APITestCase):
     def test_negative_create_with_invalid_username(self):
         """Create User with invalid Username
 
-        @id: aaf157a9-0375-4405-ad87-b13970e0609b
+        :id: aaf157a9-0375-4405-ad87-b13970e0609b
 
-        @Assert: User is not created. Appropriate error shown.
+        :Assert: User is not created. Appropriate error shown.
         """
         for invalid_name in invalid_usernames_list():
             with self.subTest(invalid_name):
@@ -162,9 +162,9 @@ class UserTestCase(APITestCase):
     def test_negative_create_with_invalid_firstname(self):
         """Create User with invalid Firstname
 
-        @id: cb1ca8a9-38b1-4d58-ae32-915b47b91657
+        :id: cb1ca8a9-38b1-4d58-ae32-915b47b91657
 
-        @Assert: User is not created. Appropriate error shown.
+        :Assert: User is not created. Appropriate error shown.
         """
         for invalid_name in invalid_names_list():
             with self.subTest(invalid_name):
@@ -175,9 +175,9 @@ class UserTestCase(APITestCase):
     def test_negative_create_with_invalid_lastname(self):
         """Create User with invalid Lastname
 
-        @id: 59546d26-2b6b-400b-990f-0b5d1c35004e
+        :id: 59546d26-2b6b-400b-990f-0b5d1c35004e
 
-        @Assert: User is not created. Appropriate error shown.
+        :Assert: User is not created. Appropriate error shown.
         """
         for invalid_name in invalid_names_list():
             with self.subTest(invalid_name):
@@ -200,10 +200,10 @@ class UserRoleTestCase(APITestCase):
     def test_positive_create_with_role(self):
         """Create a user with the ``role`` attribute.
 
-        @id: 32daacf1-eed4-49b1-81e1-ab0a5b0113f2
+        :id: 32daacf1-eed4-49b1-81e1-ab0a5b0113f2
 
-        @Assert: A user is created with the given role(s) and the default
-        'Anonymous' role.
+        :Assert: A user is created with the given role(s) and the default
+            'Anonymous' role.
 
         This test targets BZ 1216239.
         """
@@ -221,10 +221,10 @@ class UserRoleTestCase(APITestCase):
     def test_positive_update(self):
         """Update an existing user and give it roles.
 
-        @id: 7fdca879-d65f-44fa-b9f2-b6bb5df30c2d
+        :id: 7fdca879-d65f-44fa-b9f2-b6bb5df30c2d
 
-        @Assert: The user has whatever roles are given, plus the 'Anonymous'
-        role.
+        :Assert: The user has whatever roles are given, plus the 'Anonymous'
+            role.
 
         This test targets BZ 1216239.
         """

--- a/tests/foreman/api/test_usergroup.py
+++ b/tests/foreman/api/test_usergroup.py
@@ -4,19 +4,19 @@ Each ``APITestCase`` subclass tests a single URL. A full list of URLs to be
 tested can be found here:
 http://theforeman.org/api/1.11/apidoc/v2/usergroups.html
 
-@Requirement: Usergroup
+:Requirement: Usergroup
 
-@CaseAutomation: Automated
+:CaseAutomation: Automated
 
-@CaseLevel: Acceptance
+:CaseLevel: Acceptance
 
-@CaseComponent: API
+:CaseComponent: API
 
-@TestType: Functional
+:TestType: Functional
 
-@CaseImportance: High
+:CaseImportance: High
 
-@Upstream: No
+:Upstream: No
 """
 from fauxfactory import gen_string
 from nailgun import entities
@@ -38,9 +38,9 @@ class UserGroupTestCase(APITestCase):
     def test_positive_create_with_name(self):
         """Create new user group using different valid names
 
-        @id: 3a2255d9-f48d-4f22-a4b9-132361bd9224
+        :id: 3a2255d9-f48d-4f22-a4b9-132361bd9224
 
-        @Assert: User group is created successfully.
+        :Assert: User group is created successfully.
         """
         for name in valid_data_list():
             with self.subTest(name):
@@ -51,9 +51,9 @@ class UserGroupTestCase(APITestCase):
     def test_positive_create_with_user(self):
         """Create new user group using valid user attached to that group.
 
-        @id: ab127e09-31d2-4c5b-ae6c-726e4b11a21e
+        :id: ab127e09-31d2-4c5b-ae6c-726e4b11a21e
 
-        @Assert: User group is created successfully.
+        :Assert: User group is created successfully.
         """
         for login in valid_usernames_list():
             with self.subTest(login):
@@ -66,10 +66,10 @@ class UserGroupTestCase(APITestCase):
     def test_positive_create_with_users(self):
         """Create new user group using multiple users attached to that group.
 
-        @id: b8dbbacd-b5cb-49b1-985d-96df21440652
+        :id: b8dbbacd-b5cb-49b1-985d-96df21440652
 
-        @Assert: User group is created successfully and contains all expected
-        users.
+        :Assert: User group is created successfully and contains all expected
+            users.
         """
         users = [entities.User().create() for _ in range(randint(3, 5))]
         user_group = entities.UserGroup(user=users).create()
@@ -82,9 +82,9 @@ class UserGroupTestCase(APITestCase):
     def test_positive_create_with_role(self):
         """Create new user group using valid role attached to that group.
 
-        @id: c4fac71a-9dda-4e5f-a5df-be362d3cbd52
+        :id: c4fac71a-9dda-4e5f-a5df-be362d3cbd52
 
-        @Assert: User group is created successfully.
+        :Assert: User group is created successfully.
         """
         for role_name in valid_data_list():
             with self.subTest(role_name):
@@ -97,10 +97,10 @@ class UserGroupTestCase(APITestCase):
     def test_positive_create_with_roles(self):
         """Create new user group using multiple roles attached to that group.
 
-        @id: 5838fcfd-e256-49cf-aef8-b2bf215b3586
+        :id: 5838fcfd-e256-49cf-aef8-b2bf215b3586
 
-        @Assert: User group is created successfully and contains all expected
-        roles
+        :Assert: User group is created successfully and contains all expected
+            roles
         """
         roles = [entities.Role().create() for _ in range(randint(3, 5))]
         user_group = entities.UserGroup(role=roles).create()
@@ -114,9 +114,9 @@ class UserGroupTestCase(APITestCase):
         """Create new user group using another user group attached to the
         initial group.
 
-        @id: 2a3f7b1a-7411-4c12-abaf-9a3ca1dfae31
+        :id: 2a3f7b1a-7411-4c12-abaf-9a3ca1dfae31
 
-        @Assert: User group is created successfully.
+        :Assert: User group is created successfully.
         """
         for name in valid_data_list():
             with self.subTest(name):
@@ -132,12 +132,12 @@ class UserGroupTestCase(APITestCase):
         """Create new user group using multiple user groups attached to that
         initial group.
 
-        @id: 9ba71288-af8b-4957-8413-442a47057634
+        :id: 9ba71288-af8b-4957-8413-442a47057634
 
-        @Assert: User group is created successfully and contains all expected
-        user groups
+        :Assert: User group is created successfully and contains all expected
+            user groups
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         sub_user_groups = [
             entities.UserGroup().create() for _ in range(randint(3, 5))]
@@ -152,9 +152,9 @@ class UserGroupTestCase(APITestCase):
     def test_negative_create_with_name(self):
         """Attempt to create user group with invalid name.
 
-        @id: 1a3384dc-5d52-442c-87c8-e38048a61dfa
+        :id: 1a3384dc-5d52-442c-87c8-e38048a61dfa
 
-        @Assert: User group is not created.
+        :Assert: User group is not created.
         """
         for name in invalid_values_list():
             with self.subTest(name):
@@ -165,9 +165,9 @@ class UserGroupTestCase(APITestCase):
     def test_negative_create_with_same_name(self):
         """Attempt to create user group with a name of already existent entity.
 
-        @id: aba0925a-d5ec-4e90-86c6-404b9b6f0179
+        :id: aba0925a-d5ec-4e90-86c6-404b9b6f0179
 
-        @Assert: User group is not created.
+        :Assert: User group is not created.
         """
         user_group = entities.UserGroup().create()
         with self.assertRaises(HTTPError):
@@ -177,9 +177,9 @@ class UserGroupTestCase(APITestCase):
     def test_positive_update(self):
         """Update existing user group with different valid names.
 
-        @id: b4f0a19b-9059-4e8b-b245-5a30ec06f9f3
+        :id: b4f0a19b-9059-4e8b-b245-5a30ec06f9f3
 
-        @Assert: User group is updated successfully.
+        :Assert: User group is updated successfully.
         """
         user_group = entities.UserGroup().create()
         for new_name in valid_data_list():
@@ -192,9 +192,9 @@ class UserGroupTestCase(APITestCase):
     def test_positive_update_with_new_user(self):
         """Add new user to user group
 
-        @id: e11b57c3-5f86-4963-9cc6-e10e2f02468b
+        :id: e11b57c3-5f86-4963-9cc6-e10e2f02468b
 
-        @Assert: User is added to user group successfully.
+        :Assert: User is added to user group successfully.
         """
         user = entities.User().create()
         user_group = entities.UserGroup().create()
@@ -206,11 +206,11 @@ class UserGroupTestCase(APITestCase):
     def test_positive_update_with_existing_user(self):
         """Update user that assigned to user group with another one
 
-        @id: 71b78f64-867d-4bf5-9b1e-02698a17fb38
+        :id: 71b78f64-867d-4bf5-9b1e-02698a17fb38
 
-        @Assert: User group is updated successfully.
+        :Assert: User group is updated successfully.
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         users = [entities.User().create() for _ in range(2)]
         user_group = entities.UserGroup(user=[users[0]]).create()
@@ -222,9 +222,9 @@ class UserGroupTestCase(APITestCase):
     def test_positive_update_with_new_role(self):
         """Add new role to user group
 
-        @id: 8e0872c1-ae88-4971-a6fc-cd60127d6663
+        :id: 8e0872c1-ae88-4971-a6fc-cd60127d6663
 
-        @Assert: Role is added to user group successfully.
+        :Assert: Role is added to user group successfully.
         """
         new_role = entities.Role().create()
         user_group = entities.UserGroup().create()
@@ -236,9 +236,9 @@ class UserGroupTestCase(APITestCase):
     def test_positive_update_with_new_usergroup(self):
         """Add new user group to existing one
 
-        @id: 3cb29d07-5789-4f94-9fd9-a7e494b3c110
+        :id: 3cb29d07-5789-4f94-9fd9-a7e494b3c110
 
-        @Assert: User group is added to existing group successfully.
+        :Assert: User group is added to existing group successfully.
         """
         new_usergroup = entities.UserGroup().create()
         user_group = entities.UserGroup().create()
@@ -251,9 +251,9 @@ class UserGroupTestCase(APITestCase):
     def test_negative_update(self):
         """Attempt to update existing user group using different invalid names.
 
-        @id: 03772bd0-0d52-498d-8259-5c8a87e08344
+        :id: 03772bd0-0d52-498d-8259-5c8a87e08344
 
-        @Assert: User group is not updated.
+        :Assert: User group is not updated.
         """
         user_group = entities.UserGroup().create()
         for new_name in invalid_values_list():
@@ -267,9 +267,9 @@ class UserGroupTestCase(APITestCase):
     def test_negative_update_with_same_name(self):
         """Attempt to update user group with a name of already existent entity.
 
-        @id: 14888998-9282-4d81-9e99-234d19706783
+        :id: 14888998-9282-4d81-9e99-234d19706783
 
-        @Assert: User group is not updated.
+        :Assert: User group is not updated.
         """
         name = gen_string('alphanumeric')
         entities.UserGroup(name=name).create()
@@ -283,9 +283,9 @@ class UserGroupTestCase(APITestCase):
     def test_positive_delete(self):
         """Create user group with valid name and then delete it
 
-        @id: c5cfcc4a-9177-47bb-8f19-7a8930eb7ca3
+        :id: c5cfcc4a-9177-47bb-8f19-7a8930eb7ca3
 
-        @assert: User group is deleted successfully
+        :assert: User group is deleted successfully
         """
         user_group = entities.UserGroup().create()
         user_group.delete()

--- a/tests/foreman/api/test_variables.py
+++ b/tests/foreman/api/test_variables.py
@@ -1,19 +1,19 @@
 # -*- encoding: utf-8 -*-
 """Test class for Smart/Puppet Variables
 
-@Requirement: Smart_Variables
+:Requirement: Smart_Variables
 
-@CaseAutomation: Automated
+:CaseAutomation: Automated
 
-@CaseLevel: Acceptance
+:CaseLevel: Acceptance
 
-@CaseComponent: API
+:CaseComponent: API
 
-@TestType: Functional
+:TestType: Functional
 
-@CaseImportance: High
+:CaseImportance: High
 
-@Upstream: No
+:Upstream: No
 """
 import json
 from random import choice, uniform
@@ -178,11 +178,11 @@ class SmartVariablesTestCase(APITestCase):
     def test_positive_create(self):
         """Create a Smart Variable with valid name
 
-        @id: 4cd20cca-d419-43f5-9734-e9ae1caae4cb
+        :id: 4cd20cca-d419-43f5-9734-e9ae1caae4cb
 
-        @steps: Create a smart Variable with Valid name and valid default value
+        :steps: Create a smart Variable with Valid name and valid default value
 
-        @assert: The smart Variable is created successfully
+        :assert: The smart Variable is created successfully
         """
         for name in valid_data_list():
             with self.subTest(name):
@@ -197,12 +197,12 @@ class SmartVariablesTestCase(APITestCase):
     def test_negative_create(self):
         """Create a Smart Variable with invalid name
 
-        @id: d92f8bdd-93de-49ba-85a3-685aac9eda0a
+        :id: d92f8bdd-93de-49ba-85a3-685aac9eda0a
 
-        @steps: Create a smart Variable with invalid name and valid default
-        value
+        :steps: Create a smart Variable with invalid name and valid default
+            value
 
-        @assert: The smart Variable is not created
+        :assert: The smart Variable is not created
         """
         for name in invalid_values_list():
             with self.subTest(name), self.assertRaises(HTTPError):
@@ -216,11 +216,11 @@ class SmartVariablesTestCase(APITestCase):
     def test_positive_delete_smart_variable_by_id(self):
         """Delete a Smart Variable by id
 
-        @id: 6d8354db-a028-4ae0-bcb6-87aa1cb9ec5d
+        :id: 6d8354db-a028-4ae0-bcb6-87aa1cb9ec5d
 
-        @steps: Delete a smart Variable by id
+        :steps: Delete a smart Variable by id
 
-        @assert: The smart Variable is deleted successfully
+        :assert: The smart Variable is deleted successfully
         """
         smart_variable = entities.SmartVariable(
             puppetclass=self.puppet_class
@@ -239,15 +239,14 @@ class SmartVariablesTestCase(APITestCase):
     def test_positive_update_variable_puppet_class(self):
         """Update Smart Variable's puppet class.
 
-        @id: 2312cb28-c3b0-4fbc-84cf-b66f0c0c64f0
+        :id: 2312cb28-c3b0-4fbc-84cf-b66f0c0c64f0
 
-        @steps:
+        :steps:
+            1. Create a smart variable with valid name.
+            2. Update the puppet class associated to the smart variable created
+               in step1.
 
-        1. Create a smart variable with valid name.
-        2. Update the puppet class associated to the smart variable created in
-           step1.
-
-        @assert: The variable is updated with new puppet class.
+        :assert: The variable is updated with new puppet class.
         """
         smart_variable = entities.SmartVariable(
             puppetclass=self.puppet_class,
@@ -265,14 +264,13 @@ class SmartVariablesTestCase(APITestCase):
     def test_positive_update_name(self):
         """Update Smart Variable's name
 
-        @id: b8214eaa-e276-4fc4-8381-fb0386cda6a5
+        :id: b8214eaa-e276-4fc4-8381-fb0386cda6a5
 
-        @steps:
+        :steps:
+            1. Create a smart variable with valid name.
+            2. Update smart variable name created in step1.
 
-        1. Create a smart variable with valid name.
-        2. Update smart variable name created in step1.
-
-        @assert: The variable is updated with new name.
+        :assert: The variable is updated with new name.
         """
         smart_variable = entities.SmartVariable(
             puppetclass=self.puppet_class,
@@ -288,15 +286,15 @@ class SmartVariablesTestCase(APITestCase):
     def test_negative_duplicate_name_variable(self):
         """Create Smart Variable with an existing name.
 
-        @id: c49ad14d-913f-4adc-8ebf-88493556c027
+        :id: c49ad14d-913f-4adc-8ebf-88493556c027
 
-        @steps:
+        :steps:
+            1. Create a smart Variable with Valid name and default value.
+            2. Attempt to create a variable with same name from same/other
+               class.
 
-        1. Create a smart Variable with Valid name and default value.
-        2. Attempt to create a variable with same name from same/other class.
-
-        @assert: The variable with same name are not allowed to create from
-        any class.
+        :assert: The variable with same name are not allowed to create from any
+            class.
         """
         name = gen_string('alpha')
         entities.SmartVariable(
@@ -318,11 +316,11 @@ class SmartVariablesTestCase(APITestCase):
     def test_positive_list_variables_by_host_id(self):
         """List all the variables associated to Host by host id
 
-        @id: 4fc1f249-5da7-493b-a1d3-4ce7b625ad96
+        :id: 4fc1f249-5da7-493b-a1d3-4ce7b625ad96
 
-        @assert: All variables listed for Host
+        :assert: All variables listed for Host
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         entities.SmartVariable(puppetclass=self.puppet_class).create()
         host = entities.Host(organization=self.org).create()
@@ -336,11 +334,11 @@ class SmartVariablesTestCase(APITestCase):
     def test_positive_list_variables_by_hostgroup_id(self):
         """List all the variables associated to HostGroup by hostgroup id
 
-        @id: db6861cc-b390-45bc-8c7d-cf10f46aecb3
+        :id: db6861cc-b390-45bc-8c7d-cf10f46aecb3
 
-        @assert: All variables listed for HostGroup
+        :assert: All variables listed for HostGroup
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         entities.SmartVariable(puppetclass=self.puppet_class).create()
         hostgroup = entities.HostGroup().create()
@@ -353,9 +351,9 @@ class SmartVariablesTestCase(APITestCase):
     def test_positive_list_variables_by_puppetclass_id(self):
         """List all the variables associated to puppet class by puppet class id
 
-        @id: cd743329-b354-4ddc-ada0-3ddd774e2701
+        :id: cd743329-b354-4ddc-ada0-3ddd774e2701
 
-        @assert: All variables listed for puppet class
+        :assert: All variables listed for puppet class
         """
         self.assertGreater(len(self.puppet_class.list_smart_variables()), 0)
 
@@ -366,11 +364,11 @@ class SmartVariablesTestCase(APITestCase):
 
         Types - string, boolean, integer, real, array, hash, yaml, json
 
-        @id: 4c8b4134-33c1-4f7f-83f9-a751c49ae2da
+        :id: 4c8b4134-33c1-4f7f-83f9-a751c49ae2da
 
-        @steps: Create a variable with all valid key types and default values
+        :steps: Create a variable with all valid key types and default values
 
-        @assert: Variable created with all given types successfully
+        :assert: Variable created with all given types successfully
         """
         for data in valid_sc_variable_data():
             with self.subTest(data):
@@ -398,12 +396,12 @@ class SmartVariablesTestCase(APITestCase):
 
         Types - string, boolean, integer, real, array, hash, yaml, json
 
-        @id: 9709d67c-682f-4e6c-8b8b-f02f6c2d3b71
+        :id: 9709d67c-682f-4e6c-8b8b-f02f6c2d3b71
 
-        @steps: Create a variable with all valid key types and invalid default
-        values
+        :steps: Create a variable with all valid key types and invalid default
+            values
 
-        @assert: Variable is not created for invalid value
+        :assert: Variable is not created for invalid value
         """
         for data in invalid_sc_variable_data():
             with self.subTest(data):
@@ -423,13 +421,11 @@ class SmartVariablesTestCase(APITestCase):
     def test_positive_create_matcher_empty_value(self):
         """Create matcher with empty value with string type
 
-        @id: a90b5bcd-f76c-4663-bf41-2f96e7e15c0f
+        :id: a90b5bcd-f76c-4663-bf41-2f96e7e15c0f
 
-        @steps:
+        :steps: Create a matcher for variable with empty value and type string
 
-        1. Create a matcher for variable with empty value and type string
-
-        @assert: Matcher is created with empty value
+        :assert: Matcher is created with empty value
         """
         smart_variable = entities.SmartVariable(
             puppetclass=self.puppet_class,
@@ -451,14 +447,12 @@ class SmartVariablesTestCase(APITestCase):
     def test_negative_create_matcher_empty_value(self):
         """Create matcher with empty value with type other than string
 
-        @id: ad24999f-1bed-4abb-a01f-3cb485d67968
+        :id: ad24999f-1bed-4abb-a01f-3cb485d67968
 
-        @steps:
+        :steps: Create a matcher for variable with empty value and type any
+            other than string
 
-        1. Create a matcher for variable with empty value and type any other
-           than string
-
-        @assert: Matcher is not created for empty value
+        :assert: Matcher is not created for empty value
         """
         smart_variable = entities.SmartVariable(
             puppetclass=self.puppet_class,
@@ -482,11 +476,11 @@ class SmartVariablesTestCase(APITestCase):
     def test_negative_create_with_invalid_match_value(self):
         """Attempt to create matcher with invalid match value.
 
-        @id: 625e3221-237d-4440-ab71-6d98cff67713
+        :id: 625e3221-237d-4440-ab71-6d98cff67713
 
-        @steps: Create a matcher for variable with invalid match value
+        :steps: Create a matcher for variable with invalid match value
 
-        @assert: Matcher is not created
+        :assert: Matcher is not created
         """
         smart_variable = entities.SmartVariable(
             puppetclass=self.puppet_class,
@@ -507,15 +501,14 @@ class SmartVariablesTestCase(APITestCase):
     def test_negative_create_default_value_with_regex(self):
         """Create variable with non matching regex validator
 
-        @id: 0c80bd58-26aa-4c2a-a087-ed3b88b226a7
+        :id: 0c80bd58-26aa-4c2a-a087-ed3b88b226a7
 
-        @steps:
+        :steps:
+            1. Create variable with default value that doesn't matches the
+               regex of step 2
+            2. Validate this value with regexp validator type and rule
 
-        1. Create variable with default value that doesn't matches the regex
-           of step 2
-        2. Validate this value with regexp validator type and rule
-
-        @assert: Variable is not created for non matching value with regex
+        :assert: Variable is not created for non matching value with regex
         """
         value = gen_string('alpha')
         smart_variable = entities.SmartVariable(
@@ -540,15 +533,14 @@ class SmartVariablesTestCase(APITestCase):
     def test_positive_create_default_value_with_regex(self):
         """Create variable with matching regex validator
 
-        @id: aa9803b9-9a45-4ad8-b502-e0e32fc4b7d8
+        :id: aa9803b9-9a45-4ad8-b502-e0e32fc4b7d8
 
-        @steps:
+        :steps:
+            1. Create variable with default value that matches the regex of
+               step 2
+            2. Validate this value with regex validator type and rule
 
-        1. Create variable with default value that matches the regex of
-           step 2
-        2. Validate this value with regex validator type and rule
-
-        @assert: Variable is created for matching value with regex
+        :assert: Variable is created for matching value with regex
         """
         value = gen_string('numeric')
         smart_variable = entities.SmartVariable(
@@ -571,14 +563,14 @@ class SmartVariablesTestCase(APITestCase):
     def test_negative_create_matcher_value_with_regex(self):
         """Create matcher with non matching regexp validator
 
-        @id: 8a0f9251-7992-4d1e-bace-7e32637bf56f
+        :id: 8a0f9251-7992-4d1e-bace-7e32637bf56f
 
-        @steps:
+        :steps:
+            1. Create a matcher with value that doesn't matches the regex of
+               step 2
+            2. Validate this value with regex validator type and rule
 
-        1. Create a matcher with value that doesn't matches the regex of step 2
-        2. Validate this value with regex validator type and rule
-
-        @assert: Matcher is not created for non matching value with regexp
+        :assert: Matcher is not created for non matching value with regexp
         """
         smart_variable = entities.SmartVariable(
             puppetclass=self.puppet_class,
@@ -603,14 +595,13 @@ class SmartVariablesTestCase(APITestCase):
     def test_positive_create_matcher_value_with_regex(self):
         """Create matcher with matching regex validator
 
-        @id: 3ad09261-eb55-4758-b915-84006c9e527c
+        :id: 3ad09261-eb55-4758-b915-84006c9e527c
 
-        @steps:
+        :steps:
+            1. Create a matcher with value that matches the regex of step 2
+            2. Validate this value with regex validator type and rule
 
-        1. Create a matcher with value that matches the regex of step 2
-        2. Validate this value with regex validator type and rule
-
-        @assert: Matcher is created for matching value with regex
+        :assert: Matcher is created for matching value with regex
         """
         value = gen_string('numeric')
         smart_variable = entities.SmartVariable(
@@ -637,16 +628,16 @@ class SmartVariablesTestCase(APITestCase):
     def test_negative_create_default_value_with_list(self):
         """Create variable with non matching list validator
 
-        @id: cacb83a5-3e50-490b-b94f-a5d27f44ae12
+        :id: cacb83a5-3e50-490b-b94f-a5d27f44ae12
 
-        @steps:
+        :steps:
 
-        1. Create variable with default value that doesn't matches the list
-           validator of step 2
-        2. Validate this value with list validator type and rule
+            1. Create variable with default value that doesn't matches the list
+               validator of step 2
+            2. Validate this value with list validator type and rule
 
-        @assert: Variable is not created for non matching value with list
-        validator
+        :assert: Variable is not created for non matching value with list
+            validator
         """
         with self.assertRaises(HTTPError) as context:
             entities.SmartVariable(
@@ -665,15 +656,15 @@ class SmartVariablesTestCase(APITestCase):
     def test_positive_create_default_value_with_list(self):
         """Create variable with matching list validator
 
-        @id: 6bc2caa0-1300-4751-8239-34b96517465b
+        :id: 6bc2caa0-1300-4751-8239-34b96517465b
 
-        @steps:
+        :steps:
 
-        1. Create variable with default value that matches the list validator
-           of step 2
-        2. Validate this value with list validator type and rule
+            1. Create variable with default value that matches the list
+               validator of step 2
+            2. Validate this value with list validator type and rule
 
-        @assert: Variable is created for matching value with list
+        :assert: Variable is created for matching value with list
         """
         # Generate list of values
         values_list = [
@@ -700,16 +691,16 @@ class SmartVariablesTestCase(APITestCase):
     def test_negative_create_matcher_value_with_list(self):
         """Create matcher with non matching list validator
 
-        @id: 0aff0fdf-5a62-49dc-abe1-b727459d030a
+        :id: 0aff0fdf-5a62-49dc-abe1-b727459d030a
 
-        @steps:
+        :steps:
 
-        1. Create a matcher with value that doesn't matches the list validator
-           of step 2
-        2. Validate this value with list validator type and rule
+            1. Create a matcher with value that doesn't matches the list
+               validator of step 2
+            2. Validate this value with list validator type and rule
 
-        @assert: Matcher is not created for non matching value with list
-        validator
+        :assert: Matcher is not created for non matching value with list
+            validator
         """
         smart_variable = entities.SmartVariable(
             puppetclass=self.puppet_class,
@@ -734,15 +725,15 @@ class SmartVariablesTestCase(APITestCase):
     def test_positive_create_matcher_value_with_list(self):
         """Create matcher with matching list validator
 
-        @id: f5eda535-6623-4130-bea0-97faf350a6a6
+        :id: f5eda535-6623-4130-bea0-97faf350a6a6
 
-        @steps:
+        :steps:
 
-        1. Create a matcher with value that matches the list validator
-           of step 2
-        2. Validate this value with list validator type and rule
+            1. Create a matcher with value that matches the list validator of
+               step 2
+            2. Validate this value with list validator type and rule
 
-        @assert: Matcher is created for matching value with list validator
+        :assert: Matcher is created for matching value with list validator
         """
         smart_variable = entities.SmartVariable(
             puppetclass=self.puppet_class,
@@ -769,15 +760,16 @@ class SmartVariablesTestCase(APITestCase):
     def test_negative_create_matcher_value_with_default_type(self):
         """Create matcher with non matching type of default value
 
-        @id: 790c63d7-4e8a-4187-8566-3d85d57f9a4f
+        :id: 790c63d7-4e8a-4187-8566-3d85d57f9a4f
 
-        @steps:
+        :steps:
 
-        1. Create variable with valid type and value
-        2. Create a matcher with value that doesn't matches the default type
+            1. Create variable with valid type and value
+            2. Create a matcher with value that doesn't matches the default
+               type
 
-        @assert: Matcher is not created for non matching the type of default
-        value
+        :assert: Matcher is not created for non matching the type of default
+            value
         """
         smart_variable = entities.SmartVariable(
             puppetclass=self.puppet_class,
@@ -801,14 +793,14 @@ class SmartVariablesTestCase(APITestCase):
     def test_positive_create_matcher_value_with_default_type(self):
         """Create matcher with matching type of default value
 
-        @id: 99057f05-62cb-4230-b16c-d96ca6a5ae91
+        :id: 99057f05-62cb-4230-b16c-d96ca6a5ae91
 
-        @steps:
+        :steps:
 
-        1. Create variable with valid type and value
-        2. Create a matcher with value that matches the default value type
+            1. Create variable with valid type and value
+            2. Create a matcher with value that matches the default value type
 
-        @assert: Matcher is created for matching the type of default value
+        :assert: Matcher is created for matching the type of default value
         """
         smart_variable = entities.SmartVariable(
             puppetclass=self.puppet_class,
@@ -831,11 +823,11 @@ class SmartVariablesTestCase(APITestCase):
     def test_negative_create_matcher_non_existing_attribute(self):
         """Create matcher for non existing attribute
 
-        @id: 23b16e7f-0626-467e-b53b-35e1634cc30d
+        :id: 23b16e7f-0626-467e-b53b-35e1634cc30d
 
-        @steps: Create matcher for non existing attribute
+        :steps: Create matcher for non existing attribute
 
-        @assert: Matcher is not created for non existing attribute
+        :assert: Matcher is not created for non existing attribute
         """
         smart_variable = entities.SmartVariable(
             puppetclass=self.puppet_class,
@@ -858,11 +850,11 @@ class SmartVariablesTestCase(APITestCase):
     def test_positive_create_matcher(self):
         """Create matcher for attribute in variable
 
-        @id: f0b3d51a-cf9a-4b43-9567-eb12cd973299
+        :id: f0b3d51a-cf9a-4b43-9567-eb12cd973299
 
-        @steps: Create a matcher with all valid values
+        :steps: Create a matcher with all valid values
 
-        @assert: The matcher has been created successfully
+        :assert: The matcher has been created successfully
         """
         value = gen_string('alpha')
         smart_variable = entities.SmartVariable(
@@ -885,22 +877,22 @@ class SmartVariablesTestCase(APITestCase):
     def test_positive_update_variable_attribute_priority(self):
         """Variable value set on Attribute Priority for Host
 
-        @id: 78474b5e-7a50-4de0-b22c-3413ac06d067
+        :id: 78474b5e-7a50-4de0-b22c-3413ac06d067
 
-        @bz: 1362372
+        :bz: 1362372
 
-        @steps:
+        :steps:
 
-        1. Create variable with some valid value and type
-        2. Set fqdn as top priority attribute
-        3. Create first matcher for fqdn with valid details
-        4. Create second matcher for some attribute with valid details
-           Note - The FQDN/host should have this attribute
-        5. Check ENC output of associated host.
+            1. Create variable with some valid value and type
+            2. Set fqdn as top priority attribute
+            3. Create first matcher for fqdn with valid details
+            4. Create second matcher for some attribute with valid details Note
+               - The FQDN/host should have this attribute
+            5. Check ENC output of associated host.
 
-        @assert: The ENC output shows variable value of fqdn matcher only
+        :assert: The ENC output shows variable value of fqdn matcher only
 
-        @caseautomation: notautomated
+        :caseautomation: notautomated
         """
 
     @run_only_on('sat')
@@ -910,22 +902,22 @@ class SmartVariablesTestCase(APITestCase):
         """Matcher Value set on Attribute Priority
         for Host - alternate priority
 
-        @id: f6ef2193-5d63-43f1-8d91-e30984b2c0c5
+        :id: f6ef2193-5d63-43f1-8d91-e30984b2c0c5
 
-        @bz: 1362372
+        :bz: 1362372
 
-        @steps:
+        :steps:
 
-        1. Create variable with valid value and type
-        2. Set some attribute(other than fqdn) as top priority attribute
-           Note - The fqdn/host should have this attribute
-        3. Create first matcher for fqdn with valid details
-        4. Create second matcher for attribute of step 3 with valid details
-        5. Check ENC output of associated host.
+            1. Create variable with valid value and type
+            2. Set some attribute(other than fqdn) as top priority attribute
+               Note - The fqdn/host should have this attribute
+            3. Create first matcher for fqdn with valid details
+            4. Create second matcher for attribute of step 3 with valid details
+            5. Check ENC output of associated host.
 
-        @assert: The ENC output shows variable value of step 4 matcher only
+        :assert: The ENC output shows variable value of step 4 matcher only
 
-        @caseautomation: notautomated
+        :caseautomation: notautomated
         """
 
     @run_only_on('sat')
@@ -936,29 +928,29 @@ class SmartVariablesTestCase(APITestCase):
 
         Note - This TC is only for array and hash key types
 
-        @id: bb37995e-71f9-441c-b4d5-79e5b5ff3973
+        :id: bb37995e-71f9-441c-b4d5-79e5b5ff3973
 
-        @bz: 1362372
+        :bz: 1362372
 
-        @steps:
+        :steps:
 
-        1. Create variable with valid value and type
-        2. Create first matcher for attribute fqdn with valid details
-        3. Create second matcher for other attribute with valid details.
-           Note - The fqdn/host should have this attribute
-        4. Create more matchers for some more attributes if any
-           Note - The fqdn/host should have this attributes
-        5. Set 'merge overrides' to True
-        6. Check ENC output of associated host
+            1. Create variable with valid value and type
+            2. Create first matcher for attribute fqdn with valid details
+            3. Create second matcher for other attribute with valid details.
+               Note - The fqdn/host should have this attribute
+            4. Create more matchers for some more attributes if any Note - The
+               fqdn/host should have this attributes
+            5. Set 'merge overrides' to True
+            6. Check ENC output of associated host
 
-        @assert:
+        :assert:
 
-        1. The ENC output shows variable values merged from all the
-           associated matchers
-        2. The variable doesn't show the default value of variable.
-        3. Duplicate values in any are displayed
+            1. The ENC output shows variable values merged from all the
+               associated matchers
+            2. The variable doesn't show the default value of variable.
+            3. Duplicate values in any are displayed
 
-        @caseautomation: notautomated
+        :caseautomation: notautomated
         """
 
     @run_only_on('sat')
@@ -969,30 +961,30 @@ class SmartVariablesTestCase(APITestCase):
 
         Note - This TC is only for array and hash key types
 
-        @id: afcb7ef4-38dd-484b-8a02-bc4e3d027204
+        :id: afcb7ef4-38dd-484b-8a02-bc4e3d027204
 
-        @bz: 1362372
+        :bz: 1362372
 
-        @steps:
+        :steps:
 
-        1. Create variable with valid value and type
-        2. Create first matcher for attribute fqdn with valid details
-        3. Create second matcher for other attribute with valid details
-           Note - The fqdn/host should not have this attribute
-        4. Create more matchers for some more attributes if any
-           Note - The fqdn/host should not have this attributes
-        5. Set 'merge overrides' to True
-        6. Check ENC output of associated host
+            1. Create variable with valid value and type
+            2. Create first matcher for attribute fqdn with valid details
+            3. Create second matcher for other attribute with valid details
+               Note - The fqdn/host should not have this attribute
+            4. Create more matchers for some more attributes if any Note - The
+               fqdn/host should not have this attributes
+            5. Set 'merge overrides' to True
+            6. Check ENC output of associated host
 
-        @assert:
+        :assert:
 
-        1. The ENC output shows variable values only for fqdn
-        2. The variable doesn't have the values for attribute
-           which are not associated to host
-        3. The variable doesn't have the default value of variable
-        4. Duplicate values if any are displayed
+            1. The ENC output shows variable values only for fqdn
+            2. The variable doesn't have the values for attribute which are not
+               associated to host
+            3. The variable doesn't have the default value of variable
+            4. Duplicate values if any are displayed
 
-        @caseautomation: notautomated
+        :caseautomation: notautomated
         """
 
     @run_only_on('sat')
@@ -1003,30 +995,30 @@ class SmartVariablesTestCase(APITestCase):
 
         Note - This TC is only for array and hash key types
 
-        @id: 9607c52c-f4c7-468b-a741-d179de144646
+        :id: 9607c52c-f4c7-468b-a741-d179de144646
 
-        @bz: 1362372
+        :bz: 1362372
 
-        @steps:
+        :steps:
 
-        1. Create variable with valid value and type
-        2. Create first matcher for attribute fqdn with valid details
-        3. Create second matcher for other attribute with valid details
-           Note - The fqdn/host should have this attribute
-        4. Create more matchers for some more attributes if any
-           Note - The fqdn/host should have this attributes
-        5. Set 'merge overrides' to True
-        6. Set 'merge default' to True
-        7. Check ENC output of associated host
+            1. Create variable with valid value and type
+            2. Create first matcher for attribute fqdn with valid details
+            3. Create second matcher for other attribute with valid details
+               Note - The fqdn/host should have this attribute
+            4. Create more matchers for some more attributes if any Note - The
+               fqdn/host should have this attributes
+            5. Set 'merge overrides' to True
+            6. Set 'merge default' to True
+            7. Check ENC output of associated host
 
-        @assert:
+        :assert:
 
-        1. The ENC output shows the variable values merged from all the
-           associated matchers
-        2. The variable values has the default value of variable
-        3. Duplicate values if any are displayed
+            1. The ENC output shows the variable values merged from all the
+               associated matchers
+            2. The variable values has the default value of variable
+            3. Duplicate values if any are displayed
 
-        @caseautomation: notautomated
+        :caseautomation: notautomated
         """
 
     @run_only_on('sat')
@@ -1037,30 +1029,30 @@ class SmartVariablesTestCase(APITestCase):
 
         Note - This TC is only for array and hash key types
 
-        @id: 9033de15-f7e8-42be-b2be-c04c13aa039b
+        :id: 9033de15-f7e8-42be-b2be-c04c13aa039b
 
-        @bz: 1362372
+        :bz: 1362372
 
-        @steps:
+        :steps:
 
-        1. Create variable with empty value and type
-        2. Create first matcher for attribute fqdn with valid details
-        3. Create second matcher for other attribute with valid details
-           Note - The fqdn/host should have this attribute
-        4. Create more matchers for some more attributes if any
-           Note - The fqdn/host should have this attributes
-        5. Set 'merge overrides' to True
-        6. Set 'merge default' to True
-        7. Check ENC output of associated host
+            1. Create variable with empty value and type
+            2. Create first matcher for attribute fqdn with valid details
+            3. Create second matcher for other attribute with valid details
+               Note - The fqdn/host should have this attribute
+            4. Create more matchers for some more attributes if any Note - The
+               fqdn/host should have this attributes
+            5. Set 'merge overrides' to True
+            6. Set 'merge default' to True
+            7. Check ENC output of associated host
 
-        @assert:
+        :assert:
 
-        1. The ENC output shows variable values merged from all the associated
-           matchers
-        2. The variable doesn't have the empty default value of variable
-        3. Duplicate values if any are displayed
+            1. The ENC output shows variable values merged from all the
+               associated matchers
+            2. The variable doesn't have the empty default value of variable
+            3. Duplicate values if any are displayed
 
-        @caseautomation: notautomated
+        :caseautomation: notautomated
         """
 
     @run_only_on('sat')
@@ -1071,30 +1063,28 @@ class SmartVariablesTestCase(APITestCase):
 
         Note - This TC is only for array and hash key types
 
-        @id: fcb2dfb9-64d6-4647-bbcc-3e5c900aca1b
+        :id: fcb2dfb9-64d6-4647-bbcc-3e5c900aca1b
 
-        @bz: 1362372
+        :bz: 1362372
 
-        @steps:
+        :steps:
+            1. Create variable with valid value and type
+            2. Create first matcher for attribute fqdn with some value
+            3. Create second matcher for other attribute with same value as
+               fqdn matcher.  Note - The fqdn/host should have this attribute
+            4. Set 'merge overrides' to True
+            5. Set 'merge default' to True
+            6. Set 'avoid duplicate' to True
+            7. Check ENC output of associated host
 
-        1. Create variable with valid value and type
-        2. Create first matcher for attribute fqdn with some value
-        3. Create second matcher for other attribute with same value as fqdn
-           matcher.
-           Note - The fqdn/host should have this attribute
-        4. Set 'merge overrides' to True
-        5. Set 'merge default' to True
-        6. Set 'avoid duplicate' to True
-        7. Check ENC output of associated host
+        :assert:
 
-        @assert:
+            1. The ENC output shows the variable values merged from all the
+               associated matchers
+            2. The variable shows the default value of variable
+            3. Duplicate values are removed / not displayed
 
-        1. The ENC output shows the variable values merged from all the
-           associated matchers
-        2. The variable shows the default value of variable
-        3. Duplicate values are removed / not displayed
-
-        @caseautomation: notautomated
+        :caseautomation: notautomated
         """
 
     @run_only_on('sat')
@@ -1105,29 +1095,30 @@ class SmartVariablesTestCase(APITestCase):
 
         Note - This TC is only for array and hash key types
 
-        @id: 1f8a06de-0c53-424e-b2c9-b48a580d6298
+        :id: 1f8a06de-0c53-424e-b2c9-b48a580d6298
 
-        @bz: 1362372
+        :bz: 1362372
 
-        @steps:
+        :steps:
 
-        1. Create variable with valid value and type
-        2. Create first matcher for attribute fqdn with some value
-        3. Create second matcher for other attribute with other value than fqdn
-           matcher and default value.
-           Note - The fqdn/host should have this attribute
-        4. Set 'merge overrides' to True
-        5. Set 'merge default' to True
-        6. Set 'avoid duplicates' to True
-        7. Check ENC output of associated host
+            1. Create variable with valid value and type
+            2. Create first matcher for attribute fqdn with some value
+            3. Create second matcher for other attribute with other value than
+               fqdn matcher and default value.  Note - The fqdn/host should
+               have this attribute
+            4. Set 'merge overrides' to True
+            5. Set 'merge default' to True
+            6. Set 'avoid duplicates' to True
+            7. Check ENC output of associated host
 
-        @assert:
+        :assert:
 
-        1. The ENC output shows the variable values merged from all matchers
-        2. The variable shows default value of variable
-        3. No value removed as duplicate value
+            1. The ENC output shows the variable values merged from all
+               matchers
+            2. The variable shows default value of variable
+            3. No value removed as duplicate value
 
-        @caseautomation: notautomated
+        :caseautomation: notautomated
         """
 
     @run_only_on('sat')
@@ -1135,11 +1126,11 @@ class SmartVariablesTestCase(APITestCase):
     def test_positive_enable_merge_overrides_and_default_flags(self):
         """Enable Merge Overrides, Merge Default flags for supported types
 
-        @id: af2c16e1-9a78-4615-9bc3-34fadca6a179
+        :id: af2c16e1-9a78-4615-9bc3-34fadca6a179
 
-        @steps: Set variable type to array/hash
+        :steps: Set variable type to array/hash
 
-        @assert: The Merge Overrides, Merge Default flags are enabled to set
+        :assert: The Merge Overrides, Merge Default flags are enabled to set
         """
         smart_variable = entities.SmartVariable(
             puppetclass=self.puppet_class,
@@ -1158,12 +1149,12 @@ class SmartVariablesTestCase(APITestCase):
     def test_negative_enable_merge_overrides_default_flags(self):
         """Disable Merge Overrides, Merge Default flags for non supported types
 
-        @id: f62a7e23-6fb4-469a-8589-4c987ff589ef
+        :id: f62a7e23-6fb4-469a-8589-4c987ff589ef
 
-        @steps: Set variable type other than array/hash
+        :steps: Set variable type other than array/hash
 
-        @assert: The Merge Overrides, Merge Default flags are not enabled to
-        set
+        :assert: The Merge Overrides, Merge Default flags are not enabled to
+            set
         """
         smart_variable = entities.SmartVariable(
             puppetclass=self.puppet_class,
@@ -1195,14 +1186,14 @@ class SmartVariablesTestCase(APITestCase):
     def test_positive_enable_avoid_duplicates_flag(self):
         """Enable Avoid duplicates flag for supported type
 
-        @id: 98fb1884-ad2b-45a0-b376-66bbc5ef6f72
+        :id: 98fb1884-ad2b-45a0-b376-66bbc5ef6f72
 
-        @steps:
+        :steps:
 
-        1. Set variable type to array
-        2. Set 'merge overrides' to True
+            1. Set variable type to array
+            2. Set 'merge overrides' to True
 
-        @assert: The Avoid Duplicates is enabled to set to True
+        :assert: The Avoid Duplicates is enabled to set to True
         """
         smart_variable = entities.SmartVariable(
             puppetclass=self.puppet_class,
@@ -1220,16 +1211,16 @@ class SmartVariablesTestCase(APITestCase):
     def test_negative_enable_avoid_duplicates_flag(self):
         """Disable Avoid duplicates flag for non supported types
 
-        @id: c7a2f718-6346-4851-b5f1-ab36c2fa8c6a
+        :id: c7a2f718-6346-4851-b5f1-ab36c2fa8c6a
 
-        @steps: Set variable type other than array
+        :steps: Set variable type other than array
 
-        @assert:
+        :assert:
 
-        1. The Merge Overrides flag is only enabled to set for type hash
-           other than array
-        2. The Avoid duplicates flag not enabled to set for any type than
-           array
+            1. The Merge Overrides flag is only enabled to set for type hash
+               other than array
+            2. The Avoid duplicates flag not enabled to set for any type than
+               array
         """
         smart_variable = entities.SmartVariable(
             puppetclass=self.puppet_class,
@@ -1261,14 +1252,14 @@ class SmartVariablesTestCase(APITestCase):
     def test_positive_remove_matcher(self):
         """Removal of matcher from variable
 
-        @id: 7a932a99-2bd9-43ee-bcda-2b01a389787c
+        :id: 7a932a99-2bd9-43ee-bcda-2b01a389787c
 
-        @steps:
+        :steps:
 
-        1. Create the variable and create a matcher for some attribute
-        2. Remove the matcher created in step 1
+            1. Create the variable and create a matcher for some attribute
+            2. Remove the matcher created in step 1
 
-        @assert: The matcher removed from variable
+        :assert: The matcher removed from variable
         """
         value = gen_string('alpha')
         smart_variable = entities.SmartVariable(
@@ -1292,20 +1283,21 @@ class SmartVariablesTestCase(APITestCase):
     def test_positive_impact_variable_delete_attribute(self):
         """Impact on variable after deleting associated attribute
 
-        @id: d4faec04-be29-48e6-8585-10ff1c361a9e
+        :id: d4faec04-be29-48e6-8585-10ff1c361a9e
 
-        @steps:
+        :steps:
 
-        1. Create a variable and matcher for some attribute
-        2. Delete the attribute
-        3. Recreate the attribute with same name as earlier
+            1. Create a variable and matcher for some attribute
+            2. Delete the attribute
+            3. Recreate the attribute with same name as earlier
 
-        @assert:
+        :assert:
 
-        1. The matcher for deleted attribute removed from variable
-        2. On recreating attribute, the matcher should not reappear in variable
+            1. The matcher for deleted attribute removed from variable
+            2. On recreating attribute, the matcher should not reappear in
+               variable
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         hostgroup_name = gen_string('alpha')
         matcher_value = gen_string('alpha')
@@ -1350,14 +1342,13 @@ class SmartVariablesTestCase(APITestCase):
     def test_positive_hide_variable_default_value(self):
         """Hide the default value of variable
 
-        @id: 04bed7fa8-a5be-4fc0-8e9b-d68da00f8de0
+        :id: 04bed7fa8-a5be-4fc0-8e9b-d68da00f8de0
 
-        @steps:
+        :steps:
+            1. Create variable with valid type and value
+            2. Set 'Hidden Value' flag to true
 
-        1. Create variable with valid type and value
-        2. Set 'Hidden Value' flag to true
-
-        @assert: The 'hidden value' flag is set
+        :assert: The 'hidden value' flag is set
         """
         smart_variable = entities.SmartVariable(
             puppetclass=self.puppet_class,
@@ -1371,15 +1362,14 @@ class SmartVariablesTestCase(APITestCase):
     def test_positive_unhide_variable_default_value(self):
         """Unhide the default value of variable
 
-        @id: e8b3ec03-1abb-48d8-9409-17178bb887cb
+        :id: e8b3ec03-1abb-48d8-9409-17178bb887cb
 
-        @steps:
+        :steps:
+            1. Create variable with valid type and value
+            2. Set 'Hidden Value' flag to True
+            3. After hiding, set the 'Hidden Value' flag to False
 
-        1. Create variable with valid type and value
-        2. Set 'Hidden Value' flag to True
-        3. After hiding, set the 'Hidden Value' flag to False
-
-        @assert: The 'hidden value' flag set to false
+        :assert: The 'hidden value' flag set to false
         """
         smart_variable = entities.SmartVariable(
             puppetclass=self.puppet_class,
@@ -1396,18 +1386,16 @@ class SmartVariablesTestCase(APITestCase):
     def test_positive_update_hidden_value_in_variable(self):
         """Update the hidden default value of variable
 
-        @id: 21b5586e-9434-45ea-ae85-12e24c549412
+        :id: 21b5586e-9434-45ea-ae85-12e24c549412
 
-        @steps:
+        :steps:
+            1. Create variable with valid type and value
+            2. Set 'Hidden Value' flag to true
+            3. Now in hidden state, update the default value
 
-        1. Create variable with valid type and value
-        2. Set 'Hidden Value' flag to true
-        3. Now in hidden state, update the default value
-
-        @assert:
-
-        1. The variable default value is updated
-        2. The 'hidden value' flag set to True
+        :assert:
+            1. The variable default value is updated
+            2. The 'hidden value' flag set to True
         """
         value = gen_string('alpha')
         smart_variable = entities.SmartVariable(

--- a/tests/foreman/cli/test_abrt.py
+++ b/tests/foreman/cli/test_abrt.py
@@ -1,18 +1,18 @@
 """Test for abrt report
 
-@Requirement: Abrt
+:Requirement: Abrt
 
-@CaseAutomation: Automated
+:CaseAutomation: Automated
 
-@CaseLevel: Acceptance
+:CaseLevel: Acceptance
 
-@CaseComponent: CLI
+:CaseComponent: CLI
 
-@TestType: Functional
+:TestType: Functional
 
-@CaseImportance: High
+:CaseImportance: High
 
-@Upstream: No
+:Upstream: No
 """
 from robottelo.decorators import stubbed
 from robottelo.test import CLITestCase
@@ -25,19 +25,17 @@ class AbrtTestCase(CLITestCase):
     def test_positive_create_report(self):
         """a crashed program and abrt reports are send
 
-        @id: 6e6e7525-895a-4192-9e56-4a0df1ad41ff
+        :id: 6e6e7525-895a-4192-9e56-4a0df1ad41ff
 
-        @Setup: abrt
+        :Setup: abrt
 
-        @Steps:
+        :Steps: start a sleep process in background, kill it send the report
+            using smart-proxy-abrt-send
 
-        1. start a sleep process in background, kill it send the report using
-        smart-proxy-abrt-send
+        :Assert: A abrt report with ccpp.* extension  created under
+            /var/tmp/abrt
 
-        @Assert: A abrt report with ccpp.* extension  created under
-        /var/tmp/abrt
-
-        @caseautomation: notautomated
+        :caseautomation: notautomated
 
         """
 
@@ -45,18 +43,18 @@ class AbrtTestCase(CLITestCase):
     def test_positive_create_reports(self):
         """Counts are correct when abrt sends multiple reports
 
-        @id: 13aed05c-b72d-4a35-aa0e-5ac2029300e7
+        :id: 13aed05c-b72d-4a35-aa0e-5ac2029300e7
 
-        @Setup: abrt
+        :Setup: abrt
 
-        @Steps:
+        :Steps:
 
-        1. Create multiple reports of abrt
-        2. Keep track of counts
+            1. Create multiple reports of abrt
+            2. Keep track of counts
 
-        @Assert: Count is updated in proper manner
+        :Assert: Count is updated in proper manner
 
-        @caseautomation: notautomated
+        :caseautomation: notautomated
 
         """
 
@@ -64,17 +62,15 @@ class AbrtTestCase(CLITestCase):
     def test_positive_update_timer(self):
         """Edit the smart-proxy-abrt timer
 
-        @id: 8e62d8d4-9b1c-4eb7-9352-c001be09a4d9
+        :id: 8e62d8d4-9b1c-4eb7-9352-c001be09a4d9
 
-        @Setup: abrt
+        :Setup: abrt
 
-        @Steps:
+        :Steps: edit the timer for /etc/cron.d/rubygem-smart_proxy_abrt
 
-        1. edit the timer for /etc/cron.d/rubygem-smart_proxy_abrt
+        :Assert: the timer file is edited
 
-        @Assert: the timer file is edited
-
-        @caseautomation: notautomated
+        :caseautomation: notautomated
 
         """
 
@@ -82,17 +78,15 @@ class AbrtTestCase(CLITestCase):
     def test_positive_identify_hostname(self):
         """Identifying the hostnames
 
-        @id: d9ab279b-45cf-412e-bc0f-af31737cfa74
+        :id: d9ab279b-45cf-412e-bc0f-af31737cfa74
 
-        @Setup: abrt
+        :Setup: abrt
 
-        @Steps:
+        :Steps: UI => Settings => Abrt tab => edit hostnames
 
-        1. UI => Settings => Abrt tab => edit hostnames
+        :Assert: Assertion of hostnames is possible
 
-        @Assert: Assertion of hostnames is possible
-
-        @caseautomation: notautomated
+        :caseautomation: notautomated
 
         """
 
@@ -100,16 +94,14 @@ class AbrtTestCase(CLITestCase):
     def test_positive_search_report(self):
         """Able to retrieve reports in CLI
 
-        @id: b0623309-1b76-466d-a026-496e117f2d04
+        :id: b0623309-1b76-466d-a026-496e117f2d04
 
-        @Setup: abrt
+        :Setup: abrt
 
-        @Steps:
+        :Steps: access /var/tmp/abrt/ccpp-* files
 
-        1. access /var/tmp/abrt/ccpp-* files
+        :Assert: Assertion of parameters
 
-        @Assert: Assertion of parameters
-
-        @caseautomation: notautomated
+        :caseautomation: notautomated
 
         """

--- a/tests/foreman/cli/test_activationkey.py
+++ b/tests/foreman/cli/test_activationkey.py
@@ -2,19 +2,19 @@
 # pylint: disable=unexpected-keyword-arg
 """Test class for Activation key CLI
 
-@Requirement: Activationkey
+:Requirement: Activationkey
 
-@CaseAutomation: Automated
+:CaseAutomation: Automated
 
-@CaseLevel: Acceptance
+:CaseLevel: Acceptance
 
-@CaseComponent: CLI
+:CaseComponent: CLI
 
-@TestType: Functional
+:TestType: Functional
 
-@CaseImportance: High
+:CaseImportance: High
 
-@Upstream: No
+:Upstream: No
 """
 
 from fauxfactory import gen_string
@@ -95,9 +95,9 @@ class ActivationKeyTestCase(CLITestCase):
         """Create Activation key for all variations of Activation key
         name
 
-        @id: a5aaab5e-bc18-459e-a384-74aef752ec88
+        :id: a5aaab5e-bc18-459e-a384-74aef752ec88
 
-        @Assert: Activation key is created with chosen name
+        :Assert: Activation key is created with chosen name
         """
         for name in valid_data_list():
             with self.subTest(name):
@@ -108,9 +108,9 @@ class ActivationKeyTestCase(CLITestCase):
     def test_positive_create_with_description(self):
         """Create Activation key for all variations of Description
 
-        @id: 5a5ca7f9-1449-4365-ac8a-978605620bf2
+        :id: 5a5ca7f9-1449-4365-ac8a-978605620bf2
 
-        @Assert: Activation key is created with chosen description
+        :Assert: Activation key is created with chosen description
         """
         for desc in valid_data_list():
             with self.subTest(desc):
@@ -124,9 +124,9 @@ class ActivationKeyTestCase(CLITestCase):
     def test_positive_create_with_default_lce_by_id(self):
         """Create Activation key with associated default environment
 
-        @id: 9171adb2-c9ac-4cda-978f-776826668aa3
+        :id: 9171adb2-c9ac-4cda-978f-776826668aa3
 
-        @Assert: Activation key is created and associated to Library
+        :Assert: Activation key is created and associated to Library
         """
         lce = self.get_default_env()
         new_ak_env = self._make_activation_key({
@@ -139,10 +139,10 @@ class ActivationKeyTestCase(CLITestCase):
     def test_positive_create_with_non_default_lce(self):
         """Create Activation key with associated custom environment
 
-        @id: ad4d4611-3fb5-4449-ae47-305f9931350e
+        :id: ad4d4611-3fb5-4449-ae47-305f9931350e
 
-        @Assert: Activation key is created and associated to expected
-        environment
+        :Assert: Activation key is created and associated to expected
+            environment
         """
         env = make_lifecycle_environment({u'organization-id': self.org['id']})
         new_ak_env = self._make_activation_key({
@@ -155,9 +155,9 @@ class ActivationKeyTestCase(CLITestCase):
     def test_positive_create_with_default_lce_by_name(self):
         """Create Activation key with associated environment by name
 
-        @id: 7410f7c4-e8b5-4080-b6d2-65dbcedffe8a
+        :id: 7410f7c4-e8b5-4080-b6d2-65dbcedffe8a
 
-        @assert: Activation key is created
+        :assert: Activation key is created
         """
         lce = self.get_default_env()
         new_ak_env = self._make_activation_key({
@@ -170,11 +170,11 @@ class ActivationKeyTestCase(CLITestCase):
     def test_positive_create_with_cv(self):
         """Create Activation key for all variations of Content Views
 
-        @id: ec7b1af5-c3f4-40c3-b1df-c69c02a3b9a7
+        :id: ec7b1af5-c3f4-40c3-b1df-c69c02a3b9a7
 
-        @Assert: Activation key is created and has proper content view assigned
+        :Assert: Activation key is created and has proper content view assigned
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         for name in valid_data_list():
             with self.subTest(name):
@@ -193,9 +193,9 @@ class ActivationKeyTestCase(CLITestCase):
     def test_positive_create_with_usage_limit_default(self):
         """Create Activation key with default Usage limit (Unlimited)
 
-        @id: cba13c72-9845-486d-beff-e0fb55bb762c
+        :id: cba13c72-9845-486d-beff-e0fb55bb762c
 
-        @Assert: Activation key is created
+        :Assert: Activation key is created
         """
         new_ak = self._make_activation_key()
         self.assertEqual(new_ak['host-limit'], u'Unlimited')
@@ -204,9 +204,9 @@ class ActivationKeyTestCase(CLITestCase):
     def test_positive_create_with_usage_limit_finite(self):
         """Create Activation key with finite Usage limit
 
-        @id: 529a0f9e-977f-4e9d-a1af-88bb98c28a6a
+        :id: 529a0f9e-977f-4e9d-a1af-88bb98c28a6a
 
-        @Assert: Activation key is created
+        :Assert: Activation key is created
         """
         new_ak = self._make_activation_key({
             u'max-hosts': '10',
@@ -234,9 +234,9 @@ class ActivationKeyTestCase(CLITestCase):
     def test_negative_create_with_invalid_name(self):
         """Create Activation key with invalid Name
 
-        @id: d9b7e3a9-1d24-4e47-bd4a-dce75772d829
+        :id: d9b7e3a9-1d24-4e47-bd4a-dce75772d829
 
-        @Assert: Activation key is not created. Appropriate error shown.
+        :Assert: Activation key is not created. Appropriate error shown.
         """
         for name in invalid_values_list():
             with self.subTest(name), self.assertRaises(
@@ -252,9 +252,9 @@ class ActivationKeyTestCase(CLITestCase):
     def test_negative_create_with_usage_limit_with_not_integers(self):
         """Create Activation key with non integers Usage Limit
 
-        @id: 247ebc2e-c80f-488b-aeaf-6bf5eba55375
+        :id: 247ebc2e-c80f-488b-aeaf-6bf5eba55375
 
-        @Assert: Activation key is not created. Appropriate error shown.
+        :Assert: Activation key is not created. Appropriate error shown.
         """
         self.assert_negative_create_with_usage_limit(
             invalid_values_list() + [0.5],
@@ -265,9 +265,9 @@ class ActivationKeyTestCase(CLITestCase):
     def test_negative_create_with_usage_limit_with_invalid_integers(self):
         """Create Activation key with invalid integers Usage Limit
 
-        @id: 9089f756-fda8-4e28-855c-cf8273f7c6cd
+        :id: 9089f756-fda8-4e28-855c-cf8273f7c6cd
 
-        @Assert: Activation key is not created. Appropriate error shown.
+        :Assert: Activation key is not created. Appropriate error shown.
         """
         self.assert_negative_create_with_usage_limit(
             ('-1', '-500', 0),
@@ -279,9 +279,9 @@ class ActivationKeyTestCase(CLITestCase):
         """Create Activation key and delete it for all variations of
         Activation key name
 
-        @id: ef5f6a28-6bfd-415b-aac9-b3dc9a014ca9
+        :id: ef5f6a28-6bfd-415b-aac9-b3dc9a014ca9
 
-        @Assert: Activation key is deleted
+        :Assert: Activation key is deleted
         """
         for name in valid_data_list():
             with self.subTest(name):
@@ -302,9 +302,9 @@ class ActivationKeyTestCase(CLITestCase):
         """Create Activation key and delete it using organization name
         for which that key was created
 
-        @id: 006cbe5c-fb72-43a1-9760-30c97043c36b
+        :id: 006cbe5c-fb72-43a1-9760-30c97043c36b
 
-        @Assert: Activation key is deleted
+        :Assert: Activation key is deleted
         """
         new_ak = self._make_activation_key()
         ActivationKey.delete({
@@ -320,9 +320,9 @@ class ActivationKeyTestCase(CLITestCase):
         """Create Activation key and delete it using organization label
         for which that key was created
 
-        @id: f66e5a42-b531-4290-a907-9f5c01305885
+        :id: f66e5a42-b531-4290-a907-9f5c01305885
 
-        @Assert: Activation key is deleted
+        :Assert: Activation key is deleted
         """
         new_ak = self._make_activation_key()
         ActivationKey.delete({
@@ -338,11 +338,11 @@ class ActivationKeyTestCase(CLITestCase):
         """Create activation key with content view assigned to it and
         delete it using activation key id
 
-        @id: bba323fa-0362-4a9b-97af-560d446cbb6c
+        :id: bba323fa-0362-4a9b-97af-560d446cbb6c
 
-        @Assert: Activation key is deleted
+        :Assert: Activation key is deleted
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         new_cv = make_content_view({u'organization-id': self.org['id']})
         new_ak = self._make_activation_key({u'content-view': new_cv['name']})
@@ -356,11 +356,11 @@ class ActivationKeyTestCase(CLITestCase):
         """Create activation key with lifecycle environment assigned to
         it and delete it using activation key id
 
-        @id: e1830e52-5b1a-4ac4-8d0a-df6efb218a8b
+        :id: e1830e52-5b1a-4ac4-8d0a-df6efb218a8b
 
-        @Assert: Activation key is deleted
+        :Assert: Activation key is deleted
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         new_ak = self._make_activation_key({
             u'lifecycle-environment': self.get_default_env()['name'],
@@ -374,9 +374,9 @@ class ActivationKeyTestCase(CLITestCase):
     def test_positive_update_name_by_id(self):
         """Update Activation Key Name in Activation key searching by ID
 
-        @id: bc304894-fd9b-4622-96e3-57c2257e26ca
+        :id: bc304894-fd9b-4622-96e3-57c2257e26ca
 
-        @Assert: Activation key is updated
+        :Assert: Activation key is updated
         """
         activation_key = self._make_activation_key()
         for name in valid_data_list():
@@ -395,9 +395,9 @@ class ActivationKeyTestCase(CLITestCase):
         """Update Activation Key Name in an Activation key searching by
         name
 
-        @id: bce4533e-1a58-4edb-a51a-4aa46bc28676
+        :id: bce4533e-1a58-4edb-a51a-4aa46bc28676
 
-        @Assert: Activation key is updated
+        :Assert: Activation key is updated
         """
         new_name = gen_string('alpha')
         activation_key = self._make_activation_key()
@@ -414,9 +414,9 @@ class ActivationKeyTestCase(CLITestCase):
     def test_positive_update_description(self):
         """Update Description in an Activation key
 
-        @id: 60a4e860-d99c-431e-b70b-9b0fa90d839b
+        :id: 60a4e860-d99c-431e-b70b-9b0fa90d839b
 
-        @Assert: Activation key is updated
+        :Assert: Activation key is updated
         """
         activation_key = self._make_activation_key()
         for description in valid_data_list():
@@ -434,11 +434,11 @@ class ActivationKeyTestCase(CLITestCase):
     def test_positive_update_lce(self):
         """Update Environment in an Activation key
 
-        @id: 55aaee60-b8c8-49f0-995a-6c526b9b653b
+        :id: 55aaee60-b8c8-49f0-995a-6c526b9b653b
 
-        @Assert: Activation key is updated
+        :Assert: Activation key is updated
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         ak_env = self._make_activation_key({
             u'lifecycle-environment-id': self.get_default_env()['id'],
@@ -465,11 +465,11 @@ class ActivationKeyTestCase(CLITestCase):
     def test_positive_update_cv(self):
         """Update Content View in an Activation key
 
-        @id: aa94997d-fc9b-4532-aeeb-9f27b9834914
+        :id: aa94997d-fc9b-4532-aeeb-9f27b9834914
 
-        @Assert: Activation key is updated
+        :Assert: Activation key is updated
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         cv = make_content_view({u'organization-id': self.org['id']})
         ak_cv = self._make_activation_key({u'content-view-id': cv['id']})
@@ -486,9 +486,9 @@ class ActivationKeyTestCase(CLITestCase):
     def test_positive_update_usage_limit_to_finite_number(self):
         """Update Usage limit from Unlimited to a finite number
 
-        @id: a55bb8dc-c7d8-4a6a-ac0f-1d5a377da543
+        :id: a55bb8dc-c7d8-4a6a-ac0f-1d5a377da543
 
-        @Assert: Activation key is updated
+        :Assert: Activation key is updated
         """
         new_ak = self._make_activation_key()
         self.assertEqual(new_ak['host-limit'], u'Unlimited')
@@ -504,9 +504,9 @@ class ActivationKeyTestCase(CLITestCase):
     def test_positive_update_usage_limit_to_unlimited(self):
         """Update Usage limit from definite number to Unlimited
 
-        @id: 0b83657b-41d1-4fb2-9c23-c36011322b83
+        :id: 0b83657b-41d1-4fb2-9c23-c36011322b83
 
-        @Assert: Activation key is updated
+        :Assert: Activation key is updated
         """
         new_ak = self._make_activation_key({
             u'max-hosts': '10',
@@ -524,9 +524,9 @@ class ActivationKeyTestCase(CLITestCase):
     def test_negative_update_name(self):
         """Try to update Activation Key using invalid value for its name
 
-        @id: b75e7c38-fde2-4110-ba65-4157319fc159
+        :id: b75e7c38-fde2-4110-ba65-4157319fc159
 
-        @Assert: Activation key is not updated. Appropriate error shown.
+        :Assert: Activation key is not updated. Appropriate error shown.
         """
         new_ak = self._make_activation_key()
         for name in invalid_values_list():
@@ -547,9 +547,9 @@ class ActivationKeyTestCase(CLITestCase):
         """Try to update Activation Key using invalid value for its
         usage limit attribute
 
-        @id: cb5fa263-924c-471f-9c57-9506117ca92d
+        :id: cb5fa263-924c-471f-9c57-9506117ca92d
 
-        @Assert: Activation key is not updated. Appropriate error shown.
+        :Assert: Activation key is not updated. Appropriate error shown.
         """
         new_ak = self._make_activation_key()
         with self.assertRaises(CLIReturnCodeError) as raise_ctx:
@@ -568,19 +568,19 @@ class ActivationKeyTestCase(CLITestCase):
     def test_positive_usage_limit(self):
         """Test that Usage limit actually limits usage
 
-        @id: 00ded856-e939-4140-ac84-91b6a8643623
+        :id: 00ded856-e939-4140-ac84-91b6a8643623
 
-        @Steps:
+        :Steps:
 
-        1. Create Activation key
-        2. Update Usage Limit to a finite number
-        3. Register Content hosts to match the Usage Limit
-        4. Attempt to register an other Content host after reaching the Usage
-           Limit
+            1. Create Activation key
+            2. Update Usage Limit to a finite number
+            3. Register Content hosts to match the Usage Limit
+            4. Attempt to register an other Content host after reaching the
+               Usage Limit
 
-        @Assert: Content host Registration fails. Appropriate error shown
+        :Assert: Content host Registration fails. Appropriate error shown
 
-        @CaseLevel: System
+        :CaseLevel: System
         """
         env = make_lifecycle_environment({u'organization-id': self.org['id']})
         new_cv = make_content_view({u'organization-id': self.org['id']})
@@ -614,13 +614,13 @@ class ActivationKeyTestCase(CLITestCase):
         """Test that host collection can be associated to Activation
         Keys
 
-        @id: 2114132a-fede-4791-98e7-a463ad79f398
+        :id: 2114132a-fede-4791-98e7-a463ad79f398
 
-        @BZ: 1110476
+        :BZ: 1110476
 
-        @Assert: Hosts are successfully associated to Activation key
+        :Assert: Hosts are successfully associated to Activation key
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         for host_col_name in valid_data_list():
             with self.subTest(host_col_name):
@@ -648,11 +648,11 @@ class ActivationKeyTestCase(CLITestCase):
     def test_positive_add_redhat_product(self):
         """Test that RH product can be associated to Activation Keys
 
-        @id: 7b15de8e-edde-41aa-937b-ad6aa529891a
+        :id: 7b15de8e-edde-41aa-937b-ad6aa529891a
 
-        @Assert: RH products are successfully associated to Activation key
+        :Assert: RH products are successfully associated to Activation key
 
-        @CaseLevel: System
+        :CaseLevel: System
         """
         org = make_org()
         result = setup_org_for_a_rh_repo({
@@ -672,13 +672,13 @@ class ActivationKeyTestCase(CLITestCase):
     def test_positive_add_custom_product(self):
         """Test that custom product can be associated to Activation Keys
 
-        @id: 96ace967-e165-4069-8ff7-f54c4c822de0
+        :id: 96ace967-e165-4069-8ff7-f54c4c822de0
 
-        @Assert: Custom products are successfully associated to Activation key
+        :Assert: Custom products are successfully associated to Activation key
 
-        @CaseLevel: System
+        :CaseLevel: System
 
-        @BZ: 1360239
+        :BZ: 1360239
         """
         result = setup_org_for_a_custom_repo({
             u'url': FAKE_0_YUM_REPO,
@@ -698,19 +698,19 @@ class ActivationKeyTestCase(CLITestCase):
     def test_positive_add_redhat_and_custom_products(self):
         """Test if RH/Custom product can be associated to Activation key
 
-        @id: 74c77426-18f5-4abb-bca9-a2135f7fcc1f
+        :id: 74c77426-18f5-4abb-bca9-a2135f7fcc1f
 
-        @Steps:
+        :Steps:
 
-        1. Create Activation key
-        2. Associate RH product(s) to Activation Key
-        3. Associate custom product(s) to Activation Key
+            1. Create Activation key
+            2. Associate RH product(s) to Activation Key
+            3. Associate custom product(s) to Activation Key
 
-        @Assert: RH/Custom product is successfully associated to Activation key
+        :Assert: RH/Custom product is successfully associated to Activation key
 
-        @CaseLevel: System
+        :CaseLevel: System
 
-        @BZ: 1360239
+        :BZ: 1360239
         """
         org = make_org()
         result = setup_org_for_a_rh_repo({
@@ -739,17 +739,18 @@ class ActivationKeyTestCase(CLITestCase):
     def test_positive_delete_manifest(self):
         """Check if deleting a manifest removes it from Activation key
 
-        @id: 8256ac6d-3f60-4668-897d-2e88d29532d3
+        :id: 8256ac6d-3f60-4668-897d-2e88d29532d3
 
-        @Steps:
-        1. Upload manifest
-        2. Create activation key - attach some subscriptions
-        3. Delete manifest
-        4. See if the activation key automatically removed the subscriptions.
+        :Steps:
+            1. Upload manifest
+            2. Create activation key - attach some subscriptions
+            3. Delete manifest
+            4. See if the activation key automatically removed the
+               subscriptions.
 
-        @Assert: Deleting a manifest removes it from the Activation key
+        :Assert: Deleting a manifest removes it from the Activation key
 
-        @caseautomation: notautomated
+        :caseautomation: notautomated
         """
 
     @run_in_one_thread
@@ -759,11 +760,11 @@ class ActivationKeyTestCase(CLITestCase):
     def test_positive_delete_subscription(self):
         """Check if deleting a subscription removes it from Activation key
 
-        @id: bbbe4641-bfb0-48d6-acfc-de4294b18c15
+        :id: bbbe4641-bfb0-48d6-acfc-de4294b18c15
 
-        @Assert: Deleting subscription removes it from the Activation key
+        :Assert: Deleting subscription removes it from the Activation key
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         new_ak = self._make_activation_key()
         with manifests.clone() as manifest:
@@ -803,11 +804,11 @@ class ActivationKeyTestCase(CLITestCase):
         """Check if multiple Activation keys can be attached to a
         Content host
 
-        @id: 24fddd9c-03ae-41a7-8649-72296cbbafdf
+        :id: 24fddd9c-03ae-41a7-8649-72296cbbafdf
 
-        @Assert: Multiple Activation keys are attached to a Content host
+        :Assert: Multiple Activation keys are attached to a Content host
 
-        @CaseLevel: System
+        :CaseLevel: System
         """
         env = make_lifecycle_environment({u'organization-id': self.org['id']})
         new_cv = make_content_view({u'organization-id': self.org['id']})
@@ -851,20 +852,20 @@ class ActivationKeyTestCase(CLITestCase):
         This means that we can re-use `--activationkey` option more than once
         to add different keys
 
-        @id: 888669e2-2ff7-48e3-9c56-6ac497bec5a0
+        :id: 888669e2-2ff7-48e3-9c56-6ac497bec5a0
 
-        @Assert: Multiple Activation keys are attached to a Content host
+        :Assert: Multiple Activation keys are attached to a Content host
 
-        @CaseLevel: System
+        :CaseLevel: System
         """
 
     @tier1
     def test_positive_list_by_name(self):
         """List Activation key for all variations of Activation key name
 
-        @id: 644b70d9-86c1-4e26-b38e-6aafab3efa34
+        :id: 644b70d9-86c1-4e26-b38e-6aafab3efa34
 
-        @Assert: Activation key is listed
+        :Assert: Activation key is listed
         """
         for name in valid_data_list():
             with self.subTest(name):
@@ -880,9 +881,9 @@ class ActivationKeyTestCase(CLITestCase):
     def test_positive_list_by_cv_id(self):
         """List Activation key for provided Content View ID
 
-        @id: 4d9aad38-cd6e-41cb-99a0-9a593cf22655
+        :id: 4d9aad38-cd6e-41cb-99a0-9a593cf22655
 
-        @Assert: Activation key is listed
+        :Assert: Activation key is listed
         """
         cv = make_content_view({u'organization-id': self.org['id']})
         self._make_activation_key({u'content-view-id': cv['id']})
@@ -898,9 +899,9 @@ class ActivationKeyTestCase(CLITestCase):
         """Create activation key, rename it and create another with the
         initial name
 
-        @id: 9801319a-f42c-41a4-9ea4-3718e544c8e0
+        :id: 9801319a-f42c-41a4-9ea4-3718e544c8e0
 
-        @Assert: Activation key is created
+        :Assert: Activation key is created
         """
         name = gen_string('utf8')
         activation_key = self._make_activation_key({'name': name})
@@ -924,19 +925,19 @@ class ActivationKeyTestCase(CLITestCase):
         """Test that hosts associated to Activation Keys can be removed
         using id of that host collection
 
-        @id: 20f8ecca-1756-4900-b966-f0144b6bd0aa
+        :id: 20f8ecca-1756-4900-b966-f0144b6bd0aa
 
-        @Steps:
+        :Steps:
 
-        1. Create Activation key
-        2. Create host collection
-        3. Associate host collection to Activation key
-        4. Remove host collection associated to Activation key using id of that
-           collection
+            1. Create Activation key
+            2. Create host collection
+            3. Associate host collection to Activation key
+            4. Remove host collection associated to Activation key using id of
+               that collection
 
-        @Assert: Host collection successfully removed from activation key
+        :Assert: Host collection successfully removed from activation key
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         activation_key = self._make_activation_key()
         new_host_col = make_host_collection({
@@ -964,19 +965,19 @@ class ActivationKeyTestCase(CLITestCase):
         """Test that hosts associated to Activation Keys can be removed
         using name of that host collection
 
-        @id: 1a559a82-db5f-48b0-beeb-2fa02aed7ef9
+        :id: 1a559a82-db5f-48b0-beeb-2fa02aed7ef9
 
-        @Steps:
+        :Steps:
 
-        1. Create Activation key
-        2. Create host collection
-        3. Associate host collection to Activation key
-        4. Remove the host collection associated to Activation key using name
-           of that collection
+            1. Create Activation key
+            2. Create host collection
+            3. Associate host collection to Activation key
+            4. Remove the host collection associated to Activation key using
+               name of that collection
 
-        @Assert: Host collection successfully removed from activation key
+        :Assert: Host collection successfully removed from activation key
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         for host_col in valid_data_list():
             with self.subTest(host_col):
@@ -1016,17 +1017,17 @@ class ActivationKeyTestCase(CLITestCase):
     def test_positive_add_subscription_by_id(self):
         """Test that subscription can be added to activation key
 
-        @id: b884be1c-b35d-440a-9a9d-c854c83e10a7
+        :id: b884be1c-b35d-440a-9a9d-c854c83e10a7
 
-        @Steps:
+        :Steps:
 
-        1. Create Activation key
-        2. Upload manifest and add subscription
-        3. Associate the activation key to subscription
+            1. Create Activation key
+            2. Upload manifest and add subscription
+            3. Associate the activation key to subscription
 
-        @Assert: Subscription successfully added to activation key
+        :Assert: Subscription successfully added to activation key
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         with manifests.clone() as manifest:
             upload_file(manifest.content, manifest.filename)
@@ -1051,9 +1052,9 @@ class ActivationKeyTestCase(CLITestCase):
         """Copy Activation key for all valid Activation Key name
         variations
 
-        @id: c9ad8aff-07ba-4804-a198-f719fe905123
+        :id: c9ad8aff-07ba-4804-a198-f719fe905123
 
-        @Assert: Activation key is successfully copied
+        :Assert: Activation key is successfully copied
         """
         parent_ak = self._make_activation_key()
         for new_name in valid_data_list():
@@ -1069,9 +1070,9 @@ class ActivationKeyTestCase(CLITestCase):
     def test_positive_copy_by_parent_name(self):
         """Copy Activation key by passing name of parent
 
-        @id: 5d5405e6-3b26-47a3-96ff-f6c0f6c32607
+        :id: 5d5405e6-3b26-47a3-96ff-f6c0f6c32607
 
-        @Assert: Activation key is successfully copied
+        :Assert: Activation key is successfully copied
         """
         parent_ak = self._make_activation_key()
         result = ActivationKey.copy({
@@ -1085,9 +1086,9 @@ class ActivationKeyTestCase(CLITestCase):
     def test_negative_copy_with_same_name(self):
         """Copy activation key with duplicate name
 
-        @id: f867c468-4155-495c-a1e5-c04d9868a2e0
+        :id: f867c468-4155-495c-a1e5-c04d9868a2e0
 
-        @Assert: Activation key is not successfully copied
+        :Assert: Activation key is not successfully copied
         """
         parent_ak = self._make_activation_key()
         with self.assertRaises(CLIReturnCodeError) as raise_ctx:
@@ -1108,17 +1109,17 @@ class ActivationKeyTestCase(CLITestCase):
     def test_positive_copy_subscription(self):
         """Copy Activation key and verify contents
 
-        @id: f4ee8096-4120-4d06-8c9a-57ac1eaa8f68
+        :id: f4ee8096-4120-4d06-8c9a-57ac1eaa8f68
 
-        @Steps:
+        :Steps:
 
-        1. Create parent key and add content
-        2. Copy Activation key by passing id of parent
-        3. Verify content was successfully copied
+            1. Create parent key and add content
+            2. Copy Activation key by passing id of parent
+            3. Verify content was successfully copied
 
-        @Assert: Activation key is successfully copied
+        :Assert: Activation key is successfully copied
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         # Begin test setup
         parent_ak = self._make_activation_key()
@@ -1156,15 +1157,15 @@ class ActivationKeyTestCase(CLITestCase):
     def test_positive_update_autoattach_toggle(self):
         """Update Activation key with inverse auto-attach value
 
-        @id: de3b5fb7-7963-420a-b4c9-c66e78a111dc
+        :id: de3b5fb7-7963-420a-b4c9-c66e78a111dc
 
-        @Steps:
+        :Steps:
 
-        1. Get the key's current auto attach value.
-        2. Update the key with the value's inverse.
-        3. Verify key was updated.
+            1. Get the key's current auto attach value.
+            2. Update the key with the value's inverse.
+            3. Verify key was updated.
 
-        @Assert: Activation key is successfully copied
+        :Assert: Activation key is successfully copied
         """
         new_ak = self._make_activation_key()
         attach_value = new_ak['auto-attach']
@@ -1182,9 +1183,9 @@ class ActivationKeyTestCase(CLITestCase):
     def test_positive_update_autoattach(self):
         """Update Activation key with valid auto-attach values
 
-        @id: 9e18b950-6f0f-4f82-a3ac-ef6aba950a78
+        :id: 9e18b950-6f0f-4f82-a3ac-ef6aba950a78
 
-        @Assert: Activation key is successfully updated
+        :Assert: Activation key is successfully updated
         """
         new_ak = self._make_activation_key()
         for new_value in (u'1', u'0', u'true', u'false', u'yes', u'no'):
@@ -1201,14 +1202,14 @@ class ActivationKeyTestCase(CLITestCase):
     def test_negative_update_autoattach(self):
         """Attempt to update Activation key with bad auto-attach value
 
-        @id: 54b6f808-ff54-4e69-a54d-e1f99a4652f9
+        :id: 54b6f808-ff54-4e69-a54d-e1f99a4652f9
 
-        @Steps:
+        :Steps:
 
-        1. Attempt to update a key with incorrect auto-attach value
-        2. Verify that an appropriate error message was returned
+            1. Attempt to update a key with incorrect auto-attach value
+            2. Verify that an appropriate error message was returned
 
-        @Assert: Activation key is not updated. Appropriate error shown.
+        :Assert: Activation key is not updated. Appropriate error shown.
         """
         new_ak = self._make_activation_key()
         with self.assertRaises(CLIReturnCodeError) as exe:
@@ -1225,18 +1226,18 @@ class ActivationKeyTestCase(CLITestCase):
     def test_positive_content_override(self):
         """Positive content override
 
-        @id: a4912cc0-3bf7-4e90-bb51-ec88b2fad227
+        :id: a4912cc0-3bf7-4e90-bb51-ec88b2fad227
 
-        @Steps:
+        :Steps:
 
-        1. Create activation key and add content
-        2. Get the first product's label
-        3. Override the product's content enabled state
-        4. Verify that the command succeeded
+            1. Create activation key and add content
+            2. Get the first product's label
+            3. Override the product's content enabled state
+            4. Verify that the command succeeded
 
-        @Assert: Activation key content override was successful
+        :Assert: Activation key content override was successful
 
-        @CaseLevel: System
+        :CaseLevel: System
         """
         result = setup_org_for_a_custom_repo({
             u'url': FAKE_0_YUM_REPO,
@@ -1266,11 +1267,11 @@ class ActivationKeyTestCase(CLITestCase):
         """Delete any user who has previously created an activation key
         and check that activation key still exists
 
-        @id: ba9c4b29-2349-47ea-8081-917de2c17ed2
+        :id: ba9c4b29-2349-47ea-8081-917de2c17ed2
 
-        @Assert: Activation Key can be read
+        :Assert: Activation Key can be read
 
-        @BZ: 1291271
+        :BZ: 1291271
         """
         password = gen_string('alpha')
         user = make_user({'password': password, 'admin': 'true'})

--- a/tests/foreman/cli/test_architecture.py
+++ b/tests/foreman/cli/test_architecture.py
@@ -1,19 +1,19 @@
 # -*- encoding: utf-8 -*-
 """Test class for Architecture CLI
 
-@Requirement: Architecture
+:Requirement: Architecture
 
-@CaseAutomation: Automated
+:CaseAutomation: Automated
 
-@CaseLevel: Acceptance
+:CaseLevel: Acceptance
 
-@CaseComponent: CLI
+:CaseComponent: CLI
 
-@TestType: Functional
+:TestType: Functional
 
-@CaseImportance: High
+:CaseImportance: High
 
-@Upstream: No
+:Upstream: No
 """
 
 from robottelo.cli.architecture import Architecture
@@ -35,9 +35,9 @@ class ArchitectureTestCase(CLITestCase):
     def test_positive_create_with_name(self):
         """Successfully creates an Architecture.
 
-        @id: a3955346-cfc0-428d-8871-a10386fe7c59
+        :id: a3955346-cfc0-428d-8871-a10386fe7c59
 
-        @Assert: Architecture is created.
+        :Assert: Architecture is created.
         """
         for name in valid_data_list():
             with self.subTest(name):
@@ -48,9 +48,9 @@ class ArchitectureTestCase(CLITestCase):
     def test_negative_create_with_name(self):
         """Don't create an Architecture with invalid data.
 
-        @id: cfed972e-9b09-4852-bdd2-b5a8a8aed170
+        :id: cfed972e-9b09-4852-bdd2-b5a8a8aed170
 
-        @Assert: Architecture is not created.
+        :Assert: Architecture is not created.
         """
         for name in invalid_values_list():
             with self.subTest(name):
@@ -63,9 +63,9 @@ class ArchitectureTestCase(CLITestCase):
     def test_positive_update_name(self):
         """Successfully update an Architecture.
 
-        @id: 67f1e60b-29e2-44a4-8019-498e5ad0e201
+        :id: 67f1e60b-29e2-44a4-8019-498e5ad0e201
 
-        @Assert: Architecture is updated.
+        :Assert: Architecture is updated.
         """
         architecture = make_architecture()
         for new_name in valid_data_list():
@@ -82,9 +82,9 @@ class ArchitectureTestCase(CLITestCase):
     def test_negative_update_name(self):
         """Create Architecture then fail to update its name
 
-        @id: 037c4892-5e62-46dd-a2ed-92243e870e40
+        :id: 037c4892-5e62-46dd-a2ed-92243e870e40
 
-        @assert: Architecture name is not updated
+        :assert: Architecture name is not updated
         """
         architecture = make_architecture()
         for new_name in invalid_values_list():
@@ -105,9 +105,9 @@ class ArchitectureTestCase(CLITestCase):
         """Create Architecture with valid values then delete it
         by ID
 
-        @id: df699e29-29a3-417a-a6ee-81e74b7211a4
+        :id: df699e29-29a3-417a-a6ee-81e74b7211a4
 
-        @assert: Architecture is deleted
+        :assert: Architecture is deleted
         """
         for name in valid_data_list():
             with self.subTest(name):
@@ -121,9 +121,9 @@ class ArchitectureTestCase(CLITestCase):
     def test_negative_delete_by_id(self):
         """Create Architecture then delete it by wrong ID
 
-        @id: 78bae664-6493-4c74-a587-94170f20746e
+        :id: 78bae664-6493-4c74-a587-94170f20746e
 
-        @assert: Architecture is not deleted
+        :assert: Architecture is not deleted
         """
         for entity_id in invalid_id_list():
             with self.subTest(entity_id):

--- a/tests/foreman/cli/test_bootstrap_script.py
+++ b/tests/foreman/cli/test_bootstrap_script.py
@@ -1,19 +1,19 @@
 # -*- encoding: utf-8 -*-
 """Test for bootstrap script
 
-@Requirement: Bootstrap script
+:Requirement: Bootstrap script
 
-@CaseAutomation: Automated
+:CaseAutomation: Automated
 
-@CaseLevel: Acceptance
+:CaseLevel: Acceptance
 
-@CaseComponent: CLI
+:CaseComponent: CLI
 
-@TestType: Functional
+:TestType: Functional
 
-@CaseImportance: High
+:CaseImportance: High
 
-@Upstream: No
+:Upstream: No
 """
 from robottelo.decorators import stubbed, tier1
 from robottelo.test import CLITestCase
@@ -32,16 +32,16 @@ class BootstrapScriptTestCase(CLITestCase):
     def test_positive_register(self):
         """System is registered
 
-        @id: e34561fd-e0d6-4587-84eb-f86bd131aab1
+        :id: e34561fd-e0d6-4587-84eb-f86bd131aab1
 
-        @Steps:
+        :Steps:
 
-        1. assure system is not registered
-        2. register a system
+            1. assure system is not registered
+            2. register a system
 
-        @Assert: system is registered, host is created
+        :Assert: system is registered, host is created
 
-        @caseautomation: notautomated
+        :caseautomation: notautomated
         """
 
     @tier1
@@ -49,17 +49,17 @@ class BootstrapScriptTestCase(CLITestCase):
     def test_positive_reregister(self):
         """Registered system is re-registered
 
-        @id: d8a7aef1-7522-47a8-8478-77e81ca236be
+        :id: d8a7aef1-7522-47a8-8478-77e81ca236be
 
-        @Steps:
+        :Steps:
 
-        1. register a system
-        2. assure system is registered
-        3. register system once again
+            1. register a system
+            2. assure system is registered
+            3. register system once again
 
-        @Assert: system is newly registered, host is created
+        :Assert: system is newly registered, host is created
 
-        @caseautomation: notautomated
+        :caseautomation: notautomated
         """
 
     @tier1
@@ -67,17 +67,17 @@ class BootstrapScriptTestCase(CLITestCase):
     def test_positive_migrate(self):
         """RHN registered system is migrated
 
-        @id: 26911dce-f2e3-4aef-a490-ad55236493bf
+        :id: 26911dce-f2e3-4aef-a490-ad55236493bf
 
-        @Steps:
+        :Steps:
 
-        1. register system to SAT5 (or use precreated stored registration)
-        2. assure system is registered with rhn classic
-        3. migrate system
+            1. register system to SAT5 (or use precreated stored registration)
+            2. assure system is registered with rhn classic
+            3. migrate system
 
-        @Assert: system is migrated, ie. registered
+        :Assert: system is migrated, ie. registered
 
-        @caseautomation: notautomated
+        :caseautomation: notautomated
         """
 
     @tier1
@@ -85,16 +85,16 @@ class BootstrapScriptTestCase(CLITestCase):
     def test_negative_register_no_subs(self):
         """Attempt to register when no subscriptions are available
 
-        @id: 26f04562-6242-4542-8852-4242156f6e45
+        :id: 26f04562-6242-4542-8852-4242156f6e45
 
-        @Steps:
+        :Steps:
 
-        1. create AK with no available subscriptions
-        2. try to register a system
+            1. create AK with no available subscriptions
+            2. try to register a system
 
-        @Assert: ends gracefully, reason displayed to user
+        :Assert: ends gracefully, reason displayed to user
 
-        @caseautomation: notautomated
+        :caseautomation: notautomated
         """
 
     @tier1
@@ -102,17 +102,17 @@ class BootstrapScriptTestCase(CLITestCase):
     def test_negative_register_bad_hostgroup(self):
         """Attempt to register when hostgroup doesn't meet all criteria
 
-        @id: 29551e22-ae63-47f2-86f3-5f1444df8493
+        :id: 29551e22-ae63-47f2-86f3-5f1444df8493
 
-        @Steps:
+        :Steps:
 
-        1. create hostgroup not matching required criteria for bootstrapping
-           (Domain can't be blank...)
-        2. try to register a system
+            1. create hostgroup not matching required criteria for
+               bootstrapping (Domain can't be blank...)
+            2. try to register a system
 
-        @Assert: ends gracefully, reason displayed to user
+        :Assert: ends gracefully, reason displayed to user
 
-        @caseautomation: notautomated
+        :caseautomation: notautomated
         """
 
     @tier1
@@ -120,16 +120,16 @@ class BootstrapScriptTestCase(CLITestCase):
     def test_positive_register_host_collision(self):
         """Attempt to register with already created host
 
-        @id: ec39c981-5b8a-43a3-84f1-71871a951c53
+        :id: ec39c981-5b8a-43a3-84f1-71871a951c53
 
-        @Steps:
+        :Steps:
 
-        1. create host profile
-        2. register a system
+            1. create host profile
+            2. register a system
 
-        @Assert: system is registered, pre-created host profile is used
+        :Assert: system is registered, pre-created host profile is used
 
-        @caseautomation: notautomated
+        :caseautomation: notautomated
         """
 
     @tier1
@@ -137,15 +137,15 @@ class BootstrapScriptTestCase(CLITestCase):
     def test_negative_register_missing_sattools(self):
         """Attempt to register when sat tools not available
 
-        @id: 88f95080-a6f1-4a4f-bd7a-5d030c0bd2e0
+        :id: 88f95080-a6f1-4a4f-bd7a-5d030c0bd2e0
 
-        @Steps:
+        :Steps:
 
-        1. create env without available sat tools repo
-           (AK or hostgroup being used doesn't provide CV that have sattools)
-        2. try to register a system
+            1. create env without available sat tools repo (AK or hostgroup
+               being used doesn't provide CV that have sattools)
+            2. try to register a system
 
-        @Assert: ends gracefully, reason displayed to user
+        :Assert: ends gracefully, reason displayed to user
 
-        @caseautomation: notautomated
+        :caseautomation: notautomated
         """

--- a/tests/foreman/cli/test_capsule.py
+++ b/tests/foreman/cli/test_capsule.py
@@ -1,19 +1,19 @@
 # -*- encoding: utf-8 -*-
 """Test class for the capsule CLI.
 
-@Requirement: Capsule
+:Requirement: Capsule
 
-@CaseAutomation: Automated
+:CaseAutomation: Automated
 
-@CaseLevel: Acceptance
+:CaseLevel: Acceptance
 
-@CaseComponent: CLI
+:CaseComponent: CLI
 
-@TestType: Functional
+:TestType: Functional
 
-@CaseImportance: High
+:CaseImportance: High
 
-@Upstream: No
+:Upstream: No
 """
 
 from fauxfactory import gen_alphanumeric, gen_string
@@ -47,9 +47,9 @@ class CapsuleTestCase(CLITestCase):
     def test_negative_create_with_url(self):
         """Proxy creation with random URL
 
-        @id: 9050b362-c710-43ba-9d77-7680b8f9ed8c
+        :id: 9050b362-c710-43ba-9d77-7680b8f9ed8c
 
-        @Assert: Proxy is not created
+        :Assert: Proxy is not created
         """
         # Create a random proxy
         with self.assertRaisesRegex(
@@ -68,9 +68,9 @@ class CapsuleTestCase(CLITestCase):
     def test_positive_create_with_name(self):
         """Proxy creation with the home proxy
 
-        @id: 7decd7a3-2d35-43ff-9a20-de44e83c7389
+        :id: 7decd7a3-2d35-43ff-9a20-de44e83c7389
 
-        @Assert: Proxy is created
+        :Assert: Proxy is created
         """
         for name in valid_data_list():
             with self.subTest(name):
@@ -86,9 +86,9 @@ class CapsuleTestCase(CLITestCase):
     def test_positive_delete_by_id(self):
         """Proxy deletion with the home proxy
 
-        @id: 1b6973b1-259d-4866-b36f-c2d5fb154035
+        :id: 1b6973b1-259d-4866-b36f-c2d5fb154035
 
-        @Assert: Proxy is deleted
+        :Assert: Proxy is deleted
         """
         for name in valid_data_list():
             with self.subTest(name):
@@ -103,9 +103,9 @@ class CapsuleTestCase(CLITestCase):
     def test_positive_update_name(self):
         """Proxy name update with the home proxy
 
-        @id: 1a02a06b-e9ab-4b9b-bcb0-ac7060188316
+        :id: 1a02a06b-e9ab-4b9b-bcb0-ac7060188316
 
-        @Assert: Proxy has the name updated
+        :Assert: Proxy has the name updated
         """
         proxy = make_proxy({u'name': gen_alphanumeric()})
         for new_name in valid_data_list():
@@ -128,11 +128,11 @@ class CapsuleTestCase(CLITestCase):
     def test_positive_refresh_features_by_id(self):
         """Refresh smart proxy features, search for proxy by id
 
-        @id: d3db63ce-b877-40eb-a863-294c12489ddd
+        :id: d3db63ce-b877-40eb-a863-294c12489ddd
 
-        @Assert: Proxy features are refreshed
+        :Assert: Proxy features are refreshed
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         # Since we want to run multiple commands against our fake capsule, we
         # need the tunnel kept open in order not to allow different concurrent
@@ -153,11 +153,11 @@ class CapsuleTestCase(CLITestCase):
     def test_positive_refresh_features_by_name(self):
         """Refresh smart proxy features, search for proxy by name
 
-        @id: 2ddd0097-8f65-430e-963d-a3b5dcffe86b
+        :id: 2ddd0097-8f65-430e-963d-a3b5dcffe86b
 
-        @Assert: Proxy features are refreshed
+        :Assert: Proxy features are refreshed
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         # Since we want to run multiple commands against our fake capsule, we
         # need the tunnel kept open in order not to allow different concurrent
@@ -178,9 +178,9 @@ class CapsuleTestCase(CLITestCase):
     def test_positive_import_puppet_classes(self):
         """Import puppet classes from proxy
 
-        @id: 42e3a9c0-62e1-4049-9667-f3c0cdfe0b04
+        :id: 42e3a9c0-62e1-4049-9667-f3c0cdfe0b04
 
-        @Assert: Puppet classes are imported from proxy
+        :Assert: Puppet classes are imported from proxy
         """
         port = get_available_capsule_port()
         with default_url_on_new_port(9090, port):
@@ -198,52 +198,48 @@ class CapsuleIntegrationTestCase(CLITestCase):
     def test_positive_provision(self):
         """User can provision through a capsule
 
-        @id: 1b91e6ed-56bb-4a21-9b69-8b41242458c5
+        :id: 1b91e6ed-56bb-4a21-9b69-8b41242458c5
 
-        @Setup: Some valid, functional compute resource (perhaps one variation
-        of this case for each supported compute resource type). Also,
-        functioning capsule with proxy is required.
+        :Setup: Some valid, functional compute resource (perhaps one variation
+            of this case for each supported compute resource type). Also,
+            functioning capsule with proxy is required.
 
-        @Steps:
+        :Steps:
 
-        1. Attempt to route provisioning content through capsule that is using
-           a proxy
-        2. Attempt to provision instance
+            1. Attempt to route provisioning content through capsule that is
+               using a proxy
+            2. Attempt to provision instance
 
-        @Assert: Instance can be provisioned, with content coming through
-        proxy-enabled capsule.
+        :Assert: Instance can be provisioned, with content coming through
+            proxy-enabled capsule.
 
-        @caseautomation: notautomated
+        :caseautomation: notautomated
         """
 
     @stubbed()
     def test_positive_register(self):
         """User can register system through proxy-enabled capsule
 
-        @id: dc544ec8-0320-4897-a6ca-ce9ebad27975
+        :id: dc544ec8-0320-4897-a6ca-ce9ebad27975
 
-        @Steps:
+        :Steps: attempt to register a system trhough a proxy-enabled capsule
 
-        1. attempt to register a system trhough a proxy-enabled capsule
+        :Assert: system is successfully registered
 
-        @Assert: system is successfully registered
-
-        @caseautomation: notautomated
+        :caseautomation: notautomated
         """
 
     @stubbed()
     def test_positive_unregister(self):
         """User can unregister system through proxy-enabled capsule
 
-        @id: 9b7714da-74be-4c0a-9209-9d15c2c98eaa
+        :id: 9b7714da-74be-4c0a-9209-9d15c2c98eaa
 
-        @Steps:
+        :Steps: attempt to unregister a system through a proxy-enabled capsule
 
-        1. attempt to unregister a system through a proxy-enabled capsule
+        :Assert: system is successfully unregistered
 
-        @Assert: system is successfully unregistered
-
-        @caseautomation: notautomated
+        :caseautomation: notautomated
         """
 
     @stubbed()
@@ -251,19 +247,17 @@ class CapsuleIntegrationTestCase(CLITestCase):
         """User can subscribe system to content through proxy-enabled
         capsule
 
-        @id: 091bba73-bc78-4b8c-ac27-5c10e9838cfb
+        :id: 091bba73-bc78-4b8c-ac27-5c10e9838cfb
 
-        @Setup: Content source types configured/synced for [RH, Custom, Puppet,
-        Docker] etc.
+        :Setup: Content source types configured/synced for [RH, Custom, Puppet,
+            Docker] etc.
 
-        @Steps:
+        :Steps: attempt to subscribe a system to a content type variation, via
+            a proxy-enabled capsule
 
-        1. attempt to subscribe a system to a content type variation, via a
-           proxy-enabled capsule
+        :Assert: system is successfully subscribed to each content type
 
-        @Assert: system is successfully subscribed to each content type
-
-        @caseautomation: notautomated
+        :caseautomation: notautomated
         """
 
     @stubbed()
@@ -271,21 +265,21 @@ class CapsuleIntegrationTestCase(CLITestCase):
         """User can consume content on system, from a content source,
         through proxy-enabled capsule
 
-        @id: a3fb9879-7799-4743-99a8-963701e687c1
+        :id: a3fb9879-7799-4743-99a8-963701e687c1
 
-        @Setup: Content source types configured/synced for [RH, Custom, Puppet,
-        Docker] etc.
+        :Setup: Content source types configured/synced for [RH, Custom, Puppet,
+            Docker] etc.
 
-        @Steps:
+        :Steps:
 
-        1. attempt to subscribe a system to a content type variation, via a
-           proxy-enabled capsule
-        2. Attempt to install content (RPMs, puppet modules) via proxy-enabled
-           capsule
+            1. attempt to subscribe a system to a content type variation, via a
+               proxy-enabled capsule
+            2. Attempt to install content (RPMs, puppet modules) via
+               proxy-enabled capsule
 
-        @Assert: system successfully consume content
+        :Assert: system successfully consume content
 
-        @caseautomation: notautomated
+        :caseautomation: notautomated
         """
 
     @stubbed()
@@ -293,21 +287,21 @@ class CapsuleIntegrationTestCase(CLITestCase):
         """User can unsubscribe system from content through
         proxy-enabled capsule
 
-        @id: 0d34713d-3d60-4e5a-ada6-9a24aa865cb4
+        :id: 0d34713d-3d60-4e5a-ada6-9a24aa865cb4
 
-        @Setup: Content source types configured/synced for [RH, Custom, Puppet]
-        etc.
+        :Setup: Content source types configured/synced for [RH, Custom, Puppet]
+            etc.
 
-        @Steps:
+        :Steps:
 
-        1. attempt to subscribe a system to a content type variation, via a
-           proxy-enabled capsule
-        2. attempt to unsubscribe a system from said content type(s) via a
-           proxy-enabled capsule
+            1. attempt to subscribe a system to a content type variation, via a
+               proxy-enabled capsule
+            2. attempt to unsubscribe a system from said content type(s) via a
+               proxy-enabled capsule
 
-        @Assert: system is successfully unsubscribed from each content type
+        :Assert: system is successfully unsubscribed from each content type
 
-        @caseautomation: notautomated
+        :caseautomation: notautomated
         """
 
     @stubbed()
@@ -315,66 +309,62 @@ class CapsuleIntegrationTestCase(CLITestCase):
         """system can register via capsule using cert provided by
         the capsule itself.
 
-        @id: 785b94ea-ffbf-4c18-8160-f705e3d7cbe6
+        :id: 785b94ea-ffbf-4c18-8160-f705e3d7cbe6
 
-        @Setup: functional capsule and certs rpm installed on target client.
+        :Setup: functional capsule and certs rpm installed on target client.
 
-        @Steps:
+        :Steps:
 
-        1. Attempt to register from parent satellite; unregister and remove
-           cert rpm
-        2. Attempt to reregister using same credentials and certs from a
-           functional capsule.
+            1. Attempt to register from parent satellite; unregister and remove
+               cert rpm
+            2. Attempt to reregister using same credentials and certs from a
+               functional capsule.
 
-        @Assert: Registration works , and certs RPM installed
-        from capsule.
+        :Assert: Registration works , and certs RPM installed from capsule.
 
-        @caseautomation: notautomated
+        :caseautomation: notautomated
         """
 
     @stubbed()
     def test_positive_ssl_capsule(self):
         """Assure SSL functionality for capsules
 
-        @id: 4d19bee6-15d4-4fd5-b3de-9144608cdba7
+        :id: 4d19bee6-15d4-4fd5-b3de-9144608cdba7
 
-        @Setup: A capsule installed with SSL enabled.
+        :Setup: A capsule installed with SSL enabled.
 
-        @Steps:
+        :Steps: Execute basic steps from above (register, subscribe, consume,
+            unsubscribe, unregister) while connected to a capsule that is
+            SSL-enabled
 
-        1. Execute basic steps from above (register, subscribe, consume,
-           unsubscribe, unregister) while connected to a capsule that is
-           SSL-enabled
+        :Assert: No failures executing said test scenarios against SSL,
+            baseline functionality identical to non-SSL
 
-        @Assert: No failures executing said test scenarios against SSL,
-        baseline functionality identical to non-SSL
-
-        @caseautomation: notautomated
+        :caseautomation: notautomated
         """
 
     @stubbed()
     def test_positive_enable_bmc(self):
         """Enable BMC feature on smart-proxy
 
-        @id: 9cc4db2f-3bec-4e51-89a2-18a0a6167012
+        :id: 9cc4db2f-3bec-4e51-89a2-18a0a6167012
 
-        @Setup: A capsule installed with SSL enabled.
+        :Setup: A capsule installed with SSL enabled.
 
-        @Steps:
+        :Steps:
 
-        1. Enable BMC feature on proxy by running installer with:
-           ``katello-installer --foreman-proxy-bmc 'true'``
-        2. Please make sure to check default values to other BMC options.
-           Should be like below:
-           ``--foreman-proxy-bmc-default-provider  BMC default provider.
-           (default: "ipmitool")``
-           ``--foreman-proxy-bmc-listen-on  BMC proxy to listen on https, http,
-           or both (default: "https")``
-        3. Check if BMC plugin is enabled with:
-           ``#cat /etc/foreman-proxy/settings.d/bmc.yml | grep enabled``
-        4. Restart foreman-proxy service
+            1. Enable BMC feature on proxy by running installer with:
+               ``katello-installer --foreman-proxy-bmc 'true'``
+            2. Please make sure to check default values to other BMC options.
+               Should be like below: ``--foreman-proxy-bmc-default-provider
+               BMC default provider.  (default: "ipmitool")``
+               ``--foreman-proxy-bmc-listen-on  BMC proxy to listen on https,
+               http, or both (default: "https")``
+            3. Check if BMC plugin is enabled with: ``#cat
+               /etc/foreman-proxy/settings.d/bmc.yml | grep enabled``
+            4. Restart foreman-proxy service
 
-        @Assert: Katello installer should show the options to enable BMC
+        :Assert: Katello installer should show the options to enable BMC
 
-        @caseautomation: notautomated
+        :caseautomation: notautomated
         """

--- a/tests/foreman/cli/test_capsule_installer.py
+++ b/tests/foreman/cli/test_capsule_installer.py
@@ -1,19 +1,19 @@
 # -*- encoding: utf-8 -*-
 """Test for capsule installer CLI
 
-@Requirement: Capsule installer
+:Requirement: Capsule installer
 
-@CaseAutomation: Automated
+:CaseAutomation: Automated
 
-@CaseLevel: Acceptance
+:CaseLevel: Acceptance
 
-@CaseComponent: CLI
+:CaseComponent: CLI
 
-@TestType: Functional
+:TestType: Functional
 
-@CaseImportance: High
+:CaseImportance: High
 
-@Upstream: No
+:Upstream: No
 """
 from robottelo.decorators import stubbed
 from robottelo.test import CLITestCase
@@ -26,18 +26,19 @@ class CapsuleInstallerTestCase(CLITestCase):
     def test_positive_basic(self):
         """perform a basic install of capsule.
 
-        @id: 47445685-5924-4980-89d0-bbb2fb608f4d
+        :id: 47445685-5924-4980-89d0-bbb2fb608f4d
 
-        @Steps:
+        :Steps:
 
-        1. Assure your target capsule has ONLY the Capsule repo enabled. In
-           other words, the Satellite repo itself is not enabled by default.
-        2. attempt to perform a basic, functional install the capsule using
-           `capsule-installer`.
+            1. Assure your target capsule has ONLY the Capsule repo enabled. In
+               other words, the Satellite repo itself is not enabled by
+               default.
+            2. attempt to perform a basic, functional install the capsule using
+               `capsule-installer`.
 
-        @Assert: product is installed
+        :Assert: product is installed
 
-        @caseautomation: notautomated
+        :caseautomation: notautomated
 
         """
 
@@ -47,16 +48,13 @@ class CapsuleInstallerTestCase(CLITestCase):
         capsule-installer to enable katello-agent functionality via
         remote clients
 
-        @id: d040a72d-72b2-41cf-b14e-a8e37e80200d
+        :id: d040a72d-72b2-41cf-b14e-a8e37e80200d
 
-        @Steps:
+        :Steps: Install capsule-installer with the '--qpid-router=true` flag
 
-        1. Install capsule-installer with the '--qpid-router=true` flag
+        :Assert: Capsule installs correctly and qpid functionality is enabled.
 
-        @Assert: Capsule installs correctly and qpid functionality is
-        enabled.
-
-        @caseautomation: notautomated
+        :caseautomation: notautomated
 
         """
 
@@ -66,16 +64,13 @@ class CapsuleInstallerTestCase(CLITestCase):
         capsule-installer to enable katello-agent functionality via
         remote clients
 
-        @id: 756fd76a-0183-4637-93c8-fe7c375be751
+        :id: 756fd76a-0183-4637-93c8-fe7c375be751
 
-        @Steps:
+        :Steps: Install using the '--reverse-proxy=true' flag
 
-        1. Install using the '--reverse-proxy=true' flag
+        :Assert: Capsule installs correctly and functionality is enabled.
 
-        @Assert: Capsule installs correctly and functionality is
-        enabled.
-
-        @caseautomation: notautomated
+        :caseautomation: notautomated
 
         """
 
@@ -83,17 +78,15 @@ class CapsuleInstallerTestCase(CLITestCase):
     def test_negative_invalid_parameters(self):
         """invalid (non-boolean) parameters cannot be passed to flag
 
-        @id: f4366c87-e436-42b4-ada4-55f0e66a481e
+        :id: f4366c87-e436-42b4-ada4-55f0e66a481e
 
-        @Steps:
+        :Steps: attempt to provide a variety of invalid parameters to installer
+            (strings, numerics, whitespace, etc.)
 
-        1. attempt to provide a variety of invalid parameters
-           to installer (strings, numerics, whitespace, etc.)
+        :Assert: user is told that such parameters are invalid and install
+            aborts.
 
-        @Assert: user is told that such parameters are invalid and install
-        aborts.
-
-        @caseautomation: notautomated
+        :caseautomation: notautomated
 
         """
 
@@ -101,19 +94,17 @@ class CapsuleInstallerTestCase(CLITestCase):
     def test_negative_option_parent_reverse_proxy_port(self):
         """invalid (non-integer) parameters cannot be passed to flag
 
-        @id: a1af16d3-84da-4e94-818e-90bc82cc5698
+        :id: a1af16d3-84da-4e94-818e-90bc82cc5698
 
-        @Setup: na
+        :Setup: na
 
-        @Steps:
+        :Steps: attempt to provide a variety of invalid parameters to
+            --parent-reverse-proxy-port flag (strings, numerics, whitespace,
+            etc.)
 
-        1. attempt to provide a variety of invalid parameters to
-           --parent-reverse-proxy-port flag (strings, numerics, whitespace,
-           etc.)
+        :Assert: user told parameters are invalid; install aborts.
 
-        @Assert: user told parameters are invalid; install aborts.
-
-        @caseautomation: notautomated
+        :caseautomation: notautomated
 
         """
 
@@ -122,17 +113,15 @@ class CapsuleInstallerTestCase(CLITestCase):
         """ valid parameters can be passed to --parent-reverse-proxy
         (true)
 
-        @id: a905f4ca-a729-4efb-84fc-43923737f75b
+        :id: a905f4ca-a729-4efb-84fc-43923737f75b
 
-        @Setup: note that this requires an accompanying, valid port value
+        :Setup: note that this requires an accompanying, valid port value
 
-        @Steps:
+        :Steps: Attempt to provide a value of "true" to --parent-reverse-proxy
 
-        1. Attempt to provide a value of "true" to --parent-reverse-proxy
+        :Assert: Install commences/completes with proxy installed correctly.
 
-        @Assert: Install commences/completes with proxy installed correctly.
-
-        @caseautomation: notautomated
+        :caseautomation: notautomated
 
         """
 
@@ -141,18 +130,16 @@ class CapsuleInstallerTestCase(CLITestCase):
         """valid parameters can be passed to
         --parent-reverse-proxy-port (integer)
 
-        @id: 32238045-53e2-4ed4-ac86-57917e7aedcd
+        :id: 32238045-53e2-4ed4-ac86-57917e7aedcd
 
-        @Setup: note that this requires an accompanying, valid host for
-        proxy parameter
+        :Setup: note that this requires an accompanying, valid host for proxy
+            parameter
 
-        @Steps:
+        :Steps: Attempt to provide a valid proxy port # to flag
 
-        1. Attempt to provide a valid proxy port # to flag
+        :Assert: Install commences and completes with proxy installed
+            correctly.
 
-        @Assert: Install commences and completes with proxy installed
-        correctly.
-
-        @caseautomation: notautomated
+        :caseautomation: notautomated
 
         """

--- a/tests/foreman/cli/test_classparameters.py
+++ b/tests/foreman/cli/test_classparameters.py
@@ -1,19 +1,19 @@
 # -*- encoding: utf-8 -*-
 """Test class for Smart/Puppet Class Parameter
 
-@Requirement: Classparameters
+:Requirement: Classparameters
 
-@CaseAutomation: Automated
+:CaseAutomation: Automated
 
-@CaseLevel: Acceptance
+:CaseLevel: Acceptance
 
-@CaseComponent: CLI
+:CaseComponent: CLI
 
-@TestType: Functional
+:TestType: Functional
 
-@CaseImportance: High
+:CaseImportance: High
 
-@Upstream: No
+:Upstream: No
 """
 
 import json
@@ -169,11 +169,11 @@ class SmartClassParametersTestCase(CLITestCase):
     def test_positive_list_by_env_name(self):
         """List all the parameters included in specific Env by its name.
 
-        @id: 9fcfbe32-d388-435d-a629-6969a50a4243
+        :id: 9fcfbe32-d388-435d-a629-6969a50a4243
 
-        @assert: Parameters listed for specific Environment.
+        :assert: Parameters listed for specific Environment.
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         env_sc_params = SmartClassParameter.list(
             {'environment': self.env['name']})
@@ -193,11 +193,11 @@ class SmartClassParametersTestCase(CLITestCase):
     def test_positive_list_by_env_id(self):
         """List all the parameters included in specific Env by its id.
 
-        @id: b3202175-c040-41dc-a66c-c07573534dec
+        :id: b3202175-c040-41dc-a66c-c07573534dec
 
-        @assert: Parameters listed for specific Environment.
+        :assert: Parameters listed for specific Environment.
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         env_sc_params = SmartClassParameter.list(
             {'environment-id': self.env['id']})
@@ -217,11 +217,11 @@ class SmartClassParametersTestCase(CLITestCase):
     def test_positive_list_by_host_name(self):
         """List all the parameters included in specific Host by its name.
 
-        @id: a8165746-3480-4875-8931-b20ebec241dc
+        :id: a8165746-3480-4875-8931-b20ebec241dc
 
-        @assert: Parameters listed for specific Host.
+        :assert: Parameters listed for specific Host.
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         sc_param_id = self.sc_params_ids_list.pop()
         SmartClassParameter.update({
@@ -253,11 +253,11 @@ class SmartClassParametersTestCase(CLITestCase):
     def test_positive_list_by_host_id(self):
         """List all the parameters included in specific Host by its id.
 
-        @id: 79050de6-b894-4a88-b155-32bf488b692c
+        :id: 79050de6-b894-4a88-b155-32bf488b692c
 
-        @assert: Parameters listed for specific Host.
+        :assert: Parameters listed for specific Host.
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         sc_param_id = self.sc_params_ids_list.pop()
         SmartClassParameter.update({
@@ -289,11 +289,11 @@ class SmartClassParametersTestCase(CLITestCase):
     def test_positive_list_by_hostgroup_name(self):
         """List all the parameters included in specific HostGroup by its name.
 
-        @id: a2a01ca7-4dd2-4db6-a654-a632864998d9
+        :id: a2a01ca7-4dd2-4db6-a654-a632864998d9
 
-        @assert: Parameters listed for specific HostGroup.
+        :assert: Parameters listed for specific HostGroup.
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         sc_param_id = self.sc_params_ids_list.pop()
         SmartClassParameter.update({
@@ -324,11 +324,11 @@ class SmartClassParametersTestCase(CLITestCase):
     def test_positive_list_by_hostgroup_id(self):
         """List all the parameters included in specific HostGroup by id.
 
-        @id: 80c1058d-b87d-4c09-957f-7d3daacdedf4
+        :id: 80c1058d-b87d-4c09-957f-7d3daacdedf4
 
-        @assert: Parameters listed for specific HostGroup.
+        :assert: Parameters listed for specific HostGroup.
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         sc_param_id = self.sc_params_ids_list.pop()
         SmartClassParameter.update({
@@ -359,9 +359,9 @@ class SmartClassParametersTestCase(CLITestCase):
     def test_positive_list_by_puppetclass_name(self):
         """List all the parameters for specific puppet class by name.
 
-        @id: 6d62968f-dc5b-4d7f-ac21-c1335a827960
+        :id: 6d62968f-dc5b-4d7f-ac21-c1335a827960
 
-        @assert: Parameters listed for specific Puppet class.
+        :assert: Parameters listed for specific Puppet class.
         """
         sc_params = SmartClassParameter.list(
             {'puppet-class': self.puppet_class['name']})
@@ -378,9 +378,9 @@ class SmartClassParametersTestCase(CLITestCase):
     def test_positive_list_by_puppetclass_id(self):
         """List all the parameters for specific puppet class by id.
 
-        @id: a7a8af1a-514b-4910-9e19-75306f634041
+        :id: a7a8af1a-514b-4910-9e19-75306f634041
 
-        @assert: Parameters listed for specific Puppet class.
+        :assert: Parameters listed for specific Puppet class.
         """
         sc_params = SmartClassParameter.list(
             {'puppet-class-id': self.puppet_class['id']})
@@ -398,9 +398,9 @@ class SmartClassParametersTestCase(CLITestCase):
         """Import same puppet class twice (e.g. into different Content Views)
         but list class parameters only for specific puppet class.
 
-        @id: 79a33641-54af-4e04-89ff-3b7f9a4e3ec2
+        :id: 79a33641-54af-4e04-89ff-3b7f9a4e3ec2
 
-        @assert: Parameters listed for specific Puppet class.
+        :assert: Parameters listed for specific Puppet class.
 
         BZ: 1385351
         """
@@ -427,15 +427,15 @@ class SmartClassParametersTestCase(CLITestCase):
     def test_positive_override(self):
         """Override the Default Parameter value.
 
-        @id: 25e34bac-084c-4b68-a082-822633e19f7e
+        :id: 25e34bac-084c-4b68-a082-822633e19f7e
 
-        @steps:
+        :steps:
 
-        1.  Override the parameter.
-        2.  Set the new valid Default Value.
-        3.  Submit the changes.
+            1.  Override the parameter.
+            2.  Set the new valid Default Value.
+            3.  Submit the changes.
 
-        @assert: Parameter Value overridden with new value.
+        :assert: Parameter Value overridden with new value.
         """
         sc_param_id = self.sc_params_ids_list.pop()
         value = gen_string('alpha')
@@ -455,15 +455,15 @@ class SmartClassParametersTestCase(CLITestCase):
     def test_negative_override(self):
         """Override the Default Parameter value - override Unchecked.
 
-        @id: eb24c44d-0e34-40a3-aa3e-05a3cd4ed1ea
+        :id: eb24c44d-0e34-40a3-aa3e-05a3cd4ed1ea
 
-        @steps:
+        :steps:
 
-        1.  Don't override the parameter.
-        2.  Set the new valid Default Value.
-        3.  Attempt to submit the changes.
+            1.  Don't override the parameter.
+            2.  Set the new valid Default Value.
+            3.  Attempt to submit the changes.
 
-        @assert: Not overridden parameter value cannot be updated.
+        :assert: Not overridden parameter value cannot be updated.
         """
         sc_param_id = self.sc_params_ids_list.pop()
         with self.assertRaises(CLIReturnCodeError):
@@ -477,15 +477,15 @@ class SmartClassParametersTestCase(CLITestCase):
     def test_positive_puppet_default(self):
         """On Override, Set Puppet Default Value.
 
-        @id: 360be750-ee96-414c-ac04-b2762f77503a
+        :id: 360be750-ee96-414c-ac04-b2762f77503a
 
-        @steps:
+        :steps:
 
-        1.  Override the parameter.
-        2.  Set puppet default value to 'Use Puppet Default'.
-        3.  Submit the changes.
+            1.  Override the parameter.
+            2.  Set puppet default value to 'Use Puppet Default'.
+            3.  Submit the changes.
 
-        @assert: Puppet Default Value applied on parameter.
+        :assert: Puppet Default Value applied on parameter.
         """
         sc_param_id = self.sc_params_ids_list.pop()
         SmartClassParameter.update({
@@ -506,16 +506,16 @@ class SmartClassParametersTestCase(CLITestCase):
 
         Types - string, boolean, integer, real, array, hash, yaml, json
 
-        @id: 19567098-2087-4633-bdb6-1450a233285c
+        :id: 19567098-2087-4633-bdb6-1450a233285c
 
-        @steps:
+        :steps:
 
-        1.  Override the parameter.
-        2.  Update the Key Type.
-        3.  Provide a 'valid' default Value.
-        4.  Submit the changes.
+            1.  Override the parameter.
+            2.  Update the Key Type.
+            3.  Provide a 'valid' default Value.
+            4.  Submit the changes.
 
-        @assert: Parameter Updated with a new type successfully.
+        :assert: Parameter Updated with a new type successfully.
         """
         sc_param_id = self.sc_params_ids_list.pop()
         for data in valid_sc_parameters_data():
@@ -554,19 +554,19 @@ class SmartClassParametersTestCase(CLITestCase):
 
         Types - string, boolean, integer, real, array, hash, yaml, json
 
-        @id: 5c2c859a-8164-4733-8b41-d37f333656c7
+        :id: 5c2c859a-8164-4733-8b41-d37f333656c7
 
-        @steps:
+        :steps:
 
-        1.  Override the parameter.
-        2.  Update the Key Type.
-        3.  Enter an 'Invalid' default Value.
-        4.  Submit the changes.
+            1.  Override the parameter.
+            2.  Update the Key Type.
+            3.  Enter an 'Invalid' default Value.
+            4.  Submit the changes.
 
-        @assert:
+        :assert:
 
-        1.  Parameter not updated with string type for invalid value.
-        2.  Error raised for invalid default value.
+            1.  Parameter not updated with string type for invalid value.
+            2.  Error raised for invalid default value.
         """
         sc_param_id = self.sc_params_ids_list.pop()
         for test_data in invalid_sc_parameters_data():
@@ -590,16 +590,16 @@ class SmartClassParametersTestCase(CLITestCase):
     def test_positive_validate_default_value_required_check(self):
         """No error raised for non-empty default Value - Required check.
 
-        @id: 812aceb8-8d5e-4374-bf73-61d7085ee510
+        :id: 812aceb8-8d5e-4374-bf73-61d7085ee510
 
-        @steps:
+        :steps:
 
-        1.  Override the parameter.
-        2.  Provide some default value, Not empty.
-        3.  Set '--required' check.
-        4.  Submit the change.
+            1.  Override the parameter.
+            2.  Provide some default value, Not empty.
+            3.  Set '--required' check.
+            4.  Submit the change.
 
-        @assert: No error raised for non-empty default value
+        :assert: No error raised for non-empty default value
         """
         sc_param_id = self.sc_params_ids_list.pop()
         SmartClassParameter.update({
@@ -621,17 +621,17 @@ class SmartClassParametersTestCase(CLITestCase):
     def test_positive_validate_matcher_value_required_check(self):
         """Error not raised for matcher Value - Required check.
 
-        @id: e62c3c5a-d900-44d4-9793-2c17202974e5
+        :id: e62c3c5a-d900-44d4-9793-2c17202974e5
 
-        @steps:
+        :steps:
 
-        1.  Override the parameter.
-        2.  Create a matcher for Parameter for some attribute.
-        3.  Provide some Value for matcher.
-        4.  Set '--required' check.
-        5.  Submit the change.
+            1.  Override the parameter.
+            2.  Create a matcher for Parameter for some attribute.
+            3.  Provide some Value for matcher.
+            4.  Set '--required' check.
+            5.  Submit the change.
 
-        @assert: Error not raised for matcher value.
+        :assert: Error not raised for matcher value.
         """
         sc_param_id = self.sc_params_ids_list.pop()
         SmartClassParameter.add_override_value({
@@ -655,16 +655,16 @@ class SmartClassParametersTestCase(CLITestCase):
     def test_negative_validate_default_value_with_regex(self):
         """Error raised for default value not matching with regex.
 
-        @id: f36ed6e8-04ef-4614-98b3-38703d8aeeb0
+        :id: f36ed6e8-04ef-4614-98b3-38703d8aeeb0
 
-        @steps:
+        :steps:
 
-        1.  Override the parameter.
-        2.  Provide default value that doesn't matches the regex of step 3.
-        3.  Validate this value with regex validator type and rule.
-        4.  Submit the change.
+            1.  Override the parameter.
+            2.  Provide default value that doesn't matches the regex of step 3.
+            3.  Validate this value with regex validator type and rule.
+            4.  Submit the change.
 
-        @assert: Error raised for default value not matching with regex.
+        :assert: Error raised for default value not matching with regex.
         """
         value = gen_string('alpha')
         sc_param_id = self.sc_params_ids_list.pop()
@@ -687,16 +687,16 @@ class SmartClassParametersTestCase(CLITestCase):
     def test_positive_validate_default_value_with_regex(self):
         """Error not raised for default value matching with regex.
 
-        @id: 74666d12-e3be-46c1-8bd5-18d86dcf7f4b
+        :id: 74666d12-e3be-46c1-8bd5-18d86dcf7f4b
 
-        @steps:
+        :steps:
 
-        1.  Override the parameter.
-        2.  Provide default value that matches the regex of step 3.
-        3.  Validate this value with regex validator type and rule.
-        4.  Submit the change.
+            1.  Override the parameter.
+            2.  Provide default value that matches the regex of step 3.
+            3.  Validate this value with regex validator type and rule.
+            4.  Submit the change.
 
-        @assert: Error not raised for default value matching with regex.
+        :assert: Error not raised for default value matching with regex.
         """
         value = gen_string('numeric')
         sc_param_id = self.sc_params_ids_list.pop()
@@ -720,17 +720,17 @@ class SmartClassParametersTestCase(CLITestCase):
     def test_negative_validate_matcher_value_with_regex(self):
         """Error raised for matcher value not matching with regex.
 
-        @id: b8b2f1c2-a20c-42d6-a687-79e6eee0268e
+        :id: b8b2f1c2-a20c-42d6-a687-79e6eee0268e
 
-        @steps:
+        :steps:
 
-        1.  Override the parameter.
-        2.  Create a matcher with value that doesn't match
-            the regex of step 3.
-        3.  Validate this value with regex validator type and rule.
-        4.  Submit the change.
+            1.  Override the parameter.
+            2.  Create a matcher with value that doesn't match the regex of
+                step 3.
+            3.  Validate this value with regex validator type and rule.
+            4.  Submit the change.
 
-        @assert: Error raised for matcher value not matching with regex.
+        :assert: Error raised for matcher value not matching with regex.
         """
         value = gen_string('numeric')
         sc_param_id = self.sc_params_ids_list.pop()
@@ -758,16 +758,16 @@ class SmartClassParametersTestCase(CLITestCase):
     def test_positive_validate_matcher_value_with_regex(self):
         """Error not raised for matcher value matching with regex.
 
-        @id: 2c8273aa-e621-4d4e-b03e-f8d50a596bc2
+        :id: 2c8273aa-e621-4d4e-b03e-f8d50a596bc2
 
-        @steps:
+        :steps:
 
-        1.  Override the parameter.
-        2.  Create a matcher with value that matches the regex of step 3.
-        3.  Validate this value with regex validator type and rule.
-        4.  Submit the change.
+            1.  Override the parameter.
+            2.  Create a matcher with value that matches the regex of step 3.
+            3.  Validate this value with regex validator type and rule.
+            4.  Submit the change.
 
-        @assert: Error not raised for matcher value matching with regex.
+        :assert: Error not raised for matcher value matching with regex.
         """
         value = gen_string('numeric')
         sc_param_id = self.sc_params_ids_list.pop()
@@ -794,16 +794,16 @@ class SmartClassParametersTestCase(CLITestCase):
     def test_negative_validate_default_value_with_list(self):
         """Error raised for default value not in list.
 
-        @id: cdcafbea-612e-4b60-90de-fa0c76442bbe
+        :id: cdcafbea-612e-4b60-90de-fa0c76442bbe
 
-        @steps:
+        :steps:
 
-        1.  Override the parameter.
-        2.  Provide default value that doesn't matches the list of step 3.
-        3.  Validate this value with list validator type and rule.
-        4.  Submit the change.
+            1.  Override the parameter.
+            2.  Provide default value that doesn't matches the list of step 3.
+            3.  Validate this value with list validator type and rule.
+            4.  Submit the change.
 
-        @assert: Error raised for default value not in list.
+        :assert: Error raised for default value not in list.
         """
         value = gen_string('alphanumeric')
         sc_param_id = self.sc_params_ids_list.pop()
@@ -826,16 +826,16 @@ class SmartClassParametersTestCase(CLITestCase):
     def test_positive_validate_default_value_with_list(self):
         """Error not raised for default value in list.
 
-        @id: b03708e8-e597-40fb-bb24-a1ac87475846
+        :id: b03708e8-e597-40fb-bb24-a1ac87475846
 
-        @steps:
+        :steps:
 
-        1.  Override the parameter.
-        2.  Provide default value that matches the list of step 3.
-        3.  Validate this value with list validator type and rule.
-        4.  Submit the change.
+            1.  Override the parameter.
+            2.  Provide default value that matches the list of step 3.
+            3.  Validate this value with list validator type and rule.
+            4.  Submit the change.
 
-        @assert: Error not raised for default value in list.
+        :assert: Error not raised for default value in list.
         """
         sc_param_id = self.sc_params_ids_list.pop()
         SmartClassParameter.update({
@@ -858,17 +858,17 @@ class SmartClassParametersTestCase(CLITestCase):
     def test_negative_validate_matcher_value_with_list(self):
         """Error raised for matcher value not in list.
 
-        @id: 6e02c3f2-40aa-49ec-976d-7a12f5fa1e04
+        :id: 6e02c3f2-40aa-49ec-976d-7a12f5fa1e04
 
-        @steps:
+        :steps:
 
-        1.  Override the parameter.
-        2.  Create a matcher with value that doesn't match
-            the list of step 3.
-        3.  Validate this value with list validator type and rule.
-        4.  Submit the change.
+            1.  Override the parameter.
+            2.  Create a matcher with value that doesn't match the list of step
+                3.
+            3.  Validate this value with list validator type and rule.
+            4.  Submit the change.
 
-        @assert: Error raised for matcher value not in list.
+        :assert: Error raised for matcher value not in list.
         """
         sc_param_id = self.sc_params_ids_list.pop()
         SmartClassParameter.add_override_value({
@@ -895,16 +895,16 @@ class SmartClassParametersTestCase(CLITestCase):
     def test_positive_validate_matcher_value_with_list(self):
         """Error not raised for matcher value in list.
 
-        @id: 16927050-0bf2-4cbd-bb34-43c669f81304
+        :id: 16927050-0bf2-4cbd-bb34-43c669f81304
 
-        @steps:
+        :steps:
 
-        1.  Override the parameter.
-        2.  Create a matcher with value that matches the list of step 3.
-        3.  Validate this value with list validator type and rule.
-        4.  Submit the change.
+            1.  Override the parameter.
+            2.  Create a matcher with value that matches the list of step 3.
+            3.  Validate this value with list validator type and rule.
+            4.  Submit the change.
 
-        @assert: Error not raised for matcher value in list.
+        :assert: Error not raised for matcher value in list.
         """
         sc_param_id = self.sc_params_ids_list.pop()
         SmartClassParameter.add_override_value({
@@ -930,16 +930,17 @@ class SmartClassParametersTestCase(CLITestCase):
     def test_negative_validate_matcher_value_with_default_type(self):
         """Error raised for matcher value not of default type.
 
-        @id: 307b0ea1-a035-4ce1-bcc5-f582147359e7
+        :id: 307b0ea1-a035-4ce1-bcc5-f582147359e7
 
-        @steps:
+        :steps:
 
-        1.  Override the parameter.
-        2.  Update parameter default type with valid value.
-        3.  Create a matcher with value that doesn't matches the default type.
-        4.  Submit the change.
+            1.  Override the parameter.
+            2.  Update parameter default type with valid value.
+            3.  Create a matcher with value that doesn't matches the default
+                type.
+            4.  Submit the change.
 
-        @assert: Error raised for matcher value not of default type.
+        :assert: Error raised for matcher value not of default type.
         """
         sc_param_id = self.sc_params_ids_list.pop()
         SmartClassParameter.update({
@@ -960,16 +961,16 @@ class SmartClassParametersTestCase(CLITestCase):
     def test_positive_validate_matcher_value_with_default_type(self):
         """No error for matcher value of default type.
 
-        @id: a247adac-4631-4b90-ae4a-a768cd05be34
+        :id: a247adac-4631-4b90-ae4a-a768cd05be34
 
-        @steps:
+        :steps:
 
-        1.  Override the parameter.
-        2.  Update parameter default type with valid value.
-        3.  Create a matcher with value that matches the default type.
-        4.  Submit the change.
+            1.  Override the parameter.
+            2.  Update parameter default type with valid value.
+            3.  Create a matcher with value that matches the default type.
+            4.  Submit the change.
 
-        @assert: Error not raised for matcher value of default type.
+        :assert: Error not raised for matcher value of default type.
         """
         sc_param_id = self.sc_params_ids_list.pop()
         SmartClassParameter.update({
@@ -999,16 +1000,17 @@ class SmartClassParametersTestCase(CLITestCase):
     def test_negative_validate_matcher_and_default_value(self):
         """Error for invalid default and matcher value both at a time.
 
-        @id: 07dfcdad-e619-4672-9fe8-75a8352e44a4
+        :id: 07dfcdad-e619-4672-9fe8-75a8352e44a4
 
-        @steps:
+        :steps:
 
-        1.  Override the parameter.
-        2.  Update parameter default type with Invalid value.
-        3.  Create a matcher with value that doesn't matches the default type.
-        4.  Attempt to submit the change.
+            1.  Override the parameter.
+            2.  Update parameter default type with Invalid value.
+            3.  Create a matcher with value that doesn't matches the default
+                type.
+            4.  Attempt to submit the change.
 
-        @assert: Error raised for invalid default and matcher value both.
+        :assert: Error raised for invalid default and matcher value both.
         """
         sc_param_id = self.sc_params_ids_list.pop()
         SmartClassParameter.add_override_value({
@@ -1029,15 +1031,15 @@ class SmartClassParametersTestCase(CLITestCase):
     def test_negative_validate_matcher_non_existing_attribute(self):
         """Error while creating matcher for Non Existing Attribute.
 
-        @id: 5223e582-81b4-442d-b4ba-b16ede460ef6
+        :id: 5223e582-81b4-442d-b4ba-b16ede460ef6
 
-        @steps:
+        :steps:
 
-        1.  Override the parameter.
-        2.  Create a matcher with non existing attribute in org.
-        3.  Attempt to submit the change.
+            1.  Override the parameter.
+            2.  Create a matcher with non existing attribute in org.
+            3.  Attempt to submit the change.
 
-        @assert: Error raised for non existing attribute.
+        :assert: Error raised for non existing attribute.
         """
         sc_param_id = self.sc_params_ids_list.pop()
         with self.assertRaises(CLIReturnCodeError):
@@ -1052,16 +1054,16 @@ class SmartClassParametersTestCase(CLITestCase):
     def test_positive_create_matcher(self):
         """Create matcher for attribute in parameter.
 
-        @id: 37fe299b-1e81-4faf-b1c3-2edfc3d53dc1
+        :id: 37fe299b-1e81-4faf-b1c3-2edfc3d53dc1
 
-        @steps:
+        :steps:
 
-        1.  Override the parameter.
-        2.  Set some default Value.
-        3.  Create a matcher with all valid values.
-        4.  Submit the change.
+            1.  Override the parameter.
+            2.  Set some default Value.
+            3.  Create a matcher with all valid values.
+            4.  Submit the change.
 
-        @assert: The matcher has been created successfully.
+        :assert: The matcher has been created successfully.
         """
         sc_param_id = self.sc_params_ids_list.pop()
         value = gen_string('alpha')
@@ -1086,15 +1088,15 @@ class SmartClassParametersTestCase(CLITestCase):
     def test_negative_create_matcher(self):
         """Error while creating matcher with empty value
 
-        @id: d4d9f730-152c-428d-b48c-294a23b183ea
+        :id: d4d9f730-152c-428d-b48c-294a23b183ea
 
-        @steps:
+        :steps:
 
-        1.  Override the parameter.
-        2.  Create a matcher with empty value.
-        3.  Attempt to submit the change.
+            1.  Override the parameter.
+            2.  Create a matcher with empty value.
+            3.  Attempt to submit the change.
 
-        @assert: Error is raised for attempt to add matcher with empty value
+        :assert: Error is raised for attempt to add matcher with empty value
         """
         sc_param_id = self.sc_params_ids_list.pop()
         with self.assertRaises(CLIReturnCodeError):
@@ -1110,17 +1112,17 @@ class SmartClassParametersTestCase(CLITestCase):
         """Create matcher for attribute in parameter,
         Where Value is puppet default value.
 
-        @id: c08fcf25-e5c7-411e-beed-3741a24496fd
+        :id: c08fcf25-e5c7-411e-beed-3741a24496fd
 
-        @steps:
+        :steps:
 
-        1.  Override the parameter.
-        2.  Set some default Value.
-        3.  Create matcher with valid attribute type, name and
-            puppet default value.
-        4.  Submit the change.
+            1.  Override the parameter.
+            2.  Set some default Value.
+            3.  Create matcher with valid attribute type, name and puppet
+                default value.
+            4.  Submit the change.
 
-        @assert: The matcher has been created successfully.
+        :assert: The matcher has been created successfully.
         """
         sc_param_id = self.sc_params_ids_list.pop()
         SmartClassParameter.update({
@@ -1148,22 +1150,22 @@ class SmartClassParametersTestCase(CLITestCase):
     def test_positive_create_matcher_attribute_priority(self):
         """Matcher Value set on Attribute Priority for Host.
 
-        @id: 77894977-0355-4309-8c96-09589ea7e814
+        :id: 77894977-0355-4309-8c96-09589ea7e814
 
-        @steps:
+        :steps:
 
-        1.  Override the parameter.
-        2.  Set some default Value.
-        3.  Set fqdn as top priority attribute.
-        4.  Create first matcher for fqdn with valid details.
-        5.  Create second matcher for some attribute with valid details.
-            Note - The fqdn/host should have this attribute.
-        6.  Submit the change.
-        7.  Go to YAML output of associated host.
+            1.  Override the parameter.
+            2.  Set some default Value.
+            3.  Set fqdn as top priority attribute.
+            4.  Create first matcher for fqdn with valid details.
+            5.  Create second matcher for some attribute with valid details.
+                Note - The fqdn/host should have this attribute.
+            6.  Submit the change.
+            7.  Go to YAML output of associated host.
 
-        @assert: The YAML output has the value only for fqdn matcher.
+        :assert: The YAML output has the value only for fqdn matcher.
 
-        @caseautomation: notautomated
+        :caseautomation: notautomated
         """
 
     @run_only_on('sat')
@@ -1172,25 +1174,26 @@ class SmartClassParametersTestCase(CLITestCase):
     def test_negative_create_matcher_attribute_priority(self):
         """Matcher Value set on Attribute Priority for Host - alternate priority.
 
-        @id: 593a9327-9439-49f7-b952-70934c924535
+        :id: 593a9327-9439-49f7-b952-70934c924535
 
-        @steps:
+        :steps:
 
-        1.  Override the parameter.
-        2.  Set some default Value.
-        3.  Set some attribute(other than fqdn) as top priority attribute.
-            Note - The fqdn/host should have this attribute.
-        4.  Create first matcher for fqdn with valid details.
-        5.  Create second matcher for attribute of step 3 with valid details.
-        6.  Submit the change.
-        7.  Go to YAML output of associated host.
+            1.  Override the parameter.
+            2.  Set some default Value.
+            3.  Set some attribute(other than fqdn) as top priority attribute.
+                Note - The fqdn/host should have this attribute.
+            4.  Create first matcher for fqdn with valid details.
+            5.  Create second matcher for attribute of step 3 with valid
+                details.
+            6.  Submit the change.
+            7.  Go to YAML output of associated host.
 
-        @assert:
+        :assert:
 
-        1.  The YAML output has the value only for step 5 matcher.
-        2.  The YAML output doesn't have value for fqdn/host matcher.
+            1.  The YAML output has the value only for step 5 matcher.
+            2.  The YAML output doesn't have value for fqdn/host matcher.
 
-        @caseautomation: notautomated
+        :caseautomation: notautomated
         """
 
     @run_only_on('sat')
@@ -1199,29 +1202,29 @@ class SmartClassParametersTestCase(CLITestCase):
     def test_positive_create_matcher_merge_override(self):
         """Merge the values of all the associated matchers.
 
-        @id: f394a41f-f516-4759-bfff-89d6e5ccffd5
+        :id: f394a41f-f516-4759-bfff-89d6e5ccffd5
 
-        @steps:
+        :steps:
 
-        1.  Override the parameter.
-        2.  Set some default Value.
-        3.  Create first matcher for attribute fqdn with valid details.
-        4.  Create second matcher for other attribute with valid details.
-            Note - The fqdn/host should have this attribute.
-        5.  Create more matchers for some more attributes if any.
-            Note - The fqdn/host should have this attributes.
-        6.  Set '--merge overrides' check.
-        7.  Submit the change.
-        8.  Go to YAML output of associated host.
+            1.  Override the parameter.
+            2.  Set some default Value.
+            3.  Create first matcher for attribute fqdn with valid details.
+            4.  Create second matcher for other attribute with valid details.
+                Note - The fqdn/host should have this attribute.
+            5.  Create more matchers for some more attributes if any.
+                Note - The fqdn/host should have this attributes.
+            6.  Set '--merge overrides' check.
+            7.  Submit the change.
+            8.  Go to YAML output of associated host.
 
-        @assert:
+        :assert:
 
-        1.  The YAML output has the values merged from all the associated
-            matchers.
-        2.  The YAML output doesn't have the default value of parameter.
-        3.  Duplicate values in YAML output if any are displayed.
+            1.  The YAML output has the values merged from all the associated
+                matchers.
+            2.  The YAML output doesn't have the default value of parameter.
+            3.  Duplicate values in YAML output if any are displayed.
 
-        @caseautomation: notautomated
+        :caseautomation: notautomated
         """
 
     @run_only_on('sat')
@@ -1230,30 +1233,30 @@ class SmartClassParametersTestCase(CLITestCase):
     def test_negative_create_matcher_merge_override(self):
         """Attempt to merge the values from non associated matchers.
 
-        @id: fe936ad0-997f-468b-8113-f6a47d3e41eb
+        :id: fe936ad0-997f-468b-8113-f6a47d3e41eb
 
-        @steps:
+        :steps:
 
-        1.  Override the parameter.
-        2.  Set some default Value.
-        3.  Create first matcher for attribute fqdn with valid details.
-        4.  Create second matcher for other attribute with valid details.
-            Note - The fqdn/host should not have this attribute.
-        5.  Create more matchers for some more attributes if any.
-            Note - The fqdn/host should not have this attributes.
-        6.  Set '--merge overrides' check.
-        7.  Submit the change.
-        8.  Go to YAML output of associated host.
+            1.  Override the parameter.
+            2.  Set some default Value.
+            3.  Create first matcher for attribute fqdn with valid details.
+            4.  Create second matcher for other attribute with valid details.
+                Note - The fqdn/host should not have this attribute.
+            5.  Create more matchers for some more attributes if any.
+                Note - The fqdn/host should not have this attributes.
+            6.  Set '--merge overrides' check.
+            7.  Submit the change.
+            8.  Go to YAML output of associated host.
 
-        @assert:
+        :assert:
 
-        1.  The YAML output has the values only for fqdn.
-        2.  The YAML output doesn't have the values for attribute
-            which are not associated to host.
-        3.  The YAML output doesn't have the default value of parameter.
-        4.  Duplicate values in YAML output if any are displayed.
+            1.  The YAML output has the values only for fqdn.
+            2.  The YAML output doesn't have the values for attribute which are
+                not associated to host.
+            3.  The YAML output doesn't have the default value of parameter.
+            4.  Duplicate values in YAML output if any are displayed.
 
-        @caseautomation: notautomated
+        :caseautomation: notautomated
         """
 
     @run_only_on('sat')
@@ -1262,31 +1265,32 @@ class SmartClassParametersTestCase(CLITestCase):
     def test_positive_create_matcher_merge_override_puppet_value(self):
         """Merge the values of all the associated matchers + puppet default value.
 
-        @id: 64e0e9f4-7b75-410a-938e-67f8b32b7e1f
+        :id: 64e0e9f4-7b75-410a-938e-67f8b32b7e1f
 
-        @steps:
+        :steps:
 
-        1.  Override the parameter.
-        2.  Set some default Value.
-        3.  Create first matcher for attribute fqdn with valid details.
-        4.  Create second matcher for other attribute with value
-            as puppet default.
-            Note - The fqdn/host should have this attribute.
-        5.  Create more matchers for some more attributes with value
-            as puppet default.
-            Note - The fqdn/host should have this attributes.
-        6.  Set '--merge overrides' check.
-        7.  Set '--merge default' check.
-        8.  Submit the change.
-        9.  Go to YAML output of associated host.
+            1.  Override the parameter.
+            2.  Set some default Value.
+            3.  Create first matcher for attribute fqdn with valid details.
+            4.  Create second matcher for other attribute with value as puppet
+                default.
+                Note - The fqdn/host should have this attribute.
+            5.  Create more matchers for some more attributes with value as
+                puppet default.
+                Note - The fqdn/host should have this attributes.
+            6.  Set '--merge overrides' check.
+            7.  Set '--merge default' check.
+            8.  Submit the change.
+            9.  Go to YAML output of associated host.
 
-        @assert:
+        :assert:
 
-        1.  The YAML output has the value only for fqdn.
-        2.  The YAML output doesn't have the puppet default values of matchers.
-        3.  Duplicate values in YAML output if any are displayed.
+            1.  The YAML output has the value only for fqdn.
+            2.  The YAML output doesn't have the puppet default values of
+                matchers.
+            3.  Duplicate values in YAML output if any are displayed.
 
-        @caseautomation: notautomated
+        :caseautomation: notautomated
         """
 
     @run_only_on('sat')
@@ -1295,30 +1299,30 @@ class SmartClassParametersTestCase(CLITestCase):
     def test_positive_create_matcher_merge_default(self):
         """Merge the values of all the associated matchers + default value.
 
-        @id: df5a482a-09ec-4942-bc1f-1354eced6f66
+        :id: df5a482a-09ec-4942-bc1f-1354eced6f66
 
-        @steps:
+        :steps:
 
-        1.  Override the parameter.
-        2.  Set some default Value.
-        3.  Create first matcher for attribute fqdn with valid details.
-        4.  Create second matcher for other attribute with valid details.
-            Note - The fqdn/host should have this attribute.
-        5.  Create more matchers for some more attributes if any.
-            Note - The fqdn/host should have this attributes.
-        6.  Set '--merge overrides' check.
-        7.  Set '--merge default' check.
-        8.  Submit the change.
-        9.  Go to YAML output of associated host.
+            1.  Override the parameter.
+            2.  Set some default Value.
+            3.  Create first matcher for attribute fqdn with valid details.
+            4.  Create second matcher for other attribute with valid details.
+                Note - The fqdn/host should have this attribute.
+            5.  Create more matchers for some more attributes if any.
+                Note - The fqdn/host should have this attributes.
+            6.  Set '--merge overrides' check.
+            7.  Set '--merge default' check.
+            8.  Submit the change.
+            9.  Go to YAML output of associated host.
 
-        @assert:
+        :assert:
 
-        1.  The YAML output has the values merged from all
-            the associated matchers.
-        2.  The YAML output has the default value of parameter.
-        3.  Duplicate values in YAML output if any are displayed.
+            1.  The YAML output has the values merged from all the associated
+                matchers.
+            2.  The YAML output has the default value of parameter.
+            3.  Duplicate values in YAML output if any are displayed.
 
-        @caseautomation: notautomated
+        :caseautomation: notautomated
         """
 
     @run_only_on('sat')
@@ -1327,30 +1331,31 @@ class SmartClassParametersTestCase(CLITestCase):
     def test_negative_create_matcher_merge_default(self):
         """Empty default value is not shown in merged values.
 
-        @id: d0ccb1fc-5620-4071-8bbc-7970def16cae
+        :id: d0ccb1fc-5620-4071-8bbc-7970def16cae
 
-        @steps:
+        :steps:
 
-        1.  Override the parameter.
-        2.  Set empty default Value.
-        3.  Create first matcher for attribute fqdn with valid details.
-        4.  Create second matcher for other attribute with valid details.
-            Note - The fqdn/host should have this attribute.
-        5.  Create more matchers for some more attributes if any.
-            Note - The fqdn/host should have this attributes.
-        6.  Set '--merge overrides' check.
-        7.  Set '--merge default' check.
-        8.  Submit the change.
-        9.  Go to YAML output of associated host.
+            1.  Override the parameter.
+            2.  Set empty default Value.
+            3.  Create first matcher for attribute fqdn with valid details.
+            4.  Create second matcher for other attribute with valid details.
+                Note - The fqdn/host should have this attribute.
+            5.  Create more matchers for some more attributes if any.
+                Note - The fqdn/host should have this attributes.
+            6.  Set '--merge overrides' check.
+            7.  Set '--merge default' check.
+            8.  Submit the change.
+            9.  Go to YAML output of associated host.
 
-        @assert:
+        :assert:
 
-        1.  The YAML output has the values merged from all
-            the associated matchers.
-        2.  The YAML output doesn't have the empty default value of parameter.
-        3.  Duplicate values in YAML output if any are displayed.
+            1.  The YAML output has the values merged from all the associated
+                matchers.
+            2.  The YAML output doesn't have the empty default value of
+                parameter.
+            3.  Duplicate values in YAML output if any are displayed.
 
-        @caseautomation: notautomated
+        :caseautomation: notautomated
         """
 
     @run_only_on('sat')
@@ -1359,30 +1364,30 @@ class SmartClassParametersTestCase(CLITestCase):
     def test_positive_create_matcher_merge_puppet_default(self):
         """Merge the values of all the associated matchers + puppet default value.
 
-        @id: 3a69a439-987a-4901-b2cf-efc95945c634
+        :id: 3a69a439-987a-4901-b2cf-efc95945c634
 
-        @steps:
+        :steps:
 
-        1.  Override the parameter.
-        2.  Set default Value as puppet default value.
-        3.  Create first matcher for attribute fqdn with valid details.
-        4.  Create second matcher for other attribute with valid details.
-            Note - The fqdn/host should have this attribute.
-        5.  Create more matchers for some more attributes if any.
-            Note - The fqdn/host should have this attributes.
-        6.  Set '--merge overrides' check.
-        7.  Set '--merge default' check.
-        8.  Submit the change.
-        9.  Go to YAML output of associated host.
+            1.  Override the parameter.
+            2.  Set default Value as puppet default value.
+            3.  Create first matcher for attribute fqdn with valid details.
+            4.  Create second matcher for other attribute with valid details.
+                Note - The fqdn/host should have this attribute.
+            5.  Create more matchers for some more attributes if any.
+                Note - The fqdn/host should have this attributes.
+            6.  Set '--merge overrides' check.
+            7.  Set '--merge default' check.
+            8.  Submit the change.
+            9.  Go to YAML output of associated host.
 
-        @assert:
+        :assert:
 
-        1.  The YAML output has the values merged from all
-            the associated matchers.
-        2.  The YAML output doesn't have the puppet default value.
-        3.  Duplicate values in YAML output if any are displayed.
+            1.  The YAML output has the values merged from all the associated
+                matchers.
+            2.  The YAML output doesn't have the puppet default value.
+            3.  Duplicate values in YAML output if any are displayed.
 
-        @caseautomation: notautomated
+        :caseautomation: notautomated
         """
 
     @run_only_on('sat')
@@ -1391,30 +1396,30 @@ class SmartClassParametersTestCase(CLITestCase):
     def test_positive_create_matcher_avoid_duplicate(self):
         """Merge the values of all the associated matchers, remove duplicates.
 
-        @id: 671c27c8-8270-41d6-8958-f76061a20c36
+        :id: 671c27c8-8270-41d6-8958-f76061a20c36
 
-        @steps:
+        :steps:
 
-        1.  Override the parameter.
-        2.  Set some default Value of array type.
-        3.  Create first matcher for attribute fqdn with some value.
-        4.  Create second matcher for other attribute with
-            same value as fqdn matcher.
-            Note - The fqdn/host should have this attribute.
-        5.  Set '--merge overrides' check.
-        6.  Set '--merge default' check.
-        7.  Set '--avoid duplicate' check.
-        8.  Submit the change.
-        9.  Go to YAML output of associated host.
+            1.  Override the parameter.
+            2.  Set some default Value of array type.
+            3.  Create first matcher for attribute fqdn with some value.
+            4.  Create second matcher for other attribute with same value as
+                fqdn matcher.
+                Note - The fqdn/host should have this attribute.
+            5.  Set '--merge overrides' check.
+            6.  Set '--merge default' check.
+            7.  Set '--avoid duplicate' check.
+            8.  Submit the change.
+            9.  Go to YAML output of associated host.
 
-        @assert:
+        :assert:
 
-        1.  The YAML output has the values merged from all
-            the associated matchers.
-        2.  The YAML output has the default value of parameter.
-        3.  Duplicate values in YAML output are removed / not displayed.
+            1.  The YAML output has the values merged from all the associated
+                matchers.
+            2.  The YAML output has the default value of parameter.
+            3.  Duplicate values in YAML output are removed / not displayed.
 
-        @caseautomation: notautomated
+        :caseautomation: notautomated
         """
 
     @run_only_on('sat')
@@ -1423,29 +1428,29 @@ class SmartClassParametersTestCase(CLITestCase):
     def test_negative_create_matcher_avoid_duplicate(self):
         """Duplicates not removed as they were not really present.
 
-        @id: 98966558-475a-4f84-ba66-31eba38eb13f
+        :id: 98966558-475a-4f84-ba66-31eba38eb13f
 
-        @steps:
+        :steps:
 
-        1.  Override the parameter.
-        2.  Set some default Value of array type.
-        3.  Create first matcher for attribute fqdn with some value.
-        4.  Create second matcher for other attribute with other value
-            than fqdn matcher and default value.
-            Note - The fqdn/host should have this attribute.
-        5.  Set '--merge overrides' check.
-        6.  Set '--merge default' check.
-        7.  Set '--merge avoid duplicates' check.
-        8.  Submit the change.
-        9.  Go to YAML output of associated host.
+            1.  Override the parameter.
+            2.  Set some default Value of array type.
+            3.  Create first matcher for attribute fqdn with some value.
+            4.  Create second matcher for other attribute with other value than
+                fqdn matcher and default value.
+                Note - The fqdn/host should have this attribute.
+            5.  Set '--merge overrides' check.
+            6.  Set '--merge default' check.
+            7.  Set '--merge avoid duplicates' check.
+            8.  Submit the change.
+            9.  Go to YAML output of associated host.
 
-        @assert:
+        :assert:
 
-        1.  The YAML output has the values merged from all matchers.
-        2.  The YAML output has the default value of parameter.
-        3.  No value removed as duplicate value.
+            1.  The YAML output has the values merged from all matchers.
+            2.  The YAML output has the default value of parameter.
+            3.  No value removed as duplicate value.
 
-        @caseautomation: notautomated
+        :caseautomation: notautomated
         """
 
     @run_only_on('sat')
@@ -1453,14 +1458,14 @@ class SmartClassParametersTestCase(CLITestCase):
     def test_positive_remove_matcher(self):
         """Removal of matcher from parameter.
 
-        @id: f51ea9ca-f57c-482e-841f-3ea5cc8f8958
+        :id: f51ea9ca-f57c-482e-841f-3ea5cc8f8958
 
-        @steps:
+        :steps:
 
-        1. Override the parameter and create a matcher for some attribute.
-        2. Remove the matcher created in step 1.
+            1. Override the parameter and create a matcher for some attribute.
+            2. Remove the matcher created in step 1.
 
-        @assert: The matcher removed from parameter.
+        :assert: The matcher removed from parameter.
         """
         sc_param_id = self.sc_params_ids_list.pop()
         value = gen_string('alpha')
@@ -1489,15 +1494,15 @@ class SmartClassParametersTestCase(CLITestCase):
     def test_positive_hide_parameter_default_value(self):
         """Hide the default value of parameter.
 
-        @id: a1e206ae-67dc-48f0-886e-d543c682af34
+        :id: a1e206ae-67dc-48f0-886e-d543c682af34
 
-        @steps:
+        :steps:
 
-        1. Set the override flag for the parameter.
-        2. Set some valid default value.
-        3. Set 'Hidden Value' to true.
+            1. Set the override flag for the parameter.
+            2. Set some valid default value.
+            3. Set 'Hidden Value' to true.
 
-        @assert: The 'hidden value' set to true for that parameter.
+        :assert: The 'hidden value' set to true for that parameter.
         """
         sc_param_id = self.sc_params_ids_list.pop()
         SmartClassParameter.update({
@@ -1517,16 +1522,16 @@ class SmartClassParametersTestCase(CLITestCase):
     def test_positive_unhide_parameter_default_value(self):
         """Unhide the default value of parameter.
 
-        @id: 3daf662f-a0dd-469c-8088-262bfaa5246a
+        :id: 3daf662f-a0dd-469c-8088-262bfaa5246a
 
-        @steps:
+        :steps:
 
-        1. Set the override flag for the parameter.
-        2. Set some valid default value.
-        3. Set 'Hidden Value' to true and submit.
-        4. After hiding, set the 'Hidden Value' to false.
+            1. Set the override flag for the parameter.
+            2. Set some valid default value.
+            3. Set 'Hidden Value' to true and submit.
+            4. After hiding, set the 'Hidden Value' to false.
 
-        @assert: The 'hidden value' set to false for that parameter.
+        :assert: The 'hidden value' set to false for that parameter.
         """
         sc_param_id = self.sc_params_ids_list.pop()
         SmartClassParameter.update({
@@ -1555,19 +1560,19 @@ class SmartClassParametersTestCase(CLITestCase):
     def test_positive_update_hidden_value_in_parameter(self):
         """Update the hidden default value of parameter.
 
-        @id: 8602abc9-80bd-412d-bf46-68a1c7f832e4
+        :id: 8602abc9-80bd-412d-bf46-68a1c7f832e4
 
-        @steps:
+        :steps:
 
-        1. Set the override flag for the parameter.
-        2. Set some valid default value.
-        3. Set 'Hidden Value' to true and submit.
-        4. Now in hidden state, update the default value.
+            1. Set the override flag for the parameter.
+            2. Set some valid default value.
+            3. Set 'Hidden Value' to true and submit.
+            4. Now in hidden state, update the default value.
 
-        @assert:
+        :assert:
 
-        1. The parameter default value is updated.
-        2. The 'hidden value' displayed as true for that parameter.
+            1. The parameter default value is updated.
+            2. The 'hidden value' displayed as true for that parameter.
         """
         sc_param_id = self.sc_params_ids_list.pop()
         old_value = gen_string('alpha')
@@ -1600,18 +1605,18 @@ class SmartClassParametersTestCase(CLITestCase):
     def test_positive_hide_empty_default_value(self):
         """Hiding the empty default value.
 
-        @id: 31069fff-c6d5-42b6-94f2-9551057eb15b
+        :id: 31069fff-c6d5-42b6-94f2-9551057eb15b
 
-        @steps:
+        :steps:
 
-        1. Set the override flag for the parameter.
-        2. Don't set any default value/Set empty value.
-        3. Set 'Hidden Value' to true and submit.
+            1. Set the override flag for the parameter.
+            2. Don't set any default value/Set empty value.
+            3. Set 'Hidden Value' to true and submit.
 
-        @assert:
+        :assert:
 
-        1. The 'hidden value' set to true for that parameter.
-        2. The default value is still empty on hide.
+            1. The 'hidden value' set to true for that parameter.
+            2. The default value is still empty on hide.
         """
         sc_param_id = self.sc_params_ids_list.pop()
         SmartClassParameter.update({

--- a/tests/foreman/cli/test_computeresource.py
+++ b/tests/foreman/cli/test_computeresource.py
@@ -18,19 +18,19 @@ Subcommands::
     image                         View and manage compute resource's images
 
 
-@Requirement: Computeresource
+:Requirement: Computeresource
 
-@CaseAutomation: Automated
+:CaseAutomation: Automated
 
-@CaseLevel: Acceptance
+:CaseLevel: Acceptance
 
-@CaseComponent: CLI
+:CaseComponent: CLI
 
-@TestType: Functional
+:TestType: Functional
 
-@CaseImportance: High
+:CaseImportance: High
 
-@Upstream: No
+:Upstream: No
 """
 import random
 
@@ -123,9 +123,9 @@ class ComputeResourceTestCase(CLITestCase):
     def test_positive_create_with_name(self):
         """Create Compute Resource
 
-        @id: 6460bcc7-d7f7-406a-aecb-b3d54d51e697
+        :id: 6460bcc7-d7f7-406a-aecb-b3d54d51e697
 
-        @Assert: Compute resource is created
+        :Assert: Compute resource is created
 
         """
         ComputeResource.create({
@@ -139,9 +139,9 @@ class ComputeResourceTestCase(CLITestCase):
     def test_positive_info(self):
         """Test Compute Resource Info
 
-        @id: f54af041-4471-4d8e-9429-45d821df0440
+        :id: f54af041-4471-4d8e-9429-45d821df0440
 
-        @Assert: Compute resource Info is displayed
+        :Assert: Compute resource Info is displayed
 
         """
         name = gen_string('utf8')
@@ -158,9 +158,9 @@ class ComputeResourceTestCase(CLITestCase):
     def test_positive_list(self):
         """Test Compute Resource List
 
-        @id: 11123361-ffbc-4c59-a0df-a4af3408af7a
+        :id: 11123361-ffbc-4c59-a0df-a4af3408af7a
 
-        @Assert: Compute resource List is displayed
+        :Assert: Compute resource List is displayed
 
         """
         comp_res = make_compute_resource({
@@ -179,9 +179,9 @@ class ComputeResourceTestCase(CLITestCase):
     def test_positive_delete_by_name(self):
         """Test Compute Resource delete
 
-        @id: 7fcc0b66-f1c1-4194-8a4b-7f04b1dd439a
+        :id: 7fcc0b66-f1c1-4194-8a4b-7f04b1dd439a
 
-        @Assert: Compute resource deleted
+        :Assert: Compute resource deleted
 
         """
         comp_res = make_compute_resource({
@@ -200,9 +200,9 @@ class ComputeResourceTestCase(CLITestCase):
     def test_positive_create_with_libvirt(self):
         """Test Compute Resource create
 
-        @id: adc6f4f8-6420-4044-89d1-c69e0bfeeab9
+        :id: adc6f4f8-6420-4044-89d1-c69e0bfeeab9
 
-        @Assert: Compute Resource created
+        :Assert: Compute Resource created
 
         """
         for options in valid_name_desc_data():
@@ -219,9 +219,9 @@ class ComputeResourceTestCase(CLITestCase):
     def test_positive_create_with_loc(self):
         """Create Compute Resource with location
 
-        @id: 224c7cbc-6bac-4a94-8141-d6249896f5a2
+        :id: 224c7cbc-6bac-4a94-8141-d6249896f5a2
 
-        @Assert: Compute resource is created and has location assigned
+        :Assert: Compute resource is created and has location assigned
 
         """
         location = make_location()
@@ -234,11 +234,10 @@ class ComputeResourceTestCase(CLITestCase):
     def test_positive_create_with_locs(self):
         """Create Compute Resource with multiple locations
 
-        @id: f665c586-39bf-480a-a0fc-81d9e1eb7c54
+        :id: f665c586-39bf-480a-a0fc-81d9e1eb7c54
 
-        @Assert: Compute resource is created and has multiple locations
-        assigned
-
+        :Assert: Compute resource is created and has multiple locations
+            assigned
         """
         locations_amount = random.randint(3, 5)
         locations = [make_location() for _ in range(locations_amount)]
@@ -256,12 +255,12 @@ class ComputeResourceTestCase(CLITestCase):
         """Create Compute Resource with different values of
         set-console-password parameter
 
-        @id: 4531b3e3-906b-4835-a6ab-3332dc9bd636
+        :id: 4531b3e3-906b-4835-a6ab-3332dc9bd636
 
-        @Assert: Compute Resource is created and set-console-password
-        parameter is set
+        :Assert: Compute Resource is created and set-console-password parameter
+            is set
 
-        @BZ: 1214312
+        :BZ: 1214312
 
         """
         for console_password in (u'True', u'Yes', 1, u'False', u'No', 0):
@@ -284,9 +283,9 @@ class ComputeResourceTestCase(CLITestCase):
     def test_negative_create_with_name_url(self):
         """Compute Resource negative create with invalid values
 
-        @id: cd432ff3-b3b9-49cd-9a16-ed00d81679dd
+        :id: cd432ff3-b3b9-49cd-9a16-ed00d81679dd
 
-        @Assert: Compute resource not created
+        :Assert: Compute resource not created
         """
         for options in invalid_create_data():
             with self.subTest(options):
@@ -303,9 +302,9 @@ class ComputeResourceTestCase(CLITestCase):
     def test_negative_create_with_same_name(self):
         """Compute Resource negative create with the same name
 
-        @id: ddb5c45b-1ea3-46d0-b248-56c0388d2e4b
+        :id: ddb5c45b-1ea3-46d0-b248-56c0388d2e4b
 
-        @Assert: Compute resource not created
+        :Assert: Compute resource not created
 
         """
         comp_res = make_compute_resource()
@@ -323,9 +322,9 @@ class ComputeResourceTestCase(CLITestCase):
     def test_positive_update_name(self):
         """Compute Resource positive update
 
-        @id: 213d7f04-4c54-4985-8ca0-d2a1a9e3b305
+        :id: 213d7f04-4c54-4985-8ca0-d2a1a9e3b305
 
-        @Assert: Compute Resource successfully updated
+        :Assert: Compute Resource successfully updated
 
         """
         for options in valid_update_data():
@@ -360,9 +359,9 @@ class ComputeResourceTestCase(CLITestCase):
     def test_negative_update(self):
         """Compute Resource negative update
 
-        @id: e7aa9b39-dd01-4f65-8e89-ff5a6f4ee0e3
+        :id: e7aa9b39-dd01-4f65-8e89-ff5a6f4ee0e3
 
-        @Assert: Compute Resource not updated
+        :Assert: Compute Resource not updated
 
         """
         for options in invalid_update_data():
@@ -383,9 +382,9 @@ class ComputeResourceTestCase(CLITestCase):
     def test_positive_create_with_console_password_and_name(self):
         """Create a compute resource with ``--set-console-password``.
 
-        @id: 5b4c838a-0265-4c71-a73d-305fecbe508a
+        :id: 5b4c838a-0265-4c71-a73d-305fecbe508a
 
-        @Assert: No error is returned.
+        :Assert: No error is returned.
 
         Targets BZ 1100344.
 
@@ -404,9 +403,9 @@ class ComputeResourceTestCase(CLITestCase):
     def test_positive_update_console_password(self):
         """Update a compute resource with ``--set-console-password``.
 
-        @id: ef09351e-dcd3-4b4f-8d3b-995e9e5873b3
+        :id: ef09351e-dcd3-4b4f-8d3b-995e9e5873b3
 
-        @Assert: No error is returned.
+        :Assert: No error is returned.
 
         Targets BZ 1100344.
 

--- a/tests/foreman/cli/test_contentview.py
+++ b/tests/foreman/cli/test_contentview.py
@@ -1,18 +1,18 @@
 """Test class for Content Views
 
-@Requirement: Contentview
+:Requirement: Contentview
 
-@CaseAutomation: Automated
+:CaseAutomation: Automated
 
-@CaseLevel: Acceptance
+:CaseLevel: Acceptance
 
-@CaseComponent: CLI
+:CaseComponent: CLI
 
-@TestType: Functional
+:TestType: Functional
 
-@CaseImportance: High
+:CaseImportance: High
 
-@Upstream: No
+:Upstream: No
 """
 import random
 
@@ -161,9 +161,9 @@ class ContentViewTestCase(CLITestCase):
     def test_positive_create_with_name(self):
         """create content views with different names
 
-        @id: a154308c-3982-4cf1-a236-3051e740970e
+        :id: a154308c-3982-4cf1-a236-3051e740970e
 
-        @assert: content views are created
+        :assert: content views are created
 
         """
         for name in generate_strings_list(exclude_types=['cjk']):
@@ -180,10 +180,10 @@ class ContentViewTestCase(CLITestCase):
     def test_negative_create_with_invalid_name(self):
         """create content views with invalid names
 
-        @id: 83046271-76f9-4cda-b579-a2fe63493295
+        :id: 83046271-76f9-4cda-b579-a2fe63493295
 
-        @assert: content views are not created; proper error thrown and
-        system handles it gracefully
+        :assert: content views are not created; proper error thrown and system
+            handles it gracefully
 
         """
         org_id = make_org(cached=True)['id']
@@ -201,10 +201,10 @@ class ContentViewTestCase(CLITestCase):
         # Use an invalid org name
         """Create content view with invalid org name
 
-        @id: f8b76e98-ccc8-41ac-af04-541650e8f5ba
+        :id: f8b76e98-ccc8-41ac-af04-541650e8f5ba
 
-        @assert: content views are not created; proper error thrown and
-        system handles it gracefully
+        :assert: content views are not created; proper error thrown and system
+            handles it gracefully
 
         """
         with self.assertRaises(CLIReturnCodeError):
@@ -215,11 +215,11 @@ class ContentViewTestCase(CLITestCase):
     def test_positive_create_with_repo_id(self):
         """Create content view providing repository id
 
-        @id: bb91affe-f8d4-4724-8b61-41f3cb898fd3
+        :id: bb91affe-f8d4-4724-8b61-41f3cb898fd3
 
-        @assert: Content view is created and repository is associated with CV
+        :assert: Content view is created and repository is associated with CV
 
-        @BZ: 1213097
+        :BZ: 1213097
         """
         repo = make_repository({'product-id': self.product['id']})
         cv = make_content_view({
@@ -233,11 +233,11 @@ class ContentViewTestCase(CLITestCase):
     def test_positive_create_with_repo_name(self):
         """Create content view providing repository name
 
-        @id: 80992a94-4c8e-4dbe-bc62-25af0bd2301d
+        :id: 80992a94-4c8e-4dbe-bc62-25af0bd2301d
 
-        @assert: Content view is created and repository is associated with CV
+        :assert: Content view is created and repository is associated with CV
 
-        @BZ: 1213097
+        :BZ: 1213097
         """
         repo = make_repository({'product-id': self.product['id']})
         cv = make_content_view({
@@ -252,10 +252,10 @@ class ContentViewTestCase(CLITestCase):
         """Create an empty content view and make sure no files are created at
         /var/lib/pulp/published.
 
-        @id: 0e31573d-bf02-44ae-b3f4-d8aae450ba5e
+        :id: 0e31573d-bf02-44ae-b3f4-d8aae450ba5e
 
-        @Assert: Content view is published and no file is present at
-        /var/lib/pulp/published.
+        :Assert: Content view is published and no file is present at
+            /var/lib/pulp/published.
         """
         content_view = make_content_view({'organization-id': self.org['id']})
         ContentView.publish({u'id': content_view['id']})
@@ -276,11 +276,11 @@ class ContentViewTestCase(CLITestCase):
     def test_positive_update_name(self):
         """Update content view name
 
-        @id: 35fccf2c-abc4-4ca8-a565-a7a6adaaf429
+        :id: 35fccf2c-abc4-4ca8-a565-a7a6adaaf429
 
-        @assert: Content view is updated with new name
+        :assert: Content view is updated with new name
 
-        @BZ: 1359665
+        :BZ: 1359665
         """
         con_view = make_content_view({
             'name': gen_string('utf8'),
@@ -305,11 +305,11 @@ class ContentViewTestCase(CLITestCase):
         # severity.
         """Edit content views for a rh content
 
-        @id: 4beab1e4-fc58-460e-af24-cdd2c3d283e6
+        :id: 4beab1e4-fc58-460e-af24-cdd2c3d283e6
 
-        @assert: Edited content view save is successful and info is updated
+        :assert: Edited content view save is successful and info is updated
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         self.create_rhel_content()
         # Create CV
@@ -352,9 +352,9 @@ class ContentViewTestCase(CLITestCase):
     def test_positive_delete_by_id(self):
         """delete content views
 
-        @id: e96d6d47-8be4-4705-979f-e5c320eca293
+        :id: e96d6d47-8be4-4705-979f-e5c320eca293
 
-        @assert: content view can be deleted
+        :assert: content view can be deleted
 
         """
         con_view = make_content_view({
@@ -370,12 +370,12 @@ class ContentViewTestCase(CLITestCase):
         """Delete content view containing custom repo and verify it was
         actually deleted from hard drive.
 
-        @id: 9f381f77-ce43-4b68-8d00-459f40c9efb6
+        :id: 9f381f77-ce43-4b68-8d00-459f40c9efb6
 
-        @Assert: Content view was deleted and pulp folder doesn't contain
-        content view files anymore
+        :Assert: Content view was deleted and pulp folder doesn't contain
+            content view files anymore
 
-        @BZ: 1317057, 1265703
+        :BZ: 1317057, 1265703
         """
         # Create and sync a repository
         new_product = make_product({u'organization-id': self.org['id']})
@@ -422,12 +422,12 @@ class ContentViewTestCase(CLITestCase):
         'remove-from-environment' command and delete content view version from
         that content view. Use content view version name as a parameter.
 
-        @id: 6e903131-1aeb-478c-ad92-5dedcc22c3f9
+        :id: 6e903131-1aeb-478c-ad92-5dedcc22c3f9
 
-        @assert: Content view version deleted successfully
+        :assert: Content view version deleted successfully
 
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         content_view = make_content_view({u'organization-id': self.org['id']})
         ContentView.publish({u'id': content_view['id']})
@@ -456,9 +456,9 @@ class ContentViewTestCase(CLITestCase):
         that content view. Use content view version id as a parameter. Also,
         add repository to initial content view for better coverage.
 
-        @id: 09457d48-2a92-401d-8dd0-45679a547e70
+        :id: 09457d48-2a92-401d-8dd0-45679a547e70
 
-        @assert: Content view version deleted successfully
+        :assert: Content view version deleted successfully
 
         """
         # Create new organization, product and repository
@@ -500,12 +500,12 @@ class ContentViewTestCase(CLITestCase):
         view version while content view is still associated with lifecycle
         environment
 
-        @id: 7334118b-e6c5-4db3-9167-3f006c43f863
+        :id: 7334118b-e6c5-4db3-9167-3f006c43f863
 
-        @assert: Content view version is not deleted
+        :assert: Content view version is not deleted
 
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         content_view = make_content_view({u'organization-id': self.org['id']})
         ContentView.publish({u'id': content_view['id']})
@@ -524,9 +524,9 @@ class ContentViewTestCase(CLITestCase):
     def test_positive_remove_lce_by_id(self):
         """Remove content view from lifecycle environment
 
-        @id: 1bf8a647-d82e-4145-b13b-f92bf6642532
+        :id: 1bf8a647-d82e-4145-b13b-f92bf6642532
 
-        @Assert: Content view removed from environment successfully
+        :Assert: Content view removed from environment successfully
 
         """
         new_org = make_org({u'name': gen_alphanumeric()})
@@ -547,12 +547,12 @@ class ContentViewTestCase(CLITestCase):
         """Remove content view environment and re-assign activation key to
         another environment and content view
 
-        @id: 3e3ac439-fa85-42ce-8277-2258bc0c7cb4
+        :id: 3e3ac439-fa85-42ce-8277-2258bc0c7cb4
 
-        @Assert: Activation key re-assigned successfully
+        :Assert: Activation key re-assigned successfully
 
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         new_org = make_org({u'name': gen_alphanumeric()})
         env = [
@@ -606,12 +606,12 @@ class ContentViewTestCase(CLITestCase):
         """Remove content view environment and re-assign content host to
         another environment and content view
 
-        @id: 40900199-dcfc-4906-bf54-16c13882c05b
+        :id: 40900199-dcfc-4906-bf54-16c13882c05b
 
-        @Assert: Content host re-assigned successfully
+        :Assert: Content host re-assigned successfully
 
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         new_org = make_org({u'name': gen_alphanumeric()})
         env = [
@@ -668,9 +668,9 @@ class ContentViewTestCase(CLITestCase):
     def test_positive_remove_version_by_id(self):
         """Delete content view version using 'remove' command
 
-        @id: e8664353-6601-4566-8478-440be20a089d
+        :id: e8664353-6601-4566-8478-440be20a089d
 
-        @Assert: Content view version deleted successfully
+        :Assert: Content view version deleted successfully
 
         """
         new_org = make_org({u'name': gen_alphanumeric()})
@@ -700,14 +700,14 @@ class ContentViewTestCase(CLITestCase):
         # repo, however, are a valid variation.
         """create a composite content view
 
-        @id: bded6acd-8da3-45ea-9e39-19bdc6c06341
+        :id: bded6acd-8da3-45ea-9e39-19bdc6c06341
 
-        @setup: sync multiple content source/types (RH, custom, etc.)
+        :setup: sync multiple content source/types (RH, custom, etc.)
 
-        @assert: Composite content views are created
+        :assert: Composite content views are created
 
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         # Create REPO
         new_repo = make_repository({u'product-id': self.product['id']})
@@ -748,11 +748,11 @@ class ContentViewTestCase(CLITestCase):
     def test_positive_remove_version_by_id_from_composite(self):
         """Create a composite content view and remove its content version by id
 
-        @id: 0ff675d0-45d6-4f15-9e84-3b5ce98ce7de
+        :id: 0ff675d0-45d6-4f15-9e84-3b5ce98ce7de
 
-        @assert: Composite content view info output does not contain any values
+        :assert: Composite content view info output does not contain any values
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         # Create new repository
         new_repo = make_repository({u'product-id': self.product['id']})
@@ -795,12 +795,12 @@ class ContentViewTestCase(CLITestCase):
     def test_positive_create_composite_with_component_ids(self):
         """create a composite content view with a component_ids option
 
-        @id: 6d4b94da-258d-4690-a5b6-bacaf6b1671a
+        :id: 6d4b94da-258d-4690-a5b6-bacaf6b1671a
 
-        @assert: Composite content view component ids are similar to the
-        nested content view versions ids
+        :assert: Composite content view component ids are similar to the nested
+            content view versions ids
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         # Create CV
         new_cv = make_content_view({u'organization-id': self.org['id']})
@@ -831,12 +831,12 @@ class ContentViewTestCase(CLITestCase):
     def test_positive_update_composite_with_component_ids(self):
         """Update a composite content view with a component_ids option
 
-        @id: e6106ff6-c526-40f2-bdc0-ae291f7b267e
+        :id: e6106ff6-c526-40f2-bdc0-ae291f7b267e
 
-        @assert: Composite content view component ids are similar to the
-        nested content view versions ids
+        :assert: Composite content view component ids are similar to the nested
+            content view versions ids
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         # Create a CV to add to the composite one
         cv = make_content_view({u'organization-id': self.org['id']})
@@ -873,14 +873,14 @@ class ContentViewTestCase(CLITestCase):
     def test_positive_add_rh_repo_by_id(self):
         """Associate Red Hat content to a content view
 
-        @id: b31a85c3-aa56-461b-9e3a-f7754c742573
+        :id: b31a85c3-aa56-461b-9e3a-f7754c742573
 
-        @setup: Sync RH content
+        :setup: Sync RH content
 
-        @assert: RH Content can be seen in the content view
+        :assert: RH Content can be seen in the content view
 
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         self.create_rhel_content()
         # Create CV
@@ -907,18 +907,18 @@ class ContentViewTestCase(CLITestCase):
     def test_positive_add_rh_repo_by_id_and_create_filter(self):
         """Associate Red Hat content to a content view and create filter
 
-        @id: 7723247a-9367-4367-b251-bd079b79b8a2
+        :id: 7723247a-9367-4367-b251-bd079b79b8a2
 
-        @setup: Sync RH content
+        :setup: Sync RH content
 
-        @steps: 1. Assure filter(s) applied to associated content
+        :steps: Assure filter(s) applied to associated content
 
-        @assert: Filtered RH content only is available/can be seen in a view
+        :assert: Filtered RH content only is available/can be seen in a view
 
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
 
-        @BZ: 1359665
+        :BZ: 1359665
         """
         self.create_rhel_content()
         # Create CV
@@ -955,14 +955,14 @@ class ContentViewTestCase(CLITestCase):
     def test_positive_add_custom_repo_by_id(self):
         """Associate custom content to a Content view
 
-        @id: b813b222-b984-47e0-8d9b-2daa43f9a221
+        :id: b813b222-b984-47e0-8d9b-2daa43f9a221
 
-        @setup: Sync custom content
+        :setup: Sync custom content
 
-        @assert: Custom content can be seen in a view
+        :assert: Custom content can be seen in a view
 
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         new_repo = make_repository({u'product-id': self.product['id']})
         # Sync REPO
@@ -987,9 +987,9 @@ class ContentViewTestCase(CLITestCase):
     def test_positive_add_custom_repo_by_name(self):
         """Associate custom content to a content view with name
 
-        @id: 62431e11-bec6-4444-abb0-e3758ba25fd8
+        :id: 62431e11-bec6-4444-abb0-e3758ba25fd8
 
-        @assert: whether repos are added to cv.
+        :assert: whether repos are added to cv.
 
         """
         new_repo = make_repository({u'product-id': self.product['id']})
@@ -1016,11 +1016,11 @@ class ContentViewTestCase(CLITestCase):
     def test_positive_add_puppet_module(self):
         """Add puppet module to Content View by name
 
-        @id: 81d3305e-c0c2-487b-9fd8-828b3250fe6e
+        :id: 81d3305e-c0c2-487b-9fd8-828b3250fe6e
 
-        @Assert: Module was added and has latest version.
+        :Assert: Module was added and has latest version.
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         module = {'name': 'versioned', 'version': '3.3.3'}
         puppet_repository = make_repository({
@@ -1054,18 +1054,18 @@ class ContentViewTestCase(CLITestCase):
     def test_positive_add_puppet_module_older_version(self):
         """Add older version of puppet module to Content View by id/uuid
 
-        @id: 39654b3e-963f-4859-81f2-9992b60433c2
+        :id: 39654b3e-963f-4859-81f2-9992b60433c2
 
-        @Steps:
+        :Steps:
 
-        1. Upload/sync puppet repo with several versions of the same module
-        2. Add older version by id/uuid to CV
+            1. Upload/sync puppet repo with several versions of the same module
+            2. Add older version by id/uuid to CV
 
-        @Assert: Exact version (and not latest) was added.
+        :Assert: Exact version (and not latest) was added.
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
 
-        @BZ: 1240491
+        :BZ: 1240491
         """
         module = {'name': 'versioned', 'version': '2.2.2'}
         puppet_repository = make_repository({
@@ -1102,11 +1102,11 @@ class ContentViewTestCase(CLITestCase):
     def test_positive_remove_puppet_module_by_name(self):
         """Remove puppet module from Content View by name
 
-        @id: b9d161de-d2a1-46e1-922d-5e22826a41e4
+        :id: b9d161de-d2a1-46e1-922d-5e22826a41e4
 
-        @Assert: Module successfully removed and no modules are listed
+        :Assert: Module successfully removed and no modules are listed
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         puppet_repository = make_repository({
             u'content-type': u'puppet',
@@ -1141,13 +1141,13 @@ class ContentViewTestCase(CLITestCase):
     def test_positive_remove_puppet_module_by_id(self):
         """Remove puppet module from Content View by id
 
-        @id: 972a484c-6f38-4015-b20b-6a83d15b6c97
+        :id: 972a484c-6f38-4015-b20b-6a83d15b6c97
 
-        @Assert: Module successfully removed and no modules are listed
+        :Assert: Module successfully removed and no modules are listed
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
 
-        @BZ: 1427260
+        :BZ: 1427260
         """
         puppet_repository = make_repository({
             u'content-type': u'puppet',
@@ -1179,11 +1179,11 @@ class ContentViewTestCase(CLITestCase):
     def test_positive_remove_puppet_module_by_uuid(self):
         """Remove puppet module from Content View by uuid
 
-        @id: c63339aa-3d74-4a37-aaef-6777e0f6cb35
+        :id: c63339aa-3d74-4a37-aaef-6777e0f6cb35
 
-        @Assert: Module successfully removed and no modules are listed
+        :Assert: Module successfully removed and no modules are listed
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         puppet_repository = make_repository({
             u'content-type': u'puppet',
@@ -1217,13 +1217,12 @@ class ContentViewTestCase(CLITestCase):
         """attempt to associate puppet repos within a custom content
         view
 
-        @id: 7625c07b-edeb-48ef-85a2-4d1c09874a4b
+        :id: 7625c07b-edeb-48ef-85a2-4d1c09874a4b
 
-        @assert: User cannot create a content view that contains direct puppet
-        repos.
+        :assert: User cannot create a content view that contains direct puppet
+            repos.
 
-
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         new_repo = make_repository({
             u'content-type': u'puppet',
@@ -1244,12 +1243,12 @@ class ContentViewTestCase(CLITestCase):
         """attempt to associate components in a non-composite content
         view
 
-        @id: 2a6f150d-e012-47c1-9423-d73f5d620dc9
+        :id: 2a6f150d-e012-47c1-9423-d73f5d620dc9
 
-        @assert: User cannot add components to the view
+        :assert: User cannot add components to the view
 
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         # Create REPO
         new_repo = make_repository({u'product-id': self.product['id']})
@@ -1281,12 +1280,12 @@ class ContentViewTestCase(CLITestCase):
         """attempt to associate the same repo multiple times within a
         content view
 
-        @id: 5fb09b30-5f5b-4473-a62b-8f41045ac2b6
+        :id: 5fb09b30-5f5b-4473-a62b-8f41045ac2b6
 
-        @assert: User cannot add repos multiple times to the view
+        :assert: User cannot add repos multiple times to the view
 
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         new_repo = make_repository({u'product-id': self.product['id']})
         # Sync REPO
@@ -1323,12 +1322,12 @@ class ContentViewTestCase(CLITestCase):
         """attempt to associate duplicate puppet module(s) within a
         content view
 
-        @id: 674cbae2-8493-466d-a2e4-dc11fb5c6b6f
+        :id: 674cbae2-8493-466d-a2e4-dc11fb5c6b6f
 
-        @assert: User cannot add puppet modules multiple times to the content
-        view
+        :assert: User cannot add puppet modules multiple times to the content
+            view
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         # see BZ #1222118
         repository = make_repository({
@@ -1371,19 +1370,19 @@ class ContentViewTestCase(CLITestCase):
         """Attempt to associate unpublished non-composite content view with
         composite content view.
 
-        @id: acee782f-2792-4c4e-b0c9-87d6b89992ef
+        :id: acee782f-2792-4c4e-b0c9-87d6b89992ef
 
-        @steps:
+        :steps:
 
-        1. Create an empty non-composite content view. Do not publish it.
-        2. Create a new composite content view
+            1. Create an empty non-composite content view. Do not publish it.
+            2. Create a new composite content view
 
-        @assert: Non-composite content view cannot be added to
-        composite content view.
+        :assert: Non-composite content view cannot be added to composite
+            content view.
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
 
-        @BZ: 1367123
+        :BZ: 1367123
         """
         # Create component CV
         content_view = make_content_view({'organization-id': self.org['id']})
@@ -1410,26 +1409,26 @@ class ContentViewTestCase(CLITestCase):
         """Attempt to associate both published and unpublished
         non-composite content views with composite content view.
 
-        @id: 4f6d3308-8083-4fc3-bb4f-5d5e1b886a96
+        :id: 4f6d3308-8083-4fc3-bb4f-5d5e1b886a96
 
-        @steps:
+        :steps:
 
-        1. Create an empty non-composite content view. Do not publish it
-        2. Create a second non-composite content view. Publish it.
-        3. Create a new composite content view.
-        4. Add the published non-composite content view to the composite
-            content view.
+            1. Create an empty non-composite content view. Do not publish it
+            2. Create a second non-composite content view. Publish it.
+            3. Create a new composite content view.
+            4. Add the published non-composite content view to the composite
+               content view.
 
-        @assert:
+        :assert:
 
-        1. Unpublished non-composite content view cannot be added to
-        composite content view
-        2. Published non-composite content view is successfully added to
-        composite content view.
+            1. Unpublished non-composite content view cannot be added to
+               composite content view
+            2. Published non-composite content view is successfully added to
+               composite content view.
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
 
-        @BZ: 1367123
+        :BZ: 1367123
         """
         # Create published component CV
         published_cv = make_content_view({'organization-id': self.org['id']})
@@ -1474,14 +1473,14 @@ class ContentViewTestCase(CLITestCase):
     def test_positive_promote_rh_content(self):
         """attempt to promote a content view containing RH content
 
-        @id: 53b3661b-b40f-466e-a742-bc4b8c1f6cd8
+        :id: 53b3661b-b40f-466e-a742-bc4b8c1f6cd8
 
-        @setup: Multiple environments for an org; RH content synced
+        :setup: Multiple environments for an org; RH content synced
 
-        @assert: Content view can be promoted
+        :assert: Content view can be promoted
 
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         self.create_rhel_content()
         # Create CV
@@ -1518,13 +1517,13 @@ class ContentViewTestCase(CLITestCase):
         """attempt to promote a content view containing RH content and
         custom content using filters
 
-        @id: f96e97ef-f73c-4506-855c-2392e06f3a6a
+        :id: f96e97ef-f73c-4506-855c-2392e06f3a6a
 
-        @setup: Multiple environments for an org; RH content synced
+        :setup: Multiple environments for an org; RH content synced
 
-        @assert: Content view can be promoted
+        :assert: Content view can be promoted
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         # Enable RH repo
         self.create_rhel_content()
@@ -1581,14 +1580,14 @@ class ContentViewTestCase(CLITestCase):
     def test_positive_promote_custom_content(self):
         """attempt to promote a content view containing custom content
 
-        @id: 64c2f1c2-7443-4836-a108-060b913ad2b1
+        :id: 64c2f1c2-7443-4836-a108-060b913ad2b1
 
-        @setup: Multiple environments for an org; custom content synced
+        :setup: Multiple environments for an org; custom content synced
 
-        @assert: Content view can be promoted
+        :assert: Content view can be promoted
 
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         # Create REPO
         new_repo = make_repository({u'product-id': self.product['id']})
@@ -1624,16 +1623,16 @@ class ContentViewTestCase(CLITestCase):
         # ...etc.
         """attempt to promote a content view containing custom content
 
-        @id: 9d31113d-39ec-4524-854c-7f03b0f028fe
+        :id: 9d31113d-39ec-4524-854c-7f03b0f028fe
 
-        @setup: Multiple environments for an org; custom content synced
+        :setup: Multiple environments for an org; custom content synced
 
-        @steps: create a composite view containing multiple content types
+        :steps: create a composite view containing multiple content types
 
-        @assert: Content view can be promoted
+        :assert: Content view can be promoted
 
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         # Create REPO
         new_repo = make_repository({u'product-id': self.product['id']})
@@ -1681,12 +1680,12 @@ class ContentViewTestCase(CLITestCase):
     def test_negative_promote_default_cv(self):
         """attempt to promote a default content view
 
-        @id: ef25a4d9-8852-4d2c-8355-e9b07eb0560b
+        :id: ef25a4d9-8852-4d2c-8355-e9b07eb0560b
 
-        @assert: Default content views cannot be promoted
+        :assert: Default content views cannot be promoted
 
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         result = ContentView.list(
             {u'organization-id': self.org['id']},
@@ -1711,12 +1710,12 @@ class ContentViewTestCase(CLITestCase):
         """attempt to promote a content view using an invalid
         environment
 
-        @id: b143552e-610e-4188-b754-e7462ced8cf3
+        :id: b143552e-610e-4188-b754-e7462ced8cf3
 
-        @assert: Content views cannot be promoted; handled gracefully
+        :assert: Content views cannot be promoted; handled gracefully
 
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         # Create REPO
         new_repo = make_repository({u'product-id': self.product['id']})
@@ -1750,14 +1749,14 @@ class ContentViewTestCase(CLITestCase):
     def test_positive_publish_rh_content(self):
         """attempt to publish a content view containing RH content
 
-        @id: d4323759-d869-4d62-ab2e-f1ea3dbb38ba
+        :id: d4323759-d869-4d62-ab2e-f1ea3dbb38ba
 
-        @setup: Multiple environments for an org; RH content synced
+        :setup: Multiple environments for an org; RH content synced
 
-        @assert: Content view can be published
+        :assert: Content view can be published
 
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         self.create_rhel_content()
         # Create CV
@@ -1789,13 +1788,13 @@ class ContentViewTestCase(CLITestCase):
         """attempt to publish  a content view containing a RH and custom
         repos and has filters
 
-        @id: 0b116172-06a3-4327-81a8-17a098a1a564
+        :id: 0b116172-06a3-4327-81a8-17a098a1a564
 
-        @setup: Multiple environments for an org; RH content synced
+        :setup: Multiple environments for an org; RH content synced
 
-        @assert: Content view can be published
+        :assert: Content view can be published
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         # Enable RH repo
         self.create_rhel_content()
@@ -1843,14 +1842,14 @@ class ContentViewTestCase(CLITestCase):
     def test_positive_publish_custom_content(self):
         """attempt to publish a content view containing custom content
 
-        @id: 84158023-3980-45c6-87d8-faacea3c942f
+        :id: 84158023-3980-45c6-87d8-faacea3c942f
 
-        @setup: Multiple environments for an org; custom content synced
+        :setup: Multiple environments for an org; custom content synced
 
-        @assert: Content view can be published
+        :assert: Content view can be published
 
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         new_repo = make_repository({u'product-id': self.product['id']})
         # Sync REPO
@@ -1886,14 +1885,14 @@ class ContentViewTestCase(CLITestCase):
         """attempt to publish a composite content view containing custom
         content
 
-        @id: fde99446-241f-422d-987b-fa1987b654ee
+        :id: fde99446-241f-422d-987b-fa1987b654ee
 
-        @setup: Multiple environments for an org; custom content synced
+        :setup: Multiple environments for an org; custom content synced
 
-        @assert: Content view can be published
+        :assert: Content view can be published
 
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         repository = make_repository({u'product-id': self.product['id']})
         # Sync REPO
@@ -1954,19 +1953,19 @@ class ContentViewTestCase(CLITestCase):
         """when publishing new version to environment, version
         gets updated
 
-        @id: cef62d34-c006-4bd0-950e-29e732388c00
+        :id: cef62d34-c006-4bd0-950e-29e732388c00
 
-        @setup: Multiple environments for an org; multiple versions
-        of a content view created/published
+        :setup: Multiple environments for an org; multiple versions of a
+            content view created/published
 
-        @steps:
-        1. publish a view to an environment noting the CV version
-        2. edit and republish a new version of a CV
+        :steps:
+            1. publish a view to an environment noting the CV version
+            2. edit and republish a new version of a CV
 
-        @assert: Content view version is updated in target environment.
+        :assert: Content view version is updated in target environment.
 
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         # Create REPO
         new_repo = make_repository({u'product-id': self.product['id']})
@@ -2041,19 +2040,20 @@ class ContentViewTestCase(CLITestCase):
         # Library (ie when I publish version 2, version 1 disappears)
         """when publishing new version to environment, version
         gets updated
-        @id: e5704b86-9919-471b-8362-1831d1983e70
 
-        @setup: Multiple environments for an org; multiple versions
-        of a content view created/published
+        :id: e5704b86-9919-471b-8362-1831d1983e70
 
-        @steps:
-        1. publish a view to an environment
-        2. edit and republish a new version of a CV
+        :setup: Multiple environments for an org; multiple versions of a
+            content view created/published
 
-        @assert: Content view version is updated in source environment.
+        :steps:
+            1. publish a view to an environment
+            2. edit and republish a new version of a CV
+
+        :assert: Content view version is updated in source environment.
 
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         # Create REPO
         new_repo = make_repository({u'product-id': self.product['id']})
@@ -2134,12 +2134,12 @@ class ContentViewTestCase(CLITestCase):
     def test_positive_subscribe_chost_by_id(self):
         """Attempt to subscribe content host to content view
 
-        @id: db0bfd9d-3150-427e-9683-a68af33813e7
+        :id: db0bfd9d-3150-427e-9683-a68af33813e7
 
-        @assert: Content host can be subscribed to content view
+        :assert: Content host can be subscribed to content view
 
 
-        @CaseLevel: System
+        :CaseLevel: System
         """
         new_org = make_org()
         env = make_lifecycle_environment({u'organization-id': new_org['id']})
@@ -2169,13 +2169,12 @@ class ContentViewTestCase(CLITestCase):
         """Attempt to subscribe content host to content view that has
         Red Hat repository assigned to it
 
-        @id: aeaaa363-5146-45ee-8c81-e54c7876fb81
+        :id: aeaaa363-5146-45ee-8c81-e54c7876fb81
 
-        @assert: Content Host can be subscribed to content view with Red Hat
-        repository
+        :assert: Content Host can be subscribed to content view with Red Hat
+            repository
 
-
-        @CaseLevel: System
+        :CaseLevel: System
         """
         self.create_rhel_content()
         env = make_lifecycle_environment({
@@ -2220,15 +2219,14 @@ class ContentViewTestCase(CLITestCase):
         """Attempt to subscribe content host to filtered content view
         that has Red Hat repository assigned to it
 
-        @id: 8d1e0daf-6130-4b50-827d-061e6c32749d
+        :id: 8d1e0daf-6130-4b50-827d-061e6c32749d
 
-        @assert: Content Host can be subscribed to filtered content view with
-        Red Hat repository
+        :assert: Content Host can be subscribed to filtered content view with
+            Red Hat repository
 
+        :CaseLevel: System
 
-        @CaseLevel: System
-
-        @BZ: 1359665
+        :BZ: 1359665
         """
         self.create_rhel_content()
         env = make_lifecycle_environment({
@@ -2288,13 +2286,12 @@ class ContentViewTestCase(CLITestCase):
         """Attempt to subscribe content host to content view that has
         custom repository assigned to it
 
-        @id: 9758756a-2536-4777-a6a9-ed618453ebe7
+        :id: 9758756a-2536-4777-a6a9-ed618453ebe7
 
-        @assert: Content Host can be subscribed to content view with custom
-        repository
+        :assert: Content Host can be subscribed to content view with custom
+            repository
 
-
-        @CaseLevel: System
+        :CaseLevel: System
         """
         new_org = make_org()
         new_product = make_product({u'organization-id': new_org['id']})
@@ -2333,12 +2330,12 @@ class ContentViewTestCase(CLITestCase):
     def test_positive_subscribe_chost_by_id_using_ccv(self):
         """Attempt to subscribe content host to composite content view
 
-        @id: 4be340c0-9e58-4b96-ab37-d7e3b12c724f
+        :id: 4be340c0-9e58-4b96-ab37-d7e3b12c724f
 
-        @assert: Content host can be subscribed to composite content view
+        :assert: Content host can be subscribed to composite content view
 
 
-        @CaseLevel: System
+        :CaseLevel: System
         """
         new_org = make_org()
         env = make_lifecycle_environment({u'organization-id': new_org['id']})
@@ -2372,12 +2369,12 @@ class ContentViewTestCase(CLITestCase):
         """Attempt to subscribe content host to content view that has
         puppet module assigned to it
 
-        @id: 7f45a162-e944-4e2c-a892-b26d1d21c844
+        :id: 7f45a162-e944-4e2c-a892-b26d1d21c844
 
-        @assert: Content Host can be subscribed to content view with puppet
-        module
+        :assert: Content Host can be subscribed to content view with puppet
+            module
 
-        @CaseLevel: System
+        :CaseLevel: System
         """
         # see BZ #1222118
         new_org = make_org()
@@ -2432,12 +2429,12 @@ class ContentViewTestCase(CLITestCase):
         """Attempt to create, publish and promote new content view based on
         existing view within the same environment as the original content view
 
-        @id: 4d7fa623-3516-4abe-a98c-98acbfb7e9c9
+        :id: 4d7fa623-3516-4abe-a98c-98acbfb7e9c9
 
-        @assert: Cloned content view can be published and promoted to the same
-        environment as the original content view
+        :assert: Cloned content view can be published and promoted to the same
+            environment as the original content view
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         org = make_org()
         cloned_cv_name = gen_string('alpha')
@@ -2473,12 +2470,12 @@ class ContentViewTestCase(CLITestCase):
         """Attempt to create, publish and promote new content view based on
         existing view but promoted to a different environment
 
-        @id: 308ffaa3-cd01-4a16-b84d-c60c32959235
+        :id: 308ffaa3-cd01-4a16-b84d-c60c32959235
 
-        @Assert: Cloned content view can be published and promoted to a
-        different environment as the original content view
+        :Assert: Cloned content view can be published and promoted to a
+            different environment as the original content view
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         org = make_org()
         cloned_cv_name = gen_string('alpha')
@@ -2515,15 +2512,16 @@ class ContentViewTestCase(CLITestCase):
     def test_positive_restart_dynflow_promote(self):
         """attempt to restart a failed content view promotion
 
-        @id: 2be23f85-3f62-4319-87ea-41f28cf401dc
+        :id: 2be23f85-3f62-4319-87ea-41f28cf401dc
 
-        @steps:
-        1. (Somehow) cause a CV promotion to fail.  Not exactly sure how yet.
-        2. Via Dynflow, restart promotion
+        :steps:
+            1. (Somehow) cause a CV promotion to fail.  Not exactly sure how
+               yet.
+            2. Via Dynflow, restart promotion
 
-        @assert: Promotion is restarted.
+        :assert: Promotion is restarted.
 
-        @caseautomation: notautomated
+        :caseautomation: notautomated
 
         """
 
@@ -2532,15 +2530,16 @@ class ContentViewTestCase(CLITestCase):
     def test_positive_restart_dynflow_publish(self):
         """attempt to restart a failed content view publish
 
-        @id: 24468014-46b2-403e-8ed6-2daeda5a0163
+        :id: 24468014-46b2-403e-8ed6-2daeda5a0163
 
-        @steps:
-        1. (Somehow) cause a CV publish  to fail.  Not exactly sure how yet.
-        2. Via Dynflow, restart publish
+        :steps:
+            1. (Somehow) cause a CV publish  to fail.  Not exactly sure how
+               yet.
+            2. Via Dynflow, restart publish
 
-        @assert: Publish is restarted.
+        :assert: Publish is restarted.
 
-        @caseautomation: notautomated
+        :caseautomation: notautomated
 
         """
 
@@ -2549,19 +2548,19 @@ class ContentViewTestCase(CLITestCase):
     def test_positive_remove_renamed_cv_version_from_default_env(self):
         """Remove version of renamed content view from Library environment
 
-        @id: aa9bbfda-72e8-45ec-b26d-fdf2691980cf
+        :id: aa9bbfda-72e8-45ec-b26d-fdf2691980cf
 
-        @Steps:
+        :Steps:
 
-        1. Create a content view
-        2. Add a yum repo to the content view
-        3. Publish the content view
-        4. Rename the content view
-        5. remove the published version from Library environment
+            1. Create a content view
+            2. Add a yum repo to the content view
+            3. Publish the content view
+            4. Rename the content view
+            5. remove the published version from Library environment
 
-        @Assert: content view version is removed from Library environment
+        :Assert: content view version is removed from Library environment
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         new_name = gen_string('alpha')
         org = make_org()
@@ -2620,22 +2619,22 @@ class ContentViewTestCase(CLITestCase):
     def test_positive_remove_promoted_cv_version_from_default_env(self):
         """Remove promoted content view version from Library environment
 
-        @id: 6643837a-560a-47de-aa4d-90778914dcfa
+        :id: 6643837a-560a-47de-aa4d-90778914dcfa
 
-        @Steps:
+        :Steps:
 
-        1. Create a content view
-        2. Add a puppet module(s) to the content view
-        3. Publish the content view
-        4. Promote the content view version from Library -> DEV
-        5. remove the content view version from Library environment
+            1. Create a content view
+            2. Add a puppet module(s) to the content view
+            3. Publish the content view
+            4. Promote the content view version from Library -> DEV
+            5. remove the content view version from Library environment
 
-        @Assert:
+        :Assert:
 
-        1. Content view version exist only in DEV and not in Library
-        2. The puppet module(s) exists in content view version
+            1. Content view version exist only in DEV and not in Library
+            2. The puppet module(s) exists in content view version
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         org = make_org()
         lce_dev = make_lifecycle_environment({'organization-id': org['id']})
@@ -2718,21 +2717,20 @@ class ContentViewTestCase(CLITestCase):
     def test_positive_remove_qe_promoted_cv_version_from_default_env(self):
         """Remove QE promoted content view version from Library environment
 
-        @id: e286697f-4113-40a3-b8e8-9ca50647e6d5
+        :id: e286697f-4113-40a3-b8e8-9ca50647e6d5
 
-        @Steps:
+        :Steps:
 
-        1. Create a content view
-        2. Add docker repo(s) to it
-        3. Publish content view
-        4. Promote the content view version to multiple environments
-           Library -> DEV -> QE
-        5. remove the content view version from Library environment
+            1. Create a content view
+            2. Add docker repo(s) to it
+            3. Publish content view
+            4. Promote the content view version to multiple environments
+               Library -> DEV -> QE
+            5. remove the content view version from Library environment
 
-        @Assert: Content view version exist only in DEV, QE
-        and not in Library
+        :Assert: Content view version exist only in DEV, QE and not in Library
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         org = make_org()
         lce_dev = make_lifecycle_environment({'organization-id': org['id']})
@@ -2796,21 +2794,21 @@ class ContentViewTestCase(CLITestCase):
     def test_positive_remove_prod_promoted_cv_version_from_default_env(self):
         """Remove PROD promoted content view version from Library environment
 
-        @id: ffe3d64e-c3d2-4889-9454-ccc6b10f4db7
+        :id: ffe3d64e-c3d2-4889-9454-ccc6b10f4db7
 
-        @Steps:
+        :Steps:
 
-        1. Create a content view
-        2. Add yum repositories, puppet modules, docker repositories to CV
-        3. Publish content view
-        4. Promote the content view version to multiple environments
-           Library -> DEV -> QE -> PROD
-        5. remove the content view version from Library environment
+            1. Create a content view
+            2. Add yum repositories, puppet modules, docker repositories to CV
+            3. Publish content view
+            4. Promote the content view version to multiple environments
+               Library -> DEV -> QE -> PROD
+            5. remove the content view version from Library environment
 
-        @Assert: Content view version exist only in DEV, QE, PROD
-        and not in Library
+        :Assert: Content view version exist only in DEV, QE, PROD and not in
+            Library
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         org = make_org()
         lce_dev = make_lifecycle_environment({'organization-id': org['id']})
@@ -2903,23 +2901,23 @@ class ContentViewTestCase(CLITestCase):
     def test_positive_remove_cv_version_from_env(self):
         """Remove promoted content view version from environment
 
-        @id: 577757ac-b184-4ece-9310-182dd5ceb718
+        :id: 577757ac-b184-4ece-9310-182dd5ceb718
 
-        @Steps:
+        :Steps:
 
-        1. Create a content view
-        2. Add a yum repo and a puppet module to the content view
-        3. Publish the content view
-        4. Promote the content view version to multiple environments
-           Library -> DEV -> QE -> STAGE -> PROD
-        5. remove the content view version from PROD environment
-        6. Assert: content view version exists only in Library, DEV, QE, STAGE
-           and not in PROD
-        7. Promote again from STAGE -> PROD
+            1. Create a content view
+            2. Add a yum repo and a puppet module to the content view
+            3. Publish the content view
+            4. Promote the content view version to multiple environments
+               Library -> DEV -> QE -> STAGE -> PROD
+            5. remove the content view version from PROD environment
+            6. Assert: content view version exists only in Library, DEV, QE,
+               STAGE and not in PROD
+            7. Promote again from STAGE -> PROD
 
-        @Assert: Content view version exist in Library, DEV, QE, STAGE, PROD
+        :Assert: Content view version exist in Library, DEV, QE, STAGE, PROD
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         org = make_org()
         lce_dev = make_lifecycle_environment({'organization-id': org['id']})
@@ -3020,20 +3018,20 @@ class ContentViewTestCase(CLITestCase):
     def test_positive_remove_cv_version_from_multi_env(self):
         """Remove promoted content view version from multiple environment
 
-        @id: 997cfd7d-9029-47e2-a41e-84f4370b5ce5
+        :id: 997cfd7d-9029-47e2-a41e-84f4370b5ce5
 
-        @Steps:
+        :Steps:
 
-        1. Create a content view
-        2. Add a yum repo and a puppet module to the content view
-        3. Publish the content view
-        4. Promote the content view version to multiple environments
-           Library -> DEV -> QE -> STAGE -> PROD
-        5. Remove content view version from QE, STAGE and PROD
+            1. Create a content view
+            2. Add a yum repo and a puppet module to the content view
+            3. Publish the content view
+            4. Promote the content view version to multiple environments
+               Library -> DEV -> QE -> STAGE -> PROD
+            5. Remove content view version from QE, STAGE and PROD
 
-        @Assert: Content view version exists only in Library, DEV
+        :Assert: Content view version exists only in Library, DEV
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         org = make_org()
         lce_dev = make_lifecycle_environment({'organization-id': org['id']})
@@ -3124,21 +3122,21 @@ class ContentViewTestCase(CLITestCase):
         """Delete published content view with version promoted to multiple
          environments
 
-        @id: 93dd7518-5901-4a71-a4c3-0f1215238b26
+        :id: 93dd7518-5901-4a71-a4c3-0f1215238b26
 
-        @Steps:
+        :Steps:
 
-        1. Create a content view
-        2. Add a yum repo and a puppet module to the content view
-        3. Publish the content view
-        4. Promote the content view to multiple environment
-           Library -> DEV -> QE -> STAGE -> PROD
-        5. Delete the content view
-           (may delete the published versions environments prior this step)
+            1. Create a content view
+            2. Add a yum repo and a puppet module to the content view
+            3. Publish the content view
+            4. Promote the content view to multiple environment Library -> DEV
+               -> QE -> STAGE -> PROD
+            5. Delete the content view (may delete the published versions
+               environments prior this step)
 
-        @Assert: The content view doesn't exists
+        :Assert: The content view doesn't exists
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         org = make_org()
         lce_dev = make_lifecycle_environment({'organization-id': org['id']})
@@ -3235,35 +3233,36 @@ class ContentViewTestCase(CLITestCase):
         """Remove promoted content view version from environment that is used
         in association of an Activation key and content-host registration.
 
-        @id: 001a2b76-a87b-4c11-8837-f5fe3c04a075
+        :id: 001a2b76-a87b-4c11-8837-f5fe3c04a075
 
-        @Steps:
+        :Steps:
 
-        1. Create a content view cv1
-        2. Add a yum repo and a puppet module to the content view
-        3. Publish the content view
-        4. Promote the content view to multiple environment
-           Library -> DEV -> QE
-        5. Create an Activation key with the QE environment
-        6. Register a content-host using the Activation key
-        7. Remove the content view cv1 version from QE environment.
-           Note - prior removing replace the current QE environment of cv1 by
-           DEV and content view cv1 for Content-host and for Activation key.
-        8. Refresh content-host subscription
+            1. Create a content view cv1
+            2. Add a yum repo and a puppet module to the content view
+            3. Publish the content view
+            4. Promote the content view to multiple environment Library -> DEV
+               -> QE
+            5. Create an Activation key with the QE environment
+            6. Register a content-host using the Activation key
+            7. Remove the content view cv1 version from QE environment.
+               Note - prior removing replace the current QE environment of cv1
+               by DEV and content view cv1 for Content-host and for Activation
+               key.
+            8. Refresh content-host subscription
 
-        @Assert:
+        :Assert:
 
-        1. Activation key exists
-        2. Content-host exists
-        3. QE environment of cv1 was replaced by DEV environment of cv1
-           in activation key
-        4. QE environment of cv1 was replaced by DEV environment of cv1
-           in content-host
-        5. At content-host some package from cv1 is installable
+            1. Activation key exists
+            2. Content-host exists
+            3. QE environment of cv1 was replaced by DEV environment of cv1 in
+               activation key
+            4. QE environment of cv1 was replaced by DEV environment of cv1 in
+               content-host
+            5. At content-host some package from cv1 is installable
 
-        @caseautomation: notautomated
+        :caseautomation: notautomated
 
-        @CaseLevel: System
+        :CaseLevel: System
         """
 
     @stubbed()
@@ -3274,36 +3273,37 @@ class ContentViewTestCase(CLITestCase):
          environments, with one of the environments used in association of an
          Activation key and content-host registration.
 
-        @id: 82442d23-45b5-4d39-b867-c5d46bbcbbf9
+        :id: 82442d23-45b5-4d39-b867-c5d46bbcbbf9
 
-        @Steps:
+        :Steps:
 
-        1. Create two content view cv1 and cv2
-        2. Add a yum repo and a puppet module to both content views
-        3. Publish the content views
-        4. Promote the content views to multiple environment
-           Library -> DEV -> QE
-        5. Create an Activation key with the QE environment and cv1
-        6. Register a content-host using the Activation key
-        7. Delete the content view cv1.
-           Note - prior deleting replace the current QE environment of cv1 by
-           DEV and content view cv2 for Content-host and for Activation key.
-        8. Refresh content-host subscription
+            1. Create two content view cv1 and cv2
+            2. Add a yum repo and a puppet module to both content views
+            3. Publish the content views
+            4. Promote the content views to multiple environment Library -> DEV
+               -> QE
+            5. Create an Activation key with the QE environment and cv1
+            6. Register a content-host using the Activation key
+            7. Delete the content view cv1.
+               Note - prior deleting replace the current QE environment of cv1
+               by DEV and content view cv2 for Content-host and for Activation
+               key.
+            8. Refresh content-host subscription
 
-        @Assert:
+        :Assert:
 
-        1. The content view cv1 doesn't exist
-        2. Activation key exists
-        3. Content-host exists
-        4. QE environment of cv1 was replaced by DEV environment of cv2
-           in activation key
-        5. QE environment of cv1 was replaced by DEV environment of cv2
-           in content-host
-        6. At content-host some package from cv2 is installable
+            1. The content view cv1 doesn't exist
+            2. Activation key exists
+            3. Content-host exists
+            4. QE environment of cv1 was replaced by DEV environment of cv2 in
+               activation key
+            5. QE environment of cv1 was replaced by DEV environment of cv2 in
+               content-host
+            6. At content-host some package from cv2 is installable
 
-        @caseautomation: notautomated
+        :caseautomation: notautomated
 
-        @CaseLevel: System
+        :CaseLevel: System
         """
 
     @stubbed()
@@ -3313,33 +3313,34 @@ class ContentViewTestCase(CLITestCase):
         """Remove promoted content view version from multiple environment,
         with satellite setup to use capsule
 
-        @id: 3725fef6-73a4-4dcb-a306-70e6ba826a3d
+        :id: 3725fef6-73a4-4dcb-a306-70e6ba826a3d
 
-        @Steps:
+        :Steps:
 
-        1. Create a content view
-        2. Setup satellite to use a capsule and to sync all lifecycle
-           environments
-        3. Add a yum repo, puppet module and a docker repo to the content view
-        4. Publish the content view
-        5. Promote the content view to multiple environment
-           Library -> DEV -> QE -> PROD
-        6. Make sure the capsule is updated (content synchronization may be
-           applied)
-        7. Disconnect the capsule
-        8. Remove the content view version from Library and DEV environments
-           and assert successful completion
-        9. Bring the capsule back online and assert that the task is completed
-           in capsule
-        10. Make sure the capsule is updated (content synchronization may be
-            applied)
+            1. Create a content view
+            2. Setup satellite to use a capsule and to sync all lifecycle
+               environments
+            3. Add a yum repo, puppet module and a docker repo to the content
+               view
+            4. Publish the content view
+            5. Promote the content view to multiple environment Library -> DEV
+               -> QE -> PROD
+            6. Make sure the capsule is updated (content synchronization may be
+               applied)
+            7. Disconnect the capsule
+            8. Remove the content view version from Library and DEV
+               environments and assert successful completion
+            9. Bring the capsule back online and assert that the task is
+               completed in capsule
+            10. Make sure the capsule is updated (content synchronization may
+                be applied)
 
-        @Assert: content view version in capsule is removed from Library
-        and DEV and exists only in QE and PROD
+        :Assert: content view version in capsule is removed from Library and
+            DEV and exists only in QE and PROD
 
-        @caseautomation: notautomated
+        :caseautomation: notautomated
 
-        @CaseLevel: System
+        :CaseLevel: System
         """
         # Note: This test case requires complete external capsule
         #  configuration.
@@ -3352,12 +3353,12 @@ class ContentViewTestCase(CLITestCase):
     def test_negative_user_with_no_create_view_cv_permissions(self):
         """Unauthorized users are not able to create/view content views
 
-        @id: 17617893-27c2-4cb2-a2ed-47378ef90e7a
+        :id: 17617893-27c2-4cb2-a2ed-47378ef90e7a
 
-        @setup: Create a user without the Content View create/view permissions
+        :setup: Create a user without the Content View create/view permissions
 
-        @assert: User with no content view create/view permissions cannot
-        create or view the content view
+        :assert: User with no content view create/view permissions cannot
+            create or view the content view
         """
         password = gen_alphanumeric()
         no_rights_user = make_user({'password': password})
@@ -3390,14 +3391,14 @@ class ContentViewTestCase(CLITestCase):
     def test_negative_user_with_read_only_cv_permission(self):
         """Read-only user is able to view content view
 
-        @id: 588f57b5-9855-4c14-80d0-64b617c6b6dc
+        :id: 588f57b5-9855-4c14-80d0-64b617c6b6dc
 
-        @setup: create a user with the Content View read-only role
+        :setup: create a user with the Content View read-only role
 
-        @assert: User with read-only role for content view can view the content
-        view but not Create / Modify / Promote / Publish
+        :assert: User with read-only role for content view can view the content
+            view but not Create / Modify / Promote / Publish
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         cv = make_content_view({'organization-id': self.org['id']})
         password = gen_string('alphanumeric')
@@ -3445,14 +3446,14 @@ class ContentViewTestCase(CLITestCase):
         """A user with all content view permissions is able to create,
         read, modify, promote, publish content views
 
-        @id: ac40e9bb-9f1a-48d1-a0fe-9ac2be0f33f4
+        :id: ac40e9bb-9f1a-48d1-a0fe-9ac2be0f33f4
 
-        @setup: create a user with all content view permissions
+        :setup: create a user with all content view permissions
 
-        @assert: User is able to perform create, read, modify, promote, publish
-        content view
+        :assert: User is able to perform create, read, modify, promote, publish
+            content view
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         cv = make_content_view({'organization-id': self.org['id']})
         password = gen_string('alphanumeric')
@@ -3555,11 +3556,11 @@ class OstreeContentViewTestCase(CLITestCase):
     def test_positive_add_custom_ostree_content(self):
         """Associate custom ostree content in a view
 
-        @id: 6e89094d-ffd3-4dc6-b925-f76531c56c20
+        :id: 6e89094d-ffd3-4dc6-b925-f76531c56c20
 
-        @Assert: Custom ostree content assigned and present in content view
+        :Assert: Custom ostree content assigned and present in content view
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         # Create CV
         cv = make_content_view({u'organization-id': self.org['id']})
@@ -3582,11 +3583,11 @@ class OstreeContentViewTestCase(CLITestCase):
     def test_positive_publish_custom_ostree(self):
         """Publish a content view with custom ostree contents
 
-        @id: ec66f1d3-9750-4dfc-a189-f3b0fd6af3e8
+        :id: ec66f1d3-9750-4dfc-a189-f3b0fd6af3e8
 
-        @Assert: Content-view with Custom ostree published successfully
+        :Assert: Content-view with Custom ostree published successfully
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         cv = make_content_view({u'organization-id': self.org['id']})
         # Associate repo to CV with names.
@@ -3604,11 +3605,11 @@ class OstreeContentViewTestCase(CLITestCase):
     def test_positive_promote_custom_ostree(self):
         """Promote a content view with custom ostree contents
 
-        @id: 5eb7b9e6-8757-4152-9114-42a5eb021bbc
+        :id: 5eb7b9e6-8757-4152-9114-42a5eb021bbc
 
-        @Assert: Content-view with custom ostree contents promoted successfully
+        :Assert: Content-view with custom ostree contents promoted successfully
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         cv = make_content_view({u'organization-id': self.org['id']})
         # Associate repo to CV with names.
@@ -3636,12 +3637,12 @@ class OstreeContentViewTestCase(CLITestCase):
     def test_positive_publish_promote_with_custom_ostree_and_other(self):
         """Publish & Promote a content view with custom ostree and other contents
 
-        @id: 35668fa6-0a24-43ae-b562-26c5ac77e94d
+        :id: 35668fa6-0a24-43ae-b562-26c5ac77e94d
 
-        @Assert: Content-view with custom ostree and other contents promoted
-        successfully
+        :Assert: Content-view with custom ostree and other contents promoted
+            successfully
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         cv = make_content_view({u'organization-id': self.org['id']})
         # Associate repo to CV with names.
@@ -3737,11 +3738,11 @@ class ContentViewRedHatOstreeContent(CLITestCase):
     def test_positive_add_rh_ostree_content(self):
         """Associate RH atomic ostree content in a view
 
-        @id: 5e9dfb32-9cc7-4257-ab6b-f439fb9db2bd
+        :id: 5e9dfb32-9cc7-4257-ab6b-f439fb9db2bd
 
-        @Assert: RH atomic ostree content assigned and present in content view
+        :Assert: RH atomic ostree content assigned and present in content view
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         cv = make_content_view({u'organization-id': self.org['id']})
         # Associate repo to CV with names.
@@ -3762,11 +3763,11 @@ class ContentViewRedHatOstreeContent(CLITestCase):
     def test_positive_publish_RH_ostree(self):
         """Publish a content view with RH ostree contents
 
-        @id: 4ac5c7d1-9ab2-4a65-b4b8-1582b001125f
+        :id: 4ac5c7d1-9ab2-4a65-b4b8-1582b001125f
 
-        @Assert: Content-view with RH ostree contents published successfully
+        :Assert: Content-view with RH ostree contents published successfully
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         cv = make_content_view({u'organization-id': self.org['id']})
         # Associate repo to CV with names.
@@ -3784,11 +3785,11 @@ class ContentViewRedHatOstreeContent(CLITestCase):
     def test_positive_promote_RH_ostree(self):
         """Promote a content view with RH ostree contents
 
-        @id: 71986705-fe45-4e0f-af0b-288c9c7ce61b
+        :id: 71986705-fe45-4e0f-af0b-288c9c7ce61b
 
-        @Assert: Content-view with RH ostree contents promoted successfully
+        :Assert: Content-view with RH ostree contents promoted successfully
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         cv = make_content_view({u'organization-id': self.org['id']})
         # Associate repo to CV with names.
@@ -3816,12 +3817,12 @@ class ContentViewRedHatOstreeContent(CLITestCase):
     def test_positive_publish_promote_with_RH_ostree_and_other(self):
         """Publish & Promote a content view with RH ostree and other contents
 
-        @id: 87c8ddb1-da32-4103-810d-8e5e28fa888f
+        :id: 87c8ddb1-da32-4103-810d-8e5e28fa888f
 
-        @Assert: Content-view with RH ostree and other contents promoted
-        successfully
+        :Assert: Content-view with RH ostree and other contents promoted
+            successfully
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         RepositorySet.enable({
             'name': REPOSET['rhst7'],

--- a/tests/foreman/cli/test_contentviewfilter.py
+++ b/tests/foreman/cli/test_contentviewfilter.py
@@ -1,19 +1,19 @@
 # -*- encoding: utf-8 -*-
 """Test class for Content View Filters
 
-@Requirement: Contentviewfilter
+:Requirement: Contentviewfilter
 
-@CaseAutomation: Automated
+:CaseAutomation: Automated
 
-@CaseLevel: Acceptance
+:CaseLevel: Acceptance
 
-@CaseComponent: CLI
+:CaseComponent: CLI
 
-@TestType: Functional
+:TestType: Functional
 
-@CaseImportance: High
+:CaseImportance: High
 
-@Upstream: No
+:Upstream: No
 """
 
 from fauxfactory import gen_choice, gen_string
@@ -59,10 +59,10 @@ class ContentViewFilterTestCase(CLITestCase):
         view by id. Use different value types as a name and random filter
         content type as a parameter for this filter
 
-        @id: 2cfdf72e-179d-4bba-8aab-288594cac836
+        :id: 2cfdf72e-179d-4bba-8aab-288594cac836
 
-        @Assert: Content view filter created successfully and has correct and
-        expected parameters
+        :Assert: Content view filter created successfully and has correct and
+            expected parameters
 
         """
         for name in valid_data_list():
@@ -90,10 +90,10 @@ class ContentViewFilterTestCase(CLITestCase):
         """Create new content view filter and assign it to existing content
         view by id. Use different content types as a parameter
 
-        @id: b3e5a58b-eddc-4ceb-ae34-6c0ab5664784
+        :id: b3e5a58b-eddc-4ceb-ae34-6c0ab5664784
 
-        @Assert: Content view filter created successfully and has correct and
-        expected parameters
+        :Assert: Content view filter created successfully and has correct and
+            expected parameters
 
         """
         for filter_content_type in ('rpm', 'package_group', 'erratum'):
@@ -116,10 +116,10 @@ class ContentViewFilterTestCase(CLITestCase):
         """Create new content view filter and assign it to existing content
         view by id. Use different inclusions as a parameter
 
-        @id: 4a18ee71-3f0d-4e8b-909e-999d722ebc0a
+        :id: 4a18ee71-3f0d-4e8b-909e-999d722ebc0a
 
-        @Assert: Content view filter created successfully and has correct and
-        expected parameters
+        :Assert: Content view filter created successfully and has correct and
+            expected parameters
 
         """
         for inclusion in ('true', 'false'):
@@ -143,10 +143,10 @@ class ContentViewFilterTestCase(CLITestCase):
         """Create new content view filter with description and assign it to
         existing content view.
 
-        @id: e283a42a-122b-467c-8d00-d6487f657692
+        :id: e283a42a-122b-467c-8d00-d6487f657692
 
-        @Assert: Content view filter created successfully and has proper
-        description
+        :Assert: Content view filter created successfully and has proper
+            description
 
         """
         description = gen_string('utf8')
@@ -170,11 +170,11 @@ class ContentViewFilterTestCase(CLITestCase):
         """Create new content view filter and assign it to existing content
         view by name. Use organization id for reference
 
-        @id: 0fb2fbc2-0d81-451e-9b20-9e996e14c977
+        :id: 0fb2fbc2-0d81-451e-9b20-9e996e14c977
 
-        @Assert: Content view filter created successfully
+        :Assert: Content view filter created successfully
 
-        @BZ: 1356906
+        :BZ: 1356906
         """
         cvf_name = gen_string('utf8')
         ContentView.filter.create({
@@ -194,9 +194,9 @@ class ContentViewFilterTestCase(CLITestCase):
         """Create new content view filter and assign it to existing content
         view by name. Use organization name for reference
 
-        @id: 295847fe-51e4-483d-af2f-b972c8b5064c
+        :id: 295847fe-51e4-483d-af2f-b972c8b5064c
 
-        @Assert: Content view filter created successfully
+        :Assert: Content view filter created successfully
 
         """
         cvf_name = gen_string('utf8')
@@ -217,9 +217,9 @@ class ContentViewFilterTestCase(CLITestCase):
         """Create new content view filter and assign it to existing content
         view by name. Use organization label for reference
 
-        @id: f233e223-c08c-4ce1-b87a-9e055fdd7b83
+        :id: f233e223-c08c-4ce1-b87a-9e055fdd7b83
 
-        @Assert: Content view filter created successfully
+        :Assert: Content view filter created successfully
 
         """
         cvf_name = gen_string('utf8')
@@ -241,10 +241,10 @@ class ContentViewFilterTestCase(CLITestCase):
         view that has repository assigned to it. Use that repository id for
         proper filter assignment.
 
-        @id: 6d517e09-6a6a-4eed-91fe-9459610c0062
+        :id: 6d517e09-6a6a-4eed-91fe-9459610c0062
 
-        @Assert: Content view filter created successfully and has proper
-        repository affected
+        :Assert: Content view filter created successfully and has proper
+            repository affected
         """
         cvf_name = gen_string('utf8')
         ContentView.filter.create({
@@ -269,12 +269,12 @@ class ContentViewFilterTestCase(CLITestCase):
         view that has repository assigned to it. Use that repository name for
         proper filter assignment.
 
-        @id: 1b38c7c1-c8cd-49af-adcf-9e05a9201767
+        :id: 1b38c7c1-c8cd-49af-adcf-9e05a9201767
 
-        @Assert: Content view filter created successfully and has proper
-        repository affected
+        :Assert: Content view filter created successfully and has proper
+            repository affected
 
-        @BZ: 1228890
+        :BZ: 1228890
         """
         cvf_name = gen_string('utf8')
         ContentView.filter.create({
@@ -299,10 +299,10 @@ class ContentViewFilterTestCase(CLITestCase):
         view that has repository assigned to it. Enable 'original packages'
         option for that filter
 
-        @id: 5491233a-9361-435f-87ad-dca97e6d5d2f
+        :id: 5491233a-9361-435f-87ad-dca97e6d5d2f
 
-        @Assert: Content view filter created successfully and has proper
-        repository affected
+        :Assert: Content view filter created successfully and has proper
+            repository affected
 
         """
         cvf_name = gen_string('utf8')
@@ -327,10 +327,10 @@ class ContentViewFilterTestCase(CLITestCase):
         it to mentioned content view. Use these repositories id for proper
         filter assignment.
 
-        @id: 8419a5fa-0530-42a7-964c-7c513443c5c8
+        :id: 8419a5fa-0530-42a7-964c-7c513443c5c8
 
-        @Assert: Content view filter created successfully and has both
-        repositories affected (yum and docker)
+        :Assert: Content view filter created successfully and has both
+            repositories affected (yum and docker)
 
         """
         docker_repository = make_repository({
@@ -365,9 +365,9 @@ class ContentViewFilterTestCase(CLITestCase):
     def test_negative_create_with_invalid_name(self):
         """Try to create content view filter using invalid names only
 
-        @id: f3497a23-6e34-4fee-9964-f95762fc737c
+        :id: f3497a23-6e34-4fee-9964-f95762fc737c
 
-        @Assert: Content view filter is not created
+        :Assert: Content view filter is not created
 
         """
         for name in invalid_values_list():
@@ -384,9 +384,9 @@ class ContentViewFilterTestCase(CLITestCase):
     def test_negative_create_with_same_name(self):
         """Try to create content view filter using same name twice
 
-        @id: 7e7444f4-e2b5-406d-a210-49b4008c88d9
+        :id: 7e7444f4-e2b5-406d-a210-49b4008c88d9
 
-        @Assert: Second content view filter is not created
+        :Assert: Second content view filter is not created
 
         """
         cvf_name = gen_string('utf8')
@@ -409,9 +409,9 @@ class ContentViewFilterTestCase(CLITestCase):
         """Try to create content view filter without providing required
         parameter 'type'
 
-        @id: 8af65427-d0f0-4661-b062-93e054079f44
+        :id: 8af65427-d0f0-4661-b062-93e054079f44
 
-        @Assert: Content view filter is not created
+        :Assert: Content view filter is not created
 
         """
         with self.assertRaises(CLIReturnCodeError):
@@ -426,9 +426,9 @@ class ContentViewFilterTestCase(CLITestCase):
         """Try to create content view filter without providing content
         view information which should be used as basis for filter
 
-        @id: 4ed3828e-52e8-457c-a2af-bb03b00467e8
+        :id: 4ed3828e-52e8-457c-a2af-bb03b00467e8
 
-        @Assert: Content view filter is not created
+        :Assert: Content view filter is not created
 
         """
         with self.assertRaises(CLIReturnCodeError):
@@ -441,9 +441,9 @@ class ContentViewFilterTestCase(CLITestCase):
     def test_negative_create_with_invalid_repo_id(self):
         """Try to create content view filter using incorrect repository
 
-        @id: 21fdbeca-ad0a-4e29-93dc-f850b5639f4f
+        :id: 21fdbeca-ad0a-4e29-93dc-f850b5639f4f
 
-        @Assert: Content view filter is not created
+        :Assert: Content view filter is not created
 
         """
         with self.assertRaises(CLIReturnCodeError):
@@ -461,13 +461,13 @@ class ContentViewFilterTestCase(CLITestCase):
         view by id. Try to update that filter using different value types as a
         name
 
-        @id: 70ba8916-5898-4911-9de8-21d2e0fb3df9
+        :id: 70ba8916-5898-4911-9de8-21d2e0fb3df9
 
-        @Assert: Content view filter updated successfully and has proper and
-        expected name
+        :Assert: Content view filter updated successfully and has proper and
+            expected name
 
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         cvf_name = gen_string('utf8')
         cvf = make_content_view_filter({
@@ -496,13 +496,13 @@ class ContentViewFilterTestCase(CLITestCase):
         that has repository assigned to it. Try to update that filter and
         change affected repository on another one.
 
-        @id: b2f444fd-e65e-41ba-9941-620d3cdb260f
+        :id: b2f444fd-e65e-41ba-9941-620d3cdb260f
 
-        @Assert: Content view filter updated successfully and has new
-        repository affected
+        :Assert: Content view filter updated successfully and has new
+            repository affected
 
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         cvf_name = gen_string('utf8')
         ContentView.filter.create({
@@ -545,13 +545,12 @@ class ContentViewFilterTestCase(CLITestCase):
         change affected repository on another one. That new repository should
         have another type from initial one (e.g. yum->docker)
 
-        @id: cf3daa0d-e918-4330-95ad-f88933579829
+        :id: cf3daa0d-e918-4330-95ad-f88933579829
 
-        @Assert: Content view filter updated successfully and has new
-        repository affected
+        :Assert: Content view filter updated successfully and has new
+            repository affected
 
-
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         cvf_name = gen_string('utf8')
         ContentView.filter.create({
@@ -595,13 +594,13 @@ class ContentViewFilterTestCase(CLITestCase):
         view by id. Try to update that filter and assign opposite inclusion
         value for it
 
-        @id: 76b3c66d-8200-4cf0-8cd0-b57de4ff12b0
+        :id: 76b3c66d-8200-4cf0-8cd0-b57de4ff12b0
 
-        @Assert: Content view filter updated successfully and has correct and
-        expected value for inclusion parameter
+        :Assert: Content view filter updated successfully and has correct and
+            expected value for inclusion parameter
 
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         cvf_name = gen_string('utf8')
         ContentView.filter.create({
@@ -631,11 +630,11 @@ class ContentViewFilterTestCase(CLITestCase):
     def test_negative_update_with_name(self):
         """Try to update content view filter using invalid names only
 
-        @id: 6c40e452-f786-4e28-9f03-b1935b55b33a
+        :id: 6c40e452-f786-4e28-9f03-b1935b55b33a
 
-        @Assert: Content view filter is not updated
+        :Assert: Content view filter is not updated
 
-        @BZ: 1328943
+        :BZ: 1328943
         """
         cvf_name = gen_string('utf8')
         content_view_filter = ContentView.filter.create({
@@ -671,9 +670,9 @@ class ContentViewFilterTestCase(CLITestCase):
         """Try to update content view filter using name of already
         existing entity
 
-        @id: 9c1b1c75-af57-4218-9e2d-e69d74f50e04
+        :id: 9c1b1c75-af57-4218-9e2d-e69d74f50e04
 
-        @Assert: Content view filter is not updated
+        :Assert: Content view filter is not updated
 
         """
         cvf_name = gen_string('utf8')
@@ -702,9 +701,9 @@ class ContentViewFilterTestCase(CLITestCase):
         """Try to update content view filter and assign incorrect inclusion
         value for it
 
-        @id: 760400a8-49a5-4a31-924c-c232cb22ddad
+        :id: 760400a8-49a5-4a31-924c-c232cb22ddad
 
-        @Assert: Content view filter is not updated
+        :Assert: Content view filter is not updated
 
         """
         cvf_name = gen_string('utf8')
@@ -731,9 +730,9 @@ class ContentViewFilterTestCase(CLITestCase):
     def test_negative_update_with_non_existent_repo_id(self):
         """Try to update content view filter using non-existing repository ID
 
-        @id: 457af8c2-fb32-4164-9e19-98676f4ea063
+        :id: 457af8c2-fb32-4164-9e19-98676f4ea063
 
-        @Assert: Content view filter is not updated
+        :Assert: Content view filter is not updated
 
         """
         cvf_name = gen_string('utf8')
@@ -755,9 +754,9 @@ class ContentViewFilterTestCase(CLITestCase):
         """Try to update filter and assign repository which does not belong to
         filter content view
 
-        @id: aa550619-c436-4184-bb29-2becadf69e5b
+        :id: aa550619-c436-4184-bb29-2becadf69e5b
 
-        @Assert: Content view filter is not updated
+        :Assert: Content view filter is not updated
 
         """
         cvf_name = gen_string('utf8')
@@ -781,9 +780,9 @@ class ContentViewFilterTestCase(CLITestCase):
         view by id. Try to delete that filter using different value types as a
         name
 
-        @id: a01baf17-9c3c-4923-bfe0-865a4cbc4223
+        :id: a01baf17-9c3c-4923-bfe0-865a4cbc4223
 
-        @Assert: Content view filter deleted successfully
+        :Assert: Content view filter deleted successfully
 
         """
         for name in valid_data_list():
@@ -813,9 +812,9 @@ class ContentViewFilterTestCase(CLITestCase):
         """Create new content view filter and assign it to existing content
         view by id. Try to delete that filter using its id as a parameter
 
-        @id: e3865a11-1ba0-481a-bfe0-f9235901946d
+        :id: e3865a11-1ba0-481a-bfe0-f9235901946d
 
-        @Assert: Content view filter deleted successfully
+        :Assert: Content view filter deleted successfully
 
         """
         cvf_name = gen_string('utf8')
@@ -843,9 +842,9 @@ class ContentViewFilterTestCase(CLITestCase):
         view by id. Try to delete that filter using organization and content
         view names where that filter was applied
 
-        @id: 61b25ae5-98d5-4b7d-9197-2b1935054a92
+        :id: 61b25ae5-98d5-4b7d-9197-2b1935054a92
 
-        @Assert: Content view filter deleted successfully
+        :Assert: Content view filter deleted successfully
 
         """
         cvf_name = gen_string('utf8')
@@ -874,9 +873,9 @@ class ContentViewFilterTestCase(CLITestCase):
     def test_negative_delete_by_name(self):
         """Try to delete non-existent filter using generated name
 
-        @id: 84509061-6652-4594-b68a-4566c04bc289
+        :id: 84509061-6652-4594-b68a-4566c04bc289
 
-        @Assert: System returned error
+        :Assert: System returned error
 
         """
         with self.assertRaises(CLIReturnCodeError):

--- a/tests/foreman/cli/test_discoveredhost.py
+++ b/tests/foreman/cli/test_discoveredhost.py
@@ -1,19 +1,19 @@
 # -*- encoding: utf-8 -*-
 """Test class for CLI Foreman Discovery
 
-@Requirement: Discoveredhost
+:Requirement: Discoveredhost
 
-@CaseAutomation: Automated
+:CaseAutomation: Automated
 
-@CaseLevel: Acceptance
+:CaseLevel: Acceptance
 
-@CaseComponent: CLI
+:CaseComponent: CLI
 
-@TestType: Functional
+:TestType: Functional
 
-@CaseImportance: High
+:CaseImportance: High
 
-@Upstream: No
+:Upstream: No
 """
 from robottelo.cli.base import CLIReturnCodeError
 from robottelo.cli.discoveredhost import DiscoveredHost
@@ -121,15 +121,15 @@ class DiscoveredTestCase(CLITestCase):
         """Discover a host via PXE boot by setting "proxy.type=proxy" in
         PXE default
 
-        @id: 25e935fe-18f4-477e-b791-7ea5a395b4f6
+        :id: 25e935fe-18f4-477e-b791-7ea5a395b4f6
 
-        @Setup: Provisioning should be configured
+        :Setup: Provisioning should be configured
 
-        @Steps: PXE boot a host/VM
+        :Steps: PXE boot a host/VM
 
-        @Assert: Host should be successfully discovered
+        :Assert: Host should be successfully discovered
 
-        @CaseLevel: System
+        :CaseLevel: System
         """
         with LibvirtGuest() as pxe_host:
             hostname = pxe_host.guest_name
@@ -142,15 +142,15 @@ class DiscoveredTestCase(CLITestCase):
         """Discover a host with dhcp via bootable discovery ISO by setting
         "proxy.type=proxy" in PXE default in unattended mode.
 
-        @id: a23bd065-8385-4876-aa45-e38470be79b8
+        :id: a23bd065-8385-4876-aa45-e38470be79b8
 
-        @Setup: Provisioning should be configured
+        :Setup: Provisioning should be configured
 
-        @Steps: Boot a host/VM using modified discovery ISO.
+        :Steps: Boot a host/VM using modified discovery ISO.
 
-        @Assert: Host should be successfully discovered
+        :Assert: Host should be successfully discovered
 
-        @CaseLevel: System
+        :CaseLevel: System
         """
         with LibvirtGuest(boot_iso=True) as pxe_less_host:
             hostname = pxe_less_host.guest_name
@@ -164,21 +164,20 @@ class DiscoveredTestCase(CLITestCase):
         """Check if defined custom facts of pxeless host are correctly
         displayed under host's facts
 
-        @id: 0d39f2cc-654f-41ed-8e31-4d9a37c5b9b1
+        :id: 0d39f2cc-654f-41ed-8e31-4d9a37c5b9b1
 
-        @Setup:
+        :Setup:
 
-        1. Provisioning should be configured
+            1. Provisioning should be configured
+            2. Host is already discovered
 
-        2. Host is already discovered
+        :Steps: Validate specified custom facts
 
-        @Steps: Validate specified custom facts
+        :Assert: All defined custom facts should be displayed correctly
 
-        @Assert: All defined custom facts should be displayed correctly
+        :caseautomation: notautomated
 
-        @caseautomation: notautomated
-
-        @CaseLevel: System
+        :CaseLevel: System
         """
 
     @run_only_on('sat')
@@ -188,21 +187,20 @@ class DiscoveredTestCase(CLITestCase):
         """Check if defined custom facts of pxe-based discovered host are
         correctly displayed under host's facts
 
-        @id: 2c65925c-05d9-4f6d-b1b7-1fa1492c95a8
+        :id: 2c65925c-05d9-4f6d-b1b7-1fa1492c95a8
 
-        @Setup:
+        :Setup:
 
-        1. Provisioning should be configured
+            1. Provisioning should be configured
+            2. Host is already discovered
 
-        2. Host is already discovered
+        :Steps: Validate specified custom facts
 
-        @Steps: Validate specified custom facts
+        :Assert: All defined custom facts should be displayed correctly
 
-        @Assert: All defined custom facts should be displayed correctly
+        :caseautomation: notautomated
 
-        @caseautomation: notautomated
-
-        @CaseLevel: System
+        :CaseLevel: System
         """
 
     @run_only_on('sat')
@@ -210,14 +208,14 @@ class DiscoveredTestCase(CLITestCase):
     def test_positive_provision_pxeless_host(self):
         """Provision the pxe-less discovered host from cli
 
-        @id: ae7f3ce2-e66e-44dc-85cb-0c3c4782cbb1
+        :id: ae7f3ce2-e66e-44dc-85cb-0c3c4782cbb1
 
-        @Setup: Host should already be discovered
+        :Setup: Host should already be discovered
 
-        @Assert: Host should be provisioned successfully and entry from
-        discovered host list should be auto removed
+        :Assert: Host should be provisioned successfully and entry from
+            discovered host list should be auto removed
 
-        @CaseLevel: System
+        :CaseLevel: System
         """
         if not self.configured_env:
             self.configured_env = configure_env_for_provision(
@@ -260,14 +258,14 @@ class DiscoveredTestCase(CLITestCase):
     def test_positive_provision_pxe_host(self):
         """Provision the pxe based discovered host from cli
 
-        @id: b5385fe3-d532-4373-af64-5492275ff8d4
+        :id: b5385fe3-d532-4373-af64-5492275ff8d4
 
-        @Setup: Host should already be discovered
+        :Setup: Host should already be discovered
 
-        @Assert: Host should be provisioned successfully and entry from
-        discovered host list should be automatically removed.
+        :Assert: Host should be provisioned successfully and entry from
+            discovered host list should be automatically removed.
 
-        @CaseLevel: System
+        :CaseLevel: System
         """
         if not self.configured_env:
             self.configured_env = configure_env_for_provision(
@@ -310,13 +308,13 @@ class DiscoveredTestCase(CLITestCase):
     def test_positive_delete_pxeless_host(self):
         """Delete the selected pxe-less discovered host
 
-        @id: 3959abd7-a1c0-418f-a75a-dec06b5ea0e2
+        :id: 3959abd7-a1c0-418f-a75a-dec06b5ea0e2
 
-        @Setup: Host should already be discovered
+        :Setup: Host should already be discovered
 
-        @Assert: Selected host should be removed successfully
+        :Assert: Selected host should be removed successfully
 
-        @CaseLevel: System
+        :CaseLevel: System
         """
         with LibvirtGuest(boot_iso=True) as pxe_less_host:
             hostname = pxe_less_host.guest_name
@@ -331,13 +329,13 @@ class DiscoveredTestCase(CLITestCase):
     def test_positive_delete_pxe_host(self):
         """Delete the selected pxe-based discovered host
 
-        @id: c4103de8-145c-4a7d-b837-a1dec97231a2
+        :id: c4103de8-145c-4a7d-b837-a1dec97231a2
 
-        @Setup: Host should already be discovered
+        :Setup: Host should already be discovered
 
-        @Assert: Selected host should be removed successfully
+        :Assert: Selected host should be removed successfully
 
-        @CaseLevel: System
+        :CaseLevel: System
         """
         with LibvirtGuest() as pxe_host:
             hostname = pxe_host.guest_name
@@ -353,15 +351,15 @@ class DiscoveredTestCase(CLITestCase):
     def test_positive_refresh_facts_pxe_host(self):
         """Refresh the facts of pxe based discovered hosts by adding a new NIC
 
-        @id: 410eaa5d-cc6a-44f7-8c6f-e8cfa81610f0
+        :id: 410eaa5d-cc6a-44f7-8c6f-e8cfa81610f0
 
-        @Setup: Host should already be discovered
+        :Setup: Host should already be discovered
 
-        @Assert: Facts should be refreshed successfully with a new NIC
+        :Assert: Facts should be refreshed successfully with a new NIC
 
-        @caseautomation: notautomated
+        :caseautomation: notautomated
 
-        @CaseLevel: System
+        :CaseLevel: System
         """
 
     @run_only_on('sat')
@@ -370,15 +368,15 @@ class DiscoveredTestCase(CLITestCase):
     def test_positive_refresh_facts_of_pxeless_host(self):
         """Refresh the facts of pxeless discovered hosts by adding a new NIC
 
-        @id: 2e199eaa-9651-47b1-a2fd-622778dfe68e
+        :id: 2e199eaa-9651-47b1-a2fd-622778dfe68e
 
-        @Setup: Host should already be discovered
+        :Setup: Host should already be discovered
 
-        @Assert: Facts should be refreshed successfully with a new NIC
+        :Assert: Facts should be refreshed successfully with a new NIC
 
-        @caseautomation: notautomated
+        :caseautomation: notautomated
 
-        @CaseLevel: System
+        :CaseLevel: System
         """
 
     @run_only_on('sat')
@@ -387,15 +385,15 @@ class DiscoveredTestCase(CLITestCase):
     def test_positive_reboot_pxe_host(self):
         """Reboot pxe based discovered hosts
 
-        @id: 9cc17742-f810-4be7-b410-a6c68e6cc64a
+        :id: 9cc17742-f810-4be7-b410-a6c68e6cc64a
 
-        @Setup: Host should already be discovered
+        :Setup: Host should already be discovered
 
-        @Assert: Host is rebooted
+        :Assert: Host is rebooted
 
-        @caseautomation: notautomated
+        :caseautomation: notautomated
 
-        @CaseLevel: System
+        :CaseLevel: System
         """
 
     @run_only_on('sat')
@@ -404,15 +402,15 @@ class DiscoveredTestCase(CLITestCase):
     def test_positive_reboot_pxeless_host(self):
         """Reboot pxe-less discovered hosts
 
-        @id: e72e1607-8778-45b6-b8b9-8215514546f0
+        :id: e72e1607-8778-45b6-b8b9-8215514546f0
 
-        @Setup: PXELess host should already be discovered
+        :Setup: PXELess host should already be discovered
 
-        @Assert: Host is rebooted
+        :Assert: Host is rebooted
 
-        @caseautomation: notautomated
+        :caseautomation: notautomated
 
-        @CaseLevel: System
+        :CaseLevel: System
         """
 
     @run_only_on('sat')
@@ -422,13 +420,13 @@ class DiscoveredTestCase(CLITestCase):
         """Discover a pxe based host and auto-provision it with
         discovery rule and by enabling auto-provision flag
 
-        @id: 701a1892-1c6a-4ba1-bbd8-a37b7fb02fa0
+        :id: 701a1892-1c6a-4ba1-bbd8-a37b7fb02fa0
 
-        @Assert: Host should be successfully rebooted and provisioned
+        :Assert: Host should be successfully rebooted and provisioned
 
-        @caseautomation: notautomated
+        :caseautomation: notautomated
 
-        @CaseLevel: System
+        :CaseLevel: System
         """
 
     @run_only_on('sat')
@@ -438,13 +436,13 @@ class DiscoveredTestCase(CLITestCase):
         """Discover a pxe-less host and auto-provision it with
         discovery rule and by enabling auto-provision flag
 
-        @id: 298417b3-d242-4999-89f9-198095704c0e
+        :id: 298417b3-d242-4999-89f9-198095704c0e
 
-        @Assert: Host should be successfully rebooted and provisioned
+        :Assert: Host should be successfully rebooted and provisioned
 
-        @caseautomation: notautomated
+        :caseautomation: notautomated
 
-        @CaseLevel: System
+        :CaseLevel: System
         """
 
     @run_only_on('sat')
@@ -453,13 +451,13 @@ class DiscoveredTestCase(CLITestCase):
     def test_positive_list_discovered_host(self):
         """List pxe-based and pxe-less discovered hosts
 
-        @id: 3a827080-3fab-4f64-a830-1b41841aa2df
+        :id: 3a827080-3fab-4f64-a830-1b41841aa2df
 
-        @Assert: Host should be discovered and listed with names.
+        :Assert: Host should be discovered and listed with names.
 
-        @caseautomation: notautomated
+        :caseautomation: notautomated
 
-        @CaseLevel: System
+        :CaseLevel: System
         """
 
     @run_only_on('sat')
@@ -468,15 +466,15 @@ class DiscoveredTestCase(CLITestCase):
     def test_positive_assign_discovery_manager_role(self):
         """Assign 'Discovery_Manager' role to a normal user
 
-        @id: f694c361-5fbb-4c3a-b2ff-6dfe6ea14820
+        :id: f694c361-5fbb-4c3a-b2ff-6dfe6ea14820
 
-        @Assert: User should be able to view, provision, edit and destroy one
-        or more discovered host as well view, create_new, edit, execute and
-        delete discovery rules.
+        :Assert: User should be able to view, provision, edit and destroy one
+            or more discovered host as well view, create_new, edit, execute and
+            delete discovery rules.
 
-        @caseautomation: notautomated
+        :caseautomation: notautomated
 
-        @CaseLevel: System
+        :CaseLevel: System
         """
 
     @run_only_on('sat')
@@ -485,12 +483,12 @@ class DiscoveredTestCase(CLITestCase):
     def test_positive_assign_discovery_role(self):
         """Assign 'Discovery" role to a normal user
 
-        @id: 873e8411-563d-4bf9-84ce-62e522410cfe
+        :id: 873e8411-563d-4bf9-84ce-62e522410cfe
 
-        @Assert: User should be able to list, provision, and destroy one
-        or more discovered host
+        :Assert: User should be able to list, provision, and destroy one or
+            more discovered host
 
-        @caseautomation: notautomated
+        :caseautomation: notautomated
 
-        @CaseLevel: System
+        :CaseLevel: System
         """

--- a/tests/foreman/cli/test_discoveryrule.py
+++ b/tests/foreman/cli/test_discoveryrule.py
@@ -1,19 +1,19 @@
 # -*- encoding: utf-8 -*-
 """Test class for Foreman Discovery Rules
 
-@Requirement: Discoveryrule
+:Requirement: Discoveryrule
 
-@CaseAutomation: Automated
+:CaseAutomation: Automated
 
-@CaseLevel: Acceptance
+:CaseLevel: Acceptance
 
-@CaseComponent: CLI
+:CaseComponent: CLI
 
-@TestType: Functional
+:TestType: Functional
 
-@CaseImportance: High
+:CaseImportance: High
 
-@Upstream: No
+:Upstream: No
 """
 
 from fauxfactory import gen_alphanumeric, gen_choice, gen_string
@@ -108,9 +108,9 @@ class DiscoveryRuleTestCase(CLITestCase):
     def test_positive_create_with_name(self):
         """Create Discovery Rule using different names
 
-        @id: 066e66bc-c572-4ae9-b458-90daf83bab54
+        :id: 066e66bc-c572-4ae9-b458-90daf83bab54
 
-        @Assert: Rule should be successfully created
+        :Assert: Rule should be successfully created
         """
         for name in valid_data_list():
             with self.subTest(name):
@@ -122,10 +122,10 @@ class DiscoveryRuleTestCase(CLITestCase):
     def test_positive_create_with_search(self):
         """Create Discovery Rule using different search queries
 
-        @id: 2383e898-a968-4183-a270-55e9350e0596
+        :id: 2383e898-a968-4183-a270-55e9350e0596
 
-        @Assert: Rule should be successfully created and has expected search
-        value
+        :Assert: Rule should be successfully created and has expected search
+            value
         """
         search_query = 'cpu_count = 2'
         rule = self._make_discoveryrule({u'search': search_query})
@@ -136,10 +136,10 @@ class DiscoveryRuleTestCase(CLITestCase):
     def test_positive_create_with_hostname(self):
         """Create Discovery Rule using valid hostname
 
-        @id: deee22c3-dcfd-4940-b27c-cca137ec9a92
+        :id: deee22c3-dcfd-4940-b27c-cca137ec9a92
 
-        @Assert: Rule should be successfully created and has expected hostname
-        value
+        :Assert: Rule should be successfully created and has expected hostname
+            value
         """
         host_name = 'myhost'
         rule = self._make_discoveryrule({u'hostname': host_name})
@@ -151,9 +151,9 @@ class DiscoveryRuleTestCase(CLITestCase):
     def test_positive_create_with_org_loc_name(self):
         """Create discovery rule by associating org and location names
 
-        @id: f0d550ae-16d8-48ec-817e-d2e5b7405b46
+        :id: f0d550ae-16d8-48ec-817e-d2e5b7405b46
 
-        @Assert: Rule was created and with given org & location names.
+        :Assert: Rule was created and with given org & location names.
         """
         rule = self._make_discoveryrule({
             u'hostgroup-id': self.hostgroup['id'],
@@ -169,10 +169,10 @@ class DiscoveryRuleTestCase(CLITestCase):
         """Create Discovery Rule providing any number from range 1..100 for
         hosts limit option
 
-        @id: c28422c2-1f6a-4045-b722-f9f9d864e963
+        :id: c28422c2-1f6a-4045-b722-f9f9d864e963
 
-        @Assert: Rule should be successfully created and has expected hosts
-        limit value
+        :Assert: Rule should be successfully created and has expected hosts
+            limit value
         """
         hosts_limit = '5'
         rule = self._make_discoveryrule({u'hosts-limit': hosts_limit})
@@ -184,10 +184,10 @@ class DiscoveryRuleTestCase(CLITestCase):
         """Create Discovery Rule providing any number from range 1..100 for
         max count option
 
-        @id: 590ca353-d3d7-4700-be34-13de00f46276
+        :id: 590ca353-d3d7-4700-be34-13de00f46276
 
-        @Assert: Rule should be successfully created and has max_count set
-        as per given value
+        :Assert: Rule should be successfully created and has max_count set as
+            per given value
         """
         max_count = '10'
         rule = self._make_discoveryrule({u'max-count': max_count})
@@ -199,10 +199,10 @@ class DiscoveryRuleTestCase(CLITestCase):
         """Create Discovery Rule providing any number from range 1..100 for
         priority option
 
-        @id: 8ef58279-0ad3-41a4-b8dd-65594afdb655
+        :id: 8ef58279-0ad3-41a4-b8dd-65594afdb655
 
-        @Assert: Rule should be successfully created and has expected priority
-        value
+        :Assert: Rule should be successfully created and has expected priority
+            value
         """
         rule_priority = '100'
         rule = self._make_discoveryrule({u'priority': rule_priority})
@@ -213,9 +213,9 @@ class DiscoveryRuleTestCase(CLITestCase):
     def test_positive_create_disabled_rule(self):
         """Create Discovery Rule in disabled state
 
-        @id: 8837a0c6-e19a-4c33-8b87-07b6f69dbb0f
+        :id: 8837a0c6-e19a-4c33-8b87-07b6f69dbb0f
 
-        @Assert: Disabled rule should be successfully created
+        :Assert: Disabled rule should be successfully created
         """
         rule = self._make_discoveryrule({u'enabled': 'false'})
         self.assertEqual(rule['enabled'], 'false')
@@ -225,9 +225,9 @@ class DiscoveryRuleTestCase(CLITestCase):
     def test_negative_create_with_invalid_name(self):
         """Create Discovery Rule with invalid names
 
-        @id: a0350dc9-8f5b-4673-be88-a5e35d1f8ca7
+        :id: a0350dc9-8f5b-4673-be88-a5e35d1f8ca7
 
-        @Assert: Error should be raised and rule should not be created
+        :Assert: Error should be raised and rule should not be created
         """
         for name in invalid_values_list():
             with self.subTest(name):
@@ -239,9 +239,9 @@ class DiscoveryRuleTestCase(CLITestCase):
     def test_negative_create_with_invalid_hostname(self):
         """Create Discovery Rule with invalid hostname
 
-        @id: 0ae51085-30d0-44f9-9e49-abe928a8a4b7
+        :id: 0ae51085-30d0-44f9-9e49-abe928a8a4b7
 
-        @Assert: Error should be raised and rule should not be created
+        :Assert: Error should be raised and rule should not be created
         """
         for name in self.invalid_hostnames_list():
             with self.subTest(name):
@@ -256,10 +256,10 @@ class DiscoveryRuleTestCase(CLITestCase):
     def test_negative_create_with_too_long_limit(self):
         """Create Discovery Rule with too long host limit value
 
-        @id: 12dbb023-c963-4ead-a81e-ad53033de947
+        :id: 12dbb023-c963-4ead-a81e-ad53033de947
 
-        @Assert: Validation error should be raised and rule should not be
-        created
+        :Assert: Validation error should be raised and rule should not be
+            created
         """
         with self.assertRaises(CLIFactoryError):
             self._make_discoveryrule({u'hosts-limit': '9999999999'})
@@ -269,9 +269,9 @@ class DiscoveryRuleTestCase(CLITestCase):
     def test_negative_create_with_same_name(self):
         """Create Discovery Rule with name that already exists
 
-        @id: 5a914e76-de01-406d-9860-0e4e1521b074
+        :id: 5a914e76-de01-406d-9860-0e4e1521b074
 
-        @Assert: Error should be raised and rule should not be created
+        :Assert: Error should be raised and rule should not be created
         """
         name = gen_string('alpha')
         self._make_discoveryrule({u'name': name})
@@ -283,9 +283,9 @@ class DiscoveryRuleTestCase(CLITestCase):
     def test_positive_delete(self):
         """Delete existing Discovery Rule
 
-        @id: c9b88a94-13c4-496f-a5c1-c088187250dc
+        :id: c9b88a94-13c4-496f-a5c1-c088187250dc
 
-        @Assert: Rule should be successfully deleted
+        :Assert: Rule should be successfully deleted
         """
         rule = self._make_discoveryrule()
         DiscoveryRule.delete({u'id': rule['id']})
@@ -297,9 +297,9 @@ class DiscoveryRuleTestCase(CLITestCase):
     def test_positive_update_name(self):
         """Update discovery rule name
 
-        @id: 1045e2c4-e1f7-42c9-95f7-488fc79bf70b
+        :id: 1045e2c4-e1f7-42c9-95f7-488fc79bf70b
 
-        @Assert: Rule name is updated
+        :Assert: Rule name is updated
         """
         rule = self._make_discoveryrule()
         new_name = gen_string('numeric')
@@ -313,11 +313,11 @@ class DiscoveryRuleTestCase(CLITestCase):
     def test_positive_update_org_loc(self):
         """Update org and location of selected discovery rule
 
-        @id: 26da79aa-30e5-4052-98ae-141de071a68a
+        :id: 26da79aa-30e5-4052-98ae-141de071a68a
 
-        @Assert: Rule was updated and with given org & location.
+        :Assert: Rule was updated and with given org & location.
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         new_org = make_org()
         new_loc = make_location()
@@ -336,9 +336,9 @@ class DiscoveryRuleTestCase(CLITestCase):
     def test_positive_update_query(self):
         """Update discovery rule search query
 
-        @id: 86943095-acc5-40ff-8e3c-88c76b36333d
+        :id: 86943095-acc5-40ff-8e3c-88c76b36333d
 
-        @Assert: Rule search field is updated
+        :Assert: Rule search field is updated
         """
         rule = self._make_discoveryrule()
         new_query = 'model = KVM'
@@ -351,9 +351,9 @@ class DiscoveryRuleTestCase(CLITestCase):
     def test_positive_update_hostgroup(self):
         """Update discovery rule host group
 
-        @id: 07992a3f-2aa9-4e45-b2e8-ef3d2f255292
+        :id: 07992a3f-2aa9-4e45-b2e8-ef3d2f255292
 
-        @Assert: Rule host group is updated
+        :Assert: Rule host group is updated
         """
         new_hostgroup = make_hostgroup({u'organization-ids': self.org['id']})
         rule = self._make_discoveryrule()
@@ -369,9 +369,9 @@ class DiscoveryRuleTestCase(CLITestCase):
     def test_positive_update_hostname(self):
         """Update discovery rule hostname value
 
-        @id: 4c123488-92df-42f6-afe3-8a88cd90ffc2
+        :id: 4c123488-92df-42f6-afe3-8a88cd90ffc2
 
-        @Assert: Rule host name is updated
+        :Assert: Rule host name is updated
         """
         new_hostname = gen_string('alpha')
         rule = self._make_discoveryrule()
@@ -384,9 +384,9 @@ class DiscoveryRuleTestCase(CLITestCase):
     def test_positive_update_limit(self):
         """Update discovery rule limit value
 
-        @id: efa6f5bc-4d56-4449-90f5-330affbcfb09
+        :id: efa6f5bc-4d56-4449-90f5-330affbcfb09
 
-        @Assert: Rule host limit field is updated
+        :Assert: Rule host limit field is updated
         """
         rule = self._make_discoveryrule({u'hosts-limit': '5'})
         new_limit = '10'
@@ -399,9 +399,9 @@ class DiscoveryRuleTestCase(CLITestCase):
     def test_positive_update_priority(self):
         """Update discovery rule priority value
 
-        @id: 0543cc73-c692-4bbf-818b-37353ec98986
+        :id: 0543cc73-c692-4bbf-818b-37353ec98986
 
-        @Assert: Rule priority is updated
+        :Assert: Rule priority is updated
         """
         rule = self._make_discoveryrule({u'priority': 100})
         new_priority = '1'
@@ -414,9 +414,9 @@ class DiscoveryRuleTestCase(CLITestCase):
     def test_positive_update_disable_enable(self):
         """Update discovery rule enabled state. (Disabled->Enabled)
 
-        @id: 64e8b21b-2ab0-49c3-a12d-02dbdb36647a
+        :id: 64e8b21b-2ab0-49c3-a12d-02dbdb36647a
 
-        @Assert: Rule is successfully enabled
+        :Assert: Rule is successfully enabled
         """
         rule = self._make_discoveryrule({u'enabled': 'false'})
         self.assertEqual(rule['enabled'], 'false')
@@ -429,9 +429,9 @@ class DiscoveryRuleTestCase(CLITestCase):
     def test_negative_update_name(self):
         """Update discovery rule name using invalid names only
 
-        @id: 8293cc6a-d983-460a-b76e-221ad02b54b7
+        :id: 8293cc6a-d983-460a-b76e-221ad02b54b7
 
-        @Assert: Rule name is not updated
+        :Assert: Rule name is not updated
         """
         rule = self._make_discoveryrule()
         for name in invalid_values_list():
@@ -444,9 +444,9 @@ class DiscoveryRuleTestCase(CLITestCase):
     def test_negative_update_hostname(self):
         """Update discovery rule host name using number as a value
 
-        @id: c382dbc7-9509-4060-9038-1617f7fef038
+        :id: c382dbc7-9509-4060-9038-1617f7fef038
 
-        @Assert: Rule host name is not updated
+        :Assert: Rule host name is not updated
         """
         rule = self._make_discoveryrule()
         with self.assertRaises(CLIReturnCodeError):
@@ -457,9 +457,9 @@ class DiscoveryRuleTestCase(CLITestCase):
     def test_negative_update_limit(self):
         """Update discovery rule host limit using invalid values
 
-        @id: e3257d8a-91b9-406f-bd74-0fd1fb05bb77
+        :id: e3257d8a-91b9-406f-bd74-0fd1fb05bb77
 
-        @Assert: Rule host limit is not updated
+        :Assert: Rule host limit is not updated
         """
         rule = self._make_discoveryrule()
         host_limit = gen_string('alpha')
@@ -471,9 +471,9 @@ class DiscoveryRuleTestCase(CLITestCase):
     def test_negative_update_priority(self):
         """Update discovery rule priority using invalid values
 
-        @id: 0778dd00-aa19-4062-bdf3-752e1b546ec2
+        :id: 0778dd00-aa19-4062-bdf3-752e1b546ec2
 
-        @Assert: Rule priority is not updated
+        :Assert: Rule priority is not updated
         """
         rule = self._make_discoveryrule()
         priority = gen_string('alpha')
@@ -519,11 +519,11 @@ class DiscoveryRuleRoleTestCase(CLITestCase):
     def test_positive_create_rule_with_non_admin_user(self):
         """Create rule with non-admin user by associating discovery_manager role
 
-        @id: 056535aa-3338-4c1e-8a4b-ebfc8bd6e456
+        :id: 056535aa-3338-4c1e-8a4b-ebfc8bd6e456
 
-        @Assert: Rule should be created successfully.
+        :Assert: Rule should be created successfully.
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         rule_name = gen_string('alpha')
         rule = DiscoveryRule.with_user(
@@ -547,11 +547,11 @@ class DiscoveryRuleRoleTestCase(CLITestCase):
     def test_positive_delete_rule_with_non_admin_user(self):
         """Delete rule with non-admin user by associating discovery_manager role
 
-        @id: 87ab969b-7d92-478d-a5c0-1c0d50e9bdd6
+        :id: 87ab969b-7d92-478d-a5c0-1c0d50e9bdd6
 
-        @Assert: Rule should be deleted successfully.
+        :Assert: Rule should be deleted successfully.
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         rule_name = gen_string('alpha')
         rule = DiscoveryRule.with_user(
@@ -581,17 +581,17 @@ class DiscoveryRuleRoleTestCase(CLITestCase):
         """Existing rule should be viewed to non-admin user by associating
         discovery_reader role.
 
-        @id: 7b1d90b9-fc2d-4ccb-93d3-605c2da876f7
+        :id: 7b1d90b9-fc2d-4ccb-93d3-605c2da876f7
 
-        @Steps:
+        :Steps:
 
-        1. create a rule with admin user
-        2. create a non-admin user and assign 'Discovery Reader' role
-        3. Login with non-admin user
+            1. create a rule with admin user
+            2. create a non-admin user and assign 'Discovery Reader' role
+            3. Login with non-admin user
 
-        @Assert: Rule should be visible to non-admin user.
+        :Assert: Rule should be visible to non-admin user.
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         rule_name = gen_string('alpha')
         rule = make_discoveryrule({
@@ -613,12 +613,12 @@ class DiscoveryRuleRoleTestCase(CLITestCase):
     def test_negative_delete_rule_with_non_admin_user(self):
         """Delete rule with non-admin user by associating discovery_reader role
 
-        @id: f7f9569b-916e-46f3-bd89-a05e33483741
+        :id: f7f9569b-916e-46f3-bd89-a05e33483741
 
-        @Assert: User should validation error and rule should not be deleted
-        successfully.
+        :Assert: User should validation error and rule should not be deleted
+            successfully.
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         rule = make_discoveryrule({
             u'enabled': 'false',

--- a/tests/foreman/cli/test_docker.py
+++ b/tests/foreman/cli/test_docker.py
@@ -1,19 +1,19 @@
 # pylint: attribute-defined-outside-init
 """Unit tests for the Docker feature.
 
-@Requirement: Docker
+:Requirement: Docker
 
-@CaseAutomation: Automated
+:CaseAutomation: Automated
 
-@CaseLevel: Acceptance
+:CaseLevel: Acceptance
 
-@CaseComponent: CLI
+:CaseComponent: CLI
 
-@TestType: Functional
+:TestType: Functional
 
-@CaseImportance: High
+:CaseImportance: High
 
-@Upstream: No
+:Upstream: No
 """
 from fauxfactory import gen_alpha, gen_string, gen_url
 from random import choice, randint
@@ -83,12 +83,12 @@ class DockerManifestTestCase(CLITestCase):
     def test_positive_read_docker_tags(self):
         """docker manifest displays tags information for a docker manifest
 
-        @id: 59b605b5-ac2d-46e3-a85e-a259e78a07a8
+        :id: 59b605b5-ac2d-46e3-a85e-a259e78a07a8
 
-        @Assert: docker manifest displays tags info for a docker manifest
+        :Assert: docker manifest displays tags info for a docker manifest
 
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         organization = make_org()
         product = make_product_wait({
@@ -138,9 +138,9 @@ class DockerRepositoryTestCase(CLITestCase):
     def test_positive_create_with_name(self):
         """Create one Docker-type repository
 
-        @id: e82a36c8-3265-4c10-bafe-c7e07db3be78
+        :id: e82a36c8-3265-4c10-bafe-c7e07db3be78
 
-        @Assert: A repository is created with a Docker upstream repository.
+        :Assert: A repository is created with a Docker upstream repository.
 
         """
         for name in valid_data_list():
@@ -159,10 +159,10 @@ class DockerRepositoryTestCase(CLITestCase):
     def test_positive_create_repos_using_same_product(self):
         """Create multiple Docker-type repositories
 
-        @id: 6dd25cf4-f8b6-4958-976a-c116daf27b44
+        :id: 6dd25cf4-f8b6-4958-976a-c116daf27b44
 
-        @Assert: Multiple docker repositories are created with a Docker
-        upstream repository and they all belong to the same product.
+        :Assert: Multiple docker repositories are created with a Docker
+            upstream repository and they all belong to the same product.
 
         """
         product = make_product_wait({'organization-id': self.org_id})
@@ -185,10 +185,11 @@ class DockerRepositoryTestCase(CLITestCase):
         """Create multiple Docker-type repositories on multiple
         products.
 
-        @id: 43f4ab0d-731e-444e-9014-d663ff945f36
+        :id: 43f4ab0d-731e-444e-9014-d663ff945f36
 
-        @Assert: Multiple docker repositories are created with a Docker
-        upstream repository and they all belong to their respective products.
+        :Assert: Multiple docker repositories are created with a Docker
+            upstream repository and they all belong to their respective
+            products.
 
         """
         for _ in range(randint(2, 5)):
@@ -211,10 +212,10 @@ class DockerRepositoryTestCase(CLITestCase):
     def test_positive_sync(self):
         """Create and sync a Docker-type repository
 
-        @id: bff1d40e-181b-48b2-8141-8c86e0db62a2
+        :id: bff1d40e-181b-48b2-8141-8c86e0db62a2
 
-        @Assert: A repository is created with a Docker repository
-        and it is synchronized.
+        :Assert: A repository is created with a Docker repository and it is
+            synchronized.
 
         """
         repo = _make_docker_repo(
@@ -230,10 +231,10 @@ class DockerRepositoryTestCase(CLITestCase):
     def test_positive_update_name(self):
         """Create a Docker-type repository and update its name.
 
-        @id: 8b3a8496-e9bd-44f1-916f-6763a76b9b1b
+        :id: 8b3a8496-e9bd-44f1-916f-6763a76b9b1b
 
-        @Assert: A repository is created with a Docker upstream repository and
-        that its name can be updated.
+        :Assert: A repository is created with a Docker upstream repository and
+            that its name can be updated.
 
         """
         repo = _make_docker_repo(
@@ -253,10 +254,10 @@ class DockerRepositoryTestCase(CLITestCase):
     def test_positive_update_upstream_name(self):
         """Create a Docker-type repository and update its upstream name.
 
-        @id: 1a6985ed-43ec-4ea6-ba27-e3870457ac56
+        :id: 1a6985ed-43ec-4ea6-ba27-e3870457ac56
 
-        @Assert: A repository is created with a Docker upstream repository and
-        that its upstream name can be updated.
+        :Assert: A repository is created with a Docker upstream repository and
+            that its upstream name can be updated.
 
         """
         new_upstream_name = 'fedora/ssh'
@@ -275,10 +276,10 @@ class DockerRepositoryTestCase(CLITestCase):
     def test_positive_update_url(self):
         """Create a Docker-type repository and update its URL.
 
-        @id: 73caacd4-7f17-42a7-8d93-3dee8b9341fa
+        :id: 73caacd4-7f17-42a7-8d93-3dee8b9341fa
 
-        @Assert: A repository is created with a Docker upstream repository and
-        that its URL can be updated.
+        :Assert: A repository is created with a Docker upstream repository and
+            that its URL can be updated.
 
         """
         new_url = gen_url()
@@ -296,10 +297,10 @@ class DockerRepositoryTestCase(CLITestCase):
     def test_positive_delete_by_id(self):
         """Create and delete a Docker-type repository
 
-        @id: ab1e8228-92a8-45dc-a863-7181711f2745
+        :id: ab1e8228-92a8-45dc-a863-7181711f2745
 
-        @Assert: A repository with a upstream repository is created and then
-        deleted.
+        :Assert: A repository with a upstream repository is created and then
+            deleted.
 
         """
         repo = _make_docker_repo(
@@ -314,10 +315,10 @@ class DockerRepositoryTestCase(CLITestCase):
         """Create Docker-type repositories on multiple products and
         delete a random repository from a random product.
 
-        @id: d4db5eaa-7379-4788-9b72-76f2589d8f20
+        :id: d4db5eaa-7379-4788-9b72-76f2589d8f20
 
-        @Assert: Random repository can be deleted from random product without
-        altering the other products.
+        :Assert: Random repository can be deleted from random product without
+            altering the other products.
 
         """
         products = [
@@ -385,10 +386,10 @@ class DockerContentViewTestCase(CLITestCase):
     def test_positive_add_docker_repo_by_id(self):
         """Add one Docker-type repository to a non-composite content view
 
-        @id: 87d6c7bb-92f8-4a32-8ad2-2a1af896500b
+        :id: 87d6c7bb-92f8-4a32-8ad2-2a1af896500b
 
-        @Assert: A repository is created with a Docker repository and the
-        product is added to a non-composite content view
+        :Assert: A repository is created with a Docker repository and the
+            product is added to a non-composite content view
 
         """
         repo = _make_docker_repo(
@@ -412,10 +413,10 @@ class DockerContentViewTestCase(CLITestCase):
     def test_positive_add_docker_repos_by_id(self):
         """Add multiple Docker-type repositories to a non-composite CV.
 
-        @id: 2eb19e28-a633-4c21-9469-75a686c83b34
+        :id: 2eb19e28-a633-4c21-9469-75a686c83b34
 
-        @Assert: Repositories are created with Docker upstream repositories
-        and the product is added to a non-composite content view.
+        :Assert: Repositories are created with Docker upstream repositories and
+            the product is added to a non-composite content view.
 
         """
         product = make_product_wait({'organization-id': self.org_id})
@@ -444,13 +445,13 @@ class DockerContentViewTestCase(CLITestCase):
     def test_positive_add_synced_docker_repo_by_id(self):
         """Create and sync a Docker-type repository
 
-        @id: 6f51d268-ed23-48ab-9dea-cd3571daa647
+        :id: 6f51d268-ed23-48ab-9dea-cd3571daa647
 
-        @Assert: A repository is created with a Docker repository
-        and it is synchronized.
+        :Assert: A repository is created with a Docker repository and it is
+            synchronized.
 
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         repo = _make_docker_repo(
             make_product_wait({'organization-id': self.org_id})['id'])
@@ -478,13 +479,13 @@ class DockerContentViewTestCase(CLITestCase):
     def test_positive_add_docker_repo_by_id_to_ccv(self):
         """Add one Docker-type repository to a composite content view
 
-        @id: 8e2ef5ba-3cdf-4ef9-a22a-f1701e20a5d5
+        :id: 8e2ef5ba-3cdf-4ef9-a22a-f1701e20a5d5
 
-        @Assert: A repository is created with a Docker repository and the
-        product is added to a content view which is then added to a composite
-        content view.
+        :Assert: A repository is created with a Docker repository and the
+            product is added to a content view which is then added to a
+            composite content view.
 
-        @BZ: 1359665
+        :BZ: 1359665
         """
         self._create_and_associate_repo_with_cv()
         ContentView.publish({'id': self.content_view['id']})
@@ -513,13 +514,13 @@ class DockerContentViewTestCase(CLITestCase):
     def test_positive_add_docker_repos_by_id_to_ccv(self):
         """Add multiple Docker-type repositories to a composite content view.
 
-        @id: b79cbc97-3dba-4059-907d-19316684d569
+        :id: b79cbc97-3dba-4059-907d-19316684d569
 
-        @Assert: One repository is created with a Docker upstream repository
-        and the product is added to a random number of content views which are
-        then added to a composite content view.
+        :Assert: One repository is created with a Docker upstream repository
+            and the product is added to a random number of content views which
+            are then added to a composite content view.
 
-        @BZ: 1359665
+        :BZ: 1359665
         """
         cv_versions = []
         product = make_product_wait({'organization-id': self.org_id})
@@ -563,14 +564,13 @@ class DockerContentViewTestCase(CLITestCase):
     def test_positive_publish_with_docker_repo(self):
         """Add Docker-type repository to content view and publish it once.
 
-        @id: 28480de3-ffb5-4b8e-8174-fffffeef6af4
+        :id: 28480de3-ffb5-4b8e-8174-fffffeef6af4
 
-        @Assert: One repository is created with a Docker upstream repository
-        and the product is added to a content view which is then published only
-        once.
+        :Assert: One repository is created with a Docker upstream repository
+            and the product is added to a content view which is then published
+            only once.
 
-
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         self._create_and_associate_repo_with_cv()
         self.assertEqual(len(self.content_view['versions']), 0)
@@ -586,16 +586,16 @@ class DockerContentViewTestCase(CLITestCase):
     def test_positive_publish_with_docker_repo_composite(self):
         """Add Docker-type repository to composite CV and publish it once.
 
-        @id: 2d75419b-73ed-4f29-ae0d-9af8d9624c87
+        :id: 2d75419b-73ed-4f29-ae0d-9af8d9624c87
 
-        @Assert: One repository is created with a Docker upstream repository
-        and the product is added to a content view which is then published once
-        and added to a composite content view which is also published once.
+        :Assert: One repository is created with a Docker upstream repository
+            and the product is added to a content view which is then published
+            once and added to a composite content view which is also published
+            once.
 
+        :CaseLevel: Integration
 
-        @CaseLevel: Integration
-
-        @BZ: 1359665
+        :BZ: 1359665
         """
         self._create_and_associate_repo_with_cv()
         self.assertEqual(len(self.content_view['versions']), 0)
@@ -635,14 +635,13 @@ class DockerContentViewTestCase(CLITestCase):
         """Add Docker-type repository to content view and publish it multiple
         times.
 
-        @id: 33c1b2ee-ae8a-4a7e-8254-123d97aaaa58
+        :id: 33c1b2ee-ae8a-4a7e-8254-123d97aaaa58
 
-        @Assert: One repository is created with a Docker upstream repository
-        and the product is added to a content view which is then published
-        multiple times.
+        :Assert: One repository is created with a Docker upstream repository
+            and the product is added to a content view which is then published
+            multiple times.
 
-
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         self._create_and_associate_repo_with_cv()
         self.assertEqual(len(self.content_view['versions']), 0)
@@ -661,16 +660,15 @@ class DockerContentViewTestCase(CLITestCase):
         """Add Docker-type repository to content view and publish it multiple
         times.
 
-        @id: 014adf90-d399-4a99-badb-76ee03a2c350
+        :id: 014adf90-d399-4a99-badb-76ee03a2c350
 
-        @Assert: One repository is created with a Docker upstream repository
-        and the product is added to a content view which is then added to a
-        composite content view which is then published multiple times.
+        :Assert: One repository is created with a Docker upstream repository
+            and the product is added to a content view which is then added to a
+            composite content view which is then published multiple times.
 
+        :CaseLevel: Integration
 
-        @CaseLevel: Integration
-
-        @BZ: 1359665
+        :BZ: 1359665
         """
         self._create_and_associate_repo_with_cv()
         self.assertEqual(len(self.content_view['versions']), 0)
@@ -711,13 +709,12 @@ class DockerContentViewTestCase(CLITestCase):
         """Add Docker-type repository to content view and publish it.
         Then promote it to the next available lifecycle-environment.
 
-        @id: a7df98f4-0ec0-40f6-8941-3dbb776d47b9
+        :id: a7df98f4-0ec0-40f6-8941-3dbb776d47b9
 
-        @Assert: Docker-type repository is promoted to content view found in
-        the specific lifecycle-environment.
+        :Assert: Docker-type repository is promoted to content view found in
+            the specific lifecycle-environment.
 
-
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         lce = make_lifecycle_environment({'organization-id': self.org_id})
         self._create_and_associate_repo_with_cv()
@@ -744,13 +741,12 @@ class DockerContentViewTestCase(CLITestCase):
         """Add Docker-type repository to content view and publish it.
         Then promote it to multiple available lifecycle-environments.
 
-        @id: e9432bc4-a709-44d7-8e1d-00ca466aa32d
+        :id: e9432bc4-a709-44d7-8e1d-00ca466aa32d
 
-        @Assert: Docker-type repository is promoted to content view found in
-        the specific lifecycle-environments.
+        :Assert: Docker-type repository is promoted to content view found in
+            the specific lifecycle-environments.
 
-
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         self._create_and_associate_repo_with_cv()
         ContentView.publish({'id': self.content_view['id']})
@@ -779,15 +775,14 @@ class DockerContentViewTestCase(CLITestCase):
         """Add Docker-type repository to composite content view and publish it.
         Then promote it to the next available lifecycle-environment.
 
-        @id: fb7d132e-d7fa-4890-a0ec-746dd093513e
+        :id: fb7d132e-d7fa-4890-a0ec-746dd093513e
 
-        @Assert: Docker-type repository is promoted to content view found in
-        the specific lifecycle-environment.
+        :Assert: Docker-type repository is promoted to content view found in
+            the specific lifecycle-environment.
 
+        :CaseLevel: Integration
 
-        @CaseLevel: Integration
-
-        @BZ: 1359665
+        :BZ: 1359665
         """
         self._create_and_associate_repo_with_cv()
         ContentView.publish({'id': self.content_view['id']})
@@ -838,15 +833,14 @@ class DockerContentViewTestCase(CLITestCase):
         """Add Docker-type repository to composite content view and publish it.
         Then promote it to the multiple available lifecycle-environments.
 
-        @id: 345288d6-581b-4c07-8062-e58cb6343f1b
+        :id: 345288d6-581b-4c07-8062-e58cb6343f1b
 
-        @Assert: Docker-type repository is promoted to content view found in
-        the specific lifecycle-environments.
+        :Assert: Docker-type repository is promoted to content view found in
+            the specific lifecycle-environments.
 
+        :CaseLevel: Integration
 
-        @CaseLevel: Integration
-
-        @BZ: 1359665
+        :BZ: 1359665
         """
         self._create_and_associate_repo_with_cv()
         ContentView.publish({'id': self.content_view['id']})
@@ -939,12 +933,12 @@ class DockerActivationKeyTestCase(CLITestCase):
         and publish it. Then create an activation key and associate it with the
         Docker content view.
 
-        @id: bb128642-d39f-45c2-aa69-a4776ea536a2
+        :id: bb128642-d39f-45c2-aa69-a4776ea536a2
 
-        @Assert: Docker-based content view can be added to activation key
+        :Assert: Docker-based content view can be added to activation key
 
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         activation_key = make_activation_key({
             'content-view-id': self.content_view['id'],
@@ -962,13 +956,12 @@ class DockerActivationKeyTestCase(CLITestCase):
         Docker content view. Then remove this content view from the activation
         key.
 
-        @id: d696e5fe-1818-46ce-9499-924c96e1ef88
+        :id: d696e5fe-1818-46ce-9499-924c96e1ef88
 
-        @Assert: Docker-based content view can be added and then removed
-        from the activation key.
+        :Assert: Docker-based content view can be added and then removed from
+            the activation key.
 
-
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         activation_key = make_activation_key({
             'content-view-id': self.content_view['id'],
@@ -1012,14 +1005,14 @@ class DockerActivationKeyTestCase(CLITestCase):
         and publish it. Create an activation key and associate it with the
         composite Docker content view.
 
-        @id: 1d9b82fd-8dab-4fd9-ad35-656d712d56a2
+        :id: 1d9b82fd-8dab-4fd9-ad35-656d712d56a2
 
-        @Assert: Docker-based content view can be added to activation key
+        :Assert: Docker-based content view can be added to activation key
 
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
 
-        @BZ: 1359665
+        :BZ: 1359665
         """
         comp_content_view = make_content_view({
             'composite': True,
@@ -1069,12 +1062,12 @@ class DockerActivationKeyTestCase(CLITestCase):
         composite Docker content view. Then, remove the composite content view
         from the activation key.
 
-        @id: b4e63537-d3a8-4afa-8e18-57052b93fb4c
+        :id: b4e63537-d3a8-4afa-8e18-57052b93fb4c
 
-        @Assert: Docker-based composite content view can be added and then
-        removed from the activation key.
+        :Assert: Docker-based composite content view can be added and then
+            removed from the activation key.
 
-        @BZ: 1359665
+        :BZ: 1359665
         """
         comp_content_view = make_content_view({
             'composite': True,
@@ -1156,16 +1149,16 @@ class DockerClientTestCase(CLITestCase):
         """A Docker-enabled client can use ``docker pull`` to pull a
         Docker image off a Satellite 6 instance.
 
-        @id: 023f0538-2aad-4f87-b8a8-6ccced648366
+        :id: 023f0538-2aad-4f87-b8a8-6ccced648366
 
-        @Steps:
+        :Steps:
 
-        1. Publish and promote content view with Docker content
-        2. Register Docker-enabled client against Satellite 6.
+            1. Publish and promote content view with Docker content
+            2. Register Docker-enabled client against Satellite 6.
 
-        @Assert: Client can pull Docker images from server and run it.
+        :Assert: Client can pull Docker images from server and run it.
 
-        @CaseLevel: System
+        :CaseLevel: System
         """
         product = make_product_wait({'organization-id': self.org['id']})
         repo = _make_docker_repo(product['id'])
@@ -1199,18 +1192,18 @@ class DockerClientTestCase(CLITestCase):
         Then, using ``docker build`` generate a new image which can then be
         uploaded back onto the Satellite 6 as a new repository.
 
-        @id: 2c47559c-b27f-436e-9b1e-df5c3633b007
+        :id: 2c47559c-b27f-436e-9b1e-df5c3633b007
 
-        @Steps:
+        :Steps:
 
-        1. Publish and promote content view with Docker content
-        2. Register Docker-enabled client against Satellite 6.
+            1. Publish and promote content view with Docker content
+            2. Register Docker-enabled client against Satellite 6.
 
-        @Assert: Client can create a new image based off an existing Docker
-        image from a Satellite 6 instance, add a new package and upload the
-        modified image (plus layer) back to the Satellite 6.
+        :Assert: Client can create a new image based off an existing Docker
+            image from a Satellite 6 instance, add a new package and upload the
+            modified image (plus layer) back to the Satellite 6.
 
-        @CaseLevel: System
+        :CaseLevel: System
         """
         compute_resource = make_compute_resource({
             'organization-ids': [self.org['id']],
@@ -1300,12 +1293,12 @@ class DockerComputeResourceTestCase(CLITestCase):
         """Create a Docker-based Compute Resource in the Satellite 6
         instance.
 
-        @id: 8c8e6185-9aad-42d4-bab2-e067d9a98ffb
+        :id: 8c8e6185-9aad-42d4-bab2-e067d9a98ffb
 
-        @Assert: Compute Resource can be created and listed.
+        :Assert: Compute Resource can be created and listed.
 
 
-        @CaseLevel: System
+        :CaseLevel: System
         """
         for name in valid_data_list():
             with self.subTest(name):
@@ -1327,13 +1320,12 @@ class DockerComputeResourceTestCase(CLITestCase):
         """Create a Docker-based Compute Resource in the Satellite 6
         instance then edit its attributes.
 
-        @id: 0b6411a9-2e9d-4ea6-9b9d-e026b1ff3c1c
+        :id: 0b6411a9-2e9d-4ea6-9b9d-e026b1ff3c1c
 
-        @Assert: Compute Resource can be created, listed and its attributes can
-        be updated.
+        :Assert: Compute Resource can be created, listed and its attributes can
+            be updated.
 
-
-        @CaseLevel: System
+        :CaseLevel: System
         """
         for url in (settings.docker.external_url,
                     settings.docker.get_unix_socket_url()):
@@ -1359,13 +1351,12 @@ class DockerComputeResourceTestCase(CLITestCase):
         """Create a Docker-based Compute Resource in the Satellite 6
         instance then list its running containers.
 
-        @id: 52606017-bbf8-4630-9516-9ae069eaf09d
+        :id: 52606017-bbf8-4630-9516-9ae069eaf09d
 
-        @Assert: Compute Resource can be created, listed and existing running
-        instances can be listed.
+        :Assert: Compute Resource can be created, listed and existing running
+            instances can be listed.
 
-
-        @CaseLevel: System
+        :CaseLevel: System
         """
         for url in (settings.docker.external_url,
                     settings.docker.get_unix_socket_url()):
@@ -1396,12 +1387,12 @@ class DockerComputeResourceTestCase(CLITestCase):
         """Create a Docker-based Compute Resource using an external
         Docker-enabled system.
 
-        @id: d7c9fbc9-3b6b-4cff-8a48-9b93d63075a8
+        :id: d7c9fbc9-3b6b-4cff-8a48-9b93d63075a8
 
-        @Assert: Compute Resource can be created and listed.
+        :Assert: Compute Resource can be created and listed.
 
 
-        @CaseLevel: System
+        :CaseLevel: System
         """
         for name in valid_data_list():
             with self.subTest(name):
@@ -1420,12 +1411,12 @@ class DockerComputeResourceTestCase(CLITestCase):
     def test_positive_delete_by_id(self):
         """Create a Docker-based Compute Resource then delete it.
 
-        @id: df96331a-6a4c-4db9-9188-5ff510ef4356
+        :id: df96331a-6a4c-4db9-9188-5ff510ef4356
 
-        @Assert: Compute Resource can be created, listed and deleted.
+        :Assert: Compute Resource can be created, listed and deleted.
 
 
-        @CaseLevel: System
+        :CaseLevel: System
         """
         for url in (settings.docker.external_url,
                     settings.docker.get_unix_socket_url()):
@@ -1476,12 +1467,12 @@ class DockerContainersTestCase(CLITestCase):
     def test_positive_create_with_compresource(self):
         """Create containers for local and external compute resources
 
-        @id: aa1d5216-deaf-403e-9d4c-60157a251762
+        :id: aa1d5216-deaf-403e-9d4c-60157a251762
 
-        @Assert: The docker container is created for each compute resource
+        :Assert: The docker container is created for each compute resource
 
 
-        @CaseLevel: System
+        :CaseLevel: System
         """
         for compute_resource in (self.cr_internal, self.cr_external):
             with self.subTest(compute_resource['url']):
@@ -1500,13 +1491,13 @@ class DockerContainersTestCase(CLITestCase):
         environment and docker repository for local and external compute
         resources
 
-        @id: 5569186f-667b-4866-a88e-fd6cf6e821da
+        :id: 5569186f-667b-4866-a88e-fd6cf6e821da
 
-        @Assert: The docker container is created for each compute resource
+        :Assert: The docker container is created for each compute resource
 
-        @BZ: 1282431
+        :BZ: 1282431
 
-        @CaseLevel: System
+        :CaseLevel: System
         """
         lce = make_lifecycle_environment({'organization-id': self.org['id']})
         repo = _make_docker_repo(
@@ -1551,15 +1542,15 @@ class DockerContainersTestCase(CLITestCase):
         """Create containers for local and external compute resource, then
         power them on and finally power them off
 
-        @id: c7150e63-f81c-4a55-808d-a2bed1a4eaf2
+        :id: c7150e63-f81c-4a55-808d-a2bed1a4eaf2
 
-        @Assert: The docker container is created for each compute resource
-        and the power status is showing properly
+        :Assert: The docker container is created for each compute resource and
+            the power status is showing properly
 
-        @BZ: 1230915, 1269196
+        :BZ: 1230915, 1269196
 
 
-        @CaseLevel: System
+        :CaseLevel: System
         """
         # testing the text status may fail i18n tests but for now there is
         # nothing else to assert
@@ -1585,15 +1576,15 @@ class DockerContainersTestCase(CLITestCase):
         """Create containers for local and external compute resource and read
         their logs
 
-        @id: 7c818e53-9833-4a4c-b9bf-a62895dad37f
+        :id: 7c818e53-9833-4a4c-b9bf-a62895dad37f
 
-        @Assert: The docker container is created for each compute resource and
-        its log can be read
+        :Assert: The docker container is created for each compute resource and
+            its log can be read
 
-        @BZ: 1230915, 1269208
+        :BZ: 1230915, 1269208
 
 
-        @CaseLevel: System
+        :CaseLevel: System
         """
         for compute_resource in (self.cr_internal, self.cr_external):
             with self.subTest(compute_resource['url']):
@@ -1611,12 +1602,12 @@ class DockerContainersTestCase(CLITestCase):
     def test_positive_create_with_external_registry(self):
         """Create a container pulling an image from a custom external registry
 
-        @id: 006ff4c2-8ff8-41fc-8096-dda24267a223
+        :id: 006ff4c2-8ff8-41fc-8096-dda24267a223
 
-        @Assert: The docker container is created and the image is pulled from
-        the external registry
+        :Assert: The docker container is created and the image is pulled from
+            the external registry
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         repo_name = 'rhel'
         registry = make_registry({'url': settings.docker.external_registry_1})
@@ -1643,15 +1634,15 @@ class DockerContainersTestCase(CLITestCase):
     def test_positive_delete_by_id(self):
         """Delete containers in local and external compute resources
 
-        @id: 7280efa4-2569-4034-bce4-12dc08838e36
+        :id: 7280efa4-2569-4034-bce4-12dc08838e36
 
-        @Assert: The docker containers are deleted in local and external
-        compute resources
+        :Assert: The docker containers are deleted in local and external
+            compute resources
 
-        @BZ: 1230915
+        :BZ: 1230915
 
 
-        @CaseLevel: System
+        :CaseLevel: System
         """
         for compute_resource in (self.cr_internal, self.cr_external):
             with self.subTest(compute_resource['url']):
@@ -1684,9 +1675,9 @@ class DockerRegistryTestCase(CLITestCase):
     def test_positive_create_with_name(self):
         """Create an external docker registry
 
-        @id: c2380323-56d6-4465-ad79-06868b97be16
+        :id: c2380323-56d6-4465-ad79-06868b97be16
 
-        @Assert: the external registry is created
+        :Assert: the external registry is created
         """
         for name in valid_data_list():
             with self.subTest(name):
@@ -1709,9 +1700,9 @@ class DockerRegistryTestCase(CLITestCase):
         """Create an external docker registry and update its name. Use registry
         ID to search by
 
-        @id: b702a33c-1c23-4b55-9ea1-f0b3bfc9cca2
+        :id: b702a33c-1c23-4b55-9ea1-f0b3bfc9cca2
 
-        @Assert: the external registry is updated with the new name
+        :Assert: the external registry is updated with the new name
         """
         registry = make_registry()
         try:
@@ -1732,9 +1723,9 @@ class DockerRegistryTestCase(CLITestCase):
         """Create an external docker registry and update its name. Use registry
         name to search by
 
-        @id: d74e5795-5336-414c-844f-04bf1171d337
+        :id: d74e5795-5336-414c-844f-04bf1171d337
 
-        @Assert: the external registry is updated with the new name
+        :Assert: the external registry is updated with the new name
         """
         registry = make_registry()
         try:
@@ -1755,9 +1746,9 @@ class DockerRegistryTestCase(CLITestCase):
         """Create an external docker registry and update its URL. Use registry
         ID to search by
 
-        @id: 71e8c75a-ce5d-4e8a-9564-2c6d9084f8fc
+        :id: 71e8c75a-ce5d-4e8a-9564-2c6d9084f8fc
 
-        @Assert: the external registry is updated with the new URL
+        :Assert: the external registry is updated with the new URL
         """
         registry = make_registry()
         try:
@@ -1777,9 +1768,9 @@ class DockerRegistryTestCase(CLITestCase):
         """Create an external docker registry and update its URL. Use registry
         name to search by
 
-        @id: 7d4fcdb3-c66f-4d0b-9df0-7a105ab29cb2
+        :id: 7d4fcdb3-c66f-4d0b-9df0-7a105ab29cb2
 
-        @Assert: the external registry is updated with the new URL
+        :Assert: the external registry is updated with the new URL
         """
         registry = make_registry()
         try:
@@ -1799,9 +1790,9 @@ class DockerRegistryTestCase(CLITestCase):
         """Create an external docker registry and update its description. Use
         registry ID to search by
 
-        @id: 84efd73c-517e-411a-8a4a-5cf2718ca03c
+        :id: 84efd73c-517e-411a-8a4a-5cf2718ca03c
 
-        @Assert: the external registry is updated with the new description
+        :Assert: the external registry is updated with the new description
         """
         registry = make_registry({'description': gen_string('alpha')})
         try:
@@ -1822,9 +1813,9 @@ class DockerRegistryTestCase(CLITestCase):
         """Create an external docker registry and update its description. Use
         registry name to search by
 
-        @id: 0c452868-096f-46ae-b884-a6553611b1f3
+        :id: 0c452868-096f-46ae-b884-a6553611b1f3
 
-        @Assert: the external registry is updated with the new description
+        :Assert: the external registry is updated with the new description
         """
         registry = make_registry({'description': gen_string('alpha')})
         try:
@@ -1845,9 +1836,9 @@ class DockerRegistryTestCase(CLITestCase):
         """Create an external docker registry and update its username. Use
         registry ID to search by
 
-        @id: 58e119e9-5681-49f3-bb33-41bb7d024930
+        :id: 58e119e9-5681-49f3-bb33-41bb7d024930
 
-        @Assert: the external registry is updated with the new username
+        :Assert: the external registry is updated with the new username
         """
         registry = make_registry({'username': gen_string('alpha')})
         try:
@@ -1868,9 +1859,9 @@ class DockerRegistryTestCase(CLITestCase):
         """Create an external docker registry and update its username. Use
         registry name to search by
 
-        @id: d139f89f-ce84-449c-9938-945c6dc980b6
+        :id: d139f89f-ce84-449c-9938-945c6dc980b6
 
-        @Assert: the external registry is updated with the new username
+        :Assert: the external registry is updated with the new username
         """
         registry = make_registry({'username': gen_string('alpha')})
         try:
@@ -1890,9 +1881,9 @@ class DockerRegistryTestCase(CLITestCase):
     def test_positive_delete_by_id(self):
         """Create an external docker registry. Use registry ID to search by
 
-        @id: c518011c-8665-4a7f-8b0e-af00232f876a
+        :id: c518011c-8665-4a7f-8b0e-af00232f876a
 
-        @Assert: the external registry is created
+        :Assert: the external registry is created
         """
         registry = make_registry()
         Docker.registry.delete({'id': registry['id']})
@@ -1904,9 +1895,9 @@ class DockerRegistryTestCase(CLITestCase):
     def test_positive_delete_by_name(self):
         """Create an external docker registry. Use registry name to search by
 
-        @id: a0c52cef-1757-4b91-a144-7dc0405cd33d
+        :id: a0c52cef-1757-4b91-a144-7dc0405cd33d
 
-        @Assert: the external registry is created
+        :Assert: the external registry is created
         """
         for name in valid_data_list():
             with self.subTest(name):

--- a/tests/foreman/cli/test_domain.py
+++ b/tests/foreman/cli/test_domain.py
@@ -1,19 +1,19 @@
 # -*- encoding: utf-8 -*-
 """Test class for Domain  CLI
 
-@Requirement: Domain
+:Requirement: Domain
 
-@CaseAutomation: Automated
+:CaseAutomation: Automated
 
-@CaseLevel: Acceptance
+:CaseLevel: Acceptance
 
-@CaseComponent: CLI
+:CaseComponent: CLI
 
-@TestType: Functional
+:TestType: Functional
 
-@CaseImportance: High
+:CaseImportance: High
 
-@Upstream: No
+:Upstream: No
 """
 from fauxfactory import gen_string
 from robottelo.cli.base import CLIReturnCodeError
@@ -129,9 +129,9 @@ class DomainTestCase(CLITestCase):
     def test_positive_create_with_name_description(self):
         """Create domain with valid name and description
 
-        @id: 018740bf-1551-4162-b88e-4d4905af097b
+        :id: 018740bf-1551-4162-b88e-4d4905af097b
 
-        @Assert: Domain successfully created
+        :Assert: Domain successfully created
 
         """
         for options in valid_create_params():
@@ -146,9 +146,9 @@ class DomainTestCase(CLITestCase):
     def test_positive_create_with_loc(self):
         """Check if domain with location can be created
 
-        @id: 033cc37d-0189-4b88-94cf-97a96839197a
+        :id: 033cc37d-0189-4b88-94cf-97a96839197a
 
-        @Assert: Domain is created and has new location assigned
+        :Assert: Domain is created and has new location assigned
 
         """
         location = make_location()
@@ -160,9 +160,9 @@ class DomainTestCase(CLITestCase):
     def test_positive_create_with_org(self):
         """Check if domain with organization can be created
 
-        @id: f4dfef1b-9b2a-49b8-ade5-031da29e7f6a
+        :id: f4dfef1b-9b2a-49b8-ade5-031da29e7f6a
 
-        @Assert: Domain is created and has new organization assigned
+        :Assert: Domain is created and has new organization assigned
 
         """
         org = make_org()
@@ -174,9 +174,9 @@ class DomainTestCase(CLITestCase):
     def test_negative_create(self):
         """Create domain with invalid values
 
-        @id: 6d3aec19-75dc-41ca-89af-fef0ca37082d
+        :id: 6d3aec19-75dc-41ca-89af-fef0ca37082d
 
-        @Assert: Domain is not created
+        :Assert: Domain is not created
 
         """
         for options in invalid_create_params():
@@ -189,9 +189,9 @@ class DomainTestCase(CLITestCase):
     def test_positive_update(self):
         """Update domain with valid values
 
-        @id: 9da3cc96-c146-4f82-bb25-b237a367ba91
+        :id: 9da3cc96-c146-4f82-bb25-b237a367ba91
 
-        @Assert: Domain is updated
+        :Assert: Domain is updated
 
         """
         domain = make_domain({
@@ -211,9 +211,9 @@ class DomainTestCase(CLITestCase):
     def test_negative_update(self):
         """Update domain with invalid values
 
-        @id: 9fc708dc-20f9-4d7c-af53-863826462981
+        :id: 9fc708dc-20f9-4d7c-af53-863826462981
 
-        @Assert: Domain is not updated
+        :Assert: Domain is not updated
 
         """
         domain = make_domain()
@@ -231,9 +231,9 @@ class DomainTestCase(CLITestCase):
     def test_positive_set_parameter(self):
         """Domain set-parameter with valid key and value
 
-        @id: 62fea9f7-95e2-47f7-bf4b-415ea6fd72f8
+        :id: 62fea9f7-95e2-47f7-bf4b-415ea6fd72f8
 
-        @Assert: Domain parameter is set
+        :Assert: Domain parameter is set
 
         """
         for options in valid_set_params():
@@ -253,9 +253,9 @@ class DomainTestCase(CLITestCase):
     def test_negative_set_parameter(self):
         """Domain set-parameter with invalid values
 
-        @id: 991fb849-83be-48f4-a12b-81eabb2bd8d3
+        :id: 991fb849-83be-48f4-a12b-81eabb2bd8d3
 
-        @Assert: Domain parameter is not set
+        :Assert: Domain parameter is not set
 
         """
         domain = make_domain()
@@ -275,9 +275,9 @@ class DomainTestCase(CLITestCase):
         """Create Domain with valid values then delete it
         by ID
 
-        @id: b50a5daa-67f8-4ecd-8e03-2a3c492d3c25
+        :id: b50a5daa-67f8-4ecd-8e03-2a3c492d3c25
 
-        @assert: Domain is deleted
+        :assert: Domain is deleted
         """
         for name in valid_data_list():
             with self.subTest(name):
@@ -291,9 +291,9 @@ class DomainTestCase(CLITestCase):
     def test_negative_delete_by_id(self):
         """Create Domain then delete it by wrong ID
 
-        @id: 0e4ef107-f006-4433-abc3-f872613e0b91
+        :id: 0e4ef107-f006-4433-abc3-f872613e0b91
 
-        @assert: Domain is not deleted
+        :assert: Domain is not deleted
         """
         for entity_id in invalid_id_list():
             with self.subTest(entity_id):
@@ -305,9 +305,9 @@ class DomainTestCase(CLITestCase):
     def test_positive_delete_parameter(self):
         """Domain delete-parameter removes parameter
 
-        @id: 481afe1c-0b9e-435f-a581-159d9619291c
+        :id: 481afe1c-0b9e-435f-a581-159d9619291c
 
-        @Assert: Domain parameter is removed
+        :Assert: Domain parameter is removed
 
         """
         for options in valid_delete_params():

--- a/tests/foreman/cli/test_environment.py
+++ b/tests/foreman/cli/test_environment.py
@@ -1,19 +1,19 @@
 # -*- encoding: utf-8 -*-
 """Test for Environment  CLI
 
-@Requirement: Environment
+:Requirement: Environment
 
-@CaseAutomation: Automated
+:CaseAutomation: Automated
 
-@CaseLevel: Acceptance
+:CaseLevel: Acceptance
 
-@CaseComponent: CLI
+:CaseComponent: CLI
 
-@TestType: Functional
+:TestType: Functional
 
-@CaseImportance: High
+:CaseImportance: High
 
-@Upstream: No
+:Upstream: No
 """
 from random import choice
 
@@ -67,11 +67,11 @@ class EnvironmentTestCase(CLITestCase):
     def test_positive_list_with_name(self):
         """Test Environment List
 
-        @id: 8a81f853-929c-4eaa-8ae0-4c92ebf1f250
+        :id: 8a81f853-929c-4eaa-8ae0-4c92ebf1f250
 
-        @Assert: Environment list is displayed
+        :Assert: Environment list is displayed
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         for name in valid_environments_list():
             with self.subTest(name):
@@ -87,13 +87,13 @@ class EnvironmentTestCase(CLITestCase):
     def test_positive_list_with_org_and_loc_by_id(self):
         """Test Environment List filtering.
 
-        @id: 643f7cb5-0817-4b0a-ba5e-434df2033a40
+        :id: 643f7cb5-0817-4b0a-ba5e-434df2033a40
 
-        @Assert: Results that match both organization and location are returned
+        :Assert: Results that match both organization and location are returned
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
 
-        @BZ: 1337947
+        :BZ: 1337947
         """
         # Create 2 envs with the same organization but different locations
         org = make_org()
@@ -122,13 +122,13 @@ class EnvironmentTestCase(CLITestCase):
     def test_positive_list_with_org_and_loc_by_name(self):
         """Test Environment List filtering.
 
-        @id: 962c6750-f203-4478-8827-651db208ff92
+        :id: 962c6750-f203-4478-8827-651db208ff92
 
-        @Assert: Results that match both organization and location are returned
+        :Assert: Results that match both organization and location are returned
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
 
-        @BZ: 1337947
+        :BZ: 1337947
         """
         # Create 2 envs with the same organization but different locations
         org = make_org()
@@ -157,14 +157,14 @@ class EnvironmentTestCase(CLITestCase):
     def test_negative_list_with_org_and_loc_by_id(self):
         """Test Environment List filtering.
 
-        @id: b1659c48-302b-4fe3-a38b-cd34c0fd4878
+        :id: b1659c48-302b-4fe3-a38b-cd34c0fd4878
 
-        @Assert: Server returns empty result as there is no environment
-        associated with location or organization
+        :Assert: Server returns empty result as there is no environment
+            associated with location or organization
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
 
-        @BZ: 1337947
+        :BZ: 1337947
         """
         # Create env with specified organization and location
         org = make_org()
@@ -185,14 +185,14 @@ class EnvironmentTestCase(CLITestCase):
     def test_negative_list_with_org_and_loc_by_name(self):
         """Test Environment List filtering.
 
-        @id: b8382ebb-ffa3-4637-b3b4-444af6c2fe9b
+        :id: b8382ebb-ffa3-4637-b3b4-444af6c2fe9b
 
-        @Assert: Server returns empty result as there is no environment
-        associated with location or organization
+        :Assert: Server returns empty result as there is no environment
+            associated with location or organization
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
 
-        @BZ: 1337947
+        :BZ: 1337947
         """
         # Create env with specified organization and location
         org = make_org()
@@ -213,14 +213,14 @@ class EnvironmentTestCase(CLITestCase):
     def test_negative_list_with_non_existing_org_and_loc_by_id(self):
         """Test Environment List filtering parameters validation.
 
-        @id: 97872953-e1aa-44bd-9ce0-a04bccbc9e94
+        :id: 97872953-e1aa-44bd-9ce0-a04bccbc9e94
 
-        @Assert: Server returns empty result as there is no environment
-        associated with location
+        :Assert: Server returns empty result as there is no environment
+            associated with location
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
 
-        @BZ: 1337947
+        :BZ: 1337947
         """
         # Create env with specified organization and location
         org = make_org()
@@ -247,14 +247,14 @@ class EnvironmentTestCase(CLITestCase):
     def test_negative_list_with_non_existing_org_and_loc_by_name(self):
         """Test Environment List filtering parameters validation.
 
-        @id: 38cb48e3-a836-47d0-b8a8-9acd33a30546
+        :id: 38cb48e3-a836-47d0-b8a8-9acd33a30546
 
-        @Assert: Server returns empty result as there is no environment
-        associated with location
+        :Assert: Server returns empty result as there is no environment
+            associated with location
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
 
-        @BZ: 1337947
+        :BZ: 1337947
         """
         # Create env with specified organization and location
         org = make_org()
@@ -280,9 +280,9 @@ class EnvironmentTestCase(CLITestCase):
     def test_positive_create_with_name(self):
         """Successfully creates an Environment.
 
-        @id: 3b22f035-ee3a-489e-89c5-e54571584af1
+        :id: 3b22f035-ee3a-489e-89c5-e54571584af1
 
-        @Assert: Environment is created.
+        :Assert: Environment is created.
         """
         for name in valid_environments_list():
             with self.subTest(name):
@@ -293,9 +293,9 @@ class EnvironmentTestCase(CLITestCase):
     def test_negative_create_with_name(self):
         """Don't create an Environment with invalid data.
 
-        @id: 8a4141b0-3bb9-47e5-baca-f9f027086d4c
+        :id: 8a4141b0-3bb9-47e5-baca-f9f027086d4c
 
-        @Assert: Environment is not created.
+        :Assert: Environment is not created.
         """
         for name in invalid_values_list():
             with self.subTest(name):
@@ -307,9 +307,9 @@ class EnvironmentTestCase(CLITestCase):
     def test_positive_create_with_loc(self):
         """Check if Environment with Location can be created
 
-        @id: d2187971-86b2-40c9-a93c-66f37691ae2b
+        :id: d2187971-86b2-40c9-a93c-66f37691ae2b
 
-        @Assert: Environment is created and has new Location assigned
+        :Assert: Environment is created and has new Location assigned
 
         """
         new_loc = make_location()
@@ -324,9 +324,9 @@ class EnvironmentTestCase(CLITestCase):
     def test_positive_create_with_org(self):
         """Check if Environment with Organization can be created
 
-        @id: 9fd9d2d5-db46-40a7-b341-41cdbde4356a
+        :id: 9fd9d2d5-db46-40a7-b341-41cdbde4356a
 
-        @Assert: Environment is created and has new Organization assigned
+        :Assert: Environment is created and has new Organization assigned
 
         """
         new_org = make_org()
@@ -342,9 +342,9 @@ class EnvironmentTestCase(CLITestCase):
         """Create Environment with valid values then delete it
         by ID
 
-        @id: e25af73a-d4ef-4287-83bf-625337d91392
+        :id: e25af73a-d4ef-4287-83bf-625337d91392
 
-        @assert: Environment is deleted
+        :assert: Environment is deleted
         """
         for name in valid_environments_list():
             with self.subTest(name):
@@ -358,9 +358,9 @@ class EnvironmentTestCase(CLITestCase):
     def test_negative_delete_by_id(self):
         """Create Environment then delete it by wrong ID
 
-        @id: fe77920c-62fd-4e0e-b960-a940a1370d10
+        :id: fe77920c-62fd-4e0e-b960-a940a1370d10
 
-        @assert: Environment is not deleted
+        :assert: Environment is not deleted
         """
         for entity_id in invalid_id_list():
             with self.subTest(entity_id):
@@ -372,9 +372,9 @@ class EnvironmentTestCase(CLITestCase):
     def test_positive_delete_by_name(self):
         """Delete the environment by its name.
 
-        @id: 48765173-6086-4b91-9da7-594135f68751
+        :id: 48765173-6086-4b91-9da7-594135f68751
 
-        @Assert: Environment is deleted.
+        :Assert: Environment is deleted.
         """
         environment = make_environment()
         Environment.delete({'name': environment['name']})
@@ -386,9 +386,9 @@ class EnvironmentTestCase(CLITestCase):
     def test_positive_update_name(self):
         """Update the environment
 
-        @id: 7b34ce64-24be-4b3b-8f7e-1de07daafdd9
+        :id: 7b34ce64-24be-4b3b-8f7e-1de07daafdd9
 
-        @Assert: Environment Update is displayed
+        :Assert: Environment Update is displayed
         """
         environment = make_environment()
         for new_name in valid_environments_list():
@@ -405,9 +405,9 @@ class EnvironmentTestCase(CLITestCase):
     def test_negative_update_name(self):
         """Update the Environment with invalid values
 
-        @id: adc5ad73-0547-40f9-b4d4-649780cfb87a
+        :id: adc5ad73-0547-40f9-b4d4-649780cfb87a
 
-        @Assert: Environment is not updated
+        :Assert: Environment is not updated
         """
         environment = make_environment()
         for new_name in invalid_values_list():
@@ -425,9 +425,9 @@ class EnvironmentTestCase(CLITestCase):
     def test_positive_update_loc(self):
         """Update environment location with new value
 
-        @id: d58d6dc5-a820-4c61-bd69-0c631c2d3f2e
+        :id: d58d6dc5-a820-4c61-bd69-0c631c2d3f2e
 
-        @Assert: Environment Update finished and new location is assigned
+        :Assert: Environment Update finished and new location is assigned
 
         """
         old_loc = make_location()
@@ -447,9 +447,9 @@ class EnvironmentTestCase(CLITestCase):
     def test_positive_update_org(self):
         """Update environment organization with new value
 
-        @id: 2c40caf9-95a0-4b87-bd97-0a4448746052
+        :id: 2c40caf9-95a0-4b87-bd97-0a4448746052
 
-        @Assert: Environment Update finished and new organization is assigned
+        :Assert: Environment Update finished and new organization is assigned
 
         """
         old_org = make_org()
@@ -474,9 +474,9 @@ class EnvironmentTestCase(CLITestCase):
         """Check if environment sc-param subcommand works passing
         an environment id
 
-        @id: 32de4f0e-7b52-411c-a111-9ed472c3fc34
+        :id: 32de4f0e-7b52-411c-a111-9ed472c3fc34
 
-        @Assert: The command runs without raising an error
+        :Assert: The command runs without raising an error
         """
         # Override one of the sc-params from puppet class
         sc_params_list = SmartClassParameter.list({
@@ -496,9 +496,9 @@ class EnvironmentTestCase(CLITestCase):
         """Check if environment sc-param subcommand works passing
         an environment name
 
-        @id: e2fdd262-9b09-4252-8a5a-4e578e3b8547
+        :id: e2fdd262-9b09-4252-8a5a-4e578e3b8547
 
-        @Assert: The command runs without raising an error
+        :Assert: The command runs without raising an error
         """
         sc_params_list = SmartClassParameter.list({
             'environment': self.env['name'],

--- a/tests/foreman/cli/test_errata.py
+++ b/tests/foreman/cli/test_errata.py
@@ -1,18 +1,18 @@
 """CLI Tests for the errata management feature
 
-@Requirement: Errata
+:Requirement: Errata
 
-@CaseAutomation: Automated
+:CaseAutomation: Automated
 
-@CaseLevel: Acceptance
+:CaseLevel: Acceptance
 
-@CaseComponent: CLI
+:CaseComponent: CLI
 
-@TestType: Functional
+:TestType: Functional
 
-@CaseImportance: High
+:CaseImportance: High
 
-@Upstream: No
+:Upstream: No
 """
 from operator import itemgetter
 from fauxfactory import gen_string
@@ -72,18 +72,16 @@ class HostCollectionErrataInstallTestCase(CLITestCase):
     def test_positive_install_by_hc_id_and_org_id(self):
         """Using hc-id and org id to install an erratum in a hc
 
-        @id: 8b22eb9d-1321-4374-8127-6d7bfdb89ad5
+        :id: 8b22eb9d-1321-4374-8127-6d7bfdb89ad5
 
-        @Setup: Errata synced on satellite server.
+        :Setup: Errata synced on satellite server.
 
-        @Steps:
+        :Steps: host-collection erratum install --errata <errata> --id <id>
+            --organization-id <orgid>
 
-        1. host-collection erratum install --errata <errata> --id <id>
-           --organization-id <orgid>
+        :Assert: Erratum is installed.
 
-        @Assert: Erratum is installed.
-
-        @caseautomation: notautomated
+        :caseautomation: notautomated
 
         """
 
@@ -91,18 +89,16 @@ class HostCollectionErrataInstallTestCase(CLITestCase):
     def test_positive_install_by_hc_id_and_org_name(self):
         """Using hc-id and org name to install an erratum in a hc
 
-        @id: 7e5b87d7-f4d2-47b7-96aa-f86bcb64c742
+        :id: 7e5b87d7-f4d2-47b7-96aa-f86bcb64c742
 
-        @Setup: Errata synced on satellite server.
+        :Setup: Errata synced on satellite server.
 
-        @Steps:
+        :Steps: host-collection erratum install --errata <errata> --id <id>
+            --organization <org name>
 
-        1. host-collection erratum install --errata <errata> --id <id>
-           --organization <org name>
+        :Assert: Erratum is installed.
 
-        @Assert: Erratum is installed.
-
-        @caseautomation: notautomated
+        :caseautomation: notautomated
 
         """
 
@@ -110,18 +106,16 @@ class HostCollectionErrataInstallTestCase(CLITestCase):
     def test_positive_install_by_hc_id_and_org_label(self):
         """Use hc-id and org label to install an erratum in a hc
 
-        @id: bde80181-6526-43dc-bfc2-511bb5c00676
+        :id: bde80181-6526-43dc-bfc2-511bb5c00676
 
-        @Setup: errata synced on satellite server.
+        :Setup: errata synced on satellite server.
 
-        @Steps:
+        :Steps: host-collection erratum install --errata <errata> --id <id>
+            --organization-label <org label>
 
-        1. host-collection erratum install --errata <errata> --id <id>
-           --organization-label <org label>
+        :Assert: Errata is installed.
 
-        @Assert: Errata is installed.
-
-        @caseautomation: notautomated
+        :caseautomation: notautomated
 
         """
 
@@ -129,18 +123,16 @@ class HostCollectionErrataInstallTestCase(CLITestCase):
     def test_positive_install_by_hc_name_and_org_id(self):
         """Use hc-name and org id to install an erratum in a hc
 
-        @id: c4a38806-cbec-47cc-bbd6-228897b3b16d
+        :id: c4a38806-cbec-47cc-bbd6-228897b3b16d
 
-        @Setup: Errata synced on satellite server.
+        :Setup: Errata synced on satellite server.
 
-        @Steps:
+        :Steps: host-collection erratum install --errata <errata> --name <name>
+            --organization-id <orgid>
 
-        1. host-collection erratum install --errata <errata> --name <name>
-           --organization-id <orgid>
+        :Assert: Erratum is installed.
 
-        @Assert: Erratum is installed.
-
-        @caseautomation: notautomated
+        :caseautomation: notautomated
 
         """
 
@@ -148,18 +140,16 @@ class HostCollectionErrataInstallTestCase(CLITestCase):
     def test_positive_install_by_hc_name_and_org_name(self):
         """Use hc name and org name to install an erratum in a hc
 
-        @id: 501319ea-9d3c-4329-9405-4366ce6ee797
+        :id: 501319ea-9d3c-4329-9405-4366ce6ee797
 
-        @Setup: Errata synced on satellite server.
+        :Setup: Errata synced on satellite server.
 
-        @Steps:
+        :Steps: host-collection erratum install --errata <errata> --name <name>
+            --organization <org name>
 
-        1. host-collection erratum install --errata <errata> --name <name>
-           --organization <org name>
+        :Assert: Erratum is installed.
 
-        @Assert: Erratum is installed.
-
-        @caseautomation: notautomated
+        :caseautomation: notautomated
 
         """
 
@@ -167,18 +157,16 @@ class HostCollectionErrataInstallTestCase(CLITestCase):
     def test_positive_install_by_hc_name_and_org_label(self):
         """Use hc-name and org label to install an erratum in a hc
 
-        @id: 12287827-44df-4dda-872a-ac7e416e8bd7
+        :id: 12287827-44df-4dda-872a-ac7e416e8bd7
 
-        @Setup: Errata synced on satellite server.
+        :Setup: Errata synced on satellite server.
 
-        @Steps:
+        :Steps: host-collection erratum install --errata <errata> --name <name>
+            --organization-label <org label>
 
-        1. host-collection erratum install --errata <errata> --name <name>
-           --organization-label <org label>
+        :Assert: Erratum is installed.
 
-        @Assert: Erratum is installed.
-
-        @caseautomation: notautomated
+        :caseautomation: notautomated
 
         """
 
@@ -187,17 +175,16 @@ class HostCollectionErrataInstallTestCase(CLITestCase):
         """Attempt to install an erratum in a hc using hc-id and not
         specifying the erratum info
 
-        @id: 3635698d-4f09-4a60-91ea-1957e5949750
+        :id: 3635698d-4f09-4a60-91ea-1957e5949750
 
-        @Setup: Errata synced on satellite server.
+        :Setup: Errata synced on satellite server.
 
-        @Steps:
+        :Steps: host-collection erratum install --id <id> --organization-id
+            <orgid>
 
-        1. host-collection erratum install --id <id> --organization-id <orgid>
+        :Assert: Error message thrown.
 
-        @Assert: Error message thrown.
-
-        @caseautomation: notautomated
+        :caseautomation: notautomated
 
         """
 
@@ -206,18 +193,16 @@ class HostCollectionErrataInstallTestCase(CLITestCase):
         """Attempt to install an erratum in a hc using hc-name and not
         specifying the erratum info
 
-        @id: 12d78bca-efd1-407a-9bd3-f989c2bda6a8
+        :id: 12d78bca-efd1-407a-9bd3-f989c2bda6a8
 
-        @Setup: Errata synced on satellite server.
+        :Setup: Errata synced on satellite server.
 
-        @Steps:
+        :Steps: host-collection erratum install --name <name> --organization-id
+            <orgid>
 
-        1. host-collection erratum install --name <name> --organization-id
-           <orgid>
+        :Assert: Error message thrown.
 
-        @Assert: Error message thrown.
-
-        @caseautomation: notautomated
+        :caseautomation: notautomated
 
         """
 
@@ -226,18 +211,16 @@ class HostCollectionErrataInstallTestCase(CLITestCase):
         """Attempt to install an erratum in a hc by not specifying hc
         info
 
-        @id: 753d36f0-d19b-494d-a247-ce2d61c4cf74
+        :id: 753d36f0-d19b-494d-a247-ce2d61c4cf74
 
-        @Setup: Errata synced on satellite server.
+        :Setup: Errata synced on satellite server.
 
-        @Steps:
+        :Steps: host-collection erratum install --errata <errata>
+            --organization-id <orgid>
 
-        1. host-collection erratum install --errata <errata> --organization-id
-           <orgid>
+        :Assert: Error message thrown.
 
-        @Assert: Error message thrown.
-
-        @caseautomation: notautomated
+        :caseautomation: notautomated
 
         """
 
@@ -246,17 +229,15 @@ class HostCollectionErrataInstallTestCase(CLITestCase):
         """Attempt to install an erratum in a hc using hc-id and not
         specifying org info
 
-        @id: b7d32bb3-9c5f-452b-b421-f8e9976ca52c
+        :id: b7d32bb3-9c5f-452b-b421-f8e9976ca52c
 
-        @Setup: Errata synced on satellite server.
+        :Setup: Errata synced on satellite server.
 
-        @Steps:
+        :Steps: host-collection erratum install --errata <errata> --id <id>
 
-        1. host-collection erratum install --errata <errata> --id <id>
+        :Assert: Error message thrown.
 
-        @Assert: Error message thrown.
-
-        @caseautomation: notautomated
+        :caseautomation: notautomated
 
         """
 
@@ -265,17 +246,15 @@ class HostCollectionErrataInstallTestCase(CLITestCase):
         """Attempt to install an erratum in a hc without specifying org
         info
 
-        @id: 991f5b61-a4d1-444c-8a21-8ffe48e83f76
+        :id: 991f5b61-a4d1-444c-8a21-8ffe48e83f76
 
-        @Setup: Errata synced on satellite server.
+        :Setup: Errata synced on satellite server.
 
-        @Steps:
+        :Steps: host-collection erratum install --errata <errata> --name <name>
 
-        1. host-collection erratum install --errata <errata> --name <name>
+        :Assert: Error message thrown.
 
-        @Assert: Error message thrown.
-
-        @caseautomation: notautomated
+        :caseautomation: notautomated
 
         """
 
@@ -373,16 +352,16 @@ class ErrataTestCase(CLITestCase):
     def test_positive_list_sort_by_issued_date(self):
         """Sort errata by Issued date
 
-        @id: d838a969-d70a-43ae-9805-2e94dd985d6b
+        :id: d838a969-d70a-43ae-9805-2e94dd985d6b
 
-        @Setup: Errata synced on satellite server.
+        :Setup: Errata synced on satellite server.
 
-        @Steps:
+        :Steps:
 
-        1. erratum list --order 'issued ASC'
-        2. erratum list --order 'issued DESC'
+            1. erratum list --order 'issued ASC'
+            2. erratum list --order 'issued DESC'
 
-        @Assert: Errata is sorted by Issued date.
+        :Assert: Errata is sorted by Issued date.
         """
         sort_data = [('issued', 'ASC'), ('issued', 'DESC')]
         for sort_field, sort_order in sort_data:
@@ -441,16 +420,16 @@ class ErrataTestCase(CLITestCase):
     def test_positive_list_filter_by_org_id_and_sort_by_updated_date(self):
         """Filter errata by org id and sort by updated date
 
-        @id: 9b7f98ee-bbde-47b6-8727-b02550df13ae
+        :id: 9b7f98ee-bbde-47b6-8727-b02550df13ae
 
-        @Setup: Errata synced on satellite server.
+        :Setup: Errata synced on satellite server.
 
-        @Steps:
+        :Steps:
 
-        1. erratum list --organization-id=<orgid> --order 'updated ASC'
-        2. erratum list --organization-id=<orgid> --order 'updated DESC'
+            1. erratum list --organization-id=<orgid> --order 'updated ASC'
+            2. erratum list --organization-id=<orgid> --order 'updated DESC'
 
-        @Assert: Errata is filtered by org id and sorted by updated date.
+        :Assert: Errata is filtered by org id and sorted by updated date.
         """
         sort_data = [('updated', 'ASC'), ('updated', 'DESC')]
         for sort_field, sort_order in sort_data:
@@ -510,16 +489,16 @@ class ErrataTestCase(CLITestCase):
     def test_positive_list_filter_by_org_name_and_sort_by_updated_date(self):
         """Filter errata by org name and sort by updated date
 
-        @id: f202616b-cd4f-4ab2-bf2a-2788579e355a
+        :id: f202616b-cd4f-4ab2-bf2a-2788579e355a
 
-        @Setup: Errata synced on satellite server.
+        :Setup: Errata synced on satellite server.
 
-        @Steps:
+        :Steps:
 
-        1. erratum list --organization=<org name> --order 'updated ASC'
-        2. erratum list --organization=<org name> --order 'updated DESC'
+            1. erratum list --organization=<org name> --order 'updated ASC'
+            2. erratum list --organization=<org name> --order 'updated DESC'
 
-        @Assert: Errata is filtered by org name and sorted by updated date.
+        :Assert: Errata is filtered by org name and sorted by updated date.
         """
         sort_data = [('updated', 'ASC'), ('updated', 'DESC')]
         for sort_field, sort_order in sort_data:
@@ -579,16 +558,18 @@ class ErrataTestCase(CLITestCase):
     def test_positive_list_filter_by_org_label_and_sort_by_updated_date(self):
         """Filter errata by org label and sort by updated date
 
-        @id: ce891bdf-cc2f-46e9-ab43-91527d40c3ed
+        :id: ce891bdf-cc2f-46e9-ab43-91527d40c3ed
 
-        @Setup: Errata synced on satellite server.
+        :Setup: Errata synced on satellite server.
 
-        @Steps:
+        :Steps:
 
-        1. erratum list --organization-label=<org_label> --order 'updated ASC'
-        2. erratum list --organization-label=<org_label> --order 'updated DESC'
+            1. erratum list --organization-label=<org_label> --order 'updated
+               ASC'
+            2. erratum list --organization-label=<org_label> --order 'updated
+               DESC'
 
-        @Assert: Errata is filtered by org label and sorted by updated date.
+        :Assert: Errata is filtered by org label and sorted by updated date.
         """
         sort_data = [('updated', 'ASC'), ('updated', 'DESC')]
         for sort_field, sort_order in sort_data:
@@ -648,16 +629,16 @@ class ErrataTestCase(CLITestCase):
     def test_positive_list_filter_by_org_id_and_sort_by_issued_date(self):
         """Filter errata by org id and sort by issued date
 
-        @id: 5d0f396c-f930-4fe7-8d1e-5039a4ed359a
+        :id: 5d0f396c-f930-4fe7-8d1e-5039a4ed359a
 
-        @Setup: Errata synced on satellite server.
+        :Setup: Errata synced on satellite server.
 
-        @Steps:
+        :Steps:
 
-        1. erratum list --organization-id=<org_id> --order 'issued ASC'
-        2. erratum list --organization-id=<org_id> --order 'issued DESC'
+            1. erratum list --organization-id=<org_id> --order 'issued ASC'
+            2. erratum list --organization-id=<org_id> --order 'issued DESC'
 
-        @Assert: Errata is filtered by org id and sorted by issued date.
+        :Assert: Errata is filtered by org id and sorted by issued date.
         """
         sort_data = [('issued', 'ASC'), ('issued', 'DESC')]
         for sort_field, sort_order in sort_data:
@@ -717,16 +698,16 @@ class ErrataTestCase(CLITestCase):
     def test_positive_list_filter_by_org_name_and_sort_by_issued_date(self):
         """Filter errata by org name and sort by issued date
 
-        @id: 22f05ac0-fefa-48c4-861d-eeed41d9b235
+        :id: 22f05ac0-fefa-48c4-861d-eeed41d9b235
 
-        @Setup: Errata synced on satellite server.
+        :Setup: Errata synced on satellite server.
 
-        @Steps:
+        :Steps:
 
-        1. erratum list --organization=<org_name> --order 'issued ASC'
-        2. erratum list --organization=<org_name> --order 'issued DESC'
+            1. erratum list --organization=<org_name> --order 'issued ASC'
+            2. erratum list --organization=<org_name> --order 'issued DESC'
 
-        @Assert: Errata is filtered by org name and sorted by issued date.
+        :Assert: Errata is filtered by org name and sorted by issued date.
         """
         sort_data = [('issued', 'ASC'), ('issued', 'DESC')]
         for sort_field, sort_order in sort_data:
@@ -786,16 +767,18 @@ class ErrataTestCase(CLITestCase):
     def test_positive_list_filter_by_org_label_and_sort_by_issued_date(self):
         """Filter errata by org label and sort by issued date
 
-        @id: 31acb734-8705-4d3c-b05e-edfd63d1ca3b
+        :id: 31acb734-8705-4d3c-b05e-edfd63d1ca3b
 
-        @Setup: Errata synced on satellite server.
+        :Setup: Errata synced on satellite server.
 
-        @Steps:
+        :Steps:
 
-        1. erratum list --organization-label=<org_label> --order 'issued ASC'
-        2. erratum list --organization-label=<org_label> --order 'issued DESC'
+            1. erratum list --organization-label=<org_label> --order 'issued
+               ASC'
+            2. erratum list --organization-label=<org_label> --order 'issued
+               DESC'
 
-        @Assert: Errata is filtered by org label and sorted by issued date.
+        :Assert: Errata is filtered by org label and sorted by issued date.
         """
         sort_data = [('issued', 'ASC'), ('issued', 'DESC')]
         for sort_field, sort_order in sort_data:
@@ -855,15 +838,13 @@ class ErrataTestCase(CLITestCase):
     def test_positive_list_filter_by_product_id(self):
         """Filter errata by product id
 
-        @id: 7d06950a-c058-48b3-a384-c3565cbd643f
+        :id: 7d06950a-c058-48b3-a384-c3565cbd643f
 
-        @Setup: Errata synced on satellite server.
+        :Setup: Errata synced on satellite server.
 
-        @Steps:
+        :Steps: erratum list --product-id=<productid>
 
-        1. erratum list --product-id=<productid>
-
-        @Assert: Errata is filtered by product id.
+        :Assert: Errata is filtered by product id.
         """
         org_product_erratum_list = Erratum.list({
             'product-id': self.org_product['id'],
@@ -899,15 +880,14 @@ class ErrataTestCase(CLITestCase):
     def test_positive_list_filter_by_product_id_and_org_id(self):
         """Filter errata by product id and Org id
 
-        @id: caf14671-d8b2-4a23-8c7e-6667bb78d4b7
+        :id: caf14671-d8b2-4a23-8c7e-6667bb78d4b7
 
-        @Setup: Errata synced on satellite server.
+        :Setup: Errata synced on satellite server.
 
-        @Steps:
+        :Steps: erratum list --product-id=<product_id>
+            --organization-id=<org_id>
 
-        1. erratum list --product-id=<product_id> --organization-id=<org_id>
-
-        @Assert: Errata is filtered by product id and Org id.
+        :Assert: Errata is filtered by product id and Org id.
         """
         product_erratum_list = Erratum.list({
             'organization-id': self.org['id'],
@@ -971,15 +951,14 @@ class ErrataTestCase(CLITestCase):
     def test_positive_list_filter_by_product_id_and_org_name(self):
         """Filter errata by product id and Org name
 
-        @id: 574a6f7e-a89e-482e-bf15-39cfd7730630
+        :id: 574a6f7e-a89e-482e-bf15-39cfd7730630
 
-        @Setup: errata synced on satellite server.
+        :Setup: errata synced on satellite server.
 
-        @Steps:
+        :Steps: erratum list --product-id=<product_id>
+            --organization=<org_name>
 
-        1. erratum list --product-id=<product_id> --organization=<org_name>
-
-        @Assert: Errata is filtered by product id and Org name.
+        :Assert: Errata is filtered by product id and Org name.
         """
         product_erratum_list = Erratum.list({
             'organization': self.org['name'],
@@ -1042,16 +1021,14 @@ class ErrataTestCase(CLITestCase):
     def test_positive_list_filter_by_product_id_and_org_label(self):
         """Filter errata by product id and Org label
 
-        @id: 7b92ee32-2386-452c-9443-65b0c233a564
+        :id: 7b92ee32-2386-452c-9443-65b0c233a564
 
-        @Setup: errata synced on satellite server.
+        :Setup: errata synced on satellite server.
 
-        @Steps:
+        :Steps: erratum list --product-id=<product_id>
+            --organization-label=<org_label>
 
-        1. erratum list --product-id=<product_id>
-           --organization-label=<org_label>
-
-        @Assert: Errata is filtered by product id and Org label
+        :Assert: Errata is filtered by product id and Org label
         """
         product_erratum_list = Erratum.list({
             'organization-label': self.org['label'],
@@ -1112,34 +1089,31 @@ class ErrataTestCase(CLITestCase):
     def test_positive_list_filter_by_product_name(self):
         """Filter errata by product name
 
-        @id: c7a5988b-668f-4c48-bc1e-97cb968a2563
+        :id: c7a5988b-668f-4c48-bc1e-97cb968a2563
 
-        @Setup: Errata synced on satellite server.
+        :Setup: Errata synced on satellite server.
 
-        @Steps:
+        :Steps: erratum list --product=<productname>
 
-        1. erratum list --product=<productname>
+        :Assert: Errata is filtered by product name.
 
-        @Assert: Errata is filtered by product name.
+        :caseautomation: notautomated
 
-        @caseautomation: notautomated
-
-        @BZ: 1400235
+        :BZ: 1400235
         """
 
     @tier3
     def test_positive_list_filter_by_product_name_and_org_id(self):
         """Filter errata by product name and Org id
 
-        @id: 53f7afa2-285d-4d40-9fdd-5013b3f02462
+        :id: 53f7afa2-285d-4d40-9fdd-5013b3f02462
 
-        @Setup: Errata synced on satellite server.
+        :Setup: Errata synced on satellite server.
 
-        @Steps:
+        :Steps: erratum list --product=<product_name>
+            --organization-id=<org_id>
 
-        1. erratum list --product=<product_name> --organization-id=<org_id>
-
-        @Assert: Errata is filtered by product name and Org id.
+        :Assert: Errata is filtered by product name and Org id.
         """
         product_erratum_list = Erratum.list({
             'organization-id': self.org['id'],
@@ -1200,15 +1174,13 @@ class ErrataTestCase(CLITestCase):
     def test_positive_list_filter_by_product_name_and_org_name(self):
         """Filter errata by product name and Org name
 
-        @id: 8102d688-30d7-4ee5-a1aa-7e041d842a6f
+        :id: 8102d688-30d7-4ee5-a1aa-7e041d842a6f
 
-        @Setup: Errata synced on satellite server.
+        :Setup: Errata synced on satellite server.
 
-        @Steps:
+        :Steps: erratum list --product=<product_name> --organization=<org_name>
 
-        1. erratum list --product=<product_name> --organization=<org_name>
-
-        @Assert: Errata is filtered by product name and Org name.
+        :Assert: Errata is filtered by product name and Org name.
         """
         product_erratum_list = Erratum.list({
             'organization': self.org['name'],
@@ -1269,16 +1241,14 @@ class ErrataTestCase(CLITestCase):
     def test_positive_list_filter_by_product_name_and_org_label(self):
         """Filter errata by product name and Org label
 
-        @id: 64abb151-3f9d-4cad-b4a1-6bf0d73d8a3c
+        :id: 64abb151-3f9d-4cad-b4a1-6bf0d73d8a3c
 
-        @Setup: Errata synced on satellite server.
+        :Setup: Errata synced on satellite server.
 
-        @Steps:
+        :Steps: erratum list --product=<product_name>
+            --organization-label=<org_label>
 
-        1. erratum list --product=<product_name>
-           --organization-label=<org_label>
-
-        @Assert: Errata is filtered by product name and Org label.
+        :Assert: Errata is filtered by product name and Org label.
         """
         product_erratum_list = Erratum.list({
             'organization-label': self.org['label'],
@@ -1339,15 +1309,13 @@ class ErrataTestCase(CLITestCase):
     def test_positive_list_filter_by_org_id(self):
         """Filter errata by Org id
 
-        @id: eeb2b409-89dc-4576-9f89-520cf7152a5a
+        :id: eeb2b409-89dc-4576-9f89-520cf7152a5a
 
-        @Setup: Errata synced on satellite server.
+        :Setup: Errata synced on satellite server.
 
-        @Steps:
+        :Steps: erratum list --organization-id=<orgid>
 
-        1. erratum list --organization-id=<orgid>
-
-        @Assert: Errata is filtered by Org id.
+        :Assert: Errata is filtered by Org id.
         """
         org_erratum_list = Erratum.list({
             'organization-id': self.org['id'],
@@ -1379,15 +1347,13 @@ class ErrataTestCase(CLITestCase):
     def test_positive_list_filter_by_org_name(self):
         """Filter errata by Org name
 
-        @id: f2b20bb5-0938-4c7b-af95-d2b3e2b36581
+        :id: f2b20bb5-0938-4c7b-af95-d2b3e2b36581
 
-        @Setup: Errata synced on satellite server.
+        :Setup: Errata synced on satellite server.
 
-        @Steps:
+        :Steps: erratum list --organization=<org name>
 
-        1. erratum list --organization=<org name>
-
-        @Assert: Errata is filtered by Org name.
+        :Assert: Errata is filtered by Org name.
         """
         org_erratum_list = Erratum.list({
             'organization': self.org['name'],
@@ -1419,15 +1385,13 @@ class ErrataTestCase(CLITestCase):
     def test_positive_list_filter_by_org_label(self):
         """Filter errata by Org label
 
-        @id: 398123f5-d3ad-4a16-ac5d-e157d6d67595
+        :id: 398123f5-d3ad-4a16-ac5d-e157d6d67595
 
-        @Setup: Errata synced on satellite server.
+        :Setup: Errata synced on satellite server.
 
-        @Steps:
+        :Steps: erratum list --organization-label=<org_label>
 
-        1. erratum list --organization-label=<org_label>
-
-        @Assert: Errata is filtered by Org label.
+        :Assert: Errata is filtered by Org label.
         """
         org_erratum_list = Erratum.list({
             'organization-label': self.org['label'],
@@ -1461,15 +1425,13 @@ class ErrataTestCase(CLITestCase):
     def test_positive_list_filter_by_cve(self):
         """Filter errata by CVE
 
-        @id: 7791137c-95a7-4518-a56b-766a5680c5fb
+        :id: 7791137c-95a7-4518-a56b-766a5680c5fb
 
-        @Setup: Errata synced on satellite server.
+        :Setup: Errata synced on satellite server.
 
-        @Steps:
+        :Steps: erratum list --cve <cve_id>
 
-        1. erratum list --cve <cve_id>
-
-        @Assert: Errata is filtered by CVE.
+        :Assert: Errata is filtered by CVE.
 
         """
         org = make_org()
@@ -1512,21 +1474,19 @@ class ErrataTestCase(CLITestCase):
     def test_positive_user_permission(self):
         """Show errata only if the User has permissions to view them
 
-        @id: f350c13b-8cf9-4aa5-8c3a-1c48397ea514
+        :id: f350c13b-8cf9-4aa5-8c3a-1c48397ea514
 
-        @Setup:
+        :Setup:
 
-        1. Create two products with one repo each. Sync them.
-        2. Make sure that they both have errata.
-        3. Create a user with view access on one product and not on the other.
+            1. Create two products with one repo each. Sync them.
+            2. Make sure that they both have errata.
+            3. Create a user with view access on one product and not on the
+               other.
 
-        @Steps:
+        :Steps: erratum list --organization-id=<orgid>
 
-        1. erratum list --organization-id=<orgid>
-
-        @Assert: Check that the new user is able to see errata for one
-        product only.
-
+        :Assert: Check that the new user is able to see errata for one product
+            only.
         """
         user_password = gen_string('alphanumeric')
         user_name = gen_string('alphanumeric')
@@ -1612,18 +1572,16 @@ class ErrataTestCase(CLITestCase):
     def test_positive_list_affected_chosts(self):
         """View a list of affected content hosts for an erratum
 
-        @id: 3b592253-52c0-4165-9a48-ba55287e9ee9
+        :id: 3b592253-52c0-4165-9a48-ba55287e9ee9
 
-        @Setup: Errata synced on satellite server.
+        :Setup: Errata synced on satellite server.
 
-        @Steps:
+        :Steps: content-host list --erratum-id=<erratum_id>
+            --organization-id=<org_id>
 
-        1. content-host list --erratum-id=<erratum_id>
-           --organization-id=<org_id>
+        :Assert: List of affected content hosts for an erratum is displayed.
 
-        @Assert: List of affected content hosts for an erratum is displayed.
-
-        @caseautomation: notautomated
+        :caseautomation: notautomated
 
         """
 
@@ -1632,25 +1590,25 @@ class ErrataTestCase(CLITestCase):
         """View a list of affected content hosts for an erratum filtered
         with restrict flags
 
-        @id: 594acd48-892c-499e-b0cb-6506cea7cd64
+        :id: 594acd48-892c-499e-b0cb-6506cea7cd64
 
-        @Setup: Errata synced on satellite server.
+        :Setup: Errata synced on satellite server.
 
-        @Steps:
+        :Steps:
 
-        1. content-host list --erratum-id=<erratum_id>
-           --organization-id=<org_id> --erratum-restrict-available=1
-        2. content-host list --erratum-id=<erratum_id>
-           --organization-id=<org_id> --erratum-restrict-unavailable=1
-        3. content-host list --erratum-id=<erratum_id>
-           --organization-id=<org_id> --erratum-restrict-available=0
-        4. content-host list --erratum-id=<erratum_id>
-           --organization-id=<org_id> --erratum-restrict-unavailable=0
+            1. content-host list --erratum-id=<erratum_id>
+               --organization-id=<org_id> --erratum-restrict-available=1
+            2. content-host list --erratum-id=<erratum_id>
+               --organization-id=<org_id> --erratum-restrict-unavailable=1
+            3. content-host list --erratum-id=<erratum_id>
+               --organization-id=<org_id> --erratum-restrict-available=0
+            4. content-host list --erratum-id=<erratum_id>
+               --organization-id=<org_id> --erratum-restrict-unavailable=0
 
-        @Assert: List of affected content hosts for an erratum is displayed
-        filtered with corresponding restrict flags.
+        :Assert: List of affected content hosts for an erratum is displayed
+            filtered with corresponding restrict flags.
 
-        @caseautomation: notautomated
+        :caseautomation: notautomated
 
         """
 
@@ -1659,19 +1617,17 @@ class ErrataTestCase(CLITestCase):
         """Available errata count displayed while viewing a list of
         Content hosts
 
-        @id: 1d174432-bb51-4192-990d-3c62087b96df
+        :id: 1d174432-bb51-4192-990d-3c62087b96df
 
-        @Setup:
+        :Setup:
 
-        1. Errata synced on satellite server.
-        2. Some content hosts present.
+            1. Errata synced on satellite server.
+            2. Some content hosts present.
 
-        @Steps:
+        :Steps: hammer content-host list --organization-id=<orgid>
 
-        1. hammer content-host list --organization-id=<orgid>
+        :Assert: The available errata count is retrieved.
 
-        @Assert: The available errata count is retrieved.
-
-        @caseautomation: notautomated
+        :caseautomation: notautomated
 
         """

--- a/tests/foreman/cli/test_fact.py
+++ b/tests/foreman/cli/test_fact.py
@@ -1,18 +1,18 @@
 """Test class for Fact  CLI
 
-@Requirement: Fact
+:Requirement: Fact
 
-@CaseAutomation: Automated
+:CaseAutomation: Automated
 
-@CaseLevel: Acceptance
+:CaseLevel: Acceptance
 
-@CaseComponent: CLI
+:CaseComponent: CLI
 
-@TestType: Functional
+:TestType: Functional
 
-@CaseImportance: High
+:CaseImportance: High
 
-@Upstream: No
+:Upstream: No
 """
 
 from fauxfactory import gen_string
@@ -29,9 +29,9 @@ class FactTestCase(CLITestCase):
     def test_positive_list_by_name(self):
         """Test Fact List
 
-        @id: 83794d97-d21b-4482-9522-9b41053e595f
+        :id: 83794d97-d21b-4482-9522-9b41053e595f
 
-        @Assert: Fact List is displayed
+        :Assert: Fact List is displayed
 
         """
         for fact in (
@@ -50,9 +50,9 @@ class FactTestCase(CLITestCase):
     def test_negative_list_by_name(self):
         """Test Fact List failure
 
-        @id: bd56d27e-59c0-4f35-bd53-2999af7c6946
+        :id: bd56d27e-59c0-4f35-bd53-2999af7c6946
 
-        @Assert: Fact List is not displayed
+        :Assert: Fact List is not displayed
 
         """
         fact = gen_string('alpha')

--- a/tests/foreman/cli/test_filter.py
+++ b/tests/foreman/cli/test_filter.py
@@ -1,19 +1,19 @@
 # -*- encoding: utf-8 -*-
 """Test for Roles CLI
 
-@Requirement: Filter
+:Requirement: Filter
 
-@CaseAutomation: Automated
+:CaseAutomation: Automated
 
-@CaseLevel: Acceptance
+:CaseLevel: Acceptance
 
-@CaseComponent: CLI
+:CaseComponent: CLI
 
-@TestType: Functional
+:TestType: Functional
 
-@CaseImportance: High
+:CaseImportance: High
 
-@Upstream: No
+:Upstream: No
 """
 
 from robottelo.cli.base import CLIReturnCodeError
@@ -50,9 +50,9 @@ class FilterTestCase(APITestCase):
     def test_positive_create_with_permission(self):
         """Create a filter and assign it some permissions.
 
-        @id: 6da6c5d3-2727-4eb7-aa15-9f7b6f91d3b2
+        :id: 6da6c5d3-2727-4eb7-aa15-9f7b6f91d3b2
 
-        @Assert: The created filter has the assigned permissions.
+        :Assert: The created filter has the assigned permissions.
         """
         # Assign filter to created role
         filter_ = make_filter({
@@ -69,9 +69,9 @@ class FilterTestCase(APITestCase):
     def test_positive_create_with_org(self):
         """Create a filter and assign it some permissions.
 
-        @id: f6308192-0e1f-427b-a296-b285f6684691
+        :id: f6308192-0e1f-427b-a296-b285f6684691
 
-        @Assert: The created filter has the assigned permissions.
+        :Assert: The created filter has the assigned permissions.
         """
         org = make_org()
         # Assign filter to created role
@@ -88,9 +88,9 @@ class FilterTestCase(APITestCase):
     def test_positive_create_with_loc(self):
         """Create a filter and assign it some permissions.
 
-        @id: d7d1969a-cb30-4e97-a9a3-3a4aaf608795
+        :id: d7d1969a-cb30-4e97-a9a3-3a4aaf608795
 
-        @Assert: The created filter has the assigned permissions.
+        :Assert: The created filter has the assigned permissions.
         """
         loc = make_location()
         # Assign filter to created role
@@ -106,9 +106,9 @@ class FilterTestCase(APITestCase):
     def test_positive_delete(self):
         """Create a filter and delete it afterwards.
 
-        @id: 97d1093c-0d49-454b-86f6-f5be87b32775
+        :id: 97d1093c-0d49-454b-86f6-f5be87b32775
 
-        @Assert: The deleted filter cannot be fetched.
+        :Assert: The deleted filter cannot be fetched.
         """
         filter_ = make_filter({
             'role-id': self.role['id'],
@@ -122,9 +122,9 @@ class FilterTestCase(APITestCase):
     def test_positive_delete_role(self):
         """Create a filter and delete the role it points at.
 
-        @id: e2adb6a4-e408-4912-a32d-2bf2c43187d9
+        :id: e2adb6a4-e408-4912-a32d-2bf2c43187d9
 
-        @Assert: The filter cannot be fetched.
+        :Assert: The filter cannot be fetched.
         """
         filter_ = make_filter({
             'role-id': self.role['id'],
@@ -143,9 +143,9 @@ class FilterTestCase(APITestCase):
     def test_positive_update_permissions(self):
         """Create a filter and update its permissions.
 
-        @id: 3d6a52d8-2f8f-4f97-a155-9b52888af16e
+        :id: 3d6a52d8-2f8f-4f97-a155-9b52888af16e
 
-        @Assert: Permissions updated.
+        :Assert: Permissions updated.
         """
         filter_ = make_filter({
             'role-id': self.role['id'],
@@ -170,9 +170,9 @@ class FilterTestCase(APITestCase):
     def test_positive_update_role(self):
         """Create a filter and assign it to another role.
 
-        @id: 2950b3a1-2bce-447f-9df2-869b1d10eaf5
+        :id: 2950b3a1-2bce-447f-9df2-869b1d10eaf5
 
-        @Assert: Filter is created and assigned to new role.
+        :Assert: Filter is created and assigned to new role.
         """
         filter_ = make_filter({
             'role-id': self.role['id'],
@@ -192,9 +192,9 @@ class FilterTestCase(APITestCase):
     def test_positive_update_org_loc(self):
         """Create a filter and assign it to another organization and location.
 
-         @id: 9bb59109-9701-4ef3-95c6-81f387d372da
+         :id: 9bb59109-9701-4ef3-95c6-81f387d372da
 
-         @Assert: Filter is created and assigned to new org and loc.
+         :Assert: Filter is created and assigned to new org and loc.
          """
         org = make_org()
         loc = make_location()

--- a/tests/foreman/cli/test_globalparam.py
+++ b/tests/foreman/cli/test_globalparam.py
@@ -1,19 +1,19 @@
 # -*- encoding: utf-8 -*-
 """Test class for Global parameters CLI
 
-@Requirement: Globalparam
+:Requirement: Globalparam
 
-@CaseAutomation: Automated
+:CaseAutomation: Automated
 
-@CaseLevel: Acceptance
+:CaseLevel: Acceptance
 
-@CaseComponent: CLI
+:CaseComponent: CLI
 
-@TestType: Functional
+:TestType: Functional
 
-@CaseImportance: High
+:CaseImportance: High
 
-@Upstream: No
+:Upstream: No
 """
 
 from fauxfactory import gen_string
@@ -31,9 +31,9 @@ class GlobalParameterTestCase(CLITestCase):
     def test_positive_set(self):
         """Check if Global Param can be set
 
-        @id: af0d3338-d7a1-41e5-959a-289ebc326c5b
+        :id: af0d3338-d7a1-41e5-959a-289ebc326c5b
 
-        @Assert: Global Param is set
+        :Assert: Global Param is set
 
         """
         name = 'opt-%s' % gen_string('alpha', 10)
@@ -49,9 +49,9 @@ class GlobalParameterTestCase(CLITestCase):
     def test_positive_list_by_name(self):
         """Test Global Param List
 
-        @id: 8dd6c4e8-4ec9-4bee-8a04-f5788960973a
+        :id: 8dd6c4e8-4ec9-4bee-8a04-f5788960973a
 
-        @Assert: Global Param List is displayed
+        :Assert: Global Param List is displayed
 
         """
         name = 'opt-%s' % gen_string('alpha', 10)
@@ -70,9 +70,9 @@ class GlobalParameterTestCase(CLITestCase):
     def test_positive_delete_by_name(self):
         """Check if Global Param can be deleted
 
-        @id: 2c44d9c9-2a21-4415-8e89-cfd3d963891b
+        :id: 2c44d9c9-2a21-4415-8e89-cfd3d963891b
 
-        @Assert: Global Param is deleted
+        :Assert: Global Param is deleted
 
         """
         name = 'opt-%s' % gen_string('alpha', 10)

--- a/tests/foreman/cli/test_gpgkey.py
+++ b/tests/foreman/cli/test_gpgkey.py
@@ -1,19 +1,19 @@
 # -*- encoding: utf-8 -*-
 """Test class for GPG Key CLI
 
-@Requirement: Gpgkey
+:Requirement: Gpgkey
 
-@CaseAutomation: Automated
+:CaseAutomation: Automated
 
-@CaseLevel: Acceptance
+:CaseLevel: Acceptance
 
-@CaseComponent: CLI
+:CaseComponent: CLI
 
-@TestType: Functional
+:TestType: Functional
 
-@CaseImportance: High
+:CaseImportance: High
 
-@Upstream: No
+:Upstream: No
 """
 
 from fauxfactory import (
@@ -87,9 +87,9 @@ class TestGPGKey(CLITestCase):
     def test_verify_redmine_4272(self):
         """gpg info should display key content
 
-        @id: 2c6176ca-34dd-4d52-930d-6e79da6b0c15
+        :id: 2c6176ca-34dd-4d52-930d-6e79da6b0c15
 
-        @Assert: gpg info should display key content
+        :Assert: gpg info should display key content
         """
         # Setup a new key file
         content = gen_alphanumeric()
@@ -107,9 +107,9 @@ class TestGPGKey(CLITestCase):
     def test_positive_get_info_by_name(self):
         """Create single gpg key and get its info by name
 
-        @id: be418cf8-8a90-46db-9e8c-8ff349c98401
+        :id: be418cf8-8a90-46db-9e8c-8ff349c98401
 
-        @Assert: specific information for GPG key matches the creation name
+        :Assert: specific information for GPG key matches the creation name
         """
         name = gen_string('utf8')
         gpg_key = make_gpg_key({
@@ -131,9 +131,9 @@ class TestGPGKey(CLITestCase):
         """Create gpg key with valid name and valid gpg key via file
         import using the default created organization
 
-        @id: c64d4959-e53e-44c0-82da-dc4dd4c89733
+        :id: c64d4959-e53e-44c0-82da-dc4dd4c89733
 
-        @assert: gpg key is created
+        :assert: gpg key is created
         """
         org = Org.info({'name': DEFAULT_ORG})
         for name in valid_data_list():
@@ -159,9 +159,9 @@ class TestGPGKey(CLITestCase):
         """Create gpg key with valid name and valid gpg key via file
         import using a new organization
 
-        @id: f1bcf748-0890-4b54-8f30-2df4924c80b3
+        :id: f1bcf748-0890-4b54-8f30-2df4924c80b3
 
-        @assert: gpg key is created
+        :assert: gpg key is created
         """
         for name in valid_data_list():
             with self.subTest(name):
@@ -188,9 +188,9 @@ class TestGPGKey(CLITestCase):
         """Create gpg key with valid name and valid gpg key via file
         import then try to create new one with same name
 
-        @id: 3f1423da-bcc1-4320-8b9b-260784eb123c
+        :id: 3f1423da-bcc1-4320-8b9b-260784eb123c
 
-        @assert: gpg key is not created
+        :assert: gpg key is not created
         """
         name = gen_string('alphanumeric')
         gpg_key = make_gpg_key({
@@ -215,9 +215,9 @@ class TestGPGKey(CLITestCase):
     def test_negative_create_with_no_gpg_key(self):
         """Create gpg key with valid name and no gpg key
 
-        @id: 9440a1a0-eb0d-445e-88d3-3139c2b1d17a
+        :id: 9440a1a0-eb0d-445e-88d3-3139c2b1d17a
 
-        @assert: gpg key is not created
+        :assert: gpg key is not created
         """
         for name in valid_data_list():
             with self.subTest(name):
@@ -233,9 +233,9 @@ class TestGPGKey(CLITestCase):
         """Create gpg key with invalid name and valid gpg key via
         file import
 
-        @id: 93160f88-b653-42a9-b44f-9b2ba56f38d9
+        :id: 93160f88-b653-42a9-b44f-9b2ba56f38d9
 
-        @assert: gpg key is not created
+        :assert: gpg key is not created
         """
         for name in invalid_values_list():
             with self.subTest(name):
@@ -253,9 +253,9 @@ class TestGPGKey(CLITestCase):
         """Create gpg key with valid name and valid gpg key via file
         import then delete it
 
-        @id: 5bf72e5c-767a-4321-8781-a5cea9474421
+        :id: 5bf72e5c-767a-4321-8781-a5cea9474421
 
-        @assert: gpg key is deleted
+        :assert: gpg key is deleted
         """
         for name in valid_data_list():
             with self.subTest(name):
@@ -289,9 +289,9 @@ class TestGPGKey(CLITestCase):
         """Create gpg key with valid name and valid gpg key via file
         import then update its name
 
-        @id: e18d7cd8-2757-4134-9ed9-7eb68f2872e2
+        :id: e18d7cd8-2757-4134-9ed9-7eb68f2872e2
 
-        @assert: gpg key is updated
+        :assert: gpg key is updated
         """
         gpg_key = make_gpg_key({'organization-id': self.org['id']})
         for new_name in valid_data_list():
@@ -312,9 +312,9 @@ class TestGPGKey(CLITestCase):
         """Create gpg key with valid name and valid gpg key via file
         import then update its gpg key file
 
-        @id: 58a8ed14-adfc-4046-af63-59a7008ff4d7
+        :id: 58a8ed14-adfc-4046-af63-59a7008ff4d7
 
-        @assert: gpg key is updated
+        :assert: gpg key is updated
         """
         gpg_key = make_gpg_key({'organization-id': self.org['id']})
         content = gen_alphanumeric(gen_integer(20, 50))
@@ -341,9 +341,9 @@ class TestGPGKey(CLITestCase):
         """Create gpg key with valid name and valid gpg key via file
         import then fail to update its name
 
-        @id: 938d2925-c82c-43b6-8dfc-29c42eca7424
+        :id: 938d2925-c82c-43b6-8dfc-29c42eca7424
 
-        @assert: gpg key is not updated
+        :assert: gpg key is not updated
         """
         gpg_key = make_gpg_key({'organization-id': self.org['id']})
         for new_name in invalid_values_list():
@@ -362,11 +362,11 @@ class TestGPGKey(CLITestCase):
         """Create gpg key with valid name and valid gpg key via file
         import then associate it with empty (no repos) custom product
 
-        @id: b7477c2f-586c-4593-96c0-1fbc532ce8bf
+        :id: b7477c2f-586c-4593-96c0-1fbc532ce8bf
 
-        @assert: gpg key is associated with product
+        :assert: gpg key is associated with product
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         gpg_key = make_gpg_key({'organization-id': self.org['id']})
         product = make_product({
@@ -381,12 +381,12 @@ class TestGPGKey(CLITestCase):
         """Create gpg key with valid name and valid gpg key via file
         import then associate it with custom product that has one repository
 
-        @id: 5529a852-9ef6-48f8-b2bc-2bbf463657dd
+        :id: 5529a852-9ef6-48f8-b2bc-2bbf463657dd
 
-        @assert: gpg key is associated with product as well as with
-        the repository
+        :assert: gpg key is associated with product as well as with the
+            repository
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         product = make_product({'organization-id': self.org['id']})
         repo = make_repository({'product-id': product['id']})
@@ -411,12 +411,12 @@ class TestGPGKey(CLITestCase):
         import then associate it with custom product that has more than one
         repository
 
-        @id: b05c5223-44d5-4a48-9d99-18ca351c84a5
+        :id: b05c5223-44d5-4a48-9d99-18ca351c84a5
 
-        @assert: gpg key is associated with product as well as with
-        the repositories
+        :assert: gpg key is associated with product as well as with the
+            repositories
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         product = make_product({'organization-id': self.org['id']})
         repos = [
@@ -446,13 +446,13 @@ class TestGPGKey(CLITestCase):
         import then associate it with custom product using Repo discovery
         method
 
-        @id: fb12db0f-583f-49f4-9d8f-d19f2d5550ee
+        :id: fb12db0f-583f-49f4-9d8f-d19f2d5550ee
 
-        @assert: gpg key is associated with product but not the repositories
+        :assert: gpg key is associated with product but not the repositories
 
-        @caseautomation: notautomated
+        :caseautomation: notautomated
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
 
     @run_only_on('sat')
@@ -462,12 +462,12 @@ class TestGPGKey(CLITestCase):
         import then associate it to repository from custom product that has
         one repository
 
-        @id: 1427f145-9faf-41ef-ae42-dc91d61ce1f6
+        :id: 1427f145-9faf-41ef-ae42-dc91d61ce1f6
 
-        @assert: gpg key is associated with the repository but not with
-        the product
+        :assert: gpg key is associated with the repository but not with the
+            product
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         product = make_product({'organization-id': self.org['id']})
         repo = make_repository({'product-id': product['id']})
@@ -494,11 +494,11 @@ class TestGPGKey(CLITestCase):
         to one repository from custom product. Make sure custom product should
         have more than one repository.
 
-        @id: 9796f6f0-e688-4f14-89ec-447feb4e4911
+        :id: 9796f6f0-e688-4f14-89ec-447feb4e4911
 
-        @assert: gpg key is associated with the repository
+        :assert: gpg key is associated with the repository
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         product = make_product({'organization-id': self.org['id']})
         repos = [
@@ -532,13 +532,13 @@ class TestGPGKey(CLITestCase):
         import then associate it to repos from custom product using Repo
         discovery method
 
-        @id: 1e91871c-0298-4cd0-b63b-f02d02622259
+        :id: 1e91871c-0298-4cd0-b63b-f02d02622259
 
-        @assert: gpg key is associated with product and all the repositories
+        :assert: gpg key is associated with product and all the repositories
 
-        @caseautomation: notautomated
+        :caseautomation: notautomated
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
 
     @run_only_on('sat')
@@ -548,11 +548,11 @@ class TestGPGKey(CLITestCase):
         import then associate it with empty (no repos) custom product then
         update the key
 
-        @id: c0c84c45-21fc-4940-9d52-00babb807ec7
+        :id: c0c84c45-21fc-4940-9d52-00babb807ec7
 
-        @assert: gpg key is associated with product before/after update
+        :assert: gpg key is associated with product before/after update
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         # Create a product and a gpg key
         product = make_product({'organization-id': self.org['id']})
@@ -596,12 +596,12 @@ class TestGPGKey(CLITestCase):
         import then associate it with custom product that has one repository
         then update the key
 
-        @id: 3fb550a7-507e-4988-beb6-35bdfc2e99a8
+        :id: 3fb550a7-507e-4988-beb6-35bdfc2e99a8
 
-        @assert: gpg key is associated with product before/after update as well
-        as with the repository
+        :assert: gpg key is associated with product before/after update as well
+            as with the repository
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         # Create a product and a gpg key
         product = make_product({'organization-id': self.org['id']})
@@ -652,12 +652,12 @@ class TestGPGKey(CLITestCase):
         import then associate it with custom product that has more than one
         repository then update the key
 
-        @id: a95eb51b-4b6b-4c04-bb4d-cbe600431850
+        :id: a95eb51b-4b6b-4c04-bb4d-cbe600431850
 
-        @assert: gpg key is associated with product before/after update as well
-        as with the repositories
+        :assert: gpg key is associated with product before/after update as well
+            as with the repositories
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         # Create a product and a gpg key
         product = make_product({'organization-id': self.org['id']})
@@ -714,14 +714,14 @@ class TestGPGKey(CLITestCase):
         import then associate it with custom product using Repo discovery
         method then update the key
 
-        @id: 8092bd11-75f3-4657-9309-d327498e7d52
+        :id: 8092bd11-75f3-4657-9309-d327498e7d52
 
-        @assert: gpg key is associated with product before/after update but
-        not the repositories
+        :assert: gpg key is associated with product before/after update but not
+            the repositories
 
-        @caseautomation: notautomated
+        :caseautomation: notautomated
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
 
     @run_only_on('sat')
@@ -731,12 +731,12 @@ class TestGPGKey(CLITestCase):
         import then associate it to repository from custom product that has
         one repository then update the key
 
-        @id: 549e2e1e-fd10-4487-a3a5-fdee9b8cfc48
+        :id: 549e2e1e-fd10-4487-a3a5-fdee9b8cfc48
 
-        @assert: gpg key is associated with the repository before/after update,
-        but not with the product
+        :assert: gpg key is associated with the repository before/after update,
+            but not with the product
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         # Create a product and a gpg key
         product = make_product({'organization-id': self.org['id']})
@@ -778,12 +778,12 @@ class TestGPGKey(CLITestCase):
         import then associate it to repository from custom product that has
         more than one repository then update the key
 
-        @id: 773a9141-9f04-40ba-b3df-4b6d80db25a6
+        :id: 773a9141-9f04-40ba-b3df-4b6d80db25a6
 
-        @assert: gpg key is associated with a single repository before/after
-        update and not associated with product or other repositories
+        :assert: gpg key is associated with a single repository before/after
+            update and not associated with product or other repositories
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         # Create a product and a gpg key
         product = make_product({'organization-id': self.org['id']})
@@ -837,14 +837,14 @@ class TestGPGKey(CLITestCase):
         import then associate it to repos from custom product using Repo
         discovery method then update the key
 
-        @id: 21dfd9b0-3de9-4876-aeea-c856adb5ed98
+        :id: 21dfd9b0-3de9-4876-aeea-c856adb5ed98
 
-        @assert: gpg key is associated with product and all repositories
-        before/after update
+        :assert: gpg key is associated with product and all repositories
+            before/after update
 
-        @caseautomation: notautomated
+        :caseautomation: notautomated
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
 
     @run_only_on('sat')
@@ -854,12 +854,12 @@ class TestGPGKey(CLITestCase):
         import then associate it with empty (no repos) custom product
         then delete it
 
-        @id: da76cada-5ccf-47e1-8c12-24f30c41c8b6
+        :id: da76cada-5ccf-47e1-8c12-24f30c41c8b6
 
-        @assert: gpg key is associated with product during creation but removed
-        from product after deletion
+        :assert: gpg key is associated with product during creation but removed
+            from product after deletion
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         # Create a product and a gpg key
         gpg_key = make_gpg_key({'organization-id': self.org['id']})
@@ -894,12 +894,13 @@ class TestGPGKey(CLITestCase):
         import then associate it with custom product that has one repository
         then delete it
 
-        @id: a5d4ea02-f015-4026-b4dc-7365eaf00049
+        :id: a5d4ea02-f015-4026-b4dc-7365eaf00049
 
-        @assert: gpg key is associated with product but and its repository
-        during creation but removed from product and repository after deletion
+        :assert: gpg key is associated with product but and its repository
+            during creation but removed from product and repository after
+            deletion
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         # Create product, repository and gpg key
         product = make_product({'organization-id': self.org['id']})
@@ -946,13 +947,13 @@ class TestGPGKey(CLITestCase):
         import then associate it with custom product that has more than one
         repository then delete it
 
-        @id: f92d4643-1892-4f95-ae6b-fcea8e726946
+        :id: f92d4643-1892-4f95-ae6b-fcea8e726946
 
-        @assert: gpg key is associated with product and its repositories
-        during creation but removed from the product and the repositories after
-        deletion
+        :assert: gpg key is associated with product and its repositories during
+            creation but removed from the product and the repositories after
+            deletion
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         # Create product, repositories and gpg key
         product = make_product({'organization-id': self.org['id']})
@@ -1006,14 +1007,14 @@ class TestGPGKey(CLITestCase):
         import then associate it with custom product using Repo discovery
         method then delete it
 
-        @id: f8492db8-12f3-4d32-833a-f177734e2253
+        :id: f8492db8-12f3-4d32-833a-f177734e2253
 
-        @assert: gpg key is associated with product but not the repositories
-        during creation but removed from product after deletion
+        :assert: gpg key is associated with product but not the repositories
+            during creation but removed from product after deletion
 
-        @caseautomation: notautomated
+        :caseautomation: notautomated
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
 
     @run_only_on('sat')
@@ -1023,12 +1024,13 @@ class TestGPGKey(CLITestCase):
         import then associate it to repository from custom product that has
         one repository then delete the key
 
-        @id: 3658e04d-fc63-499f-a22d-b512941cc96b
+        :id: 3658e04d-fc63-499f-a22d-b512941cc96b
 
-        @assert: gpg key is associated with the single repository but not the
-        product during creation and was removed from repository after deletion
+        :assert: gpg key is associated with the single repository but not the
+            product during creation and was removed from repository after
+            deletion
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         # Create product, repository and gpg key
         product = make_product({'organization-id': self.org['id']})
@@ -1071,12 +1073,12 @@ class TestGPGKey(CLITestCase):
         import then associate it to repository from custom product that has
         more than one repository then delete the key
 
-        @id: e7ed4ed9-ecfe-4954-b806-cdd0668e8822
+        :id: e7ed4ed9-ecfe-4954-b806-cdd0668e8822
 
-        @assert: gpg key is associated with a single repository but not the
-        product during creation and removed from repository after deletion
+        :assert: gpg key is associated with a single repository but not the
+            product during creation and removed from repository after deletion
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         # Create product, repositories and gpg key
         product = make_product({'organization-id': self.org['id']})
@@ -1123,15 +1125,15 @@ class TestGPGKey(CLITestCase):
         import then associate it to repos from custom product using Repo
         discovery method then delete the key
 
-        @id: 8ae226c6-f27c-4fb5-94f2-89792cccda0b
+        :id: 8ae226c6-f27c-4fb5-94f2-89792cccda0b
 
-        @assert: gpg key is associated with product and all repositories
-        during creation but removed from product and all repositories after
-        deletion
+        :assert: gpg key is associated with product and all repositories during
+            creation but removed from product and all repositories after
+            deletion
 
-        @caseautomation: notautomated
+        :caseautomation: notautomated
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
 
     # Content
@@ -1143,13 +1145,13 @@ class TestGPGKey(CLITestCase):
         """Hosts can install packages using gpg key associated with
         single custom repository
 
-        @id: 39357649-4c60-4c82-9114-a43dfef81e5b
+        :id: 39357649-4c60-4c82-9114-a43dfef81e5b
 
-        @assert: host can install package from custom repository
+        :assert: host can install package from custom repository
 
-        @caseautomation: notautomated
+        :caseautomation: notautomated
 
-        @CaseLevel: System
+        :CaseLevel: System
         """
 
     @stubbed()
@@ -1159,13 +1161,13 @@ class TestGPGKey(CLITestCase):
         """Hosts can install packages using gpg key associated with
         multiple custom repositories
 
-        @id: fedd6fa2-e28b-468b-8e15-802b52970bb9
+        :id: fedd6fa2-e28b-468b-8e15-802b52970bb9
 
-        @assert: host can install package from custom repositories
+        :assert: host can install package from custom repositories
 
-        @caseautomation: notautomated
+        :caseautomation: notautomated
 
-        @CaseLevel: System
+        :CaseLevel: System
         """
 
     @stubbed()
@@ -1175,13 +1177,13 @@ class TestGPGKey(CLITestCase):
         """Hosts can install packages using different gpg keys
         associated with multiple custom repositories
 
-        @id: ac908aee-0928-4f81-a98b-b60d46b10c90
+        :id: ac908aee-0928-4f81-a98b-b60d46b10c90
 
-        @assert: host can install package from custom repositories
+        :assert: host can install package from custom repositories
 
-        @caseautomation: notautomated
+        :caseautomation: notautomated
 
-        @CaseLevel: System
+        :CaseLevel: System
         """
 
     # Miscelaneous
@@ -1191,9 +1193,9 @@ class TestGPGKey(CLITestCase):
     def test_positive_list(self):
         """Create gpg key and list it
 
-        @id: 5da535b3-1728-4edf-bd33-3822c4427ef3
+        :id: 5da535b3-1728-4edf-bd33-3822c4427ef3
 
-        @assert: gpg key is displayed/listed
+        :assert: gpg key is displayed/listed
         """
         gpg_key = make_gpg_key({
             'key': VALID_GPG_KEY_FILE_PATH,
@@ -1207,9 +1209,9 @@ class TestGPGKey(CLITestCase):
     def test_positive_search(self):
         """Create gpg key and search/find it
 
-        @id: 9ef15add-b067-4134-b930-aaeda18bddfa
+        :id: 9ef15add-b067-4134-b930-aaeda18bddfa
 
-        @assert: gpg key can be found
+        :assert: gpg key can be found
         """
         for name in valid_data_list():
             with self.subTest(name):

--- a/tests/foreman/cli/test_hammer.py
+++ b/tests/foreman/cli/test_hammer.py
@@ -1,18 +1,18 @@
 """Tests related to hammer command and its options and subcommands.
 
-@Requirement: Hammer
+:Requirement: Hammer
 
-@CaseAutomation: Automated
+:CaseAutomation: Automated
 
-@CaseLevel: Acceptance
+:CaseLevel: Acceptance
 
-@CaseComponent: CLI
+:CaseComponent: CLI
 
-@TestType: Functional
+:TestType: Functional
 
-@CaseImportance: High
+:CaseImportance: High
 
-@Upstream: No
+:Upstream: No
 """
 import json
 
@@ -149,9 +149,9 @@ class HammerCommandsTestCase(CLITestCase):
     def test_positive_all_options(self):
         """check all provided options for every hammer command
 
-        @id: 1203ab9f-896d-4039-a166-9e2d36925b5b
+        :id: 1203ab9f-896d-4039-a166-9e2d36925b5b
 
-        @Assert: All expected options are present
+        :Assert: All expected options are present
         """
         self.maxDiff = None
         self._traverse_command_tree('hammer')

--- a/tests/foreman/cli/test_host.py
+++ b/tests/foreman/cli/test_host.py
@@ -1,18 +1,18 @@
 """CLI tests for ``hammer host``.
 
-@Requirement: Host
+:Requirement: Host
 
-@CaseAutomation: Automated
+:CaseAutomation: Automated
 
-@CaseLevel: Acceptance
+:CaseLevel: Acceptance
 
-@CaseComponent: CLI
+:CaseComponent: CLI
 
-@TestType: Functional
+:TestType: Functional
 
-@CaseImportance: High
+:CaseImportance: High
 
-@Upstream: No
+:Upstream: No
 """
 from random import choice
 
@@ -145,9 +145,9 @@ class HostCreateTestCase(CLITestCase):
     def test_positive_create_with_name(self):
         """A host can be created with a random name
 
-        @id: 2e8dd25d-47ed-4131-bba6-1ff024808d05
+        :id: 2e8dd25d-47ed-4131-bba6-1ff024808d05
 
-        @assert: A host is created and the name matches
+        :assert: A host is created and the name matches
         """
         for name in valid_hosts_list():
             with self.subTest(name):
@@ -178,9 +178,9 @@ class HostCreateTestCase(CLITestCase):
     def test_positive_create_with_org_name(self):
         """Check if host can be created with organization name
 
-        @id: c08b0dac-9820-4261-bb0b-8a78f5c78a74
+        :id: c08b0dac-9820-4261-bb0b-8a78f5c78a74
 
-        @Assert: Host is created using organization name
+        :Assert: Host is created using organization name
         """
         new_host = make_fake_host({
             'content-view-id': self.DEFAULT_CV['id'],
@@ -195,9 +195,9 @@ class HostCreateTestCase(CLITestCase):
         """Check if host can be created with default content view ('Default
         Organization View')
 
-        @id: bb69a70e-17f9-4639-802d-90e6a4520afa
+        :id: bb69a70e-17f9-4639-802d-90e6a4520afa
 
-        @Assert: Host is created, default content view is associated
+        :Assert: Host is created, default content view is associated
         """
         new_host = make_fake_host({
             'content-view-id': self.DEFAULT_CV['id'],
@@ -215,9 +215,9 @@ class HostCreateTestCase(CLITestCase):
         """Check if host can be created with default lifecycle environment
         ('Library')
 
-        @id: 0093be1c-3664-448e-87f5-758bab34958a
+        :id: 0093be1c-3664-448e-87f5-758bab34958a
 
-        @Assert: Host is created, default lifecycle environment is associated
+        :Assert: Host is created, default lifecycle environment is associated
         """
         new_host = make_fake_host({
             'content-view-id': self.DEFAULT_CV['id'],
@@ -234,9 +234,9 @@ class HostCreateTestCase(CLITestCase):
     def test_positive_create_with_lce(self):
         """Check if host can be created with new lifecycle
 
-        @id: e102b034-0011-471d-ba21-5ef8d129a61f
+        :id: e102b034-0011-471d-ba21-5ef8d129a61f
 
-        @Assert: Host is created using new lifecycle
+        :Assert: Host is created using new lifecycle
         """
         new_host = make_fake_host({
             'content-view-id': self.promoted_cv['id'],
@@ -253,9 +253,9 @@ class HostCreateTestCase(CLITestCase):
     def test_positive_create_with_cv(self):
         """Check if host can be created with new content view
 
-        @id: f90873b9-fb3a-4c93-8647-4b1aea0a2c35
+        :id: f90873b9-fb3a-4c93-8647-4b1aea0a2c35
 
-        @Assert: Host is created using new published, promoted cv
+        :Assert: Host is created using new published, promoted cv
         """
         new_host = make_fake_host({
             'content-view-id': self.promoted_cv['id'],
@@ -271,9 +271,9 @@ class HostCreateTestCase(CLITestCase):
     def test_positive_create_with_puppet_class_id(self):
         """Check if host can be created with puppet class id
 
-        @id: 6bb1bbdc-23fd-4493-9283-fbb70d72b2eb
+        :id: 6bb1bbdc-23fd-4493-9283-fbb70d72b2eb
 
-        @Assert: Host is created and has puppet class assigned
+        :Assert: Host is created and has puppet class assigned
         """
         host = make_fake_host({
             'puppet-class-ids': self.puppet_class['id'],
@@ -289,9 +289,9 @@ class HostCreateTestCase(CLITestCase):
     def test_positive_create_with_puppet_class_name(self):
         """Check if host can be created with puppet class name
 
-        @id: a65df36e-db4b-48d2-b0e1-5ccfbefd1e7a
+        :id: a65df36e-db4b-48d2-b0e1-5ccfbefd1e7a
 
-        @Assert: Host is created and has puppet class assigned
+        :Assert: Host is created and has puppet class assigned
         """
         host = make_fake_host({
             'puppet-classes': self.puppet_class['name'],
@@ -307,9 +307,9 @@ class HostCreateTestCase(CLITestCase):
     def test_negative_create_with_name(self):
         """Check if host can be created with random long names
 
-        @id: f92b6070-b2d1-4e3e-975c-39f1b1096697
+        :id: f92b6070-b2d1-4e3e-975c-39f1b1096697
 
-        @Assert: Host is not created
+        :Assert: Host is not created
         """
         for name in invalid_values_list():
             with self.subTest(name):
@@ -326,9 +326,9 @@ class HostCreateTestCase(CLITestCase):
     def test_negative_create_with_unpublished_cv(self):
         """Check if host can be created using unpublished cv
 
-        @id: 9997383d-3c27-4f14-94f9-4b8b51180eb6
+        :id: 9997383d-3c27-4f14-94f9-4b8b51180eb6
 
-        @Assert: Host is not created using new unpublished cv
+        :Assert: Host is not created using new unpublished cv
         """
         cv = make_content_view({'organization-id': self.new_org['id']})
         env = self.new_lce['id']
@@ -343,11 +343,11 @@ class HostCreateTestCase(CLITestCase):
     def test_positive_register_with_no_ak(self):
         """Register host to satellite without activation key
 
-        @id: 6a7cedd2-aa9c-4113-a83b-3f0eea43ecb4
+        :id: 6a7cedd2-aa9c-4113-a83b-3f0eea43ecb4
 
-        @Assert: Host successfully registered to appropriate org
+        :Assert: Host successfully registered to appropriate org
 
-        @CaseLevel: System
+        :CaseLevel: System
         """
         with VirtualMachine(distro=DISTRO_RHEL7) as client:
             client.install_katello_ca()
@@ -362,11 +362,11 @@ class HostCreateTestCase(CLITestCase):
     def test_negative_register_twice(self):
         """Attempt to register a host twice to Satellite
 
-        @id: 0af81129-cd69-4fa7-a128-9e8fcf2d03b1
+        :id: 0af81129-cd69-4fa7-a128-9e8fcf2d03b1
 
-        @Assert: host cannot be registered twice
+        :Assert: host cannot be registered twice
 
-        @CaseLevel: System
+        :CaseLevel: System
         """
         activation_key = make_activation_key({
             'content-view-id': self.promoted_cv['id'],
@@ -395,11 +395,11 @@ class HostCreateTestCase(CLITestCase):
     def test_positive_list_scparams_by_id(self):
         """List all smart class parameters using host id
 
-        @id: 596322f6-9fdc-441a-a36d-ae2f22132b38
+        :id: 596322f6-9fdc-441a-a36d-ae2f22132b38
 
-        @Assert: Overridden sc-param from puppet class is listed
+        :Assert: Overridden sc-param from puppet class is listed
 
-        @Caselevel: Integration
+        :Caselevel: Integration
         """
         # Create hostgroup with associated puppet class
         host = make_fake_host({
@@ -422,11 +422,11 @@ class HostCreateTestCase(CLITestCase):
     def test_positive_list_scparams_by_name(self):
         """List all smart class parameters using host name
 
-        @id: 26e406ea-56f5-4813-bb93-e908c9015ee3
+        :id: 26e406ea-56f5-4813-bb93-e908c9015ee3
 
-        @Assert: Overridden sc-param from puppet class is listed
+        :Assert: Overridden sc-param from puppet class is listed
 
-        @Caselevel: Integration
+        :Caselevel: Integration
         """
         # Create hostgroup with associated puppet class
         host = make_fake_host({
@@ -449,11 +449,11 @@ class HostCreateTestCase(CLITestCase):
     def test_positive_list_smartvariables_by_id(self):
         """List all smart variables using host id
 
-        @id: 22d85dea-0fc0-47c2-8f38-c6f6712dad7e
+        :id: 22d85dea-0fc0-47c2-8f38-c6f6712dad7e
 
-        @Assert: Smart variable from puppet class is listed
+        :Assert: Smart variable from puppet class is listed
 
-        @Caselevel: Integration
+        :Caselevel: Integration
         """
         # Create hostgroup with associated puppet class
         host = make_fake_host({
@@ -473,11 +473,11 @@ class HostCreateTestCase(CLITestCase):
     def test_positive_list_smartvariables_by_name(self):
         """List all smart variables using host name
 
-        @id: a254d3a6-cf7f-4847-acb6-9813d23369d4
+        :id: a254d3a6-cf7f-4847-acb6-9813d23369d4
 
-        @Assert: Smart variable from puppet class is listed
+        :Assert: Smart variable from puppet class is listed
 
-        @Caselevel: Integration
+        :Caselevel: Integration
         """
         # Create hostgroup with associated puppet class
         host = make_fake_host({
@@ -496,11 +496,11 @@ class HostCreateTestCase(CLITestCase):
     def test_positive_list(self):
         """List hosts for a given org
 
-        @id: b9c056cd-11ca-4870-bac4-0ebc4a782cb0
+        :id: b9c056cd-11ca-4870-bac4-0ebc4a782cb0
 
-        @Assert: Hosts are listed for the given org
+        :Assert: Hosts are listed for the given org
 
-        @CaseLevel: System
+        :CaseLevel: System
         """
         activation_key = make_activation_key({
             'content-view-id': self.promoted_cv['id'],
@@ -524,12 +524,12 @@ class HostCreateTestCase(CLITestCase):
     def test_positive_unregister(self):
         """Unregister a host
 
-        @id: c5ce988d-d0ea-4958-9956-5a4b039b285c
+        :id: c5ce988d-d0ea-4958-9956-5a4b039b285c
 
-        @Assert: Host is successfully unregistered. Unlike content host, host
-        has not disappeared from list of hosts after unregistering.
+        :Assert: Host is successfully unregistered. Unlike content host, host
+            has not disappeared from list of hosts after unregistering.
 
-        @CaseLevel: System
+        :CaseLevel: System
         """
         activation_key = make_activation_key({
             'content-view-id': self.promoted_cv['id'],
@@ -561,9 +561,9 @@ class HostCreateTestCase(CLITestCase):
     def test_positive_create_using_libvirt_without_mac(self):
         """Create a libvirt host and not specify a MAC address.
 
-        @id: b003faa9-2810-4176-94d2-ea84bed248eb
+        :id: b003faa9-2810-4176-94d2-ea84bed248eb
 
-        @Assert: Host is created
+        :Assert: Host is created
         """
         compute_resource = entities.LibvirtComputeResource(
             url='qemu+ssh://root@{0}/system'.format(
@@ -595,14 +595,14 @@ class HostCreateTestCase(CLITestCase):
         """Create a host with hostgroup specified. Make sure host inherited
         hostgroup's lifecycle environment and content-view
 
-        @id: ba73b8c8-3ce1-4fa8-a33b-89ded9ffef47
+        :id: ba73b8c8-3ce1-4fa8-a33b-89ded9ffef47
 
-        @Assert: Host's lifecycle environment and content view match the ones
-        specified in hostgroup
+        :Assert: Host's lifecycle environment and content view match the ones
+            specified in hostgroup
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
 
-        @BZ: 1391656
+        :BZ: 1391656
         """
         hostgroup = make_hostgroup({
             'content-view-id': self.new_cv['id'],
@@ -628,22 +628,19 @@ class HostCreateTestCase(CLITestCase):
     def test_positive_create_baremetal_with_bios(self):
         """Create a new Host from provided MAC address
 
-        @id: 01509973-9f0b-4166-9fbd-59b753a7384b
+        :id: 01509973-9f0b-4166-9fbd-59b753a7384b
 
-        @setup:
+        :setup: Create a PXE-based VM with BIOS boot mode (outside of
+            Satellite).
 
-        1. Create a PXE-based VM with BIOS boot mode (outside of Satellite).
+        :steps: Create a new host using 'BareMetal' option and MAC address of
+            the pre-created VM
 
-        @steps:
+        :assert: Host is created
 
-        1. Create a new host using 'BareMetal' option and MAC address of the
-        pre-created VM
+        :caseautomation: notautomated
 
-        @assert: Host is created
-
-        @caseautomation: notautomated
-
-        @caselevel: System
+        :caselevel: System
         """
 
     @run_only_on('sat')
@@ -652,22 +649,19 @@ class HostCreateTestCase(CLITestCase):
     def test_positive_create_baremetal_with_uefi(self):
         """Create a new Host from provided MAC address
 
-        @id: 508b268b-244d-4bf0-a92a-fbee96e7e8ae
+        :id: 508b268b-244d-4bf0-a92a-fbee96e7e8ae
 
-        @setup:
+        :setup: Create a PXE-based VM with UEFI boot mode (outside of
+            Satellite).
 
-        1. Create a PXE-based VM with UEFI boot mode (outside of Satellite).
+        :steps: Create a new host using 'BareMetal' option and MAC address of
+            the pre-created VM
 
-        @steps:
+        :assert: Host is created
 
-        1. Create a new host using 'BareMetal' option and MAC address of the
-        pre-created VM
+        :caseautomation: notautomated
 
-        @assert: Host is created
-
-        @caseautomation: notautomated
-
-        @caselevel: System
+        :caselevel: System
         """
 
     @run_only_on('sat')
@@ -677,27 +671,27 @@ class HostCreateTestCase(CLITestCase):
         """Provision a new Host and verify the tftp and dhcp file structure is
         correct
 
-        @id: 8b4f5bb3-d949-4000-bc97-2be85c4f57be
+        :id: 8b4f5bb3-d949-4000-bc97-2be85c4f57be
 
-        @steps:
+        :steps:
 
-        1. Associate a pxegrub-type provisioning template with the os
-        2. Create new host (can be fictive bare metal) with the above OS and
-        PXE loader set to Grub UEFI
-        3. Build the host
+            1. Associate a pxegrub-type provisioning template with the os
+            2. Create new host (can be fictive bare metal) with the above OS
+               and PXE loader set to Grub UEFI
+            3. Build the host
 
-        @assert:
-        Verify [/var/lib/tftpboot/] contains the following dir/file structure:
-            grub/bootia32.efi
-            grub/bootx64.efi
-            grub/01-AA-BB-CC-DD-EE-FF
-            grub/efidefault
-            grub/shim.efi
-        and record in /var/lib/dhcpd/dhcpd.leases points to the bootloader
+        :assert: Verify [/var/lib/tftpboot/] contains the following dir/file
+            structure:
+                grub/bootia32.efi
+                grub/bootx64.efi
+                grub/01-AA-BB-CC-DD-EE-FF
+                grub/efidefault
+                grub/shim.efi
+            and record in /var/lib/dhcpd/dhcpd.leases points to the bootloader
 
-        @caseautomation: notautomated
+        :caseautomation: notautomated
 
-        @caselevel: System
+        :caselevel: System
         """
 
     @run_only_on('sat')
@@ -708,27 +702,27 @@ class HostCreateTestCase(CLITestCase):
         correct
 
 
-        @id: a5482ecd-7bb8-4fda-9a74-f17751e11daf
+        :id: a5482ecd-7bb8-4fda-9a74-f17751e11daf
 
-        @steps:
+        :steps:
 
-        1. Associate a pxegrub-type provisioning template with the os
-        2. Create new host (can be fictive bare metal) with the above OS and
-        PXE loader set to Grub UEFI SecureBoot
-        3. Build the host
+            1. Associate a pxegrub-type provisioning template with the os
+            2. Create new host (can be fictive bare metal) with the above OS
+               and PXE loader set to Grub UEFI SecureBoot
+            3. Build the host
 
-        @assert:
-        Verify [/var/lib/tftpboot/] contains the following dir/file structure:
-            grub/bootia32.efi
-            grub/bootx64.efi
-            grub/01-AA-BB-CC-DD-EE-FF
-            grub/efidefault
-            grub/shim.efi
-        and record in /var/lib/dhcpd/dhcpd.leases points to the bootloader
+        :assert: Verify [/var/lib/tftpboot/] contains the following dir/file
+            structure:
+                grub/bootia32.efi
+                grub/bootx64.efi
+                grub/01-AA-BB-CC-DD-EE-FF
+                grub/efidefault
+                grub/shim.efi
+            and record in /var/lib/dhcpd/dhcpd.leases points to the bootloader
 
-        @caseautomation: notautomated
+        :caseautomation: notautomated
 
-        @caselevel: System
+        :caselevel: System
         """
 
     @run_only_on('sat')
@@ -738,28 +732,28 @@ class HostCreateTestCase(CLITestCase):
         """Provision a new UEFI Host and verify the tftp and dhcp file
         structure is correct
 
-        @id: ce1acb0b-ff2e-4622-9e69-e3c0c4fdc466
+        :id: ce1acb0b-ff2e-4622-9e69-e3c0c4fdc466
 
-        @steps:
+        :steps:
 
-        1. Associate a pxegrub-type provisioning template with the os
-        2. Create new host (can be fictive bare metal) with the above OS and
-        PXE loader set to Grub2 UEFI
-        3. Build the host
+            1. Associate a pxegrub-type provisioning template with the os
+            2. Create new host (can be fictive bare metal) with the above OS
+               and PXE loader set to Grub2 UEFI
+            3. Build the host
 
-        @assert:
-        Verify [/var/lib/tftpboot/] contains the following dir/file structure:
-            pxegrub2
-            grub2/grub.cfg-01-aa-bb-cc-dd-ee-ff
-            grub2/grub.cfg
-            grub2/grubx32.efi
-            grub2/grubx64.efi
-            grub/shim.efi
-        and record in /var/lib/dhcpd/dhcpd.leases points to the bootloader
+        :assert: Verify [/var/lib/tftpboot/] contains the following dir/file
+            structure:
+                pxegrub2
+                grub2/grub.cfg-01-aa-bb-cc-dd-ee-ff
+                grub2/grub.cfg
+                grub2/grubx32.efi
+                grub2/grubx64.efi
+                grub/shim.efi
+            and record in /var/lib/dhcpd/dhcpd.leases points to the bootloader
 
-        @caseautomation: notautomated
+        :caseautomation: notautomated
 
-        @caselevel: System
+        :caselevel: System
         """
 
     @run_only_on('sat')
@@ -769,28 +763,28 @@ class HostCreateTestCase(CLITestCase):
         """Provision a new UEFI Host and verify the tftp and dhcp file
         structure is correct
 
-        @id: 6811e0b0-154a-4af6-80c0-86009672a965
+        :id: 6811e0b0-154a-4af6-80c0-86009672a965
 
-        @steps:
+        :steps:
 
-        1. Associate a pxegrub-type provisioning template with the os
-        2. Create new host (can be fictive bare metal) with the above OS and
-        PXE loader set to Grub2 UEFI SecureBoot
-        3. Build the host
+            1. Associate a pxegrub-type provisioning template with the os
+            2. Create new host (can be fictive bare metal) with the above OS
+               and PXE loader set to Grub2 UEFI SecureBoot
+            3. Build the host
 
-        @assert:
-        Verify [/var/lib/tftpboot/] contains the following dir/file structure:
-            pxegrub2
-            grub2/grub.cfg-01-aa-bb-cc-dd-ee-ff
-            grub2/grub.cfg
-            grub2/grubx32.efi
-            grub2/grubx64.efi
-            grub/shim.efi
-        and record in /var/lib/dhcpd/dhcpd.leases points to the bootloader
+        :assert: Verify [/var/lib/tftpboot/] contains the following dir/file
+            structure:
+                pxegrub2
+                grub2/grub.cfg-01-aa-bb-cc-dd-ee-ff
+                grub2/grub.cfg
+                grub2/grubx32.efi
+                grub2/grubx64.efi
+                grub/shim.efi
+            and record in /var/lib/dhcpd/dhcpd.leases points to the bootloader
 
-        @caseautomation: notautomated
+        :caseautomation: notautomated
 
-        @caselevel: System
+        :caselevel: System
         """
 
 
@@ -827,9 +821,9 @@ class HostDeleteTestCase(CLITestCase):
     def test_positive_delete_by_id(self):
         """Create a host and then delete it by id.
 
-        @id: e687a685-ab8b-4c5f-97f9-e14d3ab52f29
+        :id: e687a685-ab8b-4c5f-97f9-e14d3ab52f29
 
-        @Assert: Host is deleted
+        :Assert: Host is deleted
         """
         Host.delete({'id': self.host['id']})
         with self.assertRaises(CLIReturnCodeError):
@@ -839,9 +833,9 @@ class HostDeleteTestCase(CLITestCase):
     def test_positive_delete_by_name(self):
         """Create a host and then delete it by name.
 
-        @id: 93f7504d-9a63-491f-8fdb-ed8017aefab9
+        :id: 93f7504d-9a63-491f-8fdb-ed8017aefab9
 
-        @Assert: Host is deleted
+        :Assert: Host is deleted
         """
         Host.delete({'name': self.host['name']})
         with self.assertRaises(CLIReturnCodeError):
@@ -884,9 +878,9 @@ class HostUpdateTestCase(CLITestCase):
         """A host can be updated with a new random name. Use id to
         access the host
 
-        @id: 058dbcbf-d543-483d-b755-be0602588464
+        :id: 058dbcbf-d543-483d-b755-be0602588464
 
-        @assert: A host is updated and the name matches
+        :assert: A host is updated and the name matches
         """
         for new_name in valid_hosts_list():
             with self.subTest(new_name):
@@ -907,9 +901,9 @@ class HostUpdateTestCase(CLITestCase):
         """A host can be updated with a new random name. Use name to
         access the host
 
-        @id: f95a5952-17bd-49da-b2a7-c79f0614f1c7
+        :id: f95a5952-17bd-49da-b2a7-c79f0614f1c7
 
-        @assert: A host is updated and the name matches
+        :assert: A host is updated and the name matches
         """
         for new_name in valid_hosts_list():
             with self.subTest(new_name):
@@ -931,9 +925,9 @@ class HostUpdateTestCase(CLITestCase):
         """A host can be updated with a new random MAC address. Use id
         to access the host
 
-        @id: 72ed9ae8-989a-46d1-8b7d-46f5db106e75
+        :id: 72ed9ae8-989a-46d1-8b7d-46f5db106e75
 
-        @assert: A host is updated and the MAC address matches
+        :assert: A host is updated and the MAC address matches
         """
         new_mac = gen_mac()
         Host.update({
@@ -948,9 +942,9 @@ class HostUpdateTestCase(CLITestCase):
         """A host can be updated with a new random MAC address. Use name
         to access the host
 
-        @id: a422788d-5473-4846-a86b-90d8f236285a
+        :id: a422788d-5473-4846-a86b-90d8f236285a
 
-        @assert: A host is updated and the MAC address matches
+        :assert: A host is updated and the MAC address matches
         """
         new_mac = gen_mac()
         Host.update({
@@ -965,11 +959,11 @@ class HostUpdateTestCase(CLITestCase):
         """A host can be updated with a new domain. Use entities ids for
         association
 
-        @id: 3aac0896-d16a-46ee-afe9-2d3ecea6ca9b
+        :id: 3aac0896-d16a-46ee-afe9-2d3ecea6ca9b
 
-        @assert: A host is updated and the domain matches
+        :assert: A host is updated and the domain matches
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         new_domain = make_domain({
             'location-id': self.host_args.location.id,
@@ -987,11 +981,11 @@ class HostUpdateTestCase(CLITestCase):
         """A host can be updated with a new domain. Use entities names
         for association
 
-        @id: 9b4fb1b9-a226-4b8a-bfaf-1121de7df5bc
+        :id: 9b4fb1b9-a226-4b8a-bfaf-1121de7df5bc
 
-        @assert: A host is updated and the domain matches
+        :assert: A host is updated and the domain matches
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         new_domain = make_domain({
             'location': self.host_args.location.name,
@@ -1014,11 +1008,11 @@ class HostUpdateTestCase(CLITestCase):
         """A host can be updated with a new environment. Use entities
         ids for association
 
-        @id: 4e1d1e31-fa84-43e4-9e66-7fb953767ee5
+        :id: 4e1d1e31-fa84-43e4-9e66-7fb953767ee5
 
-        @assert: A host is updated and the environment matches
+        :assert: A host is updated and the environment matches
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         new_env = make_environment({
             'location-id': self.host_args.location.id,
@@ -1036,11 +1030,11 @@ class HostUpdateTestCase(CLITestCase):
         """A host can be updated with a new environment. Use entities
         names for association
 
-        @id: f0ec469a-7550-4f05-b39c-e68b9267247d
+        :id: f0ec469a-7550-4f05-b39c-e68b9267247d
 
-        @assert: A host is updated and the environment matches
+        :assert: A host is updated and the environment matches
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         new_env = make_environment({
             'location': self.host_args.location.name,
@@ -1058,11 +1052,11 @@ class HostUpdateTestCase(CLITestCase):
         """A host can be updated with a new architecture. Use entities
         ids for association
 
-        @id: a4546fd6-997a-44e4-853a-eac235ea87b0
+        :id: a4546fd6-997a-44e4-853a-eac235ea87b0
 
-        @assert: A host is updated and the architecture matches
+        :assert: A host is updated and the architecture matches
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         new_arch = make_architecture({
             'location-id': self.host_args.location.id,
@@ -1085,11 +1079,11 @@ class HostUpdateTestCase(CLITestCase):
         """A host can be updated with a new architecture. Use entities
         names for association
 
-        @id: 92da3782-47db-4701-aaab-3ea974043d20
+        :id: 92da3782-47db-4701-aaab-3ea974043d20
 
-        @assert: A host is updated and the architecture matches
+        :assert: A host is updated and the architecture matches
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         new_arch = make_architecture({
             'location': self.host_args.location.name,
@@ -1112,11 +1106,11 @@ class HostUpdateTestCase(CLITestCase):
         """A host can be updated with a new operating system. Use
         entities ids for association
 
-        @id: 9ea88634-9c14-4519-be6e-fb163897efb7
+        :id: 9ea88634-9c14-4519-be6e-fb163897efb7
 
-        @assert: A host is updated and the operating system matches
+        :assert: A host is updated and the operating system matches
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         new_os = make_os({
             'architecture-ids': self.host_args.architecture.id,
@@ -1139,11 +1133,11 @@ class HostUpdateTestCase(CLITestCase):
         """A host can be updated with a new operating system. Use
         entities names for association
 
-        @id: bd48887f-3db3-47b0-8231-de58884efe57
+        :id: bd48887f-3db3-47b0-8231-de58884efe57
 
-        @assert: A host is updated and the operating system matches
+        :assert: A host is updated and the operating system matches
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         new_os = make_os({
             'architectures': self.host_args.architecture.name,
@@ -1167,11 +1161,11 @@ class HostUpdateTestCase(CLITestCase):
         """A host can be updated with a new medium. Use entities ids for
         association
 
-        @id: 899f1eef-07a9-4227-848a-92e377a8d55c
+        :id: 899f1eef-07a9-4227-848a-92e377a8d55c
 
-        @assert: A host is updated and the medium matches
+        :assert: A host is updated and the medium matches
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         new_medium = make_medium({
             'location-id': self.host_args.location.id,
@@ -1195,11 +1189,11 @@ class HostUpdateTestCase(CLITestCase):
         """A host can be updated with a new medium. Use entities names
         for association
 
-        @id: f47edb02-d649-4ca8-94b2-0637ebdac2e8
+        :id: f47edb02-d649-4ca8-94b2-0637ebdac2e8
 
-        @assert: A host is updated and the medium matches
+        :assert: A host is updated and the medium matches
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         new_medium = make_medium({
             'location': self.host_args.location.name,
@@ -1222,9 +1216,9 @@ class HostUpdateTestCase(CLITestCase):
     def test_negative_update_name(self):
         """A host can not be updated with invalid or empty name
 
-        @id: e8068d2a-6a51-4627-908b-60a516c67032
+        :id: e8068d2a-6a51-4627-908b-60a516c67032
 
-        @assert: A host is not updated
+        :assert: A host is not updated
         """
         for new_name in invalid_values_list():
             with self.subTest(new_name):
@@ -1246,9 +1240,9 @@ class HostUpdateTestCase(CLITestCase):
     def test_negative_update_mac(self):
         """A host can not be updated with invalid or empty MAC address
 
-        @id: 2f03032d-789d-419f-9ff2-a6f3561444da
+        :id: 2f03032d-789d-419f-9ff2-a6f3561444da
 
-        @assert: A host is not updated
+        :assert: A host is not updated
         """
         for new_mac in invalid_values_list():
             with self.subTest(new_mac):
@@ -1265,11 +1259,11 @@ class HostUpdateTestCase(CLITestCase):
         """A host can not be updated with a architecture, which does not
         belong to host's operating system
 
-        @id: a86524da-8caf-472b-9a3d-17a4385c3a18
+        :id: a86524da-8caf-472b-9a3d-17a4385c3a18
 
-        @assert: A host is not updated
+        :assert: A host is not updated
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         new_arch = make_architecture({
             'location': self.host_args.location.name,
@@ -1289,11 +1283,11 @@ class HostUpdateTestCase(CLITestCase):
         """A host can not be updated with a operating system, which is
         not associated with host's medium
 
-        @id: ff13d2af-e54a-4daf-a24d-7ec930b4fbbe
+        :id: ff13d2af-e54a-4daf-a24d-7ec930b4fbbe
 
-        @assert: A host is not updated
+        :assert: A host is not updated
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         new_arch = make_architecture({
             'location': self.host_args.location.name,
@@ -1349,9 +1343,9 @@ class HostParameterTestCase(CLITestCase):
     def test_positive_add_parameter_with_name(self):
         """Add host parameter with different valid names.
 
-        @id: 67b1c496-8f33-4a34-aebb-7339bc33ce77
+        :id: 67b1c496-8f33-4a34-aebb-7339bc33ce77
 
-        @Assert: Host parameter was successfully added with correct name.
+        :Assert: Host parameter was successfully added with correct name.
 
         """
         for name in valid_data_list():
@@ -1369,9 +1363,9 @@ class HostParameterTestCase(CLITestCase):
     def test_positive_add_parameter_with_value(self):
         """Add host parameter with different valid values.
 
-        @id: 1932b61d-8be4-4f58-9760-dc588cbca1d7
+        :id: 1932b61d-8be4-4f58-9760-dc588cbca1d7
 
-        @Assert: Host parameter was successfully added with value.
+        :Assert: Host parameter was successfully added with value.
 
         """
         for value in valid_data_list():
@@ -1390,11 +1384,10 @@ class HostParameterTestCase(CLITestCase):
     def test_positive_add_parameter_by_host_name(self):
         """Add host parameter by specifying host name.
 
-        @id: 32b09b07-39de-4706-ac5e-75a54255df17
+        :id: 32b09b07-39de-4706-ac5e-75a54255df17
 
-        @Assert: Host parameter was successfully added with correct name and
-        value.
-
+        :Assert: Host parameter was successfully added with correct name and
+            value.
         """
         name = gen_string('alphanumeric').lower()
         value = gen_string('alphanumeric')
@@ -1411,9 +1404,9 @@ class HostParameterTestCase(CLITestCase):
     def test_positive_update_parameter_by_host_id(self):
         """Update existing host parameter by specifying host ID.
 
-        @id: 56c43ab4-7fb0-44f5-9d54-107d3c1011bf
+        :id: 56c43ab4-7fb0-44f5-9d54-107d3c1011bf
 
-        @Assert: Host parameter was successfully updated with new value.
+        :Assert: Host parameter was successfully updated with new value.
 
         """
         name = gen_string('alphanumeric').lower()
@@ -1438,9 +1431,9 @@ class HostParameterTestCase(CLITestCase):
     def test_positive_update_parameter_by_host_name(self):
         """Update existing host parameter by specifying host name.
 
-        @id: 24bcc8a4-7787-4fa8-9bf8-dfc5e697684f
+        :id: 24bcc8a4-7787-4fa8-9bf8-dfc5e697684f
 
-        @Assert: Host parameter was successfully updated with new value.
+        :Assert: Host parameter was successfully updated with new value.
 
         """
         name = gen_string('alphanumeric').lower()
@@ -1465,9 +1458,9 @@ class HostParameterTestCase(CLITestCase):
     def test_positive_delete_parameter_by_host_id(self):
         """Delete existing host parameter by specifying host ID.
 
-        @id: a52da845-0403-4b66-9e83-6065f7d4551d
+        :id: a52da845-0403-4b66-9e83-6065f7d4551d
 
-        @Assert: Host parameter was successfully deleted.
+        :Assert: Host parameter was successfully deleted.
 
         """
         for name in valid_data_list():
@@ -1489,9 +1482,9 @@ class HostParameterTestCase(CLITestCase):
     def test_posistive_delete_parameter_by_host_name(self):
         """Delete existing host parameter by specifying host name.
 
-        @id: d28cbbba-d296-49c7-91f5-8fb63a80d82c
+        :id: d28cbbba-d296-49c7-91f5-8fb63a80d82c
 
-        @Assert: Host parameter was successfully deleted.
+        :Assert: Host parameter was successfully deleted.
 
         """
         for name in valid_data_list():
@@ -1513,9 +1506,9 @@ class HostParameterTestCase(CLITestCase):
     def test_negative_add_parameter(self):
         """Try to add host parameter with different invalid names.
 
-        @id: 473f8c3f-b66e-4526-88af-e139cc3dabcb
+        :id: 473f8c3f-b66e-4526-88af-e139cc3dabcb
 
-        @Assert: Host parameter was not added.
+        :Assert: Host parameter was not added.
 
         """
         for name in invalid_values_list():
@@ -1603,12 +1596,12 @@ class KatelloAgentTestCase(CLITestCase):
     def test_positive_get_errata_info(self):
         """Get errata info
 
-        @id: afb5ab34-1703-49dc-8ddc-5e032c1b86d7
+        :id: afb5ab34-1703-49dc-8ddc-5e032c1b86d7
 
-        @Assert: Errata info was displayed
+        :Assert: Errata info was displayed
 
 
-        @CaseLevel: System
+        :CaseLevel: System
         """
         self.client.download_install_rpm(
             FAKE_0_YUM_REPO,
@@ -1626,12 +1619,12 @@ class KatelloAgentTestCase(CLITestCase):
     def test_positive_apply_errata(self):
         """Apply errata to a host
 
-        @id: 8d0e5c93-f9fd-4ec0-9a61-aa93082a30c5
+        :id: 8d0e5c93-f9fd-4ec0-9a61-aa93082a30c5
 
-        @Assert: Errata is scheduled for installation
+        :Assert: Errata is scheduled for installation
 
 
-        @CaseLevel: System
+        :CaseLevel: System
         """
         self.client.download_install_rpm(
             FAKE_0_YUM_REPO,
@@ -1647,12 +1640,12 @@ class KatelloAgentTestCase(CLITestCase):
     def test_positive_install_package(self):
         """Install a package to a host remotely
 
-        @id: b1009bba-0c7e-4b00-8ac4-256e5cfe4a78
+        :id: b1009bba-0c7e-4b00-8ac4-256e5cfe4a78
 
-        @Assert: Package was successfully installed
+        :Assert: Package was successfully installed
 
 
-        @CaseLevel: System
+        :CaseLevel: System
         """
         Host.package_install({
             u'host-id': self.host['id'],
@@ -1668,12 +1661,12 @@ class KatelloAgentTestCase(CLITestCase):
     def test_positive_remove_package(self):
         """Remove a package from a host remotely
 
-        @id: 573dec11-8f14-411f-9e41-84426b0f23b5
+        :id: 573dec11-8f14-411f-9e41-84426b0f23b5
 
-        @Assert: Package was successfully removed
+        :Assert: Package was successfully removed
 
 
-        @CaseLevel: System
+        :CaseLevel: System
         """
         self.client.download_install_rpm(
             FAKE_0_YUM_REPO,
@@ -1693,12 +1686,12 @@ class KatelloAgentTestCase(CLITestCase):
     def test_positive_upgrade_package(self):
         """Upgrade a host package remotely
 
-        @id: ad751c63-7175-40ae-8bc4-800462cd9c29
+        :id: ad751c63-7175-40ae-8bc4-800462cd9c29
 
-        @Assert: Package was successfully upgraded
+        :Assert: Package was successfully upgraded
 
 
-        @CaseLevel: System
+        :CaseLevel: System
         """
         self.client.run('yum install -y {0}'.format(FAKE_1_CUSTOM_PACKAGE))
         Host.package_upgrade({
@@ -1713,13 +1706,12 @@ class KatelloAgentTestCase(CLITestCase):
     def test_positive_upgrade_packages_all(self):
         """Upgrade all the host packages remotely
 
-        @id: 003101c7-bb95-4e51-a598-57977b2858a9
+        :id: 003101c7-bb95-4e51-a598-57977b2858a9
 
-        @Assert: Packages (at least 1 with newer version available) were
-        successfully upgraded
+        :Assert: Packages (at least 1 with newer version available) were
+            successfully upgraded
 
-
-        @CaseLevel: System
+        :CaseLevel: System
         """
         self.client.run('yum install -y {0}'.format(FAKE_1_CUSTOM_PACKAGE))
         Host.package_upgrade_all({'host-id': self.host['id']})
@@ -1731,12 +1723,12 @@ class KatelloAgentTestCase(CLITestCase):
     def test_positive_install_package_group(self):
         """Install a package group to a host remotely
 
-        @id: 8c28c188-2903-44d1-ab1e-b74f6d6affcf
+        :id: 8c28c188-2903-44d1-ab1e-b74f6d6affcf
 
-        @Assert: Package group was successfully installed
+        :Assert: Package group was successfully installed
 
 
-        @CaseLevel: System
+        :CaseLevel: System
         """
         Host.package_group_install({
             u'groups': FAKE_0_CUSTOM_PACKAGE_GROUP_NAME,
@@ -1751,12 +1743,12 @@ class KatelloAgentTestCase(CLITestCase):
     def test_positive_remove_package_group(self):
         """Remove a package group from a host remotely
 
-        @id: c80dbeff-93b4-4cd4-8fae-6a4d1bfc94f0
+        :id: c80dbeff-93b4-4cd4-8fae-6a4d1bfc94f0
 
-        @Assert: Package group was successfully removed
+        :Assert: Package group was successfully removed
 
 
-        @CaseLevel: System
+        :CaseLevel: System
         """
         hammer_args = {
             u'groups': FAKE_0_CUSTOM_PACKAGE_GROUP_NAME,
@@ -1773,11 +1765,11 @@ class KatelloAgentTestCase(CLITestCase):
         """Attempt to retrieve content after host has been unregistered from
         Satellite
 
-        @id: de0d0d91-b1e1-4f0e-8a41-c27df4d6b6fd
+        :id: de0d0d91-b1e1-4f0e-8a41-c27df4d6b6fd
 
-        @assert: Host can no longer retrieve content from satellite
+        :assert: Host can no longer retrieve content from satellite
 
-        @CaseLevel: System
+        :CaseLevel: System
         """
         result = self.client.run('subscription-manager unregister')
         self.assertEqual(result.return_code, 0)
@@ -1793,11 +1785,11 @@ class HostErrataTestCase(CLITestCase):
     def test_positive_errata_list_of_sat_server(self):
         """Check if errata list doesn't raise exception. Check BZ for details.
 
-        @id: 6b22f0c0-9c4b-11e6-ab93-68f72889dc7f
+        :id: 6b22f0c0-9c4b-11e6-ab93-68f72889dc7f
 
-        @assert: Satellite host errata list not failing
+        :assert: Satellite host errata list not failing
 
-        @BZ: 1351040
+        :BZ: 1351040
         """
         hostname = ssh.command('hostname').stdout[0]
         host = Host.info({'name': hostname})

--- a/tests/foreman/cli/test_host_collection.py
+++ b/tests/foreman/cli/test_host_collection.py
@@ -1,19 +1,19 @@
 # -*- encoding: utf-8 -*-
 """Test class for Host Collection CLI
 
-@Requirement: Host collection
+:Requirement: Host collection
 
-@CaseAutomation: Automated
+:CaseAutomation: Automated
 
-@CaseLevel: Acceptance
+:CaseLevel: Acceptance
 
-@CaseComponent: CLI
+:CaseComponent: CLI
 
-@TestType: Functional
+:TestType: Functional
 
-@CaseImportance: High
+:CaseImportance: High
 
-@Upstream: No
+:Upstream: No
 """
 
 from fauxfactory import gen_string
@@ -106,9 +106,9 @@ class HostCollectionTestCase(CLITestCase):
     def test_positive_create_with_name(self):
         """Check if host collection can be created with random names
 
-        @id: 40f1095a-cc1d-426e-b255-38319f5bd221
+        :id: 40f1095a-cc1d-426e-b255-38319f5bd221
 
-        @Assert: Host collection is created and has random name
+        :Assert: Host collection is created and has random name
 
         """
         for name in valid_data_list():
@@ -121,9 +121,9 @@ class HostCollectionTestCase(CLITestCase):
         """Check if host collection can be created with random
         description
 
-        @id: 9736e3aa-bbc1-4c5f-98e9-b9dd18ba47ca
+        :id: 9736e3aa-bbc1-4c5f-98e9-b9dd18ba47ca
 
-        @Assert: Host collection is created and has random description
+        :Assert: Host collection is created and has random description
 
         """
         for desc in valid_data_list():
@@ -135,9 +135,9 @@ class HostCollectionTestCase(CLITestCase):
     def test_positive_create_with_limit(self):
         """Check if host collection can be created with random limits
 
-        @id: 682b5624-1095-48e6-a0dd-c76e70ca6540
+        :id: 682b5624-1095-48e6-a0dd-c76e70ca6540
 
-        @Assert: Host collection is created and has random limits
+        :Assert: Host collection is created and has random limits
 
         """
         for limit in ('1', '3', '5', '10', '20'):
@@ -151,10 +151,10 @@ class HostCollectionTestCase(CLITestCase):
         """Create Host Collection with different values of
         unlimited-hosts parameter
 
-        @id: d688fd4a-88eb-484e-9e90-854e0595edd0
+        :id: d688fd4a-88eb-484e-9e90-854e0595edd0
 
-        @Assert: Host Collection is created and unlimited-hosts
-        parameter is set
+        :Assert: Host Collection is created and unlimited-hosts parameter is
+            set
         """
         for unlimited in ('True', 'Yes', 1, 'False', 'No', 0):
             with self.subTest(unlimited):
@@ -177,9 +177,9 @@ class HostCollectionTestCase(CLITestCase):
     def test_negative_create_with_name(self):
         """Check if host collection can be created with random names
 
-        @id: 92a9eff0-693f-4ab8-b2c4-de08e5f709a7
+        :id: 92a9eff0-693f-4ab8-b2c4-de08e5f709a7
 
-        @Assert: Host collection is created and has random name
+        :Assert: Host collection is created and has random name
 
         """
         for name in invalid_values_list():
@@ -192,11 +192,11 @@ class HostCollectionTestCase(CLITestCase):
     def test_positive_update_name(self):
         """Check if host collection name can be updated
 
-        @id: 10d395e6-4ac6-4c35-a78c-c59a78c55799
+        :id: 10d395e6-4ac6-4c35-a78c-c59a78c55799
 
-        @Assert: Host collection is created and name is updated
+        :Assert: Host collection is created and name is updated
 
-        @BZ: 1328925
+        :BZ: 1328925
         """
         new_host_col = self._new_host_collection()
         for new_name in valid_data_list():
@@ -214,11 +214,11 @@ class HostCollectionTestCase(CLITestCase):
     def test_positive_update_description(self):
         """Check if host collection description can be updated
 
-        @id: 298b1f86-d4ab-4e10-a948-a0034826505f
+        :id: 298b1f86-d4ab-4e10-a948-a0034826505f
 
-        @Assert: Host collection is created and description is updated
+        :Assert: Host collection is created and description is updated
 
-        @BZ: 1328925
+        :BZ: 1328925
         """
         new_host_col = self._new_host_collection()
         for desc in valid_data_list():
@@ -236,11 +236,11 @@ class HostCollectionTestCase(CLITestCase):
     def test_positive_update_limit(self):
         """Check if host collection limits be updated
 
-        @id: 4c0e0c3b-82ac-4aa2-8378-6adc7946d4ec
+        :id: 4c0e0c3b-82ac-4aa2-8378-6adc7946d4ec
 
-        @Assert: Host collection limits is updated
+        :Assert: Host collection limits is updated
 
-        @BZ: 1245334
+        :BZ: 1245334
 
         """
         new_host_col = self._new_host_collection()
@@ -259,11 +259,11 @@ class HostCollectionTestCase(CLITestCase):
     def test_positive_delete_by_id(self):
         """Check if host collection can be created and deleted
 
-        @id: ef54a26e-a18f-4f29-8ef4-a7124785dbae
+        :id: ef54a26e-a18f-4f29-8ef4-a7124785dbae
 
-        @Assert: Host collection is created and then deleted
+        :Assert: Host collection is created and then deleted
 
-        @BZ: 1328925
+        :BZ: 1328925
         """
         for name in valid_data_list():
             with self.subTest(name):
@@ -279,11 +279,11 @@ class HostCollectionTestCase(CLITestCase):
     def test_positive_add_host_by_id(self):
         """Check if content host can be added to host collection
 
-        @id: db987da4-6326-43d5-a4c5-93a0c4da7f00
+        :id: db987da4-6326-43d5-a4c5-93a0c4da7f00
 
-        @Assert: Host collection is created and content-host is added
+        :Assert: Host collection is created and content-host is added
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         new_host_col = self._new_host_collection({
             'name': gen_string('alpha', 15)
@@ -305,11 +305,11 @@ class HostCollectionTestCase(CLITestCase):
     def test_positive_remove_host_by_id(self):
         """Check if content host can be removed from host collection
 
-        @id: 61f4aab1-398b-4d3a-a4f4-f558ad8d2679
+        :id: 61f4aab1-398b-4d3a-a4f4-f558ad8d2679
 
-        @Assert: Host collection is created and content-host is removed
+        :Assert: Host collection is created and content-host is removed
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         new_host_col = self._new_host_collection({
             'name': gen_string('alpha', 15)
@@ -339,11 +339,11 @@ class HostCollectionTestCase(CLITestCase):
     def test_positive_list_hosts(self):
         """Check if content hosts added to host collection is listed
 
-        @id: 3075cb97-8448-4358-8ffc-0d5cd0078ca3
+        :id: 3075cb97-8448-4358-8ffc-0d5cd0078ca3
 
-        @Assert: Content-host added to host-collection is listed
+        :Assert: Content-host added to host-collection is listed
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         host_col_name = gen_string('alpha', 15)
         new_host_col = self._new_host_collection({'name': host_col_name})
@@ -369,11 +369,11 @@ class HostCollectionTestCase(CLITestCase):
     def test_positive_list_by_name(self):
         """Check if host collection list can be filtered by name
 
-        @id: 2d611a48-1e51-49b5-8f20-81b09f96c542
+        :id: 2d611a48-1e51-49b5-8f20-81b09f96c542
 
-        @Assert: Only host-collection with specific name is listed
+        :Assert: Only host-collection with specific name is listed
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         # Create two host collections within the same org
         host_col = self._new_host_collection()
@@ -389,11 +389,11 @@ class HostCollectionTestCase(CLITestCase):
     def test_positive_list_by_org_id(self):
         """Check if host collection list can be filtered by organization id
 
-        @id: afbe077a-0de1-432c-a0c4-082129aab92e
+        :id: afbe077a-0de1-432c-a0c4-082129aab92e
 
-        @Assert: Only host-collection within specific org is listed
+        :Assert: Only host-collection within specific org is listed
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         # Create two host collections within different organizations
         self._new_host_collection()
@@ -411,11 +411,11 @@ class HostCollectionTestCase(CLITestCase):
     def test_positive_list_by_org_name(self):
         """Check if host collection list can be filtered by organization name
 
-        @id: 0102094f-f5af-4067-8a07-541ba9d94f61
+        :id: 0102094f-f5af-4067-8a07-541ba9d94f61
 
-        @Assert: Only host-collection within specific org is listed
+        :Assert: Only host-collection within specific org is listed
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         # Create two host collections within different organizations
         self._new_host_collection()
@@ -433,13 +433,13 @@ class HostCollectionTestCase(CLITestCase):
     def test_positive_list_by_host_id(self):
         """Check if host collection list can be filtered by associated host id
 
-        @id: de272461-9804-4524-83c8-23e47abfc8e3
+        :id: de272461-9804-4524-83c8-23e47abfc8e3
 
-        @Assert: Only host-collection with specific host is listed
+        :Assert: Only host-collection with specific host is listed
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
 
-        @BZ: 1379372
+        :BZ: 1379372
         """
         # Create two host collections within the same org but only one with
         # associated host that will be used for filtering
@@ -472,13 +472,13 @@ class HostCollectionTestCase(CLITestCase):
         """Check if host collection list can be filtered by
         associated host name
 
-        @id: 2a99e11f-50b8-48b4-8dce-e6ad8ff9c051
+        :id: 2a99e11f-50b8-48b4-8dce-e6ad8ff9c051
 
-        @Assert: Only host-collection with specific host is listed
+        :Assert: Only host-collection with specific host is listed
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
 
-        @BZ: 1379372
+        :BZ: 1379372
         """
         # Create two host collections within the same org but only one with
         # associated host that will be used for filtering
@@ -512,14 +512,14 @@ class HostCollectionTestCase(CLITestCase):
         host-collection hosts command overrides global configuration defined
         on /etc/hammer/cli_config.yml, which default is 20 per page
 
-        @BZ: 1343583
+        :BZ: 1343583
 
-        @id: bbe1108b-bfb2-4a03-94ef-8fd1b5a0ec82
+        :id: bbe1108b-bfb2-4a03-94ef-8fd1b5a0ec82
 
-        @Assert: Number of host per page follows per_page configuration
-        restriction
+        :Assert: Number of host per page follows per_page configuration
+            restriction
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         host_collection = self._new_host_collection({
             'name': gen_string('alpha', 15)

--- a/tests/foreman/cli/test_hostgroup.py
+++ b/tests/foreman/cli/test_hostgroup.py
@@ -1,19 +1,19 @@
 # -*- encoding: utf-8 -*-
 """Test class for :class:`robottelo.cli.hostgroup.HostGroup` CLI.
 
-@Requirement: Hostgroup
+:Requirement: Hostgroup
 
-@CaseAutomation: Automated
+:CaseAutomation: Automated
 
-@CaseLevel: Acceptance
+:CaseLevel: Acceptance
 
-@CaseComponent: CLI
+:CaseComponent: CLI
 
-@TestType: Functional
+:TestType: Functional
 
-@CaseImportance: High
+:CaseImportance: High
 
-@Upstream: No
+:Upstream: No
 """
 from random import choice
 
@@ -83,9 +83,9 @@ class HostGroupTestCase(CLITestCase):
     def test_positive_create_with_name(self):
         """Successfully creates an HostGroup.
 
-        @id: f5f2056f-d090-4e0d-8fb9-d29255a47908
+        :id: f5f2056f-d090-4e0d-8fb9-d29255a47908
 
-        @Assert: HostGroup is created.
+        :Assert: HostGroup is created.
         """
         for name in valid_hostgroups_list():
             with self.subTest(name):
@@ -96,9 +96,9 @@ class HostGroupTestCase(CLITestCase):
     def test_negative_create_with_name(self):
         """Don't create an HostGroup with invalid data.
 
-        @id: 853a6d43-129a-497b-94f0-08dc622862f8
+        :id: 853a6d43-129a-497b-94f0-08dc622862f8
 
-        @Assert: HostGroup is not created.
+        :Assert: HostGroup is not created.
         """
         for name in invalid_values_list():
             with self.subTest(name):
@@ -110,9 +110,9 @@ class HostGroupTestCase(CLITestCase):
     def test_positive_create_with_env(self):
         """Check if hostgroup with environment can be created
 
-        @id: f1bfb333-90cf-4a9f-b183-cf77c1773247
+        :id: f1bfb333-90cf-4a9f-b183-cf77c1773247
 
-        @Assert: Hostgroup is created and has new environment assigned
+        :Assert: Hostgroup is created and has new environment assigned
 
         """
         environment = make_environment()
@@ -124,9 +124,9 @@ class HostGroupTestCase(CLITestCase):
     def test_positive_create_with_loc(self):
         """Check if hostgroup with location can be created
 
-        @id: 84ae02a4-ea7e-43ce-87bd-7bbde3766b14
+        :id: 84ae02a4-ea7e-43ce-87bd-7bbde3766b14
 
-        @Assert: Hostgroup is created and has new location assigned
+        :Assert: Hostgroup is created and has new location assigned
 
         """
         location = make_location()
@@ -138,9 +138,9 @@ class HostGroupTestCase(CLITestCase):
     def test_positive_create_with_os(self):
         """Check if hostgroup with operating system can be created
 
-        @id: d12c5939-1aac-44f5-8aa3-a04a824f4e83
+        :id: d12c5939-1aac-44f5-8aa3-a04a824f4e83
 
-        @Assert: Hostgroup is created and has operating system assigned
+        :Assert: Hostgroup is created and has operating system assigned
 
         """
         os = make_os()
@@ -152,9 +152,9 @@ class HostGroupTestCase(CLITestCase):
     def test_positive_create_with_org(self):
         """Check if hostgroup with organization can be created
 
-        @id: 780d4b93-f35a-4c5b-a645-4053aed4c37b
+        :id: 780d4b93-f35a-4c5b-a645-4053aed4c37b
 
-        @Assert: Hostgroup is created and has new organization assigned
+        :Assert: Hostgroup is created and has new organization assigned
 
         """
         org = make_org()
@@ -165,9 +165,9 @@ class HostGroupTestCase(CLITestCase):
     def test_positive_create_with_orgs(self):
         """Check if hostgroup with multiple organizations can be created
 
-        @id: 32be4630-0032-4f5f-89d4-44f8d05fe585
+        :id: 32be4630-0032-4f5f-89d4-44f8d05fe585
 
-        @Assert: Hostgroup is created and has both new organizations assigned
+        :Assert: Hostgroup is created and has both new organizations assigned
         """
         orgs = [make_org() for _ in range(2)]
         hostgroup = make_hostgroup({
@@ -183,9 +183,9 @@ class HostGroupTestCase(CLITestCase):
     def test_positive_create_with_puppet_ca_proxy(self):
         """Check if hostgroup with puppet CA proxy server can be created
 
-        @id: f7ea1c94-8a0e-4500-98b3-0ecd63b3ce3c
+        :id: f7ea1c94-8a0e-4500-98b3-0ecd63b3ce3c
 
-        @Assert: Hostgroup is created and has puppet CA proxy server assigned
+        :Assert: Hostgroup is created and has puppet CA proxy server assigned
 
         """
         puppet_proxy = Proxy.list({
@@ -199,9 +199,9 @@ class HostGroupTestCase(CLITestCase):
     def test_positive_create_with_puppet_proxy(self):
         """Check if hostgroup with puppet proxy server can be created
 
-        @id: 3a922d9f-7466-4565-b279-c1481f63a4ce
+        :id: 3a922d9f-7466-4565-b279-c1481f63a4ce
 
-        @Assert: Hostgroup is created and has puppet proxy server assigned
+        :Assert: Hostgroup is created and has puppet proxy server assigned
         """
         puppet_proxy = Proxy.list({
             'search': 'url = https://{0}:9090'.format(settings.server.hostname)
@@ -216,9 +216,9 @@ class HostGroupTestCase(CLITestCase):
     def test_positive_create_with_puppet_class_id(self):
         """Check if hostgroup with puppet class id can be created
 
-        @id: 0a07856d-4432-4b72-a636-460ec12f1b65
+        :id: 0a07856d-4432-4b72-a636-460ec12f1b65
 
-        @Assert: Hostgroup is created and has puppet class assigned
+        :Assert: Hostgroup is created and has puppet class assigned
         """
         hostgroup = make_hostgroup({
             'puppet-class-ids': self.puppet_classes[0]['id'],
@@ -233,9 +233,9 @@ class HostGroupTestCase(CLITestCase):
     def test_positive_create_with_puppet_class_name(self):
         """Check if hostgroup with puppet class name can be created
 
-        @id: 78545a14-742f-4db6-abce-49fbeccd836e
+        :id: 78545a14-742f-4db6-abce-49fbeccd836e
 
-        @Assert: Hostgroup is created and has puppet class assigned
+        :Assert: Hostgroup is created and has puppet class assigned
         """
         hostgroup = make_hostgroup({
             'puppet-classes': self.puppet_classes[0]['name'],
@@ -252,11 +252,11 @@ class HostGroupTestCase(CLITestCase):
     def test_positive_create_with_architecture(self):
         """Check if hostgroup with architecture can be created
 
-        @id: 21c619f4-7339-4fb0-9e29-e12dae65f943
+        :id: 21c619f4-7339-4fb0-9e29-e12dae65f943
 
-        @Assert: Hostgroup should be created and has architecture assigned
+        :Assert: Hostgroup should be created and has architecture assigned
 
-        @BZ: 1354544
+        :BZ: 1354544
         """
         arch = 'x86_64'
         hostgroup = make_hostgroup({'architecture': arch})
@@ -267,9 +267,9 @@ class HostGroupTestCase(CLITestCase):
     def test_positive_create_with_domain(self):
         """Check if hostgroup with domain can be created
 
-        @id: c468fcac-9e42-4ee6-a431-abe29b6848ce
+        :id: c468fcac-9e42-4ee6-a431-abe29b6848ce
 
-        @Assert: Hostgroup should be created and has domain assigned
+        :Assert: Hostgroup should be created and has domain assigned
         """
         domain = make_domain()
         hostgroup = make_hostgroup({'domain-id': domain['id']})
@@ -281,11 +281,11 @@ class HostGroupTestCase(CLITestCase):
     def test_positive_create_with_lifecycle_environment(self):
         """Check if hostgroup with lifecyle environment can be created
 
-        @id: 24bc3010-4e61-47d8-b8ae-0d66e1055aea
+        :id: 24bc3010-4e61-47d8-b8ae-0d66e1055aea
 
-        @Assert: Hostgroup should be created and has lifecycle env assigned
+        :Assert: Hostgroup should be created and has lifecycle env assigned
 
-        @BZ: 1359694
+        :BZ: 1359694
         """
         org = make_org()
         lc_env = make_lifecycle_environment({'organization-id': org['id']})
@@ -303,10 +303,10 @@ class HostGroupTestCase(CLITestCase):
         """Check if hostgroup with multiple organizations can be created
         if one of them is associated with lifecycle environment
 
-        @id: ca110a74-401d-48f9-9700-6c57f1c10f11
+        :id: ca110a74-401d-48f9-9700-6c57f1c10f11
 
-        @Assert: Hostgroup is created, has both new organizations assigned
-        and has lifecycle env assigned
+        :Assert: Hostgroup is created, has both new organizations assigned and
+            has lifecycle env assigned
         """
         orgs = [make_org() for _ in range(2)]
         lce = make_lifecycle_environment({'organization-id': orgs[0]['id']})
@@ -324,12 +324,12 @@ class HostGroupTestCase(CLITestCase):
     def test_positive_create_with_multiple_entities(self):
         """Check if hostgroup with multiple options can be created
 
-        @id: a3ef4f0e-971d-4307-8d0a-35103dff6586
+        :id: a3ef4f0e-971d-4307-8d0a-35103dff6586
 
-        @Assert: Hostgroup should be created and has all defined entities
-        assigned
+        :Assert: Hostgroup should be created and has all defined entities
+            assigned
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         # Common entities
         loc = make_location()
@@ -429,11 +429,11 @@ class HostGroupTestCase(CLITestCase):
     def test_negative_create_with_subnet_id(self):
         """Check if hostgroup with invalid subnet id raises proper error
 
-        @id: c352d7ea-4fc6-4b78-863d-d3ee4c0ad439
+        :id: c352d7ea-4fc6-4b78-863d-d3ee4c0ad439
 
-        @Assert: Proper error should be raised
+        :Assert: Proper error should be raised
 
-        @BZ: 1354568
+        :BZ: 1354568
         """
         subnet_id = gen_string('numeric', 4)
         with self.assertRaises(CLIReturnCodeError) as exception:
@@ -452,11 +452,11 @@ class HostGroupTestCase(CLITestCase):
     def test_negative_create_with_domain_id(self):
         """Check if hostgroup with invalid domain id raises proper error
 
-        @id: b36c83d6-b27c-4f1a-ac45-6c4999005bf7
+        :id: b36c83d6-b27c-4f1a-ac45-6c4999005bf7
 
-        @Assert: Proper error should be raised
+        :Assert: Proper error should be raised
 
-        @BZ: 1354568
+        :BZ: 1354568
         """
         domain_id = gen_string('numeric', 4)
         with self.assertRaises(CLIReturnCodeError) as exception:
@@ -475,11 +475,11 @@ class HostGroupTestCase(CLITestCase):
     def test_negative_create_with_architecture_id(self):
         """Check if hostgroup with invalid architecture id raises proper error
 
-        @id: 7b7de0fa-aee9-4163-adc2-354c1e720d90
+        :id: 7b7de0fa-aee9-4163-adc2-354c1e720d90
 
-        @Assert: Proper error should be raised
+        :Assert: Proper error should be raised
 
-        @BZ: 1354568
+        :BZ: 1354568
         """
         arch_id = gen_string('numeric', 4)
         with self.assertRaises(CLIReturnCodeError) as exception:
@@ -496,9 +496,9 @@ class HostGroupTestCase(CLITestCase):
     def test_positive_update_name(self):
         """Successfully update an HostGroup.
 
-        @id: a36e3cbe-83d9-44ce-b8f7-5fab2a2cadf9
+        :id: a36e3cbe-83d9-44ce-b8f7-5fab2a2cadf9
 
-        @Assert: HostGroup is updated.
+        :Assert: HostGroup is updated.
         """
         hostgroup = make_hostgroup()
         for new_name in valid_hostgroups_list():
@@ -515,9 +515,9 @@ class HostGroupTestCase(CLITestCase):
     def test_negative_update_name(self):
         """Create HostGroup then fail to update its name
 
-        @id: 42d208a4-f518-4ff2-9b7a-311adb460abd
+        :id: 42d208a4-f518-4ff2-9b7a-311adb460abd
 
-        @assert: HostGroup name is not updated
+        :assert: HostGroup name is not updated
         """
         hostgroup = make_hostgroup()
         for new_name in invalid_values_list():
@@ -534,9 +534,9 @@ class HostGroupTestCase(CLITestCase):
     def test_positive_update_puppet_class_by_id(self):
         """Update hostgroup with puppet class by name by id
 
-        @id: 4b044719-431d-4d72-8974-330cc62fd020
+        :id: 4b044719-431d-4d72-8974-330cc62fd020
 
-        @Assert: Puppet class is associated with hostgroup
+        :Assert: Puppet class is associated with hostgroup
         """
         hostgroup = make_hostgroup({
             'environment-id': self.env['id'],
@@ -556,9 +556,9 @@ class HostGroupTestCase(CLITestCase):
     def test_positive_update_puppet_class_by_name(self):
         """Update hostgroup with puppet class by name
 
-        @id: 4c37354f-ef2d-4d54-98ac-906bc611d292
+        :id: 4c37354f-ef2d-4d54-98ac-906bc611d292
 
-        @Assert: Puppet class is associated with hostgroup
+        :Assert: Puppet class is associated with hostgroup
         """
         hostgroup = make_hostgroup({
             'environment-id': self.env['id'],
@@ -578,11 +578,11 @@ class HostGroupTestCase(CLITestCase):
     def test_positive_update_multiple_puppet_classes(self):
         """Update hostgroup with multiple puppet classes by name
 
-        @id: 2e977aed-c0d4-478e-9c84-f07deac912cd
+        :id: 2e977aed-c0d4-478e-9c84-f07deac912cd
 
-        @Assert: All puppet classes are associated with hostgroup
+        :Assert: All puppet classes are associated with hostgroup
 
-        @BZ: 1264163
+        :BZ: 1264163
         """
         puppet_classes = [puppet['name'] for puppet in self.puppet_classes]
         hostgroup = make_hostgroup({
@@ -602,9 +602,9 @@ class HostGroupTestCase(CLITestCase):
         """Create HostGroup with valid values then delete it
         by ID
 
-        @id: fe7dedd4-d7c3-4c70-b70d-c2deff357b76
+        :id: fe7dedd4-d7c3-4c70-b70d-c2deff357b76
 
-        @assert: HostGroup is deleted
+        :assert: HostGroup is deleted
         """
         for name in valid_hostgroups_list():
             with self.subTest(name):
@@ -618,9 +618,9 @@ class HostGroupTestCase(CLITestCase):
     def test_negative_delete_by_id(self):
         """Create HostGroup then delete it by wrong ID
 
-        @id: 047c9f1a-4dd6-4fdc-b7ed-37cc725c68d3
+        :id: 047c9f1a-4dd6-4fdc-b7ed-37cc725c68d3
 
-        @assert: HostGroup is not deleted
+        :assert: HostGroup is not deleted
         """
         for entity_id in invalid_id_list():
             with self.subTest(entity_id):
@@ -631,11 +631,11 @@ class HostGroupTestCase(CLITestCase):
     def test_positive_list_scparams_by_id(self):
         """List all overridden smart class parameters using hostgroup id
 
-        @id: 42a24060-2ed7-427e-8396-86d73bbe5f69
+        :id: 42a24060-2ed7-427e-8396-86d73bbe5f69
 
-        @Assert: Overridden sc-param from puppet class is listed
+        :Assert: Overridden sc-param from puppet class is listed
 
-        @Caselevel: Integration
+        :Caselevel: Integration
         """
         # Create hostgroup with associated puppet class
         hostgroup = make_hostgroup({
@@ -659,11 +659,11 @@ class HostGroupTestCase(CLITestCase):
     def test_positive_list_scparams_by_name(self):
         """List all smart class parameters using hostgroup name
 
-        @id: 8e4fc561-2446-4a89-989b-e6814973aa56
+        :id: 8e4fc561-2446-4a89-989b-e6814973aa56
 
-        @Assert: Overridden sc-param from puppet class is listed
+        :Assert: Overridden sc-param from puppet class is listed
 
-        @Caselevel: Integration
+        :Caselevel: Integration
         """
         # Create hostgroup with associated puppet class
         hostgroup = make_hostgroup({
@@ -687,11 +687,11 @@ class HostGroupTestCase(CLITestCase):
     def test_positive_list_smartvariables_by_id(self):
         """List all smart variables using hostgroup id
 
-        @id: 1d614441-7ef9-4fdb-a8e7-2f1c1054bf2f
+        :id: 1d614441-7ef9-4fdb-a8e7-2f1c1054bf2f
 
-        @Assert: Smart variable from puppet class is listed
+        :Assert: Smart variable from puppet class is listed
 
-        @Caselevel: Integration
+        :Caselevel: Integration
         """
         # Create hostgroup with associated puppet class
         hostgroup = make_hostgroup({
@@ -712,11 +712,11 @@ class HostGroupTestCase(CLITestCase):
     def test_positive_list_smartvariables_by_name(self):
         """List all smart variables using hostgroup name
 
-        @id: 2b0da695-57fa-4f91-b164-e1ff60076c26
+        :id: 2b0da695-57fa-4f91-b164-e1ff60076c26
 
-        @Assert: Smart variable from puppet class is listed
+        :Assert: Smart variable from puppet class is listed
 
-        @Caselevel: Integration
+        :Caselevel: Integration
         """
         # Create hostgroup with associated puppet class
         hostgroup = make_hostgroup({

--- a/tests/foreman/cli/test_import.py
+++ b/tests/foreman/cli/test_import.py
@@ -1,19 +1,19 @@
 # -*- encoding: utf-8 -*-
 """Test class for Host Collection CLI
 
-@Requirement: Import
+:Requirement: Import
 
-@CaseAutomation: Automated
+:CaseAutomation: Automated
 
-@CaseLevel: Acceptance
+:CaseLevel: Acceptance
 
-@CaseComponent: CLI
+:CaseComponent: CLI
 
-@TestType: Functional
+:TestType: Functional
 
-@CaseImportance: High
+:CaseImportance: High
 
-@Upstream: No
+:Upstream: No
 """
 import csv
 import os
@@ -530,9 +530,9 @@ class TestImport(CLITestCase):
         """Import all organizations from the default data set
         (predefined source).
 
-        @id: e7d91832-72bb-4d15-9a75-b3bc0d40b857
+        :id: e7d91832-72bb-4d15-9a75-b3bc0d40b857
 
-        @assert: 3 Organizations are created
+        :assert: 3 Organizations are created
 
         """
         for test_data in gen_import_org_data():
@@ -551,12 +551,12 @@ class TestImport(CLITestCase):
         """Import all organizations from the default data set
         (predefined source) and upload manifests for each of them
 
-        @id: 4e64ecb7-68ac-40ed-91b8-a2ac1b426b20
+        :id: 4e64ecb7-68ac-40ed-91b8-a2ac1b426b20
 
-        @assert: 3 Organizations are created with 3 manifests uploaded
+        :assert: 3 Organizations are created with 3 manifests uploaded
 
 
-        @CaseLevel: System
+        :CaseLevel: System
         """
         for test_data in gen_import_org_manifest_data():
             with self.subTest(test_data):
@@ -585,9 +585,9 @@ class TestImport(CLITestCase):
         """Try to Import all organizations from the predefined source
         and try to import them again
 
-        @id: 990e5efc-7f72-45c9-a402-76633adcd49f
+        :id: 990e5efc-7f72-45c9-a402-76633adcd49f
 
-        @assert: 2nd Import will result in No Action Taken
+        :assert: 2nd Import will result in No Action Taken
 
         """
         for test_data in gen_import_org_data():
@@ -606,10 +606,10 @@ class TestImport(CLITestCase):
         """Try to Import organizations with the same name to invoke
         usage of a recovery strategy (rename, map, none)
 
-        @id: e85563e8-284c-420c-9b62-30a847039e36
+        :id: e85563e8-284c-420c-9b62-30a847039e36
 
-        @assert: 2nd Import will result in No Action Taken, 3rd one will rename
-        the new organizations, and the 4th one will map them
+        :assert: 2nd Import will result in No Action Taken, 3rd one will rename
+            the new organizations, and the 4th one will map them
 
         """
         for test_data in gen_import_org_data():
@@ -656,10 +656,10 @@ class TestImport(CLITestCase):
         """Try to Import all organizations and their users from CSV
         to a mapped organization.
 
-        @id: f456d8ea-2388-4944-a194-8860154c2529
+        :id: f456d8ea-2388-4944-a194-8860154c2529
 
-        @assert: 3 Organizations Mapped and their Users created
-        in a single Organization
+        :assert: 3 Organizations Mapped and their Users created in a single
+            Organization
 
         """
         for test_data in gen_import_user_data():
@@ -694,9 +694,9 @@ class TestImport(CLITestCase):
         """Import all 3 users from the default data set (predefined
         source).
 
-        @id: 4306e315-85dc-4324-9ecc-911f97d461ae
+        :id: 4306e315-85dc-4324-9ecc-911f97d461ae
 
-        @assert: 3 Users created
+        :assert: 3 Users created
 
         """
         for test_data in gen_import_user_data():
@@ -724,9 +724,9 @@ class TestImport(CLITestCase):
         """Try to Import all users from the
         predefined source and try to import them again
 
-        @id: 7142fcf0-1766-4bf6-bb82-26dbf9fb18ec
+        :id: 7142fcf0-1766-4bf6-bb82-26dbf9fb18ec
 
-        @assert: 2nd Import will result in No Action Taken
+        :assert: 2nd Import will result in No Action Taken
 
         """
         for test_data in gen_import_user_data():
@@ -754,10 +754,10 @@ class TestImport(CLITestCase):
         """Try to Merge users with the same name using 'merge-users'
         option.
 
-        @id: 466a9bbd-f804-4d22-993d-37a8c6b9dade
+        :id: 466a9bbd-f804-4d22-993d-37a8c6b9dade
 
-        @assert: Users imported in 2nd import are being mapped to the existing
-        ones with the same name
+        :assert: Users imported in 2nd import are being mapped to the existing
+            ones with the same name
 
         """
         for test_data in gen_import_user_data():
@@ -793,10 +793,10 @@ class TestImport(CLITestCase):
         """Try to Import users with the same name to invoke
         usage of a recovery strategy (rename, map, none)
 
-        @id: 6c235a7a-d957-4144-a0f3-0f048851da0f
+        :id: 6c235a7a-d957-4144-a0f3-0f048851da0f
 
-        @assert: 2nd Import will rename new users, 3rd one will result
-        in No Action Taken and 4th import will map them
+        :assert: 2nd Import will rename new users, 3rd one will result in No
+            Action Taken and 4th import will map them
 
         """
         for test_data in gen_import_user_data():
@@ -855,9 +855,9 @@ class TestImport(CLITestCase):
         """Import all System Groups from the default data set
         (predefined source) as the Host Collections.
 
-        @id: c0d19696-49fb-4dd2-b66d-6fc05042a668
+        :id: c0d19696-49fb-4dd2-b66d-6fc05042a668
 
-        @assert: 3 Host Collections created
+        :assert: 3 Host Collections created
 
         """
         for test_data in gen_import_hostcol_data():
@@ -891,9 +891,9 @@ class TestImport(CLITestCase):
         """Try to re-import all System Groups from the default data set
         (predefined source) as the Host Collections.
 
-        @id: cb3e4799-2d3d-4e5f-8a3a-7f2d1f7ea4cc
+        :id: cb3e4799-2d3d-4e5f-8a3a-7f2d1f7ea4cc
 
-        @assert: 3 Host Collections created, no action taken on 2nd Import
+        :assert: 3 Host Collections created, no action taken on 2nd Import
 
         """
         for test_data in gen_import_hostcol_data():
@@ -924,10 +924,10 @@ class TestImport(CLITestCase):
         """Try to Import Collections with the same name to invoke
         usage of a recovery strategy (rename, map, none)
 
-        @id: e0520f6b-64c3-4263-8064-9ec5ba7eb2f5
+        :id: e0520f6b-64c3-4263-8064-9ec5ba7eb2f5
 
-        @assert: 2nd Import will rename the new collections, 3nd import will
-        result in No Action Taken and the 4th one will map them
+        :assert: 2nd Import will rename the new collections, 3nd import will
+            result in No Action Taken and the 4th one will map them
 
         """
         for test_data in gen_import_hostcol_data():
@@ -987,9 +987,9 @@ class TestImport(CLITestCase):
         """Import and enable all Repositories from the default data set
         (predefined source)
 
-        @id: ae506d6c-a24b-4d27-85a0-9a3791684e6f
+        :id: ae506d6c-a24b-4d27-85a0-9a3791684e6f
 
-        @assert: 3 Repositories imported and enabled
+        :assert: 3 Repositories imported and enabled
 
         """
         for test_data in gen_import_repo_data():
@@ -1027,10 +1027,10 @@ class TestImport(CLITestCase):
         (predefined source), then try to Import Repositories from the same CSV
         again.
 
-        @id: 75d5cd18-fe73-4a2c-8036-4a60dab7a729
+        :id: 75d5cd18-fe73-4a2c-8036-4a60dab7a729
 
-        @assert: 3 Repositories imported and enabled, second run should trigger
-        no action.
+        :assert: 3 Repositories imported and enabled, second run should trigger
+            no action.
         """
         for test_data in gen_import_repo_data():
             with self.subTest(test_data):
@@ -1077,11 +1077,10 @@ class TestImport(CLITestCase):
         """Try to Import Repos with the same name to invoke
         usage of a recovery strategy (rename, map, none)
 
-        @id: 6ab9d08f-74e6-488d-932c-1ef0fca319d9
+        :id: 6ab9d08f-74e6-488d-932c-1ef0fca319d9
 
-        @assert: 2nd Import will rename the new repos, 3rd import will
-        map them and the 4th one will result in No Action Taken
-
+        :assert: 2nd Import will rename the new repos, 3rd import will map them
+            and the 4th one will result in No Action Taken
         """
         for test_data in gen_import_repo_data():
             with self.subTest(test_data):
@@ -1140,9 +1139,9 @@ class TestImport(CLITestCase):
         """Import and enable all Content Views from the default data set
         (predefined source)
 
-        @id: 6c42e82f-4939-41bb-9445-cf9ea4a5d3ab
+        :id: 6c42e82f-4939-41bb-9445-cf9ea4a5d3ab
 
-        @assert: 3 Content Views imported and enabled
+        :assert: 3 Content Views imported and enabled
 
         """
         for test_data in gen_import_cv_data():
@@ -1185,11 +1184,10 @@ class TestImport(CLITestCase):
         (predefined source), then try to Import them from the same CSV
         again.
 
-        @id: ad600c5b-057e-45b5-be67-ab6a338f9fef
+        :id: ad600c5b-057e-45b5-be67-ab6a338f9fef
 
-        @assert: 3 Content Views imported and enabled, 2nd run should trigger
-        no action.
-
+        :assert: 3 Content Views imported and enabled, 2nd run should trigger
+            no action.
         """
         for test_data in gen_import_cv_data():
             with self.subTest(test_data):
@@ -1240,11 +1238,10 @@ class TestImport(CLITestCase):
         """Try to Import Content Views with the same name to invoke
         usage of a recovery strategy (rename, map, none)
 
-        @id: 29bd0728-ae3c-4866-b9db-6b033ec36b2f
+        :id: 29bd0728-ae3c-4866-b9db-6b033ec36b2f
 
-        @assert: 2nd Import will rename the new Content Views, 3rd import will
-        map them and the 4th one will result in No Action Taken
-
+        :assert: 2nd Import will rename the new Content Views, 3rd import will
+            map them and the 4th one will result in No Action Taken
         """
         for test_data in gen_import_cv_data():
             with self.subTest(test_data):
@@ -1315,9 +1312,9 @@ class TestImport(CLITestCase):
         converted to the Puppet facts.
         According to RH Transition Guide (Chapter 3.7.8, Table 3.1)
 
-        @id: 1e6d2979-1187-4f54-a7f7-84349afc1db4
+        :id: 1e6d2979-1187-4f54-a7f7-84349afc1db4
 
-        @assert: Generated .erb file contains correctly formatted puppet facts
+        :assert: Generated .erb file contains correctly formatted puppet facts
 
         """
         # This bug was originally created to verify BZ 1160847
@@ -1429,12 +1426,12 @@ class TestImport(CLITestCase):
         """Import and enable all red hat repositories from predefined
         dataset
 
-        @id: 6b5c8955-979b-4852-b401-b2c534631dce
+        :id: 6b5c8955-979b-4852-b401-b2c534631dce
 
-        @assert: All Repositories imported and synchronized
+        :assert: All Repositories imported and synchronized
 
 
-        @CaseLevel: System
+        :CaseLevel: System
         """
         for test_data in gen_import_rh_repo_data():
             with self.subTest(test_data):
@@ -1480,12 +1477,12 @@ class TestImport(CLITestCase):
         """Repetitive Import and enable of all red hat repositories from
         the predefined dataset
 
-        @id: ca345863-8e94-463e-bc06-b217ecb1189f
+        :id: ca345863-8e94-463e-bc06-b217ecb1189f
 
-        @assert: All Repositories imported and synchronized only once
+        :assert: All Repositories imported and synchronized only once
 
 
-        @CaseLevel: System
+        :CaseLevel: System
         """
         for test_data in gen_import_rh_repo_data():
             with self.subTest(test_data):
@@ -1527,9 +1524,9 @@ class TestImport(CLITestCase):
     def test_positive_import_hosts_default(self):
         """Import all hosts from the predefined dataset
 
-        @id: 90662be7-335f-43a4-816c-b6bb906614fd
+        :id: 90662be7-335f-43a4-816c-b6bb906614fd
 
-        @assert: Profiles for all Hosts created
+        :assert: Profiles for all Hosts created
 
         """
         for test_data in gen_import_chost_data():
@@ -1557,9 +1554,9 @@ class TestImport(CLITestCase):
     def test_negative_reimport_hosts(self):
         """Repetitive Import of all hosts from the predefined dataset
 
-        @id: b98ef26e-e938-40c2-805d-6292b12b64d5
+        :id: b98ef26e-e938-40c2-805d-6292b12b64d5
 
-        @assert: Profiles for all Hosts created only once
+        :assert: Profiles for all Hosts created only once
 
         """
         for test_data in gen_import_chost_data():
@@ -1598,9 +1595,9 @@ class TestImport(CLITestCase):
     def test_negative_import_chosts_recovery(self):
         """Try to invoke usage of a recovery strategy
 
-        @id: 29d59eab-2f30-4812-82ba-ca4c49439da5
+        :id: 29d59eab-2f30-4812-82ba-ca4c49439da5
 
-        @assert: No such option exists, error is shown
+        :assert: No such option exists, error is shown
 
         """
         for test_data in gen_import_chost_data():
@@ -1630,9 +1627,9 @@ class TestImport(CLITestCase):
         """Import template snippets from the default data set
         (predefined source)
 
-        @id: fcced407-4e94-49ae-ab5a-8e868aee6625
+        :id: fcced407-4e94-49ae-ab5a-8e868aee6625
 
-        @assert: All Snippets imported
+        :assert: All Snippets imported
 
         """
         for test_data in gen_import_snippet_data():
@@ -1669,9 +1666,9 @@ class TestImport(CLITestCase):
         """Import all Config Files from the default data set
         (predefined source)
 
-        @id: 760393d2-b4c5-48ec-96ff-8947dd3bca62
+        :id: 760393d2-b4c5-48ec-96ff-8947dd3bca62
 
-        @assert: All Config Files are imported
+        :assert: All Config Files are imported
 
         """
         for test_data in gen_import_config_files_data():
@@ -1709,9 +1706,9 @@ class TestImport(CLITestCase):
         """Repetitive Import of all Config Files from the default
         data set (predefined source)
 
-        @id: 8b3d2956-c842-4a91-bf3e-6dcda174bd5f
+        :id: 8b3d2956-c842-4a91-bf3e-6dcda174bd5f
 
-        @assert: All Config Files are imported only once
+        :assert: All Config Files are imported only once
 
         """
         for test_data in gen_import_config_files_data():
@@ -1765,9 +1762,9 @@ class TestImport(CLITestCase):
         """Import AKs from the default data set
         (predefined source)
 
-        @id: 86b35ce4-c51d-4391-98c9-9dd0ff50963a
+        :id: 86b35ce4-c51d-4391-98c9-9dd0ff50963a
 
-        @assert: 3 AKs imported
+        :assert: 3 AKs imported
 
         """
         for test_data in gen_import_ak_data():

--- a/tests/foreman/cli/test_installer.py
+++ b/tests/foreman/cli/test_installer.py
@@ -1,19 +1,19 @@
 # -*- encoding: utf-8 -*-
 """Tests for Installer
 
-@Requirement: Installer
+:Requirement: Installer
 
-@CaseAutomation: Automated
+:CaseAutomation: Automated
 
-@CaseLevel: Acceptance
+:CaseLevel: Acceptance
 
-@CaseComponent: CLI
+:CaseComponent: CLI
 
-@TestType: Functional
+:TestType: Functional
 
-@CaseImportance: High
+:CaseImportance: High
 
-@Upstream: No
+:Upstream: No
 """
 from robottelo.decorators import run_only_on, stubbed
 from robottelo.test import CLITestCase
@@ -34,13 +34,13 @@ class InstallerTestCase(CLITestCase):
         # the health status
         """Services services start correctly
 
-        @id: d3f99d2d-8e87-47c4-b80e-151edac5b0c3
+        :id: d3f99d2d-8e87-47c4-b80e-151edac5b0c3
 
-        @assert: All services {katello-jobs, tomcat6, foreman, pulp,
-        passenger-analytics, httpd, foreman_proxy, elasticsearch, postgresql,
-        mongod} are started
+        :assert: All services {katello-jobs, tomcat6, foreman, pulp,
+            passenger-analytics, httpd, foreman_proxy, elasticsearch,
+            postgresql, mongod} are started
 
-        @caseautomation: notautomated
+        :caseautomation: notautomated
         """
 
     @stubbed()
@@ -48,16 +48,15 @@ class InstallerTestCase(CLITestCase):
     def test_positive_installer_logfile_check(self):
         """Look for ERROR or FATAL references in logfiles
 
-        @id: fe29310d-7fe2-4563-bd4b-ecebc0a24f7f
+        :id: fe29310d-7fe2-4563-bd4b-ecebc0a24f7f
 
-        @steps:
-        1.  search all relevant logfiles for ERROR/FATAL
+        :steps: search all relevant logfiles for ERROR/FATAL
 
-        @assert: No ERROR/FATAL notifcations occur in {katello-jobs, tomcat6,
-        foreman, pulp, passenger-analytics,httpd, foreman_proxy, elasticsearch,
-        postgresql, mongod} logfiles.
+        :assert: No ERROR/FATAL notifcations occur in {katello-jobs, tomcat6,
+            foreman, pulp, passenger-analytics,httpd, foreman_proxy,
+            elasticsearch, postgresql, mongod} logfiles.
 
-        @caseautomation: notautomated
+        :caseautomation: notautomated
         """
 
     @stubbed()
@@ -65,12 +64,12 @@ class InstallerTestCase(CLITestCase):
     def test_positive_installer_check_progress_meter(self):
         """ Assure progress indicator/meter "works"
 
-        @id: c654be1b-d018-4eb4-9867-6ecbb0a8ae5a
+        :id: c654be1b-d018-4eb4-9867-6ecbb0a8ae5a
 
-        @assert: Progress indicator increases appropriately as install
-        commences, through to completion
+        :assert: Progress indicator increases appropriately as install
+            commences, through to completion
 
-        @caseautomation: notautomated
+        :caseautomation: notautomated
         """
 
     @stubbed()
@@ -78,11 +77,11 @@ class InstallerTestCase(CLITestCase):
     def test_positive_server_installer_from_iso(self):
         """ Can install product from ISO
 
-        @id: 38c08646-9f71-48d9-a9c2-66bd94c3e5bb
+        :id: 38c08646-9f71-48d9-a9c2-66bd94c3e5bb
 
-        @assert: Install from ISO is sucessful.
+        :assert: Install from ISO is sucessful.
 
-        @caseautomation: notautomated
+        :caseautomation: notautomated
         """
 
     @stubbed()
@@ -90,11 +89,11 @@ class InstallerTestCase(CLITestCase):
     def test_positive_server_installer_from_repository(self):
         """ Can install main satellite instance successfully via RPM
 
-        @id: 4dac99c3-6334-43df-adc4-c26e19f762ce
+        :id: 4dac99c3-6334-43df-adc4-c26e19f762ce
 
-        @assert: Install of main instance successful.
+        :assert: Install of main instance successful.
 
-        @caseautomation: notautomated
+        :caseautomation: notautomated
         """
 
     @stubbed()
@@ -102,11 +101,11 @@ class InstallerTestCase(CLITestCase):
     def test_positive_capsule_installer_from_repository(self):
         """ Can install capsule successfully via RPM
 
-        @id: 07b0aaa3-651a-4103-904d-c8bcc632a3d1
+        :id: 07b0aaa3-651a-4103-904d-c8bcc632a3d1
 
-        @assert: Install of capsule successful.
+        :assert: Install of capsule successful.
 
-        @caseautomation: notautomated
+        :caseautomation: notautomated
         """
 
     @stubbed()
@@ -115,11 +114,11 @@ class InstallerTestCase(CLITestCase):
         """ Can install  satellite disconnected utility successfully
         via RPM
 
-        @id: b738cf2a-9c5f-4865-b134-102a4688534c
+        :id: b738cf2a-9c5f-4865-b134-102a4688534c
 
-        @assert: Install of disconnected utility successful.
+        :assert: Install of disconnected utility successful.
 
-        @caseautomation: notautomated
+        :caseautomation: notautomated
         """
 
     @stubbed()
@@ -128,12 +127,12 @@ class InstallerTestCase(CLITestCase):
         """Upon installation, capsule instance self-registers
         itself to parent instance
 
-        @id: efd03442-5a08-445d-b257-e4d346084379
+        :id: efd03442-5a08-445d-b257-e4d346084379
 
-        @assert: capsule is communicating properly with parent,
-        following install.
+        :assert: capsule is communicating properly with parent, following
+            install.
 
-        @caseautomation: notautomated
+        :caseautomation: notautomated
         """
 
     @stubbed()
@@ -141,11 +140,11 @@ class InstallerTestCase(CLITestCase):
     def test_positive_installer_clear_data(self):
         """ User can run installer to clear existing data
 
-        @id: 11ed1ed5-7f72-4310-80df-5cac6547b01a
+        :id: 11ed1ed5-7f72-4310-80df-5cac6547b01a
 
-        @assert: All data is cleared from satellite instance
+        :assert: All data is cleared from satellite instance
 
-        @bz: 1072780
+        :bz: 1072780
 
-        @caseautomation: notautomated
+        :caseautomation: notautomated
         """

--- a/tests/foreman/cli/test_lifecycleenvironment.py
+++ b/tests/foreman/cli/test_lifecycleenvironment.py
@@ -1,19 +1,19 @@
 # -*- encoding: utf-8 -*-
 """Test class for Host CLI
 
-@Requirement: Lifecycleenvironment
+:Requirement: Lifecycleenvironment
 
-@CaseAutomation: Automated
+:CaseAutomation: Automated
 
-@CaseLevel: Acceptance
+:CaseLevel: Acceptance
 
-@CaseComponent: CLI
+:CaseComponent: CLI
 
-@TestType: Functional
+:TestType: Functional
 
-@CaseImportance: High
+:CaseImportance: High
 
-@Upstream: No
+:Upstream: No
 """
 
 from fauxfactory import gen_alphanumeric, gen_string
@@ -50,9 +50,9 @@ class LifeCycleEnvironmentTestCase(CLITestCase):
     def test_verify_bugzilla_1077386(self):
         """List subcommand returns standard output
 
-        @id: cca249d0-fb77-422b-aae3-3361887269db
+        :id: cca249d0-fb77-422b-aae3-3361887269db
 
-        @Assert: There should not be an error returned
+        :Assert: There should not be an error returned
 
         """
 
@@ -73,9 +73,9 @@ class LifeCycleEnvironmentTestCase(CLITestCase):
         """Search lifecycle environment via its name containing UTF-8
         chars
 
-        @id: d15001ed-5bbf-43cf-bdd3-1e129dff14ec
+        :id: d15001ed-5bbf-43cf-bdd3-1e129dff14ec
 
-        @Assert: Can get info for lifecycle by its name
+        :Assert: Can get info for lifecycle by its name
 
         """
         test_data = {
@@ -96,9 +96,9 @@ class LifeCycleEnvironmentTestCase(CLITestCase):
         """Create lifecycle environment with valid name, prior to
         Library
 
-        @id: fffe67e2-9a45-478d-a538-99f04a9c40ff
+        :id: fffe67e2-9a45-478d-a538-99f04a9c40ff
 
-        @Assert: Lifecycle environment is created with Library as prior
+        :Assert: Lifecycle environment is created with Library as prior
 
         """
         for name in valid_data_list():
@@ -116,9 +116,9 @@ class LifeCycleEnvironmentTestCase(CLITestCase):
         """Create lifecycle environment with valid description prior to
         Library
 
-        @id: 714c42f8-d09e-4e48-9f35-bbc25fe9e229
+        :id: 714c42f8-d09e-4e48-9f35-bbc25fe9e229
 
-        @Assert: Lifecycle environment is created with Library as prior
+        :Assert: Lifecycle environment is created with Library as prior
 
         """
         for desc in valid_data_list():
@@ -139,9 +139,9 @@ class LifeCycleEnvironmentTestCase(CLITestCase):
     def test_positive_create_with_label(self):
         """Create lifecycle environment with valid name and label
 
-        @id: 8d82932f-dedf-46f0-a6dc-280cfb228f44
+        :id: 8d82932f-dedf-46f0-a6dc-280cfb228f44
 
-        @Assert: Lifecycle environment with label is created
+        :Assert: Lifecycle environment with label is created
 
         """
         for label in (gen_string("alpha", 15), gen_string("alphanumeric", 15),
@@ -159,9 +159,9 @@ class LifeCycleEnvironmentTestCase(CLITestCase):
     def test_positive_create_with_organization_name(self):
         """Create lifecycle environment, specifying organization name
 
-        @id: e62ddb5a-7a38-4b7c-9346-b4dce31448c1
+        :id: e62ddb5a-7a38-4b7c-9346-b4dce31448c1
 
-        @Assert: Lifecycle environment is created for correct organization
+        :Assert: Lifecycle environment is created for correct organization
 
         """
         new_lce = make_lifecycle_environment({
@@ -175,9 +175,9 @@ class LifeCycleEnvironmentTestCase(CLITestCase):
     def test_positive_create_with_organization_label(self):
         """Create lifecycle environment, specifying organization label
 
-        @id: eb5cfc71-c83d-45ca-ba34-9ef79197691d
+        :id: eb5cfc71-c83d-45ca-ba34-9ef79197691d
 
-        @Assert: Lifecycle environment is created for correct organization
+        :Assert: Lifecycle environment is created for correct organization
 
         """
         new_lce = make_lifecycle_environment({
@@ -192,9 +192,9 @@ class LifeCycleEnvironmentTestCase(CLITestCase):
         """Create lifecycle environment with valid name, prior to
         Library
 
-        @id: 76989039-5389-4136-9f7c-220eb38f157b
+        :id: 76989039-5389-4136-9f7c-220eb38f157b
 
-        @Assert: Lifecycle environment is deleted
+        :Assert: Lifecycle environment is deleted
 
         """
         for name in valid_data_list():
@@ -215,9 +215,9 @@ class LifeCycleEnvironmentTestCase(CLITestCase):
     def test_positive_update_name(self):
         """Create lifecycle environment then update its name
 
-        @id: de67a44e-6c6a-430e-927b-4fa43c7c2771
+        :id: de67a44e-6c6a-430e-927b-4fa43c7c2771
 
-        @Assert: Lifecycle environment name is updated
+        :Assert: Lifecycle environment name is updated
 
         """
         new_lce = make_lifecycle_environment({
@@ -242,9 +242,9 @@ class LifeCycleEnvironmentTestCase(CLITestCase):
     def test_positive_update_description(self):
         """Create lifecycle environment then update its description
 
-        @id: 15b82949-3c3a-4942-b42b-db1de34cf5be
+        :id: 15b82949-3c3a-4942-b42b-db1de34cf5be
 
-        @Assert: Lifecycle environment description is updated
+        :Assert: Lifecycle environment description is updated
 
         """
         new_lce = make_lifecycle_environment({
@@ -269,9 +269,9 @@ class LifeCycleEnvironmentTestCase(CLITestCase):
     def test_positve_list_paths(self):
         """List the environment paths under a given organization
 
-        @id: 71600d6b-1ef4-4b88-8e9b-eb2481ee1fe2
+        :id: 71600d6b-1ef4-4b88-8e9b-eb2481ee1fe2
 
-        @Assert: Lifecycle environment paths listed
+        :Assert: Lifecycle environment paths listed
 
         """
         org = make_org()
@@ -295,11 +295,11 @@ class LifeCycleEnvironmentTestCase(CLITestCase):
         """Attempt to list more than 20 lifecycle environment with per-page
         option.
 
-        @id: 6e10fb0e-5e2c-45e6-85a8-0c853450257b
+        :id: 6e10fb0e-5e2c-45e6-85a8-0c853450257b
 
-        @BZ: 1420503
+        :BZ: 1420503
 
-        @assert: all the Lifecycle environments are listed
+        :assert: all the Lifecycle environments are listed
         """
         org = make_org()
         lifecycle_environments_count = 25

--- a/tests/foreman/cli/test_location.py
+++ b/tests/foreman/cli/test_location.py
@@ -1,19 +1,19 @@
 # -*- encoding: utf-8 -*-
 """Test class for Location CLI
 
-@Requirement: Location
+:Requirement: Location
 
-@CaseAutomation: Automated
+:CaseAutomation: Automated
 
-@CaseLevel: Acceptance
+:CaseLevel: Acceptance
 
-@CaseComponent: CLI
+:CaseComponent: CLI
 
-@TestType: Functional
+:TestType: Functional
 
-@CaseImportance: High
+:CaseImportance: High
 
-@Upstream: No
+:Upstream: No
 """
 
 from fauxfactory import gen_string
@@ -67,9 +67,9 @@ class LocationTestCase(CLITestCase):
     def test_positive_create_with_name(self):
         """Try to create location using different value types as a name
 
-        @id: 76a90b92-296c-4b5a-9c81-183ff71937e2
+        :id: 76a90b92-296c-4b5a-9c81-183ff71937e2
 
-        @Assert: Location is created successfully and has proper name
+        :Assert: Location is created successfully and has proper name
 
         """
         for name in valid_loc_data_list():
@@ -82,11 +82,10 @@ class LocationTestCase(CLITestCase):
     def test_positive_create_with_description(self):
         """Create new location with custom description
 
-        @id: e1844d9d-ec4a-44b3-9743-e932cc70020d
+        :id: e1844d9d-ec4a-44b3-9743-e932cc70020d
 
-        @Assert: Location created successfully and has expected and correct
-        description
-
+        :Assert: Location created successfully and has expected and correct
+            description
         """
         description = gen_string('utf8')
         loc = make_location({'description': description})
@@ -97,11 +96,10 @@ class LocationTestCase(CLITestCase):
         """Create new location with assigned user to it. Use user id as
         a parameter
 
-        @id: 96dd25bf-8535-41a5-ba63-60a2b52487b8
+        :id: 96dd25bf-8535-41a5-ba63-60a2b52487b8
 
-        @Assert: Location created successfully and has correct user assigned to
-        it with expected login name
-
+        :Assert: Location created successfully and has correct user assigned to
+            it with expected login name
         """
         user = make_user()
         loc = make_location({'user-ids': user['id']})
@@ -112,11 +110,10 @@ class LocationTestCase(CLITestCase):
         """Create new location with assigned user to it. Use user login
         as a parameter
 
-        @id: ed65dfd2-00b6-4ec9-9da0-1956d8a5cf5d
+        :id: ed65dfd2-00b6-4ec9-9da0-1956d8a5cf5d
 
-        @Assert: Location created successfully and has correct user assigned to
-        it with expected login name
-
+        :Assert: Location created successfully and has correct user assigned to
+            it with expected login name
         """
         user = make_user()
         loc = make_location({'users': user['login']})
@@ -127,11 +124,10 @@ class LocationTestCase(CLITestCase):
         """Create new location with compute resource assigned to it. Use
         compute resource id as a parameter
 
-        @id: 49c72f7d-08b7-4dd3-af7f-5b97889a4583
+        :id: 49c72f7d-08b7-4dd3-af7f-5b97889a4583
 
-        @Assert: Location created successfully and has correct compute resource
-        assigned to it
-
+        :Assert: Location created successfully and has correct compute resource
+            assigned to it
         """
         comp_resource = make_compute_resource()
         loc = make_location({'compute-resource-ids': comp_resource['id']})
@@ -142,11 +138,10 @@ class LocationTestCase(CLITestCase):
         """Create new location with compute resource assigned to it. Use
         compute resource name as a parameter
 
-        @id: a849c847-bc18-4d87-a47b-43975090f509
+        :id: a849c847-bc18-4d87-a47b-43975090f509
 
-        @Assert: Location created successfully and has correct compute resource
-        assigned to it
-
+        :Assert: Location created successfully and has correct compute resource
+            assigned to it
         """
         comp_resource = make_compute_resource()
         loc = make_location({'compute-resources': comp_resource['name']})
@@ -157,11 +152,10 @@ class LocationTestCase(CLITestCase):
         """Create new location with config template assigned to it. Use
         config template id as a parameter
 
-        @id: 1ae669e3-479a-427a-ac97-0878667c3dce
+        :id: 1ae669e3-479a-427a-ac97-0878667c3dce
 
-        @Assert: Location created successfully and list of config templates
-        assigned to that location should contain expected one
-
+        :Assert: Location created successfully and list of config templates
+            assigned to that location should contain expected one
         """
         template = make_template()
         loc = make_location({'config-template-ids': template['id']})
@@ -176,11 +170,10 @@ class LocationTestCase(CLITestCase):
         """Create new location with config template assigned to it. Use
         config template name as a parameter
 
-        @id: a523bf4e-dc90-4f15-ae79-5246d0568fa5
+        :id: a523bf4e-dc90-4f15-ae79-5246d0568fa5
 
-        @Assert: Location created successfully and list of config templates
-        assigned to that location should contain expected one
-
+        :Assert: Location created successfully and list of config templates
+            assigned to that location should contain expected one
         """
         template = make_template()
         loc = make_location({'config-templates': template['name']})
@@ -195,11 +188,10 @@ class LocationTestCase(CLITestCase):
         """Create new location with assigned domain to it. Use domain id
         as a parameter
 
-        @id: 54507b72-93ea-471e-bfd5-857c44b6abed
+        :id: 54507b72-93ea-471e-bfd5-857c44b6abed
 
-        @Assert: Location created successfully and has correct and expected
-        domain assigned to it
-
+        :Assert: Location created successfully and has correct and expected
+            domain assigned to it
         """
         domain = make_domain()
         loc = make_location({'domain-ids': domain['id']})
@@ -210,11 +202,10 @@ class LocationTestCase(CLITestCase):
         """Create new location with assigned domain to it. Use domain
         name as a parameter
 
-        @id: 06426c06-744d-44cf-bbba-449ef1f62659
+        :id: 06426c06-744d-44cf-bbba-449ef1f62659
 
-        @Assert: Location created successfully and has correct and expected
-        domain assigned to it
-
+        :Assert: Location created successfully and has correct and expected
+            domain assigned to it
         """
         domain = make_domain()
         loc = make_location({'domains': domain['name']})
@@ -225,11 +216,10 @@ class LocationTestCase(CLITestCase):
         """Create new location with assigned subnet to it. Use subnet id
         as a parameter
 
-        @id: cef956bd-7c78-49f8-917a-f344fadf217a
+        :id: cef956bd-7c78-49f8-917a-f344fadf217a
 
-        @Assert: Location created successfully and has correct subnet with
-        expected network address assigned to it
-
+        :Assert: Location created successfully and has correct subnet with
+            expected network address assigned to it
         """
         subnet = make_subnet()
         loc = make_location({'subnet-ids': subnet['id']})
@@ -241,11 +231,10 @@ class LocationTestCase(CLITestCase):
         """Create new location with assigned subnet to it. Use subnet
         name as a parameter
 
-        @id: efe2fce4-ecd9-4765-8d77-dff776a1ba13
+        :id: efe2fce4-ecd9-4765-8d77-dff776a1ba13
 
-        @Assert: Location created successfully and has correct subnet with
-        expected network address assigned to it
-
+        :Assert: Location created successfully and has correct subnet with
+            expected network address assigned to it
         """
         subnet = make_subnet()
         loc = make_location({'subnets': subnet['name']})
@@ -257,11 +246,10 @@ class LocationTestCase(CLITestCase):
         """Create new location with assigned environment to it. Use
         environment id as a parameter
 
-        @id: cd38b895-57f7-4d07-aa4b-7299a69ec203
+        :id: cd38b895-57f7-4d07-aa4b-7299a69ec203
 
-        @Assert: Location created successfully and has correct and expected
-        environment assigned to it
-
+        :Assert: Location created successfully and has correct and expected
+            environment assigned to it
         """
         env = make_environment()
         loc = make_location({'environment-ids': env['id']})
@@ -272,11 +260,10 @@ class LocationTestCase(CLITestCase):
         """Create new location with assigned environment to it. Use
         environment name as a parameter
 
-        @id: 3c9a47b5-798b-4f41-a9dc-219ad43b6fdf
+        :id: 3c9a47b5-798b-4f41-a9dc-219ad43b6fdf
 
-        @Assert: Location created successfully and has correct and expected
-        environment assigned to it
-
+        :Assert: Location created successfully and has correct and expected
+            environment assigned to it
         """
         env = make_environment()
         loc = make_location({'environments': env['name']})
@@ -287,11 +274,10 @@ class LocationTestCase(CLITestCase):
         """Create new location with assigned host group to it. Use host
         group id as a parameter
 
-        @id: d4421f79-72ea-4d68-8ae7-aedd2b32dfe9
+        :id: d4421f79-72ea-4d68-8ae7-aedd2b32dfe9
 
-        @Assert: Location created successfully and has correct and expected
-        host group assigned to it
-
+        :Assert: Location created successfully and has correct and expected
+            host group assigned to it
         """
         host_group = make_hostgroup()
         loc = make_location({'hostgroup-ids': host_group['id']})
@@ -302,11 +288,10 @@ class LocationTestCase(CLITestCase):
         """Create new location with assigned host group to it. Use host
         group name as a parameter
 
-        @id: 7b465d98-efcc-4c49-b45b-b51c26d5010d
+        :id: 7b465d98-efcc-4c49-b45b-b51c26d5010d
 
-        @Assert: Location created successfully and has correct and expected
-        host group assigned to it
-
+        :Assert: Location created successfully and has correct and expected
+            host group assigned to it
         """
         host_group = make_hostgroup()
         loc = make_location({'hostgroups': host_group['name']})
@@ -317,11 +302,10 @@ class LocationTestCase(CLITestCase):
     def test_positive_create_with_medium(self):
         """Create new location with assigned media to it.
 
-        @id: 72d71056-6bf7-4af0-95d4-828709e1efba
+        :id: 72d71056-6bf7-4af0-95d4-828709e1efba
 
-        @Assert: Location created successfully and has correct and expected
-        media assigned to it
-
+        :Assert: Location created successfully and has correct and expected
+            media assigned to it
         """
         medium = make_medium()
         loc = make_location({'medium-ids': medium['id']})
@@ -334,11 +318,10 @@ class LocationTestCase(CLITestCase):
         assigned to it by id can be created in the system. Environments were
         chosen for that purpose.
 
-        @id: eac6bfe2-1ead-4784-b9a8-d21b1f10d8d2
+        :id: eac6bfe2-1ead-4784-b9a8-d21b1f10d8d2
 
-        @Assert: Location created successfully and has correct environments
-        assigned to it
-
+        :Assert: Location created successfully and has correct environments
+            assigned to it
         """
         envs_amount = randint(3, 5)
         envs = [make_environment() for _ in range(envs_amount)]
@@ -353,11 +336,10 @@ class LocationTestCase(CLITestCase):
         assigned to it by name can be created in the system. Domains were
         chosen for that purpose.
 
-        @id: 71e581ef-0950-4cc7-8671-6fddfd06e378
+        :id: 71e581ef-0950-4cc7-8671-6fddfd06e378
 
-        @Assert: Location created successfully and has correct domains assigned
-        to it
-
+        :Assert: Location created successfully and has correct domains assigned
+            to it
         """
         domains_amount = randint(3, 5)
         domains = [make_domain() for _ in range(domains_amount)]
@@ -372,9 +354,9 @@ class LocationTestCase(CLITestCase):
     def test_negative_create_with_name(self):
         """Try to create location using invalid names only
 
-        @id: 2dfe8ff0-e84a-42c0-a480-0f8345ee66d0
+        :id: 2dfe8ff0-e84a-42c0-a480-0f8345ee66d0
 
-        @Assert: Location is not created
+        :Assert: Location is not created
 
         """
         for invalid_name in invalid_values_list():
@@ -386,9 +368,9 @@ class LocationTestCase(CLITestCase):
     def test_negative_create_with_same_name(self):
         """Try to create location using same name twice
 
-        @id: 4fbaea41-9775-40a2-85a5-4dc05cc95134
+        :id: 4fbaea41-9775-40a2-85a5-4dc05cc95134
 
-        @Assert: Second location is not created
+        :Assert: Second location is not created
 
         """
         name = gen_string('utf8')
@@ -402,9 +384,9 @@ class LocationTestCase(CLITestCase):
         """Try to create new location with incorrect compute resource
         assigned to it. Use compute resource id as a parameter
 
-        @id: 83115ace-9340-44cd-9e47-5585b267d7ed
+        :id: 83115ace-9340-44cd-9e47-5585b267d7ed
 
-        @Assert: Location is not created
+        :Assert: Location is not created
 
         """
         with self.assertRaises(CLIFactoryError):
@@ -415,9 +397,9 @@ class LocationTestCase(CLITestCase):
         """Try to create new location with incorrect user assigned to it
         Use user login as a parameter
 
-        @id: fa892edf-8c42-44dc-8f36-bed50798b59b
+        :id: fa892edf-8c42-44dc-8f36-bed50798b59b
 
-        @Assert: Location is not created
+        :Assert: Location is not created
 
         """
         with self.assertRaises(CLIFactoryError):
@@ -427,11 +409,10 @@ class LocationTestCase(CLITestCase):
     def test_positive_update_with_name(self):
         """Try to update location using different value types as a name
 
-        @id: 09fa55a5-c688-4bd3-94df-8ab7a2ccda84
+        :id: 09fa55a5-c688-4bd3-94df-8ab7a2ccda84
 
-        @Assert: Location is updated successfully and has proper and expected
-        name
-
+        :Assert: Location is updated successfully and has proper and expected
+            name
         """
         loc = make_location()
         for new_name in valid_loc_data_list():
@@ -449,11 +430,10 @@ class LocationTestCase(CLITestCase):
         that location and change assigned user on another one. Use user id as a
         parameter
 
-        @id: 123a8a28-f81d-439a-82d0-5c3d814d1a25
+        :id: 123a8a28-f81d-439a-82d0-5c3d814d1a25
 
-        @Assert: Location is updated successfully and has correct user assigned
-        to it
-
+        :Assert: Location is updated successfully and has correct user assigned
+            to it
         """
         user = [make_user() for _ in range(2)]
         loc = make_location({'user-ids': user[0]['id']})
@@ -471,11 +451,10 @@ class LocationTestCase(CLITestCase):
         that location and change assigned subnet on another one. Use subnet
         name as a parameter
 
-        @id: 2bb2ec4a-2423-46a8-8772-a263823640df
+        :id: 2bb2ec4a-2423-46a8-8772-a263823640df
 
-        @Assert: Location is updated successfully and has correct subnet with
-        expected network address assigned to it
-
+        :Assert: Location is updated successfully and has correct subnet with
+            expected network address assigned to it
         """
         subnet = [make_subnet() for _ in range(2)]
         loc = make_location({'subnets': subnet[0]['name']})
@@ -496,11 +475,10 @@ class LocationTestCase(CLITestCase):
         compute resources with a new single compute resource. Use compute
         resource id as a parameter
 
-        @id: 3a547413-53dc-4305-84e9-8db7a6bed3b2
+        :id: 3a547413-53dc-4305-84e9-8db7a6bed3b2
 
-        @Assert: Location updated successfully and has correct compute resource
-        assigned to it
-
+        :Assert: Location updated successfully and has correct compute resource
+            assigned to it
         """
         resources_amount = randint(3, 5)
         resources = [make_compute_resource() for _ in range(resources_amount)]
@@ -527,11 +505,10 @@ class LocationTestCase(CLITestCase):
         it. Try to update location and overwrite all host groups by new
         multiple (two) host groups. Use host groups name as a parameter
 
-        @id: e53504d0-8328-485c-bc8c-36ea9a2ad3e1
+        :id: e53504d0-8328-485c-bc8c-36ea9a2ad3e1
 
-        @Assert: Location updated successfully and has correct and expected
-        host groups assigned to it
-
+        :Assert: Location updated successfully and has correct and expected
+            host groups assigned to it
         """
         host_groups = [make_hostgroup() for _ in range(3)]
         loc = make_location({
@@ -554,9 +531,9 @@ class LocationTestCase(CLITestCase):
     def test_negative_update_with_name(self):
         """Try to update location using invalid names only
 
-        @id: a41abf03-61ca-4201-8a80-7062a6196851
+        :id: a41abf03-61ca-4201-8a80-7062a6196851
 
-        @Assert: Location is not updated
+        :Assert: Location is not updated
 
         """
         for invalid_name in invalid_values_list():
@@ -573,9 +550,9 @@ class LocationTestCase(CLITestCase):
         """Try to update existing location with incorrect domain. Use
         domain id as a parameter
 
-        @id: ec49ea4d-754a-4958-8180-f61eb6d8cede
+        :id: ec49ea4d-754a-4958-8180-f61eb6d8cede
 
-        @Assert: Location is not updated
+        :Assert: Location is not updated
 
         """
         loc = make_location()
@@ -590,9 +567,9 @@ class LocationTestCase(CLITestCase):
         """Try to update existing location with incorrect config
         template. Use template name as a parameter
 
-        @id: 937730ff-bb46-437b-bfc7-915045d1782c
+        :id: 937730ff-bb46-437b-bfc7-915045d1782c
 
-        @Assert: Location is not updated
+        :Assert: Location is not updated
 
         """
         loc = make_location()
@@ -608,11 +585,11 @@ class LocationTestCase(CLITestCase):
     def test_positive_add_capsule_by_name(self):
         """Add a capsule to location by its name
 
-        @id: 32b1e969-a1a8-4d65-bde9-a825ab542b1d
+        :id: 32b1e969-a1a8-4d65-bde9-a825ab542b1d
 
-        @Assert: Capsule is added to the org
+        :Assert: Capsule is added to the org
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         loc = make_location()
         proxy = make_proxy()
@@ -633,11 +610,11 @@ class LocationTestCase(CLITestCase):
     def test_positive_add_capsule_by_id(self):
         """Add a capsule to location by its ID
 
-        @id: 15e3c1e6-4fa3-4965-8808-a9ba01d1c050
+        :id: 15e3c1e6-4fa3-4965-8808-a9ba01d1c050
 
-        @assert: Capsule is added to the org
+        :assert: Capsule is added to the org
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         loc = make_location()
         proxy = make_proxy()
@@ -658,11 +635,11 @@ class LocationTestCase(CLITestCase):
     def test_positive_remove_capsule_by_id(self):
         """Remove a capsule from organization by its id
 
-        @id: 98681f4f-a5e2-44f6-8879-d23ad90b4c59
+        :id: 98681f4f-a5e2-44f6-8879-d23ad90b4c59
 
-        @Assert: Capsule is removed from the org
+        :Assert: Capsule is removed from the org
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         loc = make_location()
         proxy = make_proxy()
@@ -687,11 +664,11 @@ class LocationTestCase(CLITestCase):
     def test_positive_remove_capsule_by_name(self):
         """Remove a capsule from organization by its name
 
-        @id: 91dcafbe-5f52-48af-b5c7-9319b2929f5a
+        :id: 91dcafbe-5f52-48af-b5c7-9319b2929f5a
 
-        @Assert: Capsule is removed from the org
+        :Assert: Capsule is removed from the org
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         loc = make_location()
         proxy = make_proxy()
@@ -715,9 +692,9 @@ class LocationTestCase(CLITestCase):
         """Try to delete location using name of that location as a
         parameter. Use different value types for testing.
 
-        @id: b44e56e4-00f0-4b7c-bef6-48b10c7b2b59
+        :id: b44e56e4-00f0-4b7c-bef6-48b10c7b2b59
 
-        @Assert: Location is deleted successfully
+        :Assert: Location is deleted successfully
 
         """
         for name in valid_loc_data_list():
@@ -733,9 +710,9 @@ class LocationTestCase(CLITestCase):
         """Try to delete location using id of that location as a
         parameter
 
-        @id: 71e394e3-85e6-456d-b03d-6787db9059aa
+        :id: 71e394e3-85e6-456d-b03d-6787db9059aa
 
-        @Assert: Location is deleted successfully
+        :Assert: Location is deleted successfully
 
         """
         loc = make_location()
@@ -747,9 +724,9 @@ class LocationTestCase(CLITestCase):
     def test_positive_add_parameter_by_loc_name(self):
         """Add a parameter to location
 
-        @id: d4c2f27d-7c16-4296-9da6-2e7135bfb6ad
+        :id: d4c2f27d-7c16-4296-9da6-2e7135bfb6ad
 
-        @Assert: Parameter is added to the location
+        :Assert: Parameter is added to the location
         """
         param_name = gen_string('alpha')
         param_value = gen_string('alpha')
@@ -768,9 +745,9 @@ class LocationTestCase(CLITestCase):
     def test_positive_add_parameter_by_loc_id(self):
         """Add a parameter to location
 
-        @id: 61b564f2-a42a-48de-833d-bec3a127d0f5
+        :id: 61b564f2-a42a-48de-833d-bec3a127d0f5
 
-        @Assert: Parameter is added to the location
+        :Assert: Parameter is added to the location
         """
         param_name = gen_string('alpha')
         param_value = gen_string('alpha')
@@ -789,9 +766,9 @@ class LocationTestCase(CLITestCase):
     def test_positive_update_parameter(self):
         """Update a parameter associated with location
 
-        @id: 7b61fa71-0203-4709-9abd-9bb51ce6c19f
+        :id: 7b61fa71-0203-4709-9abd-9bb51ce6c19f
 
-        @Assert: Parameter is updated
+        :Assert: Parameter is updated
         """
         param_name = gen_string('alpha')
         param_new_value = gen_string('alpha')
@@ -818,9 +795,9 @@ class LocationTestCase(CLITestCase):
     def test_positive_remove_parameter_by_loc_name(self):
         """Remove a parameter from location
 
-        @id: 97fda466-1894-431e-bc76-3b1c7643522f
+        :id: 97fda466-1894-431e-bc76-3b1c7643522f
 
-        @Assert: Parameter is removed from the location
+        :Assert: Parameter is removed from the location
         """
         param_name = gen_string('alpha')
         location = make_location()
@@ -843,9 +820,9 @@ class LocationTestCase(CLITestCase):
     def test_positive_remove_parameter_by_loc_id(self):
         """Remove a parameter from location
 
-        @id: 13836073-3e39-4d3e-b4b4-e87619c28bae
+        :id: 13836073-3e39-4d3e-b4b4-e87619c28bae
 
-        @Assert: Parameter is removed from the location
+        :Assert: Parameter is removed from the location
         """
         param_name = gen_string('alpha')
         location = make_location()

--- a/tests/foreman/cli/test_medium.py
+++ b/tests/foreman/cli/test_medium.py
@@ -1,19 +1,19 @@
 # -*- encoding: utf-8 -*-
 """Test for Medium  CLI
 
-@Requirement: Medium
+:Requirement: Medium
 
-@CaseAutomation: Automated
+:CaseAutomation: Automated
 
-@CaseLevel: Acceptance
+:CaseLevel: Acceptance
 
-@CaseComponent: CLI
+:CaseComponent: CLI
 
-@TestType: Functional
+:TestType: Functional
 
-@CaseImportance: High
+:CaseImportance: High
 
-@Upstream: No
+:Upstream: No
 """
 
 from fauxfactory import gen_alphanumeric
@@ -43,9 +43,9 @@ class MediumTestCase(CLITestCase):
     def test_positive_create_with_name(self):
         """Check if Medium can be created
 
-        @id: 4a1caaf8-4401-48cc-85ad-e7189944688d
+        :id: 4a1caaf8-4401-48cc-85ad-e7189944688d
 
-        @Assert: Medium is created
+        :Assert: Medium is created
 
         """
         for name in valid_data_list():
@@ -58,9 +58,9 @@ class MediumTestCase(CLITestCase):
     def test_positive_create_with_location(self):
         """Check if medium with location can be created
 
-        @id: cbc6c586-fae7-4bb9-aeb1-e30158f16a98
+        :id: cbc6c586-fae7-4bb9-aeb1-e30158f16a98
 
-        @Assert: Medium is created and has new location assigned
+        :Assert: Medium is created and has new location assigned
 
         """
         location = make_location()
@@ -72,9 +72,9 @@ class MediumTestCase(CLITestCase):
     def test_positive_create_with_organization_by_id(self):
         """Check if medium with organization can be created
 
-        @id: 631bb6ed-e42b-482a-83f0-f6ce0f20729a
+        :id: 631bb6ed-e42b-482a-83f0-f6ce0f20729a
 
-        @Assert: Medium is created and has new organization assigned
+        :Assert: Medium is created and has new organization assigned
 
         """
         org = make_org()
@@ -86,9 +86,9 @@ class MediumTestCase(CLITestCase):
     def test_positive_delete_by_id(self):
         """Check if Medium can be deleted
 
-        @id: dc62c9ad-d2dc-42df-80eb-02cf8d26cdee
+        :id: dc62c9ad-d2dc-42df-80eb-02cf8d26cdee
 
-        @Assert: Medium is deleted
+        :Assert: Medium is deleted
 
         """
         for name in valid_data_list():
@@ -104,12 +104,12 @@ class MediumTestCase(CLITestCase):
     def test_positive_add_os(self):
         """Check if Medium can be associated with operating system
 
-        @id: 47d1e6f0-d8a6-4190-b2ac-41b09a559429
+        :id: 47d1e6f0-d8a6-4190-b2ac-41b09a559429
 
-        @Assert: Operating system added
+        :Assert: Operating system added
 
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         medium = make_medium()
         os = make_os()
@@ -123,12 +123,12 @@ class MediumTestCase(CLITestCase):
     def test_positive_remove_os(self):
         """Check if operating system can be removed from media
 
-        @id: 23b5b55b-3624-440c-8001-75c7c5a5a004
+        :id: 23b5b55b-3624-440c-8001-75c7c5a5a004
 
-        @Assert: Operating system removed
+        :Assert: Operating system removed
 
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         medium = make_medium()
         os = make_os()
@@ -150,9 +150,9 @@ class MediumTestCase(CLITestCase):
     def test_positive_update_name(self):
         """Check if medium can be updated
 
-        @id: 2111090a-21d3-47f7-bb81-5f19ab71a91d
+        :id: 2111090a-21d3-47f7-bb81-5f19ab71a91d
 
-        @Assert: Medium updated
+        :Assert: Medium updated
 
         """
         new_name = gen_alphanumeric(6)

--- a/tests/foreman/cli/test_model.py
+++ b/tests/foreman/cli/test_model.py
@@ -1,19 +1,19 @@
 # -*- encoding: utf-8 -*-
 """Test for Model CLI
 
-@Requirement: Model
+:Requirement: Model
 
-@CaseAutomation: Automated
+:CaseAutomation: Automated
 
-@CaseLevel: Acceptance
+:CaseLevel: Acceptance
 
-@CaseComponent: CLI
+:CaseComponent: CLI
 
-@TestType: Functional
+:TestType: Functional
 
-@CaseImportance: High
+:CaseImportance: High
 
-@Upstream: No
+:Upstream: No
 """
 
 from fauxfactory import gen_string
@@ -35,9 +35,9 @@ class ModelTestCase(CLITestCase):
     def test_positive_create_with_name(self):
         """Successfully creates a Model.
 
-        @id: c8192831-5dde-4c3c-8427-00902ddbc0ac
+        :id: c8192831-5dde-4c3c-8427-00902ddbc0ac
 
-        @Assert: Model is created.
+        :Assert: Model is created.
         """
         for name in valid_data_list():
             with self.subTest(name):
@@ -49,9 +49,9 @@ class ModelTestCase(CLITestCase):
     def test_positive_create_with_vendor_class(self):
         """Check if Model can be created with specific vendor class
 
-        @id: c36d3490-cd12-4f5f-a453-2ae5d0404496
+        :id: c36d3490-cd12-4f5f-a453-2ae5d0404496
 
-        @Assert: Model is created with specific vendor class
+        :Assert: Model is created with specific vendor class
         """
         vendor_class = gen_string('utf8')
         model = make_model({'vendor-class': vendor_class})
@@ -61,9 +61,9 @@ class ModelTestCase(CLITestCase):
     def test_negative_create_with_name(self):
         """Don't create an Model with invalid data.
 
-        @id: b2eade66-b612-47e7-bfcc-6e363023f498
+        :id: b2eade66-b612-47e7-bfcc-6e363023f498
 
-        @Assert: Model is not created.
+        :Assert: Model is not created.
         """
         for name in invalid_values_list():
             with self.subTest(name):
@@ -74,9 +74,9 @@ class ModelTestCase(CLITestCase):
     def test_positive_update_name(self):
         """Successfully update an Model.
 
-        @id: 66eb6cf2-9ec5-4947-97e0-b612780c5cc3
+        :id: 66eb6cf2-9ec5-4947-97e0-b612780c5cc3
 
-        @Assert: Model is updated.
+        :Assert: Model is updated.
         """
         model = make_model()
         for new_name in valid_data_list():
@@ -93,9 +93,9 @@ class ModelTestCase(CLITestCase):
     def test_negative_update_name(self):
         """Create Model then fail to update its name
 
-        @id: 98020a4a-1789-4df3-929c-6c132b57f5a1
+        :id: 98020a4a-1789-4df3-929c-6c132b57f5a1
 
-        @assert: Model name is not updated
+        :assert: Model name is not updated
         """
         model = make_model()
         for new_name in invalid_values_list():
@@ -114,9 +114,9 @@ class ModelTestCase(CLITestCase):
         """Create Model with valid values then delete it
         by ID
 
-        @id: 39f02cec-ac4c-4801-9a4a-11160247213f
+        :id: 39f02cec-ac4c-4801-9a4a-11160247213f
 
-        @assert: Model is deleted
+        :assert: Model is deleted
         """
         for name in valid_data_list():
             with self.subTest(name):
@@ -130,9 +130,9 @@ class ModelTestCase(CLITestCase):
     def test_negative_delete_by_id(self):
         """Create Model then delete it by wrong ID
 
-        @id: f8b0d428-1b3d-4fc9-9ca1-1eb30c8ac20a
+        :id: f8b0d428-1b3d-4fc9-9ca1-1eb30c8ac20a
 
-        @assert: Model is not deleted
+        :assert: Model is not deleted
         """
         for entity_id in invalid_id_list():
             with self.subTest(entity_id):

--- a/tests/foreman/cli/test_myaccount.py
+++ b/tests/foreman/cli/test_myaccount.py
@@ -1,19 +1,19 @@
 # -*- encoding: utf-8 -*-
 """Test class for Users CLI
 
-@Requirement: Myaccount
+:Requirement: Myaccount
 
-@CaseAutomation: Automated
+:CaseAutomation: Automated
 
-@CaseLevel: Acceptance
+:CaseLevel: Acceptance
 
-@CaseComponent: CLI
+:CaseComponent: CLI
 
-@TestType: Functional
+:TestType: Functional
 
-@CaseImportance: High
+:CaseImportance: High
 
-@Upstream: No
+:Upstream: No
 """
 
 from fauxfactory import gen_string
@@ -99,9 +99,9 @@ class MyAccountTestCase(CLITestCase):
     def test_positive_update_first_name(self):
         """Update Firstname in My Account
 
-        @id: f8de3843-f2dc-4121-ab75-625c8f542627
+        :id: f8de3843-f2dc-4121-ab75-625c8f542627
 
-        @Assert: Current User is updated
+        :Assert: Current User is updated
         """
         new_firstname = gen_string('alphanumeric')
         self.update_user({'firstname': new_firstname})
@@ -113,9 +113,9 @@ class MyAccountTestCase(CLITestCase):
     def test_positive_update_surname(self):
         """Update Surname in My Account
 
-        @id: 40ad2e78-a2af-45ca-bbd8-e9ca5178dc41
+        :id: 40ad2e78-a2af-45ca-bbd8-e9ca5178dc41
 
-        @Assert: Current User is updated
+        :Assert: Current User is updated
         """
         new_lastname = gen_string('alphanumeric')
         self.update_user({'lastname': new_lastname})
@@ -127,9 +127,9 @@ class MyAccountTestCase(CLITestCase):
     def test_positive_update_email(self):
         """Update Email Address in My Account
 
-        @id: 70bab43b-0842-45a1-81fb-e47ff8646c8e
+        :id: 70bab43b-0842-45a1-81fb-e47ff8646c8e
 
-        @Assert: Current User is updated
+        :Assert: Current User is updated
         """
         email = u'{0}@example.com'.format(gen_string('alphanumeric'))
         self.update_user({'mail': email})
@@ -140,14 +140,13 @@ class MyAccountTestCase(CLITestCase):
     def test_positive_update_all_locales(self):
         """Update Language in My Account
 
-        @id: f0993495-5117-461d-a116-44867b820139
+        :id: f0993495-5117-461d-a116-44867b820139
 
-        @Steps:
-        1. Update current User with all different Language options
+        :Steps: Update current User with all different Language options
 
-        @Assert: Current User is updated
+        :Assert: Current User is updated
 
-        @caseautomation: notautomated
+        :caseautomation: notautomated
         """
 
         for locale in LOCALES:
@@ -160,9 +159,9 @@ class MyAccountTestCase(CLITestCase):
     def test_negative_update_first_name(self):
         """Update My Account with invalid FirstName
 
-        @id: 1e0e1a94-4cef-4110-b65c-8cd35df254e0
+        :id: 1e0e1a94-4cef-4110-b65c-8cd35df254e0
 
-        @Assert: User is not updated. Appropriate error shown.
+        :Assert: User is not updated. Appropriate error shown.
         """
         with self.assertRaises(CLIReturnCodeError):
             self.update_user({'firstname': gen_string('alphanumeric', 300)})
@@ -171,9 +170,9 @@ class MyAccountTestCase(CLITestCase):
     def test_negative_update_surname(self):
         """Update My Account with invalid Surname
 
-        @id: 4d31ba71-2dcc-47ee-94d2-adc168ba89d7
+        :id: 4d31ba71-2dcc-47ee-94d2-adc168ba89d7
 
-        @Assert: User is not updated. Appropriate error shown.
+        :Assert: User is not updated. Appropriate error shown.
         """
         with self.assertRaises(CLIReturnCodeError):
             self.update_user({'lastname': gen_string('alphanumeric', 300)})
@@ -182,9 +181,9 @@ class MyAccountTestCase(CLITestCase):
     def test_negative_update_email(self):
         """Update My Account with invalid Email Address
 
-        @id: 619f6285-8d50-47d4-b074-d8854c7567a6
+        :id: 619f6285-8d50-47d4-b074-d8854c7567a6
 
-        @Assert: User is not updated. Appropriate error shown.
+        :Assert: User is not updated. Appropriate error shown.
         """
         for email in invalid_emails_list():
             with self.subTest(email):
@@ -197,9 +196,9 @@ class MyAccountTestCase(CLITestCase):
     def test_negative_update_locale(self):
         """Update My Account with invalid Locale
 
-        @id: 6f63c9b4-80e6-11e6-8ea1-68f72889dc7f
+        :id: 6f63c9b4-80e6-11e6-8ea1-68f72889dc7f
 
-        @Assert: User is not updated. Appropriate error shown.
+        :Assert: User is not updated. Appropriate error shown.
         """
         with self.assertRaises(CLIReturnCodeError):
             self.update_user({'locale': 'invalid'})
@@ -234,9 +233,9 @@ class MyAccountEphemeralUserTestCase(CLITestCase):
     def test_positive_update_password(self):
         """Update Password in My Account
 
-        @id: e7e9b212-f0aa-4f7e-8433-b4639da89495
+        :id: e7e9b212-f0aa-4f7e-8433-b4639da89495
 
-        @Assert: User is updated
+        :Assert: User is updated
         """
         new_password = gen_string('alphanumeric')
         self.update_user({'password': new_password})

--- a/tests/foreman/cli/test_operatingsystem.py
+++ b/tests/foreman/cli/test_operatingsystem.py
@@ -1,19 +1,19 @@
 # -*- encoding: utf-8 -*-
 """Test class for Operating System CLI
 
-@Requirement: Operatingsystem
+:Requirement: Operatingsystem
 
-@CaseAutomation: Automated
+:CaseAutomation: Automated
 
-@CaseLevel: Acceptance
+:CaseLevel: Acceptance
 
-@CaseComponent: CLI
+:CaseComponent: CLI
 
-@TestType: Functional
+:TestType: Functional
 
-@CaseImportance: High
+:CaseImportance: High
 
-@Upstream: No
+:Upstream: No
 """
 from fauxfactory import gen_alphanumeric, gen_string
 from robottelo.cli.base import CLIReturnCodeError
@@ -55,9 +55,9 @@ class OperatingSystemTestCase(CLITestCase):
     def test_positive_search_by_name(self):
         """Search for newly created OS by name
 
-        @id: ff9f667c-97ca-49cd-902b-a9b18b5aa021
+        :id: ff9f667c-97ca-49cd-902b-a9b18b5aa021
 
-        @assert: Operating System is created and listed
+        :assert: Operating System is created and listed
         """
         os_list_before = OperatingSys.list()
         os = make_os()
@@ -72,9 +72,9 @@ class OperatingSystemTestCase(CLITestCase):
     def test_positive_search_by_title(self):
         """Search for newly created OS by title
 
-        @id: a555e848-f1f2-4326-aac6-9de8ff45abee
+        :id: a555e848-f1f2-4326-aac6-9de8ff45abee
 
-        @assert: Operating System is created and listed
+        :assert: Operating System is created and listed
         """
         os_list_before = OperatingSys.list()
         os = make_os()
@@ -89,9 +89,9 @@ class OperatingSystemTestCase(CLITestCase):
     def test_positive_list(self):
         """Displays list for operating system
 
-        @id: fca309c5-edff-4296-a800-55470669935a
+        :id: fca309c5-edff-4296-a800-55470669935a
 
-        @assert: Operating System is created and listed
+        :assert: Operating System is created and listed
         """
         os_list_before = OperatingSys.list()
         name = gen_string('alpha')
@@ -107,9 +107,9 @@ class OperatingSystemTestCase(CLITestCase):
     def test_positive_info_by_id(self):
         """Displays info for operating system by its ID
 
-        @id: b8f23b53-439a-4726-9757-164d99d5ed05
+        :id: b8f23b53-439a-4726-9757-164d99d5ed05
 
-        @assert: Operating System is created and can be looked up by its ID
+        :assert: Operating System is created and can be looked up by its ID
         """
         os = make_os()
         os_info = OperatingSys.info({'id': os['id']})
@@ -125,9 +125,9 @@ class OperatingSystemTestCase(CLITestCase):
     def test_positive_create_with_name(self):
         """Create Operating System for all variations of name
 
-        @id: d36eba9b-ccf6-4c9d-a07f-c74eebada89b
+        :id: d36eba9b-ccf6-4c9d-a07f-c74eebada89b
 
-        @assert: Operating System is created and can be found
+        :assert: Operating System is created and can be found
         """
         for name in valid_data_list():
             with self.subTest(name):
@@ -139,9 +139,9 @@ class OperatingSystemTestCase(CLITestCase):
     def test_positive_create_with_arch_medium_ptable(self):
         """Create an OS pointing to an arch, medium and partition table.
 
-        @id: 05bdb2c6-0d2e-4141-9e07-3ada3933b577
+        :id: 05bdb2c6-0d2e-4141-9e07-3ada3933b577
 
-        @assert: An operating system is created.
+        :assert: An operating system is created.
         """
         architecture = make_architecture()
         medium = make_medium()
@@ -167,9 +167,9 @@ class OperatingSystemTestCase(CLITestCase):
     def test_negative_create_with_name(self):
         """Create Operating System using invalid names
 
-        @id: 848a20ce-292a-47d8-beea-da5916c43f11
+        :id: 848a20ce-292a-47d8-beea-da5916c43f11
 
-        @assert: Operating System is not created
+        :assert: Operating System is not created
         """
         for name in invalid_values_list():
             with self.subTest(name):
@@ -181,9 +181,9 @@ class OperatingSystemTestCase(CLITestCase):
     def test_positive_update_name(self):
         """Positive update of operating system name
 
-        @id: 49b655f7-ba9b-4bb9-b09d-0f7140969a40
+        :id: 49b655f7-ba9b-4bb9-b09d-0f7140969a40
 
-        @assert: Operating System name is updated
+        :assert: Operating System name is updated
         """
         os = make_os({'name': gen_alphanumeric()})
         for new_name in valid_data_list():
@@ -201,9 +201,9 @@ class OperatingSystemTestCase(CLITestCase):
     def test_positive_update_major_version(self):
         """Update an Operating System's major version.
 
-        @id: 38a89dbe-6d1c-4602-a4c1-664425668de8
+        :id: 38a89dbe-6d1c-4602-a4c1-664425668de8
 
-        @assert: Operating System major version is updated
+        :assert: Operating System major version is updated
         """
         os = make_os()
         # New value for major
@@ -222,9 +222,9 @@ class OperatingSystemTestCase(CLITestCase):
     def test_negative_update_name(self):
         """Negative update of system name
 
-        @id: 4b18ff6d-7728-4245-a1ce-38e62c05f454
+        :id: 4b18ff6d-7728-4245-a1ce-38e62c05f454
 
-        @assert: Operating System name is not updated
+        :assert: Operating System name is not updated
         """
         os = make_os({'name': gen_alphanumeric()})
         for new_name in invalid_values_list():
@@ -242,9 +242,9 @@ class OperatingSystemTestCase(CLITestCase):
     def test_positive_delete_by_id(self):
         """Successfully deletes Operating System by its ID
 
-        @id: a67a7b01-081b-42f8-a9ab-1f41166d649e
+        :id: a67a7b01-081b-42f8-a9ab-1f41166d649e
 
-        @assert: Operating System is deleted
+        :assert: Operating System is deleted
         """
         for name in valid_data_list():
             with self.subTest(name):
@@ -258,9 +258,9 @@ class OperatingSystemTestCase(CLITestCase):
     def test_negative_delete_by_id(self):
         """Delete Operating System using invalid data
 
-        @id: d29a9c95-1fe3-4a7a-9f7b-127be065856d
+        :id: d29a9c95-1fe3-4a7a-9f7b-127be065856d
 
-        @assert: Operating System is not deleted
+        :assert: Operating System is not deleted
         """
         for test_data in negative_delete_data():
             with self.subTest(test_data):
@@ -278,11 +278,11 @@ class OperatingSystemTestCase(CLITestCase):
     def test_positive_add_arch(self):
         """Add Architecture to operating system
 
-        @id: 99add22d-d936-4232-9441-beff85867040
+        :id: 99add22d-d936-4232-9441-beff85867040
 
-        @assert: Architecture is added to Operating System
+        :assert: Architecture is added to Operating System
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         architecture = make_architecture()
         os = make_os()
@@ -299,11 +299,11 @@ class OperatingSystemTestCase(CLITestCase):
     def test_positive_add_template(self):
         """Add provisioning template to operating system
 
-        @id: 0ea9eb88-2d27-423d-a9d3-fdd788b4e28a
+        :id: 0ea9eb88-2d27-423d-a9d3-fdd788b4e28a
 
-        @assert: Provisioning template is added to Operating System
+        :assert: Provisioning template is added to Operating System
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         template = make_template()
         os = make_os()
@@ -321,11 +321,11 @@ class OperatingSystemTestCase(CLITestCase):
     def test_positive_add_ptable(self):
         """Add partition table to operating system
 
-        @id: beba676f-b4e4-48e1-bb0c-18ad91847566
+        :id: beba676f-b4e4-48e1-bb0c-18ad91847566
 
-        @assert: Partition table is added to Operating System
+        :assert: Partition table is added to Operating System
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         # Create a partition table.
         ptable_name = make_partition_table()['name']

--- a/tests/foreman/cli/test_organization.py
+++ b/tests/foreman/cli/test_organization.py
@@ -2,19 +2,19 @@
 # pylint: disable=no-self-use
 """Test class for Organization CLI
 
-@Requirement: Organization
+:Requirement: Organization
 
-@CaseAutomation: Automated
+:CaseAutomation: Automated
 
-@CaseLevel: Acceptance
+:CaseLevel: Acceptance
 
-@CaseComponent: CLI
+:CaseComponent: CLI
 
-@TestType: Functional
+:TestType: Functional
 
-@CaseImportance: High
+:CaseImportance: High
 
-@Upstream: No
+:Upstream: No
 """
 import random
 
@@ -83,9 +83,9 @@ class OrganizationTestCase(CLITestCase):
         """hammer organization <info,list> --help types information
         doubled
 
-        @id: 7938bcc4-7107-40b0-bb88-6288ebec0dcd
+        :id: 7938bcc4-7107-40b0-bb88-6288ebec0dcd
 
-        @Assert: no duplicated lines in usage message
+        :Assert: no duplicated lines in usage message
         """
         # org list --help:
         result = Org.list({'help': True})
@@ -106,9 +106,9 @@ class OrganizationTestCase(CLITestCase):
     def test_positive_create_with_name(self):
         """Create organization with valid name only
 
-        @id: 35840da7-668e-4f78-990a-738aa688d586
+        :id: 35840da7-668e-4f78-990a-738aa688d586
 
-        @assert: organization is created and has appropriate name
+        :assert: organization is created and has appropriate name
         """
         for name in valid_org_names_list():
             with self.subTest(name):
@@ -119,9 +119,9 @@ class OrganizationTestCase(CLITestCase):
     def test_positive_create_with_matching_name_label(self):
         """Create organization with valid matching name and label only
 
-        @id: aea551de-145b-4894-b4fb-65878ff1f101
+        :id: aea551de-145b-4894-b4fb-65878ff1f101
 
-        @assert: organization is created, label matches name
+        :assert: organization is created, label matches name
         """
         for test_data in valid_labels_list():
             with self.subTest(test_data):
@@ -135,9 +135,9 @@ class OrganizationTestCase(CLITestCase):
     def test_positive_create_with_unmatched_name_label(self):
         """Create organization with valid unmatching name and label only
 
-        @id: a4730b09-1bd7-4b00-a7ee-76080a916ea8
+        :id: a4730b09-1bd7-4b00-a7ee-76080a916ea8
 
-        @assert: organization is created, label does not match name
+        :assert: organization is created, label does not match name
         """
         for name in valid_org_names_list():
             with self.subTest(name):
@@ -154,9 +154,9 @@ class OrganizationTestCase(CLITestCase):
     def test_positive_create_with_name_description(self):
         """Create organization with valid name and description only
 
-        @id: b28c95ba-918e-47fe-8681-61e05b8fe2ea
+        :id: b28c95ba-918e-47fe-8681-61e05b8fe2ea
 
-        @assert: organization is created
+        :assert: organization is created
         """
         for name, desc in zip(valid_org_names_list(), valid_data_list()):
             with self.subTest(name + desc):
@@ -171,9 +171,9 @@ class OrganizationTestCase(CLITestCase):
     def test_positive_create_with_name_label_description(self):
         """Create organization with valid name, label and description
 
-        @id: 9a1f70f6-fb5f-4b23-9f7e-b0973fbbba30
+        :id: 9a1f70f6-fb5f-4b23-9f7e-b0973fbbba30
 
-        @assert: organization is created
+        :assert: organization is created
         """
         for description in valid_data_list():
             with self.subTest(description):
@@ -192,9 +192,9 @@ class OrganizationTestCase(CLITestCase):
     def test_positive_list(self):
         """Check if Org can be listed
 
-        @id: bdd26bb3-e3d2-4a5c-8be7-fb12c1114ccc
+        :id: bdd26bb3-e3d2-4a5c-8be7-fb12c1114ccc
 
-        @Assert: Org is listed
+        :Assert: Org is listed
         """
         org = make_org()
         result_list = Org.list({
@@ -207,11 +207,11 @@ class OrganizationTestCase(CLITestCase):
     def test_positive_add_subnet_by_name(self):
         """Add a subnet to organization by its name
 
-        @id: 1f464eba-d024-4f37-87c2-5cfff1ac1e23
+        :id: 1f464eba-d024-4f37-87c2-5cfff1ac1e23
 
-        @Assert: Subnet is added to the org
+        :Assert: Subnet is added to the org
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         for name in valid_data_list():
             with self.subTest(name):
@@ -229,11 +229,11 @@ class OrganizationTestCase(CLITestCase):
     def test_positive_add_subnet_by_id(self):
         """Add a subnet to organization by its ID
 
-        @id: f65e4264-4aad-42f8-b74f-933741d9f7ab
+        :id: f65e4264-4aad-42f8-b74f-933741d9f7ab
 
-        @assert: Subnet is added to the org
+        :assert: Subnet is added to the org
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         org = make_org()
         new_subnet = make_subnet()
@@ -250,11 +250,11 @@ class OrganizationTestCase(CLITestCase):
     def test_positive_remove_subnet_by_name(self):
         """Remove a subnet from organization by its name
 
-        @id: adb5310b-76c5-4aca-8220-fdf0fe605cb0
+        :id: adb5310b-76c5-4aca-8220-fdf0fe605cb0
 
-        @Assert: Subnet is removed from the org
+        :Assert: Subnet is removed from the org
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         org = make_org()
         subnet = make_subnet()
@@ -278,11 +278,11 @@ class OrganizationTestCase(CLITestCase):
     def test_positive_remove_subnet_by_id(self):
         """Remove a subnet from organization by its ID
 
-        @id: 4868ef18-983a-48b4-940a-e1b55f01f0b6
+        :id: 4868ef18-983a-48b4-940a-e1b55f01f0b6
 
-        @Assert: Subnet is removed from the org
+        :Assert: Subnet is removed from the org
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         org = make_org()
         subnet = make_subnet()
@@ -304,11 +304,11 @@ class OrganizationTestCase(CLITestCase):
     def test_positive_add_user_by_name(self):
         """Add an user to organization by its name
 
-        @id: c35b2e88-a65f-4eea-ba55-89cef59f30be
+        :id: c35b2e88-a65f-4eea-ba55-89cef59f30be
 
-        @Assert: User is added to the org
+        :Assert: User is added to the org
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         org = make_org()
         user = make_user()
@@ -323,11 +323,11 @@ class OrganizationTestCase(CLITestCase):
     def test_positive_add_user_by_id(self):
         """Add an user to organization by its ID
 
-        @id: 1cd4e912-dd59-4cf7-b1a3-87b130972f8d
+        :id: 1cd4e912-dd59-4cf7-b1a3-87b130972f8d
 
-        @Assert: User is added to the org
+        :Assert: User is added to the org
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         org = make_org()
         user = make_user()
@@ -343,11 +343,11 @@ class OrganizationTestCase(CLITestCase):
     def test_positive_remove_user_by_id(self):
         """Remove an user from organization by its ID
 
-        @id: 6e292d5f-3bce-48c5-88d7-2c94f7db51c1
+        :id: 6e292d5f-3bce-48c5-88d7-2c94f7db51c1
 
-        @Assert: The user is removed from the organization
+        :Assert: The user is removed from the organization
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         org = make_org()
         user = make_user()
@@ -367,11 +367,11 @@ class OrganizationTestCase(CLITestCase):
     def test_positive_remove_user_by_name(self):
         """Remove an user from organization by its login and organization name
 
-        @id: 98cf1224-750a-449b-8807-638ef07a55e5
+        :id: 98cf1224-750a-449b-8807-638ef07a55e5
 
-        @assert: The user is removed from the organization
+        :assert: The user is removed from the organization
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         org = make_org()
         user = make_user()
@@ -391,11 +391,11 @@ class OrganizationTestCase(CLITestCase):
         """Add an admin user to an organization by user ID and the organization
         ID
 
-        @id: 176f1d07-c24c-481d-912e-045ec9cbfa67
+        :id: 176f1d07-c24c-481d-912e-045ec9cbfa67
 
-        @assert: The user is added to the organization
+        :assert: The user is added to the organization
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         org = make_org()
         user = make_user({'admin': '1'})
@@ -412,11 +412,11 @@ class OrganizationTestCase(CLITestCase):
         """Add an admin user to an organization by user login and the
         organization name
 
-        @id: 31e9ceeb-1ae2-4c95-8b60-c5774e570476
+        :id: 31e9ceeb-1ae2-4c95-8b60-c5774e570476
 
-        @assert: The user is added to the organization
+        :assert: The user is added to the organization
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         org = make_org()
         user = make_user({'admin': '1'})
@@ -434,11 +434,11 @@ class OrganizationTestCase(CLITestCase):
         """Remove an admin user from organization by user ID and the
         organization ID
 
-        @id: 7ecfb7d0-35af-48ba-a460-70da81ade4bd
+        :id: 7ecfb7d0-35af-48ba-a460-70da81ade4bd
 
-        @assert: The admin user is removed from the organization
+        :assert: The admin user is removed from the organization
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         org = make_org()
         user = make_user({'admin': '1'})
@@ -460,11 +460,11 @@ class OrganizationTestCase(CLITestCase):
         """Remove an admin user from organization by user login and the
         organization name
 
-        @id: 41f0d3e6-3b4b-4a3e-b3d1-3126a10ed433
+        :id: 41f0d3e6-3b4b-4a3e-b3d1-3126a10ed433
 
-        @assert: The user is added then removed from the organization
+        :assert: The user is added then removed from the organization
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         org = make_org()
         user = make_user({'admin': '1'})
@@ -484,11 +484,11 @@ class OrganizationTestCase(CLITestCase):
     def test_positive_add_hostgroup_by_id(self):
         """Add a hostgroup to organization by its ID
 
-        @id: 4edbb371-fbb0-4918-b4ac-afa3ab30cee0
+        :id: 4edbb371-fbb0-4918-b4ac-afa3ab30cee0
 
-        @Assert: Hostgroup is added to the org
+        :Assert: Hostgroup is added to the org
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         org = make_org()
         hostgroup = make_hostgroup()
@@ -504,11 +504,11 @@ class OrganizationTestCase(CLITestCase):
     def test_positive_add_hostgroup_by_name(self):
         """Add a hostgroup to organization by its name
 
-        @id: 9cb2ef26-a98a-43a4-977c-d97c82509508
+        :id: 9cb2ef26-a98a-43a4-977c-d97c82509508
 
-        @Assert: Hostgroup is added to the org
+        :Assert: Hostgroup is added to the org
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         org = make_org()
         hostgroup = make_hostgroup()
@@ -525,11 +525,11 @@ class OrganizationTestCase(CLITestCase):
     def test_positive_remove_hostgroup_by_name(self):
         """Remove a hostgroup from an organization by its name
 
-        @id: 8b2804c9-cefe-4a8a-b3a4-12ea131cdef0
+        :id: 8b2804c9-cefe-4a8a-b3a4-12ea131cdef0
 
-        @Assert: Hostgroup is removed from the organization
+        :Assert: Hostgroup is removed from the organization
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         org = make_org()
         hostgroup = make_hostgroup()
@@ -550,11 +550,11 @@ class OrganizationTestCase(CLITestCase):
     def test_positive_remove_hostgroup_by_id(self):
         """Remove a hostgroup from an organization by its ID
 
-        @id: 34e2c7c8-dc20-4709-a5a9-83c0dee9d84d
+        :id: 34e2c7c8-dc20-4709-a5a9-83c0dee9d84d
 
-        @assert: Hostgroup is removed from the org
+        :assert: Hostgroup is removed from the org
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         org = make_org()
         hostgroup = make_hostgroup()
@@ -575,11 +575,11 @@ class OrganizationTestCase(CLITestCase):
     def test_positive_add_compresource_by_name(self):
         """Add a compute resource to organization by its name
 
-        @id: 4bc1f281-ef8e-450b-8ef6-f8d11da5324f
+        :id: 4bc1f281-ef8e-450b-8ef6-f8d11da5324f
 
-        @Assert: Compute Resource is added to the org
+        :Assert: Compute Resource is added to the org
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         org = make_org()
         compute_res = make_compute_resource({
@@ -599,11 +599,11 @@ class OrganizationTestCase(CLITestCase):
     def test_positive_add_compresource_by_id(self):
         """Add a compute resource to organization by its ID
 
-        @id: 355e20c5-ec04-49f7-a0ae-0864a3fe0f3f
+        :id: 355e20c5-ec04-49f7-a0ae-0864a3fe0f3f
 
-        @Assert: Compute Resource is added to the org
+        :Assert: Compute Resource is added to the org
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         compute_res = make_compute_resource()
         org = make_org({'compute-resource-ids': compute_res['id']})
@@ -614,11 +614,11 @@ class OrganizationTestCase(CLITestCase):
     def test_positive_add_compresources_by_id(self):
         """Add multiple compute resources to organization by their IDs
 
-        @id: 65846f05-583b-4914-ad0a-9251ca585af5
+        :id: 65846f05-583b-4914-ad0a-9251ca585af5
 
-        @Assert: All compute resources are added to the org
+        :Assert: All compute resources are added to the org
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         cr_amount = random.randint(3, 5)
         resources = [make_compute_resource() for _ in range(cr_amount)]
@@ -637,11 +637,11 @@ class OrganizationTestCase(CLITestCase):
     def test_positive_remove_compresource_by_id(self):
         """Remove a compute resource from organization by its ID
 
-        @id: 415c14ab-f879-4ed8-9ba7-8af4ada2e277
+        :id: 415c14ab-f879-4ed8-9ba7-8af4ada2e277
 
-        @Assert: Compute resource is removed from the org
+        :Assert: Compute resource is removed from the org
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         org = make_org()
         compute_res = make_compute_resource({
@@ -668,11 +668,11 @@ class OrganizationTestCase(CLITestCase):
     def test_positive_remove_compresource_by_name(self):
         """Remove a compute resource from organization by its name
 
-        @id: 1b1313a8-8326-4b33-8113-17c5cf0d4ffb
+        :id: 1b1313a8-8326-4b33-8113-17c5cf0d4ffb
 
-        @Assert: Compute resource is removed from the org
+        :Assert: Compute resource is removed from the org
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         org = make_org()
         compute_res = make_compute_resource({
@@ -697,11 +697,11 @@ class OrganizationTestCase(CLITestCase):
     def test_positive_add_medium_by_id(self):
         """Add a medium to organization by its ID
 
-        @id: c2943a81-c8f7-44c4-926b-388055d7c290
+        :id: c2943a81-c8f7-44c4-926b-388055d7c290
 
-        @Assert: Medium is added to the org
+        :Assert: Medium is added to the org
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         org = make_org()
         medium = make_medium()
@@ -717,11 +717,11 @@ class OrganizationTestCase(CLITestCase):
     def test_positive_add_medium_by_name(self):
         """Add a medium to organization by its name
 
-        @id: dcbaf2bb-ebb9-4430-8584-08b4cad00ad5
+        :id: dcbaf2bb-ebb9-4430-8584-08b4cad00ad5
 
-        @Assert: Medium is added to the org
+        :Assert: Medium is added to the org
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         org = make_org()
         medium = make_medium()
@@ -738,11 +738,11 @@ class OrganizationTestCase(CLITestCase):
     def test_positive_remove_medium_by_id(self):
         """Remove a medium from organization by its ID
 
-        @id: 703103d8-f4d4-4070-bd6b-1fd239a92fa5
+        :id: 703103d8-f4d4-4070-bd6b-1fd239a92fa5
 
-        @Assert: Medium is removed from the org
+        :Assert: Medium is removed from the org
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         org = make_org()
         medium = make_medium()
@@ -763,11 +763,11 @@ class OrganizationTestCase(CLITestCase):
     def test_positive_remove_medium_by_name(self):
         """Remove a medium from organization by its name
 
-        @id: feb6c092-3459-496d-a403-69b540ba469a
+        :id: feb6c092-3459-496d-a403-69b540ba469a
 
-        @Assert: Medium is removed from the org
+        :Assert: Medium is removed from the org
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         org = make_org()
         medium = make_medium()
@@ -787,11 +787,11 @@ class OrganizationTestCase(CLITestCase):
     def test_positive_add_template_by_name(self):
         """Add a provisioning template to organization by its name
 
-        @id: bd46a192-488f-4da0-bf47-1f370ae5f55c
+        :id: bd46a192-488f-4da0-bf47-1f370ae5f55c
 
-        @Assert: Template is added to the org
+        :Assert: Template is added to the org
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         for name in valid_data_list():
             with self.subTest(name):
@@ -814,11 +814,11 @@ class OrganizationTestCase(CLITestCase):
     def test_positive_add_template_by_id(self):
         """Add a provisioning template to organization by its ID
 
-        @id: 4dd119bf-e9e1-4c9a-9b6b-b2c1cc7bc015
+        :id: 4dd119bf-e9e1-4c9a-9b6b-b2c1cc7bc015
 
-        @Assert: Template is added to the org
+        :Assert: Template is added to the org
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         conf_templ = make_template()
         org = make_org()
@@ -836,11 +836,11 @@ class OrganizationTestCase(CLITestCase):
     def test_positive_add_templates_by_id(self):
         """Add multiple provisioning templates to organization by their IDs
 
-        @id: 24cf7c8f-1e3b-4f37-b66d-24e6c125c752
+        :id: 24cf7c8f-1e3b-4f37-b66d-24e6c125c752
 
-        @Assert: All provisioning templates are added to the org
+        :Assert: All provisioning templates are added to the org
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         templates_amount = random.randint(3, 5)
         templates = [make_template() for _ in range(templates_amount)]
@@ -860,11 +860,11 @@ class OrganizationTestCase(CLITestCase):
     def test_positive_remove_template_by_id(self):
         """Remove a provisioning template from organization by its ID
 
-        @id: 8f3e05c2-6c0d-48a6-a311-41ad032b7977
+        :id: 8f3e05c2-6c0d-48a6-a311-41ad032b7977
 
-        @Assert: Template is removed from the org
+        :Assert: Template is removed from the org
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         org = make_org()
         template = make_template({'content': gen_string('alpha')})
@@ -894,11 +894,11 @@ class OrganizationTestCase(CLITestCase):
     def test_positive_remove_template_by_name(self):
         """ARemove a provisioning template from organization by its name
 
-        @id: 6db69282-8a0a-40cb-b494-8f555772ca81
+        :id: 6db69282-8a0a-40cb-b494-8f555772ca81
 
-        @Assert: Template is removed from the org
+        :Assert: Template is removed from the org
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         for name in valid_data_list():
             with self.subTest(name):
@@ -933,11 +933,11 @@ class OrganizationTestCase(CLITestCase):
     def test_positive_add_domain_by_name(self):
         """Add a domain to organization by its name
 
-        @id: 97359ffe-4ce6-4e44-9e3f-583d3fdebbc8
+        :id: 97359ffe-4ce6-4e44-9e3f-583d3fdebbc8
 
-        @assert: Domain is added to organization
+        :assert: Domain is added to organization
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         org = make_org()
         domain = make_domain()
@@ -954,11 +954,11 @@ class OrganizationTestCase(CLITestCase):
     def test_positive_add_domain_by_id(self):
         """Add a domain to organization by its ID
 
-        @id: 33df2dc5-33ea-416d-bf13-f90aaf327e18
+        :id: 33df2dc5-33ea-416d-bf13-f90aaf327e18
 
-        @assert: Domain is added to organization
+        :assert: Domain is added to organization
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         org = make_org()
         domain = make_domain()
@@ -976,11 +976,11 @@ class OrganizationTestCase(CLITestCase):
     def test_positive_remove_domain_by_name(self):
         """Remove a domain from organization by its name
 
-        @id: 59ab55ab-782b-4ee2-b347-f1a1e37c55aa
+        :id: 59ab55ab-782b-4ee2-b347-f1a1e37c55aa
 
-        @Assert: Domain is removed from the org
+        :Assert: Domain is removed from the org
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         org = make_org()
         domain = make_domain()
@@ -1004,11 +1004,11 @@ class OrganizationTestCase(CLITestCase):
     def test_positive_remove_domain_by_id(self):
         """Remove a domain from organization by its ID
 
-        @id: 01ef8a26-e944-4cda-b60a-2b9d86a8051f
+        :id: 01ef8a26-e944-4cda-b60a-2b9d86a8051f
 
-        @assert: Domain is removed from the organization
+        :assert: Domain is removed from the organization
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         org = make_org()
         domain = make_domain()
@@ -1031,11 +1031,11 @@ class OrganizationTestCase(CLITestCase):
     def test_positive_add_lce(self):
         """Add a lifecycle environment to organization
 
-        @id: 3620eeac-bf4e-4055-a6b4-4da10efbbfa2
+        :id: 3620eeac-bf4e-4055-a6b4-4da10efbbfa2
 
-        @Assert: Lifecycle environment is added to the org
+        :Assert: Lifecycle environment is added to the org
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         # Create a lifecycle environment.
         org_id = make_org()['id']
@@ -1054,11 +1054,11 @@ class OrganizationTestCase(CLITestCase):
     def test_positive_remove_lce(self):
         """Remove a lifecycle environment from organization
 
-        @id: bfa9198e-6078-4f10-b79a-3d7f51b835fd
+        :id: bfa9198e-6078-4f10-b79a-3d7f51b835fd
 
-        @Assert: Lifecycle environment is removed from the org
+        :Assert: Lifecycle environment is removed from the org
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         # Create a lifecycle environment.
         org_id = make_org()['id']
@@ -1083,11 +1083,11 @@ class OrganizationTestCase(CLITestCase):
     def test_positive_add_capsule_by_name(self):
         """Add a capsule to organization by its name
 
-        @id: dbf9dd74-3b9e-4124-9468-b0eb978897df
+        :id: dbf9dd74-3b9e-4124-9468-b0eb978897df
 
-        @Assert: Capsule is added to the org
+        :Assert: Capsule is added to the org
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         org = make_org()
         proxy = make_proxy()
@@ -1107,11 +1107,11 @@ class OrganizationTestCase(CLITestCase):
     def test_positive_add_capsule_by_id(self):
         """Add a capsule to organization by its ID
 
-        @id: 0a64ebbe-d357-4ca8-b19e-86ea0963dc71
+        :id: 0a64ebbe-d357-4ca8-b19e-86ea0963dc71
 
-        @assert: Capsule is added to the org
+        :assert: Capsule is added to the org
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         org = make_org()
         proxy = make_proxy()
@@ -1131,11 +1131,11 @@ class OrganizationTestCase(CLITestCase):
     def test_positive_remove_capsule_by_id(self):
         """Remove a capsule from organization by its id
 
-        @id: 71af64ec-5cbb-4dd8-ba90-652e302305ec
+        :id: 71af64ec-5cbb-4dd8-ba90-652e302305ec
 
-        @Assert: Capsule is removed from the org
+        :Assert: Capsule is removed from the org
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         org = make_org()
         proxy = make_proxy()
@@ -1159,11 +1159,11 @@ class OrganizationTestCase(CLITestCase):
     def test_positive_remove_capsule_by_name(self):
         """Remove a capsule from organization by its name
 
-        @id: f56eaf46-fef5-4b52-819f-e30e61f0ec4a
+        :id: f56eaf46-fef5-4b52-819f-e30e61f0ec4a
 
-        @Assert: Capsule is removed from the org
+        :Assert: Capsule is removed from the org
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         org = make_org()
         proxy = make_proxy()
@@ -1187,11 +1187,11 @@ class OrganizationTestCase(CLITestCase):
     def test_positive_add_location_by_id(self):
         """Add a location to organization by its id
 
-        @id: 83848f18-2cca-457c-af57-e6249386c81c
+        :id: 83848f18-2cca-457c-af57-e6249386c81c
 
-        @Assert: Location is added to the org
+        :Assert: Location is added to the org
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         org = make_org()
         loc = make_location()
@@ -1208,11 +1208,11 @@ class OrganizationTestCase(CLITestCase):
     def test_positive_add_location_by_name(self):
         """Add a location to organization by its name
 
-        @id: f39522e8-5280-429e-b954-79153c2c73c2
+        :id: f39522e8-5280-429e-b954-79153c2c73c2
 
-        @Assert: Location is added to the org
+        :Assert: Location is added to the org
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         org = make_org()
         loc = make_location()
@@ -1230,11 +1230,11 @@ class OrganizationTestCase(CLITestCase):
     def test_positive_remove_location_by_id(self):
         """Remove a location from organization by its id
 
-        @id: 37b63e5c-8fd5-439c-9540-972b597b590a
+        :id: 37b63e5c-8fd5-439c-9540-972b597b590a
 
-        @Assert: Location is removed from the org
+        :Assert: Location is removed from the org
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         org = make_org()
         loc = make_location()
@@ -1258,11 +1258,11 @@ class OrganizationTestCase(CLITestCase):
     def test_positive_remove_location_by_name(self):
         """Remove a location from organization by its name
 
-        @id: 35770afa-1623-448c-af4f-a702851063db
+        :id: 35770afa-1623-448c-af4f-a702851063db
 
-        @Assert: Location is removed from the org
+        :Assert: Location is removed from the org
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         org = make_org()
         loc = make_location()
@@ -1285,9 +1285,9 @@ class OrganizationTestCase(CLITestCase):
     def test_positive_add_parameter_by_org_name(self):
         """Add a parameter to organization
 
-        @id: b0b59650-5718-45e2-8724-151dc52b1486
+        :id: b0b59650-5718-45e2-8724-151dc52b1486
 
-        @Assert: Parameter is added to the org
+        :Assert: Parameter is added to the org
         """
         param_name = gen_string('alpha')
         param_value = gen_string('alpha')
@@ -1306,9 +1306,9 @@ class OrganizationTestCase(CLITestCase):
     def test_positive_add_parameter_by_org_id(self):
         """Add a parameter to organization
 
-        @id: bb76f67e-5329-4777-b563-3fe4ebffc9ce
+        :id: bb76f67e-5329-4777-b563-3fe4ebffc9ce
 
-        @Assert: Parameter is added to the org
+        :Assert: Parameter is added to the org
         """
         param_name = gen_string('alpha')
         param_value = gen_string('alpha')
@@ -1327,9 +1327,9 @@ class OrganizationTestCase(CLITestCase):
     def test_positive_update_parameter(self):
         """Update a parameter associated with organization
 
-        @id: 4a7ed165-a0c5-4ba6-833a-5a1b3ee47ace
+        :id: 4a7ed165-a0c5-4ba6-833a-5a1b3ee47ace
 
-        @Assert: Parameter is updated
+        :Assert: Parameter is updated
         """
         param_name = gen_string('alpha')
         param_new_value = gen_string('alpha')
@@ -1357,9 +1357,9 @@ class OrganizationTestCase(CLITestCase):
     def test_positive_remove_parameter_by_org_name(self):
         """Remove a parameter from organization
 
-        @id: e4099279-4e73-4c14-9e7c-912b3787b99f
+        :id: e4099279-4e73-4c14-9e7c-912b3787b99f
 
-        @Assert: Parameter is removed from the org
+        :Assert: Parameter is removed from the org
         """
         param_name = gen_string('alpha')
         org = make_org()
@@ -1383,9 +1383,9 @@ class OrganizationTestCase(CLITestCase):
     def test_positive_remove_parameter_by_org_id(self):
         """Remove a parameter from organization
 
-        @id: 9b0e7c5c-32cd-4428-8798-3469599c9b05
+        :id: 9b0e7c5c-32cd-4428-8798-3469599c9b05
 
-        @Assert: Parameter is removed from the org
+        :Assert: Parameter is removed from the org
         """
         param_name = gen_string('alpha')
         org = make_org()
@@ -1411,9 +1411,9 @@ class OrganizationTestCase(CLITestCase):
         """Try to create an organization with invalid name, but valid label and
         description
 
-        @id: f0aecf1e-d093-4365-af85-b3650ed21318
+        :id: f0aecf1e-d093-4365-af85-b3650ed21318
 
-        @assert: organization is not created
+        :assert: organization is not created
         """
         for name in invalid_values_list():
             with self.subTest(name):
@@ -1429,9 +1429,9 @@ class OrganizationTestCase(CLITestCase):
         """Create organization with valid values, then create a new one with
         same values
 
-        @id: 07924e1f-1eff-4bae-b0db-e41b84966bc1
+        :id: 07924e1f-1eff-4bae-b0db-e41b84966bc1
 
-        @assert: organization is not created
+        :assert: organization is not created
         """
         for desc, name, label in zip(
                 valid_data_list(),
@@ -1457,9 +1457,9 @@ class OrganizationTestCase(CLITestCase):
     def test_positive_delete_by_id(self):
         """Delete an organization by ID
 
-        @id: b1f5d246-2b12-4302-9824-00d3561f8699
+        :id: b1f5d246-2b12-4302-9824-00d3561f8699
 
-        @assert: organization is deleted
+        :assert: organization is deleted
         """
         org = make_org()
         Org.delete({'id': org['id']})
@@ -1471,9 +1471,9 @@ class OrganizationTestCase(CLITestCase):
     def test_positive_delete_by_label(self):
         """Delete an organization by label
 
-        @id: 5624f318-ce10-4eaa-815b-0d6ec1e6b438
+        :id: 5624f318-ce10-4eaa-815b-0d6ec1e6b438
 
-        @assert: organization is deleted
+        :assert: organization is deleted
         """
         for label in valid_labels_list():
             with self.subTest(label):
@@ -1487,9 +1487,9 @@ class OrganizationTestCase(CLITestCase):
     def test_positive_delete_by_name(self):
         """Delete an organization by name
 
-        @id: c2787b85-fa87-4aaf-bee4-4695249dd5d8
+        :id: c2787b85-fa87-4aaf-bee4-4695249dd5d8
 
-        @assert: organization is deleted
+        :assert: organization is deleted
         """
         for name in valid_org_names_list():
             with self.subTest(name):
@@ -1503,9 +1503,9 @@ class OrganizationTestCase(CLITestCase):
     def test_positive_update_name(self):
         """Create organization with valid values then update its name
 
-        @id: 66581003-f5d9-443c-8cd6-00f68087e8e9
+        :id: 66581003-f5d9-443c-8cd6-00f68087e8e9
 
-        @assert: organization name is updated
+        :assert: organization name is updated
         """
         for new_name in valid_org_names_list():
             with self.subTest(new_name):
@@ -1523,9 +1523,9 @@ class OrganizationTestCase(CLITestCase):
     def test_positive_update_description(self):
         """Create organization with valid values then update its description
 
-        @id: c5cb0d68-10dd-48ee-8d56-83be8b33d729
+        :id: c5cb0d68-10dd-48ee-8d56-83be8b33d729
 
-        @assert: organization description is updated
+        :assert: organization description is updated
         """
         for new_desc in valid_data_list():
             with self.subTest(new_desc):
@@ -1544,9 +1544,9 @@ class OrganizationTestCase(CLITestCase):
         """Create organization with valid values then update its name and
         description
 
-        @id: 42635526-fb10-4811-8fe7-1d4c218a056e
+        :id: 42635526-fb10-4811-8fe7-1d4c218a056e
 
-        @assert: organization name and description are updated
+        :assert: organization name and description are updated
         """
         for new_name, new_desc in zip(
                 valid_org_names_list(), valid_data_list()):
@@ -1569,9 +1569,9 @@ class OrganizationTestCase(CLITestCase):
     def test_negative_update_name(self):
         """Create organization then fail to update its name
 
-        @id: 582d41b8-370d-45ed-9b7b-8096608e1324
+        :id: 582d41b8-370d-45ed-9b7b-8096608e1324
 
-        @assert: organization name is not updated
+        :assert: organization name is not updated
         """
         for new_name in invalid_values_list():
             with self.subTest(new_name):
@@ -1588,9 +1588,9 @@ class OrganizationTestCase(CLITestCase):
     def test_positive_search_by_name(self):
         """Can search for an organization by name
 
-        @id: 4279972b-180d-40ce-944f-47a1940af25d
+        :id: 4279972b-180d-40ce-944f-47a1940af25d
 
-        @assert: organization is created and can be searched by name
+        :assert: organization is created and can be searched by name
         """
         for name in valid_org_names_list():
             with self.subTest(name):
@@ -1603,9 +1603,9 @@ class OrganizationTestCase(CLITestCase):
     def test_positive_search_by_label(self):
         """Can search for an organization by name
 
-        @id: 0e5a23fa-86d2-4114-be39-0e6228c76f19
+        :id: 0e5a23fa-86d2-4114-be39-0e6228c76f19
 
-        @assert: organization is created and can be searched by label
+        :assert: organization is created and can be searched by label
         """
         for name in valid_org_names_list():
             with self.subTest(name):
@@ -1618,10 +1618,10 @@ class OrganizationTestCase(CLITestCase):
     def test_positive_info_by_label(self):
         """Get org information by its label
 
-        @id: 02328b67-5d24-4873-b716-113eee3ff67b
+        :id: 02328b67-5d24-4873-b716-113eee3ff67b
 
-        @Assert: Organization is created and info can be obtained by its label
-        graciously
+        :Assert: Organization is created and info can be obtained by its label
+            graciously
         """
         org = make_org()
         result = Org.info({'label': org['label']})
@@ -1631,10 +1631,10 @@ class OrganizationTestCase(CLITestCase):
     def test_positive_info_by_name(self):
         """Get org information by its name
 
-        @id: cf971026-26a4-428f-b560-bb14e5324207
+        :id: cf971026-26a4-428f-b560-bb14e5324207
 
-        @Assert: Organization is created and info can be obtained by its name
-        graciously
+        :Assert: Organization is created and info can be obtained by its name
+            graciously
         """
         org = make_org()
         result = Org.info({'name': org['name']})

--- a/tests/foreman/cli/test_oscap.py
+++ b/tests/foreman/cli/test_oscap.py
@@ -1,16 +1,16 @@
 """Test for oscap cli hammer plugin
 
-@Requirement: Oscap
+:Requirement: Oscap
 
-@CaseLevel: Acceptance
+:CaseLevel: Acceptance
 
-@CaseComponent: CLI
+:CaseComponent: CLI
 
-@TestType: Functional
+:TestType: Functional
 
-@CaseImportance: High
+:CaseImportance: High
 
-@Upstream: No
+:Upstream: No
 """
 
 from robottelo.decorators import run_only_on, stubbed, tier1, tier2, tier4
@@ -26,22 +26,22 @@ class OpenScapTestCase(CLITestCase):
     def test_positive_list_default_content_with_admin(self):
         """List the default scap content with admin account
 
-        @id: 32c41c22-6aef-424e-8e69-a65c00f1c811
+        :id: 32c41c22-6aef-424e-8e69-a65c00f1c811
 
-        @setup:
+        :setup:
 
-        1. Oscap should be enabled.
-        2. Default content should already be populated.
-        3. Oscap-cli hammer plugin installed.
+            1. Oscap should be enabled.
+            2. Default content should already be populated.
+            3. Oscap-cli hammer plugin installed.
 
-        @steps:
+        :steps:
 
-        1. Login to shell from admin account.
-        2. Execute the scap-content command with list as sub-command.
+            1. Login to shell from admin account.
+            2. Execute the scap-content command with list as sub-command.
 
-        @Assert: The scap-content are listed.
+        :Assert: The scap-content are listed.
 
-        @caseautomation: notautomated
+        :caseautomation: notautomated
         """
 
     @run_only_on('sat')
@@ -50,22 +50,22 @@ class OpenScapTestCase(CLITestCase):
     def test_negative_list_default_content_with_viewer_role(self):
         """List the default scap content by user with viewer role
 
-        @id: 1e909ffc-10d9-4bcd-b4bb-c26981912bb4
+        :id: 1e909ffc-10d9-4bcd-b4bb-c26981912bb4
 
-        @setup:
+        :setup:
 
-        1. Oscap should be enabled.
-        2. Default content should already be populated.
-        3. Oscap-cli hammer plugin installed.
+            1. Oscap should be enabled.
+            2. Default content should already be populated.
+            3. Oscap-cli hammer plugin installed.
 
-        @steps:
+        :steps:
 
-        1. Login to shell from user account.
-        2. Execute the scap-content command with list as sub-Command.
+            1. Login to shell from user account.
+            2. Execute the scap-content command with list as sub-Command.
 
-        @Assert: The scap-content is not listed.
+        :Assert: The scap-content is not listed.
 
-        @caseautomation: notautomated
+        :caseautomation: notautomated
         """
 
     @run_only_on('sat')
@@ -74,23 +74,23 @@ class OpenScapTestCase(CLITestCase):
     def test_positive_view_scap_content_info_admin(self):
         """View info of scap content with admin account
 
-        @id: 539ea982-0701-43f5-bb91-e566e6687e35
+        :id: 539ea982-0701-43f5-bb91-e566e6687e35
 
-        @setup:
+        :setup:
 
-        1. Oscap should be enabled.
-        2. Default content should already be populated.
-        3. Oscap-cli hammer plugin installed.
+            1. Oscap should be enabled.
+            2. Default content should already be populated.
+            3. Oscap-cli hammer plugin installed.
 
-        @steps:
+        :steps:
 
-        1. Login to hammer shell as admin.
-        2. Execute the "scap-content" command with info as sub-command.
-        3. Pass valid "ID" of scap-content as argument.
+            1. Login to hammer shell as admin.
+            2. Execute the "scap-content" command with info as sub-command.
+            3. Pass valid "ID" of scap-content as argument.
 
-        @Assert: The info of the scap-content is listed.
+        :Assert: The info of the scap-content is listed.
 
-        @caseautomation: notautomated
+        :caseautomation: notautomated
         """
 
     @run_only_on('sat')
@@ -99,23 +99,23 @@ class OpenScapTestCase(CLITestCase):
     def test_negative_info_scap_content_viewer_role(self):
         """View info of scap content with viewer role
 
-        @id: 15eb035b-d301-4dbd-b66a-c4621d2003a3
+        :id: 15eb035b-d301-4dbd-b66a-c4621d2003a3
 
-        @setup:
+        :setup:
 
-        1. Oscap should be enabled.
-        2. Default content should already be populated.
-        3. Oscap-cli hammer plugin installed.
+            1. Oscap should be enabled.
+            2. Default content should already be populated.
+            3. Oscap-cli hammer plugin installed.
 
-        @steps:
+        :steps:
 
-        1. Login to hammer shell with user with viewer role.
-        2. Execute the "scap-content" command with info as sub-command.
-        3. Pass valid parameters.
+            1. Login to hammer shell with user with viewer role.
+            2. Execute the "scap-content" command with info as sub-command.
+            3. Pass valid parameters.
 
-        @Assert: The info of the scap-content is not listed.
+        :Assert: The info of the scap-content is not listed.
 
-        @caseautomation: notautomated
+        :caseautomation: notautomated
         """
 
     @run_only_on('sat')
@@ -124,23 +124,23 @@ class OpenScapTestCase(CLITestCase):
     def test_negative_info_scap_content(self):
         """View info of scap content with invalid ID as parameter
 
-        @id: 86f44fb1-2e2b-4004-83c1-4a62162ebea9
+        :id: 86f44fb1-2e2b-4004-83c1-4a62162ebea9
 
-        @setup:
+        :setup:
 
-        1. Oscap should be enabled.
-        2. Default content should already be populated.
-        3. Oscap-cli hammer plugin installed.
+            1. Oscap should be enabled.
+            2. Default content should already be populated.
+            3. Oscap-cli hammer plugin installed.
 
-        @steps:
+        :steps:
 
-        1. Login to hammer shell as admin.
-        2. Execute the "scap-content" command with info as sub-command.
-        3. Pass invalid "ID" of scap-content as argument.
+            1. Login to hammer shell as admin.
+            2. Execute the "scap-content" command with info as sub-command.
+            3. Pass invalid "ID" of scap-content as argument.
 
-        @Assert: The info of the scap-content is not listed.
+        :Assert: The info of the scap-content is not listed.
 
-        @caseautomation: notautomated
+        :caseautomation: notautomated
         """
 
     @run_only_on('sat')
@@ -149,23 +149,23 @@ class OpenScapTestCase(CLITestCase):
     def test_positive_create_scap_content_with_valid_title(self):
         """Create scap-content with valid title
 
-        @id: 68e9fbe2-e3c3-48e7-a774-f1260a3b7f4f
+        :id: 68e9fbe2-e3c3-48e7-a774-f1260a3b7f4f
 
-        @setup:
+        :setup:
 
-        1. Oscap should be enabled.
-        2. Oscap-cli hammer plugin installed.
-        3. Scap data stream ".xml" file.
+            1. Oscap should be enabled.
+            2. Oscap-cli hammer plugin installed.
+            3. Scap data stream ".xml" file.
 
-        @steps:
+        :steps:
 
-        1. Login to hammer shell.
-        2. Execute "scap-content" command with "create" as sub-command.
-        3. Pass valid parameters.
+            1. Login to hammer shell.
+            2. Execute "scap-content" command with "create" as sub-command.
+            3. Pass valid parameters.
 
-        @Assert: The scap-content is created successfully.
+        :Assert: The scap-content is created successfully.
 
-        @caseautomation: notautomated
+        :caseautomation: notautomated
         """
 
     @run_only_on('sat')
@@ -174,23 +174,23 @@ class OpenScapTestCase(CLITestCase):
     def test_negative_create_scap_content_with_invalid_title(self):
         """Create scap-content with invalid title
 
-        @id: 90a2590e-a6ff-41f1-9e0a-67d4b16435c0
+        :id: 90a2590e-a6ff-41f1-9e0a-67d4b16435c0
 
-        @setup:
+        :setup:
 
-        1. Oscap should be enabled.
-        2. Oscap-cli hammer plugin installed.
-        3. Scap data stream ".xml" file.
+            1. Oscap should be enabled.
+            2. Oscap-cli hammer plugin installed.
+            3. Scap data stream ".xml" file.
 
-        @steps:
+        :steps:
 
-        1. Login to hammer shell.
-        2. Execute "scap-content" command with "create" as sub-command.
-        3. Pass valid parameters and invalid title.
+            1. Login to hammer shell.
+            2. Execute "scap-content" command with "create" as sub-command.
+            3. Pass valid parameters and invalid title.
 
-        @Assert: The scap-content is not created.
+        :Assert: The scap-content is not created.
 
-        @caseautomation: notautomated
+        :caseautomation: notautomated
         """
 
     @run_only_on('sat')
@@ -199,23 +199,23 @@ class OpenScapTestCase(CLITestCase):
     def test_positive_create_scap_content_with_valid_originalfile_name(self):
         """Create scap-content with valid original file name
 
-        @id: 25441174-11cb-4d9b-9ec5-b1c69411b5bc
+        :id: 25441174-11cb-4d9b-9ec5-b1c69411b5bc
 
-        @setup:
+        :setup:
 
-        1. Oscap should be enabled.
-        2. Oscap-cli hammer plugin installed.
-        3. Scap data stream ".xml" file.
+            1. Oscap should be enabled.
+            2. Oscap-cli hammer plugin installed.
+            3. Scap data stream ".xml" file.
 
-        @steps:
+        :steps:
 
-        1. Login to hammer shell.
-        2. Execute "scap-content" command with "create" as sub-command.
-        3. Pass valid parameters.
+            1. Login to hammer shell.
+            2. Execute "scap-content" command with "create" as sub-command.
+            3. Pass valid parameters.
 
-        @Assert: The scap-content is not created.
+        :Assert: The scap-content is not created.
 
-        @caseautomation: notautomated
+        :caseautomation: notautomated
         """
 
     @run_only_on('sat')
@@ -224,23 +224,23 @@ class OpenScapTestCase(CLITestCase):
     def test_negative_create_scap_content_with_invalid_originalfile_name(self):
         """Create scap-content with invalid original file name
 
-        @id: 83feb67a-a6bf-4a99-923d-889e8d1013fa
+        :id: 83feb67a-a6bf-4a99-923d-889e8d1013fa
 
-        @setup:
+        :setup:
 
-        1. Oscap should be enabled.
-        2. Oscap-cli hammer plugin installed.
-        3. Scap data stream ".xml" file.
+            1. Oscap should be enabled.
+            2. Oscap-cli hammer plugin installed.
+            3. Scap data stream ".xml" file.
 
-        @steps:
+        :steps:
 
-        1. Login to hammer shell.
-        2. Execute "scap-content" command with "create" as sub-command.
-        3. Pass valid parameters and invalid title.
+            1. Login to hammer shell.
+            2. Execute "scap-content" command with "create" as sub-command.
+            3. Pass valid parameters and invalid title.
 
-        @Assert: The scap-content is not created.
+        :Assert: The scap-content is not created.
 
-        @caseautomation: notautomated
+        :caseautomation: notautomated
         """
 
     @run_only_on('sat')
@@ -249,23 +249,23 @@ class OpenScapTestCase(CLITestCase):
     def test_positive_create_scap_content_with_dsfile(self):
         """Create scap-content with scap data stream xml file
 
-        @id: 62f1a663-fe0f-4d02-9329-59fa044e2674
+        :id: 62f1a663-fe0f-4d02-9329-59fa044e2674
 
-        @setup:
+        :setup:
 
-        1. Oscap should be enabled.
-        2. Oscap-cli hammer plugin installed.
-        3. vaild Scap data stream ".xml" file.
+            1. Oscap should be enabled.
+            2. Oscap-cli hammer plugin installed.
+            3. vaild Scap data stream ".xml" file.
 
-        @steps:
+        :steps:
 
-        1. Login to hammer shell.
-        2. Execute "scap-content" command with "create" as sub-command.
-        3. Pass valid parameters and valid scap ds file.
+            1. Login to hammer shell.
+            2. Execute "scap-content" command with "create" as sub-command.
+            3. Pass valid parameters and valid scap ds file.
 
-        @Assert: The scap-content is created successfully.
+        :Assert: The scap-content is created successfully.
 
-        @caseautomation: notautomated
+        :caseautomation: notautomated
         """
 
     @run_only_on('sat')
@@ -274,22 +274,22 @@ class OpenScapTestCase(CLITestCase):
     def test_negative_create_scap_content_without_dsfile(self):
         """Create scap-content without scap data stream xml file
 
-        @id: ea811994-12cd-4382-9382-37fa806cc26f
+        :id: ea811994-12cd-4382-9382-37fa806cc26f
 
-        @setup:
+        :setup:
 
-        1. Oscap should be enabled.
-        2. Oscap-cli hammer plugin installed.
+            1. Oscap should be enabled.
+            2. Oscap-cli hammer plugin installed.
 
-        @steps:
+        :steps:
 
-        1. Login to hammer shell.
-        2. Execute "scap-content" command with "create" as sub-command.
-        3. Don't pass the scap-file parameter.
+            1. Login to hammer shell.
+            2. Execute "scap-content" command with "create" as sub-command.
+            3. Don't pass the scap-file parameter.
 
-        @Assert: The scap-content is not created.
+        :Assert: The scap-content is not created.
 
-        @caseautomation: notautomated
+        :caseautomation: notautomated
         """
 
     @run_only_on('sat')
@@ -298,22 +298,22 @@ class OpenScapTestCase(CLITestCase):
     def test_positive_update_scap_content_with_newtitle(self):
         """Update scap content title
 
-        @id: 2c32e94a-237d-40b9-8a3b-fca2ef26fe79
+        :id: 2c32e94a-237d-40b9-8a3b-fca2ef26fe79
 
-        @setup:
+        :setup:
 
-        1. Oscap should be enabled.
-        2. Oscap-cli hammer plugin installed.
+            1. Oscap should be enabled.
+            2. Oscap-cli hammer plugin installed.
 
-        @steps:
+        :steps:
 
-        1. Login to hammer shell.
-        2. Execute "scap-content" command with "update" as sub-command.
-        3. Pass valid parameters and newtitle parameter.
+            1. Login to hammer shell.
+            2. Execute "scap-content" command with "update" as sub-command.
+            3. Pass valid parameters and newtitle parameter.
 
-        @Assert: The scap-content is updated successfully.
+        :Assert: The scap-content is updated successfully.
 
-        @caseautomation: notautomated
+        :caseautomation: notautomated
         """
 
     @run_only_on('sat')
@@ -322,22 +322,22 @@ class OpenScapTestCase(CLITestCase):
     def test_positive_delete_scap_content_with_id(self):
         """Delete a scap content with id as parameter
 
-        @id: 11ae7652-65e0-4751-b1e0-246b27919238
+        :id: 11ae7652-65e0-4751-b1e0-246b27919238
 
-        @setup:
+        :setup:
 
-        1. Oscap should be enabled.
-        2. Oscap-cli hammer plugin installed.
+            1. Oscap should be enabled.
+            2. Oscap-cli hammer plugin installed.
 
-        @steps:
+        :steps:
 
-        1. Login to hammer shell.
-        2. Execute "scap-content" command with "delete" as sub-command.
-        3. Pass ID as parameter.
+            1. Login to hammer shell.
+            2. Execute "scap-content" command with "delete" as sub-command.
+            3. Pass ID as parameter.
 
-        @Assert: The scap-content is deleted successfully.
+        :Assert: The scap-content is deleted successfully.
 
-        @caseautomation: notautomated
+        :caseautomation: notautomated
         """
 
     @run_only_on('sat')
@@ -346,22 +346,22 @@ class OpenScapTestCase(CLITestCase):
     def test_positive_delete_scap_content_with_name(self):
         """Delete a scap content with name as parameter
 
-        @id: aa4ca830-3250-4517-b40c-0256cdda5e0a
+        :id: aa4ca830-3250-4517-b40c-0256cdda5e0a
 
-        @setup:
+        :setup:
 
-        1. Oscap should be enabled.
-        2. Oscap-cli hammer plugin installed.
+            1. Oscap should be enabled.
+            2. Oscap-cli hammer plugin installed.
 
-        @steps:
+        :steps:
 
-        1. Login to hammer shell.
-        2. Execute "scap-content" command with "delete" as sub-command.
-        3. Pass name as parameter.
+            1. Login to hammer shell.
+            2. Execute "scap-content" command with "delete" as sub-command.
+            3. Pass name as parameter.
 
-        @Assert: The scap-content is deleted successfully.
+        :Assert: The scap-content is deleted successfully.
 
-        @caseautomation: notautomated
+        :caseautomation: notautomated
         """
 
     @run_only_on('sat')
@@ -370,22 +370,22 @@ class OpenScapTestCase(CLITestCase):
     def test_postive_create_scap_policy_with_valid_name(self):
         """Create scap policy with valid name
 
-        @id: c9327675-62b2-4e22-933a-02818ef68c11
+        :id: c9327675-62b2-4e22-933a-02818ef68c11
 
-        @setup:
+        :setup:
 
-        1. Oscap should be enabled.
-        2. Oscap-cli hammer plugin installed.
+            1. Oscap should be enabled.
+            2. Oscap-cli hammer plugin installed.
 
-        @steps:
+        :steps:
 
-        1. Login to hammer shell.
-        2. Execute "policy" command with "create" as sub-command.
-        3. Pass valid parameters and valid name.
+            1. Login to hammer shell.
+            2. Execute "policy" command with "create" as sub-command.
+            3. Pass valid parameters and valid name.
 
-        @Assert: The policy is created successfully.
+        :Assert: The policy is created successfully.
 
-        @caseautomation: notautomated
+        :caseautomation: notautomated
         """
 
     @run_only_on('sat')
@@ -394,22 +394,22 @@ class OpenScapTestCase(CLITestCase):
     def test_negative_create_scap_policy_with_invalid_name(self):
         """Create scap policy with invalid name
 
-        @id: 0d163968-7759-4cfd-9c4d-98533d8db925
+        :id: 0d163968-7759-4cfd-9c4d-98533d8db925
 
-        @setup:
+        :setup:
 
-        1. Oscap should be enabled.
-        2. Oscap-cli hammer plugin installed.
+            1. Oscap should be enabled.
+            2. Oscap-cli hammer plugin installed.
 
-        @steps:
+        :steps:
 
-        1. Login to hammer shell.
-        2. Execute "policy" command with "create" as sub-command.
-        3. Pass valid parameters and invalid name.
+            1. Login to hammer shell.
+            2. Execute "policy" command with "create" as sub-command.
+            3. Pass valid parameters and invalid name.
 
-        @Assert: The policy is not created.
+        :Assert: The policy is not created.
 
-        @caseautomation: notautomated
+        :caseautomation: notautomated
         """
 
     @run_only_on('sat')
@@ -418,22 +418,22 @@ class OpenScapTestCase(CLITestCase):
     def test_negative_create_scap_policy_without_content(self):
         """Create scap policy without scap content
 
-        @id: 88a8fba3-f45a-4e22-9ee1-f0d701f1135f
+        :id: 88a8fba3-f45a-4e22-9ee1-f0d701f1135f
 
-        @setup:
+        :setup:
 
-        1. Oscap should be enabled.
-        2. Oscap-cli hammer plugin installed.
+            1. Oscap should be enabled.
+            2. Oscap-cli hammer plugin installed.
 
-        @steps:
+        :steps:
 
-        1. Login to hammer shell.
-        2. Execute "policy" command with "create" as sub-command.
-        3. Pass valid parameters without passing the scap-content-id.
+            1. Login to hammer shell.
+            2. Execute "policy" command with "create" as sub-command.
+            3. Pass valid parameters without passing the scap-content-id.
 
-        @Assert: The policy is not created.
+        :Assert: The policy is not created.
 
-        @caseautomation: notautomated
+        :caseautomation: notautomated
         """
 
     @run_only_on('sat')
@@ -442,24 +442,24 @@ class OpenScapTestCase(CLITestCase):
     def test_positive_associate_scap_policy_with_hostgroups(self):
         """Associate hostgroups to scap policy
 
-        @id: 916403a0-572d-4cf3-9155-3e3d0373577f
+        :id: 916403a0-572d-4cf3-9155-3e3d0373577f
 
-        @setup:
+        :setup:
 
-        1. Oscap should be enabled.
-        2. Oscap-cli hammer plugin installed.
-        3. More than 1 hostgroups
+            1. Oscap should be enabled.
+            2. Oscap-cli hammer plugin installed.
+            3. More than 1 hostgroups
 
-        @steps:
+        :steps:
 
-        1. Login to hammer shell.
-        2. Execute "policy" command with "create" as sub-command.
-        3. Pass valid parameters.
-        4. Associate multiple hostgroups with policy
+            1. Login to hammer shell.
+            2. Execute "policy" command with "create" as sub-command.
+            3. Pass valid parameters.
+            4. Associate multiple hostgroups with policy
 
-        @Assert: The policy is created and associated successfully.
+        :Assert: The policy is created and associated successfully.
 
-        @caseautomation: notautomated
+        :caseautomation: notautomated
         """
 
     @run_only_on('sat')
@@ -468,24 +468,24 @@ class OpenScapTestCase(CLITestCase):
     def test_positive_create_scap_policy_without_hostgroups(self):
         """Create scap policy without hostgroups
 
-        @id: de705ba8-a946-4835-a79c-5da9510d591a
+        :id: de705ba8-a946-4835-a79c-5da9510d591a
 
-        @setup:
+        :setup:
 
-        1. Oscap should be enabled.
-        2. Oscap-cli hammer plugin installed.
-        3. More than 1 hostgroups.
+            1. Oscap should be enabled.
+            2. Oscap-cli hammer plugin installed.
+            3. More than 1 hostgroups.
 
-        @steps:
+        :steps:
 
-        1. Login to hammer shell.
-        2. Execute "policy" command with "create" as sub-command.
-        3. Pass valid parameters.
-        4. Associate multiple hostgroups with policy.
+            1. Login to hammer shell.
+            2. Execute "policy" command with "create" as sub-command.
+            3. Pass valid parameters.
+            4. Associate multiple hostgroups with policy.
 
-        @Assert: The policy is created.
+        :Assert: The policy is created.
 
-        @caseautomation: notautomated
+        :caseautomation: notautomated
         """
 
     @run_only_on('sat')
@@ -494,22 +494,22 @@ class OpenScapTestCase(CLITestCase):
     def test_positive_list_scap_policy(self):
         """List all scap policies
 
-        @id: d14ab43e-c7a9-4eee-b61c-420b07ca1da9
+        :id: d14ab43e-c7a9-4eee-b61c-420b07ca1da9
 
-        @setup:
+        :setup:
 
-        1. Oscap should be enabled.
-        2. Oscap-cli hammer plugin installed.
-        3. Atleast 1 policy.
+            1. Oscap should be enabled.
+            2. Oscap-cli hammer plugin installed.
+            3. Atleast 1 policy.
 
-        @steps:
+        :steps:
 
-        1. Login to hammer shell.
-        2. Execute "policy" command with "list" as sub-command.
+            1. Login to hammer shell.
+            2. Execute "policy" command with "list" as sub-command.
 
-        @Assert: The policies are listed successfully.
+        :Assert: The policies are listed successfully.
 
-        @caseautomation: notautomated
+        :caseautomation: notautomated
         """
 
     @run_only_on('sat')
@@ -518,23 +518,23 @@ class OpenScapTestCase(CLITestCase):
     def test_positive_info_scap_policy_with_id(self):
         """View info of policy with id as parameter
 
-        @id: d309000b-777e-4cfb-bf6c-7f02ab130b9d
+        :id: d309000b-777e-4cfb-bf6c-7f02ab130b9d
 
-        @setup:
+        :setup:
 
-        1. Oscap should be enabled.
-        2. Oscap-cli hammer plugin installed.
-        3. Atleast 1 policy.
+            1. Oscap should be enabled.
+            2. Oscap-cli hammer plugin installed.
+            3. Atleast 1 policy.
 
-        @steps:
+        :steps:
 
-        1. Login to hammer shell.
-        2. Execute "policy" command with "info" as sub-command.
-        3. Pass ID as the parameter.
+            1. Login to hammer shell.
+            2. Execute "policy" command with "info" as sub-command.
+            3. Pass ID as the parameter.
 
-        @Assert: The information is displayed.
+        :Assert: The information is displayed.
 
-        @caseautomation: notautomated
+        :caseautomation: notautomated
         """
 
     @run_only_on('sat')
@@ -543,23 +543,23 @@ class OpenScapTestCase(CLITestCase):
     def test_positive_info_scap_policy_with_name(self):
         """View info of policy with name as parameter
 
-        @id: eece98b2-3e6a-4ac0-b742-913482343e9d
+        :id: eece98b2-3e6a-4ac0-b742-913482343e9d
 
-        @setup:
+        :setup:
 
-        1. Oscap should be enabled.
-        2. Oscap-cli hammer plugin installed.
-        3. Atleast 1 policy.
+            1. Oscap should be enabled.
+            2. Oscap-cli hammer plugin installed.
+            3. Atleast 1 policy.
 
-        @steps:
+        :steps:
 
-        1. Login to hammer shell.
-        2. Execute "policy" command with "info" as sub-command.
-        3. Pass name as the parameter.
+            1. Login to hammer shell.
+            2. Execute "policy" command with "info" as sub-command.
+            3. Pass name as the parameter.
 
-        @Assert: The information is displayed.
+        :Assert: The information is displayed.
 
-        @caseautomation: notautomated
+        :caseautomation: notautomated
         """
 
     @run_only_on('sat')
@@ -568,23 +568,23 @@ class OpenScapTestCase(CLITestCase):
     def test_positive_update_scap_policy_with_hostgroup(self):
         """Update scap policy by addition of hostgroup
 
-        @id: 21b9b82b-7c6c-4944-bc2f-67631e1d4086
+        :id: 21b9b82b-7c6c-4944-bc2f-67631e1d4086
 
-        @setup:
+        :setup:
 
-        1. Oscap should be enabled.
-        2. Oscap-cli hammer plugin installed.
-        3. Atleast 1 policy and hostgroup.
+            1. Oscap should be enabled.
+            2. Oscap-cli hammer plugin installed.
+            3. Atleast 1 policy and hostgroup.
 
-        @steps:
+        :steps:
 
-        1. Login to hammer shell.
-        2. Execute "policy" command with "update" as sub-command.
-        3. Pass hostgoups as the parameter.
+            1. Login to hammer shell.
+            2. Execute "policy" command with "update" as sub-command.
+            3. Pass hostgoups as the parameter.
 
-        @Assert: The scap policy is updated.
+        :Assert: The scap policy is updated.
 
-        @caseautomation: notautomated
+        :caseautomation: notautomated
         """
 
     @run_only_on('sat')
@@ -594,23 +594,23 @@ class OpenScapTestCase(CLITestCase):
         """Update scap policy by updating the period strategy
         from monthly to weekly
 
-        @id: 4892bc3c-d886-49b4-a5b1-250d96b7e278
+        :id: 4892bc3c-d886-49b4-a5b1-250d96b7e278
 
-        @setup:
+        :setup:
 
-        1. Oscap should be enabled.
-        2. Oscap-cli hammer plugin installed.
-        3. Atleast 1 policy.
+            1. Oscap should be enabled.
+            2. Oscap-cli hammer plugin installed.
+            3. Atleast 1 policy.
 
-        @steps:
+        :steps:
 
-        1. Login to hammer shell.
-        2. Execute "policy" command with "update" as sub-command.
-        3. Pass period as parameter and weekday as parameter.
+            1. Login to hammer shell.
+            2. Execute "policy" command with "update" as sub-command.
+            3. Pass period as parameter and weekday as parameter.
 
-        @Assert: The scap policy is updated.
+        :Assert: The scap policy is updated.
 
-        @caseautomation: notautomated
+        :caseautomation: notautomated
         """
 
     @run_only_on('sat')
@@ -620,23 +620,23 @@ class OpenScapTestCase(CLITestCase):
         """Update the scap policy by updating the scap content
         associated with the policy
 
-        @id: 3c9df098-9ff8-4f48-a9a0-2ba21a8e48e0
+        :id: 3c9df098-9ff8-4f48-a9a0-2ba21a8e48e0
 
-        @setup:
+        :setup:
 
-        1. Oscap should be enabled.
-        2. Oscap-cli hammer plugin installed.
-        3. Atleast 1 policy.
+            1. Oscap should be enabled.
+            2. Oscap-cli hammer plugin installed.
+            3. Atleast 1 policy.
 
-        @steps:
+        :steps:
 
-        1. Login to hammer shell.
-        2. Execute "policy" command with "update" as sub-command.
-        3. Pass scap-content-id as parameter.
+            1. Login to hammer shell.
+            2. Execute "policy" command with "update" as sub-command.
+            3. Pass scap-content-id as parameter.
 
-        @Assert: The scap policy is updated.
+        :Assert: The scap policy is updated.
 
-        @caseautomation: notautomated
+        :caseautomation: notautomated
         """
 
     @run_only_on('sat')
@@ -645,23 +645,23 @@ class OpenScapTestCase(CLITestCase):
     def test_positive_delete_scap_policy_with_id(self):
         """Delete the scap policy with id as parameter
 
-        @id: db9d925f-c730-4299-ad8e-5aaa08895f6e
+        :id: db9d925f-c730-4299-ad8e-5aaa08895f6e
 
-        @setup:
+        :setup:
 
-        1. Oscap should be enabled.
-        2. Oscap-cli hammer plugin installed.
-        3. Atleast 1 policy.
+            1. Oscap should be enabled.
+            2. Oscap-cli hammer plugin installed.
+            3. Atleast 1 policy.
 
-        @steps:
+        :steps:
 
-        1. Login to hammer shell.
-        2. Execute "policy" command with "delete" as sub-command.
-        3. Pass id as parameter.
+            1. Login to hammer shell.
+            2. Execute "policy" command with "delete" as sub-command.
+            3. Pass id as parameter.
 
-        @Assert: The scap policy is deleted successfully.
+        :Assert: The scap policy is deleted successfully.
 
-        @caseautomation: notautomated
+        :caseautomation: notautomated
         """
 
     @run_only_on('sat')
@@ -670,23 +670,23 @@ class OpenScapTestCase(CLITestCase):
     def test_positive_delete_scap_policy_with_name(self):
         """Delete the scap policy with name as parameter
 
-        @id: 6c167e7b-cbdd-4059-808c-04c686ba9fe8
+        :id: 6c167e7b-cbdd-4059-808c-04c686ba9fe8
 
-        @setup:
+        :setup:
 
-        1. Oscap should be enabled.
-        2. Oscap-cli hammer plugin installed.
-        3. Atleast 1 policy.
+            1. Oscap should be enabled.
+            2. Oscap-cli hammer plugin installed.
+            3. Atleast 1 policy.
 
-        @steps:
+        :steps:
 
-        1. Login to hammer shell.
-        2. Execute "policy" command with "delete" as sub-command.
-        3. Pass name as parameter.
+            1. Login to hammer shell.
+            2. Execute "policy" command with "delete" as sub-command.
+            3. Pass name as parameter.
 
-        @Assert: The scap policy is deleted successfully.
+        :Assert: The scap policy is deleted successfully.
 
-        @caseautomation: notautomated
+        :caseautomation: notautomated
         """
 
     @run_only_on('sat')
@@ -695,24 +695,24 @@ class OpenScapTestCase(CLITestCase):
     def test_positive_list_arf_reports(self):
         """List all arf-reports
 
-        @id: f364ea3c-ba74-4848-be39-df33f80fcd21
+        :id: f364ea3c-ba74-4848-be39-df33f80fcd21
 
-        @setup:
+        :setup:
 
-        1. Oscap should be enabled.
-        2. Oscap-cli hammer plugin installed.
-        3. Atleast 1 policy.
-        4. A provisioned host with scap enabled.
-        5. Reports from the host send to satellite.
+            1. Oscap should be enabled.
+            2. Oscap-cli hammer plugin installed.
+            3. Atleast 1 policy.
+            4. A provisioned host with scap enabled.
+            5. Reports from the host send to satellite.
 
-        @steps:
+        :steps:
 
-        1. Login to hammer shell.
-        2. Execute "policy" command with "list" as sub-command.
+            1. Login to hammer shell.
+            2. Execute "policy" command with "list" as sub-command.
 
-        @Assert: The arf-reports are listed successfully.
+        :Assert: The arf-reports are listed successfully.
 
-        @caseautomation: notautomated
+        :caseautomation: notautomated
         """
 
     @run_only_on('sat')
@@ -721,25 +721,25 @@ class OpenScapTestCase(CLITestCase):
     def test_positive_info_arf_report(self):
         """View information of arf-report
 
-        @id: 5ac866f9-fc23-48a1-9766-a8a5f52cfd63
+        :id: 5ac866f9-fc23-48a1-9766-a8a5f52cfd63
 
-        @setup:
+        :setup:
 
-        1. Oscap should be enabled.
-        2. Oscap-cli hammer plugin installed.
-        3. Atleast 1 policy.
-        4. A provisioned host with scap enabled
-        5. Reports from the host send to satellite
+            1. Oscap should be enabled.
+            2. Oscap-cli hammer plugin installed.
+            3. Atleast 1 policy.
+            4. A provisioned host with scap enabled
+            5. Reports from the host send to satellite
 
-        @steps:
+        :steps:
 
-        1. Login to hammer shell.
-        2. Execute "policy" command with "info" as sub-command.
-        3. Pass id as parameter.
+            1. Login to hammer shell.
+            2. Execute "policy" command with "info" as sub-command.
+            3. Pass id as parameter.
 
-        @Assert: The information of arf-report is listed successfully.
+        :Assert: The information of arf-report is listed successfully.
 
-        @caseautomation: notautomated
+        :caseautomation: notautomated
         """
 
     @run_only_on('sat')
@@ -748,23 +748,23 @@ class OpenScapTestCase(CLITestCase):
     def test_positive_delete_arf_report(self):
         """Delete an arf-report
 
-        @id: 85b6d483-eb83-4af5-96d6-3cd74d2c007c
+        :id: 85b6d483-eb83-4af5-96d6-3cd74d2c007c
 
-        @setup:
+        :setup:
 
-        1. Oscap should be enabled.
-        2. Oscap-cli hammer plugin installed.
-        3. Atleast 1 policy.
-        4. A provisioned host with scap enabled.
-        5. Reports from the host send to satellite.
+            1. Oscap should be enabled.
+            2. Oscap-cli hammer plugin installed.
+            3. Atleast 1 policy.
+            4. A provisioned host with scap enabled.
+            5. Reports from the host send to satellite.
 
-        @steps:
+        :steps:
 
-        1. Login to hammer shell.
-        2. Execute "policy" command with "delete" as sub-command.
-        3. Pass id as parameter.
+            1. Login to hammer shell.
+            2. Execute "policy" command with "delete" as sub-command.
+            3. Pass id as parameter.
 
-        @Assert: Arf-report is deleted successfully.
+        :Assert: Arf-report is deleted successfully.
 
-        @caseautomation: notautomated
+        :caseautomation: notautomated
         """

--- a/tests/foreman/cli/test_ostreebranch.py
+++ b/tests/foreman/cli/test_ostreebranch.py
@@ -1,19 +1,19 @@
 # -*- encoding: utf-8 -*-
 """Test class for Ostree Branch CLI.
 
-@Requirement: Ostreebranch
+:Requirement: Ostreebranch
 
-@CaseAutomation: Automated
+:CaseAutomation: Automated
 
-@CaseLevel: Acceptance
+:CaseLevel: Acceptance
 
-@CaseComponent: CLI
+:CaseComponent: CLI
 
-@TestType: Functional
+:TestType: Functional
 
-@CaseImportance: High
+:CaseImportance: High
 
-@Upstream: No
+:Upstream: No
 """
 
 import random
@@ -59,9 +59,9 @@ class OstreeBranchTestCase(CLITestCase):
     def test_positive_list(self):
         """List Ostree Branches
 
-        @id: 0f5e7e63-c0e3-43fc-8238-caf19a478a46
+        :id: 0f5e7e63-c0e3-43fc-8238-caf19a478a46
 
-        @Assert: Ostree Branch List is displayed
+        :Assert: Ostree Branch List is displayed
         """
         result = OstreeBranch.list()
         self.assertGreater(len(result), 0)
@@ -71,9 +71,9 @@ class OstreeBranchTestCase(CLITestCase):
     def test_positive_list_by_repo_id(self):
         """List Ostree branches by repo id
 
-        @id: 8cf1a973-031c-4c02-af14-0faba22ab60b
+        :id: 8cf1a973-031c-4c02-af14-0faba22ab60b
 
-        @Assert: Ostree Branch List is displayed
+        :Assert: Ostree Branch List is displayed
         """
         result = OstreeBranch.list({'repository-id': self.ostree_repo['id']})
         self.assertGreater(len(result), 0)
@@ -83,9 +83,9 @@ class OstreeBranchTestCase(CLITestCase):
     def test_positive_list_by_product_id(self):
         """List Ostree branches by product id
 
-        @id: e7b9d04d-cace-4271-b166-214017200c53
+        :id: e7b9d04d-cace-4271-b166-214017200c53
 
-        @Assert: Ostree Branch List is displayed
+        :Assert: Ostree Branch List is displayed
         """
         result = OstreeBranch.list({'product-id': self.product['id']})
         self.assertGreater(len(result), 0)
@@ -95,9 +95,9 @@ class OstreeBranchTestCase(CLITestCase):
     def test_positive_list_by_org_id(self):
         """List Ostree branches by org id
 
-        @id: 5b169619-305f-4934-b363-068193330701
+        :id: 5b169619-305f-4934-b363-068193330701
 
-        @Assert: Ostree Branch List is displayed
+        :Assert: Ostree Branch List is displayed
         """
         result = OstreeBranch.list({'organization-id': self.org['id']})
         self.assertGreater(len(result), 0)
@@ -107,9 +107,9 @@ class OstreeBranchTestCase(CLITestCase):
     def test_positive_list_by_cv_id(self):
         """List Ostree branches by cv id
 
-        @id: 3654f107-44ee-4af2-a9e4-f9fd8c68491e
+        :id: 3654f107-44ee-4af2-a9e4-f9fd8c68491e
 
-        @Assert: Ostree Branch List is displayed
+        :Assert: Ostree Branch List is displayed
         """
         result = OstreeBranch.list({'content-view-id': self.cv['id']})
         self.assertGreater(len(result), 0)
@@ -119,9 +119,9 @@ class OstreeBranchTestCase(CLITestCase):
     def test_positive_info_by_id(self):
         """Get info for Ostree branch by id
 
-        @id: 7838c9a8-56da-44de-883c-28571ecfa75c
+        :id: 7838c9a8-56da-44de-883c-28571ecfa75c
 
-        @Assert: Ostree Branch Info is displayed
+        :Assert: Ostree Branch Info is displayed
         """
         result = OstreeBranch.list()
         self.assertGreater(len(result), 0)

--- a/tests/foreman/cli/test_partitiontable.py
+++ b/tests/foreman/cli/test_partitiontable.py
@@ -1,19 +1,19 @@
 # -*- encoding: utf-8 -*-
 """Test class for Partition table CLI
 
-@Requirement: Partitiontable
+:Requirement: Partitiontable
 
-@CaseAutomation: Automated
+:CaseAutomation: Automated
 
-@CaseLevel: Acceptance
+:CaseLevel: Acceptance
 
-@CaseComponent: CLI
+:CaseComponent: CLI
 
-@TestType: Functional
+:TestType: Functional
 
-@CaseImportance: High
+:CaseImportance: High
 
-@Upstream: No
+:Upstream: No
 """
 from random import randint
 from robottelo.datafactory import generate_strings_list
@@ -32,11 +32,11 @@ class PartitionTableUpdateCreateTestCase(CLITestCase):
     def test_positive_create_with_one_character_name(self):
         """Create Partition table with 1 character in name
 
-        @id: cfec857c-ed6e-4472-93bb-70e1d4f39bae
+        :id: cfec857c-ed6e-4472-93bb-70e1d4f39bae
 
-        @Assert: Partition table was created
+        :Assert: Partition table was created
 
-        @BZ: 1229384
+        :BZ: 1229384
         """
         for name in generate_strings_list(length=1):
             with self.subTest(name):
@@ -48,9 +48,9 @@ class PartitionTableUpdateCreateTestCase(CLITestCase):
     def test_positive_create_with_name(self):
         """Create Partition Tables with different names
 
-        @id: e7d8a444-c69a-4863-a715-83d2dcb3b6ec
+        :id: e7d8a444-c69a-4863-a715-83d2dcb3b6ec
 
-        @Assert: Partition Table is created and has correct name
+        :Assert: Partition Table is created and has correct name
         """
         for name in generate_strings_list(length=randint(4, 30)):
             with self.subTest(name):
@@ -61,9 +61,9 @@ class PartitionTableUpdateCreateTestCase(CLITestCase):
     def test_positive_create_with_content(self):
         """Create a Partition Table with content
 
-        @id: 28bfbd8b-2ada-44d0-89f3-63885cfb3495
+        :id: 28bfbd8b-2ada-44d0-89f3-63885cfb3495
 
-        @Assert: Partition Table is created and has correct content
+        :Assert: Partition Table is created and has correct content
         """
         content = 'Fake ptable'
         ptable = make_partition_table({'content': content})
@@ -75,9 +75,9 @@ class PartitionTableUpdateCreateTestCase(CLITestCase):
     def test_positive_update_name(self):
         """Create a Partition Table and update its name
 
-        @id: 6242c915-0f15-4d5f-9f7a-73cb58fac81e
+        :id: 6242c915-0f15-4d5f-9f7a-73cb58fac81e
 
-        @Assert: Partition Table is created and its name can be updated
+        :Assert: Partition Table is created and its name can be updated
         """
         ptable = make_partition_table()
         for new_name in generate_strings_list(length=randint(4, 30)):
@@ -93,9 +93,9 @@ class PartitionTableUpdateCreateTestCase(CLITestCase):
     def test_positive_delete_by_id(self):
         """Create a Partition Table then delete it by its ID
 
-        @id: 4d2369eb-4dc1-4ab5-96d4-c872c39f4ff5
+        :id: 4d2369eb-4dc1-4ab5-96d4-c872c39f4ff5
 
-        @Assert: Partition Table is deleted
+        :Assert: Partition Table is deleted
         """
         ptable = make_partition_table()
         PartitionTable.delete({'id': ptable['id']})
@@ -106,9 +106,9 @@ class PartitionTableUpdateCreateTestCase(CLITestCase):
     def test_positive_delete_by_name(self):
         """Create a Partition Table then delete it by its name
 
-        @id: 27bd427c-7601-4f3b-998f-b7baaaad0fb0
+        :id: 27bd427c-7601-4f3b-998f-b7baaaad0fb0
 
-        @Assert: Partition Table is deleted
+        :Assert: Partition Table is deleted
         """
         ptable = make_partition_table()
         PartitionTable.delete({'name': ptable['name']})
@@ -120,11 +120,11 @@ class PartitionTableUpdateCreateTestCase(CLITestCase):
         """Create a partition table then add an operating system to it using
         IDs for association
 
-        @id: 37415a34-5dba-4551-b1c5-e6e59329f4ca
+        :id: 37415a34-5dba-4551-b1c5-e6e59329f4ca
 
-        @Assert: Operating system is added to partition table
+        :Assert: Operating system is added to partition table
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         ptable = make_partition_table()
         os = make_os()
@@ -140,11 +140,11 @@ class PartitionTableUpdateCreateTestCase(CLITestCase):
         """Create a partition table then add an operating system to it using
         names for association
 
-        @id: ad97800a-0ef8-4ee9-ab49-05c82c77017f
+        :id: ad97800a-0ef8-4ee9-ab49-05c82c77017f
 
-        @Assert: Operating system is added to partition table
+        :Assert: Operating system is added to partition table
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         ptable = make_partition_table()
         os = make_os()
@@ -160,11 +160,11 @@ class PartitionTableUpdateCreateTestCase(CLITestCase):
         """Add an operating system to a partition table then remove it. Use IDs
         for removal
 
-        @id: ee37be42-9ed3-44dd-9206-514e340e5524
+        :id: ee37be42-9ed3-44dd-9206-514e340e5524
 
-        @Assert: Operating system is added then removed from partition table
+        :Assert: Operating system is added then removed from partition table
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         ptable = make_partition_table()
         os = make_os()
@@ -185,11 +185,11 @@ class PartitionTableUpdateCreateTestCase(CLITestCase):
         """Add an operating system to a partition table then remove it. Use
         names for removal
 
-        @id: f7544419-af4c-4dcf-8673-cad472745794
+        :id: f7544419-af4c-4dcf-8673-cad472745794
 
-        @Assert: Operating system is added then removed from partition table
+        :Assert: Operating system is added then removed from partition table
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         ptable = make_partition_table()
         os = make_os()

--- a/tests/foreman/cli/test_ping.py
+++ b/tests/foreman/cli/test_ping.py
@@ -1,18 +1,18 @@
 """Test Class for hammer ping
 
-@Requirement: Ping
+:Requirement: Ping
 
-@CaseAutomation: Automated
+:CaseAutomation: Automated
 
-@CaseLevel: Acceptance
+:CaseLevel: Acceptance
 
-@CaseComponent: CLI
+:CaseComponent: CLI
 
-@TestType: Functional
+:TestType: Functional
 
-@CaseImportance: High
+:CaseImportance: High
 
-@Upstream: No
+:Upstream: No
 """
 from robottelo import ssh
 from robottelo.decorators import tier1
@@ -27,13 +27,14 @@ class PingTestCase(CLITestCase):
     def test_positive_ping(self):
         """hammer ping return code
 
-        @id: dfa3ab4f-a64f-4a96-8c7f-d940df22b8bf
+        :id: dfa3ab4f-a64f-4a96-8c7f-d940df22b8bf
 
-        @steps:
-        1. Execute hammer ping
-        2. Check its return code, should be 0 if all services are ok else != 0
+        :steps:
+            1. Execute hammer ping
+            2. Check its return code, should be 0 if all services are ok else
+               != 0
 
-        @assert: hammer ping returns a right return code
+        :assert: hammer ping returns a right return code
         """
         result = ssh.command('hammer -u {0} -p {1} ping'.format(
             self.foreman_user,

--- a/tests/foreman/cli/test_product.py
+++ b/tests/foreman/cli/test_product.py
@@ -1,19 +1,19 @@
 # -*- encoding: utf-8 -*-
 """Test class for Product CLI
 
-@Requirement: Product
+:Requirement: Product
 
-@CaseAutomation: Automated
+:CaseAutomation: Automated
 
-@CaseLevel: Acceptance
+:CaseLevel: Acceptance
 
-@CaseComponent: CLI
+:CaseComponent: CLI
 
-@TestType: Functional
+:TestType: Functional
 
-@CaseImportance: High
+:CaseImportance: High
 
-@Upstream: No
+:Upstream: No
 """
 import time
 
@@ -57,9 +57,9 @@ class ProductTestCase(CLITestCase):
     def test_positive_create_with_name(self):
         """Check if product can be created with random names
 
-        @id: 252a2073-5094-4996-b157-bf7ff81f40af
+        :id: 252a2073-5094-4996-b157-bf7ff81f40af
 
-        @Assert: Product is created and has random name
+        :Assert: Product is created and has random name
         """
         for name in valid_data_list():
             with self.subTest(name):
@@ -75,9 +75,9 @@ class ProductTestCase(CLITestCase):
     def test_positive_create_with_label(self):
         """Check if product can be created with random labels
 
-        @id: 07ff96b2-cc55-4d07-86a2-f20b77cc9b14
+        :id: 07ff96b2-cc55-4d07-86a2-f20b77cc9b14
 
-        @Assert: Product is created and has random label
+        :Assert: Product is created and has random label
         """
         for label in valid_labels_list():
             with self.subTest(label):
@@ -95,9 +95,9 @@ class ProductTestCase(CLITestCase):
     def test_positive_create_with_description(self):
         """Check if product can be created with random description
 
-        @id: 4b64dc60-ac08-4276-b31a-d3851ae064ba
+        :id: 4b64dc60-ac08-4276-b31a-d3851ae064ba
 
-        @Assert: Product is created and has random description
+        :Assert: Product is created and has random description
         """
         for desc in valid_data_list():
             with self.subTest(desc):
@@ -114,9 +114,9 @@ class ProductTestCase(CLITestCase):
     def test_positive_create_with_gpg_key(self):
         """Check if product can be created with gpg key
 
-        @id: 64f02b3b-f8c1-42c5-abb2-bf963ac24670
+        :id: 64f02b3b-f8c1-42c5-abb2-bf963ac24670
 
-        @Assert: Product is created and has gpg key
+        :Assert: Product is created and has gpg key
         """
         gpg_key = make_gpg_key({u'organization-id': self.org['id']})
         for name in valid_data_list():
@@ -133,9 +133,9 @@ class ProductTestCase(CLITestCase):
     def test_positive_create_with_sync_plan(self):
         """Check if product can be created with sync plan
 
-        @id: c54ff608-9f59-4fd6-a45c-bd70ce656023
+        :id: c54ff608-9f59-4fd6-a45c-bd70ce656023
 
-        @Assert: Product is created and has random sync plan
+        :Assert: Product is created and has random sync plan
         """
         sync_plan = make_sync_plan({
             u'organization-id': self.org['id']
@@ -154,9 +154,9 @@ class ProductTestCase(CLITestCase):
     def test_negative_create_with_name(self):
         """Check that only valid names can be used
 
-        @id: 2da26ab2-8d79-47ea-b4d2-defcd98a0649
+        :id: 2da26ab2-8d79-47ea-b4d2-defcd98a0649
 
-        @Assert: Product is not created
+        :Assert: Product is not created
         """
         for invalid_name in invalid_values_list():
             with self.subTest(invalid_name):
@@ -170,9 +170,9 @@ class ProductTestCase(CLITestCase):
     def test_negative_create_with_label(self):
         """Check that only valid labels can be used
 
-        @id: 7cf970aa-48dc-425b-ae37-1e15dfab0626
+        :id: 7cf970aa-48dc-425b-ae37-1e15dfab0626
 
-        @Assert: Product is not created
+        :Assert: Product is not created
         """
         product_name = gen_alphanumeric()
         for invalid_label in (gen_string('latin1', 15), gen_string('utf8', 15),
@@ -189,9 +189,9 @@ class ProductTestCase(CLITestCase):
     def test_positive_update_description(self):
         """Update the description of a product
 
-        @id: 4b3b4c5b-3eaa-4b9c-93c6-6ee9d62061eb
+        :id: 4b3b4c5b-3eaa-4b9c-93c6-6ee9d62061eb
 
-        @Assert: Product description is updated
+        :Assert: Product description is updated
         """
         product = make_product({u'organization-id': self.org['id']})
         for desc in valid_data_list():
@@ -211,9 +211,9 @@ class ProductTestCase(CLITestCase):
     def test_positive_update_gpg_key(self):
         """Update product's gpg keys
 
-        @id: e7febd14-ac8b-424e-9ddf-bf0f63ebe430
+        :id: e7febd14-ac8b-424e-9ddf-bf0f63ebe430
 
-        @Assert: Product gpg key is updated
+        :Assert: Product gpg key is updated
         """
         first_gpg_key = make_gpg_key({u'organization-id': self.org['id']})
         second_gpg_key = make_gpg_key({u'organization-id': self.org['id']})
@@ -239,9 +239,9 @@ class ProductTestCase(CLITestCase):
     def test_positive_update_sync_plan(self):
         """Update product's sync plan
 
-        @id: 78cbde49-b6c8-41ab-8991-fcb4b648e79b
+        :id: 78cbde49-b6c8-41ab-8991-fcb4b648e79b
 
-        @Assert: Product sync plan is updated
+        :Assert: Product sync plan is updated
         """
         first_sync_plan = make_sync_plan({u'organization-id': self.org['id']})
         second_sync_plan = make_sync_plan({u'organization-id': self.org['id']})
@@ -267,9 +267,9 @@ class ProductTestCase(CLITestCase):
     def test_positive_update_name(self):
         """Rename Product back to original name
 
-        @id: 4dec056b-8084-4372-bf7a-ce1db0c47cc9
+        :id: 4dec056b-8084-4372-bf7a-ce1db0c47cc9
 
-        @Assert: Product Renamed to original
+        :Assert: Product Renamed to original
         """
         for prod_name in generate_strings_list():
             with self.subTest(prod_name):
@@ -306,9 +306,9 @@ class ProductTestCase(CLITestCase):
     def test_positive_delete_by_id(self):
         """Check if product can be deleted
 
-        @id: 21bb8373-96d1-402c-973c-cf70d4b8244e
+        :id: 21bb8373-96d1-402c-973c-cf70d4b8244e
 
-        @Assert: Product is deleted
+        :Assert: Product is deleted
         """
         new_product = make_product({u'organization-id': self.org['id']})
         Product.delete({u'id': new_product['id']})
@@ -329,11 +329,11 @@ class ProductTestCase(CLITestCase):
     def test_positive_add_sync_plan_by_id(self):
         """Check if a sync plan can be added to a product
 
-        @id: 1517bc4b-5474-41c1-bc96-6e2130a2c2f4
+        :id: 1517bc4b-5474-41c1-bc96-6e2130a2c2f4
 
-        @Assert: Product has sync plan
+        :Assert: Product has sync plan
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         new_product = make_product({u'organization-id': self.org['id']})
         sync_plan = make_sync_plan({'organization-id': self.org['id']})
@@ -351,11 +351,11 @@ class ProductTestCase(CLITestCase):
     def test_positive_remove_sync_plan_by_id(self):
         """Check if a sync plan can be removed from a product
 
-        @id: 0df2005c-158a-48cb-8a16-9a63923699fc
+        :id: 0df2005c-158a-48cb-8a16-9a63923699fc
 
-        @Assert: Product has sync plan
+        :Assert: Product has sync plan
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         product = make_product({u'organization-id': self.org['id']})
         sync_plan = make_sync_plan({'organization-id': self.org['id']})
@@ -379,11 +379,11 @@ class ProductTestCase(CLITestCase):
     def test_positive_sync_by_id(self):
         """Check if product can be synchronized by its ID.
 
-        @id: b0e436df-dd97-4fd2-a69f-3a2fb7a12c3c
+        :id: b0e436df-dd97-4fd2-a69f-3a2fb7a12c3c
 
-        @Assert: Product is synchronized
+        :Assert: Product is synchronized
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         org = make_org()
         product = make_product({'organization-id': org['id']})
@@ -402,11 +402,11 @@ class ProductTestCase(CLITestCase):
     def test_positive_sync_by_name(self):
         """Check if product can be synchronized by its name.
 
-        @id: 92058501-7786-4440-b612-6f7f79aa454e
+        :id: 92058501-7786-4440-b612-6f7f79aa454e
 
-        @Assert: Product is synchronized
+        :Assert: Product is synchronized
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         org = make_org()
         product = make_product({'organization-id': org['id']})
@@ -425,11 +425,11 @@ class ProductTestCase(CLITestCase):
     def test_positive_sync_by_label(self):
         """Check if product can be synchronized by its label.
 
-        @id: 2e4e75dd-45f4-4013-ac74-7d4b38b0faec
+        :id: 2e4e75dd-45f4-4013-ac74-7d4b38b0faec
 
-        @Assert: Product is synchronized
+        :Assert: Product is synchronized
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         org = make_org()
         product = make_product({'organization-id': org['id']})

--- a/tests/foreman/cli/test_puppet.py
+++ b/tests/foreman/cli/test_puppet.py
@@ -1,18 +1,18 @@
 """End to end test for Puppet funcionality
 
-@Requirement: Puppet
+:Requirement: Puppet
 
-@CaseAutomation: Automated
+:CaseAutomation: Automated
 
-@CaseLevel: Acceptance
+:CaseLevel: Acceptance
 
-@CaseComponent: CLI
+:CaseComponent: CLI
 
-@TestType: Functional
+:TestType: Functional
 
-@CaseImportance: High
+:CaseImportance: High
 
-@Upstream: No
+:Upstream: No
 """
 
 from robottelo.config import settings
@@ -42,33 +42,34 @@ class PuppetTestCase(CLITestCase):
     def test_positive_puppet_scenario(self):
         """Tests extensive all-in-one puppet scenario
 
-        @id: d4fdba9f-6333-4d47-987b-ce920da20d77
+        :id: d4fdba9f-6333-4d47-987b-ce920da20d77
 
-        @Steps:
+        :Steps:
 
-        1. Create an organization and upload a cloned manifest for it.
-        2. Enable respective Satellite Tools repos and sync them.
-        3. Create a product and a LFE
-        4. Create a puppet repos within the product
-        5. Upload motd puppet module into the repo
-        6. Upload parameterizable puppet module and create smart params for it
-        7. Create a CV and add Tools repo and puppet module(s)
-        8. Publish and promote CV to the LFE
-        9. Create AK with the product and enable Satellite Tools in it
-        10. Create a libvirt compute resource
-        11. Create a sane subnet and sane domain to be used by libvirt
-        12. Create a hostgroup associated with all created entities
-            (especially Puppet Classes has added puppet modules)
-        13. Provision a host using the hostgroup on libvirt resource
-        14. Assert that puppet agent can run on the host
-        15. Assert that the puppet modules get installed by provisioning
-        16. Run facter on host and assert that was successful
+            1. Create an organization and upload a cloned manifest for it.
+            2. Enable respective Satellite Tools repos and sync them.
+            3. Create a product and a LFE
+            4. Create a puppet repos within the product
+            5. Upload motd puppet module into the repo
+            6. Upload parameterizable puppet module and create smart params for
+               it
+            7. Create a CV and add Tools repo and puppet module(s)
+            8. Publish and promote CV to the LFE
+            9. Create AK with the product and enable Satellite Tools in it
+            10. Create a libvirt compute resource
+            11. Create a sane subnet and sane domain to be used by libvirt
+            12. Create a hostgroup associated with all created entities
+                (especially Puppet Classes has added puppet modules)
+            13. Provision a host using the hostgroup on libvirt resource
+            14. Assert that puppet agent can run on the host
+            15. Assert that the puppet modules get installed by provisioning
+            16. Run facter on host and assert that was successful
 
-        @Assert: multiple asserts along the code
+        :Assert: multiple asserts along the code
 
-        @caseautomation: notautomated
+        :caseautomation: notautomated
 
-        @CaseLevel: System
+        :CaseLevel: System
         """
 
 
@@ -88,31 +89,32 @@ class PuppetCapsuleTestCase(CLITestCase):
     def test_positive_puppet_capsule_scenario(self):
         """Tests extensive all-in-one puppet scenario via Capsule
 
-        @id: 51ffe74e-7131-43d0-a919-1175233b4763
+        :id: 51ffe74e-7131-43d0-a919-1175233b4763
 
-        @Steps:
+        :Steps:
 
-        1. Create an organization and upload a cloned manifest for it.
-        2. Enable respective Satellite Tools repos and sync them.
-        3. Create a product and a LFE
-        4. Create a puppet repos within the product
-        5. Upload motd puppet module into the repo
-        6. Upload parameterizable puppet module and create smart params for it
-        7. Create a CV and add Tools repo and puppet module(s)
-        8. Publish and promote CV to the LFE
-        9. Create AK with the product and enable Satellite Tools in it
-        10. Create a libvirt compute resource
-        11. Create a sane subnet and sane domain to be used by libvirt
-        12. Create a hostgroup associated with all created entities
-            (especially Puppet Classes has added puppet modules)
-        13. Provision a host using the hostgroup on libvirt resource
-        14. Assert that puppet agent can run on the host
-        15. Assert that the puppet modules get installed by provisioning
-        16. Run facter on host and assert that was successful
+            1. Create an organization and upload a cloned manifest for it.
+            2. Enable respective Satellite Tools repos and sync them.
+            3. Create a product and a LFE
+            4. Create a puppet repos within the product
+            5. Upload motd puppet module into the repo
+            6. Upload parameterizable puppet module and create smart params for
+               it
+            7. Create a CV and add Tools repo and puppet module(s)
+            8. Publish and promote CV to the LFE
+            9. Create AK with the product and enable Satellite Tools in it
+            10. Create a libvirt compute resource
+            11. Create a sane subnet and sane domain to be used by libvirt
+            12. Create a hostgroup associated with all created entities
+                (especially Puppet Classes has added puppet modules)
+            13. Provision a host using the hostgroup on libvirt resource
+            14. Assert that puppet agent can run on the host
+            15. Assert that the puppet modules get installed by provisioning
+            16. Run facter on host and assert that was successful
 
-        @Assert: multiple asserts along the code
+        :Assert: multiple asserts along the code
 
-        @caseautomation: notautomated
+        :caseautomation: notautomated
 
-        @CaseLevel: System
+        :CaseLevel: System
         """

--- a/tests/foreman/cli/test_puppetclass.py
+++ b/tests/foreman/cli/test_puppetclass.py
@@ -1,19 +1,19 @@
 # -*- encoding: utf-8 -*-
 """Test class for Puppet Classes CLI
 
-@Requirement: Puppetclass
+:Requirement: Puppetclass
 
-@CaseAutomation: Automated
+:CaseAutomation: Automated
 
-@CaseLevel: Acceptance
+:CaseLevel: Acceptance
 
-@CaseComponent: CLI
+:CaseComponent: CLI
 
-@TestType: Functional
+:TestType: Functional
 
-@CaseImportance: High
+:CaseImportance: High
 
-@Upstream: No
+:Upstream: No
 """
 
 from robottelo.cli.environment import Environment
@@ -57,9 +57,9 @@ class PuppetClassTestCase(CLITestCase):
     def test_positive_list_smart_class_parameters(self):
         """List smart class parameters associated with the puppet class.
 
-        @id: 56b370c2-8fc6-49be-9676-242178cc709a
+        :id: 56b370c2-8fc6-49be-9676-242178cc709a
 
-        @assert: Smart class parameters listed for the class.
+        :assert: Smart class parameters listed for the class.
         """
         class_sc_parameters = Puppet.sc_params({
             u'puppet-class': self.puppet['name']})
@@ -70,9 +70,9 @@ class PuppetClassTestCase(CLITestCase):
     def test_positive_list_smart_variables(self):
         """List smart variables associated with the puppet class.
 
-        @id: cb2b41c0-29cc-4c0b-a7c8-38403d6dda5b
+        :id: cb2b41c0-29cc-4c0b-a7c8-38403d6dda5b
 
-        @assert: Smart variables listed for the class.
+        :assert: Smart variables listed for the class.
         """
         make_smart_variable({'puppet-class': self.puppet['name']})
         class_smart_variables = Puppet.smart_variables({

--- a/tests/foreman/cli/test_puppetmodule.py
+++ b/tests/foreman/cli/test_puppetmodule.py
@@ -1,19 +1,19 @@
 # -*- encoding: utf-8 -*-
 """Test class for PuppetModule CLI
 
-@Requirement: Puppetmodule
+:Requirement: Puppetmodule
 
-@CaseAutomation: Automated
+:CaseAutomation: Automated
 
-@CaseLevel: Acceptance
+:CaseLevel: Acceptance
 
-@CaseComponent: CLI
+:CaseComponent: CLI
 
-@TestType: Functional
+:TestType: Functional
 
-@CaseImportance: High
+:CaseImportance: High
 
-@Upstream: No
+:Upstream: No
 """
 
 from robottelo.cli.factory import make_org, make_product, make_repository
@@ -49,9 +49,9 @@ class PuppetModuleTestCase(CLITestCase):
         """Check if puppet-module list retrieves puppet-modules of
         the given org
 
-        @id: 77635e70-19e7-424d-9c89-ec5dbe91de75
+        :id: 77635e70-19e7-424d-9c89-ec5dbe91de75
 
-        @Assert: Puppet-modules are retrieved for the given org
+        :Assert: Puppet-modules are retrieved for the given org
         """
         result = PuppetModule.list({'organization-id': self.org['id']})
         # There are 4 puppet modules in the test puppet-module url
@@ -63,9 +63,9 @@ class PuppetModuleTestCase(CLITestCase):
         """Check if puppet-module info retrieves info for the given
         puppet-module id
 
-        @id: 8aaa9243-5e20-49d6-95ce-620cc1ba18dc
+        :id: 8aaa9243-5e20-49d6-95ce-620cc1ba18dc
 
-        @Assert: The puppet-module info is retrieved
+        :Assert: The puppet-module info is retrieved
         """
         return_value = PuppetModule.list({
             'organization-id': self.org['id'],
@@ -83,10 +83,10 @@ class PuppetModuleTestCase(CLITestCase):
         """Verify that puppet-modules list for specific repo is correct
         and does not affected by other repositories.
 
-        @id: f36d25b3-2495-4e89-a1cf-e39d52762d95
+        :id: f36d25b3-2495-4e89-a1cf-e39d52762d95
 
-        @Assert: Number of modules has no changed after a second repo
-        was synced.
+        :Assert: Number of modules has no changed after a second repo was
+            synced.
         """
         # Verify that number of synced modules is correct
         repo1 = Repository.info({'id': self.repo['id']})

--- a/tests/foreman/cli/test_remoteexecution.py
+++ b/tests/foreman/cli/test_remoteexecution.py
@@ -1,19 +1,19 @@
 # -*- encoding: utf-8 -*-
 """Test class for Remote Execution Management UI
 
-@Requirement: Remoteexecution
+:Requirement: Remoteexecution
 
-@CaseAutomation: Automated
+:CaseAutomation: Automated
 
-@CaseLevel: Acceptance
+:CaseLevel: Acceptance
 
-@CaseComponent: CLI
+:CaseComponent: CLI
 
-@TestType: Functional
+:TestType: Functional
 
-@CaseImportance: High
+:CaseImportance: High
 
-@Upstream: No
+:Upstream: No
 """
 from datetime import datetime, timedelta
 from fauxfactory import gen_string
@@ -71,9 +71,9 @@ class JobTemplateTestCase(CLITestCase):
     def test_positive_create_job_template(self):
         """Create a simple Job Template
 
-        @id: a5a67b10-61b0-4362-b671-9d9f095c452c
+        :id: a5a67b10-61b0-4362-b671-9d9f095c452c
 
-        @Assert: The job template was successfully created
+        :Assert: The job template was successfully created
         """
         template_name = gen_string('alpha', 7)
         make_job_template({
@@ -89,10 +89,10 @@ class JobTemplateTestCase(CLITestCase):
     def test_negative_create_job_template_with_invalid_name(self):
         """Create Job Template with invalid name
 
-        @id: eb51afd4-e7b3-42c3-81c3-6e18ef3d7efe
+        :id: eb51afd4-e7b3-42c3-81c3-6e18ef3d7efe
 
-        @Assert: Job Template with invalid name cannot be created and error is
-        raised
+        :Assert: Job Template with invalid name cannot be created and error is
+            raised
         """
         for name in invalid_values_list():
             with self.subTest(name):
@@ -111,9 +111,9 @@ class JobTemplateTestCase(CLITestCase):
     def test_negative_create_job_template_with_same_name(self):
         """Create Job Template with duplicate name
 
-        @id: 66100c82-97f5-4300-a0c9-8cf041f7789f
+        :id: 66100c82-97f5-4300-a0c9-8cf041f7789f
 
-        @Assert: The name duplication is caught and error is raised
+        :Assert: The name duplication is caught and error is raised
         """
         template_name = gen_string('alpha', 7)
         make_job_template({
@@ -135,9 +135,9 @@ class JobTemplateTestCase(CLITestCase):
     def test_negative_create_empty_job_template(self):
         """Create Job Template with empty template file
 
-        @id: 749be863-94ae-4008-a242-c23f353ca404
+        :id: 749be863-94ae-4008-a242-c23f353ca404
 
-        @Assert: The empty file is detected and error is raised
+        :Assert: The empty file is detected and error is raised
         """
         template_name = gen_string('alpha', 7)
         with self.assertRaisesRegex(
@@ -154,9 +154,9 @@ class JobTemplateTestCase(CLITestCase):
     def test_positive_delete_job_template(self):
         """Delete a job template
 
-        @id: 33104c04-20e9-47aa-99da-4bf3414ea31a
+        :id: 33104c04-20e9-47aa-99da-4bf3414ea31a
 
-        @Assert: The Job Template has been deleted
+        :Assert: The Job Template has been deleted
         """
         template_name = gen_string('alpha', 7)
         make_job_template({
@@ -172,9 +172,9 @@ class JobTemplateTestCase(CLITestCase):
     def test_positive_view_dump(self):
         """Export contents of a job template
 
-        @id: 25fcfcaa-fc4c-425e-919e-330e36195c4a
+        :id: 25fcfcaa-fc4c-425e-919e-330e36195c4a
 
-        @Assert: Verify no errors are thrown
+        :Assert: Verify no errors are thrown
         """
         template_name = gen_string('alpha', 7)
         make_job_template({
@@ -243,9 +243,9 @@ class RemoteExecutionTestCase(CLITestCase):
     def test_positive_run_default_job_template(self):
         """Run default job template against a single host
 
-        @id: f4470ed4-f971-4a3c-a2f1-150d45755e48
+        :id: f4470ed4-f971-4a3c-a2f1-150d45755e48
 
-        @Assert: Verify the job was successfully ran against the host
+        :Assert: Verify the job was successfully ran against the host
         """
         invocation_command = make_job_invocation({
             'job-template': 'Run Command - SSH Default',
@@ -258,9 +258,9 @@ class RemoteExecutionTestCase(CLITestCase):
     def test_positive_run_custom_job_template(self):
         """Run custom job template against a single host
 
-        @id: 71928f36-61b4-46e6-842c-a051cfd9a68e
+        :id: 71928f36-61b4-46e6-842c-a051cfd9a68e
 
-        @Assert: Verify the job was successfully ran against the host
+        :Assert: Verify the job was successfully ran against the host
         """
         template_name = gen_string('alpha', 7)
         make_job_template({
@@ -278,9 +278,9 @@ class RemoteExecutionTestCase(CLITestCase):
     def test_positive_run_scheduled_job_template(self):
         """Schedule a job to be ran against a host
 
-        @id: 1953517b-6908-40aa-858b-747629d2f374
+        :id: 1953517b-6908-40aa-858b-747629d2f374
 
-        @Assert: Verify the job was successfully ran after the designated time
+        :Assert: Verify the job was successfully ran after the designated time
         """
         system_current_time = ssh.command('date +"%b %d %Y %I:%M%p"').stdout[0]
         current_time_object = datetime.strptime(

--- a/tests/foreman/cli/test_report.py
+++ b/tests/foreman/cli/test_report.py
@@ -2,19 +2,19 @@
 # pylint: disable=no-self-use
 """Test class for Reports CLI.
 
-@Requirement: Report
+:Requirement: Report
 
-@CaseAutomation: Automated
+:CaseAutomation: Automated
 
-@CaseLevel: Acceptance
+:CaseLevel: Acceptance
 
-@CaseComponent: CLI
+:CaseComponent: CLI
 
-@TestType: Functional
+:TestType: Functional
 
-@CaseImportance: High
+:CaseImportance: High
 
-@Upstream: No
+:Upstream: No
 """
 
 import random
@@ -45,9 +45,9 @@ class ReportTestCase(CLITestCase):
     def test_positive_list(self):
         """Test list for Puppet report
 
-        @id: 8325e18f-58a4-49b8-a5f3-eebbe1d568b5
+        :id: 8325e18f-58a4-49b8-a5f3-eebbe1d568b5
 
-        @Assert: Puppert Report List is displayed
+        :Assert: Puppert Report List is displayed
         """
         Report.list()
 
@@ -56,9 +56,9 @@ class ReportTestCase(CLITestCase):
     def test_positive_info(self):
         """Test Info for Puppet report
 
-        @id: 32646d4b-7101-421a-85e0-777d3c6b71ec
+        :id: 32646d4b-7101-421a-85e0-777d3c6b71ec
 
-        @Assert: Puppet Report Info is displayed
+        :Assert: Puppet Report Info is displayed
         """
         result = Report.list()
         self.assertGreater(len(result), 0)
@@ -72,9 +72,9 @@ class ReportTestCase(CLITestCase):
     def test_positive_delete_by_id(self):
         """Check if Puppet Report can be deleted by its ID
 
-        @id: bf918ec9-e2d4-45d0-b913-ab939b5d5e6a
+        :id: bf918ec9-e2d4-45d0-b913-ab939b5d5e6a
 
-        @Assert: Puppet Report is deleted
+        :Assert: Puppet Report is deleted
         """
         result = Report.list()
         self.assertGreater(len(result), 0)

--- a/tests/foreman/cli/test_repository.py
+++ b/tests/foreman/cli/test_repository.py
@@ -1,19 +1,19 @@
 # -*- encoding: utf-8 -*-
 """Test class for Repository CLI
 
-@Requirement: Repository
+:Requirement: Repository
 
-@CaseAutomation: Automated
+:CaseAutomation: Automated
 
-@CaseLevel: Acceptance
+:CaseLevel: Acceptance
 
-@CaseComponent: CLI
+:CaseComponent: CLI
 
-@TestType: Functional
+:TestType: Functional
 
-@CaseImportance: High
+:CaseImportance: High
 
-@Upstream: No
+:Upstream: No
 """
 
 from fauxfactory import gen_string
@@ -111,10 +111,9 @@ class RepositoryTestCase(CLITestCase):
         """Check if repository docker-upstream-name is shown
         in repository info
 
-        @id: f197a14c-2cf3-4564-9b18-5fd37d469ea4
+        :id: f197a14c-2cf3-4564-9b18-5fd37d469ea4
 
-        @Assert: repository info command returns upstream-repository-name
-        value
+        :Assert: repository info command returns upstream-repository-name value
         """
         repository = self._make_repository({
             u'content-type': u'docker',
@@ -130,9 +129,9 @@ class RepositoryTestCase(CLITestCase):
     def test_positive_create_with_name(self):
         """Check if repository can be created with random names
 
-        @id: 604dea2c-d512-4a27-bfc1-24c9655b6ea9
+        :id: 604dea2c-d512-4a27-bfc1-24c9655b6ea9
 
-        @Assert: Repository is created and has random name
+        :Assert: Repository is created and has random name
         """
         for name in valid_data_list():
             with self.subTest(name):
@@ -144,9 +143,9 @@ class RepositoryTestCase(CLITestCase):
         """Check if repository can be created with random names and
         labels
 
-        @id: 79d2a6d0-5032-46cd-880c-46cf392521fa
+        :id: 79d2a6d0-5032-46cd-880c-46cf392521fa
 
-        @Assert: Repository is created and has random name and labels
+        :Assert: Repository is created and has random name and labels
         """
         for name in valid_data_list():
             with self.subTest(name):
@@ -164,9 +163,9 @@ class RepositoryTestCase(CLITestCase):
     def test_positive_create_with_yum_repo(self):
         """Create YUM repository
 
-        @id: 4c08824f-ba95-486c-94c2-9abf0a3441ea
+        :id: 4c08824f-ba95-486c-94c2-9abf0a3441ea
 
-        @Assert: YUM repository is created
+        :Assert: YUM repository is created
         """
         for url in (FAKE_0_YUM_REPO, FAKE_1_YUM_REPO, FAKE_2_YUM_REPO,
                     FAKE_3_YUM_REPO, FAKE_4_YUM_REPO):
@@ -182,9 +181,9 @@ class RepositoryTestCase(CLITestCase):
     def test_positive_create_with_puppet_repo(self):
         """Create Puppet repository
 
-        @id: 75c309ba-fbc9-419d-8427-7a61b063ec13
+        :id: 75c309ba-fbc9-419d-8427-7a61b063ec13
 
-        @Assert: Puppet repository is created
+        :Assert: Puppet repository is created
         """
         for url in (FAKE_1_PUPPET_REPO, FAKE_2_PUPPET_REPO, FAKE_3_PUPPET_REPO,
                     FAKE_4_PUPPET_REPO, FAKE_5_PUPPET_REPO):
@@ -201,9 +200,9 @@ class RepositoryTestCase(CLITestCase):
     def test_positive_create_with_auth_yum_repo(self):
         """Create YUM repository with basic HTTP authentication
 
-        @id: da8309fd-3076-427b-a96f-8d883d6e944f
+        :id: da8309fd-3076-427b-a96f-8d883d6e944f
 
-        @Assert: YUM repository is created
+        :Assert: YUM repository is created
         """
         url = FAKE_5_YUM_REPO
         for creds in valid_http_credentials(url_encoded=True):
@@ -220,9 +219,9 @@ class RepositoryTestCase(CLITestCase):
     def test_positive_create_with_download_policy(self):
         """Create YUM repositories with available download policies
 
-        @id: ffb386e6-c360-4d4b-a324-ccc21768b4f8
+        :id: ffb386e6-c360-4d4b-a324-ccc21768b4f8
 
-        @Assert: YUM repository with a download policy is created
+        :Assert: YUM repository with a download policy is created
         """
         for policy in DOWNLOAD_POLICIES:
             with self.subTest(policy):
@@ -237,9 +236,9 @@ class RepositoryTestCase(CLITestCase):
         """Verify if the default download policy is assigned
         when creating a YUM repo without `--download-policy`
 
-        @id: 9a3c4d95-d6ca-4377-9873-2c552b7d6ce7
+        :id: 9a3c4d95-d6ca-4377-9873-2c552b7d6ce7
 
-        @Assert: YUM repository with a default download policy
+        :Assert: YUM repository with a default download policy
         """
         default_dl_policy = Settings.list(
             {'search': 'name=default_download_policy'}
@@ -255,9 +254,9 @@ class RepositoryTestCase(CLITestCase):
         """Update `immediate` download policy to `on_demand`
         for a newly created YUM repository
 
-        @id: 1a80d686-3f7b-475e-9d1a-3e1f51d55101
+        :id: 1a80d686-3f7b-475e-9d1a-3e1f51d55101
 
-        @Assert: immediate download policy is updated to on_demand
+        :Assert: immediate download policy is updated to on_demand
         """
         new_repo = self._make_repository({
             u'content-type': u'yum',
@@ -275,9 +274,9 @@ class RepositoryTestCase(CLITestCase):
         """Update `immediate` download policy to `background`
         for a newly created YUM repository
 
-        @id: 7a9243eb-012c-40ad-9105-b078ed0a9eda
+        :id: 7a9243eb-012c-40ad-9105-b078ed0a9eda
 
-        @Assert: immediate download policy is updated to background
+        :Assert: immediate download policy is updated to background
         """
         new_repo = self._make_repository({
             u'content-type': u'yum',
@@ -295,9 +294,9 @@ class RepositoryTestCase(CLITestCase):
         """Update `on_demand` download policy to `immediate`
         for a newly created YUM repository
 
-        @id: 1e8338af-32e5-4f92-9215-bfdc1973c8f7
+        :id: 1e8338af-32e5-4f92-9215-bfdc1973c8f7
 
-        @Assert: on_demand download policy is updated to immediate
+        :Assert: on_demand download policy is updated to immediate
         """
         new_repo = self._make_repository({
             u'content-type': u'yum',
@@ -315,9 +314,9 @@ class RepositoryTestCase(CLITestCase):
         """Update `on_demand` download policy to `background`
         for a newly created YUM repository
 
-        @id: da600200-5bd4-4cb8-a891-37cd2233803e
+        :id: da600200-5bd4-4cb8-a891-37cd2233803e
 
-        @Assert: on_demand download policy is updated to background
+        :Assert: on_demand download policy is updated to background
         """
         new_repo = self._make_repository({
             u'content-type': u'yum',
@@ -335,9 +334,9 @@ class RepositoryTestCase(CLITestCase):
         """Update `background` download policy to `immediate`
         for a newly created YUM repository
 
-        @id: cf4dca0c-36bd-4a3c-aa29-f435ac60b3f8
+        :id: cf4dca0c-36bd-4a3c-aa29-f435ac60b3f8
 
-        @Assert: background download policy is updated to immediate
+        :Assert: background download policy is updated to immediate
         """
         new_repo = self._make_repository({
             u'content-type': u'yum',
@@ -355,9 +354,9 @@ class RepositoryTestCase(CLITestCase):
         """Update `background` download policy to `on_demand`
         for a newly created YUM repository
 
-        @id: 0f943e3d-44b7-4b6e-9a7d-d33f7f4864d1
+        :id: 0f943e3d-44b7-4b6e-9a7d-d33f7f4864d1
 
-        @Assert: background download policy is updated to on_demand
+        :Assert: background download policy is updated to on_demand
         """
         new_repo = self._make_repository({
             u'content-type': u'yum',
@@ -374,9 +373,9 @@ class RepositoryTestCase(CLITestCase):
     def test_positive_create_with_auth_puppet_repo(self):
         """Create Puppet repository with basic HTTP authentication
 
-        @id: b13f8ae2-60ab-47e6-a096-d3f368e5cab3
+        :id: b13f8ae2-60ab-47e6-a096-d3f368e5cab3
 
-        @Assert: Puppet repository is created
+        :Assert: Puppet repository is created
         """
         url = FAKE_7_PUPPET_REPO
         for creds in valid_http_credentials(url_encoded=True):
@@ -394,9 +393,9 @@ class RepositoryTestCase(CLITestCase):
     def test_positive_create_with_gpg_key_by_id(self):
         """Check if repository can be created with gpg key ID
 
-        @id: 6d22f0ea-2d27-4827-9b7a-3e1550a47285
+        :id: 6d22f0ea-2d27-4827-9b7a-3e1550a47285
 
-        @Assert: Repository is created and has gpg key
+        :Assert: Repository is created and has gpg key
         """
         # Make a new gpg key
         gpg_key = make_gpg_key({'organization-id': self.org['id']})
@@ -415,11 +414,11 @@ class RepositoryTestCase(CLITestCase):
     def test_positive_create_with_gpg_key_by_name(self):
         """Check if repository can be created with gpg key name
 
-        @id: 95cde404-3449-410d-9a08-d7f8619a2ad5
+        :id: 95cde404-3449-410d-9a08-d7f8619a2ad5
 
-        @Assert: Repository is created and has gpg key
+        :Assert: Repository is created and has gpg key
 
-        @BZ: 1103944
+        :BZ: 1103944
         """
         gpg_key = make_gpg_key({'organization-id': self.org['id']})
         for name in valid_data_list():
@@ -437,9 +436,9 @@ class RepositoryTestCase(CLITestCase):
     def test_positive_create_publish_via_http(self):
         """Create repository published via http
 
-        @id: faf6058c-9dd3-444c-ace2-c41791669e9e
+        :id: faf6058c-9dd3-444c-ace2-c41791669e9e
 
-        @Assert: Repository is created and is published via http
+        :Assert: Repository is created and is published via http
         """
         for use_http in u'true', u'yes', u'1':
             with self.subTest(use_http):
@@ -451,9 +450,9 @@ class RepositoryTestCase(CLITestCase):
     def test_positive_create_publish_via_https(self):
         """Create repository not published via http
 
-        @id: 4395a5df-207c-4b34-a42d-7b3273bd68ec
+        :id: 4395a5df-207c-4b34-a42d-7b3273bd68ec
 
-        @Assert: Repository is created and is not published via http
+        :Assert: Repository is created and is not published via http
         """
         for use_http in u'false', u'no', u'0':
             with self.subTest(use_http):
@@ -465,10 +464,10 @@ class RepositoryTestCase(CLITestCase):
     def test_positive_create_yum_repo_with_checksum_type(self):
         """Create a YUM repository with a checksum type
 
-        @id: 934f4a09-2a64-485d-ae6c-8ef73aa8fb2b
+        :id: 934f4a09-2a64-485d-ae6c-8ef73aa8fb2b
 
-        @Assert: A YUM repository is created and contains the correct checksum
-        type
+        :Assert: A YUM repository is created and contains the correct checksum
+            type
         """
         for checksum_type in u'sha1', u'sha256':
             with self.subTest(checksum_type):
@@ -485,9 +484,9 @@ class RepositoryTestCase(CLITestCase):
     def test_positive_create_docker_repo_with_upstream_name(self):
         """Create a Docker repository with upstream name.
 
-        @id: 776f92eb-8b40-4efd-8315-4fbbabcb2d4e
+        :id: 776f92eb-8b40-4efd-8315-4fbbabcb2d4e
 
-        @Assert: Docker repository is created and contains correct values.
+        :Assert: Docker repository is created and contains correct values.
         """
         content_type = u'docker'
         new_repo = self._make_repository({
@@ -506,9 +505,9 @@ class RepositoryTestCase(CLITestCase):
     def test_positive_create_docker_repo_with_name(self):
         """Create a Docker repository with a random name.
 
-        @id: b6a01434-8672-4196-b61a-dcb86c49f43b
+        :id: b6a01434-8672-4196-b61a-dcb86c49f43b
 
-        @Assert: Docker repository is created and contains correct values.
+        :Assert: Docker repository is created and contains correct values.
         """
         for name in valid_data_list():
             with self.subTest(name):
@@ -528,12 +527,12 @@ class RepositoryTestCase(CLITestCase):
     def test_positive_create_puppet_repo_same_url_different_orgs(self):
         """Create two repos with the same URL in two different organizations.
 
-        @id: b3502064-f400-4e60-a11f-b3772bd23a98
+        :id: b3502064-f400-4e60-a11f-b3772bd23a98
 
-        @Assert: Repositories are created and puppet modules are visible from
-        different organizations.
+        :Assert: Repositories are created and puppet modules are visible from
+            different organizations.
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         url = 'https://omaciel.fedorapeople.org/b3502064/'
         # Create first repo
@@ -560,9 +559,9 @@ class RepositoryTestCase(CLITestCase):
     def test_negative_create_with_name(self):
         """Repository name cannot be 300-characters long
 
-        @id: af0652d3-012d-4846-82ac-047918f74722
+        :id: af0652d3-012d-4846-82ac-047918f74722
 
-        @Assert: Repository cannot be created
+        :Assert: Repository cannot be created
         """
         for name in invalid_values_list():
             with self.subTest(name):
@@ -573,9 +572,9 @@ class RepositoryTestCase(CLITestCase):
     def test_negative_create_with_auth_url_with_special_characters(self):
         """Verify that repository URL cannot contain unquoted special characters
 
-        @id: 2bd5ee17-0fe5-43cb-9cdc-dc2178c5374c
+        :id: 2bd5ee17-0fe5-43cb-9cdc-dc2178c5374c
 
-        @Assert: Repository cannot be created
+        :Assert: Repository cannot be created
         """
         # get a list of valid credentials without quoting them
         for cred in [creds for creds in valid_http_credentials()
@@ -589,9 +588,9 @@ class RepositoryTestCase(CLITestCase):
     def test_negative_create_with_auth_url_too_long(self):
         """Verify that repository URL length is limited
 
-        @id: de356c66-4237-4421-89e3-f4f8bbe6f526
+        :id: de356c66-4237-4421-89e3-f4f8bbe6f526
 
-        @Assert: Repository cannot be created
+        :Assert: Repository cannot be created
         """
         for cred in invalid_http_credentials():
             with self.subTest(cred):
@@ -603,9 +602,9 @@ class RepositoryTestCase(CLITestCase):
     def test_negative_create_with_invalid_download_policy(self):
         """Verify that YUM repository cannot be created with invalid download policy
 
-        @id: 3b143bf8-7056-4c94-910d-69a451071f26
+        :id: 3b143bf8-7056-4c94-910d-69a451071f26
 
-        @Assert: YUM repository is not created with invalid download policy
+        :Assert: YUM repository is not created with invalid download policy
         """
         with self.assertRaises(CLIFactoryError):
             self._make_repository({
@@ -617,9 +616,9 @@ class RepositoryTestCase(CLITestCase):
     def test_negative_update_to_invalid_download_policy(self):
         """Verify that YUM repository cannot be updated to invalid download policy
 
-        @id: 5bd6a2e4-7ff0-42ac-825a-6b2a2f687c89
+        :id: 5bd6a2e4-7ff0-42ac-825a-6b2a2f687c89
 
-        @Assert: YUM repository is not updated to invalid download policy
+        :Assert: YUM repository is not updated to invalid download policy
         """
         with self.assertRaises(CLIReturnCodeError):
             new_repo = self._make_repository({u'content-type': u'yum'})
@@ -632,9 +631,9 @@ class RepositoryTestCase(CLITestCase):
     def test_negative_create_non_yum_with_download_policy(self):
         """Verify that non-YUM repositories cannot be created with download policy
 
-        @id: 71388973-50ea-4a20-9406-0aca142014ca
+        :id: 71388973-50ea-4a20-9406-0aca142014ca
 
-        @Assert: Non-YUM repository is not created with a download policy
+        :Assert: Non-YUM repository is not created with a download policy
         """
         os_version = get_host_os_version()
         # ostree is not supported for rhel6 so the following check
@@ -664,11 +663,11 @@ class RepositoryTestCase(CLITestCase):
     def test_positive_synchronize_yum_repo(self):
         """Check if repository can be created and synced
 
-        @id: e3a62529-edbd-4062-9246-bef5f33bdcf0
+        :id: e3a62529-edbd-4062-9246-bef5f33bdcf0
 
-        @Assert: Repository is created and synced
+        :Assert: Repository is created and synced
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         for url in FAKE_1_YUM_REPO, FAKE_3_YUM_REPO, FAKE_4_YUM_REPO:
             with self.subTest(url):
@@ -690,11 +689,11 @@ class RepositoryTestCase(CLITestCase):
     def test_positive_synchronize_auth_yum_repo(self):
         """Check if secured repository can be created and synced
 
-        @id: b0db676b-e0f0-428c-adf3-1d7c0c3599f0
+        :id: b0db676b-e0f0-428c-adf3-1d7c0c3599f0
 
-        @Assert: Repository is created and synced
+        :Assert: Repository is created and synced
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         url = FAKE_5_YUM_REPO
         for creds in [cred for cred in valid_http_credentials(url_encoded=True)
@@ -721,11 +720,11 @@ class RepositoryTestCase(CLITestCase):
     def test_negative_synchronize_auth_yum_repo(self):
         """Check if secured repo fails to synchronize with invalid credentials
 
-        @id: 809905ae-fb76-465d-9468-1f99c4274aeb
+        :id: 809905ae-fb76-465d-9468-1f99c4274aeb
 
-        @Assert: Repository is created but synchronization fails
+        :Assert: Repository is created but synchronization fails
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         url = FAKE_5_YUM_REPO
         for creds in [cred for cred in valid_http_credentials(url_encoded=True)
@@ -754,11 +753,11 @@ class RepositoryTestCase(CLITestCase):
     def test_positive_synchronize_auth_puppet_repo(self):
         """Check if secured puppet repository can be created and synced
 
-        @id: 1d2604fc-8a18-4cbe-bf4c-5c7d9fbdb82c
+        :id: 1d2604fc-8a18-4cbe-bf4c-5c7d9fbdb82c
 
-        @Assert: Repository is created and synced
+        :Assert: Repository is created and synced
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         url = FAKE_7_PUPPET_REPO
         for creds in [cred for cred in valid_http_credentials(url_encoded=True)
@@ -782,11 +781,11 @@ class RepositoryTestCase(CLITestCase):
     def test_positive_synchronize_docker_repo(self):
         """Check if Docker repository can be created and synced
 
-        @id: cb9ae788-743c-4785-98b2-6ae0c161bc9a
+        :id: cb9ae788-743c-4785-98b2-6ae0c161bc9a
 
-        @Assert: Docker repository is created and synced
+        :Assert: Docker repository is created and synced
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         new_repo = self._make_repository({
             u'content-type': u'docker',
@@ -807,13 +806,13 @@ class RepositoryTestCase(CLITestCase):
         """Check that repository content is resynced after packages were
         removed from repository
 
-        @id: dc415563-c9b8-4e3c-9d2a-f4ac251c7d35
+        :id: dc415563-c9b8-4e3c-9d2a-f4ac251c7d35
 
-        @Assert: Repository has updated non-zero packages count
+        :Assert: Repository has updated non-zero packages count
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
 
-        @BZ: 1318004
+        :BZ: 1318004
         """
         # Create repository and synchronize it
         repo = self._make_repository({
@@ -844,13 +843,13 @@ class RepositoryTestCase(CLITestCase):
         """Check that repository content is resynced after puppet modules
         were removed from repository
 
-        @id: 9e28f0ae-3875-4c1e-ad8b-d068f4409fe3
+        :id: 9e28f0ae-3875-4c1e-ad8b-d068f4409fe3
 
-        @Assert: Repository has updated non-zero puppet modules count
+        :Assert: Repository has updated non-zero puppet modules count
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
 
-        @BZ: 1318004
+        :BZ: 1318004
         """
         # Create repository and synchronize it
         repo = self._make_repository({
@@ -880,9 +879,9 @@ class RepositoryTestCase(CLITestCase):
     def test_positive_update_url(self):
         """Update the original url for a repository
 
-        @id: 1a2cf29b-5c30-4d4c-b6d1-2f227b0a0a57
+        :id: 1a2cf29b-5c30-4d4c-b6d1-2f227b0a0a57
 
-        @Assert: Repository url is updated
+        :Assert: Repository url is updated
         """
         new_repo = self._make_repository()
         # generate repo URLs with all valid credentials
@@ -910,9 +909,9 @@ class RepositoryTestCase(CLITestCase):
         """Verify that repository URL credentials cannot be updated to contain
         the forbidden characters
 
-        @id: 566553b2-d077-4fd8-8ed5-00ba75355386
+        :id: 566553b2-d077-4fd8-8ed5-00ba75355386
 
-        @Assert: Repository url not updated
+        :Assert: Repository url not updated
         """
         new_repo = self._make_repository()
         # get auth repos with credentials containing unquoted special chars
@@ -938,9 +937,9 @@ class RepositoryTestCase(CLITestCase):
     def test_negative_update_auth_url_too_long(self):
         """Update the original url for a repository to value which is too long
 
-        @id: a703de60-8631-4e31-a9d9-e51804f27f03
+        :id: a703de60-8631-4e31-a9d9-e51804f27f03
 
-        @Assert: Repository url not updated
+        :Assert: Repository url not updated
         """
         new_repo = self._make_repository()
         # generate repo URLs with all invalid credentials
@@ -966,9 +965,9 @@ class RepositoryTestCase(CLITestCase):
     def test_positive_update_gpg_key(self):
         """Update the original gpg key
 
-        @id: 367ff375-4f52-4a8c-b974-8c1c54e3fdd3
+        :id: 367ff375-4f52-4a8c-b974-8c1c54e3fdd3
 
-        @Assert: Repository gpg key is updated
+        :Assert: Repository gpg key is updated
         """
         gpg_key = make_gpg_key({'organization-id': self.org['id']})
         gpg_key_new = make_gpg_key({'organization-id': self.org['id']})
@@ -987,9 +986,9 @@ class RepositoryTestCase(CLITestCase):
     def test_positive_update_publish_method(self):
         """Update the original publishing method
 
-        @id: e7bd2667-4851-4a64-9c70-1b5eafbc3f71
+        :id: e7bd2667-4851-4a64-9c70-1b5eafbc3f71
 
-        @Assert: Repository publishing method is updated
+        :Assert: Repository publishing method is updated
         """
         new_repo = self._make_repository({
             u'publish-via-http': 'no',
@@ -1006,10 +1005,10 @@ class RepositoryTestCase(CLITestCase):
     def test_positive_update_checksum_type(self):
         """Create a YUM repository and update the checksum type
 
-        @id: 42f14257-d860-443d-b337-36fd355014bc
+        :id: 42f14257-d860-443d-b337-36fd355014bc
 
-        @Assert: A YUM repository is updated and contains the correct checksum
-        type
+        :Assert: A YUM repository is updated and contains the correct checksum
+            type
         """
         content_type = u'yum'
         repository = self._make_repository({
@@ -1032,9 +1031,9 @@ class RepositoryTestCase(CLITestCase):
     def test_positive_delete_by_id(self):
         """Check if repository can be created and deleted
 
-        @id: bcf096db-0033-4138-90a3-cb7355d5dfaf
+        :id: bcf096db-0033-4138-90a3-cb7355d5dfaf
 
-        @Assert: Repository is created and then deleted
+        :Assert: Repository is created and then deleted
         """
         for name in valid_data_list():
             with self.subTest(name):
@@ -1048,9 +1047,9 @@ class RepositoryTestCase(CLITestCase):
     def test_positive_delete_by_name(self):
         """Check if repository can be created and deleted
 
-        @id: 463980a4-dbcf-4178-83a6-1863cf59909a
+        :id: 463980a4-dbcf-4178-83a6-1863cf59909a
 
-        @Assert: Repository is created and then deleted
+        :Assert: Repository is created and then deleted
         """
         for name in valid_data_list():
             with self.subTest(name):
@@ -1067,9 +1066,9 @@ class RepositoryTestCase(CLITestCase):
     def test_positive_delete_rpm(self):
         """Check if rpm repository with packages can be deleted.
 
-        @id: 1172492f-d595-4c8e-89c1-fabb21eb04ac
+        :id: 1172492f-d595-4c8e-89c1-fabb21eb04ac
 
-        @Assert: Repository is deleted.
+        :Assert: Repository is deleted.
         """
         new_repo = self._make_repository({
             u'content-type': u'yum', u'url': FAKE_1_YUM_REPO})
@@ -1087,11 +1086,11 @@ class RepositoryTestCase(CLITestCase):
     def test_positive_delete_puppet(self):
         """Check if puppet repository with puppet modules can be deleted.
 
-        @id: 83d92454-11b7-4f9a-952d-650ffe5135e4
+        :id: 83d92454-11b7-4f9a-952d-650ffe5135e4
 
-        @Assert: Repository is deleted.
+        :Assert: Repository is deleted.
 
-        @BZ: 1316681
+        :BZ: 1316681
         """
         new_repo = self._make_repository({
             u'content-type': u'puppet', u'url': FAKE_1_PUPPET_REPO})
@@ -1110,11 +1109,11 @@ class RepositoryTestCase(CLITestCase):
     def test_positive_remove_content_by_repo_name(self):
         """Synchronize repository and remove rpm content from using repo name
 
-        @id: a8b6f17d-3b13-4185-920a-2558ace59458
+        :id: a8b6f17d-3b13-4185-920a-2558ace59458
 
-        @Assert: Content Counts shows zero packages
+        :Assert: Content Counts shows zero packages
 
-        @BZ: 1349646, 1413145
+        :BZ: 1349646, 1413145
         """
         # Create repository and synchronize it
         repo = self._make_repository({
@@ -1153,9 +1152,9 @@ class RepositoryTestCase(CLITestCase):
     def test_positive_remove_content_rpm(self):
         """Synchronize repository and remove rpm content from it
 
-        @id: c4bcda0e-c0d6-424c-840d-26684ca7c9f1
+        :id: c4bcda0e-c0d6-424c-840d-26684ca7c9f1
 
-        @Assert: Content Counts shows zero packages
+        :Assert: Content Counts shows zero packages
         """
         # Create repository and synchronize it
         repo = self._make_repository({
@@ -1180,9 +1179,9 @@ class RepositoryTestCase(CLITestCase):
     def test_positive_remove_content_puppet(self):
         """Synchronize repository and remove puppet content from it
 
-        @id: b025ccd0-9beb-4ac0-9fbf-21340c90650e
+        :id: b025ccd0-9beb-4ac0-9fbf-21340c90650e
 
-        @Assert: Content Counts shows zero puppet modules
+        :Assert: Content Counts shows zero puppet modules
         """
         # Create repository and synchronize it
         repo = self._make_repository({
@@ -1207,9 +1206,9 @@ class RepositoryTestCase(CLITestCase):
     def test_positive_upload_content(self):
         """Create repository and upload content
 
-        @id: eb0ec599-2bf1-483a-8215-66652f948d67
+        :id: eb0ec599-2bf1-483a-8215-66652f948d67
 
-        @Assert: upload content is successful
+        :Assert: upload content is successful
         """
         new_repo = self._make_repository({'name': gen_string('alpha', 15)})
         ssh.upload_file(local_file=get_data_file(RPM_TO_UPLOAD),
@@ -1230,9 +1229,9 @@ class RepositoryTestCase(CLITestCase):
     def test_positive_upload_content_srpm(self):
         """Create repository and upload a SRPM content
 
-        @id: 706dc3e2-dacb-4fdd-8eef-5715ce498888
+        :id: 706dc3e2-dacb-4fdd-8eef-5715ce498888
 
-        @Assert: File successfully uploaded
+        :Assert: File successfully uploaded
         """
         new_repo = self._make_repository({'name': gen_string('alpha', 15)})
         ssh.upload_file(local_file=get_data_file(SRPM_TO_UPLOAD),
@@ -1274,9 +1273,9 @@ class OstreeRepositoryTestCase(CLITestCase):
     def test_positive_create_ostree_repo(self):
         """Create a ostree repository
 
-        @id: a93c52e1-b32e-4590-981b-636ae8b8314d
+        :id: a93c52e1-b32e-4590-981b-636ae8b8314d
 
-        @Assert: ostree repository is created
+        :Assert: ostree repository is created
         """
         for name in valid_data_list():
             with self.subTest(name):
@@ -1294,9 +1293,9 @@ class OstreeRepositoryTestCase(CLITestCase):
     def test_negative_create_ostree_repo_with_checksum(self):
         """Create a ostree repository with checksum type
 
-        @id: a334e0f7-e1be-4add-bbf2-2fd9f0b982c4
+        :id: a334e0f7-e1be-4add-bbf2-2fd9f0b982c4
 
-        @Assert: Validation error is raised
+        :Assert: Validation error is raised
         """
         for checksum_type in u'sha1', u'sha256':
             with self.subTest(checksum_type):
@@ -1316,9 +1315,9 @@ class OstreeRepositoryTestCase(CLITestCase):
     def test_negative_create_unprotected_ostree_repo(self):
         """Create a ostree repository and published via http
 
-        @id: 2b139560-65bb-4a40-9724-5cca57bd8d30
+        :id: 2b139560-65bb-4a40-9724-5cca57bd8d30
 
-        @Assert: ostree repository is not created
+        :Assert: ostree repository is not created
         """
         for use_http in u'true', u'yes', u'1':
             with self.subTest(use_http):
@@ -1337,11 +1336,11 @@ class OstreeRepositoryTestCase(CLITestCase):
     def test_positive_synchronize_ostree_repo(self):
         """Synchronize ostree repo
 
-        @id: 64fcae0a-44ae-46ae-9938-032bba1331e9
+        :id: 64fcae0a-44ae-46ae-9938-032bba1331e9
 
-        @Assert: Ostree repository is created and synced
+        :Assert: Ostree repository is created and synced
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         new_repo = self._make_repository({
             u'content-type': u'ostree',
@@ -1358,9 +1357,9 @@ class OstreeRepositoryTestCase(CLITestCase):
     def test_positive_delete_ostree_by_name(self):
         """Delete Ostree repository by name
 
-        @id: 0b545c22-acff-47b6-92ff-669b348f9fa6
+        :id: 0b545c22-acff-47b6-92ff-669b348f9fa6
 
-        @Assert: Repository is deleted by name
+        :Assert: Repository is deleted by name
         """
         new_repo = self._make_repository({
             u'content-type': u'ostree',
@@ -1379,9 +1378,9 @@ class OstreeRepositoryTestCase(CLITestCase):
     def test_positive_delete_ostree_by_id(self):
         """Delete Ostree repository by id
 
-        @id: 171917f5-1a1b-440f-90c7-b8418f1da132
+        :id: 171917f5-1a1b-440f-90c7-b8418f1da132
 
-        @Assert: Repository is deleted by id
+        :Assert: Repository is deleted by id
         """
         new_repo = self._make_repository({
             u'content-type': u'ostree',
@@ -1407,9 +1406,9 @@ class SRPMRepositoryTestCase(CLITestCase):
     def test_positive_sync(self):
         """Synchronize repository with SRPMs
 
-        @id: eb69f840-122d-4180-b869-1bd37518480c
+        :id: eb69f840-122d-4180-b869-1bd37518480c
 
-        @Assert: srpms can be listed in repository
+        :Assert: srpms can be listed in repository
         """
         repo = make_repository({
             'product-id': self.product['id'],
@@ -1433,9 +1432,9 @@ class SRPMRepositoryTestCase(CLITestCase):
         """Synchronize repository with SRPMs, add repository to content view
         and publish content view
 
-        @id: 78cd6345-9c6c-490a-a44d-2ad64b7e959b
+        :id: 78cd6345-9c6c-490a-a44d-2ad64b7e959b
 
-        @Assert: srpms can be listed in content view
+        :Assert: srpms can be listed in content view
         """
         repo = make_repository({
             'product-id': self.product['id'],
@@ -1466,10 +1465,10 @@ class SRPMRepositoryTestCase(CLITestCase):
         """Synchronize repository with SRPMs, add repository to content view,
         publish and promote content view to lifecycle environment
 
-        @id: 3d197118-b1fa-456f-980e-ad1a517bc769
+        :id: 3d197118-b1fa-456f-980e-ad1a517bc769
 
-        @Assert: srpms can be listed in content view in proper lifecycle
-        environment
+        :Assert: srpms can be listed in content view in proper lifecycle
+            environment
         """
         lce = make_lifecycle_environment({'organization-id': self.org['id']})
         repo = make_repository({
@@ -1518,9 +1517,9 @@ class DRPMRepositoryTestCase(CLITestCase):
     def test_positive_sync(self):
         """Synchronize repository with DRPMs
 
-        @id: a645966c-750b-40ef-a264-dc3bb632b9fd
+        :id: a645966c-750b-40ef-a264-dc3bb632b9fd
 
-        @Assert: drpms can be listed in repository
+        :Assert: drpms can be listed in repository
         """
         repo = make_repository({
             'product-id': self.product['id'],
@@ -1544,9 +1543,9 @@ class DRPMRepositoryTestCase(CLITestCase):
         """Synchronize repository with DRPMs, add repository to content view
         and publish content view
 
-        @id: 014bfc80-4622-422e-a0ec-755b1d9f845e
+        :id: 014bfc80-4622-422e-a0ec-755b1d9f845e
 
-        @Assert: drpms can be listed in content view
+        :Assert: drpms can be listed in content view
         """
         repo = make_repository({
             'product-id': self.product['id'],
@@ -1577,10 +1576,10 @@ class DRPMRepositoryTestCase(CLITestCase):
         """Synchronize repository with DRPMs, add repository to content view,
         publish and promote content view to lifecycle environment
 
-        @id: a01cb12b-d388-4902-8532-714f4e28ec56
+        :id: a01cb12b-d388-4902-8532-714f4e28ec56
 
-        @Assert: drpms can be listed in content view in proper lifecycle
-        environment
+        :Assert: drpms can be listed in content view in proper lifecycle
+            environment
         """
         lce = make_lifecycle_environment({'organization-id': self.org['id']})
         repo = make_repository({
@@ -1633,20 +1632,18 @@ class GitPuppetMirrorTestCase(CLITestCase):
     def test_positive_git_local_create(self):
         """Create repository with local git puppet mirror.
 
-        @id: 89211cd5-82b8-4391-b729-a7502e57f824
+        :id: 89211cd5-82b8-4391-b729-a7502e57f824
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
 
-        @Setup: Assure local GIT puppet has been created and found by pulp
+        :Setup: Assure local GIT puppet has been created and found by pulp
 
-        @Steps:
+        :Steps: Create link to local puppet mirror via cli
 
-        1.  Create link to local puppet mirror via cli
+        :Assert: Content source containing local GIT puppet mirror content is
+            created
 
-        @Assert: Content source containing local GIT puppet mirror content
-        is created
-
-        @CaseAutomation: notautomated
+        :CaseAutomation: notautomated
         """
 
     @stubbed()
@@ -1654,20 +1651,18 @@ class GitPuppetMirrorTestCase(CLITestCase):
     def test_positive_git_local_update(self):
         """Update repository with local git puppet mirror.
 
-        @id: 341f40f2-3501-4754-9acf-7cda1a61f7db
+        :id: 341f40f2-3501-4754-9acf-7cda1a61f7db
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
 
-        @Setup: Assure local GIT puppet has been created and found by pulp
+        :Setup: Assure local GIT puppet has been created and found by pulp
 
-        @Steps:
+        :Steps: Modify details for existing puppet repo (name, etc.) via cli
 
-        1.  Modify details for existing puppet repo (name, etc.) via cli
+        :Assert: Content source containing local GIT puppet mirror content is
+            modified
 
-        @Assert: Content source containing local GIT puppet mirror content
-        is modified
-
-        @CaseAutomation: notautomated
+        :CaseAutomation: notautomated
         """
 
     @stubbed()
@@ -1675,20 +1670,18 @@ class GitPuppetMirrorTestCase(CLITestCase):
     def test_positive_git_local_delete(self):
         """Delete repository with local git puppet mirror.
 
-        @id: a243f5bb-5186-41b3-8e8a-07d5cc784ccd
+        :id: a243f5bb-5186-41b3-8e8a-07d5cc784ccd
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
 
-        @Setup: Assure local GIT puppet has been created and found by pulp
+        :Setup: Assure local GIT puppet has been created and found by pulp
 
-        @Steps:
+        :Steps: Delete link to local puppet mirror via cli
 
-        1.  Delete link to local puppet mirror via cli
+        :Assert: Content source containing local GIT puppet mirror content no
+            longer exists/is available.
 
-        @Assert: Content source containing local GIT puppet mirror content
-        no longer exists/is available.
-
-        @CaseAutomation: notautomated
+        :CaseAutomation: notautomated
         """
 
     @stubbed()
@@ -1696,20 +1689,18 @@ class GitPuppetMirrorTestCase(CLITestCase):
     def test_positive_git_remote_create(self):
         """Create repository with remote git puppet mirror.
 
-        @id: 8582529f-3112-4b49-8d8f-f2bbf7dceca7
+        :id: 8582529f-3112-4b49-8d8f-f2bbf7dceca7
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
 
-        @Setup: Assure remote GIT puppet has been created and found by pulp
+        :Setup: Assure remote GIT puppet has been created and found by pulp
 
-        @Steps:
+        :Steps: Create link to local puppet mirror via cli
 
-        1.  Create link to local puppet mirror via cli
+        :Assert: Content source containing remote GIT puppet mirror content is
+            created
 
-        @Assert: Content source containing remote GIT puppet mirror content
-        is created
-
-        @CaseAutomation: notautomated
+        :CaseAutomation: notautomated
         """
 
     @stubbed()
@@ -1717,20 +1708,18 @@ class GitPuppetMirrorTestCase(CLITestCase):
     def test_positive_git_remote_update(self):
         """Update repository with remote git puppet mirror.
 
-        @id: 582c50b3-3b90-4244-b694-97642b1b13a9
+        :id: 582c50b3-3b90-4244-b694-97642b1b13a9
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
 
-        @Setup: Assure remote  GIT puppet has been created and found by pulp
+        :Setup: Assure remote  GIT puppet has been created and found by pulp
 
-        @Steps:
+        :Steps: modify details for existing puppet repo (name, etc.) via cli
 
-        1.  modify details for existing puppet repo (name, etc.) via cli
+        :Assert: Content source containing remote GIT puppet mirror content is
+            modified
 
-        @Assert: Content source containing remote GIT puppet mirror content
-        is modified
-
-        @CaseAutomation: notautomated
+        :CaseAutomation: notautomated
         """
 
     @stubbed()
@@ -1738,42 +1727,39 @@ class GitPuppetMirrorTestCase(CLITestCase):
     def test_positive_git_remote_delete(self):
         """Delete repository with remote git puppet mirror.
 
-        @id: 0a23f969-b202-4c6c-b12e-f651a0b7d049
+        :id: 0a23f969-b202-4c6c-b12e-f651a0b7d049
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
 
-        @Setup: Assure remote GIT puppet has been created and found by pulp
+        :Setup: Assure remote GIT puppet has been created and found by pulp
 
-        @Steps:
+        :Steps: Delete link to remote puppet mirror via cli
 
-        1.  Delete link to remote puppet mirror via cli
+        :Assert: Content source containing remote GIT puppet mirror content no
+            longer exists/is available.
 
-        @Assert: Content source containing remote GIT puppet mirror content
-        no longer exists/is available.
-
-        @CaseAutomation: notautomated
+        :CaseAutomation: notautomated
         """
 
     @stubbed()
     @tier2
     def test_positive_git_sync(self):
         """Sync repository with git puppet mirror.
-        @id: a46c16bd-0986-48db-8e62-aeb3907ba4d2
 
-        @CaseLevel: Integration
+        :id: a46c16bd-0986-48db-8e62-aeb3907ba4d2
 
-        @Setup: git mirror (local or remote) exists as a content source
+        :CaseLevel: Integration
 
-        @Steps:
+        :Setup: git mirror (local or remote) exists as a content source
 
-        1.  Attempt to sync content from mirror via cli
+        :Steps: Attempt to sync content from mirror via cli
 
-        @Assert: Content is pulled down without error
+        :Assert: Content is pulled down without error
 
-        @Assert: Confirmation that various resources actually exist in
-        local content repo
+        :Assert: Confirmation that various resources actually exist in local
+            content repo
 
-        @CaseAutomation: notautomated
+        :CaseAutomation: notautomated
         """
 
     @stubbed()
@@ -1783,25 +1769,25 @@ class GitPuppetMirrorTestCase(CLITestCase):
         If module changes in GIT mirror but the version in manifest
         does not change, content still pulled.
 
-        @id: 7d9519ca-8660-4014-8e0e-836594891c0c
+        :id: 7d9519ca-8660-4014-8e0e-836594891c0c
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
 
-        @Setup: Assure remote GIT puppet has been created and found by pulp
+        :Setup: Assure remote GIT puppet has been created and found by pulp
 
-        @Steps:
+        :Steps:
+            1.  Sync a git repo and observe the contents/checksum etc. of an
+                existing puppet module
+            2.  Assure a puppet module in git repo has changed but the manifest
+                version for this module does not change.
+            3.  Using pulp script, update repo mirror and re-sync within
+                satellite
+            4.  View contents/details of same puppet module
 
-        1.  Sync a git repo and observe the contents/checksum etc. of an
-            existing puppet module
-        2.  Assure a puppet module in git repo has changed but the manifest
-            version for this module does not change.
-        3.  Using pulp script, update repo mirror and re-sync within satellite
-        4.  View contents/details of same puppet module
+        :Assert: Puppet module has been updated in our content, even though the
+            module's version number has not changed.
 
-        @Assert: Puppet module has been updated in our content, even though
-        the module's version number has not changed.
-
-        @CaseAutomation: notautomated
+        :CaseAutomation: notautomated
         """
 
     @stubbed()
@@ -1809,19 +1795,17 @@ class GitPuppetMirrorTestCase(CLITestCase):
     def test_positive_git_sync_schedule(self):
         """Scheduled sync of git puppet mirror.
 
-        @id: 0d58d180-9836-4524-b608-66b67f9cab12
+        :id: 0d58d180-9836-4524-b608-66b67f9cab12
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
 
-        @Setup: git mirror (local or remote) exists as a content source
+        :Setup: git mirror (local or remote) exists as a content source
 
-        @Steps:
+        :Steps: Attempt to create a scheduled sync content from mirror, via cli
 
-        1.  Attempt to create a scheduled sync content from mirror, via cli
+        :Assert: Content is pulled down without error  on expected schedule
 
-        @Assert: Content is pulled down without error  on expected schedule
-
-        @CaseAutomation: notautomated
+        :CaseAutomation: notautomated
         """
 
     @stubbed()
@@ -1829,18 +1813,16 @@ class GitPuppetMirrorTestCase(CLITestCase):
     def test_positive_git_view_content(self):
         """View content in synced git puppet mirror
 
-        @id: 02f06092-dd6c-49fa-be9f-831e52476e41
+        :id: 02f06092-dd6c-49fa-be9f-831e52476e41
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
 
-        @Setup: git mirror (local or remote) exists as a content source
+        :Setup: git mirror (local or remote) exists as a content source
 
-        @Steps:
+        :Steps: Attempt to list contents of repo via cli
 
-        1.  Attempt to list contents of repo via cli
+        :Assert: Spot-checked items (filenames, dates, perhaps checksums?) are
+            correct.
 
-        @Assert: Spot-checked items (filenames, dates, perhaps checksums?)
-        are correct.
-
-        @CaseAutomation: notautomated
+        :CaseAutomation: notautomated
         """

--- a/tests/foreman/cli/test_repository_set.py
+++ b/tests/foreman/cli/test_repository_set.py
@@ -1,18 +1,18 @@
 """Tests for cli repository set
 
-@Requirement: Repository set
+:Requirement: Repository set
 
-@CaseAutomation: Automated
+:CaseAutomation: Automated
 
-@CaseLevel: Acceptance
+:CaseLevel: Acceptance
 
-@CaseComponent: CLI
+:CaseComponent: CLI
 
-@TestType: Functional
+:TestType: Functional
 
-@CaseImportance: High
+:CaseImportance: High
 
-@Upstream: No
+:Upstream: No
 """
 from robottelo.cli.factory import make_org
 from robottelo.cli.product import Product
@@ -33,10 +33,10 @@ class RepositorySetTestCase(CLITestCase):
     def test_positive_list_available_repositories(self):
         """List available repositories for repository-set
 
-        @id: 987d6b08-acb0-4264-a459-9cef0d2c6f3f
+        :id: 987d6b08-acb0-4264-a459-9cef0d2c6f3f
 
-        @Assert: List of available repositories is displayed, with
-        valid amount of enabled repositories
+        :Assert: List of available repositories is displayed, with valid amount
+            of enabled repositories
         """
         rhel_product_name = PRDS['rhel']
         rhel_repo_set = REPOSET['rhva6']
@@ -145,9 +145,9 @@ class RepositorySetTestCase(CLITestCase):
     def test_positive_enable_by_name(self):
         """Enable repo from reposet by names of reposet, org and product
 
-        @id: a78537bd-b88d-4f00-8901-e7944e5de729
+        :id: a78537bd-b88d-4f00-8901-e7944e5de729
 
-        @Assert: Repository was enabled
+        :Assert: Repository was enabled
         """
         org = make_org()
         with manifests.clone() as manifest:
@@ -181,9 +181,9 @@ class RepositorySetTestCase(CLITestCase):
         """Enable repo from reposet by org label, reposet and product
         names
 
-        @id: 5230c1cd-fed7-40ac-8445-bac4f9c5ee68
+        :id: 5230c1cd-fed7-40ac-8445-bac4f9c5ee68
 
-        @Assert: Repository was enabled
+        :Assert: Repository was enabled
         """
         org = make_org()
         with manifests.clone() as manifest:
@@ -216,9 +216,9 @@ class RepositorySetTestCase(CLITestCase):
     def test_positive_enable_by_id(self):
         """Enable repo from reposet by IDs of reposet, org and product
 
-        @id: f7c88534-1d45-45d9-9b87-c50c4e268e8d
+        :id: f7c88534-1d45-45d9-9b87-c50c4e268e8d
 
-        @Assert: Repository was enabled
+        :Assert: Repository was enabled
         """
         org = make_org()
         with manifests.clone() as manifest:
@@ -261,9 +261,9 @@ class RepositorySetTestCase(CLITestCase):
         """Disable repo from reposet by names of reposet, org and
         product
 
-        @id: 1690a701-ae41-4724-bbc6-b0adba5a5319
+        :id: 1690a701-ae41-4724-bbc6-b0adba5a5319
 
-        @Assert: Repository was disabled
+        :Assert: Repository was disabled
         """
         org = make_org()
         with manifests.clone() as manifest:
@@ -304,9 +304,9 @@ class RepositorySetTestCase(CLITestCase):
         """Disable repo from reposet by org label, reposet and product
         names
 
-        @id: a87a5df6-f8ab-469e-94e5-ca79378f8dbe
+        :id: a87a5df6-f8ab-469e-94e5-ca79378f8dbe
 
-        @Assert: Repository was disabled
+        :Assert: Repository was disabled
         """
         org = make_org()
         with manifests.clone() as manifest:
@@ -346,9 +346,9 @@ class RepositorySetTestCase(CLITestCase):
     def test_positive_disable_by_id(self):
         """Disable repo from reposet by IDs of reposet, org and product
 
-        @id: 0d6102ba-3fb9-4eb8-972e-d537e252a8e6
+        :id: 0d6102ba-3fb9-4eb8-972e-d537e252a8e6
 
-        @Assert: Repository was disabled
+        :Assert: Repository was disabled
         """
         org = make_org()
         with manifests.clone() as manifest:

--- a/tests/foreman/cli/test_role.py
+++ b/tests/foreman/cli/test_role.py
@@ -1,19 +1,19 @@
 # -*- encoding: utf-8 -*-
 """Test for Roles CLI
 
-@Requirement: Role
+:Requirement: Role
 
-@CaseAutomation: Automated
+:CaseAutomation: Automated
 
-@CaseLevel: Acceptance
+:CaseLevel: Acceptance
 
-@CaseComponent: CLI
+:CaseComponent: CLI
 
-@TestType: Functional
+:TestType: Functional
 
-@CaseImportance: High
+:CaseImportance: High
 
-@Upstream: No
+:Upstream: No
 """
 from fauxfactory import gen_string
 from robottelo.cli.base import CLIReturnCodeError
@@ -32,11 +32,11 @@ class RoleTestCase(CLITestCase):
     def test_positive_create_with_name(self):
         """Create new roles with provided name
 
-        @id: 6883177c-6926-428c-92ab-9effbe1372ae
+        :id: 6883177c-6926-428c-92ab-9effbe1372ae
 
-        @Assert: Role is created and has correct name
+        :Assert: Role is created and has correct name
 
-        @BZ: 1138553
+        :BZ: 1138553
         """
         for name in generate_strings_list(length=10):
             with self.subTest(name):
@@ -47,9 +47,9 @@ class RoleTestCase(CLITestCase):
     def test_positive_create_with_filter(self):
         """Create new role with a filter
 
-        @id: 6c99ee25-4e58-496c-af42-f8ad2da6cf07
+        :id: 6c99ee25-4e58-496c-af42-f8ad2da6cf07
 
-        @assert: Role is created and correct filter is assigned
+        :assert: Role is created and correct filter is assigned
         """
         role = make_role()
         # Pick permissions by its resource type
@@ -69,9 +69,9 @@ class RoleTestCase(CLITestCase):
     def test_positive_create_with_permission(self):
         """Create new role with a set of permission
 
-        @id: 7cb2b2e2-ad4d-41e9-b6b2-c0366eb09b9a
+        :id: 7cb2b2e2-ad4d-41e9-b6b2-c0366eb09b9a
 
-        @assert: Role is created and has correct set of permissions
+        :assert: Role is created and has correct set of permissions
         """
         role = make_role()
         # Pick permissions by its resource type
@@ -94,9 +94,9 @@ class RoleTestCase(CLITestCase):
     def test_positive_delete_by_id(self):
         """Create a new role and then delete role by its ID
 
-        @id: 351780b4-697c-4f87-b989-dd9a9a2ad012
+        :id: 351780b4-697c-4f87-b989-dd9a9a2ad012
 
-        @Assert: Role is created and then deleted by its ID
+        :Assert: Role is created and then deleted by its ID
         """
         for name in generate_strings_list(length=10):
             with self.subTest(name):
@@ -110,9 +110,9 @@ class RoleTestCase(CLITestCase):
     def test_positive_update_name(self):
         """Create new role and update its name
 
-        @id: 3ce1b337-fd52-4460-b8a8-df49c94ffed1
+        :id: 3ce1b337-fd52-4460-b8a8-df49c94ffed1
 
-        @Assert: Role is created and its name is updated
+        :Assert: Role is created and its name is updated
         """
         role = make_role({'name': gen_string('alpha', 15)})
         for new_name in generate_strings_list(length=10):
@@ -133,13 +133,13 @@ class CannedRoleTestCases(CLITestCase):
     def test_positive_create_role_with_taxonomies(self):
         """create role with taxonomies
 
-        @id: 4ce9fd35-4d3d-47f7-8bc6-7cf0b3b2d2f5
+        :id: 4ce9fd35-4d3d-47f7-8bc6-7cf0b3b2d2f5
 
-        @steps: Create new role with taxonomies
+        :steps: Create new role with taxonomies
 
-        @assert: New role is created with taxonomies
+        :assert: New role is created with taxonomies
 
-        @caseautomation: notautomated
+        :caseautomation: notautomated
         """
 
     @stubbed
@@ -147,13 +147,13 @@ class CannedRoleTestCases(CLITestCase):
     def test_positive_create_role_without_taxonomies(self):
         """Create role without taxonomies
 
-        @id: 4dc80114-9629-487f-805c-c14241bdcde1
+        :id: 4dc80114-9629-487f-805c-c14241bdcde1
 
-        @steps: Create new role without any taxonomies
+        :steps: Create new role without any taxonomies
 
-        @assert: New role is created without taxonomies
+        :assert: New role is created without taxonomies
 
-        @caseautomation: notautomated
+        :caseautomation: notautomated
         """
 
     @stubbed
@@ -161,20 +161,20 @@ class CannedRoleTestCases(CLITestCase):
     def test_positive_create_filter_without_override(self):
         """Create filter in role w/o overriding it
 
-        @id: 247ab670-29e6-4c14-9140-51966f4632f4
+        :id: 247ab670-29e6-4c14-9140-51966f4632f4
 
-        @steps:
+        :steps:
 
-        1. Create a role with taxonomies assigned
-        2. Create filter in role without overriding it
+            1. Create a role with taxonomies assigned
+            2. Create filter in role without overriding it
 
-        @assert:
+        :assert:
 
-        1. Filter w/o override is created in role
-        2. The taxonomies of role are inherited to filter
-        3. Override check is not marked by default in filters table
+            1. Filter w/o override is created in role
+            2. The taxonomies of role are inherited to filter
+            3. Override check is not marked by default in filters table
 
-        @caseautomation: notautomated
+        :caseautomation: notautomated
         """
 
     @stubbed
@@ -182,19 +182,19 @@ class CannedRoleTestCases(CLITestCase):
     def test_positive_create_non_overridable_filter(self):
         """Create non overridable filter in role
 
-        @id: c53713a3-d4b6-47a1-b19e-8d2020f98efd
+        :id: c53713a3-d4b6-47a1-b19e-8d2020f98efd
 
-        @steps:
+        :steps:
 
-        1. Create a filter to which taxonomies cannot be associated.
-        e.g Architecture filter
+            1. Create a filter to which taxonomies cannot be associated.
+            e.g Architecture filter
 
-        @assert:
+        :assert:
 
-        1. Filter is created without taxonomies
-        2. Filter doesnt inherit taxonomies from role
+            1. Filter is created without taxonomies
+            2. Filter doesnt inherit taxonomies from role
 
-        @caseautomation: notautomated
+        :caseautomation: notautomated
         """
 
     @stubbed
@@ -202,18 +202,15 @@ class CannedRoleTestCases(CLITestCase):
     def test_negative_override_non_overridable_filter(self):
         """Override non overridable filter
 
-        @id: 163313eb-4401-4bb0-bf9a-58030251643b
+        :id: 163313eb-4401-4bb0-bf9a-58030251643b
 
-        @steps:
+        :steps: Attempt to override a filter to which taxonomies cannot be
+            associated.  e.g Architecture filter
 
-        1. Attempt to override a filter to which taxonomies cannot be
-        associated.
-        e.g Architecture filter
+        :assert: Filter is not overrided as taxonomies cannot be applied to
+            that filter
 
-        @assert: Filter is not overrided as taxonomies cannot be applied to
-        that filter
-
-        @caseautomation: notautomated
+        :caseautomation: notautomated
         """
 
     @stubbed
@@ -221,21 +218,21 @@ class CannedRoleTestCases(CLITestCase):
     def test_positive_create_overridable_filter(self):
         """Create overridable filter in role
 
-        @id: 47816636-d215-45a8-9d21-495b1e193913
+        :id: 47816636-d215-45a8-9d21-495b1e193913
 
-        @steps:
+        :steps:
 
-        1. Create a filter to which taxonomies can be associated.
-        e.g Domain filter
-        2. Override a filter with some taxonomies
+            1. Create a filter to which taxonomies can be associated.
+            e.g Domain filter
+            2. Override a filter with some taxonomies
 
-        @assert:
+        :assert:
 
-        1. Filter is created with taxonomies
-        2. Override check is set to true
-        3. Filter doesnt inherits taxonomies from role
+            1. Filter is created with taxonomies
+            2. Override check is set to true
+            3. Filter doesnt inherits taxonomies from role
 
-        @caseautomation: notautomated
+        :caseautomation: notautomated
         """
 
     @stubbed
@@ -243,15 +240,13 @@ class CannedRoleTestCases(CLITestCase):
     def test_positive_update_role_taxonomies(self):
         """Update role taxonomies which applies to its non-overrided filters
 
-        @id: 988cf8c6-8f6e-49de-be54-d17085f260b6
+        :id: 988cf8c6-8f6e-49de-be54-d17085f260b6
 
-        @steps:
+        :steps: Update existing role with different taxonomies
 
-        1. Update existing role with different taxonomies
+        :assert: The taxonomies are applied only to non-overrided role filters
 
-        @assert: The taxonomies are applied only to non-overrided role filters
-
-        @caseautomation: notautomated
+        :caseautomation: notautomated
         """
 
     @stubbed
@@ -259,15 +254,13 @@ class CannedRoleTestCases(CLITestCase):
     def test_negative_update_role_taxonomies(self):
         """Update role taxonomies which doesnt applies to its overrided filters
 
-        @id: 9d0d94fa-34ee-41a0-868d-4dc7d774fb02
+        :id: 9d0d94fa-34ee-41a0-868d-4dc7d774fb02
 
-        @steps:
+        :steps: Update existing role with different taxonomies
 
-        1. Update existing role with different taxonomies
+        :assert: The overridden role filters are not updated
 
-        @assert: The overridden role filters are not updated
-
-        @caseautomation: notautomated
+        :caseautomation: notautomated
         """
 
     @stubbed
@@ -275,17 +268,17 @@ class CannedRoleTestCases(CLITestCase):
     def test_positive_disable_filter_override(self):
         """Unset override resets filter taxonomies
 
-        @id: f00f4f1f-caee-47ac-b02e-7802300d08a8
+        :id: f00f4f1f-caee-47ac-b02e-7802300d08a8
 
-        @steps:
+        :steps:
 
-        1. Create role with overridden filter having different taxonomies than
-        its role.
-        2. Unset the override flag in above role filter
+            1. Create role with overridden filter having different taxonomies
+               than its role.
+            2. Unset the override flag in above role filter
 
-        @assert: The taxonomies of filters resets/synced to role taxonomies
+        :assert: The taxonomies of filters resets/synced to role taxonomies
 
-        @caseautomation: notautomated
+        :caseautomation: notautomated
         """
 
     @stubbed
@@ -293,21 +286,21 @@ class CannedRoleTestCases(CLITestCase):
     def test_positive_access_resources_from_role_taxonomies(self):
         """Test user access resources from taxonomies of assigned role
 
-        @id: 754cf23e-43ed-4d2b-b4ec-dacc77bc009d
+        :id: 754cf23e-43ed-4d2b-b4ec-dacc77bc009d
 
-        @steps:
+        :steps:
 
-        1. Create role with taxonomies
-        2. Create resource(s) filter(s) without overriding them
-        3. Create user with taxonomies same as role taxonomies
-        4. Assign step 1 role to user
+            1. Create role with taxonomies
+            2. Create resource(s) filter(s) without overriding them
+            3. Create user with taxonomies same as role taxonomies
+            4. Assign step 1 role to user
 
-        @assert: User should be able to access the resource(s) of the assigned
-        role
+        :assert: User should be able to access the resource(s) of the assigned
+            role
 
-        @caseautomation: notautomated
+        :caseautomation: notautomated
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
 
     @stubbed
@@ -316,19 +309,19 @@ class CannedRoleTestCases(CLITestCase):
         """Test user cannot access resources from non associated taxonomies to
         role
 
-        @id: 8a82e935-c5f1-460f-b1ff-1203b9c88df9
+        :id: 8a82e935-c5f1-460f-b1ff-1203b9c88df9
 
-        @steps:
+        :steps:
 
-        1. Create role with taxonomies
-        2. Create resource(s) filter(s) without overriding them
-        3. Create user with taxonomies not matching role taxonomies
-        4. Assign step 1 role to user
+            1. Create role with taxonomies
+            2. Create resource(s) filter(s) without overriding them
+            3. Create user with taxonomies not matching role taxonomies
+            4. Assign step 1 role to user
 
-        @assert: User should not be able to access the resource(s) that are not
-        associated to assigned role
+        :assert: User should not be able to access the resource(s) that are not
+            associated to assigned role
 
-        @caseautomation: notautomated
+        :caseautomation: notautomated
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """

--- a/tests/foreman/cli/test_satellitesync.py
+++ b/tests/foreman/cli/test_satellitesync.py
@@ -1,19 +1,19 @@
 # -*- encoding: utf-8 -*-
 """Test class for InterSatellite Sync
 
-@Requirement: Satellitesync
+:Requirement: Satellitesync
 
-@CaseAutomation: Automated
+:CaseAutomation: Automated
 
-@CaseLevel: Acceptance
+:CaseLevel: Acceptance
 
-@CaseComponent: CLI
+:CaseComponent: CLI
 
-@TestType: Functional
+:TestType: Functional
 
-@CaseImportance: High
+:CaseImportance: High
 
-@Upstream: No
+:Upstream: No
 """
 
 from fauxfactory import gen_string
@@ -114,12 +114,12 @@ class RepositoryExportTestCase(CLITestCase):
     def test_positive_export_custom_product(self):
         """Export a repository from the custom product
 
-        @id: 9c855866-b9b1-4e32-b3eb-7342fdaa7116
+        :id: 9c855866-b9b1-4e32-b3eb-7342fdaa7116
 
-        @Assert: Repository was successfully exported, rpm files are present on
-        satellite machine
+        :Assert: Repository was successfully exported, rpm files are present on
+            satellite machine
 
-        @CaseLevel: System
+        :CaseLevel: System
         """
         # Create custom product and repository
         product = make_product({'organization-id': self.org['id']})
@@ -159,12 +159,12 @@ class RepositoryExportTestCase(CLITestCase):
     def test_positive_export_rh_product(self):
         """Export a repository from the Red Hat product
 
-        @id: e17898db-ca92-4121-a723-0d4b3cf120eb
+        :id: e17898db-ca92-4121-a723-0d4b3cf120eb
 
-        @Assert: Repository was successfully exported, rpm files are present on
-        satellite machine
+        :Assert: Repository was successfully exported, rpm files are present on
+            satellite machine
 
-        @CaseLevel: System
+        :CaseLevel: System
         """
         # Enable RH repository
         with manifests.clone() as manifest:
@@ -231,24 +231,24 @@ class InterSatelliteSyncTestCase(CLITestCase):
     def test_positive_export_import_cv(self):
         """Export CV version contents in directory and Import them.
 
-        @id: b08e9f24-f18e-43b7-9189-ad7b596ccb5b
+        :id: b08e9f24-f18e-43b7-9189-ad7b596ccb5b
 
-        @steps:
+        :steps:
 
-        1. Export whole CV version contents to a directory specified in
-           settings.
-        2. Copy exported contents to /var/www/html/pub/export directory.
-        3. Import these copied contents from some other org/satellite.
+            1. Export whole CV version contents to a directory specified in
+               settings.
+            2. Copy exported contents to /var/www/html/pub/export directory.
+            3. Import these copied contents from some other org/satellite.
 
-        @assert:
+        :assert:
 
-        1. Whole CV version contents has been exported to directory
-           specified in settings.
-        2. All The exported contents has been imported in org/satellite.
+            1. Whole CV version contents has been exported to directory
+               specified in settings.
+            2. All The exported contents has been imported in org/satellite.
 
-        @caseautomation: notautomated
+        :caseautomation: notautomated
 
-        @CaseLevel: System
+        :CaseLevel: System
         """
 
     @run_only_on('sat')
@@ -257,26 +257,27 @@ class InterSatelliteSyncTestCase(CLITestCase):
     def test_negative_import_cv(self):
         """Export whole CV version contents in directory and Import nothing.
 
-        @id: bcb4f64f-a480-4be0-a4ef-3ee1f024d8d7
+        :id: bcb4f64f-a480-4be0-a4ef-3ee1f024d8d7
 
-        @steps:
+        :steps:
 
-        1. Export whole CV version contents to a directory specified in
-           settings.
-        2. Don't copy exported contents to /var/www/html/pub/export directory.
-        3. Attempt to import these not copied contents from some other
-           org/satellite.
+            1. Export whole CV version contents to a directory specified in
+               settings.
+            2. Don't copy exported contents to /var/www/html/pub/export
+               directory.
+            3. Attempt to import these not copied contents from some other
+               org/satellite.
 
-        @assert:
+        :assert:
 
-        1. Whole CV version contents has been exported to directory specified
-           in settings.
-        2. The exported contents are not imported due to non availability.
-        3. Error is thrown for non availability of CV contents to import.
+            1. Whole CV version contents has been exported to directory
+               specified in settings.
+            2. The exported contents are not imported due to non availability.
+            3. Error is thrown for non availability of CV contents to import.
 
-        @caseautomation: notautomated
+        :caseautomation: notautomated
 
-        @CaseLevel: System
+        :CaseLevel: System
         """
 
     @run_only_on('sat')
@@ -286,21 +287,17 @@ class InterSatelliteSyncTestCase(CLITestCase):
         """Export whole CV version contents is aborted due to insufficient
         memory.
 
-        @id: 4fa58c0c-95d2-45f5-a7fc-c5f3312a989c
+        :id: 4fa58c0c-95d2-45f5-a7fc-c5f3312a989c
 
-        @steps:
+        :steps: Attempt to Export whole CV version contents to a directory
+            which has less memory available than contents size.
 
-        1. Attempt to Export whole CV version contents to a directory which
-           has less memory available than contents size.
+        :assert: The export CV version contents has been aborted due to
+            insufficient memory.
 
-        @assert:
+        :caseautomation: notautomated
 
-        1. The export CV version contents has been aborted due to insufficient
-           memory.
-
-        @caseautomation: notautomated
-
-        @CaseLevel: System
+        :CaseLevel: System
         """
 
     @run_only_on('sat')
@@ -309,24 +306,24 @@ class InterSatelliteSyncTestCase(CLITestCase):
     def test_positive_export_import_cv_iso(self):
         """Export CV version contents in directory as iso and Import it.
 
-        @id: 5c39afd4-09d6-43c5-8d50-edc98105b7db
+        :id: 5c39afd4-09d6-43c5-8d50-edc98105b7db
 
-        @steps:
+        :steps:
 
-        1. Export whole CV version contents as ISO to a directory specified in
-           settings.
-        2. Copy exported ISO to /var/www/html/pub/export directory.
-        3. Import these copied ISO from some other org/satellite.
+            1. Export whole CV version contents as ISO to a directory specified
+               in settings.
+            2. Copy exported ISO to /var/www/html/pub/export directory.
+            3. Import these copied ISO from some other org/satellite.
 
-        @assert:
+        :assert:
 
-        1. CV version has been exported to directory as ISO in specified in
-           settings.
-        2. The exported ISO has been imported in org/satellite.
+            1. CV version has been exported to directory as ISO in specified in
+               settings.
+            2. The exported ISO has been imported in org/satellite.
 
-        @caseautomation: notautomated
+        :caseautomation: notautomated
 
-        @CaseLevel: System
+        :CaseLevel: System
         """
 
     @run_only_on('sat')
@@ -335,24 +332,25 @@ class InterSatelliteSyncTestCase(CLITestCase):
     def test_negative_import_cv_iso(self):
         """Export whole CV version as ISO in directory and Import nothing.
 
-        @id: af9b3d6f-25c0-43a5-b8a7-d9a0df1986b4
+        :id: af9b3d6f-25c0-43a5-b8a7-d9a0df1986b4
 
-        @steps:
+        :steps:
 
-        1. Export whole CV version as ISO to a directory specified in
-           settings.
-        2. Don't copy exported ISO to /var/www/html/pub/export directory.
-        3. Attempt to import this not copied ISO from some other
-           org/satellite.
+            1. Export whole CV version as ISO to a directory specified in
+               settings.
+            2. Don't copy exported ISO to /var/www/html/pub/export directory.
+            3. Attempt to import this not copied ISO from some other
+               org/satellite.
 
-        @assert:
+        :assert:
 
-        2. The exported iso is not imported due to non availability.
-        3. Error is thrown for non availability of CV version ISO to import.
+            1. The exported iso is not imported due to non availability.
+            2. Error is thrown for non availability of CV version ISO to
+               import.
 
-        @caseautomation: notautomated
+        :caseautomation: notautomated
 
-        @CaseLevel: System
+        :CaseLevel: System
         """
 
     @run_only_on('sat')
@@ -362,21 +360,17 @@ class InterSatelliteSyncTestCase(CLITestCase):
         """Export whole CV version to iso is aborted due to insufficient
         memory.
 
-        @id: ef84ffbd-c7cf-4d9a-9944-3c3b06a18872
+        :id: ef84ffbd-c7cf-4d9a-9944-3c3b06a18872
 
-        @steps:
+        :steps: Attempt to Export whole CV version as iso to a directory which
+            has less memory available than contents size.
 
-        1. Attempt to Export whole CV version as iso to a directory which has
-           less memory available than contents size.
+        :assert: The export CV version to iso has been aborted due to
+            insufficient memory.
 
-        @assert:
+        :caseautomation: notautomated
 
-        1. The export CV version to iso has been aborted due to insufficient
-           memory.
-
-        @caseautomation: notautomated
-
-        @CaseLevel: System
+        :CaseLevel: System
         """
 
     @run_only_on('sat')
@@ -386,21 +380,17 @@ class InterSatelliteSyncTestCase(CLITestCase):
         """Export whole CV version to iso is aborted due to inadequate maximum
         iso size.
 
-        @id: 93fe1cef-254b-484d-a628-bec56b356234
+        :id: 93fe1cef-254b-484d-a628-bec56b356234
 
-        @steps:
+        :steps: Attempt to Export whole CV version as iso with mb size less
+            than required.
 
-        1. Attempt to Export whole CV version as iso with mb size less than
-           required.
+        :assert: The export CV version to iso has been aborted due to maximum
+            size is not enough to contain the CV version contents.
 
-        @assert:
+        :caseautomation: notautomated
 
-        1. The export CV version to iso has been aborted due to maximum size is
-           not enough to contain the CV version contents.
-
-        @caseautomation: notautomated
-
-        @CaseLevel: System
+        :CaseLevel: System
         """
 
     @run_only_on('sat')
@@ -409,20 +399,16 @@ class InterSatelliteSyncTestCase(CLITestCase):
     def test_positive_export_cv_iso_max_size(self):
         """CV version exported to iso in maximum iso size.
 
-        @id: 7ec91557-bafc-490d-b760-573a07389be5
+        :id: 7ec91557-bafc-490d-b760-573a07389be5
 
-        @steps:
+        :steps: Attempt to Export whole CV version as iso with mb size more
+            than required.
 
-        1. Attempt to Export whole CV version as iso with mb size more than
-           required.
+        :assert: CV version has been exported to iso successfully.
 
-        @assert:
+        :caseautomation: notautomated
 
-        1. CV version has been exported to iso successfully.
-
-        @caseautomation: notautomated
-
-        @CaseLevel: System
+        :CaseLevel: System
         """
 
     @run_only_on('sat')
@@ -431,27 +417,28 @@ class InterSatelliteSyncTestCase(CLITestCase):
     def test_positive_export_import_cv_incremental(self):
         """Export and Import CV version contents incrementally.
 
-        @id: 3c4dfafb-fabf-406e-bca8-7af1ab551135
+        :id: 3c4dfafb-fabf-406e-bca8-7af1ab551135
 
-        @steps:
+        :steps:
 
-        1. In upstream, Export CV version contents to a directory specified in
-           settings.
-        2. In downstream, Import these copied contents from some other
-           org/satellite.
-        3. In upstream, Add new packages to the CV.
-        4. Export the CV incrementally from the last date time.
-        5. In downstream, Import the CV incrementally.
+            1. In upstream, Export CV version contents to a directory specified
+               in settings.
+            2. In downstream, Import these copied contents from some other
+               org/satellite.
+            3. In upstream, Add new packages to the CV.
+            4. Export the CV incrementally from the last date time.
+            5. In downstream, Import the CV incrementally.
 
-        @assert:
+        :assert:
 
-        1. On incremental export, only the new packages are exported.
-        2. New directory of incremental export with new packages is created.
-        3. On incremental import, only the new packages are imported.
+            1. On incremental export, only the new packages are exported.
+            2. New directory of incremental export with new packages is
+               created.
+            3. On incremental import, only the new packages are imported.
 
-        @caseautomation: notautomated
+        :caseautomation: notautomated
 
-        @CaseLevel: System
+        :CaseLevel: System
         """
 
     @run_only_on('sat')
@@ -460,26 +447,26 @@ class InterSatelliteSyncTestCase(CLITestCase):
     def test_negative_export_import_cv_incremental(self):
         """No new incremental packages exported or imported.
 
-        @id: 90692d59-788c-4e18-add1-33db04204a4b
+        :id: 90692d59-788c-4e18-add1-33db04204a4b
 
-        @steps:
+        :steps:
 
-        1. In upstream, Export CV version contents to a directory specified in
-           settings.
-        2. In downstream, Import these copied contents from some other
-           org/satellite.
-        3. In upstream, Don't add any new packages to the CV.
-        4. Export the CV incrementally from the last date time.
-        5. In downstream, Import the CV incrementally.
+            1. In upstream, Export CV version contents to a directory specified
+               in settings.
+            2. In downstream, Import these copied contents from some other
+               org/satellite.
+            3. In upstream, Don't add any new packages to the CV.
+            4. Export the CV incrementally from the last date time.
+            5. In downstream, Import the CV incrementally.
 
-        @assert:
+        :assert:
 
-        1. An Empty packages directory created on incremental export.
-        2. On incremental import, no new packages are imported.
+            1. An Empty packages directory created on incremental export.
+            2. On incremental import, no new packages are imported.
 
-        @caseautomation: notautomated
+        :caseautomation: notautomated
 
-        @CaseLevel: System
+        :CaseLevel: System
         """
 
     @run_only_on('sat')
@@ -488,21 +475,19 @@ class InterSatelliteSyncTestCase(CLITestCase):
     def test_positive_exported_cv_iso_dir_structure(self):
         """Exported CV in iso format respects cdn directory structure.
 
-        @id: cb901dde-1839-4e7d-a57b-8e41c212dc77
+        :id: cb901dde-1839-4e7d-a57b-8e41c212dc77
 
-        @steps:
+        :steps:
 
-        1. Export the full CV in iso format.
-        2. Mount the iso.
-        3. Verify iso directory structure.
+            1. Export the full CV in iso format.
+            2. Mount the iso.
+            3. Verify iso directory structure.
 
-        @assert:
+        :assert: Exported CV in iso should follow the cdn directory structure.
 
-        1. Exported CV in iso should follow the cdn directory structure.
+        :caseautomation: notautomated
 
-        @caseautomation: notautomated
-
-        @CaseLevel: System
+        :CaseLevel: System
         """
 
     @run_only_on('sat')
@@ -511,22 +496,23 @@ class InterSatelliteSyncTestCase(CLITestCase):
     def test_positive_export_import_repo(self):
         """Export repo in directory and Import them.
 
-        @id: 2c5f09ce-225b-4f9d-ad4b-a26fe094b0e7
+        :id: 2c5f09ce-225b-4f9d-ad4b-a26fe094b0e7
 
-        @steps:
+        :steps:
 
-        1. Export repo to a directory specified in settings.
-        2. Copy exported repo contents to /var/www/html/pub/export directory.
-        3. Import these copied repo contents from some other org/satellite.
+            1. Export repo to a directory specified in settings.
+            2. Copy exported repo contents to /var/www/html/pub/export
+               directory.
+            3. Import these copied repo contents from some other org/satellite.
 
-        @assert:
+        :assert:
 
-        1. The repo has been exported to directory specified in settings.
-        2. The exported repo has been imported in org/satellite.
+            1. The repo has been exported to directory specified in settings.
+            2. The exported repo has been imported in org/satellite.
 
-        @caseautomation: notautomated
+        :caseautomation: notautomated
 
-        @CaseLevel: System
+        :CaseLevel: System
         """
 
     @run_only_on('sat')
@@ -535,24 +521,24 @@ class InterSatelliteSyncTestCase(CLITestCase):
     def test_negative_import_repo(self):
         """Export repo contents in directory and Import nothing.
 
-        @id: 8e0bbed9-bc68-44d3-a79c-2861f323e2ff
+        :id: 8e0bbed9-bc68-44d3-a79c-2861f323e2ff
 
-        @steps:
+        :steps:
 
-        1. Export repo to a directory specified in settings.
-        2. Dont copy exported repo to /var/www/html/pub/export directory.
-        3. Attempt to import this not copied repo from some other
-           org/satellite.
+            1. Export repo to a directory specified in settings.
+            2. Dont copy exported repo to /var/www/html/pub/export directory.
+            3. Attempt to import this not copied repo from some other
+               org/satellite.
 
-        @assert:
+        :assert:
 
-        1. The repo has been exported to directory specified in settings.
-        2. The exported repo are not imported due to non availability.
-        3. Error is thrown for non availability of repo contents to import.
+            1. The repo has been exported to directory specified in settings.
+            2. The exported repo are not imported due to non availability.
+            3. Error is thrown for non availability of repo contents to import.
 
-        @caseautomation: notautomated
+        :caseautomation: notautomated
 
-        @CaseLevel: System
+        :CaseLevel: System
         """
 
     @run_only_on('sat')
@@ -561,20 +547,16 @@ class InterSatelliteSyncTestCase(CLITestCase):
     def test_negative_export_repo(self):
         """Export repo is aborted due ti insufficient memory.
 
-        @id: 4bdd1183-a3a5-41a8-8a38-34c1035b64da
+        :id: 4bdd1183-a3a5-41a8-8a38-34c1035b64da
 
-        @steps:
+        :steps: Attempt to Export repo to a directory which has less memory
+            available than contents size.
 
-        1. Attempt to Export repo to a directory which has less memory
-           available than contents size.
+        :assert: The export repo has been aborted due to insufficient memory.
 
-        @assert:
+        :caseautomation: notautomated
 
-        1. The export repo has been aborted due to insufficient memory.
-
-        @caseautomation: notautomated
-
-        @CaseLevel: System
+        :CaseLevel: System
         """
 
     @run_only_on('sat')
@@ -583,20 +565,16 @@ class InterSatelliteSyncTestCase(CLITestCase):
     def test_negative_export_lazy_sync_repo(self):
         """Error is raised for lazy sync repo.
 
-        @id: 296a7bde-d8af-4e4d-b673-a7c393f6f846
+        :id: 296a7bde-d8af-4e4d-b673-a7c393f6f846
 
-        @steps:
+        :steps: Attempt to Export repo with 'on_demand' download policy.
 
-        1. Attempt to Export repo with 'on_demand' download policy.
+        :assert: An Error is raised for updating the repo download policy to
+            'immediate' to be exported.
 
-        @assert:
+        :caseautomation: notautomated
 
-        1. An Error is raised for updating the repo download policy to
-           'immediate' to be exported.
-
-        @caseautomation: notautomated
-
-        @CaseLevel: System
+        :CaseLevel: System
         """
 
     @run_only_on('sat')
@@ -605,22 +583,20 @@ class InterSatelliteSyncTestCase(CLITestCase):
     def test_positive_reimport_repo(self):
         """Packages missing from upstream are removed from downstream on reimport.
 
-        @id: b3a71405-d8f0-4085-b728-8fc3513611c8
+        :id: b3a71405-d8f0-4085-b728-8fc3513611c8
 
-        @steps:
+        :steps:
 
-        1. From upstream Export repo fully and import it in downstream.
-        2. In upstream delete some packages from repo.
-        3. Re-export the full repo.
-        4. In downstream, reimport the repo re-exported.
+            1. From upstream Export repo fully and import it in downstream.
+            2. In upstream delete some packages from repo.
+            3. Re-export the full repo.
+            4. In downstream, reimport the repo re-exported.
 
-        @assert:
+        :assert: Deleted packages from upstream are removed from downstream.
 
-        1. Deleted packages from upstream are removed from downstream.
+        :caseautomation: notautomated
 
-        @caseautomation: notautomated
-
-        @CaseLevel: System
+        :CaseLevel: System
         """
 
     @run_only_on('sat')
@@ -629,22 +605,23 @@ class InterSatelliteSyncTestCase(CLITestCase):
     def test_positive_export_import_repo_iso(self):
         """Export repo in directory as iso and Import it.
 
-        @id: 95658d9e-9f0b-466f-a412-1bebadc709c9
+        :id: 95658d9e-9f0b-466f-a412-1bebadc709c9
 
-        @steps:
+        :steps:
 
-        1. Export repo as ISO to a directory specified in settings.
-        2. Copy exported ISO to /var/www/html/pub/export directory.
-        3. Import this copied ISO from some other org/satellite.
+            1. Export repo as ISO to a directory specified in settings.
+            2. Copy exported ISO to /var/www/html/pub/export directory.
+            3. Import this copied ISO from some other org/satellite.
 
-        @assert:
+        :assert:
 
-        1. repo has been exported to directory as ISO in specified in settings.
-        2. The exported ISO has been imported in org/satellite.
+            1. repo has been exported to directory as ISO in specified in
+               settings.
+            2. The exported ISO has been imported in org/satellite.
 
-        @caseautomation: notautomated
+        :caseautomation: notautomated
 
-        @CaseLevel: System
+        :CaseLevel: System
         """
 
     @run_only_on('sat')
@@ -653,23 +630,23 @@ class InterSatelliteSyncTestCase(CLITestCase):
     def test_negative_import_repo_iso(self):
         """Export repo as ISO in directory and Import nothing.
 
-        @id: dab72a79-e508-4236-ad7e-f92bb9639b5e
+        :id: dab72a79-e508-4236-ad7e-f92bb9639b5e
 
-        @steps:
+        :steps:
 
-        1. Export repo as ISO to a directory specified in settings.
-        2. Dont copy exported ISO to /var/www/html/pub/export directory.
-        3. Attempt to import this not copied ISO from some other
-           org/satellite.
+            1. Export repo as ISO to a directory specified in settings.
+            2. Dont copy exported ISO to /var/www/html/pub/export directory.
+            3. Attempt to import this not copied ISO from some other
+               org/satellite.
 
-        @assert:
+        :assert:
 
-        2. The exported iso is not imported due to non availability.
-        3. Error is thrown for non availability of repo ISO to import.
+            1. The exported iso is not imported due to non availability.
+            2. Error is thrown for non availability of repo ISO to import.
 
-        @caseautomation: notautomated
+        :caseautomation: notautomated
 
-        @CaseLevel: System
+        :CaseLevel: System
         """
 
     @run_only_on('sat')
@@ -678,20 +655,17 @@ class InterSatelliteSyncTestCase(CLITestCase):
     def test_negative_export_repo_iso(self):
         """Export repo to iso is aborted due to insufficient memory.
 
-        @id: 028c4972-5746-463d-afd3-a1cea337ee11
+        :id: 028c4972-5746-463d-afd3-a1cea337ee11
 
-        @steps:
+        :steps: Attempt to Export repo as iso to a directory which has less
+            memory available than contents size.
 
-        1. Attempt to Export repo as iso to a directory which has less memory
-           available than contents size.
+        :assert: The export repo to iso has been aborted due to insufficient
+            memory.
 
-        @assert:
+        :caseautomation: notautomated
 
-        1. The export repo to iso has been aborted due to insufficient memory.
-
-        @caseautomation: notautomated
-
-        @CaseLevel: System
+        :CaseLevel: System
         """
 
     @run_only_on('sat')
@@ -700,20 +674,16 @@ class InterSatelliteSyncTestCase(CLITestCase):
     def test_negative_export_repo_iso_max_size(self):
         """Export repo to iso is aborted due to inadequate maximum iso size.
 
-        @id: ef2ba2ec-0ec6-4c33-9c22-e4102734eecf
+        :id: ef2ba2ec-0ec6-4c33-9c22-e4102734eecf
 
-        @steps:
+        :steps: Attempt to Export repo as iso with mb size less than required.
 
-        1. Attempt to Export repo as iso with mb size less than required.
+        :assert: The export repo to iso has been aborted due to maximum size is
+            not enough to contain the repo  contents.
 
-        @assert:
+        :caseautomation: notautomated
 
-        1. The export repo to iso has been aborted due to maximum size is not
-           enough to contain the repo  contents.
-
-        @caseautomation: notautomated
-
-        @CaseLevel: System
+        :CaseLevel: System
         """
 
     @run_only_on('sat')
@@ -722,20 +692,15 @@ class InterSatelliteSyncTestCase(CLITestCase):
     def test_positive_export_repo_iso_max_size(self):
         """Repo exported to iso with maximum iso size.
 
-        @id: 19626697-9c5e-49d1-8429-720881dfe73d
+        :id: 19626697-9c5e-49d1-8429-720881dfe73d
 
-        @steps:
+        :steps: Attempt to Export repo as iso with mb size more than required.
 
-        1. Attempt to Export repo as iso with mb size more than
-           required.
+        :assert: Repo has been exported to iso successfully.
 
-        @assert:
+        :caseautomation: notautomated
 
-        1. Repo has been exported to iso successfully.
-
-        @caseautomation: notautomated
-
-        @CaseLevel: System
+        :CaseLevel: System
         """
 
     @run_only_on('sat')
@@ -744,19 +709,15 @@ class InterSatelliteSyncTestCase(CLITestCase):
     def test_negative_export_repo_from_future_datetime(self):
         """Incremental export fails with future datetime.
 
-        @id: 1e8bc352-198f-4d59-b437-1b184141fab4
+        :id: 1e8bc352-198f-4d59-b437-1b184141fab4
 
-        @steps:
+        :steps: Export the repo incrementally from the future date time.
 
-        1. Export the repo incrementally from the future date time.
+        :assert: Error is raised for attempting to export from future datetime.
 
-        @assert:
+        :caseautomation: notautomated
 
-        1. Error is raised for attempting to export from future datetime.
-
-        @caseautomation: notautomated
-
-        @CaseLevel: System
+        :CaseLevel: System
         """
 
     @run_only_on('sat')
@@ -765,26 +726,26 @@ class InterSatelliteSyncTestCase(CLITestCase):
     def test_positive_export_import_repo_incremental(self):
         """Export and Import repo incrementally.
 
-        @id: b2537c09-4dd8-440d-be11-0728ee4be804
+        :id: b2537c09-4dd8-440d-be11-0728ee4be804
 
-        @steps:
+        :steps:
 
-        1. In upstream, Export repo to a directory specified in
-           settings.
-        2. In downstream, Import this repo fully.
-        3. In upstream, Add new packages to the repo.
-        4. Export the repo incrementally from the last date time.
-        5. In downstream, Import the repo incrementally.
+            1. In upstream, Export repo to a directory specified in settings.
+            2. In downstream, Import this repo fully.
+            3. In upstream, Add new packages to the repo.
+            4. Export the repo incrementally from the last date time.
+            5. In downstream, Import the repo incrementally.
 
-        @assert:
+        :assert:
 
-        1. On incremental export, only the new packages are exported.
-        2. New directory of incremental export with new packages is created.
-        3. On incremental import, only the new packages are imported.
+            1. On incremental export, only the new packages are exported.
+            2. New directory of incremental export with new packages is
+               created.
+            3. On incremental import, only the new packages are imported.
 
-        @caseautomation: notautomated
+        :caseautomation: notautomated
 
-        @CaseLevel: System
+        :CaseLevel: System
         """
 
     @run_only_on('sat')
@@ -793,24 +754,24 @@ class InterSatelliteSyncTestCase(CLITestCase):
     def test_negative_export_import_repo_incremental(self):
         """No new incremental packages exported or imported.
 
-        @id: b51a3718-87d0-4aa1-8bff-fa153bd72df0
+        :id: b51a3718-87d0-4aa1-8bff-fa153bd72df0
 
-        @steps:
+        :steps:
 
-        1. In upstream, Export repo to a directory specified in settings.
-        2. In downstream, fully Import this repo.
-        3. In upstream, Don't add any new packages to the repo.
-        4. Export the repo incrementally from the last date time.
-        5. In downstream, Import the repo incrementally.
+            1. In upstream, Export repo to a directory specified in settings.
+            2. In downstream, fully Import this repo.
+            3. In upstream, Don't add any new packages to the repo.
+            4. Export the repo incrementally from the last date time.
+            5. In downstream, Import the repo incrementally.
 
-        @assert:
+        :assert:
 
-        1. An Empty packages directory created on incremental export.
-        2. On incremental import, no new packages are imported.
+            1. An Empty packages directory created on incremental export.
+            2. On incremental import, no new packages are imported.
 
-        @caseautomation: notautomated
+        :caseautomation: notautomated
 
-        @CaseLevel: System
+        :CaseLevel: System
         """
 
     @run_only_on('sat')
@@ -819,21 +780,20 @@ class InterSatelliteSyncTestCase(CLITestCase):
     def test_positive_exported_repo_iso_dir_structure(self):
         """Exported repo in iso format respects cdn directory structure.
 
-        @id: 6bfc28a8-6615-4927-976a-30e7a9bb6860
+        :id: 6bfc28a8-6615-4927-976a-30e7a9bb6860
 
-        @steps:
+        :steps:
 
-        1. Export the full repo in iso format.
-        2. Mount the iso.
-        3. Verify iso directory structure.
+            1. Export the full repo in iso format.
+            2. Mount the iso.
+            3. Verify iso directory structure.
 
-        @assert:
+        :assert: Exported repo in iso should follow the cdn directory
+            structure.
 
-        1. Exported repo in iso should follow the cdn directory structure.
+        :caseautomation: notautomated
 
-        @caseautomation: notautomated
-
-        @CaseLevel: System
+        :CaseLevel: System
         """
 
     @run_only_on('sat')
@@ -842,23 +802,24 @@ class InterSatelliteSyncTestCase(CLITestCase):
     def test_positive_export_import_kickstart_tree(self):
         """kickstart tree is exported to specified location.
 
-        @id: bb9e77ed-fbbb-4e43-b118-2ddcb7c6341f
+        :id: bb9e77ed-fbbb-4e43-b118-2ddcb7c6341f
 
-        @steps:
+        :steps:
 
-        1. Export the full kickstart tree.
-        2. Copy exported kickstart tree contents to /var/www/html/pub/export.
-        3. Import above exported kickstart tree from other org/satellite.
+            1. Export the full kickstart tree.
+            2. Copy exported kickstart tree contents to
+               /var/www/html/pub/export.
+            3. Import above exported kickstart tree from other org/satellite.
 
-        @assert:
+        :assert:
 
-        1. Whole kickstart tree contents has been exported to directory
-           specified in settings.
-        2. All The exported contents has been imported in org/satellite.
+            1. Whole kickstart tree contents has been exported to directory
+               specified in settings.
+            2. All The exported contents has been imported in org/satellite.
 
-        @caseautomation: notautomated
+        :caseautomation: notautomated
 
-        @CaseLevel: System
+        :CaseLevel: System
         """
 
     @run_only_on('sat')
@@ -867,26 +828,28 @@ class InterSatelliteSyncTestCase(CLITestCase):
     def test_negative_import_kickstart_tree(self):
         """Export whole kickstart tree in directory and Import nothing.
 
-        @id: 55ddf6a6-b99a-4986-bdd3-7a5384f06915
+        :id: 55ddf6a6-b99a-4986-bdd3-7a5384f06915
 
-        @steps:
+        :steps:
 
-        1. Export whole kickstart tree contents to a directory specified in
-           settings.
-        2. Dont copy exported contents to /var/www/html/pub/export directory.
-        3. Attempt to import these not copied contents from some other
-           org/satellite.
+            1. Export whole kickstart tree contents to a directory specified in
+                settings.
+            2. Dont copy exported contents to /var/www/html/pub/export
+                directory.
+            3. Attempt to import these not copied contents from some other
+                org/satellite.
 
-        @assert:
+        :assert:
 
-        1. Whole kickstart tree has been exported to directory specified
-           in settings.
-        2. The exported contents are not imported due to non availability.
-        3. Error is thrown for non availability of kickstart tree to import.
+            1. Whole kickstart tree has been exported to directory specified in
+                settings.
+            2. The exported contents are not imported due to non availability.
+            3. Error is thrown for non availability of kickstart tree to
+                import.
 
-        @caseautomation: notautomated
+        :caseautomation: notautomated
 
-        @CaseLevel: System
+        :CaseLevel: System
         """
 
     @run_only_on('sat')
@@ -896,21 +859,17 @@ class InterSatelliteSyncTestCase(CLITestCase):
         """Export whole kickstart tree contents is aborted due to insufficient
         memory.
 
-        @id: 5f681f43-bac8-4196-9b3c-8b66b9c149f9
+        :id: 5f681f43-bac8-4196-9b3c-8b66b9c149f9
 
-        @steps:
+        :steps: Attempt to Export whole kickstart tree contents to a directory
+            which has less memory available than contents size.
 
-        1. Attempt to Export whole kickstart tree contents to a directory which
-           has less memory available than contents size.
+        :assert: The export kickstart tree has been aborted due to insufficient
+            memory.
 
-        @assert:
+        :caseautomation: notautomated
 
-        1. The export kickstart tree has been aborted due to insufficient
-           memory.
-
-        @caseautomation: notautomated
-
-        @CaseLevel: System
+        :CaseLevel: System
         """
 
 # Red Hat Repositories Export and Import
@@ -921,18 +880,16 @@ class InterSatelliteSyncTestCase(CLITestCase):
     def test_positive_export_redhat_yum_repo(self):
         """Export Red Hat YUM repo in directory.
 
-        @id: 96bd5c72-6eb0-4b32-b75a-14c6ad556cc0
+        :id: 96bd5c72-6eb0-4b32-b75a-14c6ad556cc0
 
-        @steps:
+        :steps: Export whole Red Hat YUM repo to some path.
 
-        1. Export whole Red Hat YUM repo to some path.
+        :assert: Whole YUM repo contents has been exported to directory
+            specified in settings.
 
-        @assert: Whole YUM repo contents has been exported to directory
-        specified in settings.
+        :caseautomation: notautomated
 
-        @caseautomation: notautomated
-
-        @CaseLevel: System
+        :CaseLevel: System
         """
 
     @run_only_on('sat')
@@ -941,19 +898,20 @@ class InterSatelliteSyncTestCase(CLITestCase):
     def test_positive_export_import_redhat_yum_repo(self):
         """Import the exported YUM repo contents.
 
-        @id: afc447b4-ed74-4ed3-839f-3d0048e4eca3
+        :id: afc447b4-ed74-4ed3-839f-3d0048e4eca3
 
-        @steps:
+        :steps:
 
-        1. Export Red Hat YUM repo to path which will be accessible over HTTP.
-        2. Import the repository by defining the CDN URL the same as the
-           exported HTTP URL.
+            1. Export Red Hat YUM repo to path which will be accessible over
+               HTTP.
+            2. Import the repository by defining the CDN URL the same as the
+               exported HTTP URL.
 
-        @assert: All the exported YUM repo contents are imported successfully.
+        :assert: All the exported YUM repo contents are imported successfully.
 
-        @caseautomation: notautomated
+        :caseautomation: notautomated
 
-        @CaseLevel: System
+        :CaseLevel: System
         """
 
     @run_only_on('sat')
@@ -962,20 +920,20 @@ class InterSatelliteSyncTestCase(CLITestCase):
     def test_positive_export_redhat_incremental_yum_repo(self):
         """Export Red Hat YUM repo in directory incrementally.
 
-        @id: be054636-629a-40a0-b414-da3964154bd1
+        :id: be054636-629a-40a0-b414-da3964154bd1
 
-        @steps:
+        :steps:
 
-        1. Export whole Red Hat YUM repo.
-        2. Add some packages to the earlier exported yum repo.
-        3. Incrementally export the yum repo from last exported date.
+            1. Export whole Red Hat YUM repo.
+            2. Add some packages to the earlier exported yum repo.
+            3. Incrementally export the yum repo from last exported date.
 
-        @assert: Red Hat YUM repo contents have been exported incrementally in
-        separate directory.
+        :assert: Red Hat YUM repo contents have been exported incrementally in
+            separate directory.
 
-        @caseautomation: notautomated
+        :caseautomation: notautomated
 
-        @CaseLevel: System
+        :CaseLevel: System
         """
 
     @run_only_on('sat')
@@ -984,20 +942,21 @@ class InterSatelliteSyncTestCase(CLITestCase):
     def test_positive_export_import_redhat_incremental_yum_repo(self):
         """Import the exported YUM repo contents incrementally.
 
-        @id: 318560d7-71f5-4646-ab5c-12a2ec22d031
+        :id: 318560d7-71f5-4646-ab5c-12a2ec22d031
 
-        @steps:
+        :steps:
 
-        1. First, Export and Import whole Red Hat YUM repo.
-        2. Add some packages to the earlier exported yum repo.
-        3. Incrementally export the Red Hat YUM repo from last exported date.
-        4. Import the exported YUM repo contents incrementally.
+            1. First, Export and Import whole Red Hat YUM repo.
+            2. Add some packages to the earlier exported yum repo.
+            3. Incrementally export the Red Hat YUM repo from last exported
+               date.
+            4. Import the exported YUM repo contents incrementally.
 
-        @assert: YUM repo contents have been imported incrementally.
+        :assert: YUM repo contents have been imported incrementally.
 
-        @caseautomation: notautomated
+        :caseautomation: notautomated
 
-        @CaseLevel: System
+        :CaseLevel: System
         """
 
     @run_only_on('sat')
@@ -1006,18 +965,16 @@ class InterSatelliteSyncTestCase(CLITestCase):
     def test_positive_export_redhat_yum_repo_iso(self):
         """Export Red Hat YUM repo as ISO in directory.
 
-        @id: e96a7a8c-9e71-4379-86e6-78177dfbf555
+        :id: e96a7a8c-9e71-4379-86e6-78177dfbf555
 
-        @steps:
+        :steps: Export whole Red Hat YUM repo as ISO.
 
-        1. Export whole Red Hat YUM repo as ISO.
+        :assert: Whole repo contents has been exported as ISO in separate
+            directory.
 
-        @assert: Whole repo contents has been exported as ISO in separate
-        directory.
+        :caseautomation: notautomated
 
-        @caseautomation: notautomated
-
-        @CaseLevel: System
+        :CaseLevel: System
         """
 
     @run_only_on('sat')
@@ -1026,21 +983,21 @@ class InterSatelliteSyncTestCase(CLITestCase):
     def test_positive_export_import_redhat_yum_repo_iso(self):
         """Export Red Hat YUM repo as ISO in directory and Import.
 
-        @id: d1af556e-c622-4ca0-a617-0216d5805d45
+        :id: d1af556e-c622-4ca0-a617-0216d5805d45
 
-        @steps:
+        :steps:
 
-        1. Export whole Red Hat YUM repo as ISO.
-        2. Mount exported ISO and explore the ISO contents on HTTP.
-        3. Import the repository by defining the CDN URL the same as the
-           exported HTTP URL.
+            1. Export whole Red Hat YUM repo as ISO.
+            2. Mount exported ISO and explore the ISO contents on HTTP.
+            3. Import the repository by defining the CDN URL the same as the
+               exported HTTP URL.
 
-        @assert: All The exported repo contents in ISO has been imported
-        successfully.
+        :assert: All The exported repo contents in ISO has been imported
+            successfully.
 
-        @caseautomation: notautomated
+        :caseautomation: notautomated
 
-        @CaseLevel: System
+        :CaseLevel: System
         """
 
     @run_only_on('sat')
@@ -1049,20 +1006,21 @@ class InterSatelliteSyncTestCase(CLITestCase):
     def test_positive_export_redhat_yum_incremental_repo_iso(self):
         """Export Red Hat YUM repo as ISO in directory and import incrementally.
 
-        @id: c54e9410-9945-4662-bea0-a4ab35e90606
+        :id: c54e9410-9945-4662-bea0-a4ab35e90606
 
-        @steps:
+        :steps:
 
-        1. First, Export and Import whole Red Hat YUM repo.
-        2. Add some packages to the earlier exported yum repo.
-        3. Incrementally export the yum repo as ISO from last exported date.
+            1. First, Export and Import whole Red Hat YUM repo.
+            2. Add some packages to the earlier exported yum repo.
+            3. Incrementally export the yum repo as ISO from last exported
+                date.
 
-        @assert: Repo contents have been exported as ISO incrementally in
-        separate directory.
+        :assert: Repo contents have been exported as ISO incrementally in
+            separate directory.
 
-        @caseautomation: notautomated
+        :caseautomation: notautomated
 
-        @CaseLevel: System
+        :CaseLevel: System
         """
 
     @run_only_on('sat')
@@ -1071,22 +1029,23 @@ class InterSatelliteSyncTestCase(CLITestCase):
     def test_positive_export_import_redhat_yum_incremental_repo_iso(self):
         """Export Red Hat YUM repo as ISO in directory and import incrementally.
 
-        @id: 5e3f4013-489e-4d4e-abd9-49077f89efcd
+        :id: 5e3f4013-489e-4d4e-abd9-49077f89efcd
 
-        @steps:
+        :steps:
 
-        1. First, Export and Import whole Red Hat YUM repo.
-        2. Add some packages to the earlier exported yum repo.
-        3. Incrementally export the yum repo as ISO from last exported date.
-        4. Mount incrementally exported contents ISO.
-        5. Import the repo contents incrementally.
+            1. First, Export and Import whole Red Hat YUM repo.
+            2. Add some packages to the earlier exported yum repo.
+            3. Incrementally export the yum repo as ISO from last exported
+                date.
+            4. Mount incrementally exported contents ISO.
+            5. Import the repo contents incrementally.
 
-        @assert: Repo contents have been exported as ISO and imported
-        incrementally.
+        :assert: Repo contents have been exported as ISO and imported
+            incrementally.
 
-        @caseautomation: notautomated
+        :caseautomation: notautomated
 
-        @CaseLevel: System
+        :CaseLevel: System
         """
 
     @run_only_on('sat')
@@ -1095,19 +1054,17 @@ class InterSatelliteSyncTestCase(CLITestCase):
     def test_positive_export_redhat_cv(self):
         """Export CV version having Red Hat contents in directory.
 
-        @id: 3eacbd64-e81b-455e-969d-570582616c4a
+        :id: 3eacbd64-e81b-455e-969d-570582616c4a
 
-        @steps:
+        :steps: Export whole CV version having Red Hat contents to a directory
+            specified in settings.
 
-        1. Export whole CV version having Red Hat contents to a directory
-           specified in settings.
+        :assert: Whole CV version contents has been exported to directory
+            specified in settings.
 
-        @assert: Whole CV version contents has been exported to directory
-        specified in settings.
+        :caseautomation: notautomated
 
-        @caseautomation: notautomated
-
-        @CaseLevel: System
+        :CaseLevel: System
         """
 
     @run_only_on('sat')
@@ -1117,21 +1074,21 @@ class InterSatelliteSyncTestCase(CLITestCase):
         """Export CV version having Red Hat contents in directory and Import
         them.
 
-        @id: 0c9f1a9b-a166-4b9a-a9c4-099f3a45d552
+        :id: 0c9f1a9b-a166-4b9a-a9c4-099f3a45d552
 
-        @steps:
+        :steps:
 
-        1. Export whole CV version having Red Hat contents to a path accessible
-           over HTTP.
-        2. Import the repository by defining the CDN URL from the exported HTTP
-           URL.
+            1. Export whole CV version having Red Hat contents to a path
+               accessible over HTTP.
+            2. Import the repository by defining the CDN URL from the exported
+               HTTP URL.
 
-        @assert: The repo from an exported CV contents has been imported
-        successfully.
+        :assert: The repo from an exported CV contents has been imported
+            successfully.
 
-        @caseautomation: notautomated
+        :caseautomation: notautomated
 
-        @CaseLevel: System
+        :CaseLevel: System
         """
 
     @run_only_on('sat')
@@ -1141,22 +1098,22 @@ class InterSatelliteSyncTestCase(CLITestCase):
         """Export CV version having Red Hat and custom repo in directory
         and Import them.
 
-        @id: a38cf67d-563c-46f0-a263-4825b26faf2b
+        :id: a38cf67d-563c-46f0-a263-4825b26faf2b
 
-        @steps:
+        :steps:
 
-        1. Export whole CV version having mixed repos to a path accessible over
-           HTTP.
-        2. Import the Red Hat repository by defining the CDN URL from the
-           exported HTTP URL.
-        3. Import custom repo by creating new repo and setting yum repo url to
-           exported HTTP url.
+            1. Export whole CV version having mixed repos to a path accessible
+               over HTTP.
+            2. Import the Red Hat repository by defining the CDN URL from the
+               exported HTTP URL.
+            3. Import custom repo by creating new repo and setting yum repo url
+               to exported HTTP url.
 
-        @assert: Both custom and Red Hat repos are imported successfully.
+        :assert: Both custom and Red Hat repos are imported successfully.
 
-        @caseautomation: notautomated
+        :caseautomation: notautomated
 
-        @CaseLevel: System
+        :CaseLevel: System
         """
 
     @run_only_on('sat')
@@ -1165,17 +1122,15 @@ class InterSatelliteSyncTestCase(CLITestCase):
     def test_positive_export_redhat_cv_iso(self):
         """Export CV version having Red Hat contents as ISO.
 
-        @id: 7a35b76b-046f-402b-ba0d-4336e1757b8b
+        :id: 7a35b76b-046f-402b-ba0d-4336e1757b8b
 
-        @steps:
+        :steps: Export whole CV version having Red Hat contents as ISO.
 
-        1. Export whole CV version having Red Hat contents as ISO.
+        :assert: Whole CV version contents has been exported as ISO.
 
-        @assert: Whole CV version contents has been exported as ISO.
+        :caseautomation: notautomated
 
-        @caseautomation: notautomated
-
-        @CaseLevel: System
+        :CaseLevel: System
         """
 
     @run_only_on('sat')
@@ -1184,21 +1139,22 @@ class InterSatelliteSyncTestCase(CLITestCase):
     def test_positive_export_import_redhat_cv_iso(self):
         """Export CV version having Red Hat contents as ISO and Import them.
 
-        @id: 44b3d4b7-2da2-4db0-afd7-6c696a444915
+        :id: 44b3d4b7-2da2-4db0-afd7-6c696a444915
 
-        @steps:
+        :steps:
 
-        1. Export whole CV version having Red Hat contents as ISO.
-        2. Mount ISO to local filesystem and explore iso contents over HTTP.
-        3. Import the Red Hat repository by defining the CDN URL from the
-           exported HTTP URL.
+            1. Export whole CV version having Red Hat contents as ISO.
+            2. Mount ISO to local filesystem and explore iso contents over
+               HTTP.
+            3. Import the Red Hat repository by defining the CDN URL from the
+               exported HTTP URL.
 
-        @assert: The repo is imported successfully from exported CV ISO
-        contents.
+        :assert: The repo is imported successfully from exported CV ISO
+            contents.
 
-        @caseautomation: notautomated
+        :caseautomation: notautomated
 
-        @CaseLevel: System
+        :CaseLevel: System
         """
 
     @run_only_on('sat')
@@ -1207,22 +1163,22 @@ class InterSatelliteSyncTestCase(CLITestCase):
     def test_positive_install_package_from_imported_repos(self):
         """Install packages in client from imported repo of Downstream satellite.
 
-        @id: a81ffb55-398d-4ad0-bcae-5ed48f504ded
+        :id: a81ffb55-398d-4ad0-bcae-5ed48f504ded
 
-        @steps:
+        :steps:
 
-        1. Export whole Red Hat YUM repo to a path accessible over HTTP.
-        2. Import the Red Hat repository by defining the CDN URL from the
-           exported HTTP URL.
-        3. In downstream satellite create CV, AK with this imported repo.
-        4. Register/Subscribe a client with a downstream satellite.
-        5. Attempt to install a package on a client from imported repo of
-           downstream.
+            1. Export whole Red Hat YUM repo to a path accessible over HTTP.
+            2. Import the Red Hat repository by defining the CDN URL from the
+               exported HTTP URL.
+            3. In downstream satellite create CV, AK with this imported repo.
+            4. Register/Subscribe a client with a downstream satellite.
+            5. Attempt to install a package on a client from imported repo of
+               downstream.
 
-        @assert: The package is installed on client from imported repo of
-        downstream satellite.
+        :assert: The package is installed on client from imported repo of
+            downstream satellite.
 
-        @caseautomation: notautomated
+        :caseautomation: notautomated
 
-        @CaseLevel: System
+        :CaseLevel: System
         """

--- a/tests/foreman/cli/test_sso.py
+++ b/tests/foreman/cli/test_sso.py
@@ -1,19 +1,19 @@
 # -*- encoding: utf-8 -*-
 """Test class for SSO (CLI)
 
-@Requirement: Sso
+:Requirement: Sso
 
-@CaseAutomation: Automated
+:CaseAutomation: Automated
 
-@CaseLevel: Acceptance
+:CaseLevel: Acceptance
 
-@CaseComponent: CLI
+:CaseComponent: CLI
 
-@TestType: Functional
+:TestType: Functional
 
-@CaseImportance: High
+:CaseImportance: High
 
-@Upstream: No
+:Upstream: No
 """
 
 from robottelo.decorators import stubbed
@@ -37,37 +37,37 @@ class SingleSignOnTestCase(CLITestCase):
     def test_positive_login_kerberos_user(self):
         """kerberos user can login to CLI
 
-        @id: 59a1b463-67b3-4f18-b851-afaa3c65ccb6
+        :id: 59a1b463-67b3-4f18-b851-afaa3c65ccb6
 
-        @setup: kerberos configured against foreman.
+        :setup: kerberos configured against foreman.
 
-        @assert: Log in to hammer cli successfully
+        :assert: Log in to hammer cli successfully
 
-        @caseautomation: notautomated
+        :caseautomation: notautomated
         """
 
     @stubbed()
     def test_positive_login_ipa_user(self):
         """IPA user can login to CLI
 
-        @id: cbd0df84-6a4d-4c82-bf30-cecd51f40c03
+        :id: cbd0df84-6a4d-4c82-bf30-cecd51f40c03
 
-        @setup: IPA configured against foreman.
+        :setup: IPA configured against foreman.
 
-        @assert: Log in to hammer cli successfully
+        :assert: Log in to hammer cli successfully
 
-        @caseautomation: notautomated
+        :caseautomation: notautomated
         """
 
     @stubbed()
     def test_positive_login_openldap_user(self):
         """OpenLDAP user can login to CLI
 
-        @id: de31d5eb-4e0d-495e-bf31-bc49f9d50d68
+        :id: de31d5eb-4e0d-495e-bf31-bc49f9d50d68
 
-        @setup: OpenLDAP configured against foreman.
+        :setup: OpenLDAP configured against foreman.
 
-        @assert: Log in to hammer cli successfully
+        :assert: Log in to hammer cli successfully
 
-        @caseautomation: notautomated
+        :caseautomation: notautomated
         """

--- a/tests/foreman/cli/test_subnet.py
+++ b/tests/foreman/cli/test_subnet.py
@@ -1,19 +1,19 @@
 # -*- encoding: utf-8 -*-
 """Test class for Subnet CLI
 
-@Requirement: Subnet
+:Requirement: Subnet
 
-@CaseAutomation: Automated
+:CaseAutomation: Automated
 
-@CaseLevel: Acceptance
+:CaseLevel: Acceptance
 
-@CaseComponent: CLI
+:CaseComponent: CLI
 
-@TestType: Functional
+:TestType: Functional
 
-@CaseImportance: High
+:CaseImportance: High
 
-@Upstream: No
+:Upstream: No
 """
 
 import random
@@ -73,9 +73,9 @@ class SubnetTestCase(CLITestCase):
     def test_positive_create_with_name(self):
         """Check if Subnet can be created with random names
 
-        @id: 99cda3eb-3912-461b-83bd-f906b78eeca0
+        :id: 99cda3eb-3912-461b-83bd-f906b78eeca0
 
-        @Assert: Subnet is created and has random name
+        :Assert: Subnet is created and has random name
         """
         for name in valid_data_list():
             with self.subTest(name):
@@ -87,9 +87,9 @@ class SubnetTestCase(CLITestCase):
     def test_positive_create_with_address_pool(self):
         """Create subnet with valid address pool
 
-        @id: d74a52a7-df56-44ef-89a3-081c14e81e43
+        :id: d74a52a7-df56-44ef-89a3-081c14e81e43
 
-        @Assert: Subnet is created and address pool is set
+        :Assert: Subnet is created and address pool is set
         """
         for pool in valid_addr_pools():
             with self.subTest(pool):
@@ -113,9 +113,9 @@ class SubnetTestCase(CLITestCase):
     def test_positive_create_with_domain(self):
         """Check if subnet with domain can be created
 
-        @id: 7ce7b139-d2b7-44f4-9c1a-1bd591f95334
+        :id: 7ce7b139-d2b7-44f4-9c1a-1bd591f95334
 
-        @Assert: Subnet is created and has new domain assigned
+        :Assert: Subnet is created and has new domain assigned
         """
         domain = make_domain()
         subnet = make_subnet({'domain-ids': domain['id']})
@@ -127,9 +127,9 @@ class SubnetTestCase(CLITestCase):
         """Check if subnet with different amount of domains can be
         created in the system
 
-        @id: e81ddec5-38b0-4c42-b89b-5cf2af580d39
+        :id: e81ddec5-38b0-4c42-b89b-5cf2af580d39
 
-        @Assert: Subnet is created and has new domains assigned
+        :Assert: Subnet is created and has new domains assigned
         """
         domains_amount = random.randint(3, 5)
         domains = [make_domain() for _ in range(domains_amount)]
@@ -145,9 +145,9 @@ class SubnetTestCase(CLITestCase):
     def test_positive_create_with_gateway(self):
         """Check if subnet with gateway can be created
 
-        @id: 483c0d1d-c542-4be5-8c56-27b2a09db54a
+        :id: 483c0d1d-c542-4be5-8c56-27b2a09db54a
 
-        @Assert: Subnet is created and has gateway assigned
+        :Assert: Subnet is created and has gateway assigned
         """
         gateway = gen_ipaddr(ip3=True)
         subnet = make_subnet({'gateway': gateway})
@@ -158,9 +158,9 @@ class SubnetTestCase(CLITestCase):
     def test_positive_create_with_ipam(self):
         """Check if subnet with different ipam types can be created
 
-        @id: ba4c66fd-50e6-441d-acc2-6ab39d8439d2
+        :id: ba4c66fd-50e6-441d-acc2-6ab39d8439d2
 
-        @Assert: Subnet is created and correct ipam type is assigned
+        :Assert: Subnet is created and correct ipam type is assigned
         """
         for ipam_type in (SUBNET_IPAM_TYPES['dhcp'],
                           SUBNET_IPAM_TYPES['internal'],
@@ -174,9 +174,9 @@ class SubnetTestCase(CLITestCase):
     def test_negative_create_with_attributes(self):
         """Create subnet with invalid or missing required attributes
 
-        @id: de468dd3-7ba8-463e-881a-fd1cb3cfc7b6
+        :id: de468dd3-7ba8-463e-881a-fd1cb3cfc7b6
 
-        @Assert: Subnet is not created
+        :Assert: Subnet is not created
         """
         for options in invalid_missing_attributes():
             with self.subTest(options):
@@ -191,9 +191,9 @@ class SubnetTestCase(CLITestCase):
     def test_negative_create_with_address_pool(self):
         """Create subnet with invalid address pool range
 
-        @id: c7824327-b5ef-4f95-bd4b-ba4eff73551c
+        :id: c7824327-b5ef-4f95-bd4b-ba4eff73551c
 
-        @Assert: Subnet is not created
+        :Assert: Subnet is not created
         """
         mask = '255.255.255.0'
         network = gen_ipaddr()
@@ -215,9 +215,9 @@ class SubnetTestCase(CLITestCase):
     def test_positive_list(self):
         """Check if Subnet can be listed
 
-        @id: 2ee376f7-9dd9-4b46-b414-801197d5455c
+        :id: 2ee376f7-9dd9-4b46-b414-801197d5455c
 
-        @Assert: Subnet is listed
+        :Assert: Subnet is listed
         """
         # Make a new subnet
         subnet = make_subnet()
@@ -230,9 +230,9 @@ class SubnetTestCase(CLITestCase):
     def test_positive_update_name(self):
         """Check if Subnet name can be updated
 
-        @id: 34533e6c-7081-4b13-99bd-bd57533e05c0
+        :id: 34533e6c-7081-4b13-99bd-bd57533e05c0
 
-        @Assert: Subnet name is updated
+        :Assert: Subnet name is updated
         """
         new_subnet = make_subnet()
         for new_name in valid_data_list():
@@ -246,9 +246,9 @@ class SubnetTestCase(CLITestCase):
     def test_positive_update_network_mask(self):
         """Check if Subnet network and mask can be updated
 
-        @id: 6a8d7750-71f1-4cd8-bf90-f2eac457c3b4
+        :id: 6a8d7750-71f1-4cd8-bf90-f2eac457c3b4
 
-        @Assert: Subnet network and mask are updated
+        :Assert: Subnet network and mask are updated
         """
         network = gen_ipaddr()
         mask = '255.255.255.0'
@@ -273,9 +273,9 @@ class SubnetTestCase(CLITestCase):
     def test_positive_update_address_pool(self):
         """Check if Subnet address pool can be updated
 
-        @id: 18ced88f-d62e-4e15-8b7b-0a08c4ef239b
+        :id: 18ced88f-d62e-4e15-8b7b-0a08c4ef239b
 
-        @Assert: Subnet address pool is updated
+        :Assert: Subnet address pool is updated
         """
         subnet = make_subnet({u'mask': '255.255.255.0'})
         for pool in valid_addr_pools():
@@ -298,9 +298,9 @@ class SubnetTestCase(CLITestCase):
     def test_negative_update_attributes(self):
         """Update subnet with invalid or missing required attributes
 
-        @id: ab60372e-cef7-4495-bd66-68e7dbece475
+        :id: ab60372e-cef7-4495-bd66-68e7dbece475
 
-        @Assert: Subnet is not updated
+        :Assert: Subnet is not updated
         """
         subnet = make_subnet()
         for options in invalid_missing_attributes():
@@ -321,9 +321,9 @@ class SubnetTestCase(CLITestCase):
     def test_negative_update_address_pool(self):
         """Update subnet with invalid address pool
 
-        @id: d0a857b4-be10-4b5d-86d4-43cf99c11619
+        :id: d0a857b4-be10-4b5d-86d4-43cf99c11619
 
-        @Assert: Subnet is not updated
+        :Assert: Subnet is not updated
         """
         subnet = make_subnet()
         for options in invalid_addr_pools():
@@ -347,9 +347,9 @@ class SubnetTestCase(CLITestCase):
     def test_positive_delete_by_id(self):
         """Check if Subnet can be deleted
 
-        @id: ad269df8-4bb2-46a5-9c82-010a80087408
+        :id: ad269df8-4bb2-46a5-9c82-010a80087408
 
-        @Assert: Subnet is deleted
+        :Assert: Subnet is deleted
         """
         for name in valid_data_list():
             with self.subTest(name):

--- a/tests/foreman/cli/test_subscription.py
+++ b/tests/foreman/cli/test_subscription.py
@@ -1,18 +1,18 @@
 """Test class for Subscriptions
 
-@Requirement: Subscription
+:Requirement: Subscription
 
-@CaseAutomation: Automated
+:CaseAutomation: Automated
 
-@CaseLevel: Acceptance
+:CaseLevel: Acceptance
 
-@CaseComponent: CLI
+:CaseComponent: CLI
 
-@TestType: Functional
+:TestType: Functional
 
-@CaseImportance: High
+:CaseImportance: High
 
-@Upstream: No
+:Upstream: No
 """
 from robottelo import manifests
 from robottelo.cli.base import CLIReturnCodeError
@@ -59,9 +59,9 @@ class SubscriptionTestCase(CLITestCase):
     def test_positive_manifest_upload(self):
         """upload manifest
 
-        @id: e5a0e4f8-fed9-4896-87a0-ac33f6baa227
+        :id: e5a0e4f8-fed9-4896-87a0-ac33f6baa227
 
-        @Assert: Manifest are uploaded properly
+        :Assert: Manifest are uploaded properly
         """
         self._upload_manifest(self.org['id'])
         Subscription.list(
@@ -73,9 +73,9 @@ class SubscriptionTestCase(CLITestCase):
     def test_positive_manifest_delete(self):
         """Delete uploaded manifest
 
-        @id: 01539c07-00d5-47e2-95eb-c0fd4f39090f
+        :id: 01539c07-00d5-47e2-95eb-c0fd4f39090f
 
-        @Assert: Manifest are deleted properly
+        :Assert: Manifest are deleted properly
         """
         self._upload_manifest(self.org['id'])
         Subscription.list(
@@ -94,12 +94,12 @@ class SubscriptionTestCase(CLITestCase):
     def test_positive_enable_manifest_reposet(self):
         """enable repository set
 
-        @id: cc0f8f40-5ea6-4fa7-8154-acdc2cb56b45
+        :id: cc0f8f40-5ea6-4fa7-8154-acdc2cb56b45
 
-        @Assert: you are able to enable and synchronize
-        repository contained in a manifest
+        :Assert: you are able to enable and synchronize repository contained in
+            a manifest
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         self._upload_manifest(self.org['id'])
         Subscription.list(
@@ -123,9 +123,9 @@ class SubscriptionTestCase(CLITestCase):
     def test_positive_manifest_history(self):
         """upload manifest and check history
 
-        @id: 000ab0a0-ec1b-497a-84ff-3969a965b52c
+        :id: 000ab0a0-ec1b-497a-84ff-3969a965b52c
 
-        @Assert: Manifest history is shown properly
+        :Assert: Manifest history is shown properly
         """
         self._upload_manifest(self.org['id'])
         Subscription.list(
@@ -144,9 +144,9 @@ class SubscriptionTestCase(CLITestCase):
     def test_positive_manifest_refresh(self):
         """upload manifest and refresh
 
-        @id: 579bbbf7-11cf-4d78-a3b1-16d73bd4ca57
+        :id: 579bbbf7-11cf-4d78-a3b1-16d73bd4ca57
 
-        @Assert: Manifests can be refreshed
+        :Assert: Manifests can be refreshed
         """
         self._upload_manifest(
             self.org['id'], manifests.original_manifest())
@@ -166,11 +166,11 @@ class SubscriptionTestCase(CLITestCase):
     def test_negative_manifest_refresh(self):
         """manifest refresh must fail with a cloned manifest
 
-        @id: 7f40795f-7841-4063-8a43-de0325c92b1f
+        :id: 7f40795f-7841-4063-8a43-de0325c92b1f
 
-        @Assert: the refresh command returns a non-zero return code
+        :Assert: the refresh command returns a non-zero return code
 
-        @BZ: 1226425
+        :BZ: 1226425
         """
         self._upload_manifest(self.org['id'])
         Subscription.list(

--- a/tests/foreman/cli/test_syncplan.py
+++ b/tests/foreman/cli/test_syncplan.py
@@ -1,19 +1,19 @@
 # -*- encoding: utf-8 -*-
 """Test class for Sync Plan CLI
 
-@Requirement: Syncplan
+:Requirement: Syncplan
 
-@CaseAutomation: Automated
+:CaseAutomation: Automated
 
-@CaseLevel: Acceptance
+:CaseLevel: Acceptance
 
-@CaseComponent: CLI
+:CaseComponent: CLI
 
-@TestType: Functional
+:TestType: Functional
 
-@CaseImportance: High
+:CaseImportance: High
 
-@Upstream: No
+:Upstream: No
 """
 
 from datetime import datetime, timedelta
@@ -179,9 +179,9 @@ class SyncPlanTestCase(CLITestCase):
     def test_positive_create_with_name(self):
         """Check if syncplan can be created with random names
 
-        @id: dc0a86f7-4219-427e-92fd-29352dbdbfce
+        :id: dc0a86f7-4219-427e-92fd-29352dbdbfce
 
-        @Assert: Sync plan is created and has random name
+        :Assert: Sync plan is created and has random name
         """
         for name in valid_data_list():
             with self.subTest(name):
@@ -192,9 +192,9 @@ class SyncPlanTestCase(CLITestCase):
     def test_positive_create_with_description(self):
         """Check if syncplan can be created with random description
 
-        @id: a1bbe81b-60f5-4a19-b400-a02a23fa1dfa
+        :id: a1bbe81b-60f5-4a19-b400-a02a23fa1dfa
 
-        @Assert: Sync plan is created and has random description
+        :Assert: Sync plan is created and has random description
         """
         for desc in valid_data_list():
             with self.subTest(desc):
@@ -205,9 +205,9 @@ class SyncPlanTestCase(CLITestCase):
     def test_positive_create_with_interval(self):
         """Check if syncplan can be created with varied intervals
 
-        @id: 32eb0c1d-0c9a-4fb5-a185-68d0d705fbce
+        :id: 32eb0c1d-0c9a-4fb5-a185-68d0d705fbce
 
-        @Assert: Sync plan is created and has selected interval
+        :Assert: Sync plan is created and has selected interval
         """
         for test_data in valid_name_interval_create_tests():
             with self.subTest(test_data):
@@ -225,9 +225,9 @@ class SyncPlanTestCase(CLITestCase):
     def test_negative_create_with_name(self):
         """Check if syncplan can be created with random names
 
-        @id: 4c1aee35-271e-4ed8-9369-d2abfea8cfd9
+        :id: 4c1aee35-271e-4ed8-9369-d2abfea8cfd9
 
-        @Assert: Sync plan is created and has random name
+        :Assert: Sync plan is created and has random name
         """
         for name in invalid_values_list():
             with self.subTest(name):
@@ -241,9 +241,9 @@ class SyncPlanTestCase(CLITestCase):
     def test_positive_update_description(self):
         """Check if syncplan description can be updated
 
-        @id: 00a279cd-1f49-4ebb-a59a-6f0b4e4cb83c
+        :id: 00a279cd-1f49-4ebb-a59a-6f0b4e4cb83c
 
-        @Assert: Sync plan is created and description is updated
+        :Assert: Sync plan is created and description is updated
         """
         new_sync_plan = self._make_sync_plan()
         for new_desc in valid_data_list():
@@ -259,9 +259,9 @@ class SyncPlanTestCase(CLITestCase):
     def test_positive_update_interval(self):
         """Check if syncplan interval be updated
 
-        @id: d676d7f3-9f7c-4375-bb8b-277d71af94b4
+        :id: d676d7f3-9f7c-4375-bb8b-277d71af94b4
 
-        @Assert: Sync plan interval is updated
+        :Assert: Sync plan interval is updated
         """
         for test_data in valid_name_interval_update_tests():
             with self.subTest(test_data):
@@ -281,9 +281,9 @@ class SyncPlanTestCase(CLITestCase):
     def test_positive_update_sync_date(self):
         """Check if syncplan sync date can be updated
 
-        @id: f0c17d7d-3e86-4b64-9747-6cba6809815e
+        :id: f0c17d7d-3e86-4b64-9747-6cba6809815e
 
-        @Assert: Sync plan is created and sync plan is updated
+        :Assert: Sync plan is created and sync plan is updated
         """
         # Set the sync date to today/right now
         today = datetime.now()
@@ -325,9 +325,9 @@ class SyncPlanTestCase(CLITestCase):
     def test_positive_delete_by_id(self):
         """Check if syncplan can be created and deleted
 
-        @id: b5d97c6b-aead-422b-8d9f-4a192bbe4a3b
+        :id: b5d97c6b-aead-422b-8d9f-4a192bbe4a3b
 
-        @Assert: Sync plan is created and then deleted
+        :Assert: Sync plan is created and then deleted
         """
         for name in valid_data_list():
             with self.subTest(name):
@@ -340,9 +340,9 @@ class SyncPlanTestCase(CLITestCase):
     def test_positive_info_enabled_field_is_displayed(self):
         """Check if Enabled field is displayed in sync-plan info output
 
-        @id: 54e3a4ea-315c-4026-8101-c4605ca6b874
+        :id: 54e3a4ea-315c-4026-8101-c4605ca6b874
 
-        @Assert: Sync plan Enabled state is displayed
+        :Assert: Sync plan Enabled state is displayed
         """
         new_sync_plan = self._make_sync_plan()
         result = SyncPlan.info({'id': new_sync_plan['id']})
@@ -355,13 +355,13 @@ class SyncPlanTestCase(CLITestCase):
         """Verify product won't get synced immediately after adding association
         with a sync plan which has already been started
 
-        @id: c80f5c0c-3863-47da-8d7b-7d65c73664b0
+        :id: c80f5c0c-3863-47da-8d7b-7d65c73664b0
 
-        @Assert: Repository was not synchronized
+        :Assert: Repository was not synchronized
 
-        @BZ: 1279539
+        :BZ: 1279539
 
-        @CaseLevel: System
+        :CaseLevel: System
         """
         sync_plan = self._make_sync_plan({
             'enabled': 'true',
@@ -390,13 +390,13 @@ class SyncPlanTestCase(CLITestCase):
         custom product and verify the product gets synchronized on the next
         sync occurrence
 
-        @id: 21efdd08-698c-443c-a681-edce19a4c83a
+        :id: 21efdd08-698c-443c-a681-edce19a4c83a
 
-        @Assert: Product is synchronized successfully.
+        :Assert: Product is synchronized successfully.
 
-        @BZ: 1279539
+        :BZ: 1279539
 
-        @CaseLevel: System
+        :CaseLevel: System
         """
         interval = 60 * 60  # 'hourly' sync interval in seconds
         sync_plan = self._make_sync_plan({
@@ -428,11 +428,11 @@ class SyncPlanTestCase(CLITestCase):
         """Create a sync plan with sync date in a future and sync one custom
         product with it automatically.
 
-        @id: 635bffe2-df98-4971-8950-40edc89e479e
+        :id: 635bffe2-df98-4971-8950-40edc89e479e
 
-        @Assert: Product is synchronized successfully.
+        :Assert: Product is synchronized successfully.
 
-        @CaseLevel: System
+        :CaseLevel: System
         """
         delay = 10 * 60  # delay for sync date in seconds
         sync_plan = self._make_sync_plan({
@@ -467,11 +467,11 @@ class SyncPlanTestCase(CLITestCase):
         """Create a sync plan with sync date in a future and sync multiple
         custom products with multiple repos automatically.
 
-        @id: dd262cf3-b836-422c-baca-b3adbc532478
+        :id: dd262cf3-b836-422c-baca-b3adbc532478
 
-        @Assert: Products are synchronized successfully.
+        :Assert: Products are synchronized successfully.
 
-        @CaseLevel: System
+        :CaseLevel: System
         """
         delay = 10 * 60  # delay for sync date in seconds
         sync_plan = self._make_sync_plan({
@@ -521,13 +521,13 @@ class SyncPlanTestCase(CLITestCase):
         RH product and verify the product gets synchronized on the next sync
         occurrence
 
-        @id: 47280ef4-3936-4dbc-8ed0-1076aa8d40df
+        :id: 47280ef4-3936-4dbc-8ed0-1076aa8d40df
 
-        @Assert: Product is synchronized successfully.
+        :Assert: Product is synchronized successfully.
 
-        @BZ: 1279539
+        :BZ: 1279539
 
-        @CaseLevel: System
+        :CaseLevel: System
         """
         interval = 60 * 60  # 'hourly' sync interval in seconds
         org = make_org()
@@ -580,11 +580,11 @@ class SyncPlanTestCase(CLITestCase):
         """Create a sync plan with sync date in a future and sync one RH
         product with it automatically.
 
-        @id: 6ce2f777-f230-4bb8-9822-2cf3580c21aa
+        :id: 6ce2f777-f230-4bb8-9822-2cf3580c21aa
 
-        @Assert: Product is synchronized successfully.
+        :Assert: Product is synchronized successfully.
 
-        @CaseLevel: System
+        :CaseLevel: System
         """
         delay = 10 * 60  # delay for sync date in seconds
         org = make_org()

--- a/tests/foreman/cli/test_template.py
+++ b/tests/foreman/cli/test_template.py
@@ -1,19 +1,19 @@
 # -*- encoding: utf-8 -*-
 """Test class for Template CLI
 
-@Requirement: Template
+:Requirement: Template
 
-@CaseAutomation: Automated
+:CaseAutomation: Automated
 
-@CaseLevel: Acceptance
+:CaseLevel: Acceptance
 
-@CaseComponent: CLI
+:CaseComponent: CLI
 
-@TestType: Functional
+:TestType: Functional
 
-@CaseImportance: High
+:CaseImportance: High
 
-@Upstream: No
+:Upstream: No
 """
 
 from fauxfactory import gen_string
@@ -37,9 +37,9 @@ class TemplateTestCase(CLITestCase):
     def test_positive_create_with_name(self):
         """Check if Template can be created
 
-        @id: 77deaae8-447b-47cc-8af3-8b17476c905f
+        :id: 77deaae8-447b-47cc-8af3-8b17476c905f
 
-        @Assert: Template is created
+        :Assert: Template is created
         """
         name = gen_string('alpha')
         template = make_template({'name': name})
@@ -50,9 +50,9 @@ class TemplateTestCase(CLITestCase):
     def test_positive_update_name(self):
         """Check if Template can be updated
 
-        @id: 99bdab7b-1279-4349-a655-4294395ecbe1
+        :id: 99bdab7b-1279-4349-a655-4294395ecbe1
 
-        @Assert: Template is updated
+        :Assert: Template is updated
         """
         template = make_template()
         updated_name = gen_string('alpha')
@@ -68,9 +68,9 @@ class TemplateTestCase(CLITestCase):
     def test_positive_create_with_loc(self):
         """Check if Template with Location can be created
 
-        @id: 263aba0e-4f54-4227-af97-f4bc8f5c0788
+        :id: 263aba0e-4f54-4227-af97-f4bc8f5c0788
 
-        @Assert: Template is created and new Location has been assigned
+        :Assert: Template is created and new Location has been assigned
         """
         new_loc = make_location()
         new_template = make_template({'location-ids': new_loc['id']})
@@ -81,9 +81,9 @@ class TemplateTestCase(CLITestCase):
     def test_positive_create_locked(self):
         """Check that locked Template can be created
 
-        @id: ff10e369-85c6-45f3-9cda-7e1c17a6632d
+        :id: ff10e369-85c6-45f3-9cda-7e1c17a6632d
 
-        @Assert: The locked template is created successfully
+        :Assert: The locked template is created successfully
 
         """
         new_template = make_template({
@@ -97,9 +97,9 @@ class TemplateTestCase(CLITestCase):
     def test_positive_create_with_org(self):
         """Check if Template with Organization can be created
 
-        @id: 5de5ca76-1a39-46ac-8dd4-5d41b4b49076
+        :id: 5de5ca76-1a39-46ac-8dd4-5d41b4b49076
 
-        @Assert: Template is created and new Organization has been assigned
+        :Assert: Template is created and new Organization has been assigned
         """
         new_org = make_org()
         new_template = make_template({
@@ -113,11 +113,11 @@ class TemplateTestCase(CLITestCase):
     def test_positive_add_os_by_id(self):
         """Check if operating system can be added to a template
 
-        @id: d9f481b3-9757-4208-b451-baf4792d4d70
+        :id: d9f481b3-9757-4208-b451-baf4792d4d70
 
-        @Assert: Operating system is added to the template
+        :Assert: Operating system is added to the template
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         new_template = make_template()
         new_os = make_os()
@@ -136,11 +136,11 @@ class TemplateTestCase(CLITestCase):
     def test_positive_remove_os_by_id(self):
         """Check if operating system can be removed from a template
 
-        @id: b5362565-6dce-4770-81e1-4fe3ec6f6cee
+        :id: b5362565-6dce-4770-81e1-4fe3ec6f6cee
 
-        @Assert: Operating system is removed from template
+        :Assert: Operating system is removed from template
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         template = make_template()
         new_os = make_os()
@@ -165,9 +165,9 @@ class TemplateTestCase(CLITestCase):
     def test_positive_create_with_content(self):
         """Check if Template can be created with specific content
 
-        @id: 0fcfc46d-5e97-4451-936a-e8684acac275
+        :id: 0fcfc46d-5e97-4451-936a-e8684acac275
 
-        @Assert: Template is created with specific content
+        :Assert: Template is created with specific content
         """
         content = gen_string('alpha')
         name = gen_string('alpha')
@@ -184,9 +184,9 @@ class TemplateTestCase(CLITestCase):
     def test_positive_delete_by_id(self):
         """Check if Template can be deleted
 
-        @id: 8e5245ee-13dd-44d4-8111-d4382cacf005
+        :id: 8e5245ee-13dd-44d4-8111-d4382cacf005
 
-        @Assert: Template is deleted
+        :Assert: Template is deleted
         """
         template = make_template()
         Template.delete({'id': template['id']})
@@ -198,11 +198,11 @@ class TemplateTestCase(CLITestCase):
     def test_positive_clone(self):
         """Assure ability to clone a provisioning template
 
-        @id: 27d69c1e-0d83-4b99-8a3c-4f1bdec3d261
+        :id: 27d69c1e-0d83-4b99-8a3c-4f1bdec3d261
 
-        @Assert: The template is cloned successfully
+        :Assert: The template is cloned successfully
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         cloned_template_name = gen_string('alpha')
         template = make_template()

--- a/tests/foreman/cli/test_user.py
+++ b/tests/foreman/cli/test_user.py
@@ -7,19 +7,19 @@ When testing email validation [1] and [2] should be taken into consideration.
 [2] https://github.com/theforeman/foreman/pull/1776
 
 
-@Requirement: User
+:Requirement: User
 
-@CaseAutomation: Automated
+:CaseAutomation: Automated
 
-@CaseLevel: Acceptance
+:CaseLevel: Acceptance
 
-@CaseComponent: CLI
+:CaseComponent: CLI
 
-@TestType: Functional
+:TestType: Functional
 
-@CaseImportance: High
+:CaseImportance: High
 
-@Upstream: No
+:Upstream: No
 """
 import random
 
@@ -48,9 +48,9 @@ class UserTestCase(CLITestCase):
     def test_positive_create_with_name(self):
         """Create User for all variations of Username
 
-        @id: 2d430243-8512-46ee-8d21-7ccf0c7af807
+        :id: 2d430243-8512-46ee-8d21-7ccf0c7af807
 
-        @Assert: User is created
+        :Assert: User is created
         """
         include_list = [gen_string("alphanumeric", 100)]
         for login in valid_usernames_list() + include_list:
@@ -62,9 +62,9 @@ class UserTestCase(CLITestCase):
     def test_positive_create_with_firstname(self):
         """Create User for all variations of First Name
 
-        @id: b5f07890-020c-4ea0-a519-75d325127b2b
+        :id: b5f07890-020c-4ea0-a519-75d325127b2b
 
-        @Assert: User is created
+        :Assert: User is created
         """
         include_list = [gen_string("alphanumeric", 50)]
         for firstname in valid_usernames_list() + include_list:
@@ -76,9 +76,9 @@ class UserTestCase(CLITestCase):
     def test_positive_create_with_surname(self):
         """Create User for all variations of Surname
 
-        @id: 1b3d7014-6575-4cfd-b6d7-8ff2bfef587e
+        :id: 1b3d7014-6575-4cfd-b6d7-8ff2bfef587e
 
-        @Assert: User is created
+        :Assert: User is created
         """
         include_list = [gen_string("alphanumeric", 50)]
         for lastname in valid_usernames_list() + include_list:
@@ -90,9 +90,9 @@ class UserTestCase(CLITestCase):
     def test_positive_create_with_email(self):
         """Create User for all variations of Email Address
 
-        @id: 2c3ba244-3bd7-4455-8289-03dc7a28a4a6
+        :id: 2c3ba244-3bd7-4455-8289-03dc7a28a4a6
 
-        @Assert: User is created
+        :Assert: User is created
         """
         for email in valid_emails_list():
             with self.subTest(email):
@@ -106,9 +106,9 @@ class UserTestCase(CLITestCase):
     def test_positive_create_with_password(self):
         """Create User for all variations of Password
 
-        @id: cffb7317-0a17-4fff-bd2b-66d295cd40ad
+        :id: cffb7317-0a17-4fff-bd2b-66d295cd40ad
 
-        @Assert: User is created
+        :Assert: User is created
         """
         include_list = [gen_string("alphanumeric", 3000)]
         for password in valid_usernames_list() + include_list:
@@ -120,9 +120,9 @@ class UserTestCase(CLITestCase):
     def test_positive_create_admin(self):
         """Create an Admin user
 
-        @id: 0d0384ad-d85a-492e-8630-7f48912a4fd5
+        :id: 0d0384ad-d85a-492e-8630-7f48912a4fd5
 
-        @Assert: Admin User is created
+        :Assert: Admin User is created
         """
         user = make_user({'admin': '1'})
         self.assertEqual(user['admin'], 'yes')
@@ -131,9 +131,9 @@ class UserTestCase(CLITestCase):
     def test_positive_create_with_default_loc(self):
         """Check if user with default location can be created
 
-        @id: efe7256d-8c8f-444c-8d59-43500e1319c3
+        :id: efe7256d-8c8f-444c-8d59-43500e1319c3
 
-        @Assert: User is created and has new default location assigned
+        :Assert: User is created and has new default location assigned
         """
         location = make_location()
         user = make_user({
@@ -147,9 +147,9 @@ class UserTestCase(CLITestCase):
     def test_positive_create_with_defaut_org(self):
         """Check if user with default organization can be created
 
-        @id: cc692b6f-2519-429b-8ecb-c4bb51ed3544
+        :id: cc692b6f-2519-429b-8ecb-c4bb51ed3544
 
-        @Assert: User is created and has new default organization assigned
+        :Assert: User is created and has new default organization assigned
         """
         org = make_org()
         user = make_user({
@@ -163,9 +163,9 @@ class UserTestCase(CLITestCase):
     def test_positive_create_with_org(self):
         """Create User associated to one Organization
 
-        @id: 336bc067-9edd-481a-ae7a-0ff1270b2e41
+        :id: 336bc067-9edd-481a-ae7a-0ff1270b2e41
 
-        @Assert: User is created
+        :Assert: User is created
         """
         org = make_org()
         user = make_user({'organization-ids': org['id']})
@@ -175,11 +175,11 @@ class UserTestCase(CLITestCase):
     def test_positive_create_with_orgs(self):
         """Create User associated to multiple Organizations
 
-        @id: f537296c-a8a8-45ef-8996-c1d32b8f64de
+        :id: f537296c-a8a8-45ef-8996-c1d32b8f64de
 
-        @Assert: User is created
+        :Assert: User is created
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         orgs_amount = random.randint(3, 5)
         orgs = [make_org() for _ in range(orgs_amount)]
@@ -193,26 +193,25 @@ class UserTestCase(CLITestCase):
     def test_positive_create_in_ldap_modes(self):
         """Create User in supported ldap modes
 
-        @id: ef107cea-c0e1-4d67-88e5-45cd30122d29
+        :id: ef107cea-c0e1-4d67-88e5-45cd30122d29
 
-        @Steps:
-        1. Create User in all supported ldap modes - (Active Driectory,
-        IPA, Posix)
+        :Steps: Create User in all supported ldap modes - (Active Driectory,
+            IPA, Posix)
 
-        @Assert: User is created without specifying the password
+        :Assert: User is created without specifying the password
 
-        @caseautomation: notautomated
+        :caseautomation: notautomated
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
 
     @tier1
     def test_negative_create_with_invalid_username(self):
         """Create User with invalid Username
 
-        @id: 8bb53001-6377-49fe-a85c-f92204a5dea4
+        :id: 8bb53001-6377-49fe-a85c-f92204a5dea4
 
-        @Assert: User is not created. Appropriate error shown.
+        :Assert: User is not created. Appropriate error shown.
         """
         invalid_names = (
             '', 'space {0}'.format(gen_string('alpha')),
@@ -238,9 +237,9 @@ class UserTestCase(CLITestCase):
     def test_negative_create_with_invalid_firstname(self):
         """Create User with invalid First Name
 
-        @id: 08b7be40-40f5-4423-91a6-03bb2bfb714c
+        :id: 08b7be40-40f5-4423-91a6-03bb2bfb714c
 
-        @Assert: User is not created. Appropriate error shown.
+        :Assert: User is not created. Appropriate error shown.
         """
         invalid_first_names = (gen_string("alpha", 51), gen_string("html"))
         for invalid_first_name in invalid_first_names:
@@ -262,9 +261,9 @@ class UserTestCase(CLITestCase):
     def test_negative_create_with_invalid_lastname(self):
         """Create User with invalid lastname
 
-        @id: f73d2374-6bdf-4d25-945e-46a34fe692e7
+        :id: f73d2374-6bdf-4d25-945e-46a34fe692e7
 
-        @Assert: User is not created. Appropriate error shown.
+        :Assert: User is not created. Appropriate error shown.
         """
         invalid_lastnames = (gen_string("alpha", 51), gen_string("html"))
         for invalid_lastname in invalid_lastnames:
@@ -286,9 +285,9 @@ class UserTestCase(CLITestCase):
     def test_negative_create_with_invalid_email(self):
         """Create User with invalid Email Address
 
-        @id: e21be14c-e985-4f27-b189-1cfe454e03d2
+        :id: e21be14c-e985-4f27-b189-1cfe454e03d2
 
-        @Assert: User is not created. Appropriate error shown.
+        :Assert: User is not created. Appropriate error shown.
         """
         for email in invalid_emails_list():
             with self.subTest(email):
@@ -311,11 +310,11 @@ class UserTestCase(CLITestCase):
     def test_negative_create_with_empty_email(self):
         """Create User with empty Email Address
 
-        @id: e55b2937-9b43-45ee-aa22-2d4ae6da01f3
+        :id: e55b2937-9b43-45ee-aa22-2d4ae6da01f3
 
-        @Assert: User is not created. Appropriate error shown.
+        :Assert: User is not created. Appropriate error shown.
 
-        @BZ: 1204686
+        :BZ: 1204686
         """
         with self.assertRaisesRegex(
             CLIReturnCodeError,
@@ -334,9 +333,9 @@ class UserTestCase(CLITestCase):
     def test_negative_create_with_blank_authorized_by(self):
         """Create User with blank Authorized by
 
-        @id: 1f60fbf8-a5f0-432e-9b4e-60bc0224294a
+        :id: 1f60fbf8-a5f0-432e-9b4e-60bc0224294a
 
-        @Assert: User is not created. Appropriate error shown.
+        :Assert: User is not created. Appropriate error shown.
         """
         with self.assertRaisesRegex(
             CLIReturnCodeError,
@@ -354,9 +353,9 @@ class UserTestCase(CLITestCase):
         values in Password and verify fields and using valid Username, First
         Name, Surname, Email Address, Language
 
-        @id: 4b142a12-8354-437e-89cc-c0505bda2027
+        :id: 4b142a12-8354-437e-89cc-c0505bda2027
 
-        @Assert: User is not created. Appropriate error shown.
+        :Assert: User is not created. Appropriate error shown.
         """
         with self.assertRaisesRegex(
             CLIReturnCodeError,
@@ -373,9 +372,9 @@ class UserTestCase(CLITestCase):
     def test_positive_update_to_non_admin(self):
         """Convert an user from an admin user to non-admin user
 
-        @id: 6a291547-d60d-4dc6-aeb6-d7ad969993a8
+        :id: 6a291547-d60d-4dc6-aeb6-d7ad969993a8
 
-        @Assert: User is updated
+        :Assert: User is updated
         """
         user = make_user({'admin': '1'})
         self.assertEqual(user['admin'], 'yes')
@@ -390,9 +389,9 @@ class UserTestCase(CLITestCase):
     def test_positive_delete_by_name(self):
         """Create an user and then delete it using its name
 
-        @id: 37cf4313-012f-4215-b537-030ee61c1c3c
+        :id: 37cf4313-012f-4215-b537-030ee61c1c3c
 
-        @Assert: User is deleted
+        :Assert: User is deleted
         """
         for login in valid_usernames_list():
             with self.subTest(login), self.assertRaises(CLIReturnCodeError):
@@ -406,9 +405,9 @@ class UserTestCase(CLITestCase):
     def test_positive_delete_by_id(self):
         """Create an user and then delete it using its id
 
-        @id: 7e97e177-b676-49b3-86ee-644f6f6ff30c
+        :id: 7e97e177-b676-49b3-86ee-644f6f6ff30c
 
-        @Assert: User is deleted
+        :Assert: User is deleted
         """
         user = make_user()
         User.exists(search=('login', user['login']))
@@ -420,9 +419,9 @@ class UserTestCase(CLITestCase):
     def test_positive_delete_admin(self):
         """Delete an admin user
 
-        @id: 9752706c-fdbd-4a36-af6f-27824d22ea03
+        :id: 9752706c-fdbd-4a36-af6f-27824d22ea03
 
-        @Assert: User is deleted
+        :Assert: User is deleted
         """
         for login in valid_usernames_list():
             with self.subTest(login), self.assertRaises(CLIReturnCodeError):
@@ -435,9 +434,9 @@ class UserTestCase(CLITestCase):
     def test_negative_delete_internal_admin(self):
         """Attempt to delete internal admin user
 
-        @id: 4fc92958-9e75-4bd2-bcbe-32f906e432f5
+        :id: 4fc92958-9e75-4bd2-bcbe-32f906e432f5
 
-        @Assert: User is not deleted
+        :Assert: User is not deleted
         """
         with self.assertRaisesRegex(
             CLIReturnCodeError,
@@ -450,9 +449,9 @@ class UserTestCase(CLITestCase):
     def test_positive_list_username(self):
         """List User for all variations of Username
 
-        @id: 3beef11a-c1d0-4b8f-a9f9-1eb557b36579
+        :id: 3beef11a-c1d0-4b8f-a9f9-1eb557b36579
 
-        @Assert: User is listed
+        :Assert: User is listed
         """
         for login in valid_usernames_list():
             with self.subTest(login):
@@ -473,9 +472,9 @@ class UserTestCase(CLITestCase):
     def test_positive_list_firstname(self):
         """List User for all variations of First Name
 
-        @id: 7786d834-f899-4277-b7ed-5d66605fb746
+        :id: 7786d834-f899-4277-b7ed-5d66605fb746
 
-        @Assert: User is listed
+        :Assert: User is listed
         """
         for firstname in valid_usernames_list():
             with self.subTest(firstname):
@@ -495,9 +494,9 @@ class UserTestCase(CLITestCase):
     def test_positive_list_surname(self):
         """List User for all variations of Surname
 
-        @id: 1fcc6b76-28d8-4253-86b0-dae09703abe1
+        :id: 1fcc6b76-28d8-4253-86b0-dae09703abe1
 
-        @Assert: User is listed
+        :Assert: User is listed
         """
         for lastname in valid_usernames_list():
             with self.subTest(lastname):
@@ -517,9 +516,9 @@ class UserTestCase(CLITestCase):
     def test_positive_list_email(self):
         """List User for all variations of Email Address
 
-        @id: 252f5583-6c34-43ae-9966-636fa0a2bb10
+        :id: 252f5583-6c34-43ae-9966-636fa0a2bb10
 
-        @Assert: User is listed
+        :Assert: User is listed
         """
         valid_emails = (
             gen_string("alpha") + "@somemail.com",
@@ -546,11 +545,11 @@ class UserTestCase(CLITestCase):
     def test_positive_create_with_email_utf8_latin(self):
         """List User for utf-8,latin variations of Email Address
 
-        @id: 3d865df5-2e28-44fb-add8-c79a18db2f95
+        :id: 3d865df5-2e28-44fb-add8-c79a18db2f95
 
-        @Assert: User is listed
+        :Assert: User is listed
 
-        @BZ: 1204667
+        :BZ: 1204667
         """
         valid_mails = (
             gen_string("latin1") + "@somemail.com",
@@ -575,22 +574,22 @@ class UserTestCase(CLITestCase):
     def test_positive_end_to_end(self):
         """Create User and perform different operations
 
-        @id: fc723d97-fc36-4468-8b1e-3c07d28f4d10
+        :id: fc723d97-fc36-4468-8b1e-3c07d28f4d10
 
-        @Steps:
-        1. Create User
-        2. Login with the new user
-        3. Upload Subscriptions
-        4. Provision Systems
-        5. Add/Remove Users
-        6. Add/Remove Orgs
-        7. Delete the User
+        :Steps:
+            1. Create User
+            2. Login with the new user
+            3. Upload Subscriptions
+            4. Provision Systems
+            5. Add/Remove Users
+            6. Add/Remove Orgs
+            7. Delete the User
 
-        @Assert: All actions passed
+        :Assert: All actions passed
 
-        @caseautomation: notautomated
+        :caseautomation: notautomated
 
-        @CaseLevel: System
+        :CaseLevel: System
         """
 
     @stubbed()
@@ -598,21 +597,21 @@ class UserTestCase(CLITestCase):
     def test_positive_end_to_end_without_org(self):
         """Create User with no Org assigned and attempt different operations
 
-        @id: a5ed8e77-942f-4b48-b184-b72b38cdb4f9
+        :id: a5ed8e77-942f-4b48-b184-b72b38cdb4f9
 
-        @Steps:
-        1. Create User.  Do not assign any Org
-        2. Login with the new user
-        3. Attempt to Upload Subscriptions
-        4. Attempt to Provision Systems
-        5. Attempt to Add/Remove Users
-        6. Attempt to Add/Remove Orgs
+        :Steps:
+            1. Create User.  Do not assign any Org
+            2. Login with the new user
+            3. Attempt to Upload Subscriptions
+            4. Attempt to Provision Systems
+            5. Attempt to Add/Remove Users
+            6. Attempt to Add/Remove Orgs
 
-        @Assert: All actions failed since the User is not assigned to any Org
+        :Assert: All actions failed since the User is not assigned to any Org
 
-        @caseautomation: notautomated
+        :caseautomation: notautomated
 
-        @CaseLevel: System
+        :CaseLevel: System
         """
 
 
@@ -679,9 +678,9 @@ class UserWithCleanUpTestCase(CLITestCase):
     def test_positive_update_firstname(self):
         """Update firstname value for existing User
 
-        @id: c51baf5e-206d-4e95-a713-795574080bd9
+        :id: c51baf5e-206d-4e95-a713-795574080bd9
 
-        @Assert: User is updated
+        :Assert: User is updated
         """
         user = self.user
         for new_firstname in valid_usernames_list():
@@ -698,9 +697,9 @@ class UserWithCleanUpTestCase(CLITestCase):
     def test_positive_update_username(self):
         """Update username value for existing User
 
-        @id: 72734d5a-bfba-4db8-9c8f-cc6190c74b69
+        :id: 72734d5a-bfba-4db8-9c8f-cc6190c74b69
 
-        @Assert: User is updated
+        :Assert: User is updated
         """
         user = self.user
         include_list = [gen_string("alphanumeric", 100)]
@@ -717,9 +716,9 @@ class UserWithCleanUpTestCase(CLITestCase):
     def test_positive_update_lastname(self):
         """Update Last Name value for existing User
 
-        @id: 03479f69-7606-46b3-9dc1-664d30f40ae1
+        :id: 03479f69-7606-46b3-9dc1-664d30f40ae1
 
-        @Assert: User is updated
+        :Assert: User is updated
         """
         user = self.user
         for new_lastname in valid_usernames_list():
@@ -736,9 +735,9 @@ class UserWithCleanUpTestCase(CLITestCase):
     def test_positive_update_email(self):
         """Update Email Address value for existing User
 
-        @id: 75067bf3-e43e-4c6a-b3fd-63e564eda7db
+        :id: 75067bf3-e43e-4c6a-b3fd-63e564eda7db
 
-        @Assert: User is updated
+        :Assert: User is updated
         """
         user = self.user
         for email in valid_emails_list():
@@ -755,9 +754,9 @@ class UserWithCleanUpTestCase(CLITestCase):
     def test_positive_update_password(self):
         """Update Password/Verify fields for existing User
 
-        @id: 065197ab-1352-4da8-9df6-b6ff332e6847
+        :id: 065197ab-1352-4da8-9df6-b6ff332e6847
 
-        @Assert: User is updated
+        :Assert: User is updated
         """
         user = self.user
         for password in valid_usernames_list():
@@ -773,9 +772,9 @@ class UserWithCleanUpTestCase(CLITestCase):
     def test_positive_update_to_admin(self):
         """Convert usual user to an admin user
 
-        @id: 3c5cdeb0-c529-472e-a291-269b703bf9d1
+        :id: 3c5cdeb0-c529-472e-a291-269b703bf9d1
 
-        @Assert: User is updated
+        :Assert: User is updated
         """
         user = self.user
         self.assertEqual(user['admin'], 'no')
@@ -790,9 +789,9 @@ class UserWithCleanUpTestCase(CLITestCase):
     def test_positive_update_org(self):
         """Assign a User to an Org
 
-        @id: 7d16ea11-b1e9-4f3b-b3c5-a4b8569947da
+        :id: 7d16ea11-b1e9-4f3b-b3c5-a4b8569947da
 
-        @Assert: User is updated
+        :Assert: User is updated
         """
         user = self.user
         org = make_org()
@@ -807,11 +806,11 @@ class UserWithCleanUpTestCase(CLITestCase):
     def test_positive_update_orgs(self):
         """Assign a User to multiple Orgs
 
-        @id: 2303ea38-eb08-4f68-ac73-48968e06aec0
+        :id: 2303ea38-eb08-4f68-ac73-48968e06aec0
 
-        @Assert: User is updated
+        :Assert: User is updated
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         user = self.user
         orgs_amount = random.randint(3, 5)
@@ -830,9 +829,9 @@ class UserWithCleanUpTestCase(CLITestCase):
     def test_negative_update_username(self):
         """Try to update User using invalid Username
 
-        @id: 208bb597-1b33-44c8-9b15-b7bfcbb739fd
+        :id: 208bb597-1b33-44c8-9b15-b7bfcbb739fd
 
-        @Assert: User is not updated. Appropriate error shown.
+        :Assert: User is not updated. Appropriate error shown.
         """
         user = self.user
         for new_user_name in invalid_names_list():
@@ -848,9 +847,9 @@ class UserWithCleanUpTestCase(CLITestCase):
     def test_negative_update_firstname(self):
         """Try to update User using invalid First Name
 
-        @id: fb425e86-6e09-4535-b1dc-aef1e02ea712
+        :id: fb425e86-6e09-4535-b1dc-aef1e02ea712
 
-        @Assert: User is not updated. Appropriate error shown.
+        :Assert: User is not updated. Appropriate error shown.
         """
         user = self.user
         for invalid_firstname in invalid_names_list():
@@ -870,9 +869,9 @@ class UserWithCleanUpTestCase(CLITestCase):
     def test_negative_update_surname(self):
         """Try to update User using invalid Last Name
 
-        @id: 92ca237a-daa8-43bd-927b-a0bdc8250658
+        :id: 92ca237a-daa8-43bd-927b-a0bdc8250658
 
-        @Assert: User is not updated. Appropriate error shown.
+        :Assert: User is not updated. Appropriate error shown.
         """
         user = self.user
         for invalid_lastname in (gen_string('alpha', 51), gen_string('html')):
@@ -890,9 +889,9 @@ class UserWithCleanUpTestCase(CLITestCase):
     def test_negative_update_email(self):
         """Try to update User using invalid Email Address
 
-        @id: 4a2876cc-2580-4ae9-8ce7-d7390bfebd4b
+        :id: 4a2876cc-2580-4ae9-8ce7-d7390bfebd4b
 
-        @Assert: User is not updated.  Appropriate error shown.
+        :Assert: User is not updated.  Appropriate error shown.
         """
         user = self.user
         for email in invalid_emails_list():
@@ -911,13 +910,13 @@ class UserWithCleanUpTestCase(CLITestCase):
     def test_positive_add_role(self):
         """Add role to User for all variations of role names
 
-        @id: 4df495b8-ed02-480e-a935-ffc0b6746e08
+        :id: 4df495b8-ed02-480e-a935-ffc0b6746e08
 
-        @Assert: Role is added to user
+        :Assert: Role is added to user
 
-        @BZ: 1138553
+        :BZ: 1138553
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         user = self.user
         for role_id, role in self.stubbed_roles.items():
@@ -938,11 +937,11 @@ class UserWithCleanUpTestCase(CLITestCase):
         So if if it gets fixed this test can be updated:
         (http://projects.theforeman.org/issues/16206)
 
-        @id: d769ac61-f158-4e4e-a176-1c87de8b00f6
+        :id: d769ac61-f158-4e4e-a176-1c87de8b00f6
 
-        @Assert: Roles are added to user
+        :Assert: Roles are added to user
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         user = self.user
         original_role_names = set(user['roles'])
@@ -962,13 +961,13 @@ class UserWithCleanUpTestCase(CLITestCase):
     def test_positive_remove_role(self):
         """Remove role from User for all variations of role names
 
-        @id: 51b15516-da42-4149-8032-87baa93f9e56
+        :id: 51b15516-da42-4149-8032-87baa93f9e56
 
-        @Assert: Role is removed
+        :Assert: Role is removed
 
-        @BZ: 1138553
+        :BZ: 1138553
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         user = self.user
         for role_id, role in self.stubbed_roles.items():
@@ -987,24 +986,24 @@ class UserWithCleanUpTestCase(CLITestCase):
     def test_positive_add_all_default_roles(self):
         """Create User and assign all available default roles to it
 
-        @id: 7faa3254-36ad-4496-9c0e-7b0454e4bc26
+        :id: 7faa3254-36ad-4496-9c0e-7b0454e4bc26
 
-        @Assert: All default roles are added to user
+        :Assert: All default roles are added to user
 
-        @caseautomation: notautomated
+        :caseautomation: notautomated
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
 
     @tier1
     def test_positive_update_role(self):
         """Update User with one role
 
-        @id: 9b23f242-6a55-4267-bd70-b4a5619f7990
+        :id: 9b23f242-6a55-4267-bd70-b4a5619f7990
 
-        @Assert: User is updated
+        :Assert: User is updated
 
-        @caseautomation: notautomated
+        :caseautomation: notautomated
         """
         for role_id, role in self.stubbed_roles.items():
             self.assert_user_roles({role_id: role})
@@ -1014,11 +1013,11 @@ class UserWithCleanUpTestCase(CLITestCase):
     def test_positive_update_roles(self):
         """Update User with multiple roles
 
-        @id: a41663a7-eb77-4083-9ca3-a1c1df1c87eb
+        :id: a41663a7-eb77-4083-9ca3-a1c1df1c87eb
 
-        @Assert: User is updated
+        :Assert: User is updated
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         self.assert_user_roles(self.stubbed_roles)
 
@@ -1026,10 +1025,10 @@ class UserWithCleanUpTestCase(CLITestCase):
     def test_positive_update_all_roles(self):
         """Update User with all roles
 
-        @id: fc520d70-36ff-4676-93c1-ca8ba6cd8efc
+        :id: fc520d70-36ff-4676-93c1-ca8ba6cd8efc
 
-        @Assert: User is updated
+        :Assert: User is updated
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         self.assert_user_roles(self.all_roles)

--- a/tests/foreman/cli/test_usergroup.py
+++ b/tests/foreman/cli/test_usergroup.py
@@ -1,19 +1,19 @@
 # -*- encoding: utf-8 -*-
 """Test class for User Group CLI
 
-@Requirement: Usergroup
+:Requirement: Usergroup
 
-@CaseAutomation: Automated
+:CaseAutomation: Automated
 
-@CaseLevel: Acceptance
+:CaseLevel: Acceptance
 
-@CaseComponent: CLI
+:CaseComponent: CLI
 
-@TestType: Functional
+:TestType: Functional
 
-@CaseImportance: High
+:CaseImportance: High
 
-@Upstream: No
+:Upstream: No
 """
 
 from random import randint
@@ -41,9 +41,9 @@ class UserGroupTestCase(CLITestCase):
     def test_positive_create_with_name(self):
         """Create new user group using different valid names
 
-        @id: 4cb19ecf-53f8-4804-8fbd-a028c02f13c6
+        :id: 4cb19ecf-53f8-4804-8fbd-a028c02f13c6
 
-        @Assert: User group is created successfully.
+        :Assert: User group is created successfully.
         """
         for name in valid_data_list():
             with self.subTest(name):
@@ -55,9 +55,9 @@ class UserGroupTestCase(CLITestCase):
         """Create new user group using valid user attached to that group. Use
         user name as a parameter
 
-        @id: 50baa271-c741-4905-aa56-a3ee48be0dc0
+        :id: 50baa271-c741-4905-aa56-a3ee48be0dc0
 
-        @Assert: User group is created successfully.
+        :Assert: User group is created successfully.
         """
         for login in valid_usernames_list():
             with self.subTest(login):
@@ -71,9 +71,9 @@ class UserGroupTestCase(CLITestCase):
         """Create new user group using valid user attached to that group. Use
         user id as a parameter
 
-        @id: bacef0e3-31dd-4991-93f7-f54fbe64d0f0
+        :id: bacef0e3-31dd-4991-93f7-f54fbe64d0f0
 
-        @Assert: User group is created successfully.
+        :Assert: User group is created successfully.
         """
         user = make_user()
         user_group = make_usergroup({'user-ids': user['id']})
@@ -84,10 +84,10 @@ class UserGroupTestCase(CLITestCase):
         """Create new user group using multiple users attached to that group.
         Use users name as a parameter
 
-        @id: 3b0a3c3c-aab2-4e8a-b043-7462621c7333
+        :id: 3b0a3c3c-aab2-4e8a-b043-7462621c7333
 
-        @Assert: User group is created successfully and contains all expected
-        users.
+        :Assert: User group is created successfully and contains all expected
+            users.
         """
         users = [make_user()['login'] for _ in range(randint(3, 5))]
         user_group = make_usergroup({'users': users})
@@ -98,9 +98,9 @@ class UserGroupTestCase(CLITestCase):
         """Create new user group using valid role attached to that group. Use
         role name as a parameter
 
-        @id: 47fb3037-f48a-4f99-9a50-792b0fd77569
+        :id: 47fb3037-f48a-4f99-9a50-792b0fd77569
 
-        @Assert: User group is created successfully.
+        :Assert: User group is created successfully.
         """
         for role_name in valid_data_list():
             with self.subTest(role_name):
@@ -114,9 +114,9 @@ class UserGroupTestCase(CLITestCase):
         """Create new user group using valid role attached to that group. Use
         role id as a parameter
 
-        @id: 8524a561-037c-4509-aaba-3213924a1cfe
+        :id: 8524a561-037c-4509-aaba-3213924a1cfe
 
-        @Assert: User group is created successfully.
+        :Assert: User group is created successfully.
         """
         role = make_role()
         user_group = make_usergroup({'role-ids': role['id']})
@@ -127,10 +127,10 @@ class UserGroupTestCase(CLITestCase):
         """Create new user group using multiple roles attached to that group.
         Use roles name as a parameter
 
-        @id: b7113d49-b9ce-4603-a09d-5ab23fe2d568
+        :id: b7113d49-b9ce-4603-a09d-5ab23fe2d568
 
-        @Assert: User group is created successfully and contains all expected
-        roles
+        :Assert: User group is created successfully and contains all expected
+            roles
         """
         roles = [make_role()['name'] for _ in range(randint(3, 5))]
         user_group = make_usergroup({'roles': roles})
@@ -141,9 +141,9 @@ class UserGroupTestCase(CLITestCase):
         """Create new user group using another user group attached to the
         initial group. Use user group name as a parameter
 
-        @id: 7bbe3af7-af36-4d13-a4ce-7ec5441b88bf
+        :id: 7bbe3af7-af36-4d13-a4ce-7ec5441b88bf
 
-        @Assert: User group is created successfully.
+        :Assert: User group is created successfully.
         """
         for name in valid_data_list():
             with self.subTest(name):
@@ -158,9 +158,9 @@ class UserGroupTestCase(CLITestCase):
         """Create new user group using another user group attached to the
         initial group. Use user group id as a parameter
 
-        @id: 04ee66e5-e721-431b-ac6d-c7413fdc6dc2
+        :id: 04ee66e5-e721-431b-ac6d-c7413fdc6dc2
 
-        @Assert: User group is created successfully.
+        :Assert: User group is created successfully.
         """
         sub_user_group = make_usergroup()
         user_group = make_usergroup({
@@ -172,10 +172,10 @@ class UserGroupTestCase(CLITestCase):
         """Create new user group using multiple user groups attached to that
         initial group. Use user groups name as a parameter
 
-        @id: ca6031f7-0998-444b-94be-f8a9e4a9f733
+        :id: ca6031f7-0998-444b-94be-f8a9e4a9f733
 
-        @Assert: User group is created successfully and contains all expected
-        user groups
+        :Assert: User group is created successfully and contains all expected
+            user groups
         """
         sub_user_groups = [
             make_usergroup()['name'] for _ in range(randint(3, 5))]
@@ -187,9 +187,9 @@ class UserGroupTestCase(CLITestCase):
     def test_negative_create_with_name(self):
         """Attempt to create user group with invalid name.
 
-        @id: 79d2d28d-a0d9-42ab-ba88-c259a463533a
+        :id: 79d2d28d-a0d9-42ab-ba88-c259a463533a
 
-        @Assert: User group is not created.
+        :Assert: User group is not created.
         """
         for name in invalid_values_list():
             with self.subTest(name):
@@ -202,9 +202,9 @@ class UserGroupTestCase(CLITestCase):
     def test_negative_create_with_same_name(self):
         """Attempt to create user group with a name of already existent entity.
 
-        @id: b1eebf2f-a59e-43af-a980-ae73320b4311
+        :id: b1eebf2f-a59e-43af-a980-ae73320b4311
 
-        @Assert: User group is not created.
+        :Assert: User group is not created.
         """
         user_group = make_usergroup()
         with self.assertRaises(CLIFactoryError):
@@ -214,9 +214,9 @@ class UserGroupTestCase(CLITestCase):
     def test_positive_list(self):
         """Test user group list command
 
-        @id: 828d0051-53c8-4737-809a-983517f675bb
+        :id: 828d0051-53c8-4737-809a-983517f675bb
 
-        @Assert: User group list command returns valid and expected data
+        :Assert: User group list command returns valid and expected data
 
         """
         user_group = make_usergroup()
@@ -231,9 +231,9 @@ class UserGroupTestCase(CLITestCase):
         """Update existing user group with different valid names. Use id of the
         user group as a parameter
 
-        @id: bed911fe-da39-4798-a5d2-8a0467bfacc3
+        :id: bed911fe-da39-4798-a5d2-8a0467bfacc3
 
-        @Assert: User group is update successfully.
+        :Assert: User group is update successfully.
         """
         user_group = make_usergroup()
         for new_name in valid_data_list():
@@ -250,9 +250,9 @@ class UserGroupTestCase(CLITestCase):
         """Update existing user group with different valid names. Use name of
         the user group as a parameter
 
-        @id: 3bee63ff-ae2a-4fa4-a5bd-58ec85358c19
+        :id: 3bee63ff-ae2a-4fa4-a5bd-58ec85358c19
 
-        @Assert: User group is update successfully.
+        :Assert: User group is update successfully.
         """
         user_group = make_usergroup()
         for new_name in valid_data_list():
@@ -269,9 +269,9 @@ class UserGroupTestCase(CLITestCase):
         """Attempt to update existing user group using different invalid names.
         Use id of the user group as a parameter
 
-        @id: e5aecee1-7c4c-4ac5-aee2-a3190cbe956f
+        :id: e5aecee1-7c4c-4ac5-aee2-a3190cbe956f
 
-        @Assert: User group is not updated.
+        :Assert: User group is not updated.
         """
         user_group = make_usergroup()
         for new_name in invalid_values_list():
@@ -289,9 +289,9 @@ class UserGroupTestCase(CLITestCase):
         """Attempt to update existing user group using different invalid names.
         Use name of the user group as a parameter
 
-        @id: 32ad14cf-4ed8-4deb-b2fc-df4ed60efb78
+        :id: 32ad14cf-4ed8-4deb-b2fc-df4ed60efb78
 
-        @Assert: User group is not updated.
+        :Assert: User group is not updated.
         """
         user_group = make_usergroup()
         for new_name in invalid_values_list():
@@ -308,9 +308,9 @@ class UserGroupTestCase(CLITestCase):
     def test_positive_delete_by_name(self):
         """Create user group with valid name and then delete it using that name
 
-        @id: 359b1806-64c5-42ec-9448-991e82f70e98
+        :id: 359b1806-64c5-42ec-9448-991e82f70e98
 
-        @assert: User group is deleted successfully
+        :assert: User group is deleted successfully
         """
         for name in valid_data_list():
             with self.subTest(name):
@@ -323,9 +323,9 @@ class UserGroupTestCase(CLITestCase):
     def test_positive_delete_by_id(self):
         """Create user group with valid data and then delete it using its ID
 
-        @id: b60b4da7-9d1b-487d-89e5-ebf3aa2218d6
+        :id: b60b4da7-9d1b-487d-89e5-ebf3aa2218d6
 
-        @assert: User group is deleted successfully
+        :assert: User group is deleted successfully
         """
         user_group = make_usergroup()
         UserGroup.delete({'id': user_group['id']})
@@ -337,9 +337,9 @@ class UserGroupTestCase(CLITestCase):
         """Create new user group using valid user attached to that group. Then
         delete that user group using id of that group as a parameter
 
-        @id: 34ffa204-9376-41f2-aca1-edf29f553957
+        :id: 34ffa204-9376-41f2-aca1-edf29f553957
 
-        @Assert: User group is deleted successfully.
+        :Assert: User group is deleted successfully.
         """
         user = make_user()
         user_group = make_usergroup({'user-ids': user['id']})
@@ -352,11 +352,11 @@ class UserGroupTestCase(CLITestCase):
         """Create new user group and new role. Then add created role to user
         group by id
 
-        @id: a4ce8724-d3c8-4c00-9421-aaa40394134d
+        :id: a4ce8724-d3c8-4c00-9421-aaa40394134d
 
-        @Assert: Role is added to user group successfully.
+        :Assert: Role is added to user group successfully.
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         role = make_role()
         user_group = make_usergroup()
@@ -372,11 +372,11 @@ class UserGroupTestCase(CLITestCase):
         """Create new user group and new role. Then add created role to user
         group by name
 
-        @id: 181bf2d5-0650-4fb0-890c-475eac3306a2
+        :id: 181bf2d5-0650-4fb0-890c-475eac3306a2
 
-        @Assert: Role is added to user group successfully.
+        :Assert: Role is added to user group successfully.
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         role = make_role()
         user_group = make_usergroup()
@@ -392,11 +392,11 @@ class UserGroupTestCase(CLITestCase):
         """Create new user group and new user. Then add created user to user
         group by id
 
-        @id: f2972e48-67c3-4dc9-8c4b-aa550086afb7
+        :id: f2972e48-67c3-4dc9-8c4b-aa550086afb7
 
-        @Assert: User is added to user group successfully.
+        :Assert: User is added to user group successfully.
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         user = make_user()
         user_group = make_usergroup()
@@ -412,11 +412,11 @@ class UserGroupTestCase(CLITestCase):
         """Create new user group and new user. Then add created user to user
         group by name
 
-        @id: f622eb11-a3d2-4a25-8889-766133750431
+        :id: f622eb11-a3d2-4a25-8889-766133750431
 
-        @Assert: User is added to user group successfully.
+        :Assert: User is added to user group successfully.
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         user = make_user()
         user_group = make_usergroup()
@@ -431,11 +431,11 @@ class UserGroupTestCase(CLITestCase):
     def test_positive_add_user_group_by_id(self):
         """Create two new user groups. Then add one user group to another by id
 
-        @id: f041d325-93c0-4799-88d7-5ece65568266
+        :id: f041d325-93c0-4799-88d7-5ece65568266
 
-        @Assert: User group is added to another user group successfully.
+        :Assert: User group is added to another user group successfully.
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         sub_user_group = make_usergroup()
         user_group = make_usergroup()
@@ -451,11 +451,11 @@ class UserGroupTestCase(CLITestCase):
         """Create two new user groups. Then add one user group to another by
         name
 
-        @id: de60c347-b440-45c6-8e79-19aa0d338099
+        :id: de60c347-b440-45c6-8e79-19aa0d338099
 
-        @Assert: User group is added to another user group successfully.
+        :Assert: User group is added to another user group successfully.
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         sub_user_group = make_usergroup()
         user_group = make_usergroup()
@@ -472,11 +472,11 @@ class UserGroupTestCase(CLITestCase):
         """Create new user group using valid role attached to that group. Then
         remove that role from user group by id
 
-        @id: f086e7f0-4a24-4097-8ec6-3f698ac926ba
+        :id: f086e7f0-4a24-4097-8ec6-3f698ac926ba
 
-        @Assert: Role is removed from user group successfully.
+        :Assert: Role is removed from user group successfully.
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         role = make_role()
         user_group = make_usergroup({'role-ids': role['id']})
@@ -494,11 +494,11 @@ class UserGroupTestCase(CLITestCase):
         """Create new user group using valid role attached to that group. Then
         remove that role from user group by name
 
-        @id: 0a5fdeaf-a05f-4153-b2c8-c5f8745cbb80
+        :id: 0a5fdeaf-a05f-4153-b2c8-c5f8745cbb80
 
-        @Assert: Role is removed from user group successfully.
+        :Assert: Role is removed from user group successfully.
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         role = make_role()
         user_group = make_usergroup({'role-ids': role['id']})
@@ -516,11 +516,11 @@ class UserGroupTestCase(CLITestCase):
         """Create new user group using valid user attached to that group. Then
         remove that user from user group by id
 
-        @id: 9ae91110-88dd-4449-82c7-59f626fdd2be
+        :id: 9ae91110-88dd-4449-82c7-59f626fdd2be
 
-        @Assert: User is removed from user group successfully.
+        :Assert: User is removed from user group successfully.
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         user = make_user()
         user_group = make_usergroup({'user-ids': user['id']})
@@ -538,11 +538,11 @@ class UserGroupTestCase(CLITestCase):
         """Create new user group using valid user attached to that group. Then
         remove that user from user group by name
 
-        @id: e99b215b-05bb-4e7b-a11a-cd506d88df6c
+        :id: e99b215b-05bb-4e7b-a11a-cd506d88df6c
 
-        @Assert: User is removed from user group successfully.
+        :Assert: User is removed from user group successfully.
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         user = make_user()
         user_group = make_usergroup({'user-ids': user['id']})
@@ -560,11 +560,11 @@ class UserGroupTestCase(CLITestCase):
         """Create new user group using another user group attached to the
         initial group. Then remove that attached user group by id
 
-        @id: e7e8ccb2-a93d-420d-b71e-218ffbb428b4
+        :id: e7e8ccb2-a93d-420d-b71e-218ffbb428b4
 
-        @Assert: User group is removed from initial one successfully.
+        :Assert: User group is removed from initial one successfully.
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         sub_user_group = make_usergroup()
         user_group = make_usergroup({'user-group-ids': sub_user_group['id']})
@@ -582,11 +582,11 @@ class UserGroupTestCase(CLITestCase):
         """Create new user group using another user group attached to the
         initial group. Then remove that attached user group by name
 
-        @id: 45a070b5-60b1-4c8c-8171-9d63e0a55698
+        :id: 45a070b5-60b1-4c8c-8171-9d63e0a55698
 
-        @Assert: User group is removed from initial one successfully.
+        :Assert: User group is removed from initial one successfully.
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         sub_user_group = make_usergroup()
         user_group = make_usergroup({'user-group-ids': sub_user_group['id']})

--- a/tests/foreman/cli/test_variables.py
+++ b/tests/foreman/cli/test_variables.py
@@ -1,19 +1,19 @@
 # -*- encoding: utf-8 -*-
 """Test class for Puppet Smart Variables
 
-@Requirement: Variables
+:Requirement: Variables
 
-@CaseAutomation: Automated
+:CaseAutomation: Automated
 
-@CaseLevel: Acceptance
+:CaseLevel: Acceptance
 
-@CaseComponent: CLI
+:CaseComponent: CLI
 
-@TestType: Functional
+:TestType: Functional
 
-@CaseImportance: High
+:CaseImportance: High
 
-@Upstream: No
+:Upstream: No
 """
 from random import choice
 
@@ -92,11 +92,11 @@ class SmartVariablesTestCase(CLITestCase):
     def test_positive_list_by_host_name(self):
         """List all smart variables associated to host by hostname.
 
-        @id: ee0da54c-ab60-4dde-8e1f-d548b52bac73
+        :id: ee0da54c-ab60-4dde-8e1f-d548b52bac73
 
-        @assert: Smart Variables listed for specific Host by hostname.
+        :assert: Smart Variables listed for specific Host by hostname.
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         smart_variable = make_smart_variable(
             {'puppet-class': self.puppet_class['name']})
@@ -118,11 +118,11 @@ class SmartVariablesTestCase(CLITestCase):
     def test_positive_list_by_host_id(self):
         """List all smart variables associated to host by host id.
 
-        @id: ee2e994b-2a6d-4069-a2f7-e244a3134772
+        :id: ee2e994b-2a6d-4069-a2f7-e244a3134772
 
-        @assert: Smart Variables listed for specific Host by host id.
+        :assert: Smart Variables listed for specific Host by host id.
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         smart_variable = make_smart_variable(
             {'puppet-class': self.puppet_class['name']})
@@ -142,12 +142,12 @@ class SmartVariablesTestCase(CLITestCase):
     def test_positive_list_by_hostgroup_name(self):
         """List all smart variables associated to hostgroup by hostgroup name
 
-        @id: cb69abe0-2349-4114-91e9-ef93f261dc50
+        :id: cb69abe0-2349-4114-91e9-ef93f261dc50
 
-        @assert: Smart Variables listed for specific HostGroup by hostgroup
-        name.
+        :assert: Smart Variables listed for specific HostGroup by hostgroup
+            name.
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         smart_variable = make_smart_variable(
             {'puppet-class': self.puppet_class['name']})
@@ -168,11 +168,11 @@ class SmartVariablesTestCase(CLITestCase):
     def test_positive_list_by_hostgroup_id(self):
         """List all smart variables associated to hostgroup by hostgroup id
 
-        @id: 0f167c4c-e4de-4b66-841f-d5a9e410391e
+        :id: 0f167c4c-e4de-4b66-841f-d5a9e410391e
 
-        @assert: Smart Variables listed for specific HostGroup by hostgroup id.
+        :assert: Smart Variables listed for specific HostGroup by hostgroup id.
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         smart_variable = make_smart_variable(
             {'puppet-class': self.puppet_class['name']})
@@ -192,10 +192,10 @@ class SmartVariablesTestCase(CLITestCase):
         """List all smart variables associated to puppet class by puppet class
         name.
 
-        @id: 43b795c2-a64d-4a84-bb35-1e8fd0e1a0c9
+        :id: 43b795c2-a64d-4a84-bb35-1e8fd0e1a0c9
 
-        @assert: Smart Variables listed for specific puppet class by puppet
-        class name.
+        :assert: Smart Variables listed for specific puppet class by puppet
+            class name.
         """
         smart_variable = make_smart_variable(
             {'puppet-class': self.puppet_class['name']})
@@ -214,10 +214,10 @@ class SmartVariablesTestCase(CLITestCase):
         """List all smart variables associated to puppet class by puppet class
         id.
 
-        @id: 57d290e8-2ae2-4c09-ab1e-7c7914bc4ba8
+        :id: 57d290e8-2ae2-4c09-ab1e-7c7914bc4ba8
 
-        @assert: Smart Variables listed for specific puppet class by puppet
-        class id.
+        :assert: Smart Variables listed for specific puppet class by puppet
+            class id.
         """
         smart_variable = make_smart_variable(
             {'puppet-class-id': self.puppet_class['id']})
@@ -233,13 +233,11 @@ class SmartVariablesTestCase(CLITestCase):
     def test_positive_create(self):
         """Create a Smart Variable.
 
-        @id: 8be9ed26-9a27-42a8-8edd-b255637f205e
+        :id: 8be9ed26-9a27-42a8-8edd-b255637f205e
 
-        @steps:
+        :steps: Create a smart Variable with Valid name.
 
-        1. Create a smart Variable with Valid name.
-
-        @assert: The smart Variable is created successfully.
+        :assert: The smart Variable is created successfully.
         """
         for name in valid_data_list():
             with self.subTest(name):
@@ -254,13 +252,11 @@ class SmartVariablesTestCase(CLITestCase):
     def test_negative_create(self):
         """Create Smart Variable with invalid name.
 
-        @id: 3f71f39f-4178-42e7-be40-2a3538361466
+        :id: 3f71f39f-4178-42e7-be40-2a3538361466
 
-        @steps:
+        :steps: Create a smart Variable with Invalid name.
 
-        1. Create a smart Variable with Invalid name.
-
-        @assert: The smart Variable is not created.
+        :assert: The smart Variable is not created.
         """
         for name in invalid_values_list():
             with self.subTest(name):
@@ -275,13 +271,11 @@ class SmartVariablesTestCase(CLITestCase):
     def test_positive_delete_smart_variable_by_id(self):
         """Delete a Smart Variable by id.
 
-        @id: b0c4f7f0-d568-411f-94c2-fa525f36a8fd
+        :id: b0c4f7f0-d568-411f-94c2-fa525f36a8fd
 
-        @steps:
+        :steps: Delete a smart Variable by id.
 
-        1. Delete a smart Variable by id.
-
-        @assert: The smart Variable is deleted successfully.
+        :assert: The smart Variable is deleted successfully.
         """
         smart_variable = make_smart_variable({
             'puppet-class': self.puppet_class['name']})
@@ -294,13 +288,11 @@ class SmartVariablesTestCase(CLITestCase):
     def test_positive_delete_smart_variable_by_name(self):
         """Delete a Smart Variable by name.
 
-        @id: 52900000-d7e1-4f0c-b67e-a2a1d25fc76e
+        :id: 52900000-d7e1-4f0c-b67e-a2a1d25fc76e
 
-        @steps:
+        :steps: Delete a smart Variable by name.
 
-        1. Delete a smart Variable by name.
-
-        @assert: The smart Variable is deleted successfully.
+        :assert: The smart Variable is deleted successfully.
         """
         smart_variable = make_smart_variable({
             'puppet-class': self.puppet_class['name']})
@@ -313,15 +305,15 @@ class SmartVariablesTestCase(CLITestCase):
     def test_positive_update_variable_puppet_class(self):
         """Update Smart Variable's puppet class.
 
-        @id: 0f2d617b-c9ec-46e9-ac84-7a0d59a84811
+        :id: 0f2d617b-c9ec-46e9-ac84-7a0d59a84811
 
-        @steps:
+        :steps:
 
-        1. Create a smart variable with valid name.
-        2. Update the puppet class associated to the smart variable created in
-           step1.
+            1. Create a smart variable with valid name.
+            2. Update the puppet class associated to the smart variable created
+               in step1.
 
-        @assert: The variable is updated with new puppet class.
+        :assert: The variable is updated with new puppet class.
         """
         smart_variable = make_smart_variable({
             'puppet-class': self.puppet_class['name']})
@@ -343,14 +335,14 @@ class SmartVariablesTestCase(CLITestCase):
     def test_positive_update_name(self):
         """Update Smart Variable's name
 
-        @id: e73c1366-6745-4576-ae22-d87cbf03faf9
+        :id: e73c1366-6745-4576-ae22-d87cbf03faf9
 
-        @steps:
+        :steps:
 
-        1. Create a smart variable with valid name.
-        2. Update smart variable name created in step1.
+            1. Create a smart variable with valid name.
+            2. Update smart variable name created in step1.
 
-        @assert: The variable is updated with new name.
+        :assert: The variable is updated with new name.
         """
         smart_variable = make_smart_variable({
             'puppet-class': self.puppet_class['name']})
@@ -369,15 +361,16 @@ class SmartVariablesTestCase(CLITestCase):
     def test_negative_duplicate_name_variable(self):
         """Create Smart Variable with an existing name.
 
-        @id: cc219111-1d2a-47ae-9b22-0b399f2d586d
+        :id: cc219111-1d2a-47ae-9b22-0b399f2d586d
 
-        @steps:
+        :steps:
 
-        1. Create a smart Variable with Valid name and default value.
-        2. Attempt to create a variable with same name from same/other class.
+            1. Create a smart Variable with Valid name and default value.
+            2. Attempt to create a variable with same name from same/other
+               class.
 
-        @assert: The variable with same name are not allowed to create from
-        any class.
+        :assert: The variable with same name are not allowed to create from any
+            class.
         """
         name = gen_string('alpha')
         make_smart_variable(
@@ -391,13 +384,12 @@ class SmartVariablesTestCase(CLITestCase):
     def test_positive_create_with_default_value(self):
         """Create a Smart Variable with default value.
 
-        @id: 31c9e92d-94d2-4cbf-b496-c5f038182c20
+        :id: 31c9e92d-94d2-4cbf-b496-c5f038182c20
 
-        @steps:
+        :steps: Create a smart Variable with Valid name and valid default
+            value.
 
-        1. Create a smart Variable with Valid name and valid default value.
-
-        @assert: The smart Variable is created successfully.
+        :assert: The smart Variable is created successfully.
         """
         for value in valid_data_list():
             with self.subTest(value):
@@ -415,15 +407,13 @@ class SmartVariablesTestCase(CLITestCase):
 
         Types - string, boolean, integer, real, array, hash, yaml, json
 
-        @id: 63d9c79a-5d54-44f8-b36d-45eb183cb148
+        :id: 63d9c79a-5d54-44f8-b36d-45eb183cb148
 
-        @steps:
+        :steps: Create a variable with valid key type and default value.
 
-        1.  Create a variable with valid key type and default value.
+        :assert: Variable is created with a new type successfully.
 
-        @assert: Variable is created with a new type successfully.
-
-        @caseautomation: notautomated
+        :caseautomation: notautomated
         """
 
     @run_only_on('sat')
@@ -434,15 +424,14 @@ class SmartVariablesTestCase(CLITestCase):
 
         Types - string, boolean, integer, real, array, hash, yaml, json
 
-        @id: aab8423e-3857-4ac9-9f18-aec64f95a90d
+        :id: aab8423e-3857-4ac9-9f18-aec64f95a90d
 
-        @steps:
+        :steps: Create a variable with valid key type and invalid default
+            value.
 
-        1.  Create a variable with valid key type and invalid default value.
+        :assert: Variable is not created with new type for invalid value.
 
-        @assert: Variable is not created with new type for invalid value.
-
-        @caseautomation: notautomated
+        :caseautomation: notautomated
         """
 
     @run_only_on('sat')
@@ -450,11 +439,11 @@ class SmartVariablesTestCase(CLITestCase):
     def test_positive_create_empty_matcher_value(self):
         """Create matcher with empty value for string type.
 
-        @id: 00fe9a2b-a4c0-4f3e-9bc3-db22f8625005
+        :id: 00fe9a2b-a4c0-4f3e-9bc3-db22f8625005
 
-        @steps: Create a matcher for variable with type string and empty value
+        :steps: Create a matcher for variable with type string and empty value
 
-        @assert: Matcher is created with empty value
+        :assert: Matcher is created with empty value
         """
         smart_variable = make_smart_variable({
             'puppet-class': self.puppet_class['name'],
@@ -478,12 +467,12 @@ class SmartVariablesTestCase(CLITestCase):
     def test_negative_create_empty_matcher_value(self):
         """Create matcher with empty value for non string type.
 
-        @id: 677a0881-c42a-4063-ac7b-7e7d9b5bc307
+        :id: 677a0881-c42a-4063-ac7b-7e7d9b5bc307
 
-        @steps: Create a matcher for variable with type other than string and
-        empty value
+        :steps: Create a matcher for variable with type other than string and
+            empty value
 
-        @assert: Matcher is not created with empty value
+        :assert: Matcher is not created with empty value
         """
         smart_variable = make_smart_variable({
             'puppet-class': self.puppet_class['name'],
@@ -502,11 +491,11 @@ class SmartVariablesTestCase(CLITestCase):
     def test_negative_create_with_invalid_match_value(self):
         """Attempt to create matcher with invalid match value.
 
-        @id: 1026bc74-1bd0-40ab-81f1-d1371cc49d8f
+        :id: 1026bc74-1bd0-40ab-81f1-d1371cc49d8f
 
-        @steps: Create a matcher for variable with invalid match value
+        :steps: Create a matcher for variable with invalid match value
 
-        @assert: Matcher is not created
+        :assert: Matcher is not created
         """
         smart_variable = make_smart_variable({
             'puppet-class': self.puppet_class['name'],
@@ -523,14 +512,15 @@ class SmartVariablesTestCase(CLITestCase):
     def test_negative_validate_default_value_with_regex(self):
         """Test variable is not created for unmatched validator type regex.
 
-        @id: f728ea2c-f7f4-4d9b-8c92-9681e0b21769
+        :id: f728ea2c-f7f4-4d9b-8c92-9681e0b21769
 
-        @steps:
+        :steps:
 
-        1.  Create a variable with value that doesn't match the regex of step 2
-        2.  Validate this value with regex validator type and valid rule.
+            1.  Create a variable with value that doesn't match the regex of
+                step 2
+            2.  Validate this value with regex validator type and valid rule.
 
-        @assert: Variable is not created for unmatched validator rule.
+        :assert: Variable is not created for unmatched validator rule.
         """
         value = gen_string('alpha')
         smart_variable = make_smart_variable({
@@ -552,15 +542,15 @@ class SmartVariablesTestCase(CLITestCase):
     def test_positive_validate_default_value_with_regex(self):
         """Test variable is created for matched validator type regex.
 
-        @id: f720c888-0ed0-4d32-bf72-8f5db5c1b5ed
+        :id: f720c888-0ed0-4d32-bf72-8f5db5c1b5ed
 
-        @steps:
+        :steps:
 
-        1.  Create a variable with some default value that matches the regex of
-            step 2
-        2.  Validate this value with regex validator type and rule.
+            1.  Create a variable with some default value that matches the
+                regex of step 2
+            2.  Validate this value with regex validator type and rule.
 
-        @assert: Variable is created for matched validator rule.
+        :assert: Variable is created for matched validator rule.
         """
         value = gen_string('numeric').lstrip('0')
         smart_variable = make_smart_variable({
@@ -583,14 +573,15 @@ class SmartVariablesTestCase(CLITestCase):
     def test_negative_validate_matcher_value_with_regex(self):
         """Test matcher is not created for unmatched validator type regex.
 
-        @id: 6542a847-7627-4bc2-828f-33b06d30d4e4
+        :id: 6542a847-7627-4bc2-828f-33b06d30d4e4
 
-        @steps:
+        :steps:
 
-        1.  Create a matcher with value that doesn't match the regex of step 2.
-        2.  Validate this value with regex validator type and rule.
+            1.  Create a matcher with value that doesn't match the regex of
+                step 2.
+            2.  Validate this value with regex validator type and rule.
 
-        @assert: Matcher is not created for unmatched validator rule.
+        :assert: Matcher is not created for unmatched validator rule.
         """
         smart_variable = make_smart_variable({
             'puppet-class': self.puppet_class['name'],
@@ -610,14 +601,14 @@ class SmartVariablesTestCase(CLITestCase):
     def test_positive_validate_matcher_value_with_regex(self):
         """Test matcher is created for matched validator type regex.
 
-        @id: 67e20b4b-cf39-4dbc-b553-80c5d54b7ad2
+        :id: 67e20b4b-cf39-4dbc-b553-80c5d54b7ad2
 
-        @steps:
+        :steps:
 
-        1.  Create a matcher with value that matches the regex of step 2.
-        2.  Validate this value with regex validator type and rule.
+            1.  Create a matcher with value that matches the regex of step 2.
+            2.  Validate this value with regex validator type and rule.
 
-        @assert: Matcher is created for matched validator rule.
+        :assert: Matcher is created for matched validator rule.
         """
         value = gen_string('numeric').lstrip('0')
         smart_variable = make_smart_variable({
@@ -646,14 +637,12 @@ class SmartVariablesTestCase(CLITestCase):
     def test_negative_validate_default_value_with_list(self):
         """Test variable is not created for unmatched validator type list.
 
-        @id: dc2b6471-99d7-448b-b90a-9675baacbebe
+        :id: dc2b6471-99d7-448b-b90a-9675baacbebe
 
-        @steps:
+        :steps: Attempt to create variable with default value that doesn't
+            match values from validator list
 
-        1.  Attempt to create variable with default value that doesn't match
-            values from validator list
-
-        @assert: Variable is not created for unmatched validator rule.
+        :assert: Variable is not created for unmatched validator rule.
         """
         with self.assertRaises(CLIReturnCodeError):
             SmartVariable.create({
@@ -668,14 +657,12 @@ class SmartVariablesTestCase(CLITestCase):
     def test_positive_validate_default_value_with_list(self):
         """Test variable is created for matched validator type list.
 
-        @id: e3cbb3a6-5ac0-43b4-a566-6da758ae4cf6
+        :id: e3cbb3a6-5ac0-43b4-a566-6da758ae4cf6
 
-        @steps:
+        :steps: Create a variable with default value that matches the values
+            from validator list
 
-        1.  Create a variable with default value that matches the values from
-            validator list
-
-        @assert: Variable is created for matched validator rule.
+        :assert: Variable is created for matched validator rule.
         """
         smart_variable = make_smart_variable({
             'puppet-class': self.puppet_class['name'],
@@ -692,15 +679,15 @@ class SmartVariablesTestCase(CLITestCase):
     def test_negative_validate_matcher_value_with_list(self):
         """Test matcher is not created for unmatched validator type list.
 
-        @id: b6523714-8d6f-4b23-8ecf-6972a584bfee
+        :id: b6523714-8d6f-4b23-8ecf-6972a584bfee
 
-        @steps:
+        :steps:
 
-        1.  Create smart variable with proper validator
-        2.  Attempt to associate a matcher with value that doesn't match values
-            from validator list
+            1.  Create smart variable with proper validator
+            2.  Attempt to associate a matcher with value that doesn't match
+                values from validator list
 
-        @assert: Matcher is not created for unmatched validator rule.
+        :assert: Matcher is not created for unmatched validator rule.
         """
         smart_variable = make_smart_variable({
             'puppet-class': self.puppet_class['name'],
@@ -720,15 +707,15 @@ class SmartVariablesTestCase(CLITestCase):
     def test_positive_validate_matcher_value_with_list(self):
         """Test matcher is created for matched validator type list.
 
-        @id: 751e70ba-f1a4-4b73-878f-b2ab260a8a78
+        :id: 751e70ba-f1a4-4b73-878f-b2ab260a8a78
 
-        @steps:
+        :steps:
 
-        1.  Create smart variable with proper validator
-        2.  Create a matcher with value that matches the values from validator
-            list
+            1.  Create smart variable with proper validator
+            2.  Create a matcher with value that matches the values from
+                validator list
 
-        @assert: Matcher is created for matched validator rule.
+        :assert: Matcher is created for matched validator rule.
         """
         smart_variable = make_smart_variable({
             'puppet-class': self.puppet_class['name'],
@@ -757,14 +744,14 @@ class SmartVariablesTestCase(CLITestCase):
     def test_negative_validate_matcher_value_with_default_type(self):
         """Matcher is not created for value not of default type.
 
-        @id: 84463d56-839f-4d5b-8646-cb6772fe5875
+        :id: 84463d56-839f-4d5b-8646-cb6772fe5875
 
-        @steps:
+        :steps:
 
-        1.  Create variable with valid default value.
-        2.  Create matcher with value that doesn't match the default type.
+            1.  Create variable with valid default value.
+            2.  Create matcher with value that doesn't match the default type.
 
-        @assert: Matcher is not created for unmatched type.
+        :assert: Matcher is not created for unmatched type.
         """
         smart_variable = make_smart_variable({
             'puppet-class': self.puppet_class['name'],
@@ -783,14 +770,14 @@ class SmartVariablesTestCase(CLITestCase):
     def test_positive_validate_matcher_value_with_default_type(self):
         """Matcher is created for default type value.
 
-        @id: fc29aeb4-ead9-48ff-92de-3db659e8b0d1
+        :id: fc29aeb4-ead9-48ff-92de-3db659e8b0d1
 
-        @steps:
+        :steps:
 
-        1.  Create variable default type with valid value.
-        2.  Create a matcher with value that matches the default type.
+            1.  Create variable default type with valid value.
+            2.  Create a matcher with value that matches the default type.
 
-        @assert: Matcher is created for matched type.
+        :assert: Matcher is created for matched type.
         """
         smart_variable = make_smart_variable({
             'puppet-class': self.puppet_class['name'],
@@ -816,15 +803,13 @@ class SmartVariablesTestCase(CLITestCase):
     def test_negative_validate_matcher_non_existing_attribute(self):
         """Test matcher creation for non-existing attribute.
 
-        @id: bde1edf6-12b8-457e-ac8f-a909666abfb5
+        :id: bde1edf6-12b8-457e-ac8f-a909666abfb5
 
-        @steps:
+        :steps: Attempt to create a matcher with non existing attribute.
 
-        1.  Attempt to create a matcher with non existing attribute.
+        :assert: Matcher is not created for non-existing attribute.
 
-        @assert: Matcher is not created for non-existing attribute.
-
-        @caseautomation: notautomated
+        :caseautomation: notautomated
         """
 
     @run_only_on('sat')
@@ -832,17 +817,17 @@ class SmartVariablesTestCase(CLITestCase):
     def test_positive_create_matcher(self):
         """Create a Smart Variable with matcher.
 
-        @id: 9ab8ae74-ee58-4738-8d8b-0e465eee8696
+        :id: 9ab8ae74-ee58-4738-8d8b-0e465eee8696
 
-        @steps:
+        :steps:
 
-        1. Create a smart variable with valid name and default value.
-        2. Create a matcher for Host with valid value.
+            1. Create a smart variable with valid name and default value.
+            2. Create a matcher for Host with valid value.
 
-        @assert:
+        :assert:
 
-        1. The smart Variable with matcher is created successfully.
-        2. The variable is associated with host with match.
+            1. The smart Variable with matcher is created successfully.
+            2. The variable is associated with host with match.
         """
         value = gen_string('alpha')
         smart_variable = make_smart_variable({
@@ -866,19 +851,19 @@ class SmartVariablesTestCase(CLITestCase):
         """Create a Smart Variable with matcher and remove that matcher
         afterwards.
 
-        @id: 883e0f3b-6367-4fbb-a0b2-434fbeb10fcf
+        :id: 883e0f3b-6367-4fbb-a0b2-434fbeb10fcf
 
-        @steps:
+        :steps:
 
-        1. Create a smart variable with valid name and default value.
-        2. Create a matcher for that variable.
-        3. Remove just assigned matcher.
+            1. Create a smart variable with valid name and default value.
+            2. Create a matcher for that variable.
+            3. Remove just assigned matcher.
 
-        @assert:
+        :assert:
 
-        1. The smart Variable is created successfully.
-        2. The matcher is associated with variable.
-        3. Matcher removed successfully
+            1. The smart Variable is created successfully.
+            2. The matcher is associated with variable.
+            3. Matcher removed successfully
         """
         value = gen_string('alpha')
         smart_variable = make_smart_variable({
@@ -908,22 +893,22 @@ class SmartVariablesTestCase(CLITestCase):
     def test_positive_create_matcher_attribute_priority(self):
         """Matcher Value set on Attribute Priority for Host.
 
-        @id: 1a774df6-d704-4e89-b951-bc6740c233cd
+        :id: 1a774df6-d704-4e89-b951-bc6740c233cd
 
-        @steps:
+        :steps:
 
-        1.  Create variable with some default value.
-        2.  Set fqdn as top priority attribute.
-        3.  Create first matcher for fqdn with valid details.
-        4.  Create second matcher for some attribute with valid details.
-            Note - The fqdn/host should have this attribute.
-        5.  Go to YAML output of associated host.
+            1.  Create variable with some default value.
+            2.  Set fqdn as top priority attribute.
+            3.  Create first matcher for fqdn with valid details.
+            4.  Create second matcher for some attribute with valid details.
+                Note - The fqdn/host should have this attribute.
+            5.  Go to YAML output of associated host.
 
-        @assert: The YAML output has the value only for fqdn matcher.
+        :assert: The YAML output has the value only for fqdn matcher.
 
-        @caseautomation: notautomated
+        :caseautomation: notautomated
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
 
     @run_only_on('sat')
@@ -932,25 +917,26 @@ class SmartVariablesTestCase(CLITestCase):
     def test_negative_create_matcher_attribute_priority(self):
         """Matcher Value set on Attribute Priority for Host - alternate priority.
 
-        @id: e4e8da4d-f37c-44c8-8cbb-17171cc0648b
+        :id: e4e8da4d-f37c-44c8-8cbb-17171cc0648b
 
-        @steps:
+        :steps:
 
-        1.  Create variable with some default value.
-        2.  Set some attribute(other than fqdn) as top priority attribute.
-            Note - The fqdn/host should have this attribute.
-        3.  Create first matcher for fqdn with valid details.
-        4.  Create second matcher for attribute of step 3 with valid details.
-        5.  Go to YAML output of associated host.
+            1.  Create variable with some default value.
+            2.  Set some attribute(other than fqdn) as top priority attribute.
+                Note - The fqdn/host should have this attribute.
+            3.  Create first matcher for fqdn with valid details.
+            4.  Create second matcher for attribute of step 3 with valid
+                details.
+            5.  Go to YAML output of associated host.
 
-        @assert:
+        :assert:
 
-        1.  The YAML output has the value only for step 5 matcher.
-        2.  The YAML output doesn't have value for fqdn/host matcher.
+            1.  The YAML output has the value only for step 5 matcher.
+            2.  The YAML output doesn't have value for fqdn/host matcher.
 
-        @caseautomation: notautomated
+        :caseautomation: notautomated
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
 
     @run_only_on('sat')
@@ -959,29 +945,29 @@ class SmartVariablesTestCase(CLITestCase):
     def test_positive_create_matcher_merge_override(self):
         """Merge the values of all the associated matchers.
 
-        @id: 2f8e80ff-612f-461e-9498-90ebab2352c5
+        :id: 2f8e80ff-612f-461e-9498-90ebab2352c5
 
-        @steps:
+        :steps:
 
-        1.  Create variable with some default value.
-        2.  Create first matcher for attribute fqdn with valid details.
-        3.  Create second matcher for other attribute with valid details.
-            Note - The fqdn/host should have this attribute.
-        4.  Create more matchers for some more attributes if any.
-            Note - The fqdn/host should have this attributes.
-        5.  Set --merge-overrides to true.
-        6.  Go to YAML output of associated host.
+            1.  Create variable with some default value.
+            2.  Create first matcher for attribute fqdn with valid details.
+            3.  Create second matcher for other attribute with valid details.
+                Note - The fqdn/host should have this attribute.
+            4.  Create more matchers for some more attributes if any.
+                Note - The fqdn/host should have this attributes.
+            5.  Set --merge-overrides to true.
+            6.  Go to YAML output of associated host.
 
-        @assert:
+        :assert:
 
-        1.  The YAML output has the values merged from all the associated
-            matchers.
-        2.  The YAML output doesn't have the default value of variable.
-        3.  Duplicate values in YAML output if any are displayed.
+            1.  The YAML output has the values merged from all the associated
+                matchers.
+            2.  The YAML output doesn't have the default value of variable.
+            3.  Duplicate values in YAML output if any are displayed.
 
-        @caseautomation: notautomated
+        :caseautomation: notautomated
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         smart_variable = make_smart_variable({
             'puppet-class': self.puppet_class['name'],
@@ -1011,30 +997,30 @@ class SmartVariablesTestCase(CLITestCase):
     def test_negative_create_matcher_merge_override(self):
         """Test merge the values from non associated matchers.
 
-        @id: 97831f91-c55a-4861-8730-4857c92f8829
+        :id: 97831f91-c55a-4861-8730-4857c92f8829
 
-        @steps:
+        :steps:
 
-        1.  Create variable with some default value.
-        2.  Create first matcher for attribute fqdn with valid details.
-        3.  Create second matcher for other attribute with valid details.
-            Note - The fqdn/host should not have this attribute.
-        4.  Create more matchers for some more attributes if any.
-            Note - The fqdn/host should not have this attributes.
-        5.  Set --merge-overrides to true.
-        6.  Go to YAML output of associated host.
+            1.  Create variable with some default value.
+            2.  Create first matcher for attribute fqdn with valid details.
+            3.  Create second matcher for other attribute with valid details.
+                Note - The fqdn/host should not have this attribute.
+            4.  Create more matchers for some more attributes if any.
+                Note - The fqdn/host should not have this attributes.
+            5.  Set --merge-overrides to true.
+            6.  Go to YAML output of associated host.
 
-        @assert:
+        :assert:
 
-        1.  The YAML output has the values only for fqdn.
-        2.  The YAML output doesn't have the values for attribute
-            which are not associated to host.
-        3.  The YAML output doesn't have the default value of variable.
-        4.  Duplicate values in YAML output if any are displayed.
+            1.  The YAML output has the values only for fqdn.
+            2.  The YAML output doesn't have the values for attribute which are
+                not associated to host.
+            3.  The YAML output doesn't have the default value of variable.
+            4.  Duplicate values in YAML output if any are displayed.
 
-        @caseautomation: notautomated
+        :caseautomation: notautomated
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
 
     @run_only_on('sat')
@@ -1043,30 +1029,30 @@ class SmartVariablesTestCase(CLITestCase):
     def test_positive_create_matcher_merge_default(self):
         """Merge the values of all the associated matchers + default value.
 
-        @id: 3ff6bddd-c384-41bf-9209-d554b9859da0
+        :id: 3ff6bddd-c384-41bf-9209-d554b9859da0
 
-        @steps:
+        :steps:
 
-        1. Create variable with some default value.
-        2. Create first matcher for attribute fqdn with valid details.
-        3. Create second matcher for other attribute with valid details.
-           Note - The fqdn/host should have this attribute.
-        4. Create more matchers for some more attributes if any.
-           Note - The fqdn/host should have this attributes.
-        5. Set --merge-overrides to true.
-        6. Set --merge-default to true.
-        7. Go to YAML output of associated host.
+            1. Create variable with some default value.
+            2. Create first matcher for attribute fqdn with valid details.
+            3. Create second matcher for other attribute with valid details.
+               Note - The fqdn/host should have this attribute.
+            4. Create more matchers for some more attributes if any.
+               Note - The fqdn/host should have this attributes.
+            5. Set --merge-overrides to true.
+            6. Set --merge-default to true.
+            7. Go to YAML output of associated host.
 
-        @assert:
+        :assert:
 
-        1. The YAML output has the values merged from all
-           the associated matchers.
-        2. The YAML output has the default value of variable.
-        3. Duplicate values in YAML output if any are displayed.
+            1. The YAML output has the values merged from all the associated
+               matchers.
+            2. The YAML output has the default value of variable.
+            3. Duplicate values in YAML output if any are displayed.
 
-        @caseautomation: notautomated
+        :caseautomation: notautomated
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
 
     @run_only_on('sat')
@@ -1075,30 +1061,31 @@ class SmartVariablesTestCase(CLITestCase):
     def test_negative_create_matcher_merge_default(self):
         """Test empty default value in merged values.
 
-        @id: 7a7211f2-be81-4d5b-9a9b-755ba064fc76
+        :id: 7a7211f2-be81-4d5b-9a9b-755ba064fc76
 
-        @steps:
+        :steps:
 
-        1. Create variable with some default value.
-        2. Create first matcher for attribute fqdn with valid details.
-        3. Create second matcher for other attribute with valid details.
-           Note - The fqdn/host should have this attribute.
-        4. Create more matchers for some more attributes if any.
-           Note - The fqdn/host should have this attributes.
-        5. Set --merge-overrides to true.
-        6. Set --merge-default to true.
-        7. Go to YAML output of associated host.
+            1. Create variable with some default value.
+            2. Create first matcher for attribute fqdn with valid details.
+            3. Create second matcher for other attribute with valid details.
+               Note - The fqdn/host should have this attribute.
+            4. Create more matchers for some more attributes if any.
+               Note - The fqdn/host should have this attributes.
+            5. Set --merge-overrides to true.
+            6. Set --merge-default to true.
+            7. Go to YAML output of associated host.
 
-        @assert:
+        :assert:
 
-        1. The YAML output has the values merged from all
-           the associated matchers.
-        2. The YAML output doesn't have the empty default value of variable.
-        3. Duplicate values in YAML output if any are displayed.
+            1.  The YAML output has the values merged from all the associated
+                matchers.
+            2.  The YAML output doesn't have the empty default value of
+                variable.
+            3.  Duplicate values in YAML output if any are displayed.
 
-        @caseautomation: notautomated
+        :caseautomation: notautomated
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
 
     @run_only_on('sat')
@@ -1107,30 +1094,30 @@ class SmartVariablesTestCase(CLITestCase):
     def test_positive_create_matcher_avoid_duplicate(self):
         """Merge the values of all the associated matchers, remove duplicates.
 
-        @id: d37bb265-796b-485f-8305-85c84f830fe5
+        :id: d37bb265-796b-485f-8305-85c84f830fe5
 
-        @steps:
+        :steps:
 
-        1.  Create variable with type array and value.
-        2.  Create first matcher for attribute fqdn with some value.
-        3.  Create second matcher for other attribute with
-            same value as fqdn matcher.
-            Note - The fqdn/host should have this attribute.
-        4.  Set --merge-overrides to true.
-        5.  Set --merge-default to true.
-        6.  Set --avoid -duplicates' to true.
-        7.  Go to YAML output of associated host.
+            1.  Create variable with type array and value.
+            2.  Create first matcher for attribute fqdn with some value.
+            3.  Create second matcher for other attribute with same value as
+                fqdn matcher.
+                Note - The fqdn/host should have this attribute.
+            4.  Set --merge-overrides to true.
+            5.  Set --merge-default to true.
+            6.  Set --avoid -duplicates' to true.
+            7.  Go to YAML output of associated host.
 
-        @assert:
+        :assert:
 
-        1.  The YAML output has the values merged from all
-            the associated matchers.
-        2.  The YAML output has the default value of variable.
-        3.  Duplicate values in YAML output are removed / not displayed.
+            1.  The YAML output has the values merged from all the associated
+                matchers.
+            2.  The YAML output has the default value of variable.
+            3.  Duplicate values in YAML output are removed / not displayed.
 
-        @caseautomation: notautomated
+        :caseautomation: notautomated
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
 
     @run_only_on('sat')
@@ -1139,29 +1126,29 @@ class SmartVariablesTestCase(CLITestCase):
     def test_negative_create_matcher_avoid_duplicate(self):
         """Duplicates not removed as they were not really present.
 
-        @id: 972cf68b-fd3d-4731-97bf-119e03c61b33
+        :id: 972cf68b-fd3d-4731-97bf-119e03c61b33
 
-        @steps:
+        :steps:
 
-        1.  Create variable with type array and value.
-        2.  Create first matcher for attribute fqdn with some value.
-        3.  Create second matcher for other attribute with other value
-            than fqdn matcher and default value.
-            Note - The fqdn/host should have this attribute.
-        4.  Set --merge-overrides to true.
-        5.  Set --merge-default to true.
-        6.  Set --avoid -duplicates' to true.
-        7.  Go to YAML output of associated host.
+            1.  Create variable with type array and value.
+            2.  Create first matcher for attribute fqdn with some value.
+            3.  Create second matcher for other attribute with other value than
+                fqdn matcher and default value.
+                Note - The fqdn/host should have this attribute.
+            4.  Set --merge-overrides to true.
+            5.  Set --merge-default to true.
+            6.  Set --avoid -duplicates' to true.
+            7.  Go to YAML output of associated host.
 
-        @assert:
+        :assert:
 
-        1.  The YAML output has the values merged from all matchers.
-        2.  The YAML output has the default value of variable.
-        3.  No value removed as duplicate value.
+            1.  The YAML output has the values merged from all matchers.
+            2.  The YAML output has the default value of variable.
+            3.  No value removed as duplicate value.
 
-        @caseautomation: notautomated
+        :caseautomation: notautomated
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
 
     @run_only_on('sat')
@@ -1169,15 +1156,16 @@ class SmartVariablesTestCase(CLITestCase):
     def test_positive_enable_merge_overrides_default_flags(self):
         """Enable Merge Overrides, Merge Default flags for supported types.
 
-        @id: c000f408-c293-4915-9432-6b597a2e6ad0
+        :id: c000f408-c293-4915-9432-6b597a2e6ad0
 
-        @steps:
+        :steps:
 
-        1.  Create smart variable with array/hash type.
-        2.  Update smart variable and set corresponding flags to True state.
+            1.  Create smart variable with array/hash type.
+            2.  Update smart variable and set corresponding flags to True
+                state.
 
-        @assert: The Merge Overrides, Merge Default flags are allowed to set
-        True.
+        :assert: The Merge Overrides, Merge Default flags are allowed to set
+            True.
         """
         smart_variable = make_smart_variable({
             'puppet-class': self.puppet_class['name'],
@@ -1201,16 +1189,16 @@ class SmartVariablesTestCase(CLITestCase):
         """Attempt to enable Merge Overrides, Merge Default flags for non
         supported types.
 
-        @id: 306400df-e823-48d6-b541-ef3b20181c78
+        :id: 306400df-e823-48d6-b541-ef3b20181c78
 
-        @steps:
+        :steps:
 
-        1.  Create smart variable with type that is not array/hash.
-        2.  Attempt to update smart variable and set corresponding flags to
-            True state.
+            1.  Create smart variable with type that is not array/hash.
+            2.  Attempt to update smart variable and set corresponding flags to
+                True state.
 
-        @assert: The Merge Overrides, Merge Default flags are not allowed
-        to set to True.
+        :assert: The Merge Overrides, Merge Default flags are not allowed to
+            set to True.
         """
         smart_variable = make_smart_variable({
             'puppet-class': self.puppet_class['name'],
@@ -1234,14 +1222,14 @@ class SmartVariablesTestCase(CLITestCase):
     def test_positive_enable_avoid_duplicates_flag(self):
         """Enable Avoid duplicates flag for supported array type.
 
-        @id: 0c7063e0-8e85-44b7-abae-4def7f68833a
+        :id: 0c7063e0-8e85-44b7-abae-4def7f68833a
 
-        @steps:
+        :steps:
 
-        1. Create smart variable with array/hash type.
-        2. Set '--merge-overrides' to true.
+            1. Create smart variable with array/hash type.
+            2. Set '--merge-overrides' to true.
 
-        @assert: The '--avoid-duplicates' flag is allowed to set true.
+        :assert: The '--avoid-duplicates' flag is allowed to set true.
         """
         smart_variable = make_smart_variable({
             'puppet-class': self.puppet_class['name'],
@@ -1265,20 +1253,20 @@ class SmartVariablesTestCase(CLITestCase):
     def test_negative_enable_avoid_duplicates_flag(self):
         """Attempt to enable Avoid duplicates flag for non supported types.
 
-        @id: ea1e8e31-4374-4172-82fd-538d29d70c03
+        :id: ea1e8e31-4374-4172-82fd-538d29d70c03
 
-        @steps:
+        :steps:
 
-        1.  Create smart variable with type that is not array/hash.
-        2.  Attempt to update smart variable and set corresponding flags to
-            True state.
+            1.  Create smart variable with type that is not array/hash.
+            2.  Attempt to update smart variable and set corresponding flags to
+                True state.
 
-        @assert:
+        :assert:
 
-        1.  The '--merge-overrides' is only allowed to set to true for type
-            hash.
-        2.  The '--avoid-duplicates' is not allowed to set to true for type
-            other than array.
+            1.  The '--merge-overrides' is only allowed to set to true for type
+                hash.
+            2.  The '--avoid-duplicates' is not allowed to set to true for type
+                other than array.
         """
         smart_variable = make_smart_variable({
             'puppet-class': self.puppet_class['name'],
@@ -1301,21 +1289,21 @@ class SmartVariablesTestCase(CLITestCase):
     def test_positive_impact_delete_attribute(self):
         """Impact on variable after deleting associated attribute.
 
-        @id: ac6f3a65-ed39-4e97-bdee-349f08bd878e
+        :id: ac6f3a65-ed39-4e97-bdee-349f08bd878e
 
-        @steps:
+        :steps:
 
-        1.  Create a variable with matcher for some attribute.
-        2.  Delete the attribute.
-        3.  Recreate the attribute with same name as earlier.
+            1.  Create a variable with matcher for some attribute.
+            2.  Delete the attribute.
+            3.  Recreate the attribute with same name as earlier.
 
-        @assert:
+        :assert:
 
-        1.  The matcher for deleted attribute removed from variable.
-        2.  On recreating attribute, the matcher should not reappear in
-            variable.
+            1.  The matcher for deleted attribute removed from variable.
+            2.  On recreating attribute, the matcher should not reappear in
+                variable.
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         hostgroup_name = gen_string('alpha')
         matcher_value = gen_string('alpha')
@@ -1357,16 +1345,16 @@ class SmartVariablesTestCase(CLITestCase):
     def test_positive_hide_default_value(self):
         """Test hiding of the default value of variable.
 
-        @id: 00dd5627-5d7c-4fb2-9bbc-bf812205459e
+        :id: 00dd5627-5d7c-4fb2-9bbc-bf812205459e
 
-        @steps:
+        :steps:
 
-        1. Create a variable.
-        2. Enter some valid default value.
-        3. Set '--hidden-value' to true.
+            1. Create a variable.
+            2. Enter some valid default value.
+            3. Set '--hidden-value' to true.
 
-        @assert: The 'hidden value' set to true for that variable. Default
-        value is hidden
+        :assert: The 'hidden value' set to true for that variable. Default
+            value is hidden
         """
         smart_variable = make_smart_variable({
             'puppet-class': self.puppet_class['name'],
@@ -1381,15 +1369,15 @@ class SmartVariablesTestCase(CLITestCase):
     def test_positive_unhide_default_value(self):
         """Test unhiding of the default value of variable.
 
-        @id: e1928ebf-32dd-4fb6-a40b-4c84507c1e2f
+        :id: e1928ebf-32dd-4fb6-a40b-4c84507c1e2f
 
-        @steps:
+        :steps:
 
-        1. Create a variable with some default value.
-        2. Set '--hidden-value' to true.
-        3. After hiding, set '--hidden-value' to false.
+            1. Create a variable with some default value.
+            2. Set '--hidden-value' to true.
+            3. After hiding, set '--hidden-value' to false.
 
-        @assert: The hidden value is set to false.
+        :assert: The hidden value is set to false.
         """
         smart_variable = make_smart_variable({
             'puppet-class': self.puppet_class['name'],
@@ -1410,18 +1398,18 @@ class SmartVariablesTestCase(CLITestCase):
     def test_positive_update_hidden_value(self):
         """Update the hidden default value of variable.
 
-        @id: 944d3fb9-ce90-47d8-bc54-fdf505bd5317
+        :id: 944d3fb9-ce90-47d8-bc54-fdf505bd5317
 
-        @steps:
+        :steps:
 
-        1. Create a variable with some valid default value.
-        2. Set '--hidden-value' to true.
-        3. Again update the default value.
+            1. Create a variable with some valid default value.
+            2. Set '--hidden-value' to true.
+            3. Again update the default value.
 
-        @assert:
+        :assert:
 
-        1. The variable default value is updated.
-        2. The variable '--hidden-value' is set true.
+            1. The variable default value is updated.
+            2. The variable '--hidden-value' is set true.
         """
         value = gen_string('alpha')
         smart_variable = make_smart_variable({
@@ -1443,17 +1431,17 @@ class SmartVariablesTestCase(CLITestCase):
     def test_positive_hide_empty_default_value(self):
         """Hiding the empty default value.
 
-        @id: dc4f7200-dd20-4b63-a27a-e6dc4d5607a5
+        :id: dc4f7200-dd20-4b63-a27a-e6dc4d5607a5
 
-        @steps:
+        :steps:
 
-        1.  Create a variable with empty value.
-        2.  Set '--hidden-value' to true.
+            1.  Create a variable with empty value.
+            2.  Set '--hidden-value' to true.
 
-        @assert:
+        :assert:
 
-        1.  The '--hidden-value' is set to true.
-        2.  The default value is empty.
+            1.  The '--hidden-value' is set to true.
+            2.  The default value is empty.
         """
         smart_variable = make_smart_variable({
             'puppet-class': self.puppet_class['name'],

--- a/tests/foreman/endtoend/test_api_endtoend.py
+++ b/tests/foreman/endtoend/test_api_endtoend.py
@@ -1,19 +1,19 @@
 # coding=utf-8
 """Smoke tests for the ``API`` end-to-end scenario.
 
-@Requirement: Api endtoend
+:Requirement: Api endtoend
 
-@CaseAutomation: Automated
+:CaseAutomation: Automated
 
-@CaseLevel: Acceptance
+:CaseLevel: Acceptance
 
-@CaseComponent: API
+:CaseComponent: API
 
-@TestType: Functional
+:TestType: Functional
 
-@CaseImportance: High
+:CaseImportance: High
 
-@Upstream: No
+:Upstream: No
 """
 import random
 
@@ -786,9 +786,9 @@ class AvailableURLsTestCase(TestCase):
     def test_positive_get_status_code(self):
         """GET ``api/v2`` and examine the response.
 
-        @id: 9d9c1afd-9158-419e-9a6e-91e9888f0c04
+        :id: 9d9c1afd-9158-419e-9a6e-91e9888f0c04
 
-        @Assert: HTTP 200 is returned with an ``application/json`` content-type
+        :Assert: HTTP 200 is returned with an ``application/json`` content-type
 
         """
         response = client.get(
@@ -802,9 +802,9 @@ class AvailableURLsTestCase(TestCase):
     def test_positive_get_links(self):
         """GET ``api/v2`` and check the links returned.
 
-        @id: 7b2dd77a-a821-485b-94db-b583f93c9a89
+        :id: 7b2dd77a-a821-485b-94db-b583f93c9a89
 
-        @Assert: The paths returned are equal to ``API_PATHS``.
+        :Assert: The paths returned are equal to ``API_PATHS``.
 
         """
         # Did the server give us any paths at all?
@@ -868,9 +868,9 @@ class EndToEndTestCase(TestCase, ClientProvisioningMixin):
     def test_positive_find_default_org(self):
         """Check if 'Default Organization' is present
 
-        @id: c6e45b36-d8b6-4507-8dcd-0645668496b9
+        :id: c6e45b36-d8b6-4507-8dcd-0645668496b9
 
-        @Assert: 'Default Organization' is found
+        :Assert: 'Default Organization' is found
 
         """
         results = entities.Organization().search(
@@ -882,9 +882,9 @@ class EndToEndTestCase(TestCase, ClientProvisioningMixin):
     def test_positive_find_default_loc(self):
         """Check if 'Default Location' is present
 
-        @id: 1f40b3c6-488d-4037-a7ab-250a02bf919a
+        :id: 1f40b3c6-488d-4037-a7ab-250a02bf919a
 
-        @Assert: 'Default Location' is found
+        :Assert: 'Default Location' is found
 
         """
         results = entities.Location().search(
@@ -896,9 +896,9 @@ class EndToEndTestCase(TestCase, ClientProvisioningMixin):
     def test_positive_find_admin_user(self):
         """Check if Admin User is present
 
-        @id: 892fdfcd-18c0-42ef-988b-f13a04097f5c
+        :id: 892fdfcd-18c0-42ef-988b-f13a04097f5c
 
-        @Assert: Admin User is found and has Admin role
+        :Assert: Admin User is found and has Admin role
 
         """
         results = entities.User().search(query={'search': 'login=admin'})
@@ -908,9 +908,9 @@ class EndToEndTestCase(TestCase, ClientProvisioningMixin):
     def test_positive_ping(self):
         """Check if all services are running
 
-        @id: b8ecc7ba-8007-4067-bf99-21a82c833de7
+        :id: b8ecc7ba-8007-4067-bf99-21a82c833de7
 
-        @Assert: Overall and individual services status should be 'ok'.
+        :Assert: Overall and individual services status should be 'ok'.
 
         """
         response = entities.Ping().search_json()
@@ -958,10 +958,10 @@ class EndToEndTestCase(TestCase, ClientProvisioningMixin):
             19. Create a new hostgroup and associate previous entities to it
             20. Provision a client
 
-        @id: b2f73740-d3ce-4e6e-abc7-b23e5562bac1
+        :id: b2f73740-d3ce-4e6e-abc7-b23e5562bac1
 
-        @Assert: All tests should succeed and Content should be successfully
-        fetched by client.
+        :Assert: All tests should succeed and Content should be successfully
+            fetched by client.
         """
         # step 1: Create a new user with admin permissions
         login = gen_string('alphanumeric')

--- a/tests/foreman/endtoend/test_cli_endtoend.py
+++ b/tests/foreman/endtoend/test_cli_endtoend.py
@@ -1,19 +1,19 @@
 # coding=utf-8
 """Smoke tests for the ``CLI`` end-to-end scenario.
 
-@Requirement: Cli endtoend
+:Requirement: Cli endtoend
 
-@CaseAutomation: Automated
+:CaseAutomation: Automated
 
-@CaseLevel: Acceptance
+:CaseLevel: Acceptance
 
-@CaseComponent: CLI
+:CaseComponent: CLI
 
-@TestType: Functional
+:TestType: Functional
 
-@CaseImportance: High
+:CaseImportance: High
 
-@Upstream: No
+:Upstream: No
 """
 import random
 
@@ -69,9 +69,9 @@ class EndToEndTestCase(CLITestCase, ClientProvisioningMixin):
     def test_positive_find_default_org(self):
         """Check if 'Default Organization' is present
 
-        @id: 95ffeb7a-134e-4273-bccc-fe8a3a336b2a
+        :id: 95ffeb7a-134e-4273-bccc-fe8a3a336b2a
 
-        @Assert: 'Default Organization' is found
+        :Assert: 'Default Organization' is found
         """
         result = Org.info({u'name': DEFAULT_ORG})
         self.assertEqual(result['name'], DEFAULT_ORG)
@@ -79,9 +79,9 @@ class EndToEndTestCase(CLITestCase, ClientProvisioningMixin):
     def test_positive_find_default_loc(self):
         """Check if 'Default Location' is present
 
-        @id: 11cf0d06-78ff-47e8-9d50-407a2ea31988
+        :id: 11cf0d06-78ff-47e8-9d50-407a2ea31988
 
-        @Assert: 'Default Location' is found
+        :Assert: 'Default Location' is found
         """
         result = Location.info({u'name': DEFAULT_LOC})
         self.assertEqual(result['name'], DEFAULT_LOC)
@@ -89,9 +89,9 @@ class EndToEndTestCase(CLITestCase, ClientProvisioningMixin):
     def test_positive_find_admin_user(self):
         """Check if Admin User is present
 
-        @id: f6755189-05a6-4d2f-a3b8-98be0cfacaee
+        :id: f6755189-05a6-4d2f-a3b8-98be0cfacaee
 
-        @Assert: Admin User is found and has Admin role
+        :Assert: Admin User is found and has Admin role
         """
         result = User.info({u'login': u'admin'})
         self.assertEqual(result['login'], 'admin')
@@ -124,10 +124,10 @@ class EndToEndTestCase(CLITestCase, ClientProvisioningMixin):
             19. Create a new hostgroup and associate previous entities to it
             20. Provision a client
 
-        @id: 8c8b3ffa-0d54-436b-8eeb-1a3542e100a8
+        :id: 8c8b3ffa-0d54-436b-8eeb-1a3542e100a8
 
-        @Assert: All tests should succeed and Content should be successfully
-        fetched by client.
+        :Assert: All tests should succeed and Content should be successfully
+            fetched by client.
         """
         # step 1: Create a new user with admin permissions
         password = gen_alphanumeric()

--- a/tests/foreman/endtoend/test_ui_endtoend.py
+++ b/tests/foreman/endtoend/test_ui_endtoend.py
@@ -1,19 +1,19 @@
 # coding=utf-8
 """Smoke tests for the ``UI`` end-to-end scenario.
 
-@Requirement: Ui endtoend
+:Requirement: Ui endtoend
 
-@CaseAutomation: Automated
+:CaseAutomation: Automated
 
-@CaseLevel: Acceptance
+:CaseLevel: Acceptance
 
-@CaseComponent: UI
+:CaseComponent: UI
 
-@TestType: Functional
+:TestType: Functional
 
-@CaseImportance: High
+:CaseImportance: High
 
-@Upstream: No
+:Upstream: No
 """
 
 from fauxfactory import gen_string, gen_ipaddr
@@ -74,11 +74,11 @@ class EndToEndTestCase(UITestCase, ClientProvisioningMixin):
         cls.fake_manifest_is_set = setting_is_set('fake_manifest')
 
     def test_positive_find_default_org(self):
-        """@Test: Check if :data:`robottelo.constants.DEFAULT_ORG` is present
+        """Check if :data:`robottelo.constants.DEFAULT_ORG` is present
 
-        @id: 90646b0a-ce56-43cf-8cd7-2b4586478acc
+        :id: 90646b0a-ce56-43cf-8cd7-2b4586478acc
 
-        @Assert: 'Default Organization' is found
+        :Assert: 'Default Organization' is found
         """
         with Session(self.browser) as session:
             self.assertEqual(
@@ -87,11 +87,11 @@ class EndToEndTestCase(UITestCase, ClientProvisioningMixin):
             )
 
     def test_positive_find_default_loc(self):
-        """@Test: Check if :data:`robottelo.constants.DEFAULT_LOC` is present
+        """Check if :data:`robottelo.constants.DEFAULT_LOC` is present
 
-        @id: 4b7cc80b-7368-4ee4-8aaf-c946968e49a4
+        :id: 4b7cc80b-7368-4ee4-8aaf-c946968e49a4
 
-        @Assert: 'Default Location' is found
+        :Assert: 'Default Location' is found
         """
         with Session(self.browser) as session:
             self.assertEqual(
@@ -102,9 +102,9 @@ class EndToEndTestCase(UITestCase, ClientProvisioningMixin):
     def test_positive_find_admin_user(self):
         """Check if Admin User is present
 
-        @id: 9cab1b65-70af-4245-98cb-7da90a98d347
+        :id: 9cab1b65-70af-4245-98cb-7da90a98d347
 
-        @Assert: Admin User is found and has Admin role
+        :Assert: Admin User is found and has Admin role
         """
         with Session(self.browser):
             self.assertTrue(self.user.user_admin_role_toggle('admin'))
@@ -136,10 +136,10 @@ class EndToEndTestCase(UITestCase, ClientProvisioningMixin):
             19. Create a new hostgroup and associate previous entities to it
             20. Provision a client
 
-        @id: 6b7c6187-3cc2-4bd3-89f2-fa7a5f570986
+        :id: 6b7c6187-3cc2-4bd3-89f2-fa7a5f570986
 
-        @Assert: All tests should succeed and Content should be successfully
-        fetched by client.
+        :Assert: All tests should succeed and Content should be successfully
+            fetched by client.
         """
         activation_key_name = gen_string('alpha')
         compute_resource_name = gen_string('alpha')
@@ -330,9 +330,9 @@ class EndToEndTestCase(UITestCase, ClientProvisioningMixin):
     def test_positive_puppet_install(self):
         """Perform puppet end to end smoke tests using RH repos.
 
-        @id: 30b0f872-d035-431a-988f-2b3fde620c78
+        :id: 30b0f872-d035-431a-988f-2b3fde620c78
 
-        @Assert: Client should get configured by puppet-module.
+        :Assert: Client should get configured by puppet-module.
         """
         activation_key_name = gen_string('alpha')
         cv_name = gen_string('alpha')

--- a/tests/foreman/installer/test_infoblox.py
+++ b/tests/foreman/installer/test_infoblox.py
@@ -1,18 +1,18 @@
 """Tests for Infoblox Plugin
 
-@Requirement: Infoblox
+:Requirement: Infoblox
 
-@CaseAutomation: Automated
+:CaseAutomation: Automated
 
-@CaseLevel: System
+:CaseLevel: System
 
-@CaseComponent: Installer
+:CaseComponent: Installer
 
-@TestType: Functional
+:TestType: Functional
 
-@CaseImportance: High
+:CaseImportance: High
 
-@Upstream: No
+:Upstream: No
 """
 
 from robottelo.decorators import stubbed, tier3
@@ -25,21 +25,21 @@ class InfobloxTestCase(TestCase):
     def test_set_dns_provider(self):
         """Check Infoblox DNS plugin is set as provider
 
-        @id: 23f76fa8-79bb-11e6-a3d4-68f72889dc7f
+        :id: 23f76fa8-79bb-11e6-a3d4-68f72889dc7f
 
-        @Steps: Set infoblox as dns provider with options
-        --foreman-proxy-dns=true
-        --foreman-proxy-plugin-provider=infoblox
-        --enable-foreman-proxy-plugin-dns-infoblox
-        --foreman-proxy-plugin-dns-infoblox-dns-server=<ip>
-        --foreman-proxy-plugin-dns-infoblox-username=<username>
-        --foreman-proxy-plugin-dns-infoblox-password=<password>
+        :Steps: Set infoblox as dns provider with options
+            --foreman-proxy-dns=true
+            --foreman-proxy-plugin-provider=infoblox
+            --enable-foreman-proxy-plugin-dns-infoblox
+            --foreman-proxy-plugin-dns-infoblox-dns-server=<ip>
+            --foreman-proxy-plugin-dns-infoblox-username=<username>
+            --foreman-proxy-plugin-dns-infoblox-password=<password>
 
-        @Assert: Check inflobox is set as DNS provider
+        :Assert: Check inflobox is set as DNS provider
 
-        @CaseLevel: System
+        :CaseLevel: System
 
-        @caseautomation: notautomated
+        :caseautomation: notautomated
         """
 
     @stubbed()
@@ -47,21 +47,21 @@ class InfobloxTestCase(TestCase):
     def test_set_dhcp_provider(self):
         """Check Infoblox DHCP plugin is set as provider
 
-        @id: 40783976-7e68-11e6-b728-68f72889dc7f
+        :id: 40783976-7e68-11e6-b728-68f72889dc7f
 
-        @Steps: Set infoblox as dhcp provider with options
-        --foreman-proxy-dhcp=true
-        --foreman-proxy-plugin-dhcp-provider=infoblox
-        --enable-foreman-proxy-plugin-dhcp-infoblox
-        --foreman-proxy-plugin-dhcp-infoblox-dhcp-server=<ip>
-        --foreman-proxy-plugin-dhcp-infoblox-username=<username>
-        --foreman-proxy-plugin-dhcp-infoblox-password=<password>
+        :Steps: Set infoblox as dhcp provider with options
+            --foreman-proxy-dhcp=true
+            --foreman-proxy-plugin-dhcp-provider=infoblox
+            --enable-foreman-proxy-plugin-dhcp-infoblox
+            --foreman-proxy-plugin-dhcp-infoblox-dhcp-server=<ip>
+            --foreman-proxy-plugin-dhcp-infoblox-username=<username>
+            --foreman-proxy-plugin-dhcp-infoblox-password=<password>
 
-        @Assert: Check inflobox is set as DHCP provider
+        :Assert: Check inflobox is set as DHCP provider
 
-        @CaseLevel: System
+        :CaseLevel: System
 
-        @caseautomation: notautomated
+        :caseautomation: notautomated
         """
 
     @stubbed()
@@ -69,20 +69,18 @@ class InfobloxTestCase(TestCase):
     def test_update_dns_appliance_credentials(self):
         """Check infoblox appliance credentials are updated
 
-        @id: 2e84a8b4-79b6-11e6-8bf8-68f72889dc7f
+        :id: 2e84a8b4-79b6-11e6-8bf8-68f72889dc7f
 
-        @Steps:
+        :Steps: Pass appliance credentials via installer options
+            --foreman-proxy-plugin-dns-infoblox-username=<username>
+            --foreman-proxy-plugin-dns-infoblox-password=<password>
 
-        1. Pass appliance credentials via installer options
-        --foreman-proxy-plugin-dns-infoblox-username=<username>
-        --foreman-proxy-plugin-dns-infoblox-password=<password>
+        :Assert: config/dns_infoblox.yml should be updated with
+            infoblox_hostname, username & password
 
-        @Assert: config/dns_infoblox.yml should be updated with
-        infoblox_hostname, username & password
+        :CaseLevel: System
 
-        @CaseLevel: System
-
-        @caseautomation: notautomated
+        :caseautomation: notautomated
         """
 
     @stubbed()
@@ -90,16 +88,16 @@ class InfobloxTestCase(TestCase):
     def test_enable_dns_plugin(self):
         """Check Infoblox DNS plugin can be enabled on server
 
-        @id: f8be8c34-79b2-11e6-8992-68f72889dc7f
+        :id: f8be8c34-79b2-11e6-8992-68f72889dc7f
 
-        @Steps: Enable Infoblox plugin via installer options
-        --enable-foreman-proxy-plugin-dns-infoblox
+        :Steps: Enable Infoblox plugin via installer options
+            --enable-foreman-proxy-plugin-dns-infoblox
 
-        @CaseLevel: System
+        :CaseLevel: System
 
-        @Assert: Check DNS plugin is enabled on host
+        :Assert: Check DNS plugin is enabled on host
 
-        @caseautomation: notautomated
+        :caseautomation: notautomated
         """
 
     @stubbed()
@@ -107,17 +105,15 @@ class InfobloxTestCase(TestCase):
     def test_disable_dns_plugin(self):
         """Check Infoblox DNS plugin can be disabled on host
 
-        @id: c5f563c6-79b3-11e6-8cb6-68f72889dc7f
+        :id: c5f563c6-79b3-11e6-8cb6-68f72889dc7f
 
-        @Steps:
+        :Steps: Disable Infoblox plugin via installer
 
-        1. Disable Infoblox plugin via installer
+        :Assert: Check DNS plugin is disabled on host
 
-        @Assert: Check DNS plugin is disabled on host
+        :CaseLevel: System
 
-        @CaseLevel: System
-
-        @caseautomation: notautomated
+        :caseautomation: notautomated
         """
 
     @stubbed()
@@ -125,18 +121,16 @@ class InfobloxTestCase(TestCase):
     def test_enable_dhcp_plugin(self):
         """Check Infoblox DHCP plugin can be enabled on host
 
-        @id: 75650c06-79b6-11e6-ad91-68f72889dc7f
+        :id: 75650c06-79b6-11e6-ad91-68f72889dc7f
 
-        @Steps:
+        :Steps: Enable Infoblox plugin via installer option
+            --enable-foreman-proxy-plugin-dhcp-infoblox
 
-        1. Enable Infoblox plugin via installer option
-        --enable-foreman-proxy-plugin-dhcp-infoblox
+        :Assert: Check DHCP plugin is enabled on host
 
-        @Assert: Check DHCP plugin is enabled on host
+        :CaseLevel: System
 
-        @CaseLevel: System
-
-        @caseautomation: notautomated
+        :caseautomation: notautomated
         """
 
     @stubbed()
@@ -144,17 +138,15 @@ class InfobloxTestCase(TestCase):
     def test_disable_dhcp_plugin(self):
         """Check Infoblox DHCP plugin can be disabled on host
 
-        @id: ea347f34-79b7-11e6-bb03-68f72889dc7f
+        :id: ea347f34-79b7-11e6-bb03-68f72889dc7f
 
-        @Steps:
+        :Steps: Disable Infoblox plugin via installer
 
-        1. Disable Infoblox plugin via installer
+        :Assert: Check DHCP plugin is disabled on host
 
-        @Assert: Check DHCP plugin is disabled on host
+        :CaseLevel: System
 
-        @CaseLevel: System
-
-        @caseautomation: notautomated
+        :caseautomation: notautomated
         """
 
     @stubbed()
@@ -162,18 +154,16 @@ class InfobloxTestCase(TestCase):
     def test_dhcp_ip_range(self):
         """Check host get IP from Infoblox IP range while provisioning a host
 
-        @id: ba957e82-79bb-11e6-94c5-68f72889dc7f
+        :id: ba957e82-79bb-11e6-94c5-68f72889dc7f
 
-        @Steps:
+        :Steps: Provision a host with infoblox as dhcp provider
 
-        1. Provision a host with infoblox as dhcp provider
+        :Assert: Check host ip is on infoblox range configured by option
+            --foreman-proxy-plugin-dhcp-infoblox-use-ranges=true
 
-        @Assert: Check host ip is on infoblox range configured by option
-        --foreman-proxy-plugin-dhcp-infoblox-use-ranges=true
+        :CaseLevel: System
 
-        @CaseLevel: System
-
-        @caseautomation: notautomated
+        :caseautomation: notautomated
         """
 
     @stubbed()
@@ -181,16 +171,16 @@ class InfobloxTestCase(TestCase):
     def test_dns_records(self):
         """Check DNS records are updated via infoblox DNS plugin
 
-        @id: 007ad06e-79bc-11e6-885f-68f72889dc7f
+        :id: 007ad06e-79bc-11e6-885f-68f72889dc7f
 
-        @Steps:
+        :Steps:
 
-        1. Provision a host with infoblox as dns provider
-        2. Update a DNS record on infoblox
+            1. Provision a host with infoblox as dns provider
+            2. Update a DNS record on infoblox
 
-        @Assert: Check host dns is updated accordingly to infoblox
+        :Assert: Check host dns is updated accordingly to infoblox
 
-        @CaseLevel: System
+        :CaseLevel: System
 
-        @caseautomation: notautomated
+        :caseautomation: notautomated
         """

--- a/tests/foreman/installer/test_installer.py
+++ b/tests/foreman/installer/test_installer.py
@@ -1,18 +1,18 @@
 """Smoke tests to check installation health
 
-@Requirement: Installer
+:Requirement: Installer
 
-@CaseAutomation: Automated
+:CaseAutomation: Automated
 
-@CaseLevel: Acceptance
+:CaseLevel: Acceptance
 
-@CaseComponent: INSTALLER
+:CaseComponent: INSTALLER
 
-@TestType: Functional
+:TestType: Functional
 
-@CaseImportance: High
+:CaseImportance: High
 
-@Upstream: No
+:Upstream: No
 """
 import re
 
@@ -34,10 +34,9 @@ class SELinuxTestCase(TestCase):
     def test_positive_foreman_module(self):
         """Check if SELinux foreman module has the right version
 
-        @id: a0736b3a-3d42-4a09-a11a-28c1d58214a5
+        :id: a0736b3a-3d42-4a09-a11a-28c1d58214a5
 
-        @Assert: Foreman RPM and SELinux module versions match
-
+        :Assert: Foreman RPM and SELinux module versions match
         """
         rpm_result = ssh.command('rpm -q foreman-selinux')
         self.assertEqual(rpm_result.return_code, 0)
@@ -64,13 +63,12 @@ class SELinuxTestCase(TestCase):
     def test_positive_check_installer_services(self):
         """Check if services start correctly
 
-        @id: 85fd4388-6d94-42f5-bed2-24be38e9f104
+        :id: 85fd4388-6d94-42f5-bed2-24be38e9f104
 
-        @Assert: All services {'elasticsearch', 'foreman-proxy',
-        'foreman-tasks', 'httpd', 'mongod', 'postgresql', 'pulp_celerybeat',
-        'pulp_resource_manager', 'pulp_workers', 'qdrouterd', 'qpidd',
-        'tomcat'} are started
-
+        :Assert: All services {'elasticsearch', 'foreman-proxy',
+            'foreman-tasks', 'httpd', 'mongod', 'postgresql',
+            'pulp_celerybeat', 'pulp_resource_manager', 'pulp_workers',
+            'qdrouterd', 'qpidd', 'tomcat'} are started
         """
         major_version = get_host_info()[1]
         services = (
@@ -126,16 +124,13 @@ class SELinuxTestCase(TestCase):
     def test_positive_check_installer_logfile(self):
         """Look for ERROR or FATAL references in logfiles
 
-        @id: 80537809-8be4-42db-9cc8-5155378ee4d4
+        :id: 80537809-8be4-42db-9cc8-5155378ee4d4
 
-        @Steps:
+        :Steps: search all relevant logfiles for ERROR/FATAL
 
-        1. search all relevant logfiles for ERROR/FATAL
-
-        @Assert: No ERROR/FATAL notifcations occur in {katello-jobs, tomcat6,
-        foreman, pulp, passenger-analytics, httpd, foreman_proxy,
-        elasticsearch, postgresql, mongod} logfiles.
-
+        :Assert: No ERROR/FATAL notifcations occur in {katello-jobs, tomcat6,
+            foreman, pulp, passenger-analytics, httpd, foreman_proxy,
+            elasticsearch, postgresql, mongod} logfiles.
         """
         logfiles = (
             {

--- a/tests/foreman/longrun/test_inc_updates.py
+++ b/tests/foreman/longrun/test_inc_updates.py
@@ -1,18 +1,18 @@
 """Tests for the Incremental Update feature
 
-@Requirement: Inc updates
+:Requirement: Inc updates
 
-@CaseAutomation: Automated
+:CaseAutomation: Automated
 
-@CaseLevel: Acceptance
+:CaseLevel: Acceptance
 
-@CaseComponent: API
+:CaseComponent: API
 
-@TestType: Functional
+:TestType: Functional
 
-@CaseImportance: High
+:CaseImportance: High
 
-@Upstream: No
+:Upstream: No
 """
 
 from datetime import date, timedelta
@@ -235,21 +235,21 @@ class IncrementalUpdateTestCase(TestCase):
         """Check if api incremental update can be done without
         actually applying it
 
-        @id: 481c5ff2-801f-4eff-b1e0-95ea5bb37f95
+        :id: 481c5ff2-801f-4eff-b1e0-95ea5bb37f95
 
-        @Setup:  The prerequisites are already covered in the setUpClass() but
-        for easy debug, get the content view id, Repository id and Lifecycle
-        environment id using hammer and plug these statements on the top of the
-        test. For example::
+        :Setup:  The prerequisites are already covered in the setUpClass() but
+            for easy debug, get the content view id, Repository id and
+            Lifecycle environment id using hammer and plug these statements on
+            the top of the test. For example::
 
-            self.rhel_6_partial_cv = ContentView(id=38).read()
-            self.rhva_6_repo = Repository(id=164).read()
-            self.qe_lce = LifecycleEnvironment(id=46).read()
+                self.rhel_6_partial_cv = ContentView(id=38).read()
+                self.rhva_6_repo = Repository(id=164).read()
+                self.qe_lce = LifecycleEnvironment(id=46).read()
 
-        @Assert: Incremental update completed with no errors and Content view
-        has a newer version
+        :Assert: Incremental update completed with no errors and Content view
+            has a newer version
 
-        @CaseLevel: System
+        :CaseLevel: System
         """
         # Get the content view versions and use the recent one.  API always
         # returns the versions in ascending order so it is safe to assume the
@@ -284,12 +284,12 @@ class IncrementalUpdateTestCase(TestCase):
         """Check if cli incremental update can be done without
         actually applying it
 
-        @id: f25b0919-74cb-4e2c-829e-482558990b3c
+        :id: f25b0919-74cb-4e2c-829e-482558990b3c
 
-        @Assert: Incremental update completed with no errors and Content view
-        has a newer version
+        :Assert: Incremental update completed with no errors and Content view
+            has a newer version
 
-        @CaseLevel: System
+        :CaseLevel: System
         """
         # Get the content view versions and use the recent one.  API always
         # returns the versions in ascending order so it is safe to assume the

--- a/tests/foreman/longrun/test_oscap.py
+++ b/tests/foreman/longrun/test_oscap.py
@@ -1,18 +1,18 @@
 """Tests for the Oscap report upload feature
 
-@Requirement: Oscap
+:Requirement: Oscap
 
-@CaseAutomation: Automated
+:CaseAutomation: Automated
 
-@CaseLevel: Acceptance
+:CaseLevel: Acceptance
 
-@CaseComponent: UI
+:CaseComponent: UI
 
-@TestType: Functional
+:TestType: Functional
 
-@CaseImportance: High
+:CaseImportance: High
 
-@Upstream: No
+:Upstream: No
 """
 from fauxfactory import gen_string
 from robottelo.api.utils import configure_puppet_test
@@ -57,7 +57,6 @@ class OpenScapTestCase(UITestCase):
         6. Promote/publish content-view
         7. Create an activation-key
         8. Add product to activation-key
-
         """
         super(OpenScapTestCase, cls).setUpClass()
         cls.config_env = configure_puppet_test()
@@ -67,12 +66,12 @@ class OpenScapTestCase(UITestCase):
     def test_positive_upload_to_satellite(self):
         """Perform end to end oscap test and upload reports.
 
-        @id: 17a0978d-64f9-44ad-8303-1f54ada08602
+        :id: 17a0978d-64f9-44ad-8303-1f54ada08602
 
-        @Assert: Oscap reports from rhel6 and rhel7 clients should be
-        uploaded to satellite6 and be searchable.
+        :Assert: Oscap reports from rhel6 and rhel7 clients should be uploaded
+            to satellite6 and be searchable.
 
-        @CaseLevel: System
+        :CaseLevel: System
         """
         if settings.rhel6_repo is None:
             self.skipTest('Missing configuration for rhel6_repo')
@@ -184,12 +183,12 @@ class OpenScapTestCase(UITestCase):
         """Perform end to end oscap test, and push the updated scap content
          after first run.
 
-        @id: 7eb75ca5-2ea1-434e-bb43-1223fa4d8e9f
+        :id: 7eb75ca5-2ea1-434e-bb43-1223fa4d8e9f
 
-        @Assert: Satellite should push updated content to Clients
-        and satellite should get updated reports
+        :Assert: Satellite should push updated content to Clients and satellite
+            should get updated reports
 
-        @CaseLevel: System
+        :CaseLevel: System
         """
         if settings.rhel7_repo is None:
             self.skipTest('Missing configuration for rhel7_repo')
@@ -302,18 +301,18 @@ class OpenScapTestCase(UITestCase):
     def test_positive_has_arf_report_summary_page(self):
         """OSCAP ARF Report now has summary page
 
-        @id: 25be7898-50c5-4825-adc7-978c7b4e3488
+        :id: 25be7898-50c5-4825-adc7-978c7b4e3488
 
-        @Steps:
-        1. Make sure the oscap report with it's corresponding hostname
-           is visible in the UI.
-        2. Click on the host name to access the oscap report.
+        :Steps:
+            1. Make sure the oscap report with it's corresponding hostname
+               is visible in the UI.
+            2. Click on the host name to access the oscap report.
 
-        @Assert: Oscap ARF reports should have summary page.
+        :Assert: Oscap ARF reports should have summary page.
 
-        @caseautomation: notautomated
+        :caseautomation: notautomated
 
-        @CaseLevel: System
+        :CaseLevel: System
         """
 
     @run_only_on('sat')
@@ -322,19 +321,19 @@ class OpenScapTestCase(UITestCase):
     def test_positive_view_full_report_button(self):
         """'View full Report' button should exist for OSCAP Reports.
 
-        @id: 5a41916d-66db-4d2f-8261-b83f833189b9
+        :id: 5a41916d-66db-4d2f-8261-b83f833189b9
 
-        @Steps:
-        1. Make sure the oscap report with it's corresponding hostname
-           is visible in the UI.
-        2. Click on the host name to access the oscap report.
+        :Steps:
+            1. Make sure the oscap report with it's corresponding hostname
+               is visible in the UI.
+            2. Click on the host name to access the oscap report.
 
-        @Assert: Should have 'view full report' button to view the
-        actual HTML report.
+        :Assert: Should have 'view full report' button to view the actual HTML
+            report.
 
-        @caseautomation: notautomated
+        :caseautomation: notautomated
 
-        @CaseLevel: System
+        :CaseLevel: System
         """
 
     @run_only_on('sat')
@@ -344,19 +343,19 @@ class OpenScapTestCase(UITestCase):
         """'Download xml' button should exist for OSCAP Reports
         to be downloaded in xml format.
 
-        @id: 07a5f495-a702-4ca4-b5a4-579a133f9181
+        :id: 07a5f495-a702-4ca4-b5a4-579a133f9181
 
-        @Steps:
-        1. Make sure the oscap report with it's corresponding hostname
-           is visible in the UI.
-        2. Click on the host name to access the oscap report.
+        :Steps:
+            1. Make sure the oscap report with it's corresponding hostname
+               is visible in the UI.
+            2. Click on the host name to access the oscap report.
 
-        @Assert: Should have 'Download xml in bzip' button to download
-        the xml report.
+        :Assert: Should have 'Download xml in bzip' button to download the xml
+            report.
 
-        @caseautomation: notautomated
+        :caseautomation: notautomated
 
-        @CaseLevel: System
+        :CaseLevel: System
         """
 
     @run_only_on('sat')
@@ -366,18 +365,17 @@ class OpenScapTestCase(UITestCase):
         """Oscap-Proxy select box should exist while filling hosts
         and host-groups form.
 
-        @id: d56576c8-6fab-4af6-91c1-6a56d9cca94b
+        :id: d56576c8-6fab-4af6-91c1-6a56d9cca94b
 
-        @Steps:
-        1.Choose the Oscap Proxy/capsule appropriately for the host
-          or host-groups.
+        :Steps: Choose the Oscap Proxy/capsule appropriately for the host or
+            host-groups.
 
-        @Assert: Should have an Oscap-Proxy select box while filling
-        hosts and host-groups form.
+        :Assert: Should have an Oscap-Proxy select box while filling hosts and
+            host-groups form.
 
-        @caseautomation: notautomated
+        :caseautomation: notautomated
 
-        @CaseLevel: System
+        :CaseLevel: System
         """
 
     @run_only_on('sat')
@@ -386,20 +384,20 @@ class OpenScapTestCase(UITestCase):
     def test_positive_delete_multiple_arf_reports(self):
         """Multiple arf reports deletion should be possible.
 
-        @id: c1a8ce02-f42f-4c48-893d-8f31432b5520
+        :id: c1a8ce02-f42f-4c48-893d-8f31432b5520
 
-        @Steps:
-        1. Run Oscap scans are run for multiple Hosts.
-        2. Make sure the oscap reports with it's corresponding hostnames
-           are visible in the UI.
-        3. Now select multiple reports from the checkbox and delete the
-           reports.
+        :Steps:
+            1. Run Oscap scans are run for multiple Hosts.
+            2. Make sure the oscap reports with it's corresponding hostnames
+               are visible in the UI.
+            3. Now select multiple reports from the checkbox and delete the
+               reports.
 
-        @Assert: Multiple Oscap ARF reports can be deleted.
+        :Assert: Multiple Oscap ARF reports can be deleted.
 
-        @caseautomation: notautomated
+        :caseautomation: notautomated
 
-        @CaseLevel: System
+        :CaseLevel: System
         """
 
     @run_only_on('sat')
@@ -408,11 +406,11 @@ class OpenScapTestCase(UITestCase):
     def test_positive_reporting_emails_of_oscap_reports(self):
         """Email Reporting of oscap reports should be possible.
 
-        @id: 003d4d28-f694-4e54-a149-247f58298ecc
+        :id: 003d4d28-f694-4e54-a149-247f58298ecc
 
-        @Assert: Whether email reporting of oscap reports is possible.
+        :Assert: Whether email reporting of oscap reports is possible.
 
-        @caseautomation: notautomated
+        :caseautomation: notautomated
 
-        @CaseLevel: System
+        :CaseLevel: System
         """

--- a/tests/foreman/longrun/test_puppet_upgrade.py
+++ b/tests/foreman/longrun/test_puppet_upgrade.py
@@ -1,18 +1,18 @@
 """Test for upgrading Puppet to Puppet4
 
-@Requirement: Puppet
+:Requirement: Puppet
 
-@CaseAutomation: Automated
+:CaseAutomation: Automated
 
-@CaseLevel: Acceptance
+:CaseLevel: Acceptance
 
-@CaseComponent: CLI
+:CaseComponent: CLI
 
-@TestType: Functional
+:TestType: Functional
 
-@CaseImportance: High
+:CaseImportance: High
 
-@Upstream: No
+:Upstream: No
 """
 
 from robottelo.config import settings
@@ -27,11 +27,11 @@ from robottelo.test import CLITestCase
 
 
 @run_in_one_thread
-@skip_if_not_set('clients')
 class PuppetUpgradeTestCase(CLITestCase):
     """Implements Puppet test scenario"""
 
     @classmethod
+    @skip_if_not_set('clients')
     def setUpClass(cls):
         super(PuppetUpgradeTestCase, cls).setUpClass()
         cls.sat6_hostname = settings.server.hostname
@@ -42,24 +42,24 @@ class PuppetUpgradeTestCase(CLITestCase):
     def test_positive_puppet_upgrade(self):
         """Upgrade Satellite/client puppet versions
 
-        @id: fd311168-afda-49b6-ac5f-533c4fd411b5
+        :id: fd311168-afda-49b6-ac5f-533c4fd411b5
 
-        @Steps:
+        :Steps:
 
-        1. register client (p3)
-        2. prepare puppet module
-        3. upgrade Satellite from p3 to p4
-        4. apply puppet module to p3 client
-        5. upgrade client from p3 to p4
-        6. apply puppet module to the client
-        7. register another client (p4)
-        8. apply puppet module to the client
+            1. register client (p3)
+            2. prepare puppet module
+            3. upgrade Satellite from p3 to p4
+            4. apply puppet module to p3 client
+            5. upgrade client from p3 to p4
+            6. apply puppet module to the client
+            7. register another client (p4)
+            8. apply puppet module to the client
 
-        @Assert: multiple asserts along the code that motd module was applied
+        :Assert: multiple asserts along the code that motd module was applied
 
-        @caseautomation: notautomated
+        :caseautomation: notautomated
 
-        @CaseLevel: System
+        :CaseLevel: System
         """
 
     @run_only_on('sat')
@@ -67,22 +67,23 @@ class PuppetUpgradeTestCase(CLITestCase):
     @tier4
     def test_positive_puppet_capsule_upgrade(self):
         """Upgrade standalone Capsule/client puppet versions
-        @id: 7e8e9047-d012-4fc5-9e6e-f11c1b05df5d
 
-        @Steps:
+        :id: 7e8e9047-d012-4fc5-9e6e-f11c1b05df5d
 
-        1. register client (p3)
-        2. prepare puppet module
-        3. upgrade Capsule from p3 to p4
-        4. apply puppet module to p3 client
-        5. upgrade client from p3 to p4
-        6. apply puppet module to the client
-        7. register another client (p4)
-        8. apply puppet module to the client
+        :Steps:
 
-        @Assert: multiple asserts along the code that motd module was applied
+            1. register client (p3)
+            2. prepare puppet module
+            3. upgrade Capsule from p3 to p4
+            4. apply puppet module to p3 client
+            5. upgrade client from p3 to p4
+            6. apply puppet module to the client
+            7. register another client (p4)
+            8. apply puppet module to the client
 
-        @caseautomation: notautomated
+        :Assert: multiple asserts along the code that motd module was applied
 
-        @CaseLevel: System
+        :caseautomation: notautomated
+
+        :CaseLevel: System
         """

--- a/tests/foreman/performance/test_candlepin_concurrent_delete.py
+++ b/tests/foreman/performance/test_candlepin_concurrent_delete.py
@@ -1,18 +1,18 @@
 """Test class for concurrent subscription deletion
 
-@Requirement: Candlepin concurrent delete
+:Requirement: Candlepin concurrent delete
 
-@CaseAutomation: Automated
+:CaseAutomation: Automated
 
-@CaseLevel: Acceptance
+:CaseLevel: Acceptance
 
-@CaseComponent: OTHER
+:CaseComponent: OTHER
 
-@TestType: Functional
+:TestType: Functional
 
-@CaseImportance: High
+:CaseImportance: High
 
-@Upstream: No
+:Upstream: No
 """
 from robottelo import ssh
 from robottelo.performance.constants import (
@@ -55,85 +55,79 @@ class ConcurrentDeleteTestCase(ConcurrentTestCase):
     def test_delete_sequential(self):
         """Delete subscriptions using 1 thread
 
-        @id: 19909194-23a4-4ac4-95c0-e8e107cd95b0
+        :id: 19909194-23a4-4ac4-95c0-e8e107cd95b0
 
-        @Steps:
+        :Steps:
 
-        1. get list of all registered systems' uuid
-        2. create result dictionary
-        3. create thread names
-        4. run by only one thread as deleting sequentially
-        5. produce result of timing
+            1. get list of all registered systems' uuid
+            2. create result dictionary
+            3. create thread names
+            4. run by only one thread as deleting sequentially
+            5. produce result of timing
 
-        @Assert: Restoring from database would have 5k registered systems.
-
+        :Assert: Restoring from database would have 5k registered systems.
         """
         self.kick_off_del_test(self.num_threads[0])
 
     def test_delete_2_clients(self):
         """Delete subscriptions concurrently using 2 threads
 
-        @id: 3691eff7-2482-474a-8efb-0e5275a8ca4c
+        :id: 3691eff7-2482-474a-8efb-0e5275a8ca4c
 
-        @Steps:
+        :Steps:
 
-        1. get list of all registered systems' uuid
-        2. create result dictionary
-        3. create a list of thread names
-        4. concurrent run by multiple threads;
-           each thread delete only a sublist of uuids
-        5. produce result of timing
+            1. get list of all registered systems' uuid
+            2. create result dictionary
+            3. create a list of thread names
+            4. concurrent run by multiple threads; each thread delete only a
+               sublist of uuids
+            5. produce result of timing
 
-        @Assert: Restoring from database would have 5k registered systems.
-
+        :Assert: Restoring from database would have 5k registered systems.
         """
         self.kick_off_del_test(self.num_threads[1])
 
     def test_delete_4_clients(self):
         """Delete subscriptions concurrently using 4 threads
 
-        @id: 7c68ab12-503d-4aa6-b9fe-0ac44c9a72f2
+        :id: 7c68ab12-503d-4aa6-b9fe-0ac44c9a72f2
 
-        @Assert: Restoring from database would have 5k registered systems.
-
+        :Assert: Restoring from database would have 5k registered systems.
         """
         self.kick_off_del_test(self.num_threads[2])
 
     def test_delete_6_clients(self):
         """Delete subscriptions concurrently using 6 threads
 
-        @id: 7a9dddf3-cc0f-4f27-8f8e-329af6eb85a0
+        :id: 7a9dddf3-cc0f-4f27-8f8e-329af6eb85a0
 
-        @Assert: Restoring from database would have 5k registered systems.
-
+        :Assert: Restoring from database would have 5k registered systems.
         """
         self.kick_off_del_test(self.num_threads[3])
 
     def test_delete_8_clients(self):
         """Delete subscriptions concurrently using 8 threads
 
-        @id: 7ce2c9d3-2eda-4f71-b360-d5f7219d524f
+        :id: 7ce2c9d3-2eda-4f71-b360-d5f7219d524f
 
-        @Assert: Restoring from database would have 5k registered systems.
-
+        :Assert: Restoring from database would have 5k registered systems.
         """
         self.kick_off_del_test(self.num_threads[4])
 
     def test_delete_10_clients(self):
         """Delete subscriptions concurrently using 10 virtual machines
 
-        @id: edd74cec-30e3-435a-b604-42c21963b5a3
+        :id: edd74cec-30e3-435a-b604-42c21963b5a3
 
-        @Steps:
+        :Steps:
 
-        1. get list of all registered systems' uuid
-        2. create result dictionary
-        3. create a list of thread names
-        4. concurrent run by multiple threads;
-           each thread delete only a sublist of uuids
-        5. produce result of timing
+            1. get list of all registered systems' uuid
+            2. create result dictionary
+            3. create a list of thread names
+            4. concurrent run by multiple threads; each thread delete only a
+               sublist of uuids
+            5. produce result of timing
 
-        @Assert: Restoring from database would have 5k registered systems.
-
+        :Assert: Restoring from database would have 5k registered systems.
         """
         self.kick_off_del_test(self.num_threads[5])

--- a/tests/foreman/performance/test_candlepin_concurrent_subscription_ak.py
+++ b/tests/foreman/performance/test_candlepin_concurrent_subscription_ak.py
@@ -1,18 +1,18 @@
 """Test class for concurrent subscription by Activation Key
 
-@Requirement: Candlepin concurrent subscription ak
+:Requirement: Candlepin concurrent subscription ak
 
-@CaseAutomation: Automated
+:CaseAutomation: Automated
 
-@CaseLevel: Acceptance
+:CaseLevel: Acceptance
 
-@CaseComponent: OTHER
+:CaseComponent: OTHER
 
-@TestType: Functional
+:TestType: Functional
 
-@CaseImportance: High
+:CaseImportance: High
 
-@Upstream: No
+:Upstream: No
 """
 from robottelo.cli.activationkey import ActivationKey
 from robottelo.cli.base import CLIReturnCodeError
@@ -107,49 +107,47 @@ class ConcurrentSubActivationKeyTestCase(ConcurrentTestCase):
     def test_subscribe_ak_sequential(self):
         """Subscribe system sequentially using 1 virtual machine
 
-        @id: b6315e54-4722-476e-9c31-518b12e458db
+        :id: b6315e54-4722-476e-9c31-518b12e458db
 
-        @Steps:
+        :Steps:
 
-        1. create activation key (setup)
-        2. get subscription id (setup)
-        3. add activation key to subscription (setup)
-        4. create result dictionary
-        5. sequentially run by one thread;
-           the thread iterates all total number of iterations
-        6. produce result of timing
+            1. create activation key (setup)
+            2. get subscription id (setup)
+            3. add activation key to subscription (setup)
+            4. create result dictionary
+            5. sequentially run by one thread;
+               the thread iterates all total number of iterations
+            6. produce result of timing
 
-        @Assert: Restoring where there's no activation key or registration
-
+        :Assert: Restoring where there's no activation key or registration
         """
         self.kick_off_ak_test(self.num_threads[0], 5000)
 
     def test_subscribe_ak_2_clients(self):
         """Subscribe system concurrently using 2 virtual machines
 
-        @id: b1dfabf0-ff3d-471e-8285-4fc5aca8506e
+        :id: b1dfabf0-ff3d-471e-8285-4fc5aca8506e
 
-        @Steps:
+        :Steps:
 
-        1. create activation key (setup)
-        2. get subscription id (setup)
-        3. add activation key to subscription (setup)
-        4. create result dictionary
-        5. concurrent run by multiple threads;
-           each thread iterates a limited number of times
-        6. produce result of timing
+            1. create activation key (setup)
+            2. get subscription id (setup)
+            3. add activation key to subscription (setup)
+            4. create result dictionary
+            5. concurrent run by multiple threads; each thread iterates a
+               limited number of times
+            6. produce result of timing
 
-        @Assert: Restoring where there's no activation key or registration
-
+        :Assert: Restoring where there's no activation key or registration
         """
         self.kick_off_ak_test(self.num_threads[1], 5000)
 
     def test_subscribe_ak_4_clients(self):
         """Subscribe system concurrently using 4 virtual machines
 
-        @id: 65059f79-fea2-4359-b039-843951c383dc
+        :id: 65059f79-fea2-4359-b039-843951c383dc
 
-        @Assert: Restoring where there's no activation key or registration
+        :Assert: Restoring where there's no activation key or registration
 
         """
         self.kick_off_ak_test(self.num_threads[2], 5000)
@@ -157,39 +155,36 @@ class ConcurrentSubActivationKeyTestCase(ConcurrentTestCase):
     def test_subscribe_ak_6_clients(self):
         """Subscribe system concurrently using 6 virtual machines
 
-        @id: cf893a78-73ab-4f0c-a077-11e4ee43cd3d
+        :id: cf893a78-73ab-4f0c-a077-11e4ee43cd3d
 
-        @Assert: Restoring where there's no activation key or registration
-
+        :Assert: Restoring where there's no activation key or registration
         """
         self.kick_off_ak_test(self.num_threads[3], 6000)
 
     def test_subscribe_ak_8_clients(self):
         """Subscribe system concurrently using 8 virtual machines
 
-        @id: fa0f85fc-027f-4aac-8b81-8e9cf25f7f2b
+        :id: fa0f85fc-027f-4aac-8b81-8e9cf25f7f2b
 
-        @Assert: Restoring where there's no activation key or registration
-
+        :Assert: Restoring where there's no activation key or registration
         """
         self.kick_off_ak_test(self.num_threads[4], 5000)
 
     def test_subscribe_ak_10_clients(self):
         """Subscribe system concurrently using 10 virtual machines
 
-        @id: 9e9794be-c6f1-4843-9249-425b603853b1
+        :id: 9e9794be-c6f1-4843-9249-425b603853b1
 
-        @Steps:
+        :Steps:
 
-        1. create activation key (setup)
-        2. get subscription id (setup)
-        3. add activation key to subscription (setup)
-        4. create result dictionary
-        5. concurrent run by multiple threads
-           each thread iterates a limited number of times
-        6. produce result of timing
+            1. create activation key (setup)
+            2. get subscription id (setup)
+            3. add activation key to subscription (setup)
+            4. create result dictionary
+            5. concurrent run by multiple threads each thread iterates a
+               limited number of times
+            6. produce result of timing
 
-        @Assert: Restoring where there's no activation key or registration
-
+        :Assert: Restoring where there's no activation key or registration
         """
         self.kick_off_ak_test(self.num_threads[5], 5000)

--- a/tests/foreman/performance/test_candlepin_concurrent_subscription_attach.py
+++ b/tests/foreman/performance/test_candlepin_concurrent_subscription_attach.py
@@ -1,18 +1,18 @@
 """Test class for concurrent subscription by register and attach
 
-@Requirement: Candlepin concurrent subscription attach
+:Requirement: Candlepin concurrent subscription attach
 
-@CaseAutomation: Automated
+:CaseAutomation: Automated
 
-@CaseLevel: Acceptance
+:CaseLevel: Acceptance
 
-@CaseComponent: OTHER
+:CaseComponent: OTHER
 
-@TestType: Functional
+:TestType: Functional
 
-@CaseImportance: High
+:CaseImportance: High
 
-@Upstream: No
+:Upstream: No
 """
 from robottelo.performance.constants import (
     ATTACH_ENV,
@@ -55,80 +55,74 @@ class ConcurrentSubAttachTestCase(ConcurrentTestCase):
     def test_subscribe_ak_sequential(self):
         """Subscribe system sequentially using 1 virtual machine
 
-        @id: 41d80f4f-60df-4a49-967c-929604ca156e
+        :id: 41d80f4f-60df-4a49-967c-929604ca156e
 
-        @Steps:
+        :Steps:
 
-        1. create result dictionary
-        2. sequentially run by one thread;
-           the thread iterates all total number of iterations
-        3. produce result of timing
+            1. create result dictionary
+            2. sequentially run by one thread; the thread iterates all total
+               number of iterations
+            3. produce result of timing
 
-        @Assert: Restoring where there's no system registered
-
+        :Assert: Restoring where there's no system registered
         """
         self.kick_off_ak_test(self.num_threads[0], 5000)
 
     def test_register_attach_2_clients(self):
         """Subscribe system concurrently using 2 virtual machines
 
-        @id: 9849c556-c2a7-4ae3-a7b7-5291bdf158fd
+        :id: 9849c556-c2a7-4ae3-a7b7-5291bdf158fd
 
-        @Steps:
+        :Steps:
 
-        1. create result dictionary
-        2. concurrent run by multiple threads;
-           each thread iterates a limited number of times
-        3. produce result of timing
+            1. create result dictionary
+            2. concurrent run by multiple threads; each thread iterates a
+               limited number of times
+            3. produce result of timing
 
-        @Assert: Restoring from database without any registered systems.
-
+        :Assert: Restoring from database without any registered systems.
         """
         self.kick_off_att_test(self.num_threads[1], 5000)
 
     def test_register_attach_4_clients(self):
         """Subscribe system concurrently using 4 virtual machines
 
-        @id: dfc7da77-6127-42ee-bbaa-4e3b48c86c9d
+        :id: dfc7da77-6127-42ee-bbaa-4e3b48c86c9d
 
-        @Assert: Restoring from database without any registered systems.
-
+        :Assert: Restoring from database without any registered systems.
         """
         self.kick_off_att_test(self.num_threads[2], 5000)
 
     def test_register_attach_6_clients(self):
         """Subscribe system concurrently using 6 virtual machines
 
-        @id: 1a03261a-2756-4ea2-a718-86b5cfa9bd87
+        :id: 1a03261a-2756-4ea2-a718-86b5cfa9bd87
 
-        @Assert: Restoring from database without any registered systems.
-
+        :Assert: Restoring from database without any registered systems.
         """
         self.kick_off_att_test(self.num_threads[3], 6000)
 
     def test_register_attach_8_clients(self):
         """Subscribe system concurrently using 8 virtual machines
 
-        @id: fc5049b1-93ba-4cba-854f-bb763d137832
+        :id: fc5049b1-93ba-4cba-854f-bb763d137832
 
-        @Assert: Restoring from database without any registered systems.
-
+        :Assert: Restoring from database without any registered systems.
         """
         self.kick_off_att_test(self.num_threads[4], 5000)
 
     def test_register_attach_10_clients(self):
         """Subscribe system concurrently using 10 virtual machines
 
-        @id: a7ce9e04-b9cc-4c2b-b9e8-22ea8ceb1fab
+        :id: a7ce9e04-b9cc-4c2b-b9e8-22ea8ceb1fab
 
-        @Steps:
+        :Steps:
 
-        1. create result dictionary
-        2. concurrent run by multiple threads;
-           and each thread iterates a limited number of times
-        3. produce result of timing
+            1. create result dictionary
+            2. concurrent run by multiple threads; and each thread iterates a
+               limited number of times
+            3. produce result of timing
 
-        @Assert: Restoring from database without any registered systems.
-
+        :Assert: Restoring from database without any registered systems.
         """
         self.kick_off_att_test(self.num_threads[5], 5000)

--- a/tests/foreman/performance/test_pulp_sync.py
+++ b/tests/foreman/performance/test_pulp_sync.py
@@ -1,18 +1,18 @@
 """Test class for concurrent Synchronization
 
-@Requirement: Pulp sync
+:Requirement: Pulp sync
 
-@CaseAutomation: Automated
+:CaseAutomation: Automated
 
-@CaseLevel: Acceptance
+:CaseLevel: Acceptance
 
-@CaseComponent: OTHER
+:CaseComponent: OTHER
 
-@TestType: Functional
+:TestType: Functional
 
-@CaseImportance: High
+:CaseImportance: High
 
-@Upstream: No
+:Upstream: No
 """
 
 
@@ -99,24 +99,25 @@ class ConcurrentSyncTestCase(ConcurrentTestCase):
     def test_concurrent_synchronization(self):
         """Synchronize two repos concurrently
 
-        @id: ba0e8b76-f24d-433b-b14f-5bc7a7fefd95
+        :id: ba0e8b76-f24d-433b-b14f-5bc7a7fefd95
 
-        @Steps:
+        :Steps:
 
-        1. get list of all enabled repositories (setUpClass)
-        2. sync 2, 3, ..., X repositories as consecutive test cases
-        3. for each test case, delegate synchronization to
-            ``robottelo.tests.kick_off_sync_test``
-        4. in each test case, get the max timing value on each iteration
-            and store into max-timing-dict. For example, for 2-repo
-            test case, it sync 2 repositories and repeat 3 three times
-                     1       2       3
-            repo-1   21.48   13.87   33.16
-            repo-2   95.33   81.77   21.69
+            1. get list of all enabled repositories (setUpClass)
+            2. sync 2, 3, ..., X repositories as consecutive test cases
+            3. for each test case, delegate synchronization to
+                ``robottelo.tests.kick_off_sync_test``
+            4. in each test case, get the max timing value on each iteration
+                and store into max-timing-dict. For example, for 2-repo
+                test case, it sync 2 repositories and repeat 3 three times::
 
-            Then it would extract the max only and return the dictionary:
-            ``{2: [95.33, 81.77, 33.16]}``. Repeat from 2-repo test case
-            to 10-repo case.
+                             1       2       3
+                    repo-1   21.48   13.87   33.16
+                    repo-2   95.33   81.77   21.69
+
+                Then it would extract the max only and return the dictionary:
+                ``{2: [95.33, 81.77, 33.16]}``. Repeat from 2-repo test case
+                to 10-repo case.
         """
         total_max_timing = {}
         for current_num_threads in range(2, self.max_num_tests + 1):
@@ -228,16 +229,16 @@ class ConcurrentSyncTestCase(ConcurrentTestCase):
     def test_sequential_synchronization(self):
         """Synchronize two repos sequentially
 
-        @id: 78ec0c73-d29e-4b11-b58d-7de473b16f61
+        :id: 78ec0c73-d29e-4b11-b58d-7de473b16f61
 
-        @Steps:
+        :Steps:
 
-        1. get list of all enabled repositories (setUpClass)
-        2. Synchronize from the first to last repo sequentially
-        3. produce result of timing, delegated to
-           ``robottelo.tests.kick_off_sync_test``
+            1. get list of all enabled repositories (setUpClass)
+            2. Synchronize from the first to last repo sequentially
+            3. produce result of timing, delegated to
+               ``robottelo.tests.kick_off_sync_test``
 
-        @Assert: Target repositories are enabled
+        :Assert: Target repositories are enabled
         """
         time_result_dict_sync = Pulp.repositories_sequential_sync(
             self.repo_names_list,

--- a/tests/foreman/performance/test_standard_prep.py
+++ b/tests/foreman/performance/test_standard_prep.py
@@ -1,18 +1,18 @@
 """Test class for Environment Preparation after a fresh installation
 
-@Requirement: Standard prep
+:Requirement: Standard prep
 
-@CaseAutomation: Automated
+:CaseAutomation: Automated
 
-@CaseLevel: Acceptance
+:CaseLevel: Acceptance
 
-@CaseComponent: OTHER
+:CaseComponent: OTHER
 
-@TestType: Functional
+:TestType: Functional
 
-@CaseImportance: High
+:CaseImportance: High
 
-@Upstream: No
+:Upstream: No
 """
 from robottelo import ssh
 from robottelo.cli.base import CLIReturnCodeError
@@ -218,18 +218,17 @@ class StandardPrepTestCase(TestCase):
     def test_standard_prep(self):
         """add Manifest to Satellite Server
 
-        @id: c77a1afe-1e9b-4d31-bebf-2650049d524d
+        :id: c77a1afe-1e9b-4d31-bebf-2650049d524d
 
-        @Steps:
+        :Steps:
 
-        1. download manifest
-        2. upload to subscription
-        3. update Red Hat CDN URL
-        4. enable repositories
-        5. take db snapshot backup
+            1. download manifest
+            2. upload to subscription
+            3. update Red Hat CDN URL
+            4. enable repositories
+            5. take db snapshot backup
 
-        @Assert: Restoring from database where its status is clean
-
+        :Assert: Restoring from database where its status is clean
         """
         self._download_manifest()
         self._upload_manifest()

--- a/tests/foreman/rhai/test_rhai.py
+++ b/tests/foreman/rhai/test_rhai.py
@@ -1,18 +1,18 @@
 """Tests for Red Hat Access Insights
 
-@Requirement: Rhai
+:Requirement: Rhai
 
-@CaseAutomation: Automated
+:CaseAutomation: Automated
 
-@CaseLevel: Acceptance
+:CaseLevel: Acceptance
 
-@CaseComponent: UI
+:CaseComponent: UI
 
-@TestType: Functional
+:TestType: Functional
 
-@CaseImportance: High
+:CaseImportance: High
 
-@Upstream: No
+:Upstream: No
 """
 
 import time
@@ -76,11 +76,10 @@ class RHAITestCase(UITestCase):
     def test_positive_register_client_to_rhai(self):
         """Check client registration to redhat-access-insights service.
 
-        @id: f3aefdb3-ac99-402d-afd9-e53e9ee1e8d7
+        :id: f3aefdb3-ac99-402d-afd9-e53e9ee1e8d7
 
-        @Assert: Registered client should appear in the Systems sub-menu of Red
-        Hat Access Insights
-
+        :Assert: Registered client should appear in the Systems sub-menu of Red
+            Hat Access Insights
         """
         # Register a VM to Access Insights Service
         with VirtualMachine(distro=DISTRO_RHEL6) as vm:
@@ -104,12 +103,11 @@ class RHAITestCase(UITestCase):
         """Verify that user attempting to access RHAI is directed to select an
         Organization if there is no organization selected
 
-        @id: 6ddfdb29-eeb5-41a4-8851-ad19130b112c
+        :id: 6ddfdb29-eeb5-41a4-8851-ad19130b112c
 
-        @Assert: 'Organization Selection Required' message must be displayed if
-        the user tries to view Access Insights overview without selecting an
-        org
-
+        :Assert: 'Organization Selection Required' message must be displayed if
+            the user tries to view Access Insights overview without selecting
+            an org
         """
         with Session(self.browser) as session:
             # Given that the user does not specify any Organization
@@ -126,12 +124,11 @@ class RHAITestCase(UITestCase):
         """Verify that 'Unregister' a system from RHAI works correctly then the
         system should not be able to use the service.
 
-        @id: 580f9704-8c6d-4f63-b027-68a6ac97af77
+        :id: 580f9704-8c6d-4f63-b027-68a6ac97af77
 
-        @Assert: Once the system is unregistered from the RHAI web interface
-        then the unregistered system should return `1` on running the
-        service 'redhat-access-insights'
-
+        :Assert: Once the system is unregistered from the RHAI web interface
+            then the unregistered system should return `1` on running the
+            service 'redhat-access-insights'
         """
         # Register a VM to Access Insights Service
         with VirtualMachine(distro=DISTRO_RHEL7) as vm:

--- a/tests/foreman/rhai/test_rhai_client.py
+++ b/tests/foreman/rhai/test_rhai_client.py
@@ -1,18 +1,18 @@
 """Tests for Red Hat Access Insights Client rpm
 
-@Requirement: Rhai client
+:Requirement: Rhai client
 
-@CaseAutomation: Automated
+:CaseAutomation: Automated
 
-@CaseLevel: Acceptance
+:CaseLevel: Acceptance
 
-@CaseComponent: CLI
+:CaseComponent: CLI
 
-@TestType: Functional
+:TestType: Functional
 
-@CaseImportance: High
+:CaseImportance: High
 
-@Upstream: No
+:Upstream: No
 """
 
 from fauxfactory import gen_string
@@ -73,10 +73,10 @@ class RHAIClientTestCase(TestCase):
         client rpm tests the connection with the satellite server connection
         with satellite server
 
-        @id: 167758c9-cbfa-4a81-9a11-27f88aaf9118
+        :id: 167758c9-cbfa-4a81-9a11-27f88aaf9118
 
-        @Assert: 'redhat-access-insights --test-connection' should return
-        zero on a successfully registered machine to RHAI service
+        :Assert: 'redhat-access-insights --test-connection' should return zero
+            on a successfully registered machine to RHAI service
         """
         with VirtualMachine(distro=DISTRO_RHEL6) as vm:
             vm.configure_rhai_client(self.ak_name, self.org_label,

--- a/tests/foreman/rhci/test_rhci.py
+++ b/tests/foreman/rhci/test_rhci.py
@@ -1,19 +1,19 @@
 # pylint:disable=too-many-public-methods
 """Unit tests for the ``fusor/api/v21/deployments`` paths.
 
-@Requirement: Rhci
+:Requirement: Rhci
 
-@CaseAutomation: Automated
+:CaseAutomation: Automated
 
-@CaseLevel: Acceptance
+:CaseLevel: Acceptance
 
-@CaseComponent: API
+:CaseComponent: API
 
-@TestType: Functional
+:TestType: Functional
 
-@CaseImportance: High
+:CaseImportance: High
 
-@Upstream: No
+:Upstream: No
 """
 from fauxfactory import gen_string
 from nailgun import entities
@@ -59,9 +59,9 @@ class RHCIDeploymentTestCase(APITestCase):
     def test_positive_create_deployment(self):
         """Create a simple deployment.
 
-        @id: b1162fea-9afd-4b8d-89cc-e141e02fcdbe
+        :id: b1162fea-9afd-4b8d-89cc-e141e02fcdbe
 
-        @Assert: An RHCI deployment is created with a random name.
+        :Assert: An RHCI deployment is created with a random name.
 
         """
         for name in (gen_string(str_type='alpha'),
@@ -87,9 +87,9 @@ class RHCIDeploymentTestCase(APITestCase):
     def test_positive_update_name(self):
         """Update a deployment's name.
 
-        @id: 1761b17f-b2cb-44fc-9dd8-f2e9fbccbb38
+        :id: 1761b17f-b2cb-44fc-9dd8-f2e9fbccbb38
 
-        @Assert: An RHCI deployment is updated with a random name.
+        :Assert: An RHCI deployment is updated with a random name.
 
         """
         for data in valid_name_update_tests():
@@ -114,9 +114,9 @@ class RHCIDeploymentTestCase(APITestCase):
     def test_positive_delete_deployment(self):
         """Create and delete a simple deployment.
 
-        @id: 89bb4342-a99d-4653-a7cd-fc3f08acaf72
+        :id: 89bb4342-a99d-4653-a7cd-fc3f08acaf72
 
-        @Assert: An RHCI deployment is deleted.
+        :Assert: An RHCI deployment is deleted.
 
         """
         data = gen_string(str_type='alpha')

--- a/tests/foreman/sys/test_hot_backup.py
+++ b/tests/foreman/sys/test_hot_backup.py
@@ -1,21 +1,21 @@
 # -*- encoding: utf-8 -*-
 """Test class for ``katello-backup``
 
-@Requirement: HotBackup
+:Requirement: HotBackup
 
-@CaseAutomation: notautomated
+:CaseAutomation: notautomated
 
-@CaseLevel: System
+:CaseLevel: System
 
-@CaseComponent: Backup
+:CaseComponent: Backup
 
-@TestType: functional
+:TestType: functional
 
-@CaseImportance: High
+:CaseImportance: High
 
-@Upstream: No
+:Upstream: No
 
-@Setup: Populate a Satellite with hosts/repos/contents
+:Setup: Populate a Satellite with hosts/repos/contents
 """
 from fauxfactory import gen_string
 from nailgun import entities
@@ -49,16 +49,15 @@ class HotBackupTestCase(TestCase):
     def test_positive_backup_with_existing_directory(self):
         """katello-backup with existing directory
 
-        @id: 3f8285d5-c68b-4d84-8568-bcd7e4f7f19e
+        :id: 3f8285d5-c68b-4d84-8568-bcd7e4f7f19e
 
-        @Steps:
+        :Steps:
 
-        1. Create a directory (ie /tmp/xyz)
-        2. Run ``katello-backup /tmp/xyz``
+            1. Create a directory (ie /tmp/xyz)
+            2. Run ``katello-backup /tmp/xyz``
 
-        @Assert: The backup is successfully created in existing folder and
-        contains all the default files needed to restore.
-
+        :Assert: The backup is successfully created in existing folder and
+            contains all the default files needed to restore.
         """
         with get_connection() as connection:
             dir_name = make_random_tmp_directory(connection)
@@ -81,16 +80,15 @@ class HotBackupTestCase(TestCase):
         """katello-backup with non-existing directory
 
 
-        @id: 946991ad-125a-4f24-a33e-ea27fce38eda
+        :id: 946991ad-125a-4f24-a33e-ea27fce38eda
 
-        @Steps:
+        :Steps:
 
-        1. Ensure the directory /tmp/xyz does not exist.
-        2. Run ``katello /tmp/xyz``
+            1. Ensure the directory /tmp/xyz does not exist.
+            2. Run ``katello /tmp/xyz``
 
-        @Assert: ``/tmp/xyz`` is created and the backup is saved to it
-        containing all the default files needed to restore.
-
+        :Assert: ``/tmp/xyz`` is created and the backup is saved to it
+            containing all the default files needed to restore.
         """
         with get_connection() as connection:
             dir_name = gen_string('alpha')
@@ -113,16 +111,15 @@ class HotBackupTestCase(TestCase):
         """Katello-backup with --skip-pulp option should not create pulp
         files in destination.
 
-        @id: 0f0c1915-dd07-4571-9b05-e0778efc85b2
+        :id: 0f0c1915-dd07-4571-9b05-e0778efc85b2
 
-        @Steps:
+        :Steps:
 
-        1. Run backup with --skip-pulp option to /tmp/bck-no-pulp
-        2. List contents of the destination
+            1. Run backup with --skip-pulp option to /tmp/bck-no-pulp
+            2. List contents of the destination
 
-        @Assert: ``/tmp/bck-no-pulp`` is created and pulp related files are not
-        present.
-
+        :Assert: ``/tmp/bck-no-pulp`` is created and pulp related files are not
+            present.
         """
         with get_connection() as connection:
             dir_name = make_random_tmp_directory(connection)
@@ -142,17 +139,17 @@ class HotBackupTestCase(TestCase):
     def test_positive_incremental(self):
         """Make an incremental backup
 
-        @id: a5b3536f-8365-41c7-9386-cddde588fe8c
+        :id: a5b3536f-8365-41c7-9386-cddde588fe8c
 
-        @Steps:
+        :Steps:
 
-        1. Run full backup (base)
-        2. Make config change c1
-        3. Run incremental backup ib1
-        4. Restore base backup, verify c1 config doesnt not exist
-        5. restore ib1, verify c1 config does exist
+            1. Run full backup (base)
+            2. Make config change c1
+            3. Run incremental backup ib1
+            4. Restore base backup, verify c1 config doesnt not exist
+            5. restore ib1, verify c1 config does exist
 
-        @Assert: Backup "ib1" is backed up.
+        :Assert: Backup "ib1" is backed up.
 
         """
         with get_connection() as connection:
@@ -204,20 +201,20 @@ class HotBackupTestCase(TestCase):
     def test_positive_restore_after_update(self):
         """Restore from a backup in updated version of satellite
 
-        @id: 2069b860-43d4-4b65-a8cd-89a8b2feafbe
+        :id: 2069b860-43d4-4b65-a8cd-89a8b2feafbe
 
-        @Steps:
+        :Steps:
 
-        1. Create backup from previous version of satellite
-        2. Update satellite to latest version
-        3. Restore online backup
-        4. Restore offline backup
-        5. Restore online incremental backup
-        6. Restore offline incremental backup
+            1. Create backup from previous version of satellite
+            2. Update satellite to latest version
+            3. Restore online backup
+            4. Restore offline backup
+            5. Restore online incremental backup
+            6. Restore offline incremental backup
 
-        @Assert: Each backup is fully restored.
+        :Assert: Each backup is fully restored.
 
-        @CaseAutomation: notautomated
+        :CaseAutomation: notautomated
 
         """
         # IS THIS CASE REASONABLE?
@@ -228,18 +225,18 @@ class HotBackupTestCase(TestCase):
         """Restore to a Satellite with config that has been updated since the
         backup
 
-        @id: 03a47dec-9cd4-4cae-88ec-c19dfaa1d5ad
+        :id: 03a47dec-9cd4-4cae-88ec-c19dfaa1d5ad
 
-        @Steps:
+        :Steps:
 
-        1. Restore online backup
-        2. Restore offline backup
-        3. Restore online incremental backup
-        4. Restore offline incremental backup
+            1. Restore online backup
+            2. Restore offline backup
+            3. Restore online incremental backup
+            4. Restore offline incremental backup
 
-        @Assert: Each backup is fully restored.
+        :Assert: Each backup is fully restored.
 
-        @CaseAutomation: notautomated
+        :CaseAutomation: notautomated
 
         """
 
@@ -248,17 +245,18 @@ class HotBackupTestCase(TestCase):
     def test_positive_load_backup(self):
         """Load testing, backup
 
-        @id: b0d7de3a-d1d5-4cb9-8041-47301b658408
+        :id: b0d7de3a-d1d5-4cb9-8041-47301b658408
 
-        @Steps:
-        1. Create load on the Satellite by having multiple host pull content.
-        2. Run a backup while the Satellite is under load
-        3. Restore the backup
+        :Steps:
+            1. Create load on the Satellite by having multiple host pull
+               content.
+            2. Run a backup while the Satellite is under load
+            3. Restore the backup
 
-        @Assert: The backup is successful and the restored configuration is
-        correct.
+        :Assert: The backup is successful and the restored configuration is
+            correct.
 
-        @CaseAutomation: notautomated
+        :CaseAutomation: notautomated
 
         """
 
@@ -267,16 +265,16 @@ class HotBackupTestCase(TestCase):
     def test_positive_load_restore(self):
         """Load testing, restore
 
-        @id: c0347aee-48b4-45da-92ef-1e92397c5543
+        :id: c0347aee-48b4-45da-92ef-1e92397c5543
 
-        @Steps:
+        :Steps:
 
-        1. Run a backup.
-        2. Run a restore.
+            1. Run a backup.
+            2. Run a restore.
 
-        @Assert: The restore is successful.
+        :Assert: The restore is successful.
 
-        @CaseAutomation: notautomated
+        :CaseAutomation: notautomated
 
         """
 
@@ -285,15 +283,15 @@ class HotBackupTestCase(TestCase):
     def test_positive_pull_content(self):
         """Pull content while a backup is running.
 
-        @id: 1026f5f5-4180-4215-acce-876dd2d09ba9
+        :id: 1026f5f5-4180-4215-acce-876dd2d09ba9
 
-        @Steps:
+        :Steps:
 
-        1. Start a backup
-        2. While backing up, have a host pull content from the satellite.
+            1. Start a backup
+            2. While backing up, have a host pull content from the satellite.
 
-        @Assert: The backup succeeds  and the host gets the requested content.
+        :Assert: The backup succeeds  and the host gets the requested content.
 
-        @CaseAutomation: notautomated
+        :CaseAutomation: notautomated
 
         """

--- a/tests/foreman/ui/test_activationkey.py
+++ b/tests/foreman/ui/test_activationkey.py
@@ -1,19 +1,19 @@
 # -*- encoding: utf-8 -*-
 """Test class for Activation key UI
 
-@Requirement: Activationkey
+:Requirement: Activationkey
 
-@CaseAutomation: Automated
+:CaseAutomation: Automated
 
-@CaseLevel: Acceptance
+:CaseLevel: Acceptance
 
-@CaseComponent: UI
+:CaseComponent: UI
 
-@TestType: Functional
+:TestType: Functional
 
-@CaseImportance: High
+:CaseImportance: High
 
-@Upstream: No
+:Upstream: No
 """
 
 import random
@@ -140,9 +140,9 @@ class ActivationKeyTestCase(UITestCase):
         """Create Activation key for all variations of Activation key
         name
 
-        @id: 091f1034-9850-4004-a0ca-d398d1626a5e
+        :id: 091f1034-9850-4004-a0ca-d398d1626a5e
 
-        @Assert: Activation key is created
+        :Assert: Activation key is created
         """
         with Session(self.browser) as session:
             for name in valid_data_list():
@@ -159,9 +159,9 @@ class ActivationKeyTestCase(UITestCase):
     def test_positive_create_with_description(self):
         """Create Activation key with description
 
-        @id: 4c8f4dca-723f-4dae-a8df-4e00a7fc7d95
+        :id: 4c8f4dca-723f-4dae-a8df-4e00a7fc7d95
 
-        @Assert: Activation key is created
+        :Assert: Activation key is created
         """
         name = gen_string('alpha')
         with Session(self.browser) as session:
@@ -179,11 +179,11 @@ class ActivationKeyTestCase(UITestCase):
     def test_positive_create_with_envs(self):
         """Create Activation key for all variations of Environments
 
-        @id: f75e994a-6da1-40a3-9685-f8387388b3f0
+        :id: f75e994a-6da1-40a3-9685-f8387388b3f0
 
-        @Assert: Activation key is created
+        :Assert: Activation key is created
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         with Session(self.browser) as session:
             for env_name in valid_data_list():
@@ -208,11 +208,11 @@ class ActivationKeyTestCase(UITestCase):
     def test_positive_create_with_cv(self):
         """Create Activation key for all variations of Content Views
 
-        @id: 2ad000f1-6c80-46aa-a61b-9ea62cefe91b
+        :id: 2ad000f1-6c80-46aa-a61b-9ea62cefe91b
 
-        @Assert: Activation key is created
+        :Assert: Activation key is created
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         with Session(self.browser) as session:
             for cv_name in valid_data_list():
@@ -235,11 +235,11 @@ class ActivationKeyTestCase(UITestCase):
     def test_positive_create_with_host_collection(self):
         """Create Activation key with Host Collection
 
-        @id: 0e4ad2b4-47a7-4087-828f-2b0535a97b69
+        :id: 0e4ad2b4-47a7-4087-828f-2b0535a97b69
 
-        @Assert: Activation key is created
+        :Assert: Activation key is created
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         name = gen_string(str_type='alpha')
         # create Host Collection using API
@@ -272,11 +272,11 @@ class ActivationKeyTestCase(UITestCase):
         """Test that host collection can be associated to Activation Keys
         by non-admin user.
 
-        @id: 417f0b36-fd49-4414-87ab-6f72a09696f2
+        :id: 417f0b36-fd49-4414-87ab-6f72a09696f2
 
-        @Assert: Activation key is created, added host collection is listed
+        :Assert: Activation key is created, added host collection is listed
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         ak_name = gen_string('alpha')
         # create Host Collection using API
@@ -318,12 +318,12 @@ class ActivationKeyTestCase(UITestCase):
         """Test that host collection can be removed from Activation Keys
         by non-admin user.
 
-        @id: 187456ec-5690-4524-9701-8bdb74c7912a
+        :id: 187456ec-5690-4524-9701-8bdb74c7912a
 
-        @Assert: Activation key is created, removed host collection
-        is not listed
+        :Assert: Activation key is created, removed host collection is not
+            listed
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         ak_name = gen_string('alpha')
         # create Host Collection using API
@@ -373,9 +373,9 @@ class ActivationKeyTestCase(UITestCase):
     def test_positive_create_with_usage_limit(self):
         """Create Activation key with finite Usage limit
 
-        @id: cd45363e-8a79-4aa4-be97-885aea9434c9
+        :id: cd45363e-8a79-4aa4-be97-885aea9434c9
 
-        @Assert: Activation key is created
+        :Assert: Activation key is created
         """
         name = gen_string('alpha')
         with Session(self.browser) as session:
@@ -392,11 +392,11 @@ class ActivationKeyTestCase(UITestCase):
     def test_negative_create_with_invalid_name(self):
         """Create Activation key with invalid Name
 
-        @id: 143ca57d-89ff-45e0-99cf-4d4033ea3690
+        :id: 143ca57d-89ff-45e0-99cf-4d4033ea3690
 
-        @Assert: Activation key is not created. Appropriate error shown.
+        :Assert: Activation key is not created. Appropriate error shown.
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         with Session(self.browser) as session:
             for name in invalid_names_list():
@@ -416,11 +416,11 @@ class ActivationKeyTestCase(UITestCase):
         """Create Activation key with invalid Usage Limit. Both with too
         long numbers and using letters.
 
-        @id: 71ecf5b2-ce4f-41b0-b30d-45f89713f8c1
+        :id: 71ecf5b2-ce4f-41b0-b30d-45f89713f8c1
 
-        @Assert: Activation key is not created. Appropriate error shown.
+        :Assert: Activation key is not created. Appropriate error shown.
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         with Session(self.browser) as session:
             for limit in invalid_names_list():
@@ -442,9 +442,9 @@ class ActivationKeyTestCase(UITestCase):
         """Create Activation key and delete it for all variations of
         Activation key name
 
-        @id: 113e4c1e-cf4d-4c6a-88c9-766db8271933
+        :id: 113e4c1e-cf4d-4c6a-88c9-766db8271933
 
-        @Assert: Activation key is deleted
+        :Assert: Activation key is deleted
         """
         with Session(self.browser) as session:
             for name in valid_data_list():
@@ -464,11 +464,11 @@ class ActivationKeyTestCase(UITestCase):
     def test_positive_delete_with_env(self):
         """Create Activation key with environment and delete it
 
-        @id: b6019881-3d6e-4b75-89f5-1b62aff3b1ca
+        :id: b6019881-3d6e-4b75-89f5-1b62aff3b1ca
 
-        @Assert: Activation key is deleted
+        :Assert: Activation key is deleted
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         name = gen_string('alpha')
         cv_name = gen_string('alpha')
@@ -492,11 +492,11 @@ class ActivationKeyTestCase(UITestCase):
     def test_positive_delete_with_cv(self):
         """Create Activation key with content view and delete it
 
-        @id: 7e40e1ed-8314-406b-9451-05f64806a6e6
+        :id: 7e40e1ed-8314-406b-9451-05f64806a6e6
 
-        @Assert: Activation key is deleted
+        :Assert: Activation key is deleted
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         name = gen_string('alpha')
         cv_name = gen_string('utf8')
@@ -520,16 +520,16 @@ class ActivationKeyTestCase(UITestCase):
     def test_positive_delete_with_system(self):
         """Delete an Activation key which has registered systems
 
-        @id: 86cd070e-cf46-4bb1-b555-e7cb42e4dc9f
+        :id: 86cd070e-cf46-4bb1-b555-e7cb42e4dc9f
 
-        @Steps:
-        1. Create an Activation key
-        2. Register systems to it
-        3. Delete the Activation key
+        :Steps:
+            1. Create an Activation key
+            2. Register systems to it
+            3. Delete the Activation key
 
-        @Assert: Activation key is deleted
+        :Assert: Activation key is deleted
 
-        @CaseLevel: System
+        :CaseLevel: System
         """
         name = gen_string('alpha')
         cv_name = gen_string('alpha')
@@ -560,14 +560,14 @@ class ActivationKeyTestCase(UITestCase):
     def test_negative_delete(self):
         """[UI ONLY] Attempt to delete an Activation Key and cancel it
 
-        @id: 07a17b98-b756-405c-b0c2-516f2a16aff1
+        :id: 07a17b98-b756-405c-b0c2-516f2a16aff1
 
-        @Steps:
-        1. Create an Activation key
-        2. Attempt to remove an Activation Key
-        3. Click Cancel in the confirmation dialog box
+        :Steps:
+            1. Create an Activation key
+            2. Attempt to remove an Activation Key
+            3. Click Cancel in the confirmation dialog box
 
-        @Assert: Activation key is not deleted
+        :Assert: Activation key is not deleted
         """
         name = gen_string('alpha', 10)
         with Session(self.browser) as session:
@@ -584,9 +584,9 @@ class ActivationKeyTestCase(UITestCase):
     def test_positive_update_name(self):
         """Update Activation Key Name in an Activation key
 
-        @id: 81d74424-893d-46c4-a20c-c20c85d4e898
+        :id: 81d74424-893d-46c4-a20c-c20c85d4e898
 
-        @Assert: Activation key is updated
+        :Assert: Activation key is updated
         """
         name = gen_string('alpha', 10)
         with Session(self.browser) as session:
@@ -608,9 +608,9 @@ class ActivationKeyTestCase(UITestCase):
     def test_positive_update_description(self):
         """Update Description in an Activation key
 
-        @id: 24988466-af1d-4dcd-80b7-9c7d317fb805
+        :id: 24988466-af1d-4dcd-80b7-9c7d317fb805
 
-        @Assert: Activation key is updated
+        :Assert: Activation key is updated
         """
         name = gen_string('alpha')
         description = gen_string('alpha')
@@ -634,11 +634,11 @@ class ActivationKeyTestCase(UITestCase):
     def test_positive_update_env(self):
         """Update Environment in an Activation key
 
-        @id: 895cda6a-bb1e-4b94-a858-95f0be78a17b
+        :id: 895cda6a-bb1e-4b94-a858-95f0be78a17b
 
-        @Assert: Activation key is updated
+        :Assert: Activation key is updated
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         name = gen_string('alpha')
         cv_name = gen_string('alpha')
@@ -668,16 +668,16 @@ class ActivationKeyTestCase(UITestCase):
     def test_positive_update_cv(self):
         """Update Content View in an Activation key
 
-        @id: 68880ca6-acb9-4a16-aaa0-ced680126732
+        :id: 68880ca6-acb9-4a16-aaa0-ced680126732
 
-        @Steps:
-        1. Create Activation key
-        2. Update the Content view with another Content view which has custom
-        products
+        :Steps:
+            1. Create Activation key
+            2. Update the Content view with another Content view which has
+                custom products
 
-        @Assert: Activation key is updated
+        :Assert: Activation key is updated
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         # Pick one of the valid data list items - data driven tests is not
         # necessary for this test
@@ -717,17 +717,17 @@ class ActivationKeyTestCase(UITestCase):
     def test_positive_update_rh_product(self):
         """Update Content View in an Activation key
 
-        @id: 9b0ac209-45de-4cc4-97e8-e191f3f37239
+        :id: 9b0ac209-45de-4cc4-97e8-e191f3f37239
 
-        @Steps:
+        :Steps:
 
-        1. Create an activation key
-        2. Update the content view with another content view which has RH
-           products
+            1. Create an activation key
+            2. Update the content view with another content view which has RH
+                products
 
-        @Assert: Activation key is updated
+        :Assert: Activation key is updated
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         # Pick one of the valid data list items - data driven tests is not
         # necessary for this test
@@ -785,9 +785,9 @@ class ActivationKeyTestCase(UITestCase):
     def test_positive_update_limit(self):
         """Update Usage limit from Unlimited to a finite number
 
-        @id: e6ef8dbe-dfb6-4226-8253-ff2e24cabe12
+        :id: e6ef8dbe-dfb6-4226-8253-ff2e24cabe12
 
-        @Assert: Activation key is updated
+        :Assert: Activation key is updated
         """
         name = gen_string('alpha')
         with Session(self.browser) as session:
@@ -806,9 +806,9 @@ class ActivationKeyTestCase(UITestCase):
     def test_positive_update_limit_to_unlimited(self):
         """Update Usage limit from definite number to Unlimited
 
-        @id: 2585ac91-baf0-43de-ba6e-862415402e62
+        :id: 2585ac91-baf0-43de-ba6e-862415402e62
 
-        @Assert: Activation key is updated
+        :Assert: Activation key is updated
         """
         name = gen_string('alpha')
         with Session(self.browser) as session:
@@ -828,9 +828,9 @@ class ActivationKeyTestCase(UITestCase):
     def test_negative_update_name(self):
         """Update invalid name in an activation key
 
-        @id: 6eb0f747-cd4d-421d-b11e-b8917bb0cec6
+        :id: 6eb0f747-cd4d-421d-b11e-b8917bb0cec6
 
-        @Assert: Activation key is not updated.  Appropriate error shown.
+        :Assert: Activation key is not updated.  Appropriate error shown.
         """
         name = gen_string('alpha', 10)
         with Session(self.browser) as session:
@@ -852,9 +852,9 @@ class ActivationKeyTestCase(UITestCase):
     def test_negative_update_limit(self):
         """Update invalid Usage Limit in an activation key
 
-        @id: d42d8b6a-d3f4-4baa-be20-127f52f2313e
+        :id: d42d8b6a-d3f4-4baa-be20-127f52f2313e
 
-        @Assert: Activation key is not updated.  Appropriate error shown.
+        :Assert: Activation key is not updated.  Appropriate error shown.
         """
         name = gen_string('alpha')
         with Session(self.browser) as session:
@@ -881,17 +881,18 @@ class ActivationKeyTestCase(UITestCase):
     def test_negative_usage_limit(self):
         """Test that Usage limit actually limits usage
 
-        @id: 9fe2d661-66f8-46a4-ae3f-0a9329494bdd
+        :id: 9fe2d661-66f8-46a4-ae3f-0a9329494bdd
 
-        @Steps:
-        1. Create Activation key
-        2. Update Usage Limit to a finite number
-        3. Register Systems to match the Usage Limit
-        4. Attempt to register an other system after reaching the Usage Limit
+        :Steps:
+            1. Create Activation key
+            2. Update Usage Limit to a finite number
+            3. Register Systems to match the Usage Limit
+            4. Attempt to register an other system after reaching the Usage
+                Limit
 
-        @Assert: System Registration fails. Appropriate error shown
+        :Assert: System Registration fails. Appropriate error shown
 
-        @CaseLevel: System
+        :CaseLevel: System
         """
         name = gen_string('alpha')
         host_limit = '1'
@@ -928,16 +929,16 @@ class ActivationKeyTestCase(UITestCase):
     def test_positive_add_host(self):
         """Test that hosts can be associated to Activation Keys
 
-        @id: 886e9ea5-d917-40e0-a3b1-41254c4bf5bf
+        :id: 886e9ea5-d917-40e0-a3b1-41254c4bf5bf
 
-        @Steps:
-        1. Create Activation key
-        2. Create different hosts
-        3. Associate the hosts to Activation key
+        :Steps:
+            1. Create Activation key
+            2. Create different hosts
+            3. Associate the hosts to Activation key
 
-        @Assert: Hosts are successfully associated to Activation key
+        :Assert: Hosts are successfully associated to Activation key
 
-        @CaseLevel: System
+        :CaseLevel: System
         """
         key_name = gen_string('utf8')
         with Session(self.browser) as session:
@@ -963,11 +964,11 @@ class ActivationKeyTestCase(UITestCase):
     def test_positive_add_rh_product(self):
         """Test that RH product can be associated to Activation Keys
 
-        @id: d805341b-6d2f-4e16-8cb4-902de00b9a6c
+        :id: d805341b-6d2f-4e16-8cb4-902de00b9a6c
 
-        @Assert: RH products are successfully associated to Activation key
+        :Assert: RH products are successfully associated to Activation key
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         name = gen_string('alpha')
         cv_name = gen_string('alpha')
@@ -1008,11 +1009,11 @@ class ActivationKeyTestCase(UITestCase):
     def test_positive_add_custom_product(self):
         """Test that custom product can be associated to Activation Keys
 
-        @id: e66db2bf-517a-46ff-ba23-9f9744bef884
+        :id: e66db2bf-517a-46ff-ba23-9f9744bef884
 
-        @Assert: Custom products are successfully associated to Activation key
+        :Assert: Custom products are successfully associated to Activation key
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         name = gen_string('alpha')
         cv_name = gen_string('alpha')
@@ -1042,16 +1043,16 @@ class ActivationKeyTestCase(UITestCase):
         """Test that RH/Custom product can be associated to Activation
         keys
 
-        @id: 3d8876fa-1412-47ca-a7a4-bce2e8baf3bc
+        :id: 3d8876fa-1412-47ca-a7a4-bce2e8baf3bc
 
-        @Steps:
-        1. Create Activation key
-        2. Associate RH product(s) to Activation Key
-        3. Associate custom product(s) to Activation Key
+        :Steps:
+            1. Create Activation key
+            2. Associate RH product(s) to Activation Key
+            3. Associate custom product(s) to Activation Key
 
-        @Assert: RH/Custom product is successfully associated to Activation key
+        :Assert: RH/Custom product is successfully associated to Activation key
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         name = gen_string('alpha')
         rh_repo = {
@@ -1114,16 +1115,16 @@ class ActivationKeyTestCase(UITestCase):
     def test_positive_delete_manifest(self):
         """Check if deleting a manifest removes it from Activation key
 
-        @id: 512d8e41-b937-451e-a9c6-840457d3d7d4
+        :id: 512d8e41-b937-451e-a9c6-840457d3d7d4
 
-        @Steps:
-        1. Create Activation key
-        2. Associate a manifest to the Activation Key
-        3. Delete the manifest
+        :Steps:
+            1. Create Activation key
+            2. Associate a manifest to the Activation Key
+            3. Delete the manifest
 
-        @Assert: Deleting a manifest removes it from the Activation key
+        :Assert: Deleting a manifest removes it from the Activation key
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         # Upload manifest
         org = entities.Organization().create()
@@ -1168,11 +1169,11 @@ class ActivationKeyTestCase(UITestCase):
     def test_positive_add_multiple_aks_to_system(self):
         """Check if multiple Activation keys can be attached to a system
 
-        @id: 4d6b6b69-9d63-4180-af2e-a5d908f8adb7
+        :id: 4d6b6b69-9d63-4180-af2e-a5d908f8adb7
 
-        @Assert: Multiple Activation keys are attached to a system
+        :Assert: Multiple Activation keys are attached to a system
 
-        @CaseLevel: System
+        :CaseLevel: System
         """
         key_1_name = gen_string('alpha')
         key_2_name = gen_string('alpha')
@@ -1236,19 +1237,19 @@ class ActivationKeyTestCase(UITestCase):
         Associate activation-key with host-group to auto-register the
         content-host during provisioning itself.
 
-        @id: 1dc0079d-f41f-454b-9554-1235cabd1a4c
+        :id: 1dc0079d-f41f-454b-9554-1235cabd1a4c
 
-        @Steps:
-        1. Create Activation key
-        2. Associate it to host-group
-        3. Provision content-host with same Activation key
+        :Steps:
+            1. Create Activation key
+            2. Associate it to host-group
+            3. Provision content-host with same Activation key
 
-        @Assert: Content-host should be successfully provisioned and registered
-        with Activation key
+        :Assert: Content-host should be successfully provisioned and registered
+            with Activation key
 
-        @caseautomation: notautomated
+        :caseautomation: notautomated
 
-        @CaseLevel: System
+        :CaseLevel: System
         """
 
     @run_only_on('sat')
@@ -1256,9 +1257,9 @@ class ActivationKeyTestCase(UITestCase):
     def test_positive_copy(self):
         """Create Activation key and copy it
 
-        @id: f43d9ecf-f8ec-49cc-bd12-be7cdb3bf07c
+        :id: f43d9ecf-f8ec-49cc-bd12-be7cdb3bf07c
 
-        @Assert: Activation Key copy exists
+        :Assert: Activation Key copy exists
         """
         with Session(self.browser) as session:
             for new_name in valid_data_list():
@@ -1275,9 +1276,9 @@ class ActivationKeyTestCase(UITestCase):
     def test_negative_copy(self):
         """Create Activation key and fail copying it
 
-        @id: 117af9a8-e669-46cb-8a54-071087d0d082
+        :id: 117af9a8-e669-46cb-8a54-071087d0d082
 
-        @Assert: Activation Key copy does not exist
+        :Assert: Activation Key copy does not exist
         """
         with Session(self.browser) as session:
             for new_name in invalid_names_list():
@@ -1294,16 +1295,16 @@ class ActivationKeyTestCase(UITestCase):
         """Verify only hosts registered by specific activation key are listed
         on Activation Key -> Associations -> Content Hosts page
 
-        @id: 9364bfcc-ef69-4183-9ca8-e2904b3f4068
+        :id: 9364bfcc-ef69-4183-9ca8-e2904b3f4068
 
-        @Steps:
-        1. Create 2 activation keys
-        2. Register 2 hosts, one for each activation key
+        :Steps:
+            1. Create 2 activation keys
+            2. Register 2 hosts, one for each activation key
 
-        @Assert: Activation Key -> Associations -> Content Hosts page should
-        show only hosts registered via the key
+        :Assert: Activation Key -> Associations -> Content Hosts page should
+            show only hosts registered via the key
 
-        @BZ: 1372826
+        :BZ: 1372826
         """
         org = make_org()
         env = make_lifecycle_environment({'organization-id': org['id']})
@@ -1365,11 +1366,11 @@ class ActivationKeyTestCase(UITestCase):
         """Delete any user who has previously created an activation key
         and check that activation key still exists
 
-        @id: f0504bd8-52d2-40cd-91c6-64d71b14c876
+        :id: f0504bd8-52d2-40cd-91c6-64d71b14c876
 
-        @Assert: Activation Key can be read
+        :Assert: Activation Key can be read
 
-        @BZ: 1291271
+        :BZ: 1291271
         """
         ak_name = gen_string('alpha')
         # Create user
@@ -1401,14 +1402,14 @@ class ActivationKeyTestCase(UITestCase):
     def test_positive_fetch_product_content(self):
         """Associate RH & custom product with AK and fetch AK's product content
 
-        @id: 4c37fb12-ea2a-404e-b7cc-a2735e8dedb6
+        :id: 4c37fb12-ea2a-404e-b7cc-a2735e8dedb6
 
-        @Assert: Both Red Hat and custom product subscriptions are assigned as
-        Activation Key's product content
+        :Assert: Both Red Hat and custom product subscriptions are assigned as
+            Activation Key's product content
 
-        @BZ: 1360239
+        :BZ: 1360239
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         org = entities.Organization().create()
         with manifests.clone() as manifest:

--- a/tests/foreman/ui/test_adusergroup.py
+++ b/tests/foreman/ui/test_adusergroup.py
@@ -1,18 +1,18 @@
 """Test class for Active Directory Feature
 
-@Requirement: Adusergroup
+:Requirement: Adusergroup
 
-@CaseAutomation: Automated
+:CaseAutomation: Automated
 
-@CaseLevel: Acceptance
+:CaseLevel: Acceptance
 
-@CaseComponent: UI
+:CaseComponent: UI
 
-@TestType: Functional
+:TestType: Functional
 
-@CaseImportance: High
+:CaseImportance: High
 
-@Upstream: No
+:Upstream: No
 """
 from fauxfactory import gen_string
 from nailgun import entities
@@ -94,16 +94,16 @@ class ActiveDirectoryUserGroupTestCase(UITestCase):
         """Associate Admin role to User Group. [belonging to external AD User
         Group.]
 
-        @id: c3371810-1ddc-4a2c-b7e1-3b4d5db3a755
+        :id: c3371810-1ddc-4a2c-b7e1-3b4d5db3a755
 
-        @Steps:
+        :Steps:
 
-        1. Create an UserGroup.
-        2. Assign admin role to UserGroup.
-        3. Create and associate an External AD UserGroup.
+            1. Create an UserGroup.
+            2. Assign admin role to UserGroup.
+            3. Create and associate an External AD UserGroup.
 
-        @Assert: Whether a User belonging to User Group is able to access some
-        of the pages.
+        :Assert: Whether a User belonging to User Group is able to access some
+            of the pages.
         """
         self.check_external_user()
         with Session(self.browser) as session:
@@ -136,18 +136,18 @@ class ActiveDirectoryUserGroupTestCase(UITestCase):
         """Associate foreman roles to User Group.
         [belonging to external AD User Group.]
 
-        @id: c11fbf85-e144-4576-99e3-1ba111479f0f
+        :id: c11fbf85-e144-4576-99e3-1ba111479f0f
 
-        @Steps:
+        :Steps:
 
-        1. Create an UserGroup.
-        2. Assign some foreman roles to UserGroup.
-        3. Create and associate an External AD UserGroup.
+            1. Create an UserGroup.
+            2. Assign some foreman roles to UserGroup.
+            3. Create and associate an External AD UserGroup.
 
-        @Assert: Whether a User belonging to User Group is able to access
-        foreman entities as per roles.
+        :Assert: Whether a User belonging to User Group is able to access
+            foreman entities as per roles.
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         self.check_external_user()
         strategy, value = locators['login.loggedin']
@@ -191,18 +191,18 @@ class ActiveDirectoryUserGroupTestCase(UITestCase):
         """Associate katello roles to User Group.
         [belonging to external AD User Group.]
 
-        @id: aa5e3bf4-cb42-43a4-93ea-a2eea54b847a
+        :id: aa5e3bf4-cb42-43a4-93ea-a2eea54b847a
 
-        @Steps:
+        :Steps:
 
-        1. Create an UserGroup.
-        2. Assign some foreman roles to UserGroup.
-        3. Create and associate an External AD UserGroup.
+            1. Create an UserGroup.
+            2. Assign some foreman roles to UserGroup.
+            3. Create and associate an External AD UserGroup.
 
-        @Assert: Whether a User belonging to User Group is able to access
-        katello entities as per roles.
+        :Assert: Whether a User belonging to User Group is able to access
+            katello entities as per roles.
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         self.check_external_user()
         katello_role = gen_string('alpha')
@@ -241,15 +241,15 @@ class ActiveDirectoryUserGroupTestCase(UITestCase):
     def test_positive_create_external(self):
         """Create External AD User Group as per AD group
 
-        @id: b5e64316-55b9-4480-8701-308e91be9344
+        :id: b5e64316-55b9-4480-8701-308e91be9344
 
-        @Steps:
+        :Steps:
 
-        1. Create an UserGroup.
-        2. Assign some roles to UserGroup.
-        3. Create an External AD UserGroup as per the UserGroup name in AD
+            1. Create an UserGroup.
+            2. Assign some roles to UserGroup.
+            3. Create an External AD UserGroup as per the UserGroup name in AD
 
-        @Assert: Whether creation of External AD User Group is possible.
+        :Assert: Whether creation of External AD User Group is possible.
         """
         with Session(self.browser) as session:
             make_usergroup(
@@ -266,16 +266,17 @@ class ActiveDirectoryUserGroupTestCase(UITestCase):
         """Attempt to create two User Groups with same External AD User Group
         name
 
-        @id: 8f2cde96-644a-4729-880a-65a22c7e7262
+        :id: 8f2cde96-644a-4729-880a-65a22c7e7262
 
-        @Steps:
+        :Steps:
 
-        1. Create an UserGroup.
-        2. Assign External AD UserGroup as per the UserGroup name in AD.
-        3. Repeat steps 1) and 2), but provide the same external UserGroup name
+            1. Create an UserGroup.
+            2. Assign External AD UserGroup as per the UserGroup name in AD.
+            3. Repeat steps 1) and 2), but provide the same external UserGroup
+               name
 
-        @Assert: Creation of User Group should not be possible with same
-        External AD User Group name.
+        :Assert: Creation of User Group should not be possible with same
+            External AD User Group name.
         """
         new_usergroup_name = gen_string('alpha')
         with Session(self.browser) as session:
@@ -300,16 +301,16 @@ class ActiveDirectoryUserGroupTestCase(UITestCase):
     def test_negative_create_external_with_invalid_name(self):
         """Create External AD User Group with random name
 
-        @id: 2fd12301-9a35-49f1-9723-2b74551414c2
+        :id: 2fd12301-9a35-49f1-9723-2b74551414c2
 
-        @Steps:
+        :Steps:
 
-        1. Create an UserGroup.
-        2. Assign some roles to UserGroup.
-        3. Create an External AD UserGroup with any random name.
+            1. Create an UserGroup.
+            2. Assign some roles to UserGroup.
+            3. Create an External AD UserGroup with any random name.
 
-        @Assert: Creation of External AD User Group should not be possible with
-        random name.
+        :Assert: Creation of External AD User Group should not be possible with
+            random name.
         """
         with Session(self.browser) as session:
             make_usergroup(
@@ -329,24 +330,24 @@ class ActiveDirectoryUserGroupTestCase(UITestCase):
     def test_positive_delete_external(self):
         """Delete External AD User Group
 
-        @id: 364e9ddc-4ab7-46a9-b52c-8159aab7f811
+        :id: 364e9ddc-4ab7-46a9-b52c-8159aab7f811
 
-        @Steps:
+        :Steps:
 
-        1. Create an UserGroup.
-        2. Assign some roles to UserGroup.
-        3. Create an External AD UserGroup as per the UserGroup name in AD.
-        4. Delete the External AD UserGroup.
+            1. Create an UserGroup.
+            2. Assign some roles to UserGroup.
+            3. Create an External AD UserGroup as per the UserGroup name in AD.
+            4. Delete the External AD UserGroup.
+               Note:- Deletion as of sat6.1 is possible only via CLI and not
+               via UI.
 
-        Note:- Deletion as of sat6.1 is possible only via CLI and not via UI.
+        :Assert: Deletion of External AD User Group should be possible and the
+            user should not be able to perform the roles that were assigned to
+            it at the UserGroup level.
 
-        @Assert: Deletion of External AD User Group should be possible and the
-        user should not be able to perform the roles that were assigned to it
-        at the UserGroup level.
+        :caseautomation: notautomated
 
-        @caseautomation: notautomated
-
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
 
     @skip_if_bug_open('bugzilla', '1221971')
@@ -354,23 +355,23 @@ class ActiveDirectoryUserGroupTestCase(UITestCase):
     def test_positive_update_external_roles(self):
         """Added AD UserGroup roles get pushed down to user
 
-        @id: f3ca1aae-5461-4af3-a508-82679bb6afed
+        :id: f3ca1aae-5461-4af3-a508-82679bb6afed
 
-        @setup: assign additional roles to the UserGroup
+        :setup: assign additional roles to the UserGroup
 
-        @steps:
-        1. Create an UserGroup.
-        2. Assign some roles to UserGroup.
-        3. Create an External AD UserGroup as per the UserGroup name in AD.
-        4. Login to sat6 with the AD user.
-        5. Assign additional roles to the UserGroup.
-        6. Login to sat6 with LDAP user that is part of aforementioned
-        UserGroup.
+        :steps:
+            1. Create an UserGroup.
+            2. Assign some roles to UserGroup.
+            3. Create an External AD UserGroup as per the UserGroup name in AD.
+            4. Login to sat6 with the AD user.
+            5. Assign additional roles to the UserGroup.
+            6. Login to sat6 with LDAP user that is part of aforementioned
+               UserGroup.
 
-        @assert: User has access to all NEW functional areas that are assigned
-        to aforementioned UserGroup.
+        :assert: User has access to all NEW functional areas that are assigned
+            to aforementioned UserGroup.
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         self.check_external_user()
         foreman_role = gen_string('alpha')
@@ -434,23 +435,23 @@ class ActiveDirectoryUserGroupTestCase(UITestCase):
     def test_positive_delete_external_roles(self):
         """Deleted AD UserGroup roles get pushed down to user
 
-        @id: 479bc8fe-f6a3-4c89-8c7e-3d997315383f
+        :id: 479bc8fe-f6a3-4c89-8c7e-3d997315383f
 
-        @setup: delete roles from an AD UserGroup
+        :setup: delete roles from an AD UserGroup
 
-        @steps:
-        1. Create an UserGroup.
-        2. Assign some roles to UserGroup.
-        3. Create an External AD UserGroup as per the UserGroup name in AD.
-        4. Login to sat6 with the AD user.
-        5. Unassign some of the existing roles of the UserGroup.
-        6. Login to sat6 with LDAP user that is part of aforementioned
-        UserGroup.
+        :steps:
+            1. Create an UserGroup.
+            2. Assign some roles to UserGroup.
+            3. Create an External AD UserGroup as per the UserGroup name in AD.
+            4. Login to sat6 with the AD user.
+            5. Unassign some of the existing roles of the UserGroup.
+            6. Login to sat6 with LDAP user that is part of aforementioned
+               UserGroup.
 
-        @assert: User no longer has access to all deleted functional areas
-        that were assigned to aforementioned UserGroup.
+        :assert: User no longer has access to all deleted functional areas that
+            were assigned to aforementioned UserGroup.
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         self.check_external_user()
         foreman_role = gen_string('alpha')
@@ -502,26 +503,26 @@ class ActiveDirectoryUserGroupTestCase(UITestCase):
         """Assure that user has roles/can access feature areas for
         additional roles assigned outside any roles assigned by his group
 
-        @id: a487f7d6-22f2-4e42-b34f-8d984f721c83
+        :id: a487f7d6-22f2-4e42-b34f-8d984f721c83
 
-        @setup: Assign roles to UserGroup and configure external
-        UserGroup subsequently assign specified roles to the user(s).
-        roles that are not part of the larger UserGroup
+        :setup: Assign roles to UserGroup and configure external UserGroup
+            subsequently assign specified roles to the user(s).  roles that are
+            not part of the larger UserGroup
 
-        @steps:
-        1. Create an UserGroup.
-        2. Assign some roles to UserGroup.
-        3. Create an External AD UserGroup as per the UserGroup name in AD.
-        4. Assign some more roles to a User(which is part of external AD
-        UserGroup) at the User level.
-        5. Login to sat6 with the above AD user and attempt to access areas
-        assigned specifically to user.
+        :steps:
+            1. Create an UserGroup.
+            2. Assign some roles to UserGroup.
+            3. Create an External AD UserGroup as per the UserGroup name in AD.
+            4. Assign some more roles to a User(which is part of external AD
+               UserGroup) at the User level.
+            5. Login to sat6 with the above AD user and attempt to access areas
+               assigned specifically to user.
 
-        @assert: User can access not only those feature areas in his
-        UserGroup but those additional feature areas / roles assigned
-        specifically to user
+        :assert: User can access not only those feature areas in his UserGroup
+            but those additional feature areas / roles assigned specifically to
+            user
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         self.check_external_user()
         foreman_role = gen_string('alpha')
@@ -583,22 +584,22 @@ class ActiveDirectoryUserGroupTestCase(UITestCase):
     def test_positive_add_external_user(self):
         """New user added to UserGroup at AD side inherits roles in Sat6
 
-        @id: da41d197-85d5-4405-98ec-30c1d69f4c93
+        :id: da41d197-85d5-4405-98ec-30c1d69f4c93
 
-        @setup: UserGroup with specified roles.
+        :setup: UserGroup with specified roles.
 
-        @steps:
-        1. Create an UserGroup.
-        2. Assign some roles to UserGroup.
-        3. Create an External AD UserGroup as per the UserGroup name in AD.
-        4. On AD server side, assign a new user to a UserGroup.
-        5. Login to sat6 with the above new AD user and attempt to access the
-        functional areas assigned to the user.
+        :steps:
+            1. Create an UserGroup.
+            2. Assign some roles to UserGroup.
+            3. Create an External AD UserGroup as per the UserGroup name in AD.
+            4. On AD server side, assign a new user to a UserGroup.
+            5. Login to sat6 with the above new AD user and attempt to access
+               the functional areas assigned to the user.
 
-        @assert: User can access feature areas as defined by roles in the
-        UserGroup of which he is a part.
+        :assert: User can access feature areas as defined by roles in the
+            UserGroup of which he is a part.
 
-        @caseautomation: notautomated
+        :caseautomation: notautomated
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """

--- a/tests/foreman/ui/test_ansible.py
+++ b/tests/foreman/ui/test_ansible.py
@@ -1,16 +1,16 @@
 """Tests for Ansible integration in UI
 
-@Requirement: Ansible Integration
+:Requirement: Ansible Integration
 
-@CaseLevel: System
+:CaseLevel: System
 
-@CaseComponent: UI
+:CaseComponent: UI
 
-@TestType: Functional
+:TestType: Functional
 
-@CaseImportance: High
+:CaseImportance: High
 
-@Upstream: No
+:Upstream: No
 """
 
 
@@ -27,18 +27,17 @@ class AnsibleTestCase(UITestCase):
     def test_positive_install_ansible_plugin(self):
         """Install Ansible plugin in Satellite
 
-        @id: 88b5bad8-7d15-4286-a70e-0c7125a0de39
+        :id: 88b5bad8-7d15-4286-a70e-0c7125a0de39
 
-        @steps:
+        :steps: Install Ansible plugin in Satellite by running
+            `satellite-installer` using `--enable-foreman-plugin-ansible`
+            option
 
-        1. Install Ansible plugin in Satellite by running
-           `satellite-installer` using `--enable-foreman-plugin-ansible`
-           option
+        :assert: Ansible plugin is installed successfully. This can be verified
+            by editing any host and checking the presence of `Ansible Roles`
+            tab.
 
-        @assert: Ansible plugin is installed successfully. This can be verified
-        by editing any host and checking the presence of `Ansible Roles` tab.
-
-        @caseautomation: notautomated
+        :caseautomation: notautomated
 
         """
 
@@ -49,18 +48,16 @@ class AnsibleTestCase(UITestCase):
         """Setup Ansible callback when Ansible is installed in the Satellite
         host
 
-        @id: d9296383-66f8-4999-9102-ef28aff77877
+        :id: d9296383-66f8-4999-9102-ef28aff77877
 
-        @steps:
+        :steps: Follow the Ansible callback setup steps mentioned in
+            https://theforeman.org/plugins/foreman_ansible/1.x/index.html
+            #2.1Ansiblecallback
 
-        1. Follow the Ansible callback setup steps mentioned in
-           https://theforeman.org/plugins/foreman_ansible/1.x/index.html
-           #2.1Ansiblecallback
+        :assert: Ansible callback is setup successfully. This can be verified
+            by running Ansible setup module in any of the hosts.
 
-        @assert: Ansible callback is setup successfully. This can be verified
-        by running Ansible setup module in any of the hosts.
-
-        @caseautomation: notautomated
+        :caseautomation: notautomated
 
         """
 
@@ -70,19 +67,17 @@ class AnsibleTestCase(UITestCase):
     def test_positive_setup_ansible_callback_capsule(self):
         """Setup Ansible callback when Ansible is installed in the Capsule
 
-        @id: 72dec524-268e-480a-b7c1-6df2ebbe0d43
+        :id: 72dec524-268e-480a-b7c1-6df2ebbe0d43
 
-        @steps:
-
-        1. Follow the Ansible callback setup steps mentioned in
-           https://theforeman.org/plugins/foreman_ansible/1.x/index.html
-           #2.1Ansiblecallback
+        :steps: Follow the Ansible callback setup steps mentioned in
+            https://theforeman.org/plugins/foreman_ansible/1.x/index.html
+            #2.1Ansiblecallback
 
 
-        @assert: Ansible callback is setup successfully. This can be verified
-        by running Ansible setup module in any of the hosts.
+        :assert: Ansible callback is setup successfully. This can be verified
+            by running Ansible setup module in any of the hosts.
 
-        @caseautomation: notautomated
+        :caseautomation: notautomated
 
         """
 
@@ -93,18 +88,18 @@ class AnsibleTestCase(UITestCase):
         """Generate Ansible run reports when Ansible Tower is installed in the
         Satellite host
 
-        @id: 45d1f7e2-1071-432c-a6cc-7757a26ca2e4
+        :id: 45d1f7e2-1071-432c-a6cc-7757a26ca2e4
 
-        @steps:
+        :steps:
 
-        1. Install Ansible Tower in the Satellite host
-        2. Setup Ansible callback in the Tower
-        3. Run Ansible setup module
+            1. Install Ansible Tower in the Satellite host
+            2. Setup Ansible callback in the Tower
+            3. Run Ansible setup module
 
-        @assert: Ansible Tower is integrated with Satellite and the Ansible run
-        reports are shown in Satellite.
+        :assert: Ansible Tower is integrated with Satellite and the Ansible run
+            reports are shown in Satellite.
 
-        @caseautomation: notautomated
+        :caseautomation: notautomated
 
         """
 
@@ -114,18 +109,18 @@ class AnsibleTestCase(UITestCase):
     def test_positive_tower_installed_in_capsule(self):
         """Check Ansible runs when Ansible Tower is installed in the Capsule
 
-        @id: 5af34b23-b6d7-49f5-9e92-ac0ba2182c86
+        :id: 5af34b23-b6d7-49f5-9e92-ac0ba2182c86
 
-        @steps:
+        :steps:
 
-        1. Install Ansible Tower in the Capsule
-        2. Setup Ansible callback in the Tower
-        3. Run Ansible setup module
+            1. Install Ansible Tower in the Capsule
+            2. Setup Ansible callback in the Tower
+            3. Run Ansible setup module
 
-        @assert: Ansible Tower is integrated with Satellite and the Ansible run
-        reports are shown in Satellite.
+        :assert: Ansible Tower is integrated with Satellite and the Ansible run
+            reports are shown in Satellite.
 
-        @caseautomation: notautomated
+        :caseautomation: notautomated
         """
 
     @run_only_on('sat')
@@ -135,16 +130,16 @@ class AnsibleTestCase(UITestCase):
         """Ansible report creation for a host which is already present in
         Satellite
 
-        @id: 334dfe58-6019-4d20-ab29-8cc002422ce6
+        :id: 334dfe58-6019-4d20-ab29-8cc002422ce6
 
-        @steps:
+        :steps:
 
-        1. Register a host to Satellite
-        2. Run Ansible on the host
+            1. Register a host to Satellite
+            2. Run Ansible on the host
 
-        @assert: Ansible report is created for the host
+        :assert: Ansible report is created for the host
 
-        @caseautomation: notautomated
+        :caseautomation: notautomated
         """
 
     @run_only_on('sat')
@@ -154,16 +149,14 @@ class AnsibleTestCase(UITestCase):
         """Ansible report creation for a host which is not present in
         Satellite
 
-        @id: 7f6f5767-3967-4741-9021-ce09ad69926a
+        :id: 7f6f5767-3967-4741-9021-ce09ad69926a
 
-        @steps:
+        :steps: Run Ansible on a host not registered to Satellite yet
 
-        1. Run Ansible on a host not registered to Satellite yet
+        :assert: The host is created in Satellite and the Ansible report is
+            created for the host
 
-        @assert: The host is created in Satellite and the Ansible report is
-        created for the host
-
-        @caseautomation: notautomated
+        :caseautomation: notautomated
         """
 
     @run_only_on('sat')
@@ -172,20 +165,19 @@ class AnsibleTestCase(UITestCase):
     def test_positive_associate_ansible_roles_to_hosts(self):
         """Associate Ansible roles to hosts
 
-        @id: 2f4d0e17-9cee-4d77-b309-1ba5a1b96173
+        :id: 2f4d0e17-9cee-4d77-b309-1ba5a1b96173
 
-        @steps:
+        :steps:
+            1. From Web UI -> Hosts -> Select a Host -> Edit -> Ansible Roles
+                -> Select the required Ansible roles -> Click Submit.
+            2. Run the associated Ansible roles in the hosts.
 
-        1. From Web UI -> Hosts -> Select a Host -> Edit -> Ansible Roles ->
-           Select the required Ansible roles -> Click Submit.
-        2. Run the associated Ansible roles in the hosts.
+        :assert:
 
-        @assert:
+            1. The Ansible roles are associated to the appropriate hosts
+            2. The Ansible run reports generated
 
-        1. The Ansible roles are associated to the appropriate hosts
-        2. The Ansible run reports generated
-
-        @caseautomation: notautomated
+        :caseautomation: notautomated
         """
 
     @run_only_on('sat')
@@ -194,28 +186,27 @@ class AnsibleTestCase(UITestCase):
     def test_positive_execute_custom_ansible_role(self):
         """Execute custom Ansible roles on hosts
 
-        @id: 39bc81fd-2b6c-4dac-8db7-38312ba9bffb
+        :id: 39bc81fd-2b6c-4dac-8db7-38312ba9bffb
 
-        @steps:
+        :steps:
 
-        1. On Satellite server create a new custom Ansible role.
-           A role with a single task writing a new file on client host, can be
-           created using a template like.
-           "echo 'task: shell: touch /tmp/file.test' >
-           /etc/ansible/roles/custom/"
-        2. From Web UI -> Hosts -> Select a Host -> Edit -> Ansible Roles ->
-           Select the new custom Ansible role -> Click Submit.
-        3. Run the associated Ansible role in the host.
+            1. On Satellite server create a new custom Ansible role.  A role
+                with a single task writing a new file on client host, can be
+                created using a template like.  "echo 'task: shell: touch
+                /tmp/file.test' > /etc/ansible/roles/custom/"
+            2. From Web UI -> Hosts -> Select a Host -> Edit -> Ansible Roles
+                -> Select the new custom Ansible role -> Click Submit.
+            3. Run the associated Ansible role in the host.
 
-        @assert:
+        :assert:
 
-        1. The custom role are available in Satellite.
-        2. The Ansible roles are associated to the appropriate hosts.
-        3. The Ansible run reports generated.
-        4. The role task has been performed successfully in the client host
-           (ssh in to the client host and check that /tmp/file.test exists)
+            1. The custom role are available in Satellite.
+            2. The Ansible roles are associated to the appropriate hosts.
+            3. The Ansible run reports generated.
+            4. The role task has been performed successfully in the client host
+               (ssh in to the client host and check that /tmp/file.test exists)
 
-        @caseautomation: notautomated
+        :caseautomation: notautomated
         """
 
     @run_only_on('sat')
@@ -224,20 +215,21 @@ class AnsibleTestCase(UITestCase):
     def test_positive_associate_ansible_roles_to_hostgroups(self):
         """Associate Ansible roles to hostgroups
 
-        @id: 685ce52d-5684-49b6-ace6-ede253a58b24
+        :id: 685ce52d-5684-49b6-ace6-ede253a58b24
 
-        @steps:
+        :steps:
 
-        1. From Web UI -> Configure -> Host groups -> Select a Host group ->
-           Ansible Roles -> Select the required Ansible roles -> Click Submit
-        2. Provision a host with the Host group from above
+            1. From Web UI -> Configure -> Host groups -> Select a Host group
+                -> Ansible Roles -> Select the required Ansible roles -> Click
+                Submit
+            2. Provision a host with the Host group from above
 
-        @assert:
+        :assert:
 
-        1. The Ansible role is associated to the appropriate Host group
-        2. The Ansible run reports generated
+            1. The Ansible role is associated to the appropriate Host group
+            2. The Ansible run reports generated
 
-        @caseautomation: notautomated
+        :caseautomation: notautomated
         """
 
     @run_only_on('sat')
@@ -246,12 +238,12 @@ class AnsibleTestCase(UITestCase):
     def test_positive_run_ansibles_role_one_host(self):
         """Check if Ansible roles can be run on one host
 
-        @id: ab40f3ae-7dc3-47d1-b5e6-18ca1f1d5460
+        :id: ab40f3ae-7dc3-47d1-b5e6-18ca1f1d5460
 
-        @assert: Ansibles roles ran successfully on the host and the reports
-        generated
+        :assert: Ansibles roles ran successfully on the host and the reports
+            generated
 
-        @caseautomation: notautomated
+        :caseautomation: notautomated
         """
 
     @run_only_on('sat')
@@ -260,16 +252,14 @@ class AnsibleTestCase(UITestCase):
     def test_positive_run_ansibles_role_multiple_hosts(self):
         """Check if Ansible roles can be run on multiple hosts
 
-        @id: 349b8bd8-7fd6-482a-99d2-641ac319f44f
+        :id: 349b8bd8-7fd6-482a-99d2-641ac319f44f
 
-        @steps:
+        :steps: From Web UI -> Hosts -> Select multiple hosts -> Select Action
+            -> Play Ansible Roles
 
-        1. From Web UI -> Hosts -> Select multiple hosts -> Select Action ->
-           Play Ansible Roles
+        :assert: Ansibles roles ran successfully on multiple hosts
 
-        @assert: Ansibles roles ran successfully on multiple hosts
-
-        @caseautomation: notautomated
+        :caseautomation: notautomated
         """
 
     @run_only_on('sat')
@@ -279,14 +269,14 @@ class AnsibleTestCase(UITestCase):
         """Check if an user with view_ansible_roles permission able to view
         the Ansible roles
 
-        @id: 60aa2d5a-571c-40af-bfaf-ca406b6a4672
+        :id: 60aa2d5a-571c-40af-bfaf-ca406b6a4672
 
-        @assert: An user with view_ansible_roles permission is able to view the
-        Ansible roles.
+        :assert: An user with view_ansible_roles permission is able to view the
+            Ansible roles.
 
-        @caseautomation: notautomated
+        :caseautomation: notautomated
 
-        @caselevel: Acceptance
+        :caselevel: Acceptance
         """
 
     @run_only_on('sat')
@@ -296,14 +286,14 @@ class AnsibleTestCase(UITestCase):
         """Check if an user with import_ansible_roles permission able to
         import Ansible roles
 
-        @id: f2cb633b-fa9a-4096-b2c9-54175a30da06
+        :id: f2cb633b-fa9a-4096-b2c9-54175a30da06
 
-        @assert: An user with import_ansible_roles permission is able to import
-        Ansible roles.
+        :assert: An user with import_ansible_roles permission is able to import
+            Ansible roles.
 
-        @caseautomation: notautomated
+        :caseautomation: notautomated
 
-        @caselevel: Acceptance
+        :caselevel: Acceptance
 
         """
 
@@ -314,14 +304,14 @@ class AnsibleTestCase(UITestCase):
         """Check if an user with destroy_ansible_roles permission able to
         delete Ansible roles
 
-        @id: e9c3df3f-3a03-4665-a0f7-184212b73e74
+        :id: e9c3df3f-3a03-4665-a0f7-184212b73e74
 
-        @assert: An user with destroy_ansible_roles permission is able to
-        delete Ansible roles
+        :assert: An user with destroy_ansible_roles permission is able to
+            delete Ansible roles
 
-        @caseautomation: notautomated
+        :caseautomation: notautomated
 
-        @caselevel: Acceptance
+        :caselevel: Acceptance
 
         """
 
@@ -332,12 +322,12 @@ class AnsibleTestCase(UITestCase):
         """Check if an user with play_roles permission able to run the Ansible
         roles
 
-        @id: 14948966-4ee0-44c6-9de0-6b98ef11dc62
+        :id: 14948966-4ee0-44c6-9de0-6b98ef11dc62
 
-        @assert: The user with play_roles permission is able to run the
-        Ansible roles
+        :assert: The user with play_roles permission is able to run the Ansible
+            roles
 
-        @caseautomation: notautomated
+        :caseautomation: notautomated
         """
 
     @run_only_on('sat')
@@ -347,12 +337,12 @@ class AnsibleTestCase(UITestCase):
         """Check if an user with play_multiple_roles permission able to run
         multiple Ansible roles
 
-        @id: ba3119b8-024f-4624-94b3-96bdbeede4d3
+        :id: ba3119b8-024f-4624-94b3-96bdbeede4d3
 
-        @assert: The user with play_multiple_roles permission is able to run
-        multiple Ansible roles
+        :assert: The user with play_multiple_roles permission is able to run
+            multiple Ansible roles
 
-        @caseautomation: notautomated
+        :caseautomation: notautomated
         """
 
     @run_only_on('sat')
@@ -362,27 +352,26 @@ class AnsibleTestCase(UITestCase):
         """Check if an user without appropriate Ansible permissions is
         prevented from using Ansible actions
 
-        @id: ac4a5d48-01c8-4e4a-8fa2-f054965880a1
+        :id: ac4a5d48-01c8-4e4a-8fa2-f054965880a1
 
-        @steps:
+        :steps: Make sure that the user does not have the following
+            permissions:
 
-        1. Make sure that the user does not have the following permissions:
             * view_ansible_roles
             * import_ansible_roles
             * destroy_ansible_roles
             * play_roles
             * play_multiple_roles
 
-        @assert:
+        :assert: The user is not able to:
 
-        The user is not able to
-             * View Ansible roles
-             * Import Ansible roles
-             * Delete Ansible roles
-             * Run roles
-             * Run multiple roles
+            * View Ansible roles
+            * Import Ansible roles
+            * Delete Ansible roles
+            * Run roles
+            * Run multiple roles
 
-        @caseautomation: notautomated
+        :caseautomation: notautomated
         """
 
     @run_only_on('sat')
@@ -391,13 +380,13 @@ class AnsibleTestCase(UITestCase):
     def test_positive_add_ansible_parameter_to_host(self):
         """Check if an Ansible parameter can be added to a host
 
-        @id: 79395d8d-599e-4330-9f9f-40ef6762510d
+        :id: 79395d8d-599e-4330-9f9f-40ef6762510d
 
-        @assert: Ansible parameter added to the host successfully
+        :assert: Ansible parameter added to the host successfully
 
-        @caseautomation: notautomated
+        :caseautomation: notautomated
 
-        @caselevel: Acceptance
+        :caselevel: Acceptance
 
         """
 
@@ -407,12 +396,12 @@ class AnsibleTestCase(UITestCase):
     def test_positive_add_ansible_parameter_to_hostgroup(self):
         """Check if an Ansible parameter can be added to a hostgroup
 
-        @id: 37c826d5-ddb8-4739-8a03-18ffbce7915a
+        :id: 37c826d5-ddb8-4739-8a03-18ffbce7915a
 
-        @assert: Ansible parameter added to the hostgroup successfully
+        :assert: Ansible parameter added to the hostgroup successfully
 
-        @caseautomation: notautomated
+        :caseautomation: notautomated
 
-        @caselevel: Acceptance
+        :caselevel: Acceptance
 
         """

--- a/tests/foreman/ui/test_architecture.py
+++ b/tests/foreman/ui/test_architecture.py
@@ -1,19 +1,19 @@
 # -*- encoding: utf-8 -*-
 """Test class for Architecture UI
 
-@Requirement: Architecture
+:Requirement: Architecture
 
-@CaseAutomation: Automated
+:CaseAutomation: Automated
 
-@CaseLevel: Acceptance
+:CaseLevel: Acceptance
 
-@CaseComponent: UI
+:CaseComponent: UI
 
-@TestType: Functional
+:TestType: Functional
 
-@CaseImportance: High
+:CaseImportance: High
 
-@Upstream: No
+:Upstream: No
 """
 from fauxfactory import gen_string
 from nailgun import entities
@@ -49,9 +49,9 @@ class ArchitectureTestCase(UITestCase):
     def test_positive_create_with_os(self):
         """Create a new Architecture with OS
 
-        @id: 6c386230-2285-4f41-a3a5-6a17ae844f80
+        :id: 6c386230-2285-4f41-a3a5-6a17ae844f80
 
-        @Assert: Architecture is created
+        :Assert: Architecture is created
         """
         with Session(self.browser) as session:
             for test_data in valid_arch_os_names():
@@ -71,9 +71,9 @@ class ArchitectureTestCase(UITestCase):
     def test_positive_create_with_name(self):
         """Create a new Architecture with different data
 
-        @id: 0ac5f63b-b296-425b-8bb2-e0fe32d394c5
+        :id: 0ac5f63b-b296-425b-8bb2-e0fe32d394c5
 
-        @Assert: Architecture is created
+        :Assert: Architecture is created
         """
         with Session(self.browser) as session:
             for name in generate_strings_list():
@@ -87,9 +87,9 @@ class ArchitectureTestCase(UITestCase):
         """Try to create architecture and use whitespace, blank, tab
         symbol or too long string of different types as its name value
 
-        @id: f4b8ed72-f20b-4f5d-bf0a-3475a6124f3a
+        :id: f4b8ed72-f20b-4f5d-bf0a-3475a6124f3a
 
-        @Assert: Architecture is not created
+        :Assert: Architecture is not created
         """
         with Session(self.browser) as session:
             for invalid_name in invalid_values_list(interface='ui'):
@@ -103,9 +103,9 @@ class ArchitectureTestCase(UITestCase):
     def test_negative_create_with_same_name(self):
         """Create a new Architecture with same name
 
-        @id: 4000674e-7b39-4958-8992-1363b25b2cd6
+        :id: 4000674e-7b39-4958-8992-1363b25b2cd6
 
-        @Assert: Architecture is not created
+        :Assert: Architecture is not created
         """
         with Session(self.browser) as session:
             for name in generate_strings_list():
@@ -121,9 +121,9 @@ class ArchitectureTestCase(UITestCase):
     def test_positive_delete(self):
         """Delete an existing Architecture
 
-        @id: f58af0ba-45c8-456c-abe3-8aaf48055c23
+        :id: f58af0ba-45c8-456c-abe3-8aaf48055c23
 
-        @Assert: Architecture is deleted
+        :Assert: Architecture is deleted
         """
         os = entities.OperatingSystem(name=gen_string('alpha')).create()
         with Session(self.browser):
@@ -138,9 +138,9 @@ class ArchitectureTestCase(UITestCase):
     def test_positive_update_name_and_os(self):
         """Update Architecture with new name and OS
 
-        @id: cbb2e8fc-1dde-42c4-aab0-479bd16fb5ec
+        :id: cbb2e8fc-1dde-42c4-aab0-479bd16fb5ec
 
-        @Assert: Architecture is updated
+        :Assert: Architecture is updated
         """
         old_name = gen_string('alpha')
         os_name = gen_string('alpha')

--- a/tests/foreman/ui/test_bookmark.py
+++ b/tests/foreman/ui/test_bookmark.py
@@ -1,18 +1,18 @@
 """Test classes for Bookmark tests
 
-@Requirement: Bookmark
+:Requirement: Bookmark
 
-@CaseAutomation: Automated
+:CaseAutomation: Automated
 
-@CaseLevel: Acceptance
+:CaseLevel: Acceptance
 
-@CaseComponent: UI
+:CaseComponent: UI
 
-@TestType: Functional
+:TestType: Functional
 
-@CaseImportance: High
+:CaseImportance: High
 
-@Upstream: No
+:Upstream: No
 """
 # -*- encoding: utf-8 -*-
 import random
@@ -105,22 +105,22 @@ class BookmarkTestCase(UITestCase):
     def test_positive_create_bookmark_populate_auto(self):
         """Create a bookmark with auto-populating of the query
 
-        @id: 6a51a8d4-b641-4148-9ee8-a62f09aaa4af
+        :id: 6a51a8d4-b641-4148-9ee8-a62f09aaa4af
 
-        @Steps:
+        :Steps:
 
-        1. Navigate to the entity page
-        2. Input a random text into the search field
-        3. Choose "bookmark this search" from the search drop-down menu
-        4. Input a random name for a bookmark name
-        5. Verify the query field is automatically populated and the public
-           option is checked
-        6. Click the create button
-        7. Verify that bookmark's name appears in the search dropdown
-        8. List the bookmarks (Navigate to Administer -> Bookmarks)
+            1. Navigate to the entity page
+            2. Input a random text into the search field
+            3. Choose "bookmark this search" from the search drop-down menu
+            4. Input a random name for a bookmark name
+            5. Verify the query field is automatically populated and the public
+                option is checked
+            6. Click the create button
+            7. Verify that bookmark's name appears in the search dropdown
+            8. List the bookmarks (Navigate to Administer -> Bookmarks)
 
-        @Assert: No errors, Bookmark is displayed, controller matches the
-        entity the bookmark was created for
+        :Assert: No errors, Bookmark is displayed, controller matches the
+            entity the bookmark was created for
         """
         for entity in self.getOneEntity():
             with self.subTest(entity):
@@ -141,20 +141,20 @@ class BookmarkTestCase(UITestCase):
     def test_positive_create_bookmark_populate_manual(self):
         """Create a bookmark with manually populating the name and query
 
-        @id: 6ab2221d-8fd5-484f-ac99-b856db9fa70a
+        :id: 6ab2221d-8fd5-484f-ac99-b856db9fa70a
 
-        @Steps:
+        :Steps:
 
-        1. Navigate to the entity page
-        2. Choose "bookmark this search" from the search drop-down menu
-        3. Input a random name for a bookmark name
-        4. Enter random text into Query field
-        5. Click the create button
-        6. Verify that bookmark's name appears in the search dropdown
-        7. List the bookmarks (Navigate to Administer -> Bookmarks)
+            1. Navigate to the entity page
+            2. Choose "bookmark this search" from the search drop-down menu
+            3. Input a random name for a bookmark name
+            4. Enter random text into Query field
+            5. Click the create button
+            6. Verify that bookmark's name appears in the search dropdown
+            7. List the bookmarks (Navigate to Administer -> Bookmarks)
 
-        @Assert: No errors, Bookmark is displayed, controller matches the
-        entity the bookmark was created for
+        :Assert: No errors, Bookmark is displayed, controller matches the
+            entity the bookmark was created for
         """
         for entity in self.getOneEntity():
             with self.subTest(entity):
@@ -173,37 +173,35 @@ class BookmarkTestCase(UITestCase):
     def test_positive_create_bookmark_public(self):
         """Create and check visibility of the (non)public bookmarks
 
-        @id: 93139529-7690-429b-83fe-3dcbac4f91dc
+        :id: 93139529-7690-429b-83fe-3dcbac4f91dc
 
-        @Setup:
+        :Setup: Create a non-admin user with 'viewer' role
 
-        1. Create a non-admin user with 'viewer' role
+        :Steps:
 
-        @Steps:
+            1. Navigate to the entity page
+            2. Input a random text into the search field
+            3. Choose "bookmark this search" from the search drop-down menu
+            4. Input a random name for a bookmark name
+            5. Verify the query field is automatically populated and the public
+               option is checked
+            6. Click the create button
+            7. Choose "bookmark this search" from the search drop-down menu
+            8. Input a random name for a bookmark name
+            9. Verify the query field is automatically populated and the public
+               option is unchecked
+            10. Click the create button
+            11. Verify that bookmark's name appears in the search dropdown
+            12. List the bookmarks (Navigate to Administer -> Bookmarks)
+            13. Login as the pre-created user
+            14. Navigate to the entity
+            15. Click the dropdown
+            16. Verify that the non-public bookmark is not listed
 
-        1. Navigate to the entity page
-        2. Input a random text into the search field
-        3. Choose "bookmark this search" from the search drop-down menu
-        4. Input a random name for a bookmark name
-        5. Verify the query field is automatically populated and the public
-           option is checked
-        6. Click the create button
-        7. Choose "bookmark this search" from the search drop-down menu
-        8. Input a random name for a bookmark name
-        9. Verify the query field is automatically populated and the public
-           option is unchecked
-        10. Click the create button
-        11. Verify that bookmark's name appears in the search dropdown
-        12. List the bookmarks (Navigate to Administer -> Bookmarks)
-        13. Login as the pre-created user
-        14. Navigate to the entity
-        15. Click the dropdown
-        16. Verify that the non-public bookmark is not listed
+        :Assert: No errors, Bookmark is displayed, controller matches the
+            entity the bookmark was created for
 
-        @Assert: No errors, Bookmark is displayed, controller matches the
-        entity the bookmark was created for
-
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         for entity in self.getOneEntity():
             with self.subTest(entity):
@@ -229,19 +227,19 @@ class BookmarkTestCase(UITestCase):
     def test_negative_create_bookmark_no_name(self):
         """Create a bookmark with empty name
 
-        @id: ebb64459-a865-4029-bc7e-93e8d13dd877
+        :id: ebb64459-a865-4029-bc7e-93e8d13dd877
 
-        @Steps:
+        :Steps:
 
-        1. Navigate to the entity page
-        2. Choose "bookmark this search" from the search drop-down menu
-        3. Input empty string for name
-        4. Enter random text into Query field
-        5. Click the create button
-        6. List the bookmarks (Navigate to Administer -> Bookmarks)
+            1. Navigate to the entity page
+            2. Choose "bookmark this search" from the search drop-down menu
+            3. Input empty string for name
+            4. Enter random text into Query field
+            5. Click the create button
+            6. List the bookmarks (Navigate to Administer -> Bookmarks)
 
-        @Assert: Error notification - name cannot be empty, Bookmark is not
-        created (not listed)
+        :Assert: Error notification - name cannot be empty, Bookmark is not
+            created (not listed)
         """
         for entity in self.getOneEntity():
             with self.subTest(entity):
@@ -265,19 +263,19 @@ class BookmarkTestCase(UITestCase):
     def test_negative_create_bookmark_no_query(self):
         """Create a bookmark with empty query
 
-        @id: 2c22ba18-a465-4977-8013-9336d1f648e8
+        :id: 2c22ba18-a465-4977-8013-9336d1f648e8
 
-        @Steps:
+        :Steps:
 
-        1. Navigate to the entity page
-        2. Choose "bookmark this search" from the search drop-down menu
-        3. Enter random text into name field
-        4. Input empty string for search query
-        5. Click the create button
-        6. List the bookmarks (Navigate to Administer -> Bookmarks)
+            1. Navigate to the entity page
+            2. Choose "bookmark this search" from the search drop-down menu
+            3. Enter random text into name field
+            4. Input empty string for search query
+            5. Click the create button
+            6. List the bookmarks (Navigate to Administer -> Bookmarks)
 
-        @Assert: Error notification - search query cannot be empty, Bookmark is
-        not created (not listed)
+        :Assert: Error notification - search query cannot be empty, Bookmark is
+            not created (not listed)
         """
         for entity in self.getOneEntity():
             with self.subTest(entity):
@@ -296,23 +294,21 @@ class BookmarkTestCase(UITestCase):
     def test_negative_create_bookmark_same_name(self):
         """Create bookmarks with the same names
 
-        @id: 210c36b2-29bd-40d9-b120-16a1a031b20c
+        :id: 210c36b2-29bd-40d9-b120-16a1a031b20c
 
-        @Setup:
+        :Setup: Create a bookmark of a random name
 
-        1. Create a bookmark of a random name
+        :Steps:
 
-        @Steps:
+            1. Navigate to the entity page
+            2. Choose "bookmark this search" from the search drop-down menu
+            3. Input the same name as the pre-created bm
+            4. Enter random text into Query field
+            5. Click the create button
+            6. List the bookmarks (Navigate to Administer -> Bookmarks)
 
-        1. Navigate to the entity page
-        2. Choose "bookmark this search" from the search drop-down menu
-        3. Input the same name as the pre-created bm
-        4. Enter random text into Query field
-        5. Click the create button
-        6. List the bookmarks (Navigate to Administer -> Bookmarks)
-
-        @Assert: Error notification - name already taken, Bookmark is not
-        created (not listed)
+        :Assert: Error notification - name already taken, Bookmark is not
+            created (not listed)
         """
         for entity in self.getOneEntity():
             with self.subTest(entity):
@@ -336,22 +332,20 @@ class BookmarkTestCase(UITestCase):
     def test_positive_update_bookmark_name(self):
         """Update and save a bookmark
 
-        @id: 095ba7c5-82bd-4ed3-ae6d-f6ba0ad7480c
+        :id: 095ba7c5-82bd-4ed3-ae6d-f6ba0ad7480c
 
-        @Setup:
+        :Setup: Create a bookmark of a random name with random query
 
-        1. Create a bookmark of a random name with random query
+        :Steps:
 
-        @Steps:
+            1. List the bookmarks (Navigate to Administer -> Bookmarks)
+            2. Click the pre-created bookmark
+            3. Edit the name
+            4. Submit
+            5. Navigate to the entity page
+            6. Click the search dropdown
 
-        1. List the bookmarks (Navigate to Administer -> Bookmarks)
-        2. Click the pre-created bookmark
-        3. Edit the name
-        4. Submit
-        5. Navigate to the entity page
-        6. Click the search dropdown
-
-        @Assert: The new bookmark name is listed
+        :Assert: The new bookmark name is listed
         """
         for entity in self.getOneEntity():
             with self.subTest(entity):
@@ -374,20 +368,18 @@ class BookmarkTestCase(UITestCase):
     def test_negative_update_bookmark_name(self):
         """Update and save a bookmark with name already taken
 
-        @id: 3e74cf60-2863-4ca3-9440-7081547f3c4f
+        :id: 3e74cf60-2863-4ca3-9440-7081547f3c4f
 
-        @Setup:
+        :Setup: Create 2 bookmarks of random names with random query
 
-        1. Create 2 bookmarks of random names with random query
+        :Steps:
 
-        @Steps:
+            1. List the bookmarks (Navigate to Administer -> Bookmarks)
+            2. Select the first pre-created bookmark
+            3. Edit the name to one of the other pre-created bookmarks
+            4. Submit
 
-        1. List the bookmarks (Navigate to Administer -> Bookmarks)
-        2. Select the first pre-created bookmark
-        3. Edit the name to one of the other pre-created bookmarks
-        4. Submit
-
-        @Assert: Error - name already taken, bookmark not updated
+        :Assert: Error - name already taken, bookmark not updated
         """
         for entity in self.getOneEntity():
             with self.subTest(entity):
@@ -416,22 +408,20 @@ class BookmarkTestCase(UITestCase):
     def test_negative_update_bookmark_name_empty(self):
         """Update and save a bookmark with an empty name
 
-        @id: 7d7f713d-e377-446e-a9e9-06364bcc25c0
+        :id: 7d7f713d-e377-446e-a9e9-06364bcc25c0
 
-        @Setup:
+        :Setup: Create a bookmark of a random name with random query
 
-        1. Create a bookmark of a random name with random query
+        :Steps:
 
-        @Steps:
+            1. List the bookmarks (Navigate to Administer -> Bookmarks)
+            2. Click the pre-created bookmark
+            3. Delete the name
+            4. Submit
+            5. Navigate to the entity page
+            6. Click the search dropdown
 
-        1. List the bookmarks (Navigate to Administer -> Bookmarks)
-        2. Click the pre-created bookmark
-        3. Delete the name
-        4. Submit
-        5. Navigate to the entity page
-        6. Click the search dropdown
-
-        @Assert: Error - name cannot be empty, bookmark not updated
+        :Assert: Error - name cannot be empty, bookmark not updated
         """
         for entity in self.getOneEntity():
             with self.subTest(entity):
@@ -456,22 +446,20 @@ class BookmarkTestCase(UITestCase):
     def test_positive_update_bookmark_query(self):
         """Update and save a bookmark query
 
-        @id: 19c994f0-2567-47bb-8486-bc441602bc7a
+        :id: 19c994f0-2567-47bb-8486-bc441602bc7a
 
-        @Setup:
+        :Setup: Create a bookmark of a random name with random query
 
-        1. Create a bookmark of a random name with random query
+        :Steps:
 
-        @Steps:
+            1. List the bookmarks (Navigate to Administer -> Bookmarks)
+            2. Click the pre-created bookmark
+            3. Edit the Search query field
+            4. Submit
+            5. Navigate to the entity page
+            6. Select the updated bookmark from the query
 
-        1. List the bookmarks (Navigate to Administer -> Bookmarks)
-        2. Click the pre-created bookmark
-        3. Edit the Search query field
-        4. Submit
-        5. Navigate to the entity page
-        6. Select the updated bookmark from the query
-
-        @Assert: The updated query is populated and submitted
+        :Assert: The updated query is populated and submitted
         """
         for entity in self.getOneEntity():
             with self.subTest(entity):
@@ -496,22 +484,20 @@ class BookmarkTestCase(UITestCase):
     def test_negative_update_bookmark_query_empty(self):
         """Update and save a bookmark with an empty query
 
-        @id: 516b314b-7712-455a-b1d4-d09730acbec9
+        :id: 516b314b-7712-455a-b1d4-d09730acbec9
 
-        @Setup:
+        :Setup: Create a bookmark of a random name with random query
 
-        1. Create a bookmark of a random name with random query
+        :Steps:
 
-        @Steps:
+            1. List the bookmarks (Navigate to Administer -> Bookmarks)
+            2. Click the pre-created bookmark
+            3. Delete the search query
+            4. Submit
+            5. Navigate to the entity page
+            6. Click the search dropdown
 
-        1. List the bookmarks (Navigate to Administer -> Bookmarks)
-        2. Click the pre-created bookmark
-        3. Delete the search query
-        4. Submit
-        5. Navigate to the entity page
-        6. Click the search dropdown
-
-        @Assert: Error - search query cannot be empty, bookmark not updated
+        :Assert: Error - search query cannot be empty, bookmark not updated
         """
         for entity in self.getOneEntity():
             with self.subTest(entity):
@@ -537,41 +523,40 @@ class BookmarkTestCase(UITestCase):
     def test_positive_update_bookmark_public(self):
         """Update and save a bookmark public state
 
-        @id: 63646c41-5441-4547-a4d0-744286122405
+        :id: 63646c41-5441-4547-a4d0-744286122405
 
-        @Setup:
+        :Setup:
 
-        1. Create 2 bookmarks of a random name with random query, one public
-        and one private
-        2. Create a non-admin user with 'viewer' role
+            1. Create 2 bookmarks of a random name with random query, one
+               public and one private
+            2. Create a non-admin user with 'viewer' role
 
-        @Steps:
+        :Steps:
 
-        1. Login to Satellite server (establish a UI session) as
-        the pre-created user
-        2. Navigate to the entity
-        3. List the bookmarks by clicking the drop down menu
-        4. Verify that only the public bookmark is listed
-        5. Log out
-        6. Login to Satellite server (establish a UI session) as the admin
-        user
-        7. List the bookmarks (Navigate to Administer -> Bookmarks)
-        8. Click the public pre-created bookmark
-        9. Uncheck 'public'
-        10. Submit
-        11. Click the private pre-created bookmark
-        12. Check 'public'
-        13. Submit
-        14. Logout
-        15. Login to Satellite server (establish a UI session) as the
-        pre-created user
-        16. Navigate to the entity
-        17. List the bookmarks by clicking the drop down menu
+            1. Login to Satellite server (establish a UI session) as the
+               pre-created user
+            2. Navigate to the entity
+            3. List the bookmarks by clicking the drop down menu
+            4. Verify that only the public bookmark is listed
+            5. Log out
+            6. Login to Satellite server (establish a UI session) as the admin
+               user
+            7. List the bookmarks (Navigate to Administer -> Bookmarks)
+            8. Click the public pre-created bookmark
+            9. Uncheck 'public'
+            10. Submit
+            11. Click the private pre-created bookmark
+            12. Check 'public'
+            13. Submit
+            14. Logout
+            15. Login to Satellite server (establish a UI session) as the
+                pre-created user
+            16. Navigate to the entity
+            17. List the bookmarks by clicking the drop down menu
 
-        @Assert: New public bookmark is listed, and the private
-        one is hidden
+        :Assert: New public bookmark is listed, and the private one is hidden
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         with Session(self.browser):
             bm1_name = gen_string(random.choice(STRING_TYPES))
@@ -613,19 +598,17 @@ class BookmarkTestCase(UITestCase):
     def test_positive_delete_bookmark(self):
         """Simple removal of a bookmark query
 
-        @id: 46c7cf47-7e86-4d81-ba07-4c2405801552
+        :id: 46c7cf47-7e86-4d81-ba07-4c2405801552
 
-        @Setup:
+        :Setup: Create a bookmark of a random name with random query
 
-        1. Create a bookmark of a random name with random query
+        :Steps:
 
-        @Steps:
+            1. List the bookmarks (Navigate to Administer -> Bookmarks)
+            2. Click Delete next to a pre-created bookmark
+            3. Verify the bookmark is no longer listed
 
-        1. List the bookmarks (Navigate to Administer -> Bookmarks)
-        2. Click Delete next to a pre-created bookmark
-        3. Verify the bookmark is no longer listed
-
-        @Assert: The bookmark is deleted
+        :Assert: The bookmark is deleted
         """
         for entity in self.entities:
             with self.subTest(entity):
@@ -645,22 +628,23 @@ class BookmarkTestCase(UITestCase):
     def test_negative_delete_bookmark(self):
         """Simple removal of a bookmark query without permissions
 
-        @id: 1a94bf2b-bcc6-4663-b70d-e13244a0783b
+        :id: 1a94bf2b-bcc6-4663-b70d-e13244a0783b
 
-        @Setup:
+        :Setup:
 
-        1. Create a bookmark of a random name with random query
-        2. Create a non-admin user without destroy_bookmark role (e.g. viewer)
+            1. Create a bookmark of a random name with random query
+            2. Create a non-admin user without destroy_bookmark role (e.g.
+               viewer)
 
-        @Steps:
+        :Steps:
 
-        1. Login to Satellite server (establish a UI session) as a non-admin
-        user
-        2. List the bookmarks (Navigate to Administer -> Bookmarks)
+            1. Login to Satellite server (establish a UI session) as a
+               non-admin user
+            2. List the bookmarks (Navigate to Administer -> Bookmarks)
 
-        @Assert: The delete buttons are not displayed
+        :Assert: The delete buttons are not displayed
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         bm = entities.Bookmark(
             controller=self.getOneEntity()[0]['controller'],

--- a/tests/foreman/ui/test_capsule.py
+++ b/tests/foreman/ui/test_capsule.py
@@ -1,19 +1,19 @@
 # -*- encoding: utf-8 -*-
 """Test class for UI functions against an isolated capsule
 
-@Requirement: Capsule
+:Requirement: Capsule
 
-@CaseAutomation: Automated
+:CaseAutomation: Automated
 
-@CaseLevel: Acceptance
+:CaseLevel: Acceptance
 
-@CaseComponent: UI
+:CaseComponent: UI
 
-@TestType: Functional
+:TestType: Functional
 
-@CaseImportance: High
+:CaseImportance: High
 
-@Upstream: No
+:Upstream: No
 """
 
 from robottelo.decorators import run_only_on, stubbed, tier1, tier3, tier4
@@ -29,21 +29,18 @@ class CapsuleTestCase(UITestCase):
         """User can push errata through to a client on
         an isolated capsule
 
-        @id: f714692d-534b-48e8-b052-c93241f86615
+        :id: f714692d-534b-48e8-b052-c93241f86615
 
-        @Setup: Client on an isolated capsule; errata synced
-        on server
+        :Setup: Client on an isolated capsule; errata synced on server
 
-        @Steps:
+        :Steps: Attempt to install errata via Sat UI against client on an
+            isolated capsule - this is a satellite-initiated action.
 
-        1. Attempt to install errata via Sat UI against client on an
-        isolated capsule - this is a satellite-initiated action.
+        :Assert: Errata can be installed.
 
-        @Assert: Errata can be installed.
+        :caseautomation: notautomated
 
-        @caseautomation: notautomated
-
-        @CaseLevel: System
+        :CaseLevel: System
         """
 
     @stubbed()
@@ -52,21 +49,18 @@ class CapsuleTestCase(UITestCase):
         """User can install a new errata on a client through
         an isolated capsule - this is a satellite-initiated action
 
-        @id: 682c8c57-461f-46ce-ae7a-9f4da6e09f1b
+        :id: 682c8c57-461f-46ce-ae7a-9f4da6e09f1b
 
-        @Setup: Client on an isolated capsule; rpms synced (RH,
-        custom content)
+        :Setup: Client on an isolated capsule; rpms synced (RH, custom content)
 
-        @Steps:
+        :Steps: attempt to push an RPM install onto client connected to
+            isolated capsule - this is a satellite-initiated action.
 
-        1. attempt to push an RPM install onto client connected to
-        isolated capsule - this is a satellite-initiated action.
+        :Assert: Package is installed
 
-        @Assert: Package is installed
+        :caseautomation: notautomated
 
-        @caseautomation: notautomated
-
-        @CaseLevel: System
+        :CaseLevel: System
         """
 
     @stubbed()
@@ -75,20 +69,18 @@ class CapsuleTestCase(UITestCase):
         """user can install new puppet module on a client
         through an isolated capsule
 
-        @id: 34582de2-7dd4-472c-89ce-14224750eb21
+        :id: 34582de2-7dd4-472c-89ce-14224750eb21
 
-        @Setup: Client on an isolated capsule; puppet content synced
+        :Setup: Client on an isolated capsule; puppet content synced
 
-        @Steps:
+        :Steps: attempt to push a puppet module install initiated from
+            Satellite
 
-        1. attempt to push a puppet module install initiated from
-        Satellite
+        :Assert: module is installed
 
-        @Assert: module is installed
+        :caseautomation: notautomated
 
-        @caseautomation: notautomated
-
-        @CaseLevel: System
+        :CaseLevel: System
         """
 
     @stubbed()
@@ -98,23 +90,21 @@ class CapsuleTestCase(UITestCase):
         the content hosts UI, any referenced capsule in order to
         learn/setup registration against said capsule(s).
 
-        @id: c9cd3c0e-78c8-4548-8103-be42de408f36
+        :id: c9cd3c0e-78c8-4548-8103-be42de408f36
 
-        @Setup: A satellite with at least one capsule configured.
+        :Setup: A satellite with at least one capsule configured.
 
-        @Steps:
+        :Steps:
+            1. Go to Hosts > Content Hosts > Register Content Host
+            2. Observe the section labeled 'Consuming Content From A Capsule'
 
-        1. Go to Hosts > Content Hosts > Register Content Host
-        2. Observe the section labeled 'Consuming Content From
-           A Capsule'
+        :Assert: capsule(s) appear in dropdown and the instructions for using
+            subscription-manager update accordingly when choosing said
+            capsule(s).
 
-        @Assert: capsule(s) appear in dropdown and the instructions
-        for using subscription-manager update accordingly when
-        choosing said capsule(s).
+        :caseautomation: notautomated
 
-        @caseautomation: notautomated
-
-        @CaseLevel: System
+        :CaseLevel: System
         """
 
     @run_only_on('sat')
@@ -123,16 +113,15 @@ class CapsuleTestCase(UITestCase):
     def test_positive_capsule_version(self):
         """Check Capsule Version in About Page.
 
-        @id: 24a6e423-9550-453a-a953-9350ff5a57bc
+        :id: 24a6e423-9550-453a-a953-9350ff5a57bc
 
-        @Steps:
+        :Steps:
+            1. Navigate to the About Page
+            2. Check the versions column of the Capsules.
 
-        1. Navigate to the About Page
-        2. Check the versions column of the Capsules.
+        :Assert: The version of the Capsules exists in the about page.
 
-        @Assert: The version of the Capsules exists in the about page.
-
-        @caseautomation: notautomated
+        :caseautomation: notautomated
         """
 
     @run_only_on('sat')
@@ -141,17 +130,15 @@ class CapsuleTestCase(UITestCase):
     def test_positive_capsule_status(self):
         """Check Capsule Status in Index Page.
 
-        @id: ec084b9f-ccb4-4657-8d5b-903156658703
+        :id: ec084b9f-ccb4-4657-8d5b-903156658703
 
-        @Steps:
+        :Steps:
+            1. Navigate to the Capsules Index Page
+            2. Check the status of the Proxy.
 
-        1. Navigate to the Capsules Index Page
-        2. Check the status of the Proxy.
+        :Assert: The status of the Capsules is up and running.
 
-        @Assert: The status of the Capsules
-        is up and running.
-
-        @caseautomation: notautomated
+        :caseautomation: notautomated
         """
 
     @run_only_on('sat')
@@ -160,17 +147,16 @@ class CapsuleTestCase(UITestCase):
     def test_positive_capsule_context(self):
         """Check Capsule has Location and Organization column in Index Page.
 
-        @id: 330da7b9-6f52-4dc0-a824-d7f3af964b7f
+        :id: 330da7b9-6f52-4dc0-a824-d7f3af964b7f
 
-        @Steps:
+        :Steps:
+            1. Navigate to the Capsules Index Page
+            2. Check the capsule's columns in the Index Page.
 
-        1. Navigate to the Capsules Index Page
-        2. Check the capsule's columns in the Index Page.
+        :Assert: The Capsules Organization and Location info is visible on the
+            index page.
 
-        @Assert: The Capsules Organization and Location
-        info is visible on the index page.
-
-        @caseautomation: notautomated
+        :caseautomation: notautomated
         """
 
     @run_only_on('sat')
@@ -179,17 +165,16 @@ class CapsuleTestCase(UITestCase):
     def test_positive_capsule_url(self):
         """Check Capsule no longer has 'Foreman URL' column in Index page.
 
-        @id: c5f7c1f9-d887-4600-b7d2-902039ffed65
+        :id: c5f7c1f9-d887-4600-b7d2-902039ffed65
 
-        @Steps:
+        :Steps:
+            1. Navigate to the Capsules Index Page
+            2. Check the capsule's columns in the Index Page.
 
-        1. Navigate to the Capsules Index Page
-        2. Check the capsule's columns in the Index Page.
+        :Assert: The Capsules no longer have the 'Foreman URL' on the index
+            page.
 
-        @Assert: The Capsules no longer have the
-        'Foreman URL' on the index page.
-
-        @caseautomation: notautomated
+        :caseautomation: notautomated
         """
 
     @run_only_on('sat')
@@ -199,18 +184,16 @@ class CapsuleTestCase(UITestCase):
         """Check Capsule has pulp_storage Used and Free
         info in the Overview tab of the Capsules show Page.
 
-        @id: 0bce3dbb-8444-4f37-a4c4-ab565927be39
+        :id: 0bce3dbb-8444-4f37-a4c4-ab565927be39
 
-        @Steps:
+        :Steps:
+            1. Navigate to the Capsules Show Page
+            2. Check the capsule's overview tab in the show Page.
 
-        1. Navigate to the Capsules Show Page
-        2. Check the capsule's overview tab in the show Page.
+        :Assert: The 'Pulp Storage' used and free info is visible for the
+            default capsule in the Overview Tab.
 
-        @Assert: The 'Pulp Storage' used and free info
-        is visible for the default capsule in the
-        Overview Tab.
-
-        @caseautomation: notautomated
+        :caseautomation: notautomated
         """
 
     @run_only_on('sat')
@@ -220,19 +203,18 @@ class CapsuleTestCase(UITestCase):
         """Check for Sync button and Syncing for Isolated Capsule in Overview
         tab.
 
-        @id: 6c68984a-1246-4868-bc52-6291e9df9b89
+        :id: 6c68984a-1246-4868-bc52-6291e9df9b89
 
-        @Steps:
+        :Steps:
+            1. Navigate to the Capsules Show Page
+            2. Check the capsule's overview tab in the show Page.
 
-        1. Navigate to the Capsules Show Page
-        2. Check the capsule's overview tab in the show Page.
+        :Assert: The 'Content Sync' button is visible and sync works for the
+            isolated capsule.
 
-        @Assert: The 'Content Sync' button is visible
-        and sync works for the isolated capsule.
+        :caseautomation: notautomated
 
-        @caseautomation: notautomated
-
-        @CaseLevel: System
+        :CaseLevel: System
         """
 
     @run_only_on('sat')
@@ -242,19 +224,18 @@ class CapsuleTestCase(UITestCase):
         """Check for Cancel Sync button and whether sync cancels
         for Isolated Capsule in the Overview tab.
 
-        @id: 8f44dadd-00f0-4921-98bc-02dd860bc4fb
+        :id: 8f44dadd-00f0-4921-98bc-02dd860bc4fb
 
-        @Steps:
+        :Steps:
+            1. Navigate to the Capsules Show Page
+            2. Check the capsule's overview tab in the show Page.
 
-        1. Navigate to the Capsules Show Page
-        2. Check the capsule's overview tab in the show Page.
+        :Assert: The 'Cancel Sync" button is visible and sync cancels for the
+            isolated capsule.
 
-        @Assert: The 'Cancel Sync" button is visible
-        and sync cancels for the isolated capsule.
+        :caseautomation: notautomated
 
-        @caseautomation: notautomated
-
-        @CaseLevel: System
+        :CaseLevel: System
         """
 
     @run_only_on('sat')
@@ -263,19 +244,17 @@ class CapsuleTestCase(UITestCase):
     def test_positive_capsule_details(self):
         """Check for details of Capsule in the Overview tab.
 
-        @id: 4c012dc0-4ce3-4f88-b05c-67faa5ad16e4
+        :id: 4c012dc0-4ce3-4f88-b05c-67faa5ad16e4
 
-        @Steps:
+        :Steps:
+            1. Navigate to the Capsules Show Page
+            2. Check the capsule's overview tab in the show Page.
 
-        1. Navigate to the Capsules Show Page
-        2. Check the capsule's overview tab in the show Page.
+        :Assert: The Overview tab displays these information 'Status',
+            'Verison', 'Uptime', 'Registration Date', 'Packages', 'Location',
+            'Puppet', 'Storage' info is displayed.
 
-        @Assert: The Overview tab displays these
-        information 'Status', 'Verison', 'Uptime',
-        'Registration Date', 'Packages', 'Location',
-        'Puppet', 'Storage' info is displayed.
-
-        @caseautomation: notautomated
+        :caseautomation: notautomated
         """
 
     @run_only_on('sat')
@@ -284,21 +263,20 @@ class CapsuleTestCase(UITestCase):
     def test_positive_capsule_environment(self):
         """Check for environment info of Capsule in the Puppet tab.
 
-        @id: 2b1448c1-e566-49fa-a4dc-3136702fd74f
+        :id: 2b1448c1-e566-49fa-a4dc-3136702fd74f
 
-        @Steps:
+        :Steps:
+            1. Create a CV and add a puppet module to it.
+            2. Publish the CV
+            3. Navigate to the Capsules Show Page
+            4. Check the capsule's Puppet tab in the show Page.
+            5. Now check the Enviroments Tab.
 
-        1. Create a CV and add a puppet module to it.
-        2. Publish the CV
-        3. Navigate to the Capsules Show Page
-        4. Check the capsule's Puppet tab in the show Page.
-        5. Now check the Enviroments Tab.
+        :Assert: The puppet environment which got created after adding the
+            puppet-module to CV, exists in the Environment column of the Puppet
+            Tab.
 
-        @Assert: The puppet environment which got created
-        after adding the puppet-module to CV, exists in the
-        Environment column of the Puppet Tab.
-
-        @caseautomation: notautomated
+        :caseautomation: notautomated
         """
 
     @run_only_on('sat')
@@ -307,20 +285,19 @@ class CapsuleTestCase(UITestCase):
     def test_positive_capsule_puppet_classes_count(self):
         """Check for Puppet Classes count info of Capsule in Puppet tab.
 
-        @id: 2e657b25-d777-4907-b0a9-19262a0a4e0b
+        :id: 2e657b25-d777-4907-b0a9-19262a0a4e0b
 
-        @Steps:
+        :Steps:
+            1. Create a CV and add a puppet module to it.
+            2. Publish the CV and import the classes to puppet-env.
+            3. Navigate to the Capsules Show Page
+            4. Check the capsule's Puppet tab in the show Page.
+            5. Now check the Enviroments Tab.
 
-        1. Create a CV and add a puppet module to it.
-        2. Publish the CV and import the classes to puppet-env.
-        3. Navigate to the Capsules Show Page
-        4. Check the capsule's Puppet tab in the show Page.
-        5. Now check the Enviroments Tab.
-
-        @Assert: The puppet-classes count is visible in the
+        :Assert: The puppet-classes count is visible in the
         'Number of classes' column.
 
-        @caseautomation: notautomated
+        :caseautomation: notautomated
         """
 
     @run_only_on('sat')
@@ -329,22 +306,21 @@ class CapsuleTestCase(UITestCase):
     def test_positive_capsule_puppet_hosts_managed_count(self):
         """Check Puppet 'Hosts managed' count info of Capsule in Puppet tab.
 
-        @id: 147e6472-3459-41e1-94fe-39f4db25a4de
+        :id: 147e6472-3459-41e1-94fe-39f4db25a4de
 
-        @Steps:
+        :Steps:
+            1. Get any host configured to consume Puppet.
+            2. Publish the CV and import the classes to puppet-env.
+            3. Navigate to the Capsules Show Page
+            4. Check the capsule's Puppet tab in the show Page.
+            5. Now check the General Tab.
 
-        1. Get any host configured to consume Puppet.
-        2. Publish the CV and import the classes to puppet-env.
-        3. Navigate to the Capsules Show Page
-        4. Check the capsule's Puppet tab in the show Page.
-        5. Now check the General Tab.
+        :Assert: The Puppet Hosts managed count is visible in the 'Number of
+            classes' column.
 
-        @Assert: The Puppet Hosts managed count is visible in the
-        'Number of classes' column.
+        :caseautomation: notautomated
 
-        @caseautomation: notautomated
-
-        @CaseLevel: System
+        :CaseLevel: System
         """
 
     @run_only_on('sat')
@@ -354,22 +330,20 @@ class CapsuleTestCase(UITestCase):
         """Check for Puppet 'Hosts managed' count info of Capsule
         in the Puppet-ca tab.
 
-        @id: 0af8acb3-3765-4cc8-8100-c62dda30513f
+        :id: 0af8acb3-3765-4cc8-8100-c62dda30513f
 
-        @Steps:
+        :Steps:
+            1. Get any host configured to consume Puppet.
+            2. Publish the CV and import the classes to puppet-env.
+            3. Navigate to the Capsules Show Page
+            4. Check the capsule's Puppet-ca tab in the show Page.
+            5. Now check the General Tab.
 
-        1. Get any host configured to consume Puppet.
-        2. Publish the CV and import the classes to puppet-env.
-        3. Navigate to the Capsules Show Page
-        4. Check the capsule's Puppet-ca tab in the show Page.
-        5. Now check the General Tab.
+        :Assert: The Puppet 'Hosts managed' count properly is visible.
 
-        @Assert: The Puppet 'Hosts managed' count properly
-        is visible.
+        :caseautomation: notautomated
 
-        @caseautomation: notautomated
-
-        @CaseLevel: System
+        :CaseLevel: System
         """
 
     @run_only_on('sat')
@@ -378,21 +352,19 @@ class CapsuleTestCase(UITestCase):
     def test_positive_capsule_puppetca_certificate_name(self):
         """Check for Hosts certifcate-name is visible in Puppet-ca tab.
 
-        @id: 7b3da902-f602-46c8-aa98-036125127752
+        :id: 7b3da902-f602-46c8-aa98-036125127752
 
-        @Steps:
+        :Steps:
+            1. Get any host configured to consume Puppet.
+            2. Navigate to the Capsules Show Page
+            3. Check the capsule's Puppet-ca tab in the show Page.
+            4. Now check the General Tab.
 
-        1. Get any host configured to consume Puppet.
-        2. Navigate to the Capsules Show Page
-        3. Check the capsule's Puppet-ca tab in the show Page.
-        4. Now check the General Tab.
+        :Assert: The Hosts certificate-name is visible in the Puppet-ca Tab.
 
-        @Assert: The Hosts certificate-name is visible in the
-        Puppet-ca Tab.
+        :caseautomation: notautomated
 
-        @caseautomation: notautomated
-
-        @CaseLevel: System
+        :CaseLevel: System
         """
 
     @run_only_on('sat')
@@ -401,23 +373,22 @@ class CapsuleTestCase(UITestCase):
     def test_positive_capsule_puppetca_certificate_revoked(self):
         """Check for Hosts puppet certifcate can be revoked in Puppet-ca tab.
 
-        @id: 6ce6f088-1542-4df2-9004-eaaf53b1ccc1
+        :id: 6ce6f088-1542-4df2-9004-eaaf53b1ccc1
 
-        @Steps:
+        :Steps:
+            1. Get any host configured to consume Puppet.
+            2. Navigate to the Capsules Show Page
+            3. Check the capsule's Puppet-ca tab in the show Page.
+            4. Now check the Certificates Tab.
+            5. Click the revoke button of the corresponding host.
+            6. Puppet runs should now not be possible on the hosts.
 
-        1. Get any host configured to consume Puppet.
-        2. Navigate to the Capsules Show Page
-        3. Check the capsule's Puppet-ca tab in the show Page.
-        4. Now check the Certificates Tab.
-        5. Click the revoke button of the corresponding host.
-        6. Puppet runs should now not be possible on the hosts.
+        :Assert: The puppet runs on hosts are possible after the certs are
+            revoked for the host.
 
-        @Assert: The puppet runs on hosts are possible
-        after the certs are revoked for the host.
+        :caseautomation: notautomated
 
-        @caseautomation: notautomated
-
-        @CaseLevel: System
+        :CaseLevel: System
         """
 
     @run_only_on('sat')
@@ -427,24 +398,23 @@ class CapsuleTestCase(UITestCase):
         """Check for Hosts puppet certifcate can be auto-signed in Puppet-ca
         tab.
 
-        @id: d88d6b8f-d6f1-4785-a949-84a65953e525
+        :id: d88d6b8f-d6f1-4785-a949-84a65953e525
 
-        @Steps:
+        :Steps:
+            1. Get any host configured to consume Puppet.
+            2. Navigate to the Capsules Show Page
+            3. Check the capsule's Puppet-ca tab in the show Page.
+            4. Now check the 'autosign entries' Tab.
+            5. Click the new button to add a host entry.
+            6. Puppet run should now be possible on the host, without
+            having to manually sign the certificate.
 
-        1. Get any host configured to consume Puppet.
-        2. Navigate to the Capsules Show Page
-        3. Check the capsule's Puppet-ca tab in the show Page.
-        4. Now check the 'autosign entries' Tab.
-        5. Click the new button to add a host entry.
-        6. Puppet run should now be possible on the host, without
-           having to manually sign the certificate.
+        :Assert: The puppet run on host is possible without having to sign the
+            certs manually for the host.
 
-        @Assert: The puppet run on host is possible
-        without having to sign the certs manually for the host.
+        :caseautomation: notautomated
 
-        @caseautomation: notautomated
-
-        @CaseLevel: System
+        :CaseLevel: System
         """
 
     @stubbed()
@@ -452,15 +422,13 @@ class CapsuleTestCase(UITestCase):
     def test_dns_and_dhcp_enabled_on_capsule(self):
         """Check DNS ana DHCP is enabled on capsule
 
-        @id: 56778d8e-79be-11e6-886c-68f72889dc7f
+        :id: 56778d8e-79be-11e6-886c-68f72889dc7f
 
-        @Steps:
+        :Steps: Enable DHCP and DNS infoblox plugins on capsule
 
-        1. Enable DHCP and DNS infoblox plugins on capsule
+        :Assert: DNS and DHCP must be included on capsule features
 
-        @Assert: DNS and DHCP must be included on capsule features
+        :caseautomation: notautomated
 
-        @caseautomation: notautomated
-
-        @CaseLevel: System
+        :CaseLevel: System
         """

--- a/tests/foreman/ui/test_classparameters.py
+++ b/tests/foreman/ui/test_classparameters.py
@@ -1,19 +1,19 @@
 # -*- encoding: utf-8 -*-
 """Test class for Smart/Puppet Class Parameter
 
-@Requirement: Classparameters
+:Requirement: Classparameters
 
-@CaseAutomation: Automated
+:CaseAutomation: Automated
 
-@CaseLevel: Acceptance
+:CaseLevel: Acceptance
 
-@CaseComponent: UI
+:CaseComponent: UI
 
-@TestType: Functional
+:TestType: Functional
 
-@CaseImportance: High
+:CaseImportance: High
 
-@Upstream: No
+:Upstream: No
 """
 
 from robottelo.decorators import (
@@ -35,19 +35,18 @@ class SmartClassParametersTestCase(UITestCase):
     def test_positive_override_checkbox(self):
         """Override the Default Parameter value.
 
-        @id: e798b1be-b176-48e2-887f-3f3370efef90
+        :id: e798b1be-b176-48e2-887f-3f3370efef90
 
-        @steps:
+        :steps:
+            1.  Check the Override checkbox.
+            2.  Set the new valid Default Value.
+            3.  Submit the changes.
 
-        1.  Check the Override checkbox.
-        2.  Set the new valid Default Value.
-        3.  Submit the changes.
+        :assert: Parameter Value overridden with new value.
 
-        @assert: Parameter Value overridden with new value.
+        :caseautomation: notautomated
 
-        @caseautomation: notautomated
-
-        @CaseLevel: System
+        :CaseLevel: System
         """
 
     @run_only_on('sat')
@@ -56,19 +55,18 @@ class SmartClassParametersTestCase(UITestCase):
     def test_negative_override_checkbox(self):
         """Override the Default Parameter value - override Unchecked.
 
-        @id: 3002d976-7c34-4da0-9b43-db28441d94de
+        :id: 3002d976-7c34-4da0-9b43-db28441d94de
 
-        @steps:
+        :steps:
+            1.  Don't check the Override checkbox.
+            2.  Set the new valid Default Value.
+            3.  Attempt to submit the changes.
 
-        1.  Don't check the Override checkbox.
-        2.  Set the new valid Default Value.
-        3.  Attempt to submit the changes.
+        :assert: Parameter value not allowed/disabled to override.
 
-        @assert: Parameter value not allowed/disabled to override.
+        :caseautomation: notautomated
 
-        @caseautomation: notautomated
-
-        @CaseLevel: System
+        :CaseLevel: System
         """
 
     @run_only_on('sat')
@@ -77,18 +75,16 @@ class SmartClassParametersTestCase(UITestCase):
     def test_positive_edit_parameter_dialog(self):
         """Enable Validation, merging and matcher sections.
 
-        @id: a6639110-1a58-4f68-8265-369b515f9c4a
+        :id: a6639110-1a58-4f68-8265-369b515f9c4a
 
-        @steps:
+        :steps: Check the Override checkbox.
 
-        1.  Check the Override checkbox.
+        :assert: Puppet Default, Hiding, Validation, Merging and Matcher
+            section enabled.
 
-        @assert: Puppet Default, Hiding, Validation, Merging and
-        Matcher section enabled.
+        :caseautomation: notautomated
 
-        @caseautomation: notautomated
-
-        @CaseLevel: System
+        :CaseLevel: System
         """
 
     @run_only_on('sat')
@@ -97,18 +93,16 @@ class SmartClassParametersTestCase(UITestCase):
     def test_negative_edit_parameter_dialog(self):
         """Disable Validation, merging and matcher sections.
 
-        @id: 30da3a17-05a5-4c19-8210-80c3a8dcf32b
+        :id: 30da3a17-05a5-4c19-8210-80c3a8dcf32b
 
-        @steps:
+        :steps: Dont't Check the Override checkbox.
 
-        1.  Dont't Check the Override checkbox.
+        :assert: Puppet Default, Hiding, Validation, Merging and Matcher
+            section is disabled.
 
-        @assert: Puppet Default, Hiding, Validation, Merging and
-        Matcher section is disabled.
+        :caseautomation: notautomated
 
-        @caseautomation: notautomated
-
-        @CaseLevel: System
+        :CaseLevel: System
         """
 
     @run_only_on('sat')
@@ -117,19 +111,18 @@ class SmartClassParametersTestCase(UITestCase):
     def test_positive_puppet_default(self):
         """On Override, Set Puppet Default Value.
 
-        @id: 49b68cd4-8a4b-4980-b3f0-40678f687fd7
+        :id: 49b68cd4-8a4b-4980-b3f0-40678f687fd7
 
-        @steps:
+        :steps:
+            1.  Check the Override checkbox.
+            2.  Check 'Use Puppet Default' checkbox.
+            3.  Submit the changes.
 
-        1.  Check the Override checkbox.
-        2.  Check 'Use Puppet Default' checkbox.
-        3.  Submit the changes.
+        :assert: Puppet Default Value applied on parameter.
 
-        @assert: Puppet Default Value applied on parameter.
+        :caseautomation: notautomated
 
-        @caseautomation: notautomated
-
-        @CaseLevel: System
+        :CaseLevel: System
         """
 
     @run_only_on('sat')
@@ -140,18 +133,17 @@ class SmartClassParametersTestCase(UITestCase):
 
         Types - string, boolean, integer, real, array, hash, yaml, json
 
-        @id: 5157c174-54f2-422f-8028-89604267c8e8
+        :id: 5157c174-54f2-422f-8028-89604267c8e8
 
-        @steps:
+        :steps:
+            1.  Check the Override checkbox.
+            2.  Update the Key Type.
+            3.  Enter a 'valid' default Value.
+            4.  Submit the changes.
 
-        1.  Check the Override checkbox.
-        2.  Update the Key Type.
-        3.  Enter a 'valid' default Value.
-        4.  Submit the changes.
+        :assert: Parameter Updated with a new type successfully.
 
-        @assert: Parameter Updated with a new type successfully.
-
-        @caseautomation: notautomated
+        :caseautomation: notautomated
         """
 
     @run_only_on('sat')
@@ -162,18 +154,17 @@ class SmartClassParametersTestCase(UITestCase):
 
         Types - string, boolean, integer, real, array, hash, yaml, json
 
-        @id: 4285b397-0426-4523-8cc2-8e5d79f49aae
+        :id: 4285b397-0426-4523-8cc2-8e5d79f49aae
 
-        @steps:
+        :steps:
+            1.  Check the Override checkbox.
+            2.  Update the Key Type.
+            3.  Enter an 'Invalid' default Value.
+            4.  Submit the changes.
 
-        1.  Check the Override checkbox.
-        2.  Update the Key Type.
-        3.  Enter an 'Invalid' default Value.
-        4.  Submit the changes.
+        :assert: Parameter not updated with string type for invalid value.
 
-        @assert: Parameter not updated with string type for invalid value.
-
-        @caseautomation: notautomated
+        :caseautomation: notautomated
         """
 
     @run_only_on('sat')
@@ -182,19 +173,18 @@ class SmartClassParametersTestCase(UITestCase):
     def test_positive_validate_puppet_default_value(self):
         """Validation doesn't works on puppet default value.
 
-        @id: 8671338d-5547-4259-9119-a8952b4d982d
+        :id: 8671338d-5547-4259-9119-a8952b4d982d
 
-        @steps:
+        :steps:
+            1.  Check the Override checkbox.
+            2.  Check 'Use Puppet Default' value.
+            3.  Validate this value under section 'Optional Input Validator'.
 
-        1.  Check the Override checkbox.
-        2.  Check 'Use Puppet Default' value.
-        3.  Validate this value under section 'Optional Input Validator'.
+        :assert: Validation shouldn't work with puppet default value.
 
-        @assert: Validation shouldn't work with puppet default value.
+        :caseautomation: notautomated
 
-        @caseautomation: notautomated
-
-        @CaseLevel: System
+        :CaseLevel: System
         """
 
     @run_only_on('sat')
@@ -203,20 +193,19 @@ class SmartClassParametersTestCase(UITestCase):
     def test_negative_validate_default_value_required_checkbox(self):
         """Error raised for blank default Value - Required checkbox.
 
-        @id: b665891a-15c2-4e7b-a118-f239ff45d37a
+        :id: b665891a-15c2-4e7b-a118-f239ff45d37a
 
-        @steps:
+        :steps:
+            1.  Check the Override checkbox.
+            2.  Don't provide any default value, keep blank.
+            3.  Check Required checkbox in 'Optional Input Validator'.
+            4.  Submit the change.
 
-        1.  Check the Override checkbox.
-        2.  Don't provide any default value, keep blank.
-        3.  Check Required checkbox in 'Optional Input Validator'.
-        4.  Submit the change.
+        :assert: Error raised for blank default value by 'Required' checkbox.
 
-        @assert: Error raised for blank default value by 'Required' checkbox.
+        :caseautomation: notautomated
 
-        @caseautomation: notautomated
-
-        @CaseLevel: System
+        :CaseLevel: System
         """
 
     @run_only_on('sat')
@@ -225,20 +214,19 @@ class SmartClassParametersTestCase(UITestCase):
     def test_positive_validate_default_value_required_checkbox(self):
         """Error not raised for default Value - Required checkbox.
 
-        @id: a4c82c28-8bdf-4c6a-93d6-5d57145f095f
+        :id: a4c82c28-8bdf-4c6a-93d6-5d57145f095f
 
-        @steps:
+        :steps:
+            1.  Check the Override checkbox.
+            2.  Provide some default value.
+            3.  Check Required checkbox in 'Optional Input Validator'.
+            4.  Submit the change.
 
-        1.  Check the Override checkbox.
-        2.  Provide some default value.
-        3.  Check Required checkbox in 'Optional Input Validator'.
-        4.  Submit the change.
+        :assert: Error not raised default value by 'Required' checkbox.
 
-        @assert: Error not raised default value by 'Required' checkbox.
+        :caseautomation: notautomated
 
-        @caseautomation: notautomated
-
-        @CaseLevel: System
+        :CaseLevel: System
         """
 
     @run_only_on('sat')
@@ -247,21 +235,20 @@ class SmartClassParametersTestCase(UITestCase):
     def test_negative_validate_matcher_value_required_checkbox(self):
         """Error raised for blank matcher Value - Required checkbox.
 
-        @id: e88b1bc7-529a-4dbd-9e43-4738580e12ab
+        :id: e88b1bc7-529a-4dbd-9e43-4738580e12ab
 
-        @steps:
+        :steps:
+            1.  Check the Override checkbox.
+            2.  Create a matcher for Parameter for some attribute.
+            3.  Dont provide Value for matcher. Keep blank.
+            4.  Check Required checkbox in 'Optional Input Validator'.
+            5.  Submit the change.
 
-        1.  Check the Override checkbox.
-        2.  Create a matcher for Parameter for some attribute.
-        3.  Dont provide Value for matcher. Keep blank.
-        4.  Check Required checkbox in 'Optional Input Validator'.
-        5.  Submit the change.
+        :assert: Error raised for blank matcher value by 'Required' checkbox.
 
-        @assert: Error raised for blank matcher value by 'Required' checkbox.
+        :caseautomation: notautomated
 
-        @caseautomation: notautomated
-
-        @CaseLevel: System
+        :CaseLevel: System
         """
 
     @run_only_on('sat')
@@ -270,21 +257,20 @@ class SmartClassParametersTestCase(UITestCase):
     def test_positive_validate_matcher_value_required_checkbox(self):
         """Error not raised for matcher Value - Required checkbox.
 
-        @id: f91d2868-0d87-4cc5-984b-a114badd366f
+        :id: f91d2868-0d87-4cc5-984b-a114badd366f
 
-        @steps:
+        :steps:
+            1.  Check the Override checkbox.
+            2.  Create a matcher for Parameter for some attribute.
+            3.  Provide some Value for matcher.
+            4.  Check Required checkbox in 'Optional Input Validator'.
+            5.  Submit the change.
 
-        1.  Check the Override checkbox.
-        2.  Create a matcher for Parameter for some attribute.
-        3.  Provide some Value for matcher.
-        4.  Check Required checkbox in 'Optional Input Validator'.
-        5.  Submit the change.
+        :assert: Error not raised for matcher value by 'Required' checkbox.
 
-        @assert: Error not raised for matcher value by 'Required' checkbox.
+        :caseautomation: notautomated
 
-        @caseautomation: notautomated
-
-        @CaseLevel: System
+        :CaseLevel: System
         """
 
     @run_only_on('sat')
@@ -293,20 +279,19 @@ class SmartClassParametersTestCase(UITestCase):
     def test_negative_validate_default_value_with_regex(self):
         """Error raised for default value not matching with regex.
 
-        @id: 1854c189-8a5f-410c-b195-ea2a51e72b30
+        :id: 1854c189-8a5f-410c-b195-ea2a51e72b30
 
-        @steps:
+        :steps:
+            1.  Check the Override checkbox.
+            2.  Provide default value that doesn't matches the regex of step 3.
+            3.  Validate this value with regex validator type and rule.
+            4.  Submit the change.
 
-        1.  Check the Override checkbox.
-        2.  Provide default value that doesn't matches the regex of step 3.
-        3.  Validate this value with regex validator type and rule.
-        4.  Submit the change.
+        :assert: Error raised for default value not matching with regex.
 
-        @assert: Error raised for default value not matching with regex.
+        :caseautomation: notautomated
 
-        @caseautomation: notautomated
-
-        @CaseLevel: System
+        :CaseLevel: System
         """
 
     @run_only_on('sat')
@@ -315,20 +300,19 @@ class SmartClassParametersTestCase(UITestCase):
     def test_positive_validate_default_value_with_regex(self):
         """Error not raised for default value matching with regex.
 
-        @id: 81ab3074-dc22-4c60-b638-62fdfabe60fb
+        :id: 81ab3074-dc22-4c60-b638-62fdfabe60fb
 
-        @steps:
+        :steps:
+            1.  Check the Override checkbox.
+            2.  Provide default value that matches the regex of step 3..
+            3.  Validate this value with regex validator type and rule.
+            4.  Submit the change.
 
-        1.  Check the Override checkbox.
-        2.  Provide default value that matches the regex of step 3..
-        3.  Validate this value with regex validator type and rule.
-        4.  Submit the change.
+        :assert: Error not raised for default value matching with regex.
 
-        @assert: Error not raised for default value matching with regex.
+        :caseautomation: notautomated
 
-        @caseautomation: notautomated
-
-        @CaseLevel: System
+        :CaseLevel: System
         """
 
     @run_only_on('sat')
@@ -337,21 +321,20 @@ class SmartClassParametersTestCase(UITestCase):
     def test_negative_validate_matcher_value_with_regex(self):
         """Error raised for matcher value not matching with regex.
 
-        @id: 77e56e9b-ddee-41e8-bd9f-e1a43f5053b2
+        :id: 77e56e9b-ddee-41e8-bd9f-e1a43f5053b2
 
-        @steps:
+        :steps:
+            1.  Check the Override checkbox.
+            2.  Create a matcher with value that doesn't matches the regex of
+                step 3.
+            3.  Validate this value with regex validator type and rule.
+            4.  Submit the change.
 
-        1.  Check the Override checkbox.
-        2.  Create a matcher with value that doesn't matches
-            the regex of step 3.
-        3.  Validate this value with regex validator type and rule.
-        4.  Submit the change.
+        :assert: Error raised for matcher value not matching with regex.
 
-        @assert: Error raised for matcher value not matching with regex.
+        :caseautomation: notautomated
 
-        @caseautomation: notautomated
-
-        @CaseLevel: System
+        :CaseLevel: System
         """
 
     @run_only_on('sat')
@@ -360,20 +343,19 @@ class SmartClassParametersTestCase(UITestCase):
     def test_positive_validate_matcher_value_with_regex(self):
         """Error not raised for matcher value matching with regex.
 
-        @id: e642fcb1-f1dc-4263-adf1-8f881ce06f68
+        :id: e642fcb1-f1dc-4263-adf1-8f881ce06f68
 
-        @steps:
+        :steps:
+            1.  Check the Override checkbox.
+            2.  Create a matcher with value that matches the regex of step 3.
+            3.  Validate this value with regex validator type and rule.
+            4.  Submit the change.
 
-        1.  Check the Override checkbox.
-        2.  Create a matcher with value that matches the regex of step 3.
-        3.  Validate this value with regex validator type and rule.
-        4.  Submit the change.
+        :assert: Error not raised for matcher value matching with regex.
 
-        @assert: Error not raised for matcher value matching with regex.
+        :caseautomation: notautomated
 
-        @caseautomation: notautomated
-
-        @CaseLevel: System
+        :CaseLevel: System
         """
 
     @run_only_on('sat')
@@ -382,20 +364,19 @@ class SmartClassParametersTestCase(UITestCase):
     def test_negative_validate_default_value_with_list(self):
         """Error raised for default value not in list.
 
-        @id: 3d353610-97cd-45a3-8e99-425bc948ee51
+        :id: 3d353610-97cd-45a3-8e99-425bc948ee51
 
-        @steps:
+        :steps:
+            1.  Check the Override checkbox.
+            2.  Provide default value that doesn't matches the list of step 3.
+            3.  Validate this value with list validator type and rule.
+            4.  Submit the change.
 
-        1.  Check the Override checkbox.
-        2.  Provide default value that doesn't matches the list of step 3.
-        3.  Validate this value with list validator type and rule.
-        4.  Submit the change.
+        :assert: Error raised for default value not in list.
 
-        @assert: Error raised for default value not in list.
+        :caseautomation: notautomated
 
-        @caseautomation: notautomated
-
-        @CaseLevel: System
+        :CaseLevel: System
         """
 
     @run_only_on('sat')
@@ -404,20 +385,19 @@ class SmartClassParametersTestCase(UITestCase):
     def test_positive_validate_default_value_with_list(self):
         """Error not raised for default value in list.
 
-        @id: 62658cde-becd-4083-ba06-1fd4c8904173
+        :id: 62658cde-becd-4083-ba06-1fd4c8904173
 
-        @steps:
+        :steps:
+            1.  Check the Override checkbox.
+            2.  Provide default value that matches the list of step 3.
+            3.  Validate this value with list validator type and rule.
+            4.  Submit the change.
 
-        1.  Check the Override checkbox.
-        2.  Provide default value that matches the list of step 3.
-        3.  Validate this value with list validator type and rule.
-        4.  Submit the change.
+        :assert: Error not raised for default value in list.
 
-        @assert: Error not raised for default value in list.
+        :caseautomation: notautomated
 
-        @caseautomation: notautomated
-
-        @CaseLevel: System
+        :CaseLevel: System
         """
 
     @run_only_on('sat')
@@ -426,21 +406,20 @@ class SmartClassParametersTestCase(UITestCase):
     def test_negative_validate_matcher_value_with_list(self):
         """Error raised for matcher value not in list.
 
-        @id: ab8000e9-0110-473e-9c86-eeb709cbfd08
+        :id: ab8000e9-0110-473e-9c86-eeb709cbfd08
 
-        @steps:
+        :steps:
+            1.  Check the Override checkbox.
+            2.  Create a matcher with value that doesn't matches the list of
+                step 3.
+            3.  Validate this value with list validator type and rule.
+            4.  Submit the change.
 
-        1.  Check the Override checkbox.
-        2.  Create a matcher with value that doesn't matches
-            the list of step 3.
-        3.  Validate this value with list validator type and rule.
-        4.  Submit the change.
+        :assert: Error raised for matcher value not in list.
 
-        @assert: Error raised for matcher value not in list.
+        :caseautomation: notautomated
 
-        @caseautomation: notautomated
-
-        @CaseLevel: System
+        :CaseLevel: System
         """
 
     @run_only_on('sat')
@@ -449,20 +428,19 @@ class SmartClassParametersTestCase(UITestCase):
     def test_positive_validate_matcher_value_with_list(self):
         """Error not raised for matcher value in list.
 
-        @id: ae5b38e5-f7ea-4325-8a2c-917120470688
+        :id: ae5b38e5-f7ea-4325-8a2c-917120470688
 
-        @steps:
+        :steps:
+            1.  Check the Override checkbox.
+            2.  Create a matcher with value that matches the list of step 3.
+            3.  Validate this value with list validator type and rule.
+            4.  Submit the change.
 
-        1.  Check the Override checkbox.
-        2.  Create a matcher with value that matches the list of step 3.
-        3.  Validate this value with list validator type and rule.
-        4.  Submit the change.
+        :assert: Error not raised for matcher value in list.
 
-        @assert: Error not raised for matcher value in list.
+        :caseautomation: notautomated
 
-        @caseautomation: notautomated
-
-        @CaseLevel: System
+        :CaseLevel: System
         """
 
     @run_only_on('sat')
@@ -471,20 +449,20 @@ class SmartClassParametersTestCase(UITestCase):
     def test_negative_validate_matcher_value_with_default_type(self):
         """Error raised for matcher value not of default type.
 
-        @id: 70109667-c72e-4045-92a4-6b8bbbd615eb
+        :id: 70109667-c72e-4045-92a4-6b8bbbd615eb
 
-        @steps:
+        :steps:
+            1.  Check the Override checkbox.
+            2.  Update parameter default type with valid value.
+            3.  Create a matcher with value that doesn't matches the default
+                type.
+            4.  Submit the change.
 
-        1.  Check the Override checkbox.
-        2.  Update parameter default type with valid value.
-        3.  Create a matcher with value that doesn't matches the default type.
-        4.  Submit the change.
+        :assert: Error raised for matcher value not of default type.
 
-        @assert: Error raised for matcher value not of default type.
+        :caseautomation: notautomated
 
-        @caseautomation: notautomated
-
-        @CaseLevel: System
+        :CaseLevel: System
         """
 
     @run_only_on('sat')
@@ -493,20 +471,19 @@ class SmartClassParametersTestCase(UITestCase):
     def test_positive_validate_matcher_value_with_default_type(self):
         """No error for matcher value of default type.
 
-        @id: 57d4d82a-fc5b-4d85-8e8e-9a7ca880c5a2
+        :id: 57d4d82a-fc5b-4d85-8e8e-9a7ca880c5a2
 
-        @steps:
+        :steps:
+            1.  Check the Override checkbox.
+            2.  Update parameter default type with valid value.
+            3.  Create a matcher with value that matches the default type.
+            4.  Submit the change.
 
-        1.  Check the Override checkbox.
-        2.  Update parameter default type with valid value.
-        3.  Create a matcher with value that matches the default type.
-        4.  Submit the change.
+        :assert: Error not raised for matcher value of default type.
 
-        @assert: Error not raised for matcher value of default type.
+        :caseautomation: notautomated
 
-        @caseautomation: notautomated
-
-        @CaseLevel: System
+        :CaseLevel: System
         """
 
     @run_only_on('sat')
@@ -515,20 +492,20 @@ class SmartClassParametersTestCase(UITestCase):
     def test_negative_validate_matcher_and_default_value(self):
         """Error for invalid default and matcher value both at a time.
 
-        @id: 141b9e6a-7c4c-4ab0-8e30-7c3ddff0b9c8
+        :id: 141b9e6a-7c4c-4ab0-8e30-7c3ddff0b9c8
 
-        @steps:
+        :steps:
+            1.  Check the Override checkbox.
+            2.  Update parameter default type with Invalid value.
+            3.  Create a matcher with value that doesn't matches the default
+                type.
+            4.  Submit the change.
 
-        1.  Check the Override checkbox.
-        2.  Update parameter default type with Invalid value.
-        3.  Create a matcher with value that doesn't matches the default type.
-        4.  Submit the change.
+        :assert: Error raised for invalid default and matcher value both.
 
-        @assert: Error raised for invalid default and matcher value both.
+        :caseautomation: notautomated
 
-        @caseautomation: notautomated
-
-        @CaseLevel: System
+        :CaseLevel: System
         """
 
     @run_only_on('sat')
@@ -537,19 +514,18 @@ class SmartClassParametersTestCase(UITestCase):
     def test_negative_validate_matcher_non_existing_attribute(self):
         """Error while creating matcher for Non Existing Attribute.
 
-        @id: 46fd985d-2e7f-4a8a-8059-0c4d2ffcc8cd
+        :id: 46fd985d-2e7f-4a8a-8059-0c4d2ffcc8cd
 
-        @steps:
+        :steps:
+            1.  Check the Override checkbox.
+            2.  Create a matcher with non existing attribute in org.
+            3.  Attempt to submit the change.
 
-        1.  Check the Override checkbox.
-        2.  Create a matcher with non existing attribute in org.
-        3.  Attempt to submit the change.
+        :assert: Error raised for non existing attribute.
 
-        @assert: Error raised for non existing attribute.
+        :caseautomation: notautomated
 
-        @caseautomation: notautomated
-
-        @CaseLevel: System
+        :CaseLevel: System
         """
 
     @run_only_on('sat')
@@ -558,19 +534,18 @@ class SmartClassParametersTestCase(UITestCase):
     def test_positive_create_matcher(self):
         """Create matcher for attribute in parameter.
 
-        @id: 36ef93af-d79a-4e94-9759-fbdfa77df98b
+        :id: 36ef93af-d79a-4e94-9759-fbdfa77df98b
 
-        @steps:
+        :steps:
+            1.  Check the Override checkbox.
+            2.  Set some default Value.
+            3.  Click on 'Add Matcher' button to add matcher.
+            4.  Choose valid attribute type, name and value.
+            5.  Submit the change.
 
-        1.  Check the Override checkbox.
-        2.  Set some default Value.
-        3.  Click on 'Add Matcher' button to add matcher.
-        4.  Choose valid attribute type, name and value.
-        5.  Submit the change.
+        :assert: The matcher has been created successfully.
 
-        @assert: The matcher has been created successfully.
-
-        @caseautomation: notautomated
+        :caseautomation: notautomated
         """
 
     @run_only_on('sat')
@@ -580,19 +555,18 @@ class SmartClassParametersTestCase(UITestCase):
         """Create matcher for attribute in parameter,
         Where Value is puppet default value.
 
-        @id: 656f25cd-4394-414a-bd8e-458f0e51c668
+        :id: 656f25cd-4394-414a-bd8e-458f0e51c668
 
-        @steps:
+        :steps:
+            1.  Check the Override checkbox.
+            2.  Set some default Value.
+            3.  Click on 'Add Matcher' button to add matcher.
+            4.  Choose valid attribute type, name and puppet default value.
+            5.  Submit the change.
 
-        1.  Check the Override checkbox.
-        2.  Set some default Value.
-        3.  Click on 'Add Matcher' button to add matcher.
-        4.  Choose valid attribute type, name and puppet default value.
-        5.  Submit the change.
+        :assert: The matcher has been created successfully.
 
-        @assert: The matcher has been created successfully.
-
-        @caseautomation: notautomated
+        :caseautomation: notautomated
         """
 
     @run_only_on('sat')
@@ -601,22 +575,21 @@ class SmartClassParametersTestCase(UITestCase):
     def test_positive_create_matcher_attribute_priority(self):
         """Matcher Value set on Attribute Priority for Host.
 
-        @id: b83afe54-207e-4d6b-b705-1f3601c484a6
+        :id: b83afe54-207e-4d6b-b705-1f3601c484a6
 
-        @steps:
+        :steps:
+            1.  Check the Override checkbox.
+            2.  Set some default Value.
+            3.  Set fqdn as top priority attribute.
+            4.  Create first matcher for fqdn with valid details.
+            5.  Create second matcher for some attribute with valid details.
+                Note - The fqdn/host should have this attribute.
+            6.  Submit the change.
+            7.  Go to YAML output of associated host.
 
-        1.  Check the Override checkbox.
-        2.  Set some default Value.
-        3.  Set fqdn as top priority attribute.
-        4.  Create first matcher for fqdn with valid details.
-        5.  Create second matcher for some attribute with valid details.
-            Note - The fqdn/host should have this attribute.
-        6.  Submit the change.
-        7.  Go to YAML output of associated host.
+        :assert: The YAML output has the value only for fqdn matcher.
 
-        @assert: The YAML output has the value only for fqdn matcher.
-
-        @caseautomation: notautomated
+        :caseautomation: notautomated
         """
 
     @run_only_on('sat')
@@ -625,25 +598,25 @@ class SmartClassParametersTestCase(UITestCase):
     def test_negative_create_matcher_attribute_priority(self):
         """Matcher Value set on Attribute Priority for Host - alternate priority.
 
-        @id: f494b815-b9fd-4648-b984-e5a07e29b5b9
+        :id: f494b815-b9fd-4648-b984-e5a07e29b5b9
 
-        @steps:
+        :steps:
+            1.  Check the Override checkbox.
+            2.  Set some default Value.
+            3.  Set some attribute(other than fqdn) as top priority attribute.
+                Note - The fqdn/host should have this attribute.
+            4.  Create first matcher for fqdn with valid details.
+            5.  Create second matcher for attribute of step 3 with valid
+                details.
+            6.  Submit the change.
+            7.  Go to YAML output of associated host.
 
-        1.  Check the Override checkbox.
-        2.  Set some default Value.
-        3.  Set some attribute(other than fqdn) as top priority attribute.
-            Note - The fqdn/host should have this attribute.
-        4.  Create first matcher for fqdn with valid details.
-        5.  Create second matcher for attribute of step 3 with valid details.
-        6.  Submit the change.
-        7.  Go to YAML output of associated host.
+        :assert:
 
-        @assert:
+            1.  The YAML output has the value only for step 5 matcher.
+            2.  The YAML output doesn't have value for fqdn/host matcher.
 
-        1.  The YAML output has the value only for step 5 matcher.
-        2.  The YAML output doesn't have value for fqdn/host matcher.
-
-        @caseautomation: notautomated
+        :caseautomation: notautomated
         """
 
     @run_only_on('sat')
@@ -652,29 +625,28 @@ class SmartClassParametersTestCase(UITestCase):
     def test_positive_create_matcher_merge_override(self):
         """Merge the values of all the associated matchers.
 
-        @id: adf9823b-714d-490f-8dfa-f4f9cc888be1
+        :id: adf9823b-714d-490f-8dfa-f4f9cc888be1
 
-        @steps:
+        :steps:
+            1.  Check the Override checkbox.
+            2.  Set some default Value.
+            3.  Create first matcher for attribute fqdn with valid details.
+            4.  Create second matcher for other attribute with valid details.
+                Note - The fqdn/host should have this attribute.
+            5.  Create more matchers for some more attributes if any.
+                Note - The fqdn/host should have this attributes.
+            6.  Select 'Merge overrides' checkbox.
+            7.  Submit the change.
+            8.  Go to YAML output of associated host.
 
-        1.  Check the Override checkbox.
-        2.  Set some default Value.
-        3.  Create first matcher for attribute fqdn with valid details.
-        4.  Create second matcher for other attribute with valid details.
-            Note - The fqdn/host should have this attribute.
-        5.  Create more matchers for some more attributes if any.
-            Note - The fqdn/host should have this attributes.
-        6.  Select 'Merge overrides' checkbox.
-        7.  Submit the change.
-        8.  Go to YAML output of associated host.
+        :assert:
 
-        @assert:
+            1.  The YAML output has the values merged from all the associated
+                matchers.
+            2.  The YAML output doesn't have the default value of parameter.
+            3.  Duplicate values in YAML output if any are displayed.
 
-        1.  The YAML output has the values merged from all the associated
-            matchers.
-        2.  The YAML output doesn't have the default value of parameter.
-        3.  Duplicate values in YAML output if any are displayed.
-
-        @caseautomation: notautomated
+        :caseautomation: notautomated
         """
 
     @run_only_on('sat')
@@ -683,30 +655,29 @@ class SmartClassParametersTestCase(UITestCase):
     def test_negative_create_matcher_merge_override(self):
         """Attempt to merge the values from non associated matchers.
 
-        @id: 46326bd6-e51f-48e7-87b2-6d65ad602af9
+        :id: 46326bd6-e51f-48e7-87b2-6d65ad602af9
 
-        @steps:
+        :steps:
+            1.  Check the Override checkbox.
+            2.  Set some default Value.
+            3.  Create first matcher for attribute fqdn with valid details.
+            4.  Create second matcher for other attribute with valid details.
+                Note - The fqdn/host should not have this attribute.
+            5.  Create more matchers for some more attributes if any.
+                Note - The fqdn/host should not have this attributes.
+            6.  Select 'Merge overrides' checkbox.
+            7.  Submit the change.
+            8.  Go to YAML output of associated host.
 
-        1.  Check the Override checkbox.
-        2.  Set some default Value.
-        3.  Create first matcher for attribute fqdn with valid details.
-        4.  Create second matcher for other attribute with valid details.
-            Note - The fqdn/host should not have this attribute.
-        5.  Create more matchers for some more attributes if any.
-            Note - The fqdn/host should not have this attributes.
-        6.  Select 'Merge overrides' checkbox.
-        7.  Submit the change.
-        8.  Go to YAML output of associated host.
+        :assert:
 
-        @assert:
+            1.  The YAML output has the values only for fqdn.
+            2.  The YAML output doesn't have the values for attribute
+                which are not associated to host.
+            3.  The YAML output doesn't have the default value of parameter.
+            4.  Duplicate values in YAML output if any are displayed.
 
-        1.  The YAML output has the values only for fqdn.
-        2.  The YAML output doesn't have the values for attribute
-            which are not associated to host.
-        3.  The YAML output doesn't have the default value of parameter.
-        4.  Duplicate values in YAML output if any are displayed.
-
-        @caseautomation: notautomated
+        :caseautomation: notautomated
         """
 
     @run_only_on('sat')
@@ -715,31 +686,31 @@ class SmartClassParametersTestCase(UITestCase):
     def test_positive_create_matcher_merge_oveeride_puppet_value(self):
         """Merge the values of all the associated matchers + puppet default value.
 
-        @id: 4eed74ac-0ead-4723-af4d-8638406691f6
+        :id: 4eed74ac-0ead-4723-af4d-8638406691f6
 
-        @steps:
+        :steps:
+            1.  Check the Override checkbox.
+            2.  Set some default Value.
+            3.  Create first matcher for attribute fqdn with valid details.
+            4.  Create second matcher for other attribute with value as puppet
+                default.
+                Note - The fqdn/host should have this attribute.
+            5.  Create more matchers for some more attributes with value as
+                puppet default.
+                Note - The fqdn/host should have this attributes.
+            6.  Select 'Merge overrides' checkbox.
+            7.  Select 'Merge default' checkbox.
+            8.  Submit the change.
+            9.  Go to YAML output of associated host.
 
-        1.  Check the Override checkbox.
-        2.  Set some default Value.
-        3.  Create first matcher for attribute fqdn with valid details.
-        4.  Create second matcher for other attribute with value
-            as puppet default.
-            Note - The fqdn/host should have this attribute.
-        5.  Create more matchers for some more attributes with value
-            as puppet default.
-            Note - The fqdn/host should have this attributes.
-        6.  Select 'Merge overrides' checkbox.
-        7.  Select 'Merge default' checkbox.
-        8.  Submit the change.
-        9.  Go to YAML output of associated host.
+        :assert:
 
-        @assert:
+            1.  The YAML output has the value only for fqdn.
+            2.  The YAML output doesn't have the puppet default values of
+                matchers.
+            3.  Duplicate values in YAML output if any are displayed.
 
-        1.  The YAML output has the value only for fqdn.
-        2.  The YAML output doesn't have the puppet default values of matchers.
-        3.  Duplicate values in YAML output if any are displayed.
-
-        @caseautomation: notautomated
+        :caseautomation: notautomated
         """
 
     @run_only_on('sat')
@@ -748,30 +719,29 @@ class SmartClassParametersTestCase(UITestCase):
     def test_positive_create_matcher_merge_default(self):
         """Merge the values of all the associated matchers + default value.
 
-        @id: b79ce9fd-2497-4f6e-85cc-957077c4f097
+        :id: b79ce9fd-2497-4f6e-85cc-957077c4f097
 
-        @steps:
+        :steps:
+            1.  Check the Override checkbox.
+            2.  Set some default Value.
+            3.  Create first matcher for attribute fqdn with valid details.
+            4.  Create second matcher for other attribute with valid details.
+                Note - The fqdn/host should have this attribute.
+            5.  Create more matchers for some more attributes if any.
+                Note - The fqdn/host should have this attributes.
+            6.  Select 'Merge overrides' checkbox.
+            7.  Select 'Merge default' checkbox.
+            8.  Submit the change.
+            9.  Go to YAML output of associated host.
 
-        1.  Check the Override checkbox.
-        2.  Set some default Value.
-        3.  Create first matcher for attribute fqdn with valid details.
-        4.  Create second matcher for other attribute with valid details.
-            Note - The fqdn/host should have this attribute.
-        5.  Create more matchers for some more attributes if any.
-            Note - The fqdn/host should have this attributes.
-        6.  Select 'Merge overrides' checkbox.
-        7.  Select 'Merge default' checkbox.
-        8.  Submit the change.
-        9.  Go to YAML output of associated host.
+        :assert:
 
-        @assert:
+            1.  The YAML output has the values merged from all
+                the associated matchers.
+            2.  The YAML output has the default value of parameter.
+            3.  Duplicate values in YAML output if any are displayed.
 
-        1.  The YAML output has the values merged from all
-            the associated matchers.
-        2.  The YAML output has the default value of parameter.
-        3.  Duplicate values in YAML output if any are displayed.
-
-        @caseautomation: notautomated
+        :caseautomation: notautomated
         """
 
     @run_only_on('sat')
@@ -780,30 +750,30 @@ class SmartClassParametersTestCase(UITestCase):
     def test_negative_create_matcher_merge_default(self):
         """Empty default value is not shown in merged values.
 
-        @id: b9c46949-34ea-4edd-ac3f-53708bf7885d
+        :id: b9c46949-34ea-4edd-ac3f-53708bf7885d
 
-        @steps:
+        :steps:
+            1.  Check the Override checkbox.
+            2.  Set empty default Value.
+            3.  Create first matcher for attribute fqdn with valid details.
+            4.  Create second matcher for other attribute with valid details.
+                Note - The fqdn/host should have this attribute.
+            5.  Create more matchers for some more attributes if any.
+                Note - The fqdn/host should have this attributes.
+            6.  Select 'Merge overrides' checkbox.
+            7.  Select 'Merge default' checkbox.
+            8.  Submit the change.
+            9.  Go to YAML output of associated host.
 
-        1.  Check the Override checkbox.
-        2.  Set empty default Value.
-        3.  Create first matcher for attribute fqdn with valid details.
-        4.  Create second matcher for other attribute with valid details.
-            Note - The fqdn/host should have this attribute.
-        5.  Create more matchers for some more attributes if any.
-            Note - The fqdn/host should have this attributes.
-        6.  Select 'Merge overrides' checkbox.
-        7.  Select 'Merge default' checkbox.
-        8.  Submit the change.
-        9.  Go to YAML output of associated host.
+        :assert:
 
-        @assert:
+            1.  The YAML output has the values merged from all
+                the associated matchers.
+            2.  The YAML output doesn't have the empty default value of
+                parameter.
+            3.  Duplicate values in YAML output if any are displayed.
 
-        1.  The YAML output has the values merged from all
-            the associated matchers.
-        2.  The YAML output doesn't have the empty default value of parameter.
-        3.  Duplicate values in YAML output if any are displayed.
-
-        @caseautomation: notautomated
+        :caseautomation: notautomated
         """
 
     @run_only_on('sat')
@@ -812,30 +782,29 @@ class SmartClassParametersTestCase(UITestCase):
     def test_positive_create_matcher_merge_puppet_default(self):
         """Merge the values of all the associated matchers + puppet default value.
 
-        @id: 8e9075c1-adc5-474e-8aa3-4252f507c155
+        :id: 8e9075c1-adc5-474e-8aa3-4252f507c155
 
-        @steps:
+        :steps:
+            1.  Check the Override checkbox.
+            2.  Set default Value as puppet default value.
+            3.  Create first matcher for attribute fqdn with valid details.
+            4.  Create second matcher for other attribute with valid details.
+                Note - The fqdn/host should have this attribute.
+            5.  Create more matchers for some more attributes if any.
+                Note - The fqdn/host should have this attributes.
+            6.  Select 'Merge overrides' checkbox.
+            7.  Select 'Merge default' checkbox.
+            8.  Submit the change.
+            9.  Go to YAML output of associated host.
 
-        1.  Check the Override checkbox.
-        2.  Set default Value as puppet default value.
-        3.  Create first matcher for attribute fqdn with valid details.
-        4.  Create second matcher for other attribute with valid details.
-            Note - The fqdn/host should have this attribute.
-        5.  Create more matchers for some more attributes if any.
-            Note - The fqdn/host should have this attributes.
-        6.  Select 'Merge overrides' checkbox.
-        7.  Select 'Merge default' checkbox.
-        8.  Submit the change.
-        9.  Go to YAML output of associated host.
+        :assert:
 
-        @assert:
+            1.  The YAML output has the values merged from all the associated
+                matchers.
+            2.  The YAML output doesn't have the puppet default value.
+            3.  Duplicate values in YAML output if any are displayed.
 
-        1.  The YAML output has the values merged from all
-            the associated matchers.
-        2.  The YAML output doesn't have the puppet default value.
-        3.  Duplicate values in YAML output if any are displayed.
-
-        @caseautomation: notautomated
+        :caseautomation: notautomated
         """
 
     @run_only_on('sat')
@@ -844,30 +813,29 @@ class SmartClassParametersTestCase(UITestCase):
     def test_positive_create_matcher_avoid_duplicate(self):
         """Merge the values of all the associated matchers, remove duplicates.
 
-        @id: c8557813-2c09-4196-b1c1-f7e609aa0310
+        :id: c8557813-2c09-4196-b1c1-f7e609aa0310
 
-        @steps:
+        :steps:
+            1.  Check the Override checkbox.
+            2.  Set some default Value of array type.
+            3.  Create first matcher for attribute fqdn with some value.
+            4.  Create second matcher for other attribute with same value as
+                fqdn matcher.
+                Note - The fqdn/host should have this attribute.
+            5.  Select 'Merge overrides' checkbox.
+            6.  Select 'Merge default' checkbox.
+            7.  Select 'Avoid Duplicates' checkbox.
+            8.  Submit the change.
+            9.  Go to YAML output of associated host.
 
-        1.  Check the Override checkbox.
-        2.  Set some default Value of array type.
-        3.  Create first matcher for attribute fqdn with some value.
-        4.  Create second matcher for other attribute with
-            same value as fqdn matcher.
-            Note - The fqdn/host should have this attribute.
-        5.  Select 'Merge overrides' checkbox.
-        6.  Select 'Merge default' checkbox.
-        7.  Select 'Avoid Duplicates' checkbox.
-        8.  Submit the change.
-        9.  Go to YAML output of associated host.
+        :assert:
 
-        @assert:
+            1.  The YAML output has the values merged from all the associated
+                matchers.
+            2.  The YAML output has the default value of parameter.
+            3.  Duplicate values in YAML output are removed / not displayed.
 
-        1.  The YAML output has the values merged from all
-            the associated matchers.
-        2.  The YAML output has the default value of parameter.
-        3.  Duplicate values in YAML output are removed / not displayed.
-
-        @caseautomation: notautomated
+        :caseautomation: notautomated
         """
 
     @run_only_on('sat')
@@ -876,29 +844,28 @@ class SmartClassParametersTestCase(UITestCase):
     def test_negative_create_matcher_avoid_duplicate(self):
         """Duplicates not removed as they were not really present.
 
-        @id: f7a34928-c3a3-4b85-907b-f95c26240652
+        :id: f7a34928-c3a3-4b85-907b-f95c26240652
 
-        @steps:
+        :steps:
+            1.  Check the Override checkbox.
+            2.  Set some default Value of array type.
+            3.  Create first matcher for attribute fqdn with some value.
+            4.  Create second matcher for other attribute with other value than
+                fqdn matcher and default value.
+                Note - The fqdn/host should have this attribute.
+            5.  Select 'Merge overrides' checkbox.
+            6.  Select 'Merge default' checkbox.
+            7.  Select 'Avoid Duplicates' checkbox.
+            8.  Submit the change.
+            9.  Go to YAML output of associated host.
 
-        1.  Check the Override checkbox.
-        2.  Set some default Value of array type.
-        3.  Create first matcher for attribute fqdn with some value.
-        4.  Create second matcher for other attribute with other value
-            than fqdn matcher and default value.
-            Note - The fqdn/host should have this attribute.
-        5.  Select 'Merge overrides' checkbox.
-        6.  Select 'Merge default' checkbox.
-        7.  Select 'Avoid Duplicates' checkbox.
-        8.  Submit the change.
-        9.  Go to YAML output of associated host.
+        :assert:
 
-        @assert:
+            1.  The YAML output has the values merged from all matchers.
+            2.  The YAML output has the default value of parameter.
+            3.  No value removed as duplicate value.
 
-        1.  The YAML output has the values merged from all matchers.
-        2.  The YAML output has the default value of parameter.
-        3.  No value removed as duplicate value.
-
-        @caseautomation: notautomated
+        :caseautomation: notautomated
         """
 
     @run_only_on('sat')
@@ -907,19 +874,18 @@ class SmartClassParametersTestCase(UITestCase):
     def test_positive_enable_merge_overrides_default_checkboxes(self):
         """Enable Merge Overrides, Merge Default checkbox for supported types.
 
-        @id: d6323648-4720-4c33-b25f-2b2b569d9df0
+        :id: d6323648-4720-4c33-b25f-2b2b569d9df0
 
-        @steps:
+        :steps:
+            1.  Check the Override checkbox.
+            2.  Set parameter type to array/hash.
 
-        1.  Check the Override checkbox.
-        2.  Set parameter type to array/hash.
+        :assert: The Merge Overrides, Merge Default checkbox are enabled to
+            check.
 
-        @assert: The Merge Overrides, Merge Default checkbox
-        are enabled to check.
+        :caseautomation: notautomated
 
-        @caseautomation: notautomated
-
-        @CaseLevel: System
+        :CaseLevel: System
         """
 
     @run_only_on('sat')
@@ -928,19 +894,18 @@ class SmartClassParametersTestCase(UITestCase):
     def test_negative_enable_merge_overrides_default_checkboxes(self):
         """Disable Merge Overrides, Merge Default checkboxes for non supported types.
 
-        @id: 58e42a4d-fabb-4a93-8787-3399cd6d3394
+        :id: 58e42a4d-fabb-4a93-8787-3399cd6d3394
 
-        @steps:
+        :steps:
+            1.  Check the Override checkbox.
+            2.  Set parameter type other than array/hash.
 
-        1.  Check the Override checkbox.
-        2.  Set parameter type other than array/hash.
+        :assert: The Merge Overrides, Merge Default checkboxes are not enabled
+            to check.
 
-        @assert: The Merge Overrides, Merge Default checkboxes
-        are not enabled to check.
+        :caseautomation: notautomated
 
-        @caseautomation: notautomated
-
-        @CaseLevel: System
+        :CaseLevel: System
         """
 
     @run_only_on('sat')
@@ -949,19 +914,18 @@ class SmartClassParametersTestCase(UITestCase):
     def test_positive_enable_avaoid_duplicates_checkbox(self):
         """Enable Avoid duplicates checkbox for supported type- array.
 
-        @id: 77eaa0b6-4388-4e49-88cd-b059d0c53e02
+        :id: 77eaa0b6-4388-4e49-88cd-b059d0c53e02
 
-        @steps:
+        :steps:
+            1.  Check the Override checkbox.
+            2.  Set parameter type to array.
+            3.  Check Merge Overrides checkbox.
 
-        1.  Check the Override checkbox.
-        2.  Set parameter type to array.
-        3.  Check Merge Overrides checkbox.
+        :assert: The Avoid Duplicates checkbox is enabled to check.
 
-        @assert: The Avoid Duplicates checkbox is enabled to check.
+        :caseautomation: notautomated
 
-        @caseautomation: notautomated
-
-        @CaseLevel: System
+        :CaseLevel: System
         """
 
     @run_only_on('sat')
@@ -970,23 +934,21 @@ class SmartClassParametersTestCase(UITestCase):
     def test_negative_enable_avaoid_duplicates_checkbox(self):
         """Disable Avoid duplicates checkbox for non supported types.
 
-        @id: 2b69cec7-1136-4566-9c75-80c71e917fbf
+        :id: 2b69cec7-1136-4566-9c75-80c71e917fbf
 
-        @steps:
+        :steps:
+            1.  Check the Override checkbox.
+            2.  Set parameter type other than array.
 
-        1.  Check the Override checkbox.
-        2.  Set parameter type other than array.
+        :assert:
+            1.  The Merge Overrides checkbox is only enabled to check for type
+                hash.
+            2.  The Avoid duplicates checkbox not enabled to check for any type
+                than array.
 
-        @assert:
+        :caseautomation: notautomated
 
-        1.  The Merge Overrides checkbox is only enabled to check
-            for type hash.
-        2.  The Avoid duplicates checkbox not enabled to check
-            for any type than array.
-
-        @caseautomation: notautomated
-
-        @CaseLevel: System
+        :CaseLevel: System
         """
 
     @run_only_on('sat')
@@ -995,24 +957,21 @@ class SmartClassParametersTestCase(UITestCase):
     def test_positive_impact_parameter_delete_attribute(self):
         """Impact on parameter after deleting associated attribute.
 
-        @id: 5d9bed6d-d9c0-4eb3-aaf7-bdda1f9203dd
+        :id: 5d9bed6d-d9c0-4eb3-aaf7-bdda1f9203dd
 
-        @steps:
+        :steps:
+            1.  Override the parameter and create a matcher for some attribute.
+            2.  Delete the attribute.
+            3.  Recreate the attribute with same name as earlier.
 
-        1.  Override the parameter and create a matcher
-            for some attribute.
-        2.  Delete the attribute.
-        3.  Recreate the attribute with same name as earlier.
+        :assert:
+            1.  The matcher for deleted attribute removed from parameter.
+            2.  On recreating attribute, the matcher should not reappear in
+                parameter.
 
-        @assert:
+        :caseautomation: notautomated
 
-        1.  The matcher for deleted attribute removed from parameter.
-        2.  On recreating attribute, the matcher should not
-            reappear in parameter.
-
-        @caseautomation: notautomated
-
-        @CaseLevel: System
+        :CaseLevel: System
         """
 
     @run_only_on('sat')
@@ -1021,21 +980,18 @@ class SmartClassParametersTestCase(UITestCase):
     def test_positive_create_override_from_attribute(self):
         """Impact on parameter on overriding the parameter value from attribute.
 
-        @id: dcc8a9f5-191d-42d1-bff5-3083cc46cce1
+        :id: dcc8a9f5-191d-42d1-bff5-3083cc46cce1
 
-        @steps:
+        :steps:
+            1.  Check the override checkbox for the parameter.
+            2.  Associate parameter with fqdn/hostgroup.
+            3.  From host/hostgroup, override the parameter value.
+            4.  Submit the changes.
 
-        1.  Check the override checkbox for the parameter.
-        2.  Associate parameter with fqdn/hostgroup.
-        3.  From host/hostgroup, override the parameter value.
-        4.  Submit the changes.
-
-        @assert:
-
-        1.  The host/hostgroup is saved with changes.
-        2.  New matcher for fqdn/hostgroup created inside parameter.
-
-        @caseautomation: notautomated
+        :assert:
+            1.  The host/hostgroup is saved with changes.
+            2.  New matcher for fqdn/hostgroup created inside parameter.
+        :caseautomation: notautomated
         """
 
     @run_only_on('sat')
@@ -1045,21 +1001,17 @@ class SmartClassParametersTestCase(UITestCase):
         """No impact on parameter on overriding the parameter
         with invalid value from attribute.
 
-        @id: 475d71cc-d52c-4a94-adb6-27ea52493176
+        :id: 475d71cc-d52c-4a94-adb6-27ea52493176
 
-        @steps:
-
-        1.  Check the override checkbox for the parameter.
-        2.  Associate parameter with fqdn/hostgroup.
-        3.  From host/hostgroup, Attempt to override the parameter with
-            some other key type of value.
-
-        @assert:
-
-        1.  Error thrown for invalid type value.
-        2.  No matcher for fqdn/hostgroup is created inside parameter.
-
-        @caseautomation: notautomated
+        :steps:
+            1.  Check the override checkbox for the parameter.
+            2.  Associate parameter with fqdn/hostgroup.
+            3.  From host/hostgroup, Attempt to override the parameter with
+                some other key type of value.
+        :assert:
+            1.  Error thrown for invalid type value.
+            2.  No matcher for fqdn/hostgroup is created inside parameter.
+        :caseautomation: notautomated
         """
 
     @run_only_on('sat')
@@ -1069,23 +1021,23 @@ class SmartClassParametersTestCase(UITestCase):
         """Impact on parameter on overriding the parameter value
         from attribute - puppet default.
 
-        @id: 2a013541-a4f2-4b54-b6ab-52932b17eb4a
+        :id: 2a013541-a4f2-4b54-b6ab-52932b17eb4a
 
-        @steps:
+        :steps:
 
-        1.  Check the override checkbox for the parameter.
-        2.  Associate parameter with fqdn/hostgroup.
-        3.  From host/hostgroup, override the parameter value as
-            puppet default value.
-        4.  Submit the changes.
+            1.  Check the override checkbox for the parameter.
+            2.  Associate parameter with fqdn/hostgroup.
+            3.  From host/hostgroup, override the parameter value as puppet
+                default value.
+            4.  Submit the changes.
 
-        @assert:
+        :assert:
 
-        1.  The host/hostgroup is saved with changes.
-        2.  New matcher for fqdn/hostgroup created inside parameter.
-        3.  In matcher, 'Use Puppet Default' checkbox is checked.
+            1.  The host/hostgroup is saved with changes.
+            2.  New matcher for fqdn/hostgroup created inside parameter.
+            3.  In matcher, 'Use Puppet Default' checkbox is checked.
 
-        @caseautomation: notautomated
+        :caseautomation: notautomated
         """
 
     @run_only_on('sat')
@@ -1095,23 +1047,23 @@ class SmartClassParametersTestCase(UITestCase):
         """Error for empty value on overriding the parameter value
         from attribute - Required checked.
 
-        @id: c4fadfa6-0747-475f-8fc5-227c147d585a
+        :id: c4fadfa6-0747-475f-8fc5-227c147d585a
 
-        @steps:
+        :steps:
 
-        1.  Check the override checkbox for the parameter.
-        2.  Check 'Required' checkbox in parameter.
-        3.  Associate parameter with fqdn/hostgroup.
-        4.  From host/hostgroup, Attempt to override the parameter
-            with empty value.
+            1.  Check the override checkbox for the parameter.
+            2.  Check 'Required' checkbox in parameter.
+            3.  Associate parameter with fqdn/hostgroup.
+            4.  From host/hostgroup, Attempt to override the parameter with
+                empty value.
 
-        @assert:
+        :assert:
 
-        1.  Error thrown for empty value as the value is required to pass.
-        2.  The info icon changed to warning icon for that parameter.
-        3.  No matcher for fqdn/hostgroup created inside parameter.
+            1.  Error thrown for empty value as the value is required to pass.
+            2.  The info icon changed to warning icon for that parameter.
+            3.  No matcher for fqdn/hostgroup created inside parameter.
 
-        @caseautomation: notautomated
+        :caseautomation: notautomated
         """
 
     @run_only_on('sat')
@@ -1120,22 +1072,22 @@ class SmartClassParametersTestCase(UITestCase):
     def test_positive_update_matcher_from_attribute(self):
         """Impact on parameter on editing the parameter value from attribute.
 
-        @id: a7b3ecde-a311-421c-be4b-0f72ab1f44ba
+        :id: a7b3ecde-a311-421c-be4b-0f72ab1f44ba
 
-        @steps:
+        :steps:
 
-        1.  Check the override checkbox for the parameter.
-        2.  Associate parameter with fqdn/hostgroup.
-        3.  Create a matcher for fqdn/hostgroup with valid details.
-        4.  From host/hostgroup, edit the parameter value.
-        5.  Submit the changes.
+            1.  Check the override checkbox for the parameter.
+            2.  Associate parameter with fqdn/hostgroup.
+            3.  Create a matcher for fqdn/hostgroup with valid details.
+            4.  From host/hostgroup, edit the parameter value.
+            5.  Submit the changes.
 
-        @assert:
+        :assert:
 
-        1.  The host/hostgroup is saved with changes.
-        2.  Matcher value in parameter is updated from fqdn/hostgroup.
+            1.  The host/hostgroup is saved with changes.
+            2.  Matcher value in parameter is updated from fqdn/hostgroup.
 
-        @caseautomation: notautomated
+        :caseautomation: notautomated
         """
 
     @run_only_on('sat')
@@ -1145,22 +1097,22 @@ class SmartClassParametersTestCase(UITestCase):
         """No Impact on parameter on editing the parameter with
         invalid value from attribute.
 
-        @id: 554de8b7-0ddb-4f2e-b406-882b13eac882
+        :id: 554de8b7-0ddb-4f2e-b406-882b13eac882
 
-        @steps:
+        :steps:
 
-        1.  Check the override checkbox for the parameter.
-        2.  Associate parameter with fqdn/hostgroup.
-        3.  Create a matcher for fqdn/hostgroup with valid details.
-        4.  From host/hostgroup, attempt to edit the parameter
-            with invalid value.
+            1.  Check the override checkbox for the parameter.
+            2.  Associate parameter with fqdn/hostgroup.
+            3.  Create a matcher for fqdn/hostgroup with valid details.
+            4.  From host/hostgroup, attempt to edit the parameter with invalid
+                value.
 
-        @assert:
+        :assert:
 
-        1.  Error thrown for invalid value.
-        2.  Matcher value in parameter is not updated from fqdn/hostgroup.
+            1.  Error thrown for invalid value.
+            2.  Matcher value in parameter is not updated from fqdn/hostgroup.
 
-        @caseautomation: notautomated
+        :caseautomation: notautomated
         """
 
     @run_only_on('sat')
@@ -1170,22 +1122,22 @@ class SmartClassParametersTestCase(UITestCase):
     def test_positive_update_parameter_in_nested_hostgroup(self):
         """Update parameter value in nested hostgroup.
 
-        @id: 9aacec96-593c-4089-ad14-d4bbbbd43ef8
+        :id: 9aacec96-593c-4089-ad14-d4bbbbd43ef8
 
-        @steps:
+        :steps:
 
-        1.  Check the override checkbox for the parameter.
-        2.  Associate parameter with one hostgroup.
-        3.  Create a nested hostgroup from above parent hostgroup.
-        4.  And Update the value of parameter from nested hostgroup.
-        5.  Submit the changes.
+            1.  Check the override checkbox for the parameter.
+            2.  Associate parameter with one hostgroup.
+            3.  Create a nested hostgroup from above parent hostgroup.
+            4.  And Update the value of parameter from nested hostgroup.
+            5.  Submit the changes.
 
-        @assert:
+        :assert:
 
-        1.  The parameter value updated in nested hostgroup.
-        2.  Changes submitted successfully.
+            1.  The parameter value updated in nested hostgroup.
+            2.  Changes submitted successfully.
 
-        @caseautomation: notautomated
+        :caseautomation: notautomated
         """
 
     @run_only_on('sat')
@@ -1194,23 +1146,23 @@ class SmartClassParametersTestCase(UITestCase):
     def test_positive_hide_parameter_default_value(self):
         """Hide the default value of parameter.
 
-        @id: 8b3d294e-58e7-454c-b19e-ead1c6a6a342
+        :id: 8b3d294e-58e7-454c-b19e-ead1c6a6a342
 
-        @steps:
+        :steps:
 
-        1.  Check the override checkbox for the parameter.
-        2.  Enter some valid default value.
-        3.  Check 'Hidden Value' checkbox.
+            1.  Check the override checkbox for the parameter.
+            2.  Enter some valid default value.
+            3.  Check 'Hidden Value' checkbox.
 
-        @assert:
+        :assert:
 
-        1.  The default value shown in hidden state.
-        2.  Changes submitted successfully.
-        3.  Matcher values shown hidden if any.
+            1.  The default value shown in hidden state.
+            2.  Changes submitted successfully.
+            3.  Matcher values shown hidden if any.
 
-        @caseautomation: notautomated
+        :caseautomation: notautomated
 
-        @CaseLevel: System
+        :CaseLevel: System
         """
 
     @run_only_on('sat')
@@ -1219,24 +1171,24 @@ class SmartClassParametersTestCase(UITestCase):
     def test_positive_unhide_parameter_default_value(self):
         """Unhide the default value of parameter.
 
-        @id: fca478b9-eeb9-41ea-8c41-2d9601f4ea4f
+        :id: fca478b9-eeb9-41ea-8c41-2d9601f4ea4f
 
-        @steps:
+        :steps:
 
-        1.  Check the override checkbox for the parameter.
-        2.  Enter some valid default value.
-        3.  Hide the value of parameter.
-        4.  After hiding, uncheck the 'Hidden Value' checkbox.
+            1.  Check the override checkbox for the parameter.
+            2.  Enter some valid default value.
+            3.  Hide the value of parameter.
+            4.  After hiding, uncheck the 'Hidden Value' checkbox.
 
-        @assert:
+        :assert:
 
-        1.  The default value shown in unhidden state.
-        2.  Changes submitted successfully.
-        3.  Matcher values shown unhidden if any.
+            1.  The default value shown in unhidden state.
+            2.  Changes submitted successfully.
+            3.  Matcher values shown unhidden if any.
 
-        @caseautomation: notautomated
+        :caseautomation: notautomated
 
-        @CaseLevel: System
+        :CaseLevel: System
         """
 
     @run_only_on('sat')
@@ -1245,25 +1197,26 @@ class SmartClassParametersTestCase(UITestCase):
     def test_positive_hide_default_value_in_attribute(self):
         """Hide the default value of parameter in attribute.
 
-        @id: a44d35df-877c-469b-b82c-e5f85e592e8d
+        :id: a44d35df-877c-469b-b82c-e5f85e592e8d
 
-        @steps:
+        :steps:
 
-        1.  Check the override checkbox for the parameter.
-        2.  Enter some valid default value.
-        3.  Hide the default Value.
-        4.  Submit the changes.
-        5.  Associate parameter on host/hostgroup.
+            1.  Check the override checkbox for the parameter.
+            2.  Enter some valid default value.
+            3.  Hide the default Value.
+            4.  Submit the changes.
+            5.  Associate parameter on host/hostgroup.
 
-        @assert:
+        :assert:
 
-        1.  In host/hostgroup, the parameter value shown in hidden state.
-        2.  The button for unhiding the value is displayed and accessible.
-        3.  The button for overriding the value is displayed and accessible.
+            1.  In host/hostgroup, the parameter value shown in hidden state.
+            2.  The button for unhiding the value is displayed and accessible.
+            3.  The button for overriding the value is displayed and
+                accessible.
 
-        @caseautomation: notautomated
+        :caseautomation: notautomated
 
-        @CaseLevel: System
+        :CaseLevel: System
         """
 
     @run_only_on('sat')
@@ -1272,27 +1225,28 @@ class SmartClassParametersTestCase(UITestCase):
     def test_positive_unhide_default_value_in_attribute(self):
         """Unhide the default value of parameter in attribute.
 
-        @id: 76611ba0-e583-4c4b-b794-005a21240d26
+        :id: 76611ba0-e583-4c4b-b794-005a21240d26
 
-        @steps:
+        :steps:
 
-        1.  Check the override checkbox for the parameter.
-        2.  Enter some valid default value.
-        3.  Hide the default Value.
-        4.  Submit the changes.
-        5.  Associate parameter on host/hostgroup.
-        6.  In host/hostgroup, Click Unhide button icon.
+            1.  Check the override checkbox for the parameter.
+            2.  Enter some valid default value.
+            3.  Hide the default Value.
+            4.  Submit the changes.
+            5.  Associate parameter on host/hostgroup.
+            6.  In host/hostgroup, Click Unhide button icon.
 
-        @assert:
+        :assert:
 
-        1.  In host/hostgroup, the parameter value shown in unhidden state.
-        2.  The button for hiding the value is displayed and accessible.
-        3.  The button for overriding the value is displayed and accessible.
-        4.  In parameter, the default value is still hidden.
+            1.  In host/hostgroup, the parameter value shown in unhidden state.
+            2.  The button for hiding the value is displayed and accessible.
+            3.  The button for overriding the value is displayed and
+                accessible.
+            4.  In parameter, the default value is still hidden.
 
-        @caseautomation: notautomated
+        :caseautomation: notautomated
 
-        @CaseLevel: System
+        :CaseLevel: System
         """
 
     @run_only_on('sat')
@@ -1301,22 +1255,22 @@ class SmartClassParametersTestCase(UITestCase):
     def test_positive_update_hidden_value_in_parameter(self):
         """Update the hidden default value of parameter.
 
-        @id: e7a6e172-d0b9-48e4-81ae-16d866d6f63b
+        :id: e7a6e172-d0b9-48e4-81ae-16d866d6f63b
 
-        @steps:
+        :steps:
 
-        1.  Check the override checkbox for the parameter.
-        2.  Enter some valid default value.
-        3.  Hide the default Value.
-        4.  Again update the default value.
-        5.  Submit the changes.
+            1.  Check the override checkbox for the parameter.
+            2.  Enter some valid default value.
+            3.  Hide the default Value.
+            4.  Again update the default value.
+            5.  Submit the changes.
 
-        @assert:
+        :assert:
 
-        1.  The parameter default value is updated.
-        2.  The parameter default value displayed as hidden.
+            1.  The parameter default value is updated.
+            2.  The parameter default value displayed as hidden.
 
-        @caseautomation: notautomated
+        :caseautomation: notautomated
         """
 
     @run_only_on('sat')
@@ -1325,25 +1279,25 @@ class SmartClassParametersTestCase(UITestCase):
     def test_positive_update_hidden_value_in_attribute(self):
         """Update the hidden default value of parameter in attribute.
 
-        @id: c10c20bd-0284-4e5d-b789-fddd3b81b81b
+        :id: c10c20bd-0284-4e5d-b789-fddd3b81b81b
 
-        @steps:
+        :steps:
 
-        1.  Check the override checkbox for the parameter.
-        2.  Enter some valid default value.
-        3.  Hide the default Value.
-        4.  Submit the changes.
-        5.  Associate parameter on host/hostgroup.
-        6.  In host/hostgroup, update the parameter value.
+            1.  Check the override checkbox for the parameter.
+            2.  Enter some valid default value.
+            3.  Hide the default Value.
+            4.  Submit the changes.
+            5.  Associate parameter on host/hostgroup.
+            6.  In host/hostgroup, update the parameter value.
 
-        @assert:
+        :assert:
 
-        1.  In host/hostgroup, the parameter value is updated.
-        2.  The parameter Value displayed as hidden.
-        3.  In parameter, new matcher created for fqdn/hostgroup.
-        4.  And the value shown hidden.
+            1.  In host/hostgroup, the parameter value is updated.
+            2.  The parameter Value displayed as hidden.
+            3.  In parameter, new matcher created for fqdn/hostgroup.
+            4.  And the value shown hidden.
 
-        @caseautomation: notautomated
+        :caseautomation: notautomated
         """
 
     @run_only_on('sat')
@@ -1352,22 +1306,22 @@ class SmartClassParametersTestCase(UITestCase):
     def test_positive_hide_empty_default_value(self):
         """Hiding the empty default value.
 
-        @id: 8b02e575-c7bf-45d1-a5eb-4640b65a4d60
+        :id: 8b02e575-c7bf-45d1-a5eb-4640b65a4d60
 
-        @steps:
+        :steps:
 
-        1.  Check the override checkbox for the parameter.
-        2.  Don't enter any value, keep blank.
-        3.  Check the 'Hidden Value' icon.
-        4.  Create a matcher with some value.
+            1.  Check the override checkbox for the parameter.
+            2.  Don't enter any value, keep blank.
+            3.  Check the 'Hidden Value' icon.
+            4.  Create a matcher with some value.
 
-        @assert:
+        :assert:
 
-        1.  The 'Hidden Value' checkbox is enabled to check.
-        2.  The default value shows empty on hide.
-        3.  Matcher Value shown as hidden.
+            1.  The 'Hidden Value' checkbox is enabled to check.
+            2.  The default value shows empty on hide.
+            3.  Matcher Value shown as hidden.
 
-        @caseautomation: notautomated
+        :caseautomation: notautomated
 
-        @CaseLevel: System
+        :CaseLevel: System
         """

--- a/tests/foreman/ui/test_computeprofile.py
+++ b/tests/foreman/ui/test_computeprofile.py
@@ -1,18 +1,18 @@
 """Test class for Compute Profile UI
 
-@Requirement: Computeprofile
+:Requirement: Computeprofile
 
-@CaseAutomation: Automated
+:CaseAutomation: Automated
 
-@CaseLevel: Acceptance
+:CaseLevel: Acceptance
 
-@CaseComponent: UI
+:CaseComponent: UI
 
-@TestType: Functional
+:TestType: Functional
 
-@CaseImportance: High
+:CaseImportance: High
 
-@Upstream: No
+:Upstream: No
 """
 
 from fauxfactory import gen_string
@@ -35,9 +35,9 @@ class ComputeProfileTestCase(UITestCase):
     def test_positive_create(self):
         """Create new Compute Profile using different names
 
-        @id: 138a3e6f-7eb5-4204-b48d-edc6ce363576
+        :id: 138a3e6f-7eb5-4204-b48d-edc6ce363576
 
-        @Assert: Compute Profile is created
+        :Assert: Compute Profile is created
         """
         with Session(self.browser) as session:
             for name in valid_data_list():
@@ -49,9 +49,9 @@ class ComputeProfileTestCase(UITestCase):
     def test_negative_create(self):
         """Attempt to create Compute Profile using invalid names only
 
-        @id: 6da73996-c235-45ee-a11e-5b4f0ae75d93
+        :id: 6da73996-c235-45ee-a11e-5b4f0ae75d93
 
-        @Assert: Compute Profile is not created
+        :Assert: Compute Profile is not created
         """
         with Session(self.browser) as session:
             for name in invalid_values_list('ui'):
@@ -64,9 +64,9 @@ class ComputeProfileTestCase(UITestCase):
     def test_positive_update(self):
         """Update selected Compute Profile entity using proper names
 
-        @id: b6dac9a4-8c5d-44d4-91e4-be2813e3ea50
+        :id: b6dac9a4-8c5d-44d4-91e4-be2813e3ea50
 
-        @Assert: Compute Profile is updated.
+        :Assert: Compute Profile is updated.
         """
         name = gen_string('alpha')
         with Session(self.browser) as session:
@@ -82,9 +82,9 @@ class ComputeProfileTestCase(UITestCase):
     def test_negative_update(self):
         """Attempt to update Compute Profile entity using invalid names only
 
-        @id: cf7d46c2-6edc-43be-b5d4-ba92f10b921b
+        :id: cf7d46c2-6edc-43be-b5d4-ba92f10b921b
 
-        @Assert: Compute Profile is not updated.
+        :Assert: Compute Profile is not updated.
         """
         name = gen_string('alpha')
         with Session(self.browser) as session:
@@ -100,9 +100,9 @@ class ComputeProfileTestCase(UITestCase):
     def test_positive_delete(self):
         """Delete Compute Profile entity
 
-        @id: 9029b8ec-44c3-4f41-9ea0-0c13c2add76c
+        :id: 9029b8ec-44c3-4f41-9ea0-0c13c2add76c
 
-        @Assert: Compute Profile is deleted successfully.
+        :Assert: Compute Profile is deleted successfully.
         """
         with Session(self.browser) as session:
             for name in generate_strings_list(length=7):

--- a/tests/foreman/ui/test_computeresource.py
+++ b/tests/foreman/ui/test_computeresource.py
@@ -1,19 +1,19 @@
 # -*- encoding: utf-8 -*-
 """Test for Compute Resource UI
 
-@Requirement: Computeresource
+:Requirement: Computeresource
 
-@CaseAutomation: Automated
+:CaseAutomation: Automated
 
-@CaseLevel: Acceptance
+:CaseLevel: Acceptance
 
-@CaseComponent: UI
+:CaseComponent: UI
 
-@TestType: Functional
+:TestType: Functional
 
-@CaseImportance: High
+:CaseImportance: High
 
-@Upstream: No
+:Upstream: No
 """
 from fauxfactory import gen_string
 from nailgun import entities
@@ -44,9 +44,9 @@ class ComputeResourceTestCase(UITestCase):
         """Create a new libvirt Compute Resource using different value
         types as a name
 
-        @id: 71307d6d-04be-431f-b8fc-81ea883b4f19
+        :id: 71307d6d-04be-431f-b8fc-81ea883b4f19
 
-        @Assert: A libvirt Compute Resource is created successfully
+        :Assert: A libvirt Compute Resource is created successfully
         """
         with Session(self.browser) as session:
             for name in valid_data_list():
@@ -66,9 +66,9 @@ class ComputeResourceTestCase(UITestCase):
     def test_positive_create_libvirt_with_description(self):
         """Create libvirt Compute Resource with description.
 
-        @id: 0ef00468-d6e6-449b-be3e-de95ba03a73b
+        :id: 0ef00468-d6e6-449b-be3e-de95ba03a73b
 
-        @Assert: A libvirt Compute Resource is created successfully
+        :Assert: A libvirt Compute Resource is created successfully
         """
         with Session(self.browser) as session:
             for description in valid_data_list():
@@ -90,9 +90,9 @@ class ComputeResourceTestCase(UITestCase):
     def test_positive_create_libvirt_with_display_type(self):
         """Create libvirt Compute Resource with different display types.
 
-        @id: 95e8cf49-8cb5-4c3b-9b21-8d33c51c9ac6
+        :id: 95e8cf49-8cb5-4c3b-9b21-8d33c51c9ac6
 
-        @Assert: A libvirt Compute Resource is created successfully
+        :Assert: A libvirt Compute Resource is created successfully
         """
         with Session(self.browser) as session:
             for display_type in 'VNC', 'SPICE':
@@ -115,9 +115,9 @@ class ComputeResourceTestCase(UITestCase):
         """Create libvirt Compute Resource with checked/unchecked
         console password checkbox
 
-        @id: 26726673-a467-47d5-b24a-4535b98b3e50
+        :id: 26726673-a467-47d5-b24a-4535b98b3e50
 
-        @Assert: A libvirt Compute Resource is created successfully
+        :Assert: A libvirt Compute Resource is created successfully
         """
         with Session(self.browser) as session:
             for console_password in True, False:
@@ -140,9 +140,9 @@ class ComputeResourceTestCase(UITestCase):
         """Create a new libvirt Compute Resource with incorrect values
         only
 
-        @id: 4d9be6b5-f9d4-402e-ad13-843335d83879
+        :id: 4d9be6b5-f9d4-402e-ad13-843335d83879
 
-        @Assert: A libvirt Compute Resource is not created
+        :Assert: A libvirt Compute Resource is not created
         """
         include_list = [' ']
         with Session(self.browser) as session:
@@ -167,9 +167,9 @@ class ComputeResourceTestCase(UITestCase):
     def test_positive_update_libvirt_name(self):
         """Update a libvirt Compute Resource name
 
-        @id: 508d34bd-491c-461d-b568-7063c68e971d
+        :id: 508d34bd-491c-461d-b568-7063c68e971d
 
-        @Assert: The libvirt Compute Resource is updated
+        :Assert: The libvirt Compute Resource is updated
         """
         with Session(self.browser) as session:
             for newname in valid_data_list():
@@ -192,9 +192,9 @@ class ComputeResourceTestCase(UITestCase):
     def test_positive_update_libvirt_organization(self):
         """Update a libvirt Compute Resource organization
 
-        @id: a1c3fd14-62e9-4e80-8ef7-bfa36420ce9b
+        :id: a1c3fd14-62e9-4e80-8ef7-bfa36420ce9b
 
-        @Assert: The libvirt Compute Resource is updated
+        :Assert: The libvirt Compute Resource is updated
         """
         name = gen_string('alpha')
         with Session(self.browser) as session:
@@ -219,9 +219,9 @@ class ComputeResourceTestCase(UITestCase):
     def test_positive_delete(self):
         """Delete a Compute Resource
 
-        @id: 2790e1c2-ecdc-4257-9912-49b50891aa1f
+        :id: 2790e1c2-ecdc-4257-9912-49b50891aa1f
 
-        @Assert: The Compute Resource is deleted
+        :Assert: The Compute Resource is deleted
         """
         with Session(self.browser) as session:
             for name in valid_data_list():
@@ -243,9 +243,9 @@ class ComputeResourceTestCase(UITestCase):
         """Try to access libvirt compute resource via compute profile
         (1-Small) screen
 
-        @id: 860b0036-24ab-49de-8d99-75243444df06
+        :id: 860b0036-24ab-49de-8d99-75243444df06
 
-        @Assert: The Compute Resource created and opened successfully
+        :Assert: The Compute Resource created and opened successfully
         """
         name = gen_string('alpha')
         with Session(self.browser) as session:

--- a/tests/foreman/ui/test_computeresource_azure.py
+++ b/tests/foreman/ui/test_computeresource_azure.py
@@ -1,16 +1,16 @@
 """Test for compute resource UI
 
-@Requirement: Computeresource
+:Requirement: Computeresource
 
-@CaseLevel: Acceptance
+:CaseLevel: Acceptance
 
-@CaseComponent: UI
+:CaseComponent: UI
 
-@TestType: Functional
+:TestType: Functional
 
-@CaseImportance: High
+:CaseImportance: High
 
-@Upstream: No
+:Upstream: No
 """
 
 from robottelo.decorators import run_only_on, stubbed, tier1, tier2, tier3
@@ -26,26 +26,26 @@ class AzureComputeResourceTestCase(UITestCase):
     def test_positive_create_azure_with_name(self):
         """Create a new azure compute resource with valid name.
 
-        @id: 477194a8-ac7e-4ab0-a59c-a45c0c2e9520
+        :id: 477194a8-ac7e-4ab0-a59c-a45c0c2e9520
 
-        @setup:
+        :setup:
 
-        1. Management certificates, two certificates are needed.
-        2. ".cer" file, which is uploaded to Azure.
-        3. ".pem" file, which is stored locally.
-        4. Subscription ID from azure.
+            1. Management certificates, two certificates are needed.
+            2. ".cer" file, which is uploaded to Azure.
+            3. ".pem" file, which is stored locally.
+            4. Subscription ID from azure.
 
-        @steps:
+        :steps:
 
-        1. Create a compute resource of type azure.
-        2. Provide a valid subscription ID and a path
-           to the ".pem" certificate.
-        3. Provide a valid name to azure compute resource.
-        4. Test the connection using "Test Connection" and submit.
+            1. Create a compute resource of type azure.
+            2. Provide a valid subscription ID and a path to the ".pem"
+                certificate.
+            3. Provide a valid name to azure compute resource.
+            4. Test the connection using "Test Connection" and submit.
 
-        @Assert: An azure compute resource is created successfully.
+        :Assert: An azure compute resource is created successfully.
 
-        @Caseautomation: notautomated
+        :Caseautomation: notautomated
         """
 
     @run_only_on('sat')
@@ -54,26 +54,26 @@ class AzureComputeResourceTestCase(UITestCase):
     def test_positive_create_azure_with_description(self):
         """Create azure compute resource with description.
 
-        @id: 40f62a58-3f8c-4c9d-b8df-582ed6bb4367
+        :id: 40f62a58-3f8c-4c9d-b8df-582ed6bb4367
 
-        @setup:
+        :setup:
 
-        1. Management certificates, two certificates are needed.
-        2. ".cer" file, which is uploaded to Azure.
-        3. ".pem" file, which is stored locally.
-        4. Subscription ID from azure.
+            1. Management certificates, two certificates are needed.
+            2. ".cer" file, which is uploaded to Azure.
+            3. ".pem" file, which is stored locally.
+            4. Subscription ID from azure.
 
-        @steps:
+        :steps:
 
-        1. Create a compute resource of type azure.
-        2. Provide a valid subscription ID and a path
-           to the ".pem" certificate.
-        3. Provide a valid description to azure compute resource.
-        4. Test the connection using "Test Connection" and submit.
+            1. Create a compute resource of type azure.
+            2. Provide a valid subscription ID and a path to the ".pem"
+                certificate.
+            3. Provide a valid description to azure compute resource.
+            4. Test the connection using "Test Connection" and submit.
 
-        @Assert: An azure compute resource is created successfully
+        :Assert: An azure compute resource is created successfully
 
-        @Caseautomation: notautomated
+        :Caseautomation: notautomated
         """
 
     @run_only_on('sat')
@@ -82,26 +82,26 @@ class AzureComputeResourceTestCase(UITestCase):
     def test_negative_create_azure_with_invalid_name(self):
         """Create a new azure compute resource with invalid names.
 
-        @id: 350edd6f-16fb-410e-a118-d9a3f496da3c
+        :id: 350edd6f-16fb-410e-a118-d9a3f496da3c
 
-        @setup:
+        :setup:
 
-        1. Management certificates, two certificates are needed.
-        2. ".cer" file, which is uploaded to Azure.
-        3. ".pem" file, which is stored locally.
-        4. Subscription ID from azure.
+            1. Management certificates, two certificates are needed.
+            2. ".cer" file, which is uploaded to Azure.
+            3. ".pem" file, which is stored locally.
+            4. Subscription ID from azure.
 
-        @steps:
+        :steps:
 
-        1. Create a compute resource of type azure.
-        2. Provide a valid subscription ID and a path
-           to the ".pem" certificate.
-        3. Provide a invalid name to azure compute resource.
-        4. Test the connection using "Test Connection" and submit.
+            1. Create a compute resource of type azure.
+            2. Provide a valid subscription ID and a path to the ".pem"
+                certificate.
+            3. Provide a invalid name to azure compute resource.
+            4. Test the connection using "Test Connection" and submit.
 
-        @Assert: An azure compute resource is not created
+        :Assert: An azure compute resource is not created
 
-        @Caseautomation: notautomated
+        :Caseautomation: notautomated
         """
 
     @run_only_on('sat')
@@ -110,27 +110,27 @@ class AzureComputeResourceTestCase(UITestCase):
     def test_positive_update_azure_name(self):
         """Update An azure compute resource name.
 
-        @id: 9bfcb0a8-9806-41de-8faf-3b7a40f05823
+        :id: 9bfcb0a8-9806-41de-8faf-3b7a40f05823
 
-        @setup:
+        :setup:
 
-        1. Management certificates, two certificates are needed.
-        2. ".cer" file, which is uploaded to Azure.
-        3. ".pem" file, which is stored locally.
-        4. Subscription ID from azure.
+            1. Management certificates, two certificates are needed.
+            2. ".cer" file, which is uploaded to Azure.
+            3. ".pem" file, which is stored locally.
+            4. Subscription ID from azure.
 
-        @steps:
+        :steps:
 
-        1. Create a compute resource of type azure.
-        2. Provide a valid subscription ID and a path
-           to the ".pem" certificate.
-        3. Provide a valid name to azure compute resource.
-        4. Test the connection using "Test Connection" and submit.
-        5. Update the name of the created CR with valid string.
+            1. Create a compute resource of type azure.
+            2. Provide a valid subscription ID and a path to the ".pem"
+                certificate.
+            3. Provide a valid name to azure compute resource.
+            4. Test the connection using "Test Connection" and submit.
+            5. Update the name of the created CR with valid string.
 
-        @Assert: The azure compute resource is updated
+        :Assert: The azure compute resource is updated
 
-        @Caseautomation: notautomated
+        :Caseautomation: notautomated
         """
 
     @run_only_on('sat')
@@ -139,28 +139,28 @@ class AzureComputeResourceTestCase(UITestCase):
     def test_positive_update_azure_organization(self):
         """Update An azure compute resource organization.
 
-        @id: 724546cf-185a-4d91-92f2-9ef078ab38cf
+        :id: 724546cf-185a-4d91-92f2-9ef078ab38cf
 
-        @setup:
+        :setup:
 
-        1. Management certificates, two certificates are needed.
-        2. ".cer" file, which is uploaded to Azure.
-        3. ".pem" file, which is stored locally.
-        4. Subscription ID from azure.
+            1. Management certificates, two certificates are needed.
+            2. ".cer" file, which is uploaded to Azure.
+            3. ".pem" file, which is stored locally.
+            4. Subscription ID from azure.
 
-        @steps:
+        :steps:
 
-        1. Create a compute resource of type azure.
-        2. Provide a valid subscription ID and a path
-           to the ".pem" certificate.
-        3. Provide a valid name to azure compute resource.
-        4. Test the connection using "Test Connection" and submit.
-        5. Create a new organization.
-        6. Add the CR to new organization.
+            1. Create a compute resource of type azure.
+            2. Provide a valid subscription ID and a path to the ".pem"
+                certificate.
+            3. Provide a valid name to azure compute resource.
+            4. Test the connection using "Test Connection" and submit.
+            5. Create a new organization.
+            6. Add the CR to new organization.
 
-        @Assert: The azure compute resource is updated
+        :Assert: The azure compute resource is updated
 
-        @Caseautomation: notautomated
+        :Caseautomation: notautomated
         """
 
     @run_only_on('sat')
@@ -169,27 +169,27 @@ class AzureComputeResourceTestCase(UITestCase):
     def test_positive_delete_azure(self):
         """Delete An azure compute resource.
 
-        @id: c9223ef6-00a7-4463-9f67-4f8cee3475c6
+        :id: c9223ef6-00a7-4463-9f67-4f8cee3475c6
 
-        @setup:
+        :setup:
 
-        1. Management certificates, two certificates are needed.
-        2. ".cer" file, which is uploaded to Azure.
-        3. ".pem" file, which is stored locally.
-        4. Subscription ID from azure.
+            1. Management certificates, two certificates are needed.
+            2. ".cer" file, which is uploaded to Azure.
+            3. ".pem" file, which is stored locally.
+            4. Subscription ID from azure.
 
-        @steps:
+        :steps:
 
-        1. Create a compute resource of type azure.
-        2. Provide a valid subscription ID and a path
-           to the ".pem" certificate.
-        3. Provide a valid name to azure compute resource.
-        4. Test the connection using "Test Connection" and submit.
-        5. Delete the created compute resource.
+            1. Create a compute resource of type azure.
+            2. Provide a valid subscription ID and a path to the ".pem"
+                certificate.
+            3. Provide a valid name to azure compute resource.
+            4. Test the connection using "Test Connection" and submit.
+            5. Delete the created compute resource.
 
-        @Assert: The compute resource is deleted
+        :Assert: The compute resource is deleted
 
-        @Caseautomation: notautomated
+        :Caseautomation: notautomated
         """
 
     @run_only_on('sat')
@@ -198,28 +198,28 @@ class AzureComputeResourceTestCase(UITestCase):
     def test_positive_add_image_azure_with_name(self):
         """Add images to the azure compute resource with valid name.
 
-        @id: 6cd42f2f-44cb-4e10-b5f9-bcc617b63cab
+        :id: 6cd42f2f-44cb-4e10-b5f9-bcc617b63cab
 
-        @setup:
+        :setup:
 
-        1. Management certificates, two certificates are needed
-        2. ".cer" file, which is uploaded to Azure.
-        3. ".pem" file, which is stored locally.
-        4. Subscription ID from azure.
-        5. Make sure Images available in azure region.
+            1. Management certificates, two certificates are needed
+            2. ".cer" file, which is uploaded to Azure.
+            3. ".pem" file, which is stored locally.
+            4. Subscription ID from azure.
+            5. Make sure Images available in azure region.
 
-        @steps:
+        :steps:
 
-        1. Create a compute resource of type azure.
-        2. Provide a valid subscription ID and a path
-           to the ".pem" certificate.
-        3. Select the created azure CR and click images tab.
-        4. Select "New image" , provide it valid name and information.
-        5. Select the desired template to create image and submit.
+            1. Create a compute resource of type azure.
+            2. Provide a valid subscription ID and a path to the ".pem"
+                certificate.
+            3. Select the created azure CR and click images tab.
+            4. Select "New image" , provide it valid name and information.
+            5. Select the desired template to create image and submit.
 
-        @Assert: The image is added to the CR successfully
+        :Assert: The image is added to the CR successfully
 
-        @Caseautomation: notautomated
+        :Caseautomation: notautomated
         """
 
     @run_only_on('sat')
@@ -228,28 +228,28 @@ class AzureComputeResourceTestCase(UITestCase):
     def test_negative_add_image_azure_with_invalid_name(self):
         """Add images to the azure compute resource with invalid name.
 
-        @id: 3cef6a33-e614-4571-a1ee-cf9b62dac764
+        :id: 3cef6a33-e614-4571-a1ee-cf9b62dac764
 
-        @setup:
+        :setup:
 
-        1. Management certificates, two certificates are needed
-        2. ".cer" file, which is uploaded to Azure.
-        3. ".pem" file, which is stored locally.
-        4. Subscription ID from azure.
-        5. Make sure Images available in azure region.
+            1. Management certificates, two certificates are needed
+            2. ".cer" file, which is uploaded to Azure.
+            3. ".pem" file, which is stored locally.
+            4. Subscription ID from azure.
+            5. Make sure Images available in azure region.
 
-        @steps:
+        :steps:
 
-        1. Create a compute resource of type azure.
-        2. Provide a valid subscription ID and a path
-           to the ".pem" certificate.
-        3. Select the created azure CR and click images tab.
-        4. Select "New image" , provide it invalid name.
-        5. Select the desired template to create the image from and submit.
+            1. Create a compute resource of type azure.
+            2. Provide a valid subscription ID and a path to the ".pem"
+                certificate.
+            3. Select the created azure CR and click images tab.
+            4. Select "New image" , provide it invalid name.
+            5. Select the desired template to create the image from and submit.
 
-        @Assert: The image should not be added to the CR
+        :Assert: The image should not be added to the CR
 
-        @Caseautomation: notautomated
+        :Caseautomation: notautomated
         """
 
     @run_only_on('sat')
@@ -258,23 +258,23 @@ class AzureComputeResourceTestCase(UITestCase):
     def test_positive_retrieve_azure_vm_list(self):
         """List the virtual machines from azure compute resource.
 
-        @id: 9e0b29f9-6873-4b10-931a-e2a54720f076
+        :id: 9e0b29f9-6873-4b10-931a-e2a54720f076
 
-        @setup:
+        :setup:
 
-        1. Management certificates, two certificates are needed
-        2. ".cer" file, which is uploaded to Azure.
-        3. ".pem" file, which is stored locally.
-        4. Subscription ID from azure.
+            1. Management certificates, two certificates are needed
+            2. ".cer" file, which is uploaded to Azure.
+            3. ".pem" file, which is stored locally.
+            4. Subscription ID from azure.
 
-        @steps:
+        :steps:
 
-        1. Select the created compute resource.
-        2. Go to "Virtual Machines" tab.
+            1. Select the created compute resource.
+            2. Go to "Virtual Machines" tab.
 
-        @Assert: The Virtual machines should be displayed
+        :Assert: The Virtual machines should be displayed
 
-        @Caseautomation: notautomated
+        :Caseautomation: notautomated
         """
 
     @run_only_on('sat')
@@ -284,23 +284,23 @@ class AzureComputeResourceTestCase(UITestCase):
         """ Provision a host on azure compute resource with
         the help of hostgroup.
 
-        @id: d3c2d0e3-8a3a-4f3c-9b7f-ce21c32a7347
+        :id: d3c2d0e3-8a3a-4f3c-9b7f-ce21c32a7347
 
-        @setup:
+        :setup:
 
-        1. Management certificates, two certificates are needed
-        2. ".cer" file, which is uploaded to Azure.
-        3. ".pem" file, which is stored locally.
-        4. Subscription ID from azure.
+            1. Management certificates, two certificates are needed
+            2. ".cer" file, which is uploaded to Azure.
+            3. ".pem" file, which is stored locally.
+            4. Subscription ID from azure.
 
-        @steps:
+        :steps:
 
-        1. Go to "Hosts --> New host".
-        2. Assign the host group to the host.
-        3. Select the Deploy on as azure compute resource.
-        4. Provision the host.
+            1. Go to "Hosts --> New host".
+            2. Assign the host group to the host.
+            3. Select the Deploy on as azure compute resource.
+            4. Provision the host.
 
-        @Assert: The host should be provisioned with host group
+        :Assert: The host should be provisioned with host group
 
-        @Caseautomation: notautomated
+        :Caseautomation: notautomated
         """

--- a/tests/foreman/ui/test_computeresource_openstack.py
+++ b/tests/foreman/ui/test_computeresource_openstack.py
@@ -1,16 +1,16 @@
 """Test for compute resource UI
 
-@Requirement: Computeresource
+:Requirement: Computeresource
 
-@CaseLevel: Acceptance
+:CaseLevel: Acceptance
 
-@CaseComponent: UI
+:CaseComponent: UI
 
-@TestType: Functional
+:TestType: Functional
 
-@CaseImportance: High
+:CaseImportance: High
 
-@Upstream: No
+:Upstream: No
 """
 
 from robottelo.decorators import run_only_on, stubbed, tier1, tier2, tier3
@@ -26,20 +26,19 @@ class OpenstackComputeResourceTestCase(UITestCase):
     def test_positive_create_openstack_with_name(self):
         """Create a new openstack compute resource with valid name
 
-        @id: 17f8e903-c2db-4580-8162-0706da6c6368
+        :id: 17f8e903-c2db-4580-8162-0706da6c6368
 
-        @setup: openstack hostname and credentials.
+        :setup: openstack hostname and credentials.
 
-        @steps:
+        :steps:
+            1. Create a compute resource of type openstack.
+            2. Provide a valid hostname, username and password.
+            3. Provide a valid name to openstack compute resource.
+            4. Test the connection using Load Tenants and submit.
 
-        1. Create a compute resource of type openstack.
-        2. Provide a valid hostname, username and password.
-        3. Provide a valid name to openstack compute resource.
-        4. Test the connection using Load Tenants and submit.
+        :Assert: An openstack compute resource is created successfully.
 
-        @Assert: An openstack compute resource is created successfully.
-
-        @Caseautomation: notautomated
+        :Caseautomation: notautomated
         """
 
     @run_only_on('sat')
@@ -48,20 +47,19 @@ class OpenstackComputeResourceTestCase(UITestCase):
     def test_positive_create_openstack_with_description(self):
         """Create openstack compute resource with description.
 
-        @id: 8373b79a-bffc-409b-95fe-0bb170536c5b
+        :id: 8373b79a-bffc-409b-95fe-0bb170536c5b
 
-        @setup: openstack hostname and credentials.
+        :setup: openstack hostname and credentials.
 
-        @steps:
+        :steps:
+            1. Create a compute resource of type openstack.
+            2. Provide a valid hostname, username and password.
+            3. Provide a valid description to openstack compute resource.
+            4. Test the connection using Load Tenants and submit.
 
-        1. Create a compute resource of type openstack.
-        2. Provide a valid hostname, username and password.
-        3. Provide a valid description to openstack compute resource.
-        4. Test the connection using Load Tenants and submit.
+        :Assert: An openstack compute resource is created successfully
 
-        @Assert: An openstack compute resource is created successfully
-
-        @Caseautomation: notautomated
+        :Caseautomation: notautomated
         """
 
     @run_only_on('sat')
@@ -70,20 +68,20 @@ class OpenstackComputeResourceTestCase(UITestCase):
     def test_negative_create_openstack_with_invalid_name(self):
         """Create a new openstack compute resource with invalid names.
 
-        @id: aa0cf21d-40a2-4478-9ab5-8e18db7fb8c0
+        :id: aa0cf21d-40a2-4478-9ab5-8e18db7fb8c0
 
-        @setup: openstack hostname and credentials.
+        :setup: openstack hostname and credentials.
 
-        @steps:
+        :steps:
 
-        1. Create a compute resource of type openstack.
-        2. Provide a valid hostname, username and password.
-        3. Provide a invalid name to openstack compute resource.
-        4. Test the connection using Load Tenants and submit.
+            1. Create a compute resource of type openstack.
+            2. Provide a valid hostname, username and password.
+            3. Provide a invalid name to openstack compute resource.
+            4. Test the connection using Load Tenants and submit.
 
-        @Assert: An openstack compute resource is not created
+        :Assert: An openstack compute resource is not created
 
-        @Caseautomation: notautomated
+        :Caseautomation: notautomated
         """
 
     @run_only_on('sat')
@@ -92,21 +90,21 @@ class OpenstackComputeResourceTestCase(UITestCase):
     def test_positive_update_openstack_name(self):
         """Update An openstack compute resource name
 
-        @id: 27b475dc-bec8-4b25-a67a-0bdba4d086c9
+        :id: 27b475dc-bec8-4b25-a67a-0bdba4d086c9
 
-        @setup: openstack hostname and credentials.
+        :setup: openstack hostname and credentials.
 
-        @steps:
+        :steps:
 
-        1. Create a compute resource of type openstack.
-        2. Provide a valid hostname, username and password.
-        3. Provide a valid name to openstack compute resource.
-        4. Test the connection using Load Tenants and submit.
-        5. Update the name of the created CR with valid string.
+            1. Create a compute resource of type openstack.
+            2. Provide a valid hostname, username and password.
+            3. Provide a valid name to openstack compute resource.
+            4. Test the connection using Load Tenants and submit.
+            5. Update the name of the created CR with valid string.
 
-        @Assert: The openstack compute resource is updated
+        :Assert: The openstack compute resource is updated
 
-        @Caseautomation: notautomated
+        :Caseautomation: notautomated
         """
 
     @run_only_on('sat')
@@ -115,22 +113,22 @@ class OpenstackComputeResourceTestCase(UITestCase):
     def test_positive_update_openstack_organization(self):
         """Update An openstack compute resource organization
 
-        @id: 571119e2-cac2-4d05-8e70-c258242bda98
+        :id: 571119e2-cac2-4d05-8e70-c258242bda98
 
-        @setup: openstack hostname and credentials.
+        :setup: openstack hostname and credentials.
 
-        @steps:
+        :steps:
 
-        1. Create a compute resource of type openstack.
-        2. Provide a valid hostname, username and password.
-        3. Provide a valid name to openstack compute resource.
-        4. Test the connection using Load Tenants and submit.
-        5. Create a new organization.
-        6. Add the CR to new organization.
+            1. Create a compute resource of type openstack.
+            2. Provide a valid hostname, username and password.
+            3. Provide a valid name to openstack compute resource.
+            4. Test the connection using Load Tenants and submit.
+            5. Create a new organization.
+            6. Add the CR to new organization.
 
-        @Assert: The openstack compute resource is updated
+        :Assert: The openstack compute resource is updated
 
-        @Caseautomation: notautomated
+        :Caseautomation: notautomated
         """
 
     @run_only_on('sat')
@@ -139,21 +137,21 @@ class OpenstackComputeResourceTestCase(UITestCase):
     def test_positive_delete_openstack(self):
         """Delete An openstack compute resource
 
-        @id: 9336c44a-81d3-4132-96b7-013aad45ba67
+        :id: 9336c44a-81d3-4132-96b7-013aad45ba67
 
-        @setup: openstack hostname and credentials.
+        :setup: openstack hostname and credentials.
 
-        @steps:
+        :steps:
 
-        1. Create a compute resource of type openstack.
-        2. Provide a valid hostname, username and password.
-        3. Provide a valid name to openstack compute resource.
-        4. Test the connection using Load Tenants and submit.
-        5. Delete the created compute resource.
+            1. Create a compute resource of type openstack.
+            2. Provide a valid hostname, username and password.
+            3. Provide a valid name to openstack compute resource.
+            4. Test the connection using Load Tenants and submit.
+            5. Delete the created compute resource.
 
-        @Assert: The compute resource is deleted
+        :Assert: The compute resource is deleted
 
-        @Caseautomation: notautomated
+        :Caseautomation: notautomated
         """
 
     @run_only_on('sat')
@@ -162,21 +160,21 @@ class OpenstackComputeResourceTestCase(UITestCase):
     def test_positive_add_image_openstack_with_name(self):
         """Add images to the openstack compute resource with valid name.
 
-        @id: bbd49aa3-97d6-4d8f-8caa-1e2660afa6ee
+        :id: bbd49aa3-97d6-4d8f-8caa-1e2660afa6ee
 
-        @setup: openstack hostname, credentials and images in openstack.
+        :setup: openstack hostname, credentials and images in openstack.
 
-        @steps:
+        :steps:
 
-        1. Create a compute resource of type openstack.
-        2. Provide a valid hostname, username and password.
-        3. Select the created openstack CR and click images tab.
-        4. Select "New image" , provide it valid name and information.
-        5. Select the desired template to create image and submit.
+            1. Create a compute resource of type openstack.
+            2. Provide a valid hostname, username and password.
+            3. Select the created openstack CR and click images tab.
+            4. Select "New image" , provide it valid name and information.
+            5. Select the desired template to create image and submit.
 
-        @Assert: The image is added to the CR successfully
+        :Assert: The image is added to the CR successfully
 
-        @Caseautomation: notautomated
+        :Caseautomation: notautomated
          """
 
     @run_only_on('sat')
@@ -185,44 +183,45 @@ class OpenstackComputeResourceTestCase(UITestCase):
     def test_negative_add_image_openstack_with_invalid_name(self):
         """Add images to the openstack compute resource with invalid name.
 
-        @id: e2e5989b-b033-4691-b91c-adba1c88af28
+        :id: e2e5989b-b033-4691-b91c-adba1c88af28
 
-        @setup: openstack hostname, credentials and images in openstack.
+        :setup: openstack hostname, credentials and images in openstack.
 
-        @steps:
+        :steps:
 
-        1. Create a compute resource of type openstack.
-        2. Provide a valid hostname, username and password.
-        3. Select the created openstack CR and click images tab.
-        4. Select "New image" , provide it invalid name.
-        5. Select the desired template to create the image from and submit.
+            1. Create a compute resource of type openstack.
+            2. Provide a valid hostname, username and password.
+            3. Select the created openstack CR and click images tab.
+            4. Select "New image" , provide it invalid name.
+            5. Select the desired template to create the image from and submit.
 
-        @Assert: The image should not be added to the CR
+        :Assert: The image should not be added to the CR
 
-        @Caseautomation: notautomated
+        :Caseautomation: notautomated
         """
 
     @run_only_on('sat')
     @stubbed()
     @tier2
     def test_positive_access_openstack_with_default_profile(self):
-        """Associate default (3-Large) compute profile to openstack compute resource
+        """Associate default (3-Large) compute profile to openstack compute
+        resource
 
-        @id: 5706bf0a-b052-47eb-8129-559d8fd3238b
+        :id: 5706bf0a-b052-47eb-8129-559d8fd3238b
 
-        @setup: openstack hostname, credentials, and flavor.
+        :setup: openstack hostname, credentials, and flavor.
 
-        @steps:
+        :steps:
 
-        1. Create a compute resource of type openstack.
-        2. Provide a valid hostname, username and password.
-        3. Select the created openstack CR.
-        4. Click Compute Profile tab.
-        5. Select (3-Large) and submit.
+            1. Create a compute resource of type openstack.
+            2. Provide a valid hostname, username and password.
+            3. Select the created openstack CR.
+            4. Click Compute Profile tab.
+            5. Select (3-Large) and submit.
 
-        @Assert: The compute resource created and opened successfully
+        :Assert: The compute resource created and opened successfully
 
-        @Caseautomation: notautomated
+        :Caseautomation: notautomated
         """
 
     @run_only_on('sat')
@@ -231,21 +230,21 @@ class OpenstackComputeResourceTestCase(UITestCase):
     def test_positive_access_openstack_with_custom_profile(self):
         """Associate custom (3-Large) compute profile to openstack compute resource
 
-        @id: 253e9639-128d-4b3e-a3b7-f5287c58550e
+        :id: 253e9639-128d-4b3e-a3b7-f5287c58550e
 
-        @setup: openstack hostname and credentials, custom flavor.
+        :setup: openstack hostname and credentials, custom flavor.
 
-        @steps:
+        :steps:
 
-        1. Create a compute resource of type openstack.
-        2. Provide a valid hostname, username and password.
-        3. Select the created openstack CR.
-        4. Click Compute Profile tab.
-        5. Edit (3-Large) with valid configurations and submit.
+            1. Create a compute resource of type openstack.
+            2. Provide a valid hostname, username and password.
+            3. Select the created openstack CR.
+            4. Click Compute Profile tab.
+            5. Edit (3-Large) with valid configurations and submit.
 
-        @Assert: The compute resource created and opened successfully
+        :Assert: The compute resource created and opened successfully
 
-        @Caseautomation: notautomated
+        :Caseautomation: notautomated
         """
 
     @run_only_on('sat')
@@ -254,18 +253,18 @@ class OpenstackComputeResourceTestCase(UITestCase):
     def test_positive_retrieve_openstack_vm_list(self):
         """List the virtual machines from openstack compute resource.
 
-        @id: c04cdd6b-5ecc-4103-8410-57b73240aeb5
+        :id: c04cdd6b-5ecc-4103-8410-57b73240aeb5
 
-        @setup: openstack hostname and credentials.
+        :setup: openstack hostname and credentials.
 
-        @steps:
+        :steps:
 
-        1. Select the created compute resource.
-        2. Go to "Virtual Machines" tab.
+            1. Select the created compute resource.
+            2. Go to "Virtual Machines" tab.
 
-        @Assert: The Virtual machines should be displayed
+        :Assert: The Virtual machines should be displayed
 
-        @Caseautomation: notautomated
+        :Caseautomation: notautomated
         """
 
     @run_only_on('sat')
@@ -274,32 +273,30 @@ class OpenstackComputeResourceTestCase(UITestCase):
     def test_positive_provision_openstack_host_with_image(self):
         """ Provision a host on openstack compute resource with image based
 
-        @id: b3dff8c1-e613-4914-82c1-e2ee36108a19
+        :id: b3dff8c1-e613-4914-82c1-e2ee36108a19
 
-        @setup: openstack hostname and credentials.
+        :setup: openstack hostname and credentials.
+            1. The addition of foreman-proxy-dns-reverse subnets.
+            2. The addition of foreman-proxy-dns-zone domain.
+            3. Addition of custom provisioning template
+            to add ssh-key parameter.
 
-        1. The addition of foreman-proxy-dns-reverse subnets.
-        2. The addition of foreman-proxy-dns-zone domain.
-        3. Addition of custom provisioning template
-           to add ssh-key parameter.
+        :steps:
+            1. Populate images into satellite from openstack images.
+            2. Associate Activation key and CV to the host.
+            3. Edit the required Operating system to use the custom
+               provisioning template.
+            4. Go to "Hosts --> New host".
+            5. Fill in the required details.(eg name,loc, org)(hostgroup)
+            6. Select openstack compute resource from "Deploy on" drop down.
+            7. Associate appropriate feature capsules.
+            8. Go to "operating system tab".
+            9. Select the appropriate image .
+            10. Associate the activation key and submit.
 
-        @steps:
+        :Assert: The host should be provisioned successfully
 
-        1. Populate images into satellite from openstack images.
-        2. Associate Activation key and CV to the host.
-        3. Edit the required Operating system to
-           use the custom provisioning template.
-        4. Go to "Hosts --> New host".
-        5. Fill in the required details.(eg name,loc, org)(hostgroup)
-        6. Select openstack compute resource from "Deploy on" drop down.
-        7. Associate appropriate feature capsules.
-        8. Go to "operating system tab".
-        9. Select the appropriate image .
-        10. Associate the activation key and submit.
-
-        @Assert: The host should be provisioned successfully
-
-        @Caseautomation: notautomated
+        :Caseautomation: notautomated
         """
 
     @run_only_on('sat')
@@ -309,21 +306,20 @@ class OpenstackComputeResourceTestCase(UITestCase):
         """ Provision a host on openstack compute resource with compute profile
         default (3-Large)
 
-        @id: b1e1ad3e-9ad2-45c6-b8dd-4f39ce7729ca
+        :id: b1e1ad3e-9ad2-45c6-b8dd-4f39ce7729ca
 
-        @setup: openstack hostname ,credentials and provisioning setup.
+        :setup: openstack hostname ,credentials and provisioning setup.
 
-        @steps:
+        :steps:
+            1. Go to "Hosts --> New host".
+            2. Fill in the required details.(eg name,loc, org).
+            3. Select openstack compute resource from "Deploy on" drop down.
+            4. Select the "Compute profile" from the drop down.
+            5. Provision the host using the compute profile.
 
-        1. Go to "Hosts --> New host".
-        2. Fill in the required details.(eg name,loc, org).
-        3. Select openstack compute resource from "Deploy on" drop down.
-        4. Select the "Compute profile" from the drop down.
-        5. Provision the host using the compute profile.
+        :Assert: The host should be provisioned successfully
 
-        @Assert: The host should be provisioned successfully
-
-        @Caseautomation: notautomated
+        :Caseautomation: notautomated
         """
 
     @run_only_on('sat')
@@ -333,21 +329,22 @@ class OpenstackComputeResourceTestCase(UITestCase):
         """ Provision a host on openstack compute resource with
          custom flavour and disk.
 
-        @id: 52c53d90-8eaa-47dd-8c44-6c03293cf64c
+        :id: 52c53d90-8eaa-47dd-8c44-6c03293cf64c
 
-        @setup: openstack hostname ,credentials and provisioning setup.
+        :setup: openstack hostname ,credentials and provisioning setup.
 
-        @steps:
+        :steps:
+            1. Go to "Hosts --> New host".
+            2. Fill in the required details.(eg name,loc, org).
+            3. Select openstack custom compute resource from "Deploy on" drop
+               down.
+            4. Select the custom compute profile" with custom disk size and
+               flavor.
+            5. Provision the host using the compute profile.
 
-        1. Go to "Hosts --> New host".
-        2. Fill in the required details.(eg name,loc, org).
-        3. Select openstack custom compute resource from "Deploy on" drop down.
-        4. Select the custom compute profile" with custom disk size and flavor.
-        5. Provision the host using the compute profile.
+        :Assert: The host should be provisioned with custom settings
 
-        @Assert: The host should be provisioned with custom settings
-
-        @Caseautomation: notautomated
+        :Caseautomation: notautomated
         """
 
     @run_only_on('sat')
@@ -357,19 +354,18 @@ class OpenstackComputeResourceTestCase(UITestCase):
         """ Provision a host on openstack compute resource with
         the help of hostgroup.
 
-        @id: a3fecc66-0162-4b92-8341-14d255adc118
+        :id: a3fecc66-0162-4b92-8341-14d255adc118
 
-        @setup: openstack hostname ,credentials, provisioning
-        setup and hostgroup for openstack.
+        :setup: openstack hostname ,credentials, provisioning setup and
+            hostgroup for openstack.
 
-        @steps:
+        :steps:
+            1. Go to "Hosts --> New host".
+            2. Assign the host group to the host.
+            3. Select the Deploy on as openstack compute resource.
+            4. Provision the host.
 
-        1. Go to "Hosts --> New host".
-        2. Assign the host group to the host.
-        3. Select the Deploy on as openstack compute resource.
-        4. Provision the host.
+        :Assert: The host should be provisioned with host group
 
-        @Assert: The host should be provisioned with host group
-
-        @Caseautomation: notautomated
+        :Caseautomation: notautomated
         """

--- a/tests/foreman/ui/test_computeresource_rhev.py
+++ b/tests/foreman/ui/test_computeresource_rhev.py
@@ -1,16 +1,16 @@
 """Test for Compute Resource UI
 
-@Requirement: Computeresource
+:Requirement: Computeresource
 
-@CaseLevel: Acceptance
+:CaseLevel: Acceptance
 
-@CaseComponent: UI
+:CaseComponent: UI
 
-@TestType: Functional
+:TestType: Functional
 
-@CaseImportance: High
+:CaseImportance: High
 
-@Upstream: No
+:Upstream: No
 """
 
 from fauxfactory import gen_string
@@ -57,20 +57,20 @@ class RhevComputeResourceTestCase(UITestCase):
         """Create a new rhev Compute Resource using different value
         types as a name
 
-        @id: be735d8c-5644-4a42-9a08-2f9c6181a8c6
+        :id: be735d8c-5644-4a42-9a08-2f9c6181a8c6
 
-        @setup: rhev hostname and credentials.
+        :setup: rhev hostname and credentials.
 
-        @steps:
+        :steps:
 
-        1. Create a compute resource of type rhev.
-        2. Provide it with the valid hostname, username and password.
-        3. Provide a valid name to rhev Compute Resource.
-        4. Test the connection using Load Datacenter and submit.
+            1. Create a compute resource of type rhev.
+            2. Provide it with the valid hostname, username and password.
+            3. Provide a valid name to rhev Compute Resource.
+            4. Test the connection using Load Datacenter and submit.
 
-        @CaseAutomation: Automated
+        :CaseAutomation: Automated
 
-        @Assert: A rhev CR is created successfully with proper connection.
+        :Assert: A rhev CR is created successfully with proper connection.
         """
         parameter_list = [
             ['URL', self.rhev_url, 'field'],
@@ -94,20 +94,20 @@ class RhevComputeResourceTestCase(UITestCase):
     def test_positive_create_rhev_with_description(self):
         """Create rhev Compute Resource with description.
 
-        @id: bd5e3066-395c-486e-bce8-b0a9bdd4e236
+        :id: bd5e3066-395c-486e-bce8-b0a9bdd4e236
 
-        @setup: rhev hostname and credentials.
+        :setup: rhev hostname and credentials.
 
-        @steps:
+        :steps:
 
-        1. Create a compute resource of type rhev.
-        2. Provide it with the valid hostname, username and password.
-        3. Provide it with some valid description to rhev Compute Resource.
-        4. Test the connection using Load Datacenter and submit.
+            1. Create a compute resource of type rhev.
+            2. Provide it with the valid hostname, username and password.
+            3. Provide it with some valid description to rhev Compute Resource.
+            4. Test the connection using Load Datacenter and submit.
 
-        @CaseAutomation: Automated
+        :CaseAutomation: Automated
 
-        @Assert: A rhev Compute Resource is created successfully
+        :Assert: A rhev Compute Resource is created successfully
         """
         parameter_list = [
             ['URL', self.rhev_url, 'field'],
@@ -133,20 +133,20 @@ class RhevComputeResourceTestCase(UITestCase):
         """Create a new rhev Compute Resource with incorrect values
         only
 
-        @id: 5598b123-b6ad-4bdf-b192-2b1ccc2f41eb
+        :id: 5598b123-b6ad-4bdf-b192-2b1ccc2f41eb
 
-        @setup: rhev hostname and credentials.
+        :setup: rhev hostname and credentials.
 
-        @steps:
+        :steps:
 
-        1. Create a compute resource of type rhev.
-        2. Provide it with the valid hostname, username and password.
-        3. Provide a invalid name to rhev Compute Resource.
-        4. Test the connection using Load Datacenter and submit.
+            1. Create a compute resource of type rhev.
+            2. Provide it with the valid hostname, username and password.
+            3. Provide a invalid name to rhev Compute Resource.
+            4. Test the connection using Load Datacenter and submit.
 
-        @CaseAutomation: Automated
+        :CaseAutomation: Automated
 
-        @Assert: A rhev Compute Resource is not created
+        :Assert: A rhev Compute Resource is not created
         """
         parameter_list = [
             ['URL', self.rhev_url, 'field'],
@@ -174,21 +174,21 @@ class RhevComputeResourceTestCase(UITestCase):
     def test_positive_update_rhev_name(self):
         """Update a rhev Compute Resource name
 
-        @id: 62d0c495-c87e-42dd-91aa-9b9b728f7dda
+        :id: 62d0c495-c87e-42dd-91aa-9b9b728f7dda
 
-        @setup: rhev hostname and credentials.
+        :setup: rhev hostname and credentials.
 
-        @steps:
+        :steps:
 
-        1. Create a compute resource of type rhev.
-        2. Provide it with the valid hostname, username and password.
-        3. Provide a valid name to rhev Compute Resource.
-        4. Test the connection using Load Datacenter and submit.
-        5. Update the name of the created CR with valid string.
+            1. Create a compute resource of type rhev.
+            2. Provide it with the valid hostname, username and password.
+            3. Provide a valid name to rhev Compute Resource.
+            4. Test the connection using Load Datacenter and submit.
+            5. Update the name of the created CR with valid string.
 
-        @CaseAutomation: Automated
+        :CaseAutomation: Automated
 
-        @Assert: The rhev Compute Resource is updated
+        :Assert: The rhev Compute Resource is updated
         """
         parameter_list = [
             ['URL', self.rhev_url, 'field'],
@@ -215,22 +215,22 @@ class RhevComputeResourceTestCase(UITestCase):
     def test_positive_update_rhev_organization(self):
         """Update a rhev Compute Resource organization
 
-        @id: f6656c8e-70a3-40e5-8dda-2154f2eeb042
+        :id: f6656c8e-70a3-40e5-8dda-2154f2eeb042
 
-        @setup: rhev hostname and credentials.
+        :setup: rhev hostname and credentials.
 
-        @steps:
+        :steps:
 
-        1. Create a compute resource of type rhev.
-        2. Provide it with the valid hostname, username and password.
-        3. Provide a valid name to rhev Compute Resource.
-        4. Test the connection using Load Datacenter and submit.
-        5. Create a new organization.
-        6. Add the new CR to organization that is created.
+            1. Create a compute resource of type rhev.
+            2. Provide it with the valid hostname, username and password.
+            3. Provide a valid name to rhev Compute Resource.
+            4. Test the connection using Load Datacenter and submit.
+            5. Create a new organization.
+            6. Add the new CR to organization that is created.
 
-        @CaseAutomation: Automated
+        :CaseAutomation: Automated
 
-        @Assert: The rhev Compute Resource is updated
+        :Assert: The rhev Compute Resource is updated
         """
         parameter_list = [
             ['URL', self.rhev_url, 'field'],
@@ -260,21 +260,21 @@ class RhevComputeResourceTestCase(UITestCase):
     def test_positive_delete_rhev(self):
         """Delete a rhev Compute Resource
 
-        @id: 4a8b18f0-a2af-491a-bcf7-64d59a0fbc01
+        :id: 4a8b18f0-a2af-491a-bcf7-64d59a0fbc01
 
-        @setup: rhev hostname and credentials.
+        :setup: rhev hostname and credentials.
 
-        @steps:
+        :steps:
 
-        1. Create a compute resource of type rhev.
-        2. Provide it with the valid hostname, username and password.
-        3. Provide a valid name to rhev Compute Resource.
-        4. Test the connection using Load Datacenter and submit.
-        5. Delete the created compute resource.
+            1. Create a compute resource of type rhev.
+            2. Provide it with the valid hostname, username and password.
+            3. Provide a valid name to rhev Compute Resource.
+            4. Test the connection using Load Datacenter and submit.
+            5. Delete the created compute resource.
 
-        @CaseAutomation: Automated
+        :CaseAutomation: Automated
 
-        @Assert: The Compute Resource is deleted
+        :Assert: The Compute Resource is deleted
         """
         parameter_list = [
             ['URL', self.rhev_url, 'field'],
@@ -299,21 +299,21 @@ class RhevComputeResourceTestCase(UITestCase):
     def test_positive_add_image_rhev_with_name(self):
         """Add images to the rhev compute resource
 
-        @id: 6c7f4169-2e78-44d6-87af-434146093bcc
+        :id: 6c7f4169-2e78-44d6-87af-434146093bcc
 
-        @setup: rhev hostname, credentials and images as templates in rhev.
+        :setup: rhev hostname, credentials and images as templates in rhev.
 
-        @steps:
+        :steps:
 
-        1. Create a compute resource of type rhev.
-        2. Provide it with the valid hostname, username and password.
-        3. Select the created rhev CR and click images tab.
-        4. Select "New image" , provide it valid name and information.
-        5. Select the desired template to create image and submit.
+            1. Create a compute resource of type rhev.
+            2. Provide it with the valid hostname, username and password.
+            3. Select the created rhev CR and click images tab.
+            4. Select "New image" , provide it valid name and information.
+            5. Select the desired template to create image and submit.
 
-        @CaseAutomation: Automated
+        :CaseAutomation: Automated
 
-        @Assert: The image is added to the CR successfully
+        :Assert: The image is added to the CR successfully
          """
         parameter_list = [
             ['URL', self.rhev_url, 'field'],
@@ -349,21 +349,22 @@ class RhevComputeResourceTestCase(UITestCase):
     def test_negative_add_image_rhev_with_invalid_name(self):
         """Add images to the rhev compute resource
 
-        @id: 0054b389-1e2f-44d9-a306-0410fc0b9d99
+        :id: 0054b389-1e2f-44d9-a306-0410fc0b9d99
 
-        @setup: rhev hostname, credentials and images as templates in rhev.
+        :setup: rhev hostname, credentials and images as templates in rhev.
 
-        @steps:
+        :steps:
 
-        1. Create a compute resource of type rhev.
-        2. Provide it with the valid hostname, username and password.
-        3. Select the created rhev CR and click images tab.
-        4. Select "New image" , provide it invalid name and valid information.
-        5. Select the desired template to create the image from and submit.
+            1. Create a compute resource of type rhev.
+            2. Provide it with the valid hostname, username and password.
+            3. Select the created rhev CR and click images tab.
+            4. Select "New image", provide it invalid name and valid
+               information.
+            5. Select the desired template to create the image from and submit.
 
-        @CaseAutomation: Automated
+        :CaseAutomation: Automated
 
-        @Assert: The image should not be added to the CR
+        :Assert: The image should not be added to the CR
         """
         parameter_list = [
             ['URL', self.rhev_url, 'field'],
@@ -400,21 +401,21 @@ class RhevComputeResourceTestCase(UITestCase):
     def test_positive_access_rhev_with_default_profile(self):
         """Associate default (3-Large) compute profile to rhev compute resource
 
-        @id: 7049227e-f384-4aa1-8a01-228c3e7292a6
+        :id: 7049227e-f384-4aa1-8a01-228c3e7292a6
 
-        @setup: rhev hostname and credentials.
+        :setup: rhev hostname and credentials.
 
-        @steps:
+        :steps:
 
-        1. Create a compute resource of type rhev.
-        2. Provide it with the valid hostname, username and password.
-        3. Select the created rhev CR.
-        4. Click Compute Profile tab.
-        5. Select (3-Large) and submit.
+            1. Create a compute resource of type rhev.
+            2. Provide it with the valid hostname, username and password.
+            3. Select the created rhev CR.
+            4. Click Compute Profile tab.
+            5. Select (3-Large) and submit.
 
-        @CaseAutomation: Automated
+        :CaseAutomation: Automated
 
-        @Assert: The Compute Resource created and opened successfully
+        :Assert: The Compute Resource created and opened successfully
         """
         parameter_list = [
             ['URL', self.rhev_url, 'field'],
@@ -439,21 +440,21 @@ class RhevComputeResourceTestCase(UITestCase):
     def test_positive_access_rhev_with_custom_profile(self):
         """Associate custom default (3-Large) compute profile to rhev compute resource
 
-        @id: e7698154-62ff-492b-8e56-c5dc70f0c9df
+        :id: e7698154-62ff-492b-8e56-c5dc70f0c9df
 
-        @setup: rhev hostname and credentials.
+        :setup: rhev hostname and credentials.
 
-        @steps:
+        :steps:
 
-        1. Create a compute resource of type rhev.
-        2. Provide it with the valid hostname, username and password.
-        3. Select the created rhev CR.
-        4. Click Compute Profile tab.
-        5. Edit (3-Large) with valid configurations and submit.
+            1. Create a compute resource of type rhev.
+            2. Provide it with the valid hostname, username and password.
+            3. Select the created rhev CR.
+            4. Click Compute Profile tab.
+            5. Edit (3-Large) with valid configurations and submit.
 
-        @Assert: The Compute Resource created and opened successfully
+        :Assert: The Compute Resource created and opened successfully
 
-        @Caseautomation: notautomated
+        :Caseautomation: notautomated
         """
 
     @run_only_on('sat')
@@ -461,18 +462,18 @@ class RhevComputeResourceTestCase(UITestCase):
     def test_positive_retrieve_rhev_vm_list(self):
         """Retrieve the Virtual machine list from rhev compute resource
 
-        @id: f8cef7fb-e14c-4d12-9862-0e448a59ca50
+        :id: f8cef7fb-e14c-4d12-9862-0e448a59ca50
 
-        @setup: rhev hostname and credentials.
+        :setup: rhev hostname and credentials.
 
-        @steps:
+        :steps:
 
-        1. Select the created compute resource.
-        2. Go to "Virtual Machines" tab.
+            1. Select the created compute resource.
+            2. Go to "Virtual Machines" tab.
 
-        @CaseAutomation: Automated
+        :CaseAutomation: Automated
 
-        @Assert: The Virtual machines should be displayed
+        :Assert: The Virtual machines should be displayed
         """
         parameter_list = [
             ['URL', self.rhev_url, 'field'],
@@ -498,29 +499,29 @@ class RhevComputeResourceTestCase(UITestCase):
     def test_positive_provision_rhev_with_image(self):
         """ Provision a host on rhev compute resource with image based
 
-        @id: 80abd6b1-31cd-4f3e-949c-f1ca608d0bbb
+        :id: 80abd6b1-31cd-4f3e-949c-f1ca608d0bbb
 
-        @setup: rhev hostname and credentials.
+        :setup: rhev hostname and credentials.
 
-        1. Configured subnet for provisioning of the host.
-        2. Configured domains for the host.
-        3. Population of images into satellite from rhev templates.
-        4. Activation key and CV for the host.
+            1. Configured subnet for provisioning of the host.
+            2. Configured domains for the host.
+            3. Population of images into satellite from rhev templates.
+            4. Activation key and CV for the host.
 
-        @steps:
+        :steps:
 
-        1. Go to "Hosts --> New host".
-        2. Fill in the required details.(eg name,loc, org).
-        3. Select rhev compute resource from "Deploy on" drop down.
-        4. Associate appropriate feature capsules.
-        5. Go to "operating system tab".
-        6. Edit Provisioning Method to image based.
-        7. Select the appropriate image .
-        8. Associate the activation key and submit.
+            1. Go to "Hosts --> New host".
+            2. Fill in the required details.(eg name,loc, org).
+            3. Select rhev compute resource from "Deploy on" drop down.
+            4. Associate appropriate feature capsules.
+            5. Go to "operating system tab".
+            6. Edit Provisioning Method to image based.
+            7. Select the appropriate image .
+            8. Associate the activation key and submit.
 
-        @Assert: The host should be provisioned successfully
+        :Assert: The host should be provisioned successfully
 
-        @Caseautomation: notautomated
+        :Caseautomation: notautomated
         """
 
     @run_only_on('sat')
@@ -530,21 +531,21 @@ class RhevComputeResourceTestCase(UITestCase):
         """ Provision a host on rhev compute resource with compute profile
         default (3-Large)
 
-        @id: fe4a05ef-d548-4c28-80d0-d17851fb4b03
+        :id: fe4a05ef-d548-4c28-80d0-d17851fb4b03
 
-        @setup: rhev hostname ,credentials and provisioning setup.
+        :setup: rhev hostname ,credentials and provisioning setup.
 
-        @steps:
+        :steps:
 
-        1. Go to "Hosts --> New host".
-        2. Fill in the required details.(eg name,loc, org).
-        3. Select rhev compute resource from "Deploy on" drop down.
-        4. Select the "Compute profile" from the drop down.
-        5. Provision the host using the compute profile.
+            1. Go to "Hosts --> New host".
+            2. Fill in the required details.(eg name,loc, org).
+            3. Select rhev compute resource from "Deploy on" drop down.
+            4. Select the "Compute profile" from the drop down.
+            5. Provision the host using the compute profile.
 
-        @Assert: The host should be provisioned successfully
+        :Assert: The host should be provisioned successfully
 
-        @Caseautomation: notautomated
+        :Caseautomation: notautomated
         """
 
     @run_only_on('sat')
@@ -554,22 +555,22 @@ class RhevComputeResourceTestCase(UITestCase):
         """ Provision a host on rhev compute resource with
          custom disk, cpu count and memory
 
-        @id: a972c095-7567-4bb0-86cb-9bd835fed7b7
+        :id: a972c095-7567-4bb0-86cb-9bd835fed7b7
 
-        @setup: rhev hostname ,credentials and provisioning setup.
+        :setup: rhev hostname ,credentials and provisioning setup.
 
-        @steps:
+        :steps:
 
-        1. Go to "Hosts --> New host".
-        2. Fill in the required details.(eg name,loc, org).
-        3. Select rhev custom compute resource from "Deploy on" drop down.
-        4. Select the custom compute profile" with custom disk size, cpu count
-           and memory.
-        5. Provision the host using the compute profile.
+            1. Go to "Hosts --> New host".
+            2. Fill in the required details.(eg name,loc, org).
+            3. Select rhev custom compute resource from "Deploy on" drop down.
+            4. Select the custom compute profile" with custom disk size, cpu
+               count and memory.
+            5. Provision the host using the compute profile.
 
-        @Assert: The host should be provisioned with custom settings
+        :Assert: The host should be provisioned with custom settings
 
-        @Caseautomation: notautomated
+        :Caseautomation: notautomated
         """
 
     @run_only_on('sat')
@@ -579,20 +580,20 @@ class RhevComputeResourceTestCase(UITestCase):
         """ Provision a host on rhev compute resource with
         the help of hostgroup.
 
-        @id: e02fae7d-ac39-4068-ba82-ec0cf110aae8
+        :id: e02fae7d-ac39-4068-ba82-ec0cf110aae8
 
-        @setup: rhev hostname ,credentials provisioning setup and hostgroup
+        :setup: rhev hostname ,credentials provisioning setup and hostgroup
 
-        @steps:
+        :steps:
 
-        1. Go to "Hosts --> New host".
-        2. Assign the host group to the host.
-        3. Select the Deploy on as rhev Compute Resource.
-        4. Provision the host.
+            1. Go to "Hosts --> New host".
+            2. Assign the host group to the host.
+            3. Select the Deploy on as rhev Compute Resource.
+            4. Provision the host.
 
-        @Assert: The host should be provisioned with host group
+        :Assert: The host should be provisioned with host group
 
-        @Caseautomation: notautomated
+        :Caseautomation: notautomated
         """
 
     @run_only_on('sat')
@@ -600,11 +601,11 @@ class RhevComputeResourceTestCase(UITestCase):
     def test_positive_rhev_vm_power_on(self):
         """The virtual machine in rhev cr should be powered on.
 
-        @id: fb42e739-c35b-4c6f-a727-b99a4d695191
+        :id: fb42e739-c35b-4c6f-a727-b99a4d695191
 
-        @Assert: The virtual machine is switched on
+        :Assert: The virtual machine is switched on
 
-        @CaseAutomation: Automated
+        :CaseAutomation: Automated
         """
         parameter_list = [
             ['URL', self.rhev_url, 'field'],
@@ -628,11 +629,11 @@ class RhevComputeResourceTestCase(UITestCase):
     def test_positive_rhev_vm_power_off(self):
         """The virtual machine in rhev cr should be powered Off.
 
-        @id: e2996210-7f49-4de4-a298-4a142506ed48
+        :id: e2996210-7f49-4de4-a298-4a142506ed48
 
-        @Assert: The virtual machine is switched Off
+        :Assert: The virtual machine is switched Off
 
-        @CaseAutomation: Automated
+        :CaseAutomation: Automated
         """
         parameter_list = [
             ['URL', self.rhev_url, 'field'],

--- a/tests/foreman/ui/test_computeresource_vmware.py
+++ b/tests/foreman/ui/test_computeresource_vmware.py
@@ -1,16 +1,16 @@
 """Test for compute resource UI
 
-@Requirement: Computeresource
+:Requirement: Computeresource
 
-@CaseComponent: UI
+:CaseComponent: UI
 
-@CaseLevel: Acceptance
+:CaseLevel: Acceptance
 
-@TestType: Functional
+:TestType: Functional
 
-@CaseImportance: High
+:CaseImportance: High
 
-@Upstream: No
+:Upstream: No
 """
 
 from robottelo.decorators import run_only_on, stubbed, tier1, tier2, tier3
@@ -26,20 +26,19 @@ class VmwareComputeResourceTestCase(UITestCase):
     def test_positive_create_vmware_with_name(self):
         """Create a new vmware compute resource using valid name.
 
-        @id: 944ed0da-49d4-4c14-8884-9184d2aef126
+        :id: 944ed0da-49d4-4c14-8884-9184d2aef126
 
-        @setup: vmware hostname and credentials.
+        :setup: vmware hostname and credentials.
 
-        @steps:
+        :steps:
+            1. Create a compute resource of type vmware.
+            2. Provide a valid hostname, username and password.
+            3. Provide a valid name to vmware compute resource.
+            4. Test the connection using Load Datacenters and submit.
 
-        1. Create a compute resource of type vmware.
-        2. Provide a valid hostname, username and password.
-        3. Provide a valid name to vmware compute resource.
-        4. Test the connection using Load Datacenters and submit.
+        :Assert: A vmware compute resource is created successfully.
 
-        @Assert: A vmware compute resource is created successfully.
-
-        @Caseautomation: notautomated
+        :Caseautomation: notautomated
         """
 
     @run_only_on('sat')
@@ -48,19 +47,19 @@ class VmwareComputeResourceTestCase(UITestCase):
     def test_positive_create_vmware_with_description(self):
         """Create vmware compute resource with valid description.
 
-        @id: bdd879be-3467-41ca-9a67-d98f185ba892
+        :id: bdd879be-3467-41ca-9a67-d98f185ba892
 
-        @setup: vmware hostname and credentials.
+        :setup: vmware hostname and credentials.
 
-        @steps:
-        1. Create a compute resource of type vmware.
-        2. Provide a valid hostname, username and password.
-        3. Provide a valid description to vmware compute resource.
-        4. Test the connection using Load Datacenters and submit.
+        :steps:
+            1. Create a compute resource of type vmware.
+            2. Provide a valid hostname, username and password.
+            3. Provide a valid description to vmware compute resource.
+            4. Test the connection using Load Datacenters and submit.
 
-        @Assert: A vmware compute resource is created successfully
+        :Assert: A vmware compute resource is created successfully
 
-        @Caseautomation: notautomated
+        :Caseautomation: notautomated
         """
 
     @run_only_on('sat')
@@ -69,20 +68,19 @@ class VmwareComputeResourceTestCase(UITestCase):
     def test_negative_create_vmware_with_invalid_name(self):
         """Create a new vmware compute resource with invalid names.
 
-        @id: 19c206dc-5efc-4a7d-b04d-2aa04a22448c
+        :id: 19c206dc-5efc-4a7d-b04d-2aa04a22448c
 
-        @setup: vmware hostname and credentials.
+        :setup: vmware hostname and credentials.
 
-        @steps:
+        :steps:
+            1. Create a compute resource of type vmware.
+            2. Provide valid hostname, username and password.
+            3. Provide invalid name to vmware compute resource.
+            4. Test the connection using Load Datacenters and submit.
 
-        1. Create a compute resource of type vmware.
-        2. Provide valid hostname, username and password.
-        3. Provide invalid name to vmware compute resource.
-        4. Test the connection using Load Datacenters and submit.
+        :Assert: A vmware compute resource is not created
 
-        @Assert: A vmware compute resource is not created
-
-        @Caseautomation: notautomated
+        :Caseautomation: notautomated
         """
 
     @run_only_on('sat')
@@ -91,21 +89,20 @@ class VmwareComputeResourceTestCase(UITestCase):
     def test_positive_update_vmware_name(self):
         """Update a vmware compute resource name
 
-        @id: e2bf2fcb-4611-445e-bc36-a54b3fd2d559
+        :id: e2bf2fcb-4611-445e-bc36-a54b3fd2d559
 
-        @setup: vmware hostname and credentials.
+        :setup: vmware hostname and credentials.
 
-        @steps:
+        :steps:
+            1. Create a compute resource of type vmware.
+            2. Provide valid hostname, username and password.
+            3. Provide valid name to vmware compute resource.
+            4. Test the connection using Load Datacenters and submit.
+            5. Update the name of the created CR with valid string.
 
-        1. Create a compute resource of type vmware.
-        2. Provide valid hostname, username and password.
-        3. Provide valid name to vmware compute resource.
-        4. Test the connection using Load Datacenters and submit.
-        5. Update the name of the created CR with valid string.
+        :Assert: The vmware compute resource is updated
 
-        @Assert: The vmware compute resource is updated
-
-        @Caseautomation: notautomated
+        :Caseautomation: notautomated
         """
 
     @run_only_on('sat')
@@ -114,24 +111,23 @@ class VmwareComputeResourceTestCase(UITestCase):
     def test_positive_update_vmware_organization(self):
         """Update a vmware compute resource organization
 
-        @id: b7ffc933-9ffb-4bcd-ab23-33fde67f27e4
+        :id: b7ffc933-9ffb-4bcd-ab23-33fde67f27e4
 
-        @setup: vmware hostname and credentials.
+        :setup: vmware hostname and credentials.
 
-        @steps:
+        :steps:
+            1. Create a compute resource of type vmware.
+            2. Provide valid hostname, username and password.
+            3. Provide valid name to vmware compute resource.
+            4. Test the connection using Load Datacenters and submit.
+            5. Create a new organization.
+            6. Add the CR to new organization.
 
-        1. Create a compute resource of type vmware.
-        2. Provide valid hostname, username and password.
-        3. Provide valid name to vmware compute resource.
-        4. Test the connection using Load Datacenters and submit.
-        5. Create a new organization.
-        6. Add the CR to new organization.
+        :Assert: The vmware compute resource is updated
 
-        @Assert: The vmware compute resource is updated
+        :Caseautomation: notautomated
 
-        @Caseautomation: notautomated
-
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
 
     @run_only_on('sat')
@@ -140,21 +136,20 @@ class VmwareComputeResourceTestCase(UITestCase):
     def test_positive_delete_vmware(self):
         """Delete a vmware compute resource
 
-        @id: b38f2c9b-f4e3-41e3-8ee1-3b342025860c
+        :id: b38f2c9b-f4e3-41e3-8ee1-3b342025860c
 
-        @setup: vmware hostname and credentials.
+        :setup: vmware hostname and credentials.
 
-        @steps:
+        :steps:
+            1. Create compute resource of type vmware.
+            2. Provide valid hostname, username and password.
+            3. Provide valid name to vmware compute resource.
+            4. Test the connection using Load Datacenters and submit.
+            5. Delete the created compute resource.
 
-        1. Create compute resource of type vmware.
-        2. Provide valid hostname, username and password.
-        3. Provide valid name to vmware compute resource.
-        4. Test the connection using Load Datacenters and submit.
-        5. Delete the created compute resource.
+        :Assert: The compute resource is deleted
 
-        @Assert: The compute resource is deleted
-
-        @Caseautomation: notautomated
+        :Caseautomation: notautomated
         """
 
     @run_only_on('sat')
@@ -163,26 +158,25 @@ class VmwareComputeResourceTestCase(UITestCase):
     def test_positive_add_image_vmware_with_name(self):
         """Add images to the vmware compute resource
 
-        @id: 4b749529-b98d-4a3e-a2d1-b9738c96c283
+        :id: 4b749529-b98d-4a3e-a2d1-b9738c96c283
 
-        @setup:
+        :setup:
+            1. Valid vmware hostname, credentials.
+            2. Add images as templates in vmware.
 
-        1. Valid vmware hostname, credentials.
-        2. Add images as templates in vmware.
+        :steps:
 
-        @steps:
+            1. Create a compute resource of type vmware.
+            2. Provide valid hostname, username and password.
+            3. Select the created vmware CR and click images tab.
+            4. Select "New image", provide valid name and information.
+            5. Select the desired template to create image and submit.
 
-        1. Create a compute resource of type vmware.
-        2. Provide valid hostname, username and password.
-        3. Select the created vmware CR and click images tab.
-        4. Select "New image", provide valid name and information.
-        5. Select the desired template to create image and submit.
+        :Assert: The image is added to the CR successfully
 
-        @Assert: The image is added to the CR successfully
+        :Caseautomation: notautomated
 
-        @Caseautomation: notautomated
-
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
 
     @run_only_on('sat')
@@ -191,26 +185,26 @@ class VmwareComputeResourceTestCase(UITestCase):
     def test_negative_add_image_vmware_with_invalid_name(self):
         """Add images to the vmware compute resource
 
-        @id: 436324bf-7dcf-4197-b1ca-198492bf0356
+        :id: 436324bf-7dcf-4197-b1ca-198492bf0356
 
-        @setup:
+        :setup:
 
-        1. Valid vmware hostname, credentials.
-        2. Add images as templates in vmware.
+            1. Valid vmware hostname, credentials.
+            2. Add images as templates in vmware.
 
-        @steps:
+        :steps:
 
-        1. Create a compute resource of type vmware.
-        2. Provide valid hostname, username and password.
-        3. Select the created vmware CR and click images tab.
-        4. Select "New image" , provide invalid name and valid information.
-        5. Select the desired template to create the image from and submit.
+            1. Create a compute resource of type vmware.
+            2. Provide valid hostname, username and password.
+            3. Select the created vmware CR and click images tab.
+            4. Select "New image" , provide invalid name and valid information.
+            5. Select the desired template to create the image from and submit.
 
-        @Assert: The image should not be added to the CR
+        :Assert: The image should not be added to the CR
 
-        @Caseautomation: notautomated
+        :Caseautomation: notautomated
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
 
     @run_only_on('sat')
@@ -219,23 +213,23 @@ class VmwareComputeResourceTestCase(UITestCase):
     def test_positive_access_vmware_with_default_profile(self):
         """Associate default (3-Large) compute profile
 
-        @id: ceb2ef14-fa96-4951-9198-768ffcc4d01f
+        :id: ceb2ef14-fa96-4951-9198-768ffcc4d01f
 
-        @setup: vmware hostname and credentials.
+        :setup: vmware hostname and credentials.
 
-        @steps:
+        :steps:
 
-        1. Create a compute resource of type vmware.
-        2. Provide valid hostname, username and password.
-        3. Select the created vmware CR.
-        4. Click Compute Profile tab.
-        5. Select (3-Large) and submit.
+            1. Create a compute resource of type vmware.
+            2. Provide valid hostname, username and password.
+            3. Select the created vmware CR.
+            4. Click Compute Profile tab.
+            5. Select (3-Large) and submit.
 
-        @Assert: The Compute Resource created and opened successfully
+        :Assert: The Compute Resource created and opened successfully
 
-        @Caseautomation: notautomated
+        :Caseautomation: notautomated
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
 
     @run_only_on('sat')
@@ -244,23 +238,23 @@ class VmwareComputeResourceTestCase(UITestCase):
     def test_positive_access_vmware_with_custom_profile(self):
         """Associate custom default (3-Large) compute profile
 
-        @id: 751ef765-5091-4322-a0d9-0c9c73009cc4
+        :id: 751ef765-5091-4322-a0d9-0c9c73009cc4
 
-        @setup: vmware hostname and credentials.
+        :setup: vmware hostname and credentials.
 
-        @steps:
+        :steps:
 
-        1. Create a compute resource of type vmware.
-        2. Provide valid hostname, username and password.
-        3. Select the created vmware CR.
-        4. Click Compute Profile tab.
-        5. Edit (3-Large) with valid configurations and submit.
+            1. Create a compute resource of type vmware.
+            2. Provide valid hostname, username and password.
+            3. Select the created vmware CR.
+            4. Click Compute Profile tab.
+            5. Edit (3-Large) with valid configurations and submit.
 
-        @Assert: The Compute Resource created and opened successfully
+        :Assert: The Compute Resource created and opened successfully
 
-        @Caseautomation: notautomated
+        :Caseautomation: notautomated
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
 
     @run_only_on('sat')
@@ -269,20 +263,20 @@ class VmwareComputeResourceTestCase(UITestCase):
     def test_positive_retrieve_vmware_vm_list(self):
         """List the virtual machine list from vmware compute resource
 
-        @id: 21ade57a-0caa-4144-9c46-c8e22f33414e
+        :id: 21ade57a-0caa-4144-9c46-c8e22f33414e
 
-        @setup: vmware hostname and credentials.
+        :setup: vmware hostname and credentials.
 
-        @steps:
+        :steps:
 
-        1. Select the created compute resource.
-        2. Go to "Virtual Machines" tab.
+            1. Select the created compute resource.
+            2. Go to "Virtual Machines" tab.
 
-        @Assert: The Virtual machines should be displayed
+        :Assert: The Virtual machines should be displayed
 
-        @Caseautomation: notautomated
+        :Caseautomation: notautomated
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
 
     @run_only_on('sat')
@@ -291,31 +285,31 @@ class VmwareComputeResourceTestCase(UITestCase):
     def test_positive_provision_vmware_with_image(self):
         """ Provision a host on vmware compute resource with image based
 
-        @id: 2cbddac9-c5fa-4f6e-a098-d3e47a3aeb3c
+        :id: 2cbddac9-c5fa-4f6e-a098-d3e47a3aeb3c
 
-        @setup: vmware hostname and credentials.
+        :setup: vmware hostname and credentials.
 
-        1. Configured subnet for provisioning of the host.
-        2. Configured domains for the host.
-        3. Population of images into satellite from vmware templates.
-        4. Activation key and CV for the host.
+            1. Configured subnet for provisioning of the host.
+            2. Configured domains for the host.
+            3. Population of images into satellite from vmware templates.
+            4. Activation key and CV for the host.
 
-        @steps:
+        :steps:
 
-        1. Go to "Hosts --> New host".
-        2. Fill the required details.(eg name,loc, org).
-        3. Select vmware compute resource from "Deploy on" drop down.
-        4. Associate appropriate feature capsules.
-        5. Go to "operating system tab".
-        6. Edit Provisioning Method to image based.
-        7. Select the appropriate image .
-        8. Associate the activation key and submit.
+            1. Go to "Hosts --> New host".
+            2. Fill the required details.(eg name,loc, org).
+            3. Select vmware compute resource from "Deploy on" drop down.
+            4. Associate appropriate feature capsules.
+            5. Go to "operating system tab".
+            6. Edit Provisioning Method to image based.
+            7. Select the appropriate image .
+            8. Associate the activation key and submit.
 
-        @Assert: The host should be provisioned successfully
+        :Assert: The host should be provisioned successfully
 
-        @Caseautomation: notautomated
+        :Caseautomation: notautomated
 
-        @CaseLevel: System
+        :CaseLevel: System
         """
 
     @run_only_on('sat')
@@ -325,26 +319,26 @@ class VmwareComputeResourceTestCase(UITestCase):
         """ Provision a host on vmware compute resource with compute profile
         default (3-Large)
 
-        @id: cfe68708-f062-425e-bed7-a46e04007b11
+        :id: cfe68708-f062-425e-bed7-a46e04007b11
 
-        @setup:
+        :setup:
 
-        1. Vaild vmware hostname ,credentials.
-        2. Configure provisioning setup.
+            1. Vaild vmware hostname ,credentials.
+            2. Configure provisioning setup.
 
-        @steps:
+        :steps:
 
-        1. Go to "Hosts --> New host".
-        2. Fill the required details.(eg name,loc, org).
-        3. Select vmware compute resource from "Deploy on" drop down.
-        4. Select the "Compute profile" from the drop down.
-        5. Provision the host using the compute profile.
+            1. Go to "Hosts --> New host".
+            2. Fill the required details.(eg name,loc, org).
+            3. Select vmware compute resource from "Deploy on" drop down.
+            4. Select the "Compute profile" from the drop down.
+            5. Provision the host using the compute profile.
 
-        @Assert: The host should be provisioned successfully
+        :Assert: The host should be provisioned successfully
 
-        @Caseautomation: notautomated
+        :Caseautomation: notautomated
 
-        @CaseLevel: System
+        :CaseLevel: System
         """
 
     @run_only_on('sat')
@@ -354,27 +348,28 @@ class VmwareComputeResourceTestCase(UITestCase):
         """ Provision a host on vmware compute resource with
         custom disk, cpu count and memory
 
-        @id: d82c2b81-3a24-4d6e-82eb-c35709861a44
+        :id: d82c2b81-3a24-4d6e-82eb-c35709861a44
 
-        @setup:
+        :setup:
 
-        1. Vaild vmware hostname ,credentials.
-        2. Configure provisioning setup.
+            1. Vaild vmware hostname ,credentials.
+            2. Configure provisioning setup.
 
-        @steps:
+        :steps:
 
-        1. Go to "Hosts --> New host".
-        2. Fill the required details.(eg name,loc, org).
-        3. Select vmware custom compute resource from "Deploy on" drop down.
-        4. Select the custom compute profile" with custom disk size, cpu count
-           and memory.
-        5. Provision the host using the compute profile.
+            1. Go to "Hosts --> New host".
+            2. Fill the required details.(eg name,loc, org).
+            3. Select vmware custom compute resource from "Deploy on" drop
+               down.
+            4. Select the custom compute profile" with custom disk size, cpu
+               count and memory.
+            5. Provision the host using the compute profile.
 
-        @Assert: The host should be provisioned with custom settings
+        :Assert: The host should be provisioned with custom settings
 
-        @Caseautomation: notautomated
+        :Caseautomation: notautomated
 
-        @CaseLevel: System
+        :CaseLevel: System
         """
 
     @run_only_on('sat')
@@ -384,26 +379,26 @@ class VmwareComputeResourceTestCase(UITestCase):
         """ Provision a host on vmware compute resource with
         the help of hostgroup.
 
-        @id: d4e442ad-77f1-4d5e-9d1b-9a60d69b034f
+        :id: d4e442ad-77f1-4d5e-9d1b-9a60d69b034f
 
-        @setup:
+        :setup:
 
-        1. Vaild vmware hostname ,credentials.
-        2. Configure provisioning setup.
-        3. Configure host group setup.
+            1. Vaild vmware hostname ,credentials.
+            2. Configure provisioning setup.
+            3. Configure host group setup.
 
-        @steps:
+        :steps:
 
-        1. Go to "Hosts --> New host".
-        2. Assign the host group to the host.
-        3. Select the Deploy on as vmware Compute Resource.
-        4. Provision the host.
+            1. Go to "Hosts --> New host".
+            2. Assign the host group to the host.
+            3. Select the Deploy on as vmware Compute Resource.
+            4. Provision the host.
 
-        @Assert: The host should be provisioned with host group
+        :Assert: The host should be provisioned with host group
 
-        @Caseautomation: notautomated
+        :Caseautomation: notautomated
 
-        @CaseLevel: System
+        :CaseLevel: System
         """
 
     @run_only_on('sat')
@@ -412,24 +407,24 @@ class VmwareComputeResourceTestCase(UITestCase):
     def test_positive_poweroff_vmware_vms(self):
         """Poweroff the vmware virtual machine
 
-        @id: cc5e1957-ebd6-4621-9451-99607da76aeb
+        :id: cc5e1957-ebd6-4621-9451-99607da76aeb
 
-        @setup:
+        :setup:
 
-        1. Valid vmware hostname, credentials.
-        2. Virtual machine in vmware.
+            1. Valid vmware hostname, credentials.
+            2. Virtual machine in vmware.
 
-        @steps:
+        :steps:
 
-        1. Select the created compute resource.
-        2. Go to "Virtual Machines" tab.
-        3. Click "Poweroff" button associated with the vm.
+            1. Select the created compute resource.
+            2. Go to "Virtual Machines" tab.
+            3. Click "Poweroff" button associated with the vm.
 
-        @Assert: The Virtual machine should be switched off
+        :Assert: The Virtual machine should be switched off
 
-        @Caseautomation: notautomated
+        :Caseautomation: notautomated
 
-        @Caselevel: Integration
+        :Caselevel: Integration
         """
 
     @run_only_on('sat')
@@ -438,22 +433,22 @@ class VmwareComputeResourceTestCase(UITestCase):
     def test_positive_poweron_vmware_vms(self):
         """Power on the vmware virtual machine
 
-        @id: 846318e9-8b95-46ea-b7bc-26689064f80c
+        :id: 846318e9-8b95-46ea-b7bc-26689064f80c
 
-        @setup:
+        :setup:
 
-        1. Valid vmware hostname, credentials.
-        2. Virtual machine in vmware.
+            1. Valid vmware hostname, credentials.
+            2. Virtual machine in vmware.
 
-        @steps:
+        :steps:
 
-        1. Select the created compute resource.
-        2. Go to "Virtual Machines" tab.
-        3. Click "Power on" button associated with the vm.
+            1. Select the created compute resource.
+            2. Go to "Virtual Machines" tab.
+            3. Click "Power on" button associated with the vm.
 
-        @Assert: The Virtual machine should be switched on
+        :Assert: The Virtual machine should be switched on
 
-        @Caseautomation: notautomated
+        :Caseautomation: notautomated
 
-        @Caselevel: Integration
+        :Caselevel: Integration
         """

--- a/tests/foreman/ui/test_config_group.py
+++ b/tests/foreman/ui/test_config_group.py
@@ -1,18 +1,18 @@
 """Test class for Config Groups UI
 
-@Requirement: Config group
+:Requirement: Config group
 
-@CaseAutomation: Automated
+:CaseAutomation: Automated
 
-@CaseLevel: Acceptance
+:CaseLevel: Acceptance
 
-@CaseComponent: UI
+:CaseComponent: UI
 
-@TestType: Functional
+:TestType: Functional
 
-@CaseImportance: High
+:CaseImportance: High
 
-@Upstream: No
+:Upstream: No
 """
 
 from fauxfactory import gen_string
@@ -36,9 +36,9 @@ class ConfigGroupTestCase(UITestCase):
     def test_positive_create(self):
         """Create new Config-Group
 
-        @id: b9e170a3-29b1-49e6-bfc6-c48fb0021ecb
+        :id: b9e170a3-29b1-49e6-bfc6-c48fb0021ecb
 
-        @Assert: Config-Groups is created
+        :Assert: Config-Groups is created
 
         """
         with Session(self.browser) as session:
@@ -53,9 +53,9 @@ class ConfigGroupTestCase(UITestCase):
         """Try to create config group and use whitespace, blank, tab
         symbol or too long string of different types as its name value
 
-        @id: 1c8d098c-60c2-4dc4-af24-1c8a4cfff5e2
+        :id: 1c8d098c-60c2-4dc4-af24-1c8a4cfff5e2
 
-        @Assert: Config-Groups is not created
+        :Assert: Config-Groups is not created
         """
         with Session(self.browser) as session:
             for name in invalid_values_list('ui'):
@@ -70,9 +70,9 @@ class ConfigGroupTestCase(UITestCase):
     def test_positive_update(self):
         """Update selected config-group
 
-        @id: c8589969-1fdb-4977-b973-3795a36704be
+        :id: c8589969-1fdb-4977-b973-3795a36704be
 
-        @Assert: Config-Groups is updated.
+        :Assert: Config-Groups is updated.
 
         """
         name = gen_string('alpha')
@@ -90,9 +90,9 @@ class ConfigGroupTestCase(UITestCase):
     def test_positive_delete(self):
         """Delete selected config-groups
 
-        @id: 50879d3c-7c38-4294-aae4-0f3f146c9613
+        :id: 50879d3c-7c38-4294-aae4-0f3f146c9613
 
-        @Assert: Config-Groups is deleted
+        :Assert: Config-Groups is deleted
         """
         with Session(self.browser) as session:
             for name in valid_data_list():

--- a/tests/foreman/ui/test_contenthost.py
+++ b/tests/foreman/ui/test_contenthost.py
@@ -1,19 +1,19 @@
 # -*- encoding: utf-8 -*-
 """Test class for Content Hosts UI
 
-@Requirement: Content Host
+:Requirement: Content Host
 
-@CaseAutomation: Automated
+:CaseAutomation: Automated
 
-@CaseLevel: Acceptance
+:CaseLevel: Acceptance
 
-@CaseComponent: UI
+:CaseComponent: UI
 
-@TestType: Functional
+:TestType: Functional
 
-@CaseImportance: High
+:CaseImportance: High
 
-@Upstream: No
+:Upstream: No
 """
 from nailgun import entities
 from robottelo.cleanup import vm_cleanup
@@ -101,11 +101,11 @@ class ContentHostTestCase(UITestCase):
     def test_positive_install_package(self):
         """Install a package to a host remotely
 
-        @id: 13b9422d-4b7a-4068-9a57-a94602cd6410
+        :id: 13b9422d-4b7a-4068-9a57-a94602cd6410
 
-        @assert: Package was successfully installed
+        :assert: Package was successfully installed
 
-        @CaseLevel: System
+        :CaseLevel: System
         """
         with Session(self.browser):
             result = self.contenthost.execute_package_action(
@@ -121,11 +121,11 @@ class ContentHostTestCase(UITestCase):
     def test_positive_remove_package(self):
         """Remove a package from a host remotely
 
-        @id: 86d8896b-06d9-4c99-937e-f3aa07b4eb69
+        :id: 86d8896b-06d9-4c99-937e-f3aa07b4eb69
 
-        @Assert: Package was successfully removed
+        :Assert: Package was successfully removed
 
-        @CaseLevel: System
+        :CaseLevel: System
         """
         self.client.download_install_rpm(
             FAKE_6_YUM_REPO,
@@ -145,11 +145,11 @@ class ContentHostTestCase(UITestCase):
     def test_positive_upgrade_package(self):
         """Upgrade a host package remotely
 
-        @id: 1969db93-e7af-4f5f-973d-23c222224db6
+        :id: 1969db93-e7af-4f5f-973d-23c222224db6
 
-        @Assert: Package was successfully upgraded
+        :Assert: Package was successfully upgraded
 
-        @CaseLevel: System
+        :CaseLevel: System
         """
         self.client.run('yum install -y {0}'.format(FAKE_1_CUSTOM_PACKAGE))
         with Session(self.browser):
@@ -166,11 +166,11 @@ class ContentHostTestCase(UITestCase):
     def test_positive_install_package_group(self):
         """Install a package group to a host remotely
 
-        @id: a43fb21b-5f6a-4f14-8cd6-114ec287540c
+        :id: a43fb21b-5f6a-4f14-8cd6-114ec287540c
 
-        @Assert: Package group was successfully installed
+        :Assert: Package group was successfully installed
 
-        @CaseLevel: System
+        :CaseLevel: System
         """
         with Session(self.browser):
             result = self.contenthost.execute_package_action(
@@ -187,11 +187,11 @@ class ContentHostTestCase(UITestCase):
     def test_positive_remove_package_group(self):
         """Remove a package group from a host remotely
 
-        @id: dbeea1f2-adf4-4ad8-a989-efad8ce21b98
+        :id: dbeea1f2-adf4-4ad8-a989-efad8ce21b98
 
-        @Assert: Package group was successfully removed
+        :Assert: Package group was successfully removed
 
-        @CaseLevel: System
+        :CaseLevel: System
         """
         with Session(self.browser):
             result = self.contenthost.execute_package_action(
@@ -214,11 +214,11 @@ class ContentHostTestCase(UITestCase):
     def test_positive_install_errata(self):
         """Install a errata to a host remotely
 
-        @id: b69b9797-3c0c-42cd-94ed-3f751bb9b24c
+        :id: b69b9797-3c0c-42cd-94ed-3f751bb9b24c
 
-        @assert: Errata was successfully installed
+        :assert: Errata was successfully installed
 
-        @CaseLevel: System
+        :CaseLevel: System
         """
         self.client.run('yum install -y {0}'.format(FAKE_1_CUSTOM_PACKAGE))
         with Session(self.browser):
@@ -235,14 +235,14 @@ class ContentHostTestCase(UITestCase):
         """Register a host with activation key and fetch host's 'Registered by'
         field value.
 
-        @id: 5c6dbb5d-bd26-4439-ab04-536a6ad012b9
+        :id: 5c6dbb5d-bd26-4439-ab04-536a6ad012b9
 
-        @assert: 'Registered By' field on content host page points to
-        activation key which was used to register the host
+        :assert: 'Registered By' field on content host page points to
+            activation key which was used to register the host
 
-        @BZ: 1380117
+        :BZ: 1380117
 
-        @CaseLevel: System
+        :CaseLevel: System
         """
         with Session(self.browser):
             result = self.contenthost.fetch_parameters(

--- a/tests/foreman/ui/test_contentview.py
+++ b/tests/foreman/ui/test_contentview.py
@@ -4,19 +4,19 @@
 Feature details: https://fedorahosted.org/katello/wiki/ContentViews
 
 
-@Requirement: Contentview
+:Requirement: Contentview
 
-@CaseAutomation: Automated
+:CaseAutomation: Automated
 
-@CaseLevel: Acceptance
+:CaseLevel: Acceptance
 
-@CaseComponent: UI
+:CaseComponent: UI
 
-@TestType: Functional
+:TestType: Functional
 
-@CaseImportance: High
+:CaseImportance: High
 
-@Upstream: No
+:Upstream: No
 """
 import random
 
@@ -146,9 +146,9 @@ class ContentViewTestCase(UITestCase):
     def test_positive_create_with_name(self):
         """Create content views using different names
 
-        @id: 804e51d7-f025-4ec2-a247-834afd351e89
+        :id: 804e51d7-f025-4ec2-a247-834afd351e89
 
-        @assert: Content views are created
+        :assert: Content views are created
         """
         with Session(self.browser) as session:
             for name in valid_data_list():
@@ -166,10 +166,10 @@ class ContentViewTestCase(UITestCase):
     def test_negative_create_with_invalid_name(self):
         """try to create content views using invalid names
 
-        @id: 974f2adc-b7da-4a8c-a8b5-d231b6bda1ce
+        :id: 974f2adc-b7da-4a8c-a8b5-d231b6bda1ce
 
-        @assert: content views are not created; proper error thrown and
-        system handles it gracefully
+        :assert: content views are not created; proper error thrown and system
+            handles it gracefully
         """
         with Session(self.browser) as session:
             # invalid_names_list is used instead of invalid_values_list
@@ -191,18 +191,18 @@ class ContentViewTestCase(UITestCase):
         """create content view with yum repo, publish it
         and promote it to Library +1 env
 
-        @id: 74c1b00d-c582-434f-bf73-588532588d50
+        :id: 74c1b00d-c582-434f-bf73-588532588d50
 
-        @steps:
-        1. Create Product/repo and Sync it
-        2. Create CV and add created repo in step1
-        3. Publish and promote it to 'Library'
-        4. Promote it to next environment
+        :steps:
+            1. Create Product/repo and Sync it
+            2. Create CV and add created repo in step1
+            3. Publish and promote it to 'Library'
+            4. Promote it to next environment
 
-        @assert: content view is created, updated with repo publish and
-        promoted to next selected env
+        :assert: content view is created, updated with repo publish and
+            promoted to next selected env
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         repo_name = gen_string('alpha')
         env_name = gen_string('alpha')
@@ -235,15 +235,15 @@ class ContentViewTestCase(UITestCase):
     def test_positive_add_puppet_module(self):
         """create content view with puppet repository
 
-        @id: c772d55b-6762-4c25-bbaf-83e7c200fe8a
+        :id: c772d55b-6762-4c25-bbaf-83e7c200fe8a
 
-        @steps:
-        1. Create Product/puppet repo and Sync it
-        2. Create CV and add puppet modules from created repo
+        :steps:
+            1. Create Product/puppet repo and Sync it
+            2. Create CV and add puppet modules from created repo
 
-        @assert: content view is created, updated with puppet module
+        :assert: content view is created, updated with puppet module
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         repo_url = FAKE_0_PUPPET_REPO
         cv_name = gen_string('alpha')
@@ -274,11 +274,11 @@ class ContentViewTestCase(UITestCase):
     def test_positive_remove_filter(self):
         """create empty content views filter and remove it
 
-        @id: 6c6deae7-13f1-4638-a960-d3565d93fd64
+        :id: 6c6deae7-13f1-4638-a960-d3565d93fd64
 
-        @assert: content views filter removed successfully
+        :assert: content views filter removed successfully
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         cv_name = gen_string('alpha')
         filter_name = gen_string('alpha')
@@ -301,12 +301,12 @@ class ContentViewTestCase(UITestCase):
     def test_positive_add_package_filter(self):
         """add package to content views filter
 
-        @id: 1cc8d921-92e5-4b51-8050-a7e775095f97
+        :id: 1cc8d921-92e5-4b51-8050-a7e775095f97
 
-        @assert: content views filter created and selected packages
-        can be added for inclusion/exclusion
+        :assert: content views filter created and selected packages can be
+            added for inclusion/exclusion
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         cv_name = gen_string('alpha')
         filter_name = gen_string('alpha')
@@ -338,11 +338,11 @@ class ContentViewTestCase(UITestCase):
         """Add package to inclusion content views filter, publish CV and verify
         package was actually filtered
 
-        @id: 58c32cb5-1392-478e-807a-9c023d5ca0ea
+        :id: 58c32cb5-1392-478e-807a-9c023d5ca0ea
 
-        @assert: Package is included in content view version
+        :assert: Package is included in content view version
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         cv_name = gen_string('alpha')
         filter_name = gen_string('alpha')
@@ -397,11 +397,11 @@ class ContentViewTestCase(UITestCase):
         """Add package to exclusion content views filter, publish CV and verify
         package was actually filtered
 
-        @id: 304dfb76-a222-48ab-b6de-578a2c81210c
+        :id: 304dfb76-a222-48ab-b6de-578a2c81210c
 
-        @assert: Package is excluded from content view version
+        :assert: Package is excluded from content view version
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         cv_name = gen_string('alpha')
         filter_name = gen_string('alpha')
@@ -456,12 +456,12 @@ class ContentViewTestCase(UITestCase):
     def test_positive_remove_package_from_exclusion_filter(self):
         """Remove package from content view exclusion filter
 
-        @id: 2f0adc16-2305-4adf-8582-82e6110fa385
+        :id: 2f0adc16-2305-4adf-8582-82e6110fa385
 
-        @assert: Package was successfully removed from content view filter and
-        is present in next published content view version
+        :assert: Package was successfully removed from content view filter and
+            is present in next published content view version
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         cv_name = gen_string('alpha')
         filter_name = gen_string('alpha')
@@ -526,12 +526,12 @@ class ContentViewTestCase(UITestCase):
     def test_positive_update_inclusive_filter_package_version(self):
         """Update version of package inside inclusive cv package filter
 
-        @id: 8d6801de-ab82-49d6-bdeb-0f6e5c95b906
+        :id: 8d6801de-ab82-49d6-bdeb-0f6e5c95b906
 
-        @assert: Version was updated, next content view version contains
-        package with updated version
+        :assert: Version was updated, next content view version contains
+            package with updated version
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         cv_name = gen_string('alpha')
         filter_name = gen_string('alpha')
@@ -613,12 +613,12 @@ class ContentViewTestCase(UITestCase):
     def test_positive_update_exclusive_filter_package_version(self):
         """Update version of package inside exclusive cv package filter
 
-        @id: a8aa8864-190a-46c3-aeed-4953c8f3f601
+        :id: a8aa8864-190a-46c3-aeed-4953c8f3f601
 
-        @assert: Version was updated, next content view version contains
-        package with updated version
+        :assert: Version was updated, next content view version contains
+            package with updated version
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         cv_name = gen_string('alpha')
         filter_name = gen_string('alpha')
@@ -700,12 +700,12 @@ class ContentViewTestCase(UITestCase):
     def test_positive_update_filter_affected_repos(self):
         """Update content view package filter affected repos
 
-        @id: 8f095b11-fd63-4a23-9586-a85d6191314f
+        :id: 8f095b11-fd63-4a23-9586-a85d6191314f
 
-        @assert: Affected repos were updated, after new content view version
-        publishing only updated repos are affected by content view filter
+        :assert: Affected repos were updated, after new content view version
+            publishing only updated repos are affected by content view filter
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         cv_name = gen_string('alpha')
         filter_name = gen_string('alpha')
@@ -778,11 +778,11 @@ class ContentViewTestCase(UITestCase):
     def test_negative_add_same_package_filter_twice(self):
         """Update version of package inside exclusive cv package filter
 
-        @id: 5a97de5a-679e-4150-adf7-b4a28290b834
+        :id: 5a97de5a-679e-4150-adf7-b4a28290b834
 
-        @assert: Same package filter can not be added again
+        :assert: Same package filter can not be added again
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         cv_name = gen_string('alpha')
         repo_name = gen_string('alpha')
@@ -828,12 +828,12 @@ class ContentViewTestCase(UITestCase):
     def test_positive_add_package_group_filter(self):
         """add package group to content views filter
 
-        @id: 8c02a432-8b2a-4ba3-9613-7070b2dc2bcb
+        :id: 8c02a432-8b2a-4ba3-9613-7070b2dc2bcb
 
-        @assert: content views filter created and selected package groups
-        can be added for inclusion/exclusion
+        :assert: content views filter created and selected package groups can
+            be added for inclusion/exclusion
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         cv_name = gen_string('alpha')
         filter_name = gen_string('alpha')
@@ -863,12 +863,12 @@ class ContentViewTestCase(UITestCase):
     def test_positive_add_errata_filter(self):
         """add errata to content views filter
 
-        @id: bb9eef30-62c4-435c-9573-9f31210b8d7d
+        :id: bb9eef30-62c4-435c-9573-9f31210b8d7d
 
-        @assert: content views filter created and selected errata-id
-        can be added for inclusion/exclusion
+        :assert: content views filter created and selected errata-id can be
+            added for inclusion/exclusion
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         cv_name = gen_string('alpha')
         filter_name = gen_string('alpha')
@@ -895,9 +895,9 @@ class ContentViewTestCase(UITestCase):
     def test_positive_update_name(self):
         """Update content views name to valid one.
 
-        @id: 7d8eb36a-536e-49dc-9eb4-a5885ec77819
+        :id: 7d8eb36a-536e-49dc-9eb4-a5885ec77819
 
-        @assert: Content view is updated successfully and has proper name
+        :assert: Content view is updated successfully and has proper name
         """
         name = gen_string('alpha')
         with Session(self.browser) as session:
@@ -919,9 +919,9 @@ class ContentViewTestCase(UITestCase):
     def test_negative_update_name(self):
         """Try to update content views name to invalid one.
 
-        @id: 211c319f-802a-4407-9c16-205a82d4afca
+        :id: 211c319f-802a-4407-9c16-205a82d4afca
 
-        @assert: Content View is not updated. Appropriate error shown.
+        :assert: Content View is not updated. Appropriate error shown.
         """
         name = gen_string('alpha')
         with Session(self.browser) as session:
@@ -942,10 +942,10 @@ class ContentViewTestCase(UITestCase):
     def test_positive_update_description(self):
         """Update content views description to valid one.
 
-        @id: f5e46a3b-c317-4575-9c66-ef1da1926f66
+        :id: f5e46a3b-c317-4575-9c66-ef1da1926f66
 
-        @assert: Content view is updated successfully and has proper
-        description
+        :assert: Content view is updated successfully and has proper
+            description
         """
         name = gen_string('alpha', 8)
         desc = gen_string('alpha', 15)
@@ -976,12 +976,11 @@ class ContentViewTestCase(UITestCase):
         """Edit content views for a custom rh spin.  For example,
         modify a filter
 
-        @id: 05639074-ef6d-4c6b-8ff6-53033821e686
+        :id: 05639074-ef6d-4c6b-8ff6-53033821e686
 
-        @assert: edited content view save is successful and info is
-        updated
+        :assert: edited content view save is successful and info is updated
 
-        @CaseLevel: System
+        :CaseLevel: System
         """
         cv_name = gen_string('alpha')
         filter_name = gen_string('alpha')
@@ -1030,9 +1029,9 @@ class ContentViewTestCase(UITestCase):
     def test_positive_delete(self):
         """Delete content views
 
-        @id: bcea6ef0-bc25-4cc7-9c0c-3591bb8810e5
+        :id: bcea6ef0-bc25-4cc7-9c0c-3591bb8810e5
 
-        @assert: Content view can be deleted and no longer appears in UI
+        :assert: Content view can be deleted and no longer appears in UI
         """
         with Session(self.browser) as session:
             for name in valid_data_list():
@@ -1057,13 +1056,13 @@ class ContentViewTestCase(UITestCase):
         # variation.
         """create a composite content views
 
-        @id: 550f1970-5cbd-4571-bb7b-17e97639b715
+        :id: 550f1970-5cbd-4571-bb7b-17e97639b715
 
-        @setup: sync multiple content source/types (RH, custom, etc.)
+        :setup: sync multiple content source/types (RH, custom, etc.)
 
-        @assert: Composite content views are created
+        :assert: Composite content views are created
 
-        @CaseLevel: System
+        :CaseLevel: System
         """
         puppet_module = 'httpd'
         cv_name1 = gen_string('alpha')
@@ -1119,13 +1118,13 @@ class ContentViewTestCase(UITestCase):
     def test_positive_add_rh_content(self):
         """Add Red Hat content to a content view
 
-        @id: c370fd79-0c0d-4685-99cb-848556c786c1
+        :id: c370fd79-0c0d-4685-99cb-848556c786c1
 
-        @setup: Sync RH content
+        :setup: Sync RH content
 
-        @assert: RH Content can be seen in a view
+        :assert: RH Content can be seen in a view
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         cv_name = gen_string('alpha')
         rh_repo = {
@@ -1158,15 +1157,15 @@ class ContentViewTestCase(UITestCase):
         # severity.
         """associate Red Hat content in a view
 
-        @id: 3e6c2d8a-b62d-4ec7-8353-4a6a4cb58209
+        :id: 3e6c2d8a-b62d-4ec7-8353-4a6a4cb58209
 
-        @setup: Sync RH content
+        :setup: Sync RH content
 
-        @steps: 1. Assure filter(s) applied to associated content
+        :steps: Assure filter(s) applied to associated content
 
-        @assert: Filtered RH content only is available/can be seen in a view
+        :assert: Filtered RH content only is available/can be seen in a view
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         cv_name = gen_string('alpha')
         filter_name = gen_string('alpha')
@@ -1219,13 +1218,13 @@ class ContentViewTestCase(UITestCase):
     def test_positive_add_custom_content(self):
         """associate custom content in a view
 
-        @id: 7128fc8b-0e8c-4f00-8541-2ca2399650c8
+        :id: 7128fc8b-0e8c-4f00-8541-2ca2399650c8
 
-        @setup: Sync custom content
+        :setup: Sync custom content
 
-        @assert: Custom content can be seen in a view
+        :assert: Custom content can be seen in a view
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         cv_name = gen_string('alpha')
         repo_name = gen_string('alpha')
@@ -1245,12 +1244,12 @@ class ContentViewTestCase(UITestCase):
         """attempt to associate puppet repos within a composite
         content view
 
-        @id: 283fa7da-ca40-4ce2-b3c5-da58ae01b8e7
+        :id: 283fa7da-ca40-4ce2-b3c5-da58ae01b8e7
 
-        @assert: User cannot create a composite content view
-        that contains direct puppet repos.
+        :assert: User cannot create a composite content view that contains
+            direct puppet repos.
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         composite_name = gen_string('alpha')
         with Session(self.browser) as session:
@@ -1275,11 +1274,11 @@ class ContentViewTestCase(UITestCase):
         """attempt to associate components to a non-composite
         content view
 
-        @id: fa3e6aea-7ee3-46a6-a5ba-248de3c20a8f
+        :id: fa3e6aea-7ee3-46a6-a5ba-248de3c20a8f
 
-        @assert: User cannot add components to the view
+        :assert: User cannot add components to the view
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         cv1_name = gen_string('alpha')
         cv2_name = gen_string('alpha')
@@ -1304,19 +1303,19 @@ class ContentViewTestCase(UITestCase):
         """Attempt to associate unpublished non-composite content view with
         composite content view.
 
-        @id: dc253606-3425-489d-bc01-266787d36841
+        :id: dc253606-3425-489d-bc01-266787d36841
 
-        @steps:
+        :steps:
 
-        1. Create an empty non-composite content view. Do not publish it.
-        2. Create a new composite content view
+            1. Create an empty non-composite content view. Do not publish it.
+            2. Create a new composite content view
 
-        @assert: Non-composite content view is not listed as available to be
-        added to composite content view.
+        :assert: Non-composite content view is not listed as available to be
+            added to composite content view.
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
 
-        @BZ: 1367123
+        :BZ: 1367123
         """
         unpublished_cv_name = gen_string('alpha')
         composite_cv_name = gen_string('alpha')
@@ -1345,28 +1344,28 @@ class ContentViewTestCase(UITestCase):
         """Attempt to associate both published and unpublished
         non-composite content views with composite content view.
 
-        @id: 93307c2a-a03f-44fa-972d-43f6e40b9de6
+        :id: 93307c2a-a03f-44fa-972d-43f6e40b9de6
 
-        @steps:
+        :steps:
 
-        1. Create an empty non-composite content view. Do not publish it
-        2. Create a second non-composite content view. Publish it.
-        3. Create a new composite content view.
-        4. Add the published non-composite content view to the composite
-            content view.
+            1. Create an empty non-composite content view. Do not publish it
+            2. Create a second non-composite content view. Publish it.
+            3. Create a new composite content view.
+            4. Add the published non-composite content view to the composite
+                content view.
 
-        @assert:
+        :assert:
 
-        1. Unpublished non-composite content view is not listed as available
-            to be added to composite content view.
-        2. Published non-composite content view is listed as available to be
-            added to composite content view.
-        3. Published non-composite content view is successfully added to
-            composite content view.
+            1. Unpublished non-composite content view is not listed as
+                available to be added to composite content view.
+            2. Published non-composite content view is listed as available to
+                be added to composite content view.
+            3. Published non-composite content view is successfully added to
+                composite content view.
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
 
-        @BZ: 1367123
+        :BZ: 1367123
         """
         published_cv_name = gen_string('alpha')
         unpublished_cv_name = gen_string('alpha')
@@ -1409,11 +1408,11 @@ class ContentViewTestCase(UITestCase):
         """attempt to associate the same repo multiple times within a
         content view
 
-        @id: 24b98075-fca6-4d80-a778-066193c71e7f
+        :id: 24b98075-fca6-4d80-a778-066193c71e7f
 
-        @assert: User cannot add repos multiple times to the view
+        :assert: User cannot add repos multiple times to the view
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         cv_name = gen_string('alpha')
         repo_name = gen_string('alpha')
@@ -1439,11 +1438,11 @@ class ContentViewTestCase(UITestCase):
         """attempt to associate duplicate puppet module(s) within a
         content view
 
-        @id: ee33a306-9f91-439d-ac7c-d30f7e1a14cc
+        :id: ee33a306-9f91-439d-ac7c-d30f7e1a14cc
 
-        @assert: User cannot add modules multiple times to the view
+        :assert: User cannot add modules multiple times to the view
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         cv_name = gen_string('alpha')
         module_name = 'samba'
@@ -1487,13 +1486,13 @@ class ContentViewTestCase(UITestCase):
     def test_positive_promote_with_rh_content(self):
         """attempt to promote a content view containing RH content
 
-        @id: 82f71639-3580-49fd-bd5a-8dba568b98d1
+        :id: 82f71639-3580-49fd-bd5a-8dba568b98d1
 
-        @setup: Multiple environments for an org; RH content synced
+        :setup: Multiple environments for an org; RH content synced
 
-        @assert: Content view can be promoted
+        :assert: Content view can be promoted
 
-        @CaseLevel: System
+        :CaseLevel: System
         """
         cv_name = gen_string('alpha')
         rh_repo = {
@@ -1533,13 +1532,13 @@ class ContentViewTestCase(UITestCase):
         """attempt to promote a content view containing a custom RH
         spin - i.e., contains filters.
 
-        @id: 7d93c81f-2815-4b0e-b72c-23a902fe34b1
+        :id: 7d93c81f-2815-4b0e-b72c-23a902fe34b1
 
-        @setup: Multiple environments for an org; RH content synced
+        :setup: Multiple environments for an org; RH content synced
 
-        @assert: Content view can be promoted
+        :assert: Content view can be promoted
 
-        @CaseLevel: System
+        :CaseLevel: System
         """
         cv_name = gen_string('alpha')
         filter_name = gen_string('alpha')
@@ -1597,13 +1596,13 @@ class ContentViewTestCase(UITestCase):
     def test_positive_promote_with_custom_content(self):
         """attempt to promote a content view containing custom content
 
-        @id: 7c2fd8f0-c83f-4725-8953-9590112fae50
+        :id: 7c2fd8f0-c83f-4725-8953-9590112fae50
 
-        @setup: Multiple environments for an org; custom content synced
+        :setup: Multiple environments for an org; custom content synced
 
-        @assert: Content view can be promoted
+        :assert: Content view can be promoted
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         repo_name = gen_string('alpha')
         env_name = gen_string('alpha')
@@ -1641,15 +1640,15 @@ class ContentViewTestCase(UITestCase):
         """attempt to promote composite content view containing custom
         content
 
-        @id: 35efbd83-d32e-4831-9d5b-1adb15289f54
+        :id: 35efbd83-d32e-4831-9d5b-1adb15289f54
 
-        @setup: Multiple environments for an org; custom content synced
+        :setup: Multiple environments for an org; custom content synced
 
-        @steps: create a composite view containing multiple content types
+        :steps: create a composite view containing multiple content types
 
-        @assert: Composite content view can be promoted
+        :assert: Composite content view can be promoted
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         env_name = gen_string('alpha')
         cv1_name = gen_string('alpha')
@@ -1752,13 +1751,13 @@ class ContentViewTestCase(UITestCase):
     def test_positive_publish_with_rh_content(self):
         """attempt to publish a content view containing RH content
 
-        @id: bd24dc13-b6c4-4a9b-acb2-cd6df30f436c
+        :id: bd24dc13-b6c4-4a9b-acb2-cd6df30f436c
 
-        @setup: RH content synced
+        :setup: RH content synced
 
-        @assert: Content view can be published
+        :assert: Content view can be published
 
-        @CaseLevel: System
+        :CaseLevel: System
         """
         cv_name = gen_string('alpha')
         rh_repo = {
@@ -1790,13 +1789,13 @@ class ContentViewTestCase(UITestCase):
         """attempt to publish  a content view containing a custom RH
         spin - i.e., contains filters.
 
-        @id: 6804f399-8f09-4c53-8f0d-8e681892e93c
+        :id: 6804f399-8f09-4c53-8f0d-8e681892e93c
 
-        @setup: Multiple environments for an org; RH content synced
+        :setup: Multiple environments for an org; RH content synced
 
-        @assert: Content view can be published
+        :assert: Content view can be published
 
-        @CaseLevel: System
+        :CaseLevel: System
         """
         cv_name = gen_string('alpha')
         filter_name = gen_string('alpha')
@@ -1854,13 +1853,13 @@ class ContentViewTestCase(UITestCase):
     def test_positive_publish_with_custom_content(self):
         """attempt to publish a content view containing custom content
 
-        @id: 66b5efc7-2e43-438e-bd80-a754814222f9
+        :id: 66b5efc7-2e43-438e-bd80-a754814222f9
 
-        @setup: Multiple environments for an org; custom content synced
+        :setup: Multiple environments for an org; custom content synced
 
-        @assert: Content view can be published
+        :assert: Content view can be published
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         repo_name = gen_string('alpha')
         env_name = gen_string('alpha')
@@ -1893,13 +1892,13 @@ class ContentViewTestCase(UITestCase):
         """attempt to publish composite content view containing custom
         content
 
-        @id: 73947204-408e-4e2e-b87f-ba2e52ee50b6
+        :id: 73947204-408e-4e2e-b87f-ba2e52ee50b6
 
-        @setup: Multiple environments for an org; custom content synced
+        :setup: Multiple environments for an org; custom content synced
 
-        @assert: Composite content view can be published
+        :assert: Composite content view can be published
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         env_name = gen_string('alpha')
         cv1_name = gen_string('alpha')
@@ -2005,18 +2004,18 @@ class ContentViewTestCase(UITestCase):
         """when publishing new version to environment, version
         gets updated
 
-        @id: c9fa3def-baa2-497f-b6a6-f3b2d72d1ce9
+        :id: c9fa3def-baa2-497f-b6a6-f3b2d72d1ce9
 
-        @setup: Multiple environments for an org; multiple versions
-        of a content view created/published
+        :setup: Multiple environments for an org; multiple versions of a
+            content view created/published
 
-        @steps:
-        1. publish a view to an environment noting the CV version
-        2. edit and republish a new version of a CV
+        :steps:
+            1. publish a view to an environment noting the CV version
+            2. edit and republish a new version of a CV
 
-        @assert: Content view version is updated in target environment.
+        :assert: Content view version is updated in target environment.
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         cv_name = gen_string('alpha')
         env_name = gen_string('alpha')
@@ -2077,18 +2076,18 @@ class ContentViewTestCase(UITestCase):
         """when publishing new version to environment, version
         gets updated
 
-        @id: 576ac8b4-7efe-4267-a672-868a5f3eb28a
+        :id: 576ac8b4-7efe-4267-a672-868a5f3eb28a
 
-        @setup: Multiple environments for an org; multiple versions
-        of a content view created/published
+        :setup: Multiple environments for an org; multiple versions of a
+            content view created/published
 
-        @steps:
-        1. publish a view to an environment
-        2. edit and republish a new version of a CV
+        :steps:
+            1. publish a view to an environment
+            2. edit and republish a new version of a CV
 
-        @assert: Content view version is updated in source environment.
+        :assert: Content view version is updated in source environment.
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         cv_name = gen_string('alpha')
         env_name = gen_string('alpha')
@@ -2158,11 +2157,11 @@ class ContentViewTestCase(UITestCase):
         """attempt to create new content view based on existing
         view within environment
 
-        @id: 862c385b-d98c-4c29-8345-fd7a5900483a
+        :id: 862c385b-d98c-4c29-8345-fd7a5900483a
 
-        @assert: Content view can be cloned
+        :assert: Content view can be cloned
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         repo_name = gen_string('alpha')
         cv_name = gen_string('alpha')
@@ -2198,11 +2197,11 @@ class ContentViewTestCase(UITestCase):
         """attempt to create new content view based on existing
         view, inside a different environment
 
-        @id: 09b9307f-91de-4d3d-a6af-31c526ea816f
+        :id: 09b9307f-91de-4d3d-a6af-31c526ea816f
 
-        @assert: Content view can be published
+        :assert: Content view can be published
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         repo_name = gen_string('alpha')
         cv_name = gen_string('alpha')
@@ -2268,13 +2267,13 @@ class ContentViewTestCase(UITestCase):
         """Attempt to subscribe a host to content view with rh repository
          and custom filter
 
-        @id: 3ea6719b-df4d-4b0f-b4b4-69ce852f632e
+        :id: 3ea6719b-df4d-4b0f-b4b4-69ce852f632e
 
-        @setup: content view with rh repo and custom spin
+        :setup: content view with rh repo and custom spin
 
-        @assert: Systems can be subscribed to content view(s)
+        :assert: Systems can be subscribed to content view(s)
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         cv_name = gen_string('alpha')
         filter_name = gen_string('alpha')
@@ -2364,13 +2363,13 @@ class ContentViewTestCase(UITestCase):
     def test_positive_subscribe_system_with_custom_content(self):
         """Attempt to subscribe a host to content view with custom repository
 
-        @id: 715db997-707b-4868-b7cc-b6977fd6ac04
+        :id: 715db997-707b-4868-b7cc-b6977fd6ac04
 
-        @setup: content view with custom yum repo
+        :setup: content view with custom yum repo
 
-        @assert: Systems can be subscribed to content view(s)
+        :assert: Systems can be subscribed to content view(s)
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         cv_name = gen_string('alpha')
         repo_name = gen_string('alpha')
@@ -2427,13 +2426,13 @@ class ContentViewTestCase(UITestCase):
     def test_positive_subscribe_system_with_puppet_modules(self):
         """Attempt to subscribe a host to content view with puppet modules
 
-        @id: c57fbdca-31e8-43f1-844d-b82b13c0c4de
+        :id: c57fbdca-31e8-43f1-844d-b82b13c0c4de
 
-        @setup: content view with puppet module
+        :setup: content view with puppet module
 
-        @assert: Systems can be subscribed to content view(s)
+        :assert: Systems can be subscribed to content view(s)
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         cv_name = gen_string('alpha')
         repo_name = gen_string('alpha')
@@ -2498,18 +2497,19 @@ class ContentViewTestCase(UITestCase):
     def test_positive_restart_promote_via_dynflow(self):
         """attempt to restart a promotion
 
-        @id: c7f4e673-5164-417f-a072-1cc51d176780
+        :id: c7f4e673-5164-417f-a072-1cc51d176780
 
-        @steps:
-        1. (Somehow) cause a CV promotion to fail.  Not exactly sure how yet.
-        2. Via Dynflow, restart promotion
+        :steps:
+            1. (Somehow) cause a CV promotion to fail.  Not exactly sure how
+                yet.
+            2. Via Dynflow, restart promotion
 
-        @assert: Promotion is restarted.
+        :assert: Promotion is restarted.
 
-        @caseautomation: notautomated
+        :caseautomation: notautomated
 
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
 
     @stubbed()
@@ -2518,18 +2518,19 @@ class ContentViewTestCase(UITestCase):
     def test_positive_restart_publish_via_dynflow(self):
         """attempt to restart a publish
 
-        @id: d7a1204f-5d7c-4978-bb78-f366786d006a
+        :id: d7a1204f-5d7c-4978-bb78-f366786d006a
 
-        @steps:
-        1. (Somehow) cause a CV publish  to fail.  Not exactly sure how yet.
-        2. Via Dynflow, restart publish
+        :steps:
+            1. (Somehow) cause a CV publish  to fail.  Not exactly sure how
+                yet.
+            2. Via Dynflow, restart publish
 
-        @assert: Publish is restarted.
+        :assert: Publish is restarted.
 
-        @caseautomation: notautomated
+        :caseautomation: notautomated
 
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
 
     # ROLES TESTING
@@ -2540,21 +2541,20 @@ class ContentViewTestCase(UITestCase):
     def test_positive_admin_user_actions(self):
         """Attempt to manage content views
 
-        @id: c4d270fc-a3e6-4ae2-a338-41d864a5622a
+        :id: c4d270fc-a3e6-4ae2-a338-41d864a5622a
 
-        @steps:
-        with global admin account:
+        :steps: with global admin account:
 
-        1. create a user with all content views permissions
-        2. create lifecycle environment
-        3. create 2 content views (one to delete, the other to manage)
+            1. create a user with all content views permissions
+            2. create lifecycle environment
+            3. create 2 content views (one to delete, the other to manage)
 
-        @setup: create a user with all content views permissions
+        :setup: create a user with all content views permissions
 
-        @assert: The user can Read, Modify, Delete, Publish, Promote the
-        content views
+        :assert: The user can Read, Modify, Delete, Publish, Promote the
+            content views
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         # note: the user to be created should not have permissions to access
         # products repositories
@@ -2755,18 +2755,18 @@ class ContentViewTestCase(UITestCase):
     def test_positive_readonly_user_actions(self):
         """Attempt to view content views
 
-        @id: ebdc37ed-7887-4f64-944c-f2f92c58a206
+        :id: ebdc37ed-7887-4f64-944c-f2f92c58a206
 
-        @setup:
+        :setup:
 
-        1. create a user with the Content View read-only role
-        2. create content view
-        3. add a custom repository to content view
+            1. create a user with the Content View read-only role
+            2. create content view
+            3. add a custom repository to content view
 
-        @assert: User with read-only role for content view can view the
-        repository in the content view
+        :assert: User with read-only role for content view can view the
+            repository in the content view
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         repo_name = gen_string('alpha')
         cv_name = gen_string('alpha')
@@ -2882,21 +2882,21 @@ class ContentViewTestCase(UITestCase):
         """Attempt to add and remove content view's yum and docker repositories
         as a readonly user
 
-        @id: 907bf51f-8ebc-420e-b594-af0dc823e5b4
+        :id: 907bf51f-8ebc-420e-b594-af0dc823e5b4
 
-        @Setup:
+        :Setup:
 
-        1. Create a user with the Content View read-only role
-        2. Create a content view
-        3. Add custom yum and docker repositories to content view
+            1. Create a user with the Content View read-only role
+            2. Create a content view
+            3. Add custom yum and docker repositories to content view
 
-        @Assert: User with read-only role for content view can not see 'Add'/
-        'Remove' repositories tabs as well as 'Add repository' and 'Remove
-        repository' buttons
+        :Assert: User with read-only role for content view can not see 'Add'/
+            'Remove' repositories tabs as well as 'Add repository' and 'Remove
+            repository' buttons
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
 
-        @BZ: 1317828
+        :BZ: 1317828
         """
         user_login = gen_string('alpha')
         user_password = gen_string('alphanumeric')
@@ -2980,18 +2980,18 @@ class ContentViewTestCase(UITestCase):
     def test_negative_non_admin_user_actions(self):
         """Attempt to manage content views
 
-        @id: aae6eede-b40e-4e06-a5f7-59d9251aa35d
+        :id: aae6eede-b40e-4e06-a5f7-59d9251aa35d
 
-        @setup:
+        :setup:
 
-        1. create a user with the Content View read-only role
-        2. create content view
-        3. add a custom repository to content view
+            1. create a user with the Content View read-only role
+            2. create content view
+            3. add a custom repository to content view
 
-        @assert: User with read only role for content view cannot Modify,
-         Delete, Publish, Promote the content views
+        :assert: User with read only role for content view cannot Modify,
+            Delete, Publish, Promote the content views
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         # create a content view read only user with lifecycle environment
         # permissions: view_lifecycle_environments and
@@ -3107,14 +3107,14 @@ class ContentViewTestCase(UITestCase):
     def test_negative_non_readonly_user_actions(self):
         """Attempt to view content views
 
-        @id: 9cbc661a-dbe3-4b88-af27-4cf7b9544074
+        :id: 9cbc661a-dbe3-4b88-af27-4cf7b9544074
 
-        @setup: create a user with the Content View without the content views
-        read role
+        :setup: create a user with the Content View without the content views
+            read role
 
-        @assert: the user cannot access content views web resources
+        :assert: the user cannot access content views web resources
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         env_name = gen_string('alpha')
         user_login = gen_string('alpha')
@@ -3203,11 +3203,11 @@ class ContentViewTestCase(UITestCase):
     def test_positive_delete_default_version(self):
         """Delete a content-view version associated to 'Library'
 
-        @id: 6000a3f5-a8c2-49a4-ba30-d73a18d39e0a
+        :id: 6000a3f5-a8c2-49a4-ba30-d73a18d39e0a
 
-        @Assert: Deletion was performed successfully
+        :Assert: Deletion was performed successfully
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         key_content = read_data_file(ZOO_CUSTOM_GPG_KEY)
         org = entities.Organization().create()
@@ -3250,11 +3250,11 @@ class ContentViewTestCase(UITestCase):
         """Delete a content-view version associated to non-default
         environment
 
-        @id: 1c1beb36-e06b-419f-96db-43b4d85c5e25
+        :id: 1c1beb36-e06b-419f-96db-43b4d85c5e25
 
-        @Assert: Deletion was performed successfully
+        :Assert: Deletion was performed successfully
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         org = entities.Organization().create()
         product = entities.Product(organization=org).create()
@@ -3281,11 +3281,11 @@ class ContentViewTestCase(UITestCase):
         """Delete a content-view version that had associated activation
         key to it
 
-        @id: 0da50b26-f82b-4663-9372-4c39270d4323
+        :id: 0da50b26-f82b-4663-9372-4c39270d4323
 
-        @Assert: Deletion was performed successfully
+        :Assert: Deletion was performed successfully
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         org = entities.Organization().create()
         cv = entities.ContentView(organization=org).create()
@@ -3323,11 +3323,11 @@ class ContentViewTestCase(UITestCase):
     def test_positive_add_custom_ostree(self):
         """Create a CV with custom ostree contents
 
-        @id: 66626fcd-9d2b-4ff5-a596-b7754b044dbe
+        :id: 66626fcd-9d2b-4ff5-a596-b7754b044dbe
 
-        @Assert: CV should be created successfully with custom ostree contents
+        :Assert: CV should be created successfully with custom ostree contents
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         repo_name = gen_string('alpha')
         cv_name = gen_string('alpha')
@@ -3359,11 +3359,11 @@ class ContentViewTestCase(UITestCase):
     def test_positive_add_rh_ostree(self):
         """Create a CV with RH ostree contents
 
-        @id: 2c6ee15f-a058-4569-a324-aec4bba1bd17
+        :id: 2c6ee15f-a058-4569-a324-aec4bba1bd17
 
-        @Assert: CV should be created successfully with RH ostree contents
+        :Assert: CV should be created successfully with RH ostree contents
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         cv_name = gen_string('alpha')
         rh_repo = {
@@ -3398,12 +3398,12 @@ class ContentViewTestCase(UITestCase):
         """Create a CV with custom ostree contents and remove the
         contents.
 
-        @id: 0e312f20-846b-440e-9c3a-392e889c9cdd
+        :id: 0e312f20-846b-440e-9c3a-392e889c9cdd
 
-        @Assert: Content should be removed and CV should be updated
-        successfully
+        :Assert: Content should be removed and CV should be updated
+            successfully
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         repo_name = gen_string('alpha')
         cv_name = gen_string('alpha')
@@ -3446,12 +3446,12 @@ class ContentViewTestCase(UITestCase):
         """Create a CV with RH ostree contents and remove the
         contents.
 
-        @id: 852ce474-82a7-4199-9f12-5b9ad352e036
+        :id: 852ce474-82a7-4199-9f12-5b9ad352e036
 
-        @Assert: Content should be removed and CV should be updated
-        successfully
+        :Assert: Content should be removed and CV should be updated
+            successfully
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         cv_name = gen_string('alpha')
         rh_repo = {
@@ -3496,11 +3496,11 @@ class ContentViewTestCase(UITestCase):
         """Create a CV with custom ostree contents and other custom yum, puppet
         repos.
 
-        @id: b139eb12-d960-4a45-9e22-3a22184c5415
+        :id: b139eb12-d960-4a45-9e22-3a22184c5415
 
-        @Assert: CV should be created successfully with all custom contents
+        :Assert: CV should be created successfully with all custom contents
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         cv_name = gen_string('alpha')
         puppet_module = 'httpd'
@@ -3572,11 +3572,11 @@ class ContentViewTestCase(UITestCase):
     def test_positive_create_with_rh_ostree_other_contents(self):
         """Create a CV with RH ostree contents and other RH yum repos.
 
-        @id: 4398f5cc-62de-4a11-996b-24a7ad30ad3a
+        :id: 4398f5cc-62de-4a11-996b-24a7ad30ad3a
 
-        @Assert: CV should be created successfully with all custom contents
+        :Assert: CV should be created successfully with all custom contents
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         cv_name = gen_string('alpha')
         rh_ah_repo = {
@@ -3644,11 +3644,11 @@ class ContentViewTestCase(UITestCase):
     def test_positive_publish_with_custom_ostree(self):
         """Create a CV with custom ostree contents and publish it.
 
-        @id: c5e8d2ba-8cb2-47d8-b352-60972cf291e9
+        :id: c5e8d2ba-8cb2-47d8-b352-60972cf291e9
 
-        @Assert: CV should be published with OStree contents
+        :Assert: CV should be published with OStree contents
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         prod = entities.Product(organization=self.organization).create()
         # Creates new ostree repository using api
@@ -3684,12 +3684,12 @@ class ContentViewTestCase(UITestCase):
     def test_positive_remove_published_custom_ostree_version(self):
         """Remove published custom ostree contents version from selected CV.
 
-        @id: 949d6ee7-330a-4423-b219-550693522c7f
+        :id: 949d6ee7-330a-4423-b219-550693522c7f
 
-        @Assert: Published version with OStree contents should be removed
-        successfully.
+        :Assert: Published version with OStree contents should be removed
+            successfully.
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         org = entities.Organization().create()
         prod = entities.Product(organization=org).create()
@@ -3725,11 +3725,11 @@ class ContentViewTestCase(UITestCase):
         """Create a CV with custom ostree contents and publish, promote it
         to next environment.
 
-        @id: 05f4ddc8-a3ad-4caf-b417-3b437b48fa47
+        :id: 05f4ddc8-a3ad-4caf-b417-3b437b48fa47
 
-        @Assert: CV should be promoted with custom OStree contents
+        :Assert: CV should be promoted with custom OStree contents
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         prod = entities.Product(organization=self.organization).create()
         lc_env = entities.LifecycleEnvironment(
@@ -3772,11 +3772,11 @@ class ContentViewTestCase(UITestCase):
         """Remove promoted custom ostree contents from selected environment of
         CV.
 
-        @id: a66c8a9e-953e-41a5-aaac-9d9473a3d9fc
+        :id: a66c8a9e-953e-41a5-aaac-9d9473a3d9fc
 
-        @Assert: Promoted custom OStree contents should be removed successfully
+        :Assert: Promoted custom OStree contents should be removed successfully
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         org = entities.Organization().create()
         prod = entities.Product(organization=org).create()
@@ -3815,12 +3815,12 @@ class ContentViewTestCase(UITestCase):
         """Create a CV with ostree as well as yum and puppet type contents and
         publish and promote them to next environment.
 
-        @id: cf86f9bc-e32a-4048-b793-fe6e9447f7e4
+        :id: cf86f9bc-e32a-4048-b793-fe6e9447f7e4
 
-        @Assert: CV should be published and promoted with custom OStree and all
-        other contents
+        :Assert: CV should be published and promoted with custom OStree and all
+            other contents
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         puppet_module = 'httpd'
         lc_env = entities.LifecycleEnvironment(
@@ -3886,12 +3886,12 @@ class ContentViewTestCase(UITestCase):
         """Remove mixed(ostree, yum, puppet, docker) published content version
         from selected CV.
 
-        @id: b4d69aff-b667-43df-ac1f-28c58c73d846
+        :id: b4d69aff-b667-43df-ac1f-28c58c73d846
 
-        @Assert: Published version with mixed(ostree, yum, puppet, docker)
-        contents should be removed successfully.
+        :Assert: Published version with mixed(ostree, yum, puppet, docker)
+            contents should be removed successfully.
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         prod = entities.Product(organization=self.organization).create()
         # Creates new ostree repository using api
@@ -3958,11 +3958,11 @@ class ContentViewTestCase(UITestCase):
     def test_positive_publish_with_rh_ostree(self):
         """Create a CV with RH ostree contents and publish it.
 
-        @id: 4b5f487d-9de9-4645-8d73-7272f564eb75
+        :id: 4b5f487d-9de9-4645-8d73-7272f564eb75
 
-        @Assert: CV should be published with RH OStree contents
+        :Assert: CV should be published with RH OStree contents
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         rh_ah_repo = {
             'name': REPOS['rhaht']['name'],
@@ -3996,12 +3996,12 @@ class ContentViewTestCase(UITestCase):
     def test_positive_remove_published_rh_ostree_version(self):
         """Remove published rh ostree contents version from selected CV.
 
-        @id: a5767568-df3a-43c0-beb7-474c82a445d4
+        :id: a5767568-df3a-43c0-beb7-474c82a445d4
 
-        @Assert: Published version with RH OStree contents should be removed
-        successfully.
+        :Assert: Published version with RH OStree contents should be removed
+            successfully.
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         rh_ah_repo = {
             'name': REPOS['rhaht']['name'],
@@ -4034,13 +4034,13 @@ class ContentViewTestCase(UITestCase):
         """Create a CV with RH ostree contents and publish, promote it
         to next environment.
 
-        @id: 19b7a33f-d13e-454b-bfee-295296e78967
+        :id: 19b7a33f-d13e-454b-bfee-295296e78967
 
-        @Assert: CV should be promoted with RH OStree contents
+        :Assert: CV should be promoted with RH OStree contents
 
-        @caseautomation: notautomated
+        :caseautomation: notautomated
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         rh_ah_repo = {
             'name': REPOS['rhaht']['name'],
@@ -4075,11 +4075,11 @@ class ContentViewTestCase(UITestCase):
     def test_positive_remove_promoted_rh_ostree_contents(self):
         """Remove promoted rh ostree contents from selected environment of CV.
 
-        @id: 9e49e470-8b30-4941-9868-23d9718aaad9
+        :id: 9e49e470-8b30-4941-9868-23d9718aaad9
 
-        @Assert: Promoted rh OStree contents should be removed successfully
+        :Assert: Promoted rh OStree contents should be removed successfully
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         rh_ah_repo = {
             'name': REPOS['rhaht']['name'],
@@ -4114,12 +4114,12 @@ class ContentViewTestCase(UITestCase):
         """Create a CV with rh ostree as well as rh yum contents and
         publish, promote them to next environment.
 
-        @id: f1849f6a-6ad6-432f-a70c-7d61079f482a
+        :id: f1849f6a-6ad6-432f-a70c-7d61079f482a
 
-        @Assert: CV should be published and promoted with rh ostree and all
-        other contents
+        :Assert: CV should be published and promoted with rh ostree and all
+            other contents
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         rh_ah_repo = {
             'name': REPOS['rhaht']['name'],
@@ -4190,11 +4190,11 @@ class ContentViewTestCase(UITestCase):
     def test_positive_promote_CV_with_custom_user_role_and_filters(self):
         """Publish and promote cv with user with custom role and filter
 
-        @id: a07fe3df-8645-4a0c-8c56-3f8314ae4878
+        :id: a07fe3df-8645-4a0c-8c56-3f8314ae4878
 
-        @Assert: CV should be published and promoted successfully
+        :Assert: CV should be published and promoted successfully
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         myrole = get_role_by_bz(1306359)
         username = gen_string('alpha')
@@ -4233,18 +4233,18 @@ class ContentViewTestCase(UITestCase):
     def test_positive_remove_cv_version_from_default_env(self):
         """Remove content view version from Library environment
 
-        @id: 43c83c15-c883-45a7-be05-d9b26da99e3c
+        :id: 43c83c15-c883-45a7-be05-d9b26da99e3c
 
-        @Steps:
+        :Steps:
 
-        1. Create a content view
-        2. Add a yum repo to it
-        3. Publish content view
-        4. remove the published version from Library environment
+            1. Create a content view
+            2. Add a yum repo to it
+            3. Publish content view
+            4. remove the published version from Library environment
 
-        @Assert: content view version is removed from Library environment
+        :Assert: content view version is removed from Library environment
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         cv_name = gen_string('alpha')
         repo_name = gen_string('alpha')
@@ -4283,19 +4283,19 @@ class ContentViewTestCase(UITestCase):
     def test_positive_remove_renamed_cv_version_from_default_env(self):
         """Remove version of renamed content view from Library environment
 
-        @id: bd5ca409-f3ab-43b5-bb63-3b747aa75506
+        :id: bd5ca409-f3ab-43b5-bb63-3b747aa75506
 
-        @Steps:
+        :Steps:
 
-        1. Create a content view
-        2. Add a yum repo to the content view
-        3. Publish the content view
-        4. Rename the content view
-        5. remove the published version from Library environment
+            1. Create a content view
+            2. Add a yum repo to the content view
+            3. Publish the content view
+            4. Rename the content view
+            5. remove the published version from Library environment
 
-        @Assert: content view version is removed from Library environment
+        :Assert: content view version is removed from Library environment
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         cv_name = gen_string('alpha')
         new_cv_name = gen_string('alpha')
@@ -4343,22 +4343,22 @@ class ContentViewTestCase(UITestCase):
     def test_positive_remove_promoted_cv_version_from_default_env(self):
         """Remove promoted content view version from Library environment
 
-        @id: a8649444-b063-4fb4-b932-a3fae7d4021d
+        :id: a8649444-b063-4fb4-b932-a3fae7d4021d
 
-        @Steps:
+        :Steps:
 
-        1. Create a content view
-        2. Add a puppet module(s) to the content view
-        3. Publish the content view
-        4. Promote the content view version from Library -> DEV
-        5. remove the content view version from Library environment
+            1. Create a content view
+            2. Add a puppet module(s) to the content view
+            3. Publish the content view
+            4. Promote the content view version from Library -> DEV
+            5. remove the content view version from Library environment
 
-        @Assert:
+        :Assert:
 
-        1. Content view version exist only in DEV and not in Library
-        2. The puppet module(s) exists in content view version
+            1. Content view version exist only in DEV and not in Library
+            2. The puppet module(s) exists in content view version
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         cv_name = gen_string('alpha')
         env_dev_name = gen_string('alpha')
@@ -4425,21 +4425,20 @@ class ContentViewTestCase(UITestCase):
     def test_positive_remove_qe_promoted_cv_version_from_default_env(self):
         """Remove QE promoted content view version from Library environment
 
-        @id: 71ad8b72-68c4-4c98-9387-077f54ef0184
+        :id: 71ad8b72-68c4-4c98-9387-077f54ef0184
 
-        @Steps:
+        :Steps:
 
-        1. Create a content view
-        2. Add docker repo(s) to it
-        3. Publish content view
-        4. Promote the content view version to multiple environments
-           Library -> DEV -> QE
-        5. remove the content view version from Library environment
+            1. Create a content view
+            2. Add docker repo(s) to it
+            3. Publish content view
+            4. Promote the content view version to multiple environments
+                Library -> DEV -> QE
+            5. remove the content view version from Library environment
 
-        @Assert: Content view version exist only in DEV, QE
-        and not in Library
+        :Assert: Content view version exist only in DEV, QE and not in Library
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         cv_name = gen_string('alpha')
         env_dev_name = gen_string('alpha')
@@ -4499,21 +4498,21 @@ class ContentViewTestCase(UITestCase):
     def test_positive_remove_prod_promoted_cv_version_from_default_env(self):
         """Remove PROD promoted content view version from Library environment
 
-        @id: 6a874041-43c7-4682-ba06-571e49d5bbea
+        :id: 6a874041-43c7-4682-ba06-571e49d5bbea
 
-        @Steps:
+        :Steps:
 
-        1. Create a content view
-        2. Add yum repositories, puppet modules, docker repositories to CV
-        3. Publish content view
-        4. Promote the content view version to multiple environments
-           Library -> DEV -> QE -> PROD
-        5. remove the content view version from Library environment
+            1. Create a content view
+            2. Add yum repositories, puppet modules, docker repositories to CV
+            3. Publish content view
+            4. Promote the content view version to multiple environments
+                Library -> DEV -> QE -> PROD
+            5. remove the content view version from Library environment
 
-        @Assert: Content view version exist only in DEV, QE, PROD
-        and not in Library
+        :Assert: Content view version exist only in DEV, QE, PROD and not in
+            Library
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         cv_name = gen_string('alpha')
         # create env names [DEV, QE, PROD]
@@ -4604,23 +4603,23 @@ class ContentViewTestCase(UITestCase):
     def test_positive_remove_cv_version_from_env(self):
         """Remove promoted content view version from environment
 
-        @id: d1da23ee-a5db-4990-9572-1a0919a9fe1c
+        :id: d1da23ee-a5db-4990-9572-1a0919a9fe1c
 
-        @Steps:
+        :Steps:
 
-        1. Create a content view
-        2. Add a yum repo and a puppet module to the content view
-        3. Publish the content view
-        4. Promote the content view version to multiple environments
-           Library -> DEV -> QE -> STAGE -> PROD
-        5. remove the content view version from PROD environment
-        6. Assert: content view version exists only in Library, DEV, QE, STAGE
-           and not in PROD
-        7. Promote again from STAGE -> PROD
+            1. Create a content view
+            2. Add a yum repo and a puppet module to the content view
+            3. Publish the content view
+            4. Promote the content view version to multiple environments
+                Library -> DEV -> QE -> STAGE -> PROD
+            5. remove the content view version from PROD environment
+            6. Assert: content view version exists only in Library, DEV, QE,
+                STAGE and not in PROD
+            7. Promote again from STAGE -> PROD
 
-        @Assert: Content view version exist in Library, DEV, QE, STAGE, PROD
+        :Assert: Content view version exist in Library, DEV, QE, STAGE, PROD
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         cv_name = gen_string('alpha')
         # create env names [DEV, QE, STAGE, PROD]
@@ -4712,20 +4711,20 @@ class ContentViewTestCase(UITestCase):
     def test_positive_remove_cv_version_from_multi_env(self):
         """Remove promoted content view version from multiple environment
 
-        @id: 0d54c256-ac6d-4487-ab09-4e8dd257358e
+        :id: 0d54c256-ac6d-4487-ab09-4e8dd257358e
 
-        @Steps:
+        :Steps:
 
-        1. Create a content view
-        2. Add a yum repo and a puppet module to the content view
-        3. Publish the content view
-        4. Promote the content view version to multiple environments
-           Library -> DEV -> QE -> STAGE -> PROD
-        5. Remove content view version from QE, STAGE and PROD
+            1. Create a content view
+            2. Add a yum repo and a puppet module to the content view
+            3. Publish the content view
+            4. Promote the content view version to multiple environments
+                Library -> DEV -> QE -> STAGE -> PROD
+            5. Remove content view version from QE, STAGE and PROD
 
-        @Assert: Content view version exists only in Library, DEV
+        :Assert: Content view version exists only in Library, DEV
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         cv_name = gen_string('alpha')
         # create env names [DEV, QE, STAGE, PROD]
@@ -4812,21 +4811,21 @@ class ContentViewTestCase(UITestCase):
         """Delete published content view with version promoted to multiple
          environments
 
-        @id: f16f2db5-7f5b-4ebb-863e-6c18ff745ce4
+        :id: f16f2db5-7f5b-4ebb-863e-6c18ff745ce4
 
-        @Steps:
+        :Steps:
 
-        1. Create a content view
-        2. Add a yum repo and a puppet module to the content view
-        3. Publish the content view
-        4. Promote the content view to multiple environment
-           Library -> DEV -> QE -> STAGE -> PROD
-        5. Delete the content view, this should delete the content with all
-           it's published/promoted versions from all environments
+            1. Create a content view
+            2. Add a yum repo and a puppet module to the content view
+            3. Publish the content view
+            4. Promote the content view to multiple environment Library -> DEV
+                -> QE -> STAGE -> PROD
+            5. Delete the content view, this should delete the content with all
+                it's published/promoted versions from all environments
 
-        @Assert: The content view doesn't exists
+        :Assert: The content view doesn't exists
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         cv_name = gen_string('alpha')
         # create env names [DEV, QE, STAGE, PROD]
@@ -4912,38 +4911,37 @@ class ContentViewTestCase(UITestCase):
         """Remove promoted content view version from environment that is used
         in association of an Activation key and content-host registration.
 
-        @id: a8ca3de1-3f79-4029-8033-00315b6b854f
+        :id: a8ca3de1-3f79-4029-8033-00315b6b854f
 
-        @Steps:
+        :Steps:
 
-        1. Create a content view cv1
-        2. Add a yum repo and a puppet module to the content view
-        3. Publish the content view
-        4. Promote the content view to multiple environment
-           Library -> DEV -> QE
-        5. Create an Activation key with the QE environment
-        6. Register a content-host using the Activation key
-        7. Remove the content view cv1 version from QE environment.
-           The remove environment wizard should propose to replace the current
-           QE environment of cv1 by an other (as QE environment of cv1
-           is attached to a content-host),
-           choose DEV and content view cv1 as a replacement for Content-host
-           and for Activation key.
-        8. Refresh content-host subscription
+            1. Create a content view cv1
+            2. Add a yum repo and a puppet module to the content view
+            3. Publish the content view
+            4. Promote the content view to multiple environment Library -> DEV
+                -> QE
+            5. Create an Activation key with the QE environment
+            6. Register a content-host using the Activation key
+            7. Remove the content view cv1 version from QE environment.  The
+                remove environment wizard should propose to replace the current
+                QE environment of cv1 by an other (as QE environment of cv1 is
+                attached to a content-host), choose DEV and content view cv1 as
+                a replacement for Content-host and for Activation key.
+            8. Refresh content-host subscription
 
-        @Assert:
+        :Assert:
 
-        1. Activation key exists
-        2. Content-host exists
-        3. QE environment of cv1 was replaced by DEV environment of cv1
-           in activation key
-        4. QE environment of cv1 was replaced by DEV environment of cv1
-           in content-host
-        5. At content-host some package from cv1 is installable
+            1. Activation key exists
+            2. Content-host exists
+            3. QE environment of cv1 was replaced by DEV environment of cv1 in
+                activation key
+            4. QE environment of cv1 was replaced by DEV environment of cv1 in
+                content-host
+            5. At content-host some package from cv1 is installable
 
-        @caseautomation: notautomated
+        :caseautomation: notautomated
 
-        @CaseLevel: System
+        :CaseLevel: System
         """
 
     @stubbed()
@@ -4954,38 +4952,38 @@ class ContentViewTestCase(UITestCase):
          environments, with one of the environments used in association of an
          Activation key and content-host registration.
 
-        @id: 73453c99-8f34-413d-8f95-e4a2f4c58a00
+        :id: 73453c99-8f34-413d-8f95-e4a2f4c58a00
 
-        @Steps:
+        :Steps:
 
-        1. Create two content view cv1 and cv2
-        2. Add a yum repo and a puppet module to both content views
-        3. Publish the content views
-        4. Promote the content views to multiple environment
-           Library -> DEV -> QE
-        5. Create an Activation key with the QE environment and cv1
-        6. Register a content-host using the Activation key
-        7. Delete the content view cv1.
-           The delete content view wizard should propose to replace the current
-           QE environment of cv1 by an other (as QE environment of cv1
-           is attached to a content-host), choose DEV and content view cv2
-           as a replacement for Content-host and for Activation key.
-        8. Refresh content-host subscription
+            1. Create two content view cv1 and cv2
+            2. Add a yum repo and a puppet module to both content views
+            3. Publish the content views
+            4. Promote the content views to multiple environment Library -> DEV
+                -> QE
+            5. Create an Activation key with the QE environment and cv1
+            6. Register a content-host using the Activation key
+            7. Delete the content view cv1.  The delete content view wizard
+                should propose to replace the current QE environment of cv1 by
+                an other (as QE environment of cv1 is attached to a
+                content-host), choose DEV and content view cv2 as a replacement
+                for Content-host and for Activation key.
+            8. Refresh content-host subscription
 
-        @Assert:
+        :Assert:
 
-        1. The content view cv1 doesn't exist
-        2. Activation key exists
-        3. Content-host exists
-        4. QE environment of cv1 was replaced by DEV environment of cv2
-           in activation key
-        5. QE environment of cv1 was replaced by DEV environment of cv2
-           in content-host
-        6. At content-host some package from cv2 is installable
+            1. The content view cv1 doesn't exist
+            2. Activation key exists
+            3. Content-host exists
+            4. QE environment of cv1 was replaced by DEV environment of cv2 in
+                activation key
+            5. QE environment of cv1 was replaced by DEV environment of cv2 in
+                content-host
+            6. At content-host some package from cv2 is installable
 
-        @caseautomation: notautomated
+        :caseautomation: notautomated
 
-        @CaseLevel: System
+        :CaseLevel: System
         """
 
     @stubbed()
@@ -4995,33 +4993,34 @@ class ContentViewTestCase(UITestCase):
         """Remove promoted content view version from multiple environment,
         with satellite setup to use capsule
 
-        @id: ba731272-66e6-461e-8e9d-564b4092a92d
+        :id: ba731272-66e6-461e-8e9d-564b4092a92d
 
-        @Steps:
+        :Steps:
 
-        1. Create a content view
-        2. Setup satellite to use a capsule and to sync all lifecycle
-           environments
-        3. Add a yum repo, puppet module and a docker repo to the content view
-        4. Publish the content view
-        5. Promote the content view to multiple environment
-           Library -> DEV -> QE -> PROD
-        6. Make sure the capsule is updated (content synchronization may be
-           applied)
-        7. Disconnect the capsule
-        8. Remove the content view version from Library and DEV environments
-           and assert successful completion
-        9. Bring the capsule back online and assert that the task is completed
-           in capsule
-        10. Make sure the capsule is updated (content synchronization may be
-            applied)
+            1. Create a content view
+            2. Setup satellite to use a capsule and to sync all lifecycle
+                environments
+            3. Add a yum repo, puppet module and a docker repo to the content
+                view
+            4. Publish the content view
+            5. Promote the content view to multiple environment Library -> DEV
+                -> QE -> PROD
+            6. Make sure the capsule is updated (content synchronization may be
+                applied)
+            7. Disconnect the capsule
+            8. Remove the content view version from Library and DEV
+                environments and assert successful completion
+            9. Bring the capsule back online and assert that the task is
+                completed in capsule
+            10. Make sure the capsule is updated (content synchronization may
+                be applied)
 
-        @Assert: content view version in capsule is removed from Library
-        and DEV and exists only in QE and PROD
+        :Assert: content view version in capsule is removed from Library and
+            DEV and exists only in QE and PROD
 
-        @caseautomation: notautomated
+        :caseautomation: notautomated
 
-        @CaseLevel: System
+        :CaseLevel: System
         """
         # Note: This test case requires complete external capsule
         #  configuration.

--- a/tests/foreman/ui/test_dashboard.py
+++ b/tests/foreman/ui/test_dashboard.py
@@ -1,18 +1,18 @@
 """Test module for Dashboard UI
 
-@Requirement: Dashboard
+:Requirement: Dashboard
 
-@CaseAutomation: Automated
+:CaseAutomation: Automated
 
-@CaseLevel: Acceptance
+:CaseLevel: Acceptance
 
-@CaseComponent: UI
+:CaseComponent: UI
 
-@TestType: Functional
+:TestType: Functional
 
-@CaseImportance: High
+:CaseImportance: High
 
-@Upstream: No
+:Upstream: No
 """
 from nailgun import entities
 from requests.exceptions import HTTPError
@@ -34,17 +34,17 @@ class DashboardTestCase(UITestCase):
     def test_positive_search_random(self):
         """Perform search on Dashboard using any random string
 
-        @id: 28062a97-d642-41ac-b107-0b8a41eac478
+        :id: 28062a97-d642-41ac-b107-0b8a41eac478
 
-        @Steps:
+        :Steps:
 
-        1. Navigate to Monitor -> Dashboard
-        2. Perform search using any random test string
+            1. Navigate to Monitor -> Dashboard
+            2. Perform search using any random test string
 
-        @BZ: 1391365
+        :BZ: 1391365
 
-        @Assert: Check that we have zero as a result of search and any error is
-        not raised
+        :Assert: Check that we have zero as a result of search and any error is
+            not raised
         """
         with Session(self.browser) as session:
             set_context(session, org=ANY_CONTEXT['org'])
@@ -56,14 +56,14 @@ class DashboardTestCase(UITestCase):
     def test_positive_search(self):
         """Check if the search box is working in the Dashboard UI
 
-        @id: 1545580c-1f0e-4991-a400-4a6224199452
+        :id: 1545580c-1f0e-4991-a400-4a6224199452
 
-        @Steps:
+        :Steps:
 
-        1. Navigate to Monitor -> Dashboard
-        2. Add a filter to search box (eg. environment)
+            1. Navigate to Monitor -> Dashboard
+            2. Add a filter to search box (eg. environment)
 
-        @Assert: Data displayed according to search box
+        :Assert: Data displayed according to search box
         """
         with Session(self.browser) as session:
             set_context(session, org=ANY_CONTEXT['org'])
@@ -75,16 +75,16 @@ class DashboardTestCase(UITestCase):
         """Check if the user is able to clear the search box in the Dashboard
         UI
 
-        @id: 97335970-dc1a-485d-aeb2-de6ece2197c3
+        :id: 97335970-dc1a-485d-aeb2-de6ece2197c3
 
-        @Steps:
+        :Steps:
 
-        1. Navigate to Monitor -> Dashboard
-        2. Add a filter to search box (eg. environment)
-        3. Data displayed according to search box
-        4. On left side of the box click the Clear cross sign
+            1. Navigate to Monitor -> Dashboard
+            2. Add a filter to search box (eg. environment)
+            3. Data displayed according to search box
+            4. On left side of the box click the Clear cross sign
 
-        @Assert: Search box is cleared
+        :Assert: Search box is cleared
         """
         org = entities.Organization().create()
         entities.Host(organization=org).create()
@@ -103,14 +103,14 @@ class DashboardTestCase(UITestCase):
     def test_positive_remove_widget(self):
         """Check if the user is able to remove widget in the Dashboard UI
 
-        @id: 25c6e9e8-a7b6-4aa4-96dd-0d303e0c3aa0
+        :id: 25c6e9e8-a7b6-4aa4-96dd-0d303e0c3aa0
 
-        @Steps:
+        :Steps:
 
-        1. Navigate to Monitor -> Dashboard
-        2. Try to remove some widget
+            1. Navigate to Monitor -> Dashboard
+            2. Try to remove some widget
 
-        @Assert: Widget is removed and is not present on Dashboard
+        :Assert: Widget is removed and is not present on Dashboard
         """
         with Session(self.browser):
             self.dashboard.remove_widget('Latest Events')
@@ -121,17 +121,17 @@ class DashboardTestCase(UITestCase):
     def test_positive_save(self):
         """Save the Dashboard UI
 
-        @id: 0bd8560c-d612-49c7-83ee-558bbaa16bce
+        :id: 0bd8560c-d612-49c7-83ee-558bbaa16bce
 
-        @Steps:
+        :Steps:
 
-        1. Navigate to Monitor -> Dashboard
-        2. Try to remove some widgets
-        3. Select the Manage Dropdown box
-        4. Save the Dashboard
+            1. Navigate to Monitor -> Dashboard
+            2. Try to remove some widgets
+            3. Select the Manage Dropdown box
+            4. Save the Dashboard
 
-        @Assert: Dashboard is saved successfully and the removed widgets does
-        not appear.
+        :Assert: Dashboard is saved successfully and the removed widgets does
+            not appear.
         """
         with Session(self.browser):
             self.dashboard.remove_widget('Host Configuration Chart')
@@ -144,18 +144,18 @@ class DashboardTestCase(UITestCase):
     def test_positive_reset(self):
         """Reset the Dashboard to default UI
 
-        @id: 040c5910-a296-4cfc-ad1f-1b4fc9be8199
+        :id: 040c5910-a296-4cfc-ad1f-1b4fc9be8199
 
-        @Steps:
+        :Steps:
 
-        1. Navigate to Monitor -> Dashboard
-        2. Try to remove some widgets
-        3. Select the Manage Dropdown box
-        4. Save the Dashboard
-        5. Dashboard Widgets are saved successfully
-        6. Click Reset to default
+            1. Navigate to Monitor -> Dashboard
+            2. Try to remove some widgets
+            3. Select the Manage Dropdown box
+            4. Save the Dashboard
+            5. Dashboard Widgets are saved successfully
+            6. Click Reset to default
 
-        @Assert: Widget positions successfully saved.
+        :Assert: Widget positions successfully saved.
         """
         with Session(self.browser):
             self.dashboard.remove_widget('Task Status')
@@ -169,17 +169,17 @@ class DashboardTestCase(UITestCase):
     def test_positive_add_widgets(self):
         """Add Widgets to the Dashboard UI
 
-        @id: ec57d051-83d9-4c11-84ff-4de292784fc1
+        :id: ec57d051-83d9-4c11-84ff-4de292784fc1
 
-        @Steps:
+        :Steps:
 
-        1. Navigate to Monitor -> Dashboard
-        2. Select Manage Dropdown box
-        3. Add Widgets
+            1. Navigate to Monitor -> Dashboard
+            2. Select Manage Dropdown box
+            3. Add Widgets
 
-        @Assert: User is able to add widgets.
+        :Assert: User is able to add widgets.
 
-        @caseautomation: notautomated
+        :caseautomation: notautomated
         """
 
     @run_in_one_thread
@@ -188,17 +188,17 @@ class DashboardTestCase(UITestCase):
         """Check if the user is able to add removed
         widget in the Dashboard UI
 
-        @id: 156f559f-bb23-480f-bdf0-5dd2ee545fa9
+        :id: 156f559f-bb23-480f-bdf0-5dd2ee545fa9
 
-        @Steps:
+        :Steps:
 
-        1. Navigate to Monitor -> Dashboard
-        2. Try to remove some widget
-        3. Widget is removed
-        4. The widget is listed under Manage -> Add Widget
-        5. Click to add the widget back
+            1. Navigate to Monitor -> Dashboard
+            2. Try to remove some widget
+            3. Widget is removed
+            4. The widget is listed under Manage -> Add Widget
+            5. Click to add the widget back
 
-        @Assert: The widget is added back to the Dashboard
+        :Assert: The widget is added back to the Dashboard
         """
         with Session(self.browser):
             for widget in ['Discovered Hosts', 'Content View History']:
@@ -213,14 +213,14 @@ class DashboardTestCase(UITestCase):
         """Check if the user is able to minimize the widget
         in the Dashboard UI
 
-        @id: 21f10b30-b121-4347-807d-7b949a3f0e4f
+        :id: 21f10b30-b121-4347-807d-7b949a3f0e4f
 
-        @Steps:
+        :Steps:
 
-        1. Navigate to Monitor -> Dashboard
-        2. Try to minimize some widget
+            1. Navigate to Monitor -> Dashboard
+            2. Try to minimize some widget
 
-        @Assert: Widget is minimized and is not present on Dashboard
+        :Assert: Widget is minimized and is not present on Dashboard
         """
         with Session(self.browser):
             for widget in ['Sync Overview', 'Compliance Reports Breakdown']:
@@ -232,17 +232,17 @@ class DashboardTestCase(UITestCase):
         """Check if the user is able to restoring the minimized
         widget in the Dashboard UI
 
-        @id: f42fdcce-26fb-4c56-ac4e-1e00b077bd78
+        :id: f42fdcce-26fb-4c56-ac4e-1e00b077bd78
 
-        @Steps:
+        :Steps:
 
-        1. Navigate to Monitor -> Dashboard
-        2. Try to minimize some widget
-        3. Widget is minimized
-        4. The widget is listed under Manage -> Restore Widget
-        5. Click to add the widget back
+            1. Navigate to Monitor -> Dashboard
+            2. Try to minimize some widget
+            3. Widget is minimized
+            4. The widget is listed under Manage -> Restore Widget
+            5. Click to add the widget back
 
-        @Assert: The widget is added back to the Dashboard
+        :Assert: The widget is added back to the Dashboard
         """
         with Session(self.browser):
             self.dashboard.minimize_widget('Latest Errata')
@@ -253,14 +253,14 @@ class DashboardTestCase(UITestCase):
     def test_positive_toggle_auto_refresh(self):
         """Check if the user is able to Toggle Auto refresh in the Dashboard UI
 
-        @id: 2cbb2f2c-ddf2-492a-bda1-904c30da0de3
+        :id: 2cbb2f2c-ddf2-492a-bda1-904c30da0de3
 
-        @Steps:
+        :Steps:
 
-        1. Navigate to Monitor -> Dashboard
-        2. Click Auto Refresh ON/OFF
+            1. Navigate to Monitor -> Dashboard
+            2. Click Auto Refresh ON/OFF
 
-        @Assert: The auto refresh functionality works as per the set value.
+        :Assert: The auto refresh functionality works as per the set value.
         """
         with Session(self.browser):
             self.dashboard.navigate_to_entity()
@@ -281,35 +281,35 @@ class DashboardTestCase(UITestCase):
     def test_positive_search_bookmark(self):
         """Bookmark the search filter in Dashboard UI
 
-        @id: f9e6259e-2b97-46fc-b357-26ea5ea8d16c
+        :id: f9e6259e-2b97-46fc-b357-26ea5ea8d16c
 
-        @Steps:
+        :Steps:
 
-        1. Navigate to Monitor -> Dashboard
-        2. Add a filter to search box (eg. environment)
-        3. Bookmark the search filter
+            1. Navigate to Monitor -> Dashboard
+            2. Add a filter to search box (eg. environment)
+            3. Bookmark the search filter
 
-        @Assert: User is able to list the Bookmark
+        :Assert: User is able to list the Bookmark
 
-        @caseautomation: notautomated
+        :caseautomation: notautomated
         """
 
     @tier2
     def test_positive_host_configuration_status(self):
         """Check if the Host Configuration Status Widget links are working
 
-        @id: ffb0a6a1-2b65-4578-83c7-61492122d865
+        :id: ffb0a6a1-2b65-4578-83c7-61492122d865
 
-        @Steps:
+        :Steps:
 
-        1. Navigate to Monitor -> Dashboard
-        2. Review the Host Configuration Status
-        3. Navigate to each of the links which has search string associated
-           with it.
+            1. Navigate to Monitor -> Dashboard
+            2. Review the Host Configuration Status
+            3. Navigate to each of the links which has search string associated
+               with it.
 
-        @Assert: Each link shows the right info
+        :Assert: Each link shows the right info
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         criteria_list = [
             'Hosts that had performed modifications without error',
@@ -357,17 +357,17 @@ class DashboardTestCase(UITestCase):
     def test_positive_host_configuration_chart(self):
         """Check if the Host Configuration Chart is working in the Dashboard UI
 
-        @id: b03314aa-4394-44e5-86da-c341c783003d
+        :id: b03314aa-4394-44e5-86da-c341c783003d
 
-        @Steps:
+        :Steps:
 
-        1. Navigate to Monitor -> Dashboard
-        2. Review the Host Configuration Chart widget
-        3. Check that chart contains correct percentage value
+            1. Navigate to Monitor -> Dashboard
+            2. Review the Host Configuration Chart widget
+            3. Check that chart contains correct percentage value
 
-        @Assert: Chart showing correct data
+        :Assert: Chart showing correct data
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         org = entities.Organization().create()
         entities.Host(organization=org).create()
@@ -383,17 +383,17 @@ class DashboardTestCase(UITestCase):
     def test_positive_task_status(self):
         """Check if the Task Status is working in the Dashboard UI
 
-        @id: fb667d6a-7255-4341-9f79-2f03d19e8e0f
+        :id: fb667d6a-7255-4341-9f79-2f03d19e8e0f
 
-        @Steps:
+        :Steps:
 
-        1. Navigate to Monitor -> Dashboard
-        2. Review the Task Status widget
-        3. Click each link
+            1. Navigate to Monitor -> Dashboard
+            2. Review the Task Status widget
+            3. Click each link
 
-        @Assert: Each link shows the right info
+        :Assert: Each link shows the right info
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         org = entities.Organization().create()
         content_view = entities.ContentView(organization=org).create()
@@ -416,16 +416,16 @@ class DashboardTestCase(UITestCase):
         """Check if the Latest Warning/Error
         Tasks Status are working in the Dashboard UI
 
-        @id: c90df864-1472-4b7c-91e6-9ea9e98384a9
+        :id: c90df864-1472-4b7c-91e6-9ea9e98384a9
 
-        @Steps:
+        :Steps:
 
-        1. Navigate to Monitor -> Dashboard
-        2. Review the Latest Warning/Error Tasks widget.
+            1. Navigate to Monitor -> Dashboard
+            2. Review the Latest Warning/Error Tasks widget.
 
-        @Assert: The links to all failed/warnings tasks are working
+        :Assert: The links to all failed/warnings tasks are working
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         name = entities.Organization().create().name
         with self.assertRaises(HTTPError):
@@ -442,17 +442,17 @@ class DashboardTestCase(UITestCase):
     def test_positive_content_view_history(self):
         """Check if the Content View History are working in the Dashboard UI
 
-        @id: cb63a67d-7cca-4d2c-9abf-9f4f5e92c856
+        :id: cb63a67d-7cca-4d2c-9abf-9f4f5e92c856
 
-        @Steps:
+        :Steps:
 
-        1. Navigate to Monitor -> Dashboard
-        2. Review the Content View History widget
+            1. Navigate to Monitor -> Dashboard
+            2. Review the Content View History widget
 
-        @Assert: Each Content View link shows its current status
-        (the environment to which it is published)
+        :Assert: Each Content View link shows its current status (the
+            environment to which it is published)
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         org = entities.Organization().create()
         lc_env = entities.LifecycleEnvironment(organization=org).create()
@@ -478,19 +478,19 @@ class DashboardTestCase(UITestCase):
         """Check if the user can access Discovered Host Widget in the Dashboard
         UI
 
-        @id: 1e06af1b-c21f-42a9-a432-2ed18e0b225f
+        :id: 1e06af1b-c21f-42a9-a432-2ed18e0b225f
 
-        @Steps:
+        :Steps:
 
-        1. Navigate to Monitor -> Dashboard
-        2. Review the Discovered Hosts widget
-        3. Click on the list of Discovered Hosts
+            1. Navigate to Monitor -> Dashboard
+            2. Review the Discovered Hosts widget
+            3. Click on the list of Discovered Hosts
 
-        @Assert: It takes you to discovered hosts
+        :Assert: It takes you to discovered hosts
 
-        @caseautomation: notautomated
+        :caseautomation: notautomated
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
 
     @stubbed()
@@ -498,34 +498,34 @@ class DashboardTestCase(UITestCase):
     def test_positive_latest_events_widget(self):
         """Check if the Latest Events Widget is working in the Dashboard UI
 
-        @id: 6ca2f113-bf15-406a-8b15-77c377048ac6
+        :id: 6ca2f113-bf15-406a-8b15-77c377048ac6
 
-        @Steps:
+        :Steps:
 
-        1. Navigate to Monitor -> Dashboard
-        2. Review the Latest Events widget
+            1. Navigate to Monitor -> Dashboard
+            2. Review the Latest Events widget
 
-        @Assert: The Widget is updated with all the latest events
+        :Assert: The Widget is updated with all the latest events
 
-        @caseautomation: notautomated
+        :caseautomation: notautomated
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
 
     @tier1
     def test_positive_sync_overview_widget(self):
         """Check if the Sync Overview Widget is working in the Dashboard UI
 
-        @id: 515027f5-19e8-4f83-9042-1c347a63758f
+        :id: 515027f5-19e8-4f83-9042-1c347a63758f
 
-        @Steps:
+        :Steps:
 
-        1. Create a product
-        2. Add a repo and sync it
-        3. Navigate to Monitor -> Dashboard
-        4. Review the Sync Overview widget for the above sync details
+            1. Create a product
+            2. Add a repo and sync it
+            3. Navigate to Monitor -> Dashboard
+            4. Review the Sync Overview widget for the above sync details
 
-        @Assert: Sync Overview widget is updated with all sync processes
+        :Assert: Sync Overview widget is updated with all sync processes
         """
         org = entities.Organization().create()
         product = entities.Product(organization=org).create()
@@ -548,25 +548,25 @@ class DashboardTestCase(UITestCase):
         """Check if the Content Host Subscription Status is working in the
         Dashboard UI
 
-        @id: ce0d7b0c-ae6a-4361-8173-e50f6381194a
+        :id: ce0d7b0c-ae6a-4361-8173-e50f6381194a
 
-        @Steps:
+        :Steps:
 
-        1. Register Content Host and subscribe it
-        2. Navigate Monitor -> Dashboard
-        3. Review the Content Host Subscription Status
-        4. Click each link:
+            1. Register Content Host and subscribe it
+            2. Navigate Monitor -> Dashboard
+            3. Review the Content Host Subscription Status
+            4. Click each link:
 
-          a. Invalid Subscriptions
-          b. Insufficient Subscriptions
-          c. Current Subscriptions
+                a. Invalid Subscriptions
+                b. Insufficient Subscriptions
+                c. Current Subscriptions
 
-        @Assert: The widget is updated with all details for Current,
-        Invalid and Insufficient Subscriptions
+        :Assert: The widget is updated with all details for Current, Invalid
+            and Insufficient Subscriptions
 
-        @caseautomation: notautomated
+        :caseautomation: notautomated
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
 
     @tier1
@@ -574,16 +574,16 @@ class DashboardTestCase(UITestCase):
         """Check if the Current Subscriptions Totals widget is working in the
         Dashboard UI
 
-        @id: 6d0f56ff-7007-4cdb-96f3-d9e8b6cc1701
+        :id: 6d0f56ff-7007-4cdb-96f3-d9e8b6cc1701
 
-        @Steps:
+        :Steps:
 
-        1. Make sure sat6 has some active subscriptions
-        2. Navigate to Monitor -> Dashboard
-        3. Review the Current Subscription Total widget
+            1. Make sure sat6 has some active subscriptions
+            2. Navigate to Monitor -> Dashboard
+            3. Review the Current Subscription Total widget
 
-        @Assert: The widget displays all the active subscriptions and expired
-        subscriptions details
+        :Assert: The widget displays all the active subscriptions and expired
+            subscriptions details
         """
         org = entities.Organization().create()
         with manifests.clone() as manifest:
@@ -602,18 +602,18 @@ class DashboardTestCase(UITestCase):
         """Check if the Host Collections widget displays list of host
         collection in UI
 
-        @id: 1feae601-987d-4553-8644-4ceef5059e64
+        :id: 1feae601-987d-4553-8644-4ceef5059e64
 
-        @Steps:
+        :Steps:
 
-        1. Make sure to have some hosts and host collections
-        2. Navigate Monitor -> Dashboard
-        3. Review the Host Collections Widget
+            1. Make sure to have some hosts and host collections
+            2. Navigate Monitor -> Dashboard
+            3. Review the Host Collections Widget
 
-        @Assert: The list of host collections along with content host is
-        displayed in the widget
+        :Assert: The list of host collections along with content host is
+            displayed in the widget
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         org = entities.Organization().create()
         host = entities.Host(organization=org).create()
@@ -633,18 +633,18 @@ class DashboardTestCase(UITestCase):
     def test_positive_run_distribution_widget(self):
         """Check if the Run distribution widget is working in the Dashboard UI
 
-        @id: ed2205c6-9ba6-4b9a-895a-d6fa8157cb90
+        :id: ed2205c6-9ba6-4b9a-895a-d6fa8157cb90
 
-        @Steps:
+        :Steps:
 
-        1. Navigate Monitor -> Dashboard
-        2. Review the Run Distribution in the last 30 minutes widget
+            1. Navigate Monitor -> Dashboard
+            2. Review the Run Distribution in the last 30 minutes widget
 
-        @Assert: The widget shows appropriate data
+        :Assert: The widget shows appropriate data
 
-        @caseautomation: notautomated
+        :caseautomation: notautomated
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
 
     @stubbed()
@@ -652,17 +652,17 @@ class DashboardTestCase(UITestCase):
     def test_positive_latest_errata_widget(self):
         """Check if the Latest Errata widget is working in Dashboard the UI
 
-        @id: 9012744f-9717-4d6e-a05c-bc7b4b1c1657
+        :id: 9012744f-9717-4d6e-a05c-bc7b4b1c1657
 
-        @Steps:
+        :Steps:
 
-        1. Make sure you have applied some errata to content host
-        2. Navigate Monitor -> Dashboard
-        3. Review the Latest Errata widget
+            1. Make sure you have applied some errata to content host
+            2. Navigate Monitor -> Dashboard
+            3. Review the Latest Errata widget
 
-        @Assert: The widget is updated with all errata related details
+        :Assert: The widget is updated with all errata related details
 
-        @caseautomation: notautomated
+        :caseautomation: notautomated
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """

--- a/tests/foreman/ui/test_discoveredhost.py
+++ b/tests/foreman/ui/test_discoveredhost.py
@@ -1,19 +1,19 @@
 # -*- encoding: utf-8 -*-
 """Test class for Foreman Discovery
 
-@Requirement: Discoveredhost
+:Requirement: Discoveredhost
 
-@CaseAutomation: Automated
+:CaseAutomation: Automated
 
-@CaseLevel: Acceptance
+:CaseLevel: Acceptance
 
-@CaseComponent: UI
+:CaseComponent: UI
 
-@TestType: Functional
+:TestType: Functional
 
-@CaseImportance: High
+:CaseImportance: High
 
-@Upstream: No
+:Upstream: No
 """
 import subprocess
 import time
@@ -145,16 +145,15 @@ class DiscoveryTestCase(UITestCase):
         """Discover a host via PXE boot by setting "proxy.type=proxy" in
         PXE default
 
-        @id: 43a8857d-2f08-436e-97fb-ffec6a0c84dd
+        :id: 43a8857d-2f08-436e-97fb-ffec6a0c84dd
 
-        @Setup: Provisioning should be configured
+        :Setup: Provisioning should be configured
 
-        @Steps: PXE boot a host/VM
+        :Steps: PXE boot a host/VM
 
-        @Assert: Host should be successfully discovered
+        :Assert: Host should be successfully discovered
 
-
-        @CaseLevel: System
+        :CaseLevel: System
         """
         with Session(self.browser) as session:
             session.nav.go_to_select_org(self.org_name)
@@ -171,16 +170,15 @@ class DiscoveryTestCase(UITestCase):
         """Discover a host with dhcp via bootable discovery ISO by setting
         "proxy.type=proxy" in PXE default in unattended mode.
 
-        @id: fc13167f-6fa0-4fe5-8584-7716292866ce
+        :id: fc13167f-6fa0-4fe5-8584-7716292866ce
 
-        @Setup: Provisioning should be configured
+        :Setup: Provisioning should be configured
 
-        @Steps: Boot a host/VM using modified discovery ISO.
+        :Steps: Boot a host/VM using modified discovery ISO.
 
-        @Assert: Host should be successfully discovered
+        :Assert: Host should be successfully discovered
 
-
-        @CaseLevel: System
+        :CaseLevel: System
         """
         with Session(self.browser) as session:
             session.nav.go_to_select_org(self.org_name)
@@ -198,17 +196,17 @@ class DiscoveryTestCase(UITestCase):
         """Discover a host with dhcp via bootable discovery ISO in
         semi-automated mode.
 
-        @id: 05c88618-6f15-4eb8-8501-3505160c5450
+        :id: 05c88618-6f15-4eb8-8501-3505160c5450
 
-        @Setup: Provisioning should be configured
+        :Setup: Provisioning should be configured
 
-        @Steps: Boot a host/VM using discovery ISO
+        :Steps: Boot a host/VM using discovery ISO
 
-        @Assert: Host should be successfully discovered
+        :Assert: Host should be successfully discovered
 
-        @caseautomation: notautomated
+        :caseautomation: notautomated
 
-        @CaseLevel: System
+        :CaseLevel: System
         """
 
     @run_only_on('sat')
@@ -218,17 +216,17 @@ class DiscoveryTestCase(UITestCase):
         """Discover a host with dhcp via bootable discovery ISO using
         interactive TUI mode.
 
-        @id: 08780627-9ac1-4837-88eb-df673d974d05
+        :id: 08780627-9ac1-4837-88eb-df673d974d05
 
-        @Setup: Provisioning should be configured
+        :Setup: Provisioning should be configured
 
-        @Steps: Boot a host/VM using discovery ISO
+        :Steps: Boot a host/VM using discovery ISO
 
-        @Assert: Host should be successfully discovered
+        :Assert: Host should be successfully discovered
 
-        @caseautomation: notautomated
+        :caseautomation: notautomated
 
-        @CaseLevel: System
+        :CaseLevel: System
         """
 
     @run_only_on('sat')
@@ -238,13 +236,13 @@ class DiscoveryTestCase(UITestCase):
         """Discover a host with single NIC on a network without DHCP and PXE
         using ISO image in interactive TUI interface.
 
-        @id: 9703eb00-9857-4076-8b83-031a58d7c1cd
+        :id: 9703eb00-9857-4076-8b83-031a58d7c1cd
 
-        @Assert: Host should be discovered successfully
+        :Assert: Host should be discovered successfully
 
-        @caseautomation: notautomated
+        :caseautomation: notautomated
 
-        @CaseLevel: System
+        :CaseLevel: System
         """
 
     @run_only_on('sat')
@@ -254,13 +252,13 @@ class DiscoveryTestCase(UITestCase):
         """Discover a host with single NIC on a network without DHCP and PXE
         using ISO image in semi-automated mode.
 
-        @id: 8254a85f-21c8-4483-b453-15126762f6e5
+        :id: 8254a85f-21c8-4483-b453-15126762f6e5
 
-        @Assert: Host should be discovered successfully
+        :Assert: Host should be discovered successfully
 
-        @caseautomation: notautomated
+        :caseautomation: notautomated
 
-        @CaseLevel: System
+        :CaseLevel: System
         """
 
     @run_only_on('sat')
@@ -270,13 +268,13 @@ class DiscoveryTestCase(UITestCase):
         """Discover a host with single NIC on a network without DHCP and PXE
         using ISO image in unattended mode.
 
-        @id: ae75173f-8358-4886-9420-06cff3a8510e
+        :id: ae75173f-8358-4886-9420-06cff3a8510e
 
-        @Assert: Host should be discovered successfully
+        :Assert: Host should be discovered successfully
 
-        @caseautomation: notautomated
+        :caseautomation: notautomated
 
-        @CaseLevel: System
+        :CaseLevel: System
         """
 
     @run_only_on('sat')
@@ -286,13 +284,13 @@ class DiscoveryTestCase(UITestCase):
         """Discover a EFI host with single NIC on a network
         using ISO image in interactive TUI mode.
 
-        @id: f13fd843-6b39-4c5e-bb7a-b9af9e71eb7b
+        :id: f13fd843-6b39-4c5e-bb7a-b9af9e71eb7b
 
-        @Assert: Host should be discovered successfully
+        :Assert: Host should be discovered successfully
 
-        @caseautomation: notautomated
+        :caseautomation: notautomated
 
-        @CaseLevel: System
+        :CaseLevel: System
         """
 
     @run_only_on('sat')
@@ -302,13 +300,13 @@ class DiscoveryTestCase(UITestCase):
         """Discover a EFI host with single NIC on a network
         using ISO image in unattended mode.
 
-        @id: 515d32ce-44eb-4d27-a353-699bc80fc566
+        :id: 515d32ce-44eb-4d27-a353-699bc80fc566
 
-        @Assert: Host should be discovered successfully
+        :Assert: Host should be discovered successfully
 
-        @caseautomation: notautomated
+        :caseautomation: notautomated
 
-        @CaseLevel: System
+        :CaseLevel: System
         """
 
     @run_only_on('sat')
@@ -317,11 +315,11 @@ class DiscoveryTestCase(UITestCase):
         """Discover a host with multiple NIC on a network with dhcp
         using ISO image in unattended mode.
 
-        @id: cdfebc3d-d8c1-4f82-a384-cc5cd9926c65
+        :id: cdfebc3d-d8c1-4f82-a384-cc5cd9926c65
 
-        @Assert: Host should be discovered successfully
+        :Assert: Host should be discovered successfully
 
-        @CaseLevel: System
+        :CaseLevel: System
         """
         with Session(self.browser) as session:
             session.nav.go_to_select_org(self.org_name)
@@ -345,13 +343,13 @@ class DiscoveryTestCase(UITestCase):
         """Discover a host with multiple NIC on a network with dhcp
         using ISO image in interactive TUI mode.
 
-        @id: e29c7f71-096e-42ef-9bbf-77fecac86a9c
+        :id: e29c7f71-096e-42ef-9bbf-77fecac86a9c
 
-        @Assert: Host should be discovered successfully
+        :Assert: Host should be discovered successfully
 
-        @caseautomation: notautomated
+        :caseautomation: notautomated
 
-        @CaseLevel: System
+        :CaseLevel: System
         """
 
     @run_only_on('sat')
@@ -361,13 +359,13 @@ class DiscoveryTestCase(UITestCase):
         """Discover a host with multiple NIC on a network without dhcp
         using ISO image in interactive TUI mode.
 
-        @id: 206a375c-3f42-4cc8-b338-bb85127cffc9
+        :id: 206a375c-3f42-4cc8-b338-bb85127cffc9
 
-        @Assert: Host should be discovered successfully
+        :Assert: Host should be discovered successfully
 
-        @caseautomation: notautomated
+        :caseautomation: notautomated
 
-        @CaseLevel: System
+        :CaseLevel: System
         """
 
     @run_only_on('sat')
@@ -377,13 +375,13 @@ class DiscoveryTestCase(UITestCase):
         """Discover a host with multiple NIC on a network without dhcp
         using ISO image in unattended mode.
 
-        @id: 1e25326d-2976-4a12-8e02-c4be6705f522
+        :id: 1e25326d-2976-4a12-8e02-c4be6705f522
 
-        @Assert: Host should be discovered successfully
+        :Assert: Host should be discovered successfully
 
-        @caseautomation: notautomated
+        :caseautomation: notautomated
 
-        @CaseLevel: System
+        :CaseLevel: System
         """
 
     @run_only_on('sat')
@@ -392,11 +390,11 @@ class DiscoveryTestCase(UITestCase):
         """Discover a host with multiple NIC on a network with dhcp
         using pxe in unattended mode.
 
-        @id: 0d004ed0-594f-492f-8756-33349094aa8e
+        :id: 0d004ed0-594f-492f-8756-33349094aa8e
 
-        @Assert: Host should be discovered successfully
+        :Assert: Host should be discovered successfully
 
-        @CaseLevel: System
+        :CaseLevel: System
         """
         with Session(self.browser) as session:
             session.nav.go_to_select_org(self.org_name)
@@ -418,16 +416,15 @@ class DiscoveryTestCase(UITestCase):
     def test_custom_facts_discovery(self):
         """Check if defined custom facts are displayed under host's facts
 
-        @id: 5492e063-72db-44b8-a34a-9c75c351b89a
+        :id: 5492e063-72db-44b8-a34a-9c75c351b89a
 
-        @Setup: Provisioning should be configured
+        :Setup: Provisioning should be configured
 
-        @Steps: Validate specified custom facts
+        :Steps: Validate specified custom facts
 
-        @Assert: All defined custom facts should be displayed correctly
+        :Assert: All defined custom facts should be displayed correctly
 
-
-        @CaseLevel: System
+        :CaseLevel: System
         """
         param_value = 'myfact'
         with Session(self.browser) as session:
@@ -450,14 +447,14 @@ class DiscoveryTestCase(UITestCase):
         """Provision the selected discovered host from facts page by
         clicking 'provision'
 
-        @id: 610bbf32-b342-44ef-8339-0201e0592260
+        :id: 610bbf32-b342-44ef-8339-0201e0592260
 
-        @Setup: Host should already be discovered
+        :Setup: Host should already be discovered
 
-        @Assert: Host should be provisioned successfully and entry from
-        discovered host should be auto removed
+        :Assert: Host should be provisioned successfully and entry from
+            discovered host should be auto removed
 
-        @CaseLevel: System
+        :CaseLevel: System
         """
         with Session(self.browser) as session:
             session.nav.go_to_select_org(self.org_name)
@@ -488,13 +485,13 @@ class DiscoveryTestCase(UITestCase):
     def test_positive_delete(self):
         """Delete the selected discovered host
 
-        @id: 25a2a3ea-9659-4bdb-8631-c4dd19766014
+        :id: 25a2a3ea-9659-4bdb-8631-c4dd19766014
 
-        @Setup: Host should already be discovered
+        :Setup: Host should already be discovered
 
-        @Assert: Selected host should be removed successfully
+        :Assert: Selected host should be removed successfully
 
-        @CaseLevel: System
+        :CaseLevel: System
         """
         with Session(self.browser) as session:
             session.nav.go_to_select_org(self.org_name)
@@ -510,13 +507,13 @@ class DiscoveryTestCase(UITestCase):
     def test_positive_delete_from_facts(self):
         """Delete the selected discovered host from facts page
 
-        @id: 892aa809-bcf0-46ae-8495-70d7a6483b75
+        :id: 892aa809-bcf0-46ae-8495-70d7a6483b75
 
-        @Setup: Host should already be discovered
+        :Setup: Host should already be discovered
 
-        @Assert: Selected host should be removed successfully
+        :Assert: Selected host should be removed successfully
 
-        @CaseLevel: System
+        :CaseLevel: System
         """
         with Session(self.browser) as session:
             session.nav.go_to_select_org(self.org_name)
@@ -534,14 +531,13 @@ class DiscoveryTestCase(UITestCase):
         """Delete multiple discovered hosts from 'Select Action'
         drop down
 
-        @id: 556fb306-512f-46a4-8a0f-af8013161efe
+        :id: 556fb306-512f-46a4-8a0f-af8013161efe
 
-        @Setup: Host should already be discovered
+        :Setup: Host should already be discovered
 
-        @Assert: Selected host should be removed successfully
+        :Assert: Selected host should be removed successfully
 
-
-        @CaseLevel: System
+        :CaseLevel: System
         """
         with Session(self.browser) as session:
             session.nav.go_to_select_org(self.org_name)
@@ -576,14 +572,13 @@ class DiscoveryTestCase(UITestCase):
     def test_positive_refresh_facts_pxe(self):
         """Refresh the facts of pxe-based discovered host by adding a new NIC.
 
-        @id: cda4103c-6d1a-4f9e-bf57-e516ef1f2a37
+        :id: cda4103c-6d1a-4f9e-bf57-e516ef1f2a37
 
-        @Setup: Host should already be discovered
+        :Setup: Host should already be discovered
 
-        @Assert: Facts should be refreshed successfully with new NIC
+        :Assert: Facts should be refreshed successfully with new NIC
 
-
-        @CaseLevel: System
+        :CaseLevel: System
         """
         param_value = 'interfaces'
         with Session(self.browser) as session:
@@ -611,13 +606,13 @@ class DiscoveryTestCase(UITestCase):
     def test_positive_refresh_facts_pxe_less(self):
         """Refresh the facts of pxe-less discovered host by adding a new NIC.
 
-        @id: 367a5336-a0fa-491b-8153-3e39d68eb978
+        :id: 367a5336-a0fa-491b-8153-3e39d68eb978
 
-        @Setup: Host should already be discovered
+        :Setup: Host should already be discovered
 
-        @Assert: Facts should be refreshed successfully with new NIC
+        :Assert: Facts should be refreshed successfully with new NIC
 
-        @CaseLevel: System
+        :CaseLevel: System
         """
         with Session(self.browser) as session:
             session.nav.go_to_select_org(self.org_name)
@@ -644,13 +639,13 @@ class DiscoveryTestCase(UITestCase):
     def test_positive_reboot(self):
         """Reboot a discovered host.
 
-        @id: 5edc6831-bfc8-4e69-9029-b4c0caa3ee32
+        :id: 5edc6831-bfc8-4e69-9029-b4c0caa3ee32
 
-        @Setup: Host should already be discovered
+        :Setup: Host should already be discovered
 
-        @Assert: Host should be successfully rebooted.
+        :Assert: Host should be successfully rebooted.
 
-        @CaseLevel: System
+        :CaseLevel: System
         """
         with Session(self.browser) as session:
             session.nav.go_to_select_org(self.org_name)
@@ -680,13 +675,13 @@ class DiscoveryTestCase(UITestCase):
         """Change the default org of more than one discovered hosts
         from 'Select Action' drop down
 
-        @id: fe6ab6e0-c942-46c1-8ae2-4f4caf00e0d8
+        :id: fe6ab6e0-c942-46c1-8ae2-4f4caf00e0d8
 
-        @Setup: Host should already be discovered
+        :Setup: Host should already be discovered
 
-        @Assert: Default org should be successfully changed for multiple hosts
+        :Assert: Default org should be successfully changed for multiple hosts
 
-        @CaseLevel: System
+        :CaseLevel: System
         """
         new_org = gen_string('alpha')
         entities.Organization(name=new_org).create()
@@ -714,14 +709,14 @@ class DiscoveryTestCase(UITestCase):
         """Change the default location of more than one discovered hosts
         from 'Select Action' drop down
 
-        @id: 537bfb51-144a-44be-a087-d2437f074464
+        :id: 537bfb51-144a-44be-a087-d2437f074464
 
-        @Setup: Host should already be discovered
+        :Setup: Host should already be discovered
 
-        @Assert: Default Location should be successfully changed for multiple
-        hosts
+        :Assert: Default Location should be successfully changed for multiple
+            hosts
 
-        @CaseLevel: System
+        :CaseLevel: System
         """
         loc = entities.Location().create()
         with Session(self.browser) as session:
@@ -752,15 +747,15 @@ class DiscoveryTestCase(UITestCase):
 
         Set query as (e.g IP=IP_of_discovered_host)
 
-        @id: 00686008-87eb-4b76-9579-ceddb578ef31
+        :id: 00686008-87eb-4b76-9579-ceddb578ef31
 
-        @Setup: Host should already be discovered
+        :Setup: Host should already be discovered
 
-        @Assert: Host should reboot and provision
+        :Assert: Host should reboot and provision
 
-        @CaseLevel: System
+        :CaseLevel: System
 
-        @caseautomation: notautomated
+        :caseautomation: notautomated
         """
 
     @run_only_on('sat')
@@ -771,13 +766,13 @@ class DiscoveryTestCase(UITestCase):
 
         Set query as (e.g IP=IP_of_discovered_host)
 
-        @id: 4488ab9a-d462-4a62-a1a1-e5656c8a8b99
+        :id: 4488ab9a-d462-4a62-a1a1-e5656c8a8b99
 
-        @Setup: Host should already be discovered
+        :Setup: Host should already be discovered
 
-        @Assert: Host should reboot and provision
+        :Assert: Host should reboot and provision
 
-        @CaseLevel: System
+        :CaseLevel: System
         """
         rule_name = gen_string('alpha')
         with Session(self.browser) as session:
@@ -818,15 +813,15 @@ class DiscoveryTestCase(UITestCase):
         that applies to multi hosts.
         Set query as cpu_count = 1 OR mem > 500
 
-        @id: d25c088f-ee7a-4a3a-9b51-8f65f545e680
+        :id: d25c088f-ee7a-4a3a-9b51-8f65f545e680
 
-        @Setup: Multiple hosts should already be discovered in same subnet.
+        :Setup: Multiple hosts should already be discovered in same subnet.
 
-        @Assert: All Hosts of same subnet should reboot and provision
+        :Assert: All Hosts of same subnet should reboot and provision
 
-        @caseautomation: notautomated
+        :caseautomation: notautomated
 
-        @CaseLevel: System
+        :CaseLevel: System
         """
 
     @run_only_on('sat')
@@ -836,16 +831,16 @@ class DiscoveryTestCase(UITestCase):
         """Create multiple discovery rules with different priority and check
         rule with highest priority executed first
 
-        @id: 8daf0b35-912b-441d-97d3-45f48799f4ba
+        :id: 8daf0b35-912b-441d-97d3-45f48799f4ba
 
-        @Setup: Multiple hosts should already be discovered
+        :Setup: Multiple hosts should already be discovered
 
-        @Assert: Host with lower count have higher priority
-        and that rule should be executed first.
+        :Assert: Host with lower count have higher priority and that rule
+            should be executed first.
 
-        @caseautomation: notautomated
+        :caseautomation: notautomated
 
-        @CaseLevel: System
+        :CaseLevel: System
         """
 
     @run_only_on('sat')
@@ -854,13 +849,13 @@ class DiscoveryTestCase(UITestCase):
         """Create a discovery rule and execute it when
         "auto_provisioning" flag set to 'false'
 
-        @id: 25f5112b-7bbd-4bda-8d75-c43bd6390aa8
+        :id: 25f5112b-7bbd-4bda-8d75-c43bd6390aa8
 
-        @Setup: Host should already be discovered
+        :Setup: Host should already be discovered
 
-        @Assert: Host should not be rebooted automatically
+        :Assert: Host should not be rebooted automatically
 
-        @CaseLevel: System
+        :CaseLevel: System
         """
         try:
             # Disable flag to auto provision
@@ -908,14 +903,14 @@ class DiscoveryTestCase(UITestCase):
         """Create a discovery rule with invalid query
         e.g. BIOS = xyz
 
-        @id: 89014adf-6346-4681-9107-6d92e14b6a3e
+        :id: 89014adf-6346-4681-9107-6d92e14b6a3e
 
-        @Setup: Host should already be discovered
+        :Setup: Host should already be discovered
 
-        @Assert: Rule should automatically be skipped on clicking
-        'Auto provision'. UI Should raise 'No matching rule found'
+        :Assert: Rule should automatically be skipped on clicking 'Auto
+            provision'. UI Should raise 'No matching rule found'
 
-        @CaseLevel: System
+        :CaseLevel: System
         """
 
     @run_only_on('sat')
@@ -925,16 +920,16 @@ class DiscoveryTestCase(UITestCase):
         """Create a discovery rule (CPU_COUNT = 2) with host limit 1 and
         provision more than one host with same rule
 
-        @id: ab14c56d-331f-466b-aeb0-41fb19f7b3aa
+        :id: ab14c56d-331f-466b-aeb0-41fb19f7b3aa
 
-        @Setup: Host with two CPUs should already be discovered
+        :Setup: Host with two CPUs should already be discovered
 
-        @Assert: Rule should only be applied to one discovered host and for
-        other rule should already be skipped.
+        :Assert: Rule should only be applied to one discovered host and for
+            other rule should already be skipped.
 
-        @caseautomation: notautomated
+        :caseautomation: notautomated
 
-        @CaseLevel: System
+        :CaseLevel: System
         """
 
     @run_only_on('sat')
@@ -943,16 +938,16 @@ class DiscoveryTestCase(UITestCase):
     def test_positive_update_discovery_rule(self):
         """Update an existing rule and execute it
 
-        @id: 0969cf6f-215d-44c5-96b5-91cb1d865ad0
+        :id: 0969cf6f-215d-44c5-96b5-91cb1d865ad0
 
-        @Setup: Host should already be discovered
+        :Setup: Host should already be discovered
 
-        @Assert: User should be able to update the rule and it should be
-        executed on discovered host
+        :Assert: User should be able to update the rule and it should be
+            executed on discovered host
 
-        @caseautomation: notautomated
+        :caseautomation: notautomated
 
-        @CaseLevel: System
+        :CaseLevel: System
         """
 
     @run_only_on('sat')
@@ -960,13 +955,13 @@ class DiscoveryTestCase(UITestCase):
     def test_positive_update_name(self):
         """Update the discovered host name and provision it
 
-        @id: 3770b007-5006-4815-ae03-fbd330aad304
+        :id: 3770b007-5006-4815-ae03-fbd330aad304
 
-        @Setup: Host should already be discovered
+        :Setup: Host should already be discovered
 
-        @Assert: The hostname should be updated and host should be provisioned
+        :Assert: The hostname should be updated and host should be provisioned
 
-        @CaseLevel: System
+        :CaseLevel: System
         """
         name = gen_string('alpha')
         with Session(self.browser) as session:
@@ -994,11 +989,11 @@ class DiscoveryTestCase(UITestCase):
     def test_positive_auto_provision_all(self):
         """Discover a bunch of hosts and auto-provision all
 
-        @id: e26129b5-16fa-418c-b768-21670e9f0b74
+        :id: e26129b5-16fa-418c-b768-21670e9f0b74
 
-        @Assert: All host should be successfully rebooted and provisioned
+        :Assert: All host should be successfully rebooted and provisioned
 
-        @CaseLevel: System
+        :CaseLevel: System
         """
         rule_name = gen_string('alpha')
         with Session(self.browser) as session:
@@ -1039,21 +1034,18 @@ class DiscoveryTestCase(UITestCase):
     def test_positive_add_fact_column(self):
         """Add a new fact column to display on discovered host page
 
-        @id: 914bd47f-b2a6-459e-b166-70dbc9ce1bc6
+        :id: 914bd47f-b2a6-459e-b166-70dbc9ce1bc6
 
-        @Steps:
+        :Steps:
+            1. Goto settings -> Discovered tab -> discovery_fact_coloumn
+            2. Edit discovery_fact_coloumn
+            3. Add bios_vendor
 
-        1. Goto settings -> Discovered tab -> discovery_fact_coloumn
-
-        2. Edit discovery_fact_coloumn
-
-        3. Add bios_vendor
-
-        @Assert: The added fact should be displayed on 'discovered_host' page
-        after successful discovery
+        :Assert: The added fact should be displayed on 'discovered_host' page
+            after successful discovery
 
 
-        @CaseLevel: System
+        :CaseLevel: System
         """
         param_value = 'bios_vendor'
         with Session(self.browser) as session:
@@ -1076,18 +1068,18 @@ class DiscoveryTestCase(UITestCase):
         """Add a new fact column with invalid fact to display on
         discovered host page
 
-        @id: 4e9bc843-4ba2-40d4-a1b3-2d7be117664f
+        :id: 4e9bc843-4ba2-40d4-a1b3-2d7be117664f
 
-        @Steps:
+        :Steps:
 
-        1. Goto settings -> Discovered tab -> discovery_fact_coloumn
-        2. Edit discovery_fact_coloumn
-        3. Add 'test'
+            1. Goto settings -> Discovered tab -> discovery_fact_coloumn
+            2. Edit discovery_fact_coloumn
+            3. Add 'test'
 
-        @Assert: The added fact should be displayed on 'discovered_host' page
-        after successful discovery and shows 'N/A'
+        :Assert: The added fact should be displayed on 'discovered_host' page
+            after successful discovery and shows 'N/A'
 
-        @CaseLevel: System
+        :CaseLevel: System
         """
         param_value = 'test'
         expected_value = u'N/A'
@@ -1113,15 +1105,15 @@ class DiscoveryTestCase(UITestCase):
     def test_positive_discovery_manager_role(self):
         """Assign 'Discovery_Manager' role to a normal user
 
-        @id: c219c877-e785-41a3-9abe-803a9b26bcad
+        :id: c219c877-e785-41a3-9abe-803a9b26bcad
 
-        @Assert: User should be able to view, provision, edit and destroy one
-        or more discovered host as well view, create_new, edit, execute and
-        delete discovery rules.
+        :Assert: User should be able to view, provision, edit and destroy one
+            or more discovered host as well view, create_new, edit, execute and
+            delete discovery rules.
 
-        @caseautomation: notautomated
+        :caseautomation: notautomated
 
-        @CaseLevel: System
+        :CaseLevel: System
         """
 
     @run_only_on('sat')
@@ -1130,13 +1122,13 @@ class DiscoveryTestCase(UITestCase):
     def test_positive_discovery_reader_role(self):
         """Assign 'Discovery Reader" role to a normal user
 
-        @id: 075bd559-a3bb-42ca-86a4-60581c650a1d
+        :id: 075bd559-a3bb-42ca-86a4-60581c650a1d
 
-        @Assert: User should be able to view existing discovered host and rule
+        :Assert: User should be able to view existing discovered host and rule
 
-        @caseautomation: notautomated
+        :caseautomation: notautomated
 
-        @CaseLevel: System
+        :CaseLevel: System
         """
 
     @run_only_on('sat')
@@ -1146,13 +1138,13 @@ class DiscoveryTestCase(UITestCase):
         """Validate all the buttons from "Discovery Status" TUI screen of a
         pxe-less discovered host
 
-        @id: a18694ad-7642-472f-8e7c-c911c892a763
+        :id: a18694ad-7642-472f-8e7c-c911c892a763
 
-        @Assert: All buttons should work
+        :Assert: All buttons should work
 
-        @caseautomation: notautomated
+        :caseautomation: notautomated
 
-        @CaseLevel: System
+        :CaseLevel: System
         """
 
     @run_only_on('sat')
@@ -1162,13 +1154,13 @@ class DiscoveryTestCase(UITestCase):
         """Validate network configuration screen by specifying invalid
         IP/gateway/DNS address notation.
 
-        @id: b1d24367-9a7e-4d8e-85b6-989d8c520498
+        :id: b1d24367-9a7e-4d8e-85b6-989d8c520498
 
-        @Assert: User should get an error message
+        :Assert: User should get an error message
 
-        @caseautomation: notautomated
+        :caseautomation: notautomated
 
-        @CaseLevel: System
+        :CaseLevel: System
         """
 
     @run_only_on('sat')
@@ -1178,15 +1170,15 @@ class DiscoveryTestCase(UITestCase):
         """Discover a host via pxe-less and select "Discover using DHCP"
         interactively when no dhcp is available.
 
-        @id: adef940c-8948-4cd9-88b3-f0b307134536
+        :id: adef940c-8948-4cd9-88b3-f0b307134536
 
-        @Assert: User should get an error message "Unable to bring network via
-        DHCP" and click on 'OK' should open the ''Network configuration screen"
-        to manually specify the IP/GW/DNS.
+        :Assert: User should get an error message "Unable to bring network via
+            DHCP" and click on 'OK' should open the ''Network configuration
+            screen" to manually specify the IP/GW/DNS.
 
-        @caseautomation: notautomated
+        :caseautomation: notautomated
 
-        @CaseLevel: System
+        :CaseLevel: System
         """
 
     @run_only_on('sat')
@@ -1196,13 +1188,13 @@ class DiscoveryTestCase(UITestCase):
         """Provision a discovered host manually by associating org & loc from
         host properties model window and select create host button.
 
-        @id: 8c6a7d3f-e34e-4888-9b1c-58e71ee584a3
+        :id: 8c6a7d3f-e34e-4888-9b1c-58e71ee584a3
 
-        @Assert: Provisioned host is associated with selected org & location
+        :Assert: Provisioned host is associated with selected org & location
 
-        @caseautomation: notautomated
+        :caseautomation: notautomated
 
-        @CaseLevel: System
+        :CaseLevel: System
         """
 
     @run_only_on('sat')
@@ -1211,12 +1203,12 @@ class DiscoveryTestCase(UITestCase):
         """Provision a discovered host manually by associating hostgroup from
         host properties model window and select create host button.
 
-        @id: f17fb8c9-f9cb-4547-80bc-3b40c6691bb1
+        :id: f17fb8c9-f9cb-4547-80bc-3b40c6691bb1
 
-        @Assert: Provisioned host is created with selected host-group and entry
-        from discovered host should be auto removed.
+        :Assert: Provisioned host is created with selected host-group and entry
+            from discovered host should be auto removed.
 
-        @CaseLevel: System
+        :CaseLevel: System
         """
         with Session(self.browser) as session:
             session.nav.go_to_select_org(self.org_name)
@@ -1243,17 +1235,17 @@ class DiscoveryTestCase(UITestCase):
         """Associate hostgroup while provisioning a discovered host from
         host properties model window and select quick host.
 
-        @id: 34c1e9ea-f210-4a1e-aead-421eb962643b
+        :id: 34c1e9ea-f210-4a1e-aead-421eb962643b
 
-        @Setup:
+        :Setup:
 
-        1. Host should already be discovered
-        2. Hostgroup should already be created with all required entities.
+            1. Host should already be discovered
+            2. Hostgroup should already be created with all required entities.
 
-        @Assert: Host should be quickly provisioned and entry from
-        discovered host should be auto removed.
+        :Assert: Host should be quickly provisioned and entry from discovered
+            host should be auto removed.
 
-        @CaseLevel: System
+        :CaseLevel: System
         """
         with Session(self.browser) as session:
             session.nav.go_to_select_org(self.org_name)
@@ -1282,19 +1274,19 @@ class DiscoveryTestCase(UITestCase):
         """Provision a discovered host with clear_all_facts setting's default
         value 'No'
 
-        @id: 5dbb9a9f-117d-41aa-8f15-d4da6163b244
+        :id: 5dbb9a9f-117d-41aa-8f15-d4da6163b244
 
-        @Setup:
+        :Setup:
 
-        1. Host should already be discovered
-        2. Go to setting -> clear_all_facts -> No
+            1. Host should already be discovered
+            2. Go to setting -> clear_all_facts -> No
 
-        @Assert: After successful provisioning, all facts set by user should be
-        visible, including the one started with discovery keyword.
+        :Assert: After successful provisioning, all facts set by user should be
+            visible, including the one started with discovery keyword.
 
-        @caseautomation: notautomated
+        :caseautomation: notautomated
 
-        @CaseLevel: System
+        :CaseLevel: System
         """
 
     @run_only_on('sat')
@@ -1304,18 +1296,18 @@ class DiscoveryTestCase(UITestCase):
         """Provision a discovered host by setting clear_all_facts
         value to 'Yes'
 
-        @id: 9f153b3a-4c21-41a2-b2a0-a0b1bee262d3
+        :id: 9f153b3a-4c21-41a2-b2a0-a0b1bee262d3
 
-        @Setup:
-        1. Host should already be discovered
-        2. Go to setting -> clear_all_facts -> Yes
+        :Setup:
+            1. Host should already be discovered
+            2. Go to setting -> clear_all_facts -> Yes
 
-        @Assert: After successful provisioning, all facts set by user should be
-        deleted execpt the one started with discovery keyword.
+        :Assert: After successful provisioning, all facts set by user should be
+            deleted execpt the one started with discovery keyword.
 
-        @caseautomation: notautomated
+        :caseautomation: notautomated
 
-        @CaseLevel: System
+        :CaseLevel: System
         """
 
     @run_only_on('sat')
@@ -1324,19 +1316,19 @@ class DiscoveryTestCase(UITestCase):
     def test_positive_lock_discovered_host_into_discovery(self):
         """Lock host into discovery via PXE configuration
 
-        @id: 4ba9f923-0b8f-40ee-8bcb-90ff496587c4
+        :id: 4ba9f923-0b8f-40ee-8bcb-90ff496587c4
 
-        @Steps:
+        :Steps:
 
-        1. Go to setting -> discovery_lock -> true
-        2. Go to setting -> discovery_lock_template -> template to be locked
-            with
+            1. Go to setting -> discovery_lock -> true
+            2. Go to setting -> discovery_lock_template -> template to be
+                locked with
 
-        @Assert: Host should boot into discovery mode and should be discovered.
+        :Assert: Host should boot into discovery mode and should be discovered.
 
-        @caseautomation: notautomated
+        :caseautomation: notautomated
 
-        @CaseLevel: System
+        :CaseLevel: System
         """
 
     @run_only_on('sat')
@@ -1346,19 +1338,19 @@ class DiscoveryTestCase(UITestCase):
         """On provisioning a host associate hostgroup and see if PuppetCA
         and Puppetmaster are being populated.
 
-        @id: 21e55ffa-02bc-4f96-b463-887da30fb1c4
+        :id: 21e55ffa-02bc-4f96-b463-887da30fb1c4
 
-        @Steps:
+        :Steps:
 
-        1. Discover a host
-        2. Create a hostgroup with puppetCA and puppetmaster
+            1. Discover a host
+            2. Create a hostgroup with puppetCA and puppetmaster
 
-        @Assert: Parameters like PuppetCA/Puppetmaster should be populated on
-        associating hostgroup to discovered host
+        :Assert: Parameters like PuppetCA/Puppetmaster should be populated on
+            associating hostgroup to discovered host
 
-        @caseautomation: notautomated
+        :caseautomation: notautomated
 
-        @CaseLevel: System
+        :CaseLevel: System
         """
 
     @run_only_on('sat')
@@ -1368,19 +1360,19 @@ class DiscoveryTestCase(UITestCase):
         """Update the default 'Discovery Organization' settings to place the
         discovered hosts in.
 
-        @id: 596a98ad-90f6-42ff-b8ef-47f02dc5d595
+        :id: 596a98ad-90f6-42ff-b8ef-47f02dc5d595
 
-        @Steps:
+        :Steps:
 
-        1. Go to setting -> Discovered -> Discovery organization
-        2. Update default org from dropdown
+            1. Go to setting -> Discovered -> Discovery organization
+            2. Update default org from dropdown
 
-        @Assert: Discovered host should automatically be placed in selected
-        default org
+        :Assert: Discovered host should automatically be placed in selected
+            default org
 
-        @caseautomation: notautomated
+        :caseautomation: notautomated
 
-        @CaseLevel: System
+        :CaseLevel: System
         """
 
     @run_only_on('sat')
@@ -1390,19 +1382,19 @@ class DiscoveryTestCase(UITestCase):
         """Update the default 'Discovery Location' settings to place the
         discovered hosts in.
 
-        @id: 4bba9899-a53e-4521-b212-aee893f7a726
+        :id: 4bba9899-a53e-4521-b212-aee893f7a726
 
-        @Steps:
+        :Steps:
 
-        1. Go to setting -> Discovered -> Discovery Location
-        2. Update default location from dropdown
+            1. Go to setting -> Discovered -> Discovery Location
+            2. Update default location from dropdown
 
-        @Assert: Discovered host should automatically be placed in selected
-        default location
+        :Assert: Discovered host should automatically be placed in selected
+            default location
 
-        @caseautomation: notautomated
+        :caseautomation: notautomated
 
-        @CaseLevel: System
+        :CaseLevel: System
         """
 
     @run_only_on('sat')
@@ -1412,18 +1404,18 @@ class DiscoveryTestCase(UITestCase):
         """Check if network facts ending with _eth0 are correctly displayed
         under discovered host page
 
-        @id: 5a06236c-05dc-4a98-b1b5-9586c95203f9
+        :id: 5a06236c-05dc-4a98-b1b5-9586c95203f9
 
-        @Assert: Network facts like below should be displayed on discovered
-        host page:
+        :Assert: Network facts like below should be displayed on discovered
+            host page:
 
-        1. facts ending with _eth0
-        2. auto_negotiation_XXX
-        3. LLDAP facts like lldp_neighbor_portid_XXX
+            1. facts ending with _eth0
+            2. auto_negotiation_XXX
+            3. LLDAP facts like lldp_neighbor_portid_XXX
 
-        @caseautomation: notautomated
+        :caseautomation: notautomated
 
-        @CaseLevel: System
+        :CaseLevel: System
         """
 
     @run_only_on('sat')
@@ -1432,15 +1424,15 @@ class DiscoveryTestCase(UITestCase):
     def test_positive_rebuild_dns_on_provisioning(self):
         """Force DNS rebuild when provisioning discovered host
 
-        @id: 87aa3279-7c29-40e8-a4d2-0aab43f0972f
+        :id: 87aa3279-7c29-40e8-a4d2-0aab43f0972f
 
-        @Setup: Make sure 'discovery_always_rebuild_dns' setting set to true
+        :Setup: Make sure 'discovery_always_rebuild_dns' setting set to true
 
-        @Assert: DNS record should be recreated on provisioning discovered host
+        :Assert: DNS record should be recreated on provisioning discovered host
 
-        @caseautomation: notautomated
+        :caseautomation: notautomated
 
-        @CaseLevel: System
+        :CaseLevel: System
         """
 
 
@@ -1478,18 +1470,19 @@ class DiscoveryPrefixTestCase(UITestCase):
     def test_positive_update_discovery_prefix(self):
         """Update the discovery_prefix parameter other than mac
 
-        @id: 08f1d852-e9a0-430e-b73a-e2a7a144ac10
+        :id: 08f1d852-e9a0-430e-b73a-e2a7a144ac10
 
-        @Steps:
+        :Steps:
 
-        1. Goto settings -> Discovered tab -> discovery_prefix
-        2. Edit discovery_prefix using any text that must start with a letter
+            1. Goto settings -> Discovered tab -> discovery_prefix
+            2. Edit discovery_prefix using any text that must start with a
+               letter
 
-        @Setup: Host should already be discovered
+        :Setup: Host should already be discovered
 
-        @Assert: Host should be discovered with updated prefix.
+        :Assert: Host should be discovered with updated prefix.
 
-        @CaseLevel: System
+        :CaseLevel: System
         """
         with Session(self.browser) as session:
             session.nav.go_to_select_org(self.org_name)

--- a/tests/foreman/ui/test_discoveryrule.py
+++ b/tests/foreman/ui/test_discoveryrule.py
@@ -1,19 +1,19 @@
 # -*- encoding: utf-8 -*-
 """Test class for Foreman Discovery Rules
 
-@Requirement: Discoveryrule
+:Requirement: Discoveryrule
 
-@CaseAutomation: Automated
+:CaseAutomation: Automated
 
-@CaseLevel: Acceptance
+:CaseLevel: Acceptance
 
-@CaseComponent: UI
+:CaseComponent: UI
 
-@TestType: Functional
+:TestType: Functional
 
-@CaseImportance: High
+:CaseImportance: High
 
-@Upstream: No
+:Upstream: No
 """
 from fauxfactory import gen_integer, gen_ipaddr, gen_string
 from nailgun import entities
@@ -88,9 +88,9 @@ class DiscoveryRuleTestCase(UITestCase):
     def test_positive_create_with_name(self):
         """Create Discovery Rule using different names
 
-        @id: afdf7000-4bd0-41ec-9773-96ff68e27b8d
+        :id: afdf7000-4bd0-41ec-9773-96ff68e27b8d
 
-        @Assert: Rule should be successfully created
+        :Assert: Rule should be successfully created
         """
         with Session(self.browser) as session:
             for name in valid_data_list():
@@ -104,10 +104,10 @@ class DiscoveryRuleTestCase(UITestCase):
     def test_positive_create_with_search(self):
         """Create Discovery Rule using different search queries
 
-        @id: 973ff6e5-572e-401c-bc8c-d614a583e883
+        :id: 973ff6e5-572e-401c-bc8c-d614a583e883
 
-        @Assert: Rule should be successfully created and has expected search
-        field value
+        :Assert: Rule should be successfully created and has expected search
+            field value
         """
         with Session(self.browser) as session:
             for query in valid_search_queries():
@@ -131,10 +131,10 @@ class DiscoveryRuleTestCase(UITestCase):
     def test_positive_create_with_hostname(self):
         """Create Discovery Rule using valid hostname value
 
-        @id: e6742ca5-1d41-4ba3-8f2c-2169db92485b
+        :id: e6742ca5-1d41-4ba3-8f2c-2169db92485b
 
-        @Assert: Rule should be successfully created and has expected hostname
-        field value
+        :Assert: Rule should be successfully created and has expected hostname
+            field value
         """
         name = gen_string('alpha')
         hostname = gen_string('alpha')
@@ -158,10 +158,10 @@ class DiscoveryRuleTestCase(UITestCase):
         """Create Discovery Rule providing any number from range 1..100 for
         hosts limit field
 
-        @id: 64b90586-c1a9-4be4-8c44-4fa19ca998f8
+        :id: 64b90586-c1a9-4be4-8c44-4fa19ca998f8
 
-        @Assert: Rule should be successfully created and has expected hosts
-        limit field value
+        :Assert: Rule should be successfully created and has expected hosts
+            limit field value
         """
         name = gen_string('alpha')
         limit = str(gen_integer(1, 100))
@@ -184,10 +184,10 @@ class DiscoveryRuleTestCase(UITestCase):
         """Create Discovery Rule providing any number from range 1..100 for
         priority field
 
-        @id: de847288-257a-4f0e-9cb6-9a0dd0877d23
+        :id: de847288-257a-4f0e-9cb6-9a0dd0877d23
 
-        @Assert: Rule should be successfully created and has expected priority
-        field value
+        :Assert: Rule should be successfully created and has expected priority
+            field value
         """
         name = gen_string('alpha')
         priority = str(gen_integer(1, 100))
@@ -209,9 +209,9 @@ class DiscoveryRuleTestCase(UITestCase):
     def test_positive_create_disabled(self):
         """Create Discovery Rule in disabled state
 
-        @id: 0b98d467-aabf-4efe-890f-50d6edcd99ff
+        :id: 0b98d467-aabf-4efe-890f-50d6edcd99ff
 
-        @Assert: Disabled rule should be successfully created
+        :Assert: Disabled rule should be successfully created
         """
         name = gen_string('alpha')
         with Session(self.browser) as session:
@@ -234,9 +234,9 @@ class DiscoveryRuleTestCase(UITestCase):
     def test_negative_create_with_invalid_name(self):
         """Create Discovery Rule with invalid names
 
-        @id: 79d950dc-4ca1-407e-84ca-9092d1cba978
+        :id: 79d950dc-4ca1-407e-84ca-9092d1cba978
 
-        @Assert: Error should be raised and rule should not be created
+        :Assert: Error should be raised and rule should not be created
         """
         with Session(self.browser) as session:
             for name in invalid_values_list(interface='ui'):
@@ -254,9 +254,9 @@ class DiscoveryRuleTestCase(UITestCase):
     def test_negative_create_with_invalid_hostname(self):
         """Create Discovery Rule with invalid hostname
 
-        @id: a322c8ce-4f05-401a-88cb-a3d30b4ac446
+        :id: a322c8ce-4f05-401a-88cb-a3d30b4ac446
 
-        @Assert: Error should be raised and rule should not be created
+        :Assert: Error should be raised and rule should not be created
         """
         name = gen_string('alpha')
         with Session(self.browser) as session:
@@ -276,9 +276,9 @@ class DiscoveryRuleTestCase(UITestCase):
     def test_negative_create_with_limit(self):
         """Create Discovery Rule with invalid host limit
 
-        @id: 743d29f4-a901-400c-ad98-a3b8942f02b5
+        :id: 743d29f4-a901-400c-ad98-a3b8942f02b5
 
-        @Assert: Error should be raised and rule should not be created
+        :Assert: Error should be raised and rule should not be created
         """
         name = gen_string('alpha')
         with Session(self.browser) as session:
@@ -302,10 +302,10 @@ class DiscoveryRuleTestCase(UITestCase):
     def test_negative_create_with_too_long_limit(self):
         """Create Discovery Rule with too long host limit value
 
-        @id: 450b49d9-1058-4186-9b23-15cc615e5bd6
+        :id: 450b49d9-1058-4186-9b23-15cc615e5bd6
 
-        @Assert: Validation error should be raised and rule should not be
-        created
+        :Assert: Validation error should be raised and rule should not be
+            created
         """
         name = gen_string('alpha')
         with Session(self.browser) as session:
@@ -325,9 +325,9 @@ class DiscoveryRuleTestCase(UITestCase):
     def test_negative_create_with_same_name(self):
         """Create Discovery Rule with name that already exists
 
-        @id: 5a914e76-de01-406d-9860-0e4e1521b074
+        :id: 5a914e76-de01-406d-9860-0e4e1521b074
 
-        @Assert: Error should be raised and rule should not be created
+        :Assert: Error should be raised and rule should not be created
         """
         name = gen_string('alpha')
         with Session(self.browser) as session:
@@ -345,9 +345,9 @@ class DiscoveryRuleTestCase(UITestCase):
     def test_negative_create_with_invalid_priority(self):
         """Create Discovery Rule with invalid priority
 
-        @id: f8829cce-86c0-452c-b866-d5645174e9e1
+        :id: f8829cce-86c0-452c-b866-d5645174e9e1
 
-        @Assert: Error should be raised and rule should not be created
+        :Assert: Error should be raised and rule should not be created
         """
         name = gen_string('alpha')
         with Session(self.browser) as session:
@@ -367,9 +367,9 @@ class DiscoveryRuleTestCase(UITestCase):
     def test_positive_delete(self):
         """Delete existing Discovery Rule
 
-        @id: fc5b714c-e5bc-4b0f-bc94-88e080318704
+        :id: fc5b714c-e5bc-4b0f-bc94-88e080318704
 
-        @Assert: Rule should be successfully deleted
+        :Assert: Rule should be successfully deleted
         """
         with Session(self.browser) as session:
             for name in generate_strings_list():
@@ -384,9 +384,9 @@ class DiscoveryRuleTestCase(UITestCase):
     def test_positive_update_name(self):
         """Update discovery rule name
 
-        @id: 16a79449-7200-492e-9ddb-65fc034e510d
+        :id: 16a79449-7200-492e-9ddb-65fc034e510d
 
-        @Assert: Rule name is updated
+        :Assert: Rule name is updated
         """
         name = gen_string('alpha')
         with Session(self.browser) as session:
@@ -404,9 +404,9 @@ class DiscoveryRuleTestCase(UITestCase):
     def test_positive_update_query(self):
         """Update discovery rule search query
 
-        @id: bcf85a4c-0b27-47a5-8d5d-7ede0f6eea41
+        :id: bcf85a4c-0b27-47a5-8d5d-7ede0f6eea41
 
-        @Assert: Rule search field is updated
+        :Assert: Rule search field is updated
         """
         name = gen_string('alpha')
         with Session(self.browser) as session:
@@ -428,9 +428,9 @@ class DiscoveryRuleTestCase(UITestCase):
     def test_positive_update_hostgroup(self):
         """Update discovery rule host group
 
-        @id: e10274e9-bf1b-42cd-a809-f19e707e7f4c
+        :id: e10274e9-bf1b-42cd-a809-f19e707e7f4c
 
-        @Assert: Rule host group is updated
+        :Assert: Rule host group is updated
         """
         name = gen_string('alpha')
         new_hostgroup_name = entities.HostGroup(
@@ -456,9 +456,9 @@ class DiscoveryRuleTestCase(UITestCase):
     def test_positive_update_hostname(self):
         """Update discovery rule hostname value
 
-        @id: 753ff15b-da73-4fb3-87cd-14d504d8e882
+        :id: 753ff15b-da73-4fb3-87cd-14d504d8e882
 
-        @Assert: Rule host name is updated
+        :Assert: Rule host name is updated
         """
         name = gen_string('alpha')
         hostname = gen_string('alpha')
@@ -477,9 +477,9 @@ class DiscoveryRuleTestCase(UITestCase):
     def test_positive_update_limit(self):
         """Update discovery rule limit value
 
-        @id: 69d59c34-407b-47d0-a2b8-46decb95ef47
+        :id: 69d59c34-407b-47d0-a2b8-46decb95ef47
 
-        @Assert: Rule host limit field is updated
+        :Assert: Rule host limit field is updated
         """
         name = gen_string('alpha')
         limit = str(gen_integer(1, 100))
@@ -498,9 +498,9 @@ class DiscoveryRuleTestCase(UITestCase):
     def test_positive_update_priority(self):
         """Update discovery rule priority value
 
-        @id: be4de7a9-df8e-44ae-9910-7397341f6d07
+        :id: be4de7a9-df8e-44ae-9910-7397341f6d07
 
-        @Assert: Rule priority is updated
+        :Assert: Rule priority is updated
         """
         name = gen_string('alpha')
         priority = str(gen_integer(1, 100))
@@ -519,9 +519,9 @@ class DiscoveryRuleTestCase(UITestCase):
     def test_positive_update_disable_enable(self):
         """Update discovery rule enabled state. (Disabled->Enabled)
 
-        @id: 60d619e4-a039-4f9e-a16c-b05f0598e8fa
+        :id: 60d619e4-a039-4f9e-a16c-b05f0598e8fa
 
-        @Assert: Rule enabled checkbox is updated
+        :Assert: Rule enabled checkbox is updated
         """
         name = gen_string('alpha')
         with Session(self.browser) as session:
@@ -545,9 +545,9 @@ class DiscoveryRuleTestCase(UITestCase):
     def test_negative_update_name(self):
         """Update discovery rule name using invalid names only
 
-        @id: 65f32628-796a-4d7e-bf2c-c84c6b06f309
+        :id: 65f32628-796a-4d7e-bf2c-c84c6b06f309
 
-        @Assert: Rule name is not updated
+        :Assert: Rule name is not updated
         """
         name = gen_string('alpha')
         with Session(self.browser) as session:
@@ -568,9 +568,9 @@ class DiscoveryRuleTestCase(UITestCase):
     def test_negative_update_hostname(self):
         """Update discovery rule host name using number as a value
 
-        @id: 18713425-22fe-4eaa-a515-8e08aa07e116
+        :id: 18713425-22fe-4eaa-a515-8e08aa07e116
 
-        @Assert: Rule host name is not updated
+        :Assert: Rule host name is not updated
         """
         name = gen_string('alpha')
         hostname = gen_string('alpha')
@@ -597,9 +597,9 @@ class DiscoveryRuleTestCase(UITestCase):
     def test_negative_update_limit(self):
         """Update discovery rule host limit using invalid values
 
-        @id: 7e8b7218-3c8a-4b03-b0df-484e0d793ceb
+        :id: 7e8b7218-3c8a-4b03-b0df-484e0d793ceb
 
-        @Assert: Rule host limit is not updated
+        :Assert: Rule host limit is not updated
         """
         name = gen_string('alpha')
         limit = str(gen_integer(1, 100))
@@ -629,9 +629,9 @@ class DiscoveryRuleTestCase(UITestCase):
     def test_negative_update_priority(self):
         """Update discovery rule priority using invalid values
 
-        @id: d44ad49c-5d95-442f-a1b3-cd82dd8ffabf
+        :id: d44ad49c-5d95-442f-a1b3-cd82dd8ffabf
 
-        @Assert: Rule priority is not updated
+        :Assert: Rule priority is not updated
         """
         name = gen_string('alpha')
         priority = str(gen_integer(1, 100))
@@ -663,12 +663,12 @@ class DiscoveryRuleTestCase(UITestCase):
         """Create rule with same priority and see their ordering should be based
         on create time.
 
-        @id: 585c4bc2-6e34-4fdd-88fb-d788f9e0625b
+        :id: 585c4bc2-6e34-4fdd-88fb-d788f9e0625b
 
-        @Assert: The ordering of rules should be based on priority as well as
-        create time.
+        :Assert: The ordering of rules should be based on priority as well as
+            create time.
 
-        @caseautomation: notautomated
+        :caseautomation: notautomated
         """
 
 
@@ -744,11 +744,11 @@ class DiscoveryRuleRoleTestCase(UITestCase):
     def test_positive_create_rule_with_non_admin_user(self):
         """Create rule with non-admin user by associating discovery_manager role
 
-        @id: 6a03983b-363d-4646-b277-34af5f5abc55
+        :id: 6a03983b-363d-4646-b277-34af5f5abc55
 
-        @Assert: Rule should be created successfully.
+        :Assert: Rule should be created successfully.
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         with Session(
             self.browser, self.manager_user, self.manager_user_password
@@ -766,11 +766,11 @@ class DiscoveryRuleRoleTestCase(UITestCase):
     def test_positive_delete_rule_with_non_admin_user(self):
         """Delete rule with non-admin user by associating discovery_manager role
 
-        @id: 7fa56bab-82d7-46c9-a4fa-c44ef173c703
+        :id: 7fa56bab-82d7-46c9-a4fa-c44ef173c703
 
-        @Assert: Rule should be deleted successfully.
+        :Assert: Rule should be deleted successfully.
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         with Session(
             self.browser, self.manager_user, self.manager_user_password
@@ -789,17 +789,17 @@ class DiscoveryRuleRoleTestCase(UITestCase):
         """Existing rule should be viewed to non-admin user by associating
         discovery_reader role.
 
-        @id: 0f5b0221-43be-47bc-8619-749824c4e54f
+        :id: 0f5b0221-43be-47bc-8619-749824c4e54f
 
-        @Steps:
+        :Steps:
 
-        1. create a rule with admin user
-        2. create a non-admin user and assign 'Discovery Reader' role
-        3. Login with non-admin user
+            1. create a rule with admin user
+            2. create a non-admin user and assign 'Discovery Reader' role
+            3. Login with non-admin user
 
-        @Assert: Rule should be visible to non-admin user.
+        :Assert: Rule should be visible to non-admin user.
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         with Session(
             self.browser, self.reader_user, self.reader_user_password
@@ -814,12 +814,12 @@ class DiscoveryRuleRoleTestCase(UITestCase):
     def test_negative_delete_rule_with_non_admin_user(self):
         """Delete rule with non-admin user by associating discovery_reader role
 
-        @id: 23a7627c-6a9b-493b-871f-698543adf1d2
+        :id: 23a7627c-6a9b-493b-871f-698543adf1d2
 
-        @Assert: User should validation error and rule should not be deleted
-        successfully.
+        :Assert: User should validation error and rule should not be deleted
+            successfully.
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         with Session(
             self.browser, self.reader_user, self.reader_user_password
@@ -845,18 +845,18 @@ class DiscoveryRuleRoleTestCase(UITestCase):
         """List all the discovered hosts resolved by given rule's search query
         e.g. all hosts with cpu_count = 1
 
-        @id: f7473fa2-7349-42d3-9cdb-f74b55d2f440
+        :id: f7473fa2-7349-42d3-9cdb-f74b55d2f440
 
-        @Steps:
+        :Steps:
 
-        1. discovered a host with cpu_count = 2
-        2. Define a rule 'rule1' with search query cpu_count = 2
-        3. Click on 'Discovered Hosts' from rule1
+            1. discovered a host with cpu_count = 2
+            2. Define a rule 'rule1' with search query cpu_count = 2
+            3. Click on 'Discovered Hosts' from rule1
 
-        @Assert: All hosts based on rule's search query( w/ cpu_count = 2)
-        should be listed
+        :Assert: All hosts based on rule's search query( w/ cpu_count = 2)
+            should be listed
 
-        @caseautomation: notautomated
+        :caseautomation: notautomated
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """

--- a/tests/foreman/ui/test_docker.py
+++ b/tests/foreman/ui/test_docker.py
@@ -1,18 +1,18 @@
 """WebUI tests for the Docker feature.
 
-@Requirement: Docker
+:Requirement: Docker
 
-@CaseAutomation: Automated
+:CaseAutomation: Automated
 
-@CaseLevel: Acceptance
+:CaseLevel: Acceptance
 
-@CaseComponent: UI
+:CaseComponent: UI
 
-@TestType: Functional
+:TestType: Functional
 
-@CaseImportance: High
+:CaseImportance: High
 
-@Upstream: No
+:Upstream: No
 """
 
 from fauxfactory import gen_string, gen_url
@@ -108,11 +108,11 @@ class DockerTagTestCase(UITestCase):
     def test_positive_search_docker_image(self):
         """Search for a docker image
 
-        @id: 28640396-c44d-4487-9d6d-3d5f2ed599d7
+        :id: 28640396-c44d-4487-9d6d-3d5f2ed599d7
 
-        @Assert: The docker tag can be searched and found
+        :Assert: The docker tag can be searched and found
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         organization = entities.Organization().create()
         pr = entities.Product(organization=organization).create()
@@ -146,9 +146,9 @@ class DockerRepositoryTestCase(UITestCase):
     def test_positive_create_with_name(self):
         """Create one Docker-type repository using different names
 
-        @id: 233f39b5-ec75-4035-a45f-0f37a40bbdfe
+        :id: 233f39b5-ec75-4035-a45f-0f37a40bbdfe
 
-        @Assert: A repository is created with a Docker upstream repository.
+        :Assert: A repository is created with a Docker upstream repository.
         """
         with Session(self.browser) as session:
             for name in valid_data_list():
@@ -169,10 +169,10 @@ class DockerRepositoryTestCase(UITestCase):
     def test_positive_create_repos_using_same_product(self):
         """Create multiple Docker-type repositories
 
-        @id: f6e7d9fe-7dec-42ef-8cbd-071871e4b8ac
+        :id: f6e7d9fe-7dec-42ef-8cbd-071871e4b8ac
 
-        @Assert: Multiple docker repositories are created with a Docker
-        upstream repository and they all belong to the same product.
+        :Assert: Multiple docker repositories are created with a Docker
+            upstream repository and they all belong to the same product.
         """
         product = entities.Product(organization=self.organization).create()
         with Session(self.browser) as session:
@@ -192,10 +192,11 @@ class DockerRepositoryTestCase(UITestCase):
     def test_positive_create_repos_using_multiple_products(self):
         """Create multiple Docker-type repositories on multiple products.
 
-        @id: da76f1e8-236e-455d-b300-676e00e3df8e
+        :id: da76f1e8-236e-455d-b300-676e00e3df8e
 
-        @Assert: Multiple docker repositories are created with a Docker
-        upstream repository and they all belong to their respective products.
+        :Assert: Multiple docker repositories are created with a Docker
+            upstream repository and they all belong to their respective
+            products.
         """
         with Session(self.browser) as session:
             for _ in range(randint(2, 3)):
@@ -216,12 +217,12 @@ class DockerRepositoryTestCase(UITestCase):
     def test_positive_sync(self):
         """Create and sync a Docker-type repository
 
-        @id: 00b700f4-7e52-48ed-98b2-e49b3be102f2
+        :id: 00b700f4-7e52-48ed-98b2-e49b3be102f2
 
-        @Assert: A repository is created with a Docker repository and it is
-        synchronized.
+        :Assert: A repository is created with a Docker repository and it is
+            synchronized.
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         repo_name = gen_string('alphanumeric')
         product = entities.Product(organization=self.organization).create()
@@ -243,10 +244,10 @@ class DockerRepositoryTestCase(UITestCase):
     def test_positive_update_name(self):
         """Create a Docker-type repository and update its name.
 
-        @id: 64878d14-39ed-44fd-9a71-5923edaa6e3d
+        :id: 64878d14-39ed-44fd-9a71-5923edaa6e3d
 
-        @Assert: A repository is created with a Docker upstream repository and
-        that its name can be updated.
+        :Assert: A repository is created with a Docker upstream repository and
+            that its name can be updated.
         """
         with Session(self.browser) as session:
             name = gen_string('alphanumeric')
@@ -271,10 +272,10 @@ class DockerRepositoryTestCase(UITestCase):
     def test_positive_update_upstream_name(self):
         """Create a Docker-type repository and update its upstream name.
 
-        @id: b7e17891-e248-4044-ac88-8f8a9d0e95f2
+        :id: b7e17891-e248-4044-ac88-8f8a9d0e95f2
 
-        @Assert: A repository is created with a Docker upstream repository and
-        that its upstream name can be updated.
+        :Assert: A repository is created with a Docker upstream repository and
+            that its upstream name can be updated.
         """
         with Session(self.browser) as session:
             repo_name = gen_string('alphanumeric')
@@ -302,10 +303,10 @@ class DockerRepositoryTestCase(UITestCase):
     def test_positive_update_url(self):
         """Create a Docker-type repository and update its URL.
 
-        @id: d85892a2-a887-413d-81c6-97a2a518f365
+        :id: d85892a2-a887-413d-81c6-97a2a518f365
 
-        @Assert: A repository is created with a Docker upstream repository and
-        that its URL can be updated.
+        :Assert: A repository is created with a Docker upstream repository and
+            that its URL can be updated.
         """
         with Session(self.browser) as session:
             name = gen_string('alphanumeric')
@@ -332,10 +333,10 @@ class DockerRepositoryTestCase(UITestCase):
     def test_positive_delete(self):
         """Create and delete a Docker-type repository
 
-        @id: 725a0f6b-67c5-4a59-a7b9-2308333a42bd
+        :id: 725a0f6b-67c5-4a59-a7b9-2308333a42bd
 
-        @Assert: A repository is created with a Docker upstream repository and
-        then deleted.
+        :Assert: A repository is created with a Docker upstream repository and
+            then deleted.
         """
         with Session(self.browser) as session:
             for name in valid_data_list():
@@ -359,12 +360,12 @@ class DockerRepositoryTestCase(UITestCase):
         """Create Docker-type repositories on multiple products and
         delete a random repository from a random product.
 
-        @id: a3dce435-c46e-41d7-a2f8-29421f7427f5
+        :id: a3dce435-c46e-41d7-a2f8-29421f7427f5
 
-        @Assert: Random repository can be deleted from random product without
-        altering the other products.
+        :Assert: Random repository can be deleted from random product without
+            altering the other products.
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         entities_list = []
         products = [
@@ -418,12 +419,12 @@ class DockerContentViewTestCase(UITestCase):
     def test_positive_add_docker_repo(self):
         """Add one Docker-type repository to a non-composite content view
 
-        @id: 2868cfd5-d27e-4db9-b4a3-2827e31d1601
+        :id: 2868cfd5-d27e-4db9-b4a3-2827e31d1601
 
-        @Assert: A repository is created with a Docker repository and the
-        product is added to a non-composite content view
+        :Assert: A repository is created with a Docker repository and the
+            product is added to a non-composite content view
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         repo_name = gen_string('alphanumeric')
         content_view = entities.ContentView(
@@ -447,12 +448,12 @@ class DockerContentViewTestCase(UITestCase):
         """Add multiple Docker-type repositories to a non-composite
         content view.
 
-        @id: 60d0ea23-fe8c-49f3-bed9-cc062ab1118d
+        :id: 60d0ea23-fe8c-49f3-bed9-cc062ab1118d
 
-        @Assert: Repositories are created with Docker upstream repositories and
-        the product is added to a non-composite content view.
+        :Assert: Repositories are created with Docker upstream repositories and
+            the product is added to a non-composite content view.
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         repos = []
         content_view = entities.ContentView(
@@ -478,12 +479,12 @@ class DockerContentViewTestCase(UITestCase):
     def test_positive_add_synced_docker_repo(self):
         """Create and sync a Docker-type repository
 
-        @id: 338a7ed4-9e10-4bc0-8666-5c8cd0ff0504
+        :id: 338a7ed4-9e10-4bc0-8666-5c8cd0ff0504
 
-        @Assert: A repository is created with a Docker repository and it is
-        synchronized.
+        :Assert: A repository is created with a Docker repository and it is
+            synchronized.
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         repo_name = gen_string('alphanumeric')
         content_view = entities.ContentView(
@@ -510,13 +511,13 @@ class DockerContentViewTestCase(UITestCase):
     def test_positive_add_docker_repo_to_ccv(self):
         """Add one Docker-type repository to a composite content view
 
-        @id: 76b68407-b429-4ad7-b8b5-bfde327a0404
+        :id: 76b68407-b429-4ad7-b8b5-bfde327a0404
 
-        @Assert: A repository is created with a Docker repository and the
-        product is added to a content view which is then added to a composite
-        content view.
+        :Assert: A repository is created with a Docker repository and the
+            product is added to a content view which is then added to a
+            composite content view.
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         repo_name = gen_string('alphanumeric')
         content_view = entities.ContentView(
@@ -546,13 +547,13 @@ class DockerContentViewTestCase(UITestCase):
         """Add multiple Docker-type repositories to a composite content
         view.
 
-        @id: 30187102-7106-45de-a68b-e32fbaecedb9
+        :id: 30187102-7106-45de-a68b-e32fbaecedb9
 
-        @Assert: One repository is created with a Docker upstream repository
-        and the product is added to a random number of content views which are
-        then added to a composite content view.
+        :Assert: One repository is created with a Docker upstream repository
+            and the product is added to a random number of content views which
+            are then added to a composite content view.
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         cvs = []
         with Session(self.browser) as session:
@@ -585,13 +586,13 @@ class DockerContentViewTestCase(UITestCase):
         """Add Docker-type repository to content view and publish it
         once.
 
-        @id: 2004b2d4-177b-47de-9e61-bcfb58f05f88
+        :id: 2004b2d4-177b-47de-9e61-bcfb58f05f88
 
-        @Assert: One repository is created with a Docker upstream repository
-        and the product is added to a content view which is then published only
-        once.
+        :Assert: One repository is created with a Docker upstream repository
+            and the product is added to a content view which is then published
+            only once.
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         with Session(self.browser) as session:
             for repo_name in valid_data_list():
@@ -619,14 +620,14 @@ class DockerContentViewTestCase(UITestCase):
         """Add Docker-type repository to composite content view and
         publish it once.
 
-        @id: 7aad525a-a9d3-4100-9611-ca02c6a95a22
+        :id: 7aad525a-a9d3-4100-9611-ca02c6a95a22
 
-        @Assert: One repository is created with a Docker upstream repository
-        and the product is added to a content view which is then published only
-        once and then added to a composite content view which is also published
-        only once.
+        :Assert: One repository is created with a Docker upstream repository
+            and the product is added to a content view which is then published
+            only once and then added to a composite content view which is also
+            published only once.
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         repo_name = gen_string('alphanumeric')
         content_view = entities.ContentView(
@@ -660,13 +661,13 @@ class DockerContentViewTestCase(UITestCase):
         """Add Docker-type repository to content view and publish it
         multiple times.
 
-        @id: acc703b7-6e99-48d7-96ce-ea0985409ef9
+        :id: acc703b7-6e99-48d7-96ce-ea0985409ef9
 
-        @Assert: One repository is created with a Docker upstream repository
-        and the product is added to a content view which is then published
-        multiple times.
+        :Assert: One repository is created with a Docker upstream repository
+            and the product is added to a content view which is then published
+            multiple times.
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         repo_name = gen_string('utf8')
         with Session(self.browser) as session:
@@ -694,14 +695,14 @@ class DockerContentViewTestCase(UITestCase):
         """Add Docker-type repository to content view and publish it
         multiple times.
 
-        @id: 07755bff-9071-45e5-b861-77a5c2fed3d9
+        :id: 07755bff-9071-45e5-b861-77a5c2fed3d9
 
-        @Assert: One repository is created with a Docker upstream repository
-        and the product is added to a content view which is then added to a
-        composite content view which is then published multiple times.
+        :Assert: One repository is created with a Docker upstream repository
+            and the product is added to a content view which is then added to a
+            composite content view which is then published multiple times.
 
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         repo_name = gen_string('alphanumeric')
         content_view = entities.ContentView(
@@ -735,12 +736,12 @@ class DockerContentViewTestCase(UITestCase):
         """Add Docker-type repository to content view and publish it.
         Then promote it to the next available lifecycle-environment.
 
-        @id: c7e8c4a2-9676-429b-a452-f50d7bdd78b3
+        :id: c7e8c4a2-9676-429b-a452-f50d7bdd78b3
 
-        @Assert: Docker-type repository is promoted to content view found in
-        the specific lifecycle-environment.
+        :Assert: Docker-type repository is promoted to content view found in
+            the specific lifecycle-environment.
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         repo_name = gen_string('utf8')
         lce = entities.LifecycleEnvironment(
@@ -773,12 +774,12 @@ class DockerContentViewTestCase(UITestCase):
         """Add Docker-type repository to content view and publish it.
         Then promote it to multiple available lifecycle-environments.
 
-        @id: c23d582e-502c-49ac-83f7-dcf0f192cbc6
+        :id: c23d582e-502c-49ac-83f7-dcf0f192cbc6
 
-        @Assert: Docker-type repository is promoted to content view found in
-        the specific lifecycle-environments.
+        :Assert: Docker-type repository is promoted to content view found in
+            the specific lifecycle-environments.
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         repo_name = gen_string('utf8')
         with Session(self.browser) as session:
@@ -813,13 +814,13 @@ class DockerContentViewTestCase(UITestCase):
         publish it. Then promote it to the next available
         lifecycle-environment.
 
-        @id: 1c7817c7-60b5-4383-bc6f-2878c2b27fa5
+        :id: 1c7817c7-60b5-4383-bc6f-2878c2b27fa5
 
-        @Assert: Docker-type repository is promoted to content view found in
-        the specific lifecycle-environment.
+        :Assert: Docker-type repository is promoted to content view found in
+            the specific lifecycle-environment.
 
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         repo_name = gen_string('alphanumeric')
         lce = entities.LifecycleEnvironment(
@@ -858,12 +859,12 @@ class DockerContentViewTestCase(UITestCase):
         publish it. Then promote it to the multiple available
         lifecycle-environments.
 
-        @id: b735b1fa-3d60-4fc0-92d2-4af0ab003097
+        :id: b735b1fa-3d60-4fc0-92d2-4af0ab003097
 
-        @Assert: Docker-type repository is promoted to content view found in
-        the specific lifecycle-environments.
+        :Assert: Docker-type repository is promoted to content view found in
+            the specific lifecycle-environments.
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         repo_name = gen_string('alphanumeric')
         content_view = entities.ContentView(
@@ -931,11 +932,11 @@ class DockerActivationKeyTestCase(UITestCase):
         publish it. Then create an activation key and associate it with the
         Docker content view.
 
-        @id: e4935729-c5bc-46be-a23a-93ebde6b3506
+        :id: e4935729-c5bc-46be-a23a-93ebde6b3506
 
-        @Assert: Docker-based content view can be added to activation key
+        :Assert: Docker-based content view can be added to activation key
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         ak_name = gen_string('utf8')
         with Session(self.browser) as session:
@@ -957,14 +958,14 @@ class DockerActivationKeyTestCase(UITestCase):
         publish it. Create an activation key and associate it with the Docker
         content view. Then remove this content view from the activation key.
 
-        @id: 4336093e-141b-47e0-9a39-3952cfaaf377
+        :id: 4336093e-141b-47e0-9a39-3952cfaaf377
 
-        @Assert: Docker-based content view can be added and then removed
-        from the activation key.
+        :Assert: Docker-based content view can be added and then removed from
+            the activation key.
 
-        @caseautomation: notautomated
+        :caseautomation: notautomated
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
 
     @run_only_on('sat')
@@ -975,11 +976,11 @@ class DockerActivationKeyTestCase(UITestCase):
         publish it. Create an activation key and associate it with the
         composite Docker content view.
 
-        @id: 0d412f54-6333-413e-8040-4e51ae5c069c
+        :id: 0d412f54-6333-413e-8040-4e51ae5c069c
 
-        @Assert: Docker-based content view can be added to activation key
+        :Assert: Docker-based content view can be added to activation key
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         ak_name = gen_string('utf8')
         composite_name = gen_string('utf8')
@@ -1014,14 +1015,14 @@ class DockerActivationKeyTestCase(UITestCase):
         composite Docker content view. Then, remove the composite content view
         from the activation key.
 
-        @id: 0bf0360f-555a-4d79-9a14-71360f56633f
+        :id: 0bf0360f-555a-4d79-9a14-71360f56633f
 
-        @Assert: Docker-based composite content view can be added and then
-        removed from the activation key.
+        :Assert: Docker-based composite content view can be added and then
+            removed from the activation key.
 
-        @caseautomation: notautomated
+        :caseautomation: notautomated
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
 
 
@@ -1041,9 +1042,9 @@ class DockerComputeResourceTestCase(UITestCase):
         """Create a Docker-based Compute Resource in the Satellite 6
         instance.
 
-        @id: 78a65ed3-0dbf-413f-91cf-3a02f7ee12d1
+        :id: 78a65ed3-0dbf-413f-91cf-3a02f7ee12d1
 
-        @Assert: Compute Resource can be created and listed.
+        :Assert: Compute Resource can be created and listed.
         """
         with Session(self.browser) as session:
             for comp_name in valid_data_list():
@@ -1067,10 +1068,10 @@ class DockerComputeResourceTestCase(UITestCase):
         """Create a Docker-based Compute Resource in the Satellite 6
         instance then edit its attributes.
 
-        @id: 6a22e770-6a9a-48ab-94b6-e991e484812d
+        :id: 6a22e770-6a9a-48ab-94b6-e991e484812d
 
-        @Assert: Compute Resource can be created, listed and its attributes can
-        be updated.
+        :Assert: Compute Resource can be created, listed and its attributes can
+            be updated.
         """
         comp_name = gen_string('alphanumeric')
         with Session(self.browser) as session:
@@ -1096,12 +1097,12 @@ class DockerComputeResourceTestCase(UITestCase):
         """Create a Docker-based Compute Resource in the Satellite 6
         instance then list its running containers.
 
-        @id: ebac82ed-5a29-4a06-8aae-bd5b08f60fba
+        :id: ebac82ed-5a29-4a06-8aae-bd5b08f60fba
 
-        @Assert: Compute Resource can be created, listed and existing running
-        instances can be listed.
+        :Assert: Compute Resource can be created, listed and existing running
+            instances can be listed.
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         cr_internal = entities.DockerComputeResource(
             organization=[self.organization],
@@ -1133,9 +1134,9 @@ class DockerComputeResourceTestCase(UITestCase):
         """Create a Docker-based Compute Resource using an external
         Docker-enabled system.
 
-        @id: 73ca3ee1-4353-4399-90ba-56560407246e
+        :id: 73ca3ee1-4353-4399-90ba-56560407246e
 
-        @Assert: Compute Resource can be created and listed.
+        :Assert: Compute Resource can be created and listed.
         """
         with Session(self.browser) as session:
             for comp_name in valid_data_list():
@@ -1159,10 +1160,10 @@ class DockerComputeResourceTestCase(UITestCase):
         """Create a Docker-based Compute Resource using an external
         Docker-enabled system then edit its attributes.
 
-        @id: 13d6c7ee-0c90-46cd-8661-73fa1a3c4ef3
+        :id: 13d6c7ee-0c90-46cd-8661-73fa1a3c4ef3
 
-        @Assert: Compute Resource can be created, listed and its
-        attributes can be updated.
+        :Assert: Compute Resource can be created, listed and its attributes can
+            be updated.
         """
         comp_name = gen_string('alphanumeric')
         with Session(self.browser) as session:
@@ -1189,9 +1190,9 @@ class DockerComputeResourceTestCase(UITestCase):
     def test_positive_delete(self):
         """Create a Docker-based Compute Resource then delete it.
 
-        @id: 151d5c08-4f66-461d-9535-f904cd26ce49
+        :id: 151d5c08-4f66-461d-9535-f904cd26ce49
 
-        @Assert: Compute Resource can be created, listed and deleted.
+        :Assert: Compute Resource can be created, listed and deleted.
         """
         comp_name = gen_string('alphanumeric')
         with Session(self.browser) as session:
@@ -1272,11 +1273,11 @@ class DockerContainerTestCase(UITestCase):
     def test_positive_create_with_compresource(self):
         """Create containers for local and external compute resources
 
-        @id: 4916c72f-e921-450c-8023-2ee516deaf25
+        :id: 4916c72f-e921-450c-8023-2ee516deaf25
 
-        @Assert: The docker container is created for each compute resource
+        :Assert: The docker container is created for each compute resource
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         with Session(self.browser) as session:
             for compute_resource in (self.cr_internal, self.cr_external):
@@ -1295,12 +1296,12 @@ class DockerContainerTestCase(UITestCase):
         """Create containers for local and external compute resource,
         then power them on and finally power them off
 
-        @id: cc27bb6f-7fa4-4c87-bf7e-339f2f888717
+        :id: cc27bb6f-7fa4-4c87-bf7e-339f2f888717
 
-        @Assert: The docker container is created for each compute resource and
-        the power status is showing properly
+        :Assert: The docker container is created for each compute resource and
+            the power status is showing properly
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         with Session(self.browser) as session:
             for compute_resource in (self.cr_internal, self.cr_external):
@@ -1324,12 +1325,12 @@ class DockerContainerTestCase(UITestCase):
         """Create a container pulling an image from a custom external
         registry
 
-        @id: e609b411-7533-4f65-917a-bed3672ae03c
+        :id: e609b411-7533-4f65-917a-bed3672ae03c
 
-        @Assert: The docker container is created and the image is pulled from
-        the external registry
+        :Assert: The docker container is created and the image is pulled from
+            the external registry
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         repo_name = 'rhel'
         container_name = gen_string('alphanumeric')
@@ -1367,12 +1368,12 @@ class DockerContainerTestCase(UITestCase):
     def test_positive_delete(self):
         """Delete containers in local and external compute resources
 
-        @id: e69808e7-6a0c-4310-b57a-2271ac61d11a
+        :id: e69808e7-6a0c-4310-b57a-2271ac61d11a
 
-        @Assert: The docker containers are deleted in local and external
-        compute resources
+        :Assert: The docker containers are deleted in local and external
+            compute resources
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         with Session(self.browser) as session:
             for compute_resource in (self.cr_internal, self.cr_external):
@@ -1395,12 +1396,12 @@ class DockerContainerTestCase(UITestCase):
         """Create and delete containers using direct API calls and verify
         result of these operations through UI interface
 
-        @id: 047e2ef9-66b6-41e2-9c29-b7c2da2b64f8
+        :id: 047e2ef9-66b6-41e2-9c29-b7c2da2b64f8
 
-        @Assert: The docker containers are deleted successfully and are not
-        present on UI
+        :Assert: The docker containers are deleted successfully and are not
+            present on UI
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         for compute_resource in (self.cr_internal, self.cr_external):
             with self.subTest(compute_resource.url):
@@ -1439,9 +1440,9 @@ class DockerRegistryTestCase(UITestCase):
     def test_positive_create_with_name(self):
         """Create an external docker registry
 
-        @id: 7d2a2271-801e-454b-af0e-fedf1d96a7d5
+        :id: 7d2a2271-801e-454b-af0e-fedf1d96a7d5
 
-        @Assert: the external registry is created
+        :Assert: the external registry is created
         """
         with Session(self.browser) as session:
             for name in valid_data_list():
@@ -1463,9 +1464,9 @@ class DockerRegistryTestCase(UITestCase):
     def test_positive_update_name(self):
         """Create an external docker registry and update its name
 
-        @id: 2b59f929-4a47-4216-b8b3-7f923d8e7de9
+        :id: 2b59f929-4a47-4216-b8b3-7f923d8e7de9
 
-        @Assert: the external registry is updated with the new name
+        :Assert: the external registry is updated with the new name
         """
         with Session(self.browser) as session:
             name = gen_string('utf8')
@@ -1492,9 +1493,9 @@ class DockerRegistryTestCase(UITestCase):
     def test_positive_update_url(self):
         """Create an external docker registry and update its URL
 
-        @id: cf477436-085d-4517-ad86-23e3d254ad70
+        :id: cf477436-085d-4517-ad86-23e3d254ad70
 
-        @Assert: the external registry is updated with the new URL
+        :Assert: the external registry is updated with the new URL
         """
         with Session(self.browser) as session:
             name = gen_string('utf8')
@@ -1520,9 +1521,9 @@ class DockerRegistryTestCase(UITestCase):
     def test_positive_update_description(self):
         """Create an external docker registry and update its description
 
-        @id: 0ca5e992-b28e-452e-a2be-fca57b4b5195
+        :id: 0ca5e992-b28e-452e-a2be-fca57b4b5195
 
-        @Assert: the external registry is updated with the new description
+        :Assert: the external registry is updated with the new description
         """
         with Session(self.browser) as session:
             name = gen_string('utf8')
@@ -1549,9 +1550,9 @@ class DockerRegistryTestCase(UITestCase):
     def test_positive_update_username(self):
         """Create an external docker registry and update its username
 
-        @id: 9cb24a5a-e383-446e-9b1a-3bf02e0ef439
+        :id: 9cb24a5a-e383-446e-9b1a-3bf02e0ef439
 
-        @Assert: the external registry is updated with the new username
+        :Assert: the external registry is updated with the new username
         """
         with Session(self.browser) as session:
             name = gen_string('utf8')
@@ -1578,9 +1579,9 @@ class DockerRegistryTestCase(UITestCase):
     def test_positive_delete(self):
         """Create an external docker registry and then delete it
 
-        @id: a85d82f5-88b1-4235-8763-1d2f05c8913a
+        :id: a85d82f5-88b1-4235-8763-1d2f05c8913a
 
-        @Assert: The external registry is deleted successfully
+        :Assert: The external registry is deleted successfully
         """
         with Session(self.browser) as session:
             for name in valid_data_list():

--- a/tests/foreman/ui/test_domain.py
+++ b/tests/foreman/ui/test_domain.py
@@ -1,19 +1,19 @@
 # -*- encoding: utf-8 -*-
 """Test class for Domain UI
 
-@Requirement: Domain
+:Requirement: Domain
 
-@CaseAutomation: Automated
+:CaseAutomation: Automated
 
-@CaseLevel: Acceptance
+:CaseLevel: Acceptance
 
-@CaseComponent: UI
+:CaseComponent: UI
 
-@TestType: Functional
+:TestType: Functional
 
-@CaseImportance: High
+:CaseImportance: High
 
-@Upstream: No
+:Upstream: No
 """
 from fauxfactory import gen_string
 from robottelo.constants import DOMAIN
@@ -70,9 +70,9 @@ class DomainTestCase(UITestCase):
     def test_positive_create_with_name(self):
         """Create a new domain with different names
 
-        @id: 142f90e3-a2a3-4f99-8f9b-11189f230bc5
+        :id: 142f90e3-a2a3-4f99-8f9b-11189f230bc5
 
-        @Assert: Domain is created
+        :Assert: Domain is created
         """
         with Session(self.browser) as session:
             for name in generate_strings_list(length=4):
@@ -87,9 +87,9 @@ class DomainTestCase(UITestCase):
     def test_positive_create_with_long_name(self):
         """Create a new domain with long names
 
-        @id: 0b856ad7-97a6-4632-8b84-1d8ee45bedc8
+        :id: 0b856ad7-97a6-4632-8b84-1d8ee45bedc8
 
-        @Assert: Domain is created
+        :Assert: Domain is created
         """
         with Session(self.browser) as session:
             for name in valid_long_domain_names():
@@ -105,9 +105,9 @@ class DomainTestCase(UITestCase):
     def test_positive_delete(self):
         """Delete a domain
 
-        @id: 07c1cc34-4569-4f04-9c4a-2842821a6977
+        :id: 07c1cc34-4569-4f04-9c4a-2842821a6977
 
-        @Assert: Domain is deleted
+        :Assert: Domain is deleted
         """
         domain_name = description = DOMAIN % gen_string('alpha')
         with Session(self.browser) as session:
@@ -119,9 +119,9 @@ class DomainTestCase(UITestCase):
     def test_positive_update(self):
         """Update a domain with name and description
 
-        @id: 25ff4a1d-3ca1-4153-be45-4fe1e63f3f16
+        :id: 25ff4a1d-3ca1-4153-be45-4fe1e63f3f16
 
-        @Assert: Domain is updated
+        :Assert: Domain is updated
         """
         domain_name = description = DOMAIN % gen_string('alpha')
         with Session(self.browser) as session:
@@ -144,9 +144,9 @@ class DomainTestCase(UITestCase):
         """Try to create domain and use whitespace, blank, tab symbol or
         too long string of different types as its name value
 
-        @id: 5a8ba1a8-2da8-48e1-8b2a-96d91161bf94
+        :id: 5a8ba1a8-2da8-48e1-8b2a-96d91161bf94
 
-        @Assert: Domain is not created
+        :Assert: Domain is not created
         """
         with Session(self.browser) as session:
             for name in invalid_values_list(interface='ui'):
@@ -161,11 +161,11 @@ class DomainTestCase(UITestCase):
     def test_positive_set_parameter(self):
         """Set parameter name and value for domain
 
-        @id: a05615de-c9e5-4784-995c-b2fe2a1dfd3e
+        :id: a05615de-c9e5-4784-995c-b2fe2a1dfd3e
 
-        @Assert: Domain is updated
+        :Assert: Domain is updated
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         with Session(self.browser) as session:
             for name in generate_strings_list(length=4):
@@ -185,11 +185,11 @@ class DomainTestCase(UITestCase):
     def test_positive_set_parameter_long(self):
         """Set a parameter in a domain with 255 chars in name and value.
 
-        @id: b346ae66-1720-46af-b0da-460c52ce9476
+        :id: b346ae66-1720-46af-b0da-460c52ce9476
 
-        @Assert: Domain parameter is created.
+        :Assert: Domain parameter is created.
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         domain_name = description = DOMAIN % gen_string('alpha', 4)
         with Session(self.browser) as session:
@@ -206,11 +206,11 @@ class DomainTestCase(UITestCase):
     def test_positive_set_parameter_blank(self):
         """Set a parameter in a domain with blank value.
 
-        @id: b5a67709-57ad-4043-8e72-190ec31b8217
+        :id: b5a67709-57ad-4043-8e72-190ec31b8217
 
-        @Assert: Domain parameter is created with blank value.
+        :Assert: Domain parameter is created with blank value.
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         domain_name = description = DOMAIN % gen_string('alpha', 4)
         with Session(self.browser) as session:
@@ -227,11 +227,11 @@ class DomainTestCase(UITestCase):
     def test_negative_set_parameter(self):
         """Set a parameter in a domain with 256 chars in name and value.
 
-        @id: 1c647d66-6a3f-4d88-8e6b-60f2fc7fd603
+        :id: 1c647d66-6a3f-4d88-8e6b-60f2fc7fd603
 
-        @Assert: Domain parameter is not updated. Error is raised
+        :Assert: Domain parameter is not updated. Error is raised
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         domain_name = description = DOMAIN % gen_string('alpha', 4)
         with Session(self.browser) as session:
@@ -250,11 +250,11 @@ class DomainTestCase(UITestCase):
     def test_negative_set_parameter_same(self):
         """Again set the same parameter for domain with name and value.
 
-        @id: 6266f12e-cf94-4564-ba26-b467ced2737f
+        :id: 6266f12e-cf94-4564-ba26-b467ced2737f
 
-        @Assert: Domain parameter with same values is not created.
+        :Assert: Domain parameter with same values is not created.
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         domain_name = description = DOMAIN % gen_string('alpha', 4)
         param_name = gen_string('alpha')
@@ -274,11 +274,11 @@ class DomainTestCase(UITestCase):
     def test_positive_remove_parameter(self):
         """Remove a selected domain parameter
 
-        @id: 8f7f8501-cf39-418f-a412-1a4b53698bc3
+        :id: 8f7f8501-cf39-418f-a412-1a4b53698bc3
 
-        @Assert: Domain parameter is removed
+        :Assert: Domain parameter is removed
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         with Session(self.browser) as session:
             domain_name = description = DOMAIN % gen_string('alpha', 4)

--- a/tests/foreman/ui/test_email.py
+++ b/tests/foreman/ui/test_email.py
@@ -1,19 +1,19 @@
 # -*- encoding: utf-8 -*-
 """UI Tests for the email notification feature
 
-@Requirement: Email
+:Requirement: Email
 
-@CaseAutomation: Automated
+:CaseAutomation: Automated
 
-@CaseLevel: Acceptance
+:CaseLevel: Acceptance
 
-@CaseComponent: UI
+:CaseComponent: UI
 
-@TestType: Functional
+:TestType: Functional
 
-@CaseImportance: High
+:CaseImportance: High
 
-@Upstream: No
+:Upstream: No
 """
 
 from robottelo.decorators import stubbed, tier1, tier3
@@ -28,20 +28,20 @@ class EmailTestCase(UITestCase):
     def test_positive_preferences(self):
         """Manage user email notification preferences
 
-        @id: 6852256e-4907-454d-bb53-242063222a1f
+        :id: 6852256e-4907-454d-bb53-242063222a1f
 
-        @Steps:
+        :Steps:
 
-        1. Navigate to User → My Account → Mail Preferences.
-        2. Attempt to enable and disable the following email notification
-           preferences: Mail Enabled, Katello Sync Errata, Katello Host
-           Advisory, Katello Promote Errata, Puppet Error state, Puppet
-           Summary.
+            1. Navigate to User → My Account → Mail Preferences.
+            2. Attempt to enable and disable the following email notification
+                preferences: Mail Enabled, Katello Sync Errata, Katello Host
+                Advisory, Katello Promote Errata, Puppet Error state, Puppet
+                Summary.
 
-        @Assert: Enabling and disabling email notification preferences saved
-        accordingly.
+        :Assert: Enabling and disabling email notification preferences saved
+            accordingly.
 
-        @caseautomation: notautomated
+        :caseautomation: notautomated
 
         """
 
@@ -50,20 +50,20 @@ class EmailTestCase(UITestCase):
     def test_positive_sync_with_enabled_notification(self):
         """Receive email after every sync operation
 
-        @id: 79ed2bc9-3707-4548-bdab-290ae5e9abf3
+        :id: 79ed2bc9-3707-4548-bdab-290ae5e9abf3
 
-        @Steps:
+        :Steps:
 
-        1. Navigate to User → My Account → Mail Preferences.
-        2. Enable notification for 'Katello Sync Errata'.
-        3. Perform a sync operation on a product.
+            1. Navigate to User → My Account → Mail Preferences.
+            2. Enable notification for 'Katello Sync Errata'.
+            3. Perform a sync operation on a product.
 
-        @Assert: Email notification received after sync operation.
+        :Assert: Email notification received after sync operation.
 
-        @caseautomation: notautomated
+        :caseautomation: notautomated
 
 
-        @CaseLevel: System
+        :CaseLevel: System
         """
 
     @stubbed()
@@ -71,20 +71,19 @@ class EmailTestCase(UITestCase):
     def test_positive_sync_with_disabled_notification(self):
         """Do not receive email after every sync operation
 
-        @id: c0b8b5d6-ed44-42b7-9700-1dd26bb4ae55
+        :id: c0b8b5d6-ed44-42b7-9700-1dd26bb4ae55
 
-        @Steps:
+        :Steps:
 
-        1. Navigate to User → My Account → Mail Preferences.
-        2. Disable notification by 'Katello Sync Errata' → 'No Emails'.
-        3. Perform a sync operation on a product.
+            1. Navigate to User → My Account → Mail Preferences.
+            2. Disable notification by 'Katello Sync Errata' → 'No Emails'.
+            3. Perform a sync operation on a product.
 
-        @Assert: No email notification received after sync operation.
+        :Assert: No email notification received after sync operation.
 
-        @caseautomation: notautomated
+        :caseautomation: notautomated
 
-
-        @CaseLevel: System
+        :CaseLevel: System
         """
 
     @stubbed()
@@ -92,20 +91,19 @@ class EmailTestCase(UITestCase):
     def test_positive_promote_with_enabled_notification(self):
         """Receive email after every promote operation
 
-        @id: cb14b622-cbfd-4834-889d-bc6e7884bfb0
+        :id: cb14b622-cbfd-4834-889d-bc6e7884bfb0
 
-        @Steps:
+        :Steps:
 
-        1. Navigate to User → My Account → Mail Preferences.
-        2. Enable notification for 'Katello Promote Errata'.
-        3. Perform a promote operation in a content view.
+            1. Navigate to User → My Account → Mail Preferences.
+            2. Enable notification for 'Katello Promote Errata'.
+            3. Perform a promote operation in a content view.
 
-        @Assert: Email notification received after Promote operation.
+        :Assert: Email notification received after Promote operation.
 
-        @caseautomation: notautomated
+        :caseautomation: notautomated
 
-
-        @CaseLevel: System
+        :CaseLevel: System
         """
 
     @stubbed()
@@ -113,20 +111,19 @@ class EmailTestCase(UITestCase):
     def test_positive_promote_with_disabled_notification(self):
         """Do not receive email after every promote operation
 
-        @id: 4cca1869-f869-414b-b652-d6a5b3ce6f17
+        :id: 4cca1869-f869-414b-b652-d6a5b3ce6f17
 
-        @Steps:
+        :Steps:
 
-        1. Navigate to User → My Account → Mail Preferences.
-        2. Disable notification by 'Katello Promote Errata' → 'No Emails'.
-        3. Perform a promote operation in a content view.
+            1. Navigate to User → My Account → Mail Preferences.
+            2. Disable notification by 'Katello Promote Errata' → 'No Emails'.
+            3. Perform a promote operation in a content view.
 
-        @Assert: No email notification received after Promote operation.
+        :Assert: No email notification received after Promote operation.
 
-        @caseautomation: notautomated
+        :caseautomation: notautomated
 
-
-        @CaseLevel: System
+        :CaseLevel: System
         """
 
     @stubbed()
@@ -134,20 +131,19 @@ class EmailTestCase(UITestCase):
     def test_positive_host_with_daily_notification(self):
         """Receive daily email with host advisory information
 
-        @id: 3a21d0ef-3c67-4e47-bcec-a8dd1a5aa564
+        :id: 3a21d0ef-3c67-4e47-bcec-a8dd1a5aa564
 
-        @Steps:
+        :Steps:
 
-        1. Navigate to User → My Account → Mail Preferences.
-        2. Enable notification for 'Katello Host Advisory' → Daily.
+            1. Navigate to User → My Account → Mail Preferences.
+            2. Enable notification for 'Katello Host Advisory' → Daily.
 
-        @Assert: Email notification received daily with Katello Host Advisory
-        information.
+        :Assert: Email notification received daily with Katello Host Advisory
+            information.
 
-        @caseautomation: notautomated
+        :caseautomation: notautomated
 
-
-        @CaseLevel: System
+        :CaseLevel: System
         """
 
     @stubbed()
@@ -155,20 +151,19 @@ class EmailTestCase(UITestCase):
     def test_positive_host_with_weekly_notification(self):
         """Receive weekly email with host advisory information
 
-        @id: b195fc2e-0449-4cb3-9f4c-ed8c8266651b
+        :id: b195fc2e-0449-4cb3-9f4c-ed8c8266651b
 
-        @Steps:
+        :Steps:
 
-        1. Navigate to User → My Account → Mail Preferences.
-        2. Enable notification for 'Katello Host Advisory' → Weekly.
+            1. Navigate to User → My Account → Mail Preferences.
+            2. Enable notification for 'Katello Host Advisory' → Weekly.
 
-        @Assert: Email notification received Weekly with Katello Host Advisory
-        information.
+        :Assert: Email notification received Weekly with Katello Host Advisory
+            information.
 
-        @caseautomation: notautomated
+        :caseautomation: notautomated
 
-
-        @CaseLevel: System
+        :CaseLevel: System
         """
 
     @stubbed()
@@ -176,20 +171,19 @@ class EmailTestCase(UITestCase):
     def test_positive_host_with_monthly_notification(self):
         """Receive monthly email with host advisory information
 
-        @id: e05398b9-6fbd-4aa5-84e9-70ae0a2db9a1
+        :id: e05398b9-6fbd-4aa5-84e9-70ae0a2db9a1
 
-        @Steps:
+        :Steps:
 
-        1. Navigate to User → My Account → Mail Preferences.
-        2. Enable notification for 'Katello Host Advisory' → Monthly.
+            1. Navigate to User → My Account → Mail Preferences.
+            2. Enable notification for 'Katello Host Advisory' → Monthly.
 
-        @Assert: Email notification received monthly with Katello Host Advisory
-        information.
+        :Assert: Email notification received monthly with Katello Host Advisory
+            information.
 
-        @caseautomation: notautomated
+        :caseautomation: notautomated
 
-
-        @CaseLevel: System
+        :CaseLevel: System
         """
 
     @stubbed()
@@ -197,20 +191,19 @@ class EmailTestCase(UITestCase):
     def test_positive_host_with_disabled_notification(self):
         """Receive no email with host advisory information
 
-        @id: 5540ba69-aab0-42a3-afda-298249880348
+        :id: 5540ba69-aab0-42a3-afda-298249880348
 
-        @Steps:
+        :Steps:
 
-        1. Navigate to User → My Account → Mail Preferences.
-        2. Disable notification by 'Katello Host Advisory' → 'No emails'.
+            1. Navigate to User → My Account → Mail Preferences.
+            2. Disable notification by 'Katello Host Advisory' → 'No emails'.
 
-        @Assert: No email notification received with Katello Host Advisory
-        information.
+        :Assert: No email notification received with Katello Host Advisory
+            information.
 
-        @caseautomation: notautomated
+        :caseautomation: notautomated
 
-
-        @CaseLevel: System
+        :CaseLevel: System
         """
 
     @stubbed()
@@ -218,20 +211,19 @@ class EmailTestCase(UITestCase):
     def test_positive_puppet_error_with_enabled_notification(self):
         """Receive email after puppet error
 
-        @id: 2c14a0d9-2f37-47da-b095-0c984a24091d
+        :id: 2c14a0d9-2f37-47da-b095-0c984a24091d
 
-        @Steps:
+        :Steps:
 
-        1. Navigate to User → My Account → Mail Preferences.
-        2. Enable notification for 'Puppet Error State'.
-        3. Simulate a Puppet error.
+            1. Navigate to User → My Account → Mail Preferences.
+            2. Enable notification for 'Puppet Error State'.
+            3. Simulate a Puppet error.
 
-        @Assert: Email notification received with Puppet error.
+        :Assert: Email notification received with Puppet error.
 
-        @caseautomation: notautomated
+        :caseautomation: notautomated
 
-
-        @CaseLevel: System
+        :CaseLevel: System
         """
 
     @stubbed()
@@ -239,20 +231,19 @@ class EmailTestCase(UITestCase):
     def test_positive_puppet_error_with_disabled_notification(self):
         """Do not receive email after puppet error
 
-        @id: fd6e7274-b9c1-44f8-91de-ad5162f21c74
+        :id: fd6e7274-b9c1-44f8-91de-ad5162f21c74
 
-        @Steps:
+        :Steps:
 
-        1. Navigate to User → My Account → Mail Preferences.
-        2. Disable notification by 'Puppet Error State' → 'No Emails'.
-        3. Simulate a Puppet error.
+            1. Navigate to User → My Account → Mail Preferences.
+            2. Disable notification by 'Puppet Error State' → 'No Emails'.
+            3. Simulate a Puppet error.
 
-        @Assert: No email notification received after Puppet error.
+        :Assert: No email notification received after Puppet error.
 
-        @caseautomation: notautomated
+        :caseautomation: notautomated
 
-
-        @CaseLevel: System
+        :CaseLevel: System
         """
 
     @stubbed()
@@ -261,27 +252,26 @@ class EmailTestCase(UITestCase):
         """Receive 'Katello Sync Errata' notifications - only for
         repositories and content views that the user has view access to
 
-        @id: b0e4a823-4225-4788-8cfd-2d1ccf4d9ded
+        :id: b0e4a823-4225-4788-8cfd-2d1ccf4d9ded
 
-        @setup:
+        :setup:
 
-        1. Create multiple products with synced errata.
-        2. The test user does not have view access to atleast some of the
-           products.
+            1. Create multiple products with synced errata.
+            2. The test user does not have view access to atleast some of the
+                products.
 
-        @Steps:
+        :Steps:
 
-        1. Navigate to User → My Account → Mail Preferences.
-        2. Enable notification for test user for 'Katello Sync Errata'.
-        3. Login as admin and perform sync on a product for which the test user
-           does not have view access.
+            1. Navigate to User → My Account → Mail Preferences.
+            2. Enable notification for test user for 'Katello Sync Errata'.
+            3. Login as admin and perform sync on a product for which the test
+                user does not have view access.
 
-        @Assert: Test user does not receive email notification.
+        :Assert: Test user does not receive email notification.
 
-        @caseautomation: notautomated
+        :caseautomation: notautomated
 
-
-        @CaseLevel: System
+        :CaseLevel: System
         """
 
     @stubbed()
@@ -290,27 +280,27 @@ class EmailTestCase(UITestCase):
         """Receive 'Katello Promote Errata' notifications - only for
         repositories and content views that the user has view access to
 
-        @id: 44435f4f-ea9f-4f6e-b1c0-d273974ec9e5
+        :id: 44435f4f-ea9f-4f6e-b1c0-d273974ec9e5
 
-        @setup:
+        :setup:
 
-        1. Create multiple products with synced errata.
-        2. The test user does not have view access to atleast some of the
-           products.
+            1. Create multiple products with synced errata.
+            2. The test user does not have view access to atleast some of the
+                products.
 
-        @Steps:
+        :Steps:
 
-        1. Navigate to User → My Account → Mail Preferences.
-        2. Enable notification for the test user for 'Katello Promote Errata'.
-        3. Login as admin and perform sync on a product for which the test user
-           does not have view access.
+            1. Navigate to User → My Account → Mail Preferences.
+            2. Enable notification for the test user for 'Katello Promote
+                Errata'.
+            3. Login as admin and perform sync on a product for which the test
+                user does not have view access.
 
-        @Assert: Test user does not receive email notification.
+        :Assert: Test user does not receive email notification.
 
-        @caseautomation: notautomated
+        :caseautomation: notautomated
 
-
-        @CaseLevel: System
+        :CaseLevel: System
         """
 
     @stubbed()
@@ -319,26 +309,26 @@ class EmailTestCase(UITestCase):
         """Receive 'Katello Host Advisory' notifications - only for
         repositories and content views that the user has view access to
 
-        @id: aea2cfa7-0a44-4b72-bd10-275e604100a9
+        :id: aea2cfa7-0a44-4b72-bd10-275e604100a9
 
-        @setup:
+        :setup:
 
-        1. Create multiple products with synced errata.
-        2. The test user does not have view access to atleast some of the
-           products.
+            1. Create multiple products with synced errata.
+            2. The test user does not have view access to atleast some of the
+                products.
 
-        @Steps:
+        :Steps:
 
-        1. Navigate to User → My Account → Mail Preferences.
-        2. Enable notification for the test user for 'Katello Host Advisory'.
+            1. Navigate to User → My Account → Mail Preferences.
+            2. Enable notification for the test user for 'Katello Host
+                Advisory'.
 
-        @Assert: Test user receives email notification with the host info for
-        the repositories and content views that the user has access to.
+        :Assert: Test user receives email notification with the host info for
+            the repositories and content views that the user has access to.
 
-        @caseautomation: notautomated
+        :caseautomation: notautomated
 
-
-        @CaseLevel: System
+        :CaseLevel: System
         """
 
     @stubbed()
@@ -347,24 +337,23 @@ class EmailTestCase(UITestCase):
         """Receive 'Katello Host Advisory' notifications - only for
         content hosts that the user has view access to
 
-        @id: 2acc2979-926a-4176-b87a-57bc880e4b31
+        :id: 2acc2979-926a-4176-b87a-57bc880e4b31
 
-        @setup:
+        :setup:
 
-        1. Make sure to have multiple content hosts
-        2. The test user does not have view access to atleast some of the
-           products
+            1. Make sure to have multiple content hosts
+            2. The test user does not have view access to atleast some of the
+                products
 
-        @Steps:
+        :Steps:
 
-        1. Navigate to User → My Account → Mail Preferences.
-        2. Enable notification for test user for 'Katello Host Advisory'.
+            1. Navigate to User → My Account → Mail Preferences.
+            2. Enable notification for test user for 'Katello Host Advisory'.
 
-        @Assert: Test user receives email notification which does not list the
-        content hosts for which the user does not have view access.
+        :Assert: Test user receives email notification which does not list the
+            content hosts for which the user does not have view access.
 
-        @caseautomation: notautomated
+        :caseautomation: notautomated
 
-
-        @CaseLevel: System
+        :CaseLevel: System
         """

--- a/tests/foreman/ui/test_environment.py
+++ b/tests/foreman/ui/test_environment.py
@@ -1,19 +1,19 @@
 # -*- encoding: utf-8 -*-
 """Test class for Environment UI
 
-@Requirement: Environment
+:Requirement: Environment
 
-@CaseAutomation: Automated
+:CaseAutomation: Automated
 
-@CaseLevel: Acceptance
+:CaseLevel: Acceptance
 
-@CaseComponent: UI
+:CaseComponent: UI
 
-@TestType: Functional
+:TestType: Functional
 
-@CaseImportance: High
+:CaseImportance: High
 
-@Upstream: No
+:Upstream: No
 """
 
 from fauxfactory import gen_string
@@ -37,9 +37,9 @@ class EnvironmentTestCase(UITestCase):
     def test_positive_create_with_name(self):
         """Create new environment
 
-        @id: be8ee96a-29e4-4c64-9cae-78ab6aa483d7
+        :id: be8ee96a-29e4-4c64-9cae-78ab6aa483d7
 
-        @Assert: Environment is created
+        :Assert: Environment is created
         """
         with Session(self.browser) as session:
             for name in valid_environments_list():
@@ -52,9 +52,9 @@ class EnvironmentTestCase(UITestCase):
     def test_positive_create_with_long_name(self):
         """Create new environment with 255 chars
 
-        @id: 37a57326-debf-498f-96f8-8f9d518817aa
+        :id: 37a57326-debf-498f-96f8-8f9d518817aa
 
-        @Assert: Environment is created
+        :Assert: Environment is created
         """
         # TODO: This test can be removed by adding the value
         # gen_string('alphanumeric', 255) to valid_env_names().  But since
@@ -75,9 +75,9 @@ class EnvironmentTestCase(UITestCase):
         """Try to create environment and use whitespace, blank, tab
         symbol or too long string of different types as its name value
 
-        @id: 51c7e300-5f59-4de8-bc55-1a75b03aa456
+        :id: 51c7e300-5f59-4de8-bc55-1a75b03aa456
 
-        @Assert: Environment is not created
+        :Assert: Environment is not created
         """
         with Session(self.browser) as session:
             for name in invalid_values_list(interface='ui'):
@@ -93,9 +93,9 @@ class EnvironmentTestCase(UITestCase):
     def test_positive_update(self):
         """Update an environment and associated OS
 
-        @id: 4fd6aa68-c850-4fcd-8c9b-f88d6c0d1c2d
+        :id: 4fd6aa68-c850-4fcd-8c9b-f88d6c0d1c2d
 
-        @Assert: Environment is updated
+        :Assert: Environment is updated
         """
         name = gen_string('alpha')
         with Session(self.browser) as session:
@@ -111,9 +111,9 @@ class EnvironmentTestCase(UITestCase):
     def test_positive_delete(self):
         """Delete an environment
 
-        @id: 8572461e-2457-4a1c-bb63-78f49ce2d0fd
+        :id: 8572461e-2457-4a1c-bb63-78f49ce2d0fd
 
-        @Assert: Environment is deleted
+        :Assert: Environment is deleted
         """
         with Session(self.browser) as session:
             for name in valid_environments_list():

--- a/tests/foreman/ui/test_errata.py
+++ b/tests/foreman/ui/test_errata.py
@@ -1,18 +1,18 @@
 """UI Tests for the errata management feature
 
-@Requirement: Errata
+:Requirement: Errata
 
-@CaseAutomation: Automated
+:CaseAutomation: Automated
 
-@CaseLevel: Acceptance
+:CaseLevel: Acceptance
 
-@CaseComponent: UI
+:CaseComponent: UI
 
-@TestType: Functional
+:TestType: Functional
 
-@CaseImportance: High
+:CaseImportance: High
 
-@Upstream: No
+:Upstream: No
 """
 
 from fauxfactory import gen_string
@@ -113,39 +113,37 @@ class ErrataTestCase(UITestCase):
     def test_positive_sort(self):
         """Sort the columns of Errata page
 
-        @id: 213b8592-ccb5-485d-b5fa-e445b853b20c
+        :id: 213b8592-ccb5-485d-b5fa-e445b853b20c
 
-        @Setup: Errata synced on satellite server.
+        :Setup: Errata synced on satellite server.
 
-        @Steps:
+        :Steps:
 
-        1. Go to Content -> Errata.
-        2. Sort by Errata Id, Title, Type, Affected Content Hosts, Updated.
+            1. Go to Content -> Errata.
+            2. Sort by Errata Id, Title, Type, Affected Content Hosts, Updated.
 
-        @Assert: Errata is sorted by selected column.
+        :Assert: Errata is sorted by selected column.
 
-        @caseautomation: notautomated
+        :caseautomation: notautomated
 
-
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
 
     @tier2
     def test_positive_list(self):
         """View all errata in an Org
 
-        @id: 71c7a054-a644-4c1e-b304-6bc34ea143f4
+        :id: 71c7a054-a644-4c1e-b304-6bc34ea143f4
 
-        @Setup: Errata synced on satellite server.
+        :Setup: Errata synced on satellite server.
 
-        @Steps:
+        :Steps: Create two Orgs each having a product synced which contains
+            errata.
 
-        1. Create two Orgs each having a product synced which contains errata.
+        :Assert: Check that the errata belonging to one Org is not showing in
+            the other.
 
-        @Assert: Check that the errata belonging to one Org is not showing in
-        the other.
-
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         org = entities.Organization().create()
         env = entities.LifecycleEnvironment(organization=org).create()
@@ -176,22 +174,21 @@ class ErrataTestCase(UITestCase):
     def test_positive_list_permission(self):
         """Show errata only if the User has permissions to view them
 
-        @id: cdb28f6a-23df-47a2-88ab-cd3b492126b2
+        :id: cdb28f6a-23df-47a2-88ab-cd3b492126b2
 
-        @Setup:
+        :Setup:
 
-        1. Create two products with one repo each. Sync them.
-        2. Make sure that they both have errata.
-        3. Create a user with view access on one product and not on the other.
+            1. Create two products with one repo each. Sync them.
+            2. Make sure that they both have errata.
+            3. Create a user with view access on one product and not on the
+                other.
 
-        @Steps:
+        :Steps: Go to Content -> Errata.
 
-        1. Go to Content -> Errata.
+        :Assert: Check that the new user is able to see errata for one product
+            only.
 
-        @Assert: Check that the new user is able to see errata for one product
-        only.
-
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         role = entities.Role().create()
         entities.Filter(
@@ -218,19 +215,19 @@ class ErrataTestCase(UITestCase):
     def test_positive_apply_for_host(self):
         """Apply an erratum for selected content hosts
 
-        @id: 442d1c20-bf7e-4e4c-9a48-ab3f4809fa61
+        :id: 442d1c20-bf7e-4e4c-9a48-ab3f4809fa61
 
-        @Setup: Errata synced on satellite server.
+        :Setup: Errata synced on satellite server.
 
-        @Steps:
+        :Steps:
 
-        1. Go to Content -> Errata. Select an erratum -> Content Hosts tab.
-        2. Select few Content Hosts and apply the erratum.
+            1. Go to Content -> Errata. Select an erratum -> Content Hosts tab.
+            2. Select few Content Hosts and apply the erratum.
 
-        @Assert: Check that the erratum is applied in the selected content
-        hosts.
+        :Assert: Check that the erratum is applied in the selected content
+            hosts.
 
-        @CaseLevel: System
+        :CaseLevel: System
         """
         with VirtualMachine(distro=DISTRO_RHEL7) as client:
             client.install_katello_ca()
@@ -253,18 +250,18 @@ class ErrataTestCase(UITestCase):
     def test_positive_apply_for_all_hosts(self):
         """Apply an erratum for all content hosts
 
-        @id: d70a1bee-67f4-4883-a0b9-2ccc08a91738
+        :id: d70a1bee-67f4-4883-a0b9-2ccc08a91738
 
-        @Setup: Errata synced on satellite server.
+        :Setup: Errata synced on satellite server.
 
-        @Steps:
+        :Steps:
 
-        1. Go to Content -> Errata. Select an erratum -> Content Hosts tab.
-        2. Select all Content Hosts and apply the erratum.
+            1. Go to Content -> Errata. Select an erratum -> Content Hosts tab.
+            2. Select all Content Hosts and apply the erratum.
 
-        @Assert: Check that the erratum is applied in all the content hosts.
+        :Assert: Check that the erratum is applied in all the content hosts.
 
-        @CaseLevel: System
+        :CaseLevel: System
         """
         with VirtualMachine(distro=DISTRO_RHEL7) as client1, VirtualMachine(
                 distro=DISTRO_RHEL7) as client2:
@@ -294,18 +291,16 @@ class ErrataTestCase(UITestCase):
     def test_positive_view(self):
         """View erratum similar to RH Customer portal
 
-        @id: 7d0814fd-70e8-4451-ac96-c632cae55731
+        :id: 7d0814fd-70e8-4451-ac96-c632cae55731
 
-        @Setup: Errata synced on satellite server.
+        :Setup: Errata synced on satellite server.
 
-        @Steps:
+        :Steps: Go to Content -> Errata. Review the Errata page.
 
-        1. Go to Content -> Errata. Review the Errata page.
+        :Assert: The following fields: Errata Id, Title, Type, Affected Content
+            Hosts, Updated has expected values for errata table.
 
-        @Assert: The following fields: Errata Id, Title, Type, Affected Content
-        Hosts, Updated has expected values for errata table.
-
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         with Session(self.browser):
             self.errata.validate_table_fields(
@@ -318,19 +313,17 @@ class ErrataTestCase(UITestCase):
     def test_positive_view_details(self):
         """View erratum details similar to RH Customer portal
 
-        @id: c00aeacc-eefb-4371-a0ee-5a68041a16a2
+        :id: c00aeacc-eefb-4371-a0ee-5a68041a16a2
 
-        @Setup: Errata synced on satellite server.
+        :Setup: Errata synced on satellite server.
 
-        @Steps:
+        :Steps: Go to Content -> Errata.  Select an Errata -> Details tab.
 
-        1. Go to Content -> Errata.  Select an Errata -> Details tab.
+        :Assert: The following fields are displayed: : Advisory, CVEs, Type,
+            Severity, Issued, Last Update on, Reboot Suggested, Topic,
+            Description, Solution, Affected Packages.
 
-        @Assert: The following fields are displayed: : Advisory, CVEs, Type,
-        Severity, Issued, Last Update on, Reboot Suggested, Topic, Description,
-        Solution, Affected Packages.
-
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         with Session(self.browser):
             self.errata.check_errata_details(
@@ -343,17 +336,15 @@ class ErrataTestCase(UITestCase):
     def test_positive_view_products_and_repos(self):
         """View a list of products/repositories for an erratum
 
-        @id: 3023006d-514f-436a-b12b-dc08d9609fa6
+        :id: 3023006d-514f-436a-b12b-dc08d9609fa6
 
-        @Setup: Errata synced on satellite server.
+        :Setup: Errata synced on satellite server.
 
-        @Steps:
+        :Steps: Go to Content -> Errata.  Select an Errata -> Repositories tab.
 
-        1. Go to Content -> Errata.  Select an Errata -> Repositories tab.
+        :Assert: The Repositories tab lists affected Products and Repositories.
 
-        @Assert: The Repositories tab lists affected Products and Repositories.
-
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         product = entities.Product(
             id=self.custom_entitites['product-id']).read()
@@ -373,21 +364,18 @@ class ErrataTestCase(UITestCase):
     def test_positive_view_cve(self):
         """View CVE number(s) in Errata Details page
 
-        @id: e1c2de13-fed8-448e-b618-c2adb6e82a35
+        :id: e1c2de13-fed8-448e-b618-c2adb6e82a35
 
-        @Setup: Errata synced on satellite server.
+        :Setup: Errata synced on satellite server.
 
-        @Steps:
+        :Steps: Go to Content -> Errata.  Select an Errata.
 
-        1. Go to Content -> Errata.  Select an Errata.
+        :Assert:
 
-        @Assert:
+            1. Check if the CVE information is shown in Errata Details page.
+            2. Check if 'N/A' is displayed if CVE information is not present.
 
-        1: Check if the CVE information is shown in Errata Details page.
-
-        2. Check if 'N/A' is displayed if CVE information is not present.
-
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         real_errata_id = 'RHSA-2014:1873'  # rhva6 errata with CVEs
         real_errata_cves = 'CVE-2014-3633 , CVE-2014-3657 , CVE-2014-7823'
@@ -420,18 +408,16 @@ class ErrataTestCase(UITestCase):
     def test_positive_filter(self):
         """Filter Content hosts by environment
 
-        @id: 578c3a92-c4d8-4933-b122-7ff511c276ec
+        :id: 578c3a92-c4d8-4933-b122-7ff511c276ec
 
-        @Setup: Errata synced on satellite server.
+        :Setup: Errata synced on satellite server.
 
-        @Steps:
+        :Steps: Go to Content -> Errata.  Select an Errata -> Content Hosts tab
+            -> Filter content hosts by Environment.
 
-        1. Go to Content -> Errata.  Select an Errata -> Content Hosts tab ->
-        Filter content hosts by Environment.
+        :Assert: Content hosts can be filtered by Environment.
 
-        @Assert: Content hosts can be filtered by Environment.
-
-        @CaseLevel: System
+        :CaseLevel: System
         """
         with VirtualMachine(distro=DISTRO_RHEL7) as client1, VirtualMachine(
                 distro=DISTRO_RHEL7) as client2:
@@ -502,17 +488,15 @@ class ErrataTestCase(UITestCase):
     def test_positive_search_autocomplete(self):
         """Check if autocomplete works in search field of Errata page
 
-        @id: d93941d9-faad-4a31-9815-87dff9132082
+        :id: d93941d9-faad-4a31-9815-87dff9132082
 
-        @Setup: Errata synced on satellite server.
+        :Setup: Errata synced on satellite server.
 
-        @Steps:
+        :Steps: Go to Content -> Errata.
 
-        1. Go to Content -> Errata.
+        :Assert: Check if autocomplete works in search field of Errata page.
 
-        @Assert: Check if autocomplete works in search field of Errata page.
-
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         with Session(self.browser):
             self.assertIsNotNone(
@@ -526,29 +510,28 @@ class ErrataTestCase(UITestCase):
         """Check if all the errata searches are redirected to the new
         errata page
 
-        @id: 3de38510-d0d9-447e-8dee-a3aadba1f3c7
+        :id: 3de38510-d0d9-447e-8dee-a3aadba1f3c7
 
-        @Setup: Errata synced on satellite server.
+        :Setup: Errata synced on satellite server.
 
-        @Steps:
+        :Steps:
 
-        1. Go to Content -> Products -> Repositories ->
-        Click on any of the errata hyperlink.
-        2. Go to Content -> Products -> Repositories -> Click on a repository->
-        Click on any of the errata hyperlink.
-        3. Go to Content -> Content Views -> Select a Content View -> Yum
-        Content -> Click on any of the errata hyperlink.
-        4. Go to Content -> Content Views -> Select a Content View -> Yum
-        Content -> Filters -> Select a Filter -> Click on any of the errata
-        hyperlink.
+            1. Go to Content -> Products -> Repositories -> Click on any of the
+                errata hyperlink.
+            2. Go to Content -> Products -> Repositories -> Click on a
+                repository-> Click on any of the errata hyperlink.
+            3. Go to Content -> Content Views -> Select a Content View -> Yum
+                Content -> Click on any of the errata hyperlink.
+            4. Go to Content -> Content Views -> Select a Content View -> Yum
+                Content -> Filters -> Select a Filter -> Click on any of the
+                errata hyperlink.
 
-        @Assert: Check if all the above mentioned scenarios redirect to the new
-        errata page.
+        :Assert: Check if all the above mentioned scenarios redirect to the new
+            errata page.
 
-        @caseautomation: notautomated
+        :caseautomation: notautomated
 
-
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
 
     @tier3
@@ -556,21 +539,19 @@ class ErrataTestCase(UITestCase):
         """Check if the applicable errata are available from the content
         host's previous environment
 
-        @id: 78110ba8-3942-46dd-8c14-bffa1dbd5195
+        :id: 78110ba8-3942-46dd-8c14-bffa1dbd5195
 
-        @Setup:
+        :Setup:
 
-        1. Make sure multiple environments are present.
-        2. Content host's previous environments have additional errata.
+            1. Make sure multiple environments are present.
+            2. Content host's previous environments have additional errata.
 
-        @Steps:
+        :Steps: Go to Content Hosts -> Select content host -> Errata Tab ->
+            Select Previous environments.
 
-        1. Go to Content Hosts -> Select content host -> Errata Tab -> Select
-        Previous environments.
+        :Assert: The errata from previous environments are displayed.
 
-        @Assert: The errata from previous environments are displayed.
-
-        @CaseLevel: System
+        :CaseLevel: System
         """
         with VirtualMachine(distro=DISTRO_RHEL7) as client:
                 client.install_katello_ca()
@@ -619,21 +600,19 @@ class ErrataTestCase(UITestCase):
         """Check if the applicable errata are available from the content
         host's Library
 
-        @id: 4e627410-b7b8-471b-b9b4-a18e77fdd3f8
+        :id: 4e627410-b7b8-471b-b9b4-a18e77fdd3f8
 
-        @Setup:
+        :Setup:
 
-        1. Make sure multiple environments are present.
-        2. Content host's Library environment has additional errata.
+            1. Make sure multiple environments are present.
+            2. Content host's Library environment has additional errata.
 
-        @Steps:
+        :Steps: Go to Content Hosts -> Select content host -> Errata Tab ->
+            Select 'Library'.
 
-        1. Go to Content Hosts -> Select content host -> Errata Tab -> Select
-        'Library'.
+        :Assert: The errata from Library are displayed.
 
-        @Assert: The errata from Library are displayed.
-
-        @CaseLevel: System
+        :CaseLevel: System
         """
         with VirtualMachine(distro=DISTRO_RHEL7) as client:
             client.install_katello_ca()
@@ -659,27 +638,25 @@ class ErrataTestCase(UITestCase):
     def test_positive_show_count_on_chost_page(self):
         """Available errata count displayed in Content hosts page
 
-        @id: 8575e282-d56e-41dc-80dd-f5f6224417cb
+        :id: 8575e282-d56e-41dc-80dd-f5f6224417cb
 
-        @Setup:
+        :Setup:
 
-        1. Errata synced on satellite server.
-        2. Some content hosts are present.
+            1. Errata synced on satellite server.
+            2. Some content hosts are present.
 
-        @Steps:
+        :Steps: Go to Hosts -> Content Hosts.
 
-        1. Go to Hosts -> Content Hosts.
+        :Assert:
 
-        @Assert:
-
-        1. The available errata count is displayed.
-        2. Errata count is displayed with color icons.
+            1. The available errata count is displayed.
+            2. Errata count is displayed with color icons.
 
            - An errata count of 0 = black
            - If security errata, >0 = red
            - If any other errata, >0 = yellow
 
-        @CaseLevel: System
+        :CaseLevel: System
         """
         org = entities.Organization().create()
         env = entities.LifecycleEnvironment(
@@ -766,25 +743,24 @@ class ErrataTestCase(UITestCase):
     def test_positive_show_count_on_chost_details_page(self):
         """Errata count on Content host Details page
 
-        @id: 388229da-2b0b-41aa-a457-9b5ecbf3df4b
+        :id: 388229da-2b0b-41aa-a457-9b5ecbf3df4b
 
-        @Setup:
+        :Setup:
 
-        1. Errata synced on satellite server.
-        2. Some content hosts are present.
+            1. Errata synced on satellite server.
+            2. Some content hosts are present.
 
-        @Steps:
+        :Steps: Go to Hosts -> Content Hosts -> Select Content Host -> Details
+            page.
 
-        1. Go to Hosts -> Content Hosts -> Select Content Host -> Details page.
+        :Assert:
 
-        @Assert:
+            1. The errata section should be displayed with Security, Bugfix,
+                Enhancement types.
+            2. The number should link to the errata details page, filtered  by
+                type.
 
-        1. The errata section should be displayed with Security, Bugfix,
-        Enhancement types.
-        2. The number should link to the errata details page, filtered  by
-        type.
-
-        @CaseLevel: System
+        :CaseLevel: System
         """
         org = entities.Organization().create()
         env = entities.LifecycleEnvironment(
@@ -876,28 +852,25 @@ class ErrataTestCase(UITestCase):
         """Update composite content views and environments with new
         point releases
 
-        @id: d30bae6f-e45f-4ba9-9151-32dfa14ed2b8
+        :id: d30bae6f-e45f-4ba9-9151-32dfa14ed2b8
 
-        @Setup:
+        :Setup:
 
-        1. Errata synced on satellite server.
-        2. Composite content views present.
+            1. Errata synced on satellite server.
+            2. Composite content views present.
 
-        @Steps:
+        :Steps: As a user, I would expect updated point releases to update
+            composites with a new point release as well in the respective
+            environments (i.e. if ComponentA gets updated from 1.0 to 1.1, any
+            composite that is using 1.0 will have a new point release bumped
+            and published with the new 1.1 ComponentA and pushed to the
+            environment it was in.
 
-        1. As a user, I would expect updated point releases to update
-        composites with a new point release as well in the respective
-        environments (i.e. if ComponentA gets updated from 1.0 to 1.1, any
-        composite that is using 1.0 will have a new point release bumped and
-        published with the new 1.1 ComponentA and pushed to the environment
-        it was in.
+        :Assert: Composite content views updated with point releases.
 
-        @Assert: Composite content views updated with point releases.
+        :caseautomation: notautomated
 
-        @caseautomation: notautomated
-
-
-        @CaseLevel: System
+        :CaseLevel: System
         """
 
 
@@ -918,25 +891,26 @@ class FilteredErrataTestCase(UITestCase):
         correspondence to filtered errata and `errata status installable`
         settings flag value
 
-        @id: ed94cf34-b8b9-4411-8edc-5e210ea6af4f
+        :id: ed94cf34-b8b9-4411-8edc-5e210ea6af4f
 
-        @Steps:
+        :Steps:
 
-        1. Prepare setup: Create Lifecycle Environment, Content View,
-        Activation Key and all necessary repos
-        2. Register Content Host using created data
-        3. Create necessary Content View Filter and Rule for repository errata
-        4. Publish and Promote Content View to a new version and remove old
-        ones.
-        5. Go to created Host page and check its properties
-        6. Change 'errata status installable' flag in the settings and check
-        host properties once more
+            1. Prepare setup: Create Lifecycle Environment, Content View,
+                Activation Key and all necessary repos
+            2. Register Content Host using created data
+            3. Create necessary Content View Filter and Rule for repository
+                errata
+            4. Publish and Promote Content View to a new version and remove old
+                ones.
+            5. Go to created Host page and check its properties
+            6. Change 'errata status installable' flag in the settings and
+                check host properties once more
 
-        @Assert: Check that 'errata status installable' flag works as intended
+        :Assert: Check that 'errata status installable' flag works as intended
 
-        @BZ: 1368254
+        :BZ: 1368254
 
-        @CaseLevel: System
+        :CaseLevel: System
         """
         env = entities.LifecycleEnvironment(
             organization=self.session_org).create()

--- a/tests/foreman/ui/test_gpgkey.py
+++ b/tests/foreman/ui/test_gpgkey.py
@@ -1,19 +1,19 @@
 # -*- encoding: utf-8 -*-
 """Test class for GPG Key UI
 
-@Requirement: Gpgkey
+:Requirement: Gpgkey
 
-@CaseAutomation: Automated
+:CaseAutomation: Automated
 
-@CaseLevel: Acceptance
+:CaseLevel: Acceptance
 
-@CaseComponent: UI
+:CaseComponent: UI
 
-@TestType: Functional
+:TestType: Functional
 
-@CaseImportance: High
+:CaseImportance: High
 
-@Upstream: No
+:Upstream: No
 """
 
 import random
@@ -70,9 +70,9 @@ class GPGKey(UITestCase):
         """Create gpg key with valid name and valid gpg key via file
         import
 
-        @id: 3a6f3a58-da2d-4fd7-9ceb-c95f7c9dce7c
+        :id: 3a6f3a58-da2d-4fd7-9ceb-c95f7c9dce7c
 
-        @assert: gpg key is created
+        :assert: gpg key is created
         """
         with Session(self.browser) as session:
             for name in valid_data_list():
@@ -92,9 +92,9 @@ class GPGKey(UITestCase):
         """Create gpg key with valid name and valid gpg key text via
         cut and paste/string
 
-        @id: 8b5d112c-b52c-458d-bddd-56bd26afdeb1
+        :id: 8b5d112c-b52c-458d-bddd-56bd26afdeb1
 
-        @assert: gpg key is created
+        :assert: gpg key is created
         """
         with Session(self.browser) as session:
             for name in valid_data_list():
@@ -115,9 +115,9 @@ class GPGKey(UITestCase):
         """Create gpg key with valid name and valid gpg key via file import
         then try to create new one with same name and same content
 
-        @id: d5e28e8a-e0ef-4c74-a18b-e2646a2cdba5
+        :id: d5e28e8a-e0ef-4c74-a18b-e2646a2cdba5
 
-        @assert: gpg key is not created
+        :assert: gpg key is not created
         """
         name = gen_string('alphanumeric')
         kwargs = {
@@ -141,9 +141,9 @@ class GPGKey(UITestCase):
         paste/string import then try to create new one with same name and same
         content
 
-        @id: c6b256a5-6b9b-4927-a6c6-048ba36d2834
+        :id: c6b256a5-6b9b-4927-a6c6-048ba36d2834
 
-        @assert: gpg key is not created
+        :assert: gpg key is not created
         """
         name = gen_string('alphanumeric')
         kwargs = {
@@ -164,9 +164,9 @@ class GPGKey(UITestCase):
     def test_negative_create_without_content(self):
         """Create gpg key with valid name and no gpg key
 
-        @id: 20167716-48c5-4f28-afe2-07fa22aeb240
+        :id: 20167716-48c5-4f28-afe2-07fa22aeb240
 
-        @assert: gpg key is not created
+        :assert: gpg key is not created
         """
         name = gen_string('alphanumeric')
         with Session(self.browser) as session:
@@ -181,9 +181,9 @@ class GPGKey(UITestCase):
     def test_negative_create_via_import_and_invalid_name(self):
         """Create gpg key with invalid name and valid gpg key via file import
 
-        @id: bc5f96e6-e997-4995-ad04-614e66480b7f
+        :id: bc5f96e6-e997-4995-ad04-614e66480b7f
 
-        @assert: gpg key is not created
+        :assert: gpg key is not created
         """
         with Session(self.browser) as session:
             for name in invalid_names_list():
@@ -207,9 +207,9 @@ class GPGKey(UITestCase):
         """Create gpg key with invalid name and valid gpg key text via cut and
         paste/string
 
-        @id: 652857de-c522-4c68-a758-13d0b37cc62a
+        :id: 652857de-c522-4c68-a758-13d0b37cc62a
 
-        @assert: gpg key is not created
+        :assert: gpg key is not created
         """
         with Session(self.browser) as session:
             for name in invalid_names_list():
@@ -234,9 +234,9 @@ class GPGKey(UITestCase):
         """Create gpg key with valid name and valid gpg key via file import
         then delete it
 
-        @id: 495547c0-8e38-49cc-9be4-3f24a20d3af7
+        :id: 495547c0-8e38-49cc-9be4-3f24a20d3af7
 
-        @assert: gpg key is deleted
+        :assert: gpg key is deleted
         """
         with Session(self.browser) as session:
             for name in valid_data_list():
@@ -257,9 +257,9 @@ class GPGKey(UITestCase):
         """Create gpg key with valid name and valid gpg key text via cut and
         paste/string then delete it
 
-        @id: 77c97202-a877-4647-b7e2-3a9b68945fc4
+        :id: 77c97202-a877-4647-b7e2-3a9b68945fc4
 
-        @assert: gpg key is deleted
+        :assert: gpg key is deleted
         """
         with Session(self.browser) as session:
             for name in valid_data_list():
@@ -281,9 +281,9 @@ class GPGKey(UITestCase):
         """Create gpg key with valid name and valid gpg key via file
         import then update its name
 
-        @id: 85e211fb-bcb4-4895-af3e-febb189be5c0
+        :id: 85e211fb-bcb4-4895-af3e-febb189be5c0
 
-        @assert: gpg key is updated
+        :assert: gpg key is updated
         """
         name = gen_string('alpha')
         new_name = gen_string('alpha')
@@ -307,9 +307,9 @@ class GPGKey(UITestCase):
         """Create gpg key with valid name and valid gpg key via file
         import then update its gpg key file
 
-        @id: 9f74b337-3ea5-48a1-af6e-d72ab41c2348
+        :id: 9f74b337-3ea5-48a1-af6e-d72ab41c2348
 
-        @assert: gpg key is updated
+        :assert: gpg key is updated
         """
         name = gen_string('alpha')
         new_key_path = get_data_file(VALID_GPG_KEY_BETA_FILE)
@@ -332,9 +332,9 @@ class GPGKey(UITestCase):
         """Create gpg key with valid name and valid gpg key text via
         cut and paste/string then update its name
 
-        @id: 4336b539-15fd-4a40-bb98-0b0248f8abd8
+        :id: 4336b539-15fd-4a40-bb98-0b0248f8abd8
 
-        @assert: gpg key is updated
+        :assert: gpg key is updated
         """
         name = gen_string('alpha')
         new_name = gen_string('alpha')
@@ -357,9 +357,9 @@ class GPGKey(UITestCase):
         """Create gpg key with valid name and valid gpg key text via
         cut and paste/string then update its gpg key text
 
-        @id: 07902ef6-a918-433a-9dad-d5376c3dd001
+        :id: 07902ef6-a918-433a-9dad-d5376c3dd001
 
-        @assert: gpg key is updated
+        :assert: gpg key is updated
         """
         name = gen_string('alpha')
         new_key_path = get_data_file(VALID_GPG_KEY_BETA_FILE)
@@ -383,9 +383,9 @@ class GPGKey(UITestCase):
         """Create gpg key with valid name and valid gpg key via file
         import then fail to update its name
 
-        @id: 969aad7c-ba4c-4d1d-84a5-c9e1b9130867
+        :id: 969aad7c-ba4c-4d1d-84a5-c9e1b9130867
 
-        @assert: gpg key is not updated
+        :assert: gpg key is not updated
         """
         name = gen_string('alpha')
         with Session(self.browser) as session:
@@ -412,11 +412,11 @@ class GPGKey(UITestCase):
         """Hosts can install packages using gpg key associated with single
         custom repository
 
-        @id: c6b78312-91d3-47a2-a6c6-f906a4522fe4
+        :id: c6b78312-91d3-47a2-a6c6-f906a4522fe4
 
-        @assert: host can install package from custom repository
+        :assert: host can install package from custom repository
 
-        @CaseLevel: System
+        :CaseLevel: System
         """
         key_name = gen_string('alphanumeric')
         # step1: Create gpg-key
@@ -528,14 +528,13 @@ class GPGKey(UITestCase):
         """Hosts can install packages using gpg key associated with
         multiple custom repositories
 
-        @id: bef406dd-1266-4c87-8eac-9bbdb6f81085
+        :id: bef406dd-1266-4c87-8eac-9bbdb6f81085
 
-        @assert: host can install package from custom repositories
+        :assert: host can install package from custom repositories
 
-        @caseautomation: notautomated
+        :caseautomation: notautomated
 
-
-        @CaseLevel: System
+        :CaseLevel: System
         """
 
     @stubbed()
@@ -545,14 +544,13 @@ class GPGKey(UITestCase):
         """Hosts can install packages using different gpg keys
         associated with multiple custom repositories
 
-        @id: ad48a055-72d3-4f4b-a0dc-faee1e29e28e
+        :id: ad48a055-72d3-4f4b-a0dc-faee1e29e28e
 
-        @assert: host can install package from custom repositories
+        :assert: host can install package from custom repositories
 
-        @caseautomation: notautomated
+        :caseautomation: notautomated
 
-
-        @CaseLevel: System
+        :CaseLevel: System
         """
 
     @stubbed()
@@ -561,12 +559,11 @@ class GPGKey(UITestCase):
     def test_positive_info(self):
         """Create single gpg key and get its info
 
-        @id: c8b75db1-9394-4a99-9d91-0d388aacfd1a
+        :id: c8b75db1-9394-4a99-9d91-0d388aacfd1a
 
-        @assert: specific information for gpg key matches the creation values
+        :assert: specific information for gpg key matches the creation values
 
-        @caseautomation: notautomated
-
+        :caseautomation: notautomated
         """
 
 
@@ -586,11 +583,11 @@ class GPGKeyProductAssociateTestCase(UITestCase):
         """Create gpg key with valid name and valid gpg key then associate
         it with empty (no repos) custom product
 
-        @id: e18ae9f5-43d9-4049-92ca-1eafaca05096
+        :id: e18ae9f5-43d9-4049-92ca-1eafaca05096
 
-        @assert: gpg key is associated with product
+        :assert: gpg key is associated with product
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         name = get_random_gpgkey_name()
         gpg_key = entities.GPGKey(
@@ -617,12 +614,12 @@ class GPGKeyProductAssociateTestCase(UITestCase):
         """Create gpg key with valid name and valid gpg key then associate it
         with custom product that has one repository
 
-        @id: 7514b33a-da75-43bd-a84b-5a805c84511d
+        :id: 7514b33a-da75-43bd-a84b-5a805c84511d
 
-        @assert: gpg key is associated with product as well as with the
-        repository
+        :assert: gpg key is associated with product as well as with the
+            repository
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         name = get_random_gpgkey_name()
         gpg_key = entities.GPGKey(
@@ -662,14 +659,14 @@ class GPGKeyProductAssociateTestCase(UITestCase):
         then associate it with custom product that has one repository
         After search and select product through gpg key interface
 
-        @id: 0bef0c1b-4811-489e-89e9-609d57fc45ee
+        :id: 0bef0c1b-4811-489e-89e9-609d57fc45ee
 
-        @assert: Associated product can be found and selected through gpg key
-        'Product' tab
+        :assert: Associated product can be found and selected through gpg key
+            'Product' tab
 
-        @BZ: 1411800
+        :BZ: 1411800
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         name = get_random_gpgkey_name()
         gpg_key = entities.GPGKey(
@@ -704,11 +701,11 @@ class GPGKeyProductAssociateTestCase(UITestCase):
         """Create gpg key with valid name and valid gpg key then associate it
         with custom product that has more than one repository
 
-        @id: 0edffad7-0ab4-4bef-b16b-f6c8de55b0dc
+        :id: 0edffad7-0ab4-4bef-b16b-f6c8de55b0dc
 
-        @assert: gpg key is properly associated with repositories
+        :assert: gpg key is properly associated with repositories
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         name = get_random_gpgkey_name()
         gpg_key = entities.GPGKey(
@@ -753,14 +750,14 @@ class GPGKeyProductAssociateTestCase(UITestCase):
         """Create gpg key with valid name and valid gpg key
         then associate it with custom product using Repo discovery method
 
-        @id: 7490a5a6-8575-45eb-addc-298ed3b62649
+        :id: 7490a5a6-8575-45eb-addc-298ed3b62649
 
-        @assert: gpg key is associated with product as well as with
-        the repositories
+        :assert: gpg key is associated with product as well as with the
+            repositories
 
-        @BZ: 1210180
+        :BZ: 1210180
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         name = get_random_gpgkey_name()
         product_name = gen_string('alpha')
@@ -795,12 +792,12 @@ class GPGKeyProductAssociateTestCase(UITestCase):
         """Create gpg key with valid name and valid gpg key then associate it
         to repository from custom product that has one repository
 
-        @id: 5d78890f-4130-4dc3-9cfe-48999149422f
+        :id: 5d78890f-4130-4dc3-9cfe-48999149422f
 
-        @assert: gpg key is associated with the repository but not with
-        the product
+        :assert: gpg key is associated with the repository but not with the
+            product
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         name = get_random_gpgkey_name()
         gpg_key = entities.GPGKey(
@@ -838,12 +835,12 @@ class GPGKeyProductAssociateTestCase(UITestCase):
         """Create gpg key with valid name and valid gpg key then associate it
         to repository from custom product that has more than one repository
 
-        @id: 1fb38e01-4c04-4609-842d-069f96157317
+        :id: 1fb38e01-4c04-4609-842d-069f96157317
 
-        @assert: gpg key is associated with one of the repositories but
-        not with the product
+        :assert: gpg key is associated with one of the repositories but not
+            with the product
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         name = get_random_gpgkey_name()
         gpg_key = entities.GPGKey(
@@ -895,13 +892,13 @@ class GPGKeyProductAssociateTestCase(UITestCase):
         """Create gpg key with valid name and valid gpg key then
         associate it to repos from custom product using Repo discovery method
 
-        @id: d841f0f2-8623-443f-8deb-212cee9a247e
+        :id: d841f0f2-8623-443f-8deb-212cee9a247e
 
-        @assert: gpg key is associated with product and all the repositories
+        :assert: gpg key is associated with product and all the repositories
 
-        @caseautomation: notautomated
+        :caseautomation: notautomated
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
 
     @run_only_on('sat')
@@ -910,11 +907,11 @@ class GPGKeyProductAssociateTestCase(UITestCase):
         """Create gpg key with valid name and valid gpg key then associate it
         with empty (no repos) custom product then update the key
 
-        @id: 519817c3-9b67-4859-8069-95987ebf9453
+        :id: 519817c3-9b67-4859-8069-95987ebf9453
 
-        @assert: gpg key is associated with product before/after update
+        :assert: gpg key is associated with product before/after update
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         name = get_random_gpgkey_name()
         new_name = gen_string('alpha')
@@ -948,12 +945,12 @@ class GPGKeyProductAssociateTestCase(UITestCase):
         """Create gpg key with valid name and valid gpg key then associate it
         with custom product that has one repository then update the key
 
-        @id: 02cb0601-6aa2-4589-b61e-3d3785a7e100
+        :id: 02cb0601-6aa2-4589-b61e-3d3785a7e100
 
-        @assert: gpg key is associated with product as well as with repository
-        before/after update
+        :assert: gpg key is associated with product as well as with repository
+            before/after update
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         name = get_random_gpgkey_name()
         gpg_key = entities.GPGKey(
@@ -1004,12 +1001,12 @@ class GPGKeyProductAssociateTestCase(UITestCase):
         with custom product that has more than one repository then update the
         key
 
-        @id: 3ca4d9ff-8032-4c2a-aed9-00ac2d1352d1
+        :id: 3ca4d9ff-8032-4c2a-aed9-00ac2d1352d1
 
-        @assert: gpg key is associated with product as well as with
-        repositories before/after update
+        :assert: gpg key is associated with product as well as with
+            repositories before/after update
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         name = get_random_gpgkey_name()
         gpg_key = entities.GPGKey(
@@ -1068,14 +1065,14 @@ class GPGKeyProductAssociateTestCase(UITestCase):
         then associate it with custom product using Repo discovery
         method then update the key
 
-        @id: 49279be8-cbea-477e-a1ff-c07171e7084e
+        :id: 49279be8-cbea-477e-a1ff-c07171e7084e
 
-        @assert: gpg key is associated with product as well as with
-        repository before/after update
+        :assert: gpg key is associated with product as well as with repository
+            before/after update
 
-        @BZ: 1210180
+        :BZ: 1210180
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         name = get_random_gpgkey_name()
         new_name = gen_string('alpha')
@@ -1121,12 +1118,12 @@ class GPGKeyProductAssociateTestCase(UITestCase):
         to repository from custom product that has one repository then update
         the key
 
-        @id: 9827306e-76d7-4aef-8074-e97fc39d3bbb
+        :id: 9827306e-76d7-4aef-8074-e97fc39d3bbb
 
-        @assert: gpg key is associated with repository before/after update but
-        not with product.
+        :assert: gpg key is associated with repository before/after update but
+            not with product.
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         name = get_random_gpgkey_name()
         gpg_key = entities.GPGKey(
@@ -1180,12 +1177,12 @@ class GPGKeyProductAssociateTestCase(UITestCase):
         to repository from custom product that has more than one repository
         then update the key
 
-        @id: d4f2fa16-860c-4ad5-b04f-8ce24b5618e9
+        :id: d4f2fa16-860c-4ad5-b04f-8ce24b5618e9
 
-        @assert: gpg key is associated with single repository before/after
-        update but not with product
+        :assert: gpg key is associated with single repository before/after
+            update but not with product
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         name = get_random_gpgkey_name()
         gpg_key = entities.GPGKey(
@@ -1259,15 +1256,14 @@ class GPGKeyProductAssociateTestCase(UITestCase):
         then associate it to repos from custom product
         using Repo discovery method then update the key
 
-        @id: d0777db3-109a-4c63-9387-7cff235c5f46
+        :id: d0777db3-109a-4c63-9387-7cff235c5f46
 
-        @assert: gpg key is associated with product and all repositories
-        before/after update
+        :assert: gpg key is associated with product and all repositories
+            before/after update
 
-        @caseautomation: notautomated
+        :caseautomation: notautomated
 
-
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
 
     @run_only_on('sat')
@@ -1276,12 +1272,12 @@ class GPGKeyProductAssociateTestCase(UITestCase):
         """Create gpg key with valid name and valid gpg key then
         associate it with empty (no repos) custom product then delete it
 
-        @id: b9766403-61b2-4a88-a744-a25d53d577fb
+        :id: b9766403-61b2-4a88-a744-a25d53d577fb
 
-        @assert: gpg key is associated with product during creation but
-        removed from product after deletion
+        :assert: gpg key is associated with product during creation but removed
+            from product after deletion
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         name = get_random_gpgkey_name()
         gpg_key = entities.GPGKey(
@@ -1313,12 +1309,12 @@ class GPGKeyProductAssociateTestCase(UITestCase):
         """Create gpg key with valid name and valid gpg key then
         associate it with custom product that has one repository then delete it
 
-        @id: 75057dd2-9083-47a8-bea7-4f073bdb667e
+        :id: 75057dd2-9083-47a8-bea7-4f073bdb667e
 
-        @assert: gpg key is associated with product as well as with the
-        repository during creation but removed from product after deletion
+        :assert: gpg key is associated with product as well as with the
+            repository during creation but removed from product after deletion
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         name = get_random_gpgkey_name()
         gpg_key = entities.GPGKey(
@@ -1365,12 +1361,13 @@ class GPGKeyProductAssociateTestCase(UITestCase):
         associate it with custom product that has more than one repository then
         delete it
 
-        @id: cb5d4efd-863a-4b8e-b1f8-a0771e90ff5e
+        :id: cb5d4efd-863a-4b8e-b1f8-a0771e90ff5e
 
-        @assert: gpg key is associated with product as well as with
-        repositories during creation but removed from product after deletion
+        :assert: gpg key is associated with product as well as with
+            repositories during creation but removed from product after
+            deletion
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         name = get_random_gpgkey_name()
         gpg_key = entities.GPGKey(
@@ -1410,15 +1407,15 @@ class GPGKeyProductAssociateTestCase(UITestCase):
         """Create gpg key with valid name and valid gpg then associate
         it with custom product using Repo discovery method then delete it
 
-        @id: 513ae138-84d9-4c43-8d4e-7b9fb797208d
+        :id: 513ae138-84d9-4c43-8d4e-7b9fb797208d
 
-        @assert: gpg key is associated with product as well as with
-        the repositories during creation but removed from product
-        after deletion
+        :assert: gpg key is associated with product as well as with the
+            repositories during creation but removed from product after
+            deletion
 
-        @BZ: 1210180
+        :BZ: 1210180
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         name = get_random_gpgkey_name()
         product_name = gen_string('alpha')
@@ -1450,12 +1447,12 @@ class GPGKeyProductAssociateTestCase(UITestCase):
         associate it to repository from custom product that has one repository
         then delete the key
 
-        @id: 92ba492e-79af-48fe-84cb-763102b42fa7
+        :id: 92ba492e-79af-48fe-84cb-763102b42fa7
 
-        @assert: gpg key is associated with single repository
-        during creation but removed from repository after deletion
+        :assert: gpg key is associated with single repository during creation
+            but removed from repository after deletion
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         name = get_random_gpgkey_name()
         gpg_key = entities.GPGKey(
@@ -1490,12 +1487,12 @@ class GPGKeyProductAssociateTestCase(UITestCase):
         associate it to repository from custom product that has more than
         one repository then delete the key
 
-        @id: 5f204a44-bf7b-4a9c-9974-b701e0d38860
+        :id: 5f204a44-bf7b-4a9c-9974-b701e0d38860
 
-        @assert: gpg key is associated with single repository but not with
-        product during creation but removed from repository after deletion
+        :assert: gpg key is associated with single repository but not with
+            product during creation but removed from repository after deletion
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         name = get_random_gpgkey_name()
         # Creates New GPGKey
@@ -1541,14 +1538,13 @@ class GPGKeyProductAssociateTestCase(UITestCase):
         associate it to repos from custom product using Repo discovery method
         then delete the key
 
-        @id: b1ece282-0cba-4816-9e6a-312c63894168
+        :id: b1ece282-0cba-4816-9e6a-312c63894168
 
-        @assert: gpg key is associated with product and all repositories
-        during creation but removed from product and all repositories
-        after deletion
+        :assert: gpg key is associated with product and all repositories during
+            creation but removed from product and all repositories after
+            deletion
 
-        @caseautomation: notautomated
+        :caseautomation: notautomated
 
-
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """

--- a/tests/foreman/ui/test_host.py
+++ b/tests/foreman/ui/test_host.py
@@ -1,19 +1,19 @@
 # -*- encoding: utf-8 -*-
 """Test class for Hosts UI
 
-@Requirement: Host
+:Requirement: Host
 
-@CaseAutomation: Automated
+:CaseAutomation: Automated
 
-@CaseLevel: Acceptance
+:CaseLevel: Acceptance
 
-@CaseComponent: UI
+:CaseComponent: UI
 
-@TestType: Functional
+:TestType: Functional
 
-@CaseImportance: High
+:CaseImportance: High
 
-@Upstream: No
+:Upstream: No
 """
 from fauxfactory import gen_string
 from nailgun import entities, entity_mixins
@@ -337,11 +337,11 @@ class HostTestCase(UITestCase):
     def test_positive_create_libvirt(self):
         """Create a new Host on libvirt compute resource
 
-        @id: 2678f95f-0c0e-4b46-a3c1-3f9a954d3bde
+        :id: 2678f95f-0c0e-4b46-a3c1-3f9a954d3bde
 
-        @Assert: Host is created
+        :Assert: Host is created
 
-        @CaseLevel: System
+        :CaseLevel: System
         """
         resource = u'{0} (Libvirt)'.format(self.computeresource.name)
         root_pwd = gen_string('alpha', 15)
@@ -381,22 +381,19 @@ class HostTestCase(UITestCase):
     def test_positive_create_baremetal_with_bios(self):
         """Create a new Host from provided MAC address
 
-        @id: 2cedc634-7761-4326-b77a-b999098f5c00
+        :id: 2cedc634-7761-4326-b77a-b999098f5c00
 
-        @setup:
+        :setup: Create a PXE-based VM with BIOS boot mode (outside of
+            Satellite).
 
-        1. Create a PXE-based VM with BIOS boot mode (outside of Satellite).
+        :steps: Create a new host using 'BareMetal' option and MAC address of
+            the pre-created VM
 
-        @steps:
+        :assert: Host is created
 
-        1. Create a new host using 'BareMetal' option and MAC address of the
-        pre-created VM
+        :caseautomation: notautomated
 
-        @assert: Host is created
-
-        @caseautomation: notautomated
-
-        @caselevel: System
+        :caselevel: System
         """
 
     @run_only_on('sat')
@@ -405,23 +402,19 @@ class HostTestCase(UITestCase):
     def test_positive_create_baremetal_with_uefi(self):
         """Create a new Host from provided MAC address
 
-        @id: ec62e90b-1b2a-4eac-8b15-7e36c8179086
+        :id: ec62e90b-1b2a-4eac-8b15-7e36c8179086
 
-        @setup:
+        :setup: Create a PXE-based VM with UEFI boot mode (outside of
+            Satellite).
 
-        1. Create a PXE-based VM with UEFI boot mode (outside of Satellite).
+        :steps: Create a new host using 'BareMetal' option and MAC address of
+            the pre-created VM
 
-        @steps:
+        :assert: Host is created
 
-        1. Create a new host using 'BareMetal' option and MAC address of the
-        pre-created VM
+        :caseautomation: notautomated
 
-        @assert: Host is created
-
-        @caseautomation: notautomated
-
-        @caselevel: System
-
+        :caselevel: System
         """
 
     @run_only_on('sat')
@@ -431,27 +424,26 @@ class HostTestCase(UITestCase):
         """Provision a new Host and verify the tftp and dhcpd file
         structure is correct
 
-        @id: e3dd2334-6e82-4272-a099-6f4214b77151
+        :id: e3dd2334-6e82-4272-a099-6f4214b77151
 
-        @steps:
+        :steps:
 
-        1. Associate a pxegrub-type provisioning template with the os
-        2. Create new host (can be fictive bare metal) with the above OS and
-        PXE loader set to Grub UEFI
-        3. Build the host
+            1. Associate a pxegrub-type provisioning template with the os
+            2. Create new host (can be fictive bare metal) with the above OS
+                and PXE loader set to Grub UEFI
+            3. Build the host
 
-        @assert:
-        Verify [/var/lib/tftpboot/] contains the following dir/file structure:
-            grub/bootia32.efi
-            grub/bootx64.efi
-            grub/01-AA-BB-CC-DD-EE-FF
-            grub/efidefault
-            grub/shim.efi
-        and record in /var/lib/dhcpd/dhcpd.leases points to the bootloader
+        :assert: Verify [/var/lib/tftpboot/] contains the following dir/file
+            structure: grub/bootia32.efi
+                grub/bootx64.efi
+                grub/01-AA-BB-CC-DD-EE-FF
+                grub/efidefault
+                grub/shim.efi
+            and record in /var/lib/dhcpd/dhcpd.leases points to the bootloader
 
-        @caseautomation: notautomated
+        :caseautomation: notautomated
 
-        @caselevel: System
+        :caselevel: System
         """
 
     @run_only_on('sat')
@@ -461,27 +453,26 @@ class HostTestCase(UITestCase):
         """Provision a new Host and verify the tftp and dhcpd file
         structure is correct
 
-        @id: fc97dfcc-15d0-4eab-a778-fa1bcf82be22
+        :id: fc97dfcc-15d0-4eab-a778-fa1bcf82be22
 
-        @steps:
+        :steps:
 
-        1. Associate a pxegrub-type provisioning template with the os
-        2. Create new host (can be fictive bare metal) with the above OS and
-        PXE loader set to Grub UEFI SecureBoot
-        3. Build the host
+            1. Associate a pxegrub-type provisioning template with the os
+            2. Create new host (can be fictive bare metal) with the above OS
+                and PXE loader set to Grub UEFI SecureBoot
+            3. Build the host
 
-        @assert:
-        Verify [/var/lib/tftpboot/] contains the following dir/file structure:
-            grub/bootia32.efi
-            grub/bootx64.efi
-            grub/01-AA-BB-CC-DD-EE-FF
-            grub/efidefault
-            grub/shim.efi
-        and record in /var/lib/dhcpd/dhcpd.leases points to the bootloader
+        :assert: Verify [/var/lib/tftpboot/] contains the following dir/file
+            structure: grub/bootia32.efi
+                grub/bootx64.efi
+                grub/01-AA-BB-CC-DD-EE-FF
+                grub/efidefault
+                grub/shim.efi
+            and record in /var/lib/dhcpd/dhcpd.leases points to the bootloader
 
-        @caseautomation: notautomated
+        :caseautomation: notautomated
 
-        @caselevel: System
+        :caselevel: System
         """
 
     @run_only_on('sat')
@@ -491,28 +482,27 @@ class HostTestCase(UITestCase):
         """Provision a new UEFI Host and verify the and dhcpd file
         structure is correct
 
-        @id: eec31881-eb20-4fb3-8d19-e3a4012ba4a0
+        :id: eec31881-eb20-4fb3-8d19-e3a4012ba4a0
 
-        @steps:
+        :steps:
 
-        1. Associate a pxegrub-type provisioning template with the os
-        2. Create new host (can be fictive bare metal) with the above OS and
-        PXE loader set to Grub2 UEFI
-        3. Build the host
+            1. Associate a pxegrub-type provisioning template with the os
+            2. Create new host (can be fictive bare metal) with the above OS
+                and PXE loader set to Grub2 UEFI
+            3. Build the host
 
-        @assert:
-        Verify [/var/lib/tftpboot/] contains the following dir/file structure:
-            pxegrub2
-            grub2/grub.cfg-01-aa-bb-cc-dd-ee-ff
-            grub2/grub.cfg
-            grub2/grubx32.efi
-            grub2/grubx64.efi
-            grub/shim.efi
-        and record in /var/lib/dhcpd/dhcpd.leases points to the bootloader
+        :assert: Verify [/var/lib/tftpboot/] contains the following dir/file
+            structure: pxegrub2
+                grub2/grub.cfg-01-aa-bb-cc-dd-ee-ff
+                grub2/grub.cfg
+                grub2/grubx32.efi
+                grub2/grubx64.efi
+                grub/shim.efi
+            and record in /var/lib/dhcpd/dhcpd.leases points to the bootloader
 
-        @caseautomation: notautomated
+        :caseautomation: notautomated
 
-        @caselevel: System
+        :caselevel: System
         """
 
     @run_only_on('sat')
@@ -522,28 +512,27 @@ class HostTestCase(UITestCase):
         """Provision a new UEFI Host and verify the tftp and dhcpd file
         structure is correct
 
-        @id: fdbb3617-74f2-46c4-930f-028dd4edcf9e
+        :id: fdbb3617-74f2-46c4-930f-028dd4edcf9e
 
-        @steps:
+        :steps:
 
-        1. Associate a pxegrub-type provisioning template with the os
-        2. Create new host (can be fictive bare metal) with the above OS and
-        PXE loader set to Grub2 UEFI SecureBoot
-        3. Build the host
+            1. Associate a pxegrub-type provisioning template with the os
+            2. Create new host (can be fictive bare metal) with the above OS
+                and PXE loader set to Grub2 UEFI SecureBoot
+            3. Build the host
 
-        @assert:
-        Verify [/var/lib/tftpboot/] contains the following dir/file structure:
-            pxegrub2
-            grub2/grub.cfg-01-aa-bb-cc-dd-ee-ff
-            grub2/grub.cfg
-            grub2/grubx32.efi
-            grub2/grubx64.efi
-            grub/shim.efi
-        and record in /var/lib/dhcpd/dhcpd.leases points to the bootloader
+        :assert: Verify [/var/lib/tftpboot/] contains the following dir/file
+            structure: pxegrub2
+                grub2/grub.cfg-01-aa-bb-cc-dd-ee-ff
+                grub2/grub.cfg
+                grub2/grubx32.efi
+                grub2/grubx64.efi
+                grub/shim.efi
+            and record in /var/lib/dhcpd/dhcpd.leases points to the bootloader
 
-        @caseautomation: notautomated
+        :caseautomation: notautomated
 
-        @caselevel: System
+        :caselevel: System
         """
 
     @run_only_on('sat')
@@ -551,11 +540,11 @@ class HostTestCase(UITestCase):
     def test_positive_create(self):
         """Create a new Host
 
-        @id: 4821444d-3c86-4f93-849b-60460e025ba0
+        :id: 4821444d-3c86-4f93-849b-60460e025ba0
 
-        @Assert: Host is created
+        :Assert: Host is created
 
-        @CaseLevel: System
+        :CaseLevel: System
         """
         host = entities.Host()
         host.create_missing()
@@ -600,11 +589,11 @@ class HostTestCase(UITestCase):
     def test_positive_update_name(self):
         """Create a new Host and update its name to valid one
 
-        @id: f1c19599-f613-431d-bf09-62addec1e60b
+        :id: f1c19599-f613-431d-bf09-62addec1e60b
 
-        @Assert: Host is updated successfully
+        :Assert: Host is updated successfully
 
-        @CaseLevel: System
+        :CaseLevel: System
         """
         host = entities.Host()
         host.create_missing()
@@ -655,11 +644,11 @@ class HostTestCase(UITestCase):
     def test_positive_delete(self):
         """Delete a Host
 
-        @id: 13735af1-f1c7-466e-a969-80618a1d854d
+        :id: 13735af1-f1c7-466e-a969-80618a1d854d
 
-        @Assert: Host is delete
+        :Assert: Host is delete
 
-        @CaseLevel: System
+        :CaseLevel: System
         """
         host = entities.Host()
         host.create_missing()
@@ -703,14 +692,14 @@ class HostTestCase(UITestCase):
         inherited hostgroup's lifecycle environment, content view and both
         fields are properly reflected via WebUI
 
-        @id: c83f6819-2649-4a8b-bb1d-ce93b2243765
+        :id: c83f6819-2649-4a8b-bb1d-ce93b2243765
 
-        @Assert: Host's lifecycle environment and content view match the ones
-        specified in hostgroup
+        :Assert: Host's lifecycle environment and content view match the ones
+            specified in hostgroup
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
 
-        @BZ: 1391656
+        :BZ: 1391656
         """
         host = entities.Host()
         host.create_missing()
@@ -767,13 +756,13 @@ class HostTestCase(UITestCase):
     def test_positive_create_with_user(self):
         """Create Host with new user specified
 
-        @id: b97d6fe5-b0a1-4ddc-8d7f-cbf7b17c823d
+        :id: b97d6fe5-b0a1-4ddc-8d7f-cbf7b17c823d
 
-        @Assert: Host is created
+        :Assert: Host is created
 
-        @caseautomation: notautomated
+        :caseautomation: notautomated
 
-        @CaseLevel: System
+        :CaseLevel: System
         """
 
     @stubbed()
@@ -781,13 +770,13 @@ class HostTestCase(UITestCase):
     def test_positive_update_with_user(self):
         """Update Host with new user specified
 
-        @id: 4c030cf5-b89c-4dec-bb3e-0cb3215a2315
+        :id: 4c030cf5-b89c-4dec-bb3e-0cb3215a2315
 
-        @Assert: Host is updated
+        :Assert: Host is updated
 
-        @caseautomation: notautomated
+        :caseautomation: notautomated
 
-        @CaseLevel: System
+        :CaseLevel: System
         """
 
 
@@ -1069,12 +1058,12 @@ class AtomicHostTestCase(UITestCase):
     def test_positive_provision_atomic_host(self):
         """Provision an atomic host on libvirt and register it with satellite
 
-        @id: 5ddf2f7f-f7aa-4321-8717-372c7b6e99b6
+        :id: 5ddf2f7f-f7aa-4321-8717-372c7b6e99b6
 
-        @Assert: Atomic host should be provisioned and listed under
-        content-hosts/Hosts
+        :Assert: Atomic host should be provisioned and listed under
+            content-hosts/Hosts
 
-        @CaseLevel: System
+        :CaseLevel: System
         """
         resource = u'{0} (Libvirt)'.format(self.computeresource.name)
         root_pwd = gen_string('alpha', 15)
@@ -1109,14 +1098,14 @@ class AtomicHostTestCase(UITestCase):
         """Register a pre-installed atomic host with satellite using admin
         credentials
 
-        @id: 09729944-b60b-4742-8f1b-e8859e2e36d3
+        :id: 09729944-b60b-4742-8f1b-e8859e2e36d3
 
-        @Assert: Atomic host should be registered successfully and listed under
-        content-hosts/Hosts
+        :Assert: Atomic host should be registered successfully and listed under
+            content-hosts/Hosts
 
-        @caseautomation: notautomated
+        :caseautomation: notautomated
 
-        @CaseLevel: System
+        :CaseLevel: System
         """
 
     @stubbed()
@@ -1125,26 +1114,26 @@ class AtomicHostTestCase(UITestCase):
         """Register a pre-installed atomic host with satellite using activation
         key
 
-        @id: 31e5ffcf-2e3c-474a-a6a3-6d8e2f392abe
+        :id: 31e5ffcf-2e3c-474a-a6a3-6d8e2f392abe
 
-        @Assert: Atomic host should be registered successfully and listed under
-        content-hosts/Hosts
+        :Assert: Atomic host should be registered successfully and listed under
+            content-hosts/Hosts
 
-        @caseautomation: notautomated
+        :caseautomation: notautomated
 
-        @CaseLevel: System
+        :CaseLevel: System
         """
 
     @tier3
     def test_positive_delete_atomic_host(self):
         """Delete a provisioned atomic host
 
-        @id: c0bcf753-8ddf-4e95-b214-42d1e077a6cf
+        :id: c0bcf753-8ddf-4e95-b214-42d1e077a6cf
 
-        @Assert: Atomic host should be deleted successfully and shouldn't be
-        listed under hosts/content-hosts
+        :Assert: Atomic host should be deleted successfully and shouldn't be
+            listed under hosts/content-hosts
 
-        @CaseLevel: System
+        :CaseLevel: System
         """
         resource = u'{0} (Libvirt)'.format(self.computeresource.name)
         root_pwd = gen_string('alpha', 15)
@@ -1177,13 +1166,13 @@ class AtomicHostTestCase(UITestCase):
     def test_positive_bulk_delete_atomic_host(self):
         """Delete a multiple atomic hosts
 
-        @id: 7740e7c2-db54-4f6a-b5d4-6005fccb4c61
+        :id: 7740e7c2-db54-4f6a-b5d4-6005fccb4c61
 
-        @Assert: All selected atomic hosts should be deleted successfully
+        :Assert: All selected atomic hosts should be deleted successfully
 
-        @caseautomation: notautomated
+        :caseautomation: notautomated
 
-        @CaseLevel: System
+        :CaseLevel: System
         """
 
     @stubbed()
@@ -1191,13 +1180,13 @@ class AtomicHostTestCase(UITestCase):
     def test_positive_update_atomic_host_cv(self):
         """Update atomic-host with a new environment and content-view
 
-        @id: 2ddd3bb7-ef58-42c0-908c-ae4d4bd0bff9
+        :id: 2ddd3bb7-ef58-42c0-908c-ae4d4bd0bff9
 
-        @Assert: Atomic host should be updated with new content-view
+        :Assert: Atomic host should be updated with new content-view
 
-        @caseautomation: notautomated
+        :caseautomation: notautomated
 
-        @CaseLevel: System
+        :CaseLevel: System
         """
 
     @stubbed()
@@ -1206,12 +1195,12 @@ class AtomicHostTestCase(UITestCase):
         """Execute ostree/atomic commands on provisioned atomic host with job
         templates
 
-        @id: 56a46a1e-9e24-4ad7-9cea-3d78c7310b14
+        :id: 56a46a1e-9e24-4ad7-9cea-3d78c7310b14
 
-        @Assert: Ostree/atomic commands should be executed successfully via job
-        templates
+        :Assert: Ostree/atomic commands should be executed successfully via job
+            templates
 
-        @caseautomation: notautomated
+        :caseautomation: notautomated
 
-        @CaseLevel: System
+        :CaseLevel: System
         """

--- a/tests/foreman/ui/test_hostcollection.py
+++ b/tests/foreman/ui/test_hostcollection.py
@@ -1,19 +1,19 @@
 # -*- encoding: utf-8 -*-
 """Test class for Host Collection UI
 
-@Requirement: Hostcollection
+:Requirement: Hostcollection
 
-@CaseAutomation: Automated
+:CaseAutomation: Automated
 
-@CaseLevel: Acceptance
+:CaseLevel: Acceptance
 
-@CaseComponent: UI
+:CaseComponent: UI
 
-@TestType: Functional
+:TestType: Functional
 
-@CaseImportance: High
+:CaseImportance: High
 
-@Upstream: No
+:Upstream: No
 """
 
 from fauxfactory import gen_string
@@ -73,9 +73,9 @@ class HostCollectionTestCase(UITestCase):
     def test_positive_create_with_name(self):
         """Create Host Collection for all name variations
 
-        @id: 267bd784-1ef7-4270-a264-6f8659e239fd
+        :id: 267bd784-1ef7-4270-a264-6f8659e239fd
 
-        @Assert: Host Collection is created
+        :Assert: Host Collection is created
         """
         with Session(self.browser) as session:
             for name in valid_data_list():
@@ -88,9 +88,9 @@ class HostCollectionTestCase(UITestCase):
     def test_positive_create_with_description(self):
         """Create Host Collection with valid description
 
-        @id: 830ff39e-0d4c-4368-bc47-12b060a09410
+        :id: 830ff39e-0d4c-4368-bc47-12b060a09410
 
-        @Assert: Host Collection is created
+        :Assert: Host Collection is created
         """
         name = gen_string('alpha')
         with Session(self.browser) as session:
@@ -106,9 +106,9 @@ class HostCollectionTestCase(UITestCase):
     def test_positive_create_with_limit(self):
         """Create Host Collection with finite content hosts limit
 
-        @id: 9983b61d-f820-4b60-ae5e-a45925f2dcf0
+        :id: 9983b61d-f820-4b60-ae5e-a45925f2dcf0
 
-        @Assert: Host Collection is created
+        :Assert: Host Collection is created
         """
         name = gen_string('alpha')
         with Session(self.browser) as session:
@@ -120,10 +120,10 @@ class HostCollectionTestCase(UITestCase):
     def test_negative_create_with_name(self):
         """Create Host Collections with invalid name
 
-        @id: 04e36c46-7577-4308-b9bb-4ec74549d9d3
+        :id: 04e36c46-7577-4308-b9bb-4ec74549d9d3
 
-        @Assert: Host Collection is not created and appropriate error message
-        thrown
+        :Assert: Host Collection is not created and appropriate error message
+            thrown
         """
         with Session(self.browser) as session:
             for name in invalid_values_list('ui'):
@@ -141,9 +141,9 @@ class HostCollectionTestCase(UITestCase):
         """Create Host Collections with invalid Content Host Limit value. Both
         with too long numbers and using letters.
 
-        @id: c15b3540-809e-4339-ad5f-1ab488244299
+        :id: c15b3540-809e-4339-ad5f-1ab488244299
 
-        @Assert: Host Collection is not created. Appropriate error shown.
+        :Assert: Host Collection is not created. Appropriate error shown.
         """
         with Session(self.browser) as session:
             for limit in invalid_names_list():
@@ -163,9 +163,9 @@ class HostCollectionTestCase(UITestCase):
     def test_positive_update_name(self):
         """Update existing Host Collection name
 
-        @id: 9df33661-7a9c-40d9-8f2c-52e5ed21c156
+        :id: 9df33661-7a9c-40d9-8f2c-52e5ed21c156
 
-        @Assert: Host Collection is updated
+        :Assert: Host Collection is updated
         """
         name = gen_string('alpha')
         with Session(self.browser) as session:
@@ -182,9 +182,9 @@ class HostCollectionTestCase(UITestCase):
     def test_positive_update_description(self):
         """Update existing Host Collection entity description
 
-        @id: 5ef92657-489f-46a2-9b3a-e40322ca86d8
+        :id: 5ef92657-489f-46a2-9b3a-e40322ca86d8
 
-        @Assert: Host Collection is updated
+        :Assert: Host Collection is updated
         """
         name = gen_string('alpha')
         with Session(self.browser) as session:
@@ -209,9 +209,9 @@ class HostCollectionTestCase(UITestCase):
     def test_positive_update_limit(self):
         """Update Content Host limit from Unlimited to a finite number
 
-        @id: 6f5015c4-06c9-4873-806e-5f9d39c9d8a8
+        :id: 6f5015c4-06c9-4873-806e-5f9d39c9d8a8
 
-        @Assert: Host Collection is updated
+        :Assert: Host Collection is updated
         """
         name = gen_string('alpha')
         with Session(self.browser) as session:
@@ -228,9 +228,9 @@ class HostCollectionTestCase(UITestCase):
     def test_positive_update_limit_to_unlimited(self):
         """Update Content Host limit from definite number to Unlimited
 
-        @id: 823acd9e-1259-47b6-8236-7547ef3fff98
+        :id: 823acd9e-1259-47b6-8236-7547ef3fff98
 
-        @Assert: Host Collection is updated
+        :Assert: Host Collection is updated
         """
         name = gen_string('alpha')
         with Session(self.browser) as session:
@@ -247,9 +247,9 @@ class HostCollectionTestCase(UITestCase):
     def test_negative_update_name(self):
         """Update existing Host Collection entity name with invalid value
 
-        @id: 7af999e8-5189-45c0-a92d-8c05b03f556a
+        :id: 7af999e8-5189-45c0-a92d-8c05b03f556a
 
-        @Assert: Host Collection is not updated.  Appropriate error shown.
+        :Assert: Host Collection is not updated.  Appropriate error shown.
         """
         name = gen_string('alpha')
         with Session(self.browser) as session:
@@ -268,9 +268,9 @@ class HostCollectionTestCase(UITestCase):
     def test_negative_update_limit(self):
         """Update Host Collection with invalid Content Host Limit
 
-        @id: 3f3749f9-cf52-4897-993f-804def785510
+        :id: 3f3749f9-cf52-4897-993f-804def785510
 
-        @Assert: Host Collection is not updated.  Appropriate error shown.
+        :Assert: Host Collection is not updated.  Appropriate error shown.
         """
         name = gen_string('alpha')
         with Session(self.browser) as session:
@@ -286,9 +286,9 @@ class HostCollectionTestCase(UITestCase):
     def test_positive_delete(self):
         """Create Host Collection and delete it for all variations of name
 
-        @id: 978a985c-29f4-4b1f-8c68-8cd412af21e6
+        :id: 978a985c-29f4-4b1f-8c68-8cd412af21e6
 
-        @Assert: Host Collection is deleted
+        :Assert: Host Collection is deleted
         """
         with Session(self.browser) as session:
             for name in valid_data_list():
@@ -302,9 +302,9 @@ class HostCollectionTestCase(UITestCase):
     def test_positive_copy(self):
         """Create Host Collection and copy it
 
-        @id: af8d968c-8241-40dc-b92c-81965f470191
+        :id: af8d968c-8241-40dc-b92c-81965f470191
 
-        @Assert: Host Collection copy exists
+        :Assert: Host Collection copy exists
         """
         name = gen_string('alpha')
         with Session(self.browser) as session:
@@ -321,9 +321,9 @@ class HostCollectionTestCase(UITestCase):
     def test_negative_copy(self):
         """Create Host Collection and copy it. Use invalid values for copy name
 
-        @id: 99d47520-c09a-4fbc-8e53-a4e889af0187
+        :id: 99d47520-c09a-4fbc-8e53-a4e889af0187
 
-        @Assert: Host Collection copy does not exist
+        :Assert: Host Collection copy does not exist
         """
         name = gen_string('alpha')
         with Session(self.browser) as session:
@@ -342,11 +342,11 @@ class HostCollectionTestCase(UITestCase):
     def test_positive_add_host(self):
         """Check if host can be added to Host Collection
 
-        @id: 80824c9f-15a1-4f76-b7ac-7d9ca9f6ed9e
+        :id: 80824c9f-15a1-4f76-b7ac-7d9ca9f6ed9e
 
-        @Assert: Host is added to Host Collection successfully
+        :Assert: Host is added to Host Collection successfully
 
-        @CaseLevel: System
+        :CaseLevel: System
         """
         name = gen_string('alpha')
         cv = entities.ContentView(organization=self.organization).create()
@@ -369,20 +369,20 @@ class HostCollectionTestCase(UITestCase):
     def test_negative_hosts_limit(self):
         """Check that Host limit actually limits usage
 
-        @id: 57b70977-2110-47d9-be3b-461ad15c70c7
+        :id: 57b70977-2110-47d9-be3b-461ad15c70c7
 
-        @Steps:
-        1. Create Host Collection entity that can contain only one Host (using
-        Host Limit field)
-        2. Create Host and add it to Host Collection. Check that it was added
-        successfully
-        3. Create one more Host and try to add it to Host Collection
-        4. Check that expected error is shown
+        :Steps:
+            1. Create Host Collection entity that can contain only one Host
+                (using Host Limit field)
+            2. Create Host and add it to Host Collection. Check that it was
+                added successfully
+            3. Create one more Host and try to add it to Host Collection
+            4. Check that expected error is shown
 
-        @Assert: Second host is not added to Host Collection and appropriate
-        error is shown
+        :Assert: Second host is not added to Host Collection and appropriate
+            error is shown
 
-        @CaseLevel: System
+        :CaseLevel: System
         """
         name = gen_string('alpha')
         org = entities.Organization().create()
@@ -506,12 +506,12 @@ class HostCollectionPackageManagementTest(UITestCase):
     def test_positive_install_package(self):
         """Install a package to hosts inside host collection remotely
 
-        @id: eead8392-0ffc-4062-b045-5d0252670775
+        :id: eead8392-0ffc-4062-b045-5d0252670775
 
-        @assert: Package was successfully installed on all the hosts in host
-        collection
+        :assert: Package was successfully installed on all the hosts in host
+            collection
 
-        @CaseLevel: System
+        :CaseLevel: System
         """
         with Session(self.browser):
             self.hostcollection.execute_bulk_package_action(
@@ -527,12 +527,12 @@ class HostCollectionPackageManagementTest(UITestCase):
     def test_positive_remove_package(self):
         """Remove a package from hosts inside host collection remotely
 
-        @id: 488fa88d-d0ef-4108-a050-96fb621383df
+        :id: 488fa88d-d0ef-4108-a050-96fb621383df
 
-        @Assert: Package was successfully removed from all the hosts in host
-        collection
+        :Assert: Package was successfully removed from all the hosts in host
+            collection
 
-        @CaseLevel: System
+        :CaseLevel: System
         """
         for client in self.hosts:
             client.download_install_rpm(
@@ -556,12 +556,12 @@ class HostCollectionPackageManagementTest(UITestCase):
     def test_positive_upgrade_package(self):
         """Upgrade a package on hosts inside host collection remotely
 
-        @id: 5a6fff0a-686f-419b-a773-4d03713e47e9
+        :id: 5a6fff0a-686f-419b-a773-4d03713e47e9
 
-        @Assert: Package was successfully upgraded on all the hosts in host
-        collection
+        :Assert: Package was successfully upgraded on all the hosts in host
+            collection
 
-        @CaseLevel: System
+        :CaseLevel: System
         """
         for client in self.hosts:
             client.run('yum install -y {0}'.format(FAKE_1_CUSTOM_PACKAGE))
@@ -578,12 +578,12 @@ class HostCollectionPackageManagementTest(UITestCase):
     def test_positive_install_package_group(self):
         """Install a package group to hosts inside host collection remotely
 
-        @id: 2bf47798-d30d-451a-8de5-bc03bd8b9a48
+        :id: 2bf47798-d30d-451a-8de5-bc03bd8b9a48
 
-        @Assert: Package group was successfully installed on all the hosts in
-        host collection
+        :Assert: Package group was successfully installed on all the hosts in
+            host collection
 
-        @CaseLevel: System
+        :CaseLevel: System
         """
         with Session(self.browser):
             self.hostcollection.execute_bulk_package_action(
@@ -599,12 +599,12 @@ class HostCollectionPackageManagementTest(UITestCase):
     def test_positive_remove_package_group(self):
         """Remove a package group from hosts inside host collection remotely
 
-        @id: 458897dc-9836-481a-b777-b147d64836f2
+        :id: 458897dc-9836-481a-b777-b147d64836f2
 
-        @Assert: Package group was successfully removed  on all the hosts in
-        host collection
+        :Assert: Package group was successfully removed  on all the hosts in
+            host collection
 
-        @CaseLevel: System
+        :CaseLevel: System
         """
         with Session(self.browser):
             self.hostcollection.execute_bulk_package_action(
@@ -629,12 +629,12 @@ class HostCollectionPackageManagementTest(UITestCase):
     def test_positive_install_errata(self):
         """Install an errata to the hosts inside host collection remotely
 
-        @id: 69c83000-0b46-4735-8c03-e9e0b48af0fb
+        :id: 69c83000-0b46-4735-8c03-e9e0b48af0fb
 
-        @Assert: Errata was successfully installed in all the hosts in host
-        collection
+        :Assert: Errata was successfully installed in all the hosts in host
+            collection
 
-        @CaseLevel: System
+        :CaseLevel: System
         """
         for client in self.hosts:
             client.run('yum install -y {0}'.format(FAKE_1_CUSTOM_PACKAGE))

--- a/tests/foreman/ui/test_hostgroup.py
+++ b/tests/foreman/ui/test_hostgroup.py
@@ -1,19 +1,19 @@
 # -*- encoding: utf-8 -*-
 """Test class for Host Group UI
 
-@Requirement: Hostgroup
+:Requirement: Hostgroup
 
-@CaseAutomation: Automated
+:CaseAutomation: Automated
 
-@CaseLevel: Acceptance
+:CaseLevel: Acceptance
 
-@CaseComponent: UI
+:CaseComponent: UI
 
-@TestType: Functional
+:TestType: Functional
 
-@CaseImportance: High
+:CaseImportance: High
 
-@Upstream: No
+:Upstream: No
 """
 
 from fauxfactory import gen_string
@@ -52,9 +52,9 @@ class HostgroupTestCase(UITestCase):
     def test_positive_create_with_name(self):
         """Create new hostgroup
 
-        @id: 8bcf45e5-9e7f-4050-9de6-a90350b70006
+        :id: 8bcf45e5-9e7f-4050-9de6-a90350b70006
 
-        @Assert: Hostgroup is created
+        :Assert: Hostgroup is created
         """
         with Session(self.browser) as session:
             for name in generate_strings_list():
@@ -67,9 +67,9 @@ class HostgroupTestCase(UITestCase):
     def test_negative_create_with_invalid_name(self):
         """Create new hostgroup with invalid names
 
-        @id: a0232740-ae9f-44ce-9f3d-bafc8f1b05cb
+        :id: a0232740-ae9f-44ce-9f3d-bafc8f1b05cb
 
-        @Assert: Hostgroup is not created
+        :Assert: Hostgroup is not created
         """
         with Session(self.browser) as session:
             for name in invalid_values_list(interface='ui'):
@@ -85,9 +85,9 @@ class HostgroupTestCase(UITestCase):
     def test_negative_create_with_same_name(self):
         """Create new hostgroup with same name
 
-        @id: 237b684d-3b55-444a-be00-a9825952bb53
+        :id: 237b684d-3b55-444a-be00-a9825952bb53
 
-        @Assert: Hostgroup is not created
+        :Assert: Hostgroup is not created
         """
         name = gen_string('utf8')
         with Session(self.browser) as session:
@@ -104,9 +104,9 @@ class HostgroupTestCase(UITestCase):
     def test_positive_delete(self):
         """Delete a hostgroup
 
-        @id: f118532b-ca9b-4bf4-b53b-9573abcb347a
+        :id: f118532b-ca9b-4bf4-b53b-9573abcb347a
 
-        @Assert: Hostgroup is deleted
+        :Assert: Hostgroup is deleted
         """
         with Session(self.browser) as session:
             for name in generate_strings_list(length=4):
@@ -119,9 +119,9 @@ class HostgroupTestCase(UITestCase):
     def test_positive_update(self):
         """Update hostgroup with a new name
 
-        @id: 7c8de1b8-aced-44f0-88a0-dc9e6b83bf7f
+        :id: 7c8de1b8-aced-44f0-88a0-dc9e6b83bf7f
 
-        @Assert: Hostgroup is updated
+        :Assert: Hostgroup is updated
         """
         name = gen_string('alpha')
         with Session(self.browser) as session:
@@ -138,9 +138,9 @@ class HostgroupTestCase(UITestCase):
     def test_positive_create_with_oscap_capsule(self):
         """Create new hostgroup with oscap capsule
 
-        @id: c0ab1148-93ff-41d3-93c3-2ff139349884
+        :id: c0ab1148-93ff-41d3-93c3-2ff139349884
 
-        @Assert: Hostgroup is created with oscap capsule
+        :Assert: Hostgroup is created with oscap capsule
         """
         name = gen_string('alpha')
         with Session(self.browser) as session:
@@ -159,9 +159,9 @@ class HostgroupTestCase(UITestCase):
     def test_positive_create_with_activation_keys(self):
         """Create new hostgroup with activation keys
 
-        @id: cfda3c1b-37fd-42c1-a74c-841efb83b2f5
+        :id: cfda3c1b-37fd-42c1-a74c-841efb83b2f5
 
-        @Assert: Hostgroup is created with activation keys
+        :Assert: Hostgroup is created with activation keys
         """
         name = gen_string('alpha')
         with Session(self.browser) as session:
@@ -180,20 +180,20 @@ class HostgroupTestCase(UITestCase):
         """Open Hostgroup New/Edit modal and verify that Activation Keys
         autocomplete respects selected Content View
 
-        @id: 07906caf-871d-4d1f-8914-38027e71c16b
+        :id: 07906caf-871d-4d1f-8914-38027e71c16b
 
-        @Steps:
+        :Steps:
 
-        1. Create two content views A & B
-        2. Publish both content views
-        3. Create an activation key pointed to view A in Library
-        4. Create an activation key pointed to view B in Library
-        5. Go to the new Hostgroup page, select content view B & Library,
-            click on the activation key tab and click in the input box
+            1. Create two content views A & B
+            2. Publish both content views
+            3. Create an activation key pointed to view A in Library
+            4. Create an activation key pointed to view B in Library
+            5. Go to the new Hostgroup page, select content view B & Library,
+                click on the activation key tab and click in the input box
 
-        @Assert: Only the activation key for view B is listed
+        :Assert: Only the activation key for view B is listed
 
-        @BZ: 1321511
+        :BZ: 1321511
         """
         # Use setup entities as A and create another set for B.
         cv_b = entities.ContentView(organization=self.organization).create()

--- a/tests/foreman/ui/test_hostunification.py
+++ b/tests/foreman/ui/test_hostunification.py
@@ -1,19 +1,19 @@
 # -*- encoding: utf-8 -*-
 """Test class for Host/System Unification
 
-@Requirement: Hostunification
+:Requirement: Hostunification
 
-@CaseAutomation: Automated
+:CaseAutomation: Automated
 
-@CaseLevel: Acceptance
+:CaseLevel: Acceptance
 
-@CaseComponent: UI
+:CaseComponent: UI
 
-@TestType: Functional
+:TestType: Functional
 
-@CaseImportance: High
+:CaseImportance: High
 
-@Upstream: No
+:Upstream: No
 """
 
 from fauxfactory import gen_string
@@ -64,17 +64,17 @@ class HostContentHostUnificationTestCase(UITestCase):
     def test_positive_register_host_via_rhsm(self):
         """Register a pre-installed host via rhsm using credentials
 
-        @id: 4e685241-b671-4cfd-bfaa-f44a5cf78654
+        :id: 4e685241-b671-4cfd-bfaa-f44a5cf78654
 
-        @steps:
-        1.  Register a host via rhsm using credentials
-        2.  View host under content hosts
-        3.  View host under 'All Hosts'
+        :steps:
+            1.  Register a host via rhsm using credentials
+            2.  View host under content hosts
+            3.  View host under 'All Hosts'
 
-        @assert: Hosts registered via rhsm appears under 'All hosts' as well
-        as under content-hosts.
+        :assert: Hosts registered via rhsm appears under 'All hosts' as well as
+            under content-hosts.
 
-        @CaseLevel: System
+        :CaseLevel: System
         """
         with VirtualMachine(distro=DISTRO_RHEL7) as vm:
             vm.install_katello_ca()
@@ -91,17 +91,17 @@ class HostContentHostUnificationTestCase(UITestCase):
     def test_positive_register_host_via_ak(self):
         """Register a pre-installed host via rhsm using activation-key
 
-        @id: b42a1a13-49ef-418e-bb66-12ed71cf3038
+        :id: b42a1a13-49ef-418e-bb66-12ed71cf3038
 
-        @steps:
-        1.  Register a host via rhsm using activation-key
-        2.  View host under content hosts
-        3.  View host under 'All Hosts'
+        :steps:
+            1.  Register a host via rhsm using activation-key
+            2.  View host under content hosts
+            3.  View host under 'All Hosts'
 
-        @assert: Hosts registered via activation key appears under 'All hosts'
-        as well as under content-hosts
+        :assert: Hosts registered via activation key appears under 'All hosts'
+            as well as under content-hosts
 
-        @CaseLevel: System
+        :CaseLevel: System
         """
         org = entities.Organization().create()
         env = entities.LifecycleEnvironment(organization=org).create()
@@ -133,18 +133,18 @@ class HostContentHostUnificationTestCase(UITestCase):
     def test_positive_provision_foreman_host(self):
         """Test if a foreman host can be provisioned
 
-        @id: 985b4432-4d99-43a7-a304-1b93760257dd
+        :id: 985b4432-4d99-43a7-a304-1b93760257dd
 
-        @steps:
+        :steps:
 
-        1.  Provision a host via foreman
-        2.  View host under content hosts
-        3.  View host under 'All Hosts'
+            1.  Provision a host via foreman
+            2.  View host under content hosts
+            3.  View host under 'All Hosts'
 
-        @assert: Hosts provisioned via foreman should appear under 'All hosts'
-        as well as under content-hosts.
+        :assert: Hosts provisioned via foreman should appear under 'All hosts'
+            as well as under content-hosts.
 
-        @CaseLevel: System
+        :CaseLevel: System
         """
         host = entities.Host()
         host.create_missing()
@@ -187,16 +187,16 @@ class HostContentHostUnificationTestCase(UITestCase):
     def test_positive_rename_foreman_host(self):
         """Hosts renamed in foreman appears in katello under content-hosts
 
-        @id: 24182edc-8bff-46a1-b158-bcc7a3615166
+        :id: 24182edc-8bff-46a1-b158-bcc7a3615166
 
-        @steps:
-        1.  Rename a host from 'All Hosts' page
-        2.  View host under content-hosts page
-        3.  View host under 'All Hosts'
+        :steps:
+            1.  Rename a host from 'All Hosts' page
+            2.  View host under content-hosts page
+            3.  View host under 'All Hosts'
 
-        @assert: Host appears in both places despite being renamed
+        :assert: Host appears in both places despite being renamed
 
-        @CaseLevel: System
+        :CaseLevel: System
         """
         with VirtualMachine(distro=DISTRO_RHEL7) as vm:
             vm.install_katello_ca()
@@ -227,16 +227,16 @@ class HostContentHostUnificationTestCase(UITestCase):
     def test_positive_rename_content_host(self):
         """Hosts renamed in katello via content-hosts appear in foreman
 
-        @id: 34a2c507-b992-46fa-81d9-e4b31ffd9706
+        :id: 34a2c507-b992-46fa-81d9-e4b31ffd9706
 
-        @steps:
-        1.  Rename a host from 'Content-hosts' page
-        2.  View host under content-hosts
-        3.  View host under 'All Hosts'
+        :steps:
+            1.  Rename a host from 'Content-hosts' page
+            2.  View host under content-hosts
+            3.  View host under 'All Hosts'
 
-        @assert: Host appears in both places despite being renamed
+        :assert: Host appears in both places despite being renamed
 
-        @CaseLevel: System
+        :CaseLevel: System
         """
         with VirtualMachine(distro=DISTRO_RHEL7) as vm:
             vm.install_katello_ca()
@@ -259,17 +259,17 @@ class HostContentHostUnificationTestCase(UITestCase):
     def test_positive_delete_from_allhosts(self):
         """Delete a host from 'All hosts'
 
-        @id: 896c1a7e-9292-45f2-a2b7-3d2560ae4a2d
+        :id: 896c1a7e-9292-45f2-a2b7-3d2560ae4a2d
 
-        @steps:
-        1.  Delete a host from 'All hosts' page
-        2.  View host under 'Content-hosts'
-        3.  View host under 'All hosts'
+        :steps:
+            1.  Delete a host from 'All hosts' page
+            2.  View host under 'Content-hosts'
+            3.  View host under 'All hosts'
 
-        @assert: Host should be removed from 'All hosts' as well as
-        content-hosts
+        :assert: Host should be removed from 'All hosts' as well as
+            content-hosts
 
-        @CaseLevel: System
+        :CaseLevel: System
         """
         with VirtualMachine(distro=DISTRO_RHEL7) as vm:
             vm.install_katello_ca()
@@ -286,17 +286,17 @@ class HostContentHostUnificationTestCase(UITestCase):
     def test_positive_unregister_content_host(self):
         """Unregister a host from content-hosts page
 
-        @id: a7d8a081-b0f2-4944-a8dc-5527cb6ab914
+        :id: a7d8a081-b0f2-4944-a8dc-5527cb6ab914
 
-        @steps:
-        1.  Un-register a host from content-host page
-        2.  View host under content hosts
-        3.  View host under 'All hosts'
+        :steps:
+            1.  Un-register a host from content-host page
+            2.  View host under content hosts
+            3.  View host under 'All hosts'
 
-        @assert: Hosts un-registered from content-host should appear in both
-        sides of UI
+        :assert: Hosts un-registered from content-host should appear in both
+            sides of UI
 
-        @CaseLevel: System
+        :CaseLevel: System
         """
         org = entities.Organization().create()
         env = entities.LifecycleEnvironment(organization=org).create()
@@ -332,17 +332,17 @@ class HostContentHostUnificationTestCase(UITestCase):
     def test_positive_delete_content_host(self):
         """Unregister and delete a host from content-hosts page
 
-        @id: 3c75c1e6-85e3-49e6-a10e-6052a0db2b7f
+        :id: 3c75c1e6-85e3-49e6-a10e-6052a0db2b7f
 
-        @steps:
-        1.  Un-register and delete a host from content-host page
-        2.  View host under content hosts
-        3.  View host under 'All hosts'
+        :steps:
+            1.  Un-register and delete a host from content-host page
+            2.  View host under content hosts
+            3.  View host under 'All hosts'
 
-        @assert: Hosts un-registered from content-host should disappear from
-        both sides of UI
+        :assert: Hosts un-registered from content-host should disappear from
+            both sides of UI
 
-        @CaseLevel: System
+        :CaseLevel: System
         """
         org = entities.Organization().create()
         env = entities.LifecycleEnvironment(organization=org).create()
@@ -375,17 +375,17 @@ class HostContentHostUnificationTestCase(UITestCase):
     def test_positive_re_register_host(self):
         """Re-register a host which was un-registered earlier from content-host
 
-        @id: 898695dc-36ff-45b8-85be-6734e6a232d6
+        :id: 898695dc-36ff-45b8-85be-6734e6a232d6
 
-        @steps:
-        1.  Re-register a host which was unregistered before
-        2.  View host under content hosts
-        3.  View host under 'All hosts'
+        :steps:
+            1.  Re-register a host which was unregistered before
+            2.  View host under content hosts
+            3.  View host under 'All hosts'
 
-        @assert: A single entry of host should appear at both places on
-        re-registering
+        :assert: A single entry of host should appear at both places on
+            re-registering
 
-        @CaseLevel: System
+        :CaseLevel: System
         """
         org = entities.Organization().create()
         env = entities.LifecycleEnvironment(organization=org).create()
@@ -425,16 +425,16 @@ class HostContentHostUnificationTestCase(UITestCase):
     def test_negative_add_subs_to_unregistered_host(self):
         """Perform a subscription action on a host which is not registered
 
-        @id: 83ebd98e-309d-4209-bf01-0547334af5af
+        :id: 83ebd98e-309d-4209-bf01-0547334af5af
 
-        @steps:
-        1.  Provision a host via foreman which is not registered via rhsm
-        2.  Try to add subscription from content-hosts page
+        :steps:
+            1.  Provision a host via foreman which is not registered via rhsm
+            2.  Try to add subscription from content-hosts page
 
-        @assert: User get a warning:
-        This Host is not currently registered with subscription-manager.
+        :assert: User get a warning: This Host is not currently registered with
+            subscription-manager.
 
-        @CaseLevel: System
+        :CaseLevel: System
         """
         host = entities.Host()
         host.create_missing()
@@ -480,16 +480,16 @@ class HostContentHostUnificationTestCase(UITestCase):
     def test_negative_add_contents_to_unregistered_host(self):
         """Perform a content action like on a host which is not registered
 
-        @id: 67396c26-67fa-4cee-9937-65c2b9befabc
+        :id: 67396c26-67fa-4cee-9937-65c2b9befabc
 
-        @steps:
-        1.  Provision a host via foreman which is not registered via rhsm
-        2.  Try to add package from content-hosts page
+        :steps:
+            1.  Provision a host via foreman which is not registered via rhsm
+            2.  Try to add package from content-hosts page
 
-        @assert: User get a warning:
-        This Host is not currently registered with subscription-manager.
+        :assert: User get a warning: This Host is not currently registered with
+            subscription-manager.
 
-        @CaseLevel: System
+        :CaseLevel: System
         """
         host = entities.Host()
         host.create_missing()

--- a/tests/foreman/ui/test_hw_model.py
+++ b/tests/foreman/ui/test_hw_model.py
@@ -1,18 +1,18 @@
 """Test class for Config Groups UI
 
-@Requirement: Hw model
+:Requirement: Hw model
 
-@CaseAutomation: Automated
+:CaseAutomation: Automated
 
-@CaseLevel: Acceptance
+:CaseLevel: Acceptance
 
-@CaseComponent: UI
+:CaseComponent: UI
 
-@TestType: Functional
+:TestType: Functional
 
-@CaseImportance: High
+:CaseImportance: High
 
-@Upstream: No
+:Upstream: No
 """
 
 from fauxfactory import gen_string
@@ -35,9 +35,9 @@ class HardwareModelTestCase(UITestCase):
     def test_positive_create_with_name(self):
         """Create new Hardware-Model
 
-        @id: e2ebac95-4d0b-404d-98c6-dcba40158c28
+        :id: e2ebac95-4d0b-404d-98c6-dcba40158c28
 
-        @assert: Hardware-Model is created
+        :assert: Hardware-Model is created
         """
         with Session(self.browser) as session:
             for name in valid_data_list():
@@ -50,9 +50,9 @@ class HardwareModelTestCase(UITestCase):
     def test_negative_create_with_invalid_name(self):
         """Create new Hardware-Model with invalid names
 
-        @id: ccaeec78-28e9-432d-bb2e-6fb92280d996
+        :id: ccaeec78-28e9-432d-bb2e-6fb92280d996
 
-        @assert: Hardware-Model is not created
+        :assert: Hardware-Model is not created
         """
         with Session(self.browser) as session:
             for name in invalid_values_list(interface='ui'):
@@ -67,9 +67,9 @@ class HardwareModelTestCase(UITestCase):
     def test_positive_update(self):
         """Updates the Hardware-Model
 
-        @id: 56ec6d62-1520-4de2-9231-b62e57578223
+        :id: 56ec6d62-1520-4de2-9231-b62e57578223
 
-        @assert: Hardware-Model is updated.
+        :assert: Hardware-Model is updated.
         """
         name = gen_string('alpha')
         with Session(self.browser) as session:
@@ -86,9 +86,9 @@ class HardwareModelTestCase(UITestCase):
     def test_positive_delete(self):
         """Deletes the Hardware-Model
 
-        @id: 160319bb-c67c-4086-8d48-fce88c110a2e
+        :id: 160319bb-c67c-4086-8d48-fce88c110a2e
 
-        @assert: Hardware-Model is deleted
+        :assert: Hardware-Model is deleted
         """
         with Session(self.browser) as session:
             for name in valid_data_list():

--- a/tests/foreman/ui/test_isodownload.py
+++ b/tests/foreman/ui/test_isodownload.py
@@ -1,18 +1,18 @@
 """Test class for ISO downloads UI
 
-@Requirement: Isodownload
+:Requirement: Isodownload
 
-@CaseAutomation: Automated
+:CaseAutomation: Automated
 
-@CaseLevel: Acceptance
+:CaseLevel: Acceptance
 
-@CaseComponent: UI
+:CaseComponent: UI
 
-@TestType: Functional
+:TestType: Functional
 
-@CaseImportance: High
+:CaseImportance: High
 
-@Upstream: No
+:Upstream: No
 """
 from robottelo.decorators import run_only_on, stubbed, tier1
 from robottelo.test import UITestCase
@@ -27,17 +27,16 @@ class ISODownloadTestCase(UITestCase):
     def test_positive_download(self):
         """Downloading ISO from export
 
-        @id: 47f20df7-f6f3-422b-b57b-3a5ef9cf62ad
+        :id: 47f20df7-f6f3-422b-b57b-3a5ef9cf62ad
 
-        @Steps:
+        :Steps:
 
-        1. find out the location where all iso's are kept
-        2. check whether a valid iso can be downloaded
+            1. find out the location where all iso's are kept
+            2. check whether a valid iso can be downloaded
 
-        @Assert: iso file is properly downloaded on your satellite 6
-        system
+            :Assert: iso file is properly downloaded on your satellite 6 system
 
-        @caseautomation: notautomated
+        :caseautomation: notautomated
 
         """
 
@@ -47,16 +46,16 @@ class ISODownloadTestCase(UITestCase):
     def test_positive_upload(self):
         """Uploadng the iso successfully to the sat6 system
 
-        @id: daf87a68-7c61-46f1-b4cc-021476080b6b
+        :id: daf87a68-7c61-46f1-b4cc-021476080b6b
 
-        @Steps:
+        :Steps:
 
-        1. download the iso
-        2. upload it to sat6 system
+            1. download the iso
+            2. upload it to sat6 system
 
-        @Assert: uploading iso to satellite6 is successful
+        :Assert: uploading iso to satellite6 is successful
 
-        @caseautomation: notautomated
+        :caseautomation: notautomated
 
         """
 
@@ -66,17 +65,17 @@ class ISODownloadTestCase(UITestCase):
     def test_positive_mount(self):
         """Mounting iso to directory accessible to satellite6 works
 
-        @id: 44d3c8fa-c01f-438c-b83e-8f6894befbbf
+        :id: 44d3c8fa-c01f-438c-b83e-8f6894befbbf
 
-        @Steps:
+        :Steps:
 
-        1. download the iso
-        2. upload it to sat6 system
-        3. mount it a local sat6 directory
+            1. download the iso
+            2. upload it to sat6 system
+            3. mount it a local sat6 directory
 
-        @Assert: iso is mounted to sat6 local directory
+        :Assert: iso is mounted to sat6 local directory
 
-        @caseautomation: notautomated
+        :caseautomation: notautomated
 
         """
 
@@ -86,16 +85,16 @@ class ISODownloadTestCase(UITestCase):
     def test_positive_validate_cdn_url(self):
         """Validate that cdn url to file path works
 
-        @id: 00157f61-1557-48a7-b7c9-6dac726eff94
+        :id: 00157f61-1557-48a7-b7c9-6dac726eff94
 
-        @Steps:
+        :Steps:
 
-        1. after mounting the iso locally try to update the cdn url
-        2. the path should be validated
+            1. after mounting the iso locally try to update the cdn url
+            2. the path should be validated
 
-        @Assert: cdn url path is validated
+        :Assert: cdn url path is validated
 
-        @caseautomation: notautomated
+        :caseautomation: notautomated
 
         """
 
@@ -105,17 +104,17 @@ class ISODownloadTestCase(UITestCase):
     def test_positive_check_message(self):
         """Check if proper message is displayed after successful upload
 
-        @id: 5ed31a26-b902-4352-900f-bb38eac95511
+        :id: 5ed31a26-b902-4352-900f-bb38eac95511
 
-        @Steps:
+        :Steps:
 
-        1. mount the iso to sat6
-        2. update the cdn url with file path
-        3. check if proper message is displayed
+            1. mount the iso to sat6
+            2. update the cdn url with file path
+            3. check if proper message is displayed
 
-        @Assert: Asserting the message after successful upload
+        :Assert: Asserting the message after successful upload
 
-        @caseautomation: notautomated
+        :caseautomation: notautomated
 
         """
 
@@ -125,19 +124,18 @@ class ISODownloadTestCase(UITestCase):
     def test_positive_enable_repo(self):
         """Enable the repositories
 
-        @id: e33e2796-0554-419f-b5a1-3e2c8e23e950
+        :id: e33e2796-0554-419f-b5a1-3e2c8e23e950
 
-        @Steps:
+        :Steps:
 
-        1. mount iso to directory
-        2. update cdn url
-        3. upload manifest
-        4. try to enable redhat repositories
+            1. mount iso to directory
+            2. update cdn url
+            3. upload manifest
+            4. try to enable redhat repositories
 
+        :Assert: Redhat repositories are enabled
 
-        @Assert: Redhat repositories are enabled
-
-        @caseautomation: notautomated
+        :caseautomation: notautomated
 
         """
 
@@ -147,20 +145,19 @@ class ISODownloadTestCase(UITestCase):
     def test_positive_validate_checkboxes(self):
         """Check if enabling the checkbox works
 
-        @id: 10b19405-f82e-4f95-869d-28d91cac1e6f
+        :id: 10b19405-f82e-4f95-869d-28d91cac1e6f
 
-        @Steps:
+        :Steps:
 
-        1. mount iso to directory
-        2. update cdn url
-        3. upload manifest
-        4. Click the checkbox to enable redhat repositories
-        5. redhat repository enabled
+            1. mount iso to directory
+            2. update cdn url
+            3. upload manifest
+            4. Click the checkbox to enable redhat repositories
+            5. redhat repository enabled
 
+        :Assert: Checkbox functionality works
 
-        @Assert: Checkbox functionality works
-
-        @caseautomation: notautomated
+        :caseautomation: notautomated
 
         """
 
@@ -170,19 +167,19 @@ class ISODownloadTestCase(UITestCase):
     def test_positive_sync_repos(self):
         """Sync repos to local iso's
 
-        @id: 96266438-4a52-4222-b573-96bd7cde1700
+        :id: 96266438-4a52-4222-b573-96bd7cde1700
 
-        @Steps:
+        :Steps:
 
-         1. mount iso to directory
-         2. update cdn url
-         3. upload manifest
-         4. try to enable redhat repositories
-         5. sync the repos
+            1. mount iso to directory
+            2. update cdn url
+            3. upload manifest
+            4. try to enable redhat repositories
+            5. sync the repos
 
-        @Assert: Repos are synced after upload
+        :Assert: Repos are synced after upload
 
-        @caseautomation: notautomated
+        :caseautomation: notautomated
 
         """
 
@@ -192,19 +189,19 @@ class ISODownloadTestCase(UITestCase):
     def test_positive_disable_repo(self):
         """Disabling the repo works
 
-        @id: 075700a7-fda0-41db-b9b7-3d6b29f63784
+        :id: 075700a7-fda0-41db-b9b7-3d6b29f63784
 
-        @Steps:
+        :Steps:
 
-        1. mount iso to directory
-        2. update cdn url
-        3. upload manifest
-        4. try to enable redhat repositories
-        5. sync the contents
-        6. try disabling the repository
+            1. mount iso to directory
+            2. update cdn url
+            3. upload manifest
+            4. try to enable redhat repositories
+            5. sync the contents
+            6. try disabling the repository
 
-        @Assert: Assert disabling the repo
+        :Assert: Assert disabling the repo
 
-        @caseautomation: notautomated
+        :caseautomation: notautomated
 
         """

--- a/tests/foreman/ui/test_ldap_auth.py
+++ b/tests/foreman/ui/test_ldap_auth.py
@@ -1,18 +1,18 @@
 """Test class for installer (UI)
 
-@Requirement: Ldap auth
+:Requirement: Ldap auth
 
-@CaseAutomation: Automated
+:CaseAutomation: Automated
 
-@CaseLevel: Acceptance
+:CaseLevel: Acceptance
 
-@CaseComponent: UI
+:CaseComponent: UI
 
-@TestType: Functional
+:TestType: Functional
 
-@CaseImportance: High
+:CaseImportance: High
 
-@Upstream: No
+:Upstream: No
 """
 
 from robottelo.decorators import skip_if_not_set, stubbed, tier3
@@ -42,20 +42,18 @@ class LDAPAuthTestCase(UITestCase):
     def test_positive_ipa_basic_no_roles(self):
         """Login with LDAP Auth- IPA for user with no roles/rights
 
-        @id: e742a9ff-f41b-4fac-b277-b5ab9c9b346f
+        :id: e742a9ff-f41b-4fac-b277-b5ab9c9b346f
 
-        @setup: assure properly functioning IPA server for authentication
+        :setup: assure properly functioning IPA server for authentication
 
-        @steps:
-        1. Login to server with an IPA user.
+        :steps: Login to server with an IPA user.
 
-        @assert: Log in to foreman UI successfully but cannot access
-        functional areas of UI
+        :assert: Log in to foreman UI successfully but cannot access functional
+            areas of UI
 
-        @caseautomation: notautomated
+        :caseautomation: notautomated
 
-
-        @CaseLevel: System
+        :CaseLevel: System
         """
 
     @skip_if_not_set('ldap')
@@ -64,20 +62,18 @@ class LDAPAuthTestCase(UITestCase):
     def test_positive_ipa_basic_roles(self):
         """Login with LDAP - IPA for user with roles/rights
 
-        @id: e7c67103-b863-4576-8d89-d35fa69cc0eb
+        :id: e7c67103-b863-4576-8d89-d35fa69cc0eb
 
-        @setup: assure properly functioning IPA server for authentication
+        :setup: assure properly functioning IPA server for authentication
 
-        @steps:
-        1. Login to server with an IPA user.
+        :steps: Login to server with an IPA user.
 
-        @assert: Log in to foreman UI successfully and can access appropriate
-        functional areas in UI
+        :assert: Log in to foreman UI successfully and can access appropriate
+            functional areas in UI
 
-        @caseautomation: notautomated
+        :caseautomation: notautomated
 
-
-        @CaseLevel: System
+        :CaseLevel: System
         """
 
     @skip_if_not_set('ldap')
@@ -87,19 +83,18 @@ class LDAPAuthTestCase(UITestCase):
         """LDAP - IPA user activity when IPA user account has been
         deleted or deactivated
 
-        @id: dac8b17a-6644-41f8-9252-c13eb7abe86a
+        :id: dac8b17a-6644-41f8-9252-c13eb7abe86a
 
-        @steps:
-        1. Login to the foreman UI.
-        2. Delete or disable user on IPA server side.
+        :steps:
+            1. Login to the foreman UI.
+            2. Delete or disable user on IPA server side.
 
-        @assert: This is handled gracefully (user is logged out perhaps?)
-        and no data corruption
+        :assert: This is handled gracefully (user is logged out perhaps?) and
+            no data corruption
 
-        @caseautomation: notautomated
+        :caseautomation: notautomated
 
-
-        @CaseLevel: System
+        :CaseLevel: System
         """
 
     @skip_if_not_set('ldap')
@@ -108,20 +103,18 @@ class LDAPAuthTestCase(UITestCase):
     def test_positive_ad_basic_no_roles(self):
         """Login with LDAP Auth- AD for user with no roles/rights
 
-        @id: 7dc8d9a7-ff08-4d8e-a842-d370ffd69741
+        :id: 7dc8d9a7-ff08-4d8e-a842-d370ffd69741
 
-        @setup: assure properly functioning AD server for authentication
+        :setup: assure properly functioning AD server for authentication
 
-        @steps:
-        1. Login to server with an AD user.
+        :steps: Login to server with an AD user.
 
-        @assert: Log in to foreman UI successfully but cannot access
-        functional areas of UI
+        :assert: Log in to foreman UI successfully but cannot access functional
+            areas of UI
 
-        @caseautomation: notautomated
+        :caseautomation: notautomated
 
-
-        @CaseLevel: System
+        :CaseLevel: System
         """
 
     @skip_if_not_set('ldap')
@@ -130,20 +123,18 @@ class LDAPAuthTestCase(UITestCase):
     def test_positive_ad_basic_roles(self):
         """Login with LDAP - AD for user with roles/rights
 
-        @id: ef202e94-8e5d-4333-a4bc-e573b03ebfc8
+        :id: ef202e94-8e5d-4333-a4bc-e573b03ebfc8
 
-        @setup: assure properly functioning AD server for authentication
+        :setup: assure properly functioning AD server for authentication
 
-        @steps:
-        1. Login to server with an AD user.
+        :steps: Login to server with an AD user.
 
-        @assert: Log in to foreman UI successfully and can access appropriate
-        functional areas in UI
+        :assert: Log in to foreman UI successfully and can access appropriate
+            functional areas in UI
 
-        @caseautomation: notautomated
+        :caseautomation: notautomated
 
-
-        @CaseLevel: System
+        :CaseLevel: System
         """
 
     @skip_if_not_set('ldap')
@@ -153,19 +144,18 @@ class LDAPAuthTestCase(UITestCase):
         """LDAP - AD user activity when AD user account has been deleted
         or deactivated
 
-        @id: a11dfd8e-9935-474b-9374-c7d8824dcf58
+        :id: a11dfd8e-9935-474b-9374-c7d8824dcf58
 
-        @steps:
-        1. Login to the Sat6 UI.
-        2. Delete or disable userid on AD server side.
+        :steps:
+            1. Login to the Sat6 UI.
+            2. Delete or disable userid on AD server side.
 
-        @assert: This is handled gracefully (user is logged out perhaps?)
-        and no data corruption
+        :assert: This is handled gracefully (user is logged out perhaps?) and
+            no data corruption
 
-        @caseautomation: notautomated
+        :caseautomation: notautomated
 
-
-        @CaseLevel: System
+        :CaseLevel: System
         """
 
     @skip_if_not_set('ldap')
@@ -174,20 +164,18 @@ class LDAPAuthTestCase(UITestCase):
     def test_positive_openldap_basic_no_roles(self):
         """Login with LDAP - RHDSLDAP that has no roles / rights
 
-        @id: 24ba9b67-faf5-4abc-a835-2d3ce6ff86cf
+        :id: 24ba9b67-faf5-4abc-a835-2d3ce6ff86cf
 
-        @setup: assure properly functioning RHDSLDAP server for authentication
+        :setup: assure properly functioning RHDSLDAP server for authentication
 
-        @steps:
-        1. Login to server with a RHDSLDAP user.
+        :steps: Login to server with a RHDSLDAP user.
 
-        @assert: Log in to foreman UI successfully but has no access to
-        functional areas of UI.
+        :assert: Log in to foreman UI successfully but has no access to
+            functional areas of UI.
 
-        @caseautomation: notautomated
+        :caseautomation: notautomated
 
-
-        @CaseLevel: System
+        :CaseLevel: System
         """
 
     @skip_if_not_set('ldap')
@@ -197,20 +185,18 @@ class LDAPAuthTestCase(UITestCase):
         """Login with LDAP - RHDS LDAP for user with roles/rights
         assigned.
 
-        @id: fe3ca8b9-470d-4d42-9a3e-7ad6b0ee1783
+        :id: fe3ca8b9-470d-4d42-9a3e-7ad6b0ee1783
 
-        @setup: assure properly functioning RHDS LDAP server for authentication
+        :setup: assure properly functioning RHDS LDAP server for authentication
 
-        @steps:
-        1. Login to server with a RHDS LDAP id.
+        :steps: Login to server with a RHDS LDAP id.
 
-        @assert: Log in to foreman UI successfully and can access appropriate
-        functional areas in UI
+        :assert: Log in to foreman UI successfully and can access appropriate
+            functional areas in UI
 
-        @caseautomation: notautomated
+        :caseautomation: notautomated
 
-
-        @CaseLevel: System
+        :CaseLevel: System
         """
 
     @skip_if_not_set('ldap')
@@ -220,19 +206,18 @@ class LDAPAuthTestCase(UITestCase):
         """LDAP - RHDSLDAP user activity when RHDS ldap account has been
         deleted or deactivated
 
-        @id: ec366106-58bd-4904-8014-965506767ea2
+        :id: ec366106-58bd-4904-8014-965506767ea2
 
-        @steps:
-        1. Login to the foreman UI.
-        2. Delete or disable userid on RHDS LDAP server side.
+        :steps:
+            1. Login to the foreman UI.
+            2. Delete or disable userid on RHDS LDAP server side.
 
-        @assert: This is handled gracefully (user is logged out perhaps?) and
-        no data corruption
+        :assert: This is handled gracefully (user is logged out perhaps?) and
+            no data corruption
 
-        @caseautomation: notautomated
+        :caseautomation: notautomated
 
-
-        @CaseLevel: System
+        :CaseLevel: System
         """
 
     @skip_if_not_set('ldap')
@@ -241,23 +226,21 @@ class LDAPAuthTestCase(UITestCase):
     def test_positive_multiple_ldap_backends(self):
         """LDAP - multiple LDAP servers kafo instance
 
-        @id: fc23ec1b-c637-435c-aa85-28078470b311
+        :id: fc23ec1b-c637-435c-aa85-28078470b311
 
-        @setup: Assure more than one ldap server backend is provided for
-        sat6
+        :setup: Assure more than one ldap server backend is provided for sat6
 
-        @steps:
-        1. Attempt to login with a user that exists on one ldap server.
-        2. Logout and attempt to login with a user that exists on other ldap
-        server(s).
+        :steps:
+            1. Attempt to login with a user that exists on one ldap server.
+            2. Logout and attempt to login with a user that exists on other
+                ldap server(s).
 
-        @assert: Log in to foreman UI successfully for users on both LDAP
-        servers.
+        :assert: Log in to foreman UI successfully for users on both LDAP
+            servers.
 
-        @caseautomation: notautomated
+        :caseautomation: notautomated
 
-
-        @CaseLevel: System
+        :CaseLevel: System
         """
 
     @skip_if_not_set('ldap')
@@ -270,22 +253,21 @@ class LDAPAuthTestCase(UITestCase):
         """LDAP - multiple LDAP servers colliding namespace
         (e.g "jsmith")
 
-        @id: 936cd280-22de-47c3-b17d-aaffb7bf7c49
+        :id: 936cd280-22de-47c3-b17d-aaffb7bf7c49
 
-        @setup: more than 1 ldap server backend provide for instance with
+        :setup: more than 1 ldap server backend provide for instance with
 
-        @steps:
-        1. Attempt to login with a user that exists on one ldap server.
-        2. Logout and attempt to login with a user that exists on other
-        ldap server(s).
+        :steps:
+            1. Attempt to login with a user that exists on one ldap server.
+            2. Logout and attempt to login with a user that exists on other
+                ldap server(s).
 
-        @assert: Foreman should have some method for distinguishing/specifying
-        which server a user comes from.
+        :assert: Foreman should have some method for distinguishing/specifying
+            which server a user comes from.
 
-        @caseautomation: notautomated
+        :caseautomation: notautomated
 
-
-        @CaseLevel: System
+        :CaseLevel: System
         """
 
     @skip_if_not_set('ldap')
@@ -299,18 +281,16 @@ class LDAPAuthTestCase(UITestCase):
         # I'm not sure about result
         """LDAP - what happens when we have an ldap user named "admin"?
 
-        @id: 7dd6fef2-6813-4aa2-b8ba-98d99e92446d
+        :id: 7dd6fef2-6813-4aa2-b8ba-98d99e92446d
 
-        @steps:
-        1. Try to login with ldap user "admin".
+        :steps: Try to login with ldap user "admin".
 
-        @assert: Login from local db user "admin" overrides any ldap user
-        "admin"
+        :assert: Login from local db user "admin" overrides any ldap user
+            "admin"
 
-        @caseautomation: notautomated
+        :caseautomation: notautomated
 
-
-        @CaseLevel: System
+        :CaseLevel: System
         """
 
     @skip_if_not_set('ldap')
@@ -320,18 +300,16 @@ class LDAPAuthTestCase(UITestCase):
         """LDAP - what happens when we have an ldap server that goes
         down before logging in?
 
-        @id: bc466317-6c7f-4765-b11f-9428e687c6da
+        :id: bc466317-6c7f-4765-b11f-9428e687c6da
 
-        @steps:
-        1. Try to login with ldap user when server is non-responsive.
+        :steps: Try to login with ldap user when server is non-responsive.
 
-        @assert: UI does handles situation gracefully, perhaps informing user
-        that LDAP instance is not responding
+        :assert: UI does handles situation gracefully, perhaps informing user
+            that LDAP instance is not responding
 
-        @caseautomation: notautomated
+        :caseautomation: notautomated
 
-
-        @CaseLevel: System
+        :CaseLevel: System
         """
 
     @skip_if_not_set('ldap')
@@ -341,19 +319,19 @@ class LDAPAuthTestCase(UITestCase):
         """LDAP - what happens when we have an ldap server that goes
         down after login?
 
-        @id: de3e7466-b22f-416d-ac68-458d55c98390
+        :id: de3e7466-b22f-416d-ac68-458d55c98390
 
-        @steps:
-        1. Try to login with ldap user.
-        2. While logged in with ldap user, disconnect access to ldap server.
+        :steps:
+            1. Try to login with ldap user.
+            2. While logged in with ldap user, disconnect access to ldap
+                server.
 
-        @assert: Situation is handled gracefully and without serious data
-        loss on foreman server
+        :assert: Situation is handled gracefully and without serious data loss
+            on foreman server
 
-        @caseautomation: notautomated
+        :caseautomation: notautomated
 
-
-        @CaseLevel: System
+        :CaseLevel: System
         """
 
     @skip_if_not_set('ldap')
@@ -362,21 +340,19 @@ class LDAPAuthTestCase(UITestCase):
     def test_positive_usergroup_roles_read(self):
         """Group roles get pushed down to user
 
-        @id: 95fa0fd9-a5b7-42dc-85fa-7e573e5d34a2
+        :id: 95fa0fd9-a5b7-42dc-85fa-7e573e5d34a2
 
-        @setup: assign roles to an LDAP UserGroup
+        :setup: assign roles to an LDAP UserGroup
 
-        @steps:
-        1. Login to sat6 with LDAP user that is part of aforementioned
-        UserGroup.
+        :steps: Login to sat6 with LDAP user that is part of aforementioned
+            UserGroup.
 
-        @assert: User has access to all functional areas that are assigned to
-        aforementioned UserGroup.
+        :assert: User has access to all functional areas that are assigned to
+            aforementioned UserGroup.
 
-        @caseautomation: notautomated
+        :caseautomation: notautomated
 
-
-        @CaseLevel: System
+        :CaseLevel: System
         """
 
     @skip_if_not_set('ldap')
@@ -385,21 +361,19 @@ class LDAPAuthTestCase(UITestCase):
     def test_positive_usergroup_roles_update(self):
         """Added UserGroup roles get pushed down to user
 
-        @id: e1d93ae4-cbd5-4d2c-b2b9-abc4ae1813c7
+        :id: e1d93ae4-cbd5-4d2c-b2b9-abc4ae1813c7
 
-        @setup: assign additional roles to an LDAP UserGroup
+        :setup: assign additional roles to an LDAP UserGroup
 
-        @steps:
-        1. Login to sat6 with LDAP user that is part of aforementioned
-        UserGroup.
+        :steps: Login to sat6 with LDAP user that is part of aforementioned
+            UserGroup.
 
-        @assert: User has access to all NEW functional areas that are assigned
-        to aforementioned UserGroup.
+        :assert: User has access to all NEW functional areas that are assigned
+            to aforementioned UserGroup.
 
-        @caseautomation: notautomated
+        :caseautomation: notautomated
 
-
-        @CaseLevel: System
+        :CaseLevel: System
         """
 
     @skip_if_not_set('ldap')
@@ -408,21 +382,19 @@ class LDAPAuthTestCase(UITestCase):
     def test_positive_usergroup_roles_delete(self):
         """Deleted UserGroup roles get pushed down to user
 
-        @id: 149e0faf-48c3-4184-adcb-a1e55fe5d953
+        :id: 149e0faf-48c3-4184-adcb-a1e55fe5d953
 
-        @setup: delete roles from an LDAP UserGroup
+        :setup: delete roles from an LDAP UserGroup
 
-        @steps:
-        1. Login to sat6 with LDAP user that is part of aforementioned
-        UserGroup.
+        :steps: Login to sat6 with LDAP user that is part of aforementioned
+            UserGroup.
 
-        @assert: User no longer has access to all deleted functional areas
-        that were assigned to aforementioned UserGroup.
+        :assert: User no longer has access to all deleted functional areas that
+            were assigned to aforementioned UserGroup.
 
-        @caseautomation: notautomated
+        :caseautomation: notautomated
 
-
-        @CaseLevel: System
+        :CaseLevel: System
         """
 
     @skip_if_not_set('ldap')
@@ -432,24 +404,22 @@ class LDAPAuthTestCase(UITestCase):
         """Assure that user has roles/can access feature areas for
         additional roles assigned outside any roles assigned by his group
 
-        @id: 52a2a22f-4862-4cdf-986e-cff18bab08fd
+        :id: 52a2a22f-4862-4cdf-986e-cff18bab08fd
 
-        @setup: Assign roles to UserGroup and users to this group;
-        subsequently assign specified roles to the user(s) --
-        roles that are not part of the larger UserGroup
+        :setup: Assign roles to UserGroup and users to this group; subsequently
+            assign specified roles to the user(s) -- roles that are not part of
+            the larger UserGroup
 
-        @steps:
-        1. Login to sat6 with LDAP user and attempt to access areas assigned
-        specifically to user.
+        :steps: Login to sat6 with LDAP user and attempt to access areas
+            assigned specifically to user.
 
-        @assert: User can access not only those feature areas in his
-        UserGroup but those additional feature areas / roles assigned
-        specifically to user
+        :assert: User can access not only those feature areas in his UserGroup
+            but those additional feature areas / roles assigned specifically to
+            user
 
-        @caseautomation: notautomated
+        :caseautomation: notautomated
 
-
-        @CaseLevel: System
+        :CaseLevel: System
         """
 
     @skip_if_not_set('ldap')
@@ -458,20 +428,19 @@ class LDAPAuthTestCase(UITestCase):
     def test_positive_ldap_auth_usergroup_user_add(self):
         """New user added to UserGroup inherits roles
 
-        @id: 9df694d4-7fa5-4883-ae17-b996c2734f41
+        :id: 9df694d4-7fa5-4883-ae17-b996c2734f41
 
-        @setup: UserGroup with specified roles.
+        :setup: UserGroup with specified roles.
 
-        @steps:
-        1. Login to sat6 with LDAP user that is not part of UserGroup.
-        2. On LDAP server, assign user to aforementioned UserGroup.
-        3. Attempt once more to sign in with user.
+        :steps:
+            1. Login to sat6 with LDAP user that is not part of UserGroup.
+            2. On LDAP server, assign user to aforementioned UserGroup.
+            3. Attempt once more to sign in with user.
 
-        @assert: User can access feature areas as defined by roles in the
-        UserGroup of which he is a part.
+        :assert: User can access feature areas as defined by roles in the
+            UserGroup of which he is a part.
 
-        @caseautomation: notautomated
+        :caseautomation: notautomated
 
-
-        @CaseLevel: System
+        :CaseLevel: System
         """

--- a/tests/foreman/ui/test_ldapauthsource.py
+++ b/tests/foreman/ui/test_ldapauthsource.py
@@ -1,18 +1,18 @@
 """Test class for Active Directory Feature
 
-@Requirement: Ldapauthsource
+:Requirement: Ldapauthsource
 
-@CaseAutomation: Automated
+:CaseAutomation: Automated
 
-@CaseLevel: Acceptance
+:CaseLevel: Acceptance
 
-@CaseComponent: UI
+:CaseComponent: UI
 
-@TestType: Functional
+:TestType: Functional
 
-@CaseImportance: High
+:CaseImportance: High
 
-@Upstream: No
+:Upstream: No
 """
 from robottelo.config import settings
 from robottelo.constants import LDAP_ATTR, LDAP_SERVER_TYPE
@@ -40,14 +40,14 @@ class LDAPAuthSourceTestCase(UITestCase):
     def test_positive_create_withad(self):
         """Create LDAP authentication with AD
 
-        @id: 02693108-83d9-4b2b-969e-2d8a00d0a935
+        :id: 02693108-83d9-4b2b-969e-2d8a00d0a935
 
-        @steps:
+        :steps:
 
-        1. Create a new LDAP Auth source with AD.
-        2. Fill in all the fields appropriately for AD.
+            1. Create a new LDAP Auth source with AD.
+            2. Fill in all the fields appropriately for AD.
 
-        @Assert: Whether creating LDAP Auth with AD is successful.
+        :Assert: Whether creating LDAP Auth with AD is successful.
         """
         with Session(self.browser) as session:
             for server_name in generate_strings_list():
@@ -74,14 +74,14 @@ class LDAPAuthSourceTestCase(UITestCase):
     def test_positive_delete_withad(self):
         """Delete LDAP authentication with AD
 
-        @id: 0fbb09d3-7a19-468d-898c-1484a5682793
+        :id: 0fbb09d3-7a19-468d-898c-1484a5682793
 
-        @steps:
+        :steps:
 
-        1. Create a new LDAP Auth source with AD.
-        2. Delete LDAP Auth source with AD.
+            1. Create a new LDAP Auth source with AD.
+            2. Delete LDAP Auth source with AD.
 
-        @Assert: Whether deleting LDAP Auth with AD is successful.
+        :Assert: Whether deleting LDAP Auth with AD is successful.
         """
         with Session(self.browser) as session:
             for server_name in generate_strings_list():

--- a/tests/foreman/ui/test_lifecycleenvironment.py
+++ b/tests/foreman/ui/test_lifecycleenvironment.py
@@ -1,19 +1,19 @@
 # -*- encoding: utf-8 -*-
 """Test class for Life cycle environments UI
 
-@Requirement: Lifecycleenvironment
+:Requirement: Lifecycleenvironment
 
-@CaseAutomation: Automated
+:CaseAutomation: Automated
 
-@CaseLevel: Acceptance
+:CaseLevel: Acceptance
 
-@CaseComponent: UI
+:CaseComponent: UI
 
-@TestType: Functional
+:TestType: Functional
 
-@CaseImportance: High
+:CaseImportance: High
 
-@Upstream: No
+:Upstream: No
 """
 from itertools import chain
 
@@ -48,9 +48,9 @@ class LifeCycleEnvironmentTestCase(UITestCase):
     def test_positive_create(self):
         """Create content environment with minimal input parameters
 
-        @id: 2c3a9c4c-3508-4d75-8f60-8bc6f7c0717f
+        :id: 2c3a9c4c-3508-4d75-8f60-8bc6f7c0717f
 
-        @Assert: Environment is created
+        :Assert: Environment is created
         """
         with Session(self.browser) as session:
             for name in generate_strings_list():
@@ -69,11 +69,11 @@ class LifeCycleEnvironmentTestCase(UITestCase):
     def test_positive_create_chain(self):
         """Create Content Environment in a chain
 
-        @id: ed3d2c88-ef0a-4a1a-9f11-5bdb2119fc18
+        :id: ed3d2c88-ef0a-4a1a-9f11-5bdb2119fc18
 
-        @Assert: Environment is created
+        :Assert: Environment is created
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         env1_name = gen_string('alpha')
         env2_name = gen_string('alpha')
@@ -100,9 +100,9 @@ class LifeCycleEnvironmentTestCase(UITestCase):
     def test_positive_delete(self):
         """Create Content Environment and delete it
 
-        @id: fe2d9b10-fc46-47e3-827c-6f87d725ed8f
+        :id: fe2d9b10-fc46-47e3-827c-6f87d725ed8f
 
-        @Assert: Environment is deleted
+        :Assert: Environment is deleted
         """
         name = gen_string('alpha')
         with Session(self.browser) as session:
@@ -121,9 +121,9 @@ class LifeCycleEnvironmentTestCase(UITestCase):
     def test_positive_update(self):
         """Create Content Environment and update it
 
-        @id: 5cf64c5b-2105-4384-8630-965d9b8e3024
+        :id: 5cf64c5b-2105-4384-8630-965d9b8e3024
 
-        @Assert: Environment is updated
+        :Assert: Environment is updated
         """
         name = gen_string('alpha')
         new_name = gen_string('alpha')
@@ -144,38 +144,36 @@ class LifeCycleEnvironmentTestCase(UITestCase):
         """Verify that no error is thrown when creating an evironment after
         registering a host to Library.
 
-        @id: feab2298-4faf-470b-b906-8b50d148f52a
+        :id: feab2298-4faf-470b-b906-8b50d148f52a
 
-        @BZ: 1348727
+        :BZ: 1348727
 
-        @Setup:
+        :Setup:
 
-        1. Create an organization.
-        2. Create a new content host.
-        3. Register the content host to the Library environment.
+            1. Create an organization.
+            2. Create a new content host.
+            3. Register the content host to the Library environment.
 
-        @Steps:
+        :Steps: Create a new environment.
 
-        1. Create a new environment.
+        :Assert: The environment is created without any errors.
 
-        @Assert: The environment is created without any errors.
+        :CaseLevel: Integration
 
-        @CaseLevel: Integration
-
-        @caseautomation: notautomated
+        :caseautomation: notautomated
         """
 
     @tier1
     def test_positive_env_list_fits_browser_screen(self):
         """Check if long list of lifecycle environments fits into screen
 
-        @id: 63b985b0-c847-11e6-92ad-68f72889dc7f
+        :id: 63b985b0-c847-11e6-92ad-68f72889dc7f
 
-        @Setup: save 8+ chained lifecycles environments
+        :Setup: save 8+ chained lifecycles environments
 
-        @BZ: 1295922
+        :BZ: 1295922
 
-        @Assert: lifecycle environments table fits screen
+        :Assert: lifecycle environments table fits screen
         """
         with Session(self.browser) as session:
             env_names = [gen_string('alpha') for _ in range(11)]
@@ -200,39 +198,39 @@ class LifeCycleEnvironmentTestCase(UITestCase):
         """As a custom user attempt to view a lifecycle environment created
         by admin user
 
-        @id: 768b647b-c530-4eca-9caa-38cf8622f36d
+        :id: 768b647b-c530-4eca-9caa-38cf8622f36d
 
-        @BZ: 1420511
+        :BZ: 1420511
 
-        @Steps:
+        :Steps:
 
-        As an admin user:
+            As an admin user:
 
-        1. Create an additional lifecycle environments other than Library
-        2. Create a user without administrator privileges
-        3. Create a role with the the following permissions:
+            1. Create an additional lifecycle environments other than Library
+            2. Create a user without administrator privileges
+            3. Create a role with the the following permissions:
 
-        * (Miscellaneous): access_dashboard
-        * Lifecycle Environment:
+                * (Miscellaneous): access_dashboard
+                * Lifecycle Environment:
 
-          * edit_lifecycle_environments
-          * promote_or_remove_content_views_to_environment
-          * view_lifecycle_environments
+                * edit_lifecycle_environments
+                * promote_or_remove_content_views_to_environment
+                * view_lifecycle_environments
 
-        * Location: view_locations
-        * Organization: view_organizations
+                * Location: view_locations
+                * Organization: view_organizations
 
-        4. Assign the created role to the custom user
+            4. Assign the created role to the custom user
 
-        As a custom user:
+            As a custom user:
 
-        1. Log in
-        2. Navigate to Content -> Lifecycle Environments
+            1. Log in
+            2. Navigate to Content -> Lifecycle Environments
 
-        @Assert: The additional lifecycle environment is viewable
-        and accessible by the custom user.
+        :Assert: The additional lifecycle environment is viewable and
+            accessible by the custom user.
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         role_name = gen_string('alpha')
         env_name = gen_string('alpha')

--- a/tests/foreman/ui/test_location.py
+++ b/tests/foreman/ui/test_location.py
@@ -1,19 +1,19 @@
 # -*- encoding: utf-8 -*-
 """Test class for Locations UI
 
-@Requirement: Location
+:Requirement: Location
 
-@CaseAutomation: Automated
+:CaseAutomation: Automated
 
-@CaseLevel: Acceptance
+:CaseLevel: Acceptance
 
-@CaseComponent: UI
+:CaseComponent: UI
 
-@TestType: Functional
+:TestType: Functional
 
-@CaseImportance: High
+:CaseImportance: High
 
-@Upstream: No
+:Upstream: No
 """
 
 from fauxfactory import gen_ipaddr, gen_string
@@ -86,9 +86,9 @@ class LocationTestCase(UITestCase):
     def test_positive_auto_search(self):
         """Can auto-complete search for location by partial name
 
-        @id: 6aaf104b-481a-4dd9-8639-8ddb1e4d6828
+        :id: 6aaf104b-481a-4dd9-8639-8ddb1e4d6828
 
-        @assert: Created location can be auto search by its partial name
+        :assert: Created location can be auto search by its partial name
         """
         loc_name = gen_string('alpha')
         with Session(self.browser) as session:
@@ -110,9 +110,9 @@ class LocationTestCase(UITestCase):
     def test_positive_create_with_name(self):
         """Create Location with valid name only
 
-        @id: 92b23082-09e4-49e1-92e1-d6d89d5180ac
+        :id: 92b23082-09e4-49e1-92e1-d6d89d5180ac
 
-        @assert: Location is created, label is auto-generated
+        :assert: Location is created, label is auto-generated
         """
         with Session(self.browser) as session:
             for loc_name in generate_strings_list():
@@ -125,9 +125,9 @@ class LocationTestCase(UITestCase):
     def test_negative_create_with_invalid_names(self):
         """Create location with invalid name
 
-        @id: 85f05458-b86c-4d94-a412-ea03412c4588
+        :id: 85f05458-b86c-4d94-a412-ea03412c4588
 
-        @assert: location is not created
+        :assert: location is not created
         """
         with Session(self.browser) as session:
             for loc_name in invalid_values_list(interface='ui'):
@@ -143,9 +143,9 @@ class LocationTestCase(UITestCase):
         """Create location with valid values, then create a new one with same
         values.
 
-        @id: 33983f00-406b-4289-b9e2-ffe6901bf99d
+        :id: 33983f00-406b-4289-b9e2-ffe6901bf99d
 
-        @assert: location is not created
+        :assert: location is not created
         """
         loc_name = gen_string('utf8')
         with Session(self.browser) as session:
@@ -161,11 +161,11 @@ class LocationTestCase(UITestCase):
     def test_positive_create_with_location_and_org(self):
         """Create and select both organization and location.
 
-        @id: a1640ada-d4e9-447e-9e1b-40d17e1ede7e
+        :id: a1640ada-d4e9-447e-9e1b-40d17e1ede7e
 
-        @assert: Both organization and location are selected.
+        :assert: Both organization and location are selected.
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         with Session(self.browser) as session:
             for test_data in valid_org_loc_data():
@@ -188,9 +188,9 @@ class LocationTestCase(UITestCase):
     def test_positive_update_name(self):
         """Create Location with valid values then update its name
 
-        @id: 79d8dbbb-9b7f-4482-a0f5-4fe72713d575
+        :id: 79d8dbbb-9b7f-4482-a0f5-4fe72713d575
 
-        @assert: Location name is updated
+        :assert: Location name is updated
         """
         loc_name = gen_string('alpha')
         with Session(self.browser) as session:
@@ -210,9 +210,9 @@ class LocationTestCase(UITestCase):
         """Create Location with valid values then fail to update
         its name
 
-        @id: 57fed455-47f0-4b7c-a58e-3d8f6d761da9
+        :id: 57fed455-47f0-4b7c-a58e-3d8f6d761da9
 
-        @assert: Location name is not updated
+        :assert: Location name is not updated
         """
         loc_name = gen_string('alphanumeric')
         with Session(self.browser) as session:
@@ -229,9 +229,9 @@ class LocationTestCase(UITestCase):
     def test_positive_delete(self):
         """Create location with valid values then delete it.
 
-        @id: b7664152-9398-499c-b165-3107f4350ba4
+        :id: b7664152-9398-499c-b165-3107f4350ba4
 
-        @assert: Location is deleted
+        :assert: Location is deleted
         """
         with Session(self.browser) as session:
             for loc_name in generate_strings_list():
@@ -245,11 +245,11 @@ class LocationTestCase(UITestCase):
     def test_positive_add_subnet(self):
         """Add a subnet by using location name and subnet name
 
-        @id: fe70ffba-e594-48d5-b2c5-be93e827cc60
+        :id: fe70ffba-e594-48d5-b2c5-be93e827cc60
 
-        @assert: subnet is added
+        :assert: subnet is added
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         strategy, value = common_locators['entity_deselect']
         with Session(self.browser) as session:
@@ -276,11 +276,11 @@ class LocationTestCase(UITestCase):
     def test_positive_add_domain(self):
         """Add a domain to a Location
 
-        @id: 4f50f5cb-64eb-4790-b4c5-62d67669f48f
+        :id: 4f50f5cb-64eb-4790-b4c5-62d67669f48f
 
-        @assert: Domain is added to Location
+        :assert: Domain is added to Location
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         strategy, value = common_locators['entity_deselect']
         with Session(self.browser) as session:
@@ -303,11 +303,11 @@ class LocationTestCase(UITestCase):
     def test_positive_add_user(self):
         """Create user then add that user by using the location name
 
-        @id: bf9b3fc2-6193-4edc-aaec-cd7b87f0804c
+        :id: bf9b3fc2-6193-4edc-aaec-cd7b87f0804c
 
-        @assert: User is added to location
+        :assert: User is added to location
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         strategy, value = common_locators['entity_deselect']
         with Session(self.browser) as session:
@@ -339,9 +339,9 @@ class LocationTestCase(UITestCase):
     def test_positive_check_all_values_hostgroup(self):
         """check whether host group has the 'All values' checked.
 
-        @id: ca2f2522-ba34-4d20-87f4-7777ec9a1282
+        :id: ca2f2522-ba34-4d20-87f4-7777ec9a1282
 
-        @assert: host group 'All values' checkbox is checked.
+        :assert: host group 'All values' checkbox is checked.
         """
         loc_name = gen_string('alpha')
         with Session(self.browser) as session:
@@ -361,11 +361,11 @@ class LocationTestCase(UITestCase):
     def test_positive_add_hostgroup(self):
         """Add a hostgroup by using the location name and hostgroup name
 
-        @id: e998d20c-e201-4675-b45f-8768f59584da
+        :id: e998d20c-e201-4675-b45f-8768f59584da
 
-        @assert: hostgroup is added to location
+        :assert: hostgroup is added to location
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         strategy, value = common_locators['all_values_selection']
         with Session(self.browser) as session:
@@ -387,11 +387,11 @@ class LocationTestCase(UITestCase):
     def test_positive_add_org(self):
         """Add a organization by using the location name
 
-        @id: 27d56d64-6866-46b6-962d-1ac2a11ae136
+        :id: 27d56d64-6866-46b6-962d-1ac2a11ae136
 
-        @assert: organization is added to location
+        :assert: organization is added to location
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         strategy, value = common_locators['entity_deselect']
         with Session(self.browser) as session:
@@ -416,11 +416,11 @@ class LocationTestCase(UITestCase):
     def test_add_environment(self):
         """Add environment by using location name and environment name
 
-        @id: bbca1af0-a31f-4096-bc6e-bb341ffed575
+        :id: bbca1af0-a31f-4096-bc6e-bb341ffed575
 
-        @assert: environment is added
+        :assert: environment is added
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         strategy, value = common_locators['entity_deselect']
         with Session(self.browser) as session:
@@ -445,11 +445,11 @@ class LocationTestCase(UITestCase):
         """Add compute resource using the location name and compute resource
         name
 
-        @id: 1d24414a-666d-490d-89b9-cd0704684cdd
+        :id: 1d24414a-666d-490d-89b9-cd0704684cdd
 
-        @assert: compute resource is added successfully
+        :assert: compute resource is added successfully
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         strategy, value = common_locators['entity_deselect']
         with Session(self.browser) as session:
@@ -476,11 +476,11 @@ class LocationTestCase(UITestCase):
     def test_positive_add_medium(self):
         """Add medium by using the location name and medium name
 
-        @id: 738c5ff1-ef09-466f-aaac-64f194cac78d
+        :id: 738c5ff1-ef09-466f-aaac-64f194cac78d
 
-        @assert: medium is added
+        :assert: medium is added
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         strategy, value = common_locators['entity_deselect']
         with Session(self.browser) as session:
@@ -507,9 +507,9 @@ class LocationTestCase(UITestCase):
     def test_positive_check_all_values_template(self):
         """check whether config template has the 'All values' checked.
 
-        @id: 358cf1c0-4187-4b5a-b900-5971e708b83f
+        :id: 358cf1c0-4187-4b5a-b900-5971e708b83f
 
-        @assert: configtemplate 'All values' checkbox is checked.
+        :assert: configtemplate 'All values' checkbox is checked.
         """
         loc_name = gen_string('alpha')
         with Session(self.browser) as session:
@@ -526,11 +526,11 @@ class LocationTestCase(UITestCase):
     def test_positive_add_template(self):
         """Add config template by using location name and config template name.
 
-        @id: 8faf60d1-f4d6-4a58-a484-606a42957ce7
+        :id: 8faf60d1-f4d6-4a58-a484-606a42957ce7
 
-        @assert: config template is added.
+        :assert: config template is added.
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         strategy, value = common_locators['all_values_selection']
         with Session(self.browser) as session:
@@ -558,11 +558,11 @@ class LocationTestCase(UITestCase):
     def test_positive_remove_environment(self):
         """Remove environment by using location name & environment name
 
-        @id: eaf08f82-d76c-4bd5-bc9b-ac91ca409b81
+        :id: eaf08f82-d76c-4bd5-bc9b-ac91ca409b81
 
-        @assert: environment is removed from Location
+        :assert: environment is removed from Location
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         strategy, value = common_locators['entity_select']
         strategy1, value1 = common_locators['entity_deselect']
@@ -602,11 +602,11 @@ class LocationTestCase(UITestCase):
     def test_positive_remove_subnet(self):
         """Remove subnet by using location name and subnet name
 
-        @id: 53bc28a4-1fe1-4628-b7b9-18ea4b07dfc8
+        :id: 53bc28a4-1fe1-4628-b7b9-18ea4b07dfc8
 
-        @assert: subnet is added then removed
+        :assert: subnet is added then removed
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         strategy, value = common_locators['entity_select']
         strategy1, value1 = common_locators['entity_deselect']
@@ -648,11 +648,11 @@ class LocationTestCase(UITestCase):
         """Add a domain to an location and remove it by location name and
         domain name
 
-        @id: 39374e24-2b38-47f4-b69b-c2b0ca0d754f
+        :id: 39374e24-2b38-47f4-b69b-c2b0ca0d754f
 
-        @assert: the domain is removed from the location
+        :assert: the domain is removed from the location
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         strategy, value = common_locators['entity_select']
         strategy1, value1 = common_locators['entity_deselect']
@@ -693,11 +693,11 @@ class LocationTestCase(UITestCase):
         """Create admin users then add user and remove it by using the location
         name
 
-        @id: c2dd189d-c928-4051-ae38-c08a15b95879
+        :id: c2dd189d-c928-4051-ae38-c08a15b95879
 
-        @assert: The user is added then removed from the location
+        :assert: The user is added then removed from the location
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         strategy, value = common_locators['entity_select']
         strategy1, value1 = common_locators['entity_deselect']
@@ -743,11 +743,11 @@ class LocationTestCase(UITestCase):
         """Add a hostgroup and remove it by using the location name and
         hostgroup name
 
-        @id: dd8c58af-3037-44c0-a7f7-5e8337f110c9
+        :id: dd8c58af-3037-44c0-a7f7-5e8337f110c9
 
-        @assert: hostgroup is added to location then removed
+        :assert: hostgroup is added to location then removed
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         strategy, value = common_locators['all_values_selection']
         with Session(self.browser) as session:
@@ -787,11 +787,11 @@ class LocationTestCase(UITestCase):
         """Remove compute resource by using the location name and compute
         resource name
 
-        @id: dae7c7ae-b162-4601-8727-f227d1544e09
+        :id: dae7c7ae-b162-4601-8727-f227d1544e09
 
-        @assert: compute resource is added then removed
+        :assert: compute resource is added then removed
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         strategy, value = common_locators['entity_select']
         strategy1, value1 = common_locators['entity_deselect']
@@ -834,11 +834,11 @@ class LocationTestCase(UITestCase):
     def test_positive_remove_medium(self):
         """Remove medium by using location name and medium name
 
-        @id: 61dece81-73bf-4f80-8894-ed7ca745120c
+        :id: 61dece81-73bf-4f80-8894-ed7ca745120c
 
-        @assert: medium is added then removed
+        :assert: medium is added then removed
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         strategy, value = common_locators['entity_select']
         strategy1, value1 = common_locators['entity_deselect']
@@ -880,11 +880,11 @@ class LocationTestCase(UITestCase):
     def test_positive_remove_template(self):
         """Remove config template
 
-        @id: f510eb04-6bbb-4153-bda0-a183d070b9f2
+        :id: f510eb04-6bbb-4153-bda0-a183d070b9f2
 
-        @assert: config template is added and then removed
+        :assert: config template is added and then removed
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         strategy, value = common_locators['all_values_selection']
         with Session(self.browser) as session:

--- a/tests/foreman/ui/test_login.py
+++ b/tests/foreman/ui/test_login.py
@@ -1,19 +1,19 @@
 # -*- encoding: utf-8 -*-
 """Test class for Login UI
 
-@Requirement: Login
+:Requirement: Login
 
-@CaseAutomation: Automated
+:CaseAutomation: Automated
 
-@CaseLevel: Acceptance
+:CaseLevel: Acceptance
 
-@CaseComponent: UI
+:CaseComponent: UI
 
-@TestType: Functional
+:TestType: Functional
 
-@CaseImportance: High
+:CaseImportance: High
 
-@Upstream: No
+:Upstream: No
 """
 
 from fauxfactory import gen_string
@@ -42,9 +42,9 @@ class LoginTestCase(UITestCase):
     def test_positive_login(self):
         """Login as an admin user
 
-        @id: 7ec027ec-4c51-460a-81f9-643e5bb2c5f5
+        :id: 7ec027ec-4c51-460a-81f9-643e5bb2c5f5
 
-        @Assert: Successfully logged in as an admin user
+        :Assert: Successfully logged in as an admin user
         """
         self.login.login(self.foreman_user,
                          self.foreman_password)
@@ -54,9 +54,9 @@ class LoginTestCase(UITestCase):
     def test_negative_login(self):
         """Login into application using invalid credentials
 
-        @id: 23090dce-b918-4a8e-8481-188ea76c376d
+        :id: 23090dce-b918-4a8e-8481-188ea76c376d
 
-        @Assert: Fails to login
+        :Assert: Fails to login
         """
         for test_data in invalid_credentials():
             with self.subTest(test_data):

--- a/tests/foreman/ui/test_medium.py
+++ b/tests/foreman/ui/test_medium.py
@@ -1,19 +1,19 @@
 # -*- encoding: utf-8 -*-
 """Test class for Medium UI
 
-@Requirement: Medium
+:Requirement: Medium
 
-@CaseAutomation: Automated
+:CaseAutomation: Automated
 
-@CaseLevel: Acceptance
+:CaseLevel: Acceptance
 
-@CaseComponent: UI
+:CaseComponent: UI
 
-@TestType: Functional
+:TestType: Functional
 
-@CaseImportance: High
+:CaseImportance: High
 
-@Upstream: No
+:Upstream: No
 """
 
 from fauxfactory import gen_string
@@ -34,9 +34,9 @@ class MediumTestCase(UITestCase):
     def test_positive_create(self):
         """Create a new media
 
-        @id: 17067a4d-a639-4187-a51b-1eae825e4f9c
+        :id: 17067a4d-a639-4187-a51b-1eae825e4f9c
 
-        @Assert: Media is created
+        :Assert: Media is created
         """
         with Session(self.browser) as session:
             for name in valid_data_list():
@@ -51,9 +51,9 @@ class MediumTestCase(UITestCase):
     def test_negative_create_with_too_long_name(self):
         """Create a new install media with 256 characters in name
 
-        @id: a15307a3-5a1f-4cca-8594-44e8f3295a51
+        :id: a15307a3-5a1f-4cca-8594-44e8f3295a51
 
-        @Assert: Media is not created
+        :Assert: Media is not created
         """
         name = gen_string('alpha', 256)
         path = INSTALL_MEDIUM_URL % name
@@ -68,9 +68,9 @@ class MediumTestCase(UITestCase):
     def test_negative_create_with_blank_name(self):
         """Create a new install media with blank and whitespace in name
 
-        @id: db7a58dd-8f4a-4443-be17-e5029e1c2b0e
+        :id: db7a58dd-8f4a-4443-be17-e5029e1c2b0e
 
-        @Assert: Media is not created
+        :Assert: Media is not created
         """
         path = INSTALL_MEDIUM_URL % gen_string('alpha', 6)
         with Session(self.browser) as session:
@@ -88,9 +88,9 @@ class MediumTestCase(UITestCase):
     def test_negative_create_with_same_name(self):
         """Create a new install media with same name
 
-        @id: 6379b9b4-a67e-4abf-b8b5-930e40b6c293
+        :id: 6379b9b4-a67e-4abf-b8b5-930e40b6c293
 
-        @Assert: Media is not created
+        :Assert: Media is not created
         """
         name = gen_string('alpha', 6)
         path = INSTALL_MEDIUM_URL % name
@@ -107,9 +107,9 @@ class MediumTestCase(UITestCase):
     def test_negative_create_without_path(self):
         """Create a new install media without media URL
 
-        @id: 8ccdd659-3c11-4266-848f-919f3ac853be
+        :id: 8ccdd659-3c11-4266-848f-919f3ac853be
 
-        @Assert: Media is not created
+        :Assert: Media is not created
         """
         name = gen_string('alpha', 6)
         with Session(self.browser) as session:
@@ -123,9 +123,9 @@ class MediumTestCase(UITestCase):
     def test_negative_create_medium_with_same_path(self):
         """Create an install media with an existing URL
 
-        @id: ce3367ef-5ad3-4d81-8174-fe5ba4eecb00
+        :id: ce3367ef-5ad3-4d81-8174-fe5ba4eecb00
 
-        @Assert: Media is not created
+        :Assert: Media is not created
         """
         name = gen_string('alpha', 6)
         new_name = gen_string('alpha', 6)
@@ -144,9 +144,9 @@ class MediumTestCase(UITestCase):
     def test_positive_delete(self):
         """Delete a media
 
-        @id: 08c982ef-e8de-4d50-97f5-b8803d7eb9ca
+        :id: 08c982ef-e8de-4d50-97f5-b8803d7eb9ca
 
-        @Assert: Media is deleted
+        :Assert: Media is deleted
         """
         name = gen_string('alpha', 6)
         path = INSTALL_MEDIUM_URL % name
@@ -159,9 +159,9 @@ class MediumTestCase(UITestCase):
     def test_positive_update(self):
         """Updates Install media with name, path, OS family
 
-        @id: 6926eaec-fe74-4171-bc8e-76e28926456b
+        :id: 6926eaec-fe74-4171-bc8e-76e28926456b
 
-        @Assert: Media is updated
+        :Assert: Media is updated
         """
         name = gen_string('alpha', 6)
         newname = gen_string('alpha', 4)

--- a/tests/foreman/ui/test_multinetwork.py
+++ b/tests/foreman/ui/test_multinetwork.py
@@ -1,19 +1,19 @@
 # -*- encoding: utf-8 -*-
 """Test class for Multi-Network Support feature
 
-@Requirement: Multinetwork
+:Requirement: Multinetwork
 
-@CaseAutomation: Automated
+:CaseAutomation: Automated
 
-@CaseLevel: Acceptance
+:CaseLevel: Acceptance
 
-@CaseComponent: UI
+:CaseComponent: UI
 
-@TestType: Functional
+:TestType: Functional
 
-@CaseImportance: High
+:CaseImportance: High
 
-@Upstream: No
+:Upstream: No
 """
 from robottelo.decorators import stubbed, tier3
 from robottelo.test import UITestCase
@@ -28,21 +28,21 @@ class MultinetworkTestCase(UITestCase):
         """Create host with default interface and set 'DHCP' for IPAM
         and BootMode for provisioning subnet
 
-        @id: e953dbf1-3592-48d6-b217-956676fd04d7
+        :id: e953dbf1-3592-48d6-b217-956676fd04d7
 
-        @Setup: Provisioning should be configured
+        :Setup: Provisioning should be configured
 
-        @Steps:
+        :Steps:
 
-        1. Set 'DHCP' for IPAM and BootMode for provisioning subnet
-        2. All other fields on subnet page should be filled
+            1. Set 'DHCP' for IPAM and BootMode for provisioning subnet
+            2. All other fields on subnet page should be filled
 
-        @Assert: Host should be provisioned with correct configuration under
-        /etc/sysconfig/network-scripts/ifcfg-<interface>
+        :Assert: Host should be provisioned with correct configuration under
+            /etc/sysconfig/network-scripts/ifcfg-<interface>
 
-        @caseautomation: notautomated
+        :caseautomation: notautomated
 
-        @CaseLevel: System
+        :CaseLevel: System
         """
 
     @stubbed()
@@ -52,23 +52,23 @@ class MultinetworkTestCase(UITestCase):
         'Internal DB' (without specifying start and end range) and BootMode
         set as 'DHCP' for provisioning subnet
 
-        @id: 558a92e9-e769-4093-8a38-4a3e2f820aa2
+        :id: 558a92e9-e769-4093-8a38-4a3e2f820aa2
 
-        @Setup: Provisioning should be configured
+        :Setup: Provisioning should be configured
 
-        @Steps:
+        :Steps:
 
-        1. Set IPAM with 'Internal DB' and BootMode with 'DHCP for provisioning
-           subnet
-        2. All other fields on subnet page should be filled except start and
-           end IP range
+            1. Set IPAM with 'Internal DB' and BootMode with 'DHCP for
+                provisioning subnet
+            2. All other fields on subnet page should be filled except start
+                and end IP range
 
-        @Assert: Host should be provisioned with correct configuration under
-        /etc/sysconfig/network-scripts/ifcfg-<interface>
+        :Assert: Host should be provisioned with correct configuration under
+            /etc/sysconfig/network-scripts/ifcfg-<interface>
 
-        @caseautomation: notautomated
+        :caseautomation: notautomated
 
-        @CaseLevel: System
+        :CaseLevel: System
         """
 
     @stubbed()
@@ -78,23 +78,23 @@ class MultinetworkTestCase(UITestCase):
         'Internal DB' (with start and end IP range) and BootMode set as
         'DHCP' for provisioning subnet
 
-        @id: c5d0eb65-33d6-4126-800c-ff3bf97e7fe0
+        :id: c5d0eb65-33d6-4126-800c-ff3bf97e7fe0
 
-        @Setup: Provisioning should be configured
+        :Setup: Provisioning should be configured
 
-        @Steps:
+        :Steps:
 
-        1. Set IPAM with 'Internal DB' and BootMode with 'DHCP for provisioning
-           subnet
-        2. All other fields on subnet page should be filled including start and
-           end IP range
+            1. Set IPAM with 'Internal DB' and BootMode with 'DHCP for
+                provisioning subnet
+            2. All other fields on subnet page should be filled including start
+                and end IP range
 
-        @Assert: Host should be provisioned with correct configuration under
-        /etc/sysconfig/network-scripts/ifcfg-<interface>
+        :Assert: Host should be provisioned with correct configuration under
+            /etc/sysconfig/network-scripts/ifcfg-<interface>
 
-        @caseautomation: notautomated
+        :caseautomation: notautomated
 
-        @CaseLevel: System
+        :CaseLevel: System
         """
 
     @stubbed()
@@ -104,23 +104,23 @@ class MultinetworkTestCase(UITestCase):
         'Internal DB' (with start and end IP range) and BootMode set as
         'Static' for provisioning subnet
 
-        @id: 9130917a-b0f5-4fb3-a516-733ee569218e
+        :id: 9130917a-b0f5-4fb3-a516-733ee569218e
 
-        @Setup: Provisioning should be configured
+        :Setup: Provisioning should be configured
 
-        @Steps:
+        :Steps:
 
-        1. Set IPAM with 'Internal DB' and BootMode with 'Static' for
-           provisioning subnet
-        2. All other fields on subnet page should be filled including start and
-           end IP range
+            1. Set IPAM with 'Internal DB' and BootMode with 'Static' for
+                provisioning subnet
+            2. All other fields on subnet page should be filled including start
+                and end IP range
 
-        @Assert: Host should be provisioned with correct configuration under
-        /etc/sysconfig/network-scripts/ifcfg-<interface>
+        :Assert: Host should be provisioned with correct configuration under
+            /etc/sysconfig/network-scripts/ifcfg-<interface>
 
-        @caseautomation: notautomated
+        :caseautomation: notautomated
 
-        @CaseLevel: System
+        :CaseLevel: System
         """
 
     @stubbed()
@@ -130,23 +130,23 @@ class MultinetworkTestCase(UITestCase):
         'Internal DB' (without start and end IP range) and BootMode set
         as 'Static' for provisioning subnet
 
-        @id: 36602343-377d-419a-8ad5-e0b37ceaddba
+        :id: 36602343-377d-419a-8ad5-e0b37ceaddba
 
-        @Setup: Provisioning should be configured
+        :Setup: Provisioning should be configured
 
-        @Steps:
+        :Steps:
 
-        1. Set IPAM with 'Internal DB' and BootMode with 'Static' for
-           provisioning subnet
-        2. All other fields on subnet page should be filled except start and
-           end IP range
+            1. Set IPAM with 'Internal DB' and BootMode with 'Static' for
+                provisioning subnet
+            2. All other fields on subnet page should be filled except start
+                and end IP range
 
-        @Assert: Host should be provisioned with correct configuration under
-        /etc/sysconfig/network-scripts/ifcfg-<interface>
+        :Assert: Host should be provisioned with correct configuration under
+            /etc/sysconfig/network-scripts/ifcfg-<interface>
 
-        @caseautomation: notautomated
+        :caseautomation: notautomated
 
-        @CaseLevel: System
+        :CaseLevel: System
         """
 
     @stubbed()
@@ -156,23 +156,23 @@ class MultinetworkTestCase(UITestCase):
         (with start and end IP range) and BootMode set as 'Static' for
         provisioning subnet
 
-        @id: 37b950e8-ad30-4edd-aca8-54a7e16315bc
+        :id: 37b950e8-ad30-4edd-aca8-54a7e16315bc
 
-        @Setup: Provisioning should be configured
+        :Setup: Provisioning should be configured
 
-        @Steps:
+        :Steps:
 
-        1. Set IPAM with 'DHCP' and BootMode with 'Static' for provisioning
-           subnet
-        2. All other fields on subnet page should be filled including start and
-           end IP range
+            1. Set IPAM with 'DHCP' and BootMode with 'Static' for provisioning
+                subnet
+            2. All other fields on subnet page should be filled including start
+                and end IP range
 
-        @Assert: Host should be provisioned with correct configuration under
-        /etc/sysconfig/network-scripts/ifcfg-<interface>
+        :Assert: Host should be provisioned with correct configuration under
+            /etc/sysconfig/network-scripts/ifcfg-<interface>
 
-        @caseautomation: notautomated
+        :caseautomation: notautomated
 
-        @CaseLevel: System
+        :CaseLevel: System
         """
 
     @stubbed()
@@ -182,23 +182,23 @@ class MultinetworkTestCase(UITestCase):
         (without start and end IP range) and BootMode set as 'Static' for
         provisioning subnet
 
-        @id: e1fe6337-8620-4b23-868a-ba2b95b4d046
+        :id: e1fe6337-8620-4b23-868a-ba2b95b4d046
 
-        @Setup: Provisioning should be configured
+        :Setup: Provisioning should be configured
 
-        @Steps:
+        :Steps:
 
-        1. Set IPAM with 'DHCP' and BootMode with 'Static' for provisioning
-           subnet
-        2. All other fields on subnet page should be filled except start and
-           end IP range
+            1. Set IPAM with 'DHCP' and BootMode with 'Static' for provisioning
+                subnet
+            2. All other fields on subnet page should be filled except start
+                and end IP range
 
-        @Assert: Host should be provisioned with correct configuration under
-        /etc/sysconfig/network-scripts/ifcfg-<interface>
+        :Assert: Host should be provisioned with correct configuration under
+            /etc/sysconfig/network-scripts/ifcfg-<interface>
 
-        @caseautomation: notautomated
+        :caseautomation: notautomated
 
-        @CaseLevel: System
+        :CaseLevel: System
         """
 
     @stubbed()
@@ -207,22 +207,22 @@ class MultinetworkTestCase(UITestCase):
         """Create host with default interface when IPAM set as 'None'
         and BootMode set as 'Static' for provisioning subnet
 
-        @id: 693725c9-5c46-4ea8-8f22-96e2a0808563
+        :id: 693725c9-5c46-4ea8-8f22-96e2a0808563
 
-        @Setup: Provisioning should be configured
+        :Setup: Provisioning should be configured
 
-        @Steps:
+        :Steps:
 
-        1. Set IPAM with 'None' and BootMode with 'Static' for provisioning
-           subnet
-        2. All other fields on subnet page should be filled
+            1. Set IPAM with 'None' and BootMode with 'Static' for provisioning
+                subnet
+            2. All other fields on subnet page should be filled
 
-        @Assert: Host should be provisioned with correct configuration under
-        /etc/sysconfig/network-scripts/ifcfg-<interface>
+        :Assert: Host should be provisioned with correct configuration under
+            /etc/sysconfig/network-scripts/ifcfg-<interface>
 
-        @caseautomation: notautomated
+        :caseautomation: notautomated
 
-        @CaseLevel: System
+        :CaseLevel: System
         """
 
     @stubbed()
@@ -231,22 +231,22 @@ class MultinetworkTestCase(UITestCase):
         """Create host with default interface when IPAM set as 'None'
         and BootMode set as 'DHCP' for provisioning subnet
 
-        @id: 8feea115-ecf3-4f1d-a579-484188377a9d
+        :id: 8feea115-ecf3-4f1d-a579-484188377a9d
 
-        @Setup: Provisioning should be configured
+        :Setup: Provisioning should be configured
 
-        @Steps:
+        :Steps:
 
-        1. Set IPAM with 'None' and BootMode with 'DHCP' for provisioning
-           subnet
-        2. All other fields on subnet page should be filled
+            1. Set IPAM with 'None' and BootMode with 'DHCP' for provisioning
+                subnet
+            2. All other fields on subnet page should be filled
 
-        @Assert: Host should be provisioned with correct configuration under
-        /etc/sysconfig/network-scripts/ifcfg-<interface>
+        :Assert: Host should be provisioned with correct configuration under
+            /etc/sysconfig/network-scripts/ifcfg-<interface>
 
-        @caseautomation: notautomated
+        :caseautomation: notautomated
 
-        @CaseLevel: System
+        :CaseLevel: System
         """
 
     @stubbed()
@@ -255,28 +255,28 @@ class MultinetworkTestCase(UITestCase):
         """Add an alias interface with mac different than
         primary interface's mac
 
-        @id: 93671234-77af-494d-8d29-8d7255c94437
+        :id: 93671234-77af-494d-8d29-8d7255c94437
 
-        @Setup: Provisioning should be configured
+        :Setup: Provisioning should be configured
 
-        @Steps:
+        :Steps:
 
-        1. Go to 'Network' tab of 'New host' page
-        2. Click on 'Add Interface' from 'Network tab
-        3. Choose Type: 'Interface'
-        4. mac address: should be different from primary interface
-        5. Identifier: eth0:0
-        6. Select 'Managed'
-        7. Select 'Virtual Nic'
-        8. attached_to: identifier of primary interface(eth0)
-        9. Fill all other details correctly in new host form and submit it
+            1. Go to 'Network' tab of 'New host' page
+            2. Click on 'Add Interface' from 'Network tab
+            3. Choose Type: 'Interface'
+            4. mac address: should be different from primary interface
+            5. Identifier: eth0:0
+            6. Select 'Managed'
+            7. Select 'Virtual Nic'
+            8. attached_to: identifier of primary interface(eth0)
+            9. Fill all other details correctly in new host form and submit it
 
-        @Assert: Validation error should be raised as mac address of alias
-        interface should be same as of primary interface
+        :Assert: Validation error should be raised as mac address of alias
+            interface should be same as of primary interface
 
-        @caseautomation: notautomated
+        :caseautomation: notautomated
 
-        @CaseLevel: System
+        :CaseLevel: System
         """
 
     @stubbed()
@@ -284,26 +284,26 @@ class MultinetworkTestCase(UITestCase):
     def test_negative_add_alias_interface_without_nic(self):
         """Add an alias interface without selecting virtual nic
 
-        @id: bf840727-b9a0-400e-9167-f1cdbca99546
+        :id: bf840727-b9a0-400e-9167-f1cdbca99546
 
-        @Setup: Provisioning should be configured
+        :Setup: Provisioning should be configured
 
-        @Steps:
+        :Steps:
 
-        1. Go to 'Network' tab of 'New host' page
-        2. Click on 'Add Interface' from 'Network tab
-        3. Choose Type: 'Interface'
-        4. mac address: mac should be same as of primary interface
-        5. Identifier: eth0:0
-        6. Select 'Managed'
-        7. Fill all other details correctly in new host form and submit it
+            1. Go to 'Network' tab of 'New host' page
+            2. Click on 'Add Interface' from 'Network tab
+            3. Choose Type: 'Interface'
+            4. mac address: mac should be same as of primary interface
+            5. Identifier: eth0:0
+            6. Select 'Managed'
+            7. Fill all other details correctly in new host form and submit it
 
-        @Assert: Validation error should be raised as two nics can not have
-        same mac
+        :Assert: Validation error should be raised as two nics can not have
+            same mac
 
-        @caseautomation: notautomated
+        :caseautomation: notautomated
 
-        @CaseLevel: System
+        :CaseLevel: System
         """
 
     @stubbed()
@@ -312,28 +312,28 @@ class MultinetworkTestCase(UITestCase):
         """Add an alias interface without defining
         'attached_to' interface under 'Virtual Nic'
 
-        @id: 2f9273fb-a598-439c-af44-fec11548d918
+        :id: 2f9273fb-a598-439c-af44-fec11548d918
 
-        @Setup: Provisioning should be configured
+        :Setup: Provisioning should be configured
 
-        @Steps:
+        :Steps:
 
-        1. Go to 'Network' tab of 'New host' page
-        2. Click on 'Add Interface' from 'Network tab
-        3. Choose Type: 'Interface'
-        4. mac address: mac should be same as of primary interface
-        5. Identifier: eth0:0
-        6. Select 'Managed'
-        7. Select 'Virtual Nic'
-        8. Do not specify anything under 'attached_to'
-        9. Fill all other details correctly in new host form and submit it
+            1. Go to 'Network' tab of 'New host' page
+            2. Click on 'Add Interface' from 'Network tab
+            3. Choose Type: 'Interface'
+            4. mac address: mac should be same as of primary interface
+            5. Identifier: eth0:0
+            6. Select 'Managed'
+            7. Select 'Virtual Nic'
+            8. Do not specify anything under 'attached_to'
+            9. Fill all other details correctly in new host form and submit it
 
-        @Assert: Validation error should be raised as attached_to is mandatory
-        option to create alias interface
+        :Assert: Validation error should be raised as attached_to is mandatory
+            option to create alias interface
 
-        @caseautomation: notautomated
+        :caseautomation: notautomated
 
-        @CaseLevel: System
+        :CaseLevel: System
         """
 
     @stubbed()
@@ -342,31 +342,31 @@ class MultinetworkTestCase(UITestCase):
         """Add an alias interface when bootMode set to 'DHCP'
         mode under selected subnet
 
-        @id: 9f2a916c-f8df-4d8b-b597-916f27d89073
+        :id: 9f2a916c-f8df-4d8b-b597-916f27d89073
 
-        @Setup: Provisioning should be configured
+        :Setup: Provisioning should be configured
 
-        @Steps:
+        :Steps:
 
-        1. Go to 'Network' tab of 'New host' page
-        2. Click on 'Add Interface' from 'Network tab
-        3. Choose Type: 'Interface'
-        4. mac address: mac should be same as of primary interface
-        5. Identifier: eth0:0
-        6. Select 'Managed'
-        7. Select 'Virtual Nic'
-        8. attached_to: identifier of primary interface(eth0)
-        9. Go to Infrastructure -> Subnet
-        10. Set IPAM mode to 'Internal DB'
-        11. BootMode 'DHCP'
-        12. Fill all other details correctly in new host form and submit it
+            1. Go to 'Network' tab of 'New host' page
+            2. Click on 'Add Interface' from 'Network tab
+            3. Choose Type: 'Interface'
+            4. mac address: mac should be same as of primary interface
+            5. Identifier: eth0:0
+            6. Select 'Managed'
+            7. Select 'Virtual Nic'
+            8. attached_to: identifier of primary interface(eth0)
+            9. Go to Infrastructure -> Subnet
+            10. Set IPAM mode to 'Internal DB'
+            11. BootMode 'DHCP'
+            12. Fill all other details correctly in new host form and submit it
 
-        @Assert: Validation error should be raised as you can't configure alias
-        interface in 'DHCP' mode.
+        :Assert: Validation error should be raised as you can't configure alias
+            interface in 'DHCP' mode.
 
-        @caseautomation: notautomated
+        :caseautomation: notautomated
 
-        @CaseLevel: System
+        :CaseLevel: System
         """
 
     @stubbed()
@@ -375,32 +375,32 @@ class MultinetworkTestCase(UITestCase):
         """Add an alias interface when bootMode set to 'Static'
         mode under selected subnet
 
-        @id: dc8a9056-bc1c-43b6-80b8-f9a105264755
+        :id: dc8a9056-bc1c-43b6-80b8-f9a105264755
 
-        @Setup: Provisioning should be configured
+        :Setup: Provisioning should be configured
 
-        @Steps:
+        :Steps:
 
-        1. Go to 'Network' tab of 'New host' page
-        2. Click on 'Add Interface' from 'Network tab
-        3. Choose Type: 'Interface'
-        4. mac address: mac should be same as of primary interface
-        5. Identifier: eth0:0
-        6. Select 'Managed'
-        7. Select 'Virtual Nic'
-        8. attached_to: identifier of primary interface(eth0)
-        9. Go to Infrastructure → Subnet
-        10. Set IPAM mode to 'Internal DB'
-        11. BootMode 'Static'
-        12. Fill all other details correctly in new host form and submit it
+            1. Go to 'Network' tab of 'New host' page
+            2. Click on 'Add Interface' from 'Network tab
+            3. Choose Type: 'Interface'
+            4. mac address: mac should be same as of primary interface
+            5. Identifier: eth0:0
+            6. Select 'Managed'
+            7. Select 'Virtual Nic'
+            8. attached_to: identifier of primary interface(eth0)
+            9. Go to Infrastructure → Subnet
+            10. Set IPAM mode to 'Internal DB'
+            11. BootMode 'Static'
+            12. Fill all other details correctly in new host form and submit it
 
-        @Assert: Interface should be configured successfully and correct
-        configuration should displayed on proviisoned host
-        under /etc/sysconfig/network-scripts/ifcfg-<interface_name>
+        :Assert: Interface should be configured successfully and correct
+            configuration should displayed on proviisoned host under
+            /etc/sysconfig/network-scripts/ifcfg-<interface_name>
 
-        @caseautomation: notautomated
+        :caseautomation: notautomated
 
-        @CaseLevel: System
+        :CaseLevel: System
         """
 
     @stubbed()
@@ -408,30 +408,30 @@ class MultinetworkTestCase(UITestCase):
     def test_negative_add_alias_interface_same(self):
         """Add an interface with same identifier of exiting interface
 
-        @id: b976fe33-6b08-4f64-ba46-d32601e6f71f
+        :id: b976fe33-6b08-4f64-ba46-d32601e6f71f
 
-        @Setup: Provisioning should be configured
+        :Setup: Provisioning should be configured
 
-        @Steps:
+        :Steps:
 
-        1. Go to 'Network' tab of 'New host' page
-        2. Click on 'Add Interface' from 'Network tab
-        3. Choose Type: 'Interface'
-        4. mac address: mac should be same as of primary interface
-        5. Identifier: eth0:0
-        6. Select 'Managed'
-        7. Select 'Virtual Nic'
-        8. attached_to: identifier of primary interface(eth0)
-        9. Go to Infrastructure → Subnet
-        10. Set IPAM mode to 'Internal DB'
-        11. BootMode 'Static'
-        12. Fill all other details correctly in new host form and submit it
+            1. Go to 'Network' tab of 'New host' page
+            2. Click on 'Add Interface' from 'Network tab
+            3. Choose Type: 'Interface'
+            4. mac address: mac should be same as of primary interface
+            5. Identifier: eth0:0
+            6. Select 'Managed'
+            7. Select 'Virtual Nic'
+            8. attached_to: identifier of primary interface(eth0)
+            9. Go to Infrastructure → Subnet
+            10. Set IPAM mode to 'Internal DB'
+            11. BootMode 'Static'
+            12. Fill all other details correctly in new host form and submit it
 
-        @Assert: Validation error should be raised on UI
+        :Assert: Validation error should be raised on UI
 
-        @caseautomation: notautomated
+        :caseautomation: notautomated
 
-        @CaseLevel: System
+        :CaseLevel: System
         """
 
     @stubbed()
@@ -439,21 +439,21 @@ class MultinetworkTestCase(UITestCase):
     def test_positive_delete_alias_interface(self):
         """Delete an alias interface
 
-        @id: 8370940a-088a-403b-9b77-1be499c992e7
+        :id: 8370940a-088a-403b-9b77-1be499c992e7
 
-        @Setup: Provisioning should be configured
+        :Setup: Provisioning should be configured
 
-        @Steps:
+        :Steps:
 
-        1. Create an aliased interface
-        2. Edit the new host → Network → delete the selected interface
-        3. submit form
+            1. Create an aliased interface
+            2. Edit the new host → Network → delete the selected interface
+            3. submit form
 
-        @Assert: Interface should be deleted successfully
+        :Assert: Interface should be deleted successfully
 
-        @caseautomation: notautomated
+        :caseautomation: notautomated
 
-        @CaseLevel: System
+        :CaseLevel: System
         """
 
     @stubbed()
@@ -461,30 +461,30 @@ class MultinetworkTestCase(UITestCase):
     def test_positive_add_bond_interface_using_two_existing(self):
         """Add bond interface using existing two interfaces
 
-        @id: 6d72a89a-48c4-44a9-afb4-d1427264695d
+        :id: 6d72a89a-48c4-44a9-afb4-d1427264695d
 
-        @Setup: Provisioning should be configured
+        :Setup: Provisioning should be configured
 
-        @Steps:
+        :Steps:
 
-        1. Go to 'Network' tab of 'New host' page
-        2. Click on 'Add Interface' from 'Network tab
-        3. Choose Type: 'Bond'
-        4. mac address: mac should be same as of any of two primary interfaces
-        5. Identifier: bond0
-        6. Select 'Managed'
-        7. Mode 'Balanced rr'
-        8. attached_devices: eth0, eth1
-        9. Go to Infrastructure → Subnet
-        10. Set IPAM mode to 'Internal DB'
-        11. BootMode 'Static'
-        12. Fill all other details correctly in new host form and submit it
+            1. Go to 'Network' tab of 'New host' page
+            2. Click on 'Add Interface' from 'Network tab
+            3. Choose Type: 'Bond'
+            4. mac address: mac should be same as of any of two primary
+               interfaces 5. Identifier: bond0
+            5. Select 'Managed'
+            6. Mode 'Balanced rr'
+            7. attached_devices: eth0, eth1
+            8. Go to Infrastructure → Subnet
+            9. Set IPAM mode to 'Internal DB'
+            10. BootMode 'Static'
+            11. Fill all other details correctly in new host form and submit it
 
-        @Assert: Interface should be configured successfully with name bond0
+        :Assert: Interface should be configured successfully with name bond0
 
-        @caseautomation: notautomated
+        :caseautomation: notautomated
 
-        @CaseLevel: System
+        :CaseLevel: System
         """
 
     @stubbed()
@@ -493,31 +493,31 @@ class MultinetworkTestCase(UITestCase):
         """Add bond interface using existing two interfaces without
         specifying mac
 
-        @id: 51498c07-a3ba-40d5-a521-bad3d012ce0e
+        :id: 51498c07-a3ba-40d5-a521-bad3d012ce0e
 
-        @Setup: Provisioning should be configured
+        :Setup: Provisioning should be configured
 
-        @Steps:
+        :Steps:
 
-        1. Go to 'Network' tab of 'New host' page
-        2. Click on 'Add Interface' from 'Network tab
-        3. Choose Type: 'Bond'
-        4. mac address: leave it blank
-        5. Identifier: bond0
-        6. Select 'Managed'
-        7. Mode 'Balanced rr'
-        8. attached_devices: eth0, eth1
-        9. Go to Infrastructure → Subnet
-        10. Set IPAM mode to 'Internal DB'
-        11. BootMode 'Static'
-        12. Fill all other details correctly in new host form and submit it
+            1. Go to 'Network' tab of 'New host' page
+            2. Click on 'Add Interface' from 'Network tab
+            3. Choose Type: 'Bond'
+            4. mac address: leave it blank
+            5. Identifier: bond0
+            6. Select 'Managed'
+            7. Mode 'Balanced rr'
+            8. attached_devices: eth0, eth1
+            9. Go to Infrastructure → Subnet
+            10. Set IPAM mode to 'Internal DB'
+            11. BootMode 'Static'
+            12. Fill all other details correctly in new host form and submit it
 
-        @Assert: UI should raise validation error as user shouldn't be allowed
-        create bond interface without mac
+        :Assert: UI should raise validation error as user shouldn't be allowed
+            create bond interface without mac
 
-        @caseautomation: notautomated
+        :caseautomation: notautomated
 
-        @CaseLevel: System
+        :CaseLevel: System
         """
 
     @stubbed()
@@ -525,31 +525,31 @@ class MultinetworkTestCase(UITestCase):
     def test_positive_add_bond_interface_without_attached_device(self):
         """Add bond interface without specifying attached devices
 
-        @id: 1ed737f5-a371-4bcb-95b5-fa75e372654b
+        :id: 1ed737f5-a371-4bcb-95b5-fa75e372654b
 
-        @Setup: Provisioning should be configured
+        :Setup: Provisioning should be configured
 
-        @Steps:
+        :Steps:
 
-        1. Go to 'Network' tab of 'New host' page
-        2. Click on 'Add Interface' from 'Network tab
-        3. Choose Type: 'Bond'
-        4. mac address: leave it blank
-        5. Identifier: bond0
-        6. Select 'Managed'
-        7. Mode 'Balanced rr'
-        8. attached_devices: leave it blank
-        9. Go to Infrastructure → Subnet
-        10. Set IPAM mode to 'Internal DB'
-        11. BootMode 'Static'
-        12. Fill all other details correctly in new host form and submit it
+            1. Go to 'Network' tab of 'New host' page
+            2. Click on 'Add Interface' from 'Network tab
+            3. Choose Type: 'Bond'
+            4. mac address: leave it blank
+            5. Identifier: bond0
+            6. Select 'Managed'
+            7. Mode 'Balanced rr'
+            8. attached_devices: leave it blank
+            9. Go to Infrastructure → Subnet
+            10. Set IPAM mode to 'Internal DB'
+            11. BootMode 'Static'
+            12. Fill all other details correctly in new host form and submit it
 
-        @Assert: Interface should be configured successfully without attaching
-        any device to it.
+        :Assert: Interface should be configured successfully without attaching
+            any device to it.
 
-        @caseautomation: notautomated
+        :caseautomation: notautomated
 
-        @CaseLevel: System
+        :CaseLevel: System
         """
 
     @stubbed()
@@ -557,32 +557,32 @@ class MultinetworkTestCase(UITestCase):
     def test_positive_add_bond_interface(self):
         """Add bond interface with one alias interface
 
-        @id: 0252b5a7-3854-47d9-9791-863ad245308d
+        :id: 0252b5a7-3854-47d9-9791-863ad245308d
 
-        @Setup: Provisioning should be configured
+        :Setup: Provisioning should be configured
 
-        @Steps:
+        :Steps:
 
-        1. Alias interface should already be configured
-        2. Go to 'Network' tab of 'New host' page
-        3. Click on 'Add Interface' from 'Network tab
-        4. Choose Type: 'Bond'
-        5. mac address: leave it blank
-        6. Identifier: bond0
-        7. Select 'Managed'
-        8. Mode 'Balanced rr'
-        9. attached_devices: eth0, eth0:0
-        10. Go to Infrastructure → Subnet
-        11. Set IPAM mode to 'Internal DB'
-        12. BootMode 'Static'
-        13. Fill all other details correctly in new host form and submit it
+            1. Alias interface should already be configured
+            2. Go to 'Network' tab of 'New host' page
+            3. Click on 'Add Interface' from 'Network tab
+            4. Choose Type: 'Bond'
+            5. mac address: leave it blank
+            6. Identifier: bond0
+            7. Select 'Managed'
+            8. Mode 'Balanced rr'
+            9. attached_devices: eth0, eth0:0
+            10. Go to Infrastructure → Subnet
+            11. Set IPAM mode to 'Internal DB'
+            12. BootMode 'Static'
+            13. Fill all other details correctly in new host form and submit it
 
-        @Assert: Interface should be configured successfully with name bond0
-        attached to eth0 eth0:0
+        :Assert: Interface should be configured successfully with name bond0
+            attached to eth0 eth0:0
 
-        @caseautomation: notautomated
+        :caseautomation: notautomated
 
-        @CaseLevel: System
+        :CaseLevel: System
         """
 
     @stubbed()
@@ -590,30 +590,29 @@ class MultinetworkTestCase(UITestCase):
     def test_positive_add_bmc_interface(self):
         """Add bmc interface
 
-        @id: 7c5a9bb8-70c9-4fe3-a61e-179d7946bb62
+        :id: 7c5a9bb8-70c9-4fe3-a61e-179d7946bb62
 
-        @Setup: Provisioning should be configured
+        :Setup: Provisioning should be configured
 
-        @Steps:
+        :Steps:
 
-        1. Go to 'Network' tab of 'New host' page
-        2. Click on 'Add Interface' from 'Network tab
-        3. Choose Type: 'BMC'
-        4. mac address: Mac of BMC
-        5. Identifier: bmc
-        6. Select 'Managed'
-        7. User name:
-        8. password:
-        9. Provider: IPMI
-        10. Fill all other details correctly in new host form and submit it
+            1. Go to 'Network' tab of 'New host' page
+            2. Click on 'Add Interface' from 'Network tab
+            3. Choose Type: 'BMC'
+            4. mac address: Mac of BMC
+            5. Identifier: bmc
+            6. Select 'Managed'
+            7. User name:
+            8. password:
+            9. Provider: IPMI
+            10. Fill all other details correctly in new host form and submit it
 
-        @Assert: Interface should be configured successfully and user
-        should get On/OFF button on host page
+        :Assert: Interface should be configured successfully and user should
+            get On/OFF button on host page
 
-        @caseautomation: notautomated
+        :caseautomation: notautomated
 
-
-        @CaseLevel: System
+        :CaseLevel: System
         """
 
     @stubbed()
@@ -621,26 +620,26 @@ class MultinetworkTestCase(UITestCase):
     def test_positive_add_bmc_interface_without_mac(self):
         """Add bmc interface without mac
 
-        @id: 3daf53ed-2ef1-4503-b181-6f96377b187e
+        :id: 3daf53ed-2ef1-4503-b181-6f96377b187e
 
-        @Setup: Provisioning should be configured
+        :Setup: Provisioning should be configured
 
-        @Steps:
+        :Steps:
 
-        1. Go to 'Network' tab of 'New host' page
-        2. Click on 'Add Interface' from 'Network tab
-        3. Choose Type: 'BMC'
-        4. mac address: blank
-        5. Identifier: bmc
-        6. Select 'Managed'
-        7. User name:
-        8. password:
-        9. Provider: IPMI
-        10. Fill all other details correctly in new host form and submit it
+            1. Go to 'Network' tab of 'New host' page
+            2. Click on 'Add Interface' from 'Network tab
+            3. Choose Type: 'BMC'
+            4. mac address: blank
+            5. Identifier: bmc
+            6. Select 'Managed'
+            7. User name:
+            8. password:
+            9. Provider: IPMI
+            10. Fill all other details correctly in new host form and submit it
 
-        @Assert: UI should raise validation error
+        :Assert: UI should raise validation error
 
-        @caseautomation: notautomated
+        :caseautomation: notautomated
 
-        @CaseLevel: System
+        :CaseLevel: System
         """

--- a/tests/foreman/ui/test_myaccount.py
+++ b/tests/foreman/ui/test_myaccount.py
@@ -1,19 +1,19 @@
 # -*- encoding: utf-8 -*-
 """Test class for Users UI
 
-@Requirement: Myaccount
+:Requirement: Myaccount
 
-@CaseAutomation: Automated
+:CaseAutomation: Automated
 
-@CaseLevel: Acceptance
+:CaseLevel: Acceptance
 
-@CaseComponent: UI
+:CaseComponent: UI
 
-@TestType: Functional
+:TestType: Functional
 
-@CaseImportance: High
+:CaseImportance: High
 
-@Upstream: No
+:Upstream: No
 """
 
 from fauxfactory import gen_string, gen_alpha
@@ -102,12 +102,11 @@ class MyAccountTestCase(UITestCase):
     def test_positive_update_firstname(self):
         """Update Firstname in My Account
 
-        @id: d5e617e6-ff61-451b-9e82-dd14e7348de6
+        :id: d5e617e6-ff61-451b-9e82-dd14e7348de6
 
-        @Steps:
-        1. Update current User with all variations of Firstname in [1]
+        :Steps: Update current User with all variations of Firstname in [1]
 
-        @Assert: Current User is updated
+        :Assert: Current User is updated
         """
         valid_strs = _valid_string_data()
         valid_strs.append('name with space')
@@ -117,12 +116,11 @@ class MyAccountTestCase(UITestCase):
     def test_positive_update_email(self):
         """Update Email Address in My Account
 
-        @id: 1c535b77-36d8-44d1-aaf0-07e0ca4eeb28
+        :id: 1c535b77-36d8-44d1-aaf0-07e0ca4eeb28
 
-        @Steps:
-        1. Update current User with with Email
+        :Steps: Update current User with with Email
 
-        @Assert: Current User is updated
+        :Assert: Current User is updated
         """
         email = u'{0}@example.com'.format(gen_string('alpha'))
         self.assert_text_field_update('users.email', email)
@@ -131,14 +129,13 @@ class MyAccountTestCase(UITestCase):
     def test_positive_update_surname(self):
         """Update Surname in My Account
 
-        @id: 755c1acc-901b-40de-8bdc-1eace9713ed7
+        :id: 755c1acc-901b-40de-8bdc-1eace9713ed7
 
-        @Steps:
-        1. Update current User with all variations of Surname in [1]
+        :Steps: Update current User with all variations of Surname in [1]
 
-        @Assert: Current User is updated
+        :Assert: Current User is updated
 
-        @caseautomation: notautomated
+        :caseautomation: notautomated
         """
         valid_strs = _valid_string_data()
         valid_strs.append('name with space')
@@ -148,12 +145,11 @@ class MyAccountTestCase(UITestCase):
     def test_positive_update_language(self):
         """Update Language in My Account
 
-        @id: 87604475-3a8e-4cb1-ace4-ea874b1d9e72
+        :id: 87604475-3a8e-4cb1-ace4-ea874b1d9e72
 
-        @Steps:
-        1. Update current User with all different Language options
+        :Steps: Update current User with all different Language options
 
-        @Assert: Current User is updated
+        :Assert: Current User is updated
         """
 
         for lang, locale in LANGUAGES.items():
@@ -182,12 +178,11 @@ class MyAccountTestCase(UITestCase):
     def test_positive_update_password(self):
         """Update Password/Verify fields in My Account
 
-        @id: 3ab5d347-e02a-4d34-aec0-970419525268
+        :id: 3ab5d347-e02a-4d34-aec0-970419525268
 
-        @Steps:
-        1. Update Password/Verify fields with all variations in [1]
+        :Steps: Update Password/Verify fields with all variations in [1]
 
-        @Assert: User is updated
+        :Assert: User is updated
         """
         for password in _valid_string_data(max_len=254):
             with self.subTest(password):
@@ -211,14 +206,13 @@ class MyAccountTestCase(UITestCase):
     def test_negative_update_firstname(self):
         """Update My Account with invalid FirstName
 
-        @id: 3b6250a5-437c-4540-8e95-32a915776f7f
+        :id: 3b6250a5-437c-4540-8e95-32a915776f7f
 
-        @Steps:
-        1. Update Current user with all variations of FirstName in [2]
+        :Steps: Update Current user with all variations of FirstName in [2]
 
-        @Assert: User is not updated. Appropriate error shown.
+        :Assert: User is not updated. Appropriate error shown.
 
-        @caseautomation: notautomated
+        :caseautomation: notautomated
         """
 
     @stubbed()
@@ -226,14 +220,13 @@ class MyAccountTestCase(UITestCase):
     def test_negative_update_surname(self):
         """Update My Account with invalid Surname
 
-        @id: 97c9ae7b-73d8-4896-bff1-f701d2b53776
+        :id: 97c9ae7b-73d8-4896-bff1-f701d2b53776
 
-        @Steps:
-        1. Update Current user with all variations of Surname in [2]
+        :Steps: Update Current user with all variations of Surname in [2]
 
-        @Assert: User is not updated. Appropriate error shown.
+        :Assert: User is not updated. Appropriate error shown.
 
-        @caseautomation: notautomated
+        :caseautomation: notautomated
         """
 
     @stubbed()
@@ -241,14 +234,13 @@ class MyAccountTestCase(UITestCase):
     def test_negative_update_email(self):
         """Update My Account with invalid Email Address
 
-        @id: 06ace1c7-9a0e-4a0d-9b42-a5b510d697e1
+        :id: 06ace1c7-9a0e-4a0d-9b42-a5b510d697e1
 
-        @Steps:
-        1. Update Current user with all variations of Email Address in [2]
+        :Steps: Update Current user with all variations of Email Address in [2]
 
-        @Assert: User is not updated. Appropriate error shown.
+        :Assert: User is not updated. Appropriate error shown.
 
-        @caseautomation: notautomated
+        :caseautomation: notautomated
         """
 
     @stubbed()
@@ -256,15 +248,14 @@ class MyAccountTestCase(UITestCase):
     def test_negative_update_password(self):
         """Update My Account with invalid Password/Verify fields
 
-        @id: 09739b2e-8717-4104-a9c8-3377227599f0
+        :id: 09739b2e-8717-4104-a9c8-3377227599f0
 
-        @Steps:
-        1. Update Current user with all variations of Password/Verify fields
-        in [2]
+        :Steps: Update Current user with all variations of Password/Verify
+            fields in [2]
 
-        @Assert: User is not updated. Appropriate error shown.
+        :Assert: User is not updated. Appropriate error shown.
 
-        @caseautomation: notautomated
+        :caseautomation: notautomated
         """
 
     @stubbed()
@@ -273,15 +264,14 @@ class MyAccountTestCase(UITestCase):
         """Update My Account with non-matching values in Password and
         verify fields
 
-        @id: b729ade7-ee69-4c43-a576-10be38f5c5fa
+        :id: b729ade7-ee69-4c43-a576-10be38f5c5fa
 
-        @Steps:
-        1. Update Current user with non-matching values in Password and verify
-        fields
+        :Steps: Update Current user with non-matching values in Password and
+            verify fields
 
-        @Assert: User is not updated. Appropriate error shown.
+        :Assert: User is not updated. Appropriate error shown.
 
-        @caseautomation: notautomated
+        :caseautomation: notautomated
         """
 
     @stubbed()
@@ -290,14 +280,14 @@ class MyAccountTestCase(UITestCase):
         """[UI ONLY] Attempt to update all info in My Accounts page and
         Cancel
 
-        @id: 3867c4c3-b458-4d7b-a6c9-f2e65604e994
+        :id: 3867c4c3-b458-4d7b-a6c9-f2e65604e994
 
-        @Steps:
-        1. Update Current user with valid Firstname, Surname, Email Address,
-        Language, Password/Verify fields
-        2. Click Cancel
+        :Steps:
+            1. Update Current user with valid Firstname, Surname, Email
+                Address, Language, Password/Verify fields
+            2. Click Cancel
 
-        @Assert: User is not updated.
+        :Assert: User is not updated.
 
-        @caseautomation: notautomated
+        :caseautomation: notautomated
         """

--- a/tests/foreman/ui/test_navigation.py
+++ b/tests/foreman/ui/test_navigation.py
@@ -1,19 +1,19 @@
 # -*- encoding: utf-8 -*-
 """Test class for Navigation UI
 
-@Requirement: Navigation
+:Requirement: Navigation
 
-@CaseAutomation: Automated
+:CaseAutomation: Automated
 
-@CaseLevel: Acceptance
+:CaseLevel: Acceptance
 
-@CaseComponent: UI
+:CaseComponent: UI
 
-@TestType: Functional
+:TestType: Functional
 
-@CaseImportance: High
+:CaseImportance: High
 
-@Upstream: No
+:Upstream: No
 """
 
 from robottelo.decorators import skip_if_bug_open, tier1
@@ -78,9 +78,9 @@ class NavigationTestCase(UITestCase):
     def test_positive_navigate(self):
         """Navigate through application pages
 
-        @id: da8b1242-364e-44ec-8a17-dd5d8047a386
+        :id: da8b1242-364e-44ec-8a17-dd5d8047a386
 
-        @Assert: Page is opened without errors
+        :Assert: Page is opened without errors
         """
         with Session(self.browser) as session:
             for page in self.page_objects().values():
@@ -97,12 +97,12 @@ class NavigationTestCase(UITestCase):
         """Check that we can be redirected from current page using application
         logo in the top left section of the screen
 
-        @id: 9f05ac85-3b0f-4220-b2b4-a9fd050f3dc0
+        :id: 9f05ac85-3b0f-4220-b2b4-a9fd050f3dc0
 
-        @BZ: 1394974
+        :BZ: 1394974
 
-        @Assert: No error is raised after redirection and logo is still present
-        on the page
+        :Assert: No error is raised after redirection and logo is still present
+            on the page
         """
         with Session(self.browser) as session:
             pages = self.page_objects()

--- a/tests/foreman/ui/test_openscap.py
+++ b/tests/foreman/ui/test_openscap.py
@@ -1,18 +1,18 @@
 """Test class for OpenScap Feature
 
-@Requirement: Openscap
+:Requirement: Openscap
 
-@CaseAutomation: Automated
+:CaseAutomation: Automated
 
-@CaseLevel: Acceptance
+:CaseLevel: Acceptance
 
-@CaseComponent: UI
+:CaseComponent: UI
 
-@TestType: Functional
+:TestType: Functional
 
-@CaseImportance: High
+:CaseImportance: High
 
-@Upstream: No
+:Upstream: No
 """
 from robottelo.decorators import stubbed, tier1, tier2, tier3
 from robottelo.test import UITestCase
@@ -26,16 +26,16 @@ class OpenScapTestCase(UITestCase):
     def test_positive_create_policy(self):
         """Create policies for OpenScap.
 
-        @id: 9a7564d6-387a-4a92-b6d6-d28683845b40
+        :id: 9a7564d6-387a-4a92-b6d6-d28683845b40
 
-        @Steps:
+        :Steps:
 
-        1. Create an openscap policies.
-        2. Provide all the appropriate parameters.
+            1. Create an openscap policies.
+            2. Provide all the appropriate parameters.
 
-        @Assert: Whether creating policies for OpenScap is successful.
+        :Assert: Whether creating policies for OpenScap is successful.
 
-        @caseautomation: notautomated
+        :caseautomation: notautomated
         """
 
     @stubbed()
@@ -43,11 +43,11 @@ class OpenScapTestCase(UITestCase):
     def test_negative_create_policy(self):
         """Create policies for OpenScap with 256 chars.
 
-        @id: e832d9f4-fee1-4502-937e-375c08d5f042
+        :id: e832d9f4-fee1-4502-937e-375c08d5f042
 
-        @Assert: Creating policies for OpenScap is unsuccessful.
+        :Assert: Creating policies for OpenScap is unsuccessful.
 
-        @caseautomation: notautomated
+        :caseautomation: notautomated
         """
 
     @stubbed()
@@ -55,17 +55,17 @@ class OpenScapTestCase(UITestCase):
     def test_positive_delete_policy(self):
         """Delete policies of OpenScap.
 
-        @id: 7324f2a7-a9ad-49e6-b564-4e58a8bb2c42
+        :id: 7324f2a7-a9ad-49e6-b564-4e58a8bb2c42
 
-        @Steps:
+        :Steps:
 
-        1. Create an openscap policies.
-        2. Provide all the appropriate parameters.
-        3. Delete the policy.
+            1. Create an openscap policies.
+            2. Provide all the appropriate parameters.
+            3. Delete the policy.
 
-        @Assert: Whether deleting policies for OpenScap is successful.
+        :Assert: Whether deleting policies for OpenScap is successful.
 
-        @caseautomation: notautomated
+        :caseautomation: notautomated
         """
 
     @stubbed()
@@ -73,16 +73,16 @@ class OpenScapTestCase(UITestCase):
     def test_positive_create_content(self):
         """Create OpenScap content.
 
-        @id: 35c52cb4-b6c4-431a-b9c8-f5b15b6d67a8
+        :id: 35c52cb4-b6c4-431a-b9c8-f5b15b6d67a8
 
-        @Steps:
+        :Steps:
 
-        1. Create an openscap content.
-        2. Provide all the appropriate parameters.
+            1. Create an openscap content.
+            2. Provide all the appropriate parameters.
 
-        @Assert: Whether creating  content for OpenScap is successful
+        :Assert: Whether creating  content for OpenScap is successful
 
-        @caseautomation: notautomated
+        :caseautomation: notautomated
         """
 
     @stubbed()
@@ -90,11 +90,11 @@ class OpenScapTestCase(UITestCase):
     def test_negative_create_content(self):
         """Create OpenScap content with 256 chars.
 
-        @id: 3410fe9b-55ba-4b87-bc7a-ec9138fc035a
+        :id: 3410fe9b-55ba-4b87-bc7a-ec9138fc035a
 
-        @Assert: Creating content for OpenScap is unsuccessful
+        :Assert: Creating content for OpenScap is unsuccessful
 
-        @caseautomation: notautomated
+        :caseautomation: notautomated
         """
 
     @stubbed()
@@ -102,17 +102,17 @@ class OpenScapTestCase(UITestCase):
     def test_positive_delete_content(self):
         """Create OpenScap content and then delete it.
 
-        @id: 1c6b63b3-c838-4b14-a7f4-a151d3bb49d4
+        :id: 1c6b63b3-c838-4b14-a7f4-a151d3bb49d4
 
-        @Steps:
+        :Steps:
 
-        1. Create an openscap content.
-        2. Provide all the appropriate parameters.
-        3. Delete the openscap content.
+            1. Create an openscap content.
+            2. Provide all the appropriate parameters.
+            3. Delete the openscap content.
 
-        @Assert: Deleting content for OpenScap is successful
+        :Assert: Deleting content for OpenScap is successful
 
-        @caseautomation: notautomated
+        :caseautomation: notautomated
         """
 
     @stubbed()
@@ -120,11 +120,11 @@ class OpenScapTestCase(UITestCase):
     def test_positive_access_oscap_reports(self):
         """OpenScap should have it's own Compliance Reporting page.
 
-        @id: b1decf7e-f4e8-45aa-941b-c9b9c5b9efb0
+        :id: b1decf7e-f4e8-45aa-941b-c9b9c5b9efb0
 
-        @Assert: Whether separate Compliance Reporting page exists.
+        :Assert: Whether separate Compliance Reporting page exists.
 
-        @caseautomation: notautomated
+        :caseautomation: notautomated
         """
 
     @stubbed()
@@ -132,27 +132,27 @@ class OpenScapTestCase(UITestCase):
     def test_positive_set_periodic_audit(self):
         """Should be able to periodically set OpenScap Audit.
 
-        @id: f750710b-14ed-4448-ae3c-cec2fde4297a
+        :id: f750710b-14ed-4448-ae3c-cec2fde4297a
 
-        @Steps:
+        :Steps:
 
-        1. Create oscap content.
-        2. Create puppet repo with puppet-foreman_scap_client puppet-module
-        3. create cv with the above puppet content, publish and promote.
-        4. Register the host as puppet client to default sat6 capsule.
-        5. while creating the oscap policy select the period as weekly
-           or monthly.
-        6. Create oscap policy and associate it to the host-group or host.
-        7. Run 'puppet agent' on the host to configure/schedule OSCAP scan.
-        8. Make sure the appropriate crontab entries are added as per the
-           period selected.
+            1. Create oscap content.
+            2. Create puppet repo with puppet-foreman_scap_client puppet-module
+            3. create cv with the above puppet content, publish and promote.
+            4. Register the host as puppet client to default sat6 capsule.
+            5. while creating the oscap policy select the period as weekly or
+                monthly.
+            6. Create oscap policy and associate it to the host-group or host.
+            7. Run 'puppet agent' on the host to configure/schedule OSCAP scan.
+            8. Make sure the appropriate crontab entries are added as per the
+                period selected.
 
-        @Assert: Whether OpenScap Audit scans can be periodically set as per
-        intervals.
+        :Assert: Whether OpenScap Audit scans can be periodically set as per
+            intervals.
 
-        @caseautomation: notautomated
+        :caseautomation: notautomated
 
-        @CaseLevel: System
+        :CaseLevel: System
         """
 
     @stubbed()
@@ -160,26 +160,26 @@ class OpenScapTestCase(UITestCase):
     def test_positive_set_custom_periodic_audit(self):
         """Should be able to periodically set custom OpenScap Audit.
 
-        @id: 595f87d6-ae35-4034-8b0d-50b6bec5d370
+        :id: 595f87d6-ae35-4034-8b0d-50b6bec5d370
 
-        @Steps:
+        :Steps:
 
-        1. Create oscap content.
-        2. Create puppet repo with puppet-foreman_scap_client puppet-module
-        3. create cv with the above puppet content, publish and promote.
-        4. Register the host as puppet client to default sat6 capsule.
-        5. while creating the oscap policy select the period as custom.
-        6. Create oscap policy and associate it to the host-group or host.
-        7. Run 'puppet agent' on the host to configure/schedule OSCAP scan.
-        8. Make sure the appropriate crontab entries are added as per the
-           period selected.
+            1. Create oscap content.
+            2. Create puppet repo with puppet-foreman_scap_client puppet-module
+            3. create cv with the above puppet content, publish and promote.
+            4. Register the host as puppet client to default sat6 capsule.
+            5. while creating the oscap policy select the period as custom.
+            6. Create oscap policy and associate it to the host-group or host.
+            7. Run 'puppet agent' on the host to configure/schedule OSCAP scan.
+            8. Make sure the appropriate crontab entries are added as per the
+                period selected.
 
-        @Assert: Whether OpenScap Audit scans can be periodically set as per
-        custom intervals.
+        :Assert: Whether OpenScap Audit scans can be periodically set as per
+            custom intervals.
 
-        @caseautomation: notautomated
+        :caseautomation: notautomated
 
-        @CaseLevel: System
+        :CaseLevel: System
         """
 
     @stubbed()
@@ -187,24 +187,24 @@ class OpenScapTestCase(UITestCase):
     def test_positive_search_audit(self):
         """Should be able to search OpenScap audit results.
 
-        @id: 77eb277f-c2a6-48fc-aa35-e08b7d595e41
+        :id: 77eb277f-c2a6-48fc-aa35-e08b7d595e41
 
-        @Steps:
+        :Steps:
 
-        1. Create oscap content.
-        2. Create puppet repo with puppet-foreman_scap_client puppet-module
-        3. create cv with the above puppet content, publish and promote.
-        4. Register the host as puppet client to default sat6 capsule.
-        5. Create oscap policy and associate it to the host-group or host.
-        6. Run 'puppet agent' on the host to configure/schedule OSCAP scan.
-        7. Make sure the scan reports are generated under OSCAP reports.
-        8. Search for the audit reports is possible.
+            1. Create oscap content.
+            2. Create puppet repo with puppet-foreman_scap_client puppet-module
+            3. create cv with the above puppet content, publish and promote.
+            4. Register the host as puppet client to default sat6 capsule.
+            5. Create oscap policy and associate it to the host-group or host.
+            6. Run 'puppet agent' on the host to configure/schedule OSCAP scan.
+            7. Make sure the scan reports are generated under OSCAP reports.
+            8. Search for the audit reports is possible.
 
-        @Assert: Whether searching audit results is possible.
+        :Assert: Whether searching audit results is possible.
 
-        @caseautomation: notautomated
+        :caseautomation: notautomated
 
-        @CaseLevel: System
+        :CaseLevel: System
         """
 
     @stubbed()
@@ -213,24 +213,24 @@ class OpenScapTestCase(UITestCase):
         """OpenScap should be able to audit foreman managed
         infrastructure(Reports from default Capsule.)
 
-        @id: 915b14e0-e41a-4857-b0ae-913c51251126
+        :id: 915b14e0-e41a-4857-b0ae-913c51251126
 
-        @Steps:
+        :Steps:
 
-        1. Create oscap content.
-        2. Create puppet repo with puppet-foreman_scap_client puppet-module
-        3. create cv with the above puppet content, publish and promote.
-        4. Register the host to default sat6 capsule.
-        5. Create oscap policy and associate it to the host-group or host.
-        6. Run 'puppet agent' on the host to configure/schedule OSCAP scan.
-        7. Make sure the scan reports are generated under OSCAP reports.
+            1. Create oscap content.
+            2. Create puppet repo with puppet-foreman_scap_client puppet-module
+            3. create cv with the above puppet content, publish and promote.
+            4. Register the host to default sat6 capsule.
+            5. Create oscap policy and associate it to the host-group or host.
+            6. Run 'puppet agent' on the host to configure/schedule OSCAP scan.
+            7. Make sure the scan reports are generated under OSCAP reports.
 
-        @Assert: Whether audit reports of Foreman managed Infrastructure
-        (Hosts from default Capsule) are generated.
+        :Assert: Whether audit reports of Foreman managed Infrastructure (Hosts
+            from default Capsule) are generated.
 
-        @caseautomation: notautomated
+        :caseautomation: notautomated
 
-        @CaseLevel: System
+        :CaseLevel: System
         """
 
     @stubbed()
@@ -239,24 +239,24 @@ class OpenScapTestCase(UITestCase):
         """OpenScap should be able to audit foreman managed
         infrastructure (Reports from Non-Default Capsule)
 
-        @id: db9db833-56a6-4628-9a91-6b3a9475dfc8
+        :id: db9db833-56a6-4628-9a91-6b3a9475dfc8
 
-        @Steps:
+        :Steps:
 
-        1. Create oscap content.
-        2. Create puppet repo with puppet-foreman_scap_client puppet-module
-        3. create cv with the above puppet content, publish and promote.
-        4. Register the host to external sat6 capsule.
-        5. Create oscap policy and associate it to the host-group or host.
-        6. Run 'puppet agent' on the host to configure/schedule OSCAP scan.
-        7. Make sure the scan reports are generated under OSCAP reports.
+            1. Create oscap content.
+            2. Create puppet repo with puppet-foreman_scap_client puppet-module
+            3. create cv with the above puppet content, publish and promote.
+            4. Register the host to external sat6 capsule.
+            5. Create oscap policy and associate it to the host-group or host.
+            6. Run 'puppet agent' on the host to configure/schedule OSCAP scan.
+            7. Make sure the scan reports are generated under OSCAP reports.
 
-        @Assert: Whether audit of Foreman managed Infrastructure
-        (Hosts from Non-Default Capsule) is possible.
+        :Assert: Whether audit of Foreman managed Infrastructure (Hosts from
+            Non-Default Capsule) is possible.
 
-        @caseautomation: notautomated
+        :caseautomation: notautomated
 
-        @CaseLevel: System
+        :CaseLevel: System
         """
 
     @stubbed()
@@ -264,19 +264,19 @@ class OpenScapTestCase(UITestCase):
     def test_positive_search_content(self):
         """Should be able to search OpenScap content.
 
-        @id: 4aeef3ae-7e9a-488a-a906-b4aef024592f
+        :id: 4aeef3ae-7e9a-488a-a906-b4aef024592f
 
-        @steps:
+        :steps:
 
-        1. Create an openscap content.
-        2. Provide valid data-stream.xml file available from
-           scap-security-guide. (ssg-rhel6-ds.xml)
+            1. Create an openscap content.
+            2. Provide valid data-stream.xml file available from
+                scap-security-guide. (ssg-rhel6-ds.xml)
 
-        @Assert: Whether searching OpenScap content is possible.
+        :Assert: Whether searching OpenScap content is possible.
 
-        @caseautomation: notautomated
+        :caseautomation: notautomated
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
 
     @stubbed()
@@ -284,18 +284,18 @@ class OpenScapTestCase(UITestCase):
     def test_positive_search_policies(self):
         """Should be able to search OpenScap policies.
 
-        @id: 6a46438a-7248-4e48-90dc-e5b0ee57e1ec
+        :id: 6a46438a-7248-4e48-90dc-e5b0ee57e1ec
 
-        @Steps:
+        :Steps:
 
-        1. Create an openscap content.
-        2. Provide all the appropriate parameters
+            1. Create an openscap content.
+            2. Provide all the appropriate parameters
 
-        @Assert: Whether searching OpenScap policies is possible.
+        :Assert: Whether searching OpenScap policies is possible.
 
-        @caseautomation: notautomated
+        :caseautomation: notautomated
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
 
     @stubbed()
@@ -303,24 +303,24 @@ class OpenScapTestCase(UITestCase):
     def test_positive_search_nonaudited_hosts(self):
         """Should be able to search Non-Audited Hosts/systems
 
-        @id: c7ef2735-3af5-45a0-9ce7-e7e4ee1481eb
+        :id: c7ef2735-3af5-45a0-9ce7-e7e4ee1481eb
 
-        @Steps:
+        :Steps:
 
-        1. Create oscap content.
-        2. Create puppet repo with puppet-foreman_scap_client puppet-module
-        3. create cv with the above puppet content, publish and promote.
-        4. Register the host as puppet client to default sat6 capsule.
-        5. Create oscap policy and associate it to the host-group or host.
-        6. Run 'puppet agent' on the host to configure/schedule OSCAP scan.
-        7. Make sure the scan reports are generated under OSCAP reports.
-        8. Search for the non audited hosts.
+            1. Create oscap content.
+            2. Create puppet repo with puppet-foreman_scap_client puppet-module
+            3. create cv with the above puppet content, publish and promote.
+            4. Register the host as puppet client to default sat6 capsule.
+            5. Create oscap policy and associate it to the host-group or host.
+            6. Run 'puppet agent' on the host to configure/schedule OSCAP scan.
+            7. Make sure the scan reports are generated under OSCAP reports.
+            8. Search for the non audited hosts.
 
-        @Assert: Whether searching Non-Audited Hosts/Systems is possible.
+        :Assert: Whether searching Non-Audited Hosts/Systems is possible.
 
-        @caseautomation: notautomated
+        :caseautomation: notautomated
 
-        @CaseLevel: System
+        :CaseLevel: System
         """
 
     @stubbed()
@@ -328,24 +328,24 @@ class OpenScapTestCase(UITestCase):
     def test_positive_search_noncompliant_hosts(self):
         """Should be able to search Non-Compliant "Hosts"/systems
 
-        @id: c75007f8-0567-444c-8f0e-08e535c3753c
+        :id: c75007f8-0567-444c-8f0e-08e535c3753c
 
-        @Steps:
+        :Steps:
 
-        1. Create oscap content.
-        2. Create puppet repo with puppet-foreman_scap_client puppet-module
-        3. create cv with the above puppet content, publish and promote.
-        4. Register the host as puppet client to default sat6 capsule.
-        5. Create oscap policy and associate it to the host-group or host.
-        6. Run 'puppet agent' on the host to configure/schedule OSCAP scan.
-        7. Make sure the scan reports are generated under OSCAP reports.
-        8. Search for the audit reports for non-compliant hosts.
+            1. Create oscap content.
+            2. Create puppet repo with puppet-foreman_scap_client puppet-module
+            3. create cv with the above puppet content, publish and promote.
+            4. Register the host as puppet client to default sat6 capsule.
+            5. Create oscap policy and associate it to the host-group or host.
+            6. Run 'puppet agent' on the host to configure/schedule OSCAP scan.
+            7. Make sure the scan reports are generated under OSCAP reports.
+            8. Search for the audit reports for non-compliant hosts.
 
-        @Assert: Whether searching Non-Compliant systems is possible.
+        :Assert: Whether searching Non-Compliant systems is possible.
 
-        @caseautomation: notautomated
+        :caseautomation: notautomated
 
-        @CaseLevel: System
+        :CaseLevel: System
         """
 
     @stubbed()
@@ -354,25 +354,25 @@ class OpenScapTestCase(UITestCase):
         """Should be able to compare multiple audit results of
         "Hosts"/systems.
 
-        @id: 4169707c-02e6-4fc3-a478-39cb27379e33
+        :id: 4169707c-02e6-4fc3-a478-39cb27379e33
 
-        @Steps:
+        :Steps:
 
-        1. Create oscap content.
-        2. Create puppet repo with puppet-foreman_scap_client puppet-module
-        3. create cv with the above puppet content, publish and promote.
-        4. Register the host as puppet client to default sat6 capsule.
-        5. Create oscap policy and associate it to the host-group or host.
-        6. Run 'puppet agent' on the host to configure/schedule OSCAP scan.
-        7. Make sure the scan reports are generated under OSCAP reports.
-        8. Compare audit reports.
+            1. Create oscap content.
+            2. Create puppet repo with puppet-foreman_scap_client puppet-module
+            3. create cv with the above puppet content, publish and promote.
+            4. Register the host as puppet client to default sat6 capsule.
+            5. Create oscap policy and associate it to the host-group or host.
+            6. Run 'puppet agent' on the host to configure/schedule OSCAP scan.
+            7. Make sure the scan reports are generated under OSCAP reports.
+            8. Compare audit reports.
 
-        @Assert: Whether Comparing multiple audit results of Hosts/Systems
-        is possible.
+        :Assert: Whether Comparing multiple audit results of Hosts/Systems is
+            possible.
 
-        @caseautomation: notautomated
+        :caseautomation: notautomated
 
-        @CaseLevel: System
+        :CaseLevel: System
         """
 
     @stubbed()
@@ -380,21 +380,21 @@ class OpenScapTestCase(UITestCase):
     def test_positive_assign_policies_for_hosts(self):
         """Should be able to assign policies for the hosts.
 
-        @id: 1399ec3e-8f03-4faf-8440-d580e05368d9
+        :id: 1399ec3e-8f03-4faf-8440-d580e05368d9
 
-        @Steps:
+        :Steps:
 
-        1. Create oscap content.
-        2. Create puppet repo with puppet-foreman_scap_client puppet-module
-        3. create cv with the above puppet content, publish and promote.
-        4. Register the host as puppet client to default sat6 capsule.
-        5. Create oscap policy and associate it to multiple hosts.
+            1. Create oscap content.
+            2. Create puppet repo with puppet-foreman_scap_client puppet-module
+            3. create cv with the above puppet content, publish and promote.
+            4. Register the host as puppet client to default sat6 capsule.
+            5. Create oscap policy and associate it to multiple hosts.
 
-        @Assert: Whether assigning policies to multiple hosts is possible.
+        :Assert: Whether assigning policies to multiple hosts is possible.
 
-        @caseautomation: notautomated
+        :caseautomation: notautomated
 
-        @CaseLevel: System
+        :CaseLevel: System
         """
 
     @stubbed()
@@ -403,11 +403,11 @@ class OpenScapTestCase(UITestCase):
         """Dashboard views that can tell Audited/Un-Audited,
         Compliant/Non-Compliant and trends.
 
-        @id: 41bc8692-0830-4b17-b5be-7a798a13cc4c
+        :id: 41bc8692-0830-4b17-b5be-7a798a13cc4c
 
-        @Assert: Expected Dashboard views are visible.
+        :Assert: Expected Dashboard views are visible.
 
-        @caseautomation: notautomated
+        :caseautomation: notautomated
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """

--- a/tests/foreman/ui/test_operatingsystem.py
+++ b/tests/foreman/ui/test_operatingsystem.py
@@ -1,19 +1,19 @@
 # -*- encoding: utf-8 -*-
 """Test class for Operating System UI
 
-@Requirement: Operatingsystem
+:Requirement: Operatingsystem
 
-@CaseAutomation: Automated
+:CaseAutomation: Automated
 
-@CaseLevel: Acceptance
+:CaseLevel: Acceptance
 
-@CaseComponent: UI
+:CaseComponent: UI
 
-@TestType: Functional
+:TestType: Functional
 
-@CaseImportance: High
+:CaseImportance: High
 
-@Upstream: No
+:Upstream: No
 """
 
 from fauxfactory import gen_string
@@ -74,9 +74,9 @@ class OperatingSystemTestCase(UITestCase):
     def test_positive_create_with_name(self):
         """Create a new OS using different string types as a name
 
-        @id: 08cb212e-586f-4630-af1b-ad3e749e82e7
+        :id: 08cb212e-586f-4630-af1b-ad3e749e82e7
 
-        @Assert: OS is created
+        :Assert: OS is created
         """
         with Session(self.browser) as session:
             for name in valid_data_list():
@@ -96,9 +96,9 @@ class OperatingSystemTestCase(UITestCase):
     def test_positive_create(self):
         """Create a new OS with different data values
 
-        @id: fcb41aff-c963-403b-a80f-5f9c467d0632
+        :id: fcb41aff-c963-403b-a80f-5f9c467d0632
 
-        @Assert: OS is created
+        :Assert: OS is created
         """
         with Session(self.browser) as session:
             for test_data in valid_os_parameters():
@@ -121,9 +121,9 @@ class OperatingSystemTestCase(UITestCase):
     def test_negative_create_with_invalid_name(self):
         """OS - Create a new OS with invalid name
 
-        @id: aa035ef6-a503-48c4-b95a-021a03a145c0
+        :id: aa035ef6-a503-48c4-b95a-021a03a145c0
 
-        @Assert: OS is not created
+        :Assert: OS is not created
         """
         with Session(self.browser) as session:
             for name in invalid_values_list(interface='ui'):
@@ -145,9 +145,9 @@ class OperatingSystemTestCase(UITestCase):
         """OS - Create a new OS with description containing
         256 characters
 
-        @id: 7f395b9a-2d48-468a-937b-bba4e6576ba9
+        :id: 7f395b9a-2d48-468a-937b-bba4e6576ba9
 
-        @Assert: OS is not created
+        :Assert: OS is not created
         """
         name = gen_string('alpha')
         with Session(self.browser) as session:
@@ -170,9 +170,9 @@ class OperatingSystemTestCase(UITestCase):
         """OS - Create a new OS with incorrect major version value
         (More than 5 characters, empty value, negative number)
 
-        @id: 89d061a8-cb4c-4460-a7fb-7cea73c323af
+        :id: 89d061a8-cb4c-4460-a7fb-7cea73c323af
 
-        @Assert: OS is not created
+        :Assert: OS is not created
         """
         with Session(self.browser) as session:
             for major_version in gen_string('numeric', 6), '', '-6':
@@ -196,9 +196,9 @@ class OperatingSystemTestCase(UITestCase):
         """OS - Create a new OS with incorrect minor version value
         (More than 16 characters and negative number)
 
-        @id: 2828cd68-d57a-4e3e-bced-90937290251e
+        :id: 2828cd68-d57a-4e3e-bced-90937290251e
 
-        @Assert: OS is not created
+        :Assert: OS is not created
         """
         name = gen_string('alpha')
         with Session(self.browser) as session:
@@ -221,11 +221,11 @@ class OperatingSystemTestCase(UITestCase):
     def test_negative_create_with_same_name_and_version(self):
         """OS - Create a new OS with same name and version
 
-        @id: f1865efe-bdc0-4065-90b8-b48c9fad80bb
+        :id: f1865efe-bdc0-4065-90b8-b48c9fad80bb
 
-        @Assert: OS is not created
+        :Assert: OS is not created
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         name = gen_string('alpha')
         major_version = gen_string('numeric', 1)
@@ -256,9 +256,9 @@ class OperatingSystemTestCase(UITestCase):
     def test_positive_delete(self):
         """Delete an existing OS
 
-        @id: 252f1512-78a6-415d-a4fd-5f6d268cbb82
+        :id: 252f1512-78a6-415d-a4fd-5f6d268cbb82
 
-        @Assert: OS is deleted successfully
+        :Assert: OS is deleted successfully
         """
         os_name = entities.OperatingSystem().create().name
         with Session(self.browser):
@@ -270,9 +270,9 @@ class OperatingSystemTestCase(UITestCase):
         """Update OS name, major_version, minor_version, os_family
         and arch
 
-        @id: d86aeac2-c2b6-4766-96a8-c2e427a9c8be
+        :id: d86aeac2-c2b6-4766-96a8-c2e427a9c8be
 
-        @Assert: OS is updated
+        :Assert: OS is updated
         """
         os_name = entities.OperatingSystem().create().name
         with Session(self.browser):
@@ -295,9 +295,9 @@ class OperatingSystemTestCase(UITestCase):
     def test_positive_update_medium(self):
         """Update OS medium
 
-        @id: 4fbcd341-5aff-465c-b251-7ecd97471e01
+        :id: 4fbcd341-5aff-465c-b251-7ecd97471e01
 
-        @Assert: OS is updated
+        :Assert: OS is updated
         """
         medium_name = gen_string('alpha')
         entities.Media(
@@ -317,9 +317,9 @@ class OperatingSystemTestCase(UITestCase):
     def test_positive_update_ptable(self):
         """Update OS partition table
 
-        @id: 08ddbc40-dcc1-4695-b209-ba72a6a458df
+        :id: 08ddbc40-dcc1-4695-b209-ba72a6a458df
 
-        @Assert: OS is updated
+        :Assert: OS is updated
         """
         ptable = gen_string('alpha', 4)
         script_file = get_data_file(PARTITION_SCRIPT_DATA_FILE)
@@ -342,9 +342,9 @@ class OperatingSystemTestCase(UITestCase):
     def test_positive_update_template(self):
         """Update provisioning template
 
-        @id: df21419a-1fdd-414c-86fc-64cde10d3e05
+        :id: df21419a-1fdd-414c-86fc-64cde10d3e05
 
-        @Assert: OS is updated
+        :Assert: OS is updated
         """
         os_name = gen_string('alpha')
         template_name = gen_string('alpha')
@@ -365,11 +365,11 @@ class OperatingSystemTestCase(UITestCase):
     def test_positive_set_parameter(self):
         """Set Operating System parameter
 
-        @id: 05b504d8-2518-4359-a53a-f577339f1ebe
+        :id: 05b504d8-2518-4359-a53a-f577339f1ebe
 
-        @Assert: OS is updated with new parameter
+        :Assert: OS is updated with new parameter
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         with Session(self.browser):
             try:
@@ -386,11 +386,11 @@ class OperatingSystemTestCase(UITestCase):
     def test_positive_set_parameter_with_blank_value(self):
         """Set OS parameter with blank value
 
-        @id: 38ef9293-0f83-4c9d-8314-0c72fdf7e2a6
+        :id: 38ef9293-0f83-4c9d-8314-0c72fdf7e2a6
 
-        @Assert: Parameter is created with blank value
+        :Assert: Parameter is created with blank value
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         with Session(self.browser):
             try:
@@ -407,11 +407,11 @@ class OperatingSystemTestCase(UITestCase):
     def test_positive_remove_parameter(self):
         """Remove selected OS parameter
 
-        @id: 14aa3459-9941-43ba-8c17-d7f32e9db43b
+        :id: 14aa3459-9941-43ba-8c17-d7f32e9db43b
 
-        @Assert: Expected OS parameter is removed
+        :Assert: Expected OS parameter is removed
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         param_name = gen_string('alpha', 4)
         os_name = entities.OperatingSystem().create().name
@@ -428,11 +428,11 @@ class OperatingSystemTestCase(UITestCase):
     def test_negative_set_parameter_same_values(self):
         """Set same OS parameter again as it was set earlier
 
-        @id: 4211c9c6-d61f-4254-ac45-6791f7577142
+        :id: 4211c9c6-d61f-4254-ac45-6791f7577142
 
-        @Assert: Proper error should be raised - Name is already taken
+        :Assert: Proper error should be raised - Name is already taken
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         param_name = gen_string('alpha', 4)
         param_value = gen_string('alpha', 3)
@@ -453,11 +453,11 @@ class OperatingSystemTestCase(UITestCase):
     def test_negative_set_parameter_with_blank_name_and_value(self):
         """Set OS parameter with blank name and value
 
-        @id: 635c354f-3360-403c-9bcb-78f2da9ed893
+        :id: 635c354f-3360-403c-9bcb-78f2da9ed893
 
-        @Assert: Proper error should be raised - Name can't contain whitespaces
+        :Assert: Proper error should be raised - Name can't contain whitespaces
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         with Session(self.browser):
             try:
@@ -474,11 +474,11 @@ class OperatingSystemTestCase(UITestCase):
     def test_negative_set_parameter_with_too_long_values(self):
         """Set OS parameter with name and value exceeding 255 characters
 
-        @id: e961ce00-f86b-476e-afad-468491cb2a12
+        :id: e961ce00-f86b-476e-afad-468491cb2a12
 
-        @Assert: Proper error should be raised, Name should contain a value
+        :Assert: Proper error should be raised, Name should contain a value
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         os_name = entities.OperatingSystem().create().name
         with Session(self.browser):

--- a/tests/foreman/ui/test_organization.py
+++ b/tests/foreman/ui/test_organization.py
@@ -1,19 +1,19 @@
 # -*- encoding: utf-8 -*-
 """Test class for Organization UI
 
-@Requirement: Organization
+:Requirement: Organization
 
-@CaseAutomation: Automated
+:CaseAutomation: Automated
 
-@CaseLevel: Acceptance
+:CaseLevel: Acceptance
 
-@CaseComponent: UI
+:CaseComponent: UI
 
-@TestType: Functional
+:TestType: Functional
 
-@CaseImportance: High
+:CaseImportance: High
 
-@Upstream: No
+:Upstream: No
 """
 
 from fauxfactory import gen_ipaddr, gen_string
@@ -86,9 +86,9 @@ class OrganizationTestCase(UITestCase):
         """Search for an organization can be auto-completed by partial
         name
 
-        @id: f3c492ab-46fb-4b1d-b5d5-29a82385d681
+        :id: f3c492ab-46fb-4b1d-b5d5-29a82385d681
 
-        @assert: Auto search for created organization works as intended
+        :assert: Auto search for created organization works as intended
         """
         org_name = gen_string('alpha')
         part_string = org_name[:3]
@@ -104,9 +104,9 @@ class OrganizationTestCase(UITestCase):
     def test_positive_create_with_name(self):
         """Create organization with valid name only.
 
-        @id: bb5c6400-e837-4e3b-add9-bab2c0b826c9
+        :id: bb5c6400-e837-4e3b-add9-bab2c0b826c9
 
-        @assert: Organization is created, label is auto-generated
+        :assert: Organization is created, label is auto-generated
         """
         with Session(self.browser) as session:
             for org_name in generate_strings_list():
@@ -118,9 +118,9 @@ class OrganizationTestCase(UITestCase):
     def test_positive_create_with_unmatched_name_label(self):
         """Create organization with valid unmatching name and label only
 
-        @id: 82954640-05c2-4d6c-a293-dc4aa3e5611b
+        :id: 82954640-05c2-4d6c-a293-dc4aa3e5611b
 
-        @assert: organization is created, label does not match name
+        :assert: organization is created, label does not match name
         """
         with Session(self.browser) as session:
             for label in valid_labels():
@@ -139,9 +139,9 @@ class OrganizationTestCase(UITestCase):
     def test_positive_create_with_same_name_and_label(self):
         """Create organization with valid matching name and label only.
 
-        @id: 73befc8c-bf96-48b7-8315-34f0cfef9382
+        :id: 73befc8c-bf96-48b7-8315-34f0cfef9382
 
-        @assert: organization is created, label matches name
+        :assert: organization is created, label matches name
         """
         with Session(self.browser) as session:
             for item in valid_labels():
@@ -160,11 +160,11 @@ class OrganizationTestCase(UITestCase):
         """Create organization with valid name. Check that organization
         label is auto-populated
 
-        @id: 29793945-c553-4a6e-881f-cdcde373aa62
+        :id: 29793945-c553-4a6e-881f-cdcde373aa62
 
-        @assert: organization is created, label is auto-generated
+        :assert: organization is created, label is auto-generated
 
-        @BZ: 1079482
+        :BZ: 1079482
         """
         with Session(self.browser) as session:
             for org_name in generate_strings_list():
@@ -181,11 +181,11 @@ class OrganizationTestCase(UITestCase):
     def test_positive_create_with_both_loc_and_org(self):
         """Select both organization and location.
 
-        @id: 7387a8cd-6ebb-4143-b77e-cfc72cb89ca9
+        :id: 7387a8cd-6ebb-4143-b77e-cfc72cb89ca9
 
-        @assert: Both organization and location are selected.
+        :assert: Both organization and location are selected.
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         with Session(self.browser) as session:
             for name in generate_strings_list():
@@ -205,9 +205,9 @@ class OrganizationTestCase(UITestCase):
         """Try to create organization and use whitespace, blank, tab
         symbol or too long string of different types as its name value
 
-        @id: e69ab8c1-e53f-41fa-a84f-290c6c152484
+        :id: e69ab8c1-e53f-41fa-a84f-290c6c152484
 
-        @assert: organization is not created
+        :assert: organization is not created
         """
         with Session(self.browser) as session:
             for org_name in invalid_values_list(interface='ui'):
@@ -222,9 +222,9 @@ class OrganizationTestCase(UITestCase):
         """Create organization with valid names, then create a new one
         with same names.
 
-        @id: d7fd91aa-1a0e-4403-8dea-cc03cbb93070
+        :id: d7fd91aa-1a0e-4403-8dea-cc03cbb93070
 
-        @assert: organization is not created
+        :assert: organization is not created
         """
         with Session(self.browser) as session:
             for org_name in generate_strings_list():
@@ -240,9 +240,9 @@ class OrganizationTestCase(UITestCase):
     def test_positive_delete(self):
         """Create organization with valid values then delete it.
 
-        @id: 6b69d505-56b1-4d7d-bf2a-8762d5184ca8
+        :id: 6b69d505-56b1-4d7d-bf2a-8762d5184ca8
 
-        @assert: Organization is deleted successfully
+        :assert: Organization is deleted successfully
         """
         with Session(self.browser):
             for org_name in generate_strings_list():
@@ -258,11 +258,11 @@ class OrganizationTestCase(UITestCase):
         """Create Organization with valid values and upload manifest.
         Then try to delete that organization.
 
-        @id: 851c8557-a406-4a70-9c8b-94bcf0482f8d
+        :id: 851c8557-a406-4a70-9c8b-94bcf0482f8d
 
-        @assert: Organization is deleted successfully.
+        :assert: Organization is deleted successfully.
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         org_name = gen_string('alphanumeric')
         org = entities.Organization(name=org_name).create()
@@ -291,11 +291,11 @@ class OrganizationTestCase(UITestCase):
         certificate for that organization and refresh added manifest for few
         times in a row
 
-        @id: 1fcd7cd1-8ba1-434f-b9fb-c4e920046eb4
+        :id: 1fcd7cd1-8ba1-434f-b9fb-c4e920046eb4
 
-        @assert: Scenario passed successfully
+        :assert: Scenario passed successfully
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         org = entities.Organization().create()
         sub = entities.Subscription(organization=org)
@@ -319,9 +319,9 @@ class OrganizationTestCase(UITestCase):
     def test_positive_update_name(self):
         """Create organization with valid values then update its name.
 
-        @id: 776f5268-4f05-4cfc-a1e9-339a3e224677
+        :id: 776f5268-4f05-4cfc-a1e9-339a3e224677
 
-        @assert: Organization name is updated successfully
+        :assert: Organization name is updated successfully
         """
         org_name = gen_string('alpha')
         with Session(self.browser) as session:
@@ -338,9 +338,9 @@ class OrganizationTestCase(UITestCase):
         """Create organization with valid values then try to update it
         using incorrect name values
 
-        @id: 1467a04e-ebd6-4106-94b1-841a4f0ddecb
+        :id: 1467a04e-ebd6-4106-94b1-841a4f0ddecb
 
-        @assert: Organization name is not updated
+        :assert: Organization name is not updated
         """
         org_name = gen_string('alpha')
         with Session(self.browser) as session:
@@ -359,11 +359,11 @@ class OrganizationTestCase(UITestCase):
         """Add a domain to an organization and remove it by organization
         name and domain name.
 
-        @id: a49e86c7-f859-4120-b59e-3f89e99a9054
+        :id: a49e86c7-f859-4120-b59e-3f89e99a9054
 
-        @assert: the domain is removed from the organization
+        :assert: the domain is removed from the organization
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         with Session(self.browser) as session:
             for domain_name in generate_strings_list():
@@ -393,11 +393,11 @@ class OrganizationTestCase(UITestCase):
         """Create admin users then add user and remove it
         by using the organization name.
 
-        @id: 01a221f7-d0fe-4b46-ab5c-b4e861677126
+        :id: 01a221f7-d0fe-4b46-ab5c-b4e861677126
 
-        @assert: The user is added then removed from the organization
+        :assert: The user is added then removed from the organization
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         with Session(self.browser) as session:
             for user_name in valid_users():
@@ -435,11 +435,11 @@ class OrganizationTestCase(UITestCase):
         """Add a hostgroup and remove it by using the organization
         name and hostgroup name.
 
-        @id: 12e2fc40-d721-4e71-af7c-3db67b9e718e
+        :id: 12e2fc40-d721-4e71-af7c-3db67b9e718e
 
-        @assert: hostgroup is added to organization then removed.
+        :assert: hostgroup is added to organization then removed.
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         with Session(self.browser) as session:
             for host_grp_name in generate_strings_list():
@@ -476,13 +476,13 @@ class OrganizationTestCase(UITestCase):
     def test_positive_add_smartproxy(self):
         """Add a smart proxy by using org and smartproxy name
 
-        @id: 7ad6f610-91ca-4f1f-b9c4-8ce82f50ea9e
+        :id: 7ad6f610-91ca-4f1f-b9c4-8ce82f50ea9e
 
-        @assert: smartproxy is added
+        :assert: smartproxy is added
 
-        @caseautomation: notautomated
+        :caseautomation: notautomated
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
 
     @run_only_on('sat')
@@ -490,11 +490,11 @@ class OrganizationTestCase(UITestCase):
     def test_positive_add_subnet(self):
         """Add a subnet using organization name and subnet name.
 
-        @id: 6736cd82-a2b0-4fc0-a2bc-99c9f13464d7
+        :id: 6736cd82-a2b0-4fc0-a2bc-99c9f13464d7
 
-        @assert: subnet is added.
+        :assert: subnet is added.
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         with Session(self.browser) as session:
             for subnet_name in generate_strings_list():
@@ -521,11 +521,11 @@ class OrganizationTestCase(UITestCase):
     def test_positive_add_domain(self):
         """Add a domain to an organization.
 
-        @id: f5739862-ac2e-49ef-8f95-1823287f4978
+        :id: f5739862-ac2e-49ef-8f95-1823287f4978
 
-        @assert: Domain is added to organization.
+        :assert: Domain is added to organization.
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         with Session(self.browser) as session:
             for domain_name in generate_strings_list():
@@ -547,11 +547,11 @@ class OrganizationTestCase(UITestCase):
         """Create different types of users then add user using
         organization name.
 
-        @id: 5f2ec06b-952d-445d-b8a1-c32d74d33584
+        :id: 5f2ec06b-952d-445d-b8a1-c32d74d33584
 
-        @assert: User is added to organization.
+        :assert: User is added to organization.
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         with Session(self.browser) as session:
             for user_name in valid_users():
@@ -579,11 +579,11 @@ class OrganizationTestCase(UITestCase):
         """Add a hostgroup by using the organization
         name and hostgroup name.
 
-        @id: ce1b5334-5601-42ae-aa04-3e766daa3984
+        :id: ce1b5334-5601-42ae-aa04-3e766daa3984
 
-        @assert: hostgroup is added to organization
+        :assert: hostgroup is added to organization
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         with Session(self.browser) as session:
             for host_grp_name in generate_strings_list():
@@ -607,11 +607,11 @@ class OrganizationTestCase(UITestCase):
         """Add a location by using the organization name and location
         name
 
-        @id: 65ee568b-c0c5-4849-969d-02d7a804292c
+        :id: 65ee568b-c0c5-4849-969d-02d7a804292c
 
-        @assert: location is added to organization.
+        :assert: location is added to organization.
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         with Session(self.browser) as session:
             for location_name in generate_strings_list():
@@ -635,11 +635,11 @@ class OrganizationTestCase(UITestCase):
         """Remove compute resource using the organization name and
         compute resource name.
 
-        @id: db119bb1-8f79-415b-a056-70a19ffceeea
+        :id: db119bb1-8f79-415b-a056-70a19ffceeea
 
-        @assert: compute resource is added then removed.
+        :assert: compute resource is added then removed.
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         with Session(self.browser) as session:
             for resource_name in generate_strings_list():
@@ -680,11 +680,11 @@ class OrganizationTestCase(UITestCase):
     def test_positive_remove_medium(self):
         """Remove medium by using organization name and medium name.
 
-        @id: bcf3aaf4-cad9-4a22-a087-60b213eb87cf
+        :id: bcf3aaf4-cad9-4a22-a087-60b213eb87cf
 
-        @assert: medium is added then removed.
+        :assert: medium is added then removed.
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         with Session(self.browser) as session:
             for medium_name in generate_strings_list():
@@ -720,11 +720,11 @@ class OrganizationTestCase(UITestCase):
     def test_positive_remove_template(self):
         """Remove config template.
 
-        @id: 67bec745-5f10-494c-92a7-173ee63e8297
+        :id: 67bec745-5f10-494c-92a7-173ee63e8297
 
-        @assert: Config Template is added and then removed.
+        :assert: Config Template is added and then removed.
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         with Session(self.browser) as session:
             for template_name in generate_strings_list():
@@ -755,11 +755,11 @@ class OrganizationTestCase(UITestCase):
     def test_positive_remove_ptable(self):
         """Remove partition table.
 
-        @id: 75662a83-0921-45fd-a4b5-012c48bb003a
+        :id: 75662a83-0921-45fd-a4b5-012c48bb003a
 
-        @assert: Partition table is added and then removed.
+        :assert: Partition table is added and then removed.
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         with Session(self.browser) as session:
             for ptable_name in generate_strings_list():
@@ -790,11 +790,11 @@ class OrganizationTestCase(UITestCase):
     def test_positive_add_environment(self):
         """Add environment by using organization name and env name.
 
-        @id: 95b96642-0424-4df1-83ef-d548ceb6e10b
+        :id: 95b96642-0424-4df1-83ef-d548ceb6e10b
 
-        @assert: Environment is added.
+        :assert: Environment is added.
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         with Session(self.browser) as session:
             for env_name in valid_env_names():
@@ -818,13 +818,13 @@ class OrganizationTestCase(UITestCase):
         """Remove smartproxy by using organization name and smartproxy
         name
 
-        @id: 25bc6334-de59-462c-824a-51d615d9fdd0
+        :id: 25bc6334-de59-462c-824a-51d615d9fdd0
 
-        @assert: smartproxy is added then removed
+        :assert: smartproxy is added then removed
 
-        @caseautomation: notautomated
+        :caseautomation: notautomated
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
 
     @run_only_on('sat')
@@ -834,11 +834,11 @@ class OrganizationTestCase(UITestCase):
         """Add compute resource using the organization
         name and compute resource name.
 
-        @id: de9f755a-cf06-4ee0-a2f7-f1bfb1015b36
+        :id: de9f755a-cf06-4ee0-a2f7-f1bfb1015b36
 
-        @assert: compute resource is added.
+        :assert: compute resource is added.
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         with Session(self.browser) as session:
             for resource_name in generate_strings_list():
@@ -866,11 +866,11 @@ class OrganizationTestCase(UITestCase):
     def test_positive_add_medium(self):
         """Add medium by using the organization name and medium name.
 
-        @id: e9b1004d-55f0-448f-8013-543d8b9ec248
+        :id: e9b1004d-55f0-448f-8013-543d8b9ec248
 
-        @assert: medium is added.
+        :assert: medium is added.
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         with Session(self.browser) as session:
             for medium_name in generate_strings_list():
@@ -898,11 +898,11 @@ class OrganizationTestCase(UITestCase):
         """Add config template by using organization name and
         config template name.
 
-        @id: 2af534d4-2f92-4b25-81d9-d0129f9cf866
+        :id: 2af534d4-2f92-4b25-81d9-d0129f9cf866
 
-        @assert: config template is added
+        :assert: config template is added
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         with Session(self.browser) as session:
             for template_name in generate_strings_list():
@@ -924,11 +924,11 @@ class OrganizationTestCase(UITestCase):
     def test_positive_remove_environment(self):
         """Remove environment by using org & environment name.
 
-        @id: 270de90d-062e-4893-89c9-f6d0665ab967
+        :id: 270de90d-062e-4893-89c9-f6d0665ab967
 
-        @assert: environment is removed from Organization.
+        :assert: environment is removed from Organization.
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         with Session(self.browser) as session:
             for env_name in valid_env_names():
@@ -959,11 +959,11 @@ class OrganizationTestCase(UITestCase):
     def test_positive_remove_subnet(self):
         """Remove subnet by using organization name and subnet name.
 
-        @id: bc59bdeb-b538-4473-a096-e4de2454497d
+        :id: bc59bdeb-b538-4473-a096-e4de2454497d
 
-        @assert: subnet is added then removed.
+        :assert: subnet is added then removed.
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         with Session(self.browser) as session:
             for subnet_name in generate_strings_list():

--- a/tests/foreman/ui/test_oscapcontent.py
+++ b/tests/foreman/ui/test_oscapcontent.py
@@ -1,18 +1,18 @@
 """Tests for Oscapcontent
 
-@Requirement: Oscapcontent
+:Requirement: Oscapcontent
 
-@CaseAutomation: Automated
+:CaseAutomation: Automated
 
-@CaseLevel: Acceptance
+:CaseLevel: Acceptance
 
-@CaseComponent: UI
+:CaseComponent: UI
 
-@TestType: Functional
+:TestType: Functional
 
-@CaseImportance: High
+:CaseImportance: High
 
-@Upstream: No
+:Upstream: No
 """
 import unittest2
 
@@ -57,14 +57,14 @@ class OpenScapContentTestCase(UITestCase):
     def test_positive_create(self):
         """Create OpenScap content.
 
-        @id: 6580cffa-da37-40d5-affa-cfb1ff27c545
+        :id: 6580cffa-da37-40d5-affa-cfb1ff27c545
 
-        @Steps:
+        :Steps:
 
-        1. Create an openscap content.
-        2. Provide all the appropriate parameters.
+            1. Create an openscap content.
+            2. Provide all the appropriate parameters.
 
-        @Assert: Whether creating  content for OpenScap is successful.
+        :Assert: Whether creating  content for OpenScap is successful.
         """
         with Session(self.browser) as session:
             for content_name in valid_data_list():
@@ -83,16 +83,16 @@ class OpenScapContentTestCase(UITestCase):
     def test_negative_create_with_invalid_name(self):
         """Create OpenScap content with negative values
 
-        @id: 8ce0e8b4-396a-43cd-8cbe-fb60fcf853b0
+        :id: 8ce0e8b4-396a-43cd-8cbe-fb60fcf853b0
 
-        @Steps:
+        :Steps:
 
-        1. Create an openscap content.
-        2. Provide all the appropriate parameters.
+            1. Create an openscap content.
+            2. Provide all the appropriate parameters.
 
-        @Assert: Creating content for OpenScap is not successful.
+        :Assert: Creating content for OpenScap is not successful.
 
-        @BZ: 1289571
+        :BZ: 1289571
         """
         with Session(self.browser) as session:
             for content_name in invalid_values_list(interface='ui'):
@@ -112,14 +112,14 @@ class OpenScapContentTestCase(UITestCase):
     def test_positive_default(self):
         """Check whether OpenScap content exists by default.
 
-        @id: 0beca127-8294-4d85-bace-b9170215c0cd
+        :id: 0beca127-8294-4d85-bace-b9170215c0cd
 
-        @Steps:
+        :Steps:
 
-        1. Set Org as Any Org.
-        2. Navigate to oscap Content page.
+            1. Set Org as Any Org.
+            2. Navigate to oscap Content page.
 
-        @Assert: Whether oscap content exists by default.
+        :Assert: Whether oscap content exists by default.
         """
         # see BZ 1336374
         with Session(self.browser):
@@ -132,17 +132,17 @@ class OpenScapContentTestCase(UITestCase):
     def test_positive_update(self):
         """Update OpenScap content.
 
-        @id: 9870555d-0b60-41ab-a481-81d4d3f78fec
+        :id: 9870555d-0b60-41ab-a481-81d4d3f78fec
 
-        @Steps:
+        :Steps:
 
-        1. Create an openscap content.
-        2. Provide all the appropriate parameters.
-        3. Update the openscap content, here the Org.
+            1. Create an openscap content.
+            2. Provide all the appropriate parameters.
+            3. Update the openscap content, here the Org.
 
-        @Assert: Whether creating  content for OpenScap is successful.
+        :Assert: Whether creating  content for OpenScap is successful.
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         org = entities.Organization(name=gen_string('alpha')).create()
         content_name = gen_string('alpha')
@@ -162,15 +162,15 @@ class OpenScapContentTestCase(UITestCase):
     def test_positive_delete(self):
         """Create OpenScap content and then delete it.
 
-        @id: 8eade129-5666-4e90-ba3e-f0c51a3090ce
+        :id: 8eade129-5666-4e90-ba3e-f0c51a3090ce
 
-        @Steps:
+        :Steps:
 
-        1. Create an openscap content.
-        2. Provide all the appropriate parameters.
-        3. Delete the openscap content.
+            1. Create an openscap content.
+            2. Provide all the appropriate parameters.
+            3. Delete the openscap content.
 
-        @Assert: Deleting content for OpenScap is successful.
+        :Assert: Deleting content for OpenScap is successful.
         """
         with Session(self.browser) as session:
             for content_name in valid_data_list():

--- a/tests/foreman/ui/test_oscappolicy.py
+++ b/tests/foreman/ui/test_oscappolicy.py
@@ -1,18 +1,18 @@
 """Tests for Oscappolicy
 
-@Requirement: Oscappolicy
+:Requirement: Oscappolicy
 
-@CaseAutomation: Automated
+:CaseAutomation: Automated
 
-@CaseLevel: Acceptance
+:CaseLevel: Acceptance
 
-@CaseComponent: UI
+:CaseComponent: UI
 
-@TestType: Functional
+:TestType: Functional
 
-@CaseImportance: High
+:CaseImportance: High
 
-@Upstream: No
+:Upstream: No
 """
 from fauxfactory import gen_string
 from robottelo.config import settings
@@ -44,15 +44,15 @@ class OpenScapPolicy(UITestCase):
     def test_positive_create_with_policy_name(self):
         """Create OpenScap Policy.
 
-        @id: cdf2bc8c-ce60-4d49-b4e9-9acbf1192bc2
+        :id: cdf2bc8c-ce60-4d49-b4e9-9acbf1192bc2
 
-        @Steps:
+        :Steps:
 
-        1. Create an openscap content.
-        2. Create an openscap Policy.
-        3. Provide all the appropriate parameters.
+            1. Create an openscap content.
+            2. Create an openscap Policy.
+            3. Provide all the appropriate parameters.
 
-        @Assert: Whether creating  Policy for OpenScap is successful.
+        :Assert: Whether creating  Policy for OpenScap is successful.
         """
         content_name = gen_string('alpha')
         with Session(self.browser) as session:
@@ -80,16 +80,16 @@ class OpenScapPolicy(UITestCase):
     def test_positive_delete_by_policy_name(self):
         """Create OpenScap Policy.
 
-        @id: 7497aad0-1e2f-426e-928d-72e430a0e853
+        :id: 7497aad0-1e2f-426e-928d-72e430a0e853
 
-        @Steps:
+        :Steps:
 
-        1. Create an openscap content.
-        2. Create an openscap Policy.
-        3. Provide all the appropriate parameters.
-        4. Delete the openscap Policy.
+            1. Create an openscap content.
+            2. Create an openscap Policy.
+            3. Provide all the appropriate parameters.
+            4. Delete the openscap Policy.
 
-        @Assert: Whether deleting  Policy for OpenScap is successful.
+        :Assert: Whether deleting  Policy for OpenScap is successful.
         """
         content_name = gen_string('alpha')
         with Session(self.browser) as session:
@@ -119,17 +119,17 @@ class OpenScapPolicy(UITestCase):
     def test_negative_create_with_invalid_name(self):
         """Create OpenScap Policy with negative values.
 
-        @id: dfebf26b-194f-473d-b5a6-9061c520f57e
+        :id: dfebf26b-194f-473d-b5a6-9061c520f57e
 
-        @Steps:
+        :Steps:
 
-        1. Create an openscap content.
-        2. Create an openscap Policy.
-        3. Provide all the appropriate parameters.
+            1. Create an openscap content.
+            2. Create an openscap Policy.
+            3. Provide all the appropriate parameters.
 
-        @Assert: Creating  Policy for OpenScap is not successful.
+        :Assert: Creating  Policy for OpenScap is not successful.
 
-        @BZ: 1293296
+        :BZ: 1293296
         """
         content_name = gen_string('alpha')
         with Session(self.browser) as session:
@@ -156,16 +156,16 @@ class OpenScapPolicy(UITestCase):
     def test_positive_update(self):
         """Update OpenScap Policy.
 
-        @id: 58392782-ab25-4c12-aebc-adf23c5d9d43
+        :id: 58392782-ab25-4c12-aebc-adf23c5d9d43
 
-        @Steps:
+        :Steps:
 
-        1. Create an openscap content.
-        2. Create an openscap Policy.
-        3. Provide all the appropriate parameters.
-        4. Update openscap policy with valid values.
+            1. Create an openscap content.
+            2. Create an openscap Policy.
+            3. Provide all the appropriate parameters.
+            4. Update openscap policy with valid values.
 
-        @Assert: Updating Policy for OpenScap is successful.
+        :Assert: Updating Policy for OpenScap is successful.
         """
         content_name = gen_string('alpha')
         policy_name = gen_string('alpha')
@@ -206,18 +206,18 @@ class OpenScapPolicy(UITestCase):
     def test_positive_create_with_space_policy_name(self):
         """Create OpenScap Policy with a space in its name.
 
-        @id: a45ec231-0ca9-4719-9239-eef0355822dc
+        :id: a45ec231-0ca9-4719-9239-eef0355822dc
 
-        @Steps:
+        :Steps:
 
-        1. Create an openscap content.
-        2. Create an openscap Policy.
-        3. Provide openscap policy name with space in it.
-        4. Provide all other the appropriate parameters.
+            1. Create an openscap content.
+            2. Create an openscap Policy.
+            3. Provide openscap policy name with space in it.
+            4. Provide all other the appropriate parameters.
 
-        @Assert: Creation of Policy with a space in its name is successful.
+        :Assert: Creation of Policy with a space in its name is successful.
 
-        @BZ: 1292622
+        :BZ: 1292622
         """
         content_name = gen_string('alpha')
         with Session(self.browser) as session:

--- a/tests/foreman/ui/test_packages.py
+++ b/tests/foreman/ui/test_packages.py
@@ -1,19 +1,19 @@
 # -*- encoding: utf-8 -*-
 """Test class for Packages UI
 
-@Requirement: Packages
+:Requirement: Packages
 
-@CaseAutomation: Automated
+:CaseAutomation: Automated
 
-@CaseLevel: Acceptance
+:CaseLevel: Acceptance
 
-@CaseComponent: UI
+:CaseComponent: UI
 
-@TestType: Functional
+:TestType: Functional
 
-@CaseImportance: High
+:CaseImportance: High
 
-@Upstream: No
+:Upstream: No
 """
 
 from fauxfactory import gen_string
@@ -64,12 +64,12 @@ class PackagesTestCase(UITestCase):
         """Create product with yum repository assigned to it. Search for
         packages inside of it
 
-        @id: e182a89f-74e4-4b29-8152-1ea3bd014fd3
+        :id: e182a89f-74e4-4b29-8152-1ea3bd014fd3
 
-        @Assert: Content search functionality works as intended and expected
-        packages are present inside of repository
+        :Assert: Content search functionality works as intended and expected
+            packages are present inside of repository
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         with Session(self.browser) as session:
             session.nav.go_to_select_org(self.organization.name)
@@ -83,12 +83,12 @@ class PackagesTestCase(UITestCase):
         Search for packages inside of these repositories. Make sure that unique
         packages present in corresponding repos.
 
-        @id: 249ac04b-8e31-42e9-ac37-08608bf867a1
+        :id: 249ac04b-8e31-42e9-ac37-08608bf867a1
 
-        @Assert: Content search functionality works as intended and expected
-        packages are present inside of repositories
+        :Assert: Content search functionality works as intended and expected
+            packages are present inside of repositories
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         with Session(self.browser) as session:
             session.nav.go_to_select_org(self.organization.name)
@@ -107,12 +107,12 @@ class PackagesTestCase(UITestCase):
         package inside of it and then open it. Check all the details about that
         package
 
-        @id: 57625386-4a9e-4bea-b2d5-d97326043150
+        :id: 57625386-4a9e-4bea-b2d5-d97326043150
 
-        @Assert: Package is present inside of repository and has all expected
-        values in details section
+        :Assert: Package is present inside of repository and has all expected
+            values in details section
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         with Session(self.browser) as session:
             session.nav.go_to_select_org(self.organization.name)
@@ -142,14 +142,14 @@ class PackagesTestCase(UITestCase):
         """Upload custom rpm package to repository. Search for package
         and then open it. Check that package details are available
 
-        @id: 679622a7-003e-4887-8622-b95b9468da7d
+        :id: 679622a7-003e-4887-8622-b95b9468da7d
 
-        @Assert: Package is present inside of repository and it possible to
-        view its details
+        :Assert: Package is present inside of repository and it possible to
+            view its details
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
 
-        @BZ: 1384673
+        :BZ: 1384673
         """
         with open(get_data_file(RPM_TO_UPLOAD), 'rb') as handle:
             self.yum_repo.upload_content(files={'content': handle})
@@ -190,12 +190,12 @@ class RHPackagesTestCase(UITestCase):
         """Synchronize one of RH repos (for example Satellite Tools). Search
         for packages inside of it
 
-        @id: 8eae9cc1-6902-49ed-a474-ef175fe5ab5f
+        :id: 8eae9cc1-6902-49ed-a474-ef175fe5ab5f
 
-        @Assert: Content search functionality works as intended and expected
-        packages are present inside of repository
+        :Assert: Content search functionality works as intended and expected
+            packages are present inside of repository
 
-        @CaseLevel: System
+        :CaseLevel: System
         """
         with Session(self.browser) as session:
             session.nav.go_to_select_org(self.organization.name)
@@ -209,12 +209,12 @@ class RHPackagesTestCase(UITestCase):
         for packages inside of it. Open one of the package and check list of
         file inside of it
 
-        @id: 01c9dccb-2b2b-4b90-b277-047e772e56e7
+        :id: 01c9dccb-2b2b-4b90-b277-047e772e56e7
 
-        @Assert: Content search functionality works as intended and package
-        contains expected list of files
+        :Assert: Content search functionality works as intended and package
+            contains expected list of files
 
-        @CaseLevel: System
+        :CaseLevel: System
         """
         with Session(self.browser) as session:
             session.nav.go_to_select_org(self.organization.name)

--- a/tests/foreman/ui/test_partitiontable.py
+++ b/tests/foreman/ui/test_partitiontable.py
@@ -1,19 +1,19 @@
 # -*- encoding: utf-8 -*-
 """Test class for Partition Table UI
 
-@Requirement: Partitiontable
+:Requirement: Partitiontable
 
-@CaseAutomation: Automated
+:CaseAutomation: Automated
 
-@CaseLevel: Acceptance
+:CaseLevel: Acceptance
 
-@CaseComponent: UI
+:CaseComponent: UI
 
-@TestType: Functional
+:TestType: Functional
 
-@CaseImportance: High
+:CaseImportance: High
 
-@Upstream: No
+:Upstream: No
 """
 from fauxfactory import gen_string
 from nailgun import entities
@@ -45,11 +45,11 @@ class PartitionTableTestCase(UITestCase):
     def test_positive_create_with_one_character_name(self):
         """Create a Partition table with 1 character in name
 
-        @id: 2b8ee84f-34d4-464f-8fcb-4dd9647e43f0
+        :id: 2b8ee84f-34d4-464f-8fcb-4dd9647e43f0
 
-        @Assert: Partition table is created
+        :Assert: Partition table is created
 
-        @BZ: 1229384
+        :BZ: 1229384
         """
         with Session(self.browser) as session:
             for name in generate_strings_list(length=1):
@@ -67,9 +67,9 @@ class PartitionTableTestCase(UITestCase):
     def test_positive_create_with_name(self):
         """Create a new partition table
 
-        @id: 2dd8e34d-5a39-49d0-9bde-dd1cdfddb2ad
+        :id: 2dd8e34d-5a39-49d0-9bde-dd1cdfddb2ad
 
-        @Assert: Partition table is created
+        :Assert: Partition table is created
         """
         with Session(self.browser) as session:
             for name in generate_strings_list():
@@ -87,9 +87,9 @@ class PartitionTableTestCase(UITestCase):
     def test_positive_create_with_snippet(self):
         """Create a new partition table with enabled snippet option
 
-        @id: 37bb748a-63d1-4d88-954f-71634168072a
+        :id: 37bb748a-63d1-4d88-954f-71634168072a
 
-        @Assert: Partition table is created
+        :Assert: Partition table is created
         """
         name = gen_string('alpha')
         with Session(self.browser) as session:
@@ -107,9 +107,9 @@ class PartitionTableTestCase(UITestCase):
         """Create a new partition table with some text inputted into audit
         comment section
 
-        @id: f17e16ff-b07f-44ec-a824-b9af460c35aa
+        :id: f17e16ff-b07f-44ec-a824-b9af460c35aa
 
-        @Assert: Partition table is created
+        :Assert: Partition table is created
         """
         name = gen_string('alpha')
         with Session(self.browser) as session:
@@ -129,12 +129,12 @@ class PartitionTableTestCase(UITestCase):
         """Create new partition table with enabled 'default' option. Check
         that newly created organization has that partition table assigned to it
 
-        @id: 91c64054-cd0c-4d4b-888b-17d42e298527
+        :id: 91c64054-cd0c-4d4b-888b-17d42e298527
 
-        @Assert: New partition table is created and is present in the list of
-        selected partition tables for any new organization
+        :Assert: New partition table is created and is present in the list of
+            selected partition tables for any new organization
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         name = gen_string('alpha')
         org_name = gen_string('alpha')
@@ -161,12 +161,12 @@ class PartitionTableTestCase(UITestCase):
         """Create new partition table with disabled 'default' option. Check
         that newly created organization does not contain that partition table.
 
-        @id: 69e6df0f-af1f-4aa2-8987-3e3b9a16be37
+        :id: 69e6df0f-af1f-4aa2-8987-3e3b9a16be37
 
-        @Assert: New partition table is created and is not present in the list
-        of selected partition tables for any new organization
+        :Assert: New partition table is created and is not present in the list
+            of selected partition tables for any new organization
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         name = gen_string('alpha')
         org_name = gen_string('alpha')
@@ -193,12 +193,12 @@ class PartitionTableTestCase(UITestCase):
         """Create new partition table with enabled 'default' option. Check
         that newly created location has that partition table assigned to it
 
-        @id: 8dfaae7c-2f33-4f0d-93f6-1f78ea4d750d
+        :id: 8dfaae7c-2f33-4f0d-93f6-1f78ea4d750d
 
-        @Assert: New partition table is created and is present in the list of
-        selected partition tables for any new location
+        :Assert: New partition table is created and is present in the list of
+            selected partition tables for any new location
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         name = gen_string('alpha')
         loc_name = gen_string('alpha')
@@ -225,12 +225,12 @@ class PartitionTableTestCase(UITestCase):
         """Create new partition table with disabled 'default' option. Check
         that newly created location does not contain that partition table.
 
-        @id: 094d4583-763b-48d4-a89a-23b90741fd6f
+        :id: 094d4583-763b-48d4-a89a-23b90741fd6f
 
-        @Assert: New partition table is created and is not present in the list
-        of selected partition tables for any new location
+        :Assert: New partition table is created and is not present in the list
+            of selected partition tables for any new location
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         name = gen_string('alpha')
         org_name = gen_string('alpha')
@@ -256,9 +256,9 @@ class PartitionTableTestCase(UITestCase):
     def test_negative_create_with_invalid_name(self):
         """Create partition table with invalid names
 
-        @id: 225f1bb9-d5b2-4863-b89b-416f7cf5a7be
+        :id: 225f1bb9-d5b2-4863-b89b-416f7cf5a7be
 
-        @Assert: Partition table is not created
+        :Assert: Partition table is not created
         """
         with Session(self.browser) as session:
             for name in invalid_values_list(interface='ui'):
@@ -279,9 +279,9 @@ class PartitionTableTestCase(UITestCase):
     def test_negative_create_with_same_name(self):
         """Create a new partition table with same name
 
-        @id: 3462ff33-1645-41c1-8fbd-513c7e4a18ed
+        :id: 3462ff33-1645-41c1-8fbd-513c7e4a18ed
 
-        @Assert: Partition table is not created
+        :Assert: Partition table is not created
         """
         name = gen_string('utf8')
         os_family = 'Red Hat'
@@ -307,9 +307,9 @@ class PartitionTableTestCase(UITestCase):
     def test_negative_create_with_empty_layout(self):
         """Create a new partition table with empty layout
 
-        @id: 427bce9b-c38e-4d78-943f-3cc7f422ebcd
+        :id: 427bce9b-c38e-4d78-943f-3cc7f422ebcd
 
-        @Assert: Partition table is not created
+        :Assert: Partition table is not created
         """
         name = gen_string('utf8')
         with Session(self.browser) as session:
@@ -324,9 +324,9 @@ class PartitionTableTestCase(UITestCase):
     def test_positive_delete(self):
         """Delete a partition table
 
-        @id: 405ed98a-4207-4bf8-899e-dcea7791850e
+        :id: 405ed98a-4207-4bf8-899e-dcea7791850e
 
-        @Assert: Partition table is deleted
+        :Assert: Partition table is deleted
         """
         with Session(self.browser) as session:
             for name in generate_strings_list():
@@ -344,9 +344,9 @@ class PartitionTableTestCase(UITestCase):
     def test_positive_update(self):
         """Update partition table with its name, layout and OS family
 
-        @id: 63203508-7c73-4ce0-853e-64564167bec3
+        :id: 63203508-7c73-4ce0-853e-64564167bec3
 
-        @Assert: Partition table is updated
+        :Assert: Partition table is updated
         """
         name = gen_string('alphanumeric')
         with Session(self.browser) as session:
@@ -373,9 +373,9 @@ class PartitionTableTestCase(UITestCase):
     def test_negative_update_name(self):
         """Update invalid name in partition table
 
-        @id: 704e8336-e14a-4d1a-b9db-2f81c8af6ecc
+        :id: 704e8336-e14a-4d1a-b9db-2f81c8af6ecc
 
-        @Assert: Partition table is not updated.  Appropriate error shown.
+        :Assert: Partition table is not updated.  Appropriate error shown.
         """
         name = gen_string('alphanumeric')
         with Session(self.browser) as session:

--- a/tests/foreman/ui/test_product.py
+++ b/tests/foreman/ui/test_product.py
@@ -1,19 +1,19 @@
 # -*- encoding: utf-8 -*-
 """Test class for Products UI
 
-@Requirement: Product
+:Requirement: Product
 
-@CaseAutomation: Automated
+:CaseAutomation: Automated
 
-@CaseLevel: Acceptance
+:CaseLevel: Acceptance
 
-@CaseComponent: UI
+:CaseComponent: UI
 
-@TestType: Functional
+:TestType: Functional
 
-@CaseImportance: High
+:CaseImportance: High
 
-@Upstream: No
+:Upstream: No
 """
 
 from fauxfactory import gen_string
@@ -41,9 +41,9 @@ class ProductTestCase(UITestCase):
         """Create Content Product providing different names and minimal
         input parameters
 
-        @id: b73d9440-1f30-4fc5-ad7c-e1febe879cbc
+        :id: b73d9440-1f30-4fc5-ad7c-e1febe879cbc
 
-        @Assert: Product is created
+        :Assert: Product is created
         """
         with Session(self.browser) as session:
             for prd_name in generate_strings_list():
@@ -62,11 +62,11 @@ class ProductTestCase(UITestCase):
     def test_positive_create_in_different_orgs(self):
         """Create Content Product with same name but in another org
 
-        @id: 469fc036-a48a-4c0a-9da9-33e73f903479
+        :id: 469fc036-a48a-4c0a-9da9-33e73f903479
 
-        @Assert: Product is created successfully in both organizations.
+        :Assert: Product is created successfully in both organizations.
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         organization_2 = entities.Organization().create()
         with Session(self.browser) as session:
@@ -87,9 +87,9 @@ class ProductTestCase(UITestCase):
     def test_negative_create_with_invalid_name(self):
         """Create Content Product with invalid names
 
-        @id: 11efd16c-6471-4191-934f-79c7278c66e8
+        :id: 11efd16c-6471-4191-934f-79c7278c66e8
 
-        @Assert: Product is not created
+        :Assert: Product is not created
         """
         with Session(self.browser) as session:
             for name in invalid_values_list(interface='ui'):
@@ -109,9 +109,9 @@ class ProductTestCase(UITestCase):
     def test_negative_create_with_same_name(self):
         """Create Content Product with same name input parameter
 
-        @id: 90ceee6e-0ccc-4065-87ba-42d36484f032
+        :id: 90ceee6e-0ccc-4065-87ba-42d36484f032
 
-        @Assert: Product is not created
+        :Assert: Product is not created
         """
         prd_name = gen_string('alphanumeric')
         description = gen_string('alphanumeric')
@@ -133,9 +133,9 @@ class ProductTestCase(UITestCase):
     def test_positive_update_name(self):
         """Update Content Product name with minimal input parameters
 
-        @id: 2c0539b4-84e1-46c6-aaca-12fe3865da3d
+        :id: 2c0539b4-84e1-46c6-aaca-12fe3865da3d
 
-        @Assert: Product is updated
+        :Assert: Product is updated
         """
         prd_name = gen_string('alpha')
         with Session(self.browser) as session:
@@ -158,11 +158,11 @@ class ProductTestCase(UITestCase):
     def test_positive_update_to_original_name(self):
         """Rename Product back to original name.
 
-        @id: 6632effe-06ba-4690-b81d-4f5eae20b7b9
+        :id: 6632effe-06ba-4690-b81d-4f5eae20b7b9
 
-        @Assert: Product renamed to previous value.
+        :Assert: Product renamed to previous value.
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         prd_name = gen_string('alphanumeric')
         new_prd_name = gen_string('alphanumeric')
@@ -185,9 +185,9 @@ class ProductTestCase(UITestCase):
     def test_negative_update_with_too_long_name(self):
         """Update Content Product with too long input parameters
 
-        @id: c6938675-4a2a-4bec-9315-b1c951b628bb
+        :id: c6938675-4a2a-4bec-9315-b1c951b628bb
 
-        @Assert: Product is not updated
+        :Assert: Product is not updated
         """
         prd_name = gen_string('alpha')
         with Session(self.browser) as session:
@@ -208,9 +208,9 @@ class ProductTestCase(UITestCase):
     def test_positive_delete(self):
         """Delete Content Product
 
-        @id: cf80bafb-8581-483a-b5c1-3a162642c6c1
+        :id: cf80bafb-8581-483a-b5c1-3a162642c6c1
 
-        @Assert: Product is deleted
+        :Assert: Product is deleted
         """
         with Session(self.browser) as session:
             for prd_name in generate_strings_list():

--- a/tests/foreman/ui/test_puppet.py
+++ b/tests/foreman/ui/test_puppet.py
@@ -1,18 +1,18 @@
 """End to end test for Puppet funcionality
 
-@Requirement: Puppet
+:Requirement: Puppet
 
-@CaseAutomation: Automated
+:CaseAutomation: Automated
 
-@CaseLevel: Acceptance
+:CaseLevel: Acceptance
 
-@CaseComponent: UI
+:CaseComponent: UI
 
-@TestType: Functional
+:TestType: Functional
 
-@CaseImportance: High
+:CaseImportance: High
 
-@Upstream: No
+:Upstream: No
 """
 
 from robottelo.config import settings
@@ -42,33 +42,34 @@ class PuppetTestCase(UITestCase):
     def test_positive_puppet_scenario(self):
         """Tests extensive all-in-one puppet scenario
 
-        @id: eecfbd37-2bd4-41d3-b6fd-9b3427d1158d
+        :id: eecfbd37-2bd4-41d3-b6fd-9b3427d1158d
 
-        @Steps:
+        :Steps:
 
-        1. Create an organization and upload a cloned manifest for it.
-        2. Enable respective Satellite Tools repos and sync them.
-        3. Create a product and a LFE
-        4. Create a puppet repos within the product
-        5. Upload motd puppet module into the repo
-        6. Upload parameterizable puppet module and create smart params for it
-        7. Create a CV and add Tools repo and puppet module(s)
-        8. Publish and promote CV to the LFE
-        9. Create AK with the product and enable Satellite Tools in it
-        10. Create a libvirt compute resource
-        11. Create a sane subnet and sane domain to be used by libvirt
-        12. Create a hostgroup associated with all created entities
-            (especially Puppet Classes has added puppet modules)
-        13. Provision a host using the hostgroup on libvirt resource
-        14. Assert that puppet agent can run on the host
-        15. Assert that the puppet modules get installed by provisioning
-        16. Run facter on host and assert that was successful
+            1. Create an organization and upload a cloned manifest for it.
+            2. Enable respective Satellite Tools repos and sync them.
+            3. Create a product and a LFE
+            4. Create a puppet repos within the product
+            5. Upload motd puppet module into the repo
+            6. Upload parameterizable puppet module and create smart params for
+                it
+            7. Create a CV and add Tools repo and puppet module(s)
+            8. Publish and promote CV to the LFE
+            9. Create AK with the product and enable Satellite Tools in it
+            10. Create a libvirt compute resource
+            11. Create a sane subnet and sane domain to be used by libvirt
+            12. Create a hostgroup associated with all created entities
+                (especially Puppet Classes has added puppet modules)
+            13. Provision a host using the hostgroup on libvirt resource
+            14. Assert that puppet agent can run on the host
+            15. Assert that the puppet modules get installed by provisioning
+            16. Run facter on host and assert that was successful
 
-        @Assert: multiple asserts along the code
+        :Assert: multiple asserts along the code
 
-        @caseautomation: notautomated
+        :caseautomation: notautomated
 
-        @CaseLevel: System
+        :CaseLevel: System
         """
 
 
@@ -88,31 +89,32 @@ class PuppetCapsuleTestCase(UITestCase):
     def test_positive_puppet_capsule_scenario(self):
         """Tests extensive all-in-one puppet scenario via Capsule
 
-        @id: d028bb38-2224-45fd-b2af-79666c6b0b72
+        :id: d028bb38-2224-45fd-b2af-79666c6b0b72
 
-        @Steps:
+        :Steps:
 
-        1. Create an organization and upload a cloned manifest for it.
-        2. Enable respective Satellite Tools repos and sync them.
-        3. Create a product and a LFE
-        4. Create a puppet repos within the product
-        5. Upload motd puppet module into the repo
-        6. Upload parameterizable puppet module and create smart params for it
-        7. Create a CV and add Tools repo and puppet module(s)
-        8. Publish and promote CV to the LFE
-        9. Create AK with the product and enable Satellite Tools in it
-        10. Create a libvirt compute resource
-        11. Create a sane subnet and sane domain to be used by libvirt
-        12. Create a hostgroup associated with all created entities
-            (especially Puppet Classes has added puppet modules)
-        13. Provision a host using the hostgroup on libvirt resource
-        14. Assert that puppet agent can run on the host
-        15. Assert that the puppet modules get installed by provisioning
-        16. Run facter on host and assert that was successful
+            1. Create an organization and upload a cloned manifest for it.
+            2. Enable respective Satellite Tools repos and sync them.
+            3. Create a product and a LFE
+            4. Create a puppet repos within the product
+            5. Upload motd puppet module into the repo
+            6. Upload parameterizable puppet module and create smart params for
+                it
+            7. Create a CV and add Tools repo and puppet module(s)
+            8. Publish and promote CV to the LFE
+            9. Create AK with the product and enable Satellite Tools in it
+            10. Create a libvirt compute resource
+            11. Create a sane subnet and sane domain to be used by libvirt
+            12. Create a hostgroup associated with all created entities
+                (especially Puppet Classes has added puppet modules)
+            13. Provision a host using the hostgroup on libvirt resource
+            14. Assert that puppet agent can run on the host
+            15. Assert that the puppet modules get installed by provisioning
+            16. Run facter on host and assert that was successful
 
-        @Assert: multiple asserts along the code
+        :Assert: multiple asserts along the code
 
-        @caseautomation: notautomated
+        :caseautomation: notautomated
 
-        @CaseLevel: System
+        :CaseLevel: System
         """

--- a/tests/foreman/ui/test_puppetclass.py
+++ b/tests/foreman/ui/test_puppetclass.py
@@ -1,19 +1,19 @@
 # -*- encoding: utf-8 -*-
 """Test class for Puppet Classes UI
 
-@Requirement: Puppetclass
+:Requirement: Puppetclass
 
-@CaseAutomation: Automated
+:CaseAutomation: Automated
 
-@CaseLevel: Acceptance
+:CaseLevel: Acceptance
 
-@CaseComponent: UI
+:CaseComponent: UI
 
-@TestType: Functional
+:TestType: Functional
 
-@CaseImportance: High
+:CaseImportance: High
 
-@Upstream: No
+:Upstream: No
 """
 
 from nailgun import entities
@@ -32,9 +32,9 @@ class PuppetClassTestCase(UITestCase):
         """Create new puppet-class and update its description to a valid
         one
 
-        @id: 711fe4de-b62f-48b5-9845-2d8725eb3548
+        :id: 711fe4de-b62f-48b5-9845-2d8725eb3548
 
-        @Assert: Puppet-Classes is updated successfully.
+        :Assert: Puppet-Classes is updated successfully.
         """
         class_name = 'foreman_scap_client'
         param_name = 'ca_file'
@@ -59,9 +59,9 @@ class PuppetClassTestCase(UITestCase):
     def test_positive_delete(self):
         """Create new puppet-class and then delete it
 
-        @id: 0d6e579e-8a7a-46a1-9932-5f345905671d
+        :id: 0d6e579e-8a7a-46a1-9932-5f345905671d
 
-        @Assert: Puppet-Class is deleted successfully.
+        :Assert: Puppet-Class is deleted successfully.
         """
         with Session(self.browser):
             for name in valid_data_list():

--- a/tests/foreman/ui/test_puppetmodule.py
+++ b/tests/foreman/ui/test_puppetmodule.py
@@ -1,19 +1,19 @@
 # -*- encoding: utf-8 -*-
 """Test class for Puppet Module UI
 
-@Requirement: Puppet Module
+:Requirement: Puppet Module
 
-@CaseAutomation: Automated
+:CaseAutomation: Automated
 
-@CaseLevel: Acceptance
+:CaseLevel: Acceptance
 
-@CaseComponent: UI
+:CaseComponent: UI
 
-@TestType: Functional
+:TestType: Functional
 
-@CaseImportance: High
+:CaseImportance: High
 
-@Upstream: No
+:Upstream: No
 """
 
 from nailgun import entities
@@ -50,10 +50,10 @@ class PuppetModuleTestCase(UITestCase):
         """Create product with puppet repository assigned to it. Search for
         modules inside of it
 
-        @id: 86af4bff-a404-453e-b05a-912ac8aeb52d
+        :id: 86af4bff-a404-453e-b05a-912ac8aeb52d
 
-        @Assert: Content search functionality works as intended and expected
-        puppet modules are present inside of repository
+        :Assert: Content search functionality works as intended and expected
+            puppet modules are present inside of repository
         """
         with Session(self.browser):
             self.assertIsNotNone(self.puppetmodule.search('ntp'))
@@ -64,10 +64,10 @@ class PuppetModuleTestCase(UITestCase):
         module inside of it and then open it. Check all the details about that
         puppet module
 
-        @id: 15dc567c-1e9a-4008-a3bc-40c1dbd69ae1
+        :id: 15dc567c-1e9a-4008-a3bc-40c1dbd69ae1
 
-        @Assert: Puppet module is present inside of repository and has all
-        expected values in details section
+        :Assert: Puppet module is present inside of repository and has all
+            expected values in details section
         """
         with Session(self.browser):
             self.puppetmodule.check_puppet_details(
@@ -96,10 +96,10 @@ class PuppetModuleTestCase(UITestCase):
         module inside of it and then open it. Check that proper repositories
         are displayed for Puppet Module in Library Repositories tab
 
-        @id: 7de4325c-905a-4fde-8e30-01a6a40b9e31
+        :id: 7de4325c-905a-4fde-8e30-01a6a40b9e31
 
-        @Assert: Puppet module is present inside of repository and has proper
-        repositories assigned to
+        :Assert: Puppet module is present inside of repository and has proper
+            repositories assigned to
         """
         with Session(self.browser):
             self.puppetmodule.check_repo('ntp', [self.repo.name])

--- a/tests/foreman/ui/test_remoteexecution.py
+++ b/tests/foreman/ui/test_remoteexecution.py
@@ -1,18 +1,18 @@
 """Test class for Remote Execution Management UI
 
-@Requirement: Remoteexecution
+:Requirement: Remoteexecution
 
-@CaseAutomation: Automated
+:CaseAutomation: Automated
 
-@CaseLevel: Acceptance
+:CaseLevel: Acceptance
 
-@CaseComponent: UI
+:CaseComponent: UI
 
-@TestType: Functional
+:TestType: Functional
 
-@CaseImportance: High
+:CaseImportance: High
 
-@Upstream: No
+:Upstream: No
 """
 from datetime import datetime, timedelta
 from nailgun import entities
@@ -49,18 +49,18 @@ class JobsTemplateTestCase(UITestCase):
     def test_positive_create_simple_job_template(self):
         """Create a simple Job Template
 
-        @id: 7cb1e5b0-5420-47c5-bb43-e2c58bed7a9d
+        :id: 7cb1e5b0-5420-47c5-bb43-e2c58bed7a9d
 
-        @Steps:
+        :Steps:
 
-        1. Navigate to Hosts -> Job Templates
-        2. Enter a valid name
-        3. Populate the template code
-        4. Navigate to the job tab
-        5. Enter a job name
-        6. Click submit
+            1. Navigate to Hosts -> Job Templates
+            2. Enter a valid name
+            3. Populate the template code
+            4. Navigate to the job tab
+            5. Enter a job name
+            6. Click submit
 
-        @Assert: The job template was successfully created
+        :Assert: The job template was successfully created
         """
         with Session(self.browser) as session:
             for name in generate_strings_list():
@@ -77,18 +77,18 @@ class JobsTemplateTestCase(UITestCase):
     def test_positive_template_upload(self):
         """Use a template file to populate the job template
 
-        @id: 976cf310-b2af-41bd-845a-f08baa2e8490
+        :id: 976cf310-b2af-41bd-845a-f08baa2e8490
 
-        @Setup: Create or use a pre-made job template file
+        :Setup: Create or use a pre-made job template file
 
-        @Steps:
+        :Steps:
 
-        1. Create a new job template.
-        2. Enter a valid name
-        3. Click the upload button to upload a template from the file
-        4. Select the file with the desired template
+            1. Create a new job template.
+            2. Enter a valid name
+            3. Click the upload button to upload a template from the file
+            4. Select the file with the desired template
 
-        @Assert: Verify the template correctly imported the file's contents
+        :Assert: Verify the template correctly imported the file's contents
         """
         with Session(self.browser) as session:
             for name in generate_strings_list():
@@ -105,21 +105,21 @@ class JobsTemplateTestCase(UITestCase):
     def test_positive_create_job_template_input(self):
         """Create a Job Template using input
 
-        @id: dbaf5aa9-101d-47dc-bdf8-d5b4d1a52396
+        :id: dbaf5aa9-101d-47dc-bdf8-d5b4d1a52396
 
-        @Steps:
+        :Steps:
 
-        1. Navigate to Hosts -> Job Templates
-        2. Enter a name
-        3. Navigate to the job tab
-        4. Enter a job name
-        5. Click the +Add Input button
-        6. Add an appropriate name
-        7. Choose an input type
-        8. Populate the template code and reference the newly created input
-        9. Click submit
+            1. Navigate to Hosts -> Job Templates
+            2. Enter a name
+            3. Navigate to the job tab
+            4. Enter a job name
+            5. Click the +Add Input button
+            6. Add an appropriate name
+            7. Choose an input type
+            8. Populate the template code and reference the newly created input
+            9. Click submit
 
-        @Assert: The job template was successfully saved with new input added
+        :Assert: The job template was successfully saved with new input added
         """
         name = gen_string('alpha')
         var_name = gen_string('alpha')
@@ -142,16 +142,16 @@ class JobsTemplateTestCase(UITestCase):
     def test_negative_create_job_template(self):
         """Create Job Template with invalid name
 
-        @id: 79342781-1369-4d1f-a512-ca1a809d98fb
+        :id: 79342781-1369-4d1f-a512-ca1a809d98fb
 
-        @Steps:
+        :Steps:
 
-        1. Navigate to Hosts -> Job Templates
-        2. Enter an invalid name
-        3. Click submit
+            1. Navigate to Hosts -> Job Templates
+            2. Enter an invalid name
+            3. Click submit
 
-        @Assert: Job Template with invalid name cannot be created and error is
-        raised
+        :Assert: Job Template with invalid name cannot be created and error is
+            raised
         """
         with Session(self.browser) as session:
             for name in invalid_values_list('ui'):
@@ -169,15 +169,15 @@ class JobsTemplateTestCase(UITestCase):
     def test_negative_create_job_template_with_same_name(self):
         """Create Job Template with duplicate name
 
-        @id: 2c193758-dc34-4701-863c-f2823851223a
+        :id: 2c193758-dc34-4701-863c-f2823851223a
 
-        @Steps:
+        :Steps:
 
-        1. Create a new job template.
-        2. Enter a name that has already been used
-        3. Click submit
+            1. Create a new job template.
+            2. Enter a name that has already been used
+            3. Click submit
 
-        @Assert: The name duplication is caught and error is raised
+        :Assert: The name duplication is caught and error is raised
         """
         name = gen_string('alpha')
         with Session(self.browser) as session:
@@ -201,17 +201,17 @@ class JobsTemplateTestCase(UITestCase):
     def test_positive_delete_job_template(self):
         """Delete a job template
 
-        @id: b25e4fb9-ad75-407d-b15f-76df381c4f9c
+        :id: b25e4fb9-ad75-407d-b15f-76df381c4f9c
 
-        @Setup: Create a valid job template.
+        :Setup: Create a valid job template.
 
-        @Steps:
+        :Steps:
 
-        1. Click the dropdown next to the Job Template's Run button
-        2. Select Delete from the list
-        3. Confirm the deletion
+            1. Click the dropdown next to the Job Template's Run button
+            2. Select Delete from the list
+            3. Confirm the deletion
 
-        @Assert: The Job Template has been deleted
+        :Assert: The Job Template has been deleted
         """
         name = gen_string('alpha')
         with Session(self.browser) as session:
@@ -227,18 +227,18 @@ class JobsTemplateTestCase(UITestCase):
     def test_positive_clone_job_template(self):
         """Clone a Job Template
 
-        @id: a1ec5d1d-907f-4d18-93d3-adb1134d9cca
+        :id: a1ec5d1d-907f-4d18-93d3-adb1134d9cca
 
-        @Setup: Create a valid job template.
+        :Setup: Create a valid job template.
 
-        @Steps:
+        :Steps:
 
-        1. Navigate to Hosts -> Job Templates
-        2. Click the clone button next to a job template
-        3. Change the name
-        4. Click submit
+            1. Navigate to Hosts -> Job Templates
+            2. Click the clone button next to a job template
+            3. Change the name
+            4. Click submit
 
-        @Assert: Verify all job template contents were successfully copied
+        :Assert: Verify all job template contents were successfully copied
         """
         name = gen_string('alpha')
         clone_name = gen_string('alpha')
@@ -257,17 +257,17 @@ class JobsTemplateTestCase(UITestCase):
     def test_positive_view_diff(self):
         """View diff within template editor
 
-        @id: 4b8fff93-4862-4119-bb97-aadc50fc817d
+        :id: 4b8fff93-4862-4119-bb97-aadc50fc817d
 
-        @Setup: Create a valid job template.
+        :Setup: Create a valid job template.
 
-        @Steps:
+        :Steps:
 
-        1. Open the job template created during setup
-        2. Modify the template's code
-        3. Click the Diff button
+            1. Open the job template created during setup
+            2. Modify the template's code
+            3. Click the Diff button
 
-        @Assert: Verify that the new changes are displayed in the window
+        :Assert: Verify that the new changes are displayed in the window
         """
         name = gen_string('alpha')
         old_template = gen_string('alpha')
@@ -292,16 +292,16 @@ class JobsTemplateTestCase(UITestCase):
     def test_positive_preview_verify(self):
         """Use preview within the job template editor to verify template
 
-        @id: 4b4939f3-c056-4716-8071-e8fa00233e3e
+        :id: 4b4939f3-c056-4716-8071-e8fa00233e3e
 
-        @Steps:
+        :Steps:
 
-        1. Create a new job template.
-        2. Add input controls under jobs
-        3. Reference those input controls in the template text
-        4. Select "preview" within the template viewer
+            1. Create a new job template.
+            2. Add input controls under jobs
+            3. Reference those input controls in the template text
+            4. Select "preview" within the template viewer
 
-        @Assert: Verify no errors are thrown
+        :Assert: Verify no errors are thrown
         """
         name = gen_string('alpha')
         var_name = gen_string('alpha')
@@ -331,17 +331,18 @@ class JobsTemplateTestCase(UITestCase):
     def test_negative_preview_verify(self):
         """Use a template file to populate the job template
 
-        @id: 8c0d132c-b500-44b5-a549-d32c7636a712
+        :id: 8c0d132c-b500-44b5-a549-d32c7636a712
 
-        @Steps:
+        :Steps:
 
-        1. Create a new job template
-        2. Add input controls under jobs
-        3. Incorrectly reference those input controls in the template text
-        4. And/or reference non-existent input controls in the template text
-        5. Select "preview" within the template viewer
+            1. Create a new job template
+            2. Add input controls under jobs
+            3. Incorrectly reference those input controls in the template text
+            4. And/or reference non-existent input controls in the template
+               text
+            5. Select "preview" within the template viewer
 
-        @Assert: Verify appropriate errors are thrown
+        :Assert: Verify appropriate errors are thrown
         """
         name = gen_string('alpha')
         with Session(self.browser) as session:
@@ -378,19 +379,19 @@ class RemoteExecutionTestCase(UITestCase):
     def test_positive_run_default_job_template(self):
         """Run a job template against a single host
 
-        @id: 7f0cdd1a-c87c-4324-ae9c-dbc30abad217
+        :id: 7f0cdd1a-c87c-4324-ae9c-dbc30abad217
 
-        @Setup: Use pre-defined job template.
+        :Setup: Use pre-defined job template.
 
-        @Steps:
+        :Steps:
 
-        1. Navigate to an individual host and click Run Job
-        2. Select the job and appropriate template
-        3. Run the job
+            1. Navigate to an individual host and click Run Job
+            2. Select the job and appropriate template
+            3. Run the job
 
-        @Assert: Verify the job was successfully ran against the host
+        :Assert: Verify the job was successfully ran against the host
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         with VirtualMachine(distro=DISTRO_RHEL7) as client:
             client.install_katello_ca()
@@ -410,19 +411,19 @@ class RemoteExecutionTestCase(UITestCase):
     def test_positive_run_custom_job_template(self):
         """Run a job template against a single host
 
-        @id: 89b75feb-afff-44f2-a2bd-2ffe74b63ec7
+        :id: 89b75feb-afff-44f2-a2bd-2ffe74b63ec7
 
-        @Setup: Create a working job template.
+        :Setup: Create a working job template.
 
-        @Steps:
+        :Steps:
 
-        1. Navigate to an individual host and click Run Job
-        2. Select the job and appropriate template
-        3. Run the job
+            1. Navigate to an individual host and click Run Job
+            2. Select the job and appropriate template
+            3. Run the job
 
-        @Assert: Verify the job was successfully ran against the host
+        :Assert: Verify the job was successfully ran against the host
 
-        @CaseLevel: System
+        :CaseLevel: System
         """
         jobs_template_name = gen_string('alpha')
         with VirtualMachine(distro=DISTRO_RHEL7) as client:
@@ -454,20 +455,20 @@ class RemoteExecutionTestCase(UITestCase):
     def test_positive_run_job_template_multiple_hosts(self):
         """Run a job template against multiple hosts
 
-        @id: 7f1981cb-afcc-49b7-a565-7fef9aa8ddde
+        :id: 7f1981cb-afcc-49b7-a565-7fef9aa8ddde
 
-        @Setup: Create a working job template.
+        :Setup: Create a working job template.
 
-        @Steps:
+        :Steps:
 
-        1. Navigate to the hosts page and select at least two hosts
-        2. Click the "Select Action"
-        3. Select the job and appropriate template
-        4. Run the job
+            1. Navigate to the hosts page and select at least two hosts
+            2. Click the "Select Action"
+            3. Select the job and appropriate template
+            4. Run the job
 
-        @Assert: Verify the job was successfully ran against the hosts
+        :Assert: Verify the job was successfully ran against the hosts
 
-        @CaseLevel: System
+        :CaseLevel: System
         """
         with VirtualMachine(distro=DISTRO_RHEL7) as client:
             with VirtualMachine(distro=DISTRO_RHEL7) as client2:
@@ -492,24 +493,24 @@ class RemoteExecutionTestCase(UITestCase):
     def test_positive_run_scheduled_job_template(self):
         """Schedule a job to be ran against a host
 
-        @id: 35c8b68e-1ac5-4c33-ad62-a939b87f76fb
+        :id: 35c8b68e-1ac5-4c33-ad62-a939b87f76fb
 
-        @Setup: Use pre-defined job template.
+        :Setup: Use pre-defined job template.
 
-        @Steps:
+        :Steps:
 
-        1. Navigate to an individual host and click Run Job
-        2. Select the job and appropriate template
-        3. Select "Schedule Future Job"
-        4. Enter a desired time for the job to run
-        5. Click submit
+            1. Navigate to an individual host and click Run Job
+            2. Select the job and appropriate template
+            3. Select "Schedule Future Job"
+            4. Enter a desired time for the job to run
+            5. Click submit
 
-        @Assert:
+        :Assert:
 
-        1. Verify the job was not immediately ran
-        2. Verify the job was successfully ran after the designated time
+            1. Verify the job was not immediately ran
+            2. Verify the job was successfully ran after the designated time
 
-        @CaseLevel: System
+        :CaseLevel: System
         """
         with VirtualMachine(distro=DISTRO_RHEL7) as client:
             client.install_katello_ca()
@@ -541,24 +542,24 @@ class RemoteExecutionTestCase(UITestCase):
     def test_positive_run_job_against_provisioned_rhel6_host(self):
         """Run a job against a single provisioned RHEL 6 host
 
-        @id: 7cc94029-69a0-43e0-8ce5-fdf802d0addc
+        :id: 7cc94029-69a0-43e0-8ce5-fdf802d0addc
 
-        @Setup:
+        :Setup:
 
-        1. Provision a RHEL 6 host.
-        2. Create a working job template.
+            1. Provision a RHEL 6 host.
+            2. Create a working job template.
 
-        @Steps:
+        :Steps:
 
-        1. Navigate to the provisioned host and click Run Job
-        2. Select the created job and appropriate template
-        3. Click submit
+            1. Navigate to the provisioned host and click Run Job
+            2. Select the created job and appropriate template
+            3. Click submit
 
-        @Assert: Verify the job was successfully ran on the provisioned host
+        :Assert: Verify the job was successfully ran on the provisioned host
 
-        @caseautomation: notautomated
+        :caseautomation: notautomated
 
-        @CaseLevel: System
+        :CaseLevel: System
         """
 
     @stubbed()
@@ -566,24 +567,24 @@ class RemoteExecutionTestCase(UITestCase):
     def test_positive_run_job_against_provisioned_rhel7_host(self):
         """Run a job against a single provisioned RHEL 7 host
 
-        @id: e911edfb-abcf-4ea2-940d-44f3e4de1954
+        :id: e911edfb-abcf-4ea2-940d-44f3e4de1954
 
-        @Setup:
+        :Setup:
 
-        1. Provision a RHEL 7 host.
-        2. Create a working job template.
+            1. Provision a RHEL 7 host.
+            2. Create a working job template.
 
-        @Steps:
+        :Steps:
 
-        1. Navigate to the provisioned host and click Run Job
-        2. Select the created job and appropriate template
-        3. Click submit
+            1. Navigate to the provisioned host and click Run Job
+            2. Select the created job and appropriate template
+            3. Click submit
 
-        @Assert: Verify the job was successfully ran on the provisioned host
+        :Assert: Verify the job was successfully ran on the provisioned host
 
-        @caseautomation: notautomated
+        :caseautomation: notautomated
 
-        @CaseLevel: System
+        :CaseLevel: System
         """
 
     @stubbed()
@@ -591,23 +592,23 @@ class RemoteExecutionTestCase(UITestCase):
     def test_positive_run_job_against_multiple_provisioned_hosts(self):
         """Run a job against multiple provisioned hosts
 
-        @id: 7637f724-924f-478d-88d8-25f500335236
+        :id: 7637f724-924f-478d-88d8-25f500335236
 
-        @Setup:
+        :Setup:
 
-        1. Provision at least two hosts (RHEL6/7 preferred).
-        2. Create a working job template.
+            1. Provision at least two hosts (RHEL6/7 preferred).
+            2. Create a working job template.
 
-        @Steps:
+        :Steps:
 
-        1. Navigate to the hosts page and select all provisioned hosts
-        2. Click Select Action -> Run Job
-        3. Select the created job and appropriate template
-        4. Click submit
+            1. Navigate to the hosts page and select all provisioned hosts
+            2. Click Select Action -> Run Job
+            3. Select the created job and appropriate template
+            4. Click submit
 
-        @Assert: Verify the job was successfully ran on the provisioned hosts
+        :Assert: Verify the job was successfully ran on the provisioned hosts
 
-        @caseautomation: notautomated
+        :caseautomation: notautomated
 
-        @CaseLevel: System
+        :CaseLevel: System
         """

--- a/tests/foreman/ui/test_repository.py
+++ b/tests/foreman/ui/test_repository.py
@@ -1,19 +1,19 @@
 # -*- encoding: utf-8 -*-
 """Test class for Repository UI
 
-@Requirement: Repository
+:Requirement: Repository
 
-@CaseAutomation: Automated
+:CaseAutomation: Automated
 
-@CaseLevel: Acceptance
+:CaseLevel: Acceptance
 
-@CaseComponent: UI
+:CaseComponent: UI
 
-@TestType: Functional
+:TestType: Functional
 
-@CaseImportance: High
+:CaseImportance: High
 
-@Upstream: No
+:Upstream: No
 """
 
 import time
@@ -130,9 +130,9 @@ class RepositoryTestCase(UITestCase):
         """Create repository with different names and minimal input
         parameters
 
-        @id: 3713c811-ea80-43ce-a753-344d1dcb7486
+        :id: 3713c811-ea80-43ce-a753-344d1dcb7486
 
-        @Assert: Repository is created successfully
+        :Assert: Repository is created successfully
         """
         prod = entities.Product(organization=self.session_org).create()
         with Session(self.browser) as session:
@@ -152,11 +152,11 @@ class RepositoryTestCase(UITestCase):
     def test_positive_create_in_different_orgs(self):
         """Create repository in two different orgs with same name
 
-        @id: 019c2242-8802-4bae-82c5-accf8f793dbc
+        :id: 019c2242-8802-4bae-82c5-accf8f793dbc
 
-        @Assert: Repository is created successfully for both organizations
+        :Assert: Repository is created successfully for both organizations
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         org_2 = entities.Organization(name=gen_string('alpha')).create()
         product_1 = entities.Product(organization=self.session_org).create()
@@ -186,12 +186,12 @@ class RepositoryTestCase(UITestCase):
     def test_positive_create_puppet_repo_same_url_different_orgs(self):
         """Create two repos with the same URL in two different organizations.
 
-        @id: f4cb00ed-6faf-4c79-9f66-76cd333299cb
+        :id: f4cb00ed-6faf-4c79-9f66-76cd333299cb
 
-        @Assert: Repositories are created and puppet modules are visible from
-        different organizations.
+        :Assert: Repositories are created and puppet modules are visible from
+            different organizations.
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         url = 'https://omaciel.fedorapeople.org/f4cb00ed/'
         # Create first repository
@@ -232,9 +232,9 @@ class RepositoryTestCase(UITestCase):
     def test_positive_create_repo_with_checksum(self):
         """Create repository with checksum type as sha256.
 
-        @id: 06f37bb3-b0cf-4f1f-ae12-df13a6a7eaab
+        :id: 06f37bb3-b0cf-4f1f-ae12-df13a6a7eaab
 
-        @Assert: Repository is created with expected checksum type.
+        :Assert: Repository is created with expected checksum type.
         """
         checksum = CHECKSUM_TYPE[u'sha256']
         # Creates new product
@@ -258,9 +258,9 @@ class RepositoryTestCase(UITestCase):
     def test_negative_create_with_invalid_name(self):
         """Create repository with invalid names
 
-        @id: 385d0222-6466-4bc0-9686-b215f41e4274
+        :id: 385d0222-6466-4bc0-9686-b215f41e4274
 
-        @Assert: Repository is not created
+        :Assert: Repository is not created
         """
         # Creates new product
         product = entities.Product(organization=self.session_org).create()
@@ -283,9 +283,9 @@ class RepositoryTestCase(UITestCase):
     def test_negative_create_with_same_names(self):
         """Try to create two repositories with same name
 
-        @id: f9515a61-0c5e-4767-9fc9-b17d440418d8
+        :id: f9515a61-0c5e-4767-9fc9-b17d440418d8
 
-        @Assert: Repository is not created
+        :Assert: Repository is not created
         """
         repo_name = gen_string('alphanumeric')
         product = entities.Product(organization=self.session_org).create()
@@ -312,9 +312,9 @@ class RepositoryTestCase(UITestCase):
     def test_positive_update_url(self):
         """Update content repository with new URL
 
-        @id: cb864338-9d18-4e18-a2ee-37f22e7036b8
+        :id: cb864338-9d18-4e18-a2ee-37f22e7036b8
 
-        @Assert: Repository is updated with expected url value
+        :Assert: Repository is updated with expected url value
         """
         product = entities.Product(organization=self.session_org).create()
         with Session(self.browser) as session:
@@ -341,9 +341,9 @@ class RepositoryTestCase(UITestCase):
     def test_positive_update_gpg(self):
         """Update content repository with new gpg-key
 
-        @id: 51da6572-02d0-43d7-96cc-895b5bebfadb
+        :id: 51da6572-02d0-43d7-96cc-895b5bebfadb
 
-        @Assert: Repository is updated with new gpg key
+        :Assert: Repository is updated with new gpg key
         """
         repo_name = gen_string('alphanumeric')
         key_1_content = read_data_file(VALID_GPG_KEY_FILE)
@@ -381,9 +381,9 @@ class RepositoryTestCase(UITestCase):
     def test_positive_update_checksum_type(self):
         """Update content repository with new checksum type
 
-        @id: eed4e77d-baa2-42c2-9774-f1bed52efe39
+        :id: eed4e77d-baa2-42c2-9774-f1bed52efe39
 
-        @Assert: Repository is updated with expected checksum type.
+        :Assert: Repository is updated with expected checksum type.
         """
         repo_name = gen_string('alphanumeric')
         checksum_default = CHECKSUM_TYPE['default']
@@ -412,9 +412,9 @@ class RepositoryTestCase(UITestCase):
     def test_positive_delete(self):
         """Create content repository and then remove it
 
-        @id: 9edc93b1-d4e5-453e-b4ee-0731df491397
+        :id: 9edc93b1-d4e5-453e-b4ee-0731df491397
 
-        @Assert: Repository is deleted successfully
+        :Assert: Repository is deleted successfully
         """
         product = entities.Product(organization=self.session_org).create()
         with Session(self.browser) as session:
@@ -436,26 +436,27 @@ class RepositoryTestCase(UITestCase):
     def test_negative_delete_puppet_repo_associated_with_cv(self):
         """Delete a puppet repo associated with a content view - BZ#1271000
 
-        @id: 72639e14-4089-4f40-bad7-e18021ad376f
+        :id: 72639e14-4089-4f40-bad7-e18021ad376f
 
-        @Steps:
+        :Steps:
 
-        1. Create a new product
-        2. Create a new puppet repo, no sync source
-        3. Upload a puppet module (say ntpd) to repo
-        4. Create a CV, go to add puppet modules page
-        5. Add latest version of the puppet module from Step 3
-        6. View puppet repo details, it should show "Latest (Currently X.Y.Z)"
-        7. Go back to product, drill down into repo and delete the puppet
-        module from Step 3
-        8. Go back to same CV puppet module details page
+            1. Create a new product
+            2. Create a new puppet repo, no sync source
+            3. Upload a puppet module (say ntpd) to repo
+            4. Create a CV, go to add puppet modules page
+            5. Add latest version of the puppet module from Step 3
+            6. View puppet repo details, it should show "Latest (Currently
+                X.Y.Z)"
+            7. Go back to product, drill down into repo and delete the puppet
+                module from Step 3
+            8. Go back to same CV puppet module details page
 
-        @Assert: Proper error message saying that the puppet module version is
-        not found
+        :Assert: Proper error message saying that the puppet module version is
+            not found
 
-        @caseautomation: notautomated
+        :caseautomation: notautomated
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
 
     @run_only_on('sat')
@@ -463,11 +464,11 @@ class RepositoryTestCase(UITestCase):
     def test_positive_discover_repo_via_existing_product(self):
         """Create repository via repo-discovery under existing product
 
-        @id: 9181950c-a756-456f-a46a-059e7a2add3c
+        :id: 9181950c-a756-456f-a46a-059e7a2add3c
 
-        @Assert: Repository is discovered and created
+        :Assert: Repository is discovered and created
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         discovered_urls = 'fakerepo01/'
         product = entities.Product(organization=self.session_org).create()
@@ -485,11 +486,11 @@ class RepositoryTestCase(UITestCase):
     def test_positive_discover_repo_via_new_product(self):
         """Create repository via repo discovery under new product
 
-        @id: dc5281f8-1a8a-4a17-b746-728f344a1504
+        :id: dc5281f8-1a8a-4a17-b746-728f344a1504
 
-        @Assert: Repository is discovered and created
+        :Assert: Repository is discovered and created
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         product_name = gen_string('alpha')
         discovered_urls = 'fakerepo01/'
@@ -510,11 +511,11 @@ class RepositoryTestCase(UITestCase):
     def test_positive_sync_custom_repo_yum(self):
         """Create Custom yum repos and sync it via the repos page.
 
-        @id: afa218f4-e97a-4240-a82a-e69538d837a1
+        :id: afa218f4-e97a-4240-a82a-e69538d837a1
 
-        @Assert: Sync procedure for specific yum repository is successful
+        :Assert: Sync procedure for specific yum repository is successful
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         product = entities.Product(organization=self.session_org).create()
         with Session(self.browser) as session:
@@ -539,11 +540,11 @@ class RepositoryTestCase(UITestCase):
     def test_positive_sync_custom_repo_puppet(self):
         """Create Custom puppet repos and sync it via the repos page.
 
-        @id: 135176cc-7664-41ee-8c41-b77e193f2f22
+        :id: 135176cc-7664-41ee-8c41-b77e193f2f22
 
-        @Assert: Sync procedure for specific puppet repository is successful
+        :Assert: Sync procedure for specific puppet repository is successful
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         # Creates new product
         product = entities.Product(organization=self.session_org).create()
@@ -570,11 +571,11 @@ class RepositoryTestCase(UITestCase):
     def test_positive_sync_custom_repo_docker(self):
         """Create Custom docker repos and sync it via the repos page.
 
-        @id: 942e0b4f-3524-4f00-812d-bdad306f81de
+        :id: 942e0b4f-3524-4f00-812d-bdad306f81de
 
-        @Assert: Sync procedure for specific docker repository is successful
+        :Assert: Sync procedure for specific docker repository is successful
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         # Creates new product
         product = entities.Product(organization=self.session_org).create()
@@ -600,13 +601,13 @@ class RepositoryTestCase(UITestCase):
         """Check that repository content is resynced after packages were
         removed from repository
 
-        @id: dc415563-c9b8-4e3c-9d2a-f4ac251c7d35
+        :id: dc415563-c9b8-4e3c-9d2a-f4ac251c7d35
 
-        @Assert: Repository has updated non-zero package count
+        :Assert: Repository has updated non-zero package count
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
 
-        @BZ: 1318004
+        :BZ: 1318004
         """
         with Session(self.browser) as session:
             repo = entities.Repository(
@@ -644,13 +645,13 @@ class RepositoryTestCase(UITestCase):
         """Check that repository content is resynced after packages were
         removed from repository
 
-        @id: c82dfe9d-aa1c-4922-ab3f-5d66ba8375c5
+        :id: c82dfe9d-aa1c-4922-ab3f-5d66ba8375c5
 
-        @Assert: Repository has updated non-zero package count
+        :Assert: Repository has updated non-zero package count
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
 
-        @BZ: 1318004
+        :BZ: 1318004
         """
         with Session(self.browser) as session:
             repo = entities.Repository(
@@ -689,9 +690,9 @@ class RepositoryTestCase(UITestCase):
     def test_positive_create_custom_ostree_repo(self):
         """Create Custom ostree repository.
 
-        @id: 852cccdc-7289-4d2f-b23a-7caad2dfa195
+        :id: 852cccdc-7289-4d2f-b23a-7caad2dfa195
 
-        @Assert: Create custom ostree repository should be successful
+        :Assert: Create custom ostree repository should be successful
         """
         prod = entities.Product(organization=self.session_org).create()
         with Session(self.browser) as session:
@@ -714,9 +715,9 @@ class RepositoryTestCase(UITestCase):
     def test_positive_delete_custom_ostree_repo(self):
         """Delete custom ostree repository.
 
-        @id: 87dcb236-4eb4-4897-9c2a-be1d0f4bc3e7
+        :id: 87dcb236-4eb4-4897-9c2a-be1d0f4bc3e7
 
-        @Assert: Delete custom ostree repository should be successful
+        :Assert: Delete custom ostree repository should be successful
         """
         prod = entities.Product(organization=self.session_org).create()
         repo_name = gen_string('alphanumeric')
@@ -740,11 +741,11 @@ class RepositoryTestCase(UITestCase):
     def test_positive_update_custom_ostree_repo_name(self):
         """Update custom ostree repository name.
 
-        @id: 098ee88f-6cdb-45e0-850a-e1b71662f7ab
+        :id: 098ee88f-6cdb-45e0-850a-e1b71662f7ab
 
-        @Steps: Update repo name
+        :Steps: Update repo name
 
-        @Assert: ostree repo name should be updated successfully
+        :Assert: ostree repo name should be updated successfully
         """
         prod = entities.Product(organization=self.session_org).create()
         repo_name = gen_string('alphanumeric')
@@ -772,11 +773,11 @@ class RepositoryTestCase(UITestCase):
     def test_positive_update_custom_ostree_repo_url(self):
         """Update custom ostree repository url.
 
-        @id: dfd392f9-6f1d-4d87-a43b-ced40606b8c2
+        :id: dfd392f9-6f1d-4d87-a43b-ced40606b8c2
 
-        @Steps: Update ostree repo URL
+        :Steps: Update ostree repo URL
 
-        @Assert: ostree repo URL should be updated successfully
+        :Assert: ostree repo URL should be updated successfully
         """
         prod = entities.Product(organization=self.session_org).create()
         repo_name = gen_string('alphanumeric')
@@ -808,9 +809,9 @@ class RepositoryTestCase(UITestCase):
     def test_positive_download_policy_displayed_for_yum_repos(self):
         """Verify that YUM repositories can be created with download policy
 
-        @id: 8037a68b-66b8-4b42-a80b-fb08495f948d
+        :id: 8037a68b-66b8-4b42-a80b-fb08495f948d
 
-        @Assert: Dropdown for download policy is displayed for yum repo
+        :Assert: Dropdown for download policy is displayed for yum repo
         """
         with Session(self.browser) as session:
             session.nav.go_to_select_org(self.session_org.name, force=False)
@@ -828,9 +829,9 @@ class RepositoryTestCase(UITestCase):
     def test_positive_create_with_download_policy(self):
         """Create YUM repositories with available download policies
 
-        @id: 8099fb98-963d-4370-bf51-6807f5efd6d3
+        :id: 8099fb98-963d-4370-bf51-6807f5efd6d3
 
-        @Assert: YUM repository with a download policy is created
+        :Assert: YUM repository with a download policy is created
         """
         repo_name = gen_string('alpha')
         with Session(self.browser) as session:
@@ -850,9 +851,9 @@ class RepositoryTestCase(UITestCase):
         """Verify if the default download policy is assigned when creating
         a YUM repo without `download_policy` field
 
-        @id: ee7637fe-3864-4b2f-a153-14312658d75a
+        :id: ee7637fe-3864-4b2f-a153-14312658d75a
 
-        @Assert: YUM repository with a default download policy
+        :Assert: YUM repository with a default download policy
         """
         repo_name = gen_string('alphanumeric')
         default_dl_policy = entities.Setting().search(
@@ -888,9 +889,9 @@ class RepositoryTestCase(UITestCase):
         """Update `immediate` download policy to `on_demand` for a newly
         created YUM repository
 
-        @id: 4aa4d914-74f3-4c2e-9e8a-6e1b7fdb34ea
+        :id: 4aa4d914-74f3-4c2e-9e8a-6e1b7fdb34ea
 
-        @Assert: immediate download policy is updated to on_demand
+        :Assert: immediate download policy is updated to on_demand
         """
         repo_name = gen_string('alphanumeric')
         self._create_yum_repo_with_download_policy(repo_name, 'Immediate')
@@ -908,9 +909,9 @@ class RepositoryTestCase(UITestCase):
         """Update `immediate` download policy to `background` for a newly
         created YUM repository
 
-        @id: d61bf6b6-6485-4d3a-816a-b533e96deb69
+        :id: d61bf6b6-6485-4d3a-816a-b533e96deb69
 
-        @Assert: immediate download policy is updated to background
+        :Assert: immediate download policy is updated to background
         """
         repo_name = gen_string('alphanumeric')
         self._create_yum_repo_with_download_policy(repo_name, 'Immediate')
@@ -928,9 +929,9 @@ class RepositoryTestCase(UITestCase):
         """Update `on_demand` download policy to `immediate` for a newly
         created YUM repository
 
-        @id: 51cac66d-05a4-47da-adb5-d2909725457e
+        :id: 51cac66d-05a4-47da-adb5-d2909725457e
 
-        @Assert: on_demand download policy is updated to immediate
+        :Assert: on_demand download policy is updated to immediate
         """
         repo_name = gen_string('alphanumeric')
         self._create_yum_repo_with_download_policy(repo_name, 'On Demand')
@@ -948,9 +949,9 @@ class RepositoryTestCase(UITestCase):
         """Update `on_demand` download policy to `background` for a newly
         created YUM repository
 
-        @id: 25b5ba4e-a1cf-41c2-8ca8-4fa3153570f8
+        :id: 25b5ba4e-a1cf-41c2-8ca8-4fa3153570f8
 
-        @Assert: on_demand download policy is updated to background
+        :Assert: on_demand download policy is updated to background
         """
         repo_name = gen_string('alphanumeric')
         self._create_yum_repo_with_download_policy(repo_name, 'On Demand')
@@ -968,9 +969,9 @@ class RepositoryTestCase(UITestCase):
         """Update `background` download policy to `immediate` for a newly
         created YUM repository
 
-        @id: 7a6efe70-8edb-4fa8-b2a4-93762d6e4bc5
+        :id: 7a6efe70-8edb-4fa8-b2a4-93762d6e4bc5
 
-        @Assert: background download policy is updated to immediate
+        :Assert: background download policy is updated to immediate
         """
         repo_name = gen_string('alphanumeric')
         self._create_yum_repo_with_download_policy(repo_name, 'Background')
@@ -988,9 +989,9 @@ class RepositoryTestCase(UITestCase):
         """Update `background` download policy to `on_demand` for a newly
         created YUM repository
 
-        @id: d36b96b1-6e09-455e-82e7-36a23f8c6c06
+        :id: d36b96b1-6e09-455e-82e7-36a23f8c6c06
 
-        @Assert: background download policy is updated to on_demand
+        :Assert: background download policy is updated to on_demand
         """
         repo_name = gen_string('alphanumeric')
         self._create_yum_repo_with_download_policy(repo_name, 'Background')
@@ -1008,9 +1009,9 @@ class RepositoryTestCase(UITestCase):
         """Verify that YUM repository cannot be created with invalid download
         policy
 
-        @id: dded6dda-3576-4485-8f3c-bb7c091e7ff2
+        :id: dded6dda-3576-4485-8f3c-bb7c091e7ff2
 
-        @Assert: YUM repository is not created with invalid download policy
+        :Assert: YUM repository is not created with invalid download policy
         """
         repo_name = gen_string('alphanumeric')
         with Session(self.browser) as session:
@@ -1030,9 +1031,9 @@ class RepositoryTestCase(UITestCase):
         """Verify that YUM repository cannot be updated to invalid download
         policy
 
-        @id: e6c725f2-172e-49f6-ae92-c56af8a1200b
+        :id: e6c725f2-172e-49f6-ae92-c56af8a1200b
 
-        @Assert: YUM repository is not updated to invalid download policy
+        :Assert: YUM repository is not updated to invalid download policy
         """
         repo_name = gen_string('alphanumeric')
         self._create_yum_repo_with_download_policy(repo_name, 'Immediate')
@@ -1051,9 +1052,9 @@ class RepositoryTestCase(UITestCase):
         """Verify that non-YUM repositories cannot be created with download
         policy
 
-        @id: 47d55251-5f89-443d-b980-a441da34e205
+        :id: 47d55251-5f89-443d-b980-a441da34e205
 
-        @Assert: Dropdown for download policy is not displayed for non-yum repo
+        :Assert: Dropdown for download policy is not displayed for non-yum repo
         """
         os_version = get_host_os_version()
         # ostree is not supported for rhel6 so the following check
@@ -1087,11 +1088,11 @@ class RepositoryTestCase(UITestCase):
     def test_positive_srpm_sync(self):
         """Synchronize repository with SRPMs
 
-        @id: 1967a540-a265-4046-b87b-627524b63688
+        :id: 1967a540-a265-4046-b87b-627524b63688
 
-        @Assert: srpms can be listed in repository
+        :Assert: srpms can be listed in repository
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         product = entities.Product(organization=self.session_org).create()
         repo_name = gen_string('alphanumeric')
@@ -1126,11 +1127,11 @@ class RepositoryTestCase(UITestCase):
         """Synchronize repository with SRPMs, add repository to content view
         and publish content view
 
-        @id: 2a57cbde-c616-440d-8bcb-6e18bd2d5c5f
+        :id: 2a57cbde-c616-440d-8bcb-6e18bd2d5c5f
 
-        @Assert: srpms can be listed in content view
+        :Assert: srpms can be listed in content view
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         product = entities.Product(organization=self.session_org).create()
         repo_name = gen_string('alphanumeric')
@@ -1176,12 +1177,12 @@ class RepositoryTestCase(UITestCase):
         """Synchronize repository with SRPMs, add repository to content view,
         publish and promote content view to lifecycle environment
 
-        @id: 4563d1c1-cdce-4838-a67f-c0a5d4e996a6
+        :id: 4563d1c1-cdce-4838-a67f-c0a5d4e996a6
 
-        @Assert: srpms can be listed in content view in proper lifecycle
-        environment
+        :Assert: srpms can be listed in content view in proper lifecycle
+            environment
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         lce = entities.LifecycleEnvironment(
             organization=self.session_org).create()
@@ -1232,11 +1233,11 @@ class RepositoryTestCase(UITestCase):
     def test_positive_drpm_sync(self):
         """Synchronize repository with DRPMs
 
-        @id: 5e703d9a-ea26-4062-9d5c-d31bfbe87417
+        :id: 5e703d9a-ea26-4062-9d5c-d31bfbe87417
 
-        @Assert: drpms can be listed in repository
+        :Assert: drpms can be listed in repository
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         product = entities.Product(organization=self.session_org).create()
         repo_name = gen_string('alphanumeric')
@@ -1271,11 +1272,11 @@ class RepositoryTestCase(UITestCase):
         """Synchronize repository with DRPMs, add repository to content view
         and publish content view
 
-        @id: cffa862c-f972-4aa4-96b2-5a4513cb3eef
+        :id: cffa862c-f972-4aa4-96b2-5a4513cb3eef
 
-        @Assert: drpms can be listed in content view
+        :Assert: drpms can be listed in content view
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         product = entities.Product(organization=self.session_org).create()
         repo_name = gen_string('alphanumeric')
@@ -1321,12 +1322,12 @@ class RepositoryTestCase(UITestCase):
         """Synchronize repository with DRPMs, add repository to content view,
         publish and promote content view to lifecycle environment
 
-        @id: e33ee07c-4677-4be8-bd53-73689edfda34
+        :id: e33ee07c-4677-4be8-bd53-73689edfda34
 
-        @Assert: drpms can be listed in content view in proper lifecycle
-        environment
+        :Assert: drpms can be listed in content view in proper lifecycle
+            environment
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         lce = entities.LifecycleEnvironment(
             organization=self.session_org).create()
@@ -1379,10 +1380,10 @@ class RepositoryTestCase(UITestCase):
         Verify that puppet modules list for specific repo is correct
         and does not affected by other repositories.
 
-        @id: 82ef2987-cb71-4164-aee5-4496b974d1bd
+        :id: 82ef2987-cb71-4164-aee5-4496b974d1bd
 
-        @Assert: Number of modules has no changed after a second repo
-        was synced.
+        :Assert: Number of modules has no changed after a second repo was
+            synced.
         """
         with Session(self.browser):
             # Create and sync first repo
@@ -1423,11 +1424,11 @@ class RepositoryTestCase(UITestCase):
     def test_positive_reposet_disable(self):
         """Enable RH repo, sync it and then disable
 
-        @id: de596c56-1327-49e8-86d5-a1ab907f26aa
+        :id: de596c56-1327-49e8-86d5-a1ab907f26aa
 
-        @Assert: RH repo was disabled
+        :Assert: RH repo was disabled
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         org = entities.Organization().create()
         with manifests.clone() as manifest:
@@ -1456,11 +1457,11 @@ class RepositoryTestCase(UITestCase):
     def test_positive_upload_rpm(self):
         """Create yum repository and upload rpm package
 
-        @id: 201d5742-cb1a-4534-ac02-91b5a4669d22
+        :id: 201d5742-cb1a-4534-ac02-91b5a4669d22
 
-        @Assert: Upload is successful and package is listed
+        :Assert: Upload is successful and package is listed
 
-        @BZ: 1394390, 1154384
+        :BZ: 1394390, 1154384
         """
         repo_name = gen_string('alpha')
         with Session(self.browser) as session:
@@ -1491,9 +1492,9 @@ class RepositoryTestCase(UITestCase):
     def test_negative_upload_rpm(self):
         """Create yum repository but upload any content except rpm
 
-        @id: 77a098c2-3f63-4e9f-88b9-f0657b721611
+        :id: 77a098c2-3f63-4e9f-88b9-f0657b721611
 
-        @Assert: Error is raised during upload and file is not listed
+        :Assert: Error is raised during upload and file is not listed
         """
         repo_name = gen_string('alpha')
         with Session(self.browser) as session:
@@ -1514,11 +1515,11 @@ class RepositoryTestCase(UITestCase):
     def test_positive_upload_puppet(self):
         """Create puppet repository and upload puppet module
 
-        @id: 2da4ddeb-3d6a-4b77-b44a-190a0c20a4f6
+        :id: 2da4ddeb-3d6a-4b77-b44a-190a0c20a4f6
 
-        @Assert: Upload is successful and module is listed
+        :Assert: Upload is successful and module is listed
 
-        @BZ: 1154384
+        :BZ: 1154384
         """
         repo_name = gen_string('alpha')
         with Session(self.browser) as session:
@@ -1551,9 +1552,9 @@ class RepositoryTestCase(UITestCase):
     def test_negative_upload_puppet(self):
         """Create puppet repository but upload any content except puppet module
 
-        @id: 79ebea29-2c5c-476d-8d1a-54e6b9d49e17
+        :id: 79ebea29-2c5c-476d-8d1a-54e6b9d49e17
 
-        @Assert: Error is raised during upload and file is not listed
+        :Assert: Error is raised during upload and file is not listed
         """
         repo_name = gen_string('alpha')
         with Session(self.browser) as session:
@@ -1576,9 +1577,9 @@ class RepositoryTestCase(UITestCase):
     def test_positive_remove_content_rpm(self):
         """Synchronize repository and remove content from it
 
-        @id: 054763e5-b6a8-4f06-a9f7-6819fbc7aba8
+        :id: 054763e5-b6a8-4f06-a9f7-6819fbc7aba8
 
-        @Assert: Content Counts shows zero rpm packages
+        :Assert: Content Counts shows zero rpm packages
         """
         with Session(self.browser) as session:
             repo = entities.Repository(
@@ -1607,9 +1608,9 @@ class RepositoryTestCase(UITestCase):
     def test_positive_remove_content_puppet(self):
         """Synchronize repository and remove content from it
 
-        @id: be178e21-5d64-46d4-8a41-c3f0f62dabe0
+        :id: be178e21-5d64-46d4-8a41-c3f0f62dabe0
 
-        @Assert: Content Counts shows zero puppet modules
+        :Assert: Content Counts shows zero puppet modules
         """
         with Session(self.browser) as session:
             repo = entities.Repository(
@@ -1651,20 +1652,18 @@ class GitPuppetMirrorTestCase(UITestCase):
     def test_positive_git_local_create(self):
         """Create repository with local git puppet mirror.
 
-        @id: b1d3ef84-cf59-4d08-8123-abda3b2086ca
+        :id: b1d3ef84-cf59-4d08-8123-abda3b2086ca
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
 
-        @Setup: Assure local GIT puppet has been created and found by pulp
+        :Setup: Assure local GIT puppet has been created and found by pulp
 
-        @Steps:
+        :Steps: Create link to local puppet mirror
 
-        1.  Create link to local puppet mirror
+        :Assert: Content source containing local GIT puppet mirror content is
+            created
 
-        @Assert: Content source containing local GIT puppet mirror content
-        is created
-
-        @CaseAutomation: notautomated
+        :CaseAutomation: notautomated
         """
 
     @stubbed()
@@ -1672,20 +1671,18 @@ class GitPuppetMirrorTestCase(UITestCase):
     def test_positive_git_local_update(self):
         """Update repository with local git puppet mirror.
 
-        @id: d8b32e52-ee3e-4c99-b47f-8726ece6ab94
+        :id: d8b32e52-ee3e-4c99-b47f-8726ece6ab94
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
 
-        @Setup: Assure local GIT puppet has been created and found by pulp
+        :Setup: Assure local GIT puppet has been created and found by pulp
 
-        @Steps:
+        :Steps: Modify details for existing puppet repo (name, etc.)
 
-        1.  Modify details for existing puppet repo (name, etc.)
+        :Assert: Content source containing local GIT puppet mirror content is
+            modified
 
-        @Assert: Content source containing local GIT puppet mirror content
-        is modified
-
-        @CaseAutomation: notautomated
+        :CaseAutomation: notautomated
         """
 
     @stubbed()
@@ -1693,20 +1690,18 @@ class GitPuppetMirrorTestCase(UITestCase):
     def test_positive_git_local_delete(self):
         """Delete repository with local git puppet mirror.
 
-        @id: 45b02a5d-0536-4a89-8222-3584a69363ea
+        :id: 45b02a5d-0536-4a89-8222-3584a69363ea
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
 
-        @Setup: Assure local GIT puppet has been created and found by pulp
+        :Setup: Assure local GIT puppet has been created and found by pulp
 
-        @Steps:
+        :Steps: Delete link to local puppet mirror
 
-        1.  Delete link to local puppet mirror
+        :Assert: Content source containing local GIT puppet mirror content no
+            longer exists/is available.
 
-        @Assert: Content source containing local GIT puppet mirror content
-        no longer exists/is available.
-
-        @CaseAutomation: notautomated
+        :CaseAutomation: notautomated
         """
 
     @stubbed()
@@ -1714,20 +1709,18 @@ class GitPuppetMirrorTestCase(UITestCase):
     def test_positive_git_remote_create(self):
         """Create repository with remote git puppet mirror.
 
-        @id: 50d90ae5-9c3d-4ec7-bdd8-9c418d56e167
+        :id: 50d90ae5-9c3d-4ec7-bdd8-9c418d56e167
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
 
-        @Setup: Assure remote GIT puppet has been created and found by pulp
+        :Setup: Assure remote GIT puppet has been created and found by pulp
 
-        @Steps:
+        :Steps: Create link to local puppet mirror
 
-        1.  Create link to local puppet mirror
+        :Assert: Content source containing remote GIT puppet mirror content is
+            created
 
-        @Assert: Content source containing remote GIT puppet mirror content
-        is created
-
-        @CaseAutomation: notautomated
+        :CaseAutomation: notautomated
         """
 
     @stubbed()
@@ -1735,20 +1728,18 @@ class GitPuppetMirrorTestCase(UITestCase):
     def test_positive_git_remote_update(self):
         """Update repository with remote git puppet mirror.
 
-        @id: df53b612-eadb-411a-abf0-07eae3ae1059
+        :id: df53b612-eadb-411a-abf0-07eae3ae1059
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
 
-        @Setup: Assure remote  GIT puppet has been created and found by pulp
+        :Setup: Assure remote  GIT puppet has been created and found by pulp
 
-        @Steps:
+        :Steps: modify details for existing puppet repo (name, etc.)
 
-        1.  modify details for existing puppet repo (name, etc.)
+        :Assert: Content source containing remote GIT puppet mirror content is
+            modified
 
-        @Assert: Content source containing remote GIT puppet mirror content
-        is modified
-
-        @CaseAutomation: notautomated
+        :CaseAutomation: notautomated
         """
 
     @stubbed()
@@ -1756,42 +1747,40 @@ class GitPuppetMirrorTestCase(UITestCase):
     def test_positive_git_remote_delete(self):
         """Delete repository with remote git puppet mirror.
 
-        @id: 3971f330-2b91-44cb-89e4-350002ef0ee8
+        :id: 3971f330-2b91-44cb-89e4-350002ef0ee8
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
 
-        @Setup: Assure remote GIT puppet has been created and found by pulp
+        :Setup: Assure remote GIT puppet has been created and found by pulp
 
-        @Steps:
+        :Steps: Delete link to remote puppet mirror
 
-        1.  Delete link to remote puppet mirror
+        :Assert: Content source containing remote GIT puppet mirror content no
+            longer exists/is available.
 
-        @Assert: Content source containing remote GIT puppet mirror content
-        no longer exists/is available.
-
-        @CaseAutomation: notautomated
+        :CaseAutomation: notautomated
         """
 
     @stubbed()
     @tier2
     def test_positive_git_sync(self):
         """Sync repository with git puppet mirror.
-        @id: f46fa078-81d3-492b-86e9-c11fa97fae0b
 
-        @CaseLevel: Integration
+        :id: f46fa078-81d3-492b-86e9-c11fa97fae0b
 
-        @Setup: git mirror (local or remote) exists as a content source
+        :CaseLevel: Integration
 
-        @Steps:
+        :Setup: git mirror (local or remote) exists as a content source
 
-        1.  Attempt to sync content from mirror
+        :Steps: Attempt to sync content from mirror
 
-        @Assert: Content is pulled down without error
+        :Assert:
 
-        @Assert: Confirmation that various resources actually exist in
-        local content repo
+            1. Content is pulled down without error
+            2. Confirmation that various resources actually exist in local
+                content repo
 
-        @CaseAutomation: notautomated
+        :CaseAutomation: notautomated
         """
 
     @stubbed()
@@ -1801,25 +1790,26 @@ class GitPuppetMirrorTestCase(UITestCase):
         If module changes in GIT mirror but the version in manifest
         does not change, content still pulled.
 
-        @id: 7b0484c2-df0a-46e8-95a7-1535435e6079
+        :id: 7b0484c2-df0a-46e8-95a7-1535435e6079
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
 
-        @Setup: Assure remote GIT puppet has been created and found by pulp
+        :Setup: Assure remote GIT puppet has been created and found by pulp
 
-        @Steps:
+        :Steps:
 
-        1.  Sync a git repo and observe the contents/checksum etc. of an
-            existing puppet module
-        2.  Assure a puppet module in git repo has changed but the manifest
-            version for this module does not change.
-        3.  Using pulp script, update repo mirror and re-sync within satellite
-        4.  View contents/details of same puppet module
+            1.  Sync a git repo and observe the contents/checksum etc. of an
+                existing puppet module
+            2.  Assure a puppet module in git repo has changed but the manifest
+                version for this module does not change.
+            3.  Using pulp script, update repo mirror and re-sync within
+                satellite
+            4.  View contents/details of same puppet module
 
-        @Assert: Puppet module has been updated in our content, even though
-        the module's version number has not changed.
+        :Assert: Puppet module has been updated in our content, even though the
+            module's version number has not changed.
 
-        @CaseAutomation: notautomated
+        :CaseAutomation: notautomated
         """
 
     @stubbed()
@@ -1827,19 +1817,17 @@ class GitPuppetMirrorTestCase(UITestCase):
     def test_positive_git_sync_schedule(self):
         """Scheduled sync of git puppet mirror.
 
-        @id: 1e15e4ad-35e8-493f-84f5-47ad180d2a7a
+        :id: 1e15e4ad-35e8-493f-84f5-47ad180d2a7a
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
 
-        @Setup: git mirror (local or remote) exists as a content source
+        :Setup: git mirror (local or remote) exists as a content source
 
-        @Steps:
+        :Steps: Attempt to create a scheduled sync content from mirror
 
-        1.  Attempt to create a scheduled sync content from mirror
+        :Assert: Content is pulled down without error  on expected schedule
 
-        @Assert: Content is pulled down without error  on expected schedule
-
-        @CaseAutomation: notautomated
+        :CaseAutomation: notautomated
         """
 
     @stubbed()
@@ -1847,18 +1835,16 @@ class GitPuppetMirrorTestCase(UITestCase):
     def test_positive_git_view_content(self):
         """View content in synced git puppet mirror
 
-        @id: bb536b1b-13f6-448d-b1b2-44e2fdf93b5f
+        :id: bb536b1b-13f6-448d-b1b2-44e2fdf93b5f
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
 
-        @Setup: git mirror (local or remote) exists as a content source
+        :Setup: git mirror (local or remote) exists as a content source
 
-        @Steps:
+        :Steps: Attempt to list contents of repo
 
-        1.  Attempt to list contents of repo
+        :Assert: Spot-checked items (filenames, dates, perhaps checksums?) are
+            correct.
 
-        @Assert: Spot-checked items (filenames, dates, perhaps checksums?)
-        are correct.
-
-        @CaseAutomation: notautomated
+        :CaseAutomation: notautomated
         """

--- a/tests/foreman/ui/test_role.py
+++ b/tests/foreman/ui/test_role.py
@@ -1,19 +1,19 @@
 # -*- encoding: utf-8 -*-
 """Test class for Roles UI
 
-@Requirement: Role
+:Requirement: Role
 
-@CaseAutomation: Automated
+:CaseAutomation: Automated
 
-@CaseLevel: Acceptance
+:CaseLevel: Acceptance
 
-@CaseComponent: UI
+:CaseComponent: UI
 
-@TestType: Functional
+:TestType: Functional
 
-@CaseImportance: High
+:CaseImportance: High
 
-@Upstream: No
+:Upstream: No
 """
 from random import choice
 
@@ -35,9 +35,9 @@ class RoleTestCase(UITestCase):
     def test_positive_create_with_name(self):
         """Create new role using different names
 
-        @id: 8170598b-cf3b-4ff7-9baa-bee73f90d255
+        :id: 8170598b-cf3b-4ff7-9baa-bee73f90d255
 
-        @Assert: Role is created successfully
+        :Assert: Role is created successfully
         """
         with Session(self.browser) as session:
             for name in generate_strings_list(length=10):
@@ -49,9 +49,9 @@ class RoleTestCase(UITestCase):
     def test_negative_create_with_invalid_name(self):
         """Create new role using invalid names
 
-        @id: 4159a2ad-0952-4196-9e3b-56c721d24355
+        :id: 4159a2ad-0952-4196-9e3b-56c721d24355
 
-        @Assert: Role is not created
+        :Assert: Role is not created
         """
         with Session(self.browser) as session:
             for name in invalid_values_list(interface='ui'):
@@ -64,9 +64,9 @@ class RoleTestCase(UITestCase):
     def test_positive_delete(self):
         """Delete an existing role
 
-        @id: c8bd515a-e556-4b98-a993-ec37f541ffc3
+        :id: c8bd515a-e556-4b98-a993-ec37f541ffc3
 
-        @Assert: Role is deleted successfully
+        :Assert: Role is deleted successfully
         """
         with Session(self.browser) as session:
             for name in generate_strings_list(length=10):
@@ -78,9 +78,9 @@ class RoleTestCase(UITestCase):
     def test_positive_update_name(self):
         """Update existing role name
 
-        @id: c3ad9eed-6896-470d-9043-3fda37bbe489
+        :id: c3ad9eed-6896-470d-9043-3fda37bbe489
 
-        @Assert: Role is updated
+        :Assert: Role is updated
         """
         name = gen_string('utf8')
         with Session(self.browser) as session:
@@ -96,9 +96,9 @@ class RoleTestCase(UITestCase):
     def test_positive_update_permission(self):
         """Update existing role permissions
 
-        @id: d57abcf2-a42f-40db-a61c-61b56bcc55b9
+        :id: d57abcf2-a42f-40db-a61c-61b56bcc55b9
 
-        @Assert: Role is updated
+        :Assert: Role is updated
         """
         name = gen_string('alpha')
         resource_type = 'Architecture'
@@ -123,9 +123,9 @@ class RoleTestCase(UITestCase):
     def test_positive_clone_builtin(self):
         """Clone one of the builtin roles
 
-        @id: e3e6af90-fb31-4de9-8f36-f50550d7f00e
+        :id: e3e6af90-fb31-4de9-8f36-f50550d7f00e
 
-        @Assert: New role is created.
+        :Assert: New role is created.
         """
         builtin_name = choice(ROLES)
         new_name = gen_string('alpha')
@@ -156,9 +156,9 @@ class RoleTestCase(UITestCase):
     def test_positive_clone_custom(self):
         """Create custom role with permissions and clone it
 
-        @id: a4367968-eae5-4b8a-9b5c-61824b261320
+        :id: a4367968-eae5-4b8a-9b5c-61824b261320
 
-        @Assert: New role is created and contains all permissions
+        :Assert: New role is created and contains all permissions
         """
         name = gen_string('alpha')
         new_name = gen_string('alpha')
@@ -192,11 +192,11 @@ class RoleTestCase(UITestCase):
     def test_positive_assign_cloned_role(self):
         """Clone role and assign it to user
 
-        @id: cbb17f37-9039-4875-981b-1f427b095ed1
+        :id: cbb17f37-9039-4875-981b-1f427b095ed1
 
-        @Assert: User is created successfully
+        :Assert: User is created successfully
 
-        @BZ: 1353788
+        :BZ: 1353788
         """
         user_name = gen_string('alpha')
         role_name = gen_string('alpha')
@@ -216,11 +216,11 @@ class RoleTestCase(UITestCase):
     def test_positive_delete_cloned(self):
         """Delete cloned role
 
-        @id: 7f0a595b-2b27-4dca-b15a-02cd2519b2f7
+        :id: 7f0a595b-2b27-4dca-b15a-02cd2519b2f7
 
-        @Assert: Role is deleted
+        :Assert: Role is deleted
 
-        @BZ: 1353788
+        :BZ: 1353788
         """
         new_name = gen_string('alpha')
         with Session(self.browser):
@@ -247,11 +247,11 @@ class CannedRoleTestCases(UITestCase):
     def test_positive_create_role_with_taxonomies(self):
         """create role with taxonomies
 
-        @id: 5d9da688-f371-4654-93d3-b221211be280
+        :id: 5d9da688-f371-4654-93d3-b221211be280
 
-        @steps: Create new role with taxonomies (location and organization)
+        :steps: Create new role with taxonomies (location and organization)
 
-        @assert: New role is created with taxonomies
+        :assert: New role is created with taxonomies
         """
         name = gen_string('alpha')
         with Session(self.browser) as session:
@@ -267,21 +267,22 @@ class CannedRoleTestCases(UITestCase):
     def test_positive_create_filter_without_override(self):
         """Create filter in role w/o overriding it
 
-        @id: a7f76f6e-6c13-4b34-b38c-19501b65786f
+        :id: a7f76f6e-6c13-4b34-b38c-19501b65786f
 
-        @steps:
+        :steps:
 
-        1. Create a role with taxonomies (location and organization) assigned
-        2. Create filter in role without overriding it
-        3. Create user and assign new role to it
-        4. Re-login into application using new user with a role
+            1. Create a role with taxonomies (location and organization)
+                assigned
+            2. Create filter in role without overriding it
+            3. Create user and assign new role to it
+            4. Re-login into application using new user with a role
 
-        @assert:
+        :assert:
 
-        1. Filter w/o override is created in role
-        2. The taxonomies of role are inherited to filter
-        3. Override check is not marked by default in filters table
-        4. User can access application sections specified in a filter
+            1. Filter w/o override is created in role
+            2. The taxonomies of role are inherited to filter
+            3. Override check is not marked by default in filters table
+            4. User can access application sections specified in a filter
         """
         name = gen_string('alpha')
         username = gen_string('alpha')
@@ -327,23 +328,22 @@ class CannedRoleTestCases(UITestCase):
     def test_positive_create_non_overridable_filter(self):
         """Create non overridden filter in role
 
-        @id: 5ee281cf-28fa-439d-888d-b1f9aacc6d57
+        :id: 5ee281cf-28fa-439d-888d-b1f9aacc6d57
 
-        @steps:
+        :steps:
 
-        1. Create a filter in a role to which taxonomies
-        (location and organization) cannot be associated.
-        e.g Architecture filter
-        2. Create an user with taxonomies different than role and assign role
-        to it
-        3. Login as new user and attempt to acess the resources
+            1. Create a filter in a role to which taxonomies (location and
+                organization) cannot be associated.  e.g Architecture filter
+            2. Create an user with taxonomies different than role and assign
+                role to it
+            3. Login as new user and attempt to acess the resources
 
-        @assert:
+        :assert:
 
-        1. Filter is created without taxonomies
-        2. Override checkbox is not available to check
-        3. User can access resources, permissions specified in a filter
-        4. User have access in all taxonomies available to user
+            1. Filter is created without taxonomies
+            2. Override checkbox is not available to check
+            3. User can access resources, permissions specified in a filter
+            4. User have access in all taxonomies available to user
         """
         name = gen_string('alpha')
         username = gen_string('alpha')
@@ -388,25 +388,25 @@ class CannedRoleTestCases(UITestCase):
     def test_positive_create_overridable_filter(self):
         """Create overridden filter in role
 
-        @id: 325e7e3e-60fc-4182-9585-0449d9660e8d
+        :id: 325e7e3e-60fc-4182-9585-0449d9660e8d
 
-        @steps:
+        :steps:
 
-        1. Create a role with some taxonomies (organizations and locations)
-        2. Create a filter in role to which taxonomies can be associated
-            e.g Domain filter
-        3. Override a filter with some taxonomies which doesnt match the
-            taxonomies of role
-        4. Create user with taxonomies including filter taxonomies and assign
-            role to it
-        5. Login with user and attempt to access the resources
+            1. Create a role with some taxonomies (organizations and locations)
+            2. Create a filter in role to which taxonomies can be associated
+                e.g Domain filter
+            3. Override a filter with some taxonomies which doesnt match the
+                taxonomies of role
+            4. Create user with taxonomies including filter taxonomies and
+                assign role to it
+            5. Login with user and attempt to access the resources
 
-        @assert:
+        :assert:
 
-        1. Filter is created with taxonomies
-        2. Override checkmark is displayed in filters table for that filter
-        3. User can access resources, permissions specified in filter
-        4. User have access only in taxonomies specified in filter
+            1. Filter is created with taxonomies
+            2. Override checkmark is displayed in filters table for that filter
+            3. User can access resources, permissions specified in filter
+            4. User have access only in taxonomies specified in filter
         """
         name = gen_string('alpha')
         username = gen_string('alpha')
@@ -462,25 +462,25 @@ class CannedRoleTestCases(UITestCase):
         """Update role taxonomies which applies only to non-overrided filters
         in role
 
-        @id: f705faea-0d1c-4c11-b82d-b6b0e848f75d
+        :id: f705faea-0d1c-4c11-b82d-b6b0e848f75d
 
-        @steps:
+        :steps:
 
-        1. Create role with overrided, non-overrided resources and assign some
-            taxonomies (organizations and locations) to role
-        2. Assign this role to user
-        3. Update existing role with different taxonomies
-        4. Login with new user and attempt to access the resources
+            1. Create role with overrided, non-overrided resources and assign
+                some taxonomies (organizations and locations) to role
+            2. Assign this role to user
+            3. Update existing role with different taxonomies
+            4. Login with new user and attempt to access the resources
 
-        @assert:
+        :assert:
 
-        1. The role is updated successfully
-        2. User should have access to non-overrided resources of role in
-            updated taxonomies
-        3. User shouldnt have access to overrided resources of role in updated
-            taxonomies
+            1. The role is updated successfully
+            2. User should have access to non-overrided resources of role in
+                updated taxonomies
+            3. User shouldnt have access to overrided resources of role in
+                updated taxonomies
 
-        @caseautomation: notautomated
+        :caseautomation: notautomated
         """
 
     @stubbed
@@ -488,26 +488,27 @@ class CannedRoleTestCases(UITestCase):
     def test_positive_disable_filter_override(self):
         """Uncheck override resets filter taxonomies
 
-        @id: cae31e44-c3d6-4a08-a088-d12cb2088068
+        :id: cae31e44-c3d6-4a08-a088-d12cb2088068
 
-        @steps:
+        :steps:
 
-        1. Create role with some taxonomies (Organizations and Locations)
-        2. Create and override filter having different taxonomies than its role
-        3. Create user with role
-        4. Uncheck the override checkbox in role filter
-        5. Login with user and attempt to access resources
+            1. Create role with some taxonomies (Organizations and Locations)
+            2. Create and override filter having different taxonomies than its
+                role
+            3. Create user with role
+            4. Uncheck the override checkbox in role filter
+            5. Login with user and attempt to access resources
 
-        @assert:
+        :assert:
 
-        1. On unchecking override, the override mark is not displayed for that
-            filter in filters table
-        2. On unchecking override, User should have access to resources in
-            taxonomies assigned to role
-        3. On unchecking override, User shouldn't have access to resources in
-            taxonomies mentioned in filter
+            1. On unchecking override, the override mark is not displayed for
+                that filter in filters table
+            2. On unchecking override, User should have access to resources in
+                taxonomies assigned to role
+            3. On unchecking override, User shouldn't have access to resources
+                in taxonomies mentioned in filter
 
-        @caseautomation: notautomated
+        :caseautomation: notautomated
         """
 
     @stubbed
@@ -515,26 +516,28 @@ class CannedRoleTestCases(UITestCase):
     def test_positive_disable_overriding_option(self):
         """Disable overriding option to disable single filter overriding
 
-        @id: e692d114-1b0b-4106-afdb-cf894ea09acf
+        :id: e692d114-1b0b-4106-afdb-cf894ea09acf
 
-        @steps:
+        :steps:
 
-        1. Create role with some taxonomies (Organizations and Locations)
-        2. Create and override filter having different taxonomies than its role
-        3. Create user with role
-        4. Click on 'Disable overriding' option of that filter in filters table
-        5. Login with user and attempt to access resources
+            1. Create role with some taxonomies (Organizations and Locations)
+            2. Create and override filter having different taxonomies than its
+                role
+            3. Create user with role
+            4. Click on 'Disable overriding' option of that filter in filters
+                table
+            5. Login with user and attempt to access resources
 
-        @assert:
+        :assert:
 
-        1. On unchecking override, the override mark is not displayed for that
-            filter in filters table
-        2. On unchecking override, User should have access to resources in
-            taxonomies assigned to role
-        3. On unchecking override, User shouldn't have access to resources in
-            taxonomies mentioned in filter
+            1. On unchecking override, the override mark is not displayed for
+                that filter in filters table
+            2. On unchecking override, User should have access to resources in
+                taxonomies assigned to role
+            3. On unchecking override, User shouldn't have access to resources
+                in taxonomies mentioned in filter
 
-        @caseautomation: notautomated
+        :caseautomation: notautomated
         """
 
     @stubbed
@@ -543,26 +546,26 @@ class CannedRoleTestCases(UITestCase):
         """Disable all filters overriding option to disable all filters
         overriding in a role
 
-        @id: 2942835a-f156-4211-ab7d-77e2b08fceac
+        :id: 2942835a-f156-4211-ab7d-77e2b08fceac
 
-        @steps:
+        :steps:
 
-        1. Create role with more than one overridden filters
-        2. Create user with role
-        3. Click on 'Disable all filters overriding' button in filters table
-            in role
-        4. Login with user and attempt to access resources
+            1. Create role with more than one overridden filters
+            2. Create user with role
+            3. Click on 'Disable all filters overriding' button in filters
+                table in role
+            4. Login with user and attempt to access resources
 
-        @assert:
+        :assert:
 
-        1. On disable, the overridden mark is disabled for all the overridden
-            filters in role
-        2. On disable, User should have access to resources in
-            taxonomies (orgnizations and locations) assigned to role
-        3. On disable, User shouldn't have access to resources in
-            taxonomies mentioned in filter
+            1. On disable, the overridden mark is disabled for all the
+                overridden filters in role
+            2. On disable, User should have access to resources in taxonomies
+                (orgnizations and locations) assigned to role
+            3. On disable, User shouldn't have access to resources in
+                taxonomies mentioned in filter
 
-        @caseautomation: notautomated
+        :caseautomation: notautomated
         """
 
     @stubbed
@@ -571,29 +574,30 @@ class CannedRoleTestCases(UITestCase):
         """Create Org admin role which has access to all the resources within
         organization
 
-        @id: 03f41736-c5c5-414a-ab75-650cecd6f6cd
+        :id: 03f41736-c5c5-414a-ab75-650cecd6f6cd
 
-        @steps:
+        :steps:
 
-        1. Clone Manager role which has most resource permissions
-        2. Assign taxonomies (organizations and locations) to the cloned role
-        3. Add more missing resource permission to the cloned role to make it
-            Org Admin having access to all resources
-        4. Create user and assign org admin role
-        5. Login with user and attempt to access resources
+            1. Clone Manager role which has most resource permissions
+            2. Assign taxonomies (organizations and locations) to the cloned
+                role
+            3. Add more missing resource permission to the cloned role to make
+                it Org Admin having access to all resources
+            4. Create user and assign org admin role
+            5. Login with user and attempt to access resources
 
-        @assert:
+        :assert:
 
-        1. Successfully created Org Admin by cloning manager role
-        2. Successfully assigned taxonomiess to role
-        3. Missing resource filters are added successfully to the Org Admin
-            role
-        4. User is able to access all the resources, permissions only in
-            taxonomies selected in org admin role
-        5. User shouldnt be able to access resources, permissions in
-            taxonomies not selected in org admin role
+            1. Successfully created Org Admin by cloning manager role
+            2. Successfully assigned taxonomiess to role
+            3. Missing resource filters are added successfully to the Org Admin
+                role
+            4. User is able to access all the resources, permissions only in
+                taxonomies selected in org admin role
+            5. User shouldnt be able to access resources, permissions in
+                taxonomies not selected in org admin role
 
-        @caseautomation: notautomated
+        :caseautomation: notautomated
         """
 
     @stubbed
@@ -601,20 +605,20 @@ class CannedRoleTestCases(UITestCase):
     def test_positive_create_cloned_role_with_taxonomies(self):
         """Test taxonomies can be set on cloned role.
 
-        @id: ad20f5c7-3df7-4b43-8a52-097c87676d07
+        :id: ad20f5c7-3df7-4b43-8a52-097c87676d07
 
-        @steps:
+        :steps:
 
-        1. Attempt to clone any existing role(e.g Manager Role)
-        2. Set new taxonomies (locations and organizations) to cloned role
+            1. Attempt to clone any existing role(e.g Manager Role)
+            2. Set new taxonomies (locations and organizations) to cloned role
 
-        @assert:
+        :assert:
 
-        1. While cloning, role has no taxonomies selected by default
-        2. While cloning, role allows to set taxonomies
-        3. New taxonomies should be applied to cloned role
+            1. While cloning, role has no taxonomies selected by default
+            2. While cloning, role allows to set taxonomies
+            3. New taxonomies should be applied to cloned role
 
-        @caseautomation: notautomated
+        :caseautomation: notautomated
         """
 
     @stubbed
@@ -622,18 +626,16 @@ class CannedRoleTestCases(UITestCase):
     def test_positive_override_cloned_role_filter(self):
         """Test if the cloned role filter can be overrided
 
-        @id: e475aa7d-4844-4bb3-bfd3-3d4082a41fe4
+        :id: e475aa7d-4844-4bb3-bfd3-3d4082a41fe4
 
-        @steps:
+        :steps:
 
-        1. Clone any existing role(e.g Manager Role)
-        2. Attempt to override the filter in cloned role
+            1. Clone any existing role(e.g Manager Role)
+            2. Attempt to override the filter in cloned role
 
-        @assert:
+        :assert: Filter in cloned role should be successfully overriding
 
-        1. Filter in cloned role should be successfully overriding
-
-        @caseautomation: notautomated
+        :caseautomation: notautomated
         """
 
     @stubbed
@@ -641,20 +643,18 @@ class CannedRoleTestCases(UITestCase):
     def test_positive_empty_filter_taxonomies_in_cloned_role(self):
         """Test overridden filters taxonomies in cloned role
 
-        @id: 86d9cd93-8189-45b3-86c6-ac9185e48655
+        :id: 86d9cd93-8189-45b3-86c6-ac9185e48655
 
-        @steps:
+        :steps: Clone a role having overridden filter(s), where filters should
+            have some taxonomies (locations and organizations) assigned
 
-        1. Clone a role having overridden filter(s), where filters should have
-            some taxonomies (locations and organizations) assigned
+        :assert:
 
-        @assert:
+            1. On cloning, taxonomies of the overridden filters in cloned role
+                are set to None
+            2. Override mark is filters table is marked
 
-        1. On cloning, taxonomies of the overridden filters in cloned role are
-            set to None
-        2. Override mark is filters table is marked
-
-        @caseautomation: notautomated
+        :caseautomation: notautomated
         """
 
     @stubbed
@@ -662,17 +662,17 @@ class CannedRoleTestCases(UITestCase):
     def test_positive_override_empty_filter_taxonomies_in_cloned_role(self):
         """Override overridden filters in cloned role
 
-        @id: 978bf745-0b63-4dc7-9512-77731b0caa23
+        :id: 978bf745-0b63-4dc7-9512-77731b0caa23
 
-        @steps:
+        :steps:
 
-        1. Clone a role having overridden filter(s)
-        2. In cloned role, Assign some taxonomies (locations and organizations)
-            to these filters as taxonomies in filters will be blank after
-            cloning
+            1. Clone a role having overridden filter(s)
+            2. In cloned role, Assign some taxonomies (locations and
+                organizations) to these filters as taxonomies in filters will
+                be blank after cloning
 
-        @assert: In cloned role, The taxonomies should be able to assign to
-        overridden filters
+        :assert: In cloned role, The taxonomies should be able to assign to
+            overridden filters
 
-        @caseautomation: notautomated
+        :caseautomation: notautomated
         """

--- a/tests/foreman/ui/test_satellitesync.py
+++ b/tests/foreman/ui/test_satellitesync.py
@@ -1,19 +1,19 @@
 # -*- encoding: utf-8 -*-
 """Test class for InterSatellite Sync feature
 
-@Requirement: Satellitesync
+:Requirement: Satellitesync
 
-@CaseAutomation: Automated
+:CaseAutomation: Automated
 
-@CaseLevel: Acceptance
+:CaseLevel: Acceptance
 
-@CaseComponent: UI
+:CaseComponent: UI
 
-@TestType: Functional
+:TestType: Functional
 
-@CaseImportance: High
+:CaseImportance: High
 
-@Upstream: No
+:Upstream: No
 """
 
 from robottelo.decorators import (
@@ -34,18 +34,16 @@ class InterSatelliteSyncTestCase(UITestCase):
     def test_positive_show_repo_export_history(self):
         """Product history shows repo export history on export.
 
-        @id: 01d82253-081b-4d11-9a5b-e6052173fe47
+        :id: 01d82253-081b-4d11-9a5b-e6052173fe47
 
-        @steps:
+        :steps: Export a repo to a specified location in settings.
 
-        1. Export a repo to a specified location in settings.
+        :assert: Repo/Product history should reflect the export history with
+            user and time.
 
-        @assert: Repo/Product history should reflect the export history with
-        user and time.
+        :caseautomation: notautomated
 
-        @caseautomation: notautomated
-
-        @CaseLevel: System
+        :CaseLevel: System
         """
 
     @run_only_on('sat')
@@ -54,18 +52,16 @@ class InterSatelliteSyncTestCase(UITestCase):
     def test_positive_show_cv_export_history(self):
         """CV history shows CV version export history on export.
 
-        @id: 06e26cca-e262-4eff-b8d7-fbca504a8acb
+        :id: 06e26cca-e262-4eff-b8d7-fbca504a8acb
 
-        @steps:
+        :steps: Export a CV to a specified location in settings.
 
-        1. Export a CV to a specified location in settings.
+        :assert: CV history should reflect the export history with user,
+            version, action and time.
 
-        @assert: CV history should reflect the export history with user,
-        version, action and time.
+        :caseautomation: notautomated
 
-        @caseautomation: notautomated
-
-        @CaseLevel: System
+        :CaseLevel: System
         """
 
     @run_only_on('sat')
@@ -74,22 +70,22 @@ class InterSatelliteSyncTestCase(UITestCase):
     def test_positive_update_cdn_url(self):
         """Update CDN URL to import from upstream.
 
-        @id: 5ff30764-a1b1-48df-a6a1-0f1d23f883b9
+        :id: 5ff30764-a1b1-48df-a6a1-0f1d23f883b9
 
-        @steps:
+        :steps:
 
-        1. In upstream, Export Redhat repo/CV to a directory.
-        2. Copy exported contents to /var/www/html.
-        3. In downstream, Update CDN URL with step 2 location to import the
-           Redhat contents.
-        4. Enable and sync the imported repo from Redhat Repositories page.
+            1. In upstream, Export Redhat repo/CV to a directory.
+            2. Copy exported contents to /var/www/html.
+            3. In downstream, Update CDN URL with step 2 location to import the
+               Redhat contents.
+            4. Enable and sync the imported repo from Redhat Repositories page.
 
-        @assert:
+        :assert:
 
-        1. The CDN URL is is updated successfully.
-        2. The imported repo is enabled and sync.
+            1. The CDN URL is is updated successfully.
+            2. The imported repo is enabled and sync.
 
-        @caseautomation: notautomated
+        :caseautomation: notautomated
         """
 
     @run_only_on('sat')
@@ -98,19 +94,20 @@ class InterSatelliteSyncTestCase(UITestCase):
     def test_negative_update_cdn_url(self):
         """Update non existing CDN URL to import from upstream.
 
-        @id: 4bf74712-dac8-447b-9c9f-227a41cdec4d
+        :id: 4bf74712-dac8-447b-9c9f-227a41cdec4d
 
-        @steps:
+        :steps:
 
-        1. In downstream, Update CDN URL with some non existing url.
-        2. Attempt to Enable and sync some repo from Redhat Repositories page.
+            1. In downstream, Update CDN URL with some non existing url.
+            2. Attempt to Enable and sync some repo from Redhat Repositories
+               page.
 
-        @assert:
+        :assert:
 
-        1. The CDN URL is not allowed to update any non existing url.
-        2. None of the repo is allowed to enable and sync.
+            1. The CDN URL is not allowed to update any non existing url.
+            2. None of the repo is allowed to enable and sync.
 
-        @caseautomation: notautomated
+        :caseautomation: notautomated
         """
 
     @run_only_on('sat')
@@ -119,18 +116,19 @@ class InterSatelliteSyncTestCase(UITestCase):
     def test_positive_restrict_other_redhat_repo_import(self):
         """Restrict the import/sync of non exported repos.
 
-        @id: 7091ca13-7f58-4733-87d5-1fa3670bfcee
+        :id: 7091ca13-7f58-4733-87d5-1fa3670bfcee
 
-        @steps:
+        :steps:
 
-        1. Export Red Hat YUM repo to path which will be accessible over HTTP.
-        2. Define the CDN URL the same as the exported HTTP URL.
-        3. Attempt to Import/Enable non exported repos from Redhat Repositories
-           page.
+            1. Export Red Hat YUM repo to path which will be accessible over
+                HTTP.
+            2. Define the CDN URL the same as the exported HTTP URL.
+            3. Attempt to Import/Enable non exported repos from Redhat
+               Repositories page.
 
-        @assert: The import of non exported repos is restricted.
+        :assert: The import of non exported repos is restricted.
 
-        @caseautomation: notautomated
+        :caseautomation: notautomated
 
-        @CaseLevel: System
+        :CaseLevel: System
         """

--- a/tests/foreman/ui/test_setting.py
+++ b/tests/foreman/ui/test_setting.py
@@ -1,19 +1,19 @@
 # -*- encoding: utf-8 -*-
 """Test class for Setting Parameter values
 
-@Requirement: Setting
+:Requirement: Setting
 
-@CaseAutomation: Automated
+:CaseAutomation: Automated
 
-@CaseLevel: Acceptance
+:CaseLevel: Acceptance
 
-@CaseComponent: UI
+:CaseComponent: UI
 
-@TestType: Functional
+:TestType: Functional
 
-@CaseImportance: High
+:CaseImportance: High
 
-@Upstream: No
+:Upstream: No
 """
 
 from fauxfactory import gen_email, gen_string, gen_url
@@ -170,9 +170,9 @@ class SettingTestCase(UITestCase):
     def test_positive_update_authorize_login_delegation_param(self):
         """Updates parameter "authorize_login_delegation" under Auth tab
 
-        @id: 0b752f6a-5987-483a-9cef-2d02fa42fe73
+        :id: 0b752f6a-5987-483a-9cef-2d02fa42fe73
 
-        @Assert: Parameter is updated successfully
+        :Assert: Parameter is updated successfully
         """
         self.tab_locator = tab_locators['settings.tab_auth']
         self.param_name = 'authorize_login_delegation'
@@ -195,9 +195,9 @@ class SettingTestCase(UITestCase):
     def test_positive_update_administrator_param(self):
         """Updates parameter "administrator" under General tab
 
-        @id: ecab6d51-ad29-4904-bc04-e62673ab1028
+        :id: ecab6d51-ad29-4904-bc04-e62673ab1028
 
-        @Assert: Parameter is updated successfully
+        :Assert: Parameter is updated successfully
         """
         self.tab_locator = tab_locators['settings.tab_general']
         self.param_name = 'administrator'
@@ -221,9 +221,9 @@ class SettingTestCase(UITestCase):
     def test_positive_update_authorize_login_delegation_api_param(self):
         """Updates parameter "authorize_login_delegation_api" under Auth tab
 
-        @id: 1dc39d96-a0e3-4d2e-aeb8-14aedab2ebe3
+        :id: 1dc39d96-a0e3-4d2e-aeb8-14aedab2ebe3
 
-        @Assert: Parameter is updated successfully
+        :Assert: Parameter is updated successfully
         """
         self.tab_locator = tab_locators['settings.tab_auth']
         self.param_name = 'authorize_login_delegation_api'
@@ -247,9 +247,9 @@ class SettingTestCase(UITestCase):
         """Updates parameter "entries_per_page" under General tab with
         invalid values
 
-        @id: b6bb39e2-797e-43e4-9629-d319c62992a4
+        :id: b6bb39e2-797e-43e4-9629-d319c62992a4
 
-        @Assert: Parameter is not updated
+        :Assert: Parameter is not updated
         """
         self.tab_locator = tab_locators['settings.tab_general']
         self.param_name = 'entries_per_page'
@@ -274,9 +274,9 @@ class SettingTestCase(UITestCase):
     def test_positive_update_entries_per_page_param(self):
         """Updates parameter "entries_per_page" under General tab
 
-        @id: e41933c8-d835-4126-a356-a186c8e9013f
+        :id: e41933c8-d835-4126-a356-a186c8e9013f
 
-        @Assert: Parameter is updated successfully
+        :Assert: Parameter is updated successfully
         """
         param_value = str(randint(30, 1000))
         self.tab_locator = tab_locators['settings.tab_general']
@@ -298,9 +298,9 @@ class SettingTestCase(UITestCase):
     def test_positive_update_email_reply_address_param(self):
         """Updates parameter "email_reply_address" under General tab
 
-        @id: 274eaa6d-a6ba-4dbe-a843-c3717fbd70ae
+        :id: 274eaa6d-a6ba-4dbe-a843-c3717fbd70ae
 
-        @Assert: Parameter is updated successfully
+        :Assert: Parameter is updated successfully
         """
         self.tab_locator = tab_locators['settings.tab_general']
         self.param_name = 'email_reply_address'
@@ -323,9 +323,9 @@ class SettingTestCase(UITestCase):
     def test_positive_update_fix_db_cache_param(self):
         """Updates parameter "fix_db_cache" under General tab
 
-        @id: b7f8df0e-9ac8-4075-8955-c895267e424c
+        :id: b7f8df0e-9ac8-4075-8955-c895267e424c
 
-        @Assert: Parameter is updated successfully
+        :Assert: Parameter is updated successfully
         """
         self.tab_locator = tab_locators['settings.tab_general']
         self.param_name = 'fix_db_cache'
@@ -348,9 +348,9 @@ class SettingTestCase(UITestCase):
     def test_positive_update_use_gravatar_param(self):
         """Updates parameter "use_gravatar" under General tab
 
-        @id: 6ea676c1-acb9-495f-9ee7-0a2c14f34ea1
+        :id: 6ea676c1-acb9-495f-9ee7-0a2c14f34ea1
 
-        @Assert: Parameter is updated successfully
+        :Assert: Parameter is updated successfully
         """
         self.tab_locator = tab_locators['settings.tab_general']
         self.param_name = 'use_gravatar'
@@ -374,9 +374,9 @@ class SettingTestCase(UITestCase):
         """Updates parameter "max_trend" under General tab with invalid
         values
 
-        @id: bcc2848d-734a-4b13-80fa-9fd34545cbe7
+        :id: bcc2848d-734a-4b13-80fa-9fd34545cbe7
 
-        @Assert: Parameter is not updated
+        :Assert: Parameter is not updated
         """
         self.tab_locator = tab_locators['settings.tab_general']
         self.param_name = 'max_trend'
@@ -401,9 +401,9 @@ class SettingTestCase(UITestCase):
     def test_positive_update_max_trend_param(self):
         """Updates parameter "max_trend" under General tab
 
-        @id: 6e08bb3b-de48-45b4-b982-7180dbb65ed2
+        :id: 6e08bb3b-de48-45b4-b982-7180dbb65ed2
 
-        @Assert: Parameter is updated successfully
+        :Assert: Parameter is updated successfully
         """
         self.tab_locator = tab_locators['settings.tab_general']
         self.param_name = 'max_trend'
@@ -427,9 +427,9 @@ class SettingTestCase(UITestCase):
         """Updates parameter "idle_timeout" under General tab with
         invalid values
 
-        @id: 0c46ec21-7402-4241-8b22-5f8afa1f5316
+        :id: 0c46ec21-7402-4241-8b22-5f8afa1f5316
 
-        @Assert: Parameter is not updated
+        :Assert: Parameter is not updated
         """
         self.tab_locator = tab_locators['settings.tab_auth']
         self.param_name = 'idle_timeout'
@@ -454,9 +454,9 @@ class SettingTestCase(UITestCase):
     def test_positive_update_idle_timeout_param(self):
         """Updates parameter "idle_timeout" under Auth tab
 
-        @id: fd5b2fe0-7124-444b-9f00-fca2b38c52f4
+        :id: fd5b2fe0-7124-444b-9f00-fca2b38c52f4
 
-        @Assert: Parameter is updated successfully
+        :Assert: Parameter is updated successfully
         """
         self.tab_locator = tab_locators['settings.tab_auth']
         self.param_name = 'idle_timeout'
@@ -479,9 +479,9 @@ class SettingTestCase(UITestCase):
     def test_positive_update_foreman_url_param(self):
         """Updates parameter "foreman_url" under General tab
 
-        @id: e09e95e9-510a-48b6-a59f-5adc0a383ddc
+        :id: e09e95e9-510a-48b6-a59f-5adc0a383ddc
 
-        @Assert: Parameter is updated successfully
+        :Assert: Parameter is updated successfully
         """
         self.tab_locator = tab_locators['settings.tab_general']
         self.param_name = 'foreman_url'
@@ -504,9 +504,9 @@ class SettingTestCase(UITestCase):
     def test_negative_update_foreman_url_param(self):
         """Updates parameter "foreman_url" under General tab
 
-        @id: ee450e0a-d02e-40c4-a67e-5508a29dc9c8
+        :id: ee450e0a-d02e-40c4-a67e-5508a29dc9c8
 
-        @Assert: Parameter is not updated
+        :Assert: Parameter is not updated
         """
         self.tab_locator = tab_locators['settings.tab_general']
         self.param_name = 'foreman_url'
@@ -532,9 +532,9 @@ class SettingTestCase(UITestCase):
         """Updates parameter "dynflow_enable_console" under ForemanTasks
         tab
 
-        @id: 11a710f1-d5fc-48c7-9f31-a92dbbaebc40
+        :id: 11a710f1-d5fc-48c7-9f31-a92dbbaebc40
 
-        @Assert: Parameter is updated successfully
+        :Assert: Parameter is updated successfully
         """
         self.tab_locator = tab_locators['settings.tab_foremantasks']
         self.param_name = 'dynflow_enable_console'
@@ -558,9 +558,9 @@ class SettingTestCase(UITestCase):
         """Updates parameter
         "authorize_login_delegation_auth_source_user_autocreate" under Auth tab
 
-        @id: 82137c0c-1cf5-445d-87fe-1ff80a12df3c
+        :id: 82137c0c-1cf5-445d-87fe-1ff80a12df3c
 
-        @Assert: Parameter is updated successfully
+        :Assert: Parameter is updated successfully
         """
         self.tab_locator = tab_locators['settings.tab_auth']
         self.param_name = ('authorize_login_delegation_auth_source_user'
@@ -585,9 +585,9 @@ class SettingTestCase(UITestCase):
         """Updates parameter "login_delegation_logout_url" under Auth
         tab
 
-        @id: 67b32c5f-7e8e-4ba7-ab29-9af2ac3660a9
+        :id: 67b32c5f-7e8e-4ba7-ab29-9af2ac3660a9
 
-        @Assert: Parameter is updated successfully
+        :Assert: Parameter is updated successfully
         """
         self.tab_locator = tab_locators['settings.tab_auth']
         self.param_name = 'login_delegation_logout_url'
@@ -611,9 +611,9 @@ class SettingTestCase(UITestCase):
         """Read-only param "oauth_active" under Auth tab shouldn't be
         updated
 
-        @id: e69d791a-e5c4-4f42-b5dd-c9d3bca49673
+        :id: e69d791a-e5c4-4f42-b5dd-c9d3bca49673
 
-        @Assert: Parameter is not editable
+        :Assert: Parameter is not editable
         """
         self.tab_locator = tab_locators['settings.tab_auth']
         with Session(self.browser) as session:
@@ -634,9 +634,9 @@ class SettingTestCase(UITestCase):
     def test_positive_update_require_ssl_smart_proxies_param(self):
         """Updates parameter "require_ssl_smart_proxies" under Auth tab
 
-        @id: 79d5bb5f-6bec-4c1c-b68e-6727aeb04614
+        :id: 79d5bb5f-6bec-4c1c-b68e-6727aeb04614
 
-        @Assert: Parameter is updated successfully
+        :Assert: Parameter is updated successfully
         """
         self.tab_locator = tab_locators['settings.tab_auth']
         self.param_name = 'require_ssl_smart_proxies'
@@ -660,9 +660,9 @@ class SettingTestCase(UITestCase):
         """Updates parameter "restrict_registered_smart_proxies" under
         Auth tab
 
-        @id: 7dbcf471-3cee-4718-a316-18da6c4c1ef0
+        :id: 7dbcf471-3cee-4718-a316-18da6c4c1ef0
 
-        @Assert: Parameter is updated successfully
+        :Assert: Parameter is updated successfully
         """
         self.tab_locator = tab_locators['settings.tab_auth']
         self.param_name = 'restrict_registered_smart_proxies'
@@ -687,9 +687,9 @@ class SettingTestCase(UITestCase):
     def test_positive_update_trusted_puppetmaster_hosts_param(self):
         """Updates parameter "trusted_puppetmaster_hosts" under Auth tab
 
-        @id: 18596dbc-7e2a-426c-bd1a-338a31ba6e97
+        :id: 18596dbc-7e2a-426c-bd1a-338a31ba6e97
 
-        @Assert: Parameter is updated successfully
+        :Assert: Parameter is updated successfully
         """
         self.tab_locator = tab_locators['settings.tab_auth']
         self.param_name = 'trusted_puppetmaster_hosts'
@@ -712,9 +712,9 @@ class SettingTestCase(UITestCase):
     def test_negative_update_trusted_puppetmaster_hosts_param(self):
         """Updates parameter "trusted_puppetmaster_hosts" under Auth tab
 
-        @id: 23af2612-1291-41a1-8002-87263e39bdbe
+        :id: 23af2612-1291-41a1-8002-87263e39bdbe
 
-        @Assert: Parameter is not updated
+        :Assert: Parameter is not updated
         """
         self.tab_locator = tab_locators['settings.tab_auth']
         self.param_name = 'trusted_puppetmaster_hosts'
@@ -740,9 +740,9 @@ class SettingTestCase(UITestCase):
         """Updates parameter "ignore_puppet_facts_for_provisioning" under
         Provisioning tab
 
-        @id: 71cb4779-7982-43b6-ab65-7198ec193941
+        :id: 71cb4779-7982-43b6-ab65-7198ec193941
 
-        @Assert: Parameter is updated successfully
+        :Assert: Parameter is updated successfully
         """
         self.tab_locator = tab_locators['settings.tab_provisioning']
         self.param_name = 'ignore_puppet_facts_for_provisioning'
@@ -766,9 +766,9 @@ class SettingTestCase(UITestCase):
     def test_positive_update_manage_puppetca_param(self):
         """Updates parameter "manage_puppetca" under Provisioning tab
 
-        @id: 2f652441-6beb-40c0-9fb3-f0b835d06ca7
+        :id: 2f652441-6beb-40c0-9fb3-f0b835d06ca7
 
-        @Assert: Parameter is updated successfully
+        :Assert: Parameter is updated successfully
         """
         self.tab_locator = tab_locators['settings.tab_provisioning']
         self.param_name = 'manage_puppetca'
@@ -793,9 +793,9 @@ class SettingTestCase(UITestCase):
         """Updates parameter "query_local_nameservers" under
         Provisioning tab
 
-        @id: 643960f4-121c-44f3-a5e8-00b9cf66ff99
+        :id: 643960f4-121c-44f3-a5e8-00b9cf66ff99
 
-        @Assert: Parameter is updated successfully
+        :Assert: Parameter is updated successfully
         """
         self.tab_locator = tab_locators['settings.tab_provisioning']
         self.param_name = 'query_local_nameservers'
@@ -819,9 +819,9 @@ class SettingTestCase(UITestCase):
     def test_positive_update_safemode_render_param(self):
         """Updates parameter "safemode_render" under Provisioning tab
 
-        @id: 4762a89a-2ebe-4834-b44f-f74888e609bb
+        :id: 4762a89a-2ebe-4834-b44f-f74888e609bb
 
-        @Assert: Parameter is updated successfully
+        :Assert: Parameter is updated successfully
         """
         self.tab_locator = tab_locators['settings.tab_provisioning']
         self.param_name = 'safemode_render'
@@ -846,9 +846,9 @@ class SettingTestCase(UITestCase):
         """Updates parameter "token_duration" under Provisioning tab
         with invalid values
 
-        @id: a1d18ba3-a14f-47ab-82fb-1249abc7b076
+        :id: a1d18ba3-a14f-47ab-82fb-1249abc7b076
 
-        @Assert: Parameter is not updated
+        :Assert: Parameter is not updated
         """
         self.tab_locator = tab_locators['settings.tab_provisioning']
         self.param_name = 'token_duration'
@@ -874,9 +874,9 @@ class SettingTestCase(UITestCase):
     def test_positive_update_token_duration_param(self):
         """Updates param "token_duration" under Provisioning tab
 
-        @id: a200b578-4463-444b-bed1-82e540a77529
+        :id: a200b578-4463-444b-bed1-82e540a77529
 
-        @Assert: Parameter is updated successfully
+        :Assert: Parameter is updated successfully
         """
         self.tab_locator = tab_locators['settings.tab_provisioning']
         self.param_name = 'token_duration'

--- a/tests/foreman/ui/test_sso.py
+++ b/tests/foreman/ui/test_sso.py
@@ -1,19 +1,19 @@
 # -*- encoding: utf-8 -*-
 """Test class for SSO (UI)
 
-@Requirement: Sso
+:Requirement: Sso
 
-@CaseAutomation: Automated
+:CaseAutomation: Automated
 
-@CaseLevel: Acceptance
+:CaseLevel: Acceptance
 
-@CaseComponent: UI
+:CaseComponent: UI
 
-@TestType: Functional
+:TestType: Functional
 
-@CaseImportance: High
+:CaseImportance: High
 
-@Upstream: No
+:Upstream: No
 """
 
 from robottelo.decorators import stubbed, tier3
@@ -50,21 +50,21 @@ class SingleSignOnTestCase(UITestCase):
     def test_positive_sso_kerberos_basic_no_roles(self):
         """SSO - kerberos (IdM or AD) login (basic) that has no roles
 
-        @id: c271d9fd-7528-4b19-b5c6-e9c0148c2047
+        :id: c271d9fd-7528-4b19-b5c6-e9c0148c2047
 
-        @setup: Assure SSO with kerberos (IdM or AD) is set up.
+        :setup: Assure SSO with kerberos (IdM or AD) is set up.
 
-        @steps:
-        1. Login using a kerberos (IdM or AD) ID to the client
-        2. Login to the Web-UI should be automatic without the need to fill in
-        the form.
+        :steps:
+            1. Login using a kerberos (IdM or AD) ID to the client
+            2. Login to the Web-UI should be automatic without the need to fill
+                in the form.
 
-        @assert: Log in to sat6 UI successfully but cannot access anything
-        useful in UI
+        :assert: Log in to sat6 UI successfully but cannot access anything
+            useful in UI
 
-        @caseautomation: notautomated
+        :caseautomation: notautomated
 
-        @CaseLevel: System
+        :CaseLevel: System
         """
 
     @stubbed()
@@ -73,22 +73,21 @@ class SingleSignOnTestCase(UITestCase):
         """SSO - kerberos (IdM or AD) login (basic) that has roles
         assigned.
 
-        @id: df55a0e7-1387-4ea5-9b2f-27836dd4815e
+        :id: df55a0e7-1387-4ea5-9b2f-27836dd4815e
 
-        @setup: Assure SSO with kerberos (IdM or AD) is set up.
+        :setup: Assure SSO with kerberos (IdM or AD) is set up.
 
-        @steps:
-        1. Login using a kerberos (IdM or AD) ID to the client
-        2. Login to the Web-UI should be automatic without the need to fill in
-        the form.
+        :steps:
+            1. Login using a kerberos (IdM or AD) ID to the client
+            2. Login to the Web-UI should be automatic without the need to fill
+                in the form.
 
-        @assert: Log in to sat6 UI successfully and can access functional
-        areas in UI
+        :assert: Log in to sat6 UI successfully and can access functional areas
+            in UI
 
-        @caseautomation: notautomated
+        :caseautomation: notautomated
 
-
-        @CaseLevel: System
+        :CaseLevel: System
         """
 
     @stubbed()
@@ -97,16 +96,16 @@ class SingleSignOnTestCase(UITestCase):
         """Kerberos (IdM or AD) user activity when kerb (IdM or AD)
         account has been deleted or deactivated.
 
-        @id: ee838e76-2522-470e-ae70-f22d845e683e
+        :id: ee838e76-2522-470e-ae70-f22d845e683e
 
-        @steps:
-        1. Login to the foreman UI
-        2. Delete or disable userid on IdM server or AD side.
+        :steps:
+            1. Login to the foreman UI
+            2. Delete or disable userid on IdM server or AD side.
 
-        @assert: This is handled gracefully (user is logged out perhaps?)
-        and no data corruption
+        :assert: This is handled gracefully (user is logged out perhaps?) and
+            no data corruption
 
-        @caseautomation: notautomated
+        :caseautomation: notautomated
 
-        @CaseLevel: System
+        :CaseLevel: System
         """

--- a/tests/foreman/ui/test_subnet.py
+++ b/tests/foreman/ui/test_subnet.py
@@ -1,19 +1,19 @@
 # -*- encoding: utf-8 -*-
 """Test class for Subnet UI
 
-@Requirement: Subnet
+:Requirement: Subnet
 
-@CaseAutomation: Automated
+:CaseAutomation: Automated
 
-@CaseLevel: Acceptance
+:CaseLevel: Acceptance
 
-@CaseComponent: UI
+:CaseComponent: UI
 
-@TestType: Functional
+:TestType: Functional
 
-@CaseImportance: High
+:CaseImportance: High
 
-@Upstream: No
+:Upstream: No
 """
 
 from fauxfactory import gen_ipaddr, gen_netmask, gen_string
@@ -44,9 +44,9 @@ class SubnetTestCase(UITestCase):
     def test_positive_create_with_name(self):
         """Create new subnet using different names
 
-        @id: 2318f13c-db38-4919-831f-667fc6e2e7bf
+        :id: 2318f13c-db38-4919-831f-667fc6e2e7bf
 
-        @Assert: Subnet is created
+        :Assert: Subnet is created
         """
         with Session(self.browser) as session:
             for name in generate_strings_list():
@@ -64,9 +64,9 @@ class SubnetTestCase(UITestCase):
     def test_positive_create_with_long_name(self):
         """Create new subnet with 255 characters in name
 
-        @id: b86772ad-a8ff-4c2b-93f4-4a715e4da59b
+        :id: b86772ad-a8ff-4c2b-93f4-4a715e4da59b
 
-        @Assert: Subnet is created with 255 chars
+        :Assert: Subnet is created with 255 chars
         """
         with Session(self.browser) as session:
             for name in valid_data_list():
@@ -85,11 +85,11 @@ class SubnetTestCase(UITestCase):
     def test_positive_add_domain(self):
         """Create new subnet and associate domain with it
 
-        @id: adbc7189-b451-49df-aa10-2ae732832dfe
+        :id: adbc7189-b451-49df-aa10-2ae732832dfe
 
-        @Assert: Subnet is created with domain associated
+        :Assert: Subnet is created with domain associated
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         name = gen_string('alpha')
         domain = entities.Domain(
@@ -122,9 +122,9 @@ class SubnetTestCase(UITestCase):
     def test_negative_create_with_invalid_name(self):
         """Create new subnet with invalid names
 
-        @id: d53056ad-a219-40d5-b20e-95ad343c9d38
+        :id: d53056ad-a219-40d5-b20e-95ad343c9d38
 
-        @Assert: Subnet is not created
+        :Assert: Subnet is not created
         """
         with Session(self.browser) as session:
             for name in invalid_values_list(interface='ui'):
@@ -143,9 +143,9 @@ class SubnetTestCase(UITestCase):
     def test_negative_create_with_invalid_params(self):
         """Create new subnet with negative values
 
-        @id: 5caa6aed-2bba-43d8-bb40-2d80b9d42b69
+        :id: 5caa6aed-2bba-43d8-bb40-2d80b9d42b69
 
-        @Assert: Subnet is not created
+        :Assert: Subnet is not created
         """
         with Session(self.browser) as session:
             make_subnet(
@@ -173,9 +173,9 @@ class SubnetTestCase(UITestCase):
     def test_positive_delete(self):
         """Delete an existing subnet
 
-        @id: cb1265de-a0ed-40b7-ba25-fe92251b9001
+        :id: cb1265de-a0ed-40b7-ba25-fe92251b9001
 
-        @Assert: Subnet is deleted
+        :Assert: Subnet is deleted
         """
         with Session(self.browser) as session:
             for name in generate_strings_list():
@@ -194,9 +194,9 @@ class SubnetTestCase(UITestCase):
         """Delete subnet. Attempt to delete subnet, but cancel in the
         confirmation dialog box.
 
-        @id: 9eed9020-8d13-4ba0-909a-db44ad0aecb6
+        :id: 9eed9020-8d13-4ba0-909a-db44ad0aecb6
 
-        @Assert: Subnet is not deleted
+        :Assert: Subnet is not deleted
         """
         name = gen_string('utf8')
         with Session(self.browser) as session:
@@ -213,9 +213,9 @@ class SubnetTestCase(UITestCase):
     def test_positive_update_name(self):
         """Update Subnet name
 
-        @id: ec9f11e3-27a7-45d8-91fe-f04c20b595bc
+        :id: ec9f11e3-27a7-45d8-91fe-f04c20b595bc
 
-        @Assert: Subnet name is updated
+        :Assert: Subnet name is updated
         """
         name = gen_string('alpha')
         with Session(self.browser) as session:
@@ -237,9 +237,9 @@ class SubnetTestCase(UITestCase):
     def test_positive_update_network(self):
         """Update Subnet network
 
-        @id: f79d3b1b-6101-4009-88ad-b259d4794e6c
+        :id: f79d3b1b-6101-4009-88ad-b259d4794e6c
 
-        @Assert: Subnet network is updated
+        :Assert: Subnet network is updated
         """
         name = gen_string('alpha')
         new_network = gen_ipaddr(ip3=True)
@@ -259,9 +259,9 @@ class SubnetTestCase(UITestCase):
     def test_positive_update_mask(self):
         """Update Subnet mask
 
-        @id: 6cc5de06-5463-4919-abe4-92cef4506a54
+        :id: 6cc5de06-5463-4919-abe4-92cef4506a54
 
-        @Assert: Subnet mask is updated
+        :Assert: Subnet mask is updated
         """
         name = gen_string('alpha')
         new_mask = gen_netmask(16, 31)

--- a/tests/foreman/ui/test_subscription.py
+++ b/tests/foreman/ui/test_subscription.py
@@ -1,18 +1,18 @@
 """Test class for Subscriptions/Manifests UI
 
-@Requirement: Subscription
+:Requirement: Subscription
 
-@CaseAutomation: Automated
+:CaseAutomation: Automated
 
-@CaseLevel: Acceptance
+:CaseLevel: Acceptance
 
-@CaseComponent: UI
+:CaseComponent: UI
 
-@TestType: Functional
+:TestType: Functional
 
-@CaseImportance: High
+:CaseImportance: High
 
-@Upstream: No
+:Upstream: No
 """
 from nailgun import entities
 from robottelo import manifests
@@ -36,9 +36,9 @@ class SubscriptionTestCase(UITestCase):
     def test_positive_upload_and_delete(self):
         """Upload a manifest with minimal input parameters and delete it
 
-        @id: 58e549b0-1ba3-421d-8075-dcf65d07510b
+        :id: 58e549b0-1ba3-421d-8075-dcf65d07510b
 
-        @Assert: Manifest is uploaded and deleted successfully
+        :Assert: Manifest is uploaded and deleted successfully
         """
         with Session(self.browser) as session:
             session.nav.go_to_red_hat_subscriptions()

--- a/tests/foreman/ui/test_sync.py
+++ b/tests/foreman/ui/test_sync.py
@@ -1,18 +1,18 @@
 """Test class for Custom Sync UI
 
-@Requirement: Sync
+:Requirement: Sync
 
-@CaseAutomation: Automated
+:CaseAutomation: Automated
 
-@CaseLevel: Acceptance
+:CaseLevel: Acceptance
 
-@CaseComponent: UI
+:CaseComponent: UI
 
-@TestType: Functional
+:TestType: Functional
 
-@CaseImportance: High
+:CaseImportance: High
 
-@Upstream: No
+:Upstream: No
 """
 
 from fauxfactory import gen_string
@@ -63,9 +63,9 @@ class SyncTestCase(UITestCase):
     def test_positive_sync_custom_repo(self):
         """Create Content Custom Sync with minimal input parameters
 
-        @id: 00fb0b04-0293-42c2-92fa-930c75acee89
+        :id: 00fb0b04-0293-42c2-92fa-930c75acee89
 
-        @Assert: Sync procedure is successful
+        :Assert: Sync procedure is successful
         """
         # Creates new product
         product = entities.Product(organization=self.organization).create()
@@ -92,11 +92,11 @@ class SyncTestCase(UITestCase):
     def test_positive_sync_rh_repos(self):
         """Create Content RedHat Sync with two repos.
 
-        @id: e30f6509-0b65-4bcc-a522-b4f3089d3911
+        :id: e30f6509-0b65-4bcc-a522-b4f3089d3911
 
-        @Assert: Sync procedure for RedHat Repos is successful
+        :Assert: Sync procedure for RedHat Repos is successful
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         repos = self.sync.create_repos_tree(RHCT)
         with manifests.clone() as manifest:
@@ -114,28 +114,29 @@ class SyncTestCase(UITestCase):
     def test_positive_sync_disconnected_to_connected_rh_repos(self):
         """Migrating from disconnected to connected satellite.
 
-        @id: 03b3d904-1697-441b-bb12-8b353a556218
+        :id: 03b3d904-1697-441b-bb12-8b353a556218
 
-        @Steps:
-        1. Update the link to an internal http link where the content has been
-           extracted from ISO's.
-        2. Import a valid manifest.
-        3. Enable few RedHat repos and Sync them.
-        4. Now let's revert back the link to CDN's default link which is,
-           'https://cdn.redhat.com'.
-        5. Now Navigate to the 'Sync Page' and resync the repos synced earlier.
+        :Steps:
+            1. Update the link to an internal http link where the content has
+                been extracted from ISO's.
+            2. Import a valid manifest.
+            3. Enable few RedHat repos and Sync them.
+            4. Now let's revert back the link to CDN's default link which is,
+                'https://cdn.redhat.com'.
+            5. Now Navigate to the 'Sync Page' and resync the repos synced
+                earlier.
 
-        @Assert:
-        1. Syncing should work fine without any issues.
-        2. Only the deltas are re-downloaded and not the entire repo.
-           [ Could be an exception when 7Server was earlier pointing to 7.1
-             and current 7Server points to latest 7.2]
-        3. After reverting the link the repos should not be seen in
-           'Others Tab' and should be seen only in 'RPM's Tab'.
+        :Assert:
+            1. Syncing should work fine without any issues.
+            2. Only the deltas are re-downloaded and not the entire repo.  [
+                Could be an exception when 7Server was earlier pointing to 7.1
+                and current 7Server points to latest 7.2]
+            3. After reverting the link the repos should not be seen in 'Others
+                Tab' and should be seen only in 'RPM's Tab'.
 
-        @caseautomation: notautomated
+        :caseautomation: notautomated
 
-        @CaseLevel: System
+        :CaseLevel: System
         """
 
     @run_only_on('sat')
@@ -144,11 +145,11 @@ class SyncTestCase(UITestCase):
     def test_positive_sync_custom_ostree_repo(self):
         """Create custom ostree repository and sync it.
 
-        @id: e4119b9b-0356-4661-a3ec-e5807224f7d2
+        :id: e4119b9b-0356-4661-a3ec-e5807224f7d2
 
-        @Assert: ostree repo should be synced successfully
+        :Assert: ostree repo should be synced successfully
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         prod = entities.Product(organization=self.organization).create()
         repo_name = gen_string('alpha')
@@ -174,15 +175,15 @@ class SyncTestCase(UITestCase):
     def test_positive_sync_rh_ostree_repo(self):
         """Sync CDN based ostree repository .
 
-        @id: 4d28fff0-5fda-4eee-aa0c-c5af02c31de5
+        :id: 4d28fff0-5fda-4eee-aa0c-c5af02c31de5
 
-        @Steps:
-        1. Import a valid manifest
-        2. Enable the OStree repo and sync it
+        :Steps:
+            1. Import a valid manifest
+            2. Enable the OStree repo and sync it
 
-        @Assert: ostree repo should be synced successfully from CDN
+        :Assert: ostree repo should be synced successfully from CDN
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         repos = self.sync.create_repos_tree(ATOMIC_HOST_TREE)
         org = entities.Organization().create()

--- a/tests/foreman/ui/test_syncplan.py
+++ b/tests/foreman/ui/test_syncplan.py
@@ -1,18 +1,18 @@
 """Test class for Sync Plan UI
 
-@Requirement: Syncplan
+:Requirement: Syncplan
 
-@CaseAutomation: Automated
+:CaseAutomation: Automated
 
-@CaseLevel: Acceptance
+:CaseLevel: Acceptance
 
-@CaseComponent: UI
+:CaseComponent: UI
 
-@TestType: Functional
+:TestType: Functional
 
-@CaseImportance: High
+:CaseImportance: High
 
-@Upstream: No
+:Upstream: No
 """
 
 from datetime import datetime, timedelta
@@ -107,7 +107,7 @@ class SyncPlanTestCase(UITestCase):
             on a client
         """
         script = ('var currentdate = new Date(); return ({0} + "-" + {1} + '
-                  '"-" + {2} + " @ " + {3} + ":" + {4});').format(
+                  '"-" + {2} + " : " + {3} + ":" + {4});').format(
             'currentdate.getFullYear()',
             '(currentdate.getMonth()+1)',
             'currentdate.getDate()',
@@ -115,15 +115,15 @@ class SyncPlanTestCase(UITestCase):
             'currentdate.getMinutes()',
         )
         client_datetime = self.browser.execute_script(script)
-        return datetime.strptime(client_datetime, '%Y-%m-%d @ %H:%M')
+        return datetime.strptime(client_datetime, '%Y-%m-%d : %H:%M')
 
     @tier1
     def test_positive_create_with_name(self):
         """Create Sync Plan with valid name values
 
-        @id: ceb125a4-449a-4a86-a94f-2a28884e3a41
+        :id: ceb125a4-449a-4a86-a94f-2a28884e3a41
 
-        @Assert: Sync Plan is created
+        :Assert: Sync Plan is created
         """
         with Session(self.browser) as session:
             for name in generate_strings_list():
@@ -141,9 +141,9 @@ class SyncPlanTestCase(UITestCase):
     def test_positive_create_with_description(self):
         """Create Sync Plan with valid desc values
 
-        @id: 6ccd2229-dcc3-4090-9ec9-84fea837c50c
+        :id: 6ccd2229-dcc3-4090-9ec9-84fea837c50c
 
-        @Assert: Sync Plan is created
+        :Assert: Sync Plan is created
         """
         with Session(self.browser) as session:
             for desc in generate_strings_list():
@@ -162,9 +162,9 @@ class SyncPlanTestCase(UITestCase):
     def test_positive_create_with_sync_interval(self):
         """Create Sync Plan with valid sync intervals
 
-        @id: 8916285a-c8d2-415a-b694-c32727e93ac0
+        :id: 8916285a-c8d2-415a-b694-c32727e93ac0
 
-        @Assert: Sync Plan is created
+        :Assert: Sync Plan is created
         """
         with Session(self.browser) as session:
             for interval in valid_sync_intervals():
@@ -183,11 +183,11 @@ class SyncPlanTestCase(UITestCase):
     def test_positive_create_with_start_time(self):
         """Create Sync plan with specified start time
 
-        @id: a4709229-325c-4027-b4dc-10a226c4d7bf
+        :id: a4709229-325c-4027-b4dc-10a226c4d7bf
 
-        @Assert: Sync Plan is created with the specified time.
+        :Assert: Sync Plan is created with the specified time.
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         plan_name = gen_string('alpha')
         startdate = self.get_client_datetime() + timedelta(minutes=10)
@@ -215,11 +215,11 @@ class SyncPlanTestCase(UITestCase):
     def test_positive_create_with_start_date(self):
         """Create Sync plan with specified start date
 
-        @id: 020b3aff-7216-4ad6-b95e-8ffaf68cba20
+        :id: 020b3aff-7216-4ad6-b95e-8ffaf68cba20
 
-        @Assert: Sync Plan is created with the specified date
+        :Assert: Sync Plan is created with the specified date
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         plan_name = gen_string('alpha')
         startdate = self.get_client_datetime() + timedelta(days=10)
@@ -244,9 +244,9 @@ class SyncPlanTestCase(UITestCase):
     def test_negative_create_with_invalid_name(self):
         """Create Sync Plan with invalid names
 
-        @id: 64724669-0289-4e8a-a44d-eb47e094ef18
+        :id: 64724669-0289-4e8a-a44d-eb47e094ef18
 
-        @Assert: Sync Plan is not created
+        :Assert: Sync Plan is not created
         """
         with Session(self.browser) as session:
             for name in invalid_values_list(interface='ui'):
@@ -264,9 +264,9 @@ class SyncPlanTestCase(UITestCase):
     def test_negative_create_with_same_name(self):
         """Create Sync Plan with an existing name
 
-        @id: 6d042f9b-82f2-4795-aa48-4603c1698aaa
+        :id: 6d042f9b-82f2-4795-aa48-4603c1698aaa
 
-        @Assert: Sync Plan cannot be created with existing name
+        :Assert: Sync Plan cannot be created with existing name
         """
         name = gen_string('alphanumeric')
         with Session(self.browser) as session:
@@ -285,9 +285,9 @@ class SyncPlanTestCase(UITestCase):
     def test_positive_update_name(self):
         """Update Sync plan's name
 
-        @id: 6b22468f-6abc-4a63-b283-28c7816a5e86
+        :id: 6b22468f-6abc-4a63-b283-28c7816a5e86
 
-        @Assert: Sync Plan's name is updated
+        :Assert: Sync Plan's name is updated
         """
         plan_name = gen_string('alpha')
         entities.SyncPlan(
@@ -307,9 +307,9 @@ class SyncPlanTestCase(UITestCase):
     def test_positive_update_interval(self):
         """Update Sync plan's interval
 
-        @id: 35820efd-099e-45dd-8298-77d5f35c26db
+        :id: 35820efd-099e-45dd-8298-77d5f35c26db
 
-        @Assert: Sync Plan's interval is updated
+        :Assert: Sync Plan's interval is updated
         """
         name = gen_string('alpha')
         entities.SyncPlan(
@@ -334,11 +334,11 @@ class SyncPlanTestCase(UITestCase):
     def test_positive_update_product(self):
         """Update Sync plan and associate products
 
-        @id: 19bdb36a-ed2a-4bbb-9d8d-9ad9f6a800a2
+        :id: 19bdb36a-ed2a-4bbb-9d8d-9ad9f6a800a2
 
-        @Assert: Sync Plan has the associated product
+        :Assert: Sync Plan has the associated product
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         strategy, value = locators['sp.prd_select']
         product = entities.Product(organization=self.organization).create()
@@ -363,11 +363,11 @@ class SyncPlanTestCase(UITestCase):
     def test_positive_update_and_disassociate_product(self):
         """Update Sync plan and disassociate products
 
-        @id: 860bd88e-a425-4218-b02c-64402ee8af9d
+        :id: 860bd88e-a425-4218-b02c-64402ee8af9d
 
-        @Assert: Sync Plan does not have the associated product
+        :Assert: Sync Plan does not have the associated product
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         plan_name = gen_string('utf8')
         strategy, value = locators['sp.prd_select']
@@ -399,9 +399,9 @@ class SyncPlanTestCase(UITestCase):
     def test_positive_delete(self):
         """Delete an existing Sync plan
 
-        @id: 81beec05-e38c-48bc-8f01-10cb1e10a3f6
+        :id: 81beec05-e38c-48bc-8f01-10cb1e10a3f6
 
-        @Assert: Sync Plan is deleted successfully
+        :Assert: Sync Plan is deleted successfully
         """
         with Session(self.browser) as session:
             for plan_name in generate_strings_list():
@@ -420,13 +420,13 @@ class SyncPlanTestCase(UITestCase):
     def test_positive_create_ostree_sync_plan(self):
         """Create a sync plan for ostree contents.
 
-        @id: bf01f23f-ba55-4c88-baad-85603fce57a4
+        :id: bf01f23f-ba55-4c88-baad-85603fce57a4
 
-        @Assert: sync plan should be created successfully
+        :Assert: sync plan should be created successfully
 
-        @caseautomation: notautomated
+        :caseautomation: notautomated
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
 
     # This Bugzilla bug is private. It is impossible to fetch info about it.
@@ -436,13 +436,13 @@ class SyncPlanTestCase(UITestCase):
         """Verify product won't get synced immediately after adding association
         with a sync plan which has already been started
 
-        @id: b56fccb9-8f84-4676-a777-b3c6458c909e
+        :id: b56fccb9-8f84-4676-a777-b3c6458c909e
 
-        @Assert: Repository was not synchronized
+        :Assert: Repository was not synchronized
 
-        @BZ: 1279539
+        :BZ: 1279539
 
-        @CaseLevel: System
+        :CaseLevel: System
         """
         plan_name = gen_string('alpha')
         product = entities.Product(organization=self.organization).create()
@@ -474,13 +474,13 @@ class SyncPlanTestCase(UITestCase):
         custom product and verify the product gets synchronized on the next
         sync occurrence
 
-        @id: d65e91c4-a0b6-4588-a3ff-fe9cd3762556
+        :id: d65e91c4-a0b6-4588-a3ff-fe9cd3762556
 
-        @Assert: Product is synchronized successfully.
+        :Assert: Product is synchronized successfully.
 
-        @BZ: 1279539
+        :BZ: 1279539
 
-        @CaseLevel: System
+        :CaseLevel: System
         """
         interval = 60 * 60  # 'hourly' sync interval in seconds
         plan_name = gen_string('alpha')
@@ -522,11 +522,11 @@ class SyncPlanTestCase(UITestCase):
         """Create a sync plan with sync date in a future and sync one custom
         product with it automatically.
 
-        @id: fdd3b2a2-8d8e-4a18-b6a5-363e8dd5f998
+        :id: fdd3b2a2-8d8e-4a18-b6a5-363e8dd5f998
 
-        @Assert: Product is synchronized successfully.
+        :Assert: Product is synchronized successfully.
 
-        @CaseLevel: System
+        :CaseLevel: System
         """
         delay = 10 * 60  # delay for sync date in seconds
         plan_name = gen_string('alpha')
@@ -574,11 +574,11 @@ class SyncPlanTestCase(UITestCase):
         """Create a sync plan with sync date in a future and sync multiple
         custom products with multiple repos automatically.
 
-        @id: 9564e726-59c6-4d24-bb3d-f0ab3c4b26a5
+        :id: 9564e726-59c6-4d24-bb3d-f0ab3c4b26a5
 
-        @Assert: Products are synchronized successfully.
+        :Assert: Products are synchronized successfully.
 
-        @CaseLevel: System
+        :CaseLevel: System
         """
         delay = 10 * 60  # delay for sync date in seconds
         plan_name = gen_string('alpha')
@@ -642,13 +642,13 @@ class SyncPlanTestCase(UITestCase):
         RH product and verify the product gets synchronized on the next sync
         occurrence
 
-        @id: 73a456fb-ad17-4921-b57c-27fc8e432a83
+        :id: 73a456fb-ad17-4921-b57c-27fc8e432a83
 
-        @Assert: Product is synchronized successfully.
+        :Assert: Product is synchronized successfully.
 
-        @BZ: 1279539
+        :BZ: 1279539
 
-        @CaseLevel: System
+        :CaseLevel: System
         """
         interval = 60 * 60  # 'hourly' sync interval in seconds
         plan_name = gen_string('alpha')
@@ -705,11 +705,11 @@ class SyncPlanTestCase(UITestCase):
         """Create a sync plan with sync date in a future and sync one RH
         product with it automatically.
 
-        @id: 193d0159-d4a7-4f50-b037-7289f4576ade
+        :id: 193d0159-d4a7-4f50-b037-7289f4576ade
 
-        @Assert: Product is synchronized successfully.
+        :Assert: Product is synchronized successfully.
 
-        @CaseLevel: System
+        :CaseLevel: System
         """
         delay = 10 * 60  # delay for sync date in seconds
         plan_name = gen_string('alpha')

--- a/tests/foreman/ui/test_system_registration.py
+++ b/tests/foreman/ui/test_system_registration.py
@@ -1,18 +1,18 @@
 """Test module for System Registration UI
 
-@Requirement: System registration
+:Requirement: System registration
 
-@CaseAutomation: Automated
+:CaseAutomation: Automated
 
-@CaseLevel: Acceptance
+:CaseLevel: Acceptance
 
-@CaseComponent: UI
+:CaseComponent: UI
 
-@TestType: Functional
+:TestType: Functional
 
-@CaseImportance: High
+:CaseImportance: High
 
-@Upstream: No
+:Upstream: No
 """
 from robottelo.decorators import stubbed, tier3
 from robottelo.test import UITestCase
@@ -28,13 +28,13 @@ class SystemRegistrationTestCase(UITestCase):
         # puppet modules
         """assure content types can be pushed down to client via UI
 
-        @id: 9427294f-42f7-4f7b-bdcc-88d0fc22b893
+        :id: 9427294f-42f7-4f7b-bdcc-88d0fc22b893
 
-        @assert: content is installed on client system
+        :assert: content is installed on client system
 
-        @caseautomation: notautomated
+        :caseautomation: notautomated
 
-        @CaseLevel: System
+        :CaseLevel: System
         """
 
     @stubbed()
@@ -42,13 +42,13 @@ class SystemRegistrationTestCase(UITestCase):
     def test_positive_list_system_for_org(self):
         """perform a system list for a given org
 
-        @id: 795605d6-01c2-4db1-8ca2-a966545c0db1
+        :id: 795605d6-01c2-4db1-8ca2-a966545c0db1
 
-        @assert: newly registered system can be found in Systems UI
+        :assert: newly registered system can be found in Systems UI
 
-        @caseautomation: notautomated
+        :caseautomation: notautomated
 
-        @CaseLevel: System
+        :CaseLevel: System
         """
 
     @stubbed()
@@ -56,13 +56,13 @@ class SystemRegistrationTestCase(UITestCase):
     def test_positive_deregister_system(self):
         """delete system via Systems UI
 
-        @id: ce1844c5-a853-49e2-8eaf-dbac24d6afde
+        :id: ce1844c5-a853-49e2-8eaf-dbac24d6afde
 
-        @assert: after deleting, system no longer appears in system UI.
+        :assert: after deleting, system no longer appears in system UI.
 
-        @caseautomation: notautomated
+        :caseautomation: notautomated
 
-        @CaseLevel: System
+        :CaseLevel: System
         """
 
     @stubbed()
@@ -70,13 +70,13 @@ class SystemRegistrationTestCase(UITestCase):
     def test_positive_compliance_green(self):
         """system with appropriate entitlements for subscriptions
 
-        @id: 42adeb01-765d-4ee8-a326-4b799c1e91ab
+        :id: 42adeb01-765d-4ee8-a326-4b799c1e91ab
 
-        @assert: compliance status is green in UI
+        :assert: compliance status is green in UI
 
-        @caseautomation: notautomated
+        :caseautomation: notautomated
 
-        @CaseLevel: System
+        :CaseLevel: System
         """
 
     @stubbed()
@@ -84,13 +84,13 @@ class SystemRegistrationTestCase(UITestCase):
     def test_positive_compliance_red(self):
         """system without appropriate entitlements for subscriptions
 
-        @id: dce486cc-66fc-4959-8cce-e9dbb86eff26
+        :id: dce486cc-66fc-4959-8cce-e9dbb86eff26
 
-        @assert: compliance status is red in UI
+        :assert: compliance status is red in UI
 
-        @caseautomation: notautomated
+        :caseautomation: notautomated
 
-        @CaseLevel: System
+        :CaseLevel: System
         """
 
     @stubbed()
@@ -99,11 +99,11 @@ class SystemRegistrationTestCase(UITestCase):
         """system with some, but not all, appropriate entitlements for
         subscriptions
 
-        @id: 788d0da4-f498-4ad2-9a2c-6897d2e699e4
+        :id: 788d0da4-f498-4ad2-9a2c-6897d2e699e4
 
-        @assert: compliance status is yellow in UI
+        :assert: compliance status is yellow in UI
 
-        @caseautomation: notautomated
+        :caseautomation: notautomated
 
-        @CaseLevel: System
+        :CaseLevel: System
         """

--- a/tests/foreman/ui/test_template.py
+++ b/tests/foreman/ui/test_template.py
@@ -1,19 +1,19 @@
 # -*- encoding: utf-8 -*-
 """Test class for Template UI
 
-@Requirement: Template
+:Requirement: Template
 
-@CaseAutomation: Automated
+:CaseAutomation: Automated
 
-@CaseLevel: Acceptance
+:CaseLevel: Acceptance
 
-@CaseComponent: UI
+:CaseComponent: UI
 
-@TestType: Functional
+:TestType: Functional
 
-@CaseImportance: High
+:CaseImportance: High
 
-@Upstream: No
+:Upstream: No
 """
 from fauxfactory import gen_string
 from nailgun import entities
@@ -44,10 +44,10 @@ class TemplateTestCase(UITestCase):
     def test_positive_create_with_name(self):
         """Create new template using different valid names
 
-        @id: 12767d13-2531-4a3c-9527-3191bc9a1149
+        :id: 12767d13-2531-4a3c-9527-3191bc9a1149
 
-        @Assert: New template of type 'Provisioning template' should be created
-        successfully
+        :Assert: New template of type 'Provisioning template' should be created
+            successfully
         """
         with Session(self.browser) as session:
             for name in generate_strings_list():
@@ -66,9 +66,9 @@ class TemplateTestCase(UITestCase):
     def test_negative_create_with_invalid_name(self):
         """Create a new template with invalid names
 
-        @id: cfbc8e10-96b3-425c-ac21-f995a8b038e8
+        :id: cfbc8e10-96b3-425c-ac21-f995a8b038e8
 
-        @Assert: Template is not created
+        :Assert: Template is not created
         """
         with Session(self.browser) as session:
             for name in invalid_values_list(interface='ui'):
@@ -88,9 +88,9 @@ class TemplateTestCase(UITestCase):
     def test_negative_create_with_same_name(self):
         """Template - Create a new template with same name
 
-        @id: 52382553-2708-47d0-97b2-fce6ddb366ad
+        :id: 52382553-2708-47d0-97b2-fce6ddb366ad
 
-        @Assert: Template is not created
+        :Assert: Template is not created
         """
         name = gen_string('alpha')
         with Session(self.browser) as session:
@@ -117,9 +117,9 @@ class TemplateTestCase(UITestCase):
     def test_negative_create_without_type(self):
         """Template - Create a new template without selecting its type
 
-        @id: 370af6a5-0814-4474-b758-46ec25ccbc4a
+        :id: 370af6a5-0814-4474-b758-46ec25ccbc4a
 
-        @Assert: Template is not created
+        :Assert: Template is not created
         """
         name = gen_string('alpha')
         with Session(self.browser) as session:
@@ -141,9 +141,9 @@ class TemplateTestCase(UITestCase):
     def test_negative_create_without_upload(self):
         """Template - Create a new template without uploading a template
 
-        @id: dd4bb3cb-a7a0-46fa-bc16-e2d117ce79d8
+        :id: dd4bb3cb-a7a0-46fa-bc16-e2d117ce79d8
 
-        @Assert: Template is not created
+        :Assert: Template is not created
         """
         name = gen_string('alpha')
         with Session(self.browser) as session:
@@ -165,9 +165,9 @@ class TemplateTestCase(UITestCase):
     def test_negative_create_with_too_long_audit(self):
         """Create a new template with 256 characters in audit comments
 
-        @id: 62b06765-f9d5-4e69-967f-76f2649f83ff
+        :id: 62b06765-f9d5-4e69-967f-76f2649f83ff
 
-        @Assert: Template is not created
+        :Assert: Template is not created
         """
         with Session(self.browser) as session:
             make_templates(
@@ -186,10 +186,10 @@ class TemplateTestCase(UITestCase):
     def test_positive_create_with_snippet_type(self):
         """Create new template of type snippet
 
-        @id: 56f62153-6dd2-4120-9f23-386442f643c4
+        :id: 56f62153-6dd2-4120-9f23-386442f643c4
 
-        @Assert: New provisioning template of type 'snippet' should be created
-        successfully
+        :Assert: New provisioning template of type 'snippet' should be created
+            successfully
         """
         with Session(self.browser) as session:
             for name in generate_strings_list():
@@ -208,9 +208,9 @@ class TemplateTestCase(UITestCase):
     def test_positive_delete(self):
         """Delete an existing template
 
-        @id: e4a687e5-6581-4481-ad9b-8d2ac3f2c9d5
+        :id: e4a687e5-6581-4481-ad9b-8d2ac3f2c9d5
 
-        @Assert: Template is deleted successfully
+        :Assert: Template is deleted successfully
         """
         with Session(self.browser) as session:
             session.nav.go_to_select_org(self.organization.name)
@@ -227,9 +227,9 @@ class TemplateTestCase(UITestCase):
     def test_positive_update_name_and_type(self):
         """Update template name and template type
 
-        @id: f1a7d44d-5ac8-47e1-9084-ce8f166dbde5
+        :id: f1a7d44d-5ac8-47e1-9084-ce8f166dbde5
 
-        @Assert: The template name and type should be updated successfully
+        :Assert: The template name and type should be updated successfully
         """
         name = gen_string('alpha')
         new_name = gen_string('alpha')
@@ -252,10 +252,10 @@ class TemplateTestCase(UITestCase):
         """Creates new template, along with two OS's and associate list
         of OS's with created template
 
-        @id: 160d7906-dd60-4870-8ca0-dde61ccab67c
+        :id: 160d7906-dd60-4870-8ca0-dde61ccab67c
 
-        @Assert: The template should be updated with newly created OS's
-        successfully
+        :Assert: The template should be updated with newly created OS's
+            successfully
         """
         name = gen_string('alpha')
         new_name = gen_string('alpha')
@@ -279,15 +279,15 @@ class TemplateTestCase(UITestCase):
     def test_positive_clone(self):
         """Assure ability to clone a provisioning template
 
-        @id: 912f1619-4bb0-4e0f-88ce-88b5726fdbe0
+        :id: 912f1619-4bb0-4e0f-88ce-88b5726fdbe0
 
-        @Steps:
-         1.  Go to Provisioning template UI
-         2.  Choose a template and attempt to clone it
+        :Steps:
+            1.  Go to Provisioning template UI
+            2.  Choose a template and attempt to clone it
 
-        @Assert: The template is cloned
+        :Assert: The template is cloned
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         name = gen_string('alpha')
         clone_name = gen_string('alpha')
@@ -318,11 +318,11 @@ class TemplateTestCase(UITestCase):
         organization and location. Also associate it with new hostgroup.
         Afterwards search for that template by hostgroup
 
-        @id: 5bcecd40-28af-4913-92a4-863c8dc05ecc
+        :id: 5bcecd40-28af-4913-92a4-863c8dc05ecc
 
-        @BZ: 1386334
+        :BZ: 1386334
 
-        @Assert: Template can be found successfully and no error is raised
+        :Assert: Template can be found successfully and no error is raised
         """
         org = entities.Organization().create()
         loc = entities.Location().create()

--- a/tests/foreman/ui/test_trend.py
+++ b/tests/foreman/ui/test_trend.py
@@ -1,19 +1,19 @@
 # -*- encoding: utf-8 -*-
 """Test class for Trend UI
 
-@Requirement: Trend
+:Requirement: Trend
 
-@CaseAutomation: Automated
+:CaseAutomation: Automated
 
-@CaseLevel: Acceptance
+:CaseLevel: Acceptance
 
-@CaseComponent: UI
+:CaseComponent: UI
 
-@TestType: Functional
+:TestType: Functional
 
-@CaseImportance: High
+:CaseImportance: High
 
-@Upstream: No
+:Upstream: No
 """
 
 from fauxfactory import gen_string
@@ -39,9 +39,9 @@ class TrendTest(UITestCase):
     def test_positive_create(self):
         """Create new trend
 
-        @id: d0c040cf-8132-43cd-9569-26148b80a44b
+        :id: d0c040cf-8132-43cd-9569-26148b80a44b
 
-        @Assert: Trend is created successfully
+        :Assert: Trend is created successfully
         """
         with Session(self.browser) as session:
             make_trend(session, trend_type=TREND_TYPES['model'])
@@ -52,9 +52,9 @@ class TrendTest(UITestCase):
     def test_positive_update(self):
         """Update trend entity value
 
-        @id: 329af7a7-e7c1-4c09-9849-d9ec12ddcee9
+        :id: 329af7a7-e7c1-4c09-9849-d9ec12ddcee9
 
-        @Assert: Trend entity is updated successfully
+        :Assert: Trend entity is updated successfully
         """
         name = gen_string('alphanumeric')
         new_name = gen_string('alphanumeric')
@@ -76,9 +76,9 @@ class TrendTest(UITestCase):
     def test_positive_delete(self):
         """Delete existing trend
 
-        @id: 0b5376f0-c8ae-434a-a5da-10b16ac3b932
+        :id: 0b5376f0-c8ae-434a-a5da-10b16ac3b932
 
-        @Assert: Trend is deleted
+        :Assert: Trend is deleted
         """
         with Session(self.browser) as session:
             make_trend(session, trend_type=TREND_TYPES['environment'])

--- a/tests/foreman/ui/test_user.py
+++ b/tests/foreman/ui/test_user.py
@@ -1,19 +1,19 @@
 # -*- encoding: utf-8 -*-
 """Test class for Users UI
 
-@Requirement: User
+:Requirement: User
 
-@CaseAutomation: Automated
+:CaseAutomation: Automated
 
-@CaseLevel: Acceptance
+:CaseLevel: Acceptance
 
-@CaseComponent: UI
+:CaseComponent: UI
 
-@TestType: Functional
+:TestType: Functional
 
-@CaseImportance: High
+:CaseImportance: High
 
-@Upstream: No
+:Upstream: No
 """
 
 import random
@@ -85,9 +85,9 @@ class UserTestCase(UITestCase):
     def test_positive_create_with_username(self):
         """Create User for all variations of Username
 
-        @id: 2acc8c7d-cb14-4eda-98f9-fb379950f2f5
+        :id: 2acc8c7d-cb14-4eda-98f9-fb379950f2f5
 
-        @Assert: User is created successfully
+        :Assert: User is created successfully
         """
         with Session(self.browser) as session:
             for user_name in valid_strings():
@@ -99,9 +99,9 @@ class UserTestCase(UITestCase):
     def test_positive_create_with_first_name(self):
         """Create User for all variations of First Name
 
-        @id: dd398cd6-821e-4b0e-a111-22d5a6eeafd8
+        :id: dd398cd6-821e-4b0e-a111-22d5a6eeafd8
 
-        @Assert: User is created successfully
+        :Assert: User is created successfully
         """
         with Session(self.browser) as session:
             for first_name in valid_strings():
@@ -114,9 +114,9 @@ class UserTestCase(UITestCase):
     def test_positive_create_with_surname(self):
         """Create User for all variations of Surname
 
-        @id: 0a2dc093-0cd1-41eb-99cd-79935c74563f
+        :id: 0a2dc093-0cd1-41eb-99cd-79935c74563f
 
-        @Assert: User is created successfully
+        :Assert: User is created successfully
         """
         with Session(self.browser) as session:
             for last_name in valid_strings(50):
@@ -129,9 +129,9 @@ class UserTestCase(UITestCase):
     def test_positive_create_with_email(self):
         """Create User for all variations of Email Address
 
-        @id: 1c6c0f50-401c-4b7d-9795-97a1be3806f8
+        :id: 1c6c0f50-401c-4b7d-9795-97a1be3806f8
 
-        @Assert: User is created successfully
+        :Assert: User is created successfully
         """
         with Session(self.browser) as session:
             for email in valid_emails_list():
@@ -144,9 +144,9 @@ class UserTestCase(UITestCase):
     def test_positive_create_with_language(self):
         """Create User for all variations of Language
 
-        @id: 1c5581a8-79ae-40a6-8052-f47be2d4c5eb
+        :id: 1c5581a8-79ae-40a6-8052-f47be2d4c5eb
 
-        @Assert: User is created successfully
+        :Assert: User is created successfully
         """
         with Session(self.browser) as session:
             for language in LANGUAGES:
@@ -159,9 +159,9 @@ class UserTestCase(UITestCase):
     def test_positive_create_with_password(self):
         """Create User for all variations of Password
 
-        @id: 83d6efe0-7526-465c-9c97-5673c7736fc4
+        :id: 83d6efe0-7526-465c-9c97-5673c7736fc4
 
-        @Assert: User is created successfully
+        :Assert: User is created successfully
         """
         test_data = valid_strings()
         extra_passwords = (
@@ -185,9 +185,9 @@ class UserTestCase(UITestCase):
     def test_positive_create_admin(self):
         """Create an Admin user
 
-        @id: 9bf56045-1026-435c-bf4c-623e160582d5
+        :id: 9bf56045-1026-435c-bf4c-623e160582d5
 
-        @Assert: Admin User is created successfully
+        :Assert: Admin User is created successfully
         """
         user_name = gen_string('alpha')
         with Session(self.browser) as session:
@@ -198,9 +198,9 @@ class UserTestCase(UITestCase):
     def test_positive_create_with_one_role(self):
         """Create User with one role
 
-        @id: 6d6c795e-8b46-4f0f-84e1-f7e22add6173
+        :id: 6d6c795e-8b46-4f0f-84e1-f7e22add6173
 
-        @Assert: User is created successfully
+        :Assert: User is created successfully
         """
         name = gen_string('alpha')
         role = entities.Role().create()
@@ -216,11 +216,11 @@ class UserTestCase(UITestCase):
     def test_positive_create_with_multiple_roles(self):
         """Create User with multiple roles
 
-        @id: d3cc4434-25ca-4465-8878-42495390c17b
+        :id: d3cc4434-25ca-4465-8878-42495390c17b
 
-        @Assert: User is created successfully
+        :Assert: User is created successfully
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         name = gen_string('alpha')
         role1 = gen_string('alpha')
@@ -241,11 +241,11 @@ class UserTestCase(UITestCase):
     def test_positive_create_with_all_roles(self):
         """Create User and assign all available roles to it
 
-        @id: 814593ca-1566-45ea-9eff-e880183b1ee3
+        :id: 814593ca-1566-45ea-9eff-e880183b1ee3
 
-        @Assert: User is created successfully
+        :Assert: User is created successfully
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         name = gen_string('alpha')
         with Session(self.browser) as session:
@@ -260,9 +260,9 @@ class UserTestCase(UITestCase):
     def test_positive_create_with_one_org(self):
         """Create User associated to one Org
 
-        @id: 830bc5fc-e773-466c-9b38-4f33a2c1d05e
+        :id: 830bc5fc-e773-466c-9b38-4f33a2c1d05e
 
-        @Assert: User is created successfully
+        :Assert: User is created successfully
         """
         name = gen_string('alpha')
         org_name = gen_string('alpha')
@@ -280,11 +280,11 @@ class UserTestCase(UITestCase):
     def test_positive_create_with_multiple_orgs(self):
         """Create User associated to multiple Orgs
 
-        @id: d74c0284-3995-4a4a-8746-00858282bf5d
+        :id: d74c0284-3995-4a4a-8746-00858282bf5d
 
-        @Assert: User is created successfully
+        :Assert: User is created successfully
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         name = gen_string('alpha')
         org_name1 = gen_string('alpha')
@@ -310,9 +310,9 @@ class UserTestCase(UITestCase):
     def test_positive_create_with_default_org(self):
         """Create User and has default organization associated with it
 
-        @id: 3d51dead-9053-427d-8292-c42e87ed6289
+        :id: 3d51dead-9053-427d-8292-c42e87ed6289
 
-        @Assert: User is created with default Org selected.
+        :Assert: User is created with default Org selected.
         """
         name = gen_string('alpha')
         org_name = gen_string('alpha')
@@ -333,9 +333,9 @@ class UserTestCase(UITestCase):
     def test_positive_create_with_default_location(self):
         """Create User and associate a default Location.
 
-        @id: 952a0be5-d393-49a2-8fd9-f6dfcc31f762
+        :id: 952a0be5-d393-49a2-8fd9-f6dfcc31f762
 
-        @Assert: User is created with default Location selected.
+        :Assert: User is created with default Location selected.
         """
         name = gen_string('alpha')
         loc_name = gen_string('alpha')
@@ -356,9 +356,9 @@ class UserTestCase(UITestCase):
     def test_negative_create(self):
         """Enter all User creation details and Cancel
 
-        @id: 2774be2f-303e-498f-8072-80462f33c52e
+        :id: 2774be2f-303e-498f-8072-80462f33c52e
 
-        @Assert: User is not created
+        :Assert: User is not created
         """
         user_name = gen_string('alpha')
         with Session(self.browser) as session:
@@ -376,9 +376,9 @@ class UserTestCase(UITestCase):
     def test_negative_create_with_invalid_name(self):
         """Create User with invalid User Name
 
-        @id: 31bbe350-0275-4aaf-99ec-3f77bfd4ba00
+        :id: 31bbe350-0275-4aaf-99ec-3f77bfd4ba00
 
-        @Assert: User is not created. Appropriate error shown.
+        :Assert: User is not created. Appropriate error shown.
         """
         with Session(self.browser) as session:
             for user_name in invalid_values_list(interface='ui'):
@@ -391,9 +391,9 @@ class UserTestCase(UITestCase):
     def test_negative_create_with_invalid_firstname(self):
         """Create User with invalid FirstName
 
-        @id: 21525bf2-4de9-43f0-8c92-b2fad1fdc944
+        :id: 21525bf2-4de9-43f0-8c92-b2fad1fdc944
 
-        @Assert: User is not created. Appropriate error shown.
+        :Assert: User is not created. Appropriate error shown.
         """
         with Session(self.browser) as session:
             # invalid_values_list is not used here because first name is an
@@ -412,9 +412,9 @@ class UserTestCase(UITestCase):
     def test_negative_create_with_invalid_surname(self):
         """Create User with invalid Surname
 
-        @id: 47d9e8be-3b29-4a56-85d7-898145b5b034
+        :id: 47d9e8be-3b29-4a56-85d7-898145b5b034
 
-        @Assert: User is not created. Appropriate error shown.
+        :Assert: User is not created. Appropriate error shown.
         """
         with Session(self.browser) as session:
             # invalid_values_list is not used here because sur name is an
@@ -433,9 +433,9 @@ class UserTestCase(UITestCase):
     def test_negative_create_with_invalid_emails(self):
         """Create User with invalid Email Address
 
-        @id: 36511b82-e070-41ea-81fa-6e29faa9da1c
+        :id: 36511b82-e070-41ea-81fa-6e29faa9da1c
 
-        @Assert: User is not created. Appropriate error shown.
+        :Assert: User is not created. Appropriate error shown.
         """
         with Session(self.browser) as session:
             for email in invalid_emails_list():
@@ -449,9 +449,9 @@ class UserTestCase(UITestCase):
     def test_negative_create_with_blank_auth(self):
         """Create User with blank value for 'Authorized by' field
 
-        @id: 68f670ed-ac6e-4052-889c-6671d659e510
+        :id: 68f670ed-ac6e-4052-889c-6671d659e510
 
-        @Assert: User is not created. Appropriate error shown.
+        :Assert: User is not created. Appropriate error shown.
         """
         with Session(self.browser) as session:
             make_user(session, username=gen_string('alpha'), authorized_by='')
@@ -462,9 +462,9 @@ class UserTestCase(UITestCase):
     def test_negative_create_with_wrong_pass_confirmation(self):
         """Create User with non-matching values in Password and verify
 
-        @id: f818e5fc-b378-4bc7-afa8-18b23ee05053
+        :id: f818e5fc-b378-4bc7-afa8-18b23ee05053
 
-        @Assert: User is not created. Appropriate error shown.
+        :Assert: User is not created. Appropriate error shown.
         """
         with Session(self.browser) as session:
             make_user(
@@ -480,9 +480,9 @@ class UserTestCase(UITestCase):
     def test_positive_update_username(self):
         """Update Username in User
 
-        @id: 4ecb2816-9bef-4089-86a0-02d7d065cdb1
+        :id: 4ecb2816-9bef-4089-86a0-02d7d065cdb1
 
-        @Assert: User is updated successfully
+        :Assert: User is updated successfully
         """
         name = gen_string('alpha')
         password = gen_string('alpha')
@@ -511,9 +511,9 @@ class UserTestCase(UITestCase):
     def test_positive_update_firstname(self):
         """Update first name in User
 
-        @id: 03ef8a7f-2bf1-4314-b0cd-a7a6acfc17ea
+        :id: 03ef8a7f-2bf1-4314-b0cd-a7a6acfc17ea
 
-        @Assert: User is updated successful
+        :Assert: User is updated successful
         """
         first_name = gen_string('alpha')
         new_first_name = gen_string('alpha')
@@ -527,9 +527,9 @@ class UserTestCase(UITestCase):
     def test_positive_update_surname(self):
         """Update surname in User
 
-        @id: 0326d221-28b0-4a6b-934e-b67ee6c9f696
+        :id: 0326d221-28b0-4a6b-934e-b67ee6c9f696
 
-        @Assert: User is updated successful
+        :Assert: User is updated successful
         """
         last_name = gen_string('alpha')
         new_last_name = gen_string('alpha')
@@ -543,9 +543,9 @@ class UserTestCase(UITestCase):
     def test_positive_update_email(self):
         """Update Email Address in User
 
-        @id: e48314b7-2a49-48ec-896d-af7bf427b1c4
+        :id: e48314b7-2a49-48ec-896d-af7bf427b1c4
 
-        @Assert: User is updated successfully
+        :Assert: User is updated successfully
         """
         email = u'{0}@example.com'.format(gen_string('alpha'))
         new_email = u'{0}@myexample.com'.format(gen_string('alpha'))
@@ -559,9 +559,9 @@ class UserTestCase(UITestCase):
     def test_positive_update_language(self):
         """Update Language in User
 
-        @id: 64b6a90e-0d4c-4a55-a4bd-7347010e39f2
+        :id: 64b6a90e-0d4c-4a55-a4bd-7347010e39f2
 
-        @Assert: User is updated successfully
+        :Assert: User is updated successfully
         """
         locale = random.choice(list(LANGUAGES.keys()))
         username = gen_string('alpha')
@@ -574,9 +574,9 @@ class UserTestCase(UITestCase):
     def test_positive_update_password(self):
         """Update password for a user
 
-        @id: db57c3bc-4fae-4ee7-bf6d-8e0bcc7fd55c
+        :id: db57c3bc-4fae-4ee7-bf6d-8e0bcc7fd55c
 
-        @Assert: User password is updated successfully
+        :Assert: User password is updated successfully
 
         """
         user_name = gen_string('alpha')
@@ -597,9 +597,9 @@ class UserTestCase(UITestCase):
     def test_positive_update_to_non_admin(self):
         """Convert an user from an admin user to non-admin user
 
-        @id: b41cbcf8-d819-4daa-b217-a4812541dca3
+        :id: b41cbcf8-d819-4daa-b217-a4812541dca3
 
-        @Assert: User is updated and has proper admin role value
+        :Assert: User is updated and has proper admin role value
         """
         user_name = gen_string('alpha')
         with Session(self.browser) as session:
@@ -612,9 +612,9 @@ class UserTestCase(UITestCase):
     def test_positive_update_to_admin(self):
         """Convert a user to an admin user
 
-        @id: d3cdda62-1384-4b49-97a3-0c66764583bb
+        :id: d3cdda62-1384-4b49-97a3-0c66764583bb
 
-        @Assert: User is updated and has proper admin role value
+        :Assert: User is updated and has proper admin role value
         """
         user_name = gen_string('alpha')
         with Session(self.browser) as session:
@@ -626,9 +626,9 @@ class UserTestCase(UITestCase):
     def test_positive_update_role(self):
         """Update role for a user
 
-        @id: 2a13529c-3863-403b-a319-9569ca1287cb
+        :id: 2a13529c-3863-403b-a319-9569ca1287cb
 
-        @Assert: User role is updated
+        :Assert: User role is updated
         """
         strategy, value = common_locators['entity_deselect']
         name = gen_string('alpha')
@@ -649,11 +649,11 @@ class UserTestCase(UITestCase):
     def test_positive_update_with_multiple_roles(self):
         """Update User with multiple roles
 
-        @id: 127fb368-09fd-4f10-8319-566a1bcb5cd2
+        :id: 127fb368-09fd-4f10-8319-566a1bcb5cd2
 
-        @Assert: User is updated successfully
+        :Assert: User is updated successfully
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         name = gen_string('alpha')
         role_names = [
@@ -675,11 +675,11 @@ class UserTestCase(UITestCase):
     def test_positive_update_with_all_roles(self):
         """Update User with all roles
 
-        @id: cd7a9cfb-a700-45f2-a11d-bba6be3c810d
+        :id: cd7a9cfb-a700-45f2-a11d-bba6be3c810d
 
-        @Assert: User is updated successfully
+        :Assert: User is updated successfully
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         name = gen_string('alpha')
         with Session(self.browser) as session:
@@ -697,9 +697,9 @@ class UserTestCase(UITestCase):
     def test_positive_update_org(self):
         """Assign a User to an Org
 
-        @id: d891e54b-76bf-4537-8eb9-c3f8832e4c2c
+        :id: d891e54b-76bf-4537-8eb9-c3f8832e4c2c
 
-        @Assert: User is updated successfully
+        :Assert: User is updated successfully
         """
         name = gen_string('alpha')
         org_name = gen_string('alpha')
@@ -717,11 +717,11 @@ class UserTestCase(UITestCase):
     def test_positive_update_orgs(self):
         """Assign a User to multiple Orgs
 
-        @id: a207188d-1ad1-4ff1-9906-bae1d91104fd
+        :id: a207188d-1ad1-4ff1-9906-bae1d91104fd
 
-        @Assert: User is updated
+        :Assert: User is updated
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         name = gen_string('alpha')
         org_names = [
@@ -743,9 +743,9 @@ class UserTestCase(UITestCase):
     def test_negative_update_username(self):
         """Update invalid Username in an User
 
-        @id: 7019461e-13c6-4761-b3e9-4df81abcd0f9
+        :id: 7019461e-13c6-4761-b3e9-4df81abcd0f9
 
-        @Assert: User is not updated. Appropriate error shown.
+        :Assert: User is not updated. Appropriate error shown.
         """
         name = gen_string('alpha')
         with Session(self.browser) as session:
@@ -760,9 +760,9 @@ class UserTestCase(UITestCase):
     def test_negative_update_firstname(self):
         """Update invalid Firstname in an User
 
-        @id: 1e3945d1-5b47-45ca-aff9-3ddd44688e6b
+        :id: 1e3945d1-5b47-45ca-aff9-3ddd44688e6b
 
-        @Assert: User is not updated. Appropriate error shown.
+        :Assert: User is not updated. Appropriate error shown.
         """
         name = gen_string('alpha')
         with Session(self.browser) as session:
@@ -777,9 +777,9 @@ class UserTestCase(UITestCase):
     def test_negative_update_surname(self):
         """Update invalid Surname in an User
 
-        @id: 14033c1f-4c7e-4ee5-8ffc-76c4dd672cc1
+        :id: 14033c1f-4c7e-4ee5-8ffc-76c4dd672cc1
 
-        @Assert: User is not updated. Appropriate error shown.
+        :Assert: User is not updated. Appropriate error shown.
         """
         name = gen_string('alpha')
         with Session(self.browser) as session:
@@ -794,9 +794,9 @@ class UserTestCase(UITestCase):
     def test_negative_update_email(self):
         """Update invalid Email Address in an User
 
-        @id: 6aec3816-16ca-487a-b0f1-a5c1fbc3e0a3
+        :id: 6aec3816-16ca-487a-b0f1-a5c1fbc3e0a3
 
-        @Assert: User is not updated. Appropriate error shown.
+        :Assert: User is not updated. Appropriate error shown.
         """
         name = gen_string('alpha')
         with Session(self.browser) as session:
@@ -811,14 +811,14 @@ class UserTestCase(UITestCase):
     def test_negative_update_password(self):
         """Update different values in Password and verify fields
 
-        @id: ab4a5dbf-70c2-4adc-b948-bc350329e166
+        :id: ab4a5dbf-70c2-4adc-b948-bc350329e166
 
-        @Steps:
-        1. Create User
-        2. Update the password by entering different values in Password and
-        verify fields
+        :Steps:
+            1. Create User
+            2. Update the password by entering different values in Password and
+                verify fields
 
-        @Assert: User is not updated.  Appropriate error shown.
+        :Assert: User is not updated.  Appropriate error shown.
         """
         name = gen_string('alpha')
         with Session(self.browser) as session:
@@ -835,13 +835,13 @@ class UserTestCase(UITestCase):
     def test_negative_update_password_empty_confirmation(self):
         """Update user password without providing confirmation value
 
-        @id: c2b569c9-8120-4125-8bfe-61324a881395
+        :id: c2b569c9-8120-4125-8bfe-61324a881395
 
-        @Steps:
-        1. Create User
-        2. Update the password by entering value only in Password field
+        :Steps:
+            1. Create User
+            2. Update the password by entering value only in Password field
 
-        @Assert: User is not updated.  Appropriate error shown.
+        :Assert: User is not updated.  Appropriate error shown.
         """
         name = gen_string('alpha')
         with Session(self.browser) as session:
@@ -858,9 +858,9 @@ class UserTestCase(UITestCase):
     def test_negative_update(self):
         """[UI ONLY] Attempt to update User info and Cancel
 
-        @id: 56c8ea13-4add-4a51-8428-9d9f9ddde33e
+        :id: 56c8ea13-4add-4a51-8428-9d9f9ddde33e
 
-        @Assert: User is not updated.
+        :Assert: User is not updated.
         """
         new_first_name = gen_string('alpha')
         new_last_name = gen_string('alpha')
@@ -882,9 +882,9 @@ class UserTestCase(UITestCase):
     def test_positive_delete_user(self):
         """Delete an existing User
 
-        @id: 49534eda-f8ea-404e-9714-a8d0d2210979
+        :id: 49534eda-f8ea-404e-9714-a8d0d2210979
 
-        @Assert: User is deleted successfully
+        :Assert: User is deleted successfully
         """
         with Session(self.browser) as session:
             for user_name in valid_strings():
@@ -896,9 +896,9 @@ class UserTestCase(UITestCase):
     def test_positive_delete_admin(self):
         """Delete an admin user
 
-        @id: afda171a-b464-461f-93ce-96d770935200
+        :id: afda171a-b464-461f-93ce-96d770935200
 
-        @Assert: User is deleted
+        :Assert: User is deleted
         """
         user_name = gen_string('alpha')
         with Session(self.browser) as session:
@@ -910,9 +910,9 @@ class UserTestCase(UITestCase):
     def test_negative_delete_user(self):
         """[UI ONLY] Attempt to delete an User and cancel
 
-        @id: 43aed0c0-a3c3-4044-addc-910dc29e4f37
+        :id: 43aed0c0-a3c3-4044-addc-910dc29e4f37
 
-        @Assert: User is not deleted
+        :Assert: User is not deleted
         """
         user_name = gen_string('alpha')
         with Session(self.browser) as session:
@@ -925,22 +925,22 @@ class UserTestCase(UITestCase):
     def test_positive_end_to_end(self):
         """Create User and perform different operations
 
-        @id: 57f7054e-2865-4ab8-bc2b-e300a8dacee5
+        :id: 57f7054e-2865-4ab8-bc2b-e300a8dacee5
 
-        @Steps:
-        1. Create User
-        2. Login with the new user
-        3. Upload Subscriptions
-        4. Provision Systems
-        5. Add/Remove Users
-        6. Add/Remove Orgs
-        7. Delete the User
+        :Steps:
+            1. Create User
+            2. Login with the new user
+            3. Upload Subscriptions
+            4. Provision Systems
+            5. Add/Remove Users
+            6. Add/Remove Orgs
+            7. Delete the User
 
-        @Assert: All actions passed
+        :Assert: All actions passed
 
-        @caseautomation: notautomated
+        :caseautomation: notautomated
 
-        @CaseLevel: System
+        :CaseLevel: System
         """
 
     @stubbed()
@@ -949,37 +949,37 @@ class UserTestCase(UITestCase):
         """Create User with no Org assigned and attempt different
         operations
 
-        @id: 36b6d667-59cc-4442-aa40-c029bdb2b534
+        :id: 36b6d667-59cc-4442-aa40-c029bdb2b534
 
-        @Steps:
-        1. Create User.  Do not assign any Org
-        2. Login with the new user
-        3. Attempt to Upload Subscriptions
-        4. Attempt to Provision Systems
-        5. Attempt to Add/Remove Users
-        6. Attempt to Add/Remove Orgs
+        :Steps:
+            1. Create User.  Do not assign any Org
+            2. Login with the new user
+            3. Attempt to Upload Subscriptions
+            4. Attempt to Provision Systems
+            5. Attempt to Add/Remove Users
+            6. Attempt to Add/Remove Orgs
 
-        @Assert: All actions failed since the User is not assigned to any Org
+        :Assert: All actions failed since the User is not assigned to any Org
 
-        @caseautomation: notautomated
+        :caseautomation: notautomated
 
-        @CaseLevel: System
+        :CaseLevel: System
         """
 
     @tier1
     def test_positive_set_timezone(self):
         """Set a new timezone for the user
 
-        @id: 3219c245-2914-4412-8df1-72e041a58a9f
+        :id: 3219c245-2914-4412-8df1-72e041a58a9f
 
-        @Steps:
+        :Steps:
 
-        1.Navigate to Administer -> Users
-        2.Click on the User
-        3.Select the Timezone Dropdown list
-        4.Try to apply some timezone
+            1. Navigate to Administer -> Users
+            2. Click on the User
+            3. Select the Timezone Dropdown list
+            4. Try to apply some timezone
 
-        @Assert: User should be able to change timezone
+        :Assert: User should be able to change timezone
         """
         with Session(self.browser) as session:
             for timezone in TIMEZONES:
@@ -994,17 +994,17 @@ class UserTestCase(UITestCase):
         """Check if the Dashboard shows the time according to the new
         timezone set
 
-        @id: c2d80855-631c-46f6-8950-c296df8c0cbe
+        :id: c2d80855-631c-46f6-8950-c296df8c0cbe
 
-        @Steps:
+        :Steps:
 
-        1.Change the timezone for a user in Administer -> Users tab
-        2.Navigate to Monitor -> Dashboard
-        3.The left corner displays time according to the new timezone set
+            1. Change the timezone for a user in Administer -> Users tab
+            2. Navigate to Monitor -> Dashboard
+            3. The left corner displays time according to the new timezone set
 
-        @Assert: Dashboard UI displays new time based on the new timezone
+        :Assert: Dashboard UI displays new time based on the new timezone
 
-        @caseautomation: notautomated
+        :caseautomation: notautomated
         """
 
     @stubbed()
@@ -1013,20 +1013,20 @@ class UserTestCase(UITestCase):
         """Check if the logfiles reflect the new timezone set by
         the user
 
-        @id: b687182b-9d4f-4ff4-9f19-1b6ae3c126ad
+        :id: b687182b-9d4f-4ff4-9f19-1b6ae3c126ad
 
-        @Steps:
+        :Steps:
 
-        1.Change the timezones for user in Administer -> Users Tab
-        2.Try to modify content view or environment
-        so that the changes are reflected in log file
-        3.Check if log file shows the new timezone set
+            1. Change the timezones for user in Administer -> Users Tab
+            2. Try to modify content view or environment so that the changes
+               are reflected in log file
+            3. Check if log file shows the new timezone set
 
-        @Assert: Logfiles display time according to changed timezone
+        :Assert: Logfiles display time according to changed timezone
 
-        @caseautomation: notautomated
+        :caseautomation: notautomated
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
 
     @stubbed()
@@ -1035,20 +1035,20 @@ class UserTestCase(UITestCase):
         """Check if the mails are received according to new
         timezone set by the user
 
-        @id: ab34dd9d-4fc1-43f1-b40a-b0ebf0802887
+        :id: ab34dd9d-4fc1-43f1-b40a-b0ebf0802887
 
-        @Steps:
+        :Steps:
 
-        1.Change the timezones for user in Administer -> Users tab
-        2.Navigate to Administer -> Users tab
-        3.Make sure under Email Preferences -> Mail Enabled
-        4.Send daily/weekly/monthly mails
+            1. Change the timezones for user in Administer -> Users tab
+            2. Navigate to Administer -> Users tab
+            3. Make sure under Email Preferences -> Mail Enabled
+            4. Send daily/weekly/monthly mails
 
-        @Assert: Emails are sent according to new timezone set
+        :Assert: Emails are sent according to new timezone set
 
-        @caseautomation: notautomated
+        :caseautomation: notautomated
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
 
     @stubbed()
@@ -1057,28 +1057,28 @@ class UserTestCase(UITestCase):
         """Check if non admin users with edit_params permission can access
         parameters tab on organization details screen
 
-        @id: 086ea8bf-2219-425e-acf4-d2ba59a77ee9
+        :id: 086ea8bf-2219-425e-acf4-d2ba59a77ee9
 
-        @BZ: 1354572
+        :BZ: 1354572
 
-        @Steps:
+        :Steps:
 
-        1.Create a Role in Administer -> Roles
-        2.On Role creation set Resource type to Parameters
-        3.On Role creation add permission edit_params
-        4.On Role creation set Resource type to Organization
-        5.On Role creation add permissions edit_organizations and
-        view_organizations
-        6.Create a non admin user in Administer -> Users
-        7.Add previous role to this user
-        8.Login with previous user credentials
-        9.Go to Organization -> Manage Organizations
-        10.Choose Default Organization
-        11.Assert "Parameters" tab is present
+            1. Create a Role in Administer -> Roles
+            2. On Role creation set Resource type to Parameters
+            3. On Role creation add permission edit_params
+            4. On Role creation set Resource type to Organization
+            5. On Role creation add permissions edit_organizations and
+                view_organizations
+            6. Create a non admin user in Administer -> Users
+            7. Add previous role to this user
+            8. Login with previous user credentials
+            9. Go to Organization -> Manage Organizations
+            10. Choose Default Organization
+            11. Assert "Parameters" tab is present
 
-        @Assert: Parameters tab visible to users with edit_params permission
+        :Assert: Parameters tab visible to users with edit_params permission
 
-        @caseautomation: notautomated
+        :caseautomation: notautomated
         """
 
     @stubbed()
@@ -1087,27 +1087,27 @@ class UserTestCase(UITestCase):
         """Check if non admin users without edit_params permission can not
         access parameters tab on organization details screen
 
-        @id: eac65b64-16d4-4df5-8402-e58ddb31050d
+        :id: eac65b64-16d4-4df5-8402-e58ddb31050d
 
-        @BZ: 1354572
+        :BZ: 1354572
 
-        @Steps:
+        :Steps:
 
-        1.Create a Role in Administer -> Roles
-        4.On Role creation set Resource type to Organization
-        5.On Role creation add permissions edit_organizations and
-        view_organizations
-        6.Create a non admin user in Administer -> Users
-        7.Add previous role to this user
-        8.Login with previous user credentials
-        9.Go to Organization -> Manage Organizations
-        10.Choose Default Organization
-        11.Assert "Parameters" tab is not present
+            1. Create a Role in Administer -> Roles
+            2. On Role creation set Resource type to Organization
+            3. On Role creation add permissions edit_organizations and
+                view_organizations
+            4. Create a non admin user in Administer -> Users
+            5. Add previous role to this user
+            6. Login with previous user credentials
+            7. Go to Organization -> Manage Organizations
+            8. Choose Default Organization
+            9. Assert "Parameters" tab is not present
 
-        @Assert: Parameters tab not visible to users with no edit_params
-        permission
+        :Assert: Parameters tab not visible to users with no edit_params
+            permission
 
-        @caseautomation: notautomated
+        :caseautomation: notautomated
         """
 
 
@@ -1147,11 +1147,11 @@ class ActiveDirectoryUserTestCase(UITestCase):
     def test_positive_create_in_ldap_mode(self):
         """Create User in ldap mode
 
-        @id: 0668b2ca-831e-4568-94fb-80e45dd7d001
+        :id: 0668b2ca-831e-4568-94fb-80e45dd7d001
 
-        @Assert: User is created without specifying the password
+        :Assert: User is created without specifying the password
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         user_name = gen_string('alpha')
         with Session(self.browser) as session:

--- a/tests/foreman/ui/test_usergroup.py
+++ b/tests/foreman/ui/test_usergroup.py
@@ -1,19 +1,19 @@
 # -*- encoding: utf-8 -*-
 """Test class for UserGroup UI
 
-@Requirement: Usergroup
+:Requirement: Usergroup
 
-@CaseAutomation: Automated
+:CaseAutomation: Automated
 
-@CaseLevel: Acceptance
+:CaseLevel: Acceptance
 
-@CaseComponent: UI
+:CaseComponent: UI
 
-@TestType: Functional
+:TestType: Functional
 
-@CaseImportance: High
+:CaseImportance: High
 
-@Upstream: No
+:Upstream: No
 """
 from fauxfactory import gen_string
 from nailgun import entities
@@ -37,9 +37,9 @@ class UserGroupTestCase(UITestCase):
     def test_positive_create_with_name(self):
         """Create new Usergroup using different names
 
-        @id: 43e70c8d-455e-4da8-9c69-ab80dae2a0bc
+        :id: 43e70c8d-455e-4da8-9c69-ab80dae2a0bc
 
-        @Assert: Usergroup is created successfully
+        :Assert: Usergroup is created successfully
         """
         user_name = gen_string('alpha')
         # Create a new user
@@ -63,9 +63,9 @@ class UserGroupTestCase(UITestCase):
     def test_negative_create_with_invalid_name(self):
         """Create a new UserGroup with invalid names
 
-        @id: 2c67dcd6-89b7-4a04-8528-d1f1f2c4530d
+        :id: 2c67dcd6-89b7-4a04-8528-d1f1f2c4530d
 
-        @Assert: Usergroup is not created
+        :Assert: Usergroup is not created
         """
         with Session(self.browser) as session:
             for group_name in invalid_names_list():
@@ -80,9 +80,9 @@ class UserGroupTestCase(UITestCase):
     def test_negative_create_with_same_name(self):
         """Create a new UserGroup with same name
 
-        @id: 5dafa0d4-e2a2-4ac0-926d-fa57d56bbe0b
+        :id: 5dafa0d4-e2a2-4ac0-926d-fa57d56bbe0b
 
-        @Assert: Usergroup cannot be created with existing name
+        :Assert: Usergroup cannot be created with existing name
         """
         group_name = gen_string('alphanumeric')
         with Session(self.browser) as session:
@@ -98,9 +98,9 @@ class UserGroupTestCase(UITestCase):
     def test_positive_delete_empty(self):
         """Delete an empty Usergroup
 
-        @id: ca82f84b-bc5a-4f7d-b70d-9ee3e1b0fffa
+        :id: ca82f84b-bc5a-4f7d-b70d-9ee3e1b0fffa
 
-        @Assert: Usergroup is deleted
+        :Assert: Usergroup is deleted
         """
         with Session(self.browser) as session:
             for group_name in generate_strings_list():
@@ -113,11 +113,11 @@ class UserGroupTestCase(UITestCase):
     def test_positive_delete_with_user(self):
         """Delete an Usergroup that contains a user
 
-        @id: 2bda3db5-f54f-412f-831f-8e005631f271
+        :id: 2bda3db5-f54f-412f-831f-8e005631f271
 
-        @Assert: Usergroup is deleted but not the added user
+        :Assert: Usergroup is deleted but not the added user
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         user_name = gen_string('alpha')
         group_name = gen_string('utf8')
@@ -142,9 +142,9 @@ class UserGroupTestCase(UITestCase):
     def test_positive_update_name(self):
         """Update usergroup with new name
 
-        @id: 2f49ab7c-2f11-48c0-99c2-448fc86b5ad2
+        :id: 2f49ab7c-2f11-48c0-99c2-448fc86b5ad2
 
-        @Assert: Usergroup is updated
+        :Assert: Usergroup is updated
         """
         name = gen_string('alpha')
         with Session(self.browser) as session:
@@ -160,9 +160,9 @@ class UserGroupTestCase(UITestCase):
     def test_positive_update_user(self):
         """Update usergroup with new user
 
-        @id: 5fdb1c36-196d-4ba5-898d-40f484b81090
+        :id: 5fdb1c36-196d-4ba5-898d-40f484b81090
 
-        @Assert: Usergroup is updated
+        :Assert: Usergroup is updated
         """
         name = gen_string('alpha')
         user_name = gen_string('alpha')

--- a/tests/foreman/ui/test_variables.py
+++ b/tests/foreman/ui/test_variables.py
@@ -1,19 +1,19 @@
 # -*- encoding: utf-8 -*-
 """Test class for Puppet Smart Variables
 
-@Requirement: Variables
+:Requirement: Variables
 
-@CaseAutomation: Automated
+:CaseAutomation: Automated
 
-@CaseLevel: Acceptance
+:CaseLevel: Acceptance
 
-@CaseComponent: UI
+:CaseComponent: UI
 
-@TestType: Functional
+:TestType: Functional
 
-@CaseImportance: High
+:CaseImportance: High
 
-@Upstream: No
+:Upstream: No
 """
 
 import yaml
@@ -179,13 +179,11 @@ class SmartVariablesTestCase(UITestCase):
     def test_positive_create(self):
         """Creates a Smart Variable using different names.
 
-        @id: a729c1b4-7a85-45d3-858d-614234d82f92
+        :id: a729c1b4-7a85-45d3-858d-614234d82f92
 
-        @steps:
+        :steps: Creates a smart variable with valid name
 
-        1. Creates a smart variable with valid name
-
-        @assert: The smart variable is created successfully.
+        :assert: The smart variable is created successfully.
         """
         with Session(self.browser) as session:
             for name in valid_data_list():
@@ -202,21 +200,19 @@ class SmartVariablesTestCase(UITestCase):
     def test_positive_create_with_host(self):
         """Creates a Smart Variable and associate it with host.
 
-        @id: 4a8589bf-7b11-48e8-a25d-984bea2ba676
+        :id: 4a8589bf-7b11-48e8-a25d-984bea2ba676
 
-        @steps:
+        :steps: Creates a smart variable with valid name and default value.
 
-        1. Creates a smart variable with valid name and default value.
+        :assert:
 
-        @assert:
+            1. The smart Variable is created successfully.
+            2. In YAML output of associated host, the variable with name and
+               its default value is displayed.
+            3. In Host-> variables tab, the smart variable should be displayed
+               with its respective puppet class.
 
-        1. The smart Variable is created successfully.
-        2. In YAML output of associated host, the variable with name and its
-           default value is displayed.
-        3. In Host-> variables tab, the smart variable should be displayed with
-           its respective puppet class.
-
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         name = gen_string('alpha')
         value = gen_string('alpha')
@@ -246,16 +242,15 @@ class SmartVariablesTestCase(UITestCase):
     def test_negative_create(self):
         """Smart Variable is not created with invalid data.
 
-        @id: 09a67cb6-5de0-41b3-90f4-593323936c6c
+        :id: 09a67cb6-5de0-41b3-90f4-593323936c6c
 
-        @steps:
+        :steps: Creates a smart variable with invalid name and valid default
+            value.
 
-        1. Creates a smart variable with invalid name and valid default value.
+        :assert:
 
-        @assert:
-
-        1. Error is displayed for invalid variable name.
-        2. The smart Variable is not created.
+            1. Error is displayed for invalid variable name.
+            2. The smart Variable is not created.
         """
         with Session(self.browser) as session:
             for name in invalid_names_list():
@@ -277,19 +272,18 @@ class SmartVariablesTestCase(UITestCase):
     def test_positive_delete(self):
         """Deletes a Smart Variable from Smart Variables Menu.
 
-        @id: 19fedbdf-48a1-46a7-b184-615a0efd7b4e
+        :id: 19fedbdf-48a1-46a7-b184-615a0efd7b4e
 
-        @steps:
+        :steps: Deletes a smart Variable from Configure - Smart Variables menu.
 
-        1. Deletes a smart Variable from Configure - Smart Variables menu.
+        :assert:
 
-        @assert:
+            1. The smart Variable is deleted successfully.
+            2. In YAML output of associated Host, the variable should be
+               removed.
+            3. In Host-> variables tab, the smart variable should be removed.
 
-        1. The smart Variable is deleted successfully.
-        2. In YAML output of associated Host, the variable should be removed.
-        3. In Host-> variables tab, the smart variable should be removed.
-
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         name = gen_string('alpha')
         value = gen_string('alpha')
@@ -316,16 +310,14 @@ class SmartVariablesTestCase(UITestCase):
     def test_positive_update_name(self):
         """Update Smart Variable name.
 
-        @id: 2083cfb7-eed6-4086-8f6a-86d6cd08bd06
+        :id: 2083cfb7-eed6-4086-8f6a-86d6cd08bd06
 
-        @steps:
+        :steps:
 
-        1. In Puppet Class, create a smart variable with valid name
-        2. After successful creation, update the name of variable.
+            1. In Puppet Class, create a smart variable with valid name
+            2. After successful creation, update the name of variable.
 
-        @assert:
-
-        1. The variable is updated with new name.
+        :assert: The variable is updated with new name.
         """
         old_name = gen_string('alpha')
         with Session(self.browser) as session:
@@ -346,15 +338,15 @@ class SmartVariablesTestCase(UITestCase):
     def test_positive_update_variable_puppet_class(self):
         """Update Smart Variable puppet class.
 
-        @id: 6c3e2da9-420c-4e39-8b71-e5be6b605bd7
+        :id: 6c3e2da9-420c-4e39-8b71-e5be6b605bd7
 
-        @steps:
+        :steps:
 
-        1. In Puppet Class, creates a smart variable with valid name and
-           default value.
-        2. After successful creation, update the puppet class of variable.
+            1. In Puppet Class, creates a smart variable with valid name and
+               default value.
+            2. After successful creation, update the puppet class of variable.
 
-        @assert: The variable is updated with new puppet class.
+        :assert: The variable is updated with new puppet class.
         """
         name = gen_string('alpha')
         with Session(self.browser) as session:
@@ -375,20 +367,21 @@ class SmartVariablesTestCase(UITestCase):
         """Attempt to create Smart Variable with same name as already existent
         entity
 
-        @id: 7f37194d-4a12-437b-a284-3350cf048eea
+        :id: 7f37194d-4a12-437b-a284-3350cf048eea
 
-        @steps:
+        :steps:
 
-        1. In Puppet Class, create a smart Variable with valid name and default
-           value.
-        2. After successful creation, attempt to create a variable with same
-           name from same/other class.
+            1. In Puppet Class, create a smart Variable with valid name and
+               default value.
+            2. After successful creation, attempt to create a variable with
+               same name from same/other class.
 
-        @assert:
+        :assert:
 
-        1. An error is displayed in front of Variable Key field as 'has already
-           been taken'.
-        2. The variable with same name are not allowed to create from any class
+            1. An error is displayed in front of Variable Key field as 'has
+               already been taken'.
+            2. The variable with same name are not allowed to create from any
+               class
         """
         name = gen_string('alpha')
         with Session(self.browser) as session:
@@ -411,15 +404,15 @@ class SmartVariablesTestCase(UITestCase):
 
         Types - string, boolean, integer, real, array, hash, yaml, json
 
-        @id: d89cdd32-dd2b-46fe-bcc2-8c66d92cc6f8
+        :id: d89cdd32-dd2b-46fe-bcc2-8c66d92cc6f8
 
-        @steps:
+        :steps:
 
-        1.  Update the Key Type.
-        2.  Enter a 'valid' default Value.
-        3.  Submit the changes.
+            1.  Update the Key Type.
+            2.  Enter a 'valid' default Value.
+            3.  Submit the changes.
 
-        @assert: Variable is updated with a new type and value successfully.
+        :assert: Variable is updated with a new type and value successfully.
         """
         name = gen_string('alpha')
         with Session(self.browser) as session:
@@ -453,16 +446,16 @@ class SmartVariablesTestCase(UITestCase):
 
         Types - string, boolean, integer, real, array, hash, yaml, json
 
-        @id: d64d1b6d-028a-4782-a6d4-e3029d7118b6
+        :id: d64d1b6d-028a-4782-a6d4-e3029d7118b6
 
-        @steps:
+        :steps:
 
-        1.  Update the Key Type.
-        2.  Enter an 'Invalid' default Value.
-        3.  Submit the changes.
+            1.  Update the Key Type.
+            2.  Enter an 'Invalid' default Value.
+            3.  Submit the changes.
 
-        @assert: Variable is not updated with new type and invalid default
-        value.
+        :assert: Variable is not updated with new type and invalid default
+            value.
         """
         name = gen_string('alpha')
         initial_value = gen_string('alpha')
@@ -495,16 +488,16 @@ class SmartVariablesTestCase(UITestCase):
         """Attempt to create Smart Variable that has default value that doesn't
         match regexp from validator rule
 
-        @id: 5285b784-e02c-4f3b-a053-93b36bf9fbfc
+        :id: 5285b784-e02c-4f3b-a053-93b36bf9fbfc
 
-        @steps:
+        :steps:
 
-        1.  Provide regexp to validator rule
-        2.  Provide default value that doesn't match the regex from validator
-            rule
-        3.  Submit the change.
+            1.  Provide regexp to validator rule
+            2.  Provide default value that doesn't match the regex from
+                validator rule
+            3.  Submit the change.
 
-        @assert: Error is raised for default value not matching with regex.
+        :assert: Error is raised for default value not matching with regex.
         """
         with Session(self.browser) as session:
             make_smart_variable(
@@ -525,15 +518,16 @@ class SmartVariablesTestCase(UITestCase):
         """Create Smart Variable that has default value that match regexp from
         validator rule
 
-        @id: 7a329b05-7efd-42d2-b472-1a36d0ee6464
+        :id: 7a329b05-7efd-42d2-b472-1a36d0ee6464
 
-        @steps:
+        :steps:
 
-        1.  Provide regexp to validator rule
-        2.  Provide default value that matches the regexp from validator rule
-        3.  Submit the change.
+            1.  Provide regexp to validator rule
+            2.  Provide default value that matches the regexp from validator
+                rule
+            3.  Submit the change.
 
-        @assert: Smart Variable is created successfully
+        :assert: Smart Variable is created successfully
         """
         name = gen_string('alpha')
         with Session(self.browser) as session:
@@ -553,16 +547,16 @@ class SmartVariablesTestCase(UITestCase):
         """Attempt to create Smart Variable that has matcher value that doesn't
         match regexp from validator rule
 
-        @id: b8e039b3-2491-4dba-a91b-a4aa3fc7f544
+        :id: b8e039b3-2491-4dba-a91b-a4aa3fc7f544
 
-        @steps:
+        :steps:
 
-        1.  Provide regexp to validator rule
-        2.  Create a matcher with value that doesn't match the regexp from
-            validator rule
-        3.  Submit the change.
+            1.  Provide regexp to validator rule
+            2.  Create a matcher with value that doesn't match the regexp from
+                validator rule
+            3.  Submit the change.
 
-        @assert: Error is raised for matcher value not matching with regex.
+        :assert: Error is raised for matcher value not matching with regex.
         """
         with Session(self.browser) as session:
             make_smart_variable(
@@ -588,17 +582,17 @@ class SmartVariablesTestCase(UITestCase):
         """Create Smart Variable that has matcher value that match regexp from
         validator rule
 
-        @id: 04a8f849-6323-4e54-9f07-fb750b911a4c
+        :id: 04a8f849-6323-4e54-9f07-fb750b911a4c
 
-        @steps:
+        :steps:
 
-        1.  Provide regexp to validator rule
-        2.  Create a matcher with value that matches the regex from validator
-            rule
-        3.  Submit the change.
+            1.  Provide regexp to validator rule
+            2.  Create a matcher with value that matches the regex from
+                validator rule
+            3.  Submit the change.
 
-        @assert: Smart Variable is created successfully and error is not raised
-        for matcher value matching with regex.
+        :assert: Smart Variable is created successfully and error is not raised
+            for matcher value matching with regex.
         """
         name = gen_string('alpha')
         with Session(self.browser) as session:
@@ -626,16 +620,17 @@ class SmartVariablesTestCase(UITestCase):
         """Attempt to create Smart Variable that has default value that is not
         in list from validator rule
 
-        @id: d1aa9149-9025-4492-95d0-e72aec8eadc3
+        :id: d1aa9149-9025-4492-95d0-e72aec8eadc3
 
-        @steps:
+        :steps:
 
-        1.  Provide list of values to validator rule
-        2.  Provide default value that doesn't match list from validator rule
-        3.  Submit the change.
+            1.  Provide list of values to validator rule
+            2.  Provide default value that doesn't match list from validator
+                rule
+            3.  Submit the change.
 
-        @assert: Error is raised for default value which is not in the list
-        from validator rule.
+        :assert: Error is raised for default value which is not in the list
+            from validator rule.
         """
         with Session(self.browser) as session:
             make_smart_variable(
@@ -656,15 +651,15 @@ class SmartVariablesTestCase(UITestCase):
         """Creates Smart Variable that has default value that is in the list
         from validator rule
 
-        @id: 5ea443f2-ec91-4986-b97c-1c28fb862e1c
+        :id: 5ea443f2-ec91-4986-b97c-1c28fb862e1c
 
-        @steps:
+        :steps:
 
-        1.  Provide list of values to validator rule
-        2.  Provide default value that matches list from validator rule
-        3.  Submit the change.
+            1.  Provide list of values to validator rule
+            2.  Provide default value that matches list from validator rule
+            3.  Submit the change.
 
-        @assert: Smart Variable is created successfully
+        :assert: Smart Variable is created successfully
         """
         name = gen_string('alpha')
         with Session(self.browser) as session:
@@ -684,17 +679,17 @@ class SmartVariablesTestCase(UITestCase):
         """Attempt to create Smart Variable that has matcher value that is not
         in list from validator rule
 
-        @id: 87d128b9-c7f7-4396-b162-60021b0ef682
+        :id: 87d128b9-c7f7-4396-b162-60021b0ef682
 
-        @steps:
+        :steps:
 
-        1.  Provide list of values to validator rule
-        2.  Create a matcher with value that is not in the list from validator
-            rule
-        3.  Submit the change.
+            1.  Provide list of values to validator rule
+            2.  Create a matcher with value that is not in the list from
+                validator rule
+            3.  Submit the change.
 
-        @assert: Error is raised for matcher value that is not in list from
-        validator rule.
+        :assert: Error is raised for matcher value that is not in list from
+            validator rule.
         """
         with Session(self.browser) as session:
             make_smart_variable(
@@ -720,16 +715,16 @@ class SmartVariablesTestCase(UITestCase):
         """Create Smart Variable that has matcher value that is in the list
         from validator rule
 
-        @id: ac91eaf5-2a15-4d54-b078-a37b60074287
+        :id: ac91eaf5-2a15-4d54-b078-a37b60074287
 
-        @steps:
+        :steps:
 
-        1.  Provide list of values to validator rule
-        2.  Create a matcher with value that present in the list from validator
-            rule
-        3.  Submit the change.
+            1.  Provide list of values to validator rule
+            2.  Create a matcher with value that present in the list from
+                validator rule
+            3.  Submit the change.
 
-        @assert: Smart Variable is created successfully
+        :assert: Smart Variable is created successfully
         """
         name = gen_string('alpha')
         with Session(self.browser) as session:
@@ -753,15 +748,16 @@ class SmartVariablesTestCase(UITestCase):
         """Attempt to create Smart Variable that has matcher value of another
         type than key type
 
-        @id: 466197ea-44f0-46d0-b111-686b72183fe5
+        :id: 466197ea-44f0-46d0-b111-686b72183fe5
 
-        @steps:
+        :steps:
 
-        1.  Update smart variable with default type and value.
-        2.  Create a matcher with value that doesn't match the default type.
-        3.  Submit the change.
+            1.  Update smart variable with default type and value.
+            2.  Create a matcher with value that doesn't match the default
+                type.
+            3.  Submit the change.
 
-        @assert: Error is raised for matcher value which is not of default type
+        :assert: Error is raised for matcher value which is not of default type
         """
         with Session(self.browser) as session:
             make_smart_variable(
@@ -786,15 +782,15 @@ class SmartVariablesTestCase(UITestCase):
         """Create Smart Variable that has matcher value of the same type than
         key type
 
-        @id: 033bf7d8-a488-49c1-b900-9e7169e945e0
+        :id: 033bf7d8-a488-49c1-b900-9e7169e945e0
 
-        @steps:
+        :steps:
 
-        1.  Update smart variable with default type and value.
-        2.  Create a matcher with value that matches the default type.
-        3.  Submit the change.
+            1.  Update smart variable with default type and value.
+            2.  Create a matcher with value that matches the default type.
+            3.  Submit the change.
 
-        @assert: Smart Variable is created successfully
+        :assert: Smart Variable is created successfully
         """
         name = gen_string('alpha')
         with Session(self.browser) as session:
@@ -817,15 +813,17 @@ class SmartVariablesTestCase(UITestCase):
         """Attempt to create Smart Variable that has default value and matcher
         value of another type than key type
 
-        @id: 9f5987d1-ac40-4031-bcfe-979dc95866d3
+        :id: 9f5987d1-ac40-4031-bcfe-979dc95866d3
 
-        @steps:
+        :steps:
 
-        1.  Update smart variable with default type and invalid default value.
-        2.  Create a matcher with value that doesn't match the default type.
-        3.  Submit the change.
+            1.  Update smart variable with default type and invalid default
+                value.
+            2.  Create a matcher with value that doesn't match the default
+                type.
+            3.  Submit the change.
 
-        @assert: Error is raised for invalid default and matcher value both.
+        :assert: Error is raised for invalid default and matcher value both.
         """
         with Session(self.browser) as session:
             make_smart_variable(
@@ -854,14 +852,14 @@ class SmartVariablesTestCase(UITestCase):
         """Attempt to create Smart Variable with a matcher that has value for
         non existing attribute.
 
-        @id: 27ef1ef0-1c89-47eb-89e0-3da161154513
+        :id: 27ef1ef0-1c89-47eb-89e0-3da161154513
 
-        @steps:
+        :steps:
 
-        1.  Create a matcher with non existing attribute in org.
-        2.  Attempt to submit the change.
+            1.  Create a matcher with non existing attribute in org.
+            2.  Attempt to submit the change.
 
-        @assert: Error is raised for non existing attribute.
+        :assert: Error is raised for non existing attribute.
         """
         with Session(self.browser) as session:
             make_smart_variable(
@@ -885,22 +883,22 @@ class SmartVariablesTestCase(UITestCase):
     def test_positive_create_matcher(self):
         """Create a Smart Variable with matcher.
 
-        @id: 42113584-d2db-4b91-8775-06bffee36be4
+        :id: 42113584-d2db-4b91-8775-06bffee36be4
 
-        @steps:
+        :steps:
 
-        1. Create a smart Variable with valid name and default value.
-        2. Create a matcher for Host attribute with valid value.
+            1. Create a smart Variable with valid name and default value.
+            2. Create a matcher for Host attribute with valid value.
 
-        @assert:
+        :assert:
 
-        1. The smart Variable with matcher is created successfully.
-        2. In YAML output, the variable name with overrided value for
-           host is displayed.
-        3. In Host-> variables tab, the variable name with overrided value
-           for host is displayed.
+            1. The smart Variable with matcher is created successfully.
+            2. In YAML output, the variable name with overrided value for host
+               is displayed.
+            3. In Host-> variables tab, the variable name with overrided value
+               for host is displayed.
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         name = gen_string('alpha')
         default_value = gen_string('alpha')
@@ -933,21 +931,21 @@ class SmartVariablesTestCase(UITestCase):
     def test_positive_create_matcher_attribute_priority(self):
         """Matcher Value set on Attribute Priority for Host.
 
-        @id: 65144295-f0ca-4bd0-ae01-96c50ca829fe
+        :id: 65144295-f0ca-4bd0-ae01-96c50ca829fe
 
-        @steps:
+        :steps:
 
-        1.  Create variable with some default value.
-        2.  Set fqdn as top priority attribute.
-        3.  Create first matcher for fqdn with valid details.
-        4.  Create second matcher for some attribute with valid details.
-            Note - The fqdn/host should have this attribute.
-        5.  Submit the change.
-        6.  Go to YAML output of associated host.
+            1.  Create variable with some default value.
+            2.  Set fqdn as top priority attribute.
+            3.  Create first matcher for fqdn with valid details.
+            4.  Create second matcher for some attribute with valid details.
+                Note - The fqdn/host should have this attribute.
+            5.  Submit the change.
+            6.  Go to YAML output of associated host.
 
-        @assert: The YAML output has the value only for fqdn matcher.
+        :assert: The YAML output has the value only for fqdn matcher.
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         name = gen_string('alpha')
         override_value = gen_string('alphanumeric')
@@ -983,24 +981,25 @@ class SmartVariablesTestCase(UITestCase):
         """Matcher Value set on Attribute Priority for Host - alternate
         priority.
 
-        @id: 7e52b054-4fcb-4c58-ae49-0d3348d14570
+        :id: 7e52b054-4fcb-4c58-ae49-0d3348d14570
 
-        @steps:
+        :steps:
 
-        1.  Create variable with some default value.
-        2.  Set some attribute(other than fqdn) as top priority attribute.
-            Note - The fqdn/host should have this attribute.
-        3.  Create first matcher for fqdn with valid details.
-        4.  Create second matcher for attribute of step 2 with valid details.
-        5.  Submit the change.
-        6.  Go to YAML output of associated host.
+            1.  Create variable with some default value.
+            2.  Set some attribute(other than fqdn) as top priority attribute.
+                Note - The fqdn/host should have this attribute.
+            3.  Create first matcher for fqdn with valid details.
+            4.  Create second matcher for attribute of step 2 with valid
+                details.
+            5.  Submit the change.
+            6.  Go to YAML output of associated host.
 
-        @assert:
+        :assert:
 
-        1.  The YAML output has the value only for step 4 matcher.
-        2.  The YAML output doesn't have value for fqdn/host matcher.
+            1.  The YAML output has the value only for step 4 matcher.
+            2.  The YAML output doesn't have value for fqdn/host matcher.
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         name = gen_string('alpha')
         override_value = gen_string('alphanumeric')
@@ -1036,28 +1035,28 @@ class SmartVariablesTestCase(UITestCase):
     def test_positive_create_matcher_merge_override(self):
         """Merge the values of all the associated matchers.
 
-        @id: b9c9b1c7-ff9a-4080-aeee-3b61b5414332
+        :id: b9c9b1c7-ff9a-4080-aeee-3b61b5414332
 
-        @steps:
+        :steps:
 
-        1.  Create variable with some default value.
-        2.  Create first matcher for attribute fqdn with valid details.
-        3.  Create second matcher for other attribute with valid details.
-            Note - The fqdn/host should have this attribute.
-        4.  Create more matchers for some more attributes if any.
-            Note - The fqdn/host should have this attributes.
-        5.  Select 'Merge overrides' checkbox.
-        6.  Submit the change.
-        7.  Go to YAML output of associated host.
+            1.  Create variable with some default value.
+            2.  Create first matcher for attribute fqdn with valid details.
+            3.  Create second matcher for other attribute with valid details.
+                Note - The fqdn/host should have this attribute.
+            4.  Create more matchers for some more attributes if any.
+                Note - The fqdn/host should have this attributes.
+            5.  Select 'Merge overrides' checkbox.
+            6.  Submit the change.
+            7.  Go to YAML output of associated host.
 
-        @assert:
+        :assert:
 
-        1.  The YAML output has the values merged from all the associated
-            matchers.
-        2.  The YAML output doesn't have the default value of variable.
-        3.  Duplicate values in YAML output if any are displayed.
+            1.  The YAML output has the values merged from all the associated
+                matchers.
+            2.  The YAML output doesn't have the default value of variable.
+            3.  Duplicate values in YAML output if any are displayed.
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         name = gen_string('alpha')
         override_value = '[80, 90]'
@@ -1093,29 +1092,29 @@ class SmartVariablesTestCase(UITestCase):
     def test_negative_create_matcher_merge_override(self):
         """Attempt to merge the values from non associated matchers.
 
-        @id: 3cc2a7b3-7b46-4c8c-b719-79c004ae04c6
+        :id: 3cc2a7b3-7b46-4c8c-b719-79c004ae04c6
 
-        @steps:
+        :steps:
 
-        1.  Create variable with some default value.
-        2.  Create first matcher for attribute fqdn with valid details.
-        3.  Create second matcher for other attribute with valid details.
-            Note - The fqdn/host should not have this attribute.
-        4.  Create more matchers for some more attributes if any.
-            Note - The fqdn/host should not have this attributes.
-        5.  Select 'Merge overrides' checkbox.
-        6.  Submit the change.
-        7.  Go to YAML output of associated host.
+            1.  Create variable with some default value.
+            2.  Create first matcher for attribute fqdn with valid details.
+            3.  Create second matcher for other attribute with valid details.
+                Note - The fqdn/host should not have this attribute.
+            4.  Create more matchers for some more attributes if any.
+                Note - The fqdn/host should not have this attributes.
+            5.  Select 'Merge overrides' checkbox.
+            6.  Submit the change.
+            7.  Go to YAML output of associated host.
 
-        @assert:
+        :assert:
 
-        1.  The YAML output has the values only for fqdn.
-        2.  The YAML output doesn't have the values for attribute
-            which are not associated to host.
-        3.  The YAML output doesn't have the default value of variable.
-        4.  Duplicate values in YAML output if any are displayed.
+            1.  The YAML output has the values only for fqdn.
+            2.  The YAML output doesn't have the values for attribute which are
+                not associated to host.
+            3.  The YAML output doesn't have the default value of variable.
+            4.  Duplicate values in YAML output if any are displayed.
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         name = gen_string('alpha')
         override_value = '[80, 90]'
@@ -1150,29 +1149,29 @@ class SmartVariablesTestCase(UITestCase):
     def test_positive_create_matcher_merge_default(self):
         """Merge the values of all the associated matchers + default value.
 
-        @id: 21d8fde8-0844-4384-b86a-30547c82b221
+        :id: 21d8fde8-0844-4384-b86a-30547c82b221
 
-        @steps:
+        :steps:
 
-        1.  Create variable with some default value.
-        2.  Create first matcher for attribute fqdn with valid details.
-        3.  Create second matcher for other attribute with valid details.
-            Note - The fqdn/host should have this attribute.
-        4.  Create more matchers for some more attributes if any.
-            Note - The fqdn/host should have this attributes.
-        5.  Select 'Merge overrides' checkbox.
-        6.  Select 'Merge default' checkbox.
-        7.  Submit the change.
-        8.  Go to YAML output of associated host.
+            1.  Create variable with some default value.
+            2.  Create first matcher for attribute fqdn with valid details.
+            3.  Create second matcher for other attribute with valid details.
+                Note - The fqdn/host should have this attribute.
+            4.  Create more matchers for some more attributes if any.
+                Note - The fqdn/host should have this attributes.
+            5.  Select 'Merge overrides' checkbox.
+            6.  Select 'Merge default' checkbox.
+            7.  Submit the change.
+            8.  Go to YAML output of associated host.
 
-        @assert:
+        :assert:
 
-        1.  The YAML output has the values merged from all
-            the associated matchers.
-        2.  The YAML output has the default value of variable.
-        3.  Duplicate values in YAML output if any are displayed.
+            1.  The YAML output has the values merged from all the associated
+                matchers.
+            2.  The YAML output has the default value of variable.
+            3.  Duplicate values in YAML output if any are displayed.
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         name = gen_string('alpha')
         override_value = '[80, 90]'
@@ -1210,29 +1209,30 @@ class SmartVariablesTestCase(UITestCase):
     def test_negative_create_matcher_merge_default(self):
         """Empty default value is not shown in merged values.
 
-        @id: 98f8fe63-d125-4d27-a15a-2550c9e5f0ff
+        :id: 98f8fe63-d125-4d27-a15a-2550c9e5f0ff
 
-        @steps:
+        :steps:
 
-        1.  Create variable with empty default value.
-        2.  Create first matcher for attribute fqdn with valid details.
-        3.  Create second matcher for other attribute with valid details.
-            Note - The fqdn/host should have this attribute.
-        4.  Create more matchers for some more attributes if any.
-            Note - The fqdn/host should have this attributes.
-        5.  Select 'Merge overrides' checkbox.
-        6.  Select 'Merge default' checkbox.
-        7.  Submit the change.
-        8.  Go to YAML output of associated host.
+            1.  Create variable with empty default value.
+            2.  Create first matcher for attribute fqdn with valid details.
+            3.  Create second matcher for other attribute with valid details.
+                Note - The fqdn/host should have this attribute.
+            4.  Create more matchers for some more attributes if any.
+                Note - The fqdn/host should have this attributes.
+            5.  Select 'Merge overrides' checkbox.
+            6.  Select 'Merge default' checkbox.
+            7.  Submit the change.
+            8.  Go to YAML output of associated host.
 
-        @assert:
+        :assert:
 
-        1.  The YAML output has the values merged from all
-            the associated matchers.
-        2.  The YAML output doesn't have the empty default value of variable.
-        3.  Duplicate values in YAML output if any are displayed.
+            1.  The YAML output has the values merged from all the associated
+                matchers.
+            2.  The YAML output doesn't have the empty default value of
+                variable.
+            3.  Duplicate values in YAML output if any are displayed.
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         name = gen_string('alpha')
         override_value = '[80, 90]'
@@ -1269,29 +1269,29 @@ class SmartVariablesTestCase(UITestCase):
     def test_positive_create_matcher_avoid_duplicate(self):
         """Merge the values of all the associated matchers, remove duplicates.
 
-        @id: 75fc514f-70dd-4cc1-8069-221e9edda89a
+        :id: 75fc514f-70dd-4cc1-8069-221e9edda89a
 
-        @steps:
+        :steps:
 
-        1.  Create variable with type array and value.
-        2.  Create first matcher for attribute fqdn with some value.
-        3.  Create second matcher for other attribute with
-            same value as fqdn matcher.
-            Note - The fqdn/host should have this attribute.
-        4.  Select 'Merge overrides' checkbox.
-        5.  Select 'Merge default' checkbox.
-        6.  Select 'Avoid Duplicates' checkbox.
-        7.  Submit the change.
-        8.  Go to YAML output of associated host.
+            1.  Create variable with type array and value.
+            2.  Create first matcher for attribute fqdn with some value.
+            3.  Create second matcher for other attribute with same value as
+                fqdn matcher.
+                Note - The fqdn/host should have this attribute.
+            4.  Select 'Merge overrides' checkbox.
+            5.  Select 'Merge default' checkbox.
+            6.  Select 'Avoid Duplicates' checkbox.
+            7.  Submit the change.
+            8.  Go to YAML output of associated host.
 
-        @assert:
+        :assert:
 
-        1.  The YAML output has the values merged from all
-            the associated matchers.
-        2.  The YAML output has the default value of variable.
-        3.  Duplicate values in YAML output are removed / not displayed.
+            1.  The YAML output has the values merged from all the associated
+                matchers.
+            2.  The YAML output has the default value of variable.
+            3.  Duplicate values in YAML output are removed / not displayed.
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         name = gen_string('alpha')
         override_value = '[80, 90]'
@@ -1328,28 +1328,28 @@ class SmartVariablesTestCase(UITestCase):
     def test_negative_create_matcher_avoid_duplicate(self):
         """Duplicates not removed as they were not really present.
 
-        @id: 050c7cef-eed6-4a61-b567-371f398647a2
+        :id: 050c7cef-eed6-4a61-b567-371f398647a2
 
-        @steps:
+        :steps:
 
-        1.  Create variable with type array and value.
-        2.  Create first matcher for attribute fqdn with some value.
-        3.  Create second matcher for other attribute with other value
-            than fqdn matcher and default value.
-            Note - The fqdn/host should have this attribute.
-        4.  Select 'Merge overrides' checkbox.
-        5.  Select 'Merge default' checkbox.
-        6.  Select 'Avoid Duplicates' checkbox.
-        7.  Submit the change.
-        8.  Go to YAML output of associated host.
+            1.  Create variable with type array and value.
+            2.  Create first matcher for attribute fqdn with some value.
+            3.  Create second matcher for other attribute with other value than
+                fqdn matcher and default value.
+                Note - The fqdn/host should have this attribute.
+            4.  Select 'Merge overrides' checkbox.
+            5.  Select 'Merge default' checkbox.
+            6.  Select 'Avoid Duplicates' checkbox.
+            7.  Submit the change.
+            8.  Go to YAML output of associated host.
 
-        @assert:
+        :assert:
 
-        1.  The YAML output has the values merged from all matchers.
-        2.  The YAML output has the default value of variable.
-        3.  No value removed as duplicate value.
+            1.  The YAML output has the values merged from all matchers.
+            2.  The YAML output has the default value of variable.
+            3.  No value removed as duplicate value.
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         name = gen_string('alpha')
         override_value = '[70, 80]'
@@ -1387,14 +1387,12 @@ class SmartVariablesTestCase(UITestCase):
         """Verify that Merge Overrides and Merge Default checkboxes are
         disabled for non supported types
 
-        @id: 834af938-e056-4a40-8831-91f6400aedd3
+        :id: 834af938-e056-4a40-8831-91f6400aedd3
 
-        @steps:
+        :steps: Set variable type other than array/hash.
 
-        1.  Set variable type other than array/hash.
-
-        @assert: The Merge Overrides, Merge Default checkboxes are disabled for
-        editing
+        :assert: The Merge Overrides, Merge Default checkboxes are disabled for
+            editing
         """
         name = gen_string('alpha')
         with Session(self.browser) as session:
@@ -1416,14 +1414,12 @@ class SmartVariablesTestCase(UITestCase):
         """Verify that Merge Overrides and Avoid Duplicates checkboxes are
         disabled for non supported types
 
-        @id: 8dc28e77-584a-46f9-aed7-dcc3345a2d9b
+        :id: 8dc28e77-584a-46f9-aed7-dcc3345a2d9b
 
-        @steps:
+        :steps: Set variable type other than array.
 
-        1.  Set variable type other than array.
-
-        @assert: The Merge Overrides, Avoid Duplicates checkboxes are disabled
-        for editing
+        :assert: The Merge Overrides, Avoid Duplicates checkboxes are disabled
+            for editing
         """
         name = gen_string('alpha')
         with Session(self.browser) as session:
@@ -1445,21 +1441,21 @@ class SmartVariablesTestCase(UITestCase):
     def test_positive_impact_delete_attribute(self):
         """Impact on variable after deleting associated attribute.
 
-        @id: 26ce3c25-0deb-415d-a2f5-0eacaf354f92
+        :id: 26ce3c25-0deb-415d-a2f5-0eacaf354f92
 
-        @steps:
+        :steps:
 
-        1.  Create a variable with matcher for some attribute.
-        2.  Delete the attribute.
-        3.  Recreate the attribute with same name as earlier.
+            1.  Create a variable with matcher for some attribute.
+            2.  Delete the attribute.
+            3.  Recreate the attribute with same name as earlier.
 
-        @assert:
+        :assert:
 
-        1.  The matcher for deleted attribute removed from variable.
-        2.  On recreating attribute, the matcher should not reappear in
-            variable.
+            1.  The matcher for deleted attribute removed from variable.
+            2.  On recreating attribute, the matcher should not reappear in
+                variable.
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         sv_name = gen_string('alpha')
         hg_name = gen_string('alpha')
@@ -1496,21 +1492,21 @@ class SmartVariablesTestCase(UITestCase):
     def test_positive_create_override_from_attribute(self):
         """Impact on variable on overriding the variable value from attribute.
 
-        @id: 0d4a6b5f-09d8-4d64-ae4b-efa152815ea8
+        :id: 0d4a6b5f-09d8-4d64-ae4b-efa152815ea8
 
-        @steps:
+        :steps:
 
-        1.  Create a variable.
-        2.  Associate variable with fqdn/hostgroup.
-        3.  From host/hostgroup, override the variable value.
-        4.  Submit the changes.
+            1.  Create a variable.
+            2.  Associate variable with fqdn/hostgroup.
+            3.  From host/hostgroup, override the variable value.
+            4.  Submit the changes.
 
-        @assert:
+        :assert:
 
-        1.  The host/hostgroup is saved with changes.
-        2.  New matcher for fqdn/hostgroup created inside variable.
+            1.  The host/hostgroup is saved with changes.
+            2.  New matcher for fqdn/hostgroup created inside variable.
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         name = gen_string('alpha')
         with Session(self.browser) as session:
@@ -1533,21 +1529,21 @@ class SmartVariablesTestCase(UITestCase):
         """No impact on variable on overriding the variable with invalid value
         from attribute.
 
-        @id: 18071443-a511-49c4-9ca9-04c7594b831d
+        :id: 18071443-a511-49c4-9ca9-04c7594b831d
 
-        @steps:
+        :steps:
 
-        1.  Create a variable.
-        2.  Associate variable with fqdn/hostgroup.
-        3.  From host/hostgroup, attempt to override the variable with some
-            other key type of value.
+            1.  Create a variable.
+            2.  Associate variable with fqdn/hostgroup.
+            3.  From host/hostgroup, attempt to override the variable with some
+                other key type of value.
 
-        @assert:
+        :assert:
 
-        1.  Error thrown for invalid type value.
-        2.  No matcher for fqdn/hostgroup is created inside variable.
+            1.  Error thrown for invalid type value.
+            2.  No matcher for fqdn/hostgroup is created inside variable.
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         name = gen_string('alpha')
         default_value = gen_string('numeric').lstrip('0')
@@ -1575,22 +1571,22 @@ class SmartVariablesTestCase(UITestCase):
     def test_positive_update_matcher_from_attribute(self):
         """Impact on variable on editing the variable value from attribute.
 
-        @id: e98a8404-5e32-4d2e-af81-4339d214658a
+        :id: e98a8404-5e32-4d2e-af81-4339d214658a
 
-        @steps:
+        :steps:
 
-        1.  Create a variable.
-        2.  Associate variable with fqdn/hostgroup.
-        3.  Create a matcher for fqdn/hostgroup with valid details.
-        4.  From host/hostgroup, edit the variable value.
-        5.  Submit the changes.
+            1.  Create a variable.
+            2.  Associate variable with fqdn/hostgroup.
+            3.  Create a matcher for fqdn/hostgroup with valid details.
+            4.  From host/hostgroup, edit the variable value.
+            5.  Submit the changes.
 
-        @assert:
+        :assert:
 
-        1.  The host/hostgroup is saved with changes.
-        2.  Matcher value in variable is updated from fqdn/hostgroup.
+            1.  The host/hostgroup is saved with changes.
+            2.  Matcher value in variable is updated from fqdn/hostgroup.
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         name = gen_string('alpha')
         host_override_value = gen_string('numeric').lstrip('0')
@@ -1626,22 +1622,22 @@ class SmartVariablesTestCase(UITestCase):
         """No impact on variable on editing the variable with invalid value
         from attribute.
 
-        @id: bd4a2535-57dd-49a8-b8b5-c5e8de652aa7
+        :id: bd4a2535-57dd-49a8-b8b5-c5e8de652aa7
 
-        @steps:
+        :steps:
 
-        1.  Create a variable.
-        2.  Associate variable with fqdn/hostgroup.
-        3.  Create a matcher for fqdn/hostgroup with valid details.
-        4.  From host/hostgroup, attempt to edit the variable
-            with invalid value.
+            1.  Create a variable.
+            2.  Associate variable with fqdn/hostgroup.
+            3.  Create a matcher for fqdn/hostgroup with valid details.
+            4.  From host/hostgroup, attempt to edit the variable with invalid
+                value.
 
-        @assert:
+        :assert:
 
-        1.  Error thrown for invalid value.
-        2.  Matcher value in variable is not updated from fqdn/hostgroup.
+            1.  Error thrown for invalid value.
+            2.  Matcher value in variable is not updated from fqdn/hostgroup.
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         name = gen_string('alpha')
         override_value = gen_string('numeric').lstrip('0')
@@ -1680,15 +1676,15 @@ class SmartVariablesTestCase(UITestCase):
     def test_positive_hide_default_value(self):
         """Hide the default value of variable.
 
-        @id: cd2ec5a5-4bf1-4239-9b3a-8fbca02d7070
+        :id: cd2ec5a5-4bf1-4239-9b3a-8fbca02d7070
 
-        @steps:
+        :steps:
 
-        1.  Create a variable.
-        2.  Enter some valid default value.
-        3.  Check 'Hidden Value' checkbox.
+            1.  Create a variable.
+            2.  Enter some valid default value.
+            3.  Check 'Hidden Value' checkbox.
 
-        @assert: Created Smart Variable has hidden default value
+        :assert: Created Smart Variable has hidden default value
         """
         name = gen_string('alpha')
         value = gen_string('alphanumeric')
@@ -1711,18 +1707,16 @@ class SmartVariablesTestCase(UITestCase):
     def test_positive_unhide_default_value(self):
         """Unhide the default value of variable.
 
-        @id: 708fbd15-5177-4eb5-800a-4266e2476439
+        :id: 708fbd15-5177-4eb5-800a-4266e2476439
 
-        @steps:
+        :steps:
 
-        1.  Create a variable.
-        2.  Enter some valid default value.
-        3.  Hide the value of variable.
-        4.  After hiding, uncheck the 'Hidden Value' checkbox.
+            1.  Create a variable.
+            2.  Enter some valid default value.
+            3.  Hide the value of variable.
+            4.  After hiding, uncheck the 'Hidden Value' checkbox.
 
-        @assert:
-
-        1.  The default value shown in unhidden state.
+        :assert: The default value shown in unhidden state.
         """
         name = gen_string('alpha')
         value = gen_string('alphanumeric')
@@ -1751,23 +1745,24 @@ class SmartVariablesTestCase(UITestCase):
     def test_positive_hide_default_value_in_attribute(self):
         """Hide the default value of variable in attribute.
 
-        @id: 3b9661f9-f7f7-4dbe-8b08-1a712db6a83d
+        :id: 3b9661f9-f7f7-4dbe-8b08-1a712db6a83d
 
-        @steps:
+        :steps:
 
-        1.  Create a variable.
-        2.  Enter some valid default value.
-        3.  Hide the default Value.
-        4.  Submit the changes.
-        5.  Associate variable on host/hostgroup.
+            1.  Create a variable.
+            2.  Enter some valid default value.
+            3.  Hide the default Value.
+            4.  Submit the changes.
+            5.  Associate variable on host/hostgroup.
 
-        @assert:
+        :assert:
 
-        1.  In host/hostgroup, the variable value shown in hidden state.
-        2.  The button for unhiding the value is displayed and accessible.
-        3.  The button for overriding the value is displayed and accessible.
+            1.  In host/hostgroup, the variable value shown in hidden state.
+            2.  The button for unhiding the value is displayed and accessible.
+            3.  The button for overriding the value is displayed and
+                accessible.
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         name = gen_string('alpha')
         default_value = gen_string('numeric').lstrip('0')
@@ -1800,25 +1795,26 @@ class SmartVariablesTestCase(UITestCase):
     def test_positive_unhide_default_value_in_attribute(self):
         """Unhide the default value of variable in attribute.
 
-        @id: 5d7c1eb2-3f98-4dfd-aac0-ff740b7f82ec
+        :id: 5d7c1eb2-3f98-4dfd-aac0-ff740b7f82ec
 
-        @steps:
+        :steps:
 
-        1.  Create a variable.
-        2.  Enter some valid default value.
-        3.  Hide the default Value.
-        4.  Submit the changes.
-        5.  Associate variable on host/hostgroup.
-        6.  In host/hostgroup, Click Unhide button icon.
+            1.  Create a variable.
+            2.  Enter some valid default value.
+            3.  Hide the default Value.
+            4.  Submit the changes.
+            5.  Associate variable on host/hostgroup.
+            6.  In host/hostgroup, Click Unhide button icon.
 
-        @assert:
+        :assert:
 
-        1.  In host/hostgroup, the variable value shown in unhidden state.
-        2.  The button for hiding the value is displayed and accessible.
-        3.  The button for overriding the value is displayed and accessible.
-        4.  In variable, the default value is still hidden.
+            1.  In host/hostgroup, the variable value shown in unhidden state.
+            2.  The button for hiding the value is displayed and accessible.
+            3.  The button for overriding the value is displayed and
+                accessible.
+            4.  In variable, the default value is still hidden.
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         name = gen_string('alpha')
         default_value = gen_string('numeric').lstrip('0')
@@ -1851,20 +1847,20 @@ class SmartVariablesTestCase(UITestCase):
     def test_positive_update_hidden_value(self):
         """Update the hidden default value of variable.
 
-        @id: b56e2b84-ba31-4fd2-b65a-ac9f3eb1c1e1
+        :id: b56e2b84-ba31-4fd2-b65a-ac9f3eb1c1e1
 
-        @steps:
+        :steps:
 
-        1.  Create a variable.
-        2.  Enter some valid default value.
-        3.  Hide the default Value.
-        4.  Again update the default value.
-        5.  Submit the changes.
+            1.  Create a variable.
+            2.  Enter some valid default value.
+            3.  Hide the default Value.
+            4.  Again update the default value.
+            5.  Submit the changes.
 
-        @assert:
+        :assert:
 
-        1.  The variable default value is updated.
-        2.  The variable default value displayed as hidden.
+            1.  The variable default value is updated.
+            2.  The variable default value displayed as hidden.
         """
         name = gen_string('alpha')
         value = gen_string('alphanumeric')
@@ -1896,25 +1892,25 @@ class SmartVariablesTestCase(UITestCase):
     def test_positive_update_hidden_value_in_attribute(self):
         """Update the hidden default value of variable in attribute.
 
-        @id: 2f506d47-aed5-45ad-a6fb-133ece18eb14
+        :id: 2f506d47-aed5-45ad-a6fb-133ece18eb14
 
-        @steps:
+        :steps:
 
-        1.  Create a variable.
-        2.  Enter some valid default value.
-        3.  Hide the default Value.
-        4.  Submit the changes.
-        5.  Associate variable on host/hostgroup.
-        6.  In host/hostgroup, update the variable value.
+            1.  Create a variable.
+            2.  Enter some valid default value.
+            3.  Hide the default Value.
+            4.  Submit the changes.
+            5.  Associate variable on host/hostgroup.
+            6.  In host/hostgroup, update the variable value.
 
-        @assert:
+        :assert:
 
-        1.  In host/hostgroup, the variable value is updated.
-        2.  The variable Value displayed as hidden.
-        3.  In variable, new matcher created for fqdn/hostgroup.
-        4.  And the value shown hidden.
+            1.  In host/hostgroup, the variable value is updated.
+            2.  The variable Value displayed as hidden.
+            3.  In variable, new matcher created for fqdn/hostgroup.
+            4.  And the value shown hidden.
 
-        @CaseLevel: Integration
+        :CaseLevel: Integration
         """
         name = gen_string('alpha')
         default_value = gen_string('numeric').lstrip('0')
@@ -1959,20 +1955,20 @@ class SmartVariablesTestCase(UITestCase):
     def test_positive_hide_empty_default_value(self):
         """Hiding the empty default value.
 
-        @id: ee96bc8c-5294-4580-8316-e62e72e9e3ea
+        :id: ee96bc8c-5294-4580-8316-e62e72e9e3ea
 
-        @steps:
+        :steps:
 
-        1.  Create a variable.
-        2.  Don't enter any value, keep blank.
-        3.  Check the 'Hidden Value' icon.
-        4.  Create a matcher with some value.
+            1.  Create a variable.
+            2.  Don't enter any value, keep blank.
+            3.  Check the 'Hidden Value' icon.
+            4.  Create a matcher with some value.
 
-        @assert:
+        :assert:
 
-        1.  The 'Hidden Value' checkbox is enabled to check.
-        2.  The default value shows empty on hide.
-        3.  Matcher Value shown as hidden.
+            1.  The 'Hidden Value' checkbox is enabled to check.
+            2.  The default value shows empty on hide.
+            3.  Matcher Value shown as hidden.
         """
         name = gen_string('alpha')
         override_value = gen_string('alpha')

--- a/tests/foreman/upgrade/test_organization.py
+++ b/tests/foreman/upgrade/test_organization.py
@@ -2,19 +2,19 @@
 
 """Test class for Organization PostUpgrade
 
-@Requirement: Organization
+:Requirement: Organization
 
-@CaseAutomation: Automated
+:CaseAutomation: Automated
 
-@CaseLevel: Acceptance
+:CaseLevel: Acceptance
 
-@CaseComponent: CLI
+:CaseComponent: CLI
 
-@TestType: Structural
+:TestType: Structural
 
-@CaseImportance: High
+:CaseImportance: High
 
-@Upstream: No
+:Upstream: No
 """
 from robottelo.cli.org import Org
 from robottelo.datafactory import get_valid_preupgrade_data
@@ -29,9 +29,9 @@ class OrganizationTestCase(CLITestCase):
     def test_positive_exits_org_by_id(self):
         """Test whether the Organization exists on Post Upgrade - id
 
-        @id: da2821d0-1ea2-423d-8172-7372c98d8858
+        :id: da2821d0-1ea2-423d-8172-7372c98d8858
 
-        @assert: Organization by id exists post Upgrade
+        :assert: Organization by id exists post Upgrade
         """
         for org, org_id in get_valid_preupgrade_data(
                 'organization-tests', 'id'):
@@ -43,9 +43,9 @@ class OrganizationTestCase(CLITestCase):
     def test_positive_exists_org_by_name(self):
         """Test whether the Organization exists on Post Upgrade - name
 
-        @id: 639c3fec-ed5d-4c05-a301-801e3b47efb8
+        :id: 639c3fec-ed5d-4c05-a301-801e3b47efb8
 
-        @assert: Organization by name exists post Upgrade
+        :assert: Organization by name exists post Upgrade
         """
         for org, org_name in get_valid_preupgrade_data(
                 'organization-tests', 'name'):
@@ -57,9 +57,9 @@ class OrganizationTestCase(CLITestCase):
     def test_positive_association_org_smart_proxy(self):
         """Test Smart Proxy is associated with Organization
 
-        @id: 9986ec9d-b37c-482c-9bb1-7c25f6bfd34c
+        :id: 9986ec9d-b37c-482c-9bb1-7c25f6bfd34c
 
-        @assert: Smart Proxy is associated with Organization
+        :assert: Smart Proxy is associated with Organization
         """
         for org, sp in get_valid_preupgrade_data(
                 'organization-tests', 'smart-proxy'):
@@ -71,9 +71,9 @@ class OrganizationTestCase(CLITestCase):
     def test_positive_association_org_template(self):
         """Test Template is associated with Organization
 
-        @id: 2c8a6362-f95f-4aec-bc63-57242a639167
+        :id: 2c8a6362-f95f-4aec-bc63-57242a639167
 
-        @assert: Template is associated with Organization
+        :assert: Template is associated with Organization
         """
         for org, template in get_valid_preupgrade_data(
                 'organization-tests', 'template'):
@@ -85,9 +85,9 @@ class OrganizationTestCase(CLITestCase):
     def test_positive_association_org_puppet_environment(self):
         """Test Puppet Environment is associated with Organization
 
-        @id: 12c6d711-c6d6-4bcb-9e24-01cadb205f7b
+        :id: 12c6d711-c6d6-4bcb-9e24-01cadb205f7b
 
-        @assert: Puppet Environment is associated with Organization
+        :assert: Puppet Environment is associated with Organization
         """
         for org, penv in get_valid_preupgrade_data(
                 'organization-tests', 'Puppet-Environments'):


### PR DESCRIPTION
Change the prefix from `@` to `:` this will ensure the following:

* Better compatibility with the RST format and Sphinx will produce
  better documentation.
* `make docs` will help on identifying if some of the token values are
  not formatted properly.
* Use new version of Testimony which drops the token-prefix option and
  will provide better tolling for managing the test cases' information

The majority of the changes are just s/@/: for the tokens but since now
following the RST format is being enforced it was needed to also update
some docstrings. The remaining changes was to update the scripts that
deal with the `:id:` token and test-docstrings make target.