### PR TITLE
[6.2.z] UI get job-invocation ouput with asserts

### DIFF
--- a/tests/foreman/ui/test_remoteexecution.py
+++ b/tests/foreman/ui/test_remoteexecution.py
@@ -22,6 +22,7 @@ from robottelo.datafactory import (
     generate_strings_list,
     invalid_values_list,
 )
+from robottelo.cli.job_invocation import JobInvocation
 from robottelo.decorators import stubbed, tier1, tier2, tier3
 from robottelo.helpers import add_remote_execution_ssh_key, get_data_file
 from robottelo.test import UITestCase
@@ -374,6 +375,30 @@ class RemoteExecutionTestCase(UITestCase):
         super(RemoteExecutionTestCase, cls).setUpClass()
         cls.organization = entities.Organization().create()
 
+    def get_client_datetime(self):
+        """Make Javascript call inside of browser session to get exact current
+        date and time. In that way, we will be isolated from any issue that can
+        happen due different environments where test automation code is
+        executing and where browser session is opened. That should help us to
+        have successful run for docker containers or separated virtual machines
+        When calling .getMonth() you need to add +1 to display the correct
+        month. Javascript count always starts at 0, so calling .getMonth() in
+        May will return 4 and not 5.
+
+        @return: Datetime object that contains data for current date and time
+            on a client
+        """
+        script = ('var currentdate = new Date(); return ({0} + "-" + {1} + '
+                  '"-" + {2} + " : " + {3} + ":" + {4});').format(
+            'currentdate.getFullYear()',
+            '(currentdate.getMonth()+1)',
+            'currentdate.getDate()',
+            'currentdate.getHours()',
+            'currentdate.getMinutes()',
+        )
+        client_datetime = self.browser.execute_script(script)
+        return datetime.strptime(client_datetime, '%Y-%m-%d : %H:%M')
+
     @tier2
     def test_positive_run_default_job_template(self):
         """Run a job template against a single host
@@ -404,7 +429,17 @@ class RemoteExecutionTestCase(UITestCase):
                     job_template='Run Command - SSH Default',
                     options_list=[{'name': 'command', 'value': 'ls'}]
                 )
-                self.assertTrue(status)
+                # get job invocation id from the current url
+                invocation_id = self.browser.current_url.rsplit('/', 1)[-1]
+                self.assertTrue(
+                        status,
+                        'host output: {0}'.format(
+                            ' '.join(JobInvocation.get_output({
+                                'id': invocation_id,
+                                'host': client.hostname})
+                            )
+                        )
+                    )
 
     @tier3
     def test_positive_run_custom_job_template(self):
@@ -448,7 +483,17 @@ class RemoteExecutionTestCase(UITestCase):
                     job_template=jobs_template_name,
                     options_list=[{'name': 'command', 'value': 'ls'}]
                 )
-                self.assertTrue(status)
+                # get job invocation id from the current url
+                invocation_id = self.browser.current_url.rsplit('/', 1)[-1]
+                self.assertTrue(
+                        status,
+                        'host output: {0}'.format(
+                            ' '.join(JobInvocation.get_output({
+                                'id': invocation_id,
+                                'host': client.hostname})
+                            )
+                        )
+                    )
 
     @tier3
     def test_positive_run_job_template_multiple_hosts(self):
@@ -485,8 +530,18 @@ class RemoteExecutionTestCase(UITestCase):
                         parameters_list=[{'command': 'ls'}],
                     )
                     strategy, value = locators['job_invocation.status']
-                    self.job.wait_until_element(
-                        (strategy, value % 'succeeded'), 240)
+                    if self.job.wait_until_element(
+                            (strategy, value % 'succeeded'), 240) is not None:
+                        status = True
+                    else:
+                        status = False
+                    # get job invocation id from the current url
+                    invocation_id = self.browser.current_url.rsplit('/', 1)[-1]
+                    self.assertTrue(status, 'host output: {0}'.format(
+                        ' '.join(JobInvocation.get_output({
+                             'id': invocation_id,
+                             'host': client.hostname
+                         }))))
 
     @tier3
     def test_positive_run_scheduled_job_template(self):
@@ -518,8 +573,9 @@ class RemoteExecutionTestCase(UITestCase):
             with Session(self.browser) as session:
                 set_context(session, org=self.organization.name)
                 self.hosts.click(self.hosts.search(client.hostname))
-                plan_time = (datetime.now() + timedelta(seconds=90)).strftime(
-                    "%Y-%m-%d %H:%M")
+                plan_time = (
+                        self.get_client_datetime() + timedelta(seconds=90)
+                        ).strftime("%Y-%m-%d %H:%M")
                 status = self.job.run(
                     job_category='Commands',
                     job_template='Run Command - SSH Default',
@@ -533,8 +589,22 @@ class RemoteExecutionTestCase(UITestCase):
                 strategy, value = locators['job_invocation.status']
                 self.job.wait_until_element_is_not_visible(
                     (strategy, value % 'queued'), 95)
-                self.job.wait_until_element(
-                    (strategy, value % 'succeeded'), 30)
+                if self.job.wait_until_element(
+                        (strategy, value % 'succeeded'), 180) is not None:
+                    status2 = True
+                else:
+                    status2 = False
+                # get job invocation id from the current url
+                invocation_id = self.browser.current_url.rsplit('/', 1)[-1]
+                self.assertTrue(
+                        status2,
+                        'host output: {0}'.format(
+                            ' '.join(JobInvocation.get_output({
+                                'id': invocation_id,
+                                'host': client.hostname})
+                            )
+                        )
+                    )
 
     @stubbed()
     @tier3


### PR DESCRIPTION
UI part of the changes requested in issue #4402 
For test results see the standalone automation job number 379, the rex tests there fail, which is expected with this setup as the virtual hosts can't be reached from behind the NAT, though the results show that the job invocation output is correctly propagated to give a hint about the error, which was the intent behind this PR, in this case the job output is:

```
Error initializing command #<Proxy::RemoteExecution::Ssh::Dispatcher::Command:0x007fae7c1be720>
SocketError getaddrinfo: Name or service not known
Exit status: EXCEPTION
```

Also some other changes were made, test_positive_run_scheduled_job_template had trouble with datetime conversion, therefore i borrowed get_client_datetime from from test_syncplan (btw this issue uncovered https://bugzilla.redhat.com/show_bug.cgi?id=1431190). 