### PR TITLE
[6.3][cherry-pick] Implement function locking

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -9,6 +9,7 @@ mock==2.0.0
 paramiko==2.1.2
 pygal==2.3.1
 pytest==3.0.6
+pytest_services==1.1.14
 requests==2.13.0
 selenium==2.48.0  # pyup: ignore
 six==1.10.0

--- a/robottelo/decorators/func_locker.py
+++ b/robottelo/decorators/func_locker.py
@@ -1,0 +1,171 @@
+# -*- encoding: utf-8 -*-
+"""Implements test function locking, using pytest_services file locking
+
+Usage::
+
+
+    from robottelo.decorators.func_locker import (
+        locking_function,
+        lock_function,
+     )
+
+    # in many cases we have tests that need some test functions to run isolated
+    # from other py.test workers when used in --boxed mode
+    class SomeTestCase(TestCase):
+
+        @classmethod
+        @lock_function
+        def setUpClass(cls):
+            pass
+
+    # in other cases we want only a portion of the test function to be isolated
+    class SomeTestCase(TestCase):
+
+        @classmethod
+        def setUpClass(cls):
+
+            with locking_function(cls.setUpClass, 'publish_puppet_class'):
+                # call the publish function
+
+
+    # some tests can be in conflicts with other tests parts
+    class SomeTestCase(TestCase):
+
+       @lock_function
+       def test_to_lock(self):
+          pass
+
+       def test_that_conflict_with_test_to_lock(self)
+            with locking_function(self.test_to_lock):
+                # do some operations that conflict with test_to_lock
+"""
+import functools
+import logging
+import os
+import tempfile
+import unittest2
+
+from contextlib import contextmanager
+
+from pytest_services.locks import file_lock
+
+logger = logging.getLogger(__name__)
+
+TEMP_ROOT_DIR = 'robottelo'
+TEMP_FUNC_LOCK_DIR = 'lock_functions'
+LOCK_DIR = None
+
+
+def _get_temp_lock_function_dir(create=True):
+    global LOCK_DIR
+    if LOCK_DIR is not None:
+        return LOCK_DIR
+    tmp_lock_dir = os.path.join(tempfile.gettempdir(), TEMP_ROOT_DIR,
+                                TEMP_FUNC_LOCK_DIR)
+    if create and not os.path.exists(tmp_lock_dir):
+        try:
+            # it can happen that the workers try to create this path at the
+            # same time
+            os.makedirs(tmp_lock_dir)
+        except OSError:
+            if not os.path.exists(tmp_lock_dir):
+                raise
+
+    LOCK_DIR = tmp_lock_dir
+
+    return LOCK_DIR
+
+
+def _get_function_name(function, context=None):
+    """Return a string representation of the function as
+     module_path.Class_name.function_name, if context is defined return
+     module_path.Class_name.function_name.context
+     """
+    names = [function.__module__]
+    if hasattr(function, 'im_self'):
+
+        self = function.im_self
+        if isinstance(self, type):
+            # this is a class method
+            names.append(self.__name__)
+        else:
+            # this is an instance
+            names.append(self.__class__.__name__)
+
+    names.append(function.__name__)
+    if context is not None:
+        names.append(context)
+    return '.'.join(names)
+
+
+def _get_context_function_name(context, function):
+    """Return a string representation of the function as
+    module_path.Class_name.function_name
+    """
+    names = [function.__module__]
+    if context and hasattr(context, function.__name__):
+
+        if isinstance(context, type):
+            context_class = context
+        else:
+            context_class = context.__class__
+
+        if issubclass(context_class, unittest2.TestCase):
+            names.append(context_class.__name__)
+
+    names.append(function.__name__)
+    return '.'.join(names)
+
+
+def _get_function_lock_path(function, context=None):
+    """Return the path of the file to lock"""
+    return os.path.join(
+        _get_temp_lock_function_dir(),
+        _get_function_name(function, context=context)
+    )
+
+
+def _get_context_function_lock_path(context, function):
+    """Return the path of the file to lock"""
+    return os.path.join(
+        _get_temp_lock_function_dir(),
+        _get_context_function_name(context, function)
+    )
+
+
+def lock_function(func):
+    """Generic function locker, lock any decorated function, any parallel
+     pytest xdist worker will wait for this function to finish"""
+
+    @functools.wraps(func)
+    def function_wrapper(*args, **kwargs):
+        if len(args) > 0:
+            context = args[0]
+        else:
+            context = None
+
+        lock_file_path = _get_context_function_lock_path(context, func)
+        with file_lock(lock_file_path):
+            logger.info('lock function using file path:{}'.format(
+                lock_file_path))
+            res = func(*args, **kwargs)
+
+        return res
+
+    return function_wrapper
+
+
+@contextmanager
+def locking_function(function, context=None):
+    """Lock Lock a function in combination with a context
+    :type function: callable
+    :type context: str
+    :param function: the function that is intended to be locked
+    :param context: an added context string if applicable, of a concrete lock
+    in combination with function.
+    """
+    lock_file_path = _get_function_lock_path(function, context=context)
+    with file_lock(lock_file_path) as lock_handler:
+        logger.info('locking function using file path:{}'.format(
+            lock_file_path))
+        yield lock_handler

--- a/tests/foreman/api/test_host.py
+++ b/tests/foreman/api/test_host.py
@@ -42,6 +42,7 @@ from robottelo.decorators import (
     tier2,
     tier3,
 )
+from robottelo.decorators.func_locker import lock_function
 from robottelo.test import APITestCase
 
 
@@ -49,6 +50,7 @@ class HostTestCase(APITestCase):
     """Tests for ``entities.Host().path()``."""
 
     @classmethod
+    @lock_function
     def setUpClass(cls):
         """Setup common entities."""
         super(HostTestCase, cls).setUpClass()


### PR DESCRIPTION
https://github.com/SatelliteQE/robottelo/issues/4310
```console
(2.7) dlezz@elysion:~/projects/robottelo-fork$ py.test tests/foreman/api/test_host.py -n 8 -v -k "HostTestCase"
================================================= test session starts ==================================================
platform linux2 -- Python 2.7.12, pytest-3.0.6, py-1.4.31, pluggy-0.4.0 -- /home/dlezz/bin/redhat/python/2.7/bin/python2.7
cachedir: .cache
rootdir: /home/dlezz/projects/robottelo-fork, inifile: 
plugins: xdist-1.15.0, cov-2.3.1, services-1.1.14
[gw0] linux2 Python 2.7.12 cwd: /home/dlezz/projects/robottelo-fork
[gw1] linux2 Python 2.7.12 cwd: /home/dlezz/projects/robottelo-fork
[gw2] linux2 Python 2.7.12 cwd: /home/dlezz/projects/robottelo-fork
[gw3] linux2 Python 2.7.12 cwd: /home/dlezz/projects/robottelo-fork
[gw4] linux2 Python 2.7.12 cwd: /home/dlezz/projects/robottelo-fork
[gw5] linux2 Python 2.7.12 cwd: /home/dlezz/projects/robottelo-fork
[gw6] linux2 Python 2.7.12 cwd: /home/dlezz/projects/robottelo-fork
[gw7] linux2 Python 2.7.12 cwd: /home/dlezz/projects/robottelo-fork
[gw5] Python 2.7.12 (default, Oct 11 2016, 17:04:14)  -- [GCC 4.8.4]
[gw4] Python 2.7.12 (default, Oct 11 2016, 17:04:14)  -- [GCC 4.8.4]
[gw3] Python 2.7.12 (default, Oct 11 2016, 17:04:14)  -- [GCC 4.8.4]
[gw0] Python 2.7.12 (default, Oct 11 2016, 17:04:14)  -- [GCC 4.8.4]
[gw6] Python 2.7.12 (default, Oct 11 2016, 17:04:14)  -- [GCC 4.8.4]
[gw2] Python 2.7.12 (default, Oct 11 2016, 17:04:14)  -- [GCC 4.8.4]
[gw1] Python 2.7.12 (default, Oct 11 2016, 17:04:14)  -- [GCC 4.8.4]
[gw7] Python 2.7.12 (default, Oct 11 2016, 17:04:14)  -- [GCC 4.8.4]
gw0 [63] / gw1 [63] / gw2 [63] / gw3 [63] / gw4 [63] / gw5 [63] / gw6 [63] / gw7 [63]
scheduling tests via LoadScheduling

tests/foreman/api/test_host.py::HostTestCase::test_positive_create_baremetal_with_uefi <- robottelo/decorators/__init__.py 
tests/foreman/api/test_host.py::HostTestCase::test_negative_update_name <- robottelo/decorators/__init__.py 
tests/foreman/api/test_host.py::HostTestCase::test_positive_create_inherit_lce_cv <- robottelo/decorators/__init__.py 
tests/foreman/api/test_host.py::HostTestCase::test_negative_update_arch <- robottelo/decorators/__init__.py 
tests/foreman/api/test_host.py::HostTestCase::test_positive_create_with_build_parameter <- robottelo/decorators/__init__.py 
tests/foreman/api/test_host.py::HostTestCase::test_negative_update_mac <- robottelo/decorators/__init__.py 
tests/foreman/api/test_host.py::HostTestCase::test_positive_create_baremetal_with_bios <- robottelo/decorators/__init__.py 
tests/foreman/api/test_host.py::HostTestCase::test_negative_update_os <- robottelo/decorators/__init__.py 
[gw0] PASSED tests/foreman/api/test_host.py::HostTestCase::test_positive_create_inherit_lce_cv <- robottelo/decorators/__init__.py 
tests/foreman/api/test_host.py::HostTestCase::test_positive_create_with_hostgroup <- robottelo/decorators/__init__.py 
[gw0] PASSED tests/foreman/api/test_host.py::HostTestCase::test_positive_create_with_hostgroup <- robottelo/decorators/__init__.py 
tests/foreman/api/test_host.py::HostTestCase::test_positive_create_with_ip <- robottelo/decorators/__init__.py 
[gw0] PASSED tests/foreman/api/test_host.py::HostTestCase::test_positive_create_with_ip <- robottelo/decorators/__init__.py 
tests/foreman/api/test_host.py::HostTestCase::test_positive_create_with_managed_parameter <- robottelo/decorators/__init__.py 
[gw7] PASSED tests/foreman/api/test_host.py::HostTestCase::test_positive_create_baremetal_with_uefi <- robottelo/decorators/__init__.py 
tests/foreman/api/test_host.py::HostTestCase::test_positive_create_with_host_parameters <- robottelo/decorators/__init__.py 
[gw0] PASSED tests/foreman/api/test_host.py::HostTestCase::test_positive_create_with_managed_parameter <- robottelo/decorators/__init__.py 
tests/foreman/api/test_host.py::HostTestCase::test_positive_create_with_model <- robottelo/decorators/__init__.py 
[gw7] PASSED tests/foreman/api/test_host.py::HostTestCase::test_positive_create_with_host_parameters <- robottelo/decorators/__init__.py 
tests/foreman/api/test_host.py::HostTestCase::test_positive_create_with_name <- robottelo/decorators/__init__.py 
[gw0] PASSED tests/foreman/api/test_host.py::HostTestCase::test_positive_create_with_model <- robottelo/decorators/__init__.py 
tests/foreman/api/test_host.py::HostTestCase::test_positive_create_with_owner_type <- robottelo/decorators/__init__.py 
[gw0] PASSED tests/foreman/api/test_host.py::HostTestCase::test_positive_create_with_owner_type <- robottelo/decorators/__init__.py 
tests/foreman/api/test_host.py::HostTestCase::test_positive_create_with_puppet_ca_proxy <- robottelo/decorators/__init__.py 
[gw0] PASSED tests/foreman/api/test_host.py::HostTestCase::test_positive_create_with_puppet_ca_proxy <- robottelo/decorators/__init__.py 
tests/foreman/api/test_host.py::HostTestCase::test_positive_create_with_puppet_class <- robottelo/decorators/__init__.py 
[gw7] PASSED tests/foreman/api/test_host.py::HostTestCase::test_positive_create_with_name <- robottelo/decorators/__init__.py 
tests/foreman/api/test_host.py::HostTestCase::test_positive_create_with_provision_method <- robottelo/decorators/__init__.py 
[gw0] PASSED tests/foreman/api/test_host.py::HostTestCase::test_positive_create_with_puppet_class <- robottelo/decorators/__init__.py 
tests/foreman/api/test_host.py::HostTestCase::test_positive_create_with_puppet_proxy <- robottelo/decorators/__init__.py 
[gw2] PASSED tests/foreman/api/test_host.py::HostTestCase::test_negative_update_arch <- robottelo/decorators/__init__.py 
tests/foreman/api/test_host.py::HostTestCase::test_positive_create_with_comment <- robottelo/decorators/__init__.py 
[gw7] PASSED tests/foreman/api/test_host.py::HostTestCase::test_positive_create_with_provision_method <- robottelo/decorators/__init__.py 
tests/foreman/api/test_host.py::HostTestCase::test_positive_create_with_subnet <- robottelo/decorators/__init__.py 
[gw0] PASSED tests/foreman/api/test_host.py::HostTestCase::test_positive_create_with_puppet_proxy <- robottelo/decorators/__init__.py 
tests/foreman/api/test_host.py::HostTestCase::test_positive_create_with_user <- robottelo/decorators/__init__.py 
[gw7] PASSED tests/foreman/api/test_host.py::HostTestCase::test_positive_create_with_subnet <- robottelo/decorators/__init__.py 
tests/foreman/api/test_host.py::HostTestCase::test_positive_delete <- robottelo/decorators/__init__.py 
[gw0] PASSED tests/foreman/api/test_host.py::HostTestCase::test_positive_create_with_user <- robottelo/decorators/__init__.py 
tests/foreman/api/test_host.py::HostTestCase::test_positive_get_per_page <- robottelo/decorators/__init__.py 
[gw0] PASSED tests/foreman/api/test_host.py::HostTestCase::test_positive_get_per_page <- robottelo/decorators/__init__.py 
tests/foreman/api/test_host.py::HostTestCase::test_positive_read_puppet_ca_proxy_name 
[gw7] PASSED tests/foreman/api/test_host.py::HostTestCase::test_positive_delete <- robottelo/decorators/__init__.py 
tests/foreman/api/test_host.py::HostTestCase::test_positive_get_search <- robottelo/decorators/__init__.py 
[gw7] PASSED tests/foreman/api/test_host.py::HostTestCase::test_positive_get_search <- robottelo/decorators/__init__.py 
tests/foreman/api/test_host.py::HostTestCase::test_positive_update_arch <- robottelo/decorators/__init__.py 
[gw0] PASSED tests/foreman/api/test_host.py::HostTestCase::test_positive_read_puppet_ca_proxy_name 
tests/foreman/api/test_host.py::HostTestCase::test_positive_read_puppet_proxy_name 
[gw7] PASSED tests/foreman/api/test_host.py::HostTestCase::test_positive_update_arch <- robottelo/decorators/__init__.py 
tests/foreman/api/test_host.py::HostTestCase::test_positive_update_build_parameter <- robottelo/decorators/__init__.py 
[gw0] PASSED tests/foreman/api/test_host.py::HostTestCase::test_positive_read_puppet_proxy_name 
tests/foreman/api/test_host.py::HostTestCase::test_positive_update_comment <- robottelo/decorators/__init__.py 
[gw1] PASSED tests/foreman/api/test_host.py::HostTestCase::test_negative_update_name <- robottelo/decorators/__init__.py 
tests/foreman/api/test_host.py::HostTestCase::test_positive_create_with_compute_profile <- robottelo/decorators/__init__.py 
[gw7] PASSED tests/foreman/api/test_host.py::HostTestCase::test_positive_update_build_parameter <- robottelo/decorators/__init__.py 
tests/foreman/api/test_host.py::HostTestCase::test_positive_update_compresource <- robottelo/decorators/__init__.py 
[gw1] PASSED tests/foreman/api/test_host.py::HostTestCase::test_positive_create_with_compute_profile <- robottelo/decorators/__init__.py 
tests/foreman/api/test_host.py::HostTestCase::test_positive_update_content_view <- robottelo/decorators/__init__.py 
[gw5] PASSED tests/foreman/api/test_host.py::HostTestCase::test_negative_update_os <- robottelo/decorators/__init__.py 
tests/foreman/api/test_host.py::HostTestCase::test_positive_create_with_content_view <- robottelo/decorators/__init__.py 
[gw2] PASSED tests/foreman/api/test_host.py::HostTestCase::test_positive_create_with_comment <- robottelo/decorators/__init__.py 
tests/foreman/api/test_host.py::HostTestCase::test_positive_create_with_usergroup <- robottelo/decorators/__init__.py 
[gw1] PASSED tests/foreman/api/test_host.py::HostTestCase::test_positive_update_content_view <- robottelo/decorators/__init__.py 
tests/foreman/api/test_host.py::HostTestCase::test_positive_update_enabled_parameter <- robottelo/decorators/__init__.py 
[gw7] PASSED tests/foreman/api/test_host.py::HostTestCase::test_positive_update_compresource <- robottelo/decorators/__init__.py 
tests/foreman/api/test_host.py::HostTestCase::test_positive_update_domain <- robottelo/decorators/__init__.py 
[gw5] PASSED tests/foreman/api/test_host.py::HostTestCase::test_positive_create_with_content_view <- robottelo/decorators/__init__.py 
tests/foreman/api/test_host.py::HostTestCase::test_positive_update_env <- robottelo/decorators/__init__.py 
[gw2] PASSED tests/foreman/api/test_host.py::HostTestCase::test_positive_create_with_usergroup <- robottelo/decorators/__init__.py 
tests/foreman/api/test_host.py::HostTestCase::test_positive_update_host_parameters <- robottelo/decorators/__init__.py 
[gw7] PASSED tests/foreman/api/test_host.py::HostTestCase::test_positive_update_domain <- robottelo/decorators/__init__.py 
tests/foreman/api/test_host.py::HostTestCase::test_positive_update_image <- robottelo/decorators/__init__.py 
[gw5] PASSED tests/foreman/api/test_host.py::HostTestCase::test_positive_update_env <- robottelo/decorators/__init__.py 
tests/foreman/api/test_host.py::HostTestCase::test_positive_update_ip <- robottelo/decorators/__init__.py 
[gw2] PASSED tests/foreman/api/test_host.py::HostTestCase::test_positive_update_host_parameters <- robottelo/decorators/__init__.py 
tests/foreman/api/test_host.py::HostTestCase::test_positive_update_mac <- robottelo/decorators/__init__.py 
[gw1] PASSED tests/foreman/api/test_host.py::HostTestCase::test_positive_update_enabled_parameter <- robottelo/decorators/__init__.py 
tests/foreman/api/test_host.py::HostTestCase::test_positive_update_hostgroup <- robottelo/decorators/__init__.py 
[gw6] PASSED tests/foreman/api/test_host.py::HostTestCase::test_positive_create_with_build_parameter <- robottelo/decorators/__init__.py 
tests/foreman/api/test_host.py::HostTestCase::test_positive_create_with_image <- robottelo/decorators/__init__.py 
[gw5] PASSED tests/foreman/api/test_host.py::HostTestCase::test_positive_update_ip <- robottelo/decorators/__init__.py 
tests/foreman/api/test_host.py::HostTestCase::test_positive_update_medium <- robottelo/decorators/__init__.py 
[gw2] PASSED tests/foreman/api/test_host.py::HostTestCase::test_positive_update_mac <- robottelo/decorators/__init__.py 
tests/foreman/api/test_host.py::HostTestCase::test_positive_update_model <- robottelo/decorators/__init__.py 
[gw7] PASSED tests/foreman/api/test_host.py::HostTestCase::test_positive_update_image <- robottelo/decorators/__init__.py 
tests/foreman/api/test_host.py::HostTestCase::test_positive_update_managed_parameter <- robottelo/decorators/__init__.py 
[gw6] PASSED tests/foreman/api/test_host.py::HostTestCase::test_positive_create_with_image <- robottelo/decorators/__init__.py 
tests/foreman/api/test_host.py::HostTestCase::test_positive_update_os <- robottelo/decorators/__init__.py 
[gw1] PASSED tests/foreman/api/test_host.py::HostTestCase::test_positive_update_hostgroup <- robottelo/decorators/__init__.py 
tests/foreman/api/test_host.py::HostTestCase::test_positive_update_name <- robottelo/decorators/__init__.py 
[gw5] PASSED tests/foreman/api/test_host.py::HostTestCase::test_positive_update_medium <- robottelo/decorators/__init__.py 
tests/foreman/api/test_host.py::HostTestCase::test_positive_update_owner_type <- robottelo/decorators/__init__.py 
[gw2] PASSED tests/foreman/api/test_host.py::HostTestCase::test_positive_update_model <- robottelo/decorators/__init__.py 
tests/foreman/api/test_host.py::HostTestCase::test_positive_update_puppet_ca_proxy <- robottelo/decorators/__init__.py 
[gw0] PASSED tests/foreman/api/test_host.py::HostTestCase::test_positive_update_comment <- robottelo/decorators/__init__.py 
tests/foreman/api/test_host.py::HostTestCase::test_positive_update_compute_profile <- robottelo/decorators/__init__.py 
[gw6] PASSED tests/foreman/api/test_host.py::HostTestCase::test_positive_update_os <- robottelo/decorators/__init__.py 
tests/foreman/api/test_host.py::HostTestCase::test_positive_update_puppet_proxy <- robottelo/decorators/__init__.py 
[gw7] PASSED tests/foreman/api/test_host.py::HostTestCase::test_positive_update_managed_parameter <- robottelo/decorators/__init__.py 
tests/foreman/api/test_host.py::HostTestCase::test_positive_update_puppet_class <- robottelo/decorators/__init__.py 
[gw1] PASSED tests/foreman/api/test_host.py::HostTestCase::test_positive_update_name <- robottelo/decorators/__init__.py 
tests/foreman/api/test_host.py::HostTestCase::test_positive_update_subnet <- robottelo/decorators/__init__.py 
[gw2] PASSED tests/foreman/api/test_host.py::HostTestCase::test_positive_update_puppet_ca_proxy <- robottelo/decorators/__init__.py 
[gw5] PASSED tests/foreman/api/test_host.py::HostTestCase::test_positive_update_owner_type <- robottelo/decorators/__init__.py 
[gw7] PASSED tests/foreman/api/test_host.py::HostTestCase::test_positive_update_puppet_class <- robottelo/decorators/__init__.py 
[gw6] PASSED tests/foreman/api/test_host.py::HostTestCase::test_positive_update_puppet_proxy <- robottelo/decorators/__init__.py 
[gw0] PASSED tests/foreman/api/test_host.py::HostTestCase::test_positive_update_compute_profile <- robottelo/decorators/__init__.py 
[gw1] PASSED tests/foreman/api/test_host.py::HostTestCase::test_positive_update_subnet <- robottelo/decorators/__init__.py 
[gw3] PASSED tests/foreman/api/test_host.py::HostTestCase::test_negative_update_mac <- robottelo/decorators/__init__.py 
[gw4] PASSED tests/foreman/api/test_host.py::HostTestCase::test_positive_create_baremetal_with_bios <- robottelo/decorators/__init__.py 
tests/foreman/api/test_host.py::HostTestCase::test_positive_verify_files_with_pxegrub_uefi_secureboot <- robottelo/decorators/__init__.py 
[gw1] PASSED tests/foreman/api/test_host.py::HostTestCase::test_positive_verify_files_with_pxegrub_uefi_secureboot <- robottelo/decorators/__init__.py 
tests/foreman/api/test_host.py::HostTestCase::test_positive_update_usergroup <- robottelo/decorators/__init__.py 
tests/foreman/api/test_host.py::HostTestCase::test_positive_create_with_compresource <- robottelo/decorators/__init__.py 
tests/foreman/api/test_host.py::HostTestCase::test_positive_create_with_enabled_parameter <- robottelo/decorators/__init__.py 
tests/foreman/api/test_host.py::HostTestCase::test_positive_verify_files_with_pxegrub_uefi <- robottelo/decorators/__init__.py 
[gw7] PASSED tests/foreman/api/test_host.py::HostTestCase::test_positive_verify_files_with_pxegrub_uefi <- robottelo/decorators/__init__.py 
tests/foreman/api/test_host.py::HostTestCase::test_positive_update_user <- robottelo/decorators/__init__.py 
tests/foreman/api/test_host.py::HostTestCase::test_positive_verify_files_with_pxegrub2_uefi_secureboot <- robottelo/decorators/__init__.py 
tests/foreman/api/test_host.py::HostTestCase::test_positive_verify_files_with_pxegrub2_uefi <- robottelo/decorators/__init__.py 
[gw6] PASSED tests/foreman/api/test_host.py::HostTestCase::test_positive_verify_files_with_pxegrub2_uefi_secureboot <- robottelo/decorators/__init__.py 
[gw0] PASSED tests/foreman/api/test_host.py::HostTestCase::test_positive_verify_files_with_pxegrub2_uefi <- robottelo/decorators/__init__.py 
[gw4] PASSED tests/foreman/api/test_host.py::HostTestCase::test_positive_create_with_enabled_parameter <- robottelo/decorators/__init__.py 
[gw3] PASSED tests/foreman/api/test_host.py::HostTestCase::test_positive_create_with_compresource <- robottelo/decorators/__init__.py 
[gw5] PASSED tests/foreman/api/test_host.py::HostTestCase::test_positive_update_user <- robottelo/decorators/__init__.py 
[gw2] PASSED tests/foreman/api/test_host.py::HostTestCase::test_positive_update_usergroup <- robottelo/decorators/__init__.py 

============================================= 63 passed in 546.94 seconds ==============================================
(2.7) dlezz@elysion:~/projects/robottelo-fork$ 
```