### PR TITLE
[6.2.z][Cherry-pick] Automated BZ1360239

### DIFF
--- a/robottelo/api/utils.py
+++ b/robottelo/api/utils.py
@@ -17,7 +17,7 @@ def enable_rhrepo_and_fetchid(basearch, org_id, product, repo,
     :param str reposet: The reposet name in which repository exists.
     :param str repo: The repository name who's Id is to be fetched.
     :param str basearch: The architecture of the repository.
-    :param str releasever: The releasever of the repository.
+    :param str optional releasever: The releasever of the repository.
     :return: Returns the repository Id.
     :rtype: str
 

--- a/robottelo/ui/activationkey.py
+++ b/robottelo/ui/activationkey.py
@@ -185,6 +185,15 @@ class ActivationKey(Base):
         self.click(locators['ak.content_hosts'])
         return self.wait_until_element(locators['ak.content_host_name']).text
 
+    def fetch_product_contents(self, name):
+        """Fetch associated product content from selected activation key."""
+        self.search_and_click(name)
+        self.click(tab_locators['ak.tab_prd_content'])
+        return [
+            el.text for el
+            in self.find_elements(locators['ak.product_contents'])
+        ]
+
     def copy(self, name, new_name=None):
         """Copies an existing activation key"""
         self.click(self.search(name))

--- a/robottelo/ui/locators.py
+++ b/robottelo/ui/locators.py
@@ -2281,6 +2281,12 @@ locators = LocatorDict({
     "ak.subscriptions.search": (
         By.XPATH,
         "//input[@ng-model='subscriptionSearch']"),
+    "ak.product_contents": (
+        By.XPATH,
+        ("//div[contains(@ng-controller, "
+         "'ActivationKeyProductDetailsController')]/div[@class='row']"
+         "/div[@ng-repeat='content in product.available_content']/h4/u"),
+    ),
 
     # Sync Status
     "sync.prd_expander": (

--- a/tests/foreman/cli/test_activationkey.py
+++ b/tests/foreman/cli/test_activationkey.py
@@ -625,7 +625,6 @@ class ActivationKeyTestCase(CLITestCase):
         self.assertEqual(content[0]['name'], REPOSET['rhst7'])
 
     @run_only_on('sat')
-    @skip_if_bug_open('bugzilla', 1360239)
     @tier3
     def test_positive_add_custom_product(self):
         """Test that custom product can be associated to Activation Keys
@@ -635,6 +634,8 @@ class ActivationKeyTestCase(CLITestCase):
         @Assert: Custom products are successfully associated to Activation key
 
         @CaseLevel: System
+
+        @BZ: 1360239
         """
         result = setup_org_for_a_custom_repo({
             u'url': FAKE_0_YUM_REPO,
@@ -649,7 +650,6 @@ class ActivationKeyTestCase(CLITestCase):
 
     @run_in_one_thread
     @run_only_on('sat')
-    @skip_if_bug_open('bugzilla', 1360239)
     @skip_if_not_set('fake_manifest')
     @tier3
     def test_positive_add_redhat_and_custom_products(self):
@@ -666,6 +666,8 @@ class ActivationKeyTestCase(CLITestCase):
         @Assert: RH/Custom product is successfully associated to Activation key
 
         @CaseLevel: System
+
+        @BZ: 1360239
         """
         org = make_org()
         result = setup_org_for_a_rh_repo({

--- a/tests/foreman/ui/test_activationkey.py
+++ b/tests/foreman/ui/test_activationkey.py
@@ -32,6 +32,9 @@ from robottelo.constants import (
     ENVIRONMENT,
     FAKE_1_YUM_REPO,
     FAKE_2_YUM_REPO,
+    PRDS,
+    REPOSET,
+    REPOS,
     REPO_TYPE,
 )
 from robottelo.datafactory import invalid_names_list, valid_data_list


### PR DESCRIPTION
Cherry-pick of #4416 
https://bugzilla.redhat.com/show_bug.cgi?id=1360239
```python
py.test tests/foreman/{api,cli,ui}/test_activationkey.py -k 'test_positive_add_custom_product or test_positive_add_redhat_and_custom_products or test_positive_fetch_product_content'
============================= test session starts ==============================
platform darwin -- Python 2.7.13, pytest-2.9.2, py-1.4.32, pluggy-0.3.1
rootdir: /Users/andrii/workspace/robottelo, inifile:
plugins: xdist-1.15.0, services-1.1.14, cov-2.3.1
collected 106 items
2017-03-15 15:23:45 - conftest - DEBUG - Found WONTFIX in decorated tests ['1156555', '1269196', '1245334', '1217635', '1226425', '1204686', '1267224', '1103157', '1230902', '1214312', '1079482']

2017-03-15 15:23:45 - conftest - DEBUG - Collected 106 test cases

2017-03-15 15:23:45 - conftest - DEBUG - Deselected test tests.foreman.api.test_activationkey.test_negative_create_with_no_host_limit_set_max due to WONTFIX


tests/foreman/api/test_activationkey.py .
tests/foreman/cli/test_activationkey.py ..
tests/foreman/ui/test_activationkey.py ..

 101 tests deselected by '-ktest_positive_add_custom_product or test_positive_add_redhat_and_custom_products or test_positive_fetch_product_content'
================= 5 passed, 101 deselected in 1308.65 seconds ==================
```

Depends on SatelliteQE/nailgun#389