### PR TITLE
workaround for katello_agent_install() - BZ#1431747

### DIFF
--- a/robottelo/vm.py
+++ b/robottelo/vm.py
@@ -16,6 +16,7 @@ import time
 from robottelo import ssh
 from robottelo.config import settings
 from robottelo.constants import DISTRO_RHEL6, DISTRO_RHEL7
+from robottelo.decorators import bz_bug_is_open
 from robottelo.helpers import install_katello_ca, remove_katello_ca
 
 logger = logging.getLogger(__name__)
@@ -240,6 +241,13 @@ class VirtualMachine(object):
         result = self.run('rpm -q katello-agent')
         if result.return_code != 0:
             raise VirtualMachineError('Failed to install katello-agent')
+        if bz_bug_is_open('1431747'):
+            gofer_start = self.run('service goferd start')
+            if gofer_start.return_code != 0:
+                raise VirtualMachineError('Failed to start katello-agent')
+        gofer_check = self.run('service goferd status')
+        if gofer_check.return_code != 0:
+            raise VirtualMachineError('katello-agent is not running')
 
     def install_katello_ca(self):
         """Downloads and installs katello-ca rpm on the virtual machine.


### PR DESCRIPTION
- add workaround to katello_agent_install() to start goferd
- add goferd service check to katello_agent_install()

workaround for https://github.com/SatelliteQE/robottelo/issues/4429

```
In [16]: vm.install_katello_agent()
2017-03-14 14:03:04 - robottelo.ssh - INFO - Instantiated Paramiko client 0x7f6420fb6890
2017-03-14 14:03:04 - robottelo.ssh - DEBUG - Connected to [10.8.30.166]
2017-03-14 14:03:04 - robottelo.ssh - DEBUG - >>> yum install -y katello-agent
2017-03-14 14:03:28 - robottelo.ssh - DEBUG - <<< stdout
Loaded plugins: langpacks, product-id, search-disabled-repos, subscription-
              : manager
Resolving Dependencies
--> Running transaction check
---> Package katello-agent.noarch 0:2.9.0-1.el7sat will be installed
--> Processing Dependency: gofer >= 2.5 for package: katello-agent-2.9.0-1.el7sat.noarch
--> Processing Dependency: pulp-rpm-handlers >= 2.6 for package: katello-agent-2.9.0-1.el7sat.noarch
--> Processing Dependency: python-gofer-proton >= 2.5 for package: katello-agent-2.9.0-1.el7sat.noarch
--> Processing Dependency: python-pulp-agent-lib >= 2.6 for package: katello-agent-2.9.0-1.el7sat.noarch
--> Processing Dependency: katello-agent-fact-plugin for package: katello-agent-2.9.0-1.el7sat.noarch
--> Running transaction check
---> Package gofer.noarch 0:2.7.6-1.el7sat will be installed
--> Processing Dependency: python-gofer = 2.7.6 for package: gofer-2.7.6-1.el7sat.noarch
---> Package katello-agent-fact-plugin.noarch 0:2.9.0-1.el7sat will be installed
---> Package pulp-rpm-handlers.noarch 0:2.8.7.8-1.el7sat will be installed
--> Processing Dependency: python-pulp-rpm-common >= 2.8.3 for package: pulp-rpm-handlers-2.8.7.8-1.el7sat.noarch
---> Package python-gofer-proton.noarch 0:2.7.6-1.el7sat will be installed
--> Processing Dependency: python-qpid-proton >= 0.9-5 for package: python-gofer-proton-2.7.6-1.el7sat.noarch
---> Package python-pulp-agent-lib.noarch 0:2.8.7.6-1.el7sat will be installed
--> Processing Dependency: python-pulp-common = 2.8.7.6 for package: python-pulp-agent-lib-2.8.7.6-1.el7sat.noarch
--> Running transaction check
---> Package python-gofer.noarch 0:2.7.6-1.el7sat will be installed
---> Package python-pulp-common.noarch 0:2.8.7.6-1.el7sat will be installed
--> Processing Dependency: python-isodate >= 0.5.0-1.pulp for package: python-pulp-common-2.8.7.6-1.el7sat.noarch
---> Package python-pulp-rpm-common.noarch 0:2.8.7.8-1.el7sat will be installed
---> Package python-qpid-proton.x86_64 0:0.9-16.el7 will be installed
--> Processing Dependency: qpid-proton-c(x86-64) = 0.9-16.el7 for package: python-qpid-proton-0.9-16.el7.x86_64
--> Processing Dependency: libqpid-proton.so.2()(64bit) for package: python-qpid-proton-0.9-16.el7.x86_64
--> Running transaction check
---> Package python-isodate.noarch 0:0.5.0-4.el7sat will be installed
---> Package qpid-proton-c.x86_64 0:0.9-16.el7 will be installed
--> Finished Dependency Resolution

Dependencies Resolved

================================================================================
 Package   Arch   Version          Repository                              Size
================================================================================
Installing:
 katello-agent
           noarch 2.9.0-1.el7sat   rhel-7-server-satellite-tools-6.2-rpms  27 k
Installing for dependencies:
 gofer     noarch 2.7.6-1.el7sat   rhel-7-server-satellite-tools-6.2-rpms  85 k
 katello-agent-fact-plugin
           noarch 2.9.0-1.el7sat   rhel-7-server-satellite-tools-6.2-rpms  11 k
 pulp-rpm-handlers
           noarch 2.8.7.8-1.el7sat rhel-7-server-satellite-tools-6.2-rpms  75 k
 python-gofer
           noarch 2.7.6-1.el7sat   rhel-7-server-satellite-tools-6.2-rpms 132 k
 python-gofer-proton
           noarch 2.7.6-1.el7sat   rhel-7-server-satellite-tools-6.2-rpms  54 k
 python-isodate
           noarch 0.5.0-4.el7sat   rhel-7-server-satellite-tools-6.2-rpms  51 k
 python-pulp-agent-lib
           noarch 2.8.7.6-1.el7sat rhel-7-server-satellite-tools-6.2-rpms  93 k
 python-pulp-common
           noarch 2.8.7.6-1.el7sat rhel-7-server-satellite-tools-6.2-rpms 126 k
 python-pulp-rpm-common
           noarch 2.8.7.8-1.el7sat rhel-7-server-satellite-tools-6.2-rpms  68 k
 python-qpid-proton
           x86_64 0.9-16.el7       rhel-7-server-satellite-tools-6.2-rpms 200 k
 qpid-proton-c
           x86_64 0.9-16.el7       rhel-7-server-satellite-tools-6.2-rpms 135 k

Transaction Summary
================================================================================
Install  1 Package (+11 Dependent packages)

Total download size: 1.0 M
Installed size: 3.1 M
Downloading packages:
Public key for katello-agent-2.9.0-1.el7sat.noarch.rpm is not installed
--------------------------------------------------------------------------------
Total                                              502 kB/s | 1.0 MB  00:02     
Retrieving key from file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
Running transaction check
Running transaction test
Transaction test succeeded
Running transaction
  Installing : python-gofer-2.7.6-1.el7sat.noarch                          1/12 
  Installing : gofer-2.7.6-1.el7sat.noarch                                 2/12 
  Installing : python-isodate-0.5.0-4.el7sat.noarch                        3/12 
  Installing : python-pulp-common-2.8.7.6-1.el7sat.noarch                  4/12 
  Installing : python-pulp-agent-lib-2.8.7.6-1.el7sat.noarch               5/12 
  Installing : python-pulp-rpm-common-2.8.7.8-1.el7sat.noarch              6/12 
  Installing : pulp-rpm-handlers-2.8.7.8-1.el7sat.noarch                   7/12 
  Installing : katello-agent-fact-plugin-2.9.0-1.el7sat.noarch             8/12 
  Installing : qpid-proton-c-0.9-16.el7.x86_64                             9/12 
  Installing : python-qpid-proton-0.9-16.el7.x86_64                       10/12 
  Installing : python-gofer-proton-2.7.6-1.el7sat.noarch                  11/12 
  Installing : katello-agent-2.9.0-1.el7sat.noarch                        12/12 
Note: Forwarding request to 'systemctl enable goferd.service'.
Created symlink from /etc/systemd/system/multi-user.target.wants/goferd.service to /usr/lib/systemd/system/goferd.service.
  Verifying  : python-qpid-proton-0.9-16.el7.x86_64                        1/12 
  Verifying  : python-pulp-common-2.8.7.6-1.el7sat.noarch                  2/12 
  Verifying  : gofer-2.7.6-1.el7sat.noarch                                 3/12 
  Verifying  : python-pulp-agent-lib-2.8.7.6-1.el7sat.noarch               4/12 
  Verifying  : qpid-proton-c-0.9-16.el7.x86_64                             5/12 
  Verifying  : katello-agent-fact-plugin-2.9.0-1.el7sat.noarch             6/12 
  Verifying  : python-isodate-0.5.0-4.el7sat.noarch                        7/12 
  Verifying  : katello-agent-2.9.0-1.el7sat.noarch                         8/12 
  Verifying  : python-gofer-proton-2.7.6-1.el7sat.noarch                   9/12 
  Verifying  : pulp-rpm-handlers-2.8.7.8-1.el7sat.noarch                  10/12 
  Verifying  : python-gofer-2.7.6-1.el7sat.noarch                         11/12 
  Verifying  : python-pulp-rpm-common-2.8.7.8-1.el7sat.noarch             12/12 

Installed:
  katello-agent.noarch 0:2.9.0-1.el7sat                                         

Dependency Installed:
  gofer.noarch 0:2.7.6-1.el7sat                                                 
  katello-agent-fact-plugin.noarch 0:2.9.0-1.el7sat                             
  pulp-rpm-handlers.noarch 0:2.8.7.8-1.el7sat                                   
  python-gofer.noarch 0:2.7.6-1.el7sat                                          
  python-gofer-proton.noarch 0:2.7.6-1.el7sat                                   
  python-isodate.noarch 0:0.5.0-4.el7sat                                        
  python-pulp-agent-lib.noarch 0:2.8.7.6-1.el7sat                               
  python-pulp-common.noarch 0:2.8.7.6-1.el7sat                                  
  python-pulp-rpm-common.noarch 0:2.8.7.8-1.el7sat                              
  python-qpid-proton.x86_64 0:0.9-16.el7                                        
  qpid-proton-c.x86_64 0:0.9-16.el7                                             

Complete!

2017-03-14 14:03:28 - robottelo.ssh - DEBUG - <<< stderr
warning: /var/cache/yum/x86_64/7Server/rhel-7-server-satellite-tools-6.2-rpms/packages/katello-agent-2.9.0-1.el7sat.noarch.rpm: Header V3 RSA/SHA256 Signature, key ID fd431d51: NOKEY
Importing GPG key 0xFD431D51:
 Userid     : "Red Hat, Inc. (release key 2) <security@redhat.com>"
 Fingerprint: 567e 347a d004 4ade 55ba 8a5f 199e 2f91 fd43 1d51
 Package    : redhat-release-server-7.3-7.el7.x86_64 (@anaconda/7.3)
 From       : /etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
Importing GPG key 0x2FA658E0:
 Userid     : "Red Hat, Inc. (auxiliary key) <security@redhat.com>"
 Fingerprint: 43a6 e49c 4a38 f4be 9abf 2a53 4568 9c88 2fa6 58e0
 Package    : redhat-release-server-7.3-7.el7.x86_64 (@anaconda/7.3)
 From       : /etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release

2017-03-14 14:03:28 - robottelo.ssh - INFO - Destroying Paramiko client 0x7f6420fb6890
2017-03-14 14:03:28 - robottelo.ssh - INFO - Destroyed Paramiko client 0x7f6420fb6890
2017-03-14 14:03:29 - robottelo.ssh - INFO - Instantiated Paramiko client 0x7f6429965190
2017-03-14 14:03:29 - robottelo.ssh - DEBUG - Connected to [10.8.30.166]
2017-03-14 14:03:29 - robottelo.ssh - DEBUG - >>> rpm -q katello-agent
2017-03-14 14:03:29 - robottelo.ssh - DEBUG - <<< stdout
katello-agent-2.9.0-1.el7sat.noarch

2017-03-14 14:03:29 - robottelo.ssh - INFO - Destroying Paramiko client 0x7f6429965190
2017-03-14 14:03:29 - robottelo.ssh - INFO - Destroyed Paramiko client 0x7f6429965190
2017-03-14 14:03:29 - robottelo.decorators - INFO - Bugzilla bug 1431747 not in cache. Fetching.
2017-03-14 14:03:30 - robottelo.decorators - WARNING - Unauthenticated call made to BZ API, no flags data will be available
2017-03-14 14:03:31 - robottelo.ssh - INFO - Instantiated Paramiko client 0x7f641b7c1d10
2017-03-14 14:03:31 - robottelo.ssh - DEBUG - Connected to [10.8.30.166]
2017-03-14 14:03:31 - robottelo.ssh - DEBUG - >>> service goferd start
2017-03-14 14:03:32 - robottelo.ssh - DEBUG - <<< stderr
Redirecting to /bin/systemctl start  goferd.service

2017-03-14 14:03:32 - robottelo.ssh - INFO - Destroying Paramiko client 0x7f641b7c1d10
2017-03-14 14:03:32 - robottelo.ssh - INFO - Destroyed Paramiko client 0x7f641b7c1d10
2017-03-14 14:03:33 - robottelo.ssh - INFO - Instantiated Paramiko client 0x7f641b7c8d10
2017-03-14 14:03:33 - robottelo.ssh - DEBUG - Connected to [10.8.30.166]
2017-03-14 14:03:33 - robottelo.ssh - DEBUG - >>> service goferd status
2017-03-14 14:03:34 - robottelo.ssh - DEBUG - <<< stdout
● goferd.service - Gofer Agent
   Loaded: loaded (/usr/lib/systemd/system/goferd.service; enabled; vendor preset: disabled)
   Active: active (running) since Tue 2017-03-14 09:03:32 EDT; 1s ago
 Main PID: 10737 (python)
   CGroup: /system.slice/goferd.service
           └─10737 python /usr/bin/goferd --foreground

Mar 14 09:03:32 140067934575376.com goferd[10737]: [INFO][Thread-1] gofer.rmi.store:114 - Using: /var/lib/gofer/messaging/pending/demo
Mar 14 09:03:32 140067934575376.com goferd[10737]: [WARNING][MainThread] gofer.agent.plugin:639 - plugin:demo, DISABLED
Mar 14 09:03:32 140067934575376.com goferd[10737]: [INFO][Thread-2] gofer.rmi.store:114 - Using: /var/lib/gofer/messaging/pending/katelloplugin
Mar 14 09:03:32 140067934575376.com goferd[10737]: [INFO][Thread-3] gofer.rmi.store:114 - Using: /var/lib/gofer/messaging/pending/katelloplugin
Mar 14 09:03:33 140067934575376.com goferd[10737]: [INFO][MainThread] gofer.agent.plugin:682 - plugin:katelloplugin loaded using: /usr/lib/gofer/plugins/katelloplugin.py
Mar 14 09:03:33 140067934575376.com goferd[10737]: [INFO][MainThread] rhsm.connection:830 - Connection built: host=subscription.rhsm.redhat.com port=443 handler=/subscription auth=identity_cert ca_dir=/etc/rhsm/ca/ verify=False
Mar 14 09:03:33 140067934575376.com goferd[10737]: [INFO][MainThread] katelloplugin:178 - Using /etc/rhsm/ca/redhat-uep.pem as the ca cert for qpid connection
Mar 14 09:03:33 140067934575376.com goferd[10737]: [INFO][MainThread] rhsm.connection:830 - Connection built: host=subscription.rhsm.redhat.com port=443 handler=/subscription auth=identity_cert ca_dir=/etc/rhsm/ca/ verify=False
Mar 14 09:03:33 140067934575376.com goferd[10737]: Loaded plugins: langpacks, product-id
Mar 14 09:03:34 140067934575376.com goferd[10737]: [INFO][MainThread] katelloplugin:409 - reporting: {'enabled_repos': {'repos': [{'baseurl': ['https://cdn.redhat.com/content/dist/rhel/server/7/7Server/x86_64/os'], 'repositoryid': 'rhel-7-server-rpms'}, {'baseurl': ['https://cdn.redhat.com/content/dist/rhel/server/7/7Server/x86_64/sat-tools/6.2/os'], 'repositoryid': 'rhel-7-server-satellite-tools-6.2-rpms'}, {'baseurl': ['https://cdn.redhat.com/content/dist/rhel/server/7/7Server/x86_64/highavailability/os'], 'repositoryid': 'rhel-ha-for-rhel-7-server-rpms'}]}}

2017-03-14 14:03:34 - robottelo.ssh - DEBUG - <<< stderr
Redirecting to /bin/systemctl status  goferd.service

2017-03-14 14:03:34 - robottelo.ssh - INFO - Destroying Paramiko client 0x7f641b7c8d10
2017-03-14 14:03:34 - robottelo.ssh - INFO - Destroyed Paramiko client 0x7f641b7c8d10

In [17]:
```