### PR TITLE
[6.2.z] [Cherry-pick] Automated BZ 1379372 and host-collection list

### DIFF
--- a/robottelo/cli/hostcollection.py
+++ b/robottelo/cli/hostcollection.py
@@ -50,6 +50,11 @@ class HostCollection(Base):
             ]
             if host_ids:
                 options['host-ids'] = ','.join(host_ids)
+        if 'host-id' in options:
+            host_id = options.get('host-id')
+            if host_id and not host_id.isdigit():
+                host_name = ContentHost.info({'id': host_id})['name'].lower()
+                options['host-id'] = Host.info({'name': host_name})['id']
 
     @classmethod
     def add_host(cls, options=None):
@@ -99,6 +104,13 @@ class HostCollection(Base):
         cls.command_sub = 'hosts'
         return cls.execute(
             cls._construct_command(options), output_format='csv')
+
+    @classmethod
+    def list(cls, options=None, per_page=True):
+        """List host collections"""
+        if options:
+            cls.transform_ids(options)
+        return super(HostCollection, cls).list(options, per_page)
 
     @classmethod
     def erratum_install(cls, options):

--- a/robottelo/cli/hostcollection.py
+++ b/robottelo/cli/hostcollection.py
@@ -50,11 +50,10 @@ class HostCollection(Base):
             ]
             if host_ids:
                 options['host-ids'] = ','.join(host_ids)
-        if 'host-id' in options:
-            host_id = options.get('host-id')
-            if host_id and not host_id.isdigit():
-                host_name = ContentHost.info({'id': host_id})['name'].lower()
-                options['host-id'] = Host.info({'name': host_name})['id']
+        host_id = options.get('host-id')
+        if host_id and not host_id.isdigit():
+            host_name = ContentHost.info({'id': host_id})['name'].lower()
+            options['host-id'] = Host.info({'name': host_name})['id']
 
     @classmethod
     def add_host(cls, options=None):

--- a/tests/foreman/cli/test_host_collection.py
+++ b/tests/foreman/cli/test_host_collection.py
@@ -361,6 +361,147 @@ class HostCollectionTestCase(CLITestCase):
         self.assertEqual(new_system['name'].lower(), result[0]['name'])
 
     @tier2
+    def test_positive_list_by_name(self):
+        """Check if host collection list can be filtered by name
+
+        @id: 2d611a48-1e51-49b5-8f20-81b09f96c542
+
+        @Assert: Only host-collection with specific name is listed
+
+        @CaseLevel: Integration
+        """
+        # Create two host collections within the same org
+        host_col = self._new_host_collection()
+        self._new_host_collection()
+        # List all host collections
+        self.assertGreaterEqual(len(HostCollection.list()), 2)
+        # Filter list by name
+        result = HostCollection.list({'name': host_col['name']})
+        self.assertEqual(len(result), 1)
+        self.assertEqual(result[0]['id'], host_col['id'])
+
+    @tier2
+    def test_positive_list_by_org_id(self):
+        """Check if host collection list can be filtered by organization id
+
+        @id: afbe077a-0de1-432c-a0c4-082129aab92e
+
+        @Assert: Only host-collection within specific org is listed
+
+        @CaseLevel: Integration
+        """
+        # Create two host collections within different organizations
+        self._new_host_collection()
+        new_org = make_org()
+        host_col = self._new_host_collection(
+            {'organization-id': new_org['id']})
+        # List all host collections
+        self.assertGreaterEqual(len(HostCollection.list()), 2)
+        # Filter list by org id
+        result = HostCollection.list({'organization-id': new_org['id']})
+        self.assertEqual(len(result), 1)
+        self.assertEqual(result[0]['id'], host_col['id'])
+
+    @tier2
+    def test_positive_list_by_org_name(self):
+        """Check if host collection list can be filtered by organization name
+
+        @id: 0102094f-f5af-4067-8a07-541ba9d94f61
+
+        @Assert: Only host-collection within specific org is listed
+
+        @CaseLevel: Integration
+        """
+        # Create two host collections within different organizations
+        self._new_host_collection()
+        new_org = make_org()
+        host_col = self._new_host_collection(
+            {'organization-id': new_org['id']})
+        # List all host collections
+        self.assertGreaterEqual(len(HostCollection.list()), 2)
+        # Filter list by org id
+        result = HostCollection.list({'organization': new_org['name']})
+        self.assertEqual(len(result), 1)
+        self.assertEqual(result[0]['name'], host_col['name'])
+
+    @tier2
+    def test_positive_list_by_host_id(self):
+        """Check if host collection list can be filtered by associated host id
+
+        @id: de272461-9804-4524-83c8-23e47abfc8e3
+
+        @Assert: Only host-collection with specific host is listed
+
+        @CaseLevel: Integration
+
+        @BZ: 1379372
+        """
+        # Create two host collections within the same org but only one with
+        # associated host that will be used for filtering
+        host_col = self._new_host_collection()
+        self._new_host_collection()
+        host = self._make_fake_host_helper()
+        HostCollection.add_host({
+            'host-ids': host['id'],
+            'id': host_col['id'],
+            'organization-id': self.org['id'],
+        })
+        host_col = HostCollection.info({
+            'id': host_col['id'],
+            'organization-id': self.org['id']
+        })
+        self.assertEqual(host_col['total-hosts'], '1')
+        # List all host collections within organization
+        result = HostCollection.list({'organization-id': self.org['id']})
+        self.assertGreaterEqual(len(result), 2)
+        # Filter list by associated host name
+        result = HostCollection.list({
+            'organization-id': self.org['id'],
+            'host-id': host['id']
+        })
+        self.assertEqual(len(result), 1)
+        self.assertEqual(result[0]['id'], host_col['id'])
+
+    @tier2
+    def test_positive_list_by_host_name(self):
+        """Check if host collection list can be filtered by
+        associated host name
+
+        @id: 2a99e11f-50b8-48b4-8dce-e6ad8ff9c051
+
+        @Assert: Only host-collection with specific host is listed
+
+        @CaseLevel: Integration
+
+        @BZ: 1379372
+        """
+        # Create two host collections within the same org but only one with
+        # associated host that will be used for filtering
+        host_col = self._new_host_collection()
+        self._new_host_collection()
+        host = self._make_fake_host_helper()
+        HostCollection.add_host({
+            'hosts': host['name'],
+            'name': host_col['name'],
+            'organization': self.org['name'],
+        })
+        host_col = HostCollection.info({
+            'name': host_col['name'],
+            'organization': self.org['name']
+        })
+        self.assertEqual(host_col['total-hosts'], '1')
+        # List all host collections within organization
+        result = HostCollection.list({'organization': self.org['name']})
+        self.assertGreaterEqual(len(result), 2)
+        # Filter list by associated host name
+        result = HostCollection.list({
+            'organization': self.org['name'],
+            'host': host['name']
+        })
+        self.assertEqual(len(result), 1)
+        self.assertEqual(result[0]['name'], host_col['name'])
+
+    @tier2
     def test_positive_host_collection_host_pagination(self):
         """Check if pagination configured on per-page param defined in hammer
         host-collection hosts command overrides global configuration defined

--- a/tests/foreman/cli/test_host_collection.py
+++ b/tests/foreman/cli/test_host_collection.py
@@ -374,9 +374,11 @@ class HostCollectionTestCase(CLITestCase):
         host_col = self._new_host_collection()
         self._new_host_collection()
         # List all host collections
-        self.assertGreaterEqual(len(HostCollection.list()), 2)
+        self.assertGreaterEqual(
+            len(HostCollection.list({'organization-id': self.org['id']})), 2)
         # Filter list by name
-        result = HostCollection.list({'name': host_col['name']})
+        result = HostCollection.list(
+            {'name': host_col['name'], 'organization-id': self.org['id']})
         self.assertEqual(len(result), 1)
         self.assertEqual(result[0]['id'], host_col['id'])
 
@@ -395,8 +397,6 @@ class HostCollectionTestCase(CLITestCase):
         new_org = make_org()
         host_col = self._new_host_collection(
             {'organization-id': new_org['id']})
-        # List all host collections
-        self.assertGreaterEqual(len(HostCollection.list()), 2)
         # Filter list by org id
         result = HostCollection.list({'organization-id': new_org['id']})
         self.assertEqual(len(result), 1)
@@ -417,8 +417,6 @@ class HostCollectionTestCase(CLITestCase):
         new_org = make_org()
         host_col = self._new_host_collection(
             {'organization-id': new_org['id']})
-        # List all host collections
-        self.assertGreaterEqual(len(HostCollection.list()), 2)
         # Filter list by org id
         result = HostCollection.list({'organization': new_org['name']})
         self.assertEqual(len(result), 1)
@@ -440,7 +438,7 @@ class HostCollectionTestCase(CLITestCase):
         # associated host that will be used for filtering
         host_col = self._new_host_collection()
         self._new_host_collection()
-        host = self._make_fake_host_helper()
+        host = self._make_content_host_helper()
         HostCollection.add_host({
             'host-ids': host['id'],
             'id': host_col['id'],
@@ -479,9 +477,9 @@ class HostCollectionTestCase(CLITestCase):
         # associated host that will be used for filtering
         host_col = self._new_host_collection()
         self._new_host_collection()
-        host = self._make_fake_host_helper()
+        host = self._make_content_host_helper()
         HostCollection.add_host({
-            'hosts': host['name'],
+            'hosts': host['name'].lower(),
             'name': host_col['name'],
             'organization': self.org['name'],
         })
@@ -496,7 +494,7 @@ class HostCollectionTestCase(CLITestCase):
         # Filter list by associated host name
         result = HostCollection.list({
             'organization': self.org['name'],
-            'host': host['name']
+            'host': host['name'].lower(),
         })
         self.assertEqual(len(result), 1)
         self.assertEqual(result[0]['name'], host_col['name'])


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1379372

Cherry-picked from #4203 with changes specific for 6.2. Most significant one is that now all added tests use organization id as mandatory argument because BZ 1331875 [1] was fixed only for 6.3

[1] https://bugzilla.redhat.com/show_bug.cgi?id=1331875

```python
]% py.test -v tests/foreman/cli/test_host_collection.py -k 'list_by'
========================================== test session starts ===========================================
platform linux2 -- Python 2.7.12, pytest-2.9.2, py-1.4.32, pluggy-0.3.1 -- /home/qui/code/venv/2/bin/python2
cachedir: .cache
rootdir: /home/qui/code/robottelo, inifile: 
plugins: xdist-1.15.0, html-1.12.0, cov-2.3.1
collected 18 items 

tests/foreman/cli/test_host_collection.py::HostCollectionTestCase::test_positive_list_by_host_id PASSED
tests/foreman/cli/test_host_collection.py::HostCollectionTestCase::test_positive_list_by_host_name PASSED
tests/foreman/cli/test_host_collection.py::HostCollectionTestCase::test_positive_list_by_name PASSED
tests/foreman/cli/test_host_collection.py::HostCollectionTestCase::test_positive_list_by_org_id PASSED
tests/foreman/cli/test_host_collection.py::HostCollectionTestCase::test_positive_list_by_org_name PASSED

=================================== 13 tests deselected by '-klist_by' ===================================
=============================== 5 passed, 13 deselected in 188.27 seconds ================================
```