### PR TITLE
Revert python-bugzilla to 1.2.2 due to some missing methods

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -14,7 +14,12 @@ selenium==2.48.0  # pyup: ignore
 six==1.10.0
 testimony==1.3.1
 unittest2==1.1.0
-python-bugzilla==2.0.0
+
+# python-bugzilla 2.0.0 changed a lot of function signatures
+# also it removed some functions use e.g: getbugsimple
+# to update it code changes is needed.
+python-bugzilla==1.2.2  # pyup: ignore
+
 PyYAML==3.12
 robozilla==0.1.7
 


### PR DESCRIPTION
Example: they removed `getbugsimple` and our tools are using that
In future we should refactor the code to use latest version.