### PR TITLE
[6.2.z] BZ 1379856 test coverage

### DIFF
--- a/robottelo/vm.py
+++ b/robottelo/vm.py
@@ -256,7 +256,8 @@ class VirtualMachine(object):
                 'Failed to download and install the katello-ca rpm')
 
     def register_contenthost(self, org, activation_key=None, lce=None,
-                             force=True, releasever=None):
+                             force=True, releasever=None, username=None,
+                             password=None):
         """Registers content host on foreman server using activation-key. This
         can be done in two ways: either by specifying organization name and
         activation key name or by specifying organization name and lifecycle
@@ -265,21 +266,28 @@ class VirtualMachine(object):
 
         :param activation_key: Activation key name to register content host
             with.
+        :param lce: lifecycle environment name to which register the content
+            host.
         :param org: Organization name to register content host for.
         :param force: Register the content host even if it's already registered
         :param releasever: Set a release version
+        :param username: a user name to register the content host with
+        :param password: the user password
         :return: SSHCommandResult instance filled with the result of the
             registration.
-
         """
         cmd = (u'subscription-manager register --org {0}'.format(org))
         if activation_key is not None:
             cmd += u' --activationkey {0}'.format(activation_key)
         elif lce is not None:
+            if username is None and password is None:
+                username = settings.server.admin_username
+                password = settings.server.admin_password
+
             cmd += u' --environment {0} --username {1} --password {2}'.format(
                 lce,
-                settings.server.admin_username,
-                settings.server.admin_password,
+                username,
+                password,
             )
         else:
             raise VirtualMachineError(

--- a/tests/foreman/cli/test_contentview.py
+++ b/tests/foreman/cli/test_contentview.py
@@ -27,19 +27,26 @@ from robottelo.cli.factory import (
     make_activation_key,
     make_content_host,
     make_content_view,
+    make_filter,
     make_lifecycle_environment,
     make_org,
     make_product,
     make_repository,
+    make_role,
     make_user,
 )
+from robottelo.cli.filter import Filter
+from robottelo.cli.host import Host
 from robottelo.cli.puppetmodule import PuppetModule
 from robottelo.cli.repository import Repository
 from robottelo.cli.repository_set import RepositorySet
+from robottelo.cli.role import Role
 from robottelo.cli.subscription import Subscription
+from robottelo.cli.user import User
 from robottelo.constants import (
     CUSTOM_PUPPET_REPO,
     DEFAULT_CV,
+    DISTRO_RHEL7,
     DOCKER_REGISTRY_HUB,
     DOCKER_UPSTREAM_NAME,
     ENVIRONMENT,
@@ -61,6 +68,7 @@ from robottelo.decorators import (
 )
 from robottelo.ssh import upload_file
 from robottelo.test import CLITestCase
+from robottelo.vm import VirtualMachine
 from robottelo.vm_capsule import CapsuleVirtualMachine
 
 
@@ -2071,6 +2079,168 @@ class ContentViewTestCase(CLITestCase):
         })
         content_view = ContentView.info({u'id': content_view['id']})
         self.assertEqual(content_view['content-host-count'], '1')
+
+    @tier3
+    @run_only_on('sat')
+    def test_positive_subscribe_host_with_restricted_user_permissions(self):
+        """Attempt to subscribe a host with restricted user permissions.
+
+        @id: 7b5ec90b-3942-48a9-9cc1-a361e698d16d
+
+        @BZ: 1379856
+
+        @steps:
+
+            1. Create organization, content view with custom yum repository.
+            2. Publish the content view
+            3. Create a user within the created organization with the following
+               permissions::
+
+                - (Miscellaneous) [my_organizations]
+                - Environment [view_environments]
+                - Organization [view_organizations]
+                - Katello::Subscription [view_subscriptions,
+                    attach_subscriptions,
+                    unattach_subscriptions,
+                    import_manifest,
+                    delete_manifest]
+                - Katello::ContentView [view_content_views]
+                - ConfigGroup [view_config_groups]
+                - Hostgroup view_hostgroups
+                - Host [view_hosts, create_hosts, edit_hosts]
+                - Location [view_locations]
+                - Katello::KTEnvironment [view_lifecycle_environments]
+                - SmartProxy [view_smart_proxies, view_capsule_content]
+                - Architecture [view_architectures]
+                - Katello::System ['create_content_hosts']
+
+        @assert: host subscribed to content view with user that has restricted
+            permissions.
+
+        @CaseLevel: System
+        """
+        # prepare the user and the required permissions data
+        user_name = gen_alphanumeric()
+        user_password = gen_alphanumeric()
+        required_rc_permissions = {
+            '(Miscellaneous)': ['my_organizations'],
+            'Environment': ['view_environments'],
+            'Organization': ['view_organizations'],
+            'Katello::Subscription': [
+                'view_subscriptions',
+                'attach_subscriptions',
+                'unattach_subscriptions',
+                'import_manifest',
+                'delete_manifest'
+            ],
+            'Katello::ContentView': ['view_content_views'],
+            'ConfigGroup': ['view_config_groups'],
+            'Hostgroup': ['view_hostgroups'],
+            'Host': ['view_hosts', 'create_hosts', 'edit_hosts'],
+            'Location': ['view_locations'],
+            'Katello::KTEnvironment': ['view_lifecycle_environments'],
+            'SmartProxy': ['view_smart_proxies', 'view_capsule_content'],
+            'Architecture': ['view_architectures'],
+            'Katello::System': ['create_content_hosts']
+        }
+        # Create an organization
+        org = make_org()
+        # Create a non admin user, for the moment without any permissions
+        user = make_user({
+            'admin': False,
+            'default-organization-id': org['id'],
+            'organization-ids': [org['id']],
+            'login': user_name,
+            'password': user_password,
+        })
+        # Create a new role
+        role = make_role()
+        # Get the available permissions
+        available_permissions = Filter.available_permissions()
+        # group the available permissions by resource type
+        available_rc_permissions = {}
+        for permission in available_permissions:
+            permission_resource = permission['resource']
+            if permission_resource not in available_rc_permissions:
+                available_rc_permissions[permission_resource] = []
+            available_rc_permissions[permission_resource].append(
+                permission)
+        # create only the required role permissions per resource type
+        for resource_type, permission_names in required_rc_permissions.items():
+            # assert that the required resource type is available
+            self.assertIn(resource_type, available_rc_permissions)
+            available_permission_names = [
+                permission['name']
+                for permission in available_rc_permissions[resource_type]
+                if permission['name'] in permission_names
+            ]
+            # assert that all the required permissions are available
+            self.assertEqual(set(permission_names),
+                             set(available_permission_names))
+            # Create the current resource type role permissions
+            make_filter({
+                'role-id': role['id'],
+                'permissions': permission_names,
+            })
+        # Add the created and initiated role with permissions to user
+        User.add_role({'id': user['id'], 'role-id': role['id']})
+        # assert that the user is not an admin one and cannot read the current
+        # role info (note: view_roles is not in the required permissions)
+        with self.assertRaises(CLIReturnCodeError) as context:
+            Role.with_user(user_name, user_password).info(
+                {'id': role['id']})
+        self.assertIn(
+            'Forbidden - server refused to process the request',
+            context.exception.stderr
+        )
+        # Create a lifecycle environment
+        env = make_lifecycle_environment({'organization-id': org['id']})
+        # Create a product
+        product = make_product({'organization-id': org['id']})
+        # Create a yum repository and synchronize
+        repo = make_repository({
+            'product-id': product['id'],
+            'url': FAKE_1_YUM_REPO
+        })
+        Repository.synchronize({'id': repo['id']})
+        # Create a content view, add the yum repository and publish
+        content_view = make_content_view({u'organization-id': org['id']})
+        ContentView.add_repository({
+            'id': content_view['id'],
+            'organization-id': org['id'],
+            'repository-id': repo['id'],
+        })
+        ContentView.publish({u'id': content_view['id']})
+        content_view = ContentView.info({u'id': content_view['id']})
+        # assert that the content view has been published and has versions
+        self.assertGreater(len(content_view['versions']), 0)
+        content_view_version = content_view['versions'][0]
+        # Promote the content view version to the created environment
+        ContentView.version_promote({
+            'id': content_view_version['id'],
+            'to-lifecycle-environment-id': env['id'],
+        })
+        # assert that the user can read the content view info as per required
+        # permissions
+        user_content_view = ContentView.with_user(
+            user_name, user_password).info({'id': content_view['id']})
+        # assert that this is the same content view
+        self.assertEqual(content_view['name'], user_content_view['name'])
+        # create a client host and register it with the created user
+        with VirtualMachine(distro=DISTRO_RHEL7) as host_client:
+            host_client.install_katello_ca()
+            result = host_client.register_contenthost(
+                org['name'],
+                lce=u'{0}/{1}'.format(env['name'], content_view['name']),
+                username=user_name,
+                password=user_password
+            )
+            self.assertIn(u'The system has been registered with ID',
+                          u''.join(result.stdout))
+            # check that the client host exist in the system
+            org_hosts = Host.list({'organization-id': org['id']})
+            self.assertEqual(len(org_hosts), 1)
+            self.assertEqual(org_hosts[0]['name'], host_client.hostname)
 
     @tier2
     @run_only_on('sat')


### PR DESCRIPTION
qe_coverage BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1379856

```console
(sat-6.2.z) dlezz@elysion:~/projects/robottelo-fork$ py.test tests/foreman/cli/test_contentview.py::ContentViewTestCase::test_positive_subscribe_host_with_restricted_user_permissions -v 
================================================= test session starts ==================================================
platform linux2 -- Python 2.7.13, pytest-2.9.2, py-1.4.32, pluggy-0.3.1 -- /home/dlezz/.pyenv/versions/sat-6.2.z/bin/python
cachedir: .cache
rootdir: /home/dlezz/projects/robottelo-fork, inifile: 
plugins: xdist-1.15.0, services-1.1.14, cov-2.3.1
collected 68 items 
2017-03-15 15:40:26 - conftest - DEBUG - Found WONTFIX in decorated tests ['1156555', '1269196', '1245334', '1217635', '1226425', '1204686', '1267224', '1103157', '1230902', '1214312', '1079482']

2017-03-15 15:40:26 - conftest - DEBUG - Collected 1 test cases


tests/foreman/cli/test_contentview.py::ContentViewTestCase::test_positive_subscribe_host_with_restricted_user_permissions <- robottelo/decorators/__init__.py PASSED

============================================== 1 passed in 610.69 seconds ==============================================
```

as we refactored VirtualMachine provide one test to check that nothing was broken
```console
(sat-6.2.z) dlezz@elysion:~/projects/robottelo-fork$ py.test tests/foreman/cli/test_contenthost.py::ContentHostTestCase::test_positive_list -v 
================================================= test session starts ==================================================
platform linux2 -- Python 2.7.13, pytest-2.9.2, py-1.4.32, pluggy-0.3.1 -- /home/dlezz/.pyenv/versions/sat-6.2.z/bin/python
cachedir: .cache
rootdir: /home/dlezz/projects/robottelo-fork, inifile: 
plugins: xdist-1.15.0, services-1.1.14, cov-2.3.1
collected 17 items 
2017-03-15 15:40:30 - conftest - DEBUG - Found WONTFIX in decorated tests ['1156555', '1269196', '1245334', '1217635', '1226425', '1204686', '1267224', '1103157', '1230902', '1214312', '1079482']

2017-03-15 15:40:30 - conftest - DEBUG - Collected 1 test cases


tests/foreman/cli/test_contenthost.py::ContentHostTestCase::test_positive_list PASSED

============================================== 1 passed in 238.88 seconds ==============================================
(sat-6.2.z) dlezz@elysion:~/projects/robottelo-fork$ 
```