### PR TITLE
[6.2.z] [Cherry-pick] Automate BZ 1371900/1427192

### DIFF
--- a/tests/foreman/api/test_host.py
+++ b/tests/foreman/api/test_host.py
@@ -1184,6 +1184,42 @@ class HostTestCase(APITestCase):
         self.assertNotEqual(
             host.read().operatingsystem.read().name, new_os.name)
 
+    @tier1
+    def test_positive_read_puppet_proxy_name(self):
+        """Read a hostgroup created with puppet proxy and inspect server's
+        response
+
+        @id: 8825462e-f1dc-4054-b7fb-69c2b10722a2
+
+        @Assert: Field 'puppet_proxy_name' is returned
+
+        @BZ: 1371900
+        """
+        proxy = entities.SmartProxy().search(query={
+            'search': 'url = https://{0}:9090'.format(settings.server.hostname)
+        })[0]
+        host = entities.Host(puppet_proxy=proxy).create().read_json()
+        self.assertIn('puppet_proxy_name', host)
+        self.assertEqual(proxy.name, host['puppet_proxy_name'])
+
+    @tier1
+    def test_positive_read_puppet_ca_proxy_name(self):
+        """Read a hostgroup created with puppet ca proxy and inspect server's
+        response
+
+        @id: 8941395f-8040-4705-a981-5da21c47efd1
+
+        @Assert: Field 'puppet_ca_proxy_name' is returned
+
+        @BZ: 1371900
+        """
+        proxy = entities.SmartProxy().search(query={
+            'search': 'url = https://{0}:9090'.format(settings.server.hostname)
+        })[0]
+        host = entities.Host(puppet_ca_proxy=proxy).create().read_json()
+        self.assertIn('puppet_ca_proxy_name', host)
+        self.assertEqual(proxy.name, host['puppet_ca_proxy_name'])
+
 
 class HostInterfaceTestCase(APITestCase):
     """Tests for Host Interfaces"""

--- a/tests/foreman/api/test_host.py
+++ b/tests/foreman/api/test_host.py
@@ -34,7 +34,13 @@ from robottelo.datafactory import (
     valid_hosts_list,
     valid_interfaces_list,
 )
-from robottelo.decorators import bz_bug_is_open, run_only_on, tier1, tier2
+from robottelo.decorators import (
+    bz_bug_is_open,
+    run_only_on,
+    skip_if_bug_open,
+    tier1,
+    tier2,
+)
 from robottelo.decorators.func_locker import lock_function
 from robottelo.test import APITestCase
 
@@ -1185,6 +1191,7 @@ class HostTestCase(APITestCase):
             host.read().operatingsystem.read().name, new_os.name)
 
     @tier1
+    @skip_if_bug_open('bugzilla', 1427192)
     def test_positive_read_puppet_proxy_name(self):
         """Read a hostgroup created with puppet proxy and inspect server's
         response
@@ -1203,6 +1210,7 @@ class HostTestCase(APITestCase):
         self.assertEqual(proxy.name, host['puppet_proxy_name'])
 
     @tier1
+    @skip_if_bug_open('bugzilla', 1427192)
     def test_positive_read_puppet_ca_proxy_name(self):
         """Read a hostgroup created with puppet ca proxy and inspect server's
         response

--- a/tests/foreman/api/test_hostgroup.py
+++ b/tests/foreman/api/test_hostgroup.py
@@ -1183,6 +1183,7 @@ class HostGroupMissingAttrTestCase(APITestCase):
         )
 
     @tier1
+    @skip_if_bug_open('bugzilla', 1427192)
     def test_positive_read_puppet_proxy_name(self):
         """Read a hostgroup created with puppet proxy and inspect server's
         response
@@ -1201,6 +1202,7 @@ class HostGroupMissingAttrTestCase(APITestCase):
         self.assertEqual(proxy.name, hg['puppet_proxy_name'])
 
     @tier1
+    @skip_if_bug_open('bugzilla', 1427192)
     def test_positive_read_puppet_ca_proxy_name(self):
         """Read a hostgroup created with puppet ca proxy and inspect server's
         response

--- a/tests/foreman/api/test_hostgroup.py
+++ b/tests/foreman/api/test_hostgroup.py
@@ -1181,3 +1181,39 @@ class HostGroupMissingAttrTestCase(APITestCase):
                 self.host_group_attrs
             )
         )
+
+    @tier1
+    def test_positive_read_puppet_proxy_name(self):
+        """Read a hostgroup created with puppet proxy and inspect server's
+        response
+
+        @id: f93d0866-0073-4577-8777-6d645b63264f
+
+        @Assert: Field 'puppet_proxy_name' is returned
+
+        @BZ: 1371900
+        """
+        proxy = entities.SmartProxy().search(query={
+            'search': 'url = https://{0}:9090'.format(settings.server.hostname)
+        })[0]
+        hg = entities.HostGroup(puppet_proxy=proxy).create().read_json()
+        self.assertIn('puppet_proxy_name', hg)
+        self.assertEqual(proxy.name, hg['puppet_proxy_name'])
+
+    @tier1
+    def test_positive_read_puppet_ca_proxy_name(self):
+        """Read a hostgroup created with puppet ca proxy and inspect server's
+        response
+
+        @id: ab151e09-8e64-4377-95e8-584629750659
+
+        @Assert: Field 'puppet_ca_proxy_name' is returned
+
+        @BZ: 1371900
+        """
+        proxy = entities.SmartProxy().search(query={
+            'search': 'url = https://{0}:9090'.format(settings.server.hostname)
+        })[0]
+        hg = entities.HostGroup(puppet_ca_proxy=proxy).create().read_json()
+        self.assertIn('puppet_ca_proxy_name', hg)
+        self.assertEqual(proxy.name, hg['puppet_ca_proxy_name'])


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1427192
Cherry-picked from #4380

```python
% py.test -v tests/foreman/api/test_host{,group}.py -k 'read' 
========================================== test session starts ===========================================
platform linux2 -- Python 2.7.12, pytest-2.9.2, py-1.4.31, pluggy-0.3.1 -- /home/qui/code/venv/6.2.z/bin/python2
cachedir: .cache
rootdir: /home/qui/code/robottelo, inifile: 
plugins: xdist-1.14, services-1.1.14, cov-2.3.1
collected 110 items 
2017-03-16 17:11:32 - conftest - DEBUG - Found WONTFIX in decorated tests ['1156555', '1269196', '1245334', '1217635', '1226425', '1204686', '1267224', '1103157', '1230902', '1214312', '1079482']

2017-03-16 17:11:32 - conftest - DEBUG - Collected 110 test cases


tests/foreman/api/test_host.py::HostTestCase::test_positive_read_puppet_ca_proxy_name <- robottelo/decorators/__init__.py SKIPPED
tests/foreman/api/test_host.py::HostTestCase::test_positive_read_puppet_proxy_name <- robottelo/decorators/__init__.py SKIPPED
tests/foreman/api/test_hostgroup.py::HostGroupMissingAttrTestCase::test_positive_read_puppet_ca_proxy_name <- robottelo/decorators/__init__.py SKIPPED
tests/foreman/api/test_hostgroup.py::HostGroupMissingAttrTestCase::test_positive_read_puppet_proxy_name <- robottelo/decorators/__init__.py SKIPPED

==================================== 106 tests deselected by '-kread' ====================================
=============================== 4 skipped, 106 deselected in 58.27 seconds ==============================
```