### PR TITLE
KatelloAgent: Use internal/CDN Tools appropriately

### DIFF
--- a/robottelo/config/base.py
+++ b/robottelo/config/base.py
@@ -741,6 +741,7 @@ class Settings(object):
         self._configured = False
         self._validation_errors = []
         self.browser = None
+        self.cdn = None
         self.locale = None
         self.project = None
         self.reader = None
@@ -748,6 +749,8 @@ class Settings(object):
         self.rhel7_repo = None
         self.rhel6_os = None
         self.rhel7_os = None
+        self.capsule_repo = None
+        self.sattools_repo = None
         self.screenshots_path = None
         self.saucelabs_key = None
         self.saucelabs_user = None
@@ -840,12 +843,16 @@ class Settings(object):
         )
         self.browser = self.reader.get(
             'robottelo', 'browser', 'selenium')
+        self.cdn = self.reader.get('robottelo', 'cdn', True, bool)
         self.locale = self.reader.get('robottelo', 'locale', 'en_US.UTF-8')
         self.project = self.reader.get('robottelo', 'project', 'sat')
         self.rhel6_repo = self.reader.get('robottelo', 'rhel6_repo', None)
         self.rhel7_repo = self.reader.get('robottelo', 'rhel7_repo', None)
         self.rhel6_os = self.reader.get('robottelo', 'rhel6_os', None)
         self.rhel7_os = self.reader.get('robottelo', 'rhel7_os', None)
+        self.capsule_repo = self.reader.get('robottelo', 'capsule_repo', None)
+        self.sattools_repo = self.reader.get(
+            'robottelo', 'sattools_repo', None)
         self.screenshots_path = self.reader.get(
             'robottelo', 'screenshots_path', '/tmp/robottelo/screenshots')
         self.run_one_datapoint = self.reader.get(

--- a/tests/foreman/cli/test_host.py
+++ b/tests/foreman/cli/test_host.py
@@ -1552,16 +1552,26 @@ class KatelloAgentTestCase(CLITestCase):
             u'lifecycle-environment-id': KatelloAgentTestCase.env['id'],
             u'organization-id': KatelloAgentTestCase.org['id'],
         })
-        # Add subscription to Satellite Tools repo to activation key
-        setup_org_for_a_rh_repo({
-            u'product': PRDS['rhel'],
-            u'repository-set': REPOSET['rhst7'],
-            u'repository': REPOS['rhst7']['name'],
-            u'organization-id': KatelloAgentTestCase.org['id'],
-            u'content-view-id': KatelloAgentTestCase.content_view['id'],
-            u'lifecycle-environment-id': KatelloAgentTestCase.env['id'],
-            u'activationkey-id': KatelloAgentTestCase.activation_key['id'],
-        })
+        if settings.cdn:
+            # Add subscription to Satellite Tools repo to activation key
+            setup_org_for_a_rh_repo({
+                u'product': PRDS['rhel'],
+                u'repository-set': REPOSET['rhst7'],
+                u'repository': REPOS['rhst7']['name'],
+                u'organization-id': KatelloAgentTestCase.org['id'],
+                u'content-view-id': KatelloAgentTestCase.content_view['id'],
+                u'lifecycle-environment-id': KatelloAgentTestCase.env['id'],
+                u'activationkey-id': KatelloAgentTestCase.activation_key['id'],
+            })
+        else:
+            # Create custom internal Tools repo, add to activation key
+            setup_org_for_a_custom_repo({
+                u'url': settings.sattools_repo,
+                u'organization-id': KatelloAgentTestCase.org['id'],
+                u'content-view-id': KatelloAgentTestCase.content_view['id'],
+                u'lifecycle-environment-id': KatelloAgentTestCase.env['id'],
+                u'activationkey-id': KatelloAgentTestCase.activation_key['id'],
+            })
         # Create custom repo, add subscription to activation key
         setup_org_for_a_custom_repo({
             u'url': FAKE_0_YUM_REPO,
@@ -1588,7 +1598,8 @@ class KatelloAgentTestCase(CLITestCase):
             KatelloAgentTestCase.activation_key['name'],
         )
         self.host = Host.info({'name': self.client.hostname})
-        self.client.enable_repo(REPOS['rhst7']['id'])
+        if settings.cdn:
+            self.client.enable_repo(REPOS['rhst7']['id'])
         self.client.install_katello_agent()
 
     @tier3


### PR DESCRIPTION
- add new settings: cdn, capsule_repo, sattools_repo
- use internal/CDN Tools according to `cdn` setting

(addresses #4429 for master)