### PR TITLE
Add test coverage for filtered errata functionality (BZ1368254)

### DIFF
--- a/robottelo/cli/contentview.py
+++ b/robottelo/cli/contentview.py
@@ -35,7 +35,52 @@ Options::
 """
 
 from robottelo.cli import hammer
-from robottelo.cli.base import Base
+from robottelo.cli.base import Base, CLIError
+
+
+class ContentViewFilterRule(Base):
+    """Manipulates content view filter rules."""
+
+    command_base = 'content-view filter rule'
+
+    @classmethod
+    def create(cls, options=None):
+        """Create a content-view filter rule"""
+        if (
+                not options or
+                'content-view-filter' not in options and
+                'content-view-filter-id' not in options):
+            raise CLIError(
+                'Could not find content_view_filter, please set one of options'
+                ' "content-view-filter" or "content-view-filter-id".'
+            )
+        cls.command_sub = 'create'
+        result = cls.execute(
+            cls._construct_command(options), output_format='csv')
+
+        # Extract new CV filter rule ID if it was successfully created
+        if len(result) > 0 and 'id' in result[0]:
+            cvfr_id = result[0]['id']
+            # CV filter rule can only be fetched by specifying either
+            # content-view-filter-id or content-view-filter + content-view-id.
+            # Passing these options to info command
+            info_options = {
+                'content-view-id': options.get('content-view-id'),
+                'content-view-filter': options.get('content-view-filter'),
+                'content-view-filter-id': options.get(
+                    'content-view-filter-id'),
+                'id': cvfr_id,
+            }
+            result = cls.info(info_options)
+        return result
+
+
+class ContentViewFilter(Base):
+    """Manipulates content view filters."""
+
+    command_base = 'content-view filter'
+
+    rule = ContentViewFilterRule
 
 
 class ContentView(Base):

--- a/robottelo/cli/factory.py
+++ b/robottelo/cli/factory.py
@@ -24,7 +24,11 @@ from robottelo.cli.architecture import Architecture
 from robottelo.cli.base import CLIReturnCodeError
 from robottelo.cli.computeresource import ComputeResource
 from robottelo.cli.contenthost import ContentHost
-from robottelo.cli.contentview import ContentView
+from robottelo.cli.contentview import (
+    ContentView,
+    ContentViewFilter,
+    ContentViewFilterRule
+)
 from robottelo.cli.docker import DockerContainer, DockerRegistry
 from robottelo.cli.domain import Domain
 from robottelo.cli.environment import Environment
@@ -316,6 +320,112 @@ def make_content_view(options=None):
     }
 
     return create_object(ContentView, args, options)
+
+
+@cacheable
+def make_content_view_filter(options=None):
+    """
+    Usage::
+
+        content-view filter create [OPTIONS]
+
+    Options::
+
+        --content-view CONTENT_VIEW_NAME        Content view name to search by
+        --content-view-id CONTENT_VIEW_ID       content view numeric identifier
+        --description DESCRIPTION               description of the filter
+        --inclusion INCLUSION                   specifies if content should be
+                                                included or excluded, default:
+                                                inclusion=false
+                                                One of true/false, yes/no, 1/0.
+        --name NAME                             name of the filter
+        --organization ORGANIZATION_NAME        Organization name to search by
+        --organization-id ORGANIZATION_ID       Organization ID to search by
+        --organization-label ORGANIZATION_LABEL Organization label to search by
+        --original-packages ORIGINAL_PACKAGES   add all packages without errata
+                                                to the included/ excluded list.
+                                                (package filter only)
+                                                One of true/false, yes/no, 1/0.
+        --repositories REPOSITORY_NAMES         Comma separated list of values.
+        --repository-ids REPOSITORY_IDS         list of repository ids
+                                                Comma separated list of values.
+        --type TYPE                             type of filter (e.g. rpm,
+                                                package_group, erratum)
+        -h, --help                              print help
+    """
+    args = {
+        u'content-view': None,
+        u'content-view-id': None,
+        u'description': None,
+        u'inclusion': None,
+        u'name': gen_string('alpha', 10),
+        u'organization': None,
+        u'organization-id': None,
+        u'organization-label': None,
+        u'original-packages': None,
+        u'repositories': None,
+        u'repository-ids': None,
+        u'type': None,
+    }
+
+    return create_object(ContentViewFilter, args, options)
+
+
+@cacheable
+def make_content_view_filter_rule(options=None):
+    """
+    Usage::
+
+        content-view filter rule create [OPTIONS]
+
+    Options::
+
+        --content-view CONTENT_VIEW_NAME        Content view name to search by
+        --content-view-filter CONTENT_VIEW_FILTER_NAME  Name to search by
+        --content-view-filter-id CONTENT_VIEW_FILTER_ID filter identifier
+        --content-view-id CONTENT_VIEW_ID       content view numeric identifier
+        --date-type DATE_TYPE                   erratum: search using the
+                                                'Issued On' or 'Updated On'
+                                                column of the errata.
+                                                Values are 'issued'/'updated'
+        --end-date END_DATE                     erratum: end date (YYYY-MM-DD)
+        --errata-id ERRATA_ID                   erratum: id
+        --errata-ids ERRATA_IDS                 erratum: IDs or a select all
+                                                object
+                                                Comma separated list of values.
+        --max-version MAX_VERSION               package: maximum version
+        --min-version MIN_VERSION               package: minimum version
+        --name NAME                             package and package group names
+                                                Comma separated list of values.
+        --names NAMES                           Package and package group names
+        --start-date START_DATE                 erratum: start date
+                                                (YYYY-MM-DD)
+        --types TYPES                           erratum: types (enhancement,
+                                                bugfix, security)
+                                                Comma separated list of values.
+        --version VERSION                       package: version
+        -h, --help                              print help
+    """
+
+    args = {
+        u'content-view': None,
+        u'content-view-filter': None,
+        u'content-view-filter-id': None,
+        u'content-view-id': None,
+        u'date-type': None,
+        u'end-date': None,
+        u'errata-id': None,
+        u'errata-ids': None,
+        u'max-version': None,
+        u'min-version': None,
+        u'name': None,
+        u'names': None,
+        u'start-date': None,
+        u'types': None,
+        u'version': None,
+    }
+
+    return create_object(ContentViewFilterRule, args, options)
 
 
 @cacheable

--- a/robottelo/ui/hosts.py
+++ b/robottelo/ui/hosts.py
@@ -285,3 +285,13 @@ class Hosts(Base):
             strategy, value = locators['host.smart_variable_value']
         self.assign_value((strategy, value % sv_name), sv_value)
         self.click(common_locators['submit'])
+
+    def get_host_properties(self, host, parameters_list):
+        """Get necessary host properties by theirs names"""
+        self.search_and_click(host)
+        result = {}
+        for parameter_name in parameters_list:
+            locator = locators['.property_'.join(
+                ('host', (parameter_name.lower()).replace(' ', '_')))]
+            result[parameter_name] = self.wait_until_element(locator).text
+        return result

--- a/robottelo/ui/locators.py
+++ b/robottelo/ui/locators.py
@@ -697,6 +697,8 @@ tab_locators = LocatorDict({
         By.XPATH, "//a[@data-toggle='tab' and contains(@href, 'Puppet')]"),
     "settings.tab_discovered": (
         By.XPATH, "//a[@data-toggle='tab' and contains(@href, 'Discovered')]"),
+    "settings.tab_katello": (
+        By.XPATH, "//a[@data-toggle='tab' and contains(@href, 'Katello')]"),
     "settings.tab_foremantasks": (
         By.XPATH,
         "//a[@data-toggle='tab' and contains(@href, 'ForemanTasks')]"),
@@ -1327,6 +1329,20 @@ locators = LocatorDict({
     "host.yaml_button": (By.XPATH, "//a[text()='YAML' and "
                                    "contains(@class, 'btn')]"),
     "host.yaml_output": (By.XPATH, "//pre"),
+    "host.property_status": (
+        By.XPATH, "//td[text()='Status']/following-sibling::td/span[2]"),
+    "host.property_errata": (
+        By.XPATH, "//td[text()='Errata']/following-sibling::td/span[2]"),
+    "host.property_subscription": (
+        By.XPATH, "//td[text()='Subscription']/following-sibling::td/span[2]"),
+    "host.property_ip_address": (
+        By.XPATH, "//table[@id='properties_table']//td[text()='IP Address']/"
+                  "following-sibling::td"),
+    "host.property_mac_address": (
+        By.XPATH, "//table[@id='properties_table']//td[text()='MAC Address']/"
+                  "following-sibling::td"),
+    "host.property_host_architecture": (
+        By.XPATH, "//td[text()='Host Architecture']/following-sibling::td/a"),
     "host.name": (By.ID, "host_name"),
     "host.organization": (
         By.XPATH,

--- a/tests/foreman/ui/test_errata.py
+++ b/tests/foreman/ui/test_errata.py
@@ -15,10 +15,41 @@
 @Upstream: No
 """
 
-from robottelo.decorators import stubbed, tier2, tier3
+from nailgun import entities
+from robottelo.cli.factory import (
+    make_content_view_filter,
+    make_content_view_filter_rule,
+    setup_org_for_a_custom_repo,
+    setup_org_for_a_rh_repo,
+)
+from robottelo.cli.contentview import ContentView
+from robottelo.constants import (
+    DISTRO_RHEL7,
+    FAKE_1_CUSTOM_PACKAGE,
+    FAKE_2_ERRATA_ID,
+    FAKE_6_YUM_REPO,
+    PRDS,
+    REPOS,
+    REPOSET,
+)
+from robottelo.decorators import (
+    run_in_one_thread,
+    stubbed,
+    tier2,
+    tier3,
+)
 from robottelo.test import UITestCase
+from robottelo.ui.factory import edit_param
+from robottelo.ui.locators import tab_locators
+from robottelo.ui.session import Session
+from robottelo.vm import VirtualMachine
 
 
+CUSTOM_REPO_URL = FAKE_6_YUM_REPO
+CUSTOM_REPO_ERRATA_ID = FAKE_2_ERRATA_ID
+
+
+@run_in_one_thread
 class ErrataTestCase(UITestCase):
     """UI Tests for the errata management feature"""
 
@@ -443,3 +474,133 @@ class ErrataTestCase(UITestCase):
 
         @CaseLevel: System
         """
+
+
+@run_in_one_thread
+class FilteredErrataTestCase(UITestCase):
+    """UI Tests for filtering functionality of errata management feature"""
+
+    @classmethod
+    def set_session_org(cls):
+        """Create an organization for tests, which will be selected
+        automatically"""
+        cls.session_org = entities.Organization().create()
+
+    @tier3
+    def test_positive_errata_status_installable_param(self):
+        """Filter errata for specific content view and verify that host that
+        was registered using that content view has different states in
+        correspondence to filtered errata and `errata status installable`
+        settings flag value
+
+        @id: ed94cf34-b8b9-4411-8edc-5e210ea6af4f
+
+        @Steps:
+
+        1. Prepare setup: Create Lifecycle Environment, Content View,
+        Activation Key and all necessary repos
+        2. Register Content Host using created data
+        3. Create necessary Content View Filter and Rule for repository errata
+        4. Publish and Promote Content View to a new version and remove old
+        ones.
+        5. Go to created Host page and check its properties
+        6. Change 'errata status installable' flag in the settings and check
+        host properties once more
+
+        @Assert: Check that 'errata status installable' flag works as intended
+
+        @BZ: 1368254
+
+        @CaseLevel: System
+        """
+        env = entities.LifecycleEnvironment(
+            organization=self.session_org).create()
+        content_view = entities.ContentView(
+            organization=self.session_org).create()
+        activation_key = entities.ActivationKey(
+            environment=env,
+            organization=self.session_org,
+        ).create()
+        setup_org_for_a_rh_repo({
+            'product': PRDS['rhel'],
+            'repository-set': REPOSET['rhst7'],
+            'repository': REPOS['rhst7']['name'],
+            'organization-id': self.session_org.id,
+            'content-view-id': content_view.id,
+            'lifecycle-environment-id': env.id,
+            'activationkey-id': activation_key.id,
+        })
+        custom_entitites = setup_org_for_a_custom_repo({
+            'url': CUSTOM_REPO_URL,
+            'organization-id': self.session_org.id,
+            'content-view-id': content_view.id,
+            'lifecycle-environment-id': env.id,
+            'activationkey-id': activation_key.id,
+        })
+        with VirtualMachine(distro=DISTRO_RHEL7) as client:
+            client.install_katello_ca()
+            result = client.register_contenthost(
+                self.session_org.label,
+                activation_key.name,
+            )
+            self.assertEqual(result.return_code, 0)
+            client.enable_repo(REPOS['rhst7']['id'])
+            client.install_katello_agent()
+            client.run('yum install -y {0}'.format(FAKE_1_CUSTOM_PACKAGE))
+            # Adding content view filter and content view filter rule to
+            # exclude errata that we are going to track
+            cvf = make_content_view_filter({
+                u'content-view-id': content_view.id,
+                u'inclusion': 'false',
+                u'organization-id': self.session_org.id,
+                u'repository-ids': custom_entitites['repository-id'],
+                u'type': 'erratum',
+            })
+            make_content_view_filter_rule({
+                u'content-view-id': content_view.id,
+                u'content-view-filter-id': cvf['filter-id'],
+                u'errata-id': CUSTOM_REPO_ERRATA_ID,
+            })
+            ContentView.publish({u'id': content_view.id})
+            cvv = ContentView.info({u'id': content_view.id})['versions'][-1]
+            ContentView.version_promote({
+                u'id': cvv['id'],
+                u'organization-id': self.session_org.id,
+                u'to-lifecycle-environment-id': env.id,
+            })
+            # Remove old cv versions to have unambiguous one for testing
+            cvvs = ContentView.info({u'id': content_view.id})['versions']
+            self.assertGreater(len(cvvs), 1)
+            for i in range(len(cvvs)-1):
+                ContentView.version_delete({u'id': cvvs[i]['id']})
+            with Session(self.browser) as session:
+                edit_param(
+                    session,
+                    tab_locator=tab_locators['settings.tab_katello'],
+                    param_name='errata_status_installable',
+                    value_type='dropdown',
+                    param_value='true',
+                )
+                expected_dict = {
+                    'Status': u'Warning',
+                    'Errata': u'Non-security errata installable',
+                    'Subscription': u'Fully entitled',
+                }
+                actual_dict = self.hosts.get_host_properties(
+                    client.hostname, expected_dict.keys())
+                self.assertEqual(expected_dict, actual_dict)
+                edit_param(
+                    session,
+                    tab_locator=tab_locators['settings.tab_katello'],
+                    param_name='errata_status_installable',
+                    value_type='dropdown',
+                    param_value='false',
+                )
+                expected_dict = {
+                    'Status': u'Error',
+                    'Errata': u'Security errata applicable',
+                    'Subscription': u'Fully entitled',
+                }
+                actual_dict = self.hosts.get_host_properties(
+                    client.hostname, expected_dict.keys())
+                self.assertEqual(expected_dict, actual_dict)


### PR DESCRIPTION
Katello-agent is not starting automatically as it should at that moment, so it is impossible to provide run-time results. Instead I put breakpoint and started it manually. Here is a test result:
http://pastebin.test.redhat.com/463780

It doesn't make sense to wait till issue is resolved as it has nothing in common with current PR